### PR TITLE
fix(index): exclude build dirs (bin/obj/packages/target) — index full hang on C#/Java

### DIFF
--- a/tree_sitter_analyzer/_ast_extraction.py
+++ b/tree_sitter_analyzer/_ast_extraction.py
@@ -14,6 +14,7 @@ import os
 import sqlite3
 from typing import Any
 
+from .constants import EXCLUDE_DIRS
 from .core.parser import Parser
 
 # ---------------------------------------------------------------------------
@@ -40,32 +41,10 @@ def _has_fts5(conn: sqlite3.Connection) -> bool:
 # File-walk constants
 # ---------------------------------------------------------------------------
 
-_EXCLUDE_DIRS = frozenset(
-    {
-        "node_modules",
-        ".git",
-        ".hg",
-        ".svn",
-        "__pycache__",
-        ".venv",
-        "venv",
-        ".tox",
-        ".mypy_cache",
-        ".pytest_cache",
-        ".ruff_cache",
-        "dist",
-        "build",
-        "htmlcov",
-        ".cache",
-        ".eggs",
-        ".idea",
-        ".vscode",
-        ".claude",
-        ".swarm",
-        ".claude-flow",
-        ".opencode",
-    }
-)
+# Shared exclude set (incl. C#/Java/Rust/Go build-artifact dirs) — see
+# constants.EXCLUDE_DIRS. Indexing must skip bin/obj/packages/target/etc or
+# `index full` hangs on compiled-language projects.
+_EXCLUDE_DIRS = EXCLUDE_DIRS
 
 
 # ---------------------------------------------------------------------------

