### PR TITLE
test: efficiency + coverage (dogfood) — kill 277s test, cover JSON plugin

### DIFF
--- a/tests/unit/languages/test_json_plugin.py
+++ b/tests/unit/languages/test_json_plugin.py
@@ -1,0 +1,90 @@
+"""Unit tests for the JSON language plugin (json_plugin.py).
+
+json_plugin had ~17% unit coverage: it has a golden-corpus test (high-level
+output match) but no unit tests exercising the extractor's element-type logic.
+tree-sitter-json is a core dependency, so these run on every platform.
+"""
+
+from __future__ import annotations
+
+import tree_sitter
+
+from tree_sitter_analyzer.languages.json_plugin import JSONPlugin
+
+
+def _parse(code: str) -> tuple[tree_sitter.Tree, JSONPlugin]:
+    plugin = JSONPlugin()
+    parser = tree_sitter.Parser(plugin.get_tree_sitter_language())
+    return parser.parse(code.encode("utf-8")), plugin
+
+
+class TestJSONExtraction:
+    def test_extract_elements_returns_json_elements_bucket(self) -> None:
+        code = '{"name": "demo"}'
+        tree, plugin = _parse(code)
+        els = plugin.create_extractor().extract_elements(tree, code)
+        assert "json_elements" in els
+        assert len(els["json_elements"]) > 0
+
+    def test_extracts_pairs_with_key_names(self) -> None:
+        code = '{"name": "demo", "count": 42}'
+        tree, plugin = _parse(code)
+        elements = plugin.create_extractor().extract_json_elements(tree, code)
+        pair_names = {e.name for e in elements if e.element_type == "pair"}
+        assert {"name", "count"} <= pair_names
+
+    def test_extracts_value_types(self) -> None:
+        code = '{"s": "x", "n": 1, "b": true, "z": null}'
+        tree, plugin = _parse(code)
+        elements = plugin.create_extractor().extract_json_elements(tree, code)
+        types = {e.element_type for e in elements}
+        # object + pair + the scalar value node types
+        assert "object" in types
+        assert "pair" in types
+        assert "string" in types
+        assert "number" in types
+
+    def test_nested_object_is_extracted(self) -> None:
+        code = '{"outer": {"inner": 1}}'
+        tree, plugin = _parse(code)
+        elements = plugin.create_extractor().extract_json_elements(tree, code)
+        object_count = sum(1 for e in elements if e.element_type == "object")
+        assert object_count >= 2  # outer + inner
+        pair_names = {e.name for e in elements if e.element_type == "pair"}
+        assert {"outer", "inner"} <= pair_names
+
+    def test_array_is_extracted(self) -> None:
+        code = '{"items": [1, 2, 3]}'
+        tree, plugin = _parse(code)
+        elements = plugin.create_extractor().extract_json_elements(tree, code)
+        types = {e.element_type for e in elements}
+        assert "array" in types
+
+    def test_empty_object_does_not_crash(self) -> None:
+        code = "{}"
+        tree, plugin = _parse(code)
+        elements = plugin.create_extractor().extract_json_elements(tree, code)
+        # one object element, no pairs
+        assert all(e.element_type != "pair" for e in elements)
+
+    def test_extract_with_none_tree_returns_empty(self) -> None:
+        plugin = JSONPlugin()
+        elements = plugin.create_extractor().extract_json_elements(None, "")
+        assert elements == []
+
+
+class TestJSONPluginMetadata:
+    def test_language_name(self) -> None:
+        assert JSONPlugin().get_language_name() == "json"
+
+    def test_file_extensions(self) -> None:
+        assert ".json" in JSONPlugin().get_file_extensions()
+
+    def test_is_applicable(self) -> None:
+        plugin = JSONPlugin()
+        assert plugin.is_applicable("config.json") is True
+        assert plugin.is_applicable("script.py") is False
+
+    def test_create_extractor_is_fresh_instance(self) -> None:
+        plugin = JSONPlugin()
+        assert plugin.create_extractor() is not None

--- a/tests/unit/security/_test_mcp_security_helpers.py
+++ b/tests/unit/security/_test_mcp_security_helpers.py
@@ -202,14 +202,20 @@ async def assert_external_path_blocked_or_temp_allowed(
     tool: FindAndGrepTool, external_path: str
 ) -> None:
     """Assert an external root is blocked unless it is an allowed temp path."""
