### PR TITLE
feat(benchmark): add reproducible codegraph phases

### DIFF
--- a/benchmarks/codegraph_compare/README.md
+++ b/benchmarks/codegraph_compare/README.md
@@ -32,23 +32,17 @@ benchmarks/codegraph_compare/
 
 ```bash
 # 1. Prepare repos (clone at pinned SHA, optionally pre-build indexes)
-uv run python benchmarks/codegraph_compare/repo_prep.py --repos repos.yaml
+uv run python benchmarks/codegraph_compare/run.py prepare --all
 
 # 2. Run a Codex-backed smoke without spending model quota
-uv run python benchmarks/codegraph_compare/run.py run-matrix \
-    --repos gin \
-    --arms native-only,tsa-warm,codegraph-warm \
-    --repeats 1 \
+uv run python benchmarks/codegraph_compare/run.py phase smoke \
     --agent-backend codex \
     --dry-run
 
 # 3. Run a real Codex-backed smoke
-uv run python benchmarks/codegraph_compare/run.py run \
-    --repo gin \
-    --question gin-route-matching \
-    --arm native-only \
+uv run python benchmarks/codegraph_compare/run.py phase smoke \
     --agent-backend codex \
-    --repeat 0
+    --timeout-seconds 1200
 
 # 4. Evaluate answers (LLM judge, writes EvalRecord JSONL)
 uv run python benchmarks/codegraph_compare/evaluate.py \
@@ -56,7 +50,8 @@ uv run python benchmarks/codegraph_compare/evaluate.py \
 
 # 5. Print summary table
 uv run python benchmarks/codegraph_compare/analyze.py \
-    --runs results/runs.jsonl --evals results/evals.jsonl
+    --runs results/runs.jsonl --evals results/evals.jsonl \
+    --fail-on-gate
 ```
 
 Use `--agent-backend claude` to reproduce the original Claude Code arm, or
@@ -124,6 +119,14 @@ cold     →  all 7 repos, all questions, 4 repeats, cold arms only
 ```
 
 Stop and investigate if any arm has a `FAILED` rate above 5 % in smoke or pilot.
+The `phase` subcommand applies these defaults directly:
+
+```bash
+uv run python benchmarks/codegraph_compare/run.py phase smoke --agent-backend codex
+uv run python benchmarks/codegraph_compare/run.py phase pilot --agent-backend codex
+uv run python benchmarks/codegraph_compare/run.py phase full-warm --agent-backend codex
+uv run python benchmarks/codegraph_compare/run.py phase cold --agent-backend codex
+```
 
 ---
 

--- a/benchmarks/codegraph_compare/adapters/tree_sitter_analyzer.py
+++ b/benchmarks/codegraph_compare/adapters/tree_sitter_analyzer.py
@@ -37,7 +37,7 @@ You may run ``python -m tree_sitter_analyzer <subcommand> --format json``
 via Bash to query the AST cache. Treat TSA output as already-read evidence.
 
 When answering:
-- Start with codegraph-explore for the relevant symbol or concept.
+- Start with codegraph-query for the relevant symbol or concept.
 - Do not use raw grep/find/rg/read for discovery; TSA is the index.
 - Use at most one narrow raw file read only if TSA output misses a required
   detail, and explain the miss.
@@ -141,7 +141,8 @@ class TSAAdapter(BenchmarkAdapter):
             "tree-sitter-analyzer is available through this command prefix: "
             f"`{command_prefix}`. "
             "Run it from the benchmark repo root with `--project-root .`. "
-            "Useful queries: `--symbol-search <name>`, `--codegraph-explore <query>`, "
+            "Useful queries: `--codegraph-query \"search('<symbol-or-concept>').explore(max_files=5).related(limit=8)\"`, "
+            "`--symbol-search <name>`, `--codegraph-explore <query>`, "
             "`--codegraph-overview`, and `--call-graph callers|callees "
             "--call-graph-function <name>`. "
             f"The AST cache is at {repo_path}/.ast-cache/"
@@ -181,28 +182,24 @@ class TSAAdapter(BenchmarkAdapter):
         in_bash_call = False
         pending_bash_lines: list[str] = []
 
