### PR TITLE
feat: Hyphae DSL — CSS-selector graph query (mycelium RFC-0003 port)

### DIFF
--- a/tests/unit/hyphae/test_evaluator.py
+++ b/tests/unit/hyphae/test_evaluator.py
@@ -1,0 +1,152 @@
+"""Tests for the Hyphae evaluator over a fake ASTCache."""
+
+from __future__ import annotations
+
+from tree_sitter_analyzer.hyphae.evaluator import Evaluator
+from tree_sitter_analyzer.hyphae.parser import parse
+
+
+class FakeCache:
+    """Minimal ASTCache stand-in driven by in-memory fixtures."""
+
+    def __init__(self, functions, callers=None, callees=None):
+        self._functions = functions
+        self._callers = callers or {}
+        self._callees = callees or {}
+
+    def get_functions(self):
+        return list(self._functions)
+
+    def search_symbols_cascade(self, query, limit=100):
+        return [f for f in self._functions if f.get("name") == query]
+
+    def query_callers(self, name, file=None):
+        return self._callers.get(name, [])
+
+    def query_callees(self, name, file=None):
+        return self._callees.get(name, [])
+
+
+def _names(rows):
+    return sorted(r["name"] for r in rows)
+
+
+def _fixture():
+    funcs = [
+        {
+            "name": "save",
+            "file": "svc/UserService.java",
+            "line": 10,
+            "language": "java",
+            "class": "UserService",
+        },
+        {
+            "name": "delete",
+            "file": "svc/UserService.java",
+            "line": 20,
+            "language": "java",
+            "class": "UserService",
+        },
+        {
+            "name": "helper",
+            "file": "util/Helpers.java",
+            "line": 5,
+            "language": "java",
+            "class": None,
+        },
+        {
+            "name": "find",
+            "file": "svc/UserRepo.java",
+            "line": 8,
+            "language": "java",
+            "class": "UserRepo",
+        },
+    ]
+    # save() and find() call UserRepo; delete() does not.
+    callers = {
+        "UserRepo": [
+            {
+                "caller_name": "save",
+                "caller_file": "svc/UserService.java",
+                "caller_line": 10,
+            },
+            {
+                "caller_name": "find",
+                "caller_file": "svc/UserRepo.java",
+                "caller_line": 8,
+            },
+        ],
+    }
+    callees = {
+        "save": [
+            {
+                "callee_name": "UserRepo",
+                "callee_file": "svc/UserRepo.java",
+                "callee_line": 1,
+            },
+        ],
+    }
+    return Evaluator(FakeCache(funcs, callers, callees))
+
+
+def test_name_lookup():
+    ev = _fixture()
+    assert _names(ev.eval(parse("#save"))) == ["save"]
+
+
+def test_kind_method_requires_class_field():
+    ev = _fixture()
+    # .method = functions with a class; helper (class=None) excluded.
+    got = _names(ev.eval(parse(".method")))
+    assert "helper" not in got
+    assert "save" in got and "find" in got
+
+
+def test_calls_reverse_driven():
+    ev = _fixture()
+    # .method:calls(#UserRepo) → methods that call UserRepo = save, find.
+    got = _names(ev.eval(parse(".method:calls(#UserRepo)")))
+    assert got == ["find", "save"]
+    assert "delete" not in got
+
+
+def test_attribute_file_filter():
+    ev = _fixture()
+    got = _names(ev.eval(parse(".method[file=UserService]")))
+    assert got == ["delete", "save"]
+
+
+def test_not_pseudo_excludes():
+    ev = _fixture()
+    # .method:calls(#UserRepo):not(#find) → save only.
+    got = _names(ev.eval(parse(".method:calls(#UserRepo):not(#find)")))
+    assert got == ["save"]
+
+
+def test_in_path_filter():
+    ev = _fixture()
+    got = _names(ev.eval(parse(".method:in(svc/)")))
+    assert "helper" not in got
+    assert "save" in got
+
+
+def test_child_combinator_via_class_field():
+    ev = _fixture()
+    # #UserService > .method → methods whose class is UserService.
+    # (#UserService resolves via search; add it as a symbol.)
+    ev._cache._functions.append(
+        {
+            "name": "UserService",
+            "file": "svc/UserService.java",
+            "line": 1,
+            "class": None,
+        }
+    )
+    got = _names(ev.eval(parse("#UserService > .method")))
+    assert got == ["delete", "save"]
+
+
+def test_selector_list_union():
+    ev = _fixture()
+    got = _names(ev.eval(parse("#save, #delete")))
+    assert got == ["delete", "save"]

