### PR TITLE
fix: address Codex P2 reviews on Hyphae edge filters (file identity + subclasses + implements)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,6 +311,31 @@ cd ~/.claude/skills/gstack && ./setup --team
 Skills like /qa, /ship, /review, /investigate, and /browse become available after install.
 Use /browse for all web browsing. Use ~/.claude/skills/gstack/... for gstack file paths.
 
+## PR Review Rules — NEVER ignore Codex review
+
+**🔒 LOCKED BY USER (2026-06-03):** 「每次 PR 之後不可以無視 codex 的 review」。After creating OR updating any PR, you MUST fetch and triage the Codex (`chatgpt-codex-connector[bot]`) review. Ignoring it — even when CI is green or the PR already merged — is a violation of this rule.
+
+### Mandatory workflow after every PR
+
+1. **Fetch the review** (the PR-body summary is just a template — the real findings are inline comments):
+   ```bash
+   gh api repos/aimasteracc/tree-sitter-analyzer/pulls/<N>/comments \
+     | python3 -c "import json,sys; [print(c['path'],c.get('line'),'\n',c['body'][:1500],'\n---') for c in json.load(sys.stdin)]"
+   ```
+   Codex review is triggered on open / ready-for-review / `@codex review` comment. If it hasn't posted yet, wait for it (CI-monitor pattern) before merging.
+
+2. **Triage EVERY comment** — do not skip any. For each, render an explicit verdict:
+   - **Real problem** → fix it (own PR or follow-up PR). Codex P-badges (P1/P2/P3) set priority; P1/P2 must be fixed before or right after merge.
+   - **Already fixed** → Codex often reviews an older commit; verify on the current HEAD and record "already fixed by #X".
+   - **False positive / won't-fix** → state the concrete reason (cross-ref a CLAUDE.md design decision if applicable). Never dismiss silently.
+
+3. **Report the triage to the user** — a table of (comment → verdict → action), so nothing is swept under the rug.
+
+4. **If the PR already merged when the review lands**, still triage; open a follow-up PR for any real finding. A merged PR does NOT exempt its review.
+
+### Why (past incident, 2026-06-03)
+Codex flagged 3 real P2 correctness bugs across #269/#270 (Hyphae file-identity false positives, `:subclasses` wrong endpoint → empty results, `:implements` missing the `implements` edge kind). All three were genuine; ignoring them would have shipped a query DSL that returns wrong graph results to agents. The 4th finding (`.class` empty) was a stale-commit review already fixed by a later PR — which is exactly why each comment needs an explicit verdict, not a blanket dismiss. Fixed via #271.
+
 ## Release Gate Rules
 
 **NEVER merge release branch → main until ALL of these are confirmed:**

--- a/tests/unit/hyphae/test_evaluator.py
+++ b/tests/unit/hyphae/test_evaluator.py
@@ -252,3 +252,51 @@ def test_unknown_pseudo_raises():
 def test_nth_child_requires_number():
     with pytest.raises(HyphaeSyntaxError):
         _fixture().eval(parse(".method:nth-child(#x)"))
+
+
+# -- codex review fixes --------------------------------------------------------
+def test_subclasses_returns_children():
+    # :subclasses(#Base) must match the parent endpoint (callee) and return
+    # children (caller) — same direction as :extends.
+    got = _names(_fixture().eval(parse(".class:subclasses(#BaseService)")))
+    assert got == ["UserService"]
+
+
+def test_calls_distinguishes_same_name_across_files():
+    # Two methods named 'save' in different files; only one calls 'find'.
+    functions = [
+        {"name": "save", "file": "a/A.java", "line": 10, "class": "A"},
+        {"name": "save", "file": "b/B.java", "line": 20, "class": "B"},
+    ]
+    edges = [
+        {
+            "kind": "calls",
+            "caller_name": "save",
+            "callee_name": "find",
+            "file_path": "a/A.java",
+            "callee_resolved_file": "r/R.java",
+        },
+    ]
+    ev = Evaluator(FakeCache(functions, [], edges))
+    got = ev.eval(parse(".method:calls(#find)"))
+    # file identity: only a/A.java's save, not b/B.java's.
+    assert len(got) == 1
+    assert got[0]["file"] == "a/A.java"
+
+
+def test_implements_queries_implements_edge_kind():
+    # An indexer that emits a distinct 'implements' edge must be matched.
+    classes = [
+        {"name": "JsonWriter", "file": "JsonWriter.java", "line": 1, "kind": "class"},
+    ]
+    edges = [
+        {
+            "kind": "implements",
+            "caller_name": "JsonWriter",
+            "callee_name": "Writeable",
+            "file_path": "JsonWriter.java",
+        },
+    ]
+    ev = Evaluator(FakeCache([], classes, edges))
+    got = _names(ev.eval(parse(".class:implements(#Writeable)")))
+    assert got == ["JsonWriter"]

--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -689,8 +689,8 @@ class ASTCache:
         import sqlite3 as _sqlite3
 
         sql = (
-            "SELECT caller_name, callee_name, file_path, caller_line, callee_line "
-            "FROM edges WHERE kind = ?"
+            "SELECT caller_name, callee_name, file_path, caller_line, "
+            "callee_line, callee_resolved_file FROM edges WHERE kind = ?"
         )
         params: list[Any] = [kind]
         if caller_name is not None:

--- a/tree_sitter_analyzer/hyphae/evaluator.py
+++ b/tree_sitter_analyzer/hyphae/evaluator.py
@@ -45,16 +45,23 @@ from .parser import HyphaeSyntaxError
 _FUNCTIONISH = frozenset({"function", "method", "func", "fn"})
 _CLASSISH = frozenset({"class", "struct", "interface", "trait", "enum"})
 
