### PR TITLE
refactor: expose ASTCache.get_conn() as public API

### DIFF
--- a/openspec/changes/expose-ast-cache-get-conn/spec.md
+++ b/openspec/changes/expose-ast-cache-get-conn/spec.md
@@ -1,0 +1,36 @@
+# Spec: Expose ASTCache.get_conn() Public API
+
+## Problem
+
+`ASTCache._get_conn()` is called directly by 17 production modules across 31
+call sites, bypassing encapsulation.  This is an API contract violation — callers
+are coupled to the private attribute name.
+
+Affected modules (sample):
+- `xref.py`, `call_path.py`, `incremental_sync.py`, `class_hierarchy.py`
+- `code_similarity.py`, `codegraph_query_backend.py`, `cross_file_resolver.py`
+- `semantic_search.py`, `symbol_resolver.py`, `synapse_resolver/_context.py`
+- 7 MCP tool files
+
+## Decision
+
+Add `ASTCache.get_conn()` as a public alias for `_get_conn()`, then migrate all
+31 call sites.  `_get_conn()` is kept as an internal delegation to avoid touching
+any non-Python callers (none found, but kept for safety).
+
+This is the minimal-change approach: no behavioral change, no query refactoring,
+no new abstractions.  The goal is purely to eliminate private-attribute coupling.
+
+## Non-Goals
+
+- Replacing raw SQL with higher-level `ASTCache` methods (separate, larger refactor)
+- Changing connection lifecycle or WAL settings
+- Touching any test infrastructure
+
+## Acceptance Criteria
+
+1. `ASTCache.get_conn()` is defined and returns the same connection as `_get_conn()`
+2. All 31 production call sites use `get_conn()` instead of `_get_conn()`
+3. `_get_conn()` remains (delegates to `get_conn()`) for backward compat
+4. All existing tests pass
+5. `change-impact` shows `risk=low` or lower after the change

--- a/openspec/changes/expose-ast-cache-get-conn/tasks.md
+++ b/openspec/changes/expose-ast-cache-get-conn/tasks.md
@@ -1,0 +1,21 @@
+# Tasks: Expose ASTCache.get_conn() Public API
+
+## Phase 1 — TDD: Write Failing Test
+
+- [x] **T1** Write test: `ASTCache.get_conn()` exists and returns a `sqlite3.Connection`
+  - File: `tests/unit/test_ast_cache.py` — `TestASTCacheGetConnPublicAccessor`
+  - 3 tests: returns Connection, same as _get_conn, thread-local stable
+
+## Phase 2 — Implementation
+
+- [x] **I1** Add `get_conn()` to `ASTCache` as public method
+  - `_get_conn()` now delegates to `get_conn()` for backward compat
+- [x] **I2** Migrate call sites in production code (17 files, 31 call sites)
+  - sed replace: all external `._get_conn()` → `.get_conn()`
+- [x] **I3** Fix test mocks: `test_xref.py` + `test_symbol_resolver.py` MockCache
+
+## Phase 3 — Verification
+
+- [x] **V1** 249 tests pass (focused: ast_cache, xref, cross_file, symbol_resolver, etc.)
+- [ ] **V2** Run `uv run python -m tree_sitter_analyzer --change-impact --format json`
+- [ ] **V3** Push + PR to develop

--- a/tests/unit/test_ast_cache.py
+++ b/tests/unit/test_ast_cache.py
@@ -755,3 +755,30 @@ class TestSQLNativeCallGraph:
         callers = call_cache.query_callers("bar")
         for e in callers:
             assert e["depth"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# ASTCache.get_conn() public accessor (TDD — replaces private _get_conn usage)
+# ---------------------------------------------------------------------------
+
+
+class TestASTCacheGetConnPublicAccessor:
+    """get_conn() must expose the same SQLite connection as _get_conn()."""
+
+    def test_get_conn_returns_sqlite_connection(self, tmp_project):
+        """get_conn() must return a live sqlite3.Connection, not None."""
+        cache = ASTCache(str(tmp_project))
+        conn = cache.get_conn()
+        assert isinstance(conn, sqlite3.Connection)
+
+    def test_get_conn_same_as_private_get_conn(self, tmp_project):
+        """get_conn() and _get_conn() must return the same connection object."""
+        cache = ASTCache(str(tmp_project))
+        assert cache.get_conn() is cache._get_conn()
+
+    def test_get_conn_thread_local_stable(self, tmp_project):
+        """Repeated calls to get_conn() within the same thread return the same object."""
+        cache = ASTCache(str(tmp_project))
+        conn1 = cache.get_conn()
+        conn2 = cache.get_conn()
+        assert conn1 is conn2

--- a/tests/unit/test_call_path.py
+++ b/tests/unit/test_call_path.py
@@ -62,7 +62,8 @@ def _make_cache_with_edges(tmp_path: Path, edges: list[dict]) -> MagicMock:
             ),
         )
     conn.commit()
