### PR TITLE
fix(codegraph): resolve Go method call edges

### DIFF
--- a/tests/unit/test_ast_cache.py
+++ b/tests/unit/test_ast_cache.py
@@ -145,6 +145,46 @@ class TestIndexFile:
         finally:
             migrated.close()
 
+    def test_init_tolerates_extractor_version_migration_operational_error(
+        self, tmp_path, monkeypatch
+    ):
+        class FlakyConnection:
+            def __init__(self, path):
+                self._conn = sqlite3.connect(path)
+                self._conn.row_factory = sqlite3.Row
+
+            def execute(self, sql, *args, **kwargs):
+                if "PRAGMA table_info(ast_index)" in sql:
+                    raise sqlite3.OperationalError("metadata temporarily unavailable")
+                return self._conn.execute(sql, *args, **kwargs)
+
+            def executescript(self, *args, **kwargs):
+                return self._conn.executescript(*args, **kwargs)
+
+            def commit(self):
+                self._conn.commit()
+
+            def close(self):
+                self._conn.close()
+
+        class FlakyASTCache(ASTCache):
+            def _get_conn(self):
+                conn = getattr(self._local, "conn", None)
+                if conn is None:
+                    conn = FlakyConnection(self.db_path)
+                    self._local.conn = conn
+                return conn
+
+        monkeypatch.setattr(
+            ASTCache, "_verify_schema_integrity", lambda self, conn: None
+        )
+
+        cache = FlakyASTCache(str(tmp_path), db_path=str(tmp_path / "flaky.db"))
+        try:
+            assert cache.project_root == str(tmp_path)
+        finally:
+            cache.close()
+
     def test_index_with_explicit_language(self, cache, tmp_project):
         f = str(tmp_project / "src" / "main.py")
         result = cache.index_file(f, language="python")

--- a/tests/unit/test_ast_cache.py
+++ b/tests/unit/test_ast_cache.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from tree_sitter_analyzer.ast_cache import (
+    _AST_CACHE_EXTRACTOR_VERSION,
     _EXT_TO_LANG,
     ASTCache,
     _content_hash,
@@ -72,6 +73,22 @@ class TestIndexFile:
         result = cache.index_file(f)
         assert result["status"] == "cached"
 
+    def test_stale_extractor_version_reindexes_unchanged_file(self, cache, tmp_project):
+        f = str(tmp_project / "src" / "main.py")
+        cache.index_file(f)
+        conn = cache._get_conn()
+        conn.execute("UPDATE ast_index SET extractor_version = 0")
+        conn.commit()
+
+        result = cache.index_file(f)
+
+        assert result["status"] == "indexed"
+        version = conn.execute(
+            "SELECT extractor_version FROM ast_index WHERE file_path = ?",
+            ("src/main.py",),
+        ).fetchone()[0]
+        assert version == _AST_CACHE_EXTRACTOR_VERSION
+
     def test_index_with_explicit_language(self, cache, tmp_project):
         f = str(tmp_project / "src" / "main.py")
         result = cache.index_file(f, language="python")
@@ -88,6 +105,17 @@ class TestIndexProject:
         cache.index_project()
         result = cache.index_project()
         assert result["cached"] >= 2
+
+    def test_index_project_reindexes_stale_extractor_version(self, cache):
+        cache.index_project(workers=0)
+        conn = cache._get_conn()
+        conn.execute("UPDATE ast_index SET extractor_version = 0")
+        conn.commit()
+
+        result = cache.index_project(workers=0)
+
+        assert result["indexed"] >= 2
+        assert result["cached"] == 0
 
     def test_index_project_force(self, cache):
         cache.index_project()

--- a/tests/unit/test_ast_cache.py
+++ b/tests/unit/test_ast_cache.py
@@ -73,6 +73,23 @@ class TestIndexFile:
         result = cache.index_file(f)
         assert result["status"] == "cached"
 
+    def test_content_unchanged_refreshes_file_metadata(self, cache, tmp_project):
+        f = str(tmp_project / "src" / "main.py")
+        cache.index_file(f)
+        conn = cache._get_conn()
+        conn.execute(
+            "UPDATE ast_index SET mtime_ns = 0 WHERE file_path = ?", ("src/main.py",)
+        )
+        conn.commit()
+
+        result = cache.index_file(f)
+
+        assert result == {
+            "file": "src/main.py",
+            "status": "cached",
+            "reason": "content unchanged",
+        }
+
     def test_stale_extractor_version_reindexes_unchanged_file(self, cache, tmp_project):
         f = str(tmp_project / "src" / "main.py")
         cache.index_file(f)

--- a/tests/unit/test_ast_cache.py
+++ b/tests/unit/test_ast_cache.py
@@ -539,6 +539,33 @@ class TestSQLNativeCallGraph:
         callee_names = [e["callee_name"] for e in callees]
         assert "bar" in callee_names
 
+    def test_query_callees_finds_go_method_selector_calls(self, tmp_path):
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "gin.go").write_text(
+            "package gin\n\n"
+            "type Engine struct{}\n\n"
+            "func (engine *Engine) ServeHTTP() {\n"
+            "    engine.handleHTTPRequest()\n"
+            "}\n\n"
+            "func (engine *Engine) handleHTTPRequest() {}\n",
+            encoding="utf-8",
+        )
+        cache = ASTCache(str(tmp_path))
+        try:
+            cache.index_project()
+
+            callees = cache.query_callees("ServeHTTP", caller_file="src/gin.go")
+            assert [edge["callee_name"] for edge in callees] == ["handleHTTPRequest"]
+            assert [edge["callee_full"] for edge in callees] == [
+                "engine.handleHTTPRequest"
+            ]
+
+            callers = cache.query_callers("handleHTTPRequest", callee_file="src/gin.go")
+            assert [edge["caller_name"] for edge in callers] == ["ServeHTTP"]
+        finally:
+            cache.close()
+
     def test_query_callers_finds_caller(self, call_cache):
         callers = call_cache.query_callers("bar")
         caller_names = [e["caller_name"] for e in callers]

