### PR TITLE
fix(codegraph): index large repo hot paths

### DIFF
--- a/tests/unit/mcp/tools/test_tool_response_contract.py
+++ b/tests/unit/mcp/tools/test_tool_response_contract.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -73,6 +74,77 @@ class TestEnvelopeSuccess:
         tool = ASTCacheTool(str(tiny_project))
         result = _run(tool.execute({"mode": "stats"}))
         validate_tool_response(result, "ast_cache:stats")
+
+    def test_codegraph_metrics_call_graph_is_read_only_on_cold_cache(
+        self, tiny_project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from tree_sitter_analyzer.mcp.tools import codegraph_metrics_tool
+        from tree_sitter_analyzer.mcp.tools.codegraph_metrics_tool import (
+            CodeGraphMetricsTool,
+        )
+
+        monkeypatch.setattr(
+            codegraph_metrics_tool, "ensure_indexed", lambda *_, **__: None
+        )
+
+        tool = CodeGraphMetricsTool(str(tiny_project))
+        result = _run(
+            tool.execute({"sections": ["call_graph"], "output_format": "json"})
+        )
+
+        validate_tool_response(result, "codegraph_metrics")
+        assert result["success"] is True
+        assert result["call_graph"]["status"] == "empty"
+        assert result["call_graph"]["data_source"] == "none"
+
+    def test_codegraph_metrics_call_graph_uses_cached_graph(
+        self, tiny_project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from tree_sitter_analyzer import call_graph
+        from tree_sitter_analyzer.mcp.tools import codegraph_metrics_tool
+        from tree_sitter_analyzer.mcp.tools.codegraph_metrics_tool import (
+            CodeGraphMetricsTool,
+        )
+
+        fake_cache = object()
+        monkeypatch.setattr(
+            codegraph_metrics_tool, "ensure_indexed", lambda *_, **__: fake_cache
+        )
+
+        class FakeCachedCallGraph:
+            def __init__(self, project_root: str, cache: object) -> None:
+                assert project_root == str(tiny_project)
+                assert cache is fake_cache
+                self._call_edges = [
+                    (
+                        SimpleNamespace(file_path="main.py", name="entry"),
+                        SimpleNamespace(file_path="main.py", name="helper"),
+                        2,
+                    )
+                ]
+
+            def build(self) -> None:
+                self.built = True
+
+            def all_functions(self) -> list[dict[str, str]]:
+                return [
+                    {"file_path": "main.py", "name": "entry"},
+                    {"file_path": "main.py", "name": "helper"},
+                ]
+
+        monkeypatch.setattr(call_graph, "CachedCallGraph", FakeCachedCallGraph)
+
+        tool = CodeGraphMetricsTool(str(tiny_project))
+        result = _run(
+            tool.execute({"sections": ["call_graph"], "output_format": "json"})
+        )
+
+        validate_tool_response(result, "codegraph_metrics")
+        assert result["success"] is True
+        assert result["call_graph"]["status"] == "computed"
+        assert result["call_graph"]["total_functions"] == 2
+        assert result["call_graph"]["total_call_edges"] == 1
+        assert result["call_graph"]["data_source"] == "ast_cache"
 
 
 class TestEnvelopeFailure:

--- a/tests/unit/test_ast_cache.py
+++ b/tests/unit/test_ast_cache.py
@@ -33,6 +33,11 @@ def cache(tmp_project):
     c.close()
 
 
+def _query_plan(conn: sqlite3.Connection, sql: str, params: tuple[str, ...]) -> str:
+    rows = conn.execute(f"EXPLAIN QUERY PLAN {sql}", params).fetchall()
+    return " ".join(str(row[3]) for row in rows)
+
+
 class TestContentHash:
     def test_deterministic(self):
         assert _content_hash("hello") == _content_hash("hello")
@@ -270,6 +275,110 @@ class TestStats:
 
         ASTCache._clear_activation_for_file(conn, "src/main.py")
 
+        conn.close()
+
+
+class TestLargeRepoHotPathIndexes:
+    def test_large_repo_hot_path_indexes_exist(self, cache):
+        if not cache._fts5_available:
+            pytest.skip("tracked: large-repo-hotpath-indexes require FTS5")
+        conn = cache._get_conn()
+        index_names = {
+            row["name"]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'index'"
+            ).fetchall()
+        }
+
+        assert "idx_sym_rows_name_kind_path_line" in index_names
+        assert "idx_sym_rows_file_name_kind_line" in index_names
+        assert "idx_ce_callee_name_resolved_file" in index_names
+        assert "idx_ce_callee_name_file_path" in index_names
+        assert "idx_ce_caller_name_file" in index_names
+
+    def test_symbol_resolver_hot_queries_use_composite_indexes(self, cache):
+        if not cache._fts5_available:
+            pytest.skip("tracked: large-repo-hotpath-indexes require FTS5")
+        conn = cache._get_conn()
+
+        symbol_plan = _query_plan(
+            conn,
+            """SELECT name, kind, file_path, language, line, end_line
+               FROM ast_symbol_rows
+               WHERE name = ? AND kind IN ('function', 'class', 'method', 'variable')
+               ORDER BY file_path, line""",
+            ("target",),
+        )
+        scoped_symbol_plan = _query_plan(
+            conn,
+            """SELECT name, kind, file_path, language, line, end_line
+               FROM ast_symbol_rows
+               WHERE file_path = ? AND name = ? AND kind IN ('function', 'class', 'method')
+               ORDER BY line""",
+            ("src/main.py", "target"),
+        )
+
+        assert "idx_sym_rows_name_kind_path_line" in symbol_plan
+        assert "idx_sym_rows_file_name_kind_line" in scoped_symbol_plan
+
+    def test_call_graph_hot_queries_use_composite_indexes(self, cache):
+        conn = cache._get_conn()
+
+        callers_plan = _query_plan(
+            conn,
+            """SELECT caller_name, caller_file, caller_line,
+                      callee_name, file_path, callee_line, callee_resolved_file
+               FROM ast_call_edges
+               WHERE callee_name = ? AND callee_resolved_file = ?""",
+            ("render", "src/view.py"),
+        )
+        callers_fallback_plan = _query_plan(
+            conn,
+            """SELECT caller_name, caller_file, caller_line,
+                      callee_name, file_path, callee_line, callee_resolved_file
+               FROM ast_call_edges
+               WHERE callee_name = ? AND file_path = ?""",
+            ("render", "src/view.py"),
+        )
+        callees_plan = _query_plan(
+            conn,
+            """SELECT caller_name, caller_file, caller_line,
+                      callee_name, callee_full, file_path, callee_line, callee_resolved_file
+               FROM ast_call_edges
+               WHERE caller_name = ? AND caller_file = ?""",
+            ("handle", "src/handler.py"),
+        )
+
+        assert "idx_ce_callee_name_resolved_file" in callers_plan
+        assert "idx_ce_callee_name_file_path" in callers_fallback_plan
+        assert "idx_ce_caller_name_file" in callees_plan
+
+    def test_large_repo_index_helper_skips_missing_tables(self):
+        conn = sqlite3.connect(":memory:")
+
+        ASTCache._ensure_large_repo_indexes(conn)
+
+        assert (
+            conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'index'"
+            ).fetchall()
+            == []
+        )
+        conn.close()
+
+    def test_large_repo_index_helper_tolerates_legacy_partial_tables(self):
+        conn = sqlite3.connect(":memory:")
+        conn.execute("CREATE TABLE ast_call_edges (callee_name TEXT)")
+
+        ASTCache._ensure_large_repo_indexes(conn)
+
+        index_names = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'index'"
+            ).fetchall()
+        }
+        assert "idx_ce_callee_name_resolved_file" not in index_names
         conn.close()
 
 

