### PR TITLE
fix(mcp): nav context resolves camelCase concept queries via substring cascade

### DIFF
--- a/tests/unit/test_codegraph_context_tool.py
+++ b/tests/unit/test_codegraph_context_tool.py
@@ -417,6 +417,48 @@ def test_resolve_entry_points_skips_cascade_when_fts_has_hits() -> None:
     assert "Engine" not in cascade_calls
 
 
+def test_resolve_entry_points_falls_back_when_fts_only_returns_imports() -> None:
+    """Cascade must run when FTS rows are non-empty but all UNUSABLE.
+
+    Codex P2 on #288: gating the fallback on ``raw_hits`` being non-empty is
+    wrong — FTS can return only ``kind == "import"`` rows, which ``_absorb``
+    discards, so the candidate adds no entry point yet the cascade is
+    suppressed and the query still ends NOT_FOUND, missing camelCase symbols.
+    The fallback must trigger on zero USABLE hits, not zero raw rows.
+    """
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        CodeGraphContextTool,
+    )
+
+    class ImportOnlyCache:
+        def fts_search_ranked(self, candidate: str, limit: int):
+            # Non-empty, but every row is an import → all discarded by _absorb.
+            return [
+                {"name": "route", "kind": "import", "file": "imp.go", "line": 1},
+                {"name": "", "kind": "function", "file": "x.go", "line": 2},
+            ]
+
+        def search_symbols_cascade(self, query: str, limit: int):
+            if query.lower() == "route":
+                return [
+                    {
+                        "name": "addRoute",
+                        "kind": "function",
+                        "file": "router.go",
+                        "line": 10,
+                    }
+                ]
+            return []
+
+    tool = CodeGraphContextTool(str(Path.cwd()))
+    tool._cache = ImportOnlyCache()
+
+    hits = tool._resolve_entry_points(["route"], limit=5)
+    names = {h["name"] for h in hits}
+
+    assert names == {"addRoute"}
+
+
 def test_expand_nodes_handles_graph_limits_and_trace_chain() -> None:
     from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
         CodeGraphContextTool,

--- a/tests/unit/test_codegraph_context_tool.py
+++ b/tests/unit/test_codegraph_context_tool.py
@@ -331,6 +331,92 @@ def test_resolve_entry_points_uses_compound_recall_for_multiword() -> None:
     assert names[0] == "applyIndexOperationOnPrimary"
 
 
+def test_resolve_entry_points_single_word_falls_back_to_substring_cascade() -> None:
+    """A plain concept word with NO FTS hits must fall back to the cascade.
+
+    Cost root cause: FTS5 tokenizes a camelCase identifier (``addRoute``) as
+    ONE token, so a natural-language word like ``route`` returns zero FTS
+    hits and the whole query collapses to NOT_FOUND — forcing the agent to
+    abandon the index and Read raw files (the gin file_r=5-vs-2 gap). The
+    resolver must run the substring cascade for any single word that FTS
+    cannot resolve, so ``route`` recalls {addRoute, updateRouteTree, ...}.
+    """
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        CodeGraphContextTool,
+    )
+
+    class CamelCaseCache:
+        def fts_search_ranked(self, candidate: str, limit: int):
+            # FTS5 whole-token match: the plain word never hits camelCase names.
+            return []
+
+        def search_symbols_cascade(self, query: str, limit: int):
+            if query.lower() == "route":
+                return [
+                    {
+                        "name": "addRoute",
+                        "kind": "function",
+                        "file": "router.go",
+                        "line": 10,
+                    },
+                    {
+                        "name": "updateRouteTree",
+                        "kind": "function",
+                        "file": "tree.go",
+                        "line": 20,
+                    },
+                ]
+            return []
+
+    tool = CodeGraphContextTool(str(Path.cwd()))
+    tool._cache = CamelCaseCache()
+
+    hits = tool._resolve_entry_points(["route"], limit=5)
+    names = {h["name"] for h in hits}
+
+    assert names == {"addRoute", "updateRouteTree"}
+
+
+def test_resolve_entry_points_skips_cascade_when_fts_has_hits() -> None:
+    """The substring cascade is a FALLBACK — it must not run when FTS hits.
+
+    Guards against double-querying (and over-broad substring noise) on the
+    common exact-match path: an exact symbol word that FTS resolves should
+    return the FTS hit without invoking the cascade at all.
+    """
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        CodeGraphContextTool,
+    )
+
+    cascade_calls: list[str] = []
+
+    class ExactCache:
+        def fts_search_ranked(self, candidate: str, limit: int):
+            return [
+                {
+                    "name": "Engine",
+                    "kind": "class",
+                    "file": "gin.go",
+                    "line": 1,
+                }
+            ]
+
+        def search_symbols_cascade(self, query: str, limit: int):
+            cascade_calls.append(query)
+            return [{"name": "EngineNoise", "kind": "class", "file": "x.go", "line": 9}]
+
+    tool = CodeGraphContextTool(str(Path.cwd()))
+    tool._cache = ExactCache()
+
+    hits = tool._resolve_entry_points(["Engine"], limit=5)
+    names = {h["name"] for h in hits}
+
+    # Single-word cascade NOT triggered for "Engine" (FTS already hit). The
+    # compound-recall tier never fires for a single candidate either.
+    assert "Engine" in names
+    assert "Engine" not in cascade_calls
+
+
 def test_expand_nodes_handles_graph_limits_and_trace_chain() -> None:
     from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
         CodeGraphContextTool,