--- a/tests/unit/test_ast_cache.py
+++ b/tests/unit/test_ast_cache.py
@@ -89,6 +89,45 @@ class TestIndexFile:
         ).fetchone()[0]
         assert version == _AST_CACHE_EXTRACTOR_VERSION
 
+    def test_init_migrates_legacy_index_without_extractor_version(self, tmp_path):
+        db_path = tmp_path / "legacy.db"
+        conn = sqlite3.connect(db_path)
+        conn.execute(
+            """CREATE TABLE ast_index (
+                file_path TEXT NOT NULL,
+                content_hash TEXT NOT NULL,
+                language TEXT NOT NULL,
+                mtime_ns INTEGER NOT NULL,
+                file_size INTEGER NOT NULL,
+                symbols_json TEXT NOT NULL DEFAULT '{}',
+                imports_json TEXT NOT NULL DEFAULT '[]',
+                structure_json TEXT NOT NULL DEFAULT '{}',
+                indexed_at TEXT NOT NULL,
+                PRIMARY KEY (file_path)
+            )"""
+        )
+        conn.commit()
+        conn.close()
+
+        migrated = ASTCache(str(tmp_path), db_path=str(db_path))
+        try:
+            columns = {
+                row[1]
+                for row in migrated._get_conn()
+                .execute("PRAGMA table_info(ast_index)")
+                .fetchall()
+            }
+            version_row = (
+                migrated._get_conn()
+                .execute("SELECT version FROM ast_schema_version WHERE version = 7")
+                .fetchone()
+            )
+
+            assert "extractor_version" in columns
+            assert version_row is not None
+        finally:
+            migrated.close()
+
     def test_index_with_explicit_language(self, cache, tmp_project):
         f = str(tmp_project / "src" / "main.py")
         result = cache.index_file(f, language="python")
@@ -591,6 +630,11 @@ class TestSQLNativeCallGraph:
 
             callers = cache.query_callers("handleHTTPRequest", callee_file="src/gin.go")
             assert [edge["caller_name"] for edge in callers] == ["ServeHTTP"]
