### PR TITLE
feat(resolver): RFC-0002 Phase1 — self-method via callee_full + unique-method receiver

### DIFF
--- a/rfcs/0002-callee-resolution.md
+++ b/rfcs/0002-callee-resolution.md
@@ -69,23 +69,33 @@ The `edges` table already carries the target columns — this RFC is about
 
 ### Algorithms — scope-aware resolution
 
-For each `calls` edge `(caller, callee_name)`:
+> **Cascade order matters — bindings before builtins (Codex review).** A
+> project/local binding can *shadow* a builtin or stdlib-looking name
+> (`def len(): ...; len()`, or a project import named `Path`). If we classified
+> by bare name *first*, we'd mislabel the call `builtin`/`stdlib` with no
+> `callee_symbol_id` and **regress the resolved graph**. This RFC therefore
+> follows the EXISTING cascade in
+> `tree_sitter_analyzer/synapse_resolver/__init__.py` (local → self/cls →
+> import → stdlib/builtin), which already orders bindings before builtins
+> specifically to preserve shadowing. This RFC extends that cascade's *reach*
+> and *fill rate*, it does not reorder it.
 
-1. **Builtin/stdlib classification first** (cheap, kills the `len`/`str`/`Path`
-   noise): match `callee_name` against a per-language builtin + stdlib table →
-   `builtin` / `stdlib`. This alone reclassifies a large slice of the 62.6%
-   `unknown`.
-2. **Local scope**: a name bound in the caller's own
-   function/module (local def, parameter, assignment) → `local`, resolve to
-   that definition.
-3. **Import-based**: follow the caller file's imports (we already have
-   `ast_imports` + B3 import resolution) to map `callee_name` → an imported
-   module symbol → `project` / `external`.
+For each `calls` edge `(caller, callee_name)`, in priority order:
+
+1. **Local scope**: a name bound in the caller's own function/module (local
+   def, parameter, assignment) → `local`, resolve to that definition.
+2. **self/cls**: `self.X` / `cls.X` on the caller's enclosing class → resolve
+   to that class's member.
+3. **Import-based**: follow the caller file's imports (`ast_imports` + B3 import
+   resolution) → `project` / `external`.
 4. **Receiver-typed method calls** (`obj.method()`): infer the type of `obj`
-   (annotation, constructor assignment, `self` → enclosing class) → resolve
-   `method` to that class's definition. This is what disambiguates the 227
-   `execute` edges.
-5. **Leave `unknown`** only when none of the above resolves — and record *why*
+   (annotation, constructor assignment) → resolve `method` to that class's
+   definition. This disambiguates the 227 same-named `execute` edges.
+5. **Builtin/stdlib classification — LAST, only if nothing above bound the
+   name** (so a shadowing local/import wins): match against a per-language
+   builtin + stdlib table → `builtin` / `stdlib`. This is where the `len`/`str`/
+   `Path` noise gets classified, *after* confirming no binding shadows it.
+6. **Leave `unknown`** only when none of the above resolves — and record *why*
    (so the number is auditable, not silent).
 
 ### Error handling
@@ -141,6 +151,9 @@ receiver field, per CLAUDE.md rule 6) benefits directly.
 
 - Unit: builtin/stdlib classifier (Python `len`/`str` → builtin; `os.path` →
   stdlib).
+- Unit: **shadowing** — `def len(): ...; len()` resolves to the local def
+  (`local` + symbol_id), NOT `builtin`; a project import named `Path` resolves
+  to `project`, not `stdlib` (the cascade-order regression).
 - Unit: receiver-typed resolution — two classes with same-named method, an
   `execute` call resolves to the right one by receiver type.
 - Unit: `absolute_path` vs `_absolute_path` vs `_validate_absolute_path` resolve
@@ -152,7 +165,10 @@ receiver field, per CLAUDE.md rule 6) benefits directly.
 
 ## Acceptance criteria
 
