### PR TITLE
Added support for c/c++

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -285,6 +285,8 @@ csharp = "tree_sitter_analyzer.languages.csharp_plugin:CSharpPlugin"
 sql = "tree_sitter_analyzer.languages.sql_plugin:SQLPlugin"
 php = "tree_sitter_analyzer.languages.php_plugin:PHPPlugin"
 ruby = "tree_sitter_analyzer.languages.ruby_plugin:RubyPlugin"
+cpp = "tree_sitter_analyzer.languages.cpp_plugin:CppPlugin"
+c = "tree_sitter_analyzer.languages.c_plugin:CPlugin"
 
 [project.urls]
 Homepage = "https://github.com/aimasteracc/tree-sitter-analyzer"

--- a/tests/test_languages/test_c_plugin.py
+++ b/tests/test_languages/test_c_plugin.py
@@ -1,0 +1,527 @@
+#!/usr/bin/env python3
+"""
+Tests for tree_sitter_analyzer.languages.c_plugin module.
+
+This module tests the CPlugin class which provides C language
+support in the new plugin architecture.
+"""
+
+import os
+import tempfile
+from unittest.mock import Mock, patch
+
+import pytest
+
+from tree_sitter_analyzer.languages.c_plugin import CElementExtractor, CPlugin
+from tree_sitter_analyzer.models import Class, Function, Import
+from tree_sitter_analyzer.plugins.base import ElementExtractor, LanguagePlugin
+
+
+class TestCElementExtractor:
+    """Test cases for CElementExtractor class"""
+
+    @pytest.fixture
+    def extractor(self) -> CElementExtractor:
+        """Create a CElementExtractor instance for testing"""
+        return CElementExtractor()
+
+    @pytest.fixture
+    def mock_tree(self) -> Mock:
+        """Create a mock tree-sitter tree"""
+        tree = Mock()
+        root_node = Mock()
+        root_node.children = []
+        tree.root_node = root_node
+        tree.language = Mock()
+        return tree
+
+    @pytest.fixture
+    def sample_c_code(self) -> str:
+        """Sample C code for testing"""
+        return """
+#include <stdio.h>
+#include <stdlib.h>
+
+/**
+ * Calculator struct for basic arithmetic operations
+ */
+typedef struct {
+    int value;
+    char* name;
+} Calculator;
+
+/**
+ * Initialize the calculator
+ */
+Calculator* calculator_init(int initialValue) {
+    Calculator* calc = malloc(sizeof(Calculator));
+    if (calc) {
+        calc->value = initialValue;
+        calc->name = "Calculator";
+    }
+    return calc;
+}
+
+/**
+ * Add a number to the current value
+ */
+int calculator_add(Calculator* calc, int number) {
+    if (calc) {
+        return calc->value + number;
+    }
+    return 0;
+}
+
+/**
+ * Get the current value
+ */
+int calculator_get_value(const Calculator* calc) {
+    return calc ? calc->value : 0;
+}
+
+static void internal_function(void) {
+    printf("Internal function\\n");
+}
+"""
+
+    def test_extractor_initialization(self, extractor: CElementExtractor) -> None:
+        """Test CElementExtractor initialization"""
+        assert extractor is not None
+        assert isinstance(extractor, ElementExtractor)
+        assert hasattr(extractor, "extract_functions")
+        assert hasattr(extractor, "extract_classes")
+        assert hasattr(extractor, "extract_variables")
+        assert hasattr(extractor, "extract_imports")
+
+    def test_extract_functions_success(
+        self, extractor: CElementExtractor, mock_tree: Mock
+    ) -> None:
+        """Test successful function extraction"""
+        mock_query = Mock()
+        mock_tree.language.query.return_value = mock_query
+        mock_query.captures.return_value = {"function.definition": []}
+
+        functions = extractor.extract_functions(mock_tree, "test code")
+
+        assert isinstance(functions, list)
+
+    def test_extract_functions_no_language(
+        self, extractor: CElementExtractor
+    ) -> None:
+        """Test function extraction when language is not available"""
+        mock_tree = Mock()
+        mock_tree.language = None
+        mock_root = Mock()
+        mock_root.children = []
+        mock_tree.root_node = mock_root
+
+        functions = extractor.extract_functions(mock_tree, "test code")
+
+        assert isinstance(functions, list)
+        assert len(functions) == 0
+
+    def test_extract_classes_success(
+        self, extractor: CElementExtractor, mock_tree: Mock
+    ) -> None:
+        """Test successful class extraction (structs in C)"""
+        mock_query = Mock()
+        mock_tree.language.query.return_value = mock_query
+        mock_query.captures.return_value = {"struct.specifier": []}
+
+        classes = extractor.extract_classes(mock_tree, "test code")
+
+        assert isinstance(classes, list)
+
+    def test_extract_variables_success(
+        self, extractor: CElementExtractor, mock_tree: Mock
+    ) -> None:
+        """Test successful variable extraction"""
+        mock_query = Mock()
+        mock_tree.language.query.return_value = mock_query
+        mock_query.captures.return_value = {"field.declaration": []}
+
+        variables = extractor.extract_variables(mock_tree, "test code")
+
+        assert isinstance(variables, list)
+
+    def test_extract_imports_success(
+        self, extractor: CElementExtractor, mock_tree: Mock
+    ) -> None:
+        """Test successful import extraction"""
+        mock_query = Mock()
+        mock_tree.language.query.return_value = mock_query
+        mock_query.captures.return_value = {"include": []}
+
+        imports = extractor.extract_imports(mock_tree, "test code")
+
+        assert isinstance(imports, list)
+
+    def test_extract_function_optimized(
+        self, extractor: CElementExtractor
+    ) -> None:
+        """Test optimized function extraction"""
+        mock_node = Mock()
+        mock_node.type = "function_definition"
+        mock_node.start_point = (0, 0)
+        mock_node.end_point = (10, 0)
+        mock_node.start_byte = 0
+        mock_node.end_byte = 100
+        mock_node.children = []
+
+        result = extractor._extract_function_optimized(mock_node)
+
+        assert result is None or isinstance(result, Function)
+
+    def test_extract_struct_optimized(self, extractor: CElementExtractor) -> None:
+        """Test optimized struct extraction"""
+        mock_node = Mock()
+        mock_node.type = "struct_specifier"
+        mock_node.start_point = (0, 0)
+        mock_node.end_point = (10, 0)
+        mock_node.start_byte = 0
+        mock_node.end_byte = 100
+        mock_node.children = []
+
+        result = extractor._extract_struct_optimized(mock_node)
+
+        assert result is None or isinstance(result, Class)
+
+    def test_extract_union_optimized(self, extractor: CElementExtractor) -> None:
+        """Test optimized union extraction"""
+        mock_node = Mock()
+        mock_node.type = "union_specifier"
+        mock_node.start_point = (0, 0)
+        mock_node.end_point = (10, 0)
+        mock_node.start_byte = 0
+        mock_node.end_byte = 100
+        mock_node.children = []
+
+        result = extractor._extract_union_optimized(mock_node)
+
+        assert result is None or isinstance(result, Class)
+
+    def test_extract_enum_optimized(self, extractor: CElementExtractor) -> None:
+        """Test optimized enum extraction"""
+        mock_node = Mock()
+        mock_node.type = "enum_specifier"
+        mock_node.start_point = (0, 0)
+        mock_node.end_point = (10, 0)
+        mock_node.start_byte = 0
+        mock_node.end_byte = 100
+        mock_node.children = []
+
+        result = extractor._extract_enum_optimized(mock_node)
+
+        assert result is None or isinstance(result, Class)
+
+    def test_extract_field_optimized(self, extractor: CElementExtractor) -> None:
+        """Test field information extraction"""
+        mock_node = Mock()
+        mock_node.type = "field_declaration"
+        mock_node.start_point = (0, 0)
+        mock_node.end_point = (1, 0)
+        mock_node.start_byte = 0
+        mock_node.end_byte = 20
+        mock_node.children = []
+
+        result = extractor._extract_field_optimized(mock_node)
+
+        assert isinstance(result, list)
+
+    def test_calculate_complexity_optimized(
+        self, extractor: CElementExtractor
+    ) -> None:
+        """Test complexity calculation"""
+        simple_node = Mock()
+        simple_node.type = "return_statement"
+        simple_node.children = []
+
+        complex_node = Mock()
+        complex_node.type = "if_statement"
+        complex_node.children = [Mock(), Mock(), Mock()]
+
+        simple_complexity = extractor._calculate_complexity_optimized(simple_node)
+        complex_complexity = extractor._calculate_complexity_optimized(complex_node)
+
+        assert isinstance(simple_complexity, int)
+        assert isinstance(complex_complexity, int)
+        assert simple_complexity >= 1
+        assert complex_complexity >= 1
+
+
+class TestCPlugin:
+    """Test cases for CPlugin class"""
+
+    @pytest.fixture
+    def plugin(self) -> CPlugin:
+        """Create a CPlugin instance for testing"""
+        return CPlugin()
+
+    def test_plugin_initialization(self, plugin: CPlugin) -> None:
+        """Test CPlugin initialization"""
+        assert plugin is not None
+        assert isinstance(plugin, LanguagePlugin)
+        assert hasattr(plugin, "get_language_name")
+        assert hasattr(plugin, "get_file_extensions")
+        assert hasattr(plugin, "create_extractor")
+
+    def test_get_language_name(self, plugin: CPlugin) -> None:
+        """Test getting language name"""
+        language_name = plugin.get_language_name()
+
+        assert language_name == "c"
+
+    def test_get_file_extensions(self, plugin: CPlugin) -> None:
+        """Test getting file extensions"""
+        extensions = plugin.get_file_extensions()
+
+        assert isinstance(extensions, list)
+        assert ".c" in extensions
+        assert ".h" in extensions
+
+    def test_create_extractor(self, plugin: CPlugin) -> None:
+        """Test creating element extractor"""
+        extractor = plugin.create_extractor()
+
+        assert isinstance(extractor, CElementExtractor)
+        assert isinstance(extractor, ElementExtractor)
+
+    def test_is_applicable_c_file(self, plugin: CPlugin) -> None:
+        """Test applicability check for C file"""
+        assert plugin.is_applicable("test.c") is True
+        assert plugin.is_applicable("test.h") is True
+
+    def test_is_applicable_non_c_file(self, plugin: CPlugin) -> None:
+        """Test applicability check for non-C file"""
+        assert plugin.is_applicable("test.py") is False
+        assert plugin.is_applicable("test.java") is False
+        assert plugin.is_applicable("test.cpp") is False
+
+    def test_get_plugin_info(self, plugin: CPlugin) -> None:
+        """Test getting plugin information"""
+        info = plugin.get_plugin_info()
+
+        assert isinstance(info, dict)
+        assert "language" in info
+        assert "extensions" in info
+        assert info["language"] == "c"
+
+    def test_get_tree_sitter_language(self, plugin: CPlugin) -> None:
+        """Test getting tree-sitter language"""
+        with (
+            patch("tree_sitter_c.language") as mock_language,
+            patch("tree_sitter.Language") as mock_language_constructor,
+        ):
+            mock_lang_obj = Mock()
+            mock_language.return_value = mock_lang_obj
+            mock_language_constructor.return_value = mock_lang_obj
+
+            language = plugin.get_tree_sitter_language()
+
+            assert language is mock_lang_obj
+
+    def test_get_tree_sitter_language_caching(self, plugin: CPlugin) -> None:
+        """Test tree-sitter language caching"""
+        with (
+            patch("tree_sitter_c.language") as mock_language,
+            patch("tree_sitter.Language") as mock_language_constructor,
+        ):
+            mock_lang_obj = Mock()
+            mock_language.return_value = mock_lang_obj
+            mock_language_constructor.return_value = mock_lang_obj
+
+            language1 = plugin.get_tree_sitter_language()
+            language2 = plugin.get_tree_sitter_language()
+
+            assert language1 is language2
+            mock_language.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_analyze_file_success(self, plugin: CPlugin) -> None:
+        """Test successful file analysis"""
+        c_code = """
+#include <stdio.h>
+
+int main() {
+    printf("Hello, World!\\n");
+    return 0;
+}
+"""
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".c", delete=False) as f:
+            f.write(c_code)
+            temp_path = f.name
+
+        try:
+            mock_request = Mock()
+            mock_request.file_path = temp_path
+            mock_request.language = "c"
+            mock_request.include_complexity = False
+            mock_request.include_details = False
+
+            result = await plugin.analyze_file(temp_path, mock_request)
+
+            assert result is not None
+            assert hasattr(result, "success")
+            assert hasattr(result, "file_path")
+            assert hasattr(result, "language")
+
+        finally:
+            os.unlink(temp_path)
+
+    @pytest.mark.asyncio
+    async def test_analyze_file_nonexistent(self, plugin: CPlugin) -> None:
+        """Test analysis of non-existent file"""
+        mock_request = Mock()
+        mock_request.file_path = "/nonexistent/file.c"
+        mock_request.language = "c"
+
+        result = await plugin.analyze_file("/nonexistent/file.c", mock_request)
+
+        assert result is not None
+        assert hasattr(result, "success")
+        assert result.success is False
+
+
+class TestCPluginErrorHandling:
+    """Test error handling in CPlugin"""
+
+    @pytest.fixture
+    def plugin(self) -> CPlugin:
+        """Create a CPlugin instance for testing"""
+        return CPlugin()
+
+    @pytest.fixture
+    def extractor(self) -> CElementExtractor:
+        """Create a CElementExtractor instance for testing"""
+        return CElementExtractor()
+
+    def test_extract_functions_with_exception(
+        self, extractor: CElementExtractor
+    ) -> None:
+        """Test function extraction with exception"""
+        mock_tree = Mock()
+        mock_tree.language = None
+        mock_root = Mock()
+        mock_root.children = []
+        mock_tree.root_node = mock_root
+
+        functions = extractor.extract_functions(mock_tree, "test code")
+
+        assert isinstance(functions, list)
+        assert len(functions) == 0
+
+    def test_extract_classes_with_exception(
+        self, extractor: CElementExtractor
+    ) -> None:
+        """Test class extraction with exception"""
+        mock_tree = Mock()
+        mock_tree.language = None
+        mock_root = Mock()
+        mock_root.children = []
+        mock_tree.root_node = mock_root
+
+        classes = extractor.extract_classes(mock_tree, "test code")
+
+        assert isinstance(classes, list)
+        assert len(classes) == 0
+
+    def test_get_tree_sitter_language_failure(self, plugin: CPlugin) -> None:
+        """Test tree-sitter language loading failure"""
+        with patch("tree_sitter_c.language") as mock_language:
+            mock_language.side_effect = ImportError("Module not found")
+
+            language = plugin.get_tree_sitter_language()
+
+            assert language is None
+
+    @pytest.mark.asyncio
+    async def test_analyze_file_with_exception(self, plugin: CPlugin) -> None:
+        """Test file analysis with exception"""
+        c_code = "int main() { return 0; }"
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".c", delete=False) as f:
+            f.write(c_code)
+            temp_path = f.name
+
+        try:
+            mock_request = Mock()
+            mock_request.file_path = temp_path
+            mock_request.language = "c"
+
+            with patch("builtins.open") as mock_open:
+                mock_open.side_effect = Exception("Read error")
+
+                result = await plugin.analyze_file(temp_path, mock_request)
+
+                assert result is not None
+                assert hasattr(result, "success")
+                assert result.success is False
+
+        finally:
+            os.unlink(temp_path)
+
+
+class TestCPluginIntegration:
+    """Integration tests for CPlugin"""
+
+    @pytest.fixture
+    def plugin(self) -> CPlugin:
+        """Create a CPlugin instance for testing"""
+        return CPlugin()
+
+    def test_full_extraction_workflow(self, plugin: CPlugin) -> None:
+        """Test complete extraction workflow"""
+        extractor = plugin.create_extractor()
+        assert isinstance(extractor, CElementExtractor)
+
+        # Test applicability
+        assert plugin.is_applicable("main.c") is True
+        assert plugin.is_applicable("calculator.py") is False
+
+        # Test plugin info
+        info = plugin.get_plugin_info()
+        assert info["language"] == "c"
+        assert ".c" in info["extensions"]
+
+    def test_plugin_consistency(self, plugin: CPlugin) -> None:
+        """Test plugin consistency across multiple calls"""
+        for _ in range(5):
+            assert plugin.get_language_name() == "c"
+            assert ".c" in plugin.get_file_extensions()
+            assert isinstance(plugin.create_extractor(), CElementExtractor)
+
+    def test_extractor_consistency(self, plugin: CPlugin) -> None:
+        """Test extractor consistency"""
+        extractor1 = plugin.create_extractor()
+        extractor2 = plugin.create_extractor()
+
+        assert extractor1 is not extractor2
+        assert isinstance(extractor1, CElementExtractor)
+        assert isinstance(extractor2, CElementExtractor)
+
+    def test_plugin_with_various_c_files(self, plugin: CPlugin) -> None:
+        """Test plugin with various C file types"""
+        c_files = [
+            "test.c",
+            "test.h",
+            "src/main.c",
+            "include/header.h",
+            "TEST.C",
+            "test.H",
+        ]
+
+        for c_file in c_files:
+            assert plugin.is_applicable(c_file) is True
+
+        non_c_files = [
+            "test.py",
+            "test.java",
+            "test.cpp",  # C++ files should not match C plugin
+            "test.hpp",
+            "test.txt",
+            "c.txt",
+        ]
+
+        for non_c_file in non_c_files:
+            assert plugin.is_applicable(non_c_file) is False

