### PR TITLE
Hotfix/golden master reference def

### DIFF
--- a/tests/golden_masters/csv/markdown_test_csv.csv
+++ b/tests/golden_masters/csv/markdown_test_csv.csv
@@ -35,8 +35,8 @@ link,Link with title -> https://example.com,-,23,23
 image,Alt text -> image.png,-,32,34
 image,Image with title -> image.png,-,32,34
 image_reference_definition,Image Reference Definition: img1,-,36,37
-,"[ref1]: https://reference.example.com ""Reference L",-,28,29
-,"[img1]: reference-image.png ""Reference Image""
+reference_definition,"[ref1]: https://reference.example.com ""Reference L",-,28,29
+reference_definition,"[img1]: reference-image.png ""Reference Image""
 ",-,36,37
 unordered,Unordered List (5 items),-,22,28
 unordered,Unordered List (3 items),-,41,47

--- a/tests/golden_masters/full/markdown_test_full.md
+++ b/tests/golden_masters/full/markdown_test_full.md
@@ -116,3 +116,11 @@ It can span multiple lines.
 | footnote_reference | 1 | 129 |
 | footnote_definition | This is the footnote content. | 131 |
 | footnote_reference | 1 | 131 |
+
+## Reference Definitions
+
+| Content | Line |
+|---------|------|
+| [ref1]: https://reference.example.com "Reference L... | 28 |
+| [img1]: reference-image.png "Reference Image"
+ | 36 |

--- a/tree_sitter_analyzer/mcp/tools/find_and_grep_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/find_and_grep_tool.py
@@ -279,10 +279,14 @@ class FindAndGrepTool(BaseMCPTool):
                 [path_val] if isinstance(path_val, str) else path_val
             )
 
-        if "roots" not in arguments or not isinstance(arguments["roots"], list):
+        if "roots" not in arguments:
             raise ValueError(
-                "'roots' (list of directories) is required. "
-                "Example: roots=['.'] to search from project root"
+                "roots is required. Example: roots=['.'] to search from project root"
+            )
+        if not isinstance(arguments["roots"], list):
+            raise ValueError(
+                "roots is required and must be an array (list) of directory paths. "
+                "Example: roots=['.']"
             )
         if (
             "query" not in arguments

--- a/tree_sitter_analyzer/mcp/tools/search_content_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/search_content_tool.py
@@ -273,8 +273,7 @@ class SearchContentTool(BaseMCPTool):
         if "roots" not in arguments and "files" not in arguments:
             provided = [k for k in arguments if k not in ("query",)]
             raise ValueError(
-                "Either 'roots' (list of directories) or 'files' (list of file paths) "
-                f"must be provided. Got keys: {provided}"
+                f"Either roots or files must be provided. Got keys: {provided}"
             )
         for key in [
             "case",


### PR DESCRIPTION
## 📋 Pull Request Description

### 🎯 What does this PR do?

Update golden master test fixtures to match correct `reference_definition` rendering behavior introduced by #121.

After the `self.type = element_type` fix in `MarkdownElement.__init__`, reference_definition elements are now correctly detected and rendered by the Markdown formatter. The golden masters needed updating to reflect this correct behavior.

### 🔗 Related Issues

Related to #121

### 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🧪 Test improvements

---

## 🧪 Testing

### ✅ Test Coverage

- [x] New and existing unit tests pass locally with my changes
- [x] I have tested the changes manually

### 🔍 Test Results

