### PR TITLE
fix(change-impact): reuse cached dependency graph

### DIFF
--- a/tests/unit/test_call_graph_impact.py
+++ b/tests/unit/test_call_graph_impact.py
@@ -84,15 +84,22 @@ class TestComputeCallGraphImpact:
         assert result is None
 
     @patch("tree_sitter_analyzer.mcp.tools.utils.call_graph_impact._build_call_graph")
+    def test_can_disable_full_scan_fallback(self, mock_build):
+        mock_build.return_value = None
+        result = compute_call_graph_impact(
+            "/tmp/project", ["a.py"], allow_full_scan=False
+        )
+        assert result is None
+        mock_build.assert_called_once_with("/tmp/project", allow_full_scan=False)
+
+    @patch("tree_sitter_analyzer.mcp.tools.utils.call_graph_impact._build_call_graph")
     def test_basic_impact(self, mock_build):
         cg = MagicMock()
         cg.all_functions.return_value = [
             {"name": "foo", "file": "a.py", "line": 10},
             {"name": "bar", "file": "b.py", "line": 5},
         ]
-        cg.callers_of.return_value = [
-            {"name": "bar", "file": "b.py", "line": 7}
-        ]
+        cg.callers_of.return_value = [{"name": "bar", "file": "b.py", "line": 7}]
         cg.callees_of.return_value = []
         mock_build.return_value = cg
 
@@ -110,8 +117,7 @@ class TestComputeCallGraphImpact:
             {"name": "critical_fn", "file": "core.py", "line": 42},
         ]
         cg.callers_of.return_value = [
-            {"name": f"caller_{i}", "file": f"mod_{i}.py", "line": i}
-            for i in range(6)
+            {"name": f"caller_{i}", "file": f"mod_{i}.py", "line": i} for i in range(6)
         ]
         cg.callees_of.return_value = []
         mock_build.return_value = cg

--- a/tests/unit/test_change_impact_analysis.py
+++ b/tests/unit/test_change_impact_analysis.py
@@ -263,3 +263,42 @@ class TestFindAffectedSymbols:
             assert any(s["name"] == "helper" for s in result)
         finally:
             cache.close()
+
+
+class TestSummaryOnlyFastPath:
+    def test_summary_only_skips_ast_cache_enrichment(self, tmp_path, monkeypatch):
+        from tree_sitter_analyzer.mcp.tools.utils import change_impact_analysis as ci
+
+        class FakeGraph:
+            _nodes = {"src/app.py", "tests/test_app.py"}
+
+            def nodes(self):
+                return sorted(self._nodes)
+
+            def dependents_of(self, file_rel):
+                return []
+
+            def dependencies_of(self, file_rel):
+                return []
+
+        monkeypatch.setattr(ci, "_load_dependency_graph", lambda _: FakeGraph())
+        monkeypatch.setattr(ci, "compute_call_graph_impact", lambda *_, **__: None)
+
+        def fail_enrichment(*args, **kwargs):
+            raise AssertionError("summary-only should not sync AST cache")
+
+        monkeypatch.setattr(ci, "_ensure_ast_cache", fail_enrichment)
+
+        result = ci._build_change_impact_result(
+            ci.ChangeImpactRequest(
+                mode="diff",
+                changed_files=["src/app.py"],
+                diff_stat="src/app.py | 1 +",
+                project_root=str(tmp_path),
+                include_tests=True,
+                agent_summary_only=True,
+            )
+        )
+
+        assert result["success"] is True
+        assert result["affected_count"] == 0

