### PR TITLE
docs: refine README positioning for MCP use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Version](https://img.shields.io/badge/version-1.10.4-blue.svg)](https://github.com/aimasteracc/tree-sitter-analyzer/releases)
 [![GitHub Stars](https://img.shields.io/github/stars/aimasteracc/tree-sitter-analyzer.svg?style=social)](https://github.com/aimasteracc/tree-sitter-analyzer)
 
-> 🚀 **Enterprise-Grade Code Analysis Tool for the AI Era** - Deep AI Integration · Powerful Search · 17 Languages · Intelligent Analysis
+> 🔎 **Evidence-based code navigation for AI on large repositories** - MCP integration · Minimal context retrieval · Search without heavy preprocessing
 
 ---
 
@@ -31,6 +31,22 @@
 
 <!-- GIF placeholder - see docs/assets/demo-placeholder.md for creation instructions -->
 *Demo GIF coming soon - showcasing AI integration with SMART workflow*
+
+---
+
+## 🎯 Why Tree-sitter Analyzer
+
+Tree-sitter Analyzer is an open-source MCP and CLI toolkit for helping AI assistants read only what matters in large codebases.
+
+- **Minimal context, not whole-file stuffing**: retrieve the smallest useful code regions before sending them to AI
+- **Evidence-based analysis**: combine tree-sitter structure with `fd` and `ripgrep` to surface relevant files, symbols, and paths
+- **No heavy preprocessing required**: useful on messy repositories where full indexing can be slow, stale, or difficult to maintain
+
+### Common Use Cases
+
+- Understand what a very large file or module is doing without loading the entire file into an AI prompt
+- Trace business logic, UI handlers, or bug-related code paths across a complex repository
+- Narrow AI context for Java and other large codebases before asking for analysis or changes
 
 ---
 
@@ -63,6 +79,8 @@ uv run tree-sitter-analyzer --show-supported-languages
 ## 🤖 AI Integration
 
 Configure your AI assistant to use Tree-sitter Analyzer via MCP protocol.
+
+This works especially well when your assistant struggles with very large files, noisy repository-wide context, or legacy code that is too expensive to load all at once.
 
 ### Claude Desktop / Cursor / Roo Code
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -10,7 +10,7 @@
 [![Version](https://img.shields.io/badge/version-1.10.4-blue.svg)](https://github.com/aimasteracc/tree-sitter-analyzer/releases)
 [![GitHub Stars](https://img.shields.io/github/stars/aimasteracc/tree-sitter-analyzer.svg?style=social)](https://github.com/aimasteracc/tree-sitter-analyzer)
 
-> 🚀 **AI時代のエンタープライズグレードコード解析ツール** - 深いAI統合 · 強力な検索 · 17言語対応 · インテリジェント分析
+> 🔎 **大規模リポジトリ向けのAI用エビデンスベースコードナビゲーション** - MCP統合 · 最小コンテキスト取得 · 重い前処理なしの検索
 
 ---
 
@@ -30,6 +30,22 @@
 
 <!-- GIF プレースホルダー - 作成手順は docs/assets/demo-placeholder.md を参照 -->
 *デモGIF準備中 - SMARTワークフローとAI統合のデモンストレーション*
+
+---
+
+## 🎯 Tree-sitter Analyzer が解決すること
+
+Tree-sitter Analyzer は、大規模コードベースで AI アシスタントが本当に必要な部分だけを読めるようにする、オープンソースの MCP / CLI ツールキットです。
+
+- **ファイル丸ごと投入ではなく最小コンテキスト**: AI に渡す前に、本当に必要なコード断片だけを絞り込みます
+- **エビデンスベースの解析**: tree-sitter の構造解析と `fd` / `ripgrep` を組み合わせて、関連ファイル・シンボル・経路を見つけます
+- **重い前処理に依存しない**: フルインデックスが遅い、古くなりやすい、保守しづらいリポジトリでも使いやすい設計です
+
+### よくあるユースケース
+
+- 非常に大きなファイルやモジュールの役割を、全文を AI に渡さずに理解する
+- 複雑なリポジトリで、業務ロジックや UI ハンドラ、バグに関係するコード経路を追跡する
+- Java など巨大コードベースで、AI に解析や変更依頼を出す前にコンテキストを絞り込む
 
 ---
 
@@ -62,6 +78,8 @@ uv run tree-sitter-analyzer --show-supported-languages
 ## 🤖 AI統合
 
 MCPプロトコルでAIアシスタントにTree-sitter Analyzerを設定します。
+
+特に、非常に大きなファイル、ノイズの多いリポジトリ全体コンテキスト、あるいは一括投入コストが高いレガシーコードで効果を発揮します。
 
 ### Claude Desktop / Cursor / Roo Code
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -10,7 +10,7 @@
 [![Version](https://img.shields.io/badge/version-1.10.4-blue.svg)](https://github.com/aimasteracc/tree-sitter-analyzer/releases)
 [![GitHub Stars](https://img.shields.io/github/stars/aimasteracc/tree-sitter-analyzer.svg?style=social)](https://github.com/aimasteracc/tree-sitter-analyzer)
 
-> 🚀 **AI时代的企业级代码分析工具** - 深度AI集成 · 强大搜索 · 17种语言 · 智能分析
+> 🔎 **面向大型仓库的 AI 证据式代码导航** - MCP 集成 · 最小上下文提取 · 无需重型预处理的搜索
 
 ---
 
@@ -30,6 +30,22 @@
 
 <!-- GIF占位符 - 创建说明请参见 docs/assets/demo-placeholder.md -->
 *演示GIF即将推出 - 展示SMART工作流的AI集成*
+
+---
+
+## 🎯 Tree-sitter Analyzer 解决什么问题
+
+Tree-sitter Analyzer 是一个开源的 MCP 和 CLI 工具集，帮助 AI 助手在大型代码库中只读取真正需要的部分。
+
+- **不是整文件硬塞，而是最小上下文**: 在把代码交给 AI 之前，先缩小到最有用的代码片段
+- **基于证据的分析**: 结合 tree-sitter 的结构解析与 `fd`、`ripgrep`，定位相关文件、符号和路径
+- **不依赖重型预处理**: 对那些全库索引慢、易过期、难维护的复杂仓库更友好
+
+### 常见使用场景
+
+- 不把整个大文件都塞给 AI，也能理解某个超大文件或模块到底在做什么
+- 在复杂仓库里追踪业务逻辑、UI 处理链路或与 bug 相关的代码路径
+- 在 Java 等大型代码库中，先缩小 AI 所需上下文，再让它继续分析或修改
 
 ---
 
@@ -62,6 +78,8 @@ uv run tree-sitter-analyzer --show-supported-languages
 ## 🤖 AI集成
 
 通过MCP协议配置AI助手使用Tree-sitter Analyzer。
+
+当你的 AI 助手面对超大文件、噪音很多的全仓库上下文，或者一次性加载成本很高的遗留代码时，这种方式尤其有用。
 
 ### Claude Desktop / Cursor / Roo Code
 


### PR DESCRIPTION
## Summary
- refine the top-level positioning copy for the English, Japanese, and Chinese READMEs
- add a short why/use-cases section to better explain the MCP value proposition
- keep installation, commands, and overall README structure unchanged

## Testing
- not run (docs-only change)