--- a/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
@@ -235,7 +235,17 @@ class CodeGraphContextTool(BaseMCPTool):
                     if bm25_rank < entry["best_rank"]:
                         entry["best_rank"] = bm25_rank
 
-        # Single-word recall: FTS5 BM25 over each task word.
+        cascade = getattr(cache, "search_symbols_cascade", None)
+
+        # Single-word recall: FTS5 BM25 over each task word. When a word yields
+        # NO FTS hits, fall back to the substring cascade. This is the cost
+        # root cause: FTS5 tokenizes camelCase/compound identifiers as ONE
+        # token, so a natural-language word like ``route`` matches neither
+        # ``addRoute`` nor ``updateRouteTree``. Without this fallback the whole
+        # query returns NOT_FOUND and the agent abandons the index to Read raw
+        # files (the gin file_r=5-vs-2 gap). The substring cascade resolves
+        # ``route`` -> {addRoute, updateRouteTree, NoRoute, Routes}, so a
+        # conceptual query still returns inline source from the index.
         for candidate in candidates[:10]:
             try:
                 raw_hits = cache.fts_search_ranked(candidate, limit=fetch) or []
@@ -244,13 +254,17 @@ class CodeGraphContextTool(BaseMCPTool):
                     raw_hits = cache.fts_search(candidate, limit=fetch) or []
                 except Exception:
                     raw_hits = []
+            if not raw_hits and callable(cascade):
+                try:
+                    raw_hits = cascade(candidate, limit=fetch) or []
+                except Exception:
+                    raw_hits = []
             _absorb(raw_hits)
 
         # Compound recall: camelCase word pairs (applyIndex, indexOperation)
         # reach multi-word methods that single-word FTS tokenization misses —
         # the cascade substring tier resolves them. This is the fix for the
         # dogfood loss where 'apply' only matched generic same-name methods.
-        cascade = getattr(cache, "search_symbols_cascade", None)
         if callable(cascade):
             for compound in _compound_candidates(candidates):
                 try:

--- a/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
@@ -217,11 +217,21 @@ class CodeGraphContextTool(BaseMCPTool):
         fetch = max(limit * 3, limit)
         agg: dict[tuple[str, str, int], dict[str, Any]] = {}
 
-        def _absorb(raw_hits: list[Any]) -> None:
+        def _absorb(raw_hits: list[Any]) -> int:
+            """Merge raw hits into ``agg``; return the count of USABLE hits.
+
+            A usable hit is one that is not skipped (non-empty name, not an
+            ``import``). The count drives the cascade fallback below: raw FTS
+            rows may be non-empty yet entirely unusable (e.g. only import-path
+            rows), which would otherwise suppress the substring fallback and
+            still yield NOT_FOUND.
+            """
+            usable = 0
             for bm25_rank, raw in enumerate(raw_hits):
                 hit = _normalise_hit(raw)
                 if not hit["name"] or hit["kind"] == "import":
                     continue
