### PR TITLE
fix(mcp): consistent test-aware ranking via shared utils.test_detection

### DIFF
--- a/tests/unit/test_semantic_symbol_search.py
+++ b/tests/unit/test_semantic_symbol_search.py
@@ -233,3 +233,37 @@ class TestSemanticSymbolSearchFallbackSchema:
         results = SemanticSymbolSearch(cache).search("route handler", limit=5)
 
         assert any(r["name"] == "route_handler" for r in results)
+
+
+class TestSemanticSymbolSearchTestDeprioritization:
+    """Impl symbols must rank above test symbols (shared utils.test_detection)."""
+
+    def test_impl_ranks_above_test_for_concept_query(self):
+        cache = _make_cache(
+            [
+                ("TestRenderJSON", "function", "render_test.go", "go"),
+                ("Render", "method", "render.go", "go"),
+            ]
+        )
+
+        results = SemanticSymbolSearch(cache).search("render", limit=5)
+        names = [r["name"] for r in results]
+
+        assert "Render" in names and "TestRenderJSON" in names
+        # Implementation must come first despite the test's strong name match.
+        assert names.index("Render") < names.index("TestRenderJSON")
+
+    def test_test_intent_query_keeps_tests_on_top(self):
+        cache = _make_cache(
+            [
+                ("TestRenderJSON", "function", "render_test.go", "go"),
+                ("Render", "method", "render.go", "go"),
+            ]
+        )
+
+        # "render tests" expresses test intent → tests are NOT demoted.
+        results = SemanticSymbolSearch(cache).search("render tests", limit=5)
+        names = [r["name"] for r in results]
+
+        assert "TestRenderJSON" in names
+        assert names.index("TestRenderJSON") < names.index("Render")

--- a/tests/unit/test_test_detection.py
+++ b/tests/unit/test_test_detection.py
@@ -1,0 +1,60 @@
+"""Tests for the canonical test-file detection util (utils.test_detection)."""
+
+from __future__ import annotations
+
+from tree_sitter_analyzer.utils.test_detection import (
+    is_test_file,
+    query_wants_tests,
+    rank_tier,
+)
+
+
+def test_is_test_file_detects_cross_language_conventions() -> None:
+    # Go / Python / Rust / C++ / Ruby suffixes
+    assert is_test_file("response_writer_test.go")
+    assert is_test_file("pkg/router_test.go")
+    assert is_test_file("thing_test.py")
+    assert is_test_file("test_thing.py")
+    assert is_test_file("mod_test.rs")
+    assert is_test_file("widget_test.cc")
+    assert is_test_file("model_spec.rb")
+    # JS / TS
+    assert is_test_file("src/app/foo.test.tsx")
+    assert is_test_file("foo.spec.ts")
+    assert is_test_file("comp.test.jsx")
+    # Directory conventions
+    assert is_test_file("tests/test_thing.py")
+    assert is_test_file("src/test/java/FooTest.java")
+    assert is_test_file("__tests__/comp.jsx")
+    assert is_test_file("project/testdata/sample.go")
+    assert is_test_file("pkg/fixtures/data.go")
+
+
+def test_is_test_file_no_false_positives() -> None:
+    assert not is_test_file("response_writer.go")
+    assert not is_test_file("src/TestRunner.java")  # production class
+    assert not is_test_file("latest.java")  # 'test' substring trap
+    assert not is_test_file("contest.py")
+    assert not is_test_file("greatest_hits.rb")
+    assert not is_test_file("")
+    assert not is_test_file(None)
+
+
+def test_query_wants_tests() -> None:
+    assert query_wants_tests("response writer tests")
+    assert query_wants_tests("how is routing tested")
+    assert query_wants_tests("the spec for the parser")
+    assert query_wants_tests("router benchmark")
+    assert query_wants_tests("fixtures for the model")
+    assert not query_wants_tests("how does route matching work")
+    assert not query_wants_tests("latest contest results")
+    assert not query_wants_tests("")
+
+
+def test_rank_tier_behaviour() -> None:
+    # Non-test → 0, test → 1.
+    assert rank_tier("router.go") == 0
+    assert rank_tier("router_test.go") == 1
+    # wants_tests forces tier 0 so tests are not demoted.
+    assert rank_tier("router_test.go", wants_tests=True) == 0
+    assert rank_tier("router.go", wants_tests=True) == 0

