### PR TITLE
feat(codegraph): prioritize declaration query evidence

### DIFF
--- a/tests/unit/test_codegraph_explore_helpers.py
+++ b/tests/unit/test_codegraph_explore_helpers.py
@@ -54,6 +54,16 @@ class TestConceptSearchHelpers:
 
         assert helpers._concept_candidate_paths(conn, [], [], max_paths=5) == set()
 
+    def test_concept_candidate_paths_full_scans_declaration_queries(self):
+        conn = sqlite3.connect(":memory:")
+
+        assert (
+            helpers._concept_candidate_paths(
+                conn, ["node", "type", "struct"], [], max_paths=5
+            )
+            == set()
+        )
+
     def test_concept_candidate_paths_breaks_after_term_cap(self):
         conn = sqlite3.connect(":memory:")
         conn.execute("CREATE TABLE ast_index (file_path TEXT)")
@@ -237,6 +247,122 @@ class TestConceptSearchHelpers:
 
         assert entry is not None
         assert len(entry["matches"]) == 1
+
+    def test_concept_file_entry_prioritizes_type_declaration_matches(self, tmp_path):
+        source = tmp_path / "tree.go"
+        source.write_text(
+            "package gin\n\n"
+            "type Param struct {\n"
+            "\tKey string\n"
+            "}\n\n"
+            "type methodTree struct {\n"
+            "\troot *node\n"
+            "}\n\n"
+            "type nodeType uint8\n\n"
+            "type node struct {\n"
+            "\tpath string\n"
+            "\tchildren []*node\n"
+            "}\n\n"
+            "func (n *node) addChild(child *node) {}\n",
+            encoding="utf-8",
+        )
+
+        entry = helpers._concept_file_entry(
+            project_root=str(tmp_path),
+            rel_path="tree.go",
+            language="go",
+            symbols_json='{"symbols": [{"name": "addChild", "kind": "function", "line": 18}]}',
+            terms=["node", "type", "struct"],
+            max_matches=2,
+        )
+
+        assert entry is not None
+        assert any(match["text"] == "type node struct {" for match in entry["matches"])
+        assert entry["symbols"][0]["name"] == "node"
+        assert entry["symbols"][0]["kind"] == "type"
+        assert "children []*node" in entry["symbols"][0]["code"]
+
+    def test_concept_search_ranks_declaration_file_above_test_usage(self, tmp_path):
+        src = tmp_path / "tree.go"
+        test = tmp_path / "tree_test.go"
+        src.write_text(
+            "package gin\n\ntype node struct {\n\tpath string\n}\n",
+            encoding="utf-8",
+        )
+        test.write_text(
+            "package gin\n\nfunc checkRequests(t *testing.T, tree *node) {}\n",
+            encoding="utf-8",
+        )
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.execute(
+            """CREATE TABLE ast_index (
+                file_path TEXT,
+                language TEXT,
+                file_size INTEGER,
+                symbols_json TEXT
+            )"""
+        )
+        for path in (test, src):
+            conn.execute(
+                "INSERT INTO ast_index VALUES (?, ?, ?, ?)",
+                (
+                    path.name,
+                    "go",
+                    path.stat().st_size,
+                    '{"symbols": []}',
+                ),
+            )
+        cache = MagicMock()
+        cache._get_conn.return_value = conn
+
+        result = helpers.concept_search(
+            cache,
+            ["node", "type", "struct"],
+            [],
+            str(tmp_path),
+            max_files=2,
+        )
+
+        assert result[0]["file_path"] == "tree.go"
+        assert result[0]["symbols"][0]["name"] == "node"
+
+    def test_declaration_helpers_cover_invalid_lines_and_unclosed_blocks(self):
+        symbols = helpers._declaration_symbols_from_matches(
+            ["type node struct {}\n"],
+            [{"line": 0}, {"line": 2}, {"line": 1}],
+            ["node"],
+        )
+
+        assert [symbol["name"] for symbol in symbols] == ["node"]
+        assert helpers._declaration_symbol_from_line(
+            "class Router {}", 1, [], ["router"]
+        ) == {
+            "name": "Router",
+            "kind": "type",
+            "start_line": 1,
+            "end_line": 1,
+            "code": "class Router {}",
+        }
+        assert (
+            helpers._declaration_end_line(
+                ["type node struct {\n", "\tpath string\n"], 1
+            )
+            == 1
+        )
+
+    def test_dedupe_concept_symbols_skips_invalid_and_duplicates(self):
+        deduped = helpers._dedupe_concept_symbols(
+            [
+                {},
+                {"name": "node"},
+                {"name": "node", "start_line": 1},
+                {"name": "node", "start_line": 1},
+                {"name": "nodeValue", "start_line": 2},
+            ]
+        )
+
+        assert [symbol["name"] for symbol in deduped] == ["node", "nodeValue"]
 
     def test_nearby_symbols_skips_far_duplicates_and_caps_results(self):
         matches = [{"line": 50}]

