### PR TITLE
Fix tree-sitter-analyzer github action error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -317,8 +317,7 @@ testpaths = ["tests"]
 python_files = "test_*.py"
 python_classes = "Test*"
 python_functions = "test_*"
-asyncio_mode = "auto"
-asyncio_default_fixture_loop_scope = "function"
+asyncio_mode = "strict"
 addopts = [
     "--strict-markers",
     "--strict-config",

--- a/tests/test_languages/test_typescript_plugin.py
+++ b/tests/test_languages/test_typescript_plugin.py
@@ -422,6 +422,7 @@ class TestTypeScriptPlugin:
         assert "TSX/JSX support" in features
 
     @patch('tree_sitter_analyzer.languages.typescript_plugin.TREE_SITTER_AVAILABLE', False)
+    @pytest.mark.asyncio
     async def test_analyze_file_no_tree_sitter(self, plugin):
         """Test file analysis when tree-sitter is not available"""
         from tree_sitter_analyzer.core.analysis_engine import AnalysisRequest
@@ -433,6 +434,7 @@ class TestTypeScriptPlugin:
         assert "Tree-sitter library not available" in result.error_message
 
     @patch('tree_sitter_analyzer.languages.typescript_plugin.loader.load_language')
+    @pytest.mark.asyncio
     async def test_analyze_file_no_language(self, mock_load_language, plugin):
         """Test file analysis when TypeScript language cannot be loaded"""
         from tree_sitter_analyzer.core.analysis_engine import AnalysisRequest
@@ -444,6 +446,7 @@ class TestTypeScriptPlugin:
         assert result.success is False
         assert "Could not load TypeScript language for parsing" in result.error_message
 
+    @pytest.mark.asyncio
     async def test_analyze_file_missing_file(self, plugin):
         """Test file analysis with missing file"""
         from tree_sitter_analyzer.core.analysis_engine import AnalysisRequest

--- a/tests/test_typescript_integration.py
+++ b/tests/test_typescript_integration.py
@@ -242,6 +242,7 @@ class TestTypeScriptIntegration:
 
     @patch('tree_sitter_analyzer.languages.typescript_plugin.TREE_SITTER_AVAILABLE', True)
     @patch('tree_sitter_analyzer.languages.typescript_plugin.loader.load_language')
+    @pytest.mark.asyncio
     async def test_typescript_plugin_analyze_file_mock(self, mock_load_language):
         """Test TypeScript plugin file analysis with mocked dependencies"""
         # Mock tree-sitter language and parser

--- a/tree_sitter_analyzer/queries/typescript.py
+++ b/tree_sitter_analyzer/queries/typescript.py
@@ -573,7 +573,7 @@ ALL_QUERIES["predicate_type"] = {
     parameter_name: (identifier) @predicate.param
     type: (_) @predicate.type) @predicate.signature
 """,
-    "description": "Search type predicate signatures",
+    "description": "Search predicate type signatures",
 }
 
 ALL_QUERIES["asserts_type"] = {
@@ -622,7 +622,7 @@ ALL_QUERIES["jsx_self_closing"] = {
 (jsx_self_closing_element
     name: (_) @jsx.tag_name) @jsx.self_closing
 """,
-    "description": "Search self-closing JSX elements",
+    "description": "Search jsx self closing elements",
 }
 
 ALL_QUERIES["jsx_fragment"] = {
@@ -643,7 +643,7 @@ ALL_QUERIES["as_expression"] = {
     "query": """
 (as_expression) @as.assertion
 """,
-    "description": "Search 'as' type assertions",
+    "description": "Search as expression type assertions",
 }
 
 ALL_QUERIES["type_assertion"] = {
@@ -661,7 +661,7 @@ ALL_QUERIES["satisfies_expression"] = {
     expression: (_) @satisfies.expression
     type: (_) @satisfies.type) @satisfies.assertion
 """,
-    "description": "Search 'satisfies' expressions",
+    "description": "Search satisfies expression type checks",
 }
 
 ALL_QUERIES["non_null_expression"] = {
@@ -669,7 +669,7 @@ ALL_QUERIES["non_null_expression"] = {
 (non_null_expression
     expression: (_) @non_null.expression) @non_null.assertion
 """,
-    "description": "Search non-null assertions (!)",
+    "description": "Search non null expression assertions (!)",
 }
 
 ALL_QUERIES["optional_chain"] = {
@@ -722,14 +722,14 @@ ALL_QUERIES["regex_literal"] = {
     "query": """
 (regex) @regex.literal
 """,
-    "description": "Search regular expression literals",
+    "description": "Search regex literal patterns",
 }
 
 ALL_QUERIES["this_type"] = {
     "query": """
 (this_type) @this.type
 """,
-    "description": "Search 'this' type references",
+    "description": "Search this type references",
 }
 
 ALL_QUERIES["import_type"] = {
@@ -739,7 +739,7 @@ ALL_QUERIES["import_type"] = {
     (import_clause) @import_type.clause
     source: (string) @import_type.source) @import_type.statement
 """,
-    "description": "Search type-only import statements",
+    "description": "Search import type statements",
 }
 
 ALL_QUERIES["export_type"] = {
@@ -747,7 +747,7 @@ ALL_QUERIES["export_type"] = {
 (export_statement
     "type" @export_type.keyword) @export_type.statement
 """,
-    "description": "Search type-only export statements",
+    "description": "Search export type statements",
 }
 
 ALL_QUERIES["declare_statement"] = {
@@ -791,7 +791,7 @@ ALL_QUERIES["triple_slash_directive"] = {
 (comment) @directive.comment
 (#match? @directive.comment "^///\\s*<")
 """,
-    "description": "Search triple-slash directives",
+    "description": "Search triple slash directive comments",
 }
 
 ALL_QUERIES["readonly_modifier"] = {


### PR DESCRIPTION
Fix CI failures by adding `@pytest.mark.asyncio` to async tests, unifying `pytest-asyncio` configuration, and correcting TypeScript query descriptions.

The CI was failing due to two main issues:
1.  Asynchronous test methods were not properly decorated, preventing `pytest-asyncio` from running them correctly.
2.  A quality check for TypeScript query descriptions expected the query name (with underscores replaced by spaces) to be present in the description, but several descriptions had different phrasing or word order.

---
<a href="https://cursor.com/background-agent?bcId=bc-f89332e9-4fbd-4fd2-af49-5a2abce04038"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f89332e9-4fbd-4fd2-af49-5a2abce04038"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

