### PR TITLE
chore: Migrate CI from macOS 13 to macos-latest

### DIFF
--- a/.github/actions/setup-system/action.yml
+++ b/.github/actions/setup-system/action.yml
@@ -9,7 +9,7 @@ description: 'Install fd and ripgrep system dependencies for all platforms'
 
 inputs:
   os:
-    description: 'Operating system (ubuntu-latest, windows-latest, macos-13)'
+    description: 'Operating system (ubuntu-latest, windows-latest, macos-latest)'
     required: true
 
 runs:
@@ -33,7 +33,7 @@ runs:
       shell: bash
 
     - name: Install system dependencies (macOS)
-      if: inputs.os == 'macos-13'
+      if: startsWith(inputs.os, 'macos-')
       run: |
         echo "Installing fd and ripgrep on macOS..."
         brew install fd ripgrep

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -35,13 +35,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
         exclude:
           # Reduce matrix size for faster CI
           - os: windows-latest
             python-version: "3.10"
-          - os: macos-13
+          - os: macos-latest
             python-version: "3.10"
 
     env:
@@ -70,7 +70,7 @@ jobs:
       shell: bash
 
     - name: Install system dependencies (macOS)
-      if: matrix.os == 'macos-13'
+      if: startsWith(matrix.os, 'macos-')
       run: |
         # Install fd and ripgrep for MCP tools
         brew install fd ripgrep

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -233,7 +233,7 @@ Configure in GitHub repository Settings → Branches → Branch protection rules
 ### Test Environment
 
 - **Python versions**: 3.10, 3.11, 3.12, 3.13
-- **OS platforms**: ubuntu-latest, windows-latest, macos-13
+- **OS platforms**: ubuntu-latest, windows-latest, macos-latest
 - **System dependencies**: fd, ripgrep
 - **Quality checks**: mypy, black, ruff, isort, bandit, pydocstyle
 

--- a/docs/ci-cd-migration-guide.md
+++ b/docs/ci-cd-migration-guide.md
@@ -266,7 +266,7 @@ matrix:
 # ci.yml
 matrix:
   python-version: ["3.10", "3.11"]
-  os: [ubuntu-latest, macos-13]
+  os: [ubuntu-latest, macos-latest]
 ```
 
 **After**: Unified matrix across all branches
@@ -275,11 +275,11 @@ matrix:
 # All workflows use the same matrix
 matrix:
   python-version: ["3.10", "3.11", "3.12", "3.13"]
-  os: [ubuntu-latest, windows-latest, macos-13]
+  os: [ubuntu-latest, windows-latest, macos-latest]
   exclude:
     - os: windows-latest
       python-version: "3.10"
-    - os: macos-13
+    - os: macos-latest
       python-version: "3.10"
 ```
 

--- a/docs/ci-cd-overview.md
+++ b/docs/ci-cd-overview.md
@@ -71,7 +71,7 @@ upload-coverage: true    # Whether to upload coverage to Codecov
 
 **Test Matrix**:
 - **Python Versions**: 3.10, 3.11, 3.12, 3.13
-- **Operating Systems**: ubuntu-latest, windows-latest, macos-13
+- **Operating Systems**: ubuntu-latest, windows-latest, macos-latest
 - **Exclusions**: Windows and macOS skip Python 3.10 for optimization
 
 ### 2. Reusable Quality Check Workflow
@@ -297,12 +297,12 @@ All branch workflows use the same test matrix to ensure consistency:
 strategy:
   fail-fast: false
   matrix:
-    os: [ubuntu-latest, windows-latest, macos-13]
+    os: [ubuntu-latest, windows-latest, macos-latest]
     python-version: ["3.10", "3.11", "3.12", "3.13"]
     exclude:
       - os: windows-latest
         python-version: "3.10"
-      - os: macos-13
+      - os: macos-latest
         python-version: "3.10"
 ```
 

--- a/docs/ci-cd-secrets-reference.md
+++ b/docs/ci-cd-secrets-reference.md
@@ -135,7 +135,7 @@ env:
 **Values**:
 - `ubuntu-latest`
 - `windows-latest`
-- `macos-13`
+- `macos-latest`
 
 **Used By**: All test jobs
 

--- a/docs/ci-cd-troubleshooting.md
+++ b/docs/ci-cd-troubleshooting.md
@@ -702,13 +702,13 @@ Review and optimize the test matrix in workflows:
 ```yaml
 strategy:
   matrix:
