### PR TITLE
fix(change-impact): fast-path test-only diffs

### DIFF
--- a/tests/unit/mcp/test_change_impact_tool_execute_and_mapping.py
+++ b/tests/unit/mcp/test_change_impact_tool_execute_and_mapping.py
@@ -189,6 +189,52 @@ def test_execute_supports_agent_summary_only(monkeypatch):
     assert "test_mapping" not in result
 
 
+def test_execute_test_only_diff_skips_expensive_analysis(monkeypatch):
+    """Changed test files are exact targets; no graph/cache walk is needed."""
+    monkeypatch.setattr(
+        tool_module,
+        "_get_changed_files",
+        lambda mode, project_root, scope_paths=None: ["tests/unit/test_fast.py"],
+    )
+    monkeypatch.setattr(
+        tool_module,
+        "_get_diff_stat",
+        lambda mode, project_root, scope_paths=None: "tests/unit/test_fast.py | 1 +",
+    )
+
+    def fail_expensive_path(*args, **kwargs):
+        raise AssertionError("test-only change-impact should not scan the project")
+
+    monkeypatch.setattr(
+        change_impact_tool, "_load_dependency_graph", fail_expensive_path
+    )
+    monkeypatch.setattr(change_impact_tool, "_ensure_ast_cache", fail_expensive_path)
+    monkeypatch.setattr(
+        change_impact_tool,
+        "compute_call_graph_impact",
+        fail_expensive_path,
+    )
+
+    tool = tool_module.ChangeImpactTool()
+    result = asyncio.run(tool.execute({"output_format": "json"}))
+
+    assert result["analysis_fast_path"] == "test_only"
+    assert result["risk_level"] == "low"
+    assert result["affected_count"] == 0
+    assert result["tests_to_run"] == ["tests/unit/test_fast.py"]
+    assert result["verification_command"] == (
+        "uv run pytest tests/unit/test_fast.py -q"
+    )
+    assert result["file_impacts"] == [
+        {
+            "file": "tests/unit/test_fast.py",
+            "direct_dependents": [],
+            "total_affected": 0,
+            "test_only": True,
+        }
+    ]
+
+
 def test_change_impact_result_uses_complete_mapped_tests_for_verification(monkeypatch):
     """Display limits must not silently drop tests from the runnable command."""
 

--- a/tests/unit/test_change_impact_analysis.py
+++ b/tests/unit/test_change_impact_analysis.py
@@ -12,6 +12,7 @@ from tree_sitter_analyzer.mcp.tools.utils.change_impact_analysis import (
     _build_test_plan,
     _find_test_files,
     _is_runnable_test_file,
+    _is_test_only_change_set,
     _load_dependency_graph,
     _test_file_matches_change,
 )
@@ -83,6 +84,18 @@ class TestIsRunnableTestFile:
         assert (
             _is_runnable_test_file("src/example.py", {"tests/"}, ("_test.py",)) is False
         )
+
+
+class TestIsTestOnlyChangeSet:
+    def test_true_for_runnable_test_files(self):
+        assert _is_test_only_change_set(
+            ["tests/unit/test_alpha.py", "tests/unit/beta_test.py"]
+        )
+
+    def test_false_for_runtime_or_test_support_files(self):
+        assert not _is_test_only_change_set(["tree_sitter_analyzer/runtime.py"])
+        assert not _is_test_only_change_set(["tests/conftest.py"])
+        assert not _is_test_only_change_set([])
 
 
 class TestAssessRisk:

--- a/tree_sitter_analyzer/mcp/tools/utils/change_impact_analysis.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/change_impact_analysis.py
@@ -42,6 +42,18 @@ logger = logging.getLogger(__name__)
 
 TESTS_TO_RUN_DISPLAY_LIMIT = 30
 FOCUSED_TEST_COMMAND_LIMIT = 20
+TEST_DIRS = {"tests/", "test/", "spec/", "__tests__/"}
+TEST_SUFFIXES = (
+    "_test.py",
+    "_test.js",
+    "_test.ts",
+    "Test.java",
+    ".test.py",
+    ".test.js",
+    ".test.ts",
+    "_spec.py",
+    "_spec.js",
+)
 
 
 @dataclass(frozen=True)
@@ -61,23 +73,10 @@ def _find_test_files(
     graph_nodes: set[str],
 ) -> dict[str, list[str]]:
     """Map changed files to related test files using stem matching."""
-    test_dirs = {"tests/", "test/", "spec/", "__tests__/"}
-    test_suffixes = (
-        "_test.py",
-        "_test.js",
-        "_test.ts",
-        "Test.java",
-        ".test.py",
-        ".test.js",
-        ".test.ts",
-        "_spec.py",
-        "_spec.js",
-    )
-
     test_files = {
         node
         for node in graph_nodes
-        if _is_runnable_test_file(node, test_dirs, test_suffixes)
+        if _is_runnable_test_file(node, TEST_DIRS, TEST_SUFFIXES)
     }
 
     mapping: dict[str, list[str]] = {}
