### PR TITLE
fix(go): index method receiver functions in CallGraph + CLI mode arg fix

### DIFF
--- a/tree_sitter_analyzer/call_graph.py
+++ b/tree_sitter_analyzer/call_graph.py
@@ -160,6 +160,8 @@ def _extract_recursive(
                 parent_class = _find_parent_class_python(node) or enclosing_class
             elif language in ("java",):
                 parent_class = _find_parent_class_java(node) or enclosing_class
+            elif language == "go" and node.type == "method_declaration":
+                parent_class = _find_receiver_type_go(node) or enclosing_class
 
             definitions.append(
                 {
@@ -211,7 +213,7 @@ def _get_func_name(node: Any, language: str) -> str | None:
                     )
         elif language == "go":
             for child in node.children:
-                if child.type == "identifier":
+                if child.type in ("identifier", "field_identifier"):
                     text = child.text
                     return (
                         text.decode("utf-8") if isinstance(text, bytes) else str(text)
@@ -403,6 +405,40 @@ def _find_parent_class_java(node: Any) -> str | None:
                         text.decode("utf-8") if isinstance(text, bytes) else str(text)
                     )
         current = current.parent
+    return None
+
+
+def _find_receiver_type_go(node: Any) -> str | None:
+    """Extract receiver type from a Go method_declaration node.
+
+    For ``func (e *Engine) ServeHTTP(...)`` returns ``Engine``.
+    """
+    if node is None or node.type != "method_declaration":
+        return None
+    for child in node.children:
+        if child.type == "parameter_list":
+            for param in child.children:
+                for sub in param.children if hasattr(param, "children") else []:
+                    if sub.type in ("type_identifier", "generic_type", "pointer_type"):
+                        text = sub.text
+                        raw = (
+                            text.decode("utf-8")
+                            if isinstance(text, bytes)
+                            else str(text)
+                        )
+                        return raw.lstrip("*")
+                    for leaf in sub.children if hasattr(sub, "children") else []:
+                        if leaf.type in (
+                            "type_identifier",
+                            "generic_type",
+                        ):
+                            text = leaf.text
+                            raw = (
+                                text.decode("utf-8")
+                                if isinstance(text, bytes)
+                                else str(text)
+                            )
+                            return raw.lstrip("*")
     return None
 
 

--- a/tree_sitter_analyzer/cli/commands/mcp_commands.py
+++ b/tree_sitter_analyzer/cli/commands/mcp_commands.py
@@ -491,7 +491,7 @@ MCP_COMMAND_SPECS: tuple[McpCommandSpec, ...] = (
         tool_attr="CodeGraphCallTool",
         label="Function-level call graph (CodeGraph parity)",
         build_tool_args=lambda args, output_format: {
-            "mode": getattr(args, "call_graph_mode", "summary") or "summary",
+            "mode": getattr(args, "call_graph", "summary") or "summary",
             "function_name": getattr(args, "call_graph_function", None),
             "file_path": getattr(args, "call_graph_file", None),
             "depth": getattr(args, "call_graph_depth", 5),


### PR DESCRIPTION
## Summary

Two critical bugs found via DogFood live comparison (CodeGraph vs TSA on gin repo):

### Bug 1: CLI call-graph mode arg typo
`mcp_commands.py:494` read `call_graph_mode` (non-existent argparse attr) instead of `call_graph`. This caused `--call-graph callers/callees/chain` to always fallback to `summary` mode.

### Bug 2: Go method receiver functions invisible to CallGraph
`_get_func_name()` for Go only checked `identifier` child nodes, but Go `method_declaration` uses `field_identifier` for the function name. All Go methods like `func (e \*Engine) ServeHTTP()` were completely invisible.

Additionally:
- Added `_find_receiver_type_go()` to extract receiver type for qualified name matching
- Set `parent_class` for Go method_declaration nodes

## DogFood Evidence

```bash
# Before fix:
--call-graph callers --call-graph-function ServeHTTP → mode=summary, 0 callers

# After fix:
--call-graph callers --call-graph-function ServeHTTP → mode=callers, 37 callers
--call-graph callees --call-graph-function ServeHTTP → mode=callees, 11 callees
```

## Test plan
- [x] 63 contract + CLI parity tests pass
- [x] 16359 unit tests pass
- [x] Live verification on gin repo (Go, ~150 files)
- [x] Pre-commit hooks (ruff, mypy, bandit) pass