### PR TITLE
fix(resolver+nav): bind callees to the correct definition (language + test-shadow + unresolved)

### DIFF
--- a/tests/unit/mcp/tools/test_symbol_body_inline.py
+++ b/tests/unit/mcp/tools/test_symbol_body_inline.py
@@ -104,6 +104,42 @@ def test_inline_neighbor_bodies_attaches_body_to_each(tmp_path):
     assert "SMALL_MARKER" in small["body"]["content"]
 
 
+def test_inline_neighbor_body_does_not_cross_languages(tmp_path):
+    """A Python callee with no Python def must not inline a foreign-language body.
+
+    Regression: ``sorted()`` (a Python builtin call, no Python definition) has a
+    call-site ``file`` but no matching def there, so ``_resolve_def`` fell back to
+    ``candidates[0]`` — grabbing a Swift ``func sorted`` body and inlining it
+    under the Python callee. The record carries ``language='python'``; a
+    cross-language body must be suppressed (callee stays body-less).
+    """
+    (tmp_path / "corpus.swift").write_text("func sorted() -> Int {\n    return 1\n}\n")
+    cache = _build_cache(tmp_path)
+    cache.get_conn.return_value.execute(
+        "INSERT INTO ast_index (file_path, symbols_json, language) VALUES (?,?,?)",
+        (
+            "corpus.swift",
+            json.dumps(
+                {
+                    "symbols": [
+                        {"name": "sorted", "kind": "function", "line": 1, "end_line": 3}
+                    ]
+                }
+            ),
+            "swift",
+        ),
+    )
+    cache.get_conn.return_value.commit()
+    # Python callee record: a ``sorted()`` call from a Python file, no end_line.
+    neighbors = [
+        {"name": "sorted", "file": "small.py", "line": 1, "language": "python"}
+    ]
+    enriched = sbi.inline_neighbor_bodies(str(tmp_path), cache, neighbors)
+    assert "body" not in enriched[0], (
+        f"cross-language body inlined: {enriched[0].get('body')}"
+    )
+
+
 def test_inline_neighbor_bodies_caps_at_top_n(tmp_path):
     cache = _build_cache(tmp_path)
     neighbors = [{"name": "small", "file": "small.py", "line": 1} for _ in range(50)]

--- a/tests/unit/mcp/tools/test_symbol_body_inline.py
+++ b/tests/unit/mcp/tools/test_symbol_body_inline.py
@@ -140,6 +140,40 @@ def test_inline_neighbor_body_does_not_cross_languages(tmp_path):
     )
 
 
+def test_inline_neighbor_body_skipped_for_unknown_callee(tmp_path):
+    """An unresolved callee gets no inlined body (it would be a bare-name guess).
+
+    A callee the resolver left ``unknown`` (builtin / dynamic / truly unknown)
+    has no real definition; the def-index fallback could only attach a
+    same-named symbol from elsewhere. Such records stay coordinate-only — both
+    correct and leaner. Resolved callees are unaffected.
+    """
+    cache = _build_cache(tmp_path)
+    neighbors = [
+        # Resolved callee → keeps its body.
+        {
+            "name": "small",
+            "file": "small.py",
+            "line": 1,
+            "callee_resolution": "local",
+            "callee_resolved_file": "small.py",
+        },
+        # Unresolved callee that happens to share the name of a real def.
+        {
+            "name": "small",
+            "file": "small.py",
+            "line": 1,
+            "callee_resolution": "unknown",
+            "callee_resolved_file": "",
+        },
+    ]
+    enriched = sbi.inline_neighbor_bodies(str(tmp_path), cache, neighbors)
+    assert "body" in enriched[0]
+    assert "body" not in enriched[1], (
+        f"unknown callee should stay body-less: {enriched[1].get('body')}"
+    )
+
+
 def test_inline_neighbor_bodies_caps_at_top_n(tmp_path):
     cache = _build_cache(tmp_path)
     neighbors = [{"name": "small", "file": "small.py", "line": 1} for _ in range(50)]

--- a/tests/unit/test_callee_resolution.py
+++ b/tests/unit/test_callee_resolution.py
@@ -118,3 +118,34 @@ def test_resolver_first_match_helpers_avoid_collecting_all_candidates() -> None:
         )
         is None
     )