-# Edge pseudo-classes → (edge_kind, target_match_column, returned_column).
+# Edge pseudo-classes → (edge_kinds, target_match_column, returned_column).
 # Reverse-driven: match the target name on one endpoint, keep candidates whose
-# name appears on the other endpoint.
-_EDGE_PSEUDOS: dict[str, tuple[str, str, str]] = {
-    "calls": ("calls", "callee_name", "caller_name"),
-    "callees": ("calls", "caller_name", "callee_name"),
-    "called-by": ("calls", "caller_name", "callee_name"),
-    "extends": ("extends", "callee_name", "caller_name"),
-    "implements": ("extends", "callee_name", "caller_name"),
-    "subclasses": ("extends", "caller_name", "callee_name"),
+# name appears on the other endpoint. Inheritance pseudo-classes span BOTH the
+# ``extends`` and ``implements`` edge kinds, because some indexers store class
+# inheritance and interface implementation separately while others (e.g. Java)
+# fold both into ``extends`` (per edge_store's inheritance-tree readers).
+_INHERIT_KINDS = ("extends", "implements")
+_EDGE_PSEUDOS: dict[str, tuple[tuple[str, ...], str, str]] = {
+    "calls": (("calls",), "callee_name", "caller_name"),
+    "callees": (("calls",), "caller_name", "callee_name"),
+    "called-by": (("calls",), "caller_name", "callee_name"),
+    # candidate extends/implements the target → candidate is the caller (child),
+    # target is the callee (parent/interface).
+    "extends": (_INHERIT_KINDS, "callee_name", "caller_name"),
+    "implements": (_INHERIT_KINDS, "callee_name", "caller_name"),
+    # target's subclasses → also children of the target, same direction.
+    "subclasses": (_INHERIT_KINDS, "callee_name", "caller_name"),
 }
 _POSITION_PSEUDOS = frozenset({"nth-child", "first-child", "only-child"})
 
@@ -170,24 +177,48 @@ class Evaluator:
         self,
         cands: list[dict[str, Any]],
         arg: Any,
-        edge_kind: str,
+        edge_kinds: tuple[str, ...],
         target_col: str,
         return_col: str,
     ) -> list[dict[str, Any]]:
-        """Keep candidates joined to the target selector by an edge of ``edge_kind``.
+        """Keep candidates joined to the target selector by any ``edge_kinds`` edge.
 
-        Reverse-driven: match each target name on ``target_col`` of the edges
-        table and keep candidates whose name appears on ``return_col`` — one
-        query per target rather than one per candidate.
+        Reverse-driven: match each target name on ``target_col`` and collect the
+        ``return_col`` endpoint with its file, so candidates are matched on
+        (name, file) — not name alone. This avoids false positives when two
+        symbols share a name across different files (overloads / duplicate
+        names). When the edge row lacks a resolved file, the endpoint falls back
+        to name-only matching so recall is preserved.
         """
         if not isinstance(arg, SelectorList):
             raise HyphaeSyntaxError("edge pseudo-class requires a selector argument")
+        # The returned endpoint's file lives in a different column depending on
+        # whether we return the caller (source = file_path) or the callee
+        # (target = callee_resolved_file).
+        file_col = (
+            "file_path" if return_col == "caller_name" else "callee_resolved_file"
+        )
         names = self._target_names(arg)
-        related: set[Any] = set()
+        related_nf: set[tuple[Any, Any]] = set()
+        related_name_only: set[Any] = set()
         for tname in names:
-            rows = self._cache.query_edges(edge_kind, **{target_col: tname}) or []
-            related.update(r.get(return_col) for r in rows if r.get(return_col))
-        return [c for c in cands if c.get("name") in related]
+            for kind in edge_kinds:
+                rows = self._cache.query_edges(kind, **{target_col: tname}) or []
+                for r in rows:
+                    nm = r.get(return_col)
+                    if not nm:
+                        continue
+                    f = r.get(file_col)
+                    if f:
+                        related_nf.add((nm, f))
+                    else:
+                        related_name_only.add(nm)
+        return [
+            c
+            for c in cands
+            if (c.get("name"), c.get("file")) in related_nf
+            or c.get("name") in related_name_only
+        ]
 
     def _filter_imports(
         self, cands: list[dict[str, Any]], arg: Any


### PR DESCRIPTION
## What
Addresses the 3 valid P2 findings from Codex review of #269/#270. (The 4th — `.class` always empty — was already fixed by #270; Codex reviewed the older #269 commit.)

## Fixes
1. **File identity** (#269) — edge pseudo-classes intersected on symbol **name only**, so `.function:calls(#X)` returned every same-named symbol across files (false positives on overloads/duplicates). Now matches on **(name, file)** via the edge row's `file_path` (caller) / `callee_resolved_file` (callee), with name-only fallback when the file is unresolved (preserves recall).
2. **`:subclasses` direction** (#270) — matched the candidate on the wrong endpoint, returning nothing for `:subclasses(#Base)`. Fixed to match the parent on `callee_name` and return children on `caller_name` (same direction as `:extends`).
3. **`:implements` edge kind** (#270) — only queried `extends`; the edge store has a distinct `implements` kind some indexers emit separately. Inheritance pseudo-classes (`:extends`/`:implements`/`:subclasses`) now span **both** kinds.

## Verified on ES index
- `.class:subclasses(#ToXContentFragment)` → 6 children (was empty before)
- `.class:implements(#Writeable)` → 6 implementers

## Tests
42 hyphae tests (3 new: subclasses, cross-file identity, implements-edge), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)