--- a/tests/unit/hyphae/test_lexer_parser.py
+++ b/tests/unit/hyphae/test_lexer_parser.py
@@ -1,0 +1,113 @@
+"""Tests for the Hyphae lexer and parser."""
+
+from __future__ import annotations
+
+import pytest
+
+from tree_sitter_analyzer.hyphae.ast import (
+    AttributeSelector,
+    Combined,
+    SelectorList,
+    SimpleSelector,
+)
+from tree_sitter_analyzer.hyphae.lexer import tokenize
+from tree_sitter_analyzer.hyphae.parser import HyphaeSyntaxError, parse
+
+
+def _types(text: str) -> list[str]:
+    return [t.type for t in tokenize(text)]
+
+
+def test_lexer_prefix_symbols_absorb_identifier() -> None:
+    toks = tokenize("#login")
+    assert toks[0].type == "HASH" and toks[0].value == "login"
+    assert tokenize(".function")[0] == type(toks[0])("DOT", "function")
+    assert tokenize(":calls")[0].type == "COLON"
+    assert tokenize(":calls")[0].value == "calls"
+
+
+def test_lexer_path_ident_keeps_dots_and_slashes() -> None:
+    toks = tokenize("[file=src/lib.rs]")
+    # The path value is one IDENT, not split on '.' or '/'.
+    idents = [t.value for t in toks if t.type == "IDENT"]
+    assert "src/lib.rs" in idents
+
+
+def test_lexer_hash_name_allows_hyphen() -> None:
+    assert tokenize("#my-symbol")[0].value == "my-symbol"
+
+
+def test_lexer_structural_tokens() -> None:
+    assert _types("#a > #b") == ["HASH", "WS", "GT", "WS", "HASH", "EOF"]
+    assert "TILDE" in _types("#a ~ #b")
+    assert "NUMBER" in _types(":nth-child(2)")
+
+
+def test_parse_simple_name() -> None:
+    sl = parse("#IndexShard")
+    assert sl == SelectorList((SimpleSelector(base=("name", "IndexShard")),))
+
+
+def test_parse_kind_and_universal() -> None:
+    assert parse(".method").selectors[0].base == ("kind", "method")
+    assert parse("*").selectors[0].base == ("universal", "")
+
+
+def test_parse_pseudo_calls_with_nested_selector() -> None:
+    sl = parse(".method:calls(#IndexShard)")
+    simple = sl.selectors[0]
+    assert simple.base == ("kind", "method")
+    assert len(simple.pseudo_classes) == 1
+    pc = simple.pseudo_classes[0]
+    assert pc.name == "calls"
+    assert isinstance(pc.arg, SelectorList)
+    assert pc.arg.selectors[0].base == ("name", "IndexShard")
+
+
+def test_parse_attribute_filter() -> None:
+    sl = parse(".function[file=src/lib.rs]")
+    attrs = sl.selectors[0].attributes
+    assert attrs == (AttributeSelector(name="file", value="src/lib.rs"),)
+
+
+def test_parse_nth_child_number_arg() -> None:
+    pc = parse(".method:nth-child(2)").selectors[0].pseudo_classes[0]
+    assert pc.name == "nth-child" and pc.arg == 2
+
+
+def test_parse_in_path_arg() -> None:
+    pc = parse(".function:in(tests/)").selectors[0].pseudo_classes[0]
+    assert pc.name == "in" and pc.arg == "tests/"
+
+
+def test_parse_child_combinator() -> None:
+    sl = parse("#Foo > .method")
+    sel = sl.selectors[0]
+    assert isinstance(sel, Combined)
+    assert sel.combinator == ">"
+    assert sel.left.base == ("name", "Foo")
+    assert sel.right.base == ("kind", "method")
+
+
+def test_parse_descendant_combinator() -> None:
+    sel = parse(".struct .method").selectors[0]
+    assert isinstance(sel, Combined)
+    assert sel.combinator == " "
+
+
+def test_parse_selector_list_union() -> None:
+    sl = parse("#A, #B")
+    assert len(sl.selectors) == 2
+    assert sl.selectors[0].base == ("name", "A")
+    assert sl.selectors[1].base == ("name", "B")
+
+
+def test_parse_not_pseudo() -> None:
+    pc = parse(".function:not(#logout)").selectors[0].pseudo_classes[0]
+    assert pc.name == "not"
+    assert isinstance(pc.arg, SelectorList)
+
+
+def test_parse_error_on_garbage() -> None:
+    with pytest.raises(HyphaeSyntaxError):
+        parse("> #orphan")

--- a/tests/unit/hyphae/test_select_tool.py
+++ b/tests/unit/hyphae/test_select_tool.py
@@ -1,0 +1,80 @@
+"""Tests for the HyphaeSelectTool MCP wrapper."""
+
+from __future__ import annotations
+
+import pytest
+
+from tree_sitter_analyzer.mcp.tools.hyphae_select_tool import HyphaeSelectTool
+
+
+class _FakeCache:
+    def get_functions(self):
+        return [
+            {
+                "name": "save",
+                "file": "svc/UserService.java",
+                "line": 10,
+                "language": "java",
+                "class": "UserService",
+            },
+            {
+                "name": "find",
+                "file": "svc/UserRepo.java",
+                "line": 8,
+                "language": "java",
+                "class": "UserRepo",
+            },
+        ]
+
+    def search_symbols_cascade(self, query, limit=100):
+        return [f for f in self.get_functions() if f["name"] == query]
+
+    def query_callers(self, name, file=None):
+        if name == "UserRepo":
+            return [
+                {
+                    "caller_name": "save",
+                    "caller_file": "svc/UserService.java",
+                    "caller_line": 10,
+                }
+            ]
+        return []
+
+    def query_callees(self, name, file=None):
+        return []
+
+
+def _tool():
+    t = HyphaeSelectTool("/tmp")
+    t._cache = _FakeCache()
+    return t
+
+
+def test_tool_definition_names_hyphae():
+    defn = HyphaeSelectTool("/tmp").get_tool_definition()
+    assert defn["name"] == "hyphae_select"
+    assert "selector" in defn["inputSchema"]["properties"]
+    assert defn["inputSchema"]["required"] == ["selector"]
+
+
+def test_selector_required():
+    with pytest.raises(ValueError):
+        _tool().validate_arguments({"selector": "  "})
+
+
+@pytest.mark.asyncio
+async def test_execute_calls_selector_json():
+    res = await _tool().execute(
+        {"selector": ".method:calls(#UserRepo)", "output_format": "json"}
+    )
+    assert res["success"] is True
+    assert res["count"] == 1
+    assert res["symbols"][0]["name"] == "save"
+
+
+@pytest.mark.asyncio
+async def test_execute_syntax_error_is_graceful():
+    res = await _tool().execute({"selector": "> broken", "output_format": "json"})
+    assert res["success"] is False
+    assert "syntax error" in res["error"].lower()
+    assert res["symbols"] == []

