### PR TITLE
fix(benchmark): evaluate current run schema

### DIFF
--- a/benchmarks/codegraph_compare/evaluate.py
+++ b/benchmarks/codegraph_compare/evaluate.py
@@ -30,6 +30,7 @@ import argparse
 import json
 import re
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -246,12 +247,44 @@ def _build_eval_prompt(
     else:
         template = _DEFAULT_EVALUATOR_PROMPT
 
-    key_points_block = "\n".join(f"- {p}" for p in expected_key_points)
-    return template.format(
-        question=question_text,
-        key_points=key_points_block,
+    return _render_eval_template(
+        template=template,
+        question_text=question_text,
+        expected_key_points=expected_key_points,
         answer=answer,
     )
+
+
+def _render_eval_template(
+    *,
+    template: str,
+    question_text: str,
+    expected_key_points: list[str],
+    answer: str,
+) -> str:
+    """Render evaluator input without treating JSON braces as format fields."""
+    key_points_block = "\n".join(f"- {p}" for p in expected_key_points)
+    replacements = {
+        "{question}": question_text,
+        "{key_points}": key_points_block,
+        "{answer}": answer,
+    }
+    if any(placeholder in template for placeholder in replacements):
+        rendered = template
+        for placeholder, value in replacements.items():
+            rendered = rendered.replace(placeholder, value)
+        return rendered
+
+    input_block = (
+        "\n\n## Benchmark Input\n\n"
+        "### Question\n"
+        f"{question_text}\n\n"
+        "### Expected key points\n"
+        f"{key_points_block or '(none)'}\n\n"
+        "### Answer under evaluation\n"
+        f"{answer}\n"
+    )
+    return template.rstrip() + input_block
 
 
 def _call_llm(
@@ -445,7 +478,7 @@ def _evaluate_run_inner(
 ) -> dict:
     run_id = run.get("run_id", "")
     question_id = question.get("id", run.get("question_id", ""))
-    arm_id = run.get("arm_id", "")
+    arm_id = _run_arm_id(run)
     run_repo_path = run.get("repo_path", str(repo_path))
 
     # ------------------------------------------------------------------
@@ -565,7 +598,7 @@ def _minimal_error_record(run: dict, question: dict, reason: str) -> dict:
     return _build_record(
         run_id=run.get("run_id", ""),
         question_id=question.get("id", run.get("question_id", "")),
-        arm_id=run.get("arm_id", ""),
+        arm_id=_run_arm_id(run),
         repo_path=run.get("repo_path", ""),
         correctness=_ERROR_SCORE,
         completeness=_ERROR_SCORE,
@@ -598,6 +631,7 @@ def _build_record(
     eval_model: str,
 ) -> dict:
     """Assemble a canonical EvalRecord dict."""
+    evaluated_at = datetime.now(timezone.utc).isoformat()
     return {
         "run_id": run_id,
         "question_id": question_id,
@@ -613,7 +647,19 @@ def _build_record(
         "reasoning": reasoning,
         "evaluated_with_llm": evaluated_with_llm,
         "eval_model": eval_model,
+        "evaluator_model": eval_model,
+        "evaluated_at": evaluated_at,
     }
+
+
+def _run_arm_id(run: dict) -> str:
+    """Return the arm id across historical and current RunRecord schemas."""
+    return str(run.get("arm_id") or run.get("arm") or "")
+
+
+def _run_repo_id(run: dict) -> str:
+    """Return the repo id across historical and current RunRecord schemas."""
+    return str(run.get("repo_id") or run.get("repo") or "")
 
 
 # ---------------------------------------------------------------------------
@@ -678,7 +724,7 @@ def evaluate_all(
         if repo_path_str:
             repo_path = Path(repo_path_str)
         else:
-            repo_id = run.get("repo_id", "")
+            repo_id = _run_repo_id(run)
             if repo_id and repo_id in repo_path_by_id:
                 repo_path = repo_path_by_id[repo_id]
             else:

--- a/benchmarks/codegraph_compare/evaluate.py
+++ b/benchmarks/codegraph_compare/evaluate.py
@@ -123,6 +123,7 @@ _SAFE_DEFAULT_SCORES: dict[str, Any] = {
     "citation_quality": 3,
     "hallucination_risk": 3,
     "reasoning": "LLM response could not be parsed; safe defaults used.",
+    "_llm_success": False,
 }
 
 
@@ -357,6 +358,7 @@ def _call_llm(
     scores["reasoning"] = str(
         parsed.get("reasoning", _SAFE_DEFAULT_SCORES["reasoning"])
     )
+    scores["_llm_success"] = True
     return scores
 
 
@@ -552,7 +554,7 @@ def _evaluate_run_inner(
             answer=answer,
         )
         scores = _call_llm(eval_prompt, model=model)
-        evaluated_with_llm = True
+        evaluated_with_llm = bool(scores.pop("_llm_success", False))
 
     # ------------------------------------------------------------------
     # Step 4: Apply auto-penalties and compute overall

--- a/tests/unit/test_benchmark_harness.py
+++ b/tests/unit/test_benchmark_harness.py
@@ -467,3 +467,41 @@ class TestCodeGraphCompareEvaluator:
         assert record["overall"] == 3.0
         assert record["evaluated_with_llm"] is False
         assert record["evaluator_model"] == record["eval_model"]
+
+    def test_evaluate_run_marks_llm_fallback_as_not_evaluated(self, tmp_path: Path):
+        run = {
+            "run_id": "gin-route-matching__tsa-warm__codex__00",
+            "repo": "gin",
+            "question_id": "gin-route-matching",
+            "arm": "tsa-warm",
+            "answer": "Route matching is handled in tree.go:1.",
+            "citations": ["tree.go:1"],
+            "error": None,
+        }
+        question = {
+            "id": "gin-route-matching",
+            "prompt": "Where is route matching handled?",
+            "expected_key_points": ["route matching"],
+        }
+        (tmp_path / "tree.go").write_text("package gin\n", encoding="utf-8")
+
+        with patch(
+            "benchmarks.codegraph_compare.evaluate._call_llm",
+            return_value={
+                "correctness": 3,
+                "completeness": 3,
+                "citation_quality": 3,
+                "hallucination_risk": 3,
+                "reasoning": "fallback",
+                "_llm_success": False,
+            },
+        ):
+            record = compare_evaluate.evaluate_run(
+                run=run,
+                question=question,
+                repo_path=tmp_path,
+                dry_run=False,
+            )
+
+        assert record["evaluated_with_llm"] is False
+        assert record["overall"] == 3.0

--- a/tests/unit/test_benchmark_harness.py
+++ b/tests/unit/test_benchmark_harness.py
@@ -28,6 +28,7 @@ import bench_runner  # noqa: E402
 import scenarios  # noqa: E402
 
 from benchmarks.codegraph_compare import analyze as compare_analyze  # noqa: E402
+from benchmarks.codegraph_compare import evaluate as compare_evaluate  # noqa: E402
 from benchmarks.codegraph_compare import run as compare_run  # noqa: E402
 from benchmarks.codegraph_compare.adapters import IndexStats  # noqa: E402
 from benchmarks.codegraph_compare.adapters.tree_sitter_analyzer import (  # noqa: E402
@@ -391,3 +392,78 @@ class TestCodeGraphCompareAnalysisGate:
             "codex/native-only" in item and "below quality" in item
             for item in violations
         )
+
+
+class TestCodeGraphCompareEvaluator:
+    def test_eval_prompt_renders_inputs_without_formatting_json_example(self):
+        prompt = compare_evaluate._build_eval_prompt(
+            question_text="Where is route matching handled?",
+            expected_key_points=["router tree", "method matching"],
+            answer="The route tree is used in tree.go.",
+        )
+
+        assert '"correctness"' in prompt
+        assert "Where is route matching handled?" in prompt
+        assert "router tree" in prompt
+        assert "The route tree is used in tree.go." in prompt
+
+    def test_evaluate_all_accepts_current_run_schema(self, tmp_path: Path):
+        repo = tmp_path / "gin"
+        repo.mkdir()
+        (repo / "tree.go").write_text("package gin\n", encoding="utf-8")
+
+        runs_jsonl = tmp_path / "runs.jsonl"
+        runs_jsonl.write_text(
+            json.dumps(
+                {
+                    "run_id": "gin-route-matching__tsa-warm__codex__00",
+                    "repo": "gin",
+                    "question_id": "gin-route-matching",
+                    "arm": "tsa-warm",
+                    "answer": "Route matching is handled in tree.go:1.",
+                    "citations": ["tree.go:1"],
+                    "error": None,
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        questions_yaml = tmp_path / "questions.yaml"
+        questions_yaml.write_text(
+            textwrap.dedent(
+                """
+                questions:
+                  - id: gin-route-matching
+                    repo: gin
+                    category: entrypoint-tracing
+                    prompt: Where is route matching handled?
+                    expected_key_points:
+                      - route matching
+                """
+            ).strip()
+            + "\n",
+            encoding="utf-8",
+        )
+        manifest = tmp_path / "prepared_repos.json"
+        manifest.write_text(
+            json.dumps([{"id": "gin", "local_path": str(repo)}]),
+            encoding="utf-8",
+        )
+        results_dir = tmp_path / "results"
+
+        evals = compare_evaluate.evaluate_all(
+            runs_jsonl=runs_jsonl,
+            questions_yaml=questions_yaml,
+            prepared_manifest=manifest,
+            results_dir=results_dir,
+            dry_run=True,
+        )
+
+        assert len(evals) == 1
+        record = evals[0]
+        assert record["arm_id"] == "tsa-warm"
+        assert record["repo_path"] == str(repo)
+        assert record["bad_citations"] == []
+        assert record["overall"] == 3.0
+        assert record["evaluated_with_llm"] is False
+        assert record["evaluator_model"] == record["eval_model"]


### PR DESCRIPTION
## Summary
- render evaluator prompts without treating JSON examples as format placeholders
- accept current benchmark RunRecord fields (`repo`/`arm`) when resolving repo paths and eval arm IDs
- add unit coverage for evaluator prompt rendering and current run-schema dry-run evaluation

## Verification
- uv run pytest tests/unit/test_benchmark_harness.py -q
- uv run pytest -q
- uv run ruff check benchmarks/codegraph_compare/evaluate.py tests/unit/test_benchmark_harness.py
- uv run python scripts/check_patch_coverage.py --base origin/develop --coverage-json coverage.json --worktree

## Benchmark impact
This fixes the blocker where real smoke runs evaluated to zero because the evaluator crashed on JSON braces and could not resolve `repo`/`arm` fields from current runs.