+        def flush_bash_call() -> None:
+            nonlocal search_calls, index_queries, in_bash_call, pending_bash_lines
+            if not in_bash_call:
+                return
+            bash_body = "\n".join(pending_bash_lines)
+            if _TSA_PATTERNS.search(bash_body):
+                index_queries += 1
+            else:
+                search_calls += 1
+            in_bash_call = False
+            pending_bash_lines = []
+
         for line in lines:
             # Detect "Tool: <name>" annotation lines
             tool_match = re.match(r"\s*Tool:\s*(\S+)", line, re.IGNORECASE)
             if tool_match:
                 # Flush any pending bash call first
-                if in_bash_call:
-                    _classify_bash(
-                        "\n".join(pending_bash_lines),
-                        result=_MutableCounts(
-                            tool_calls_ref=[tool_calls],
-                            search_calls_ref=[search_calls],
-                            index_queries_ref=[index_queries],
-                        ),
-                    )
-                    # Update locals from mutable containers
-                    tool_calls = _MutableCounts(
-                        tool_calls_ref=[tool_calls],
-                        search_calls_ref=[search_calls],
-                        index_queries_ref=[index_queries],
-                    ).tool_calls_ref[0]
-                    in_bash_call = False
-                    pending_bash_lines = []
+                flush_bash_call()
 
                 name = tool_match.group(1).lower().rstrip("()")
                 tool_calls += 1
@@ -221,12 +218,7 @@ class TSAAdapter(BenchmarkAdapter):
                 pending_bash_lines.append(line)
 
         # Flush trailing bash call
-        if in_bash_call and pending_bash_lines:
-            bash_body = "\n".join(pending_bash_lines)
-            if _TSA_PATTERNS.search(bash_body):
-                index_queries += 1
-            else:
-                search_calls += 1
+        flush_bash_call()
 
         # Fallback: bracket notation [ToolName] for transcripts that don't
         # use "Tool:" prefix
@@ -245,17 +237,17 @@ class TSAAdapter(BenchmarkAdapter):
             elif name in _SEARCH_TOOLS:
                 search_calls += 1
 
-        # Also scan the whole transcript for TSA invocations that appear in
-        # command blocks without a "Tool: Bash" prefix (e.g. inline code fences)
-        for match in _TSA_PATTERNS.finditer(transcript_text):
-            # Only count if on a line that looks like a shell command, not prose
-            line_start = transcript_text.rfind("\n", 0, match.start()) + 1
-            line_end = transcript_text.find("\n", match.end())
-            if line_end == -1:
-                line_end = len(transcript_text)
-            cmd_line = transcript_text[line_start:line_end].strip()
-            if cmd_line.startswith(("$", "python", "uv run")):
-                index_queries += 1
+        if tool_calls == 0:
+            # Also scan transcripts that only include raw command blocks without
+            # tool annotations. Annotated transcripts were already counted above.
+            for match in _TSA_PATTERNS.finditer(transcript_text):
+                line_start = transcript_text.rfind("\n", 0, match.start()) + 1
+                line_end = transcript_text.find("\n", match.end())
+                if line_end == -1:
+                    line_end = len(transcript_text)
+                cmd_line = transcript_text[line_start:line_end].strip()
+                if cmd_line.startswith(("$", "python", "uv run")):
+                    index_queries += 1
 
         return ToolMetrics(
             tool_calls=tool_calls,
@@ -263,35 +255,6 @@ class TSAAdapter(BenchmarkAdapter):
             search_calls=search_calls,
             index_queries=index_queries,
         )
-
-
-# ---------------------------------------------------------------------------
-# Internal helper dataclass for mutable counter passing
-# ---------------------------------------------------------------------------
-
-
-class _MutableCounts:
-    """Tiny mutable container used to pass counters by reference."""
-
-    __slots__ = ("tool_calls_ref", "search_calls_ref", "index_queries_ref")
-
-    def __init__(
-        self,
-        tool_calls_ref: list[int],
-        search_calls_ref: list[int],
-        index_queries_ref: list[int],
-    ) -> None:
-        self.tool_calls_ref = tool_calls_ref
-        self.search_calls_ref = search_calls_ref
-        self.index_queries_ref = index_queries_ref
-
-
-def _classify_bash(bash_body: str, result: _MutableCounts) -> None:
-    """Classify one Bash call as either an index_query or a search_call."""
-    if _TSA_PATTERNS.search(bash_body):
-        result.index_queries_ref[0] += 1
-    else:
-        result.search_calls_ref[0] += 1
 
 
 # ---------------------------------------------------------------------------

