### PR TITLE
feat(graph): symbol_in_degree() primitive (PR-0.2 of v1.15 code-map improvement)

### DIFF
--- a/tests/unit/test_project_graph.py
+++ b/tests/unit/test_project_graph.py
@@ -205,6 +205,188 @@ class TestDependencyGraph:
 
 
 # ============================================================
+# PR-0.2: symbol_in_degree() — symbol-level fan-in primitive
+# ============================================================
+
+
+class TestSymbolInDegree:
+    """Test the PR-0.2 ``symbol_in_degree()`` API.
+
+    The primitive answers "how many project files import this symbol by
+    name?" — feeding P4's ranked entry-point detection. RED tests track
+    the planner's spec in ``.recon/pr-0-2-design.md``; GREEN tests are
+    regression guards on the existing public surface.
+    """
+
+    @pytest.fixture
+    def py_graph(self):
+        from tree_sitter_analyzer.project_graph import DependencyGraph
+
+        return DependencyGraph(str(PY_PROJECT))
+
+    @pytest.fixture
+    def custom_graph(self, tmp_path):
+        """Build a small focused project for the cases the PY_PROJECT
+        fixture doesn't cover (ambiguous defs, repeated imports, etc.).
+        """
+        from tree_sitter_analyzer.project_graph import DependencyGraph
+
+        (tmp_path / "utils.py").write_text(
+            "def format_thing(x):\n    return str(x)\n"
+            "\n"
+            "def never_imported_helper():\n    return None\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "main.py").write_text(
+            "from utils import format_thing\n"
+            "from utils import format_thing  # duplicate import on purpose\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "cli.py").write_text(
+            "from utils import format_thing\n", encoding="utf-8"
+        )
+        return DependencyGraph(str(tmp_path))
+
+    # ---- RED tests (define the new contract) ----
+
+    def test_R1_simple_fan_in_count(self, custom_graph):
+        # main.py and cli.py both import format_thing → file_count = 2.
+        result = custom_graph.symbol_in_degree("format_thing")
+        assert result.file_count == 2
+        assert set(result.importer_files) == {"main.py", "cli.py"}
+        # Definitions: utils.py only — not ambiguous.
+        assert result.defining_files == ("utils.py",)
+        assert result.ambiguous is False
+
+    def test_R2_zero_for_unimported_defined_symbol(self, custom_graph):
+        # never_imported_helper is defined in utils.py but no file imports it.
+        result = custom_graph.symbol_in_degree("never_imported_helper")
+        assert result.file_count == 0
+        assert result.importer_files == ()
+        assert result.defining_files == ("utils.py",)
+
+    def test_R3_zero_for_unknown_symbol_no_raise(self, custom_graph):
+        # Symbol that doesn't exist anywhere — must NOT raise.
+        result = custom_graph.symbol_in_degree("xyz_does_not_exist")
+        assert result.symbol == "xyz_does_not_exist"
+        assert result.file_count == 0
+        assert result.importer_files == ()
+        assert result.defining_files == ()
+        assert result.ambiguous is False
+
+    def test_R4_dedupes_repeated_imports_in_same_file(self, custom_graph):
+        # main.py imports format_thing twice → still counts as 1 importer file.
+        result = custom_graph.symbol_in_degree("format_thing")
+        assert "main.py" in result.importer_files
+        # The set was deduped during _build, so main.py appears exactly once.
+        assert sum(1 for f in result.importer_files if f == "main.py") == 1
+
+    def test_R5_ambiguous_when_two_files_define_same_name(self, tmp_path):
+        from tree_sitter_analyzer.project_graph import DependencyGraph
+
+        (tmp_path / "a.py").write_text("class Helper: pass\n", encoding="utf-8")
+        (tmp_path / "b.py").write_text("class Helper: pass\n", encoding="utf-8")
+        (tmp_path / "main.py").write_text("from a import Helper\n", encoding="utf-8")
+        graph = DependencyGraph(str(tmp_path))
+        result = graph.symbol_in_degree("Helper")
+        assert result.ambiguous is True
+        assert set(result.defining_files) == {"a.py", "b.py"}
+
+    def test_R6_disambiguate_by_defining_file(self, tmp_path):
+        from tree_sitter_analyzer.project_graph import DependencyGraph
+
+        (tmp_path / "a.py").write_text("class Helper: pass\n", encoding="utf-8")
+        (tmp_path / "b.py").write_text("class Helper: pass\n", encoding="utf-8")
+        # one importer per definition
+        (tmp_path / "uses_a.py").write_text("from a import Helper\n", encoding="utf-8")
+        (tmp_path / "uses_b.py").write_text("from b import Helper\n", encoding="utf-8")
+        graph = DependencyGraph(str(tmp_path))
+
+        result_default = graph.symbol_in_degree("Helper")
+        assert result_default.file_count == 2  # combined
+
+        result_a_only = graph.symbol_in_degree("Helper", defining_file="a.py")
+        assert result_a_only.file_count == 1
+        assert result_a_only.importer_files == ("uses_a.py",)
+
+    def test_R7_relative_import_counts(self, py_graph):
+        # main.py uses ``from .utils import helper, formatter`` — both
+        # named imports must register as importers of those symbols.
+        result_helper = py_graph.symbol_in_degree("helper")
+        assert "main.py" in result_helper.importer_files
+        result_formatter = py_graph.symbol_in_degree("formatter")
+        assert "main.py" in result_formatter.importer_files
+
+    def test_R8_stdlib_names_not_indexed(self, py_graph):
+        # main.py has ``from pathlib import Path`` — Path lives in
+        # stdlib, not the project, so the resolver returns no project
+        # file. The `resolved in self._nodes` gate must keep `Path`
+        # out of the index.
+        result = py_graph.symbol_in_degree("Path")
+        assert result.file_count == 0
+        assert result.defining_files == ()
+
+    def test_R9_js_bare_imports_yield_no_symbol_entry(self, tmp_path):
+        # PR-0.2 ships Python-only symbol extraction; JS files yield
+        # no symbol-level data (the import_extractors emit ``names: []``
+        # for JS bare imports, so the symbol-importer guard skips them).
+        from tree_sitter_analyzer.project_graph import DependencyGraph
+
+        (tmp_path / "lib.js").write_text("export function foo() {}\n", encoding="utf-8")
+        (tmp_path / "app.js").write_text(
+            "import { foo } from './lib';\n", encoding="utf-8"
+        )
+        graph = DependencyGraph(str(tmp_path))
+        # The file-edge layer still works …
+        assert "app.js" in graph.dependents_of("lib.js")
+        # … but the symbol layer is empty for JS in PR-0.2 (documented
+        # limitation; per-language extractors are follow-up PRs).
+        assert graph.symbol_in_degree("foo").file_count == 0
+        assert graph.symbol_in_degree("foo").defining_files == ()
+
+    # ---- GREEN tests (regression guard on existing surface) ----
+
+    def test_G1_dependents_of_unchanged(self, py_graph):
+        # PR-0.2 must not regress file-level dependents_of.
+        assert py_graph.dependents_of("utils.py") == ["main.py"]
+
+    def test_G2_to_dict_backward_compatible(self, py_graph):
+        result = py_graph.to_dict()
+        # All v1 keys still present.
+        for key in ("project_root", "nodes", "edges", "node_count", "edge_count"):
+            assert key in result, f"existing key {key} dropped from to_dict()"
+        # New additive key is present and non-negative.
+        assert "symbol_index_size" in result
+        assert result["symbol_index_size"] >= 0
+
+    def test_G3_find_cycles_unchanged(self, py_graph):
+        # PY_PROJECT has an intentional cycle (used by TestCycleDetection).
+        cycles = py_graph.find_cycles()
+        assert isinstance(cycles, list)
+
+    def test_G4_no_self_imports_polluting_count(self, tmp_path):
+        # ``from . import sub`` resolves to ``sub.py`` AND emits
+        # ``names: ["sub"]``. The submodule-as-name guard in _build()
+        # must skip this; otherwise every file that does ``from . import
+        # sub`` would falsely count itself as a symbol-importer of every
+        # name in sub.py.
+        from tree_sitter_analyzer.project_graph import DependencyGraph
+
+        (tmp_path / "sub.py").write_text(
+            "def real_symbol():\n    pass\n", encoding="utf-8"
+        )
+        (tmp_path / "main.py").write_text("from . import sub\n", encoding="utf-8")
+        graph = DependencyGraph(str(tmp_path))
+
+        # ``sub`` should NOT be in the symbol importer index — it is
+        # the module handle, not a symbol from sub.py.
+        result = graph.symbol_in_degree("sub")
+        # ``sub`` is also the basename of sub.py, so no file should
+        # appear as a symbol-importer of the name "sub".
+        assert "main.py" not in result.importer_files
+
+
+# ============================================================
 # Cycle detection tests
 # ============================================================
 

