### PR TITLE
docs(rules): backport Release Gate Rules to main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,3 +302,19 @@ cd ~/.claude/skills/gstack && ./setup --team
 
 Skills like /qa, /ship, /review, /investigate, and /browse become available after install.
 Use /browse for all web browsing. Use ~/.claude/skills/gstack/... for gstack file paths.
+
+## Release Gate Rules
+
+**NEVER merge release branch → main until ALL of these are confirmed:**
+
+1. **All CI axes green** — every platform (ubuntu/macos/windows) × every Python version must pass. Check with `gh run list --branch release/vX.Y.Z`.
+2. **PyPI published** — `Deploy to PyPI` job in Release Branch Automation shows ✓.
+3. **Release Automation completes** — the full `Release Branch Automation` workflow must reach the `Finalize Release` step. If that step fails (e.g. Actions permission error), fix the root cause or create the PR manually — but still wait for PyPI deploy to finish first.
+4. **README numbers verified against actuals** — CLI flag count, MCP tool count, and test count must be re-measured from the release CI logs, not assumed.
+
+**Merge order:**
+```
+feature/* → develop → release/vX.Y.Z → main (only after all gates above)
+```
+
+**Past incident (2026-05-31):** merged release/v1.17.0 → main immediately after the Release Automation `Finalize Release` step failed — before confirming PyPI had published and before README numbers were verified. The correct order is: wait for PyPI ✓, fix README, then merge.


### PR DESCRIPTION
## Why

`Release Gate Rules` were added to `CLAUDE.md` on `develop` (commit `8bc54f9c`) after we had already merged `release/v1.17.0` → `main`. As a result, `main` is missing this governance rule.

This PR backports the rule so it's visible on the stable branch where all contributors read `CLAUDE.md`.

## What changed (CLAUDE.md only)

Added `## Release Gate Rules` section:
- 4-gate checklist before merging any release branch → main
- Explicit merge order: `feature/* → develop → release/vX.Y.Z → main`
- Past incident documented (2026-05-31, premature v1.17.0 merge)

## No code changes

Docs only — no tests, no version bump needed.