--- a/tests/test_languages/test_cpp_plugin.py
+++ b/tests/test_languages/test_cpp_plugin.py
@@ -1,0 +1,509 @@
+#!/usr/bin/env python3
+"""
+Tests for tree_sitter_analyzer.languages.cpp_plugin module.
+
+This module tests the CppPlugin class which provides C++ language
+support in the new plugin architecture.
+"""
+
+import os
+import tempfile
+from unittest.mock import Mock, patch
+
+import pytest
+
+from tree_sitter_analyzer.languages.cpp_plugin import CppElementExtractor, CppPlugin
+from tree_sitter_analyzer.models import Class, Function, Import
+from tree_sitter_analyzer.plugins.base import ElementExtractor, LanguagePlugin
+
+
+class TestCppElementExtractor:
+    """Test cases for CppElementExtractor class"""
+
+    @pytest.fixture
+    def extractor(self) -> CppElementExtractor:
+        """Create a CppElementExtractor instance for testing"""
+        return CppElementExtractor()
+
+    @pytest.fixture
+    def mock_tree(self) -> Mock:
+        """Create a mock tree-sitter tree"""
+        tree = Mock()
+        root_node = Mock()
+        root_node.children = []
+        tree.root_node = root_node
+        tree.language = Mock()
+        return tree
+
+    @pytest.fixture
+    def sample_cpp_code(self) -> str:
+        """Sample C++ code for testing"""
+        return """
+#include <iostream>
+#include <string>
+
+namespace example {
+
+/**
+ * Calculator class for basic arithmetic operations
+ */
+class Calculator {
+private:
+    int value;
+    static const std::string VERSION;
+
+public:
+    /**
+     * Constructor
+     */
+    Calculator(int initialValue) : value(initialValue) {}
+
+    /**
+     * Add a number to the current value
+     */
+    int add(int number) {
+        return value + number;
+    }
+
+    /**
+     * Get the current value
+     */
+    int getValue() const {
+        return value;
+    }
+
+    virtual void reset() {
+        value = 0;
+    }
+};
+
+const std::string Calculator::VERSION = "1.0";
+
+}  // namespace example
+"""
+
+    def test_extractor_initialization(self, extractor: CppElementExtractor) -> None:
+        """Test CppElementExtractor initialization"""
+        assert extractor is not None
+        assert isinstance(extractor, ElementExtractor)
+        assert hasattr(extractor, "extract_functions")
+        assert hasattr(extractor, "extract_classes")
+        assert hasattr(extractor, "extract_variables")
+        assert hasattr(extractor, "extract_imports")
+
+    def test_extract_functions_success(
+        self, extractor: CppElementExtractor, mock_tree: Mock
+    ) -> None:
+        """Test successful function extraction"""
+        # Mock the language query
+        mock_query = Mock()
+        mock_tree.language.query.return_value = mock_query
+        mock_query.captures.return_value = {"function.definition": []}
+
+        functions = extractor.extract_functions(mock_tree, "test code")
+
+        assert isinstance(functions, list)
+
+    def test_extract_functions_no_language(
+        self, extractor: CppElementExtractor
+    ) -> None:
+        """Test function extraction when language is not available"""
+        mock_tree = Mock()
+        mock_tree.language = None
+        mock_root = Mock()
+        mock_root.children = []
+        mock_tree.root_node = mock_root
+
+        functions = extractor.extract_functions(mock_tree, "test code")
+
+        assert isinstance(functions, list)
+        assert len(functions) == 0
+
+    def test_extract_classes_success(
+        self, extractor: CppElementExtractor, mock_tree: Mock
+    ) -> None:
+        """Test successful class extraction"""
+        mock_query = Mock()
+        mock_tree.language.query.return_value = mock_query
+        mock_query.captures.return_value = {"class.specifier": []}
+
+        classes = extractor.extract_classes(mock_tree, "test code")
+
+        assert isinstance(classes, list)
+
+    def test_extract_variables_success(
+        self, extractor: CppElementExtractor, mock_tree: Mock
+    ) -> None:
+        """Test successful variable extraction"""
+        mock_query = Mock()
+        mock_tree.language.query.return_value = mock_query
+        mock_query.captures.return_value = {"field.declaration": []}
+
+        variables = extractor.extract_variables(mock_tree, "test code")
+
+        assert isinstance(variables, list)
+
+    def test_extract_imports_success(
+        self, extractor: CppElementExtractor, mock_tree: Mock
+    ) -> None:
+        """Test successful import extraction"""
+        mock_query = Mock()
+        mock_tree.language.query.return_value = mock_query
+        mock_query.captures.return_value = {"include": []}
+
+        imports = extractor.extract_imports(mock_tree, "test code")
+
+        assert isinstance(imports, list)
+
+    def test_extract_function_optimized(
+        self, extractor: CppElementExtractor
+    ) -> None:
+        """Test optimized function extraction"""
+        mock_node = Mock()
+        mock_node.type = "function_definition"
+        mock_node.start_point = (0, 0)
+        mock_node.end_point = (10, 0)
+        mock_node.start_byte = 0
+        mock_node.end_byte = 100
+        mock_node.children = []
+
+        result = extractor._extract_function_optimized(mock_node)
+
+        # The method should handle the mock gracefully
+        assert result is None or isinstance(result, Function)
+
+    def test_extract_class_optimized(self, extractor: CppElementExtractor) -> None:
+        """Test optimized class extraction"""
+        mock_node = Mock()
+        mock_node.type = "class_specifier"
+        mock_node.start_point = (0, 0)
+        mock_node.end_point = (10, 0)
+        mock_node.start_byte = 0
+        mock_node.end_byte = 100
+        mock_node.children = []
+
+        result = extractor._extract_class_optimized(mock_node)
+
+        # The method should handle the mock gracefully
+        assert result is None or isinstance(result, Class)
+
+    def test_extract_field_optimized(self, extractor: CppElementExtractor) -> None:
+        """Test field information extraction"""
+        mock_node = Mock()
+        mock_node.type = "field_declaration"
+        mock_node.start_point = (0, 0)
+        mock_node.end_point = (1, 0)
+        mock_node.start_byte = 0
+        mock_node.end_byte = 20
+        mock_node.children = []
+
+        result = extractor._extract_field_optimized(mock_node)
+
+        # The method should handle the mock gracefully and return a list
+        assert isinstance(result, list)
+
+    def test_calculate_complexity_optimized(
+        self, extractor: CppElementExtractor
+    ) -> None:
+        """Test complexity calculation"""
+        simple_node = Mock()
+        simple_node.type = "return_statement"
+        simple_node.children = []
+
+        complex_node = Mock()
+        complex_node.type = "if_statement"
+        complex_node.children = [Mock(), Mock(), Mock()]
+
+        simple_complexity = extractor._calculate_complexity_optimized(simple_node)
+        complex_complexity = extractor._calculate_complexity_optimized(complex_node)
+
+        assert isinstance(simple_complexity, int)
+        assert isinstance(complex_complexity, int)
+        assert simple_complexity >= 1
+        assert complex_complexity >= 1
+
+
+class TestCppPlugin:
+    """Test cases for CppPlugin class"""
+
+    @pytest.fixture
+    def plugin(self) -> CppPlugin:
+        """Create a CppPlugin instance for testing"""
+        return CppPlugin()
+
+    def test_plugin_initialization(self, plugin: CppPlugin) -> None:
+        """Test CppPlugin initialization"""
+        assert plugin is not None
+        assert isinstance(plugin, LanguagePlugin)
+        assert hasattr(plugin, "get_language_name")
+        assert hasattr(plugin, "get_file_extensions")
+        assert hasattr(plugin, "create_extractor")
+
+    def test_get_language_name(self, plugin: CppPlugin) -> None:
+        """Test getting language name"""
+        language_name = plugin.get_language_name()
+
+        assert language_name == "cpp"
+
+    def test_get_file_extensions(self, plugin: CppPlugin) -> None:
+        """Test getting file extensions"""
+        extensions = plugin.get_file_extensions()
+
+        assert isinstance(extensions, list)
+        assert ".cpp" in extensions
+        assert ".hpp" in extensions
+        assert ".cc" in extensions
+        assert ".cxx" in extensions
+
+    def test_create_extractor(self, plugin: CppPlugin) -> None:
+        """Test creating element extractor"""
+        extractor = plugin.create_extractor()
+
+        assert isinstance(extractor, CppElementExtractor)
+        assert isinstance(extractor, ElementExtractor)
+
+    def test_is_applicable_cpp_file(self, plugin: CppPlugin) -> None:
+        """Test applicability check for C++ file"""
+        assert plugin.is_applicable("test.cpp") is True
+        assert plugin.is_applicable("test.hpp") is True
+        assert plugin.is_applicable("test.cc") is True
+        assert plugin.is_applicable("test.cxx") is True
+
+    def test_is_applicable_non_cpp_file(self, plugin: CppPlugin) -> None:
+        """Test applicability check for non-C++ file"""
+        assert plugin.is_applicable("test.py") is False
+        assert plugin.is_applicable("test.java") is False
+        assert plugin.is_applicable("test.c") is False
+
+    def test_get_plugin_info(self, plugin: CppPlugin) -> None:
+        """Test getting plugin information"""
+        info = plugin.get_plugin_info()
+
+        assert isinstance(info, dict)
+        assert "language" in info
+        assert "extensions" in info
+        assert info["language"] == "cpp"
+
+    def test_get_tree_sitter_language(self, plugin: CppPlugin) -> None:
+        """Test getting tree-sitter language"""
+        with (
+            patch("tree_sitter_cpp.language") as mock_language,
+            patch("tree_sitter.Language") as mock_language_constructor,
+        ):
+            mock_lang_obj = Mock()
+            mock_language.return_value = mock_lang_obj
+            mock_language_constructor.return_value = mock_lang_obj
+
+            language = plugin.get_tree_sitter_language()
+
+            assert language is mock_lang_obj
+
+    def test_get_tree_sitter_language_caching(self, plugin: CppPlugin) -> None:
+        """Test tree-sitter language caching"""
+        with (
+            patch("tree_sitter_cpp.language") as mock_language,
+            patch("tree_sitter.Language") as mock_language_constructor,
+        ):
+            mock_lang_obj = Mock()
+            mock_language.return_value = mock_lang_obj
+            mock_language_constructor.return_value = mock_lang_obj
+
+            # First call
+            language1 = plugin.get_tree_sitter_language()
+
+            # Second call (should use cache)
+            language2 = plugin.get_tree_sitter_language()
+
+            assert language1 is language2
+            mock_language.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_analyze_file_success(self, plugin: CppPlugin) -> None:
+        """Test successful file analysis"""
+        cpp_code = """
+class TestClass {
+public:
+    void testMethod() {
+        std::cout << "Hello" << std::endl;
+    }
+};
+"""
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".cpp", delete=False) as f:
+            f.write(cpp_code)
+            temp_path = f.name
+
+        try:
+            mock_request = Mock()
+            mock_request.file_path = temp_path
+            mock_request.language = "cpp"
+            mock_request.include_complexity = False
+            mock_request.include_details = False
+
+            result = await plugin.analyze_file(temp_path, mock_request)
+
+            assert result is not None
+            assert hasattr(result, "success")
+            assert hasattr(result, "file_path")
+            assert hasattr(result, "language")
+
+        finally:
+            os.unlink(temp_path)
+
+    @pytest.mark.asyncio
+    async def test_analyze_file_nonexistent(self, plugin: CppPlugin) -> None:
+        """Test analysis of non-existent file"""
+        mock_request = Mock()
+        mock_request.file_path = "/nonexistent/file.cpp"
+        mock_request.language = "cpp"
+
+        result = await plugin.analyze_file("/nonexistent/file.cpp", mock_request)
+
+        assert result is not None
+        assert hasattr(result, "success")
+        assert result.success is False
+
+
+class TestCppPluginErrorHandling:
+    """Test error handling in CppPlugin"""
+
+    @pytest.fixture
+    def plugin(self) -> CppPlugin:
+        """Create a CppPlugin instance for testing"""
+        return CppPlugin()
+
+    @pytest.fixture
+    def extractor(self) -> CppElementExtractor:
+        """Create a CppElementExtractor instance for testing"""
+        return CppElementExtractor()
+
+    def test_extract_functions_with_exception(
+        self, extractor: CppElementExtractor
+    ) -> None:
+        """Test function extraction with exception"""
+        mock_tree = Mock()
+        mock_tree.language = None
+        mock_root = Mock()
+        mock_root.children = []
+        mock_tree.root_node = mock_root
+
+        functions = extractor.extract_functions(mock_tree, "test code")
+
+        assert isinstance(functions, list)
+        assert len(functions) == 0
+
+    def test_extract_classes_with_exception(
+        self, extractor: CppElementExtractor
+    ) -> None:
+        """Test class extraction with exception"""
+        mock_tree = Mock()
+        mock_tree.language = None
+        mock_root = Mock()
+        mock_root.children = []
+        mock_tree.root_node = mock_root
+
+        classes = extractor.extract_classes(mock_tree, "test code")
+
+        assert isinstance(classes, list)
+        assert len(classes) == 0
+
+    def test_get_tree_sitter_language_failure(self, plugin: CppPlugin) -> None:
+        """Test tree-sitter language loading failure"""
+        with patch("tree_sitter_cpp.language") as mock_language:
+            mock_language.side_effect = ImportError("Module not found")
+
+            language = plugin.get_tree_sitter_language()
+
+            assert language is None
+
+    @pytest.mark.asyncio
+    async def test_analyze_file_with_exception(self, plugin: CppPlugin) -> None:
+        """Test file analysis with exception"""
+        cpp_code = "class Test {};"
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".cpp", delete=False) as f:
+            f.write(cpp_code)
+            temp_path = f.name
+
+        try:
+            mock_request = Mock()
+            mock_request.file_path = temp_path
+            mock_request.language = "cpp"
+
+            with patch("builtins.open") as mock_open:
+                mock_open.side_effect = Exception("Read error")
+
+                result = await plugin.analyze_file(temp_path, mock_request)
+
+                assert result is not None
+                assert hasattr(result, "success")
+                assert result.success is False
+
+        finally:
+            os.unlink(temp_path)
+
+
+class TestCppPluginIntegration:
+    """Integration tests for CppPlugin"""
+
+    @pytest.fixture
+    def plugin(self) -> CppPlugin:
+        """Create a CppPlugin instance for testing"""
+        return CppPlugin()
+
+    def test_full_extraction_workflow(self, plugin: CppPlugin) -> None:
+        """Test complete extraction workflow"""
+        extractor = plugin.create_extractor()
+        assert isinstance(extractor, CppElementExtractor)
+
+        # Test applicability
+        assert plugin.is_applicable("Calculator.cpp") is True
+        assert plugin.is_applicable("calculator.py") is False
+
+        # Test plugin info
+        info = plugin.get_plugin_info()
+        assert info["language"] == "cpp"
+        assert ".cpp" in info["extensions"]
+
+    def test_plugin_consistency(self, plugin: CppPlugin) -> None:
+        """Test plugin consistency across multiple calls"""
+        for _ in range(5):
+            assert plugin.get_language_name() == "cpp"
+            assert ".cpp" in plugin.get_file_extensions()
+            assert isinstance(plugin.create_extractor(), CppElementExtractor)
+
+    def test_extractor_consistency(self, plugin: CppPlugin) -> None:
+        """Test extractor consistency"""
+        extractor1 = plugin.create_extractor()
+        extractor2 = plugin.create_extractor()
+
+        assert extractor1 is not extractor2
+        assert isinstance(extractor1, CppElementExtractor)
+        assert isinstance(extractor2, CppElementExtractor)
+
+    def test_plugin_with_various_cpp_files(self, plugin: CppPlugin) -> None:
+        """Test plugin with various C++ file types"""
+        cpp_files = [
+            "test.cpp",
+            "test.hpp",
+            "test.cc",
+            "test.cxx",
+            "src/main.cpp",
+            "include/header.hpp",
+            "TEST.CPP",
+            "test.Cpp",
+        ]
+
+        for cpp_file in cpp_files:
+            assert plugin.is_applicable(cpp_file) is True
+
+        non_cpp_files = [
+            "test.py",
+            "test.java",
+            "test.c",  # C files should not match C++ plugin
+            "test.txt",
+            "cpp.txt",
+        ]
+
+        for non_cpp_file in non_cpp_files:
+            assert plugin.is_applicable(non_cpp_file) is False

