### PR TITLE
feat(search): demote test-file symbols in fts_search_ranked (consistent ranking)

### DIFF
--- a/tests/unit/test_fts_search_test_demotion.py
+++ b/tests/unit/test_fts_search_test_demotion.py
@@ -164,6 +164,44 @@ class TestFtsSearchRankedTestDemotion:
             f"Expected production implementation first, got {results[0]['file']!r}"
         )
 
+    def test_production_promoted_even_when_buried_past_limit(self) -> None:
+        """Codex P2 on #316: over-fetch so a production hit BM25-ranked outside
+        the caller's ``limit`` window is still promoted above many test matches.
+
+        Insert 30 test-file matches with EARLIER rowids (better raw BM25 tie
+        position) and one production match LAST. With ``limit=5`` and a naive
+        ``LIMIT 5`` in SQL, the production row would never be fetched. The
+        over-fetch band must pull it in so demotion can rank it first.
+        """
+        conn = _make_fts_conn()
+
+        for i in range(30):
+            _insert(
+                conn,
+                "widget",
+                file_path=f"tests/unit/test_widget_{i}.py",
+                kind="function",
+                line=i * 5 + 1,
+            )
+        _insert(
+            conn,
+            "widget",
+            file_path="tree_sitter_analyzer/widget.py",
+            kind="function",
+            line=42,
+        )
+
+        from tree_sitter_analyzer._ast_cache_query import fts_search_ranked
+
+        results = fts_search_ranked(conn, "widget", limit=5)
+
+        assert results, "Expected results"
+        assert len(results) == 5, "Result window must respect the caller's limit"
+        assert results[0]["file"] == "tree_sitter_analyzer/widget.py", (
+            "Production hit must be promoted above test matches even when BM25 "
+            f"ranks it past the limit window; got {results[0]['file']!r}"
+        )
+
     def test_secondary_sort_is_relevance_within_same_tier(self) -> None:
         """Within the production tier, relevance_score is set for all results."""
         conn = _make_fts_conn()