-    os: [ubuntu-latest, windows-latest, macos-13]
+    os: [ubuntu-latest, windows-latest, macos-latest]
     python-version: ["3.10", "3.11", "3.12", "3.13"]
     exclude:
       # Add more exclusions to reduce combinations
       - os: windows-latest
         python-version: "3.10"
-      - os: macos-13
+      - os: macos-latest
         python-version: "3.10"
 ```
 

--- a/docs/ja/CONTRIBUTING_ja.md
+++ b/docs/ja/CONTRIBUTING_ja.md
@@ -331,7 +331,7 @@ GitHub リポジトリの Settings → Branches → Branch protection rules で�
 ### テスト環境
 
 - **Python バージョン**: 3.10, 3.11, 3.12, 3.13
-- **OS プラットフォーム**: ubuntu-latest, windows-latest, macos-13
+- **OS プラットフォーム**: ubuntu-latest, windows-latest, macos-latest
 - **システム依存**: fd, ripgrep
 - **品質チェック**: mypy, black, ruff, isort, bandit, pydocstyle
 

--- a/tests/test_workflows/CI_WORKFLOW_TESTING_GUIDE.md
+++ b/tests/test_workflows/CI_WORKFLOW_TESTING_GUIDE.md
@@ -73,7 +73,7 @@ Verify:
 Check that tests run on all platforms:
 - ✓ ubuntu-latest (Python 3.10, 3.11, 3.12, 3.13)
 - ✓ windows-latest (Python 3.11, 3.12, 3.13)
-- ✓ macos-13 (Python 3.11, 3.12, 3.13)
+- ✓ macos-latest (Python 3.11, 3.12, 3.13)
 
 ### Step 5: Verify Coverage Upload
 

--- a/tests/test_workflows/HOTFIX_WORKFLOW_TESTING_GUIDE.md
+++ b/tests/test_workflows/HOTFIX_WORKFLOW_TESTING_GUIDE.md
@@ -119,9 +119,9 @@ Compare the hotfix workflow execution with a recent release workflow execution:
    ├─ Test Matrix (windows-latest, Python 3.11) - PASSED
    ├─ Test Matrix (windows-latest, Python 3.12) - PASSED
    ├─ Test Matrix (windows-latest, Python 3.13) - PASSED
-   ├─ Test Matrix (macos-13, Python 3.11) - PASSED
-   ├─ Test Matrix (macos-13, Python 3.12) - PASSED
-   └─ Test Matrix (macos-13, Python 3.13) - PASSED
+   ├─ Test Matrix (macos-latest, Python 3.11) - PASSED
+   ├─ Test Matrix (macos-latest, Python 3.12) - PASSED
+   └─ Test Matrix (macos-latest, Python 3.13) - PASSED
 
 ✅ Build and Deploy Job
    ├─ Build package - PASSED

--- a/tests/test_workflows/README.md
+++ b/tests/test_workflows/README.md
@@ -107,7 +107,7 @@ These tests validate **all requirements** (1.1-7.5) and ensure:
 
 - ✅ Consistent test configurations across all branches
 - ✅ Identical Python versions (3.10, 3.11, 3.12, 3.13)
-- ✅ Identical operating systems (ubuntu-latest, windows-latest, macos-13)
+- ✅ Identical operating systems (ubuntu-latest, windows-latest, macos-latest)
 - ✅ All-extras installation flag usage
 - ✅ Quality check presence and consistency
 - ✅ Coverage configuration standardization

--- a/tests/test_workflows/RELEASE_WORKFLOW_TESTING_GUIDE.md
+++ b/tests/test_workflows/RELEASE_WORKFLOW_TESTING_GUIDE.md
@@ -52,7 +52,7 @@ The test job should:
 
 - ✅ Use the reusable-test.yml workflow
 - ✅ Run tests across multiple Python versions (3.10, 3.11, 3.12, 3.13)
-- ✅ Run tests across multiple OS platforms (ubuntu-latest, windows-latest, macos-13)
+- ✅ Run tests across multiple OS platforms (ubuntu-latest, windows-latest, macos-latest)
 - ✅ Install system dependencies (fd, ripgrep)
 - ✅ Run pre-commit quality checks
 - ✅ Upload coverage to Codecov

--- a/tests/test_workflows/TASK_4_SUMMARY.md
+++ b/tests/test_workflows/TASK_4_SUMMARY.md
@@ -55,7 +55,7 @@ jobs:
    - Validates: Requirements 3.1, 3.2
    - Ensures test matrix matches release workflow
    - Verifies Python versions: 3.10, 3.11, 3.12, 3.13
-   - Verifies OS platforms: ubuntu-latest, windows-latest, macos-13
+   - Verifies OS platforms: ubuntu-latest, windows-latest, macos-latest
 
 **Additional Tests**:
 - Reusable workflow component usage

--- a/tests/test_workflows/TASK_5_SUMMARY.md
+++ b/tests/test_workflows/TASK_5_SUMMARY.md
@@ -31,7 +31,7 @@ Task 5 successfully refactored the `ci.yml` workflow to use reusable workflow co
 1. **Property 1: Test Configuration Consistency**
    - Verifies CI workflow uses same reusable test workflow as other branches
    - Validates Python versions (3.10, 3.11, 3.12, 3.13)
-   - Validates operating systems (ubuntu-latest, windows-latest, macos-13)
+   - Validates operating systems (ubuntu-latest, windows-latest, macos-latest)
    - Validates --all-extras flag usage
    - **Validates: Requirements 1.1, 1.2, 1.3, 1.4**
 
@@ -177,7 +177,7 @@ python tests/test_workflows/validate_ci_workflow.py
 **Validation**: 
 - ✅ CI workflow uses same reusable-test.yml as other branches
 - ✅ Same Python versions (3.10, 3.11, 3.12, 3.13)
-- ✅ Same operating systems (ubuntu-latest, windows-latest, macos-13)
+- ✅ Same operating systems (ubuntu-latest, windows-latest, macos-latest)
 - ✅ Same --all-extras flag usage
 
 ### Requirement 1.5

--- a/tests/test_workflows/TASK_6_SUMMARY.md
+++ b/tests/test_workflows/TASK_6_SUMMARY.md
@@ -15,7 +15,7 @@ Created a unified test file that validates all correctness properties defined in
 - **Tests**: All branch workflows use identical test configurations
 - **Checks**:
   - Python versions: 3.10, 3.11, 3.12, 3.13
-  - Operating systems: ubuntu-latest, windows-latest, macos-13
+  - Operating systems: ubuntu-latest, windows-latest, macos-latest
   - All workflows use reusable-test.yml
   - Secrets are properly inherited
 

--- a/tests/test_workflows/test_ci_workflow_consistency.py
+++ b/tests/test_workflows/test_ci_workflow_consistency.py
@@ -190,7 +190,7 @@ class TestCIWorkflowConsistency:
         ), f"Python versions must be {expected_python_versions}"
 
         # Verify operating systems
-        expected_os = ["ubuntu-latest", "windows-latest", "macos-13"]
+        expected_os = ["ubuntu-latest", "windows-latest", "macos-latest"]
         assert (
             test_matrix["os"] == expected_os
         ), f"Operating systems must be {expected_os}"

--- a/tests/test_workflows/test_develop_workflow_consistency.py
+++ b/tests/test_workflows/test_develop_workflow_consistency.py
@@ -135,7 +135,7 @@ class TestDevelopWorkflowConsistency:
         ), f"Python versions must be {expected_python_versions}"
 
         # Verify operating systems
-        expected_os = ["ubuntu-latest", "windows-latest", "macos-13"]
+        expected_os = ["ubuntu-latest", "windows-latest", "macos-latest"]
         assert (
             test_matrix["os"] == expected_os
         ), f"Operating systems must be {expected_os}"

--- a/tests/test_workflows/test_hotfix_workflow_consistency.py
+++ b/tests/test_workflows/test_hotfix_workflow_consistency.py
@@ -182,7 +182,7 @@ class TestHotfixWorkflowConsistency:
         ), f"Test matrix must include Python versions {expected_python_versions}"
 
         # Verify operating systems
-        expected_os = ["ubuntu-latest", "windows-latest", "macos-13"]
+        expected_os = ["ubuntu-latest", "windows-latest", "macos-latest"]
         actual_os = matrix.get("os", [])
         assert (
             actual_os == expected_os

--- a/tests/test_workflows/test_workflow_properties.py
+++ b/tests/test_workflows/test_workflow_properties.py
@@ -216,7 +216,7 @@ class TestWorkflowProperties:
 
         # Expected configuration
         expected_python_versions = ["3.10", "3.11", "3.12", "3.13"]
-        expected_os = ["ubuntu-latest", "windows-latest", "macos-13"]
+        expected_os = ["ubuntu-latest", "windows-latest", "macos-latest"]
 
         # Verify test matrix configuration
         assert (
@@ -453,7 +453,7 @@ class TestWorkflowProperties:
 
         # Expected configuration
         expected_python_versions = ["3.10", "3.11", "3.12", "3.13"]
-        expected_os = ["ubuntu-latest", "windows-latest", "macos-13"]
+        expected_os = ["ubuntu-latest", "windows-latest", "macos-latest"]
 
         # Verify Python versions
         assert (

--- a/verify_workflow_structure.py
+++ b/verify_workflow_structure.py
@@ -92,7 +92,11 @@ def verify_reusable_test_workflow():
                     if "os" not in matrix:
                         errors.append("Missing os in matrix")
                     else:
-                        expected_os = ["ubuntu-latest", "windows-latest", "macos-13"]
+                        expected_os = [
+                            "ubuntu-latest",
+                            "windows-latest",
+                            "macos-latest",
+                        ]
                         if matrix["os"] != expected_os:
                             errors.append(
                                 f"OS matrix should be {expected_os}, got {matrix['os']}"
@@ -240,7 +244,7 @@ def verify_composite_action():
                 if "if" in step:
                     if "ubuntu-latest" in step["if"]:
                         has_linux = True
-                    if "macos-13" in step["if"]:
+                    if "macos-" in step["if"] or "macos-latest" in step["if"]:
                         has_macos = True
                     if "windows-latest" in step["if"]:
                         has_windows = True


### PR DESCRIPTION
## 📋 Pull Request Description

### 🎯 What does this PR do?

This PR migrates all GitHub Actions workflows from the deprecated `macos-13` runner to `macos-latest`. This ensures compatibility with GitHub Actions' deprecation timeline where macOS 13 will be fully unsupported by December 8, 2025.

### 🔗 Related Issues

Related to: https://github.com/actions/runner-images/issues/13046

### 🔄 Type of Change

- [x] 🏗️ Build/CI changes

## 🧪 Testing

### ✅ Test Coverage

- [x] New and existing unit tests pass locally with my changes
- [x] I have tested the changes manually (verified workflow files are valid)

### 🔍 Test Results

All pre-commit hooks passed successfully:
- ✅ ruff linting
- ✅ ruff-format
- ✅ yaml validation
- ✅ Workflow Consistency Tests

## 📋 Quality Checklist

### 🔧 Code Quality

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation

### 🛠️ Quality Checks Passed

- [x] ✅ Ruff linting passed
- [x] ✅ Ruff formatting passed
- [x] ✅ YAML validation passed
- [x] ✅ Workflow consistency tests passed

## 📚 Documentation

- [x] I have updated relevant documentation
  - Updated `.github/workflows/reusable-test.yml`
  - Updated `.github/actions/setup-system/action.yml`
  - Updated all test files expecting `macos-13`
  - Updated CONTRIBUTING.md (both EN and JA)
  - Updated all CI/CD documentation guides

## 🔄 Breaking Changes

No breaking changes. This is a transparent migration to newer macOS runners.

## 📝 Changes Made

### Workflow Files
- Changed `macos-13` to `macos-latest` in test matrix
- Updated macOS detection to use `startsWith(matrix.os, 'macos-')` for future compatibility

### Test Files
- Updated expected OS values from `macos-13` to `macos-latest`
- Updated verification scripts to check for `macos-latest`

### Documentation
- Updated all references in English and Japanese documentation
- Updated CI/CD guides, troubleshooting guides, and migration guides
- Updated test workflow documentation

## 🎯 Performance Impact

- [x] No performance impact (runner migration only)

## 🔍 Additional Notes

This change is required to maintain CI/CD stability as GitHub Actions will begin brownout periods for macOS 13 starting November 4, 2025, with full deprecation on December 8, 2025.

The migration to `macos-latest` ensures:
1. No interruption during brownout periods
2. Compatibility with the latest macOS runners
3. Future-proof CI configuration

## ✅ Final Checklist

- [x] I have read the Contributing Guidelines
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