--- a/tree_sitter_analyzer/languages/c_plugin.py
+++ b/tree_sitter_analyzer/languages/c_plugin.py
@@ -1,0 +1,958 @@
+#!/usr/bin/env python3
+"""
+C Language Plugin
+
+Provides C specific parsing and element extraction functionality.
+Supports standard C constructs including functions, structs, unions,
+enums, and preprocessor directives.
+"""
+
+import re
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import tree_sitter
+
+    from ..core.analysis_engine import AnalysisRequest
+    from ..models import AnalysisResult
+
+from ..encoding_utils import extract_text_slice, safe_encode
+from ..models import Class, Function, Import, Variable
+from ..plugins.base import ElementExtractor, LanguagePlugin
+from ..utils import log_debug, log_error, log_warning
+
+
+class CElementExtractor(ElementExtractor):
+    """C specific element extractor with advanced analysis support"""
+
+    def __init__(self) -> None:
+        """Initialize the C element extractor."""
+        self.current_file: str = ""
+        self.source_code: str = ""
+        self.content_lines: list[str] = []
+        self.includes: list[str] = []
+
+        # Performance optimization caches
+        self._node_text_cache: dict[int, str] = {}
+        self._processed_nodes: set[int] = set()
+        self._element_cache: dict[tuple[int, str], Any] = {}
+        self._file_encoding: str | None = None
+        self._comment_cache: dict[int, str] = {}
+        self._complexity_cache: dict[int, int] = {}
+
+    def extract_functions(
+        self, tree: "tree_sitter.Tree", source_code: str
+    ) -> list[Function]:
+        """Extract C function definitions with comprehensive details"""
+        self.source_code = source_code
+        self.content_lines = source_code.split("\n")
+        self._reset_caches()
+
+        functions: list[Function] = []
+
+        # Use optimized traversal for function types
+        extractors = {
+            "function_definition": self._extract_function_optimized,
+        }
+
+        self._traverse_and_extract_iterative(
+            tree.root_node, extractors, functions, "function"
+        )
+
+        log_debug(f"Extracted {len(functions)} C functions")
+        return functions
+
+    def extract_classes(
+        self, tree: "tree_sitter.Tree", source_code: str
+    ) -> list[Class]:
+        """Extract C struct/union/enum definitions as 'classes'"""
+        self.source_code = source_code
+        self.content_lines = source_code.split("\n")
+        self._reset_caches()
+
+        classes: list[Class] = []
+
+        # Extract struct, union, and enum declarations
+        extractors = {
+            "struct_specifier": self._extract_struct_optimized,
+            "union_specifier": self._extract_union_optimized,
+            "enum_specifier": self._extract_enum_optimized,
+        }
+
+        self._traverse_and_extract_iterative(
+            tree.root_node, extractors, classes, "class"
+        )
+
+        log_debug(f"Extracted {len(classes)} C structs/unions/enums")
+        return classes
+
+    def extract_variables(
+        self, tree: "tree_sitter.Tree", source_code: str
+    ) -> list[Variable]:
+        """Extract C variable/field declarations"""
+        self.source_code = source_code
+        self.content_lines = source_code.split("\n")
+        self._reset_caches()
+
+        variables: list[Variable] = []
+
+        # Extract field and variable declarations
+        extractors = {
+            "field_declaration": self._extract_field_optimized,
+            "declaration": self._extract_variable_declaration,
+        }
+
+        self._traverse_and_extract_iterative(
+            tree.root_node, extractors, variables, "variable"
+        )
+
+        log_debug(f"Extracted {len(variables)} C variables/fields")
+        return variables
+
+    def extract_imports(
+        self, tree: "tree_sitter.Tree", source_code: str
+    ) -> list[Import]:
+        """Extract C include directives"""
+        self.source_code = source_code
+        self.content_lines = source_code.split("\n")
+
+        imports: list[Import] = []
+
+        # Extract preprocessor includes
+        for child in tree.root_node.children:
+            if child.type == "preproc_include":
+                import_info = self._extract_include_info(child, source_code)
+                if import_info:
+                    imports.append(import_info)
+
+        # Fallback: use regex if tree-sitter doesn't catch all includes
+        if not imports and "#include" in source_code:
+            log_debug("No includes found via tree-sitter, trying regex fallback")
+            fallback_imports = self._extract_includes_fallback(source_code)
+            imports.extend(fallback_imports)
+
+        log_debug(f"Extracted {len(imports)} C includes")
+        return imports
+
+    def _reset_caches(self) -> None:
+        """Reset performance caches"""
+        self._node_text_cache.clear()
+        self._processed_nodes.clear()
+        self._element_cache.clear()
+        self._comment_cache.clear()
+        self._complexity_cache.clear()
+
+    def _traverse_and_extract_iterative(
+        self,
+        root_node: "tree_sitter.Node",
+        extractors: dict[str, Any],
+        results: list[Any],
+        element_type: str,
+    ) -> None:
+        """Iterative node traversal and extraction with caching"""
+        if root_node is None:
+            return
+
+        target_node_types = set(extractors.keys())
+        container_node_types = {
+            "translation_unit",
+            "compound_statement",
+            "struct_specifier",
+            "union_specifier",
+            "field_declaration_list",
+            "declaration_list",
+            "type_definition",  # For typedef structs
+        }
+
+        node_stack = [(root_node, 0)]
+        processed_nodes = 0
+        max_depth = 50
+
+        while node_stack:
+            current_node, depth = node_stack.pop()
+
+            if depth > max_depth:
+                log_warning(f"Maximum traversal depth ({max_depth}) exceeded")
+                continue
+
+            processed_nodes += 1
+            node_type = current_node.type
+
+            # Early termination for irrelevant nodes
+            if (
+                depth > 0
+                and node_type not in target_node_types
+                and node_type not in container_node_types
+            ):
+                continue
+
+            # Process target nodes
+            if node_type in target_node_types:
+                node_id = id(current_node)
+
+                if node_id in self._processed_nodes:
+                    continue
+
+                cache_key = (node_id, element_type)
+                if cache_key in self._element_cache:
+                    element = self._element_cache[cache_key]
+                    if element:
+                        if isinstance(element, list):
+                            results.extend(element)
+                        else:
+                            results.append(element)
+                    self._processed_nodes.add(node_id)
+                    continue
+
+                # Extract and cache
+                extractor = extractors.get(node_type)
+                if extractor:
+                    element = extractor(current_node)
+                    self._element_cache[cache_key] = element
+                    if element:
+                        if isinstance(element, list):
+                            results.extend(element)
+                        else:
+                            results.append(element)
+                    self._processed_nodes.add(node_id)
+
+            # Add children to stack (reversed for correct DFS traversal)
+            if current_node.children:
+                for child in reversed(current_node.children):
+                    node_stack.append((child, depth + 1))
+
+        log_debug(f"Iterative traversal processed {processed_nodes} nodes")
+
+    def _get_node_text_optimized(self, node: "tree_sitter.Node") -> str:
+        """Get node text with optimized caching"""
+        node_id = id(node)
+
+        if node_id in self._node_text_cache:
+            return self._node_text_cache[node_id]
+
+        try:
+            start_byte = node.start_byte
+            end_byte = node.end_byte
+
+            encoding = self._file_encoding or "utf-8"
+            content_bytes = safe_encode("\n".join(self.content_lines), encoding)
+            text = extract_text_slice(content_bytes, start_byte, end_byte, encoding)
+
+            self._node_text_cache[node_id] = text
+            return text
+        except Exception as e:
+            log_error(f"Error in _get_node_text_optimized: {e}")
+            # Fallback to simple text extraction
+            try:
+                start_point = node.start_point
+                end_point = node.end_point
+
+                if start_point[0] == end_point[0]:
+                    line = self.content_lines[start_point[0]]
+                    result: str = line[start_point[1] : end_point[1]]
+                    return result
+                else:
+                    lines = []
+                    for i in range(start_point[0], end_point[0] + 1):
+                        if i < len(self.content_lines):
+                            line = self.content_lines[i]
+                            if i == start_point[0]:
+                                lines.append(line[start_point[1] :])
+                            elif i == end_point[0]:
+                                lines.append(line[: end_point[1]])
+                            else:
+                                lines.append(line)
+                    return "\n".join(lines)
+            except Exception as fallback_error:
+                log_error(f"Fallback text extraction also failed: {fallback_error}")
+                return ""
+
+    def _extract_function_optimized(
+        self, node: "tree_sitter.Node"
+    ) -> Function | None:
+        """Extract function information optimized"""
+        try:
+            start_line = node.start_point[0] + 1
+            end_line = node.end_point[0] + 1
+
+            # Extract function details
+            function_info = self._parse_function_signature(node)
+            if not function_info:
+                return None
+
+            name, return_type, parameters, modifiers = function_info
+
+            # Extract raw text
+            start_line_idx = max(0, start_line - 1)
+            end_line_idx = min(len(self.content_lines), end_line)
+            raw_text = "\n".join(self.content_lines[start_line_idx:end_line_idx])
+
+            # Calculate complexity
+            complexity_score = self._calculate_complexity_optimized(node)
+
+            # Extract comments/documentation
+            docstring = self._extract_comment_for_line(start_line)
+
+            return Function(
+                name=name,
+                start_line=start_line,
+                end_line=end_line,
+                raw_text=raw_text,
+                language="c",
+                parameters=parameters,
+                return_type=return_type or "int",
+                modifiers=modifiers,
+                is_static="static" in modifiers,
+                visibility="public",  # C functions are effectively public
+                docstring=docstring,
+                complexity_score=complexity_score,
+            )
+        except (AttributeError, ValueError, TypeError) as e:
+            log_debug(f"Failed to extract function info: {e}")
+            return None
+        except Exception as e:
+            log_error(f"Unexpected error in function extraction: {e}")
+            return None
+
+    def _parse_function_signature(
+        self, node: "tree_sitter.Node"
+    ) -> tuple[str, str, list[str], list[str]] | None:
+        """Parse C function signature"""
+        try:
+            name = None
+            return_type = "int"
+            parameters: list[str] = []
+            modifiers: list[str] = []
+
+            def find_function_declarator(n: "tree_sitter.Node") -> None:
+                """Recursively find function_declarator in pointer_declarator"""
+                nonlocal name, parameters
+                for child in n.children:
+                    if child.type == "function_declarator":
+                        for grandchild in child.children:
+                            if grandchild.type == "identifier":
+                                name = self._get_node_text_optimized(grandchild)
+                            elif grandchild.type == "parameter_list":
+                                parameters = self._extract_parameters(grandchild)
+                    elif child.type == "pointer_declarator":
+                        find_function_declarator(child)
+
+            for child in node.children:
+                if child.type == "function_declarator":
+                    for grandchild in child.children:
+                        if grandchild.type == "identifier":
+                            name = self._get_node_text_optimized(grandchild)
+                        elif grandchild.type == "parameter_list":
+                            parameters = self._extract_parameters(grandchild)
+                elif child.type == "pointer_declarator":
+                    # Handle pointer return types (e.g., int* func())
+                    find_function_declarator(child)
+                    # Mark return type as pointer
+                    if return_type and "*" not in return_type:
+                        return_type = return_type + "*"
+                elif child.type in [
+                    "primitive_type",
+                    "type_identifier",
+                    "sized_type_specifier",
+                ]:
+                    return_type = self._get_node_text_optimized(child)
+                elif child.type == "storage_class_specifier":
+                    mod = self._get_node_text_optimized(child)
+                    if mod:
+                        modifiers.append(mod)
+                elif child.type == "type_qualifier":
+                    mod = self._get_node_text_optimized(child)
+                    if mod:
+                        modifiers.append(mod)
+
+            if not name:
+                return None
+
+            return name, return_type, parameters, modifiers
+        except Exception:
+            return None
+
+    def _extract_parameters(self, params_node: "tree_sitter.Node") -> list[str]:
+        """Extract function parameters"""
+        parameters: list[str] = []
+
+        for child in params_node.children:
+            if child.type == "parameter_declaration":
+                param_text = self._get_node_text_optimized(child)
+                parameters.append(param_text)
+            elif child.type == "variadic_parameter":
+                parameters.append("...")
+
+        return parameters
+
+    def _extract_struct_optimized(self, node: "tree_sitter.Node") -> Class | None:
+        """Extract struct information optimized"""
+        try:
+            start_line = node.start_point[0] + 1
+            end_line = node.end_point[0] + 1
+
+            struct_name = None
+
+            # Look for name in struct_specifier children first (named struct)
+            for child in node.children:
+                if child.type == "type_identifier":
+                    struct_name = self._get_node_text_optimized(child)
+
+            # If anonymous, check if parent is type_definition for typedef name
+            if not struct_name and node.parent and node.parent.type == "type_definition":
+                for sibling in node.parent.children:
+                    if sibling.type == "type_identifier":
+                        struct_name = self._get_node_text_optimized(sibling)
+                        # Use the typedef position for the start/end lines
+                        start_line = node.parent.start_point[0] + 1
+                        end_line = node.parent.end_point[0] + 1
+                        break
+
+            if not struct_name:
+                # Truly anonymous struct
+                struct_name = f"anonymous_struct_{start_line}"
+
+            # Extract raw text
+            start_line_idx = max(0, start_line - 1)
+            end_line_idx = min(len(self.content_lines), end_line)
+            raw_text = "\n".join(self.content_lines[start_line_idx:end_line_idx])
+
+            # Extract comments/documentation
+            docstring = self._extract_comment_for_line(start_line)
+
+            return Class(
+                name=struct_name,
+                start_line=start_line,
+                end_line=end_line,
+                raw_text=raw_text,
+                language="c",
+                class_type="struct",
+                full_qualified_name=struct_name,
+                docstring=docstring,
+            )
+        except Exception as e:
+            log_debug(f"Failed to extract struct info: {e}")
+            return None
+
+    def _extract_union_optimized(self, node: "tree_sitter.Node") -> Class | None:
+        """Extract union information optimized"""
+        try:
+            result = self._extract_struct_optimized(node)
+            if result:
+                result.class_type = "union"
+                if result.name.startswith("anonymous_struct_"):
+                    result.name = result.name.replace(
+                        "anonymous_struct_", "anonymous_union_"
+                    )
+                    result.full_qualified_name = result.name
+            return result
+        except Exception as e:
+            log_debug(f"Failed to extract union info: {e}")
+            return None
+
+    def _extract_enum_optimized(self, node: "tree_sitter.Node") -> Class | None:
+        """Extract enum information optimized"""
+        try:
+            start_line = node.start_point[0] + 1
+            end_line = node.end_point[0] + 1
+
+            enum_name = None
+
+            # Look for name in enum_specifier children first (named enum)
+            for child in node.children:
+                if child.type == "type_identifier":
+                    enum_name = self._get_node_text_optimized(child)
+
+            # If anonymous, check if parent is type_definition for typedef name
+            if not enum_name and node.parent and node.parent.type == "type_definition":
+                for sibling in node.parent.children:
+                    if sibling.type == "type_identifier":
+                        enum_name = self._get_node_text_optimized(sibling)
+                        # Use the typedef position for the start/end lines
+                        start_line = node.parent.start_point[0] + 1
+                        end_line = node.parent.end_point[0] + 1
+                        break
+
+            if not enum_name:
+                # Truly anonymous enum
+                enum_name = f"anonymous_enum_{start_line}"
+
+            # Extract raw text
+            start_line_idx = max(0, start_line - 1)
+            end_line_idx = min(len(self.content_lines), end_line)
+            raw_text = "\n".join(self.content_lines[start_line_idx:end_line_idx])
+
+            # Extract comments/documentation
+            docstring = self._extract_comment_for_line(start_line)
+
+            return Class(
+                name=enum_name,
+                start_line=start_line,
+                end_line=end_line,
+                raw_text=raw_text,
+                language="c",
+                class_type="enum",
+                full_qualified_name=enum_name,
+                docstring=docstring,
+            )
+        except Exception as e:
+            log_debug(f"Failed to extract enum info: {e}")
+            return None
+
+    def _extract_field_optimized(self, node: "tree_sitter.Node") -> list[Variable]:
+        """Extract field declaration"""
+        fields: list[Variable] = []
+
+        try:
+            start_line = node.start_point[0] + 1
+            end_line = node.end_point[0] + 1
+
+            field_type = None
+            field_names: list[str] = []
+            modifiers: list[str] = []
+
+            for child in node.children:
+                if child.type in [
+                    "primitive_type",
+                    "type_identifier",
+                    "sized_type_specifier",
+                    "struct_specifier",
+                    "union_specifier",
+                    "enum_specifier",
+                ]:
+                    field_type = self._get_node_text_optimized(child)
+                elif child.type == "type_qualifier":
+                    mod = self._get_node_text_optimized(child)
+                    if mod:
+                        modifiers.append(mod)
+                elif child.type == "field_identifier":
+                    field_names.append(self._get_node_text_optimized(child))
+                elif child.type == "field_declaration_list":
+                    # Nested struct/union, skip
+                    pass
+                elif child.type == "init_declarator":
+                    for grandchild in child.children:
+                        if grandchild.type == "field_identifier":
+                            field_names.append(
+                                self._get_node_text_optimized(grandchild)
+                            )
+                        elif grandchild.type == "identifier":
+                            field_names.append(
+                                self._get_node_text_optimized(grandchild)
+                            )
+                elif child.type == "pointer_declarator":
+                    # Handle pointer fields
+                    for grandchild in child.children:
+                        if grandchild.type == "field_identifier":
+                            field_names.append(
+                                self._get_node_text_optimized(grandchild)
+                            )
+                            field_type = field_type + "*" if field_type else "*"
+
+            if not field_type or not field_names:
+                return fields
+
+            raw_text = self._get_node_text_optimized(node)
+
+            for field_name in field_names:
+                field = Variable(
+                    name=field_name,
+                    start_line=start_line,
+                    end_line=end_line,
+                    raw_text=raw_text,
+                    language="c",
+                    variable_type=field_type,
+                    modifiers=modifiers,
+                    is_constant="const" in modifiers,
+                )
+                fields.append(field)
+
+        except Exception as e:
+            log_debug(f"Failed to extract field info: {e}")
+
+        return fields
+
+    def _extract_variable_declaration(
+        self, node: "tree_sitter.Node"
+    ) -> list[Variable]:
+        """Extract variable declarations (not struct members)"""
+        # Skip if parent is a struct/union body
+        if node.parent and node.parent.type == "field_declaration_list":
+            return []
+
+        variables: list[Variable] = []
+
+        try:
+            start_line = node.start_point[0] + 1
+            end_line = node.end_point[0] + 1
+
+            var_type = None
+            var_names: list[str] = []
+            modifiers: list[str] = []
+
+            for child in node.children:
+                if child.type in [
+                    "primitive_type",
+                    "type_identifier",
+                    "sized_type_specifier",
+                    "struct_specifier",
+                    "union_specifier",
+                    "enum_specifier",
+                ]:
+                    var_type = self._get_node_text_optimized(child)
+                elif child.type == "storage_class_specifier":
+                    mod = self._get_node_text_optimized(child)
+                    if mod:
+                        modifiers.append(mod)
+                elif child.type == "type_qualifier":
+                    mod = self._get_node_text_optimized(child)
+                    if mod:
+                        modifiers.append(mod)
+                elif child.type == "identifier":
+                    var_names.append(self._get_node_text_optimized(child))
+                elif child.type == "init_declarator":
+                    for grandchild in child.children:
+                        if grandchild.type == "identifier":
+                            var_names.append(
+                                self._get_node_text_optimized(grandchild)
+                            )
+                elif child.type == "pointer_declarator":
+                    # Handle pointer declarations
+                    for grandchild in child.children:
+                        if grandchild.type == "identifier":
+                            var_names.append(
+                                self._get_node_text_optimized(grandchild)
+                            )
+                            var_type = var_type + "*" if var_type else "*"
+
+            if not var_type or not var_names:
+                return variables
+
+            raw_text = self._get_node_text_optimized(node)
+
+            for var_name in var_names:
+                variable = Variable(
+                    name=var_name,
+                    start_line=start_line,
+                    end_line=end_line,
+                    raw_text=raw_text,
+                    language="c",
+                    variable_type=var_type,
+                    modifiers=modifiers,
+                    is_static="static" in modifiers,
+                    is_constant="const" in modifiers,
+                )
+                variables.append(variable)
+
+        except Exception as e:
+            log_debug(f"Failed to extract variable declaration: {e}")
+
+        return variables
+
+    def _extract_include_info(
+        self, node: "tree_sitter.Node", source_code: str
+    ) -> Import | None:
+        """Extract include directive information"""
+        try:
+            include_text = self._get_node_text_optimized(node)
+            line_num = node.start_point[0] + 1
+
+            # Determine if it's a system include (<...>) or local include ("...")
+            is_system = "<" in include_text
+
+            # Extract the included file path
+            if is_system:
+                match = re.search(r"<([^>]+)>", include_text)
+            else:
+                match = re.search(r'"([^"]+)"', include_text)
+
+            if match:
+                include_path = match.group(1)
+
+                return Import(
+                    name=include_path,
+                    start_line=line_num,
+                    end_line=line_num,
+                    raw_text=include_text,
+                    language="c",
+                    module_name=include_path,
+                    import_statement=include_text,
+                )
+
+        except Exception as e:
+            log_debug(f"Failed to extract include info: {e}")
+
+        return None
+
+    def _extract_includes_fallback(self, source_code: str) -> list[Import]:
+        """Fallback include extraction using regex"""
+        imports: list[Import] = []
+        lines = source_code.split("\n")
+
+        for line_num, line in enumerate(lines, 1):
+            line = line.strip()
+            if line.startswith("#include"):
+                # System include
+                system_match = re.search(r"#include\s*<([^>]+)>", line)
+                if system_match:
+                    include_path = system_match.group(1)
+                    imports.append(
+                        Import(
+                            name=include_path,
+                            start_line=line_num,
+                            end_line=line_num,
+                            raw_text=line,
+                            language="c",
+                            module_name=include_path,
+                            import_statement=line,
+                        )
+                    )
+                else:
+                    # Local include
+                    local_match = re.search(r'#include\s*"([^"]+)"', line)
+                    if local_match:
+                        include_path = local_match.group(1)
+                        imports.append(
+                            Import(
+                                name=include_path,
+                                start_line=line_num,
+                                end_line=line_num,
+                                raw_text=line,
+                                language="c",
+                                module_name=include_path,
+                                import_statement=line,
+                            )
+                        )
+
+        return imports
+
+    def _calculate_complexity_optimized(self, node: "tree_sitter.Node") -> int:
+        """Calculate cyclomatic complexity"""
+        complexity = 1  # Base complexity
+
+        decision_nodes = [
+            "if_statement",
+            "while_statement",
+            "for_statement",
+            "switch_statement",
+            "case_statement",
+            "conditional_expression",
+            "do_statement",
+        ]
+
+        def count_decisions(n: "tree_sitter.Node") -> int:
+            count = 0
+            if hasattr(n, "type") and n.type in decision_nodes:
+                count += 1
+            if hasattr(n, "children"):
+                try:
+                    for child in n.children:
+                        count += count_decisions(child)
+                except (TypeError, AttributeError):
+                    pass
+            return count
+
+        complexity += count_decisions(node)
+        return complexity
+
+    def _extract_comment_for_line(self, line: int) -> str | None:
+        """Extract comment (documentation) for a specific line"""
+        try:
+            # Look for comment immediately before the line
+            for i in range(max(0, line - 5), line):
+                if i < len(self.content_lines):
+                    line_content = self.content_lines[i].strip()
+                    # Check for Doxygen-style comments
+                    if line_content.startswith("/**"):
+                        comment_lines = []
+                        for j in range(i, min(len(self.content_lines), line)):
+                            doc_line = self.content_lines[j].strip()
+                            comment_lines.append(doc_line)
+                            if doc_line.endswith("*/"):
+                                break
+                        return "\n".join(comment_lines)
+                    # Check for /* ... */ style comments
+                    elif line_content.startswith("/*"):
+                        comment_lines = []
+                        for j in range(i, min(len(self.content_lines), line)):
+                            doc_line = self.content_lines[j].strip()
+                            comment_lines.append(doc_line)
+                            if doc_line.endswith("*/"):
+                                break
+                        return "\n".join(comment_lines)
+
+        except Exception as e:
+            log_debug(f"Failed to extract comment: {e}")
+
+        return None
+
+
+class CPlugin(LanguagePlugin):
+    """C language plugin implementation"""
+
+    def __init__(self) -> None:
+        """Initialize the C language plugin."""
+        super().__init__()
+        self.extractor = CElementExtractor()
+        self.language = "c"
+        self.supported_extensions = self.get_file_extensions()
+        self._cached_language: Any | None = None
+
+    def get_language_name(self) -> str:
+        """Get the language name."""
+        return "c"
+
+    def get_file_extensions(self) -> list[str]:
+        """Get supported file extensions."""
+        return [".c", ".h"]
+
+    def create_extractor(self) -> ElementExtractor:
+        """Create a new element extractor instance."""
+        return CElementExtractor()
+
+    async def analyze_file(
+        self, file_path: str, request: "AnalysisRequest"
+    ) -> "AnalysisResult":
+        """Analyze C code and return structured results."""
+        from ..models import AnalysisResult
+
+        try:
+            from ..encoding_utils import read_file_safe
+
+            file_content, detected_encoding = read_file_safe(file_path)
+
+            language = self.get_tree_sitter_language()
+            if language is None:
+                return AnalysisResult(
+                    file_path=file_path,
+                    language="c",
+                    line_count=len(file_content.split("\n")),
+                    elements=[],
+                    source_code=file_content,
+                )
+
+            import tree_sitter
+
+            parser = tree_sitter.Parser()
+
+            if hasattr(parser, "set_language"):
+                parser.set_language(language)
+            elif hasattr(parser, "language"):
+                parser.language = language
+            else:
+                try:
+                    parser = tree_sitter.Parser(language)
+                except Exception as e:
+                    log_error(f"Failed to create parser with language: {e}")
+                    return AnalysisResult(
+                        file_path=file_path,
+                        language="c",
+                        line_count=len(file_content.split("\n")),
+                        elements=[],
+                        source_code=file_content,
+                        error_message=f"Parser creation failed: {e}",
+                        success=False,
+                    )
+
+            tree = parser.parse(file_content.encode("utf-8"))
+
+            elements_dict = self.extract_elements(tree, file_content)
+
+            all_elements = []
+            all_elements.extend(elements_dict.get("functions", []))
+            all_elements.extend(elements_dict.get("classes", []))
+            all_elements.extend(elements_dict.get("variables", []))
+            all_elements.extend(elements_dict.get("imports", []))
+
+            node_count = (
+                self._count_tree_nodes(tree.root_node) if tree and tree.root_node else 0
+            )
+
+            return AnalysisResult(
+                file_path=file_path,
+                language="c",
+                line_count=len(file_content.split("\n")),
+                elements=all_elements,
+                node_count=node_count,
+                source_code=file_content,
+            )
+
+        except Exception as e:
+            log_error(f"Error analyzing C file {file_path}: {e}")
+            return AnalysisResult(
+                file_path=file_path,
+                language="c",
+                line_count=0,
+                elements=[],
+                source_code="",
+                error_message=str(e),
+                success=False,
+            )
+
+    def _count_tree_nodes(self, node: Any) -> int:
+        """Recursively count nodes in the AST tree."""
+        if node is None:
+            return 0
+
+        count = 1
+        if hasattr(node, "children"):
+            for child in node.children:
+                count += self._count_tree_nodes(child)
+        return count
+
+    def get_tree_sitter_language(self) -> Any | None:
+        """Get the tree-sitter language for C."""
+        if self._cached_language is not None:
+            return self._cached_language
+
+        try:
+            import tree_sitter
+            import tree_sitter_c
+
+            caps_or_lang = tree_sitter_c.language()
+
+            if hasattr(caps_or_lang, "__class__") and "Language" in str(
+                type(caps_or_lang)
+            ):
+                self._cached_language = caps_or_lang
+            else:
+                try:
+                    self._cached_language = tree_sitter.Language(caps_or_lang)
+                except Exception as e:
+                    log_error(f"Failed to create Language object from PyCapsule: {e}")
+                    return None
+
+            return self._cached_language
+        except ImportError as e:
+            log_error(f"tree-sitter-c not available: {e}")
+            return None
+        except Exception as e:
+            log_error(f"Failed to load tree-sitter language for C: {e}")
+            return None
+
+    def extract_elements(self, tree: Any | None, source_code: str) -> dict[str, Any]:
+        """Extract all elements from C code."""
+        if tree is None:
+            return {
+                "functions": [],
+                "classes": [],
+                "variables": [],
+                "imports": [],
+            }
+
+        try:
+            extractor = self.create_extractor()
+            return {
+                "functions": extractor.extract_functions(tree, source_code),
+                "classes": extractor.extract_classes(tree, source_code),
+                "variables": extractor.extract_variables(tree, source_code),
+                "imports": extractor.extract_imports(tree, source_code),
+            }
+        except Exception as e:
+            log_error(f"Error extracting elements: {e}")
+            return {
+                "functions": [],
+                "classes": [],
+                "variables": [],
+                "imports": [],
+            }

