### PR TITLE
feat(codegraph): add relation-aware has query step

### DIFF
--- a/docs/CODEMAPS/cli.md
+++ b/docs/CODEMAPS/cli.md
@@ -89,7 +89,7 @@ Categories of CLI surface:
 - `--ast-path FILE:LINE` — "what is at file:line?"
 - `--codegraph-symbol-search QUERY` — FTS5 symbol search
 - `--codegraph-explore QUERY` — bulk-fetch N related symbols + relmap (CodeGraph parity)
-- `--codegraph-query CHAIN` — jQuery-style chained graph query (`search(['A','B']).filter(test=False).include(callers=True).sort(by='fan_in').answer(compact=True)`)
+- `--codegraph-query CHAIN` — jQuery-style chained graph query (`search(['A','B']).has(callees=True, name='auth').filter(test=False).include(callers=True).sort(by='fan_in').answer(compact=True)`)
 - `--codegraph-query-compact` — trim duplicate source payloads and empty relationship fields in chained query answers
 - `--affected FILE [FILE...]` — list test files transitively affected by changes (CodeGraph parity; closes the last CLI surface gap)
 - `--dead-code` — transitive dead functions / unused imports

--- a/docs/CODEMAPS/mcp-tools.md
+++ b/docs/CODEMAPS/mcp-tools.md
@@ -44,7 +44,7 @@ All tools default to **TOON output** (locked — see `CLAUDE.md`).
 | **CodeGraph parity — symbol navigation** | | |
 | `codegraph_navigate` | `--codegraph-navigate` | PRIMARY symbol navigation hub (def + refs + hierarchy) |
 | `codegraph_explore` | `--codegraph-explore` | BULK fetch N related symbols' source + relationship map |
-| `codegraph_query` | `--codegraph-query` | jQuery-style chained graph query with batch seeds, filter/exclude selection, cached relationship expansion, compact answer packs, and evidence facets |
+| `codegraph_query` | `--codegraph-query` | jQuery-style chained graph query with batch seeds, filter/exclude/has selection, cached relationship expansion, compact answer packs, and evidence facets |
 | `codegraph_symbol_search` | `--codegraph-symbol-search` | FTS5-powered symbol search over indexed project |
 | `codegraph_resolve` | `--symbol-resolve` | Go-to-definition / find-all-references |
 | `codegraph_ast_path` | `--ast-path` | "What is at file:line?" AST path/scope |

--- a/tests/unit/test_codegraph_query_tool.py
+++ b/tests/unit/test_codegraph_query_tool.py
@@ -131,6 +131,25 @@ class TestParseChain:
         }
         assert steps[2].kwargs == {"regex": "Service$"}
 
+    def test_parses_relation_aware_has_step(self):
+        steps = parse_chain(
+            "search('Handler').has(callees=True, name='authorize', depth=2, limit=5)"
+            ".has(callers=True, regex='Controller$', test=False)"
+        )
+
+        assert [step.name for step in steps] == ["search", "has", "has"]
+        assert steps[1].kwargs == {
+            "callees": True,
+            "name": "authorize",
+            "depth": 2,
+            "limit": 5,
+        }
+        assert steps[2].kwargs == {
+            "callers": True,
+            "regex": "Controller$",
+            "test": False,
+        }
+
     def test_parses_kwargs_and_escaped_quotes(self):
         steps = parse_chain(r'search(query="src/a.\"b.py Run").take(2)')
 
@@ -925,6 +944,129 @@ class TestCodeGraphQueryTool:
 
         assert result["symbols"] == []
         assert result["relationships"]["callees"] == {}