-    cache._get_conn.return_value = conn
+    cache.get_conn.return_value = conn
+    cache._get_conn.return_value = conn  # backward-compat alias
     return cache
 
 

--- a/tests/unit/test_change_impact_cached_graph.py
+++ b/tests/unit/test_change_impact_cached_graph.py
@@ -120,8 +120,11 @@ def test_cached_index_rows_handles_query_failure():
             raise RuntimeError("boom")
 
     class BadCache:
-        def _get_conn(self):
+        def get_conn(self):
             return BadConn()
+
+        def _get_conn(self):  # backward-compat alias
+            return self.get_conn()
 
     assert cached._cached_index_rows(BadCache()) == []
 

--- a/tests/unit/test_codegraph_explore_helpers.py
+++ b/tests/unit/test_codegraph_explore_helpers.py
@@ -119,7 +119,8 @@ class TestConceptSearchHelpers:
             )
 
         cache = MagicMock()
-        cache._get_conn.return_value = conn
+        cache.get_conn.return_value = conn
+        cache._get_conn.return_value = conn  # backward-compat alias
         result = helpers.concept_search(
             cache,
             ["diagnostics", "marker", "service"],
@@ -164,7 +165,8 @@ class TestConceptSearchHelpers:
         ]
         conn.executemany("INSERT INTO ast_index VALUES (?, ?, ?, ?)", rows)
         cache = MagicMock()
-        cache._get_conn.return_value = conn
+        cache.get_conn.return_value = conn
+        cache._get_conn.return_value = conn  # backward-compat alias
 
         result = helpers.concept_search(
             cache,
@@ -205,7 +207,8 @@ class TestConceptSearchHelpers:
             "INSERT INTO ast_symbol_rows VALUES (?, ?)", ("src/hit.py", "needle")
         )
         cache = MagicMock()
-        cache._get_conn.return_value = conn
+        cache.get_conn.return_value = conn
+        cache._get_conn.return_value = conn  # backward-compat alias
 
         result = helpers.concept_search(
             cache,
@@ -314,7 +317,8 @@ class TestConceptSearchHelpers:
                 ),
             )
         cache = MagicMock()
-        cache._get_conn.return_value = conn
+        cache.get_conn.return_value = conn
+        cache._get_conn.return_value = conn  # backward-compat alias
 
         result = helpers.concept_search(
             cache,
@@ -472,7 +476,8 @@ class TestConceptSearchHelpers:
                 ),
             )
         cache = MagicMock()
-        cache._get_conn.return_value = conn
+        cache.get_conn.return_value = conn
+        cache._get_conn.return_value = conn  # backward-compat alias
 
         result = helpers.concept_search(
             cache,

--- a/tests/unit/test_codegraph_query_backend.py
+++ b/tests/unit/test_codegraph_query_backend.py
@@ -15,8 +15,11 @@ class RowCache:
     def __init__(self, conn: sqlite3.Connection) -> None:
         self.conn = conn
 
-    def _get_conn(self) -> sqlite3.Connection:
+    def get_conn(self) -> sqlite3.Connection:
         return self.conn
+
+    def _get_conn(self) -> sqlite3.Connection:  # backward-compat alias
+        return self.get_conn()
 
 
 def _connect() -> sqlite3.Connection:

--- a/tests/unit/test_codegraph_query_tool_advanced.py
+++ b/tests/unit/test_codegraph_query_tool_advanced.py
@@ -62,7 +62,8 @@ class TestCodeGraphQueryToolAdvanced:
                 ),
             )
         mock_cache = MagicMock()
-        mock_cache._get_conn.return_value = conn
+        mock_cache.get_conn.return_value = conn
+        mock_cache._get_conn.return_value = conn  # backward-compat alias
 
         with (
             patch("tree_sitter_analyzer.ast_cache.ASTCache", return_value=mock_cache),
@@ -131,7 +132,8 @@ class TestCodeGraphQueryToolAdvanced:
             ),
         )
         mock_cache = MagicMock()