--- a/tests/unit/test_agent_contracts.py
+++ b/tests/unit/test_agent_contracts.py
@@ -758,6 +758,7 @@ def test_facade_delegation_routes_each_action_to_expected_inner() -> None:
         ("search", "grep"): "FindAndGrepTool",
         ("search", "batch"): "BatchSearchTool",
         ("search", "chain"): "CodeGraphQueryTool",
+        ("search", "select"): "HyphaeSelectTool",
         ("search", "content"): "<bespoke>",
         ("nav", "navigate"): "CodeGraphNavigateTool",
         ("nav", "call_path"): "CodeGraphCallPathTool",

--- a/tree_sitter_analyzer/hyphae/__init__.py
+++ b/tree_sitter_analyzer/hyphae/__init__.py
@@ -1,0 +1,37 @@
+"""Hyphae — a CSS-selector-inspired query DSL for the symbol graph.
+
+Ported from the mycelium project (RFC-0003). Lets agents express graph queries
+declaratively — ``.method:calls(#IndexShard)`` instead of chaining several
+tool calls. The pipeline is the classic three stages:
+
+    text → lexer.tokenize → parser.parse → evaluator.Evaluator.eval → [symbols]
+
+Public entry point: :func:`select`, which wires all three stages against an
+``ASTCache`` and returns matching symbols.
+"""
+
+from __future__ import annotations
+
+from .ast import (
+    AttributeSelector,
+    Combined,
+    PseudoClass,
+    SelectorList,
+    SimpleSelector,
+)
+from .evaluator import Evaluator
+from .lexer import Token, tokenize
+from .parser import HyphaeSyntaxError, parse
+
+__all__ = [
+    "AttributeSelector",
+    "Combined",
+    "Evaluator",
+    "HyphaeSyntaxError",
+    "PseudoClass",
+    "SelectorList",
+    "SimpleSelector",
+    "Token",
+    "parse",
+    "tokenize",
+]

