### PR TITLE
fix(index): Codex P2s on #286 — preserve Rust src/bin, sync graph fingerprint excludes

### DIFF
--- a/tree_sitter_analyzer/_graph_cache_fingerprint.py
+++ b/tree_sitter_analyzer/_graph_cache_fingerprint.py
@@ -25,34 +25,15 @@ import os
 from collections.abc import Iterable
 from typing import NamedTuple
 
-# Mirrors the EXCLUDE_DIRS used by CallGraph and DependencyGraph so the
-# fingerprint scope matches the graphs being invalidated.
-_EXCLUDE_DIRS: frozenset[str] = frozenset(
-    {
-        "node_modules",
-        ".git",
-        ".hg",
-        ".svn",
-        "__pycache__",
-        ".venv",
-        "venv",
-        ".tox",
-        ".mypy_cache",
-        ".pytest_cache",
-        ".ruff_cache",
-        "dist",
-        "build",
-        "htmlcov",
-        ".cache",
-        ".eggs",
-        ".idea",
-        ".vscode",
-        ".claude",
-        # Project-specific caches that produce churn but aren't source.
-        ".ast-cache",
-        ".tree-sitter-cache",
-    }
-)
+from .constants import EXCLUDE_DIRS
+
+# Use the shared exclude set so the fingerprint scope matches the graph walkers
+# being invalidated — and, critically, so fingerprinting (which runs BEFORE the
+# graph build) also skips build-artifact trees (target/obj/packages/...). Codex
+# P2 on #286: previously this had its own list without build dirs, so dependency
+# fingerprinting still descended huge build trees and the hang persisted on
+# graph/dependency paths. EXCLUDE_DIRS already includes .ast-cache/.tree-sitter-cache.
+_EXCLUDE_DIRS: frozenset[str] = EXCLUDE_DIRS
 
 # Source file extensions handled by call_graph + project_graph + most plugins.
 # We cast a wide net so the same fingerprint can serve every graph kind.

--- a/tree_sitter_analyzer/constants.py
+++ b/tree_sitter_analyzer/constants.py
@@ -128,9 +128,13 @@ EXCLUDE_DIRS: frozenset[str] = frozenset(
         ".next",
         ".nuxt",
         "bower_components",
-        # Build artifacts — compiled languages (the index-full hang fix)
-        "bin",  # C#/.NET, also generic
-        "obj",  # C#/.NET
+        # Build artifacts — compiled languages (the index-full hang fix).
+        # NOTE: "bin" is intentionally NOT here. Rust uses src/bin/*.rs for
+        # first-party binary-target SOURCES; excluding "bin" at any depth would
+        # prune them. C#/Eclipse "bin" holds .dll/.class (which TSA never indexes
+        # anyway); their generated SOURCES live in obj/ (C#) and target/ (Java),
+        # both excluded below — so dropping "bin" keeps the hang fixed.
+        "obj",  # C#/.NET (incl. obj/**/*.g.cs generated sources)
         "packages",  # C#/.NET (NuGet)
         "target",  # Rust, Java (Maven)
         ".gradle",  # Java (Gradle)


### PR DESCRIPTION
## Follow-up to #286 — Codex P2 triage

Codex flagged 2 P2s on #286 (both correct, both my oversight):

### P2#1 — Rust `src/bin/*.rs` false-exclude
Globally excluding `bin` pruned Rust's first-party **binary-target sources** (`src/bin/*.rs`) at any depth — CLI entrypoints vanished from index/graph/health. **Fix**: removed `bin` from `EXCLUDE_DIRS`. C#/Eclipse `bin` holds `.dll`/`.class` (TSA never indexes those), and their generated **sources** live in `obj/` (C#) and `target/` (Java) which stay excluded — so the index-full hang stays fixed while Rust sources are preserved.

### P2#2 — graph fingerprint out of sync
`compute_graph_fingerprint()` (called by `DependencyGraph.__new__` **before** `_build`) had its own exclude list without build dirs, so dependency fingerprinting still walked `target`/`obj` trees → hang persisted on graph/dependency paths. **Fix**: switched it to the shared `constants.EXCLUDE_DIRS`.

## Verification
Rust crate (`src/bin/cli.rs` + `src/lib.rs` + `target/`) → indexes both sources, excludes `target`. fingerprint now excludes `target`/`obj`/`packages`. 139 tests green, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)