### PR TITLE
docs(rfc): RFC-0008 multi-lang method classification + beyond-CG roadmap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -330,6 +330,9 @@ local_settings.py
 # Compiled tree-sitter parsers
 parsers/
 
+# TSA dogfood index cache (local, regenerated on demand)
+.tree-sitter-cache/
+
 # Compatibility test results (keep directory structure, ignore content)
 compatibility_test/results/*/
 compatibility_test/reports/*.md

--- a/rfcs/0008-multilang-method-classification.md
+++ b/rfcs/0008-multilang-method-classification.md
@@ -78,6 +78,48 @@ tables alongside Python.
 The **language-aware project-ownership gate** stays: a project method of the same
 name in a compatible-language file wins; ambiguous names stay `unknown`.
 
+#### Java routes through its own resolver cascade (not the Python tiers)
+
+`resolve_callee` dispatches `language == "java"` straight into
+`_java.resolve_java_callee`, which has its **own** 10-stage cascade and returns
+before `_resolve_callee_python` (where `_try_stdlib_method` et al. live) ever
+runs. The Java resolver does **not** read `ResolverContext.stdlib_methods`. So
+generalising the Python tiers + registering `STDLIB_METHODS_JAVA` in the shared
+tables is **necessary but not sufficient** for Java: it would leave `list.add(x)`
+unchanged.
+
+The Java method-classification tiers are therefore added **inside
+`resolve_java_callee`** as new terminal stages (9b stdlib / 9c external), reading
+`STDLIB_METHODS_JAVA` / `EXTERNAL_METHODS_JAVA` directly, with a language-aware
+`_project_owns` ownership gate. The shared-table generalisation (caller_lang
+dispatch in `__init__.py`) still lands — it fixes a latent cross-language bug for
+the languages that *do* route through the generic Python path and registers the
+Java tables for any future unified path — but the **decisive** change for Java is
+the new tiers in `resolve_java_callee`. Go/JS will follow whichever path their
+resolver uses (measure first).
+
+A prerequisite for Java surfaced during implementation: Java
+`method_invocation` call extraction recorded the *receiver* as the callee name
+(`list.add()` → `name="list"`), so the method name never reached any tier. The
+fix (extract the `name` field, carry the `object` as receiver) ships with the
+Java PR.
+
+#### Precision over recall for ambiguous names (curation discipline)
+
+A name tier classifies on the **bare method name** with no receiver-type
+evidence (type inference is deferred — see Alternatives). The only safety net is
+the project-ownership gate, which distinguishes *project* from *not-project* but
+**not** *stdlib* from *external/third-party*. So a generic name that a domain or
+third-party object commonly defines (`get` on a Guava `Cache`, `set` on a
+builder, `map`/`filter` on a domain stream) would be over-claimed as `stdlib`.
+Each language table must therefore be **curated for precision**: include only
+names that are *distinctively* the platform's API (e.g. `substring`,
+`computeIfAbsent`, `containsKey`, `collect`, `orElseThrow`) and exclude bare
+container/accessor verbs that domain objects routinely define (`set`, `put`,
+`map`, `filter`, `peek`, `reduce`, …), mirroring `STDLIB_METHODS_PY`'s exclusion
+list. A false `stdlib` label erodes the "agents can trust the resolved graph"
+thesis more than a missed classification does.
+
 ### Error handling
 
 Best-effort and monotonic: a tier only moves an edge `unknown -> stdlib/external/

--- a/rfcs/0008-multilang-method-classification.md
+++ b/rfcs/0008-multilang-method-classification.md
@@ -1,0 +1,146 @@
+# RFC-0008: Multi-language method classification — beyond Python
+
+- **Status**: draft
+- **Author(s)**: @aimasteracc
+- **Created**: 2026-06-06
+- **Last updated**: 2026-06-06
+- **Tracking issue**: TBD
+- **Affected source paths**:
+  - `tree_sitter_analyzer/synapse_resolver/_constants.py` (per-language method tables)
+  - `tree_sitter_analyzer/synapse_resolver/_java_constants.py` (precedent: Java tables)
+  - `tree_sitter_analyzer/synapse_resolver/__init__.py` (cascade: language dispatch)
+  - `tests/unit/`
+
+## Summary
+
+Extend the method-classification cascade tiers from RFC-0004 (`_try_stdlib_method`),
+RFC-0005 (`_try_external_method`), and RFC-0007 (`_try_builtin_method`) — currently
+**Python-only** — to **Java, Go, and JavaScript/TypeScript**, so a polyglot
+repository's call graph is classified to the same ~96% completeness TSA reaches on
+a pure-Python repo.
+
+## Motivation
+
+RFC-0004/0005/0007 took Python callee classification from **83.9% to 96.5%** by
+recognising bare stdlib / external-library / builtin **method** names the binding
+cascade can't resolve, gated on the project owning no compatible-language symbol of
+that name (shadowing preserved, zero mis-wires).
+
+Those three tiers are **Python-only**: the tables (`STDLIB_METHODS_PY`,
+`EXTERNAL_METHODS_PY`, `BUILTIN_QUALIFIED_PY`) and the cascade tiers each gate on
+`caller_lang == "python"` (RFC-0007 Codex P2). On a Java / Go / JS repo those tiers
+never fire, so the `unknown` tail stays large — the same class of edge
+(`list.add`, `strings.Split`, `arr.map`, `obj.toString`) we now resolve in Python
+is left unclassified elsewhere. TSA advertises broad language coverage; resolved-
+graph completeness should follow.
+
+## Detailed design
+
+### Data structures — per-language method tables
+
+Mirror the Python tables, one set per language, grouped + commented by owning
+type/library. Curated, high-recall, conservative (exclude names projects commonly
+define):
+
+- **Java** (`STDLIB_METHODS_JAVA`): `java.util` collections (`add`, `get`, `put`,
+  `containsKey`, `stream`, `forEach`), `String` (`substring`, `trim`, `split`),
+  `Optional` (`orElse`, `isPresent`), `Stream` (`map`, `filter`, `collect`).
+  External: JUnit (`assertEquals`, `assertThat`), Mockito (`mock`, `when`, `verify`).
+- **Go** (`STDLIB_METHODS_GO`): package-qualified calls (`strings.Split`,
+  `fmt.Sprintf`) are already import-resolved; the gap is receiver methods on
+  stdlib types (`err.Error`, `ctx.Done`, `wg.Wait`, `b.WriteString`). External:
+  `testing` (`t.Run`, `t.Fatal`), testify (`assert.Equal`, `require.NoError`).
+- **JS/TS** (`STDLIB_METHODS_JS`): `Array` (`map`, `filter`, `reduce`, `forEach`,
+  `find`, `push`), `String` (`split`, `slice`, `replace`, `trim`), `Object`
+  (`keys`, `values`, `entries`), `Promise` (`then`, `catch`). External: Jest/Vitest
+  (`expect`, `toBe`, `toEqual`).
+
+### Algorithm — language-dispatched tiers
+
+The three tiers already thread `caller_file` and compute `caller_lang`. Generalise:
+each tier looks up the table for `caller_lang` instead of hard-coding `"python"`.
+
+```python
+def _try_stdlib_method(base, qualifier, caller_file, ctx):
+    caller_lang = ctx.file_languages.get(caller_file, "")
+    table = ctx.stdlib_methods.get(caller_lang)   # was: .get("python")
+    if not table or base not in table:
+        return None
+    # same language-aware project-ownership gate as today
+    ...
+```
+
+`ResolverContext` already carries `stdlib_methods` / `external_methods` /
+`builtin_methods` as `dict[str, frozenset[str]]` keyed by language — so wiring is
+"add more keys", not new plumbing. The default builder registers Java / Go / JS
+tables alongside Python.
+
+The **language-aware project-ownership gate** stays: a project method of the same
+name in a compatible-language file wins; ambiguous names stay `unknown`.
+
+### Error handling
+
+Best-effort and monotonic: a tier only moves an edge `unknown -> stdlib/external/
+builtin`, never the reverse, never crosses languages. A language with no table
+behaves exactly as today (no-op).
+
+### MCP surface
+
+None. Indexing-layer classification, consumed identically by every reader.
+
+## Three-Surface impact (CLI / MCP parity)
+
+No surface change. Computed at index time, read identically by CLI and MCP.
+
+## Drawbacks
+
+- Curating four languages' tables is more surface to maintain. Mitigated: tables
+  are high-recall floors, not exhaustive; the ownership gate prevents over-claiming.
+- Go's package-qualified calls are mostly import-resolved already; the receiver-
+  method gap is smaller there — measure before investing.
+
+## Alternatives
+
+- **Per-language full type inference**: precise, far larger, per-language type
+  systems. Deferred — the name table captured 12pp in Python cheaply.
+- **Leave non-Python at status quo**: rejected — completeness should not be
+  Python-only.
+
+## Prior art
+
+- RFC-0004/0005/0007 (this repo) — the cascade-tier + ownership-gate pattern this
+  RFC generalises across languages.
+- `_java_constants.py` already exists (Java builtins/stdlib for the binding
+  cascade) — extend it with method tables rather than starting fresh.
+
+## Test plan (RED-first)
+
+- Unit per language: a Java caller `list.add(x)` with no project `add` -> `stdlib`;
+  a project method `add` -> `project` (shadowing); a JS `arr.map(f)` -> `stdlib`;
+  cross-language gate (a Python `split` table must not classify a Java `split`).
+- Dogfood: index a polyglot/Java/Go repo; assert classified share rises vs the
+  Python-only baseline; zero mis-wires.
+
+## Acceptance criteria
+
+- [ ] `STDLIB_METHODS_JAVA` / `_GO` / `_JS` (+ external/builtin where apt), grouped + commented
+- [ ] cascade tiers dispatch on `caller_lang` (not hard-coded Python)
+- [ ] language-aware ownership gate preserved per language (shadowing + ambiguity)
+- [ ] per-language RED-first unit tests + cross-language gate test
+- [ ] dogfood on a Java or Go repo shows a measurable classified-share rise
+- [ ] CLI/MCP parity unaffected; full suite green
+- [ ] Docs/CODEMAPS + RFC status -> implemented
+
+## What this RFC does NOT do (deferred)
+
+- Full per-language type inference / prototype resolution.
+- Languages beyond Java/Go/JS/TS (C#/Ruby/Rust follow the same shape later).
+- File-level resolution of stdlib methods to their owning module (separate RFC).
+
+## Open questions
+
+1. Land all three languages in one PR, or one per PR (Java first, where
+   `_java_constants.py` already exists)? Recommendation: one PR per language for
+   focused Codex review.
+2. Go: is the receiver-method gap large enough to justify a table, or is import
+   resolution already covering most of it? Measure on a real Go repo first.

--- a/rfcs/ROADMAP-beyond-codegraph.md
+++ b/rfcs/ROADMAP-beyond-codegraph.md
@@ -1,0 +1,61 @@
+# Strategic Roadmap — beyond CodeGraph (2026-06-06)
+
+PM strategy note. Where TSA stands vs CodeGraph (CG) after the v1.21.0 work, and
+the prioritized path to becoming the default agent code-intelligence layer.
+
+## Where we stand (measured on this repo)
+
+| axis | TSA | CG | verdict |
+|---|---|---|---|
+| symbol kinds (kind=method) | 20,348 | 20,275 | TSA ahead |
+| callee classification | 96.5% (after #324) | many same-name mis-wires | TSA ahead (correct AND complete) |
+| FTS production-first | yes | test-mock shadows | TSA ahead |
+| edges_by_kind status | yes | none | TSA exclusive |
+| token / context call | ~6.6k (was 12.7k) | ~4.4k | gap 2.9x to 1.5x; near parity |
+| reactive push | wired (RFC-0001) | none | TSA exclusive |
+
+TSA's thesis is now defensible: correct + complete + nearly as cheap, with
+capabilities CG lacks. The remaining work is to make each lead decisive and
+measured, not anecdotal.
+
+## Prioritized initiatives (impact x confidence / cost)
+
+### P0 — Prove the token-cost win with a real benchmark
+The README still cites a pre-RFC-0006 dollar table. Re-run
+benchmarks/codegraph_compare/run.py phase full-warm --repos gin,django on
+current develop to get the real per-task cost after the 53% payload cut.
+If TSA is now within ~1.1x of CG (or cheaper), the "CG is cheaper" caveat can be
+retired with evidence. This converts a hedge into a headline. (Needs API budget;
+user has authorized spend.)
+
+### P1 — RFC-0008 multi-language method classification (spec drafted)
+The 83.9% to 96.5% classification win is Python-only. Extend the cascade tiers to
+Java/Go/JS/TS so polyglot repos get the same resolved-graph completeness. One PR
+per language (Java first — _java_constants.py exists). Blocked on #324 merging
+first (shared synapse_resolver). Largest single lever for non-Python users.
+
+### P2 — File-level resolution of stdlib/builtin methods (RFC-0004 phase 2)
+Today stdlib/external/builtin methods are classified but not file-resolved.
+Receiver-type inference (annotation + constructor-assignment driven) would point
+p.write_text() at pathlib, raising the file-resolution rate and enabling
+"jump to the stdlib def" for agents. Precision-sensitive; gate hard.
+
+### P3 — Reactive push as a demoed differentiator
+RFC-0001 is wired but invisible. Add a CLI watch --subscribe mode + a recorded
+demo (edit a file, agent receives resource_updated, re-reads the changed set).
+No competitor has this; make it legible.
+
+### P4 — Resolution confidence signal
+Expose per-edge callee_resolution + a confidence so agents can trust/distrust a
+binding. Turns the resolved graph from a black box into an auditable one — directly
+on-thesis ("agents know before they touch").
+
+## Operating discipline (keep)
+- RFC-first for substantial changes; RED-first TDD; one PR = one feature.
+- Triage every Codex review (locked) — 14 findings this cycle, all real-fixed or
+  clean. Codex caught 3 latent dead-code/wiring bugs that local tests missed.
+- docs-only changes now skip the heavy matrix (CI smart-routing, #323).
+
+## Next action
+Ship v1.21.0 (push release/v1.21.0), merge the 4 in-flight quality PRs after
+Codex triage, then start P0 (benchmark) + P1 (RFC-0008 Java) in parallel.


### PR DESCRIPTION
## What
- `rfcs/0008-multilang-method-classification.md` — extend the RFC-0004/0005/0007 method-classification cascade (currently Python-only) to **Java / Go / JS-TS**, so polyglot repos reach the same ~96% callee-classification completeness. One PR per language, **Java first** (`_java_constants.py` already exists).
- `rfcs/ROADMAP-beyond-codegraph.md` — PM strategy note: where TSA stands vs CodeGraph after v1.21.0 and the P0–P4 path to becoming the default agent code-intel layer.
- `.gitignore` — ignore `.tree-sitter-cache/` (local dogfood index, regenerated on demand).

## Why
Spec-first per the RFC process (locked). RFC-0008 is the P1 lever for non-Python users; this lands the spec so implementation PRs can reference an accepted design.

## Surface
Docs + gitignore only. No code, no CLI/MCP change.

## Test plan
- [x] pre-commit (ruff/mypy/secrets) green
- [x] `.tree-sitter-cache/` confirmed ignored
- N/A runtime — docs-only (CI docs-check routing, #323)