+
+            full_callers = cache.query_callers(
+                "engine.handleHTTPRequest", callee_file="src/gin.go"
+            )
+            assert [edge["caller_name"] for edge in full_callers] == ["ServeHTTP"]
         finally:
             cache.close()
 

--- a/tests/unit/test_call_graph.py
+++ b/tests/unit/test_call_graph.py
@@ -326,6 +326,16 @@ class TestGetFuncName:
         func_node = root.children[0]
         assert _get_func_name(func_node, "c") == "myfunc"
 
+    def test_go_method_name_falls_back_to_field_identifier_child(self):
+        node = MagicMock()
+        node.child_by_field_name.return_value = None
+        child = MagicMock()
+        child.type = "field_identifier"
+        child.text = b"ServeHTTP"
+        node.children = [child]
+
+        assert _get_func_name(node, "go") == "ServeHTTP"
+
     def test_no_func_name_returns_none(self):
         node = MagicMock()
         node.children = []

--- a/tests/unit/test_call_graph.py
+++ b/tests/unit/test_call_graph.py
@@ -344,6 +344,14 @@ class TestGetFuncName:
 
         assert _get_func_name(node, "go") == "ServeHTTP"
 
+    def test_go_method_name_decodes_bytes_from_name_field(self):
+        node = MagicMock()
+        name_node = MagicMock()
+        name_node.text = b"ServeHTTP"
+        node.child_by_field_name.return_value = name_node
+
+        assert _get_func_name(node, "go") == "ServeHTTP"
+
     def test_no_func_name_returns_none(self):
         node = MagicMock()
         node.children = []

--- a/tests/unit/test_call_graph.py
+++ b/tests/unit/test_call_graph.py
@@ -248,6 +248,28 @@ class TestWalkTree:
         assert "main" in names
         assert "helper" in names
 
+    def test_go_method_defs_and_selector_calls(self):
+        source = (
+            "package main\n\n"
+            "type Engine struct{}\n\n"
+            "func (engine *Engine) ServeHTTP() {\n"
+            "\tengine.handleHTTPRequest()\n"
+            "}\n\n"
+            "func (engine *Engine) handleHTTPRequest() {}\n"
+        )
+        root, src = _parse_source(source, "go")
+        defs, calls = _walk_tree(root, src, "go")
+
+        assert {d["name"] for d in defs} == {"ServeHTTP", "handleHTTPRequest"}
+        assert calls == [
+            {
+                "name": "handleHTTPRequest",
+                "full_name": "engine.handleHTTPRequest",
+                "line": 6,
+                "receiver": "engine",
+            }
+        ]
+
     def test_c_function_defs(self):
         source = "int foo(void) { return 1; }\nint bar(void) { return foo(); }\n"
         root, src = _parse_source(source, "c")
@@ -597,6 +619,23 @@ class TestCallGraphGoProject:
         callees = cg.callees_of("main")
         callee_names = {c["name"] for c in callees}
         assert "loadData" in callee_names
+
+    def test_go_method_selector_callees(self, tmp_path):
+        src = tmp_path / "gin.go"
+        src.write_text(
+            "package gin\n\n"
+            "type Engine struct{}\n\n"
+            "func (engine *Engine) ServeHTTP() {\n"
+            "\tengine.handleHTTPRequest()\n"
+            "}\n\n"
+            "func (engine *Engine) handleHTTPRequest() {}\n",
+            encoding="utf-8",
+        )
+        cg = CallGraph(str(tmp_path))
+        cg.build()
+
+        callees = cg.callees_of("ServeHTTP", file_path="gin.go")
+        assert [callee["name"] for callee in callees] == ["handleHTTPRequest"]
 
 
 class TestCallGraphJavaProject:

--- a/tests/unit/test_call_graph.py
+++ b/tests/unit/test_call_graph.py
@@ -336,6 +336,14 @@ class TestGetFuncName:
 
         assert _get_func_name(node, "go") == "ServeHTTP"
 
