### PR TITLE
fix(test): watcher detection tests now actually verify detection (Codex P2 on #282)

### DIFF
--- a/tests/unit/test_file_watcher.py
+++ b/tests/unit/test_file_watcher.py
@@ -105,24 +105,35 @@ class TestWatcherStats:
 
 class TestPollingDetection:
     def test_detects_new_file(self, watcher, project, cache):
+        # The watcher snapshots the tree at start(), then detects later changes.
+        # So: start FIRST, let the initial snapshot settle, THEN create the file,
+        # and wait for the INCREMENT (>= 3). The previous version created the file
+        # before start() (already in the snapshot) and asserted >= 2 (true after
+        # trigger_sync regardless) — it never actually exercised detection.
         watcher.trigger_sync()
-        (project / "new_file.py").write_text("def world():\n    pass\n")
+        assert cache.get_stats()["total_files"] == 2
         watcher.start()
-        _wait_until(lambda: cache.get_stats()["total_files"] >= 2)
+        time.sleep(0.3)  # let the initial snapshot complete before mutating
+        (project / "new_file.py").write_text("def world():\n    pass\n")
+        detected = _wait_until(lambda: cache.get_stats()["total_files"] >= 3)
         watcher.stop()
-        stats = cache.get_stats()
-        assert stats["total_files"] >= 2
+        assert detected, "watcher did not detect the newly created file"
+        assert cache.get_stats()["total_files"] >= 3
 
     def test_detects_modified_file(self, watcher, project, cache):
+        # Same ordering requirement: start (snapshot) -> modify -> wait for the
+        # SECOND sync (>= 2) caused by the modification.
         watcher.trigger_sync()
+        assert watcher.get_stats()["syncs_triggered"] == 1
+        watcher.start()
+        time.sleep(0.3)  # let the initial snapshot complete before mutating
         py_file = project / "src" / "main.py"
         py_file.write_text("def hello():\n    return 42\n")
         os.utime(str(py_file), (time.time() + 1, time.time() + 1))
-        watcher.start()
-        _wait_until(lambda: watcher.get_stats()["syncs_triggered"] >= 1)
+        detected = _wait_until(lambda: watcher.get_stats()["syncs_triggered"] >= 2)
         watcher.stop()
-        stats = watcher.get_stats()
-        assert stats["syncs_triggered"] >= 1
+        assert detected, "watcher did not detect the modified file"
+        assert watcher.get_stats()["syncs_triggered"] >= 2
 
 
 class TestOnSyncCallback:


### PR DESCRIPTION
## Follow-up to #282 — Codex P2 triage

Codex flagged two P2s on #282: my polling conversion left the `_wait_until` predicates already satisfied before the mutation, so the tests would pass even if detection broke. **Codex was right.**

## What I found (deeper than the flag)

Investigating revealed the **original** tests were *doubly* fake — they never verified watcher detection at all:

1. **Wrong order**: they created/modified the file *before* `start()`. But `_run_polling()` takes a tree snapshot at `start()` and only detects *later* changes — so the mutation was already in the baseline and never seen.
2. **Always-true assertion**: `total_files >= 2` / `syncs >= 1` are already satisfied by `trigger_sync()`.

So the original `sleep(3.0)` tests burned 6s asserting nothing. My #282 change kept the fakeness while making it faster — Codex caught it.

## Fix

`start()` first → let the snapshot settle → **then** mutate → wait/assert on the **increment** (`total_files >= 3`, `syncs >= 2`) with an explicit `detected` assertion. Verified the watcher genuinely reaches these (manual repro + 3× stable runs, ~3.5s). The tests now exercise real detection for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)