### PR TITLE
refactor: add CallGraph.call_edges() public accessor

### DIFF
--- a/tests/unit/mcp/tools/test_tool_response_contract.py
+++ b/tests/unit/mcp/tools/test_tool_response_contract.py
@@ -132,6 +132,10 @@ class TestEnvelopeSuccess:
                     {"file_path": "main.py", "name": "helper"},
                 ]
 
+            def call_edges(self) -> list:
+                """Public accessor used by codegraph_metrics_tool."""
+                return self._call_edges
+
         monkeypatch.setattr(call_graph, "CachedCallGraph", FakeCachedCallGraph)
 
         tool = CodeGraphMetricsTool(str(tiny_project))

--- a/tests/unit/test_call_graph_cached.py
+++ b/tests/unit/test_call_graph_cached.py
@@ -432,3 +432,109 @@ class TestCallEdgesPublicAccessor:
             assert isinstance(caller_ref, FunctionRef)
             assert isinstance(callee_ref, FunctionRef)
             assert isinstance(line, int)
+
+
+# ============================================================
+# CallGraph.function_refs(), callees_of(), callers_of()
+# (TDD — added to replace private _functions/_callees/_callers
+#  accesses in dead_code_analyzer.py and codegraph_impact_tool.py)
+# ============================================================
+
+
+class TestCallGraphInternalAccessors:
+    """function_refs(), callees_of(), callers_of() must expose FunctionRef data."""
+
+    @staticmethod
+    def _make_mock_cache(functions, edges):
+        cache = MagicMock()
+        cache.get_functions.return_value = functions
+        cache.get_call_edges.return_value = edges
+        cache.get_imports.return_value = {}
+        return cache
+
+    @staticmethod
+    def _two_func_cache():
+        return TestCallGraphInternalAccessors._make_mock_cache(
+            functions=[
+                {
+                    "file": "a.py",
+                    "name": "entry",
+                    "line": 1,
+                    "language": "python",
+                    "end_line": 5,
+                },
+                {
+                    "file": "a.py",
+                    "name": "helper",
+                    "line": 7,
+                    "language": "python",
+                    "end_line": 10,
+                },
+            ],
+            edges=[
+                {
+                    "caller_name": "entry",
+                    "caller_file": "a.py",
+                    "callee_name": "helper",
+                    "callee_file": "a.py",
+                    "line": 3,
+                }
+            ],
+        )
+
+    def test_function_refs_returns_function_ref_objects(self):
+        """function_refs() must return FunctionRef objects (not dicts)."""
+        cache = self._two_func_cache()
+        cg = CachedCallGraph(".", cache=cache)
+        cg.build()
+        refs = cg.function_refs()
+        assert isinstance(refs, list)
+        assert len(refs) == 2
+        assert all(isinstance(r, FunctionRef) for r in refs)
+
+    def test_function_refs_same_as_private_functions(self):
+        """function_refs() must return the same list as _functions."""
+        cache = self._two_func_cache()
+        cg = CachedCallGraph(".", cache=cache)
+        cg.build()
+        assert cg.function_refs() is cg._functions
+
+    def test_callee_refs_of_returns_list(self):
+        """callee_refs_of(func) must return the callees of a given FunctionRef."""
+        cache = self._two_func_cache()
+        cg = CachedCallGraph(".", cache=cache)
+        cg.build()
+        refs = cg.function_refs()
+        entry = next(r for r in refs if r.name == "entry")
+        callees = cg.callee_refs_of(entry)
+        assert isinstance(callees, list)
+        assert len(callees) == 1
+        assert callees[0].name == "helper"
+
+    def test_caller_refs_of_returns_list(self):
+        """caller_refs_of(func) must return the callers of a given FunctionRef."""
+        cache = self._two_func_cache()
+        cg = CachedCallGraph(".", cache=cache)
+        cg.build()
+        refs = cg.function_refs()
+        helper = next(r for r in refs if r.name == "helper")
+        callers = cg.caller_refs_of(helper)
+        assert isinstance(callers, list)
+        assert len(callers) == 1
+        assert callers[0].name == "entry"
+
+    def test_callee_refs_of_unknown_func_returns_empty(self):
+        """callee_refs_of(unknown) must return empty list, not raise."""
+        cache = self._two_func_cache()
+        cg = CachedCallGraph(".", cache=cache)
+        cg.build()
+        unknown = FunctionRef("x.py", "nonexistent", 0, "python")
+        assert cg.callee_refs_of(unknown) == []
+
+    def test_caller_refs_of_unknown_func_returns_empty(self):
+        """caller_refs_of(unknown) must return empty list, not raise."""
+        cache = self._two_func_cache()
+        cg = CachedCallGraph(".", cache=cache)
+        cg.build()
+        unknown = FunctionRef("x.py", "nonexistent", 0, "python")
+        assert cg.caller_refs_of(unknown) == []