-        mock_cache._get_conn.return_value = conn
+        mock_cache.get_conn.return_value = conn
+        mock_cache._get_conn.return_value = conn  # backward-compat alias
 
         with (
             patch("tree_sitter_analyzer.ast_cache.ASTCache", return_value=mock_cache),

--- a/tests/unit/test_codegraph_query_tool_core.py
+++ b/tests/unit/test_codegraph_query_tool_core.py
@@ -309,7 +309,8 @@ class TestCodeGraphQueryTool:
             ),
         )
         mock_cache = MagicMock()
-        mock_cache._get_conn.return_value = conn
+        mock_cache.get_conn.return_value = conn
+        mock_cache._get_conn.return_value = conn  # backward-compat alias
         mock_cache.query_callers.return_value = []
         mock_cache.query_callees.return_value = []
 
@@ -374,7 +375,8 @@ class TestCodeGraphQueryTool:
             ),
         )
         mock_cache = MagicMock()
-        mock_cache._get_conn.return_value = conn
+        mock_cache.get_conn.return_value = conn
+        mock_cache._get_conn.return_value = conn  # backward-compat alias
 
         with (
             patch("tree_sitter_analyzer.ast_cache.ASTCache", return_value=mock_cache),

--- a/tests/unit/test_symbol_resolver.py
+++ b/tests/unit/test_symbol_resolver.py
@@ -103,8 +103,12 @@ class TestSymbolResolverEngine:
             _fts5_available = False
 
             @staticmethod
-            def _get_conn():
+            def get_conn():
                 return conn
+
+            @staticmethod
+            def _get_conn():  # backward-compat alias
+                return Cache.get_conn()
 
         cache = Cache()
         resolver = SymbolResolver(cache)

--- a/tests/unit/test_xref.py
+++ b/tests/unit/test_xref.py
@@ -35,8 +35,11 @@ class TestXRefEngineSymbol:
                 return MockCursor()
 
         class MockCache:
-            def _get_conn(self):
+            def get_conn(self):
                 return MockConn()
+
+            def _get_conn(self):  # backward-compat alias
+                return self.get_conn()
 
         cache = MockCache()
 

--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -364,7 +364,16 @@ class ASTCache:
         os.makedirs(os.path.dirname(db_path), exist_ok=True)
         self._init_db()
 
-    def _get_conn(self) -> sqlite3.Connection:
+    def get_conn(self) -> sqlite3.Connection:
+        """Return the thread-local SQLite connection for this cache.
+
+        Public accessor for the database connection.  Each thread gets its
+        own ``sqlite3.Connection`` (created lazily on first access) configured
+        with WAL journal mode and ``Row`` row factory.
+
+        Prefer this over the private ``_get_conn()`` — external modules that
+        need raw SQL access should call ``cache.get_conn()``.
+        """
         conn = getattr(self._local, "conn", None)
         if conn is None:
             conn = sqlite3.connect(self.db_path, timeout=10)
@@ -373,6 +382,10 @@ class ASTCache:
             conn.row_factory = sqlite3.Row
             self._local.conn = conn
         return conn
+
+    def _get_conn(self) -> sqlite3.Connection:
+        """Private alias kept for backward compatibility — delegates to get_conn()."""
+        return self.get_conn()
 
     def _init_db(self) -> None:
         conn = self._get_conn()

--- a/tree_sitter_analyzer/call_path.py
+++ b/tree_sitter_analyzer/call_path.py
@@ -196,7 +196,7 @@ class CallPathFinder:
         max_depth: int,
         max_paths: int,
     ) -> CallPathResult:
-        conn = cache._get_conn()
+        conn = cache.get_conn()
         start_key = (source_function, source_file)
         target_key = (target_function, target_file)
         queue: deque[tuple[str, str | None, list[dict[str, Any]]]] = deque()
@@ -245,7 +245,7 @@ class CallPathFinder:
         max_depth: int,
         max_paths: int,
     ) -> CallPathResult:
-        conn = cache._get_conn()
+        conn = cache.get_conn()
         target_key = (target_function, target_file)
         start_key = (source_function, source_file)
         queue: deque[tuple[str, str | None, list[dict[str, Any]]]] = deque()
@@ -292,7 +292,7 @@ class CallPathFinder:
         max_depth: int,
         max_paths: int,
     ) -> CallPathResult:
-        conn = cache._get_conn()
+        conn = cache.get_conn()
         forward_visited: dict[tuple[str, str | None], list[dict[str, Any]]] = {
             (source_function, source_file): [],
         }

