### PR TITLE
Speed up MCP headless startup

### DIFF
--- a/tests/e2e/test_mcp_smoke.py
+++ b/tests/e2e/test_mcp_smoke.py
@@ -71,6 +71,32 @@ class TestStartup:
         assert "codegraph_symbol_search" in instructions
         assert "codegraph_navigate" in instructions
 
+    def test_repeated_headless_initialize_stays_under_budget(
+        self, mcp_server_factory: Any
+    ) -> None:
+        """Repeated stdio spawn→initialize should not leave clients pending."""
+        import time
+
+        elapsed_samples: list[float] = []
+        for _ in range(5):
+            client = mcp_server_factory(REPO_ROOT)
+            started = time.monotonic()
+            response = client.initialize(timeout=10.0 * _CI_FACTOR)
+            elapsed = time.monotonic() - started
+            client.terminate()
+            assert "error" not in response, (
+                f"initialize returned an error: {response.get('error')!r}\n"
+                f"stderr:\n{client.stderr_text()}"
+            )
+            elapsed_samples.append(elapsed)
+
+        budget_sec = 2.0 * _CI_FACTOR
+        assert max(elapsed_samples) < budget_sec, (
+            "MCP spawn→initialize exceeded the headless startup budget: "
+            f"{[round(sample, 3) for sample in elapsed_samples]} "
+            f"(budget {budget_sec:.1f}s)"
+        )
+
     def test_tools_list_returns_expected_minimum(self, mcp_server: MCPClient) -> None:
         """All of TSA's primary tools must be discoverable.
 

--- a/tests/unit/test_package_lazy_exports.py
+++ b/tests/unit/test_package_lazy_exports.py
@@ -1,0 +1,49 @@
+"""Top-level package lazy-export contracts."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_top_level_import_does_not_preload_heavy_analysis_modules() -> None:
+    script = (
+        "import sys, tree_sitter_analyzer; "
+        "print('tree_sitter_analyzer.core.analysis_engine' in sys.modules); "
+        "print('tree_sitter_analyzer.output_manager' in sys.modules)"
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=5,
+        check=True,
+    )
+
+    assert result.stdout.splitlines() == ["False", "False"]
+
+
+def test_lazy_export_resolves_and_caches_public_name() -> None:
+    import tree_sitter_analyzer as tsa
+
+    tsa.__dict__.pop("Function", None)
+
+    function_cls = tsa.Function
+
+    assert function_cls.__name__ == "Function"
+    assert tsa.__dict__["Function"] is function_cls
+
+
+def test_lazy_export_unknown_name_raises_attribute_error() -> None:
+    import tree_sitter_analyzer as tsa
+
+    missing = "DefinitelyMissing"
+    with pytest.raises(AttributeError, match="DefinitelyMissing"):
+        getattr(tsa, missing)

--- a/tree_sitter_analyzer/__init__.py
+++ b/tree_sitter_analyzer/__init__.py
@@ -15,66 +15,69 @@ __version__ = "1.17.4"
 __author__ = "aisheng.yu"
 __email__ = "aimasteracc@gmail.com"
 
-# Legacy imports for backward compatibility
+import importlib as _importlib
+from typing import Any as _Any
 
