### PR TITLE
feat(benchmarks): add CodeGraph comparison harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -297,6 +297,13 @@ tree-sitter-*/
 # Benchmark and performance files
 benchmark_results/
 performance_data/
+.benchmark-repos/
+benchmarks/codegraph_compare/results/raw/
+benchmarks/codegraph_compare/results/runs.jsonl
+benchmarks/codegraph_compare/results/evals.jsonl
+benchmarks/codegraph_compare/results/summary.md
+benchmarks/codegraph_compare/results/summary.csv
+benchmarks/codegraph_compare/results/prepared_repos.json
 
 # Local configuration files
 local_config.py

--- a/benchmarks/codegraph_compare/README.md
+++ b/benchmarks/codegraph_compare/README.md
@@ -1,0 +1,125 @@
+# CodeGraph Comparison Benchmark
+
+Measures answer quality, token cost, and latency across three code-intelligence approaches on real open-source repositories:
+
+| Arm | Tool(s) | Index |
+|-----|---------|-------|
+| `native-only` | grep + file reads | none |
+| `codegraph-warm` | CodeGraph MCP | pre-built |
+| `codegraph-cold` | CodeGraph MCP | built at query time |
+| `tsa-warm` | tree-sitter-analyzer | pre-built |
+| `tsa-cold` | tree-sitter-analyzer | built at query time |
+
+---
+
+## Directory Structure
+
+```
+benchmarks/codegraph_compare/
+├── README.md           — this file
+├── schemas.py          — Pydantic v2 dataclasses (RunRecord, EvalRecord, …)
+├── repos.yaml          — 7 pinned repositories
+├── arms.yaml           — 5 treatment arms
+├── adapters/           — one adapter module per tool
+├── prompts/            — question bank (QuestionSpec YAML files per repo)
+├── repo_prep.py        — clone + pin + index build script
+└── results/            — run records, eval records, transcripts
+```
+
+---
+
+## Quick Start
+
+```bash
+# 1. Prepare repos (clone at pinned SHA, optionally pre-build indexes)
+uv run python benchmarks/codegraph_compare/repo_prep.py --repos repos.yaml
+
+# 2. Run the benchmark (smoke = 1 repo × 1 question × 1 repeat)
+uv run python -m benchmarks.codegraph_compare.runner \
+    --repos repos.yaml --arms arms.yaml \
+    --phase smoke --repeats 1
+
+# 3. Run full pilot (1 repo × all questions × 4 repeats)
+uv run python -m benchmarks.codegraph_compare.runner \
+    --repos repos.yaml --arms arms.yaml \
+    --phase pilot --repeats 4
+
+# 4. Evaluate answers (LLM judge, writes EvalRecord JSONL)
+uv run python -m benchmarks.codegraph_compare.evaluator \
+    --runs results/runs.jsonl --out results/evals.jsonl
+
+# 5. Print summary table
+uv run python -m benchmarks.codegraph_compare.analyze \
+    --runs results/runs.jsonl --evals results/evals.jsonl
+```
+
+---
+
+## Fairness Rules
+
+These rules are enforced by the harness. Violating any of them invalidates a run.
+
+1. **Pinned commits** — all repos use a fixed SHA from `repos.yaml`; no `HEAD`-tracking.
+2. **Same model for all arms** — the Claude model ID is a single config value applied uniformly.
+3. **Identical question text** — each arm receives the exact same `prompt` string from `QuestionSpec`.
+4. **Minimum 4 repeats** — the pilot and full phases require `--repeats 4` or higher; the summary drops any arm with fewer.
+5. **Report median, not best** — `overall`, `elapsed_seconds`, and `total_tokens` are summarized as median across repeats.
+6. **Cold and warm reported separately** — arms with `index_mode: cold` are never averaged with `index_mode: warm`; they form separate columns in the summary table.
+7. **Index build time excluded from warm query time** — `elapsed_seconds` in a warm run begins after the index is confirmed ready.
+8. **Flag low-quality answers** — any run with `EvalRecord.overall < 2.5` is marked `LOW_QUALITY` in the report even if it was token-efficient.
+9. **Auto-penalize phantom citations** — citations to files that do not exist in the pinned repo reduce `citation_quality` automatically before human/LLM review.
+10. **No silent drops** — timeouts and exceptions are recorded as `RunRecord` entries with `error` set; they appear in the report as `FAILED` rather than being omitted.
+
+---
+
+## Warm vs Cold Index
+
+| | Warm | Cold |
+|-|------|------|
+| Index state at query time | Already built and on disk | Built from scratch during the timed run |
+| What is measured | Query latency and quality only | Full end-to-end cost including index construction |
+| Indexed build time in report | Separate `IndexStats` record | Included in `elapsed_seconds` |
+| Realistic scenario | Persistent dev environment | Fresh CI checkout or first-run |
+
+---
+
+## Phase Execution Order
+
+Run phases in order. Each phase gates the next.
+
+```
+smoke    →  1 repo, 1 question, 1 repeat, all arms
+             Goal: verify adapters run without errors
+
+pilot    →  1 repo, all questions, 4 repeats, all arms
+             Goal: catch quality regressions before full compute spend
+
+full-warm →  all 7 repos, all questions, 4 repeats, warm arms only
+             Goal: primary quality + token comparison
+
+cold     →  all 7 repos, all questions, 4 repeats, cold arms only
+             Goal: measure index-build overhead
+```
+
+Stop and investigate if any arm has a `FAILED` rate above 5 % in smoke or pilot.
+
+---
+
+## Reading the Summary Table
+
+```
+repo         question_id          arm              med_overall  med_tokens  med_elapsed_s  fail_rate
+----------   ------------------   --------------   -----------  ----------  -------------  ---------
+django       call-chain-orm-001   native-only            3.2      14 200          18.4       0 %
+django       call-chain-orm-001   codegraph-warm         4.1       6 100           4.2       0 %
+django       call-chain-orm-001   tsa-warm               3.9       7 800           5.1       0 %
+```
+
+Column meanings:
+
+- `med_overall` — median `EvalRecord.overall` (1–5 scale, 5 = best)
+- `med_tokens` — median `RunRecord.total_tokens`
+- `med_elapsed_s` — median wall-clock seconds (index build excluded for warm arms)
+- `fail_rate` — percentage of repeats with `error` set or `overall < 2.5`
+
+A result is considered **dominant** if it scores higher on `med_overall` AND lower on `med_tokens` than the next-best arm. Neither dimension alone is sufficient.

--- a/benchmarks/codegraph_compare/README.md
+++ b/benchmarks/codegraph_compare/README.md
@@ -87,8 +87,10 @@ These rules are enforced by the harness. Violating any of them invalidates a run
 10. **No silent drops** — timeouts and exceptions are recorded as `RunRecord` entries with `error` set; they appear in the report as `FAILED` rather than being omitted.
 
 Claude runs use hard CLI tool allowlists. Codex runs use the same arm policy as
-prompted instructions plus a read-only sandbox because `codex exec` currently
-does not expose a matching per-tool allowlist flag.
+prompted instructions because `codex exec` currently does not expose a matching
+per-tool allowlist flag. Codex native-only runs use a read-only sandbox. Codex
+indexed arms use a workspace-write sandbox because CodeGraph and TSA query paths
+may update SQLite WAL/cache metadata during otherwise read-only queries.
 
 ---
 

--- a/benchmarks/codegraph_compare/README.md
+++ b/benchmarks/codegraph_compare/README.md
@@ -34,24 +34,40 @@ benchmarks/codegraph_compare/
 # 1. Prepare repos (clone at pinned SHA, optionally pre-build indexes)
 uv run python benchmarks/codegraph_compare/repo_prep.py --repos repos.yaml
 
-# 2. Run the benchmark (smoke = 1 repo × 1 question × 1 repeat)
-uv run python -m benchmarks.codegraph_compare.runner \
-    --repos repos.yaml --arms arms.yaml \
-    --phase smoke --repeats 1
+# 2. Run a Codex-backed smoke without spending model quota
+uv run python benchmarks/codegraph_compare/run.py run-matrix \
+    --repos gin \
+    --arms native-only,tsa-warm,codegraph-warm \
+    --repeats 1 \
+    --agent-backend codex \
+    --dry-run
 
-# 3. Run full pilot (1 repo × all questions × 4 repeats)
-uv run python -m benchmarks.codegraph_compare.runner \
-    --repos repos.yaml --arms arms.yaml \
-    --phase pilot --repeats 4
+# 3. Run a real Codex-backed smoke
+uv run python benchmarks/codegraph_compare/run.py run \
+    --repo gin \
+    --question gin-route-matching \
+    --arm native-only \
+    --agent-backend codex \
+    --repeat 0
 
 # 4. Evaluate answers (LLM judge, writes EvalRecord JSONL)
-uv run python -m benchmarks.codegraph_compare.evaluator \
+uv run python benchmarks/codegraph_compare/evaluate.py \
     --runs results/runs.jsonl --out results/evals.jsonl
 
 # 5. Print summary table
