### PR TITLE
feat(graph): read codegraph relations from edge store

### DIFF
--- a/tests/unit/test_callers_callees_tools.py
+++ b/tests/unit/test_callers_callees_tools.py
@@ -24,6 +24,15 @@ def callees_tool():
     return CodeGraphCalleesTool(_PROJECT_ROOT)
 
 
+@pytest.fixture
+def tiny_project_root(tmp_path):
+    (tmp_path / "sample.py").write_text(
+        "def foo():\n    bar()\n\ndef bar():\n    return 1\n",
+        encoding="utf-8",
+    )
+    return str(tmp_path)
+
+
 class TestCodeGraphCallersTool:
     def test_tool_definition(self, callers_tool):
         defn = callers_tool.get_tool_definition()
@@ -70,7 +79,8 @@ class TestCodeGraphCallersTool:
         )
         assert result["success"] is True
 
-    def test_project_root_change_resets_cache(self, callers_tool):
+    def test_project_root_change_resets_cache(self, tiny_project_root):
+        callers_tool = CodeGraphCallersTool(tiny_project_root)
         callers_tool.get_call_graph()
         assert callers_tool.call_graph_initialized
         callers_tool._on_project_root_changed(None)
@@ -127,7 +137,8 @@ class TestCodeGraphCalleesTool:
         )
         assert result["success"] is True
 
-    def test_project_root_change_resets_cache(self, callees_tool):
+    def test_project_root_change_resets_cache(self, tiny_project_root):
+        callees_tool = CodeGraphCalleesTool(tiny_project_root)
         callees_tool.get_call_graph()
         assert callees_tool.call_graph_initialized
         callees_tool._on_project_root_changed(None)

--- a/tests/unit/test_callers_callees_tools.py
+++ b/tests/unit/test_callers_callees_tools.py
@@ -73,9 +73,10 @@ class TestCodeGraphCallersTool:
         assert result["success"] is True
 
     @pytest.mark.asyncio
-    async def test_execute_toon_format(self, callers_tool):
+    async def test_execute_toon_format(self, tiny_project_root):
+        callers_tool = CodeGraphCallersTool(tiny_project_root)
         result = await callers_tool.execute(
-            {"function_name": "main", "output_format": "toon"}
+            {"function_name": "bar", "output_format": "toon"}
         )
         assert result["success"] is True
 
@@ -131,9 +132,10 @@ class TestCodeGraphCalleesTool:
         assert result["success"] is True
 
     @pytest.mark.asyncio
-    async def test_execute_toon_format(self, callees_tool):
+    async def test_execute_toon_format(self, tiny_project_root):
+        callees_tool = CodeGraphCalleesTool(tiny_project_root)
         result = await callees_tool.execute(
-            {"function_name": "main", "output_format": "toon"}
+            {"function_name": "foo", "output_format": "toon"}
         )
         assert result["success"] is True
 

--- a/tests/unit/test_callers_callees_tools.py
+++ b/tests/unit/test_callers_callees_tools.py
@@ -110,22 +110,24 @@ class TestCodeGraphCalleesTool:
         assert callees_tool.validate_arguments({"function_name": "main"})
 
     @pytest.mark.asyncio
-    async def test_execute_returns_callees(self, callees_tool):
+    async def test_execute_returns_callees(self, tiny_project_root):
+        callees_tool = CodeGraphCalleesTool(tiny_project_root)
         result = await callees_tool.execute(
-            {"function_name": "build", "output_format": "json"}
+            {"function_name": "foo", "output_format": "json"}
         )
         assert result["success"] is True
-        assert result["function"] == "build"
+        assert result["function"] == "foo"
         assert "callees" in result
         assert "callee_count" in result
         assert isinstance(result["callees"], list)
 
     @pytest.mark.asyncio
-    async def test_execute_with_file_path(self, callees_tool):
+    async def test_execute_with_file_path(self, tiny_project_root):
+        callees_tool = CodeGraphCalleesTool(tiny_project_root)
         result = await callees_tool.execute(
             {
-                "function_name": "build",
-                "file_path": "tree_sitter_analyzer/call_graph.py",
+                "function_name": "foo",
+                "file_path": "sample.py",
                 "output_format": "json",
             }
         )
@@ -159,7 +161,9 @@ class TestCallerCalleeIntegration:
         assert issubclass(CodeGraphCalleesTool, CodeGraphRelationToolMixin)
 
     @pytest.mark.asyncio
-    async def test_unknown_function_returns_empty(self, callers_tool, callees_tool):
+    async def test_unknown_function_returns_empty(self, tiny_project_root):
+        callers_tool = CodeGraphCallersTool(tiny_project_root)
+        callees_tool = CodeGraphCalleesTool(tiny_project_root)
         result = await callers_tool.execute(
             {
                 "function_name": "zzz_nonexistent_function_xyz",
@@ -224,9 +228,10 @@ class TestStaleCacheWarning:
 
     @pytest.mark.asyncio
     async def test_callees_warning_omitted_when_callees_empty(
-        self, callees_tool
+        self, tiny_project_root
     ) -> None:
         # Empty callee list: nothing to be stale about, no warning.
+        callees_tool = CodeGraphCalleesTool(tiny_project_root)
         result = await callees_tool.execute(
             {"function_name": "zzz_nonexistent_function_xyz", "output_format": "json"}
         )
@@ -235,8 +240,9 @@ class TestStaleCacheWarning:
 
     @pytest.mark.asyncio
     async def test_callers_warning_omitted_when_callers_empty(
-        self, callers_tool
+        self, tiny_project_root
     ) -> None:
+        callers_tool = CodeGraphCallersTool(tiny_project_root)
         result = await callers_tool.execute(
             {"function_name": "zzz_nonexistent_function_xyz", "output_format": "json"}
         )

--- a/tests/unit/test_codegraph_callees_tool.py
+++ b/tests/unit/test_codegraph_callees_tool.py
@@ -14,14 +14,31 @@ from pathlib import Path
 
 import pytest
 
+from tree_sitter_analyzer.ast_cache import ASTCache
 from tree_sitter_analyzer.mcp.tools.callees_tool import CodeGraphCalleesTool
-
-_PROJECT_ROOT = str(Path(__file__).resolve().parent.parent.parent)
 
 
 @pytest.fixture
-def callees_tool() -> CodeGraphCalleesTool:
-    return CodeGraphCalleesTool(_PROJECT_ROOT)
+def indexed_call_project(tmp_path: Path) -> str:
+    (tmp_path / "helper.py").write_text(
+        "def helper():\n    return 1\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "worker.py").write_text(
+        "from helper import helper\n\n\ndef build():\n    return helper()\n",
+        encoding="utf-8",
+    )
+    cache = ASTCache(str(tmp_path))
+    try:
+        cache.index_project()
+    finally:
+        cache.close()
+    return str(tmp_path)
+
+
+@pytest.fixture
+def callees_tool(indexed_call_project: str) -> CodeGraphCalleesTool:
+    return CodeGraphCalleesTool(indexed_call_project)
 
 
 class TestCodeGraphCalleesResolutionFields:
@@ -33,14 +50,12 @@ class TestCodeGraphCalleesResolutionFields:
     ) -> None:
         """Each callees[*] entry must have callee_resolution + resolved_file.
 
-        Uses ``score_file`` from health_scorer as the seed function — it is
-        a real method on HealthScorer that calls several siblings (mostly
-        intra-file, with at least one cross-module call), so the response
-        list must be non-empty and must include at least one ``project``
-        entry whose ``callee_resolved_file`` is set.
+        Uses a tiny indexed project where worker.build imports helper.helper,
+        so the response list must be non-empty and include a resolved
+        cross-file project callee without scanning the whole repository.
         """
         result = await callees_tool.execute(
-            {"function_name": "score_file", "output_format": "json"}
+            {"function_name": "build", "output_format": "json"}
         )
         assert result["success"] is True, f"tool errored: {result}"
         callees = result.get("callees", [])
@@ -48,7 +63,7 @@ class TestCodeGraphCalleesResolutionFields:
             f"expected list of callees, got {type(callees).__name__}"
         )
         assert callees, (
-            "score_file is known to call other functions; got an empty "
+            "build is known to call helper; got an empty "
             "callees list, which suggests the cache is stale or the index "
             "missed the file"
         )
@@ -81,12 +96,13 @@ class TestCodeGraphCalleesResolutionFields:
             # resolved_file is a string (possibly empty for unknown/stdlib).
             assert isinstance(entry["callee_resolved_file"], str)
 