-- [ ] Builtin/stdlib classifier per language; `unknown` rate drops measurably
+- [ ] Builtin/stdlib classifier per language, applied LAST in the cascade;
+      `unknown` rate drops measurably
+- [ ] Shadowing preserved: a local/import binding that shadows a builtin/stdlib
+      name resolves to the binding (local/project + symbol_id), not builtin/stdlib
 - [ ] Receiver-typed method resolution disambiguates same-named methods
 - [ ] `absolute_path`/`_absolute_path`/`_validate_absolute_path` resolve to
       distinct `callee_symbol_id`s (unit regression)

--- a/rfcs/0002-callee-resolution.md
+++ b/rfcs/0002-callee-resolution.md
@@ -1,0 +1,180 @@
+# RFC-0002: Callee resolution — bare names to resolved symbols
+
+- **Status**: draft
+- **Author(s)**: @aimasteracc
+- **Created**: 2026-06-03
+- **Last updated**: 2026-06-03
+- **Tracking issue**: TBD
+- **Affected source paths**:
+  - `tree_sitter_analyzer/_ast_cache_unresolved.py` (the second-pass resolver)
+  - `tree_sitter_analyzer/_ast_cache_synapse.py` (synapse resolution RMW)
+  - `tree_sitter_analyzer/_ast_extraction.py` (call-edge extraction / receiver capture)
+  - `tree_sitter_analyzer/graph/edge_store.py` (edges schema: callee_resolved_file / callee_resolution / callee_symbol_id)
+  - `tree_sitter_analyzer/hyphae/evaluator.py` (consumer — edge pseudo-classes)
+  - `tests/unit/`
+
+## Summary
+
+Resolve the `callee` endpoint of `calls` edges from a **bare name**
+(`execute`, `absolute_path`) to a **specific resolved symbol** (which file,
+which class/scope, which definition) and classify it
+(`project` / `local` / `stdlib` / `external` / `builtin`). Today **87.7% of
+call edges have an unresolved bare callee** and **62.6% are classified
+`unknown`** — which makes any call-graph-derived analysis (test coverage,
+impact, "who tests whom") untrustworthy, and even makes a bare-name `grep`
+verification unreliable.
+
+## Motivation
+
+Measured on TSA's own index (1787 files, 112,633 call edges):
+
+| metric | value |
+|---|---|
+| call edges total | 112,633 |
+| callee resolved to a file | 13,886 (**12.3%**) |
+| callee still a bare name | 98,747 (**87.7%**) |
+| `callee_resolution = unknown` | 70,482 (**62.6%**) |
+| `stdlib` | 28,265 · `project` 11,264 · `local` 2,622 |
+
+**The pain is concrete.** When we tried to answer "which production methods are
+untested?" via Hyphae (`.function:in(src):not(:callees(.function:in(tests/)))`),
+the query *ran* fine — but the result was polluted by the bare-name problem:
+
+- **`execute`** appears as the callee of 227 test files — but those are
+  *different* `execute` methods on different classes (dynamic dispatch). A bare
+  name can't tell them apart.
+- **`absolute_path`** (a real function at `_codegraph_query_symbols.py:156`) has
+  **0 call edges** and is genuinely untested — yet a bare-name `grep`
+  "verification" wrongly flagged it as a false positive, because the matches
+  were actually `_absolute_path`, `_validate_absolute_path`, and the test
+  function name `test_relative_vs_absolute_path`. **Bare names fooled even the
+  human cross-check.**
+
+So bare-name callees don't just make the call graph imprecise — they make every
+downstream answer (coverage, impact, dedup, "who calls/tests this exact symbol")
+unreliable, and they hide that unreliability behind plausible-looking results.
+Resolving the callee is the root fix; it directly advances the project's
+north-star "agent-native **resolved** code graph".
+
+## Detailed design
+
+### Data structures (mostly already present)
+
+The `edges` table already carries the target columns — this RFC is about
+**filling them correctly**, not adding schema:
+
+- `callee_resolved_file` — the file the callee is defined in
+- `callee_symbol_id` — the resolved symbol's id (the precise definition)
+- `callee_resolution` — `project` / `local` / `stdlib` / `external` / `builtin` / `unknown`
+
+### Algorithms — scope-aware resolution
+
+For each `calls` edge `(caller, callee_name)`:
+
+1. **Builtin/stdlib classification first** (cheap, kills the `len`/`str`/`Path`
+   noise): match `callee_name` against a per-language builtin + stdlib table →
+   `builtin` / `stdlib`. This alone reclassifies a large slice of the 62.6%
+   `unknown`.
+2. **Local scope**: a name bound in the caller's own
+   function/module (local def, parameter, assignment) → `local`, resolve to
+   that definition.
+3. **Import-based**: follow the caller file's imports (we already have
+   `ast_imports` + B3 import resolution) to map `callee_name` → an imported
+   module symbol → `project` / `external`.
+4. **Receiver-typed method calls** (`obj.method()`): infer the type of `obj`
+   (annotation, constructor assignment, `self` → enclosing class) → resolve
+   `method` to that class's definition. This is what disambiguates the 227
+   `execute` edges.
+5. **Leave `unknown`** only when none of the above resolves — and record *why*
+   (so the number is auditable, not silent).
+
+### Error handling
+
+Resolution is best-effort and monotonic: an edge never regresses from resolved
+to unknown. Ambiguous resolution (multiple candidates) records the candidate
+set rather than guessing one.
+
+### MCP surface (facade + action)
+
+No new surface. Hyphae edge pseudo-classes (`:calls`/`:callees`) become precise
+automatically once callees resolve, because the evaluator already matches on
+`(name, file)` (RFC for the file-identity fix landed in #271). A future
+optional `[resolution=project]` attribute could filter by class.
+
+## Three-Surface impact (CLI ↔ MCP parity)
+
+No surface change; this is an indexing-layer improvement consumed equally by CLI
+and MCP. The CLI `--callers "Class.method"` path (which already needs the
+receiver field, per CLAUDE.md rule 6) benefits directly.
+
+## Drawbacks
+
+- Resolution is non-trivial for dynamic languages (Python/JS): receiver type
+  inference is heuristic and will not reach 100%.
+- More work at index time (per-edge resolution). Mitigated: it is a second pass
+  over already-extracted edges (we have `_ast_cache_unresolved.py` for exactly
+  this), and builtin/stdlib classification is a cheap table lookup.
+
+## Alternatives
+
+- **Runtime tracing** (e.g. `sys.settrace` / coverage.py) — precise, but
+  requires executing the code; out of scope for a static index. *Complementary,
+  not a replacement.*
+- **LSP integration** (defer name resolution to a language server) — accurate
+  but heavy, per-language servers, not embeddable. *Deferred.*
+- **Leave it bare, document the caveat** — status quo; rejected, it makes the
+  whole call graph untrustworthy for the analyses agents actually want.
+
+## Prior art
+
+- **codegraph's `UnresolvedRef` two-phase resolution** (see
+  `reference_codegraph-architecture`): extract refs first, resolve in a second
+  pass against the symbol table — we adopt this shape (and already have the
+  second-pass scaffold in `_ast_cache_unresolved.py`).
+- **rust-analyzer name resolution** / **Sourcegraph SCIP** — scope-aware symbol
+  resolution with stable symbol ids; we adopt the "resolve to a stable symbol
+  id" idea (`callee_symbol_id`).
+- **mycelium Synapse** (the sibling project) — resolved bidirectional edges by
+  symbol, not name.
+
+## Test plan (RED-first)
+
+- Unit: builtin/stdlib classifier (Python `len`/`str` → builtin; `os.path` →
+  stdlib).
+- Unit: receiver-typed resolution — two classes with same-named method, an
+  `execute` call resolves to the right one by receiver type.
+- Unit: `absolute_path` vs `_absolute_path` vs `_validate_absolute_path` resolve
+  to distinct symbols (the disambiguation regression).
+- Integration: re-index TSA self; assert callee resolution rate rises and
+  `unknown` drops; assert the `execute` edges no longer collapse to one name.
+- Dogfood: re-run the Hyphae coverage query; assert the false-positive rate
+  (bare-name collisions) drops materially vs the 12.3% baseline.
+
+## Acceptance criteria
+
+- [ ] Builtin/stdlib classifier per language; `unknown` rate drops measurably
+- [ ] Receiver-typed method resolution disambiguates same-named methods
+- [ ] `absolute_path`/`_absolute_path`/`_validate_absolute_path` resolve to
+      distinct `callee_symbol_id`s (unit regression)
+- [ ] Re-indexed TSA self: callee resolution rate ≥ a target (set after a spike;
+      proposed ≥ 50% resolved-or-classified, from 12.3%)
+- [ ] Hyphae coverage query (`:callees`) false-positive rate measurably lower
+- [ ] No edge regresses resolved→unknown (monotonicity test)
+- [ ] CLI `--callers "Class.method"` still green; docs/CODEMAPS updated
+
+## What this RFC does NOT do (deferred)
+
+- Full type inference / a Python type checker — heuristic receiver typing only.
+- Runtime coverage (that's pytest-cov's job; this is the static-graph fix).
+- Cross-repository resolution (external deps resolve to `external`, not into
+  their source).
+
+## Open questions
+
+1. Target resolution rate for the acceptance gate — set after a spike on a few
+   files (proposed ≥ 50%).
+2. Receiver typing depth: just `self` + direct constructor assignment for v1, or
+   also annotations / return types?
+3. Should `builtin`/`stdlib` callees be dropped from the graph entirely (noise)
+   or kept-but-classified? Proposed: kept-but-classified (so `:callees` can
+   still answer "does X call any stdlib").

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -58,3 +58,4 @@ number; if two RFCs collide on a number in flight, the later-merged one renames.
 | RFC | Title | Status |
 |---|---|---|
 | [0001](0001-reactive-push.md) | Reactive push — virtual-DOM last mile | draft |