+
+    @pytest.mark.asyncio
+    async def test_execute_has_filters_sources_by_related_symbols(self, tmp_path):
+        mock_cache = MagicMock()
+
+        def _query_callees(name, file_path, max_depth):
+            assert max_depth == 1
+            if name == "run":
+                return [
+                    {
+                        "callee_name": "authorize",
+                        "callee_file": "auth.py",
+                        "callee_line": 4,
+                        "depth": 1,
+                    },
+                    {
+                        "callee_name": "helper",
+                        "callee_file": "helper.py",
+                        "callee_line": 8,
+                        "depth": 1,
+                    },
+                ]
+            return [
+                {
+                    "callee_name": "helper",
+                    "callee_file": "helper.py",
+                    "callee_line": 8,
+                    "depth": 1,
+                }
+            ]
+
+        mock_cache.query_callees.side_effect = _query_callees
+        defs = {
+            "run": [_make_def(file="main.py", name="run", line=1)],
+            "skip": [_make_def(file="main.py", name="skip", line=10)],
+        }
+
+        with (
+            patch("tree_sitter_analyzer.ast_cache.ASTCache", return_value=mock_cache),
+            _patch_resolver_with(defs),
+        ):
+            result = await CodeGraphQueryTool(str(tmp_path)).execute(
+                {
+                    "query": "search(['run', 'skip']).has(callees=True, name='authorize')",
+                    "output_format": "json",
+                }
+            )
+
+        assert [symbol["name"] for symbol in result["symbols"]] == ["run"]
+        assert result["relationships"]["callees"]["main.py:1:run"] == [
+            {
+                "name": "authorize",
+                "kind": "function",
+                "file": "auth.py",
+                "line": 4,
+                "end_line": 4,
+                "language": "",
+                "depth": 1,
+            }
+        ]
+        assert mock_cache.query_callees.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_execute_has_reuses_relation_cache_for_later_include(self, tmp_path):
+        mock_cache = MagicMock()
+        mock_cache.query_callees.return_value = [
+            {
+                "callee_name": "helper",
+                "callee_file": "helper.py",
+                "callee_line": 4,
+                "depth": 1,
+            },
+            {
+                "callee_name": "other",
+                "callee_file": "other.py",
+                "callee_line": 8,
+                "depth": 1,
+            },
+        ]
+        defs = {"run": [_make_def(file="main.py", name="run", line=1)]}
+
+        with (
+            patch("tree_sitter_analyzer.ast_cache.ASTCache", return_value=mock_cache),
+            _patch_resolver_with(defs),
+        ):
+            result = await CodeGraphQueryTool(str(tmp_path)).execute(
+                {
+                    "query": (
+                        "search('run').has(callees=True, name='helper')"
+                        ".include(callees=True)"
+                    ),
+                    "output_format": "json",
+                }
+            )
+
+        assert [symbol["name"] for symbol in result["symbols"]] == [
+            "run",
+            "helper",
+            "other",
+        ]
+        assert [
+            symbol["name"]
+            for symbol in result["relationships"]["callees"]["main.py:1:run"]
+        ] == ["helper", "other"]
+        assert mock_cache.query_callees.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_execute_has_reports_missing_direction(self, tmp_path):
+        defs = {"run": [_make_def(file="main.py", name="run", line=1)]}
+
+        with (
+            patch("tree_sitter_analyzer.ast_cache.ASTCache", return_value=MagicMock()),
+            _patch_resolver_with(defs),
+        ):
+            result = await CodeGraphQueryTool(str(tmp_path)).execute(
+                {
+                    "query": "search('run').has(name='helper')",
+                    "output_format": "json",
+                }
+            )
+
+        assert [symbol["name"] for symbol in result["symbols"]] == ["run"]
+        assert result["warnings"] == ["has() requires callers=True or callees=True"]
 
     @pytest.mark.asyncio
     async def test_execute_reuses_relation_cache_within_single_chain(self, tmp_path):