--- a/tree_sitter_analyzer/languages/cpp_plugin.py
+++ b/tree_sitter_analyzer/languages/cpp_plugin.py
@@ -1,0 +1,1064 @@
+#!/usr/bin/env python3
+"""
+C++ Language Plugin
+
+Provides C++ specific parsing and element extraction functionality.
+Supports modern C++ features including classes, templates, namespaces,
+and advanced constructs.
+"""
+
+import re
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import tree_sitter
+
+    from ..core.analysis_engine import AnalysisRequest
+    from ..models import AnalysisResult
+
+from ..encoding_utils import extract_text_slice, safe_encode
+from ..models import Class, Function, Import, Variable
+from ..plugins.base import ElementExtractor, LanguagePlugin
+from ..utils import log_debug, log_error, log_warning
+
+
+class CppElementExtractor(ElementExtractor):
+    """C++ specific element extractor with advanced analysis support"""
+
+    def __init__(self) -> None:
+        """Initialize the C++ element extractor."""
+        self.current_namespace: str = ""
+        self.current_file: str = ""
+        self.source_code: str = ""
+        self.content_lines: list[str] = []
+        self.includes: list[str] = []
+
+        # Performance optimization caches
+        self._node_text_cache: dict[int, str] = {}
+        self._processed_nodes: set[int] = set()
+        self._element_cache: dict[tuple[int, str], Any] = {}
+        self._file_encoding: str | None = None
+        self._comment_cache: dict[int, str] = {}
+        self._complexity_cache: dict[int, int] = {}
+
+    def extract_functions(
+        self, tree: "tree_sitter.Tree", source_code: str
+    ) -> list[Function]:
+        """Extract C++ function definitions with comprehensive details"""
+        self.source_code = source_code
+        self.content_lines = source_code.split("\n")
+        self._reset_caches()
+
+        functions: list[Function] = []
+
+        # Use optimized traversal for function types
+        extractors = {
+            "function_definition": self._extract_function_optimized,
+            "function_declarator": self._extract_function_declaration,
+            "template_declaration": self._extract_template_function,
+        }
+
+        self._traverse_and_extract_iterative(
+            tree.root_node, extractors, functions, "function"
+        )
+
+        log_debug(f"Extracted {len(functions)} C++ functions")
+        return functions
+
+    def extract_classes(
+        self, tree: "tree_sitter.Tree", source_code: str
+    ) -> list[Class]:
+        """Extract C++ class/struct definitions with detailed information"""
+        self.source_code = source_code
+        self.content_lines = source_code.split("\n")
+        self._reset_caches()
+
+        classes: list[Class] = []
+
+        # Extract class, struct, and union declarations
+        extractors = {
+            "class_specifier": self._extract_class_optimized,
+            "struct_specifier": self._extract_struct_optimized,
+            "union_specifier": self._extract_union_optimized,
+            "template_declaration": self._extract_template_class,
+        }
+
+        self._traverse_and_extract_iterative(
+            tree.root_node, extractors, classes, "class"
+        )
+
+        log_debug(f"Extracted {len(classes)} C++ classes/structs")
+        return classes
+
+    def extract_variables(
+        self, tree: "tree_sitter.Tree", source_code: str
+    ) -> list[Variable]:
+        """Extract C++ variable/field declarations"""
+        self.source_code = source_code
+        self.content_lines = source_code.split("\n")
+        self._reset_caches()
+
+        variables: list[Variable] = []
+
+        # Extract field and variable declarations
+        extractors = {
+            "field_declaration": self._extract_field_optimized,
+            "declaration": self._extract_variable_declaration,
+        }
+
+        self._traverse_and_extract_iterative(
+            tree.root_node, extractors, variables, "variable"
+        )
+
+        log_debug(f"Extracted {len(variables)} C++ variables/fields")
+        return variables
+
+    def extract_imports(
+        self, tree: "tree_sitter.Tree", source_code: str
+    ) -> list[Import]:
+        """Extract C++ include directives"""
+        self.source_code = source_code
+        self.content_lines = source_code.split("\n")
+
+        imports: list[Import] = []
+
+        # Extract preprocessor includes
+        for child in tree.root_node.children:
+            if child.type == "preproc_include":
+                import_info = self._extract_include_info(child, source_code)
+                if import_info:
+                    imports.append(import_info)
+
+        # Fallback: use regex if tree-sitter doesn't catch all includes
+        if not imports and "#include" in source_code:
+            log_debug("No includes found via tree-sitter, trying regex fallback")
+            fallback_imports = self._extract_includes_fallback(source_code)
+            imports.extend(fallback_imports)
+
+        log_debug(f"Extracted {len(imports)} C++ includes")
+        return imports
+
+    def extract_packages(
+        self, tree: "tree_sitter.Tree", source_code: str
+    ) -> list[Any]:
+        """Extract C++ namespace declarations"""
+        from ..models import Package
+
+        self.source_code = source_code
+        self.content_lines = source_code.split("\n")
+
+        packages: list[Package] = []
+
+        def find_namespaces(node: "tree_sitter.Node") -> None:
+            if node.type == "namespace_definition":
+                namespace_info = self._extract_namespace_info(node)
+                if namespace_info:
+                    packages.append(namespace_info)
+
+            for child in node.children:
+                find_namespaces(child)
+
+        find_namespaces(tree.root_node)
+
+        log_debug(f"Extracted {len(packages)} C++ namespaces")
+        return packages
+
+    def _reset_caches(self) -> None:
+        """Reset performance caches"""
+        self._node_text_cache.clear()
+        self._processed_nodes.clear()
+        self._element_cache.clear()
+        self._comment_cache.clear()
+        self._complexity_cache.clear()
+        self.current_namespace = ""
+
+    def _traverse_and_extract_iterative(
+        self,
+        root_node: "tree_sitter.Node",
+        extractors: dict[str, Any],
+        results: list[Any],
+        element_type: str,
+    ) -> None:
+        """Iterative node traversal and extraction with caching"""
+        if root_node is None:
+            return
+
+        target_node_types = set(extractors.keys())
+        container_node_types = {
+            "translation_unit",
+            "namespace_definition",
+            "class_specifier",
+            "struct_specifier",
+            "union_specifier",
+            "declaration_list",
+            "field_declaration_list",
+            "compound_statement",
+            "template_declaration",
+        }
+
+        node_stack = [(root_node, 0)]
+        processed_nodes = 0
+        max_depth = 50
+
+        while node_stack:
+            current_node, depth = node_stack.pop()
+
+            if depth > max_depth:
+                log_warning(f"Maximum traversal depth ({max_depth}) exceeded")
+                continue
+
+            processed_nodes += 1
+            node_type = current_node.type
+
+            # Early termination for irrelevant nodes
+            if (
+                depth > 0
+                and node_type not in target_node_types
+                and node_type not in container_node_types
+            ):
+                continue
+
+            # Process target nodes
+            if node_type in target_node_types:
+                node_id = id(current_node)
+
+                if node_id in self._processed_nodes:
+                    continue
+
+                cache_key = (node_id, element_type)
+                if cache_key in self._element_cache:
+                    element = self._element_cache[cache_key]
+                    if element:
+                        if isinstance(element, list):
+                            results.extend(element)
+                        else:
+                            results.append(element)
+                    self._processed_nodes.add(node_id)
+                    continue
+
+                # Extract and cache
+                extractor = extractors.get(node_type)
+                if extractor:
+                    element = extractor(current_node)
+                    self._element_cache[cache_key] = element
+                    if element:
+                        if isinstance(element, list):
+                            results.extend(element)
+                        else:
+                            results.append(element)
+                    self._processed_nodes.add(node_id)
+
+            # Add children to stack (reversed for correct DFS traversal)
+            if current_node.children:
+                for child in reversed(current_node.children):
+                    node_stack.append((child, depth + 1))
+
+        log_debug(f"Iterative traversal processed {processed_nodes} nodes")
+
+    def _get_node_text_optimized(self, node: "tree_sitter.Node") -> str:
+        """Get node text with optimized caching"""
+        node_id = id(node)
+
+        if node_id in self._node_text_cache:
+            return self._node_text_cache[node_id]
+
+        try:
+            start_byte = node.start_byte
+            end_byte = node.end_byte
+
+            encoding = self._file_encoding or "utf-8"
+            content_bytes = safe_encode("\n".join(self.content_lines), encoding)
+            text = extract_text_slice(content_bytes, start_byte, end_byte, encoding)
+
+            self._node_text_cache[node_id] = text
+            return text
+        except Exception as e:
+            log_error(f"Error in _get_node_text_optimized: {e}")
+            # Fallback to simple text extraction
+            try:
+                start_point = node.start_point
+                end_point = node.end_point
+
+                if start_point[0] == end_point[0]:
+                    line = self.content_lines[start_point[0]]
+                    result: str = line[start_point[1] : end_point[1]]
+                    return result
+                else:
+                    lines = []
+                    for i in range(start_point[0], end_point[0] + 1):
+                        if i < len(self.content_lines):
+                            line = self.content_lines[i]
+                            if i == start_point[0]:
+                                lines.append(line[start_point[1] :])
+                            elif i == end_point[0]:
+                                lines.append(line[: end_point[1]])
+                            else:
+                                lines.append(line)
+                    return "\n".join(lines)
+            except Exception as fallback_error:
+                log_error(f"Fallback text extraction also failed: {fallback_error}")
+                return ""
+
+    def _extract_function_optimized(
+        self, node: "tree_sitter.Node"
+    ) -> Function | None:
+        """Extract function information optimized"""
+        try:
+            start_line = node.start_point[0] + 1
+            end_line = node.end_point[0] + 1
+
+            # Extract function details
+            function_info = self._parse_function_signature(node)
+            if not function_info:
+                return None
+
+            name, return_type, parameters, modifiers = function_info
+
+            # Extract raw text
+            start_line_idx = max(0, start_line - 1)
+            end_line_idx = min(len(self.content_lines), end_line)
+            raw_text = "\n".join(self.content_lines[start_line_idx:end_line_idx])
+
+            # Calculate complexity
+            complexity_score = self._calculate_complexity_optimized(node)
+
+            # Determine visibility (C++ default is private in class context)
+            visibility = self._determine_visibility(modifiers)
+
+            # Extract comments/documentation
+            docstring = self._extract_comment_for_line(start_line)
+
+            return Function(
+                name=name,
+                start_line=start_line,
+                end_line=end_line,
+                raw_text=raw_text,
+                language="cpp",
+                parameters=parameters,
+                return_type=return_type or "void",
+                modifiers=modifiers,
+                is_static="static" in modifiers,
+                is_private="private" in modifiers,
+                is_public="public" in modifiers,
+                visibility=visibility,
+                docstring=docstring,
+                complexity_score=complexity_score,
+            )
+        except (AttributeError, ValueError, TypeError) as e:
+            log_debug(f"Failed to extract function info: {e}")
+            return None
+        except Exception as e:
+            log_error(f"Unexpected error in function extraction: {e}")
+            return None
+
+    def _extract_function_declaration(
+        self, node: "tree_sitter.Node"
+    ) -> Function | None:
+        """Extract function declaration (prototype)"""
+        # Only extract if parent is not a function_definition
+        if node.parent and node.parent.type == "function_definition":
+            return None  # Already handled by _extract_function_optimized
+
+        try:
+            start_line = node.start_point[0] + 1
+            end_line = node.end_point[0] + 1
+
+            name = None
+            parameters: list[str] = []
+
+            for child in node.children:
+                if child.type == "identifier":
+                    name = self._get_node_text_optimized(child)
+                elif child.type == "qualified_identifier":
+                    name = self._get_node_text_optimized(child)
+                elif child.type == "parameter_list":
+                    parameters = self._extract_parameters(child)
+
+            if not name:
+                return None
+
+            raw_text = self._get_node_text_optimized(node)
+
+            return Function(
+                name=name,
+                start_line=start_line,
+                end_line=end_line,
+                raw_text=raw_text,
+                language="cpp",
+                parameters=parameters,
+                return_type="void",
+                modifiers=[],
+            )
+        except Exception as e:
+            log_debug(f"Failed to extract function declaration: {e}")
+            return None
+
+    def _extract_template_function(
+        self, node: "tree_sitter.Node"
+    ) -> Function | None:
+        """Extract template function definition"""
+        try:
+            # Find the actual function definition inside the template
+            for child in node.children:
+                if child.type == "function_definition":
+                    func = self._extract_function_optimized(child)
+                    if func:
+                        func.modifiers = func.modifiers or []
+                        if "template" not in func.modifiers:
+                            func.modifiers.append("template")
+                        return func
+            return None
+        except Exception as e:
+            log_debug(f"Failed to extract template function: {e}")
+            return None
+
+    def _parse_function_signature(
+        self, node: "tree_sitter.Node"
+    ) -> tuple[str, str, list[str], list[str]] | None:
+        """Parse C++ function signature"""
+        try:
+            name = None
+            return_type = "void"
+            parameters: list[str] = []
+            modifiers: list[str] = []
+
+            for child in node.children:
+                if child.type == "function_declarator":
+                    for grandchild in child.children:
+                        if grandchild.type == "identifier":
+                            name = self._get_node_text_optimized(grandchild)
+                        elif grandchild.type == "qualified_identifier":
+                            name = self._get_node_text_optimized(grandchild)
+                        elif grandchild.type == "field_identifier":
+                            name = self._get_node_text_optimized(grandchild)
+                        elif grandchild.type == "parameter_list":
+                            parameters = self._extract_parameters(grandchild)
+                elif child.type in [
+                    "primitive_type",
+                    "type_identifier",
+                    "qualified_identifier",
+                    "template_type",
+                ]:
+                    return_type = self._get_node_text_optimized(child)
+                elif child.type == "storage_class_specifier":
+                    mod = self._get_node_text_optimized(child)
+                    if mod:
+                        modifiers.append(mod)
+                elif child.type == "type_qualifier":
+                    mod = self._get_node_text_optimized(child)
+                    if mod:
+                        modifiers.append(mod)
+                elif child.type == "virtual":
+                    modifiers.append("virtual")
+
+            if not name:
+                return None
+
+            return name, return_type, parameters, modifiers
+        except Exception:
+            return None
+
+    def _extract_parameters(self, params_node: "tree_sitter.Node") -> list[str]:
+        """Extract function parameters"""
+        parameters: list[str] = []
+
+        for child in params_node.children:
+            if child.type == "parameter_declaration":
+                param_text = self._get_node_text_optimized(child)
+                parameters.append(param_text)
+            elif child.type == "variadic_parameter_declaration":
+                parameters.append("...")
+
+        return parameters
+
+    def _extract_class_optimized(self, node: "tree_sitter.Node") -> Class | None:
+        """Extract class information optimized"""
+        try:
+            start_line = node.start_point[0] + 1
+            end_line = node.end_point[0] + 1
+
+            class_name = None
+            superclasses: list[str] = []
+            modifiers: list[str] = []
+
+            for child in node.children:
+                if child.type == "type_identifier":
+                    class_name = self._get_node_text_optimized(child)
+                elif child.type == "base_class_clause":
+                    superclasses = self._extract_base_classes(child)
+
+            if not class_name:
+                return None
+
+            # Extract raw text
+            start_line_idx = max(0, start_line - 1)
+            end_line_idx = min(len(self.content_lines), end_line)
+            raw_text = "\n".join(self.content_lines[start_line_idx:end_line_idx])
+
+            # Extract comments/documentation
+            docstring = self._extract_comment_for_line(start_line)
+
+            # Build fully qualified name with namespace
+            full_qualified_name = (
+                f"{self.current_namespace}::{class_name}"
+                if self.current_namespace
+                else class_name
+            )
+
+            return Class(
+                name=class_name,
+                start_line=start_line,
+                end_line=end_line,
+                raw_text=raw_text,
+                language="cpp",
+                class_type="class",
+                full_qualified_name=full_qualified_name,
+                package_name=self.current_namespace,
+                superclass=superclasses[0] if superclasses else None,
+                interfaces=superclasses[1:] if len(superclasses) > 1 else [],
+                modifiers=modifiers,
+                docstring=docstring,
+            )
+        except Exception as e:
+            log_debug(f"Failed to extract class info: {e}")
+            return None
+
+    def _extract_struct_optimized(self, node: "tree_sitter.Node") -> Class | None:
+        """Extract struct information optimized"""
+        try:
+            result = self._extract_class_optimized(node)
+            if result:
+                result.class_type = "struct"
+            return result
+        except Exception as e:
+            log_debug(f"Failed to extract struct info: {e}")
+            return None
+
+    def _extract_union_optimized(self, node: "tree_sitter.Node") -> Class | None:
+        """Extract union information optimized"""
+        try:
+            result = self._extract_class_optimized(node)
+            if result:
+                result.class_type = "union"
+            return result
+        except Exception as e:
+            log_debug(f"Failed to extract union info: {e}")
+            return None
+
+    def _extract_template_class(self, node: "tree_sitter.Node") -> Class | None:
+        """Extract template class definition"""
+        try:
+            for child in node.children:
+                if child.type == "class_specifier":
+                    cls = self._extract_class_optimized(child)
+                    if cls:
+                        cls.modifiers = cls.modifiers or []
+                        if "template" not in cls.modifiers:
+                            cls.modifiers.append("template")
+                        return cls
+                elif child.type == "struct_specifier":
+                    cls = self._extract_struct_optimized(child)
+                    if cls:
+                        cls.modifiers = cls.modifiers or []
+                        if "template" not in cls.modifiers:
+                            cls.modifiers.append("template")
+                        return cls
+            return None
+        except Exception as e:
+            log_debug(f"Failed to extract template class: {e}")
+            return None
+
+    def _extract_base_classes(self, node: "tree_sitter.Node") -> list[str]:
+        """Extract base class names from base_class_clause"""
+        base_classes: list[str] = []
+
+        for child in node.children:
+            if child.type == "base_specifier":
+                for grandchild in child.children:
+                    if grandchild.type == "type_identifier":
+                        base_classes.append(self._get_node_text_optimized(grandchild))
+                    elif grandchild.type == "template_type":
+                        base_classes.append(self._get_node_text_optimized(grandchild))
+
+        return base_classes
+
+    def _extract_field_optimized(self, node: "tree_sitter.Node") -> list[Variable]:
+        """Extract field declaration"""
+        fields: list[Variable] = []
+
+        try:
+            start_line = node.start_point[0] + 1
+            end_line = node.end_point[0] + 1
+
+            field_type = None
+            field_names: list[str] = []
+            modifiers: list[str] = []
+
+            for child in node.children:
+                if child.type in [
+                    "primitive_type",
+                    "type_identifier",
+                    "qualified_identifier",
+                    "template_type",
+                ]:
+                    field_type = self._get_node_text_optimized(child)
+                elif child.type == "storage_class_specifier":
+                    mod = self._get_node_text_optimized(child)
+                    if mod:
+                        modifiers.append(mod)
+                elif child.type == "type_qualifier":
+                    mod = self._get_node_text_optimized(child)
+                    if mod:
+                        modifiers.append(mod)
+                elif child.type == "field_identifier":
+                    field_names.append(self._get_node_text_optimized(child))
+                elif child.type == "init_declarator":
+                    for grandchild in child.children:
+                        if grandchild.type == "field_identifier":
+                            field_names.append(
+                                self._get_node_text_optimized(grandchild)
+                            )
+                        elif grandchild.type == "identifier":
+                            field_names.append(
+                                self._get_node_text_optimized(grandchild)
+                            )
+
+            if not field_type or not field_names:
+                return fields
+
+            raw_text = self._get_node_text_optimized(node)
+            visibility = self._determine_visibility(modifiers)
+
+            for field_name in field_names:
+                field = Variable(
+                    name=field_name,
+                    start_line=start_line,
+                    end_line=end_line,
+                    raw_text=raw_text,
+                    language="cpp",
+                    variable_type=field_type,
+                    modifiers=modifiers,
+                    is_static="static" in modifiers,
+                    is_constant="const" in modifiers,
+                    visibility=visibility,
+                )
+                fields.append(field)
+
+        except Exception as e:
+            log_debug(f"Failed to extract field info: {e}")
+
+        return fields
+
+    def _extract_variable_declaration(
+        self, node: "tree_sitter.Node"
+    ) -> list[Variable]:
+        """Extract variable declarations (not class members)"""
+        # Skip if parent is a class/struct body
+        if node.parent and node.parent.type == "field_declaration_list":
+            return []
+
+        variables: list[Variable] = []
+
+        try:
+            start_line = node.start_point[0] + 1
+            end_line = node.end_point[0] + 1
+
+            var_type = None
+            var_names: list[str] = []
+            modifiers: list[str] = []
+
+            for child in node.children:
+                if child.type in [
+                    "primitive_type",
+                    "type_identifier",
+                    "qualified_identifier",
+                    "template_type",
+                ]:
+                    var_type = self._get_node_text_optimized(child)
+                elif child.type == "storage_class_specifier":
+                    mod = self._get_node_text_optimized(child)
+                    if mod:
+                        modifiers.append(mod)
+                elif child.type == "type_qualifier":
+                    mod = self._get_node_text_optimized(child)
+                    if mod:
+                        modifiers.append(mod)
+                elif child.type == "identifier":
+                    var_names.append(self._get_node_text_optimized(child))
+                elif child.type == "init_declarator":
+                    for grandchild in child.children:
+                        if grandchild.type == "identifier":
+                            var_names.append(
+                                self._get_node_text_optimized(grandchild)
+                            )
+
+            if not var_type or not var_names:
+                return variables
+
+            raw_text = self._get_node_text_optimized(node)
+
+            for var_name in var_names:
+                variable = Variable(
+                    name=var_name,
+                    start_line=start_line,
+                    end_line=end_line,
+                    raw_text=raw_text,
+                    language="cpp",
+                    variable_type=var_type,
+                    modifiers=modifiers,
+                    is_static="static" in modifiers,
+                    is_constant="const" in modifiers,
+                )
+                variables.append(variable)
+
+        except Exception as e:
+            log_debug(f"Failed to extract variable declaration: {e}")
+
+        return variables
+
+    def _extract_include_info(
+        self, node: "tree_sitter.Node", source_code: str
+    ) -> Import | None:
+        """Extract include directive information"""
+        try:
+            include_text = self._get_node_text_optimized(node)
+            line_num = node.start_point[0] + 1
+
+            # Determine if it's a system include (<...>) or local include ("...")
+            is_system = "<" in include_text
+
+            # Extract the included file path
+            if is_system:
+                match = re.search(r"<([^>]+)>", include_text)
+            else:
+                match = re.search(r'"([^"]+)"', include_text)
+
+            if match:
+                include_path = match.group(1)
+
+                return Import(
+                    name=include_path,
+                    start_line=line_num,
+                    end_line=line_num,
+                    raw_text=include_text,
+                    language="cpp",
+                    module_name=include_path,
+                    import_statement=include_text,
+                )
+
+        except Exception as e:
+            log_debug(f"Failed to extract include info: {e}")
+
+        return None
+
+    def _extract_includes_fallback(self, source_code: str) -> list[Import]:
+        """Fallback include extraction using regex"""
+        imports: list[Import] = []
+        lines = source_code.split("\n")
+
+        for line_num, line in enumerate(lines, 1):
+            line = line.strip()
+            if line.startswith("#include"):
+                # System include
+                system_match = re.search(r"#include\s*<([^>]+)>", line)
+                if system_match:
+                    include_path = system_match.group(1)
+                    imports.append(
+                        Import(
+                            name=include_path,
+                            start_line=line_num,
+                            end_line=line_num,
+                            raw_text=line,
+                            language="cpp",
+                            module_name=include_path,
+                            import_statement=line,
+                        )
+                    )
+                else:
+                    # Local include
+                    local_match = re.search(r'#include\s*"([^"]+)"', line)
+                    if local_match:
+                        include_path = local_match.group(1)
+                        imports.append(
+                            Import(
+                                name=include_path,
+                                start_line=line_num,
+                                end_line=line_num,
+                                raw_text=line,
+                                language="cpp",
+                                module_name=include_path,
+                                import_statement=line,
+                            )
+                        )
+
+        return imports
+
+    def _extract_namespace_info(self, node: "tree_sitter.Node") -> Any:
+        """Extract namespace information"""
+        from ..models import Package
+
+        try:
+            namespace_name = None
+
+            for child in node.children:
+                if child.type == "identifier":
+                    namespace_name = self._get_node_text_optimized(child)
+                elif child.type == "namespace_identifier":
+                    namespace_name = self._get_node_text_optimized(child)
+
+            if namespace_name:
+                self.current_namespace = namespace_name
+                return Package(
+                    name=namespace_name,
+                    start_line=node.start_point[0] + 1,
+                    end_line=node.end_point[0] + 1,
+                    raw_text=self._get_node_text_optimized(node),
+                    language="cpp",
+                )
+
+        except Exception as e:
+            log_debug(f"Failed to extract namespace info: {e}")
+
+        return None
+
+    def _determine_visibility(self, modifiers: list[str]) -> str:
+        """Determine visibility from modifiers"""
+        if "public" in modifiers:
+            return "public"
+        elif "private" in modifiers:
+            return "private"
+        elif "protected" in modifiers:
+            return "protected"
+        else:
+            return "private"  # C++ class members are private by default
+
+    def _calculate_complexity_optimized(self, node: "tree_sitter.Node") -> int:
+        """Calculate cyclomatic complexity"""
+        complexity = 1  # Base complexity
+
+        decision_nodes = [
+            "if_statement",
+            "while_statement",
+            "for_statement",
+            "for_range_loop",
+            "switch_statement",
+            "case_statement",
+            "conditional_expression",
+            "catch_clause",
+            "do_statement",
+        ]
+
+        def count_decisions(n: "tree_sitter.Node") -> int:
+            count = 0
+            if hasattr(n, "type") and n.type in decision_nodes:
+                count += 1
+            if hasattr(n, "children"):
+                try:
+                    for child in n.children:
+                        count += count_decisions(child)
+                except (TypeError, AttributeError):
+                    pass
+            return count
+
+        complexity += count_decisions(node)
+        return complexity
+
+    def _extract_comment_for_line(self, line: int) -> str | None:
+        """Extract comment (documentation) for a specific line"""
+        try:
+            # Look for comment immediately before the line
+            for i in range(max(0, line - 5), line):
+                if i < len(self.content_lines):
+                    line_content = self.content_lines[i].strip()
+                    # Check for Doxygen-style comments
+                    if line_content.startswith("/**"):
+                        comment_lines = []
+                        for j in range(i, min(len(self.content_lines), line)):
+                            doc_line = self.content_lines[j].strip()
+                            comment_lines.append(doc_line)
+                            if doc_line.endswith("*/"):
+                                break
+                        return "\n".join(comment_lines)
+                    # Check for /// style comments
+                    elif line_content.startswith("///"):
+                        return line_content
+
+        except Exception as e:
+            log_debug(f"Failed to extract comment: {e}")
+
+        return None
+
+
+class CppPlugin(LanguagePlugin):
+    """C++ language plugin implementation"""
+
+    def __init__(self) -> None:
+        """Initialize the C++ language plugin."""
+        super().__init__()
+        self.extractor = CppElementExtractor()
+        self.language = "cpp"
+        self.supported_extensions = self.get_file_extensions()
+        self._cached_language: Any | None = None
+
+    def get_language_name(self) -> str:
+        """Get the language name."""
+        return "cpp"
+
+    def get_file_extensions(self) -> list[str]:
+        """Get supported file extensions."""
+        return [".cpp", ".cxx", ".cc", ".hpp", ".hxx", ".h++", ".c++"]
+
+    def create_extractor(self) -> ElementExtractor:
+        """Create a new element extractor instance."""
+        return CppElementExtractor()
+
+    async def analyze_file(
+        self, file_path: str, request: "AnalysisRequest"
+    ) -> "AnalysisResult":
+        """Analyze C++ code and return structured results."""
+        from ..models import AnalysisResult
+
+        try:
+            from ..encoding_utils import read_file_safe
+
+            file_content, detected_encoding = read_file_safe(file_path)
+
+            language = self.get_tree_sitter_language()
+            if language is None:
+                return AnalysisResult(
+                    file_path=file_path,
+                    language="cpp",
+                    line_count=len(file_content.split("\n")),
+                    elements=[],
+                    source_code=file_content,
+                )
+
+            import tree_sitter
+
+            parser = tree_sitter.Parser()
+
+            if hasattr(parser, "set_language"):
+                parser.set_language(language)
+            elif hasattr(parser, "language"):
+                parser.language = language
+            else:
+                try:
+                    parser = tree_sitter.Parser(language)
+                except Exception as e:
+                    log_error(f"Failed to create parser with language: {e}")
+                    return AnalysisResult(
+                        file_path=file_path,
+                        language="cpp",
+                        line_count=len(file_content.split("\n")),
+                        elements=[],
+                        source_code=file_content,
+                        error_message=f"Parser creation failed: {e}",
+                        success=False,
+                    )
+
+            tree = parser.parse(file_content.encode("utf-8"))
+
+            elements_dict = self.extract_elements(tree, file_content)
+
+            all_elements = []
+            all_elements.extend(elements_dict.get("functions", []))
+            all_elements.extend(elements_dict.get("classes", []))
+            all_elements.extend(elements_dict.get("variables", []))
+            all_elements.extend(elements_dict.get("imports", []))
+            all_elements.extend(elements_dict.get("packages", []))
+
+            node_count = (
+                self._count_tree_nodes(tree.root_node) if tree and tree.root_node else 0
+            )
+
+            return AnalysisResult(
+                file_path=file_path,
+                language="cpp",
+                line_count=len(file_content.split("\n")),
+                elements=all_elements,
+                node_count=node_count,
+                source_code=file_content,
+            )
+
+        except Exception as e:
+            log_error(f"Error analyzing C++ file {file_path}: {e}")
+            return AnalysisResult(
+                file_path=file_path,
+                language="cpp",
+                line_count=0,
+                elements=[],
+                source_code="",
+                error_message=str(e),
+                success=False,
+            )
+
+    def _count_tree_nodes(self, node: Any) -> int:
+        """Recursively count nodes in the AST tree."""
+        if node is None:
+            return 0
+
+        count = 1
+        if hasattr(node, "children"):
+            for child in node.children:
+                count += self._count_tree_nodes(child)
+        return count
+
+    def get_tree_sitter_language(self) -> Any | None:
+        """Get the tree-sitter language for C++."""
+        if self._cached_language is not None:
+            return self._cached_language
+
+        try:
+            import tree_sitter
+            import tree_sitter_cpp
+
+            caps_or_lang = tree_sitter_cpp.language()
+
+            if hasattr(caps_or_lang, "__class__") and "Language" in str(
+                type(caps_or_lang)
+            ):
+                self._cached_language = caps_or_lang
+            else:
+                try:
+                    self._cached_language = tree_sitter.Language(caps_or_lang)
+                except Exception as e:
+                    log_error(f"Failed to create Language object from PyCapsule: {e}")
+                    return None
+
+            return self._cached_language
+        except ImportError as e:
+            log_error(f"tree-sitter-cpp not available: {e}")
+            return None
+        except Exception as e:
+            log_error(f"Failed to load tree-sitter language for C++: {e}")
+            return None
+
+    def extract_elements(self, tree: Any | None, source_code: str) -> dict[str, Any]:
+        """Extract all elements from C++ code."""
+        if tree is None:
+            return {
+                "functions": [],
+                "classes": [],
+                "variables": [],
+                "imports": [],
+                "packages": [],
+            }
+
+        try:
+            extractor = self.create_extractor()
+            return {
+                "functions": extractor.extract_functions(tree, source_code),
+                "classes": extractor.extract_classes(tree, source_code),
+                "variables": extractor.extract_variables(tree, source_code),
+                "imports": extractor.extract_imports(tree, source_code),
+                "packages": extractor.extract_packages(tree, source_code),
+            }
+        except Exception as e:
+            log_error(f"Error extracting elements: {e}")
+            return {
+                "functions": [],
+                "classes": [],
+                "variables": [],
+                "imports": [],
+                "packages": [],
+            }