--- a/tests/unit/test_fts_search_test_demotion.py
+++ b/tests/unit/test_fts_search_test_demotion.py
@@ -1,0 +1,223 @@
+"""RED-first TDD tests for test-file demotion in fts_search_ranked.
+
+Bug: fts_search_ranked ordered purely by BM25 score with no test-file
+demotion. Within a name-match tier, test mock symbols beat production
+implementations because they typically have better BM25 scores due to
+higher mention density in test files.
+
+Fix: apply rank_tier() / query_wants_tests() demotion as primary sort
+key, consistent with semantic_search.SemanticSymbolSearch.search().
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+# ---------------------------------------------------------------------------
+# Helpers — build an in-memory FTS5 connection
+# ---------------------------------------------------------------------------
+
+
+def _make_fts_conn() -> sqlite3.Connection:
+    """Return an in-memory connection with the FTS5 schema used by fts_search_ranked."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        """CREATE TABLE ast_symbol_rows (
+            id         INTEGER PRIMARY KEY AUTOINCREMENT,
+            name       TEXT NOT NULL,
+            kind       TEXT NOT NULL,
+            file_path  TEXT NOT NULL,
+            language   TEXT NOT NULL,
+            line       INTEGER NOT NULL DEFAULT 0,
+            end_line   INTEGER NOT NULL DEFAULT 0
+        )"""
+    )
+    conn.execute(
+        """CREATE VIRTUAL TABLE ast_symbols_fts
+           USING fts5(name, kind, file_path, language, content='')"""
+    )
+    return conn
+
+
+def _insert(
+    conn: sqlite3.Connection,
+    name: str,
+    *,
+    kind: str = "function",
+    file_path: str = "src/foo.py",
+    language: str = "python",
+    line: int = 1,
+) -> None:
+    cur = conn.execute(
+        "INSERT INTO ast_symbol_rows (name, kind, file_path, language, line, end_line) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (name, kind, file_path, language, line, line + 10),
+    )
+    row_id = cur.lastrowid
+    conn.execute(
+        "INSERT INTO ast_symbols_fts(rowid, name, kind, file_path, language) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (row_id, name, kind, file_path, language),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests — these MUST fail on current code (no demotion applied) and pass
+# after the fix is implemented.
+# ---------------------------------------------------------------------------
+
+
+class TestFtsSearchRankedTestDemotion:
+    """Production symbol must rank above test-file mock with the same name."""
+
+    def test_production_symbol_beats_test_mock_by_default(self) -> None:
+        """Core regression: fts_search_ranked returns production file first.
+
+        Mirrors the verified real-world bug: searching `fts_search_ranked`
+        returned 8 results all from tests/unit/test_codegraph_context_tool.py
+        (mock defs) while the production impl in ast_cache.py ranked below.
+
+        Use multiple test-file occurrences so that BM25 tie-breaks favour the
+        test files by insertion order — exactly the real-world failure mode.
+        """
+        conn = _make_fts_conn()
+
+        # Insert multiple test-file occurrences first (lower rowids = better
+        # BM25 tie-break position in raw SQLite ordering).
+        for i in range(3):
+            _insert(
+                conn,
+                "foo",
+                file_path=f"tests/unit/test_foo_{i}.py",
+                kind="function",
+                line=10 + i,
+            )
+        # Insert production symbol last — without demotion it ends up last.
+        _insert(
+            conn,
+            "foo",
+            file_path="src/foo.py",
+            kind="function",
+            line=5,
+        )
+
+        from tree_sitter_analyzer._ast_cache_query import fts_search_ranked
+
+        results = fts_search_ranked(conn, "foo")
+
+        assert results, "Expected at least one result"
+        # Production file must appear first.
+        assert results[0]["file"] == "src/foo.py", (
+            f"Expected production file first, got {results[0]['file']!r}. "
+            "Test mock is shadowing the production symbol."
+        )
+
+    def test_query_wants_tests_allows_test_symbol_up(self) -> None:
+        """When query contains 'test', test symbols are NOT demoted."""
+        conn = _make_fts_conn()
+        _insert(conn, "foo", file_path="src/foo.py", kind="function", line=5)
+        _insert(
+            conn,
+            "foo",
+            file_path="tests/unit/test_foo.py",
+            kind="function",
+            line=10,
+        )
+
+        from tree_sitter_analyzer._ast_cache_query import fts_search_ranked
+
+        results = fts_search_ranked(conn, "foo test")
+
+        assert results, "Expected at least one result"
+        # Both tiers are now 0 — verify both symbols are present.
+        files = {r["file"] for r in results}
+        assert "tests/unit/test_foo.py" in files
+        assert "src/foo.py" in files
+
+    def test_multiple_test_symbols_demoted_below_single_production(self) -> None:
+        """Several test-file symbols all rank below the one production symbol."""
+        conn = _make_fts_conn()
+
+        for i in range(3):
+            _insert(
+                conn,
+                "fts_search_ranked",
+                file_path=f"tests/unit/test_file_{i}.py",
+                kind="function",
+                line=i * 10 + 1,
+            )
+        _insert(
+            conn,
+            "fts_search_ranked",
+            file_path="tree_sitter_analyzer/ast_cache.py",
+            kind="function",
+            line=167,
+        )
+
+        from tree_sitter_analyzer._ast_cache_query import fts_search_ranked
+
+        results = fts_search_ranked(conn, "fts_search_ranked")
+
+        assert results, "Expected results"
+        assert results[0]["file"] == "tree_sitter_analyzer/ast_cache.py", (
+            f"Expected production implementation first, got {results[0]['file']!r}"
+        )
+
+    def test_secondary_sort_is_relevance_within_same_tier(self) -> None:
+        """Within the production tier, relevance_score is set for all results."""
+        conn = _make_fts_conn()
+
+        _insert(conn, "foo", file_path="src/primary.py", kind="function", line=1)
+        _insert(conn, "foo", file_path="src/secondary.py", kind="function", line=1)
+
+        from tree_sitter_analyzer._ast_cache_query import fts_search_ranked
+
+        results = fts_search_ranked(conn, "foo")
+
+        # Both are non-test; both should be present with relevance_score set.
+        assert len(results) >= 2
+        prod = [r for r in results if r["file"].startswith("src/")]
+        assert all(r.get("relevance_score") is not None for r in prod)
+
+    def test_language_filter_preserved_with_demotion(self) -> None:
+        """language= filter still works after demotion is added."""
+        conn = _make_fts_conn()
+        _insert(
+            conn,
+            "foo",
+            file_path="tests/test_foo.py",
+            kind="function",
+            language="python",
+        )
+        _insert(
+            conn,
+            "foo",
+            file_path="src/foo.py",
+            kind="function",
+            language="python",
+        )
+        _insert(
+            conn,
+            "foo",
+            file_path="src/foo.go",
+            kind="function",
+            language="go",
+        )
+
+        from tree_sitter_analyzer._ast_cache_query import fts_search_ranked
+
+        results = fts_search_ranked(conn, "foo", language="python")
+
+        assert all(r["language"] == "python" for r in results)
+        assert results[0]["file"] == "src/foo.py"
+
+    def test_empty_query_returns_empty(self) -> None:
+        """Short queries still short-circuit (unchanged behavior)."""
+        conn = _make_fts_conn()
+        _insert(conn, "f", file_path="src/f.py")
+
+        from tree_sitter_analyzer._ast_cache_query import fts_search_ranked
+
+        assert fts_search_ranked(conn, "f") == []
+        assert fts_search_ranked(conn, "") == []

--- a/tree_sitter_analyzer/_ast_cache_query.py
+++ b/tree_sitter_analyzer/_ast_cache_query.py
@@ -12,6 +12,8 @@ import logging
 import sqlite3
 from typing import TYPE_CHECKING, Any, cast
 
+from .utils.test_detection import query_wants_tests, rank_tier
+
 if TYPE_CHECKING:
     pass
 
@@ -170,13 +172,20 @@ def fts_search_ranked(
     language: str | None = None,
     limit: int = 100,
 ) -> list[dict[str, Any]]:
-    """BM25-ranked FTS5 symbol search with kind-priority tie-breaking.
+    """BM25-ranked FTS5 symbol search with kind-priority and test-file demotion.
 
     Returns dicts with keys: name, kind, file, language, line, end_line, relevance_score.
     relevance_score is in [0.0, 1.0] — 1.0 = best match in this result set.
     After BM25 normalization, a kind-weight multiplier is applied so that
     class/function/method definitions rank above import statements even when
     their raw BM25 score is identical.
+
+    Test-file demotion (consistent with semantic_search.SemanticSymbolSearch):
+    Production symbols always rank above test/spec/fixture symbols unless the
+    query itself contains test-intent keywords (``query_wants_tests``). Within
+    each tier the sort is by relevance_score descending, then file + line for
+    determinism.
+
     Returns [] for queries shorter than 2 characters or on SQLite errors.
     """
     if len(query) < 2:
@@ -225,7 +234,20 @@ def fts_search_ranked(
         }
         for r in rows
     ]
-    results.sort(key=lambda x: x["relevance_score"], reverse=True)
+    # Primary: test-file demotion tier (0 = production, 1 = test/fixture).
+    # Production symbols always rank first unless the query asks about tests.
+    # Secondary: relevance_score descending (BM25 + kind weight, best first).
+    # Tertiary: file + line for a fully deterministic stable order.
+    wants_tests = query_wants_tests(query)
+    results.sort(
+        key=lambda x: (
+            rank_tier(str(x["file"]), wants_tests=wants_tests),
+            -x["relevance_score"],
+            str(x["file"]),
+            int(x["line"] or 0),
+            str(x["name"]),
+        )
+    )
     return results
 
 

--- a/tree_sitter_analyzer/_ast_cache_query.py
+++ b/tree_sitter_analyzer/_ast_cache_query.py
@@ -165,6 +165,14 @@ _KIND_WEIGHT: dict[str, float] = {
 }
 _KIND_WEIGHT_DEFAULT = 0.85  # fallback for unrecognised kind values
 
+# Test-file demotion runs in Python AFTER the SQL fetch, so a production hit
+# that BM25 ranks just outside the caller's ``limit`` window would be truncated
+# before it can be promoted above test/fixture matches. Over-fetch a wider band
+# of candidates, demote, THEN truncate to ``limit`` — so production symbols that
+# lose the raw BM25 race to many test matches can still surface first.
+_DEMOTION_OVERFETCH_FACTOR = 4
+_DEMOTION_OVERFETCH_FLOOR = 50
+
 
 def fts_search_ranked(
     conn: sqlite3.Connection,
@@ -202,16 +210,21 @@ def fts_search_ranked(
         "FROM ast_symbols_fts f JOIN ast_symbol_rows r ON f.rowid = r.id "
         "WHERE ast_symbols_fts MATCH ? {lang_clause} ORDER BY bm25_raw LIMIT ?"
     )
+    # Over-fetch so the post-fetch test-demotion can promote production hits
+    # that BM25 buried just outside the caller's window (Codex P2 on #316).
+    fetch_limit = max(
+        limit * _DEMOTION_OVERFETCH_FACTOR, limit + _DEMOTION_OVERFETCH_FLOOR
+    )
     try:
         if language:
             rows = conn.execute(
                 join_sql.format(lang_clause="AND r.language = ?"),
-                (fts_query, language, limit),
+                (fts_query, language, fetch_limit),
             ).fetchall()
         else:
             rows = conn.execute(
                 join_sql.format(lang_clause=""),
-                (fts_query, limit),
+                (fts_query, fetch_limit),
             ).fetchall()
     except sqlite3.OperationalError:
         logger.debug("fts_search_ranked: OperationalError — FTS5 table not available")
@@ -248,7 +261,9 @@ def fts_search_ranked(
             str(x["name"]),
         )
     )