--- a/tree_sitter_analyzer/mcp/tools/_codegraph_query_dsl.py
+++ b/tree_sitter_analyzer/mcp/tools/_codegraph_query_dsl.py
@@ -21,6 +21,7 @@ _SUPPORTED_STEPS = {
     "where",
     "exclude",
     "not",
+    "has",
     "take",
     "sort",
     "include",
@@ -50,6 +51,7 @@ _ALLOWED_KWARGS: dict[str, frozenset[str]] = {
     "where": _FILTER_KWARGS,
     "exclude": _FILTER_KWARGS,
     "not": _FILTER_KWARGS,
+    "has": _FILTER_KWARGS | frozenset({"callers", "callees", "depth", "limit"}),
     "take": frozenset({"limit"}),
     "sort": frozenset({"by", "desc"}),
     "include": frozenset(

--- a/tree_sitter_analyzer/mcp/tools/codegraph_query_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_query_tool.py
@@ -91,10 +91,11 @@ class CodeGraphQueryTool(BaseMCPTool):
             "name": "codegraph_query",
             "description": (
                 "jQuery-style chained code graph query. Compose search(), "
-                "explore(), callers(), callees(), related(), filter(), exclude(), "
+                "explore(), callers(), callees(), related(), filter(), exclude(), has(), "
                 "include(), sort(), take(), and answer() in one statement so agents "
                 "get an answer pack without 40 separate CLI calls. Example: "
-                "search(['Router', 'Handler']).explore().include(callers=True, "
+                "search(['Router', 'Handler']).has(callees=True, name='authorize')"
+                ".explore().include(callers=True, "
                 "complexity=True).sort(by='fan_in', desc=True).answer()."
             ),
             "inputSchema": self.get_tool_schema(),
@@ -314,6 +315,10 @@ class CodeGraphQueryTool(BaseMCPTool):
             _filter_current_selection(state, step, invert=True)
             return
 
+        if step.name == "has":
+            _filter_selection_by_related_symbols(cache, state, step)
+            return
+
         if step.name == "take":
             limit = first_int(step, default_max_symbols)
             state.current = state.current[:limit]
@@ -482,28 +487,50 @@ def _relation_step(
     limit = int_kw(step, "limit", _MAX_REL_PER_SYMBOL, _MAX_SYMBOLS_CAP)
     related: list[dict[str, Any]] = []
     for symbol in state.current:
-        name = str(symbol.get("name") or "")
-        file_path = str(symbol.get("file") or "")
-        if not name:
+        entries = _relation_entries_for_symbol(
+            cache=cache,
+            state=state,
+            direction=direction,
+            symbol=symbol,
+            depth=depth,
+            limit=limit,
+        )
+        if not entries:
             continue
-        cache_key = (direction, name, file_path, depth, limit)
-        entries = state.relation_cache.get(cache_key)
-        if entries is None:
-            entries = _query_relation_entries(
-                cache=cache,
-                direction=direction,
-                name=name,
-                file_path=file_path,
-                depth=depth,
-                limit=limit,
-            )
-            state.relation_cache[cache_key] = entries
         source_key = _symbol_key(symbol)
         state.relationships[direction][source_key] = list(entries)
         related.extend(entries)
     deduped = _dedupe_symbols(related)
     state.add_symbols(deduped)
     return deduped
+
+
+def _relation_entries_for_symbol(
+    *,
+    cache: Any,
+    state: _QueryState,
+    direction: str,
+    symbol: dict[str, Any],
+    depth: int,
+    limit: int,
+) -> list[dict[str, Any]]:
+    name = str(symbol.get("name") or "")
+    file_path = str(symbol.get("file") or "")
+    if not name:
+        return []
+    cache_key = (direction, name, file_path, depth, limit)
+    entries = state.relation_cache.get(cache_key)
+    if entries is None:
+        entries = _query_relation_entries(
+            cache=cache,
+            direction=direction,
+            name=name,
+            file_path=file_path,
+            depth=depth,
+            limit=limit,
+        )
+        state.relation_cache[cache_key] = entries
+    return entries
 
 
 def _query_relation_entries(
@@ -541,7 +568,53 @@ def _filter_current_selection(
     invert: bool,
 ) -> None:
     state.selection_filters.append((step, invert))
-    state.current = _apply_selection_filters(state.current, state.selection_filters)
+    selected = _apply_selection_filters(state.current, state.selection_filters)
+    _replace_current_selection(state, selected)
+
+
+def _filter_selection_by_related_symbols(
+    cache: Any,
+    state: _QueryState,
+    step: _ChainStep,
+) -> None:
+    directions: list[str] = []
+    if bool_kw(step, "callers", False):
+        directions.append("callers")
+    if bool_kw(step, "callees", False):
+        directions.append("callees")
+    if not directions:
+        raise ValueError("has() requires callers=True or callees=True")
+
+    depth = int_kw(step, "depth", 1, 5)
+    limit = int_kw(step, "limit", _MAX_REL_PER_SYMBOL, _MAX_SYMBOLS_CAP)
+    selected: list[dict[str, Any]] = []
+    for symbol in state.current:
+        source_key = _symbol_key(symbol)
+        matched_any = False
+        for direction in directions:
+            entries = _relation_entries_for_symbol(
+                cache=cache,
+                state=state,
+                direction=direction,
+                symbol=symbol,
+                depth=depth,
+                limit=limit,
+            )
+            matches = _filters.filter_symbols(entries, step)
+            if matches:
+                state.relationships[direction][source_key] = matches
+                matched_any = True
+        if matched_any:
+            selected.append(symbol)
+
+    _replace_current_selection(state, selected)
+
+
+def _replace_current_selection(
+    state: _QueryState,
+    selected: list[dict[str, Any]],
+) -> None:
+    state.current = _dedupe_symbols(selected)
     keep_tuples = {_symbol_key_tuple(symbol) for symbol in state.current}
     keep_keys = {_symbol_key(symbol) for symbol in state.current}
     state.symbols = [


### PR DESCRIPTION
## Summary
- Add `has(...)` to the codegraph query DSL for relation-aware source filtering
- Reuse per-chain relation cache while preserving current selection semantics
- Document CLI/MCP codemap examples for relation-aware filtering

## Verification
- `uv run ruff check tree_sitter_analyzer/mcp/tools/_codegraph_query_dsl.py tree_sitter_analyzer/mcp/tools/codegraph_query_tool.py tests/unit/test_codegraph_query_tool.py`
- `uv run pytest tests/unit/test_codegraph_query_tool.py -q`
- `uv run pytest tests/unit/test_codegraph_query_tool.py --cov=tree_sitter_analyzer --cov-report=json -q`
- `uv run python scripts/check_patch_coverage.py --base origin/develop --coverage-json coverage.json`
- `uv run python -m tree_sitter_analyzer --change-impact --format json`
- `uv run pytest -q`
- CLI smoke: `uv run python -m tree_sitter_analyzer --codegraph-query "search('CodeGraphQueryTool').has(callees=True).answer(compact=True)" --format json`
