### PR TITLE
fix(codegraph-bench): avoid blocking on large index output

### DIFF
--- a/benchmarks/codegraph_compare/adapters/codegraph.py
+++ b/benchmarks/codegraph_compare/adapters/codegraph.py
@@ -212,7 +212,8 @@ def _build_index(repo_path: Path, index_dir: Path) -> IndexStats:
     result = subprocess.run(
         ["codegraph", "init", "-i"],
         cwd=repo_path,
-        capture_output=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
         text=True,
         encoding="utf-8",
         check=False,
@@ -221,9 +222,8 @@ def _build_index(repo_path: Path, index_dir: Path) -> IndexStats:
 
     if result.returncode != 0:
         logger.error(
-            "codegraph init -i exited with code %d.\nstdout: %s\nstderr: %s",
+            "codegraph init -i exited with code %d.\nstderr: %s",
             result.returncode,
-            result.stdout[:2000],
             result.stderr[:2000],
         )
 

--- a/benchmarks/codegraph_compare/adapters/tree_sitter_analyzer.py
+++ b/benchmarks/codegraph_compare/adapters/tree_sitter_analyzer.py
@@ -316,7 +316,8 @@ def _build_cache(repo_path: Path, cache_dir: Path) -> IndexStats:
             "--quiet",
         ],
         cwd=_ANALYZER_ROOT,
-        capture_output=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
         text=True,
         encoding="utf-8",
         check=False,
@@ -325,9 +326,8 @@ def _build_cache(repo_path: Path, cache_dir: Path) -> IndexStats:
 
     if result.returncode != 0:
         logger.error(
-            "tree_sitter_analyzer exited with code %d.\nstdout: %s\nstderr: %s",
+            "tree_sitter_analyzer exited with code %d.\nstderr: %s",
             result.returncode,
-            result.stdout[:2000],
             result.stderr[:2000],
         )
 


### PR DESCRIPTION
Second small slice from PR #162.\n\nScope:\n- Benchmark adapter output handling only.\n- Avoid blocking on large index output during CodeGraph/TSA comparison runs.\n\nLocal verification:\n- uv run python -m tree_sitter_analyzer --change-impact --format json\n- git diff --check origin/develop...HEAD\n- uv run pytest tests/unit/test_benchmark_harness.py -q