### PR TITLE
fix(scripts): correct sys.path and cwd after relocation to scripts/

### DIFF
--- a/scripts/run_coverage.py
+++ b/scripts/run_coverage.py
@@ -19,7 +19,7 @@ def run_quick_test():
         cmd,
         capture_output=True,
         text=True,
-        cwd=os.path.dirname(os.path.abspath(__file__)),
+        cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
     )
 
     # Write output
@@ -61,7 +61,7 @@ def run_coverage():
         cmd,
         capture_output=True,
         text=True,
-        cwd=os.path.dirname(os.path.abspath(__file__)),
+        cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
     )
 
     # Write output to file

--- a/scripts/start_mcp_server.py
+++ b/scripts/start_mcp_server.py
@@ -10,8 +10,9 @@ import asyncio
 import sys
 from pathlib import Path
 
-# Add the current directory to Python path
-sys.path.insert(0, str(Path(__file__).parent))
+# 将项目根目录（scripts/ 的上级）加入 Python path，
+# 确保从任意工作目录运行 `python scripts/start_mcp_server.py` 都能找到 tree_sitter_analyzer 包
+sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from tree_sitter_analyzer.mcp.server import TreeSitterAnalyzerMCPServer
 from tree_sitter_analyzer.project_detector import detect_project_root


### PR DESCRIPTION
## 问题来源

Codex 对 PR #97 的 Code Review 发现两个 P1 问题。

## 修复内容

### 问题 1：`scripts/start_mcp_server.py:14` — ModuleNotFoundError

```python
# 修复前（指向 scripts/ 目录）
sys.path.insert(0, str(Path(__file__).parent))

# 修复后（指向项目根目录）
sys.path.insert(0, str(Path(__file__).parent.parent))
```

脚本从根目录移到 `scripts/` 后，`Path(__file__).parent` 从项目根目录变成了 `scripts/`，导致 `tree_sitter_analyzer` 包找不到。

### 问题 2：`scripts/run_coverage.py:22,64` — `tests/` 路径找不到

```python
# 修复前（cwd = scripts/ 目录）
cwd=os.path.dirname(os.path.abspath(__file__))

# 修复后（cwd = 项目根目录）
cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
```

`subprocess pytest tests/` 在 `scripts/` 下执行，但 `tests/` 目录在项目根，所以报 "file or directory not found"。

## 验证

```
scripts dir:   .../tree-sitter-analyzer/scripts
project root:  .../tree-sitter-analyzer
has tree_sitter_analyzer: True  ✅
```

## 关联

- 修复 Codex review: https://github.com/aimasteracc/tree-sitter-analyzer/pull/97#pullrequestreview-2781703759