### PR TITLE
fix(intelligence): implement stability_metrics, hotspots, depth BFS, layer_rules validation

### DIFF
--- a/openspec/changes/add-code-intelligence-graph/specs/architecture-health/spec.md
+++ b/openspec/changes/add-code-intelligence-graph/specs/architecture-health/spec.md
@@ -2,7 +2,7 @@
 
 **Change ID**: `add-code-intelligence-graph`
 **Spec ID**: `architecture-health`
-**Status**: Implemented (v4 — 2026-02-14)
+**Status**: Partially Implemented (v5 — 2026-03-11)
 
 ---
 
@@ -236,6 +236,51 @@ The `test_coverage` overtested detection must scope counts by `(file_path, symbo
 **When** test coverage analysis runs with `overtested_threshold=10`
 **Then** `process` from `src/engine.py` is in `overtested_symbols` with `test_ref_count=15`
 
+### Requirement 15: Stability Metrics Check (v5)
+**ID**: AH-015
+**Priority**: High
+
+Report modules that exceed the instability threshold, sorted for prioritized refactoring.
+
+#### Scenario: Report unstable modules
+**Given** a module with Ca=1, Ce=5 (instability=0.833)
+**When** check_architecture_health is called with checks=["stability_metrics"]
+**Then** result.unstable_modules contains the module with instability=0.833
+
+#### Scenario: Stable modules excluded (strict threshold)
+**Given** a module with Ca=3, Ce=7 (instability exactly 0.7)
+**When** stability_metrics check runs
+**Then** the module is NOT in unstable_modules (threshold is strictly > 0.7)
+
+#### Scenario: Works without coupling_metrics in checks
+**Given** only checks=["stability_metrics"] specified
+**When** the check runs
+**Then** coupling is computed internally and unstable_modules is populated
+
+#### Scenario: Sorted by instability descending
+**Given** multiple unstable modules with different instability values
+**Then** unstable_modules[0].instability >= unstable_modules[1].instability
+
+### Requirement 16: Hotspot Detection (v5)
+**ID**: AH-016
+**Priority**: High
+
+Identify modules that are both highly unstable AND heavily coupled — the most dangerous refactoring targets.
+
+#### Scenario: High instability + high efferent coupling = hotspot
+**Given** a module with instability=0.85 and efferent_coupling=8
+**When** check_architecture_health is called with checks=["hotspots"]
+**Then** result.hotspot_modules contains the module
+
+#### Scenario: Low coupling excludes from hotspot
+**Given** a module with instability=0.9 but efferent_coupling=1 (< 3)
+**When** hotspots check runs
+**Then** the module is NOT in hotspot_modules
+
+#### Scenario: Sorted by hotspot_score (instability × efferent_coupling) descending
+**Given** multiple hotspot modules with different scores
+**Then** hotspot_modules are sorted so highest score comes first
+
 ---
 
 ## Acceptance Criteria
@@ -254,3 +299,5 @@ The `test_coverage` overtested detection must scope counts by `(file_path, symbo
 - [x] (v3) `test_coverage` check detects untested/overtested/test-only symbols
 - [x] (v4) `test_coverage` excludes `@property` and inner functions from untested list (AH-013)
 - [x] (v4) `test_coverage` overtested scoped by `(file, name)` to avoid cross-class aggregation (AH-014)
+- [ ] (v5) `stability_metrics` check returns unstable_modules sorted by instability desc (AH-015)
+- [ ] (v5) `hotspots` check returns hotspot_modules sorted by instability×Ce desc (AH-016)

--- a/openspec/changes/add-code-intelligence-graph/specs/call-graph-extraction/spec.md
+++ b/openspec/changes/add-code-intelligence-graph/specs/call-graph-extraction/spec.md
@@ -2,7 +2,7 @@
 
 **Change ID**: `add-code-intelligence-graph`
 **Spec ID**: `call-graph-extraction`
-**Status**: Implemented (v2 — 2026-02-14)
+**Status**: Partially Implemented (v3 — 2026-03-11)
 
 ---
 
@@ -68,10 +68,24 @@ Extract function/method call sites from Python source code using tree-sitter que
 **When** CallGraphBuilder.build_for_file() is called
 **Then** a FileCallGraph is returned with correct caller-callee edges
 
-#### Scenario: Find callers of a function
-**Given** a call graph built from a directory of Python files
-**When** find_callers("validate", depth=2) is called
-**Then** direct and transitive callers are returned up to depth 2
+#### Scenario: Find callers of a function with depth=1 (direct only)
+**Given** a call chain A() → B() → C()
+**When** find_callers("C", depth=1) is called
+**Then** only B is returned (direct caller), A is excluded (too deep)
+
+#### Scenario: Find callers with depth=2 (transitive)
+**Given** a call chain A() → B() → C()
+**When** find_callers("C", depth=2) is called
+**Then** both B (depth=1) and A (depth=2) are returned
+
+#### Scenario: depth=0 returns empty
+**When** find_callers("C", depth=0) is called
+**Then** an empty list is returned
+
+#### Scenario: No duplicates in results
+**Given** multiple paths to the same caller
+**When** find_callers is called
+**Then** each CallSite appears exactly once
 
 ---
 
@@ -80,4 +94,4 @@ Extract function/method call sites from Python source code using tree-sitter que
 - [x] call_expression query captures simple calls, method calls, chained calls
 - [x] CallSite model correctly populated from query results
 - [x] CallGraphBuilder builds correct edges for single-file scenarios
-- [x] find_callers and find_callees work with depth limiting
+- [ ] find_callers and find_callees work with depth limiting (BFS, v3)

--- a/tests/unit/intelligence/test_architecture_metrics.py
+++ b/tests/unit/intelligence/test_architecture_metrics.py
@@ -188,6 +188,20 @@ class TestStabilityMetrics:
                 )
 
 
