### PR TITLE
feat(codegraph): include long source excerpts in query packs

### DIFF
--- a/tests/unit/test_codegraph_query_tool.py
+++ b/tests/unit/test_codegraph_query_tool.py
@@ -927,11 +927,14 @@ class TestCodeGraphQueryInternals:
         with pytest.raises(ValueError, match="unsupported field"):
             _sort_state(state, _ChainStep("sort", [], {"by": "unknown"}))
 
-    def test_build_file_entries_skips_blank_files_and_omits_oversized_snippets(
+    def test_build_file_entries_includes_truncated_excerpt_for_long_symbols(
         self, tmp_path
     ):
         source = tmp_path / "main.py"
-        source.write_text("def run():\n    return 1\n", encoding="utf-8")
+        source.write_text(
+            "\n".join(f"line_{idx}" for idx in range(1, 201)) + "\n",
+            encoding="utf-8",
+        )
 
         entries = _build_file_entries(
             project_root=str(tmp_path),
@@ -942,7 +945,7 @@ class TestCodeGraphQueryInternals:
                     "kind": "function",
                     "file": "main.py",
                     "line": 1,
-                    "end_line": 999,
+                    "end_line": 200,
                     "language": "python",
                 },
             ],
@@ -959,7 +962,11 @@ class TestCodeGraphQueryInternals:
                         "name": "run",
                         "kind": "function",
                         "start_line": 1,
-                        "end_line": 999,
+                        "end_line": 200,
+                        "code": "\n".join(f"line_{idx}" for idx in range(1, 161))
+                        + "\n",
+                        "code_truncated": True,
+                        "code_lines": "1-160 of 200",
                     }
                 ],
             }
@@ -1052,6 +1059,8 @@ class TestCodeGraphQueryInternals:
                                 "start_line": 1,
                                 "end_line": 2,
                                 "code": "def run():\n    pass\n",
+                                "code_truncated": True,
+                                "code_lines": "1-2 of 8",
                             }
                         ],
                     }
@@ -1103,6 +1112,8 @@ class TestCodeGraphQueryInternals:
 
         assert compact["source"]["files"][0]["file"] == "main.py"
         assert compact["source"]["files"][0]["symbols"][0]["lines"] == "1-2"
+        assert compact["source"]["files"][0]["symbols"][0]["code_truncated"] is True
+        assert compact["source"]["files"][0]["symbols"][0]["code_lines"] == "1-2 of 8"
         assert compact["callees"]["edges"]["main.py:1:run"] == [
             {
                 "name": "helper",

--- a/tree_sitter_analyzer/mcp/tools/codegraph_query_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_query_tool.py
@@ -741,6 +741,10 @@ def _compact_file_entry(entry: dict[str, Any]) -> dict[str, Any]:
             symbol_entry["kind"] = symbol["kind"]
         if symbol.get("code"):
             symbol_entry["code"] = symbol["code"]
+        if symbol.get("code_truncated"):
+            symbol_entry["code_truncated"] = True
+        if symbol.get("code_lines"):
+            symbol_entry["code_lines"] = symbol["code_lines"]
         compacted["symbols"].append(symbol_entry)
     return compacted
 
@@ -837,10 +841,16 @@ def _build_file_entries(
             }
             start_line = int(symbol.get("line", 0) or 0)
             end_line = int(symbol.get("end_line", start_line) or start_line)
-            if include_code and lines and end_line - start_line <= _MAX_SNIPPET_LINES:
-                code = _h.extract_snippet_from_lines(lines, start_line, end_line)
+            if include_code and lines:
+                snippet_end = min(
+                    end_line, len(lines), start_line + _MAX_SNIPPET_LINES - 1
+                )
+                code = _h.extract_snippet_from_lines(lines, start_line, snippet_end)
                 if code:
                     entry["code"] = code
+                if snippet_end < end_line:
+                    entry["code_truncated"] = True
+                    entry["code_lines"] = f"{start_line}-{snippet_end} of {end_line}"
             symbol_entries.append(entry)
         entries.append(
             {


### PR DESCRIPTION
## Summary
- include bounded source excerpts for long symbols instead of omitting source entirely
- preserve compact truncation metadata via code_truncated/code_lines
- add regression coverage for long symbol excerpts and compact answer packs

## Dogfood evidence
- Gin route-flow query for tree.go:getValue now returns source code plus truncation metadata
- Compact output reports lines 418-577 of 665, avoiding the prior blank long-function result that pushed agents into repeated symbol exploration

## Verification
- uv run ruff check tree_sitter_analyzer/mcp/tools/codegraph_query_tool.py tests/unit/test_codegraph_query_tool.py --fix
- uv run pytest tests/unit/test_codegraph_query_tool.py -q
- uv run python scripts/check_patch_coverage.py --base origin/develop --coverage-json coverage.json --worktree
- uv run python -m tree_sitter_analyzer --change-impact --format json
- uv run pytest -q (17873 passed, 104 skipped, 2 xfailed in 58.77s)