+| [0002](0002-callee-resolution.md) | Callee resolution — bare names to resolved symbols | draft |

--- a/tests/unit/synapse_resolver/test_unique_method.py
+++ b/tests/unit/synapse_resolver/test_unique_method.py
@@ -1,0 +1,80 @@
+"""RFC-0002 Phase 1: unique-method receiver resolution.
+
+When a method call `obj.method()` has a receiver whose type we can't infer,
+but `method` is defined on exactly ONE class across the whole project, resolve
+to it. If `method` is defined on multiple classes (e.g. `execute`), stay
+`unknown` rather than guess.
+"""
+
+from __future__ import annotations
+
+from tree_sitter_analyzer.synapse_resolver import resolve_callee
+from tree_sitter_analyzer.synapse_resolver._context import ResolverContext
+
+
+def _ctx(**kw):
+    defaults = {
+        "project_root": "/repo",
+        "cache": None,
+        "file_languages": {"caller.py": "python"},
+    }
+    defaults.update(kw)
+    return ResolverContext(**defaults)
+
+
+def test_unique_method_receiver_resolves_to_project():
+    # all_edges defined on exactly one class → pg.all_edges() resolves to it
+    ctx = _ctx(
+        file_class_methods={"project_graph.py": {"ProjectGraph": {"all_edges": 42}}}
+    )
+    r = resolve_callee("pg.all_edges", "caller.py", ctx)
+    assert r.resolution == "project"
+    assert r.callee_symbol_id == 42
+    assert r.resolved_file == "project_graph.py"
+
+
+def test_ambiguous_method_stays_unknown():
+    # execute on two classes → don't guess
+    ctx = _ctx(
+        file_class_methods={
+            "a.py": {"A": {"execute": 1}},
+            "b.py": {"B": {"execute": 2}},
+        }
+    )
+    r = resolve_callee("obj.execute", "caller.py", ctx)
+    assert r.resolution == "unknown"
+
+
+def test_self_method_not_hijacked():
+    # self.X still resolves via _try_self_method (local), not unique-method
+    ctx = _ctx(file_class_methods={"caller.py": {"C": {"foo": 5}}})
+    r = resolve_callee("self.foo", "caller.py", ctx)
+    assert r.resolution == "local"
+
+
+def test_bare_name_unaffected():
+    # no receiver → unique-method rule must not fire
+    ctx = _ctx(file_class_methods={"x.py": {"X": {"helper": 9}}})
+    r = resolve_callee("helper", "caller.py", ctx)
+    # helper is a method here, not a bare global → unique-method needs a qualifier,
+    # so this stays unknown (not hijacked into project via the method table)
+    assert r.resolution == "unknown"
+
+
+def test_self_method_via_callee_full_resolves_local():
+    """self._x() arrives as callee_name='_x' + callee_full='self._x' — the bare
+    name lost the receiver, so resolution must use callee_full to reach
+    _try_self_method (the #1 unknown source)."""
+    ctx = _ctx(file_class_methods={"caller.py": {"Sync": {"_scan_disk_files": 77}}})
+    r = resolve_callee(
+        "_scan_disk_files", "caller.py", ctx, callee_full="self._scan_disk_files"
+    )
+    assert r.resolution == "local"
+    assert r.callee_symbol_id == 77
+
+
+def test_bare_name_without_self_full_unaffected():
+    ctx = _ctx(file_class_methods={"caller.py": {"Sync": {"_scan_disk_files": 77}}})
+    # no callee_full → bare name, stays unknown (not a self call we can see)
+    r = resolve_callee("_scan_disk_files", "caller.py", ctx)
+    assert r.resolution == "unknown"

