### PR TITLE
fix(logging): perf logger inherits root level + propagation off (kills MCP client log spam)

### DIFF
--- a/tests/unit/utils/test_logging.py
+++ b/tests/unit/utils/test_logging.py
@@ -671,10 +671,22 @@ class TestCreatePerformanceLogger:
         logger = create_performance_logger("test_perf_handler")
         assert len(logger.handlers) > 0
 
-    def test_create_performance_logger_level(self):
-        """测试性能日志器级别"""
+    def test_create_performance_logger_inherits_root_level(self):
+        """Perf logger inherits root level (no hard-coded DEBUG).
+
+        Previously this test asserted the perf logger was hard-pinned
+        to DEBUG, which forced every TSA tool call to spew a
+        ``PERF -`` line to stderr regardless of the operator's
+        ``LOG_LEVEL`` configuration — and the record propagated up to
+        root, producing a second duplicate line. The fix makes the
+        level inherit (so ``LOG_LEVEL`` controls visibility) and
+        turns propagation off (so we never get a duplicate).
+        """
         logger = create_performance_logger("test_perf_level")
-        assert logger.level == logging.DEBUG
+        # NOTSET means "inherit from parent" — the contract we want.
+        assert logger.level == logging.NOTSET
+        # propagate=False is the duplicate-suppression invariant.
+        assert logger.propagate is False
 
 
 class TestSetupPerformanceLogger:

--- a/tree_sitter_analyzer/utils/logging.py
+++ b/tree_sitter_analyzer/utils/logging.py
@@ -197,7 +197,28 @@ def safe_print(message: str | None, level: str = "info", quiet: bool = False) ->
 
 
 def create_performance_logger(name: str) -> logging.Logger:
-    """Create performance-focused logger"""
+    """Create performance-focused logger.
+
+    Two important invariants — observed as duplicate stderr noise in
+    real VS Code MCP client logs (every tool call produced two lines:
+    one ``PERF -`` line from this logger's handler, plus one
+    ``tree_sitter_analyzer.performance - DEBUG -`` line because the
+    record propagated up to the root logger):
+
+    1. **No hard-coded level.** We let the logger inherit the
+       configured level from the root logger (default ``WARNING`` via
+       :func:`resolve_configured_log_level`). Operators who want
+       per-call timings opt in via ``LOG_LEVEL=DEBUG``. Hard-coding
+       ``DEBUG`` here ignored that knob and emitted timings to every
+       MCP client log regardless of configuration.
+
+    2. **Propagation off.** Even when the operator does set
+       ``LOG_LEVEL=DEBUG``, the same event must not be logged twice
+       — once formatted as ``PERF -`` here, once again upstream by
+       the root logger's standard formatter. Setting
+       ``propagate = False`` prevents the double-log without
+       suppressing anything when the level is actually enabled.
+    """
     perf_logger = logging.getLogger(f"{name}.performance")
 
     if not perf_logger.handlers:
@@ -205,7 +226,9 @@ def create_performance_logger(name: str) -> logging.Logger:
         formatter = logging.Formatter("%(asctime)s - PERF - %(message)s")
         handler.setFormatter(formatter)
         perf_logger.addHandler(handler)
-        perf_logger.setLevel(logging.DEBUG)  # Change to DEBUG level
+        # Inherit level from root logger; stop propagation to root so
+        # we don't get a second formatted copy of every PERF record.
+        perf_logger.propagate = False
 
     return perf_logger
 


### PR DESCRIPTION
## Summary

Every TSA tool call printed **two stderr lines** that VS Code MCP and other clients render as `[warning]`:

```
2026-05-25 12:07:20,242 - PERF - analyze_java: 0.0171s
2026-05-25 12:07:20,242 - tree_sitter_analyzer.performance - DEBUG - analyze_java: 0.0171s
```

A 100-call session produced ~200 lines of cosmetic log noise.

## Root causes

`create_performance_logger()` in `tree_sitter_analyzer/utils/logging.py:199`:

1. **Hard-coded `setLevel(logging.DEBUG)`** — ignored the operator's `LOG_LEVEL` env var. Every tool call emitted a PERF line regardless of configuration.
2. **No `propagate = False`** — when level *was* enabled, the same record propagated up to root logger and was re-formatted there, producing a duplicate line.

## Fix

```diff
- perf_logger.setLevel(logging.DEBUG)
+ perf_logger.propagate = False
```

After:

| Configuration | Lines per tool call |
|---|---|
| Default (`LOG_LEVEL` unset → root WARNING) | **0** (was 2) |
| `LOG_LEVEL=DEBUG` | **1** (was 2 — duplicate eliminated) |

## Test plan

- [x] 131/131 logging suite tests pass
- [x] Updated contract test `test_create_performance_logger_inherits_root_level` asserting new invariants (level=NOTSET, propagate=False)
- [x] mypy clean
- [x] Empirical: in-process test confirms 0 stderr lines emitted at default WARNING level (was emitting `PERF - analyze_java: ...`)
- [x] No behaviour change for any code path that does not call `log_performance`

## Release plan

Targets `develop` — will ship in the next batch release (v1.16.0 or v1.15.2 if bundled with other patches). Not urgent enough to warrant an immediate patch release after v1.15.1 — cosmetic noise, no functional impact.