### PR TITLE
feat(codegraph): enrich chained query answer packs

### DIFF
--- a/benchmarks/codegraph_compare/adapters/tree_sitter_analyzer.py
+++ b/benchmarks/codegraph_compare/adapters/tree_sitter_analyzer.py
@@ -37,7 +37,7 @@ You may run ``python -m tree_sitter_analyzer <subcommand> --format json``
 via Bash to query the AST cache. Treat TSA output as already-read evidence.
 
 When answering:
-- Start with codegraph-query for the relevant symbol or concept.
+- Start with one codegraph-query answer pack for the relevant symbol or concept.
 - Do not use raw grep/find/rg/read for discovery; TSA is the index.
 - Use at most one narrow raw file read only if TSA output misses a required
   detail, and explain the miss.
@@ -141,7 +141,8 @@ class TSAAdapter(BenchmarkAdapter):
             "tree-sitter-analyzer is available through this command prefix: "
             f"`{command_prefix}`. "
             "Run it from the benchmark repo root with `--project-root .`. "
-            "Useful queries: `--codegraph-query \"search('<symbol-or-concept>').explore(max_files=5).related(limit=8)\"`, "
+            "Useful query: `--codegraph-query \"search('<symbol-or-concept>').explore(max_files=5, max_symbols=8, include_code=True).include(source=True, callers=True, callees=True, complexity=True, health=True, affected_tests=True, risk=True, max_files=5, limit=8).sort(by='fan_in', desc=True).answer()\"`. "
+            "Fallbacks: "
             "`--symbol-search <name>`, `--codegraph-explore <query>`, "
             "`--codegraph-overview`, and `--call-graph callers|callees "
             "--call-graph-function <name>`. "

--- a/benchmarks/codegraph_compare/prompts/system_tsa.md
+++ b/benchmarks/codegraph_compare/prompts/system_tsa.md
@@ -5,7 +5,7 @@ You are answering architecture questions about a software codebase. You have acc
 The benchmark prompt includes the exact command prefix to use. Always use that prefix, run commands from the benchmark repo root, and pass `--project-root . --format json`.
 
 Workflow:
-1. Run `... --codegraph-query "search('<symbol-or-concept>').explore(max_files=5).related(limit=8)" --project-root . --format json` FIRST. Treat its answer pack, source snippets, and line numbers as already-read evidence.
+1. Run `... --codegraph-query "search('<symbol-or-concept>').explore(max_files=5, max_symbols=8, include_code=True).include(source=True, callers=True, callees=True, complexity=True, health=True, affected_tests=True, risk=True, max_files=5, limit=8).sort(by='fan_in', desc=True).answer()" --project-root . --format json` FIRST. Treat its answer pack, source snippets, facets, and line numbers as already-read evidence.
 2. Use `... --symbol-search "<exact-symbol>" --project-root . --format json` only when you need to disambiguate a symbol name returned by the chain query.
 3. Use `... --codegraph-explore "<symbol-or-concept>" --project-root . --format json` only as a fallback if the chain query returns no useful evidence.
 4. Use `... --call-graph callers|callees --call-graph-function <symbol> --project-root . --format json` only for a concrete call-flow hop from a known symbol.

--- a/docs/CODEMAPS/cli.md
+++ b/docs/CODEMAPS/cli.md
@@ -89,7 +89,7 @@ Categories of CLI surface:
 - `--ast-path FILE:LINE` — "what is at file:line?"
 - `--codegraph-symbol-search QUERY` — FTS5 symbol search
 - `--codegraph-explore QUERY` — bulk-fetch N related symbols + relmap (CodeGraph parity)
-- `--codegraph-query CHAIN` — jQuery-style chained graph query (`search().explore().callees()`)
+- `--codegraph-query CHAIN` — jQuery-style chained graph query (`search(['A','B']).explore().include(callers=True).sort(by='fan_in').answer()`)
 - `--affected FILE [FILE...]` — list test files transitively affected by changes (CodeGraph parity; closes the last CLI surface gap)
 - `--dead-code` — transitive dead functions / unused imports
 - `--class-hierarchy` / `--dependency-matrix` / `--import-graph` — structural

--- a/docs/CODEMAPS/mcp-tools.md
+++ b/docs/CODEMAPS/mcp-tools.md
@@ -44,7 +44,7 @@ All tools default to **TOON output** (locked — see `CLAUDE.md`).
 | **CodeGraph parity — symbol navigation** | | |
 | `codegraph_navigate` | `--codegraph-navigate` | PRIMARY symbol navigation hub (def + refs + hierarchy) |
 | `codegraph_explore` | `--codegraph-explore` | BULK fetch N related symbols' source + relationship map |