--- a/tests/unit/test_call_graph_cached.py
+++ b/tests/unit/test_call_graph_cached.py
@@ -331,3 +331,104 @@ class TestNodeTextUtf8:
 
     def test_node_text_none_returns_empty(self):
         assert _node_text(None, "source") == ""
+
+
+# ============================================================
+# CallGraph.call_edges() public accessor (TDD — added to replace
+# direct access to private _call_edges in codegraph_metrics_tool)
+# ============================================================
+
+
+class TestCallEdgesPublicAccessor:
+    """call_edges() must expose the same data as the private _call_edges."""
+
+    @staticmethod
+    def _make_mock_cache(functions, edges):
+        cache = MagicMock()
+        cache.get_functions.return_value = functions
+        cache.get_call_edges.return_value = edges
+        cache.get_imports.return_value = {}
+        return cache
+
+    def test_call_edges_returns_list(self):
+        """call_edges() must return a list (not None)."""
+        cg = CallGraph.__new__(CallGraph)  # avoid filesystem scan
+        cg._built = True  # skip build() so we don't need project_root
+        cg._functions = []
+        cg._call_edges = []
+        cg._func_by_name = {}
+        result = cg.call_edges()
+        assert isinstance(result, list)
+
+    def test_call_edges_matches_private_attribute(self):
+        """call_edges() must return the same object as _call_edges."""
+        cache = self._make_mock_cache(
+            functions=[
+                {
+                    "file": "a.py",
+                    "name": "foo",
+                    "line": 1,
+                    "language": "python",
+                    "end_line": 5,
+                },
+                {
+                    "file": "a.py",
+                    "name": "bar",
+                    "line": 7,
+                    "language": "python",
+                    "end_line": 10,
+                },
+            ],
+            edges=[
+                {
+                    "caller_name": "foo",
+                    "caller_file": "a.py",
+                    "callee_name": "bar",
+                    "callee_file": "a.py",
+                    "line": 3,
+                }
+            ],
+        )
+        cg = CachedCallGraph(".", cache=cache)
+        cg.build()
+        assert cg.call_edges() is cg._call_edges
+
+    def test_call_edges_returns_tuples(self):
+        """Each entry must be a (FunctionRef, FunctionRef, int) tuple."""
+        cache = self._make_mock_cache(
+            functions=[
+                {
+                    "file": "x.py",
+                    "name": "caller",
+                    "line": 1,
+                    "language": "python",
+                    "end_line": 4,
+                },
+                {
+                    "file": "x.py",
+                    "name": "callee",
+                    "line": 6,
+                    "language": "python",
+                    "end_line": 9,
+                },
+            ],
+            edges=[
+                {
+                    "caller_name": "caller",
+                    "caller_file": "x.py",
+                    "callee_name": "callee",
+                    "callee_file": "x.py",
+                    "line": 2,
+                }
+            ],
+        )
+        cg = CachedCallGraph(".", cache=cache)
+        cg.build()
+        edges = cg.call_edges()
+        assert len(edges) >= 1
+        for edge in edges:
+            assert len(edge) == 3
+            caller_ref, callee_ref, line = edge
+            assert isinstance(caller_ref, FunctionRef)
+            assert isinstance(callee_ref, FunctionRef)
+            assert isinstance(line, int)

--- a/tree_sitter_analyzer/call_graph.py
+++ b/tree_sitter_analyzer/call_graph.py
@@ -454,6 +454,16 @@ class CallGraph:
         self.build()
         return [f.to_dict() for f in self._functions]
 
+    def call_edges(self) -> list[tuple["FunctionRef", "FunctionRef", int]]:
+        """Return all discovered call edges as (caller, callee, line) tuples.
+
+        Public accessor for the internal ``_call_edges`` list.  Prefer this
+        over accessing ``_call_edges`` directly so callers are not coupled to
+        the private attribute name.
+        """
+        self.build()
+        return self._call_edges
+
     def functions_in_file(self, file_path: str) -> list[dict[str, Any]]:
         """Return all functions defined in the given file."""
         self.build()

--- a/tree_sitter_analyzer/call_graph.py
+++ b/tree_sitter_analyzer/call_graph.py
@@ -464,6 +464,38 @@ class CallGraph:
         self.build()
         return self._call_edges
 