+    # Allowed-temp paths pass by the pure predicate. Short-circuit BEFORE running
+    # the tool: every path in this suite lives under the system temp dir, so the
+    # old code actually ran FindAndGrep over huge dirs like /tmp (~277s) only to
+    # discard the result and return on the temp check below. The search never
+    # affected the assertion — skip it.
+    if path_is_allowed_temp(external_path):
+        return
+
     try:
         result = await tool.execute({"roots": [external_path], "query": "test"})
     except (SecurityError, ValidationError, ValueError, AnalysisError):
         return
 
     if isinstance(result, dict) and not result.get("success", True):
-        return
-    if path_is_allowed_temp(external_path):
         return
 
     pytest.fail(f"Expected security block for external path: {external_path}")

--- a/tests/unit/test_file_watcher.py
+++ b/tests/unit/test_file_watcher.py
@@ -1,6 +1,5 @@
 """Tests for FileWatcherDaemon (file_watcher module)."""
 
-
 import os
 import time
 
@@ -8,6 +7,21 @@ import pytest
 
 from tree_sitter_analyzer.ast_cache import ASTCache
 from tree_sitter_analyzer.file_watcher import FileWatcherDaemon
+
+
+def _wait_until(predicate, timeout: float = 3.0, interval: float = 0.05) -> bool:
+    """Poll predicate until true or timeout. Returns the final predicate value.
+
+    Replaces fixed time.sleep() waits for watcher events: returns as soon as the
+    condition holds (typically ~1 poll interval) instead of always blocking for
+    the worst-case duration.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return bool(predicate())
 
 
 @pytest.fixture
@@ -94,19 +108,18 @@ class TestPollingDetection:
         watcher.trigger_sync()
         (project / "new_file.py").write_text("def world():\n    pass\n")
         watcher.start()
-        time.sleep(3.0)
+        _wait_until(lambda: cache.get_stats()["total_files"] >= 2)
         watcher.stop()
         stats = cache.get_stats()
         assert stats["total_files"] >= 2
 
     def test_detects_modified_file(self, watcher, project, cache):
         watcher.trigger_sync()
-        time.sleep(0.1)
         py_file = project / "src" / "main.py"
         py_file.write_text("def hello():\n    return 42\n")
         os.utime(str(py_file), (time.time() + 1, time.time() + 1))
         watcher.start()
-        time.sleep(3.0)
+        _wait_until(lambda: watcher.get_stats()["syncs_triggered"] >= 1)
         watcher.stop()
         stats = watcher.get_stats()
         assert stats["syncs_triggered"] >= 1


### PR DESCRIPTION
## What

dogfood: used TSA's own `--durations` + coverage to find the suite's biggest time sink and a real coverage gap. Focused on test efficiency + effective coverage.

## Efficiency

**Killed a 277s unit test (now 1.1s).** `--durations` on the full unit suite showed `test_project_root_enforcement` at **277s** (the single biggest sink, run on every regular CI — no `slow` marker). Root cause: `assert_external_path_blocked_or_temp_allowed` ran `FindAndGrep` over each external root — **including the system `/tmp` and the pytest temp parent dirs** — *before* checking `path_is_allowed_temp`. Every path in the suite is under the temp dir, so the search result was always discarded; it walked huge system dirs for nothing. Fix: short-circuit on the pure `path_is_allowed_temp` predicate before running the tool. **277s → 1.1s.**

**Watcher fixed sleeps → polling.** The two file-watcher tests each blocked a fixed 3.0s waiting for events. Replaced with a `_wait_until()` polling helper that returns as soon as the condition holds (3s safety timeout). ~6s → ~2.5s, and less flaky on slow CI.

## Coverage

**JSON plugin extractor 17% → 78%.** `json_plugin.py` had a golden-corpus test but no unit tests for its element-type logic (and `golden_masters/plugins/` covers 17 languages but not JSON). Added 11 tests for pair/value-type/nested/array extraction + metadata. tree-sitter-json is a core dep, so these run on every platform.

## Deliberately not changed

- **middleware_detector whole-repo tests (~15s):** already marked `@pytest.mark.slow` + `slow_ok` with "intentionally crosses 5s" — a deliberate whole-repo integration check, excluded from the regular matrix. Left as-is (distinguishing *intentional* slow from *wasteful* slow).
- **cache TTL `sleep(1.1)` ×8:** these genuinely wait for a 1s TTL to expire; polling doesn't apply. Left as-is.
- **bash_plugin (17%):** low coverage is because `tree-sitter-bash` isn't installed (optional language), not a real gap — covering it would just skip where the lib is absent.

## Verification
- All changed/new tests green (45 + 11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)