--- a/tests/unit/test_test_detection.py
+++ b/tests/unit/test_test_detection.py
@@ -28,6 +28,10 @@ def test_is_test_file_detects_cross_language_conventions() -> None:
     assert is_test_file("__tests__/comp.jsx")
     assert is_test_file("project/testdata/sample.go")
     assert is_test_file("pkg/fixtures/data.go")
+    # Repo-root fixture/test trees (prefix, no leading slash) — Codex P2 #294.
+    assert is_test_file("fixtures/data.go")
+    assert is_test_file("testdata/sample.go")
+    assert is_test_file("spec/thing_spec.rb")
 
 
 def test_is_test_file_no_false_positives() -> None:

--- a/tests/unit/utils/test_utils_init.py
+++ b/tests/unit/utils/test_utils_init.py
@@ -256,6 +256,10 @@ class TestNoExtraExports:
             # .claude_md_frontmatter import load_frontmatter``), so no
             # flat re-export is needed.
             "claude_md_frontmatter",
+            # Canonical test-file detection. Consumers import via the submodule
+            # path (``from tree_sitter_analyzer.utils.test_detection import
+            # is_test_file``); no flat re-export needed.
+            "test_detection",
         ]
 
         for item in public_items:

--- a/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
@@ -16,6 +16,8 @@ import re
 import time
 from typing import Any
 
+from ...utils.test_detection import is_test_file as _shared_is_test_file
+from ...utils.test_detection import query_wants_tests as _task_wants_tests
 from ._codegraph_explore_helpers import extract_snippet_from_lines, read_file_lines
 from .base_tool import BaseMCPTool
 
@@ -630,47 +632,15 @@ def _unique_files(nodes: list[dict[str, Any]]) -> list[str]:
     return out
 
 
-# Test-file path conventions across languages. Detected by FILE path (robust)
-# rather than symbol name (``TestRunner`` may be production code) so we never
-# demote a real symbol. Without this, a concept query whose substring-cascade
-# hits land in test files (Go ``*_test.go``, JS ``*.spec.ts``, ...) surfaces
-# ``TestResponseWriterWrite`` ABOVE the real ``ResponseWriter`` implementation,
-# degrading the inline source and pushing the agent back to raw Reads.
-_TEST_PATH_DIRS = ("/tests/", "/test/", "/__tests__/", "/spec/", "/testdata/")
-_TEST_FILE_SUFFIXES = (
-    "_test.go",  # Go
-    "_test.py",  # Python (pytest/unittest)
-    "_test.rs",  # Rust
-    "_test.cc",
-    "_test.cpp",  # C++
-    "_spec.rb",  # Ruby
-    ".test.js",
-    ".test.jsx",
-    ".test.ts",
-    ".test.tsx",  # JS/TS
-    ".spec.js",
-    ".spec.jsx",
-    ".spec.ts",
-    ".spec.tsx",
-)
-
-
 def _is_test_file(file_path: str) -> int:
-    """Return 1 when ``file_path`` is a test file, else 0 (for rank tiers).
+    """Rank-tier wrapper: 1 for test files, 0 otherwise.
 
