### PR TITLE
release: merge-back v1.13.1 → develop

### DIFF
--- a/.github/actions/setup-system/action.yml
+++ b/.github/actions/setup-system/action.yml
@@ -49,13 +49,27 @@ runs:
       if: inputs.os == 'windows-latest'
       run: |
         Write-Host "Installing fd and ripgrep on Windows..."
-        choco install fd ripgrep -y
+        # Install each package separately — `choco install fd ripgrep -y`
+        # has been observed to silently skip fd while reporting
+        # "1/1 packages" (likely ripgrep being pre-installed on the
+        # runner image and consuming the slot). Separate calls also
+        # surface per-package failure exit codes.
+        choco install fd -y --no-progress
+        if ($LASTEXITCODE -ne 0) { Write-Host "::error::choco install fd failed"; exit 1 }
+        choco install ripgrep -y --no-progress
+        if ($LASTEXITCODE -ne 0) { Write-Host "::error::choco install ripgrep failed"; exit 1 }
+
+        # Refresh PATH inside this PowerShell session so the just-installed
+        # binaries are visible to fd --version / rg --version. Chocolatey
+        # writes to the Machine PATH but the current session inherits a
+        # snapshot taken at startup.
+        $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 
         # Verify installation
         Write-Host "Verifying installation..."
         fd --version
         if ($LASTEXITCODE -ne 0) {
-          Write-Host "❌ fd installation failed"
+          Write-Host "❌ fd not found after install — PATH refresh failed"
           exit 1
         }
         rg --version

--- a/.github/actions/setup-system/action.yml
+++ b/.github/actions/setup-system/action.yml
@@ -49,7 +49,15 @@ runs:
       if: inputs.os == 'windows-latest'
       run: |
         Write-Host "Installing fd and ripgrep on Windows..."
-        # Install each package separately — `choco install fd ripgrep -y`
+        # NOTE: keep this block ASCII-only. The runner's `powershell`
+        # (Windows PowerShell 5.1) reads the inline script as cp1252,
+        # so UTF-8 emoji from this YAML get mojibake'd into
+        # `Write-Host "<garbage>"` and trip
+        # TerminatorExpectedAtEndOfString. Switching to `pwsh`
+        # (PowerShell Core, UTF-8 by default) is the long-term fix,
+        # but Windows runners ship `powershell` first.
+        #
+        # Install each package separately - `choco install fd ripgrep -y`
         # has been observed to silently skip fd while reporting
         # "1/1 packages" (likely ripgrep being pre-installed on the
         # runner image and consuming the slot). Separate calls also
@@ -69,13 +77,13 @@ runs:
         Write-Host "Verifying installation..."
         fd --version
         if ($LASTEXITCODE -ne 0) {
-          Write-Host "❌ fd not found after install — PATH refresh failed"
+          Write-Host "::error::fd not found after install - PATH refresh failed"
           exit 1
         }
         rg --version
         if ($LASTEXITCODE -ne 0) {
-          Write-Host "❌ ripgrep installation failed"
+          Write-Host "::error::ripgrep not found after install - PATH refresh failed"
           exit 1
         }
-        Write-Host "✅ System dependencies installed successfully on Windows"
+        Write-Host "[OK] System dependencies installed successfully on Windows"
       shell: powershell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## [1.13.1] - 2026-05-24
+
+CI infrastructure patch — same wheel as 1.13.0 for end-users, but the
+source distribution carries two important repository-level fixes.
+
+### Fixed
+
+- **`.github/workflows/auto-sprint-execute.yml` no longer fails on every push to `main`**.
+  PR #133 introduced an invalid `run: |` literal scalar (multi-line
+  `git commit -m` continuations returned to column 0, breaking the
+  indent). GitHub Actions parsed the file on every push and
+  synthesized a startup_failure run even though the workflow only
+  declares `on: workflow_dispatch`. The block now uses multiple `-m`
+  flags + a printf-built `$PR_BODY` so it stays inside the literal
+  scalar's 10-space indent. The action ref `anthropics/claude-code-base-action@v1`
+  (which doesn't exist) is pinned to `@beta` (the only published tag).
+  *(PR #138)*
+
+### Added
+
+- **GitFlow Branching Mandate** — three-layer enforcement so every
+  branch operation conforms to `GITFLOW.md`:
+  - `AGENTS.md § GitFlow Branching Mandate` — the head→base matrix,
+    the MUST-NEVER list (including the new "don't use `hotfix/*` for
+    non-release fixes — it auto-triggers PyPI publish" caveat
+    learned the hard way), and the full release flow.
+  - `.github/workflows/gitflow-guard.yml` — CI fails any PR whose
+    head→base pair violates the matrix (e.g. `feature/* → main`).
+    Bot PRs (`dependabot/*`, `renovate/*`, `github-actions/*`) are
+    allow-listed so automation keeps working.
+  - `test_gitflow_documentation_is_present` in
+    `tests/unit/test_agent_contracts.py` — guards against the docs
+    or workflow being silently weakened.
+  *(PR #137)*
+
+### Changed
+
+- `pyproject.toml` `[project].version` and `[tool.mcp].server_version`
+  bumped to `1.13.1` (already matched 1.13.0 after the v1.13.0
+  release; this is the routine patch bump for the new release cycle).
+
 ## [1.13.0] - 2026-05-24
 
 CodeGraph parity + benchmark + 5-language unblock release. TSA now

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tree-sitter-analyzer"
-version = "1.13.0"
+version = "1.13.1"
 description = "MCP code-intelligence server for AI agents — beats CodeGraph on 6-repo head-to-head benchmark median. 50 MCP tools, 13 curated skills, TOON output, 100% local."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -616,7 +616,7 @@ directory = "htmlcov"
 # MCP server configuration
 [tool.mcp]
 server_name = "tree-sitter-analyzer"
-server_version = "1.13.0"
+server_version = "1.13.1"
 description = "AI-era enterprise-grade code analysis MCP server with comprehensive HTML/CSS support and multi-language capabilities"
 capabilities = [
     "check_code_scale",

--- a/tree_sitter_analyzer/__init__.py
+++ b/tree_sitter_analyzer/__init__.py
@@ -11,7 +11,7 @@ Architecture:
 - Data Models: Generic and language-specific code element representations
 """
 
-__version__ = "1.13.0"
+__version__ = "1.13.1"
 __author__ = "aisheng.yu"
 __email__ = "aimasteracc@gmail.com"
 

--- a/uv.lock
+++ b/uv.lock
@@ -2396,7 +2396,7 @@ wheels = [
 
 [[package]]
 name = "tree-sitter-analyzer"
-version = "1.13.0"
+version = "1.13.1"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
## Summary

GitFlow merge-back: bring the v1.13.1 release commits (5f86fc4, 45d72e0, 6434855) into develop so develop doesn't regress on the next release cut.

PyPI 1.13.1 is published. Tag `v1.13.1` and GitHub Release are on main. This PR closes the GitFlow loop by syncing develop.

## Why a PR instead of direct merge

`gitflow-guard.yml` requires every base-touching change to go through a PR. The matrix permits `release/v* → develop`.

## What's in the diff

Three commits — version bump + 2 Windows CI infrastructure fixes. No product changes.

## Conflict expectation

Should fast-forward cleanly. develop was rebuilt from main earlier this session, so the only divergence is the 3 release commits.

## Test plan

- [x] `gitflow-guard.yml` allows `release/v1.13.1 → develop` (per matrix)
- [ ] CI greens
- [ ] After merge: delete `release/v1.13.1` (local + remote)