### PR TITLE
Merge release v1.18.0 back to develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## [1.18.0] - 2026-06-01
+
+GitFlow-compliant production release for the post-v1.17 development line.
+This supersedes the unlanded v1.17.4 production attempt: v1.17.4 reached PyPI,
+but PR #228 was closed without merging to `main`. v1.18.0 carries the work
+forward with a guarded release finalization workflow.
+
+### Added
+
+- **`codegraph_context` MCP/CLI workflow** (`#234`). Agents now have a primary
+  one-call architecture context path for natural-language tasks, including entry
+  points, source blocks, and graph relationships.
+- **MCP initialize routing instructions** (`#231`). The server now gives clients
+  clearer startup/tool-routing guidance during initialization.
+
+### Improved
+
+- **Headless MCP startup latency** (`#235`). Top-level package exports are now
+  lazy, avoiding analysis-engine imports during stdio server startup while
+  preserving legacy import compatibility.
+- **Dependabot now targets `develop`** (`#236`). The pip and GitHub Actions
+  update streams follow the project GitFlow matrix instead of opening bot PRs
+  directly to `main`.
+
+### Fixed
+
+- **Release/hotfix finalization no longer masks closed PRs** (`#237`). The
+  automation now treats an existing open or merged finalization PR as
+  idempotent, but fails on closed-unmerged PRs instead of falling through to
+  `gh pr view` and reporting a false green release.
+- **Release version metadata synchronized**. Package version,
+  `tree_sitter_analyzer.__version__`, and `[tool.mcp].server_version` are all
+  aligned for this release and guarded by an agent contract test.
+
+### Validation
+
+- Local full suite: `17456 passed, 92 skipped` (51.54 s on macOS).
+- Release-finalization fix PR #237 CI passed: GitFlow Guard, PR fast matrix,
+  MCP black-box E2E, SQL platform compatibility, regression tests, build,
+  quality gate, and Codecov patch.
+
+---
+
 ## [1.16.0] - 2026-05-30
 
 BM25 ranked search, C# language support, and code-intelligence architecture

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![PyPI](https://img.shields.io/pypi/v/tree-sitter-analyzer.svg)](https://pypi.org/project/tree-sitter-analyzer/)
 [![Python Version](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://python.org)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-17361%20passed-brightgreen.svg)](#-quality--testing)
+[![Tests](https://img.shields.io/badge/tests-17456%20passed-brightgreen.svg)](#-quality--testing)
 [![Coverage](https://codecov.io/gh/aimasteracc/tree-sitter-analyzer/branch/main/graph/badge.svg)](https://codecov.io/gh/aimasteracc/tree-sitter-analyzer)
 [![GitHub Stars](https://img.shields.io/github/stars/aimasteracc/tree-sitter-analyzer.svg?style=social)](https://github.com/aimasteracc/tree-sitter-analyzer)
 
@@ -282,7 +282,7 @@ Mostly nothing. The defaults are designed so you can hook it into your agent and
 
 | Metric | Value |
 |---|---|
-| Tests passed | 18,702 ✅ |
+| Tests passed | 17,456 ✅ |
 | Coverage | [![Coverage](https://codecov.io/gh/aimasteracc/tree-sitter-analyzer/branch/main/graph/badge.svg)](https://codecov.io/gh/aimasteracc/tree-sitter-analyzer) |
 | Type safety | 100 % mypy |
 | Platforms | macOS · Linux · Windows |

--- a/README_ja.md
+++ b/README_ja.md
@@ -9,7 +9,7 @@
 [![PyPI](https://img.shields.io/pypi/v/tree-sitter-analyzer.svg)](https://pypi.org/project/tree-sitter-analyzer/)
 [![Python Version](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://python.org)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-17361%20passed-brightgreen.svg)](#-品質とテスト)
+[![Tests](https://img.shields.io/badge/tests-17456%20passed-brightgreen.svg)](#-品質とテスト)
 [![Coverage](https://codecov.io/gh/aimasteracc/tree-sitter-analyzer/branch/main/graph/badge.svg)](https://codecov.io/gh/aimasteracc/tree-sitter-analyzer)
 [![GitHub Stars](https://img.shields.io/github/stars/aimasteracc/tree-sitter-analyzer.svg?style=social)](https://github.com/aimasteracc/tree-sitter-analyzer)
 
@@ -280,7 +280,7 @@ CodeGraph も類似の集合をサポート; 両ツール共に未実装の主�
 
 | 指標 | 値 |
 |---|---|
-| テスト通過 | 18,702 ✅ |
+| テスト通過 | 17,456 ✅ |
 | カバレッジ | [![Coverage](https://codecov.io/gh/aimasteracc/tree-sitter-analyzer/branch/main/graph/badge.svg)](https://codecov.io/gh/aimasteracc/tree-sitter-analyzer) |
 | 型安全性 | 100% mypy |
 | プラットフォーム | macOS · Linux · Windows |

--- a/README_zh.md
+++ b/README_zh.md
@@ -10,7 +10,7 @@
 [![PyPI](https://img.shields.io/pypi/v/tree-sitter-analyzer.svg)](https://pypi.org/project/tree-sitter-analyzer/)
 [![Python Version](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://python.org)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-17361%20passed-brightgreen.svg)](#-质量与测试)
+[![Tests](https://img.shields.io/badge/tests-17456%20passed-brightgreen.svg)](#-质量与测试)
 [![Coverage](https://codecov.io/gh/aimasteracc/tree-sitter-analyzer/branch/main/graph/badge.svg)](https://codecov.io/gh/aimasteracc/tree-sitter-analyzer)
 [![GitHub Stars](https://img.shields.io/github/stars/aimasteracc/tree-sitter-analyzer.svg?style=social)](https://github.com/aimasteracc/tree-sitter-analyzer)
 
@@ -281,7 +281,7 @@ CodeGraph 支持相近的集合；两者都还未发布的主流代码语言只�
 
 | 指标 | 值 |
 |---|---|
-| 测试通过 | 18,702 ✅ |
+| 测试通过 | 17,456 ✅ |
 | 覆盖率 | [![Coverage](https://codecov.io/gh/aimasteracc/tree-sitter-analyzer/branch/main/graph/badge.svg)](https://codecov.io/gh/aimasteracc/tree-sitter-analyzer) |
 | 类型安全 | 100% mypy |
 | 平台 | macOS · Linux · Windows |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tree-sitter-analyzer"
-version = "1.17.4"
-description = "MCP code-intelligence server for AI agents — beats CodeGraph on 6-repo head-to-head benchmark median. 62 MCP tools, 13 curated skills, TOON output, 100% local."
+version = "1.18.0"
+description = "MCP code-intelligence server for AI agents — beats CodeGraph on 6-repo head-to-head benchmark median. 63 MCP tools, 13 curated skills, TOON output, 100% local."
 readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "MIT"}
@@ -620,7 +620,7 @@ directory = "htmlcov"
 # MCP server configuration
 [tool.mcp]
 server_name = "tree-sitter-analyzer"
-server_version = "1.16.0"
+server_version = "1.18.0"
 description = "AI-era enterprise-grade code analysis MCP server with comprehensive HTML/CSS support and multi-language capabilities"
 capabilities = [
     "check_code_scale",

--- a/scripts/sync_version.py
+++ b/scripts/sync_version.py
@@ -17,6 +17,10 @@ class VersionSynchronizer:
         self.version_patterns = {
             "pyproject.toml": [
                 (r'version = "(\d+\.\d+\.\d+)"', 'version = "{version}"'),
+                (
+                    r'server_version = "(\d+\.\d+\.\d+)"',
+                    'server_version = "{version}"',
+                ),
             ],
             "README.md": [
                 (r"version-(\d+\.\d+\.\d+)-blue\.svg", "version-{version}-blue.svg"),
@@ -119,16 +123,18 @@ class VersionSynchronizer:
         inconsistent_files = []
 
         for file_name, patterns in self.version_patterns.items():
-            if file_name == "pyproject.toml":  # Skip the reference file
-                continue
-
             file_path = self.project_root / file_name
             if not file_path.exists():
                 continue
 
             content = file_path.read_text(encoding="utf-8")
+            patterns_to_check = (
+                patterns[1:] if file_name == "pyproject.toml" else patterns
+            )
+            if not patterns_to_check:
+                continue
 
-            for pattern, _ in patterns:
+            for pattern, _ in patterns_to_check:
                 matches = re.findall(pattern, content)
                 for match in matches:
                     found_version = (

--- a/scripts/sync_version_minimal.py
+++ b/scripts/sync_version_minimal.py
@@ -4,6 +4,7 @@ Minimal Version Synchronization Script
 
 This script only synchronizes version numbers in essential files:
 - pyproject.toml (source of truth)
+- pyproject.toml [tool.mcp].server_version (MCP metadata)
 - tree_sitter_analyzer/__init__.py (main package version)
 
 Other __init__.py files are left unchanged to reduce complexity.
@@ -52,7 +53,9 @@ def get_essential_version_files() -> list[Path]:
     return [f for f in essential_files if f.exists()]
 
 
-def update_version_in_file(file_path: Path, new_version: str) -> tuple[bool, str]:
+def update_version_in_file(
+    file_path: Path, new_version: str, *, check_only: bool = False
+) -> tuple[bool, str]:
     """Update version in a single file"""
     try:
         content = file_path.read_text(encoding="utf-8")
@@ -69,6 +72,8 @@ def update_version_in_file(file_path: Path, new_version: str) -> tuple[bool, str
         # Update existing version
         new_content = re.sub(version_pattern, f'__version__ = "{new_version}"', content)
         if new_content != content:
+            if check_only:
+                return True, f"⚠️  Would update {file_path.relative_to(Path('.'))}"
             try:
                 file_path.write_text(new_content, encoding="utf-8")
                 return True, f"✅ Updated {file_path.relative_to(Path('.'))}"
@@ -83,6 +88,35 @@ def update_version_in_file(file_path: Path, new_version: str) -> tuple[bool, str
         return False, f"⚠️  No __version__ found in {file_path.relative_to(Path('.'))}"
 
 
+def update_mcp_server_version(
+    new_version: str, *, check_only: bool = False
+) -> tuple[bool, str]:
+    """Update [tool.mcp].server_version in pyproject.toml."""
+    pyproject_path = Path("pyproject.toml")
+    try:
+        content = pyproject_path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        try:
+            content = pyproject_path.read_text(encoding="cp1252")
+        except UnicodeDecodeError:
+            content = pyproject_path.read_text(encoding="latin-1")
+
+    server_version_pattern = r'server_version\s*=\s*"([^"]+)"'
+    if not re.search(server_version_pattern, content):
+        return False, "⚠️  No [tool.mcp].server_version found in pyproject.toml"
+
+    new_content = re.sub(
+        server_version_pattern, f'server_version = "{new_version}"', content
+    )
+    if new_content == content:
+        return False, "ℹ️  No changes needed in pyproject.toml [tool.mcp].server_version"
+    if check_only:
+        return True, "⚠️  Would update pyproject.toml [tool.mcp].server_version"
+
+    pyproject_path.write_text(new_content, encoding="utf-8")
+    return True, "✅ Updated pyproject.toml [tool.mcp].server_version"
+
+
 def check_versions(check_only: bool = False) -> None:
     """Check and optionally update essential version numbers only"""
     current_version = get_version_from_pyproject()
@@ -93,8 +127,17 @@ def check_versions(check_only: bool = False) -> None:
 
     updated_files = []
 
+    server_success, server_message = update_mcp_server_version(
+        current_version, check_only=check_only
+    )
+    if server_success:
+        updated_files.append(Path("pyproject.toml"))
+    print(server_message)
+
     for file_path in essential_files:
-        success, message = update_version_in_file(file_path, current_version)
+        success, message = update_version_in_file(
+            file_path, current_version, check_only=check_only
+        )
         if success:
             updated_files.append(file_path)
         print(message)

--- a/tests/unit/test_agent_contracts.py
+++ b/tests/unit/test_agent_contracts.py
@@ -49,6 +49,18 @@ def test_pyproject_pytest_runtime_contract_mirror_is_locked() -> None:
     )
 
 
+def test_package_and_mcp_versions_are_aligned() -> None:
+    """Release prep must keep package and MCP server versions in lockstep."""
+    data = tomllib.loads((PROJECT_ROOT / "pyproject.toml").read_text())
+    project_version = data["project"]["version"]
+    package_init = (PROJECT_ROOT / "tree_sitter_analyzer" / "__init__.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert data["tool"]["mcp"]["server_version"] == project_version
+    assert f'__version__ = "{project_version}"' in package_init
+
+
 def test_ast_cache_call_edge_extraction_does_not_depend_on_call_graph() -> None:
     """ASTCache and CallGraph must share extraction helpers without a back-edge."""
     path = PROJECT_ROOT / "tree_sitter_analyzer" / "_ast_extraction.py"

--- a/tree_sitter_analyzer/__init__.py
+++ b/tree_sitter_analyzer/__init__.py
@@ -11,7 +11,7 @@ Architecture:
 - Data Models: Generic and language-specific code element representations
 """
 
-__version__ = "1.17.4"
+__version__ = "1.18.0"
 __author__ = "aisheng.yu"
 __email__ = "aimasteracc@gmail.com"
 

--- a/uv.lock
+++ b/uv.lock
@@ -2705,7 +2705,7 @@ wheels = [
 
 [[package]]
 name = "tree-sitter-analyzer"
-version = "1.17.4"
+version = "1.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

GitFlow merge-back for v1.18.0 after PR #238 landed on main and the v1.18.0 tag/GitHub Release were created.

This brings release-prep commits back to develop:
- package and MCP server version 1.18.0
- CHANGELOG v1.18.0 notes
- version sync guard for package/__version__/tool.mcp.server_version
- README test-count updates

## Validation

Release PR #238 is merged to main. Release branch automation passed, published v1.18.0 to PyPI, and finalized successfully. Local pre-release validation passed: sync checks, focused agent-contract tests, full suite (17456 passed, 92 skipped), diff check, and build metadata verification.