### PR TITLE
fix(mcp+index): 5 Codex-ignored P1/P2 — RFC-0001 push wiring + max_nodes + packages

### DIFF
--- a/tests/unit/mcp/test_hyphae_push_wiring.py
+++ b/tests/unit/mcp/test_hyphae_push_wiring.py
@@ -1,0 +1,75 @@
+"""Coverage for RFC-0001 push wiring helpers (session capture + send_update).
+
+These exercise the small, pure-ish branches added when bringing the reactive
+push path to life (PR #317): session capture outside a request context, the
+session-store round trip, and the no-session early return in _send_update.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from tree_sitter_analyzer.mcp.tools import hyphae_subscribe_tool as hst
+from tree_sitter_analyzer.mcp.watch_push_bridge import _send_update
+
+
+def test_capture_session_obj_returns_none_outside_request_context() -> None:
+    """Outside an MCP request, request_ctx is unset → capture returns None,
+    never raising (the bridge degrades gracefully)."""
+    assert hst._capture_session_obj() is None
+
+
+def test_session_obj_store_roundtrip() -> None:
+    """get_session_obj returns what was captured, and None for unknown ids."""
+    sentinel = object()
+    hst._SESSION_SESSIONS["sess-x"] = sentinel
+    try:
+        assert hst.get_session_obj("sess-x") is sentinel
+        assert hst.get_session_obj("missing") is None
+    finally:
+        hst._SESSION_SESSIONS.pop("sess-x", None)
+
+
+def test_session_loop_store_roundtrip() -> None:
+    """get_session_loop mirrors the captured loop; None when absent."""
+    loop = asyncio.new_event_loop()
+    try:
+        hst._SESSION_LOOPS["sess-y"] = loop
+        assert hst.get_session_loop("sess-y") is loop
+        assert hst.get_session_loop("nope") is None
+    finally:
+        hst._SESSION_LOOPS.pop("sess-y", None)
+        loop.close()
+
+
+@pytest.mark.asyncio
+async def test_send_update_no_session_is_noop() -> None:
+    """_send_update returns quietly when no session was captured for the id —
+    a dead/unknown session must never raise into the watch loop."""
+    # Ensure no session registered for this id.
+    hst._SESSION_SESSIONS.pop("ghost", None)
+    # Should complete without raising.
+    await _send_update("ghost", "tsa://hyphae/.function")
+
+
+@pytest.mark.asyncio
+async def test_send_update_calls_session_when_present() -> None:
+    """When a session is captured, _send_update awaits send_resource_updated
+    with an AnyUrl wrapping the uri."""
+    sent: list[object] = []
+
+    class FakeSession:
+        async def send_resource_updated(self, uri: object) -> None:
+            sent.append(uri)
+
+    hst._SESSION_SESSIONS["live"] = FakeSession()
+    try:
+        await _send_update("live", "tsa://hyphae/.function")
+    finally:
+        hst._SESSION_SESSIONS.pop("live", None)
+
+    assert len(sent) == 1
+    # Wrapped as AnyUrl — str round-trips back to the scheme.
+    assert str(sent[0]).startswith("tsa://hyphae/")

--- a/tests/unit/mcp/test_server_comprehensive_init.py
+++ b/tests/unit/mcp/test_server_comprehensive_init.py
@@ -439,7 +439,8 @@ class TestTreeSitterAnalyzerMCPServerCreation:
             list_resources_handler = captured_handlers["list_resources"]
             resources = await list_resources_handler()
 
-            assert len(resources) == 2
+            assert len(resources) == 3
             resource_names = [resource.name for resource in resources]
             assert "code_file" in resource_names
             assert "project_stats" in resource_names
+            assert "Hyphae selector result" in resource_names

--- a/tests/unit/mcp/test_watch_push_bridge.py
+++ b/tests/unit/mcp/test_watch_push_bridge.py
@@ -1,0 +1,54 @@
+"""RFC-0001 watch→push bridge: push only on real delta (Codex P2 on #317)."""
+
+from __future__ import annotations
+
+from tree_sitter_analyzer.mcp.subscription_registry import SubscriptionRegistry
+from tree_sitter_analyzer.mcp.watch_push_bridge import collect_changed_pairs
+
+
+def _seed(registry: SubscriptionRegistry, session: str, selector: str, snap: list):
+    """Subscribe and prime the stored snapshot so later diffs are meaningful."""
+    registry.subscribe(session, selector)
+    # First compute_delta stores the baseline snapshot (added == snap).
+    registry.compute_delta(session, selector, snap)
+
+
+def test_unchanged_selector_is_not_pushed() -> None:
+    """A sync event that does not move the result pushes nothing."""
+    reg = SubscriptionRegistry(min_interval_s=0.0)
+    snap = [{"name": "foo", "file": "a.py", "line": 1}]
+    _seed(reg, "s1", ".function", snap)
+
+    # Re-evaluate returns the IDENTICAL snapshot — no delta.
+    changed = collect_changed_pairs(reg, lambda sid, sel: list(snap))
+    assert changed == []
+
+
+def test_changed_selector_is_pushed() -> None:
+    """When the selector result moves, exactly that pair is returned."""
+    reg = SubscriptionRegistry(min_interval_s=0.0)
+    _seed(reg, "s1", ".function", [{"name": "foo", "file": "a.py", "line": 1}])
+
+    new_snap = [
+        {"name": "foo", "file": "a.py", "line": 1},
+        {"name": "bar", "file": "b.py", "line": 2},
+    ]
+    changed = collect_changed_pairs(reg, lambda sid, sel: list(new_snap))
+    assert changed == [("s1", ".function")]
+
+
+def test_only_the_moved_selector_among_many_is_pushed() -> None:
+    """An unrelated subscription is not woken when another selector changes."""
+    reg = SubscriptionRegistry(min_interval_s=0.0)
+    stable = [{"name": "foo", "file": "a.py", "line": 1}]
+    moving = [{"name": "baz", "file": "c.py", "line": 3}]
+    _seed(reg, "s1", ".stable", stable)
+    _seed(reg, "s1", ".moving", moving)
+
+    def evaluate(_sid: str, selector: str) -> list:
+        if selector == ".moving":
+            return [*moving, {"name": "new", "file": "d.py", "line": 4}]
+        return list(stable)
+
+    changed = collect_changed_pairs(reg, evaluate)
+    assert changed == [("s1", ".moving")]

--- a/tests/unit/test_agent_contracts.py
+++ b/tests/unit/test_agent_contracts.py
@@ -760,6 +760,8 @@ def test_facade_delegation_routes_each_action_to_expected_inner() -> None:
         ("search", "batch"): "BatchSearchTool",
         ("search", "chain"): "CodeGraphQueryTool",
         ("search", "select"): "HyphaeSelectTool",
+        ("search", "subscribe"): "HyphaeSubscribeTool",
+        ("search", "unsubscribe"): "HyphaeUnsubscribeTool",
         ("search", "content"): "<bespoke>",
         ("nav", "navigate"): "CodeGraphNavigateTool",
         ("nav", "call_path"): "CodeGraphCallPathTool",

--- a/tree_sitter_analyzer/constants.py
+++ b/tree_sitter_analyzer/constants.py
@@ -135,7 +135,11 @@ EXCLUDE_DIRS: frozenset[str] = frozenset(
         # anyway); their generated SOURCES live in obj/ (C#) and target/ (Java),
         # both excluded below — so dropping "bin" keeps the hang fixed.
         "obj",  # C#/.NET (incl. obj/**/*.g.cs generated sources)
-        "packages",  # C#/.NET (NuGet)
+        # NOTE: "packages" is intentionally NOT here. JS/TS monorepos use
+        # packages/<api>/<src>/ as first-party source directories (Yarn/pnpm
+        # workspaces), so excluding "packages" at any depth prunes real source.
+        # C#/NuGet packages live under obj/ or vendor/ which are already excluded;
+        # TSA also skips .dll/.nupkg files by extension so traversal is safe.
         "target",  # Rust, Java (Maven)
         ".gradle",  # Java (Gradle)
         "vendor",  # Go, PHP

--- a/tree_sitter_analyzer/mcp/server_utils/resource_registration.py
+++ b/tree_sitter_analyzer/mcp/server_utils/resource_registration.py
@@ -1,6 +1,6 @@
 """Resource handler registration for MCP server — extracted from server.py create_server."""
 
-from typing import Any
+from typing import Any, cast
 
 from ...utils import setup_logger
 
@@ -32,7 +32,7 @@ def register_resources(server: Any, server_instance: Any) -> None:
                 mimeType=project_stats_resource.get_resource_info()["mime_type"],
             ),
             Resource(
-                uri="tsa://hyphae/{selector}",
+                uri=cast(Any, "tsa://hyphae/{selector}"),
                 name="Hyphae selector result",
                 description=(
                     "Re-evaluate a Hyphae selector expression and return the "

--- a/tree_sitter_analyzer/mcp/server_utils/resource_registration.py
+++ b/tree_sitter_analyzer/mcp/server_utils/resource_registration.py
@@ -11,7 +11,6 @@ def register_resources(server: Any, server_instance: Any) -> None:
     """Register resource handlers on the MCP server."""
     code_file_resource = server_instance.code_file_resource
     project_stats_resource = server_instance.project_stats_resource
-    project_root = getattr(server_instance, "_project_root", None)
 
     @server.list_resources()  # type: ignore
     async def handle_list_resources() -> list[Any]:
@@ -52,7 +51,12 @@ def register_resources(server: Any, server_instance: Any) -> None:
             )
 
             if is_hyphae_resource_uri(str(uri)):
-                return await read_hyphae_resource(str(uri), project_root)
+                # Read the project root at call time — the client may rebind it
+                # via set_project_path after the server (and this closure) was
+                # created. Following the live value keeps the resource on the
+                # same project-root lifecycle as every tool.
+                live_root = getattr(server_instance, "_project_root", None)
+                return await read_hyphae_resource(str(uri), live_root)
             elif code_file_resource.matches_uri(uri):
                 return await code_file_resource.read_resource(uri)
             elif project_stats_resource.matches_uri(uri):

--- a/tree_sitter_analyzer/mcp/server_utils/resource_registration.py
+++ b/tree_sitter_analyzer/mcp/server_utils/resource_registration.py
@@ -11,6 +11,7 @@ def register_resources(server: Any, server_instance: Any) -> None:
     """Register resource handlers on the MCP server."""
     code_file_resource = server_instance.code_file_resource
     project_stats_resource = server_instance.project_stats_resource
+    project_root = getattr(server_instance, "_project_root", None)
 
     @server.list_resources()  # type: ignore
     async def handle_list_resources() -> list[Any]:
@@ -30,13 +31,29 @@ def register_resources(server: Any, server_instance: Any) -> None:
                 description=project_stats_resource.get_resource_info()["description"],
                 mimeType=project_stats_resource.get_resource_info()["mime_type"],
             ),
+            Resource(
+                uri="tsa://hyphae/{selector}",
+                name="Hyphae selector result",
+                description=(
+                    "Re-evaluate a Hyphae selector expression and return the "
+                    "current result set. URI produced by search action=subscribe."
+                ),
+                mimeType="application/json",
+            ),
         ]
 
     @server.read_resource()  # type: ignore
     async def handle_read_resource(uri: str) -> Any:
         """Read resource content."""
         try:
-            if code_file_resource.matches_uri(uri):
+            from ..resources.hyphae_resource import (
+                is_hyphae_resource_uri,
+                read_hyphae_resource,
+            )
+
+            if is_hyphae_resource_uri(str(uri)):
+                return await read_hyphae_resource(str(uri), project_root)
+            elif code_file_resource.matches_uri(uri):
                 return await code_file_resource.read_resource(uri)
             elif project_stats_resource.matches_uri(uri):
                 return await project_stats_resource.read_resource(uri)

--- a/tree_sitter_analyzer/mcp/tools/ast_cache_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/ast_cache_tool.py
@@ -637,10 +637,13 @@ class ASTCacheTool(BaseMCPTool):
         cache = self._get_cache()
         poll_interval = float(arguments.get("poll_interval", 5.0))
         backend = str(arguments.get("backend", "poll"))
+        from ..watch_push_bridge import make_on_sync_callback
+
         self._watcher = FileWatcherDaemon(
             cache,
             poll_interval=poll_interval,
             backend=backend,
+            on_sync=make_on_sync_callback(self._project_root),
         )
         self._watcher.start()
 

--- a/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
@@ -201,15 +201,20 @@ class CodeGraphContextTool(BaseMCPTool):
         total_nodes = len(nodes)
         total_edges = len(edges)
         total_entry_points = len(entry_points)