--- a/tree_sitter_analyzer/constants.py
+++ b/tree_sitter_analyzer/constants.py
@@ -92,3 +92,70 @@ def is_element_of_type(element: Any, element_type: str) -> bool:
         True if element is of the specified type
     """
     return get_element_type(element) == element_type
+
+
+# ---------------------------------------------------------------------------
+# Directories excluded from filesystem walks (indexing, health scoring, graph
+# analysis). Shared so every walker agrees — previously each module defined its
+# own near-duplicate set and they drifted.
+#
+# Covers VCS, language caches, AND build-artifact dirs for COMPILED languages
+# (C#/.NET, Java, Rust, Go, Swift, C++). These hold generated/compiled output
+# that must never be indexed and can be enormous: a C# project's bin/obj or a
+# NuGet `packages/` dir makes `index full` appear to hang on an otherwise small
+# project. (Dot-prefixed dirs like .vs/.git are skipped separately via a
+# `name.startswith(".")` check at each call site, so they are not all listed.)
+# ---------------------------------------------------------------------------
+EXCLUDE_DIRS: frozenset[str] = frozenset(
+    {
+        # Version control
+        ".git",
+        ".hg",
+        ".svn",
+        # Python caches / envs
+        "__pycache__",
+        ".venv",
+        "venv",
+        ".tox",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".eggs",
+        "htmlcov",
+        ".cache",
+        # JS / TS
+        "node_modules",
+        ".next",
+        ".nuxt",
+        "bower_components",
+        # Build artifacts — compiled languages (the index-full hang fix)
+        "bin",  # C#/.NET, also generic
+        "obj",  # C#/.NET
+        "packages",  # C#/.NET (NuGet)
+        "target",  # Rust, Java (Maven)
+        ".gradle",  # Java (Gradle)
+        "vendor",  # Go, PHP
+        "Pods",  # Swift / iOS (CocoaPods)
+        "DerivedData",  # Swift / Xcode
+        "cmake-build-debug",  # C++ (CLion)
+        "cmake-build-release",  # C++ (CLion)
+        # Generic build output
+        "dist",
+        "build",
+        "out",
+        # Editors / IDE
+        ".idea",
+        ".vscode",
+        ".vs",
+        # AI tooling
+        ".claude",
+        ".swarm",
+        ".claude-flow",
+        ".opencode",
+        ".agents",
+        ".recon",
+        # TSA's own caches
+        ".ast-cache",
+        ".tree-sitter-cache",
+    }
+)

--- a/tree_sitter_analyzer/health_scorer.py
+++ b/tree_sitter_analyzer/health_scorer.py
@@ -24,6 +24,7 @@ from ._health_scorer_helpers import (
     read_source_file,
     round_available_scores,
 )
+from .constants import EXCLUDE_DIRS
 from .core.parser import Parser
 
 logger = logging.getLogger(__name__)
@@ -417,26 +418,10 @@ class HealthScorer:
     # unit test that explicitly scores a fixture sub-tree
     # (e.g. ``score_project(tests/fixtures/project_graph/health_project)``)
     # is not broken by the broader project-level filter.
-    _EXCLUDE_DIRS = {
-        "node_modules",
-        ".git",
-        ".hg",
-        ".svn",
-        "__pycache__",
-        ".venv",
-        "venv",
-        ".tox",
-        ".mypy_cache",
-        ".pytest_cache",
-        ".ruff_cache",
-        "dist",
-        "build",
-        "htmlcov",
-        ".cache",
-        ".eggs",
-        ".idea",
-        ".vscode",
-        ".claude",
+    # Shared build/cache excludes (constants.EXCLUDE_DIRS — incl. C#/Java/Rust
+    # bin/obj/packages/target) PLUS health-scoring-specific excludes (test data
+    # / fixtures must not count toward a project's code-quality grade).
+    _EXCLUDE_DIRS = EXCLUDE_DIRS | {
         "golden_masters",
         "golden",
         "fixtures",

--- a/tree_sitter_analyzer/project_graph.py
+++ b/tree_sitter_analyzer/project_graph.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any
 
+from .constants import EXCLUDE_DIRS
 from .core.parser import Parser, ParseResult
 from .import_extractors import (
     walk_imports,
@@ -411,27 +412,8 @@ class DependencyGraph:
         fp = compute_graph_fingerprint(project_root)
         return f"{project_root}:{fp.file_count}:{fp.max_mtime_ns}"
 
-    _EXCLUDE_DIRS = {
-        "node_modules",
-        ".git",
-        ".hg",
-        ".svn",
-        "__pycache__",
-        ".venv",
-        "venv",
-        ".tox",
-        ".mypy_cache",
-        ".pytest_cache",
-        ".ruff_cache",
-        "dist",
-        "build",
-        "htmlcov",
-        ".cache",
-        ".eggs",
-        ".idea",
-        ".vscode",
-        ".claude",
-    }
+    # Shared exclude set (incl. C#/Java/Rust build dirs) — constants.EXCLUDE_DIRS
+    _EXCLUDE_DIRS = EXCLUDE_DIRS
 
     def _is_excluded(self, path: Path) -> bool:
         """Check if a path is inside an excluded directory."""


### PR DESCRIPTION
## Bug (real user report)

A user running TSA via **VS Code + Copilot on a Windows C# project** reported `index full` **never finishes** on an otherwise small project.

## Root cause

The filesystem-walk exclude sets did not include compiled-language **build dirs**. `.vs`/`.git` are skipped via the `name.startswith('.')` check, but `bin`/`obj`/`packages`/`target`/`.gradle`/`vendor`/`Pods` are **not dot-prefixed** and were walked. A C# `bin`/`obj` or NuGet `packages/` dir holds huge generated/compiled output → indexing appears to hang.

Secondary issue: `_EXCLUDE_DIRS` was **duplicated across 12+ modules** and had drifted (6–23 entries each).

## Fix

- New shared **`constants.EXCLUDE_DIRS`**: VCS + language caches + build artifacts for C#/.NET, Java, Rust, Go, Swift, C++.
- Switched the three filesystem walkers users actually hit to it: **index** (`_ast_extraction`), **health scoring** (`health_scorer`), **project graph** (`project_graph`). `health_scorer` keeps its extra test-data excludes via set union.

## Verification

Mock C# project with `src/app.cs` + `bin/` + `obj/` + `packages/` → index now picks up **only `src/app.cs`**. 139 related tests green; ruff clean.

Remaining 9 `_EXCLUDE_DIRS` copies (call_graph, dead_code, etc.) can migrate to the shared constant in a follow-up — they're not on the user's index-full path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)