### PR TITLE
chore(test): add local patch coverage gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,9 +21,21 @@
 - After edits, run `uv run python -m tree_sitter_analyzer --change-impact --format json` and follow its `verification_command`.
 - If `test_required` is `false`, do not run tests just to look busy; run the reported non-test verification such as `git diff --check`.
 - For targeted code feedback, prefer `verification_command`/`test_command`; `pytest_required` and `pytest_command` are retained for pytest-specific compatibility.
+- For PRs that change Python source, run focused tests with `--cov=tree_sitter_analyzer --cov-report=json`, then run `uv run python scripts/check_patch_coverage.py --base origin/develop --coverage-json coverage.json` before pushing. The local patch gate must report no added executable misses; add effective tests instead of waiting for CI Codecov to block the PR.
 - Benchmark-only runs are the exception: use `uv run pytest tests/benchmarks/ --benchmark-enable --benchmark-only -n 0 --session-timeout=0`.
 - Do not remove or weaken these pytest defaults. They prevent repeated agent mistakes: serial full-suite runs, accidental benchmark execution, hidden hangs, and >5 minute feedback loops.
 - If a test-runtime setting must change, update `tests/unit/test_agent_contracts.py`, explain why the new setting is faster or safer, and prove `uv run pytest -q` still finishes under 5 minutes.
