### PR TITLE
fix(codegraph-bench): query external repos through TSA project root

### DIFF
--- a/benchmarks/codegraph_compare/adapters/claude_runner.py
+++ b/benchmarks/codegraph_compare/adapters/claude_runner.py
@@ -43,6 +43,7 @@ _CODEGRAPH_TOOLS = [
 _TSA_TOOLS = [
     "Bash(python -m tree_sitter_analyzer *)",
     "Bash(uv run python -m tree_sitter_analyzer *)",
+    "Bash(uv run --project * python -m tree_sitter_analyzer *)",
 ]
 
 # Tools explicitly blocked per arm (prevents Claude from discovering and using them via ToolSearch)

--- a/benchmarks/codegraph_compare/adapters/tree_sitter_analyzer.py
+++ b/benchmarks/codegraph_compare/adapters/tree_sitter_analyzer.py
@@ -4,8 +4,9 @@ Supports two modes:
   - ``arm_id="tsa-cold"``: deletes .ast-cache/ and triggers a fresh index build.
   - ``arm_id="tsa-warm"``: verifies .ast-cache/index.db exists; rebuilds if absent.
 
-The index is populated by running ``python -m tree_sitter_analyzer --format json``
-with ``cwd=repo_path``, which parses the source tree and populates the SQLite cache.
+The index is populated by running tree-sitter-analyzer from this checkout via
+``uv run --project <analyzer-root> ... --project-root <repo_path>``, which parses
+the target source tree and populates the target repo's SQLite cache.
 Errors are logged, not raised, so the harness can continue with partial data.
 """
 
@@ -46,6 +47,7 @@ When answering:
 
 _PROMPTS_DIR = Path(__file__).resolve().parent.parent / "prompts"
 _PROMPT_FILE = _PROMPTS_DIR / "system_tsa.md"
+_ANALYZER_ROOT = Path(__file__).resolve().parents[3]
 
 # ---------------------------------------------------------------------------
 # AST cache paths
@@ -115,10 +117,16 @@ class TSAAdapter(BenchmarkAdapter):
 
     def build_run_config(self, repo_path: Path, question_prompt: str) -> RunConfig:
         system_prompt = _load_prompt(_PROMPT_FILE, _DEFAULT_SYSTEM_PROMPT)
+        command_prefix = (
+            f"uv run --project {_ANALYZER_ROOT} python -m tree_sitter_analyzer"
+        )
         extra_context = (
-            "tree-sitter-analyzer is available. "
-            f"Run: python -m tree_sitter_analyzer <subcommand> --format json. "
-            "Key subcommands: smart-context, project-graph, call-graph. "
+            "tree-sitter-analyzer is available through this command prefix: "
+            f"`{command_prefix}`. "
+            "Run it from the benchmark repo root with `--project-root .`. "
+            "Useful queries: `--symbol-search <name>`, `--codegraph-explore <query>`, "
+            "`--codegraph-overview`, and `--call-graph callers|callees "
+            "--call-graph-function <name>`. "
             f"The AST cache is at {repo_path}/.ast-cache/"
         )
 
@@ -285,13 +293,29 @@ def _delete_cache(cache_dir: Path) -> None:
 
 
 def _build_cache(repo_path: Path, cache_dir: Path) -> IndexStats:
-    """Run ``python -m tree_sitter_analyzer --format json`` to populate the cache."""
+    """Run tree-sitter-analyzer's AST-cache indexer for the target repo."""
     logger.info("Building TSA AST cache in %s ...", repo_path)
     t0 = time.perf_counter()
 
     result = subprocess.run(
-        ["python", "-m", "tree_sitter_analyzer", "--format", "json"],
-        cwd=repo_path,
+        [
+            "uv",
+            "run",
+            "--project",
+            str(_ANALYZER_ROOT),
+            "python",
+            "-m",
+            "tree_sitter_analyzer",
+            "--ast-cache",
+            "--ast-cache-mode",
+            "index",
+            "--project-root",
+            str(repo_path),
+            "--format",
+            "json",
+            "--quiet",
+        ],
+        cwd=_ANALYZER_ROOT,
         capture_output=True,
         text=True,
         encoding="utf-8",

--- a/benchmarks/codegraph_compare/prompts/system_tsa.md
+++ b/benchmarks/codegraph_compare/prompts/system_tsa.md
@@ -2,11 +2,14 @@
 
 You are answering architecture questions about a software codebase. You have access to the tree-sitter-analyzer (TSA) CLI, which parses the repo with tree-sitter and exposes structural queries.
 
+The benchmark prompt includes the exact command prefix to use. Always use that prefix, run commands from the benchmark repo root, and pass `--project-root . --format json`.
+
 Workflow:
-1. Run `python -m tree_sitter_analyzer smart-context --query "<concept from the question>" --format json` FIRST. This returns the most relevant files and symbols for the concept.
-2. Use `python -m tree_sitter_analyzer project-graph --format json` to inspect module-level dependency structure when the question is about module boundaries or subsystem layout.
-3. Use `python -m tree_sitter_analyzer call-graph --entry <symbol> --format json` to trace a specific call chain when the question asks how execution flows from a known entry point.
-4. Use raw file reads (Read) only to confirm a specific detail that TSA output did not cover.
+1. Run `... --symbol-search "<symbol-or-concept>" --project-root . --format json` FIRST to discover exact symbol names and files.
+2. Use `... --codegraph-explore "<symbol-or-concept>" --project-root . --format json` to inspect related files and symbols around the concept.
+3. Use `... --codegraph-overview --project-root . --format json` to inspect module-level dependency structure when the question is about module boundaries or subsystem layout.
+4. Use `... --call-graph callers|callees --call-graph-function <symbol> --project-root . --format json` to trace a specific call chain when the question asks how execution flows from a known entry point.
+5. Use raw file reads (Read) only to confirm a specific detail that TSA output did not cover.
 
 Rules:
 - Always cite actual file paths (and line numbers when available) in your final answer. TSA surfaces the locations; you must relay them to the reader.


### PR DESCRIPTION
First small slice from PR #162.\n\nScope:\n- Only benchmark harness/prompt changes.\n- Runs external repo TSA commands from the TSA project root while passing the target project explicitly.\n\nLocal verification:\n- uv run python -m tree_sitter_analyzer --change-impact --format json\n- git diff --check origin/develop...HEAD\n- uv run pytest tests/unit/test_benchmark_harness.py -q\n\nThis PR is intentionally small so CI can distinguish baseline/platform failures from code failures.