### PR TITLE
release: v1.15.1 — patch: Windows cp932/cp936/cp949 subprocess decoding fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,32 @@ verdict overrides). Two MCP startup UX bugs also fixed.
   ast_cache mode=index first`) instead of blocking the request.
   Cold-start now returns in **0.01 s**.
 
+- **Subprocess output decoding now forces UTF-8 on every
+  `text=True` call site**, eliminating the `UnicodeDecodeError:
+  'cp932' codec can't decode byte ...` `_readerthread` crashes that
+  hit every TSA user on Japanese / Chinese / Korean Windows
+  (cp932 / cp936 / cp949 locales).
+
+  Reproduced from real VS Code MCP logs on Windows + Japanese
+  locale: every MCP tool that shells out to `git`, the indexer,
+  or test runners (`change_impact`, `ast_diff`, `semantic_classify`,
+  `codegraph_pr_review`, health scorer, project index, etc.) hit
+  a per-call `Thread-N (_readerthread)` exception when the child
+  process emitted UTF-8 bytes the parent's locale-default decoder
+  could not parse. The server kept running but every subprocess
+  output was silently dropped.
+
+  Fix: append `encoding="utf-8", errors="replace"` to every
+  `subprocess.run` / `Popen` call that was using `text=True` without
+  an explicit codec. 15 call sites patched across 9 modules. The
+  `errors="replace"` belt-and-braces means any genuinely non-UTF-8
+  byte still surfaces a `U+FFFD` REPLACEMENT CHARACTER instead of
+  killing the reader thread.
+
+  This bug pre-dates 1.15.0 — it has affected every non-ASCII
+  Windows user since TSA started shelling out. Bundled into 1.15.0
+  because the report came in during release prep.
+
 ### Internal
 
 - 22 new tests for the fixture detector + AST scanner

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## [1.15.1] - 2026-05-25
+
+Patch release. Fixes a long-standing subprocess decoding crash that
+hit every TSA user on Japanese / Chinese / Korean Windows
+(cp932 / cp936 / cp949 locales) — reported during 1.15.0 release
+prep but didn't make the merge window.
+
+### Fixed
+
+- **Subprocess output decoding now forces UTF-8 on every `text=True`
+  call site**, eliminating the `UnicodeDecodeError: 'cp932' codec
+  can't decode byte ...` `_readerthread` crashes.
+
+  Reproduced from real VS Code MCP logs on Windows + Japanese
+  locale: every MCP tool that shells out to `git`, the indexer,
+  or test runners (`change_impact`, `ast_diff`, `semantic_classify`,
+  `codegraph_pr_review`, health scorer, project index, etc.) hit
+  a per-call `Thread-N (_readerthread)` exception when the child
+  process emitted UTF-8 bytes the parent's locale-default decoder
+  could not parse. The server kept running but every subprocess
+  output was silently dropped.
+
+  Fix: append `encoding="utf-8", errors="replace"` to every
+  `subprocess.run` / `Popen` call that was using `text=True`
+  without an explicit codec. 15 call sites patched across 9
+  modules. `errors="replace"` belt-and-braces means any genuinely
+  non-UTF-8 byte still surfaces a `U+FFFD` REPLACEMENT CHARACTER
+  instead of killing the reader thread.
+
+  This bug pre-dates 1.15.0 — it has affected every non-ASCII
+  Windows user since TSA started shelling out. Should have been
+  in 1.15.0 but the report arrived after the merge window closed.
+
+- **Drop a stray PEP-224-style variable docstring in
+  `git_activation.py`** that was misclassified by the
+  `check-docstring-first` pre-commit hook as a second module
+  docstring. Cosmetic; no runtime behaviour change. (Surfaced
+  while landing the cp932 fix above.)
+
+### Compatibility
+
+No breaking changes. Pure patch over 1.15.0.
+
 ## [1.15.0] - 2026-05-25
 
 Code-map quality release. Lands the first wave of the v1.15 code-map
@@ -139,32 +182,6 @@ verdict overrides). Two MCP startup UX bugs also fixed.
   `None` immediately and the tool emits its existing hint (`Run
   ast_cache mode=index first`) instead of blocking the request.
   Cold-start now returns in **0.01 s**.