+    def test_stability_metrics_reuses_existing_module_metrics(self, components):
+        """stability_metrics skips recomputing coupling when module_metrics already populated."""
+        dg, si = components
+        dg.add_edge(DependencyEdge("a/m.py", "b/m.py", "b"))
+        dg.add_edge(DependencyEdge("a/m.py", "c/m.py", "c"))
+        dg.add_edge(DependencyEdge("a/m.py", "d/m.py", "d"))
+        m = ArchitectureMetrics(dg, si)
+        # coupling_metrics runs first and populates module_metrics;
+        # stability_metrics must use that cached value (False branch of 'if not report.module_metrics')
+        report = m.compute_report(".", checks=["coupling_metrics", "stability_metrics"])
+        assert isinstance(report.unstable_modules, list)
+        assert len(report.module_metrics) > 0
+
+
 class TestHotspotDetection:
     """Tests for hotspots check - AH-016."""
 
@@ -239,3 +253,16 @@ class TestHotspotDetection:
         m = ArchitectureMetrics(dg, si)
         report = m.compute_report(".", checks=["hotspots"])
         assert isinstance(report.hotspot_modules, list)
+
+    def test_hotspots_reuses_existing_module_metrics(self, components):
+        """hotspots skips recomputing coupling when module_metrics already populated."""
+        dg, si = components
+        dg.add_edge(DependencyEdge("caller/m.py", "hot/m.py", "hot"))
+        for i in range(8):
+            dg.add_edge(DependencyEdge("hot/m.py", f"dep{i}/m.py", f"dep{i}"))
+        m = ArchitectureMetrics(dg, si)
+        # coupling_metrics runs first; hotspots uses cached module_metrics
+        # (False branch of 'if not report.module_metrics')
+        report = m.compute_report(".", checks=["coupling_metrics", "hotspots"])
+        hotspot_paths = [mod.path for mod in report.hotspot_modules]
+        assert "hot" in hotspot_paths

--- a/tests/unit/intelligence/test_architecture_metrics.py
+++ b/tests/unit/intelligence/test_architecture_metrics.py
@@ -110,3 +110,132 @@ class TestArchitectureMetricsBasic:
         m = ArchitectureMetrics(dg, si)
         report = m.compute_report(".", checks=["coupling_metrics"])
         assert len(report.coupling_matrix) > 0
