### PR TITLE
feat(swift): support .swiftinterface files (closes #131)

### DIFF
--- a/docs/CODEMAPS/languages.md
+++ b/docs/CODEMAPS/languages.md
@@ -1,4 +1,4 @@
-<!-- Generated: 2026-05-22 -->
+<!-- Generated: 2026-05-24 -->
 # Languages Codemap
 
 21 language plugins under `tree_sitter_analyzer/languages/` (16 single-file + 5 subdir packages).
@@ -19,7 +19,7 @@ Each implements the `LanguagePlugin` interface (`tree_sitter_analyzer/plugins/ba
 | Rust | `rust_plugin.py` | inline | traits, impl, macros, derive |
 | Kotlin | `kotlin_plugin.py` | `kotlin_helpers.py` | data classes, coroutines |
 | Scala | `scala_plugin.py` | inline | objects/traits, scaladoc |
-| Swift | `swift_plugin.py` | `_swift_plugin_*.py` ×3 | classes, structs, protocols |
+| Swift | `swift_plugin.py` | `_swift_plugin_*.py` ×3 | classes, structs, protocols; `.swift` + `.swiftinterface` (issue #131) |
 | Ruby | `ruby_plugin.py` | `ruby_helpers.py` | Rails patterns, metaprogramming |
 | PHP | `php_plugin.py` | `php_helpers.py` | PHP 8+ attributes, traits |
 | HTML | `html_plugin.py` | `html_helpers.py` | DOM elements with role classification |

--- a/tests/unit/languages/test_swift_plugin.py
+++ b/tests/unit/languages/test_swift_plugin.py
@@ -77,8 +77,11 @@ class TestSwiftPluginBasics:
 
     def test_plugin_metadata(self, plugin: SwiftPlugin) -> None:
         assert plugin.get_language_name() == "swift"
-        assert plugin.get_file_extensions() == [".swift"]
+        # ``.swiftinterface`` is module-interface emitted by
+        # ``swiftc -emit-module-interface`` — issue #131.
+        assert plugin.get_file_extensions() == [".swift", ".swiftinterface"]
         assert plugin.supports_file("Sources/App.swift")
+        assert plugin.supports_file("SDK/Foundation.swiftinterface")
         assert not plugin.supports_file("Sources/App.kt")
 
     def test_create_extractor(self, plugin: SwiftPlugin) -> None:

--- a/tests/unit/test_lang_extension_map.py
+++ b/tests/unit/test_lang_extension_map.py
@@ -151,6 +151,7 @@ def test_project_graph_alias_resolves_via_canonical() -> None:
     "ext, expected",
     [
         (".swift", "swift"),
+        (".swiftinterface", "swift"),  # issue #131
         (".kt", "kotlin"),
         (".rb", "ruby"),
         (".php", "php"),
@@ -165,6 +166,33 @@ def test_long_broken_extensions_stay_wired(ext: str, expected: str) -> None:
         f"months until the 2026-05-24 benchmark surfaced it (Alamofire "
         f"indexed 10/98 files, all of them JS noise from docs/)."
     )
+
+
+def test_swiftinterface_resolves_in_all_known_ext_maps() -> None:
+    """``.swiftinterface`` must map to swift across every ext-resolver.
+
+    Issue #131 added module-interface support. ``_lang_extension_map``
+    is the SSoT for indexer wiring, but a handful of bespoke maps in
+    ``file_handler`` / ``language_detector`` / detector helpers /
+    health_scorer / mcp tools have their own copies (intentional —
+    they cover different code paths). All of them must agree, or a
+    file resolves as swift in one path and ``unknown`` in another.
+    """
+    from tree_sitter_analyzer._lang_extension_map import language_from_ext
+    from tree_sitter_analyzer.file_handler import detect_language_from_extension
+    from tree_sitter_analyzer.language_detector import LanguageDetector
+
+    sample = "Foundation.swiftinterface"
+
+    # 1. Indexer SSoT
+    assert language_from_ext(sample) == "swift"
+
+    # 2. CLI single-file path (file_handler)
+    assert detect_language_from_extension(sample) == "swift"
+
+    # 3. Generic language detector (used by some MCP tools)
+    detector = LanguageDetector()
+    assert detector.detect_from_extension(sample) == "swift"
 
 
 # -- meta: the helper itself works --------------------------------------

--- a/tree_sitter_analyzer/_lang_extension_map.py
+++ b/tree_sitter_analyzer/_lang_extension_map.py
@@ -58,6 +58,12 @@ EXT_TO_LANG: dict[str, str] = {
     ".rb": "ruby",
     ".rs": "rust",
     ".swift": "swift",
+    # .swiftinterface — module-interface files emitted by
+    # `swiftc -emit-module-interface`. Syntactically a subset of Swift,
+    # parsed by tree-sitter-swift without modification. Useful for SDK
+    # analysis (Apple ships SwiftUI / Foundation / etc. as .swiftinterface
+    # in the toolchain). Issue #131.
+    ".swiftinterface": "swift",
     ".ts": "typescript",
     ".tsx": "typescript",
     # NOTE: ``.css / .html / .md / .sql / .yaml / .yml`` have plugins

--- a/tree_sitter_analyzer/_language_detector_helpers.py
+++ b/tree_sitter_analyzer/_language_detector_helpers.py
@@ -30,6 +30,7 @@ def build_extension_confidence_map() -> dict[str, tuple[str, float]]:
         ".php": ("php", 0.9),
         ".rb": ("ruby", 0.9),
         ".swift": ("swift", 0.9),
+        ".swiftinterface": ("swift", 0.9),
         ".kt": ("kotlin", 0.9),
         ".kts": ("kotlin", 0.9),
         ".scala": ("scala", 0.9),

--- a/tree_sitter_analyzer/file_handler.py
+++ b/tree_sitter_analyzer/file_handler.py
@@ -59,6 +59,7 @@ def detect_language_from_extension(file_path: str) -> str:
         ".kt": "kotlin",
         ".scala": "scala",
         ".swift": "swift",
+        ".swiftinterface": "swift",
     }
 
     return extension_map.get(extension, "unknown")

--- a/tree_sitter_analyzer/language_detector.py
+++ b/tree_sitter_analyzer/language_detector.py
@@ -58,6 +58,7 @@ class LanguageDetector:
         ".kt": "kotlin",
         ".kts": "kotlin",
         ".swift": "swift",
+        ".swiftinterface": "swift",
         ".cs": "csharp",
         ".vb": "vbnet",
         ".fs": "fsharp",

--- a/tree_sitter_analyzer/languages/swift_plugin.py
+++ b/tree_sitter_analyzer/languages/swift_plugin.py
@@ -36,8 +36,13 @@ class SwiftPlugin(LanguagePlugin):
         return "swift"
 
     def get_file_extensions(self) -> list[str]:
-        """Get supported file extensions."""
-        return [".swift"]
+        """Get supported file extensions.
+
+        ``.swiftinterface`` files are module-interface artifacts emitted by
+        ``swiftc -emit-module-interface``. They are syntactically a subset
+        of Swift and parse with the same tree-sitter grammar. Issue #131.
+        """
+        return [".swift", ".swiftinterface"]
 
     def create_extractor(self) -> ElementExtractor:
         """Create a new element extractor instance."""


### PR DESCRIPTION
## Summary

Closes #131. Adds `.swiftinterface` (module-interface) support to the Swift plugin.

`.swiftinterface` is the format emitted by `swiftc -emit-module-interface` — Apple ships SwiftUI / Foundation / etc. as `.swiftinterface` in the toolchain. Syntactically a subset of Swift, so tree-sitter-swift parses it without grammar changes.

## What changed

| File | Change |
|---|---|
| `tree_sitter_analyzer/_lang_extension_map.py` | added `.swiftinterface: swift` (indexer SSoT — drives `ast_cache` + `project_graph` via the dedup'd alias) |
| `tree_sitter_analyzer/languages/swift_plugin.py` | `get_file_extensions()` → `[".swift", ".swiftinterface"]` |
| `tree_sitter_analyzer/file_handler.py` | CLI single-file path map |
| `tree_sitter_analyzer/language_detector.py` | generic detector |
| `tree_sitter_analyzer/_language_detector_helpers.py` | confidence-scoring map (0.9, same as `.swift`) |
| `docs/CODEMAPS/languages.md` | Swift row lists both extensions + issue ref; regen date bumped |

## Tests

- `tests/unit/test_lang_extension_map.py`:
  - `.swiftinterface` added to the `test_long_broken_extensions_stay_wired` parametrize
  - New `test_swiftinterface_resolves_in_all_known_ext_maps` — asserts consistent resolution across the indexer SSoT, `file_handler`, and `LanguageDetector` (3 user-facing maps)
- `tests/unit/languages/test_swift_plugin.py`: `test_plugin_metadata` expects both extensions + `supports_file()` on `Foundation.swiftinterface`

Local: 48 tests passed across `tests/unit/languages/test_swift_plugin*.py`, `tests/unit/test_lang_extension_map.py`, `tests/unit/test_agent_contracts.py`.

## Smoke

```bash
$ uv run python -m tree_sitter_analyzer Sample.swiftinterface --structure --format json --project-root .
{
  "language": "swift",
  "classes": [{"name": "Greeter", "visibility": "public", "line_range": [3, 7]}],
  "methods": [{"name": "init", "visibility": "public", "line_range": [5, 5]}],
  "imports": [{"name": "Swift", ...}],
  ...
}
```

## Context

Issue #131 originally asked for Swift support, which shipped in v1.13.0 (`swift_plugin.py` + `_swift_plugin_*.py` + 100 unit tests + golden masters). This PR closes the issue completely by also supporting the `.swiftinterface` extension that came up in follow-up discussion.

## Test plan

- [x] Local pytest passes
- [x] Smoke test on a sample `.swiftinterface`
- [x] codemap sync hook clean
- [ ] CI greens

🤖 Generated with [Claude Code](https://claude.com/claude-code)