### PR TITLE
fix(tests): update patch path for start_mcp_server after relocation to scripts/

### DIFF
--- a/tests/integration/cli/test_startup_script.py
+++ b/tests/integration/cli/test_startup_script.py
@@ -24,8 +24,8 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
 class TestStartupScriptFunctions:
     """Test startup script functionality."""
 
-    @patch("start_mcp_server.check_dependencies")
-    @patch("start_mcp_server.asyncio.run")
+    @patch("scripts.start_mcp_server.check_dependencies")
+    @patch("scripts.start_mcp_server.asyncio.run")
     def test_main_execution_with_dependencies_ok(
         self, mock_asyncio_run, mock_check_deps
     ):


### PR DESCRIPTION
## 问题

CI 报错：`ModuleNotFoundError: No module named 'start_mcp_server'`

PR #97 把 `start_mcp_server.py` 从项目根目录移到了 `scripts/`，但测试文件的 `@patch` 路径没有同步更新：

```python
# 修复前（模块已不在根目录）
@patch("start_mcp_server.check_dependencies")
@patch("start_mcp_server.asyncio.run")

# 修复后
@patch("scripts.start_mcp_server.check_dependencies")
@patch("scripts.start_mcp_server.asyncio.run")
```

## 验证

本地运行通过：
```
tests/integration/cli/test_startup_script.py::TestStartupScriptFunctions::test_main_execution_with_dependencies_ok PASSED
```

## 关联

- 修复 CI run: https://github.com/aimasteracc/tree-sitter-analyzer/actions/runs/22943918386
- 因 PR #97 脚本迁移引入