-| `codegraph_query` | `--codegraph-query` | jQuery-style chained graph query |
+| `codegraph_query` | `--codegraph-query` | jQuery-style chained graph query with batch seeds, sorting, and evidence facets |
 | `codegraph_symbol_search` | `--codegraph-symbol-search` | FTS5-powered symbol search over indexed project |
 | `codegraph_resolve` | `--symbol-resolve` | Go-to-definition / find-all-references |
 | `codegraph_ast_path` | `--ast-path` | "What is at file:line?" AST path/scope |

--- a/tests/unit/test_benchmark_harness.py
+++ b/tests/unit/test_benchmark_harness.py
@@ -316,7 +316,7 @@ class TestCodeGraphCompareToolPolicy:
         assert "invalidates the benchmark" in prompt
         assert "--codegraph-query" in prompt
         assert "flow(" not in prompt
-        assert ".answer(" not in prompt
+        assert ".answer()" in prompt
 
 
 class TestCodeGraphComparePhases:

--- a/tests/unit/test_codegraph_query_tool.py
+++ b/tests/unit/test_codegraph_query_tool.py
@@ -12,14 +12,23 @@ from tree_sitter_analyzer.mcp.tools._codegraph_query_dsl import (
     first_int,
     first_str,
     int_kw,
+    string_args,
 )
 from tree_sitter_analyzer.mcp.tools.codegraph_query_tool import (
     CodeGraphQueryTool,
+    _absolute_path,
+    _affected_tests_facet,
     _build_file_entries,
+    _complexity_facet,
     _dedupe_symbols,
+    _health_facet,
+    _include_facets,
     _QueryState,
     _relation_step,
+    _resolve_queries,
     _resolve_query,
+    _risk_facet,
+    _sort_state,
     parse_chain,
 )
 from tree_sitter_analyzer.symbol_resolver import DefinitionLocation, ResolveResult
@@ -74,6 +83,21 @@ class TestParseChain:
         with pytest.raises(ValueError, match="unsupported chain step"):
             parse_chain("search('x').delete()")
 
+    def test_parses_batch_seed_and_answer_pack_steps(self):
+        steps = parse_chain(
+            "search(['Router', 'Handler']).include(callers=True, source=True)"
+            ".sort(by='fan_in', desc=True).answer()"
+        )
+
+        assert [step.name for step in steps] == [
+            "search",
+            "include",
+            "sort",
+            "answer",
+        ]
+        assert string_args(steps[0], required=True) == ["Router", "Handler"]
+        assert steps[1].kwargs == {"callers": True, "source": True}
+
     def test_parses_kwargs_and_escaped_quotes(self):
         steps = parse_chain(r'search(query="src/a.\"b.py Run").take(2)')
 
@@ -86,7 +110,9 @@ class TestParseChain:
             ("search('x'))", r"unbalanced '\)'"),
             ("search('x)", "unbalanced quote or parentheses"),
             ("search('x').callers", "invalid chain step"),
-            ("search(['x'])", "chain arguments must be scalar literals"),
+            ("search({'x': 1})", "chain arguments must be scalar literals"),
+            ("search('x', **{'limit': 1})", r"does not support \*\*kwargs"),
+            ("search('x', unknown=True)", "does not support keyword"),
         ],
     )
     def test_rejects_malformed_chains(self, query, match):
@@ -107,9 +133,41 @@ class TestParseChain:
         assert int_kw(_ChainStep("search", [], {"limit": 99}), "limit", 7, 10) == 10
         assert bool_kw(step, "enabled", default=True) is False
         assert bool_kw(_ChainStep("explore", [], {}), "include_code", True) is True
+        assert string_args(_ChainStep("search", [["a", "b"]], {}), required=True) == [
+            "a",
+            "b",
+        ]
 
         with pytest.raises(ValueError, match=r"search\(\) requires a string query"):
             first_str(_ChainStep("search", [], {}), required=True)
+
+    @pytest.mark.parametrize(
+        ("query", "match"),
+        [
+            ("x" * 4097 + "()", "query exceeds"),
+            (".".join(["answer()"] * 21), "query exceeds 20 chain steps"),
+            ("search(['ok', 1])", "list arguments must contain only strings"),
+            ("search(" + repr(["x"] * 9) + ")", "list arguments must contain <= 8"),
+            ("search(" + repr("x" * 161) + ")", "string arguments must be <= 160"),
+            (
+                "search(" + repr(["ok", "x" * 161]) + ")",
+                "string arguments must be <= 160",
+            ),
+        ],
+    )
+    def test_parser_rejects_guardrail_violations(self, query, match):
+        with pytest.raises(ValueError, match=match):
+            parse_chain(query)
+
+    def test_argument_helpers_cover_keyword_lists_and_limits(self):
+        step = _ChainStep("search", ["positional"], {"query": ["kw1", "kw2"]})
+
+        assert string_args(step, required=True) == ["kw1", "kw2"]
+        assert (
+            first_str(_ChainStep("search", ["needle"], {}), required=True) == "needle"
+        )
+        assert first_str(_ChainStep("include", [], {}), required=False) == ""
+        assert first_int(_ChainStep("take", [], {"limit": 4}), default=9) == 4
 
 
 class TestCodeGraphQueryTool:
@@ -312,6 +370,61 @@ class TestCodeGraphQueryTool:
         assert result["success"] is True
         assert [symbol["name"] for symbol in result["symbols"]] == ["run"]
 
+    @pytest.mark.asyncio
+    async def test_execute_batch_seed_include_sort_and_answer(self, tmp_path):
+        source = tmp_path / "main.py"
+        source.write_text(
+            "def run():\n    return helper()\n\ndef helper():\n    return 1\n",
+            encoding="utf-8",
+        )
+        mock_cache = MagicMock()
+        mock_cache.query_callers.return_value = [
+            {
+                "caller_name": "entry",
+                "caller_file": "tests/test_main.py",
+                "caller_line": 8,
+                "depth": 1,
+            }
+        ]
+        mock_cache.query_callees.return_value = [
+            {
+                "callee_name": "helper",
+                "callee_file": "main.py",
+                "callee_line": 4,
+                "depth": 1,
+            }
+        ]
+
+        defs = {
+            "run": [_make_def(file="main.py", name="run", line=1)],
+            "helper": [_make_def(file="main.py", name="helper", line=4)],
+        }
+
+        with (
+            patch("tree_sitter_analyzer.ast_cache.ASTCache", return_value=mock_cache),
+            _patch_resolver_with(defs),
+        ):
+            result = await CodeGraphQueryTool(str(tmp_path)).execute(
+                {
+                    "query": (
+                        "search(['run', 'helper']).explore(max_files=2)"
+                        ".include(source=True, callers=True, callees=True, "
+                        "affected_tests=True, risk=True)"
+                        ".sort(by='fan_in', desc=True).answer()"
+                    ),
+                    "output_format": "json",
+                }
+            )
+
+        assert result["success"] is True
+        assert result["stats"]["facets_returned"] == 5
+        assert result["facets"]["source"]["file_count"] == 1
+        assert result["facets"]["callers"]["edges"]
+        assert result["facets"]["callees"]["edges"]
+        assert result["facets"]["affected_tests"]["files"] == ["tests/test_main.py"]
+        assert result["facets"]["risk"]["level"] == "info"
+        assert result["normalized_chain"][-1]["name"] == "answer"
+
     def test_apply_step_rejects_unknown_step(self):
         with pytest.raises(ValueError, match="unsupported chain step"):
             CodeGraphQueryTool("/tmp")._apply_step(
@@ -345,6 +458,21 @@ class TestCodeGraphQueryInternals:
         ):
             assert _resolve_query(MagicMock(), "run", limit=5) == []
 
+    def test_resolve_queries_stops_at_limit_and_dedupes(self):
+        defs = {
+            "run": [
+                _make_def(file="main.py", name="run", line=1),
+                _make_def(file="main.py", name="run", line=1),
+            ],
+            "helper": [_make_def(file="helper.py", name="helper", line=3)],
+        }
+
+        with _patch_resolver_with(defs):
+            assert [
+                symbol["name"]
+                for symbol in _resolve_queries(MagicMock(), ["run", "helper"], limit=1)
+            ] == ["run"]
+
     def test_relation_step_skips_symbols_without_names_and_empty_rows(self):
         mock_cache = MagicMock()
         mock_cache.query_callers.return_value = [
@@ -372,6 +500,24 @@ class TestCodeGraphQueryInternals:
         assert [symbol["name"] for symbol in related] == ["entry"]
         mock_cache.query_callers.assert_called_once_with("run", "main.py", max_depth=1)
         assert state.relationships["callers"]["main.py:2:run"][0]["name"] == "entry"
+
+    def test_sort_state_supports_path_alias_fan_out_and_rejects_unknown_fields(self):
+        state = _QueryState()
+        state.current = [
+            {"file": "b.py", "line": 2, "name": "b"},
+            {"file": "a.py", "line": 1, "name": "a"},
+        ]
+        state.symbols = list(state.current)
+        state.relationships["callees"] = {"a.py:1:a": [{}, {}], "b.py:2:b": [{}]}
+
+        _sort_state(state, _ChainStep("sort", [], {"by": "path"}))
+        assert [symbol["file"] for symbol in state.current] == ["a.py", "b.py"]
+
+        _sort_state(state, _ChainStep("sort", [], {"by": "fan_out", "desc": True}))
+        assert [symbol["name"] for symbol in state.current] == ["a", "b"]
+
+        with pytest.raises(ValueError, match="unsupported field"):
+            _sort_state(state, _ChainStep("sort", [], {"by": "unknown"}))
 
     def test_build_file_entries_skips_blank_files_and_omits_oversized_snippets(
         self, tmp_path
@@ -410,6 +556,109 @@ class TestCodeGraphQueryInternals:
                 ],
             }
         ]