--- a/tests/unit/test_change_impact_cached_graph.py
+++ b/tests/unit/test_change_impact_cached_graph.py
@@ -1,0 +1,161 @@
+"""Tests for cached dependency graph reconstruction used by change-impact."""
+
+from __future__ import annotations
+
+from tree_sitter_analyzer.ast_cache import ASTCache
+from tree_sitter_analyzer.mcp.tools.utils import change_impact_cached_graph as cached
+from tree_sitter_analyzer.mcp.tools.utils.change_impact_cached_graph import (
+    CachedDependencyGraph,
+)
+
+
+def _index_project(root) -> None:
+    cache = ASTCache(str(root))
+    try:
+        cache.index_project(max_files=20)
+    finally:
+        cache.close()
+
+
+def test_load_cached_dependency_graph_returns_none_without_cache(tmp_path):
+    assert cached.load_cached_dependency_graph(str(tmp_path)) is None
+    assert cached.load_cached_dependency_graph(None) is None
+
+
+def test_cached_dependency_graph_resolves_python_relative_edges(tmp_path):
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    (pkg / "a.py").write_text(
+        "from .b import helper\n\n\ndef run():\n    return helper()\n",
+        encoding="utf-8",
+    )
+    (pkg / "b.py").write_text("def helper():\n    return 1\n", encoding="utf-8")
+    _index_project(tmp_path)
+
+    graph = cached.load_cached_dependency_graph(str(tmp_path))
+
+    assert graph is not None
+    assert graph.dependencies_of("pkg/a.py") == ["pkg/b.py"]
+    assert graph.dependents_of("pkg/b.py") == ["pkg/a.py"]
+
+
+def test_cached_dependency_graph_resolves_js_relative_edges(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "index.js").write_text(
+        "import { format } from './formatter';\nformat('x');\n",
+        encoding="utf-8",
+    )
+    (src / "formatter.js").write_text(
+        "export function format(value) { return value; }\n",
+        encoding="utf-8",
+    )
+    _index_project(tmp_path)
+
+    graph = cached.load_cached_dependency_graph(str(tmp_path))
+
+    assert graph is not None
+    assert graph.dependencies_of("src/index.js") == ["src/formatter.js"]
+    assert graph.dependents_of("src/formatter.js") == ["src/index.js"]
+
+
+def test_cached_dependency_graph_methods_ignore_invalid_edges(tmp_path):
+    graph = CachedDependencyGraph(str(tmp_path), {"a.py", "b.py"})
+
+    graph.add_edge("a.py", "a.py")
+    graph.add_edge("a.py", "missing.py")
+    graph.add_edge("a.py", "b.py")
+
+    assert graph.nodes() == ["a.py", "b.py"]
+    assert graph.edges() == [("a.py", "b.py")]
+    assert graph.dependencies_of("a.py") == ["b.py"]
+    assert graph.dependents_of("b.py") == ["a.py"]
+
+
+def test_cached_import_module_parsers_cover_supported_languages():
+    assert cached._modules_from_import_text(
+        "from . import sibling as sib", "python", "pkg/a.py"
+    ) == [(".sibling", True)]
+    assert cached._modules_from_import_text(
+        "import mod from './mod';\nconst x = require('./x')",
+        "typescript",
+        "src/a.ts",
+    ) == [("./mod", True), ("./x", True)]
+    assert cached._modules_from_import_text(
+        "import java.util.List;\nimport com.example.Handler;",
+        "java",
+        "src/Main.java",
+    ) == [("com.example.Handler", False)]
+    assert cached._modules_from_import_text(
+        'import (\n  "fmt"\n  "./internal/handler"\n)',
+        "go",
+        "main.go",
+    ) == [("fmt", False), ("./internal/handler", True)]
+    assert cached._modules_from_import_text(
+        "use crate::handler::serve;\nuse external::thing;",
+        "rust",
+        "src/main.rs",
+    ) == [("crate::handler::serve", True), ("external::thing", False)]
+    assert cached._modules_from_import_text(
+        '#include "local.h"\n#include <stdio.h>', "c", "main.c"
+    ) == [("local.h", True)]
+    assert cached._modules_from_import_text("ignored", "ruby", "app.rb") == []
+
+
+def test_iter_cached_import_modules_handles_invalid_json_and_dict_rows():
+    assert cached._iter_cached_import_modules({"imports_json": "["}) == []
+    assert cached._iter_cached_import_modules(
+        {
+            "file_path": "pkg/a.py",
+            "language": "python",
+            "imports_json": '[{"text": "from .b import helper"}, ""]',
+        }
+    ) == [(".b", True)]
+
+
+def test_cached_index_rows_handles_query_failure():
+    class BadConn:
+        def execute(self, query):
+            raise RuntimeError("boom")
+
+    class BadCache:
+        def _get_conn(self):
+            return BadConn()
+
+    assert cached._cached_index_rows(BadCache()) == []
+
+
+def test_add_cached_import_edges_ignores_unsupported_languages(tmp_path):
+    graph = CachedDependencyGraph(str(tmp_path), {"a.rb"})
+
+    cached._add_cached_import_edges(
+        graph,
+        {"file_path": "a.rb", "language": "ruby", "imports_json": '["require x"]'},
+        {"a.rb"},
+    )
+
+    assert graph.edges() == []
+
+
+def test_add_cached_import_edges_normalizes_windows_resolver_paths(
+    tmp_path, monkeypatch
+):
+    graph = CachedDependencyGraph(str(tmp_path), {"src/index.js", "src/formatter.js"})
+    monkeypatch.setitem(
+        cached._IMPORT_RESOLVERS,
+        "javascript",
+        lambda module, source, nodes, is_relative: "src\\formatter.js",
+    )
+
+    cached._add_cached_import_edges(
+        graph,
+        {
+            "file_path": "src/index.js",
+            "language": "javascript",
+            "imports_json": "[\"import { format } from './formatter';\"]",
+        },
+        {"src/index.js", "src/formatter.js"},
+    )
+
+    assert graph.dependencies_of("src/index.js") == ["src/formatter.js"]