--- a/tests/unit/test_symbol_extractors.py
+++ b/tests/unit/test_symbol_extractors.py
@@ -1,0 +1,195 @@
+"""Tests for ``tree_sitter_analyzer.symbol_extractors`` (PR-0.2).
+
+Covers the Python top-level def/class extractor that feeds
+``DependencyGraph._symbol_def_files`` and indirectly
+``DependencyGraph.symbol_in_degree``.
+
+The extractor's contract (also documented in the module docstring):
+
+1. **Top-level only.** Functions / classes nested inside other defs, ``if
+   __name__ == "__main__"`` blocks, or methods inside classes are NOT
+   counted — only the names a sibling module could ``from X import``.
+2. **Decorated definitions are unwrapped one level.** ``@decorator`` is
+   transparent for our purposes; the wrapped name is the symbol.
+3. **Failure modes are silent.** Unparseable file, missing language
+   support, OS-level read errors all return an empty set rather than
+   raising. Same contract as ``import_extractors.extract_imports_from_file``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tree_sitter_analyzer.symbol_extractors import (
+    extract_top_level_defs_from_file,
+)
+
+
+def _write(tmp_path: Path, body: str, name: str = "sample.py") -> str:
+    """Write ``body`` to ``<tmp_path>/<name>`` and return the absolute path."""
+
+    path = tmp_path / name
+    path.write_text(body, encoding="utf-8")
+    return str(path)
+
+
+class TestPythonTopLevel:
+    def test_simple_def_and_class(self, tmp_path: Path) -> None:
+        src = (
+            "def hello() -> str:\n"
+            "    return 'hi'\n"
+            "\n"
+            "class Greeter:\n"
+            "    def greet(self) -> None:\n"
+            "        pass\n"
+        )
+        names = extract_top_level_defs_from_file(_write(tmp_path, src), "python")
+        assert names == {"hello", "Greeter"}
+
+    def test_nested_def_is_excluded(self, tmp_path: Path) -> None:
+        # ``inner`` is defined inside ``outer`` — only ``outer`` is
+        # importable from elsewhere, so only ``outer`` should appear.
+        src = "def outer():\n    def inner():\n        return 1\n    return inner\n"
+        names = extract_top_level_defs_from_file(_write(tmp_path, src), "python")
+        assert names == {"outer"}
+
+    def test_class_methods_are_excluded(self, tmp_path: Path) -> None:
+        src = (
+            "class Service:\n"
+            "    def public_method(self):\n"
+            "        return 1\n"
+            "\n"
+            "    def _private(self):\n"
+            "        return 2\n"
+        )
+        names = extract_top_level_defs_from_file(_write(tmp_path, src), "python")
+        # The class is exported; its methods are not module-level symbols.
+        assert names == {"Service"}
+
+    def test_decorated_def_unwrapped(self, tmp_path: Path) -> None:
+        src = (
+            "from functools import lru_cache\n"
+            "\n"
+            "@lru_cache(maxsize=8)\n"
+            "def cached(x: int) -> int:\n"
+            "    return x * x\n"
+            "\n"
+            "@staticmethod\n"
+            "def static_helper():\n"  # invalid at module level but valid syntactically
+            "    pass\n"
+        )
+        names = extract_top_level_defs_from_file(_write(tmp_path, src), "python")
+        assert names == {"cached", "static_helper"}
+
+    def test_decorated_class_unwrapped(self, tmp_path: Path) -> None:
+        src = (
+            "from dataclasses import dataclass\n"
+            "\n"
+            "@dataclass(frozen=True)\n"
+            "class Point:\n"
+            "    x: int\n"
+            "    y: int\n"
+        )
+        names = extract_top_level_defs_from_file(_write(tmp_path, src), "python")
+        assert names == {"Point"}
+
+    def test_def_inside_if_main_is_excluded(self, tmp_path: Path) -> None:
+        # ``main`` lives inside ``if __name__ == "__main__":`` — it is
+        # NOT a top-level module symbol (it cannot be imported).
+        src = (
+            "def public_api():\n"
+            "    return 42\n"
+            "\n"
+            "if __name__ == '__main__':\n"
+            "    def main():\n"
+            "        public_api()\n"
+            "    main()\n"
+        )
+        names = extract_top_level_defs_from_file(_write(tmp_path, src), "python")
+        assert names == {"public_api"}
+
+    def test_empty_file_returns_empty_set(self, tmp_path: Path) -> None:
+        names = extract_top_level_defs_from_file(_write(tmp_path, ""), "python")
+        assert names == set()
+
+    def test_file_with_only_imports(self, tmp_path: Path) -> None:
+        src = "import os\nfrom pathlib import Path\n"
+        names = extract_top_level_defs_from_file(_write(tmp_path, src), "python")
+        assert names == set()
+
+    def test_unicode_identifiers(self, tmp_path: Path) -> None:
+        # Python 3 allows unicode identifiers; the byte-offset slicing
+        # in ``_node_text`` must handle this correctly.
+        src = "def 你好() -> str:\n    return 'hi'\n"
+        names = extract_top_level_defs_from_file(_write(tmp_path, src), "python")
+        assert names == {"你好"}
+
+    def test_multiple_decorators_still_unwrap_once(self, tmp_path: Path) -> None:
+        src = (
+            "import functools\n"
+            "\n"
+            "@functools.wraps(print)\n"
+            "@staticmethod\n"
+            "def deeply_decorated():\n"
+            "    pass\n"
+        )
+        names = extract_top_level_defs_from_file(_write(tmp_path, src), "python")
+        # Multiple stacked decorators still wrap a single function_definition
+        # at the innermost layer — extractor finds it.
+        assert names == {"deeply_decorated"}
+
+
+class TestNonPythonLanguages:
+    @pytest.mark.parametrize(
+        "language",
+        [
+            "javascript",
+            "typescript",
+            "go",
+            "rust",
+            "java",
+            "kotlin",
+            "swift",
+            "ruby",
+            "php",
+            "c",
+            "cpp",
+        ],
+    )
+    def test_non_python_returns_empty_set(self, tmp_path: Path, language: str) -> None:
+        # PR-0.2 ships Python-only; other languages are documented
+        # limitations — extractor returns empty set, not error.
+        names = extract_top_level_defs_from_file(
+            _write(tmp_path, "function foo() {}\n", name="sample.js"),
+            language,
+        )
+        assert names == set()
+
+    def test_unknown_language_returns_empty_set(self, tmp_path: Path) -> None:
+        names = extract_top_level_defs_from_file(
+            _write(tmp_path, "foo bar\n"), "klingon"
+        )
+        assert names == set()
+
+
+class TestFailureModes:
+    def test_missing_file_returns_empty_set(self) -> None:
+        names = extract_top_level_defs_from_file(
+            "/nonexistent/path/that/does/not/exist.py", "python"
+        )
+        assert names == set()
+
+    def test_syntactically_broken_python_returns_empty_set(
+        self, tmp_path: Path
+    ) -> None:
+        # Tree-sitter is error-tolerant — it parses broken Python into a
+        # tree containing ``ERROR`` nodes but still has a top-level
+        # structure. The extractor should harvest whatever defs it can
+        # find. Worst case: no defs found, empty set returned.
+        src = "def good():\n    pass\n\ndef bad(\n"  # unclosed paren
+        names = extract_top_level_defs_from_file(_write(tmp_path, src), "python")
+        # ``good`` should still be recoverable; ``bad`` might or might not
+        # be (parser-dependent). At minimum, no exception.
+        assert "good" in names or names == set()

--- a/tree_sitter_analyzer/project_graph.py
+++ b/tree_sitter_analyzer/project_graph.py
@@ -12,6 +12,7 @@ Key classes:
 import os
 from collections import defaultdict, deque
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -19,6 +20,27 @@ from .core.parser import Parser, ParseResult
 from .import_extractors import (
     walk_imports,
 )
+from .symbol_extractors import extract_top_level_defs_from_file
+
+
+@dataclass(frozen=True)
+class SymbolFanIn:
+    """Result type for :meth:`DependencyGraph.symbol_in_degree`.
+
+    ``file_count`` is the primary signal — distinct importing files,
+    deduplicated. ``importer_files`` carries the same set as a sorted
+    deterministic tuple so callers can render evidence lists without
+    re-querying. ``defining_files`` records every project file that
+    defines a symbol by this name; ``ambiguous`` is the convenience
+    flag for the >1-definition case (P4 will demote confidence when
+    set).
+    """
+
+    symbol: str
+    file_count: int
+    importer_files: tuple[str, ...]
+    defining_files: tuple[str, ...]
+    ambiguous: bool
 
 
 def _language_from_ext(file_path: str) -> str | None:
@@ -342,6 +364,21 @@ class DependencyGraph:
         self._edges: set[tuple[str, str]] = set()
         self._deps: dict[str, set[str]] = defaultdict(set)
         self._dependents: dict[str, set[str]] = defaultdict(set)
+
+        # PR-0.2: symbol-level fan-in index.
+        # ``_symbol_importers[name]`` = set of files that import a symbol
+        # with that name (deduplicated). Powers ``symbol_in_degree()``.
+        # ``_symbol_def_files[name]`` = set of files that define a symbol
+        # with that name. Lets the same query disambiguate when multiple
+        # files define a homonymous symbol.
+        # ``_symbol_importer_targets`` = which definition file each
+        # importer actually resolved to, for the ``defining_file=`` kwarg.
+        self._symbol_importers: dict[str, set[str]] = defaultdict(set)
+        self._symbol_def_files: dict[str, set[str]] = defaultdict(set)
+        self._symbol_importer_targets: dict[tuple[str, str], set[str]] = defaultdict(
+            set
+        )
+
         self._initialized = True
 
         self._build()
@@ -432,11 +469,20 @@ class DependencyGraph:
             except ValueError:
                 continue
 
-        # Parse each file and extract imports
+        # Parse each file and extract imports + top-level definitions.
+        # The symbol index lives alongside the file-edge index — same
+        # walk, no extra IO cost on the import side. See PR-0.2 design
+        # in .recon/pr-0-2-design.md for the rationale.
         for rel_path, abs_path in rel_to_abs.items():
             language = _language_from_ext(rel_path)
             if language is None:
                 continue
+
+            # Populate _symbol_def_files BEFORE the import pass so the
+            # ambiguity check in symbol_in_degree() is meaningful even
+            # if no other file imports this symbol yet.
+            for name in extract_top_level_defs_from_file(abs_path, language):
+                self._symbol_def_files[name].add(rel_path)
 
             raw_imports = extract_imports_from_file(abs_path, language)
             for imp in raw_imports:
@@ -445,6 +491,25 @@ class DependencyGraph:
                     self._edges.add((rel_path, resolved))
                     self._deps[rel_path].add(resolved)
                     self._dependents[resolved].add(rel_path)
+
+                    # Symbol-level fan-in: every named import becomes a
+                    # (symbol, importer) pair. Guards:
+                    #  (a) ``resolved in self._nodes`` (already true here)
+                    #  (b) skip empty names (JS bare imports yield [])
+                    #  (c) skip submodule-as-name imports: ``from . import
+                    #      sub`` lists ``sub`` in ``names`` AND resolves to
+                    #      ``sub.py`` — so ``name`` equals the resolved
+                    #      file's basename. That ``sub`` is the module
+                    #      handle, not an imported symbol; counting it
+                    #      would falsely treat any file with a sibling
+                    #      ``sub`` import as a symbol-importer of every
+                    #      definition in ``sub.py``.
+                    resolved_stem = Path(resolved).stem
+                    for name in imp.get("names", ()) or ():
+                        if not name or name == resolved_stem:
+                            continue
+                        self._symbol_importers[name].add(rel_path)
+                        self._symbol_importer_targets[(name, rel_path)].add(resolved)
 
     def _resolve_to_project_file(
         self,
@@ -485,6 +550,47 @@ class DependencyGraph:
         """Return files that depend on the given file."""
         return sorted(self._dependents.get(file_rel, set()))
 
+    def symbol_in_degree(
+        self,
+        symbol: str,
+        *,
+        defining_file: str | None = None,
+    ) -> SymbolFanIn:
+        """Return how many project files import a symbol by name.
+
+        Counts **distinct importer files**, not import edges — a file
+        with two ``from X import Foo`` lines still counts as 1.
+
+        ``defining_file`` (optional) narrows the count to importers whose
+        resolved import target was that exact file. Use this when the
+        symbol name is defined in multiple files (``ambiguous=True`` in
+        the default response) and the caller needs the precise fan-in
+        for one specific definition.
+
+        Returns ``SymbolFanIn(symbol, 0, (), (), False)`` for unknown
+        symbols rather than raising — same contract as ``dependents_of``
+        for unknown files.
+        """
+
+        importer_set = self._symbol_importers.get(symbol, set())
+
+        if defining_file is not None:
+            importer_set = {
+                importer
+                for importer in importer_set
+                if defining_file
+                in self._symbol_importer_targets.get((symbol, importer), set())
+            }
+
+        defining_set = self._symbol_def_files.get(symbol, set())
+        return SymbolFanIn(
+            symbol=symbol,
+            file_count=len(importer_set),
+            importer_files=tuple(sorted(importer_set)),
+            defining_files=tuple(sorted(defining_set)),
+            ambiguous=len(defining_set) > 1,
+        )
+
     def find_cycles(self) -> list[list[str]]:
         """Detect circular dependencies using DFS."""
         cycles: list[list[str]] = []
@@ -520,6 +626,10 @@ class DependencyGraph:
             "edges": [list(e) for e in self.edges()],
             "node_count": len(self._nodes),
             "edge_count": len(self._edges),
+            # PR-0.2 additive: number of distinct symbol names with at
+            # least one project-internal importer. Additive only;
+            # existing keys unchanged.
+            "symbol_index_size": len(self._symbol_importers),
         }
 
 

--- a/tree_sitter_analyzer/symbol_extractors.py
+++ b/tree_sitter_analyzer/symbol_extractors.py
@@ -1,0 +1,166 @@
+"""Top-level symbol-name extraction per source file.
+
+Sister module to :mod:`tree_sitter_analyzer.import_extractors`. Where
+``import_extractors`` answers *"what does this file import?"*, this module
+answers *"what top-level definitions does this file export?"* — the
+second half of the data needed by
+:meth:`DependencyGraph.symbol_in_degree`.
+
+Scope (PR-0.2): Python only. Other languages return an empty set as a
+graceful no-op; per-language extractors land in follow-up PRs.
+
+Anti-scope:
+* Does NOT extract methods (top-level only — class members are
+  per-definition resolved elsewhere).
+* Does NOT track ``__all__``, visibility, or export signal — that is
+  P4's scoring concern.
+* Does NOT inspect aliases, wildcard re-exports, or conditional defs.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .core.parser import Parser, ParseResult
+
+logger = logging.getLogger(__name__)
+
+
+# Tree-sitter Python node types — captured here as constants rather
+# than imported from a generated grammar header so this module is
+# resilient to grammar version churn (tree-sitter-python has been
+# stable on these names since 0.20).
+_PY_FUNCTION_DEF = "function_definition"
+_PY_CLASS_DEF = "class_definition"
+_PY_DECORATED_DEF = "decorated_definition"
+
+
+def extract_top_level_defs_from_file(file_path: str, language: str) -> set[str]:
+    """Return top-level function and class names defined in ``file_path``.
+
+    For unsupported languages (anything but Python in PR-0.2), returns an
+    empty set without raising — callers should treat empty as
+    "language not supported", not as "file has no defs".
+
+    The implementation walks ONLY the module root's direct children, so
+    nested functions / functions inside ``if __name__ == "__main__"`` /
+    methods inside classes are NOT counted. This matches the
+    ``symbol_in_degree`` contract: we count things that other files can
+    import, which means module-level top-line names.
+    """
+
+    if language != "python":
+        return set()
+
+    try:
+        parser = Parser()
+        result: ParseResult = parser.parse_file(file_path, language)
+    except Exception:  # noqa: BLE001 — same failure-mode contract as extract_imports_from_file
+        return set()
+
+    if not result.success or result.tree is None:
+        return set()
+
+    root = result.tree.root_node
+    return _python_top_level_names(root, result.source_code)
+
+
+def _python_top_level_names(root_node: Any, source: bytes | str) -> set[str]:
+    """Collect names of top-level ``def`` and ``class`` declarations.
+
+    Handles three shapes:
+
+    * Bare ``def foo(): ...`` / ``class Foo: ...`` directly under module.
+    * Decorated ``@decorator\\ndef foo(): ...`` — wrapped in
+      ``decorated_definition``; we unwrap one level.
+
+    Decorators with arbitrary expressions inside (``@some.attr.lookup``)
+    are not relevant — only the wrapped function/class name matters.
+    """
+
+    names: set[str] = set()
+
+    children = getattr(root_node, "children", None) or ()
+    for child in children:
+        node_type = getattr(child, "type", None)
+        if node_type in (_PY_FUNCTION_DEF, _PY_CLASS_DEF):
+            name = _name_of_def(child, source)
+            if name:
+                names.add(name)
+        elif node_type == _PY_DECORATED_DEF:
+            inner = _decorated_inner_def(child)
+            if inner is not None:
+                name = _name_of_def(inner, source)
+                if name:
+                    names.add(name)
+
+    return names
+
+
+def _decorated_inner_def(decorated_node: Any) -> Any | None:
+    """Return the wrapped ``function_definition`` / ``class_definition``.
+
+    A ``decorated_definition`` node has one or more ``decorator`` children
+    followed by exactly one definition child. Returns ``None`` if the
+    expected definition child is missing (degenerate AST).
+    """
+
+    children = getattr(decorated_node, "children", None) or ()
+    for child in children:
+        if getattr(child, "type", None) in (_PY_FUNCTION_DEF, _PY_CLASS_DEF):
+            return child
+    return None
+
+
+def _name_of_def(def_node: Any, source: bytes | str) -> str | None:
+    """Extract the identifier name from a function/class definition node.
+
+    Tree-sitter exposes the name child via the ``name`` field. We use the
+    ``child_by_field_name`` API when available (libtree-sitter ≥0.20) and
+    fall back to scanning children for an ``identifier`` node otherwise.
+    """
+
+    name_node = None
+    if hasattr(def_node, "child_by_field_name"):
+        try:
+            name_node = def_node.child_by_field_name("name")
+        except Exception:  # noqa: BLE001
+            name_node = None
+
+    if name_node is None:
+        for child in getattr(def_node, "children", None) or ():
+            if getattr(child, "type", None) == "identifier":
+                name_node = child
+                break
+
+    if name_node is None:
+        return None
+
+    return _node_text(name_node, source)
+
+
+def _node_text(node: Any, source: bytes | str) -> str | None:
+    """Return the literal source text of a tree-sitter node."""
+
+    start = getattr(node, "start_byte", None)
+    end = getattr(node, "end_byte", None)
+    if start is None or end is None or start >= end:
+        return None
+
+    if isinstance(source, str):
+        # tree-sitter byte offsets are over the UTF-8 encoded source;
+        # slicing a ``str`` by byte offsets is wrong for non-ASCII.
+        # Re-encode once — this only happens for the small slice that
+        # actually holds the identifier name, so the cost is negligible.
+        encoded = source.encode("utf-8")
+    else:
+        encoded = source
+
+    try:
+        return encoded[start:end].decode("utf-8")
+    except (UnicodeDecodeError, IndexError):
+        return None
+
+
+__all__ = ["extract_top_level_defs_from_file"]


