### PR TITLE
feat(index): classify class methods as kind=method (CodeGraph parity)

### DIFF
--- a/tests/unit/test_ast_cache.py
+++ b/tests/unit/test_ast_cache.py
@@ -909,9 +909,7 @@ class TestPostIndexEdgeRefreshSkip:
         c = ASTCache(str(tmp_project))
         try:
             # Force the no-FTS5 path so the refresh becomes the sole edge writer.
-            monkeypatch.setattr(
-                type(c), "fts5_available", property(lambda self: False)
-            )
+            monkeypatch.setattr(type(c), "fts5_available", property(lambda self: False))
             calls = {"n": 0}
             orig = c._refresh_graph_edges_from_cache
 
@@ -925,3 +923,143 @@ class TestPostIndexEdgeRefreshSkip:
             assert calls["n"] == 1
         finally:
             c.close()
+
+
+# ---------------------------------------------------------------------------
+# kind="method" classification (RED-first, see feature/kind-method-classification)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def method_project(tmp_path):
+    """A minimal Python project with one class method and one top-level function."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "animals.py").write_text(
+        "class Dog:\n"
+        "    def bark(self):\n"
+        "        return 'woof'\n"
+        "\n"
+        "def standalone():\n"
+        "    pass\n"
+    )
+    return tmp_path
+
+
+class TestMethodKindClassification:
+    """Verify that class methods are stored as kind='method', not kind='function'."""
+
+    def test_method_stored_as_kind_method(self, method_project):
+        """After indexing a file with a class method, ast_symbol_rows must have
+        at least one row with kind='method'."""
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        c = ASTCache(str(method_project))
+        try:
+            c.index_project()
+            conn = c._get_conn()
+            method_count = conn.execute(
+                "SELECT COUNT(*) FROM ast_symbol_rows WHERE kind='method'"
+            ).fetchone()[0]
+            assert method_count > 0, (
+                "Expected at least one kind='method' row but got 0. "
+                "Class methods are being incorrectly stored as kind='function'."
+            )
+        finally:
+            c.close()
+
+    def test_method_kind_bark_found(self, method_project):
+        """The method 'bark' inside class Dog must be stored with kind='method'."""
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        c = ASTCache(str(method_project))
+        try:
+            c.index_project()
+            conn = c._get_conn()
+            row = conn.execute(
+                "SELECT kind FROM ast_symbol_rows WHERE name='bark'"
+            ).fetchone()
+            assert row is not None, "Symbol 'bark' not found in ast_symbol_rows"
+            assert row[0] == "method", (
+                f"Expected kind='method' for 'bark' but got kind='{row[0]}'"
+            )
+        finally:
+            c.close()
+
+    def test_top_level_function_stays_kind_function(self, method_project):
+        """Top-level functions (no parent class) must keep kind='function'."""
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        c = ASTCache(str(method_project))
+        try:
+            c.index_project()
+            conn = c._get_conn()
+            row = conn.execute(
+                "SELECT kind FROM ast_symbol_rows WHERE name='standalone'"
+            ).fetchone()
+            assert row is not None, "Symbol 'standalone' not found"
+            assert row[0] == "function", (
+                f"Expected kind='function' for 'standalone' but got kind='{row[0]}'"
+            )
+        finally:
+            c.close()
+
+    @pytest.mark.skipif(
+        not _has_fts5(sqlite3.connect(":memory:")), reason="FTS5 not available"
+    )
+    def test_fts_search_finds_method_by_kind(self, method_project):
+        """fts_search results for 'bark' must include kind='method' entry in FTS."""
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        c = ASTCache(str(method_project))
+        try:
+            c.index_project()
+            conn = c._get_conn()
+            rows = conn.execute(
+                "SELECT name, kind FROM ast_symbol_rows WHERE name='bark'"
+            ).fetchall()
+            assert any(r[1] == "method" for r in rows), (
+                "FTS5 / ast_symbol_rows has no kind='method' row for 'bark'"
+            )
+        finally:
+            c.close()
+
+    def test_serial_and_parallel_agree_on_method_kind(self, method_project):
+        """Both the serial (workers=0) and parallel (workers=2) indexing paths
+        must produce the same kind='method' rows (regression guard for the
+        worker tuple serialization path)."""
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        db_serial = method_project / "ser.db"
+        db_parallel = method_project / "par.db"
+
+        serial_cache = ASTCache(str(method_project), db_path=str(db_serial))
+        serial_cache.index_project(workers=0)
+
+        parallel_cache = ASTCache(str(method_project), db_path=str(db_parallel))
+        parallel_cache.index_project(workers=2)
+
+        try:
+            symbol_sql = (
+                "SELECT name, kind FROM ast_symbol_rows "
+                "WHERE name IN ('bark', 'standalone') "
+                "ORDER BY name"
+            )
+            s_rows = [
+                tuple(r)
+                for r in serial_cache._get_conn().execute(symbol_sql).fetchall()
+            ]
+            p_rows = [
+                tuple(r)
+                for r in parallel_cache._get_conn().execute(symbol_sql).fetchall()
+            ]
+            assert s_rows == p_rows, (
+                f"Serial and parallel paths disagree on method kind:\n"
+                f"  serial={s_rows}\n  parallel={p_rows}"
+            )
+            assert ("bark", "method") in s_rows, (
+                f"'bark' not classified as method in serial path: {s_rows}"
+            )
+        finally:
+            serial_cache.close()
+            parallel_cache.close()

--- a/tests/unit/test_ast_cache_utf8_bug.py
+++ b/tests/unit/test_ast_cache_utf8_bug.py
@@ -60,7 +60,7 @@ def test_indexed_class_name_is_not_byte_shifted(utf8_project: Path) -> None:
     conn = sqlite3.connect(cache.db_path)
     rows = conn.execute(
         "SELECT name, kind FROM ast_symbol_rows "
-        "WHERE kind IN ('class','function') ORDER BY line"
+        "WHERE kind IN ('class','function','method') ORDER BY line"
     ).fetchall()
     cache.close()
     conn.close()

--- a/tests/unit/test_xref.py
+++ b/tests/unit/test_xref.py
@@ -41,7 +41,6 @@ class TestXRefEngineSymbol:
             def _get_conn(self):  # backward-compat alias
                 return self.get_conn()
 
-
         cache = MockCache()
 
         class FakeBackend:
@@ -177,6 +176,31 @@ class TestXRefEngineFile:
         engine = XRefEngine(cache)
         result = engine.file_xref("nonexistent.py")
         assert result["symbol_count"] == 0
+
+    def test_file_xref_includes_methods(self, tmp_path):
+        """Codex P2 on #314: class methods (kind='method') must appear in file
+        xref, not be dropped by a function/class-only filter. A file with only
+        a class + methods must report the methods, not just symbol_count=1."""
+        project = tmp_path / "proj_methods"
+        project.mkdir()
+        (project / "svc.py").write_text(
+            "class Service:\n"
+            "    def handle(self):\n"
+            "        pass\n\n"
+            "    def process(self):\n"
+            "        pass\n"
+        )
+        cache = ASTCache(str(project))
+        cache.index_project(max_files=100)
+
+        engine = XRefEngine(cache)
+        result = engine.file_xref("svc.py")
+        names = [s["name"] for s in result["symbols"]]
+        assert "handle" in names, f"method missing from xref: {names}"
+        assert "process" in names, f"method missing from xref: {names}"
+        assert "Service" in names
+        # class + 2 methods, all surfaced.
+        assert result["symbol_count"] >= 3
 
 
 class TestXRefResult:

--- a/tree_sitter_analyzer/_ast_cache_write.py
+++ b/tree_sitter_analyzer/_ast_cache_write.py
@@ -327,7 +327,7 @@ def write_graph_edges_for_file(
             )
 
     for sym in symbol_items:
-        if sym.get("kind") == "function" and sym.get("class"):
+        if sym.get("kind") in ("function", "method") and sym.get("class"):
             cls_name = sym["class"]
             edges.append(
                 Edge(

--- a/tree_sitter_analyzer/_ast_extraction.py
+++ b/tree_sitter_analyzer/_ast_extraction.py
@@ -441,6 +441,7 @@ def _walk_for_symbols(
             sym["decision_points"] = dp
         parent_cls = _find_parent_class(node, source)
         if parent_cls:
+            sym["kind"] = "method"
             sym["class"] = parent_cls
         symbols.append(sym)
     elif node_type in _CLASS_LIKE and name_node is not None:
@@ -497,7 +498,7 @@ def _extract_structure(symbols: dict[str, Any]) -> dict[str, Any]:
     functions = []
     classes = []
     for s in symbols.get("symbols", []):
-        if s["kind"] == "function":
+        if s["kind"] in ("function", "method"):
             functions.append({"name": s["name"], "line": s["line"]})
         elif s["kind"] == "class":
             classes.append({"name": s["name"], "line": s["line"]})

--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -631,7 +631,7 @@ class ASTCache:
             _build_function_entry(sym, row["file_path"], row["language"])
             for row in rows
             for sym in json.loads(row["symbols_json"]).get("symbols", [])
-            if sym.get("kind") == "function"
+            if sym.get("kind") in ("function", "method")
         ]
 
     def get_functions_by_file(self, file_path: str) -> list[dict[str, Any]]:
@@ -649,7 +649,7 @@ class ASTCache:
         return [
             _build_function_entry(sym, file_path, row["language"])
             for sym in json.loads(row["symbols_json"]).get("symbols", [])
-            if sym.get("kind") == "function"
+            if sym.get("kind") in ("function", "method")
         ]
 
     def get_imports(self) -> dict[str, Any]:

--- a/tree_sitter_analyzer/complexity_heatmap.py
+++ b/tree_sitter_analyzer/complexity_heatmap.py
@@ -340,7 +340,7 @@ def analyze_file_complexity_from_cache(
     lang = row.get("language", "python")
     results: list[FunctionComplexity] = []
     for sym in sym_list:
-        if sym.get("kind") != "function":
+        if sym.get("kind") not in ("function", "method"):
             continue
         dp: dict[str, int] = sym.get("decision_points", {})
         if not dp:

--- a/tree_sitter_analyzer/cross_file_resolver.py
+++ b/tree_sitter_analyzer/cross_file_resolver.py
@@ -275,7 +275,7 @@ class CrossFileResolver:
             lang = row["language"]
             symbols = json.loads(row["symbols_json"])
             for sym in symbols.get("symbols", []):
-                if sym.get("kind") != "function":
+                if sym.get("kind") not in ("function", "method"):
                     continue
                 func = FunctionDef(
                     name=sym["name"],

--- a/tree_sitter_analyzer/mcp/tools/class_inspect_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/class_inspect_tool.py
@@ -88,7 +88,7 @@ class ClassInspectTool(BaseMCPTool):
             except (json.JSONDecodeError, TypeError):
                 continue
             for sym in symbols.get("symbols", []):
-                if sym.get("kind") != "function":
+                if sym.get("kind") not in ("function", "method"):
                     continue
                 if sym.get("class") != class_name:
                     continue
@@ -125,7 +125,7 @@ class ClassInspectTool(BaseMCPTool):
             except (json.JSONDecodeError, TypeError):
                 continue
             for sym in symbols.get("symbols", []):
-                if sym.get("kind") != "function":
+                if sym.get("kind") not in ("function", "method"):
                     continue
                 if sym.get("class") in ancestor_names:
                     parent_methods.add(sym["name"])
@@ -159,7 +159,7 @@ class ClassInspectTool(BaseMCPTool):
             except (json.JSONDecodeError, TypeError):
                 continue
             for sym in symbols.get("symbols", []):
-                if sym.get("kind") != "function":
+                if sym.get("kind") not in ("function", "method"):
                     continue
                 cls = sym.get("class")
                 if cls in ancestor_names:

--- a/tree_sitter_analyzer/mcp/tools/codegraph_sitemap_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_sitemap_tool.py
@@ -207,7 +207,9 @@ class CodeGraphSitemapTool(BaseMCPTool):
                     "symbols": syms,
                     "structure": structure,
                     "symbol_count": len(syms),
-                    "functions": [s for s in syms if s.get("kind") == "function"],
+                    "functions": [
+                        s for s in syms if s.get("kind") in ("function", "method")
+                    ],
                     "classes": [s for s in syms if s.get("kind") == "class"],
                     "imports": [s for s in syms if s.get("kind") == "import"],
                 }
@@ -371,9 +373,9 @@ class CodeGraphSitemapTool(BaseMCPTool):
                     "line": sym.get("line", 0),
                     "language": f["language"],
                 }
-                if kind == "function" and sym.get("params"):
+                if kind in ("function", "method") and sym.get("params"):
                     entry["params"] = sym["params"]
-                if kind == "function" and sym.get("class"):
+                if kind in ("function", "method") and sym.get("class"):
                     entry["class"] = sym["class"]
                 by_kind[kind].append(entry)
 

--- a/tree_sitter_analyzer/synapse_resolver/_context.py
+++ b/tree_sitter_analyzer/synapse_resolver/_context.py
@@ -308,7 +308,7 @@ def _build_file_class_methods(
             continue
         per_class: dict[str, dict[str, int]] = {}
         for sym in symbols.get("symbols", []):
-            if sym.get("kind") != "function":
+            if sym.get("kind") not in ("function", "method"):
                 continue
             cls_name = sym.get("class")
             if not cls_name:

--- a/tree_sitter_analyzer/test_gap_analyzer.py
+++ b/tree_sitter_analyzer/test_gap_analyzer.py
@@ -218,7 +218,7 @@ def _extract_symbols_from_tree(
             results.append(
                 ProductionSymbol(
                     name=fname,
-                    kind="function",
+                    kind="method" if current_class else "function",
                     file_path=file_path,
                     language=language,
                     line=node.start_point[0] + 1,
@@ -723,7 +723,7 @@ def analyze_coverage_gaps(
 
     parser_cache: dict[str, Any] = {}
     for sym in prod_symbols:
-        if sym.kind == "function":
+        if sym.kind in ("function", "method"):
             sym.complexity = _get_complexity_cached(sym, parser_cache)
             sym.risk = _risk_band(sym.complexity)
 

--- a/tree_sitter_analyzer/xref.py
+++ b/tree_sitter_analyzer/xref.py
@@ -346,7 +346,10 @@ class XRefEngine:
         syms = json.loads(row["symbols_json"])
         results: list[dict[str, Any]] = []
         for sym in syms.get("symbols", []):
-            if sym.get("kind") in ("function", "class"):
+            # "method" is the in-class callable kind (added with method
+            # classification). Without it, codegraph_xref file mode would omit
+            # every method and undercount files that contain only methods.
+            if sym.get("kind") in ("function", "method", "class"):
                 results.append(
                     {
                         "name": sym.get("name", ""),


### PR DESCRIPTION
## Summary

- **Bug**: `ast_symbol_rows` had 0 rows with `kind='method'` — every class method was stored as `kind='function'`, making `search action=symbol kind=method` return NOT_FOUND for all queries. CodeGraph correctly returns 20,275 method rows for this repo.
- **Root cause**: `_walk_for_symbols` in `_ast_extraction.py` always set `"kind": "function"` unconditionally. The parent class was already detected and stored in `sym["class"]`, but kind was never promoted to `"method"`.
- **Fix**: One-liner — when `parent_cls` is present, set `sym["kind"] = "method"` before appending.

## Before / After

| Metric | Before | After |
|--------|--------|-------|
| `SELECT COUNT(*) FROM ast_symbol_rows WHERE kind='method'` | **0** | **large non-zero (20k+ on this repo)** |
| `SELECT COUNT(*) FROM ast_symbol_rows WHERE kind='function'` | 20k+ (all callables) | N (top-level only) |
| `search action=symbol query=execute kind=method` | NOT_FOUND | 10+ results |

## Consumers audited and updated

All `kind == "function"` guards that mean "callable symbol" (functions or methods) were widened to `in ("function", "method")`:

| File | Line(s) | Change |
|------|---------|--------|
| `_ast_extraction.py` | ~433 | **Core fix**: set `kind="method"` when `parent_cls` is present |
| `_ast_extraction.py` | ~500 (`_extract_structure`) | Include methods in functions list so structure output stays stable |
| `_ast_cache_write.py` | ~330 | CONTAINS-edge builder: accept method kind |
| `ast_cache.py` | ~634, ~652 | `get_functions` / `get_functions_by_file` include methods |
| `cross_file_resolver.py` | ~278 | `!= "function"` guard widened |
| `complexity_heatmap.py` | ~343 | Method complexity now measured |
| `synapse_resolver/_context.py` | ~311 | Method synapse links built |
| `test_gap_analyzer.py` | ~220, ~726 | In-class functions classified as method; complexity loop widened |
| `mcp/tools/class_inspect_tool.py` | 91, 128, 162 | 3 guards widened |
| `mcp/tools/codegraph_sitemap_tool.py` | 210, 374–376 | functions list and _build_flat updated |

**NOT touched**: `_extract_call_edges` / `function_extraction.walk_tree` (separate call-graph pipeline with its own definitions list — verified unaffected). `BaseMCPTool`, `SecurityValidator`, `PathResolver`, `symbol_search_tool.py`, `_ast_cache_query.py fts_search_ranked` ranking — all untouched per brief.

## Test plan

- [x] RED-first: `TestMethodKindClassification` (5 tests) written first, all failed before fix
- [x] GREEN: all 5 pass after fix
- [x] `test_ast_cache_utf8_bug.py` updated: SQL filter `kind IN ('class','function')` → `('class','function','method')` (same regression intent, corrected expectation)
- [x] `tests/unit/test_ast_cache.py tests/unit/test_cross_file_backfill.py tests/unit/test_synapse_resolution.py` — 113/113 pass
- [x] `tests/unit/ -n auto` — 16593 pass, 1 pre-existing failure (`subscribe/unsubscribe` in agent contracts, unrelated)
- [x] `uv run ruff check tree_sitter_analyzer/ tests/` — clean
- [x] `uv run mypy tree_sitter_analyzer/_ast_extraction.py tree_sitter_analyzer/_ast_cache_write.py` — clean
- [x] Serial/parallel agreement test (`test_serial_and_parallel_agree_on_method_kind`) passes — both paths produce identical kind='method' rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)