+
+
+class TestStabilityMetrics:
+    """Tests for stability_metrics check - AH-015."""
+
+    @pytest.fixture
+    def unstable_setup(self, components):
+        """Module 'a' has Ce=5, Ca=0 → instability=1.0 (clearly unstable)."""
+        dg, si = components
+        for target in ["b/m.py", "c/m.py", "d/m.py", "e/m.py", "f/m.py"]:
+            dg.add_edge(DependencyEdge("a/m.py", target, target.split("/")[0]))
+        return dg, si
+
+    @pytest.fixture
+    def stable_setup(self, components):
+        """Module 'stable' has Ce=1, Ca=5 → instability=0.167 (stable)."""
+        dg, si = components
+        for i in range(5):
+            dg.add_edge(DependencyEdge(f"dep{i}/m.py", "stable/m.py", "stable"))
+        dg.add_edge(DependencyEdge("stable/m.py", "utils/m.py", "utils"))
+        return dg, si
+
+    def test_stability_metrics_returns_unstable_modules(self, unstable_setup):
+        dg, si = unstable_setup
+        m = ArchitectureMetrics(dg, si)
+        report = m.compute_report(".", checks=["stability_metrics"])
+        unstable_paths = [mod.path for mod in report.unstable_modules]
+        assert "a" in unstable_paths
+
+    def test_stable_modules_excluded(self, stable_setup):
+        dg, si = stable_setup
+        m = ArchitectureMetrics(dg, si)
+        report = m.compute_report(".", checks=["stability_metrics"])
+        unstable_paths = [mod.path for mod in report.unstable_modules]
+        assert "stable" not in unstable_paths
+
+    def test_stability_metrics_without_coupling_metrics(self, unstable_setup):
+        """stability_metrics must work even if coupling_metrics not in checks."""
+        dg, si = unstable_setup
+        m = ArchitectureMetrics(dg, si)
+        report = m.compute_report(".", checks=["stability_metrics"])
+        assert isinstance(report.unstable_modules, list)
+        assert len(report.unstable_modules) > 0
+
+    def test_stability_threshold_is_strictly_greater_than_07(self, components):
+        """Exact instability=0.7 (Ca=3, Ce=7) should NOT appear (threshold is strict >0.7)."""
+        dg, si = components
+        for i in range(3):
+            dg.add_edge(DependencyEdge(f"caller{i}/m.py", "target/m.py", "target"))
+        for i in range(7):
+            dg.add_edge(DependencyEdge("target/m.py", f"dep{i}/m.py", f"dep{i}"))
+        m = ArchitectureMetrics(dg, si)
+        report = m.compute_report(".", checks=["stability_metrics"])
+        unstable_paths = [mod.path for mod in report.unstable_modules]
+        assert "target" not in unstable_paths
+
+    def test_stability_metrics_sorted_by_instability_desc(self, components):
+        """unstable_modules must be sorted by instability descending."""
+        dg, si = components
+        # module_high: Ce=9, Ca=1 → instability=0.9
+        dg.add_edge(DependencyEdge("caller_h/m.py", "high/m.py", "high"))
+        for i in range(9):
+            dg.add_edge(DependencyEdge("high/m.py", f"hd{i}/m.py", f"hd{i}"))
+        # module_mid: Ce=8, Ca=2 → instability=0.8
+        for i in range(2):
+            dg.add_edge(DependencyEdge(f"caller_m{i}/m.py", "mid/m.py", "mid"))
+        for i in range(8):
+            dg.add_edge(DependencyEdge("mid/m.py", f"md{i}/m.py", f"md{i}"))
+        m = ArchitectureMetrics(dg, si)
+        report = m.compute_report(".", checks=["stability_metrics"])
+        if len(report.unstable_modules) >= 2:
+            for i in range(len(report.unstable_modules) - 1):
+                assert (
+                    report.unstable_modules[i].instability
+                    >= report.unstable_modules[i + 1].instability
+                )
+
+
+class TestHotspotDetection:
+    """Tests for hotspots check - AH-016."""
+
+    def test_hotspot_high_instability_high_coupling(self, components):
+        """instability > 0.7 AND efferent_coupling >= 3 → hotspot."""
+        dg, si = components
+        # "hot": Ce=8, Ca=1 → instability=8/9≈0.889, Ce=8 >= 3
+        dg.add_edge(DependencyEdge("caller/m.py", "hot/m.py", "hot"))
+        for i in range(8):
+            dg.add_edge(DependencyEdge("hot/m.py", f"dep{i}/m.py", f"dep{i}"))
+        m = ArchitectureMetrics(dg, si)
+        report = m.compute_report(".", checks=["hotspots"])
+        hotspot_paths = [mod.path for mod in report.hotspot_modules]
+        assert "hot" in hotspot_paths
+
+    def test_low_coupling_not_hotspot(self, components):
+        """instability > 0.7 but efferent_coupling < 3 → NOT hotspot."""
+        dg, si = components
+        # "lonely": Ce=2, Ca=0 → instability=1.0, but Ce=2 < 3
+        for i in range(2):
+            dg.add_edge(DependencyEdge("lonely/m.py", f"dep{i}/m.py", f"dep{i}"))
+        m = ArchitectureMetrics(dg, si)
+        report = m.compute_report(".", checks=["hotspots"])
+        hotspot_paths = [mod.path for mod in report.hotspot_modules]
+        assert "lonely" not in hotspot_paths
+
+    def test_hotspot_modules_sorted_by_score_desc(self, components):
+        """hotspot_modules sorted by (instability × efferent_coupling) descending."""
+        dg, si = components
+        # "big": Ce=10, Ca=0 → I=1.0, score=10.0
+        for i in range(10):
+            dg.add_edge(DependencyEdge("big/m.py", f"b{i}/m.py", f"b{i}"))
+        # "small": Ce=4, Ca=1 → I=0.8, score=3.2
+        dg.add_edge(DependencyEdge("x/m.py", "small/m.py", "small"))
+        for i in range(4):
+            dg.add_edge(DependencyEdge("small/m.py", f"s{i}/m.py", f"s{i}"))
+        m = ArchitectureMetrics(dg, si)
+        report = m.compute_report(".", checks=["hotspots"])
+        if len(report.hotspot_modules) >= 2:
+            scores = [
+                mod.instability * mod.efferent_coupling
+                for mod in report.hotspot_modules
+            ]
+            assert scores == sorted(scores, reverse=True)
+
+    def test_hotspots_result_field_is_list(self, components):
+        """report.hotspot_modules is always a list, even when empty."""
+        dg, si = components
+        m = ArchitectureMetrics(dg, si)
+        report = m.compute_report(".", checks=["hotspots"])
+        assert isinstance(report.hotspot_modules, list)

