### PR TITLE
fix(mcp): deprioritize test-file symbols in nav context ranking

### DIFF
--- a/tests/unit/test_codegraph_context_tool.py
+++ b/tests/unit/test_codegraph_context_tool.py
@@ -266,6 +266,67 @@ def test_name_match_score_counts_distinct_task_words() -> None:
     assert _name_match_score("", cands) == 0
 
 
+def test_is_test_file_detects_cross_language_test_paths() -> None:
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import _is_test_file
+
+    # Test files across languages → 1
+    assert _is_test_file("response_writer_test.go") == 1  # Go
+    assert _is_test_file("pkg/router_test.go") == 1
+    assert _is_test_file("foo.spec.ts") == 1  # TS
+    assert _is_test_file("src/app/foo.test.tsx") == 1
+    assert _is_test_file("tests/test_thing.py") == 1  # Python dir + prefix
+    assert _is_test_file("test_thing.py") == 1
+    assert _is_test_file("thing_test.py") == 1
+    assert _is_test_file("src/test/java/FooTest.java") == 1  # Maven layout
+    assert _is_test_file("__tests__/comp.jsx") == 1
+    assert _is_test_file("project/testdata/sample.go") == 1
+    # Production files → 0 (no false positives on test-like names)
+    assert _is_test_file("response_writer.go") == 0
+    assert _is_test_file("src/TestRunner.java") == 0  # production class
+    assert _is_test_file("latest.java") == 0  # not '*test.java' substring trap
+    assert _is_test_file("contest.py") == 0
+    assert _is_test_file("") == 0
+
+
+def test_entry_rank_v2_sinks_test_file_below_impl() -> None:
+    """A test-file hit must rank BELOW an implementation hit of equal relevance.
+
+    Concept queries whose substring-cascade lands in Go ``*_test.go`` (or
+    ``*.spec.ts`` etc.) used to surface ``TestResponseWriterWrite`` above the
+    real ``ResponseWriter`` because is_test only matched ``/tests/`` paths.
+    """
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        CodeGraphContextTool,
+    )
+
+    class TestVsImplCache:
+        def fts_search_ranked(self, candidate: str, limit: int):
+            # Test symbol has the STRONGER name match, but lives in a test file;
+            # the impl must still win on the non-test tier.
+            return [
+                {
+                    "name": "TestResponseWriterWrite",
+                    "kind": "function",
+                    "file": "response_writer_test.go",
+                    "line": 10,
+                },
+                {
+                    "name": "ResponseWriter",
+                    "kind": "class",
+                    "file": "response_writer.go",
+                    "line": 20,
+                },
+            ]
+
+    tool = CodeGraphContextTool(str(Path.cwd()))
+    tool._cache = TestVsImplCache()
+
+    hits = tool._resolve_entry_points(["ResponseWriter"], limit=5)
+
+    assert hits[0]["name"] == "ResponseWriter"
+    assert hits[0]["file"] == "response_writer.go"
+
+
 def test_compound_candidates_builds_camelcase_word_pairs() -> None:
     from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
         _compound_candidates,

--- a/tests/unit/test_codegraph_context_tool.py
+++ b/tests/unit/test_codegraph_context_tool.py
@@ -327,6 +327,64 @@ def test_entry_rank_v2_sinks_test_file_below_impl() -> None:
     assert hits[0]["file"] == "response_writer.go"
 
 
+def test_task_wants_tests_detects_test_intent() -> None:
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        _task_wants_tests,
+    )
+
+    assert _task_wants_tests("response writer tests") is True
+    assert _task_wants_tests("how is routing tested") is True
+    assert _task_wants_tests("the spec for the parser") is True
+    assert _task_wants_tests("router benchmark") is True
+    # No test intent → False (and no false positive on 'latest'/'contest').
+    assert _task_wants_tests("how does route matching work") is False
+    assert _task_wants_tests("latest contest results parser") is False
+    assert _task_wants_tests("") is False
+
+
+def test_resolve_entry_points_keeps_tests_when_task_wants_tests() -> None:
+    """When the task asks about tests, test symbols must NOT be demoted.
+
+    Codex P2 on #291: unconditional test demotion (is_test as the first sort
+    tier) pushes the relevant test past the limit for a test-intent query like
+    'response writer tests'. With wants_tests set, the stronger name match
+    wins and the test symbol ranks first.
+    """
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        CodeGraphContextTool,
+    )
+
+    class TestIntentCache:
+        def fts_search_ranked(self, candidate: str, limit: int):
+            return [
+                {
+                    "name": "TestResponseWriterWrite",
+                    "kind": "function",
+                    "file": "response_writer_test.go",
+                    "line": 10,
+                },
+                {
+                    "name": "ResponseWriter",
+                    "kind": "class",
+                    "file": "response_writer.go",
+                    "line": 20,
+                },
+            ]
+
+    tool = CodeGraphContextTool(str(Path.cwd()))
+    tool._cache = TestIntentCache()
+
+    # Default (no test intent): impl wins.
+    impl_first = tool._resolve_entry_points(["ResponseWriter"], limit=5)
+    assert impl_first[0]["name"] == "ResponseWriter"
+
+    # Test intent: the test symbol (stronger name match) is kept on top.
+    test_first = tool._resolve_entry_points(
+        ["ResponseWriter"], limit=5, wants_tests=True
+    )
+    assert test_first[0]["name"] == "TestResponseWriterWrite"
+
+
 def test_compound_candidates_builds_camelcase_word_pairs() -> None:
     from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
         _compound_candidates,

