### PR TITLE
fix(mcp): cap chain/explore inline source at 24 lines (agent cost)

### DIFF
--- a/tests/unit/test_codegraph_query_internals_facets.py
+++ b/tests/unit/test_codegraph_query_internals_facets.py
@@ -213,10 +213,10 @@ class TestCodeGraphQueryInternalsFacets:
                         "kind": "function",
                         "start_line": 1,
                         "end_line": 200,
-                        "code": "\n".join(f"line_{idx}" for idx in range(1, 161))
+                        "code": "\n".join(f"line_{idx}" for idx in range(1, 25))
                         + "\n",
                         "code_truncated": True,
-                        "code_lines": "1-160 of 200",
+                        "code_lines": "1-24 of 200",
                     }
                 ],
             }

--- a/tree_sitter_analyzer/mcp/tools/_codegraph_query_symbols.py
+++ b/tree_sitter_analyzer/mcp/tools/_codegraph_query_symbols.py
@@ -8,7 +8,12 @@ from typing import Any
 from . import _codegraph_explore_helpers as _h
 from . import _codegraph_query_filters as _filters
 
-_MAX_SNIPPET_LINES = 160
+# Inline-body cap per symbol in chain/explore output. 160 lines made the
+# jQuery-chain explore ~6 KB/symbol — the single biggest driver of the chain
+# arm's per-call payload (and the agent-cost gap vs codegraph). 24 lines gives
+# the signature + head; the response carries a ``code_lines: a-b of N`` hint so
+# the agent reads the exact rest only if it must (matches nav context, #293).
+_MAX_SNIPPET_LINES = 24
 _MAX_FILE_BYTES = 1_000_000
 
 


### PR DESCRIPTION
The jQuery-chain explore step (`search('X').explore(include_code=true)`) inlined up to **160 lines per symbol** — the largest driver of the chain arm's per-call payload (~6 KB/symbol). Drop `_MAX_SNIPPET_LINES` 160 → 24 (matches nav context #293); the entry keeps the `code_lines: a-b of N` truncation hint.

Direct (gin): a single explore chain dropped ~6 KB → 2.6 KB. (Deep callee-tree chains are dominated by node count, not snippet size — separate lever.)

166 tests green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)