--- a/tests/unit/intelligence/test_call_graph.py
+++ b/tests/unit/intelligence/test_call_graph.py
@@ -202,3 +202,21 @@ class TestCallGraphDepthTraversal:
         """depth=0 must return empty list."""
         callers = chain_builder.find_callers("b", depth=0)
         assert callers == []
+
+    def test_find_callers_depth_exceeds_chain_terminates(self, chain_builder):
+        """depth > chain length: BFS terminates early when no more callers exist."""
+        # chain is only 2 levels deep (a→b→c); depth=10 must still return just [b, a]
+        callers = chain_builder.find_callers("c", depth=10)
+        caller_names = [c.caller_function for c in callers]
+        assert "b" in caller_names
+        assert "a" in caller_names
+        assert len(callers) == 2  # no phantom extra results
+
+    def test_find_callees_depth_exceeds_chain_terminates(self, chain_builder):
+        """depth > chain length: find_callees BFS terminates early when no more callees exist."""
+        # chain is only 2 levels deep (a→b→c); depth=10 must still return just [b, c]
+        callees = chain_builder.find_callees("a", depth=10)
+        callee_names = [c.callee_name for c in callees]
+        assert "b" in callee_names
+        assert "c" in callee_names
+        assert len(callees) == 2  # no phantom extra results

--- a/tests/unit/intelligence/test_call_graph.py
+++ b/tests/unit/intelligence/test_call_graph.py
@@ -145,3 +145,60 @@ class TestCallGraphBuilderFindCallees:
         assert "foo" in callee_names
         assert "bar" in callee_names
         assert "baz" not in callee_names
