### PR TITLE
feat(codegraph): surface Go const declarations in query chains

### DIFF
--- a/tests/unit/test_codegraph_explore_helpers.py
+++ b/tests/unit/test_codegraph_explore_helpers.py
@@ -374,6 +374,117 @@ class TestConceptSearchHelpers:
             is None
         )
 
+    def test_declaration_symbol_from_line_supports_go_const_blocks(self):
+        lines = [
+            "const (\n",
+            "\tstatic nodeType = iota\n",
+            "\troot\n",
+            "\tparam\n",
+            "\tcatchAll\n",
+            ")\n",
+        ]
+
+        assert helpers._declaration_symbol_from_line(
+            lines[1], 2, lines, ["static"]
+        ) == {
+            "name": "static",
+            "kind": "constant",
+            "start_line": 2,
+            "end_line": 6,
+            "code": "".join(lines),
+        }
+        assert (
+            helpers._declaration_symbol_from_line(lines[4], 5, lines, ["catchall"])[
+                "name"
+            ]
+            == "catchAll"
+        )
+        assert (
+            helpers._declaration_symbol_from_line(lines[4], 5, lines, ["node"]) is None
+        )
+        assert helpers._term_position("missing", ["static"]) == 1
+        assert helpers._declaration_symbol_from_line(
+            "const maxParams = 8", 11, [], ["maxparams"]
+        ) == {
+            "name": "maxParams",
+            "kind": "constant",
+            "start_line": 11,
+            "end_line": 11,
+            "code": "const maxParams = 8",
+        }
+        assert (
+            helpers._declaration_symbol_from_line(
+                "var routeCache = map[string]int{}", 12, [], ["routecache"]
+            )["kind"]
+            == "variable"
+        )
+
+    def test_block_declaration_bounds_cover_invalid_and_unclosed_blocks(self):
+        assert helpers._block_declaration_bounds(["const (\n"], 0) is None
+        assert (
+            helpers._block_declaration_bounds([")\n", "\tstatic nodeType = iota\n"], 2)
+            is None
+        )
+        assert helpers._block_declaration_bounds(["var (\n", "\tcurrent = 1\n"], 2) == (
+            1,
+            2,
+            "variable",
+        )
+
+    def test_concept_search_ranks_const_block_source_above_test_usage(self, tmp_path):
+        src = tmp_path / "tree.go"
+        src.write_text(
+            "package gin\n\n"
+            "type nodeType uint8\n\n"
+            "const (\n"
+            "\tstatic nodeType = iota\n"
+            "\troot\n"
+            "\tparam\n"
+            "\tcatchAll\n"
+            ")\n",
+            encoding="utf-8",
+        )
+        test = tmp_path / "tree_test.go"
+        test.write_text(
+            "package gin\n\n"
+            "func TestTreeCatchAllConflict(t *testing.T) {}\n"
+            "func TestTreeInvalidNodeType(t *testing.T) {}\n",
+            encoding="utf-8",
+        )
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.execute(
+            """CREATE TABLE ast_index (
+                file_path TEXT,
+                language TEXT,
+                file_size INTEGER,
+                symbols_json TEXT
+            )"""
+        )
+        for path in (test, src):
+            conn.execute(
+                "INSERT INTO ast_index VALUES (?, ?, ?, ?)",
+                (
+                    path.name,
+                    "go",
+                    path.stat().st_size,
+                    '{"symbols": []}',
+                ),
+            )
+        cache = MagicMock()
+        cache._get_conn.return_value = conn
+
+        result = helpers.concept_search(
+            cache,
+            ["catchAll", "nodeType"],
+            [],
+            str(tmp_path),
+            max_files=2,
+        )
+
+        assert result[0]["file_path"] == "tree.go"
+        assert result[0]["symbols"][0]["name"] == "catchAll"
+
     def test_dedupe_concept_symbols_skips_invalid_and_duplicates(self):
         deduped = helpers._dedupe_concept_symbols(
             [

--- a/tests/unit/test_codegraph_query_tool.py
+++ b/tests/unit/test_codegraph_query_tool.py
@@ -669,6 +669,33 @@ class TestCodeGraphQueryInternals:
             "HandlerFunc",
             "type",
         ]
+        assert concepts.symbol_candidate_tokens("static nodeType = iota") == [
+            "static",
+            "nodeType",
+            "iota",
+        ]
+        assert concepts.concept_query_terms("static nodeType = iota") == [
+            "static",
+            "nodeType",
+            "iota",
+            "const",
+        ]
+        assert concepts.symbol_candidate_tokens("const static nodeType = iota") == [
+            "static",
+            "nodeType",
+            "iota",
+        ]
+        assert concepts.concept_query_terms("const static nodeType = iota") == [
+            "static",
+            "nodeType",
+            "iota",
+            "const",
+        ]
+        assert concepts.concept_query_terms("catchAll nodeType") == [
+            "catchAll",
+            "nodeType",
+            "const",
+        ]
         assert concepts.normalized_query_terms("func (engine .*handleHTTPRequest)") == [
             "handleHTTPRequest"
         ]

--- a/tree_sitter_analyzer/mcp/tools/_codegraph_explore_helpers.py
+++ b/tree_sitter_analyzer/mcp/tools/_codegraph_explore_helpers.py
@@ -42,7 +42,7 @@ FILE_EXT_MARKERS = (
     ".toml",
 )
 
-DECLARATION_TERMS = {"class", "enum", "interface", "struct", "type"}
+DECLARATION_TERMS = {"class", "const", "enum", "interface", "struct", "type"}
 
 
 def split_query(query: str) -> tuple[list[str], list[str]]:
@@ -321,7 +321,7 @@ def _concept_file_entry(
     if not raw_matches:
         return None
     scored_matches = [
-        (_concept_match_rank(match, terms), match) for match in raw_matches
+        (_concept_match_rank(match, terms, lines), match) for match in raw_matches
     ]
     scored_matches.sort(key=lambda item: (-item[0], item[1]["line"]))
     matches = [match for _, match in scored_matches[:max_matches]]
@@ -344,7 +344,9 @@ def _concept_line_satisfies_declaration_query(
 ) -> bool:
     specific_terms = [term for term in terms if term not in DECLARATION_TERMS]
     kind_terms = [
-        term for term in terms if term in DECLARATION_TERMS and term != "type"
+        term
+        for term in terms
+        if term in DECLARATION_TERMS and term not in {"const", "type"}
     ]
     if specific_terms and not any(term in terms_on_line for term in specific_terms):
         return False
@@ -353,7 +355,9 @@ def _concept_line_satisfies_declaration_query(
     return True
 
 
-def _concept_match_rank(match: dict[str, Any], terms: list[str]) -> int:
+def _concept_match_rank(
+    match: dict[str, Any], terms: list[str], lines: list[str] | None = None
+) -> int:
     text = str(match.get("text") or "")
     matched = set(match.get("terms", []))
     rank = len(matched) * 20
@@ -361,7 +365,9 @@ def _concept_match_rank(match: dict[str, Any], terms: list[str]) -> int:
         rank += 100
     if _is_definition_like_match(text, terms):
         rank += 80
-    if _declaration_symbol_from_line(text, int(match.get("line", 0) or 0), [], terms):
+    line_no = int(match.get("line", 0) or 0)
+    source_line = lines[line_no - 1] if lines and 1 <= line_no <= len(lines) else text
+    if _declaration_symbol_from_line(source_line, line_no, lines or [], terms):
         rank += 120
     return rank
 
@@ -414,7 +420,21 @@ def _declaration_symbols_from_matches(
         )
         if symbol:
             symbols.append(symbol)
+    symbols.sort(
+        key=lambda symbol: (
+            _term_position(symbol.get("name", ""), terms),
+            symbol["start_line"],
+        )
+    )
     return symbols
+
+
+def _term_position(name: object, terms: list[str]) -> int:
+    lowered = str(name or "").lower()
+    try:
+        return terms.index(lowered)
+    except ValueError:
+        return len(terms)
 
 
 def _declaration_symbol_from_line(
@@ -426,6 +446,8 @@ def _declaration_symbol_from_line(
     stripped = line.strip()
     patterns = (
         (r"^type\s+([A-Za-z_][A-Za-z0-9_]*)\b", "type"),
+        (r"^const\s+([A-Za-z_][A-Za-z0-9_]*)\b", "constant"),
+        (r"^(?:var|let)\s+([A-Za-z_][A-Za-z0-9_]*)\b", "variable"),
         (
             r"^(?:export\s+)?(?:class|interface|enum)\s+([A-Za-z_][A-Za-z0-9_]*)\b",
             "type",
@@ -449,7 +471,62 @@ def _declaration_symbol_from_line(
             "end_line": end_line,
             "code": code,
         }
+    block_symbol = _block_member_declaration_symbol(stripped, line_no, lines, terms)
+    if block_symbol:
+        return block_symbol
     return None
+
+
+def _block_member_declaration_symbol(
+    stripped: str,
+    line_no: int,
+    lines: list[str],
+    terms: list[str],
+) -> dict[str, Any] | None:
+    if not lines or not stripped or stripped.startswith(("//", ")")):
+        return None
+    name_match = re.match(r"^([A-Za-z_][A-Za-z0-9_]*)\b", stripped)
+    if not name_match:
+        return None
+    name = name_match.group(1)
+    if terms and name.lower() not in terms:
+        return None
+    bounds = _block_declaration_bounds(lines, line_no)
+    if bounds is None:
+        return None
+    block_start, block_end, kind = bounds
+    return {
+        "name": name,
+        "kind": kind,
+        "start_line": line_no,
+        "end_line": block_end,
+        "code": extract_snippet_from_lines(lines, block_start, block_end),
+    }
+
+
+def _block_declaration_bounds(
+    lines: list[str], line_no: int
+) -> tuple[int, int, str] | None:
+    if line_no < 1 or line_no > len(lines):
+        return None
+    start = line_no - 1
+    while start >= 0:
+        stripped = lines[start].strip()
+        if re.match(r"^(const|var)\s*\(", stripped):
+            kind = "constant" if stripped.startswith("const") else "variable"
+            break
+        if stripped in {"}", ")"}:
+            return None
+        start -= 1
+    else:
+        return None
+
+    end = start
+    while end < len(lines):
+        if lines[end].strip().startswith(")"):
+            return start + 1, end + 1, kind
+        end += 1
+    return start + 1, line_no, kind
 
 
 def _declaration_end_line(lines: list[str], start_line: int) -> int:
@@ -493,7 +570,10 @@ def _concept_rank(entry: dict[str, Any], terms: list[str]) -> int:
         for m in entry.get("matches", [])
     ):
         rank += 70
-    if any(symbol.get("kind") == "type" for symbol in entry.get("symbols", [])):
+    if any(
+        symbol.get("kind") in {"constant", "type", "variable"}
+        for symbol in entry.get("symbols", [])
+    ):
         rank += 180
     if path.startswith("src/"):
         rank += 40

--- a/tree_sitter_analyzer/mcp/tools/_codegraph_query_concepts.py
+++ b/tree_sitter_analyzer/mcp/tools/_codegraph_query_concepts.py
@@ -72,9 +72,12 @@ def symbol_candidate_tokens(query: str) -> list[str]:
     declared_type = _declared_type_name(query)
     if declared_type:
         return [declared_type]
+    declared_const = _declared_const_name(query)
     terms = normalized_query_terms(query)
     if not terms:
         return [query] if query else []
+    if declared_const:
+        return _dedupe_tokens([declared_const, *terms])
     primary = _primary_signature_terms(query, terms)
     return _dedupe_tokens([*primary, *terms])
 
@@ -106,8 +109,24 @@ def concept_query_terms(query: str) -> list[str]:
     declared_type = _declared_type_name(query)
     if declared_type:
         return _dedupe_tokens([declared_type, *_declaration_hint_terms(query)])
+    declared_const = _declared_const_name(query)
+    normalized_terms = normalized_query_terms(query)
+    if declared_const:
+        return _dedupe_tokens(
+            [
+                declared_const,
+                *normalized_terms,
+                *_const_declaration_hint_terms(
+                    query, [declared_const, *normalized_terms]
+                ),
+            ]
+        )
     return _dedupe_tokens(
-        [*normalized_query_terms(query), *_declaration_hint_terms(query)]
+        [
+            *normalized_terms,
+            *_const_declaration_hint_terms(query, normalized_terms),
+            *_declaration_hint_terms(query),
+        ]
     )
 
 
@@ -202,6 +221,32 @@ def _primary_signature_terms(query: str, terms: list[str]) -> list[str]:
 def _declared_type_name(query: str) -> str:
     match = re.search(r"\btype\s+([A-Za-z_][A-Za-z0-9_]*)\b", query)
     return match.group(1) if match else ""
+
+
+def _declared_const_name(query: str) -> str:
+    match = re.search(r"\b(?:const|var|let)\s+([A-Za-z_][A-Za-z0-9_]*)\b", query)
+    if match:
+        return match.group(1)
+    if not re.search(r"\biota\b", query):
+        return ""
+    match = re.search(r"^\s*([A-Za-z_][A-Za-z0-9_]*)\b", query)
+    return match.group(1) if match else ""
+
+
+def _const_declaration_hint_terms(query: str, terms: list[str]) -> list[str]:
+    if re.search(r"\biota\b", query):
+        return ["const"]
+    if (
+        len(terms) >= 2
+        and _is_lower_camel(terms[0])
+        and any(term.lower().endswith("type") for term in terms[1:])
+    ):
+        return ["const"]
+    return []
+
+
+def _is_lower_camel(token: str) -> bool:
+    return bool(re.match(r"^[a-z][A-Za-z0-9]*[A-Z][A-Za-z0-9]*$", token))
 
 
 def _declaration_hint_terms(query: str) -> list[str]:


### PR DESCRIPTION
## Summary
- Treat Go const/var block members as declaration symbols in codegraph concept evidence
- Add const declaration hints for enum-like Go queries such as static nodeType = iota and catchAll nodeType
- Rank declaration symbols by selector term order so chained queries return the requested symbol first

## Dogfood
- Gin: search('static nodeType = iota') now returns tree.go:93 static as kind=constant
- Gin: search('catchAll nodeType') now returns tree.go:96 catchAll as kind=constant

## Verification
- uv run ruff check tree_sitter_analyzer/mcp/tools/_codegraph_explore_helpers.py tree_sitter_analyzer/mcp/tools/_codegraph_query_concepts.py tests/unit/test_codegraph_explore_helpers.py tests/unit/test_codegraph_query_tool.py
- uv run pytest tests/unit/test_codegraph_explore_helpers.py tests/unit/test_codegraph_query_tool.py -q
- uv run pytest tests/unit/test_codegraph_explore_tool.py -q
- uv run pytest tests/unit/test_codegraph_explore_helpers.py tests/unit/test_codegraph_query_tool.py --cov=tree_sitter_analyzer --cov-report=json --cov-report=term-missing -q
- uv run python scripts/check_patch_coverage.py --base origin/develop --coverage-json coverage.json --worktree
- uv run pytest -q
