### PR TITLE
perf(retrieval): cut cold-start first-retrieval from ~42.5s to ~7ms

### DIFF
--- a/tests/unit/test_auto_index_guard_convergence.py
+++ b/tests/unit/test_auto_index_guard_convergence.py
@@ -191,6 +191,7 @@ def test_resolution_converged_helpers_degrade_on_broken_cache() -> None:
     from tree_sitter_analyzer.mcp.utils.auto_index_guard import (
         _mark_resolution_converged,
         _resolution_converged,
+        _resolve_pending_unresolved_refs,
     )
 
     class BrokenCache:
@@ -198,4 +199,36 @@ def test_resolution_converged_helpers_degrade_on_broken_cache() -> None:
             raise RuntimeError("broken")
 
     assert _resolution_converged(BrokenCache()) is False
+    assert _resolve_pending_unresolved_refs(BrokenCache()) is False
     _mark_resolution_converged(BrokenCache())  # must not raise
+
+
+def test_ensure_indexed_does_not_mark_converged_on_resolve_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If _resolve_pending_unresolved_refs fails, convergence must NOT be persisted."""
+    _project(tmp_path)
+    cache = ASTCache(str(tmp_path))
+    try:
+        cache.index_project(max_files=10, workers=0)
+        cache.get_conn().execute("DROP TABLE IF EXISTS ast_resolve_state")
+        cache.get_conn().commit()
+    finally:
+        cache.close()
+
+    auto_index_guard.reset()
+
+    def broken_index_project(self: Any, *args: Any, **kwargs: Any) -> Any:
+        if kwargs.get("resolve_only"):
+            raise RuntimeError("disk full, resolve aborted")
+        raise RuntimeError("unexpected call")
+
+    monkeypatch.setattr(ASTCache, "index_project", broken_index_project)
+    try:
+        result = auto_index_guard.ensure_indexed(str(tmp_path), max_files=20)
+        # Cache is pre-indexed so ensure_indexed still returns it.
+        assert result is not None
+        # Resolve failed → convergence must NOT have been marked.
+        assert resolution_converged(result.get_conn()) is False
+    finally:
+        auto_index_guard.reset()

--- a/tests/unit/test_auto_index_guard_convergence.py
+++ b/tests/unit/test_auto_index_guard_convergence.py
@@ -1,0 +1,128 @@
+"""Cold-start fast path: ensure_indexed must not re-run a converged resolve.
+
+A fully-indexed, unchanged cache is already queryable. The cross-file resolve
+pass converges in one pass and is re-run by the indexing path on every file
+change, so re-running it on a cold ``ensure_indexed`` when the index is
+unchanged is a ~40 s no-op that blocks the first retrieval. These tests pin the
+convergence fingerprint + skip behaviour.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tree_sitter_analyzer._ast_cache_unresolved import (
+    index_resolution_fingerprint,
+    resolution_converged,
+)
+from tree_sitter_analyzer.ast_cache import ASTCache
+from tree_sitter_analyzer.mcp.utils import auto_index_guard
+
+
+def _project(root: Path) -> None:
+    (root / "a.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+    (root / "b.py").write_text(
+        "from a import f\n\ndef g():\n    return f()\n", encoding="utf-8"
+    )
+    # A class extending an EXTERNAL base keeps pending_unresolved_count > 0
+    # (it never resolves — base not in the project), so the OLD cold-start path
+    # would re-run the resolve-only pass on every ensure_indexed. This is what
+    # the convergence skip must short-circuit.
+    (root / "c.py").write_text("class C(Exception):\n    pass\n", encoding="utf-8")
+
+
+def test_index_project_marks_resolution_converged(tmp_path: Path) -> None:
+    _project(tmp_path)
+    cache = ASTCache(str(tmp_path))
+    try:
+        cache.index_project(max_files=10, workers=0)
+        # _post_index_backfill records the convergence fingerprint.
+        assert resolution_converged(cache.get_conn()) is True
+        assert index_resolution_fingerprint(cache.get_conn())
+    finally:
+        cache.close()
+
+
+def test_converged_false_after_a_file_is_reindexed(tmp_path: Path) -> None:
+    _project(tmp_path)
+    cache = ASTCache(str(tmp_path))
+    try:
+        cache.index_project(max_files=10, workers=0)
+        assert resolution_converged(cache.get_conn()) is True
+        # Re-index one file → indexed_at moves → fingerprint differs → the stored
+        # convergence marker no longer matches, so a resolve is warranted again.
+        time.sleep(0.01)
+        (tmp_path / "a.py").write_text(
+            "def f():\n    return 2\n\ndef h():\n    return 3\n", encoding="utf-8"
+        )
+        cache.index_file(str(tmp_path / "a.py"))
+        assert resolution_converged(cache.get_conn()) is False
+    finally:
+        cache.close()
+
+
+def test_ensure_indexed_skips_resolve_when_converged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _project(tmp_path)
+    cache = ASTCache(str(tmp_path))
+    try:
+        cache.index_project(max_files=10, workers=0)
+    finally:
+        cache.close()
+
+    auto_index_guard.reset()
+    resolve_only_calls: list[int] = []
+    real_index_project = ASTCache.index_project
+
+    def spy(self: Any, *args: Any, **kwargs: Any) -> Any:
+        if kwargs.get("resolve_only"):
+            resolve_only_calls.append(1)
+        return real_index_project(self, *args, **kwargs)
+
+    monkeypatch.setattr(ASTCache, "index_project", spy)
+    try:
+        cache = auto_index_guard.ensure_indexed(str(tmp_path), max_files=20)
+        assert cache is not None
+        # Converged → the cold path must NOT run a resolve-only pass.
+        assert resolve_only_calls == []
+    finally:
+        auto_index_guard.reset()
+
+
+def test_ensure_indexed_resolves_when_not_converged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _project(tmp_path)
+    cache = ASTCache(str(tmp_path))
+    try:
+        cache.index_project(max_files=10, workers=0)
+        # Wipe the convergence marker to simulate an index built without the
+        # final mark (legacy cache / partial build).
+        cache.get_conn().execute("DROP TABLE IF EXISTS ast_resolve_state")
+        cache.get_conn().commit()
+        assert resolution_converged(cache.get_conn()) is False
+    finally:
+        cache.close()
+
+    auto_index_guard.reset()
+    resolve_only_calls: list[int] = []
+    real_index_project = ASTCache.index_project
+
+    def spy(self: Any, *args: Any, **kwargs: Any) -> Any:
+        if kwargs.get("resolve_only"):
+            resolve_only_calls.append(1)
+        return real_index_project(self, *args, **kwargs)
+
+    monkeypatch.setattr(ASTCache, "index_project", spy)
+    try:
+        cache = auto_index_guard.ensure_indexed(str(tmp_path), max_files=20)
+        assert cache is not None
+        # Not converged → resolve runs once, and the marker is then persisted.
+        assert resolution_converged(cache.get_conn()) is True
+    finally:
+        auto_index_guard.reset()

