### PR TITLE
fix(plugins): remove business state from _reset_caches in C# and Ruby

### DIFF
--- a/openspec/changes/fix-plugin-namespace-state/specs/csharp-reset-caches-cleanup/spec.md
+++ b/openspec/changes/fix-plugin-namespace-state/specs/csharp-reset-caches-cleanup/spec.md
@@ -1,0 +1,50 @@
+# 规格说明：C# _reset_caches 职责清理
+
+## 问题描述
+
+`CSharpElementExtractor._reset_caches()` 包含 `self.current_namespace = ""`，
+违反了"缓存清理方法只清缓存"的原则（代码异味）。
+
+### 当前行为（无功能 bug）
+
+`extract_classes()` 和 `extract_functions()` 在调用 `_reset_caches()` 后，
+**立即调用** `_extract_namespace(tree.root_node)` 来重新填充 `current_namespace`，
+因此实际输出是正确的。
+
+### 为什么仍需修复
+
+1. **误导维护者**：看到 `_reset_caches()` 包含业务状态重置，会误以为这是必要的
+2. **设计不一致**：与 Java（已修复）、C++（已修复）的正确模式不一致
+3. **脆弱性**：若将来有人添加新的 extract_* 方法，忘记调用 `_extract_namespace()`，会引入 bug
+
+### 与已修复插件的对比
+
+| 插件 | `_reset_caches` 中有 `current_*`？ | `extract_classes` 补救？ | 结果 |
+|------|-----------------------------------|-----------------------|------|
+| Java（修复后）| ❌ 没有 | N/A | ✅ 正确 |
+| C++（修复后）| ✅ 有（保留，_pre_extract_namespace 补救）| ✅ 调用 `_pre_extract_namespace` | ✅ 正确 |
+| **C#（待修复）**| ✅ 有（不必要）| ✅ 调用 `_extract_namespace`（补救） | ✅ 正确但有异味 |
+
+## 修复方案
+
+从 `_reset_caches()` 中删除 `self.current_namespace = ""`，
+方法只清性能缓存：
+
+```python
+def _reset_caches(self) -> None:
+    """清除性能缓存，不触碰业务状态。"""
+    self._node_text_cache.clear()
+    self._processed_nodes.clear()
+    self._element_cache.clear()
+    self._attribute_cache.clear()
+    # current_namespace 由各 extract_* 方法按需调用 _extract_namespace() 填充
+```
+
+## 验收标准
+
+| ID | 条件 | 期望结果 |
+|----|------|---------|
+| AC-CS-001 | 调用 `_reset_caches()` 后，`current_namespace` 之前有值 | 不被清除（去除异味） |
+| AC-CS-002 | `_reset_caches()` 源码中无 `current_namespace` | 方法不包含该赋值 |
+| AC-CS-003 | `extract_classes()` 在命名空间内的类 | `full_qualified_name` 包含命名空间（行为不变）|
+| AC-CS-004 | `_reset_caches()` 调用后 | 性能缓存被清除（不影响现有行为）|

--- a/openspec/changes/fix-plugin-namespace-state/specs/ruby-dead-code-cleanup/spec.md
+++ b/openspec/changes/fix-plugin-namespace-state/specs/ruby-dead-code-cleanup/spec.md
@@ -1,0 +1,65 @@
+# 规格说明：Ruby current_module 死代码清理
+
+## 问题描述
+
+`RubyElementExtractor` 中的 `current_module` 字段是**死代码**：
+
+```python
+# __init__ 中声明
+self.current_module: str = ""
+
+# _reset_caches 中清空
+self.current_module = ""
+```
+
+但在整个文件中，`current_module` 从未被**赋值**（除了初始化和清空），
+也从未被**读取**用于任何业务逻辑（如构建类的全限定名）。
+
+### 与其他插件的对比
+
+| 插件 | 类似字段 | 是否被使用 |
+|------|---------|---------|
+| java_plugin | `current_package` | ✅ 被读取，用于构建包名 |
+| cpp_plugin | `current_namespace` | ✅ 被读取，用于构建限定名 |
+| kotlin_plugin | `current_package` | ✅ 被读取，用于构建包名 |
+| **ruby_plugin** | `current_module` | ❌ 声明但从未使用 |
+
+### 潜在来源
+
+`current_module` 可能是为了将来实现"嵌套模块支持"而预留的占位符，
+但从未实现，留下了误导性的死代码。
+
+## 修复方案
+
+1. 从 `__init__` 中删除 `self.current_module: str = ""`
+2. 从 `_reset_caches()` 中删除 `self.current_module = ""`
+
+```python
+def __init__(self) -> None:
+    """初始化提取器。"""
+    self.source_code: str = ""
+    self.content_lines: list[str] = []
+    # current_module 已移除（从未使用的死代码）
+    self._node_text_cache: dict[tuple[int, int], str] = {}
+    ...
+
+def _reset_caches(self) -> None:
+    """清除性能缓存，不触碰业务状态。"""
+    self._node_text_cache.clear()
+    self._processed_nodes.clear()
+    self._element_cache.clear()
+    # current_module 已移除（从未使用的死代码）
+```
+
+## 验收标准
+
+| ID | 条件 | 期望结果 |
+|----|------|---------|
+| AC-RB-001 | 检查 `RubyElementExtractor` 实例属性 | 无 `current_module` 属性 |
+| AC-RB-002 | `_reset_caches()` 源码 | 不包含 `current_module` |
+| AC-RB-003 | `extract_classes()` 正常调用 | 行为与之前完全一致 |
+| AC-RB-004 | `_reset_caches()` 调用后 | 性能缓存被清除（不影响现有行为）|
+
+## 范围外（不做）
+
+- 实现 `current_module` 功能（嵌套模块支持）— 超出此次 bug 修复范围