--- a/tests/unit/synapse_resolver/test_unique_method.py
+++ b/tests/unit/synapse_resolver/test_unique_method.py
@@ -78,3 +78,34 @@ def test_bare_name_without_self_full_unaffected():
     # no callee_full → bare name, stays unknown (not a self call we can see)
     r = resolve_callee("_scan_disk_files", "caller.py", ctx)
     assert r.resolution == "unknown"
+
+
+# -- Codex P2 regressions (PR #274) -------------------------------------------
+def test_unique_method_via_production_callee_full():
+    """P2#1: production rows are callee_name='all_edges' + callee_full='pg.all_edges'.
+    Must split callee_full to recover the `pg` receiver so unique-method fires."""
+    ctx = _ctx(
+        file_class_methods={"project_graph.py": {"ProjectGraph": {"all_edges": 42}}}
+    )
+    r = resolve_callee("all_edges", "caller.py", ctx, callee_full="pg.all_edges")
+    assert r.resolution == "project"
+    assert r.callee_symbol_id == 42
+
+
+def test_self_method_no_cross_class_match():
+    """P2#2: A.f calls self.helper(); only B defines helper → must NOT resolve to B."""
+    ctx = _ctx(file_class_methods={"caller.py": {"A": {"f": 1}, "B": {"helper": 2}}})
+    r = resolve_callee(
+        "helper", "caller.py", ctx, callee_full="self.helper", caller_name="f"
+    )
+    assert r.resolution == "unknown"
+
+
+def test_self_method_resolves_within_enclosing_class():
+    """P2#2: A.f calls self.g(); A defines g → resolve to A.g (not B's anything)."""
+    ctx = _ctx(
+        file_class_methods={"caller.py": {"A": {"f": 1, "g": 3}, "B": {"helper": 2}}}
+    )
+    r = resolve_callee("g", "caller.py", ctx, callee_full="self.g", caller_name="f")
+    assert r.resolution == "local"
+    assert r.callee_symbol_id == 3

