### PR TITLE
feat(graph): resolve unresolved cross-file refs

### DIFF
--- a/tests/unit/test_unresolved_refs.py
+++ b/tests/unit/test_unresolved_refs.py
@@ -1,0 +1,585 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tree_sitter_analyzer import _ast_cache_unresolved as unresolved
+from tree_sitter_analyzer import ast_cache as ast_cache_module
+from tree_sitter_analyzer._ast_cache_schema import apply_migration_v9
+from tree_sitter_analyzer.ast_cache import ASTCache
+from tree_sitter_analyzer.class_hierarchy import ClassHierarchy
+from tree_sitter_analyzer.graph.edge_store import EdgeKind, symbol_node
+from tree_sitter_analyzer.mcp.utils import auto_index_guard
+
+
+def _write_project(root: Path) -> None:
+    pkg = root / "pkg"
+    other = pkg / "other"
+    other.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    (other / "__init__.py").write_text("", encoding="utf-8")
+    (pkg / "base.py").write_text(
+        "class LanguagePlugin:\n    pass\n",
+        encoding="utf-8",
+    )
+    (other / "base.py").write_text(
+        "class LanguagePlugin:\n    pass\n",
+        encoding="utf-8",
+    )
+    (pkg / "python_plugin.py").write_text(
+        "from .base import LanguagePlugin\n\n"
+        "class PythonPlugin(LanguagePlugin):\n"
+        "    pass\n",
+        encoding="utf-8",
+    )
+    (pkg / "alias_plugin.py").write_text(
+        "from .base import LanguagePlugin as LP\n\nclass AliasPlugin(LP):\n    pass\n",
+        encoding="utf-8",
+    )
+    (pkg / "helper.py").write_text(
+        "def helper():\n    return 'ok'\n",
+        encoding="utf-8",
+    )
+    (pkg / "service.py").write_text(
+        "from .helper import helper\n\ndef build():\n    return helper()\n",
+        encoding="utf-8",
+    )
+    (pkg / "missing.py").write_text(
+        "class Orphan(MissingBase):\n    pass\n",
+        encoding="utf-8",
+    )
+
+
+def _rows(
+    cache: ASTCache, sql: str, params: tuple[Any, ...] = ()
+) -> list[dict[str, Any]]:
+    return [dict(row) for row in cache.get_conn().execute(sql, params).fetchall()]
+
+
+def test_unresolved_refs_schema_created(tmp_path: Path) -> None:
+    cache = ASTCache(str(tmp_path))
+    try:
+        conn = cache.get_conn()
+        columns = {
+            row["name"]
+            for row in conn.execute("PRAGMA table_info(unresolved_refs)").fetchall()
+        }
+        assert {
+            "from_node_id",
+            "reference_name",
+            "reference_kind",
+            "file_path",
+            "line",
+            "candidates",
+            "resolved",
+        }.issubset(columns)
+        indexes = {
+            row["name"]
+            for row in conn.execute("PRAGMA index_list(unresolved_refs)").fetchall()
+        }
+        assert {"idx_unresolved_name", "idx_unresolved_resolved"}.issubset(indexes)
+        version = conn.execute(
+            "SELECT description FROM ast_schema_version WHERE version = 9"
+        ).fetchone()
+        assert version["description"] == "Unresolved reference backfill"
+    finally:
+        cache.close()
+
+
+def test_index_file_records_unresolved_refs_before_second_pass(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_project(tmp_path)
+    cache = ASTCache(str(tmp_path))
+    try:
+        assert (
+            cache.index_file(str(tmp_path / "pkg" / "base.py"))["status"] == "indexed"
+        )
+        assert (
+            cache.index_file(str(tmp_path / "pkg" / "alias_plugin.py"))["status"]
+            == "indexed"
+        )
+        row = (
+            cache.get_conn()
+            .execute(
+                """SELECT reference_name, reference_kind, resolved
+               FROM unresolved_refs
+               WHERE file_path = 'pkg/alias_plugin.py'"""
+            )
+            .fetchone()
+        )
+        assert dict(row) == {
+            "reference_name": "LP",
+            "reference_kind": EdgeKind.EXTENDS.value,
+            "resolved": 0,
+        }
+
+        calls: list[str] = []
+        real_parse = ast_cache_module.Parser.parse_file
+
+        def counting_parse(self: Any, *args: Any, **kwargs: Any) -> Any:
+            calls.append(str(args[0]) if args else "")
+            return real_parse(self, *args, **kwargs)
+
+        monkeypatch.setattr(ast_cache_module.Parser, "parse_file", counting_parse)
+
+        stats = cache.index_project(resolve_only=True)
+        assert stats["mode_used"] == "resolve_only"
+        assert calls == []
+        resolved = (
+            cache.get_conn()
+            .execute(
+                """SELECT resolved
+               FROM unresolved_refs
+               WHERE file_path = 'pkg/alias_plugin.py'"""
+            )
+            .fetchone()
+        )
+        assert resolved["resolved"] == 1
+    finally:
+        cache.close()
+
+
+def test_index_project_resolves_cross_file_extends_and_calls(tmp_path: Path) -> None:
+    _write_project(tmp_path)
+    cache = ASTCache(str(tmp_path))
+    try:
+        stats = cache.index_project(max_files=20, workers=0)
+        assert stats["indexed"] >= 7
+        assert stats["unresolved_refs_backfill"]["resolved"] >= 3
+
+        resolved_refs = _rows(
+            cache,
+            """SELECT reference_name, reference_kind, file_path, resolved
+               FROM unresolved_refs
+               WHERE resolved = 1
+               ORDER BY file_path, reference_name""",
+        )
+        assert {
+            (row["file_path"], row["reference_name"], row["reference_kind"])
+            for row in resolved_refs
+        }.issuperset(
+            {
+                ("pkg/alias_plugin.py", "LP", EdgeKind.EXTENDS.value),
+                ("pkg/python_plugin.py", "LanguagePlugin", EdgeKind.EXTENDS.value),
+                ("pkg/service.py", "helper", EdgeKind.CALLS.value),
+            }
+        )
+
+        conn = cache.get_conn()
+        alias_edge = conn.execute(
+            """SELECT target_node_id, metadata
+               FROM edges
+               WHERE source_node_id = ?
+                 AND target_node_id = ?
+                 AND kind = ?
+                 AND provenance = 'unresolved_refs'""",
+            (
+                symbol_node("pkg/alias_plugin.py", "AliasPlugin", 3),
+                symbol_node("pkg/base.py", "LanguagePlugin", 1),
+                EdgeKind.EXTENDS.value,
+            ),
+        ).fetchone()
+        assert alias_edge is not None
+        metadata = json.loads(alias_edge["metadata"])
+        assert metadata["parent"] == "LanguagePlugin"
+        assert metadata["parent_reference"] == "LP"
+
+        hierarchy = ClassHierarchy(cache)
+        subclass_names = {
+            item["name"] for item in hierarchy.subclasses_of("LanguagePlugin")
+        }
+        assert {"AliasPlugin", "PythonPlugin"}.issubset(subclass_names)
+        assert hierarchy.superclasses_of("AliasPlugin")[0]["file"] == "pkg/base.py"
+
+        callees = cache.query_callees("build", "pkg/service.py")
+        assert any(
+            item["callee_name"] == "helper"
+            and item["callee_resolved_file"] == "pkg/helper.py"
+            for item in callees
+        )
+        callers = cache.query_callers("helper", "pkg/helper.py")
+        assert any(
+            item["caller_name"] == "build" and item["caller_file"] == "pkg/service.py"
+            for item in callers
+        )
+    finally:
+        cache.close()
+
+
+def test_unknown_parent_stays_unresolved(tmp_path: Path) -> None:
+    (tmp_path / "missing.py").write_text(
+        "class Orphan(MissingBase):\n    pass\n",
+        encoding="utf-8",
+    )
+    cache = ASTCache(str(tmp_path))
+    try:
+        cache.index_project(max_files=5, workers=0)
+        row = (
+            cache.get_conn()
+            .execute(
+                """SELECT resolved, candidates
+               FROM unresolved_refs
+               WHERE reference_name = 'MissingBase'"""
+            )
+            .fetchone()
+        )
+        assert row["resolved"] == 0
+        assert json.loads(row["candidates"]) == []
+    finally:
+        cache.close()
+
+
+def test_autoindex_resolves_pending_refs_when_cache_is_already_warm(
+    tmp_path: Path,
+) -> None:
+    _write_project(tmp_path)
+    cache = ASTCache(str(tmp_path))
+    try:
+        assert (
+            cache.index_file(str(tmp_path / "pkg" / "base.py"))["status"] == "indexed"
+        )
+        assert (
+            cache.index_file(str(tmp_path / "pkg" / "python_plugin.py"))["status"]
+            == "indexed"
+        )
+    finally:
+        cache.close()
+
+    auto_index_guard.reset()
+    warmed = auto_index_guard.ensure_indexed(str(tmp_path), max_files=20)
+    try:
+        assert warmed is not None
+        row = (
+            warmed.get_conn()
+            .execute(
+                """SELECT resolved
+               FROM unresolved_refs
+               WHERE file_path = 'pkg/python_plugin.py'"""
+            )
+            .fetchone()
+        )
+        assert row["resolved"] == 1
+    finally:
+        if warmed is not None:
+            warmed.close()
+        auto_index_guard.reset()
+
+
+def test_class_hierarchy_cli_reads_resolved_cross_file_edge(tmp_path: Path) -> None:
+    _write_project(tmp_path)
+    cache = ASTCache(str(tmp_path))
+    try:
+        cache.index_project(max_files=20, workers=0)
+    finally:
+        cache.close()
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "tree_sitter_analyzer",
+            "--project-root",
+            str(tmp_path),
+            "--class-hierarchy",
+            "--class-hierarchy-mode",
+            "subclasses",
+            "--class-hierarchy-class",
+            "LanguagePlugin",
+            "--format",
+            "json",
+        ],
+        cwd=str(tmp_path),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads(completed.stdout)
+    assert {item["name"] for item in payload["subclasses"]}.issuperset(
+        {"AliasPlugin", "PythonPlugin"}
+    )
+
+
+def test_unresolved_refs_sqlite_error_paths_are_nonfatal(
+    tmp_path: Path,
+) -> None:
+    no_schema = sqlite3.connect(":memory:")
+    no_schema.row_factory = sqlite3.Row
+    try:
+        unresolved.write_unresolved_refs_for_file(
+            no_schema,
+            "broken.py",
+            "python",
+            {"symbols": []},
+            [],
+        )
+        assert unresolved.resolve_unresolved_refs(no_schema) is None
+        assert unresolved.pending_unresolved_count(no_schema) == 0
+        assert unresolved._call_rows(
+            no_schema,
+            "broken.py",
+            [{"caller_name": "caller", "callee_name": "target"}],
+        ) == [{"caller_name": "caller", "callee_name": "target"}]
+        assert (
+            unresolved._candidate_symbols(
+                no_schema, "broken.py", "Missing", EdgeKind.CALLS.value
+            )
+            == []
+        )
+        assert unresolved._reference_names(no_schema, "broken.py", "Alias") == ["Alias"]
+        assert unresolved._import_target_hints(no_schema, "broken.py", "Alias") == set()
+        assert unresolved._file_language(no_schema, "broken.py") == ""
+    finally:
+        no_schema.close()
+
+    bad_insert = sqlite3.connect(":memory:")
+    bad_insert.row_factory = sqlite3.Row
+    try:
+        bad_insert.execute("CREATE TABLE unresolved_refs (file_path TEXT)")
+        unresolved.write_unresolved_refs_for_file(
+            bad_insert,
+            "child.py",
+            "python",
+            {
+                "symbols": [
+                    {
+                        "kind": "class",
+                        "name": "Child",
+                        "line": 1,
+                        "parents": ["Base"],
+                    }
+                ]
+            },
+            [],
+        )
+    finally:
+        bad_insert.close()
+
+
+def test_unresolved_refs_row_and_commit_error_paths() -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE unresolved_refs (
+                id INTEGER PRIMARY KEY,
+                from_node_id TEXT NOT NULL,
+                reference_name TEXT NOT NULL,
+                reference_kind TEXT NOT NULL,
+                file_path TEXT NOT NULL,
+                line INTEGER,
+                candidates TEXT,
+                resolved INTEGER DEFAULT 0
+            );
+            CREATE TABLE ast_symbol_rows (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                file_path TEXT NOT NULL,
+                language TEXT NOT NULL,
+                line INTEGER NOT NULL
+            );
+            CREATE TABLE ast_index (
+                file_path TEXT NOT NULL,
+                language TEXT NOT NULL
+            );
+            """
+        )
+        conn.execute(
+            """INSERT INTO unresolved_refs
+               (id, from_node_id, reference_name, reference_kind, file_path, line)
+               VALUES (1, 'caller.py:caller:1', 'target', 'calls', 'caller.py', 2)"""
+        )
+        conn.execute(
+            """INSERT INTO ast_symbol_rows
+               (id, name, kind, file_path, language, line)
+               VALUES (10, 'target', 'function', 'target.py', 'python', 1)"""
+        )
+        stats = unresolved.resolve_unresolved_refs(conn)
+        assert stats == {"total": 1, "resolved": 0, "unchanged": 0, "errors": 1}
+    finally:
+        conn.close()
+
+    class EmptyRows:
+        def fetchall(self) -> list[Any]:
+            return []
+
+    class CommitFails:
+        def execute(self, *_args: Any, **_kwargs: Any) -> EmptyRows:
+            return EmptyRows()
+
+        def commit(self) -> None:
+            raise sqlite3.OperationalError("commit failed")
+
+    assert unresolved.resolve_unresolved_refs(CommitFails()) == {
+        "total": 0,
+        "resolved": 0,
+        "unchanged": 0,
+        "errors": 0,
+    }
+
+
+def test_unresolved_refs_helper_branches(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert (
+        unresolved._parent_refs(
+            "child.py",
+            [
+                {"kind": "class", "parents": ["Base"]},
+                {"kind": "class", "name": "LocalChild", "line": 2, "parents": ["Base"]},
+            ],
+            {"Base"},
+        )
+        == []
+    )
+    assert (
+        unresolved._call_refs(
+            sqlite3.connect(":memory:"),
+            "caller.py",
+            "python",
+            [
+                {
+                    "caller_name": "caller",
+                    "caller_line": 1,
+                    "callee_name": "target",
+                    "callee_line": 2,
+                    "callee_resolution": "project",
+                    "callee_resolved_file": "target.py",
+                },
+                {
+                    "caller_name": "caller",
+                    "caller_line": 1,
+                    "callee_name": "local_target",
+                    "callee_line": 3,
+                },
+                {
+                    "caller_name": "caller",
+                    "caller_line": 1,
+                    "callee_name": "print",
+                    "callee_line": 4,
+                },
+            ],
+            {"local_target"},
+        )
+        == []
+    )
+    candidate = {"node_id": "same.py:Only:1", "file_path": "same.py", "line": 1}
+    assert (
+        unresolved._choose_candidate(
+            sqlite3.connect(":memory:"),
+            {
+                "file_path": "same.py",
+                "from_node_id": "same.py:Only:1",
+                "reference_name": "Only",
+            },
+            [candidate],
+        )
+        is None
+    )
+    unresolved._update_call_edge_resolution(
+        sqlite3.connect(":memory:"),
+        {
+            "from_node_id": "file:caller.py",
+            "reference_kind": EdgeKind.CALLS.value,
+            "file_path": "caller.py",
+            "reference_name": "target",
+            "line": 0,
+        },
+        {"id": 1, "file_path": "target.py"},
+    )
+    unresolved._update_call_edge_resolution(
+        sqlite3.connect(":memory:"),
+        {
+            "from_node_id": "caller.py:caller:1",
+            "reference_kind": EdgeKind.CALLS.value,
+            "file_path": "caller.py",
+            "reference_name": "target",
+            "line": 2,
+        },
+        {"id": 1, "file_path": "target.py"},
+    )
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    try:
+        conn.execute(
+            """CREATE TABLE ast_imports (
+                file_path TEXT,
+                module_path TEXT,
+                local_name TEXT,
+                alias_of TEXT
+            )"""
+        )
+        conn.execute(
+            """INSERT INTO ast_imports
+               (file_path, module_path, local_name, alias_of)
+               VALUES ('caller.py', '.base', 'Other', '')"""
+        )
+        assert unresolved._import_target_hints(conn, "caller.py", "Base") == set()
+    finally:
+        conn.close()
+
+    assert unresolved._module_path_candidates("") == set()
+    assert unresolved._matches_import_hint("pkg/base.py", set()) is False
+    assert unresolved._file_language(sqlite3.connect(":memory:"), "missing.py") == ""
+    assert unresolved._call_is_resolved({"callee_resolution": "stdlib"}) is True
+    assert unresolved._is_obvious_external("javascript", "console.log") is False
+
+    assert unresolved._line("not-an-int") == 0
+    assert unresolved._row_to_dict(("value",), ("name",)) == {"name": "value"}
+
+
+def test_unresolved_refs_migration_and_orchestration_error_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    broken_schema = sqlite3.connect(":memory:")
+    try:
+        broken_schema.execute("CREATE TABLE unresolved_refs (id INTEGER)")
+        recorded: list[int] = []
+        apply_migration_v9(
+            broken_schema,
+            lambda _conn, version, _description: recorded.append(version),
+        )
+        assert recorded == []
+    finally:
+        broken_schema.close()
+
+    cache = ASTCache(str(tmp_path))
+    try:
+        monkeypatch.setattr(cache, "backfill_cross_file_edges", lambda: {})
+        monkeypatch.setattr(cache, "_run_synapse_backfill", lambda: None)
+        monkeypatch.setattr(cache, "_refresh_graph_edges_from_cache", lambda _files: {})
+
+        def fail_unresolved() -> dict[str, int]:
+            raise RuntimeError("nope")
+
+        monkeypatch.setattr(cache, "_run_unresolved_refs_backfill", fail_unresolved)
+        stats: dict[str, Any] = {"files": []}
+        cache._post_index_backfill(stats)
+        assert "unresolved_refs_backfill" not in stats
+
+        monkeypatch.setattr(cache, "_run_unresolved_refs_backfill", lambda: None)
+        stats = {"files": []}
+        cache._post_index_backfill(stats)
+        assert "unresolved_refs_backfill" not in stats
+    finally:
+        cache.close()
+
+    clean_cache = ASTCache(str(tmp_path))
+    try:
+        auto_index_guard._resolve_pending_unresolved_refs(clean_cache)
+    finally:
+        clean_cache.close()
+
+    class BrokenCache:
+        def get_conn(self) -> None:
+            raise RuntimeError("connection failed")
+
+    auto_index_guard._resolve_pending_unresolved_refs(BrokenCache())

--- a/tree_sitter_analyzer/_ast_cache_indexer.py
+++ b/tree_sitter_analyzer/_ast_cache_indexer.py
@@ -120,6 +120,11 @@ def parse_and_write(
         else []
     )
     _write.write_call_edges(conn, rel_path, language, call_edges)
+    from . import _ast_cache_unresolved as _unresolved
+
+    _unresolved.write_unresolved_refs_for_file(
+        conn, rel_path, language, symbols, call_edges
+    )
     cache._write_imports_for_file(conn, rel_path, language, imports)  # noqa: SLF001
     cache._write_activation_for_file(conn, rel_path, inserted)  # noqa: SLF001
     cache._resolve_call_edges_for_file(conn, rel_path)  # noqa: SLF001
@@ -236,6 +241,11 @@ def insert_index_row(
     imports_list = json.loads(r.get("imports_json", "[]"))
     cache._write_imports_for_file(conn, rel_path, r["language"], imports_list)  # noqa: SLF001
     symbols = json.loads(r.get("symbols_json", "{}"))
+    from . import _ast_cache_unresolved as _unresolved
+
+    _unresolved.write_unresolved_refs_for_file(
+        conn, rel_path, r["language"], symbols, call_edges
+    )
     _write.write_graph_edges_for_file(
         conn, rel_path, r["language"], symbols, imports_list, call_edges
     )

--- a/tree_sitter_analyzer/_ast_cache_schema.py
+++ b/tree_sitter_analyzer/_ast_cache_schema.py
@@ -278,6 +278,37 @@ def apply_migration_v8(conn: sqlite3.Connection, record_fn: RecordFn) -> None:
         pass
 
 
+SCHEMA_V9_UNRESOLVED_REFS = """
+CREATE TABLE IF NOT EXISTS unresolved_refs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    from_node_id TEXT NOT NULL,
+    reference_name TEXT NOT NULL,
+    reference_kind TEXT NOT NULL,
+    file_path TEXT NOT NULL,
+    line INTEGER,
+    candidates TEXT,
+    resolved INTEGER DEFAULT 0,
+    UNIQUE(from_node_id, reference_name, reference_kind, line)
+);
+
+CREATE INDEX IF NOT EXISTS idx_unresolved_name
+    ON unresolved_refs(reference_name);
+
+CREATE INDEX IF NOT EXISTS idx_unresolved_resolved
+    ON unresolved_refs(resolved);
+"""
+
+
+def apply_migration_v9(conn: sqlite3.Connection, record_fn: RecordFn) -> None:
+    """Create ``unresolved_refs`` table (v9 — cross-file second pass)."""
+    try:
+        conn.executescript(SCHEMA_V9_UNRESOLVED_REFS)
+        record_fn(conn, 9, "Unresolved reference backfill")
+        conn.commit()
+    except sqlite3.OperationalError:
+        pass
+
+
 # ---------------------------------------------------------------------------
 # Schema DDL constants V1 and V2 (moved from ast_cache.py)
 # ---------------------------------------------------------------------------
@@ -427,6 +458,22 @@ EXPECTED_SCHEMA_VERSIONS: list[Any] = [
                 "line",
                 "provenance",
                 "metadata",
+            ],
+        },
+    ),
+    (
+        9,
+        "Unresolved reference backfill",
+        {
+            "tables": ["unresolved_refs"],
+            "unresolved_refs_columns": [
+                "from_node_id",
+                "reference_name",
+                "reference_kind",
+                "file_path",
+                "line",
+                "candidates",
+                "resolved",
             ],
         },
     ),

--- a/tree_sitter_analyzer/_ast_cache_unresolved.py
+++ b/tree_sitter_analyzer/_ast_cache_unresolved.py
@@ -1,0 +1,527 @@
+"""Second-pass unresolved reference handling for ASTCache."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sqlite3
+from typing import Any
+
+from .graph.edge_store import Edge, EdgeKind, EdgeStore, parse_node_id, symbol_node
+
+logger = logging.getLogger(__name__)
+
+_CALL_ROW_COLUMNS = (
+    "caller_name",
+    "caller_file",
+    "caller_line",
+    "callee_name",
+    "callee_full",
+    "callee_line",
+    "file_path",
+    "language",
+    "callee_resolution",
+    "callee_resolved_file",
+)
+
+
+def write_unresolved_refs_for_file(
+    conn: sqlite3.Connection,
+    rel_path: str,
+    language: str,
+    symbols: dict[str, Any],
+    call_edges: list[dict[str, Any]],
+) -> None:
+    """Refresh unresolved_refs emitted while indexing one file."""
+    try:
+        conn.execute("DELETE FROM unresolved_refs WHERE file_path = ?", (rel_path,))
+    except sqlite3.OperationalError as exc:
+        logger.debug("unresolved_refs cleanup failed for %s: %s", rel_path, exc)
+        return
+
+    symbol_items = symbols.get("symbols", [])
+    local_classes = _local_names(symbol_items, {"class"})
+    local_callables = _local_names(symbol_items, {"class", "function", "method"})
+    rows: list[tuple[str, str, str, str, int, str, int]] = []
+    rows.extend(_parent_refs(rel_path, symbol_items, local_classes))
+    rows.extend(
+        _call_refs(
+            conn,
+            rel_path,
+            language,
+            call_edges,
+            local_callables,
+        )
+    )
+    if not rows:
+        return
+    try:
+        conn.executemany(
+            """INSERT OR REPLACE INTO unresolved_refs
+               (from_node_id, reference_name, reference_kind, file_path,
+                line, candidates, resolved)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            rows,
+        )
+    except sqlite3.OperationalError as exc:
+        logger.debug("unresolved_refs insert failed for %s: %s", rel_path, exc)
+
+
+def resolve_unresolved_refs(conn: sqlite3.Connection) -> dict[str, int] | None:
+    """Resolve pending unresolved_refs rows into unified EdgeStore edges."""
+    try:
+        rows = conn.execute(
+            """SELECT id, from_node_id, reference_name, reference_kind,
+                      file_path, line
+               FROM unresolved_refs
+               WHERE resolved = 0
+               ORDER BY id"""
+        ).fetchall()
+    except sqlite3.OperationalError as exc:
+        logger.debug("unresolved_refs select failed: %s", exc)
+        return None
+
+    total = len(rows)
+    resolved = unchanged = errors = 0
+    store = EdgeStore(conn, ensure_schema=False)
+    for row in rows:
+        try:
+            row_dict = dict(row)
+            candidates = _candidate_symbols(
+                conn,
+                str(row_dict["file_path"]),
+                str(row_dict["reference_name"]),
+                str(row_dict["reference_kind"]),
+            )
+            chosen = _choose_candidate(conn, row_dict, candidates)
+            payload = _candidate_payload(candidates)
+            if chosen is None:
+                unchanged += 1
+                conn.execute(
+                    "UPDATE unresolved_refs SET candidates = ? WHERE id = ?",
+                    (json.dumps(payload, ensure_ascii=False), row_dict["id"]),
+                )
+                continue
+            edge = _resolved_edge(conn, row_dict, chosen, len(candidates))
+            store.upsert_edges([edge])
+            _update_call_edge_resolution(conn, row_dict, chosen)
+            conn.execute(
+                "UPDATE unresolved_refs SET candidates = ?, resolved = 1 WHERE id = ?",
+                (json.dumps(payload, ensure_ascii=False), row_dict["id"]),
+            )
+            resolved += 1
+        except (sqlite3.OperationalError, TypeError, ValueError) as exc:
+            logger.debug("unresolved_refs row failed: %s", exc)
+            errors += 1
+    try:
+        conn.commit()
+    except sqlite3.OperationalError:
+        pass
+    return {
+        "total": total,
+        "resolved": resolved,
+        "unchanged": unchanged,
+        "errors": errors,
+    }
+
+
+def pending_unresolved_count(conn: sqlite3.Connection) -> int:
+    """Return unresolved_refs rows still awaiting a second-pass attempt."""
+    try:
+        row = conn.execute(
+            "SELECT COUNT(*) AS c FROM unresolved_refs WHERE resolved = 0"
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return 0
+    return int(row["c"] if isinstance(row, sqlite3.Row) else row[0])
+
+
+def _parent_refs(
+    rel_path: str,
+    symbol_items: list[dict[str, Any]],
+    local_classes: set[str],
+) -> list[tuple[str, str, str, str, int, str, int]]:
+    rows: list[tuple[str, str, str, str, int, str, int]] = []
+    for sym in symbol_items:
+        if sym.get("kind") != "class" or not sym.get("parents"):
+            continue
+        class_name = str(sym.get("name") or "")
+        if not class_name:
+            continue
+        line = _line(sym.get("line"))
+        source = symbol_node(rel_path, class_name, line)
+        for parent in sym.get("parents", []):
+            parent_name = str(parent).strip()
+            base_parent = _base_name(parent_name)
+            if (
+                not parent_name
+                or parent_name in local_classes
+                or base_parent in local_classes
+            ):
+                continue
+            rows.append(
+                (
+                    source,
+                    parent_name,
+                    EdgeKind.EXTENDS.value,
+                    rel_path,
+                    line,
+                    "[]",
+                    0,
+                )
+            )
+    return rows
+
+
+def _call_refs(
+    conn: sqlite3.Connection,
+    rel_path: str,
+    language: str,
+    fallback_edges: list[dict[str, Any]],
+    local_callables: set[str],
+) -> list[tuple[str, str, str, str, int, str, int]]:
+    rows: list[tuple[str, str, str, str, int, str, int]] = []
+    for edge in _call_rows(conn, rel_path, fallback_edges):
+        if _call_is_resolved(edge):
+            continue
+        callee_name = str(edge.get("callee_name") or "").strip()
+        base = _base_name(callee_name)
+        if not callee_name or base in local_callables or callee_name in local_callables:
+            continue
+        if _is_obvious_external(language, callee_name):
+            continue
+        caller_name = str(edge.get("caller_name") or "")
+        caller_line = _line(edge.get("caller_line"))
+        source = symbol_node(rel_path, caller_name, caller_line)
+        ref_line = _line(edge.get("callee_line")) or caller_line
+        rows.append(
+            (
+                source,
+                callee_name,
+                EdgeKind.CALLS.value,
+                rel_path,
+                ref_line,
+                "[]",
+                0,
+            )
+        )
+    return rows
+
+
+def _call_rows(
+    conn: sqlite3.Connection,
+    rel_path: str,
+    fallback_edges: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    try:
+        rows = conn.execute(
+            """SELECT caller_name, caller_file, caller_line, callee_name,
+                      callee_full, callee_line, file_path, language,
+                      callee_resolution, callee_resolved_file
+               FROM ast_call_edges
+               WHERE file_path = ?
+               ORDER BY id""",
+            (rel_path,),
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return [dict(edge) for edge in fallback_edges]
+    if not rows:
+        return [dict(edge) for edge in fallback_edges]
+    return [_row_to_dict(row, _CALL_ROW_COLUMNS) for row in rows]
+
+
+def _candidate_symbols(
+    conn: sqlite3.Connection,
+    source_file: str,
+    reference_name: str,
+    reference_kind: str,
+) -> list[dict[str, Any]]:
+    names = _reference_names(conn, source_file, reference_name)
+    kinds = (
+        ["class"]
+        if reference_kind in {EdgeKind.EXTENDS.value, EdgeKind.IMPLEMENTS.value}
+        else ["function", "method", "class"]
+    )
+    rows: list[Any] = []
+    try:
+        for name in names:
+            for kind in kinds:
+                rows.extend(
+                    conn.execute(
+                        """SELECT id, name, kind, file_path, language, line
+                           FROM ast_symbol_rows
+                           WHERE name = ? AND kind = ?
+                           ORDER BY file_path, line, name""",
+                        (name, kind),
+                    ).fetchall()
+                )
+    except sqlite3.OperationalError as exc:
+        logger.debug("candidate symbol lookup failed: %s", exc)
+        return []
+    candidates: list[dict[str, Any]] = []
+    for row in rows:
+        item = _row_to_dict(
+            row, ("id", "name", "kind", "file_path", "language", "line")
+        )
+        item["line"] = _line(item.get("line"))
+        item["node_id"] = symbol_node(
+            str(item["file_path"]),
+            str(item["name"]),
+            int(item["line"]),
+        )
+        candidates.append(item)
+    return candidates
+
+
+def _reference_names(
+    conn: sqlite3.Connection,
+    source_file: str,
+    reference_name: str,
+) -> list[str]:
+    base = _base_name(reference_name)
+    names = [reference_name, base]
+    try:
+        rows = conn.execute(
+            """SELECT local_name, alias_of
+               FROM ast_imports
+               WHERE file_path = ?""",
+            (source_file,),
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return _unique(names)
+    for row in rows:
+        item = _row_to_dict(row, ("local_name", "alias_of"))
+        local_name = str(item.get("local_name") or "")
+        alias_of = str(item.get("alias_of") or "")
+        if local_name in {reference_name, base} and alias_of:
+            names.extend([alias_of, _base_name(alias_of)])
+    return _unique(names)
+
+
+def _choose_candidate(
+    conn: sqlite3.Connection,
+    row: dict[str, Any],
+    candidates: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    if not candidates:
+        return None
+    source_file = str(row["file_path"])
+    source_node = str(row["from_node_id"])
+    reference_name = str(row["reference_name"])
+    base = _base_name(reference_name)
+    import_hints = _import_target_hints(conn, source_file, reference_name)
+    eligible = [item for item in candidates if item.get("node_id") != source_node]
+    if not eligible:
+        return None
+    source_dir = os.path.dirname(source_file)
+
+    def score(item: dict[str, Any]) -> tuple[int, int, int, int, str, int]:
+        file_path = str(item["file_path"])
+        imported = 0 if _matches_import_hint(file_path, import_hints) else 1
+        same_file = 0 if file_path == source_file else 1
+        same_dir = 0 if os.path.dirname(file_path) == source_dir else 1
+        exact = 0 if item["name"] in {reference_name, base} else 1
+        return (imported, same_file, same_dir, exact, file_path, int(item["line"]))
+
+    return sorted(eligible, key=score)[0]
+
+
+def _resolved_edge(
+    conn: sqlite3.Connection,
+    row: dict[str, Any],
+    candidate: dict[str, Any],
+    candidate_count: int,
+) -> Edge:
+    kind = str(row["reference_kind"])
+    reference_name = str(row["reference_name"])
+    resolved_file = str(candidate["file_path"])
+    metadata: dict[str, Any] = {
+        "language": _file_language(conn, str(row["file_path"])),
+        "reference_name": reference_name,
+        "reference_kind": kind,
+        "resolved_file": resolved_file,
+        "resolved_name": str(candidate["name"]),
+        "resolved_symbol_id": int(candidate["id"]),
+        "resolution": "unresolved_refs",
+        "candidate_count": candidate_count,
+    }
+    if kind in {EdgeKind.EXTENDS.value, EdgeKind.IMPLEMENTS.value}:
+        metadata["parent"] = str(candidate["name"])
+        metadata["parent_reference"] = reference_name
+    if kind == EdgeKind.CALLS.value:
+        metadata.update(
+            {
+                "callee_name": str(candidate["name"]),
+                "callee_full": reference_name,
+                "callee_resolution": "project",
+                "callee_resolved_file": resolved_file,
+            }
+        )
+    return Edge(
+        str(row["from_node_id"]),
+        str(candidate["node_id"]),
+        kind,
+        _line(row.get("line")),
+        provenance="unresolved_refs",
+        metadata=metadata,
+    )
+
+
+def _update_call_edge_resolution(
+    conn: sqlite3.Connection,
+    row: dict[str, Any],
+    candidate: dict[str, Any],
+) -> None:
+    if row["reference_kind"] != EdgeKind.CALLS.value:
+        return
+    source = parse_node_id(str(row["from_node_id"]))
+    if not source.name:
+        return
+    line = _line(row.get("line"))
+    try:
+        conn.execute(
+            """UPDATE ast_call_edges
+               SET callee_symbol_id = ?, callee_resolution = 'project',
+                   callee_resolved_file = ?
+               WHERE file_path = ?
+                 AND caller_name = ?
+                 AND caller_line = ?
+                 AND callee_name = ?
+                 AND (callee_line = ? OR ? = 0)""",
+            (
+                int(candidate["id"]),
+                str(candidate["file_path"]),
+                str(row["file_path"]),
+                source.name,
+                source.line,
+                str(row["reference_name"]),
+                line,
+                line,
+            ),
+        )
+    except sqlite3.OperationalError as exc:
+        logger.debug("call edge unresolved_refs update failed: %s", exc)
+
+
+def _candidate_payload(candidates: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            "node_id": str(item["node_id"]),
+            "name": str(item["name"]),
+            "kind": str(item["kind"]),
+            "file_path": str(item["file_path"]),
+            "line": int(item["line"]),
+        }
+        for item in candidates[:20]
+    ]
+
+
+def _import_target_hints(
+    conn: sqlite3.Connection,
+    source_file: str,
+    reference_name: str,
+) -> set[str]:
+    base = _base_name(reference_name)
+    try:
+        rows = conn.execute(
+            """SELECT module_path, local_name, alias_of
+               FROM ast_imports
+               WHERE file_path = ?""",
+            (source_file,),
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return set()
+    hints: set[str] = set()
+    for row in rows:
+        item = _row_to_dict(row, ("module_path", "local_name", "alias_of"))
+        local_name = str(item.get("local_name") or "")
+        alias_of = str(item.get("alias_of") or "")
+        if local_name not in {reference_name, base} and alias_of not in {
+            reference_name,
+            base,
+        }:
+            continue
+        hints.update(_module_path_candidates(str(item.get("module_path") or "")))
+    return hints
+
+
+def _module_path_candidates(module_path: str) -> set[str]:
+    clean = module_path.lstrip(".").replace(".", "/").strip("/")
+    if not clean:
+        return set()
+    return {f"{clean}.py", f"{clean}/__init__.py"}
+
+
+def _matches_import_hint(file_path: str, hints: set[str]) -> bool:
+    if not hints:
+        return False
+    return any(file_path == hint or file_path.endswith(f"/{hint}") for hint in hints)
+
+
+def _file_language(conn: sqlite3.Connection, file_path: str) -> str:
+    try:
+        row = conn.execute(
+            "SELECT language FROM ast_index WHERE file_path = ?",
+            (file_path,),
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return ""
+    if row is None:
+        return ""
+    return str(row["language"] if isinstance(row, sqlite3.Row) else row[0])
+
+
+def _call_is_resolved(edge: dict[str, Any]) -> bool:
+    resolution = str(edge.get("callee_resolution") or "unknown")
+    resolved_file = str(edge.get("callee_resolved_file") or "")
+    if resolution == "stdlib":
+        return True
+    return resolution in {"local", "project"} and bool(resolved_file)
+
+
+def _is_obvious_external(language: str, callee_name: str) -> bool:
+    if language != "python":
+        return False
+    try:
+        from .synapse_resolver import BUILTINS_PY, STDLIB_NAMES_PY
+    except Exception:  # pragma: no cover
+        return False
+    base = _base_name(callee_name)
+    qualifier = callee_name.split(".", 1)[0]
+    return base in BUILTINS_PY or qualifier in STDLIB_NAMES_PY
+
+
+def _local_names(symbol_items: list[dict[str, Any]], kinds: set[str]) -> set[str]:
+    return {
+        str(sym.get("name") or "")
+        for sym in symbol_items
+        if sym.get("kind") in kinds and sym.get("name")
+    }
+
+
+def _base_name(name: str) -> str:
+    return name.rsplit(".", 1)[-1]
+
+
+def _line(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _unique(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for value in values:
+        if value and value not in seen:
+            seen.add(value)
+            out.append(value)
+    return out
+
+
+def _row_to_dict(row: Any, columns: tuple[str, ...]) -> dict[str, Any]:
+    if isinstance(row, sqlite3.Row):
+        return dict(row)
+    return dict(zip(columns, row, strict=False))

--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -44,6 +44,7 @@ from ._ast_cache_schema import (
     apply_migration_v6 as _apply_migration_v6,
     apply_migration_v7 as _apply_migration_v7,
     apply_migration_v8 as _apply_migration_v8,
+    apply_migration_v9 as _apply_migration_v9,
     backfill_schema_version_row as _backfill_schema_version_row,
     check_schema_expectations as _check_schema_expectations,
     clear_activation_for_file as _clear_activation_for_file_fn,
@@ -136,6 +137,7 @@ class ASTCache:
             (6, _apply_migration_v6),
             (7, _apply_migration_v7),
             (8, _apply_migration_v8),
+            (9, _apply_migration_v9),
         ]
         self._fts5_available = _schema_init_db(
             conn, self._fts5_available, _has_fts5, migrations
@@ -283,6 +285,8 @@ class ASTCache:
         activation_enabled = _project_index_activation_enabled(include_activation)
         if resolve_only:
             synapse = self._run_synapse_backfill()
+            edge_store_refresh = self._refresh_graph_edges_from_cache()
+            unresolved = self._run_unresolved_refs_backfill()
             return {
                 "mode_used": "resolve_only",
                 "resolve_only": True,
@@ -292,7 +296,8 @@ class ASTCache:
                 "skipped": 0,
                 "files": [],
                 "synapse_backfill": synapse,
-                "edge_store_refresh": self._refresh_graph_edges_from_cache(),
+                "edge_store_refresh": edge_store_refresh,
+                "unresolved_refs_backfill": unresolved,
                 "activation_enabled": activation_enabled,
             }
         if force:
@@ -376,6 +381,12 @@ class ASTCache:
             )
         except Exception:
             logger.debug("edge store refresh failed", exc_info=True)
+        try:
+            unresolved = self._run_unresolved_refs_backfill()
+            if unresolved is not None:
+                stats["unresolved_refs_backfill"] = unresolved
+        except Exception:
+            logger.debug("unresolved refs backfill failed", exc_info=True)
 
     def _refresh_graph_edges_from_cache(
         self, file_paths: list[str] | None = None
@@ -419,6 +430,12 @@ class ASTCache:
                 errors += 1
         conn.commit()
         return {"files": refreshed, "errors": errors}
+
+    def _run_unresolved_refs_backfill(self) -> dict[str, int] | None:
+        """Resolve persisted unresolved_refs rows into EdgeStore edges."""
+        from . import _ast_cache_unresolved as _unresolved
+
+        return _unresolved.resolve_unresolved_refs(self._get_conn())
 
     def _index_parallel(
         self, candidates: list[tuple[str, str]], workers: int

--- a/tree_sitter_analyzer/mcp/utils/auto_index_guard.py
+++ b/tree_sitter_analyzer/mcp/utils/auto_index_guard.py
@@ -83,6 +83,7 @@ def ensure_indexed(
 
         stats = cache.get_stats()
         if stats.get("total_files", 0) > 0:
+            _resolve_pending_unresolved_refs(cache)
             _indexed_roots[project_root] = True
             return cache
 
@@ -112,6 +113,16 @@ def _open_cache(project_root: str) -> Any:
         return ASTCache(project_root)
     except Exception:
         return None
+
+
+def _resolve_pending_unresolved_refs(cache: Any) -> None:
+    try:
+        from ..._ast_cache_unresolved import pending_unresolved_count
+
+        if pending_unresolved_count(cache.get_conn()) > 0:
+            cache.index_project(resolve_only=True)
+    except Exception:
+        logger.debug("auto-index: unresolved_refs resolve-only failed", exc_info=True)
 
 
 def mark_dirty(project_root: str) -> None:


### PR DESCRIPTION
## Summary

Closes #246.

Adds the second-pass unresolved reference pipeline on top of the unified EdgeStore from #245:

- Adds schema v9 `unresolved_refs` with required indexes and schema integrity expectations.
- Emits unresolved cross-file inheritance and unresolved call references during file/project indexing.
- Runs post-index resolution after EdgeStore refresh, and also during `index_project(resolve_only=True)` so resolved edges survive `replace_edges_for_file()`.
- Makes `codegraph_autoindex` resolve pending `unresolved_refs` when the cache is already warm/non-empty.
- Writes resolved `EXTENDS` / `CALLS` edges back to EdgeStore with provenance and metadata, including alias-aware parent resolution.
- Adds `tests/unit/test_unresolved_refs.py` covering schema, index-stage population, resolve-only no-reparse, alias inheritance, unknown refs, autoindex warm-cache behavior, CLI class hierarchy smoke, and defensive SQLite paths.

## Django Signal

Local Django prepared repo subset (`.benchmark-repos/django`, head `0325492160`, `max_files=500`, temp DBs):

- Baseline without unresolved backfill: `5061 / 35337` resolved CALLS, hit rate `14.32%`.
- Current with unresolved backfill: `8485 / 38761` resolved CALLS, hit rate `21.89%`.
- Delta: `+3424` resolved CALLS, `+3424` cross-file resolved CALLS, `+7.57` hit-rate points.

## Verification

- `uv run --frozen ruff check tree_sitter_analyzer/_ast_cache_schema.py tree_sitter_analyzer/ast_cache.py tree_sitter_analyzer/_ast_cache_indexer.py tree_sitter_analyzer/_ast_cache_unresolved.py tree_sitter_analyzer/mcp/utils/auto_index_guard.py tests/unit/test_unresolved_refs.py`
- `uv run --frozen mypy tree_sitter_analyzer/_ast_cache_unresolved.py tree_sitter_analyzer/_ast_cache_indexer.py tree_sitter_analyzer/ast_cache.py tree_sitter_analyzer/mcp/utils/auto_index_guard.py`
- `uv run --frozen pytest tests/unit/test_unresolved_refs.py -q --cov=tree_sitter_analyzer --cov-report=json`
- `uv run --frozen python scripts/check_patch_coverage.py --base origin/develop --coverage-json coverage.json`
- `uv run --frozen pytest tests/unit/test_unresolved_refs.py tests/unit/test_schema_integrity.py tests/unit/test_edge_store.py tests/unit/test_codegraph_class_hierarchy_tool.py tests/unit/test_codegraph_autoindex_tool.py tests/unit/mcp/test_index_sync_tools.py tests/integration/test_synapse_backfill.py tests/integration/test_ast_cache_lifecycle.py tests/unit/mcp/test_ast_cache_watch_modes.py tests/unit/test_ast_cache.py tests/unit/test_ast_cache_bfs.py tests/unit/test_ast_cache_mode_used.py tests/unit/test_ast_cache_tool.py tests/unit/test_ast_cache_utf8_bug.py -q --cov=tree_sitter_analyzer --cov-report=json`
- `uv run --frozen pytest -q` (`17494 passed, 92 skipped in 91.61s`)
- `git diff --check`
