### PR TITLE
ci: avoid duplicate feature PR CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ name: CI
 
 on:
   push:
-    branches: [ main, develop, hotfix/*, feature/*, release/* ]
+    branches: [ main, develop, hotfix/*, release/* ]
   pull_request:
     branches: [ main, develop ]
   workflow_dispatch:

--- a/tests/integration/workflows/test_workflow_properties.py
+++ b/tests/integration/workflows/test_workflow_properties.py
@@ -17,6 +17,7 @@ Properties tested:
 - Property 9: Test Marker Consistency
 - Property 11: Reusable Workflow Behavioral Equivalence
 - Property 12: CI runner parallelism override
+- Property 13: PR branch CI trigger de-duplication
 
 Validates: All requirements (1.1-7.5)
 """
@@ -190,3 +191,16 @@ class TestWorkflowProperties:
         for env in (reusable_env, coverage_env):
             workers = int(str(env.get("PYTEST_XDIST_AUTO_NUM_WORKERS", "0")))
             assert workers >= 4
+
+    def test_property_13_ci_does_not_duplicate_feature_pr_runs(
+        self, all_workflows: dict[str, dict[str, Any]]
+    ):
+        """Property 13: Feature PRs should use pull_request CI, not duplicate push CI."""
+        ci_triggers = all_workflows["ci"]["on"]
+        push_branches = ci_triggers["push"]["branches"]
+        pr_branches = ci_triggers["pull_request"]["branches"]
+
+        assert "feature/*" not in push_branches
+        assert {"main", "develop"}.issubset(push_branches)
+        assert {"main", "develop"}.issubset(pr_branches)
+        assert {"hotfix/*", "release/*"}.issubset(push_branches)


### PR DESCRIPTION
## Summary
- remove feature/* from the CI push trigger so feature PRs use pull_request CI only
- keep push CI for main, develop, release/*, and hotfix/*
- add a workflow property test that prevents reintroducing duplicate feature PR CI

## Verification
- uv run ruff check tests/integration/workflows/test_workflow_properties.py
- uv run pytest tests/integration/workflows/test_workflow_properties.py -q
- uv run pre-commit run actionlint --files .github/workflows/ci.yml
- uv run pre-commit run tsa-ps-ascii --files .github/workflows/ci.yml
- uv run python -m tree_sitter_analyzer --change-impact --format json
- uv run pytest tests/integration/workflows/test_workflow_properties.py tests/unit/cli/test_special_commands_smell_ratchet.py tests/unit/mcp/tools/test_landing_decision_surface_contract.py tests/unit/test_decision_journal.py -q