### PR TITLE
feat(codegraph): add chain query selection filters

### DIFF
--- a/docs/CODEMAPS/cli.md
+++ b/docs/CODEMAPS/cli.md
@@ -89,7 +89,7 @@ Categories of CLI surface:
 - `--ast-path FILE:LINE` — "what is at file:line?"
 - `--codegraph-symbol-search QUERY` — FTS5 symbol search
 - `--codegraph-explore QUERY` — bulk-fetch N related symbols + relmap (CodeGraph parity)
-- `--codegraph-query CHAIN` — jQuery-style chained graph query (`search(['A','B']).explore().include(callers=True).sort(by='fan_in').answer(compact=True)`)
+- `--codegraph-query CHAIN` — jQuery-style chained graph query (`search(['A','B']).filter(test=False).include(callers=True).sort(by='fan_in').answer(compact=True)`)
 - `--codegraph-query-compact` — trim duplicate source payloads and empty relationship fields in chained query answers
 - `--affected FILE [FILE...]` — list test files transitively affected by changes (CodeGraph parity; closes the last CLI surface gap)
 - `--dead-code` — transitive dead functions / unused imports

--- a/docs/CODEMAPS/mcp-tools.md
+++ b/docs/CODEMAPS/mcp-tools.md
@@ -44,7 +44,7 @@ All tools default to **TOON output** (locked — see `CLAUDE.md`).
 | **CodeGraph parity — symbol navigation** | | |
 | `codegraph_navigate` | `--codegraph-navigate` | PRIMARY symbol navigation hub (def + refs + hierarchy) |
 | `codegraph_explore` | `--codegraph-explore` | BULK fetch N related symbols' source + relationship map |
-| `codegraph_query` | `--codegraph-query` | jQuery-style chained graph query with batch seeds, sorting, compact answer packs, and evidence facets |
+| `codegraph_query` | `--codegraph-query` | jQuery-style chained graph query with batch seeds, filter/exclude selection, cached relationship expansion, compact answer packs, and evidence facets |
 | `codegraph_symbol_search` | `--codegraph-symbol-search` | FTS5-powered symbol search over indexed project |
 | `codegraph_resolve` | `--symbol-resolve` | Go-to-definition / find-all-references |
 | `codegraph_ast_path` | `--ast-path` | "What is at file:line?" AST path/scope |

--- a/tests/unit/test_codegraph_query_tool.py
+++ b/tests/unit/test_codegraph_query_tool.py
@@ -9,6 +9,7 @@ from unittest.mock import ANY, MagicMock, patch
 import pytest
 
 from tree_sitter_analyzer.mcp.tools import _codegraph_query_concepts as concepts
