### PR TITLE
fix: prevent false positive project root detection from common home dir files

### DIFF
--- a/tree_sitter_analyzer/project_detector.py
+++ b/tree_sitter_analyzer/project_detector.py
@@ -164,15 +164,23 @@ class ProjectRootDetector:
                 break
             current_dir = str(parent_path)
 
-        # Return the best candidate if any found
+        # Return the best candidate if any found with sufficient confidence.
+        # Require at least one high-priority (score 100) or medium-priority
+        # (score 50) marker. Low-priority markers alone (README.md, LICENSE,
+        # etc.) are too common in non-project directories like user home dirs.
+        MIN_PROJECT_SCORE = 50
         if candidates:
             # Sort by score (descending) and return the best
             candidates.sort(key=lambda x: x[1], reverse=True)
             best_candidate = candidates[0]
+            if best_candidate[1] >= MIN_PROJECT_SCORE:
+                logger.debug(
+                    f"Selected project root: {best_candidate[0]} (score: {best_candidate[1]}, markers: {best_candidate[2]})"
+                )
+                return best_candidate[0]
             logger.debug(
-                f"Selected project root: {best_candidate[0]} (score: {best_candidate[1]}, markers: {best_candidate[2]})"
+                f"Best candidate {best_candidate[0]} score {best_candidate[1]} below threshold {MIN_PROJECT_SCORE}, ignoring"
             )
-            return best_candidate[0]
 
         logger.debug(f"No project root detected from {start_dir}")
         return None
@@ -228,7 +236,7 @@ class ProjectRootDetector:
             "Cargo.toml",
             "go.mod",
         ]
-        medium_priority = ["setup.py", "requirements.txt", "CMakeLists.txt", "Makefile"]
+        medium_priority = ["setup.py", "CMakeLists.txt", "Makefile", "build.gradle", "gradlew"]
 
         for marker in markers:
             if marker in high_priority:


### PR DESCRIPTION
## Summary
- **Bug**: \ProjectRootDetector._traverse_upward()\ could falsely identify user home directories as project roots when they contained low-priority markers like \equirements.txt\ or \README.md\
- **Impact**: \	est_no_markers_found\ failed on machines where \~/\ had such files (e.g. Windows \C:\Users\<user>\requirements.txt\)
- **Fix**: Add minimum score threshold (50) for project root candidates and demote \equirements.txt\ from medium to low priority

## Changes
1. \_traverse_upward()\: Only return candidates scoring >= 50 (at least one medium/high priority marker)
2. \_calculate_score()\: Move \equirements.txt\ to low priority (score 10), add \uild.gradle\/\gradlew\ to medium (score 50)

## Test plan
- [x] All 13 tests in \	est_project_detector.py\ pass
- [x] \	est_no_markers_found\ now correctly returns \None\ on machines with \equirements.txt\ in home dir
- [x] High-priority marker detection unchanged (git, pyproject.toml, etc.)


Made with [Cursor](https://cursor.com)