--- a/tests/unit/test_auto_index_guard_convergence.py
+++ b/tests/unit/test_auto_index_guard_convergence.py
@@ -9,6 +9,7 @@ convergence fingerprint + skip behaviour.
 
 from __future__ import annotations
 
+import sqlite3
 import time
 from pathlib import Path
 from typing import Any
@@ -17,10 +18,34 @@ import pytest
 
 from tree_sitter_analyzer._ast_cache_unresolved import (
     index_resolution_fingerprint,
+    mark_resolution_converged,
     resolution_converged,
 )
 from tree_sitter_analyzer.ast_cache import ASTCache
 from tree_sitter_analyzer.mcp.utils import auto_index_guard
+
+
+def test_resolution_helpers_degrade_on_missing_tables() -> None:
+    """No ast_index / ast_resolve_state → helpers return safe defaults, no raise."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    try:
+        # ast_index absent → empty fingerprint, not converged, mark is a no-op.
+        assert index_resolution_fingerprint(conn) == ""
+        assert resolution_converged(conn) is False
+        mark_resolution_converged(conn)  # must not raise
+
+        # ast_index present but ast_resolve_state absent → converged False, then
+        # mark creates the table and persists; a second call reports converged.
+        conn.execute("CREATE TABLE ast_index (file_path TEXT, indexed_at TEXT)")
+        conn.execute("INSERT INTO ast_index VALUES ('a.py', '2026-01-01T00:00:00Z')")
+        conn.commit()
+        assert index_resolution_fingerprint(conn) == "1:2026-01-01T00:00:00Z"
+        assert resolution_converged(conn) is False
+        mark_resolution_converged(conn)
+        assert resolution_converged(conn) is True
+    finally:
+        conn.close()
 
 
 def _project(root: Path) -> None:

--- a/tests/unit/test_auto_index_guard_convergence.py
+++ b/tests/unit/test_auto_index_guard_convergence.py
@@ -151,3 +151,51 @@ def test_ensure_indexed_resolves_when_not_converged(
         assert resolution_converged(cache.get_conn()) is True
     finally:
         auto_index_guard.reset()
+
+
+def test_resolution_converged_false_when_state_table_empty() -> None:
+    """ast_resolve_state exists but has no rows → resolution_converged returns False (row is None)."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    try:
+        conn.execute("CREATE TABLE ast_index (file_path TEXT, indexed_at TEXT)")
+        conn.execute("INSERT INTO ast_index VALUES ('a.py', '2026-01-01T00:00:00Z')")
+        conn.execute(
+            "CREATE TABLE ast_resolve_state "
+            "(id INTEGER PRIMARY KEY, fingerprint TEXT NOT NULL)"
+        )
+        conn.commit()
+        assert resolution_converged(conn) is False
+    finally:
+        conn.close()
+
+
+def test_mark_resolution_converged_handles_operational_error(tmp_path: Path) -> None:
+    """Read-only connection → mark_resolution_converged hits OperationalError handler without raising."""
+    dbfile = tmp_path / "test.db"
+    conn = sqlite3.connect(str(dbfile))
+    conn.execute("CREATE TABLE ast_index (file_path TEXT, indexed_at TEXT)")
+    conn.execute("INSERT INTO ast_index VALUES ('a.py', '2026-01-01T00:00:00Z')")
+    conn.commit()
+    conn.close()
+    ro_conn = sqlite3.connect(f"file:{dbfile}?mode=ro", uri=True)
+    ro_conn.row_factory = sqlite3.Row
+    try:
+        mark_resolution_converged(ro_conn)  # must not raise
+    finally:
+        ro_conn.close()
+
+
+def test_resolution_converged_helpers_degrade_on_broken_cache() -> None:
+    """_resolution_converged/_mark_resolution_converged swallow exceptions from a broken cache."""
+    from tree_sitter_analyzer.mcp.utils.auto_index_guard import (
+        _mark_resolution_converged,
+        _resolution_converged,
+    )
+
+    class BrokenCache:
+        def get_conn(self) -> None:
+            raise RuntimeError("broken")
+
+    assert _resolution_converged(BrokenCache()) is False
+    _mark_resolution_converged(BrokenCache())  # must not raise

