### PR TITLE
fix(mcp): trim nav context response size (truncate bodies, cap edges)

### DIFF
--- a/tests/unit/test_codegraph_context_tool.py
+++ b/tests/unit/test_codegraph_context_tool.py
@@ -946,6 +946,45 @@ def test_build_code_blocks_truncates_long_bodies(tmp_path: Path) -> None:
     assert "x59 = 59" not in content
 
 
+def test_build_code_blocks_hints_when_end_unknown(tmp_path: Path) -> None:
+    """A call-graph node with no end_line still gets an 'end unknown' hint.
+
+    Codex P2 on #293: callee/caller nodes have end_line=0, so the cap-window
+    fallback equalled capped_end and NO marker was emitted — lines past the cap
+    were silently dropped. Now an explicit hint is added when the snippet is
+    capped before EOF with an unknown end.
+    """
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        _build_code_blocks,
+        _node_id,
+    )
+
+    body = "func big() {\n" + "".join(f"    line{i}();\n" for i in range(40)) + "}\n"
+    src = tmp_path / "big.go"
+    src.write_text(body, encoding="utf-8")
+
+    blocks = _build_code_blocks(
+        [
+            {
+                "id": _node_id("big", "big.go", 1),
+                "name": "big",
+                "file": "big.go",
+                "line": 1,
+                # No end_line key → simulates a call-graph-expansion node.
+            }
+        ],
+        [],
+        5,
+        str(tmp_path),
+    )
+
+    assert len(blocks) == 1
+    content = blocks[0]["content"]
+    assert "end unknown" in content
+    assert "big.go:" in content
+    assert "line39();" not in content  # full body NOT inlined
+
+
 def test_build_code_blocks_keeps_short_bodies_untruncated(tmp_path: Path) -> None:
     from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
         _build_code_blocks,
@@ -979,8 +1018,8 @@ def test_build_code_blocks_keeps_short_bodies_untruncated(tmp_path: Path) -> Non
 async def test_context_caps_inline_edges(indexed_project: Path) -> None:
     """execute() caps echoed edges to _MAX_INLINE_EDGES and records the total."""
     from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
-        CodeGraphContextTool,
         _MAX_INLINE_EDGES,
+        CodeGraphContextTool,
     )
 
     tool = CodeGraphContextTool(str(indexed_project))