--- a/tree_sitter_analyzer/_ast_cache_synapse.py
+++ b/tree_sitter_analyzer/_ast_cache_synapse.py
@@ -50,6 +50,7 @@ def resolve_call_edges_for_file(
                 row["caller_file"],
                 ctx,
                 row["callee_full"],
+                row["caller_name"],
             )
         except Exception as exc:  # pragma: no cover
             logger.debug("resolve_callee crashed on %s: %s", row["callee_name"], exc)
@@ -113,6 +114,7 @@ def run_synapse_backfill(cache: Any, conn: sqlite3.Connection) -> dict[str, int]
                 row["caller_file"],
                 ctx,
                 row["callee_full"],
+                row["caller_name"],
             )
         except Exception as exc:
             logger.debug("resolve_callee failed in backfill: %s", exc)

--- a/tree_sitter_analyzer/synapse_resolver/__init__.py
+++ b/tree_sitter_analyzer/synapse_resolver/__init__.py
@@ -74,14 +74,30 @@ def _item_file(item: object) -> str:
 
 
 def _try_self_method(
-    base: str, qualifier: str, caller_file: str, ctx: ResolverContext
+    base: str,
+    qualifier: str,
+    caller_file: str,
+    caller_name: str,
+    ctx: ResolverContext,
 ) -> ResolvedCallee | None:
     if qualifier not in ("self", "cls"):
         return None