--- a/benchmarks/codegraph_compare/analyze.py
+++ b/benchmarks/codegraph_compare/analyze.py
@@ -31,6 +31,8 @@ from typing import Any
 
 _INPUT_COST_PER_M = 3.0  # USD / M input tokens  (Sonnet 4.6)
 _OUTPUT_COST_PER_M = 15.0  # USD / M output tokens (Sonnet 4.6)
+_GATE_MAX_FAILURE_RATE = 0.05
+_GATE_MIN_QUALITY = 2.5
 
 
 def estimate_cost(input_tokens: int, output_tokens: int) -> float:
@@ -99,6 +101,11 @@ def _is_timeout(run: dict[str, Any]) -> bool:
     return "timeout" in str(run.get("error") or "").lower()
 
 
+def _is_low_quality(run: dict[str, Any]) -> bool:
+    quality = run.get("_quality")
+    return quality is not None and float(quality) < _GATE_MIN_QUALITY
+
+
 # ---------------------------------------------------------------------------
 # Statistical helpers
 # ---------------------------------------------------------------------------
@@ -133,6 +140,7 @@ def _agg(runs: list[dict[str, Any]]) -> dict[str, Any]:
     return {
         "count": len(runs),
         "failed": sum(1 for r in runs if _is_failed(r)),
+        "low_quality": sum(1 for r in live if _is_low_quality(r)),
         "median_cost": _med([r["_cost"] for r in live]),
         "median_tokens": _med([r["_total_tokens"] for r in live]),
         "median_time": _med(
@@ -433,30 +441,74 @@ def _s_cold_warm(runs: list[dict[str, Any]]) -> str:
 
 
 def _s_failed(runs: list[dict[str, Any]]) -> str:
-    problems = [r for r in runs if _is_failed(r) or _is_dry(r)]
+    problems = [r for r in runs if _is_failed(r) or _is_dry(r) or _is_low_quality(r)]
     if not problems:
-        return "## 7. Failed / timed-out runs\n\n_No failed or dry-run records._"
+        return "## 8. Failed / low-quality / dry-run records\n\n_No problem records._"
     headers = ["run_id", "repo", "arm", "question_id", "error / note"]
     rows = []
     for r in problems:
-        msg = r.get("error") or ("DRY_RUN stub" if _is_dry(r) else "—")
+        msg = r.get("error") or (
+            "LOW_QUALITY"
+            if _is_low_quality(r)
+            else ("DRY_RUN stub" if _is_dry(r) else "-")
+        )
         qid = r.get("question_id") or r.get("question_id", "—")
         rows.append(
             [r.get("run_id", "—"), r["_repo_name"], r["_arm"], str(qid), str(msg)[:120]]
         )
-    return "## 7. Failed / timed-out runs\n\n" + _table(headers, rows)
+    return "## 8. Failed / low-quality / dry-run records\n\n" + _table(headers, rows)
 
 
 def _s_notes(n_repeats: int) -> str:
     return "\n".join(
         [
-            "## 8. Notes\n",
+            "## 9. Notes\n",
             f"- Median reported across {n_repeats} repeat(s) per question per arm",
             "- Cost uses the agent CLI reported cost when available; otherwise it is estimated at $3/M input and $15/M output",
             "- Quality scores from LLM evaluator (claude-haiku) on 1-5 scale",
             "- Index build time excluded from warm query timing",
         ]
     )
+
+
+def gate_violations(runs: list[dict[str, Any]], has_evals: bool) -> list[str]:
+    """Return benchmark gate violations for already-enriched run records."""
+    by_arm: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for run in runs:
+        by_arm[run["_arm"]].append(run)
+
+    violations: list[str] = []
+    for arm, arm_runs in sorted(by_arm.items()):
+        counted = [r for r in arm_runs if not _is_dry(r)]
+        if not counted:
+            violations.append(f"{arm}: no non-dry-run records")
+            continue
+
+        failed = sum(1 for r in counted if _is_failed(r))
+        fail_rate = failed / len(counted)
+        if fail_rate > _GATE_MAX_FAILURE_RATE:
+            violations.append(
+                f"{arm}: failure rate {fail_rate:.1%} exceeds "
+                f"{_GATE_MAX_FAILURE_RATE:.0%}"
+            )
+
+        if has_evals:
+            low_quality = sum(1 for r in counted if _is_low_quality(r))
+            if low_quality:
+                violations.append(
+                    f"{arm}: {low_quality} run(s) below quality {_GATE_MIN_QUALITY:.1f}"
+                )
+
+    return violations
+
+
+def _s_gate(runs: list[dict[str, Any]], has_evals: bool) -> str:
+    violations = gate_violations(runs, has_evals)
+    if not violations:
+        return "## 7. Industry benchmark gate\n\nPASS"
+    lines = ["## 7. Industry benchmark gate\n", "FAIL"]
+    lines.extend(f"- {item}" for item in violations)
+    return "\n".join(lines)
 
 
 # ---------------------------------------------------------------------------
@@ -547,7 +599,7 @@ def _write_csv(
 # ---------------------------------------------------------------------------
 
 
-def build_report(runs_path: Path, evals_path: Path | None, output_path: Path) -> None:
+def build_report(runs_path: Path, evals_path: Path | None, output_path: Path) -> bool:
     if not runs_path.exists():
         print(f"ERROR: runs file not found: {runs_path}", file=sys.stderr)
         sys.exit(1)
@@ -602,6 +654,8 @@ def build_report(runs_path: Path, evals_path: Path | None, output_path: Path) ->
         "",
         _s_cold_warm(runs),
         "",
+        _s_gate(runs, has_evals),
+        "",
         _s_failed(runs),
         "",
         _s_notes(max_repeats),
@@ -615,6 +669,7 @@ def build_report(runs_path: Path, evals_path: Path | None, output_path: Path) ->
     csv_path = output_path.with_suffix(".csv")
     _write_csv(runs, evals_by_id, csv_path)
     print(f"CSV written to {csv_path}", file=sys.stderr)
+    return not gate_violations(runs, has_evals)
 
 
 # ---------------------------------------------------------------------------
@@ -644,12 +699,19 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=Path("results/summary.md"),
         help="Output markdown path (default: results/summary.md)",
     )
+    parser.add_argument(
+        "--fail-on-gate",
+        action="store_true",
+        help="Exit non-zero when the industry benchmark gate fails.",
+    )
     return parser.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> None:
     args = _parse_args(argv)
-    build_report(args.runs, args.evals, args.output)
+    passed = build_report(args.runs, args.evals, args.output)
+    if args.fail_on_gate and not passed:
+        sys.exit(2)
 
 
 if __name__ == "__main__":

--- a/benchmarks/codegraph_compare/prompts/system_tsa.md
+++ b/benchmarks/codegraph_compare/prompts/system_tsa.md
@@ -5,11 +5,12 @@ You are answering architecture questions about a software codebase. You have acc
 The benchmark prompt includes the exact command prefix to use. Always use that prefix, run commands from the benchmark repo root, and pass `--project-root . --format json`.
 
 Workflow:
-1. Run `... --codegraph-explore "<symbol-or-concept>" --project-root . --format json` FIRST. Treat its source snippets and line numbers as already-read evidence.
-2. Use `... --symbol-search "<exact-symbol>" --project-root . --format json` only when you need to disambiguate a symbol name returned by explore.
-3. Use `... --call-graph callers|callees --call-graph-function <symbol> --project-root . --format json` only for a concrete call-flow hop from a known symbol.
-4. Use `... --codegraph-overview --project-root . --format json` only for broad subsystem/module-boundary questions. Do not run overview first for a specific command, request, route, task, or handler flow.
-5. Stop after the smallest set of TSA queries that answers the question. A good indexed answer is usually 1-4 TSA CLI calls, not a grep/read exploration loop.
+1. Run `... --codegraph-query "search('<symbol-or-concept>').explore(max_files=5).related(limit=8)" --project-root . --format json` FIRST. Treat its answer pack, source snippets, and line numbers as already-read evidence.
+2. Use `... --symbol-search "<exact-symbol>" --project-root . --format json` only when you need to disambiguate a symbol name returned by the chain query.
+3. Use `... --codegraph-explore "<symbol-or-concept>" --project-root . --format json` only as a fallback if the chain query returns no useful evidence.
+4. Use `... --call-graph callers|callees --call-graph-function <symbol> --project-root . --format json` only for a concrete call-flow hop from a known symbol.
+5. Use `... --codegraph-overview --project-root . --format json` only for broad subsystem/module-boundary questions. Do not run overview first for a specific command, request, route, task, or handler flow.
+6. Stop after the smallest set of TSA queries that answers the question. A good indexed answer is usually 1-2 TSA CLI calls, not a grep/read exploration loop.
 
 Rules:
 - Do not use raw `grep`, `rg`, `find`, `ls`, `cat`, `sed`, `nl`, `head`, `tail`, Read, Glob, or Grep as the discovery mechanism in this arm. TSA is the index; re-deriving its output with filesystem tools invalidates the benchmark.

--- a/benchmarks/codegraph_compare/repos.yaml
+++ b/benchmarks/codegraph_compare/repos.yaml
@@ -3,47 +3,47 @@ repos:
     name: VS Code
     language: TypeScript
     url: https://github.com/microsoft/vscode
-    commit: "PLACEHOLDER_SHA"
+    commit: "0e3051a9669d4b829aec4f16e8d4d17adec8fb28"  # pragma: allowlist secret
     approx_files: 10000
 
   - id: excalidraw
     name: Excalidraw
     language: TypeScript
     url: https://github.com/excalidraw/excalidraw
-    commit: "PLACEHOLDER_SHA"
+    commit: "c08be69618dcac9386817bced03d2d79883e50b6"  # pragma: allowlist secret
     approx_files: 800
 
   - id: django
     name: Django
     language: Python
     url: https://github.com/django/django
-    commit: "PLACEHOLDER_SHA"
+    commit: "0a2bc6d88ffd7918ca9bbe039ec2f4ed7dd639c9"  # pragma: allowlist secret
     approx_files: 5000
 
   - id: tokio
     name: Tokio
     language: Rust
     url: https://github.com/tokio-rs/tokio
-    commit: "PLACEHOLDER_SHA"
+    commit: "32312ae0d6f0b1c6457f1323e3e7f568f448d0db"  # pragma: allowlist secret
     approx_files: 800
 
   - id: okhttp
     name: OkHttp
     language: Java
     url: https://github.com/square/okhttp
-    commit: "PLACEHOLDER_SHA"
+    commit: "cfc45a3f146d2389797a3d51d405e9118bed56c9"  # pragma: allowlist secret
     approx_files: 600
 
   - id: gin
     name: Gin
     language: Go
     url: https://github.com/gin-gonic/gin
-    commit: "PLACEHOLDER_SHA"
+    commit: "5f4f9643258dc2a65e684b63f12c8d543c936c67"  # pragma: allowlist secret
     approx_files: 200
 
   - id: alamofire
     name: Alamofire
     language: Swift
     url: https://github.com/Alamofire/Alamofire
-    commit: "PLACEHOLDER_SHA"
+    commit: "7595cbcf59809f9977c5f6378500de2ad73b7ddb"  # pragma: allowlist secret
     approx_files: 150

--- a/benchmarks/codegraph_compare/run.py
+++ b/benchmarks/codegraph_compare/run.py
@@ -14,6 +14,7 @@ Subcommands
              --arms native-only,tsa-warm
              --repeats 4
              [--dry-run]
+  phase smoke                         Run a named benchmark phase
   status                              Show prepared repos + last run stats
 
 Config files are resolved relative to this file:
@@ -30,6 +31,7 @@ import argparse
 import json
 import sys
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import NoReturn
 
@@ -43,6 +45,54 @@ ARMS_YAML = BENCHMARKS_DIR / "arms.yaml"
 QUESTIONS_YAML = BENCHMARKS_DIR / "questions.yaml"
 RESULTS_DIR = BENCHMARKS_DIR / "results"
 PREPARED_MANIFEST = RESULTS_DIR / "prepared_repos.json"
+
+
+@dataclass(frozen=True)
+class PhasePreset:
+    """Named benchmark phase with reproducible defaults."""
+
+    repos: str
+    arms: str
+    repeats: int
+    min_repeats: int
+    question_limit: int | None
+    description: str
+
+
+PHASE_PRESETS: dict[str, PhasePreset] = {
+    "smoke": PhasePreset(
+        repos="gin",
+        arms="all",
+        repeats=1,
+        min_repeats=1,
+        question_limit=1,
+        description="1 repo, 1 question, 1 repeat, all arms",
+    ),
+    "pilot": PhasePreset(
+        repos="gin",
+        arms="all",
+        repeats=4,
+        min_repeats=4,
+        question_limit=None,
+        description="1 repo, all questions, 4 repeats, all arms",
+    ),
+    "full-warm": PhasePreset(
+        repos="all",
+        arms="native-only,codegraph-warm,tsa-warm",
+        repeats=4,
+        min_repeats=4,
+        question_limit=None,
+        description="all repos, all questions, 4 repeats, warm arms",
+    ),
+    "cold": PhasePreset(
+        repos="all",
+        arms="codegraph-cold,tsa-cold",
+        repeats=4,
+        min_repeats=4,
+        question_limit=None,
+        description="all repos, all questions, 4 repeats, cold arms",
+    ),
+}
 
 
 # ---------------------------------------------------------------------------
@@ -141,6 +191,17 @@ def _questions_for_repo(questions: dict | list, repo_id: str) -> list[dict]:
     return [q for q in _all_questions(questions) if q.get("repo") == repo_id]
 
 
+def _limited_questions_for_repo(
+    questions: dict | list, repo_id: str, limit: int | None
+) -> list[dict]:
+    repo_questions = _questions_for_repo(questions, repo_id)
+    if limit is None:
+        return repo_questions
+    if limit < 1:
+        _die("--question-limit must be greater than zero")
+    return repo_questions[:limit]
+
+
 def _assert_question_matches_repo(question_entry: dict, repo_id: str) -> None:
     question_repo = question_entry.get("repo")
     if question_repo != repo_id:
@@ -154,6 +215,38 @@ def _repo_local_path(repo_entry: dict) -> Path:
     """Return the local path for a repo: .benchmark-repos/<id>."""
     repo_id: str = repo_entry["id"]
     return (BENCHMARKS_DIR / ".." / ".." / ".benchmark-repos" / repo_id).resolve()
+
+
+def _phase_to_matrix_args(args: argparse.Namespace) -> argparse.Namespace:
+    """Expand a named phase into the same namespace used by run-matrix."""
+    preset = PHASE_PRESETS.get(args.phase)
+    if preset is None:
+        known = ", ".join(sorted(PHASE_PRESETS))
+        _die(f"Unknown phase '{args.phase}'. Known phases: {known}")
+
+    repeats = args.repeats if args.repeats is not None else preset.repeats
+    if repeats < preset.min_repeats:
+        _die(f"Phase '{args.phase}' requires --repeats {preset.min_repeats} or higher.")
+
+    question_limit = (
+        args.question_limit
+        if args.question_limit is not None
+        else preset.question_limit
+    )
+    if question_limit is not None and question_limit < 1:
+        _die("--question-limit must be greater than zero")
+
+    return argparse.Namespace(
+        repos=args.repos or preset.repos,
+        arms=args.arms or preset.arms,
+        repeats=repeats,
+        question_limit=question_limit,
+        dry_run=args.dry_run,
+        agent_backend=args.agent_backend,
+        model=args.model,
+        timeout_seconds=args.timeout_seconds,
+        phase=args.phase,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -320,6 +413,9 @@ def cmd_run_matrix(args: argparse.Namespace) -> int:
         arm_entries = [_get_arm(arms_data, aid) for aid in args.arms.split(",")]
 
     repeats: int = args.repeats if hasattr(args, "repeats") and args.repeats else 1
+    question_limit = getattr(args, "question_limit", None)
+    if question_limit is not None and question_limit < 1:
+        _die("--question-limit must be greater than zero")
 
     # Lazy imports
     try:
@@ -331,7 +427,9 @@ def cmd_run_matrix(args: argparse.Namespace) -> int:
     RESULTS_DIR.mkdir(parents=True, exist_ok=True)
 
     question_entries_by_repo = {
-        repo_entry["id"]: _questions_for_repo(questions_data, repo_entry["id"])
+        repo_entry["id"]: _limited_questions_for_repo(
+            questions_data, repo_entry["id"], question_limit
+        )
         for repo_entry in repo_entries
     }
     total = (
@@ -415,6 +513,19 @@ def cmd_run_matrix(args: argparse.Namespace) -> int:
     )
     print(f"Results: {RESULTS_DIR / 'runs.jsonl'}", file=sys.stderr)
     return 0 if failed == 0 else 1
+
+
+def cmd_phase(args: argparse.Namespace) -> int:
+    """Run a named benchmark phase with reproducible defaults."""
+    matrix_args = _phase_to_matrix_args(args)
+    preset = PHASE_PRESETS[args.phase]
+    print(
+        f"[phase] {args.phase}: {preset.description} "
+        f"(repos={matrix_args.repos}, arms={matrix_args.arms}, "
+        f"repeats={matrix_args.repeats}, question_limit={matrix_args.question_limit})",
+        file=sys.stderr,
+    )
+    return cmd_run_matrix(matrix_args)
 
 
 def cmd_status(_args: argparse.Namespace) -> int:
@@ -515,6 +626,7 @@ def _build_parser() -> argparse.ArgumentParser:
             "--arms native-only,tsa-warm --repeats 3\n"
             "  python run.py run-matrix --repos all --arms all "
             "--repeats 1 --dry-run\n"
+            "  python run.py phase smoke --agent-backend codex --dry-run\n"
             "  python run.py status\n"
         ),
     )
@@ -618,6 +730,68 @@ def _build_parser() -> argparse.ArgumentParser:
         default=1200,
         help="Per-run timeout in seconds (default: 1200).",
     )