--- a/tree_sitter_analyzer/class_hierarchy.py
+++ b/tree_sitter_analyzer/class_hierarchy.py
@@ -103,7 +103,7 @@ class ClassHierarchy:
 
     def _load_from_cache(self) -> None:
         try:
-            conn = self._cache._get_conn()
+            conn = self._cache.get_conn()
             rows = conn.execute(
                 "SELECT file_path, symbols_json, language FROM ast_index"
             ).fetchall()

--- a/tree_sitter_analyzer/code_similarity.py
+++ b/tree_sitter_analyzer/code_similarity.py
@@ -384,7 +384,7 @@ def _extract_cached_functions(
     if not functions:
         return []
 
-    conn = cache._get_conn()
+    conn = cache.get_conn()
     rows_by_file: dict[str, dict[str, Any]] = {}
     for row in conn.execute(
         "SELECT file_path, content_hash, language FROM ast_index"

--- a/tree_sitter_analyzer/codegraph_query_backend.py
+++ b/tree_sitter_analyzer/codegraph_query_backend.py
@@ -78,7 +78,7 @@ class CodeGraphQueryBackend:
         ]
 
     def _symbol_row_definitions(self, symbol: str) -> list[dict[str, Any]]:
-        conn = self.cache._get_conn()
+        conn = self.cache.get_conn()
         try:
             rows = conn.execute(
                 """SELECT name, kind, file_path, language, line, end_line
@@ -103,7 +103,7 @@ class CodeGraphQueryBackend:
         ]
 
     def _symbols_json_definitions(self, symbol: str) -> list[dict[str, Any]]:
-        conn = self.cache._get_conn()
+        conn = self.cache.get_conn()
         try:
             rows = conn.execute(
                 "SELECT file_path, symbols_json, language FROM ast_index"

--- a/tree_sitter_analyzer/cross_file_resolver.py
+++ b/tree_sitter_analyzer/cross_file_resolver.py
@@ -220,7 +220,7 @@ class CrossFileResolver:
         return resolved
 
     def _build_module_map(self) -> None:
-        conn = self._cache._get_conn()
+        conn = self._cache.get_conn()
         rows = conn.execute("SELECT file_path, language FROM ast_index").fetchall()
         for row in rows:
             fp = row["file_path"]
@@ -260,7 +260,7 @@ class CrossFileResolver:
                     self._module_to_file[short] = fp
 
     def _build_function_index(self) -> None:
-        conn = self._cache._get_conn()
+        conn = self._cache.get_conn()
         rows = conn.execute(
             "SELECT file_path, symbols_json, language FROM ast_index"
         ).fetchall()
@@ -283,7 +283,7 @@ class CrossFileResolver:
                 self._functions_by_file.setdefault(fp, []).append(func)
 
     def _build_import_index(self) -> None:
-        conn = self._cache._get_conn()
+        conn = self._cache.get_conn()
         rows = conn.execute(
             "SELECT file_path, imports_json, language FROM ast_index"
         ).fetchall()

--- a/tree_sitter_analyzer/incremental_sync.py
+++ b/tree_sitter_analyzer/incremental_sync.py
@@ -85,7 +85,7 @@ class IncrementalSync:
         per-phase logic; ``sync`` becomes a thin orchestrator.
         """
         result = SyncResult()
-        conn = self._cache._get_conn()
+        conn = self._cache.get_conn()
 
         indexed_rows = self._load_indexed_rows(conn)
         disk_files = self._scan_disk_files(max_files)
@@ -244,7 +244,7 @@ class IncrementalSync:
         Returns dict with keys: 'new', 'modified', 'deleted' — each a list of
         relative file paths.
         """
-        conn = self._cache._get_conn()
+        conn = self._cache.get_conn()
         indexed_rows = {
             row["file_path"]: {
                 "content_hash": row["content_hash"],

--- a/tree_sitter_analyzer/mcp/tools/_codegraph_explore_helpers.py
+++ b/tree_sitter_analyzer/mcp/tools/_codegraph_explore_helpers.py
@@ -161,7 +161,7 @@ def concept_search(
     if not terms:
         return []
 
-    conn = cache._get_conn()
+    conn = cache.get_conn()
     rows = conn.execute(
         "SELECT file_path, language, file_size, symbols_json FROM ast_index"
     ).fetchall()

--- a/tree_sitter_analyzer/mcp/tools/codegraph_relation_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_relation_tool.py
@@ -182,7 +182,7 @@ class CodeGraphRelationToolMixin:
     ) -> dict[tuple[str, int], dict[str, Any]]:
         """Build a (file_path, line) -> activation map from AST cache rows."""
         try:
-            conn = cache._get_conn()
+            conn = cache.get_conn()
             rows = conn.execute(
                 "SELECT s.file_path, s.line, a.mod_count_30d, a.last_modified_at "
                 "FROM ast_symbol_activation a "

--- a/tree_sitter_analyzer/mcp/tools/codegraph_sitemap_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_sitemap_tool.py
@@ -161,7 +161,7 @@ class CodeGraphSitemapTool(BaseMCPTool):
         directory: str | None,
         max_files: int,
     ) -> list[dict[str, Any]]:
-        conn = cache._get_conn()
+        conn = cache.get_conn()
         if language and directory:
             like_dir = directory.rstrip("/") + "/%"
             rows = conn.execute(

--- a/tree_sitter_analyzer/mcp/tools/symbol_resolve_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/symbol_resolve_tool.py
@@ -107,7 +107,7 @@ class CodeGraphSymbolResolveTool(BaseMCPTool):
         output_format = arguments.get("output_format", "toon")
 
         cache = self._get_cache()
-        conn = cache._get_conn()
+        conn = cache.get_conn()
         row_count = conn.execute("SELECT COUNT(*) FROM ast_index").fetchone()[0]
         if row_count == 0:
             return apply_toon_format_to_response(

--- a/tree_sitter_analyzer/mcp/tools/symbol_search_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/symbol_search_tool.py
@@ -193,7 +193,7 @@ class CodeGraphSymbolSearchTool(BaseMCPTool):
             if terms:
                 fts_query = " OR ".join(f'"{t}"' for t in terms)
 
-                conn = cache._get_conn()
+                conn = cache.get_conn()
                 if language:
                     rows = conn.execute(
                         """SELECT r.name, r.kind, r.file_path, r.language, r.line, r.end_line
@@ -241,7 +241,7 @@ class CodeGraphSymbolSearchTool(BaseMCPTool):
     ) -> list[dict[str, Any]]:
         import json
 
-        conn = cache._get_conn()
+        conn = cache.get_conn()
         pattern_lower = pattern.lower()
 
         if language:

--- a/tree_sitter_analyzer/mcp/tools/utils/change_impact_analysis.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/change_impact_analysis.py
@@ -401,7 +401,7 @@ def _enrich_with_cache_symbols(
     """
     if cache is None:
         return []
-    conn = cache._get_conn()
+    conn = cache.get_conn()
     enriched: list[dict[str, Any]] = []
     for rel in changed_files:
         try:
@@ -451,7 +451,7 @@ def _find_affected_symbols(
     """
     if cache is None or not affected_files:
         return []
-    conn = cache._get_conn()
+    conn = cache.get_conn()
     results: list[dict[str, Any]] = []
     for rel in sorted(affected_files):
         try:

--- a/tree_sitter_analyzer/mcp/tools/utils/change_impact_cached_graph.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/change_impact_cached_graph.py
@@ -96,7 +96,7 @@ def load_cached_dependency_graph(
 
 
 def _cached_index_rows(cache: ASTCache) -> list[dict[str, Any]]:
-    conn = cache._get_conn()
+    conn = cache.get_conn()
     try:
         rows = conn.execute(
             "SELECT file_path, language, imports_json FROM ast_index"

--- a/tree_sitter_analyzer/semantic_search.py
+++ b/tree_sitter_analyzer/semantic_search.py
@@ -44,7 +44,7 @@ class SemanticSymbolSearch:
         return [item for _score, item in scored[:limit]]
 
     def _symbols(self) -> list[dict[str, Any]]:
-        conn = self.cache._get_conn()
+        conn = self.cache.get_conn()
         try:
             rows = conn.execute(
                 """SELECT name, kind, file_path, language, line, end_line

--- a/tree_sitter_analyzer/symbol_resolver.py
+++ b/tree_sitter_analyzer/symbol_resolver.py
@@ -107,7 +107,7 @@ def _build_import_map(cache: Any) -> dict[str, list[Any]]:
 
     Caller code branches on `isinstance(imp, str)` to handle both shapes.
     """
-    conn = cache._get_conn()
+    conn = cache.get_conn()
     rows = conn.execute(
         "SELECT file_path, imports_json, language FROM ast_index"
     ).fetchall()
@@ -120,7 +120,7 @@ def _build_import_map(cache: Any) -> dict[str, list[Any]]:
 
 
 def _build_module_to_file_map(cache: Any) -> dict[str, str]:
-    conn = cache._get_conn()
+    conn = cache.get_conn()
     rows = conn.execute("SELECT file_path, language FROM ast_index").fetchall()
     module_map: dict[str, str] = {}
     for row in rows:
@@ -225,7 +225,7 @@ class SymbolResolver:
         return filtered if filtered else candidates
 
     def _is_child_of(self, location: DefinitionLocation, parent_name: str) -> bool:
-        conn = self._cache._get_conn()
+        conn = self._cache.get_conn()
         row = conn.execute(
             "SELECT symbols_json FROM ast_index WHERE file_path = ?",
             (location.file,),
@@ -299,7 +299,7 @@ class SymbolResolver:
         return []
 
     def _find_defs_in_file(self, file_path: str, name: str) -> list[DefinitionLocation]:
-        conn = self._cache._get_conn()
+        conn = self._cache.get_conn()
         rows = conn.execute(
             """SELECT name, kind, file_path, language, line, end_line
                FROM ast_symbol_rows
@@ -344,7 +344,7 @@ class SymbolResolver:
     def _find_references(self, symbol: str, short_name: str) -> list[ReferenceLocation]:
         references: list[ReferenceLocation] = []
         seen: set[tuple[str, int]] = set()
-        conn = self._cache._get_conn()
+        conn = self._cache.get_conn()
         try:
             rows = conn.execute(
                 """SELECT callee_name, callee_full, caller_name, caller_file,

--- a/tree_sitter_analyzer/synapse_resolver/_context.py
+++ b/tree_sitter_analyzer/synapse_resolver/_context.py
@@ -309,7 +309,7 @@ def _build_file_class_methods(
 def _build_file_class_methods_from_cache(
     cache: ASTCache,
 ) -> dict[str, dict[str, dict[str, int]]]:
-    conn = cache._get_conn()
+    conn = cache.get_conn()
     line_idx: dict[tuple[str, str, int], int] = {}
     try:
         rows = conn.execute(
@@ -392,7 +392,7 @@ def build_resolver_context(cache: ASTCache) -> ResolverContext:
 
 def _build_resolver_context_uncached(cache: ASTCache) -> ResolverContext:
     """One DB pass; populates every map the resolver needs."""
-    conn = cache._get_conn()
+    conn = cache.get_conn()
 
     file_symbols: dict[str, list[tuple[str, str, int]]] = {}
     global_name_table: dict[str, list[tuple[str, int]]] = {}

--- a/tree_sitter_analyzer/xref.py
+++ b/tree_sitter_analyzer/xref.py
@@ -91,7 +91,7 @@ class XRefEngine:
         include_imports: bool = True,
         include_file_deps: bool = True,
     ) -> XRefResult:
-        conn = self._cache._get_conn()
+        conn = self._cache.get_conn()
 
         definitions = self._find_definitions(conn, symbol, file_path)
         primary_file = file_path
@@ -126,7 +126,7 @@ class XRefEngine:
         )
 
     def file_xref(self, file_path: str) -> dict[str, Any]:
-        conn = self._cache._get_conn()
+        conn = self._cache.get_conn()
 
         symbols = self._file_symbols(conn, file_path)
         callers = self._file_callers(conn, file_path)


### PR DESCRIPTION
## Summary

- Adds `ASTCache.get_conn()` as the canonical public method for raw SQL access
- Keeps `ASTCache._get_conn()` as a backward-compat shim that delegates to `get_conn()`
- Migrates all 31 external call sites across 17 production files from `._get_conn()` → `.get_conn()`
- Fixes 2 test mocks (`test_xref.py`, `test_symbol_resolver.py`) that relied on the private method
- Ships 3 TDD tests in `TestASTCacheGetConnPublicAccessor` (returns Connection, same-as-private, thread-local stable)

## Motivation

`_get_conn()` was a private implementation detail accessed by 17 production files — a SPEC/TDD architecture debt. The naming violated the contract that underscore-prefixed methods are internal to the class. This change makes the public contract explicit.

## Test plan

- [x] 249 tests pass locally (`pytest tests/unit/test_ast_cache.py tests/unit/test_xref.py tests/unit/test_symbol_resolver.py ...`)
- [x] Pre-commit hooks clean (ruff, mypy, bandit, tsa-codemap-sync)
- [ ] CI green on this PR
- [x] OpenSpec `expose-ast-cache-get-conn` tracks this change