-from .core.analysis_engine import (
-    UnifiedAnalysisEngine as UniversalCodeAnalyzer,  # deprecated: use AnalysisEngine from .core
-)
-from .encoding_utils import (
-    EncodingManager,
-    detect_encoding,
-    extract_text_slice,
-    read_file_safe,
-    safe_decode,
-    safe_encode,
-    write_file_safe,
-)
+# Legacy public names remain import-compatible, but loading them eagerly makes
+# the MCP stdio server pay for analysis_engine/models/output_manager before the
+# client even receives initialize. PEP 562 keeps import tree_sitter_analyzer
+# cheap while preserving from tree_sitter_analyzer import Function.
+_LAZY_EXPORTS: dict[str, tuple[str, str]] = {
+    "UniversalCodeAnalyzer": (
+        "tree_sitter_analyzer.core.analysis_engine",
+        "UnifiedAnalysisEngine",
+    ),
+    "EncodingManager": ("tree_sitter_analyzer.encoding_utils", "EncodingManager"),
+    "detect_encoding": ("tree_sitter_analyzer.encoding_utils", "detect_encoding"),
+    "extract_text_slice": ("tree_sitter_analyzer.encoding_utils", "extract_text_slice"),
+    "read_file_safe": ("tree_sitter_analyzer.encoding_utils", "read_file_safe"),
+    "safe_decode": ("tree_sitter_analyzer.encoding_utils", "safe_decode"),
+    "safe_encode": ("tree_sitter_analyzer.encoding_utils", "safe_encode"),
+    "write_file_safe": ("tree_sitter_analyzer.encoding_utils", "write_file_safe"),
+    "LanguageDetector": ("tree_sitter_analyzer.language_detector", "LanguageDetector"),
+    "get_loader": ("tree_sitter_analyzer.language_loader", "get_loader"),
+    "AnalysisResult": ("tree_sitter_analyzer.models", "AnalysisResult"),
+    "Class": ("tree_sitter_analyzer.models", "Class"),
+    "CodeElement": ("tree_sitter_analyzer.models", "CodeElement"),
+    "Function": ("tree_sitter_analyzer.models", "Function"),
+    "Import": ("tree_sitter_analyzer.models", "Import"),
+    "JavaAnnotation": ("tree_sitter_analyzer.models", "JavaAnnotation"),
+    "JavaClass": ("tree_sitter_analyzer.models", "JavaClass"),
+    "JavaField": ("tree_sitter_analyzer.models", "JavaField"),
+    "JavaImport": ("tree_sitter_analyzer.models", "JavaImport"),
+    "JavaMethod": ("tree_sitter_analyzer.models", "JavaMethod"),
+    "JavaPackage": ("tree_sitter_analyzer.models", "JavaPackage"),
+    "Variable": ("tree_sitter_analyzer.models", "Variable"),
+    "OutputManager": ("tree_sitter_analyzer.output_manager", "OutputManager"),
+    "get_output_manager": ("tree_sitter_analyzer.output_manager", "get_output_manager"),
+    "output_data": ("tree_sitter_analyzer.output_manager", "output_data"),
+    "output_error": ("tree_sitter_analyzer.output_manager", "output_error"),
+    "output_info": ("tree_sitter_analyzer.output_manager", "output_info"),
+    "output_warning": ("tree_sitter_analyzer.output_manager", "output_warning"),
+    "set_output_mode": ("tree_sitter_analyzer.output_manager", "set_output_mode"),
+    "ElementExtractor": ("tree_sitter_analyzer.plugins", "ElementExtractor"),
+    "LanguagePlugin": ("tree_sitter_analyzer.plugins", "LanguagePlugin"),
+    "PluginManager": ("tree_sitter_analyzer.plugins.manager", "PluginManager"),
+    "QueryLoader": ("tree_sitter_analyzer.query_loader", "QueryLoader"),
+    "get_query_loader": ("tree_sitter_analyzer.query_loader", "get_query_loader"),
+    "QuietMode": ("tree_sitter_analyzer.utils", "QuietMode"),
+    "log_debug": ("tree_sitter_analyzer.utils", "log_debug"),
+    "log_error": ("tree_sitter_analyzer.utils", "log_error"),
+    "log_info": ("tree_sitter_analyzer.utils", "log_info"),
+    "log_performance": ("tree_sitter_analyzer.utils", "log_performance"),
+    "log_warning": ("tree_sitter_analyzer.utils", "log_warning"),
+    "safe_print": ("tree_sitter_analyzer.utils", "safe_print"),
+}
 
-# from .java_advanced_analyzer import AdvancedAnalyzer  # Removed - migrated to plugin system
-from .language_detector import LanguageDetector
-from .language_loader import get_loader
 
-# Data Models (Java-specific for backward compatibility)
-# Data Models (Generic)
-from .models import (
-    AnalysisResult,
-    Class,
-    CodeElement,
-    Function,
-    Import,
-    JavaAnnotation,
-    JavaClass,
-    JavaField,
-    JavaImport,
-    JavaMethod,
-    JavaPackage,
-    Variable,
-)
-from .output_manager import (
-    OutputManager,
-    get_output_manager,
-    output_data,
-    output_error,
-    output_info,
-    output_warning,
-    set_output_mode,
-)
+def __getattr__(name: str) -> _Any:
+    if name not in _LAZY_EXPORTS:
+        raise AttributeError(f"module 'tree_sitter_analyzer' has no attribute {name!r}")
+    module_path, attr_name = _LAZY_EXPORTS[name]
+    value = getattr(_importlib.import_module(module_path), attr_name)
+    globals()[name] = value
+    return value
 
-# Plugin System
-from .plugins import ElementExtractor, LanguagePlugin
-from .plugins.manager import PluginManager
-from .query_loader import QueryLoader, get_query_loader
-
-# Import new utility modules
-from .utils import (
-    QuietMode,
-    log_debug,
-    log_error,
-    log_info,
-    log_performance,
-    log_warning,
-    safe_print,
-)
 
 __all__ = [
     # Core Models (optimized)


### PR DESCRIPTION
## Summary
- replace eager top-level package compatibility imports with PEP 562 lazy exports
- add unit coverage for lazy public exports and import-time module loading
- add an E2E regression that repeatedly spawns the MCP stdio server and initializes it without pending clients

## Measurements
- before: initialize p50 ~245ms, p95 ~285ms, max ~1030ms on 20 real stdio runs
- after: initialize p50 ~215ms, p95 ~228ms, max ~228ms on 20 real stdio runs
- after: tools/list p50 ~33ms, p95 ~36ms, max ~36ms, 64 tools

## Validation
- `uv run pytest tests/e2e/test_mcp_smoke.py tests/unit/test_package_lazy_exports.py -q`
- `uv sync --frozen --extra full`
- `uv run pytest -q` -> 17454 passed, 92 skipped
- `uv run pytest tests/unit/test_package_lazy_exports.py tests/e2e/test_mcp_smoke.py::TestStartup::test_repeated_headless_initialize_stays_under_budget --cov=tree_sitter_analyzer --cov-report=json -q -n 0`
- `uv run python scripts/check_patch_coverage.py --base origin/develop --coverage-json coverage.json`
- `git diff --check`

Refs #229