+
+
+class TestCallGraphDepthTraversal:
+    """Tests for depth parameter BFS traversal - CGE-004 v3."""
+
+    @pytest.fixture
+    def chain_builder(self, builder):
+        """
+        Build call chain: a() → b() → c()
+        a.py defines a(), calls b()
+        b.py defines b(), calls c()
+        """
+        builder._call_sites["a.py"] = [
+            CallSite("a.py", "a", "b", None, 2, "b()"),
+        ]
+        builder._call_sites["b.py"] = [
+            CallSite("b.py", "b", "c", None, 2, "c()"),
+        ]
+        return builder
+
+    def test_find_callers_depth1_returns_direct_only(self, chain_builder):
+        """depth=1: find_callers('b') returns only [a]."""
+        callers = chain_builder.find_callers("b", depth=1)
+        caller_names = [c.caller_function for c in callers]
+        assert "a" in caller_names
+
+    def test_find_callers_depth1_excludes_transitive(self, chain_builder):
+        """depth=1: find_callers('c') returns [b], NOT [a]."""
+        callers = chain_builder.find_callers("c", depth=1)
+        caller_names = [c.caller_function for c in callers]
+        assert "b" in caller_names
+        assert "a" not in caller_names
+
+    def test_find_callers_depth2_returns_transitive(self, chain_builder):
+        """depth=2: find_callers('c') returns both b (direct) and a (transitive)."""
+        callers = chain_builder.find_callers("c", depth=2)
+        caller_names = [c.caller_function for c in callers]
+        assert "b" in caller_names
+        assert "a" in caller_names
+
+    def test_find_callees_depth1_returns_direct_only(self, chain_builder):
+        """depth=1: find_callees('a') returns [b], NOT [c]."""
+        callees = chain_builder.find_callees("a", depth=1)
+        callee_names = [c.callee_name for c in callees]
+        assert "b" in callee_names
+        assert "c" not in callee_names
+
+    def test_find_callers_no_duplicates(self, chain_builder):
+        """No duplicate CallSite entries in results."""
+        callers = chain_builder.find_callers("c", depth=3)
+        caller_names = [c.caller_function for c in callers]
+        assert len(caller_names) == len(set(caller_names))
+
+    def test_find_callers_depth0_returns_empty(self, chain_builder):
+        """depth=0 must return empty list."""
+        callers = chain_builder.find_callers("b", depth=0)
+        assert callers == []

--- a/tests/unit/mcp/test_tools/test_check_architecture_health_tool.py
+++ b/tests/unit/mcp/test_tools/test_check_architecture_health_tool.py
@@ -45,3 +45,56 @@ class TestCheckArchitectureHealthToolExecute:
         result = await tool.execute({"path": "src/"})
         assert "data" in result
         assert "score" in result["data"]
+
+
+class TestValidChecksContainsNewChecks:
+    """Verify VALID_CHECKS includes stability_metrics and hotspots."""
+
+    def test_stability_metrics_in_valid_checks(self, tool):
+        schema_str = str(tool.get_tool_definition())
+        assert "stability_metrics" in schema_str
+
+    def test_hotspots_in_valid_checks(self, tool):
+        schema_str = str(tool.get_tool_definition())
+        assert "hotspots" in schema_str
+
+
+class TestLayerRulesValidation:
+    """layer_rules format validation and documentation - Bug 3."""
+
+    def test_layer_rules_invalid_type_raises(self, tool):
+        """layer_rules must be a dict, not a list."""
+        with pytest.raises(ValueError, match="layer_rules"):
+            tool.validate_arguments(
+                {"path": "src/", "layer_rules": ["services", "models"]}
+            )
+
+    def test_layer_rules_invalid_inner_structure_raises(self, tool):
+        """Each layer value must have 'allowed_deps' key."""
+        with pytest.raises(ValueError, match="allowed_deps"):
+            tool.validate_arguments(
+                {"path": "src/", "layer_rules": {"services": ["models"]}}
+            )
+
+    def test_layer_rules_valid_format_accepted(self, tool):
+        """Correct format must pass validation without raising."""
+        result = tool.validate_arguments({
+            "path": "src/",
+            "layer_rules": {
+                "services": {"allowed_deps": ["models", "utils"]},
+                "models": {"allowed_deps": ["utils"]},
+            },
+        })
+        assert result is True
+
+    def test_layer_rules_schema_description_contains_example(self, tool):
+        """Tool schema must document layer_rules format with an example."""
+        defn = tool.get_tool_definition()
+        layer_rules_schema = (
+            defn.get("inputSchema", {})
+            .get("properties", {})
+            .get("layer_rules", {})
+        )
+        description = layer_rules_schema.get("description", "")
+        assert "allowed_deps" in description
+        assert "example" in description.lower() or "{" in description