--- a/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
@@ -149,7 +149,10 @@ class CodeGraphContextTool(BaseMCPTool):
         output_format = arguments.get("output_format", "toon")
 
         candidates = _extract_symbol_candidates(task)
-        entry_points = self._resolve_entry_points(candidates, max(5, max_nodes // 3))
+        wants_tests = _task_wants_tests(task)
+        entry_points = self._resolve_entry_points(
+            candidates, max(5, max_nodes // 3), wants_tests
+        )
         nodes = _nodes_from_hits(entry_points, max_nodes)
         edges: list[dict[str, Any]] = []
 
@@ -198,7 +201,7 @@ class CodeGraphContextTool(BaseMCPTool):
         return apply_toon_format_to_response(result, output_format)
 
     def _resolve_entry_points(
-        self, candidates: list[str], limit: int
+        self, candidates: list[str], limit: int, wants_tests: bool = False
     ) -> list[dict[str, Any]]:
         if not candidates:
             return []
@@ -289,7 +292,10 @@ class CodeGraphContextTool(BaseMCPTool):
                     raw_hits = []
                 _absorb(raw_hits)
 
-        ranked = sorted(agg.values(), key=lambda e: _entry_rank_v2(e, candidates))
+        ranked = sorted(
+            agg.values(),
+            key=lambda e: _entry_rank_v2(e, candidates, wants_tests),
+        )
         return [e["hit"] for e in ranked[:limit]]
 
     def _expand_nodes(
@@ -721,21 +727,44 @@ def _compound_candidates(candidates: list[str]) -> list[str]:
     return out[:12]
 
 
+# Words in the TASK that signal the user actually wants test code. When any
+# appears, the test-file demotion tier is switched off so a query like
+# "response writer tests" / "how is X tested" keeps its test symbols (Codex
+# P2 on #291). Whole-word matched against the raw task, case-insensitively.
+_TEST_INTENT_RE = re.compile(
+    r"\b(tests?|testing|tested|test[_-]?cases?|spec|specs|unit[_-]?tests?|"
+    r"benchmarks?|fixtures?)\b",
+    re.IGNORECASE,
+)
+
+
+def _task_wants_tests(task: str) -> bool:
+    """True when the task explicitly asks about test/spec/benchmark code."""
+    return bool(_TEST_INTENT_RE.search(task or ""))
+
+
 def _entry_rank_v2(
-    entry: dict[str, Any], candidates: list[str]
+    entry: dict[str, Any],
+    candidates: list[str],
+    wants_tests: bool = False,
 ) -> tuple[int, int, int, int, int, str, int]:
     """Relevance-aware ranking key for an aggregated entry-point hit.
 
     Order of precedence: non-test before test, definition kinds before refs,
     MORE matched task words first, MORE candidate hits first, better BM25
     rank, then file/line for a stable tie-break.
+
+    When ``wants_tests`` is set (the task itself asks about tests/specs), the
+    test-demotion tier is disabled so relevant test symbols are not pushed
+    past the result limit — codegraph_context takes natural-language tasks,
+    and "X tests" must be allowed to return test code (Codex P2 #291).
     """
     hit = entry["hit"]
-    is_test = _is_test_file(hit.get("file", ""))
+    test_tier = 0 if wants_tests else _is_test_file(hit.get("file", ""))
     kind_rank = 0 if hit.get("kind") in {"class", "function", "method"} else 1
     name_match = _name_match_score(hit.get("name", ""), candidates)
     return (
-        is_test,
+        test_tier,
         kind_rank,
         -name_match,
         -int(entry.get("matches", 0)),

--- a/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
@@ -624,9 +624,52 @@ def _unique_files(nodes: list[dict[str, Any]]) -> list[str]:
     return out
 
 
+# Test-file path conventions across languages. Detected by FILE path (robust)
+# rather than symbol name (``TestRunner`` may be production code) so we never
+# demote a real symbol. Without this, a concept query whose substring-cascade
+# hits land in test files (Go ``*_test.go``, JS ``*.spec.ts``, ...) surfaces
+# ``TestResponseWriterWrite`` ABOVE the real ``ResponseWriter`` implementation,
+# degrading the inline source and pushing the agent back to raw Reads.
+_TEST_PATH_DIRS = ("/tests/", "/test/", "/__tests__/", "/spec/", "/testdata/")
+_TEST_FILE_SUFFIXES = (
+    "_test.go",  # Go
+    "_test.py",  # Python (pytest/unittest)
+    "_test.rs",  # Rust
+    "_test.cc",
+    "_test.cpp",  # C++
+    "_spec.rb",  # Ruby
+    ".test.js",
+    ".test.jsx",
+    ".test.ts",
+    ".test.tsx",  # JS/TS
+    ".spec.js",
+    ".spec.jsx",
+    ".spec.ts",
+    ".spec.tsx",
+)
+
+
+def _is_test_file(file_path: str) -> int:
+    """Return 1 when ``file_path`` is a test file, else 0 (for rank tiers).
+
+    Path-based only — see ``_TEST_PATH_DIRS`` rationale above.
+    """
+    p = file_path.replace("\\", "/").lower()
+    base = p.rsplit("/", 1)[-1]
+    if p.startswith(("tests/", "test/", "spec/", "__tests__/", "testdata/")):
+        return 1
+    if any(d in p for d in _TEST_PATH_DIRS):
+        return 1
+    if base.endswith(_TEST_FILE_SUFFIXES):
+        return 1
+    if base.startswith("test_") and base.endswith(".py"):
+        return 1
+    return 0
+
+
 def _entry_rank(hit: dict[str, Any]) -> tuple[int, int, str, int]:
-    file_path = hit.get("file", "").replace("\\", "/")
-    is_test = int("/tests/" in file_path or file_path.startswith("tests/"))
+    file_path = hit.get("file", "")
+    is_test = _is_test_file(file_path)
     kind_rank = 0 if hit.get("kind") in {"class", "function", "method"} else 1
     return (is_test, kind_rank, hit.get("file", ""), int(hit.get("line", 0) or 0))
 
@@ -688,8 +731,7 @@ def _entry_rank_v2(
     rank, then file/line for a stable tie-break.
     """
     hit = entry["hit"]
-    file_path = hit.get("file", "").replace("\\", "/")
-    is_test = int("/tests/" in file_path or file_path.startswith("tests/"))
+    is_test = _is_test_file(hit.get("file", ""))
     kind_rank = 0 if hit.get("kind") in {"class", "function", "method"} else 1
     name_match = _name_match_score(hit.get("name", ""), candidates)
     return (


### PR DESCRIPTION
## Problem (cost, follow-up to #288)

Once #288's substring cascade recalls camelCase matches, a concept query whose hits cluster in **test files** surfaced TEST symbols above the implementation:

| query (gin) | before |
|---|---|
| `render response writer` | 8× `TestResponseWriterWrite/...` from `response_writer_test.go` |
| `route matching` | led with `testRoutesInterface` |

The agent then gets *test* source inline instead of the real code and falls back to `Read` — re-opening the cost gap the cascade fix closed.

## Root cause

The `is_test` rank tier matched only `/tests/` paths, missing Go `*_test.go`, JS/TS `*.spec.*`/`*.test.*`, Maven `src/test/`, `__tests__/`, `testdata/`, etc. Go test files (`*_test.go`) therefore ranked as production code.

## Fix

Replace the inline check in **both** `_entry_rank` and `_entry_rank_v2` with a shared `_is_test_file()` covering these conventions **by file path only** — never by symbol name, so production classes like `TestRunner` are not demoted.

## Dogfood (gin) after

| query | after |
|---|---|
| `render response writer` | `Render` (context.go, render/*.go) |
| `route matching` | `Routes`, `updateRouteTrees`, `addRoute` (gin.go) |

## Tests

`_is_test_file` cross-language matrix incl. false-positive guards (`latest.java`, `contest.py`, `TestRunner.java` → not test); plus a ranking test that a **stronger** name-matching test symbol still sinks below the impl. 989 related tests green; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)