-        # And at least one entry must demonstrate cross-file resolution so
-        # the test fails loudly if the resolver silently always emits
-        # 'unknown'. score_file delegates to helpers across the file and
-        # at least one to another module, so we expect 'project' or 'local'.
-        non_unknown = [e for e in callees if e["callee_resolution"] != "unknown"]
-        assert non_unknown, (
-            f"every callee for score_file is 'unknown' — the resolver is "
-            f"either disabled or broken. Sample entries: {callees[:3]}"
+        project_edges = [
+            e
+            for e in callees
+            if e["callee_resolution"] == "project"
+            and e["callee_resolved_file"] == "helper.py"
+        ]
+        assert project_edges, (
+            "expected build -> helper to resolve across files via the EdgeStore "
+            f"read path. Sample entries: {callees[:3]}"
         )

--- a/tests/unit/test_codegraph_class_hierarchy_tool.py
+++ b/tests/unit/test_codegraph_class_hierarchy_tool.py
@@ -7,6 +7,16 @@ import json
 import pytest
 
 from tree_sitter_analyzer.ast_cache import ASTCache
+from tree_sitter_analyzer.class_hierarchy import ClassHierarchy
+from tree_sitter_analyzer.graph import edge_store as edge_store_module
+from tree_sitter_analyzer.graph.edge_store import (
+    Edge,
+    EdgeKind,
+    EdgeStore,
+    class_node,
+    file_node,
+    symbol_node,
+)
 from tree_sitter_analyzer.mcp.tools.class_hierarchy_tool import ClassHierarchyTool
 
 
@@ -138,3 +148,102 @@ class TestExecute:
         )
         assert result["success"] is True
         assert [item["name"] for item in result["subclasses"]] == ["Dog"]