### PR DESCRIPTION
## Summary

Adds the symbol-level fan-in primitive needed by **P4 (entry-point ranking honesty)** in the v1.15 code-map improvement PRD.

The current `_find_entry_points` in `codegraph_overview_tool.py` keys off `CallGraph._callers` — function-level call edges, not import-graph fan-in. The recon found two problems:

1. **Conflates 'no callers' with 'true entry point'** — purely inbound symbols (like a class imported by 5 files but never called within a function body) are missed.
2. **Collides with `dead_code` detection** — symbols with zero callers appear in BOTH `entry_points` and `dead_code` lists.

This PR ships **only the primitive**; P4's scoring formula + consumer integration land separately.

## API

```python
@dataclass(frozen=True)
class SymbolFanIn:
    symbol: str
    file_count: int                       # primary signal
    importer_files: tuple[str, ...]       # sorted, deduped
    defining_files: tuple[str, ...]
    ambiguous: bool                       # len(defining_files) > 1

class DependencyGraph:
    def symbol_in_degree(
        self,
        symbol: str,
        *,
        defining_file: str | None = None, # disambiguator
    ) -> SymbolFanIn: ...
```

## Design rationale (locked in `.recon/pr-0-2-design.md`)

- **Method on DependencyGraph** (not free function) — state lives with the graph cache; eviction is automatic via `_cache_key_for` fingerprint.
- **Rich frozen dataclass** (not bare int) — P4 needs both `file_count` AND `importer_files` (for evidence rendering).
- **`defining_file` kwarg** — disambiguates when multiple files define the same symbol name.
- **`file_count = len(deduped set)`**, not edge count — repeated `from X import Foo` in one file still counts as 1 importer.
- **Populated in the existing `_build()` walk** — zero new IO, no `.ast-cache/index.db` coupling, no networkx churn.

