### PR TITLE
feat(codegraph): prefer exact Go type declarations in query packs

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -31,6 +31,7 @@ on:
 jobs:
   test-matrix:
     name: Test Suite
+    timeout-minutes: 15
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/tests/unit/test_agent_contracts.py
+++ b/tests/unit/test_agent_contracts.py
@@ -91,6 +91,22 @@ def test_pytest_runtime_dependencies_are_declared() -> None:
     assert "pytest-timeout>=2.4.0" in dev_dependencies
 
 
+def test_reusable_test_workflow_has_job_timeout() -> None:
+    """The CI matrix must fail fast instead of hanging forever on runner stalls."""
+    workflow = PROJECT_ROOT / ".github" / "workflows" / "reusable-test.yml"
+    text = workflow.read_text(encoding="utf-8")
+    test_matrix = re.search(
+        r"(?ms)^  test-matrix:\n(?P<body>.*?)(?=^  [A-Za-z0-9_-]+:|\Z)",
+        text,
+    )
+
+    assert test_matrix is not None
+    assert re.search(
+        r"(?m)^    timeout-minutes:\s*15\s*$",
+        test_matrix.group("body"),
+    )
+
+
 def test_gitflow_documentation_is_present() -> None:
     """The GitFlow mandate must remain documented + machine-enforced.
 

--- a/tests/unit/test_codegraph_query_tool.py
+++ b/tests/unit/test_codegraph_query_tool.py
@@ -27,6 +27,7 @@ from tree_sitter_analyzer.mcp.tools.codegraph_query_tool import (
     _complexity_facet,
     _dedupe_symbols,
     _drop_test_shadow_symbols,
+    _filter_declaration_query_symbols,
     _health_facet,
     _include_facets,
     _QueryState,
@@ -44,16 +45,18 @@ from tree_sitter_analyzer.symbol_resolver import DefinitionLocation, ResolveResu
 def _make_def(
     file: str = "main.py",
     name: str = "run",
+    kind: str = "function",
     line: int = 1,
     end_line: int = 2,
+    language: str = "python",
 ) -> DefinitionLocation:
     return DefinitionLocation(
         file=file,
         name=name,
-        kind="function",
+        kind=kind,
         line=line,
         end_line=end_line,
-        language="python",
+        language=language,
     )
 
 
@@ -650,6 +653,46 @@ class TestCodeGraphQueryInternals:
 
         assert [symbol["name"] for symbol in result] == ["handleHTTPRequest"]
 
+    def test_resolve_query_filters_non_declaration_for_type_query(self):
+        defs = {
+            "Param": [
+                _make_def(file="context.go", name="Param", kind="function", line=503)
+            ]
+        }
+
+        with _patch_resolver_with(defs):
+            result = _resolve_query(MagicMock(), "type Param struct", limit=5)
+
+        assert result == []
+
+    def test_resolve_query_keeps_matching_declaration_for_type_query(self):
+        defs = {
+            "Param": [
+                _make_def(file="context.go", name="Param", kind="function", line=503),
+                _make_def(
+                    file="tree.go",
+                    name="Param",
+                    kind="type",
+                    line=17,
+                    end_line=20,
+                    language="go",
+                ),
+            ]
+        }
+
+        with _patch_resolver_with(defs):
+            result = _resolve_query(MagicMock(), "type Param struct", limit=5)
+
+        assert [symbol["file"] for symbol in result] == ["tree.go"]
+        assert result[0]["kind"] == "type"
+
+    def test_declaration_query_filter_keeps_unrelated_symbols(self):
+        symbols = [{"name": "Other", "kind": "function", "file": "main.go", "line": 1}]
+
+        assert (
+            _filter_declaration_query_symbols("type Param struct", symbols) == symbols
+        )
+
     def test_resolve_query_drops_test_shadow_when_source_definition_exists(self):
         defs = {
             "ServeHTTP": [
@@ -693,6 +736,7 @@ class TestCodeGraphQueryInternals:
         assert concepts.symbol_candidate_tokens("type HandlerFunc func(*Context)") == [
             "HandlerFunc"
         ]
+        assert concepts.declared_type_name("type Param struct") == "Param"
         assert concepts.concept_query_terms("type HandlerFunc func(*Context)") == [
             "HandlerFunc",
             "type",
@@ -728,6 +772,35 @@ class TestCodeGraphQueryInternals:
             "handleHTTPRequest"
         ]
         assert concepts.normalized_query_terms("...") == []
+
+    def test_declared_type_entries_prefer_exact_type_declaration(self):
+        entries = [
+            {
+                "file_path": "tree.go",
+                "matches": [{"text": "type Param struct {"}],
+            },
+            {
+                "file_path": "logger.go",
+                "matches": [{"text": "type LogFormatterParams struct {"}],
+            },
+        ]
+
+        narrowed = concepts.narrow_declared_type_entries(["type Param struct"], entries)
+
+        assert [entry["file_path"] for entry in narrowed] == ["tree.go"]
+
+    def test_declared_type_entries_keep_broad_matches_without_exact_declaration(self):
+        entries = [
+            {
+                "file_path": "logger.go",
+                "matches": [{"text": "type LogFormatterParams struct {"}],
+            }
+        ]
+
+        assert (
+            concepts.narrow_declared_type_entries(["type Param struct"], entries)
+            == entries
+        )
         assert concepts._primary_signature_terms("func ()", []) == []
 
     def test_resolve_queries_stops_at_limit_and_dedupes(self):

--- a/tree_sitter_analyzer/mcp/tools/_codegraph_query_concepts.py
+++ b/tree_sitter_analyzer/mcp/tools/_codegraph_query_concepts.py
@@ -58,13 +58,14 @@ def concept_entries_for_queries(
     query_terms, file_tokens = _split_seed_queries(queries)
     if not query_terms and not file_tokens:
         return []
-    return _h.concept_search(
+    entries = _h.concept_search(
         cache,
         query_terms,
         file_tokens,
         project_root,
         max_files,
     )
+    return narrow_declared_type_entries(queries, entries)
 
 
 def symbol_candidate_tokens(query: str) -> list[str]:
@@ -80,6 +81,35 @@ def symbol_candidate_tokens(query: str) -> list[str]:
         return _dedupe_tokens([declared_const, *terms])
     primary = _primary_signature_terms(query, terms)
     return _dedupe_tokens([*primary, *terms])
+
+
+def declared_type_name(query: str) -> str:
+    """Return the declared type name for ``type X ...`` query strings."""
+    return _declared_type_name(query)
+
+
+def narrow_declared_type_entries(
+    queries: list[str], entries: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Prefer exact ``type X`` declaration matches over broader mentions."""
+    patterns = [
+        re.compile(rf"\btype\s+{re.escape(name)}\b")
+        for query in queries
+        if (name := _declared_type_name(query))
+    ]
+    if not patterns:
+        return entries
+
+    exact_entries = [
+        entry
+        for entry in entries
+        if any(
+            pattern.search(str(match.get("text") or ""))
+            for pattern in patterns
+            for match in entry.get("matches", [])
+        )
+    ]
+    return exact_entries or entries
 
 
 def normalized_query_terms(query: str) -> list[str]:

--- a/tree_sitter_analyzer/mcp/tools/codegraph_query_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_query_tool.py
@@ -39,6 +39,7 @@ _MAX_FILES_CAP = 30
 _MAX_REL_PER_SYMBOL = 20
 _MAX_SNIPPET_LINES = 160
 _MAX_FILE_BYTES = 1_000_000
+_DECLARATION_QUERY_KINDS = frozenset({"class", "enum", "interface", "type"})
 
 
 class CodeGraphQueryTool(BaseMCPTool):
@@ -362,9 +363,32 @@ def _resolve_query(cache: Any, query: str, limit: int) -> list[dict[str, Any]]:
             resolved.append((token_order, item))
     resolved.sort(key=lambda item: (item[0], _source_preference_key(item[1])))
     symbols = [item for _, item in resolved]
+    symbols = _filter_declaration_query_symbols(query, symbols)
     if not file_tokens:
         symbols = _drop_test_shadow_symbols(symbols)
     return symbols[:limit]
+
+
+def _filter_declaration_query_symbols(
+    query: str, symbols: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    declared_type = _concepts.declared_type_name(query)
+    if not declared_type or not symbols:
+        return symbols
+
+    exact_name = declared_type.lower()
+    declaration_symbols = [
+        symbol
+        for symbol in symbols
+        if str(symbol.get("name") or "").lower() == exact_name
+        and str(symbol.get("kind") or "") in _DECLARATION_QUERY_KINDS
+    ]
+    if declaration_symbols:
+        return declaration_symbols
+
+    if any(str(symbol.get("name") or "").lower() == exact_name for symbol in symbols):
+        return []
+    return symbols
 
 
 def _apply_concept_fallback(


### PR DESCRIPTION
## Summary
- Treat `type X ...` codegraph_query seeds as declaration queries, so same-name functions do not block concept fallback.
- Narrow declared type concept matches to exact `type X` declarations when available.
- Add a reusable test-matrix `timeout-minutes: 15` guard so stuck hosted runners fail bounded instead of blocking PRs indefinitely.
- Add regression coverage for same-name function collisions, exact declaration narrowing, and the CI timeout contract.

## Dogfood evidence
- Before: `search('type Param struct')` returned `context.go:Param` function and pushed the benchmark agent into fallback `symbol-search Param` / `Key\\s+string` queries.
- After: the same query returns `tree.go:Param` with `Key` and `Value` fields, and only the exact `tree.go` source pack.
- `search('type HandlerFunc')` also narrows to `gin.go` instead of bringing unrelated HandlerFunc mentions.
- CI dogfood surfaced that the reusable matrix had pytest timeouts but no GitHub job-level timeout; this PR locks the outer timeout with an agent contract.

## Verification
- `uv run ruff check tree_sitter_analyzer/mcp/tools/codegraph_query_tool.py tree_sitter_analyzer/mcp/tools/_codegraph_query_concepts.py tests/unit/test_codegraph_query_tool.py --fix`
- `uv run pytest tests/unit/test_codegraph_query_tool.py -q`
- `uv run pre-commit run actionlint --files .github/workflows/reusable-test.yml`
- `uv run pytest tests/unit/test_agent_contracts.py::test_reusable_test_workflow_has_job_timeout -q`
- `uv run pytest tests/unit/test_agent_contracts.py -q`
- `uv run pytest tests/unit/test_codegraph_query_tool.py tests/unit/test_agent_contracts.py --cov=tree_sitter_analyzer --cov-report=json --cov-report=term-missing -q`
- `uv run python scripts/check_patch_coverage.py --base origin/develop --coverage-json coverage.json --worktree`
- `uv run python -m tree_sitter_analyzer --change-impact --format json`
- `uv sync --all-extras`
- `uv run pytest -q` (17879 passed, 104 skipped, 2 xfailed in 59.56s)
