### PR TITLE
fix: support --table json in CLI

### DIFF
--- a/tests/integration/cli/test_cli_commands.py
+++ b/tests/integration/cli/test_cli_commands.py
@@ -462,6 +462,43 @@ class TestTableCommandCoverage:
         finally:
             Path(temp_path).unlink(missing_ok=True)
 
+    def test_table_json_via_main(self, monkeypatch):
+        """Test that CLI --table json succeeds and emits JSON output."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+            f.write("def foo():\n    return 1\n")
+            temp_path = f.name
+
+        try:
+            monkeypatch.setattr(
+                sys,
+                "argv",
+                [
+                    "cli",
+                    temp_path,
+                    "--table",
+                    "json",
+                    "--quiet",
+                    "--project-root",
+                    str(Path(temp_path).parent),
+                ],
+            )
+            mock_stdout = StringIO()
+            mock_stderr = StringIO()
+            monkeypatch.setattr("sys.stdout", mock_stdout)
+            monkeypatch.setattr("sys.stderr", mock_stderr)
+
+            with contextlib.suppress(SystemExit):
+                main()
+
+            output = mock_stdout.getvalue()
+            error_output = mock_stderr.getvalue()
+
+            assert '"file_path"' in output
+            assert '"language"' in output
+            assert "Unsupported format type" not in error_output
+        finally:
+            Path(temp_path).unlink(missing_ok=True)
+
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/unit/core/test_exception_context_properties.py
+++ b/tests/unit/core/test_exception_context_properties.py
@@ -196,7 +196,9 @@ class TestExceptionContextPreservationProperty:
         message=safe_text,
         context=context_dict,
     )
-    @settings(max_examples=100)
+    @settings(
+        max_examples=100, deadline=None, suppress_health_check=[HealthCheck.too_slow]
+    )
     def test_create_error_response_preserves_context(
         self, message: str, context: dict[str, Any]
     ) -> None:

--- a/tests/unit/performance/test_async_performance.py
+++ b/tests/unit/performance/test_async_performance.py
@@ -52,20 +52,27 @@ async def test_parser_cache_effectiveness(tmp_path):
     file_path = str(f)
 
     engine = get_engine()
+    engine.clear_cache()
+    engine.parser._cache.clear()
     request = AnalysisRequest(file_path=file_path, language="python")
+    stats_before = engine.get_cache_stats()
 
     # First time - should parse
     start1 = time.perf_counter()
     res1 = await engine.analyze(request)
     duration1 = time.perf_counter() - start1
+    stats_after_first = engine.get_cache_stats()
 
     # Second time - should hit cache
     start2 = time.perf_counter()
     res2 = await engine.analyze(request)
     duration2 = time.perf_counter() - start2
+    stats_after_second = engine.get_cache_stats()
 
     print(f"\nFirst call: {duration1:.4f}s, Second call (cached): {duration2:.4f}s")
-    assert duration2 < duration1
+    assert stats_after_first["hits"] == stats_before["hits"]
+    assert stats_after_second["hits"] > stats_after_first["hits"]
+    assert duration2 <= max(duration1 * 5, 0.1)
     assert res1.elements == res2.elements
 
 

--- a/tests/unit/performance/test_mcp_performance.py
+++ b/tests/unit/performance/test_mcp_performance.py
@@ -9,6 +9,7 @@ MCP Performance Tests
 - メモリ使用量の最適化確認
 """
 
+import gc
 import os
 import time
 from pathlib import Path
@@ -523,10 +524,14 @@ class TestMemoryOptimization:
 
     @pytest.mark.asyncio
     async def test_memory_usage_optimization(
-        self, large_code_file, performance_monitor
+        self, large_code_file, performance_monitor, tmp_path
     ):
         """メモリ使用量最適化の確認"""
         tool = TableFormatTool()
+        output_file_name = f"test_output_{tmp_path.name}.json"
+
+        # Collect garbage before measuring to reduce noise from prior tests
+        gc.collect()
 
         # 初期メモリ使用量を記録
         initial_memory = psutil.Process().memory_info().rss
@@ -539,11 +544,14 @@ class TestMemoryOptimization:
                 "file_path": large_code_file,
                 "format_type": "full",
                 "suppress_output": True,
-                "output_file": "test_output.json",
+                "output_file": output_file_name,
             }
         )
 
         metrics = performance_monitor.end_measurement()
+
+        # Measure retained memory after temporary objects are collectible
+        gc.collect()
         final_memory = psutil.Process().memory_info().rss
 
         assert result["success"] is True
@@ -558,9 +566,9 @@ class TestMemoryOptimization:
         print(f"メモリ使用量増加: {memory_increase:.2f}MB")
 
         # 出力ファイルが作成されていることを確認
-        output_file = Path("test_output.json")
-        if output_file.exists():
-            output_file.unlink()  # クリーンアップ
+        saved_output = Path(result["output_file_path"])
+        assert saved_output.exists()
+        saved_output.unlink()
 
 
 if __name__ == "__main__":

--- a/tests/unit/security/test_security_boundary_properties.py
+++ b/tests/unit/security/test_security_boundary_properties.py
@@ -280,7 +280,11 @@ class TestSecurityBoundaryEnforcementProperties:
             is_valid
         ), f"Valid relative path should be accepted: {rel_path}, error: {error_msg}"
 
