### PR TITLE
ci: increase pytest worker parallelism

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -47,6 +47,7 @@ jobs:
     env:
       PYTHONIOENCODING: utf-8
       PYTHONUTF8: 1
+      PYTEST_XDIST_AUTO_NUM_WORKERS: "4"
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -30,6 +30,7 @@ on:
 env:
   COVERAGE_THRESHOLD: 40  # Minimum coverage percentage (adjust as needed)
   COVERAGE_THRESHOLD_FAIL: false  # Set to true to fail CI on low coverage
+  PYTEST_XDIST_AUTO_NUM_WORKERS: "4"
 
 jobs:
   coverage-check:

--- a/tests/integration/workflows/test_workflow_properties.py
+++ b/tests/integration/workflows/test_workflow_properties.py
@@ -16,6 +16,7 @@ Properties tested:
 - Property 8: Test Matrix Consistency
 - Property 9: Test Marker Consistency
 - Property 11: Reusable Workflow Behavioral Equivalence
+- Property 12: CI runner parallelism override
 
 Validates: All requirements (1.1-7.5)
 """
@@ -68,6 +69,13 @@ class TestWorkflowProperties:
     def reusable_quality_workflow(self, workflow_root: Path) -> dict[str, Any]:
         """Load the reusable quality workflow."""
         workflow_path = workflow_root / "reusable-quality.yml"
+        with open(workflow_path, encoding="utf-8") as f:
+            return yaml.safe_load(f)
+
+    @pytest.fixture
+    def test_coverage_workflow(self, workflow_root: Path) -> dict[str, Any]:
+        """Load the standalone coverage workflow."""
+        workflow_path = workflow_root / "test-coverage.yml"
         with open(workflow_path, encoding="utf-8") as f:
             return yaml.safe_load(f)
 
@@ -169,3 +177,16 @@ class TestWorkflowProperties:
         """Property 11: Reusable workflows must have a clear job structure."""
         assert len(reusable_test_workflow.get("jobs", {})) >= 1
         assert len(reusable_quality_workflow.get("jobs", {})) >= 1
+
+    def test_property_12_ci_xdist_worker_override(
+        self,
+        reusable_test_workflow: dict[str, Any],
+        test_coverage_workflow: dict[str, Any],
+    ):
+        """Property 12: CI should not leave xdist auto at the 2-core runner floor."""
+        reusable_env = reusable_test_workflow["jobs"]["test-matrix"].get("env", {})
+        coverage_env = test_coverage_workflow.get("env", {})
+
+        for env in (reusable_env, coverage_env):
+            workers = int(str(env.get("PYTEST_XDIST_AUTO_NUM_WORKERS", "0")))
+            assert workers >= 4


### PR DESCRIPTION
## Summary
- Set PYTEST_XDIST_AUTO_NUM_WORKERS=4 for the reusable test matrix and standalone coverage workflow.
- Add a workflow property test so PR CI does not silently fall back to the 2-worker GitHub runner floor.

## Why
Current PR runs show Ubuntu full-suite jobs creating only 2 workers and taking about 8-10 minutes, while local xdist uses more workers and finishes much faster. This is the smallest safe CI-speed slice: it preserves pytest's locked runtime contract and branch-protection gate names, but gives xdist enough workers on CI.

## Verification
- uv run --python 3.11 pytest tests/integration/workflows/test_workflow_properties.py -q
- uv run pre-commit run actionlint --files .github/workflows/reusable-test.yml .github/workflows/test-coverage.yml

Note: I also attempted the local full suite once; it exceeded 10 minutes on this macOS/Python 3.14 environment and was stopped. The focused Python 3.11 workflow verification and actionlint pass, and this PR is intended to measure the CI-side worker-count improvement directly.