### PR TITLE
feat!: big-Java unlock — multilang import resolution + single edge graph (B3+P0+B1+P2)

### DIFF
--- a/tests/integration/test_synapse_backfill.py
+++ b/tests/integration/test_synapse_backfill.py
@@ -52,8 +52,8 @@ def _reset_resolution_columns(cache: ASTCache) -> None:
     """
     conn = cache._get_conn()
     conn.execute(
-        "UPDATE ast_call_edges SET callee_resolution = 'unknown', "
-        "callee_resolved_file = '', callee_symbol_id = NULL"
+        "UPDATE edges SET callee_resolution = 'unknown', "
+        "callee_resolved_file = '', callee_symbol_id = NULL WHERE kind = 'calls'"
     )
     conn.commit()
 
@@ -87,8 +87,8 @@ def test_backfill_no_reparse(
         # Spec: the resolver wrote at least one non-'unknown' row.
         conn = cache._get_conn()
         row = conn.execute(
-            "SELECT COUNT(*) AS c FROM ast_call_edges "
-            "WHERE callee_resolution != 'unknown'"
+            "SELECT COUNT(*) AS c FROM edges "
+            "WHERE kind = 'calls' AND callee_resolution != 'unknown'"
         ).fetchone()
         assert row["c"] > 0, (
             "resolve_only=True must populate at least one edge's "
@@ -98,7 +98,7 @@ def test_backfill_no_reparse(
         # Spec: the cross-file edge specifically resolved to b.py.
         edge = conn.execute(
             "SELECT callee_resolution, callee_resolved_file "
-            "FROM ast_call_edges WHERE callee_name = 'baz'"
+            "FROM edges WHERE kind = 'calls' AND callee_name = 'baz'"
         ).fetchone()
         assert edge is not None
         assert edge["callee_resolution"] == "project"

--- a/tests/unit/cli/test_constraint_check_command.py
+++ b/tests/unit/cli/test_constraint_check_command.py
@@ -419,10 +419,17 @@ class TestRunAndPersist:
         return db
 
     def _db_with_edges(self, tmp_path: Path) -> Path:
+        from tree_sitter_analyzer.graph.edge_store import EDGE_STORE_SCHEMA
+
         db = tmp_path / "index.db"
         conn = sqlite3.connect(str(db))
-        conn.execute("CREATE TABLE ast_call_edges (id INTEGER PRIMARY KEY, c TEXT)")
-        conn.execute("INSERT INTO ast_call_edges VALUES (1, 'a')")
+        # B1.3: the edge-count gate counts CALLS rows in the unified ``edges``
+        # table (ast_call_edges was dropped).
+        conn.executescript(EDGE_STORE_SCHEMA)
+        conn.execute(
+            "INSERT INTO edges (source_node_id, target_node_id, kind) "
+            "VALUES ('a.py:f:1', 'b.py:g:1', 'calls')"
+        )
         conn.commit()
         conn.close()
         return db

--- a/tests/unit/mcp/tools/test_call_path_enrich.py
+++ b/tests/unit/mcp/tools/test_call_path_enrich.py
@@ -91,6 +91,44 @@ def _build_cache(tmp_path: Path) -> MagicMock:
                 "python",
             ),
         )
+    # B1: the path-finder reads the unified ``edges`` table (kind='calls'),
+    # not the legacy ``ast_call_edges`` table.  Mirror the same edges here so
+    # CallPathFinder finds the alpha->beta->gamma chain on this branch.
+    db.execute(
+        "CREATE TABLE edges ("
+        " id INTEGER PRIMARY KEY AUTOINCREMENT,"
+        " source_node_id TEXT NOT NULL DEFAULT '',"
+        " target_node_id TEXT NOT NULL DEFAULT '',"
+        " kind TEXT NOT NULL,"
+        " line INTEGER,"
+        " metadata TEXT,"
+        " caller_name TEXT NOT NULL DEFAULT '',"
+        " callee_name TEXT NOT NULL DEFAULT '',"
+        " file_path TEXT NOT NULL DEFAULT '',"
+        " callee_resolved_file TEXT NOT NULL DEFAULT '')"
+    )
+    for e in _EDGES:
+        db.execute(
+            "INSERT INTO edges (source_node_id, target_node_id, kind, line,"
+            " metadata, caller_name, callee_name, file_path,"
+            " callee_resolved_file) VALUES (?,?,?,?,?,?,?,?,?)",
+            (
+                f"{e['caller_file']}>{e['caller_name']}",
+                f"{e['callee_resolved_file']}>{e['callee_name']}",
+                "calls",
+                e["callee_line"],
+                json.dumps(
+                    {
+                        "caller_line": e["caller_line"],
+                        "callee_resolved_file": e["callee_resolved_file"],
+                    }
+                ),
+                e["caller_name"],
+                e["callee_name"],
+                e["caller_file"],
+                e["callee_resolved_file"],
+            ),
+        )
     db.execute(
         "CREATE TABLE ast_index ("
         " file_path TEXT PRIMARY KEY, symbols_json TEXT, language TEXT)"

--- a/tests/unit/mcp/tools/test_call_path_enrich.py
+++ b/tests/unit/mcp/tools/test_call_path_enrich.py
@@ -1,0 +1,312 @@
+"""Deterministic tests for call_path body inlining (coordinates -> content).
+
+Verifies the turn-saving upgrade: call_path now inlines verbatim source
+bodies + a deterrent ``next_step`` (path found), and inlines both endpoints'
+bodies + neighbours on a dead end. No benchmark needed — assertions check the
+response shape directly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from tree_sitter_analyzer.mcp.tools import call_path_enrich as enrich
+from tree_sitter_analyzer.mcp.tools.call_path_tool import CodeGraphCallPathTool
+
+# Source files written to disk so bodies can be read verbatim.
+_SRC_A = '''def alpha():
+    """alpha doc."""
+    beta()
+    return 1
+'''
+
+_SRC_B = """def beta():
+    # beta calls gamma
+    gamma()
+    return 2
+"""
+
+_SRC_C = """def gamma():
+    return "GAMMA_BODY_MARKER"
+"""
+
+_EDGES = [
+    {
+        "caller_name": "alpha",
+        "caller_file": "a.py",
+        "caller_line": 3,
+        "callee_name": "beta",
+        "callee_line": 1,
+        "callee_resolved_file": "b.py",
+    },
+    {
+        "caller_name": "beta",
+        "caller_file": "b.py",
+        "caller_line": 3,
+        "callee_name": "gamma",
+        "callee_line": 1,
+        "callee_resolved_file": "c.py",
+    },
+]
+
+# (file, [symbols]) — symbols carry def spans for body lookup.
+_SYMBOLS = {
+    "a.py": [{"name": "alpha", "kind": "function", "line": 1, "end_line": 4}],
+    "b.py": [{"name": "beta", "kind": "function", "line": 1, "end_line": 4}],
+    "c.py": [{"name": "gamma", "kind": "function", "line": 1, "end_line": 2}],
+}
+
+
+def _build_cache(tmp_path: Path) -> MagicMock:
+    """Build a fixture cache with ast_call_edges + ast_index + real files."""
+    (tmp_path / "a.py").write_text(_SRC_A)
+    (tmp_path / "b.py").write_text(_SRC_B)
+    (tmp_path / "c.py").write_text(_SRC_C)
+
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    db.execute(
+        "CREATE TABLE ast_call_edges ("
+        " caller_name TEXT, caller_file TEXT, caller_line INTEGER,"
+        " callee_name TEXT, callee_full TEXT DEFAULT '', callee_line INTEGER DEFAULT 0,"
+        " callee_resolved_file TEXT DEFAULT '', file_path TEXT, language TEXT)"
+    )
+    for e in _EDGES:
+        db.execute(
+            "INSERT INTO ast_call_edges (caller_name, caller_file, caller_line,"
+            " callee_name, callee_line, callee_resolved_file, file_path, language)"
+            " VALUES (?,?,?,?,?,?,?,?)",
+            (
+                e["caller_name"],
+                e["caller_file"],
+                e["caller_line"],
+                e["callee_name"],
+                e["callee_line"],
+                e["callee_resolved_file"],
+                e["caller_file"],
+                "python",
+            ),
+        )
+    db.execute(
+        "CREATE TABLE ast_index ("
+        " file_path TEXT PRIMARY KEY, symbols_json TEXT, language TEXT)"
+    )
+    for file_path, symbols in _SYMBOLS.items():
+        db.execute(
+            "INSERT INTO ast_index (file_path, symbols_json, language) VALUES (?,?,?)",
+            (file_path, json.dumps({"symbols": symbols}), "python"),
+        )
+    db.commit()
+
+    cache = MagicMock()
+    cache.has_call_edges.return_value = True
+    cache.get_conn.return_value = db
+    cache._get_conn.return_value = db
+    cache.get_functions.side_effect = AssertionError(
+        "enrich must use targeted ast_index scan, not full get_functions()"
+    )
+
+    # Real callers/callees backed by the same edge table.
+    def _callers(name, file=None, depth=1):
+        rows = db.execute(
+            "SELECT caller_name, caller_file, caller_line FROM ast_call_edges"
+            " WHERE callee_name = ?",
+            (name,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    def _callees(name, file=None, depth=1):
+        rows = db.execute(
+            "SELECT callee_name, callee_resolved_file, callee_line FROM ast_call_edges"
+            " WHERE caller_name = ?",
+            (name,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    cache.query_callers.side_effect = _callers
+    cache.query_callees.side_effect = _callees
+    return cache
+
+
+# ---------------------------------------------------------------------------
+# Helper-level: inline_path_bodies
+# ---------------------------------------------------------------------------
+
+
+def test_inline_path_bodies_returns_verbatim_bodies(tmp_path):
+    cache = _build_cache(tmp_path)
+    paths = [
+        {
+            "hops": [
+                {
+                    "caller": "alpha",
+                    "caller_file": "a.py",
+                    "callee": "beta",
+                    "callee_file": "b.py",
+                    "line": 3,
+                },
+                {
+                    "caller": "beta",
+                    "caller_file": "b.py",
+                    "callee": "gamma",
+                    "callee_file": "c.py",
+                    "line": 3,
+                },
+            ]
+        }
+    ]
+    bodies, truncated = enrich.inline_path_bodies(str(tmp_path), cache, paths)
+    names = {b["name"] for b in bodies}
+    assert names == {"alpha", "beta", "gamma"}  # deduped, all three
+    assert truncated is False
+    # Verbatim source body — not just file:line.
+    gamma = next(b for b in bodies if b["name"] == "gamma")
+    assert "GAMMA_BODY_MARKER" in gamma["content"]
+    assert "def gamma" in gamma["content"]
+
+
+def test_inline_path_bodies_dedupes(tmp_path):
+    cache = _build_cache(tmp_path)
+    # Two paths that share the alpha->beta prefix.
+    hop_ab = {
+        "caller": "alpha",
+        "caller_file": "a.py",
+        "callee": "beta",
+        "callee_file": "b.py",
+        "line": 3,
+    }
+    paths = [{"hops": [hop_ab]}, {"hops": [hop_ab]}]
+    bodies, _ = enrich.inline_path_bodies(str(tmp_path), cache, paths)
+    names = [b["name"] for b in bodies]
+    assert names.count("alpha") == 1
+    assert names.count("beta") == 1
+
+
+def test_body_truncation_caps_lines(tmp_path, monkeypatch):
+    cache = _build_cache(tmp_path)
+    # Force a tiny per-body cap so the 4-line alpha body truncates.
+    monkeypatch.setattr(enrich, "MAX_BODY_LINES", 2)
+    paths = [
+        {
+            "hops": [
+                {
+                    "caller": "alpha",
+                    "caller_file": "a.py",
+                    "callee": "beta",
+                    "callee_file": "b.py",
+                    "line": 3,
+                }
+            ]
+        }
+    ]
+    bodies, truncated = enrich.inline_path_bodies(str(tmp_path), cache, paths)
+    alpha = next(b for b in bodies if b["name"] == "alpha")
+    assert alpha.get("truncated") is True
+    assert "full_at" in alpha
+    assert truncated is True
+
+
+# ---------------------------------------------------------------------------
+# Helper-level: build_dead_end
+# ---------------------------------------------------------------------------
+
+
+def test_build_dead_end_inlines_both_endpoints(tmp_path):
+    cache = _build_cache(tmp_path)
+    out = enrich.build_dead_end(str(tmp_path), cache, "alpha", "gamma", None, None)
+    src = out["source_endpoint"]
+    tgt = out["target_endpoint"]
+    assert src["name"] == "alpha"
+    assert "def alpha" in src["body"]["content"]
+    assert "GAMMA_BODY_MARKER" in tgt["body"]["content"]
+    # Neighbours inlined for reasoning about the gap.
+    assert any(c["name"] == "beta" for c in src["callees"])
+    assert any(c["name"] == "beta" for c in tgt["callers"])
+
+
+# ---------------------------------------------------------------------------
+# Tool-level: full execute envelope
+# ---------------------------------------------------------------------------
+
+
+def _run_tool(tmp_path, cache, args):
+    tool = CodeGraphCallPathTool(str(tmp_path))
+    tool._finder = MagicMock()
+    tool._finder._try_get_cache.return_value = cache
+    # Real finder logic over the fixture cache.
+    from tree_sitter_analyzer.call_path import CallPathFinder
+
+    real = CallPathFinder(str(tmp_path), cache=cache)
+    tool._finder.find_path.side_effect = real.find_path
+    return asyncio.run(tool.execute(args))
+
+
+def test_tool_path_found_inlines_bodies_and_deterrent(tmp_path):
+    cache = _build_cache(tmp_path)
+    result = _run_tool(
+        tmp_path,
+        cache,
+        {
+            "source_function": "alpha",
+            "target_function": "gamma",
+            "direction": "forward",
+            "output_format": "json",
+        },
+    )
+    assert result["verdict"] == "PATH_FOUND"
+    assert "source_bodies" in result
+    assert result["source_bodies"], "expected inlined bodies"
+    # Verbatim body present (the whole point of the upgrade).
+    joined = " ".join(b["content"] for b in result["source_bodies"])
+    assert "GAMMA_BODY_MARKER" in joined
+    # Deterrent next_step.
+    assert "next_step" in result
+    assert "no Read needed" in result["next_step"]
+    assert "inlined" in result["next_step"]
+
+
+def test_tool_dead_end_inlines_endpoints_and_deterrent(tmp_path):
+    cache = _build_cache(tmp_path)
+    # gamma -> alpha has no forward path.
+    result = _run_tool(
+        tmp_path,
+        cache,
+        {
+            "source_function": "gamma",
+            "target_function": "alpha",
+            "direction": "forward",
+            "output_format": "json",
+        },
+    )
+    assert result["verdict"] == "NO_PATH"
+    assert "dead_end" in result
+    de = result["dead_end"]
+    assert "GAMMA_BODY_MARKER" in de["source_endpoint"]["body"]["content"]
+    assert "def alpha" in de["target_endpoint"]["body"]["content"]
+    assert "next_step" in result
+    assert "No static path" in result["next_step"]
+    assert "no Read needed" in result["next_step"]
+
+
+def test_tool_toon_format_carries_bodies(tmp_path):
+    cache = _build_cache(tmp_path)
+    result = _run_tool(
+        tmp_path,
+        cache,
+        {
+            "source_function": "alpha",
+            "target_function": "gamma",
+            "direction": "forward",
+            "output_format": "toon",
+        },
+    )
+    assert result.get("format") == "toon"
+    toon = result["toon_content"]
+    # Bodies and deterrent survive TOON serialization.
+    assert "source_bodies" in toon
+    assert "next_step" in toon
+    assert "GAMMA_BODY_MARKER" in toon

--- a/tests/unit/mcp/tools/test_symbol_body_inline.py
+++ b/tests/unit/mcp/tools/test_symbol_body_inline.py
@@ -1,0 +1,146 @@
+"""Deterministic tests for the shared symbol-body inlining helper (P2).
+
+P2 generalises the call_path "coordinates -> content + deterrent" upgrade to
+the agent-high-frequency tools: nav navigate / nav callers / nav callees /
+search symbol.  These tests assert the *shared helper* behaviour directly:
+
+  - records that already carry an end_line are inlined verbatim;
+  - records missing end_line resolve their span via the AST-index def-index;
+  - per-body and total caps truncate long bodies and flag full_at;
+  - cap tiers differ by use-case (definition 80, neighbour 40, summary 30).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from tree_sitter_analyzer.mcp.tools import symbol_body_inline as sbi
+
+_SRC_BIG = "def big():\n" + "".join(f"    x{i} = {i}\n" for i in range(120))
+_SRC_SMALL = 'def small():\n    return "SMALL_MARKER"\n'
+
+
+def _build_cache(tmp_path: Path) -> MagicMock:
+    (tmp_path / "big.py").write_text(_SRC_BIG)
+    (tmp_path / "small.py").write_text(_SRC_SMALL)
+
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    db.execute(
+        "CREATE TABLE ast_index ("
+        " file_path TEXT PRIMARY KEY, symbols_json TEXT, language TEXT)"
+    )
+    symbols = {
+        "big.py": [{"name": "big", "kind": "function", "line": 1, "end_line": 121}],
+        "small.py": [{"name": "small", "kind": "function", "line": 1, "end_line": 2}],
+    }
+    for fp, syms in symbols.items():
+        db.execute(
+            "INSERT INTO ast_index (file_path, symbols_json, language) VALUES (?,?,?)",
+            (fp, json.dumps({"symbols": syms}), "python"),
+        )
+    db.commit()
+
+    cache = MagicMock()
+    cache.get_conn.return_value = db
+    cache._get_conn.return_value = db
+    return cache
+
+
+# ---------------------------------------------------------------------------
+# inline_symbol_body — single definition, full 80-line tier
+# ---------------------------------------------------------------------------
+
+
+def test_inline_symbol_body_verbatim_with_end_line(tmp_path):
+    cache = _build_cache(tmp_path)
+    record = {"name": "small", "file": "small.py", "line": 1, "end_line": 2}
+    block = sbi.inline_symbol_body(str(tmp_path), cache, record)
+    assert block is not None
+    assert "SMALL_MARKER" in block["content"]
+    assert "def small" in block["content"]
+    assert block.get("truncated") is not True
+
+
+def test_inline_symbol_body_truncates_over_cap(tmp_path):
+    cache = _build_cache(tmp_path)
+    # 121-line body exceeds the 80-line definition tier.
+    record = {"name": "big", "file": "big.py", "line": 1, "end_line": 121}
+    block = sbi.inline_symbol_body(str(tmp_path), cache, record)
+    assert block is not None
+    assert block.get("truncated") is True
+    assert "full_at" in block
+    assert block["full_at"] == "big.py:1"
+    assert len(block["content"].splitlines()) <= sbi.MAX_DEFINITION_LINES
+
+
+def test_inline_symbol_body_resolves_missing_end_line(tmp_path):
+    cache = _build_cache(tmp_path)
+    # No end_line on the record — helper must resolve span via def-index.
+    record = {"name": "small", "file": "small.py", "line": 1}
+    block = sbi.inline_symbol_body(str(tmp_path), cache, record)
+    assert block is not None
+    assert "SMALL_MARKER" in block["content"]
+
+
+# ---------------------------------------------------------------------------
+# inline_neighbor_bodies — top-N callers/callees, 40-line tier, total cap
+# ---------------------------------------------------------------------------
+
+
+def test_inline_neighbor_bodies_attaches_body_to_each(tmp_path):
+    cache = _build_cache(tmp_path)
+    neighbors = [
+        {"name": "small", "file": "small.py", "line": 1},
+        {"name": "big", "file": "big.py", "line": 1},
+    ]
+    enriched = sbi.inline_neighbor_bodies(str(tmp_path), cache, neighbors)
+    assert len(enriched) == 2
+    small = next(n for n in enriched if n["name"] == "small")
+    assert "body" in small
+    assert "SMALL_MARKER" in small["body"]["content"]
+
+
+def test_inline_neighbor_bodies_caps_at_top_n(tmp_path):
+    cache = _build_cache(tmp_path)
+    neighbors = [{"name": "small", "file": "small.py", "line": 1} for _ in range(50)]
+    enriched = sbi.inline_neighbor_bodies(str(tmp_path), cache, neighbors)
+    bodied = [n for n in enriched if "body" in n]
+    # Only the first MAX_NEIGHBOR_BODIES get a body; the rest stay coordinate-only.
+    assert len(bodied) <= sbi.MAX_NEIGHBOR_BODIES
+
+
+def test_inline_neighbor_body_uses_40_line_tier(tmp_path):
+    cache = _build_cache(tmp_path)
+    neighbors = [{"name": "big", "file": "big.py", "line": 1, "end_line": 121}]
+    enriched = sbi.inline_neighbor_bodies(str(tmp_path), cache, neighbors)
+    body = enriched[0]["body"]
+    assert body.get("truncated") is True
+    assert len(body["content"].splitlines()) <= sbi.MAX_NEIGHBOR_LINES
+
+
+# ---------------------------------------------------------------------------
+# inline_search_summaries — top matches, 30-line tier
+# ---------------------------------------------------------------------------
+
+
+def test_inline_search_summaries_attaches_body(tmp_path):
+    cache = _build_cache(tmp_path)
+    results = [
+        {"name": "small", "file": "small.py", "line": 1, "end_line": 2},
+    ]
+    enriched = sbi.inline_search_summaries(str(tmp_path), cache, results)
+    assert "body" in enriched[0]
+    assert "SMALL_MARKER" in enriched[0]["body"]["content"]
+
+
+def test_inline_search_summaries_uses_30_line_tier(tmp_path):
+    cache = _build_cache(tmp_path)
+    results = [{"name": "big", "file": "big.py", "line": 1, "end_line": 121}]
+    enriched = sbi.inline_search_summaries(str(tmp_path), cache, results)
+    body = enriched[0]["body"]
+    assert body.get("truncated") is True
+    assert len(body["content"].splitlines()) <= sbi.MAX_SUMMARY_LINES

--- a/tests/unit/synapse_resolver/test_java.py
+++ b/tests/unit/synapse_resolver/test_java.py
@@ -1,0 +1,189 @@
+"""Unit tests for synapse_resolver/_java.py — Java import parsing + cascade.
+
+These lock in the B3 behaviour: Java imports become structured rows and
+the 10-stage cascade resolves local / project / external / unknown with
+``external`` as a terminal (non-rescan) resolution.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tree_sitter_analyzer.synapse_resolver._imports import ImportEntry
+from tree_sitter_analyzer.synapse_resolver._java import (
+    JavaResolverContext,
+    build_java_context,
+    parse_java_imports,
+    resolve_java_callee,
+)
+
+# ---------------------------------------------------------------------------
+# parse_java_imports
+# ---------------------------------------------------------------------------
+
+
+class TestParseJavaImports:
+    def test_package_declaration(self) -> None:
+        rows = parse_java_imports("package a.b.c;", "Foo.java", 1)
+        assert len(rows) == 1
+        assert rows[0].module_path == "a.b.c"
+        assert rows[0].local_name == "\x00package"
+
+    def test_single_type_import(self) -> None:
+        rows = parse_java_imports("import a.b.C;", "Foo.java", 2)
+        assert rows == [
+            ImportEntry(
+                file_path="Foo.java",
+                language="java",
+                module_path="a.b.C",
+                local_name="C",
+                is_relative=False,
+                is_star=False,
+                alias_of="",
+                line=2,
+            )
+        ]
+
+    def test_wildcard_import(self) -> None:
+        rows = parse_java_imports("import a.b.*;", "Foo.java", 3)
+        assert len(rows) == 1
+        assert rows[0].module_path == "a.b"
+        assert rows[0].is_star is True
+        assert rows[0].local_name == ""
+
+    def test_static_member_import(self) -> None:
+        rows = parse_java_imports("import static a.b.C.m;", "Foo.java", 4)
+        assert len(rows) == 1
+        assert rows[0].module_path == "a.b.C.m"
+        assert rows[0].local_name == "m"
+
+    def test_static_wildcard_import(self) -> None:
+        rows = parse_java_imports("import static a.b.C.*;", "Foo.java", 5)
+        assert len(rows) == 1
+        assert rows[0].module_path == "a.b.C"
+        assert rows[0].is_star is True
+
+    @pytest.mark.parametrize("text", ["", "   ", "// comment", "class Foo {"])
+    def test_non_import_returns_empty(self, text: str) -> None:
+        assert parse_java_imports(text, "Foo.java", 0) == []
+
+
+# ---------------------------------------------------------------------------
+# resolve_java_callee cascade
+# ---------------------------------------------------------------------------
+
+
+def _build_two_file_ctx() -> JavaResolverContext:
+    """Service.java (pkg com.acme.svc) imports Helper from com.acme.util."""
+    helper = "Helper.java"
+    service = "Service.java"
+    imports_by_file = {
+        helper: parse_java_imports("package com.acme.util;", helper, 1),
+        service: (
+            parse_java_imports("package com.acme.svc;", service, 1)
+            + parse_java_imports("import com.acme.util.Helper;", service, 2)
+            + parse_java_imports("import java.util.List;", service, 3)
+        ),
+    }
+    file_symbols = {
+        helper: [("Helper", "class", 1), ("greet", "function", 2)],
+        service: [
+            ("Service", "class", 1),
+            ("run", "function", 2),
+            ("localMethod", "function", 9),
+        ],
+    }
+    file_class_methods = {
+        service: {"Service": {"run": 20, "localMethod": 21}},
+    }
+    global_name_table = {
+        "Helper": [(helper, 10)],
+        "greet": [(helper, 11)],
+        "Service": [(service, 20)],
+        "run": [(service, 21)],
+        "localMethod": [(service, 22)],
+        "uniqueThing": [(helper, 99)],
+    }
+    return build_java_context(
+        imports_by_file=imports_by_file,
+        file_symbols=file_symbols,
+        file_class_methods=file_class_methods,
+        global_name_table=global_name_table,
+    )
+
+
+class TestResolveJavaCallee:
+    def test_local_implicit_this(self) -> None:
+        ctx = _build_two_file_ctx()
+        sym, res, f = resolve_java_callee(
+            "localMethod", "localMethod", "Service.java", ctx
+        )
+        assert res == "local"
+        assert f == "Service.java"
+
+    def test_this_qualified(self) -> None:
+        ctx = _build_two_file_ctx()
+        _sym, res, f = resolve_java_callee(
+            "localMethod", "this.localMethod", "Service.java", ctx
+        )
+        assert res == "local"
+        assert f == "Service.java"
+
+    def test_type_import_cross_file(self) -> None:
+        ctx = _build_two_file_ctx()
+        _sym, res, f = resolve_java_callee("greet", "Helper.greet", "Service.java", ctx)
+        assert res == "project"
+        assert f == "Helper.java"
+
+    def test_jdk_receiver_is_external(self) -> None:
+        ctx = _build_two_file_ctx()
+        _sym, res, f = resolve_java_callee(
+            "println", "System.out.println", "Service.java", ctx
+        )
+        assert res == "external"
+        assert f == ""
+
+    def test_java_lang_simple_type_external(self) -> None:
+        ctx = _build_two_file_ctx()
+        _sym, res, _f = resolve_java_callee(
+            "valueOf", "Integer.valueOf", "Service.java", ctx
+        )
+        assert res == "external"
+
+    def test_single_global_unqualified(self) -> None:
+        ctx = _build_two_file_ctx()
+        _sym, res, f = resolve_java_callee(
+            "uniqueThing", "uniqueThing", "Service.java", ctx
+        )
+        assert res == "project"
+        assert f == "Helper.java"
+
+    def test_unknown_instance_receiver(self) -> None:
+        ctx = _build_two_file_ctx()
+        # ``helper.compute()`` — receiver is a field/var, not a type.
+        _sym, res, _f = resolve_java_callee(
+            "compute", "helper.compute", "Service.java", ctx
+        )
+        assert res == "unknown"
+
+    def test_same_package_resolution(self) -> None:
+        helper = "Helper.java"
+        sibling = "Sibling.java"
+        imports_by_file = {
+            helper: parse_java_imports("package com.acme.util;", helper, 1),
+            sibling: parse_java_imports("package com.acme.util;", sibling, 1),
+        }
+        file_symbols = {
+            helper: [("Helper", "class", 1), ("greet", "function", 2)],
+            sibling: [("Sibling", "class", 1)],
+        }
+        ctx = build_java_context(
+            imports_by_file=imports_by_file,
+            file_symbols=file_symbols,
+            file_class_methods={},
+            global_name_table={},
+        )
+        # Sibling calls Helper.greet() without importing (same package).
+        _sym, res, f = resolve_java_callee("greet", "Helper.greet", "Sibling.java", ctx)
+        assert res == "project"
+        assert f == "Helper.java"

--- a/tests/unit/test_ast_cache.py
+++ b/tests/unit/test_ast_cache.py
@@ -308,10 +308,13 @@ class TestIndexProject:
             tuple(r) for r in parallel_conn.execute(symbol_sql).fetchall()
         ]
 
+        # B1.3: CALLS rows live in the unified ``edges`` table; ``file_path`` is
+        # the caller's file (== legacy caller_file), ``callee_line`` the call site.
         edge_sql = (
-            "SELECT caller_name, caller_file, caller_line, callee_name, "
+            "SELECT caller_name, file_path AS caller_file, caller_line, callee_name, "
             "callee_full, callee_line, file_path, language "
-            "FROM ast_call_edges ORDER BY file_path, caller_name, callee_name, callee_line"
+            "FROM edges WHERE kind = 'calls' "
+            "ORDER BY file_path, caller_name, callee_name, callee_line"
         )
         assert [tuple(r) for r in serial_conn.execute(edge_sql).fetchall()] == [
             tuple(r) for r in parallel_conn.execute(edge_sql).fetchall()
@@ -474,9 +477,10 @@ class TestLargeRepoHotPathIndexes:
 
         assert "idx_sym_rows_name_kind_path_line" in index_names
         assert "idx_sym_rows_file_name_kind_line" in index_names
-        assert "idx_ce_callee_name_resolved_file" in index_names
-        assert "idx_ce_callee_name_file_path" in index_names
-        assert "idx_ce_caller_name_file" in index_names
+        # B1.3: CALLS hot-path indexes live on the unified ``edges`` table.
+        assert "idx_edges_callee_name" in index_names
+        assert "idx_edges_caller_name" in index_names
+        assert "idx_edges_file_path" in index_names
 
     def test_symbol_resolver_hot_queries_use_composite_indexes(self, cache):
         if not cache.fts5_available:
@@ -504,36 +508,35 @@ class TestLargeRepoHotPathIndexes:
         assert "idx_sym_rows_file_name_kind_line" in scoped_symbol_plan
 
     def test_call_graph_hot_queries_use_composite_indexes(self, cache):
+        # B1.3: CALLS rows + their name/file/resolution columns are in the
+        # unified ``edges`` table, served by the EdgeStore name/file indexes.
         conn = cache._get_conn()
 
         callers_plan = _query_plan(
             conn,
-            """SELECT caller_name, caller_file, caller_line,
-                      callee_name, file_path, callee_line, callee_resolved_file
-               FROM ast_call_edges
-               WHERE callee_name = ? AND callee_resolved_file = ?""",
-            ("render", "src/view.py"),
-        )
-        callers_fallback_plan = _query_plan(
-            conn,
-            """SELECT caller_name, caller_file, caller_line,
-                      callee_name, file_path, callee_line, callee_resolved_file
-               FROM ast_call_edges
-               WHERE callee_name = ? AND file_path = ?""",
-            ("render", "src/view.py"),
+            """SELECT caller_name, file_path, caller_line, callee_name,
+                      callee_line, callee_resolved_file
+               FROM edges
+               WHERE kind = 'calls' AND callee_name = ?""",
+            ("render",),
         )
         callees_plan = _query_plan(
             conn,
-            """SELECT caller_name, caller_file, caller_line,
-                      callee_name, callee_full, file_path, callee_line, callee_resolved_file
-               FROM ast_call_edges
-               WHERE caller_name = ? AND caller_file = ?""",
-            ("handle", "src/handler.py"),
+            """SELECT caller_name, file_path, caller_line, callee_name,
+                      callee_full, callee_line, callee_resolved_file
+               FROM edges
+               WHERE kind = 'calls' AND caller_name = ?""",
+            ("handle",),
+        )
+        file_scope_plan = _query_plan(
+            conn,
+            "SELECT id FROM edges WHERE kind = 'calls' AND file_path = ?",
+            ("src/handler.py",),
         )
 
-        assert "idx_ce_callee_name_resolved_file" in callers_plan
-        assert "idx_ce_callee_name_file_path" in callers_fallback_plan
-        assert "idx_ce_caller_name_file" in callees_plan
+        assert "idx_edges_callee_name" in callers_plan
+        assert "idx_edges_caller_name" in callees_plan
+        assert "idx_edges_file_path" in file_scope_plan
 
     def test_large_repo_index_helper_skips_missing_tables(self):
         conn = sqlite3.connect(":memory:")
@@ -549,8 +552,11 @@ class TestLargeRepoHotPathIndexes:
         conn.close()
 
     def test_large_repo_index_helper_tolerates_legacy_partial_tables(self):
+        # B1.3: ast_call_edges hot-path indexes were removed; the helper now
+        # only builds the ast_symbol_rows composites and tolerates a partial
+        # legacy table without erroring.
         conn = sqlite3.connect(":memory:")
-        conn.execute("CREATE TABLE ast_call_edges (callee_name TEXT)")
+        conn.execute("CREATE TABLE ast_symbol_rows (name TEXT)")
 
         ASTCache._ensure_large_repo_indexes(conn)
 

--- a/tests/unit/test_ast_cache_bfs.py
+++ b/tests/unit/test_ast_cache_bfs.py
@@ -25,27 +25,13 @@ from tree_sitter_analyzer.graph.edge_store import EdgeKind, symbol_node
 # scalars in the metadata JSON blob, real name/file columns).
 # ---------------------------------------------------------------------------
 
-_SCHEMA = """\
-CREATE TABLE edges (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    source_node_id TEXT NOT NULL,
-    target_node_id TEXT NOT NULL,
-    kind TEXT NOT NULL,
-    line INTEGER,
-    provenance TEXT DEFAULT 'tree-sitter',
-    metadata TEXT,
-    caller_name TEXT NOT NULL DEFAULT '',
-    callee_name TEXT NOT NULL DEFAULT '',
-    file_path TEXT NOT NULL DEFAULT '',
-    UNIQUE(source_node_id, target_node_id, kind, line)
-);
-"""
-
 
 def _make_conn() -> sqlite3.Connection:
+    from tree_sitter_analyzer.graph.edge_store import EDGE_STORE_SCHEMA
+
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
-    conn.executescript(_SCHEMA)
+    conn.executescript(EDGE_STORE_SCHEMA)
     return conn
 
 
@@ -72,11 +58,14 @@ def _insert_edge(
         "callee_resolution": "unknown",
         "callee_resolved_file": callee_resolved_file,
     }
+    # B1.3: resolution scalars are real columns (the readers no longer
+    # json_extract them); populate both so this fixture matches production rows.
     conn.execute(
         "INSERT OR REPLACE INTO edges "
         "(source_node_id, target_node_id, kind, line, provenance, metadata, "
-        " caller_name, callee_name, file_path) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        " caller_name, callee_name, file_path, caller_line, callee_full, "
+        " callee_line, language, callee_resolution, callee_resolved_file) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         (
             source,
             target,
@@ -87,6 +76,12 @@ def _insert_edge(
             caller_name,
             callee_name,
             caller_file,
+            caller_line,
+            callee_full or callee_name,
+            callee_line,
+            "python",
+            "unknown",
+            callee_resolved_file,
         ),
     )
     conn.commit()

--- a/tests/unit/test_ast_cache_bfs.py
+++ b/tests/unit/test_ast_cache_bfs.py
@@ -10,27 +10,34 @@ schema — no ASTCache instance needed, proving the functions are pure.
 
 from __future__ import annotations
 
+import json
 import sqlite3
 
 from tree_sitter_analyzer._ast_cache_graph import bfs_callees, bfs_callers
+from tree_sitter_analyzer.graph.edge_store import EdgeKind, symbol_node
 
 # ---------------------------------------------------------------------------
 # Fixtures
+#
+# B1.2 moved the CALLS read path from ``ast_call_edges`` to the unified
+# ``edges`` table.  The fixture therefore populates ``edges`` CALLS rows in the
+# exact shape the production write path produces (node ids via ``symbol_node``,
+# scalars in the metadata JSON blob, real name/file columns).
 # ---------------------------------------------------------------------------
 
 _SCHEMA = """\
-CREATE TABLE ast_call_edges (
-    id INTEGER PRIMARY KEY,
-    caller_name TEXT NOT NULL,
-    caller_file TEXT NOT NULL,
-    caller_line INTEGER NOT NULL DEFAULT 0,
-    callee_name TEXT NOT NULL,
-    callee_full TEXT NOT NULL DEFAULT '',
-    file_path    TEXT NOT NULL DEFAULT '',
-    callee_line  INTEGER NOT NULL DEFAULT 0,
-    callee_resolved_file TEXT NOT NULL DEFAULT '',
-    callee_symbol_id INTEGER,
-    callee_resolution TEXT NOT NULL DEFAULT 'unknown'
+CREATE TABLE edges (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source_node_id TEXT NOT NULL,
+    target_node_id TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    line INTEGER,
+    provenance TEXT DEFAULT 'tree-sitter',
+    metadata TEXT,
+    caller_name TEXT NOT NULL DEFAULT '',
+    callee_name TEXT NOT NULL DEFAULT '',
+    file_path TEXT NOT NULL DEFAULT '',
+    UNIQUE(source_node_id, target_node_id, kind, line)
 );
 """
 
@@ -53,20 +60,33 @@ def _insert_edge(
     callee_resolved_file: str = "",
     callee_full: str = "",
 ) -> None:
+    source = symbol_node(caller_file, caller_name, caller_line)
+    target_file = callee_resolved_file or caller_file
+    target = symbol_node(target_file, callee_name, callee_line)
+    metadata = {
+        "language": "python",
+        "caller_name": caller_name,
+        "caller_line": caller_line,
+        "callee_name": callee_name,
+        "callee_full": callee_full or callee_name,
+        "callee_resolution": "unknown",
+        "callee_resolved_file": callee_resolved_file,
+    }
     conn.execute(
-        "INSERT INTO ast_call_edges "
-        "(caller_name, caller_file, caller_line, callee_name, callee_full, "
-        " file_path, callee_line, callee_resolved_file) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT OR REPLACE INTO edges "
+        "(source_node_id, target_node_id, kind, line, provenance, metadata, "
+        " caller_name, callee_name, file_path) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
         (
-            caller_name,
-            caller_file,
-            caller_line,
-            callee_name,
-            callee_full or callee_name,
-            file_path,
+            source,
+            target,
+            EdgeKind.CALLS.value,
             callee_line,
-            callee_resolved_file,
+            "tree-sitter",
+            json.dumps(metadata, ensure_ascii=False, sort_keys=True),
+            caller_name,
+            callee_name,
+            caller_file,
         ),
     )
     conn.commit()
@@ -151,11 +171,15 @@ class TestBfsCallers:
         assert result == []
 
     def test_callee_file_falls_back_to_file_path(self):
-        """When callee_resolved_file is empty, callee_file in result = file_path."""
+        """When callee_resolved_file is empty, callee_file in result = file_path.
+
+        In the unified ``edges`` model ``file_path`` is the caller's file, so an
+        unresolved callee's reported file falls back to that caller file.
+        """
         conn = _make_conn()
         _insert_edge(conn, "alpha", "a.py", "target", "b.py", callee_resolved_file="")
         result = bfs_callers(conn, "target", None, max_depth=1)
-        assert result[0]["callee_file"] == "b.py"  # falls back to file_path
+        assert result[0]["callee_file"] == "a.py"  # falls back to caller file_path
 
     def test_callee_file_uses_resolved_when_present(self):
         conn = _make_conn()
@@ -167,11 +191,15 @@ class TestBfsCallers:
 
     def test_fallback_file_path_query_when_resolved_file_not_found(self):
         """When querying with callee_file, try callee_resolved_file first,
-        then fall back to file_path query."""
+        then fall back to file_path query.
+
+        With unified ``edges`` the unresolved edge's ``file_path`` is the
+        caller file (``a.py``), so the fallback query matches on that.
+        """
         conn = _make_conn()
-        # Edge has callee_resolved_file empty but file_path = b.py
+        # Edge has callee_resolved_file empty; file_path = caller file a.py
         _insert_edge(conn, "alpha", "a.py", "target", "b.py", callee_resolved_file="")
-        result = bfs_callers(conn, "target", "b.py", max_depth=1)
+        result = bfs_callers(conn, "target", "a.py", max_depth=1)
         assert len(result) == 1
         assert result[0]["caller_name"] == "alpha"
 
@@ -188,9 +216,11 @@ class TestBfsCallers:
     def test_transitive_callers_depth2(self):
         """With max_depth=2, BFS should also return callers-of-callers."""
         conn = _make_conn()
-        # root → alpha → target
+        # root → alpha → target. The first hop's caller is alpha@a.py, so the
+        # root→alpha edge must resolve its callee (alpha) to a.py for the
+        # second hop to link (file_path is the caller file in unified edges).
         _insert_edge(conn, "alpha", "a.py", "target", "b.py")
-        _insert_edge(conn, "root", "r.py", "alpha", "a.py")
+        _insert_edge(conn, "root", "r.py", "alpha", "a.py", callee_resolved_file="a.py")
         result = bfs_callers(conn, "target", None, max_depth=2)
         caller_names = {r["caller_name"] for r in result}
         assert "alpha" in caller_names
@@ -267,10 +297,12 @@ class TestBfsCallees:
         assert result[0]["callee_resolved_file"] == "resolved.py"
 
     def test_callee_file_falls_back_to_file_path(self):
+        # Unified edges: file_path is the caller file, so an unresolved callee
+        # reports that caller file as its location.
         conn = _make_conn()
         _insert_edge(conn, "caller", "a.py", "callee", "b.py", callee_resolved_file="")
         result = bfs_callees(conn, "caller", None, max_depth=1)
-        assert result[0]["callee_file"] == "b.py"
+        assert result[0]["callee_file"] == "a.py"
 
     def test_multiple_callees_all_returned(self):
         conn = _make_conn()

--- a/tests/unit/test_b1_reader_edge_parity.py
+++ b/tests/unit/test_b1_reader_edge_parity.py
@@ -55,6 +55,13 @@ CREATE TABLE IF NOT EXISTS edges (
     caller_name TEXT NOT NULL DEFAULT '',
     callee_name TEXT NOT NULL DEFAULT '',
     file_path TEXT NOT NULL DEFAULT '',
+    caller_line INTEGER NOT NULL DEFAULT 0,
+    callee_full TEXT NOT NULL DEFAULT '',
+    callee_line INTEGER NOT NULL DEFAULT 0,
+    language TEXT NOT NULL DEFAULT '',
+    callee_resolution TEXT NOT NULL DEFAULT 'unknown',
+    callee_resolved_file TEXT NOT NULL DEFAULT '',
+    callee_symbol_id INTEGER,
     UNIQUE(source_node_id, target_node_id, kind, line)
 )
 """.strip()
@@ -138,8 +145,9 @@ def _build_db(
         conn.execute(
             "INSERT OR REPLACE INTO edges"
             " (source_node_id, target_node_id, kind, line, provenance, metadata,"
-            "  caller_name, callee_name, file_path)"
-            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "  caller_name, callee_name, file_path, caller_line, callee_full,"
+            "  callee_line, language, callee_resolution, callee_resolved_file)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 source,
                 target,
@@ -150,6 +158,12 @@ def _build_db(
                 e["caller_name"],
                 e["callee_name"],
                 e["file_path"],
+                e["caller_line"],
+                e["callee_full"],
+                e["callee_line"],
+                e["language"],
+                e["callee_resolution"],
+                e["callee_resolved_file"],
             ),
         )
 
@@ -412,3 +426,94 @@ class TestConstraintEvaluatorParity:
             _build_db(tmp_path / "mig", _SPECS, drop_ast_call_edges=True)
         )
         assert migrated == legacy
+
+
+# ---------------------------------------------------------------------------
+# B1.3 — end-to-end Python resolution must land on the unified ``edges`` table.
+#
+# After dropping ``ast_call_edges`` + ``unresolved_refs``, second-pass
+# resolution (synapse + cross-file + unresolved second pass) writes its results
+# directly onto ``edges`` CALLS/EXTENDS rows. This snapshot pins the Python
+# resolution semantics so they cannot silently regress — Python is the main
+# scenario and its resolution must not degrade.
+# ---------------------------------------------------------------------------
+
+
+class TestB13PythonResolutionOnEdges:
+    @staticmethod
+    def _write_project(root: Path) -> None:
+        pkg = root / "pkg"
+        pkg.mkdir(parents=True)
+        (pkg / "__init__.py").write_text("", encoding="utf-8")
+        (pkg / "base.py").write_text(
+            "class LanguagePlugin:\n    pass\n", encoding="utf-8"
+        )
+        (pkg / "python_plugin.py").write_text(
+            "from .base import LanguagePlugin\n\n"
+            "class PythonPlugin(LanguagePlugin):\n    pass\n",
+            encoding="utf-8",
+        )
+        (pkg / "helper.py").write_text(
+            "def helper():\n    return 'ok'\n", encoding="utf-8"
+        )
+        (pkg / "service.py").write_text(
+            "from .helper import helper\n\ndef build():\n    return helper()\n",
+            encoding="utf-8",
+        )
+
+    def test_cross_file_resolution_lands_on_edges(self, tmp_path: Path) -> None:
+        from tree_sitter_analyzer.ast_cache import ASTCache
+        from tree_sitter_analyzer.graph.edge_store import EdgeKind, symbol_node
+
+        self._write_project(tmp_path)
+        cache = ASTCache(str(tmp_path))
+        try:
+            cache.index_project(max_files=20, workers=0)
+            conn = cache.get_conn()
+
+            # 1) Cross-file CALLS resolution recorded on the edges row itself.
+            call_row = conn.execute(
+                "SELECT callee_resolution, callee_resolved_file, callee_full "
+                "FROM edges WHERE kind = 'calls' AND caller_name = 'build' "
+                "AND callee_name = 'helper'"
+            ).fetchone()
+            assert call_row is not None
+            assert call_row["callee_resolution"] in {"project", "local"}
+            assert call_row["callee_resolved_file"] == "pkg/helper.py"
+
+            # 2) Cross-file EXTENDS resolved into a real edge (was unresolved_refs).
+            extends_row = conn.execute(
+                "SELECT 1 FROM edges WHERE kind = ? "
+                "AND source_node_id = ? AND target_node_id = ?",
+                (
+                    EdgeKind.EXTENDS.value,
+                    symbol_node("pkg/python_plugin.py", "PythonPlugin", 3),
+                    symbol_node("pkg/base.py", "LanguagePlugin", 1),
+                ),
+            ).fetchone()
+            assert extends_row is not None
+
+            # 3) Public reader API reflects the resolution (no ast_call_edges).
+            callees = cache.query_callees("build", "pkg/service.py")
+            assert any(
+                c["callee_name"] == "helper"
+                and c["callee_resolved_file"] == "pkg/helper.py"
+                for c in callees
+            )
+            callers = cache.query_callers("helper", "pkg/helper.py")
+            assert any(
+                c["caller_name"] == "build" and c["caller_file"] == "pkg/service.py"
+                for c in callers
+            )
+
+            # 4) The legacy tables are gone after the v11 migration.
+            tables = {
+                r[0]
+                for r in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                ).fetchall()
+            }
+            assert "ast_call_edges" not in tables
+            assert "unresolved_refs" not in tables
+        finally:
+            cache.close()

--- a/tests/unit/test_b1_reader_edge_parity.py
+++ b/tests/unit/test_b1_reader_edge_parity.py
@@ -305,6 +305,75 @@ class TestSymbolResolverParity:
 
 
 # ---------------------------------------------------------------------------
+# ast_cache.py — ASTCache.get_call_edges  (B1.2b: the 6th content reader)
+# ---------------------------------------------------------------------------
+
+
+class TestGetCallEdgesParity:
+    """``ASTCache.get_call_edges`` must return byte-for-byte identical rows
+    whether sourced from ``ast_call_edges`` or from the unified ``edges`` table.
+    """
+
+    def _run(self, tmp_path: Path, conn: sqlite3.Connection):
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        cache = _mock_cache(tmp_path, conn)
+        # Invoke the real, unbound method against the mock's connection so the
+        # parity check exercises the production SQL, not the MagicMock stub.
+        rows = ASTCache.get_call_edges(cache)
+        # Sort for a deterministic comparison independent of row insertion order
+        # / table physical layout (ast_call_edges has an id PK; edges does too,
+        # but the migrated SELECT carries no ORDER BY — matching legacy).
+        return sorted(
+            rows,
+            key=lambda r: (
+                r["caller_name"],
+                r["caller_file"],
+                r["caller_line"],
+                r["callee_name"],
+                r["callee_line"],
+            ),
+        )
+
+    def test_edges_only_matches_legacy(self, tmp_path: Path):
+        legacy = self._run(tmp_path, _build_db(tmp_path / "legacy", _SPECS))
+        migrated = self._run(
+            tmp_path, _build_db(tmp_path / "mig", _SPECS, drop_ast_call_edges=True)
+        )
+        assert migrated == legacy
+
+    def test_returns_all_columns_from_edges_alone(self, tmp_path: Path):
+        """The post-migration reader must surface every legacy column from the
+        ``edges`` table by itself (real columns + json_extract scalars)."""
+        rows = self._run(
+            tmp_path, _build_db(tmp_path / "mig", _SPECS, drop_ast_call_edges=True)
+        )
+        assert len(rows) == len(_SPECS)
+        expected_keys = {
+            "caller_name",
+            "caller_file",
+            "caller_line",
+            "callee_name",
+            "callee_full",
+            "callee_line",
+            "file_path",
+            "language",
+        }
+        for row in rows:
+            assert set(row.keys()) == expected_keys
+        # Spot-check the resolved/qualified-callee row carries its scalars.
+        a_to_b = next(
+            r for r in rows if r["caller_name"] == "main" and r["callee_name"] == "foo"
+        )
+        assert a_to_b["caller_file"] == "a.py"
+        assert a_to_b["caller_line"] == 10
+        assert a_to_b["callee_full"] == "mod.foo"
+        assert a_to_b["callee_line"] == 12
+        assert a_to_b["file_path"] == "a.py"
+        assert a_to_b["language"] == "python"
+
+
+# ---------------------------------------------------------------------------
 # constraints/evaluator.py — evaluate
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_b1_reader_edge_parity.py
+++ b/tests/unit/test_b1_reader_edge_parity.py
@@ -1,0 +1,345 @@
+"""B1.2 parity tests: the 5 readers must return identical results whether the
+underlying CALLS data lives in the legacy ``ast_call_edges`` table or in the
+unified ``edges`` table.
+
+The migration (B1.2) switches each reader's SQL source from ``ast_call_edges``
+to ``edges`` (with a ``kind='calls'`` predicate). These tests build a single
+DB that holds BOTH tables, populated from the same edge specs in the exact
+shape the production write path produces, then assert each reader yields
+byte-for-byte identical output regardless of which table is queried.
+
+A ``drop_ast_call_edges`` fixture knob removes the legacy table so each parity
+test can prove the reader works against ``edges`` ALONE (the post-migration
+state) — not merely that it happens to read the legacy table.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+from tree_sitter_analyzer.graph.edge_store import EdgeKind, symbol_node
+
+# ---------------------------------------------------------------------------
+# Shared fixture: build a DB holding ast_call_edges + edges from one spec list
+# ---------------------------------------------------------------------------
+
+_AST_CALL_EDGES_DDL = """
+CREATE TABLE IF NOT EXISTS ast_call_edges (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    caller_name TEXT NOT NULL,
+    caller_file TEXT NOT NULL,
+    caller_line INTEGER NOT NULL,
+    callee_name TEXT NOT NULL,
+    callee_full TEXT NOT NULL DEFAULT '',
+    callee_line INTEGER NOT NULL DEFAULT 0,
+    callee_resolution TEXT NOT NULL DEFAULT 'unknown',
+    callee_resolved_file TEXT NOT NULL DEFAULT '',
+    file_path TEXT NOT NULL,
+    language TEXT NOT NULL
+)
+""".strip()
+
+_EDGES_DDL = """
+CREATE TABLE IF NOT EXISTS edges (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source_node_id TEXT NOT NULL,
+    target_node_id TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    line INTEGER,
+    provenance TEXT DEFAULT 'tree-sitter',
+    metadata TEXT,
+    caller_name TEXT NOT NULL DEFAULT '',
+    callee_name TEXT NOT NULL DEFAULT '',
+    file_path TEXT NOT NULL DEFAULT '',
+    UNIQUE(source_node_id, target_node_id, kind, line)
+)
+""".strip()
+
+
+def _normalise(spec: dict[str, Any]) -> dict[str, Any]:
+    caller_file = spec["caller_file"]
+    return {
+        "caller_name": spec["caller_name"],
+        "caller_file": caller_file,
+        "caller_line": int(spec.get("caller_line", 1)),
+        "callee_name": spec["callee_name"],
+        "callee_full": spec.get("callee_full", spec["callee_name"]),
+        "callee_line": int(spec.get("callee_line", 1)),
+        "callee_resolution": spec.get("callee_resolution", "unknown"),
+        "callee_resolved_file": spec.get("callee_resolved_file", ""),
+        "file_path": caller_file,
+        "language": spec.get("language", "python"),
+    }
+
+
+def _build_db(
+    tmp_path: Path,
+    specs: list[dict[str, Any]],
+    *,
+    drop_ast_call_edges: bool = False,
+) -> sqlite3.Connection:
+    """Build a DB with both tables populated identically from ``specs``.
+
+    Mirrors the production write path: ``ast_call_edges`` rows come from
+    ``write_call_edges`` (+ resolution columns), and ``edges`` CALLS rows are
+    produced exactly as ``write_graph_edges_for_file`` would (node ids via
+    ``symbol_node``, scalars in the metadata JSON blob, real name columns).
+    """
+    cache_dir = tmp_path / ".ast-cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(cache_dir / "index.db"))
+    conn.row_factory = sqlite3.Row
+    conn.execute(_AST_CALL_EDGES_DDL)
+    conn.execute(_EDGES_DDL)
+    # symbol_resolver._find_references also consults ast_index for import refs;
+    # an empty table keeps that path a no-op so the parity check isolates the
+    # call-edge source migration.
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS ast_index ("
+        " file_path TEXT, language TEXT, symbols_json TEXT, imports_json TEXT)"
+    )
+
+    for e in (_normalise(s) for s in specs):
+        conn.execute(
+            "INSERT INTO ast_call_edges (caller_name, caller_file, caller_line,"
+            " callee_name, callee_full, callee_line, callee_resolution,"
+            " callee_resolved_file, file_path, language)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                e["caller_name"],
+                e["caller_file"],
+                e["caller_line"],
+                e["callee_name"],
+                e["callee_full"],
+                e["callee_line"],
+                e["callee_resolution"],
+                e["callee_resolved_file"],
+                e["file_path"],
+                e["language"],
+            ),
+        )
+
+        source = symbol_node(e["caller_file"], e["caller_name"], e["caller_line"])
+        target_file = e["callee_resolved_file"] or e["caller_file"]
+        target = symbol_node(target_file, e["callee_name"], e["callee_line"])
+        metadata = {
+            "language": e["language"],
+            "caller_name": e["caller_name"],
+            "caller_line": e["caller_line"],
+            "callee_name": e["callee_name"],
+            "callee_full": e["callee_full"],
+            "callee_resolution": e["callee_resolution"],
+            "callee_resolved_file": e["callee_resolved_file"],
+        }
+        conn.execute(
+            "INSERT OR REPLACE INTO edges"
+            " (source_node_id, target_node_id, kind, line, provenance, metadata,"
+            "  caller_name, callee_name, file_path)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                source,
+                target,
+                EdgeKind.CALLS.value,
+                e["callee_line"],
+                "tree-sitter",
+                json.dumps(metadata, ensure_ascii=False, sort_keys=True),
+                e["caller_name"],
+                e["callee_name"],
+                e["file_path"],
+            ),
+        )
+
+    if drop_ast_call_edges:
+        conn.execute("DROP TABLE ast_call_edges")
+    conn.commit()
+    return conn
+
+
+def _mock_cache(tmp_path: Path, conn: sqlite3.Connection) -> MagicMock:
+    cache = MagicMock()
+    cache._project_root = str(tmp_path)
+    cache.project_root = str(tmp_path)
+    cache.has_call_edges.return_value = True
+    cache.get_conn.return_value = conn
+    cache._get_conn.return_value = conn
+    return cache
+
+
+# A spec exercising resolved + unresolved + qualified-callee cases.
+_SPECS: list[dict[str, Any]] = [
+    {
+        "caller_name": "main",
+        "caller_file": "a.py",
+        "caller_line": 10,
+        "callee_name": "foo",
+        "callee_full": "mod.foo",
+        "callee_line": 12,
+        "callee_resolution": "project",
+        "callee_resolved_file": "b.py",
+        "language": "python",
+    },
+    {
+        "caller_name": "foo",
+        "caller_file": "b.py",
+        "caller_line": 5,
+        "callee_name": "bar",
+        "callee_full": "bar",
+        "callee_line": 7,
+        "callee_resolution": "project",
+        "callee_resolved_file": "c.py",
+        "language": "python",
+    },
+    {
+        "caller_name": "main",
+        "caller_file": "a.py",
+        "caller_line": 11,
+        "callee_name": "ext",
+        "callee_full": "ext",
+        "callee_line": 13,
+        "callee_resolution": "unknown",
+        "callee_resolved_file": "",
+        "language": "python",
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# call_path.py — _query_forward_edges / _query_backward_edges
+# ---------------------------------------------------------------------------
+
+
+class TestCallPathParity:
+    def _run(self, conn: sqlite3.Connection):
+        from tree_sitter_analyzer.call_path import CallPathFinder
+
+        fwd_all = CallPathFinder._query_forward_edges(conn, "main", None)
+        fwd_scoped = CallPathFinder._query_forward_edges(conn, "main", "a.py")
+        bwd_all = CallPathFinder._query_backward_edges(conn, "bar", None)
+        bwd_scoped = CallPathFinder._query_backward_edges(conn, "foo", "b.py")
+        return fwd_all, fwd_scoped, bwd_all, bwd_scoped
+
+    def test_edges_only_matches_legacy(self, tmp_path: Path):
+        legacy = self._run(_build_db(tmp_path / "legacy", _SPECS))
+        migrated = self._run(
+            _build_db(tmp_path / "mig", _SPECS, drop_ast_call_edges=True)
+        )
+        assert migrated == legacy
+
+
+# ---------------------------------------------------------------------------
+# _ast_cache_graph.py — _bfs_callers_impl / _bfs_callees_impl
+# ---------------------------------------------------------------------------
+
+
+class TestAstCacheGraphParity:
+    def _run(self, conn: sqlite3.Connection):
+        from tree_sitter_analyzer._ast_cache_graph import bfs_callees, bfs_callers
+
+        callers = bfs_callers(conn, "bar", None, max_depth=2)
+        callers_scoped = bfs_callers(conn, "foo", "b.py", max_depth=1)
+        callees = bfs_callees(conn, "main", None, max_depth=2)
+        callees_scoped = bfs_callees(conn, "main", "a.py", max_depth=1)
+        return callers, callers_scoped, callees, callees_scoped
+
+    def test_edges_only_matches_legacy(self, tmp_path: Path):
+        legacy = self._run(_build_db(tmp_path / "legacy", _SPECS))
+        migrated = self._run(
+            _build_db(tmp_path / "mig", _SPECS, drop_ast_call_edges=True)
+        )
+        assert migrated == legacy
+
+
+# ---------------------------------------------------------------------------
+# xref.py — _find_callers / _find_callees / _file_callers / _file_callees /
+#           _find_file_dependents
+# ---------------------------------------------------------------------------
+
+
+class TestXrefParity:
+    def _run(self, tmp_path: Path, conn: sqlite3.Connection):
+        from tree_sitter_analyzer.xref import XRefEngine
+
+        cache = _mock_cache(tmp_path, conn)
+        tool = XRefEngine(cache)
+        return {
+            "callers": tool._find_callers(conn, "foo", None),
+            "callers_scoped": tool._find_callers(conn, "foo", "a.py"),
+            "callees": tool._find_callees(conn, "main", None),
+            "callees_scoped": tool._find_callees(conn, "main", "a.py"),
+            "file_callers": tool._file_callers(conn, "b.py"),
+            "file_callees": tool._file_callees(conn, "a.py"),
+            "file_dependents": tool._find_file_dependents(conn, "b.py"),
+        }
+
+    def test_edges_only_matches_legacy(self, tmp_path: Path):
+        legacy = self._run(tmp_path, _build_db(tmp_path / "legacy", _SPECS))
+        migrated = self._run(
+            tmp_path, _build_db(tmp_path / "mig", _SPECS, drop_ast_call_edges=True)
+        )
+        assert migrated == legacy
+
+
+# ---------------------------------------------------------------------------
+# symbol_resolver.py — _find_references
+# ---------------------------------------------------------------------------
+
+
+class TestSymbolResolverParity:
+    def _run(self, tmp_path: Path, conn: sqlite3.Connection):
+        from tree_sitter_analyzer.symbol_resolver import SymbolResolver
+
+        resolver = SymbolResolver(_mock_cache(tmp_path, conn))
+        refs = resolver._find_references("foo", "foo")
+        return [(r.file, r.name, r.kind, r.line, r.language) for r in refs]
+
+    def test_edges_only_matches_legacy(self, tmp_path: Path):
+        legacy = self._run(tmp_path, _build_db(tmp_path / "legacy", _SPECS))
+        migrated = self._run(
+            tmp_path, _build_db(tmp_path / "mig", _SPECS, drop_ast_call_edges=True)
+        )
+        assert migrated == legacy
+
+
+# ---------------------------------------------------------------------------
+# constraints/evaluator.py — evaluate
+# ---------------------------------------------------------------------------
+
+
+class TestConstraintEvaluatorParity:
+    def _run(self, conn: sqlite3.Connection):
+        from tree_sitter_analyzer.constraints.evaluator import evaluate
+        from tree_sitter_analyzer.constraints.schema import Constraint
+
+        constraints = [
+            Constraint(
+                id="no-a-to-b",
+                severity="error",
+                rule="forbid",
+                from_glob="a.py",
+                to_glob="b.py",
+                reason="test",
+            )
+        ]
+        violations = evaluate(constraints, conn)
+        return [
+            (
+                v.rule_id,
+                v.caller_file,
+                v.caller_name,
+                v.caller_line,
+                v.callee_name,
+                v.callee_file,
+            )
+            for v in violations
+        ]
+
+    def test_edges_only_matches_legacy(self, tmp_path: Path):
+        legacy = self._run(_build_db(tmp_path / "legacy", _SPECS))
+        migrated = self._run(
+            _build_db(tmp_path / "mig", _SPECS, drop_ast_call_edges=True)
+        )
+        assert migrated == legacy

--- a/tests/unit/test_call_path.py
+++ b/tests/unit/test_call_path.py
@@ -1,5 +1,6 @@
 """Unit tests for call_path.py — CallPathFinder, CallChain, CallPathResult."""
 
+import json
 import sqlite3
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -10,9 +11,16 @@ from tree_sitter_analyzer.call_path import (
     CallPathResult,
     _files_in_chain,
 )
+from tree_sitter_analyzer.graph.edge_store import EdgeKind, symbol_node
 
 
 def _make_cache_with_edges(tmp_path: Path, edges: list[dict]) -> MagicMock:
+    """Build a cache whose DB holds the call edges in the unified ``edges`` table.
+
+    B1.2 moved the CALLS read path from ``ast_call_edges`` to ``edges``, so the
+    fixture populates ``edges`` CALLS rows in the production shape (node ids via
+    ``symbol_node``, scalars in metadata JSON, real name/file columns).
+    """
     cache_dir = tmp_path / ".ast-cache"
     cache_dir.mkdir(parents=True, exist_ok=True)
     db_path = str(cache_dir / "index.db")
@@ -24,41 +32,58 @@ def _make_cache_with_edges(tmp_path: Path, edges: list[dict]) -> MagicMock:
     conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row
     conn.execute(
-        "CREATE TABLE IF NOT EXISTS ast_call_edges ("
+        "CREATE TABLE IF NOT EXISTS edges ("
         "  id INTEGER PRIMARY KEY AUTOINCREMENT,"
-        "  caller_name TEXT NOT NULL,"
-        "  caller_file TEXT NOT NULL,"
-        "  caller_line INTEGER NOT NULL,"
-        "  callee_name TEXT NOT NULL,"
-        "  callee_full TEXT NOT NULL DEFAULT '',"
-        "  callee_line INTEGER NOT NULL DEFAULT 0,"
-        "  callee_resolved_file TEXT NOT NULL DEFAULT '',"
-        "  file_path TEXT NOT NULL,"
-        "  language TEXT NOT NULL"
+        "  source_node_id TEXT NOT NULL,"
+        "  target_node_id TEXT NOT NULL,"
+        "  kind TEXT NOT NULL,"
+        "  line INTEGER,"
+        "  provenance TEXT DEFAULT 'tree-sitter',"
+        "  metadata TEXT,"
+        "  caller_name TEXT NOT NULL DEFAULT '',"
+        "  callee_name TEXT NOT NULL DEFAULT '',"
+        "  file_path TEXT NOT NULL DEFAULT '',"
+        "  UNIQUE(source_node_id, target_node_id, kind, line)"
         ")"
     )
     conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_ce_callee_name ON ast_call_edges(callee_name)"
+        "CREATE INDEX IF NOT EXISTS idx_edges_callee_name ON edges(callee_name, kind)"
     )
     conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_ce_caller_name ON ast_call_edges(caller_name)"
+        "CREATE INDEX IF NOT EXISTS idx_edges_caller_name ON edges(caller_name, kind)"
     )
     for e in edges:
+        caller_name = e["caller_name"]
+        caller_file = e["caller_file"]
+        caller_line = e.get("caller_line", 1)
+        callee_name = e["callee_name"]
+        callee_line = e.get("callee_line", 1)
+        resolved = e.get("callee_resolved_file", "")
+        source = symbol_node(caller_file, caller_name, caller_line)
+        target = symbol_node(resolved or caller_file, callee_name, callee_line)
+        metadata = {
+            "language": e.get("language", "python"),
+            "caller_name": caller_name,
+            "caller_line": caller_line,
+            "callee_name": callee_name,
+            "callee_full": e.get("callee_full", callee_name),
+            "callee_resolution": "unknown",
+            "callee_resolved_file": resolved,
+        }
         conn.execute(
-            "INSERT INTO ast_call_edges (caller_name, caller_file, caller_line,"
-            "  callee_name, callee_full, callee_line, callee_resolved_file,"
-            "  file_path, language)"
+            "INSERT OR REPLACE INTO edges (source_node_id, target_node_id, kind,"
+            "  line, provenance, metadata, caller_name, callee_name, file_path)"
             " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
-                e["caller_name"],
-                e["caller_file"],
-                e.get("caller_line", 1),
-                e["callee_name"],
-                e.get("callee_full", e["callee_name"]),
-                e.get("callee_line", 1),
-                e.get("callee_resolved_file", ""),
-                e["caller_file"],
-                e.get("language", "python"),
+                source,
+                target,
+                EdgeKind.CALLS.value,
+                callee_line,
+                "tree-sitter",
+                json.dumps(metadata, ensure_ascii=False, sort_keys=True),
+                caller_name,
+                callee_name,
+                caller_file,
             ),
         )
     conn.commit()

--- a/tests/unit/test_callers_callees_tools.py
+++ b/tests/unit/test_callers_callees_tools.py
@@ -80,6 +80,19 @@ class TestCodeGraphCallersTool:
         )
         assert result["success"] is True
 
+    @pytest.mark.asyncio
+    async def test_caller_inlines_source_body(self, tiny_project_root):
+        """P2: each caller carries its inlined verbatim source body (no Read)."""
+        callers_tool = CodeGraphCallersTool(tiny_project_root)
+        result = await callers_tool.execute(
+            {"function_name": "bar", "output_format": "json"}
+        )
+        foo = next((c for c in result["callers"] if c["name"] == "foo"), None)
+        assert foo is not None, "foo should call bar in the fixture"
+        assert "body" in foo, "caller must carry inlined body"
+        assert "def foo" in foo["body"]["content"]
+        assert "no Read needed" in result["next_step"]
+
     def test_project_root_change_resets_cache(self, tiny_project_root):
         callers_tool = CodeGraphCallersTool(tiny_project_root)
         callers_tool.get_call_graph()
@@ -132,6 +145,19 @@ class TestCodeGraphCalleesTool:
             }
         )
         assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_callee_inlines_source_body(self, tiny_project_root):
+        """P2: each callee carries its inlined verbatim source body (no Read)."""
+        callees_tool = CodeGraphCalleesTool(tiny_project_root)
+        result = await callees_tool.execute(
+            {"function_name": "foo", "output_format": "json"}
+        )
+        bar = next((c for c in result["callees"] if c["name"] == "bar"), None)
+        assert bar is not None, "foo should call bar in the fixture"
+        assert "body" in bar, "callee must carry inlined body"
+        assert "def bar" in bar["body"]["content"]
+        assert "no Read needed" in result["next_step"]
 
     @pytest.mark.asyncio
     async def test_execute_toon_format(self, tiny_project_root):

--- a/tests/unit/test_codegraph_navigate_tool.py
+++ b/tests/unit/test_codegraph_navigate_tool.py
@@ -229,3 +229,47 @@ class TestProjectRootChanged:
         tool_with_root._on_project_root_changed(None)
         assert not tool_with_root.call_graph_initialized
         assert not tool_with_root.cache_initialized
+
+
+class TestDefinitionBodyInlining:
+    """P2: nav navigate inlines the definition body (coordinates -> content)."""
+
+    @pytest.fixture
+    def indexed(self, tmp_path):
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        (tmp_path / "svc.py").write_text(
+            "class UserService:\n"
+            "    def get_user(self, user_id):\n"
+            "        return self._find(user_id)\n"
+            "\n"
+            "    def _find(self, user_id):\n"
+            "        return 'FOUND_MARKER'\n",
+            encoding="utf-8",
+        )
+        cache = ASTCache(str(tmp_path))
+        cache.index_project(max_files=100)
+        cache.close()
+        return str(tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_definition_inlines_body(self, indexed):
+        tool = CodeGraphNavigateTool(indexed)
+        result = await tool.execute(
+            {"symbol": "_find", "mode": "definition", "output_format": "json"}
+        )
+        assert result["definition"]["found"] is True
+        defs = result["definition"]["definitions"]
+        bodied = [d for d in defs if "body" in d]
+        assert bodied, "definition must carry an inlined body"
+        assert "FOUND_MARKER" in bodied[0]["body"]["content"]
+        assert "no Read needed" in result["next_step"]
+
+    @pytest.mark.asyncio
+    async def test_definition_body_survives_toon(self, indexed):
+        tool = CodeGraphNavigateTool(indexed)
+        result = await tool.execute(
+            {"symbol": "_find", "mode": "definition", "output_format": "toon"}
+        )
+        assert result.get("format") == "toon"
+        assert "FOUND_MARKER" in result["toon_content"]

--- a/tests/unit/test_constraint_dsl.py
+++ b/tests/unit/test_constraint_dsl.py
@@ -73,58 +73,81 @@ def _stage_constraints_file(tmp_path: Path, fixture_name: str) -> Path:
 def _build_call_edges_db(
     db_path: Path, rows: list[tuple[str, str, int, str, str, str]]
 ) -> None:
-    """Create a minimal sqlite db with the ``ast_call_edges`` schema.
+    """Create a minimal sqlite db with the unified ``edges`` schema.
 
-    The schema mirrors ``ast_cache.py:_SCHEMA_V3_CALL_EDGES`` so the
-    evaluator can run against a real on-disk db without pulling in the
-    full ``ASTCache`` indexer.
+    B1.2 moved the constraint evaluator's read source from ``ast_call_edges``
+    to the single ``edges`` table.  The CALLS rows are written in the
+    production shape (node ids via ``symbol_node``, scalars in metadata JSON,
+    real name/file columns); the callee's resolved file lives in
+    ``metadata.callee_resolved_file`` so the evaluator's COALESCE-to-file_path
+    logic behaves exactly as it did against the legacy resolution columns.
 
     Each row tuple is (caller_name, caller_file, caller_line, callee_name,
     callee_full, callee_file).
     """
+    import json as _json
+
+    from tree_sitter_analyzer.graph.edge_store import EdgeKind, symbol_node
+
     db_path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(str(db_path))
     try:
         conn.execute(
             """
-            CREATE TABLE IF NOT EXISTS ast_call_edges (
-                id          INTEGER PRIMARY KEY AUTOINCREMENT,
-                caller_name TEXT NOT NULL,
-                caller_file TEXT NOT NULL,
-                caller_line INTEGER NOT NULL,
-                callee_name TEXT NOT NULL,
-                callee_full TEXT NOT NULL DEFAULT '',
-                callee_line INTEGER NOT NULL DEFAULT 0,
-                file_path   TEXT NOT NULL,
-                language    TEXT NOT NULL
+            CREATE TABLE IF NOT EXISTS edges (
+                id             INTEGER PRIMARY KEY AUTOINCREMENT,
+                source_node_id TEXT NOT NULL,
+                target_node_id TEXT NOT NULL,
+                kind           TEXT NOT NULL,
+                line           INTEGER,
+                provenance     TEXT DEFAULT 'tree-sitter',
+                metadata       TEXT,
+                caller_name    TEXT NOT NULL DEFAULT '',
+                callee_name    TEXT NOT NULL DEFAULT '',
+                file_path      TEXT NOT NULL DEFAULT '',
+                UNIQUE(source_node_id, target_node_id, kind, line)
             )
             """
         )
-        conn.executemany(
-            "INSERT INTO ast_call_edges "
-            "(caller_name, caller_file, caller_line, callee_name, "
-            " callee_full, callee_line, file_path, language) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-            [
+        params = []
+        for (
+            caller_name,
+            caller_file,
+            caller_line,
+            callee_name,
+            _callee_full,
+            callee_file,
+        ) in rows:
+            source = symbol_node(caller_file, caller_name, caller_line)
+            target = symbol_node(callee_file or caller_file, callee_name, 0)
+            metadata = {
+                "language": "python",
+                "caller_name": caller_name,
+                "caller_line": caller_line,
+                "callee_name": callee_name,
+                "callee_full": _callee_full,
+                "callee_resolution": "project" if callee_file else "unknown",
+                "callee_resolved_file": callee_file,
+            }
+            params.append(
                 (
-                    caller_name,
-                    caller_file,
-                    caller_line,
-                    callee_name,
-                    "",
+                    source,
+                    target,
+                    EdgeKind.CALLS.value,
                     0,
-                    callee_file,  # callee_file goes into file_path column
-                    "python",
-                )
-                for (
+                    "tree-sitter",
+                    _json.dumps(metadata, ensure_ascii=False, sort_keys=True),
                     caller_name,
-                    caller_file,
-                    caller_line,
                     callee_name,
-                    _callee_full,
-                    callee_file,
-                ) in rows
-            ],
+                    caller_file,
+                )
+            )
+        conn.executemany(
+            "INSERT OR REPLACE INTO edges "
+            "(source_node_id, target_node_id, kind, line, provenance, metadata, "
+            " caller_name, callee_name, file_path) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            params,
         )
         conn.commit()
     finally:

--- a/tests/unit/test_constraint_dsl.py
+++ b/tests/unit/test_constraint_dsl.py
@@ -92,23 +92,9 @@ def _build_call_edges_db(
     db_path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(str(db_path))
     try:
-        conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS edges (
-                id             INTEGER PRIMARY KEY AUTOINCREMENT,
-                source_node_id TEXT NOT NULL,
-                target_node_id TEXT NOT NULL,
-                kind           TEXT NOT NULL,
-                line           INTEGER,
-                provenance     TEXT DEFAULT 'tree-sitter',
-                metadata       TEXT,
-                caller_name    TEXT NOT NULL DEFAULT '',
-                callee_name    TEXT NOT NULL DEFAULT '',
-                file_path      TEXT NOT NULL DEFAULT '',
-                UNIQUE(source_node_id, target_node_id, kind, line)
-            )
-            """
-        )
+        from tree_sitter_analyzer.graph.edge_store import EDGE_STORE_SCHEMA
+
+        conn.executescript(EDGE_STORE_SCHEMA)
         params = []
         for (
             caller_name,
@@ -129,6 +115,8 @@ def _build_call_edges_db(
                 "callee_resolution": "project" if callee_file else "unknown",
                 "callee_resolved_file": callee_file,
             }
+            # B1.3: resolution scalars are real columns the evaluator reads
+            # directly (no json_extract), so populate them alongside metadata.
             params.append(
                 (
                     source,
@@ -140,13 +128,20 @@ def _build_call_edges_db(
                     caller_name,
                     callee_name,
                     caller_file,
+                    caller_line,
+                    _callee_full,
+                    0,
+                    "python",
+                    "project" if callee_file else "unknown",
+                    callee_file,
                 )
             )
         conn.executemany(
             "INSERT OR REPLACE INTO edges "
             "(source_node_id, target_node_id, kind, line, provenance, metadata, "
-            " caller_name, callee_name, file_path) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            " caller_name, callee_name, file_path, caller_line, callee_full, "
+            " callee_line, language, callee_resolution, callee_resolved_file) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             params,
         )
         conn.commit()

--- a/tests/unit/test_cross_file_backfill.py
+++ b/tests/unit/test_cross_file_backfill.py
@@ -76,8 +76,8 @@ class TestBackfillCrossFileEdges:
         cache.backfill_cross_file_edges()
         conn = cache._get_conn()
         rows = conn.execute(
-            "SELECT callee_name, callee_resolved_file FROM ast_call_edges "
-            "WHERE callee_resolved_file != ''"
+            "SELECT callee_name, callee_resolved_file FROM edges "
+            "WHERE kind = 'calls' AND callee_resolved_file != ''"
         ).fetchall()
         assert len(rows) > 0
         resolved_names = {r["callee_name"] for r in rows}
@@ -114,14 +114,9 @@ class TestBackfillCrossFileEdges:
         project.mkdir()
 
         (project / "a.py").write_text(
-            "from b import helper\n"
-            "def main():\n"
-            "    return helper()\n"
+            "from b import helper\ndef main():\n    return helper()\n"
         )
-        (project / "b.py").write_text(
-            "def helper():\n"
-            "    return 42\n"
-        )
+        (project / "b.py").write_text("def helper():\n    return 42\n")
 
         cache = ASTCache(str(project))
         stats = cache.index_project(max_files=100)

--- a/tests/unit/test_edge_store.py
+++ b/tests/unit/test_edge_store.py
@@ -8,8 +8,6 @@ import pytest
 
 from tree_sitter_analyzer._ast_cache_schema import apply_migration_v8
 from tree_sitter_analyzer._ast_cache_write import (
-    _GRAPH_CALL_EDGE_COLUMNS,
-    _row_to_dict,
     write_graph_edges_for_file,
 )
 from tree_sitter_analyzer.ast_cache import ASTCache
@@ -427,9 +425,7 @@ def test_ast_cache_call_queries_read_from_edge_store_when_legacy_edges_missing(
     cache = ASTCache(str(tmp_path))
     try:
         assert cache.index_file(str(sample))["status"] == "indexed"
-        cache.get_conn().execute("DELETE FROM ast_call_edges")
-        cache.get_conn().commit()
-
+        # B1.3: CALLS rows live only in the unified ``edges`` table.
         assert cache.has_call_edges() is True
         callers = cache.query_callers("bar")
         callees = cache.query_callees("foo", caller_file="sample.py")
@@ -481,7 +477,9 @@ def test_ast_cache_call_queries_fall_back_when_edge_store_empty(
 def test_ast_cache_get_call_edges_handles_missing_table(tmp_path: Path) -> None:
     cache = ASTCache(str(tmp_path))
     try:
-        cache.get_conn().execute("DROP TABLE ast_call_edges")
+        # B1.3: CALLS rows live in the unified ``edges`` table. Dropping it
+        # exercises the missing-table degrade path for both readers.
+        cache.get_conn().execute("DROP TABLE edges")
         cache.get_conn().commit()
 
         assert cache.get_call_edges() == []
@@ -591,9 +589,8 @@ def test_project_index_refreshes_edge_store_with_resolved_call_metadata(
         stats = cache.index_project(force=True)
         assert stats["indexed"] == 1
 
-        cache.get_conn().execute("DELETE FROM ast_call_edges")
-        cache.get_conn().commit()
-
+        # B1.3: CALLS rows live only in the unified ``edges`` table; querying
+        # callees reads them directly (no ast_call_edges to clear).
         callees = cache.query_callees("foo", caller_file="sample.py")
         assert callees == [
             {
@@ -649,34 +646,6 @@ def test_write_graph_edges_handles_empty_imports_and_missing_parent(
         conn.close()
 
 
-def test_graph_call_edge_row_mapping_supports_tuple_rows() -> None:
-    row = (
-        "caller",
-        "caller.py",
-        10,
-        "callee",
-        "pkg.callee",
-        20,
-        "caller.py",
-        "python",
-        "project",
-        "callee.py",
-    )
-
-    assert _row_to_dict(row, _GRAPH_CALL_EDGE_COLUMNS) == {
-        "caller_name": "caller",
-        "caller_file": "caller.py",
-        "caller_line": 10,
-        "callee_name": "callee",
-        "callee_full": "pkg.callee",
-        "callee_line": 20,
-        "file_path": "caller.py",
-        "language": "python",
-        "callee_resolution": "project",
-        "callee_resolved_file": "callee.py",
-    }
-
-
 def test_write_graph_edges_logs_operational_error(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -685,7 +654,9 @@ def test_write_graph_edges_logs_operational_error(
         def __init__(self, _conn: sqlite3.Connection, **_kwargs: Any) -> None:
             pass
 
-        def replace_edges_for_file(self, _file_path: str, _edges: list[Edge]) -> None:
+        def replace_edges_for_file(
+            self, _file_path: str, _edges: list[Edge], **_kwargs: Any
+        ) -> None:
             raise sqlite3.OperationalError("boom")
 
     monkeypatch.setattr(edge_store_module, "EdgeStore", BrokenEdgeStore)

--- a/tests/unit/test_edge_store_name_columns.py
+++ b/tests/unit/test_edge_store_name_columns.py
@@ -1,0 +1,249 @@
+"""B1.1 — edges table name columns + SQL pushdown for CALLS queries.
+
+These tests pin the non-breaking first step of B1 (single edge table):
+- ``edges`` gains ``caller_name`` / ``callee_name`` / ``file_path`` real columns
+  (schema v10) plus indexes on the two name columns.
+- The CALLS read paths (``query_callers`` / ``query_callees``) push the name
+  filter down to SQL ``WHERE callee_name = ?`` / ``WHERE caller_name = ?``
+  instead of pulling the whole ``kind='calls'`` slice into Python.
+- Results stay byte-for-byte identical to the pre-change behaviour.
+
+The JSON ``metadata`` blob is intentionally retained (B1.3 removes it).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from tree_sitter_analyzer.ast_cache import ASTCache
+from tree_sitter_analyzer.graph.edge_store import (
+    Edge,
+    EdgeKind,
+    EdgeStore,
+    symbol_node,
+)
+
+
+def _edges_columns(conn: sqlite3.Connection) -> set[str]:
+    return {row[1] for row in conn.execute("PRAGMA table_info(edges)").fetchall()}
+
+
+def _edges_indexes(conn: sqlite3.Connection) -> set[str]:
+    return {row[1] for row in conn.execute("PRAGMA index_list(edges)").fetchall()}
+
+
+def test_edges_table_has_name_and_file_columns(tmp_path: Path) -> None:
+    """edges schema exposes caller_name / callee_name / file_path real columns."""
+    store = EdgeStore(str(tmp_path / "edges.db"))
+    try:
+        cols = _edges_columns(store.conn)
+        assert {"caller_name", "callee_name", "file_path"}.issubset(cols)
+        # JSON blob is still present (removal is B1.3, not B1.1).
+        assert "metadata" in cols
+    finally:
+        store.close()
+
+
+def test_edges_table_indexes_name_columns(tmp_path: Path) -> None:
+    """Name columns are indexed so CALLS queries can push the filter to SQL."""
+    store = EdgeStore(str(tmp_path / "edges.db"))
+    try:
+        indexes = _edges_indexes(store.conn)
+        assert "idx_edges_callee_name" in indexes
+        assert "idx_edges_caller_name" in indexes
+    finally:
+        store.close()
+
+
+def test_ast_cache_migration_v10_recorded(tmp_path: Path) -> None:
+    """A fresh ASTCache stamps schema version 10 and the new edges columns."""
+    cache = ASTCache(str(tmp_path))
+    try:
+        conn = cache.get_conn()
+        cols = _edges_columns(conn)
+        assert {"caller_name", "callee_name", "file_path"}.issubset(cols)
+        row = conn.execute(
+            "SELECT version FROM ast_schema_version WHERE version = 10"
+        ).fetchone()
+        assert row is not None
+    finally:
+        cache.close()
+
+
+def test_upsert_populates_name_columns_from_metadata(tmp_path: Path) -> None:
+    """upsert_edges writes caller_name/callee_name/file_path real columns."""
+    store = EdgeStore(str(tmp_path / "edges.db"))
+    try:
+        store.upsert_edges(
+            [
+                Edge(
+                    symbol_node("pkg/a.py", "foo", 10),
+                    symbol_node("pkg/a.py", "bar", 11),
+                    EdgeKind.CALLS,
+                    11,
+                    metadata={
+                        "caller_name": "foo",
+                        "callee_name": "bar",
+                        "callee_full": "bar",
+                    },
+                )
+            ]
+        )
+        row = store.conn.execute(
+            "SELECT caller_name, callee_name, file_path FROM edges WHERE kind = 'calls'"
+        ).fetchone()
+        assert row["caller_name"] == "foo"
+        assert row["callee_name"] == "bar"
+        assert row["file_path"] == "pkg/a.py"
+    finally:
+        store.close()
+
+
+def test_calls_query_uses_index_not_full_scan(tmp_path: Path) -> None:
+    """query_callers' direct lookup plans use the callee_name index, not a scan."""
+    store = EdgeStore(str(tmp_path / "edges.db"))
+    try:
+        store.upsert_edges(
+            [
+                Edge(
+                    symbol_node("pkg/a.py", "foo", 10),
+                    symbol_node("pkg/a.py", "bar", 11),
+                    EdgeKind.CALLS,
+                    11,
+                    metadata={"callee_full": "bar"},
+                )
+            ]
+        )
+        plan = store.conn.execute(
+            "EXPLAIN QUERY PLAN SELECT * FROM edges WHERE callee_name = ? AND kind = ?",
+            ("bar", "calls"),
+        ).fetchall()
+        detail = " ".join(str(r[-1]) for r in plan)
+        assert "idx_edges_callee_name" in detail
+        assert "SCAN edges" not in detail
+    finally:
+        store.close()
+
+
+def test_calls_queries_results_unchanged(tmp_path: Path) -> None:
+    """Pushed-down CALLS queries return identical entries to the legacy path."""
+    store = EdgeStore(str(tmp_path / "edges.db"))
+    try:
+        store.upsert_edges(
+            [
+                Edge(
+                    symbol_node("pkg/a.py", "foo", 10),
+                    symbol_node("pkg/a.py", "bar", 11),
+                    EdgeKind.CALLS,
+                    11,
+                    metadata={"callee_full": "bar"},
+                ),
+                Edge(
+                    symbol_node("pkg/b.py", "baz", 20),
+                    symbol_node("pkg/a.py", "foo", 10),
+                    EdgeKind.CALLS,
+                    21,
+                    metadata={"callee_full": "foo"},
+                ),
+                Edge(
+                    symbol_node("pkg/a.py", "bar", 11),
+                    symbol_node("pkg/c.py", "qux", 30),
+                    EdgeKind.CALLS,
+                    31,
+                    metadata={"callee_full": "qux"},
+                ),
+            ]
+        )
+
+        assert store.query_callees("foo", "pkg/a.py") == [
+            {
+                "caller_name": "foo",
+                "caller_file": "pkg/a.py",
+                "caller_line": 10,
+                "callee_name": "bar",
+                "callee_full": "bar",
+                "callee_file": "pkg/a.py",
+                "callee_resolved_file": "",
+                "callee_line": 11,
+                "depth": 1,
+            }
+        ]
+        callees_depth2 = store.query_callees("foo", "pkg/a.py", max_depth=2)
+        assert [(entry["callee_name"], entry["depth"]) for entry in callees_depth2] == [
+            ("bar", 1),
+            ("qux", 2),
+        ]
+        callers = store.query_callers("bar", max_depth=2)
+        assert [entry["caller_name"] for entry in callers] == ["foo", "baz"]
+        assert [
+            entry["caller_name"] for entry in store.query_callers("bar", "pkg/a.py")
+        ] == ["foo"]
+    finally:
+        store.close()
+
+
+def test_indexed_file_populates_name_columns(tmp_path: Path) -> None:
+    """Indexing a real file fills the new columns end-to-end via the write path."""
+    sample = tmp_path / "sample.py"
+    sample.write_text(
+        "def foo():\n    bar()\n\ndef bar():\n    return 1\n",
+        encoding="utf-8",
+    )
+    cache = ASTCache(str(tmp_path))
+    try:
+        assert cache.index_file(str(sample))["status"] == "indexed"
+        row = (
+            cache.get_conn()
+            .execute(
+                "SELECT caller_name, callee_name, file_path FROM edges "
+                "WHERE kind = 'calls' AND callee_name = 'bar'"
+            )
+            .fetchone()
+        )
+        assert row is not None
+        assert row["caller_name"] == "foo"
+        assert row["callee_name"] == "bar"
+        assert row["file_path"] == "sample.py"
+    finally:
+        cache.close()
+
+
+def test_legacy_v9_db_upgrades_to_v10(tmp_path: Path) -> None:
+    """A pre-existing edges table without name columns is migrated to v10."""
+    db_path = tmp_path / ".ast-cache" / "cache.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
+    try:
+        # Simulate a v8/v9 edges table missing the new columns.
+        conn.executescript(
+            """
+            CREATE TABLE edges (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                source_node_id TEXT NOT NULL,
+                target_node_id TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                line INTEGER,
+                provenance TEXT DEFAULT 'tree-sitter',
+                metadata TEXT,
+                UNIQUE(source_node_id, target_node_id, kind, line)
+            );
+            INSERT INTO edges
+                (source_node_id, target_node_id, kind, line, provenance, metadata)
+            VALUES
+                ('pkg/a.py:foo:10', 'pkg/a.py:bar:11', 'calls', 11,
+                 'tree-sitter',
+                 '{"caller_name": "foo", "callee_name": "bar"}');
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    # Opening through EdgeStore.ensure_schema must add the columns idempotently.
+    store = EdgeStore(str(db_path))
+    try:
+        cols = _edges_columns(store.conn)
+        assert {"caller_name", "callee_name", "file_path"}.issubset(cols)
+    finally:
+        store.close()

--- a/tests/unit/test_schema_integrity.py
+++ b/tests/unit/test_schema_integrity.py
@@ -157,21 +157,22 @@ class TestSelfCheckDetection:
         reason="Windows-specific incompatibility — tracked separately",
     )
     def test_self_check_detects_missing_column(self, tmp_path: Path) -> None:
-        """Drop callee_resolution from ast_call_edges → SchemaIntegrityError.
+        """Drop callee_resolution from the unified ``edges`` table → error.
 
-        The exact bug being closed: a missing ALTER TABLE leaves
-        ast_call_edges without callee_resolution. The check must catch
-        this on open instead of letting query-time fail downstream.
+        The exact bug being closed: a missing ALTER TABLE leaves ``edges``
+        without callee_resolution (B1.3 promoted it to a real column). The
+        check must catch this on open instead of failing downstream at query
+        time.
         """
         proj_root, db_path = _make_proj(tmp_path)
         _seed_healthy_db(str(db_path))
-        _drop_column_raw(str(db_path), "ast_call_edges", "callee_resolution")
+        _drop_column_raw(str(db_path), "edges", "callee_resolution")
 
         with pytest.raises(SchemaIntegrityError) as exc_info:
             ASTCache(str(proj_root), db_path=str(db_path))
 
         err_msg = str(exc_info.value)
-        assert "ast_call_edges.callee_resolution" in err_msg, (
+        assert "edges.callee_resolution" in err_msg, (
             f"Expected error to name the missing column (got: {err_msg!r})"
         )
         assert str(db_path) in err_msg, (
@@ -201,8 +202,8 @@ class TestSelfCheckDetection:
         _seed_healthy_db(str(db_path))
         # Raw helpers so migrations never run between drops (which would
         # heal the first drop before we could stage the second).
-        _drop_column_raw(str(db_path), "ast_call_edges", "callee_resolution")
-        _drop_column_raw(str(db_path), "ast_call_edges", "callee_resolved_file")
+        _drop_column_raw(str(db_path), "edges", "callee_resolution")
+        _drop_column_raw(str(db_path), "edges", "callee_resolved_file")
         _drop_table_raw(str(db_path), "ast_symbol_activation")
 
         with pytest.raises(SchemaIntegrityError) as exc_info:
@@ -210,8 +211,8 @@ class TestSelfCheckDetection:
 
         err_msg = str(exc_info.value)
         for needle in (
-            "ast_call_edges.callee_resolution",
-            "ast_call_edges.callee_resolved_file",
+            "edges.callee_resolution",
+            "edges.callee_resolved_file",
             "ast_symbol_activation",
         ):
             assert needle in err_msg, (

--- a/tests/unit/test_symbol_search_tool.py
+++ b/tests/unit/test_symbol_search_tool.py
@@ -148,6 +148,30 @@ class TestCodeGraphSymbolSearchExecution:
         result = await tool.execute({"query": "UserService", "output_format": "json"})
         assert "codegraph_explore" in result["next_step"]
 
+    async def test_top_match_inlines_source_body(self, indexed_project):
+        """P2: top matches carry an inlined verbatim source body (no Read)."""
+        tool = CodeGraphSymbolSearchTool(str(indexed_project))
+        result = await tool.execute({"query": "get_user", "output_format": "json"})
+        assert result["match_count"] >= 1
+        hit = next(r for r in result["results"] if r["name"] == "get_user")
+        assert "body" in hit, "top match must carry inlined body"
+        assert "content" in hit["body"]
+        assert "def get_user" in hit["body"]["content"]
+        assert "_find_user" in hit["body"]["content"]
+
+    async def test_search_deterrent_next_step(self, indexed_project):
+        """P2: a deterrent tells the agent to answer from inlined bodies."""
+        tool = CodeGraphSymbolSearchTool(str(indexed_project))
+        result = await tool.execute({"query": "get_user", "output_format": "json"})
+        assert "no Read needed" in result["next_step"]
+
+    async def test_search_body_survives_toon(self, indexed_project):
+        """P2: inlined body survives TOON serialization (MCP default)."""
+        tool = CodeGraphSymbolSearchTool(str(indexed_project))
+        result = await tool.execute({"query": "get_user", "output_format": "toon"})
+        assert result.get("format") == "toon"
+        assert "def get_user" in result["toon_content"]
+
     async def test_toon_output_format(self, indexed_project):
         tool = CodeGraphSymbolSearchTool(str(indexed_project))
         result = await tool.execute({"query": "UserService", "output_format": "toon"})

--- a/tests/unit/test_synapse_resolution.py
+++ b/tests/unit/test_synapse_resolution.py
@@ -82,10 +82,14 @@ def _table_exists(conn: sqlite3.Connection, name: str) -> bool:
 def _edges_for_caller(
     conn: sqlite3.Connection, caller_name: str, pkg_name: str = "synapse_pkg"
 ) -> list[sqlite3.Row]:
-    """ast_call_edges rows for ``caller_name``, scoped to the fixture pkg."""
+    """CALLS edges for ``caller_name`` (unified ``edges`` table), scoped to pkg.
+
+    B1.3: CALLS rows + their resolution columns live in ``edges``; ``file_path``
+    is the caller's file (== legacy ``ast_call_edges.caller_file``).
+    """
     return conn.execute(
-        "SELECT * FROM ast_call_edges "
-        "WHERE caller_name = ? AND file_path LIKE ? "
+        "SELECT * FROM edges "
+        "WHERE kind = 'calls' AND caller_name = ? AND file_path LIKE ? "
         "ORDER BY caller_line, callee_line",
         (caller_name, f"{pkg_name}%"),
     ).fetchall()
@@ -100,23 +104,23 @@ class TestSchemaMigration:
     """The cache DB must surface the new columns / table on first init."""
 
     def test_schema_migration_adds_columns(self, tmp_path: Path) -> None:
-        """ast_call_edges has callee_symbol_id / callee_resolution /
-        callee_resolved_file, and ast_imports table exists."""
+        """The unified ``edges`` table carries callee_symbol_id /
+        callee_resolution / callee_resolved_file (B1.3), and ast_imports exists."""
         cache = ASTCache(str(tmp_path))
         try:
             with _open_db(cache) as conn:
-                # New columns on ast_call_edges.
-                edge_cols = _column_names(conn, "ast_call_edges")
+                # Resolution columns now live on the unified ``edges`` table.
+                edge_cols = _column_names(conn, "edges")
                 assert "callee_symbol_id" in edge_cols, (
-                    "Expected ast_call_edges.callee_symbol_id column "
+                    "Expected edges.callee_symbol_id column "
                     f"(have: {sorted(edge_cols)})"
                 )
                 assert "callee_resolution" in edge_cols, (
-                    "Expected ast_call_edges.callee_resolution column "
+                    "Expected edges.callee_resolution column "
                     f"(have: {sorted(edge_cols)})"
                 )
                 assert "callee_resolved_file" in edge_cols, (
-                    "Expected ast_call_edges.callee_resolved_file column "
+                    "Expected edges.callee_resolved_file column "
                     f"(have: {sorted(edge_cols)})"
                 )
 
@@ -149,17 +153,20 @@ class TestSchemaMigration:
         cache = ASTCache(str(tmp_path))
         try:
             with _open_db(cache) as conn:
-                # Insert minimal row with only the legacy columns set.
+                # Insert a CALLS edge with only the structural columns set; the
+                # resolution columns must default exactly as the resolver's
+                # "unknown" verdict (B1.3 — edges, not ast_call_edges).
                 conn.execute(
-                    "INSERT INTO ast_call_edges "
-                    "(caller_name, caller_file, caller_line, callee_name, "
-                    " callee_full, callee_line, file_path, language) "
-                    "VALUES ('f', 'x.py', 1, 'g', '', 2, 'x.py', 'python')"
+                    "INSERT INTO edges "
+                    "(source_node_id, target_node_id, kind, line, caller_name, "
+                    " callee_name, file_path, caller_line, callee_line, language) "
+                    "VALUES ('x.py:f:1', 'x.py:g:2', 'calls', 2, 'f', 'g', "
+                    " 'x.py', 1, 2, 'python')"
                 )
                 conn.commit()
                 row = conn.execute(
                     "SELECT callee_resolution, callee_resolved_file, "
-                    "callee_symbol_id FROM ast_call_edges"
+                    "callee_symbol_id FROM edges WHERE kind = 'calls'"
                 ).fetchone()
                 assert row["callee_resolution"] == "unknown"
                 assert row["callee_resolved_file"] == ""
@@ -306,8 +313,8 @@ class TestResolveCrossFile:
             cache.index_project()
             with _open_db(cache) as conn:
                 count = conn.execute(
-                    "SELECT COUNT(*) AS c FROM ast_call_edges "
-                    "WHERE callee_resolution = 'project' "
+                    "SELECT COUNT(*) AS c FROM edges "
+                    "WHERE kind = 'calls' AND callee_resolution = 'project' "
                     "AND callee_resolved_file != '' "
                     "AND callee_resolved_file != file_path"
                 ).fetchone()["c"]

--- a/tests/unit/test_unresolved_refs.py
+++ b/tests/unit/test_unresolved_refs.py
@@ -427,6 +427,68 @@ def test_unresolved_refs_row_and_commit_error_paths() -> None:
     }
 
 
+def test_non_python_skips_unresolved_refs_rows() -> None:
+    """A2: non-Python languages must not emit unresolved_refs rows.
+
+    They have no structured import parsing, so second-pass resolution is pure
+    waste (and the dominant stall/OOM cost on large Java repos). Python keeps
+    writing rows.
+    """
+    assert unresolved._refs_supported("python") is True
+    for lang in ("java", "go", "cobol", "csharp", "javascript"):
+        assert unresolved._refs_supported(lang) is False
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE unresolved_refs (
+                id INTEGER PRIMARY KEY,
+                from_node_id TEXT NOT NULL,
+                reference_name TEXT NOT NULL,
+                reference_kind TEXT NOT NULL,
+                file_path TEXT NOT NULL,
+                line INTEGER,
+                candidates TEXT,
+                resolved INTEGER DEFAULT 0
+            );
+            CREATE TABLE ast_call_edges (
+                id INTEGER PRIMARY KEY,
+                caller_name TEXT, caller_file TEXT, caller_line INTEGER,
+                callee_name TEXT, callee_full TEXT, callee_line INTEGER,
+                file_path TEXT, language TEXT,
+                callee_resolution TEXT, callee_resolved_file TEXT
+            );
+            """
+        )
+        java_class = {
+            "symbols": [{"kind": "class", "name": "Foo", "line": 1, "parents": ["Bar"]}]
+        }
+        java_calls = [
+            {
+                "caller_name": "Foo",
+                "caller_line": 5,
+                "callee_name": "doThing",
+                "callee_line": 6,
+            }
+        ]
+        unresolved.write_unresolved_refs_for_file(
+            conn, "Foo.java", "java", java_class, java_calls
+        )
+        rows = conn.execute("SELECT COUNT(*) AS c FROM unresolved_refs").fetchone()
+        assert rows["c"] == 0
+
+        # Python on the same shape DOES write rows.
+        unresolved.write_unresolved_refs_for_file(
+            conn, "foo.py", "python", java_class, java_calls
+        )
+        rows = conn.execute("SELECT COUNT(*) AS c FROM unresolved_refs").fetchone()
+        assert rows["c"] > 0
+    finally:
+        conn.close()
+
+
 def test_unresolved_refs_helper_branches(monkeypatch: pytest.MonkeyPatch) -> None:
     assert (
         unresolved._parent_refs(

--- a/tests/unit/test_unresolved_refs.py
+++ b/tests/unit/test_unresolved_refs.py
@@ -1,3 +1,14 @@
+"""Cross-file second-pass resolution tests (B1.3 — unified ``edges`` table).
+
+The ``unresolved_refs`` work-queue table was dropped in B1.3. The second pass
+now recomputes its pending work set in-memory per Python file (the same
+``_parent_refs`` / ``_call_refs`` filtering) and writes results directly onto
+the ``edges`` table: a resolved EXTENDS reference becomes a real EXTENDS edge,
+and a resolved CALLS reference UPDATEs the resolution columns of its existing
+CALLS edge. These tests pin that Python resolution behaviour so it cannot
+regress.
+"""
+
 from __future__ import annotations
 
 import json
@@ -11,7 +22,6 @@ import pytest
 
 from tree_sitter_analyzer import _ast_cache_unresolved as unresolved
 from tree_sitter_analyzer import ast_cache as ast_cache_module
-from tree_sitter_analyzer._ast_cache_schema import apply_migration_v9
 from tree_sitter_analyzer.ast_cache import ASTCache
 from tree_sitter_analyzer.class_hierarchy import ClassHierarchy
 from tree_sitter_analyzer.graph.edge_store import EdgeKind, symbol_node
@@ -62,88 +72,15 @@ def _rows(
     return [dict(row) for row in cache.get_conn().execute(sql, params).fetchall()]
 
 
-def test_unresolved_refs_schema_created(tmp_path: Path) -> None:
-    cache = ASTCache(str(tmp_path))
-    try:
-        conn = cache.get_conn()
-        columns = {
-            row["name"]
-            for row in conn.execute("PRAGMA table_info(unresolved_refs)").fetchall()
-        }
-        assert {
-            "from_node_id",
-            "reference_name",
-            "reference_kind",
-            "file_path",
-            "line",
-            "candidates",
-            "resolved",
-        }.issubset(columns)
-        indexes = {
-            row["name"]
-            for row in conn.execute("PRAGMA index_list(unresolved_refs)").fetchall()
-        }
-        assert {"idx_unresolved_name", "idx_unresolved_resolved"}.issubset(indexes)
-        version = conn.execute(
-            "SELECT description FROM ast_schema_version WHERE version = 9"
-        ).fetchone()
-        assert version["description"] == "Unresolved reference backfill"
-    finally:
-        cache.close()
-
-
-def test_index_file_records_unresolved_refs_before_second_pass(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    _write_project(tmp_path)
-    cache = ASTCache(str(tmp_path))
-    try:
-        assert (
-            cache.index_file(str(tmp_path / "pkg" / "base.py"))["status"] == "indexed"
+def _pending_extends(cache: ASTCache) -> set[tuple[str, str]]:
+    """EXTENDS edges still pointing at an unresolved ``class:`` synthetic node."""
+    return {
+        (row["file_path"], row["target_node_id"].removeprefix("class:"))
+        for row in cache.get_conn().execute(
+            "SELECT file_path, target_node_id FROM edges "
+            "WHERE kind = 'extends' AND target_node_id LIKE 'class:%'"
         )
-        assert (
-            cache.index_file(str(tmp_path / "pkg" / "alias_plugin.py"))["status"]
-            == "indexed"
-        )
-        row = (
-            cache.get_conn()
-            .execute(
-                """SELECT reference_name, reference_kind, resolved
-               FROM unresolved_refs
-               WHERE file_path = 'pkg/alias_plugin.py'"""
-            )
-            .fetchone()
-        )
-        assert dict(row) == {
-            "reference_name": "LP",
-            "reference_kind": EdgeKind.EXTENDS.value,
-            "resolved": 0,
-        }
-
-        calls: list[str] = []
-        real_parse = ast_cache_module.Parser.parse_file
-
-        def counting_parse(self: Any, *args: Any, **kwargs: Any) -> Any:
-            calls.append(str(args[0]) if args else "")
-            return real_parse(self, *args, **kwargs)
-
-        monkeypatch.setattr(ast_cache_module.Parser, "parse_file", counting_parse)
-
-        stats = cache.index_project(resolve_only=True)
-        assert stats["mode_used"] == "resolve_only"
-        assert calls == []
-        resolved = (
-            cache.get_conn()
-            .execute(
-                """SELECT resolved
-               FROM unresolved_refs
-               WHERE file_path = 'pkg/alias_plugin.py'"""
-            )
-            .fetchone()
-        )
-        assert resolved["resolved"] == 1
-    finally:
-        cache.close()
+    }
 
 
 def test_index_project_resolves_cross_file_extends_and_calls(tmp_path: Path) -> None:
@@ -152,27 +89,15 @@ def test_index_project_resolves_cross_file_extends_and_calls(tmp_path: Path) -> 
     try:
         stats = cache.index_project(max_files=20, workers=0)
         assert stats["indexed"] >= 7
-        assert stats["unresolved_refs_backfill"]["resolved"] >= 3
-
-        resolved_refs = _rows(
-            cache,
-            """SELECT reference_name, reference_kind, file_path, resolved
-               FROM unresolved_refs
-               WHERE resolved = 1
-               ORDER BY file_path, reference_name""",
-        )
-        assert {
-            (row["file_path"], row["reference_name"], row["reference_kind"])
-            for row in resolved_refs
-        }.issuperset(
-            {
-                ("pkg/alias_plugin.py", "LP", EdgeKind.EXTENDS.value),
-                ("pkg/python_plugin.py", "LanguagePlugin", EdgeKind.EXTENDS.value),
-                ("pkg/service.py", "helper", EdgeKind.CALLS.value),
-            }
-        )
+        # The second pass resolves the cross-file EXTENDS references (alias_plugin
+        # + python_plugin). Cross-file CALLS resolution is handled earlier by the
+        # cross-file backfill, so it no longer flows through this counter (the
+        # resolved edge data is asserted directly below).
+        assert stats["unresolved_refs_backfill"]["resolved"] >= 2
 
         conn = cache.get_conn()
+        # The cross-file EXTENDS references resolved into real edges pointing at
+        # the resolved base class (provenance unresolved_refs).
         alias_edge = conn.execute(
             """SELECT target_node_id, metadata
                FROM edges
@@ -190,6 +115,26 @@ def test_index_project_resolves_cross_file_extends_and_calls(tmp_path: Path) -> 
         metadata = json.loads(alias_edge["metadata"])
         assert metadata["parent"] == "LanguagePlugin"
         assert metadata["parent_reference"] == "LP"
+
+        python_plugin_edge = conn.execute(
+            """SELECT 1 FROM edges
+               WHERE source_node_id = ? AND target_node_id = ?
+                 AND kind = ? AND provenance = 'unresolved_refs'""",
+            (
+                symbol_node("pkg/python_plugin.py", "PythonPlugin", 3),
+                symbol_node("pkg/base.py", "LanguagePlugin", 1),
+                EdgeKind.EXTENDS.value,
+            ),
+        ).fetchone()
+        assert python_plugin_edge is not None
+
+        # The cross-file CALLS reference resolved in place on the edge's columns.
+        call_row = conn.execute(
+            "SELECT callee_resolution, callee_resolved_file FROM edges "
+            "WHERE kind = 'calls' AND caller_name = 'build' AND callee_name = 'helper'"
+        ).fetchone()
+        assert call_row is not None
+        assert call_row["callee_resolved_file"] == "pkg/helper.py"
 
         hierarchy = ClassHierarchy(cache)
         subclass_names = {
@@ -213,6 +158,51 @@ def test_index_project_resolves_cross_file_extends_and_calls(tmp_path: Path) -> 
         cache.close()
 
 
+def test_resolve_only_does_not_reparse(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A warm cache resolves pending cross-file refs without re-parsing."""
+    _write_project(tmp_path)
+    cache = ASTCache(str(tmp_path))
+    try:
+        assert (
+            cache.index_file(str(tmp_path / "pkg" / "base.py"))["status"] == "indexed"
+        )
+        assert (
+            cache.index_file(str(tmp_path / "pkg" / "alias_plugin.py"))["status"]
+            == "indexed"
+        )
+        # AliasPlugin's parent (LP) is cross-file and not yet resolved.
+        assert ("pkg/alias_plugin.py", "LP") in _pending_extends(cache)
+
+        calls: list[str] = []
+        real_parse = ast_cache_module.Parser.parse_file
+
+        def counting_parse(self: Any, *args: Any, **kwargs: Any) -> Any:
+            calls.append(str(args[0]) if args else "")
+            return real_parse(self, *args, **kwargs)
+
+        monkeypatch.setattr(ast_cache_module.Parser, "parse_file", counting_parse)
+
+        stats = cache.index_project(resolve_only=True)
+        assert stats["mode_used"] == "resolve_only"
+        assert calls == []
+
+        # After the resolve-only pass a real resolved EXTENDS edge exists.
+        resolved = (
+            cache.get_conn()
+            .execute(
+                "SELECT 1 FROM edges WHERE kind = 'extends' "
+                "AND provenance = 'unresolved_refs' AND source_node_id = ?",
+                (symbol_node("pkg/alias_plugin.py", "AliasPlugin", 3),),
+            )
+            .fetchone()
+        )
+        assert resolved is not None
+    finally:
+        cache.close()
+
+
 def test_unknown_parent_stays_unresolved(tmp_path: Path) -> None:
     (tmp_path / "missing.py").write_text(
         "class Orphan(MissingBase):\n    pass\n",
@@ -221,17 +211,19 @@ def test_unknown_parent_stays_unresolved(tmp_path: Path) -> None:
     cache = ASTCache(str(tmp_path))
     try:
         cache.index_project(max_files=5, workers=0)
-        row = (
+        # No project class named MissingBase → the EXTENDS edge stays pointing
+        # at the unresolved ``class:`` synthetic target.
+        assert ("missing.py", "MissingBase") in _pending_extends(cache)
+        resolved = (
             cache.get_conn()
             .execute(
-                """SELECT resolved, candidates
-               FROM unresolved_refs
-               WHERE reference_name = 'MissingBase'"""
+                "SELECT 1 FROM edges WHERE kind = 'extends' "
+                "AND provenance = 'unresolved_refs' "
+                "AND target_node_id LIKE '%MissingBase%'"
             )
             .fetchone()
         )
-        assert row["resolved"] == 0
-        assert json.loads(row["candidates"]) == []
+        assert resolved is None
     finally:
         cache.close()
 
@@ -249,6 +241,8 @@ def test_autoindex_resolves_pending_refs_when_cache_is_already_warm(
             cache.index_file(str(tmp_path / "pkg" / "python_plugin.py"))["status"]
             == "indexed"
         )
+        # python_plugin's cross-file parent is unresolved before warming.
+        assert ("pkg/python_plugin.py", "LanguagePlugin") in _pending_extends(cache)
     finally:
         cache.close()
 
@@ -256,16 +250,16 @@ def test_autoindex_resolves_pending_refs_when_cache_is_already_warm(
     warmed = auto_index_guard.ensure_indexed(str(tmp_path), max_files=20)
     try:
         assert warmed is not None
-        row = (
+        resolved = (
             warmed.get_conn()
             .execute(
-                """SELECT resolved
-               FROM unresolved_refs
-               WHERE file_path = 'pkg/python_plugin.py'"""
+                "SELECT 1 FROM edges WHERE kind = 'extends' "
+                "AND provenance = 'unresolved_refs' AND source_node_id = ?",
+                (symbol_node("pkg/python_plugin.py", "PythonPlugin", 3),),
             )
             .fetchone()
         )
-        assert row["resolved"] == 1
+        assert resolved is not None
     finally:
         if warmed is not None:
             warmed.close()
@@ -307,19 +301,11 @@ def test_class_hierarchy_cli_reads_resolved_cross_file_edge(tmp_path: Path) -> N
     )
 
 
-def test_unresolved_refs_sqlite_error_paths_are_nonfatal(
-    tmp_path: Path,
-) -> None:
+def test_resolve_unresolved_refs_sqlite_error_paths_are_nonfatal() -> None:
+    """Missing schema / broken connections must degrade, not crash."""
     no_schema = sqlite3.connect(":memory:")
     no_schema.row_factory = sqlite3.Row
     try:
-        unresolved.write_unresolved_refs_for_file(
-            no_schema,
-            "broken.py",
-            "python",
-            {"symbols": []},
-            [],
-        )
         assert unresolved.resolve_unresolved_refs(no_schema) is None
         assert unresolved.pending_unresolved_count(no_schema) == 0
         assert unresolved._call_rows(
@@ -339,45 +325,20 @@ def test_unresolved_refs_sqlite_error_paths_are_nonfatal(
     finally:
         no_schema.close()
 
-    bad_insert = sqlite3.connect(":memory:")
-    bad_insert.row_factory = sqlite3.Row
-    try:
-        bad_insert.execute("CREATE TABLE unresolved_refs (file_path TEXT)")
-        unresolved.write_unresolved_refs_for_file(
-            bad_insert,
-            "child.py",
-            "python",
-            {
-                "symbols": [
-                    {
-                        "kind": "class",
-                        "name": "Child",
-                        "line": 1,
-                        "parents": ["Base"],
-                    }
-                ]
-            },
-            [],
-        )
-    finally:
-        bad_insert.close()
 
-
-def test_unresolved_refs_row_and_commit_error_paths() -> None:
+def test_resolve_unresolved_refs_row_and_commit_error_paths() -> None:
+    """A resolvable ref whose UPDATE/upsert fails counts as an error, not a crash."""
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
     try:
+        # ast_index drives the per-file loop; the EXTENDS upsert then fails
+        # because the ``edges`` table is intentionally absent.
         conn.executescript(
             """
-            CREATE TABLE unresolved_refs (
-                id INTEGER PRIMARY KEY,
-                from_node_id TEXT NOT NULL,
-                reference_name TEXT NOT NULL,
-                reference_kind TEXT NOT NULL,
+            CREATE TABLE ast_index (
                 file_path TEXT NOT NULL,
-                line INTEGER,
-                candidates TEXT,
-                resolved INTEGER DEFAULT 0
+                language TEXT NOT NULL,
+                symbols_json TEXT NOT NULL
             );
             CREATE TABLE ast_symbol_rows (
                 id INTEGER PRIMARY KEY,
@@ -387,21 +348,30 @@ def test_unresolved_refs_row_and_commit_error_paths() -> None:
                 language TEXT NOT NULL,
                 line INTEGER NOT NULL
             );
-            CREATE TABLE ast_index (
-                file_path TEXT NOT NULL,
-                language TEXT NOT NULL
-            );
             """
         )
         conn.execute(
-            """INSERT INTO unresolved_refs
-               (id, from_node_id, reference_name, reference_kind, file_path, line)
-               VALUES (1, 'caller.py:caller:1', 'target', 'calls', 'caller.py', 2)"""
+            "INSERT INTO ast_index (file_path, language, symbols_json) VALUES (?, ?, ?)",
+            (
+                "child.py",
+                "python",
+                json.dumps(
+                    {
+                        "symbols": [
+                            {
+                                "kind": "class",
+                                "name": "Child",
+                                "line": 1,
+                                "parents": ["Base"],
+                            }
+                        ]
+                    }
+                ),
+            ),
         )
         conn.execute(
-            """INSERT INTO ast_symbol_rows
-               (id, name, kind, file_path, language, line)
-               VALUES (10, 'target', 'function', 'target.py', 'python', 1)"""
+            """INSERT INTO ast_symbol_rows (id, name, kind, file_path, language, line)
+               VALUES (10, 'Base', 'class', 'base.py', 'python', 1)"""
         )
         stats = unresolved.resolve_unresolved_refs(conn)
         assert stats == {"total": 1, "resolved": 0, "unchanged": 0, "errors": 1}
@@ -427,12 +397,12 @@ def test_unresolved_refs_row_and_commit_error_paths() -> None:
     }
 
 
-def test_non_python_skips_unresolved_refs_rows() -> None:
-    """A2: non-Python languages must not emit unresolved_refs rows.
+def test_non_python_skips_second_pass_refs() -> None:
+    """A2/B1.3: non-Python languages emit no second-pass refs.
 
-    They have no structured import parsing, so second-pass resolution is pure
+    They have no structured import parsing, so cross-file resolution is pure
     waste (and the dominant stall/OOM cost on large Java repos). Python keeps
-    writing rows.
+    producing refs.
     """
     assert unresolved._refs_supported("python") is True
     for lang in ("java", "go", "cobol", "csharp", "javascript"):
@@ -441,55 +411,24 @@ def test_non_python_skips_unresolved_refs_rows() -> None:
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
     try:
-        conn.executescript(
-            """
-            CREATE TABLE unresolved_refs (
-                id INTEGER PRIMARY KEY,
-                from_node_id TEXT NOT NULL,
-                reference_name TEXT NOT NULL,
-                reference_kind TEXT NOT NULL,
-                file_path TEXT NOT NULL,
-                line INTEGER,
-                candidates TEXT,
-                resolved INTEGER DEFAULT 0
-            );
-            CREATE TABLE ast_call_edges (
-                id INTEGER PRIMARY KEY,
-                caller_name TEXT, caller_file TEXT, caller_line INTEGER,
-                callee_name TEXT, callee_full TEXT, callee_line INTEGER,
-                file_path TEXT, language TEXT,
-                callee_resolution TEXT, callee_resolved_file TEXT
-            );
-            """
-        )
         java_class = {
             "symbols": [{"kind": "class", "name": "Foo", "line": 1, "parents": ["Bar"]}]
         }
-        java_calls = [
-            {
-                "caller_name": "Foo",
-                "caller_line": 5,
-                "callee_name": "doThing",
-                "callee_line": 6,
-            }
-        ]
-        unresolved.write_unresolved_refs_for_file(
-            conn, "Foo.java", "java", java_class, java_calls
+        assert (
+            unresolved._pending_refs_for_file(conn, "Foo.java", "java", java_class)
+            == []
         )
-        rows = conn.execute("SELECT COUNT(*) AS c FROM unresolved_refs").fetchone()
-        assert rows["c"] == 0
-
-        # Python on the same shape DOES write rows.
-        unresolved.write_unresolved_refs_for_file(
-            conn, "foo.py", "python", java_class, java_calls
+        # Python on the same shape DOES produce a pending EXTENDS ref.
+        py_refs = unresolved._pending_refs_for_file(
+            conn, "foo.py", "python", java_class
         )
-        rows = conn.execute("SELECT COUNT(*) AS c FROM unresolved_refs").fetchone()
-        assert rows["c"] > 0
+        assert any(r["reference_kind"] == EdgeKind.EXTENDS.value for r in py_refs)
     finally:
         conn.close()
 
 
-def test_unresolved_refs_helper_branches(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_pending_refs_and_helper_branches() -> None:
+    # Local / already-resolved / obvious-external refs are filtered out.
     assert (
         unresolved._parent_refs(
             "child.py",
@@ -545,6 +484,8 @@ def test_unresolved_refs_helper_branches(monkeypatch: pytest.MonkeyPatch) -> Non
         )
         is None
     )
+    # _update_call_edge_resolution tolerates a file: node id and a missing edges
+    # table without raising.
     unresolved._update_call_edge_resolution(
         sqlite3.connect(":memory:"),
         {
@@ -598,21 +539,9 @@ def test_unresolved_refs_helper_branches(monkeypatch: pytest.MonkeyPatch) -> Non
     assert unresolved._row_to_dict(("value",), ("name",)) == {"name": "value"}
 
 
-def test_unresolved_refs_migration_and_orchestration_error_paths(
+def test_orchestration_error_paths(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    broken_schema = sqlite3.connect(":memory:")
-    try:
-        broken_schema.execute("CREATE TABLE unresolved_refs (id INTEGER)")
-        recorded: list[int] = []
-        apply_migration_v9(
-            broken_schema,
-            lambda _conn, version, _description: recorded.append(version),
-        )
-        assert recorded == []
-    finally:
-        broken_schema.close()
-
     cache = ASTCache(str(tmp_path))
     try:
         monkeypatch.setattr(cache, "backfill_cross_file_edges", lambda: {})

--- a/tree_sitter_analyzer/_ast_cache_graph.py
+++ b/tree_sitter_analyzer/_ast_cache_graph.py
@@ -23,10 +23,17 @@ from typing import Any
 # ---------------------------------------------------------------------------
 
 _EDGE_SELECT = (
-    "SELECT caller_name, caller_file, caller_line, "
-    "callee_name, callee_full, file_path, callee_line, callee_resolved_file "
-    "FROM ast_call_edges "
+    "SELECT caller_name, file_path AS caller_file, "
+    "json_extract(metadata, '$.caller_line') AS caller_line, "
+    "callee_name, "
+    "json_extract(metadata, '$.callee_full') AS callee_full, "
+    "file_path, line AS callee_line, "
+    "json_extract(metadata, '$.callee_resolved_file') AS callee_resolved_file "
+    "FROM edges "
 )
+
+# All CALLS queries below filter on this single edge kind.
+_CALLS_PREDICATE = "kind = 'calls' AND "
 
 # ---------------------------------------------------------------------------
 # Direction-specific row fetchers
@@ -42,18 +49,27 @@ def _fetch_caller_rows(
     if file_:
         rows = conn.execute(
             _EDGE_SELECT
-            + "WHERE (callee_name = ? OR callee_full = ?) AND callee_resolved_file = ?",
+            + "WHERE "
+            + _CALLS_PREDICATE
+            + "(callee_name = ? OR json_extract(metadata, '$.callee_full') = ?) "
+            "AND json_extract(metadata, '$.callee_resolved_file') = ?",
             (name, name, file_),
         ).fetchall()
         if not rows:
             rows = conn.execute(
                 _EDGE_SELECT
-                + "WHERE (callee_name = ? OR callee_full = ?) AND file_path = ?",
+                + "WHERE "
+                + _CALLS_PREDICATE
+                + "(callee_name = ? OR json_extract(metadata, '$.callee_full') = ?) "
+                "AND file_path = ?",
                 (name, name, file_),
             ).fetchall()
         return rows
     return conn.execute(
-        _EDGE_SELECT + "WHERE callee_name = ? OR callee_full = ?",
+        _EDGE_SELECT
+        + "WHERE "
+        + _CALLS_PREDICATE
+        + "(callee_name = ? OR json_extract(metadata, '$.callee_full') = ?)",
         (name, name),
     ).fetchall()
 
@@ -74,17 +90,20 @@ def _fetch_callee_rows(
     bare = name.split(".")[-1] if "." in name else name
     if file_:
         rows = conn.execute(
-            _EDGE_SELECT + "WHERE caller_name = ? AND caller_file = ?",
+            _EDGE_SELECT
+            + "WHERE "
+            + _CALLS_PREDICATE
+            + "caller_name = ? AND file_path = ?",
             (bare, file_),
         ).fetchall()
         if not rows:
             rows = conn.execute(
-                _EDGE_SELECT + "WHERE caller_name = ?",
+                _EDGE_SELECT + "WHERE " + _CALLS_PREDICATE + "caller_name = ?",
                 (bare,),
             ).fetchall()
         return rows
     return conn.execute(
-        _EDGE_SELECT + "WHERE caller_name = ?",
+        _EDGE_SELECT + "WHERE " + _CALLS_PREDICATE + "caller_name = ?",
         (bare,),
     ).fetchall()
 
@@ -154,7 +173,7 @@ def _bfs_traverse(
     make_entry: Callable,
     next_hop: Callable,
 ) -> list[dict[str, Any]]:
-    """BFS traversal over ``ast_call_edges`` in either direction.
+    """BFS traversal over the unified ``edges`` table in either direction.
 
     Args:
         conn: Live SQLite connection.
@@ -199,7 +218,7 @@ def bfs_callers(
     """BFS traversal returning all callers of ``callee_name``.
 
     Args:
-        conn: Live SQLite connection with ``ast_call_edges`` table.
+        conn: Live SQLite connection with the ``edges`` table.
         callee_name: Name of the function/method being looked up.
         callee_file: Optional resolved file path to narrow the match.
         max_depth: Maximum BFS hops (0 → empty, 1 → direct callers only).
@@ -230,7 +249,7 @@ def bfs_callees(
     """BFS traversal returning all callees of ``caller_name``.
 
     Args:
-        conn: Live SQLite connection with ``ast_call_edges`` table.
+        conn: Live SQLite connection with the ``edges`` table.
         caller_name: Name of the calling function/method.
         caller_file: Optional file path to narrow the match.
         max_depth: Maximum BFS hops (0 → empty, 1 → direct callees only).

--- a/tree_sitter_analyzer/_ast_cache_graph.py
+++ b/tree_sitter_analyzer/_ast_cache_graph.py
@@ -23,12 +23,8 @@ from typing import Any
 # ---------------------------------------------------------------------------
 
 _EDGE_SELECT = (
-    "SELECT caller_name, file_path AS caller_file, "
-    "json_extract(metadata, '$.caller_line') AS caller_line, "
-    "callee_name, "
-    "json_extract(metadata, '$.callee_full') AS callee_full, "
-    "file_path, line AS callee_line, "
-    "json_extract(metadata, '$.callee_resolved_file') AS callee_resolved_file "
+    "SELECT caller_name, file_path AS caller_file, caller_line, "
+    "callee_name, callee_full, file_path, callee_line, callee_resolved_file "
     "FROM edges "
 )
 
@@ -51,8 +47,8 @@ def _fetch_caller_rows(
             _EDGE_SELECT
             + "WHERE "
             + _CALLS_PREDICATE
-            + "(callee_name = ? OR json_extract(metadata, '$.callee_full') = ?) "
-            "AND json_extract(metadata, '$.callee_resolved_file') = ?",
+            + "(callee_name = ? OR callee_full = ?) "
+            "AND callee_resolved_file = ?",
             (name, name, file_),
         ).fetchall()
         if not rows:
@@ -60,7 +56,7 @@ def _fetch_caller_rows(
                 _EDGE_SELECT
                 + "WHERE "
                 + _CALLS_PREDICATE
-                + "(callee_name = ? OR json_extract(metadata, '$.callee_full') = ?) "
+                + "(callee_name = ? OR callee_full = ?) "
                 "AND file_path = ?",
                 (name, name, file_),
             ).fetchall()
@@ -69,7 +65,7 @@ def _fetch_caller_rows(
         _EDGE_SELECT
         + "WHERE "
         + _CALLS_PREDICATE
-        + "(callee_name = ? OR json_extract(metadata, '$.callee_full') = ?)",
+        + "(callee_name = ? OR callee_full = ?)",
         (name, name),
     ).fetchall()
 

--- a/tree_sitter_analyzer/_ast_cache_helpers.py
+++ b/tree_sitter_analyzer/_ast_cache_helpers.py
@@ -65,6 +65,13 @@ def _make_error_entry(rel_path: str, reason: str) -> dict[str, Any]:
     return {"file": rel_path, "status": "error", "reason": reason}
 
 
+# A4: write the index in bounded transactions instead of one giant BEGIN…COMMIT.
+# On large repos (e.g. 7.9k Java files / 884k edges) accumulating every insert in
+# a single transaction pushed RSS high enough to trigger OOM/swap and the apparent
+# "stall". Committing every _COMMIT_BATCH_SIZE files caps the dirty-page set.
+_COMMIT_BATCH_SIZE = 500
+
+
 def _commit_index_results(
     conn: Any,
     results: list[dict[str, Any]],
@@ -72,18 +79,27 @@ def _commit_index_results(
     insert_fn: Any,
     indexed_at: str,
     activation_enabled: bool,
+    batch_size: int = _COMMIT_BATCH_SIZE,
 ) -> None:
-    """Commit all worker results to the DB in a single transaction.
+    """Commit worker results to the DB in bounded-size transactions.
 
     Iterates *results*, accumulates into *stats* via ``_process_one_index_result``,
-    and rolls back the entire batch on any exception.
+    committing every *batch_size* files so the dirty-page set (and RSS) stays
+    bounded on large repos. A failure rolls back only the current batch and
+    re-raises; previously committed batches persist.
     """
+    pending = 0
     conn.execute("BEGIN")
     try:
         for r in results:
             _process_one_index_result(
                 r, stats, insert_fn, indexed_at, activation_enabled
             )
+            pending += 1
+            if pending >= batch_size:
+                conn.execute("COMMIT")
+                pending = 0
+                conn.execute("BEGIN")
         conn.execute("COMMIT")
     except Exception:
         conn.execute("ROLLBACK")

--- a/tree_sitter_analyzer/_ast_cache_indexer.py
+++ b/tree_sitter_analyzer/_ast_cache_indexer.py
@@ -119,18 +119,14 @@ def parse_and_write(
         if cache.fts5_available
         else []
     )
-    _write.write_call_edges(conn, rel_path, language, call_edges)
-    from . import _ast_cache_unresolved as _unresolved
-
-    _unresolved.write_unresolved_refs_for_file(
-        conn, rel_path, language, symbols, call_edges
-    )
     cache._write_imports_for_file(conn, rel_path, language, imports)  # noqa: SLF001
     cache._write_activation_for_file(conn, rel_path, inserted)  # noqa: SLF001
-    cache._resolve_call_edges_for_file(conn, rel_path)  # noqa: SLF001
+    # CALLS rows live in the unified ``edges`` table (B1.3 — no ast_call_edges).
+    # Write the edges first so synapse resolution can UPDATE them in place.
     _write.write_graph_edges_for_file(
         conn, rel_path, language, symbols, imports, call_edges
     )
+    cache._resolve_call_edges_for_file(conn, rel_path)  # noqa: SLF001
     conn.commit()
     return {
         "file": rel_path,
@@ -244,15 +240,11 @@ def insert_index_row(
         conn, rel_path, r["language"], r["symbol_rows"]
     )
     call_edges = json.loads(r.get("call_edges_json", "[]"))
-    _write.write_call_edges(conn, rel_path, r["language"], call_edges)
     imports_list = json.loads(r.get("imports_json", "[]"))
     cache._write_imports_for_file(conn, rel_path, r["language"], imports_list)  # noqa: SLF001
     symbols = json.loads(r.get("symbols_json", "{}"))
-    from . import _ast_cache_unresolved as _unresolved
-
-    _unresolved.write_unresolved_refs_for_file(
-        conn, rel_path, r["language"], symbols, call_edges
-    )
+    # CALLS rows live in the unified ``edges`` table (B1.3 — no ast_call_edges).
+    # Cross-file / synapse resolution UPDATEs these rows in the post-index pass.
     _write.write_graph_edges_for_file(
         conn, rel_path, r["language"], symbols, imports_list, call_edges
     )

--- a/tree_sitter_analyzer/_ast_cache_query.py
+++ b/tree_sitter_analyzer/_ast_cache_query.py
@@ -17,17 +17,22 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# SQL constants re-used by multiple query helpers.
+# SQL constants re-used by multiple query helpers. CALLS rows live in the
+# unified ``edges`` table (B1.3): ``file_path`` is the caller's file (== legacy
+# ``caller_file``), ``callee_line`` is the call-site line.
 _SQL_COUNT_RESOLVED_EDGES = (
-    "SELECT COUNT(*) as c FROM ast_call_edges WHERE callee_resolved_file != ''"
+    "SELECT COUNT(*) as c FROM edges "
+    "WHERE kind = 'calls' AND callee_resolved_file != ''"
 )
 _SQL_COUNT_CROSS_FILE_EDGES = (
-    "SELECT COUNT(*) as c FROM ast_call_edges "
-    "WHERE callee_resolved_file != '' AND callee_resolved_file != file_path"
+    "SELECT COUNT(*) as c FROM edges "
+    "WHERE kind = 'calls' AND callee_resolved_file != '' "
+    "AND callee_resolved_file != file_path"
 )
 _SQL_UPDATE_CALLEE_RESOLVED = (
-    "UPDATE ast_call_edges SET callee_resolved_file = ? "
-    "WHERE caller_file = ? AND caller_line = ? AND caller_name = ? AND callee_line = ?"
+    "UPDATE edges SET callee_resolved_file = ? "
+    "WHERE kind = 'calls' AND file_path = ? AND caller_line = ? "
+    "AND caller_name = ? AND callee_line = ?"
 )
 
 
@@ -48,9 +53,8 @@ def invalidate(
     if fts5_available:
         conn.execute("DELETE FROM ast_symbols_fts WHERE file_path = ?", (rel,))
         conn.execute("DELETE FROM ast_symbol_rows WHERE file_path = ?", (rel,))
-    conn.execute("DELETE FROM ast_call_edges WHERE file_path = ?", (rel,))
-    # CALLS rows now live in the unified ``edges`` table (B1.x). Clear them too
-    # so ``get_call_edges`` — which reads ``edges`` — reflects the invalidation.
+    # CALLS rows live in the unified ``edges`` table (B1.3 — no ast_call_edges).
+    # Clear them so ``get_call_edges`` reflects the invalidation.
     try:
         conn.execute("DELETE FROM edges WHERE kind = 'calls' AND file_path = ?", (rel,))
     except sqlite3.OperationalError:
@@ -290,7 +294,9 @@ def get_stats(
 def get_cross_file_stats(conn: sqlite3.Connection) -> dict[str, Any]:
     """Return cross-file edge resolution statistics."""
     try:
-        total = conn.execute("SELECT COUNT(*) as c FROM ast_call_edges").fetchone()["c"]
+        total = conn.execute(
+            "SELECT COUNT(*) as c FROM edges WHERE kind = 'calls'"
+        ).fetchone()["c"]
         resolved = conn.execute(_SQL_COUNT_RESOLVED_EDGES).fetchone()["c"]
         cross_file = conn.execute(_SQL_COUNT_CROSS_FILE_EDGES).fetchone()["c"]
     except sqlite3.OperationalError:

--- a/tree_sitter_analyzer/_ast_cache_query.py
+++ b/tree_sitter_analyzer/_ast_cache_query.py
@@ -49,6 +49,12 @@ def invalidate(
         conn.execute("DELETE FROM ast_symbols_fts WHERE file_path = ?", (rel,))
         conn.execute("DELETE FROM ast_symbol_rows WHERE file_path = ?", (rel,))
     conn.execute("DELETE FROM ast_call_edges WHERE file_path = ?", (rel,))
+    # CALLS rows now live in the unified ``edges`` table (B1.x). Clear them too
+    # so ``get_call_edges`` — which reads ``edges`` — reflects the invalidation.
+    try:
+        conn.execute("DELETE FROM edges WHERE kind = 'calls' AND file_path = ?", (rel,))
+    except sqlite3.OperationalError:
+        pass
     cursor = conn.execute("DELETE FROM ast_index WHERE file_path = ?", (rel,))
     conn.commit()
     return cursor.rowcount > 0

--- a/tree_sitter_analyzer/_ast_cache_schema.py
+++ b/tree_sitter_analyzer/_ast_cache_schema.py
@@ -309,6 +309,34 @@ def apply_migration_v9(conn: sqlite3.Connection, record_fn: RecordFn) -> None:
         pass
 
 
+def apply_migration_v10(conn: sqlite3.Connection, record_fn: RecordFn) -> None:
+    """Promote caller/callee/file scalars to real ``edges`` columns (v10 — B1.1).
+
+    Non-breaking first step of the single edge-table consolidation: the CALLS
+    scalars that previously only lived in the JSON ``metadata`` blob become
+    indexed real columns so callers/callees/call_path can push the name filter
+    down to SQL instead of full-scanning ``kind='calls'`` in Python.
+
+    Uses the EdgeStore schema/backfill helpers directly (not the ``EdgeStore``
+    class) so it is unaffected by tests that monkeypatch ``EdgeStore``. It
+    idempotently adds the ``caller_name`` / ``callee_name`` / ``file_path``
+    columns (ALTER for legacy v8/v9 tables) plus the supporting indexes, then
+    backfills the new columns from the existing node ids.
+    """
+    try:
+        from .graph.edge_store import (
+            backfill_edge_name_columns,
+            ensure_edge_schema,
+        )
+
+        ensure_edge_schema(conn)
+        backfill_edge_name_columns(conn)
+        record_fn(conn, 10, "Edge name columns + pushdown indexes")
+        conn.commit()
+    except sqlite3.OperationalError:
+        pass
+
+
 # ---------------------------------------------------------------------------
 # Schema DDL constants V1 and V2 (moved from ast_cache.py)
 # ---------------------------------------------------------------------------
@@ -474,6 +502,18 @@ EXPECTED_SCHEMA_VERSIONS: list[Any] = [
                 "line",
                 "candidates",
                 "resolved",
+            ],
+        },
+    ),
+    (
+        10,
+        "Edge name columns + pushdown indexes",
+        {
+            "tables": ["edges"],
+            "edges_columns": [
+                "caller_name",
+                "callee_name",
+                "file_path",
             ],
         },
     ),

--- a/tree_sitter_analyzer/_ast_cache_schema.py
+++ b/tree_sitter_analyzer/_ast_cache_schema.py
@@ -337,6 +337,35 @@ def apply_migration_v10(conn: sqlite3.Connection, record_fn: RecordFn) -> None:
         pass
 
 
+def apply_migration_v11(conn: sqlite3.Connection, record_fn: RecordFn) -> None:
+    """Consolidate to a single edge table — drop ast_call_edges + unresolved_refs.
+
+    B1.3, the terminal step of the edge consolidation. By v11 every reader and
+    every write/resolution path operates on the unified ``edges`` table:
+
+    * ``ensure_edge_schema`` promotes the remaining resolution scalars
+      (``caller_line`` / ``callee_full`` / ``callee_line`` / ``language`` /
+      ``callee_resolution`` / ``callee_resolved_file`` / ``callee_symbol_id``)
+      to real, indexable columns so the second pass can UPDATE them in place.
+    * ``ast_call_edges`` (raw extract + Synapse truth) and ``unresolved_refs``
+      (the second-pass work queue) are dropped — their data is now derived
+      data carried by ``edges`` columns + recomputed in-memory from the index.
+
+    Breaking: an ``.ast-cache`` built by an older version is rebuilt on the next
+    ``--full-index`` (call-graph is pure derived data; the source is intact).
+    """
+    try:
+        from .graph.edge_store import ensure_edge_schema
+
+        ensure_edge_schema(conn)
+        conn.execute("DROP TABLE IF EXISTS ast_call_edges")
+        conn.execute("DROP TABLE IF EXISTS unresolved_refs")
+        record_fn(conn, 11, "Single edge table (drop ast_call_edges + unresolved_refs)")
+        conn.commit()
+    except sqlite3.OperationalError:
+        pass
+
+
 # ---------------------------------------------------------------------------
 # Schema DDL constants V1 and V2 (moved from ast_cache.py)
 # ---------------------------------------------------------------------------
@@ -398,21 +427,9 @@ LARGE_REPO_INDEXES: tuple[tuple[str, str], ...] = (
         "CREATE INDEX IF NOT EXISTS idx_sym_rows_file_name_kind_line "
         "ON ast_symbol_rows(file_path, name, kind, line)",
     ),
-    (
-        "ast_call_edges",
-        "CREATE INDEX IF NOT EXISTS idx_ce_callee_name_resolved_file "
-        "ON ast_call_edges(callee_name, callee_resolved_file)",
-    ),
-    (
-        "ast_call_edges",
-        "CREATE INDEX IF NOT EXISTS idx_ce_callee_name_file_path "
-        "ON ast_call_edges(callee_name, file_path)",
-    ),
-    (
-        "ast_call_edges",
-        "CREATE INDEX IF NOT EXISTS idx_ce_caller_name_file "
-        "ON ast_call_edges(caller_name, caller_file)",
-    ),
+    # B1.3: ast_call_edges hot-path indexes removed — CALLS rows + their
+    # caller_name/callee_name/file_path/callee_resolved_file columns are now in
+    # ``edges`` (indexed by ``EDGE_STORE_SCHEMA_STATEMENTS``).
 )
 
 SCHEMA_VERSIONS_DDL = """
@@ -424,33 +441,14 @@ CREATE TABLE IF NOT EXISTS ast_schema_version (
 """
 
 EXPECTED_SCHEMA_VERSIONS: list[Any] = [
-    (
-        3,
-        "ast_call_edges + indices",
-        {
-            "tables": ["ast_call_edges"],
-            "ast_call_edges_columns": [
-                "caller_name",
-                "caller_file",
-                "caller_line",
-                "callee_name",
-                "callee_full",
-                "callee_line",
-                "file_path",
-                "language",
-            ],
-        },
-    ),
+    # v3 (ast_call_edges) and v9 (unresolved_refs) are intentionally absent:
+    # both tables are dropped by the v11 consolidation. The post-init schema
+    # self-check would otherwise report them as missing.
     (
         4,
         "Synapse: callee_resolution + ast_imports",
         {
             "tables": ["ast_imports"],
-            "ast_call_edges_columns": [
-                "callee_symbol_id",
-                "callee_resolution",
-                "callee_resolved_file",
-            ],
         },
     ),
     (
@@ -490,22 +488,6 @@ EXPECTED_SCHEMA_VERSIONS: list[Any] = [
         },
     ),
     (
-        9,
-        "Unresolved reference backfill",
-        {
-            "tables": ["unresolved_refs"],
-            "unresolved_refs_columns": [
-                "from_node_id",
-                "reference_name",
-                "reference_kind",
-                "file_path",
-                "line",
-                "candidates",
-                "resolved",
-            ],
-        },
-    ),
-    (
         10,
         "Edge name columns + pushdown indexes",
         {
@@ -517,6 +499,22 @@ EXPECTED_SCHEMA_VERSIONS: list[Any] = [
             ],
         },
     ),
+    (
+        11,
+        "Single edge table (drop ast_call_edges + unresolved_refs)",
+        {
+            "tables": ["edges"],
+            "edges_columns": [
+                "caller_line",
+                "callee_full",
+                "callee_line",
+                "language",
+                "callee_resolution",
+                "callee_resolved_file",
+                "callee_symbol_id",
+            ],
+        },
+    ),
 ]
 
 # ---------------------------------------------------------------------------
@@ -525,20 +523,9 @@ EXPECTED_SCHEMA_VERSIONS: list[Any] = [
 
 SQL_TABLE_EXISTS = "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?"
 SQL_GET_SCHEMA_VERSION = "SELECT version FROM ast_schema_version WHERE version = ?"
-SQL_UPDATE_CALLEE_RESOLVED = (
-    "UPDATE ast_call_edges SET callee_resolved_file = ? "
-    "WHERE caller_file = ? AND caller_line = ? "
-    "AND callee_name = ? AND callee_line = ?"
-)
 SQL_COUNT_SYMBOL_ROWS = "SELECT COUNT(*) as c FROM ast_symbol_rows"
-SQL_COUNT_RESOLVED_EDGES = (
-    "SELECT COUNT(*) as c FROM ast_call_edges WHERE callee_resolved_file != ''"
-)
-SQL_COUNT_CROSS_FILE_EDGES = (
-    "SELECT COUNT(*) as c FROM ast_call_edges "
-    "WHERE callee_resolved_file != '' "
-    "AND callee_resolved_file != file_path"
-)
+# Resolution count / update SQL lives in ``_ast_cache_query.py`` and now targets
+# the unified ``edges`` table (B1.3); the ast_call_edges variants were removed.
 
 # ---------------------------------------------------------------------------
 # Pure schema helper functions (moved from ASTCache static methods)

--- a/tree_sitter_analyzer/_ast_cache_synapse.py
+++ b/tree_sitter_analyzer/_ast_cache_synapse.py
@@ -36,8 +36,8 @@ def resolve_call_edges_for_file(
         return
     try:
         rows = conn.execute(
-            "SELECT id, caller_name, caller_file, callee_name, callee_full "
-            "FROM ast_call_edges WHERE file_path = ?",
+            "SELECT id, caller_name, file_path AS caller_file, callee_name, "
+            "callee_full FROM edges WHERE kind = 'calls' AND file_path = ?",
             (rel_path,),
         ).fetchall()
     except sqlite3.OperationalError as exc:
@@ -56,9 +56,9 @@ def resolve_call_edges_for_file(
             continue
         try:
             conn.execute(
-                "UPDATE ast_call_edges "
-                "SET callee_symbol_id = ?, callee_resolution = ?, callee_resolved_file = ? "
-                "WHERE id = ?",
+                "UPDATE edges "
+                "SET callee_symbol_id = ?, callee_resolution = ?, "
+                "callee_resolved_file = ? WHERE id = ?",
                 (
                     resolved.callee_symbol_id,
                     resolved.resolution,
@@ -86,11 +86,12 @@ def run_synapse_backfill(cache: Any, conn: sqlite3.Connection) -> dict[str, int]
         # project, no resolved_file by design) — re-selecting them on every
         # backfill is the unknown-> rescan loop B3 is meant to break.
         rows = conn.execute(
-            "SELECT id, caller_name, caller_file, callee_name, callee_full "
-            "FROM ast_call_edges "
-            "WHERE callee_resolution = 'unknown' "
+            "SELECT id, caller_name, file_path AS caller_file, callee_name, "
+            "callee_full FROM edges "
+            "WHERE kind = 'calls' AND ("
+            "callee_resolution = 'unknown' "
             "OR (callee_resolved_file = '' "
-            "    AND callee_resolution NOT IN ('external', 'stdlib'))"
+            "    AND callee_resolution NOT IN ('external', 'stdlib')))"
         ).fetchall()
     except sqlite3.OperationalError as exc:
         logger.debug("synapse backfill select failed: %s", exc)
@@ -131,9 +132,9 @@ def run_synapse_backfill(cache: Any, conn: sqlite3.Connection) -> dict[str, int]
     if updates:
         try:
             conn.executemany(
-                "UPDATE ast_call_edges "
-                "SET callee_symbol_id = ?, callee_resolution = ?, callee_resolved_file = ? "
-                "WHERE id = ?",
+                "UPDATE edges "
+                "SET callee_symbol_id = ?, callee_resolution = ?, "
+                "callee_resolved_file = ? WHERE id = ?",
                 updates,
             )
             resolved += len(updates)

--- a/tree_sitter_analyzer/_ast_cache_synapse.py
+++ b/tree_sitter_analyzer/_ast_cache_synapse.py
@@ -36,7 +36,7 @@ def resolve_call_edges_for_file(
         return
     try:
         rows = conn.execute(
-            "SELECT id, caller_name, caller_file, callee_name "
+            "SELECT id, caller_name, caller_file, callee_name, callee_full "
             "FROM ast_call_edges WHERE file_path = ?",
             (rel_path,),
         ).fetchall()
@@ -45,7 +45,12 @@ def resolve_call_edges_for_file(
         return
     for row in rows:
         try:
-            resolved = resolve_callee(row["callee_name"], row["caller_file"], ctx)
+            resolved = resolve_callee(
+                row["callee_name"],
+                row["caller_file"],
+                ctx,
+                row["callee_full"],
+            )
         except Exception as exc:  # pragma: no cover
             logger.debug("resolve_callee crashed on %s: %s", row["callee_name"], exc)
             continue
@@ -76,9 +81,16 @@ def run_synapse_backfill(cache: Any, conn: sqlite3.Connection) -> dict[str, int]
     if not is_enabled():
         return None
     try:
+        # Re-scan only edges that are still genuinely unresolved. ``external``
+        # and ``stdlib`` are *terminal* resolutions (target lives outside the
+        # project, no resolved_file by design) — re-selecting them on every
+        # backfill is the unknown-> rescan loop B3 is meant to break.
         rows = conn.execute(
-            "SELECT id, caller_name, caller_file, callee_name FROM ast_call_edges "
-            "WHERE callee_resolution = 'unknown' OR callee_resolved_file = ''"
+            "SELECT id, caller_name, caller_file, callee_name, callee_full "
+            "FROM ast_call_edges "
+            "WHERE callee_resolution = 'unknown' "
+            "OR (callee_resolved_file = '' "
+            "    AND callee_resolution NOT IN ('external', 'stdlib'))"
         ).fetchall()
     except sqlite3.OperationalError as exc:
         logger.debug("synapse backfill select failed: %s", exc)
@@ -95,7 +107,12 @@ def run_synapse_backfill(cache: Any, conn: sqlite3.Connection) -> dict[str, int]
     updates: list[tuple[Any, str, str, int]] = []
     for row in rows:
         try:
-            result = resolve_callee(row["callee_name"], row["caller_file"], ctx)
+            result = resolve_callee(
+                row["callee_name"],
+                row["caller_file"],
+                ctx,
+                row["callee_full"],
+            )
         except Exception as exc:
             logger.debug("resolve_callee failed in backfill: %s", exc)
             errors += 1

--- a/tree_sitter_analyzer/_ast_cache_unresolved.py
+++ b/tree_sitter_analyzer/_ast_cache_unresolved.py
@@ -1,4 +1,19 @@
-"""Second-pass unresolved reference handling for ASTCache."""
+"""Second-pass cross-file reference resolution for ASTCache.
+
+B1.3 removed the ``unresolved_refs`` work-queue table. The second pass now runs
+directly over the unified ``edges`` table + the indexed symbol/import data:
+
+* The pending work set is recomputed in-memory per Python file from the same
+  sources the queue was derived from (the file's symbols give EXTENDS parents,
+  the file's CALLS edges give unresolved calls). The exact filtering logic that
+  used to gate queue insertion (``_parent_refs`` / ``_call_refs`` — skip local
+  names, skip obvious externals, skip already-resolved) is preserved verbatim,
+  so Python resolution semantics are byte-for-byte unchanged.
+* A resolved EXTENDS reference is upserted as a real ``edges`` row (provenance
+  ``unresolved_refs``); a resolved CALLS reference UPDATEs the resolution
+  columns of its existing ``edges`` CALLS row. No separate queue table, no
+  double-write into ``ast_call_edges``.
+"""
 
 from __future__ import annotations
 
@@ -27,111 +42,99 @@ _CALL_ROW_COLUMNS = (
 
 
 def _refs_supported(language: str) -> bool:
-    """Whether unresolved_refs second-pass resolution adds value for a language.
+    """Whether second-pass resolution adds value for a language.
 
     Only Python has structured import parsing (``synapse_resolver/_imports.py``
     hard-returns ``[]`` for every other language). Without ``ast_imports`` rows,
     the second-pass resolver can only fall back to ambiguous name matching, which
-    is rejected ~100% of the time for languages like Java/COBOL/C#/Go. Writing and
-    re-resolving those rows is pure waste (and the dominant cost / OOM trigger on
-    large Java repos). So we skip emitting unresolved_refs rows entirely for
-    non-Python languages. Python behaviour is unchanged.
+    is rejected ~100% of the time for languages like Java/COBOL/C#/Go. Resolving
+    those refs is pure waste (and the dominant cost / OOM trigger on large Java
+    repos). So we skip non-Python languages entirely. Python is unchanged.
     """
     return language == "python"
 
 
-def write_unresolved_refs_for_file(
+def _pending_refs_for_file(
     conn: sqlite3.Connection,
     rel_path: str,
     language: str,
     symbols: dict[str, Any],
-    call_edges: list[dict[str, Any]],
-) -> None:
-    """Refresh unresolved_refs emitted while indexing one file."""
-    try:
-        conn.execute("DELETE FROM unresolved_refs WHERE file_path = ?", (rel_path,))
-    except sqlite3.OperationalError as exc:
-        logger.debug("unresolved_refs cleanup failed for %s: %s", rel_path, exc)
-        return
-    if not _refs_supported(language):
-        # Non-Python: no structured imports -> second-pass resolution is pure
-        # waste. Skip writing rows (the DELETE above keeps the table clean).
-        return
+) -> list[dict[str, Any]]:
+    """Recompute the pending second-pass refs for one Python file.
 
+    Returns ref dicts ``{from_node_id, reference_name, reference_kind,
+    file_path, line}`` — the in-memory equivalent of the rows the old
+    ``unresolved_refs`` queue persisted, derived from the file's symbols
+    (EXTENDS parents) and its ``edges`` CALLS rows (unresolved calls).
+    """
+    if not _refs_supported(language):
+        return []
     symbol_items = symbols.get("symbols", [])
     local_classes = _local_names(symbol_items, {"class"})
     local_callables = _local_names(symbol_items, {"class", "function", "method"})
-    rows: list[tuple[str, str, str, str, int, str, int]] = []
-    rows.extend(_parent_refs(rel_path, symbol_items, local_classes))
-    rows.extend(
-        _call_refs(
-            conn,
-            rel_path,
-            language,
-            call_edges,
-            local_callables,
-        )
-    )
-    if not rows:
-        return
-    try:
-        conn.executemany(
-            """INSERT OR REPLACE INTO unresolved_refs
-               (from_node_id, reference_name, reference_kind, file_path,
-                line, candidates, resolved)
-               VALUES (?, ?, ?, ?, ?, ?, ?)""",
-            rows,
-        )
-    except sqlite3.OperationalError as exc:
-        logger.debug("unresolved_refs insert failed for %s: %s", rel_path, exc)
+    refs: list[dict[str, Any]] = []
+    refs.extend(_parent_refs(rel_path, symbol_items, local_classes))
+    refs.extend(_call_refs(conn, rel_path, language, [], local_callables))
+    return refs
 
 
 def resolve_unresolved_refs(conn: sqlite3.Connection) -> dict[str, int] | None:
-    """Resolve pending unresolved_refs rows into unified EdgeStore edges."""
+    """Resolve pending cross-file refs into unified ``edges`` rows.
+
+    Iterates Python files from ``ast_index``, recomputes each file's pending
+    refs in-memory, and either upserts a resolved EXTENDS edge or UPDATEs a
+    CALLS edge's resolution columns. The aggregate ``total/resolved/unchanged/
+    errors`` shape matches the legacy queue-based pass so callers/stats are
+    unchanged.
+    """
     try:
-        rows = conn.execute(
-            """SELECT id, from_node_id, reference_name, reference_kind,
-                      file_path, line
-               FROM unresolved_refs
-               WHERE resolved = 0
-               ORDER BY id"""
+        index_rows = conn.execute(
+            "SELECT file_path, language, symbols_json FROM ast_index "
+            "WHERE language = 'python' ORDER BY file_path"
         ).fetchall()
     except sqlite3.OperationalError as exc:
-        logger.debug("unresolved_refs select failed: %s", exc)
+        logger.debug("unresolved second-pass index select failed: %s", exc)
         return None
 
-    total = len(rows)
-    resolved = unchanged = errors = 0
+    total = resolved = unchanged = errors = 0
     store = EdgeStore(conn, ensure_schema=False)
-    for row in rows:
+    for index_row in index_rows:
+        rel_path = str(index_row["file_path"])
         try:
-            row_dict = dict(row)
-            candidates = _candidate_symbols(
-                conn,
-                str(row_dict["file_path"]),
-                str(row_dict["reference_name"]),
-                str(row_dict["reference_kind"]),
-            )
-            chosen = _choose_candidate(conn, row_dict, candidates)
-            payload = _candidate_payload(candidates)
-            if chosen is None:
-                unchanged += 1
-                conn.execute(
-                    "UPDATE unresolved_refs SET candidates = ? WHERE id = ?",
-                    (json.dumps(payload, ensure_ascii=False), row_dict["id"]),
+            symbols = json.loads(index_row["symbols_json"] or "{}")
+        except (TypeError, json.JSONDecodeError):
+            continue
+        refs = _pending_refs_for_file(
+            conn, rel_path, str(index_row["language"]), symbols
+        )
+        for ref in refs:
+            total += 1
+            try:
+                candidates = _candidate_symbols(
+                    conn,
+                    str(ref["file_path"]),
+                    str(ref["reference_name"]),
+                    str(ref["reference_kind"]),
                 )
-                continue
-            edge = _resolved_edge(conn, row_dict, chosen, len(candidates))
-            store.upsert_edges([edge])
-            _update_call_edge_resolution(conn, row_dict, chosen)
-            conn.execute(
-                "UPDATE unresolved_refs SET candidates = ?, resolved = 1 WHERE id = ?",
-                (json.dumps(payload, ensure_ascii=False), row_dict["id"]),
-            )
-            resolved += 1
-        except (sqlite3.OperationalError, TypeError, ValueError) as exc:
-            logger.debug("unresolved_refs row failed: %s", exc)
-            errors += 1
+                chosen = _choose_candidate(conn, ref, candidates)
+                if chosen is None:
+                    unchanged += 1
+                    continue
+                if ref["reference_kind"] == EdgeKind.CALLS.value:
+                    # CALLS resolution is recorded in place on the existing edge
+                    # row's resolution columns — no separate edge, so callees
+                    # aren't double-counted (B1.3). The resolved file makes the
+                    # call cross-file-queryable via ``callee_resolved_file``.
+                    _update_call_edge_resolution(conn, ref, chosen)
+                else:
+                    # EXTENDS/IMPLEMENTS: upsert a real edge pointing at the
+                    # resolved base class so class_hierarchy can traverse it.
+                    edge = _resolved_edge(conn, ref, chosen, len(candidates))
+                    store.upsert_edges([edge])
+                resolved += 1
+            except (sqlite3.OperationalError, TypeError, ValueError) as exc:
+                logger.debug("unresolved ref failed: %s", exc)
+                errors += 1
     try:
         conn.commit()
     except sqlite3.OperationalError:
@@ -145,22 +148,48 @@ def resolve_unresolved_refs(conn: sqlite3.Connection) -> dict[str, int] | None:
 
 
 def pending_unresolved_count(conn: sqlite3.Connection) -> int:
-    """Return unresolved_refs rows still awaiting a second-pass attempt."""
+    """Return a cheap count of references still awaiting cross-file resolution.
+
+    Replaces the ``unresolved_refs WHERE resolved = 0`` gate (B1.3). Counts
+    EXTENDS edges that still point at an unresolved ``class:`` synthetic target
+    — the genuine cross-file work the second pass resolves into real edges.
+    Unknown CALLS edges are *not* counted: most are terminal externals (stdlib /
+    builtins) that never resolve, so counting them would keep this gate
+    permanently > 0 and re-trigger the resolve-only pass on every warm access.
+    Used only as a boolean ``> 0`` trigger; the resolve-only pass is idempotent.
+    """
     try:
         row = conn.execute(
-            "SELECT COUNT(*) AS c FROM unresolved_refs WHERE resolved = 0"
+            "SELECT COUNT(*) AS c FROM edges "
+            "WHERE kind = 'extends' AND target_node_id LIKE 'class:%'"
         ).fetchone()
     except sqlite3.OperationalError:
         return 0
     return int(row["c"] if isinstance(row, sqlite3.Row) else row[0])
 
 
+def _ref(
+    from_node_id: str,
+    reference_name: str,
+    reference_kind: str,
+    file_path: str,
+    line: int,
+) -> dict[str, Any]:
+    return {
+        "from_node_id": from_node_id,
+        "reference_name": reference_name,
+        "reference_kind": reference_kind,
+        "file_path": file_path,
+        "line": line,
+    }
+
+
 def _parent_refs(
     rel_path: str,
     symbol_items: list[dict[str, Any]],
     local_classes: set[str],
-) -> list[tuple[str, str, str, str, int, str, int]]:
-    rows: list[tuple[str, str, str, str, int, str, int]] = []
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
     for sym in symbol_items:
         if sym.get("kind") != "class" or not sym.get("parents"):
             continue
@@ -179,15 +208,7 @@ def _parent_refs(
             ):
                 continue
             rows.append(
-                (
-                    source,
-                    parent_name,
-                    EdgeKind.EXTENDS.value,
-                    rel_path,
-                    line,
-                    "[]",
-                    0,
-                )
+                _ref(source, parent_name, EdgeKind.EXTENDS.value, rel_path, line)
             )
     return rows
 
@@ -198,8 +219,8 @@ def _call_refs(
     language: str,
     fallback_edges: list[dict[str, Any]],
     local_callables: set[str],
-) -> list[tuple[str, str, str, str, int, str, int]]:
-    rows: list[tuple[str, str, str, str, int, str, int]] = []
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
     for edge in _call_rows(conn, rel_path, fallback_edges):
         if _call_is_resolved(edge):
             continue
@@ -213,17 +234,7 @@ def _call_refs(
         caller_line = _line(edge.get("caller_line"))
         source = symbol_node(rel_path, caller_name, caller_line)
         ref_line = _line(edge.get("callee_line")) or caller_line
-        rows.append(
-            (
-                source,
-                callee_name,
-                EdgeKind.CALLS.value,
-                rel_path,
-                ref_line,
-                "[]",
-                0,
-            )
-        )
+        rows.append(_ref(source, callee_name, EdgeKind.CALLS.value, rel_path, ref_line))
     return rows
 
 
@@ -232,13 +243,14 @@ def _call_rows(
     rel_path: str,
     fallback_edges: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
+    """Return this file's CALLS rows from the unified ``edges`` table (B1.3)."""
     try:
         rows = conn.execute(
-            """SELECT caller_name, caller_file, caller_line, callee_name,
-                      callee_full, callee_line, file_path, language,
+            """SELECT caller_name, file_path AS caller_file, caller_line,
+                      callee_name, callee_full, callee_line, file_path, language,
                       callee_resolution, callee_resolved_file
-               FROM ast_call_edges
-               WHERE file_path = ?
+               FROM edges
+               WHERE kind = 'calls' AND file_path = ?
                ORDER BY id""",
             (rel_path,),
         ).fetchall()
@@ -399,10 +411,11 @@ def _update_call_edge_resolution(
     line = _line(row.get("line"))
     try:
         conn.execute(
-            """UPDATE ast_call_edges
+            """UPDATE edges
                SET callee_symbol_id = ?, callee_resolution = 'project',
                    callee_resolved_file = ?
-               WHERE file_path = ?
+               WHERE kind = 'calls'
+                 AND file_path = ?
                  AND caller_name = ?
                  AND caller_line = ?
                  AND callee_name = ?
@@ -419,20 +432,7 @@ def _update_call_edge_resolution(
             ),
         )
     except sqlite3.OperationalError as exc:
-        logger.debug("call edge unresolved_refs update failed: %s", exc)
-
-
-def _candidate_payload(candidates: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    return [
-        {
-            "node_id": str(item["node_id"]),
-            "name": str(item["name"]),
-            "kind": str(item["kind"]),
-            "file_path": str(item["file_path"]),
-            "line": int(item["line"]),
-        }
-        for item in candidates[:20]
-    ]
+        logger.debug("call edge cross-file update failed: %s", exc)
 
 
 def _import_target_hints(

--- a/tree_sitter_analyzer/_ast_cache_unresolved.py
+++ b/tree_sitter_analyzer/_ast_cache_unresolved.py
@@ -26,6 +26,20 @@ _CALL_ROW_COLUMNS = (
 )
 
 
+def _refs_supported(language: str) -> bool:
+    """Whether unresolved_refs second-pass resolution adds value for a language.
+
+    Only Python has structured import parsing (``synapse_resolver/_imports.py``
+    hard-returns ``[]`` for every other language). Without ``ast_imports`` rows,
+    the second-pass resolver can only fall back to ambiguous name matching, which
+    is rejected ~100% of the time for languages like Java/COBOL/C#/Go. Writing and
+    re-resolving those rows is pure waste (and the dominant cost / OOM trigger on
+    large Java repos). So we skip emitting unresolved_refs rows entirely for
+    non-Python languages. Python behaviour is unchanged.
+    """
+    return language == "python"
+
+
 def write_unresolved_refs_for_file(
     conn: sqlite3.Connection,
     rel_path: str,
@@ -38,6 +52,10 @@ def write_unresolved_refs_for_file(
         conn.execute("DELETE FROM unresolved_refs WHERE file_path = ?", (rel_path,))
     except sqlite3.OperationalError as exc:
         logger.debug("unresolved_refs cleanup failed for %s: %s", rel_path, exc)
+        return
+    if not _refs_supported(language):
+        # Non-Python: no structured imports -> second-pass resolution is pure
+        # waste. Skip writing rows (the DELETE above keeps the table clean).
         return
 
     symbol_items = symbols.get("symbols", [])

--- a/tree_sitter_analyzer/_ast_cache_write.py
+++ b/tree_sitter_analyzer/_ast_cache_write.py
@@ -63,36 +63,6 @@ def write_fts5_symbols(
     ]
 
 
-def write_call_edges(
-    conn: sqlite3.Connection,
-    rel_path: str,
-    language: str,
-    call_edges: list[dict[str, Any]],
-) -> None:
-    """Replace call-edge rows for ``rel_path``."""
-    conn.execute("DELETE FROM ast_call_edges WHERE file_path = ?", (rel_path,))
-    if not call_edges:
-        return
-    conn.executemany(
-        "INSERT INTO ast_call_edges "
-        "(caller_name, caller_file, caller_line, callee_name, callee_full, callee_line, "
-        "file_path, language) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-        [
-            (
-                edge["caller_name"],
-                rel_path,
-                edge["caller_line"],
-                edge["callee_name"],
-                edge["callee_full"],
-                edge["callee_line"],
-                rel_path,
-                language,
-            )
-            for edge in call_edges
-        ],
-    )
-
-
 def write_fts5_symbols_from_tuples(
     conn: sqlite3.Connection,
     rel_path: str,
@@ -272,8 +242,16 @@ def write_graph_edges_for_file(
     symbols: dict[str, Any],
     imports: list[str] | list[dict[str, Any]],
     call_edges: list[dict[str, Any]],
+    *,
+    preserve_calls: bool = False,
 ) -> None:
-    """Refresh unified EdgeStore rows derived from one indexed file."""
+    """Refresh unified EdgeStore rows derived from one indexed file.
+
+    ``preserve_calls=True`` rebuilds only the structural edges (EXTENDS /
+    CONTAINS / IMPORTS) and leaves existing CALLS rows — with their second-pass
+    resolution columns — untouched. Used by ``_refresh_graph_edges_from_cache``,
+    which (post-B1.3) has no extracted call-edge source to rebuild calls from.
+    """
     try:
         from .graph.edge_store import (
             Edge,
@@ -290,7 +268,6 @@ def write_graph_edges_for_file(
         return
 
     symbol_items = symbols.get("symbols", [])
-    call_edges = _graph_call_edges(conn, rel_path, call_edges)
     class_nodes = {
         sym.get("name", ""): symbol_node(rel_path, sym.get("name", ""), sym.get("line"))
         for sym in symbol_items
@@ -382,52 +359,8 @@ def write_graph_edges_for_file(
                 )
 
     try:
-        EdgeStore(conn, ensure_schema=False).replace_edges_for_file(rel_path, edges)
+        EdgeStore(conn, ensure_schema=False).replace_edges_for_file(
+            rel_path, edges, preserve_calls=preserve_calls
+        )
     except sqlite3.OperationalError as exc:
         logger.debug("edge store write failed for %s: %s", rel_path, exc)
-
-
-_GRAPH_CALL_EDGE_COLUMNS = (
-    "caller_name",
-    "caller_file",
-    "caller_line",
-    "callee_name",
-    "callee_full",
-    "callee_line",
-    "file_path",
-    "language",
-    "callee_resolution",
-    "callee_resolved_file",
-)
-
-_GRAPH_CALL_EDGE_SELECT = """
-SELECT caller_name, caller_file, caller_line, callee_name, callee_full,
-       callee_line, file_path, language, callee_resolution, callee_resolved_file
-FROM ast_call_edges
-WHERE file_path = ?
-ORDER BY id
-""".strip()
-
-
-def _graph_call_edges(
-    conn: sqlite3.Connection,
-    rel_path: str,
-    fallback: list[dict[str, Any]],
-) -> list[dict[str, Any]]:
-    """Return resolved call rows for EdgeStore, falling back to extracted edges."""
-    try:
-        rows = conn.execute(
-            _GRAPH_CALL_EDGE_SELECT,
-            (rel_path,),
-        ).fetchall()
-    except sqlite3.OperationalError:
-        return fallback
-    if not rows:
-        return fallback
-    return [_row_to_dict(row, _GRAPH_CALL_EDGE_COLUMNS) for row in rows]
-
-
-def _row_to_dict(row: Any, columns: tuple[str, ...]) -> dict[str, Any]:
-    if isinstance(row, sqlite3.Row):
-        return dict(row)
-    return dict(zip(columns, row, strict=False))

--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -546,12 +546,30 @@ class ASTCache:
         )
 
     def get_call_edges(self) -> list[dict[str, Any]]:
-        """Return all stored call edges from the cache."""
+        """Return all stored call edges from the cache.
+
+        CALLS rows now live in the unified ``edges`` table (B1.2b). Real
+        columns carry ``caller_name``/``callee_name``/``file_path``; the
+        remaining legacy scalars (``caller_line``, ``callee_full``,
+        ``language``) come from the ``metadata`` JSON blob via ``json_extract``.
+        ``file_path`` is the caller's file (== legacy ``caller_file``) and the
+        ``line`` column is the call-site line (== legacy ``callee_line``).
+        Aliases reproduce the exact dict keys the legacy SELECT yielded, so the
+        three consumers (cross_file_resolver / call_graph / dependency_matrix)
+        see identical rows.
+        """
         try:
             _conn = self._get_conn()
             _cur = _conn.execute(
-                "SELECT caller_name, caller_file, caller_line, "
-                "callee_name, callee_full, callee_line, file_path, language FROM ast_call_edges"
+                "SELECT caller_name, "
+                "file_path AS caller_file, "
+                "json_extract(metadata, '$.caller_line') AS caller_line, "
+                "callee_name, "
+                "json_extract(metadata, '$.callee_full') AS callee_full, "
+                "line AS callee_line, "
+                "file_path, "
+                "json_extract(metadata, '$.language') AS language "
+                "FROM edges WHERE kind = 'calls'"
             )
             rows = _cur.fetchall()
         except sqlite3.OperationalError:

--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -46,6 +46,7 @@ from ._ast_cache_schema import (
     apply_migration_v7 as _apply_migration_v7,
     apply_migration_v8 as _apply_migration_v8,
     apply_migration_v9 as _apply_migration_v9,
+    apply_migration_v10 as _apply_migration_v10,
     backfill_schema_version_row as _backfill_schema_version_row,
     check_schema_expectations as _check_schema_expectations,
     clear_activation_for_file as _clear_activation_for_file_fn,
@@ -139,6 +140,7 @@ class ASTCache:
             (7, _apply_migration_v7),
             (8, _apply_migration_v8),
             (9, _apply_migration_v9),
+            (10, _apply_migration_v10),
         ]
         self._fts5_available = _schema_init_db(
             conn, self._fts5_available, _has_fts5, migrations

--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -47,6 +47,7 @@ from ._ast_cache_schema import (
     apply_migration_v8 as _apply_migration_v8,
     apply_migration_v9 as _apply_migration_v9,
     apply_migration_v10 as _apply_migration_v10,
+    apply_migration_v11 as _apply_migration_v11,
     backfill_schema_version_row as _backfill_schema_version_row,
     check_schema_expectations as _check_schema_expectations,
     clear_activation_for_file as _clear_activation_for_file_fn,
@@ -141,6 +142,7 @@ class ASTCache:
             (8, _apply_migration_v8),
             (9, _apply_migration_v9),
             (10, _apply_migration_v10),
+            (11, _apply_migration_v11),
         ]
         self._fts5_available = _schema_init_db(
             conn, self._fts5_available, _has_fts5, migrations
@@ -427,6 +429,7 @@ class ASTCache:
                     symbols,
                     imports,
                     [],
+                    preserve_calls=True,
                 )
                 refreshed += 1
             except (json.JSONDecodeError, sqlite3.OperationalError):
@@ -548,27 +551,25 @@ class ASTCache:
     def get_call_edges(self) -> list[dict[str, Any]]:
         """Return all stored call edges from the cache.
 
-        CALLS rows now live in the unified ``edges`` table (B1.2b). Real
-        columns carry ``caller_name``/``callee_name``/``file_path``; the
-        remaining legacy scalars (``caller_line``, ``callee_full``,
-        ``language``) come from the ``metadata`` JSON blob via ``json_extract``.
-        ``file_path`` is the caller's file (== legacy ``caller_file``) and the
-        ``line`` column is the call-site line (== legacy ``callee_line``).
-        Aliases reproduce the exact dict keys the legacy SELECT yielded, so the
-        three consumers (cross_file_resolver / call_graph / dependency_matrix)
-        see identical rows.
+        CALLS rows now live in the unified ``edges`` table. Every legacy scalar
+        is a real promoted column (B1.3): ``caller_name``/``callee_name``/
+        ``file_path``/``caller_line``/``callee_full``/``callee_line``/
+        ``language``. ``file_path`` is the caller's file (== legacy
+        ``caller_file``). Aliases reproduce the exact dict keys the legacy SELECT
+        yielded, so the three consumers (cross_file_resolver / call_graph /
+        dependency_matrix) see identical rows.
         """
         try:
             _conn = self._get_conn()
             _cur = _conn.execute(
                 "SELECT caller_name, "
                 "file_path AS caller_file, "
-                "json_extract(metadata, '$.caller_line') AS caller_line, "
+                "caller_line, "
                 "callee_name, "
-                "json_extract(metadata, '$.callee_full') AS callee_full, "
-                "line AS callee_line, "
+                "callee_full, "
+                "callee_line, "
                 "file_path, "
-                "json_extract(metadata, '$.language') AS language "
+                "language "
                 "FROM edges WHERE kind = 'calls'"
             )
             rows = _cur.fetchall()
@@ -662,17 +663,11 @@ class ASTCache:
             return []
 
     def has_call_edges(self) -> bool:
-        """Check whether the cache contains any call edge data."""
-        try:
-            row = (
-                self._get_conn()
-                .execute("SELECT COUNT(*) as c FROM ast_call_edges")
-                .fetchone()
-            )
-            if bool(row["c"] > 0):
-                return True
-        except sqlite3.OperationalError:
-            pass
+        """Check whether the cache contains any call edge data.
+
+        CALLS rows live in the unified ``edges`` table (B1.3 — no
+        ast_call_edges), so this is a single index-backed kind probe.
+        """
         try:
             from .graph.edge_store import EdgeKind, EdgeStore
 

--- a/tree_sitter_analyzer/call_path.py
+++ b/tree_sitter_analyzer/call_path.py
@@ -3,12 +3,12 @@
 Call Path Finder — BFS-based execution path discovery between two functions.
 
 Finds all call chains from a source function to a target function using
-the SQL-backed ``ast_call_edges`` table.  This is distinct from
+the SQL-backed unified ``edges`` table (CALLS rows).  This is distinct from
 callers (all X that call Y) and callees (all Y that X calls) — it
 answers "how does execution reach from A to B?"
 
 Two backends:
-  - SQL-native: queries ``ast_call_edges`` directly — O(k) per hop
+  - SQL-native: queries the ``edges`` table directly — O(k) per hop
   - In-memory: builds a :class:`CallGraph` and walks ``_callees`` / ``_callers`` maps
 """
 
@@ -23,6 +23,34 @@ from typing import Any
 from .utils import setup_logger
 
 logger = setup_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Unified edge-table SELECTs (B1.2)
+#
+# CALLS rows now live in the single ``edges`` table.  Real columns carry
+# caller_name/callee_name/file_path; the remaining scalars (caller_line,
+# callee_resolved_file) are read from the metadata JSON blob.  ``file_path`` is
+# the caller's file (== legacy ``ast_call_edges.caller_file``), and ``line`` is
+# the call-site line (== legacy ``callee_line``).  Aliases preserve the exact
+# dict keys the BFS code downstream expects, so behaviour is unchanged.
+# ---------------------------------------------------------------------------
+
+_FORWARD_EDGE_SELECT = (
+    "SELECT caller_name, file_path AS caller_file, callee_name, "
+    "line AS callee_line, "
+    "json_extract(metadata, '$.callee_resolved_file') AS callee_resolved_file, "
+    "file_path "
+    "FROM edges "
+)
+
+_BACKWARD_EDGE_SELECT = (
+    "SELECT caller_name, file_path AS caller_file, "
+    "json_extract(metadata, '$.caller_line') AS caller_line, "
+    "callee_name, "
+    "json_extract(metadata, '$.callee_resolved_file') AS callee_resolved_file, "
+    "file_path "
+    "FROM edges "
+)
 
 # ---------------------------------------------------------------------------
 # Direction helpers — forward (callee) direction
@@ -150,7 +178,7 @@ def _bfs_sql_core(
     hop_fn: Callable,
     prepend: bool,
 ) -> list[Any]:
-    """BFS over ast_call_edges in one direction (forward or backward)."""
+    """BFS over the unified ``edges`` table in one direction (forward/backward)."""
     queue: deque[tuple[str, str | None, list[dict[str, Any]]]] = deque(
         [(start_name, start_file, [])]
     )
@@ -522,17 +550,13 @@ class CallPathFinder:
         try:
             if caller_file:
                 rows = conn.execute(
-                    "SELECT caller_name, caller_file, callee_name, "
-                    "callee_line, callee_resolved_file, file_path "
-                    "FROM ast_call_edges "
-                    "WHERE caller_name = ? AND caller_file = ?",
+                    _FORWARD_EDGE_SELECT
+                    + "WHERE kind = 'calls' AND caller_name = ? AND file_path = ?",
                     (caller_name, caller_file),
                 ).fetchall()
             else:
                 rows = conn.execute(
-                    "SELECT caller_name, caller_file, callee_name, "
-                    "callee_line, callee_resolved_file, file_path "
-                    "FROM ast_call_edges WHERE caller_name = ?",
+                    _FORWARD_EDGE_SELECT + "WHERE kind = 'calls' AND caller_name = ?",
                     (caller_name,),
                 ).fetchall()
             return [dict(r) for r in rows]
@@ -548,25 +572,20 @@ class CallPathFinder:
         try:
             if callee_file:
                 rows = conn.execute(
-                    "SELECT caller_name, caller_file, caller_line, "
-                    "callee_name, callee_resolved_file, file_path "
-                    "FROM ast_call_edges "
-                    "WHERE callee_name = ? AND callee_resolved_file = ?",
+                    _BACKWARD_EDGE_SELECT + "WHERE kind = 'calls' AND callee_name = ? "
+                    "AND json_extract(metadata, '$.callee_resolved_file') = ?",
                     (callee_name, callee_file),
                 ).fetchall()
                 if not rows:
                     rows = conn.execute(
-                        "SELECT caller_name, caller_file, caller_line, "
-                        "callee_name, callee_resolved_file, file_path "
-                        "FROM ast_call_edges "
-                        "WHERE callee_name = ? AND file_path = ?",
+                        _BACKWARD_EDGE_SELECT
+                        + "WHERE kind = 'calls' AND callee_name = ? "
+                        "AND file_path = ?",
                         (callee_name, callee_file),
                     ).fetchall()
             else:
                 rows = conn.execute(
-                    "SELECT caller_name, caller_file, caller_line, "
-                    "callee_name, callee_resolved_file, file_path "
-                    "FROM ast_call_edges WHERE callee_name = ?",
+                    _BACKWARD_EDGE_SELECT + "WHERE kind = 'calls' AND callee_name = ?",
                     (callee_name,),
                 ).fetchall()
             return [dict(r) for r in rows]

--- a/tree_sitter_analyzer/cli/commands/constraint_check_command.py
+++ b/tree_sitter_analyzer/cli/commands/constraint_check_command.py
@@ -202,7 +202,9 @@ def _run_and_persist(
         conn.execute(_violations_ddl())
         try:
             edge_count = int(
-                conn.execute("SELECT COUNT(*) FROM ast_call_edges").fetchone()[0]
+                conn.execute(
+                    "SELECT COUNT(*) FROM edges WHERE kind = 'calls'"
+                ).fetchone()[0]
             )
         except sqlite3.OperationalError:
             edge_count = 0

--- a/tree_sitter_analyzer/constraints/evaluator.py
+++ b/tree_sitter_analyzer/constraints/evaluator.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python3
 """Edge-stream evaluator for architectural constraints.
 
-Given a list of loaded :class:`Constraint` rules and an open
-``ast_call_edges`` SQLite connection, yields one :class:`Violation`
-per offending edge.
+Given a list of loaded :class:`Constraint` rules and an open SQLite
+connection holding the unified ``edges`` table, yields one
+:class:`Violation` per offending CALLS edge.
 
 Design contract:
 
-* T1's ``callee_resolved_file`` column is preferred when present and
-  populated, so we benefit from import-aware resolution. Edges where
-  the column is empty or absent fall back to ``file_path`` (the legacy
-  callee location column). Edges with no callee location at all are
-  skipped — they would generate false positives on unresolved calls.
+* The callee's resolved file (``metadata.callee_resolved_file`` on the
+  ``edges`` row) is preferred when present and populated, so we benefit
+  from import-aware resolution. Edges where it is empty fall back to
+  ``file_path`` (the caller's file). Edges with no callee location at all
+  are skipped — they would generate false positives on unresolved calls.
 
 * Performance is load-bearing: this is called on every change_impact /
   safe_to_edit invocation. We compile globs once, batch the SELECT into
@@ -38,7 +38,7 @@ def evaluate(
     constraints: list[Constraint],
     db_conn: sqlite3.Connection,
 ) -> list[Violation]:
-    """Evaluate constraints against the ``ast_call_edges`` table.
+    """Evaluate constraints against the unified ``edges`` table (CALLS rows).
 
     Returns a list (materialised; downstream code wants a length-check
     and the row count is bounded by the rule × edge cross-product, which
@@ -111,35 +111,26 @@ def _is_excepted(caller_file: str, compiled: _CompiledConstraint) -> bool:
 
 
 def _build_select_sql(db_conn: sqlite3.Connection) -> str:
-    """Build the per-DB SELECT statement.
+    """Build the per-DB SELECT statement over the unified ``edges`` table.
 
-    Prefers ``callee_resolved_file`` when the column exists on
-    ``ast_call_edges`` (T1's Synapse migration) and falls back to
-    ``file_path`` when it does not (test-only minimal schema or
-    pre-T1 caches that never indexed cross-file resolution).
+    CALLS edges now live in ``edges`` (B1.2).  The resolved-file scalar lives
+    in the ``metadata`` JSON blob, so the callee file is derived as
+    ``json_extract(metadata, '$.callee_resolved_file')`` with a fall back to
+    the caller's ``file_path`` when the call was never cross-file resolved —
+    preserving the legacy ``CASE WHEN callee_resolved_file != ''`` behaviour.
 
-    The COALESCE between the two columns is also defensive against a
-    partially-migrated DB where the column exists but is empty for some
-    rows (T1's resolver may not have run on legacy data yet).
+    The ``db_conn`` argument is retained for signature compatibility; the
+    edges schema always carries ``metadata`` so no per-DB probing is needed.
     """
-    callee_expr = "file_path"
-    try:
-        columns = {
-            row[1]
-            for row in db_conn.execute("PRAGMA table_info(ast_call_edges)").fetchall()
-        }
-    except sqlite3.OperationalError:
-        columns = set()
-
-    if "callee_resolved_file" in columns:
-        # Prefer the resolved column, but fall back to file_path so
-        # legacy unresolved rows still contribute.
-        callee_expr = (
-            "CASE WHEN callee_resolved_file != '' "
-            "THEN callee_resolved_file ELSE file_path END"
-        )
+    callee_expr = (
+        "CASE WHEN json_extract(metadata, '$.callee_resolved_file') IS NOT NULL "
+        "AND json_extract(metadata, '$.callee_resolved_file') != '' "
+        "THEN json_extract(metadata, '$.callee_resolved_file') "
+        "ELSE file_path END"
+    )
     return (
-        "SELECT caller_name, caller_file, caller_line, callee_name, "
+        "SELECT caller_name, file_path AS caller_file, "
+        "json_extract(metadata, '$.caller_line') AS caller_line, callee_name, "
         f"{callee_expr} AS callee_file "  # nosec B608 — callee_expr is constructed from internal constants only
-        "FROM ast_call_edges"
+        "FROM edges WHERE kind = 'calls'"
     )

--- a/tree_sitter_analyzer/constraints/evaluator.py
+++ b/tree_sitter_analyzer/constraints/evaluator.py
@@ -113,24 +113,22 @@ def _is_excepted(caller_file: str, compiled: _CompiledConstraint) -> bool:
 def _build_select_sql(db_conn: sqlite3.Connection) -> str:
     """Build the per-DB SELECT statement over the unified ``edges`` table.
 
-    CALLS edges now live in ``edges`` (B1.2).  The resolved-file scalar lives
-    in the ``metadata`` JSON blob, so the callee file is derived as
-    ``json_extract(metadata, '$.callee_resolved_file')`` with a fall back to
-    the caller's ``file_path`` when the call was never cross-file resolved —
-    preserving the legacy ``CASE WHEN callee_resolved_file != ''`` behaviour.
+    CALLS edges now live in ``edges`` with every resolution scalar promoted to
+    a real column (B1.3). The callee file prefers ``callee_resolved_file`` and
+    falls back to the caller's ``file_path`` when the call was never cross-file
+    resolved — preserving the legacy ``CASE WHEN callee_resolved_file != ''``
+    behaviour.
 
-    The ``db_conn`` argument is retained for signature compatibility; the
-    edges schema always carries ``metadata`` so no per-DB probing is needed.
+    The ``db_conn`` argument is retained for signature compatibility.
     """
     callee_expr = (
-        "CASE WHEN json_extract(metadata, '$.callee_resolved_file') IS NOT NULL "
-        "AND json_extract(metadata, '$.callee_resolved_file') != '' "
-        "THEN json_extract(metadata, '$.callee_resolved_file') "
+        "CASE WHEN callee_resolved_file != '' "
+        "THEN callee_resolved_file "
         "ELSE file_path END"
     )
     return (
         "SELECT caller_name, file_path AS caller_file, "
-        "json_extract(metadata, '$.caller_line') AS caller_line, callee_name, "
+        "caller_line, callee_name, "
         f"{callee_expr} AS callee_file "  # nosec B608 — callee_expr is constructed from internal constants only
         "FROM edges WHERE kind = 'calls'"
     )

--- a/tree_sitter_analyzer/graph/edge_store.py
+++ b/tree_sitter_analyzer/graph/edge_store.py
@@ -91,6 +91,13 @@ CREATE TABLE IF NOT EXISTS edges (
     caller_name TEXT NOT NULL DEFAULT '',
     callee_name TEXT NOT NULL DEFAULT '',
     file_path TEXT NOT NULL DEFAULT '',
+    caller_line INTEGER NOT NULL DEFAULT 0,
+    callee_full TEXT NOT NULL DEFAULT '',
+    callee_line INTEGER NOT NULL DEFAULT 0,
+    language TEXT NOT NULL DEFAULT '',
+    callee_resolution TEXT NOT NULL DEFAULT 'unknown',
+    callee_resolved_file TEXT NOT NULL DEFAULT '',
+    callee_symbol_id INTEGER,
     UNIQUE(source_node_id, target_node_id, kind, line)
 )
 """.strip(),
@@ -99,13 +106,17 @@ CREATE TABLE IF NOT EXISTS edges (
     "CREATE INDEX IF NOT EXISTS idx_edges_kind ON edges(kind)",
     "CREATE INDEX IF NOT EXISTS idx_edges_callee_name ON edges(callee_name, kind)",
     "CREATE INDEX IF NOT EXISTS idx_edges_caller_name ON edges(caller_name, kind)",
+    "CREATE INDEX IF NOT EXISTS idx_edges_file_path ON edges(file_path)",
+    "CREATE INDEX IF NOT EXISTS idx_edges_resolved ON edges(callee_resolved_file)",
 )
 
 EDGE_STORE_SCHEMA = ";\n\n".join(EDGE_STORE_SCHEMA_STATEMENTS) + ";"
 
-# Real columns promoted from the JSON ``metadata`` blob (B1.1). ALTER TABLE has
-# no IF NOT EXISTS form, so these are added only when a legacy ``edges`` table
-# (v8/v9 shape) is missing them.
+# Real columns promoted from the JSON ``metadata`` blob. ALTER TABLE has no
+# IF NOT EXISTS form, so these are added only when a legacy ``edges`` table
+# (v8/v9/v10 shape) is missing them. B1.1 promoted caller_name/callee_name/
+# file_path; B1.3 promotes the remaining resolution scalars so synapse /
+# unresolved second-pass resolution can UPDATE them in place (no ast_call_edges).
 _EDGE_NAME_COLUMNS: tuple[tuple[str, str], ...] = (
     (
         "caller_name",
@@ -116,6 +127,29 @@ _EDGE_NAME_COLUMNS: tuple[tuple[str, str], ...] = (
         "ALTER TABLE edges ADD COLUMN callee_name TEXT NOT NULL DEFAULT ''",
     ),
     ("file_path", "ALTER TABLE edges ADD COLUMN file_path TEXT NOT NULL DEFAULT ''"),
+    (
+        "caller_line",
+        "ALTER TABLE edges ADD COLUMN caller_line INTEGER NOT NULL DEFAULT 0",
+    ),
+    (
+        "callee_full",
+        "ALTER TABLE edges ADD COLUMN callee_full TEXT NOT NULL DEFAULT ''",
+    ),
+    (
+        "callee_line",
+        "ALTER TABLE edges ADD COLUMN callee_line INTEGER NOT NULL DEFAULT 0",
+    ),
+    ("language", "ALTER TABLE edges ADD COLUMN language TEXT NOT NULL DEFAULT ''"),
+    (
+        "callee_resolution",
+        "ALTER TABLE edges ADD COLUMN callee_resolution TEXT NOT NULL "
+        "DEFAULT 'unknown'",
+    ),
+    (
+        "callee_resolved_file",
+        "ALTER TABLE edges ADD COLUMN callee_resolved_file TEXT NOT NULL DEFAULT ''",
+    ),
+    ("callee_symbol_id", "ALTER TABLE edges ADD COLUMN callee_symbol_id INTEGER"),
 )
 
 
@@ -187,14 +221,34 @@ class EdgeStore:
         if self._owns_conn:
             self._conn.close()
 
-    def replace_edges_for_file(self, file_path: str, edges: list[Edge]) -> None:
-        """Replace all edges whose source belongs to ``file_path``."""
+    def replace_edges_for_file(
+        self,
+        file_path: str,
+        edges: list[Edge],
+        *,
+        preserve_calls: bool = False,
+    ) -> None:
+        """Replace all edges whose source belongs to ``file_path``.
+
+        Deletion is keyed on the indexed ``file_path`` real column (B1.3) — the
+        source's file is recorded there for every edge kind — which replaces the
+        ``source_node_id LIKE 'file:%'`` prefix scan that was a full-table hot
+        spot on large repos. The node-id predicates remain as a belt-and-braces
+        fallback for any pre-B1.1 row whose ``file_path`` column was never
+        backfilled.
+
+        ``preserve_calls=True`` keeps existing CALLS rows (and their second-pass
+        resolution columns) intact — used by the structural-edge refresh path,
+        which has no extracted call-edge source to rebuild them from after the
+        ``ast_call_edges`` table was dropped.
+        """
         file_node_id = file_node(file_path)
         symbol_prefix = _escape_like(f"{file_path}:")
+        calls_clause = "" if not preserve_calls else "kind != 'calls' AND "
         self._conn.execute(
-            "DELETE FROM edges "
-            "WHERE source_node_id = ? OR source_node_id LIKE ? ESCAPE '\\'",
-            (file_node_id, f"{symbol_prefix}%"),
+            f"DELETE FROM edges WHERE {calls_clause}"  # nosec B608 — constant clause
+            "(file_path = ? OR source_node_id = ? OR source_node_id LIKE ? ESCAPE '\\')",
+            (file_path, file_node_id, f"{symbol_prefix}%"),
         )
         self.upsert_edges(edges)
 
@@ -205,12 +259,14 @@ class EdgeStore:
 
     def upsert_edges(self, edges: list[Edge]) -> None:
         for edge in edges:
-            caller_name, callee_name, file_path = _edge_name_columns(edge)
+            cols = _edge_real_columns(edge)
             self._conn.execute(
                 """INSERT OR REPLACE INTO edges
                    (source_node_id, target_node_id, kind, line, provenance,
-                    metadata, caller_name, callee_name, file_path)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    metadata, caller_name, callee_name, file_path,
+                    caller_line, callee_full, callee_line, language,
+                    callee_resolution, callee_resolved_file, callee_symbol_id)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     edge.source_node_id,
                     edge.target_node_id,
@@ -218,9 +274,16 @@ class EdgeStore:
                     edge.line,
                     edge.provenance,
                     json.dumps(edge.metadata, ensure_ascii=False, sort_keys=True),
-                    caller_name,
-                    callee_name,
-                    file_path,
+                    cols["caller_name"],
+                    cols["callee_name"],
+                    cols["file_path"],
+                    cols["caller_line"],
+                    cols["callee_full"],
+                    cols["callee_line"],
+                    cols["language"],
+                    cols["callee_resolution"],
+                    cols["callee_resolved_file"],
+                    cols["callee_symbol_id"],
                 ),
             )
         self._commit_if_owned()
@@ -388,16 +451,44 @@ def parse_node_id(node_id: str) -> NodeRef:
     return NodeRef(file_path="", name=node_id, line=0)
 
 
-def _edge_name_columns(edge: Edge) -> tuple[str, str, str]:
-    """Derive the (caller_name, callee_name, file_path) real-column values.
+def _edge_real_columns(edge: Edge) -> dict[str, Any]:
+    """Derive every promoted real-column value for one ``Edge``.
 
-    Values mirror what ``parse_node_id`` extracts from the source/target node
-    ids, so SQL pushdown over these columns returns the same rows the legacy
-    Python-side filter did. ``file_path`` is the caller (source) file.
+    ``caller_name``/``callee_name``/``file_path`` mirror ``parse_node_id`` over
+    the source/target node ids (so SQL pushdown returns the same rows the legacy
+    Python-side filter did). The resolution scalars (``caller_line``,
+    ``callee_full``, ``language``, ``callee_resolution``, ``callee_resolved_file``,
+    ``callee_symbol_id``) come from ``metadata`` — the same values that previously
+    only lived in the JSON blob — so synapse / unresolved second-pass resolution
+    can UPDATE them in place without a separate ``ast_call_edges`` table.
+    ``callee_line`` is the call-site line (== ``edge.line`` == legacy
+    ``ast_call_edges.callee_line``).
     """
     source = parse_node_id(edge.source_node_id)
     target = parse_node_id(edge.target_node_id)
-    return source.name, target.name, source.file_path
+    meta = edge.metadata
+    symbol_id = meta.get("callee_symbol_id")
+    return {
+        "caller_name": source.name,
+        "callee_name": target.name,
+        "file_path": source.file_path,
+        "caller_line": _as_int(meta.get("caller_line"), source.line),
+        "callee_full": str(meta.get("callee_full", "")),
+        "callee_line": _as_int(edge.line, target.line),
+        "language": str(meta.get("language", "")),
+        "callee_resolution": str(meta.get("callee_resolution", "unknown")),
+        "callee_resolved_file": str(meta.get("callee_resolved_file", "")),
+        "callee_symbol_id": int(symbol_id) if symbol_id is not None else None,
+    }
+
+
+def _as_int(value: Any, default: int = 0) -> int:
+    try:
+        if value is None:
+            return int(default)
+        return int(value)
+    except (TypeError, ValueError):
+        return int(default) if isinstance(default, int) else 0
 
 
 def _kind_value(kind: EdgeKind | str | None) -> str | None:
@@ -504,7 +595,7 @@ def _bfs_call_edges(
             if key in visited:
                 continue
             visited.add(key)
-            result.append(_call_edge_entry(edge, source, target, depth))
+            result.append(_call_edge_entry(row, edge, source, target, depth))
             if max_depth > 1:
                 if direction == "callers":
                     queue.append((source.name, source.file_path, depth + 1))
@@ -564,10 +655,18 @@ def _direct_callers(
         edge = _edge_from_row(row)
         source = parse_node_id(edge.source_node_id)
         target = parse_node_id(edge.target_node_id)
-        if not _matches_callee(edge, target, callee_name):
+        if not _matches_callee(row, target, callee_name):
             continue
         if callee_file:
-            if target.file_path == callee_file:
+            resolved_file = str(
+                _row_col(row, "callee_resolved_file", "callee_resolved_file", edge)
+                or ""
+            )
+            # B1.3: cross-file resolution lives in the ``callee_resolved_file``
+            # column on the original (same-file) CALLS edge, so a query scoped
+            # to the callee's resolved file must match it even when the edge's
+            # target node still points at the unresolved same-file symbol.
+            if target.file_path == callee_file or resolved_file == callee_file:
                 rows.append(row)
             elif source.file_path == callee_file:
                 fallback_rows.append(row)
@@ -594,24 +693,48 @@ def _direct_callees(
     return rows
 
 
-def _matches_callee(edge: Edge, target: NodeRef, callee_name: str) -> bool:
-    names = {target.name, str(edge.metadata.get("callee_full", ""))}
+def _row_col(row: sqlite3.Row, column: str, meta_key: str, edge: Edge) -> Any:
+    """Read a promoted real column, falling back to the metadata JSON.
+
+    Post-v11 every edge row carries the resolution scalars as real columns, so
+    synapse / unresolved second-pass UPDATEs are visible here. The metadata
+    fallback keeps the reader resilient to rows written by an older schema that
+    happen to coexist in the same DB.
+    """
+    try:
+        value = row[column]
+    except (IndexError, KeyError):
+        value = None
+    if value in (None, "", 0):
+        meta_value = edge.metadata.get(meta_key)
+        if meta_value not in (None, "", 0):
+            return meta_value
+    return value
+
+
+def _matches_callee(row: sqlite3.Row, target: NodeRef, callee_name: str) -> bool:
+    edge = _edge_from_row(row)
+    names = {target.name, str(_row_col(row, "callee_full", "callee_full", edge) or "")}
     return callee_name in names
 
 
 def _call_edge_entry(
+    row: sqlite3.Row,
     edge: Edge,
     source: NodeRef,
     target: NodeRef,
     depth: int,
 ) -> dict[str, Any]:
-    resolved_file = str(edge.metadata.get("callee_resolved_file", ""))
+    resolved_file = str(
+        _row_col(row, "callee_resolved_file", "callee_resolved_file", edge) or ""
+    )
+    callee_full = str(_row_col(row, "callee_full", "callee_full", edge) or "")
     return {
         "caller_name": source.name,
         "caller_file": source.file_path,
         "caller_line": source.line,
         "callee_name": target.name,
-        "callee_full": str(edge.metadata.get("callee_full", "")),
+        "callee_full": callee_full,
         "callee_file": resolved_file or target.file_path,
         "callee_resolved_file": resolved_file,
         "callee_line": target.line or edge.line or 0,

--- a/tree_sitter_analyzer/graph/edge_store.py
+++ b/tree_sitter_analyzer/graph/edge_store.py
@@ -88,15 +88,73 @@ CREATE TABLE IF NOT EXISTS edges (
     line INTEGER,
     provenance TEXT DEFAULT 'tree-sitter',
     metadata TEXT,
+    caller_name TEXT NOT NULL DEFAULT '',
+    callee_name TEXT NOT NULL DEFAULT '',
+    file_path TEXT NOT NULL DEFAULT '',
     UNIQUE(source_node_id, target_node_id, kind, line)
 )
 """.strip(),
     "CREATE INDEX IF NOT EXISTS idx_edges_source_kind ON edges(source_node_id, kind)",
     "CREATE INDEX IF NOT EXISTS idx_edges_target_kind ON edges(target_node_id, kind)",
     "CREATE INDEX IF NOT EXISTS idx_edges_kind ON edges(kind)",
+    "CREATE INDEX IF NOT EXISTS idx_edges_callee_name ON edges(callee_name, kind)",
+    "CREATE INDEX IF NOT EXISTS idx_edges_caller_name ON edges(caller_name, kind)",
 )
 
 EDGE_STORE_SCHEMA = ";\n\n".join(EDGE_STORE_SCHEMA_STATEMENTS) + ";"
+
+# Real columns promoted from the JSON ``metadata`` blob (B1.1). ALTER TABLE has
+# no IF NOT EXISTS form, so these are added only when a legacy ``edges`` table
+# (v8/v9 shape) is missing them.
+_EDGE_NAME_COLUMNS: tuple[tuple[str, str], ...] = (
+    (
+        "caller_name",
+        "ALTER TABLE edges ADD COLUMN caller_name TEXT NOT NULL DEFAULT ''",
+    ),
+    (
+        "callee_name",
+        "ALTER TABLE edges ADD COLUMN callee_name TEXT NOT NULL DEFAULT ''",
+    ),
+    ("file_path", "ALTER TABLE edges ADD COLUMN file_path TEXT NOT NULL DEFAULT ''"),
+)
+
+
+def ensure_edge_schema(conn: sqlite3.Connection) -> None:
+    """Create the ``edges`` table + indexes; ALTER legacy tables for new columns.
+
+    The table is created first (no-op if present), then the promoted name/file
+    columns are added on legacy (v8/v9) tables before the name-column indexes
+    are created — ``CREATE INDEX ON edges(callee_name, ...)`` would otherwise
+    fail on a table that predates the column.
+    """
+    conn.execute(EDGE_STORE_SCHEMA_STATEMENTS[0])
+    existing = {row[1] for row in conn.execute("PRAGMA table_info(edges)").fetchall()}
+    for column, ddl in _EDGE_NAME_COLUMNS:
+        if column not in existing:
+            conn.execute(ddl)
+    for statement in EDGE_STORE_SCHEMA_STATEMENTS[1:]:
+        conn.execute(statement)
+
+
+def backfill_edge_name_columns(conn: sqlite3.Connection) -> None:
+    """Populate caller_name/callee_name/file_path for pre-v10 rows.
+
+    Re-parses existing node ids so legacy ``edges`` rows (written before the
+    columns existed) become queryable via the name indexes. Idempotent: only
+    touches rows where all three promoted columns are still empty.
+    """
+    rows = conn.execute(
+        "SELECT id, source_node_id, target_node_id FROM edges "
+        "WHERE caller_name = '' AND callee_name = '' AND file_path = ''"
+    ).fetchall()
+    for row in rows:
+        source = parse_node_id(row[1])
+        target = parse_node_id(row[2])
+        conn.execute(
+            "UPDATE edges SET caller_name = ?, callee_name = ?, file_path = ? "
+            "WHERE id = ?",
+            (source.name, target.name, source.file_path, row[0]),
+        )
 
 
 class EdgeStore:
@@ -122,8 +180,7 @@ class EdgeStore:
         return self._conn
 
     def ensure_schema(self) -> None:
-        for statement in EDGE_STORE_SCHEMA_STATEMENTS:
-            self._conn.execute(statement)
+        ensure_edge_schema(self._conn)
         self._commit_if_owned()
 
     def close(self) -> None:
@@ -141,12 +198,19 @@ class EdgeStore:
         )
         self.upsert_edges(edges)
 
+    def backfill_name_columns(self) -> None:
+        """Populate caller_name/callee_name/file_path for pre-v10 rows."""
+        backfill_edge_name_columns(self._conn)
+        self._commit_if_owned()
+
     def upsert_edges(self, edges: list[Edge]) -> None:
         for edge in edges:
+            caller_name, callee_name, file_path = _edge_name_columns(edge)
             self._conn.execute(
                 """INSERT OR REPLACE INTO edges
-                   (source_node_id, target_node_id, kind, line, provenance, metadata)
-                   VALUES (?, ?, ?, ?, ?, ?)""",
+                   (source_node_id, target_node_id, kind, line, provenance,
+                    metadata, caller_name, callee_name, file_path)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     edge.source_node_id,
                     edge.target_node_id,
@@ -154,6 +218,9 @@ class EdgeStore:
                     edge.line,
                     edge.provenance,
                     json.dumps(edge.metadata, ensure_ascii=False, sort_keys=True),
+                    caller_name,
+                    callee_name,
+                    file_path,
                 ),
             )
         self._commit_if_owned()
@@ -321,6 +388,18 @@ def parse_node_id(node_id: str) -> NodeRef:
     return NodeRef(file_path="", name=node_id, line=0)
 
 
+def _edge_name_columns(edge: Edge) -> tuple[str, str, str]:
+    """Derive the (caller_name, callee_name, file_path) real-column values.
+
+    Values mirror what ``parse_node_id`` extracts from the source/target node
+    ids, so SQL pushdown over these columns returns the same rows the legacy
+    Python-side filter did. ``file_path`` is the caller (source) file.
+    """
+    source = parse_node_id(edge.source_node_id)
+    target = parse_node_id(edge.target_node_id)
+    return source.name, target.name, source.file_path
+
+
 def _kind_value(kind: EdgeKind | str | None) -> str | None:
     if kind is None:
         return None
@@ -434,10 +513,43 @@ def _bfs_call_edges(
     return result
 
 
-def _call_edges(conn: sqlite3.Connection) -> list[sqlite3.Row]:
+def _callers_by_name(conn: sqlite3.Connection, callee_name: str) -> list[sqlite3.Row]:
+    """CALLS rows whose callee matches ``callee_name`` (index-backed pushdown).
+
+    The ``callee_name`` column holds the *bare* callee name (target node name).
+    A query may pass a fully-qualified name (e.g. ``engine.handleHTTPRequest``)
+    that only matches via ``metadata.callee_full``; in that case the candidate
+    set is narrowed by the bare suffix and ``_matches_callee`` confirms the full
+    match in Python. Either way the SQL stays on ``idx_edges_callee_name``.
+    """
+    bare = callee_name.split(".")[-1] if "." in callee_name else callee_name
+    if callee_name == bare:
+        return conn.execute(
+            "SELECT * FROM edges WHERE kind = ? AND callee_name = ? "
+            "ORDER BY source_node_id, target_node_id, line",
+            (EdgeKind.CALLS.value, callee_name),
+        ).fetchall()
     return conn.execute(
-        "SELECT * FROM edges WHERE kind = ? ORDER BY source_node_id, target_node_id, line",
-        (EdgeKind.CALLS.value,),
+        "SELECT * FROM edges WHERE kind = ? AND callee_name IN (?, ?) "
+        "ORDER BY source_node_id, target_node_id, line",
+        (EdgeKind.CALLS.value, callee_name, bare),
+    ).fetchall()
+
+
+def _callees_by_name(
+    conn: sqlite3.Connection, caller_name: str, bare: str
+) -> list[sqlite3.Row]:
+    """CALLS rows whose caller matches ``caller_name``/``bare`` (index-backed)."""
+    if caller_name == bare:
+        return conn.execute(
+            "SELECT * FROM edges WHERE kind = ? AND caller_name = ? "
+            "ORDER BY source_node_id, target_node_id, line",
+            (EdgeKind.CALLS.value, caller_name),
+        ).fetchall()
+    return conn.execute(
+        "SELECT * FROM edges WHERE kind = ? AND caller_name IN (?, ?) "
+        "ORDER BY source_node_id, target_node_id, line",
+        (EdgeKind.CALLS.value, caller_name, bare),
     ).fetchall()
 
 
@@ -448,7 +560,7 @@ def _direct_callers(
 ) -> list[sqlite3.Row]:
     rows: list[sqlite3.Row] = []
     fallback_rows: list[sqlite3.Row] = []
-    for row in _call_edges(conn):
+    for row in _callers_by_name(conn, callee_name):
         edge = _edge_from_row(row)
         source = parse_node_id(edge.source_node_id)
         target = parse_node_id(edge.target_node_id)
@@ -471,7 +583,7 @@ def _direct_callees(
 ) -> list[sqlite3.Row]:
     rows: list[sqlite3.Row] = []
     bare = caller_name.split(".")[-1] if "." in caller_name else caller_name
-    for row in _call_edges(conn):
+    for row in _callees_by_name(conn, caller_name, bare):
         edge = _edge_from_row(row)
         source = parse_node_id(edge.source_node_id)
         if source.name not in {caller_name, bare}:

--- a/tree_sitter_analyzer/mcp/tools/call_path_enrich.py
+++ b/tree_sitter_analyzer/mcp/tools/call_path_enrich.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Call-path output enrichment — coordinates → content + deterrent.
+
+This module upgrades the ``call_path`` response from bare coordinates
+(``{caller, callee, file, line}``) into a self-contained answer that
+inlines the *verbatim source body* of every function on the path, plus a
+``next_step`` deterrent telling the agent it already has everything.
+
+Rationale (turn-saving trade-off, intentional):
+    The bare-coordinate output forces the consuming agent to issue a
+    follow-up ``Read`` per ``file:line`` to see the actual code.  An agent's
+    real cost is ``turns x tokens-per-turn``; paying once for inlined bodies
+    (a bigger single response) eliminates N downstream ``Read`` turns, so the
+    total cost drops.  Output is capped (see ``MAX_BODY_LINES`` /
+    ``MAX_TOTAL_BODY_LINES``) so the single response stays bounded; truncated
+    bodies are flagged with ``file:line`` so the agent can still Read on demand.
+
+Two enrichment paths:
+    - Path found:  inline the body of every unique function across all hops.
+    - Dead end (no static path — dynamic dispatch / missing edge): inline
+      *both endpoints'* bodies and list each endpoint's direct callers/callees,
+      mirroring ``codegraph_trace`` dead-end behaviour, so the agent can reason
+      about the gap without a single extra call.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from ._codegraph_explore_helpers import extract_snippet_from_lines, read_file_lines
+
+# ---------------------------------------------------------------------------
+# Caps — bound the single (intentionally larger) response.
+# ---------------------------------------------------------------------------
+
+#: Max source lines inlined per function body before truncation.
+MAX_BODY_LINES = 80
+#: Max total source lines inlined across the whole response.
+MAX_TOTAL_BODY_LINES = 600
+#: Max direct neighbours (callers / callees) listed per endpoint on a dead end.
+MAX_NEIGHBORS = 12
+
+
+# ---------------------------------------------------------------------------
+# Function-definition index — name -> [definition spans]
+# ---------------------------------------------------------------------------
+
+
+def _build_def_index(cache: Any, names: set[str]) -> dict[str, list[dict[str, Any]]]:
+    """Return ``name -> [ {file, line, end_line, class} ]`` for ``names`` only.
+
+    Scans ``ast_index`` once and keeps only symbols whose name is in
+    ``names`` so we never materialise the full 20k+ function set.  Degrades
+    to an empty index on any failure (the caller then omits bodies).
+    """
+    index: dict[str, list[dict[str, Any]]] = {}
+    if not names:
+        return index
+    try:
+        conn = cache.get_conn()
+        rows = conn.execute("SELECT file_path, symbols_json FROM ast_index").fetchall()
+    except Exception:
+        return index
+    for row in rows:
+        try:
+            symbols = json.loads(row["symbols_json"]).get("symbols", [])
+        except Exception:
+            continue
+        for sym in symbols:
+            name = sym.get("name")
+            if name not in names:
+                continue
+            if sym.get("kind") not in ("function", "method"):
+                continue
+            index.setdefault(name, []).append(
+                {
+                    "file": row["file_path"],
+                    "line": int(sym.get("line", 0) or 0),
+                    "end_line": int(sym.get("end_line", 0) or 0),
+                    "class": sym.get("class"),
+                }
+            )
+    return index
+
+
+def _resolve_def(
+    index: dict[str, list[dict[str, Any]]],
+    name: str,
+    file_hint: str | None,
+) -> dict[str, Any] | None:
+    """Pick the best definition span for ``name``, preferring ``file_hint``."""
+    candidates = index.get(name)
+    if not candidates:
+        return None
+    if file_hint:
+        hint = file_hint.replace("\\", "/")
+        for cand in candidates:
+            if cand["file"].replace("\\", "/") == hint:
+                return cand
+    return candidates[0]
+
+
+# ---------------------------------------------------------------------------
+# Body extraction with caps
+# ---------------------------------------------------------------------------
+
+
+def _read_body(
+    project_root: str,
+    defn: dict[str, Any],
+    budget: list[int],
+) -> dict[str, Any] | None:
+    """Read a verbatim function body, honouring per-body and total caps.
+
+    ``budget`` is a single-element mutable list carrying remaining total
+    lines so multiple calls share one global cap.
+    """
+    file_path = defn.get("file", "")
+    start = int(defn.get("line", 0) or 0)
+    if not file_path or start < 1 or budget[0] <= 0:
+        return None
+    abs_path = (
+        file_path if os.path.isabs(file_path) else os.path.join(project_root, file_path)
+    )
+    lines = read_file_lines(abs_path)
+    if not lines:
+        return None
+    end = int(defn.get("end_line", 0) or 0)
+    if end < start:
+        end = start + MAX_BODY_LINES - 1
+    span = end - start + 1
+    truncated = False
+    # Per-body cap.
+    if span > MAX_BODY_LINES:
+        end = start + MAX_BODY_LINES - 1
+        truncated = True
+    # Total cap.
+    allowed = budget[0]
+    if (end - start + 1) > allowed:
+        end = start + allowed - 1
+        truncated = True
+    content = extract_snippet_from_lines(lines, start, end)
+    if not content:
+        return None
+    consumed = end - start + 1
+    budget[0] = max(0, budget[0] - consumed)
+    block: dict[str, Any] = {
+        "name": defn.get("name", ""),
+        "file": file_path,
+        "start_line": start,
+        "end_line": min(end, len(lines)),
+        "content": content,
+    }
+    if defn.get("class"):
+        block["class"] = defn["class"]
+    if truncated:
+        block["truncated"] = True
+        block["full_at"] = f"{file_path}:{start}"
+    return block
+
+
+# ---------------------------------------------------------------------------
+# Path-found enrichment — inline every unique function on the path
+# ---------------------------------------------------------------------------
+
+
+def _collect_path_functions(
+    paths: list[dict[str, Any]],
+) -> list[tuple[str, str | None]]:
+    """Ordered unique ``(name, file_hint)`` pairs across all path hops."""
+    seen: set[str] = set()
+    ordered: list[tuple[str, str | None]] = []
+    for path in paths:
+        for hop in path.get("hops", []):
+            for role, file_key in (
+                ("caller", "caller_file"),
+                ("callee", "callee_file"),
+            ):
+                name = hop.get(role)
+                if not name or name in seen:
+                    continue
+                seen.add(name)
+                ordered.append((name, hop.get(file_key) or None))
+    return ordered
+
+
+def inline_path_bodies(
+    project_root: str,
+    cache: Any,
+    paths: list[dict[str, Any]],
+    endpoint_hints: dict[str, str] | None = None,
+) -> tuple[list[dict[str, Any]], bool]:
+    """Return ``(source_bodies, any_truncated)`` for a found path.
+
+    De-duplicates: each unique function is inlined exactly once.
+    ``endpoint_hints`` maps a function name to a caller-supplied file hint
+    (e.g. the explicit ``source_file`` / ``target_file`` args) used to
+    disambiguate otherwise ambiguous bare names whose hops carry no file.
+    """
+    functions = _collect_path_functions(paths)
+    if endpoint_hints:
+        functions = [
+            (name, file_hint or endpoint_hints.get(name))
+            for name, file_hint in functions
+        ]
+    names = {name for name, _ in functions}
+    index = _build_def_index(cache, names)
+    budget = [MAX_TOTAL_BODY_LINES]
+    bodies: list[dict[str, Any]] = []
+    any_truncated = False
+    for name, file_hint in functions:
+        defn = _resolve_def(index, name, file_hint)
+        if defn is None:
+            continue
+        defn = {**defn, "name": name}
+        block = _read_body(project_root, defn, budget)
+        if block is None:
+            continue
+        any_truncated = any_truncated or bool(block.get("truncated"))
+        bodies.append(block)
+    return bodies, any_truncated
+
+
+# ---------------------------------------------------------------------------
+# Dead-end enrichment — inline both endpoints + their neighbours
+# ---------------------------------------------------------------------------
+
+
+def _neighbor_list(rows: list[dict[str, Any]], name_key: str) -> list[dict[str, Any]]:
+    """Compact, de-duplicated neighbour list (name + file + line)."""
+    out: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+    for row in rows:
+        nm = row.get(name_key, "")
+        if not nm:
+            continue
+        file_key = (
+            "caller_file" if name_key == "caller_name" else "callee_resolved_file"
+        )
+        fl = row.get(file_key) or row.get("callee_file") or row.get("caller_file") or ""
+        key = (nm, fl)
+        if key in seen:
+            continue
+        seen.add(key)
+        line_key = "caller_line" if name_key == "caller_name" else "callee_line"
+        out.append({"name": nm, "file": fl, "line": row.get(line_key, 0)})
+        if len(out) >= MAX_NEIGHBORS:
+            break
+    return out
+
+
+def _endpoint_block(
+    project_root: str,
+    cache: Any,
+    index: dict[str, list[dict[str, Any]]],
+    name: str,
+    file_hint: str | None,
+    budget: list[int],
+) -> dict[str, Any]:
+    """Build one endpoint block: body + direct callers + direct callees."""
+    defn = _resolve_def(index, name, file_hint)
+    block: dict[str, Any] = {"name": name}
+    if defn is not None:
+        body = _read_body(project_root, {**defn, "name": name}, budget)
+        if body is not None:
+            block["body"] = body
+    try:
+        callers = cache.query_callers(name, file_hint, 1)
+    except Exception:
+        callers = []
+    try:
+        callees = cache.query_callees(name, file_hint, 1)
+    except Exception:
+        callees = []
+    block["callers"] = _neighbor_list(callers, "caller_name")
+    block["callees"] = _neighbor_list(callees, "callee_name")
+    return block
+
+
+def build_dead_end(
+    project_root: str,
+    cache: Any,
+    source: str,
+    target: str,
+    source_file: str | None,
+    target_file: str | None,
+) -> dict[str, Any]:
+    """Return a dead-end payload with both endpoints inlined + neighbours."""
+    index = _build_def_index(cache, {source, target})
+    budget = [MAX_TOTAL_BODY_LINES]
+    return {
+        "source_endpoint": _endpoint_block(
+            project_root, cache, index, source, source_file, budget
+        ),
+        "target_endpoint": _endpoint_block(
+            project_root, cache, index, target, target_file, budget
+        ),
+    }

--- a/tree_sitter_analyzer/mcp/tools/call_path_enrich.py
+++ b/tree_sitter_analyzer/mcp/tools/call_path_enrich.py
@@ -111,12 +111,17 @@ def _read_body(
     project_root: str,
     defn: dict[str, Any],
     budget: list[int],
+    max_body_lines: int | None = None,
 ) -> dict[str, Any] | None:
     """Read a verbatim function body, honouring per-body and total caps.
 
     ``budget`` is a single-element mutable list carrying remaining total
-    lines so multiple calls share one global cap.
+    lines so multiple calls share one global cap.  ``max_body_lines`` overrides
+    the per-body cap for callers that want a tighter tier (e.g. P2's neighbour
+    / summary tiers); it defaults to :data:`MAX_BODY_LINES` so the call_path
+    path is unchanged.
     """
+    per_body_cap = MAX_BODY_LINES if max_body_lines is None else max_body_lines
     file_path = defn.get("file", "")
     start = int(defn.get("line", 0) or 0)
     if not file_path or start < 1 or budget[0] <= 0:
@@ -129,12 +134,12 @@ def _read_body(
         return None
     end = int(defn.get("end_line", 0) or 0)
     if end < start:
-        end = start + MAX_BODY_LINES - 1
+        end = start + per_body_cap - 1
     span = end - start + 1
     truncated = False
     # Per-body cap.
-    if span > MAX_BODY_LINES:
-        end = start + MAX_BODY_LINES - 1
+    if span > per_body_cap:
+        end = start + per_body_cap - 1
         truncated = True
     # Total cap.
     allowed = budget[0]

--- a/tree_sitter_analyzer/mcp/tools/call_path_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/call_path_tool.py
@@ -145,6 +145,7 @@ class CodeGraphCallPathTool(BaseMCPTool):
             direction=direction,
         )
 
+        paths = [p.to_dict() for p in result.paths]
         result_dict: dict[str, Any] = {
             "success": True,
             "verdict": "PATH_FOUND" if result.paths else "NO_PATH",
@@ -153,9 +154,99 @@ class CodeGraphCallPathTool(BaseMCPTool):
             "target": target_function,
             "path_count": len(result.paths),
             "truncated": result.truncated,
-            "paths": [p.to_dict() for p in result.paths],
+            "paths": paths,
         }
+
+        # ------------------------------------------------------------------
+        # Enrich coordinates -> content (turn-saving): inline verbatim source
+        # bodies so the consuming agent can answer without per-hop Read calls.
+        # See call_path_enrich for the cost rationale and output caps.
+        # ------------------------------------------------------------------
+        self._enrich_with_bodies(
+            result_dict,
+            paths,
+            source_function,
+            target_function,
+            source_file,
+            target_file,
+        )
 
         from ..utils.format_helper import apply_toon_format_to_response
 
         return apply_toon_format_to_response(result_dict, output_format)
+
+    def _enrich_with_bodies(
+        self,
+        result_dict: dict[str, Any],
+        paths: list[dict[str, Any]],
+        source_function: str,
+        target_function: str,
+        source_file: str | None,
+        target_file: str | None,
+    ) -> None:
+        """Inline source bodies + a deterrent ``next_step`` into the envelope.
+
+        Best-effort: any failure leaves the bare-coordinate response intact
+        rather than crashing the tool. The cache is reused from the finder.
+        """
+        from . import call_path_enrich as enrich
+
+        finder = self._finder
+        cache = None
+        if finder is not None:
+            try:
+                cache = finder._try_get_cache()
+            except Exception:
+                cache = None
+
+        project_root = self.project_root or "."
+
+        if paths:
+            bodies: list[dict[str, Any]] = []
+            truncated_body = False
+            if cache is not None:
+                endpoint_hints: dict[str, str] = {}
+                if source_file:
+                    endpoint_hints[source_function] = source_file
+                if target_file:
+                    endpoint_hints[target_function] = target_file
+                try:
+                    bodies, truncated_body = enrich.inline_path_bodies(
+                        project_root, cache, paths, endpoint_hints
+                    )
+                except Exception:  # pragma: no cover - defensive
+                    bodies, truncated_body = [], False
+            result_dict["source_bodies"] = bodies
+            result_dict["bodies_truncated"] = truncated_body
+            n = result_dict.get("path_count", 0)
+            suffix = (
+                " Some bodies truncated (see full_at) — Read only those if needed."
+                if truncated_body
+                else ""
+            )
+            result_dict["next_step"] = (
+                f"Path: {n} path(s), {len(bodies)} function bodies inlined in "
+                "source_bodies below — answer directly, no Read needed." + suffix
+            )
+            return
+
+        # Dead end: no static path (dynamic dispatch or missing edge).
+        dead_end: dict[str, Any] = {}
+        if cache is not None:
+            try:
+                dead_end = enrich.build_dead_end(
+                    project_root,
+                    cache,
+                    source_function,
+                    target_function,
+                    source_file,
+                    target_file,
+                )
+            except Exception:  # pragma: no cover - defensive
+                dead_end = {}
+        result_dict["dead_end"] = dead_end
+        result_dict["next_step"] = (
+            "No static path (dynamic dispatch or missing edge). Both endpoints' "
+            "bodies + their direct callers/callees are inlined in dead_end — "
+            "answer from these, no Read needed."
+        )

--- a/tree_sitter_analyzer/mcp/tools/callees_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/callees_tool.py
@@ -115,6 +115,10 @@ class CodeGraphCalleesTool(CodeGraphRelationToolMixin, BaseMCPTool):
         if _is_stale_resolution(callees):
             warnings_list.append(_STALE_CACHE_WARNING)
 
+        # P2: inline each callee's verbatim source body (top-N capped) so the
+        # agent answers from content, not coordinates — no Read per file:line.
+        next_step = self._inline_callee_bodies(cache, callees)
+
         result = build_response(
             verdict="INFO" if callees else "NOT_FOUND",
             warnings=warnings_list or None,
@@ -123,10 +127,39 @@ class CodeGraphCalleesTool(CodeGraphRelationToolMixin, BaseMCPTool):
             callee_count=len(callees),
             callees=callees,
         )
+        if next_step:
+            result["next_step"] = next_step
 
         from ..utils.format_helper import apply_toon_format_to_response
 
         return apply_toon_format_to_response(result, output_format)
+
+    def _inline_callee_bodies(
+        self,
+        cache: Any,
+        callees: list[dict[str, Any]],
+    ) -> str | None:
+        """P2: attach a body to the top-N callees (in place). Returns deterrent.
+
+        Best-effort: any failure leaves the bare-coordinate list intact and
+        returns ``None`` (no deterrent).
+        """
+        if not callees or not self.project_root:
+            return None
+        try:
+            from . import symbol_body_inline as sbi
+
+            # cache may be None (graph-parse path with no index yet); the
+            # helper only needs it for the end_line fallback, and records on
+            # the graph path already carry end_line, so it degrades cleanly.
+            enriched = sbi.inline_neighbor_bodies(self.project_root, cache, callees)
+            if not any("body" in c for c in enriched):
+                return None
+            callees[:] = enriched
+            return sbi.NEIGHBORS_DETERRENT
+        except Exception as exc:  # best-effort enrichment
+            logger.debug(f"Callee body inlining failed: {exc}")
+            return None
 
     def _sql_native_callees(
         self,

--- a/tree_sitter_analyzer/mcp/tools/callers_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/callers_tool.py
@@ -125,6 +125,10 @@ class CodeGraphCallersTool(CodeGraphRelationToolMixin, BaseMCPTool):
         if _is_stale_resolution(callers):
             warnings_list.append(_STALE_CACHE_WARNING)
 
+        # P2: inline each caller's verbatim source body (top-N capped) so the
+        # agent answers from content, not coordinates — no Read per file:line.
+        next_step = self._inline_caller_bodies(cache, callers)
+
         result = build_response(
             verdict="INFO" if callers else "NOT_FOUND",
             warnings=warnings_list or None,
@@ -133,10 +137,39 @@ class CodeGraphCallersTool(CodeGraphRelationToolMixin, BaseMCPTool):
             caller_count=len(callers),
             callers=callers,
         )
+        if next_step:
+            result["next_step"] = next_step
 
         from ..utils.format_helper import apply_toon_format_to_response
 
         return apply_toon_format_to_response(result, output_format)
+
+    def _inline_caller_bodies(
+        self,
+        cache: Any,
+        callers: list[dict[str, Any]],
+    ) -> str | None:
+        """P2: attach a body to the top-N callers (in place). Returns deterrent.
+
+        Best-effort: any failure leaves the bare-coordinate list intact and
+        returns ``None`` (no deterrent).
+        """
+        if not callers or not self.project_root:
+            return None
+        try:
+            from . import symbol_body_inline as sbi
+
+            # cache may be None (graph-parse path with no index yet); the
+            # helper only needs it for the end_line fallback, and records on
+            # the graph path already carry end_line, so it degrades cleanly.
+            enriched = sbi.inline_neighbor_bodies(self.project_root, cache, callers)
+            if not any("body" in c for c in enriched):
+                return None
+            callers[:] = enriched
+            return sbi.NEIGHBORS_DETERRENT
+        except Exception as exc:  # best-effort enrichment
+            logger.debug(f"Caller body inlining failed: {exc}")
+            return None
 
     def _sql_native_callers(
         self,

--- a/tree_sitter_analyzer/mcp/tools/codegraph_navigate_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_navigate_tool.py
@@ -184,6 +184,10 @@ class CodeGraphNavigateTool(BaseMCPTool):
         if mode in ("hierarchy", "full"):
             result["hierarchy"] = self._call_hierarchy(symbol, file_path, depth)
 
+        # P2: inline verbatim definition bodies so the agent answers from
+        # content, not coordinates — no follow-up Read per file:line.
+        self._inline_definition_bodies(result)
+
         # Pain #16 (dogfood pass 3): codegraph_navigate emitted no verdict.
         # NOT_FOUND when nothing matched (definition/references/hierarchy
         # all empty), INFO otherwise. Agents that branch on verdict
@@ -205,6 +209,41 @@ class CodeGraphNavigateTool(BaseMCPTool):
                 )
 
         return apply_toon_format_to_response(result, output_format)
+
+    def _inline_definition_bodies(self, result: dict[str, Any]) -> None:
+        """P2: attach a verbatim source body to each definition record.
+
+        Best-effort: any failure leaves the bare-coordinate response intact.
+        Adds a deterrent ``next_step`` only when at least one body inlined.
+        """
+        definition = result.get("definition")
+        if not isinstance(definition, dict) or not definition.get("found"):
+            return
+        defs = definition.get("definitions")
+        if not isinstance(defs, list) or not defs:
+            return
+        try:
+            from . import symbol_body_inline as sbi
+
+            cache = self.get_cache()
+            if cache is None or not self.project_root:
+                return
+            inlined = False
+            new_defs: list[dict[str, Any]] = []
+            for d in defs:
+                if not isinstance(d, dict):
+                    new_defs.append(d)
+                    continue
+                body = sbi.inline_symbol_body(self.project_root, cache, d)
+                if body is not None:
+                    d = {**d, "body": body}
+                    inlined = True
+                new_defs.append(d)
+            if inlined:
+                definition["definitions"] = new_defs
+                result.setdefault("next_step", sbi.NAVIGATE_DETERRENT)
+        except Exception as exc:  # best-effort enrichment
+            logger.debug(f"Definition body inlining failed: {exc}")
 
     def _resolve_definition(self, symbol: str) -> dict[str, Any]:
         cache = self.get_cache()

--- a/tree_sitter_analyzer/mcp/tools/constraint_check_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/constraint_check_tool.py
@@ -196,8 +196,8 @@ class ConstraintCheckTool(BaseMCPTool):
         evaluator sees, which is a useful sanity signal even if it
         doesn't perfectly match the rule-count cross-product.
 
-        Cache-then-read contract: if there is no ``ast_call_edges`` table
-        (or it is empty) we DO NOT touch the existing violations table.
+        Cache-then-read contract: if there are no CALLS rows in the unified
+        ``edges`` table we DO NOT touch the existing violations table.
         That preserves rows that were seeded by another producer (the
         ``analyze_change_impact`` indexer, an earlier full run, or — in
         tests — directly by a fixture). Without this guard we'd wipe out
@@ -251,9 +251,11 @@ class ConstraintCheckTool(BaseMCPTool):
 
     @staticmethod
     def _count_edges(conn: sqlite3.Connection) -> int:
-        """Return the row count of ``ast_call_edges``, or 0 when absent."""
+        """Return the CALLS row count of the unified ``edges`` table, or 0."""
         try:
-            row = conn.execute("SELECT COUNT(*) FROM ast_call_edges").fetchone()
+            row = conn.execute(
+                "SELECT COUNT(*) FROM edges WHERE kind = 'calls'"
+            ).fetchone()
             return int(row[0]) if row else 0
         except sqlite3.OperationalError:
             # Table missing — fresh DB or a test fixture that built

--- a/tree_sitter_analyzer/mcp/tools/full_index_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/full_index_tool.py
@@ -126,16 +126,23 @@ class CodeGraphFullIndexTool(BaseMCPTool):
         if mode == "full":
             mark_dirty(self.project_root)
 
-        phases["ast_cache"] = self._phase_ast_cache(
+        ast_phase = self._phase_ast_cache(
             mode == "full",
             max_files,
             include_activation=include_activation,
         )
+        phases["ast_cache"] = ast_phase
         phases["incremental_sync"] = self._phase_incremental_sync()
         phases["fts5"] = self._phase_fts5_stats()
 
         if resolve_synapse:
-            phases["synapse_resolution"] = self._phase_synapse()
+            # A1: the ast_cache phase already ran the complete backfill chain
+            # (cross-file + synapse + edge-store refresh + unresolved_refs) via
+            # _post_index_backfill. Re-running index_project(resolve_only=True)
+            # here repeated the whole O(edges) chain a second time — on large
+            # Java repos that doubled backfill time and was a primary stall/OOM
+            # cause. Report from the already-computed stats instead of re-running.
+            phases["synapse_resolution"] = self._phase_synapse(ast_phase)
 
         phases["call_edges"] = self._phase_call_edge_stats()
 
@@ -184,6 +191,10 @@ class CodeGraphFullIndexTool(BaseMCPTool):
                 "errors": errors,
                 "mode_used": result.get("mode_used", "unknown"),
                 "activation_enabled": result.get("activation_enabled", False),
+                # Surface the backfill counts produced by _post_index_backfill so
+                # the synapse_resolution phase can report without re-running (A1).
+                "synapse_backfill": result.get("synapse_backfill"),
+                "unresolved_refs_backfill": result.get("unresolved_refs_backfill"),
             }
         except Exception as exc:
             return {
@@ -234,27 +245,28 @@ class CodeGraphFullIndexTool(BaseMCPTool):
         except Exception as exc:
             return {"status": "error", "error": str(exc)}
 
-    def _phase_synapse(self) -> dict[str, Any]:
-        t0 = time.monotonic()
-        try:
-            from ...ast_cache import ASTCache
+    def _phase_synapse(self, ast_phase: dict[str, Any]) -> dict[str, Any]:
+        """Report cross-file resolution results.
 
-            cache = ASTCache(self.project_root or ".")
-            result = cache.index_project(resolve_only=True)
-            cache.close()
-            elapsed = round(time.monotonic() - t0, 3)
-            backfill = result.get("synapse_backfill", 0)
-            return {
-                "status": "ok",
-                "elapsed_seconds": elapsed,
-                "resolved_edges": backfill,
-            }
-        except Exception as exc:
-            return {
-                "status": "error",
-                "error": str(exc),
-                "elapsed_seconds": round(time.monotonic() - t0, 3),
-            }
+        A1: cross-file resolution is performed once inside the ast_cache phase
+        (``index_project`` -> ``_post_index_backfill``). This phase no longer
+        re-runs the backfill chain; it summarizes the counts the ast_cache phase
+        already produced. This halves backfill time on large repos and removes
+        the duplicate full EdgeStore rewrite that caused the stall/OOM.
+        """
+        synapse = ast_phase.get("synapse_backfill") or {}
+        unresolved = ast_phase.get("unresolved_refs_backfill") or {}
+        resolved_edges = 0
+        if isinstance(synapse, dict):
+            resolved_edges += int(synapse.get("resolved", 0))
+        if isinstance(unresolved, dict):
+            resolved_edges += int(unresolved.get("resolved", 0))
+        return {
+            "status": "ok",
+            "elapsed_seconds": 0.0,
+            "resolved_edges": resolved_edges,
+            "note": "resolved during ast_cache phase (single-pass backfill)",
+        }
 
     def _phase_call_edge_stats(self) -> dict[str, Any]:
         try:

--- a/tree_sitter_analyzer/mcp/tools/symbol_body_inline.py
+++ b/tree_sitter_analyzer/mcp/tools/symbol_body_inline.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Shared symbol-body inlining — coordinates -> content + deterrent (P2).
+
+``call_path`` proved the turn-saving trade-off: inlining the *verbatim source
+body* next to a symbol's coordinates eliminates the follow-up ``Read`` per
+``file:line`` that an agent would otherwise issue.  An agent's real cost is
+``turns x tokens-per-turn``; paying once for a (bigger) inlined response is
+cheaper than N downstream Read turns.
+
+P2 generalises that mechanism to the tools agents actually reach for first when
+exploring an unfamiliar codebase:
+
+  - ``nav navigate``  — inline the definition body (full tier).
+  - ``nav callers`` / ``nav callees`` — inline each neighbour's body (neighbour
+    tier, capped to the top-N neighbours so a 1000-caller fan-out can't blow up
+    the response).
+  - ``search symbol`` — inline a short body summary for each top match (summary
+    tier) so the agent judges relevance from content, not coordinates.
+
+Three cap tiers keep big-Java responses bounded.  Long bodies are truncated and
+flagged with ``full_at`` ``file:line`` so the agent can still Read on demand.
+
+The low-level ``_build_def_index`` / ``_resolve_def`` / ``_read_body``
+primitives are reused from :mod:`call_path_enrich` so there is a single
+implementation of the def-index scan and the verbatim-read-with-caps logic.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .call_path_enrich import _build_def_index, _read_body, _resolve_def
+
+# ---------------------------------------------------------------------------
+# Cap tiers — bound the single (intentionally larger) response per use-case.
+# ---------------------------------------------------------------------------
+
+#: Max source lines for a single go-to-definition body (nav navigate).
+MAX_DEFINITION_LINES = 80
+#: Max source lines per caller/callee body (nav callers / nav callees).
+MAX_NEIGHBOR_LINES = 40
+#: Max source lines per search-match body summary (search symbol).
+MAX_SUMMARY_LINES = 30
+
+#: Max neighbours that get an inlined body before falling back to coordinates.
+MAX_NEIGHBOR_BODIES = 12
+#: Max search matches that get an inlined body summary.
+MAX_SUMMARY_BODIES = 8
+
+#: Total source-line budget shared across all bodies in one response.
+MAX_TOTAL_DEFINITION_LINES = 160
+MAX_TOTAL_NEIGHBOR_LINES = 320
+MAX_TOTAL_SUMMARY_LINES = 200
+
+
+# ---------------------------------------------------------------------------
+# Span resolution — prefer the record's own end_line, else def-index lookup.
+# ---------------------------------------------------------------------------
+
+
+def _record_span(
+    record: dict[str, Any],
+    cache: Any,
+) -> dict[str, Any] | None:
+    """Return a ``{name,file,line,end_line,class}`` def-span for ``record``.
+
+    Records from navigate definitions / search results already carry
+    ``end_line``; caller/callee records carry only ``name``/``file``/``line``,
+    so their span is resolved through the AST-index def-index (targeted scan,
+    name-filtered — never materialises the full symbol set).  Returns ``None``
+    when neither path yields a usable span.
+    """
+    name = record.get("name") or ""
+    file_hint = record.get("file") or None
+    line = int(record.get("line", 0) or 0)
+    if not name or line < 1:
+        return None
+
+    end_line = int(record.get("end_line", 0) or 0)
+    if end_line >= line:
+        return {
+            "name": name,
+            "file": record.get("file", ""),
+            "line": line,
+            "end_line": end_line,
+            "class": record.get("class"),
+        }
+
+    # No usable end_line — resolve via the def-index (cap to this one name).
+    index = _build_def_index(cache, {name})
+    defn = _resolve_def(index, name, file_hint)
+    if defn is None:
+        return None
+    return {**defn, "name": name}
+
+
+def _body_for_record(
+    project_root: str,
+    cache: Any,
+    record: dict[str, Any],
+    per_body_cap: int,
+    budget: list[int],
+) -> dict[str, Any] | None:
+    """Read one verbatim body for ``record`` honouring per-body + total caps."""
+    span = _record_span(record, cache)
+    if span is None:
+        return None
+    return _read_body(project_root, span, budget, max_body_lines=per_body_cap)
+
+
+# ---------------------------------------------------------------------------
+# Public API — one helper per tool surface
+# ---------------------------------------------------------------------------
+
+
+def inline_symbol_body(
+    project_root: str,
+    cache: Any,
+    record: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Inline a single definition body (full tier) for ``nav navigate``.
+
+    Returns a body block ``{name,file,start_line,end_line,content,...}`` or
+    ``None`` when the body can't be read.  Long bodies are truncated and
+    flagged with ``full_at`` so the agent can Read the remainder on demand.
+    """
+    budget = [MAX_TOTAL_DEFINITION_LINES]
+    return _body_for_record(project_root, cache, record, MAX_DEFINITION_LINES, budget)
+
+
+def inline_neighbor_bodies(
+    project_root: str,
+    cache: Any,
+    neighbors: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Attach a body (neighbour tier) to the top-N caller/callee records.
+
+    Each record is returned as a *new* dict (immutable — never mutates the
+    input) with a ``body`` key for the first ``MAX_NEIGHBOR_BODIES`` entries
+    that resolve; the remaining entries pass through coordinate-only.  The
+    total-line budget is shared so a deep fan-out still can't blow the cap.
+    """
+    budget = [MAX_TOTAL_NEIGHBOR_LINES]
+    out: list[dict[str, Any]] = []
+    bodied = 0
+    for record in neighbors:
+        new_record = dict(record)
+        if bodied < MAX_NEIGHBOR_BODIES and budget[0] > 0:
+            body = _body_for_record(
+                project_root, cache, record, MAX_NEIGHBOR_LINES, budget
+            )
+            if body is not None:
+                new_record["body"] = body
+                bodied += 1
+        out.append(new_record)
+    return out
+
+
+def inline_search_summaries(
+    project_root: str,
+    cache: Any,
+    results: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Attach a short body summary (summary tier) to the top search matches.
+
+    Returns new dicts (immutable) with a ``body`` key on the first
+    ``MAX_SUMMARY_BODIES`` matches that resolve.  The summary tier is the
+    smallest (``MAX_SUMMARY_LINES``) so a 50-match search stays bounded while
+    still giving the agent enough content to judge relevance without a Read.
+    """
+    budget = [MAX_TOTAL_SUMMARY_LINES]
+    out: list[dict[str, Any]] = []
+    bodied = 0
+    for record in results:
+        new_record = dict(record)
+        if bodied < MAX_SUMMARY_BODIES and budget[0] > 0:
+            body = _body_for_record(
+                project_root, cache, record, MAX_SUMMARY_LINES, budget
+            )
+            if body is not None:
+                new_record["body"] = body
+                bodied += 1
+        out.append(new_record)
+    return out
+
+
+#: Deterrent ``next_step`` strings — tell the agent it already has the content.
+NAVIGATE_DETERRENT = (
+    "Definition body inlined below — answer directly, no Read needed. "
+    "Truncated bodies carry full_at file:line for on-demand Read only if needed."
+)
+NEIGHBORS_DETERRENT = (
+    "Each caller/callee's source body is inlined under 'body' — answer "
+    "directly, no Read needed. Coordinate-only entries beyond the top-N can be "
+    "Read on demand."
+)
+SEARCH_DETERRENT = (
+    "Top matches carry an inlined source body — judge relevance from 'body', "
+    "no Read needed. Use codegraph_explore for broader concept matches."
+)

--- a/tree_sitter_analyzer/mcp/tools/symbol_search_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/symbol_search_tool.py
@@ -119,6 +119,9 @@ class CodeGraphSymbolSearchTool(BaseMCPTool):
 
         results = self._apply_kind_filter(raw_results, kind)
         self._add_source_context(results)
+        # P2: inline a short verbatim body for the top matches so the agent
+        # judges relevance from content, not coordinates — no Read per hit.
+        search_deterrent = self._inline_match_bodies(cache, results)
 
         by_file: dict[str, int] = {}
         for r in results:
@@ -137,10 +140,13 @@ class CodeGraphSymbolSearchTool(BaseMCPTool):
             "data_source": "fts5" if cache.fts5_available else "linear_scan",
         }
         if results:
-            result["next_step"] = (
-                f"Run codegraph_explore query={query!r} before raw grep/read "
-                "to bulk-fetch related symbols and concept matches."
-            )
+            if search_deterrent:
+                result["next_step"] = search_deterrent
+            else:
+                result["next_step"] = (
+                    f"Run codegraph_explore query={query!r} before raw grep/read "
+                    "to bulk-fetch related symbols and concept matches."
+                )
         if language:
             result["language_filter"] = language
         if kind != "any":
@@ -345,6 +351,30 @@ class CodeGraphSymbolSearchTool(BaseMCPTool):
         if kind == "any":
             return results
         return [r for r in results if r.get("kind", "") == kind]
+
+    def _inline_match_bodies(
+        self,
+        cache: Any,
+        results: list[dict[str, Any]],
+    ) -> str | None:
+        """P2: attach a short body summary to the top matches (in place).
+
+        Returns the deterrent ``next_step`` when at least one body inlined,
+        else ``None``.  Best-effort: any failure leaves results coordinate-only.
+        """
+        if not results or cache is None or not self.project_root:
+            return None
+        try:
+            from . import symbol_body_inline as sbi
+
+            enriched = sbi.inline_search_summaries(self.project_root, cache, results)
+            if not any("body" in r for r in enriched):
+                return None
+            results[:] = enriched
+            return sbi.SEARCH_DETERRENT
+        except Exception as exc:  # best-effort enrichment
+            logger.debug(f"Search body inlining failed: {exc}")
+            return None
 
     def _add_source_context(self, results: list[dict[str, Any]]) -> None:
         for r in results:

--- a/tree_sitter_analyzer/symbol_resolver.py
+++ b/tree_sitter_analyzer/symbol_resolver.py
@@ -391,10 +391,14 @@ class SymbolResolver:
         conn = self._cache.get_conn()
         try:
             rows = conn.execute(
-                """SELECT callee_name, callee_full, caller_name, caller_file,
-                          caller_line, file_path, language
-                   FROM ast_call_edges
-                   WHERE callee_name = ?""",
+                """SELECT callee_name,
+                          json_extract(metadata, '$.callee_full') AS callee_full,
+                          caller_name, file_path AS caller_file,
+                          json_extract(metadata, '$.caller_line') AS caller_line,
+                          file_path,
+                          json_extract(metadata, '$.language') AS language
+                   FROM edges
+                   WHERE kind = 'calls' AND callee_name = ?""",
                 (short_name,),
             ).fetchall()
             for row in rows:

--- a/tree_sitter_analyzer/synapse_resolver/__init__.py
+++ b/tree_sitter_analyzer/synapse_resolver/__init__.py
@@ -36,7 +36,7 @@ from ._imports import ImportEntry, parse_imports
 
 @dataclass(frozen=True)
 class ResolvedCallee:
-    """One resolution per call edge — written into ``ast_call_edges``."""
+    """One resolution per call edge — written into the unified ``edges`` table."""
 
     callee_symbol_id: int | None
     resolution: str

--- a/tree_sitter_analyzer/synapse_resolver/__init__.py
+++ b/tree_sitter_analyzer/synapse_resolver/__init__.py
@@ -213,6 +213,34 @@ def _try_single_global(
 
 
 def resolve_callee(
+    callee_name: str,
+    caller_file: str,
+    ctx: ResolverContext,
+    callee_full: str | None = None,
+) -> ResolvedCallee:
+    """Resolve a single callee, dispatching by the caller file's language.
+
+    Python keeps the original cascade verbatim. Java routes to the Java
+    resolver (when a Java context is present), using ``callee_full`` to
+    recover the receiver. Any other language falls through to the Python
+    cascade exactly as before B3 (no behaviour change for them).
+    """
+    language = ctx.file_languages.get(caller_file)
+    if language == "java" and ctx.java_context is not None:
+        from ._java import resolve_java_callee
+
+        sym_id, resolution, resolved_file = resolve_java_callee(
+            callee_name,
+            callee_full if callee_full is not None else callee_name,
+            caller_file,
+            ctx.java_context,
+        )
+        return ResolvedCallee(sym_id, resolution, resolved_file)
+
+    return _resolve_callee_python(callee_name, caller_file, ctx)
+
+
+def _resolve_callee_python(
     callee_name: str, caller_file: str, ctx: ResolverContext
 ) -> ResolvedCallee:
     """Resolve a single callee per the priority cascade above."""

--- a/tree_sitter_analyzer/synapse_resolver/_context.py
+++ b/tree_sitter_analyzer/synapse_resolver/_context.py
@@ -43,9 +43,13 @@ class ResolverContext:
         builtins: dict[str, frozenset[str]] | None = None,
         stdlib_modules: dict[str, frozenset[str]] | None = None,
         callee_resolver: CalleeResolver | None = None,
+        file_languages: dict[str, str] | None = None,
+        java_context: Any | None = None,
     ) -> None:
         self.project_root = project_root
         self.cache = cache
+        self._file_languages = file_languages or {}
+        self._java_context = java_context
         self._file_symbols = file_symbols or {}
         self._name_to_source = name_to_source or {}
         self._file_class_methods = file_class_methods or {}
@@ -68,8 +72,20 @@ class ResolverContext:
                 builtins,
                 stdlib_modules,
                 callee_resolver,
+                file_languages,
+                java_context,
             )
         )
+
+    @property
+    def file_languages(self) -> dict[str, str]:
+        self._ensure_loaded()
+        return self._file_languages
+
+    @property
+    def java_context(self) -> Any | None:
+        self._ensure_loaded()
+        return self._java_context
 
     @property
     def file_symbols(self) -> dict[str, list[tuple[str, str, int]]]:
@@ -136,6 +152,8 @@ class ResolverContext:
         self._builtins = built.builtins
         self._stdlib_modules = built.stdlib_modules
         self._callee_resolver = built.callee_resolver
+        self._file_languages = built._file_languages  # noqa: SLF001
+        self._java_context = built._java_context  # noqa: SLF001
         self._loaded = True
 
 
@@ -434,10 +452,15 @@ def _build_resolver_context_uncached(cache: ASTCache) -> ResolverContext:
         )
         imports_by_file.setdefault(entry.file_path, []).append(entry)
 
-    file_paths = [
-        r["file_path"]
-        for r in conn.execute("SELECT file_path FROM ast_index").fetchall()
-    ]
+    file_paths: list[str] = []
+    file_languages: dict[str, str] = {}
+    try:
+        idx_rows = conn.execute("SELECT file_path, language FROM ast_index").fetchall()
+    except Exception:  # nosec B110
+        idx_rows = []
+    for r in idx_rows:
+        file_paths.append(r["file_path"])
+        file_languages[r["file_path"]] = r["language"]
     module_to_file = _build_module_to_file(file_paths)
     name_to_source, alias_target = _build_import_maps(imports_by_file, module_to_file)
     callee_resolver = _build_callee_resolver(
@@ -445,6 +468,15 @@ def _build_resolver_context_uncached(cache: ASTCache) -> ResolverContext:
         global_name_table=global_name_table,
         name_to_source=name_to_source,
         alias_target=alias_target,
+    )
+
+    java_context = _maybe_build_java_context(
+        imports_by_file=imports_by_file,
+        file_languages=file_languages,
+        file_symbols=file_symbols,
+        global_name_table=global_name_table,
+        conn=conn,
+        line_idx=line_idx,
     )
 
     return ResolverContext(
@@ -458,6 +490,42 @@ def _build_resolver_context_uncached(cache: ASTCache) -> ResolverContext:
         builtins={"python": BUILTINS_PY},
         stdlib_modules={"python": STDLIB_NAMES_PY},
         callee_resolver=callee_resolver,
+        file_languages=file_languages,
+        java_context=java_context,
+    )
+
+
+def _maybe_build_java_context(
+    *,
+    imports_by_file: dict[str, list[ImportEntry]],
+    file_languages: dict[str, str],
+    file_symbols: dict[str, list[tuple[str, str, int]]],
+    global_name_table: dict[str, list[tuple[str, int]]],
+    conn: Any,
+    line_idx: dict[tuple[str, str, int], int],
+) -> Any | None:
+    """Build the Java resolver context, or ``None`` for non-Java projects.
+
+    Zero cost for Python-only projects: we only build when at least one
+    indexed file is Java. Java needs the class→method map (for this/super
+    resolution), so we build it here once and share it.
+    """
+    has_java = any(lang == "java" for lang in file_languages.values())
+    if not has_java:
+        return None
+    from ._java import build_java_context
+
+    java_imports: dict[str, list[ImportEntry]] = {
+        fp: entries
+        for fp, entries in imports_by_file.items()
+        if file_languages.get(fp) == "java"
+    }
+    file_class_methods = _build_file_class_methods(conn, line_idx)
+    return build_java_context(
+        imports_by_file=java_imports,
+        file_symbols=file_symbols,
+        file_class_methods=file_class_methods,
+        global_name_table=global_name_table,
     )
 
 

--- a/tree_sitter_analyzer/synapse_resolver/_imports.py
+++ b/tree_sitter_analyzer/synapse_resolver/_imports.py
@@ -53,16 +53,33 @@ def _split_names_clause(clause: str) -> list[tuple[str, str]]:
 def parse_imports(
     text: str, language: str, file_path: str = "", line: int = 0
 ) -> list[ImportEntry]:
-    """Parse one import statement into structured rows.
+    """Parse one import statement into structured rows (language dispatch).
+
+    Python (``from .b import x, y`` etc.) keeps its original behaviour
+    byte-for-byte via :func:`_parse_python_imports`. Java dispatches to
+    the Java import parser. Any other language returns an empty list,
+    matching the pre-B3 non-Python behaviour (no regression).
+    """
+    if language == "python":
+        return _parse_python_imports(text, file_path, line)
+    if language == "java":
+        from ._java import parse_java_imports
+
+        return parse_java_imports(text, file_path, line)
+    return []
+
+
+def _parse_python_imports(
+    text: str, file_path: str = "", line: int = 0
+) -> list[ImportEntry]:
+    """Parse one Python import statement into structured rows.
 
     ``from .b import x, y`` -> 2 rows with module_path='.b' (relative).
     ``from . import b as bb`` -> 1 row with local_name='bb', alias_of='b'.
     ``from M import *`` -> 1 row with is_star=True, local_name=''.
     ``import a.b as c`` -> 1 row with module_path='a.b', local_name='c'.
-    Non-python languages: empty (Phase 3a focuses on Python).
     """
-    if language != "python":
-        return []
+    language = "python"
     text = text.strip()
     if not text:
         return []

--- a/tree_sitter_analyzer/synapse_resolver/_java.py
+++ b/tree_sitter_analyzer/synapse_resolver/_java.py
@@ -119,7 +119,7 @@ def parse_java_imports(
 class JavaResolverContext:
     """Per-index Java resolution maps (built once per pass).
 
-    All file keys are project-relative paths, matching ``ast_call_edges``.
+    All file keys are project-relative paths, matching the ``edges`` table.
     """
 
     # package name -> files declaring that package (same-package + wildcard).

--- a/tree_sitter_analyzer/synapse_resolver/_java.py
+++ b/tree_sitter_analyzer/synapse_resolver/_java.py
@@ -1,0 +1,325 @@
+"""Java import parsing (L1) and call-target resolution (L2).
+
+This module is the Java half of the language-agnostic resolver. It
+mirrors the Python logic in ``__init__`` / ``_context`` but uses Java
+import / package / FQN semantics instead of Python dotted-module
+semantics.
+
+Two halves:
+
+* :func:`parse_java_imports` — turns one ``import`` / ``package``
+  statement (raw text) into structured :class:`ImportEntry` rows that
+  land in ``ast_imports`` (reusing the existing schema; no new columns).
+* :class:`JavaResolverContext` + :func:`resolve_java_callee` — the
+  10-stage resolution cascade. Crucially, JDK / platform calls are
+  tagged ``external`` (a *terminal* resolution) rather than ``unknown``,
+  which keeps them out of the backfill re-scan set.
+
+The cascade returns a plain ``(symbol_id, resolution, resolved_file)``
+tuple; the package ``__init__`` wraps it into a ``ResolvedCallee`` so
+this module stays free of import cycles.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+from ._imports import ImportEntry
+from ._java_constants import JAVA_LANG_TYPES, is_jdk_prefix
+
+# A ``package a.b.c;`` declaration. ``module_path`` here is reused to
+# carry the package name; ``local_name`` marks the row as a package row.
+_PKG_RE = re.compile(r"^\s*package\s+([\w.]+)\s*;?\s*$")
+# ``import [static] a.b.C[.member][.*] ;``
+_IMPORT_RE = re.compile(r"^\s*import\s+(static\s+)?([\w.]+)(\.\*)?\s*;?\s*$")
+
+# Sentinel module-path used to record the file's own package declaration
+# without adding a new ``ast_imports`` column. A package row is
+# ``local_name == _PACKAGE_MARKER`` and ``module_path == <package name>``.
+_PACKAGE_MARKER = "\x00package"
+
+
+def parse_java_imports(
+    text: str, file_path: str = "", line: int = 0
+) -> list[ImportEntry]:
+    """Parse one Java ``import`` / ``package`` statement into rows.
+
+    * ``package a.b.c;``      -> 1 package-marker row (module_path='a.b.c').
+    * ``import a.b.C;``        -> 1 row (local_name='C', module_path='a.b.C').
+    * ``import a.b.*;``        -> 1 star row (module_path='a.b', is_star=1).
+    * ``import static a.b.C.m;`` -> 1 row (local_name='m', module_path='a.b.C').
+    * ``import static a.b.C.*;`` -> 1 star row (module_path='a.b.C', is_star=1).
+
+    ``is_static`` has no dedicated column in v1; static imports are stored
+    as ordinary rows. Resolution treats an unqualified call whose simple
+    name matches an import binding as a static-member call, so a separate
+    flag is not required for the v1 cascade.
+    """
+    text = text.strip()
+    if not text:
+        return []
+
+    m_pkg = _PKG_RE.match(text)
+    if m_pkg:
+        return [
+            ImportEntry(
+                file_path=file_path,
+                language="java",
+                module_path=m_pkg.group(1),
+                local_name=_PACKAGE_MARKER,
+                is_relative=False,
+                is_star=False,
+                alias_of="",
+                line=line,
+            )
+        ]
+
+    m_imp = _IMPORT_RE.match(text)
+    if not m_imp:
+        return []
+
+    is_wildcard = bool(m_imp.group(3))
+    fqn = m_imp.group(2)
+
+    if is_wildcard:
+        # ``import a.b.*`` (or ``import static a.b.C.*``): the prefix is a
+        # package (or class for static) under which simple names resolve.
+        return [
+            ImportEntry(
+                file_path=file_path,
+                language="java",
+                module_path=fqn,
+                local_name="",
+                is_relative=False,
+                is_star=True,
+                alias_of="",
+                line=line,
+            )
+        ]
+
+    # Single-type / single-static-member import. The bound simple name is
+    # the last dotted segment; ``module_path`` keeps the full FQN.
+    simple = fqn.rsplit(".", 1)[-1] if "." in fqn else fqn
+    return [
+        ImportEntry(
+            file_path=file_path,
+            language="java",
+            module_path=fqn,
+            local_name=simple,
+            is_relative=False,
+            is_star=False,
+            alias_of="",
+            line=line,
+        )
+    ]
+
+
+@dataclass
+class JavaResolverContext:
+    """Per-index Java resolution maps (built once per pass).
+
+    All file keys are project-relative paths, matching ``ast_call_edges``.
+    """
+
+    # package name -> files declaring that package (same-package + wildcard).
+    package_to_files: dict[str, list[str]] = field(default_factory=dict)
+    # ``a.b.C`` -> file defining that top-level type.
+    fqn_to_file: dict[str, str] = field(default_factory=dict)
+    # file -> {simple name -> FQN} from type-import + static-import binds.
+    simple_to_fqn_by_file: dict[str, dict[str, str]] = field(default_factory=dict)
+    # file -> {static-member simple name -> owning class FQN}.
+    static_imports_by_file: dict[str, dict[str, str]] = field(default_factory=dict)
+    # file -> [package FQN, ...] from ``import a.b.*`` wildcard rows.
+    wildcard_pkgs_by_file: dict[str, list[str]] = field(default_factory=dict)
+    # file -> its declared package name.
+    file_package: dict[str, str] = field(default_factory=dict)
+    # file -> {class -> {method -> symbol_id}} (shared cross-language map).
+    file_class_methods: dict[str, dict[str, dict[str, int]]] = field(
+        default_factory=dict
+    )
+    # file -> [(name, kind, symbol_id), ...] (shared cross-language map).
+    file_symbols: dict[str, list[tuple[str, str, int]]] = field(default_factory=dict)
+    # simple name -> [(file, symbol_id), ...] project-wide (single-global).
+    global_name_table: dict[str, list[tuple[str, int]]] = field(default_factory=dict)
+
+
+def build_java_context(
+    imports_by_file: dict[str, list[ImportEntry]],
+    file_symbols: dict[str, list[tuple[str, str, int]]],
+    file_class_methods: dict[str, dict[str, dict[str, int]]],
+    global_name_table: dict[str, list[tuple[str, int]]],
+) -> JavaResolverContext:
+    """Assemble the Java resolution maps from already-loaded cache data.
+
+    ``imports_by_file`` must contain only the Java-language rows. Package
+    declarations are carried as marker rows (see :func:`parse_java_imports`).
+    """
+    ctx = JavaResolverContext(
+        file_class_methods=file_class_methods,
+        file_symbols=file_symbols,
+        global_name_table=global_name_table,
+    )
+
+    for caller_file, entries in imports_by_file.items():
+        simple_map: dict[str, str] = {}
+        static_map: dict[str, str] = {}
+        wildcards: list[str] = []
+        for entry in entries:
+            if entry.local_name == _PACKAGE_MARKER:
+                ctx.file_package[caller_file] = entry.module_path
+                continue
+            if entry.is_star:
+                wildcards.append(entry.module_path)
+                continue
+            if entry.local_name:
+                # A single-type import binds simple -> FQN. A single
+                # static-member import binds member -> owning class FQN.
+                # We register both maps; resolution consults the right one
+                # based on whether the call carries a receiver.
+                simple_map.setdefault(entry.local_name, entry.module_path)
+                owner = entry.module_path.rsplit(".", 1)[0]
+                static_map.setdefault(entry.local_name, owner)
+        if simple_map:
+            ctx.simple_to_fqn_by_file[caller_file] = simple_map
+        if static_map:
+            ctx.static_imports_by_file[caller_file] = static_map
+        if wildcards:
+            ctx.wildcard_pkgs_by_file[caller_file] = wildcards
+
+    # Build package_to_files + fqn_to_file from declared packages and the
+    # top-level class symbols in each file.
+    for file_path, pkg in ctx.file_package.items():
+        ctx.package_to_files.setdefault(pkg, []).append(file_path)
+    for file_path, symbols in file_symbols.items():
+        pkg = ctx.file_package.get(file_path, "")
+        for name, kind, _sym_id in symbols:
+            if kind != "class":
+                continue
+            fqn = f"{pkg}.{name}" if pkg else name
+            ctx.fqn_to_file.setdefault(fqn, file_path)
+    return ctx
+
+
+def _split_receiver(callee_full: str, callee_name: str) -> tuple[str, str]:
+    """Return ``(receiver, simple_name)`` from a Java call's full name."""
+    full = callee_full or callee_name
+    if "." in full:
+        receiver, simple = full.rsplit(".", 1)
+        return receiver, simple
+    return "", full or callee_name
+
+
+def _lookup_in_file(
+    ctx: JavaResolverContext, file_path: str, simple: str
+) -> int | None:
+    for name, kind, sym_id in ctx.file_symbols.get(file_path, []):
+        if name == simple and kind in ("function", "method", "class"):
+            return sym_id
+    return None
+
+
+def resolve_java_callee(
+    callee_name: str,
+    callee_full: str,
+    caller_file: str,
+    ctx: JavaResolverContext,
+) -> tuple[int | None, str, str]:
+    """Resolve one Java call edge per the 10-stage cascade.
+
+    Returns ``(symbol_id, resolution, resolved_file)`` where ``resolution``
+    is one of ``local`` / ``project`` / ``external`` / ``unknown``.
+    """
+    receiver, simple = _split_receiver(callee_full, callee_name)
+
+    # 1. local — no receiver (implicit ``this``) or ``this``/``super``.
+    if receiver in ("", "this", "super"):
+        sym_id = _lookup_in_file(ctx, caller_file, simple)
+        if sym_id is not None:
+            return sym_id, "local", caller_file
+        # 1b. this/super methods captured in the class-method map.
+        for _cls, methods in ctx.file_class_methods.get(caller_file, {}).items():
+            mid = methods.get(simple)
+            if mid is not None:
+                return mid, "local", caller_file
+
+    # 3. static-import — unqualified call whose name is a static member.
+    if not receiver:
+        owner_fqn = ctx.static_imports_by_file.get(caller_file, {}).get(simple)
+        if owner_fqn:
+            target = ctx.fqn_to_file.get(owner_fqn)
+            if target:
+                return _lookup_in_file(ctx, target, simple), "project", target
+            if is_jdk_prefix(owner_fqn):
+                return None, "external", ""
+
+    if receiver and receiver not in ("this", "super"):
+        # Two candidate type names from the receiver:
+        # * ``head`` = first segment — the type for a ``Type.field.m()`` or
+        #   ``Type.m()`` static call (``System`` in ``System.out.println``).
+        # * ``tail`` = last segment — the type for a fully-qualified class
+        #   reference (``C`` in ``a.b.C.m()``).
+        head = receiver.split(".", 1)[0]
+        tail = receiver.rsplit(".", 1)[-1] if "." in receiver else receiver
+
+        # 4. type-import — receiver head is an imported simple class name.
+        for type_name in (head, tail):
+            fqn = ctx.simple_to_fqn_by_file.get(caller_file, {}).get(type_name)
+            if not fqn:
+                continue
+            target = ctx.fqn_to_file.get(fqn)
+            if target:
+                return _lookup_in_file(ctx, target, simple), "project", target
+            if is_jdk_prefix(fqn):
+                return None, "external", ""
+
+        # 5. same-package — receiver type defined in the caller's package.
+        caller_pkg = ctx.file_package.get(caller_file, "")
+        if caller_pkg:
+            for type_name in (head, tail):
+                same_pkg_fqn = f"{caller_pkg}.{type_name}"
+                target = ctx.fqn_to_file.get(same_pkg_fqn)
+                if target:
+                    return _lookup_in_file(ctx, target, simple), "project", target
+
+        # 6. fqn-direct — receiver itself is a known project FQN.
+        target = ctx.fqn_to_file.get(receiver)
+        if target:
+            return _lookup_in_file(ctx, target, simple), "project", target
+
+        # 7. wildcard — receiver type under an ``import a.b.*`` package.
+        type_name = head
+        for pkg in ctx.wildcard_pkgs_by_file.get(caller_file, []):
+            cand_fqn = f"{pkg}.{type_name}"
+            target = ctx.fqn_to_file.get(cand_fqn)
+            if target:
+                return _lookup_in_file(ctx, target, simple), "project", target
+            if is_jdk_prefix(pkg + "."):
+                return None, "external", ""
+
+        # 8. jdk / external (terminal) — receiver is a JDK FQN or its head
+        # is a known ``java.lang`` simple type (``System`` in
+        # ``System.out.println``). external == "outside project, never
+        # re-scan", which is what breaks the unknown -> rescan loop.
+        if is_jdk_prefix(receiver + ".") or is_jdk_prefix(receiver):
+            return None, "external", ""
+        if head in JAVA_LANG_TYPES:
+            return None, "external", ""
+
+    # 9. single-global — exactly one project-wide definition of the name.
+    if not receiver:
+        cands = ctx.global_name_table.get(simple, [])
+        if len(cands) == 1:
+            target_file, sym_id = cands[0]
+            return sym_id, "project", target_file
+
+    # 10. unknown.
+    return None, "unknown", ""
+
+
+__all__ = [
+    "JavaResolverContext",
+    "build_java_context",
+    "parse_java_imports",
+    "resolve_java_callee",
+]

--- a/tree_sitter_analyzer/synapse_resolver/_java_constants.py
+++ b/tree_sitter_analyzer/synapse_resolver/_java_constants.py
@@ -1,0 +1,79 @@
+"""JDK / common-third-party package prefixes for the Java resolver.
+
+A call whose receiver type resolves to one of these package prefixes is
+tagged ``external`` (a *terminal* resolution — the target lives outside
+the indexed project and never needs re-resolution) rather than
+``unknown`` (which keeps the edge in the backfill re-scan set forever).
+
+Kept in a dedicated module so the literal sets stay out of the resolver
+logic and the file-size rule is honoured.
+"""
+
+from __future__ import annotations
+
+# Package prefixes that are part of the JDK / Jakarta EE platform. Any FQN
+# starting with one of these (``java.util.List``, ``javax.swing.*``,
+# ``jakarta.servlet.*``) is platform-provided, not project code.
+JDK_PACKAGE_PREFIXES: frozenset[str] = frozenset(
+    {
+        "java.",
+        "javax.",
+        "jakarta.",
+        "jdk.",
+        "sun.",
+        "com.sun.",
+        "org.w3c.dom.",
+        "org.xml.sax.",
+        "org.omg.",
+    }
+)
+
+# Simple type names that live in ``java.lang`` and are usable without an
+# explicit import. A receiver matching one of these resolves to
+# ``external`` even when no import statement names it.
+JAVA_LANG_TYPES: frozenset[str] = frozenset(
+    {
+        "Object",
+        "String",
+        "StringBuilder",
+        "StringBuffer",
+        "CharSequence",
+        "Integer",
+        "Long",
+        "Short",
+        "Byte",
+        "Double",
+        "Float",
+        "Boolean",
+        "Character",
+        "Number",
+        "Math",
+        "System",
+        "Thread",
+        "Runnable",
+        "Throwable",
+        "Exception",
+        "RuntimeException",
+        "Error",
+        "Class",
+        "Enum",
+        "Iterable",
+        "Comparable",
+        "Cloneable",
+        "Void",
+        "Process",
+        "ProcessBuilder",
+        "Runtime",
+        "Package",
+        "ClassLoader",
+        "StackTraceElement",
+    }
+)
+
+
+def is_jdk_prefix(fqn: str) -> bool:
+    """True when ``fqn`` begins with a known JDK / platform package prefix."""
+    return any(fqn.startswith(prefix) for prefix in JDK_PACKAGE_PREFIXES)
+
+
+__all__ = ["JAVA_LANG_TYPES", "JDK_PACKAGE_PREFIXES", "is_jdk_prefix"]

--- a/tree_sitter_analyzer/xref.py
+++ b/tree_sitter_analyzer/xref.py
@@ -199,22 +199,21 @@ class XRefEngine:
         symbol: str,
         file_path: str | None,
     ) -> list[dict[str, Any]]:
+        callers_sql = (
+            "SELECT caller_name, file_path AS caller_file, "
+            "json_extract(metadata, '$.caller_line') AS caller_line, "
+            "callee_name, "
+            "json_extract(metadata, '$.callee_full') AS callee_full "
+            "FROM edges "
+            "WHERE kind = 'calls' "
+            "AND (callee_name = ? "
+            "OR json_extract(metadata, '$.callee_full') LIKE ?) "
+            "ORDER BY caller_file, caller_line LIMIT 50"
+        )
         if file_path:
-            rows = conn.execute(
-                "SELECT caller_name, caller_file, caller_line, callee_name, callee_full "
-                "FROM ast_call_edges "
-                "WHERE callee_name = ? OR callee_full LIKE ? "
-                "ORDER BY caller_file, caller_line LIMIT 50",
-                (symbol, f"%{symbol}%"),
-            ).fetchall()
+            rows = conn.execute(callers_sql, (symbol, f"%{symbol}%")).fetchall()
         else:
-            rows = conn.execute(
-                "SELECT caller_name, caller_file, caller_line, callee_name, callee_full "
-                "FROM ast_call_edges "
-                "WHERE callee_name = ? OR callee_full LIKE ? "
-                "ORDER BY caller_file, caller_line LIMIT 50",
-                (symbol, f"%{symbol}%"),
-            ).fetchall()
+            rows = conn.execute(callers_sql, (symbol, f"%{symbol}%")).fetchall()
 
         seen: set[str] = set()
         results: list[dict[str, Any]] = []
@@ -239,19 +238,23 @@ class XRefEngine:
         symbol: str,
         file_path: str | None,
     ) -> list[dict[str, Any]]:
+        callee_cols = (
+            "SELECT callee_name, "
+            "json_extract(metadata, '$.callee_full') AS callee_full, "
+            "line AS callee_line, file_path, "
+            "json_extract(metadata, '$.language') AS language "
+            "FROM edges "
+        )
         if file_path:
             rows = conn.execute(
-                "SELECT callee_name, callee_full, callee_line, file_path, language "
-                "FROM ast_call_edges "
-                "WHERE caller_name = ? AND file_path = ? "
+                callee_cols
+                + "WHERE kind = 'calls' AND caller_name = ? AND file_path = ? "
                 "ORDER BY callee_line LIMIT 50",
                 (symbol, file_path),
             ).fetchall()
         else:
             rows = conn.execute(
-                "SELECT callee_name, callee_full, callee_line, file_path, language "
-                "FROM ast_call_edges "
-                "WHERE caller_name = ? "
+                callee_cols + "WHERE kind = 'calls' AND caller_name = ? "
                 "ORDER BY file_path, callee_line LIMIT 50",
                 (symbol,),
             ).fetchall()
@@ -311,9 +314,10 @@ class XRefEngine:
         file_path: str,
     ) -> list[dict[str, Any]]:
         rows = conn.execute(
-            "SELECT caller_file, callee_name, callee_full "
-            "FROM ast_call_edges "
-            "WHERE file_path = ? "
+            "SELECT file_path AS caller_file, callee_name, "
+            "json_extract(metadata, '$.callee_full') AS callee_full "
+            "FROM edges "
+            "WHERE kind = 'calls' AND file_path = ? "
             "GROUP BY caller_file LIMIT 50",
             (file_path,),
         ).fetchall()
@@ -358,9 +362,10 @@ class XRefEngine:
         file_path: str,
     ) -> list[dict[str, Any]]:
         rows = conn.execute(
-            "SELECT DISTINCT caller_name, caller_file, caller_line "
-            "FROM ast_call_edges "
-            "WHERE file_path = ? AND caller_file != ? "
+            "SELECT DISTINCT caller_name, file_path AS caller_file, "
+            "json_extract(metadata, '$.caller_line') AS caller_line "
+            "FROM edges "
+            "WHERE kind = 'calls' AND file_path = ? AND file_path != ? "
             "LIMIT 50",
             (file_path, file_path),
         ).fetchall()
@@ -372,9 +377,11 @@ class XRefEngine:
         file_path: str,
     ) -> list[dict[str, Any]]:
         rows = conn.execute(
-            "SELECT DISTINCT callee_name, callee_full, callee_line "
-            "FROM ast_call_edges "
-            "WHERE file_path = ? "
+            "SELECT DISTINCT callee_name, "
+            "json_extract(metadata, '$.callee_full') AS callee_full, "
+            "line AS callee_line "
+            "FROM edges "
+            "WHERE kind = 'calls' AND file_path = ? "
             "LIMIT 50",
             (file_path,),
         ).fetchall()


### PR DESCRIPTION
Unblocks TSA on large Java/COBOL — core data structure rebuilt toward agent-native resolved code graph.

## Breakthrough
ES/server 5304 Java files full-index: 33min stall (never completes) → core graph builds (symbols 435k + edges 1.1M + 78% resolved).

## What
- B3 multilang import resolution (Strategy registry): Java unknown 79%→47.5%, ast_imports 0→13960, JDK/external terminal (cuts backfill death-loop). Python byte-equivalent.
- P0: non-Python skip unresolved backfill, batch commit, dedup.
- B1 single edge graph (B1.1 index pushdown / B1.2+b reader migration / B1.3 drop ast_call_edges+unresolved_refs, schema v11): 3 edge copies → 1, DB 2.4→1.9GB.
- P2 content-inlining: nav/search return inline bodies + deterrent, big-Java token caps.

## Honest scope
17764 tests green, Python byte-equivalent, macOS verified. Core graph ~25min; full-index to 100% resolved ~1h (B4 follow-up). Agent turns 26→22 (closing to codegraph 8 needs explore primitives — separate battle).

Overlaps #262 (P0+call_path); #262 rebases after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)