### PR TITLE
Fix errors and submit pull request

### DIFF
--- a/tree_sitter_analyzer/formatters/markdown_formatter.py
+++ b/tree_sitter_analyzer/formatters/markdown_formatter.py
@@ -72,6 +72,10 @@ class MarkdownFormatter(BaseFormatter):
         # Robust counts to avoid undercount due to parser variance
         robust_counts = self._compute_robust_counts_from_file(file_path)
 
+        # Prefer robust counts only when they are non-zero; otherwise fallback to element counts
+        link_count_value = robust_counts.get("link_count", 0) or len(links)
+        image_count_value = robust_counts.get("image_count", 0) or len(images)
+
         structure = {
             "file_path": file_path,
             "language": "markdown",
@@ -119,9 +123,9 @@ class MarkdownFormatter(BaseFormatter):
             ],
             "statistics": {
                 "header_count": len(headers),
-                # Prefer robust counts derived from raw file to ensure consistency
-                "link_count": robust_counts.get("link_count", len(links)),
-                "image_count": robust_counts.get("image_count", len(images)),
+                # Prefer robust counts when available; else element-derived counts
+                "link_count": link_count_value,
+                "image_count": image_count_value,
                 "code_block_count": len(code_blocks),
                 "list_count": len(lists),
                 "table_count": len(tables),
@@ -163,6 +167,10 @@ class MarkdownFormatter(BaseFormatter):
         # Robust counts to avoid undercount due to parser variance
         robust_counts = self._compute_robust_counts_from_file(file_path)
 
+        # Prefer robust counts only when they are non-zero; otherwise fallback to element counts
+        link_count_value = robust_counts.get("link_count", 0) or len(links)
+        image_count_value = robust_counts.get("image_count", 0) or len(images)
+
         advanced_data = {
             "file_path": file_path,
             "language": "markdown",
@@ -174,11 +182,11 @@ class MarkdownFormatter(BaseFormatter):
                 "header_count": len(headers),
                 "max_header_level": max_header_level,
                 "avg_header_level": round(avg_header_level, 2),
-                # Prefer robust counts derived from raw file to ensure consistency
-                "link_count": robust_counts.get("link_count", len(links)),
+                # Prefer robust counts when available; else element-derived counts
+                "link_count": link_count_value,
                 "external_link_count": len(external_links),
                 "internal_link_count": len(internal_links),
-                "image_count": robust_counts.get("image_count", len(images)),
+                "image_count": image_count_value,
                 "code_block_count": len(code_blocks),
                 "total_code_lines": total_code_lines,
                 "list_count": len(lists),


### PR DESCRIPTION
Stabilize Markdown link and image counts in CLI outputs to prevent undercounting and CI failures.

The previous AST-based counting could sometimes undercount links (e.g., autolinks) and images (e.g., reference definitions), leading to inconsistent CLI outputs and CI failures. This PR introduces a robust regex-based counting mechanism from the raw file content, which is now preferred for `--structure` and `--advanced` commands. For `--summary`, it ensures consistency by adding placeholder autolinks if the robust count is higher.

---
<a href="https://cursor.com/background-agent?bcId=bc-7f2b6ee7-143b-41e4-b743-4d683a2937e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7f2b6ee7-143b-41e4-b743-4d683a2937e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

