### PR TITLE
fix(mcp): accept JS-style true/false/null in the jQuery chain DSL

### DIFF
--- a/tests/unit/test_codegraph_query_dsl.py
+++ b/tests/unit/test_codegraph_query_dsl.py
@@ -38,6 +38,28 @@ class TestParseChain:
         with pytest.raises(ValueError, match="unsupported chain step"):
             parse_chain("search('x').delete()")
 
+    def test_accepts_js_style_bare_booleans(self):
+        """LLM agents naturally write true/false/null in this jQuery-style DSL.
+
+        Python's literal_eval only knows True/False/None, so before this the
+        agent's natural ``answer(compact=true)`` failed with a cryptic
+        "malformed node or string" error and pushed it off the cheap one-call
+        chain. The parser now accepts JS/JSON-style bare words (any case).
+        """
+        steps = parse_chain(
+            "search('x').include(callers=true, source=false).answer(compact=true)"
+        )
+        assert steps[1].kwargs == {"callers": True, "source": False}
+        assert steps[2].kwargs == {"compact": True}
+
+        # Capitalised Python literals still work (back-compat).
+        py = parse_chain("search('x').answer(compact=True)")
+        assert py[1].kwargs == {"compact": True}
+
+        # null / None coerce to None.
+        nul = parse_chain("search('x').explore(max_files=null)")
+        assert nul[1].kwargs == {"max_files": None}
+
     def test_parses_semantic_search_step(self):
         steps = parse_chain("semantic('user formatting', limit=5)")
 

--- a/tree_sitter_analyzer/mcp/tools/_codegraph_query_dsl.py
+++ b/tree_sitter_analyzer/mcp/tools/_codegraph_query_dsl.py
@@ -233,7 +233,23 @@ def _parse_step(part: str) -> _ChainStep:
     return _ChainStep(name=name, args=args, kwargs=kwargs)
 
 
+# JS/JSON-style bare words LLM agents naturally write in this jQuery-style DSL.
+# Python's ast.literal_eval only knows True/False/None, so ``answer(compact=true)``
+# would otherwise blow up with a cryptic "malformed node or string" error and
+# push the agent off the cheap one-call chain back onto slow multi-call paths.
+_JS_BARE_LITERALS: dict[str, Any] = {
+    "true": True,
+    "false": False,
+    "null": None,
+    "none": None,
+}
+
+
 def _literal(node: ast.AST) -> Any:
+    # Accept bare true/false/null (any case) before literal_eval, which rejects
+    # them as undefined names.
+    if isinstance(node, ast.Name) and node.id.lower() in _JS_BARE_LITERALS:
+        return _JS_BARE_LITERALS[node.id.lower()]
     value = ast.literal_eval(node)
     if isinstance(value, str):
         if len(value) > _MAX_STRING_ARG_LENGTH:


### PR DESCRIPTION
## The insight (user's): borrow virtual-DOM + jQuery

The materialized code graph (ast_cache + edge_store) is a *virtual DOM of the whole project*; `search action=chain` is the *jQuery selector* over it. One selector call can return an entire flow (entry→exit, callers/callees, source) instead of the agent hand-assembling it across 9 nav/search/read calls.

Measured on django: `search('MigrationAutodetector').callees(depth=2).answer(compact=true)` returns the whole flow in **~1.8 KB / one call**, vs the agent's multi-call nav sequence at **~50 KB**.

## The bug that kept agents off this path

The chain parser ran every kwarg through `ast.literal_eval`, which only knows Python `True/False/None`. An LLM agent naturally writes the DSL's own jQuery idiom — `answer(compact=true)` — and got a cryptic `malformed node or string` error, then **abandoned the one-call chain for slow multi-call nav**. That's a major reason the cheapest tool went unused (and why TSA lost the agent-cost benchmark to codegraph).

## Fix

`_literal` maps bare `true`/`false`/`null`/`none` (any case) to Python before `literal_eval`; capitalised Python literals still work.

Verified on django: `...callees(depth=2).answer(compact=true)` → OK 1.8 KB (was ERROR); `explore(..., include_code=true)` → OK.

Test: JS-style booleans + null + back-compat Python literals. 42 DSL/tool tests green; ruff + mypy clean.

> Follow-up (separate PR): route agents to this one-call chain (server instructions + benchmark prompt) so the win actually lands in agent cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)