### PR TITLE
Fix/windows path

### DIFF
--- a/openspec/changes/fix-java-implements-generics-and-annotation-attribution/proposal.md
+++ b/openspec/changes/fix-java-implements-generics-and-annotation-attribution/proposal.md
@@ -1,0 +1,104 @@
+# Fix Java: implements Generics Parsing + Annotation Attribution
+
+## Overview
+
+Two correctness bugs found via caffeine validation (ben-manes/caffeine, production-grade
+caching library, 660 Java files). Both bugs cause `analyze_code_structure` to return
+structurally incorrect data that misleads Claude when navigating complex Java codebases.
+
+## Validation Project
+
+**caffeine** — `BoundedLocalCache.java` (4770 lines, 34 inner classes, heavy generics)
+- Industry-standard caching library; clean, well-structured Java
+- Inner classes with generic interfaces expose both bugs clearly
+
+---
+
+## Bug 1: `implements` with Generic Type Arguments Split Incorrectly
+
+### Observed (wrong)
+
+```python
+# BoundedLocalCache implements LocalCache<K, V>
+"implements": ["LocalCache", "K", "V"]
+
+# SizeLimiter implements Function<Stream<CacheEntry<K, V>>, Map<K, V>>
+"implements": ["Function", "Stream", "CacheEntry", "K", "V", "Map", "K", "V"]
+```
+
+### Expected (correct)
+
+```python
+"implements": ["LocalCache<K, V>"]
+"implements": ["Function<Stream<CacheEntry<K, V>>, Map<K, V>>"]
+```
+
+### Root Cause
+
+The `implements_interfaces` extraction splits on `,` or whitespace without tracking
+angle-bracket nesting depth. `LocalCache<K, V>` contains a comma inside `<>`, so the
+parser incorrectly treats `K` and `V` as separate interface names.
+
+### Impact
+
+- `trace_impact` and `modification_guard` cannot correctly identify which interfaces
+  a class implements — critical for Spring `@Component` hierarchy traversal
+- Claude gets wrong structural information when navigating class hierarchies
+- Token waste: Claude has to re-read source files to verify implements relationships
+
+---
+
+## Bug 2: `@Override` (and other method annotations) Attributed to Classes
+
+### Observed (wrong)
+
+```python
+# BoundedEviction class — @Override should never appear on a class
+"classes": [{"name": "BoundedEviction", "annotations": [{"name": "Override"}]}]
+
+# BoundedExpireAfterAccess class
+"classes": [{"name": "BoundedExpireAfterAccess", "annotations": ["SuppressWarnings", "Override"]}]
+```
+
+### Expected (correct)
+
+```python
+# @Override is NEVER valid on a class in Java — only on methods/fields
+"classes": [{"name": "BoundedEviction", "annotations": []}]  # or only class-level annotations
+"classes": [{"name": "BoundedExpireAfterAccess", "annotations": ["SuppressWarnings"]}]
+```
+
+### Root Cause
+
+`_find_annotations_for_line_cached()` uses `abs(annotation.line - element.start_line) <= 2`
+to attribute annotations to elements. When a class declaration immediately follows a method
+with `@Override`, the `@Override` falls within the 2-line window of the class start and
+gets incorrectly attributed.
+
+Example (BoundedEviction starting at line N):
+```java
+    @Override  // line N-1 — this is the last method's annotation!
+    public void someMethod() { ... }
+}
+
+@SuppressWarnings("unchecked")
+class BoundedEviction ... {  // line N+1 — class starts here
+```
+
+The 2-line window `abs(N-1 - (N+1)) = 2` matches, so `@Override` is incorrectly attributed.
+
+### Impact
+
+- Completely wrong structural metadata for classes
+- Claude cannot tell which classes are annotated with meaningful markers (`@Deprecated`,
+  `@FunctionalInterface`) vs garbage method annotations (`@Override`, `@Test`)
+- `modification_guard` impact analysis is distorted by false class annotations
+
+---
+
+## Success Criteria
+
+1. `BoundedLocalCache implements LocalCache<K, V>` → `implements: ["LocalCache<K, V>"]`
+2. `@Override` never appears in class or field annotations output
+3. All 610+ existing Java tests pass
+4. 10+ new TDD tests covering both bugs with caffeine real data

--- a/openspec/changes/fix-java-implements-generics-and-annotation-attribution/tasks.md
+++ b/openspec/changes/fix-java-implements-generics-and-annotation-attribution/tasks.md
@@ -1,0 +1,86 @@
+# Tasks: Fix Java implements Generics + Annotation Attribution
+
+## Validation Project
+caffeine (ben-manes/caffeine) — BoundedLocalCache.java
+
+## TDD Order: Write FAILING tests first, then implement fixes
+
+---
+
+### Phase 1: TDD — Write Failing Tests
+
+- [ ] **T1.1** Write test: implements with generics preserved as single string
+  - Input: `class Foo implements LocalCache<K, V>`
+  - Assert: `implements == ["LocalCache<K, V>"]`  NOT `["LocalCache", "K", "V"]`
+  - Must FAIL before fix
+
+- [ ] **T1.2** Write test: nested generics in implements preserved
+  - Input: `class Bar implements Function<Stream<CacheEntry<K,V>>, Map<K,V>>`
+  - Assert: `implements == ["Function<Stream<CacheEntry<K,V>>, Map<K,V>>"]`
+  - Must FAIL before fix
+
+- [ ] **T1.3** Write test: @Override never appears in class annotations
+  - Input: caffeine BoundedLocalCache.java via MCP
+  - Assert: no class in `classes` has annotation.name == "Override"
+  - Must FAIL before fix
+
+- [ ] **T1.4** Write test: @Test, @Override, @Before never in class/field annotations
+  - These are method-only annotations — if they appear on class/field, it's a bug
+  - Must FAIL before fix
+
+### Phase 2: Implement Fixes
+
+- [ ] **T2.1** Fix implements generic parsing in `java_plugin.py`
+  - Find: `_extract_class_optimized` → `implements_interfaces` extraction
+  - Fix: parse with angle-bracket depth counter instead of naive comma-split
+  - Algorithm:
+    ```python
+    def split_respecting_generics(s: str) -> list[str]:
+        depth = 0
+        current = []
+        parts = []
+        for ch in s:
+            if ch == '<': depth += 1
+            elif ch == '>': depth -= 1
+            if ch == ',' and depth == 0:
+                parts.append(''.join(current).strip())
+                current = []
+            else:
+                current.append(ch)
+        if current:
+            parts.append(''.join(current).strip())
+        return [p for p in parts if p]
+    ```
+
+- [ ] **T2.2** Fix annotation attribution: filter method-only annotations from class/field output
+  - In `_find_annotations_for_line_cached`, or in `_extract_class_optimized`:
+    - Define `METHOD_ONLY_ANNOTATIONS = {"Override", "Test", "Before", "After", "BeforeEach", "AfterEach", "BeforeAll", "AfterAll", "ParameterizedTest", "ValueSource"}`
+    - Strip these from class and field annotation lists
+
+- [ ] **T2.3** Alternative/additional fix: tighten annotation window for classes
+  - Class declaration can have a blank line between last annotation and `class` keyword
+  - But `@Override` from a previous method body should be further away
+  - Consider reducing window for class annotations: check annotation is BEFORE (not after) class start
+  - A class annotation is always on lines `< start_line` of the class, never after
+
+### Phase 3: Validate
+
+- [ ] **T3.1** Run: `uv run pytest tests/ -k "java" -q`
+  - Target: 610+ passed, 0 failed
+
+- [ ] **T3.2** Verify caffeine BoundedLocalCache.java via MCP:
+  - `implements: ["LocalCache<K, V>"]` for BoundedLocalCache
+  - No `@Override` in any class's annotations list
+  - Inner classes have correct implements lists
+
+- [ ] **T3.3** Verify with netty (larger scale):
+  - Run analysis on netty's largest files (AbstractBootstrap, AbstractChannel)
+  - Check implements/annotations correctness
+
+## Dependencies
+- T1.* before T2.*
+- T2.1 and T2.2 independent
+- T3.* after T2.*
+
+## Status
+In progress (2026-04-09)

