### PR TITLE
refactor(ast_cache): reduce nesting depth D→C (auto-sprint #260)

### DIFF
--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -386,19 +386,25 @@ class ASTCache:
         # time) for an IDENTICAL edge set (244,590 rows either way, verified).
         # Only refresh when insert could NOT have written them (no FTS5), where
         # this pass is the sole edge writer.
-        if not self.fts5_available:
-            try:
-                stats["edge_store_refresh"] = self._refresh_graph_edges_from_cache(
-                    indexed_files
-                )
-            except Exception:
-                logger.debug("edge store refresh failed", exc_info=True)
+        self._maybe_refresh_edge_store(stats, indexed_files)
         try:
             unresolved = self._run_unresolved_refs_backfill()
             if unresolved is not None:
                 stats["unresolved_refs_backfill"] = unresolved
         except Exception:
             logger.debug("unresolved refs backfill failed", exc_info=True)
+
+    def _maybe_refresh_edge_store(
+        self, stats: dict[str, Any], indexed_files: list[str]
+    ) -> None:
+        if self.fts5_available:
+            return
+        try:
+            stats["edge_store_refresh"] = self._refresh_graph_edges_from_cache(
+                indexed_files
+            )
+        except Exception:
+            logger.debug("edge store refresh failed", exc_info=True)
 
     def _refresh_graph_edges_from_cache(
         self, file_paths: list[str] | None = None
@@ -412,18 +418,15 @@ class ASTCache:
                 "SELECT file_path, language, symbols_json, imports_json FROM ast_index"
             ).fetchall()
         else:
-            rows = [
-                row
-                for rel_path in file_paths
-                if (
-                    row := conn.execute(
-                        "SELECT file_path, language, symbols_json, imports_json "
-                        "FROM ast_index WHERE file_path = ?",
-                        (rel_path,),
-                    ).fetchone()
-                )
-                is not None
-            ]
+            rows = []
+            for rel_path in file_paths:
+                row = conn.execute(
+                    "SELECT file_path, language, symbols_json, imports_json "
+                    "FROM ast_index WHERE file_path = ?",
+                    (rel_path,),
+                ).fetchone()
+                if row is not None:
+                    rows.append(row)
         refreshed = errors = 0
         for row in rows:
             try:


### PR DESCRIPTION
## Why

`ast_cache.py` scored Grade D (69.5) in the auto-sprint health check (#260), with `structure` dimension at 45/100. Two nested patterns were responsible:

1. **Walrus operator inside list comprehension** — 6-level nesting. Replaced with a plain for-loop (no behaviour change, same SQL).
2. **`if not fts5_available` + `try`** inside `_post_index_backfill` — extracted to `_maybe_refresh_edge_store()` (early-return style) to remove one nesting level.

## After

| dimension | before | after |
|---|---|---|
| structure | 45 | 60 |
| grade | D (69.5) | C (72.3) |

79 ast_cache tests green. No behaviour change.

Closes #260