--- a/tests/unit/test_project_graph_coverage.py
+++ b/tests/unit/test_project_graph_coverage.py
@@ -1,10 +1,11 @@
 """Coverage boost tests for project_graph.py — targets uncovered lines."""
 
 import sys
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 import pytest
 
+from tree_sitter_analyzer import project_graph
 from tree_sitter_analyzer.project_graph import (
     BlastRadius,
     DependencyGraph,
@@ -121,6 +122,42 @@ class TestResolveRelativeImport:
     def test_with_submodule(self):
         result = _resolve_relative_import(".models.user", "main.py")
         assert result == "models/user.py"
+
+
+class TestImportResolverPathNormalization:
+    def test_file_resolvers_keep_posix_paths_when_path_is_windows(self, monkeypatch):
+        monkeypatch.setattr(project_graph, "Path", PureWindowsPath)
+
+        assert (
+            project_graph._resolve_js_ts_import(
+                "./formatter", "src/index.js", {"src/formatter.js"}, True
+            )
+            == "src/formatter.js"
+        )
+        assert (
+            project_graph._resolve_js_ts_import(
+                "./pkg", "src/index.js", {"src/pkg/index.ts"}, True
+            )
+            == "src/pkg/index.ts"
+        )
+        assert (
+            project_graph._resolve_go_import(
+                "./internal/handler", "main.go", {"internal/handler.go"}, True
+            )
+            == "internal/handler.go"
+        )
+        assert (
+            project_graph._resolve_rust_import(
+                "crate::utils", "src/main.rs", {"src/utils.rs"}, True
+            )
+            == "src/utils.rs"
+        )
+        assert (
+            project_graph._resolve_c_cpp_import(
+                "handler.h", "src/main.cpp", {"src/handler.h"}, True
+            )
+            == "src/handler.h"
+        )
 
 
 class TestExtractImportsEdgeCases:

--- a/tree_sitter_analyzer/mcp/tools/change_impact_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/change_impact_tool.py
@@ -364,6 +364,7 @@ class ChangeImpactTool(BaseMCPTool):
                 project_root=self.project_root,
                 include_tests=include_tests,
                 scope_paths=scope_paths,
+                agent_summary_only=agent_summary_only,
             )
         )
         # r37fG phase 3: surface related decision_journal entries and
@@ -447,6 +448,7 @@ class ChangeImpactTool(BaseMCPTool):
                 project_root=self.project_root,
                 include_tests=include_tests,
                 scope_paths=scope_paths,
+                agent_summary_only=agent_summary_only,
             )
         )
         return self._finalize_pr_result(

--- a/tree_sitter_analyzer/mcp/tools/utils/call_graph_impact.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/call_graph_impact.py
@@ -81,7 +81,9 @@ class CallGraphImpactResult:
         }
 
 