--- a/tests/unit/test_call_graph_impact.py
+++ b/tests/unit/test_call_graph_impact.py
@@ -173,6 +173,7 @@ class TestChangeImpactIntegration:
                     diff_stat="1 file changed",
                     project_root=tmpdir,
                     include_tests=True,
+                    agent_summary_only=True,
                 )
                 result = _build_change_impact_result(req)
                 assert "call_graph_impact" in result

--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -196,6 +196,38 @@ CREATE INDEX IF NOT EXISTS idx_cv_severity
 """
 
 
+# Large-repo hot-path indexes. These are deliberately versionless and
+# idempotent: adding an index does not change row shape, but existing caches
+# still need to pick it up when opened after an upgrade.
+_LARGE_REPO_INDEXES: tuple[tuple[str, str], ...] = (
+    (
+        "ast_symbol_rows",
+        "CREATE INDEX IF NOT EXISTS idx_sym_rows_name_kind_path_line "
+        "ON ast_symbol_rows(name, kind, file_path, line)",
+    ),
+    (
+        "ast_symbol_rows",
+        "CREATE INDEX IF NOT EXISTS idx_sym_rows_file_name_kind_line "
+        "ON ast_symbol_rows(file_path, name, kind, line)",
+    ),
+    (
+        "ast_call_edges",
+        "CREATE INDEX IF NOT EXISTS idx_ce_callee_name_resolved_file "
+        "ON ast_call_edges(callee_name, callee_resolved_file)",
+    ),
+    (
+        "ast_call_edges",
+        "CREATE INDEX IF NOT EXISTS idx_ce_callee_name_file_path "
+        "ON ast_call_edges(callee_name, file_path)",
+    ),
+    (
+        "ast_call_edges",
+        "CREATE INDEX IF NOT EXISTS idx_ce_caller_name_file "
+        "ON ast_call_edges(caller_name, caller_file)",
+    ),
+)
+
+
 # Schema-version registry — the "did every migration block actually apply?"
 # self-check. Earlier this sprint a parallel agent edit clobbered V4's two
 # ALTER TABLE statements down to one, and nothing detected it until a
@@ -439,11 +471,26 @@ class ASTCache:
                 conn.commit()
             except sqlite3.OperationalError:
                 pass
+        self._ensure_large_repo_indexes(conn)
         conn.commit()
         # Post-init self-check — raise SchemaIntegrityError if any
         # expected table / column is missing. Backfills the version
         # registry for legacy DBs that pre-date this code.
         self._verify_schema_integrity(conn)
+
+    @staticmethod
+    def _ensure_large_repo_indexes(conn: sqlite3.Connection) -> None:
+        """Create non-shape-changing indexes for large-repo query hot paths."""
+        for table_name, sql in _LARGE_REPO_INDEXES:
+            try:
+                exists = conn.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+                    (table_name,),
+                ).fetchone()
+                if exists:
+                    conn.execute(sql)
+            except sqlite3.OperationalError:
+                logger.debug("Skipping optional index for table %s", table_name)
 
     @staticmethod
     def _already_applied_versions(conn: sqlite3.Connection) -> set[int]:

--- a/tree_sitter_analyzer/mcp/tools/codegraph_metrics_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_metrics_tool.py
@@ -183,15 +183,17 @@ class CodeGraphMetricsTool(BaseMCPTool):
             return {"status": "error", "error": str(exc)}
 
     def _collect_call_graph_metrics(self, cache: Any) -> dict[str, Any]:
+        if cache is None:
+            return {
+                "status": "empty",
+                "hint": "Run ast_cache mode=index first",
+                "data_source": "none",
+            }
         try:
-            from ...call_graph import CachedCallGraph, CallGraph
+            from ...call_graph import CachedCallGraph
 
             assert self.project_root is not None, "project_root required"
-            cg: CallGraph
-            if cache is not None:
-                cg = CachedCallGraph(self.project_root, cache=cache)
-            else:
-                cg = CallGraph(self.project_root)
+            cg = CachedCallGraph(self.project_root, cache=cache)
             cg.build()
 
             # Use the public ``all_functions()`` API (returns list[dict]) and
@@ -237,7 +239,7 @@ class CodeGraphMetricsTool(BaseMCPTool):
                 "dead_code_candidates": len(dead),
                 "top_hub_functions": [{"name": n, "callers": c} for n, c in top_hubs],
                 "files_with_functions": len(files),
-                "data_source": "ast_cache" if cache is not None else "on_demand",
+                "data_source": "ast_cache",
             }
         except Exception as exc:
             return {"status": "error", "error": str(exc)}


### PR DESCRIPTION
## Summary
- add idempotent composite SQLite indexes for large-repo symbol and call-edge query paths
- stop codegraph_metrics from building an on-demand call graph when the AST cache is cold
- add query-plan and cold-cache regression tests

## Verification
- uv run ruff check tree_sitter_analyzer/ast_cache.py tree_sitter_analyzer/mcp/tools/codegraph_metrics_tool.py tests/unit/test_ast_cache.py tests/unit/mcp/tools/test_tool_response_contract.py
- uv run pytest tests/unit/test_ast_cache.py::TestLargeRepoHotPathIndexes tests/unit/mcp/tools/test_tool_response_contract.py::TestEnvelopeSuccess::test_codegraph_metrics_call_graph_is_read_only_on_cold_cache -q
- uv run pytest tests/unit/test_ast_cache.py tests/unit/mcp/tools/test_tool_response_contract.py tests/e2e/test_mcp_smoke.py::TestToolLatencyBudgets::test_codegraph_metrics_cold_cache_under_5s -q
- uv run python -m tree_sitter_analyzer --change-impact --format json
- uv run pytest tests/integration/test_ast_cache_lifecycle.py tests/unit/mcp/test_ast_cache_watch_modes.py tests/unit/mcp/tools/test_tool_response_contract.py tests/unit/test_ast_cache.py tests/unit/test_ast_cache_mode_used.py tests/unit/test_ast_cache_tool.py tests/unit/test_ast_cache_utf8_bug.py -q
- uv run pytest -q (17807 passed, 104 skipped, 2 xfailed, 1 rerun in 86.50s)

## Notes
- Fresh local venvs need the Swift optional parser installed before full-suite verification; I used  once, then ran the locked full-suite command.