--- a/tree_sitter_analyzer/_ast_cache_unresolved.py
+++ b/tree_sitter_analyzer/_ast_cache_unresolved.py
@@ -176,6 +176,64 @@ def pending_unresolved_count(conn: sqlite3.Connection) -> int:
     return int(row["c"] if isinstance(row, sqlite3.Row) else row[0])
 
 
+def index_resolution_fingerprint(conn: sqlite3.Connection) -> str:
+    """Cheap fingerprint of the indexed-file set: ``"<count>:<max indexed_at>"``.
+
+    Changes whenever any file is (re)indexed (``indexed_at`` moves) or a file is
+    added/removed (count moves). Used to detect that the cross-file resolve pass
+    has already converged for the *current* index state, so a cold
+    ``ensure_indexed`` can skip a redundant ~40 s resolve-only pass (the pending
+    EXTENDS/CALLS refs that survive a pass are terminal — external bases,
+    dynamic dispatch — and never resolve, so re-running is pure waste).
+    """
+    try:
+        row = conn.execute(
+            "SELECT COUNT(*) AS c, COALESCE(MAX(indexed_at), '') AS m FROM ast_index"
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return ""
+    count = row["c"] if isinstance(row, sqlite3.Row) else row[0]
+    stamp = row["m"] if isinstance(row, sqlite3.Row) else row[1]
+    return f"{count}:{stamp}"
+
+
+def resolution_converged(conn: sqlite3.Connection) -> bool:
+    """True when the resolve pass already ran for the current index state."""
+    fingerprint = index_resolution_fingerprint(conn)
+    if not fingerprint:
+        return False
+    try:
+        row = conn.execute(
+            "SELECT fingerprint FROM ast_resolve_state WHERE id = 1"
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return False
+    if row is None:
+        return False
+    stored = row["fingerprint"] if isinstance(row, sqlite3.Row) else row[0]
+    return bool(stored) and stored == fingerprint
+
+
+def mark_resolution_converged(conn: sqlite3.Connection) -> None:
+    """Persist that the resolve pass has converged for the current index state."""
+    fingerprint = index_resolution_fingerprint(conn)
+    if not fingerprint:
+        return
+    try:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS ast_resolve_state "
+            "(id INTEGER PRIMARY KEY, fingerprint TEXT NOT NULL)"
+        )
+        conn.execute(
+            "INSERT INTO ast_resolve_state (id, fingerprint) VALUES (1, ?) "
+            "ON CONFLICT(id) DO UPDATE SET fingerprint = excluded.fingerprint",
+            (fingerprint,),
+        )
+        conn.commit()
+    except sqlite3.OperationalError:
+        logger.debug("could not persist resolution fingerprint", exc_info=True)
+
+
 def _ref(
     from_node_id: str,
     reference_name: str,

--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -399,6 +399,15 @@ class ASTCache:
                 stats["unresolved_refs_backfill"] = unresolved
         except Exception:
             logger.debug("unresolved refs backfill failed", exc_info=True)
+        # Record that resolution has converged for this index state so a later
+        # cold ensure_indexed() can skip a redundant resolve-only pass (~40 s
+        # no-op) instead of blocking the first retrieval.
+        try:
+            from ._ast_cache_unresolved import mark_resolution_converged
+
+            mark_resolution_converged(self._get_conn())
+        except Exception:
+            logger.debug("could not mark resolution converged", exc_info=True)
 
     def _refresh_graph_edges_from_cache(
         self, file_paths: list[str] | None = None

--- a/tree_sitter_analyzer/mcp/utils/auto_index_guard.py
+++ b/tree_sitter_analyzer/mcp/utils/auto_index_guard.py
@@ -91,8 +91,8 @@ def ensure_indexed(
             # resolve already converged for this exact index state; the first
             # retrieval then returns in ms instead of blocking for ~40 s.
             if not _resolution_converged(cache):
-                _resolve_pending_unresolved_refs(cache)
-                _mark_resolution_converged(cache)
+                if _resolve_pending_unresolved_refs(cache):
+                    _mark_resolution_converged(cache)
             _indexed_roots[project_root] = True
             return cache
 
@@ -124,14 +124,17 @@ def _open_cache(project_root: str) -> Any:
         return None
 
 
-def _resolve_pending_unresolved_refs(cache: Any) -> None:
+def _resolve_pending_unresolved_refs(cache: Any) -> bool:
+    """Attempt the resolve-only pass. Returns True on success, False if it failed."""
     try:
         from ..._ast_cache_unresolved import pending_unresolved_count
 
         if pending_unresolved_count(cache.get_conn()) > 0:
             cache.index_project(resolve_only=True)
+        return True
     except Exception:
         logger.debug("auto-index: unresolved_refs resolve-only failed", exc_info=True)
+        return False
 
 
 def _resolution_converged(cache: Any) -> bool:

--- a/tree_sitter_analyzer/mcp/utils/auto_index_guard.py
+++ b/tree_sitter_analyzer/mcp/utils/auto_index_guard.py
@@ -83,7 +83,16 @@ def ensure_indexed(
 
         stats = cache.get_stats()
         if stats.get("total_files", 0) > 0:
-            _resolve_pending_unresolved_refs(cache)
+            # Cold-start fast path: a fully-indexed cache is already queryable.
+            # The cross-file resolve pass converges in one pass and is re-run by
+            # the indexing path on every file change, so re-running it here when
+            # the index is UNCHANGED is a ~40 s no-op (the surviving pending refs
+            # are terminal — external bases / dynamic dispatch). Skip it when the
+            # resolve already converged for this exact index state; the first
+            # retrieval then returns in ms instead of blocking for ~40 s.
+            if not _resolution_converged(cache):
+                _resolve_pending_unresolved_refs(cache)
+                _mark_resolution_converged(cache)
             _indexed_roots[project_root] = True
             return cache
 
@@ -123,6 +132,24 @@ def _resolve_pending_unresolved_refs(cache: Any) -> None:
             cache.index_project(resolve_only=True)
     except Exception:
         logger.debug("auto-index: unresolved_refs resolve-only failed", exc_info=True)
+
+
+def _resolution_converged(cache: Any) -> bool:
+    try:
+        from ..._ast_cache_unresolved import resolution_converged
+
+        return bool(resolution_converged(cache.get_conn()))
+    except Exception:
+        return False
+
+
+def _mark_resolution_converged(cache: Any) -> None:
+    try:
+        from ..._ast_cache_unresolved import mark_resolution_converged
+
+        mark_resolution_converged(cache.get_conn())
+    except Exception:
+        logger.debug("auto-index: could not mark resolution converged", exc_info=True)
 
 
 def mark_dirty(project_root: str) -> None:


### PR DESCRIPTION
## The bottleneck (MECE breakdown of "initial retrieval time")

| stage | time |
|---|---|
| module import (one-time at server startup) | ~38 ms |
| **cold `ensure_indexed` (first query)** | **42,535 ms** |
| raw FTS5 query | 0.47 ms |
| symbol search (warm) | 1.07 ms |

TSA's actual retrieval is **sub-millisecond**. The entire "initial retrieval time" an agent waits for was a **42.5-second cold-start `ensure_indexed`** — even on an already-built index.

## Root cause

`ensure_indexed` on a fully-indexed cache calls `index_project(resolve_only=True)` whenever `pending_unresolved_count() > 0`. That count **stays > 0 forever**: the surviving pending EXTENDS refs point at **external** bases (`Exception`, `ABC`, `Enum`, `str`…) and surviving CALLS are terminal (builtins / dynamic dispatch). They never resolve, so the pass is a **no-op re-run on every first query**:

```
pending_unresolved_count: 357   (never drops)
pass1:  40,405 ms  resolved=525 unchanged=15269  pending_after=357
pass2:  40,819 ms  resolved=525 unchanged=15269  pending_after=357   (byte-for-byte identical)
```

## Fix

Fingerprint the index state — `(file_count, max(indexed_at))` — and persist it in a tiny `ast_resolve_state` table once the resolve pass converges (in `_post_index_backfill` and after the guard's own resolve). A cold `ensure_indexed` **skips the resolve when the fingerprint matches**:

```
ensure_indexed COLD (converged): 42,535 ms -> 6.6 ms   (~6400x)
first symbol search after:        16.4 ms
```

**Correctness preserved:** any file change moves `max(indexed_at)` so the fingerprint differs and the resolve runs again when there is genuinely new cross-file work. The indexing path keeps resolution up to date exactly as before; this only removes the *redundant* re-run on an unchanged index.

## Tests (RED-first, 0 regressions)

`test_ensure_indexed_skips_resolve_when_converged` fails without the skip (verified). Plus: fingerprint roundtrip, reindex invalidation, and not-converged-still-resolves. Broad sweep green across auto_index_guard / unresolved_refs / ast_cache / synapse / metrics (~360 tests), lint+mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