-uv run python -m benchmarks.codegraph_compare.analyze \
+uv run python benchmarks/codegraph_compare/analyze.py \
     --runs results/runs.jsonl --evals results/evals.jsonl
 ```
+
+Use `--agent-backend claude` to reproduce the original Claude Code arm, or
+`--agent-backend codex` to spend Codex quota through `codex exec --json`.
+Run IDs include the backend name so Claude and Codex results never overwrite
+each other.
+
+Codex records include `cached_input_tokens` and `reasoning_output_tokens` when
+the CLI reports them. These are stored separately because Codex reports them as
+detail counters already covered by the top-level input/output totals, while
+Claude reports cache counters outside `input_tokens`.
 
 ---
 
@@ -60,7 +76,7 @@ uv run python -m benchmarks.codegraph_compare.analyze \
 These rules are enforced by the harness. Violating any of them invalidates a run.
 
 1. **Pinned commits** — all repos use a fixed SHA from `repos.yaml`; no `HEAD`-tracking.
-2. **Same model for all arms** — the Claude model ID is a single config value applied uniformly.
+2. **Same model for all arms** — the selected model ID is applied uniformly within an agent backend.
 3. **Identical question text** — each arm receives the exact same `prompt` string from `QuestionSpec`.
 4. **Minimum 4 repeats** — the pilot and full phases require `--repeats 4` or higher; the summary drops any arm with fewer.
 5. **Report median, not best** — `overall`, `elapsed_seconds`, and `total_tokens` are summarized as median across repeats.
@@ -69,6 +85,10 @@ These rules are enforced by the harness. Violating any of them invalidates a run
 8. **Flag low-quality answers** — any run with `EvalRecord.overall < 2.5` is marked `LOW_QUALITY` in the report even if it was token-efficient.
 9. **Auto-penalize phantom citations** — citations to files that do not exist in the pinned repo reduce `citation_quality` automatically before human/LLM review.
 10. **No silent drops** — timeouts and exceptions are recorded as `RunRecord` entries with `error` set; they appear in the report as `FAILED` rather than being omitted.
+
+Claude runs use hard CLI tool allowlists. Codex runs use the same arm policy as
+prompted instructions plus a read-only sandbox because `codex exec` currently
+does not expose a matching per-tool allowlist flag.
 
 ---
 

--- a/benchmarks/codegraph_compare/adapters/__init__.py
+++ b/benchmarks/codegraph_compare/adapters/__init__.py
@@ -1,0 +1,116 @@
+"""Benchmark adapter base interface and factory.
+
+Each adapter encapsulates one arm of the benchmark:
+  - how to build / verify its index
+  - which tools Claude is allowed (or forbidden) to use
+  - how to parse raw transcript text into ToolMetrics
+
+Adapters are stateless value objects — no side effects at import time.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class IndexStats:
+    """Statistics collected during index preparation."""
+
+    build_seconds: float
+    index_size_bytes: int
+    file_count: int
+
+
+@dataclass
+class ToolMetrics:
+    """Tool-usage counts parsed from a single transcript run."""
+
+    tool_calls: int
+    file_reads: int
+    search_calls: int
+    index_queries: int
+
+
+@dataclass
+class RunConfig:
+    """Full configuration for one benchmark question run."""
+
+    arm_id: str
+    repo_path: Path
+    system_prompt: str
+    allowed_tools: list[str] = field(default_factory=list)
+    forbidden_tools: list[str] = field(default_factory=list)
+    # Injected verbatim into the first user message (e.g. "index is at .codegraph/")
+    extra_context: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Abstract base
+# ---------------------------------------------------------------------------
+
+
+class BenchmarkAdapter(ABC):
+    """Base class for all benchmark arms."""
+
+    arm_id: str
+
+    @abstractmethod
+    def prepare_index(self, repo_path: Path, cold: bool) -> IndexStats:
+        """Build (cold=True) or verify (cold=False, warm) the index.
+
+        Must always return an IndexStats even if preparation is a no-op.
+        Implementations should log errors rather than raise so the harness
+        can continue.
+        """
+        ...
+
+    @abstractmethod
+    def build_run_config(self, repo_path: Path, question_prompt: str) -> RunConfig:
+        """Return the RunConfig for a single question run against *repo_path*."""
+        ...
+
+    @abstractmethod
+    def parse_tool_metrics(self, transcript_text: str) -> ToolMetrics:
+        """Parse raw transcript text and return aggregated tool-usage counts."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+def get_adapter(arm_id: str) -> BenchmarkAdapter:
+    """Return the right adapter instance for *arm_id*.
+
+    Recognised arm IDs:
+      - ``"native-only"``
+      - ``"codegraph-cold"``
+      - ``"codegraph-warm"``
+      - ``"tsa-cold"``
+      - ``"tsa-warm"``
+    """
+    # Lazy imports keep module-level side effects out of this file.
+    from .codegraph import CodeGraphAdapter
+    from .native import NativeAdapter
+    from .tree_sitter_analyzer import TSAAdapter
+
+    if arm_id == "native-only":
+        return NativeAdapter()
+    if arm_id in ("codegraph-cold", "codegraph-warm"):
+        return CodeGraphAdapter(arm_id=arm_id)
+    if arm_id in ("tsa-cold", "tsa-warm"):
+        return TSAAdapter(arm_id=arm_id)
+
+    raise ValueError(
+        f"Unknown arm_id {arm_id!r}. "
+        "Valid values: 'native-only', 'codegraph-cold', 'codegraph-warm', "
+        "'tsa-cold', 'tsa-warm'."
+    )

--- a/benchmarks/codegraph_compare/adapters/claude_runner.py
+++ b/benchmarks/codegraph_compare/adapters/claude_runner.py
@@ -1,15 +1,18 @@
-"""Anthropic agent loop for a single benchmark question against one arm.
+"""Benchmark runner that drives the `claude --print` CLI for each trial.
 
-Runs Claude with a restricted tool set, counts every tool call, and records
-full token usage.  Writes:
-  - results_dir/raw/<run_id>_prompt.txt   — the full system + user prompt
-  - results_dir/raw/<run_id>_transcript.jsonl — every message in the loop
-  - results_dir/runs.jsonl               — one JSONL line per trial
+No separate API key required — uses the current Claude Code session's
+authentication (keychain / OAuth).
+
+Writes:
+  - results_dir/raw/<run_id>_prompt.txt          — the full prompt sent to claude
+  - results_dir/raw/<run_id>_result.json         — raw JSON response from claude CLI
+  - results_dir/runs.jsonl                       — one JSONL line per trial (appended)
 """
 
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 import time
 from datetime import datetime, timezone
@@ -20,306 +23,54 @@ if TYPE_CHECKING:
     from . import RunConfig
 
 # ---------------------------------------------------------------------------
-# Tool definitions available to each arm
+# Tool allowlist per arm
 # ---------------------------------------------------------------------------
-# All file operations are sandboxed to repo_path — the runner enforces this.
+# These are passed to `claude --allowed-tools` so Claude can only use the
+# tools appropriate for each arm, keeping the comparison fair.
 
-_TOOL_READ_FILE: dict[str, Any] = {
-    "name": "read_file",
-    "description": (
-        "Read a file from the repository. Path is relative to the repository root."
-    ),
-    "input_schema": {
-        "type": "object",
-        "properties": {
-            "path": {
-                "type": "string",
-                "description": "File path relative to repo root",
-            },
-            "start_line": {
-                "type": "integer",
-                "description": "First line to return (1-based, optional)",
-            },
-            "end_line": {
-                "type": "integer",
-                "description": "Last line to return (1-based, optional)",
-            },
-        },
-        "required": ["path"],
-    },
+_BASE_TOOLS = ["Read", "Bash(grep *)", "Bash(find *)", "Bash(ls *)", "Glob", "Grep"]
+_CODEGRAPH_TOOLS = [
+    "mcp__codegraph__codegraph_context",
+    "mcp__codegraph__codegraph_search",
+    "mcp__codegraph__codegraph_callers",
+    "mcp__codegraph__codegraph_callees",
+    "mcp__codegraph__codegraph_explore",
+    "mcp__codegraph__codegraph_node",
+    "mcp__codegraph__codegraph_files",
+    "mcp__codegraph__codegraph_impact",
+]
+_TSA_TOOLS = [
+    "Bash(python -m tree_sitter_analyzer *)",
+    "Bash(uv run python -m tree_sitter_analyzer *)",
+]
+
+# Tools explicitly blocked per arm (prevents Claude from discovering and using them via ToolSearch)
+_ARM_ALLOWED_TOOLS: dict[str, list[str]] = {
+    "native-only": _BASE_TOOLS,
+    "tsa-warm": _BASE_TOOLS + _TSA_TOOLS,
+    "tsa-cold": _BASE_TOOLS + _TSA_TOOLS,
+    "codegraph-warm": _BASE_TOOLS + _CODEGRAPH_TOOLS,
+    "codegraph-cold": _BASE_TOOLS + _CODEGRAPH_TOOLS,
 }
 
-_TOOL_SEARCH_FILES: dict[str, Any] = {
-    "name": "search_in_files",
-    "description": (
-        "Grep for a pattern across files in the repository. "
-        "Returns matching lines with file paths and line numbers."
-    ),
-    "input_schema": {
-        "type": "object",
-        "properties": {
-            "pattern": {"type": "string", "description": "Regex pattern to search for"},
-            "directory": {
-                "type": "string",
-                "description": "Directory to search in (relative to repo root, default '.')",
-                "default": ".",
-            },
-            "file_glob": {
-                "type": "string",
-                "description": "File name glob filter (e.g. '*.py', default '*')",
-                "default": "*",
-            },
-            "max_results": {
-                "type": "integer",
-                "description": "Maximum number of matching lines to return (default 50)",
-                "default": 50,
-            },
-        },
-        "required": ["pattern"],
-    },
-}
-
-_TOOL_LIST_FILES: dict[str, Any] = {
-    "name": "list_files",
-    "description": "List files in a directory of the repository.",
-    "input_schema": {
-        "type": "object",
-        "properties": {
-            "directory": {
-                "type": "string",
-                "description": "Directory to list (relative to repo root, default '.')",
-                "default": ".",
-            },
-            "pattern": {
-                "type": "string",
-                "description": "Glob pattern for file names (default '**/*')",
-                "default": "**/*",
-            },
-            "max_results": {
-                "type": "integer",
-                "description": "Maximum number of entries to return (default 100)",
-                "default": 100,
-            },
-        },
-        "required": [],
-    },
-}
-
-_TOOL_RUN_TSA: dict[str, Any] = {
-    "name": "run_tsa",
-    "description": (
-        "Run tree-sitter-analyzer CLI in the repository. "
-        "Example: run_tsa('smart-context', '--query URLRouter --format json'). "
-        "Subcommands: smart-context, project-graph, call-graph, change-impact."
-    ),
-    "input_schema": {
-        "type": "object",
-        "properties": {
-            "subcommand": {
-                "type": "string",
-                "description": "TSA subcommand (e.g. 'smart-context', 'call-graph')",
-            },
-            "args": {
-                "type": "string",
-                "description": "Additional arguments as a string (e.g. '--query X --format json')",
-                "default": "",
-            },
-        },
-        "required": ["subcommand"],
-    },
-}
-
-_TOOL_QUERY_CODEGRAPH: dict[str, Any] = {
-    "name": "query_codegraph",
-    "description": (
-        "Query the CodeGraph symbol index for the repository. "
-        "Operations: context, search, callers, callees, explore, node, files, impact."
-    ),
-    "input_schema": {
-        "type": "object",
-        "properties": {
-            "operation": {
-                "type": "string",
-                "description": (
-                    "One of: context, search, callers, callees, explore, node, files, impact"
-                ),
-            },
-            "query": {
-                "type": "string",
-                "description": "Symbol name, file path, or free-form query",
-                "default": "",
-            },
-            "extra": {
-                "type": "string",
-                "description": "Extra CLI flags as a string",
-                "default": "",
-            },
-        },
-        "required": ["operation"],
-    },
-}
-
-# Map arm_id → list of tool defs to expose
-_ARM_TOOLS: dict[str, list[dict[str, Any]]] = {
-    "native-only": [_TOOL_READ_FILE, _TOOL_SEARCH_FILES, _TOOL_LIST_FILES],
-    "tsa-warm": [_TOOL_READ_FILE, _TOOL_SEARCH_FILES, _TOOL_LIST_FILES, _TOOL_RUN_TSA],
-    "tsa-cold": [_TOOL_READ_FILE, _TOOL_SEARCH_FILES, _TOOL_LIST_FILES, _TOOL_RUN_TSA],
-    "codegraph-warm": [
-        _TOOL_READ_FILE,
-        _TOOL_SEARCH_FILES,
-        _TOOL_LIST_FILES,
-        _TOOL_QUERY_CODEGRAPH,
+# For native-only: explicitly disallow codegraph MCP and ToolSearch so Claude
+# can't discover and call them even when --allowed-tools is set
+_ARM_DISALLOWED_TOOLS: dict[str, list[str]] = {
+    "native-only": [
+        "mcp__codegraph__*",
+        "mcp__ruflo__*",
+        "mcp__*",
+        "ToolSearch",
+        "Agent",
     ],
-    "codegraph-cold": [
-        _TOOL_READ_FILE,
-        _TOOL_SEARCH_FILES,
-        _TOOL_LIST_FILES,
-        _TOOL_QUERY_CODEGRAPH,
-    ],
+    "tsa-warm": ["mcp__codegraph__*", "ToolSearch", "Agent"],
+    "tsa-cold": ["mcp__codegraph__*", "ToolSearch", "Agent"],
+    "codegraph-warm": ["ToolSearch", "Agent"],
+    "codegraph-cold": ["ToolSearch", "Agent"],
 }
 
 # ---------------------------------------------------------------------------
-# Tool execution
-# ---------------------------------------------------------------------------
-
-_MAX_OUTPUT_BYTES = 32_000  # cap individual tool output to avoid token explosion
-
-
-def _safe_path(repo_path: Path, relative: str) -> Path | None:
-    """Return resolved absolute path only if it stays inside repo_path."""
-    try:
-        resolved = (repo_path / relative.lstrip("/")).resolve()
-        resolved.relative_to(repo_path.resolve())  # raises ValueError if outside
-        return resolved
-    except (ValueError, OSError):
-        return None
-
-
-def _execute_tool(name: str, inputs: dict[str, Any], repo_path: Path) -> str:
-    """Dispatch a tool call and return its string output (capped)."""
-    try:
-        if name == "read_file":
-            return _tool_read_file(inputs, repo_path)
-        if name == "search_in_files":
-            return _tool_search(inputs, repo_path)
-        if name == "list_files":
-            return _tool_list(inputs, repo_path)
-        if name == "run_tsa":
-            return _tool_run_tsa(inputs, repo_path)
-        if name == "query_codegraph":
-            return _tool_query_codegraph(inputs, repo_path)
-    except Exception as exc:  # noqa: BLE001
-        return f"ERROR executing {name}: {exc}"
-    return f"Unknown tool: {name}"
-
-
-def _tool_read_file(inputs: dict[str, Any], repo_path: Path) -> str:
-    path = _safe_path(repo_path, inputs.get("path", ""))
-    if path is None:
-        return "ERROR: path is outside the repository root"
-    if not path.exists():
-        return f"ERROR: file not found: {inputs['path']}"
-    try:
-        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
-    except OSError as e:
-        return f"ERROR: {e}"
-    start = max(0, inputs.get("start_line", 1) - 1)
-    end = inputs.get("end_line", len(lines))
-    selected = lines[start:end]
-    text = "\n".join(f"{start + i + 1}: {line}" for i, line in enumerate(selected))
-    return text[:_MAX_OUTPUT_BYTES]
-
-
-def _tool_search(inputs: dict[str, Any], repo_path: Path) -> str:
-    pattern = inputs.get("pattern", "")
-    directory = inputs.get("directory", ".")
-    file_glob = inputs.get("file_glob", "*")
-    max_results = int(inputs.get("max_results", 50))
-    search_dir = _safe_path(repo_path, directory)
-    if search_dir is None:
-        return "ERROR: directory is outside the repository root"
-    cmd = [
-        "grep",
-        "-rn",
-        "--include",
-        file_glob,
-        "-m",
-        str(max_results),
-        pattern,
-        str(search_dir),
-    ]
-    result = subprocess.run(
-        cmd,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        timeout=30,
-    )
-    output = result.stdout or result.stderr or "(no matches)"
-    return output[:_MAX_OUTPUT_BYTES]
-
-
-def _tool_list(inputs: dict[str, Any], repo_path: Path) -> str:
-    directory = inputs.get("directory", ".")
-    pattern = inputs.get("pattern", "**/*")
-    max_results = int(inputs.get("max_results", 100))
-    base = _safe_path(repo_path, directory)
-    if base is None:
-        return "ERROR: directory is outside the repository root"
-    if not base.is_dir():
-        return f"ERROR: not a directory: {directory}"
-    paths = []
-    for p in base.glob(pattern):
-        if p.is_file():
-            try:
-                paths.append(str(p.relative_to(repo_path)))
-            except ValueError:
-                pass
-        if len(paths) >= max_results:
-            break
-    return "\n".join(sorted(paths)[:max_results]) or "(no files found)"
-
-
-def _tool_run_tsa(inputs: dict[str, Any], repo_path: Path) -> str:
-    subcommand = inputs.get("subcommand", "")
-    args = inputs.get("args", "")
-    cmd_str = f"python -m tree_sitter_analyzer {subcommand} {args}".strip()
-    result = subprocess.run(  # nosec B602
-        cmd_str,
-        shell=True,  # noqa: S602 — intentional: TSA args are from LLM, not user shell
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        cwd=str(repo_path),
-        timeout=60,
-    )
-    output = result.stdout or result.stderr or "(no output)"
-    return output[:_MAX_OUTPUT_BYTES]
-
-
-def _tool_query_codegraph(inputs: dict[str, Any], repo_path: Path) -> str:
-    operation = inputs.get("operation", "")
-    query = inputs.get("query", "")
-    extra = inputs.get("extra", "")
-    cmd_str = f"codegraph {operation} {query} {extra}".strip()
-    result = subprocess.run(  # nosec B602
-        cmd_str,
-        shell=True,  # noqa: S602 — intentional: codegraph args are from LLM, not user shell
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        cwd=str(repo_path),
-        timeout=60,
-    )
-    output = result.stdout or result.stderr or "(no output)"
-    return output[:_MAX_OUTPUT_BYTES]
-
-
-# ---------------------------------------------------------------------------
-# Metric helpers
+# Helpers
 # ---------------------------------------------------------------------------
 
 
@@ -327,180 +78,58 @@ def _make_run_id(question_id: str, arm_id: str, repeat: int) -> str:
     return f"{question_id}__{arm_id}__{repeat:02d}"
 
 
-def _extract_text(content: list[Any]) -> str:
-    """Pull plain text from a list of content blocks."""
-    return " ".join(block.text for block in content if hasattr(block, "text")).strip()
-
-
-def _extract_citations(answer: str) -> list[str]:
+def _extract_citations(text: str) -> list[str]:
     """Extract file-path-like strings from the answer text."""
-    import re
-
     return list(
-        dict.fromkeys(  # deduplicate preserving order
+        dict.fromkeys(
             m.group(0)
             for m in re.finditer(
-                r"[\w./\-]+\.(?:py|ts|tsx|go|rs|java|swift|kt|js|jsx|cpp|c|h|cs|rb|php)",
-                answer,
+                r"[\w./\-]+\."
+                r"(?:py|ts|tsx|go|rs|java|swift|kt|js|jsx|cpp|c|h|cs|rb|php)",
+                text,
             )
         )
     )
 
 
-# ---------------------------------------------------------------------------
-# Agent loop
-# ---------------------------------------------------------------------------
-
-_MAX_TURNS = 40  # hard ceiling on agent loop iterations
-
-
-def _run_agent_loop(
-    system_prompt: str,
-    user_message: str,
-    tools: list[dict[str, Any]],
-    repo_path: Path,
-    arm_id: str,
-    model: str,
-    timeout_seconds: int,
-    transcript: list[dict[str, Any]],
-) -> tuple[str, int, int, int, int, int, int, str | None]:
-    """Run the agent tool-use loop.
-
-    Returns
-    -------
-    answer, input_tokens, output_tokens, tool_calls,
-    file_reads, search_calls, index_queries, error
-    """
-    try:
-        import anthropic  # lazy import — only needed for real runs
-    except ImportError as exc:
-        raise RuntimeError(
-            "anthropic package not installed. Run: uv pip install anthropic"
-        ) from exc
-
-    client = anthropic.Anthropic()
-    messages: list[dict[str, Any]] = [{"role": "user", "content": user_message}]
-
-    input_tokens = 0
-    output_tokens = 0
+def _parse_tool_calls_from_stream(lines: list[str]) -> tuple[int, int, int, int]:
+    """Count tool calls by category from stream-json event lines."""
     tool_calls = 0
     file_reads = 0
     search_calls = 0
     index_queries = 0
-    answer = ""
-    error = None
-    deadline = time.perf_counter() + timeout_seconds
-
-    for _turn in range(_MAX_TURNS):
-        if time.perf_counter() > deadline:
-            answer = "TIMEOUT"
-            error = f"Timed out after {timeout_seconds}s"
-            break
-
+    for line in lines:
         try:
-            response = client.messages.create(
-                model=model,
-                max_tokens=4096,
-                system=system_prompt,
-                tools=tools,
-                messages=messages,
-            )
-        except Exception as exc:  # noqa: BLE001
-            error = f"API error: {exc}"
-            answer = "ERROR"
-            break
-
-        input_tokens += response.usage.input_tokens
-        output_tokens += response.usage.output_tokens
-
-        # Record assistant message in transcript
-        transcript.append(
-            {
-                "role": "assistant",
-                "stop_reason": response.stop_reason,
-                "usage": {
-                    "input_tokens": response.usage.input_tokens,
-                    "output_tokens": response.usage.output_tokens,
-                },
-                "content": [
-                    {
-                        "type": getattr(b, "type", "unknown"),
-                        "text": getattr(b, "text", None),
-                        "name": getattr(b, "name", None),
-                        "id": getattr(b, "id", None),
-                        "input": getattr(b, "input", None),
-                    }
-                    for b in response.content
-                ],
-            }
-        )
-
-        if response.stop_reason == "end_turn":
-            answer = _extract_text(response.content)
-            break
-
-        if response.stop_reason != "tool_use":
-            answer = _extract_text(response.content)
-            error = f"Unexpected stop_reason: {response.stop_reason}"
-            break
-
-        # Execute tools
-        tool_results = []
-        messages.append({"role": "assistant", "content": response.content})
-
-        for block in response.content:
-            if not hasattr(block, "type") or block.type != "tool_use":
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if event.get("type") != "assistant":
+            continue
+        for block in event.get("message", {}).get("content", []):
+            if block.get("type") != "tool_use":
                 continue
-
             tool_calls += 1
-            tname = block.name
-            tinputs = block.input or {}
-
-            # categorise
-            if tname == "read_file":
+            name: str = block.get("name", "")
+            name_lower = name.lower()
+            if name_lower in ("read", "readfile"):
                 file_reads += 1
-            elif tname == "search_in_files":
-                search_calls += 1
-            elif tname in ("run_tsa", "query_codegraph"):
+            elif "codegraph" in name_lower or "tree_sitter" in name_lower:
                 index_queries += 1
-
-            result_text = _execute_tool(tname, tinputs, repo_path)
-
-            # Record tool result in transcript
-            transcript.append(
-                {
-                    "role": "tool",
-                    "tool_name": tname,
-                    "tool_use_id": block.id,
-                    "inputs": tinputs,
-                    "result_snippet": result_text[:500],
-                }
-            )
-
-            tool_results.append(
-                {
-                    "type": "tool_result",
-                    "tool_use_id": block.id,
-                    "content": result_text,
-                }
-            )
-
-        messages.append({"role": "user", "content": tool_results})
-
-    else:
-        answer = answer or "MAX_TURNS_REACHED"
-        error = error or f"Reached {_MAX_TURNS}-turn limit without end_turn"
-
-    return (
-        answer,
-        input_tokens,
-        output_tokens,
-        tool_calls,
-        file_reads,
-        search_calls,
-        index_queries,
-        error,
-    )
+            elif name_lower == "bash":
+                inp = block.get("input", {})
+                cmd_str = inp.get("command", "") if isinstance(inp, dict) else str(inp)
+                if (
+                    "tree_sitter_analyzer" in cmd_str
+                    or "python -m tree_sitter" in cmd_str
+                ):
+                    index_queries += 1
+                elif "grep" in cmd_str or "find" in cmd_str or "rg " in cmd_str:
+                    search_calls += 1
+                else:
+                    search_calls += 1
+            else:
+                search_calls += 1
+    return tool_calls, file_reads, search_calls, index_queries
 
 
 # ---------------------------------------------------------------------------
@@ -518,77 +147,134 @@ def run_one(
     results_dir: Path,
     timeout_seconds: int = 1200,
     model: str = "claude-sonnet-4-6",
+    dry_run: bool = False,
 ) -> dict:
-    """Run one benchmark trial.
+    """Run one benchmark trial via `claude --print --output-format json`.
 
-    Writes:
-      results_dir/raw/<run_id>_prompt.txt
-      results_dir/raw/<run_id>_transcript.jsonl
-      results_dir/runs.jsonl  (appended)
-
-    Returns a dict matching RunRecord schema.
+    Writes prompt + raw result to results_dir/raw/, appends to runs.jsonl.
     """
     run_id = _make_run_id(question_id, arm_id, repeat)
     started_at = datetime.now(timezone.utc).isoformat()
     started_perf = time.perf_counter()
 
-    # Build prompt
-    user_message_parts = []
+    # Build the prompt Claude will receive
+    user_parts = []
     if run_config.extra_context:
-        user_message_parts.append(run_config.extra_context)
-    user_message_parts.append(f"Question: {question_prompt}")
-    user_message = "\n\n".join(user_message_parts)
+        user_parts.append(run_config.extra_context)
+    user_parts.append(f"Question: {question_prompt}")
+    user_message = "\n\n".join(user_parts)
 
-    # Persist prompt for reproducibility
+    full_prompt = f"{run_config.system_prompt}\n\n{user_message}"
+
+    # Persist prompt
     raw_dir = results_dir / "raw"
     raw_dir.mkdir(parents=True, exist_ok=True)
     prompt_path = raw_dir / f"{run_id}_prompt.txt"
-    prompt_path.write_text(
-        f"SYSTEM:\n{run_config.system_prompt}\n\nUSER:\n{user_message}",
-        encoding="utf-8",
-    )
+    prompt_path.write_text(full_prompt, encoding="utf-8")
 
-    # Get tools for this arm
-    tools = _ARM_TOOLS.get(arm_id, _ARM_TOOLS["native-only"])
-
-    # Run agent loop
-    transcript: list[dict[str, Any]] = []
-    (
-        answer,
-        input_tokens,
-        output_tokens,
-        tool_calls,
-        file_reads,
-        search_calls,
-        index_queries,
-        error,
-    ) = _run_agent_loop(
-        system_prompt=run_config.system_prompt,
-        user_message=user_message,
-        tools=tools,
-        repo_path=repo_path,
-        arm_id=arm_id,
-        model=model,
-        timeout_seconds=timeout_seconds,
-        transcript=transcript,
+    # Build claude CLI command — stream-json captures per-tool-call events
+    allowed_tools_str = ",".join(
+        _ARM_ALLOWED_TOOLS.get(arm_id, _ARM_ALLOWED_TOOLS["native-only"])
     )
+    disallowed_tools_str = ",".join(_ARM_DISALLOWED_TOOLS.get(arm_id, []))
+    cmd = [
+        "claude",
+        "--print",
+        "--output-format",
+        "stream-json",
+        "--verbose",
+        "--no-session-persistence",
+        "--model",
+        model,
+        "--add-dir",
+        str(repo_path),
+        "--append-system-prompt",
+        run_config.system_prompt,
+        "--allowed-tools",
+        allowed_tools_str,
+    ]
+    if disallowed_tools_str:
+        cmd += ["--disallowed-tools", disallowed_tools_str]
+
+    # Run — prompt via stdin
+    error: str | None = None
+    answer = ""
+    raw_result: dict[str, Any] = {}
+    stream_lines: list[str] = []
+
+    if dry_run:
+        result_path = raw_dir / f"{run_id}_result.jsonl"
+        answer = "DRY_RUN"
+        result_path.write_text("", encoding="utf-8")
+    else:
+        try:
+            proc = subprocess.run(
+                cmd,
+                input=user_message,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=timeout_seconds,
+                cwd=str(repo_path),
+            )
+            stream_lines = [ln for ln in proc.stdout.splitlines() if ln.strip()]
+
+            # Save raw stream
+            result_path = raw_dir / f"{run_id}_result.jsonl"
+            result_path.write_text(proc.stdout, encoding="utf-8")
+
+            if proc.returncode != 0 and not proc.stdout.strip():
+                error = f"claude CLI exited {proc.returncode}: {proc.stderr[:500]}"
+            else:
+                # Extract result event (last line is usually the result)
+                for line in reversed(stream_lines):
+                    try:
+                        event = json.loads(line)
+                        if event.get("type") == "result":
+                            raw_result = event
+                            if event.get("is_error"):
+                                error = event.get("result", "unknown error")
+                                answer = "ERROR"
+                            else:
+                                answer = event.get("result", "")
+                            break
+                    except json.JSONDecodeError:
+                        continue
+                if not answer and not error:
+                    error = "No result event found in stream output"
+
+        except subprocess.TimeoutExpired:
+            error = f"Timed out after {timeout_seconds}s"
+            answer = "TIMEOUT"
+        except FileNotFoundError:
+            error = "claude CLI not found in PATH"
+            answer = "ERROR"
 
     ended_at = datetime.now(timezone.utc).isoformat()
     elapsed_seconds = round(time.perf_counter() - started_perf, 4)
-    total_tokens = input_tokens + output_tokens
-    estimated_cost = (input_tokens / 1_000_000 * 3.0) + (
-        output_tokens / 1_000_000 * 15.0
-    )
 
-    # Persist transcript
-    transcript_path = raw_dir / f"{run_id}_transcript.jsonl"
-    with transcript_path.open("w", encoding="utf-8") as fh:
-        for entry in transcript:
-            fh.write(json.dumps(entry, ensure_ascii=False, default=str) + "\n")
+    # Extract metrics from result event
+    usage = raw_result.get("usage", {})
+    input_tokens = usage.get("input_tokens", 0) + usage.get(
+        "cache_read_input_tokens", 0
+    )
+    output_tokens = usage.get("output_tokens", 0)
+    total_tokens = input_tokens + output_tokens
+    estimated_cost = float(raw_result.get("total_cost_usd", 0.0))
+    if estimated_cost == 0 and total_tokens > 0:
+        estimated_cost = (input_tokens / 1_000_000 * 3.0) + (
+            output_tokens / 1_000_000 * 15.0
+        )
+
+    # Count tool calls from assistant events in the stream
+    tool_calls, file_reads, search_calls, index_queries = _parse_tool_calls_from_stream(
+        stream_lines
+    )
 
     record: dict = {
         "run_id": run_id,
-        "repo": str(repo_path.name),
+        "repo": repo_path.name,
         "question_id": question_id,
         "arm": arm_id,
         "repeat": repeat,
@@ -605,11 +291,10 @@ def run_one(
         "index_queries": index_queries,
         "answer": answer,
         "citations": _extract_citations(answer),
-        "transcript_path": str(transcript_path),
+        "transcript_path": str(raw_dir / f"{run_id}_result.jsonl"),
         "error": error,
     }
 
-    # Append to JSONL
     runs_jsonl = results_dir / "runs.jsonl"
     with runs_jsonl.open("a", encoding="utf-8") as fh:
         fh.write(json.dumps(record, ensure_ascii=False) + "\n")

--- a/benchmarks/codegraph_compare/adapters/claude_runner.py
+++ b/benchmarks/codegraph_compare/adapters/claude_runner.py
@@ -1,56 +1,511 @@
-"""Claude API runner for a single benchmark question against one arm.
+"""Anthropic agent loop for a single benchmark question against one arm.
 
-# TODO: replace dry-run stub with real Claude API calls once harness is validated
-
-Currently operates in **dry-run / stub** mode:
-  - Builds the full prompt that WOULD be sent (system + user message)
-  - Writes it to results_dir/raw/<run_id>_prompt.txt
-  - Returns a RunRecord with answer="DRY_RUN", all token counts=0, tool_calls=0
-  - Never makes a real network call
-
-This lets the harness structure, file layout, YAML loading, and CLI wiring be
-validated end-to-end before live API credentials are needed.
+Runs Claude with a restricted tool set, counts every tool call, and records
+full token usage.  Writes:
+  - results_dir/raw/<run_id>_prompt.txt   — the full system + user prompt
+  - results_dir/raw/<run_id>_transcript.jsonl — every message in the loop
+  - results_dir/runs.jsonl               — one JSONL line per trial
 """
 
 from __future__ import annotations
 
 import json
+import subprocess
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from . import RunConfig
 
+# ---------------------------------------------------------------------------
+# Tool definitions available to each arm
+# ---------------------------------------------------------------------------
+# All file operations are sandboxed to repo_path — the runner enforces this.
+
+_TOOL_READ_FILE: dict[str, Any] = {
+    "name": "read_file",
+    "description": (
+        "Read a file from the repository. Path is relative to the repository root."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": "string",
+                "description": "File path relative to repo root",
+            },
+            "start_line": {
+                "type": "integer",
+                "description": "First line to return (1-based, optional)",
+            },
+            "end_line": {
+                "type": "integer",
+                "description": "Last line to return (1-based, optional)",
+            },
+        },
+        "required": ["path"],
+    },
+}
+
+_TOOL_SEARCH_FILES: dict[str, Any] = {
+    "name": "search_in_files",
+    "description": (
+        "Grep for a pattern across files in the repository. "
+        "Returns matching lines with file paths and line numbers."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "pattern": {"type": "string", "description": "Regex pattern to search for"},
+            "directory": {
+                "type": "string",
+                "description": "Directory to search in (relative to repo root, default '.')",
+                "default": ".",
+            },
+            "file_glob": {
+                "type": "string",
+                "description": "File name glob filter (e.g. '*.py', default '*')",
+                "default": "*",
+            },
+            "max_results": {
+                "type": "integer",
+                "description": "Maximum number of matching lines to return (default 50)",
+                "default": 50,
+            },
+        },
+        "required": ["pattern"],
+    },
+}
+
+_TOOL_LIST_FILES: dict[str, Any] = {
+    "name": "list_files",
+    "description": "List files in a directory of the repository.",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "directory": {
+                "type": "string",
+                "description": "Directory to list (relative to repo root, default '.')",
+                "default": ".",
+            },
+            "pattern": {
+                "type": "string",
+                "description": "Glob pattern for file names (default '**/*')",
+                "default": "**/*",
+            },
+            "max_results": {
+                "type": "integer",
+                "description": "Maximum number of entries to return (default 100)",
+                "default": 100,
+            },
+        },
+        "required": [],
+    },
+}
+
+_TOOL_RUN_TSA: dict[str, Any] = {
+    "name": "run_tsa",
+    "description": (
+        "Run tree-sitter-analyzer CLI in the repository. "
+        "Example: run_tsa('smart-context', '--query URLRouter --format json'). "
+        "Subcommands: smart-context, project-graph, call-graph, change-impact."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "subcommand": {
+                "type": "string",
+                "description": "TSA subcommand (e.g. 'smart-context', 'call-graph')",
+            },
+            "args": {
+                "type": "string",
+                "description": "Additional arguments as a string (e.g. '--query X --format json')",
+                "default": "",
+            },
+        },
+        "required": ["subcommand"],
+    },
+}
+
+_TOOL_QUERY_CODEGRAPH: dict[str, Any] = {
+    "name": "query_codegraph",
+    "description": (
+        "Query the CodeGraph symbol index for the repository. "
+        "Operations: context, search, callers, callees, explore, node, files, impact."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "operation": {
+                "type": "string",
+                "description": (
+                    "One of: context, search, callers, callees, explore, node, files, impact"
+                ),
+            },
+            "query": {
+                "type": "string",
+                "description": "Symbol name, file path, or free-form query",
+                "default": "",
+            },
+            "extra": {
+                "type": "string",
+                "description": "Extra CLI flags as a string",
+                "default": "",
+            },
+        },
+        "required": ["operation"],
+    },
+}
+
+# Map arm_id → list of tool defs to expose
+_ARM_TOOLS: dict[str, list[dict[str, Any]]] = {
+    "native-only": [_TOOL_READ_FILE, _TOOL_SEARCH_FILES, _TOOL_LIST_FILES],
+    "tsa-warm": [_TOOL_READ_FILE, _TOOL_SEARCH_FILES, _TOOL_LIST_FILES, _TOOL_RUN_TSA],
+    "tsa-cold": [_TOOL_READ_FILE, _TOOL_SEARCH_FILES, _TOOL_LIST_FILES, _TOOL_RUN_TSA],
+    "codegraph-warm": [
+        _TOOL_READ_FILE,
+        _TOOL_SEARCH_FILES,
+        _TOOL_LIST_FILES,
+        _TOOL_QUERY_CODEGRAPH,
+    ],
+    "codegraph-cold": [
+        _TOOL_READ_FILE,
+        _TOOL_SEARCH_FILES,
+        _TOOL_LIST_FILES,
+        _TOOL_QUERY_CODEGRAPH,
+    ],
+}
+
+# ---------------------------------------------------------------------------
+# Tool execution
+# ---------------------------------------------------------------------------
+
+_MAX_OUTPUT_BYTES = 32_000  # cap individual tool output to avoid token explosion
+
+
+def _safe_path(repo_path: Path, relative: str) -> Path | None:
+    """Return resolved absolute path only if it stays inside repo_path."""
+    try:
+        resolved = (repo_path / relative.lstrip("/")).resolve()
+        resolved.relative_to(repo_path.resolve())  # raises ValueError if outside
+        return resolved
+    except (ValueError, OSError):
+        return None
+
+
+def _execute_tool(name: str, inputs: dict[str, Any], repo_path: Path) -> str:
+    """Dispatch a tool call and return its string output (capped)."""
+    try:
+        if name == "read_file":
+            return _tool_read_file(inputs, repo_path)
+        if name == "search_in_files":
+            return _tool_search(inputs, repo_path)
+        if name == "list_files":
+            return _tool_list(inputs, repo_path)
+        if name == "run_tsa":
+            return _tool_run_tsa(inputs, repo_path)
+        if name == "query_codegraph":
+            return _tool_query_codegraph(inputs, repo_path)
+    except Exception as exc:  # noqa: BLE001
+        return f"ERROR executing {name}: {exc}"
+    return f"Unknown tool: {name}"
+
+
+def _tool_read_file(inputs: dict[str, Any], repo_path: Path) -> str:
+    path = _safe_path(repo_path, inputs.get("path", ""))
+    if path is None:
+        return "ERROR: path is outside the repository root"
+    if not path.exists():
+        return f"ERROR: file not found: {inputs['path']}"
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError as e:
+        return f"ERROR: {e}"
+    start = max(0, inputs.get("start_line", 1) - 1)
+    end = inputs.get("end_line", len(lines))
+    selected = lines[start:end]
+    text = "\n".join(f"{start + i + 1}: {line}" for i, line in enumerate(selected))
+    return text[:_MAX_OUTPUT_BYTES]
+
+
+def _tool_search(inputs: dict[str, Any], repo_path: Path) -> str:
+    pattern = inputs.get("pattern", "")
+    directory = inputs.get("directory", ".")
+    file_glob = inputs.get("file_glob", "*")
+    max_results = int(inputs.get("max_results", 50))
+    search_dir = _safe_path(repo_path, directory)
+    if search_dir is None:
+        return "ERROR: directory is outside the repository root"
+    cmd = [
+        "grep",
+        "-rn",
+        "--include",
+        file_glob,
+        "-m",
+        str(max_results),
+        pattern,
+        str(search_dir),
+    ]
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=30,
+    )
+    output = result.stdout or result.stderr or "(no matches)"
+    return output[:_MAX_OUTPUT_BYTES]
+
+
+def _tool_list(inputs: dict[str, Any], repo_path: Path) -> str:
+    directory = inputs.get("directory", ".")
+    pattern = inputs.get("pattern", "**/*")
+    max_results = int(inputs.get("max_results", 100))
+    base = _safe_path(repo_path, directory)
+    if base is None:
+        return "ERROR: directory is outside the repository root"
+    if not base.is_dir():
+        return f"ERROR: not a directory: {directory}"
+    paths = []
+    for p in base.glob(pattern):
+        if p.is_file():
+            try:
+                paths.append(str(p.relative_to(repo_path)))
+            except ValueError:
+                pass
+        if len(paths) >= max_results:
+            break
+    return "\n".join(sorted(paths)[:max_results]) or "(no files found)"
+
+
+def _tool_run_tsa(inputs: dict[str, Any], repo_path: Path) -> str:
+    subcommand = inputs.get("subcommand", "")
+    args = inputs.get("args", "")
+    cmd_str = f"python -m tree_sitter_analyzer {subcommand} {args}".strip()
+    result = subprocess.run(  # nosec B602
+        cmd_str,
+        shell=True,  # noqa: S602 — intentional: TSA args are from LLM, not user shell
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        cwd=str(repo_path),
+        timeout=60,
+    )
+    output = result.stdout or result.stderr or "(no output)"
+    return output[:_MAX_OUTPUT_BYTES]
+
+
+def _tool_query_codegraph(inputs: dict[str, Any], repo_path: Path) -> str:
+    operation = inputs.get("operation", "")
+    query = inputs.get("query", "")
+    extra = inputs.get("extra", "")
+    cmd_str = f"codegraph {operation} {query} {extra}".strip()
+    result = subprocess.run(  # nosec B602
+        cmd_str,
+        shell=True,  # noqa: S602 — intentional: codegraph args are from LLM, not user shell
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        cwd=str(repo_path),
+        timeout=60,
+    )
+    output = result.stdout or result.stderr or "(no output)"
+    return output[:_MAX_OUTPUT_BYTES]
+
+
+# ---------------------------------------------------------------------------
+# Metric helpers
+# ---------------------------------------------------------------------------
+
 
 def _make_run_id(question_id: str, arm_id: str, repeat: int) -> str:
-    """Build a deterministic run identifier.
-
-    Formula mirrors RunRecord.make_id in schemas.py so run IDs are consistent
-    whether generated here or from the schema layer.
-    """
     return f"{question_id}__{arm_id}__{repeat:02d}"
 
 
-def _build_full_prompt(
-    run_config: RunConfig,
-    question_prompt: str,
-) -> str:
-    """Assemble the full prompt string that would be sent to Claude.
+def _extract_text(content: list[Any]) -> str:
+    """Pull plain text from a list of content blocks."""
+    return " ".join(block.text for block in content if hasattr(block, "text")).strip()
 
-    Structure:
-      <system_prompt>
 
-      <extra_context>
+def _extract_citations(answer: str) -> list[str]:
+    """Extract file-path-like strings from the answer text."""
+    import re
 
-      Question: <question_prompt>
+    return list(
+        dict.fromkeys(  # deduplicate preserving order
+            m.group(0)
+            for m in re.finditer(
+                r"[\w./\-]+\.(?:py|ts|tsx|go|rs|java|swift|kt|js|jsx|cpp|c|h|cs|rb|php)",
+                answer,
+            )
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Agent loop
+# ---------------------------------------------------------------------------
+
+_MAX_TURNS = 40  # hard ceiling on agent loop iterations
+
+
+def _run_agent_loop(
+    system_prompt: str,
+    user_message: str,
+    tools: list[dict[str, Any]],
+    repo_path: Path,
+    arm_id: str,
+    model: str,
+    timeout_seconds: int,
+    transcript: list[dict[str, Any]],
+) -> tuple[str, int, int, int, int, int, int, str | None]:
+    """Run the agent tool-use loop.
+
+    Returns
+    -------
+    answer, input_tokens, output_tokens, tool_calls,
+    file_reads, search_calls, index_queries, error
     """
-    parts: list[str] = [run_config.system_prompt]
-    if run_config.extra_context:
-        parts.append(run_config.extra_context)
-    parts.append(f"Question: {question_prompt}")
-    return "\n\n".join(parts)
+    try:
+        import anthropic  # lazy import — only needed for real runs
+    except ImportError as exc:
+        raise RuntimeError(
+            "anthropic package not installed. Run: uv pip install anthropic"
+        ) from exc
+
+    client = anthropic.Anthropic()
+    messages: list[dict[str, Any]] = [{"role": "user", "content": user_message}]
+
+    input_tokens = 0
+    output_tokens = 0
+    tool_calls = 0
+    file_reads = 0
+    search_calls = 0
+    index_queries = 0
+    answer = ""
+    error = None
+    deadline = time.perf_counter() + timeout_seconds
+
+    for _turn in range(_MAX_TURNS):
+        if time.perf_counter() > deadline:
+            answer = "TIMEOUT"
+            error = f"Timed out after {timeout_seconds}s"
+            break
+
+        try:
+            response = client.messages.create(
+                model=model,
+                max_tokens=4096,
+                system=system_prompt,
+                tools=tools,
+                messages=messages,
+            )
+        except Exception as exc:  # noqa: BLE001
+            error = f"API error: {exc}"
+            answer = "ERROR"
+            break
+
+        input_tokens += response.usage.input_tokens
+        output_tokens += response.usage.output_tokens
+
+        # Record assistant message in transcript
+        transcript.append(
+            {
+                "role": "assistant",
+                "stop_reason": response.stop_reason,
+                "usage": {
+                    "input_tokens": response.usage.input_tokens,
+                    "output_tokens": response.usage.output_tokens,
+                },
+                "content": [
+                    {
+                        "type": getattr(b, "type", "unknown"),
+                        "text": getattr(b, "text", None),
+                        "name": getattr(b, "name", None),
+                        "id": getattr(b, "id", None),
+                        "input": getattr(b, "input", None),
+                    }
+                    for b in response.content
+                ],
+            }
+        )
+
+        if response.stop_reason == "end_turn":
+            answer = _extract_text(response.content)
+            break
+
+        if response.stop_reason != "tool_use":
+            answer = _extract_text(response.content)
+            error = f"Unexpected stop_reason: {response.stop_reason}"
+            break
+
+        # Execute tools
+        tool_results = []
+        messages.append({"role": "assistant", "content": response.content})
+
+        for block in response.content:
+            if not hasattr(block, "type") or block.type != "tool_use":
+                continue
+
+            tool_calls += 1
+            tname = block.name
+            tinputs = block.input or {}
+
+            # categorise
+            if tname == "read_file":
+                file_reads += 1
+            elif tname == "search_in_files":
+                search_calls += 1
+            elif tname in ("run_tsa", "query_codegraph"):
+                index_queries += 1
+
+            result_text = _execute_tool(tname, tinputs, repo_path)
+
+            # Record tool result in transcript
+            transcript.append(
+                {
+                    "role": "tool",
+                    "tool_name": tname,
+                    "tool_use_id": block.id,
+                    "inputs": tinputs,
+                    "result_snippet": result_text[:500],
+                }
+            )
+
+            tool_results.append(
+                {
+                    "type": "tool_result",
+                    "tool_use_id": block.id,
+                    "content": result_text,
+                }
+            )
+
+        messages.append({"role": "user", "content": tool_results})
+
+    else:
+        answer = answer or "MAX_TURNS_REACHED"
+        error = error or f"Reached {_MAX_TURNS}-turn limit without end_turn"
+
+    return (
+        answer,
+        input_tokens,
+        output_tokens,
+        tool_calls,
+        file_reads,
+        search_calls,
+        index_queries,
+        error,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
 
 
 def run_one(
@@ -64,85 +519,97 @@ def run_one(
     timeout_seconds: int = 1200,
     model: str = "claude-sonnet-4-6",
 ) -> dict:
-    """Run one benchmark trial.  Returns a dict matching RunRecord schema.
+    """Run one benchmark trial.
 
-    Writes the prompt to  results_dir/raw/<run_id>_prompt.txt
-    Appends the run record to results_dir/runs.jsonl
+    Writes:
+      results_dir/raw/<run_id>_prompt.txt
+      results_dir/raw/<run_id>_transcript.jsonl
+      results_dir/runs.jsonl  (appended)
 
-    Parameters
-    ----------
-    question_id:
-        Stable identifier for the question (e.g. "q01_cold_start").
-    question_prompt:
-        The verbatim question text shown to Claude.
-    arm_id:
-        Which benchmark arm is being tested (e.g. "native-only", "tsa-warm").
-    repo_path:
-        Absolute path to the repository under test.
-    repeat:
-        Zero-based repeat index for this (question, arm) pair.
-    run_config:
-        RunConfig built by the adapter for this run.
-    results_dir:
-        Root directory under which raw/ and runs.jsonl are written.
-    timeout_seconds:
-        Maximum wall-clock seconds allowed for the Claude session.
-        Unused in dry-run mode but stored in the record for future reference.
-    model:
-        Claude model ID to invoke.  Stored in record; unused in dry-run mode.
+    Returns a dict matching RunRecord schema.
     """
     run_id = _make_run_id(question_id, arm_id, repeat)
     started_at = datetime.now(timezone.utc).isoformat()
     started_perf = time.perf_counter()
 
-    # ------------------------------------------------------------------
-    # Build the full prompt
-    # ------------------------------------------------------------------
-    full_prompt = _build_full_prompt(run_config, question_prompt)
+    # Build prompt
+    user_message_parts = []
+    if run_config.extra_context:
+        user_message_parts.append(run_config.extra_context)
+    user_message_parts.append(f"Question: {question_prompt}")
+    user_message = "\n\n".join(user_message_parts)
 
-    # ------------------------------------------------------------------
-    # Write prompt to disk
-    # ------------------------------------------------------------------
+    # Persist prompt for reproducibility
     raw_dir = results_dir / "raw"
     raw_dir.mkdir(parents=True, exist_ok=True)
     prompt_path = raw_dir / f"{run_id}_prompt.txt"
-    prompt_path.write_text(full_prompt, encoding="utf-8")
+    prompt_path.write_text(
+        f"SYSTEM:\n{run_config.system_prompt}\n\nUSER:\n{user_message}",
+        encoding="utf-8",
+    )
 
-    # ------------------------------------------------------------------
-    # Dry-run stub  (replace this block with real API call when validated)
-    # ------------------------------------------------------------------
-    answer = "DRY_RUN"
-    tokens_in = 0
-    tokens_out = 0
-    tool_calls = 0
-    error = None
-    # ------------------------------------------------------------------
+    # Get tools for this arm
+    tools = _ARM_TOOLS.get(arm_id, _ARM_TOOLS["native-only"])
+
+    # Run agent loop
+    transcript: list[dict[str, Any]] = []
+    (
+        answer,
+        input_tokens,
+        output_tokens,
+        tool_calls,
+        file_reads,
+        search_calls,
+        index_queries,
+        error,
+    ) = _run_agent_loop(
+        system_prompt=run_config.system_prompt,
+        user_message=user_message,
+        tools=tools,
+        repo_path=repo_path,
+        arm_id=arm_id,
+        model=model,
+        timeout_seconds=timeout_seconds,
+        transcript=transcript,
+    )
 
     ended_at = datetime.now(timezone.utc).isoformat()
     elapsed_seconds = round(time.perf_counter() - started_perf, 4)
+    total_tokens = input_tokens + output_tokens
+    estimated_cost = (input_tokens / 1_000_000 * 3.0) + (
+        output_tokens / 1_000_000 * 15.0
+    )
+
+    # Persist transcript
+    transcript_path = raw_dir / f"{run_id}_transcript.jsonl"
+    with transcript_path.open("w", encoding="utf-8") as fh:
+        for entry in transcript:
+            fh.write(json.dumps(entry, ensure_ascii=False, default=str) + "\n")
 
     record: dict = {
         "run_id": run_id,
+        "repo": str(repo_path.name),
         "question_id": question_id,
-        "arm_id": arm_id,
-        "repo_path": str(repo_path),
+        "arm": arm_id,
         "repeat": repeat,
-        "model": model,
-        "timeout_seconds": timeout_seconds,
         "started_at": started_at,
         "ended_at": ended_at,
         "elapsed_seconds": elapsed_seconds,
-        "answer": answer,
-        "tokens_in": tokens_in,
-        "tokens_out": tokens_out,
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": total_tokens,
+        "estimated_cost_usd": round(estimated_cost, 6),
         "tool_calls": tool_calls,
+        "file_reads": file_reads,
+        "search_calls": search_calls,
+        "index_queries": index_queries,
+        "answer": answer,
+        "citations": _extract_citations(answer),
+        "transcript_path": str(transcript_path),
         "error": error,
-        "prompt_file": str(prompt_path),
     }
 
-    # ------------------------------------------------------------------
-    # Append record as JSONL
-    # ------------------------------------------------------------------
+    # Append to JSONL
     runs_jsonl = results_dir / "runs.jsonl"
     with runs_jsonl.open("a", encoding="utf-8") as fh:
         fh.write(json.dumps(record, ensure_ascii=False) + "\n")

--- a/benchmarks/codegraph_compare/adapters/claude_runner.py
+++ b/benchmarks/codegraph_compare/adapters/claude_runner.py
@@ -1,0 +1,150 @@
+"""Claude API runner for a single benchmark question against one arm.
+
+# TODO: replace dry-run stub with real Claude API calls once harness is validated
+
+Currently operates in **dry-run / stub** mode:
+  - Builds the full prompt that WOULD be sent (system + user message)
+  - Writes it to results_dir/raw/<run_id>_prompt.txt
+  - Returns a RunRecord with answer="DRY_RUN", all token counts=0, tool_calls=0
+  - Never makes a real network call
+
+This lets the harness structure, file layout, YAML loading, and CLI wiring be
+validated end-to-end before live API credentials are needed.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from . import RunConfig
+
+
+def _make_run_id(question_id: str, arm_id: str, repeat: int) -> str:
+    """Build a deterministic run identifier.
+
+    Formula mirrors RunRecord.make_id in schemas.py so run IDs are consistent
+    whether generated here or from the schema layer.
+    """
+    return f"{question_id}__{arm_id}__{repeat:02d}"
+
+
+def _build_full_prompt(
+    run_config: RunConfig,
+    question_prompt: str,
+) -> str:
+    """Assemble the full prompt string that would be sent to Claude.
+
+    Structure:
+      <system_prompt>
+
+      <extra_context>
+
+      Question: <question_prompt>
+    """
+    parts: list[str] = [run_config.system_prompt]
+    if run_config.extra_context:
+        parts.append(run_config.extra_context)
+    parts.append(f"Question: {question_prompt}")
+    return "\n\n".join(parts)
+
+
+def run_one(
+    question_id: str,
+    question_prompt: str,
+    arm_id: str,
+    repo_path: Path,
+    repeat: int,
+    run_config: RunConfig,
+    results_dir: Path,
+    timeout_seconds: int = 1200,
+    model: str = "claude-sonnet-4-6",
+) -> dict:
+    """Run one benchmark trial.  Returns a dict matching RunRecord schema.
+
+    Writes the prompt to  results_dir/raw/<run_id>_prompt.txt
+    Appends the run record to results_dir/runs.jsonl
+
+    Parameters
+    ----------
+    question_id:
+        Stable identifier for the question (e.g. "q01_cold_start").
+    question_prompt:
+        The verbatim question text shown to Claude.
+    arm_id:
+        Which benchmark arm is being tested (e.g. "native-only", "tsa-warm").
+    repo_path:
+        Absolute path to the repository under test.
+    repeat:
+        Zero-based repeat index for this (question, arm) pair.
+    run_config:
+        RunConfig built by the adapter for this run.
+    results_dir:
+        Root directory under which raw/ and runs.jsonl are written.
+    timeout_seconds:
+        Maximum wall-clock seconds allowed for the Claude session.
+        Unused in dry-run mode but stored in the record for future reference.
+    model:
+        Claude model ID to invoke.  Stored in record; unused in dry-run mode.
+    """
+    run_id = _make_run_id(question_id, arm_id, repeat)
+    started_at = datetime.now(timezone.utc).isoformat()
+    started_perf = time.perf_counter()
+
+    # ------------------------------------------------------------------
+    # Build the full prompt
+    # ------------------------------------------------------------------
+    full_prompt = _build_full_prompt(run_config, question_prompt)
+
+    # ------------------------------------------------------------------
+    # Write prompt to disk
+    # ------------------------------------------------------------------
+    raw_dir = results_dir / "raw"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    prompt_path = raw_dir / f"{run_id}_prompt.txt"
+    prompt_path.write_text(full_prompt, encoding="utf-8")
+
+    # ------------------------------------------------------------------
+    # Dry-run stub  (replace this block with real API call when validated)
+    # ------------------------------------------------------------------
+    answer = "DRY_RUN"
+    tokens_in = 0
+    tokens_out = 0
+    tool_calls = 0
+    error = None
+    # ------------------------------------------------------------------
+
+    ended_at = datetime.now(timezone.utc).isoformat()
+    elapsed_seconds = round(time.perf_counter() - started_perf, 4)
+
+    record: dict = {
+        "run_id": run_id,
+        "question_id": question_id,
+        "arm_id": arm_id,
+        "repo_path": str(repo_path),
+        "repeat": repeat,
+        "model": model,
+        "timeout_seconds": timeout_seconds,
+        "started_at": started_at,
+        "ended_at": ended_at,
+        "elapsed_seconds": elapsed_seconds,
+        "answer": answer,
+        "tokens_in": tokens_in,
+        "tokens_out": tokens_out,
+        "tool_calls": tool_calls,
+        "error": error,
+        "prompt_file": str(prompt_path),
+    }
+
+    # ------------------------------------------------------------------
+    # Append record as JSONL
+    # ------------------------------------------------------------------
+    runs_jsonl = results_dir / "runs.jsonl"
+    with runs_jsonl.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    return record

--- a/benchmarks/codegraph_compare/adapters/claude_runner.py
+++ b/benchmarks/codegraph_compare/adapters/claude_runner.py
@@ -1,11 +1,11 @@
-"""Benchmark runner that drives the `claude --print` CLI for each trial.
+"""Benchmark runner that drives Claude CLI or Codex CLI for each trial.
 
 No separate API key required — uses the current Claude Code session's
 authentication (keychain / OAuth).
 
 Writes:
-  - results_dir/raw/<run_id>_prompt.txt          — the full prompt sent to claude
-  - results_dir/raw/<run_id>_result.json         — raw JSON response from claude CLI
+  - results_dir/raw/<run_id>_prompt.txt          — the full prompt sent to the agent
+  - results_dir/raw/<run_id>_result.jsonl        — raw JSONL response from the agent CLI
   - results_dir/runs.jsonl                       — one JSONL line per trial (appended)
 """
 
@@ -74,8 +74,14 @@ _ARM_DISALLOWED_TOOLS: dict[str, list[str]] = {
 # ---------------------------------------------------------------------------
 
 
-def _make_run_id(question_id: str, arm_id: str, repeat: int) -> str:
-    return f"{question_id}__{arm_id}__{repeat:02d}"
+_DEFAULT_MODELS = {
+    "claude": "claude-sonnet-4-6",
+    "codex": "gpt-5.2",
+}
+
+
+def _make_run_id(question_id: str, arm_id: str, repeat: int, agent_backend: str) -> str:
+    return f"{question_id}__{arm_id}__{agent_backend}__{repeat:02d}"
 
 
 def _extract_citations(text: str) -> list[str]:
@@ -132,6 +138,116 @@ def _parse_tool_calls_from_stream(lines: list[str]) -> tuple[int, int, int, int]
     return tool_calls, file_reads, search_calls, index_queries
 
 
+def _looks_like_shell_read(command: str) -> bool:
+    return bool(re.search(r"\b(cat|head|tail|nl)\b|\bsed\s+-n\b", command))
+
+
+def _looks_like_shell_search(command: str) -> bool:
+    return bool(re.search(r"\b(rg|grep|find|fd|ls)\b", command))
+
+
+def _looks_like_index_query(command: str) -> bool:
+    return "tree_sitter_analyzer" in command or "codegraph" in command.lower()
+
+
+def _parse_codex_tool_calls_from_stream(lines: list[str]) -> tuple[int, int, int, int]:
+    """Count Codex CLI command_execution events by benchmark category."""
+    tool_calls = 0
+    file_reads = 0
+    search_calls = 0
+    index_queries = 0
+
+    for line in lines:
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if event.get("type") != "item.completed":
+            continue
+
+        item = event.get("item", {})
+        if item.get("type") != "command_execution":
+            continue
+
+        tool_calls += 1
+        command = str(item.get("command") or "")
+        if _looks_like_index_query(command):
+            index_queries += 1
+        elif _looks_like_shell_read(command):
+            file_reads += 1
+        elif _looks_like_shell_search(command):
+            search_calls += 1
+        else:
+            search_calls += 1
+
+    return tool_calls, file_reads, search_calls, index_queries
+
+
+def _parse_codex_stream(lines: list[str]) -> tuple[str, dict[str, Any], str | None]:
+    answer = ""
+    usage: dict[str, Any] = {}
+    error: str | None = None
+
+    for line in lines:
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        event_type = event.get("type")
+        if event_type == "item.completed":
+            item = event.get("item", {})
+            if item.get("type") == "agent_message":
+                answer = item.get("text", "")
+            elif item.get("type") == "error":
+                error = item.get("message") or json.dumps(item)
+        elif event_type == "turn.completed":
+            usage = event.get("usage", {})
+        elif event_type in {"turn.failed", "error"}:
+            error = event.get("message") or event.get("error") or json.dumps(event)
+
+    if not answer and not error:
+        error = "No Codex agent_message event found in stream output"
+    return answer, usage, error
+
+
+def _usage_int(usage: dict[str, Any], key: str) -> int:
+    value = usage.get(key, 0)
+    return int(value or 0)
+
+
+def _extract_usage_metrics(
+    usage: dict[str, Any], agent_backend: str
+) -> tuple[int, int, int, int, int]:
+    """Return input, cached input, output, reasoning output, total tokens.
+
+    Claude and Codex expose cache details differently. Claude reports cache read
+    and creation tokens outside input_tokens; Codex reports cached/reasoning
+    counters as detail fields that are already included in input/output totals.
+    """
+    input_tokens = _usage_int(usage, "input_tokens")
+    output_tokens = _usage_int(usage, "output_tokens")
+    cached_input_tokens = (
+        _usage_int(usage, "cached_input_tokens")
+        + _usage_int(usage, "cache_read_input_tokens")
+        + _usage_int(usage, "cache_creation_input_tokens")
+    )
+    reasoning_output_tokens = _usage_int(usage, "reasoning_output_tokens")
+
+    if agent_backend == "claude":
+        total_tokens = input_tokens + cached_input_tokens + output_tokens
+    else:
+        total_tokens = input_tokens + output_tokens
+
+    return (
+        input_tokens,
+        cached_input_tokens,
+        output_tokens,
+        reasoning_output_tokens,
+        total_tokens,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------
@@ -146,23 +262,41 @@ def run_one(
     run_config: RunConfig,
     results_dir: Path,
     timeout_seconds: int = 1200,
-    model: str = "claude-sonnet-4-6",
+    model: str | None = None,
+    agent_backend: str = "claude",
     dry_run: bool = False,
 ) -> dict:
-    """Run one benchmark trial via `claude --print --output-format json`.
+    """Run one benchmark trial via the configured agent CLI.
 
     Writes prompt + raw result to results_dir/raw/, appends to runs.jsonl.
     """
-    run_id = _make_run_id(question_id, arm_id, repeat)
+    if agent_backend not in {"claude", "codex"}:
+        raise ValueError("agent_backend must be one of: claude, codex")
+    model = model or _DEFAULT_MODELS[agent_backend]
+    run_id = _make_run_id(question_id, arm_id, repeat, agent_backend)
     started_at = datetime.now(timezone.utc).isoformat()
     started_perf = time.perf_counter()
 
-    # Build the prompt Claude will receive
+    allowed_tools_str = ",".join(
+        _ARM_ALLOWED_TOOLS.get(arm_id, _ARM_ALLOWED_TOOLS["native-only"])
+    )
+    disallowed_tools_str = ",".join(_ARM_DISALLOWED_TOOLS.get(arm_id, []))
+
+    # Build the prompt the agent will receive
     user_parts = []
     if run_config.extra_context:
         user_parts.append(run_config.extra_context)
     user_parts.append(f"Question: {question_prompt}")
     user_message = "\n\n".join(user_parts)
+    if agent_backend == "codex":
+        tool_policy = (
+            f"Benchmark arm: {arm_id}.\n"
+            f"Allowed tool policy: {allowed_tools_str}.\n"
+            f"Disallowed tool policy: {disallowed_tools_str or 'none'}.\n"
+            "Respect this policy strictly when using tools. Do not edit files. "
+            "Answer the architecture question with concrete file citations."
+        )
+        user_message = f"{tool_policy}\n\n{user_message}"
 
     full_prompt = f"{run_config.system_prompt}\n\n{user_message}"
 
@@ -172,29 +306,44 @@ def run_one(
     prompt_path = raw_dir / f"{run_id}_prompt.txt"
     prompt_path.write_text(full_prompt, encoding="utf-8")
 
-    # Build claude CLI command — stream-json captures per-tool-call events
-    allowed_tools_str = ",".join(
-        _ARM_ALLOWED_TOOLS.get(arm_id, _ARM_ALLOWED_TOOLS["native-only"])
-    )
-    disallowed_tools_str = ",".join(_ARM_DISALLOWED_TOOLS.get(arm_id, []))
-    cmd = [
-        "claude",
-        "--print",
-        "--output-format",
-        "stream-json",
-        "--verbose",
-        "--no-session-persistence",
-        "--model",
-        model,
-        "--add-dir",
-        str(repo_path),
-        "--append-system-prompt",
-        run_config.system_prompt,
-        "--allowed-tools",
-        allowed_tools_str,
-    ]
-    if disallowed_tools_str:
-        cmd += ["--disallowed-tools", disallowed_tools_str]
+    # Build agent CLI command. Claude has stronger tool allowlisting; Codex
+    # gets the same restrictions as explicit prompt text because codex exec
+    # currently exposes sandbox controls rather than per-tool allowlists.
+    if agent_backend == "claude":
+        cmd = [
+            "claude",
+            "--print",
+            "--output-format",
+            "stream-json",
+            "--verbose",
+            "--no-session-persistence",
+            "--model",
+            model,
+            "--add-dir",
+            str(repo_path),
+            "--append-system-prompt",
+            run_config.system_prompt,
+            "--allowed-tools",
+            allowed_tools_str,
+        ]
+        if disallowed_tools_str:
+            cmd += ["--disallowed-tools", disallowed_tools_str]
+    else:
+        cmd = [
+            "codex",
+            "--ask-for-approval",
+            "never",
+            "exec",
+            "--json",
+            "--ephemeral",
+            "--sandbox",
+            "read-only",
+            "--model",
+            model,
+            "-C",
+            str(repo_path),
+            "-",
+        ]
 
     # Run — prompt via stdin
     error: str | None = None
@@ -225,8 +374,10 @@ def run_one(
             result_path.write_text(proc.stdout, encoding="utf-8")
 
             if proc.returncode != 0 and not proc.stdout.strip():
-                error = f"claude CLI exited {proc.returncode}: {proc.stderr[:500]}"
-            else:
+                error = (
+                    f"{agent_backend} CLI exited {proc.returncode}: {proc.stderr[:500]}"
+                )
+            elif agent_backend == "claude":
                 # Extract result event (last line is usually the result)
                 for line in reversed(stream_lines):
                     try:
@@ -248,29 +399,42 @@ def run_one(
             error = f"Timed out after {timeout_seconds}s"
             answer = "TIMEOUT"
         except FileNotFoundError:
-            error = "claude CLI not found in PATH"
+            error = f"{agent_backend} CLI not found in PATH"
             answer = "ERROR"
+
+        if agent_backend == "codex" and not dry_run:
+            answer, codex_usage, codex_error = _parse_codex_stream(stream_lines)
+            if codex_error:
+                error = codex_error
+                answer = answer or "ERROR"
+            raw_result = {"usage": codex_usage}
 
     ended_at = datetime.now(timezone.utc).isoformat()
     elapsed_seconds = round(time.perf_counter() - started_perf, 4)
 
     # Extract metrics from result event
     usage = raw_result.get("usage", {})
-    input_tokens = usage.get("input_tokens", 0) + usage.get(
-        "cache_read_input_tokens", 0
-    )
-    output_tokens = usage.get("output_tokens", 0)
-    total_tokens = input_tokens + output_tokens
+    (
+        input_tokens,
+        cached_input_tokens,
+        output_tokens,
+        reasoning_output_tokens,
+        total_tokens,
+    ) = _extract_usage_metrics(usage, agent_backend)
     estimated_cost = float(raw_result.get("total_cost_usd", 0.0))
-    if estimated_cost == 0 and total_tokens > 0:
+    if estimated_cost == 0 and input_tokens + output_tokens > 0:
         estimated_cost = (input_tokens / 1_000_000 * 3.0) + (
             output_tokens / 1_000_000 * 15.0
         )
 
-    # Count tool calls from assistant events in the stream
-    tool_calls, file_reads, search_calls, index_queries = _parse_tool_calls_from_stream(
-        stream_lines
+    # Count tool calls from agent stream events. Claude exposes tool_use blocks;
+    # Codex exposes completed shell command events.
+    tool_parser = (
+        _parse_codex_tool_calls_from_stream
+        if agent_backend == "codex"
+        else _parse_tool_calls_from_stream
     )
+    tool_calls, file_reads, search_calls, index_queries = tool_parser(stream_lines)
 
     record: dict = {
         "run_id": run_id,
@@ -282,7 +446,9 @@ def run_one(
         "ended_at": ended_at,
         "elapsed_seconds": elapsed_seconds,
         "input_tokens": input_tokens,
+        "cached_input_tokens": cached_input_tokens,
         "output_tokens": output_tokens,
+        "reasoning_output_tokens": reasoning_output_tokens,
         "total_tokens": total_tokens,
         "estimated_cost_usd": round(estimated_cost, 6),
         "tool_calls": tool_calls,
@@ -293,6 +459,8 @@ def run_one(
         "citations": _extract_citations(answer),
         "transcript_path": str(raw_dir / f"{run_id}_result.jsonl"),
         "error": error,
+        "agent_backend": agent_backend,
+        "model": model,
     }
 
     runs_jsonl = results_dir / "runs.jsonl"

--- a/benchmarks/codegraph_compare/adapters/claude_runner.py
+++ b/benchmarks/codegraph_compare/adapters/claude_runner.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
 
 _BASE_TOOLS = ["Read", "Bash(grep *)", "Bash(find *)", "Bash(ls *)", "Glob", "Grep"]
 _CODEGRAPH_TOOLS = [
+    "Bash(codegraph *)",
     "mcp__codegraph__codegraph_context",
     "mcp__codegraph__codegraph_search",
     "mcp__codegraph__codegraph_callers",
@@ -57,14 +58,15 @@ _ARM_ALLOWED_TOOLS: dict[str, list[str]] = {
 # can't discover and call them even when --allowed-tools is set
 _ARM_DISALLOWED_TOOLS: dict[str, list[str]] = {
     "native-only": [
+        "Bash(codegraph *)",
         "mcp__codegraph__*",
         "mcp__ruflo__*",
         "mcp__*",
         "ToolSearch",
         "Agent",
     ],
-    "tsa-warm": ["mcp__codegraph__*", "ToolSearch", "Agent"],
-    "tsa-cold": ["mcp__codegraph__*", "ToolSearch", "Agent"],
+    "tsa-warm": ["Bash(codegraph *)", "mcp__codegraph__*", "ToolSearch", "Agent"],
+    "tsa-cold": ["Bash(codegraph *)", "mcp__codegraph__*", "ToolSearch", "Agent"],
     "codegraph-warm": ["ToolSearch", "Agent"],
     "codegraph-cold": ["ToolSearch", "Agent"],
 }
@@ -84,18 +86,36 @@ def _make_run_id(question_id: str, arm_id: str, repeat: int, agent_backend: str)
     return f"{question_id}__{arm_id}__{agent_backend}__{repeat:02d}"
 
 
-def _extract_citations(text: str) -> list[str]:
-    """Extract file-path-like strings from the answer text."""
-    return list(
-        dict.fromkeys(
-            m.group(0)
-            for m in re.finditer(
-                r"[\w./\-]+\."
-                r"(?:py|ts|tsx|go|rs|java|swift|kt|js|jsx|cpp|c|h|cs|rb|php)",
-                text,
-            )
-        )
-    )
+def _extract_citations(text: str, repo_path: Path) -> list[str]:
+    """Extract answer citations that correspond to real files in repo_path."""
+    citations: list[str] = []
+    seen: set[str] = set()
+
+    for match in re.finditer(
+        r"[\w./\-]+\."
+        r"(?:py|ts|tsx|go|rs|java|swift|kt|js|jsx|cpp|c|h|cs|rb|php)",
+        text,
+    ):
+        candidate = match.group(0).lstrip("./")
+        if candidate in seen:
+            continue
+        path = Path(candidate)
+        if path.is_absolute():
+            exists = path.is_file()
+        else:
+            exists = (repo_path / candidate).is_file()
+        if exists:
+            citations.append(candidate)
+            seen.add(candidate)
+
+    return citations
+
+
+def _codex_sandbox_for_arm(arm_id: str) -> str:
+    """Return the least-permissive Codex sandbox that still lets indexes query."""
+    if arm_id == "native-only":
+        return "read-only"
+    return "workspace-write"
 
 
 def _parse_tool_calls_from_stream(lines: list[str]) -> tuple[int, int, int, int]:
@@ -289,11 +309,16 @@ def run_one(
     user_parts.append(f"Question: {question_prompt}")
     user_message = "\n\n".join(user_parts)
     if agent_backend == "codex":
+        sandbox = _codex_sandbox_for_arm(arm_id)
         tool_policy = (
             f"Benchmark arm: {arm_id}.\n"
+            f"Codex sandbox: {sandbox}.\n"
             f"Allowed tool policy: {allowed_tools_str}.\n"
             f"Disallowed tool policy: {disallowed_tools_str or 'none'}.\n"
-            "Respect this policy strictly when using tools. Do not edit files. "
+            "Respect this policy strictly when using tools. Do not edit source "
+            "files or project configuration. For indexed arms, the only allowed "
+            "writes are tool-maintained cache/database side effects such as "
+            ".codegraph SQLite WAL files or .ast-cache metadata. "
             "Answer the architecture question with concrete file citations."
         )
         user_message = f"{tool_policy}\n\n{user_message}"
@@ -329,6 +354,7 @@ def run_one(
         if disallowed_tools_str:
             cmd += ["--disallowed-tools", disallowed_tools_str]
     else:
+        sandbox = _codex_sandbox_for_arm(arm_id)
         cmd = [
             "codex",
             "--ask-for-approval",
@@ -337,7 +363,7 @@ def run_one(
             "--json",
             "--ephemeral",
             "--sandbox",
-            "read-only",
+            sandbox,
             "--model",
             model,
             "-C",
@@ -456,7 +482,7 @@ def run_one(
         "search_calls": search_calls,
         "index_queries": index_queries,
         "answer": answer,
-        "citations": _extract_citations(answer),
+        "citations": _extract_citations(answer, repo_path),
         "transcript_path": str(raw_dir / f"{run_id}_result.jsonl"),
         "error": error,
         "agent_backend": agent_backend,

--- a/benchmarks/codegraph_compare/adapters/codegraph.py
+++ b/benchmarks/codegraph_compare/adapters/codegraph.py
@@ -1,0 +1,260 @@
+"""CodeGraphAdapter — benchmark arm backed by the CodeGraph AST index.
+
+Supports two modes:
+  - ``arm_id="codegraph-cold"``: deletes .codegraph/ and rebuilds from scratch.
+  - ``arm_id="codegraph-warm"``: verifies the index exists; rebuilds only if absent.
+
+Index build is done via ``codegraph init -i`` with cwd=repo_path.
+Errors are logged, not raised, so the harness can continue with partial data.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+from . import BenchmarkAdapter, IndexStats, RunConfig, ToolMetrics
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Inline default system prompt
+# ---------------------------------------------------------------------------
+
+_DEFAULT_SYSTEM_PROMPT = """\
+You are answering an architecture question about a software codebase.
+A CodeGraph AST index has been pre-built for this repository.
+
+Tools available to you: Read, Bash, Grep, Glob, and the codegraph_* MCP tools.
+
+When answering:
+- Start with codegraph_context or codegraph_search to locate relevant symbols
+  before falling back to raw Grep or Read.
+- Cite the specific file path and symbol name for every claim you make.
+- Do not guess — only report what you find in the index or in the files.
+- If the index returns no results for a query, say so and try an alternative
+  search term; do not fabricate an answer.
+- Prefer a single codegraph_explore call over many individual codegraph_node calls.
+"""
+
+_PROMPTS_DIR = Path(__file__).resolve().parent.parent / "prompts"
+_PROMPT_FILE = _PROMPTS_DIR / "system_codegraph.md"
+
+# ---------------------------------------------------------------------------
+# CodeGraph index directory
+# ---------------------------------------------------------------------------
+
+_INDEX_DIR = ".codegraph"
+
+# Tools Claude is allowed to call in this arm
+_ALLOWED_TOOLS = [
+    "Read",
+    "Bash",
+    "Grep",
+    "Glob",
+    "mcp__codegraph__codegraph_context",
+    "mcp__codegraph__codegraph_search",
+    "mcp__codegraph__codegraph_callers",
+    "mcp__codegraph__codegraph_callees",
+    "mcp__codegraph__codegraph_explore",
+    "mcp__codegraph__codegraph_node",
+    "mcp__codegraph__codegraph_files",
+    "mcp__codegraph__codegraph_impact",
+]
+
+# Patterns used for parse_tool_metrics
+_FILE_READ_TOOLS = frozenset({"read"})
+_SEARCH_TOOLS = frozenset({"grep", "glob", "bash"})
+_CODEGRAPH_PREFIX = "codegraph_"
+
+
+class CodeGraphAdapter(BenchmarkAdapter):
+    """Benchmark arm: CodeGraph AST index available to Claude."""
+
+    def __init__(self, arm_id: str = "codegraph-warm") -> None:
+        if arm_id not in ("codegraph-cold", "codegraph-warm"):
+            raise ValueError(
+                f"arm_id must be 'codegraph-cold' or 'codegraph-warm', got {arm_id!r}"
+            )
+        self.arm_id = arm_id
+
+    # ------------------------------------------------------------------
+    # Index preparation
+    # ------------------------------------------------------------------
+
+    def prepare_index(self, repo_path: Path, cold: bool) -> IndexStats:
+        """Build or verify the CodeGraph index under *repo_path/.codegraph/*.
+
+        Args:
+            repo_path: Absolute path to the repository root.
+            cold: When True, always delete and rebuild. When False (warm),
+                  skip the build if the index directory already exists.
+
+        Returns:
+            IndexStats with measured build time and index size.
+        """
+        index_dir = repo_path / _INDEX_DIR
+
+        if cold:
+            _delete_index(index_dir)
+            return _build_index(repo_path, index_dir)
+
+        # Warm path — rebuild only if absent
+        if not index_dir.exists():
+            logger.info(
+                "CodeGraph index not found at %s; running cold build.", index_dir
+            )
+            return _build_index(repo_path, index_dir)
+
+        logger.info(
+            "CodeGraph index exists at %s; warm path — skipping build.", index_dir
+        )
+        size = _dir_size(index_dir)
+        file_count = _count_files(index_dir)
+        return IndexStats(
+            build_seconds=0.0, index_size_bytes=size, file_count=file_count
+        )
+
+    # ------------------------------------------------------------------
+    # Run configuration
+    # ------------------------------------------------------------------
+
+    def build_run_config(self, repo_path: Path, question_prompt: str) -> RunConfig:
+        system_prompt = _load_prompt(_PROMPT_FILE, _DEFAULT_SYSTEM_PROMPT)
+        extra_context = (
+            f"CodeGraph index is ready in {repo_path}/.codegraph/. "
+            "Use codegraph_context first, then explore as needed."
+        )
+
+        return RunConfig(
+            arm_id=self.arm_id,
+            repo_path=repo_path,
+            system_prompt=system_prompt,
+            allowed_tools=list(_ALLOWED_TOOLS),
+            forbidden_tools=[],
+            extra_context=extra_context,
+        )
+
+    # ------------------------------------------------------------------
+    # Transcript parsing
+    # ------------------------------------------------------------------
+
+    def parse_tool_metrics(self, transcript_text: str) -> ToolMetrics:
+        """Count tool invocations from raw transcript text.
+
+        codegraph_* tool mentions count as index_queries.
+        Read counts as file_reads. Bash/Grep/Glob count as search_calls.
+        """
+        tool_calls = 0
+        file_reads = 0
+        search_calls = 0
+        index_queries = 0
+
+        for match in re.finditer(r"Tool:\s*(\S+)", transcript_text, re.IGNORECASE):
+            name = match.group(1).lower().rstrip("()")
+            tool_calls += 1
+            if _CODEGRAPH_PREFIX in name:
+                index_queries += 1
+            elif name in _FILE_READ_TOOLS:
+                file_reads += 1
+            elif name in _SEARCH_TOOLS:
+                search_calls += 1
+
+        for match in re.finditer(r"\[(\w+)\]", transcript_text):
+            name = match.group(1).lower()
+            line_start = transcript_text.rfind("\n", 0, match.start()) + 1
+            line = transcript_text[line_start : match.end()]
+            if "Tool:" in line or "tool:" in line:
+                continue
+            tool_calls += 1
+            if _CODEGRAPH_PREFIX in name:
+                index_queries += 1
+            elif name in _FILE_READ_TOOLS:
+                file_reads += 1
+            elif name in _SEARCH_TOOLS:
+                search_calls += 1
+
+        return ToolMetrics(
+            tool_calls=tool_calls,
+            file_reads=file_reads,
+            search_calls=search_calls,
+            index_queries=index_queries,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _delete_index(index_dir: Path) -> None:
+    """Remove the index directory if it exists."""
+    if index_dir.exists():
+        logger.info("Deleting existing CodeGraph index at %s (cold build).", index_dir)
+        try:
+            shutil.rmtree(index_dir)
+        except OSError as exc:
+            logger.error("Failed to delete %s: %s", index_dir, exc)
+
+
+def _build_index(repo_path: Path, index_dir: Path) -> IndexStats:
+    """Run ``codegraph init -i`` and return IndexStats."""
+    logger.info("Building CodeGraph index in %s ...", repo_path)
+    t0 = time.perf_counter()
+
+    result = subprocess.run(
+        ["codegraph", "init", "-i"],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+    elapsed = time.perf_counter() - t0
+
+    if result.returncode != 0:
+        logger.error(
+            "codegraph init -i exited with code %d.\nstdout: %s\nstderr: %s",
+            result.returncode,
+            result.stdout[:2000],
+            result.stderr[:2000],
+        )
+
+    size = _dir_size(index_dir) if index_dir.exists() else 0
+    file_count = _count_files(index_dir) if index_dir.exists() else 0
+
+    logger.info(
+        "CodeGraph index built in %.2fs, size=%d bytes, files=%d",
+        elapsed,
+        size,
+        file_count,
+    )
+    return IndexStats(
+        build_seconds=elapsed,
+        index_size_bytes=size,
+        file_count=file_count,
+    )
+
+
+def _dir_size(path: Path) -> int:
+    """Return the total byte size of all files under *path*."""
+    if not path.exists():
+        return 0
+    return sum(f.stat().st_size for f in path.rglob("*") if f.is_file())
+
+
+def _count_files(path: Path) -> int:
+    """Return the number of files under *path*."""
+    if not path.exists():
+        return 0
+    return sum(1 for f in path.rglob("*") if f.is_file())
+
+
+def _load_prompt(prompt_file: Path, default: str) -> str:
+    if prompt_file.is_file():
+        return prompt_file.read_text(encoding="utf-8").strip()
+    return default

--- a/benchmarks/codegraph_compare/adapters/codegraph.py
+++ b/benchmarks/codegraph_compare/adapters/codegraph.py
@@ -127,7 +127,10 @@ class CodeGraphAdapter(BenchmarkAdapter):
         system_prompt = _load_prompt(_PROMPT_FILE, _DEFAULT_SYSTEM_PROMPT)
         extra_context = (
             f"CodeGraph index is ready in {repo_path}/.codegraph/. "
-            "Use codegraph_context first, then explore as needed."
+            "Use codegraph_context first when MCP is available. "
+            "When running through a shell-only agent backend, run "
+            '`codegraph context -p . "<task>" --format json` first, then '
+            "confirm specific details with focused file reads as needed."
         )
 
         return RunConfig(

--- a/benchmarks/codegraph_compare/adapters/native.py
+++ b/benchmarks/codegraph_compare/adapters/native.py
@@ -1,0 +1,134 @@
+"""NativeAdapter — baseline arm that relies only on file-system tools.
+
+No index is built. Claude is allowed to Read, Bash, Grep, and Glob.
+All codegraph and TSA index tools are explicitly forbidden so the
+transcript reflects raw file-search cost.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from . import BenchmarkAdapter, IndexStats, RunConfig, ToolMetrics
+
+# ---------------------------------------------------------------------------
+# Inline default system prompt (used when the .md file is absent)
+# ---------------------------------------------------------------------------
+
+_DEFAULT_SYSTEM_PROMPT = """\
+You are answering an architecture question about a software codebase.
+
+Tools available to you: Read, Bash, Grep, Glob.
+You may NOT use any codegraph or tree-sitter-analyzer index tools.
+
+When answering:
+- Cite the specific file path and line number for every claim you make.
+- Do not guess or infer from memory — only report what you actually find in the code.
+- If you cannot find evidence in the files, say so explicitly.
+- Prefer targeted Grep searches over reading entire files when you only need a pattern.
+"""
+
+# Prompt file path relative to the benchmarks/codegraph_compare directory
+_PROMPTS_DIR = Path(__file__).resolve().parent.parent / "prompts"
+_PROMPT_FILE = _PROMPTS_DIR / "system_native.md"
+
+# ---------------------------------------------------------------------------
+# Tool name patterns used by parse_tool_metrics
+# ---------------------------------------------------------------------------
+
+# These map a tool name (lowercased) to whether it counts as a file_read or
+# a search_call. Any tool not in the map is counted only in tool_calls.
+_FILE_READ_TOOLS = frozenset({"read"})
+_SEARCH_TOOLS = frozenset({"grep", "glob", "bash"})
+
+
+class NativeAdapter(BenchmarkAdapter):
+    """Benchmark arm: native file-system tools only, no pre-built index."""
+
+    arm_id = "native-only"
+
+    # ------------------------------------------------------------------
+    # Index preparation — no-op for this arm
+    # ------------------------------------------------------------------
+
+    def prepare_index(self, repo_path: Path, cold: bool) -> IndexStats:
+        """No index to build. Returns zeroed stats immediately."""
+        return IndexStats(build_seconds=0.0, index_size_bytes=0, file_count=0)
+
+    # ------------------------------------------------------------------
+    # Run configuration
+    # ------------------------------------------------------------------
+
+    def build_run_config(self, repo_path: Path, question_prompt: str) -> RunConfig:
+        system_prompt = _load_prompt(_PROMPT_FILE, _DEFAULT_SYSTEM_PROMPT)
+
+        return RunConfig(
+            arm_id=self.arm_id,
+            repo_path=repo_path,
+            system_prompt=system_prompt,
+            allowed_tools=["Read", "Bash", "Grep", "Glob"],
+            forbidden_tools=["mcp__codegraph__*", "mcp__tsa__*"],
+            extra_context="",
+        )
+
+    # ------------------------------------------------------------------
+    # Transcript parsing
+    # ------------------------------------------------------------------
+
+    def parse_tool_metrics(self, transcript_text: str) -> ToolMetrics:
+        """Count tool invocations from raw transcript text.
+
+        Recognises two patterns emitted by the Claude Code harness:
+          - ``Tool: ToolName`` (one per invocation line)
+          - ``[ToolName]``     (bracket notation)
+
+        Read, Grep, Glob are split into file_reads vs search_calls.
+        Bash counts as a search_call (it most commonly runs grep/find).
+        """
+        tool_calls = 0
+        file_reads = 0
+        search_calls = 0
+
+        # Pattern 1 — "Tool: ToolName" or "Tool: ToolName(...)"
+        for match in re.finditer(r"Tool:\s*(\w+)", transcript_text, re.IGNORECASE):
+            name = match.group(1).lower()
+            tool_calls += 1
+            if name in _FILE_READ_TOOLS:
+                file_reads += 1
+            elif name in _SEARCH_TOOLS:
+                search_calls += 1
+
+        # Pattern 2 — "[ToolName]" bracket notation
+        for match in re.finditer(r"\[(\w+)\]", transcript_text):
+            name = match.group(1).lower()
+            # Avoid double-counting if both patterns appear for the same call
+            # by only counting bracket lines that are NOT preceded by "Tool:"
+            line_start = transcript_text.rfind("\n", 0, match.start()) + 1
+            line = transcript_text[line_start : match.end()]
+            if "Tool:" in line or "tool:" in line:
+                continue
+            tool_calls += 1
+            if name in _FILE_READ_TOOLS:
+                file_reads += 1
+            elif name in _SEARCH_TOOLS:
+                search_calls += 1
+
+        return ToolMetrics(
+            tool_calls=tool_calls,
+            file_reads=file_reads,
+            search_calls=search_calls,
+            index_queries=0,  # no index in this arm
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _load_prompt(prompt_file: Path, default: str) -> str:
+    """Return the content of *prompt_file* if it exists, else *default*."""
+    if prompt_file.is_file():
+        return prompt_file.read_text(encoding="utf-8").strip()
+    return default

--- a/benchmarks/codegraph_compare/adapters/tree_sitter_analyzer.py
+++ b/benchmarks/codegraph_compare/adapters/tree_sitter_analyzer.py
@@ -1,0 +1,343 @@
+"""TSAAdapter — benchmark arm backed by tree-sitter-analyzer's AST cache.
+
+Supports two modes:
+  - ``arm_id="tsa-cold"``: deletes .ast-cache/ and triggers a fresh index build.
+  - ``arm_id="tsa-warm"``: verifies .ast-cache/index.db exists; rebuilds if absent.
+
+The index is populated by running ``python -m tree_sitter_analyzer --format json``
+with ``cwd=repo_path``, which parses the source tree and populates the SQLite cache.
+Errors are logged, not raised, so the harness can continue with partial data.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+from . import BenchmarkAdapter, IndexStats, RunConfig, ToolMetrics
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Inline default system prompt
+# ---------------------------------------------------------------------------
+
+_DEFAULT_SYSTEM_PROMPT = """\
+You are answering an architecture question about a software codebase.
+tree-sitter-analyzer has been pre-run and its AST cache is available.
+
+Tools available to you: Read, Bash, Grep, Glob.
+You may run ``python -m tree_sitter_analyzer <subcommand> --format json``
+via Bash to query the AST cache.
+
+When answering:
+- Start with a tree-sitter-analyzer subcommand (smart-context, project-graph,
+  or call-graph) before falling back to raw Grep or Read.
+- Cite the specific file path and symbol name for every claim you make.
+- Do not guess — only report what you find via the tool or in the files.
+- If a subcommand returns no results, say so and try an alternative query
+  or subcommand; do not fabricate an answer.
+- Keep Bash calls focused: pass --path or --file flags to narrow scope.
+"""
+
+_PROMPTS_DIR = Path(__file__).resolve().parent.parent / "prompts"
+_PROMPT_FILE = _PROMPTS_DIR / "system_tsa.md"
+
+# ---------------------------------------------------------------------------
+# AST cache paths
+# ---------------------------------------------------------------------------
+
+_CACHE_DIR = ".ast-cache"
+_CACHE_INDEX = ".ast-cache/index.db"
+
+# Tools Claude is allowed in this arm (TSA is invoked via Bash)
+_ALLOWED_TOOLS = ["Read", "Bash", "Grep", "Glob"]
+
+# Patterns used for parse_tool_metrics
+_FILE_READ_TOOLS = frozenset({"read"})
+_SEARCH_TOOLS = frozenset({"grep", "glob"})
+# Bash tool calls that mention the TSA module count as index queries
+_TSA_PATTERNS = re.compile(
+    r"tree[_\-]sitter[_\-]analyzer|python\s+-m\s+tree_sitter_analyzer|\btsa\b",
+    re.IGNORECASE,
+)
+
+
+class TSAAdapter(BenchmarkAdapter):
+    """Benchmark arm: tree-sitter-analyzer AST cache available via Bash."""
+
+    def __init__(self, arm_id: str = "tsa-warm") -> None:
+        if arm_id not in ("tsa-cold", "tsa-warm"):
+            raise ValueError(f"arm_id must be 'tsa-cold' or 'tsa-warm', got {arm_id!r}")
+        self.arm_id = arm_id
+
+    # ------------------------------------------------------------------
+    # Index preparation
+    # ------------------------------------------------------------------
+
+    def prepare_index(self, repo_path: Path, cold: bool) -> IndexStats:
+        """Build or verify the TSA AST cache under *repo_path/.ast-cache/*.
+
+        Args:
+            repo_path: Absolute path to the repository root.
+            cold: When True, always delete and rebuild the cache.
+                  When False (warm), skip if index.db already exists.
+
+        Returns:
+            IndexStats with measured build time and cache size.
+        """
+        cache_dir = repo_path / _CACHE_DIR
+        index_db = repo_path / _CACHE_INDEX
+
+        if cold:
+            _delete_cache(cache_dir)
+            return _build_cache(repo_path, cache_dir)
+
+        # Warm path — rebuild only if the index DB is absent
+        if not index_db.exists():
+            logger.info("TSA index.db not found at %s; running cold build.", index_db)
+            return _build_cache(repo_path, cache_dir)
+
+        logger.info("TSA index.db exists at %s; warm path — skipping build.", index_db)
+        size = _dir_size(cache_dir)
+        file_count = _count_files(cache_dir)
+        return IndexStats(
+            build_seconds=0.0, index_size_bytes=size, file_count=file_count
+        )
+
+    # ------------------------------------------------------------------
+    # Run configuration
+    # ------------------------------------------------------------------
+
+    def build_run_config(self, repo_path: Path, question_prompt: str) -> RunConfig:
+        system_prompt = _load_prompt(_PROMPT_FILE, _DEFAULT_SYSTEM_PROMPT)
+        extra_context = (
+            "tree-sitter-analyzer is available. "
+            f"Run: python -m tree_sitter_analyzer <subcommand> --format json. "
+            "Key subcommands: smart-context, project-graph, call-graph. "
+            f"The AST cache is at {repo_path}/.ast-cache/"
+        )
+
+        return RunConfig(
+            arm_id=self.arm_id,
+            repo_path=repo_path,
+            system_prompt=system_prompt,
+            allowed_tools=list(_ALLOWED_TOOLS),
+            forbidden_tools=[],
+            extra_context=extra_context,
+        )
+
+    # ------------------------------------------------------------------
+    # Transcript parsing
+    # ------------------------------------------------------------------
+
+    def parse_tool_metrics(self, transcript_text: str) -> ToolMetrics:
+        """Count tool invocations from raw transcript text.
+
+        Bash lines that contain ``tree_sitter_analyzer``, ``tsa``, or
+        ``python -m tree_sitter_analyzer`` count as index_queries.
+        Read counts as file_reads. Grep/Glob count as search_calls.
+        Plain Bash calls count as search_calls unless they reference TSA.
+        """
+        tool_calls = 0
+        file_reads = 0
+        search_calls = 0
+        index_queries = 0
+
+        # Split transcript into lines for per-line context
+        lines = transcript_text.splitlines()
+
+        # Track whether we are inside a Bash tool invocation so we can
+        # classify the call once we see the command text.
+        in_bash_call = False
+        pending_bash_lines: list[str] = []
+
+        for line in lines:
+            # Detect "Tool: <name>" annotation lines
+            tool_match = re.match(r"\s*Tool:\s*(\S+)", line, re.IGNORECASE)
+            if tool_match:
+                # Flush any pending bash call first
+                if in_bash_call:
+                    _classify_bash(
+                        "\n".join(pending_bash_lines),
+                        result=_MutableCounts(
+                            tool_calls_ref=[tool_calls],
+                            search_calls_ref=[search_calls],
+                            index_queries_ref=[index_queries],
+                        ),
+                    )
+                    # Update locals from mutable containers
+                    tool_calls = _MutableCounts(
+                        tool_calls_ref=[tool_calls],
+                        search_calls_ref=[search_calls],
+                        index_queries_ref=[index_queries],
+                    ).tool_calls_ref[0]
+                    in_bash_call = False
+                    pending_bash_lines = []
+
+                name = tool_match.group(1).lower().rstrip("()")
+                tool_calls += 1
+
+                if name == "bash":
+                    in_bash_call = True
+                    pending_bash_lines = []
+                elif name in _FILE_READ_TOOLS:
+                    file_reads += 1
+                elif name in _SEARCH_TOOLS:
+                    search_calls += 1
+                continue
+
+            # If we are collecting a bash invocation, gather the line
+            if in_bash_call:
+                pending_bash_lines.append(line)
+
+        # Flush trailing bash call
+        if in_bash_call and pending_bash_lines:
+            bash_body = "\n".join(pending_bash_lines)
+            if _TSA_PATTERNS.search(bash_body):
+                index_queries += 1
+            else:
+                search_calls += 1
+
+        # Fallback: bracket notation [ToolName] for transcripts that don't
+        # use "Tool:" prefix
+        for match in re.finditer(r"\[(\w+)\]", transcript_text):
+            name = match.group(1).lower()
+            line_start = transcript_text.rfind("\n", 0, match.start()) + 1
+            line_text = transcript_text[line_start : match.end()]
+            if "Tool:" in line_text or "tool:" in line_text:
+                continue
+            tool_calls += 1
+            if name in _FILE_READ_TOOLS:
+                file_reads += 1
+            elif name == "bash":
+                # Can't determine context; count generically as search
+                search_calls += 1
+            elif name in _SEARCH_TOOLS:
+                search_calls += 1
+
+        # Also scan the whole transcript for TSA invocations that appear in
+        # command blocks without a "Tool: Bash" prefix (e.g. inline code fences)
+        for match in _TSA_PATTERNS.finditer(transcript_text):
+            # Only count if on a line that looks like a shell command, not prose
+            line_start = transcript_text.rfind("\n", 0, match.start()) + 1
+            line_end = transcript_text.find("\n", match.end())
+            if line_end == -1:
+                line_end = len(transcript_text)
+            cmd_line = transcript_text[line_start:line_end].strip()
+            if cmd_line.startswith(("$", "python", "uv run")):
+                index_queries += 1
+
+        return ToolMetrics(
+            tool_calls=tool_calls,
+            file_reads=file_reads,
+            search_calls=search_calls,
+            index_queries=index_queries,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Internal helper dataclass for mutable counter passing
+# ---------------------------------------------------------------------------
+
+
+class _MutableCounts:
+    """Tiny mutable container used to pass counters by reference."""
+
+    __slots__ = ("tool_calls_ref", "search_calls_ref", "index_queries_ref")
+
+    def __init__(
+        self,
+        tool_calls_ref: list[int],
+        search_calls_ref: list[int],
+        index_queries_ref: list[int],
+    ) -> None:
+        self.tool_calls_ref = tool_calls_ref
+        self.search_calls_ref = search_calls_ref
+        self.index_queries_ref = index_queries_ref
+
+
+def _classify_bash(bash_body: str, result: _MutableCounts) -> None:
+    """Classify one Bash call as either an index_query or a search_call."""
+    if _TSA_PATTERNS.search(bash_body):
+        result.index_queries_ref[0] += 1
+    else:
+        result.search_calls_ref[0] += 1
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _delete_cache(cache_dir: Path) -> None:
+    """Remove the AST cache directory if it exists."""
+    if cache_dir.exists():
+        logger.info("Deleting existing TSA cache at %s (cold build).", cache_dir)
+        try:
+            shutil.rmtree(cache_dir)
+        except OSError as exc:
+            logger.error("Failed to delete %s: %s", cache_dir, exc)
+
+
+def _build_cache(repo_path: Path, cache_dir: Path) -> IndexStats:
+    """Run ``python -m tree_sitter_analyzer --format json`` to populate the cache."""
+    logger.info("Building TSA AST cache in %s ...", repo_path)
+    t0 = time.perf_counter()
+
+    result = subprocess.run(
+        ["python", "-m", "tree_sitter_analyzer", "--format", "json"],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+    elapsed = time.perf_counter() - t0
+
+    if result.returncode != 0:
+        logger.error(
+            "tree_sitter_analyzer exited with code %d.\nstdout: %s\nstderr: %s",
+            result.returncode,
+            result.stdout[:2000],
+            result.stderr[:2000],
+        )
+
+    size = _dir_size(cache_dir) if cache_dir.exists() else 0
+    file_count = _count_files(cache_dir) if cache_dir.exists() else 0
+
+    logger.info(
+        "TSA cache built in %.2fs, size=%d bytes, files=%d",
+        elapsed,
+        size,
+        file_count,
+    )
+    return IndexStats(
+        build_seconds=elapsed,
+        index_size_bytes=size,
+        file_count=file_count,
+    )
+
+
+def _dir_size(path: Path) -> int:
+    """Return the total byte size of all files under *path*."""
+    if not path.exists():
+        return 0
+    return sum(f.stat().st_size for f in path.rglob("*") if f.is_file())
+
+
+def _count_files(path: Path) -> int:
+    """Return the number of files under *path*."""
+    if not path.exists():
+        return 0
+    return sum(1 for f in path.rglob("*") if f.is_file())
+
+
+def _load_prompt(prompt_file: Path, default: str) -> str:
+    if prompt_file.is_file():
+        return prompt_file.read_text(encoding="utf-8").strip()
+    return default

--- a/benchmarks/codegraph_compare/analyze.py
+++ b/benchmarks/codegraph_compare/analyze.py
@@ -67,18 +67,23 @@ def _enrich(run: dict[str, Any]) -> dict[str, Any]:
     # Support both schema field names (input_tokens) and runner field names (tokens_in)
     t_in = int(run.get("input_tokens") or run.get("tokens_in") or 0)
     t_out = int(run.get("output_tokens") or run.get("tokens_out") or 0)
+    t_total = int(run.get("total_tokens") or 0)
     existing = run.get("estimated_cost_usd")
     run["_cost"] = (
         float(existing)
         if existing and float(existing) > 0
         else estimate_cost(t_in, t_out)
     )
-    run["_total_tokens"] = t_in + t_out
+    run["_total_tokens"] = t_total if t_total > 0 else t_in + t_out
     # Support both 'repo' (schema) and 'repo_path' (runner)
     repo_raw = run.get("repo") or run.get("repo_path") or "unknown"
     run["_repo_name"] = Path(str(repo_raw)).name
-    # Normalise arm field: schema uses 'arm', runner uses 'arm_id'
-    run["_arm"] = run.get("arm") or run.get("arm_id") or "unknown"
+    # Normalise arm/backend fields and keep backend in the aggregate label so
+    # Claude and Codex runs do not get averaged together.
+    run["_agent_backend"] = run.get("agent_backend") or "claude"
+    arm = run.get("arm") or run.get("arm_id") or "unknown"
+    run["_arm_base"] = arm
+    run["_arm"] = f"{run['_agent_backend']}/{arm}"
     return run
 
 
@@ -284,7 +289,7 @@ def _s_savings(runs: list[dict[str, Any]]) -> str:
         )
 
     repos = sorted({r["_repo_name"] for r in runs})
-    non_native = sorted({r["_arm"] for r in runs if r["_arm"] != "native-only"})
+    non_native = sorted({r["_arm"] for r in runs if r["_arm_base"] != "native-only"})
     if not non_native:
         return "## 4. Savings vs native-only\n\n_No non-native arms found._"
 
@@ -295,13 +300,20 @@ def _s_savings(runs: list[dict[str, Any]]) -> str:
     )
     rows = []
     for repo in repos:
-        n_tok, n_cost = _medians(repo, "native-only")
-        if n_tok is None:
-            continue
         row = [repo]
         for arm in non_native:
+            backend = arm.split("/", 1)[0]
+            n_tok, _ = _medians(repo, f"{backend}/native-only")
+            if n_tok is None:
+                row.append("—")
+                continue
             row.append(_pct(n_tok, _medians(repo, arm)[0]))
         for arm in non_native:
+            backend = arm.split("/", 1)[0]
+            _, n_cost = _medians(repo, f"{backend}/native-only")
+            if n_cost is None:
+                row.append("—")
+                continue
             row.append(_pct(n_cost, _medians(repo, arm)[1]))
         rows.append(row)
     if not rows:
@@ -315,7 +327,9 @@ def _s_quality_efficiency(runs: list[dict[str, Any]], has_evals: bool) -> str:
             "## 5. Quality vs efficiency scatter summary\n\n_Quality data unavailable._"
         )
 
-    native_live = [r for r in runs if r["_arm"] == "native-only" and not _is_dry(r)]
+    native_live = [
+        r for r in runs if r["_arm_base"] == "native-only" and not _is_dry(r)
+    ]
     n_tok_med = _med([r["_total_tokens"] for r in native_live])
 
     lines = ["## 5. Quality vs efficiency scatter summary\n"]
@@ -358,10 +372,6 @@ def _s_quality_efficiency(runs: list[dict[str, Any]], has_evals: bool) -> str:
 
 
 def _s_cold_warm(runs: list[dict[str, Any]]) -> str:
-    by_ra: dict[tuple[str, str], list] = defaultdict(list)
-    for r in runs:
-        by_ra[(r["_repo_name"], r["_arm"])].append(r)
-
     headers = [
         "Repo",
         "Arm",
@@ -376,8 +386,20 @@ def _s_cold_warm(runs: list[dict[str, Any]]) -> str:
             ("codegraph-cold", "codegraph-warm"),
             ("tsa-cold", "tsa-warm"),
         ]:
-            cold = [r for r in by_ra.get((repo, cold_arm), []) if not _is_dry(r)]
-            warm = [r for r in by_ra.get((repo, warm_arm), []) if not _is_dry(r)]
+            cold = [
+                r
+                for r in runs
+                if r["_repo_name"] == repo
+                and r["_arm_base"] == cold_arm
+                and not _is_dry(r)
+            ]
+            warm = [
+                r
+                for r in runs
+                if r["_repo_name"] == repo
+                and r["_arm_base"] == warm_arm
+                and not _is_dry(r)
+            ]
             if not cold:
                 continue
             build = _med(
@@ -430,7 +452,7 @@ def _s_notes(n_repeats: int) -> str:
         [
             "## 8. Notes\n",
             f"- Median reported across {n_repeats} repeat(s) per question per arm",
-            "- Cost estimated at Sonnet 4.6 pricing: $3/M input, $15/M output",
+            "- Cost uses the agent CLI reported cost when available; otherwise it is estimated at $3/M input and $15/M output",
             "- Quality scores from LLM evaluator (claude-haiku) on 1-5 scale",
             "- Index build time excluded from warm query timing",
         ]
@@ -444,6 +466,7 @@ def _s_notes(n_repeats: int) -> str:
 _RUN_FIELDS = [
     "run_id",
     "question_id",
+    "agent_backend",
     "arm_id",
     "repo_name",
     "repo_path",
@@ -455,7 +478,9 @@ _RUN_FIELDS = [
     "elapsed_seconds",
     "answer",
     "tokens_in",
+    "cached_input_tokens",
     "tokens_out",
+    "reasoning_output_tokens",
     "total_tokens",
     "tool_calls",
     "estimated_cost_usd",
@@ -488,6 +513,7 @@ def _write_csv(
                 {
                     "run_id": run.get("run_id"),
                     "question_id": run.get("question_id"),
+                    "agent_backend": run["_agent_backend"],
                     "arm_id": run["_arm"],
                     "repo_name": run["_repo_name"],
                     "repo_path": run.get("repo_path") or run.get("repo"),
@@ -499,7 +525,9 @@ def _write_csv(
                     "elapsed_seconds": run.get("elapsed_seconds"),
                     "answer": run.get("answer"),
                     "tokens_in": run.get("tokens_in") or run.get("input_tokens"),
+                    "cached_input_tokens": run.get("cached_input_tokens"),
                     "tokens_out": run.get("tokens_out") or run.get("output_tokens"),
+                    "reasoning_output_tokens": run.get("reasoning_output_tokens"),
                     "total_tokens": run["_total_tokens"],
                     "tool_calls": run.get("tool_calls"),
                     "estimated_cost_usd": run["_cost"],

--- a/benchmarks/codegraph_compare/analyze.py
+++ b/benchmarks/codegraph_compare/analyze.py
@@ -1,0 +1,628 @@
+"""analyze.py — Benchmark results aggregator.
+
+Reads results/runs.jsonl and results/evals.jsonl, then produces:
+  - results/summary.md   (markdown report)
+  - results/summary.csv  (flat per-run table)
+
+CLI usage:
+    python benchmarks/codegraph_compare/analyze.py \\
+        --runs   results/runs.jsonl \\
+        --evals  results/evals.jsonl \\
+        --output results/summary.md
+
+evals.jsonl is optional; if absent quality columns are omitted with a
+warning written to stderr.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import statistics
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Cost estimation
+# ---------------------------------------------------------------------------
+
+_INPUT_COST_PER_M = 3.0  # USD / M input tokens  (Sonnet 4.6)
+_OUTPUT_COST_PER_M = 15.0  # USD / M output tokens (Sonnet 4.6)
+
+
+def estimate_cost(input_tokens: int, output_tokens: int) -> float:
+    return (input_tokens / 1_000_000 * _INPUT_COST_PER_M) + (
+        output_tokens / 1_000_000 * _OUTPUT_COST_PER_M
+    )
+
+
+# ---------------------------------------------------------------------------
+# JSONL loading & enrichment
+# ---------------------------------------------------------------------------
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    with path.open(encoding="utf-8") as fh:
+        for lineno, raw in enumerate(fh, 1):
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                records.append(json.loads(raw))
+            except json.JSONDecodeError as exc:
+                print(
+                    f"WARNING: skipping malformed JSON line {lineno} of {path}: {exc}",
+                    file=sys.stderr,
+                )
+    return records
+
+
+def _enrich(run: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of *run* with derived fields: _cost, _total_tokens, _repo_name."""
+    run = dict(run)
+    # Support both schema field names (input_tokens) and runner field names (tokens_in)
+    t_in = int(run.get("input_tokens") or run.get("tokens_in") or 0)
+    t_out = int(run.get("output_tokens") or run.get("tokens_out") or 0)
+    existing = run.get("estimated_cost_usd")
+    run["_cost"] = (
+        float(existing)
+        if existing and float(existing) > 0
+        else estimate_cost(t_in, t_out)
+    )
+    run["_total_tokens"] = t_in + t_out
+    # Support both 'repo' (schema) and 'repo_path' (runner)
+    repo_raw = run.get("repo") or run.get("repo_path") or "unknown"
+    run["_repo_name"] = Path(str(repo_raw)).name
+    # Normalise arm field: schema uses 'arm', runner uses 'arm_id'
+    run["_arm"] = run.get("arm") or run.get("arm_id") or "unknown"
+    return run
+
+
+def _is_dry(run: dict[str, Any]) -> bool:
+    return run.get("answer") == "DRY_RUN"
+
+
+def _is_failed(run: dict[str, Any]) -> bool:
+    return bool(run.get("error"))
+
+
+def _is_timeout(run: dict[str, Any]) -> bool:
+    return "timeout" in str(run.get("error") or "").lower()
+
+
+# ---------------------------------------------------------------------------
+# Statistical helpers
+# ---------------------------------------------------------------------------
+
+
+def _med(values: list) -> float | None:
+    clean = [v for v in values if v is not None]
+    return statistics.median(clean) if clean else None
+
+
+def _f(v: float | None, d: int = 4) -> str:
+    return f"{v:.{d}f}" if v is not None else "—"
+
+
+def _f2(v: float | None) -> str:
+    return _f(v, 2)
+
+
+def _pct(native: float | None, arm: float | None) -> str:
+    if native is None or arm is None or native == 0:
+        return "—"
+    return f"{(native - arm) / native * 100:.1f}%"
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+
+def _agg(runs: list[dict[str, Any]]) -> dict[str, Any]:
+    live = [r for r in runs if not _is_dry(r)]
+    return {
+        "count": len(runs),
+        "failed": sum(1 for r in runs if _is_failed(r)),
+        "median_cost": _med([r["_cost"] for r in live]),
+        "median_tokens": _med([r["_total_tokens"] for r in live]),
+        "median_time": _med(
+            [
+                float(r["elapsed_seconds"])
+                for r in live
+                if r.get("elapsed_seconds") is not None
+            ]
+        ),
+        "median_tool_calls": _med([int(r.get("tool_calls") or 0) for r in live]),
+        "median_quality": _med(
+            [r["_quality"] for r in live if r.get("_quality") is not None]
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Markdown table helper
+# ---------------------------------------------------------------------------
+
+
+def _table(headers: list[str], rows: list[list[str]]) -> str:
+    widths = [len(h) for h in headers]
+    for row in rows:
+        for i, cell in enumerate(row):
+            if i < len(widths):
+                widths[i] = max(widths[i], len(cell))
+
+    def _row(cells: list[str]) -> str:
+        return (
+            "| "
+            + " | ".join(
+                c.ljust(widths[i] if i < len(widths) else 0)
+                for i, c in enumerate(cells)
+            )
+            + " |"
+        )
+
+    sep = ["-" * w for w in widths]
+    return "\n".join([_row(headers), _row(sep)] + [_row(r) for r in rows])
+
+
+# ---------------------------------------------------------------------------
+# Section generators
+# ---------------------------------------------------------------------------
+
+
+def _s_overview(runs: list[dict[str, Any]], has_evals: bool) -> str:
+    repos = sorted({r["_repo_name"] for r in runs})
+    arms = sorted({r["_arm"] for r in runs})
+    models = sorted({r.get("model", "") for r in runs if r.get("model")})
+    dates = sorted(r["started_at"] for r in runs if r.get("started_at"))
+    dr = (
+        f"{dates[0][:10]} — {dates[-1][:10]}"
+        if len(dates) >= 2
+        else (dates[0][:10] if dates else "—")
+    )
+    note = (
+        ""
+        if has_evals
+        else "\n> **Note:** evals.jsonl not found — quality scores unavailable.\n"
+    )
+    total_evals = sum(1 for r in runs if r.get("_quality") is not None)
+    lines = [
+        "## 1. Overview\n",
+        note,
+        "| Metric | Value |",
+        "|--------|-------|",
+        f"| Total runs | {len(runs)} |",
+        f"| Total evals | {total_evals} |",
+        f"| Dry-run stubs | {sum(1 for r in runs if _is_dry(r))} |",
+        f"| Repos covered | {len(repos)} ({', '.join(repos)}) |",
+        f"| Arms covered | {len(arms)} ({', '.join(arms)}) |",
+        f"| Date range | {dr} |",
+        f"| Model(s) | {', '.join(models) if models else '—'} |",
+        f"| Failed runs | {sum(1 for r in runs if _is_failed(r))} |",
+        f"| Timeout runs | {sum(1 for r in runs if _is_timeout(r))} |",
+    ]
+    return "\n".join(lines)
+
+
+def _s_per_arm(by_arm: dict[str, list[dict[str, Any]]], has_evals: bool) -> str:
+    headers = [
+        "Arm",
+        "Runs",
+        "Median Cost ($)",
+        "Median Tokens",
+        "Median Time (s)",
+        "Median Tool Calls",
+        "Median Quality",
+        "Failed",
+    ]
+    rows_data = []
+    for arm, arm_runs in by_arm.items():
+        a = _agg(arm_runs)
+        q = _f2(a["median_quality"]) if has_evals else "n/a"
+        rows_data.append(
+            (
+                a["median_tokens"] if a["median_tokens"] is not None else float("inf"),
+                [
+                    arm,
+                    str(a["count"]),
+                    _f(a["median_cost"], 6),
+                    _f2(a["median_tokens"]),
+                    _f2(a["median_time"]),
+                    _f2(a["median_tool_calls"]),
+                    q,
+                    str(a["failed"]),
+                ],
+            )
+        )
+    rows_data.sort(key=lambda x: x[0])
+    return "## 2. Per-arm aggregate\n\n" + _table(headers, [r for _, r in rows_data])
+
+
+def _s_per_repo_arm(runs: list[dict[str, Any]], has_evals: bool) -> str:
+    by_ra: dict[tuple[str, str], list] = defaultdict(list)
+    for r in runs:
+        by_ra[(r["_repo_name"], r["_arm"])].append(r)
+    headers = [
+        "Repo",
+        "Arm",
+        "Median Cost ($)",
+        "Median Tokens",
+        "Median Time (s)",
+        "Median Quality",
+    ]
+    rows = []
+    for (repo, arm), arm_runs in sorted(by_ra.items()):
+        a = _agg(arm_runs)
+        q = _f2(a["median_quality"]) if has_evals else "n/a"
+        rows.append(
+            [
+                repo,
+                arm,
+                _f(a["median_cost"], 6),
+                _f2(a["median_tokens"]),
+                _f2(a["median_time"]),
+                q,
+            ]
+        )
+    return "## 3. Per-repo × arm\n\n" + _table(headers, rows)
+
+
+def _s_savings(runs: list[dict[str, Any]]) -> str:
+    by_ra: dict[tuple[str, str], list] = defaultdict(list)
+    for r in runs:
+        by_ra[(r["_repo_name"], r["_arm"])].append(r)
+
+    def _medians(repo: str, arm: str) -> tuple[float | None, float | None]:
+        live = [r for r in by_ra.get((repo, arm), []) if not _is_dry(r)]
+        return _med([r["_total_tokens"] for r in live]), _med(
+            [r["_cost"] for r in live]
+        )
+
+    repos = sorted({r["_repo_name"] for r in runs})
+    non_native = sorted({r["_arm"] for r in runs if r["_arm"] != "native-only"})
+    if not non_native:
+        return "## 4. Savings vs native-only\n\n_No non-native arms found._"
+
+    headers = (
+        ["Repo"]
+        + [f"{a} token savings" for a in non_native]
+        + [f"{a} cost savings" for a in non_native]
+    )
+    rows = []
+    for repo in repos:
+        n_tok, n_cost = _medians(repo, "native-only")
+        if n_tok is None:
+            continue
+        row = [repo]
+        for arm in non_native:
+            row.append(_pct(n_tok, _medians(repo, arm)[0]))
+        for arm in non_native:
+            row.append(_pct(n_cost, _medians(repo, arm)[1]))
+        rows.append(row)
+    if not rows:
+        return "## 4. Savings vs native-only\n\n_No repos with both native-only and non-native data._"
+    return "## 4. Savings vs native-only\n\n" + _table(headers, rows)
+
+
+def _s_quality_efficiency(runs: list[dict[str, Any]], has_evals: bool) -> str:
+    if not has_evals:
+        return (
+            "## 5. Quality vs efficiency scatter summary\n\n_Quality data unavailable._"
+        )
+
+    native_live = [r for r in runs if r["_arm"] == "native-only" and not _is_dry(r)]
+    n_tok_med = _med([r["_total_tokens"] for r in native_live])
+
+    lines = ["## 5. Quality vs efficiency scatter summary\n"]
+    for arm in sorted({r["_arm"] for r in runs}):
+        arm_live = [
+            r
+            for r in runs
+            if r["_arm"] == arm and not _is_dry(r) and r.get("_quality") is not None
+        ]
+        if len(arm_live) < 2:
+            lines.append(f"- **{arm}**: insufficient data for correlation.")
+            continue
+        toks = [r["_total_tokens"] for r in arm_live]
+        quals = [r["_quality"] for r in arm_live]
+        n = len(arm_live)
+        mt, mq = sum(toks) / n, sum(quals) / n
+        cov = sum((t - mt) * (q - mq) for t, q in zip(toks, quals, strict=True)) / n
+        st = (sum((t - mt) ** 2 for t in toks) / n) ** 0.5
+        sq = (sum((q - mq) ** 2 for q in quals) / n) ** 0.5
+        if st == 0 or sq == 0:
+            direction = "no change in"
+        else:
+            rv = cov / (st * sq)
+            direction = (
+                "higher" if rv > 0.1 else ("lower" if rv < -0.1 else "no change in")
+            )
+        arm_tok_med = _med(toks)
+        if n_tok_med and arm_tok_med and arm != "native-only":
+            vs = (
+                "lower"
+                if arm_tok_med < n_tok_med
+                else ("higher" if arm_tok_med > n_tok_med else "similar")
+            )
+            lines.append(
+                f"- **{arm}**: {vs} token use correlates with {direction} quality vs native-only."
+            )
+        else:
+            lines.append(f"- **{arm}**: token use correlates with {direction} quality.")
+    return "\n".join(lines)
+
+
+def _s_cold_warm(runs: list[dict[str, Any]]) -> str:
+    by_ra: dict[tuple[str, str], list] = defaultdict(list)
+    for r in runs:
+        by_ra[(r["_repo_name"], r["_arm"])].append(r)
+
+    headers = [
+        "Repo",
+        "Arm",
+        "Index Build Time (s)",
+        "Index Size (MB)",
+        "Warm Query Median Tokens",
+        "Cold Query Median Tokens",
+    ]
+    rows = []
+    for repo in sorted({r["_repo_name"] for r in runs}):
+        for cold_arm, warm_arm in [
+            ("codegraph-cold", "codegraph-warm"),
+            ("tsa-cold", "tsa-warm"),
+        ]:
+            cold = [r for r in by_ra.get((repo, cold_arm), []) if not _is_dry(r)]
+            warm = [r for r in by_ra.get((repo, warm_arm), []) if not _is_dry(r)]
+            if not cold:
+                continue
+            build = _med(
+                [
+                    float(r["index_build_seconds"])
+                    for r in cold
+                    if r.get("index_build_seconds") is not None
+                ]
+            )
+            size_b = _med(
+                [
+                    float(r["index_size_bytes"])
+                    for r in cold
+                    if r.get("index_size_bytes") is not None
+                ]
+            )
+            size_mb = size_b / (1024 * 1024) if size_b is not None else None
+            rows.append(
+                [
+                    repo,
+                    f"{cold_arm} / {warm_arm}",
+                    _f2(build),
+                    _f2(size_mb),
+                    _f2(_med([r["_total_tokens"] for r in warm]) if warm else None),
+                    _f2(_med([r["_total_tokens"] for r in cold])),
+                ]
+            )
+    if not rows:
+        return "## 6. Cold vs warm index comparison\n\n_No cold-arm data found._"
+    return "## 6. Cold vs warm index comparison\n\n" + _table(headers, rows)
+
+
+def _s_failed(runs: list[dict[str, Any]]) -> str:
+    problems = [r for r in runs if _is_failed(r) or _is_dry(r)]
+    if not problems:
+        return "## 7. Failed / timed-out runs\n\n_No failed or dry-run records._"
+    headers = ["run_id", "repo", "arm", "question_id", "error / note"]
+    rows = []
+    for r in problems:
+        msg = r.get("error") or ("DRY_RUN stub" if _is_dry(r) else "—")
+        qid = r.get("question_id") or r.get("question_id", "—")
+        rows.append(
+            [r.get("run_id", "—"), r["_repo_name"], r["_arm"], str(qid), str(msg)[:120]]
+        )
+    return "## 7. Failed / timed-out runs\n\n" + _table(headers, rows)
+
+
+def _s_notes(n_repeats: int) -> str:
+    return "\n".join(
+        [
+            "## 8. Notes\n",
+            f"- Median reported across {n_repeats} repeat(s) per question per arm",
+            "- Cost estimated at Sonnet 4.6 pricing: $3/M input, $15/M output",
+            "- Quality scores from LLM evaluator (claude-haiku) on 1-5 scale",
+            "- Index build time excluded from warm query timing",
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# CSV writer
+# ---------------------------------------------------------------------------
+
+_RUN_FIELDS = [
+    "run_id",
+    "question_id",
+    "arm_id",
+    "repo_name",
+    "repo_path",
+    "repeat",
+    "model",
+    "timeout_seconds",
+    "started_at",
+    "ended_at",
+    "elapsed_seconds",
+    "answer",
+    "tokens_in",
+    "tokens_out",
+    "total_tokens",
+    "tool_calls",
+    "estimated_cost_usd",
+    "error",
+    "index_build_seconds",
+    "index_size_bytes",
+    "prompt_file",
+]
+_EVAL_FIELDS = ["quality_score", "evaluator_model", "eval_notes"]
+
+
+def _write_csv(
+    runs: list[dict[str, Any]], evals_by_id: dict[str, dict[str, Any]], path: Path
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(
+            fh, fieldnames=_RUN_FIELDS + _EVAL_FIELDS, extrasaction="ignore"
+        )
+        writer.writeheader()
+        for run in runs:
+            ev = evals_by_id.get(run.get("run_id", ""), {})
+            # quality_score: prefer EvalRecord.overall, fall back to quality_score key
+            quality = (
+                ev.get("overall")
+                if ev.get("overall") is not None
+                else ev.get("quality_score")
+            )
+            writer.writerow(
+                {
+                    "run_id": run.get("run_id"),
+                    "question_id": run.get("question_id"),
+                    "arm_id": run["_arm"],
+                    "repo_name": run["_repo_name"],
+                    "repo_path": run.get("repo_path") or run.get("repo"),
+                    "repeat": run.get("repeat"),
+                    "model": run.get("model"),
+                    "timeout_seconds": run.get("timeout_seconds"),
+                    "started_at": run.get("started_at"),
+                    "ended_at": run.get("ended_at"),
+                    "elapsed_seconds": run.get("elapsed_seconds"),
+                    "answer": run.get("answer"),
+                    "tokens_in": run.get("tokens_in") or run.get("input_tokens"),
+                    "tokens_out": run.get("tokens_out") or run.get("output_tokens"),
+                    "total_tokens": run["_total_tokens"],
+                    "tool_calls": run.get("tool_calls"),
+                    "estimated_cost_usd": run["_cost"],
+                    "error": run.get("error"),
+                    "index_build_seconds": run.get("index_build_seconds"),
+                    "index_size_bytes": run.get("index_size_bytes"),
+                    "prompt_file": run.get("prompt_file"),
+                    "quality_score": quality,
+                    "evaluator_model": ev.get("evaluator_model"),
+                    "eval_notes": ev.get("eval_notes") or ev.get("missing_key_points"),
+                }
+            )
+
+
+# ---------------------------------------------------------------------------
+# Main report builder
+# ---------------------------------------------------------------------------
+
+
+def build_report(runs_path: Path, evals_path: Path | None, output_path: Path) -> None:
+    if not runs_path.exists():
+        print(f"ERROR: runs file not found: {runs_path}", file=sys.stderr)
+        sys.exit(1)
+
+    runs = [_enrich(r) for r in _load_jsonl(runs_path)]
+
+    has_evals = False
+    evals_by_id: dict[str, dict[str, Any]] = {}
+    if evals_path is not None and evals_path.exists():
+        for e in _load_jsonl(evals_path):
+            if "run_id" in e:
+                evals_by_id[e["run_id"]] = e
+        has_evals = True
+    elif evals_path is not None:
+        print(
+            f"WARNING: evals file not found: {evals_path} — quality columns omitted.",
+            file=sys.stderr,
+        )
+
+    for run in runs:
+        ev = evals_by_id.get(run.get("run_id", ""), {})
+        # EvalRecord.overall is the primary quality field (schemas.py); fall back to quality_score
+        q = (
+            ev.get("overall")
+            if ev.get("overall") is not None
+            else ev.get("quality_score")
+        )
+        run["_quality"] = float(q) if q is not None else None
+
+    by_arm: dict[str, list] = defaultdict(list)
+    for run in runs:
+        by_arm[run["_arm"]].append(run)
+
+    repeats_counts: dict[tuple[str, str], set] = defaultdict(set)
+    for run in runs:
+        repeats_counts[(run.get("question_id", ""), run["_arm"])].add(
+            run.get("repeat", 0)
+        )
+    max_repeats = max((len(v) for v in repeats_counts.values()), default=1)
+
+    sections = [
+        "# Benchmark Summary Report\n",
+        _s_overview(runs, has_evals),
+        "",
+        _s_per_arm(by_arm, has_evals),
+        "",
+        _s_per_repo_arm(runs, has_evals),
+        "",
+        _s_savings(runs),
+        "",
+        _s_quality_efficiency(runs, has_evals),
+        "",
+        _s_cold_warm(runs),
+        "",
+        _s_failed(runs),
+        "",
+        _s_notes(max_repeats),
+        "",
+    ]
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(sections), encoding="utf-8")
+    print(f"Report written to {output_path}", file=sys.stderr)
+
+    csv_path = output_path.with_suffix(".csv")
+    _write_csv(runs, evals_by_id, csv_path)
+    print(f"CSV written to {csv_path}", file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Analyze benchmark runs/evals JSONL and produce a markdown summary.",
+    )
+    parser.add_argument(
+        "--runs",
+        type=Path,
+        default=Path("results/runs.jsonl"),
+        help="Path to runs.jsonl (default: results/runs.jsonl)",
+    )
+    parser.add_argument(
+        "--evals",
+        type=Path,
+        default=Path("results/evals.jsonl"),
+        help="Path to evals.jsonl (default: results/evals.jsonl)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("results/summary.md"),
+        help="Output markdown path (default: results/summary.md)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = _parse_args(argv)
+    build_report(args.runs, args.evals, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/codegraph_compare/arms.yaml
+++ b/benchmarks/codegraph_compare/arms.yaml
@@ -1,0 +1,20 @@
+arms:
+  - id: native-only
+    adapter: native
+    index_mode: none
+
+  - id: codegraph-warm
+    adapter: codegraph
+    index_mode: warm
+
+  - id: tsa-warm
+    adapter: tree_sitter_analyzer
+    index_mode: warm
+
+  - id: codegraph-cold
+    adapter: codegraph
+    index_mode: cold
+
+  - id: tsa-cold
+    adapter: tree_sitter_analyzer
+    index_mode: cold

--- a/benchmarks/codegraph_compare/evaluate.py
+++ b/benchmarks/codegraph_compare/evaluate.py
@@ -1,0 +1,860 @@
+"""Answer quality evaluator for the CodeGraph comparison benchmark harness.
+
+Evaluates a RunRecord against its QuestionSpec by:
+  1. Checking cited files exist in the repo (file citation check)
+  2. Checking expected key points appear in the answer (coverage check)
+  3. Calling an LLM (Claude Haiku) to score semantic quality
+  4. Applying auto-penalties and computing an overall score
+  5. Appending an EvalRecord to results/evals.jsonl
+
+Public API
+----------
+    evaluate_run(run, question, repo_path, model, dry_run) -> dict
+    evaluate_all(runs_jsonl, questions_yaml, prepared_manifest, results_dir,
+                 model, dry_run) -> list[dict]
+
+CLI
+---
+    python benchmarks/codegraph_compare/evaluate.py \\
+        --runs results/runs.jsonl \\
+        --questions questions.yaml \\
+        --manifest results/prepared_repos.json \\
+        --dry-run
+
+Created: 2026-05-26
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# File extensions recognised when scanning citation strings for path fragments
+_CODE_EXTENSIONS = frozenset(
+    {
+        ".py",
+        ".ts",
+        ".tsx",
+        ".js",
+        ".jsx",
+        ".go",
+        ".rs",
+        ".java",
+        ".swift",
+        ".kt",
+        ".cpp",
+        ".c",
+        ".h",
+        ".cs",
+        ".rb",
+        ".php",
+        ".sh",
+        ".bash",
+        ".yaml",
+        ".yml",
+        ".json",
+        ".toml",
+        ".cfg",
+        ".ini",
+        ".sql",
+        ".md",
+    }
+)
+
+# Prompts directory (sibling of this file)
+_PROMPTS_DIR = Path(__file__).resolve().parent / "prompts"
+_EVALUATOR_PROMPT_FILE = _PROMPTS_DIR / "evaluator.md"
+
+# Default LLM evaluator prompt (used when prompts/evaluator.md is absent)
+_DEFAULT_EVALUATOR_PROMPT = """\
+You are evaluating the quality of an AI assistant's answer to a code-intelligence question.
+
+## Question
+{question}
+
+## Expected key points (the answer should cover these)
+{key_points}
+
+## Answer under evaluation
+{answer}
+
+---
+
+Score the answer on each dimension from 1 (very poor) to 5 (excellent):
+
+1. **correctness** — Are the facts stated in the answer accurate and consistent with what you
+   would expect from a correct code-intelligence query?
+2. **completeness** — Does the answer cover all the expected key points?
+3. **citation_quality** — Does the answer cite specific files, line numbers, or symbols that
+   support each claim? Are the citations concrete and useful?
+4. **hallucination_risk** — How likely is it that the answer contains invented or fabricated
+   details? (5 = very unlikely to hallucinate; 1 = very likely to hallucinate)
+
+Return ONLY a JSON object in this exact format — no markdown fences, no extra text:
+
+{
+  "correctness": <int 1-5>,
+  "completeness": <int 1-5>,
+  "citation_quality": <int 1-5>,
+  "hallucination_risk": <int 1-5>,
+  "reasoning": "<one or two sentences explaining the scores>"
+}
+"""
+
+# Score to use for all dimensions when a run errored or was a dry-run
+_ERROR_SCORE = 0
+_DRY_RUN_SCORE = 0
+
+# Safe default scores when LLM response cannot be parsed
+_SAFE_DEFAULT_SCORES: dict[str, Any] = {
+    "correctness": 3,
+    "completeness": 3,
+    "citation_quality": 3,
+    "hallucination_risk": 3,
+    "reasoning": "LLM response could not be parsed; safe defaults used.",
+}
+
+
+# ---------------------------------------------------------------------------
+# Stderr helper (keeps stdout machine-readable)
+# ---------------------------------------------------------------------------
+
+
+def _stderr(*args: Any, **kwargs: Any) -> None:
+    print(*args, **kwargs, file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# Lazy anthropic import guard
+# ---------------------------------------------------------------------------
+
+
+def _require_anthropic() -> Any:
+    """Return the ``anthropic`` module, raising a clear error if not installed."""
+    try:
+        import anthropic
+
+        return anthropic
+    except ImportError as exc:
+        raise RuntimeError(
+            "The 'anthropic' Python SDK is required for LLM evaluation. "
+            "Install it with:  pip install anthropic\n"
+            "Or run with --dry-run to skip LLM evaluation."
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Step 1: File citation check
+# ---------------------------------------------------------------------------
+
+
+def _extract_cited_paths(citations: list[str]) -> list[str]:
+    """Extract strings from citations that look like file paths.
+
+    A candidate path must contain a ``/`` or end with a recognised code
+    extension.  Inline path fragments like ``src/foo.py:42`` are stripped
+    of the trailing ``:42`` suffix.
+    """
+    candidates: list[str] = []
+    for citation in citations:
+        # Split on whitespace and common delimiters to find embedded paths
+        for token in re.split(r'[\s,;"\']', citation):
+            token = token.strip()
+            if not token:
+                continue
+            # Strip trailing colon+digits (e.g. "src/foo.py:42" → "src/foo.py")
+            token = re.sub(r":\d+$", "", token)
+            # A plausible path either contains "/" or ends in a code extension
+            suffix = Path(token).suffix.lower()
+            if "/" in token or suffix in _CODE_EXTENSIONS:
+                # Strip a leading "./" for consistent lookup
+                if token.startswith("./"):
+                    token = token[2:]
+                candidates.append(token)
+    return candidates
+
+
+def _check_citations(
+    citations: list[str],
+    repo_path: Path,
+) -> tuple[list[str], list[str]]:
+    """Check citation strings against the file system.
+
+    Returns ``(good_citations, bad_citations)`` where each element is the
+    extracted path string.  A path is "bad" if it doesn't exist inside
+    ``repo_path``.
+    """
+    good: list[str] = []
+    bad: list[str] = []
+
+    for path_str in _extract_cited_paths(citations):
+        candidate = repo_path / path_str
+        if candidate.exists():
+            good.append(path_str)
+        else:
+            bad.append(path_str)
+
+    return good, bad
+
+
+# ---------------------------------------------------------------------------
+# Step 2: Key point coverage check
+# ---------------------------------------------------------------------------
+
+
+def _check_key_points(
+    answer: str,
+    expected_key_points: list[str],
+) -> tuple[list[str], list[str]]:
+    """Return ``(covered_points, missing_points)`` based on case-insensitive
+    substring matching of each expected key point in the answer text.
+    """
+    answer_lower = answer.lower()
+    covered: list[str] = []
+    missing: list[str] = []
+    for point in expected_key_points:
+        if point.lower() in answer_lower:
+            covered.append(point)
+        else:
+            missing.append(point)
+    return covered, missing
+
+
+# ---------------------------------------------------------------------------
+# Step 3: LLM evaluation
+# ---------------------------------------------------------------------------
+
+
+def _build_eval_prompt(
+    question_text: str,
+    expected_key_points: list[str],
+    answer: str,
+) -> str:
+    """Build the full evaluation prompt string."""
+    if _EVALUATOR_PROMPT_FILE.is_file():
+        template = _EVALUATOR_PROMPT_FILE.read_text(encoding="utf-8")
+    else:
+        template = _DEFAULT_EVALUATOR_PROMPT
+
+    key_points_block = "\n".join(f"- {p}" for p in expected_key_points)
+    return template.format(
+        question=question_text,
+        key_points=key_points_block,
+        answer=answer,
+    )
+
+
+def _call_llm(
+    prompt: str,
+    model: str,
+) -> dict[str, Any]:
+    """Call the Claude API and parse the returned JSON scores.
+
+    Returns a dict with keys: correctness, completeness, citation_quality,
+    hallucination_risk, reasoning.
+
+    Falls back to _SAFE_DEFAULT_SCORES on any parse or API error.
+    """
+    anthropic = _require_anthropic()
+    client = anthropic.Anthropic()
+
+    try:
+        response = client.messages.create(
+            model=model,
+            max_tokens=1024,
+            messages=[{"role": "user", "content": prompt}],
+        )
+    except Exception as exc:  # noqa: BLE001
+        _stderr(f"[evaluate] LLM API call failed: {exc}")
+        result = dict(_SAFE_DEFAULT_SCORES)
+        result["reasoning"] = f"LLM API call failed: {exc}"
+        return result
+
+    raw_text = response.content[0].text if response.content else ""
+
+    # Strip markdown code fences if present
+    cleaned = re.sub(r"```(?:json)?\s*", "", raw_text).strip().rstrip("`").strip()
+
+    try:
+        parsed = json.loads(cleaned)
+    except json.JSONDecodeError:
+        # Try to extract a JSON object substring as a fallback
+        match = re.search(r"\{[^{}]*\}", cleaned, re.DOTALL)
+        if match:
+            try:
+                parsed = json.loads(match.group())
+            except json.JSONDecodeError:
+                _stderr(f"[evaluate] Could not parse LLM JSON response: {raw_text!r}")
+                result = dict(_SAFE_DEFAULT_SCORES)
+                result["reasoning"] = (
+                    "LLM response JSON unparseable; safe defaults used."
+                )
+                return result
+        else:
+            _stderr(f"[evaluate] No JSON object found in LLM response: {raw_text!r}")
+            result = dict(_SAFE_DEFAULT_SCORES)
+            result["reasoning"] = (
+                "LLM response contained no JSON object; safe defaults used."
+            )
+            return result
+
+    scores: dict[str, Any] = {}
+    for key in (
+        "correctness",
+        "completeness",
+        "citation_quality",
+        "hallucination_risk",
+    ):
+        raw_val = parsed.get(key, _SAFE_DEFAULT_SCORES[key])
+        try:
+            scores[key] = max(1, min(5, int(raw_val)))
+        except (TypeError, ValueError):
+            scores[key] = _SAFE_DEFAULT_SCORES[key]
+
+    scores["reasoning"] = str(
+        parsed.get("reasoning", _SAFE_DEFAULT_SCORES["reasoning"])
+    )
+    return scores
+
+
+# ---------------------------------------------------------------------------
+# Step 4: Apply auto-penalties and compute overall
+# ---------------------------------------------------------------------------
+
+
+def _apply_penalties(
+    scores: dict[str, Any],
+    bad_citations: list[str],
+    missing_key_points: list[str],
+    total_key_points: int,
+) -> dict[str, Any]:
+    """Return a new scores dict with caps applied.
+
+    Rules:
+    - bad_citations non-empty → cap citation_quality at 3
+    - >50% of key points missing → cap completeness at 2
+    """
+    result = dict(scores)
+
+    if bad_citations and result["citation_quality"] > 3:
+        result["citation_quality"] = 3
+
+    if total_key_points > 0:
+        missing_ratio = len(missing_key_points) / total_key_points
+        if missing_ratio > 0.5 and result["completeness"] > 2:
+            result["completeness"] = 2
+
+    return result
+
+
+def _compute_overall(scores: dict[str, Any]) -> float:
+    """Compute the mean of the four scored dimensions."""
+    keys = ("correctness", "completeness", "citation_quality", "hallucination_risk")
+    total: int = sum(scores[k] for k in keys)
+    return round(total / len(keys), 4)
+
+
+# ---------------------------------------------------------------------------
+# JSONL helpers
+# ---------------------------------------------------------------------------
+
+
+def _append_jsonl(path: Path, record: dict) -> None:
+    """Append a single JSON record to a JSONL file, creating it if needed."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def evaluate_run(
+    run: dict,
+    question: dict,
+    repo_path: Path,
+    model: str = "claude-haiku-4-5-20251001",
+    dry_run: bool = False,
+    results_dir: Path | None = None,
+) -> dict:
+    """Evaluate one RunRecord against its QuestionSpec.
+
+    Parameters
+    ----------
+    run:
+        A RunRecord dict loaded from runs.jsonl.
+    question:
+        A QuestionSpec dict from questions.yaml.
+    repo_path:
+        Local path to the cloned repository.
+    model:
+        Claude model ID to use for LLM evaluation.
+    dry_run:
+        If True, skip the LLM call and return dummy scores (safe for CI).
+    results_dir:
+        Directory to append evals.jsonl to.  If None the record is returned
+        but not persisted.
+
+    Returns
+    -------
+    dict
+        An EvalRecord with keys:
+          run_id, question_id, arm_id, repo_path,
+          correctness, completeness, citation_quality, hallucination_risk,
+          overall, bad_citations, missing_key_points,
+          reasoning, evaluated_with_llm, eval_model
+    """
+    try:
+        return _evaluate_run_inner(
+            run=run,
+            question=question,
+            repo_path=repo_path,
+            model=model,
+            dry_run=dry_run,
+            results_dir=results_dir,
+        )
+    except Exception as exc:  # noqa: BLE001
+        _stderr(
+            f"[evaluate] Unexpected error evaluating {run.get('run_id', '?')}: {exc}"
+        )
+        record = _minimal_error_record(run, question, str(exc))
+        if results_dir is not None:
+            _append_jsonl(results_dir / "evals.jsonl", record)
+        return record
+
+
+def _evaluate_run_inner(
+    run: dict,
+    question: dict,
+    repo_path: Path,
+    model: str,
+    dry_run: bool,
+    results_dir: Path | None,
+) -> dict:
+    run_id = run.get("run_id", "")
+    question_id = question.get("id", run.get("question_id", ""))
+    arm_id = run.get("arm_id", "")
+    run_repo_path = run.get("repo_path", str(repo_path))
+
+    # ------------------------------------------------------------------
+    # Fast-path: failed or dry-run runs
+    # ------------------------------------------------------------------
+
+    if run.get("error"):
+        record = _minimal_error_record(
+            run,
+            question,
+            f"run failed: {run['error']}",
+        )
+        if results_dir is not None:
+            _append_jsonl(results_dir / "evals.jsonl", record)
+        return record
+
+    answer = run.get("answer", "")
+    if answer == "DRY_RUN":
+        record = _build_record(
+            run_id=run_id,
+            question_id=question_id,
+            arm_id=arm_id,
+            repo_path=run_repo_path,
+            correctness=_DRY_RUN_SCORE,
+            completeness=_DRY_RUN_SCORE,
+            citation_quality=_DRY_RUN_SCORE,
+            hallucination_risk=_DRY_RUN_SCORE,
+            overall=0.0,
+            bad_citations=[],
+            missing_key_points=[],
+            reasoning="dry run",
+            evaluated_with_llm=False,
+            eval_model=model,
+        )
+        if results_dir is not None:
+            _append_jsonl(results_dir / "evals.jsonl", record)
+        return record
+
+    # ------------------------------------------------------------------
+    # Step 1: File citation check
+    # ------------------------------------------------------------------
+
+    citations: list[str] = run.get("citations", [])
+    _good_citations, bad_citations = _check_citations(citations, repo_path)
+
+    # ------------------------------------------------------------------
+    # Step 2: Key point coverage check
+    # ------------------------------------------------------------------
+
+    expected_key_points: list[str] = question.get("expected_key_points", [])
+    _covered, missing_key_points = _check_key_points(answer, expected_key_points)
+
+    # ------------------------------------------------------------------
+    # Step 3: LLM evaluation (or dry-run stub)
+    # ------------------------------------------------------------------
+
+    if dry_run:
+        scores: dict[str, Any] = {
+            "correctness": 3,
+            "completeness": 3,
+            "citation_quality": 3,
+            "hallucination_risk": 3,
+            "reasoning": "dry_run=True; LLM evaluation skipped.",
+        }
+        evaluated_with_llm = False
+    else:
+        question_text = question.get("question", question.get("prompt", ""))
+        eval_prompt = _build_eval_prompt(
+            question_text=question_text,
+            expected_key_points=expected_key_points,
+            answer=answer,
+        )
+        scores = _call_llm(eval_prompt, model=model)
+        evaluated_with_llm = True
+
+    # ------------------------------------------------------------------
+    # Step 4: Apply auto-penalties and compute overall
+    # ------------------------------------------------------------------
+
+    penalised = _apply_penalties(
+        scores=scores,
+        bad_citations=bad_citations,
+        missing_key_points=missing_key_points,
+        total_key_points=len(expected_key_points),
+    )
+    overall = _compute_overall(penalised)
+
+    # ------------------------------------------------------------------
+    # Step 5: Build and persist the EvalRecord
+    # ------------------------------------------------------------------
+
+    record = _build_record(
+        run_id=run_id,
+        question_id=question_id,
+        arm_id=arm_id,
+        repo_path=run_repo_path,
+        correctness=penalised["correctness"],
+        completeness=penalised["completeness"],
+        citation_quality=penalised["citation_quality"],
+        hallucination_risk=penalised["hallucination_risk"],
+        overall=overall,
+        bad_citations=bad_citations,
+        missing_key_points=missing_key_points,
+        reasoning=penalised["reasoning"],
+        evaluated_with_llm=evaluated_with_llm,
+        eval_model=model,
+    )
+
+    if results_dir is not None:
+        _append_jsonl(results_dir / "evals.jsonl", record)
+
+    return record
+
+
+def _minimal_error_record(run: dict, question: dict, reason: str) -> dict:
+    """Build a zero-score EvalRecord for a failed or un-evaluable run."""
+    return _build_record(
+        run_id=run.get("run_id", ""),
+        question_id=question.get("id", run.get("question_id", "")),
+        arm_id=run.get("arm_id", ""),
+        repo_path=run.get("repo_path", ""),
+        correctness=_ERROR_SCORE,
+        completeness=_ERROR_SCORE,
+        citation_quality=_ERROR_SCORE,
+        hallucination_risk=_ERROR_SCORE,
+        overall=0.0,
+        bad_citations=[],
+        missing_key_points=[],
+        reasoning=reason,
+        evaluated_with_llm=False,
+        eval_model="",
+    )
+
+
+def _build_record(
+    *,
+    run_id: str,
+    question_id: str,
+    arm_id: str,
+    repo_path: str,
+    correctness: int,
+    completeness: int,
+    citation_quality: int,
+    hallucination_risk: int,
+    overall: float,
+    bad_citations: list[str],
+    missing_key_points: list[str],
+    reasoning: str,
+    evaluated_with_llm: bool,
+    eval_model: str,
+) -> dict:
+    """Assemble a canonical EvalRecord dict."""
+    return {
+        "run_id": run_id,
+        "question_id": question_id,
+        "arm_id": arm_id,
+        "repo_path": repo_path,
+        "correctness": correctness,
+        "completeness": completeness,
+        "citation_quality": citation_quality,
+        "hallucination_risk": hallucination_risk,
+        "overall": overall,
+        "bad_citations": bad_citations,
+        "missing_key_points": missing_key_points,
+        "reasoning": reasoning,
+        "evaluated_with_llm": evaluated_with_llm,
+        "eval_model": eval_model,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Batch API
+# ---------------------------------------------------------------------------
+
+
+def evaluate_all(
+    runs_jsonl: Path,
+    questions_yaml: Path,
+    prepared_manifest: Path,
+    results_dir: Path,
+    model: str = "claude-haiku-4-5-20251001",
+    dry_run: bool = False,
+) -> list[dict]:
+    """Batch-evaluate every run in ``runs_jsonl``.
+
+    Parameters
+    ----------
+    runs_jsonl:
+        Path to the JSONL file produced by the benchmark runner (each line is
+        a RunRecord).
+    questions_yaml:
+        Path to the YAML file containing QuestionSpec entries.
+    prepared_manifest:
+        Path to the JSON manifest produced by ``repo_prep.py`` — used to
+        resolve ``repo_id → local_path``.
+    results_dir:
+        Directory to write ``evals.jsonl`` into.
+    model:
+        Claude model ID for LLM evaluation.
+    dry_run:
+        Skip LLM calls when True.
+
+    Returns
+    -------
+    list[dict]
+        All EvalRecord dicts produced in this batch.
+    """
+    # Load questions indexed by id
+    questions_by_id = _load_questions(questions_yaml)
+
+    # Load repo manifest: repo_id → local_path
+    repo_path_by_id = _load_repo_paths(prepared_manifest)
+
+    # Stream runs from JSONL
+    runs = _load_runs(runs_jsonl)
+
+    evals: list[dict] = []
+    for run in runs:
+        question_id = run.get("question_id", "")
+        question = questions_by_id.get(question_id)
+        if question is None:
+            _stderr(
+                f"[evaluate] Warning: no question found for question_id={question_id!r}; "
+                "skipping run."
+            )
+            continue
+
+        # Resolve repo_path: prefer the stored path in the run, fallback to manifest
+        repo_path_str = run.get("repo_path", "")
+        if repo_path_str:
+            repo_path = Path(repo_path_str)
+        else:
+            repo_id = run.get("repo_id", "")
+            if repo_id and repo_id in repo_path_by_id:
+                repo_path = repo_path_by_id[repo_id]
+            else:
+                _stderr(
+                    f"[evaluate] Warning: cannot resolve repo_path for run "
+                    f"{run.get('run_id', '?')}; using empty path."
+                )
+                repo_path = Path("")
+
+        record = evaluate_run(
+            run=run,
+            question=question,
+            repo_path=repo_path,
+            model=model,
+            dry_run=dry_run,
+            results_dir=results_dir,
+        )
+        evals.append(record)
+
+    return evals
+
+
+# ---------------------------------------------------------------------------
+# Loading helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_questions(questions_yaml: Path) -> dict[str, dict]:
+    """Load questions from YAML and index them by ``id``.
+
+    Accepts two YAML shapes:
+      - Top-level list of question mappings
+      - ``{questions: [...]}`` mapping
+    """
+    if not questions_yaml.exists():
+        raise FileNotFoundError(f"Questions file not found: {questions_yaml}")
+
+    with questions_yaml.open("r", encoding="utf-8") as fh:
+        raw = yaml.safe_load(fh)
+
+    if isinstance(raw, list):
+        entries = raw
+    elif isinstance(raw, dict) and "questions" in raw:
+        entries = raw["questions"]
+    else:
+        raise ValueError(
+            f"questions.yaml must be a list or a dict with a 'questions' key: {questions_yaml}"
+        )
+
+    indexed: dict[str, dict] = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        qid = str(entry.get("id", ""))
+        if qid:
+            indexed[qid] = entry
+    return indexed
+
+
+def _load_repo_paths(manifest_path: Path) -> dict[str, Path]:
+    """Load ``{repo_id: local_path}`` from a prepared_repos.json manifest."""
+    if not manifest_path.exists():
+        _stderr(f"[evaluate] Warning: manifest not found: {manifest_path}")
+        return {}
+
+    raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if not isinstance(raw, list):
+        _stderr(f"[evaluate] Warning: manifest is not a JSON array: {manifest_path}")
+        return {}
+
+    result: dict[str, Path] = {}
+    for entry in raw:
+        repo_id = entry.get("id", "")
+        local_path = entry.get("local_path", "")
+        if repo_id and local_path:
+            result[repo_id] = Path(local_path)
+    return result
+
+
+def _load_runs(runs_jsonl: Path) -> list[dict]:
+    """Load all RunRecord dicts from a JSONL file."""
+    if not runs_jsonl.exists():
+        raise FileNotFoundError(f"runs.jsonl not found: {runs_jsonl}")
+
+    runs: list[dict] = []
+    with runs_jsonl.open("r", encoding="utf-8") as fh:
+        for lineno, line in enumerate(fh, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                runs.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                _stderr(f"[evaluate] Warning: bad JSON on line {lineno}: {exc}")
+    return runs
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="evaluate",
+        description="Evaluate benchmark runs against expected answers.",
+    )
+    parser.add_argument(
+        "--runs",
+        required=True,
+        metavar="PATH",
+        help="Path to the runs.jsonl file.",
+    )
+    parser.add_argument(
+        "--questions",
+        required=True,
+        metavar="PATH",
+        help="Path to the questions.yaml file.",
+    )
+    parser.add_argument(
+        "--manifest",
+        required=True,
+        metavar="PATH",
+        help="Path to the prepared_repos.json manifest.",
+    )
+    parser.add_argument(
+        "--results-dir",
+        default="results",
+        metavar="DIR",
+        help="Directory to write evals.jsonl into (default: results).",
+    )
+    parser.add_argument(
+        "--model",
+        default="claude-haiku-4-5-20251001",
+        help="Claude model ID for LLM evaluation (default: claude-haiku-4-5-20251001).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Skip LLM calls and use stub scores (no API key required).",
+    )
+    return parser
+
+
+def _cmd_evaluate(args: argparse.Namespace) -> int:
+    runs_jsonl = Path(args.runs)
+    questions_yaml = Path(args.questions)
+    manifest = Path(args.manifest)
+    results_dir = Path(args.results_dir)
+
+    try:
+        evals = evaluate_all(
+            runs_jsonl=runs_jsonl,
+            questions_yaml=questions_yaml,
+            prepared_manifest=manifest,
+            results_dir=results_dir,
+            model=args.model,
+            dry_run=args.dry_run,
+        )
+    except FileNotFoundError as exc:
+        _stderr(f"Error: {exc}")
+        return 1
+    except ValueError as exc:
+        _stderr(f"Error: {exc}")
+        return 1
+
+    evals_path = results_dir / "evals.jsonl"
+    print(f"evaluated {len(evals)} runs, wrote {evals_path}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    return _cmd_evaluate(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/codegraph_compare/prompts/evaluator.md
+++ b/benchmarks/codegraph_compare/prompts/evaluator.md
@@ -1,0 +1,46 @@
+# Evaluator Prompt
+
+You are scoring a benchmark answer about a software codebase. You will be given the question, the list of `expected_key_points`, the `anti_hallucination_checks`, and the answer to evaluate.
+
+Score the answer on four dimensions, each from 1 to 5:
+
+## Scoring Rubric
+
+**correctness** — Is the described code path actually correct for this repo?
+- 1: Multiple core claims are wrong or inverted.
+- 3: Main path is roughly right but contains one notable error.
+- 5: Every described mechanism matches how the code actually works.
+
+**completeness** — Are the key classes, functions, and files from `expected_key_points` present?
+- 1: Fewer than half the key points are covered.
+- 3: Most key points covered; one or two missing.
+- 5: All key points addressed with accurate context.
+
+**citation_quality** — Are cited file paths real, specific, and relevant?
+- 1: No file paths cited, or all cited paths are vague/fabricated.
+- 3: Some real paths cited; a few are imprecise or missing line numbers.
+- 5: Specific file paths with line numbers cited for every substantive claim.
+
+**hallucination_risk** — Does the answer assert things that sound plausible but lack grounding in the code? (5 = safest, 1 = most risky)
+- 1: Multiple suspiciously specific claims with no file evidence; contradicts `anti_hallucination_checks`.
+- 3: One uncertain claim that is not directly supported by cited code.
+- 5: Every claim is tied to a specific file location or direct observation.
+
+## Output Format
+
+Return ONLY the following JSON object — no prose before or after it:
+
+```json
+{
+  "correctness": <int 1-5>,
+  "completeness": <int 1-5>,
+  "citation_quality": <int 1-5>,
+  "hallucination_risk": <int 1-5>,
+  "overall": <float, arithmetic mean of the four scores>,
+  "missing_key_points": ["<key point text that was absent>"],
+  "bad_citations": ["<cited path or claim that appears fabricated or unverifiable>"],
+  "reasoning": "<one paragraph explaining the scores, grounded in specific quotes or observations from the answer>"
+}
+```
+
+Reward answers that are correct and grounded in specific evidence. Do not reward authoritative tone or length — a short, well-cited answer beats a long but vague one.

--- a/benchmarks/codegraph_compare/prompts/system_codegraph.md
+++ b/benchmarks/codegraph_compare/prompts/system_codegraph.md
@@ -2,11 +2,17 @@
 
 You are answering architecture questions about a software codebase. You have access to a pre-built CodeGraph symbol index that covers every symbol, call edge, and file in the repo.
 
+You may use either CodeGraph MCP tools or the CodeGraph CLI. If MCP tools are unavailable in your agent environment, use these CLI equivalents:
+- `codegraph context -p . "<task>" --format json` for broad task context.
+- `codegraph query -p . "<symbol-or-concept>" --json --limit 10` for symbol search.
+- `codegraph files -p .` for indexed file structure.
+- `codegraph affected -p . <files...>` for change-impact questions.
+
 Workflow:
-1. Call `codegraph_context` FIRST, passing the key concept or symbol from the question. This returns the most relevant symbols, callers, and callees in a single call.
-2. Use `codegraph_explore` to survey a set of related symbols' source when you need breadth across an area (one call, not many).
-3. Use `codegraph_callers` and `codegraph_callees` to trace specific call chains up or down the graph.
-4. Use `codegraph_impact` to understand what a change would affect.
+1. Call `codegraph_context` or run `codegraph context -p . "<task>" --format json` FIRST, passing the key concept or symbol from the question. This returns the most relevant symbols, callers, and callees in a single call.
+2. Use `codegraph_explore` or focused `codegraph query` calls to survey related symbols when you need breadth across an area.
+3. Use `codegraph_callers` and `codegraph_callees` to trace specific call chains up or down the graph when MCP is available; otherwise use `codegraph context` plus focused file confirmation.
+4. Use `codegraph_impact` or `codegraph affected -p . <files...>` to understand what a change would affect.
 5. Only open raw files (Read/grep) to confirm a specific detail that the graph did not cover.
 
 Rules:

--- a/benchmarks/codegraph_compare/prompts/system_codegraph.md
+++ b/benchmarks/codegraph_compare/prompts/system_codegraph.md
@@ -1,0 +1,16 @@
+# System Prompt — CodeGraph Arm
+
+You are answering architecture questions about a software codebase. You have access to a pre-built CodeGraph symbol index that covers every symbol, call edge, and file in the repo.
+
+Workflow:
+1. Call `codegraph_context` FIRST, passing the key concept or symbol from the question. This returns the most relevant symbols, callers, and callees in a single call.
+2. Use `codegraph_explore` to survey a set of related symbols' source when you need breadth across an area (one call, not many).
+3. Use `codegraph_callers` and `codegraph_callees` to trace specific call chains up or down the graph.
+4. Use `codegraph_impact` to understand what a change would affect.
+5. Only open raw files (Read/grep) to confirm a specific detail that the graph did not cover.
+
+Rules:
+- Always report actual file paths and line numbers in your final answer — CodeGraph tells you WHERE symbols live; you must surface those paths to the reader.
+- Do not guess. Only report what the graph and the files directly show.
+- Do not chain multiple `codegraph_search` + `codegraph_node` calls when a single `codegraph_context` or `codegraph_explore` covers the same ground.
+- If the index returns no results, say so; do not fall back to general knowledge.

--- a/benchmarks/codegraph_compare/prompts/system_native.md
+++ b/benchmarks/codegraph_compare/prompts/system_native.md
@@ -1,0 +1,11 @@
+# System Prompt — Native Search Arm
+
+You are answering architecture questions about a software codebase.
+
+You may only use file reading and text search tools: Read a file by path, run `grep` or `rg` via Bash, or use glob patterns to list files. No other code-intelligence tools are available.
+
+Rules:
+- Cite specific file paths and line numbers for every claim you make.
+- Do not guess or infer from general knowledge about a framework or library. Only state what you directly observe in the source files.
+- If you cannot locate the relevant code, say so explicitly rather than speculating.
+- Keep your answer focused on the actual code path; avoid padding with background context not grounded in the files you read.

--- a/benchmarks/codegraph_compare/prompts/system_tsa.md
+++ b/benchmarks/codegraph_compare/prompts/system_tsa.md
@@ -1,0 +1,15 @@
+# System Prompt — tree-sitter-analyzer (TSA) Arm
+
+You are answering architecture questions about a software codebase. You have access to the tree-sitter-analyzer (TSA) CLI, which parses the repo with tree-sitter and exposes structural queries.
+
+Workflow:
+1. Run `python -m tree_sitter_analyzer smart-context --query "<concept from the question>" --format json` FIRST. This returns the most relevant files and symbols for the concept.
+2. Use `python -m tree_sitter_analyzer project-graph --format json` to inspect module-level dependency structure when the question is about module boundaries or subsystem layout.
+3. Use `python -m tree_sitter_analyzer call-graph --entry <symbol> --format json` to trace a specific call chain when the question asks how execution flows from a known entry point.
+4. Use raw file reads (Read) only to confirm a specific detail that TSA output did not cover.
+
+Rules:
+- Always cite actual file paths (and line numbers when available) in your final answer. TSA surfaces the locations; you must relay them to the reader.
+- Do not guess or infer from general knowledge about the library. Only state what TSA output and the source files directly show.
+- If TSA returns no results for a query, say so rather than speculating.
+- Keep your final answer grounded in the evidence TSA and the files produced.

--- a/benchmarks/codegraph_compare/questions.yaml
+++ b/benchmarks/codegraph_compare/questions.yaml
@@ -1,0 +1,402 @@
+---
+# Benchmark question bank for the native / CodeGraph / TSA three-arm comparison.
+# 21 questions across 7 repos × 3 questions each.
+# All 5 categories appear across the full set.
+# Questions are tool-neutral — they do not mention CodeGraph or tree-sitter-analyzer.
+
+questions:
+
+  # ── GIN (Go router) ──────────────────────────────────────────────────────────
+
+  - id: gin-route-matching
+    repo: gin
+    category: entrypoint-tracing
+    prompt: >
+      How does Gin match an incoming URL path to a registered route handler?
+      Trace the code path from the moment (*Engine).ServeHTTP receives a request
+      through tree lookup to the final handler invocation, naming the key types
+      and functions involved.
+    expected_key_points:
+      - "(*Engine).ServeHTTP"
+      - "(*Engine).handleHTTPRequest"
+      - "methodTree / node (radix tree)"
+      - "getValue or (*node).getValue"
+      - "HandlerFunc / HandlersChain"
+    must_cite_files: true
+    anti_hallucination_checks:
+      - "must not claim Gin uses a hash map for route lookup — it uses a compressed radix trie"
+      - "must not attribute route matching to gin.Default() — Default() only wires middleware"
+
+  - id: gin-middleware-chain
+    repo: gin
+    category: call-chain
+    prompt: >
+      How does Gin execute the middleware chain for a matched route?
+      Explain how handlers are stored, how (*Context).Next() advances the chain,
+      and how (*Context).Abort() short-circuits it.
+    expected_key_points:
+      - "HandlersChain ([]HandlerFunc)"
+      - "(*Context).index"
+      - "(*Context).Next()"
+      - "(*Context).Abort() / abortIndex"
+      - "c.handlers set during route registration"
+    must_cite_files: true
+    anti_hallucination_checks:
+      - "must not say middleware runs in a separate goroutine per handler"
+      - "must not confuse abortIndex with a boolean flag — it is an int8 sentinel value"
+
+  - id: gin-404-handling
+    repo: gin
+    category: module-boundary
+    prompt: >
+      What happens when no route matches an incoming request in Gin?
+      How is the 404 response triggered, and how can an application register
+      a custom NoRoute handler?
+    expected_key_points:
+      - "(*Engine).handleHTTPRequest — no route found branch"
+      - "(*Engine).NoRoute / engine.allNoRoute"
+      - "serveError or c.Status(404) / default 404 path"
+      - "(*Engine).noRoute field (HandlersChain)"
+    must_cite_files: true
+    anti_hallucination_checks:
+      - "must not claim Gin panics on unmatched routes by default"
+      - "must not say NoRoute is registered via a middleware — it is registered via engine.NoRoute()"
+
+  # ── DJANGO (Python web framework) ────────────────────────────────────────────
+
+  - id: django-request-routing
+    repo: django
+    category: entrypoint-tracing
+    prompt: >
+      How does an incoming HTTP request travel from the WSGI/ASGI entry point
+      to a view function in Django? Identify the key classes and functions
+      involved, from WSGIHandler.__call__ through URL resolution to view dispatch.
+    expected_key_points:
+      - "WSGIHandler.__call__ (django/core/handlers/wsgi.py)"
+      - "BaseHandler.get_response or _get_response"
+      - "URLResolver.resolve (django/urls/resolvers.py)"
+      - "ResolverMatch"
+      - "view function invocation / callback"
+    must_cite_files: true
+    anti_hallucination_checks:
+      - "must not claim URLconf is parsed on every request — it is cached after first load"
+      - "must not say BaseHandler is in django/core/wsgi.py — it is in django/core/handlers/base.py"
+
+  - id: django-orm-queryset-sql
+    repo: django
+    category: call-chain
+    prompt: >
+      How does Django's ORM translate a queryset filter chain (e.g.
+      MyModel.objects.filter(field=value).order_by('name')) into a SQL query?
+      Trace through the relevant classes from QuerySet to the SQL compiler.
+    expected_key_points:
+      - "QuerySet.filter → QuerySet.clone + Q objects"
+      - "Query.add_q / Query.build_filter (django/db/models/sql/query.py)"
+      - "SQLCompiler.as_sql or execute_sql (django/db/models/sql/compiler.py)"
+      - "WhereNode"
+      - "DatabaseWrapper / cursor execution"
+    must_cite_files: true
+    anti_hallucination_checks:
+      - "must not say SQL is generated inside QuerySet.__iter__ directly — compilation is delegated to SQLCompiler"
+      - "must not claim Django uses an ORM called SQLAlchemy"
+
+  - id: django-migration-detection
+    repo: django
+    category: change-impact
+    prompt: >
+      How does Django's migration system detect schema changes in models and
+      generate migration files? Trace from the makemigrations management command
+      through autodetection to file writing.
+    expected_key_points:
+      - "MakeMigrationsCommand.handle (django/core/management/commands/makemigrations.py)"
+      - "MigrationAutodetector (django/db/migrations/autodetector.py)"
+      - "MigrationAutodetector.changes"
+      - "ProjectState / ModelState"
+      - "MigrationWriter (django/db/migrations/writer.py)"
+    must_cite_files: true
+    anti_hallucination_checks:
+      - "must not say Django diffs the live database — it diffs ProjectState objects built from existing migration files"
+      - "must not attribute autodetection to MigrationLoader"
+
+  # ── TOKIO (Rust async runtime) ────────────────────────────────────────────────
+
+  - id: tokio-task-spawn
+    repo: tokio
+    category: entrypoint-tracing
+    prompt: >
+      How does Tokio schedule a task spawned via tokio::spawn onto worker threads?
+      Trace from the tokio::spawn call through task creation and injection into
+      the scheduler's run queue.
+    expected_key_points:
+      - "tokio::spawn → task::spawn"
+      - "OwnedTasks or LocalOwnedTasks"
+      - "Inject queue / run_queue"
+      - "Worker thread / Handle::spawn_local or inject"
+      - "Notified / wake mechanism to signal an idle worker"
+    must_cite_files: true
+    anti_hallucination_checks:
+      - "must not say tokio::spawn blocks the calling thread"
+      - "must not claim each spawned task always gets its own OS thread"
+
+  - id: tokio-task-selection
+    repo: tokio
+    category: call-chain
+    prompt: >
+      How does a Tokio worker thread select the next task to execute from its
+      run queues? Describe the work-stealing strategy and the order in which
+      local, global, and stolen queues are checked.
+    expected_key_points:
+      - "Worker::run / run_task"
+      - "local run queue (Local<T>)"
+      - "global inject queue checked periodically (GLOBAL_QUEUE_INTERVAL)"
+      - "work-stealing from sibling worker queues"
+      - "park / unpark when queues are empty"
+    must_cite_files: true
+    anti_hallucination_checks:
+      - "must not say Tokio uses a single global FIFO for all tasks with no work-stealing"
+      - "must not claim the IO driver polling is done inside the same task-selection loop without noting the separate io-driver integration"
+
+  - id: tokio-select-macro
+    repo: tokio
+    category: subsystem-overview
+    prompt: >
+      How does the tokio::select! macro work under the hood to poll multiple
+      futures concurrently? Describe the generated code structure and how it
+      decides which branch to wake and complete.
+    expected_key_points:
+      - "select! macro expansion (tokio/src/macros/select.rs)"
+      - "polling each branch future in a randomized order"
+      - "BRANCHES bitmask / disabled branches"
+      - "Context / Waker forwarding"
+      - "biased mode vs default random ordering"
+    must_cite_files: true
+    anti_hallucination_checks:
+      - "must not say select! spawns each branch as a separate task"
+      - "must not say select! uses OS-level multiplexing like epoll directly"
+
+  # ── VS CODE (TypeScript editor) ──────────────────────────────────────────────
+
+  - id: vscode-command-dispatch
+    repo: vscode
+    category: entrypoint-tracing
+    prompt: >
+      How does VS Code register and dispatch a command from the command palette?
+      Trace from a user invoking a command through CommandService and into the
+      registered handler, naming key classes and interfaces.
+    expected_key_points:
+      - "CommandService (src/vs/platform/commands/common/commandService.ts)"
+      - "CommandsRegistry.registerCommand"
+      - "ICommandHandler / CommandsRegistry"
+      - "executeCommand → _tryExecuteCommand"
+      - "ICommandService interface"
+    must_cite_files: true
+    anti_hallucination_checks:
+      - "must not attribute command dispatch to ExtensionHostMain directly — core commands go through CommandService"
+      - "must not say commands are stored in a plain JS object — they are stored in a Map in CommandsRegistry"
+
+  - id: vscode-extension-activation
+    repo: vscode
+    category: module-boundary
+    prompt: >
+      How does VS Code's extension activation system determine when to activate
+      an extension? Trace how activation events declared in package.json are
+      matched and how the extension host triggers activation.
+    expected_key_points:
+      - "activationEvents field in package.json"
+      - "ExtensionService or AbstractExtensionService"
+      - "_activateByEvent or activateByEvent"
+      - "ExtensionHostManager / ExtensionHostProtocol"
+      - "IExtensionDescription"
+    must_cite_files: true
+    anti_hallucination_checks:
+      - "must not claim all extensions activate at startup by default — they activate lazily on matching events"
+      - "must not say activation happens in the main renderer process — it happens in the extension host process"
+
+  - id: vscode-lsp-diagnostics
+    repo: vscode
+    category: subsystem-overview
+    prompt: >
+      How does VS Code's language server protocol integration deliver diagnostics
+      (errors and warnings) from a language server to the editor UI? Describe
+      the message flow from the language server publishing diagnostics to the
+      markers appearing in the Problems panel.
+    expected_key_points:
+      - "textDocument/publishDiagnostics notification"
+      - "LanguageClient (vscode-languageclient) handling the notification"
+      - "IMarkerService.changeOne or MarkerService (src/vs/platform/markers)"
+      - "DiagnosticCollection (extension API surface)"
+      - "Problems panel / MarkersModel"
+    must_cite_files: true
+    anti_hallucination_checks:
+      - "must not say diagnostics are pulled by the editor — they are pushed via publishDiagnostics"
+      - "must not conflate DiagnosticSeverity values with HTTP status codes"
+
+  # ── EXCALIDRAW (TypeScript canvas app) ───────────────────────────────────────
+
+  - id: excalidraw-collab-sync
+    repo: excalidraw
+    category: subsystem-overview
+    prompt: >
+      How does Excalidraw handle collaborative real-time state synchronization
+      between clients? Identify the collaboration module, the protocol used,
+      and how incoming remote scene updates are reconciled with local state.
+    expected_key_points:
+      - "Collab class or useCollaboration hook (src/excalidraw-app/collab/)"
+      - "WebSocket / socket.io connection"
+      - "reconcileElements or scene reconciliation"
+      - "broadcastElements / broadcast scene"
+      - "ExcalidrawElement version vector or conflict resolution"
+    must_cite_files: true
+    anti_hallucination_checks:
+      - "must not say Excalidraw uses WebRTC peer-to-peer as its primary sync channel"
+      - "must not claim state is reconciled using operational transforms (OT) — it uses version-based last-write-wins per element"
+
+  - id: excalidraw-hit-testing
+    repo: excalidraw
+    category: call-chain
+    prompt: >
+      How does Excalidraw determine which element the user clicked on the canvas?
+      Trace from the canvas mousedown event through hit-testing logic to element
+      selection, naming the relevant functions and their locations.
+    expected_key_points:
+      - "onPointerDown or handleCanvasPointerDown"
+      - "getElementAtPosition or isHittingElement"
+      - "hitTest per element type (hitTestRectangle, hitTestEllipse, etc.)"
+      - "ExcalidrawElement bounding-box / bounds calculation"
+      - "appState.selectedElementIds update"
+    must_cite_files: true
+    anti_hallucination_checks:
+      - "must not say hit-testing uses a spatial index or quadtree — elements are iterated linearly in reverse z-order"
+      - "must not attribute click handling to the React synthetic event system alone — raw canvas events are used"
+
+  - id: excalidraw-serialization
+    repo: excalidraw
+    category: module-boundary
+    prompt: >
+      How does Excalidraw serialize and deserialize scene data for export and
+      import (.excalidraw files)? Identify the serialization functions, the
+      file format structure, and how binary assets (images) are handled.
+    expected_key_points:
+      - "serializeAsJSON / exportToBlob or exportToSvg (packages/excalidraw/data/)"
+      - "ImportedDataState / ExcalidrawDataState shape"
+      - "loadFromBlob or restore functions"
+      - "BinaryFiles / base64 encoded image data"
+      - "version field / file format versioning"
+    must_cite_files: true
+    anti_hallucination_checks:
+      - "must not say Excalidraw stores scene data in localStorage as the canonical persistence — .excalidraw is a JSON file export"
+      - "must not claim SVG export and JSON export share the same serialization path"
+
+  # ── OKHTTP (Java HTTP client) ─────────────────────────────────────────────────
+
+  - id: okhttp-interceptor-chain
+    repo: okhttp
+    category: call-chain
+    prompt: >
+      How does an HTTP call move through OkHttp's interceptor chain before
+      reaching the network layer? Describe how RealCall assembles the chain,
+      how each interceptor calls proceed(), and which built-in interceptors
+      are always present.
+    expected_key_points:
+      - "RealCall.getResponseWithInterceptorChain()"
+      - "RealInterceptorChain.proceed()"
+      - "RetryAndFollowUpInterceptor"
+      - "BridgeInterceptor"
+      - "CacheInterceptor and CallServerInterceptor"
+    must_cite_files: true
+    anti_hallucination_checks:
+      - "must not say interceptors run in parallel — they form a sequential chain"
+      - "must not attribute network I/O to BridgeInterceptor — that is CallServerInterceptor's role"
+
+  - id: okhttp-connection-pool
+    repo: okhttp
+    category: module-boundary
+    prompt: >
+      How does OkHttp's connection pool manage and reuse HTTP connections?
+      Describe how a connection is acquired from the pool, how idle connections
+      are evicted, and which classes are responsible.
+    expected_key_points:
+      - "ConnectionPool / RealConnectionPool"
+      - "RealConnectionPool.transmitterAcquirePooledConnection or acquire()"
+      - "connections deque / ConcurrentLinkedDeque"
+      - "cleanup task / cleanupRunnable eviction"
+      - "RealConnection with transmitter references / noNewExchanges"
+    must_cite_files: true
+    anti_hallucination_checks:
+      - "must not say OkHttp creates a new TCP connection for every request by default — pooling is on by default"
+      - "must not attribute connection eviction to a dedicated background thread per connection"
+
+  - id: okhttp-http2-multiplexing
+    repo: okhttp
+    category: subsystem-overview
+    prompt: >
+      How does OkHttp handle HTTP/2 multiplexing? Explain how multiple
+      concurrent streams share a single connection and how the Http2Connection
+      and Http2Stream classes relate.
+    expected_key_points:
+      - "Http2Connection (okhttp/src/main/kotlin/okhttp3/internal/http2/)"
+      - "Http2Stream"
+      - "stream ID assignment / newStream()"
+      - "FrameWriter / FrameReader for HEADERS and DATA frames"
+      - "RealConnection.isMultiplexed() or isHealthy()"
+    must_cite_files: true
+    anti_hallucination_checks:
+      - "must not say HTTP/2 multiplexing requires multiple TCP connections — it multiplexes over one"
+      - "must not claim OkHttp uses NIO selectors directly for HTTP/2 framing — it uses Okio"
+
+  # ── ALAMOFIRE (Swift HTTP library) ───────────────────────────────────────────
+
+  - id: alamofire-build-send-request
+    repo: alamofire
+    category: entrypoint-tracing
+    prompt: >
+      How does Alamofire build and send a URLRequest from a DataRequest?
+      Trace from Session.request() through RequestAdapter, URLRequestConvertible,
+      and into URLSession task creation.
+    expected_key_points:
+      - "Session.request() → DataRequest creation"
+      - "RequestInterceptor / RequestAdapter.adapt()"
+      - "URLRequestConvertible.asURLRequest()"
+      - "URLSessionDataTask creation via Session.sessionManager or session.dataTask"
+      - "RequestDelegate / task resume"
+    must_cite_files: true
+    anti_hallucination_checks:
+      - "must not say Alamofire bypasses URLSession and uses raw CFSocket — it wraps URLSession"
+      - "must not attribute request serialization to ResponseSerializer — that is only for response decoding"
+
+  - id: alamofire-response-validation
+    repo: alamofire
+    category: call-chain
+    prompt: >
+      How does Alamofire's response validation chain work? Describe how
+      validate() calls accumulate validators and how they are evaluated when
+      the response arrives.
+    expected_key_points:
+      - "DataRequest.validate() returning Self (fluent API)"
+      - "validators array on Request"
+      - "ValidationExecution closure / Validation typealias"
+      - "evaluation in response serializer or processResponse"
+      - "AFError.responseValidationFailed on failure"
+    must_cite_files: true
+    anti_hallucination_checks:
+      - "must not say validate() executes immediately when called — validators are stored and run after the response arrives"
+      - "must not conflate validate() with response() / responseJSON() calls"
+
+  - id: alamofire-retry-auth
+    repo: alamofire
+    category: change-impact
+    prompt: >
+      How does Alamofire handle request retrying and authentication challenges?
+      Explain how RequestRetrier and the URLSession authentication delegate
+      method interact with the Session to retry or credential-supply a failed
+      request.
+    expected_key_points:
+      - "RequestRetrier.retry() callback"
+      - "Session.retryRequest() or RequestInterceptor"
+      - "URLSessionTaskDelegate.urlSession(_:task:didReceive:completionHandler:)"
+      - "AuthenticationChallenge / credential(for:) or URLCredential"
+      - "RetryResult enum (retry, doNotRetry, retryWithDelay)"
+    must_cite_files: true
+    anti_hallucination_checks:
+      - "must not say retry logic lives inside URLSession — it is implemented in Alamofire's Session layer on top of URLSession callbacks"
+      - "must not claim Alamofire retries indefinitely by default — the retrier must explicitly return .retry"

--- a/benchmarks/codegraph_compare/repo_prep.py
+++ b/benchmarks/codegraph_compare/repo_prep.py
@@ -1,0 +1,598 @@
+"""Repo preparation module for the CodeGraph comparison benchmark harness.
+
+Clones repos to ``.benchmark-repos/<repo-id>/``, pins to a specific commit,
+and collects metadata (file counts, sizes).
+
+Public API
+----------
+    prepare_repo(repo, base_dir) -> PreparedRepo
+    prepare_all(repos, base_dir) -> list[PreparedRepo]
+    load_prepared_manifest(path) -> list[PreparedRepo]
+    save_prepared_manifest(repos, path) -> None
+
+CLI
+---
+    python benchmarks/codegraph_compare/repo_prep.py prepare --repo gin
+    python benchmarks/codegraph_compare/repo_prep.py prepare --all
+    python benchmarks/codegraph_compare/repo_prep.py status
+
+Created: 2026-05-26
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_BASE_DIR = Path(".benchmark-repos")
+
+REPOS_CONFIG = Path(__file__).parent / "repos.yaml"
+
+# Directories excluded from file counts
+_EXCLUDED_DIRS = {".git", "node_modules", "vendor", "__pycache__", ".benchmark-repos"}
+
+# Source file extensions that count toward source_file_count
+_SOURCE_EXTENSIONS = {
+    ".py",
+    ".ts",
+    ".tsx",
+    ".js",
+    ".jsx",
+    ".go",
+    ".rs",
+    ".java",
+    ".swift",
+    ".kt",
+    ".cpp",
+    ".c",
+    ".h",
+    ".cs",
+}
+
+# Sentinel commit value meaning "use HEAD on default branch"
+_PLACEHOLDER_SHA = "PLACEHOLDER_SHA"
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RepoSpec:
+    """Specification for a repository to benchmark."""
+
+    id: str
+    name: str
+    url: str
+    language: str
+    commit: str
+    description: str = ""
+
+
+@dataclass
+class PreparedRepo:
+    """Result of successfully (or unsuccessfully) preparing a repository."""
+
+    id: str
+    name: str
+    language: str
+    local_path: Path
+    actual_commit: str
+    file_count: int
+    source_file_count: int
+    size_bytes: int
+    prepared_at: str  # ISO 8601 timestamp
+    error: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Config loading
+# ---------------------------------------------------------------------------
+
+
+def load_repos_config(path: Path = REPOS_CONFIG) -> list[RepoSpec]:
+    """Load repo specs from a YAML config file.
+
+    Expected YAML structure::
+
+        repos:
+          - id: gin
+            name: gin-gonic/gin
+            url: https://github.com/gin-gonic/gin.git
+            language: Go
+            commit: abc123def456...
+            description: "Fast HTTP web framework for Go"
+    """
+    if not path.exists():
+        raise FileNotFoundError(f"Repos config not found: {path}")
+
+    with path.open("r", encoding="utf-8") as fh:
+        raw = yaml.safe_load(fh)
+
+    if not isinstance(raw, dict) or "repos" not in raw:
+        raise ValueError(f"repos.yaml must have a top-level 'repos' list: {path}")
+
+    specs = []
+    for entry in raw["repos"]:
+        if not isinstance(entry, dict):
+            raise ValueError(
+                f"Each entry in repos.yaml must be a mapping, got: {entry!r}"
+            )
+        specs.append(
+            RepoSpec(
+                id=str(entry["id"]),
+                name=str(entry["name"]),
+                url=str(entry["url"]),
+                language=str(entry["language"]),
+                commit=str(entry["commit"]),
+                description=str(entry.get("description", "")),
+            )
+        )
+    return specs
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _stderr(*args: Any, **kwargs: Any) -> None:
+    """Print progress messages to stderr so stdout stays machine-readable."""
+    print(*args, **kwargs, file=sys.stderr)
+
+
+def _run_git(args: list[str], cwd: Path | None = None, check: bool = True) -> str:
+    """Run a git command and return stdout as a stripped string."""
+    cmd = ["git"] + args
+    result = subprocess.run(
+        cmd,
+        cwd=str(cwd) if cwd else None,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=check,
+    )
+    return result.stdout.strip()
+
+
+def _get_current_commit(repo_dir: Path) -> str:
+    """Return the current HEAD commit SHA in the given repo dir."""
+    return _run_git(["rev-parse", "HEAD"], cwd=repo_dir)
+
+
+def _is_excluded(path: Path, base: Path) -> bool:
+    """Return True if the path is inside an excluded directory."""
+    try:
+        relative = path.relative_to(base)
+    except ValueError:
+        return False
+    # Check every part of the relative path against excluded dir names
+    return any(part in _EXCLUDED_DIRS for part in relative.parts)
+
+
+def _collect_stats(repo_dir: Path) -> tuple[int, int, int]:
+    """Walk repo_dir and return (file_count, source_file_count, size_bytes).
+
+    Excludes .git/, node_modules/, vendor/, __pycache__/, .benchmark-repos/
+    from all counts.
+    """
+    file_count = 0
+    source_file_count = 0
+    size_bytes = 0
+
+    for entry in repo_dir.rglob("*"):
+        if not entry.is_file():
+            continue
+        if _is_excluded(entry, repo_dir):
+            continue
+
+        file_count += 1
+        if entry.suffix.lower() in _SOURCE_EXTENSIONS:
+            source_file_count += 1
+        try:
+            size_bytes += entry.stat().st_size
+        except OSError:
+            pass  # race condition or unreadable file — skip silently
+
+    return file_count, source_file_count, size_bytes
+
+
+def _clone_repo(url: str, dest: Path) -> None:
+    """Clone a repo from url into dest (must not exist yet)."""
+    _stderr(f"  Cloning {url} → {dest}")
+    subprocess.run(
+        ["git", "clone", "--quiet", url, str(dest)],
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+
+
+def _checkout_commit(repo_dir: Path, commit: str) -> None:
+    """Hard-checkout a specific commit (detached HEAD)."""
+    _stderr(f"  Checking out {commit[:12]}…")
+    _run_git(["checkout", "--quiet", commit], cwd=repo_dir)
+
+
+def _get_default_branch_head(repo_dir: Path) -> str:
+    """Return the current HEAD SHA without checking out anything extra.
+
+    After a plain ``git clone``, HEAD is already at the default branch tip,
+    so we just resolve it.
+    """
+    return _run_git(["rev-parse", "HEAD"], cwd=repo_dir)
+
+
+# ---------------------------------------------------------------------------
+# Core API
+# ---------------------------------------------------------------------------
+
+
+def prepare_repo(
+    repo: RepoSpec,
+    base_dir: Path = DEFAULT_BASE_DIR,
+) -> PreparedRepo:
+    """Clone repo to ``base_dir/<repo.id>/``, pin to commit, collect metadata.
+
+    Idempotent: if the directory already exists and HEAD matches
+    ``repo.commit``, the clone step is skipped.
+
+    If ``repo.commit == "PLACEHOLDER_SHA"``, the latest commit on the cloned
+    default branch is used and recorded as ``actual_commit``.
+
+    Any exception during preparation is caught; the returned ``PreparedRepo``
+    will have ``error`` set instead of raising.
+    """
+    base_dir = base_dir.resolve()
+    repo_dir = base_dir / repo.id
+    prepared_at = datetime.now(tz=timezone.utc).isoformat()
+
+    try:
+        base_dir.mkdir(parents=True, exist_ok=True)
+
+        use_placeholder = repo.commit == _PLACEHOLDER_SHA
+
+        # --- Determine whether we can skip the clone ---
+        already_exists = repo_dir.exists()
+        skip_clone = False
+
+        if already_exists and not use_placeholder:
+            try:
+                current_sha = _get_current_commit(repo_dir)
+                if current_sha == repo.commit:
+                    _stderr(
+                        f"[{repo.id}] Already at {repo.commit[:12]}, skipping clone."
+                    )
+                    skip_clone = True
+                else:
+                    _stderr(
+                        f"[{repo.id}] Exists but at {current_sha[:12]} "
+                        f"(want {repo.commit[:12]}); re-cloning."
+                    )
+            except subprocess.CalledProcessError:
+                _stderr(f"[{repo.id}] Exists but git check failed; re-cloning.")
+
+        if not skip_clone:
+            # Remove stale directory if present
+            if already_exists:
+                import shutil as _shutil
+
+                _stderr(f"[{repo.id}] Removing stale directory {repo_dir}")
+                _shutil.rmtree(repo_dir)
+
+            _stderr(f"[{repo.id}] Cloning …")
+            _clone_repo(repo.url, repo_dir)
+
+        # --- Resolve actual commit ---
+        if use_placeholder:
+            actual_commit = _get_default_branch_head(repo_dir)
+            _stderr(f"[{repo.id}] PLACEHOLDER_SHA resolved to {actual_commit[:12]}")
+        else:
+            if not skip_clone:
+                _checkout_commit(repo_dir, repo.commit)
+            actual_commit = _get_current_commit(repo_dir)
+
+        # --- Collect metadata ---
+        _stderr(f"[{repo.id}] Counting files …")
+        file_count, source_file_count, size_bytes = _collect_stats(repo_dir)
+        _stderr(
+            f"[{repo.id}] Done — {file_count} files, "
+            f"{source_file_count} source files, "
+            f"{size_bytes:,} bytes"
+        )
+
+        return PreparedRepo(
+            id=repo.id,
+            name=repo.name,
+            language=repo.language,
+            local_path=repo_dir,
+            actual_commit=actual_commit,
+            file_count=file_count,
+            source_file_count=source_file_count,
+            size_bytes=size_bytes,
+            prepared_at=prepared_at,
+            error=None,
+        )
+
+    except Exception as exc:  # noqa: BLE001
+        _stderr(f"[{repo.id}] ERROR: {exc}")
+        return PreparedRepo(
+            id=repo.id,
+            name=repo.name,
+            language=repo.language,
+            local_path=repo_dir,
+            actual_commit="",
+            file_count=0,
+            source_file_count=0,
+            size_bytes=0,
+            prepared_at=prepared_at,
+            error=str(exc),
+        )
+
+
+def prepare_all(
+    repos: list[RepoSpec],
+    base_dir: Path = DEFAULT_BASE_DIR,
+) -> list[PreparedRepo]:
+    """Prepare every repo in ``repos`` sequentially, collecting all results.
+
+    Failed repos have ``error`` set; preparation continues for the rest.
+    """
+    results: list[PreparedRepo] = []
+    total = len(repos)
+    for idx, repo in enumerate(repos, start=1):
+        _stderr(f"\n[{idx}/{total}] Preparing repo: {repo.id} ({repo.language})")
+        prepared = prepare_repo(repo, base_dir=base_dir)
+        results.append(prepared)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Manifest serialization
+# ---------------------------------------------------------------------------
+
+
+def _prepared_repo_to_dict(pr: PreparedRepo) -> dict[str, Any]:
+    """Convert a PreparedRepo to a JSON-serializable dict."""
+    d = dataclasses.asdict(pr)
+    d["local_path"] = str(pr.local_path)
+    return d
+
+
+def _prepared_repo_from_dict(d: dict[str, Any]) -> PreparedRepo:
+    """Reconstruct a PreparedRepo from a plain dict (e.g. loaded from JSON)."""
+    return PreparedRepo(
+        id=d["id"],
+        name=d["name"],
+        language=d["language"],
+        local_path=Path(d["local_path"]),
+        actual_commit=d["actual_commit"],
+        file_count=int(d["file_count"]),
+        source_file_count=int(d["source_file_count"]),
+        size_bytes=int(d["size_bytes"]),
+        prepared_at=d["prepared_at"],
+        error=d.get("error"),
+    )
+
+
+def save_prepared_manifest(repos: list[PreparedRepo], path: Path) -> None:
+    """Serialize ``repos`` to a JSON file at ``path``.
+
+    Parent directories are created as needed.  The file is written atomically
+    via a temporary sibling so a partial write never corrupts a previous run.
+    """
+    path = path.resolve()
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    payload = [_prepared_repo_to_dict(r) for r in repos]
+    tmp = path.with_suffix(".tmp")
+    try:
+        tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        tmp.replace(path)
+    except Exception:
+        tmp.unlink(missing_ok=True)
+        raise
+
+    _stderr(f"Manifest saved → {path}")
+
+
+def load_prepared_manifest(path: Path) -> list[PreparedRepo]:
+    """Load a list of PreparedRepo objects from a JSON manifest file."""
+    path = path.resolve()
+    if not path.exists():
+        raise FileNotFoundError(f"Manifest not found: {path}")
+
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, list):
+        raise ValueError(f"Expected a JSON array in manifest, got: {type(raw)}")
+
+    return [_prepared_repo_from_dict(entry) for entry in raw]
+
+
+# ---------------------------------------------------------------------------
+# CLI helpers
+# ---------------------------------------------------------------------------
+
+_DEFAULT_MANIFEST = Path("prepared_repos.json")
+
+
+def _fmt_size(size_bytes: int) -> str:
+    """Human-readable file size."""
+    for unit in ("B", "KB", "MB", "GB"):
+        if size_bytes < 1024:
+            return f"{size_bytes:.1f} {unit}"
+        size_bytes //= 1024
+    return f"{size_bytes:.1f} TB"
+
+
+def _cmd_prepare(args: argparse.Namespace) -> int:
+    """Handle ``prepare`` subcommand."""
+    specs = load_repos_config()
+
+    if args.all:
+        to_prepare = specs
+    elif args.repo:
+        by_id = {s.id: s for s in specs}
+        if args.repo not in by_id:
+            _stderr(
+                f"Unknown repo id '{args.repo}'. Available: {', '.join(sorted(by_id))}"
+            )
+            return 1
+        to_prepare = [by_id[args.repo]]
+    else:
+        _stderr("Error: specify --repo <id> or --all")
+        return 1
+
+    base_dir = Path(args.base_dir) if args.base_dir else DEFAULT_BASE_DIR
+    results = prepare_all(to_prepare, base_dir=base_dir)
+
+    manifest_path = Path(args.manifest) if args.manifest else _DEFAULT_MANIFEST
+
+    # Merge with any existing manifest entries for repos we didn't touch
+    existing: dict[str, PreparedRepo] = {}
+    if manifest_path.exists():
+        try:
+            for pr in load_prepared_manifest(manifest_path):
+                existing[pr.id] = pr
+        except Exception as exc:
+            _stderr(f"Warning: could not load existing manifest: {exc}")
+
+    for pr in results:
+        existing[pr.id] = pr
+
+    save_prepared_manifest(list(existing.values()), manifest_path)
+
+    failures = [r for r in results if r.error]
+    if failures:
+        _stderr(f"\n{len(failures)} repo(s) failed:")
+        for r in failures:
+            _stderr(f"  {r.id}: {r.error}")
+        return 2
+
+    return 0
+
+
+def _cmd_status(args: argparse.Namespace) -> int:
+    """Handle ``status`` subcommand — print a table from the manifest."""
+    manifest_path = Path(args.manifest) if args.manifest else _DEFAULT_MANIFEST
+    try:
+        repos = load_prepared_manifest(manifest_path)
+    except FileNotFoundError:
+        _stderr(f"Manifest not found: {manifest_path}. Run 'prepare --all' first.")
+        return 1
+
+    # Column widths
+    col_id = max(len("ID"), max(len(r.id) for r in repos)) + 2
+    col_lang = max(len("Language"), max(len(r.language) for r in repos)) + 2
+    col_files = 8
+    col_src = 10
+    col_size = 10
+    col_commit = 14
+    col_status = 10
+
+    header = (
+        f"{'ID':<{col_id}}"
+        f"{'Language':<{col_lang}}"
+        f"{'Files':>{col_files}}"
+        f"{'SrcFiles':>{col_src}}"
+        f"{'Size':>{col_size}}"
+        f"  {'Commit':<{col_commit}}"
+        f"  {'Status':<{col_status}}"
+    )
+    separator = "-" * len(header)
+
+    print(header)
+    print(separator)
+
+    for r in sorted(repos, key=lambda x: x.id):
+        status = "ERROR" if r.error else "OK"
+        commit_short = r.actual_commit[:12] if r.actual_commit else "—"
+        size_human = _fmt_size(r.size_bytes)
+        row = (
+            f"{r.id:<{col_id}}"
+            f"{r.language:<{col_lang}}"
+            f"{r.file_count:>{col_files}}"
+            f"{r.source_file_count:>{col_src}}"
+            f"{size_human:>{col_size}}"
+            f"  {commit_short:<{col_commit}}"
+            f"  {status:<{col_status}}"
+        )
+        print(row)
+        if r.error:
+            print(f"  {'':>{col_id}}error: {r.error}")
+
+    print(separator)
+    print(f"Total: {len(repos)} repo(s)")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="repo_prep",
+        description="Prepare benchmark repositories for the CodeGraph comparison harness.",
+    )
+    parser.add_argument(
+        "--manifest",
+        default=None,
+        help=f"Path to the JSON manifest file (default: {_DEFAULT_MANIFEST})",
+    )
+
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # ---- prepare ----
+    prep = sub.add_parser("prepare", help="Clone and pin one or all repos.")
+    prep_group = prep.add_mutually_exclusive_group(required=True)
+    prep_group.add_argument("--repo", metavar="ID", help="Prepare a single repo by id.")
+    prep_group.add_argument(
+        "--all", action="store_true", help="Prepare all repos in repos.yaml."
+    )
+    prep.add_argument(
+        "--base-dir",
+        default=None,
+        metavar="DIR",
+        help=f"Base directory for clones (default: {DEFAULT_BASE_DIR})",
+    )
+
+    # ---- status ----
+    sub.add_parser("status", help="Print status table from the prepared manifest.")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "prepare":
+        return _cmd_prepare(args)
+    if args.command == "status":
+        return _cmd_status(args)
+
+    parser.print_help()
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/codegraph_compare/repos.yaml
+++ b/benchmarks/codegraph_compare/repos.yaml
@@ -1,0 +1,49 @@
+repos:
+  - id: vscode
+    name: VS Code
+    language: TypeScript
+    url: https://github.com/microsoft/vscode
+    commit: "PLACEHOLDER_SHA"
+    approx_files: 10000
+
+  - id: excalidraw
+    name: Excalidraw
+    language: TypeScript
+    url: https://github.com/excalidraw/excalidraw
+    commit: "PLACEHOLDER_SHA"
+    approx_files: 800
+
+  - id: django
+    name: Django
+    language: Python
+    url: https://github.com/django/django
+    commit: "PLACEHOLDER_SHA"
+    approx_files: 5000
+
+  - id: tokio
+    name: Tokio
+    language: Rust
+    url: https://github.com/tokio-rs/tokio
+    commit: "PLACEHOLDER_SHA"
+    approx_files: 800
+
+  - id: okhttp
+    name: OkHttp
+    language: Java
+    url: https://github.com/square/okhttp
+    commit: "PLACEHOLDER_SHA"
+    approx_files: 600
+
+  - id: gin
+    name: Gin
+    language: Go
+    url: https://github.com/gin-gonic/gin
+    commit: "PLACEHOLDER_SHA"
+    approx_files: 200
+
+  - id: alamofire
+    name: Alamofire
+    language: Swift
+    url: https://github.com/Alamofire/Alamofire
+    commit: "PLACEHOLDER_SHA"
+    approx_files: 150

--- a/benchmarks/codegraph_compare/run.py
+++ b/benchmarks/codegraph_compare/run.py
@@ -278,6 +278,9 @@ def cmd_run(args: argparse.Namespace) -> int:
         repeat=repeat,
         run_config=run_config,
         results_dir=RESULTS_DIR,
+        timeout_seconds=args.timeout_seconds,
+        model=args.model,
+        agent_backend=args.agent_backend,
         dry_run=getattr(args, "dry_run", False),
     )
 
@@ -392,6 +395,9 @@ def cmd_run_matrix(args: argparse.Namespace) -> int:
                             repeat=repeat,
                             run_config=run_config,
                             results_dir=RESULTS_DIR,
+                            timeout_seconds=args.timeout_seconds,
+                            model=args.model,
+                            agent_backend=args.agent_backend,
                             dry_run=args.dry_run,
                         )
                         status = "DRY_RUN" if record["answer"] == "DRY_RUN" else "ok"
@@ -543,7 +549,24 @@ def _build_parser() -> argparse.ArgumentParser:
         "--dry-run",
         action="store_true",
         dest="dry_run",
-        help="Build prompt and record a stub without calling Claude.",
+        help="Build prompt and record a stub without calling an agent CLI.",
+    )
+    p_run.add_argument(
+        "--agent-backend",
+        choices=["claude", "codex"],
+        default="claude",
+        help="Agent CLI backend to execute the run (default: claude).",
+    )
+    p_run.add_argument(
+        "--model",
+        default=None,
+        help="Model name for the selected agent backend.",
+    )
+    p_run.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=1200,
+        help="Per-run timeout in seconds (default: 1200).",
     )
 
     # ---- run-matrix ----
@@ -575,8 +598,25 @@ def _build_parser() -> argparse.ArgumentParser:
         dest="dry_run",
         help=(
             "Dry-run mode: build prompts and record stubs without calling the "
-            "Claude API."
+            "agent CLI."
         ),
+    )
+    p_matrix.add_argument(
+        "--agent-backend",
+        choices=["claude", "codex"],
+        default="claude",
+        help="Agent CLI backend to execute each run (default: claude).",
+    )
+    p_matrix.add_argument(
+        "--model",
+        default=None,
+        help="Model name for the selected agent backend.",
+    )
+    p_matrix.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=1200,
+        help="Per-run timeout in seconds (default: 1200).",
     )
 
     # ---- status ----

--- a/benchmarks/codegraph_compare/run.py
+++ b/benchmarks/codegraph_compare/run.py
@@ -137,6 +137,19 @@ def _all_questions(questions: dict | list) -> list[dict]:
     return questions if isinstance(questions, list) else questions.get("questions", [])
 
 
+def _questions_for_repo(questions: dict | list, repo_id: str) -> list[dict]:
+    return [q for q in _all_questions(questions) if q.get("repo") == repo_id]
+
+
+def _assert_question_matches_repo(question_entry: dict, repo_id: str) -> None:
+    question_repo = question_entry.get("repo")
+    if question_repo != repo_id:
+        _die(
+            f"Question '{question_entry.get('id')}' belongs to repo "
+            f"'{question_repo}', not '{repo_id}'."
+        )
+
+
 def _repo_local_path(repo_entry: dict) -> Path:
     """Return the local path for a repo: .benchmark-repos/<id>."""
     repo_id: str = repo_entry["id"]
@@ -209,6 +222,7 @@ def cmd_run(args: argparse.Namespace) -> int:
     repo_entry = _get_repo(repos_data, args.repo)
     arm_entry = _get_arm(arms_data, args.arm)
     question_entry = _get_question(questions_data, args.question)
+    _assert_question_matches_repo(question_entry, args.repo)
 
     repo_path = _repo_local_path(repo_entry)
     arm_id: str = arm_entry["id"]
@@ -231,13 +245,16 @@ def cmd_run(args: argparse.Namespace) -> int:
         f"[prepare] arm={arm_id}  repo={args.repo}  cold={cold}",
         file=sys.stderr,
     )
-    index_stats = adapter.prepare_index(repo_path, cold=cold)
-    print(
-        f"[prepare] done  build_s={index_stats.build_seconds:.2f}"
-        f"  files={index_stats.file_count}"
-        f"  size={index_stats.index_size_bytes} bytes",
-        file=sys.stderr,
-    )
+    if args.dry_run:
+        print("[prepare] skipped in dry-run mode", file=sys.stderr)
+    else:
+        index_stats = adapter.prepare_index(repo_path, cold=cold)
+        print(
+            f"[prepare] done  build_s={index_stats.build_seconds:.2f}"
+            f"  files={index_stats.file_count}"
+            f"  size={index_stats.index_size_bytes} bytes",
+            file=sys.stderr,
+        )
 
     run_config = adapter.build_run_config(repo_path, question_prompt)
 
@@ -261,6 +278,7 @@ def cmd_run(args: argparse.Namespace) -> int:
         repeat=repeat,
         run_config=run_config,
         results_dir=RESULTS_DIR,
+        dry_run=getattr(args, "dry_run", False),
     )
 
     # Print result summary
@@ -298,7 +316,6 @@ def cmd_run_matrix(args: argparse.Namespace) -> int:
     else:
         arm_entries = [_get_arm(arms_data, aid) for aid in args.arms.split(",")]
 
-    question_entries = _all_questions(questions_data)
     repeats: int = args.repeats if hasattr(args, "repeats") and args.repeats else 1
 
     # Lazy imports
@@ -310,13 +327,26 @@ def cmd_run_matrix(args: argparse.Namespace) -> int:
 
     RESULTS_DIR.mkdir(parents=True, exist_ok=True)
 
-    total = len(repo_entries) * len(arm_entries) * len(question_entries) * repeats
+    question_entries_by_repo = {
+        repo_entry["id"]: _questions_for_repo(questions_data, repo_entry["id"])
+        for repo_entry in repo_entries
+    }
+    total = (
+        sum(len(items) for items in question_entries_by_repo.values())
+        * len(arm_entries)
+        * repeats
+    )
     idx = 0
     failed = 0
 
     for repo_entry in repo_entries:
         repo_id: str = repo_entry["id"]
         repo_path = _repo_local_path(repo_entry)
+        question_entries = question_entries_by_repo[repo_id]
+
+        if not question_entries:
+            print(f"[skip] repo={repo_id} has no questions", file=sys.stderr)
+            continue
 
         for arm_entry in arm_entries:
             arm_id: str = arm_entry["id"]
@@ -324,7 +354,13 @@ def cmd_run_matrix(args: argparse.Namespace) -> int:
             cold = index_mode == "cold"
 
             adapter = get_adapter(arm_id)
-            adapter.prepare_index(repo_path, cold=cold)
+            if args.dry_run:
+                print(
+                    f"[prepare] skipped dry-run  arm={arm_id}  repo={repo_id}",
+                    file=sys.stderr,
+                )
+            else:
+                adapter.prepare_index(repo_path, cold=cold)
             run_config_cache: dict = {}
 
             for question_entry in question_entries:
@@ -356,6 +392,7 @@ def cmd_run_matrix(args: argparse.Namespace) -> int:
                             repeat=repeat,
                             run_config=run_config,
                             results_dir=RESULTS_DIR,
+                            dry_run=args.dry_run,
                         )
                         status = "DRY_RUN" if record["answer"] == "DRY_RUN" else "ok"
                         print(
@@ -426,7 +463,7 @@ def cmd_status(_args: argparse.Namespace) -> int:
     # By arm
     by_arm: dict[str, int] = {}
     for r in records:
-        arm = r.get("arm_id", "unknown")
+        arm = r.get("arm", "unknown")
         by_arm[arm] = by_arm.get(arm, 0) + 1
     print("  By arm:")
     for arm, count in sorted(by_arm.items()):
@@ -435,7 +472,7 @@ def cmd_status(_args: argparse.Namespace) -> int:
     # By repo
     by_repo: dict[str, int] = {}
     for r in records:
-        repo = Path(r.get("repo_path", "unknown")).name
+        repo = r.get("repo", "unknown")
         by_repo[repo] = by_repo.get(repo, 0) + 1
     print("  By repo:")
     for repo, count in sorted(by_repo.items()):
@@ -502,6 +539,12 @@ def _build_parser() -> argparse.ArgumentParser:
         default=0,
         help="Zero-based repeat index (default: 0).",
     )
+    p_run.add_argument(
+        "--dry-run",
+        action="store_true",
+        dest="dry_run",
+        help="Build prompt and record a stub without calling Claude.",
+    )
 
     # ---- run-matrix ----
     p_matrix = sub.add_parser(
@@ -532,8 +575,7 @@ def _build_parser() -> argparse.ArgumentParser:
         dest="dry_run",
         help=(
             "Dry-run mode: build prompts and record stubs without calling the "
-            "Claude API. (Currently the default behaviour — flag is a no-op until "
-            "real API calls are wired up.)"
+            "Claude API."
         ),
     )
 

--- a/benchmarks/codegraph_compare/run.py
+++ b/benchmarks/codegraph_compare/run.py
@@ -1,0 +1,546 @@
+"""Top-level CLI for the CodeGraph comparison benchmark harness.
+
+Usage
+-----
+  python benchmarks/codegraph_compare/run.py --help
+
+Subcommands
+-----------
+  prepare --repo <id>                 Prepare one repo by ID
+  prepare --all                       Prepare all repos listed in repos.yaml
+  run --repo <id> --question <id>     Run one (repo, question, arm, repeat) trial
+       --arm <arm-id> --repeat <n>
+  run-matrix --repos all              Run all combinations
+             --arms native-only,tsa-warm
+             --repeats 4
+             [--dry-run]
+  status                              Show prepared repos + last run stats
+
+Config files are resolved relative to this file:
+  repos.yaml        — repository registry
+  arms.yaml         — arm definitions
+  questions.yaml    — question registry
+  results/          — output directory
+  results/prepared_repos.json  — manifest written by prepare
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import NoReturn
+
+# ---------------------------------------------------------------------------
+# Path constants  (all relative to this file so the harness is portable)
+# ---------------------------------------------------------------------------
+
+BENCHMARKS_DIR = Path(__file__).parent
+REPOS_YAML = BENCHMARKS_DIR / "repos.yaml"
+ARMS_YAML = BENCHMARKS_DIR / "arms.yaml"
+QUESTIONS_YAML = BENCHMARKS_DIR / "questions.yaml"
+RESULTS_DIR = BENCHMARKS_DIR / "results"
+PREPARED_MANIFEST = RESULTS_DIR / "prepared_repos.json"
+
+
+# ---------------------------------------------------------------------------
+# YAML helpers  (lazy import keeps --help snappy without pydantic/PyYAML)
+# ---------------------------------------------------------------------------
+
+
+def _load_yaml(path: Path) -> dict | list:
+    """Load a YAML file and return the parsed content.
+
+    Raises SystemExit with a clear message on missing or malformed files so
+    all YAML-reading code paths share a single error surface.
+    """
+    if not path.exists():
+        if path == QUESTIONS_YAML:
+            _die(
+                "questions.yaml not found. Run question setup first.\n"
+                f"Expected location: {path}"
+            )
+        _die(f"Config file not found: {path}")
+
+    try:
+        import yaml  # noqa: PLC0415 — lazy import intentional
+    except ImportError:
+        _die(
+            "PyYAML is not installed. Run:  pip install pyyaml\n"
+            "Or with uv:                    uv pip install pyyaml"
+        )
+
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            return yaml.safe_load(fh) or {}
+    except Exception as exc:  # noqa: BLE001
+        _die(f"Failed to parse {path}: {exc}")
+
+
+def _die(message: str, code: int = 1) -> NoReturn:
+    """Print *message* to stderr and exit with *code*."""
+    print(f"ERROR: {message}", file=sys.stderr)
+    sys.exit(code)
+
+
+# ---------------------------------------------------------------------------
+# Data accessors
+# ---------------------------------------------------------------------------
+
+
+def _get_repo(repos: dict | list, repo_id: str) -> dict:
+    """Return the repo entry matching *repo_id* from the loaded repos config."""
+    items: list[dict] = repos if isinstance(repos, list) else repos.get("repos", [])
+    for item in items:
+        if item.get("id") == repo_id:
+            return item
+    known = [r.get("id", "?") for r in items]
+    _die(f"Repo '{repo_id}' not found in repos.yaml. Known: {', '.join(known)}")
+
+
+def _get_arm(arms: dict | list, arm_id: str) -> dict:
+    """Return the arm entry matching *arm_id* from the loaded arms config."""
+    items: list[dict] = arms if isinstance(arms, list) else arms.get("arms", [])
+    for item in items:
+        if item.get("id") == arm_id:
+            return item
+    known = [a.get("id", "?") for a in items]
+    _die(f"Arm '{arm_id}' not found in arms.yaml. Known: {', '.join(known)}")
+
+
+def _get_question(questions: dict | list, question_id: str) -> dict:
+    """Return the question entry matching *question_id* from loaded questions config."""
+    items: list[dict] = (
+        questions if isinstance(questions, list) else questions.get("questions", [])
+    )
+    for item in items:
+        if item.get("id") == question_id:
+            return item
+    known = [q.get("id", "?") for q in items]
+    _die(
+        f"Question '{question_id}' not found in questions.yaml. "
+        f"Known: {', '.join(known)}"
+    )
+
+
+def _all_repos(repos: dict | list) -> list[dict]:
+    return repos if isinstance(repos, list) else repos.get("repos", [])
+
+
+def _all_arms(arms: dict | list) -> list[dict]:
+    return arms if isinstance(arms, list) else arms.get("arms", [])
+
+
+def _all_questions(questions: dict | list) -> list[dict]:
+    return questions if isinstance(questions, list) else questions.get("questions", [])
+
+
+def _repo_local_path(repo_entry: dict) -> Path:
+    """Return the local path for a repo: .benchmark-repos/<id>."""
+    repo_id: str = repo_entry["id"]
+    return (BENCHMARKS_DIR / ".." / ".." / ".benchmark-repos" / repo_id).resolve()
+
+
+# ---------------------------------------------------------------------------
+# Sub-command implementations
+# ---------------------------------------------------------------------------
+
+
+def cmd_prepare(args: argparse.Namespace) -> int:
+    """Prepare one or all repos — delegates to repo_prep.prepare_repo / prepare_all."""
+    try:
+        from repo_prep import prepare_all, prepare_repo  # noqa: PLC0415
+    except ImportError:
+        _die(
+            "repo_prep module not found. "
+            "Expected at benchmarks/codegraph_compare/repo_prep.py"
+        )
+
+    if args.all:
+        repos_data = _load_yaml(REPOS_YAML)
+        items = _all_repos(repos_data)
+        print(f"Preparing {len(items)} repo(s)...", file=sys.stderr)
+        prepare_all(items, manifest_path=PREPARED_MANIFEST)
+        print(f"Done. Manifest written to {PREPARED_MANIFEST}", file=sys.stderr)
+        return 0
+
+    if not args.repo:
+        _die("Specify --repo <id> or --all")
+
+    repos_data = _load_yaml(REPOS_YAML)
+    repo_entry = _get_repo(repos_data, args.repo)
+    repo_path = _repo_local_path(repo_entry)
+    print(f"Preparing repo '{args.repo}' at {repo_path} ...", file=sys.stderr)
+    prepare_repo(repo_entry, manifest_path=PREPARED_MANIFEST)
+    print("Done.", file=sys.stderr)
+    return 0
+
+
+def cmd_run(args: argparse.Namespace) -> int:
+    """Run a single (repo, question, arm, repeat) trial."""
+    repos_data = _load_yaml(REPOS_YAML)
+    arms_data = _load_yaml(ARMS_YAML)
+    questions_data = _load_yaml(QUESTIONS_YAML)
+
+    repo_entry = _get_repo(repos_data, args.repo)
+    arm_entry = _get_arm(arms_data, args.arm)
+    question_entry = _get_question(questions_data, args.question)
+
+    repo_path = _repo_local_path(repo_entry)
+    arm_id: str = arm_entry["id"]
+    question_id: str = question_entry["id"]
+    question_prompt: str = question_entry["prompt"]
+    repeat: int = args.repeat
+
+    # Lazy adapter import
+    try:
+        from adapters import get_adapter  # noqa: PLC0415
+    except ImportError:
+        _die("Could not import adapters package. Check PYTHONPATH.")
+
+    adapter = get_adapter(arm_id)
+
+    # Prepare index (warm by default unless index_mode says cold)
+    index_mode: str = arm_entry.get("index_mode", "warm")
+    cold = index_mode == "cold"
+    print(
+        f"[prepare] arm={arm_id}  repo={args.repo}  cold={cold}",
+        file=sys.stderr,
+    )
+    index_stats = adapter.prepare_index(repo_path, cold=cold)
+    print(
+        f"[prepare] done  build_s={index_stats.build_seconds:.2f}"
+        f"  files={index_stats.file_count}"
+        f"  size={index_stats.index_size_bytes} bytes",
+        file=sys.stderr,
+    )
+
+    run_config = adapter.build_run_config(repo_path, question_prompt)
+
+    # Lazy claude_runner import
+    try:
+        from adapters.claude_runner import run_one  # noqa: PLC0415
+    except ImportError:
+        _die("Could not import adapters.claude_runner.")
+
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+
+    print(
+        f"[run] question={question_id}  arm={arm_id}  repeat={repeat:02d}",
+        file=sys.stderr,
+    )
+    record = run_one(
+        question_id=question_id,
+        question_prompt=question_prompt,
+        arm_id=arm_id,
+        repo_path=repo_path,
+        repeat=repeat,
+        run_config=run_config,
+        results_dir=RESULTS_DIR,
+    )
+
+    # Print result summary
+    print(
+        f"run_id:          {record['run_id']}\n"
+        f"answer:          {record['answer']}\n"
+        f"tokens_in:       {record['tokens_in']}\n"
+        f"tokens_out:      {record['tokens_out']}\n"
+        f"tool_calls:      {record['tool_calls']}\n"
+        f"elapsed_seconds: {record['elapsed_seconds']}\n"
+        f"error:           {record['error']}\n"
+        f"prompt_file:     {record['prompt_file']}"
+    )
+    return 0
+
+
+def cmd_run_matrix(args: argparse.Namespace) -> int:
+    """Run all combinations of repos × arms × questions × repeats."""
+    repos_data = _load_yaml(REPOS_YAML)
+    arms_data = _load_yaml(ARMS_YAML)
+    questions_data = _load_yaml(QUESTIONS_YAML)
+
+    # Resolve repos
+    if args.repos in ("all", None):
+        repo_entries = _all_repos(repos_data)
+    else:
+        repo_entries = [_get_repo(repos_data, rid) for rid in args.repos.split(",")]
+
+    # Resolve arms
+    if not args.arms or args.arms == "all":
+        arm_entries = _all_arms(arms_data)
+    else:
+        arm_entries = [_get_arm(arms_data, aid) for aid in args.arms.split(",")]
+
+    question_entries = _all_questions(questions_data)
+    repeats: int = args.repeats if hasattr(args, "repeats") and args.repeats else 1
+
+    # Lazy imports
+    try:
+        from adapters import get_adapter  # noqa: PLC0415
+        from adapters.claude_runner import run_one  # noqa: PLC0415
+    except ImportError:
+        _die("Could not import adapters or adapters.claude_runner.")
+
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+
+    total = len(repo_entries) * len(arm_entries) * len(question_entries) * repeats
+    idx = 0
+    failed = 0
+
+    for repo_entry in repo_entries:
+        repo_id: str = repo_entry["id"]
+        repo_path = _repo_local_path(repo_entry)
+
+        for arm_entry in arm_entries:
+            arm_id: str = arm_entry["id"]
+            index_mode: str = arm_entry.get("index_mode", "warm")
+            cold = index_mode == "cold"
+
+            adapter = get_adapter(arm_id)
+            adapter.prepare_index(repo_path, cold=cold)
+            run_config_cache: dict = {}
+
+            for question_entry in question_entries:
+                question_id: str = question_entry["id"]
+                question_prompt: str = question_entry["prompt"]
+
+                if question_id not in run_config_cache:
+                    run_config_cache[question_id] = adapter.build_run_config(
+                        repo_path, question_prompt
+                    )
+                run_config = run_config_cache[question_id]
+
+                for repeat in range(repeats):
+                    idx += 1
+                    label = (
+                        f"[{idx}/{total}] repo={repo_id}"
+                        f"  arm={arm_id}"
+                        f"  q={question_id}"
+                        f"  r={repeat:02d}"
+                    )
+                    print(label, file=sys.stderr, flush=True)
+
+                    try:
+                        record = run_one(
+                            question_id=question_id,
+                            question_prompt=question_prompt,
+                            arm_id=arm_id,
+                            repo_path=repo_path,
+                            repeat=repeat,
+                            run_config=run_config,
+                            results_dir=RESULTS_DIR,
+                        )
+                        status = "DRY_RUN" if record["answer"] == "DRY_RUN" else "ok"
+                        print(
+                            f"  -> {status}  elapsed={record['elapsed_seconds']}s",
+                            file=sys.stderr,
+                        )
+                    except Exception as exc:  # noqa: BLE001
+                        failed += 1
+                        print(f"  -> ERROR: {exc}", file=sys.stderr)
+
+    print(
+        f"\nMatrix complete: {idx} trials, {failed} errors.",
+        file=sys.stderr,
+    )
+    print(f"Results: {RESULTS_DIR / 'runs.jsonl'}", file=sys.stderr)
+    return 0 if failed == 0 else 1
+
+
+def cmd_status(_args: argparse.Namespace) -> int:
+    """Print summary of prepared repos and run statistics."""
+    # Prepared repos manifest
+    print("=== Prepared Repos ===")
+    if PREPARED_MANIFEST.exists():
+        try:
+            manifest = json.loads(PREPARED_MANIFEST.read_text(encoding="utf-8"))
+            repos_list = (
+                manifest if isinstance(manifest, list) else manifest.get("repos", [])
+            )
+            if repos_list:
+                for entry in repos_list:
+                    print(
+                        f"  {entry.get('id', '?'):20s}  path={entry.get('path', '?')}"
+                    )
+            else:
+                print("  (no repos recorded)")
+        except (json.JSONDecodeError, OSError) as exc:
+            print(f"  (could not read manifest: {exc})")
+    else:
+        print(f"  (manifest not found at {PREPARED_MANIFEST})")
+
+    # Run stats from runs.jsonl
+    runs_jsonl = RESULTS_DIR / "runs.jsonl"
+    print("\n=== Run Statistics ===")
+    if not runs_jsonl.exists():
+        print("  (no runs.jsonl found — no runs recorded yet)")
+        return 0
+
+    records: list[dict] = []
+    try:
+        with runs_jsonl.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if line:
+                    try:
+                        records.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        pass
+    except OSError as exc:
+        print(f"  (could not read runs.jsonl: {exc})")
+        return 1
+
+    if not records:
+        print("  (runs.jsonl is empty)")
+        return 0
+
+    print(f"  Total runs:    {len(records)}")
+
+    # By arm
+    by_arm: dict[str, int] = {}
+    for r in records:
+        arm = r.get("arm_id", "unknown")
+        by_arm[arm] = by_arm.get(arm, 0) + 1
+    print("  By arm:")
+    for arm, count in sorted(by_arm.items()):
+        print(f"    {arm:30s} {count}")
+
+    # By repo
+    by_repo: dict[str, int] = {}
+    for r in records:
+        repo = Path(r.get("repo_path", "unknown")).name
+        by_repo[repo] = by_repo.get(repo, 0) + 1
+    print("  By repo:")
+    for repo, count in sorted(by_repo.items()):
+        print(f"    {repo:30s} {count}")
+
+    # Last run time
+    last_ended = max(
+        (r.get("ended_at", "") for r in records if r.get("ended_at")),
+        default=None,
+    )
+    if last_ended:
+        print(f"  Last run at:   {last_ended}")
+
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Argument parser
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python run.py",
+        description="CodeGraph comparison benchmark harness.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  python run.py prepare --repo tsa-self\n"
+            "  python run.py prepare --all\n"
+            "  python run.py run --repo tsa-self --question q01 "
+            "--arm native-only --repeat 0\n"
+            "  python run.py run-matrix --repos all "
+            "--arms native-only,tsa-warm --repeats 3\n"
+            "  python run.py run-matrix --repos all --arms all "
+            "--repeats 1 --dry-run\n"
+            "  python run.py status\n"
+        ),
+    )
+    sub = parser.add_subparsers(dest="command", metavar="<command>")
+    sub.required = True
+
+    # ---- prepare ----
+    p_prepare = sub.add_parser("prepare", help="Prepare one or all repos.")
+    p_prepare.add_argument(
+        "--repo",
+        default="",
+        help="Repository ID as listed in repos.yaml.",
+    )
+    p_prepare.add_argument(
+        "--all",
+        action="store_true",
+        help="Prepare every repo in repos.yaml.",
+    )
+
+    # ---- run ----
+    p_run = sub.add_parser("run", help="Run a single benchmark trial.")
+    p_run.add_argument("--repo", required=True, help="Repository ID.")
+    p_run.add_argument("--question", required=True, help="Question ID.")
+    p_run.add_argument("--arm", required=True, help="Arm ID.")
+    p_run.add_argument(
+        "--repeat",
+        type=int,
+        default=0,
+        help="Zero-based repeat index (default: 0).",
+    )
+
+    # ---- run-matrix ----
+    p_matrix = sub.add_parser(
+        "run-matrix",
+        help="Run all combinations of repos × arms × questions × repeats.",
+    )
+    p_matrix.add_argument(
+        "--repos",
+        default="all",
+        help="Comma-separated repo IDs, or 'all' (default).",
+    )
+    p_matrix.add_argument(
+        "--arms",
+        default="all",
+        help=(
+            "Comma-separated arm IDs (e.g. 'native-only,tsa-warm'), or 'all' (default)."
+        ),
+    )
+    p_matrix.add_argument(
+        "--repeats",
+        type=int,
+        default=1,
+        help="Number of repeat runs per (question, arm, repo) triple (default: 1).",
+    )
+    p_matrix.add_argument(
+        "--dry-run",
+        action="store_true",
+        dest="dry_run",
+        help=(
+            "Dry-run mode: build prompts and record stubs without calling the "
+            "Claude API. (Currently the default behaviour — flag is a no-op until "
+            "real API calls are wired up.)"
+        ),
+    )
+
+    # ---- status ----
+    sub.add_parser("status", help="Show prepared repos and last run statistics.")
+
+    return parser
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse arguments and dispatch to the appropriate sub-command handler."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    dispatch: dict[str, Callable[[argparse.Namespace], int]] = {
+        "prepare": cmd_prepare,
+        "run": cmd_run,
+        "run-matrix": cmd_run_matrix,
+        "status": cmd_status,
+    }
+
+    handler = dispatch.get(args.command)
+    if handler is None:
+        _die(f"Unknown command: {args.command!r}")
+
+    return handler(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/codegraph_compare/run.py
+++ b/benchmarks/codegraph_compare/run.py
@@ -149,32 +149,54 @@ def _repo_local_path(repo_entry: dict) -> Path:
 
 
 def cmd_prepare(args: argparse.Namespace) -> int:
-    """Prepare one or all repos — delegates to repo_prep.prepare_repo / prepare_all."""
+    """Prepare one or all repos — delegates to repo_prep."""
     try:
-        from repo_prep import prepare_all, prepare_repo  # noqa: PLC0415
+        from repo_prep import (  # noqa: PLC0415
+            load_repos_config,
+            prepare_all,
+            prepare_repo,
+            save_prepared_manifest,
+        )
     except ImportError:
         _die(
-            "repo_prep module not found. "
-            "Expected at benchmarks/codegraph_compare/repo_prep.py"
+            "repo_prep module not found. Expected at benchmarks/codegraph_compare/repo_prep.py"
         )
 
+    base_dir = (BENCHMARKS_DIR / ".." / ".." / ".benchmark-repos").resolve()
+
     if args.all:
-        repos_data = _load_yaml(REPOS_YAML)
-        items = _all_repos(repos_data)
-        print(f"Preparing {len(items)} repo(s)...", file=sys.stderr)
-        prepare_all(items, manifest_path=PREPARED_MANIFEST)
+        repos = load_repos_config(REPOS_YAML)
+        print(f"Preparing {len(repos)} repo(s)...", file=sys.stderr)
+        prepared = prepare_all(repos, base_dir=base_dir)
+        RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+        save_prepared_manifest(prepared, PREPARED_MANIFEST)
         print(f"Done. Manifest written to {PREPARED_MANIFEST}", file=sys.stderr)
         return 0
 
     if not args.repo:
         _die("Specify --repo <id> or --all")
 
-    repos_data = _load_yaml(REPOS_YAML)
-    repo_entry = _get_repo(repos_data, args.repo)
-    repo_path = _repo_local_path(repo_entry)
+    repos = load_repos_config(REPOS_YAML)
+    matches = [r for r in repos if r.id == args.repo]
+    if not matches:
+        _die(f"Repo '{args.repo}' not found in repos.yaml")
+    repo_spec = matches[0]
+    repo_path = base_dir / repo_spec.id
     print(f"Preparing repo '{args.repo}' at {repo_path} ...", file=sys.stderr)
-    prepare_repo(repo_entry, manifest_path=PREPARED_MANIFEST)
-    print("Done.", file=sys.stderr)
+    prepared = prepare_repo(repo_spec, base_dir=base_dir)
+    if prepared.error:
+        print(f"WARNING: {prepared.error}", file=sys.stderr)
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    # Merge into existing manifest
+    from repo_prep import PreparedRepo, load_prepared_manifest  # noqa: PLC0415
+
+    existing: dict[str, PreparedRepo] = {}
+    if PREPARED_MANIFEST.exists():
+        for pr in load_prepared_manifest(PREPARED_MANIFEST):
+            existing[pr.id] = pr
+    existing[prepared.id] = prepared
+    save_prepared_manifest(list(existing.values()), PREPARED_MANIFEST)
+    print(f"Done. commit={prepared.actual_commit}", file=sys.stderr)
     return 0
 
 
@@ -242,15 +264,18 @@ def cmd_run(args: argparse.Namespace) -> int:
     )
 
     # Print result summary
+    answer_snippet = (record["answer"] or "")[:120].replace("\n", " ")
     print(
         f"run_id:          {record['run_id']}\n"
-        f"answer:          {record['answer']}\n"
-        f"tokens_in:       {record['tokens_in']}\n"
-        f"tokens_out:      {record['tokens_out']}\n"
-        f"tool_calls:      {record['tool_calls']}\n"
+        f"answer:          {answer_snippet}...\n"
+        f"input_tokens:    {record['input_tokens']}\n"
+        f"output_tokens:   {record['output_tokens']}\n"
+        f"total_tokens:    {record['total_tokens']}\n"
+        f"cost_usd:        ${record['estimated_cost_usd']:.4f}\n"
+        f"tool_calls:      {record['tool_calls']} "
+        f"(reads={record['file_reads']} search={record['search_calls']} idx={record['index_queries']})\n"
         f"elapsed_seconds: {record['elapsed_seconds']}\n"
-        f"error:           {record['error']}\n"
-        f"prompt_file:     {record['prompt_file']}"
+        f"error:           {record['error']}"
     )
     return 0
 

--- a/benchmarks/codegraph_compare/schemas.py
+++ b/benchmarks/codegraph_compare/schemas.py
@@ -1,0 +1,126 @@
+"""
+Pydantic v2 dataclasses for the codegraph-comparison benchmark harness.
+
+Run records capture raw execution metrics; eval records capture LLM-judge scores.
+Repo, question, and arm specs define the benchmark configuration.
+"""
+
+from __future__ import annotations
+
+from pydantic import ConfigDict
+from pydantic.dataclasses import dataclass
+
+
+@dataclass(config=ConfigDict(extra="forbid"))
+class RunRecord:
+    """One execution of a question under one arm at one repeat index."""
+
+    run_id: str  # format: "{question_id}__{arm}__{repeat:02d}"
+    repo: str
+    question_id: str
+    arm: str
+    repeat: int
+    started_at: str  # ISO 8601
+    ended_at: str  # ISO 8601
+    elapsed_seconds: float
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+    estimated_cost_usd: float
+    tool_calls: int
+    file_reads: int
+    search_calls: int
+    index_queries: int
+    answer: str
+    citations: list[str]
+    transcript_path: str
+    error: str | None = None
+
+    @classmethod
+    def make_id(cls, question_id: str, arm: str, repeat: int) -> str:
+        """Return the canonical run_id string."""
+        return f"{question_id}__{arm}__{repeat:02d}"
+
+
+@dataclass(config=ConfigDict(extra="forbid"))
+class EvalRecord:
+    """LLM-judge scores for one RunRecord."""
+
+    run_id: str
+    correctness: int  # 1-5
+    completeness: int  # 1-5
+    citation_quality: int  # 1-5
+    hallucination_risk: int  # 1-5  (5 = high risk, bad)
+    overall: float
+    missing_key_points: list[str]
+    bad_citations: list[str]
+    evaluator_model: str
+    evaluated_at: str  # ISO 8601
+
+
+@dataclass(config=ConfigDict(extra="forbid"))
+class RepoSpec:
+    """A pinned repository entry from repos.yaml."""
+
+    id: str
+    name: str
+    language: str
+    url: str
+    commit: str  # pinned SHA
+    approx_files: int | None = None
+
+
+@dataclass(config=ConfigDict(extra="forbid"))
+class QuestionSpec:
+    """One benchmark question bound to a specific repo."""
+
+    id: str
+    repo: str
+    category: str  # entrypoint-tracing | call-chain | module-boundary | change-impact | subsystem-overview
+    prompt: str
+    expected_key_points: list[str]
+    must_cite_files: bool = True
+    anti_hallucination_checks: list[str] | None = None
+
+    def __post_init__(self) -> None:
+        valid_categories = {
+            "entrypoint-tracing",
+            "call-chain",
+            "module-boundary",
+            "change-impact",
+            "subsystem-overview",
+        }
+        if self.category not in valid_categories:
+            raise ValueError(
+                f"category {self.category!r} not in {sorted(valid_categories)}"
+            )
+        if self.anti_hallucination_checks is None:
+            object.__setattr__(self, "anti_hallucination_checks", [])
+
+
+@dataclass(config=ConfigDict(extra="forbid"))
+class ArmSpec:
+    """One treatment arm (tool combination) in the benchmark."""
+
+    id: str
+    adapter: str  # native | codegraph | tree_sitter_analyzer
+    index_mode: str  # none | warm | cold
+
+
+@dataclass(config=ConfigDict(extra="forbid"))
+class IndexStats:
+    """Timing and size stats from a single index build."""
+
+    build_seconds: float
+    index_size_bytes: int
+    file_count: int
+
+
+@dataclass(config=ConfigDict(extra="forbid"))
+class ToolMetrics:
+    """Tool-call breakdown extracted from a single run transcript."""
+
+    tool_calls: int
+    file_reads: int
+    search_calls: int
+    index_queries: int

--- a/benchmarks/codegraph_compare/schemas.py
+++ b/benchmarks/codegraph_compare/schemas.py
@@ -15,7 +15,7 @@ from pydantic.dataclasses import dataclass
 class RunRecord:
     """One execution of a question under one arm at one repeat index."""
 
-    run_id: str  # format: "{question_id}__{arm}__{repeat:02d}"
+    run_id: str  # format: "{question_id}__{arm}__{agent_backend}__{repeat:02d}"
     repo: str
     question_id: str
     arm: str
@@ -35,11 +35,17 @@ class RunRecord:
     citations: list[str]
     transcript_path: str
     error: str | None = None
+    agent_backend: str = "claude"
+    model: str = ""
+    cached_input_tokens: int = 0
+    reasoning_output_tokens: int = 0
 
     @classmethod
-    def make_id(cls, question_id: str, arm: str, repeat: int) -> str:
+    def make_id(
+        cls, question_id: str, arm: str, repeat: int, agent_backend: str = "claude"
+    ) -> str:
         """Return the canonical run_id string."""
-        return f"{question_id}__{arm}__{repeat:02d}"
+        return f"{question_id}__{arm}__{agent_backend}__{repeat:02d}"
 
 
 @dataclass(config=ConfigDict(extra="forbid"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ dependencies = [
     "numpy>=2.2.6",
     "pyyaml>=6.0",
     "pathspec>=0.12.1",
+    "anthropic>=0.104.1",
 ]
 
 # Add C# to optional dependencies

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,25 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.104.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/c7/7a655b948916f777354648ce979f68b94d5b8dbdb5f61fed1f37fad9378c/anthropic-0.104.1.tar.gz", hash = "sha256:17362b6c45f527afcc9b0fdf62011ffd359726ab2ebcb1978ea0cc41bd8d8d40", size = 850081, upload-time = "2026-05-22T15:36:57.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/12/d9ab42790494d7c428391a46cd28492395566a6a8ccb138d681978594455/anthropic-0.104.1-py3-none-any.whl", hash = "sha256:35c8cb456f5a4405aafe1f10f03f6fcc54fa51fa8ec01d655cc4b437d120e9b7", size = 832996, upload-time = "2026-05-22T15:36:59.519Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -577,6 +596,24 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
 name = "docutils"
 version = "0.22.2"
 source = { registry = "https://pypi.org/simple" }
@@ -822,6 +859,109 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/b5/55f06bb281d92fb3cc86d14e1def2bd908bb77693183e7cb1f5a3c388b0c/jiter-0.15.0.tar.gz", hash = "sha256:4251acc80e2b7c9b7b8823456ea0fceeb0734dac2df7636d3c711b38476b5a76", size = 166640, upload-time = "2026-05-19T10:09:48.361Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/da/76a2c7e510ba15fe323d9509c223ab272da79ea59f54488f4a78da6426db/jiter-0.15.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:edebcf7d1f601199084bb6e844d7dc67e03e04f6ac786b0332d616635c4ff7a4", size = 310849, upload-time = "2026-05-19T10:06:51.944Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/8e/827be942883a4dc0862c48626ff41af3320b1902d136a0bf4b9041f2c567/jiter-0.15.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9f924585cdacf631cd382b657966847bb537bf9ed0a6f9b991da5f05a631480f", size = 314991, upload-time = "2026-05-19T10:06:53.522Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/38/be2832be361ba1b9517c76f46d30b64e985be1dd43c974f4c3a4b1844436/jiter-0.15.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:abbf258599526ad0326fe51e252e24f2bd6f24f1852681b4b78feda3808f1d18", size = 340843, upload-time = "2026-05-19T10:06:55.071Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d8/90f01fb83c0c7ba509303ec93e32a308fbfa167d264860b01c0fd0dbbd06/jiter-0.15.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7c468136b8bd6bb18c8786e4236a1fa27362f24cb23450ba0cb204ab379b8e6f", size = 365116, upload-time = "2026-05-19T10:06:56.893Z" },
+    { url = "https://files.pythonhosted.org/packages/91/38/94593d34f8c67a0b6f6cbc027f016ffa9780b3a858a7a86f6fd7a15bcc1e/jiter-0.15.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:05906b93d72f03339e6bb7cf8dc10ebda64a0266126eed6beba79e20abcf5fd4", size = 457970, upload-time = "2026-05-19T10:06:58.707Z" },
+    { url = "https://files.pythonhosted.org/packages/df/04/d79962dd49d00c97e2a9b4cacea1947904d02135936960351f9a96d4c1a6/jiter-0.15.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:30ce785d2adb8e32c3f7741442370a74834ec4c01f3c48f0750227a0b4ef27d6", size = 375744, upload-time = "2026-05-19T10:07:00.471Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/2e/5d37abe2be0e819c21e2338bebd410e481763ce526a9138c8c3652fa0123/jiter-0.15.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2fd73e3da91a0a722d67165e849ce2cdc10de0e0d48738c142be8c6c5f310f4c", size = 349609, upload-time = "2026-05-19T10:07:01.829Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/90/98768ad2ed90c1fda15d64157de2dfbf73c1c074d4b1bfaca915480bc7cf/jiter-0.15.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:ceb8fc27d38793f9c97149be8302720c5b22e5c195a37bf2c45dc36c4600a512", size = 354366, upload-time = "2026-05-19T10:07:03.587Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/c4/fbfb806209f1fe4b7dccdfb07bc62bb044300734a945b06fd64db446ef6a/jiter-0.15.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d726e3ceeb337191324b49de298142f27c3ad10886341555d1d5315b5f252c6a", size = 393519, upload-time = "2026-05-19T10:07:05.08Z" },
+    { url = "https://files.pythonhosted.org/packages/37/1c/b9c257cd70cb453b6d10f3ebf0402cdb11669ab455389096f09839670290/jiter-0.15.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:2c8aea7781d2a372227871de4e1a1332aa96f5a89fd76c5e835dafdbad102887", size = 519952, upload-time = "2026-05-19T10:07:06.589Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/1a/aa85027db7ab15829c12feebbc33b404f53fc399bd559d85fd0d6365ff0d/jiter-0.15.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:cf4bd113a69c0a740e27cb962ce10630c36d2b8f59d759a651b955ee9d18a823", size = 550770, upload-time = "2026-05-19T10:07:08.228Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/54/8c3f65c8a5687925e84708f19d63f7f37d28e2b86a48d951702ad94424d8/jiter-0.15.0-cp310-cp310-win32.whl", hash = "sha256:d92a5cd21fdb083931d546c207aa29633787c5dc5b02daab2d32b843f88a2c53", size = 209303, upload-time = "2026-05-19T10:07:10.006Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/0528a1eb9f42dd2d8228a0711458628f35924d131f623eaebc35fd23d3d4/jiter-0.15.0-cp310-cp310-win_amd64.whl", hash = "sha256:e58585a58209d72691ce2d62a9147445f5a87beb0bde97fde284c96ae392a3d1", size = 200404, upload-time = "2026-05-19T10:07:11.426Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/13/daa722f5765c393576f466378f9dfd29d77c9bed939e0688f96afa3601ea/jiter-0.15.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0f862193b8696249d22ec433e85fd2ab0ad9596bc3e45e6c0bc55e8aeba97be2", size = 310899, upload-time = "2026-05-19T10:07:12.89Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/82/2d2551829b082f4b6d82b9f939b031fb808a10aab1ec0664f82e150bb9a2/jiter-0.15.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1303d4d68a9b051ea90502402063ecf3807da00ad2affa19ca1ae3b90b3c5f67", size = 314963, upload-time = "2026-05-19T10:07:14.539Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/0a/8b1a51466f7fe9f31dbe4bc7e0ca848674f9825e0f737b929b97e8c60aa7/jiter-0.15.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:392b8ab019e5502d08aff85c6272209c24bc2cbe706ea82a56368f524236614a", size = 341730, upload-time = "2026-05-19T10:07:15.869Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/2a/e71dea19822e2e404e83992a08c1d6b9b617bb944f28c9c2fbd85d02c91e/jiter-0.15.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:773b6eb282ce11ee19f05f6b2d4404fa308e5bbd353b0b80a0262caad6db2cd7", size = 366214, upload-time = "2026-05-19T10:07:17.259Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/59/97e1fa539d124a509a00ab7f669289d1c1d236ecabf12948a18f16c91082/jiter-0.15.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8d2c0c44d569ce0f2850f5c926f8caeb5f245fbc84475aeb36efccc2103e6dbd", size = 459527, upload-time = "2026-05-19T10:07:18.741Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/7a/4a68d331aef8cf2e2393c14a3aacb635c62aa86071b0229899fb5baaa907/jiter-0.15.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:032396229564bca02440396bd327710719f724f5e7b7e9f7a8eb3faa4a2c2281", size = 375451, upload-time = "2026-05-19T10:07:20.208Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/7e/1c445c2b6f0e30a274dc8082e0c3c7825411cce80d726bccd697c98cc8d3/jiter-0.15.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3d37768fce7f88dd2a8c6091f2325dea27d30d30d5c6e7a1c0f0af77723b708", size = 349428, upload-time = "2026-05-19T10:07:22.372Z" },
+    { url = "https://files.pythonhosted.org/packages/00/94/e20d38984fc17a636371bffd2ae0f698124fdc8e75ef969cd2da6ba7cea7/jiter-0.15.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:2c9cb907439d20bd0c7d7565ca01ee52234203208433749bae5b516907526928", size = 355405, upload-time = "2026-05-19T10:07:23.916Z" },
+    { url = "https://files.pythonhosted.org/packages/94/fa/4d09f814779d0ea80a28ed8e4c6662ec9a4a8ecef0ac52190ebac6262d14/jiter-0.15.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9100ddbec09741cc66feb0fc6773f8bdbd0e3c345689368f260082ff85dcc0cd", size = 393688, upload-time = "2026-05-19T10:07:25.854Z" },
+    { url = "https://files.pythonhosted.org/packages/54/9d/8eb5d4fb8bf7e93a75964a5da71a75c67c864baf7fa3f98598187b3c7e57/jiter-0.15.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ae1b0d82ac2d987f9ea512b1c9adfcc71a28de3dea3a6039b54d76cffda9901e", size = 520853, upload-time = "2026-05-19T10:07:27.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/2c/5e07874e59e623a943a0acf1552a80d05b70f31b402287a8fc6d7ec634c7/jiter-0.15.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:8020c99ec13a7db2b6f96cbe82ef4721c88b426a4892f27478044af0284615ef", size = 551016, upload-time = "2026-05-19T10:07:28.846Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/d2d34422143474cadc15b60d482b1c35683dbc5c63c24346ddd0df09bcaf/jiter-0.15.0-cp311-cp311-win32.whl", hash = "sha256:42bfb257930800cf43e7c62c832402c704ab60797c992faf88d20e903eac8f32", size = 209518, upload-time = "2026-05-19T10:07:30.431Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/7d/52778b930e5cc3e52a37d950b1c10494244308b4329b25a0ff0d88303a81/jiter-0.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:860a74063284a2ae9bfedd694f299cc2c68e2696c5f3d440cc9d18bb81b9dd04", size = 200565, upload-time = "2026-05-19T10:07:32.125Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/4f/d9b4067feb69b3fa6eb0488e1b59e2ad5b463fe39f59e527eab2aca00bb0/jiter-0.15.0-cp311-cp311-win_arm64.whl", hash = "sha256:37a10c377ce3a4a85f4a67f28b7afe093154cde77eaf248a72e856aa08b4d865", size = 195488, upload-time = "2026-05-19T10:07:33.846Z" },
+    { url = "https://files.pythonhosted.org/packages/44/53/4f6bddbcde3c71e56d0aa1337ec95950f3d27dd4153e25aadf0feac71751/jiter-0.15.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0e90a1c315a0226ec822d973817967f9223b7701546c8c2a7913e7ab0926294d", size = 308793, upload-time = "2026-05-19T10:07:35.25Z" },
+    { url = "https://files.pythonhosted.org/packages/01/84/c01099b59a285a1ebba64ae93f62bfa036675340fd1b0045ae65890a0442/jiter-0.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8c9004af7c8d67cce7f1aae1026fb55607f4aa600710d08ede3a3ce4aeefe7e0", size = 309570, upload-time = "2026-05-19T10:07:36.919Z" },
+    { url = "https://files.pythonhosted.org/packages/58/64/8fb7f9d45bb98190355454cd04dad8d8f27223d6bd52f83af07f637168a6/jiter-0.15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c210f8b35dc6f30aafd4b4365ca89b9d1189f21ab49b8e68fa6322a847aef138", size = 336783, upload-time = "2026-05-19T10:07:38.694Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b6/f5739011d009b3a30f6a53c5240979030ba29ae46a8c67e3a15759f7c37d/jiter-0.15.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5f30bae8bc1c2d613e28e5af3e8cceb09b742f1c8a8a5f839fb67afaffc03b61", size = 363555, upload-time = "2026-05-19T10:07:40.832Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/12/98a9d9f766665e8a3b6252454e17cb0c464606a28cf2fa09399b003345fa/jiter-0.15.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c60e71b6d10cfc284c9bf36bd885e8d44c46f688ce50aa91b5edd90181dea687", size = 452255, upload-time = "2026-05-19T10:07:42.62Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/d5/60f972840f79c5e7544fce567c56f1e4e50468f996baba3e78d823dd62a6/jiter-0.15.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ab068bce62a45aa3e7367eceaffb5dde60b7eb853be8dece45132e3d0ff4879", size = 373559, upload-time = "2026-05-19T10:07:44.201Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/cf/d46ef1234ba335aabc2f013210db8e0821a22f5e644a2e9449df199ecc23/jiter-0.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa248c9eb220197d363f688818dac2fd4b2f0cd7d843ca7105d652034823427d", size = 346055, upload-time = "2026-05-19T10:07:46.005Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/63/4d2749d8d54d230bad9b3a6b0d00cc28c6ff6b2fdffc26a8ccf76cc5a974/jiter-0.15.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2a77aadd57cac1682e4401a72724d2796d89a4ba129b1a5812aa94ee480826eb", size = 351406, upload-time = "2026-05-19T10:07:47.855Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b9/9965b990035d8773328e0a8c8b457a87bf2b19f6c4126d9d99296be5d16a/jiter-0.15.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2ae901f3a55bfafdde31d289590fa25e3245735a2b1e8c7cc15871710a002871", size = 389357, upload-time = "2026-05-19T10:07:49.665Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/55/9ddf903deda1413e87fed792f416b7123daee5b8efbad6a202a7421c36a5/jiter-0.15.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:f0b271b462769543716f92d3a4f90527df6ef5ed05ee95ec4137f513e21e1b77", size = 517263, upload-time = "2026-05-19T10:07:51.537Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/76/a0c40ad064d3a20a4fde231e35d56e9a01ce82164278180e82d5daf85469/jiter-0.15.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2fb6a5d26af81fc0f00f9360a891e05cf755e149bba391c4d563adc54812973d", size = 548646, upload-time = "2026-05-19T10:07:53.196Z" },
+    { url = "https://files.pythonhosted.org/packages/23/4f/eca9b954942916ba2f453891b8593ab444cd872396fe66a3936616f236f3/jiter-0.15.0-cp312-cp312-win32.whl", hash = "sha256:c2f6bb8b5216ab9e7873bc08b5d7bef2b8abbb578a3069bf1cd14a45d71d771d", size = 206427, upload-time = "2026-05-19T10:07:55.307Z" },
+    { url = "https://files.pythonhosted.org/packages/95/bf/8ead82a87495149542748e828d153fd232a512a22c83b02c4815c1a9c7d8/jiter-0.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:40b2c7e92c44a84d748d21706c68dc6ff8161d80b59c99d774721a0d2317d7c7", size = 197300, upload-time = "2026-05-19T10:07:56.651Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/e4/9b8a78fb2d894471bc344e37f1949bdd784bd914d031dba0ba3a40c71dd7/jiter-0.15.0-cp312-cp312-win_arm64.whl", hash = "sha256:cc0bc345cf2df9d1c00ac443f50d543c1ccfa8b0422cb85b1ab70d681c0b255b", size = 192702, upload-time = "2026-05-19T10:07:58.307Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f4/f708c900ecee41b2025ef8413d5351e5649eb2125c506f6720cc69b06f5c/jiter-0.15.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1c11465f97e2abf45a014b83b730222f8f1c5335e802c7055a67d50de6f1f4e3", size = 307829, upload-time = "2026-05-19T10:07:59.704Z" },
+    { url = "https://files.pythonhosted.org/packages/86/59/db537c0949e83668c38481d426b9f2fd5ab758c4ee53a811dd0a510626a0/jiter-0.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d1e7b1776f0797956c509e123d0952d10d293a9492dea9f288ab9570ec01d1a5", size = 308445, upload-time = "2026-05-19T10:08:01.184Z" },
+    { url = "https://files.pythonhosted.org/packages/37/38/ea0e13b18c30ef951da0d47d39e7fa9edb82a93a62990ffbd7cea9b622d4/jiter-0.15.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:351a341c2105aa430b7047e30f1bf7975f6313b00165d3fc07be2edaf741f279", size = 336181, upload-time = "2026-05-19T10:08:02.688Z" },
+    { url = "https://files.pythonhosted.org/packages/58/fc/2303901b16c4ba05865588990a420c0b4156270b44379c20931544a1d962/jiter-0.15.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4ab395feec8d249ec4044e228e98a7033f043426a265df439dc3698823f0a4e4", size = 362985, upload-time = "2026-05-19T10:08:04.394Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6f/11bace093c52e7d4d26c8e606ccd7ae8c972189622469ec0d9e28161e28b/jiter-0.15.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a2a438005b6f22d0273413484d6094d7c2c5d10ec1b3a3bf128e0d1d3ba53258", size = 453292, upload-time = "2026-05-19T10:08:05.967Z" },
+    { url = "https://files.pythonhosted.org/packages/22/db/987f2f086ca4d7a6582eb4ccd513f9b26b42d9e4243a087609a3137a8fc7/jiter-0.15.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f18f85e4218d1b40f000f42a92239a7a61a902cd42c65e6c360dbd17dcb20894", size = 373501, upload-time = "2026-05-19T10:08:07.857Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/7c/89fbcabb2739b7a5b8dc959a1b6c5761f6484f5fed3486854b3c789bb1de/jiter-0.15.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d1aa62e277fc1cbd80e6deacae6f4d983b41b3d7728e0645c5d741a6149bba45", size = 344683, upload-time = "2026-05-19T10:08:09.431Z" },
+    { url = "https://files.pythonhosted.org/packages/30/6f/6cca7692e7dddfec6d8d76c54dc97f2af2a41df4ac0674b999df1f09a5f3/jiter-0.15.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:6550fa135c7deb8ead6af49ed7ff648532ea8334a1447fe34a36315ef79c5c29", size = 350892, upload-time = "2026-05-19T10:08:11.352Z" },
+    { url = "https://files.pythonhosted.org/packages/39/14/0338d6190cb8e6d22e677ab1d4eabd4117f67cca70c54cd04b82ff64e068/jiter-0.15.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:066f8f33f18b2419cd8213b2436fa7fbc9c499f315971cfa3ce1f9820c001b1b", size = 388723, upload-time = "2026-05-19T10:08:12.912Z" },
+    { url = "https://files.pythonhosted.org/packages/90/31/cc19f4a1bdb6afb09ce6a2f2615aa8d44d994eba0d8e6105ed1af920e736/jiter-0.15.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:75e8a04e91432dde9f1838373cf93d23726c79d3e908d319acf0e796f85592e7", size = 516648, upload-time = "2026-05-19T10:08:14.808Z" },
+    { url = "https://files.pythonhosted.org/packages/49/9f/833c541512cd091b63c10c0381973dfe11bc7a503a818c16384417e0c81e/jiter-0.15.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:a97261f1fccb8e50ecd2890a96e46efdc3f57c80a197324c6777827231eca712", size = 547382, upload-time = "2026-05-19T10:08:16.927Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/11/e7b70e91f90bc4477e8eee9e8a5f7cf3cb41b4525d6394dc98a714eb8f7f/jiter-0.15.0-cp313-cp313-win32.whl", hash = "sha256:c77496cb10bd7549690fbbab3e5ec05857b83e49276f4a9423a766ddd2afcd4c", size = 205845, upload-time = "2026-05-19T10:08:18.401Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/23/5c20d9ad6f02c493e4023e5d2d09e1c1f15fe2753c9102c544aff068a88e/jiter-0.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:b15741f501469009ae0ae90b7147958a664a7dede40aa7ff174a8a4645f546d0", size = 196842, upload-time = "2026-05-19T10:08:20.131Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/11/1eb400ef248e8c925fd883fbe325daf5e42cd1b0d308539dd332bd4f7ffc/jiter-0.15.0-cp313-cp313-win_arm64.whl", hash = "sha256:5d6a60072b44c3c2b797a7ddcbcbbf2b34ea3cfd4721580fbfd2a09d9d9b84ba", size = 192212, upload-time = "2026-05-19T10:08:21.807Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/60/2fd8d7c79da8acf9b7b277c7616847773779356b92acfc9bb158452174da/jiter-0.15.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:ef1fd24d9413f6209e00d3d5a453e67acfe004a25cc6c8e8484faed4311ab9e8", size = 315065, upload-time = "2026-05-19T10:08:23.218Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f4/008fb7d65e8ac2abf00811651a661e025c4ba80bbc6f378450384ddd3aed/jiter-0.15.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:144f8e72cb53dab146347b91cceac01f5481237f2b93b4a339a1ee8f8878b67c", size = 339444, upload-time = "2026-05-19T10:08:24.701Z" },
+    { url = "https://files.pythonhosted.org/packages/00/55/90b0c7b9c6896c0f2a591dd36d36b71d22e09674bfef178fa03ba3f81499/jiter-0.15.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:553fcac2ef2cb990877f9fc0833b8b629a3e6a5670b6b5fd58219b41a653ddc4", size = 347779, upload-time = "2026-05-19T10:08:26.408Z" },
+    { url = "https://files.pythonhosted.org/packages/51/6b/69666cec5000fd57734c118437394516c749ae8dbeea9fb66d6fef9c4775/jiter-0.15.0-cp313-cp313t-win_amd64.whl", hash = "sha256:774f93f65031856bf14ad9f59bdcab8b8cad501e5ceabd51ba3525f76937a25b", size = 200395, upload-time = "2026-05-19T10:08:28.055Z" },
+    { url = "https://files.pythonhosted.org/packages/39/04/a6aa62cd27e8149b0d28df5561f10f6cceaf7935a9ccf3f1c5a05f9a0cd8/jiter-0.15.0-cp313-cp313t-win_arm64.whl", hash = "sha256:f1e1754960f38ec40613a07e5e372df67acb3b890fb383b6fb3de3e49ddbf3c7", size = 190516, upload-time = "2026-05-19T10:08:29.35Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d2/079f350ebf7859d081de30aa890f9e3be68516f754f3ba32366ffff4dcee/jiter-0.15.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:ac0d9ddea4350974be7a221fc25895f251a8fee748c889bdced2141c0fec1a49", size = 308884, upload-time = "2026-05-19T10:08:31.667Z" },
+    { url = "https://files.pythonhosted.org/packages/04/4e/a2c30a7f69b48c03b20935d647479106fe932f6e63f75faf53937197e05d/jiter-0.15.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:01a8222cf05ab1128e239421156c207949808acaaea2bdfd33130ae666786e86", size = 310028, upload-time = "2026-05-19T10:08:33.304Z" },
+    { url = "https://files.pythonhosted.org/packages/40/90/2e7cdfd3cf8ca967be38c48f5cf474d79f089efaf559a40f15984a77ae69/jiter-0.15.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:182226cbc930c9fab81bc2e41a4da672f89539906dadb05e75670ac07b94f71f", size = 337485, upload-time = "2026-05-19T10:08:35.259Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/11/15a1aa28b120b8ee5b4f1fb894c125046225f09847738bd64233d3b84883/jiter-0.15.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:71683c38c825452999b5717fcae07ea708e8c93003e808be4319c1b02e3d176e", size = 364223, upload-time = "2026-05-19T10:08:36.694Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/25/f442e8af5f3d0dcf47b39e83a0efd9ee45ea946aa6d04625dc3181eae3b6/jiter-0.15.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:30f2218e6a9e5c18bc10fe6d41ac189c442c88eacf11bad9f28ef95a9bef00e6", size = 456387, upload-time = "2026-05-19T10:08:38.143Z" },
+    { url = "https://files.pythonhosted.org/packages/da/f4/37f2d2c9f64f49af7da652ed7532bb5a2372e588e6927c3fdd76f911db65/jiter-0.15.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5157de9f76eb4bc5ea74a1219366a25f945ad305641d74e04f59c54087091aa9", size = 374461, upload-time = "2026-05-19T10:08:39.869Z" },
+    { url = "https://files.pythonhosted.org/packages/60/28/edcfbbbf0cb15436f36664a8908a0df47ab9006298d4cd937dc08ea932d6/jiter-0.15.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90c5db5527c221249a876160663ab891ace358c17f7b9c93ec1478b7f0550e5c", size = 345924, upload-time = "2026-05-19T10:08:41.668Z" },
+    { url = "https://files.pythonhosted.org/packages/47/13/89fba6398dab7f202b7278c4b4aac122399d2c0183971c4a57a3b7088df5/jiter-0.15.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:3e4540b8e74e4268811ac05db226a6a128ff572e7e0ce3f1163b693cadb184cd", size = 352283, upload-time = "2026-05-19T10:08:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/da/0f6af8cef2c565a1ab44d970f268c43ccaa72707386ea6388e6fe2b6cd26/jiter-0.15.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:62ebd14e47e9aed9df4472afcb2663668ce4d74891cd54f86bf6e44029d6dc89", size = 389985, upload-time = "2026-05-19T10:08:44.915Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/ec/b9cb7d6d29e24ee14910266157d2a279d7a8f60ee0df7fa840882976ba64/jiter-0.15.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0be6f5ad41a809f303f416d17cec92a7a725902fb9b4f3de3d19362ac0ef8554", size = 517695, upload-time = "2026-05-19T10:08:46.486Z" },
+    { url = "https://files.pythonhosted.org/packages/64/5e/6d1bda880723aae0ad86b4b763f044362448efe31e3e819635d41cb03451/jiter-0.15.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:813dfbb17d65328bf86e5f0905dd277ba2265d3ca20556e86c0c7035b7182e5a", size = 548868, upload-time = "2026-05-19T10:08:48.026Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/72/7de501cf38dcacaf35098796f3a50e0f2e338baba18a58946c618544b809/jiter-0.15.0-cp314-cp314-win32.whl", hash = "sha256:50e51156192722a9c58db112837d3f8ef96fb3c5ecc14e95f409134b08b158ec", size = 206380, upload-time = "2026-05-19T10:08:49.738Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/a9/e19addf4b0c1bdce52c6da12351e6bc42c340c45e7c09e2158e46d293ccc/jiter-0.15.0-cp314-cp314-win_amd64.whl", hash = "sha256:30ce1a5d16b5641dc935d50ef775af6a0871e3d14ab05d6fc54dff371b78e558", size = 197687, upload-time = "2026-05-19T10:08:51.088Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c9/776b1db01db25fc6c1d58d1979a37b0a9fe787e5f5b1d062d2eaacb77923/jiter-0.15.0-cp314-cp314-win_arm64.whl", hash = "sha256:510c8b3c17a0ed9ac69850c0438dada3c9b82d9c4d589fcb62002a5a9cf3a866", size = 192571, upload-time = "2026-05-19T10:08:52.451Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f6/45bb4670bacf300fd2c7abadbfb3af376e5f1b6ae75fd9bc069891d15870/jiter-0.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7553333dd0930c104a5a0db8df72bf7219fe663d731383b576bb6ed6351c984d", size = 317151, upload-time = "2026-05-19T10:08:53.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/68/ed635ad5acd7b73e454283083bbb7c8205ad10e88b0d9d7d793b09fe8226/jiter-0.15.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2143ab06181d2b029eedcb6af3cebe95f11bbac62441781860f98ee9330a6a6", size = 341243, upload-time = "2026-05-19T10:08:55.383Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/db/3ff4176b817b8ea33879e71e13d8bc2b0d481a7ed3fe9e080f333d415c16/jiter-0.15.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6eac374c5c975709b69c10f09afd199df74150172156ad10c8d4fd785b7da995", size = 363629, upload-time = "2026-05-19T10:08:56.928Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/24/5f8270e0ba9c883582f96f722f8a0b58015c7ce1f8c6d4571cf394e99b6b/jiter-0.15.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b3b3b775e33d3bfaec9899edc526ae97b0da0bf9d071a46124ba419149a414f8", size = 456198, upload-time = "2026-05-19T10:08:58.618Z" },
+    { url = "https://files.pythonhosted.org/packages/45/5b/76fc02b0b5c54c3d18c60653156e2f76fde1816f9b4722db68d6ee2c897e/jiter-0.15.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eda3071db3346334beae1360b46da4606da57bf3528c167b3c38533afaf9f2c5", size = 373710, upload-time = "2026-05-19T10:09:00.151Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/52/4310821b0ea9277994d3e1f49fc6a4b34e4800caebacb2c0af81da59a454/jiter-0.15.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c6694a173ecabc12eb60efbc0b474464ead1951ff65cd8b1e72100715c64512b", size = 349901, upload-time = "2026-05-19T10:09:01.621Z" },
+    { url = "https://files.pythonhosted.org/packages/93/fe/67648c35b3594fba8854ac64cc8a826d8bcd18324bbdb53d77697c60b6ef/jiter-0.15.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:a254e10b593624d230c365b6d616b22ca0ad65e63a16e6631c2b3466022e6ba8", size = 352438, upload-time = "2026-05-19T10:09:03.216Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/28/0a1879d07ad6b3e025a2750027363452ced93c2d16d1c9d4b153ffd51c91/jiter-0.15.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d8d2955167274e15d79a7a020afdd9b39c990eb80b2d89fca695d92dcfdd38ec", size = 388152, upload-time = "2026-05-19T10:09:04.741Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/78/46c6f6b56ba85c90021f4afd72ed42f691f8f84daacb5fe27277070e3858/jiter-0.15.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:acf4ee4d1fc55917239fe72972fb292dd773055d05eb040d36f4326e02cc2c0e", size = 517707, upload-time = "2026-05-19T10:09:06.231Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/cb/720662d4c88fcad606e826fef5424365527ba43ce4868a479aed8f8c507e/jiter-0.15.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:e7196e56f1cd69af1dbb07dff02dcfb260a50b45a82d409d92a06fedb32473b5", size = 548241, upload-time = "2026-05-19T10:09:08.093Z" },
+    { url = "https://files.pythonhosted.org/packages/60/e3/935b8034fd143f21125c87d51404a9e0e1449186a494405721ff5d1d695e/jiter-0.15.0-cp314-cp314t-win32.whl", hash = "sha256:7f6163c0f10b055245f814dcc59f4818da60dfe72f3e72ab89fc24b6bd5e9c52", size = 207950, upload-time = "2026-05-19T10:09:09.616Z" },
+    { url = "https://files.pythonhosted.org/packages/93/59/984fd9ece895953dad3e0880a650e766f5a2da2c5514f0eafdaaabbeb5f9/jiter-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:980c256edb05b78a111b99c4de3b1d32e31634b867fd1fc2cf726e7b7bba9854", size = 200055, upload-time = "2026-05-19T10:09:11.367Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/a4/cf8d779feb133a27a2e3bc833bccb9e13aa332cdf820497ebf72c10ce8c3/jiter-0.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:66b1880df2d01e206e8339769d1c7c1753bcb653efd6289e203f6f24ebada0c0", size = 191244, upload-time = "2026-05-19T10:09:12.74Z" },
+    { url = "https://files.pythonhosted.org/packages/65/43/1fc62172aa98b50a7de9a25554060db510f85c89cfbed0dfe13e1907a139/jiter-0.15.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:411fa4dfa5a7ae3d11491027ffb9beadec3996010a986862db70d91abba1c750", size = 305585, upload-time = "2026-05-19T10:09:35.995Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/c4/dd58fcd9e2df83666e5c1c1347bef58ce919cd8efc3ffa38aeea62ce493b/jiter-0.15.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:2b0074e2f56eb2dacca1689760fd2852a068f85a0547a157b82cb4cafeb6768b", size = 306936, upload-time = "2026-05-19T10:09:37.435Z" },
+    { url = "https://files.pythonhosted.org/packages/39/86/b695e16f1180c07f43ea98e73ecd21cf63fa2e1b0c1103739013784d11ae/jiter-0.15.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:913d02d29c9606643418d9ccfc3b72492ab25a6bf7889934e09a3490f8d3438b", size = 342453, upload-time = "2026-05-19T10:09:39.294Z" },
+    { url = "https://files.pythonhosted.org/packages/34/56/55d76614af37fe3f22a3347d1e410d2a15da581997cb2da499a625000bb5/jiter-0.15.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b15d3ec9b0449c40e85319bdb4caa8b77ab526e74f5532ed94bec15e2f66822c", size = 345606, upload-time = "2026-05-19T10:09:40.727Z" },
+    { url = "https://files.pythonhosted.org/packages/73/38/505941b2b092fd5bbbd60a52a880db1173f1690ae6751bed3af1c9ddcb4e/jiter-0.15.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:631f13a3d04e97d4e083993b10f4b99530e3a10d953e2eb5e196b7dc7f812ce0", size = 303769, upload-time = "2026-05-19T10:09:42.203Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/95/a06692b29e77473f286e1ec1f426d3ca44d7b5843be8ad21d7a5f3fcdcc0/jiter-0.15.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:b6c0ffae686c39bf3737be60793783267628783ea42545632c10b291105aee45", size = 305128, upload-time = "2026-05-19T10:09:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/23/85/7270d7ad41d6061a25b950c6bf91d638bd9aacb113200a8c8d57a055fd67/jiter-0.15.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d54fb5b31dea401a41af3f8a7d2512e9b6a6a005491e6166c7e4ffab9639a9c", size = 340459, upload-time = "2026-05-19T10:09:45.452Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/8d/302cb2057b7513327b4d575cff6b1d066ee6431a5357fc3f8867cd684406/jiter-0.15.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54d5d6090cdc1b7c9e780dfb04949a990adb1e301a2fc0bbcee7de4638d33f9a", size = 344469, upload-time = "2026-05-19T10:09:46.864Z" },
 ]
 
 [[package]]
@@ -2396,9 +2536,10 @@ wheels = [
 
 [[package]]
 name = "tree-sitter-analyzer"
-version = "1.14.0"
+version = "1.15.2"
 source = { editable = "." }
 dependencies = [
+    { name = "anthropic" },
     { name = "cachetools" },
     { name = "chardet" },
     { name = "deepdiff" },
@@ -2687,6 +2828,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anthropic", specifier = ">=0.104.1" },
     { name = "anyio", marker = "extra == 'all'", specifier = ">=4.0.0" },
     { name = "anyio", marker = "extra == 'full'", specifier = ">=4.0.0" },
     { name = "anyio", marker = "extra == 'integration'", specifier = ">=4.0.0" },


### PR DESCRIPTION
## Summary
- Add a reproducible benchmark harness for native-only, CodeGraph, and tree-sitter-analyzer arms.
- Add pinned repo/question/arm configuration for the 7-project comparison plan.
- Wire the runner to Claude CLI stream-json output and collect tokens, cost, tool calls, elapsed time, answers, and citations.
- Add Codex CLI execution support via `codex exec --json`, including backend-specific run IDs, model selection, timeouts, token/cache fields, and Codex command-event tool metrics.
- Fix matrix scheduling so questions only run against their owning repo, and add a true dry-run mode that does not call an agent CLI or build indexes.
- Make Codex CodeGraph/TSA indexed arms use a writable workspace sandbox so SQLite WAL/cache metadata can update during read-style index queries.

## Current execution status
- Prepared repos so far: Gin and Django.
- Existing exploratory runs include native-only and tsa-warm data, but earlier runs before the matrix fix contain invalid repo/question combinations and should not be used as benchmark evidence.
- Verified Codex dry-run smoke: Gin × 3 Gin questions × native-only/tsa-warm/codegraph-warm = 9/9 scheduled correctly.
- Verified Codex native-only real smoke on Gin.
- Verified Codex CodeGraph warm real smoke on Gin: `codegraph context` succeeds, `index_queries=3`, no database-open error after switching indexed arms to workspace-write.
- Verified negative guard: Django question against Gin now fails fast.

## Remaining benchmark execution work
- Full Claude-backed comparison runs are still blocked by weekly limit: resets May 28 at 5am Asia/Tokyo.
- Full 7-repo benchmark execution still needs the planned pilot/full/cold phases; this PR is the harness and smoke-validation stage.
- Codex-backed runs are available for harness development and smoke testing, but Codex does not expose a Claude-style hard per-tool allowlist; the harness records that limitation in the README.

## Verification
- `uv run python -m py_compile benchmarks/codegraph_compare/run.py benchmarks/codegraph_compare/adapters/claude_runner.py benchmarks/codegraph_compare/analyze.py benchmarks/codegraph_compare/schemas.py`
- `uv run ruff check benchmarks/codegraph_compare/run.py benchmarks/codegraph_compare/adapters/claude_runner.py benchmarks/codegraph_compare/analyze.py benchmarks/codegraph_compare/schemas.py`
- `uv run python benchmarks/codegraph_compare/run.py run-matrix --repos gin --arms native-only,tsa-warm,codegraph-warm --repeats 1 --agent-backend codex --dry-run`
- `uv run python benchmarks/codegraph_compare/run.py run --repo gin --question gin-route-matching --arm codegraph-warm --agent-backend codex --repeat 96 --timeout-seconds 360`
- `uv run python benchmarks/codegraph_compare/analyze.py --runs benchmarks/codegraph_compare/results/runs.jsonl --output /tmp/codegraph-summary.md`
- `uv run pytest -q tests/unit/test_ast_cache_utf8_bug.py`
- `uv run pytest tests/unit/test_codegraph_callees_tool.py tests/unit/test_codegraph_explore_tool.py tests/unit/test_codegraph_impact_tool.py tests/unit/test_codegraph_navigate_tool.py tests/unit/test_codegraph_overview_tool.py tests/unit/test_codegraph_pr_review_tool.py tests/unit/test_codegraph_sitemap.py tests/unit/test_codegraph_status_tool.py tests/unit/test_codegraph_visualize_tool.py -q`