+                usable += 1
                 key = (hit["name"], hit["file"], hit["line"])
                 entry = agg.get(key)
                 if entry is None:
@@ -234,11 +244,12 @@ class CodeGraphContextTool(BaseMCPTool):
                     entry["matches"] += 1
                     if bm25_rank < entry["best_rank"]:
                         entry["best_rank"] = bm25_rank
+            return usable
 
         cascade = getattr(cache, "search_symbols_cascade", None)
 
         # Single-word recall: FTS5 BM25 over each task word. When a word yields
-        # NO FTS hits, fall back to the substring cascade. This is the cost
+        # no USABLE hits, fall back to the substring cascade. This is the cost
         # root cause: FTS5 tokenizes camelCase/compound identifiers as ONE
         # token, so a natural-language word like ``route`` matches neither
         # ``addRoute`` nor ``updateRouteTree``. Without this fallback the whole
@@ -246,6 +257,11 @@ class CodeGraphContextTool(BaseMCPTool):
         # files (the gin file_r=5-vs-2 gap). The substring cascade resolves
         # ``route`` -> {addRoute, updateRouteTree, NoRoute, Routes}, so a
         # conceptual query still returns inline source from the index.
+        #
+        # The fallback is gated on USABLE hits, not raw FTS rows (Codex P2 on
+        # #288): FTS can return only ``kind == "import"`` rows that ``_absorb``
+        # discards — a non-empty-but-useless result that must NOT suppress the
+        # cascade.
         for candidate in candidates[:10]:
             try:
                 raw_hits = cache.fts_search_ranked(candidate, limit=fetch) or []
@@ -254,12 +270,12 @@ class CodeGraphContextTool(BaseMCPTool):
                     raw_hits = cache.fts_search(candidate, limit=fetch) or []
                 except Exception:
                     raw_hits = []
-            if not raw_hits and callable(cascade):
+            if _absorb(raw_hits) == 0 and callable(cascade):
                 try:
-                    raw_hits = cascade(candidate, limit=fetch) or []
+                    cascade_hits = cascade(candidate, limit=fetch) or []
                 except Exception:
-                    raw_hits = []
-            _absorb(raw_hits)
+                    cascade_hits = []
+                _absorb(cascade_hits)
 
         # Compound recall: camelCase word pairs (applyIndex, indexOperation)
         # reach multi-word methods that single-word FTS tokenization misses —


### PR DESCRIPTION
## Problem (cost)

`nav action=context` (codegraph_context) is meant to be the one-call answer that returns inline source so the agent never Reads raw files. But it tokenises a natural-language task into single words and resolves each via FTS5 BM25. **FTS5 indexes a camelCase/compound identifier (`addRoute`, `updateRouteTree`) as ONE token**, so a plain concept word like `route` matches nothing. The whole query collapses to `NOT_FOUND`, the agent abandons the index and Reads raw files — the gin dogfood gap (**tsa file_reads=5 vs codegraph=2**) and the root cause of TSA's higher per-task token cost.

## Fix

In `_resolve_entry_points`, when a single task word yields **zero** FTS hits, fall back to the existing `search_symbols_cascade` substring tier (already used for compound camelCase recall). `route` then recalls `{addRoute, updateRouteTree, NoRoute, Routes}` and the query returns `INFO` with inline source blocks. The cascade is a **fallback only** — it does not run when FTS already has hits, so the exact-symbol path is byte-for-byte unchanged.

## Dogfood evidence

| query | before | after |
|---|---|---|
| gin `route matching` | NOT_FOUND (0.6 KB) | INFO, 8 code blocks (20 KB) |
| gin `render response writer` | NOT_FOUND | INFO, 8 code blocks (30 KB) |
| TSA self `tool registry` | NOT_FOUND | INFO → `_create_tool_registry` |
| TSA self `edge store resolution` | NOT_FOUND | INFO → `EdgeStore`/`_build_edges_from_edge_store` |

Exact-symbol queries unchanged: `Engine`→2 blocks, `RouterGroup`→8 blocks.

## Tests

RED-first: `test_resolve_entry_points_single_word_falls_back_to_substring_cascade` (camelCase concept word resolves) + `test_resolve_entry_points_skips_cascade_when_fts_has_hits` (fallback not triggered on exact match). Full file 25/25 green; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)