-    Path-based only — see ``_TEST_PATH_DIRS`` rationale above.
+    Thin shim over the shared, canonical ``utils.test_detection.is_test_file``
+    so every ranking path agrees on what counts as a test (see that module).
+    Detected by FILE path only, never by symbol name, so a production class
+    named ``TestRunner`` is never demoted.
     """
-    p = file_path.replace("\\", "/").lower()
-    base = p.rsplit("/", 1)[-1]
-    if p.startswith(("tests/", "test/", "spec/", "__tests__/", "testdata/")):
-        return 1
-    if any(d in p for d in _TEST_PATH_DIRS):
-        return 1
-    if base.endswith(_TEST_FILE_SUFFIXES):
-        return 1
-    if base.startswith("test_") and base.endswith(".py"):
-        return 1
-    return 0
+    return 1 if _shared_is_test_file(file_path) else 0
 
 
 def _entry_rank(hit: dict[str, Any]) -> tuple[int, int, str, int]:
@@ -725,22 +695,6 @@ def _compound_candidates(candidates: list[str]) -> list[str]:
             seen.add(low)
             out.append(joined)
     return out[:12]
-
-
-# Words in the TASK that signal the user actually wants test code. When any
-# appears, the test-file demotion tier is switched off so a query like
-# "response writer tests" / "how is X tested" keeps its test symbols (Codex
-# P2 on #291). Whole-word matched against the raw task, case-insensitively.
-_TEST_INTENT_RE = re.compile(
-    r"\b(tests?|testing|tested|test[_-]?cases?|spec|specs|unit[_-]?tests?|"
-    r"benchmarks?|fixtures?)\b",
-    re.IGNORECASE,
-)
-
-
-def _task_wants_tests(task: str) -> bool:
-    """True when the task explicitly asks about test/spec/benchmark code."""
-    return bool(_TEST_INTENT_RE.search(task or ""))
 
 
 def _entry_rank_v2(

--- a/tree_sitter_analyzer/semantic_search.py
+++ b/tree_sitter_analyzer/semantic_search.py
@@ -9,6 +9,8 @@ import sqlite3
 from collections import Counter
 from typing import Any
 
+from .utils.test_detection import query_wants_tests, rank_tier
+
 _TOKEN_RE = re.compile(r"[A-Za-z][A-Za-z0-9]*")
 
 
@@ -41,8 +43,14 @@ class SemanticSymbolSearch:
             result["semantic_score"] = round(score, 4)
             scored.append((score, result))
 
+        # Demote test/spec/fixture symbols below implementation symbols so a
+        # concept query like "render" surfaces ``Render``, not ``TestRenderJSON``
+        # — unless the query itself asks about tests. Consistent with nav
+        # context ranking via the shared utils.test_detection helpers.
+        wants_tests = query_wants_tests(query)
         scored.sort(
             key=lambda item: (
+                rank_tier(str(item[1].get("file", "")), wants_tests=wants_tests),
                 -item[0],
                 str(item[1].get("file", "")),
                 int(item[1].get("line", 0) or 0),

--- a/tree_sitter_analyzer/utils/test_detection.py
+++ b/tree_sitter_analyzer/utils/test_detection.py
@@ -1,0 +1,108 @@
+"""Canonical, cross-language test-file detection and test-intent parsing.
+
+Before this module the codebase carried ~5 independent ``_is_test_file`` /
+``is_test_or_fixture_path`` / ``_is_test_path`` variants, each covering a
+different subset of conventions (one matched only ``/tests/``; another missed
+Go ``*_test.go``; another missed ``.spec.tsx``). The divergence meant a
+concept query like ``render`` surfaced ``TestRenderJSON`` above the real
+``Render`` in some tools but not others.
+
+This module is the single source of truth, used by every symbol-ranking and
+filtering path so behavior is consistent. Detection is **path-based only** —
+never by symbol name — so a production class literally named ``TestRunner`` is
+never misclassified as a test.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Directory segments that mark a test/fixture tree (any depth).
+_TEST_DIR_SEGMENTS: tuple[str, ...] = (
+    "/test/",
+    "/tests/",
+    "/__tests__/",
+    "/spec/",
+    "/specs/",
+    "/fixtures/",
+    "/testdata/",
+)
+
+# Path prefixes (repo-root-relative) that mark a test tree.
+_TEST_DIR_PREFIXES: tuple[str, ...] = (
+    "test/",
+    "tests/",
+    "__tests__/",
+    "spec/",
+    "specs/",
+    "testdata/",
+)
+
+# Basename suffixes that mark a test file, across languages.
+_TEST_FILE_SUFFIXES: tuple[str, ...] = (
+    "_test.go",  # Go
+    "_test.py",  # Python (pytest/unittest, *_test.py)
+    "_test.rs",  # Rust
+    "_test.cc",
+    "_test.cpp",
+    "_test.cxx",  # C++
+    "_spec.rb",  # Ruby
+    ".test.js",
+    ".test.jsx",
+    ".test.ts",
+    ".test.tsx",  # JS/TS
+    ".spec.js",
+    ".spec.jsx",
+    ".spec.ts",
+    ".spec.tsx",
+)
+
+
+def is_test_file(path: str | None) -> bool:
+    """Return True when *path* points at a test/spec/fixture file.
+
+    Path-based only (see module docstring). Covers Go ``*_test.go``, Python
+    ``test_*.py`` / ``*_test.py``, JS/TS ``*.test.*`` / ``*.spec.*``, Maven
+    ``src/test/`` layouts, ``__tests__/``, ``testdata/``, ``fixtures/``, etc.
+    """
+    if not path:
+        return False
+    p = path.replace("\\", "/").lower()
+    base = p.rsplit("/", 1)[-1]
+    if p.startswith(_TEST_DIR_PREFIXES):
+        return True
+    if any(seg in p for seg in _TEST_DIR_SEGMENTS):
+        return True
+    if base.endswith(_TEST_FILE_SUFFIXES):
+        return True
+    if base.startswith("test_") and base.endswith(".py"):  # pytest test_*.py
+        return True
+    return False
+
+
+def rank_tier(path: str | None, *, wants_tests: bool = False) -> int:
+    """Ranking tier: 0 (non-test, ranks first) or 1 (test, demoted).
+
+    When *wants_tests* is set — the caller's query explicitly asks about tests —
+    the tier is forced to 0 so relevant test symbols are not demoted past a
+    result limit.
+    """
+    if wants_tests:
+        return 0
+    return 1 if is_test_file(path) else 0
+
+
+# Whole-word signals in a query/task that mean the user actually WANTS test code.
+_TEST_INTENT_RE = re.compile(
+    r"\b(tests?|testing|tested|test[_-]?cases?|spec|specs|unit[_-]?tests?|"
+    r"benchmarks?|fixtures?)\b",
+    re.IGNORECASE,
+)
+
+
+def query_wants_tests(query: str | None) -> bool:
+    """True when the query/task explicitly asks about test/spec/benchmark code."""
+    return bool(_TEST_INTENT_RE.search(query or ""))
+
+
+__all__ = ["is_test_file", "query_wants_tests", "rank_tier"]

