### PR TITLE
feat(precision): static type inference + synapse 2nd-pass fix — resolution 34%→76%

### DIFF
--- a/tests/unit/synapse_resolver/test_unique_method.py
+++ b/tests/unit/synapse_resolver/test_unique_method.py
@@ -109,3 +109,36 @@ def test_self_method_resolves_within_enclosing_class():
     r = resolve_callee("g", "caller.py", ctx, callee_full="self.g", caller_name="f")
     assert r.resolution == "local"
     assert r.callee_symbol_id == 3
+
+
+# -- RFC-0002: receiver-type-aware (class.method) resolution ------------------
+def test_class_method_disambiguates_non_unique():
+    """execute defined on A and B; ClassName.execute (receiver type inferred)
+    resolves to the right one — what unique-method can't do (it stays unknown)."""
+    ctx = _ctx(
+        file_class_methods={
+            "a.py": {"A": {"execute": 10}},
+            "b.py": {"B": {"execute": 20}},
+        }
+    )
+    # extractor inferred receiver type → callee_full='A.execute'
+    r = resolve_callee("execute", "caller.py", ctx, callee_full="A.execute")
+    assert r.resolution == "project"
+    assert r.callee_symbol_id == 10
+    assert r.resolved_file == "a.py"
+    # the other class
+    r2 = resolve_callee("execute", "caller.py", ctx, callee_full="B.execute")
+    assert r2.callee_symbol_id == 20
+
+
+def test_class_method_unknown_class_with_ambiguous_method():
+    # NotAClass not known + execute ambiguous (A and B) → neither class-method
+    # nor unique-method resolves → unknown (don't guess)
+    ctx = _ctx(
+        file_class_methods={
+            "a.py": {"A": {"execute": 10}},
+            "b.py": {"B": {"execute": 20}},
+        }
+    )
+    r = resolve_callee("execute", "caller.py", ctx, callee_full="NotAClass.execute")
+    assert r.resolution == "unknown"

--- a/tests/unit/synapse_resolver/test_unique_method.py
+++ b/tests/unit/synapse_resolver/test_unique_method.py
@@ -142,3 +142,15 @@ def test_class_method_unknown_class_with_ambiguous_method():
     )
     r = resolve_callee("execute", "caller.py", ctx, callee_full="NotAClass.execute")
     assert r.resolution == "unknown"
+
+
+def test_class_method_duplicate_class_stays_unknown():
+    """P2 (Codex): Client defined in two modules → ambiguous, don't guess a file."""
+    ctx = _ctx(
+        file_class_methods={
+            "a.py": {"Client": {"send": 1}},
+            "b.py": {"Client": {"send": 2}},
+        }
+    )
+    r = resolve_callee("send", "caller.py", ctx, callee_full="Client.send")
+    assert r.resolution == "unknown"

--- a/tests/unit/test_assignment_type_inference.py
+++ b/tests/unit/test_assignment_type_inference.py
@@ -40,3 +40,29 @@ def test_inference_is_function_scoped():
     calls = _calls(code)
     assert calls["run"]["full_name"] == "ProjectGraph.run"
     assert calls["other"]["full_name"] == "pg.other"  # g's pg untyped
+
+
+def test_pytest_fixture_return_type_typed_param():
+    # def tool(): return X(); def test(tool): tool.execute() → X.execute
+    code = (
+        "import pytest\n"
+        "@pytest.fixture\n"
+        "def tool(project):\n"
+        "    return SearchContentTool(project)\n"
+        "class TestX:\n"
+        "    def test_execute(self, tool):\n"
+        "        tool.execute(args)\n"
+    )
+    calls = _calls(code)
+    assert calls["execute"]["full_name"] == "SearchContentTool.execute"
+    assert calls["execute"]["receiver_type"] == "SearchContentTool"
+
+
+def test_fixture_return_via_local_var():
+    # def tool(): t = X(); return t
+    code = (
+        "def tool():\n    t = QueryTool()\n    return t\n"
+        "def test_q(tool):\n    tool.run()\n"
+    )
+    calls = _calls(code)
+    assert calls["run"]["full_name"] == "QueryTool.run"