+    def test_go_method_name_accepts_text_from_name_field(self):
+        node = MagicMock()
+        name_node = MagicMock()
+        name_node.text = "ServeHTTP"
+        node.child_by_field_name.return_value = name_node
+
+        assert _get_func_name(node, "go") == "ServeHTTP"
+
     def test_no_func_name_returns_none(self):
         node = MagicMock()
         node.children = []

--- a/tree_sitter_analyzer/_ast_extraction.py
+++ b/tree_sitter_analyzer/_ast_extraction.py
@@ -532,9 +532,6 @@ def _extract_call_edges(
         callee_name = call.get("name", "")
         callee_full = call.get("full_name", callee_name)
         callee_line = call_line
-        receiver = call.get("receiver")
-        if receiver:
-            callee_name = f"{receiver}.{callee_name}"
         edges.append(
             {
                 "caller_name": caller_name,

--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -404,7 +404,7 @@ class ASTCache:
                 conn.executescript(_SCHEMA_V3_CALL_EDGES)
                 self._record_schema_version(conn, 3, "ast_call_edges + indices")
                 conn.commit()
-            except sqlite3.OperationalError:
+            except sqlite3.OperationalError:  # pragma: no cover - defensive fallback
                 pass
         # Feature 1 (Synapse) — V4 schema. ALTER TABLE has no
         # IF NOT EXISTS form in SQLite, so we add the columns only when

--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -1693,25 +1693,30 @@ class ASTCache:
             if current_file:
                 rows = conn.execute(
                     "SELECT caller_name, caller_file, caller_line, "
-                    "callee_name, file_path, callee_line, callee_resolved_file "
+                    "callee_name, callee_full, file_path, callee_line, "
+                    "callee_resolved_file "
                     "FROM ast_call_edges "
-                    "WHERE callee_name = ? AND callee_resolved_file = ?",
-                    (current_name, current_file),
+                    "WHERE (callee_name = ? OR callee_full = ?) "
+                    "AND callee_resolved_file = ?",
+                    (current_name, current_name, current_file),
                 ).fetchall()
                 if not rows:
                     rows = conn.execute(
                         "SELECT caller_name, caller_file, caller_line, "
-                        "callee_name, file_path, callee_line, callee_resolved_file "
+                        "callee_name, callee_full, file_path, callee_line, "
+                        "callee_resolved_file "
                         "FROM ast_call_edges "
-                        "WHERE callee_name = ? AND file_path = ?",
-                        (current_name, current_file),
+                        "WHERE (callee_name = ? OR callee_full = ?) "
+                        "AND file_path = ?",
+                        (current_name, current_name, current_file),
                     ).fetchall()
             else:
                 rows = conn.execute(
                     "SELECT caller_name, caller_file, caller_line, "
-                    "callee_name, file_path, callee_line, callee_resolved_file "
-                    "FROM ast_call_edges WHERE callee_name = ?",
-                    (current_name,),
+                    "callee_name, callee_full, file_path, callee_line, "
+                    "callee_resolved_file "
+                    "FROM ast_call_edges WHERE callee_name = ? OR callee_full = ?",
+                    (current_name, current_name),
                 ).fetchall()
             for row in rows:
                 key = f"{row['caller_file']}:{row['caller_name']}:{row['caller_line']}"
@@ -1724,6 +1729,7 @@ class ASTCache:
                     "caller_file": row["caller_file"],
                     "caller_line": row["caller_line"],
                     "callee_name": row["callee_name"],
+                    "callee_full": row["callee_full"],
                     "callee_file": callee_file_val,
                     "callee_line": row["callee_line"],
                     "depth": depth + 1,
@@ -1796,6 +1802,7 @@ class ASTCache:
                     "caller_file": row["caller_file"],
                     "caller_line": row["caller_line"],
                     "callee_name": row["callee_name"],
+                    "callee_full": row["callee_full"],
                     "callee_file": callee_file_val,
                     "callee_line": row["callee_line"],
                     "depth": depth + 1,

--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -23,6 +23,8 @@ from .project_graph import _language_from_ext
 
 logger = logging.getLogger(__name__)
 
+_AST_CACHE_EXTRACTOR_VERSION = 2
+
 _SCHEMA_V1 = """
 CREATE TABLE IF NOT EXISTS ast_index (
     file_path    TEXT NOT NULL,
@@ -30,6 +32,7 @@ CREATE TABLE IF NOT EXISTS ast_index (
     language     TEXT NOT NULL,
     mtime_ns     INTEGER NOT NULL,
     file_size    INTEGER NOT NULL,
+    extractor_version INTEGER NOT NULL DEFAULT 0,
     symbols_json TEXT NOT NULL DEFAULT '{}',
     imports_json TEXT NOT NULL DEFAULT '[]',
     structure_json TEXT NOT NULL DEFAULT '{}',
@@ -290,6 +293,13 @@ _EXPECTED_SCHEMA_VERSIONS: list[tuple[int, str, dict[str, list[str]]]] = [
             "tables": ["ast_constraint_violations"],
         },
     ),
+    (
+        7,
+        "Extractor version invalidation",
+        {
+            "ast_index_columns": ["extractor_version"],
+        },
+    ),
 ]
 
 
@@ -468,6 +478,24 @@ class ASTCache:
             try:
                 conn.executescript(_SCHEMA_V6_VIOLATIONS)
                 self._record_schema_version(conn, 6, "Constraint violations")
+                conn.commit()
+            except sqlite3.OperationalError:
+                pass
+        # V7 records which extraction algorithm produced the serialized
+        # per-file rows. Bump ``_AST_CACHE_EXTRACTOR_VERSION`` whenever
+        # symbols/imports/structure/call_edges change semantics so existing
+        # caches are re-parsed instead of serving stale graph answers.
+        if 7 not in applied_versions:
+            try:
+                index_cols = {
+                    r[1] for r in conn.execute("PRAGMA table_info(ast_index)")
+                }
+                if "extractor_version" not in index_cols:
+                    conn.execute(
+                        "ALTER TABLE ast_index "
+                        "ADD COLUMN extractor_version INTEGER NOT NULL DEFAULT 0"
+                    )
+                self._record_schema_version(conn, 7, "Extractor version invalidation")
                 conn.commit()
             except sqlite3.OperationalError:
                 pass
@@ -651,13 +679,15 @@ class ASTCache:
         source_code: str | None = None
         conn = self._get_conn()
         row = conn.execute(
-            "SELECT content_hash, mtime_ns, file_size FROM ast_index WHERE file_path = ?",
+            "SELECT content_hash, mtime_ns, file_size, extractor_version "
+            "FROM ast_index WHERE file_path = ?",
             (rel_path,),
         ).fetchone()
         if row is not None:
             if (
                 row["mtime_ns"] == int(stat.st_mtime_ns)
                 and row["file_size"] == stat.st_size
+                and row["extractor_version"] >= _AST_CACHE_EXTRACTOR_VERSION
             ):
                 return {"file": rel_path, "status": "cached", "reason": "unchanged"}
 
@@ -669,7 +699,11 @@ class ASTCache:
 
         content_hash = _content_hash(source_code)
 
-        if row is not None and row["content_hash"] == content_hash:
+        if (
+            row is not None
+            and row["content_hash"] == content_hash
+            and row["extractor_version"] >= _AST_CACHE_EXTRACTOR_VERSION
+        ):
             conn.execute(
                 "UPDATE ast_index SET mtime_ns = ?, file_size = ? WHERE file_path = ?",
                 (int(stat.st_mtime_ns), stat.st_size, rel_path),
@@ -694,14 +728,16 @@ class ASTCache:
         conn.execute(
             """INSERT OR REPLACE INTO ast_index
                (file_path, content_hash, language, mtime_ns, file_size,
-                symbols_json, imports_json, structure_json, indexed_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                extractor_version, symbols_json, imports_json, structure_json,
+                indexed_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 rel_path,
                 content_hash,
                 language,
                 int(stat.st_mtime_ns),
                 stat.st_size,
+                _AST_CACHE_EXTRACTOR_VERSION,
                 json.dumps(symbols, ensure_ascii=False),
                 json.dumps(imports, ensure_ascii=False),
                 json.dumps(structure, ensure_ascii=False),
@@ -1180,13 +1216,15 @@ class ASTCache:
                 )
                 continue
             row = conn.execute(
-                "SELECT mtime_ns, file_size FROM ast_index WHERE file_path = ?",
+                "SELECT mtime_ns, file_size, extractor_version "
+                "FROM ast_index WHERE file_path = ?",
                 (rel_path,),
             ).fetchone()
             if (
                 row is not None
                 and row["mtime_ns"] == int(stat.st_mtime_ns)
                 and row["file_size"] == stat.st_size
+                and row["extractor_version"] >= _AST_CACHE_EXTRACTOR_VERSION
             ):
                 already_cached.append(
                     {"file": rel_path, "status": "cached", "reason": "unchanged"}
@@ -1317,14 +1355,16 @@ class ASTCache:
         conn.execute(
             """INSERT OR REPLACE INTO ast_index
                (file_path, content_hash, language, mtime_ns, file_size,
-                symbols_json, imports_json, structure_json, indexed_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                extractor_version, symbols_json, imports_json, structure_json,
+                indexed_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 rel_path,
                 r["content_hash"],
                 r["language"],
                 r["mtime_ns"],
                 r["file_size"],
+                _AST_CACHE_EXTRACTOR_VERSION,
                 r["symbols_json"],
                 r["imports_json"],
                 r["structure_json"],

--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -404,7 +404,7 @@ class ASTCache:
                 conn.executescript(_SCHEMA_V3_CALL_EDGES)
                 self._record_schema_version(conn, 3, "ast_call_edges + indices")
                 conn.commit()
-            except sqlite3.OperationalError:  # pragma: no cover - defensive fallback
+            except sqlite3.OperationalError:
                 pass
         # Feature 1 (Synapse) — V4 schema. ALTER TABLE has no
         # IF NOT EXISTS form in SQLite, so we add the columns only when

--- a/tree_sitter_analyzer/call_graph.py
+++ b/tree_sitter_analyzer/call_graph.py
@@ -210,8 +210,12 @@ def _get_func_name(node: Any, language: str) -> str | None:
                         text.decode("utf-8") if isinstance(text, bytes) else str(text)
                     )
         elif language == "go":
+            name_node = node.child_by_field_name("name")
+            if name_node is not None:
+                text = name_node.text
+                return text.decode("utf-8") if isinstance(text, bytes) else str(text)
             for child in node.children:
-                if child.type == "identifier":
+                if child.type in ("identifier", "field_identifier"):
                     text = child.text
                     return (
                         text.decode("utf-8") if isinstance(text, bytes) else str(text)


### PR DESCRIPTION
## Summary
- recognize tree-sitter-go method names exposed as field_identifier nodes
- store callable edges with bare callee_name while preserving receiver-qualified callee_full
- include callee_full in SQL-native callers/callees responses and add Go method selector regressions

## Verification
- uv run ruff check tree_sitter_analyzer/call_graph.py tree_sitter_analyzer/_ast_extraction.py tree_sitter_analyzer/ast_cache.py tests/unit/test_ast_cache.py tests/unit/test_call_graph.py
- uv run pytest tests/integration/test_ast_cache_lifecycle.py tests/integration/test_call_graph_cross_file.py tests/unit/mcp/test_ast_cache_watch_modes.py tests/unit/test_ast_cache.py tests/unit/test_ast_cache_mode_used.py tests/unit/test_ast_cache_tool.py tests/unit/test_ast_cache_utf8_bug.py tests/unit/test_cached_call_graph.py tests/unit/test_call_graph.py tests/unit/test_call_graph_impact.py tests/unit/test_call_graph_tool.py -q
- uv run pytest -q

Full suite: 17833 passed, 104 skipped, 2 xfailed in 83.03s.