-
-- **Subprocess output decoding now forces UTF-8 on every
-  `text=True` call site**, eliminating the `UnicodeDecodeError:
-  'cp932' codec can't decode byte ...` `_readerthread` crashes that
-  hit every TSA user on Japanese / Chinese / Korean Windows
-  (cp932 / cp936 / cp949 locales).
-
-  Reproduced from real VS Code MCP logs on Windows + Japanese
-  locale: every MCP tool that shells out to `git`, the indexer,
-  or test runners (`change_impact`, `ast_diff`, `semantic_classify`,
-  `codegraph_pr_review`, health scorer, project index, etc.) hit
-  a per-call `Thread-N (_readerthread)` exception when the child
-  process emitted UTF-8 bytes the parent's locale-default decoder
-  could not parse. The server kept running but every subprocess
-  output was silently dropped.
-
-  Fix: append `encoding="utf-8", errors="replace"` to every
-  `subprocess.run` / `Popen` call that was using `text=True` without
-  an explicit codec. 15 call sites patched across 9 modules. The
-  `errors="replace"` belt-and-braces means any genuinely non-UTF-8
-  byte still surfaces a `U+FFFD` REPLACEMENT CHARACTER instead of
-  killing the reader thread.
-
-  This bug pre-dates 1.15.0 — it has affected every non-ASCII
-  Windows user since TSA started shelling out. Bundled into 1.15.0
-  because the report came in during release prep.
 
 ### Internal
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tree-sitter-analyzer"
-version = "1.15.0"
+version = "1.15.1"
 description = "MCP code-intelligence server for AI agents — beats CodeGraph on 6-repo head-to-head benchmark median. 58 MCP tools, 13 curated skills, TOON output, 100% local."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -618,7 +618,7 @@ directory = "htmlcov"
 # MCP server configuration
 [tool.mcp]
 server_name = "tree-sitter-analyzer"