--- a/tests/unit/test_assignment_type_inference.py
+++ b/tests/unit/test_assignment_type_inference.py
@@ -1,0 +1,42 @@
+"""RFC-0002: static assignment-based receiver-type inference in walk_tree."""
+
+from __future__ import annotations
+
+from tree_sitter_analyzer.core.parser import Parser
+from tree_sitter_analyzer.function_extraction import walk_tree
+
+
+def _calls(code: str):
+    result = Parser().parse_code(code, "python")
+    root = result.tree.root_node
+    _defs, calls = walk_tree(root, code, "python")
+    return {c["name"]: c for c in calls}
+
+
+def test_var_constructed_from_class_infers_type():
+    code = (
+        "def handler():\n"
+        "    pg = ProjectGraph(root)\n"
+        "    pg.execute()\n"
+        "    pg.all_edges()\n"
+    )
+    calls = _calls(code)
+    assert calls["execute"]["full_name"] == "ProjectGraph.execute"
+    assert calls["execute"]["receiver_type"] == "ProjectGraph"
+    assert calls["all_edges"]["full_name"] == "ProjectGraph.all_edges"
+
+
+def test_var_from_lowercase_func_not_inferred():
+    # x = helper() — helper is a function (lowercase), not a class → no inference
+    code = "def h():\n    x = helper()\n    x.foo()\n"
+    calls = _calls(code)
+    assert calls["foo"]["full_name"] == "x.foo"
+    assert calls["foo"].get("receiver_type") is None
+
+
+def test_inference_is_function_scoped():
+    # pg is ProjectGraph in f, but a different var in g — no leak
+    code = "def f():\n    pg = ProjectGraph()\n    pg.run()\ndef g():\n    pg.other()\n"
+    calls = _calls(code)
+    assert calls["run"]["full_name"] == "ProjectGraph.run"
+    assert calls["other"]["full_name"] == "pg.other"  # g's pg untyped

--- a/tests/unit/test_assignment_type_inference.py
+++ b/tests/unit/test_assignment_type_inference.py
@@ -59,10 +59,29 @@ def test_pytest_fixture_return_type_typed_param():
 
 
 def test_fixture_return_via_local_var():
-    # def tool(): t = X(); return t
+    # @pytest.fixture def tool(): t = X(); return t
     code = (
+        "import pytest\n@pytest.fixture\n"
         "def tool():\n    t = QueryTool()\n    return t\n"
         "def test_q(tool):\n    tool.run()\n"
     )
     calls = _calls(code)
     assert calls["run"]["full_name"] == "QueryTool.run"
+
+
+def test_flow_sensitive_pre_binding_not_typed():
+    # pg.execute() BEFORE pg = ProjectGraph() must NOT be typed (P2 flow-sensitive)
+    code = "def f(pg):\n    pg.execute()\n    pg = ProjectGraph()\n    pg.run()\n"
+    calls = _calls(code)
+    assert calls["execute"]["full_name"] == "pg.execute"  # pre-binding: untyped
+    assert calls["run"]["full_name"] == "ProjectGraph.run"  # post-binding: typed
+
+
+def test_non_fixture_function_not_typed():
+    # plain (non-@fixture) def client(): return X(); param client must NOT type
+    code = (
+        "def client():\n    return HttpClient()\n"
+        "def handle(client):\n    client.send()\n"
+    )
+    calls = _calls(code)
+    assert calls["send"]["full_name"] == "client.send"  # not a fixture → untyped

