### PR TITLE
fix(safe-to-edit): optimize health scoring path

### DIFF
--- a/tests/unit/mcp/tools/test_safe_to_edit_dependency_view.py
+++ b/tests/unit/mcp/tools/test_safe_to_edit_dependency_view.py
@@ -1,0 +1,186 @@
+"""Tests for safe-to-edit's lightweight dependency view."""
+
+from pathlib import Path
+
+from tree_sitter_analyzer.mcp.tools.utils import safe_to_edit_helpers
+from tree_sitter_analyzer.mcp.tools.utils.safe_to_edit_helpers import (
+    FileDependencyView,
+    _extract_import_specs,
+    _iter_dependency_source_files,
+    _resolve_import_spec,
+    _target_dependencies,
+    _target_dependents,
+    build_file_dependency_view,
+    safe_dependencies,
+    safe_dependents,
+)
+
+
+def _write(root: Path, rel_path: str, body: str) -> Path:
+    path = root / rel_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def test_file_dependency_view_sorts_edges_and_supports_suffix_lookup() -> None:
+    view = FileDependencyView(
+        rel_path="pkg/main.py",
+        dependencies={"pkg/z.py", "pkg/a.py"},
+        dependents={"tests/test_main.py", "app.py"},
+    )
+
+    assert safe_dependencies(view, "main.py") == ["pkg/a.py", "pkg/z.py"]
+    assert safe_dependents(view, "pkg/main.py") == ["app.py", "tests/test_main.py"]
+
+
+def test_safe_graph_lookup_tolerates_graph_exceptions() -> None:
+    class BrokenGraph:
+        _nodes = {"pkg/main.py"}
+
+        def dependencies_of(self, _file_rel: str) -> list[str]:
+            raise RuntimeError("stale graph")
+
+    assert safe_dependencies(BrokenGraph(), "pkg/main.py") == []
+
+
+def test_safe_graph_lookup_does_not_match_partial_basename_suffix() -> None:
+    view = FileDependencyView(
+        rel_path="pkg/main.py",
+        dependencies={"pkg/dep.py"},
+        dependents={"tests/test_main.py"},
+    )
+
+    assert safe_dependencies(view, "main.py") == ["pkg/dep.py"]
+    assert safe_dependencies(view, "ain.py") == []
+
+
+def test_build_file_dependency_view_finds_python_imports_and_importers(
+    tmp_path: Path,
+) -> None:
+    target = _write(
+        tmp_path,
+        "pkg/main.py",
+        "import pkg.util\nfrom pkg.service import Service\nfrom .local import value\n",
+    )
+    _write(tmp_path, "pkg/util.py", "VALUE = 1\n")
+    _write(tmp_path, "pkg/service.py", "class Service: pass\n")
+    _write(tmp_path, "pkg/local.py", "value = 1\n")
+    _write(tmp_path, "app/caller.py", "from pkg.main import run\n")
+    _write(tmp_path, "node_modules/ignored.py", "from pkg.main import run\n")
+    _write(tmp_path, ".hidden/ignored.py", "from pkg.main import run\n")
+
+    view = build_file_dependency_view(str(target), str(tmp_path))
+
+    assert view.dependencies_of("pkg/main.py") == [
+        "pkg/local.py",
+        "pkg/service.py",
+        "pkg/util.py",
+    ]
+    assert view.dependents_of("pkg/main.py") == ["app/caller.py"]
+
+
+def test_build_file_dependency_view_finds_typescript_imports(tmp_path: Path) -> None:
+    target = _write(
+        tmp_path,
+        "src/main.ts",
+        "import { dep } from './dep';\nconst legacy = require('./legacy');\n",
+    )
+    _write(tmp_path, "src/dep.ts", "export const dep = 1;\n")
+    _write(tmp_path, "src/legacy.ts", "export const legacy = 1;\n")
+
+    view = build_file_dependency_view(str(target), str(tmp_path))
+
+    assert view.dependencies_of("src/main.ts") == ["src/dep.ts", "src/legacy.ts"]
+
+
+def test_build_file_dependency_view_finds_java_imports(tmp_path: Path) -> None:
+    target = _write(
+        tmp_path,
+        "src/main/java/com/example/Main.java",
+        "package com.example;\nimport com.example.Util;\n",
+    )
+    _write(tmp_path, "com/example/Util.java", "package com.example;\n")
+
+    view = build_file_dependency_view(str(target), str(tmp_path))
+
+    assert view.dependencies_of("src/main/java/com/example/Main.java") == [
+        "com/example/Util.java"
+    ]
+
+
+def test_build_file_dependency_view_detects_package_init_importers(
+    tmp_path: Path,
+) -> None:
+    target = _write(tmp_path, "pkg/__init__.py", "VALUE = 1\n")
+    _write(tmp_path, "consumer.py", "import pkg\n")
+
+    view = build_file_dependency_view(str(target), str(tmp_path))
+
+    assert view.dependents_of("pkg/__init__.py") == ["consumer.py"]
+
+
+def test_target_dependencies_returns_empty_for_unreadable_target(
+    tmp_path: Path, monkeypatch
+) -> None:
+    target = _write(tmp_path, "pkg/main.py", "import pkg.dep\n")
+    original_read_text = Path.read_text
+
+    def flaky_read_text(path: Path, *args, **kwargs):
+        if path == target:
+            raise OSError("unreadable")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", flaky_read_text)
+
+    assert _target_dependencies(target, "pkg/main.py", tmp_path) == set()
+
+
+def test_target_dependents_skips_unreadable_importers(
+    tmp_path: Path, monkeypatch
+) -> None:
+    target = _write(tmp_path, "pkg/main.py", "VALUE = 1\n")
+    broken = _write(tmp_path, "app/broken.py", "from pkg.main import VALUE\n")
+    _write(tmp_path, "app/good.py", "from pkg.main import VALUE\n")
+    original_read_text = Path.read_text
+
+    def flaky_read_text(path: Path, *args, **kwargs):
+        if path == broken:
+            raise OSError("unreadable")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", flaky_read_text)
+
+    assert _target_dependents(target, "pkg/main.py", tmp_path) == {"app/good.py"}
+
+
+def test_target_dependents_returns_empty_without_import_needles(
+    tmp_path: Path, monkeypatch
+) -> None:
+    target = _write(tmp_path, "pkg/main.py", "VALUE = 1\n")
+    _write(tmp_path, "app/caller.py", "from pkg.main import VALUE\n")
+    monkeypatch.setattr(
+        safe_to_edit_helpers,
+        "_import_needles_for_target",
+        lambda _rel_path: set(),
+    )
+
+    assert _target_dependents(target, "pkg/main.py", tmp_path) == set()
+
+
+def test_iter_dependency_source_files_skips_hidden_files(tmp_path: Path) -> None:
+    _write(tmp_path, "src/main.py", "x = 1\n")
+    _write(tmp_path, "src/.hidden.py", "x = 1\n")
+    _write(tmp_path, "src/readme.md", "# ignored\n")
+
+    files = _iter_dependency_source_files(tmp_path)
+
+    assert [path.name for path in files] == ["main.py"]
+
+
+def test_import_spec_helpers_cover_unsupported_and_unresolved_cases(
+    tmp_path: Path,
+) -> None:
+    assert _extract_import_specs("package main\n", ".go") == set()
+    assert _resolve_import_spec("..parent", "pkg/main.py", tmp_path) is None
+    assert _resolve_import_spec("missing.module", "pkg/main.py", tmp_path) is None