## Scope guardrails

- ✅ Python only in PR-0.2. Other languages return empty set as documented limitation.
- ✅ Additive change to `project_graph.py` — `dependents_of()` / `find_cycles()` / `BlastRadius` / `to_dict()` existing keys all unchanged (G1-G4 regression guards).
- ✅ Submodule-as-name guard: `from . import sub` resolving to `sub.py` doesn't falsely register `sub` as a symbol importer.
- ❌ No `__all__` / visibility / export-signal detection (that's P4's scoring concern).
- ❌ No alias tracking, wildcard imports, or transitive re-exports.

## Test plan

- [x] 24 new `symbol_extractors` tests (Python top-level def/class extractor; decorator unwrapping; nested-def exclusion; unicode identifiers)
- [x] 13 new `TestSymbolInDegree` cases — R1-R9 spec coverage (simple count, dedup, ambiguous, defining_file filter, relative import, stdlib non-indexing, JS empty symbols) + G1-G4 regression guards
- [x] 0 regression on the 251-file change-impact focused suite (150 tests across 8 affected modules)
- [x] Pre-commit hooks: ruff lint + ruff format + mypy + bandit + detect-secrets + pyupgrade all pass
- [ ] Manual macOS gate-check (CLAUDE.md §2.2 requirement for `project_graph.py` foundational changes) — covered by full unit suite passing on darwin

## Files touched

| Type | Path |
|---|---|
| ➕ new | `tree_sitter_analyzer/symbol_extractors.py` (~170 lines) |
| ➕ new | `tests/unit/test_symbol_extractors.py` (~195 lines, 24 tests) |
| ✏️ edit | `tree_sitter_analyzer/project_graph.py` (additive: dataclass + 3 state dicts + 1 method + 1 `to_dict` key) |
| ✏️ edit | `tests/unit/test_project_graph.py` (appended `TestSymbolInDegree` class, 13 tests) |

## Unblocks

- **P4** — entry-point ranking honesty: `entry_score = α·log(1+symbol_in_degree(sym).file_count) + β·is_public + γ·has_main_signature + δ·export_signal - dead_penalty·dead_overlap`