-def _build_call_graph(project_root: str) -> CallGraph | None:
+def _build_call_graph(
+    project_root: str, *, allow_full_scan: bool = True
+) -> CallGraph | None:
     try:
         cache = ASTCache(project_root)
         stats = cache.get_stats()
@@ -90,10 +92,14 @@ def _build_call_graph(project_root: str) -> CallGraph | None:
             cg = CachedCallGraph(project_root, cache=cache)
         else:
             cache.close()
+            if not allow_full_scan:
+                return None
             cg = CallGraph(project_root)
         cg.build()
         return cg
     except Exception:
+        if not allow_full_scan:
+            return None
         try:
             cg = CallGraph(project_root)
             cg.build()
@@ -106,11 +112,13 @@ def _build_call_graph(project_root: str) -> CallGraph | None:
 def compute_call_graph_impact(
     project_root: str,
     changed_files: list[str],
+    *,
+    allow_full_scan: bool = True,
 ) -> CallGraphImpactResult | None:
     if not changed_files:
         return None
 
-    cg = _build_call_graph(project_root)
+    cg = _build_call_graph(project_root, allow_full_scan=allow_full_scan)
     if cg is None:
         return None
 

--- a/tree_sitter_analyzer/mcp/tools/utils/change_impact_analysis.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/change_impact_analysis.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from ....project_graph import BlastRadius, DependencyGraph
 from .call_graph_impact import compute_call_graph_impact
