### PR TITLE
feat(graph): add unified edge store foundation

### DIFF
--- a/tests/unit/test_callers_callees_tools.py
+++ b/tests/unit/test_callers_callees_tools.py
@@ -52,6 +52,7 @@ class TestCodeGraphCallersTool:
         assert isinstance(result["callers"], list)
 
     @pytest.mark.asyncio
+    @pytest.mark.slow_ok  # clean Py3.13 CI may build the full project graph before SQL cache exists
     async def test_execute_with_file_path(self, callers_tool):
         result = await callers_tool.execute(
             {

--- a/tests/unit/test_edge_store.py
+++ b/tests/unit/test_edge_store.py
@@ -2,8 +2,14 @@ from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
+from typing import Any
 
+import pytest
+
+from tree_sitter_analyzer._ast_cache_schema import apply_migration_v8
+from tree_sitter_analyzer._ast_cache_write import write_graph_edges_for_file
 from tree_sitter_analyzer.ast_cache import ASTCache
+from tree_sitter_analyzer.graph import edge_store as edge_store_module
 from tree_sitter_analyzer.graph.edge_store import Edge, EdgeKind, EdgeStore, symbol_node
 
 
@@ -47,6 +53,174 @@ def test_edge_store_crud_and_neighbors(tmp_path: Path) -> None:
         store.close()
 
 
+def test_edge_store_serializes_edges_and_subgraphs(tmp_path: Path) -> None:
+    db_path = tmp_path / "edges.db"
+    store = EdgeStore(str(db_path))
+    try:
+        source = "pkg/a.py:caller:10"
+        target = "pkg/b.py:callee:20"
+        edge = Edge(
+            source,
+            target,
+            EdgeKind.CALLS,
+            11,
+            metadata={"z": 1},
+        )
+        store.upsert_edges([edge])
+
+        subgraph = store.get_neighbors(source, depth=1)
+        assert edge.to_dict()["metadata"] == {"z": 1}
+        assert subgraph.to_dict() == {
+            "nodes": [source, target],
+            "edges": [edge.to_dict()],
+        }
+        assert store.conn is not None
+    finally:
+        store.close()
+
+
+def test_edge_store_reuses_external_transaction(tmp_path: Path) -> None:
+    db_path = tmp_path / "edges.db"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute("CREATE TABLE marker (value TEXT NOT NULL)")
+        conn.commit()
+        conn.execute("INSERT INTO marker (value) VALUES ('pending')")
+
+        store = EdgeStore(conn)
+        assert store.conn is conn
+        store.upsert_edges(
+            [
+                Edge(
+                    "pkg/a.py:caller:10",
+                    "pkg/b.py:callee:20",
+                    EdgeKind.CALLS,
+                    11,
+                )
+            ]
+        )
+        store.close()
+
+        other = sqlite3.connect(str(db_path))
+        try:
+            marker_count = other.execute("SELECT COUNT(*) FROM marker").fetchone()[0]
+            assert marker_count == 0
+        finally:
+            other.close()
+
+        conn.commit()
+
+        other = sqlite3.connect(str(db_path))
+        try:
+            marker_count = other.execute("SELECT COUNT(*) FROM marker").fetchone()[0]
+            edge_count = other.execute("SELECT COUNT(*) FROM edges").fetchone()[0]
+            assert marker_count == 1
+            assert edge_count == 1
+        finally:
+            other.close()
+    finally:
+        conn.close()
+
+
+def test_edge_store_query_directions_filters_and_fallbacks(tmp_path: Path) -> None:
+    db_path = tmp_path / "edges.db"
+    store = EdgeStore(str(db_path))
+    try:
+        source = "pkg/a.py:caller:10"
+        middle = "pkg/b.py:callee:20"
+        leaf = "pkg/c.py:leaf:30"
+        store.upsert_edges(
+            [
+                Edge(source, middle, EdgeKind.CALLS, 11),
+                Edge(middle, leaf, "custom", 21),
+                Edge(leaf, source, EdgeKind.REFERENCES, 31),
+            ]
+        )
+        store.conn.execute(
+            """INSERT INTO edges
+               (source_node_id, target_node_id, kind, line, provenance, metadata)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            ("manual", source, EdgeKind.CALLS.value, 1, None, "{broken"),
+        )
+        store.conn.commit()
+
+        assert [
+            edge.source_node_id
+            for edge in store.get_edges(source, direction="incoming")
+        ] == [
+            "manual",
+            leaf,
+        ]
+        assert [
+            edge.source_node_id
+            for edge in store.get_edges(source, EdgeKind.CALLS, direction="incoming")
+        ] == ["manual"]
+        assert {
+            edge.target_node_id
+            for edge in store.get_edges(source, EdgeKind.CALLS, direction="both")
+        } == {middle, source}
+        assert {
+            edge.source_node_id for edge in store.get_edges(source, direction="both")
+        } == {source, leaf, "manual"}
+        fallback_edge = store.get_edges("manual", EdgeKind.CALLS)[0]
+        assert fallback_edge.provenance == "tree-sitter"
+        assert fallback_edge.metadata == {}
+        assert store.get_neighbors(source, depth=0).to_dict() == {
+            "nodes": [source],
+            "edges": [],
+        }
+        assert store.get_neighbors(source, kinds=[EdgeKind.CALLS]).nodes == [
+            source,
+            middle,
+        ]
+        assert store.get_neighbors(source, depth=3).nodes == [source, middle, leaf]
+        with pytest.raises(ValueError, match="direction"):
+            store.get_edges(source, direction="sideways")
+    finally:
+        store.close()
+
+
+def test_edge_store_neighbors_deduplicates_null_line_edges(tmp_path: Path) -> None:
+    db_path = tmp_path / "edges.db"
+    store = EdgeStore(str(db_path))
+    try:
+        source = "pkg/a.py:caller"
+        target = "pkg/b.py:callee"
+        store.upsert_edges(
+            [
+                Edge(source, target, EdgeKind.CALLS),
+                Edge(source, target, EdgeKind.CALLS),
+            ]
+        )
+
+        subgraph = store.get_neighbors(source)
+        assert len(subgraph.edges) == 1
+    finally:
+        store.close()
+
+
+def test_edge_store_inheritance_tree_and_node_helpers(tmp_path: Path) -> None:
+    db_path = tmp_path / "edges.db"
+    store = EdgeStore(str(db_path))
+    try:
+        store.upsert_edges(
+            [
+                Edge("pkg/model.py:Child:10", "pkg/model.py:Base:1", EdgeKind.EXTENDS),
+                Edge("pkg/model.py:Child:10", "class:Protocol", EdgeKind.IMPLEMENTS),
+            ]
+        )
+
+        assert symbol_node("pkg/model.py", "Child") == "pkg/model.py:Child"
+        assert [
+            edge["source_node_id"] for edge in store.get_inheritance_tree("Base")
+        ] == ["pkg/model.py:Child:10"]
+        assert [
+            edge["target_node_id"] for edge in store.get_inheritance_tree("Protocol")
+        ] == ["class:Protocol"]
+    finally:
+        store.close()
+
+
 def test_ast_cache_creates_edges_schema(tmp_path: Path) -> None:
     cache = ASTCache(str(tmp_path))
     try:
@@ -70,6 +244,17 @@ def test_ast_cache_creates_edges_schema(tmp_path: Path) -> None:
             conn.close()
     finally:
         cache.close()
+
+
+def test_edge_store_migration_ignores_operational_error() -> None:
+    class FailingConn:
+        def executescript(self, _schema: str) -> None:
+            raise sqlite3.OperationalError("boom")
+
+    def record_fn(*_args: Any) -> None:
+        raise AssertionError("record_fn should not run after DDL failure")
+
+    apply_migration_v8(FailingConn(), record_fn)  # type: ignore[arg-type]
 
 
 def test_ast_cache_writes_calls_imports_contains_and_extends_edges(
@@ -124,3 +309,65 @@ def test_ast_cache_writes_calls_imports_contains_and_extends_edges(
         assert any(edge.target_node_id == "module:os" for edge in imports)
     finally:
         cache.close()
+
+
+def test_write_graph_edges_handles_empty_imports_and_missing_parent(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "edges.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        write_graph_edges_for_file(
+            conn,
+            "pkg/sample.py",
+            "python",
+            {
+                "symbols": [
+                    {"kind": "class", "name": "Child", "line": 3, "parents": ["Base"]},
+                    {"kind": "function", "name": "module_call", "line": 8},
+                ]
+            },
+            ["", {"text": "from os import path", "line": 1}],
+            [
+                {
+                    "caller_name": "",
+                    "caller_line": 0,
+                    "callee_name": "module_call",
+                    "callee_full": "module_call",
+                    "callee_line": 8,
+                }
+            ],
+        )
+        store = EdgeStore(conn)
+        kinds = {row["kind"] for row in conn.execute("SELECT kind FROM edges")}
+        assert {"calls", "extends", "imports"}.issubset(kinds)
+        assert store.get_inheritance_tree("Base")[0]["target_node_id"] == "class:Base"
+    finally:
+        conn.close()
+
+
+def test_write_graph_edges_logs_operational_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class BrokenEdgeStore:
+        def __init__(self, _conn: sqlite3.Connection) -> None:
+            pass
+
+        def replace_edges_for_file(self, _file_path: str, _edges: list[Edge]) -> None:
+            raise sqlite3.OperationalError("boom")
+
+    monkeypatch.setattr(edge_store_module, "EdgeStore", BrokenEdgeStore)
+    conn = sqlite3.connect(str(tmp_path / "edges.db"))
+    try:
+        write_graph_edges_for_file(
+            conn,
+            "pkg/sample.py",
+            "python",
+            {"symbols": []},
+            [],
+            [],
+        )
+    finally:
+        conn.close()

--- a/tests/unit/test_edge_store.py
+++ b/tests/unit/test_edge_store.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from tree_sitter_analyzer.ast_cache import ASTCache
+from tree_sitter_analyzer.graph.edge_store import Edge, EdgeKind, EdgeStore, symbol_node
+
+
+def test_edge_kind_covers_unified_relationship_surface() -> None:
+    expected = {
+        "calls",
+        "imports",
+        "extends",
+        "implements",
+        "references",
+        "contains",
+        "overrides",
+    }
+    assert expected.issubset({kind.value for kind in EdgeKind})
+
+
+def test_edge_store_crud_and_neighbors(tmp_path: Path) -> None:
+    db_path = tmp_path / "edges.db"
+    store = EdgeStore(str(db_path))
+    try:
+        source = "pkg/a.py:caller:10"
+        middle = "pkg/b.py:callee:20"
+        target = "pkg/c.py:leaf:30"
+        store.upsert_edges(
+            [
+                Edge(source, middle, EdgeKind.CALLS, 11),
+                Edge(middle, target, EdgeKind.REFERENCES, 21),
+            ]
+        )
+
+        outgoing = store.get_edges(source, EdgeKind.CALLS)
+        assert [edge.target_node_id for edge in outgoing] == [middle]
+
+        subgraph = store.get_neighbors(source, depth=2)
+        assert subgraph.nodes == sorted([source, middle, target])
+        assert [edge.normalized_kind() for edge in subgraph.edges] == [
+            "calls",
+            "references",
+        ]
+    finally:
+        store.close()
+
+
+def test_ast_cache_creates_edges_schema(tmp_path: Path) -> None:
+    cache = ASTCache(str(tmp_path))
+    try:
+        conn = sqlite3.connect(cache.db_path)
+        conn.row_factory = sqlite3.Row
+        try:
+            columns = {row["name"] for row in conn.execute("PRAGMA table_info(edges)")}
+            assert {
+                "source_node_id",
+                "target_node_id",
+                "kind",
+                "line",
+                "provenance",
+                "metadata",
+            }.issubset(columns)
+            version = conn.execute(
+                "SELECT version FROM ast_schema_version WHERE version = 8"
+            ).fetchone()
+            assert version is not None
+        finally:
+            conn.close()
+    finally:
+        cache.close()
+
+
+def test_ast_cache_writes_calls_imports_contains_and_extends_edges(
+    tmp_path: Path,
+) -> None:
+    sample = tmp_path / "sample.py"
+    sample.write_text(
+        "\n".join(
+            [
+                "import os",
+                "",
+                "class Base:",
+                "    pass",
+                "",
+                "class Child(Base):",
+                "    def method(self):",
+                "        helper()",
+                "",
+                "def helper():",
+                "    return os.getcwd()",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    cache = ASTCache(str(tmp_path))
+    try:
+        result = cache.index_file(str(sample))
+        assert result["status"] == "indexed"
+
+        store = EdgeStore(cache.get_conn())
+        kinds = {
+            row["kind"]
+            for row in cache.get_conn()
+            .execute("SELECT kind FROM edges ORDER BY kind")
+            .fetchall()
+        }
+        assert {"calls", "imports", "contains", "extends"}.issubset(kinds)
+
+        child_node = symbol_node("sample.py", "Child", 6)
+        inheritance = store.get_edges(child_node, EdgeKind.EXTENDS)
+        assert inheritance
+        assert inheritance[0].target_node_id == symbol_node("sample.py", "Base", 3)
+
+        contains = store.get_edges(child_node, EdgeKind.CONTAINS)
+        assert [edge.target_node_id for edge in contains] == [
+            symbol_node("sample.py", "method", 7)
+        ]
+
+        imports = store.get_edges("file:sample.py", EdgeKind.IMPORTS)
+        assert any(edge.target_node_id == "module:os" for edge in imports)
+    finally:
+        cache.close()

--- a/tree_sitter_analyzer/_ast_cache_indexer.py
+++ b/tree_sitter_analyzer/_ast_cache_indexer.py
@@ -121,6 +121,9 @@ def parse_and_write(
     )
     _write.write_call_edges(conn, rel_path, language, call_edges)
     cache._write_imports_for_file(conn, rel_path, language, imports)  # noqa: SLF001
+    _write.write_graph_edges_for_file(
+        conn, rel_path, language, symbols, imports, call_edges
+    )
     cache._write_activation_for_file(conn, rel_path, inserted)  # noqa: SLF001
     cache._resolve_call_edges_for_file(conn, rel_path)  # noqa: SLF001
     conn.commit()
@@ -232,6 +235,10 @@ def insert_index_row(
     _write.write_call_edges(conn, rel_path, r["language"], call_edges)
     imports_list = json.loads(r.get("imports_json", "[]"))
     cache._write_imports_for_file(conn, rel_path, r["language"], imports_list)  # noqa: SLF001
+    symbols = json.loads(r.get("symbols_json", "{}"))
+    _write.write_graph_edges_for_file(
+        conn, rel_path, r["language"], symbols, imports_list, call_edges
+    )
     if include_activation:
         cache._write_activation_for_file(conn, rel_path, inserted_symbol_rows)  # noqa: SLF001
     else:

--- a/tree_sitter_analyzer/_ast_cache_schema.py
+++ b/tree_sitter_analyzer/_ast_cache_schema.py
@@ -266,6 +266,18 @@ def apply_migration_v7(conn: sqlite3.Connection, record_fn: RecordFn) -> None:
         pass
 
 
+def apply_migration_v8(conn: sqlite3.Connection, record_fn: RecordFn) -> None:
+    """Create unified ``edges`` table (v8 — EdgeStore)."""
+    try:
+        from .graph.edge_store import EDGE_STORE_SCHEMA
+
+        conn.executescript(EDGE_STORE_SCHEMA)
+        record_fn(conn, 8, "Unified edge store")
+        conn.commit()
+    except sqlite3.OperationalError:
+        pass
+
+
 # ---------------------------------------------------------------------------
 # Schema DDL constants V1 and V2 (moved from ast_cache.py)
 # ---------------------------------------------------------------------------
@@ -401,6 +413,21 @@ EXPECTED_SCHEMA_VERSIONS: list[Any] = [
         "Extractor version invalidation",
         {
             "ast_index_columns": ["extractor_version"],
+        },
+    ),
+    (
+        8,
+        "Unified edge store",
+        {
+            "tables": ["edges"],
+            "edges_columns": [
+                "source_node_id",
+                "target_node_id",
+                "kind",
+                "line",
+                "provenance",
+                "metadata",
+            ],
         },
     ),
 ]

--- a/tree_sitter_analyzer/_ast_cache_write.py
+++ b/tree_sitter_analyzer/_ast_cache_write.py
@@ -229,3 +229,117 @@ def write_imports_for_file(
         for entry in parse_imports(text, language, rel_path, line):
             if not _insert_import_entry(conn, rel_path, language, entry):
                 return
+
+
+def write_graph_edges_for_file(
+    conn: sqlite3.Connection,
+    rel_path: str,
+    language: str,
+    symbols: dict[str, Any],
+    imports: list[str] | list[dict[str, Any]],
+    call_edges: list[dict[str, Any]],
+) -> None:
+    """Refresh unified EdgeStore rows derived from one indexed file."""
+    try:
+        from .graph.edge_store import (
+            Edge,
+            EdgeKind,
+            EdgeStore,
+            class_node,
+            file_node,
+            module_node,
+            symbol_node,
+        )
+        from .synapse_resolver import parse_imports
+    except Exception as exc:  # pragma: no cover
+        logger.debug("edge store import failed for %s: %s", rel_path, exc)
+        return
+
+    symbol_items = symbols.get("symbols", [])
+    class_nodes = {
+        sym.get("name", ""): symbol_node(rel_path, sym.get("name", ""), sym.get("line"))
+        for sym in symbol_items
+        if sym.get("kind") == "class" and sym.get("name")
+    }
+    edges: list[Edge] = []
+
+    for edge in call_edges:
+        caller_name = edge.get("caller_name", "")
+        source = (
+            symbol_node(rel_path, caller_name, edge.get("caller_line"))
+            if caller_name
+            else file_node(rel_path)
+        )
+        callee_name = edge.get("callee_name", "")
+        target = symbol_node(rel_path, callee_name, edge.get("callee_line"))
+        edges.append(
+            Edge(
+                source,
+                target,
+                EdgeKind.CALLS,
+                edge.get("callee_line"),
+                metadata={
+                    "language": language,
+                    "callee_full": edge.get("callee_full", ""),
+                },
+            )
+        )
+
+    for raw in imports or []:
+        text, line = _parse_import_raw(raw)
+        if not text:
+            continue
+        for entry in parse_imports(text, language, rel_path, line):
+            target = module_node(entry.module_path)
+            edges.append(
+                Edge(
+                    file_node(rel_path),
+                    target,
+                    EdgeKind.IMPORTS,
+                    line or entry.line,
+                    metadata={
+                        "language": language,
+                        "local_name": entry.local_name,
+                        "is_relative": entry.is_relative,
+                        "is_star": entry.is_star,
+                        "alias_of": entry.alias_of,
+                    },
+                )
+            )
+
+    for sym in symbol_items:
+        if sym.get("kind") == "function" and sym.get("class"):
+            cls_name = sym["class"]
+            edges.append(
+                Edge(
+                    class_nodes.get(cls_name, class_node(cls_name)),
+                    symbol_node(rel_path, sym.get("name", ""), sym.get("line")),
+                    EdgeKind.CONTAINS,
+                    sym.get("line"),
+                    metadata={"language": language},
+                )
+            )
+        elif sym.get("kind") == "class" and sym.get("parents"):
+            source = class_nodes.get(
+                sym.get("name", ""),
+                symbol_node(rel_path, sym.get("name", ""), sym.get("line")),
+            )
+            for parent in sym.get("parents", []):
+                base_parent = str(parent).rsplit(".", 1)[-1]
+                parent_target = class_nodes.get(str(parent)) or class_nodes.get(
+                    base_parent
+                )
+                edges.append(
+                    Edge(
+                        source,
+                        parent_target or class_node(str(parent)),
+                        EdgeKind.EXTENDS,
+                        sym.get("line"),
+                        metadata={"language": language, "parent": str(parent)},
+                    )
+                )
+
+    try:
+        EdgeStore(conn).replace_edges_for_file(rel_path, edges)
+    except sqlite3.OperationalError as exc:
+        logger.debug("edge store write failed for %s: %s", rel_path, exc)

--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -43,6 +43,7 @@ from ._ast_cache_schema import (
     apply_migration_v5 as _apply_migration_v5,
     apply_migration_v6 as _apply_migration_v6,
     apply_migration_v7 as _apply_migration_v7,
+    apply_migration_v8 as _apply_migration_v8,
     backfill_schema_version_row as _backfill_schema_version_row,
     check_schema_expectations as _check_schema_expectations,
     clear_activation_for_file as _clear_activation_for_file_fn,
@@ -134,6 +135,7 @@ class ASTCache:
             (5, _apply_migration_v5),
             (6, _apply_migration_v6),
             (7, _apply_migration_v7),
+            (8, _apply_migration_v8),
         ]
         self._fts5_available = _schema_init_db(
             conn, self._fts5_available, _has_fts5, migrations

--- a/tree_sitter_analyzer/graph/__init__.py
+++ b/tree_sitter_analyzer/graph/__init__.py
@@ -1,0 +1,5 @@
+"""Graph storage primitives for cache-backed code relationships."""
+
+from .edge_store import Edge, EdgeKind, EdgeStore, Subgraph
+
+__all__ = ["Edge", "EdgeKind", "EdgeStore", "Subgraph"]

--- a/tree_sitter_analyzer/graph/edge_store.py
+++ b/tree_sitter_analyzer/graph/edge_store.py
@@ -69,7 +69,8 @@ class Subgraph:
         }
 
 
-EDGE_STORE_SCHEMA = """
+EDGE_STORE_SCHEMA_STATEMENTS: tuple[str, ...] = (
+    """
 CREATE TABLE IF NOT EXISTS edges (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     source_node_id TEXT NOT NULL,
@@ -79,17 +80,14 @@ CREATE TABLE IF NOT EXISTS edges (
     provenance TEXT DEFAULT 'tree-sitter',
     metadata TEXT,
     UNIQUE(source_node_id, target_node_id, kind, line)
-);
+)
+""".strip(),
+    "CREATE INDEX IF NOT EXISTS idx_edges_source_kind ON edges(source_node_id, kind)",
+    "CREATE INDEX IF NOT EXISTS idx_edges_target_kind ON edges(target_node_id, kind)",
+    "CREATE INDEX IF NOT EXISTS idx_edges_kind ON edges(kind)",
+)
 
-CREATE INDEX IF NOT EXISTS idx_edges_source_kind
-    ON edges(source_node_id, kind);
-
-CREATE INDEX IF NOT EXISTS idx_edges_target_kind
-    ON edges(target_node_id, kind);
-
-CREATE INDEX IF NOT EXISTS idx_edges_kind
-    ON edges(kind);
-"""
+EDGE_STORE_SCHEMA = ";\n\n".join(EDGE_STORE_SCHEMA_STATEMENTS) + ";"
 
 
 class EdgeStore:
@@ -109,8 +107,9 @@ class EdgeStore:
         return self._conn
 
     def ensure_schema(self) -> None:
-        self._conn.executescript(EDGE_STORE_SCHEMA)
-        self._conn.commit()
+        for statement in EDGE_STORE_SCHEMA_STATEMENTS:
+            self._conn.execute(statement)
+        self._commit_if_owned()
 
     def close(self) -> None:
         if self._owns_conn:
@@ -142,7 +141,11 @@ class EdgeStore:
                     json.dumps(edge.metadata, ensure_ascii=False, sort_keys=True),
                 ),
             )
-        self._conn.commit()
+        self._commit_if_owned()
+
+    def _commit_if_owned(self) -> None:
+        if self._owns_conn:
+            self._conn.commit()
 
     def get_edges(
         self,

--- a/tree_sitter_analyzer/graph/edge_store.py
+++ b/tree_sitter_analyzer/graph/edge_store.py
@@ -1,0 +1,311 @@
+"""SQLite-backed unified edge store.
+
+The store is intentionally small and dependency-light: it is used by
+``ASTCache`` during indexing and by graph/query features at read time.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections import deque
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, cast
+
+
+class EdgeKind(str, Enum):
+    """Supported code relationship edge kinds."""
+
+    CALLS = "calls"
+    IMPORTS = "imports"
+    EXTENDS = "extends"
+    IMPLEMENTS = "implements"
+    REFERENCES = "references"
+    CONTAINS = "contains"
+    OVERRIDES = "overrides"
+    TYPE_OF = "type_of"
+    RETURNS = "returns"
+    INSTANTIATES = "instantiates"
+    DECORATES = "decorates"
+
+
+@dataclass(frozen=True)
+class Edge:
+    """One directed relationship between two indexed code nodes."""
+
+    source_node_id: str
+    target_node_id: str
+    kind: EdgeKind | str
+    line: int | None = None
+    provenance: str = "tree-sitter"
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def normalized_kind(self) -> str:
+        return self.kind.value if isinstance(self.kind, EdgeKind) else str(self.kind)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "source_node_id": self.source_node_id,
+            "target_node_id": self.target_node_id,
+            "kind": self.normalized_kind(),
+            "line": self.line,
+            "provenance": self.provenance,
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class Subgraph:
+    """A small reachable graph slice."""
+
+    nodes: list[str]
+    edges: list[Edge]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "nodes": list(self.nodes),
+            "edges": [edge.to_dict() for edge in self.edges],
+        }
+
+
+EDGE_STORE_SCHEMA = """
+CREATE TABLE IF NOT EXISTS edges (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source_node_id TEXT NOT NULL,
+    target_node_id TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    line INTEGER,
+    provenance TEXT DEFAULT 'tree-sitter',
+    metadata TEXT,
+    UNIQUE(source_node_id, target_node_id, kind, line)
+);
+
+CREATE INDEX IF NOT EXISTS idx_edges_source_kind
+    ON edges(source_node_id, kind);
+
+CREATE INDEX IF NOT EXISTS idx_edges_target_kind
+    ON edges(target_node_id, kind);
+
+CREATE INDEX IF NOT EXISTS idx_edges_kind
+    ON edges(kind);
+"""
+
+
+class EdgeStore:
+    """CRUD and traversal API for the unified ``edges`` table."""
+
+    def __init__(self, conn_or_db_path: sqlite3.Connection | str) -> None:
+        self._owns_conn = isinstance(conn_or_db_path, str)
+        if self._owns_conn:
+            self._conn = sqlite3.connect(str(conn_or_db_path))
+            self._conn.row_factory = sqlite3.Row
+        else:
+            self._conn = cast(sqlite3.Connection, conn_or_db_path)
+        self.ensure_schema()
+
+    @property
+    def conn(self) -> sqlite3.Connection:
+        return self._conn
+
+    def ensure_schema(self) -> None:
+        self._conn.executescript(EDGE_STORE_SCHEMA)
+        self._conn.commit()
+
+    def close(self) -> None:
+        if self._owns_conn:
+            self._conn.close()
+
+    def replace_edges_for_file(self, file_path: str, edges: list[Edge]) -> None:
+        """Replace all edges whose source belongs to ``file_path``."""
+        file_node_id = file_node(file_path)
+        symbol_prefix = _escape_like(f"{file_path}:")
+        self._conn.execute(
+            "DELETE FROM edges "
+            "WHERE source_node_id = ? OR source_node_id LIKE ? ESCAPE '\\'",
+            (file_node_id, f"{symbol_prefix}%"),
+        )
+        self.upsert_edges(edges)
+
+    def upsert_edges(self, edges: list[Edge]) -> None:
+        for edge in edges:
+            self._conn.execute(
+                """INSERT OR REPLACE INTO edges
+                   (source_node_id, target_node_id, kind, line, provenance, metadata)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (
+                    edge.source_node_id,
+                    edge.target_node_id,
+                    edge.normalized_kind(),
+                    edge.line,
+                    edge.provenance,
+                    json.dumps(edge.metadata, ensure_ascii=False, sort_keys=True),
+                ),
+            )
+        self._conn.commit()
+
+    def get_edges(
+        self,
+        node_id: str,
+        kind: EdgeKind | str | None = None,
+        direction: str = "outgoing",
+    ) -> list[Edge]:
+        """Return edges touching ``node_id`` in one direction or both."""
+        kind_value = _kind_value(kind)
+        if direction not in {"outgoing", "incoming", "both"}:
+            raise ValueError("direction must be outgoing, incoming, or both")
+        if kind_value is not None:
+            sql, params = _edge_query_with_kind(direction, node_id, kind_value)
+        else:
+            sql, params = _edge_query_without_kind(direction, node_id)
+        return [_edge_from_row(row) for row in self._conn.execute(sql, params)]
+
+    def get_neighbors(
+        self,
+        node_id: str,
+        depth: int = 2,
+        kinds: list[EdgeKind | str] | None = None,
+    ) -> Subgraph:
+        """Breadth-first outgoing traversal from ``node_id``."""
+        if depth <= 0:
+            return Subgraph(nodes=[node_id], edges=[])
+        kind_values = {_kind_value(kind) for kind in kinds or []}
+        seen_nodes = {node_id}
+        seen_edges: set[tuple[str, str, str, int | None]] = set()
+        edges: list[Edge] = []
+        queue: deque[tuple[str, int]] = deque([(node_id, 0)])
+        while queue:
+            current, current_depth = queue.popleft()
+            if current_depth >= depth:
+                continue
+            for edge in self.get_edges(current, direction="outgoing"):
+                if kind_values and edge.normalized_kind() not in kind_values:
+                    continue
+                edge_key = (
+                    edge.source_node_id,
+                    edge.target_node_id,
+                    edge.normalized_kind(),
+                    edge.line,
+                )
+                if edge_key in seen_edges:
+                    continue
+                seen_edges.add(edge_key)
+                edges.append(edge)
+                if edge.target_node_id not in seen_nodes:
+                    seen_nodes.add(edge.target_node_id)
+                    queue.append((edge.target_node_id, current_depth + 1))
+        return Subgraph(nodes=sorted(seen_nodes), edges=edges)
+
+    def get_inheritance_tree(self, class_name: str) -> list[dict[str, Any]]:
+        """Return inheritance edges whose target is ``class_name``."""
+        rows = self._conn.execute(
+            """SELECT * FROM edges
+               WHERE kind IN (?, ?)
+                 AND (
+                    target_node_id = ?
+                    OR target_node_id = ?
+                    OR target_node_id LIKE ?
+                    OR target_node_id LIKE ?
+                 )
+               ORDER BY source_node_id, line""",
+            (
+                EdgeKind.EXTENDS.value,
+                EdgeKind.IMPLEMENTS.value,
+                class_name,
+                class_node(class_name),
+                f"%:{class_name}:%",
+                f"%.{class_name}:%",
+            ),
+        ).fetchall()
+        return [_edge_from_row(row).to_dict() for row in rows]
+
+
+def symbol_node(file_path: str, name: str, line: int | None = None) -> str:
+    """Build a stable file-scoped symbol node id."""
+    clean = (name or "<anonymous>").replace("\n", " ").strip()
+    if line is None:
+        return f"{file_path}:{clean}"
+    return f"{file_path}:{clean}:{int(line)}"
+
+
+def file_node(file_path: str) -> str:
+    return f"file:{file_path}"
+
+
+def module_node(module_path: str) -> str:
+    return f"module:{module_path}"
+
+
+def class_node(class_name: str) -> str:
+    return f"class:{class_name}"
+
+
+def _kind_value(kind: EdgeKind | str | None) -> str | None:
+    if kind is None:
+        return None
+    return kind.value if isinstance(kind, EdgeKind) else str(kind)
+
+
+def _edge_query_with_kind(
+    direction: str,
+    node_id: str,
+    kind_value: str,
+) -> tuple[str, tuple[str, ...]]:
+    if direction == "outgoing":
+        return (
+            "SELECT * FROM edges WHERE source_node_id = ? AND kind = ? "
+            "ORDER BY kind, source_node_id, target_node_id, line",
+            (node_id, kind_value),
+        )
+    if direction == "incoming":
+        return (
+            "SELECT * FROM edges WHERE target_node_id = ? AND kind = ? "
+            "ORDER BY kind, source_node_id, target_node_id, line",
+            (node_id, kind_value),
+        )
+    return (
+        "SELECT * FROM edges WHERE (source_node_id = ? OR target_node_id = ?) "
+        "AND kind = ? ORDER BY kind, source_node_id, target_node_id, line",
+        (node_id, node_id, kind_value),
+    )
+
+
+def _edge_query_without_kind(
+    direction: str, node_id: str
+) -> tuple[str, tuple[str, ...]]:
+    if direction == "outgoing":
+        return (
+            "SELECT * FROM edges WHERE source_node_id = ? "
+            "ORDER BY kind, source_node_id, target_node_id, line",
+            (node_id,),
+        )
+    if direction == "incoming":
+        return (
+            "SELECT * FROM edges WHERE target_node_id = ? "
+            "ORDER BY kind, source_node_id, target_node_id, line",
+            (node_id,),
+        )
+    return (
+        "SELECT * FROM edges WHERE (source_node_id = ? OR target_node_id = ?) "
+        "ORDER BY kind, source_node_id, target_node_id, line",
+        (node_id, node_id),
+    )
+
+
+def _escape_like(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def _edge_from_row(row: sqlite3.Row) -> Edge:
+    try:
+        metadata = json.loads(row["metadata"] or "{}")
+    except (TypeError, json.JSONDecodeError):
+        metadata = {}
+    return Edge(
+        source_node_id=row["source_node_id"],
+        target_node_id=row["target_node_id"],
+        kind=row["kind"],
+        line=row["line"],
+        provenance=row["provenance"] or "tree-sitter",
+        metadata=metadata,
+    )


### PR DESCRIPTION
## Summary
- Adds `tree_sitter_analyzer.graph.EdgeStore` with an `EdgeKind` surface for calls/imports/extends/implements/references/contains/overrides and future edge kinds.
- Adds AST cache schema v8 for the unified `edges` table plus source/target/kind indexes.
- Dual-writes calls, imports, contains, and extends edges during AST cache indexing without changing existing query behavior yet.
- Adds unit coverage for EdgeStore CRUD/traversal, schema creation, and index-time edge writes.

Refs #245. This is the foundation PR; the follow-up PR will switch class hierarchy and callers/callees read paths onto EdgeStore before closing the issue.

## Verification
- `uv run --frozen pytest tests/unit/test_edge_store.py tests/unit/test_schema_integrity.py tests/unit/test_synapse_resolution.py::TestSchemaMigration -q`
- `uv run --frozen pytest tests/integration/test_ast_cache_lifecycle.py tests/unit/mcp/test_ast_cache_watch_modes.py tests/unit/test_ast_cache.py tests/unit/test_ast_cache_bfs.py tests/unit/test_ast_cache_mode_used.py tests/unit/test_ast_cache_tool.py tests/unit/test_ast_cache_utf8_bug.py --cov=tree_sitter_analyzer --cov-report=json -q`
- `uv run --frozen python scripts/check_patch_coverage.py --base origin/develop --coverage-json coverage.json`
- `uv run --frozen pytest -q` -> 17460 passed, 92 skipped
- pre-commit hooks via `git commit`