### PR TITLE
feat(codegraph): fallback query chains to concept search

### DIFF
--- a/tests/unit/test_codegraph_explore_helpers.py
+++ b/tests/unit/test_codegraph_explore_helpers.py
@@ -241,6 +241,7 @@ class TestConceptSearchHelpers:
     def test_nearby_symbols_skips_far_duplicates_and_caps_results(self):
         matches = [{"line": 50}]
         symbols = [
+            {"name": 'import "fmt"', "kind": "import", "line": 49},
             {"name": "missing_line", "kind": "function"},
             {"name": "far", "kind": "function", "line": 1},
             {"name": "dup", "kind": "function", "line": 45},
@@ -258,6 +259,30 @@ class TestConceptSearchHelpers:
 
     def test_nearby_symbols_degrades_on_invalid_json(self):
         assert helpers._nearby_symbols("{not json", [{"line": 1}]) == []
+
+    def test_definition_like_and_test_path_helpers_cover_go(self):
+        assert helpers._is_definition_like_match(
+            "func addRoute(path string) {}", ["route"]
+        )
+        assert helpers._is_test_like_path("gin_test.go")
+
+        rank = helpers._concept_rank(
+            {
+                "file_path": "gin_test.go",
+                "matched_terms": ["route"],
+                "matches": [{"text": "func TestRoute(t *testing.T) {", "line": 1}],
+            },
+            ["route"],
+        )
+
+        assert rank < helpers._concept_rank(
+            {
+                "file_path": "gin.go",
+                "matched_terms": ["route"],
+                "matches": [{"text": "func addRoute(path string) {", "line": 1}],
+            },
+            ["route"],
+        )
 
     def test_definition_like_match_requires_term_in_text(self):
         assert helpers._is_definition_like_match(

--- a/tests/unit/test_codegraph_query_tool.py
+++ b/tests/unit/test_codegraph_query_tool.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+import json
+import sqlite3
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
+from tree_sitter_analyzer.mcp.tools import _codegraph_query_concepts as concepts
 from tree_sitter_analyzer.mcp.tools._codegraph_query_dsl import (
     _ChainStep,
     bool_kw,
@@ -18,6 +21,7 @@ from tree_sitter_analyzer.mcp.tools.codegraph_query_tool import (
     CodeGraphQueryTool,
     _absolute_path,
     _affected_tests_facet,
+    _apply_concept_fallback,
     _build_file_entries,
     _compact_facets,
     _complexity_facet,
@@ -373,6 +377,131 @@ class TestCodeGraphQueryTool:
         assert [symbol["name"] for symbol in result["symbols"]] == ["run"]
 
     @pytest.mark.asyncio
+    async def test_execute_explore_falls_back_to_concept_search_for_plain_language(
+        self, tmp_path
+    ):
+        source = tmp_path / "router.py"
+        source.write_text(
+            "def handle_route():\n    # route matching lives here\n    return True\n",
+            encoding="utf-8",
+        )
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.execute(
+            """CREATE TABLE ast_index (
+                file_path TEXT,
+                language TEXT,
+                file_size INTEGER,
+                symbols_json TEXT
+            )"""
+        )
+        conn.execute(
+            "INSERT INTO ast_index VALUES (?, ?, ?, ?)",
+            (
+                "router.py",
+                "python",
+                source.stat().st_size,
+                json.dumps(
+                    {
+                        "symbols": [
+                            {
+                                "name": "handle_route",
+                                "kind": "function",
+                                "line": 1,
+                                "end_line": 3,
+                            }
+                        ]
+                    }
+                ),
+            ),
+        )
+        mock_cache = MagicMock()
+        mock_cache._get_conn.return_value = conn
+        mock_cache.query_callers.return_value = []
+        mock_cache.query_callees.return_value = []
+
+        with (
+            patch("tree_sitter_analyzer.ast_cache.ASTCache", return_value=mock_cache),
+            _patch_resolver_with({}),
+        ):
+            result = await CodeGraphQueryTool(str(tmp_path)).execute(
+                {
+                    "query": (
+                        "search('route matching').explore(max_files=3)"
+                        ".include(source=True).answer(compact=True)"
+                    ),
+                    "output_format": "json",
+                }
+            )
+
+        assert result["success"] is True
+        assert result["verdict"] == "INFO"
+        assert result["stats"]["concept_files_returned"] == 1
+        assert result["symbols"][0]["name"] == "handle_route"
+        source_facet = result["facets"]["source"]["files"][0]
+        assert source_facet["file"] == "router.py"
+        assert any(match["line"] == 2 for match in source_facet["matches"])
+        assert source_facet["symbols"][0]["name"] == "handle_route"
+
+    @pytest.mark.asyncio
+    async def test_execute_include_source_can_trigger_concept_fallback(self, tmp_path):
+        source = tmp_path / "router.py"
+        source.write_text(
+            "def handle_route():\n    # route matching lives here\n    return True\n",
+            encoding="utf-8",
+        )
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.execute(
+            """CREATE TABLE ast_index (
+                file_path TEXT,
+                language TEXT,
+                file_size INTEGER,
+                symbols_json TEXT
+            )"""
+        )
+        conn.execute(
+            "INSERT INTO ast_index VALUES (?, ?, ?, ?)",
+            (
+                "router.py",
+                "python",
+                source.stat().st_size,
+                json.dumps(
+                    {
+                        "symbols": [
+                            {
+                                "name": "handle_route",
+                                "kind": "function",
+                                "line": 1,
+                                "end_line": 3,
+                            }
+                        ]
+                    }
+                ),
+            ),
+        )
+        mock_cache = MagicMock()
+        mock_cache._get_conn.return_value = conn
+
+        with (
+            patch("tree_sitter_analyzer.ast_cache.ASTCache", return_value=mock_cache),
+            _patch_resolver_with({}),
+        ):
+            result = await CodeGraphQueryTool(str(tmp_path)).execute(
+                {
+                    "query": (
+                        "search('route matching')"
+                        ".include(source=True).answer(compact=True)"
+                    ),
+                    "output_format": "json",
+                }
+            )
+
+        assert result["verdict"] == "INFO"
+        assert result["stats"]["concept_files_returned"] == 1
+        assert result["facets"]["source"]["files"][0]["file"] == "router.py"
+
+    @pytest.mark.asyncio
     async def test_execute_batch_seed_include_sort_and_answer(self, tmp_path):
         source = tmp_path / "main.py"
         source.write_text(
@@ -516,6 +645,103 @@ class TestCodeGraphQueryInternals:
                 symbol["name"]
                 for symbol in _resolve_queries(MagicMock(), ["run", "helper"], limit=1)
             ] == ["run"]
+
+    def test_apply_concept_fallback_degrades_on_missing_seed_or_matches(self):
+        state = _QueryState()
+        _apply_concept_fallback(
+            cache=MagicMock(),
+            project_root="/tmp",
+            state=state,
+            max_files=2,
+            max_symbols=2,
+        )
+        assert state.files == []
+
+        state.seed_queries = ["missing concept"]
+        with patch(
+            "tree_sitter_analyzer.mcp.tools._codegraph_query_concepts."
+            "concept_entries_for_queries",
+            return_value=[],
+        ):
+            _apply_concept_fallback(
+                cache=MagicMock(),
+                project_root="/tmp",
+                state=state,
+                max_files=2,
+                max_symbols=2,
+            )
+
+        assert state.files == []
+        assert state.current == []
+
+    def test_query_concept_helpers_cover_empty_dedupe_and_limit_paths(self):
+        assert (
+            concepts.concept_entries_for_queries(
+                MagicMock(),
+                ["  "],
+                project_root="/tmp",
+                max_files=2,
+            )
+            == []
+        )
+
+        with patch.object(
+            concepts._h,
+            "concept_search",
+            return_value=[{"file_path": "src/router.py"}],
+        ) as concept_search:
+            assert concepts.concept_entries_for_queries(
+                MagicMock(),
+                ["src/router.py route route src/router.py"],
+                project_root="/tmp",
+                max_files=2,
+            ) == [{"file_path": "src/router.py"}]
+
+        concept_search.assert_called_once_with(
+            ANY,
+            ["route"],
+            ["src/router.py"],
+            "/tmp",
+            2,
+        )
+
+        entries = [
+            {
+                "file_path": "src/router.py",
+                "language": "python",
+                "symbols": [
+                    {"name": "", "kind": "function", "start_line": 1},
+                    {"name": "missing_line", "kind": "function", "start_line": 0},
+                    {
+                        "name": "handle_route",
+                        "kind": "function",
+                        "start_line": 2,
+                        "end_line": 4,
+                    },
+                    {
+                        "name": "handle_route",
+                        "kind": "function",
+                        "start_line": 2,
+                        "end_line": 4,
+                    },
+                    {"name": "helper", "kind": "function", "start_line": 8},
+                ],
+            },
+            {
+                "file_path": "",
+                "language": "python",
+                "symbols": [{"name": "ignored", "kind": "function", "start_line": 1}],
+            },
+        ]
+
+        limited = concepts.symbols_from_concept_entries(entries, limit=1)
+        assert [symbol["name"] for symbol in limited] == ["handle_route"]
+
+        all_symbols = concepts.symbols_from_concept_entries(entries, limit=10)
+        assert [symbol["name"] for symbol in all_symbols] == [
+            "handle_route",
+            "helper",
+        ]
 
     def test_relation_step_skips_symbols_without_names_and_empty_rows(self):
         mock_cache = MagicMock()

--- a/tree_sitter_analyzer/mcp/tools/_codegraph_explore_helpers.py
+++ b/tree_sitter_analyzer/mcp/tools/_codegraph_explore_helpers.py
@@ -339,6 +339,8 @@ def _nearby_symbols(
     nearby: list[dict[str, Any]] = []
     seen: set[tuple[str, int]] = set()
     for sym in symbols:
+        if _is_noise_nearby_symbol(sym):
+            continue
         line = int(sym.get("line", 0) or 0)
         if not line or all(abs(line - ml) > 30 for ml in match_lines):
             continue
@@ -363,6 +365,8 @@ def _concept_rank(entry: dict[str, Any], terms: list[str]) -> int:
     path = entry["file_path"].lower()
     matched = set(entry.get("matched_terms", []))
     rank = len(matched) * 100
+    if terms and all(term in matched for term in terms):
+        rank += 100
     rank += sum(60 for term in terms if term in path)
     rank += min(len(entry.get("matches", [])), 5) * 3
     if any(
@@ -373,6 +377,8 @@ def _concept_rank(entry: dict[str, Any], terms: list[str]) -> int:
     if path.startswith("src/"):
         rank += 40
     if any(part in path for part in ("/test/", "/tests/", "/fixtures/", "/gen/")):
+        rank -= 80
+    if _is_test_like_path(path):
         rank -= 80
     if "/copilot/" in path:
         rank -= 40
@@ -385,7 +391,27 @@ def _is_definition_like_match(text: str, terms: list[str]) -> bool:
         return False
     return bool(
         re.search(
-            r"\b(export\s+)?(abstract\s+)?(class|interface|function|const|let|var|type|enum)\b",
+            r"\b(export\s+)?(abstract\s+)?"
+            r"(class|interface|function|const|let|var|type|enum|func|struct)\b",
             lowered,
         )
+    )
+
+
+def _is_noise_nearby_symbol(symbol: dict[str, Any]) -> bool:
+    kind = str(symbol.get("kind", "")).lower()
+    name = str(symbol.get("name", "")).strip().lower()
+    return kind in {"import", "package", "module"} or name.startswith("import (")
+
+
+def _is_test_like_path(path: str) -> bool:
+    name = os.path.basename(path)
+    return bool(
+        name.startswith("test_")
+        or "_test." in name
+        or name.endswith(".test")
+        or name.endswith(".spec.ts")
+        or name.endswith(".test.ts")
+        or name.endswith(".spec.js")
+        or name.endswith(".test.js")
     )

--- a/tree_sitter_analyzer/mcp/tools/_codegraph_query_concepts.py
+++ b/tree_sitter_analyzer/mcp/tools/_codegraph_query_concepts.py
@@ -1,0 +1,85 @@
+"""Concept-search fallback helpers for chained CodeGraph queries."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from . import _codegraph_explore_helpers as _h
+
+
+def concept_entries_for_queries(
+    cache: Any,
+    queries: list[str],
+    *,
+    project_root: str,
+    max_files: int,
+) -> list[dict[str, Any]]:
+    """Return file-level concept matches for unresolved chain seeds."""
+    query_terms, file_tokens = _split_seed_queries(queries)
+    if not query_terms and not file_tokens:
+        return []
+    return _h.concept_search(
+        cache,
+        query_terms,
+        file_tokens,
+        project_root,
+        max_files,
+    )
+
+
+def symbols_from_concept_entries(
+    entries: list[dict[str, Any]],
+    *,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Lift nearby concept-search symbols into the query chain state."""
+    symbols: list[dict[str, Any]] = []
+    seen: set[tuple[str, int, str]] = set()
+    for entry in entries:
+        file_path = str(entry.get("file_path") or "")
+        language = str(entry.get("language") or "")
+        for symbol in entry.get("symbols", []):
+            line = int(symbol.get("start_line", 0) or 0)
+            name = str(symbol.get("name") or "")
+            if not file_path or not line or not name:
+                continue
+            key = (file_path, line, name)
+            if key in seen:
+                continue
+            seen.add(key)
+            symbols.append(
+                {
+                    "name": name,
+                    "kind": symbol.get("kind", "unknown"),
+                    "file": file_path,
+                    "line": line,
+                    "end_line": int(symbol.get("end_line", line) or line),
+                    "language": language,
+                }
+            )
+            if len(symbols) >= limit:
+                return symbols
+    return symbols
+
+
+def _split_seed_queries(queries: list[str]) -> tuple[list[str], list[str]]:
+    query_terms: list[str] = []
+    file_tokens: list[str] = []
+    seen_terms: set[str] = set()
+    seen_files: set[str] = set()
+    for query in queries:
+        symbols, files = _h.split_query(query)
+        for symbol in symbols or [query]:
+            token = symbol.strip()
+            if token and token not in seen_terms:
+                seen_terms.add(token)
+                query_terms.append(token)
+        for file_token in files:
+            token = file_token.strip()
+            if token and token not in seen_files:
+                seen_files.add(token)
+                file_tokens.append(token)
+    return query_terms, file_tokens
+
+
+__all__ = ["concept_entries_for_queries", "symbols_from_concept_entries"]

--- a/tree_sitter_analyzer/mcp/tools/codegraph_query_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_query_tool.py
@@ -19,6 +19,7 @@ from typing import Any
 from ...utils import setup_logger
 from ..utils.format_helper import apply_toon_format_to_response
 from . import _codegraph_explore_helpers as _h
+from . import _codegraph_query_concepts as _concepts
 from ._codegraph_query_dsl import (
     _ChainStep,
     bool_kw,
@@ -186,8 +187,9 @@ class CodeGraphQueryTool(BaseMCPTool):
                 _compact_symbol(symbol) for symbol in state.symbols[:max_symbols]
             ]
 
+        has_evidence = bool(state.symbols or state.files)
         result = build_response(
-            verdict="INFO" if state.symbols else "NOT_FOUND",
+            verdict="INFO" if has_evidence else "NOT_FOUND",
             query=query,
             normalized_chain=[step_to_dict(step) for step in steps],
             symbols=symbols_payload,
@@ -198,6 +200,7 @@ class CodeGraphQueryTool(BaseMCPTool):
                 "steps": len(steps),
                 "symbols_returned": len(state.symbols),
                 "files_returned": len(state.files),
+                "concept_files_returned": state.concept_files_returned,
                 "facets_returned": len(state.facets),
                 "compact": state.compact,
                 "caller_edges": sum(
@@ -224,6 +227,7 @@ class CodeGraphQueryTool(BaseMCPTool):
         if step.name == "search":
             queries = string_args(step, required=True)
             limit = int_kw(step, "limit", default_max_symbols, _MAX_SYMBOLS_CAP)
+            state.seed_queries = queries
             state.current = _resolve_queries(cache, queries, limit)
             state.add_symbols(state.current)
             return
@@ -234,6 +238,7 @@ class CodeGraphQueryTool(BaseMCPTool):
                 limit = int_kw(
                     step, "max_symbols", default_max_symbols, _MAX_SYMBOLS_CAP
                 )
+                state.seed_queries = queries
                 state.current = _resolve_queries(cache, queries, limit)
                 state.add_symbols(state.current)
             max_files = int_kw(step, "max_files", default_max_files, _MAX_FILES_CAP)
@@ -241,6 +246,16 @@ class CodeGraphQueryTool(BaseMCPTool):
                 step, "max_symbols", default_max_symbols, _MAX_SYMBOLS_CAP
             )
             include_code = bool_kw(step, "include_code", default_include_code)
+            if not state.current:
+                _apply_concept_fallback(
+                    cache=cache,
+                    project_root=self.project_root or "",
+                    state=state,
+                    max_files=max_files,
+                    max_symbols=max_symbols,
+                )
+            if state.files and state.concept_files_returned:
+                return
             state.files = _build_file_entries(
                 project_root=self.project_root or "",
                 symbols=state.current[:max_symbols],
@@ -306,6 +321,8 @@ class _QueryState:
         self.facets: dict[str, Any] = {}
         self._seen_symbols: set[tuple[str, int, str]] = set()
         self.compact = compact
+        self.seed_queries: list[str] = []
+        self.concept_files_returned = 0
 
     def add_symbols(self, symbols: list[dict[str, Any]]) -> None:
         for symbol in symbols:
@@ -347,6 +364,33 @@ def _resolve_query(cache: Any, query: str, limit: int) -> list[dict[str, Any]]:
             if len(resolved) >= limit:
                 return resolved
     return resolved
+
+
+def _apply_concept_fallback(
+    *,
+    cache: Any,
+    project_root: str,
+    state: _QueryState,
+    max_files: int,
+    max_symbols: int,
+) -> None:
+    if not state.seed_queries:
+        return
+    entries = _concepts.concept_entries_for_queries(
+        cache,
+        state.seed_queries,
+        project_root=project_root,
+        max_files=max_files,
+    )
+    if not entries:
+        return
+    state.files = entries
+    state.concept_files_returned = len(entries)
+    state.current = _concepts.symbols_from_concept_entries(
+        entries,
+        limit=max_symbols,
+    )
+    state.add_symbols(state.current)
 
 
 def _resolve_queries(
@@ -463,12 +507,21 @@ def _include_facets(
         }
     if bool_kw(step, "source", False):
         if not state.files:
-            state.files = _build_file_entries(
-                project_root=project_root,
-                symbols=state.current[:max_symbols],
-                max_files=max_files,
-                include_code=include_code,
-            )
+            if not state.current:
+                _apply_concept_fallback(
+                    cache=cache,
+                    project_root=project_root,
+                    state=state,
+                    max_files=max_files,
+                    max_symbols=max_symbols,
+                )
+            if not state.files or not state.concept_files_returned:
+                state.files = _build_file_entries(
+                    project_root=project_root,
+                    symbols=state.current[:max_symbols],
+                    max_files=max_files,
+                    include_code=include_code,
+                )
         state.facets["source"] = {
             "status": "included",
             "file_count": len(state.files),
@@ -663,6 +716,15 @@ def _compact_file_entry(entry: dict[str, Any]) -> dict[str, Any]:
     }
     if entry.get("language"):
         compacted["lang"] = entry["language"]
+    if entry.get("matches"):
+        compacted["matches"] = [
+            {
+                "line": match.get("line", 0),
+                "text": match.get("text", ""),
+                "terms": match.get("terms", []),
+            }
+            for match in entry.get("matches", [])[:5]
+        ]
     for symbol in entry.get("symbols", []):
         start_line = int(symbol.get("start_line", 0) or 0)
         end_line = int(symbol.get("end_line", start_line) or start_line)


### PR DESCRIPTION
## Summary
- add concept-search fallback for unresolved codegraph_query chain seeds
- preserve file-level concept matches in compact source facets
- reduce concept noise by filtering import/package nearby symbols and penalizing root test-like files

## Dogfood
- Gin route-matching chain now returns INFO instead of NOT_FOUND:
  `search('route matching').explore(...).include(source=True, callers=True, callees=True).answer(compact=True)`
- Top source evidence now starts with `tree.go` for the Gin route-matching scenario.

## Verification
- `uv run pytest tests/unit/test_codegraph_explore_tool.py -q`
- `uv run pytest tests/unit/test_codegraph_query_tool.py tests/unit/test_codegraph_explore_helpers.py -q`
- `uv run pytest -q` -> 17852 passed, 104 skipped, 2 xfailed in 64.80s
- `uv run pytest tests/unit/test_codegraph_query_tool.py tests/unit/test_codegraph_explore_helpers.py --cov=tree_sitter_analyzer --cov-report=json --cov-report=term-missing -q`
- `uv run python scripts/check_patch_coverage.py --base origin/develop --coverage-json coverage.json --worktree`
- `uv run ruff check tree_sitter_analyzer/mcp/tools/_codegraph_explore_helpers.py tree_sitter_analyzer/mcp/tools/codegraph_query_tool.py tree_sitter_analyzer/mcp/tools/_codegraph_query_concepts.py tests/unit/test_codegraph_explore_helpers.py tests/unit/test_codegraph_query_tool.py`
- `git diff --check origin/develop...HEAD`