### PR TITLE
perf: candidate cache for unresolved 2nd-pass resolution (B4)

### DIFF
--- a/tests/unit/test_unresolved_refs_cache_parity.py
+++ b/tests/unit/test_unresolved_refs_cache_parity.py
@@ -1,0 +1,195 @@
+"""B4 perf: per-run candidate cache for the second-pass resolver.
+
+``resolve_unresolved_refs`` used to issue one ``ast_symbol_rows`` SELECT per
+(name, kind) per ref. Hot names (``get`` / ``run`` / ``build`` …) recur across
+thousands of refs, so the same SELECT ran thousands of times. B4 adds a per-run
+``(name, kind)`` candidate cache so each distinct lookup hits SQLite once.
+
+These tests are the parity gate: the cached pass must produce **byte-for-byte
+identical** ``edges`` rows + identical aggregate stats as the uncached pass, and
+must collapse the duplicate SELECTs (proven by a query counter). If parity ever
+breaks, the cache changed resolution semantics — which is forbidden.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from tree_sitter_analyzer import _ast_cache_unresolved as unresolved
+from tree_sitter_analyzer.ast_cache import ASTCache
+
+
+def _write_repeated_name_project(root: Path) -> None:
+    """A project where one callee/base name recurs across many files.
+
+    The shared name ``helper`` (function) + shared base ``Base`` (class) are
+    referenced cross-file from many call sites, which is exactly the shape that
+    makes the uncached path re-run the same SELECT over and over.
+    """
+    pkg = root / "pkg"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    (pkg / "helper.py").write_text(
+        "def helper():\n    return 1\n",
+        encoding="utf-8",
+    )
+    (pkg / "base.py").write_text(
+        "class Base:\n    pass\n",
+        encoding="utf-8",
+    )
+    # Many caller files all importing + calling the same helper and extending
+    # the same base — each produces a pending CALLS ref for ``helper`` and a
+    # pending EXTENDS ref for ``Base``.
+    for i in range(12):
+        (pkg / f"caller_{i}.py").write_text(
+            "from .helper import helper\n"
+            "from .base import Base\n\n"
+            f"class Widget{i}(Base):\n"
+            "    def run(self):\n"
+            "        return helper()\n",
+            encoding="utf-8",
+        )
+
+
+def _snapshot_edges(conn: sqlite3.Connection) -> list[tuple[Any, ...]]:
+    """Full, deterministic snapshot of every edge row (resolution columns incl.)."""
+    rows = conn.execute(
+        "SELECT source_node_id, target_node_id, kind, line, provenance, "
+        "callee_name, callee_full, callee_resolution, callee_resolved_file, "
+        "callee_symbol_id, metadata "
+        "FROM edges ORDER BY source_node_id, target_node_id, kind, line, provenance"
+    ).fetchall()
+    return [tuple(r) for r in rows]
+
+
+class _CountingConn:
+    """Wrap a sqlite3 connection and count candidate-table SELECTs."""
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+        self.candidate_selects = 0
+
+    def execute(self, sql: str, *args: Any, **kwargs: Any) -> Any:
+        if "FROM ast_symbol_rows" in sql and "name = ? AND kind = ?" in sql:
+            self.candidate_selects += 1
+        return self._conn.execute(sql, *args, **kwargs)
+
+    def commit(self) -> None:
+        self._conn.commit()
+
+    def __getattr__(self, item: str) -> Any:
+        return getattr(self._conn, item)
+
+
+def _reset_resolution(conn: sqlite3.Connection) -> None:
+    """Reset CALLS resolution + drop second-pass EXTENDS edges so the pass re-runs."""
+    conn.execute(
+        "UPDATE edges SET callee_resolution = 'unknown', "
+        "callee_resolved_file = '', callee_symbol_id = NULL WHERE kind = 'calls'"
+    )
+    conn.execute("DELETE FROM edges WHERE provenance = 'unresolved_refs'")
+    conn.commit()
+
+
+def test_cached_candidate_lookup_matches_uncached_byte_for_byte(
+    tmp_path: Path,
+) -> None:
+    """Cached pass == uncached pass: identical edge snapshot + identical stats."""
+    # Two identical projects: a/ runs the legacy uncached path, b/ the cached
+    # path. Project-relative file_path is identical, so edge snapshots compare
+    # byte-for-byte.
+    _write_repeated_name_project(tmp_path / "a")
+    _write_repeated_name_project(tmp_path / "b")
+
+    cache_a = ASTCache(str(tmp_path / "a"))
+    cache_b = ASTCache(str(tmp_path / "b"))
+    try:
+        cache_a.index_project(workers=0)
+        cache_b.index_project(workers=0)
+
+        conn_a = cache_a.get_conn()
+        conn_b = cache_b.get_conn()
+        _reset_resolution(conn_a)
+        _reset_resolution(conn_b)
+
+        # Run A with the candidate cache forcibly disabled (legacy behaviour):
+        orig = unresolved._candidate_symbols
+
+        def uncached(c: Any, sf: str, rn: str, rk: str, _cache: Any = None) -> Any:
+            return orig(c, sf, rn, rk, None)
+
+        unresolved._candidate_symbols = uncached  # type: ignore[assignment]
+        try:
+            stats_a = unresolved.resolve_unresolved_refs(conn_a)
+        finally:
+            unresolved._candidate_symbols = orig  # type: ignore[assignment]
+
+        # Run B with the cache enabled (default code path):
+        stats_b = unresolved.resolve_unresolved_refs(conn_b)
+
+        assert stats_a == stats_b, (stats_a, stats_b)
+        assert stats_b is not None and stats_b["resolved"] > 0
+
+        # Byte-for-byte edge parity (rewrite b/ paths is unnecessary — both
+        # snapshots use project-relative file_path which is identical).
+        snap_a = _snapshot_edges(conn_a)
+        snap_b = _snapshot_edges(conn_b)
+        assert snap_a == snap_b
+    finally:
+        cache_a.close()
+        cache_b.close()
+
+
+def test_candidate_cache_collapses_duplicate_selects(tmp_path: Path) -> None:
+    """The cache must issue far fewer candidate SELECTs than the uncached path."""
+    _write_repeated_name_project(tmp_path)
+    cache = ASTCache(str(tmp_path))
+    try:
+        cache.index_project(workers=0)
+        conn = cache.get_conn()
+
+        _reset_resolution(conn)
+        uncached_conn = _CountingConn(conn)
+        orig = unresolved._candidate_symbols
+
+        def uncached(c: Any, sf: str, rn: str, rk: str, _cache: Any = None) -> Any:
+            return orig(c, sf, rn, rk, None)
+
+        unresolved._candidate_symbols = uncached  # type: ignore[assignment]
+        try:
+            unresolved.resolve_unresolved_refs(uncached_conn)
+        finally:
+            unresolved._candidate_symbols = orig  # type: ignore[assignment]
+
+        _reset_resolution(conn)
+        cached_conn = _CountingConn(conn)
+        unresolved.resolve_unresolved_refs(cached_conn)
+
+        # Many refs share the names ``helper`` / ``Base`` / ``run`` → the cache
+        # collapses thousands of repeats to one SELECT per distinct (name, kind).
+        assert cached_conn.candidate_selects < uncached_conn.candidate_selects
+        assert uncached_conn.candidate_selects > 0
+    finally:
+        cache.close()
+
+
+def test_candidate_cache_returns_empty_on_broken_connection() -> None:
+    """A failing candidate SELECT still yields [] and is cached as the abort."""
+    no_schema = sqlite3.connect(":memory:")
+    no_schema.row_factory = sqlite3.Row
+    try:
+        cache: dict[tuple[str, str], Any] = {}
+        assert (
+            unresolved._candidate_symbols(no_schema, "x.py", "Foo", "calls", cache)
+            == []
+        )
+        # The abort sentinel is cached so a repeat lookup does not re-hit SQLite.
+        assert ("Foo", "function") in cache or ("Foo", "calls") in cache
+        assert (
+            unresolved._candidate_symbols(no_schema, "x.py", "Foo", "calls", cache)
+            == []
+        )
+    finally:
+        no_schema.close()

--- a/tree_sitter_analyzer/_ast_cache_unresolved.py
+++ b/tree_sitter_analyzer/_ast_cache_unresolved.py
@@ -98,6 +98,11 @@ def resolve_unresolved_refs(conn: sqlite3.Connection) -> dict[str, int] | None:
 
     total = resolved = unchanged = errors = 0
     store = EdgeStore(conn, ensure_schema=False)
+    # Per-run candidate cache keyed by ``(name, kind)``. The candidate set for a
+    # given name/kind is file-independent (see ``_candidates_for_name_kind``), so
+    # the dominant cost — one ``ast_symbol_rows`` SELECT per (name, kind) per ref
+    # — collapses to one SELECT per distinct (name, kind) across the whole pass.
+    candidate_cache: dict[tuple[str, str], list[dict[str, Any]] | None] = {}
     for index_row in index_rows:
         rel_path = str(index_row["file_path"])
         try:
@@ -115,6 +120,7 @@ def resolve_unresolved_refs(conn: sqlite3.Connection) -> dict[str, int] | None:
                     str(ref["file_path"]),
                     str(ref["reference_name"]),
                     str(ref["reference_kind"]),
+                    candidate_cache,
                 )
                 chosen = _choose_candidate(conn, ref, candidates)
                 if chosen is None:
@@ -266,6 +272,7 @@ def _candidate_symbols(
     source_file: str,
     reference_name: str,
     reference_kind: str,
+    cache: dict[tuple[str, str], list[dict[str, Any]] | None] | None = None,
 ) -> list[dict[str, Any]]:
     names = _reference_names(conn, source_file, reference_name)
     kinds = (
@@ -273,23 +280,53 @@ def _candidate_symbols(
         if reference_kind in {EdgeKind.EXTENDS.value, EdgeKind.IMPLEMENTS.value}
         else ["function", "method", "class"]
     )
-    rows: list[Any] = []
+    candidates: list[dict[str, Any]] = []
+    for name in names:
+        for kind in kinds:
+            bucket = _candidates_for_name_kind(conn, name, kind, cache)
+            if bucket is None:
+                # ``ast_symbol_rows`` missing / broken connection — preserve the
+                # legacy whole-call abort so a single failed SELECT yields [].
+                return []
+            candidates.extend(bucket)
+    return candidates
+
+
+def _candidates_for_name_kind(
+    conn: sqlite3.Connection,
+    name: str,
+    kind: str,
+    cache: dict[tuple[str, str], list[dict[str, Any]] | None] | None,
+) -> list[dict[str, Any]] | None:
+    """Built candidate items for one ``(name, kind)``; cached when ``cache`` given.
+
+    The SQL result for a ``(name, kind)`` pair is independent of which file/ref
+    requested it (``_reference_names`` already expanded the file's import
+    aliases into the ``name`` set upstream), and the derived ``node_id`` /
+    ``line`` are pure functions of the row, so the built list is safe to reuse
+    verbatim across refs. On large Python trees the same hot names (``get``,
+    ``run``, ``build`` …) recur across thousands of refs, so caching collapses
+    those duplicate SELECTs. Returns ``None`` to signal the legacy
+    ``OperationalError`` abort path (caller short-circuits to ``[]``); a real
+    empty result is cached/returned as ``[]``.
+    """
+    key = (name, kind)
+    if cache is not None and key in cache:
+        return cache[key]
     try:
-        for name in names:
-            for kind in kinds:
-                rows.extend(
-                    conn.execute(
-                        """SELECT id, name, kind, file_path, language, line
-                           FROM ast_symbol_rows
-                           WHERE name = ? AND kind = ?
-                           ORDER BY file_path, line, name""",
-                        (name, kind),
-                    ).fetchall()
-                )
+        rows = conn.execute(
+            """SELECT id, name, kind, file_path, language, line
+               FROM ast_symbol_rows
+               WHERE name = ? AND kind = ?
+               ORDER BY file_path, line, name""",
+            (name, kind),
+        ).fetchall()
     except sqlite3.OperationalError as exc:
         logger.debug("candidate symbol lookup failed: %s", exc)
-        return []
-    candidates: list[dict[str, Any]] = []
+        if cache is not None:
+            cache[key] = None
+        return None
+    bucket: list[dict[str, Any]] = []
     for row in rows:
         item = _row_to_dict(
             row, ("id", "name", "kind", "file_path", "language", "line")
@@ -300,8 +337,10 @@ def _candidate_symbols(
             str(item["name"]),
             int(item["line"]),
         )
-        candidates.append(item)
-    return candidates
+        bucket.append(item)
+    if cache is not None:
+        cache[key] = bucket
+    return bucket
 
 
 def _reference_names(


### PR DESCRIPTION
Speeds full-index completion on large Java. The unresolved 2nd-pass did N candidate SQL queries per row (resolved ~107/s on ES/server). Adds a per-run candidate cache keyed by (name,kind) — same-name candidates reused instead of re-queried.

- Resolution result **byte-equivalent** (parity test test_unresolved_refs_cache_parity).
- Resolution/synapse/backfill tests: 37 passed in 1.3s.
- Local full-suite timing unreliable right now (this machine's fseventsd is IO-saturated from a night of large-repo full-index runs) — CI clean env validates.

Last of the big-Java unlock series (B3 import + P0 + B1 single-graph + P2 inlining + B4 backfill perf).

🤖 Generated with [Claude Code](https://claude.com/claude-code)