--- a/openspec/changes/fix-trace-impact-count-truncation/proposal.md
+++ b/openspec/changes/fix-trace-impact-count-truncation/proposal.md
@@ -1,0 +1,60 @@
+# Fix trace_impact: call_count truncated by max_results
+
+## Overview
+
+`trace_impact` returns `call_count` equal to `max_results` instead of the true
+total match count when results are truncated. This causes `impact_level` to be
+misclassified (e.g., HIGH becomes LOW), breaking `modification_guard` safety verdicts.
+
+## Validation Evidence
+
+Discovered via spring-framework validation:
+
+```python
+# @Component appears 695 times in spring-framework
+trace_impact("Component", max_results=5)
+→ call_count: 5, impact_level: "low"   # WRONG — should be 695, "high"
+
+trace_impact("Component")  # no limit
+→ call_count: 695, impact_level: "high"  # CORRECT
+```
+
+## Root Cause
+
+In `trace_impact_tool.py`, `total_count` is computed from `len(usages)` AFTER
+the results list has been truncated to `max_results`:
+
+```python
+# Line 377-378: truncate matches
+if len(matches) > max_results:
+    matches = matches[:max_results]  # truncate
+
+# Line 394: WRONG — counts truncated list
+total_count = len(usages)   # → max_results, not true total
+```
+
+## Impact
+
+- `modification_guard` uses `call_count` to compute `safety_verdict`
+- With max_results=5 (common default), any symbol with >5 callers shows "LOW IMPACT"
+- Claude gets "SAFE" verdict for symbols that are actually "UNSAFE"
+- Critical: `@Transactional`, `ApplicationContext` would appear safe to modify
+
+## Fix
+
+Capture true match count before truncation:
+```python
+true_total = len(matches)
+if true_total > max_results:
+    matches = matches[:max_results]
+    truncated = True
+...
+total_count = true_total  # pre-truncation count
+```
+
+## Success Criteria
+
+1. `trace_impact("Component", max_results=5)` → `call_count=695` (true total)
+2. `impact_level` reflects true count, not display count
+3. `truncated=True` indicates results were capped
+4. `usages` still contains only `max_results` items (display limit preserved)

--- a/openspec/changes/improve-java-annotation-extraction/proposal.md
+++ b/openspec/changes/improve-java-annotation-extraction/proposal.md
@@ -1,0 +1,70 @@
+# Improve Java Annotation Extraction
+
+## Overview
+
+Java annotation extraction in `analyze_code_structure` was silently returning empty `annotations: []` for all methods, classes, and fields. Three independent bugs compounded to produce complete annotation loss. Validated against spring-petclinic (Spring MVC/JPA reference app).
+
+## Problem Statement
+
+### Bug 1: Wrong extraction order in `extract_elements()`
+
+`extract_elements()` called `extract_functions()` and `extract_classes()` **before** `extract_annotations()`. These calls invoke `_reset_caches()`, which cleared `self.annotations`. When `_find_annotations_for_line_cached()` ran, the raw annotation list was empty.
+
+**Root cause**: `self.annotations` was populated too late in the call sequence.
+
+### Bug 2: `_reset_caches()` cleared source data
+
+`_reset_caches()` cleared `self.annotations` (the raw annotation list extracted from the AST). This is source data, not a lookup cache. The line-keyed lookup cache (`self._annotation_cache`) should be cleared on file change; the source list should not.
+
+**Root cause**: Conflation of source data and derived cache in a single reset operation.
+
+### Bug 3: `analyze_code_structure_tool.py` hardcoded `annotations: []`
+
+The MCP tool layer built output dicts with `"annotations": []` hardcoded, never reading `getattr(method/class/field, "annotations", [])` from the model objects.
+
+**Root cause**: Copy-paste from a stub that was never wired up.
+
+### Bug 4: Field annotations not traversed
+
+`field_declaration` was missing from `container_node_types` in `_traverse_and_extract_iterative()`. When the traversal reached `field_declaration`, it skipped the node and never visited its children (`modifiers` → `annotation`). Field-level annotations (`@ManyToMany`, `@JoinTable`, `@Column`, `@Id`) were never extracted.
+
+**Root cause**: Incomplete container node list; `field_declaration` is a structural node that wraps annotatable declarations.
+
+## Validation Evidence
+
+Validated against `spring-petclinic` open source project (Spring MVC + JPA reference application):
+
+**Before fix** (all annotations=[] everywhere):
+```
+OwnerController class: annotations=[]
+findOwner() method: annotations=[]
+specialties field: annotations=[]
+```
+
+**After fix**:
+```
+OwnerController class: annotations=[{'name': 'Controller', 'text': '@Controller'}]
+findOwner() method: annotations=[{'name': 'ModelAttribute', 'text': '@ModelAttribute("owner")'}]
+initCreationForm() method: annotations=[{'name': 'GetMapping', 'text': '@GetMapping("/owners/new")'}]
+specialties field: annotations=[
+  {'name': 'ManyToMany', 'text': '@ManyToMany(fetch = FetchType.EAGER)'},
+  {'name': 'JoinTable', 'text': '@JoinTable(name = "vet_specialties", ...)'}
+]
+```
+
+## Impact
+
+Annotation extraction is critical for:
+- `modification_guard`: detecting high-risk symbols (`@Transactional`, `@EventListener`)
+- `trace_impact`: understanding call context
+- Code navigation: `@GetMapping`/`@PostMapping` are the routing table for Spring apps
+- AI-assisted refactoring: knowing `@Deprecated` or `@Override` status
+
+## Success Criteria
+
+1. All class-level annotations extracted (`@Entity`, `@Controller`, `@Service`, etc.)
+2. All method-level annotations extracted (`@GetMapping`, `@Transactional`, etc.)
+3. All field-level annotations extracted (`@ManyToMany`, `@Column`, `@Id`, etc.)
+4. Annotation text includes parameters (`@Table(name = "vets")`, not just `@Table`)
+5. All 610 existing Java tests pass
+6. Golden master tests pass unchanged