--- a/tree_sitter_analyzer/hyphae/ast.py
+++ b/tree_sitter_analyzer/hyphae/ast.py
@@ -1,0 +1,63 @@
+"""Hyphae AST node types (immutable).
+
+Mirrors mycelium-hyphae/src/ast.rs. All nodes are frozen dataclasses so a
+parsed selector is a hashable, side-effect-free value.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class AttributeSelector:
+    """An ``[name=value]`` filter, e.g. ``[file=src/lib.rs]``."""
+
+    name: str
+    value: str
+
+
+@dataclass(frozen=True)
+class PseudoClass:
+    """A pseudo-class filter such as ``:calls(#x)``, ``:not(.struct)``, ``:in(src/)``.
+
+    ``arg`` is one of: a nested :class:`SelectorList` (for ``:calls`` / ``:has`` /
+    ``:not`` / ``:callers`` / ``:imports`` / ``:implements``), an ``int`` (for
+    ``:nth-child``), a ``str`` path (for ``:in``), or ``None`` (for argument-less
+    pseudo-classes like ``:first-child``).
+    """
+
+    name: str
+    arg: SelectorList | int | str | None = None
+
+
+@dataclass(frozen=True)
+class SimpleSelector:
+    """A single selector unit: a base plus attribute and pseudo-class filters.
+
+    ``base`` is a ``(kind, value)`` pair where kind is one of:
+    ``"name"`` (``#Foo``), ``"kind"`` (``.method``), ``"universal"`` (``*``).
+    """
+
+    base: tuple[str, str]
+    attributes: tuple[AttributeSelector, ...] = ()
+    pseudo_classes: tuple[PseudoClass, ...] = ()
+
+
+@dataclass(frozen=True)
+class Combined:
+    """Two selectors joined by a combinator (``>`` child, ``~`` sibling, descendant)."""
+
+    left: Selector
+    combinator: str  # ">" | "~" | " "
+    right: Selector
+
+
+Selector = SimpleSelector | Combined
+
+
+@dataclass(frozen=True)
+class SelectorList:
+    """A comma-separated list of selectors; results are the union."""
+
+    selectors: tuple[Selector, ...] = field(default_factory=tuple)

--- a/tree_sitter_analyzer/hyphae/evaluator.py
+++ b/tree_sitter_analyzer/hyphae/evaluator.py
@@ -1,0 +1,183 @@
+"""Hyphae evaluator — turns a parsed selector into symbol-graph queries.
+
+Mirrors mycelium-hyphae/src/evaluator.rs semantics over a TSA ``ASTCache``:
+
+- ``#name``  → exact symbol lookup (search_symbols_cascade)
+- ``.kind``  → all functions/methods of that kind (get_functions)
+- ``*``      → all functions/methods
+- ``:calls(#X)``   → candidates that call X  (reverse-driven via query_callers)
+- ``:callees(#X)`` → candidates that X calls (reverse-driven via query_callees)
+- ``:not(sel)``    → candidates minus eval(sel)
+- ``:in(path)``    → candidates whose file is under path
+- ``[file=p]`` / ``[language=l]`` / ``[class=C]`` → attribute filters
+- ``A > B`` / ``A B`` (descendant) → B whose containing class is A (via ``class`` field)
+
+The ``:calls`` filter is reverse-driven (one ``query_callers`` per target rather
+than one ``query_callees`` per candidate) so ``.method:calls(#Hub)`` stays a
+couple of queries even on a 16k-symbol index.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .ast import Combined, PseudoClass, SelectorList, SimpleSelector
+
+# .kind alias → TSA function/method discrimination. TSA stores Java methods as
+# functions with a populated ``class`` field, so we discriminate on that.
+_FUNCTIONISH = frozenset({"function", "method", "func", "fn"})
+
+
+def _key(sym: dict[str, Any]) -> tuple[Any, Any, Any]:
+    return (sym.get("name"), sym.get("file"), sym.get("line"))
+
+
+class Evaluator:
+    """Evaluate a parsed Hyphae selector against an ``ASTCache``."""
+
+    def __init__(self, cache: Any, max_results: int = 500) -> None:
+        self._cache = cache
+        self._max = max_results
+
+    # -- public --------------------------------------------------------------
+    def eval(self, selector_list: SelectorList) -> list[dict[str, Any]]:
+        seen: set[tuple[Any, Any, Any]] = set()
+        out: list[dict[str, Any]] = []
+        for sel in selector_list.selectors:
+            for sym in self._eval_selector(sel):
+                k = _key(sym)
+                if k in seen:
+                    continue
+                seen.add(k)
+                out.append(sym)
+                if len(out) >= self._max:
+                    return out
+        return out
+
+    # -- dispatch ------------------------------------------------------------
+    def _eval_selector(self, sel: Any) -> list[dict[str, Any]]:
+        if isinstance(sel, Combined):
+            return self._eval_combined(sel)
+        return self._eval_simple(sel)
+
+    def _eval_simple(self, simple: SimpleSelector) -> list[dict[str, Any]]:
+        cands = self._eval_base(simple.base)
+        for attr in simple.attributes:
+            cands = self._apply_attribute(cands, attr.name, attr.value)
+        for pc in simple.pseudo_classes:
+            cands = self._apply_pseudo(cands, pc)
+        return cands
+
+    # -- base ----------------------------------------------------------------
+    def _eval_base(self, base: tuple[str, str]) -> list[dict[str, Any]]:
+        kind, val = base
+        if kind == "universal":
+            return self._all_functions()
+        if kind == "name":
+            hits = self._cache.search_symbols_cascade(val, limit=self._max) or []
+            return [h for h in hits if h.get("name") == val]
+        if kind == "kind":
+            funcs = self._all_functions()
+            if val in _FUNCTIONISH:
+                if val == "method":
+                    return [f for f in funcs if f.get("class")]
+                if val == "function":
+                    return funcs
+            # Fall back to matching the symbol's own kind field when present.
+            return [f for f in funcs if (f.get("kind") or "function") == val]
+        return []
+
+    def _all_functions(self) -> list[dict[str, Any]]:
+        return list(self._cache.get_functions() or [])
+
+    # -- attribute filters ---------------------------------------------------
+    def _apply_attribute(
+        self, cands: list[dict[str, Any]], name: str, value: str
+    ) -> list[dict[str, Any]]:
+        if name == "file":
+            return [c for c in cands if value in (c.get("file") or "")]
+        if name == "language":
+            return [c for c in cands if (c.get("language") or "") == value]
+        if name == "class":
+            return [c for c in cands if (c.get("class") or "") == value]
+        if name == "kind":
+            return [c for c in cands if (c.get("kind") or "function") == value]
+        return []
+
+    # -- pseudo-classes ------------------------------------------------------
+    def _apply_pseudo(
+        self, cands: list[dict[str, Any]], pc: PseudoClass
+    ) -> list[dict[str, Any]]:
+        name = pc.name
+        if name == "calls":
+            return self._filter_calls(cands, pc.arg, direction="calls")
+        if name in ("callees", "called-by"):
+            return self._filter_calls(cands, pc.arg, direction="callees")
+        if name == "not":
+            if isinstance(pc.arg, SelectorList):
+                excluded = {_key(s) for s in self.eval(pc.arg)}
+                return [c for c in cands if _key(c) not in excluded]
+            return cands
+        if name == "in":
+            path = pc.arg if isinstance(pc.arg, str) else ""
+            return [c for c in cands if (c.get("file") or "").startswith(path)]
+        # Unknown pseudo-class: be conservative and keep candidates.
+        return cands
+
+    def _filter_calls(
+        self, cands: list[dict[str, Any]], arg: Any, direction: str
+    ) -> list[dict[str, Any]]:
+        """Keep candidates that call (or are called by) the target selector.
+
+        ``direction='calls'``  → candidate calls target  (target's callers)
+        ``direction='callees'``→ target calls candidate  (target's callees)
+
+        Target names are taken directly from ``#name`` bases so the target need
+        not itself be an indexed symbol (e.g. an external class), matching the
+        edge-name semantics of the underlying call graph.
+        """
+        if not isinstance(arg, SelectorList):
+            return []
+        names = self._target_names(arg)
+        related_names: set[Any] = set()
+        for tname in names:
+            if direction == "calls":
+                rows = self._cache.query_callers(tname, None) or []
+                related_names.update(
+                    r.get("caller_name") for r in rows if r.get("caller_name")
+                )
+            else:
+                rows = self._cache.query_callees(tname, None) or []
+                related_names.update(
+                    r.get("callee_name") for r in rows if r.get("callee_name")
+                )
+        return [c for c in cands if c.get("name") in related_names]
+
+    def _target_names(self, arg: SelectorList) -> set[Any]:
+        """Extract target symbol names from a pseudo-class argument selector.
+
+        ``#name`` bases contribute their literal name directly; richer selectors
+        are evaluated and contribute the names of their matches.
+        """
+        names: set[Any] = set()
+        for sel in arg.selectors:
+            if isinstance(sel, SimpleSelector) and sel.base[0] == "name":
+                names.add(sel.base[1])
+            else:
+                names.update(s.get("name") for s in self._eval_selector(sel))
+        return {n for n in names if n}
+
+    # -- combinators ---------------------------------------------------------
+    def _eval_combined(self, combined: Combined) -> list[dict[str, Any]]:
+        left = self._eval_selector(combined.left)
+        right = self._eval_selector(combined.right)
+        left_names = {sym.get("name") for sym in left}
+        # Child / descendant: keep right symbols whose containing class is a
+        # left symbol. TSA exposes containment via the ``class`` field.
+        if combined.combinator in (">", " "):
+            return [r for r in right if (r.get("class") or None) in left_names]
+        # Sibling (~): same containing class as a left symbol.
+        if combined.combinator == "~":
+            left_classes = {sym.get("class") for sym in left if sym.get("class")}
+            return [r for r in right if (r.get("class") or None) in left_classes]
+        return right

--- a/tree_sitter_analyzer/hyphae/lexer.py
+++ b/tree_sitter_analyzer/hyphae/lexer.py
@@ -1,0 +1,91 @@
+"""Hyphae lexer.
+
+Mirrors mycelium-hyphae/src/lexer.rs. The prefix symbols ``#``/``.``/``:`` each
+absorb the following identifier as their value (``#login`` → ``HASH("login")``),
+which removes the ambiguity between ``.kind`` and a path like ``src/lib.rs``:
+a leading ``.`` starts a DOT token, while ``.`` inside an IDENT (``src/lib.rs``)
+is just part of the path.
+"""
+
+from __future__ import annotations
+
+import string
+from dataclasses import dataclass
+
+# Characters allowed in a #name / .kind / :pseudo identifier.
+_NAME_CHARS = frozenset(string.ascii_letters + string.digits + "_-")
+# Characters allowed in a bare IDENT (attribute value / pseudo path arg): adds
+# path separators ``/`` and ``.``.
+_IDENT_CHARS = _NAME_CHARS | frozenset("./")
+
+_SINGLE = {
+    "*": "STAR",
+    ">": "GT",
+    "~": "TILDE",
+    ",": "COMMA",
+    "(": "LPAREN",
+    ")": "RPAREN",
+    "[": "LBRACKET",
+    "]": "RBRACKET",
+    "=": "EQ",
+}
+
+
+@dataclass(frozen=True)
+class Token:
+    """A lexical token. ``value`` carries the identifier for HASH/DOT/COLON/IDENT
+    and the integer text for NUMBER; it is empty for structural tokens."""
+
+    type: str
+    value: str = ""
+
+
+def _read_while(text: str, start: int, allowed: frozenset[str]) -> tuple[str, int]:
+    i = start
+    n = len(text)
+    while i < n and text[i] in allowed:
+        i += 1
+    return text[start:i], i
+
+
+def tokenize(text: str) -> list[Token]:
+    """Tokenize a Hyphae selector string.
+
+    Raises:
+        ValueError: on an unexpected character.
+    """
+    tokens: list[Token] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch.isspace():
+            j = i
+            while j < n and text[j].isspace():
+                j += 1
+            # Collapse runs of whitespace into a single WS (descendant combinator).
+            tokens.append(Token("WS"))
+            i = j
+        elif ch == "#":
+            name, i = _read_while(text, i + 1, _NAME_CHARS)
+            tokens.append(Token("HASH", name))
+        elif ch == ":":
+            name, i = _read_while(text, i + 1, _NAME_CHARS)
+            tokens.append(Token("COLON", name))
+        elif ch == ".":
+            # A leading dot is a .kind selector; absorb the kind name.
+            name, i = _read_while(text, i + 1, _NAME_CHARS)
+            tokens.append(Token("DOT", name))
+        elif ch in _SINGLE:
+            tokens.append(Token(_SINGLE[ch]))
+            i += 1
+        elif ch.isdigit():
+            num, i = _read_while(text, i, frozenset("0123456789"))
+            tokens.append(Token("NUMBER", num))
+        elif ch in _IDENT_CHARS:
+            ident, i = _read_while(text, i, _IDENT_CHARS)
+            tokens.append(Token("IDENT", ident))
+        else:
+            raise ValueError(f"Hyphae lexer: unexpected character {ch!r} at {i}")
+    tokens.append(Token("EOF"))
+    return tokens

--- a/tree_sitter_analyzer/hyphae/parser.py
+++ b/tree_sitter_analyzer/hyphae/parser.py
@@ -1,0 +1,197 @@
+"""Hyphae recursive-descent parser.
+
+Grammar (mirrors mycelium RFC-0003, MVP subset)::
+
+    SelectorList := Selector (',' Selector)*
+    Selector     := SimpleSelector ((WS | '>' | '~') SimpleSelector)*
+    SimpleSelector := Base Attribute* PseudoClass*
+    Base         := HASH | DOT | STAR
+    Attribute    := '[' IDENT '=' value ']'
+    PseudoClass  := COLON ('(' PseudoArg ')')?
+    PseudoArg    := NUMBER | IDENT(path) | SelectorList
+"""
+
+from __future__ import annotations
+
+from .ast import (
+    AttributeSelector,
+    Combined,
+    PseudoClass,
+    Selector,
+    SelectorList,
+    SimpleSelector,
+)
+from .lexer import Token, tokenize
+
+_BASE_TOKENS = frozenset({"HASH", "DOT", "STAR"})
+_COMBINATORS = {"GT": ">", "TILDE": "~"}
+
+
+class HyphaeSyntaxError(ValueError):
+    """Raised when a Hyphae selector string is malformed."""
+
+
+class _Parser:
+    def __init__(self, tokens: list[Token]) -> None:
+        self._tokens = tokens
+        self._pos = 0
+
+    def _peek(self) -> Token:
+        return self._tokens[self._pos]
+
+    def _advance(self) -> Token:
+        tok = self._tokens[self._pos]
+        self._pos += 1
+        return tok
+
+    def _expect(self, type_: str) -> Token:
+        tok = self._peek()
+        if tok.type != type_:
+            raise HyphaeSyntaxError(f"expected {type_}, got {tok.type}")
+        return self._advance()
+
+    def _skip_ws(self) -> None:
+        while self._peek().type == "WS":
+            self._advance()
+
+    # -- entry ---------------------------------------------------------------
+    def parse(self) -> SelectorList:
+        selectors: list[Selector] = []
+        self._skip_ws()
+        selectors.append(self._parse_selector())
+        while True:
+            self._skip_ws()
+            if self._peek().type == "COMMA":
+                self._advance()
+                self._skip_ws()
+                selectors.append(self._parse_selector())
+            else:
+                break
+        if self._peek().type not in {"EOF", "RPAREN"}:
+            raise HyphaeSyntaxError(f"unexpected trailing {self._peek().type}")
+        return SelectorList(tuple(selectors))
+
+    # -- selector with combinators ------------------------------------------
+    def _parse_selector(self) -> Selector:
+        left: Selector = self._parse_simple()
+        while True:
+            combinator = self._next_combinator()
+            if combinator is None:
+                break
+            right = self._parse_simple()
+            left = Combined(left=left, combinator=combinator, right=right)
+        return left
+
+    def _next_combinator(self) -> str | None:
+        """Return the combinator joining the current and next simple selector.
+
+        ``>`` / ``~`` are explicit; a WS followed by another base is a descendant
+        combinator; a WS followed by ``,``/``)``/EOF is decorative and consumed.
+        """
+        tok = self._peek()
+        if tok.type in _COMBINATORS:
+            self._advance()
+            self._skip_ws()
+            return _COMBINATORS[tok.type]
+        if tok.type == "WS":
+            # Look past the whitespace.
+            save = self._pos
+            self._skip_ws()
+            nxt = self._peek()
+            if nxt.type in _BASE_TOKENS:
+                return " "  # descendant
+            if nxt.type in _COMBINATORS:
+                comb = _COMBINATORS[nxt.type]
+                self._advance()
+                self._skip_ws()
+                return comb
+            # Decorative whitespace (before comma / close / EOF).
+            self._pos = save
+            return None
+        return None
+
+    # -- simple selector -----------------------------------------------------
+    def _parse_simple(self) -> SimpleSelector:
+        tok = self._peek()
+        if tok.type == "HASH":
+            self._advance()
+            base = ("name", tok.value)
+        elif tok.type == "DOT":
+            self._advance()
+            base = ("kind", tok.value)
+        elif tok.type == "STAR":
+            self._advance()
+            base = ("universal", "")
+        else:
+            raise HyphaeSyntaxError(f"expected a base selector, got {tok.type}")
+
+        attributes: list[AttributeSelector] = []
+        pseudos: list[PseudoClass] = []
+        while True:
+            t = self._peek().type
+            if t == "LBRACKET":
+                attributes.append(self._parse_attribute())
+            elif t == "COLON":
+                pseudos.append(self._parse_pseudo())
+            else:
+                break
+        return SimpleSelector(
+            base=base,
+            attributes=tuple(attributes),
+            pseudo_classes=tuple(pseudos),
+        )
+
+    def _parse_attribute(self) -> AttributeSelector:
+        self._expect("LBRACKET")
+        name_tok = self._peek()
+        if name_tok.type != "IDENT":
+            raise HyphaeSyntaxError(
+                f"attribute name must be IDENT, got {name_tok.type}"
+            )
+        self._advance()
+        self._expect("EQ")
+        value = self._read_value_text()
+        self._expect("RBRACKET")
+        return AttributeSelector(name=name_tok.value, value=value)
+
+    def _read_value_text(self) -> str:
+        """Read an attribute value: IDENT path, or a #name / .kind literal."""
+        tok = self._peek()
+        if tok.type == "IDENT":
+            self._advance()
+            return tok.value
+        if tok.type in {"HASH", "DOT"}:
+            self._advance()
+            return tok.value
+        if tok.type == "NUMBER":
+            self._advance()
+            return tok.value
+        raise HyphaeSyntaxError(f"attribute value expected, got {tok.type}")
+
+    def _parse_pseudo(self) -> PseudoClass:
+        colon = self._expect("COLON")
+        name = colon.value
+        if self._peek().type != "LPAREN":
+            return PseudoClass(name=name, arg=None)
+        self._advance()  # (
+        self._skip_ws()
+        arg = self._parse_pseudo_arg()
+        self._skip_ws()
+        self._expect("RPAREN")
+        return PseudoClass(name=name, arg=arg)
+
+    def _parse_pseudo_arg(self) -> SelectorList | int | str:
+        tok = self._peek()
+        if tok.type == "NUMBER":
+            self._advance()
+            return int(tok.value)
+        if tok.type == "IDENT":
+            self._advance()
+            return tok.value  # path, e.g. src/lib.rs
+        # Otherwise a nested selector list (#x, .kind, *).
+        return self.parse()
+
+
+def parse(text: str) -> SelectorList:
+    """Parse a Hyphae selector string into a :class:`SelectorList`."""
+    return _Parser(tokenize(text)).parse()

--- a/tree_sitter_analyzer/mcp/tools/hyphae_select_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/hyphae_select_tool.py
@@ -1,0 +1,138 @@
+"""MCP tool: Hyphae DSL selector execution against the symbol graph.
+
+Exposes the Hyphae query DSL (RFC-0003, ported from mycelium) so an agent can
+express a graph query as one CSS-selector-style string instead of chaining
+several navigate/callers/search calls — e.g.
+``.function:calls(#IndexShard):in(server/)``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .base_tool import BaseMCPTool
+
+
+class HyphaeSelectTool(BaseMCPTool):
+    """Execute a Hyphae selector and return matching symbols."""
+
+    def __init__(self, project_root: str | None = None) -> None:
+        self._cache: Any = None
+        super().__init__(project_root)
+
+    def _on_project_root_changed(self, project_root: str | None) -> None:
+        self._cache = None
+
+    def _get_cache(self) -> Any:
+        if self._cache is None:
+            if not self.project_root:
+                raise ValueError("Project root not set. Call set_project_path first.")
+            from ...ast_cache import ASTCache
+
+            self._cache = ASTCache(self.project_root)
+        return self._cache
+
+    def get_tool_definition(self) -> dict[str, Any]:
+        return {
+            "name": "hyphae_select",
+            "description": (
+                "Run a Hyphae DSL selector (CSS-selector-style graph query) over "
+                "the indexed symbol graph — one call replaces chains of "
+                "navigate/callers/search. Grammar: #name (by name), .kind "
+                "(.function/.method/.class), * (all), :calls(#X) (symbols that "
+                "call X), :callees(#X) (symbols X calls), :not(sel), :in(path), "
+                "[file=p]/[language=l]/[class=C], and combinators A > B / A B. "
+                "Example: '.function:calls(#IndexShard):in(server/)'. "
+                "Requires ast_cache index (run index action=warm)."
+            ),
+            "inputSchema": self.get_tool_schema(),
+            "annotations": {
+                "readOnlyHint": True,
+                "destructiveHint": False,
+                "idempotentHint": True,
+                "openWorldHint": False,
+            },
+        }
+
+    def get_tool_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "selector": {
+                    "type": "string",
+                    "description": (
+                        "Hyphae selector string, e.g. "
+                        "'.method:calls(#UserRepo)' or '#Foo > .function'."
+                    ),
+                },
+                "max_results": {
+                    "type": "integer",
+                    "description": "Max symbols to return (default: 100).",
+                    "default": 100,
+                },
+                "output_format": {
+                    "type": "string",
+                    "enum": ["json", "toon"],
+                    "description": "Output format: 'toon' (default) or 'json'.",
+                    "default": "toon",
+                },
+            },
+            "required": ["selector"],
+            "additionalProperties": False,
+        }
+
+    def validate_arguments(self, arguments: dict[str, Any]) -> bool:
+        if not str(arguments.get("selector", "")).strip():
+            raise ValueError("selector is required")
+        return True
+
+    async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        self.validate_arguments(arguments)
+        selector = str(arguments["selector"]).strip()
+        max_results = int(arguments.get("max_results", 100) or 100)
+        max_results = max(1, min(max_results, 1000))
+        output_format = arguments.get("output_format", "toon")
+
+        from ...hyphae import Evaluator, parse
+        from ...hyphae.parser import HyphaeSyntaxError
+
+        try:
+            ast = parse(selector)
+        except (HyphaeSyntaxError, ValueError) as exc:
+            return {
+                "success": False,
+                "selector": selector,
+                "error": f"Hyphae syntax error: {exc}",
+                "symbols": [],
+            }
+
+        evaluator = Evaluator(self._get_cache(), max_results=max_results)
+        matches = evaluator.eval(ast)
+        symbols = [
+            {
+                "name": m.get("name"),
+                "file": m.get("file"),
+                "line": m.get("line"),
+                "language": m.get("language"),
+                "class": m.get("class"),
+            }
+            for m in matches
+        ]
+        result: dict[str, Any] = {
+            "success": True,
+            "selector": selector,
+            "count": len(symbols),
+            "symbols": symbols,
+            "agent_summary": {
+                "summary_line": f"hyphae_select: {len(symbols)} symbols for {selector!r}",
+                "verdict": "INFO" if symbols else "NOT_FOUND",
+                "next_step": (
+                    "Answer from these symbols, or refine the selector "
+                    "(add :in(path) / [file=] / :not(...) to narrow)."
+                ),
+            },
+        }
+
+        from ..utils.format_helper import apply_toon_format_to_response
+
+        return apply_toon_format_to_response(result, output_format)

--- a/tree_sitter_analyzer/mcp/tools/search_facade.py
+++ b/tree_sitter_analyzer/mcp/tools/search_facade.py
@@ -63,7 +63,13 @@ _SEARCH_DESCRIPTION = (
     "- action=batch — run multiple search queries in one call. Params: queries.\n"
     "- action=chain — jQuery-style codegraph chain DSL: compose search → "
     "explore → callers → callees in one process. "
-    "Params: chain/program, default_limit, include_source."
+    "Params: chain/program, default_limit, include_source.\n"
+    "- action=select — Hyphae DSL, a CSS-selector-style graph query (RFC-0003). "
+    "ONE selector replaces chains of navigate/callers/search: #name, .kind "
+    "(.function/.method/.class), *, :calls(#X), :callees(#X), :not(sel), "
+    ":in(path), [file=p]/[language=l]/[class=C], combinators A > B / A B. "
+    "Example: '.function:calls(#IndexShard):in(server/)'. Params: selector "
+    "(required), max_results, output_format."
 )
 
 
@@ -77,6 +83,7 @@ def build_search_facade(project_root: str | None = None) -> FacadeTool:
     from .batch_search_tool import BatchSearchTool
     from .codegraph_query_tool import CodeGraphQueryTool
     from .find_and_grep_tool import FindAndGrepTool
+    from .hyphae_select_tool import HyphaeSelectTool
     from .query_tool import QueryTool
     from .search_content_tool import SearchContentTool
     from .symbol_search_tool import CodeGraphSymbolSearchTool
@@ -102,6 +109,10 @@ def build_search_facade(project_root: str | None = None) -> FacadeTool:
             # folded here from the standalone ``codegraph_query`` tool so the
             # whole 62-row capability surface survives the facade cutover.
             "chain": CodeGraphQueryTool(project_root),
+            # Hyphae DSL — CSS-selector-style graph query (RFC-0003 port).
+            # One selector replaces chains of navigate/callers/search, e.g.
+            # ".function:calls(#IndexShard):in(server/)".
+            "select": HyphaeSelectTool(project_root),
         },
         bespoke_map={
             "content": _content_route,  # F5: search_content (dict|int)


### PR DESCRIPTION
## What
Lands the user's **jQuery metaphor** in TSA. mycelium has Hyphae ~100% (full selector + MCP tool + subscription); TSA had **zero**. Ports the MVP and wires it as `search action=select`.

## Pipeline
`text → lexer → parser → evaluator → [symbols]`
- **lexer**: prefix `#`/`.`/`:` absorb their identifier (removes .kind-vs-path ambiguity)
- **parser**: recursive-descent over RFC-0003 grammar (combinators `>` `~` descendant, attributes, pseudo-classes)
- **evaluator**: maps to the B1 single-edge graph; `:calls(#X)` reverse-driven (`query_callers(X)` ∩ candidates) → cheap on 16k symbols

## Grammar (MVP)
`#name` · `.kind` · `*` · `:calls(#X)` · `:callees(#X)` · `:not(sel)` · `:in(path)` · `[file=]/[language=]/[class=]` · `A > B` / `A B`

## Verified on ES index
`.function:calls(#getEngine):in(shard/)` → 20 scoped callers in **one call** (replaces a navigate/callers/search chain).

## Tests
27 new, ruff clean. No tool-count change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)