+
+
+def test_global_fallback_gated_by_language_for_function_less_file() -> None:
+    """Codex P2 #301: a caller file with no indexed functions is still gated.
+
+    The caller language is derived from the file extension, so a Python module
+    -level call must not fall through to a same-named JavaScript symbol.
+    """
+    js = {"name": "get", "file": "widget.js", "language": "javascript", "line": 1}
+    resolver = CalleeResolver(
+        functions_by_name={"get": [js]},
+        functions_by_file={},  # caller.py has no indexed functions
+        name_to_source={},
+    )
+    # ``caller.py`` -> python (by extension); the JS ``get`` must be gated out.
+    assert resolver.resolve_items("get", "caller.py") == []
+
+
+def test_global_fallback_allows_js_ts_family() -> None:
+    """Codex P2 #301: JavaScript and TypeScript are one interop family.
+
+    A ``.js`` caller resolving to a ``.ts`` definition (gradual migration) is
+    valid and must NOT be rejected by the cross-language gate.
+    """
+    ts_target = {"name": "foo", "file": "lib.ts", "language": "typescript", "line": 1}
+    resolver = CalleeResolver(
+        functions_by_name={"foo": [ts_target]},
+        functions_by_file={},
+        name_to_source={},
+    )
+    assert resolver.resolve_items("foo", "app.js") == [(ts_target, 0.5)]

--- a/tests/unit/test_callee_resolution.py
+++ b/tests/unit/test_callee_resolution.py
@@ -149,3 +149,48 @@ def test_global_fallback_allows_js_ts_family() -> None:
         name_to_source={},
     )
     assert resolver.resolve_items("foo", "app.js") == [(ts_target, 0.5)]
+
+
+def test_global_fallback_demotes_test_shadow_for_source_caller() -> None:
+    """Codex/dogfood: a non-test caller must prefer the source def over a test mock.
+
+    ``functions_by_name`` may enumerate the test definition first; a production
+    call must still bind to the real source symbol, not the test shadow.
+    """
+    test_def = {
+        "name": "fts_search",
+        "file": "tests/unit/test_cache.py",
+        "language": "python",
+        "line": 2,
+    }
+    src_def = {
+        "name": "fts_search",
+        "file": "tree_sitter_analyzer/ast_cache.py",
+        "language": "python",
+        "line": 9,
+    }
+    resolver = CalleeResolver(
+        functions_by_name={"fts_search": [test_def, src_def]},  # test enumerated first
+        functions_by_file={},
+        name_to_source={},
+    )
+    files = resolver.resolve_files("fts_search", "tree_sitter_analyzer/mcp/tool.py")
+    assert files, files
+    assert files[0][0] == "tree_sitter_analyzer/ast_cache.py", files
+
+
+def test_global_fallback_keeps_test_target_for_test_caller() -> None:
+    """A test caller may still resolve to a test helper (no demotion)."""
+    test_def = {
+        "name": "fixture_helper",
+        "file": "tests/unit/test_cache.py",
+        "language": "python",
+        "line": 2,
+    }
+    resolver = CalleeResolver(
+        functions_by_name={"fixture_helper": [test_def]},
+        functions_by_file={},
+        name_to_source={},
+    )
+    files = resolver.resolve_files("fixture_helper", "tests/unit/test_other.py")
+    assert files == [("tests/unit/test_cache.py", 0.5)]

--- a/tests/unit/test_unresolved_refs.py
+++ b/tests/unit/test_unresolved_refs.py
@@ -336,6 +336,92 @@ def test_call_does_not_bind_across_languages(tmp_path: Path) -> None:
         cache.close()
 
 