+
+
+class TestClassHierarchyEdgeStore:
+    def test_falls_back_to_symbol_parents_when_edge_store_unavailable(
+        self, monkeypatch, tmp_path
+    ):
+        sample = tmp_path / "models.py"
+        sample.write_text(
+            "class Animal:\n    pass\n\nclass Dog(Animal):\n    pass\n",
+            encoding="utf-8",
+        )
+        cache = ASTCache(str(tmp_path))
+
+        class BrokenEdgeStore:
+            def __init__(self, *_args, **_kwargs):
+                raise RuntimeError("edge store unavailable")
+
+        try:
+            assert cache.index_file(str(sample))["status"] == "indexed"
+            monkeypatch.setattr(edge_store_module, "EdgeStore", BrokenEdgeStore)
+
+            hierarchy = ClassHierarchy(cache)
+            hierarchy.build()
+
+            assert [item["name"] for item in hierarchy.subclasses_of("Animal")] == [
+                "Dog"
+            ]
+        finally:
+            cache.close()
+
+    def test_edge_store_metadata_fallbacks_and_empty_parent_map(self, tmp_path):
+        sample = tmp_path / "models.py"
+        sample.write_text(
+            "\n".join(
+                [
+                    "class Animal:",
+                    "    pass",
+                    "",
+                    "class Dog(Animal):",
+                    "    pass",
+                    "",
+                    "class Cat(Animal):",
+                    "    pass",
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        cache = ASTCache(str(tmp_path))
+        try:
+            assert cache.index_file(str(sample))["status"] == "indexed"
+            conn = cache.get_conn()
+            conn.execute("DELETE FROM edges")
+            store = EdgeStore(conn, ensure_schema=False)
+            store.upsert_edges(
+                [
+                    Edge(
+                        symbol_node("models.py", "Cat", 7),
+                        symbol_node("models.py", "Animal", 1),
+                        EdgeKind.EXTENDS,
+                        metadata={},
+                    ),
+                    Edge(
+                        file_node("models.py"),
+                        class_node("Animal"),
+                        EdgeKind.EXTENDS,
+                        metadata={},
+                    ),
+                ]
+            )
+            conn.execute(
+                """INSERT INTO edges
+                   (source_node_id, target_node_id, kind, line, provenance, metadata)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (
+                    symbol_node("models.py", "Dog", 4),
+                    symbol_node("models.py", "Animal", 1),
+                    EdgeKind.EXTENDS.value,
+                    4,
+                    "tree-sitter",
+                    "{broken",
+                ),
+            )
+            conn.commit()
+
+            hierarchy = ClassHierarchy(cache)
+            hierarchy.build()
+            assert [item["name"] for item in hierarchy.subclasses_of("Animal")] == [
+                "Cat",
+                "Dog",
+            ]
+
+            conn.execute("DELETE FROM edges")
+            store.upsert_edges(
+                [Edge(file_node("models.py"), class_node("Animal"), EdgeKind.EXTENDS)]
+            )
+            assert ClassHierarchy(cache)._build_edges_from_edge_store() is False
+        finally:
+            cache.close()

--- a/tests/unit/test_codegraph_class_hierarchy_tool.py
+++ b/tests/unit/test_codegraph_class_hierarchy_tool.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
+from tree_sitter_analyzer.ast_cache import ASTCache
 from tree_sitter_analyzer.mcp.tools.class_hierarchy_tool import ClassHierarchyTool
 
 
@@ -95,3 +98,43 @@ class TestExecute:
         result = await tool_with_root.execute({"mode": "summary"})
         assert result["format"] == "toon"
         assert "toon_content" in result
+
+    async def test_subclasses_mode_reads_edge_store_when_symbol_parents_missing(
+        self, tmp_path
+    ):
+        sample = tmp_path / "models.py"
+        sample.write_text(
+            "class Animal:\n    pass\n\nclass Dog(Animal):\n    pass\n",
+            encoding="utf-8",
+        )
+        cache = ASTCache(str(tmp_path))
+        try:
+            assert cache.index_file(str(sample))["status"] == "indexed"
+            row = (
+                cache.get_conn()
+                .execute(
+                    "SELECT symbols_json FROM ast_index WHERE file_path = ?",
+                    ("models.py",),
+                )
+                .fetchone()
+            )
+            symbols = json.loads(row["symbols_json"])
+            for symbol in symbols["symbols"]:
+                symbol["parents"] = []
+            cache.get_conn().execute(
+                "UPDATE ast_index SET symbols_json = ? WHERE file_path = ?",
+                (json.dumps(symbols), "models.py"),
+            )
+            cache.get_conn().commit()
+        finally:
+            cache.close()
+
+        result = await ClassHierarchyTool(str(tmp_path)).execute(
+            {
+                "mode": "subclasses",
+                "class_name": "Animal",
+                "output_format": "json",
+            }
+        )
+        assert result["success"] is True
+        assert [item["name"] for item in result["subclasses"]] == ["Dog"]

--- a/tests/unit/test_codegraph_sitemap.py
+++ b/tests/unit/test_codegraph_sitemap.py
@@ -1,6 +1,6 @@
 """Tests for codegraph_sitemap MCP tool and CLI parity."""
 
-import contextlib
+import json
 import sys
 from io import StringIO
 
@@ -141,7 +141,7 @@ class TestSitemapTool:
 
 
 class TestSitemapCLI:
-    def test_cli_smoke(self, indexed_project, monkeypatch):
+    def _run_cli(self, indexed_project, monkeypatch, mode):
         from tree_sitter_analyzer.cli_main import main
 
         monkeypatch.setattr(
@@ -149,57 +149,35 @@ class TestSitemapCLI:
             "argv",
             [
                 "tsa",
+                "--project-root",
                 str(indexed_project),
                 "--codegraph-sitemap",
                 "--codegraph-sitemap-mode",
-                "flat",
+                mode,
                 "--format",
                 "json",
             ],
         )
         mock_stdout = StringIO()
         monkeypatch.setattr("sys.stdout", mock_stdout)
-        with contextlib.suppress(SystemExit):
+        with pytest.raises(SystemExit) as exc_info:
             main()
+        assert exc_info.value.code == 0
+        return json.loads(mock_stdout.getvalue())
+
+    def test_cli_smoke(self, indexed_project, monkeypatch):
+        result = self._run_cli(indexed_project, monkeypatch, "flat")
+        assert result["success"] is True
+        assert result["file_count"] == 3
+        assert result["counts"].get("function", 0) > 0
 
     def test_cli_api_mode(self, indexed_project, monkeypatch):
-        from tree_sitter_analyzer.cli_main import main
-
-        monkeypatch.setattr(
-            sys,
-            "argv",
-            [
-                "tsa",
-                str(indexed_project),
-                "--codegraph-sitemap",
-                "--codegraph-sitemap-mode",
-                "api",
-                "--format",
-                "json",
-            ],
-        )
-        mock_stdout = StringIO()
-        monkeypatch.setattr("sys.stdout", mock_stdout)
-        with contextlib.suppress(SystemExit):
-            main()
+        result = self._run_cli(indexed_project, monkeypatch, "api")
+        assert result["success"] is True
+        names = {item["name"] for item in result["public_api"]}
+        assert "public_func" in names
 
     def test_cli_module_mode(self, indexed_project, monkeypatch):
-        from tree_sitter_analyzer.cli_main import main
-
-        monkeypatch.setattr(
-            sys,
-            "argv",
-            [
-                "tsa",
-                str(indexed_project),
-                "--codegraph-sitemap",
-                "--codegraph-sitemap-mode",
-                "module",
-                "--format",
-                "json",
-            ],
-        )
-        mock_stdout = StringIO()
-        monkeypatch.setattr("sys.stdout", mock_stdout)
-        with contextlib.suppress(SystemExit):
-            main()
+        result = self._run_cli(indexed_project, monkeypatch, "module")
+        assert result["success"] is True
+        assert any("app" in module["directory"] for module in result["modules"])

--- a/tests/unit/test_codegraph_sitemap.py
+++ b/tests/unit/test_codegraph_sitemap.py
@@ -140,6 +140,29 @@ class TestSitemapTool:
             tool.validate_arguments({"mode": "bogus"})
 
 
+def test_sitemap_builders_normalize_cached_slash_paths(tmp_path):
+    from tree_sitter_analyzer.mcp.tools.codegraph_sitemap_tool import (
+        CodeGraphSitemapTool,
+    )
+
+    tool = CodeGraphSitemapTool(project_root=str(tmp_path))
+    files = [
+        {
+            "file": "app/main.py",
+            "language": "python",
+            "symbols": [],
+            "structure": {},
+            "symbol_count": 1,
+            "functions": [{"kind": "function", "name": "run", "line": 1}],
+            "classes": [],
+            "imports": [],
+        }
+    ]
+
+    assert "main.py" in tool._build_full_map(files)["sitemap"]["app"]
+    assert tool._build_module_metrics(files)["modules"][0]["directory"] == "app"
+
+
 class TestSitemapCLI:
     def _run_cli(self, indexed_project, monkeypatch, mode):
         from tree_sitter_analyzer.cli_main import main

--- a/tests/unit/test_codegraph_visualize_tool.py
+++ b/tests/unit/test_codegraph_visualize_tool.py
@@ -233,6 +233,19 @@ class TestVisualizeIndexedProject:
         assert result["stats"]["edge_count"] <= 10
 
     @pytest.mark.asyncio
+    async def test_full_mode_stops_at_edge_limit(self, tiny_call_project: str) -> None:
+        tool = CodeGraphVisualizeTool(tiny_call_project)
+        result = await tool.execute(
+            {
+                "mode": "full",
+                "max_edges": 1,
+                "output_format": "json",
+            }
+        )
+        assert result["success"] is True
+        assert result["stats"]["edge_count"] == 1
+
+    @pytest.mark.asyncio
     async def test_function_mode_on_indexed_project(
         self, tiny_call_project: str
     ) -> None:

--- a/tests/unit/test_codegraph_visualize_tool.py
+++ b/tests/unit/test_codegraph_visualize_tool.py
@@ -17,6 +17,32 @@ from tree_sitter_analyzer.mcp.tools.codegraph_visualize_tool import (
 _PROJECT_ROOT = str(Path(__file__).resolve().parent.parent.parent)
 
 
+@pytest.fixture
+def tiny_call_project(tmp_path: Path) -> str:
+    (tmp_path / "helper.py").write_text(
+        "def helper():\n    return 1\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "worker.py").write_text(
+        "from helper import helper\n"
+        "\n\n"
+        "def build():\n"
+        "    return helper()\n"
+        "\n\n"
+        "def wrapper():\n"
+        "    return build()\n",
+        encoding="utf-8",
+    )
+    from tree_sitter_analyzer.ast_cache import ASTCache
+
+    cache = ASTCache(str(tmp_path))
+    try:
+        cache.index_project()
+    finally:
+        cache.close()
+    return str(tmp_path)
+
+
 class TestMermaidRenderer:
     def test_empty_edges(self) -> None:
         result = _render_mermaid([], "TD")
@@ -190,11 +216,10 @@ class TestVisualizeToolNoProject:
         assert result["stats"]["mode"] == "file"
 
 
-class TestVisualizeRealProject:
+class TestVisualizeIndexedProject:
     @pytest.mark.asyncio
-    @pytest.mark.slow_ok  # full-mode scan of real project; ~7s on CI hardware
-    async def test_full_mode_on_self(self) -> None:
-        tool = CodeGraphVisualizeTool(_PROJECT_ROOT)
+    async def test_full_mode_on_indexed_project(self, tiny_call_project: str) -> None:
+        tool = CodeGraphVisualizeTool(tiny_call_project)
         result = await tool.execute(
             {
                 "mode": "full",
@@ -208,13 +233,14 @@ class TestVisualizeRealProject:
         assert result["stats"]["edge_count"] <= 10
 
     @pytest.mark.asyncio
-    @pytest.mark.slow_ok  # function-mode graph walk on real project; ~13s on CI hardware
-    async def test_function_mode_on_real_func(self) -> None:
-        tool = CodeGraphVisualizeTool(_PROJECT_ROOT)
+    async def test_function_mode_on_indexed_project(
+        self, tiny_call_project: str
+    ) -> None:
+        tool = CodeGraphVisualizeTool(tiny_call_project)
         result = await tool.execute(
             {
                 "mode": "function",
-                "function": "parse_file",
+                "function": "build",
                 "depth": 1,
                 "max_edges": 20,
                 "output_format": "json",
@@ -222,3 +248,4 @@ class TestVisualizeRealProject:
         )
         assert result["success"] is True
         assert "mermaid" in result
+        assert "helper" in result["mermaid"]

--- a/tests/unit/test_edge_store.py
+++ b/tests/unit/test_edge_store.py
@@ -10,7 +10,13 @@ from tree_sitter_analyzer._ast_cache_schema import apply_migration_v8
 from tree_sitter_analyzer._ast_cache_write import write_graph_edges_for_file
 from tree_sitter_analyzer.ast_cache import ASTCache
 from tree_sitter_analyzer.graph import edge_store as edge_store_module
-from tree_sitter_analyzer.graph.edge_store import Edge, EdgeKind, EdgeStore, symbol_node
+from tree_sitter_analyzer.graph.edge_store import (
+    Edge,
+    EdgeKind,
+    EdgeStore,
+    parse_node_id,
+    symbol_node,
+)
 
 
 def test_edge_kind_covers_unified_relationship_surface() -> None:
@@ -221,6 +227,51 @@ def test_edge_store_inheritance_tree_and_node_helpers(tmp_path: Path) -> None:
         store.close()
 
 
+def test_edge_store_call_queries_and_node_parser(tmp_path: Path) -> None:
+    db_path = tmp_path / "edges.db"
+    store = EdgeStore(str(db_path))
+    try:
+        store.upsert_edges(
+            [
+                Edge(
+                    symbol_node("pkg/a.py", "foo", 10),
+                    symbol_node("pkg/a.py", "bar", 11),
+                    EdgeKind.CALLS,
+                    11,
+                    metadata={"callee_full": "bar"},
+                ),
+                Edge(
+                    symbol_node("pkg/b.py", "baz", 20),
+                    symbol_node("pkg/a.py", "foo", 10),
+                    EdgeKind.CALLS,
+                    21,
+                    metadata={"callee_full": "foo"},
+                ),
+            ]
+        )
+
+        assert parse_node_id("pkg/a.py:foo:10").name == "foo"
+        assert parse_node_id("file:pkg/a.py").file_path == "pkg/a.py"
+        assert store.has_edges(EdgeKind.CALLS) is True
+        assert store.query_callees("foo", "pkg/a.py") == [
+            {
+                "caller_name": "foo",
+                "caller_file": "pkg/a.py",
+                "caller_line": 10,
+                "callee_name": "bar",
+                "callee_full": "bar",
+                "callee_file": "pkg/a.py",
+                "callee_resolved_file": "",
+                "callee_line": 11,
+                "depth": 1,
+            }
+        ]
+        callers = store.query_callers("bar", max_depth=2)
+        assert [entry["caller_name"] for entry in callers] == ["foo", "baz"]
+    finally:
+        store.close()
+
+
 def test_ast_cache_creates_edges_schema(tmp_path: Path) -> None:
     cache = ASTCache(str(tmp_path))
     try:
@@ -311,6 +362,29 @@ def test_ast_cache_writes_calls_imports_contains_and_extends_edges(
         cache.close()
 
 
+def test_ast_cache_call_queries_read_from_edge_store_when_legacy_edges_missing(
+    tmp_path: Path,
+) -> None:
+    sample = tmp_path / "sample.py"
+    sample.write_text(
+        "def foo():\n    bar()\n\ndef bar():\n    return 1\n",
+        encoding="utf-8",
+    )
+    cache = ASTCache(str(tmp_path))
+    try:
+        assert cache.index_file(str(sample))["status"] == "indexed"
+        cache.get_conn().execute("DELETE FROM ast_call_edges")
+        cache.get_conn().commit()
+
+        assert cache.has_call_edges() is True
+        callers = cache.query_callers("bar")
+        callees = cache.query_callees("foo", caller_file="sample.py")
+        assert [entry["caller_name"] for entry in callers] == ["foo"]
+        assert [entry["callee_name"] for entry in callees] == ["bar"]
+    finally:
+        cache.close()
+
+
 def test_write_graph_edges_handles_empty_imports_and_missing_parent(
     tmp_path: Path,
 ) -> None:
@@ -318,6 +392,7 @@ def test_write_graph_edges_handles_empty_imports_and_missing_parent(
     conn = sqlite3.connect(str(db_path))
     conn.row_factory = sqlite3.Row
     try:
+        EdgeStore(conn)
         write_graph_edges_for_file(
             conn,
             "pkg/sample.py",
@@ -352,7 +427,7 @@ def test_write_graph_edges_logs_operational_error(
     tmp_path: Path,
 ) -> None:
     class BrokenEdgeStore:
-        def __init__(self, _conn: sqlite3.Connection) -> None:
+        def __init__(self, _conn: sqlite3.Connection, **_kwargs: Any) -> None:
             pass
 
         def replace_edges_for_file(self, _file_path: str, _edges: list[Edge]) -> None:

--- a/tests/unit/test_edge_store.py
+++ b/tests/unit/test_edge_store.py
@@ -231,6 +231,7 @@ def test_edge_store_call_queries_and_node_parser(tmp_path: Path) -> None:
     db_path = tmp_path / "edges.db"
     store = EdgeStore(str(db_path))
     try:
+        assert store.has_edges() is False
         store.upsert_edges(
             [
                 Edge(
@@ -252,6 +253,11 @@ def test_edge_store_call_queries_and_node_parser(tmp_path: Path) -> None:
 
         assert parse_node_id("pkg/a.py:foo:10").name == "foo"
         assert parse_node_id("file:pkg/a.py").file_path == "pkg/a.py"
+        assert parse_node_id("module:pkg.a").name == "pkg.a"
+        assert parse_node_id("class:Thing").name == "Thing"
+        assert parse_node_id("pkg/a.py:foo:not-int").line == 0
+        assert parse_node_id("loose").name == "loose"
+        assert store.has_edges() is True
         assert store.has_edges(EdgeKind.CALLS) is True
         assert store.query_callees("foo", "pkg/a.py") == [
             {
@@ -266,8 +272,40 @@ def test_edge_store_call_queries_and_node_parser(tmp_path: Path) -> None:
                 "depth": 1,
             }
         ]
+        assert store.query_callees("foo", "pkg/other.py") == []
+        assert store.query_callees("foo", "pkg/a.py", max_depth=0) == []
         callers = store.query_callers("bar", max_depth=2)
         assert [entry["caller_name"] for entry in callers] == ["foo", "baz"]
+        assert [
+            entry["caller_name"] for entry in store.query_callers("bar", "pkg/a.py")
+        ] == ["foo"]
+    finally:
+        store.close()
+
+
+def test_edge_store_call_queries_deduplicate_and_fallback_to_call_site_file(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "edges.db"
+    store = EdgeStore(str(db_path))
+    try:
+        source = symbol_node("pkg/a.py", "foo", 10)
+        target = symbol_node("pkg/b.py", "bar", 20)
+        store.upsert_edges(
+            [
+                Edge(source, target, EdgeKind.CALLS, metadata={"callee_full": "bar"}),
+                Edge(source, target, EdgeKind.CALLS, metadata={"callee_full": "bar"}),
+            ]
+        )
+
+        assert len(store.query_callers("bar")) == 1
+        assert [
+            entry["caller_name"] for entry in store.query_callers("bar", "pkg/a.py")
+        ] == ["foo"]
+        assert [
+            entry["caller_name"] for entry in store.query_callers("bar", "pkg/b.py")
+        ] == ["foo"]
+        assert store.query_callers("bar", "pkg/other.py") == []
     finally:
         store.close()
 
@@ -381,6 +419,51 @@ def test_ast_cache_call_queries_read_from_edge_store_when_legacy_edges_missing(
         callees = cache.query_callees("foo", caller_file="sample.py")
         assert [entry["caller_name"] for entry in callers] == ["foo"]
         assert [entry["callee_name"] for entry in callees] == ["bar"]
+    finally:
+        cache.close()
+
+
+def test_ast_cache_get_call_edges_handles_missing_table(tmp_path: Path) -> None:
+    cache = ASTCache(str(tmp_path))
+    try:
+        cache.get_conn().execute("DROP TABLE ast_call_edges")
+        cache.get_conn().commit()
+
+        assert cache.get_call_edges() == []
+    finally:
+        cache.close()
+
+
+def test_project_index_refreshes_edge_store_with_resolved_call_metadata(
+    tmp_path: Path,
+) -> None:
+    sample = tmp_path / "sample.py"
+    sample.write_text(
+        "def foo():\n    bar()\n\ndef bar():\n    return 1\n",
+        encoding="utf-8",
+    )
+    cache = ASTCache(str(tmp_path))
+    try:
+        stats = cache.index_project(force=True)
+        assert stats["indexed"] == 1
+
+        cache.get_conn().execute("DELETE FROM ast_call_edges")
+        cache.get_conn().commit()
+
+        callees = cache.query_callees("foo", caller_file="sample.py")
+        assert callees == [
+            {
+                "caller_name": "foo",
+                "caller_file": "sample.py",
+                "caller_line": 1,
+                "callee_name": "bar",
+                "callee_full": "bar",
+                "callee_file": "sample.py",
+                "callee_resolved_file": "sample.py",
+                "callee_line": 2,
+                "depth": 1,
+            }
+        ]
     finally:
         cache.close()
 

--- a/tests/unit/test_edge_store.py
+++ b/tests/unit/test_edge_store.py
@@ -7,7 +7,11 @@ from typing import Any
 import pytest
 
 from tree_sitter_analyzer._ast_cache_schema import apply_migration_v8
-from tree_sitter_analyzer._ast_cache_write import write_graph_edges_for_file
+from tree_sitter_analyzer._ast_cache_write import (
+    _GRAPH_CALL_EDGE_COLUMNS,
+    _row_to_dict,
+    write_graph_edges_for_file,
+)
 from tree_sitter_analyzer.ast_cache import ASTCache
 from tree_sitter_analyzer.graph import edge_store as edge_store_module
 from tree_sitter_analyzer.graph.edge_store import (
@@ -248,6 +252,13 @@ def test_edge_store_call_queries_and_node_parser(tmp_path: Path) -> None:
                     21,
                     metadata={"callee_full": "foo"},
                 ),
+                Edge(
+                    symbol_node("pkg/a.py", "bar", 11),
+                    symbol_node("pkg/c.py", "qux", 30),
+                    EdgeKind.CALLS,
+                    31,
+                    metadata={"callee_full": "qux"},
+                ),
             ]
         )
 
@@ -274,6 +285,11 @@ def test_edge_store_call_queries_and_node_parser(tmp_path: Path) -> None:
         ]
         assert store.query_callees("foo", "pkg/other.py") == []
         assert store.query_callees("foo", "pkg/a.py", max_depth=0) == []
+        callees_depth2 = store.query_callees("foo", "pkg/a.py", max_depth=2)
+        assert [(entry["callee_name"], entry["depth"]) for entry in callees_depth2] == [
+            ("bar", 1),
+            ("qux", 2),
+        ]
         callers = store.query_callers("bar", max_depth=2)
         assert [entry["caller_name"] for entry in callers] == ["foo", "baz"]
         assert [
@@ -423,6 +439,45 @@ def test_ast_cache_call_queries_read_from_edge_store_when_legacy_edges_missing(
         cache.close()
 
 
+def test_ast_cache_call_queries_fall_back_when_edge_store_raises(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class BrokenStore:
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            pass
+
+        def has_edges(self, *_args: Any, **_kwargs: Any) -> bool:
+            raise sqlite3.OperationalError("missing edges")
+
+    monkeypatch.setattr(edge_store_module, "EdgeStore", BrokenStore)
+    cache = ASTCache(str(tmp_path))
+    try:
+        assert cache.query_callers("missing") == []
+        assert cache.query_callees("missing") == []
+    finally:
+        cache.close()
+
+
+def test_ast_cache_call_queries_fall_back_when_edge_store_empty(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class EmptyStore:
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            pass
+
+        def has_edges(self, *_args: Any, **_kwargs: Any) -> bool:
+            return False
+
+    monkeypatch.setattr(edge_store_module, "EdgeStore", EmptyStore)
+    cache = ASTCache(str(tmp_path))
+    try:
+        assert cache.query_callees("missing") == []
+    finally:
+        cache.close()
+
+
 def test_ast_cache_get_call_edges_handles_missing_table(tmp_path: Path) -> None:
     cache = ASTCache(str(tmp_path))
     try:
@@ -430,6 +485,95 @@ def test_ast_cache_get_call_edges_handles_missing_table(tmp_path: Path) -> None:
         cache.get_conn().commit()
 
         assert cache.get_call_edges() == []
+        assert cache.has_call_edges() is False
+    finally:
+        cache.close()
+
+
+def test_ast_cache_resolve_only_refreshes_edge_store(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    cache = ASTCache(str(tmp_path))
+    try:
+        monkeypatch.setattr(
+            cache,
+            "_run_synapse_backfill",
+            lambda: {"updated": 1},
+        )
+        monkeypatch.setattr(
+            cache,
+            "_refresh_graph_edges_from_cache",
+            lambda: {"files": 2, "errors": 0},
+        )
+
+        stats = cache.index_project(resolve_only=True)
+
+        assert stats["mode_used"] == "resolve_only"
+        assert stats["synapse_backfill"] == {"updated": 1}
+        assert stats["edge_store_refresh"] == {"files": 2, "errors": 0}
+    finally:
+        cache.close()
+
+
+def test_ast_cache_post_index_backfill_swallows_edge_refresh_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    cache = ASTCache(str(tmp_path))
+    try:
+        monkeypatch.setattr(
+            cache,
+            "backfill_cross_file_edges",
+            lambda: {"processed": 1},
+        )
+        monkeypatch.setattr(cache, "_run_synapse_backfill", lambda: None)
+
+        def fail_refresh(file_paths: list[str] | None = None) -> dict[str, int]:
+            assert file_paths == ["sample.py"]
+            raise RuntimeError("refresh failed")
+
+        monkeypatch.setattr(cache, "_refresh_graph_edges_from_cache", fail_refresh)
+        stats: dict[str, Any] = {"files": [{"file": "sample.py", "status": "indexed"}]}
+
+        cache._post_index_backfill(stats)
+
+        assert stats["cross_file_backfill"] == {"processed": 1}
+        assert "edge_store_refresh" not in stats
+    finally:
+        cache.close()
+
+
+def test_ast_cache_refresh_edges_from_all_cached_rows_counts_json_errors(
+    tmp_path: Path,
+) -> None:
+    sample = tmp_path / "sample.py"
+    sample.write_text("def ok():\n    return 1\n", encoding="utf-8")
+    cache = ASTCache(str(tmp_path))
+    try:
+        assert cache.index_file(str(sample))["status"] == "indexed"
+        cache.get_conn().execute(
+            """INSERT OR REPLACE INTO ast_index
+               (file_path, content_hash, language, mtime_ns, file_size,
+                extractor_version, symbols_json, imports_json, structure_json,
+                indexed_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                "broken.py",
+                "hash",
+                "python",
+                0,
+                0,
+                0,
+                "{broken",
+                "[]",
+                "{}",
+                "now",
+            ),
+        )
+        cache.get_conn().commit()
+
+        assert cache._refresh_graph_edges_from_cache() == {"files": 1, "errors": 1}
     finally:
         cache.close()
 
@@ -503,6 +647,34 @@ def test_write_graph_edges_handles_empty_imports_and_missing_parent(
         assert store.get_inheritance_tree("Base")[0]["target_node_id"] == "class:Base"
     finally:
         conn.close()
+
+
+def test_graph_call_edge_row_mapping_supports_tuple_rows() -> None:
+    row = (
+        "caller",
+        "caller.py",
+        10,
+        "callee",
+        "pkg.callee",
+        20,
+        "caller.py",
+        "python",
+        "project",
+        "callee.py",
+    )
+
+    assert _row_to_dict(row, _GRAPH_CALL_EDGE_COLUMNS) == {
+        "caller_name": "caller",
+        "caller_file": "caller.py",
+        "caller_line": 10,
+        "callee_name": "callee",
+        "callee_full": "pkg.callee",
+        "callee_line": 20,
+        "file_path": "caller.py",
+        "language": "python",
+        "callee_resolution": "project",
+        "callee_resolved_file": "callee.py",
+    }
 
 
 def test_write_graph_edges_logs_operational_error(

--- a/tests/unit/test_temporal_change_impact.py
+++ b/tests/unit/test_temporal_change_impact.py
@@ -161,8 +161,8 @@ class TestHotZoneBumpsVerdict:
     @pytest.mark.asyncio
     async def test_hot_zone_bumps_verdict_to_caution(self, tmp_path, monkeypatch):
         """A symbol with ``mod_count_30d >= 5`` in a CHANGED file must:
-          * push the run's verdict to ``CAUTION``
-          * surface a ``risk_factors`` entry mentioning ``hot zone``.
+        * push the run's verdict to ``CAUTION``
+        * surface a ``risk_factors`` entry mentioning ``hot zone``.
         """
         repo = tmp_path / "repo"
         repo.mkdir()
@@ -263,15 +263,31 @@ _PROJECT_ROOT = str(Path(__file__).resolve().parent.parent.parent)
 
 
 @pytest.fixture
-def callees_tool():
-    return CodeGraphCalleesTool(_PROJECT_ROOT)
+def indexed_relation_project(tmp_path: Path) -> str:
+    (tmp_path / "helper.py").write_text(
+        "def helper():\n    return 1\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "worker.py").write_text(
+        "from helper import helper\n\n\ndef build():\n    return helper()\n",
+        encoding="utf-8",
+    )
+    cache = ASTCache(str(tmp_path))
+    try:
+        cache.index_project()
+    finally:
+        cache.close()
+    return str(tmp_path)
+
+
+@pytest.fixture
+def callees_tool(indexed_relation_project: str):
+    return CodeGraphCalleesTool(indexed_relation_project)
 
 
 class TestCalleesActivationFlag:
     @pytest.mark.asyncio
-    async def test_callees_tool_includes_activation_when_requested(
-        self, callees_tool
-    ):
+    async def test_callees_tool_includes_activation_when_requested(self, callees_tool):
         """With ``include_activation=True`` every callee entry must expose
         ``activation.mod_count_30d`` and ``activation.last_modified_at``."""
         result = await callees_tool.execute(
@@ -335,9 +351,7 @@ def test_module_imports_cleanly():
     """
     assert ASTCache is not None
     assert CodeGraphCalleesTool is not None
-    assert inspect.iscoroutinefunction(
-        CodeGraphCalleesTool(_PROJECT_ROOT).execute
-    )
+    assert inspect.iscoroutinefunction(CodeGraphCalleesTool(_PROJECT_ROOT).execute)
 
 
 # Ensure os imports used above don't trip linters/CI as "unused".

--- a/tree_sitter_analyzer/_ast_cache_indexer.py
+++ b/tree_sitter_analyzer/_ast_cache_indexer.py
@@ -121,11 +121,11 @@ def parse_and_write(
     )
     _write.write_call_edges(conn, rel_path, language, call_edges)
     cache._write_imports_for_file(conn, rel_path, language, imports)  # noqa: SLF001
+    cache._write_activation_for_file(conn, rel_path, inserted)  # noqa: SLF001
+    cache._resolve_call_edges_for_file(conn, rel_path)  # noqa: SLF001
     _write.write_graph_edges_for_file(
         conn, rel_path, language, symbols, imports, call_edges
     )
-    cache._write_activation_for_file(conn, rel_path, inserted)  # noqa: SLF001
-    cache._resolve_call_edges_for_file(conn, rel_path)  # noqa: SLF001
     conn.commit()
     return {
         "file": rel_path,

--- a/tree_sitter_analyzer/_ast_cache_write.py
+++ b/tree_sitter_analyzer/_ast_cache_write.py
@@ -280,6 +280,9 @@ def write_graph_edges_for_file(
                 edge.get("callee_line"),
                 metadata={
                     "language": language,
+                    "caller_name": caller_name,
+                    "caller_line": edge.get("caller_line", 0),
+                    "callee_name": callee_name,
                     "callee_full": edge.get("callee_full", ""),
                 },
             )
@@ -340,6 +343,6 @@ def write_graph_edges_for_file(
                 )
 
     try:
-        EdgeStore(conn).replace_edges_for_file(rel_path, edges)
+        EdgeStore(conn, ensure_schema=False).replace_edges_for_file(rel_path, edges)
     except sqlite3.OperationalError as exc:
         logger.debug("edge store write failed for %s: %s", rel_path, exc)

--- a/tree_sitter_analyzer/_ast_cache_write.py
+++ b/tree_sitter_analyzer/_ast_cache_write.py
@@ -256,6 +256,7 @@ def write_graph_edges_for_file(
         return
 
     symbol_items = symbols.get("symbols", [])
+    call_edges = _graph_call_edges(conn, rel_path, call_edges)
     class_nodes = {
         sym.get("name", ""): symbol_node(rel_path, sym.get("name", ""), sym.get("line"))
         for sym in symbol_items
@@ -271,7 +272,9 @@ def write_graph_edges_for_file(
             else file_node(rel_path)
         )
         callee_name = edge.get("callee_name", "")
-        target = symbol_node(rel_path, callee_name, edge.get("callee_line"))
+        resolved_file = str(edge.get("callee_resolved_file") or "")
+        target_file = resolved_file or rel_path
+        target = symbol_node(target_file, callee_name, edge.get("callee_line"))
         edges.append(
             Edge(
                 source,
@@ -284,6 +287,8 @@ def write_graph_edges_for_file(
                     "caller_line": edge.get("caller_line", 0),
                     "callee_name": callee_name,
                     "callee_full": edge.get("callee_full", ""),
+                    "callee_resolution": edge.get("callee_resolution", "unknown"),
+                    "callee_resolved_file": resolved_file,
                 },
             )
         )
@@ -346,3 +351,49 @@ def write_graph_edges_for_file(
         EdgeStore(conn, ensure_schema=False).replace_edges_for_file(rel_path, edges)
     except sqlite3.OperationalError as exc:
         logger.debug("edge store write failed for %s: %s", rel_path, exc)
+
+
+_GRAPH_CALL_EDGE_COLUMNS = (
+    "caller_name",
+    "caller_file",
+    "caller_line",
+    "callee_name",
+    "callee_full",
+    "callee_line",
+    "file_path",
+    "language",
+    "callee_resolution",
+    "callee_resolved_file",
+)
+
+_GRAPH_CALL_EDGE_SELECT = """
+SELECT caller_name, caller_file, caller_line, callee_name, callee_full,
+       callee_line, file_path, language, callee_resolution, callee_resolved_file
+FROM ast_call_edges
+WHERE file_path = ?
+ORDER BY id
+""".strip()
+
+
+def _graph_call_edges(
+    conn: sqlite3.Connection,
+    rel_path: str,
+    fallback: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Return resolved call rows for EdgeStore, falling back to extracted edges."""
+    try:
+        rows = conn.execute(
+            _GRAPH_CALL_EDGE_SELECT,
+            (rel_path,),
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return fallback
+    if not rows:
+        return fallback
+    return [_row_to_dict(row, _GRAPH_CALL_EDGE_COLUMNS) for row in rows]
+
+
+def _row_to_dict(row: Any, columns: tuple[str, ...]) -> dict[str, Any]:
+    if isinstance(row, sqlite3.Row):
+        return dict(row)
+    return dict(zip(columns, row, strict=False))

--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -504,9 +504,17 @@ class ASTCache:
         callee_file: str | None = None,
         max_depth: int = 1,
     ) -> list[dict[str, Any]]:
-        """SQL-native callers lookup via BFS on ast_call_edges."""
+        """SQL-native callers lookup via BFS on unified edges, with legacy fallback."""
         if callee_file:
             callee_file = callee_file.replace("\\", "/")
+        try:
+            from .graph.edge_store import EdgeKind, EdgeStore
+
+            store = EdgeStore(self._get_conn(), ensure_schema=False)
+            if store.has_edges(EdgeKind.CALLS):
+                return store.query_callers(callee_name, callee_file, max_depth)
+        except sqlite3.OperationalError:
+            pass
         try:
             return _bfs_callers_impl(
                 self._get_conn(), callee_name, callee_file, max_depth
@@ -520,9 +528,17 @@ class ASTCache:
         caller_file: str | None = None,
         max_depth: int = 1,
     ) -> list[dict[str, Any]]:
-        """SQL-native callees lookup via BFS on ast_call_edges."""
+        """SQL-native callees lookup via BFS on unified edges, with legacy fallback."""
         if caller_file:
             caller_file = caller_file.replace("\\", "/")
+        try:
+            from .graph.edge_store import EdgeKind, EdgeStore
+
+            store = EdgeStore(self._get_conn(), ensure_schema=False)
+            if store.has_edges(EdgeKind.CALLS):
+                return store.query_callees(caller_name, caller_file, max_depth)
+        except sqlite3.OperationalError:
+            pass
         try:
             return _bfs_callees_impl(
                 self._get_conn(), caller_name, caller_file, max_depth
@@ -538,7 +554,16 @@ class ASTCache:
                 .execute("SELECT COUNT(*) as c FROM ast_call_edges")
                 .fetchone()
             )
-            return bool(row["c"] > 0)
+            if bool(row["c"] > 0):
+                return True
+        except sqlite3.OperationalError:
+            pass
+        try:
+            from .graph.edge_store import EdgeKind, EdgeStore
+
+            return EdgeStore(self._get_conn(), ensure_schema=False).has_edges(
+                EdgeKind.CALLS
+            )
         except sqlite3.OperationalError:
             return False
 

--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -282,6 +282,7 @@ class ASTCache:
         """Index every source file under ``self.project_root``."""
         activation_enabled = _project_index_activation_enabled(include_activation)
         if resolve_only:
+            synapse = self._run_synapse_backfill()
             return {
                 "mode_used": "resolve_only",
                 "resolve_only": True,
@@ -290,7 +291,8 @@ class ASTCache:
                 "errors": 0,
                 "skipped": 0,
                 "files": [],
-                "synapse_backfill": self._run_synapse_backfill(),
+                "synapse_backfill": synapse,
+                "edge_store_refresh": self._refresh_graph_edges_from_cache(),
                 "activation_enabled": activation_enabled,
             }
         if force:
@@ -363,6 +365,60 @@ class ASTCache:
                 stats["synapse_backfill"] = synapse
         except Exception:
             logger.debug("synapse backfill failed", exc_info=True)
+        indexed_files = [
+            str(entry["file"])
+            for entry in stats.get("files", [])
+            if entry.get("status") == "indexed"
+        ]
+        try:
+            stats["edge_store_refresh"] = self._refresh_graph_edges_from_cache(
+                indexed_files
+            )
+        except Exception:
+            logger.debug("edge store refresh failed", exc_info=True)
+
+    def _refresh_graph_edges_from_cache(
+        self, file_paths: list[str] | None = None
+    ) -> dict[str, int]:
+        """Refresh unified EdgeStore rows from persisted AST cache rows."""
+        from . import _ast_cache_write as _write
+
+        conn = self._get_conn()
+        if file_paths is None:
+            rows = conn.execute(
+                "SELECT file_path, language, symbols_json, imports_json FROM ast_index"
+            ).fetchall()
+        else:
+            rows = [
+                row
+                for rel_path in file_paths
+                if (
+                    row := conn.execute(
+                        "SELECT file_path, language, symbols_json, imports_json "
+                        "FROM ast_index WHERE file_path = ?",
+                        (rel_path,),
+                    ).fetchone()
+                )
+                is not None
+            ]
+        refreshed = errors = 0
+        for row in rows:
+            try:
+                symbols = json.loads(row["symbols_json"] or "{}")
+                imports = json.loads(row["imports_json"] or "[]")
+                _write.write_graph_edges_for_file(
+                    conn,
+                    row["file_path"],
+                    row["language"],
+                    symbols,
+                    imports,
+                    [],
+                )
+                refreshed += 1
+            except (json.JSONDecodeError, sqlite3.OperationalError):
+                errors += 1
+        conn.commit()
+        return {"files": refreshed, "errors": errors}
 
     def _index_parallel(
         self, candidates: list[tuple[str, str]], workers: int

--- a/tree_sitter_analyzer/class_hierarchy.py
+++ b/tree_sitter_analyzer/class_hierarchy.py
@@ -98,7 +98,8 @@ class ClassHierarchy:
         if self._built:
             return
         self._load_from_cache()
-        self._build_edges()
+        if not self._build_edges_from_edge_store():
+            self._build_edges()
         self._built = True
 
     def _load_from_cache(self) -> None:
@@ -148,6 +149,51 @@ class ClassHierarchy:
 
         for key in self._children:
             self._children[key] = sorted(set(self._children[key]))
+
+    def _build_edges_from_edge_store(self) -> bool:
+        try:
+            from .graph.edge_store import EdgeKind, EdgeStore, parse_node_id
+
+            store = EdgeStore(self._cache.get_conn(), ensure_schema=False)
+            rows = store.conn.execute(
+                "SELECT * FROM edges WHERE kind IN (?, ?)",
+                (EdgeKind.EXTENDS.value, EdgeKind.IMPLEMENTS.value),
+            ).fetchall()
+        except Exception:
+            return False
+        if not rows:
+            return False
+
+        parent_map: dict[str, list[str]] = defaultdict(list)
+        children: dict[str, list[str]] = defaultdict(list)
+        for row in rows:
+            child = parse_node_id(row["source_node_id"]).name
+            parent = str(row["metadata"] or "")
+            try:
+                parent_meta = json.loads(row["metadata"] or "{}")
+                parent = str(parent_meta.get("parent") or "")
+            except (TypeError, json.JSONDecodeError):
+                parent = ""
+            if not parent:
+                parent = parse_node_id(row["target_node_id"]).name
+            if not child or not parent:
+                continue
+            parent_map[child].append(parent)
+            base = parent.rsplit(".", 1)[-1]
+            children[parent].append(child)
+            children[base].append(child)
+
+        if not parent_map:
+            return False
+        self._parent_map = defaultdict(
+            list,
+            {name: sorted(set(parents)) for name, parents in parent_map.items()},
+        )
+        self._children = defaultdict(
+            list,
+            {name: sorted(set(child_names)) for name, child_names in children.items()},
+        )
+        return True
 
     def subclasses_of(
         self,

--- a/tree_sitter_analyzer/graph/__init__.py
+++ b/tree_sitter_analyzer/graph/__init__.py
@@ -1,5 +1,5 @@
 """Graph storage primitives for cache-backed code relationships."""
 
-from .edge_store import Edge, EdgeKind, EdgeStore, Subgraph
+from .edge_store import Edge, EdgeKind, EdgeStore, NodeRef, Subgraph, parse_node_id
 
-__all__ = ["Edge", "EdgeKind", "EdgeStore", "Subgraph"]
+__all__ = ["Edge", "EdgeKind", "EdgeStore", "NodeRef", "Subgraph", "parse_node_id"]

--- a/tree_sitter_analyzer/graph/edge_store.py
+++ b/tree_sitter_analyzer/graph/edge_store.py
@@ -69,6 +69,15 @@ class Subgraph:
         }
 
 
+@dataclass(frozen=True)
+class NodeRef:
+    """Parsed node id components used by graph read paths."""
+
+    file_path: str
+    name: str
+    line: int
+
+
 EDGE_STORE_SCHEMA_STATEMENTS: tuple[str, ...] = (
     """
 CREATE TABLE IF NOT EXISTS edges (
@@ -93,14 +102,20 @@ EDGE_STORE_SCHEMA = ";\n\n".join(EDGE_STORE_SCHEMA_STATEMENTS) + ";"
 class EdgeStore:
     """CRUD and traversal API for the unified ``edges`` table."""
 
-    def __init__(self, conn_or_db_path: sqlite3.Connection | str) -> None:
+    def __init__(
+        self,
+        conn_or_db_path: sqlite3.Connection | str,
+        *,
+        ensure_schema: bool = True,
+    ) -> None:
         self._owns_conn = isinstance(conn_or_db_path, str)
         if self._owns_conn:
             self._conn = sqlite3.connect(str(conn_or_db_path))
             self._conn.row_factory = sqlite3.Row
         else:
             self._conn = cast(sqlite3.Connection, conn_or_db_path)
-        self.ensure_schema()
+        if ensure_schema:
+            self.ensure_schema()
 
     @property
     def conn(self) -> sqlite3.Connection:
@@ -146,6 +161,18 @@ class EdgeStore:
     def _commit_if_owned(self) -> None:
         if self._owns_conn:
             self._conn.commit()
+
+    def has_edges(self, kind: EdgeKind | str | None = None) -> bool:
+        """Return true when the store contains at least one edge."""
+        kind_value = _kind_value(kind)
+        if kind_value is None:
+            row = self._conn.execute("SELECT 1 FROM edges LIMIT 1").fetchone()
+        else:
+            row = self._conn.execute(
+                "SELECT 1 FROM edges WHERE kind = ? LIMIT 1",
+                (kind_value,),
+            ).fetchone()
+        return row is not None
 
     def get_edges(
         self,
@@ -222,6 +249,36 @@ class EdgeStore:
         ).fetchall()
         return [_edge_from_row(row).to_dict() for row in rows]
 
+    def query_callers(
+        self,
+        callee_name: str,
+        callee_file: str | None = None,
+        max_depth: int = 1,
+    ) -> list[dict[str, Any]]:
+        """Return callers of ``callee_name`` from unified CALLS edges."""
+        return _bfs_call_edges(
+            self._conn,
+            start_name=callee_name,
+            start_file=callee_file,
+            max_depth=max_depth,
+            direction="callers",
+        )
+
+    def query_callees(
+        self,
+        caller_name: str,
+        caller_file: str | None = None,
+        max_depth: int = 1,
+    ) -> list[dict[str, Any]]:
+        """Return callees of ``caller_name`` from unified CALLS edges."""
+        return _bfs_call_edges(
+            self._conn,
+            start_name=caller_name,
+            start_file=caller_file,
+            max_depth=max_depth,
+            direction="callees",
+        )
+
 
 def symbol_node(file_path: str, name: str, line: int | None = None) -> str:
     """Build a stable file-scoped symbol node id."""
@@ -241,6 +298,27 @@ def module_node(module_path: str) -> str:
 
 def class_node(class_name: str) -> str:
     return f"class:{class_name}"
+
+
+def parse_node_id(node_id: str) -> NodeRef:
+    """Parse a stable node id into file/name/line components."""
+    if node_id.startswith("file:"):
+        return NodeRef(file_path=node_id.removeprefix("file:"), name="", line=0)
+    if node_id.startswith("module:"):
+        return NodeRef(file_path="", name=node_id.removeprefix("module:"), line=0)
+    if node_id.startswith("class:"):
+        return NodeRef(file_path="", name=node_id.removeprefix("class:"), line=0)
+    parts = node_id.rsplit(":", 2)
+    if len(parts) == 3:
+        file_path, name, line_text = parts
+        try:
+            return NodeRef(file_path=file_path, name=name, line=int(line_text))
+        except ValueError:
+            pass
+    parts = node_id.rsplit(":", 1)
+    if len(parts) == 2:
+        return NodeRef(file_path=parts[0], name=parts[1], line=0)
+    return NodeRef(file_path="", name=node_id, line=0)
 
 
 def _kind_value(kind: EdgeKind | str | None) -> str | None:
@@ -312,3 +390,112 @@ def _edge_from_row(row: sqlite3.Row) -> Edge:
         provenance=row["provenance"] or "tree-sitter",
         metadata=metadata,
     )
+
+
+def _bfs_call_edges(
+    conn: sqlite3.Connection,
+    start_name: str,
+    start_file: str | None,
+    max_depth: int,
+    direction: str,
+) -> list[dict[str, Any]]:
+    if max_depth <= 0:
+        return []
+    start_file = start_file.replace("\\", "/") if start_file else None
+    visited: set[str] = set()
+    result: list[dict[str, Any]] = []
+    queue: deque[tuple[str, str | None, int]] = deque([(start_name, start_file, 0)])
+    while queue:
+        current_name, current_file, depth = queue.popleft()
+        if depth >= max_depth:
+            continue
+        rows = (
+            _direct_callers(conn, current_name, current_file)
+            if direction == "callers"
+            else _direct_callees(conn, current_name, current_file)
+        )
+        for row in rows:
+            edge = _edge_from_row(row)
+            source = parse_node_id(edge.source_node_id)
+            target = parse_node_id(edge.target_node_id)
+            key = (
+                f"{source.file_path}:{source.name}:{source.line}:"
+                f"{target.file_path}:{target.name}:{target.line}"
+            )
+            if key in visited:
+                continue
+            visited.add(key)
+            result.append(_call_edge_entry(edge, source, target, depth))
+            if max_depth > 1:
+                if direction == "callers":
+                    queue.append((source.name, source.file_path, depth + 1))
+                else:
+                    queue.append((target.name, None, depth + 1))
+    return result
+
+
+def _call_edges(conn: sqlite3.Connection) -> list[sqlite3.Row]:
+    return conn.execute(
+        "SELECT * FROM edges WHERE kind = ? ORDER BY source_node_id, target_node_id, line",
+        (EdgeKind.CALLS.value,),
+    ).fetchall()
+
+
+def _direct_callers(
+    conn: sqlite3.Connection,
+    callee_name: str,
+    callee_file: str | None,
+) -> list[sqlite3.Row]:
+    rows: list[sqlite3.Row] = []
+    for row in _call_edges(conn):
+        edge = _edge_from_row(row)
+        target = parse_node_id(edge.target_node_id)
+        if not _matches_callee(edge, target, callee_name):
+            continue
+        if callee_file and target.file_path != callee_file:
+            continue
+        rows.append(row)
+    return rows
+
+
+def _direct_callees(
+    conn: sqlite3.Connection,
+    caller_name: str,
+    caller_file: str | None,
+) -> list[sqlite3.Row]:
+    rows: list[sqlite3.Row] = []
+    bare = caller_name.split(".")[-1] if "." in caller_name else caller_name
+    for row in _call_edges(conn):
+        edge = _edge_from_row(row)
+        source = parse_node_id(edge.source_node_id)
+        if source.name not in {caller_name, bare}:
+            continue
+        if caller_file and source.file_path != caller_file:
+            continue
+        rows.append(row)
+    return rows
+
+
+def _matches_callee(edge: Edge, target: NodeRef, callee_name: str) -> bool:
+    names = {target.name, str(edge.metadata.get("callee_full", ""))}
+    return callee_name in names
+
+
+def _call_edge_entry(
+    edge: Edge,
+    source: NodeRef,
+    target: NodeRef,
+    depth: int,
+) -> dict[str, Any]:
+    resolved_file = str(edge.metadata.get("callee_resolved_file", ""))
+    return {
+        "caller_name": source.name,
+        "caller_file": source.file_path,
+        "caller_line": source.line,
+        "callee_name": target.name,
+        "callee_full": str(edge.metadata.get("callee_full", "")),
+        "callee_file": resolved_file or target.file_path,
+        "callee_resolved_file": resolved_file,
+        "callee_line": target.line or edge.line or 0,
+        "depth": depth + 1,
+    }

--- a/tree_sitter_analyzer/graph/edge_store.py
+++ b/tree_sitter_analyzer/graph/edge_store.py
@@ -447,15 +447,21 @@ def _direct_callers(
     callee_file: str | None,
 ) -> list[sqlite3.Row]:
     rows: list[sqlite3.Row] = []
+    fallback_rows: list[sqlite3.Row] = []
     for row in _call_edges(conn):
         edge = _edge_from_row(row)
+        source = parse_node_id(edge.source_node_id)
         target = parse_node_id(edge.target_node_id)
         if not _matches_callee(edge, target, callee_name):
             continue
-        if callee_file and target.file_path != callee_file:
+        if callee_file:
+            if target.file_path == callee_file:
+                rows.append(row)
+            elif source.file_path == callee_file:
+                fallback_rows.append(row)
             continue
         rows.append(row)
-    return rows
+    return rows or fallback_rows
 
 
 def _direct_callees(

--- a/tree_sitter_analyzer/mcp/tools/codegraph_sitemap_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_sitemap_tool.py
@@ -20,7 +20,6 @@ CodeGraph parity: equivalent to CodeGraph's code-map / sitemap view.
 from __future__ import annotations
 
 import json
-import os
 from collections import defaultdict
 from typing import Any
 
@@ -30,6 +29,10 @@ from ._response_builder import build_response
 from .base_tool import BaseMCPTool
 
 logger = setup_logger(__name__)
+
+
+def _path_parts(file_path: str) -> list[str]:
+    return [part for part in file_path.replace("\\", "/").split("/") if part]
 
 
 class CodeGraphSitemapTool(BaseMCPTool):
@@ -214,7 +217,7 @@ class CodeGraphSitemapTool(BaseMCPTool):
     def _build_full_map(self, files: list[dict[str, Any]]) -> dict[str, Any]:
         tree: dict[str, Any] = {}
         for f in files:
-            parts = f["file"].split(os.sep)
+            parts = _path_parts(f["file"])
             node = tree
             for part in parts[:-1]:
                 node = node.setdefault(part, {})
@@ -318,7 +321,7 @@ class CodeGraphSitemapTool(BaseMCPTool):
     def _build_module_metrics(self, files: list[dict[str, Any]]) -> dict[str, Any]:
         by_dir: dict[str, list[dict[str, Any]]] = defaultdict(list)
         for f in files:
-            dir_path = str(os.sep).join(f["file"].split(os.sep)[:-1]) or "."
+            dir_path = "/".join(_path_parts(f["file"])[:-1]) or "."
             by_dir[dir_path].append(f)
 
         modules: list[dict[str, Any]] = []

--- a/tree_sitter_analyzer/mcp/tools/codegraph_visualize_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_visualize_tool.py
@@ -17,7 +17,6 @@ READMEs, and any Markdown context without a running server.
 
 from __future__ import annotations
 
-from collections import defaultdict
 from typing import Any
 
 from ...call_graph import CallGraph
@@ -198,16 +197,10 @@ class CodeGraphVisualizeTool(BaseMCPTool):
     ) -> list[tuple[str, str, str, str]]:
         cg.build()
         edges: list[tuple[str, str, str, str]] = []
-        file_callers: dict[Any, list[Any]] = defaultdict(list)
-        file_callees: dict[Any, list[Any]] = defaultdict(list)
-        for func in cg.function_refs():
-            for caller in cg.caller_refs_of(func):
-                file_callers[func].append(caller)
-            for callee in cg.callee_refs_of(func):
-                file_callees[func].append(callee)
-
         seen: set[tuple[str, str]] = set()
         for func in cg.function_refs():
+            if len(seen) >= max_edges:
+                break
             for caller in cg.caller_refs_of(func):
                 pair = (
                     _safe_node_id(caller.name, caller.file_path),
@@ -223,6 +216,8 @@ class CodeGraphVisualizeTool(BaseMCPTool):
                             _short_label(func.name, func.file_path),
                         )
                     )
+                if len(seen) >= max_edges:
+                    break
         return edges
 
     def _edges_file(


### PR DESCRIPTION
## Summary\n- Route ASTCache callers/callees through EdgeStore CALLS edges with legacy ast_call_edges fallback.\n- Route class hierarchy edge construction through EdgeStore EXTENDS/IMPLEMENTS edges with symbols_json fallback.\n- Add EdgeStore call-query/read-path helpers and tests proving callers/callees and class hierarchy still work when legacy/symbol parent data is unavailable.\n\n## Verification\n- uv run --frozen pytest tests/integration/test_ast_cache_lifecycle.py tests/unit/cli/test_class_hierarchy_and_dep_matrix_cli.py tests/unit/mcp/test_ast_cache_watch_modes.py tests/unit/test_ast_cache.py tests/unit/test_ast_cache_bfs.py tests/unit/test_ast_cache_mode_used.py tests/unit/test_ast_cache_tool.py tests/unit/test_ast_cache_utf8_bug.py tests/unit/test_codegraph_class_hierarchy_tool.py -q\n- uv run --frozen pytest tests/unit/test_edge_store.py tests/unit/test_codegraph_class_hierarchy_tool.py tests/unit/test_callers_callees_tools.py tests/unit/test_ast_cache.py tests/integration/test_ast_cache_lifecycle.py tests/unit/cli/test_class_hierarchy_and_dep_matrix_cli.py tests/unit/mcp/test_ast_cache_watch_modes.py tests/unit/test_ast_cache_bfs.py tests/unit/test_ast_cache_mode_used.py tests/unit/test_ast_cache_tool.py tests/unit/test_ast_cache_utf8_bug.py --cov=tree_sitter_analyzer --cov-report=json -q\n- uv run --frozen python scripts/check_patch_coverage.py --base origin/develop --coverage-json coverage.json\n- uv run --frozen pytest -q\n\nCloses #245