+from tree_sitter_analyzer.mcp.tools import _codegraph_query_filters as filters
 from tree_sitter_analyzer.mcp.tools._codegraph_query_dsl import (
     _ChainStep,
     bool_kw,
@@ -109,6 +110,26 @@ class TestParseChain:
         assert string_args(steps[0], required=True) == ["Router", "Handler"]
         assert steps[1].kwargs == {"callers": True, "source": True}
         assert steps[3].kwargs == {"compact": True}
+
+    def test_parses_selection_filter_steps(self):
+        steps = parse_chain(
+            "search('run').filter(kind='function', path='src/', test=False)"
+            ".where(regex='Service$').exclude(generated=True).not(file='vendor/')"
+        )
+
+        assert [step.name for step in steps] == [
+            "search",
+            "filter",
+            "where",
+            "exclude",
+            "not",
+        ]
+        assert steps[1].kwargs == {
+            "kind": "function",
+            "path": "src/",
+            "test": False,
+        }
+        assert steps[2].kwargs == {"regex": "Service$"}
 
     def test_parses_kwargs_and_escaped_quotes(self):
         steps = parse_chain(r'search(query="src/a.\"b.py Run").take(2)')
@@ -508,6 +529,141 @@ class TestCodeGraphQueryTool:
         assert result["facets"]["source"]["files"][0]["file"] == "router.py"
 
     @pytest.mark.asyncio
+    async def test_execute_filter_applies_to_later_concept_fallback(self, tmp_path):
+        router = tmp_path / "router.py"
+        router.write_text(
+            "def handle_route():\n    # route matching lives here\n    return True\n",
+            encoding="utf-8",
+        )
+        service = tmp_path / "service.py"
+        service.write_text(
+            "def handle_service():\n    # route matching should be filtered\n    return True\n",
+            encoding="utf-8",
+        )
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.execute(
+            """CREATE TABLE ast_index (
+                file_path TEXT,
+                language TEXT,
+                file_size INTEGER,
+                symbols_json TEXT
+            )"""
+        )
+        for path, symbol_name in (
+            (router, "handle_route"),
+            (service, "handle_service"),
+        ):
+            conn.execute(
+                "INSERT INTO ast_index VALUES (?, ?, ?, ?)",
+                (
+                    path.name,
+                    "python",
+                    path.stat().st_size,
+                    json.dumps(
+                        {
+                            "symbols": [
+                                {
+                                    "name": symbol_name,
+                                    "kind": "function",
+                                    "line": 1,
+                                    "end_line": 3,
+                                }
+                            ]
+                        }
+                    ),
+                ),
+            )
+        mock_cache = MagicMock()
+        mock_cache._get_conn.return_value = conn
+
+        with (
+            patch("tree_sitter_analyzer.ast_cache.ASTCache", return_value=mock_cache),
+            _patch_resolver_with({}),
+        ):
+            result = await CodeGraphQueryTool(str(tmp_path)).execute(
+                {
+                    "query": (
+                        "search('route matching').filter(file='router.py')"
+                        ".include(source=True).answer(compact=True)"
+                    ),
+                    "output_format": "json",
+                }
+            )
+
+        assert result["verdict"] == "INFO"
+        assert result["stats"]["concept_files_returned"] == 1
+        assert [symbol["file"] for symbol in result["symbols"]] == ["router.py"]
+        assert [file["file"] for file in result["facets"]["source"]["files"]] == [
+            "router.py"
+        ]
+
+    @pytest.mark.asyncio
+    async def test_execute_symbol_filter_applies_to_later_concept_fallback(
+        self, tmp_path
+    ):
+        source = tmp_path / "router.py"
+        source.write_text(
+            "class Router:\n    pass\n\ndef handle_route():\n    return Router()\n",
+            encoding="utf-8",
+        )
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.execute(
+            """CREATE TABLE ast_index (
+                file_path TEXT,
+                language TEXT,
+                file_size INTEGER,
+                symbols_json TEXT
+            )"""
+        )
+        conn.execute(
+            "INSERT INTO ast_index VALUES (?, ?, ?, ?)",
+            (
+                "router.py",
+                "python",
+                source.stat().st_size,
+                json.dumps(
+                    {
+                        "symbols": [
+                            {
+                                "name": "Router",
+                                "kind": "class",
+                                "line": 1,
+                                "end_line": 2,
+                            },
+                            {
+                                "name": "handle_route",
+                                "kind": "function",
+                                "line": 4,
+                                "end_line": 5,
+                            },
+                        ]
+                    }
+                ),
+            ),
+        )
+        mock_cache = MagicMock()
+        mock_cache._get_conn.return_value = conn
+
+        with (
+            patch("tree_sitter_analyzer.ast_cache.ASTCache", return_value=mock_cache),
+            _patch_resolver_with({}),
+        ):
+            result = await CodeGraphQueryTool(str(tmp_path)).execute(
+                {
+                    "query": (
+                        "search('route').filter(kind='function')"
+                        ".include(source=True).answer(compact=True)"
+                    ),
+                    "output_format": "json",
+                }
+            )
+
+        source_symbols = result["facets"]["source"]["files"][0]["symbols"]
+        assert [symbol["name"] for symbol in source_symbols] == ["handle_route"]
+
+    @pytest.mark.asyncio
     async def test_execute_batch_seed_include_sort_and_answer(self, tmp_path):
         source = tmp_path / "main.py"
         source.write_text(
@@ -604,6 +760,202 @@ class TestCodeGraphQueryTool:
         assert result["facets"]["source"]["files"][0]["symbols"][0]["lines"] == "1-2"
         assert "language" not in result["relationships"]["callees"]["main.py:1:run"][0]
 
+    @pytest.mark.asyncio
+    async def test_execute_filter_narrows_current_selection_and_rebuilds_source(
+        self, tmp_path
+    ):
+        source = tmp_path / "src" / "main.py"
+        source.parent.mkdir()
+        source.write_text("def run():\n    return 1\n", encoding="utf-8")
+        test_source = tmp_path / "tests" / "test_main.py"
+        test_source.parent.mkdir()
+        test_source.write_text("def run():\n    return 1\n", encoding="utf-8")
+        defs = {
+            "run": [
+                _make_def(file="src/main.py", name="run", line=1),
+                _make_def(file="tests/test_main.py", name="run", line=1),
+            ]
+        }
+
+        with (
+            patch("tree_sitter_analyzer.ast_cache.ASTCache", return_value=MagicMock()),
+            _patch_resolver_with(defs),
+        ):
+            result = await CodeGraphQueryTool(str(tmp_path)).execute(
+                {
+                    "query": (
+                        "search('run').explore(max_files=5)"
+                        ".filter(path='src/', test=False)"
+                        ".include(source=True).answer(compact=True)"
+                    ),
+                    "output_format": "json",
+                }
+            )
+
+        assert result["success"] is True
+        assert [symbol["file"] for symbol in result["symbols"]] == ["src/main.py"]
+        assert result["files"] == []
+        assert result["facets"]["source"]["files"][0]["file"] == "src/main.py"
+
+    @pytest.mark.asyncio
+    async def test_execute_exclude_removes_matching_selection(self, tmp_path):
+        defs = {
+            "run": [_make_def(file="src/main.py", name="run", line=1)],
+            "test_run": [_make_def(file="tests/test_main.py", name="test_run", line=1)],
+        }
+
+        with (
+            patch("tree_sitter_analyzer.ast_cache.ASTCache", return_value=MagicMock()),
+            _patch_resolver_with(defs),
+        ):
+            result = await CodeGraphQueryTool(str(tmp_path)).execute(
+                {
+                    "query": "search(['run', 'test_run']).exclude(test=True)",
+                    "output_format": "json",
+                }
+            )
+
+        assert [symbol["name"] for symbol in result["symbols"]] == ["run"]
+
+    @pytest.mark.asyncio
+    async def test_execute_filter_prunes_relationships_to_kept_entries(self, tmp_path):
+        mock_cache = MagicMock()
+        mock_cache.query_callees.return_value = [
+            {
+                "callee_name": "helper",
+                "callee_file": "helper.py",
+                "callee_line": 4,
+                "depth": 1,
+            },
+            {
+                "callee_name": "ignored",
+                "callee_file": "ignored.py",
+                "callee_line": 8,
+                "depth": 1,
+            },
+        ]
+        defs = {"run": [_make_def(file="main.py", name="run", line=1)]}
+
+        with (
+            patch("tree_sitter_analyzer.ast_cache.ASTCache", return_value=mock_cache),
+            _patch_resolver_with(defs),
+        ):
+            result = await CodeGraphQueryTool(str(tmp_path)).execute(
+                {
+                    "query": "search('run').callees().filter(name='helper')",
+                    "output_format": "json",
+                }
+            )
+
+        assert [symbol["name"] for symbol in result["symbols"]] == ["helper"]
+        assert result["relationships"]["callees"]["main.py:1:run"] == [
+            {
+                "name": "helper",
+                "kind": "function",
+                "file": "helper.py",
+                "line": 4,
+                "end_line": 4,
+                "language": "",
+                "depth": 1,
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_execute_filter_keeps_relationships_for_kept_source(self, tmp_path):
+        mock_cache = MagicMock()
+        mock_cache.query_callees.return_value = [
+            {
+                "callee_name": "helper",
+                "callee_file": "helper.py",
+                "callee_line": 4,
+                "depth": 1,
+            }
+        ]
+        defs = {"run": [_make_def(file="main.py", name="run", line=1)]}
+
+        with (
+            patch("tree_sitter_analyzer.ast_cache.ASTCache", return_value=mock_cache),
+            _patch_resolver_with(defs),
+        ):
+            result = await CodeGraphQueryTool(str(tmp_path)).execute(
+                {
+                    "query": "search('run').include(callees=True).filter(name='run')",
+                    "output_format": "json",
+                }
+            )
+
+        assert [symbol["name"] for symbol in result["symbols"]] == ["run"]
+        assert result["relationships"]["callees"]["main.py:1:run"] == [
+            {
+                "name": "helper",
+                "kind": "function",
+                "file": "helper.py",
+                "line": 4,
+                "end_line": 4,
+                "language": "",
+                "depth": 1,
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_execute_filter_removes_relationships_without_kept_edges(
+        self, tmp_path
+    ):
+        mock_cache = MagicMock()
+        mock_cache.query_callees.return_value = [
+            {
+                "callee_name": "helper",
+                "callee_file": "helper.py",
+                "callee_line": 4,
+                "depth": 1,
+            }
+        ]
+        defs = {"run": [_make_def(file="main.py", name="run", line=1)]}
+
+        with (
+            patch("tree_sitter_analyzer.ast_cache.ASTCache", return_value=mock_cache),
+            _patch_resolver_with(defs),
+        ):
+            result = await CodeGraphQueryTool(str(tmp_path)).execute(
+                {
+                    "query": "search('run').callees().filter(name='missing')",
+                    "output_format": "json",
+                }
+            )
+
+        assert result["symbols"] == []
+        assert result["relationships"]["callees"] == {}
+
+    @pytest.mark.asyncio
+    async def test_execute_reuses_relation_cache_within_single_chain(self, tmp_path):
+        mock_cache = MagicMock()
+        mock_cache.query_callers.return_value = [
+            {
+                "caller_name": "entry",
+                "caller_file": "entry.py",
+                "caller_line": 10,
+                "depth": 1,
+            }
+        ]
+        defs = {"run": [_make_def(file="main.py", name="run", line=1)]}
+
+        with (
+            patch("tree_sitter_analyzer.ast_cache.ASTCache", return_value=mock_cache),
+            _patch_resolver_with(defs),
+        ):
+            result = await CodeGraphQueryTool(str(tmp_path)).execute(
+                {
+                    "query": (
+                        "search('run').include(callers=True).include(callers=True)"
+                    ),
+                    "output_format": "json",
+                }
+            )
+
+        assert result["success"] is True
+        assert mock_cache.query_callers.call_count == 1
+        assert result["relationships"]["callers"]["main.py:1:run"][0]["name"] == "entry"
+
     def test_apply_step_rejects_unknown_step(self):
         with pytest.raises(ValueError, match="unsupported chain step"):
             CodeGraphQueryTool("/tmp")._apply_step(
@@ -617,6 +969,76 @@ class TestCodeGraphQueryTool:
 
 
 class TestCodeGraphQueryInternals:
+    def test_filter_symbols_supports_predicates_and_inverse_selection(self):
+        symbols = [
+            {
+                "name": "RouterService",
+                "kind": "class",
+                "file": "src/router.py",
+                "language": "python",
+                "line": 1,
+            },
+            {
+                "name": "RouterServiceTest",
+                "kind": "class",
+                "file": "tests/test_router.py",
+                "language": "python",
+                "line": 1,
+            },
+            {
+                "name": "GeneratedRouter",
+                "kind": "class",
+                "file": "src/generated/router.py",
+                "language": "python",
+                "line": 1,
+            },
+        ]
+        step = _ChainStep(
+            "filter",
+            [],
+            {"kind": ["class"], "regex": "Service$", "test": False},
+        )
+
+        assert [s["name"] for s in filters.filter_symbols(symbols, step)] == [
+            "RouterService"
+        ]
+        assert [
+            s["name"] for s in filters.filter_symbols(symbols, step, invert=True)
+        ] == ["RouterServiceTest", "GeneratedRouter"]
+
+    def test_filter_symbols_reports_bad_regex(self):
+        with pytest.raises(ValueError, match=r"filter\(\) invalid regex"):
+            filters.filter_symbols(
+                [{"name": "run", "file": "main.py"}],
+                _ChainStep("filter", [], {"regex": "["}),
+            )
+
+    def test_filter_symbols_covers_empty_case_and_negative_predicates(self):
+        symbols = [
+            {"name": "RunService", "file": "src/run.py", "kind": "class"},
+            {"name": "runservice", "file": "tests/test_run.py", "kind": "class"},
+            {"name": "Generated", "file": "src/generated/run.py", "kind": "class"},
+        ]
+
+        assert filters.filter_symbols(symbols, _ChainStep("filter", [], {})) == symbols
+        assert filters.filter_symbols(
+            symbols,
+            _ChainStep("filter", [], {"name": "Run", "case": True}),
+        ) == [symbols[0]]
+        assert filters.filter_symbols(
+            symbols,
+            _ChainStep("filter", [], {"test": False, "generated": False}),
+        ) == [symbols[0]]
+        assert (
+            filters.filter_symbols(
+                symbols,
+                _ChainStep("filter", [], {"name": ""}),
+            )
+            == symbols
+        )
+        with pytest.raises(ValueError, match="regex must be a non-empty string"):
+            filters.filter_symbols(symbols, _ChainStep("filter", [], {"regex": 1}))
+
     def test_query_state_add_symbols_dedupes_repeated_entries(self):
         state = _QueryState()
         symbol = {"file": "main.py", "line": 1, "name": "run"}
@@ -1230,6 +1652,7 @@ class TestCodeGraphQueryInternals:
                     }
                 ],
             },
+            "risk": {"status": "included", "level": "info", "reasons": []},
         }
 
         compact = _compact_facets(facets)
@@ -1249,9 +1672,20 @@ class TestCodeGraphQueryInternals:
         ]
         assert compact["complexity"]["files"][0]["hotspots"][0]["cc"] == 12
         assert "dimensions" not in compact["health"]["files"][0]
+        assert compact["risk"] == {"status": "included", "level": "info", "reasons": []}
 
     def test_quality_facets_cover_empty_error_and_missing_paths(self, tmp_path):
         symbols = [{"file": "main.py", "line": 1, "name": "run"}]
+
+        with patch.dict(
+            "sys.modules", {"tree_sitter_analyzer.complexity_heatmap": None}
+        ):
+            assert (
+                _complexity_facet(MagicMock(), str(tmp_path), symbols, max_files=1)[
+                    "status"
+                ]
+                == "missing"
+            )
 
         with patch(
             "tree_sitter_analyzer.complexity_heatmap.analyze_file_complexity_from_cache",
@@ -1274,10 +1708,23 @@ class TestCodeGraphQueryInternals:
         assert health["files"] == [
             {"file": "main.py", "status": "error", "error": "bad health"}
         ]
+        with patch.dict("sys.modules", {"tree_sitter_analyzer.health_scorer": None}):
+            assert _health_facet(str(tmp_path), symbols, max_files=1)["status"] == (
+                "missing"
+            )
 
         empty_state = _QueryState()
         assert _affected_tests_facet(empty_state)["status"] == "missing"
         assert _risk_facet(empty_state)["level"] == "info"
+        caution_state = _QueryState()
+        caution_state.facets["complexity"] = {
+            "files": [
+                {"file": "mid.py", "max_complexity": 12},
+                {"file": "small.py", "max_complexity": 5},
+            ]
+        }
+        caution_state.facets["health"] = {"files": [{"file": "ok.py", "grade": "B"}]}
+        assert _risk_facet(caution_state)["reasons"] == ["mid.py: high complexity 12"]
         assert _absolute_path(str(tmp_path), str(tmp_path / "main.py")) == str(
             tmp_path / "main.py"
         )

--- a/tree_sitter_analyzer/mcp/tools/_codegraph_query_dsl.py
+++ b/tree_sitter_analyzer/mcp/tools/_codegraph_query_dsl.py
@@ -17,18 +17,39 @@ _SUPPORTED_STEPS = {
     "callers",
     "callees",
     "related",
+    "filter",
+    "where",
+    "exclude",
+    "not",
     "take",
     "sort",
     "include",
     "with",
     "answer",
 }
+_FILTER_KWARGS = frozenset(
+    {
+        "name",
+        "kind",
+        "file",
+        "path",
+        "language",
+        "test",
+        "generated",
+        "regex",
+        "case",
+    }
+)
 _ALLOWED_KWARGS: dict[str, frozenset[str]] = {
     "search": frozenset({"query", "limit"}),
     "explore": frozenset({"query", "max_files", "max_symbols", "include_code"}),
     "callers": frozenset({"depth", "limit"}),
     "callees": frozenset({"depth", "limit"}),
     "related": frozenset({"depth", "limit"}),
+    "filter": _FILTER_KWARGS,
+    "where": _FILTER_KWARGS,
+    "exclude": _FILTER_KWARGS,
+    "not": _FILTER_KWARGS,
     "take": frozenset({"limit"}),
     "sort": frozenset({"by", "desc"}),
     "include": frozenset(

--- a/tree_sitter_analyzer/mcp/tools/_codegraph_query_filters.py
+++ b/tree_sitter_analyzer/mcp/tools/_codegraph_query_filters.py
@@ -1,0 +1,148 @@
+"""Selection predicates for the codegraph_query chain DSL."""
+
+from __future__ import annotations
+
+import os
+import re
+from collections.abc import Callable
+from typing import Any
+
+from ._codegraph_query_dsl import _ChainStep
+
+
+def filter_symbols(
+    symbols: list[dict[str, Any]],
+    step: _ChainStep,
+    *,
+    invert: bool = False,
+) -> list[dict[str, Any]]:
+    """Filter a symbol selection using literal chain predicates."""
+    predicate = _compile_symbol_predicate(step)
+    if predicate is None:
+        return list(symbols)
+    return [
+        symbol
+        for symbol in symbols
+        if (not predicate(symbol) if invert else predicate(symbol))
+    ]
+
+
+def is_test_or_fixture_path(path: str) -> bool:
+    normalized = path.replace("\\", "/").lower()
+    name = os.path.basename(normalized)
+    return bool(
+        "/test/" in normalized
+        or "/tests/" in normalized
+        or "/__tests__/" in normalized
+        or "/fixtures/" in normalized
+        or name.startswith("test_")
+        or "_test." in name
+        or name.endswith((".test.ts", ".test.tsx", ".test.js", ".spec.ts", ".spec.js"))
+    )
+
+
+def is_generated_or_vendor_path(path: str) -> bool:
+    normalized = path.replace("\\", "/").lower()
+    return any(part in normalized for part in ("/vendor/", "/gen/", "/generated/"))
+
+
+def _compile_symbol_predicate(
+    step: _ChainStep,
+) -> Callable[[dict[str, Any]], bool] | None:
+    case_sensitive = bool(step.kwargs.get("case", False))
+    regex = _compile_regex(step.kwargs.get("regex"), case_sensitive=case_sensitive)
+    has_predicate = regex is not None
+    field_predicates = _field_predicates(step, case_sensitive=case_sensitive)
+    has_predicate = has_predicate or bool(field_predicates)
+    test_value = _optional_bool(step.kwargs.get("test"))
+    generated_value = _optional_bool(step.kwargs.get("generated"))
+    has_predicate = (
+        has_predicate or test_value is not None or generated_value is not None
+    )
+    if not has_predicate:
+        return None
+
+    def predicate(symbol: dict[str, Any]) -> bool:
+        if not _fields_match(symbol, field_predicates):
+            return False
+        if regex and not _regex_matches_symbol(regex, symbol):
+            return False
+        file_path = str(symbol.get("file") or "")
+        if test_value is not None and is_test_or_fixture_path(file_path) != test_value:
+            return False
+        if (
+            generated_value is not None
+            and is_generated_or_vendor_path(file_path) != generated_value
+        ):
+            return False
+        return True
+
+    return predicate
+
+
+def _field_predicates(
+    step: _ChainStep,
+    *,
+    case_sensitive: bool,
+) -> list[tuple[str, Any, bool]]:
+    fields: list[tuple[str, Any, bool]] = []
+    for field in ("name", "kind", "language"):
+        if field in step.kwargs:
+            fields.append((field, step.kwargs[field], case_sensitive))
+    for field in ("file", "path"):
+        if field in step.kwargs:
+            fields.append(("file", step.kwargs[field], case_sensitive))
+    return fields
+
+
+def _fields_match(
+    symbol: dict[str, Any],
+    predicates: list[tuple[str, Any, bool]],
+) -> bool:
+    return all(
+        _text_matches(
+            str(symbol.get(field) or ""),
+            expected,
+            case_sensitive=case_sensitive,
+        )
+        for field, expected, case_sensitive in predicates
+    )
+
+
+def _compile_regex(value: Any, *, case_sensitive: bool) -> re.Pattern[str] | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value:
+        raise ValueError("filter() regex must be a non-empty string")
+    flags = 0 if case_sensitive else re.IGNORECASE
+    try:
+        return re.compile(value, flags)
+    except re.error as exc:
+        raise ValueError(f"filter() invalid regex: {exc}") from exc
+
+
+def _text_matches(value: str, expected: Any, *, case_sensitive: bool) -> bool:
+    if isinstance(expected, list):
+        return any(
+            _text_matches(value, item, case_sensitive=case_sensitive)
+            for item in expected
+        )
+    if not isinstance(expected, str) or not expected:
+        return True
+    if case_sensitive:
+        return expected in value
+    return expected.lower() in value.lower()
+
+
+def _optional_bool(value: Any) -> bool | None:
+    return value if isinstance(value, bool) else None
+
+
+def _regex_matches_symbol(regex: re.Pattern[str], symbol: dict[str, Any]) -> bool:
+    return any(
+        regex.search(str(symbol.get(field) or ""))
+        for field in ("name", "kind", "file", "language")
+    )
+
+
+__all__ = ["filter_symbols", "is_generated_or_vendor_path", "is_test_or_fixture_path"]

--- a/tree_sitter_analyzer/mcp/tools/codegraph_query_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_query_tool.py
@@ -20,6 +20,7 @@ from ...utils import setup_logger
 from ..utils.format_helper import apply_toon_format_to_response
 from . import _codegraph_explore_helpers as _h
 from . import _codegraph_query_concepts as _concepts
+from . import _codegraph_query_filters as _filters
 from ._codegraph_query_dsl import (
     _ChainStep,
     bool_kw,
@@ -90,9 +91,9 @@ class CodeGraphQueryTool(BaseMCPTool):
             "name": "codegraph_query",
             "description": (
                 "jQuery-style chained code graph query. Compose search(), "
-                "explore(), callers(), callees(), related(), include(), sort(), "
-                "take(), and answer() in one statement so agents get an answer "
-                "pack without 40 separate CLI calls. Example: "
+                "explore(), callers(), callees(), related(), filter(), exclude(), "
+                "include(), sort(), take(), and answer() in one statement so agents "
+                "get an answer pack without 40 separate CLI calls. Example: "
                 "search(['Router', 'Handler']).explore().include(callers=True, "
                 "complexity=True).sort(by='fan_in', desc=True).answer()."
             ),
@@ -305,6 +306,14 @@ class CodeGraphQueryTool(BaseMCPTool):
             state.current = _dedupe_symbols([*callers, *callees])
             return
 
+        if step.name in {"filter", "where"}:
+            _filter_current_selection(state, step, invert=False)
+            return
+
+        if step.name in {"exclude", "not"}:
+            _filter_current_selection(state, step, invert=True)
+            return
+
         if step.name == "take":
             limit = first_int(step, default_max_symbols)
             state.current = state.current[:limit]
@@ -348,6 +357,10 @@ class _QueryState:
         self.compact = compact
         self.seed_queries: list[str] = []
         self.concept_files_returned = 0
+        self.relation_cache: dict[
+            tuple[str, str, str, int, int], list[dict[str, Any]]
+        ] = {}
+        self.selection_filters: list[tuple[_ChainStep, bool]] = []
 
     def add_symbols(self, symbols: list[dict[str, Any]]) -> None:
         for symbol in symbols:
@@ -431,6 +444,8 @@ def _apply_concept_fallback(
         project_root=project_root,
         max_files=max_files,
     )
+    if state.selection_filters:
+        entries = _filter_concept_entries(entries, state.selection_filters)
     if not entries:
         return
     state.files = entries
@@ -439,6 +454,7 @@ def _apply_concept_fallback(
         entries,
         limit=max_symbols,
     )
+    state.current = _apply_selection_filters(state.current, state.selection_filters)
     state.add_symbols(state.current)
 
 
@@ -470,29 +486,173 @@ def _relation_step(
         file_path = str(symbol.get("file") or "")
         if not name:
             continue
-        if direction == "callers":
-            rows = cache.query_callers(name, file_path or None, max_depth=depth) or []
-            entries = [
-                _row_symbol(row, "caller_name", "caller_file", "caller_line")
-                for row in rows
-            ]
-        else:
-            rows = cache.query_callees(name, file_path or None, max_depth=depth) or []
-            entries = [
-                _row_symbol(row, "callee_name", "callee_file", "callee_line")
-                for row in rows
-            ]
-        entries = _source_first_symbols(
-            entry
-            for entry in entries
-            if entry["name"] and not _is_relation_noise_symbol(entry)
-        )[:limit]
+        cache_key = (direction, name, file_path, depth, limit)
+        entries = state.relation_cache.get(cache_key)
+        if entries is None:
+            entries = _query_relation_entries(
+                cache=cache,
+                direction=direction,
+                name=name,
+                file_path=file_path,
+                depth=depth,
+                limit=limit,
+            )
+            state.relation_cache[cache_key] = entries
         source_key = _symbol_key(symbol)
-        state.relationships[direction][source_key] = entries
+        state.relationships[direction][source_key] = list(entries)
         related.extend(entries)
     deduped = _dedupe_symbols(related)
     state.add_symbols(deduped)
     return deduped
+
+
+def _query_relation_entries(
+    *,
+    cache: Any,
+    direction: str,
+    name: str,
+    file_path: str,
+    depth: int,
+    limit: int,
+) -> list[dict[str, Any]]:
+    if direction == "callers":
+        rows = cache.query_callers(name, file_path or None, max_depth=depth) or []
+        entries = [
+            _row_symbol(row, "caller_name", "caller_file", "caller_line")
+            for row in rows
+        ]
+    else:
+        rows = cache.query_callees(name, file_path or None, max_depth=depth) or []
+        entries = [
+            _row_symbol(row, "callee_name", "callee_file", "callee_line")
+            for row in rows
+        ]
+    return _source_first_symbols(
+        entry
+        for entry in entries
+        if entry["name"] and not _is_relation_noise_symbol(entry)
+    )[:limit]
+
+
+def _filter_current_selection(
+    state: _QueryState,
+    step: _ChainStep,
+    *,
+    invert: bool,
+) -> None:
+    state.selection_filters.append((step, invert))
+    state.current = _apply_selection_filters(state.current, state.selection_filters)
+    keep_tuples = {_symbol_key_tuple(symbol) for symbol in state.current}
+    keep_keys = {_symbol_key(symbol) for symbol in state.current}
+    state.symbols = [
+        symbol for symbol in state.symbols if _symbol_key_tuple(symbol) in keep_tuples
+    ]
+    state._seen_symbols = set(keep_tuples)
+    state.files = []
+    state.concept_files_returned = 0
+    _prune_relationships(
+        state.relationships, keep_tuples=keep_tuples, keep_keys=keep_keys
+    )
+
+
+def _apply_selection_filters(
+    symbols: list[dict[str, Any]],
+    selection_filters: list[tuple[_ChainStep, bool]],
+) -> list[dict[str, Any]]:
+    selected = list(symbols)
+    for step, invert in selection_filters:
+        selected = _filters.filter_symbols(selected, step, invert=invert)
+    return selected
+
+
+def _filter_concept_entries(
+    entries: list[dict[str, Any]],
+    selection_filters: list[tuple[_ChainStep, bool]],
+) -> list[dict[str, Any]]:
+    filtered: list[dict[str, Any]] = []
+    file_only = _selection_filters_are_file_only(selection_filters)
+    for entry in entries:
+        symbol_pairs = [
+            (_concept_symbol_to_query_symbol(entry, symbol), symbol)
+            for symbol in entry.get("symbols", [])
+        ]
+        kept_symbols = _apply_selection_filters(
+            [symbol for symbol, _ in symbol_pairs],
+            selection_filters,
+        )
+        file_matches = _concept_file_matches(entry, selection_filters, file_only)
+        if not file_matches and not kept_symbols:
+            continue
+        next_entry = dict(entry)
+        if not file_matches:
+            kept_keys = {_symbol_key_tuple(symbol) for symbol in kept_symbols}
+            next_entry["symbols"] = [
+                raw
+                for symbol, raw in symbol_pairs
+                if _symbol_key_tuple(symbol) in kept_keys
+            ]
+        filtered.append(next_entry)
+    return filtered
+
+
+def _concept_file_matches(
+    entry: dict[str, Any],
+    selection_filters: list[tuple[_ChainStep, bool]],
+    file_only: bool,
+) -> bool:
+    if not file_only:
+        return False
+    file_marker = {
+        "name": "",
+        "kind": "file",
+        "file": entry.get("file_path", ""),
+        "line": 0,
+        "language": entry.get("language", ""),
+    }
+    return bool(_apply_selection_filters([file_marker], selection_filters))
+
+
+def _selection_filters_are_file_only(
+    selection_filters: list[tuple[_ChainStep, bool]],
+) -> bool:
+    symbol_fields = {"name", "kind", "language", "regex"}
+    return not any(
+        symbol_fields.intersection(step.kwargs) for step, _ in selection_filters
+    )
+
+
+def _concept_symbol_to_query_symbol(
+    entry: dict[str, Any],
+    symbol: dict[str, Any],
+) -> dict[str, Any]:
+    start_line = int(symbol.get("start_line", symbol.get("line", 0)) or 0)
+    return {
+        "name": symbol.get("name", ""),
+        "kind": symbol.get("kind", ""),
+        "file": entry.get("file_path", ""),
+        "line": start_line,
+        "end_line": symbol.get("end_line", start_line),
+        "language": entry.get("language", ""),
+    }
+
+
+def _prune_relationships(
+    relationships: dict[str, dict[str, list[dict[str, Any]]]],
+    *,
+    keep_tuples: set[tuple[str, int, str]],
+    keep_keys: set[str],
+) -> None:
+    for direction, edge_map in relationships.items():
+        pruned: dict[str, list[dict[str, Any]]] = {}
+        for source_key, entries in edge_map.items():
+            kept_entries = [
+                entry for entry in entries if _symbol_key_tuple(entry) in keep_tuples
+            ]
+            if source_key in keep_keys:
+                pruned[source_key] = entries
+            elif kept_entries:
+                pruned[source_key] = kept_entries
+        relationships[direction] = pruned
 
 
 def _is_relation_noise_symbol(symbol: dict[str, Any]) -> bool:
@@ -972,20 +1132,11 @@ def _source_preference_key(symbol: dict[str, Any]) -> tuple[int, int, str, int, 
 
 
 def _is_test_or_fixture_path(path: str) -> bool:
-    name = os.path.basename(path)
-    return bool(
-        "/test/" in path
-        or "/tests/" in path
-        or "/__tests__/" in path
-        or "/fixtures/" in path
-        or name.startswith("test_")
-        or "_test." in name
-        or name.endswith((".test.ts", ".test.tsx", ".test.js", ".spec.ts", ".spec.js"))
-    )
+    return _filters.is_test_or_fixture_path(path)
 
 
 def _is_generated_or_vendor_path(path: str) -> bool:
-    return any(part in path for part in ("/vendor/", "/gen/", "/generated/"))
+    return _filters.is_generated_or_vendor_path(path)
 
 
 def _unique_symbol_files(symbols: list[dict[str, Any]]) -> list[str]:


### PR DESCRIPTION
## Summary
- Add jQuery-style selection steps to codegraph_query: filter(), where(), exclude(), and not()
- Keep selection filters active across later concept fallback/source facets so answer packs do not drift to unrelated evidence
- Memoize callers/callees expansion within one chain execution to avoid repeated SQLite relationship queries

## Verification
- uv run ruff check tree_sitter_analyzer/mcp/tools/_codegraph_query_dsl.py tree_sitter_analyzer/mcp/tools/_codegraph_query_filters.py tree_sitter_analyzer/mcp/tools/codegraph_query_tool.py tests/unit/test_codegraph_query_tool.py
- uv run pytest tests/unit/test_codegraph_query_tool.py -q
- uv run pytest tests/unit/test_codegraph_query_tool.py --cov=tree_sitter_analyzer --cov-report=json -q
- uv run python scripts/check_patch_coverage.py --base origin/develop --coverage-json coverage.json
- uv run pytest -q

## Notes
- PR #193 was merged first so this branch is cut from the updated develop line.
- Runtime cache/db files remain uncommitted.