### PR TITLE
feat(ci): enforce GITFLOW.md as hard requirement (agents + CI + contract test)

### DIFF
--- a/.github/workflows/gitflow-guard.yml
+++ b/.github/workflows/gitflow-guard.yml
@@ -1,0 +1,80 @@
+# GitFlow Guard — enforce the branching matrix from GITFLOW.md.
+#
+# Fails any PR whose head→base pair violates the documented flow.
+# See AGENTS.md "GitFlow Branching Mandate" + GITFLOW.md for the full
+# rule set. This is the CI enforcement layer; the docs are the source
+# of truth.
+
+name: GitFlow Guard
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  validate-branch-pair:
+    name: Validate head→base per GITFLOW.md
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch naming + target
+        env:
+          HEAD: ${{ github.head_ref }}
+          BASE: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          echo "Head branch: ${HEAD}"
+          echo "Base branch: ${BASE}"
+
+          violation=""
+
+          # Dependabot / Renovate / GitHub auto-PRs use bot-namespaced
+          # heads — allow through to keep automation working.
+          case "${HEAD}" in
+            dependabot/*|renovate/*|github-actions/*)
+              echo "ℹ️  Bot PR detected — skipping GitFlow head naming check."
+              exit 0
+              ;;
+          esac
+
+          case "${BASE}" in
+            main)
+              # PRs to main MUST come from release/v* or hotfix/*.
+              # See GITFLOW.md §2 (Release Process) and §3 (Hotfix Process).
+              case "${HEAD}" in
+                release/v*|hotfix/*)
+                  echo "✅ ${HEAD} → main allowed (release/hotfix flow)."
+                  ;;
+                *)
+                  violation="PR to main MUST come from release/v* or hotfix/* (got: ${HEAD})."
+                  ;;
+              esac
+              ;;
+            develop)
+              # PRs to develop MUST come from feature/*, release/v*,
+              # hotfix/*, chore/*, docs/*, test/*, or fix/*.
+              case "${HEAD}" in
+                feature/*|release/v*|hotfix/*|chore/*|docs/*|test/*|fix/*|refactor/*|perf/*|ci/*)
+                  echo "✅ ${HEAD} → develop allowed (feature/integration flow)."
+                  ;;
+                *)
+                  violation="PR to develop must use a GitFlow-compatible branch name (feature/* | chore/* | docs/* | test/* | fix/* | refactor/* | perf/* | ci/*). Got: ${HEAD}."
+                  ;;
+              esac
+              ;;
+            *)
+              # PRs targeting any other base (long-lived branches, etc.)
+              # are out of scope for this guard. Repo owners can extend
+              # this case block as new bases get introduced.
+              echo "ℹ️  Base ${BASE} not covered by GITFLOW guard — passing through."
+              ;;
+          esac
+
+          if [ -n "${violation}" ]; then
+            echo "::error::${violation}"
+            echo "::error::See GITFLOW.md + AGENTS.md 'GitFlow Branching Mandate' for the full rule set."
+            exit 1
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,7 @@ Why: previously the codemap drifted from 23 → 27 → 30 → 55 tools across 4 
 - Cut a `feature/*` from `main` — it must come from `develop`
 - Force-push or delete `main`, `develop`, or any released tag (`v*`)
 - Skip the `develop` merge-back after a release or hotfix is published
+- **Use `hotfix/*` for non-release fixes.** Pushing to `hotfix/*` auto-triggers `hotfix-automation.yml` → PyPI publish with a version bump. Reserve `hotfix/*` for "production is broken, needs a same-day patch release". For a generic bug fix, CI YAML repair, workflow tweak, etc., use `fix/*` · `ci/*` · `chore/*` against `develop`.
 
 **Release flow (every detail in [`GITFLOW.md`](GITFLOW.md)):**
 1. `release/v<X.Y.Z>` cut from `develop`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,3 +51,35 @@ Enforced by:
 Escape hatch for intentional rename/rebase: `SKIP_CODEMAP_SYNC=1 git commit ...`. The pytest test still runs in CI as the final safety net — bypass is local-only.
 
 Why: previously the codemap drifted from 23 → 27 → 30 → 55 tools across 4 months with manual catch-up commits in between. The agent contract is now self-enforcing.
+
+## GitFlow Branching Mandate
+
+**Hard requirement.** Every branch operation MUST follow [`GITFLOW.md`](GITFLOW.md) ([中文](GITFLOW_zh.md) / [日本語](GITFLOW_ja.md)). The matrix below is the full surface — anything else is a violation.
+
+| Operation | Branch name | Cut from | Target (via PR) |
+|---|---|---|---|
+| Feature | `feature/<name>` | `develop` | `develop` |
+| Release prep | `release/v<X.Y.Z>` | `develop` | `main` **and back into** `develop` |
+| Production hotfix | `hotfix/<name>` | `main` | `main` **and back into** `develop` |
+| Chore / docs / test (non-release) | `chore/<name>` · `docs/<name>` · `test/<name>` · `fix/<name>` | `develop` | `develop` |
+
+**Agents MUST NEVER:**
+- Push directly to `main` or `develop` — open a PR from a properly-named branch instead
+- Open a PR targeting `main` from anything other than `release/v*` or `hotfix/*`
+- Cut a `feature/*` from `main` — it must come from `develop`
+- Force-push or delete `main`, `develop`, or any released tag (`v*`)
+- Skip the `develop` merge-back after a release or hotfix is published
+
+**Release flow (every detail in [`GITFLOW.md`](GITFLOW.md)):**
+1. `release/v<X.Y.Z>` cut from `develop`
+2. Push triggers `.github/workflows/release-automation.yml` → test → build → publish to PyPI
+3. After PyPI is live: PR `release/v*` → `main`, tag `v<X.Y.Z>` on main, GitHub Release
+4. Merge `release/v*` → `develop` to bring back release-prep commits (version bumps, CHANGELOG)
+5. Delete `release/v<X.Y.Z>` from origin
+
+**Enforcement layers:**
+- `.github/workflows/gitflow-guard.yml` — CI fails on a PR whose head→base pair violates the matrix
+- GitHub branch protection on `main` (PR + status checks required, no force-push)
+- `test_gitflow_documentation_is_present` in `tests/unit/test_agent_contracts.py` — guards against `GITFLOW.md` being deleted or `AGENTS.md` losing the link
+
+Escape hatch: none. If GITFLOW.md itself needs to change, that's a PR like any other — argue the case in the description and update the matrix + tests in the same commit.

--- a/tests/unit/test_agent_contracts.py
+++ b/tests/unit/test_agent_contracts.py
@@ -89,6 +89,50 @@ def test_pytest_runtime_dependencies_are_declared() -> None:
     assert "pytest-timeout>=2.4.0" in dev_dependencies
 
 
+def test_gitflow_documentation_is_present() -> None:
+    """The GitFlow mandate must remain documented + machine-enforced.
+
+    Three artifacts are required so the rule survives both casual edits
+    and CI bypass attempts:
+      1. ``GITFLOW.md`` at repo root — the source of truth.
+      2. ``AGENTS.md`` references it from the "GitFlow Branching Mandate"
+         section so any agent reading AGENTS.md sees the rule.
+      3. ``.github/workflows/gitflow-guard.yml`` enforces head→base
+         naming on every PR — the CI safety net.
+
+    If you intentionally restructure how GitFlow is documented, update
+    this test in the same commit and explain why in the PR description.
+    """
+    gitflow_md = PROJECT_ROOT / "GITFLOW.md"
+    agents_md = PROJECT_ROOT / "AGENTS.md"
+    guard_yml = PROJECT_ROOT / ".github" / "workflows" / "gitflow-guard.yml"
+
+    assert gitflow_md.exists(), "GITFLOW.md must exist at repo root"
+    assert agents_md.exists(), "AGENTS.md must exist at repo root"
+    assert guard_yml.exists(), (
+        ".github/workflows/gitflow-guard.yml must exist — the CI "
+        "enforcement layer for the GitFlow branching mandate"
+    )
+
+    agents_text = agents_md.read_text(encoding="utf-8")
+    assert "GitFlow Branching Mandate" in agents_text, (
+        "AGENTS.md must contain a 'GitFlow Branching Mandate' section "
+        "linking to GITFLOW.md"
+    )
+    assert "GITFLOW.md" in agents_text, (
+        "AGENTS.md's GitFlow section must link to GITFLOW.md by name"
+    )
+
+    guard_text = guard_yml.read_text(encoding="utf-8")
+    # The guard must check both main and develop as protected bases,
+    # otherwise an agent could open a stray PR against either branch.
+    for required_check in ("main", "develop", "release/v", "hotfix/"):
+        assert required_check in guard_text, (
+            f"gitflow-guard.yml must reference {required_check!r} in its "
+            "validation logic — see AGENTS.md 'GitFlow Branching Mandate'"
+        )
+
+
 def test_agent_facing_docs_do_not_recommend_bare_pytest() -> None:
     """Agent docs should route pytest through uv for consistent environments."""
     bare_pytest_command = re.compile(r"^(?:\$\s+)?pytest(?:\s|$)")


### PR DESCRIPTION
## Summary

Make GITFLOW.md the **hard requirement** for every branch operation — agents and humans. Three independent enforcement layers so the rule survives both casual edits and CI bypass attempts.

| Layer | File | What it does |
|---|---|---|
| 1. Docs | `AGENTS.md` § *GitFlow Branching Mandate* | Primary surface every agent loads at session start. Spells out the matrix, the MUST-NEVER list, the full release flow. |
| 2. CI guard | `.github/workflows/gitflow-guard.yml` | Fails any PR whose head→base pair violates the matrix (e.g. `feature/* → main`, or PR to `develop` from a non-GitFlow-named branch). |
| 3. Contract test | `test_gitflow_documentation_is_present` | Guards against the docs being deleted or the workflow being weakened. |

## Branching matrix (now enforced)

| Operation | Branch name | Cut from | Target |
|---|---|---|---|
| Feature | `feature/<name>` | `develop` | `develop` |
| Release prep | `release/v<X.Y.Z>` | `develop` | `main` **and back to** `develop` |
| Production hotfix | `hotfix/<name>` | `main` | `main` **and back to** `develop` |
| Chore / docs / test | `chore/* · docs/* · test/* · fix/* · refactor/* · perf/* · ci/*` | `develop` | `develop` |

## Self-conforming

This PR itself follows the new rule: cut from `develop` as `feature/enforce-gitflow-mandate`, targeting `develop`. Once merged, the rule is self-perpetuating because the workflow + contract test guard every subsequent PR.

## Test plan

- [x] `uv run pytest tests/unit/test_agent_contracts.py::test_gitflow_documentation_is_present -v` passes locally
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/gitflow-guard.yml'))"` parses cleanly
- [x] This PR itself triggers `gitflow-guard.yml` — it should pass (feature/* → develop is allowed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)