--- a/tests/unit/test_codegraph_explore_helpers.py
+++ b/tests/unit/test_codegraph_explore_helpers.py
@@ -351,6 +351,29 @@ class TestConceptSearchHelpers:
             == 1
         )
 
+    def test_declaration_symbol_from_line_supports_go_type_aliases(self):
+        assert helpers._declaration_symbol_from_line(
+            "type HandlerFunc func(*Context)", 9, [], ["handlerfunc"]
+        ) == {
+            "name": "HandlerFunc",
+            "kind": "type",
+            "start_line": 9,
+            "end_line": 9,
+            "code": "type HandlerFunc func(*Context)",
+        }
+        assert (
+            helpers._declaration_symbol_from_line(
+                "type Params []Param", 12, [], ["params"]
+            )["name"]
+            == "Params"
+        )
+        assert (
+            helpers._declaration_symbol_from_line(
+                "type Params []Param", 12, [], ["node"]
+            )
+            is None
+        )
+
     def test_dedupe_concept_symbols_skips_invalid_and_duplicates(self):
         deduped = helpers._dedupe_concept_symbols(
             [

--- a/tests/unit/test_codegraph_query_tool.py
+++ b/tests/unit/test_codegraph_query_tool.py
@@ -662,6 +662,13 @@ class TestCodeGraphQueryInternals:
             "type",
             "struct",
         ]
+        assert concepts.symbol_candidate_tokens("type HandlerFunc func(*Context)") == [
+            "HandlerFunc"
+        ]
+        assert concepts.concept_query_terms("type HandlerFunc func(*Context)") == [
+            "HandlerFunc",
+            "type",
+        ]
         assert concepts.normalized_query_terms("func (engine .*handleHTTPRequest)") == [
             "handleHTTPRequest"
         ]

--- a/tests/unit/test_codegraph_query_tool.py
+++ b/tests/unit/test_codegraph_query_tool.py
@@ -657,6 +657,11 @@ class TestCodeGraphQueryInternals:
             "route",
             "matching",
         ]
+        assert concepts.concept_query_terms("type node struct") == [
+            "node",
+            "type",
+            "struct",
+        ]
         assert concepts.normalized_query_terms("func (engine .*handleHTTPRequest)") == [
             "handleHTTPRequest"
         ]

--- a/tree_sitter_analyzer/mcp/tools/_codegraph_explore_helpers.py
+++ b/tree_sitter_analyzer/mcp/tools/_codegraph_explore_helpers.py
@@ -42,6 +42,8 @@ FILE_EXT_MARKERS = (
     ".toml",
 )
 
+DECLARATION_TERMS = {"class", "enum", "interface", "struct", "type"}
+
 
 def split_query(query: str) -> tuple[list[str], list[str]]:
     """Return (symbol_tokens, file_tokens) from a whitespace-tokenised query.
@@ -208,6 +210,8 @@ def _concept_candidate_paths(
     """
     if not terms and not file_tokens:
         return set()
