### PR TITLE
feat(codegraph): filter runtime noise from query relations

### DIFF
--- a/tests/fixtures/git_temporal/make_repo.py
+++ b/tests/fixtures/git_temporal/make_repo.py
@@ -84,6 +84,9 @@ def _resolve_date(date_spec: str) -> str:
     return date_spec
 
 
+_GIT_TIMEOUT_SECONDS = 15
+
+
 def _run(repo: Path, args: list[str], env: dict[str, str] | None = None) -> str:
     """Run a git command inside ``repo`` and return stdout.
 
@@ -102,6 +105,7 @@ def _run(repo: Path, args: list[str], env: dict[str, str] | None = None) -> str:
         capture_output=True,
         text=True,
         env=base_env,
+        timeout=_GIT_TIMEOUT_SECONDS,
     )
     return completed.stdout
 

--- a/tests/unit/test_codegraph_query_tool.py
+++ b/tests/unit/test_codegraph_query_tool.py
@@ -30,6 +30,7 @@ from tree_sitter_analyzer.mcp.tools.codegraph_query_tool import (
     _filter_declaration_query_symbols,
     _health_facet,
     _include_facets,
+    _is_relation_noise_symbol,
     _QueryState,
     _relation_step,
     _resolve_queries,
@@ -971,6 +972,56 @@ class TestCodeGraphQueryInternals:
 
         assert [symbol["file"] for symbol in related] == ["gin.go"]
         assert state.relationships["callees"]["gin.go:600:dispatch"][0]["line"] == 623
+
+    def test_relation_step_filters_builtin_runtime_noise_before_limits(self):
+        mock_cache = MagicMock()
+        mock_cache.query_callees.return_value = [
+            {
+                "callee_name": "len",
+                "callee_file": "gin.go",
+                "callee_line": 698,
+                "depth": 1,
+            },
+            {
+                "callee_name": "make",
+                "callee_file": "gin.go",
+                "callee_line": 741,
+                "depth": 1,
+            },
+            {
+                "callee_name": "getValue",
+                "callee_file": "tree.go",
+                "callee_line": 418,
+                "depth": 1,
+            },
+        ]
+        state = _QueryState()
+        state.current = [{"name": "handleHTTPRequest", "file": "gin.go", "line": 690}]
+
+        related = _relation_step(
+            mock_cache,
+            state,
+            direction="callees",
+            step=_ChainStep("callees", [], {"limit": 2}),
+        )
+
+        assert [symbol["name"] for symbol in related] == ["getValue"]
+        assert state.relationships["callees"]["gin.go:690:handleHTTPRequest"] == [
+            {
+                "name": "getValue",
+                "kind": "function",
+                "file": "tree.go",
+                "line": 418,
+                "end_line": 418,
+                "language": "",
+                "depth": 1,
+            }
+        ]
+
+    def test_relation_noise_symbol_identifies_runtime_helpers(self):
+        assert _is_relation_noise_symbol({"name": "len"})
+        assert _is_relation_noise_symbol({"name": "super().__init__"})
+        assert not _is_relation_noise_symbol({"name": "getValue"})
 
     def test_source_preference_key_identifies_test_fixture_and_generated_paths(self):
         source = {"file": "gin.go", "line": 2, "name": "run"}

--- a/tests/unit/test_temporal_activation.py
+++ b/tests/unit/test_temporal_activation.py
@@ -21,6 +21,8 @@ import pytest
 from tests.fixtures.git_temporal import make_repo
 from tests.fixtures.git_temporal.make_repo import make_shallow_marker
 
+_GIT_TIMEOUT_SECONDS = 15
+
 
 def _import_git_activation():
     """Deferred import so collection works before the module exists."""
@@ -63,6 +65,41 @@ def _read_activation_rows(db_path: str) -> list[dict]:
         return [dict(r) for r in cur.fetchall()]
     finally:
         conn.close()
+
+
+def _git_env() -> dict[str, str]:
+    """Return the same isolated git environment used by the fixture builder."""
+    env = os.environ.copy()
+    env["GIT_TEMPLATE_DIR"] = ""
+    env["GIT_CONFIG_NOSYSTEM"] = "1"
+    return env
+
+
+def _run_git(repo: Path, args: list[str]) -> None:
+    """Run a bounded git command in a test repo."""
+    subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=_git_env(),
+        timeout=_GIT_TIMEOUT_SECONDS,
+    )
+
+
+def _init_git_repo(repo: Path) -> None:
+    """Initialize and configure a bounded disposable git repository."""
+    subprocess.run(
+        ["git", "init", "--initial-branch=main", str(repo)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=_git_env(),
+        timeout=_GIT_TIMEOUT_SECONDS,
+    )
+    _run_git(repo, ["config", "user.email", "test@example.com"])
+    _run_git(repo, ["config", "user.name", "Test"])
+    _run_git(repo, ["config", "commit.gpgsign", "false"])
 
 
 def _index_with_activation(repo: Path, files: list[str]) -> str:
@@ -109,9 +146,7 @@ class TestDetectGitState:
         assert ga.detect_git_state(str(loose)) == "no_repo"
 
     def test_shallow_clone_returns_shallow(self, tmp_path):
-        repo = make_repo(
-            tmp_path, [{"message": "init", "files": {"a.py": "x = 1\n"}}]
-        )
+        repo = make_repo(tmp_path, [{"message": "init", "files": {"a.py": "x = 1\n"}}])
         make_shallow_marker(repo)
         ga = _import_git_activation()
         assert ga.detect_git_state(str(repo / "a.py")) == "shallow"
@@ -187,14 +222,8 @@ class TestSymbolAttribution:
                 lines[i] = lines[i] + "  # tweaked"
         v1 = "\n".join(lines)
         (repo / "mod.py").write_text(v1, encoding="utf-8")
-        subprocess.run(
-            ["git", "-C", str(repo), "add", "mod.py"], check=True, capture_output=True
-        )
-        subprocess.run(
-            ["git", "-C", str(repo), "commit", "-m", "tweak first"],
-            check=True,
-            capture_output=True,
-        )
+        _run_git(repo, ["add", "mod.py"])
+        _run_git(repo, ["commit", "-m", "tweak first"])
 
         monkeypatch.chdir(repo)
         ga = _import_git_activation()
@@ -214,17 +243,13 @@ class TestSymbolAttribution:
                 {
                     "message": "rename and tweak",
                     "rename": ("src/old.py", "src/new.py"),
-                    "files": {
-                        "src/new.py": body.replace("a = x + 1", "a = x + 100")
-                    },
+                    "files": {"src/new.py": body.replace("a = x + 1", "a = x + 100")},
                 },
             ],
         )
         monkeypatch.chdir(repo)
         ga = _import_git_activation()
-        rows = ga.compute_symbol_activation(
-            "src/new.py", [_sym("foo", 1, 7, 10)]
-        )
+        rows = ga.compute_symbol_activation("src/new.py", [_sym("foo", 1, 7, 10)])
         assert len(rows) == 1
         # Original commit (under old.py) + rename-tweak commit (under new.py)
         assert rows[0].mod_count_all == 2
@@ -266,21 +291,7 @@ class TestColdStart:
         """Fresh ``git init`` with no commits: counts all zero, no exception."""
         repo = tmp_path / "fresh"
         repo.mkdir()
-        subprocess.run(
-            ["git", "init", "--initial-branch=main", str(repo)],
-            check=True,
-            capture_output=True,
-        )
-        subprocess.run(
-            ["git", "-C", str(repo), "config", "user.email", "test@example.com"],
-            check=True,
-            capture_output=True,
-        )
-        subprocess.run(
-            ["git", "-C", str(repo), "config", "user.name", "Test"],
-            check=True,
-            capture_output=True,
-        )
+        _init_git_repo(repo)
         (repo / "a.py").write_text(_seven_line_function("foo"), encoding="utf-8")
 
         monkeypatch.chdir(repo)
@@ -298,9 +309,7 @@ class TestColdStart:
         """Outside any git dir: git_state='no_repo', zero counts, row exists."""
         loose_dir = tmp_path / "loose"
         loose_dir.mkdir()
-        (loose_dir / "a.py").write_text(
-            _seven_line_function("foo"), encoding="utf-8"
-        )
+        (loose_dir / "a.py").write_text(_seven_line_function("foo"), encoding="utf-8")
         monkeypatch.chdir(loose_dir)
         ga = _import_git_activation()
         rows = ga.compute_symbol_activation("a.py", [_sym("foo", 1, 7, 41)])
@@ -346,14 +355,8 @@ class TestReindexIdempotence:
         # Add another commit touching the same body.
         new_body = body.replace("a = x + 1", "a = x + 999")
         (repo / "a.py").write_text(new_body, encoding="utf-8")
-        subprocess.run(
-            ["git", "-C", str(repo), "add", "a.py"], check=True, capture_output=True
-        )
-        subprocess.run(
-            ["git", "-C", str(repo), "commit", "-m", "bump"],
-            check=True,
-            capture_output=True,
-        )
+        _run_git(repo, ["add", "a.py"])
+        _run_git(repo, ["commit", "-m", "bump"])
 
         db_path_2 = _index_with_activation(repo, ["a.py"])
         assert db_path_2 == db_path  # same db
@@ -387,9 +390,7 @@ class TestEnvDisable:
             conn = sqlite3.connect(db_path)
             try:
                 try:
-                    cur = conn.execute(
-                        "SELECT COUNT(*) FROM ast_symbol_activation"
-                    )
+                    cur = conn.execute("SELECT COUNT(*) FROM ast_symbol_activation")
                     count = cur.fetchone()[0]
                 except sqlite3.OperationalError:
                     # Table may not exist when feature is disabled —
@@ -457,9 +458,7 @@ class TestModuleSurface:
         )
         monkeypatch.chdir(repo)
         ga = _import_git_activation()
-        rows = ga.compute_symbol_activation(
-            "a.py", [_sym("foo", 1, 7, 99)]
-        )
+        rows = ga.compute_symbol_activation("a.py", [_sym("foo", 1, 7, 99)])
         assert len(rows) == 1
         row = rows[0]
         for field in (

--- a/tree_sitter_analyzer/mcp/tools/codegraph_query_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_query_tool.py
@@ -40,6 +40,30 @@ _MAX_REL_PER_SYMBOL = 20
 _MAX_SNIPPET_LINES = 160
 _MAX_FILE_BYTES = 1_000_000
 _DECLARATION_QUERY_KINDS = frozenset({"class", "enum", "interface", "type"})
+_RELATION_NOISE_SYMBOLS = frozenset(
+    {
+        # Go builtins frequently appear as callsite pseudo-symbols in call edges.
+        "append",
+        "cap",
+        "clear",
+        "close",
+        "complex",
+        "copy",
+        "delete",
+        "imag",
+        "len",
+        "make",
+        "new",
+        "panic",
+        "print",
+        "println",
+        "real",
+        "recover",
+        # Python runtime helpers are similarly low-signal for architecture packs.
+        "super",
+        "super().__init__",
+    }
+)
 
 
 class CodeGraphQueryTool(BaseMCPTool):
@@ -458,15 +482,22 @@ def _relation_step(
                 _row_symbol(row, "callee_name", "callee_file", "callee_line")
                 for row in rows
             ]
-        entries = _source_first_symbols(entry for entry in entries if entry["name"])[
-            :limit
-        ]
+        entries = _source_first_symbols(
+            entry
+            for entry in entries
+            if entry["name"] and not _is_relation_noise_symbol(entry)
+        )[:limit]
         source_key = _symbol_key(symbol)
         state.relationships[direction][source_key] = entries
         related.extend(entries)
     deduped = _dedupe_symbols(related)
     state.add_symbols(deduped)
     return deduped
+
+
+def _is_relation_noise_symbol(symbol: dict[str, Any]) -> bool:
+    name = str(symbol.get("name") or "").strip()
+    return name in _RELATION_NOISE_SYMBOLS
 
 
 def _sort_state(state: _QueryState, step: _ChainStep) -> None:


### PR DESCRIPTION
## Summary
- Filter low-signal runtime/builtin callees from `codegraph_query` relationship answer packs.
- Keeps the raw call graph untouched; only the chained query surface drops common pseudo-symbols such as Go `len/make/append` and Python `super`.
- Adds regression coverage so filtering happens before relation limits are applied.

## Dogfood evidence
- Gin `handleHTTPRequest` benchmark transcript after PR #186 still showed Go builtin callees such as `len/make/append`, adding token noise to architecture answers.
- With this branch, the Gin query below returns useful callees and no `len/make/append` entries:
  `search('handleHTTPRequest').explore(max_files=3, max_symbols=8, include_code=True).include(callees=True, max_files=3, limit=12).answer(compact=True)`
- Follow-up spotted during dogfood: some Go method callee rows still carry callsite-ish line numbers; that is separate from builtin noise and should be handled in a later precision PR.

## Verification
- `uv run ruff check tree_sitter_analyzer/mcp/tools/codegraph_query_tool.py tests/unit/test_codegraph_query_tool.py --fix`
- `uv run pytest tests/unit/test_codegraph_query_tool.py -q` (58 passed)
- Gin dogfood CLI smoke with `--codegraph-query` against `gin-gonic/gin`
- `uv run python -m tree_sitter_analyzer --change-impact --format json`
- `uv run pytest tests/unit/test_codegraph_query_tool.py --cov=tree_sitter_analyzer --cov-report=json --cov-report=term-missing -q` (58 passed)
- `uv run python scripts/check_patch_coverage.py --base origin/develop --coverage-json coverage.json --worktree`
- `uv sync --all-extras`
- targeted rerun for first environment-related failures (23 passed)
- `uv run pytest -q` (17881 passed, 104 skipped, 2 xfailed, 1 rerun in 67.42s)