--- a/tests/unit/languages/test_csharp_plugin.py
+++ b/tests/unit/languages/test_csharp_plugin.py
@@ -881,3 +881,45 @@ class TestCSharpIntegration:
             code = f.read()
         # Just verify it can be read without errors
         assert len(code) > 0
+
+
+# ---------------------------------------------------------------------------
+# AC-CS-001~004: _reset_caches 职责清理单元测试（纯 Mock，无需解析器）
+# ---------------------------------------------------------------------------
+
+
+class TestCSharpResetCachesCleanup:
+    """验证 _reset_caches() 只清除性能缓存，不触碰 current_namespace 业务状态。"""
+
+    def test_reset_caches_does_not_clear_current_namespace(self) -> None:
+        """AC-CS-001: _reset_caches() 不应清除 current_namespace。"""
+        extractor = CSharpElementExtractor()
+        extractor.current_namespace = "MyApp.Services"
+
+        extractor._reset_caches()
+
+        assert extractor.current_namespace == "MyApp.Services", (
+            "_reset_caches() 不应清除 current_namespace，该状态由 _extract_namespace() 管理"
+        )
+
+    def test_reset_caches_source_has_no_current_namespace_assignment(self) -> None:
+        """AC-CS-002: _reset_caches() 源码中不应包含 current_namespace 赋值。"""
+        import inspect
+
+        source = inspect.getsource(CSharpElementExtractor._reset_caches)
+        assert "current_namespace" not in source, (
+            "_reset_caches() 不应包含 'current_namespace' 赋值，应只清缓存"
+        )
+
+    def test_reset_caches_still_clears_performance_caches(self) -> None:
+        """AC-CS-004: _reset_caches() 应继续清除性能缓存。"""
+        extractor = CSharpElementExtractor()
+        extractor._node_text_cache[(0, 5)] = "hello"
+        extractor._processed_nodes.add((0, 5))
+        extractor._element_cache[((0, 0), "class")] = object()
+
+        extractor._reset_caches()
+
+        assert len(extractor._node_text_cache) == 0
+        assert len(extractor._processed_nodes) == 0
+        assert len(extractor._element_cache) == 0

--- a/tests/unit/languages/test_ruby_plugin.py
+++ b/tests/unit/languages/test_ruby_plugin.py
@@ -467,17 +467,16 @@ class TestRubyExtractorHelpers:
     """Test RubyElementExtractor helper methods."""
 
     def test_reset_caches(self):
-        """Test cache reset functionality."""
+        """_reset_caches 只清性能缓存，current_module 已作为死代码删除。"""
         extractor = RubyElementExtractor()
         extractor._node_text_cache["test"] = "value"
         extractor._processed_nodes.add(1)
-        extractor.current_module = "TestModule"
 
         extractor._reset_caches()
 
         assert len(extractor._node_text_cache) == 0
         assert len(extractor._processed_nodes) == 0
-        assert extractor.current_module == ""
+        # current_module 是死代码，已从 __init__ 删除，此处不再断言
 
     def test_determine_visibility_default(self):
         """Test default visibility determination."""
@@ -601,3 +600,45 @@ class TestRubyIntegration:
         # Superclass extraction may vary - check it's not None
         assert dog.superclass is not None
         assert cat.superclass is not None