+def _choose_candidate_conn() -> sqlite3.Connection:
+    """Minimal conn for ``_choose_candidate`` (ast_index + ast_imports only)."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(
+        """
+        CREATE TABLE ast_index (file_path TEXT PRIMARY KEY, language TEXT);
+        CREATE TABLE ast_imports (
+            file_path TEXT, module_path TEXT, local_name TEXT, alias_of TEXT
+        );
+        INSERT INTO ast_index VALUES ('app/main.py', 'python');
+        INSERT INTO ast_index VALUES ('zsrc/real.py', 'python');
+        INSERT INTO ast_index VALUES ('tests/test_cache.py', 'python');
+        """
+    )
+    return conn
+
+
+def test_choose_candidate_prefers_source_over_test_shadow() -> None:
+    """A non-test caller must bind to the source def, not the test mock.
+
+    Regression: ``_choose_candidate`` broke ties on ``file_path`` alphabetically,
+    so ``tests/...`` sorted before the source tree and a real method
+    (``fts_search``) bound to its test mock. The test def is now demoted when the
+    caller is not itself a test file.
+    """
+    conn = _choose_candidate_conn()
+    try:
+        row = {
+            "file_path": "app/main.py",
+            "from_node_id": "app/main.py:use_cache:5",
+            "reference_name": "fts_search",
+        }
+        # Test def sorts first alphabetically ('tests/' < 'zsrc/'); source must
+        # still win via the test-demotion tier.
+        candidates = [
+            {
+                "node_id": "tests/test_cache.py:fts_search:2",
+                "id": 1,
+                "name": "fts_search",
+                "file_path": "tests/test_cache.py",
+                "line": 2,
+                "language": "python",
+            },
+            {
+                "node_id": "zsrc/real.py:fts_search:9",
+                "id": 2,
+                "name": "fts_search",
+                "file_path": "zsrc/real.py",
+                "line": 9,
+                "language": "python",
+            },
+        ]
+        chosen = unresolved._choose_candidate(conn, row, candidates)
+        assert chosen is not None
+        assert chosen["file_path"] == "zsrc/real.py", chosen
+    finally:
+        conn.close()
+
+
+def test_choose_candidate_allows_test_target_for_test_caller() -> None:
+    """A test caller may still bind to a test definition (no demotion)."""
+    conn = _choose_candidate_conn()
+    try:
+        row = {
+            "file_path": "tests/test_cache.py",
+            "from_node_id": "tests/test_cache.py:test_fetch:1",
+            "reference_name": "helper",
+        }
+        candidates = [
+            {
+                "node_id": "tests/test_cache.py:helper:2",
+                "id": 1,
+                "name": "helper",
+                "file_path": "tests/test_cache.py",
+                "line": 2,
+                "language": "python",
+            },
+        ]
+        chosen = unresolved._choose_candidate(conn, row, candidates)
+        assert chosen is not None
+        assert chosen["file_path"] == "tests/test_cache.py"
+    finally:
+        conn.close()
+
+
 def test_resolve_unresolved_refs_sqlite_error_paths_are_nonfatal() -> None:
     """Missing schema / broken connections must degrade, not crash."""
     no_schema = sqlite3.connect(":memory:")

--- a/tests/unit/test_unresolved_refs.py
+++ b/tests/unit/test_unresolved_refs.py
@@ -301,6 +301,41 @@ def test_class_hierarchy_cli_reads_resolved_cross_file_edge(tmp_path: Path) -> N
     )
 
 
+def test_call_does_not_bind_across_languages(tmp_path: Path) -> None:
+    """A Python call must not resolve to a same-named symbol in another language.
+
+    Regression: ``_choose_candidate`` scored candidates by import/path/name only,
+    with no language gate. A Python ``config.get(...)`` (bare name ``get``) with no
+    Python ``get`` definition in the tree fell through to *any* repo symbol named
+    ``get`` ordered by file path — binding to a JavaScript ``get`` and inlining its
+    JS body into the Python callee list (wrong AND token-bloat). The call must stay
+    unresolved rather than cross the language boundary.
+    """
+    (tmp_path / "service.py").write_text(
+        "def use_config(config):\n    return config.get('key')\n",
+        encoding="utf-8",
+    )
+    # Only definition of ``get`` anywhere in the tree is this JS method.
+    (tmp_path / "widget.js").write_text(
+        "class Api {\n    get(endpoint) {\n        return fetch(endpoint);\n    }\n}\n",
+        encoding="utf-8",
+    )
+    cache = ASTCache(str(tmp_path))
+    try:
+        cache.index_project(max_files=10, workers=0)
+        callees = cache.query_callees("use_config", "service.py")
+        get_callees = [c for c in callees if c.get("callee_name") == "get"]
+        # The ``get`` call may stay unresolved, but it must NEVER resolve to a
+        # JavaScript file.
+        for callee in get_callees:
+            resolved = str(callee.get("callee_resolved_file") or "")
+            assert not resolved.endswith(".js"), (
+                f"Python call bound across languages to {resolved!r}: {callee}"
+            )
+    finally:
+        cache.close()
+
+
 def test_resolve_unresolved_refs_sqlite_error_paths_are_nonfatal() -> None:
     """Missing schema / broken connections must degrade, not crash."""
     no_schema = sqlite3.connect(":memory:")

--- a/tree_sitter_analyzer/_ast_cache_unresolved.py
+++ b/tree_sitter_analyzer/_ast_cache_unresolved.py
@@ -381,6 +381,20 @@ def _choose_candidate(
     base = _base_name(reference_name)
     import_hints = _import_target_hints(conn, source_file, reference_name)
     eligible = [item for item in candidates if item.get("node_id") != source_node]
+    # Language gate: a reference in a Python file must not bind to a same-named
+    # symbol defined in another language. ``ast_symbol_rows`` is cross-language,
+    # so a Python ``config.get(...)`` with no Python ``get`` in the tree would
+    # otherwise fall through to a JavaScript/Swift ``get`` ordered by file path
+    # (cross-language false callee + foreign body inlined into the response).
+    # Drop foreign-language candidates; if none remain, leave it unresolved.
+    source_lang = _file_language(conn, source_file)
+    if source_lang:
+        eligible = [
+            item
+            for item in eligible
+            if not str(item.get("language") or "")
+            or str(item.get("language")) == source_lang
+        ]
     if not eligible:
         return None
     source_dir = os.path.dirname(source_file)

--- a/tree_sitter_analyzer/_ast_cache_unresolved.py
+++ b/tree_sitter_analyzer/_ast_cache_unresolved.py
@@ -23,6 +23,7 @@ import os
 import sqlite3
 from typing import Any
 
+from ._language_family import languages_compatible
 from .graph.edge_store import Edge, EdgeKind, EdgeStore, parse_node_id, symbol_node
 
 logger = logging.getLogger(__name__)
@@ -393,7 +394,7 @@ def _choose_candidate(
             item
             for item in eligible
             if not str(item.get("language") or "")
-            or str(item.get("language")) == source_lang
+            or languages_compatible(source_lang, str(item.get("language")))
         ]
     if not eligible:
         return None

--- a/tree_sitter_analyzer/_ast_cache_unresolved.py
+++ b/tree_sitter_analyzer/_ast_cache_unresolved.py
@@ -25,6 +25,7 @@ from typing import Any
 
 from ._language_family import languages_compatible
 from .graph.edge_store import Edge, EdgeKind, EdgeStore, parse_node_id, symbol_node
+from .utils.test_detection import is_test_file
 
 logger = logging.getLogger(__name__)
 
@@ -399,14 +400,31 @@ def _choose_candidate(
     if not eligible:
         return None
     source_dir = os.path.dirname(source_file)
+    # A call in production code must not bind to a test-only definition just
+    # because the test file sorts earlier alphabetically. ``fts_search`` /
+    # ``fts_search_ranked`` are real cache methods that were shadowed by their
+    # test mocks (FallbackCache) via the ``file_path`` tiebreak below. Demote
+    # test definitions when the CALLER itself is not a test file (a test caller
+    # may legitimately reference a test helper). Ranks AFTER import/same-file/
+    # same-dir so an explicit local/imported test target still wins.
+    caller_is_source = not is_test_file(source_file)
 
-    def score(item: dict[str, Any]) -> tuple[int, int, int, int, str, int]:
+    def score(item: dict[str, Any]) -> tuple[int, int, int, int, int, str, int]:
         file_path = str(item["file_path"])
         imported = 0 if _matches_import_hint(file_path, import_hints) else 1
         same_file = 0 if file_path == source_file else 1
         same_dir = 0 if os.path.dirname(file_path) == source_dir else 1
+        is_test = 1 if (caller_is_source and is_test_file(file_path)) else 0
         exact = 0 if item["name"] in {reference_name, base} else 1
-        return (imported, same_file, same_dir, exact, file_path, int(item["line"]))
+        return (
+            imported,
+            same_file,
+            same_dir,
+            is_test,
+            exact,
+            file_path,
+            int(item["line"]),
+        )
 
     return sorted(eligible, key=score)[0]
 

--- a/tree_sitter_analyzer/_language_family.py
+++ b/tree_sitter_analyzer/_language_family.py
@@ -1,0 +1,44 @@
+"""Language-family equivalence + lightweight path→language for resolution gates.
+
+The cross-language callee gates (synapse resolver, unresolved-ref candidate
+scoring, the global bare-name fallback, and the nav body inliner) must block a
+*known* language mismatch (Python → JavaScript/Swift) without rejecting
+legitimate same-family resolution. JavaScript and TypeScript are one interop
+family — gradual-migration projects freely cross-import ``.js``/``.ts``/
+``.jsx``/``.tsx`` — and ``CrossFileResolver._register_module_path`` already
+treats them as one import family, so the gates do too (Codex P2 #301).
+"""
+
+from __future__ import annotations
+
+import os
+
+#: Dialects that may legitimately resolve across each other.
+_JS_TS_FAMILY = frozenset({"javascript", "typescript", "jsx", "tsx"})
+
+
+def languages_compatible(a: str, b: str) -> bool:
+    """True when two language tags may legitimately resolve across each other.
+
+    Empty/unknown tags are treated as compatible (the gate only blocks on a
+    *known* mismatch), identical tags are compatible, and the JS/TS dialects
+    form one family.
+    """
+    if not a or not b or a == b:
+        return True
+    return a in _JS_TS_FAMILY and b in _JS_TS_FAMILY
+
+
+def language_from_path(path: str) -> str:
+    """Best-effort language from a file extension; ``""`` when unknown.
+
+    A pure extension lookup (no file stat) so the resolution gates can derive a
+    caller file's language even when it has no indexed function symbols — module
+    -level calls in a function-less file must still be gated (Codex P2 #301).
+    """
+    if not path:
+        return ""
+    from .language_detector import LanguageDetector
+
+    _, ext = os.path.splitext(path)
+    return LanguageDetector.EXTENSION_MAPPING.get(ext.lower(), "")

--- a/tree_sitter_analyzer/callee_resolution.py
+++ b/tree_sitter_analyzer/callee_resolution.py
@@ -159,10 +159,29 @@ class CalleeResolver:
                 _append_file_resolution(results, seen, target_file, 0.7)
 
         if include_global and not results:
+            # Global fallback is a last-resort bare-name match across the whole
+            # project. Gate it to the caller file's own language: a Python
+            # ``config.get(...)`` must never bind to a JavaScript ``get`` just
+            # because no Python ``get`` exists — that produced cross-language
+            # false callees (and inlined foreign-language bodies into the
+            # response, both wrong and token-bloat). When the source language is
+            # unknown, keep the un-gated behaviour.
+            source_lang = self._source_language(source_file)
             for func in self._functions_by_name.get(base_name, []):
+                func_lang = _item_language(func)
+                if source_lang and func_lang and func_lang != source_lang:
+                    continue
                 _append_resolution(results, seen, func, 0.5, keep_items=keep_items)
 
         return results
+
+    def _source_language(self, source_file: str) -> str:
+        """Best-effort language of ``source_file`` from its indexed functions."""
+        for func in self._functions_by_file.get(source_file, []):
+            lang = _item_language(func)
+            if lang:
+                return lang
+        return ""
 
     def _import_target(
         self,
@@ -193,6 +212,12 @@ def _item_file(item: Any) -> str:
     if isinstance(item, dict):
         return str(item.get("file", item.get("file_path", "")))
     return str(getattr(item, "file", getattr(item, "file_path", "")))
+
+
+def _item_language(item: Any) -> str:
+    if isinstance(item, dict):
+        return str(item.get("language", "") or "")
+    return str(getattr(item, "language", "") or "")
 
 
 def _append_resolution(

--- a/tree_sitter_analyzer/callee_resolution.py
+++ b/tree_sitter_analyzer/callee_resolution.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from ._language_family import language_from_path, languages_compatible
+from .utils.test_detection import is_test_file
 
 
 @dataclass(frozen=True)
@@ -169,14 +170,25 @@ class CalleeResolver:
             # response, both wrong and token-bloat). When the source language is
             # unknown, keep the un-gated behaviour.
             source_lang = self._source_language(source_file)
-            for func in self._functions_by_name.get(base_name, []):
-                func_lang = _item_language(func)
-                if (
+            globals_ = [
+                func
+                for func in self._functions_by_name.get(base_name, [])
+                if not (
                     source_lang
-                    and func_lang
-                    and not languages_compatible(source_lang, func_lang)
-                ):
-                    continue
+                    and _item_language(func)
+                    and not languages_compatible(source_lang, _item_language(func))
+                )
+            ]
+            # Demote test-only shadows for a non-test caller: a production call
+            # must not bind to a test mock (e.g. ``fts_search`` -> FallbackCache)
+            # just because the test def is enumerated first. A test caller may
+            # legitimately reference a test helper, so only filter for non-test
+            # callers and only when a non-test def actually exists.
+            if not is_test_file(source_file):
+                non_test = [f for f in globals_ if not is_test_file(_item_file(f))]
+                if non_test:
+                    globals_ = non_test
+            for func in globals_:
                 _append_resolution(results, seen, func, 0.5, keep_items=keep_items)
 
         return results

--- a/tree_sitter_analyzer/callee_resolution.py
+++ b/tree_sitter_analyzer/callee_resolution.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from ._language_family import language_from_path, languages_compatible
+
 
 @dataclass(frozen=True)
 class CalleeResolution:
@@ -169,19 +171,29 @@ class CalleeResolver:
             source_lang = self._source_language(source_file)
             for func in self._functions_by_name.get(base_name, []):
                 func_lang = _item_language(func)
-                if source_lang and func_lang and func_lang != source_lang:
+                if (
+                    source_lang
+                    and func_lang
+                    and not languages_compatible(source_lang, func_lang)
+                ):
                     continue
                 _append_resolution(results, seen, func, 0.5, keep_items=keep_items)
 
         return results
 
     def _source_language(self, source_file: str) -> str:
-        """Best-effort language of ``source_file`` from its indexed functions."""
+        """Best-effort language of ``source_file``.
+
+        Prefer an indexed function's language; fall back to the file extension
+        so module-level calls in a file with no function symbols are still gated
+        (Codex P2 #301 — an empty language here would re-open the ungated
+        cross-language fallback).
+        """
         for func in self._functions_by_file.get(source_file, []):
             lang = _item_language(func)
             if lang:
                 return lang
-        return ""
+        return language_from_path(source_file)
 
     def _import_target(
         self,

--- a/tree_sitter_analyzer/mcp/tools/call_path_enrich.py
+++ b/tree_sitter_analyzer/mcp/tools/call_path_enrich.py
@@ -60,7 +60,9 @@ def _build_def_index(cache: Any, names: set[str]) -> dict[str, list[dict[str, An
         return index
     try:
         conn = cache.get_conn()
-        rows = conn.execute("SELECT file_path, symbols_json FROM ast_index").fetchall()
+        rows = conn.execute(
+            "SELECT file_path, language, symbols_json FROM ast_index"
+        ).fetchall()
     except Exception:
         return index
     for row in rows:
@@ -68,6 +70,11 @@ def _build_def_index(cache: Any, names: set[str]) -> dict[str, list[dict[str, An
             symbols = json.loads(row["symbols_json"]).get("symbols", [])
         except Exception:
             continue
+        row_language = ""
+        try:
+            row_language = str(row["language"] or "")
+        except (IndexError, KeyError):
+            row_language = ""
         for sym in symbols:
             name = sym.get("name")
             if name not in names:
@@ -77,6 +84,7 @@ def _build_def_index(cache: Any, names: set[str]) -> dict[str, list[dict[str, An
             index.setdefault(name, []).append(
                 {
                     "file": row["file_path"],
+                    "language": row_language,
                     "line": int(sym.get("line", 0) or 0),
                     "end_line": int(sym.get("end_line", 0) or 0),
                     "class": sym.get("class"),
@@ -89,11 +97,30 @@ def _resolve_def(
     index: dict[str, list[dict[str, Any]]],
     name: str,
     file_hint: str | None,
+    lang_hint: str | None = None,
 ) -> dict[str, Any] | None:
-    """Pick the best definition span for ``name``, preferring ``file_hint``."""
+    """Pick the best definition span for ``name``, preferring ``file_hint``.
+
+    When ``lang_hint`` is given, a candidate in a *different* language is never
+    returned. The call-site ``file_hint`` is the caller file, so for a callee
+    defined elsewhere the exact-file match misses and the fallback would
+    otherwise return ``candidates[0]`` regardless of language — that is how a
+    Python ``sorted()`` builtin call (no Python def) grabbed a Swift
+    ``func sorted`` body. Gate the fallback so an unresolved/builtin call stays
+    body-less rather than inlining a foreign-language definition.
+    """
     candidates = index.get(name)
     if not candidates:
         return None
+    if lang_hint:
+        same_lang = [
+            cand
+            for cand in candidates
+            if not cand.get("language") or cand.get("language") == lang_hint
+        ]
+        if not same_lang:
+            return None
+        candidates = same_lang
     if file_hint:
         hint = file_hint.replace("\\", "/")
         for cand in candidates:

--- a/tree_sitter_analyzer/mcp/tools/call_path_enrich.py
+++ b/tree_sitter_analyzer/mcp/tools/call_path_enrich.py
@@ -29,6 +29,7 @@ import json
 import os
 from typing import Any
 
+from ..._language_family import languages_compatible
 from ._codegraph_explore_helpers import extract_snippet_from_lines, read_file_lines
 
 # ---------------------------------------------------------------------------
@@ -116,7 +117,8 @@ def _resolve_def(
         same_lang = [
             cand
             for cand in candidates
-            if not cand.get("language") or cand.get("language") == lang_hint
+            if not cand.get("language")
+            or languages_compatible(lang_hint, str(cand.get("language") or ""))
         ]
         if not same_lang:
             return None

--- a/tree_sitter_analyzer/mcp/tools/symbol_body_inline.py
+++ b/tree_sitter_analyzer/mcp/tools/symbol_body_inline.py
@@ -76,6 +76,18 @@ def _record_span(
     if not name or line < 1:
         return None
 
+    # An unresolved callee (resolver could not bind it — a builtin, a dynamic
+    # dispatch, or a truly unknown name) has no real definition. Any body here
+    # would come from the bare-name def-index fallback, i.e. a guess — that is
+    # exactly how a Swift ``func sorted`` body reached a Python ``sorted()``
+    # callee. Skip the body so an unresolved callee stays coordinate-only
+    # (correct, and trims the response). navigate/search records carry no
+    # ``callee_resolution`` key, so they are unaffected.
+    if record.get("callee_resolution") == "unknown" and not record.get(
+        "callee_resolved_file"
+    ):
+        return None
+
     end_line = int(record.get("end_line", 0) or 0)
     if end_line >= line:
         return {

--- a/tree_sitter_analyzer/mcp/tools/symbol_body_inline.py
+++ b/tree_sitter_analyzer/mcp/tools/symbol_body_inline.py
@@ -87,8 +87,12 @@ def _record_span(
         }
 
     # No usable end_line — resolve via the def-index (cap to this one name).
+    # Gate on the record's language so a Python builtin call (no real Python
+    # def) cannot inline a same-named definition from another language (e.g. a
+    # Swift ``func sorted`` body under a Python ``sorted()`` callee).
+    lang_hint = str(record.get("language") or "") or None
     index = _build_def_index(cache, {name})
-    defn = _resolve_def(index, name, file_hint)
+    defn = _resolve_def(index, name, file_hint, lang_hint)
     if defn is None:
         return None
     return {**defn, "name": name}

--- a/tree_sitter_analyzer/synapse_resolver/__init__.py
+++ b/tree_sitter_analyzer/synapse_resolver/__init__.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from .._language_family import languages_compatible
 from ._constants import BUILTINS_PY, STDLIB_NAMES_PY
 from ._context import ResolverContext, build_resolver_context, is_enabled
 from ._imports import ImportEntry, parse_imports
@@ -381,7 +382,7 @@ def _is_cross_language(
     if not caller_lang or not out.resolved_file:
         return False
     target_lang = ctx.file_languages.get(out.resolved_file, "")
-    return bool(target_lang) and target_lang != caller_lang
+    return bool(target_lang) and not languages_compatible(caller_lang, target_lang)
 
 
 __all__ = [

--- a/tree_sitter_analyzer/synapse_resolver/__init__.py
+++ b/tree_sitter_analyzer/synapse_resolver/__init__.py
@@ -347,6 +347,7 @@ def _resolve_callee_python(
     else:
         qualifier, base = _split_qualifier(callee_name)
 
+    caller_lang = ctx.file_languages.get(caller_file, "")
     for rule in (
         lambda: _try_self_method(base, qualifier, caller_file, caller_name, ctx),
         lambda: _try_local(base, caller_file, ctx) if not qualifier else None,
@@ -358,10 +359,29 @@ def _resolve_callee_python(
         lambda: _try_unique_method(base, qualifier, ctx),
     ):
         out = rule()
-        if out is not None:
+        if out is not None and not _is_cross_language(out, caller_lang, ctx):
             return out
 
     return ResolvedCallee(None, "unknown", "")
+
+
+def _is_cross_language(
+    out: ResolvedCallee, caller_lang: str, ctx: ResolverContext
+) -> bool:
+    """True when a project bind crosses a language boundary.
+
+    The project-wide rules (``_try_single_global`` / ``_try_class_method`` /
+    ``_try_unique_method``) scan every file regardless of language, so a Python
+    ``config.get(...)`` whose ``get`` is defined only on a JavaScript class would
+    bind to that JS file — a wrong callee with a foreign-language body inlined
+    into the response. Reject such binds so the cascade falls through to
+    ``unknown`` rather than crossing languages. ``local``/``stdlib`` binds resolve
+    to the caller file or carry no file, so they never trip this.
+    """
+    if not caller_lang or not out.resolved_file:
+        return False
+    target_lang = ctx.file_languages.get(out.resolved_file, "")
+    return bool(target_lang) and target_lang != caller_lang
 
 
 __all__ = [


### PR DESCRIPTION
## Problem — found by dogfooding the chain DSL / nav callees on this repo

Querying the callees of the Python `_resolve_entry_points` returned **wrong same-name binds**: callees resolved to `examples/ModernJavaScript.js` (JS), a Swift `func sorted` body, and real cache methods (`fts_search`/`fts_search_ranked`) bound to their **test mocks** instead of source. One root bug class: **callee resolution binds a call to the wrong definition of the same name.** It's both a correctness bug and a token-cost bug (foreign/guessed bodies inflate the response — the very thing that makes TSA pricier than CG per call).

Callee resolution is **not centralized** — 4 independent paths each resolve callee→file, so each fix had to land in the right writer (traced via `provenance`+`callee_resolution` on the edge).

## Fixes (6 commits, all RED-first)

### A. Cross-language gate — a call must not bind across languages
- `synapse_resolver`: central `_is_cross_language` gate on the cascade output → falls through to `unknown`.
- `_ast_cache_unresolved._choose_candidate`: drop foreign-language candidates before scoring.
- `callee_resolution.CalleeResolver`: gate the global bare-name fallback to caller language.
- **Codex P2 ×2 fixed:** JS↔TS are one interop family (`_language_family.languages_compatible`); caller language derived from file extension when a file has no indexed functions.

### B. Body inlining — no foreign / guessed bodies
- `call_path_enrich._resolve_def`: carries language, gated by `lang_hint` → no cross-language body.
- `symbol_body_inline._record_span`: an **unresolved callee gets no inlined body** (it would be a bare-name guess — the Swift `sorted` case).

### C. Test-shadow demotion — production calls bind to source, not test mocks
- `_choose_candidate` and `CalleeResolver` global fallback: when the caller is **not** a test file, demote test-only definitions (only when a source def exists; test callers keep test helpers). Uses canonical `utils.test_detection.is_test_file` (#294).

## Live proof (in-process, fixed code; the long-running MCP server holds stale code mid-session)
- `get`/`entries`/… : ~~JS `ModernJavaScript.js`~~ → Python.
- `sorted` : resolution `unknown`, **no Swift body** inlined.
- `fts_search`/`fts_search_ranked` : ~~test mock~~ → **`tree_sitter_analyzer/_ast_cache_query.py`** (real source).

## Tests — RED-first, 0 regressions
New: cross-language (resolution+body), JS/TS family, function-less-file language, unknown-callee-no-body, test-shadow demotion (both writer paths). Full sweep green across synapse/unresolved/callee/cross_file/call_path/body-inline/context/nav (**~900 tests**), lint+mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)