--- a/tree_sitter_analyzer/function_extraction.py
+++ b/tree_sitter_analyzer/function_extraction.py
@@ -159,18 +159,17 @@ def walk_tree(node: Any, source: str, language: str) -> tuple[list[dict], list[d
 
 def _collect_local_var_types(
     func_node: Any, source: str, language: str
-) -> dict[str, str]:
+) -> dict[str, tuple[str, int]]:
     """RFC-0002: infer local variable types from ``var = ClassName(...)``.
 
-    Static receiver-type inference (no runtime): a same-function assignment whose
-    right side constructs a CapitalizedName (PEP8 class convention) binds the
-    left identifier to that class. Lets ``pg = ProjectGraph(); pg.execute()``
-    resolve ``execute`` to ``ProjectGraph.execute`` — disambiguating non-unique
-    methods. Python only for v1.
+    Returns ``{var: (class, assign_line)}``. The line makes typing
+    flow-sensitive (P2, Codex): a call only takes the type if it appears AT or
+    AFTER the binding line — ``pg.execute(); pg = ProjectGraph()`` must NOT type
+    the pre-binding call. Static, Python only.
     """
     if language != "python":
         return {}
-    types: dict[str, str] = {}
+    types: dict[str, tuple[str, int]] = {}
 
     def _walk(n: Any) -> None:
         if getattr(n, "type", None) == "assignment":
@@ -186,7 +185,7 @@ def _collect_local_var_types(
                 if fn is not None and fn.type == "identifier":
                     cls = _node_text(fn, source)
                     if cls and cls[0].isupper():
-                        types[_node_text(left, source)] = cls
+                        types[_node_text(left, source)] = (cls, n.start_point[0] + 1)
         for c in n.children:
             _walk(c)
 
@@ -234,7 +233,7 @@ def _infer_return_class(func_node: Any, source: str) -> str | None:
                 elif c.type == "identifier":
                     v = _node_text(c, source)
                     if v in local:
-                        result = local[v]
+                        result = local[v][0]
         for ch in n.children:
             _walk(ch)
 
@@ -258,11 +257,23 @@ def _collect_fixture_types(
     types: dict[str, str] = {}
 
     def _walk(n: Any) -> None:
-        if getattr(n, "type", None) == "function_definition":
-            fname = get_func_name(n, "python")
-            rcls = _infer_return_class(n, source)
-            if fname and rcls:
-                types[fname] = rcls
+        # P2 (Codex): only treat ACTUAL pytest fixtures as fixtures — a
+        # decorated_definition whose decorator mentions 'fixture'. A plain
+        # ``def client(): return HttpClient()`` is NOT a fixture, so a normal
+        # parameter named ``client`` must not be typed.
+        if getattr(n, "type", None) == "decorated_definition":
+            deco_text = ""
+            inner = None
+            for c in n.children:
+                if c.type == "decorator":
+                    deco_text += _node_text(c, source)
+                elif c.type == "function_definition":
+                    inner = c
+            if inner is not None and "fixture" in deco_text:
+                fname = get_func_name(inner, "python")
+                rcls = _infer_return_class(inner, source)
+                if fname and rcls:
+                    types[fname] = rcls
         for c in n.children:
             _walk(c)
 
@@ -277,7 +288,7 @@ def _extract_recursive(
     definitions: list[dict[str, Any]],
     calls: list[dict[str, Any]],
     enclosing_class: str | None,
-    local_types: dict[str, str] | None,
+    local_types: dict[str, tuple[str, int]] | None,
     fixture_types: dict[str, str] | None = None,
 ) -> None:
     if not hasattr(node, "type"):
@@ -305,11 +316,12 @@ def _extract_recursive(
             )
             func_types = _collect_local_var_types(node, source, language)
             # pytest-fixture typing: a parameter named after a fixture function
-            # that returns a class gets that class's type.
+            # that returns a class gets that class's type. line 0 = valid for the
+            # whole function body (a parameter is bound on entry).
             if language == "python" and fixture_types:
                 for pname in _func_param_names(node, source):
                     if pname in fixture_types:
-                        func_types[pname] = fixture_types[pname]
+                        func_types[pname] = (fixture_types[pname], 0)
             for child in node.children:
                 _extract_recursive(
                     child,
@@ -328,9 +340,11 @@ def _extract_recursive(
         if call_info:
             recv = call_info.get("receiver")
             if local_types and recv in local_types:
-                cls = local_types[recv]
-                call_info["receiver_type"] = cls
-                call_info["full_name"] = f"{cls}.{call_info['name']}"
+                cls, bind_line = local_types[recv]
+                # flow-sensitive (P2): only type calls at/after the binding line
+                if (node.start_point[0] + 1) >= bind_line:
+                    call_info["receiver_type"] = cls
+                    call_info["full_name"] = f"{cls}.{call_info['name']}"
             calls.append(call_info)
 
     for child in node.children:

--- a/tree_sitter_analyzer/function_extraction.py
+++ b/tree_sitter_analyzer/function_extraction.py
@@ -150,7 +150,10 @@ def walk_tree(node: Any, source: str, language: str) -> tuple[list[dict], list[d
     """Walk an AST and return function definitions plus call sites."""
     definitions: list[dict[str, Any]] = []
     calls: list[dict[str, Any]] = []
-    _extract_recursive(node, source, language, definitions, calls, None, None)
+    fixture_types = _collect_fixture_types(node, source, language)
+    _extract_recursive(
+        node, source, language, definitions, calls, None, None, fixture_types
+    )
     return definitions, calls
 
 
@@ -191,6 +194,82 @@ def _collect_local_var_types(
     return types
 
 
+def _func_param_names(func_node: Any, source: str) -> list[str]:
+    """Parameter identifier names of a Python function def."""
+    params = func_node.child_by_field_name("parameters")
+    if params is None:
+        return []
+    names: list[str] = []
+    for c in params.children:
+        if c.type == "identifier":
+            names.append(_node_text(c, source))
+        elif c.type in (
+            "typed_parameter",
+            "default_parameter",
+            "typed_default_parameter",
+        ):
+            for sub in c.children:
+                if sub.type == "identifier":
+                    names.append(_node_text(sub, source))
+                    break
+    return names
+
+
+def _infer_return_class(func_node: Any, source: str) -> str | None:
+    """Infer the class a Python function returns: ``return ClassName(...)`` or
+    ``v = ClassName(...); return v``. Used for pytest-fixture return types."""
+    local = _collect_local_var_types(func_node, source, "python")
+    result: str | None = None
+
+    def _walk(n: Any) -> None:
+        nonlocal result
+        if getattr(n, "type", None) == "return_statement":
+            for c in n.children:
+                if c.type == "call":
+                    fn = c.child_by_field_name("function")
+                    if fn is not None and fn.type == "identifier":
+                        cls = _node_text(fn, source)
+                        if cls and cls[0].isupper():
+                            result = cls
+                elif c.type == "identifier":
+                    v = _node_text(c, source)
+                    if v in local:
+                        result = local[v]
+        for ch in n.children:
+            _walk(ch)
+
+    _walk(func_node)
+    return result
+
+
+def _collect_fixture_types(
+    module_node: Any, source: str, language: str
+) -> dict[str, str]:
+    """RFC-0002: map function name → returned class, for pytest-fixture typing.
+
+    A pytest test parameter is named after a fixture function; if that fixture
+    returns ``ClassName(...)``, the test's parameter has that type. This is the
+    dominant test pattern (``def tool(): return SearchContentTool()`` +
+    ``def test(self, tool): tool.execute()`` → tool: SearchContentTool). Static,
+    no runtime. Python only.
+    """
+    if language != "python":
+        return {}
+    types: dict[str, str] = {}
+
+    def _walk(n: Any) -> None:
+        if getattr(n, "type", None) == "function_definition":
+            fname = get_func_name(n, "python")
+            rcls = _infer_return_class(n, source)
+            if fname and rcls:
+                types[fname] = rcls
+        for c in n.children:
+            _walk(c)
+
+    _walk(module_node)
+    return types
+
+
 def _extract_recursive(
     node: Any,
     source: str,
@@ -199,6 +278,7 @@ def _extract_recursive(
     calls: list[dict[str, Any]],
     enclosing_class: str | None,
     local_types: dict[str, str] | None,
+    fixture_types: dict[str, str] | None = None,
 ) -> None:
     if not hasattr(node, "type"):
         return
@@ -224,6 +304,12 @@ def _extract_recursive(
                 }
             )
             func_types = _collect_local_var_types(node, source, language)
+            # pytest-fixture typing: a parameter named after a fixture function
+            # that returns a class gets that class's type.
+            if language == "python" and fixture_types:
+                for pname in _func_param_names(node, source):
+                    if pname in fixture_types:
+                        func_types[pname] = fixture_types[pname]
             for child in node.children:
                 _extract_recursive(
                     child,
@@ -233,6 +319,7 @@ def _extract_recursive(
                     calls,
                     parent_class,
                     func_types,
+                    fixture_types,
                 )
             return
 
@@ -248,7 +335,14 @@ def _extract_recursive(
 
     for child in node.children:
         _extract_recursive(
-            child, source, language, definitions, calls, enclosing_class, local_types
+            child,
+            source,
+            language,
+            definitions,
+            calls,
+            enclosing_class,
+            local_types,
+            fixture_types,
         )
 
 

--- a/tree_sitter_analyzer/function_extraction.py
+++ b/tree_sitter_analyzer/function_extraction.py
@@ -150,8 +150,45 @@ def walk_tree(node: Any, source: str, language: str) -> tuple[list[dict], list[d
     """Walk an AST and return function definitions plus call sites."""
     definitions: list[dict[str, Any]] = []
     calls: list[dict[str, Any]] = []
-    _extract_recursive(node, source, language, definitions, calls, None)
+    _extract_recursive(node, source, language, definitions, calls, None, None)
     return definitions, calls
+
+
+def _collect_local_var_types(
+    func_node: Any, source: str, language: str
+) -> dict[str, str]:
+    """RFC-0002: infer local variable types from ``var = ClassName(...)``.
+
+    Static receiver-type inference (no runtime): a same-function assignment whose
+    right side constructs a CapitalizedName (PEP8 class convention) binds the
+    left identifier to that class. Lets ``pg = ProjectGraph(); pg.execute()``
+    resolve ``execute`` to ``ProjectGraph.execute`` — disambiguating non-unique
+    methods. Python only for v1.
+    """
+    if language != "python":
+        return {}
+    types: dict[str, str] = {}
+
+    def _walk(n: Any) -> None:
+        if getattr(n, "type", None) == "assignment":
+            left = n.child_by_field_name("left")
+            right = n.child_by_field_name("right")
+            if (
+                left is not None
+                and right is not None
+                and left.type == "identifier"
+                and right.type == "call"
+            ):
+                fn = right.child_by_field_name("function")
+                if fn is not None and fn.type == "identifier":
+                    cls = _node_text(fn, source)
+                    if cls and cls[0].isupper():
+                        types[_node_text(left, source)] = cls
+        for c in n.children:
+            _walk(c)
+
+    _walk(func_node)
+    return types
 
 
 def _extract_recursive(
@@ -161,6 +198,7 @@ def _extract_recursive(
     definitions: list[dict[str, Any]],
     calls: list[dict[str, Any]],
     enclosing_class: str | None,
+    local_types: dict[str, str] | None,
 ) -> None:
     if not hasattr(node, "type"):
         return
@@ -185,19 +223,33 @@ def _extract_recursive(
                     "class": parent_class,
                 }
             )
+            func_types = _collect_local_var_types(node, source, language)
             for child in node.children:
                 _extract_recursive(
-                    child, source, language, definitions, calls, parent_class
+                    child,
+                    source,
+                    language,
+                    definitions,
+                    calls,
+                    parent_class,
+                    func_types,
                 )
             return
 
     if node_type in _CALL_NODE_TYPES.get(language, set()):
         call_info = extract_call(node, source, language)
         if call_info:
+            recv = call_info.get("receiver")
+            if local_types and recv in local_types:
+                cls = local_types[recv]
+                call_info["receiver_type"] = cls
+                call_info["full_name"] = f"{cls}.{call_info['name']}"
             calls.append(call_info)
 
     for child in node.children:
-        _extract_recursive(child, source, language, definitions, calls, enclosing_class)
+        _extract_recursive(
+            child, source, language, definitions, calls, enclosing_class, local_types
+        )
 
 
 def get_func_name(node: Any, language: str) -> str | None:

--- a/tree_sitter_analyzer/incremental_sync.py
+++ b/tree_sitter_analyzer/incremental_sync.py
@@ -35,6 +35,7 @@ class SyncResult:
     deleted_files: int = 0
     unchanged_files: int = 0
     errors: int = 0
+    synapse_resolved: int = 0
     details: list[dict[str, Any]] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
@@ -46,6 +47,7 @@ class SyncResult:
             "deleted_files": self.deleted_files,
             "unchanged_files": self.unchanged_files,
             "errors": self.errors,
+            "synapse_resolved": self.synapse_resolved,
             "details": self.details,
         }
 
@@ -97,6 +99,24 @@ class IncrementalSync:
         self._index_or_reindex_files(disk_files, indexed_rows, conn, result, callback)
 
         conn.commit()
+
+        # Synapse second pass: per-file resolution during indexing sees an
+        # incomplete file_class_methods (other files not yet indexed), so
+        # cross-file / receiver-typed callees stay 'unknown'. Re-resolve all
+        # unknown edges now that the whole project is indexed — this is what
+        # turns static type inference (self/unique-method/assignment/fixture/
+        # class-method) into actual resolved edges. Measured: unknown 65.8%→24.0%
+        # (resolved 47k). Only run when something changed (skip no-op syncs).
+        if result.new_files or result.updated_files or result.deleted_files:
+            try:
+                backfill = getattr(self._cache, "_run_synapse_backfill", None)
+                if callable(backfill):
+                    stats = backfill()
+                    if stats is not None:
+                        result.synapse_resolved = int(stats.get("resolved", 0))
+            except Exception:  # pragma: no cover - backfill is best-effort
+                pass
+
         return result
 
     @staticmethod

--- a/tree_sitter_analyzer/synapse_resolver/__init__.py
+++ b/tree_sitter_analyzer/synapse_resolver/__init__.py
@@ -228,6 +228,29 @@ def _try_single_global(
     return None
 
 
+def _try_class_method(
+    base: str, qualifier: str, ctx: ResolverContext
+) -> ResolvedCallee | None:
+    """RFC-0002: receiver-type-aware method resolution.
+
+    When the qualifier is a KNOWN CLASS NAME (the extractor inferred the
+    receiver's type from a ``var = ClassName(...)`` assignment and rewrote the
+    callee as ``ClassName.method``), resolve ``base`` to that class's method.
+    This is what disambiguates NON-unique methods (e.g. ``execute`` defined on
+    many classes) that ``_try_unique_method`` deliberately leaves unknown — the
+    receiver type pins down which class.
+    """
+    if not qualifier:
+        return None
+    for file_path, classes in ctx.file_class_methods.items():
+        methods = classes.get(qualifier)
+        if methods is not None:
+            sym_id = methods.get(base)
+            if sym_id is not None:
+                return ResolvedCallee(sym_id, "project", file_path)
+    return None
+
+
 def _try_unique_method(
     base: str, qualifier: str, ctx: ResolverContext
 ) -> ResolvedCallee | None:
@@ -320,6 +343,7 @@ def _resolve_callee_python(
         lambda: _try_stdlib(base, qualifier, caller_file, ctx),
         lambda: _try_builtin(base, qualifier, ctx),
         lambda: _try_single_global(base, qualifier, ctx),
+        lambda: _try_class_method(base, qualifier, ctx),
         lambda: _try_unique_method(base, qualifier, ctx),
     ):
         out = rule()

--- a/tree_sitter_analyzer/synapse_resolver/__init__.py
+++ b/tree_sitter_analyzer/synapse_resolver/__init__.py
@@ -242,12 +242,23 @@ def _try_class_method(
     """
     if not qualifier:
         return None
+    # P2 (Codex): a class name may be defined in multiple modules (Client,
+    # Config, Handler...). Picking the first match could resolve to the wrong
+    # module. Only resolve when the (class, method) is unique project-wide;
+    # otherwise stay unknown rather than guess the wrong file.
+    found: tuple[str, int] | None = None
     for file_path, classes in ctx.file_class_methods.items():
         methods = classes.get(qualifier)
-        if methods is not None:
-            sym_id = methods.get(base)
-            if sym_id is not None:
-                return ResolvedCallee(sym_id, "project", file_path)
+        if methods is None:
+            continue
+        sym_id = methods.get(base)
+        if sym_id is None:
+            continue
+        if found is not None and (file_path, sym_id) != found:
+            return None  # duplicate class name across modules — ambiguous
+        found = (file_path, sym_id)
+    if found is not None:
+        return ResolvedCallee(found[1], "project", found[0])
     return None
 
 


### PR DESCRIPTION
## Result
On TSA self (112k call edges): **callee resolution 34% → 76%, unknown 65.8% → 24.0%** (47045 edges newly resolved, 4s, **purely static — no runtime**). Implements RFC-0002 (#273).

## The chain (static type inference, mypy/pyright-style)
1. self-method via callee_full + unique-method (already merged #274)
2. assignment type inference: `pg = ProjectGraph(); pg.execute()` → `ProjectGraph.execute` (function-scoped, PEP8 Cap=class)
3. class-method resolution: qualifier is a known class → resolve to that class's method (disambiguates non-unique `execute`, on 83 classes)
4. pytest-fixture/return-type inference: `def tool(): return SearchContentTool()` + `def test(tool): tool.execute()` → `SearchContentTool.execute` (dominant test pattern, 1181 calls)

## THE root-cause fix
`IncrementalSync.sync()` **never ran the synapse 2nd pass**. Per-file resolution during indexing sees an incomplete `file_class_methods` (other files unindexed), so cross-file / receiver-typed callees stayed `unknown` — **burying all the type-inference work** (earlier measurements showed ~0pp and I nearly mis-concluded the inference was useless). sync() now runs `_run_synapse_backfill()` after indexing (only when files changed).

## Honest ceiling
Remaining 24% unknown is the genuinely-hard static cases (deep duck-typed receivers where the receiver is a function return value, dynamic getattr). Next static methods: param annotations, self-attribute types, cross-file conftest fixtures.

## Tests
119 green (resolver + assignment/fixture inference + incremental_sync). ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
