### PR TITLE
fix(resolver): add C/C++ to cross-language compatibility families (Codex P2 follow-up to #301)

### DIFF
--- a/tests/unit/test_language_family.py
+++ b/tests/unit/test_language_family.py
@@ -1,0 +1,51 @@
+"""Cross-language compatibility families for callee-resolution gates."""
+
+from __future__ import annotations
+
+import pytest
+
+from tree_sitter_analyzer._language_family import (
+    language_from_path,
+    languages_compatible,
+)
+
+
+@pytest.mark.parametrize(
+    "a,b",
+    [
+        ("python", "python"),  # identical
+        ("javascript", "typescript"),  # JS/TS family
+        ("typescript", "jsx"),
+        ("tsx", "javascript"),
+        ("c", "cpp"),  # C/C++ family (Codex P2: .cpp caller -> .h `c` def)
+        ("cpp", "c"),
+        ("objc", "cpp"),
+        ("python", ""),  # unknown -> never block
+        ("", "swift"),
+    ],
+)
+def test_compatible_pairs(a: str, b: str) -> None:
+    assert languages_compatible(a, b) is True
+
+
+@pytest.mark.parametrize(
+    "a,b",
+    [
+        ("python", "javascript"),
+        ("python", "swift"),
+        ("c", "python"),
+        ("cpp", "javascript"),
+        ("java", "kotlin"),  # interop in practice, but kept distinct for binding
+    ],
+)
+def test_incompatible_pairs(a: str, b: str) -> None:
+    assert languages_compatible(a, b) is False
+
+
+def test_language_from_path_covers_c_cpp_headers() -> None:
+    assert language_from_path("src/util.cpp") == "cpp"
+    # A C++ project's headers index as `c`; the family makes the cross-edge valid.
+    assert language_from_path("src/util.h") == "c"
+    assert language_from_path("a/b/lib.ts") == "typescript"
+    assert language_from_path("x.py") == "python"
+    assert language_from_path("noext") == ""

--- a/tests/unit/test_language_family.py
+++ b/tests/unit/test_language_family.py
@@ -11,40 +11,48 @@ from tree_sitter_analyzer._language_family import (
 
 
 @pytest.mark.parametrize(
-    "a,b",
+    "caller,callee",
     [
         ("python", "python"),  # identical
-        ("javascript", "typescript"),  # JS/TS family
+        ("javascript", "typescript"),  # JS/TS family (symmetric)
         ("typescript", "jsx"),
         ("tsx", "javascript"),
-        ("c", "cpp"),  # C/C++ family (Codex P2: .cpp caller -> .h `c` def)
-        ("cpp", "c"),
-        ("objc", "cpp"),
-        ("python", ""),  # unknown -> never block
-        ("", "swift"),
+        ("cpp", "c"),  # C++ caller → C header (the motivating case)
+        ("objc", "c"),  # Objective-C is a superset of C
+        ("objcpp", "c"),  # Objective-C++ → C
+        ("objcpp", "cpp"),  # Objective-C++ → C++
+        ("objcpp", "objc"),  # Objective-C++ → Objective-C
+        ("python", ""),  # unknown callee → never block
+        ("", "swift"),  # unknown caller → never block
     ],
 )
-def test_compatible_pairs(a: str, b: str) -> None:
-    assert languages_compatible(a, b) is True
+def test_compatible_pairs(caller: str, callee: str) -> None:
+    assert languages_compatible(caller, callee) is True
 
 
 @pytest.mark.parametrize(
-    "a,b",
+    "caller,callee",
     [
         ("python", "javascript"),
         ("python", "swift"),
         ("c", "python"),
         ("cpp", "javascript"),
         ("java", "kotlin"),  # interop in practice, but kept distinct for binding
+        # Directional C-family gates: pure-C and Objective-C must not bind to C++
+        ("c", "cpp"),  # C caller must not bind to C++ definitions
+        ("c", "objc"),  # C caller must not bind to Objective-C
+        ("c", "objcpp"),
+        ("objc", "cpp"),  # Objective-C must not bind to C++ (Codex P2 #302)
+        ("objc", "objcpp"),
     ],
 )
-def test_incompatible_pairs(a: str, b: str) -> None:
-    assert languages_compatible(a, b) is False
+def test_incompatible_pairs(caller: str, callee: str) -> None:
+    assert languages_compatible(caller, callee) is False
 
 
 def test_language_from_path_covers_c_cpp_headers() -> None:
     assert language_from_path("src/util.cpp") == "cpp"
-    # A C++ project's headers index as `c`; the family makes the cross-edge valid.
+    # A C++ project's headers index as `c`; cpp→c is directionally compatible.
     assert language_from_path("src/util.h") == "c"
     assert language_from_path("a/b/lib.ts") == "typescript"
     assert language_from_path("x.py") == "python"

--- a/tree_sitter_analyzer/_language_family.py
+++ b/tree_sitter_analyzer/_language_family.py
@@ -7,37 +7,63 @@ legitimate same-family resolution. JavaScript and TypeScript are one interop
 family — gradual-migration projects freely cross-import ``.js``/``.ts``/
 ``.jsx``/``.tsx`` — and ``CrossFileResolver._register_module_path`` already
 treats them as one import family, so the gates do too (Codex P2 #301).
+
+For C/C++/Objective-C, compatibility is **directional**: a C++ or Objective-C++
+caller may resolve symbols defined in C headers (indexed as ``c``), because
+``.h`` files are typically indexed as ``c`` even when included from ``.cpp``
+translation units. The reverse — a pure-C caller resolving a ``.cpp`` function
+— is a foreign binding and should remain blocked (Codex P2 #302).
 """
 
 from __future__ import annotations
 
 import os
 
-#: Groups of dialects that may legitimately resolve across each other. A call
-#: in one member can bind to a definition in another member of the same group.
-#: MECE intent: list every interop family the indexer can emit so the
-#: cross-language gate never produces a false negative for a real same-family
-#: call (Codex P2 #301: JS/TS, then C/C++ — a `.cpp` caller resolving a
-#: `.h` (indexed as ``c``) header function).
+#: Groups of dialects that may legitimately resolve across each other
+#: in *both* directions. JS/TS projects freely cross-import .js/.ts/.jsx/.tsx
+#: files, so the symmetric set is correct here.
 _LANGUAGE_FAMILIES: tuple[frozenset[str], ...] = (
     frozenset({"javascript", "typescript", "jsx", "tsx"}),
-    frozenset({"c", "cpp", "objc", "objcpp"}),
 )
 
 #: Back-compat alias (some imports referenced the JS/TS set directly).
 _JS_TS_FAMILY = _LANGUAGE_FAMILIES[0]
 
+#: Directed C-family compat: (caller_lang, callee_lang) pairs that are
+#: compatible in ONE direction only. A .cpp caller resolving a .h (indexed
+#: as ``c``) is the canonical case; the reverse is a foreign binding.
+#:
+#: Rules:
+#:   cpp → c      : C++ including a C header (common .h pattern)
+#:   objc → c     : Objective-C is a superset of C; plain C calls are valid
+#:   objcpp → *   : Objective-C++ is a superset of both; all C-family targets ok
+_DIRECTED_C_COMPAT: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("cpp", "c"),
+        ("objc", "c"),
+        ("objcpp", "c"),
+        ("objcpp", "cpp"),
+        ("objcpp", "objc"),
+    }
+)
 
-def languages_compatible(a: str, b: str) -> bool:
-    """True when two language tags may legitimately resolve across each other.
+
+def languages_compatible(caller: str, callee: str) -> bool:
+    """True when *caller* may legitimately resolve a symbol defined in *callee*.
 
     Empty/unknown tags are treated as compatible (the gate only blocks on a
-    *known* mismatch), identical tags are compatible, and dialects in the same
-    interop family (JS/TS, C/C++) are compatible.
+    *known* mismatch). Identical tags are always compatible. JS/TS dialects are
+    a symmetric family. C/C++/ObjC resolution is directional: C++ callers may
+    resolve C headers, but pure-C callers must not bind to C++ definitions
+    (Codex P2 #302).
     """
-    if not a or not b or a == b:
+    if not caller or not callee or caller == callee:
         return True
-    return any(a in family and b in family for family in _LANGUAGE_FAMILIES)
+    # Symmetric families (JS/TS)
+    if any(caller in family and callee in family for family in _LANGUAGE_FAMILIES):
+        return True
+    # Directed C-family
+    return (caller, callee) in _DIRECTED_C_COMPAT
 
 
 def language_from_path(path: str) -> str:

--- a/tree_sitter_analyzer/_language_family.py
+++ b/tree_sitter_analyzer/_language_family.py
@@ -13,20 +13,31 @@ from __future__ import annotations
 
 import os
 
-#: Dialects that may legitimately resolve across each other.
-_JS_TS_FAMILY = frozenset({"javascript", "typescript", "jsx", "tsx"})
+#: Groups of dialects that may legitimately resolve across each other. A call
+#: in one member can bind to a definition in another member of the same group.
+#: MECE intent: list every interop family the indexer can emit so the
+#: cross-language gate never produces a false negative for a real same-family
+#: call (Codex P2 #301: JS/TS, then C/C++ — a `.cpp` caller resolving a
+#: `.h` (indexed as ``c``) header function).
+_LANGUAGE_FAMILIES: tuple[frozenset[str], ...] = (
+    frozenset({"javascript", "typescript", "jsx", "tsx"}),
+    frozenset({"c", "cpp", "objc", "objcpp"}),
+)
+
+#: Back-compat alias (some imports referenced the JS/TS set directly).
+_JS_TS_FAMILY = _LANGUAGE_FAMILIES[0]
 
 
 def languages_compatible(a: str, b: str) -> bool:
     """True when two language tags may legitimately resolve across each other.
 
     Empty/unknown tags are treated as compatible (the gate only blocks on a
-    *known* mismatch), identical tags are compatible, and the JS/TS dialects
-    form one family.
+    *known* mismatch), identical tags are compatible, and dialects in the same
+    interop family (JS/TS, C/C++) are compatible.
     """
     if not a or not b or a == b:
         return True
-    return a in _JS_TS_FAMILY and b in _JS_TS_FAMILY
+    return any(a in family and b in family for family in _LANGUAGE_FAMILIES)
 
 
 def language_from_path(path: str) -> str:


### PR DESCRIPTION
Follow-up to merged #301. Codex P2 on `_language_family.py`:

> `languages_compatible('cpp','c')` returns false. A C++ caller resolving a function defined only in a `.h` file (LanguageDetector indexes `.h`→`c`, `.cpp`→`cpp`) is dropped by the cross-language gate → valid C++ calls to header-defined functions left unresolved.

**Verdict: real.** Same false-negative class as the JS/TS finding. Fix: generalize the single JS/TS set to a **list of interop families** (`{js,ts,jsx,tsx}`, `{c,cpp,objc,objcpp}`), so `languages_compatible` only blocks a genuine cross-*family* mismatch (Python→Swift/JS) and never a same-family dialect pair. MECE by construction — new families are one line.

Tests: `tests/unit/test_language_family.py` pins the full compatible/incompatible matrix + `.h`→`c` / `.cpp`→`cpp` path detection. `test_callee_resolution` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)