--- a/tree_sitter_analyzer/utils/test_detection.py
+++ b/tree_sitter_analyzer/utils/test_detection.py
@@ -28,13 +28,16 @@ _TEST_DIR_SEGMENTS: tuple[str, ...] = (
     "/testdata/",
 )
 
-# Path prefixes (repo-root-relative) that mark a test tree.
+# Path prefixes (repo-root-relative) that mark a test tree. Must mirror the
+# ``/segment/`` entries above so a repo-root ``fixtures/data.go`` is detected
+# the same as a nested ``pkg/fixtures/data.go`` (Codex P2 on #294).
 _TEST_DIR_PREFIXES: tuple[str, ...] = (
     "test/",
     "tests/",
     "__tests__/",
     "spec/",
     "specs/",
+    "fixtures/",
     "testdata/",
 )
 


### PR DESCRIPTION
## Common-pattern quality bug (found by dogfooding the search tools directly)

The test-file demotion shipped in #291 lived **only in nav context**. The semantic search path — `SemanticSymbolSearch.search`, and `CodeGraphQueryBackend.semantic_symbols` which delegates to it — still ranked tests first. On gin, a concept query `render` returned `TestRenderJSON`/`TestRenderYAML` **above** the real `Render`.

The codebase also carried **~5 divergent test-detectors** (`dead_code_analyzer`, `test_gap_analyzer`, `semantic_change_classifier`, `_codegraph_query_filters`, `codegraph_context_tool`) — one matched only `/tests/`, another missed Go `*_test.go`, another missed `.spec.tsx`. Tools disagreed on what a test even is.

## Fix: one canonical detector + consistent application

New `utils.test_detection`:
- `is_test_file(path)` — canonical, cross-language (Go/Py/Rust/C++/Rb/JS/TS), **path-based only** (never by symbol name, so a production `TestRunner` is never demoted).
- `query_wants_tests(query)` — whole-word test-intent detector.
- `rank_tier(path, wants_tests=)` — 0 (impl, first) / 1 (test, demoted); forced 0 under test intent.

nav context now imports it (drops its local copy); `SemanticSymbolSearch.search` applies `rank_tier` as the first sort tier with the wants_tests exception.

## Dogfood (gin) after

| query | before | after |
|---|---|---|
| `render` | TestRenderJSON… | **Render** (impl) |
| `route` | (mixed) | addRoute/updateRouteTree |
| `render tests` | — | TestRenderJSON (intent preserved) |

## Tests
`test_detection` matrix incl. false-positive guards (`latest.java`/`contest.py`/`TestRunner.java`) + semantic impl-before-test + test-intent-keeps-tests. 481 related tests green; ruff + mypy clean.

Follow-up (separate PR): migrate the other 3 analyzers (dead_code/test_gap/semantic_change_classifier) to the shared detector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)