### PR TITLE
feat(mcp): add initialize routing instructions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling>=1.27,<1.30"]
 build-backend = "hatchling.build"
 
 [project]

--- a/tests/e2e/test_mcp_smoke.py
+++ b/tests/e2e/test_mcp_smoke.py
@@ -58,6 +58,19 @@ class TestStartup:
             "'-32601 Method not found' error on every connect."
         )
 
+    def test_initialize_includes_agent_routing_instructions(
+        self, mcp_server: MCPClient
+    ) -> None:
+        """The initialize response should steer agents before any tool call."""
+        response = mcp_server.initialize()
+        assert "error" not in response
+        instructions = response["result"].get("instructions")
+        assert instructions
+        assert "TSA MCP Routing" in instructions
+        assert "codegraph_symbol_search" in instructions
+        assert "codegraph_navigate" in instructions
+        assert "codegraph_context" not in instructions
+
     def test_tools_list_returns_expected_minimum(self, mcp_server: MCPClient) -> None:
         """All of TSA's primary tools must be discoverable.
 

--- a/tests/unit/mcp/test_server_helpers.py
+++ b/tests/unit/mcp/test_server_helpers.py
@@ -1,0 +1,24 @@
+"""Tests for MCP server startup helper wiring."""
+
+from __future__ import annotations
+
+
+class _RecordingInitializationOptions:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+def test_build_initialization_options_includes_agent_routing_instructions():
+    from tree_sitter_analyzer.mcp._server_helpers import build_initialization_options
+
+    options = build_initialization_options(
+        "tree-sitter-analyzer",
+        "1.2.3",
+        _RecordingInitializationOptions,
+    )
+
+    instructions = options.kwargs["instructions"]
+    assert "TSA MCP Routing" in instructions
+    assert "codegraph_symbol_search" in instructions
+    assert "codegraph_navigate" in instructions
+    assert "codegraph_context" not in instructions

--- a/tree_sitter_analyzer/mcp/_server_helpers.py
+++ b/tree_sitter_analyzer/mcp/_server_helpers.py
@@ -40,7 +40,43 @@ def build_initialization_options(
         server_name=server_name,
         server_version=server_version,
         capabilities=capabilities,
+        instructions=_SERVER_INSTRUCTIONS,
     )
+
+
+_SERVER_INSTRUCTIONS = """
+## TSA MCP Routing
+
+Use the codegraph tools first for code-intelligence questions. They are built
+for indexed, cross-file answers and are usually cheaper than grep/read loops.
+
+## Intent -> first tool
+
+| Intent | Tool |
+| --- | --- |
+| Find a symbol, class, function, or method | codegraph_symbol_search |
+| Inspect a symbol with definition and references | codegraph_navigate |
+| Understand several related symbols at once | codegraph_explore |
+| Who calls X? | codegraph_callers |
+| What does X call? | codegraph_callees |
+| Trace a path from A to B | codegraph_call_graph |
+| File/module dependency questions | codegraph_import_graph |
+| Is the index ready? | codegraph_status |
+| File discovery | list_files |
+| Text search fallback after graph lookup misses | search_content |
+
+## Default chains
+
+- Understand an area: codegraph_symbol_search -> codegraph_navigate or codegraph_explore.
+- Trace impact: codegraph_callers -> codegraph_import_graph -> synthesize.
+- Unknown name: codegraph_symbol_search with a fuzzy query once, then stop.
+
+## Stop rules
+
+- Prefer 2-3 tool calls, then answer.
+- Do not keep drilling after 4 tool calls for one question.
+- Do not use grep/read loops when a codegraph tool covers the question.
+""".strip()
 
 
 def attach_tool_aliases(target: Any, tools: Mapping[str, Any]) -> None:


### PR DESCRIPTION
## Summary\n- add server-level MCP initialize instructions so agents receive a routing table before any tool call\n- keep the routing table limited to tools that already exist on develop\n- add unit and E2E smoke coverage for the instructions field\n\n## Verification\n- uv run --frozen --python 3.11 pytest tests/unit/mcp/test_server_helpers.py tests/e2e/test_mcp_smoke.py::TestStartup::test_initialize_includes_agent_routing_instructions -q --cov=tree_sitter_analyzer --cov-report=json\n- uv run --frozen --python 3.11 python scripts/check_patch_coverage.py --base origin/develop --coverage-json coverage.json\n- uv run --frozen --python 3.11 pytest tests/e2e/test_mcp_smoke.py tests/integration/mcp/test_server.py tests/unit/mcp/test_mcp_server.py tests/unit/mcp/test_mcp_server_initialization.py tests/unit/mcp/test_server.py tests/unit/mcp/test_server_comprehensive.py tests/unit/mcp/test_server_comprehensive_init.py tests/unit/mcp/test_server_comprehensive_tools.py tests/unit/mcp/test_server_edge_cases.py tests/unit/mcp/test_server_helpers.py tests/unit/mcp/test_server_missing_branches.py tests/unit/mcp/test_server_utils_registration.py -q\n- git diff --check\n\nRefs #229\n\n## Follow-up\nThe broader local feat/mcp-headless-fix-codegraph-context branch also contains codegraph_context, core-tier filtering, and MCP startup lazy-loading. Those are intentionally split out because the branch is large and needs separate coverage/benchmark validation.