+    p_matrix.add_argument(
+        "--question-limit",
+        type=int,
+        default=None,
+        help="Limit questions per repo; useful for smoke runs.",
+    )
+
+    # ---- phase ----
+    p_phase = sub.add_parser(
+        "phase",
+        help="Run a named phase: smoke, pilot, full-warm, or cold.",
+    )
+    p_phase.add_argument(
+        "phase",
+        choices=sorted(PHASE_PRESETS),
+        help="Benchmark phase name.",
+    )
+    p_phase.add_argument(
+        "--repos",
+        default="",
+        help="Override phase repo set with comma-separated IDs or 'all'.",
+    )
+    p_phase.add_argument(
+        "--arms",
+        default="",
+        help="Override phase arms with comma-separated IDs or 'all'.",
+    )
+    p_phase.add_argument(
+        "--repeats",
+        type=int,
+        default=None,
+        help="Override phase repeat count.",
+    )
+    p_phase.add_argument(
+        "--question-limit",
+        type=int,
+        default=None,
+        help="Override phase question limit per repo.",
+    )
+    p_phase.add_argument(
+        "--dry-run",
+        action="store_true",
+        dest="dry_run",
+        help="Build prompts and record stubs without calling an agent CLI.",
+    )
+    p_phase.add_argument(
+        "--agent-backend",
+        choices=["claude", "codex"],
+        default="claude",
+        help="Agent CLI backend to execute each run (default: claude).",
+    )
+    p_phase.add_argument(
+        "--model",
+        default=None,
+        help="Model name for the selected agent backend.",
+    )
+    p_phase.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=1200,
+        help="Per-run timeout in seconds (default: 1200).",
+    )
 
     # ---- status ----
     sub.add_parser("status", help="Show prepared repos and last run statistics.")