--- a/tree_sitter_analyzer/intelligence/architecture_metrics.py
+++ b/tree_sitter_analyzer/intelligence/architecture_metrics.py
@@ -90,6 +90,28 @@ class ArchitectureMetrics:
                 test_file_predicate=test_file_predicate,
             )
 
+        if "stability_metrics" in checks:
+            if not report.module_metrics:
+                report.module_metrics = self._compute_coupling(scope)
+            report.unstable_modules = sorted(
+                [m for m in report.module_metrics.values() if m.instability > 0.7],
+                key=lambda m: m.instability,
+                reverse=True,
+            )
+
+        if "hotspots" in checks:
+            if not report.module_metrics:
+                report.module_metrics = self._compute_coupling(scope)
+            report.hotspot_modules = sorted(
+                [
+                    m
+                    for m in report.module_metrics.values()
+                    if m.instability > 0.7 and m.efferent_coupling >= 3
+                ],
+                key=lambda m: m.instability * m.efferent_coupling,
+                reverse=True,
+            )
+
         report.score = self._compute_score(report)
         return report
 

--- a/tree_sitter_analyzer/intelligence/call_graph.py
+++ b/tree_sitter_analyzer/intelligence/call_graph.py
@@ -188,19 +188,44 @@ class CallGraphBuilder:
         return None
 
     def find_callers(self, symbol_name: str, depth: int = 1) -> list[CallSite]:
-        """Find all call sites that call the given symbol."""
-        callers: list[CallSite] = []
-        for _file_path, sites in self._call_sites.items():
-            for site in sites:
-                if site.callee_name == symbol_name:
-                    callers.append(site)
-        return callers
+        """Find call sites that call symbol_name, up to depth levels transitively."""
+        result: list[CallSite] = []
+        visited_callers: set[str] = set()
+        current_targets: set[str] = {symbol_name}
+        for _ in range(depth):
+            next_targets: set[str] = set()
+            for sites in self._call_sites.values():
+                for site in sites:
+                    if (
+                        site.callee_name in current_targets
+                        and site.caller_function not in visited_callers
+                    ):
+                        result.append(site)
+                        if site.caller_function:
+                            visited_callers.add(site.caller_function)
+                            next_targets.add(site.caller_function)
+            current_targets = next_targets
+            if not current_targets:
+                break
+        return result
 
     def find_callees(self, function_name: str, depth: int = 1) -> list[CallSite]:
-        """Find all symbols called by the given function."""
-        callees: list[CallSite] = []
-        for _file_path, sites in self._call_sites.items():
-            for site in sites:
-                if site.caller_function == function_name:
-                    callees.append(site)
-        return callees
+        """Find call sites called by function_name, up to depth levels transitively."""
+        result: list[CallSite] = []
+        visited_callees: set[str] = set()
+        current_callers: set[str] = {function_name}
+        for _ in range(depth):
+            next_callers: set[str] = set()
+            for sites in self._call_sites.values():
+                for site in sites:
+                    if (
+                        site.caller_function in current_callers
+                        and site.callee_name not in visited_callees
+                    ):
+                        result.append(site)
+                        visited_callees.add(site.callee_name)
+                        next_callers.add(site.callee_name)
+            current_callers = next_callers
+            if not current_callers:
+                break
+        return result

--- a/tree_sitter_analyzer/intelligence/models.py
+++ b/tree_sitter_analyzer/intelligence/models.py
@@ -285,6 +285,8 @@ class ArchitectureReport:
     dead_symbols: list[str] = field(default_factory=list)
     coupling_matrix: dict[str, dict[str, int]] = field(default_factory=dict)
     test_coverage: TestCoverageReport | None = None
