### PR TITLE
feat(health): wire CodeGraphTestGapTool into health facade (RFC-0003 pre-req)

### DIFF
--- a/docs/CODEMAPS/mcp-tools.md
+++ b/docs/CODEMAPS/mcp-tools.md
@@ -15,7 +15,7 @@ All tools default to **TOON output** (locked — see `CLAUDE.md`).
 | `search` | symbol / query / content / grep / batch / chain | Code search: BM25 symbol lookup, tree-sitter .scm DSL, ripgrep, fd+rg, batch, graph-chain DSL |
 | `nav` | navigate / call_path / xref / resolve / lineage / impact / trace / context / callers / callees | Call-graph navigation + one-call symbol context |
 | `structure` | outline / analyze / ast_path / sitemap / class_tree / class_detail / explore / read | Structural AST analysis + partial file read |
-| `health` | project / file / scale / patterns / heatmap / imports / matrix / dead / routes / overview / deps | Code health, complexity, dependency analysis |
+| `health` | project / file / scale / patterns / heatmap / imports / matrix / dead / routes / overview / deps / test_gap | Code health, complexity, dependency analysis, untested symbol discovery |
 | `edit` | safe / guard / impact / refactor / constraints / pr / classify / ast_diff | Edit-safety, blast-radius, refactor, PR review |
 | `project` | overview / files / smart / parser / tools / metrics / skills / workflow / journal / doc_sync | Project-intelligence hub |
 | `index` | status / cache / build / full / auto / sync | CodeGraph index lifecycle |

--- a/tests/unit/mcp/tools/test_health_facade.py
+++ b/tests/unit/mcp/tools/test_health_facade.py
@@ -48,6 +48,7 @@ _ALL_ACTIONS = frozenset(
         "routes",
         "overview",
         "deps",
+        "test_gap",  # RFC-0003 pre-req: wired from orphaned CodeGraphTestGapTool
     }
 )
 
@@ -142,10 +143,10 @@ def test_health_facade_builds_and_has_all_actions() -> None:
 
 
 def test_health_facade_total_action_count() -> None:
-    """11 actions total — uml/graph/similarity moved to the ``viz`` facade."""
+    """12 actions total — uml/graph/similarity moved to viz; test_gap wired (RFC-0003)."""
     facade = build_health_facade(project_root=None)
     total = len(facade.action_map) + len(facade.bespoke_map)
-    assert total == 11
+    assert total == 12
 
 
 def test_health_facade_does_not_contain_viz_actions() -> None:

--- a/tests/unit/test_agent_contracts.py
+++ b/tests/unit/test_agent_contracts.py
@@ -792,6 +792,7 @@ def test_facade_delegation_routes_each_action_to_expected_inner() -> None:
         ("health", "routes"): "RouteDetectorTool",
         ("health", "overview"): "CodeGraphOverviewTool",
         ("health", "deps"): "DependencyAnalysisTool",
+        ("health", "test_gap"): "CodeGraphTestGapTool",
         ("edit", "safe"): "SafeToEditTool",
         ("edit", "guard"): "ModificationGuardTool",
         ("edit", "impact"): "ChangeImpactTool",

--- a/tree_sitter_analyzer/mcp/tools/health_facade.py
+++ b/tree_sitter_analyzer/mcp/tools/health_facade.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """``health`` facade — Wave B facade for the FacadeTool framework (P0 geode layer).
 
-Folds 11 health/analysis capabilities behind one ``action`` parameter.
+Folds 12 health/analysis capabilities behind one ``action`` parameter.
 The ``uml`` / ``graph`` / ``similarity`` trio have been split into the
 separate ``viz`` facade (see ``viz_facade.py``).
 
@@ -20,6 +20,7 @@ routes      ``route_detector``  (RouteDetectorTool)      HTTP route discovery
 overview    ``codegraph_overview``                       entry-points / hubs / dead summary
 deps        ``analyze_dependencies`` (R5)                dependency analysis — mode sub-param:
                                                          summary|cycles|blast|file_deps
+test_gap    ``codegraph_test_gap`` (CodeGraphTestGapTool) untested symbol discovery, complexity-ranked
 ==========  ===========================================  ===================================================
 
 R5 (PRD §3): ``deps`` maps to the single ``DependencyAnalysisTool`` whose
@@ -84,6 +85,9 @@ _HEALTH_DESCRIPTION = (
     "  mode=cycles: detect circular dependencies.\n"
     "  mode=blast: blast-radius for a given file_path.\n"
     "  mode=file_deps: file-level dependency details.\n"
+    "- action=test_gap — untested symbol discovery ranked by cyclomatic complexity. "
+    "Params: mode (summary|gaps|file), file_path, language, max_files, max_gaps, "
+    "include_covered, output_format.\n"
     "For UML diagrams, call/dependency graph visualizations, and similarity "
     "analysis, use the ``viz`` facade instead."
 )
@@ -110,6 +114,7 @@ def build_health_facade(project_root: str | None = None) -> FacadeTool:
     from .import_graph_tool import CodeGraphImportGraphTool
     from .project_health_tool import ProjectHealthTool
     from .route_detector_tool import RouteDetectorTool
+    from .test_gap_tool import CodeGraphTestGapTool
 
     facade = FacadeTool(
         facade_name="health",
@@ -128,6 +133,8 @@ def build_health_facade(project_root: str | None = None) -> FacadeTool:
             "overview": CodeGraphOverviewTool(project_root),
             # R5: deps — multi-mode, ``mode`` kept by projection filter automatically
             "deps": DependencyAnalysisTool(project_root),
+            # RFC-0003 pre-requisite: wire orphaned test-gap tool into the facade
+            "test_gap": CodeGraphTestGapTool(project_root),
         },
         bespoke_map={},  # no F5 bespoke routes needed for health
         description=_HEALTH_DESCRIPTION,


### PR DESCRIPTION
## Why

`CodeGraphTestGapTool` was implemented and tested but unreachable from any MCP facade or CLI flag since the Wave-C facade cutover — an orphan (noted in RFC-0003 as a pre-requisite).

## What

- Adds `action=test_gap` to `build_health_facade()` — agents can now call `codegraph_health action=test_gap`
- Updates `_HEALTH_DESCRIPTION` to document the new action (mode: summary|gaps|file)
- Docstring table: 11 → 12 actions
- Tests: `_ALL_ACTIONS` += `test_gap`, count 11 → 12 (23 tests pass)
- `docs/CODEMAPS/mcp-tools.md`: health facade action list includes `test_gap`

## Verification

```bash
uv run python -c "
from tree_sitter_analyzer.mcp.tools.health_facade import build_health_facade
import asyncio
f = build_health_facade('.')
r = asyncio.run(f.execute({'action': 'test_gap', 'mode': 'summary', 'max_files': 5}))
print(r.keys())  # success, verdict, coverage_pct, ...
"
```

Part of RFC-0003 (coverage-aware test-gap analysis).