+
+
+# ---------------------------------------------------------------------------
+# AC-RB-001~004: current_module 死代码清理单元测试（纯 Mock，无需解析器）
+# ---------------------------------------------------------------------------
+
+
+class TestRubyDeadCodeCleanup:
+    """验证 current_module 死代码已被删除：不应出现在实例属性或 _reset_caches 中。"""
+
+    def test_extractor_has_no_current_module_attribute(self) -> None:
+        """AC-RB-001: RubyElementExtractor 实例不应有 current_module 属性。"""
+        from tree_sitter_analyzer.languages.ruby_plugin import RubyElementExtractor
+
+        extractor = RubyElementExtractor()
+        assert not hasattr(extractor, "current_module"), (
+            "current_module 是死代码（从未被赋值或读取），应从 __init__ 中删除"
+        )
+
+    def test_reset_caches_source_has_no_current_module(self) -> None:
+        """AC-RB-002: _reset_caches() 源码中不应包含 current_module。"""
+        import inspect
+
+        from tree_sitter_analyzer.languages.ruby_plugin import RubyElementExtractor
+
+        source = inspect.getsource(RubyElementExtractor._reset_caches)
+        assert "current_module" not in source, (
+            "_reset_caches() 不应包含 'current_module'，该字段是死代码"
+        )
+
+    def test_reset_caches_still_clears_performance_caches(self) -> None:
+        """AC-RB-004: 删除死代码后，_reset_caches() 应继续清除性能缓存。"""
+        from tree_sitter_analyzer.languages.ruby_plugin import RubyElementExtractor
+
+        extractor = RubyElementExtractor()
+        extractor._node_text_cache[(0, 5)] = "hello"
+        extractor._processed_nodes.add((0, 5))
+
+        extractor._reset_caches()
+
+        assert len(extractor._node_text_cache) == 0
+        assert len(extractor._processed_nodes) == 0

--- a/tree_sitter_analyzer/languages/csharp_plugin.py
+++ b/tree_sitter_analyzer/languages/csharp_plugin.py
@@ -66,12 +66,15 @@ class CSharpElementExtractor(ElementExtractor):
         self._attribute_cache: dict[tuple[int, int], list[dict[str, Any]]] = {}
 
     def _reset_caches(self) -> None:
-        """Reset all internal caches for a new file analysis."""
+        """清除性能缓存，不触碰业务状态。
+
+        命名空间状态由各 extract_* 方法按需调用 _extract_namespace() 填充，
+        此处无需清除，以保持方法职责单一。
+        """
         self._node_text_cache.clear()
         self._processed_nodes.clear()
         self._element_cache.clear()
         self._attribute_cache.clear()
-        self.current_namespace = ""
 
     def _get_node_text_optimized(self, node: "tree_sitter.Node") -> str:
         """

--- a/tree_sitter_analyzer/languages/ruby_plugin.py
+++ b/tree_sitter_analyzer/languages/ruby_plugin.py
@@ -54,7 +54,7 @@ class RubyElementExtractor(ElementExtractor):
         super().__init__()
         self.source_code: str = ""
         self.content_lines: list[str] = []
-        self.current_module: str = ""
+        # current_module 已移除：从未被赋值或读取，是未实现功能的残留死代码
 
         # Performance optimization caches - use position-based keys for deterministic caching
         self._node_text_cache: dict[tuple[int, int], str] = {}
@@ -63,11 +63,10 @@ class RubyElementExtractor(ElementExtractor):
         self._file_encoding: str | None = None
 
     def _reset_caches(self) -> None:
-        """Reset all internal caches for a new file analysis."""
+        """清除性能缓存，不触碰业务状态。"""
         self._node_text_cache.clear()
         self._processed_nodes.clear()
         self._element_cache.clear()
-        self.current_module = ""
 
     def _get_node_text_optimized(self, node: "tree_sitter.Node") -> str:
         """


### PR DESCRIPTION
## 问题

| 插件 | 问题类型 | 具体表现 |
|------|---------|---------|
| **C#** | 代码异味 | `_reset_caches()` 清除 `current_namespace`，但 `extract_classes/functions` 立即调用 `_extract_namespace()` 补救，无功能 bug，但违反职责单一原则 |
| **Ruby** | 死代码 | `current_module` 声明在 `__init__`、清空在 `_reset_caches()`，但从未被赋值、从未被任何业务逻辑读取 |

## 修复内容

**`csharp_plugin.py`**：从 `_reset_caches()` 删除 `self.current_namespace = ""`，命名空间状态由各 `extract_*` 方法按需调用 `_extract_namespace()` 填充。

**`ruby_plugin.py`**：从 `__init__` 和 `_reset_caches()` 删除 `current_module`（未实现功能的残留占位符）。

## 测试（先写红色，后绿色）

- `TestCSharpResetCachesCleanup`（3 个测试）：AC-CS-001~004
- `TestRubyDeadCodeCleanup`（3 个测试）：AC-RB-001~004
- 更新原有 `test_ruby_plugin.py::test_reset_caches`（之前断言死代码行为）

## 与 PR #99 的关系

本 PR 是 PR #99（Java/C++/Kotlin/PHP 修复）的后续，完成同一架构分析中发现的所有插件问题。

## Spec

`openspec/changes/fix-plugin-namespace-state/specs/csharp-reset-caches-cleanup/`
`openspec/changes/fix-plugin-namespace-state/specs/ruby-dead-code-cleanup/`