### PR TITLE
feat(codegraph): prefer source symbols in query chains

### DIFF
--- a/tests/unit/test_codegraph_query_tool.py
+++ b/tests/unit/test_codegraph_query_tool.py
@@ -26,6 +26,7 @@ from tree_sitter_analyzer.mcp.tools.codegraph_query_tool import (
     _compact_facets,
     _complexity_facet,
     _dedupe_symbols,
+    _drop_test_shadow_symbols,
     _health_facet,
     _include_facets,
     _QueryState,
@@ -34,6 +35,7 @@ from tree_sitter_analyzer.mcp.tools.codegraph_query_tool import (
     _resolve_query,
     _risk_facet,
     _sort_state,
+    _source_preference_key,
     parse_chain,
 )
 from tree_sitter_analyzer.symbol_resolver import DefinitionLocation, ResolveResult
@@ -648,6 +650,32 @@ class TestCodeGraphQueryInternals:
 
         assert [symbol["name"] for symbol in result] == ["handleHTTPRequest"]
 
+    def test_resolve_query_drops_test_shadow_when_source_definition_exists(self):
+        defs = {
+            "ServeHTTP": [
+                _make_def(file="utils_test.go", name="ServeHTTP", line=33),
+                _make_def(file="gin.go", name="ServeHTTP", line=623),
+            ]
+        }
+
+        with _patch_resolver_with(defs):
+            result = _resolve_query(MagicMock(), "ServeHTTP", limit=5)
+
+        assert [symbol["file"] for symbol in result] == ["gin.go"]
+
+    def test_resolve_query_keeps_test_shadow_with_file_hint(self):
+        defs = {
+            "ServeHTTP": [
+                _make_def(file="utils_test.go", name="ServeHTTP", line=33),
+                _make_def(file="gin.go", name="ServeHTTP", line=623),
+            ]
+        }
+
+        with _patch_resolver_with(defs):
+            result = _resolve_query(MagicMock(), "utils_test.go ServeHTTP", limit=5)
+
+        assert [symbol["file"] for symbol in result] == ["utils_test.go"]
+
     def test_query_concept_token_normalization_prefers_signature_names(self):
         assert concepts.symbol_candidate_tokens("func (trees methodTrees) get") == [
             "get",
@@ -841,6 +869,45 @@ class TestCodeGraphQueryInternals:
         assert [symbol["name"] for symbol in related] == ["entry"]
         mock_cache.query_callers.assert_called_once_with("run", "main.py", max_depth=1)
         assert state.relationships["callers"]["main.py:2:run"][0]["name"] == "entry"
+
+    def test_relation_step_sorts_source_edges_before_tests_then_limits(self):
+        mock_cache = MagicMock()
+        mock_cache.query_callees.return_value = [
+            {
+                "callee_name": "ServeHTTP",
+                "callee_file": "utils_test.go",
+                "callee_line": 33,
+                "depth": 1,
+            },
+            {
+                "callee_name": "ServeHTTP",
+                "callee_file": "gin.go",
+                "callee_line": 623,
+                "depth": 1,
+            },
+        ]
+        state = _QueryState()
+        state.current = [{"name": "dispatch", "file": "gin.go", "line": 600}]
+
+        related = _relation_step(
+            mock_cache,
+            state,
+            direction="callees",
+            step=_ChainStep("callees", [], {"limit": 1}),
+        )
+
+        assert [symbol["file"] for symbol in related] == ["gin.go"]
+        assert state.relationships["callees"]["gin.go:600:dispatch"][0]["line"] == 623
+
+    def test_source_preference_key_identifies_test_fixture_and_generated_paths(self):
+        source = {"file": "gin.go", "line": 2, "name": "run"}
+        test = {"file": "tests/fixtures/gin_test.go", "line": 1, "name": "run"}
+        generated = {"file": "src/generated/gin.go", "line": 1, "name": "run"}
+
+        assert _source_preference_key(source) < _source_preference_key(test)
+        assert _source_preference_key(source) < _source_preference_key(generated)
+        assert _drop_test_shadow_symbols([test, source]) == [source]
+        assert _drop_test_shadow_symbols([test]) == [test]
 
     def test_sort_state_supports_path_alias_fan_out_and_rejects_unknown_fields(self):
         state = _QueryState()

--- a/tree_sitter_analyzer/mcp/tools/codegraph_query_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_query_tool.py
@@ -340,9 +340,9 @@ def _resolve_query(cache: Any, query: str, limit: int) -> list[dict[str, Any]]:
     _, file_tokens = _h.split_query(query)
     symbol_tokens = _concepts.symbol_candidate_tokens(query)
 
-    resolved: list[dict[str, Any]] = []
+    resolved: list[tuple[int, dict[str, Any]]] = []
     seen: set[tuple[str, int, str]] = set()
-    for token in symbol_tokens:
+    for token_order, token in enumerate(symbol_tokens):
         try:
             defs = resolver.resolve(token).definitions
         except Exception as exc:
@@ -359,10 +359,12 @@ def _resolve_query(cache: Any, query: str, limit: int) -> list[dict[str, Any]]:
             if key in seen:
                 continue
             seen.add(key)
-            resolved.append(item)
-            if len(resolved) >= limit:
-                return resolved
-    return resolved
+            resolved.append((token_order, item))
+    resolved.sort(key=lambda item: (item[0], _source_preference_key(item[1])))
+    symbols = [item for _, item in resolved]
+    if not file_tokens:
+        symbols = _drop_test_shadow_symbols(symbols)
+    return symbols[:limit]
 
 
 def _apply_concept_fallback(
@@ -424,15 +426,17 @@ def _relation_step(
             rows = cache.query_callers(name, file_path or None, max_depth=depth) or []
             entries = [
                 _row_symbol(row, "caller_name", "caller_file", "caller_line")
-                for row in rows[:limit]
+                for row in rows
             ]
         else:
             rows = cache.query_callees(name, file_path or None, max_depth=depth) or []
             entries = [
                 _row_symbol(row, "callee_name", "callee_file", "callee_line")
-                for row in rows[:limit]
+                for row in rows
             ]
-        entries = [entry for entry in entries if entry["name"]]
+        entries = _source_first_symbols(entry for entry in entries if entry["name"])[
+            :limit
+        ]
         source_key = _symbol_key(symbol)
         state.relationships[direction][source_key] = entries
         related.extend(entries)
@@ -865,6 +869,58 @@ def _dedupe_symbols(symbols: list[dict[str, Any]]) -> list[dict[str, Any]]:
         seen.add(key)
         out.append(symbol)
     return out
+
+
+def _source_first_symbols(symbols: Any) -> list[dict[str, Any]]:
+    return sorted(symbols, key=_source_preference_key)
+
+
+def _drop_test_shadow_symbols(symbols: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    source_names = {
+        str(symbol.get("name") or "").lower()
+        for symbol in symbols
+        if symbol.get("name")
+        and not _is_test_or_fixture_path(str(symbol.get("file") or "").lower())
+    }
+    if not source_names:
+        return symbols
+    return [
+        symbol
+        for symbol in symbols
+        if not (
+            str(symbol.get("name") or "").lower() in source_names
+            and _is_test_or_fixture_path(str(symbol.get("file") or "").lower())
+        )
+    ]
+
+
+def _source_preference_key(symbol: dict[str, Any]) -> tuple[int, int, str, int, str]:
+    path = str(symbol.get("file") or "")
+    normalized = path.replace("\\", "/").lower()
+    return (
+        1 if _is_test_or_fixture_path(normalized) else 0,
+        1 if _is_generated_or_vendor_path(normalized) else 0,
+        normalized,
+        int(symbol.get("line", 0) or 0),
+        str(symbol.get("name") or ""),
+    )
+
+
+def _is_test_or_fixture_path(path: str) -> bool:
+    name = os.path.basename(path)
+    return bool(
+        "/test/" in path
+        or "/tests/" in path
+        or "/__tests__/" in path
+        or "/fixtures/" in path
+        or name.startswith("test_")
+        or "_test." in name
+        or name.endswith((".test.ts", ".test.tsx", ".test.js", ".spec.ts", ".spec.js"))
+    )
+
+
+def _is_generated_or_vendor_path(path: str) -> bool:
+    return any(part in path for part in ("/vendor/", "/gen/", "/generated/"))
 
 
 def _unique_symbol_files(symbols: list[dict[str, Any]]) -> list[str]:


### PR DESCRIPTION
## Summary
- Rank codegraph_query search and relation results source-first so production symbols appear before tests/fixtures/generated paths.
- Drop same-name test/fixture shadow definitions when a source definition exists and no explicit file hint was provided.
- Preserve explicit test file queries such as `utils_test.go ServeHTTP`.

## Dogfood evidence
- Gin `search('ServeHTTP').include(source=True, callees=True).answer(compact=True)` now expands only `gin.go:ServeHTTP` and its production callees.
- Gin `search('utils_test.go ServeHTTP')...` still returns the test fake.

## Verification
- `uv run ruff check tree_sitter_analyzer/mcp/tools/codegraph_query_tool.py tests/unit/test_codegraph_query_tool.py`
- `uv run pytest tests/unit/test_codegraph_query_tool.py -q`
- `uv run pytest tests/unit/test_codegraph_query_tool.py --cov=tree_sitter_analyzer --cov-report=json --cov-report=term-missing -q`
- `uv run python scripts/check_patch_coverage.py --base origin/develop --coverage-json coverage.json --worktree`
- `uv run python -m tree_sitter_analyzer --change-impact --format json`
- `uv sync --all-extras` (restored missing Swift optional dependency in this worktree)
- `uv run pytest -q` -> 17873 passed, 104 skipped, 2 xfailed in 57.60s