--- a/openspec/changes/improve-java-annotation-extraction/tasks.md
+++ b/openspec/changes/improve-java-annotation-extraction/tasks.md
@@ -1,0 +1,90 @@
+# Tasks: Improve Java Annotation Extraction
+
+## Overview
+
+Fix four independent bugs causing complete annotation loss in `analyze_code_structure`. Validated via spring-petclinic (Spring MVC/JPA). Drive via TDD: write failing tests first, then fix.
+
+## Validation Project
+
+**spring-petclinic** (local: `/workspaces/claude-source-run-version/spring-petclinic`)
+- Standard Spring MVC + JPA application
+- Representative annotation patterns: `@Controller`, `@GetMapping`, `@Entity`, `@ManyToMany`
+- Medium scale: 47 Java files
+
+## Task List
+
+### Phase 1: TDD — Write Failing Tests (Before any fix)
+
+- [x] **T1.1**: Write test for Bug 1+2 (annotation extraction order + reset)
+  - Test: `extract_elements()` on a class with annotations → methods/classes/fields have non-empty annotations
+  - Test: call `extract_annotations()` then `extract_functions()` → annotations preserved
+  - Verify: test FAILS before fix
+
+- [x] **T1.2**: Write test for Bug 3 (tool layer hardcodes annotations=[])
+  - Test: `analyze_code_structure` MCP tool on spring-petclinic OwnerController.java
+  - Assert: `elements.classes[0].annotations` contains `@Controller`
+  - Assert: `elements.methods` with `@GetMapping` have annotation extracted
+  - Verify: test FAILS before fix
+
+- [x] **T1.3**: Write test for Bug 4 (field_declaration not in container_node_types)
+  - Test: `analyze_code_structure` on Vet.java
+  - Assert: `specialties` field has `@ManyToMany` and `@JoinTable` annotations
+  - Verify: test FAILS before fix
+
+### Phase 2: Fix Implementation
+
+- [x] **T2.1**: Fix extraction order in `extract_elements()` (`java_plugin.py`)
+  - Move `extract_annotations()` call to FIRST position
+  - Save result in local var; reuse in returned dict (avoid double call)
+
+- [x] **T2.2**: Remove `self.annotations.clear()` from `_reset_caches()` (`java_plugin.py`)
+  - Add explanatory comment: source data vs lookup cache distinction
+  - Ensure `extract_annotations()` itself still clears via `_reset_caches()` → `self.annotations = annotations`
+
+- [x] **T2.3**: Fix `analyze_code_structure_tool.py` to read annotations from model objects
+  - Replace `"annotations": []` with `"annotations": getattr(obj, "annotations", [])`
+  - Apply to classes, methods, and fields
+
+- [x] **T2.4**: Add `"field_declaration"` to `container_node_types` (`java_plugin.py`)
+  - Add with explanatory comment: field annotations live in field_declaration > modifiers
+
+### Phase 3: Validation
+
+- [x] **T3.1**: Run all Java tests (`uv run pytest tests/ -k "java"`)
+  - Target: 610 passed, 0 failed
+
+- [x] **T3.2**: Verify against spring-petclinic
+  - OwnerController: `@Controller` on class, `@GetMapping`/`@PostMapping` on methods
+  - Vet: `@ManyToMany`, `@JoinTable` on specialties field
+  - Owner: `@Entity`, `@Table` on class
+
+- [x] **T3.3**: Update `test_reset_caches` to match correct behavior
+  - Document why `self.annotations` is NOT cleared: it's source data, not cache
+
+### Phase 4: SDD Documentation
+
+- [x] **T4.1**: Write `proposal.md` (this change's problem statement + root causes)
+- [x] **T4.2**: Write `tasks.md` (this file)
+- [ ] **T4.3**: Write `design.md` (architecture of annotation extraction pipeline)
+- [ ] **T4.4**: Update CHANGELOG.md
+
+## Next Java Quality Issues (Backlog)
+
+From spring-petclinic scan — additional items to address in future specs:
+
+1. **Annotation parameters nested annotations** — `@JoinColumn` inside `@JoinTable` detected but parsed as part of parent text (not decomposed). Low priority.
+2. **`implements=[]` for classes with implicit serialization** — Not a bug (Serializable is via superclass). No action needed.
+3. **Class visibility hardcoded to `"public"`** — `analyze_code_structure_tool.py` line 282 forces `"visibility": "public"` for all classes. Package-private classes not distinguished.
+
+## Dependencies
+
+- T1.* (write tests) must complete before T2.* (fixes)
+- T2.1, T2.2, T2.3, T2.4 are independent — can implement in any order
+- T3.1 validates T2.* changes
+- T3.2 validates T3.1
+
+## Completed Status
+
+All T1, T2, T3 tasks: COMPLETE (2026-04-09)
+T4.1, T4.2: COMPLETE
+T4.3, T4.4: PENDING

--- a/tests/unit/languages/test_java_annotation_extraction.py
+++ b/tests/unit/languages/test_java_annotation_extraction.py
@@ -1,0 +1,286 @@
+"""
+TDD tests for Java annotation extraction quality.
+
+Validated against spring-petclinic open source project.
+These tests capture the bugs found and the expected correct behavior.
+
+Bug history (all fixed 2026-04-09):
+  Bug1+2: Wrong extraction order + _reset_caches() cleared source data
+  Bug3:   analyze_code_structure_tool hardcoded annotations=[]
+  Bug4:   field_declaration missing from container_node_types
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+# Spring-petclinic paths — tests skip gracefully if project not cloned
+PETCLINIC_BASE = Path("/workspaces/claude-source-run-version/spring-petclinic")
+OWNER_CONTROLLER = PETCLINIC_BASE / "src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java"
+VET = PETCLINIC_BASE / "src/main/java/org/springframework/samples/petclinic/vet/Vet.java"
+
+pytestmark = pytest.mark.skipif(
+    not PETCLINIC_BASE.exists(),
+    reason="spring-petclinic not cloned at expected path",
+)
+
+
+@pytest.fixture
+def mcp_server():
+    """MCP server pointed at spring-petclinic."""
+    from tree_sitter_analyzer.mcp.server import TreeSitterAnalyzerMCPServer
+    return TreeSitterAnalyzerMCPServer(str(PETCLINIC_BASE))
+
+
+def call(coro):
+    """Run async coroutine synchronously."""
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+# ---------------------------------------------------------------------------
+# Bug 1+2: Annotation extraction order + _reset_caches source-data clearing
+# ---------------------------------------------------------------------------
+
+class TestAnnotationExtractionOrder:
+    """extract_annotations() must run before extract_functions/extract_classes
+    and _reset_caches() must NOT clear self.annotations (source data)."""
+
+    def test_annotations_preserved_after_extract_functions(self):
+        """self.annotations must survive a call to extract_functions()."""
+        import tree_sitter
+        import tree_sitter_java as ts_java
+
+        from tree_sitter_analyzer.languages.java_plugin import JavaElementExtractor
+
+        src = """
+@Controller
+public class FooController {
+    @GetMapping("/foo")
+    public String doFoo() { return "foo"; }
+}
+"""
+        JAVA_LANG = tree_sitter.Language(ts_java.language())
+        parser = tree_sitter.Parser()
+        parser.language = JAVA_LANG
+        tree = parser.parse(src.encode())
+
+        ext = JavaElementExtractor()
+        # Step 1: populate annotations
+        annotations = ext.extract_annotations(tree, src)
+        assert len(annotations) >= 2, "Should find @Controller and @GetMapping"
+
+        # Step 2: extract_functions calls _reset_caches internally (side effect is the point)
+        ext.extract_functions(tree, src)
+
+        # Step 3: self.annotations must still be populated (Bug 2 fix)
+        assert len(ext.annotations) >= 2, (
+            "_reset_caches() must not clear self.annotations; "
+            "it is source data set by extract_annotations(), not a lookup cache"
+        )
+
+    def test_methods_carry_annotations_from_extract_elements(self):
+        """extract_elements() must return functions with non-empty annotations."""
+        import tree_sitter
+        import tree_sitter_java as ts_java
+
+        from tree_sitter_analyzer.languages.java_plugin import JavaPlugin
+
+        src = """
+@Controller
+public class FooController {
+    @GetMapping("/foo")
+    public String doFoo() { return "foo"; }
+
+    @PostMapping("/bar")
+    public String doBar() { return "bar"; }
+}
+"""
+        JAVA_LANG = tree_sitter.Language(ts_java.language())
+        parser = tree_sitter.Parser()
+        parser.language = JAVA_LANG
+        tree = parser.parse(src.encode())
+
+        plugin = JavaPlugin()
+        elements = plugin.extract_elements(tree, src)
+
+        methods_with_annotations = [
+            m for m in elements.get("functions", [])
+            if m.annotations
+        ]
+        assert len(methods_with_annotations) >= 2, (
+            "Methods with @GetMapping and @PostMapping must have annotations "
+            "extracted. Bug: extract_elements called extract_functions before "
+            "extract_annotations, leaving self.annotations empty."
+        )
+
+    def test_reset_caches_preserves_annotations(self):
+        """_reset_caches() must clear lookup caches but preserve self.annotations."""
+        from tree_sitter_analyzer.languages.java_plugin import JavaElementExtractor
+
+        ext = JavaElementExtractor()
+        ext.annotations.append({"name": "Controller", "line": 1})
+
+        ext._reset_caches()
+
+        # Lookup caches cleared
+        assert len(ext._annotation_cache) == 0
+        assert len(ext._node_text_cache) == 0
+
+        # Source data preserved (Bug 2 fix)
+        assert len(ext.annotations) == 1, (
+            "self.annotations is source data from extract_annotations(); "
+            "_reset_caches() must not clear it."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Bug 3: analyze_code_structure_tool hardcoded annotations=[]
+# ---------------------------------------------------------------------------
+
+class TestMCPToolAnnotationOutput:
+    """MCP analyze_code_structure must surface annotations from model objects."""
+
+    def test_owner_controller_class_has_controller_annotation(self, mcp_server):
+        """OwnerController class must have @Controller in output."""
+        r = call(mcp_server.call_tool("analyze_code_structure", {
+            "file_path": str(OWNER_CONTROLLER),
+        }))
+        classes = r.get("elements", {}).get("classes", [])
+        assert classes, "Should extract at least one class"
+
+        owner_ctrl = next((c for c in classes if c.get("name") == "OwnerController"), None)
+        assert owner_ctrl is not None
+
+        ann_names = [a.get("name") for a in owner_ctrl.get("annotations", [])]
+        assert "Controller" in ann_names, (
+            f"OwnerController must have @Controller annotation. Got: {ann_names}. "
+            "Bug: analyze_code_structure_tool.py hardcoded 'annotations': []"
+        )
+
+    def test_owner_controller_methods_have_mapping_annotations(self, mcp_server):
+        """Methods with @GetMapping/@PostMapping must have those annotations in output."""
+        r = call(mcp_server.call_tool("analyze_code_structure", {
+            "file_path": str(OWNER_CONTROLLER),
+        }))
+        methods = r.get("elements", {}).get("methods", [])
+
+        annotated_methods = {
+            m.get("name"): [a.get("name") for a in m.get("annotations", [])]
+            for m in methods
+            if m.get("annotations")
+        }
+
+        # initCreationForm has @GetMapping("/owners/new")
+        assert "initCreationForm" in annotated_methods, (
+            "initCreationForm() must have @GetMapping annotation"
+        )
+        assert "GetMapping" in annotated_methods.get("initCreationForm", [])
+
+        # processCreationForm has @PostMapping("/owners/new")
+        assert "processCreationForm" in annotated_methods, (
+            "processCreationForm() must have @PostMapping annotation"
+        )
+        assert "PostMapping" in annotated_methods.get("processCreationForm", [])
+
+    def test_model_attribute_method_has_annotation(self, mcp_server):
+        """findOwner() with @ModelAttribute must have that annotation."""
+        r = call(mcp_server.call_tool("analyze_code_structure", {
+            "file_path": str(OWNER_CONTROLLER),
+        }))
+        methods = r.get("elements", {}).get("methods", [])
+        find_owner = next((m for m in methods if m.get("name") == "findOwner"), None)
+        assert find_owner is not None
+
+        ann_names = [a.get("name") for a in find_owner.get("annotations", [])]
+        assert "ModelAttribute" in ann_names, (
+            f"findOwner() must have @ModelAttribute. Got: {ann_names}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Bug 4: field_declaration missing from container_node_types
+# ---------------------------------------------------------------------------
+
+class TestFieldAnnotationExtraction:
+    """Field-level annotations must be extracted (field_declaration in containers)."""
+
+    def test_vet_specialties_has_manytomany_annotation(self, mcp_server):
+        """Vet.specialties field must have @ManyToMany annotation."""
+        r = call(mcp_server.call_tool("analyze_code_structure", {
+            "file_path": str(VET),
+        }))
+        fields = r.get("elements", {}).get("fields", [])
+        specialties = next((f for f in fields if f.get("name") == "specialties"), None)
+        assert specialties is not None, "Should find specialties field"
+
+        ann_names = [a.get("name") for a in specialties.get("annotations", [])]
+        assert "ManyToMany" in ann_names, (
+            f"specialties field must have @ManyToMany. Got: {ann_names}. "
+            "Bug: field_declaration was missing from container_node_types, "
+            "so the traversal never descended into field modifier nodes."
+        )
+
+    def test_vet_specialties_has_jointable_annotation(self, mcp_server):
+        """Vet.specialties field must have @JoinTable annotation."""
+        r = call(mcp_server.call_tool("analyze_code_structure", {
+            "file_path": str(VET),
+        }))
+        fields = r.get("elements", {}).get("fields", [])
+        specialties = next((f for f in fields if f.get("name") == "specialties"), None)
+        assert specialties is not None
+
+        ann_names = [a.get("name") for a in specialties.get("annotations", [])]
+        assert "JoinTable" in ann_names, (
+            f"specialties field must have @JoinTable. Got: {ann_names}"
+        )
+
+    def test_annotation_text_includes_parameters(self, mcp_server):
+        """Annotation text must include parameters, not just name."""
+        r = call(mcp_server.call_tool("analyze_code_structure", {
+            "file_path": str(VET),
+        }))
+        fields = r.get("elements", {}).get("fields", [])
+        specialties = next((f for f in fields if f.get("name") == "specialties"), None)
+        assert specialties is not None
+
+        many_to_many = next(
+            (a for a in specialties.get("annotations", []) if a.get("name") == "ManyToMany"),
+            None,
+        )
+        assert many_to_many is not None
+        assert "EAGER" in many_to_many.get("text", ""), (
+            "Annotation text must include parameters: "
+            f"@ManyToMany(fetch = FetchType.EAGER). Got: {many_to_many}"
+        )
+
+    def test_field_annotation_extraction_pure_unit(self):
+        """Unit test: field annotations extracted without MCP server."""
+        import tree_sitter
+        import tree_sitter_java as ts_java
+
+        from tree_sitter_analyzer.languages.java_plugin import JavaElementExtractor
+
+        src = """
+public class Entity {
+    @Column(name = "user_id", nullable = false)
+    @NotNull
+    private Long userId;
+}
+"""
+        JAVA_LANG = tree_sitter.Language(ts_java.language())
+        parser = tree_sitter.Parser()
+        parser.language = JAVA_LANG
+        tree = parser.parse(src.encode())
+
+        ext = JavaElementExtractor()
+        ext.extract_annotations(tree, src)
+        fields = ext.extract_variables(tree, src)
+
+        user_id_field = next((f for f in fields if f.name == "userId"), None)
+        assert user_id_field is not None
+
+        ann_names = [a.get("name") for a in user_id_field.annotations]
+        assert "Column" in ann_names, f"Should extract @Column. Got: {ann_names}"
+        assert "NotNull" in ann_names, f"Should extract @NotNull. Got: {ann_names}"

--- a/tests/unit/languages/test_java_caffeine_validation.py
+++ b/tests/unit/languages/test_java_caffeine_validation.py
@@ -1,0 +1,264 @@
+"""
+TDD tests for Java extraction quality — validated against caffeine open source project.
+(ben-manes/caffeine, production-grade caching library)
+
+Bugs targeted:
+  Bug 1: implements with generic type arguments split incorrectly
+  Bug 2: @Override and other method-only annotations attributed to classes
+
+Both tests must FAIL before the fix, then PASS after.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+CAFFEINE_BASE = Path("/workspaces/claude-source-run-version/caffeine/caffeine/src/main/java")
+BOUNDED_LOCAL_CACHE = CAFFEINE_BASE / "com/github/benmanes/caffeine/cache/BoundedLocalCache.java"
+REFERENCES = CAFFEINE_BASE / "com/github/benmanes/caffeine/cache/References.java"
+
+pytestmark = pytest.mark.skipif(
+    not CAFFEINE_BASE.exists(),
+    reason="caffeine not cloned at expected path",
+)
+
+
+@pytest.fixture(scope="module")
+def mcp_server():
+    from tree_sitter_analyzer.mcp.server import TreeSitterAnalyzerMCPServer
+    return TreeSitterAnalyzerMCPServer(str(CAFFEINE_BASE))
+
+
+def call(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+# ─── Bug 1: implements generics ───────────────────────────────────────────────
+
+class TestImplementsGenerics:
+    """implements with generic type parameters must be preserved as complete strings."""
+
+    def test_implements_generic_preserved_unit(self):
+        """Unit test: LocalCache<K, V> must stay as one item, not split into three."""
+        import tree_sitter
+        import tree_sitter_java as ts_java
+
+        from tree_sitter_analyzer.languages.java_plugin import JavaElementExtractor
+
+        src = """\
+package test;
+abstract class BoundedLocalCache<K, V> implements LocalCache<K, V> {
+    public void put(K key, V value) {}
+}
+"""
+        lang = tree_sitter.Language(ts_java.language())
+        parser = tree_sitter.Parser()
+        parser.language = lang
+        tree = parser.parse(src.encode())
+
+        ext = JavaElementExtractor()
+        ext.extract_annotations(tree, src)
+        classes = ext.extract_classes(tree, src)
+
+        assert classes, "Should extract BoundedLocalCache"
+        cls = classes[0]
+        implements = cls.implements_interfaces
+
+        assert len(implements) == 1, (
+            f"LocalCache<K, V> should be ONE item in implements, got {implements}. "
+            "Bug: re.findall(r'\\b[A-Z]\\w*') splits generic args as separate interfaces."
+        )
+        assert implements[0] == "LocalCache<K, V>", (
+            f"Expected 'LocalCache<K, V>', got {implements[0]!r}"
+        )
+
+    def test_implements_multiple_generic_interfaces(self):
+        """Multiple generic interfaces must each be preserved as a complete string."""
+        import tree_sitter
+        import tree_sitter_java as ts_java
+
+        from tree_sitter_analyzer.languages.java_plugin import JavaElementExtractor
+
+        src = """\
+package test;
+class Foo<K, V> implements Runnable, Comparable<Foo<K, V>>, Serializable {
+    public void run() {}
+    public int compareTo(Foo<K, V> other) { return 0; }
+}
+"""
+        lang = tree_sitter.Language(ts_java.language())
+        parser = tree_sitter.Parser()
+        parser.language = lang
+        tree = parser.parse(src.encode())
+
+        ext = JavaElementExtractor()
+        ext.extract_annotations(tree, src)
+        classes = ext.extract_classes(tree, src)
+
+        assert classes
+        implements = classes[0].implements_interfaces
+
+        # Should be exactly 3 interfaces
+        assert len(implements) == 3, (
+            f"Expected 3 interfaces (Runnable, Comparable<Foo<K,V>>, Serializable), "
+            f"got {len(implements)}: {implements}"
+        )
+        assert "Runnable" in implements
+        assert any("Comparable" in i for i in implements), f"Missing Comparable in {implements}"
+        assert "Serializable" in implements
+
+    def test_caffeine_bounded_local_cache_implements(self, mcp_server):
+        """BoundedLocalCache must show 'LocalCache<K, V>' not split into 3 items."""
+        r = call(mcp_server.call_tool("analyze_code_structure", {
+            "file_path": str(BOUNDED_LOCAL_CACHE),
+        }))
+        classes = r.get("elements", {}).get("classes", [])
+        blc = next((c for c in classes if c.get("name") == "BoundedLocalCache"), None)
+        assert blc is not None, "Should find BoundedLocalCache class"
+
+        implements = blc.get("implements", [])
+        # K and V should NOT appear as standalone interface names
+        assert "K" not in implements, (
+            f"'K' should not be a standalone interface name. implements={implements}"
+        )
+        assert "V" not in implements, (
+            f"'V' should not be a standalone interface name. implements={implements}"
+        )
+        # LocalCache<K, V> should appear as one item
+        local_cache = [i for i in implements if "LocalCache" in i]
+        assert local_cache, f"LocalCache should appear in implements. Got: {implements}"
+        assert "<" in local_cache[0], (
+            f"LocalCache should preserve generic args, got {local_cache[0]!r}"
+        )
+
+
+# ─── Bug 2: @Override on classes ──────────────────────────────────────────────
+
+class TestAnnotationAttribution:
+    """@Override and other method-only annotations must never appear on classes."""
+
+    METHOD_ONLY_ANNOTATIONS = {
+        "Override", "Test", "Before", "After",
+        "BeforeEach", "AfterEach", "BeforeAll", "AfterAll",
+        "ParameterizedTest",
+    }
+
+    def test_override_never_on_class_unit(self):
+        """@Override on a method must not bleed into the next class's annotations."""
+        import tree_sitter
+        import tree_sitter_java as ts_java
+
+        from tree_sitter_analyzer.languages.java_plugin import JavaElementExtractor
+
+        src = """\
+package test;
+class Outer {
+    static class Inner1 {
+        @Override
+        public String toString() { return "inner1"; }
+    }
+
+    // Next class — @Override from toString() above must NOT bleed here
+    @SuppressWarnings("unchecked")
+    static class Inner2 implements Runnable {
+        public void run() {}
+    }
+}
+"""
+        lang = tree_sitter.Language(ts_java.language())
+        parser = tree_sitter.Parser()
+        parser.language = lang
+        tree = parser.parse(src.encode())
+
+        ext = JavaElementExtractor()
+        ext.extract_annotations(tree, src)
+        classes = ext.extract_classes(tree, src)
+
+        inner2 = next((c for c in classes if c.name == "Inner2"), None)
+        assert inner2 is not None, "Should find Inner2"
+
+        ann_names = {a.get("name") if isinstance(a, dict) else str(a)
+                     for a in inner2.annotations}
+        assert "Override" not in ann_names, (
+            f"@Override from Inner1.toString() must not bleed into Inner2. "
+            f"Inner2 annotations: {ann_names}"
+        )
+        assert "SuppressWarnings" in ann_names, (
+            f"Inner2 should have @SuppressWarnings. Got: {ann_names}"
+        )
+
+    def test_caffeine_no_override_on_any_class(self, mcp_server):
+        """No class in BoundedLocalCache should have @Override in its annotations."""
+        r = call(mcp_server.call_tool("analyze_code_structure", {
+            "file_path": str(BOUNDED_LOCAL_CACHE),
+        }))
+        classes = r.get("elements", {}).get("classes", [])
+
+        offenders = [
+            (c.get("name"), ann.get("name"))
+            for c in classes
+            for ann in c.get("annotations", [])
+            if ann.get("name") in self.METHOD_ONLY_ANNOTATIONS
+        ]
+        assert not offenders, (
+            f"Method-only annotations found on classes (annotation bleeding): {offenders}. "
+            "Example: BoundedEviction shows @Override because the previous inner class's "
+            "last method has @Override within 2 lines of BoundedEviction's class start."
+        )
+
+    def test_references_inner_classes_clean_annotations(self, mcp_server):
+        """Inner classes in References.java should have no spurious annotations."""
+        r = call(mcp_server.call_tool("analyze_code_structure", {
+            "file_path": str(REFERENCES),
+        }))
+        classes = r.get("elements", {}).get("classes", [])
+
+        offenders = [
+            (c.get("name"), ann.get("name"))
+            for c in classes
+            for ann in c.get("annotations", [])
+            if ann.get("name") in self.METHOD_ONLY_ANNOTATIONS
+        ]
+        assert not offenders, (
+            f"Method-only annotations on classes in References.java: {offenders}"
+        )
+
+    def test_annotation_attribution_direct_ast(self):
+        """Class annotations should come from AST modifiers, not line proximity."""
+        import tree_sitter
+        import tree_sitter_java as ts_java
+
+        from tree_sitter_analyzer.languages.java_plugin import JavaElementExtractor
+
+        # Tight layout: @Override immediately before class declaration
+        src = """\
+package test;
+class A {
+    @Override
+    public String toString() { return "a"; }
+}
+@SuppressWarnings("all")
+class B {}
+"""
+        lang = tree_sitter.Language(ts_java.language())
+        parser = tree_sitter.Parser()
+        parser.language = lang
+        tree = parser.parse(src.encode())
+
+        ext = JavaElementExtractor()
+        ext.extract_annotations(tree, src)
+        classes = ext.extract_classes(tree, src)
+
+        b_class = next((c for c in classes if c.name == "B"), None)
+        assert b_class is not None
+
+        ann_names = {a.get("name") if isinstance(a, dict) else str(a)
+                     for a in b_class.annotations}
+        assert "Override" not in ann_names, (
+            f"@Override from A.toString() must not bleed into class B. Got: {ann_names}"
+        )
+        assert "SuppressWarnings" in ann_names, (
+            f"@SuppressWarnings should be on class B. Got: {ann_names}"
+        )

--- a/tests/unit/languages/test_java_plugin_comprehensive.py
+++ b/tests/unit/languages/test_java_plugin_comprehensive.py
@@ -361,7 +361,15 @@ class UserConfig {
         assert isinstance(extractor.annotations, list)
 
     def test_reset_caches(self, extractor):
-        """Test cache reset functionality"""
+        """Test cache reset functionality.
+
+        _reset_caches() clears lookup/performance caches but intentionally
+        preserves self.annotations (source data populated by extract_annotations()).
+        Clearing annotations in _reset_caches() was a bug: extract_functions() and
+        extract_classes() each call _reset_caches() at their start, which would
+        erase annotations populated by a prior extract_annotations() call, causing
+        every method/class element to report annotations=[].
+        """
         # Populate caches
         extractor._node_text_cache[1] = "test"
         extractor._processed_nodes.add(1)
@@ -373,13 +381,15 @@ class UserConfig {
         # Reset caches
         extractor._reset_caches()
 
-        # Verify caches are empty
+        # Verify lookup caches are cleared
         assert len(extractor._node_text_cache) == 0
         assert len(extractor._processed_nodes) == 0
         assert len(extractor._element_cache) == 0
         assert len(extractor._annotation_cache) == 0
         assert len(extractor._signature_cache) == 0
-        assert len(extractor.annotations) == 0
+        # self.annotations is intentionally preserved — it is source data, not a cache.
+        # extract_annotations() clears it when called; _reset_caches() must not.
+        assert len(extractor.annotations) == 1
 
     def test_extract_functions_basic(self, extractor, mock_tree, sample_java_code):
         """Test basic method extraction"""

--- a/tests/unit/languages/test_java_plugin_comprehensive.py
+++ b/tests/unit/languages/test_java_plugin_comprehensive.py
@@ -697,8 +697,13 @@ class UserConfig {
 
                     with patch.object(
                         extractor, "_find_annotations_for_line_cached"
-                    ) as mock_annotations:
+                    ) as mock_annotations, patch.object(
+                        extractor, "_extract_annotations_from_modifiers"
+                    ) as mock_ast_annotations:
                         mock_annotations.return_value = [{"name": "Service"}]
+                        # Class annotations now come from AST-direct extraction;
+                        # mock it to return the same value for this unit test.
+                        mock_ast_annotations.return_value = [{"name": "Service"}]
 
                         with patch.object(
                             extractor, "_is_nested_class"

--- a/tests/unit/mcp/test_trace_impact_count_fix.py
+++ b/tests/unit/mcp/test_trace_impact_count_fix.py
@@ -1,0 +1,107 @@
+"""
+TDD tests for trace_impact call_count truncation bug.
+
+Validated against spring-framework (@Component appears 695 times).
+
+Bug: call_count was computed from len(usages) AFTER truncation by max_results,
+causing impact_level to be classified as "low" when the true count is "high".
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+SPRING_BASE = Path("/workspaces/claude-source-run-version/spring-framework")
+
+pytestmark = pytest.mark.skipif(
+    not SPRING_BASE.exists(),
+    reason="spring-framework not cloned at expected path",
+)
+
+
+@pytest.fixture
+def tool():
+    from tree_sitter_analyzer.mcp.tools.trace_impact_tool import TraceImpactTool
+    return TraceImpactTool(str(SPRING_BASE))
+
+
+class TestTraceImpactCountAccuracy:
+    """call_count must reflect true match total, not the display-capped count."""
+
+    def test_call_count_not_capped_by_max_results(self, tool):
+        """With max_results=5 and 695 real matches, call_count must be 695."""
+        import asyncio
+        r = asyncio.get_event_loop().run_until_complete(
+            tool.execute({"symbol": "Component", "max_results": 5})
+        )
+        call_count = r.get("call_count", 0)
+        usages = r.get("usages", [])
+
+        # Display is capped at max_results
+        assert len(usages) == 5, f"usages should be capped at 5, got {len(usages)}"
+
+        # Count must be the true total
+        assert call_count > 5, (
+            f"call_count={call_count} but @Component appears 695+ times in spring-framework. "
+            "Bug: call_count was computed from len(usages) AFTER truncation."
+        )
+        assert call_count > 100, (
+            f"@Component is a core Spring stereotype, should appear hundreds of times. "
+            f"Got call_count={call_count}"
+        )
+
+    def test_impact_level_reflects_true_count(self, tool):
+        """impact_level must use true total, not capped count."""
+        import asyncio
+        r = asyncio.get_event_loop().run_until_complete(
+            tool.execute({"symbol": "Component", "max_results": 5})
+        )
+        impact_level = r.get("impact_level")
+        assert impact_level == "high", (
+            f"@Component has 695+ usages → impact must be 'high'. "
+            f"Got: '{impact_level}'. Bug: impact_level computed from truncated list."
+        )
+
+    def test_truncated_flag_set_when_results_capped(self, tool):
+        """truncated=True must be returned when results exceed max_results."""
+        import asyncio
+        r = asyncio.get_event_loop().run_until_complete(
+            tool.execute({"symbol": "Component", "max_results": 5})
+        )
+        assert r.get("truncated") is True, (
+            "truncated must be True when results are capped by max_results"
+        )
+
+    def test_unit_count_not_capped_by_mock(self):
+        """Unit test without external dependency."""
+        import asyncio
+
+        from tree_sitter_analyzer.mcp.tools.trace_impact_tool import TraceImpactTool
+
+        # Build 100 fake matches
+        fake_stdout = b"\n".join(
+            f'{{"type":"match","data":{{"path":{{"text":"file{i}.java"}},'
+            f'"line_number":{i},"lines":{{"text":"Component usage {i}"}}}}}}'.encode()
+            for i in range(100)
+        )
+
+        with patch(
+            "tree_sitter_analyzer.mcp.tools.trace_impact_tool.run_command_capture",
+            new=AsyncMock(return_value=(0, fake_stdout, b"")),
+        ):
+            tool = TraceImpactTool("/tmp")
+            r = asyncio.get_event_loop().run_until_complete(
+                tool.execute({"symbol": "Component", "max_results": 5})
+            )
+
+        assert r.get("call_count") == 100, (
+            f"call_count should be 100 (true total), got {r.get('call_count')}. "
+            "max_results=5 should only cap the display list."
+        )
+        assert len(r.get("usages", [])) == 5, "usages must be capped at max_results"
+        assert r.get("impact_level") == "high", (
+            "100 matches → HIGH IMPACT. Should not be affected by max_results=5."
+        )
+        assert r.get("truncated") is True

--- a/tree_sitter_analyzer/languages/java_plugin.py
+++ b/tree_sitter_analyzer/languages/java_plugin.py
@@ -585,10 +585,15 @@ class JavaElementExtractor(ElementExtractor):
                         extends_class = match.group(0)
                 elif child.type == "super_interfaces":
                     implements_text = self._get_node_text_optimized(child)
-                    implements_interfaces = re.findall(r"\b[A-Z]\w*", implements_text)
+                    # Use angle-bracket-aware splitting to preserve generic type args:
+                    # LocalCache<K, V>  →  ["LocalCache<K, V>"]  (not ["LocalCache","K","V"])
+                    implements_interfaces = self._split_type_list(implements_text)
 
-            # Extract annotations for this class
-            class_annotations = self._find_annotations_for_line_cached(start_line)
+            # Extract annotations directly from the AST node's modifiers child.
+            # AST-direct extraction is precise: it reads only annotations that are
+            # syntactically part of THIS class declaration, preventing @Override from
+            # a preceding method from bleeding into the next class's annotation list.
+            class_annotations = self._extract_annotations_from_modifiers(node)
 
             # Check if this is a nested class
             is_nested = self._is_nested_class(node)
@@ -1015,6 +1020,69 @@ class JavaElementExtractor(ElementExtractor):
             return "protected"
         else:
             return "package"
+
+    def _split_type_list(self, text: str) -> list[str]:
+        """Split a comma-separated type list while respecting angle-bracket nesting.
+
+        'implements LocalCache<K, V>, Serializable'
+        → ['LocalCache<K, V>', 'Serializable']
+
+        Naive re.findall(r'\\b[A-Z]\\w*') would produce
+        ['LocalCache', 'K', 'V', 'Serializable'] — WRONG.
+        """
+        # Strip leading keywords: "implements ", "extends ", angle bracket prefix etc.
+        cleaned = re.sub(r"^\s*(implements|extends|permits)\s*", "", text).strip()
+        # Also strip outer type noise that tree-sitter wraps (e.g. "type_list {")
+        cleaned = re.sub(r"[{}]", "", cleaned).strip()
+
+        depth = 0
+        current: list[str] = []
+        parts: list[str] = []
+        for ch in cleaned:
+            if ch == "<":
+                depth += 1
+            elif ch == ">":
+                depth -= 1
+            if ch == "," and depth == 0:
+                part = "".join(current).strip()
+                if part:
+                    parts.append(part)
+                current = []
+            else:
+                current.append(ch)
+        if current:
+            part = "".join(current).strip()
+            if part:
+                parts.append(part)
+
+        # Filter to items that look like type names (start with uppercase or are generic)
+        result: list[str] = []
+        for p in parts:
+            # Strip annotation prefixes like "@NonNull " from type names
+            p = re.sub(r"@\w+\s*", "", p).strip()
+            if p and (p[0].isupper() or p[0] == "_"):
+                result.append(p)
+        return result
+
+    def _extract_annotations_from_modifiers(
+        self, node: "tree_sitter.Node"
+    ) -> list[dict[str, Any]]:
+        """Extract annotations directly from a class/method/field AST node's modifiers.
+
+        This avoids the line-proximity heuristic in _find_annotations_for_line_cached(),
+        which incorrectly attributes @Override from a preceding method to the following
+        class declaration when they appear within 2 lines of each other.
+        """
+        annotations: list[dict[str, Any]] = []
+        for child in node.children:
+            if child.type == "modifiers":
+                for mod in child.children:
+                    if mod.type in ("annotation", "marker_annotation"):
+                        ann = self._extract_annotation_optimized(mod)
+                        if ann:
+                            annotations.append(ann)
+                break  # only one modifiers block per node
+        return annotations
 
     def _find_annotations_for_line_cached(self, line: int) -> list[dict[str, Any]]:
         """Find annotations for a specific line with caching"""

--- a/tree_sitter_analyzer/languages/java_plugin.py
+++ b/tree_sitter_analyzer/languages/java_plugin.py
@@ -303,13 +303,20 @@ class JavaElementExtractor(ElementExtractor):
         return packages
 
     def _reset_caches(self) -> None:
-        """Reset performance caches"""
+        """Reset performance caches.
+
+        NOTE: self.annotations (raw annotation list) is intentionally NOT cleared here.
+        It is source data populated by extract_annotations() and consumed by
+        _find_annotations_for_line_cached(). Only the line-keyed lookup cache
+        (self._annotation_cache) is cleared so it gets rebuilt on the next lookup.
+        Clearing self.annotations here would lose annotations when extract_functions()
+        or extract_classes() call _reset_caches() after extract_annotations() has run.
+        """
         self._node_text_cache.clear()
         self._processed_nodes.clear()
         self._element_cache.clear()
         self._annotation_cache.clear()
         self._signature_cache.clear()
-        self.annotations.clear()
         self.current_package = (
             ""  # Reset package state to avoid cross-test contamination
         )
@@ -1399,13 +1406,18 @@ class JavaPlugin(LanguagePlugin):
             extractor = self.create_extractor()
             # Cast to JavaElementExtractor for type checking
             java_extractor = extractor if isinstance(extractor, JavaElementExtractor) else JavaElementExtractor()
+            # MUST extract annotations first — _find_annotations_for_line_cached() reads
+            # self.annotations, which is only populated after extract_annotations() runs.
+            # Calling extract_functions/extract_classes before this leaves annotations=[]
+            # on every method and class element.
+            annotations = java_extractor.extract_annotations(tree, source_code)
             return {
                 "functions": java_extractor.extract_functions(tree, source_code),
                 "classes": java_extractor.extract_classes(tree, source_code),
                 "variables": java_extractor.extract_variables(tree, source_code),
                 "imports": java_extractor.extract_imports(tree, source_code),
                 "packages": java_extractor.extract_packages(tree, source_code),
-                "annotations": java_extractor.extract_annotations(tree, source_code),
+                "annotations": annotations,
                 "boolean_literals": java_extractor.extract_boolean_literals(tree, source_code),
                 "block_comments": java_extractor.extract_block_comments(tree, source_code),
             }

--- a/tree_sitter_analyzer/languages/java_plugin.py
+++ b/tree_sitter_analyzer/languages/java_plugin.py
@@ -356,6 +356,7 @@ class JavaElementExtractor(ElementExtractor):
             "compact_constructor_declaration",
             "block",
             "modifiers",  # Annotation nodes can appear inside modifiers
+            "field_declaration",  # Field annotations live in field_declaration > modifiers
             # Additional containers for literals and expressions
             "return_statement",
             "argument_list",

--- a/tree_sitter_analyzer/mcp/tools/analyze_code_structure_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/analyze_code_structure_tool.py
@@ -282,7 +282,7 @@ class AnalyzeCodeStructureTool(BaseMCPTool):
                     "visibility": "public",  # Force all classes to public
                     "extends": getattr(cls, "extends_class", None),
                     "implements": getattr(cls, "implements_interfaces", []),
-                    "annotations": [],
+                    "annotations": getattr(cls, "annotations", []),
                 }
                 for cls in classes
             ],
@@ -300,7 +300,7 @@ class AnalyzeCodeStructureTool(BaseMCPTool):
                     "is_constructor": getattr(method, "is_constructor", False),
                     "complexity_score": getattr(method, "complexity_score", 0),
                     "modifiers": self._get_method_modifiers(method),
-                    "annotations": [],
+                    "annotations": getattr(method, "annotations", []),
                 }
                 for method in methods
             ],
@@ -314,7 +314,7 @@ class AnalyzeCodeStructureTool(BaseMCPTool):
                     },
                     "visibility": getattr(field, "visibility", "private"),
                     "modifiers": self._get_field_modifiers(field),
-                    "annotations": [],
+                    "annotations": getattr(field, "annotations", []),
                 }
                 for field in fields
             ],

--- a/tree_sitter_analyzer/mcp/tools/trace_impact_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/trace_impact_tool.py
@@ -373,8 +373,14 @@ class TraceImpactTool(BaseMCPTool):
         # 解析 JSON 输出
         matches = parse_rg_json_lines_to_matches(stdout)
 
-        # 限制结果数量
-        if len(matches) > max_results:
+        # Capture true total BEFORE truncating for display.
+        # impact_level and call_count must reflect the actual number of callers,
+        # not the display-capped count. If max_results=5 and there are 695 matches,
+        # call_count must be 695 and impact_level must be "high", not "low".
+        true_total = len(matches)
+
+        # 限制结果数量（只影响显示，不影响 call_count）
+        if true_total > max_results:
             matches = matches[:max_results]
             truncated = True
         else:
@@ -390,8 +396,8 @@ class TraceImpactTool(BaseMCPTool):
             }
             usages.append(usage)
 
-        # 计算影响等级
-        total_count = len(usages)
+        # 计算影响等级（使用真实总数，而非截断后的显示数）
+        total_count = true_total
         impact = _get_impact_level(total_count)
 
         # 构建响应


### PR DESCRIPTION
## 📋 Pull Request Description

### 🎯 What does this PR do?

通过三个开源项目（spring-petclinic、caffeine、spring-framework）验证 Java 语言支持质量，发现并修复了 6 个独立 bug。

**核心问题**：修复前，`analyze_code_structure` 对所有 Java 文件的 `annotations` 字段均返回空列表 `[]`，Spring 代码库的核心语义（`@Controller`、`@Autowired`、`@Transactional`、`@ManyToMany`）全部丢失。

修复后 spring-petclinic 验证：
```python
# Before
OwnerController: annotations=[]
Vet.specialties field: annotations=[]

# After
OwnerController: annotations=[{@Controller}]
Vet.specialties field: annotations=[{@ManyToMany(fetch=EAGER)}, {@JoinTable(...)}]
```

### 🔗 Related Issues

N/A

### 🔄 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🧪 Test improvements

---

## 🧪 Testing

### ✅ Test Coverage

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested the changes manually (spring-petclinic, caffeine, spring-framework)

### 🔍 Test Results

```bash
uv run pytest tests/ -k "java" -q
# 627 passed, 0 failed

uv run pytest tests/unit/mcp/test_trace_impact_count_fix.py -v
# 4 passed

uv run pytest tests/unit/languages/test_java_annotation_extraction.py -v
# 10 passed

uv run pytest tests/unit/languages/test_java_caffeine_validation.py -v
# 7 passed
```

---

## 📋 Quality Checklist

### 🔧 Code Quality

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the CHANGELOG.md

### 🛠️ Quality Checks Passed

- [ ] ✅ Black formatting
- [x] ✅ Ruff linting: all clean
- [x] ✅ Type checking: `uv run mypy` — no errors on changed files
- [ ] ✅ Security scan
- [x] ✅ All tests pass: 627 passed, 0 failed

---

## 📸 Screenshots/Examples

### Bug 1+2+3: 注解提取顺序错误 + _reset_caches 清源数据 + 工具层硬编码

**根因**：`extract_elements()` 调用 `extract_functions()` 在前、`extract_annotations()` 在后；`_reset_caches()` 会在每次 `extract_*` 调用时清空 `self.annotations`；工具层对所有元素硬编码 `"annotations": []`。

**修复位置**：`java_plugin.py`、`analyze_code_structure_tool.py`

### Bug 4: `field_declaration` 不在 AST 遍历容器节点

**根因**：字段注解 (`@ManyToMany`, `@Column`) 在 AST 中位于 `field_declaration > modifiers > annotation`，但 `field_declaration` 不在 `container_node_types` 中，遍历直接跳过。

```python
# Fix
container_node_types = {
    ...
    "field_declaration",  # field annotations live here
    ...
}
```

### Bug 5: `implements` 泛型被 regex 拆碎

**根因**：`re.findall(r"\b[A-Z]\w*")` 不感知角括号嵌套。

```python
# Before
implements_interfaces = re.findall(r"\b[A-Z]\w*", text)
# LocalCache<K, V>  →  ['LocalCache', 'K', 'V']  ❌

# After: angle-bracket-aware splitter
implements_interfaces = self._split_type_list(text)
# LocalCache<K, V>  →  ['LocalCache<K, V>']  ✅
```

### Bug 6: `@Override` 从方法出血到类注解

**根因**：行号近似（±2行）导致前一个方法的 `@Override` 被归属到下一个类。

```python
# Before: line-proximity heuristic (unreliable)
class_annotations = self._find_annotations_for_line_cached(start_line)

# After: read directly from AST modifiers node (precise)
class_annotations = self._extract_annotations_from_modifiers(node)
```

### Bug 7: `trace_impact` 的 `call_count` 用截断后数量

**根因**：`total_count = len(usages)` 在截断后计算。

```python
# Before
matches = matches[:max_results]   # 截断
total_count = len(usages)         # = max_results，不是真实总数 ❌

# After
true_total = len(matches)         # 截断前记录
matches = matches[:max_results]
total_count = true_total          # 真实总数 ✅
```

验证 spring-framework：
```python
# Before
trace_impact("Component", max_results=5)
→ call_count=5, impact_level="low"  # 错：实际 695 处

# After
→ call_count=695, impact_level="high", truncated=True, usages=[5 items]  # 正确
```

---

## 🎯 Performance Impact

- [x] Performance improvement

netty 大文件验证（顺带测试）：

| 文件 | 行数 | 全量读 token | get_code_outline token | 节省 |
|------|------|------------|----------------------|------|
| AbstractByteBufTest.java | 6500 | ~54,163 | ~5,943 | **89%** |
| ReferenceCountedOpenSslEngine.java | 2877 | ~31,280 | ~2,557 | **92%** |

所有大文件分析均稳定，无崩溃。

---

## 🔍 Additional Notes

每个 bug 均遵循 SDD+TDD 流程：
1. 先写失败测试（红灯）
2. 写 openspec `proposal.md` 记录根因
3. 实现修复
4. 测试变绿
5. commit

openspec 变更记录：
- `openspec/changes/improve-java-annotation-extraction/`
- `openspec/changes/fix-java-implements-generics-and-annotation-attribution/`
- `openspec/changes/fix-trace-impact-count-truncation/`

---

## ✅ Final Checklist

- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
