### PR TITLE
fix(release): fail closed finalize PR reuse

### DIFF
--- a/.github/workflows/hotfix-automation.yml
+++ b/.github/workflows/hotfix-automation.yml
@@ -53,6 +53,27 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          existing_pr=$(
+            gh pr list \
+              --base main \
+              --head "${GITHUB_REF_NAME}" \
+              --state all \
+              --json number,state,url,mergedAt \
+              --jq '. as $prs | if length == 0 then empty else (sort_by(.number) | reverse | .[0] | [.number, .state, .url, (.mergedAt // "")] | @tsv) end'
+          )
+          if [ -n "${existing_pr}" ]; then
+            IFS=$'\t' read -r pr_number pr_state pr_url pr_merged_at <<< "${existing_pr}"
+            if [ "${pr_state}" = "OPEN" ]; then
+              echo "Hotfix PR already open: ${pr_url}"
+              exit 0
+            fi
+            if [ "${pr_state}" = "MERGED" ] || [ -n "${pr_merged_at}" ]; then
+              echo "Hotfix PR already merged: ${pr_url}"
+              exit 0
+            fi
+            echo "::error::Existing hotfix PR #${pr_number} for ${GITHUB_REF_NAME} -> main is closed without merge: ${pr_url}. Reopen or use a new hotfix version; refusing to treat finalization as successful."
+            exit 1
+          fi
           gh pr create \
             --base main \
             --head "${GITHUB_REF_NAME}" \
@@ -66,5 +87,4 @@ jobs:
           - **Action Required**: Merge immediately to main.
 
           ---
-          *Authoritative CI/CD Pipeline*" \
-            || gh pr view "${GITHUB_REF_NAME}" --json url --jq '.url'
+          *Authoritative CI/CD Pipeline*"

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -58,6 +58,27 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          existing_pr=$(
+            gh pr list \
+              --base main \
+              --head "${GITHUB_REF_NAME}" \
+              --state all \
+              --json number,state,url,mergedAt \
+              --jq '. as $prs | if length == 0 then empty else (sort_by(.number) | reverse | .[0] | [.number, .state, .url, (.mergedAt // "")] | @tsv) end'
+          )
+          if [ -n "${existing_pr}" ]; then
+            IFS=$'\t' read -r pr_number pr_state pr_url pr_merged_at <<< "${existing_pr}"
+            if [ "${pr_state}" = "OPEN" ]; then
+              echo "Release PR already open: ${pr_url}"
+              exit 0
+            fi
+            if [ "${pr_state}" = "MERGED" ] || [ -n "${pr_merged_at}" ]; then
+              echo "Release PR already merged: ${pr_url}"
+              exit 0
+            fi
+            echo "::error::Existing release PR #${pr_number} for ${GITHUB_REF_NAME} -> main is closed without merge: ${pr_url}. Reopen or use a new release version; refusing to treat finalization as successful."
+            exit 1
+          fi
           gh pr create \
             --base main \
             --head "${GITHUB_REF_NAME}" \
@@ -76,5 +97,4 @@ jobs:
           - **Deployment**: Completed
 
           ---
-          *Authoritative CI/CD Pipeline*" \
-            || gh pr view "${GITHUB_REF_NAME}" --json url --jq '.url'
+          *Authoritative CI/CD Pipeline*"

--- a/tests/unit/test_agent_contracts.py
+++ b/tests/unit/test_agent_contracts.py
@@ -394,6 +394,35 @@ def test_release_and_hotfix_prs_use_gitflow_branch_heads() -> None:
     assert "hotfix-to-main" not in hotfix_text
 
 
+def test_release_and_hotfix_finalize_prs_do_not_mask_closed_prs() -> None:
+    """A closed, unmerged finalize PR means the release/hotfix is not landed."""
+    workflows = {
+        "release-automation.yml": PROJECT_ROOT
+        / ".github"
+        / "workflows"
+        / "release-automation.yml",
+        "hotfix-automation.yml": PROJECT_ROOT
+        / ".github"
+        / "workflows"
+        / "hotfix-automation.yml",
+    }
+
+    for workflow_name, workflow_path in workflows.items():
+        text = workflow_path.read_text(encoding="utf-8")
+        create_pr = re.search(
+            r"(?ms)^      - name: Create Pull Request to main\n(?P<body>.*?)(?=^      - name:|\Z)",
+            text,
+        )
+
+        assert create_pr is not None, workflow_name
+        body = create_pr.group("body")
+        assert "--state all" in body, workflow_name
+        assert "closed without merge" in body, workflow_name
+        assert "refusing to treat finalization as successful" in body, workflow_name
+        assert "exit 1" in body, workflow_name
+        assert "|| gh pr view" not in body, workflow_name
+
+
 def test_agent_facing_docs_do_not_recommend_bare_pytest() -> None:
     """Agent docs should route pytest through uv for consistent environments."""
     bare_pytest_command = re.compile(r"^(?:\$\s+)?pytest(?:\s|$)")


### PR DESCRIPTION
## Summary
- Make release/hotfix finalization inspect existing same-head PR state before creating a main PR.
- Treat open/merged PRs as idempotent, but fail closed unmerged PRs instead of masking them with `gh pr view`.
- Add an agent contract test so this failure mode stays guarded.

## Root Cause
The workflow used `gh pr create ... || gh pr view ...`, so a previously closed unmerged release PR could make the workflow finish green even though the release was not landed on `main`. PR #228 / `v1.17.4` exposed this.

## Validation
- `uv run pytest tests/unit/test_agent_contracts.py -q`
- `uv run pre-commit run actionlint --files .github/workflows/release-automation.yml .github/workflows/hotfix-automation.yml`
- `git diff --check`
- Live probe against PR #228 returns `CLOSED` with empty `mergedAt` and the new shell guard exits 1.
- `uv run pytest -q` -> 17455 passed, 92 skipped