+    if any(term in DECLARATION_TERMS for term in terms):
+        return set()
     candidates: set[str] = set()
 
     def _add_rows(sql: str, params: tuple[Any, ...]) -> None:
@@ -298,34 +302,68 @@ def _concept_file_entry(
     except OSError:
         return None
 
-    matches: list[dict[str, Any]] = []
-    matched_terms: set[str] = set()
+    raw_matches: list[dict[str, Any]] = []
     for line_no, line in enumerate(lines, start=1):
         lowered = line.lower()
         terms_on_line = [term for term in terms if term in lowered]
         if not terms_on_line:
             continue
-        matched_terms.update(terms_on_line)
-        matches.append(
+        if not _concept_line_satisfies_declaration_query(terms_on_line, terms):
+            continue
+        raw_matches.append(
             {
                 "line": line_no,
                 "text": line.strip()[:300],
                 "terms": terms_on_line,
             }
         )
-        if len(matches) >= max_matches:
-            break
 
-    if not matches:
+    if not raw_matches:
         return None
+    scored_matches = [
+        (_concept_match_rank(match, terms), match) for match in raw_matches
+    ]
+    scored_matches.sort(key=lambda item: (-item[0], item[1]["line"]))
+    matches = [match for _, match in scored_matches[:max_matches]]
+    matches.sort(key=lambda match: int(match["line"]))
+    matched_terms = {term for match in matches for term in match.get("terms", [])}
+    declaration_symbols = _declaration_symbols_from_matches(lines, matches, terms)
+    nearby_symbols = _nearby_symbols(symbols_json, matches)
 
     return {
         "file_path": rel_path,
         "language": language,
-        "symbols": _nearby_symbols(symbols_json, matches),
+        "symbols": _dedupe_concept_symbols([*declaration_symbols, *nearby_symbols]),
         "matches": matches,
         "matched_terms": sorted(matched_terms),
     }
+
+
+def _concept_line_satisfies_declaration_query(
+    terms_on_line: list[str], terms: list[str]
+) -> bool:
+    specific_terms = [term for term in terms if term not in DECLARATION_TERMS]
+    kind_terms = [
+        term for term in terms if term in DECLARATION_TERMS and term != "type"
+    ]
+    if specific_terms and not any(term in terms_on_line for term in specific_terms):
+        return False
+    if kind_terms and not any(term in terms_on_line for term in kind_terms):
+        return False
+    return True
+
+
+def _concept_match_rank(match: dict[str, Any], terms: list[str]) -> int:
+    text = str(match.get("text") or "")
+    matched = set(match.get("terms", []))
+    rank = len(matched) * 20
+    if terms and all(term in matched for term in terms):
+        rank += 100
+    if _is_definition_like_match(text, terms):
+        rank += 80
+    if _declaration_symbol_from_line(text, int(match.get("line", 0) or 0), [], terms):
+        rank += 120
+    return rank
 
 
 def _nearby_symbols(
@@ -361,6 +399,87 @@ def _nearby_symbols(
     return nearby
 
 
+def _declaration_symbols_from_matches(
+    lines: list[str],
+    matches: list[dict[str, Any]],
+    terms: list[str],
+) -> list[dict[str, Any]]:
+    symbols: list[dict[str, Any]] = []
+    for match in matches:
+        line_no = int(match.get("line", 0) or 0)
+        if line_no < 1 or line_no > len(lines):
+            continue
+        symbol = _declaration_symbol_from_line(
+            lines[line_no - 1], line_no, lines, terms
+        )
+        if symbol:
+            symbols.append(symbol)
+    return symbols
+
+
+def _declaration_symbol_from_line(
+    line: str,
+    line_no: int,
+    lines: list[str],
+    terms: list[str],
+) -> dict[str, Any] | None:
+    stripped = line.strip()
+    patterns = (
+        (r"^type\s+([A-Za-z_][A-Za-z0-9_]*)\s+(struct|interface)\b", "type"),
+        (
+            r"^(?:export\s+)?(?:class|interface|enum)\s+([A-Za-z_][A-Za-z0-9_]*)\b",
+            "type",
+        ),
+    )
+    for pattern, kind in patterns:
+        match = re.search(pattern, stripped)
+        if not match:
+            continue
+        name = match.group(1)
+        if terms and name.lower() not in terms:
+            continue
+        end_line = _declaration_end_line(lines, line_no)
+        code = (
+            extract_snippet_from_lines(lines, line_no, end_line) if lines else stripped
+        )
+        return {
+            "name": name,
+            "kind": kind,
+            "start_line": line_no,
+            "end_line": end_line,
+            "code": code,
+        }
+    return None
+
+
+def _declaration_end_line(lines: list[str], start_line: int) -> int:
+    if not lines or start_line < 1 or start_line > len(lines):
+        return start_line
+    brace_balance = 0
+    saw_open = False
+    for idx in range(start_line - 1, min(len(lines), start_line + 80)):
+        line = lines[idx]
+        brace_balance += line.count("{")
+        if "{" in line:
+            saw_open = True
+        brace_balance -= line.count("}")
+        if saw_open and brace_balance <= 0:
+            return idx + 1
+    return start_line
+
+
+def _dedupe_concept_symbols(symbols: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    seen: set[tuple[str, int]] = set()
+    for symbol in symbols:
+        key = (str(symbol.get("name") or ""), int(symbol.get("start_line", 0) or 0))
+        if not key[0] or not key[1] or key in seen:
+            continue
+        seen.add(key)
+        out.append(symbol)
+    return out
+
+
 def _concept_rank(entry: dict[str, Any], terms: list[str]) -> int:
     path = entry["file_path"].lower()
     matched = set(entry.get("matched_terms", []))
@@ -374,6 +493,8 @@ def _concept_rank(entry: dict[str, Any], terms: list[str]) -> int:
         for m in entry.get("matches", [])
     ):
         rank += 70
+    if any(symbol.get("kind") == "type" for symbol in entry.get("symbols", [])):
+        rank += 180
     if path.startswith("src/"):
         rank += 40
     if any(part in path for part in ("/test/", "/tests/", "/fixtures/", "/gen/")):

--- a/tree_sitter_analyzer/mcp/tools/_codegraph_explore_helpers.py
+++ b/tree_sitter_analyzer/mcp/tools/_codegraph_explore_helpers.py
@@ -425,7 +425,7 @@ def _declaration_symbol_from_line(
 ) -> dict[str, Any] | None:
     stripped = line.strip()
     patterns = (
-        (r"^type\s+([A-Za-z_][A-Za-z0-9_]*)\s+(struct|interface)\b", "type"),
+        (r"^type\s+([A-Za-z_][A-Za-z0-9_]*)\b", "type"),
         (
             r"^(?:export\s+)?(?:class|interface|enum)\s+([A-Za-z_][A-Za-z0-9_]*)\b",
             "type",

--- a/tree_sitter_analyzer/mcp/tools/_codegraph_query_concepts.py
+++ b/tree_sitter_analyzer/mcp/tools/_codegraph_query_concepts.py
@@ -69,6 +69,9 @@ def concept_entries_for_queries(
 
 def symbol_candidate_tokens(query: str) -> list[str]:
     """Return high-signal resolver tokens for code-like query strings."""
+    declared_type = _declared_type_name(query)
+    if declared_type:
+        return [declared_type]
     terms = normalized_query_terms(query)
     if not terms:
         return [query] if query else []
@@ -100,6 +103,9 @@ def normalized_query_terms(query: str) -> list[str]:
 
 def concept_query_terms(query: str) -> list[str]:
     """Return terms for source concept search, including declaration hints."""
+    declared_type = _declared_type_name(query)
+    if declared_type:
+        return _dedupe_tokens([declared_type, *_declaration_hint_terms(query)])
     return _dedupe_tokens(
         [*normalized_query_terms(query), *_declaration_hint_terms(query)]
     )
@@ -191,6 +197,11 @@ def _primary_signature_terms(query: str, terms: list[str]) -> list[str]:
     if terms:
         primary.append(terms[-1])
     return [term for term in primary if term]
+
+
+def _declared_type_name(query: str) -> str:
+    match = re.search(r"\btype\s+([A-Za-z_][A-Za-z0-9_]*)\b", query)
+    return match.group(1) if match else ""
 
 
 def _declaration_hint_terms(query: str) -> list[str]:

--- a/tree_sitter_analyzer/mcp/tools/_codegraph_query_concepts.py
+++ b/tree_sitter_analyzer/mcp/tools/_codegraph_query_concepts.py
@@ -98,6 +98,13 @@ def normalized_query_terms(query: str) -> list[str]:
     return _dedupe_tokens(terms)
 
 
+def concept_query_terms(query: str) -> list[str]:
+    """Return terms for source concept search, including declaration hints."""
+    return _dedupe_tokens(
+        [*normalized_query_terms(query), *_declaration_hint_terms(query)]
+    )
+
+
 def symbols_from_concept_entries(
     entries: list[dict[str, Any]],
     *,
@@ -140,7 +147,7 @@ def _split_seed_queries(queries: list[str]) -> tuple[list[str], list[str]]:
     seen_files: set[str] = set()
     for query in queries:
         _, files = _h.split_query(query)
-        for symbol in normalized_query_terms(query):
+        for symbol in concept_query_terms(query):
             token = symbol.strip()
             if token and token not in seen_terms:
                 seen_terms.add(token)
@@ -186,6 +193,17 @@ def _primary_signature_terms(query: str, terms: list[str]) -> list[str]:
     return [term for term in primary if term]
 
 
+def _declaration_hint_terms(query: str) -> list[str]:
+    hints: list[str] = []
+    lowered = query.lower()
+    if re.search(r"\btype\b", lowered):
+        hints.append("type")
+    for keyword in ("struct", "interface", "class", "enum"):
+        if re.search(rf"\b{keyword}\b", lowered):
+            hints.append(keyword)
+    return hints
+
+
 def _dedupe_tokens(tokens: list[str]) -> list[str]:
     out: list[str] = []
     seen: set[str] = set()
@@ -199,6 +217,7 @@ def _dedupe_tokens(tokens: list[str]) -> list[str]:
 
 
 __all__ = [
+    "concept_query_terms",
     "concept_entries_for_queries",
     "normalized_query_terms",
     "symbol_candidate_tokens",


### PR DESCRIPTION
## Summary
- Treat declaration-style chain seeds like `type node struct` as source-declaration searches instead of ordinary symbol/concept lookups.
- Rank exact declaration lines before nearby usages, synthesize compact `type` symbols, and include declaration snippets in the source facet.
- Avoid broad `type` matches polluting results when a specific identifier is present.

## Dogfood
- Gin `search('type node struct').explore(...).include(source=True).answer(compact=True)` now returns `tree.go:99` as the first symbol with the full `type node struct` snippet.
- Gin `search('type nodeValue')...` now returns only `tree.go` source evidence with `nodeValue` as the first symbol, instead of broad `binding/*` type matches.

## Verification
- `uv run ruff check tree_sitter_analyzer/mcp/tools/_codegraph_explore_helpers.py tree_sitter_analyzer/mcp/tools/_codegraph_query_concepts.py tests/unit/test_codegraph_explore_helpers.py tests/unit/test_codegraph_query_tool.py`
- `uv run pytest tests/unit/test_codegraph_explore_tool.py -q`
- `uv run pytest tests/unit/test_codegraph_explore_helpers.py tests/unit/test_codegraph_query_tool.py --cov=tree_sitter_analyzer --cov-report=json --cov-report=term-missing -q`
- `uv run python scripts/check_patch_coverage.py --base origin/develop --coverage-json coverage.json --worktree`
- `uv run pytest -q`
- `git diff --check`