### PR TITLE
fix(benchmark): pin TSA MCP server to the target repo via --project-root

### DIFF
--- a/benchmarks/codegraph_compare/adapters/claude_runner.py
+++ b/benchmarks/codegraph_compare/adapters/claude_runner.py
@@ -295,19 +295,32 @@ _ANALYZER_ROOT = Path(__file__).resolve().parents[3]
 _MCP_CONFIG_DIR = Path(tempfile.gettempdir()) / "tsa_bench_mcp_configs"
 
 
-def _write_arm_mcp_config(arm_id: str) -> Path:
+def _write_arm_mcp_config(arm_id: str, repo_path: Path) -> Path:
     """Write a per-arm MCP config so each arm sees ONLY its own MCP server.
 
     Used with ``--strict-mcp-config`` so the developer's global MCP servers
     (Context7, Gmail, codegraph, ruflo, vercel, ...) do NOT leak into the
     benchmark agent — their tool definitions otherwise bloat the context by
     millions of tokens and pollute every arm. native-only gets an empty set.
+
+    CRITICAL: the TSA server is given ``--project-root <repo_path>`` explicitly.
+    Without it the server auto-detects its root and resolves to the ANALYZER
+    repo (where its package lives), NOT the benchmark target repo — so every
+    nav/structure query analyzes tree-sitter-analyzer's own code instead of
+    e.g. gin. The agent then calls set_project_path, re-queries, and falls back
+    to raw Reads of the analyzer tree, inflating cost ~2.5x and invalidating
+    the comparison. (Found by dogfooding the TSA arm transcript.)
     """
     if arm_id.startswith("tsa"):
         servers = {
             "tree-sitter-analyzer": {
                 "command": str(_ANALYZER_ROOT / ".venv" / "bin" / "python"),
-                "args": ["-m", "tree_sitter_analyzer.mcp.server"],
+                "args": [
+                    "-m",
+                    "tree_sitter_analyzer.mcp.server",
+                    "--project-root",
+                    str(repo_path),
+                ],
             }
         }
     elif arm_id.startswith("codegraph"):
@@ -350,7 +363,7 @@ def _build_agent_cmd(
         if disallowed_tools_str:
             cmd += ["--disallowed-tools", disallowed_tools_str]
         # Isolate MCP: each arm sees only its own server (no global MCP leak).
-        mcp_cfg = _write_arm_mcp_config(arm_id)
+        mcp_cfg = _write_arm_mcp_config(arm_id, repo_path)
         cmd += ["--strict-mcp-config", "--mcp-config", str(mcp_cfg)]
         return cmd
     # codex backend: the MCP arms (tsa*, codegraph*) need their server wired in

--- a/tests/unit/test_benchmark_harness.py
+++ b/tests/unit/test_benchmark_harness.py
@@ -295,9 +295,7 @@ class TestCodeGraphCompareToolPolicy:
 
             # The TSA MCP facade tools are available (index-first path).
             assert "mcp__tree-sitter-analyzer__nav" in allowed
-            assert any(
-                t.startswith("mcp__tree-sitter-analyzer__") for t in allowed
-            )
+            assert any(t.startswith("mcp__tree-sitter-analyzer__") for t in allowed)
             # The competing index and escape hatches are blocked for a fair,
             # isolated TSA-vs-CodeGraph comparison.
             assert "mcp__codegraph__*" in disallowed
@@ -325,6 +323,32 @@ class TestCodeGraphCompareToolPolicy:
         assert "AST index is the source of truth" in prompt
         # No stale CLI-DSL references from the old CLI-based arm.
         assert "--codegraph-query" not in prompt
+
+    def test_tsa_mcp_config_pins_target_repo_as_project_root(self, tmp_path: Path):
+        """The TSA MCP server must get --project-root <target repo>.
+
+        Without it the server auto-detects and resolves to the ANALYZER repo
+        (where its package lives), so every query analyzes tree-sitter-analyzer
+        instead of the benchmark target — the agent then calls set_project_path,
+        re-queries, and Reads the analyzer tree, inflating cost ~2.5x and
+        invalidating the comparison.
+        """
+        import json as _json
+
+        from benchmarks.codegraph_compare.adapters.claude_runner import (
+            _write_arm_mcp_config,
+        )
+
+        repo = tmp_path / "gin"
+        repo.mkdir()
+        cfg_path = _write_arm_mcp_config("tsa-warm", repo)
+        cfg = _json.loads(cfg_path.read_text())
+        args = cfg["mcpServers"]["tree-sitter-analyzer"]["args"]
+
+        assert "--project-root" in args
+        assert str(repo) in args
+        # The flag value must be the repo, immediately after the flag.
+        assert args[args.index("--project-root") + 1] == str(repo)
 
 
 class TestCodeGraphComparePhases:


### PR DESCRIPTION
## The bug (found by dogfooding the transcript)

Inspecting the `tsa-warm` transcript on gin revealed the TSA arm was **analyzing the wrong codebase**. `_write_arm_mcp_config` spawned the server with no `--project-root`, so `resolve_project_root` auto-detected and resolved to the **analyzer repo** (where `tree_sitter_analyzer` lives), not the benchmark target. The agent's sequence was:

```
nav context 'ServeHTTP' -> set_project_path -> re-query -> Read /…/tree-sitter-analyzer (×4) -> Grep
```

i.e. it fought the misconfig and fell back to raw Reads **of the analyzer tree**.

## Effect (gin-route-matching, tsa-warm)

| | before | after |
|---|---|---|
| cost | $0.69 | **$0.38** (−45%) |
| tool calls | 11 (reads=4 of analyzer, idx=6) | 5 (reads=0, idx=4) |
| tokens | 682k | 316k |

Now in the same ballpark as codegraph-warm ($0.28) and native-only ($0.30) — a **fair** comparison.

## Fix

`_write_arm_mcp_config(arm_id, repo_path)` passes `--project-root <repo_path>` (highest priority in `resolve_project_root`) so the server always targets the benchmark repo.

**All prior TSA benchmark numbers were invalid** because of this — a re-run is required before any README claims.

Test: `_write_arm_mcp_config('tsa-warm', repo)` embeds `--project-root <repo>`. 31 harness tests green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)