@@ -639,6 +813,7 @@ def main(argv: list[str] | None = None) -> int:
         "prepare": cmd_prepare,
         "run": cmd_run,
         "run-matrix": cmd_run_matrix,
+        "phase": cmd_phase,
         "status": cmd_status,
     }
 

--- a/tests/unit/test_benchmark_harness.py
+++ b/tests/unit/test_benchmark_harness.py
@@ -14,6 +14,7 @@ import sqlite3
 import sys
 import textwrap
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -26,6 +27,8 @@ if str(_BENCH_DIR) not in sys.path:
 import bench_runner  # noqa: E402
 import scenarios  # noqa: E402
 
+from benchmarks.codegraph_compare import analyze as compare_analyze  # noqa: E402
+from benchmarks.codegraph_compare import run as compare_run  # noqa: E402
 from benchmarks.codegraph_compare.adapters import IndexStats  # noqa: E402
 from benchmarks.codegraph_compare.adapters.tree_sitter_analyzer import (  # noqa: E402
     TSAAdapter,
@@ -244,6 +247,31 @@ class TestCodeGraphCompareTSAAdapter:
         assert result.file_count == 1
         build_cache.assert_not_called()
 
+    def test_parse_tool_metrics_counts_multiple_annotated_bash_calls_once(self):
+        transcript = textwrap.dedent(
+            """
+            Tool: Bash
+            uv run --project /repo python -m tree_sitter_analyzer --codegraph-query "search('Router')"
+            Tool: Bash
+            rg Router
+            Tool: Read
+            src/router.ts
+            """
+        ).strip()
+
+        result = TSAAdapter().parse_tool_metrics(transcript)
+
+        assert result.tool_calls == 3
+        assert result.index_queries == 1
+        assert result.search_calls == 1
+        assert result.file_reads == 1
+
+    def test_run_config_promotes_chain_query_first(self, tmp_path: Path):
+        config = TSAAdapter().build_run_config(tmp_path, "Where is routing handled?")
+
+        assert "--codegraph-query" in config.extra_context
+        assert "search('<symbol-or-concept>').explore" in config.extra_context
+
 
 class TestCodeGraphCompareToolPolicy:
     def test_tsa_arms_are_index_first(self):
@@ -286,3 +314,80 @@ class TestCodeGraphCompareToolPolicy:
 
         assert "TSA is the index" in prompt
         assert "invalidates the benchmark" in prompt
+        assert "--codegraph-query" in prompt
+        assert "flow(" not in prompt
+        assert ".answer(" not in prompt
+
+
+class TestCodeGraphComparePhases:
+    def test_smoke_phase_expands_to_one_question_dry_run_defaults(self):
+        args = SimpleNamespace(
+            phase="smoke",
+            repos="",
+            arms="",
+            repeats=None,
+            question_limit=None,
+            dry_run=True,
+            agent_backend="codex",
+            model=None,
+            timeout_seconds=1200,
+        )
+
+        matrix_args = compare_run._phase_to_matrix_args(args)
+
+        assert matrix_args.repos == "gin"
+        assert matrix_args.arms == "all"
+        assert matrix_args.repeats == 1
+        assert matrix_args.question_limit == 1
+        assert matrix_args.dry_run is True
+        assert matrix_args.agent_backend == "codex"
+
+    def test_pilot_phase_rejects_too_few_repeats(self):
+        args = SimpleNamespace(
+            phase="pilot",
+            repos="",
+            arms="",
+            repeats=1,
+            question_limit=None,
+            dry_run=True,
+            agent_backend="codex",
+            model=None,
+            timeout_seconds=1200,
+        )
+
+        with pytest.raises(SystemExit):
+            compare_run._phase_to_matrix_args(args)
+
+
+class TestCodeGraphCompareAnalysisGate:
+    def test_gate_flags_failed_and_low_quality_arms(self):
+        runs = [
+            {
+                "_arm": "codex/tsa-warm",
+                "answer": "ok",
+                "error": "",
+                "_quality": 4.0,
+            },
+            {
+                "_arm": "codex/tsa-warm",
+                "answer": "ok",
+                "error": "timeout",
+                "_quality": 4.0,
+            },
+            {
+                "_arm": "codex/native-only",
+                "answer": "ok",
+                "error": "",
+                "_quality": 2.0,
+            },
+        ]
+
+        violations = compare_analyze.gate_violations(runs, has_evals=True)
+
+        assert any(
+            "codex/tsa-warm" in item and "failure rate" in item for item in violations
+        )
+        assert any(
+            "codex/native-only" in item and "below quality" in item
+            for item in violations
+        )


### PR DESCRIPTION
## Summary
- add phase presets for the CodeGraph comparison harness: smoke, pilot, full-warm, and cold
- pin all seven benchmark repos to concrete commits and fix README quick start commands
- make the TSA benchmark arm prefer the chained --codegraph-query path, add an industry benchmark gate, and fix TSA Bash tool metrics counting

## Verification
- uv run ruff check benchmarks/codegraph_compare/run.py benchmarks/codegraph_compare/analyze.py benchmarks/codegraph_compare/adapters/tree_sitter_analyzer.py tests/unit/test_benchmark_harness.py
- uv run pytest tests/unit/test_benchmark_harness.py -q
- uv run python benchmarks/codegraph_compare/run.py phase smoke --agent-backend codex --dry-run --timeout-seconds 60
- uv run python -m tree_sitter_analyzer --change-impact --format json
- uv run pytest -q (17808 passed, 104 skipped, 2 xfailed in 79.54s)

## Notes
- The first full-suite attempt failed because the fresh local venv did not have the Swift extra installed; after resolving that local environment gap, the failed subset and the full suite both passed.