@@ -192,12 +191,84 @@ def _build_test_plan(
     return test_mapping, tests_to_run
 
 
+def _is_runnable_test_change(path: str) -> bool:
+    """Return True when a changed path is itself a direct test target."""
+    return _is_runnable_test_file(path, TEST_DIRS, TEST_SUFFIXES)
+
+
+def _is_test_only_change_set(changed_files: list[str]) -> bool:
+    """Return True when every changed file is a runnable test file."""
+    return bool(changed_files) and all(
+        _is_runnable_test_change(path) for path in changed_files
+    )
+
+
 def _load_dependency_graph(project_root: str | None) -> DependencyGraph | None:
     """Build the dependency graph, returning None when analysis is unavailable."""
     try:
         return DependencyGraph(project_root or ".")
     except Exception:
         return None
+
+
+def _build_test_only_change_impact_result(
+    request: ChangeImpactRequest,
+) -> dict[str, Any]:
+    """Build a fast change-impact response for test-only edits.
+
+    Runnable test files are already the exact verification targets. Avoid
+    walking the whole dependency graph, building a call graph, or syncing the
+    AST cache when the diff cannot alter runtime dependency edges.
+    """
+    tests_to_run = sorted(dict.fromkeys(request.changed_files))
+    test_mapping = {path: [path] for path in tests_to_run}
+    default_test_command = detect_default_test_command(request.project_root)
+    verification = _build_verification_plan(
+        request.changed_files,
+        tests_to_run,
+        test_mapping,
+        default_test_command,
+    )
+    strategy = _build_verification_strategy(
+        changed_count=len(request.changed_files),
+        tests_to_run=tests_to_run,
+        verification=verification,
+    )
+    agent_summary = build_agent_summary(
+        AgentSummaryContext(
+            risk="low",
+            changed_files=request.changed_files,
+            scope_paths=request.scope_paths,
+            verification=verification,
+            strategy=strategy,
+            affected_count=0,
+            tests_to_run_count=len(tests_to_run),
+        )
+    )
+    result = build_change_impact_response(
+        ChangeImpactResponseContext(
+            request=request,
+            risk="low",
+            affected=set(),
+            file_impacts=[
+                {
+                    "file": path,
+                    "direct_dependents": [],
+                    "total_affected": 0,
+                    "test_only": True,
+                }
+                for path in request.changed_files
+            ],
+            visible_tests=tests_to_run[:TESTS_TO_RUN_DISPLAY_LIMIT],
+            all_tests=tests_to_run,
+            verification=verification,
+            strategy=strategy,
+            test_mapping=test_mapping,
+            agent_summary=agent_summary,
+        )
+    )
+    result["analysis_fast_path"] = "test_only"
+    return result
 
 
 def _build_verification_strategy(
@@ -416,6 +487,9 @@ def _find_affected_symbols(
 
 def _build_change_impact_result(request: ChangeImpactRequest) -> dict[str, Any]:
     """Build the full change-impact response for changed files."""
+    if _is_test_only_change_set(request.changed_files):
+        return _build_test_only_change_impact_result(request)
+
     graph = _load_dependency_graph(request.project_root)
     affected, file_impacts = _build_file_impacts(request.changed_files, graph)
     risk = _assess_risk(request.changed_files, affected, graph) if graph else "unknown"


### PR DESCRIPTION
## Summary
- Add a test-only fast path for change-impact so runnable test diffs skip dependency graph, call graph, and AST cache enrichment
- Return changed test files directly as the verification targets
- Cover the fast path with unit tests that fail if expensive analysis is invoked

## Verification
- uv run --python 3.11 pytest tests/unit/mcp/test_change_impact_tool_execute_and_mapping.py tests/unit/test_change_impact_analysis.py tests/unit/mcp/test_change_impact_tool_git_and_verification.py -q
- uv run python -m tree_sitter_analyzer --change-impact --change-impact-scope tests/unit/test_change_impact_analysis.py --change-impact-full --format json
- uv run python -m tree_sitter_analyzer --change-impact --format json
- uv run pytest tests/unit/mcp/test_change_impact_tool.py tests/unit/mcp/test_change_impact_tool_execute_and_mapping.py tests/unit/mcp/test_change_impact_tool_git_and_verification.py tests/unit/test_change_impact_analysis.py tests/unit/test_change_impact_git.py tests/unit/test_change_impact_response.py tests/unit/test_temporal_change_impact.py -q

## Local full-suite note
- uv run pytest -q completed in 2m30s but failed in this fresh worktree because tree-sitter-swift extra is not installed locally and two local MCP health E2E calls timed out; focused verification for this change passed.