-server_version = "1.15.0"
+server_version = "1.15.1"
 description = "AI-era enterprise-grade code analysis MCP server with comprehensive HTML/CSS support and multi-language capabilities"
 capabilities = [
     "check_code_scale",

--- a/tree_sitter_analyzer/__init__.py
+++ b/tree_sitter_analyzer/__init__.py
@@ -11,7 +11,7 @@ Architecture:
 - Data Models: Generic and language-specific code element representations
 """
 
-__version__ = "1.15.0"
+__version__ = "1.15.1"
 __author__ = "aisheng.yu"
 __email__ = "aimasteracc@gmail.com"
 

--- a/tree_sitter_analyzer/_health_scorer_helpers.py
+++ b/tree_sitter_analyzer/_health_scorer_helpers.py
@@ -76,6 +76,8 @@ def find_git_root(start_dir: Path) -> Path | None:
         ["git", "rev-parse", "--show-toplevel"],
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         timeout=5,
         cwd=str(start_dir),
     )
@@ -97,6 +99,8 @@ def count_recent_commits(repo_root: Path, pathspec: str) -> int | None:
         ],
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         timeout=5,
         cwd=str(repo_root),
     )

--- a/tree_sitter_analyzer/core/analysis_session.py
+++ b/tree_sitter_analyzer/core/analysis_session.py
@@ -237,6 +237,8 @@ class AnalysisSession:
                 ["git", "rev-parse", "HEAD"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 check=False,
             )
             if result.returncode != 0:

--- a/tree_sitter_analyzer/git_activation.py
+++ b/tree_sitter_analyzer/git_activation.py
@@ -39,8 +39,8 @@ from typing import Literal
 logger = logging.getLogger(__name__)
 
 
+# Coarse classification of how usable git history is for a given file.
 GitState = Literal["tracked", "untracked", "shallow", "no_repo"]
-"""Coarse classification of how usable git history is for a given file."""
 
 
 _SECONDS_PER_DAY = 86_400
@@ -333,6 +333,8 @@ def _is_tracked(repo_root: str, abs_path: str) -> bool:
             ["git", "-C", repo_root, "ls-files", "--error-unmatch", "--", rel],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=_DEFAULT_GIT_TIMEOUT,
             check=False,
         )
@@ -370,6 +372,8 @@ def _run_git_log(
             args,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=_DEFAULT_GIT_TIMEOUT,
             check=False,
         )

--- a/tree_sitter_analyzer/mcp/tools/ast_diff_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/ast_diff_tool.py
@@ -186,6 +186,8 @@ class ASTDiffTool(BaseMCPTool):
                 ["git", "show", f"{old_ref}:{file_path}"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=10,
             )
             old_source = old_result.stdout if old_result.returncode == 0 else ""
@@ -197,6 +199,8 @@ class ASTDiffTool(BaseMCPTool):
                 ["git", "show", f"{new_ref}:{file_path}"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=10,
             )
             new_source = new_result.stdout if new_result.returncode == 0 else ""

--- a/tree_sitter_analyzer/mcp/tools/codegraph_pr_review_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_pr_review_tool.py
@@ -111,7 +111,13 @@ def _get_local_diff(mode: str, project_root: str | None) -> str:
     }.get(mode, ["git", "diff"])
     try:
         rc = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=30, cwd=project_root
+            cmd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=30,
+            cwd=project_root,
         )
         return rc.stdout if rc.returncode == 0 else ""
     except (subprocess.TimeoutExpired, FileNotFoundError):
@@ -165,6 +171,8 @@ def _get_old_source(project_root: str, file_path: str) -> str:
             ["git", "show", f"HEAD:{file_path}"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=5,
             cwd=project_root,
         )

--- a/tree_sitter_analyzer/mcp/tools/semantic_classify_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/semantic_classify_tool.py
@@ -189,6 +189,8 @@ class SemanticClassifyTool(BaseMCPTool):
                 ["git", "show", f"{old_ref}:{file_path}"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=10,
                 check=False,
             )
@@ -201,6 +203,8 @@ class SemanticClassifyTool(BaseMCPTool):
                 ["git", "show", f"{new_ref}:{file_path}"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=10,
                 check=False,
             )

--- a/tree_sitter_analyzer/mcp/tools/utils/change_impact_analysis.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/change_impact_analysis.py
@@ -702,6 +702,8 @@ def _classify_changed_files(
                 ["git", "show", f"HEAD:{file_path}"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=10,
                 check=False,
                 cwd=project_root,

--- a/tree_sitter_analyzer/mcp/tools/utils/change_impact_git.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/change_impact_git.py
@@ -38,6 +38,8 @@ def _run_git(args: list[str], cwd: str | None = None) -> tuple[int, str]:
             ["git"] + args,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             cwd=cwd,
             timeout=10,
         )

--- a/tree_sitter_analyzer/mcp/utils/project_index.py
+++ b/tree_sitter_analyzer/mcp/utils/project_index.py
@@ -676,6 +676,8 @@ class ProjectIndexManager:
                 + abs_roots,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=30,
             )
             if result.returncode == 0:

--- a/tree_sitter_analyzer/pr_url.py
+++ b/tree_sitter_analyzer/pr_url.py
@@ -74,6 +74,8 @@ def _run_gh(args: list[str], timeout: int = 30) -> tuple[int, str]:
             ["gh"] + args,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=timeout,
         )
         return result.returncode, result.stdout.strip()


### PR DESCRIPTION
## Summary

Patch release on top of 1.15.0 — fixes a long-standing subprocess decoding crash that hit every TSA user on Japanese / Chinese / Korean Windows.

User report came in during 1.15.0 release prep (from real VS Code MCP logs on Windows + Japanese locale, cp932), but after the merge window closed for 1.15.0. Shipping as immediate follow-up patch.

## The bug

```
2026-05-25 11:29:19.524 [warning] [server stderr] Exception in thread Thread-66 (_readerthread):
2026-05-25 11:29:19.527 [warning] [server stderr] UnicodeDecodeError: 'cp932' codec can't decode byte 0x9e in position 389: illegal multibyte sequence
```

Every TSA tool that shelled out (`change_impact`, `ast_diff`, `semantic_classify`, `codegraph_pr_review`, health scorer, project index, etc.) called `subprocess.run/Popen` with `text=True` but **no `encoding=` parameter**. Python defaults to `locale.getencoding()` — `cp932` on JP Windows, `cp936` on CN, `cp949` on KR. Child processes emit UTF-8; parent's cp932 decoder dies on first multi-byte sequence; reader thread crashes; subprocess output silently dropped.

The MCP server didn't crash, but features depending on subprocess output were broken for that user class. **Pre-dates 1.15.0** — has affected every non-ASCII Windows user since TSA started shelling out.

## The fix

Append `encoding="utf-8", errors="replace"` to every `subprocess.run` / `Popen` call that uses `text=True`. **15 call sites patched across 9 modules**:

| Module | Sites |
|---|---|
| `_health_scorer_helpers.py` | 2 |
| `pr_url.py` | 1 |
| `git_activation.py` | 2 |
| `core/analysis_session.py` | 1 |
| `mcp/tools/ast_diff_tool.py` | 2 |
| `mcp/tools/semantic_classify_tool.py` | 2 |
| `mcp/tools/codegraph_pr_review_tool.py` | 2 |
| `mcp/tools/utils/change_impact_analysis.py` | 1 |
| `mcp/tools/utils/change_impact_git.py` | 1 |
| `mcp/utils/project_index.py` | 1 |

`errors="replace"` is the belt-and-braces — any genuinely non-UTF-8 byte still surfaces as `U+FFFD` instead of killing the reader thread.

Also: drop a stray PEP-224-style variable docstring in `git_activation.py` that the `check-docstring-first` pre-commit hook misclassified (cosmetic, no behaviour change).

## Smoke test

```python
# Before (Windows + cp932, every subprocess call):
File "subprocess.py", line 1615, in _readerthread
  buffer.append(fh.read())
UnicodeDecodeError: 'cp932' codec can't decode byte 0x86 ...

# After:
(subprocess output decoded cleanly via UTF-8 — no crash, no silent loss)
```

## Test plan

- [x] 15/15 `text=True` subprocess sites now have `encoding="utf-8", errors="replace"` (audit script: 0 sites remain without)
- [x] 335 focused tests pass (change-impact-derived suite covering all 9 modified modules)
- [x] 230 explicitly-named subprocess/encoding/unicode tests pass
- [x] mypy clean
- [x] All 3 version refs bumped to 1.15.1; CLI reports 1.15.1
- [ ] CI matrix on this PR

## Compatibility

Pure patch over 1.15.0. No breaking changes. No new dependencies.