+
+## Agent Dogfood Feedback Loop
+
+For non-trivial work, expert agents must use this project as their primary feedback instrument while they work, then preserve the learning in memory:
+
+1. **Before edits:** run `uv run python -m tree_sitter_analyzer --change-impact --format json` to get the affected surface and verification command.
+2. **During exploration:** prefer TSA queries over blind file scans. Use focused codegraph/query/health commands for the area being changed, and keep the raw command outputs small enough to compare before/after.
+3. **After edits:** rerun change-impact and the reported verification command. For Python source changes, also run the local patch coverage gate from the Test Runtime Contract.
+4. **Memory capture:** store a concise JSON record in project memory with `branch`, `task`, `tools_used`, `signals`, `decision`, `verification`, and `followups`. Use the available `memory_store` MCP when present; otherwise use the Claude Flow memory CLI (`npx @claude-flow/cli@latest memory store --namespace tsa/agent-feedback ...`). If neither memory backend is available, include the JSON in the final response so the lead can store it.
+
+Memory records should capture reusable lessons, not logs: benchmark surprises, Codecov/CI failure patterns, query misses, performance bottlenecks, and successful verification recipes.
 
 ## MCP/CLI Parity Contract
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -226,6 +226,16 @@ xdg-open htmlcov/index.html  # Linux
 start htmlcov/index.html  # Windows
 ```
 
+Before pushing a PR that changes Python source, also check the patch itself:
+
+```bash
+# Use the focused tests reported by --change-impact, but add coverage JSON.
+uv run pytest <focused tests> --cov=tree_sitter_analyzer --cov-report=json --cov-report=term-missing
+
+# Fail locally on added executable lines or branch partials that Codecov would flag.
+uv run python scripts/check_patch_coverage.py --base origin/develop --coverage-json coverage.json
+```
+
 ## Running Tests
 
 ### Run All Tests

--- a/scripts/check_patch_coverage.py
+++ b/scripts/check_patch_coverage.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Fail when PR-added executable source lines are missing coverage.
+
+This is a local companion to Codecov patch coverage. Generate
+``coverage.json`` with pytest-cov, then run this script before pushing a
+PR branch. The check is intentionally strict: every added executable line
+under ``tree_sitter_analyzer/`` must be covered, and added branch source
+lines must not have missing branch arcs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+HUNK_RE = re.compile(r"\+(?P<start>\d+)(?:,(?P<count>\d+))?")
+DEFAULT_PATHS = ("tree_sitter_analyzer",)
+
+
+@dataclass(frozen=True)
+class PatchCoverageMiss:
+    """A missing coverage finding on a PR-added line."""
+
+    path: str
+    line: int
+    reason: str
+
+
+def parse_added_lines(diff_text: str) -> dict[str, set[int]]:
+    """Return added destination line numbers by path from unified diff text."""
+    added: dict[str, set[int]] = {}
+    current_file: str | None = None
+    new_line: int | None = None
+
+    for line in diff_text.splitlines():
+        if line.startswith("+++ b/"):
+            current_file = line[6:]
+            added.setdefault(current_file, set())
+            new_line = None
+            continue
+        if line.startswith("+++ /dev/null"):
+            current_file = None
+            new_line = None
+            continue
+        if line.startswith("@@"):
+            match = HUNK_RE.search(line)
+            new_line = int(match.group("start")) if match else None
+            continue
+        if current_file is None or new_line is None:
+            continue
+        if line.startswith("+") and not line.startswith("+++"):
+            added[current_file].add(new_line)
+            new_line += 1
+        elif line.startswith("-") and not line.startswith("---"):
+            continue
+        elif line.startswith("\\ No newline"):
+            continue
+        else:
+            new_line += 1
+
+    return {path: lines for path, lines in added.items() if lines}
+
+
+def load_coverage(path: Path) -> dict[str, Any]:
+    """Load a coverage.py JSON report."""
+    if not path.exists():
+        raise FileNotFoundError(
+            f"{path} does not exist. Run pytest with --cov-report=json first."
+        )
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def normalize_coverage_files(
+    coverage_data: dict[str, Any],
+    project_root: Path,
+) -> dict[str, dict[str, Any]]:
+    """Return coverage file entries keyed by repo-relative POSIX path."""
+    raw_files = coverage_data.get("files", {})
+    if isinstance(raw_files, list):
+        iterable = (
+            (entry.get("filename", ""), entry)
+            for entry in raw_files
+            if isinstance(entry, dict)
+        )
+    else:
+        iterable = raw_files.items()
+
+    files: dict[str, dict[str, Any]] = {}
+    for raw_path, entry in iterable:
+        if not isinstance(entry, dict):
+            continue
+        normalized = normalize_repo_path(str(raw_path), project_root)
+        files[normalized] = entry
+    return files
+
+
+def normalize_repo_path(path: str, project_root: Path) -> str:
+    """Normalize absolute or relative paths to repo-relative POSIX form."""
+    path_obj = Path(path)
+    if path_obj.is_absolute():
+        try:
+            path_obj = path_obj.resolve().relative_to(project_root.resolve())
+        except ValueError:
+            return path_obj.as_posix()
+    return path_obj.as_posix()
+
+
+def is_tracked_python_source(path: str) -> bool:
+    """Return true for package source paths covered by Codecov patch gate."""
+    return path.endswith(".py") and path.startswith("tree_sitter_analyzer/")
+
+
+def missing_patch_coverage(
+    added_lines: dict[str, set[int]],
+    coverage_data: dict[str, Any],
+    project_root: Path,
+) -> list[PatchCoverageMiss]:
+    """Find added executable lines and branch source lines missing coverage."""
+    coverage_files = normalize_coverage_files(coverage_data, project_root)
+    misses: list[PatchCoverageMiss] = []
+
+    for path, lines in sorted(added_lines.items()):
+        if not is_tracked_python_source(path):
+            continue
+        file_coverage = coverage_files.get(path)
+        if file_coverage is None:
+            for line in sorted(lines):
+                misses.append(PatchCoverageMiss(path, line, "no coverage data"))
+            continue
+
+        excluded = set(file_coverage.get("excluded_lines", []))
+        missing = set(file_coverage.get("missing_lines", []))
+        executed = set(file_coverage.get("executed_lines", []))
+        executable = executed | missing
+        missing_branch_sources = {
+            int(branch[0])
+            for branch in file_coverage.get("missing_branches", [])
+            if branch
+        }
+
+        for line in sorted(lines):
+            if line in excluded:
+                continue
+            if line in missing:
+                misses.append(PatchCoverageMiss(path, line, "line not covered"))
+            elif line in executable and line in missing_branch_sources:
+                misses.append(PatchCoverageMiss(path, line, "branch partially covered"))
+
+    return misses
+
+
+def git_diff(
+    project_root: Path,
+    base: str,
+    pathspecs: list[str],
+    worktree: bool,
+) -> str:
+    """Return unified diff text for the PR patch or current worktree."""
+    ref = base if worktree else f"{base}...HEAD"
+    cmd = ["git", "diff", "--unified=0", ref, "--", *pathspecs]
+    result = subprocess.run(
+        cmd,
+        cwd=project_root,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "git diff failed")
+    return result.stdout
+
+
+def print_report(misses: list[PatchCoverageMiss]) -> None:
+    """Print a human-readable gate result."""
+    if not misses:
+        print("Patch coverage gate passed: no added executable misses.")
+        return
+
+    print("Patch coverage gate failed:")
+    for miss in misses:
+        print(f"  {miss.path}:{miss.line}: {miss.reason}")
+    print(
+        "\nRun focused tests with --cov=tree_sitter_analyzer "
+        "--cov-report=json, then add effective tests for the lines above."
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Check coverage on PR-added executable source lines."
+    )
+    parser.add_argument(
+        "--base",
+        default="origin/develop",
+        help="Base ref for PR diff semantics (default: origin/develop).",
+    )
+    parser.add_argument(
+        "--coverage-json",
+        type=Path,
+        default=Path("coverage.json"),
+        help="coverage.py JSON report path (default: coverage.json).",
+    )
+    parser.add_argument(
+        "--project-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Repository root (default: inferred from script location).",
+    )
+    parser.add_argument(
+        "--path",
+        action="append",
+        dest="paths",
+        help="Git pathspec to check. Can be passed multiple times.",
+    )
+    parser.add_argument(
+        "--diff-file",
+        type=Path,
+        help="Read unified diff from a file instead of running git diff.",
+    )
+    parser.add_argument(
+        "--worktree",
+        action="store_true",
+        help="Compare base directly to the worktree instead of base...HEAD.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    project_root = args.project_root.resolve()
+    coverage_path = args.coverage_json
+    if not coverage_path.is_absolute():
+        coverage_path = project_root / coverage_path
+
+    try:
+        diff_text = (
+            args.diff_file.read_text(encoding="utf-8")
+            if args.diff_file
+            else git_diff(
+                project_root,
+                args.base,
+                args.paths or list(DEFAULT_PATHS),
+                args.worktree,
+            )
+        )
+        coverage_data = load_coverage(coverage_path)
+        misses = missing_patch_coverage(
+            parse_added_lines(diff_text),
+            coverage_data,
+            project_root,
+        )
+    except (FileNotFoundError, RuntimeError, json.JSONDecodeError) as exc:
+        print(f"Patch coverage gate error: {exc}", file=sys.stderr)
+        return 2
+
+    print_report(misses)
+    return 1 if misses else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_agent_contracts.py
+++ b/tests/unit/test_agent_contracts.py
@@ -516,6 +516,30 @@ def test_agent_docs_require_change_impact_verification_command() -> None:
         assert "--change-impact --format json" in text, path
 
 
+def test_agent_docs_require_local_patch_coverage_gate() -> None:
+    """Future agents should pass local patch coverage before Codecov sees a PR."""
+    script = PROJECT_ROOT / "scripts" / "check_patch_coverage.py"
+    agents_text = (PROJECT_ROOT / "AGENTS.md").read_text(encoding="utf-8")
+
+    assert script.exists(), "scripts/check_patch_coverage.py must exist"
+    assert "check_patch_coverage.py" in agents_text
+    assert "--cov=tree_sitter_analyzer" in agents_text
+    assert "--cov-report=json" in agents_text
+    assert "Codecov" in agents_text
+
+
+def test_agent_docs_require_dogfood_feedback_memory_loop() -> None:
+    """Agents should use TSA feedback and preserve reusable findings in memory."""
+    agents_text = (PROJECT_ROOT / "AGENTS.md").read_text(encoding="utf-8")
+
+    assert "Agent Dogfood Feedback Loop" in agents_text
+    assert "tree_sitter_analyzer --change-impact --format json" in agents_text
+    assert "memory_store" in agents_text
+    assert "tsa/agent-feedback" in agents_text
+    assert "tools_used" in agents_text
+    assert "verification" in agents_text
+
+
 def test_warning_prone_python_api_patterns_are_blocked() -> None:
     """Keep future agents from reintroducing known Python 3.14 warning sources."""
     blocked_patterns = {

--- a/tests/unit/test_patch_coverage_check.py
+++ b/tests/unit/test_patch_coverage_check.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = PROJECT_ROOT / "scripts" / "check_patch_coverage.py"
+
+spec = importlib.util.spec_from_file_location("check_patch_coverage", SCRIPT_PATH)
+assert spec is not None
+check_patch_coverage = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules["check_patch_coverage"] = check_patch_coverage
+spec.loader.exec_module(check_patch_coverage)
+
+
+def test_parse_added_lines_from_zero_context_diff() -> None:
+    diff = """diff --git a/tree_sitter_analyzer/foo.py b/tree_sitter_analyzer/foo.py
+--- a/tree_sitter_analyzer/foo.py
++++ b/tree_sitter_analyzer/foo.py
+@@ -1,2 +1,4 @@
+ context
++if flag:
++    return 1
+-old
++return 2
+"""
+
+    assert check_patch_coverage.parse_added_lines(diff) == {
+        "tree_sitter_analyzer/foo.py": {2, 3, 4}
+    }
+
+
+def test_missing_patch_coverage_reports_added_missing_lines() -> None:
+    coverage = {
+        "files": {
+            "tree_sitter_analyzer/foo.py": {
+                "executed_lines": [2],
+                "missing_lines": [3],
+                "excluded_lines": [],
+                "missing_branches": [],
+            }
+        }
+    }
+
+    misses = check_patch_coverage.missing_patch_coverage(
+        {"tree_sitter_analyzer/foo.py": {2, 3, 10}},
+        coverage,
+        PROJECT_ROOT,
+    )
+
+    assert misses == [
+        check_patch_coverage.PatchCoverageMiss(
+            "tree_sitter_analyzer/foo.py", 3, "line not covered"
+        )
+    ]
+
+
+def test_missing_patch_coverage_reports_added_partial_branches() -> None:
+    coverage = {
+        "files": {
+            "tree_sitter_analyzer/foo.py": {
+                "executed_lines": [2],
+                "missing_lines": [],
+                "excluded_lines": [],
+                "missing_branches": [[2, 5]],
+            }
+        }
+    }
+
+    misses = check_patch_coverage.missing_patch_coverage(
+        {"tree_sitter_analyzer/foo.py": {2}},
+        coverage,
+        PROJECT_ROOT,
+    )
+
+    assert misses == [
+        check_patch_coverage.PatchCoverageMiss(
+            "tree_sitter_analyzer/foo.py", 2, "branch partially covered"
+        )
+    ]
+
+
+def test_missing_patch_coverage_skips_tests_and_non_executable_lines() -> None:
+    coverage = {
+        "files": {
+            "tree_sitter_analyzer/foo.py": {
+                "executed_lines": [4],
+                "missing_lines": [],
+                "excluded_lines": [2],
+                "missing_branches": [],
+            },
+            "tests/unit/test_foo.py": {
+                "executed_lines": [],
+                "missing_lines": [2],
+                "excluded_lines": [],
+                "missing_branches": [],
+            },
+        }
+    }
+
+    misses = check_patch_coverage.missing_patch_coverage(
+        {
+            "tree_sitter_analyzer/foo.py": {1, 2, 4},
+            "tests/unit/test_foo.py": {2},
+        },
+        coverage,
+        PROJECT_ROOT,
+    )
+
+    assert misses == []
+
+
+def test_cli_fails_when_diff_has_added_missing_line(tmp_path: Path) -> None:
+    diff_file = tmp_path / "patch.diff"
+    coverage_file = tmp_path / "coverage.json"
+    diff_file.write_text(
+        """diff --git a/tree_sitter_analyzer/foo.py b/tree_sitter_analyzer/foo.py
+--- a/tree_sitter_analyzer/foo.py
++++ b/tree_sitter_analyzer/foo.py
+@@ -1,0 +1,2 @@
++def new_func():
++    return 1
+""",
+        encoding="utf-8",
+    )
+    coverage_file.write_text(
+        json.dumps(
+            {
+                "files": {
+                    "tree_sitter_analyzer/foo.py": {
+                        "executed_lines": [1],
+                        "missing_lines": [2],
+                        "excluded_lines": [],
+                        "missing_branches": [],
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--diff-file",
+            str(diff_file),
+            "--coverage-json",
+            str(coverage_file),
+        ],
+        cwd=PROJECT_ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+
+    assert result.returncode == 1
+    assert "tree_sitter_analyzer/foo.py:2: line not covered" in result.stdout


### PR DESCRIPTION
## Summary
- add scripts/check_patch_coverage.py to fail locally on PR-added executable lines and branch partials that Codecov would flag
- document the local Codecov gate in AGENTS.md and docs/TESTING.md
- add an Agent Dogfood Feedback Loop requiring TSA feedback runs and memory capture for reusable findings
- guard both processes with agent contract tests

## Verification
- uv run ruff check scripts/check_patch_coverage.py tests/unit/test_patch_coverage_check.py tests/unit/test_agent_contracts.py
- uv run pytest tests/unit/test_patch_coverage_check.py tests/unit/test_agent_contracts.py -q --cov=tree_sitter_analyzer --cov-report=json --cov-report=term-missing:skip-covered
- uv run python scripts/check_patch_coverage.py --base origin/develop --coverage-json coverage.json
- uv run pytest -q (17837 passed, 104 skipped, 2 xfailed, 1 rerun in 95.99s)