-    @settings(max_examples=100, suppress_health_check=COMMON_HEALTH_CHECKS)
+    @settings(
+        max_examples=100,
+        deadline=None,
+        suppress_health_check=COMMON_HEALTH_CHECKS,
+    )
     @given(abs_path=absolute_path_outside_project())
     def test_property_4_absolute_paths_outside_boundary_rejected(
         self, temp_project_dir, abs_path
@@ -333,7 +337,11 @@ class TestSecurityBoundaryEnforcementProperties:
 
         assert is_within, f"Path within project should be accepted: {full_path}"
 
-    @settings(max_examples=100, suppress_health_check=COMMON_HEALTH_CHECKS)
+    @settings(
+        max_examples=100,
+        deadline=None,
+        suppress_health_check=COMMON_HEALTH_CHECKS,
+    )
     @given(abs_path=absolute_path_outside_project())
     def test_property_4_boundary_manager_rejects_external_paths(
         self, temp_project_dir, abs_path
@@ -525,7 +533,11 @@ class TestSecurityBoundaryEdgeCases:
                 Path(reconstructed).resolve() == Path(full_path).resolve()
             ), f"Relative path should reconstruct to original: {relative} -> {reconstructed} != {full_path}"
 
-    @settings(max_examples=100, suppress_health_check=COMMON_HEALTH_CHECKS)
+    @settings(
+        max_examples=100,
+        deadline=None,
+        suppress_health_check=COMMON_HEALTH_CHECKS,
+    )
     @given(abs_path=absolute_path_outside_project())
     def test_property_4_get_relative_path_returns_none_for_external(
         self, temp_project_dir, abs_path

--- a/tree_sitter_analyzer/formatters/base_formatter.py
+++ b/tree_sitter_analyzer/formatters/base_formatter.py
@@ -118,11 +118,19 @@ class BaseTableFormatter(BaseFormatter):
             result = self._format_compact_table(structure_data)
         elif self.format_type == "csv":
             result = self._format_csv(structure_data)
+        elif self.format_type == "json":
+            format_json = getattr(self, "_format_json", None)
+            if callable(format_json):
+                result = format_json(structure_data)
+            else:
+                import json
+
+                result = json.dumps(structure_data, indent=2, ensure_ascii=False)
         else:
             raise ValueError(f"Unsupported format type: {self.format_type}")
 
         # Finally convert to platform-specific newline code
-        if self.format_type == "csv":
+        if self.format_type in {"csv", "json"}:
             return result
 
         return self._convert_to_platform_newlines(result)

--- a/tree_sitter_analyzer/formatters/formatter_registry.py
+++ b/tree_sitter_analyzer/formatters/formatter_registry.py
@@ -603,8 +603,10 @@ def _register_language_formatters_safe() -> None:
             "sql": SQLFormatterWrapper,
         }
 
-        # Register each language with all format types
-        format_types = ["full", "compact", "csv"]
+        # Register each language with all advertised table formats.
+        # CLI accepts --table json, and many language formatters already
+        # implement it via format_table(..., table_type="json").
+        format_types = ["full", "compact", "csv", "json"]
         for lang, formatter_class in language_formatters.items():
             for fmt in format_types:
                 FormatterRegistry.register_language_formatter(

--- a/uv.lock
+++ b/uv.lock
@@ -2366,7 +2366,7 @@ wheels = [
 
 [[package]]
 name = "tree-sitter-analyzer"
-version = "1.10.8"
+version = "1.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
## Summary
- register `json` as a valid table formatter so `--table json` works at runtime
- sync `uv.lock` package version to `1.11.1` to match `pyproject.toml`
- stabilize flaky CI tests in Hypothesis/property and performance cases without changing product logic

## Root cause
`argparse` and formatter code exposed `json` as a valid table format, but the formatter registry never registered a `json` table formatter. That caused runtime failures like `Unsupported format type: json`.

## Local verification
- `uv run --python 3.10 pytest tests/ -n auto -v --tb=short --maxfail=10 -m 'not requires_ripgrep and not requires_fd'`
- `uv run --python 3.11 pytest tests/ -n auto -v --tb=short --maxfail=10 -m 'not requires_ripgrep and not requires_fd' --cov=tree_sitter_analyzer --cov-report=term-missing --cov-report=xml`
- `uv run --python 3.12 pytest tests/ -n auto -v --tb=short --maxfail=10 -m 'not requires_ripgrep and not requires_fd'`
- `uv run --python 3.13 pytest tests/ -n auto -v --tb=short --maxfail=10 -m 'not requires_ripgrep and not requires_fd'`
- `uv sync --all-extras --python 3.11`
- `uv run --python 3.11 ruff check .`
- `uv run --python 3.11 mypy tree_sitter_analyzer/`
- `uv run --python 3.11 bandit -r tree_sitter_analyzer/ -f json -o bandit-results.json` (non-blocking; 8 existing findings)
- `uv run --python 3.11 --with build python -m build`
- `uv run --python 3.11 --with twine twine check dist/*`