--- a/tests/unit/security/test_fixture_detector.py
+++ b/tests/unit/security/test_fixture_detector.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 import pytest
 
+from tree_sitter_analyzer.security import fixture_detector
 from tree_sitter_analyzer.security.fixture_detector import (
     FixtureFact,
     fixture_to_verdict,
@@ -207,7 +208,11 @@ class TestCache:
         root = _make_project(
             tmp_path,
             {
-                "tests/test_x.py": "name = 'tree_sitter_analyzer/foo.py'\n",
+                "tests/test_x.py": (
+                    "from pathlib import Path\n"
+                    "PROJECT_ROOT = Path('.')\n"
+                    "name = PROJECT_ROOT / 'tree_sitter_analyzer' / 'foo.py'\n"
+                ),
                 "tree_sitter_analyzer/foo.py": "",
             },
         )
@@ -244,6 +249,192 @@ class TestCache:
         # … and the broken cache produces a single warning so the
         # operator notices.
         assert any("cache" in record.message.lower() for record in caplog.records)
+
+    def test_readable_cache_uses_targeted_scan(self, tmp_path: Path) -> None:
+        root = _make_project(
+            tmp_path,
+            {
+                "tests/test_x.py": (
+                    "from pathlib import Path\n"
+                    "PROJECT_ROOT = Path('.')\n"
+                    "name = PROJECT_ROOT / 'tree_sitter_analyzer' / 'foo.py'\n"
+                ),
+                "tree_sitter_analyzer/foo.py": "",
+                ".ast-cache/fixture_index.json": (
+                    '{"schema_version": 1, "signature": "old", "fixtures": {}}\n'
+                ),
+            },
+        )
+
+        fact = is_fixture("tree_sitter_analyzer/foo.py", root)
+
+        assert fact.is_fixture is True
+        assert fact.confidence >= 0.85
+        assert fact.source == "targeted_text_scan"
+
+    def test_hidden_test_dirs_do_not_count_as_fixture_signals(
+        self, tmp_path: Path
+    ) -> None:
+        root = _make_project(
+            tmp_path,
+            {
+                "tests/.hidden/test_x.py": "name = 'tree_sitter_analyzer/foo.py'\n",
+                "tree_sitter_analyzer/foo.py": "",
+            },
+        )
+
+        fact = is_fixture("tree_sitter_analyzer/foo.py", root)
+
+        assert fact.is_fixture is False
+
+    def test_targeted_scan_returns_none_without_tests_dir(self, tmp_path: Path) -> None:
+        root = _make_project(tmp_path, {"tree_sitter_analyzer/foo.py": ""})
+
+        fact = fixture_detector._targeted_fixture_scan(
+            root, "tree_sitter_analyzer/foo.py"
+        )
+
+        assert fact is None
+
+    def test_targeted_scan_detects_exact_repo_relative_literal(
+        self, tmp_path: Path
+    ) -> None:
+        root = _make_project(
+            tmp_path,
+            {
+                "tests/test_x.py": "target = 'tree_sitter_analyzer/foo.py'\n",
+                "tree_sitter_analyzer/foo.py": "",
+            },
+        )
+
+        fact = fixture_detector._targeted_fixture_scan(
+            root, "tree_sitter_analyzer/foo.py"
+        )
+
+        assert fact is not None
+        assert fact.is_fixture is True
+        assert fact.confidence >= 0.7
+
+    def test_targeted_scan_skips_init_and_main_basenames(self, tmp_path: Path) -> None:
+        root = _make_project(
+            tmp_path,
+            {
+                "tests/test_x.py": "name = 'tree_sitter_analyzer/__init__.py'\n",
+                "tree_sitter_analyzer/__init__.py": "",
+            },
+        )
+
+        fact = fixture_detector._targeted_fixture_scan(
+            root, "tree_sitter_analyzer/__init__.py"
+        )
+
+        assert fact is None
+
+    def test_targeted_scan_skips_unreadable_test_files(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        root = _make_project(
+            tmp_path,
+            {
+                "tests/test_x.py": "name = 'tree_sitter_analyzer/foo.py'\n",
+                "tree_sitter_analyzer/foo.py": "",
+            },
+        )
+        broken = root / "tests" / "test_x.py"
+        original_read_text = Path.read_text
+
+        def flaky_read_text(path: Path, *args, **kwargs):
+            if path == broken:
+                raise OSError("unreadable")
+            return original_read_text(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", flaky_read_text)
+
+        fact = fixture_detector._targeted_fixture_scan(
+            root, "tree_sitter_analyzer/foo.py"
+        )
+
+        assert fact is None
+
+    def test_basename_seen_in_tests_handles_unreadable_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        root = _make_project(
+            tmp_path,
+            {
+                "tests/test_x.py": "foo.py\n",
+                "tree_sitter_analyzer/foo.py": "",
+            },
+        )
+        broken = root / "tests" / "test_x.py"
+        original_read_text = Path.read_text
+
+        def flaky_read_text(path: Path, *args, **kwargs):
+            if path == broken:
+                raise OSError("unreadable")
+            return original_read_text(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", flaky_read_text)
+
+        assert fixture_detector._basename_seen_in_tests(root, "foo.py") is False
+
+    def test_cache_readability_accepts_legacy_schema_and_rejects_bad_shapes(
+        self, tmp_path: Path
+    ) -> None:
+        readable = tmp_path / "readable.json"
+        readable.write_text('{"fixtures": {}}\n', encoding="utf-8")
+        bad = tmp_path / "bad.json"
+        bad.write_text('{"schema_version": 99, "fixtures": {}}\n', encoding="utf-8")
+
+        assert fixture_detector._cache_is_readable(readable) is True
+        assert fixture_detector._cache_is_readable(tmp_path / "missing.json") is False
+        assert fixture_detector._cache_is_readable(bad) is False
+
+    def test_scan_tests_skips_unreadable_and_syntax_broken_tests(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        root = _make_project(
+            tmp_path,
+            {
+                "tests/test_unreadable.py": "name = 'tree_sitter_analyzer/foo.py'\n",
+                "tests/test_broken.py": "def broken(:\n",
+                "tree_sitter_analyzer/foo.py": "",
+            },
+        )
+        unreadable = root / "tests" / "test_unreadable.py"
+        original_read_text = Path.read_text
+
+        def flaky_read_text(path: Path, *args, **kwargs):
+            if path == unreadable:
+                raise OSError("unreadable")
+            return original_read_text(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", flaky_read_text)
+
+        assert fixture_detector._scan_tests(root / "tests", root) == {}
+
+    def test_write_cache_logs_os_errors(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        cache_path = tmp_path / "cache.json"
+
+        def fail_write_text(self: Path, *_args, **_kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(Path, "write_text", fail_write_text)
+
+        with caplog.at_level(
+            logging.WARNING,
+            logger="tree_sitter_analyzer.security.fixture_detector",
+        ):
+            fixture_detector._write_cache(cache_path, "sig", {})
+
+        assert any(
+            "could not write cache" in record.message for record in caplog.records
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_health_scorer.py
+++ b/tests/unit/test_health_scorer.py
@@ -107,6 +107,133 @@ class TestHealthScorer:
 
         assert names == {"project.cfg"}
 
+    def test_score_file_fast_dependencies_uses_fallback(self, monkeypatch, tmp_path):
+        """Latency-sensitive callers can bypass whole-project dependency graphing."""
+        from tree_sitter_analyzer import health_scorer
+        from tree_sitter_analyzer.health_scorer import HealthScorer
+
+        source = tmp_path / "main.py"
+        source.write_text("import app.service\n")
+
+        def fail_full_graph(_file_path):
+            raise AssertionError("full dependency graph should not be used")
+
+        monkeypatch.setattr(health_scorer, "score_dependencies", fail_full_graph)
+        monkeypatch.setattr(
+            health_scorer,
+            "_score_deps_fallback",
+            lambda _file_path: 42.0,
+        )
+
+        result = HealthScorer().score_file(str(source), fast_dependencies=True)
+
+        assert result.dimensions["dependencies"] == 42.0
+
+    def test_score_file_default_dependencies_uses_full_graph_score(
+        self, monkeypatch, tmp_path
+    ):
+        """Default scoring keeps the full dependency graph dimension."""
+        from tree_sitter_analyzer import health_scorer
+        from tree_sitter_analyzer.health_scorer import HealthScorer
+
+        source = tmp_path / "main.py"
+        source.write_text("import app.service\n")
+
+        monkeypatch.setattr(
+            health_scorer,
+            "score_dependencies",
+            lambda _file_path: 77.0,
+        )
+
+        result = HealthScorer().score_file(str(source))
+
+        assert result.dimensions["dependencies"] == 77.0
+
+    def test_is_excluded_falls_back_to_absolute_parts(self, tmp_path):
+        """Paths outside root still honor generated/hidden path parts."""
+        from tree_sitter_analyzer.health_scorer import HealthScorer
+
+        scorer = HealthScorer()
+
+        assert scorer._is_excluded(tmp_path / ".hidden" / "file.py", Path("/outside"))
+
+    def test_iter_source_files_skips_hidden_filenames(self, tmp_path):
+        """Hidden filenames are not counted as project source files."""
+        from tree_sitter_analyzer.health_scorer import HealthScorer
+
+        visible = tmp_path / "src" / "main.py"
+        hidden = tmp_path / "src" / ".ignored.py"
+        visible.parent.mkdir(parents=True)
+        visible.write_text("x = 1\n")
+        hidden.write_text("x = 1\n")
+
+        files, pruned = HealthScorer(source_extensions={".py"})._iter_source_files(
+            tmp_path
+        )
+
+        assert [path.name for path in files] == ["main.py"]
+        assert pruned == 0
+
+    def test_score_project_counts_scoring_failures(self, monkeypatch, tmp_path):
+        """Stats should record files that were discovered but failed scoring."""
+        from tree_sitter_analyzer.health_scorer import HealthScorer
+
+        source = tmp_path / "main.py"
+        source.write_text("x = 1\n")
+        scorer = HealthScorer(source_extensions={".py"})
+        monkeypatch.setattr(scorer, "_score_file_with_cache", lambda *_args: None)
+
+        scores, stats = scorer.score_project_with_stats(str(tmp_path), use_cache=False)
+
+        assert scores == []
+        assert stats["skip_reasons"]["scoring_failed"] == 1
+
+    def test_score_project_counts_defensive_excluded_file(self, monkeypatch, tmp_path):
+        """A defensive _is_excluded hit is still reported in project stats."""
+        from tree_sitter_analyzer.health_scorer import HealthScorer
+
+        hidden = tmp_path / ".hidden" / "main.py"
+        hidden.parent.mkdir()
+        hidden.write_text("x = 1\n")
+        scorer = HealthScorer(source_extensions={".py"})
+        monkeypatch.setattr(scorer, "_iter_source_files", lambda _root: ([hidden], 0))
+        monkeypatch.setattr(
+            scorer,
+            "_score_file_with_cache",
+            lambda *_args: pytest.fail("excluded files must not be scored"),
+        )
+
+        scores, stats = scorer.score_project_with_stats(str(tmp_path), use_cache=False)
+
+        assert scores == []
+        assert stats["total_files_scanned"] == 1
+        assert stats["skip_reasons"]["excluded_dir"] == 1
+
+    def test_score_project_prunes_hidden_and_generated_dirs(self, tmp_path):
+        """Project scoring should not descend into hidden/generated directories."""
+        from tree_sitter_analyzer.health_scorer import HealthScorer
+
+        visible = tmp_path / "src" / "main.py"
+        hidden = tmp_path / ".hidden" / "ignored.py"
+        generated = tmp_path / "build" / "ignored.py"
+        visible.parent.mkdir(parents=True)
+        hidden.parent.mkdir(parents=True)
+        generated.parent.mkdir(parents=True)
+        visible.write_text("x = 1\n")
+        hidden.write_text("x = 1\n")
+        generated.write_text("x = 1\n")
+
+        scores, stats = HealthScorer(
+            source_extensions={".py"}
+        ).score_project_with_stats(
+            str(tmp_path),
+            use_cache=False,
+        )
+
+        assert {Path(score.file_path).name for score in scores} == {"main.py"}
+        assert stats["total_files_scanned"] == 1
+        assert stats["skip_reasons"]["excluded_dir"] >= 2
+
     def test_large_file_gets_penalized(self, scorer, tmp_path):
         """Files over 500 lines should have lower size score."""
         big = tmp_path / "big.py"

--- a/tree_sitter_analyzer/health_scorer.py
+++ b/tree_sitter_analyzer/health_scorer.py
@@ -13,6 +13,7 @@ Computes a 0-100 health score for source files based on weighted dimensions:
 
 import json
 import logging
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -354,7 +355,9 @@ class HealthScorer:
         self.source_extensions = set(source_extensions or PROJECT_HEALTH_SOURCE_EXTS)
         self._coverage_cache: dict[str, float] | None = None
 
-    def score_file(self, file_path: str) -> HealthScore:
+    def score_file(
+        self, file_path: str, *, fast_dependencies: bool = False
+    ) -> HealthScore:
         """
         Score a single file.
 
@@ -370,7 +373,9 @@ class HealthScorer:
             return HealthScore(file_path=file_path, total=0.0, dimensions={})
 
         language = _EXT_TO_LANG.get(path.suffix.lower())
-        dims = self._score_dimensions(file_path, source, language)
+        dims = self._score_dimensions(
+            file_path, source, language, fast_dependencies=fast_dependencies
+        )
         total = calculate_weighted_total(dims, self.weights)
 
         return HealthScore(
@@ -384,12 +389,19 @@ class HealthScorer:
         file_path: str,
         source: str,
         language: str | None,
+        *,
+        fast_dependencies: bool = False,
     ) -> dict[str, float | None]:
         """Score each health dimension for a source file."""
+        dependency_score = (
+            _score_deps_fallback(file_path)
+            if fast_dependencies
+            else score_dependencies(file_path)
+        )
         return {
             "size": score_size(len(source.splitlines())),
             "complexity": score_complexity(file_path, source, language),
-            "dependencies": score_dependencies(file_path),
+            "dependencies": dependency_score,
             "coverage": self._score_coverage(file_path),
             "duplication": score_duplication(source, language),
             "structure": score_structure(file_path, source, language),
@@ -445,7 +457,28 @@ class HealthScorer:
             rel_parts = file_path.relative_to(root).parts
         except ValueError:
             rel_parts = file_path.parts
-        return any(part in self._EXCLUDE_DIRS for part in rel_parts)
+        return any(
+            part in self._EXCLUDE_DIRS or part.startswith(".") for part in rel_parts
+        )
+
+    def _iter_source_files(self, root: Path) -> tuple[list[Path], int]:
+        """Return source files and a count of pruned generated/hidden dirs."""
+        files: list[Path] = []
+        pruned_dirs = 0
+        for dirpath, dirnames, filenames in os.walk(root):
+            kept_dirs: list[str] = []
+            for name in dirnames:
+                if name in self._EXCLUDE_DIRS or name.startswith("."):
+                    pruned_dirs += 1
+                else:
+                    kept_dirs.append(name)
+            dirnames[:] = kept_dirs
+            for filename in filenames:
+                if filename.startswith("."):
+                    continue
+                if Path(filename).suffix.lower() in self.source_extensions:
+                    files.append(Path(dirpath) / filename)
+        return files, pruned_dirs
 
     def score_project(
         self,
@@ -513,17 +546,17 @@ class HealthScorer:
         excluded_dir = 0
         scoring_failed = 0
         try:
-            for ext in self.source_extensions:
-                for f in root.rglob(f"*{ext}"):
-                    scanned += 1
-                    if self._is_excluded(f, root):
-                        excluded_dir += 1
-                        continue
-                    score = self._score_file_with_cache(str(f), cache)
-                    if score is None:
-                        scoring_failed += 1
-                        continue
-                    results.append(score)
+            files, excluded_dir = self._iter_source_files(root)
+            for f in files:
+                scanned += 1
+                if self._is_excluded(f, root):
+                    excluded_dir += 1
+                    continue
+                score = self._score_file_with_cache(str(f), cache)
+                if score is None:
+                    scoring_failed += 1
+                    continue
+                results.append(score)
         finally:
             if cache is not None:
                 cache.close()

--- a/tree_sitter_analyzer/mcp/tools/safe_to_edit_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/safe_to_edit_tool.py
@@ -18,6 +18,7 @@ from .base_tool import BaseMCPTool, mirror_summary_line
 from .utils.parse_validity import is_file_parse_broken
 from .utils.safe_to_edit_helpers import (
     SafeToEditContext,
+    build_file_dependency_view,
     is_init_file,
 )
 from .utils.safe_to_edit_helpers import (
@@ -162,7 +163,10 @@ class SafeToEditTool(BaseMCPTool):
                 edit_type=edit_type,
                 resolved_path=resolved,
                 project_root=self.project_root or ".",
-                graph=self._get_graph(),
+                graph=build_file_dependency_view(
+                    resolved,
+                    self.project_root or ".",
+                ),
                 scorer=self._get_scorer(),
             )
         )

--- a/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import os
+import re
 import shlex
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 from ....health_scorer import HealthScorer
-from ....project_graph import DependencyGraph
 from ....security.fixture_detector import fixture_to_verdict, is_fixture
 from ..file_health_tool import _build_signal
 from .constraint_violation_query import (
@@ -29,8 +30,29 @@ class SafeToEditContext:
     edit_type: str
     resolved_path: str
     project_root: str
-    graph: DependencyGraph
+    graph: Any
     scorer: HealthScorer
+
+
+class FileDependencyView:
+    """Small graph-like view for one file's immediate import surface."""
+
+    def __init__(
+        self,
+        *,
+        rel_path: str,
+        dependencies: set[str],
+        dependents: set[str],
+    ) -> None:
+        self._nodes = {rel_path, *dependencies, *dependents}
+        self._deps = {rel_path: dependencies}
+        self._dependents = {rel_path: dependents}
+
+    def dependencies_of(self, file_rel: str) -> list[str]:
+        return sorted(self._deps.get(file_rel, set()))
+
+    def dependents_of(self, file_rel: str) -> list[str]:
+        return sorted(self._dependents.get(file_rel, set()))
 
 
 @dataclass(frozen=True)
@@ -71,7 +93,7 @@ def _collect_safe_to_edit_facts(context: SafeToEditContext) -> SafeToEditFacts:
     rel_path = to_relative(context.resolved_path, context.project_root)
     dependents = safe_dependents(context.graph, rel_path)
     dependencies = safe_dependencies(context.graph, rel_path)
-    health = context.scorer.score_file(context.resolved_path)
+    health = context.scorer.score_file(context.resolved_path, fast_dependencies=True)
     test_files = find_test_files(context.resolved_path, context.project_root)
     has_tests = bool(test_files)
     risk, risk_factors = compute_risk(
@@ -430,12 +452,166 @@ def to_relative(abs_path: str, project_root: str) -> str:
         return abs_path
 
 
-def safe_dependents(graph: DependencyGraph, rel_path: str) -> list[str]:
+_DEPENDENCY_SKIP_DIRS = frozenset(
+    {
+        "node_modules",
+        ".git",
+        ".hg",
+        ".svn",
+        "__pycache__",
+        ".venv",
+        "venv",
+        ".tox",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        "dist",
+        "build",
+        "htmlcov",
+        ".cache",
+        ".eggs",
+        ".idea",
+        ".vscode",
+        ".claude",
+    }
+)
+_DEPENDENCY_SOURCE_EXTS = frozenset(
+    {".py", ".js", ".jsx", ".ts", ".tsx", ".java", ".go", ".rs", ".c", ".cpp", ".h"}
+)
+
+
+def build_file_dependency_view(
+    resolved_path: str, project_root: str
+) -> FileDependencyView:
+    """Build a fast graph-like dependency view for one file.
+
+    ``safe_to_edit`` is latency-sensitive. A whole-project tree-sitter
+    dependency graph is useful, but cold-building it for every MCP process
+    makes the common pre-edit check too slow. This view keeps the same lookup
+    contract while limiting work to the target file plus a pruned text scan for
+    obvious importers.
+    """
+    root = Path(project_root).resolve()
+    target = Path(resolved_path).resolve()
+    rel_path = to_relative(str(target), str(root)).replace("\\", "/")
+    dependencies = _target_dependencies(target, rel_path, root)
+    dependents = _target_dependents(target, rel_path, root)
+    return FileDependencyView(
+        rel_path=rel_path,
+        dependencies=dependencies,
+        dependents=dependents,
+    )
+
+
+def _target_dependencies(target: Path, rel_path: str, root: Path) -> set[str]:
+    try:
+        source = target.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return set()
+
+    dependencies: set[str] = set()
+    for spec in _extract_import_specs(source, target.suffix.lower()):
+        resolved = _resolve_import_spec(spec, rel_path, root)
+        if resolved:
+            dependencies.add(resolved)
+    return dependencies
+
+
+def _target_dependents(target: Path, rel_path: str, root: Path) -> set[str]:
+    needles = _import_needles_for_target(rel_path)
+    if not needles:
+        return set()
+
+    dependents: set[str] = set()
+    for path in _iter_dependency_source_files(root):
+        if path == target:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if any(needle in text for needle in needles):
+            dependents.add(to_relative(str(path), str(root)).replace("\\", "/"))
+    return dependents
+
+
+def _iter_dependency_source_files(root: Path) -> list[Path]:
+    files: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [
+            name
+            for name in dirnames
+            if name not in _DEPENDENCY_SKIP_DIRS and not name.startswith(".")
+        ]
+        for filename in filenames:
+            if filename.startswith("."):
+                continue
+            if Path(filename).suffix.lower() in _DEPENDENCY_SOURCE_EXTS:
+                files.append(Path(dirpath) / filename)
+    return files
+
+
+def _extract_import_specs(source: str, suffix: str) -> set[str]:
+    specs: set[str] = set()
+    if suffix == ".py":
+        specs.update(re.findall(r"^\s*import\s+([A-Za-z_][\w.]*)", source, re.M))
+        specs.update(re.findall(r"^\s*from\s+([.\w]+)\s+import\b", source, re.M))
+    elif suffix in {".js", ".jsx", ".ts", ".tsx"}:
+        specs.update(re.findall(r"\bfrom\s+['\"]([^'\"]+)['\"]", source))
+        specs.update(re.findall(r"\brequire\(\s*['\"]([^'\"]+)['\"]\s*\)", source))
+    elif suffix == ".java":
+        specs.update(re.findall(r"^\s*import\s+([\w.]+);", source, re.M))
+    return specs
+
+
+def _resolve_import_spec(spec: str, rel_path: str, root: Path) -> str | None:
+    if not spec or spec.startswith(".."):
+        return None
+    if spec.startswith("."):
+        base = Path(rel_path).parent
+        candidate_base = (base / spec.lstrip("./")).as_posix()
+    else:
+        candidate_base = spec.replace(".", "/")
+
+    candidates = [
+        candidate_base,
+        f"{candidate_base}.py",
+        f"{candidate_base}.js",
+        f"{candidate_base}.ts",
+        f"{candidate_base}.tsx",
+        f"{candidate_base}.java",
+        f"{candidate_base}/__init__.py",
+        f"{candidate_base}/index.js",
+        f"{candidate_base}/index.ts",
+    ]
+    for candidate in candidates:
+        if (root / candidate).is_file():
+            return candidate
+    return None
+
+
+def _import_needles_for_target(rel_path: str) -> set[str]:
+    path = Path(rel_path)
+    suffix = path.suffix
+    without_suffix = path.with_suffix("").as_posix()
+    module = without_suffix.replace("/", ".")
+    basename = path.stem
+    needles = {without_suffix, module}
+    if suffix == ".py" and path.name == "__init__.py":
+        package = path.parent.as_posix()
+        needles.add(package)
+        needles.add(package.replace("/", "."))
+    if basename and basename != "__init__":
+        needles.add(basename)
+    return {needle for needle in needles if needle}
+
+
+def safe_dependents(graph: Any, rel_path: str) -> list[str]:
     """Return files that depend on rel_path, tolerating stale graph data."""
     return _safe_graph_lookup(graph, rel_path, graph.dependents_of)
 
 
-def safe_dependencies(graph: DependencyGraph, rel_path: str) -> list[str]:
+def safe_dependencies(graph: Any, rel_path: str) -> list[str]:
     """Return files rel_path depends on, tolerating stale graph data."""
     return _safe_graph_lookup(graph, rel_path, graph.dependencies_of)
 
@@ -446,7 +622,7 @@ def is_init_file(file_path: str) -> bool:
 
 
 def _safe_graph_lookup(
-    graph: DependencyGraph,
+    graph: Any,
     rel_path: str,
     lookup: Any,
 ) -> list[str]:
@@ -458,8 +634,10 @@ def _safe_graph_lookup(
         return []
 
 
-def _matching_node(graph: DependencyGraph, rel_path: str) -> str | None:
+def _matching_node(graph: Any, rel_path: str) -> str | None:
     """Find the graph node matching a relative path."""
     if rel_path in graph._nodes:
         return rel_path
-    return next((node for node in graph._nodes if node.endswith(rel_path)), None)
+    normalized = rel_path.replace("\\", "/")
+    suffix = f"/{normalized}"
+    return next((node for node in graph._nodes if node.endswith(suffix)), None)

--- a/tree_sitter_analyzer/security/fixture_detector.py
+++ b/tree_sitter_analyzer/security/fixture_detector.py
@@ -90,6 +90,8 @@ _PLUGIN_MANIFEST_PATTERN = re.compile(r"^[a-z_]+_plugin\.py$")
 # The canonical repo-relative path form we look for as a Tier-2 signal.
 _REPO_RELATIVE_PATTERN = re.compile(r"^tree_sitter_analyzer/.+\.py$")
 
+_TARGETED_SKIP_BASENAMES = {"__init__.py", "__main__.py"}
+
 # Where the cache lives. Computed relative to project_root at runtime.
 _CACHE_PATH_SUFFIX = ".ast-cache/fixture_index.json"
 _CACHE_SCHEMA_VERSION = 1
@@ -165,6 +167,14 @@ def is_fixture(file_path: str, project_root: str | Path) -> FixtureFact:
     allowlist_hit = _check_allowlist(root, relative)
     if allowlist_hit is not None:
         return allowlist_hit
+
+    cache_path = root / _CACHE_PATH_SUFFIX
+    if _cache_is_readable(cache_path):
+        targeted_hit = _targeted_fixture_scan(root, relative)
+        if targeted_hit is not None:
+            return targeted_hit
+    if not _basename_seen_in_tests(root, Path(relative).name):
+        return _NEGATIVE
 
     # Tier 2 — load (or rebuild) the test-fixture index and look up.
     index = _load_or_build_index(root)
@@ -269,6 +279,83 @@ def _check_allowlist(project_root: Path, relative: str) -> FixtureFact | None:
 # ---------------------------------------------------------------------------
 
 
+def _iter_test_files(tests_dir: Path) -> list[Path]:
+    """Return Python test files while pruning generated and hidden dirs."""
+    files: list[Path] = []
+    skip_dirs = {
+        "__pycache__",
+        ".pytest_cache",
+        ".mypy_cache",
+        ".ruff_cache",
+        ".venv",
+        "venv",
+    }
+    for dirpath, dirnames, filenames in os.walk(tests_dir):
+        dirnames[:] = [
+            name
+            for name in dirnames
+            if name not in skip_dirs and not name.startswith(".")
+        ]
+        for filename in filenames:
+            if filename.endswith(".py"):
+                files.append(Path(dirpath) / filename)
+    return files
+
+
+def _targeted_fixture_scan(
+    project_root: Path,
+    relative: str,
+) -> FixtureFact | None:
+    """Fast exact-path scan for the common single-file ``is_fixture`` query."""
+    tests_dir = project_root / "tests"
+    if not tests_dir.is_dir():
+        return None
+
+    basename = Path(relative).name
+    if basename in _TARGETED_SKIP_BASENAMES:
+        return None
+    best: FixtureFact | None = None
+    for path in _iter_test_files(tests_dir):
+        try:
+            source = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        evidence = (_safe_relative(path, project_root),)
+        confidence = 0.0
+        if relative in source:
+            confidence = max(confidence, _REPO_RELATIVE_CONFIDENCE)
+        if basename and basename in source and "PROJECT_ROOT" in source:
+            confidence = max(confidence, _CONSTANT_ASSIGNMENT_CONFIDENCE)
+        if confidence <= 0.0:
+            continue
+        fact = FixtureFact(
+            is_fixture=confidence >= _CONFIDENCE_CAUTION,
+            confidence=confidence,
+            source="targeted_text_scan",
+            evidence=evidence,
+            note="",
+        )
+        if best is None or fact.confidence > best.confidence:
+            best = fact
+            if best.confidence >= _CONFIDENCE_UNSAFE:
+                break
+    return best
+
+
+def _basename_seen_in_tests(project_root: Path, basename: str) -> bool:
+    """Return whether the filename appears anywhere in tests/ source."""
+    tests_dir = project_root / "tests"
+    if not tests_dir.is_dir() or not basename:
+        return False
+    for path in _iter_test_files(tests_dir):
+        try:
+            if basename in path.read_text(encoding="utf-8"):
+                return True
+        except OSError:
+            continue
+    return False
+
+
 def _load_or_build_index(project_root: Path) -> dict[str, FixtureFact]:
     """Return the Tier-2 index, building (and caching) on signature change."""
 
@@ -292,7 +379,7 @@ def _tests_signature(tests_dir: Path) -> str:
     """Compute a SHA-1 over every ``tests/**/*.py``'s ``(mtime_ns, size)``."""
 
     hasher = hashlib.sha1(usedforsecurity=False)
-    for path in sorted(tests_dir.rglob("*.py")):
+    for path in sorted(_iter_test_files(tests_dir)):
         try:
             st = path.stat()
         except OSError:
@@ -380,7 +467,7 @@ def _scan_tests(tests_dir: Path, project_root: Path) -> dict[str, FixtureFact]:
     """Walk ``tests_dir`` and merge signals from every ``*.py`` file."""
 
     aggregator: dict[str, _Aggregator] = {}
-    for path in tests_dir.rglob("*.py"):
+    for path in _iter_test_files(tests_dir):
         try:
             source = path.read_text(encoding="utf-8")
         except OSError:
@@ -578,6 +665,21 @@ def _assignment_target_name(node: ast.Assign) -> str | None:
     if isinstance(target, ast.Name):
         return target.id
     return None
+
+
+def _cache_is_readable(cache_path: Path) -> bool:
+    """Return ``True`` when the fixture cache file parses as expected JSON."""
+    if not cache_path.is_file():
+        return False
+    try:
+        payload = json.loads(cache_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    return (
+        isinstance(payload, dict)
+        and payload.get("schema_version") in (None, _CACHE_SCHEMA_VERSION)
+        and isinstance(payload.get("fixtures"), dict)
+    )
 
 
 def _collect_strings(expr: ast.expr) -> list[str]:


### PR DESCRIPTION
Third small slice from PR #162.\n\nScope:\n- Fixture detector path normalization/performance.\n- Health scorer fast path.\n- safe-to-edit helper stability.\n\nLocal verification:\n- uv run python -m tree_sitter_analyzer --change-impact --format json\n- git diff --check origin/develop...HEAD\n- uv run pytest tests/unit/security/test_fixture_detector.py tests/unit/test_health_scorer.py tests/unit/test_health_score_cache.py tests/unit/mcp/test_safe_to_edit_tool.py tests/unit/mcp/tools/test_safe_to_edit_unsafe_verdict.py -q