+from .change_impact_cached_graph import load_cached_dependency_graph
 from .change_impact_response import (
     LARGE_DIRTY_DIFF_THRESHOLD,
     AgentSummaryContext,
@@ -66,6 +67,7 @@ class ChangeImpactRequest:
     project_root: str | None
     include_tests: bool
     scope_paths: list[str] | None = None
+    agent_summary_only: bool = False
 
 
 def _find_test_files(
@@ -132,7 +134,7 @@ def _is_runnable_test_file(
 def _assess_risk(
     changed_files: list[str],
     affected: set[str],
-    graph: DependencyGraph,
+    graph: Any,
 ) -> str:
     """Assess change risk level based on blast radius size."""
     if not changed_files:
@@ -147,7 +149,7 @@ def _assess_risk(
 
 def _build_file_impacts(
     changed_files: list[str],
-    graph: DependencyGraph | None,
+    graph: Any | None,
 ) -> tuple[set[str], list[dict[str, Any]]]:
     """Build per-file impact rows and the total affected file set."""
     if graph is None:
@@ -172,7 +174,7 @@ def _build_file_impacts(
 
 def _build_test_plan(
     changed_files: list[str],
-    graph: DependencyGraph | None,
+    graph: Any | None,
     include_tests: bool,
 ) -> tuple[dict[str, list[str]], list[str]]:
     """Build changed-file-to-test mapping and a sorted runnable test list."""
@@ -203,8 +205,11 @@ def _is_test_only_change_set(changed_files: list[str]) -> bool:
     )
 
 
-def _load_dependency_graph(project_root: str | None) -> DependencyGraph | None:
+def _load_dependency_graph(project_root: str | None) -> Any | None:
     """Build the dependency graph, returning None when analysis is unavailable."""
+    cached = load_cached_dependency_graph(project_root)
+    if cached is not None:
+        return cached
     try:
         return DependencyGraph(project_root or ".")
     except Exception:
@@ -513,7 +518,9 @@ def _build_change_impact_result(request: ChangeImpactRequest) -> dict[str, Any]:
     call_graph_data: dict[str, Any] | None = None
     if request.project_root and request.changed_files:
         cg_result = compute_call_graph_impact(
-            request.project_root, request.changed_files
+            request.project_root,
+            request.changed_files,
+            allow_full_scan=not request.agent_summary_only,
         )
         if cg_result is not None:
             call_graph_data = cg_result.to_dict()
@@ -555,6 +562,9 @@ def _build_change_impact_result(request: ChangeImpactRequest) -> dict[str, Any]:
     # source file and overwrite seeded rows. The verdict bump needs the
     # CURRENT activation state, not the freshly-recomputed one.
     result = _attach_hot_zone_risk(result, request)
+
+    if request.agent_summary_only:
+        return _attach_constraint_violations(result, request, affected)
 
     cache = _ensure_ast_cache(request.project_root, request.changed_files)
     try:

--- a/tree_sitter_analyzer/mcp/tools/utils/change_impact_cached_graph.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/change_impact_cached_graph.py
@@ -1,0 +1,200 @@
+"""Cached dependency graph helpers for change-impact.
+
+The normal :class:`DependencyGraph` reparses every source file in a fresh
+process. For agent feedback loops, the AST cache already stores file imports,
+so change-impact can reconstruct the file-level graph with SQL + small import
+string parsers and fall back to the parser-backed graph when no cache exists.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from ....ast_cache import ASTCache
+from ....project_graph import _IMPORT_RESOLVERS
+from ....synapse_resolver import parse_imports
+
+logger = logging.getLogger(__name__)
+
+_JS_FROM_RE = re.compile(r"\bfrom\s+['\"]([^'\"]+)['\"]")
+_JS_IMPORT_RE = re.compile(r"^\s*import\s+['\"]([^'\"]+)['\"]", re.MULTILINE)
+_JS_REQUIRE_RE = re.compile(r"\brequire\(\s*['\"]([^'\"]+)['\"]\s*\)")
+_JAVA_IMPORT_RE = re.compile(r"^\s*import\s+(?:static\s+)?([^;]+);?", re.MULTILINE)
+_QUOTED_PATH_RE = re.compile(r"['\"]([^'\"]+)['\"]")
+_RUST_USE_RE = re.compile(r"^\s*use\s+([^;]+);?", re.MULTILINE)
+
+
+class CachedDependencyGraph:
+    """Small DependencyGraph-compatible wrapper backed by ASTCache rows."""
+
+    def __init__(self, project_root: str, nodes: set[str]) -> None:
+        self.project_root = Path(project_root).resolve()
+        self._nodes = nodes
+        self._edges: set[tuple[str, str]] = set()
+        self._deps: dict[str, set[str]] = defaultdict(set)
+        self._dependents: dict[str, set[str]] = defaultdict(set)
+
+    def add_edge(self, source: str, target: str) -> None:
+        if source == target or target not in self._nodes:
+            return
+        self._edges.add((source, target))
+        self._deps[source].add(target)
+        self._dependents[target].add(source)
+
+    def nodes(self) -> list[str]:
+        return sorted(self._nodes)
+
+    def edges(self) -> list[tuple[str, str]]:
+        return sorted(self._edges)
+
+    def dependencies_of(self, file_rel: str) -> list[str]:
+        return sorted(self._deps.get(file_rel, set()))
+
+    def dependents_of(self, file_rel: str) -> list[str]:
+        return sorted(self._dependents.get(file_rel, set()))
+
+
+def load_cached_dependency_graph(
+    project_root: str | None,
+) -> CachedDependencyGraph | None:
+    """Return a dependency graph reconstructed from ``.ast-cache/index.db``.
+
+    Returns ``None`` when the cache is absent, empty, or incompatible so callers
+    can fall back to the parser-backed DependencyGraph.
+    """
+    if not project_root:
+        return None
+    db_path = Path(project_root) / ".ast-cache" / "index.db"
+    if not db_path.is_file():
+        return None
+
+    cache: ASTCache | None = None
+    try:
+        cache = ASTCache(project_root)
+        rows = _cached_index_rows(cache)
+        if not rows:
+            return None
+        nodes = {row["file_path"] for row in rows}
+        graph = CachedDependencyGraph(project_root, nodes)
+        for row in rows:
+            _add_cached_import_edges(graph, row, nodes)
+        return graph
+    except Exception:
+        logger.debug("cached dependency graph load failed", exc_info=True)
+        return None
+    finally:
+        if cache is not None:
+            try:
+                cache.close()
+            except Exception:
+                pass
+
+
+def _cached_index_rows(cache: ASTCache) -> list[dict[str, Any]]:
+    conn = cache._get_conn()
+    try:
+        rows = conn.execute(
+            "SELECT file_path, language, imports_json FROM ast_index"
+        ).fetchall()
+    except Exception:
+        return []
+    return [dict(row) for row in rows]
+
+
+def _add_cached_import_edges(
+    graph: CachedDependencyGraph,
+    row: dict[str, Any],
+    nodes: set[str],
+) -> None:
+    source = row["file_path"]
+    language = row["language"]
+    resolver = _IMPORT_RESOLVERS.get(language)
+    if resolver is None:
+        return
+    for module, is_relative in _iter_cached_import_modules(row):
+        resolved = resolver(module, source, nodes, is_relative)
+        if resolved:
+            graph.add_edge(source, resolved.replace("\\", "/"))
+
+
+def _iter_cached_import_modules(row: dict[str, Any]) -> list[tuple[str, bool]]:
+    try:
+        raw_imports = json.loads(row.get("imports_json") or "[]")
+    except (TypeError, json.JSONDecodeError):
+        return []
+    language = row.get("language", "")
+    source = row.get("file_path", "")
+    modules: list[tuple[str, bool]] = []
+    for raw in raw_imports:
+        text = raw.get("text", "") if isinstance(raw, dict) else str(raw)
+        if not text:
+            continue
+        modules.extend(_modules_from_import_text(text, language, source))
+    return modules
+
+
+def _modules_from_import_text(
+    text: str,
+    language: str,
+    source: str,
+) -> list[tuple[str, bool]]:
+    if language == "python":
+        return _python_import_modules(text, language, source)
+    if language in {"javascript", "typescript"}:
+        return _js_ts_import_modules(text)
+    if language == "java":
+        return _java_import_modules(text)
+    if language == "go":
+        return [(path, path.startswith(".")) for path in _QUOTED_PATH_RE.findall(text)]
+    if language == "rust":
+        return _rust_import_modules(text)
+    if language in {"c", "cpp"}:
+        return [(path, True) for path in _QUOTED_PATH_RE.findall(text)]
+    return []
+
+
+def _python_import_modules(
+    text: str,
+    language: str,
+    source: str,
+) -> list[tuple[str, bool]]:
+    modules: list[tuple[str, bool]] = []
+    for entry in parse_imports(text, language, source):
+        module = entry.module_path
+        if entry.is_relative and module and set(module) == {"."} and entry.local_name:
+            module = f"{module}{entry.alias_of or entry.local_name}"
+        modules.append((module, entry.is_relative))
+    return modules
+
+
+def _js_ts_import_modules(text: str) -> list[tuple[str, bool]]:
+    modules = [
+        *_JS_FROM_RE.findall(text),
+        *_JS_IMPORT_RE.findall(text),
+        *_JS_REQUIRE_RE.findall(text),
+    ]
+    return [(module, module.startswith(".")) for module in modules]
+
+
+def _java_import_modules(text: str) -> list[tuple[str, bool]]:
+    modules: list[tuple[str, bool]] = []
+    for raw in _JAVA_IMPORT_RE.findall(text):
+        module = raw.strip()
+        if module.startswith("java.") or module.endswith(".*"):
+            continue
+        modules.append((module, False))
+    return modules
+
+
+def _rust_import_modules(text: str) -> list[tuple[str, bool]]:
+    modules: list[tuple[str, bool]] = []
+    for raw in _RUST_USE_RE.findall(text):
+        module = raw.strip()
+        is_relative = module.startswith(("crate::", "super::", "self::"))
+        modules.append((module, is_relative))
+    return modules

--- a/tree_sitter_analyzer/project_graph.py
+++ b/tree_sitter_analyzer/project_graph.py
@@ -13,7 +13,7 @@ import os
 from collections import defaultdict, deque
 from collections.abc import Callable
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 from .core.parser import Parser, ParseResult
@@ -160,7 +160,18 @@ def _relative_anchor_init(module_path: str, current_file_rel: str) -> str | None
     for _ in range(dots - 1):
         target_dir = target_dir.parent
 
-    return str(target_dir / "__init__.py")
+    return str(target_dir / "__init__.py").replace("\\", "/")
+
+
+def _project_rel_join(source_rel: str, module_path: str) -> str:
+    """Join project-relative imports with stable POSIX separators.
+
+    DependencyGraph nodes are project-relative POSIX paths even on Windows.
+    Using ``Path`` here lets the host OS leak ``\\`` into resolver candidates,
+    so keep import resolution in PurePosixPath space.
+    """
+    source_dir = PurePosixPath(source_rel.replace("\\", "/")).parent
+    return str(source_dir / module_path).replace("\\", "/")
 
 
 def extract_imports_from_file(
@@ -237,8 +248,7 @@ def _resolve_js_ts_import(
     """JS/TS import → ``./foo`` resolved to file/index w/ common extensions."""
     if not is_relative:
         return None
-    source_dir = Path(source_rel).parent
-    candidate_raw = str(source_dir / module)
+    candidate_raw = _project_rel_join(source_rel, module)
     for ext in (".js", ".ts", ".jsx", ".tsx", "/index.js", "/index.ts"):
         candidate = candidate_raw + ext
         if candidate in nodes:
@@ -254,8 +264,7 @@ def _resolve_go_import(
     """Go relative imports — extension probe similar to JS."""
     if not is_relative:
         return None
-    source_dir = Path(source_rel).parent
-    candidate_raw = str(source_dir / module)
+    candidate_raw = _project_rel_join(source_rel, module)
     if candidate_raw in nodes:
         return candidate_raw
     for ext in (".go", "/index.go"):
@@ -275,8 +284,7 @@ def _resolve_rust_import(
         module.replace("crate::", "").replace("super::", "").replace("self::", "")
     )
     path = path_parts.replace("::", "/")
-    source_dir = Path(source_rel).parent
-    candidate = str(source_dir / path)
+    candidate = _project_rel_join(source_rel, path)
     if candidate in nodes:
         return candidate
     for ext in (".rs", "/mod.rs", "/lib.rs"):
@@ -290,8 +298,7 @@ def _resolve_c_cpp_import(
     module: str, source_rel: str, nodes: set[str], is_relative: bool
 ) -> str | None:
     """C/C++ ``#include "foo.h"`` → relative to source dir."""
-    source_dir = Path(source_rel).parent
-    candidate = str(source_dir / module)
+    candidate = _project_rel_join(source_rel, module)
     if candidate in nodes:
         return candidate
     return None


### PR DESCRIPTION
## Summary
- reconstruct change-impact dependency graph from the existing AST cache before falling back to full source parsing
- pass the CLI/MCP summary-only intent into change-impact so default agent feedback skips AST-cache enrichment that would be stripped from the compact response
- keep full-detail mode intact, but avoid call-graph full scans when summary-only and no cache exists

## Performance
- branch-mode full details on this repo: ~1m50s before -> ~16.5s after
- default agent-summary command on current diff: ~3.0s
- branch-mode default agent-summary command: ~4.0s

## Verification
- uv run python -m tree_sitter_analyzer --change-impact --format json
- uv run pytest tests/unit/mcp/test_change_impact_tool.py tests/unit/mcp/test_change_impact_tool_execute_and_mapping.py tests/unit/mcp/test_change_impact_tool_git_and_verification.py tests/unit/test_call_graph_impact.py tests/unit/test_change_impact_analysis.py tests/unit/test_change_impact_cached_graph.py tests/unit/test_change_impact_git.py tests/unit/test_change_impact_response.py tests/unit/test_temporal_change_impact.py -q
- uv run mypy tree_sitter_analyzer/mcp/tools/utils/change_impact_cached_graph.py tree_sitter_analyzer/mcp/tools/utils/change_impact_analysis.py tree_sitter_analyzer/mcp/tools/utils/call_graph_impact.py tree_sitter_analyzer/mcp/tools/change_impact_tool
- uv run pytest tests/unit/test_change_impact_cached_graph.py --cov=tree_sitter_analyzer.mcp.tools.utils.change_impact_cached_graph --cov-report=term-missing -q