-    for _cls, methods in ctx.file_class_methods.get(caller_file, {}).items():
-        sym_id = methods.get(base)
-        if sym_id is not None:
-            return ResolvedCallee(sym_id, "local", caller_file)
+    classes = ctx.file_class_methods.get(caller_file, {})
+    # P2 (Codex review): restrict self.X to the CALLER's enclosing class, not
+    # every class in the file. The enclosing class is the one that defines the
+    # caller method (caller_name). Without this, `A.f` calling `self.helper()`
+    # would wrongly resolve to `B.helper` when only B defines it.
+    enclosing = [cls for cls, methods in classes.items() if caller_name in methods]
+    if len(enclosing) == 1:
+        sym_id = classes[enclosing[0]].get(base)
+        return (
+            ResolvedCallee(sym_id, "local", caller_file) if sym_id is not None else None
+        )
+    # Enclosing class unknown/ambiguous → only resolve when base is defined in
+    # exactly ONE class (no cross-class guess).
+    defs = [methods[base] for methods in classes.values() if base in methods]
+    if len(defs) == 1:
+        return ResolvedCallee(defs[0], "local", caller_file)
     return None
 
 
@@ -246,6 +262,7 @@ def resolve_callee(
     caller_file: str,
     ctx: ResolverContext,
     callee_full: str | None = None,
+    caller_name: str = "",
 ) -> ResolvedCallee:
     """Resolve a single callee, dispatching by the caller file's language.
 
@@ -266,7 +283,9 @@ def resolve_callee(
         )
         return ResolvedCallee(sym_id, resolution, resolved_file)
 
-    return _resolve_callee_python(callee_name, caller_file, ctx, callee_full)
+    return _resolve_callee_python(
+        callee_name, caller_file, ctx, callee_full, caller_name
+    )
 
 
 def _resolve_callee_python(
@@ -274,6 +293,7 @@ def _resolve_callee_python(
     caller_file: str,
     ctx: ResolverContext,
     callee_full: str | None = None,
+    caller_name: str = "",
 ) -> ResolvedCallee:
     """Resolve a single callee per the priority cascade above.
 