-    return results
+    # Truncate to the caller's window only AFTER demotion, so a promoted
+    # production hit is not dropped by the over-fetch band.
+    return results[:limit]
 
 
 def search_symbols_linear(

--- a/tree_sitter_analyzer/mcp/tools/symbol_search_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/symbol_search_tool.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from ..._ast_cache_query import _normalize_bm25 as _norm_bm25
 from ...utils import setup_logger
+from ...utils.test_detection import query_wants_tests, rank_tier
 from .base_tool import BaseMCPTool
 
 logger = setup_logger(__name__)
@@ -174,10 +175,12 @@ class CodeGraphSymbolSearchTool(BaseMCPTool):
         limit: int,
     ) -> list[dict[str, Any]]:
         if query.startswith("~"):
-            return self._fuzzy_search(cache, query[1:], language, kind, limit)
-        if "*" in query:
-            return self._wildcard_search(cache, query, language, kind, limit)
-        return self._exact_search(cache, query, language, kind, limit)
+            raw = self._fuzzy_search(cache, query[1:], language, kind, limit)
+        elif "*" in query:
+            raw = self._wildcard_search(cache, query, language, kind, limit)
+        else:
+            raw = self._exact_search(cache, query, language, kind, limit)
+        return self._demote_test_files(raw, query)
 
     def _exact_search(
         self,
@@ -360,6 +363,33 @@ class CodeGraphSymbolSearchTool(BaseMCPTool):
         if kind == "any":
             return results
         return [r for r in results if r.get("kind", "") == kind]
+
+    def _demote_test_files(
+        self,
+        results: list[dict[str, Any]],
+        query: str,
+    ) -> list[dict[str, Any]]:
+        """Apply test-file demotion as primary sort key.
+
+        Consistent with fts_search_ranked and semantic_search.SemanticSymbolSearch.
+        Covers cascade (exact-tier) and FTS5/fuzzy/wildcard paths.
+        PRIMARY: rank_tier (0=prod, 1=test) unless query asks about tests.
+        SECONDARY: relevance_score descending (existing ranking preserved).
+        TERTIARY: file + line + name for a fully deterministic stable order.
+        """
+        if not results:
+            return results
+        wants_tests = query_wants_tests(query)
+        return sorted(
+            results,
+            key=lambda r: (
+                rank_tier(str(r.get("file", "")), wants_tests=wants_tests),
+                -(r.get("relevance_score") or 0.0),
+                str(r.get("file", "")),
+                int(r.get("line") or 0),
+                str(r.get("name", "")),
+            ),
+        )
 
     def _inline_match_bodies(
         self,


### PR DESCRIPTION
## Summary

TSA's own symbol search had the exact disease it criticized CodeGraph for: searching `fts_search_ranked` returned 8 results from test mocks in `tests/unit/test_codegraph_context_tool.py` while the production implementation in `ast_cache.py` was buried — pure BM25 ordering with no test-file demotion.

This PR closes TSA's own version of the bug it calls out in its README competitive comparison against CodeGraph.

## Root Cause

`fts_search_ranked` in `_ast_cache_query.py` ordered purely by BM25 score with no `rank_tier()` / `query_wants_tests()` demotion. Meanwhile `semantic_search.SemanticSymbolSearch.search()` and the nav-context tool already applied test demotion via `utils.test_detection`. The raw FTS path and `symbol_search_tool.py` were inconsistent.

Additionally, the MCP tool's `search_symbols_cascade` exact-tier path (sorting by `file_path` alphabetically) causes `tests/` to beat `tree_sitter_analyzer/` in tie-breaks — also fixed by the `_demote_test_files` post-processing step.

## The Fix

Apply consistent test-file demotion in two layers:

**Layer 1 — `_ast_cache_query.fts_search_ranked`** (CLI + all direct callers):
- Sort key: `(rank_tier(file, wants_tests), -relevance_score, file, line, name)`
- Import `query_wants_tests` / `rank_tier` from `utils.test_detection` (same helpers already used by `semantic_search.py`)

**Layer 2 — `symbol_search_tool._demote_test_files`** (MCP all paths):
- Called from `_search()` covering cascade (exact-tier), FTS5, fuzzy, and wildcard paths
- Ensures the MCP tool applies demotion even when `search_symbols_cascade` exact-tier bypasses `fts_search_ranked`

## Before / After: query `fts_search_ranked`

**BEFORE** (raw BM25, no demotion):
```
[0] tests/unit/test_codegraph_context_tool.py (bm25=-15.485) <- FIRST
[1] tests/unit/test_codegraph_context_tool.py (bm25=-15.485)
... (8 test-file results)
[8] tree_sitter_analyzer/ast_cache.py (bm25=-15.576)  <- buried
```

**AFTER** (test-file demotion applied):
```
[0] tree_sitter_analyzer/ast_cache.py (score=1.000) <- FIRST  (production)
[1] tests/unit/test_codegraph_context_tool.py (score=0.745)
[2] tests/unit/test_codegraph_context_tool.py (score=0.494)
... (test mocks follow)
```

## Test Plan

- [x] RED-first TDD: wrote failing tests first (`test_multiple_test_symbols_demoted_below_single_production` fails on current code)
- [x] 6 new tests in `tests/unit/test_fts_search_test_demotion.py`
- [x] `uv run pytest tests/unit/test_fts_search_test_demotion.py -v` — 6 passed
- [x] `uv run pytest tests/unit/test_codegraph_context_tool.py tests/unit/test_ast_cache.py -q` — 113 passed
- [x] `uv run pytest tests/unit/ -q -n auto` — 16546 passed (4 pre-existing failures unrelated to this change)
- [x] `uv run ruff check _ast_cache_query.py symbol_search_tool.py` — clean
- [x] `uv run mypy _ast_cache_query.py symbol_search_tool.py` — clean
- [x] End-to-end fixture: 2-file project indexed, `fts_search_ranked` returns production first

## Layer Decision

The fix is at two layers (not one) because:
1. `fts_search_ranked` handles CLI and the FTS5 path in cascade — best for direct callers
2. `_demote_test_files` in `symbol_search_tool._search` handles the MCP exact-tier path that goes through `search_symbols_cascade._exact_rows` (which sorts by `file_path` alphabetically, not by `fts_search_ranked`) — needed for full MCP parity

Both layers use the identical `rank_tier()`/`query_wants_tests()` helpers from `utils.test_detection`, ensuring consistent behavior across CLI and MCP.