--- a/tests/unit/test_codegraph_context_tool.py
+++ b/tests/unit/test_codegraph_context_tool.py
@@ -905,6 +905,97 @@ def test_build_code_blocks_skips_empty_snippets(
     assert blocks == []
 
 
+def test_build_code_blocks_truncates_long_bodies(tmp_path: Path) -> None:
+    """A long function body is capped to _MAX_BLOCK_LINES with a marker.
+
+    Full 40-line bodies made nav context 2-4x larger than peer tools for no
+    added value. The block keeps the signature + head and points at the rest.
+    """
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        _MAX_BLOCK_LINES,
+        _build_code_blocks,
+        _node_id,
+    )
+
+    body = "def big():\n" + "".join(f"    x{i} = {i}\n" for i in range(60))
+    src = tmp_path / "big.py"
+    src.write_text(body, encoding="utf-8")
+
+    blocks = _build_code_blocks(
+        [
+            {
+                "id": _node_id("big", "big.py", 1),
+                "name": "big",
+                "file": "big.py",
+                "line": 1,
+                "end_line": 61,
+            }
+        ],
+        [],
+        5,
+        str(tmp_path),
+    )
+
+    assert len(blocks) == 1
+    content = blocks[0]["content"]
+    # Body proper is capped to _MAX_BLOCK_LINES; the marker line is extra.
+    assert blocks[0]["end_line"] == _MAX_BLOCK_LINES
+    assert "more lines" in content
+    assert "big.py:" in content  # marker points at the remaining range
+    # The full 60-line body is NOT inlined.
+    assert "x59 = 59" not in content
+
+
+def test_build_code_blocks_keeps_short_bodies_untruncated(tmp_path: Path) -> None:
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        _build_code_blocks,
+        _node_id,
+    )
+
+    src = tmp_path / "small.py"
+    src.write_text("def small():\n    return 1\n", encoding="utf-8")
+
+    blocks = _build_code_blocks(
+        [
+            {
+                "id": _node_id("small", "small.py", 1),
+                "name": "small",
+                "file": "small.py",
+                "line": 1,
+                "end_line": 2,
+            }
+        ],
+        [],
+        5,
+        str(tmp_path),
+    )
+
+    assert len(blocks) == 1
+    assert "more lines" not in blocks[0]["content"]
+    assert "return 1" in blocks[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_context_caps_inline_edges(indexed_project: Path) -> None:
+    """execute() caps echoed edges to _MAX_INLINE_EDGES and records the total."""
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        CodeGraphContextTool,
+        _MAX_INLINE_EDGES,
+    )
+
+    tool = CodeGraphContextTool(str(indexed_project))
+    result = await tool.execute(
+        {
+            "task": "trace handle_request to UserService.get_user",
+            "output_format": "json",
+        }
+    )
+
+    assert len(result["edges"]) <= _MAX_INLINE_EDGES
+    assert result["stats"]["edges"] == len(result["edges"])
+    assert result["stats"]["edges_total"] >= result["stats"]["edges"]
+
+
 @pytest.mark.asyncio
 async def test_context_returns_entry_points_graph_and_source(
     indexed_project: Path,

--- a/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
@@ -24,6 +24,17 @@ _STOP_WORDS = frozenset(
     "or through to trace what when where which why with work works".split()
 )
 
+# Inline-body cap per code block. A full function body (the old 40-line window)
+# bloated nav context responses 2-4x vs peer tools for little added value; the
+# agent gets signature + head and reads the exact range only if needed.
+_MAX_BLOCK_LINES = 24
+
+# Cap on edges echoed in the response. Edges are graph wiring for visualization;
+# an answering agent rarely needs the full adjacency list, and 60+ raw edge
+# tuples were a large fraction of the response. The full set is still used to
+# RANK code blocks before the cap is applied.
+_MAX_INLINE_EDGES = 30
+
 
 class CodeGraphContextTool(BaseMCPTool):
     """MCP tool for one-call architecture context and trace expansion."""
@@ -167,6 +178,12 @@ class CodeGraphContextTool(BaseMCPTool):
             project_root=self.project_root or "",
         )
         related_files = _unique_files(nodes)