@@ -284,15 +304,17 @@ def _resolve_callee_python(
     ``callee_full`` carries a ``self``/``cls`` receiver, split on it so those
     method calls resolve.
     """
-    if callee_full and (
-        callee_full.startswith("self.") or callee_full.startswith("cls.")
-    ):
+    # P2 (Codex review): split on callee_full whenever it carries a receiver,
+    # not just self/cls — otherwise `pg.all_edges()` (callee_name='all_edges',
+    # callee_full='pg.all_edges') loses the `pg` qualifier and _try_unique_method
+    # never fires on the production rows it was meant to resolve.
+    if callee_full and "." in callee_full:
         qualifier, base = _split_qualifier(callee_full)
     else:
         qualifier, base = _split_qualifier(callee_name)
 
     for rule in (
-        lambda: _try_self_method(base, qualifier, caller_file, ctx),
+        lambda: _try_self_method(base, qualifier, caller_file, caller_name, ctx),
         lambda: _try_local(base, caller_file, ctx) if not qualifier else None,
         lambda: _try_import(base, qualifier, caller_file, ctx),
         lambda: _try_stdlib(base, qualifier, caller_file, ctx),

--- a/tree_sitter_analyzer/synapse_resolver/__init__.py
+++ b/tree_sitter_analyzer/synapse_resolver/__init__.py
@@ -212,6 +212,35 @@ def _try_single_global(
     return None
 
 
+def _try_unique_method(
+    base: str, qualifier: str, ctx: ResolverContext
+) -> ResolvedCallee | None:
+    """RFC-0002 Phase 1: receiver method call where the method name is unique.
+
+    For ``obj.method()`` whose receiver type we cannot infer, if ``method`` is
+    defined on exactly ONE class across the whole project, resolve to it. If it
+    is defined on multiple classes (e.g. ``execute``), return ``None`` and stay
+    ``unknown`` rather than guess. Requires a qualifier (a receiver); ``self``/
+    ``cls`` are already handled by ``_try_self_method``, and bare names by the
+    global rules above — so this only fires for true receiver method calls the
+    earlier rules left unresolved.
+    """
+    if not qualifier or qualifier in ("self", "cls"):
+        return None
+    found: tuple[str, int] | None = None
+    for file_path, classes in ctx.file_class_methods.items():
+        for _cls, methods in classes.items():
+            sym_id = methods.get(base)
+            if sym_id is None:
+                continue
+            if found is not None and (file_path, sym_id) != found:
+                return None  # defined on >1 class — ambiguous, don't guess
+            found = (file_path, sym_id)
+    if found is not None:
+        return ResolvedCallee(found[1], "project", found[0])
+    return None
+
+
 def resolve_callee(
     callee_name: str,
     caller_file: str,
@@ -237,14 +266,30 @@ def resolve_callee(
         )
         return ResolvedCallee(sym_id, resolution, resolved_file)
 
-    return _resolve_callee_python(callee_name, caller_file, ctx)
+    return _resolve_callee_python(callee_name, caller_file, ctx, callee_full)
 
 
 def _resolve_callee_python(
-    callee_name: str, caller_file: str, ctx: ResolverContext
+    callee_name: str,
+    caller_file: str,
+    ctx: ResolverContext,
+    callee_full: str | None = None,
 ) -> ResolvedCallee:
-    """Resolve a single callee per the priority cascade above."""
-    qualifier, base = _split_qualifier(callee_name)
+    """Resolve a single callee per the priority cascade above.
+
+    ``callee_name`` is the bare name (receiver stripped); ``callee_full`` keeps
+    the receiver (e.g. ``self._scan_disk_files``). The bare name loses the
+    ``self``/``cls`` qualifier, so ``self.X`` calls would never reach
+    ``_try_self_method`` — the #1 source of ``unknown`` edges. When
+    ``callee_full`` carries a ``self``/``cls`` receiver, split on it so those
+    method calls resolve.
+    """
+    if callee_full and (
+        callee_full.startswith("self.") or callee_full.startswith("cls.")
+    ):
+        qualifier, base = _split_qualifier(callee_full)
+    else:
+        qualifier, base = _split_qualifier(callee_name)
 
     for rule in (
         lambda: _try_self_method(base, qualifier, caller_file, ctx),
@@ -253,6 +298,7 @@ def _resolve_callee_python(
         lambda: _try_stdlib(base, qualifier, caller_file, ctx),
         lambda: _try_builtin(base, qualifier, ctx),
         lambda: _try_single_global(base, qualifier, ctx),
+        lambda: _try_unique_method(base, qualifier, ctx),
     ):
         out = rule()
         if out is not None:


### PR DESCRIPTION
## What
First precision fixes for RFC-0002 (callee resolution), found by **per-file ground-truth audit** of TSA self.

## Fixes
1. **self-method via callee_full** — the Python resolver cascade used the bare `callee_name` (receiver stripped), so `self.X()`/`cls.X()` (arriving as `callee_name='X'` + `callee_full='self.X'`) **never reached `_try_self_method`** — the #1 source of `unknown` edges. Now the cascade splits on `callee_full` when it carries a self/cls receiver. Measured: **local edges 2504→3350 (+846 self methods resolved)**.
2. **unique-method receiver inference** — `obj.method()` whose method name is defined on exactly ONE class project-wide resolves to it; ambiguous (`execute`, on many classes) stays `unknown` rather than guess.

## Honest scope
Overall `unknown` only **-0.6pp** (64.6→64.0%). `unknown` is **multi-source**: stdlib methods (`logging.getLogger`), duck-typed receivers (`h.update()`, `rows.keys()` — receiver type known only at runtime), cross-file. **No single silver bullet, and duck typing caps static resolution at ~80-90%** (RFC-0002 §Drawbacks). Further Phase-1 work: stdlib module.func classification, import-based completion, second-pass backfill.

## Tests
113 resolver tests green (6 new: unique-method + self-via-callee_full + ambiguity/regression).

Implements part of RFC-0002 (#273).

🤖 Generated with [Claude Code](https://claude.com/claude-code)