+    unstable_modules: list[ModuleMetrics] = field(default_factory=list)
+    hotspot_modules: list[ModuleMetrics] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -331,4 +333,22 @@ class ArchitectureReport:
             "test_coverage": self.test_coverage.to_dict()
             if self.test_coverage
             else None,
+            "unstable_modules": [
+                {
+                    "path": m.path,
+                    "instability": m.instability,
+                    "efferent_coupling": m.efferent_coupling,
+                    "afferent_coupling": m.afferent_coupling,
+                }
+                for m in self.unstable_modules
+            ],
+            "hotspot_modules": [
+                {
+                    "path": m.path,
+                    "instability": m.instability,
+                    "efferent_coupling": m.efferent_coupling,
+                    "hotspot_score": m.instability * m.efferent_coupling,
+                }
+                for m in self.hotspot_modules
+            ],
         }

--- a/tree_sitter_analyzer/mcp/tools/check_architecture_health_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/check_architecture_health_tool.py
@@ -68,7 +68,12 @@ class CheckArchitectureHealthTool(BaseMCPTool):
                     },
                     "layer_rules": {
                         "type": "object",
-                        "description": "Custom layer dependency rules",
+                        "description": (
+                            "Layer dependency rules. "
+                            'Format: {"layer_name": {"allowed_deps": ["dep_layer"]}}. '
+                            'Example: {"services": {"allowed_deps": ["models", "utils"]}, '
+                            '"models": {"allowed_deps": ["utils"]}}'
+                        ),
                     },
                     "output_format": {
                         "type": "string",
@@ -84,6 +89,19 @@ class CheckArchitectureHealthTool(BaseMCPTool):
     def validate_arguments(self, arguments: dict[str, Any]) -> bool:
         if "path" not in arguments or not arguments["path"]:
             raise ValueError("'path' is required")
+        layer_rules = arguments.get("layer_rules")
+        if layer_rules is not None:
+            if not isinstance(layer_rules, dict):
+                raise ValueError(
+                    "layer_rules must be a dict mapping layer names to their rules. "
+                    'Example: {"services": {"allowed_deps": ["models", "utils"]}}'
+                )
+            for layer_name, rules in layer_rules.items():
+                if not isinstance(rules, dict) or "allowed_deps" not in rules:
+                    raise ValueError(
+                        f"layer_rules['{layer_name}'] must have an 'allowed_deps' key. "
+                        'Example: {"allowed_deps": ["models", "utils"]}'
+                    )
         return True
 
     async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

Spec-driven TDD fix for 3 bugs in Code Intelligence Graph (would crash if requested):

- **Bug 1 & 2**: `stability_metrics` and `hotspots` were listed in `VALID_CHECKS` but not implemented → now fully implemented
- **Bug 3**: `layer_rules` parameter had no documentation or validation → now validates format and documents schema with example  
- **Bug 4**: `depth` parameter in `find_callers`/`find_callees` was accepted but ignored → now implements BFS transitive traversal

### Changes
| File | Change |
|------|--------|
| `intelligence/models.py` | Add `unstable_modules`, `hotspot_modules` to `ArchitectureReport` |
| `intelligence/architecture_metrics.py` | Implement `stability_metrics` + `hotspots` checks |
| `intelligence/call_graph.py` | Replace depth-ignoring impl with BFS traversal |
| `mcp/tools/check_architecture_health_tool.py` | Add `layer_rules` validation + schema doc |
| `openspec/.../architecture-health/spec.md` | Add AH-015, AH-016 requirements |
| `openspec/.../call-graph-extraction/spec.md` | Update CGE-004 with BFS depth scenarios |
| `tests/unit/intelligence/test_architecture_metrics.py` | +9 tests (TestStabilityMetrics, TestHotspotDetection) |
| `tests/unit/intelligence/test_call_graph.py` | +6 tests (TestCallGraphDepthTraversal) |
| `tests/unit/mcp/test_tools/test_check_architecture_health_tool.py` | +6 tests (TestValidChecksContainsNewChecks, TestLayerRulesValidation) |

## Test plan

- [x] 21 new tests: RED → GREEN confirmed
- [x] 389 existing tests pass (0 regressions)
- [ ] CI green on all platforms (Linux/Windows/macOS × Python 3.10-3.13)