+
+    def test_include_facets_collects_quality_health_tests_and_risk(self, tmp_path):
+        source = tmp_path / "main.py"
+        source.write_text("def run():\n    return 1\n", encoding="utf-8")
+        mock_cache = MagicMock()
+        mock_cache.query_callers.return_value = [
+            {"caller_name": f"caller_{i}", "caller_file": f"c{i}.py", "caller_line": i}
+            for i in range(10)
+        ]
+        mock_cache.query_callees.return_value = [
+            {"callee_name": "helper", "callee_file": "helper.py", "callee_line": 7}
+        ]
+        state = _QueryState()
+        state.current = [
+            {"file": "main.py", "line": 1, "name": "run", "kind": "function"},
+            {
+                "file": "tests/test_main.py",
+                "line": 3,
+                "name": "test_run",
+                "kind": "function",
+            },
+        ]
+        state.symbols = list(state.current)
+
+        complexity_row = MagicMock(name="run", line=1, complexity=22)
+        health_score = MagicMock(total=51, grade="D", dimensions={"complexity": 20})
+        with (
+            patch(
+                "tree_sitter_analyzer.complexity_heatmap."
+                "analyze_file_complexity_from_cache",
+                return_value=[complexity_row],
+            ),
+            patch("tree_sitter_analyzer.health_scorer.HealthScorer") as scorer_cls,
+        ):
+            scorer_cls.return_value.score_file.return_value = health_score
+            _include_facets(
+                cache=mock_cache,
+                project_root=str(tmp_path),
+                state=state,
+                step=_ChainStep(
+                    "include",
+                    [],
+                    {
+                        "source": True,
+                        "callers": True,
+                        "callees": True,
+                        "complexity": True,
+                        "health": True,
+                        "affected_tests": True,
+                        "risk": True,
+                        "include_code": False,
+                    },
+                ),
+                default_max_symbols=10,
+                default_max_files=5,
+                default_include_code=True,
+            )
+
+        assert set(state.facets) == {
+            "source",
+            "callers",
+            "callees",
+            "complexity",
+            "health",
+            "affected_tests",
+            "risk",
+        }
+        assert state.facets["complexity"]["files"][0]["max_complexity"] == 22
+        assert state.facets["health"]["files"][0]["grade"] == "D"
+        assert state.facets["affected_tests"]["files"] == ["tests/test_main.py"]
+        assert state.facets["risk"]["level"] == "review"
+
+    def test_quality_facets_cover_empty_error_and_missing_paths(self, tmp_path):
+        symbols = [{"file": "main.py", "line": 1, "name": "run"}]
+
+        with patch(
+            "tree_sitter_analyzer.complexity_heatmap.analyze_file_complexity_from_cache",
+            side_effect=[[], RuntimeError("boom")],
+        ):
+            result = _complexity_facet(
+                MagicMock(),
+                str(tmp_path),
+                [*symbols, {"file": "other.py", "line": 2, "name": "other"}],
+                max_files=2,
+            )
+
+        assert result["files"][0]["status"] == "no_functions"
+        assert result["files"][1]["status"] == "error"
+
+        with patch("tree_sitter_analyzer.health_scorer.HealthScorer") as scorer_cls:
+            scorer_cls.return_value.score_file.side_effect = RuntimeError("bad health")
+            health = _health_facet(str(tmp_path), symbols, max_files=1)
+
+        assert health["files"] == [
+            {"file": "main.py", "status": "error", "error": "bad health"}
+        ]
+
+        empty_state = _QueryState()
+        assert _affected_tests_facet(empty_state)["status"] == "missing"
+        assert _risk_facet(empty_state)["level"] == "info"
+        assert _absolute_path(str(tmp_path), str(tmp_path / "main.py")) == str(
+            tmp_path / "main.py"
+        )
 
     def test_dedupe_symbols_keeps_first_instance(self):
         symbols = [

--- a/tree_sitter_analyzer/mcp/tools/_codegraph_query_dsl.py
+++ b/tree_sitter_analyzer/mcp/tools/_codegraph_query_dsl.py
@@ -7,7 +7,62 @@ import re
 from dataclasses import dataclass
 from typing import Any
 
-_SUPPORTED_STEPS = {"search", "explore", "callers", "callees", "related", "take"}
+_MAX_QUERY_LENGTH = 4096
+_MAX_STEPS = 20
+_MAX_LIST_ARGS = 8
+_MAX_STRING_ARG_LENGTH = 160
+_SUPPORTED_STEPS = {
+    "search",
+    "explore",
+    "callers",
+    "callees",
+    "related",
+    "take",
+    "sort",
+    "include",
+    "with",
+    "answer",
+}
+_ALLOWED_KWARGS: dict[str, frozenset[str]] = {
+    "search": frozenset({"query", "limit"}),
+    "explore": frozenset({"query", "max_files", "max_symbols", "include_code"}),
+    "callers": frozenset({"depth", "limit"}),
+    "callees": frozenset({"depth", "limit"}),
+    "related": frozenset({"depth", "limit"}),
+    "take": frozenset({"limit"}),
+    "sort": frozenset({"by", "desc"}),
+    "include": frozenset(
+        {
+            "source",
+            "callers",
+            "callees",
+            "complexity",
+            "health",
+            "risk",
+            "affected_tests",
+            "max_files",
+            "max_symbols",
+            "include_code",
+            "limit",
+        }
+    ),
+    "with": frozenset(
+        {
+            "source",
+            "callers",
+            "callees",
+            "complexity",
+            "health",
+            "risk",
+            "affected_tests",
+            "max_files",
+            "max_symbols",
+            "include_code",
+            "limit",
+        }
+    ),
+    "answer": frozenset(),
+}
 
 
 @dataclass(frozen=True)
@@ -19,6 +74,8 @@ class _ChainStep:
 
 def parse_chain(query: str) -> list[_ChainStep]:
     """Parse a safe chained query into steps."""
+    if len(query) > _MAX_QUERY_LENGTH:
+        raise ValueError(f"query exceeds {_MAX_QUERY_LENGTH} characters")
     if "(" not in query:
         return [
             _ChainStep("explore", [query], {}),
@@ -26,6 +83,8 @@ def parse_chain(query: str) -> list[_ChainStep]:
         ]
 
     parts = _split_chain(query)
+    if len(parts) > _MAX_STEPS:
+        raise ValueError(f"query exceeds {_MAX_STEPS} chain steps")
     steps = [_parse_step(part) for part in parts]
     if not steps:
         raise ValueError("query has no chain steps")
@@ -47,9 +106,31 @@ def first_str(step: _ChainStep, *, required: bool) -> str:
     return ""
 
 
+def string_args(step: _ChainStep, *, required: bool) -> list[str]:
+    values: list[str] = []
+    if step.args:
+        first = step.args[0]
+        if isinstance(first, str):
+            values = [first]
+        elif isinstance(first, list):
+            values = first
+    query = step.kwargs.get("query")
+    if isinstance(query, str):
+        values = [query]
+    elif isinstance(query, list):
+        values = query
+    values = [value for value in values if isinstance(value, str) and value.strip()]
+    if required and not values:
+        raise ValueError(f"{step.name}() requires a string query")
+    return values
+
+
 def first_int(step: _ChainStep, default: int) -> int:
     if step.args and isinstance(step.args[0], int):
         return step.args[0]
+    limit_value = step.kwargs.get("limit")
+    if isinstance(limit_value, int):
+        return limit_value
     return default
 
 
@@ -115,13 +196,31 @@ def _parse_step(part: str) -> _ChainStep:
     if not isinstance(call, ast.Call):
         raise ValueError(f"invalid chain step args: {part!r}")
     args = [_literal(node) for node in call.args]
-    kwargs = {kw.arg: _literal(kw.value) for kw in call.keywords if kw.arg is not None}
+    kwargs: dict[str, Any] = {}
+    for kw in call.keywords:
+        if kw.arg is None:
+            raise ValueError(f"{name}() does not support **kwargs")
+        if kw.arg not in _ALLOWED_KWARGS[name]:
+            raise ValueError(f"{name}() does not support keyword {kw.arg!r}")
+        kwargs[kw.arg] = _literal(kw.value)
     return _ChainStep(name=name, args=args, kwargs=kwargs)
 
 
 def _literal(node: ast.AST) -> Any:
     value = ast.literal_eval(node)
-    if isinstance(value, str | int | bool | float) or value is None:
+    if isinstance(value, str):
+        if len(value) > _MAX_STRING_ARG_LENGTH:
+            raise ValueError(f"string arguments must be <= {_MAX_STRING_ARG_LENGTH}")
+        return value
+    if isinstance(value, list):
+        if len(value) > _MAX_LIST_ARGS:
+            raise ValueError(f"list arguments must contain <= {_MAX_LIST_ARGS} items")
+        if not all(isinstance(item, str) for item in value):
+            raise ValueError("list arguments must contain only strings")
+        if any(len(item) > _MAX_STRING_ARG_LENGTH for item in value):
+            raise ValueError(f"string arguments must be <= {_MAX_STRING_ARG_LENGTH}")
+        return value
+    if isinstance(value, int | bool | float) or value is None:
         return value
     raise ValueError("chain arguments must be scalar literals")
 
@@ -134,4 +233,5 @@ __all__ = [
     "int_kw",
     "parse_chain",
     "step_to_dict",
+    "string_args",
 ]

--- a/tree_sitter_analyzer/mcp/tools/codegraph_query_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_query_tool.py
@@ -23,10 +23,10 @@ from ._codegraph_query_dsl import (
     _ChainStep,
     bool_kw,
     first_int,
-    first_str,
     int_kw,
     parse_chain,
     step_to_dict,
+    string_args,
 )
 from ._response_builder import build_response
 from .base_tool import BaseMCPTool
@@ -64,10 +64,11 @@ class CodeGraphQueryTool(BaseMCPTool):
             "name": "codegraph_query",
             "description": (
                 "jQuery-style chained code graph query. Compose search(), "
-                "explore(), callers(), callees(), related(), and take() in one "
-                "statement so agents get an answer pack without 40 separate "
-                "CLI calls. Example: search('CommandService').explore().callees()."
-                "callers()."
+                "explore(), callers(), callees(), related(), include(), sort(), "
+                "take(), and answer() in one statement so agents get an answer "
+                "pack without 40 separate CLI calls. Example: "
+                "search(['Router', 'Handler']).explore().include(callers=True, "
+                "complexity=True).sort(by='fan_in', desc=True).answer()."
             ),
             "inputSchema": self.get_tool_schema(),
             "annotations": {
@@ -170,10 +171,12 @@ class CodeGraphQueryTool(BaseMCPTool):
             symbols=state.symbols[:max_symbols],
             files=state.files[:max_files],
             relationships=state.relationships,
+            facets=state.facets or None,
             stats={
                 "steps": len(steps),
                 "symbols_returned": len(state.symbols),
                 "files_returned": len(state.files),
+                "facets_returned": len(state.facets),
                 "caller_edges": sum(
                     len(v) for v in state.relationships["callers"].values()
                 ),
@@ -196,19 +199,19 @@ class CodeGraphQueryTool(BaseMCPTool):
         default_include_code: bool,
     ) -> None:
         if step.name == "search":
-            query = first_str(step, required=True)
+            queries = string_args(step, required=True)
             limit = int_kw(step, "limit", default_max_symbols, _MAX_SYMBOLS_CAP)
-            state.current = _resolve_query(cache, query, limit)
+            state.current = _resolve_queries(cache, queries, limit)
             state.add_symbols(state.current)
             return
 
         if step.name == "explore":
-            query = first_str(step, required=False)
-            if query:
+            queries = string_args(step, required=False)
+            if queries:
                 limit = int_kw(
                     step, "max_symbols", default_max_symbols, _MAX_SYMBOLS_CAP
                 )
-                state.current = _resolve_query(cache, query, limit)
+                state.current = _resolve_queries(cache, queries, limit)
                 state.add_symbols(state.current)
             max_files = int_kw(step, "max_files", default_max_files, _MAX_FILES_CAP)
             max_symbols = int_kw(
@@ -245,6 +248,25 @@ class CodeGraphQueryTool(BaseMCPTool):
             state.symbols = state.symbols[:limit]
             return
 
+        if step.name == "sort":
+            _sort_state(state, step)
+            return
+
+        if step.name in {"include", "with"}:
+            _include_facets(
+                cache=cache,
+                project_root=self.project_root or "",
+                state=state,
+                step=step,
+                default_max_symbols=default_max_symbols,
+                default_max_files=default_max_files,
+                default_include_code=default_include_code,
+            )
+            return
+
+        if step.name == "answer":
+            return
+
         raise ValueError(f"unsupported chain step: {step.name}")
 
 
@@ -257,6 +279,7 @@ class _QueryState:
             "callers": {},
             "callees": {},
         }
+        self.facets: dict[str, Any] = {}
         self._seen_symbols: set[tuple[str, int, str]] = set()
 
     def add_symbols(self, symbols: list[dict[str, Any]]) -> None:
@@ -301,6 +324,19 @@ def _resolve_query(cache: Any, query: str, limit: int) -> list[dict[str, Any]]:
     return resolved
 
 
+def _resolve_queries(
+    cache: Any, queries: list[str], limit: int
+) -> list[dict[str, Any]]:
+    resolved: list[dict[str, Any]] = []
+    for query in queries:
+        remaining = limit - len(resolved)
+        if remaining <= 0:
+            break
+        resolved.extend(_resolve_query(cache, query, remaining))
+        resolved = _dedupe_symbols(resolved)
+    return resolved[:limit]
+
+
 def _relation_step(
     cache: Any,
     state: _QueryState,
@@ -335,6 +371,206 @@ def _relation_step(
     deduped = _dedupe_symbols(related)
     state.add_symbols(deduped)
     return deduped
+
+
+def _sort_state(state: _QueryState, step: _ChainStep) -> None:
+    sort_by = str(step.kwargs.get("by") or "name")
+    if sort_by == "path":
+        sort_by = "file"
+    allowed = {"name", "file", "line", "kind", "fan_in", "fan_out"}
+    if sort_by not in allowed:
+        raise ValueError(f"sort() unsupported field: {sort_by}")
+    desc = bool_kw(step, "desc", False)
+    fan_in = {
+        key: len(entries) for key, entries in state.relationships["callers"].items()
+    }
+    fan_out = {
+        key: len(entries) for key, entries in state.relationships["callees"].items()
+    }
+
+    def sort_key(symbol: dict[str, Any]) -> Any:
+        if sort_by == "fan_in":
+            return fan_in.get(_symbol_key(symbol), 0)
+        if sort_by == "fan_out":
+            return fan_out.get(_symbol_key(symbol), 0)
+        return symbol.get(sort_by, "")
+
+    state.current = sorted(state.current, key=sort_key, reverse=desc)
+    state.symbols = sorted(state.symbols, key=sort_key, reverse=desc)
+
+
+def _include_facets(
+    *,
+    cache: Any,
+    project_root: str,
+    state: _QueryState,
+    step: _ChainStep,
+    default_max_symbols: int,
+    default_max_files: int,
+    default_include_code: bool,
+) -> None:
+    max_files = int_kw(step, "max_files", default_max_files, _MAX_FILES_CAP)
+    max_symbols = int_kw(step, "max_symbols", default_max_symbols, _MAX_SYMBOLS_CAP)
+    include_code = bool_kw(step, "include_code", default_include_code)
+    limit = int_kw(step, "limit", max_symbols, _MAX_SYMBOLS_CAP)
+
+    if bool_kw(step, "callers", False):
+        _relation_step(
+            cache,
+            state,
+            direction="callers",
+            step=_ChainStep("callers", [], {"limit": limit}),
+        )
+        state.facets["callers"] = {
+            "status": "included",
+            "edges": state.relationships["callers"],
+        }
+    if bool_kw(step, "callees", False):
+        _relation_step(
+            cache,
+            state,
+            direction="callees",
+            step=_ChainStep("callees", [], {"limit": limit}),
+        )
+        state.facets["callees"] = {
+            "status": "included",
+            "edges": state.relationships["callees"],
+        }
+    if bool_kw(step, "source", False):
+        if not state.files:
+            state.files = _build_file_entries(
+                project_root=project_root,
+                symbols=state.current[:max_symbols],
+                max_files=max_files,
+                include_code=include_code,
+            )
+        state.facets["source"] = {
+            "status": "included",
+            "file_count": len(state.files),
+            "files": state.files[:max_files],
+        }
+    if bool_kw(step, "complexity", False):
+        state.facets["complexity"] = _complexity_facet(
+            cache, project_root, state.current[:max_symbols], max_files
+        )
+    if bool_kw(step, "health", False):
+        state.facets["health"] = _health_facet(
+            project_root, state.current[:max_symbols], max_files
+        )
+    if bool_kw(step, "affected_tests", False):
+        state.facets["affected_tests"] = _affected_tests_facet(state)
+    if bool_kw(step, "risk", False):
+        state.facets["risk"] = _risk_facet(state)
+
+
+def _complexity_facet(
+    cache: Any, project_root: str, symbols: list[dict[str, Any]], max_files: int
+) -> dict[str, Any]:
+    try:
+        from ...complexity_heatmap import analyze_file_complexity_from_cache
+    except Exception as exc:
+        return {"status": "missing", "reason": str(exc)}
+
+    entries: list[dict[str, Any]] = []
+    for file_path in _unique_symbol_files(symbols)[:max_files]:
+        abs_path = _absolute_path(project_root, file_path)
+        try:
+            functions = analyze_file_complexity_from_cache(cache, abs_path)
+        except Exception as exc:
+            entries.append({"file": file_path, "status": "error", "error": str(exc)})
+            continue
+        if not functions:
+            entries.append({"file": file_path, "status": "no_functions"})
+            continue
+        hotspots = sorted(functions, key=lambda item: item.complexity, reverse=True)[:5]
+        entries.append(
+            {
+                "file": file_path,
+                "status": "included",
+                "function_count": len(functions),
+                "max_complexity": max(item.complexity for item in functions),
+                "total_complexity": sum(item.complexity for item in functions),
+                "hotspots": [
+                    {
+                        "name": item.name,
+                        "line": item.line,
+                        "complexity": item.complexity,
+                    }
+                    for item in hotspots
+                ],
+            }
+        )
+    return {"status": "included", "files": entries}
+
+
+def _health_facet(
+    project_root: str, symbols: list[dict[str, Any]], max_files: int
+) -> dict[str, Any]:
+    try:
+        from ...health_scorer import HealthScorer
+    except Exception as exc:
+        return {"status": "missing", "reason": str(exc)}
+
+    scorer = HealthScorer()
+    entries: list[dict[str, Any]] = []
+    for file_path in _unique_symbol_files(symbols)[:max_files]:
+        abs_path = _absolute_path(project_root, file_path)
+        try:
+            score = scorer.score_file(abs_path, fast_dependencies=True)
+        except Exception as exc:
+            entries.append({"file": file_path, "status": "error", "error": str(exc)})
+            continue
+        entries.append(
+            {
+                "file": file_path,
+                "status": "included",
+                "total": score.total,
+                "grade": score.grade,
+                "dimensions": score.dimensions,
+            }
+        )
+    return {"status": "included", "files": entries}
+
+
+def _affected_tests_facet(state: _QueryState) -> dict[str, Any]:
+    files = _unique_symbol_files(state.symbols)
+    tests = [
+        file_path
+        for file_path in files
+        if "test" in os.path.basename(file_path).lower()
+        or "/test" in file_path.replace("\\", "/").lower()
+    ]
+    return {
+        "status": "included" if tests else "missing",
+        "files": tests,
+        "reason": None if tests else "no test files appeared in the current chain",
+    }
+
+
+def _risk_facet(state: _QueryState) -> dict[str, Any]:
+    reasons: list[str] = []
+    complexity = state.facets.get("complexity", {})
+    for entry in complexity.get("files", []):
+        max_complexity = int(entry.get("max_complexity") or 0)
+        if max_complexity >= 20:
+            reasons.append(f"{entry.get('file')}: critical complexity {max_complexity}")
+        elif max_complexity >= 11:
+            reasons.append(f"{entry.get('file')}: high complexity {max_complexity}")
+
+    health = state.facets.get("health", {})
+    for entry in health.get("files", []):
+        if entry.get("grade") in {"D", "F"}:
+            reasons.append(f"{entry.get('file')}: health grade {entry.get('grade')}")
+
+    caller_edges = sum(len(v) for v in state.relationships["callers"].values())
+    if caller_edges >= 10:
+        reasons.append(f"fan-in {caller_edges} across current symbols")
+
+    return {
+        "status": "included",
+        "level": "review" if reasons else "info",
+        "reasons": reasons,
+    }
 
 
 def _row_symbol(
@@ -423,6 +659,24 @@ def _dedupe_symbols(symbols: list[dict[str, Any]]) -> list[dict[str, Any]]:
         seen.add(key)
         out.append(symbol)
     return out
+
+
+def _unique_symbol_files(symbols: list[dict[str, Any]]) -> list[str]:
+    files: list[str] = []
+    seen: set[str] = set()
+    for symbol in symbols:
+        file_path = str(symbol.get("file") or "")
+        if not file_path or file_path in seen:
+            continue
+        seen.add(file_path)
+        files.append(file_path)
+    return files
+
+
+def _absolute_path(project_root: str, file_path: str) -> str:
+    if os.path.isabs(file_path):
+        return file_path
+    return os.path.join(project_root, file_path)
 
 
 def _symbol_key(symbol: dict[str, Any]) -> str:


### PR DESCRIPTION
## Summary
- extend codegraph_query with batch seed search, include()/with() evidence facets, sort(), and answer()
- add parser guardrails for query length, step count, kwargs, **kwargs, list caps, and string caps
- expose source/callers/callees/complexity/health/risk facets in one chained answer pack
- update codemaps and add unit coverage for the new chain surface

## Verification
- uv run ruff check tree_sitter_analyzer/mcp/tools/_codegraph_query_dsl.py tree_sitter_analyzer/mcp/tools/codegraph_query_tool.py tests/unit/test_codegraph_query_tool.py
- uv run pytest tests/unit/test_codegraph_query_tool.py tests/unit/cli/test_mcp_commands.py -q
- uv run python -m tree_sitter_analyzer --ast-cache --ast-cache-mode index --project-root tests/fixtures/call_graph/python_project --format json --quiet
- uv run python -m tree_sitter_analyzer --codegraph-query "search(['main', 'greet']).include(source=True, callers=True, callees=True, complexity=True, health=True, risk=True).sort(by='fan_in', desc=True).answer()" --project-root tests/fixtures/call_graph/python_project --format json
- uv run python -m tree_sitter_analyzer --change-impact --format json
- uv run pytest -q (17812 passed, 104 skipped, 2 xfailed in 82.79s)

## Notes
- One full-suite attempt had two local MCP check_project_health timeouts; the failing subset immediately passed in 0.42s each, and the next full-suite run passed.