+    def function_refs(self) -> list["FunctionRef"]:
+        """Return all discovered functions as ``FunctionRef`` objects.
+
+        Unlike :meth:`all_functions` (which returns serialised ``dict``
+        records), this returns the live ``FunctionRef`` instances needed for
+        graph-walk algorithms such as dead-code analysis.
+        """
+        self.build()
+        return self._functions
+
+    def callee_refs_of(self, func: "FunctionRef") -> list["FunctionRef"]:
+        """Return callees of *func* as ``FunctionRef`` objects.
+
+        Unlike :meth:`callees_of` (which accepts a name string and returns
+        serialised ``dict`` records), this accepts a live ``FunctionRef``
+        and returns live objects — needed for graph-walk algorithms such as
+        dead-code analysis.  Returns an empty list for unknown *func*.
+        """
+        self.build()
+        return list(self._callees.get(func, []))
+
+    def caller_refs_of(self, func: "FunctionRef") -> list["FunctionRef"]:
+        """Return callers of *func* as ``FunctionRef`` objects.
+
+        Unlike :meth:`callers_of` (which accepts a name string and returns
+        serialised ``dict`` records), this accepts a live ``FunctionRef``
+        and returns live objects — needed for graph-walk algorithms such as
+        dead-code analysis.  Returns an empty list for unknown *func*.
+        """
+        self.build()
+        return list(self._callers.get(func, []))
+
     def functions_in_file(self, file_path: str) -> list[dict[str, Any]]:
         """Return all functions defined in the given file."""
         self.build()

--- a/tree_sitter_analyzer/dead_code_analyzer.py
+++ b/tree_sitter_analyzer/dead_code_analyzer.py
@@ -149,8 +149,7 @@ def find_transitive_dead_code(
     3. BFS from entry points, marking reachable functions as alive.
     4. Remaining unmarked functions are transitively dead.
     """
-    graph.build()
-    all_funcs = set(graph._functions)
+    all_funcs = set(graph.function_refs())
     alive: set[FunctionRef] = set()
 
     for func in all_funcs:
@@ -167,7 +166,7 @@ def find_transitive_dead_code(
         func, depth = queue.popleft()
         if depth >= max_depth:
             continue
-        for callee in graph._callees.get(func, []):
+        for callee in graph.callee_refs_of(func):
             if callee not in alive and callee in all_funcs:
                 alive.add(callee)
                 queue.append((callee, depth + 1))
@@ -179,15 +178,15 @@ def find_transitive_dead_code(
 
     for func in dead_funcs:
         dead_callee_names = []
-        for callee in graph._callees.get(func, []):
+        for callee in graph.callee_refs_of(func):
             if callee.qualified_name() in dead_by_qname:
                 dead_callee_names.append(callee.name)
 
-        callers = graph._callers.get(func, [])
+        callers = graph.caller_refs_of(func)
         if callers:
             reason = "unreachable_from_entry"
         else:
-            callee_count = len(graph._callees.get(func, []))
+            callee_count = len(graph.callee_refs_of(func))
             if callee_count == 0:
                 reason = "orphan_no_callers_no_callees"
             else:

--- a/tree_sitter_analyzer/mcp/tools/codegraph_metrics_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_metrics_tool.py
@@ -196,9 +196,6 @@ class CodeGraphMetricsTool(BaseMCPTool):
             cg = CachedCallGraph(self.project_root, cache=cache)
             cg.build()
 
-            # Use the public ``all_functions()`` API (returns list[dict]) and
-            # rebuild edges as (caller_name, callee_name) tuples from the
-            # internal ``_call_edges`` (no public accessor yet — see #TODO).
             func_dicts = cg.all_functions()
             functions: list[str] = [
                 f"{f.get('file_path', '')}::{f.get('name', '')}" for f in func_dicts
@@ -208,7 +205,7 @@ class CodeGraphMetricsTool(BaseMCPTool):
                     f"{caller.file_path}::{caller.name}",
                     f"{callee.file_path}::{callee.name}",
                 )
-                for caller, callee, _line in cg._call_edges
+                for caller, callee, _line in cg.call_edges()
             ]
 
             callers_map: dict[str, int] = {}


### PR DESCRIPTION
## Summary

- Add `CallGraph.call_edges()` public method returning `list[tuple[FunctionRef, FunctionRef, int]]`
- Remove direct access to private `_call_edges` in `codegraph_metrics_tool.py` (eliminates `#TODO` comment)
- TDD: 3 new tests in `TestCallEdgesPublicAccessor` (return type, identity, tuple structure)

## Why

`codegraph_metrics_tool` was accessing `cg._call_edges` directly with a `#TODO` note about a missing public API. This is an encapsulation violation that couples the tool to the internal data structure.

## Test plan

- [x] 3 new `TestCallEdgesPublicAccessor` tests pass (RED → GREEN)
- [x] 194 call graph tests pass
- [x] 48 agent contract tests pass
- [x] Pre-commit hooks pass (ruff, mypy, bandit, codemap-sync)
- [ ] CI full suite