+        # Cap edges echoed to the response. The FULL edge set above already
+        # ranked the code blocks (via _edge_degrees); the response only needs a
+        # bounded sample, not the whole adjacency list (60+ raw tuples were a
+        # large, low-value fraction of the payload).
+        total_edges = len(edges)
+        edges = edges[:_MAX_INLINE_EDGES]
         verdict = "INFO" if entry_points else "NOT_FOUND"
         result: dict[str, Any] = {
             "success": True,
@@ -182,6 +199,7 @@ class CodeGraphContextTool(BaseMCPTool):
                 "entry_points": len(entry_points),
                 "nodes": len(nodes),
                 "edges": len(edges),
+                "edges_total": total_edges,
                 "code_blocks": len(code_blocks),
             },
             "agent_summary": {
@@ -587,20 +605,31 @@ def _build_code_blocks(
         lines = read_file_lines(abs_path)
         if not lines:
             continue
-        end_line = int(node.get("end_line", 0) or 0)
-        if end_line < start_line:
-            end_line = start_line + 39
-        else:
-            end_line = min(end_line, start_line + 39)
-        content = extract_snippet_from_lines(lines, start_line, end_line)
+        full_end = int(node.get("end_line", 0) or 0)
+        if full_end < start_line:
+            full_end = start_line + _MAX_BLOCK_LINES - 1
+        # Cap the inline body to _MAX_BLOCK_LINES. A full 40-line function body
+        # per block made nav context responses 2-4x larger than peers for no
+        # added value — the agent needs the signature + head of the body to
+        # locate and understand the symbol, then reads the exact range only if
+        # it must. Long bodies get a truncation marker pointing at the rest.
+        capped_end = min(full_end, start_line + _MAX_BLOCK_LINES - 1)
+        capped_end = min(capped_end, len(lines))
+        content = extract_snippet_from_lines(lines, start_line, capped_end)
         if not content:
             continue
+        real_end = min(full_end, len(lines))
+        if real_end > capped_end:
+            content = (
+                content.rstrip("\n") + f"\n    # … {real_end - capped_end} more lines "
+                f"({file_path}:{capped_end + 1}-{real_end})\n"
+            )
         blocks.append(
             {
                 "file": file_path,
                 "name": node["name"],
                 "start_line": start_line,
-                "end_line": min(end_line, len(lines)),
+                "end_line": capped_end,
                 "content": content,
             }
         )

--- a/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
@@ -605,9 +605,11 @@ def _build_code_blocks(
         lines = read_file_lines(abs_path)
         if not lines:
             continue
-        full_end = int(node.get("end_line", 0) or 0)
-        if full_end < start_line:
-            full_end = start_line + _MAX_BLOCK_LINES - 1
+        raw_end = int(node.get("end_line", 0) or 0)
+        end_known = raw_end >= start_line
+        # Nodes from call-graph expansion (callees/callers) often have no
+        # end_line; fall back to the cap window for those.
+        full_end = raw_end if end_known else start_line + _MAX_BLOCK_LINES - 1
         # Cap the inline body to _MAX_BLOCK_LINES. A full 40-line function body
         # per block made nav context responses 2-4x larger than peers for no
         # added value — the agent needs the signature + head of the body to
@@ -618,11 +620,23 @@ def _build_code_blocks(
         content = extract_snippet_from_lines(lines, start_line, capped_end)
         if not content:
             continue
-        real_end = min(full_end, len(lines))
-        if real_end > capped_end:
+        if end_known:
+            real_end = min(full_end, len(lines))
+            if real_end > capped_end:
+                content = (
+                    content.rstrip("\n")
+                    + f"\n    # … {real_end - capped_end} more lines "
+                    f"({file_path}:{capped_end + 1}-{real_end})\n"
+                )
+        elif capped_end < len(lines):
+            # End line unknown (call-graph node) AND we stopped at the cap before
+            # EOF — the function may continue. Emit an explicit hint so the agent
+            # knows to read onward rather than assuming the snippet is complete
+            # (Codex P2 on #293: the old fallback silently dropped lines 25+).
             content = (
-                content.rstrip("\n") + f"\n    # … {real_end - capped_end} more lines "
-                f"({file_path}:{capped_end + 1}-{real_end})\n"
+                content.rstrip("\n")
+                + f"\n    # … snippet capped at {_MAX_BLOCK_LINES} lines; "
+                f"end unknown — read {file_path}:{capped_end + 1}+ if needed\n"
             )
         blocks.append(
             {


### PR DESCRIPTION
## Method (per the 'just call MCP directly' insight)

Instead of slow, flaky, API-overload-prone agent benchmark runs, I measured TSA `nav context` vs `codegraph context` **directly** (JSON-RPC / CLI, no agents) on gin. Instant, free, deterministic — and it isolates the tool-output cost driver.

## Finding

TSA responses were **1.7–4.6× larger** than codegraph for the same query. Breakdown for `middleware chain` (18.3 KB):

| part | size | note |
|---|---|---|
| edges | 61 raw tuples = 8.3 KB | graph wiring the answering agent rarely needs |
| code_blocks | 8 × full 40-line bodies = 9.5 KB | no truncation |
| nodes | 3.5 KB | |

Both peers answer from **less** (codegraph ~3–6 KB, curated + truncated), so the extra bulk is pure token cost, not value.

## Fix (surgical, no quality loss)

- `_build_code_blocks` caps each inline body to `_MAX_BLOCK_LINES=24` with a `# … N more lines (file:start-end)` marker pointing at the rest (signature + head kept; agent reads the exact range only if needed).
- `execute()` caps echoed edges to `_MAX_INLINE_EDGES=30`; the **full** edge set still ranks code blocks first, and `stats.edges_total` records the pre-cap count.

## Direct re-measure (gin, chars)

| query | before | after |
|---|---|---|
| middleware chain | 18.3K | 13.1K |
| route matching | 12.5K | 10.7K |
| render response | 10.5K | 9.0K |

~15–30% smaller per call, stacking on the bigger project-root fix (#292).

Tests: long-body truncation + short-body untouched + execute edge cap. 33 green; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)