-        # entry_points overlap the node set; echo only the best-ranked handful.
+        # Echo a bounded, self-consistent subgraph. The inline caps scale with
+        # max_nodes so agents that request more nodes actually receive them.
+        # _MAX_INLINE_NODES / _MAX_INLINE_EDGES are the floor defaults for small
+        # requests; larger max_nodes raises the cap proportionally.
+        inline_node_cap = max(_MAX_INLINE_NODES, max_nodes)
+        inline_edge_cap = max(_MAX_INLINE_EDGES, max_nodes * 2)
         entry_points = entry_points[:_MAX_INLINE_ENTRY_POINTS]
-        nodes = nodes[:_MAX_INLINE_NODES]
+        nodes = nodes[:inline_node_cap]
         _echoed_ids = {n.get("id") for n in nodes}
         edges = [
             e
             for e in edges
             if e.get("source") in _echoed_ids and e.get("target") in _echoed_ids
-        ][:_MAX_INLINE_EDGES]
+        ][:inline_edge_cap]
         verdict = "INFO" if entry_points else "NOT_FOUND"
         result: dict[str, Any] = {
             "success": True,

--- a/tree_sitter_analyzer/mcp/tools/hyphae_subscribe_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/hyphae_subscribe_tool.py
@@ -200,9 +200,13 @@ def _capture_session_obj() -> Any:
     Returns None if unavailable — the bridge degrades gracefully.
     """
     try:
-        from mcp.server import Server
+        # The current request context lives in a module-level contextvar in the
+        # MCP low-level server; accessing ``Server.request_context`` on the class
+        # returns the property descriptor, not the live context. Read the
+        # contextvar directly (populated for the duration of a tool-call handler).
+        from mcp.server.lowlevel.server import request_ctx
 
-        return Server.request_context.session
+        return request_ctx.get().session
     except Exception:
         return None
 

--- a/tree_sitter_analyzer/mcp/tools/hyphae_subscribe_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/hyphae_subscribe_tool.py
@@ -82,7 +82,7 @@ class HyphaeSubscribeTool(BaseMCPTool):
         self.validate_arguments(arguments)
         selector = arguments["selector"]
         min_interval = float(arguments.get("min_interval", 2.0))
-        output_format = arguments.get("output_format", "json")
+        output_format = arguments.get("output_format", "toon")
 
         # RFC-0001: capture session + loop at subscribe time (the only moment
         # request_context is populated and the event loop is running).
@@ -92,9 +92,11 @@ class HyphaeSubscribeTool(BaseMCPTool):
         registry = get_subscription_registry()
         registry.subscribe(session_id, selector)
 
-        # Store the loop and min_interval so the bridge can use them
+        # Store the loop, session object, and min_interval so the bridge can use them.
+        # Session is captured here because request_context is only valid during a handler.
         _SESSION_LOOPS[session_id] = loop
         _SESSION_MIN_INTERVALS[session_id] = min_interval
+        _SESSION_SESSIONS[session_id] = _capture_session_obj()
 
         resource_uri = _selector_to_uri(selector)
         response = build_response(
@@ -140,7 +142,7 @@ class HyphaeUnsubscribeTool(BaseMCPTool):
 
     async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
         self.validate_arguments(arguments)
-        output_format = arguments.get("output_format", "json")
+        output_format = arguments.get("output_format", "toon")
         session_id = arguments.get("sub_id") or _capture_session_id()
         selector = arguments.get("selector")
 
@@ -152,6 +154,7 @@ class HyphaeUnsubscribeTool(BaseMCPTool):
 
         _SESSION_LOOPS.pop(session_id, None)
         _SESSION_MIN_INTERVALS.pop(session_id, None)
+        _SESSION_SESSIONS.pop(session_id, None)
 
         response = build_response(
             verdict="INFO",
@@ -170,6 +173,8 @@ class HyphaeUnsubscribeTool(BaseMCPTool):
 _SESSION_LOOPS: dict[str, asyncio.AbstractEventLoop] = {}
 # Maps session_id → min_interval_s
 _SESSION_MIN_INTERVALS: dict[str, float] = {}
+# Maps session_id → MCP ServerSession object (captured at subscribe time)
+_SESSION_SESSIONS: dict[str, Any] = {}
 
 
 def _capture_session_id() -> str:
@@ -188,9 +193,28 @@ def _capture_session_id() -> str:
     return "session-default"
 
 
+def _capture_session_obj() -> Any:
+    """Capture the MCP ServerSession from the current request context.
+
+    Must be called inside a tool handler (where request_context is populated).
+    Returns None if unavailable — the bridge degrades gracefully.
+    """
+    try:
+        from mcp.server import Server
+
+        return Server.request_context.session
+    except Exception:
+        return None
+
+
 def get_session_loop(session_id: str) -> asyncio.AbstractEventLoop | None:
     """Return the captured event loop for *session_id*, or None."""
     return _SESSION_LOOPS.get(session_id)
+
+
+def get_session_obj(session_id: str) -> Any:
+    """Return the captured MCP ServerSession for *session_id*, or None."""
+    return _SESSION_SESSIONS.get(session_id)
 
 
 def get_session_min_interval(session_id: str) -> float:

--- a/tree_sitter_analyzer/mcp/watch_push_bridge.py
+++ b/tree_sitter_analyzer/mcp/watch_push_bridge.py
@@ -92,14 +92,31 @@ def _drive_subscriptions(
                 "push scheduling failed for session %s", session_id, exc_info=True
             )
 
-    registry.notify_all(
-        evaluate=lambda sid, sel: _evaluate(sid, sel),
-    )
+    # Push ONLY the (session, selector) pairs whose result actually changed.
+    for session_id, selector in collect_changed_pairs(registry, _evaluate):
+        _push(session_id, selector)
 
-    # Fire the push for sessions that got a delta
+
+def collect_changed_pairs(
+    registry: Any,
+    evaluate: Any,
+) -> list[tuple[str, str]]:
+    """Return the ``(session_id, selector)`` pairs whose result changed.
+
+    ``compute_delta`` atomically applies the ``min_interval`` throttle, diffs
+    the snapshot against the stored one, and updates the stored snapshot — so
+    an unrelated file save (or a throttled event) yields an empty delta and the
+    pair is omitted. This honours the RFC-0001 contract: notify only when the
+    selector result actually moves, never on every sync event.
+    """
+    changed: list[tuple[str, str]] = []
     for session_id in registry.all_sessions():
         for selector in registry.subscriptions_for(session_id):
-            _push(session_id, selector)
+            snapshot = evaluate(session_id, selector)
+            added, removed = registry.compute_delta(session_id, selector, snapshot)
+            if added or removed:
+                changed.append((session_id, selector))
+    return changed
 
 
 async def _send_update(session_id: str, uri: str) -> None:

--- a/tree_sitter_analyzer/mcp/watch_push_bridge.py
+++ b/tree_sitter_analyzer/mcp/watch_push_bridge.py
@@ -105,11 +105,15 @@ def _drive_subscriptions(
 async def _send_update(session_id: str, uri: str) -> None:
     """Coroutine that sends resource-updated; runs on the captured loop."""
     try:
-        from mcp.server import Server
+        from pydantic import AnyUrl
 
-        server = Server.current()
-        if server is not None:
-            await server.request_context.session.send_resource_updated(uri)
+        from .tools.hyphae_subscribe_tool import get_session_obj
+
+        session = get_session_obj(session_id)
+        if session is None:
+            logger.debug("no session for %s — push skipped", session_id)
+            return
+        await session.send_resource_updated(AnyUrl(uri))
     except Exception:
         logger.debug("send_resource_updated failed for %s", uri, exc_info=True)
 


### PR DESCRIPTION
## Summary

Fixes 5 Codex review findings from PRs #297–#312 that were ignored. Re-cut cleanly onto `develop` (supersedes #313 which had a wrong base of `main`).

### P1: RFC-0001 reactive push was entirely dead code (3 missing wires)
1. **`resource_registration.py`**: `tsa://hyphae/` URIs were never registered → every re-read after a push got `Resource not found`. Now registered in `list_resources` + `read_resource`.
2. **`ast_cache_tool.py`**: `FileWatcherDaemon` built without `on_sync` → file changes never drove `_drive_subscriptions`. Now wired via `make_on_sync_callback()`.
3. **`watch_push_bridge.py` + `hyphae_subscribe_tool.py`**: `Server.current()` doesn't exist in MCP SDK 1.17.0 (mypy confirms: `"type[Server]" has no attribute "current"`) — the `AttributeError` was swallowed, so **no push ever delivered**. Now captures the `ServerSession` at subscribe time via the `request_ctx` contextvar and uses it in `_send_update`.
4. **Bonus P2**: `output_format` default `json` → `toon` (CLAUDE.md locked MCP default).

### P2: `codegraph_context` ignored `max_nodes` (PR #305)
`_MAX_INLINE_NODES = 12` capped the response regardless of the caller's `max_nodes` (default 30, max 100). Now `inline_node_cap = max(_MAX_INLINE_NODES, max_nodes)` — scales with the request, keeps the floor.

### P2: `packages` in `EXCLUDE_DIRS` broke JS/TS monorepos (PR #305)
Removed `"packages"` — JS/TS workspaces use `packages/<api>/src/` as first-party source. `obj/` already covers C# build output; `.dll`/`.nupkg` skipped by extension.

## Note: this PR also un-REDs develop
develop is currently RED on mypy (`watch_push_bridge.py:110 Server.current` from #312). This PR fixes it — the sibling PRs #314/#315/#316 inherit that RED and will go green after this merges + they pick up develop.

## Test plan
- `uv run mypy tree_sitter_analyzer/` — 676 files clean ✓
- `uv run ruff check` — clean ✓
- `uv run pytest tests/unit/ -q -n auto` — 16,589 passed ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)