--- a/tree_sitter_analyzer/queries/c.py
+++ b/tree_sitter_analyzer/queries/c.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""
+C Language Queries
+
+Tree-sitter queries specific to C language constructs.
+Covers functions, structs, unions, enums, and preprocessor directives.
+"""
+
+# C-specific query library
+C_QUERIES: dict[str, str] = {
+    # --- Functions ---
+    "function": """
+    (function_definition) @function
+    """,
+    "function_declaration": """
+    (declaration
+      declarator: (function_declarator)) @function_declaration
+    """,
+    "function_name": """
+    (function_definition
+      declarator: (function_declarator
+        declarator: (identifier) @function_name))
+    """,
+    "static_function": """
+    (function_definition
+      (storage_class_specifier) @storage
+      (#eq? @storage "static")) @static_function
+    """,
+    "inline_function": """
+    (function_definition
+      (storage_class_specifier) @storage
+      (#eq? @storage "inline")) @inline_function
+    """,
+    # --- Structs and Unions ---
+    "struct": """
+    (struct_specifier) @struct
+    """,
+    "union": """
+    (union_specifier) @union
+    """,
+    "struct_name": """
+    (struct_specifier
+      name: (type_identifier) @struct_name)
+    """,
+    "union_name": """
+    (union_specifier
+      name: (type_identifier) @union_name)
+    """,
+    "typedef_struct": """
+    (type_definition
+      type: (struct_specifier) @struct_type
+      declarator: (type_identifier) @typedef_name) @typedef_struct
+    """,
+    # --- Enums ---
+    "enum": """
+    (enum_specifier) @enum
+    """,
+    "enum_name": """
+    (enum_specifier
+      name: (type_identifier) @enum_name)
+    """,
+    "enum_constant": """
+    (enumerator) @enum_constant
+    """,
+    # --- Variables and Fields ---
+    "field": """
+    (field_declaration) @field
+    """,
+    "variable": """
+    (declaration) @variable
+    """,
+    "static_variable": """
+    (declaration
+      (storage_class_specifier) @storage
+      (#eq? @storage "static")) @static_variable
+    """,
+    "const_variable": """
+    (declaration
+      (type_qualifier) @qualifier
+      (#eq? @qualifier "const")) @const_variable
+    """,
+    "extern_variable": """
+    (declaration
+      (storage_class_specifier) @storage
+      (#eq? @storage "extern")) @extern_variable
+    """,
+    "global_variable": """
+    (translation_unit
+      (declaration) @global_variable)
+    """,
+    # --- Includes and Preprocessor ---
+    "include": """
+    (preproc_include) @include
+    """,
+    "system_include": """
+    (preproc_include
+      path: (system_lib_string) @system_include)
+    """,
+    "local_include": """
+    (preproc_include
+      path: (string_literal) @local_include)
+    """,
+    "define": """
+    (preproc_def) @define
+    """,
+    "define_name": """
+    (preproc_def
+      name: (identifier) @define_name)
+    """,
+    "ifdef": """
+    (preproc_ifdef) @ifdef
+    """,
+    "ifndef": """
+    (preproc_ifdef) @ifndef
+    (#match? @ifndef "ifndef")
+    """,
+    "macro_function": """
+    (preproc_function_def) @macro_function
+    """,
+    "pragma": """
+    (preproc_call) @pragma
+    (#match? @pragma "^#pragma")
+    """,
+    # --- Type Definitions ---
+    "typedef": """
+    (type_definition) @typedef
+    """,
+    "typedef_name": """
+    (type_definition
+      declarator: (type_identifier) @typedef_name)
+    """,
+    # --- Pointer Types ---
+    "pointer_type": """
+    (pointer_declarator) @pointer_type
+    """,
+    "array_type": """
+    (array_declarator) @array_type
+    """,
+    # --- Control Flow ---
+    "if_statement": """
+    (if_statement) @if_statement
+    """,
+    "for_statement": """
+    (for_statement) @for_statement
+    """,
+    "while_statement": """
+    (while_statement) @while_statement
+    """,
+    "do_statement": """
+    (do_statement) @do_statement
+    """,
+    "switch_statement": """
+    (switch_statement) @switch_statement
+    """,
+    "case_statement": """
+    (case_statement) @case_statement
+    """,
+    "goto_statement": """
+    (goto_statement) @goto_statement
+    """,
+    "return_statement": """
+    (return_statement) @return_statement
+    """,
+    # --- Labels ---
+    "label": """
+    (labeled_statement) @label
+    """,
+    # --- Comments ---
+    "comment": """
+    (comment) @comment
+    """,
+    "block_comment": """
+    (comment) @block_comment
+    (#match? @block_comment "^/\\*")
+    """,
+    "line_comment": """
+    (comment) @line_comment
+    (#match? @line_comment "^//")
+    """,
+    # --- String Literals ---
+    "string_literal": """
+    (string_literal) @string_literal
+    """,
+    # --- Function Calls ---
+    "function_call": """
+    (call_expression) @function_call
+    """,
+    "function_call_name": """
+    (call_expression
+      function: (identifier) @function_call_name)
+    """,
+    # --- Sizeof and Alignof ---
+    "sizeof": """
+    (sizeof_expression) @sizeof
+    """,
+    # --- Cast Expressions ---
+    "cast": """
+    (cast_expression) @cast
+    """,
+}
+
+# Query descriptions
+C_QUERY_DESCRIPTIONS: dict[str, str] = {
+    "function": "Extract C function definitions",
+    "function_declaration": "Extract C function declarations",
+    "function_name": "Extract C function names only",
+    "static_function": "Extract C static functions",
+    "inline_function": "Extract C inline functions",
+    "struct": "Extract C struct declarations",
+    "union": "Extract C union declarations",
+    "struct_name": "Extract C struct names only",
+    "union_name": "Extract C union names only",
+    "typedef_struct": "Extract C typedef struct patterns",
+    "enum": "Extract C enum declarations",
+    "enum_name": "Extract C enum names only",
+    "enum_constant": "Extract C enum constants",
+    "field": "Extract C struct/union fields",
+    "variable": "Extract C variable declarations",
+    "static_variable": "Extract C static variables",
+    "const_variable": "Extract C const variables",
+    "extern_variable": "Extract C extern variables",
+    "global_variable": "Extract C global variables",
+    "include": "Extract C include directives",
+    "system_include": "Extract C system includes",
+    "local_include": "Extract C local includes",
+    "define": "Extract C preprocessor defines",
+    "define_name": "Extract C define names only",
+    "ifdef": "Extract C preprocessor ifdef blocks",
+    "ifndef": "Extract C preprocessor ifndef blocks",
+    "macro_function": "Extract C macro functions",
+    "pragma": "Extract C pragma directives",
+    "typedef": "Extract C typedef declarations",
+    "typedef_name": "Extract C typedef names only",
+    "pointer_type": "Extract C pointer types",
+    "array_type": "Extract C array types",
+    "if_statement": "Extract C if statements",
+    "for_statement": "Extract C for loops",
+    "while_statement": "Extract C while loops",
+    "do_statement": "Extract C do-while loops",
+    "switch_statement": "Extract C switch statements",
+    "case_statement": "Extract C case statements",
+    "goto_statement": "Extract C goto statements",
+    "return_statement": "Extract C return statements",
+    "label": "Extract C labeled statements",
+    "comment": "Extract C comments",
+    "block_comment": "Extract C block comments",
+    "line_comment": "Extract C line comments",
+    "string_literal": "Extract C string literals",
+    "function_call": "Extract C function calls",
+    "function_call_name": "Extract C function call names only",
+    "sizeof": "Extract C sizeof expressions",
+    "cast": "Extract C cast expressions",
+}
+
+
+def get_c_query(name: str) -> str:
+    """
+    Get the specified C query
+
+    Args:
+        name: Query name
+
+    Returns:
+        Query string
+
+    Raises:
+        ValueError: When query is not found
+    """
+    if name not in C_QUERIES:
+        available = list(C_QUERIES.keys())
+        raise ValueError(f"C query '{name}' does not exist. Available: {available}")
+
+    return C_QUERIES[name]
+
+
+def get_c_query_description(name: str) -> str:
+    """
+    Get the description of the specified C query
+
+    Args:
+        name: Query name
+
+    Returns:
+        Query description
+    """
+    return C_QUERY_DESCRIPTIONS.get(name, "No description")
+
+
+# Convert to ALL_QUERIES format for dynamic loader compatibility
+ALL_QUERIES = {}
+for query_name, query_string in C_QUERIES.items():
+    description = C_QUERY_DESCRIPTIONS.get(query_name, "No description")
+    ALL_QUERIES[query_name] = {"query": query_string, "description": description}
+
+# Add common query aliases for cross-language compatibility
+ALL_QUERIES["functions"] = {
+    "query": C_QUERIES["function"],
+    "description": "Search all function definitions (alias for function)",
+}
+
+ALL_QUERIES["classes"] = {
+    "query": C_QUERIES["struct"],
+    "description": "Search all struct declarations (alias for struct in C)",
+}
+
+ALL_QUERIES["imports"] = {
+    "query": C_QUERIES["include"],
+    "description": "Search all include directives (alias for include)",
+}
+
+ALL_QUERIES["variables"] = {
+    "query": C_QUERIES["variable"],
+    "description": "Search all variable declarations (alias for variable)",
+}
+
+
+def get_query(name: str) -> str:
+    """Get a specific query by name."""
+    if name in ALL_QUERIES:
+        return ALL_QUERIES[name]["query"]
+    raise ValueError(
+        f"Query '{name}' not found. Available queries: {list(ALL_QUERIES.keys())}"
+    )
+
+
+def get_all_queries() -> dict:
+    """Get all available queries."""
+    return ALL_QUERIES
+
+
+def list_queries() -> list:
+    """List all available query names."""
+    return list(ALL_QUERIES.keys())
+
+
+def get_available_c_queries() -> list[str]:
+    """
+    Get list of available C queries
+
+    Returns:
+        List of query names
+    """
+    return list(C_QUERIES.keys())

--- a/tree_sitter_analyzer/queries/cpp.py
+++ b/tree_sitter_analyzer/queries/cpp.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""
+C++ Language Queries
+
+Tree-sitter queries specific to C++ language constructs.
+Covers classes, functions, templates, namespaces, and other C++ specific elements.
+"""
+
+# C++-specific query library
+CPP_QUERIES: dict[str, str] = {
+    # --- Basic Structure ---
+    "class": """
+    (class_specifier) @class
+    """,
+    "struct": """
+    (struct_specifier) @struct
+    """,
+    "union": """
+    (union_specifier) @union
+    """,
+    "enum": """
+    (enum_specifier) @enum
+    """,
+    # --- Functions and Methods ---
+    "function": """
+    (function_definition) @function
+    """,
+    "function_declaration": """
+    (declaration
+      declarator: (function_declarator)) @function_declaration
+    """,
+    "method": """
+    (function_definition
+      declarator: (function_declarator
+        declarator: (field_identifier) @method.name)) @method
+    """,
+    "constructor": """
+    (function_definition
+      declarator: (function_declarator
+        declarator: (identifier) @ctor.name)
+      body: (compound_statement)) @constructor
+    """,
+    "destructor": """
+    (function_definition
+      declarator: (function_declarator
+        declarator: (destructor_name) @dtor.name)) @destructor
+    """,
+    "virtual_function": """
+    (function_definition
+      (virtual)) @virtual_function
+    """,
+    # --- Templates ---
+    "template": """
+    (template_declaration) @template
+    """,
+    "template_function": """
+    (template_declaration
+      (function_definition) @template_function)
+    """,
+    "template_class": """
+    (template_declaration
+      (class_specifier) @template_class)
+    """,
+    "template_parameter": """
+    (template_parameter_list
+      (type_parameter_declaration) @template_parameter)
+    """,
+    # --- Namespaces ---
+    "namespace": """
+    (namespace_definition) @namespace
+    """,
+    "namespace_name": """
+    (namespace_definition
+      name: (identifier) @namespace_name)
+    """,
+    "using_declaration": """
+    (using_declaration) @using_declaration
+    """,
+    "using_directive": """
+    (using_directive) @using_directive
+    """,
+    # --- Includes and Preprocessor ---
+    "include": """
+    (preproc_include) @include
+    """,
+    "system_include": """
+    (preproc_include
+      path: (system_lib_string) @system_include)
+    """,
+    "local_include": """
+    (preproc_include
+      path: (string_literal) @local_include)
+    """,
+    "define": """
+    (preproc_def) @define
+    """,
+    "ifdef": """
+    (preproc_ifdef) @ifdef
+    """,
+    "macro_function": """
+    (preproc_function_def) @macro_function
+    """,
+    # --- Variables and Fields ---
+    "field": """
+    (field_declaration) @field
+    """,
+    "variable": """
+    (declaration) @variable
+    """,
+    "static_variable": """
+    (declaration
+      (storage_class_specifier) @storage
+      (#eq? @storage "static")) @static_variable
+    """,
+    "const_variable": """
+    (declaration
+      (type_qualifier) @qualifier
+      (#eq? @qualifier "const")) @const_variable
+    """,
+    # --- Access Specifiers ---
+    "public_access": """
+    (access_specifier) @public_access
+    (#eq? @public_access "public:")
+    """,
+    "private_access": """
+    (access_specifier) @private_access
+    (#eq? @private_access "private:")
+    """,
+    "protected_access": """
+    (access_specifier) @protected_access
+    (#eq? @protected_access "protected:")
+    """,
+    # --- Inheritance ---
+    "base_class": """
+    (base_class_clause
+      (base_specifier) @base_class)
+    """,
+    "public_inheritance": """
+    (base_class_clause
+      (base_specifier
+        (access_specifier) @access
+        (#eq? @access "public")
+        (type_identifier) @base_type)) @public_inheritance
+    """,
+    # --- Smart Pointers and Modern C++ ---
+    "smart_pointer": """
+    (template_type
+      name: (type_identifier) @ptr_type
+      (#match? @ptr_type "^(unique_ptr|shared_ptr|weak_ptr)$")) @smart_pointer
+    """,
+    "auto_type": """
+    (declaration
+      type: (auto)) @auto_type
+    """,
+    "lambda": """
+    (lambda_expression) @lambda
+    """,
+    "range_for": """
+    (for_range_loop) @range_for
+    """,
+    # --- Exception Handling ---
+    "try_catch": """
+    (try_statement) @try_catch
+    """,
+    "catch_clause": """
+    (catch_clause) @catch_clause
+    """,
+    "throw_statement": """
+    (throw_statement) @throw_statement
+    """,
+    # --- Name-only Extraction ---
+    "class_name": """
+    (class_specifier
+      name: (type_identifier) @class_name)
+    """,
+    "function_name": """
+    (function_definition
+      declarator: (function_declarator
+        declarator: (identifier) @function_name))
+    """,
+    "field_name": """
+    (field_declaration
+      declarator: (field_identifier) @field_name)
+    """,
+    # --- Comments ---
+    "comment": """
+    (comment) @comment
+    """,
+    "block_comment": """
+    (comment) @block_comment
+    (#match? @block_comment "^/\\*")
+    """,
+    # --- Operator Overloading ---
+    "operator_overload": """
+    (function_definition
+      declarator: (function_declarator
+        declarator: (operator_name) @operator_name)) @operator_overload
+    """,
+    # --- Friend Declaration ---
+    "friend": """
+    (friend_declaration) @friend
+    """,
+}
+
+# Query descriptions
+CPP_QUERY_DESCRIPTIONS: dict[str, str] = {
+    "class": "Extract C++ class declarations",
+    "struct": "Extract C++ struct declarations",
+    "union": "Extract C++ union declarations",
+    "enum": "Extract C++ enum declarations",
+    "function": "Extract C++ function definitions",
+    "function_declaration": "Extract C++ function declarations",
+    "method": "Extract C++ class methods",
+    "constructor": "Extract C++ constructors",
+    "destructor": "Extract C++ destructors",
+    "virtual_function": "Extract C++ virtual functions",
+    "template": "Extract C++ template declarations",
+    "template_function": "Extract C++ template functions",
+    "template_class": "Extract C++ template classes",
+    "template_parameter": "Extract C++ template parameters",
+    "namespace": "Extract C++ namespace definitions",
+    "namespace_name": "Extract C++ namespace names",
+    "using_declaration": "Extract C++ using declarations",
+    "using_directive": "Extract C++ using directives",
+    "include": "Extract C++ include directives",
+    "system_include": "Extract C++ system includes",
+    "local_include": "Extract C++ local includes",
+    "define": "Extract C++ preprocessor defines",
+    "ifdef": "Extract C++ preprocessor ifdef blocks",
+    "macro_function": "Extract C++ macro functions",
+    "field": "Extract C++ class/struct fields",
+    "variable": "Extract C++ variable declarations",
+    "static_variable": "Extract C++ static variables",
+    "const_variable": "Extract C++ const variables",
+    "public_access": "Extract C++ public access specifiers",
+    "private_access": "Extract C++ private access specifiers",
+    "protected_access": "Extract C++ protected access specifiers",
+    "base_class": "Extract C++ base class specifiers",
+    "public_inheritance": "Extract C++ public inheritance",
+    "smart_pointer": "Extract C++ smart pointer usage",
+    "auto_type": "Extract C++ auto type declarations",
+    "lambda": "Extract C++ lambda expressions",
+    "range_for": "Extract C++ range-based for loops",
+    "try_catch": "Extract C++ try-catch blocks",
+    "catch_clause": "Extract C++ catch clauses",
+    "throw_statement": "Extract C++ throw statements",
+    "class_name": "Extract C++ class names only",
+    "function_name": "Extract C++ function names only",
+    "field_name": "Extract C++ field names only",
+    "comment": "Extract C++ comments",
+    "block_comment": "Extract C++ block comments",
+    "operator_overload": "Extract C++ operator overloads",
+    "friend": "Extract C++ friend declarations",
+}
+
+
+def get_cpp_query(name: str) -> str:
+    """
+    Get the specified C++ query
+
+    Args:
+        name: Query name
+
+    Returns:
+        Query string
+
+    Raises:
+        ValueError: When query is not found
+    """
+    if name not in CPP_QUERIES:
+        available = list(CPP_QUERIES.keys())
+        raise ValueError(f"C++ query '{name}' does not exist. Available: {available}")
+
+    return CPP_QUERIES[name]
+
+
+def get_cpp_query_description(name: str) -> str:
+    """
+    Get the description of the specified C++ query
+
+    Args:
+        name: Query name
+
+    Returns:
+        Query description
+    """
+    return CPP_QUERY_DESCRIPTIONS.get(name, "No description")
+
+
+# Convert to ALL_QUERIES format for dynamic loader compatibility
+ALL_QUERIES = {}
+for query_name, query_string in CPP_QUERIES.items():
+    description = CPP_QUERY_DESCRIPTIONS.get(query_name, "No description")
+    ALL_QUERIES[query_name] = {"query": query_string, "description": description}
+
+# Add common query aliases for cross-language compatibility
+ALL_QUERIES["functions"] = {
+    "query": CPP_QUERIES["function"],
+    "description": "Search all function definitions (alias for function)",
+}
+
+ALL_QUERIES["methods"] = {
+    "query": CPP_QUERIES["method"],
+    "description": "Search all method declarations (alias for method)",
+}
+
+ALL_QUERIES["classes"] = {
+    "query": CPP_QUERIES["class"],
+    "description": "Search all class declarations (alias for class)",
+}
+
+ALL_QUERIES["imports"] = {
+    "query": CPP_QUERIES["include"],
+    "description": "Search all include directives (alias for include)",
+}
+
+ALL_QUERIES["variables"] = {
+    "query": CPP_QUERIES["variable"],
+    "description": "Search all variable declarations (alias for variable)",
+}
+
+
+def get_query(name: str) -> str:
+    """Get a specific query by name."""
+    if name in ALL_QUERIES:
+        return ALL_QUERIES[name]["query"]
+    raise ValueError(
+        f"Query '{name}' not found. Available queries: {list(ALL_QUERIES.keys())}"
+    )
+
+
+def get_all_queries() -> dict:
+    """Get all available queries."""
+    return ALL_QUERIES
+
+
+def list_queries() -> list:
+    """List all available query names."""
+    return list(ALL_QUERIES.keys())
+
+
+def get_available_cpp_queries() -> list[str]:
+    """
+    Get list of available C++ queries
+
+    Returns:
+        List of query names
+    """
+    return list(CPP_QUERIES.keys())


### PR DESCRIPTION
This pull request adds support for C and C++ language queries to the tree-sitter analyzer, enabling the extraction of language-specific constructs such as functions, classes, structs, variables, and preprocessor directives. It introduces two new query modules for C and C++, each with comprehensive query definitions and descriptions, and registers them in the project configuration for plugin-based loading.

**Language support additions:**

* Added plugin entries for C (`c_plugin:CPlugin`) and C++ (`cpp_plugin:CppPlugin`) to the `pyproject.toml` configuration, enabling dynamic loading of language-specific query modules.

**C language query module (`tree_sitter_analyzer/queries/c.py`):**

* Implemented a full set of tree-sitter queries for C constructs, including functions, structs, unions, enums, variables, preprocessor directives, and control flow statements.
* Provided descriptions for each query and utility functions for query retrieval, listing, and alias mapping to support dynamic and cross-language usage.

**C++ language query module (`tree_sitter_analyzer/queries/cpp.py`):**

* Implemented a comprehensive set of tree-sitter queries for C++ constructs, covering classes, methods, templates, namespaces, smart pointers, exception handling, and more.
* Included query descriptions and utility functions for dynamic access, listing, and aliasing, similar to the C module.


PR is written entirely by Copilot (it works and seems precise to me), still requesting a review!