### PR TITLE
feat(resolver): RFC-0008 Java method classification — stdlib/external tiers + method-call name extraction

### DIFF
--- a/tests/unit/test_java_method_resolution.py
+++ b/tests/unit/test_java_method_resolution.py
@@ -3,10 +3,12 @@ stdlib/external, not unknown — mirroring RFC-0004/0005 for Python.
 
 The cascade's stdlib/external method tiers, generalized to dispatch on the
 caller's language, classify a bare Java method name that survives every
-project-binding rule (``add``, ``get``, ``split``, ``verify``, …) as
+project-binding rule (``substring``, ``containsKey``, ``verify``, …) as
 ``stdlib``/``external`` — but ONLY when the project defines no
 compatible-language method of that name (shadowing preserved; ambiguous
-project names stay ``unknown``).
+project names stay ``unknown``). Per the Codex P2 #326 PRECISION re-curation,
+generic verbs (``add``/``get``/``put``/``map``/``split``/...) are DROPPED from
+the tables so a non-JDK receiver (e.g. Guava ``Cache.get``) stays ``unknown``.
 
 The mandatory cross-language gate: a name that lives ONLY in Python's table
 must NOT classify a Java caller, and a name in Java's table must NOT classify
@@ -58,151 +60,229 @@ def _resolution_for(db_path: str, callee_name: str) -> list[str]:
 # stdlib method tier
 # ---------------------------------------------------------------------------
 def test_java_stdlib_method_classifies_as_stdlib(tmp_path: Path) -> None:
-    """``list.add(x)`` with no project ``add`` → stdlib, not unknown."""
+    """``s.substring(1)`` with no project ``substring`` → stdlib, not unknown.
+    ``substring`` lives on the ``final`` ``java.lang.String`` (no domain subtype,
+    not a ``CharSequence`` interface method), so it survives the PRECISION
+    curation — unlike the dropped generic CRUD/interface names
+    (``add``/``get``/``stream``/``containsKey``…) that domain & third-party
+    objects routinely define (Codex P2 #326, review P1)."""
     _index(
         tmp_path,
         {
             "Service.java": (
-                "import java.util.List;\n"
                 "class Service {\n"
-                "    void caller(List<String> list) {\n"
-                '        list.add("x");\n'
+                "    void caller(String s) {\n"
+                "        s.substring(1);\n"
                 "    }\n"
                 "}\n"
             )
         },
     )
     db = str(tmp_path / ".ast-cache" / "index.db")
-    res = _resolution_for(db, "add")
-    assert res, "expected an add() edge"
+    res = _resolution_for(db, "substring")
+    assert res, "expected a substring() edge"
     assert "stdlib" in res, (
-        f"Java list.add must classify as stdlib (RFC-0008 tier); got {res}"
+        f"Java s.substring must classify as stdlib (RFC-0008 tier); got {res}"
     )
     assert "unknown" not in res
 
 
-def test_java_project_method_shadows_stdlib_name(tmp_path: Path) -> None:
-    """A Java class defining ``add`` → ``adder.add()`` resolves project, not
-    stdlib (shadowing preserved)."""
+def test_java_optional_method_classifies_as_stdlib(tmp_path: Path) -> None:
+    """``opt.orElseThrow()`` with no project ``orElseThrow`` → stdlib. Covers the
+    Optional half of the table (vavr ``Option`` uses ``getOrElseThrow``, not
+    ``orElseThrow``, so the name is distinctively ``java.util.Optional``)."""
     _index(
         tmp_path,
         {
-            "Adder.java": (
-                "class Adder {\n"
-                "    int add() { return 1; }\n"
-                "    void caller() {\n"
-                "        Adder adder = new Adder();\n"
-                "        adder.add();\n"
+            "Service.java": (
+                "import java.util.Optional;\n"
+                "class Service {\n"
+                "    void caller(Optional<String> opt) {\n"
+                "        opt.orElseThrow();\n"
                 "    }\n"
                 "}\n"
             )
         },
     )
     db = str(tmp_path / ".ast-cache" / "index.db")
-    res = _resolution_for(db, "add")
-    assert res, "expected an add() edge"
+    res = _resolution_for(db, "orElseThrow")
+    assert res, "expected an orElseThrow() edge"
+    assert "stdlib" in res, (
+        f"Java opt.orElseThrow must classify as stdlib (RFC-0008 tier); got {res}"
+    )
+
+
+def test_java_project_method_shadows_stdlib_name(tmp_path: Path) -> None:
+    """A Java class defining ``substring`` → ``box.substring()`` resolves
+    project, not stdlib (shadowing preserved). Uses a KEPT name so the gate is
+    actually exercised against a surviving stdlib entry."""
+    _index(
+        tmp_path,
+        {
+            "TextBox.java": (
+                "class TextBox {\n"
+                '    String substring() { return ""; }\n'
+                "    void caller() {\n"
+                "        TextBox box = new TextBox();\n"
+                "        box.substring();\n"
+                "    }\n"
+                "}\n"
+            )
+        },
+    )
+    db = str(tmp_path / ".ast-cache" / "index.db")
+    res = _resolution_for(db, "substring")
+    assert res, "expected a substring() edge"
     assert "stdlib" not in res, (
-        f"project-defined Java add must NOT be classified stdlib; got {res}"
+        f"project-defined Java substring must NOT be classified stdlib; got {res}"
     )
 
 
 def test_java_ambiguous_project_method_stays_unknown(tmp_path: Path) -> None:
-    """Two Java classes define ``add`` → a bare ``add()`` stays unknown,
-    never falsely claimed stdlib."""
+    """Two Java classes define ``substring`` → a bare ``substring()`` stays
+    unknown, never falsely claimed stdlib. Uses a KEPT name so ambiguity is
+    tested against a surviving stdlib entry."""
     _index(
         tmp_path,
         {
             "Pair.java": (
                 "class A {\n"
-                "    int add() { return 1; }\n"
+                '    String substring() { return "a"; }\n'
                 "}\n"
                 "class B {\n"
-                "    int add() { return 2; }\n"
+                '    String substring() { return "b"; }\n'
                 "}\n"
                 "class Caller {\n"
                 "    void caller(Object obj) {\n"
-                "        obj.add();\n"
+                "        obj.substring();\n"
                 "    }\n"
                 "}\n"
             )
         },
     )
     db = str(tmp_path / ".ast-cache" / "index.db")
-    res = _resolution_for(db, "add")
-    assert res, "expected an add() edge"
+    res = _resolution_for(db, "substring")
+    assert res, "expected a substring() edge"
     assert "stdlib" not in res, (
-        f"ambiguous project method add must stay unknown, not stdlib; got {res}"
+        f"ambiguous project method substring must stay unknown, not stdlib; got {res}"
     )
 
 
 def test_cross_language_python_table_does_not_classify_java_caller(
     tmp_path: Path,
 ) -> None:
-    """CRITICAL cross-language gate: a Java ``str.split()`` must still resolve
-    to (Java) stdlib even though a Python file defines a method ``split`` — the
-    Python symbol does NOT suppress Java's stdlib table because
-    ``languages_compatible('java', 'python')`` is False."""
+    """CRITICAL cross-language gate: a Java ``str.substring(1)`` must still
+    resolve to (Java) stdlib even though a Python file defines a method
+    ``substring`` — the Python symbol does NOT suppress Java's stdlib table
+    because ``languages_compatible('java', 'python')`` is False. ``substring``
+    is a KEPT distinctively-JDK name (Codex P2 #326)."""
     _index(
         tmp_path,
         {
             "Service.java": (
                 "class Service {\n"
                 "    void caller(String str) {\n"
-                '        str.split(",");\n'
+                "        str.substring(1);\n"
                 "    }\n"
                 "}\n"
             ),
-            "splitter.py": (
-                "class MySplitter:\n    def split(self):\n        return 1\n"
+            "substringer.py": (
+                "class MySubstringer:\n    def substring(self):\n        return 1\n"
             ),
         },
     )
     db = str(tmp_path / ".ast-cache" / "index.db")
-    res = _resolution_for(db, "split")
+    res = _resolution_for(db, "substring")
     assert "stdlib" in res, (
-        "Java str.split must classify stdlib despite a Python split symbol; "
-        f"languages_compatible('java','python') is False. got {res}"
+        "Java str.substring must classify stdlib despite a Python substring "
+        f"symbol; languages_compatible('java','python') is False. got {res}"
     )
 
 
-# ---------------------------------------------------------------------------
-# external method tier
-# ---------------------------------------------------------------------------
-def test_java_external_method_classifies_as_external(tmp_path: Path) -> None:
-    """A Java test ``mock.verify(...)`` with no project ``verify`` → external
-    (Mockito), not unknown."""
+def test_java_dropped_generic_method_stays_unknown(tmp_path: Path) -> None:
+    """Codex P2 #326 regression lock: a Java ``cache.get(k)`` with no project
+    ``get`` must stay UNKNOWN, never ``stdlib``.
+
+    ``get`` is a generic verb that domain and third-party objects (e.g. Guava
+    ``Cache`` — NOT the JDK) routinely define. The name tiers carry no
+    receiver-type evidence, so labelling it ``stdlib`` was a false positive; the
+    PRECISION re-curation DROPPED ``get`` (and add/put/set/remove/contains/
+    map/filter/...) from ``STDLIB_METHODS_JAVA`` so such calls fall through to
+    unknown instead of being mislabelled JDK."""
     _index(
         tmp_path,
         {
-            "ServiceTest.java": (
-                "class ServiceTest {\n"
-                "    void test(Object mock) {\n"
-                "        verify(mock);\n"
+            "Service.java": (
+                "class Service {\n"
+                "    void caller(Cache cache, String k) {\n"
+                "        cache.get(k);\n"
                 "    }\n"
                 "}\n"
             )
         },
     )
     db = str(tmp_path / ".ast-cache" / "index.db")
-    res = _resolution_for(db, "verify")
-    assert res, "expected a verify() edge"
-    assert "external" in res, (
-        f"Java Mockito verify must classify as external; got {res}"
+    res = _resolution_for(db, "get")
+    assert res, "expected a get() edge"
+    assert "stdlib" not in res, (
+        "dropped generic name get on a non-JDK receiver (Guava Cache) must NOT "
+        f"be classified stdlib (Codex P2 #326); got {res}"
+    )
+    assert "unknown" in res, (
+        f"cache.get with no project get must stay unknown; got {res}"
     )
 
 
-def test_java_project_method_shadows_external_name(tmp_path: Path) -> None:
-    """A Java class defining ``verify`` → ``v.verify()`` resolves project, not
-    external (shadowing preserved)."""
+def test_java_interface_method_stays_unknown(tmp_path: Path) -> None:
+    """Review P1 regression lock: ``flux.stream()`` must stay UNKNOWN, never
+    ``stdlib``.
+
+    ``stream``/``parallelStream`` are ``java.util.Collection`` **default
+    interface** methods — every Reactor ``Flux``, Guava ``ImmutableList``, Spring
+    Data ``Streamable`` and domain collection inherits them, and the AST cache
+    does not index inherited external-interface methods, so ``_project_owns``
+    can't see them. Dropping all interface-method names from the table is what
+    keeps these out of the JDK ``stdlib`` bucket."""
     _index(
         tmp_path,
         {
-            "MockValidator.java": (
-                "class MockValidator {\n"
-                "    boolean verify() { return true; }\n"
-                "    void caller() {\n"
-                "        MockValidator v = new MockValidator();\n"
-                "        v.verify();\n"
+            "Pipeline.java": (
+                "class Pipeline {\n"
+                "    void caller(Flux flux) {\n"
+                "        flux.stream();\n"
+                "    }\n"
+                "}\n"
+            )
+        },
+    )
+    db = str(tmp_path / ".ast-cache" / "index.db")
+    res = _resolution_for(db, "stream")
+    assert res, "expected a stream() edge"
+    assert "stdlib" not in res, (
+        "interface method stream() on a non-JDK receiver (Reactor Flux) must NOT "
+        f"be classified stdlib (review P1); got {res}"
+    )
+    assert "unknown" in res, (
+        f"flux.stream with no project stream must stay unknown; got {res}"
+    )
+
+
+def test_java_production_verify_stays_unknown(tmp_path: Path) -> None:
+    """Review P1 regression lock: ``signature.verify(sig)`` must stay UNKNOWN,
+    never ``external`` (Mockito).
+
+    Production security code calls ``verify()`` on ``java.security.Signature`` /
+    ``Certificate`` / domain JWT tokens — receiver-qualified, NOT the bare
+    Mockito ``verify(mock)``. Dropping ``verify``/``when``/``mock``/``spy`` from
+    the external table keeps these production calls out of the test-stack
+    bucket."""
+    _index(
+        tmp_path,
+        {
+            "Auth.java": (
+                "class Auth {\n"
+                "    void caller(Object signature, byte[] sig) {\n"
+                "        signature.verify(sig);\n"
                 "    }\n"
                 "}\n"
             )
@@ -212,7 +292,66 @@ def test_java_project_method_shadows_external_name(tmp_path: Path) -> None:
     res = _resolution_for(db, "verify")
     assert res, "expected a verify() edge"
     assert "external" not in res, (
-        f"project-defined Java verify must NOT be classified external; got {res}"
+        "production security verify() on a non-Mockito receiver must NOT be "
+        f"classified external (review P1); got {res}"
+    )
+    assert "unknown" in res, (
+        f"signature.verify with no project verify must stay unknown; got {res}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# external method tier
+# ---------------------------------------------------------------------------
+def test_java_external_method_classifies_as_external(tmp_path: Path) -> None:
+    """A Java test ``assertEquals(a, b)`` with no project ``assertEquals`` →
+    external (JUnit), not unknown. ``assertEquals`` is a bare static assertion
+    entry point — distinctively the test stack — unlike the dropped
+    receiver-style Mockito names (``verify``/``when``/``mock``) that collide with
+    production code (review P1)."""
+    _index(
+        tmp_path,
+        {
+            "ServiceTest.java": (
+                "class ServiceTest {\n"
+                "    void test(Object a, Object b) {\n"
+                "        assertEquals(a, b);\n"
+                "    }\n"
+                "}\n"
+            )
+        },
+    )
+    db = str(tmp_path / ".ast-cache" / "index.db")
+    res = _resolution_for(db, "assertEquals")
+    assert res, "expected an assertEquals() edge"
+    assert "external" in res, (
+        f"Java JUnit assertEquals must classify as external; got {res}"
+    )
+
+
+def test_java_project_method_shadows_external_name(tmp_path: Path) -> None:
+    """A Java class defining ``assertEquals`` → ``c.assertEquals()`` resolves
+    project, not external (shadowing preserved). Uses a KEPT external name so the
+    ownership gate is exercised against a surviving entry."""
+    _index(
+        tmp_path,
+        {
+            "CustomChecker.java": (
+                "class CustomChecker {\n"
+                "    boolean assertEquals() { return true; }\n"
+                "    void caller() {\n"
+                "        CustomChecker c = new CustomChecker();\n"
+                "        c.assertEquals();\n"
+                "    }\n"
+                "}\n"
+            )
+        },
+    )
+    db = str(tmp_path / ".ast-cache" / "index.db")
+    res = _resolution_for(db, "assertEquals")
+    assert res, "expected an assertEquals() edge"
+    assert "external" not in res, (
+        f"project-defined Java assertEquals must NOT be classified external; got {res}"
     )
 
 

--- a/tests/unit/test_java_method_resolution.py
+++ b/tests/unit/test_java_method_resolution.py
@@ -1,0 +1,243 @@
+"""RFC-0008 RED-first: Java stdlib/external method names classify as
+stdlib/external, not unknown — mirroring RFC-0004/0005 for Python.
+
+The cascade's stdlib/external method tiers, generalized to dispatch on the
+caller's language, classify a bare Java method name that survives every
+project-binding rule (``add``, ``get``, ``split``, ``verify``, …) as
+``stdlib``/``external`` — but ONLY when the project defines no
+compatible-language method of that name (shadowing preserved; ambiguous
+project names stay ``unknown``).
+
+The mandatory cross-language gate: a name that lives ONLY in Python's table
+must NOT classify a Java caller, and a name in Java's table must NOT classify
+a Python caller, because ``languages_compatible('java', 'python')`` is False.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from tree_sitter_analyzer.ast_cache import ASTCache
+
+
+def _index(tmp_path: Path, files: dict[str, str]) -> Path:
+    """Index a mixed-language project rooted at ``tmp_path``.
+
+    Files are written verbatim at the project root (Java has no ``__init__``
+    package convention), so ``.java`` and ``.py`` files coexist exactly as a
+    polyglot repository would have them.
+    """
+    for name, body in files.items():
+        target = tmp_path / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(body)
+    cache = ASTCache(str(tmp_path))
+    try:
+        cache.index_project()
+    finally:
+        cache.close()
+    return tmp_path
+
+
+def _resolution_for(db_path: str, callee_name: str) -> list[str]:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT callee_resolution FROM edges "
+            "WHERE kind = 'calls' AND callee_name = ?",
+            (callee_name,),
+        ).fetchall()
+        return [r["callee_resolution"] for r in rows]
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# stdlib method tier
+# ---------------------------------------------------------------------------
+def test_java_stdlib_method_classifies_as_stdlib(tmp_path: Path) -> None:
+    """``list.add(x)`` with no project ``add`` → stdlib, not unknown."""
+    _index(
+        tmp_path,
+        {
+            "Service.java": (
+                "import java.util.List;\n"
+                "class Service {\n"
+                "    void caller(List<String> list) {\n"
+                '        list.add("x");\n'
+                "    }\n"
+                "}\n"
+            )
+        },
+    )
+    db = str(tmp_path / ".ast-cache" / "index.db")
+    res = _resolution_for(db, "add")
+    assert res, "expected an add() edge"
+    assert "stdlib" in res, (
+        f"Java list.add must classify as stdlib (RFC-0008 tier); got {res}"
+    )
+    assert "unknown" not in res
+
+
+def test_java_project_method_shadows_stdlib_name(tmp_path: Path) -> None:
+    """A Java class defining ``add`` → ``adder.add()`` resolves project, not
+    stdlib (shadowing preserved)."""
+    _index(
+        tmp_path,
+        {
+            "Adder.java": (
+                "class Adder {\n"
+                "    int add() { return 1; }\n"
+                "    void caller() {\n"
+                "        Adder adder = new Adder();\n"
+                "        adder.add();\n"
+                "    }\n"
+                "}\n"
+            )
+        },
+    )
+    db = str(tmp_path / ".ast-cache" / "index.db")
+    res = _resolution_for(db, "add")
+    assert res, "expected an add() edge"
+    assert "stdlib" not in res, (
+        f"project-defined Java add must NOT be classified stdlib; got {res}"
+    )
+
+
+def test_java_ambiguous_project_method_stays_unknown(tmp_path: Path) -> None:
+    """Two Java classes define ``add`` → a bare ``add()`` stays unknown,
+    never falsely claimed stdlib."""
+    _index(
+        tmp_path,
+        {
+            "Pair.java": (
+                "class A {\n"
+                "    int add() { return 1; }\n"
+                "}\n"
+                "class B {\n"
+                "    int add() { return 2; }\n"
+                "}\n"
+                "class Caller {\n"
+                "    void caller(Object obj) {\n"
+                "        obj.add();\n"
+                "    }\n"
+                "}\n"
+            )
+        },
+    )
+    db = str(tmp_path / ".ast-cache" / "index.db")
+    res = _resolution_for(db, "add")
+    assert res, "expected an add() edge"
+    assert "stdlib" not in res, (
+        f"ambiguous project method add must stay unknown, not stdlib; got {res}"
+    )
+
+
+def test_cross_language_python_table_does_not_classify_java_caller(
+    tmp_path: Path,
+) -> None:
+    """CRITICAL cross-language gate: a Java ``str.split()`` must still resolve
+    to (Java) stdlib even though a Python file defines a method ``split`` — the
+    Python symbol does NOT suppress Java's stdlib table because
+    ``languages_compatible('java', 'python')`` is False."""
+    _index(
+        tmp_path,
+        {
+            "Service.java": (
+                "class Service {\n"
+                "    void caller(String str) {\n"
+                '        str.split(",");\n'
+                "    }\n"
+                "}\n"
+            ),
+            "splitter.py": (
+                "class MySplitter:\n    def split(self):\n        return 1\n"
+            ),
+        },
+    )
+    db = str(tmp_path / ".ast-cache" / "index.db")
+    res = _resolution_for(db, "split")
+    assert "stdlib" in res, (
+        "Java str.split must classify stdlib despite a Python split symbol; "
+        f"languages_compatible('java','python') is False. got {res}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# external method tier
+# ---------------------------------------------------------------------------
+def test_java_external_method_classifies_as_external(tmp_path: Path) -> None:
+    """A Java test ``mock.verify(...)`` with no project ``verify`` → external
+    (Mockito), not unknown."""
+    _index(
+        tmp_path,
+        {
+            "ServiceTest.java": (
+                "class ServiceTest {\n"
+                "    void test(Object mock) {\n"
+                "        verify(mock);\n"
+                "    }\n"
+                "}\n"
+            )
+        },
+    )
+    db = str(tmp_path / ".ast-cache" / "index.db")
+    res = _resolution_for(db, "verify")
+    assert res, "expected a verify() edge"
+    assert "external" in res, (
+        f"Java Mockito verify must classify as external; got {res}"
+    )
+
+
+def test_java_project_method_shadows_external_name(tmp_path: Path) -> None:
+    """A Java class defining ``verify`` → ``v.verify()`` resolves project, not
+    external (shadowing preserved)."""
+    _index(
+        tmp_path,
+        {
+            "MockValidator.java": (
+                "class MockValidator {\n"
+                "    boolean verify() { return true; }\n"
+                "    void caller() {\n"
+                "        MockValidator v = new MockValidator();\n"
+                "        v.verify();\n"
+                "    }\n"
+                "}\n"
+            )
+        },
+    )
+    db = str(tmp_path / ".ast-cache" / "index.db")
+    res = _resolution_for(db, "verify")
+    assert res, "expected a verify() edge"
+    assert "external" not in res, (
+        f"project-defined Java verify must NOT be classified external; got {res}"
+    )
+
+
+def test_cross_language_python_external_does_not_classify_java_caller(
+    tmp_path: Path,
+) -> None:
+    """A Java ``obj.assert_called_once()`` must NOT be classified external from
+    Python's external table (``assert_called_once`` is a unittest.mock name).
+    ``languages_compatible('java','python')`` is False, so the Python external
+    table is invisible to a Java caller → the edge stays unknown."""
+    _index(
+        tmp_path,
+        {
+            "Service.java": (
+                "class Service {\n"
+                "    void caller(Object obj) {\n"
+                "        obj.assert_called_once();\n"
+                "    }\n"
+                "}\n"
+            ),
+        },
+    )
+    db = str(tmp_path / ".ast-cache" / "index.db")
+    res = _resolution_for(db, "assert_called_once")
+    assert res, "expected an assert_called_once() edge"
+    assert "external" not in res, (
+        f"a Python external-table name must NOT classify a Java caller; got {res}"
+    )

--- a/tests/unit/test_java_method_resolution.py
+++ b/tests/unit/test_java_method_resolution.py
@@ -380,3 +380,69 @@ def test_cross_language_python_external_does_not_classify_java_caller(
     assert "external" not in res, (
         f"a Python external-table name must NOT classify a Java caller; got {res}"
     )
+
+
+# ---------------------------------------------------------------------------
+# external-import preservation (Codex P2 #326, 2nd review)
+# ---------------------------------------------------------------------------
+def test_java_external_import_receiver_not_stdlib(tmp_path: Path) -> None:
+    """``StringUtils.substring(s, 1)`` with ``import
+    org.apache.commons.lang3.StringUtils`` → external, NOT stdlib.
+
+    The receiver type resolves via the type-import to a non-project, non-JDK
+    FQN — a third-party library. The stdlib-method tier (9b) must NOT fire just
+    because ``substring`` is a JDK String name; the explicit external import
+    terminates the resolution as ``external`` first (Codex P2 #326, 2nd review)."""
+    _index(
+        tmp_path,
+        {
+            "Service.java": (
+                "import org.apache.commons.lang3.StringUtils;\n"
+                "class Service {\n"
+                "    void caller(String s) {\n"
+                "        StringUtils.substring(s, 1);\n"
+                "    }\n"
+                "}\n"
+            )
+        },
+    )
+    db = str(tmp_path / ".ast-cache" / "index.db")
+    res = _resolution_for(db, "substring")
+    assert res, "expected a substring() edge"
+    assert "stdlib" not in res, (
+        "StringUtils.substring (Apache Commons, a non-JDK import) must NOT be "
+        f"classified stdlib; the external import terminates it; got {res}"
+    )
+    assert "external" in res, (
+        f"an imported non-JDK receiver type must resolve external; got {res}"
+    )
+
+
+def test_java_external_static_import_not_stdlib(tmp_path: Path) -> None:
+    """``substring(s, 1)`` with ``import static
+    org.apache.commons.lang3.StringUtils.substring`` → external, NOT stdlib.
+
+    The bare name is statically imported from a non-project, non-JDK owner. The
+    static-import stage (3) must terminate it as ``external`` before the
+    RFC-0008 stdlib-method tier (9b) can mislabel it ``stdlib`` (Codex P2 #326,
+    2nd review)."""
+    _index(
+        tmp_path,
+        {
+            "Service.java": (
+                "import static org.apache.commons.lang3.StringUtils.substring;\n"
+                "class Service {\n"
+                "    void caller(String s) {\n"
+                "        substring(s, 1);\n"
+                "    }\n"
+                "}\n"
+            )
+        },
+    )
+    db = str(tmp_path / ".ast-cache" / "index.db")
+    res = _resolution_for(db, "substring")
+    assert res, "expected a substring() edge"
+    assert "stdlib" not in res, (
+        "a statically-imported non-JDK substring must NOT be classified stdlib; "
+        f"got {res}"
+    )

--- a/tests/unit/test_java_method_resolution.py
+++ b/tests/unit/test_java_method_resolution.py
@@ -446,3 +446,40 @@ def test_java_external_static_import_not_stdlib(tmp_path: Path) -> None:
         "a statically-imported non-JDK substring must NOT be classified stdlib; "
         f"got {res}"
     )
+
+
+def test_java_project_fqn_receiver_wins_over_imported_tail(tmp_path: Path) -> None:
+    """An explicit project FQN receiver must resolve PROJECT even when its simple
+    tail is also bound by an unrelated external import (Codex P2 #326, 3rd
+    review). ``com.proj.Service.doWork()`` resolves to the project class, not
+    ``external``, despite ``import other.lib.Service``."""
+    _index(
+        tmp_path,
+        {
+            "Service.java": (
+                "package com.proj;\n"
+                "class Service {\n"
+                "    static void doWork() {}\n"
+                "}\n"
+            ),
+            "Caller.java": (
+                "package com.app;\n"
+                "import other.lib.Service;\n"
+                "class Caller {\n"
+                "    void run() {\n"
+                "        com.proj.Service.doWork();\n"
+                "    }\n"
+                "}\n"
+            ),
+        },
+    )
+    db = str(tmp_path / ".ast-cache" / "index.db")
+    res = _resolution_for(db, "doWork")
+    assert res, "expected a doWork() edge"
+    assert "external" not in res, (
+        "an explicit project FQN receiver must NOT be classified external by an "
+        f"imported-tail coincidence; got {res}"
+    )
+    assert "project" in res, (
+        f"com.proj.Service.doWork must resolve to the project class; got {res}"
+    )

--- a/tests/unit/test_stdlib_method_resolution.py
+++ b/tests/unit/test_stdlib_method_resolution.py
@@ -200,6 +200,11 @@ def test_prebuilt_context_without_file_languages_keeps_python_tiers() -> None:
 
     stdlib = _try_stdlib_method("write_text", "", "a.py", ctx)
     assert stdlib is not None and stdlib.resolution == "stdlib"
+    # all three RFC-0004/5/7 tiers fall back to the Python table, not just stdlib.
+    ext = _try_external_method(sorted(EXTERNAL_METHODS_PY)[0], "", "a.py", ctx)
+    assert ext is not None and ext.resolution == "external"
+    builtin = _try_builtin_method(sorted(BUILTIN_QUALIFIED_PY)[0], "obj", "a.py", ctx)
+    assert builtin is not None and builtin.resolution == "builtin"
 
     # cross-language gate intact: a POPULATED non-Python caller tag no-ops.
     ctx_js = ResolverContext(

--- a/tests/unit/test_stdlib_method_resolution.py
+++ b/tests/unit/test_stdlib_method_resolution.py
@@ -165,3 +165,47 @@ def test_genuinely_unknown_name_stays_unknown(tmp_path: Path) -> None:
     res = _resolution_for(db, "frobnicate_xyz")
     assert res, "expected a frobnicate_xyz() edge"
     assert set(res) == {"unknown"}, f"expected unknown, got {res}"
+
+
+def test_prebuilt_context_without_file_languages_keeps_python_tiers() -> None:
+    """Codex P2 #326 regression lock: a pre-built ResolverContext constructed
+    via the public direct API WITHOUT ``file_languages`` must still apply the
+    RFC-0004/5/7 Python method tiers.
+
+    The RFC-0008 caller-language dispatch keys the tables on the caller's
+    language; when ``file_languages`` is unpopulated the lookup must fall back to
+    ``python`` (not an empty table), or ``path.write_text()`` /
+    ``monkeypatch.setattr()`` regress to ``unknown``. A POPULATED non-Python tag
+    must still no-op (cross-language gate preserved)."""
+    from tree_sitter_analyzer.synapse_resolver import (
+        _try_builtin_method,
+        _try_external_method,
+        _try_stdlib_method,
+    )
+    from tree_sitter_analyzer.synapse_resolver._constants import (
+        BUILTIN_QUALIFIED_PY,
+        EXTERNAL_METHODS_PY,
+        STDLIB_METHODS_PY,
+    )
+    from tree_sitter_analyzer.synapse_resolver._context import ResolverContext
+
+    ctx = ResolverContext(
+        ".",
+        None,
+        stdlib_methods={"python": STDLIB_METHODS_PY},
+        external_methods={"python": EXTERNAL_METHODS_PY},
+        builtin_methods={"python": BUILTIN_QUALIFIED_PY},
+    )
+    assert not ctx.file_languages  # the pre-built / direct-API path
+
+    stdlib = _try_stdlib_method("write_text", "", "a.py", ctx)
+    assert stdlib is not None and stdlib.resolution == "stdlib"
+
+    # cross-language gate intact: a POPULATED non-Python caller tag no-ops.
+    ctx_js = ResolverContext(
+        ".",
+        None,
+        stdlib_methods={"python": STDLIB_METHODS_PY},
+        file_languages={"a.js": "javascript"},
+    )
+    assert _try_stdlib_method("write_text", "", "a.js", ctx_js) is None

--- a/tree_sitter_analyzer/function_extraction.py
+++ b/tree_sitter_analyzer/function_extraction.py
@@ -105,7 +105,28 @@ def _call_info_field(node: Any, source: str) -> dict[str, Any] | None:
 
 
 def _call_info_java(node: Any, source: str) -> dict[str, Any] | None:
-    """Java: identifier or field_access/method_reference child."""
+    """Java method_invocation: method name from the ``name`` field, receiver
+    from the ``object`` field.
+
+    ``list.add("x")`` must extract ``name='add'`` with ``receiver='list'`` (so
+    RFC-0008 stdlib/external method tiers can match the method name), NOT the
+    receiver identifier ``list``. tree-sitter-java exposes the method as the
+    ``name`` field and the receiver as the ``object`` field; a bare call
+    ``verify(s)`` has no ``object`` field (receiver is ``None``).
+    """
+    if node.type == "method_invocation":
+        name_node = node.child_by_field_name("name")
+        if name_node is not None:
+            name = _node_text(name_node, source)
+            obj_node = node.child_by_field_name("object")
+            receiver = _node_text(obj_node, source) if obj_node is not None else None
+            full_name = f"{receiver}.{name}" if receiver else name
+            return {
+                "name": name,
+                "full_name": full_name,
+                "line": node.start_point[0] + 1,
+                "receiver": receiver,
+            }
     for child in node.children:
         if child.type == "identifier":
             return _call_from_text(_node_text(child, source), node)

--- a/tree_sitter_analyzer/synapse_resolver/__init__.py
+++ b/tree_sitter_analyzer/synapse_resolver/__init__.py
@@ -212,6 +212,24 @@ def _try_builtin(
     return None
 
 
+def _table_language(ctx: ResolverContext, caller_file: str) -> str:
+    """Language key for the RFC-0004/5/7 method tables (stdlib/external/builtin).
+
+    Trusts a populated ``file_languages`` map: a tagged non-Python caller (a JS
+    file) looks up its own (absent) table and the tier no-ops, preserving the
+    cross-language gate. Falls back to ``"python"`` ONLY when ``file_languages``
+    is entirely empty — a pre-built / direct-API ``ResolverContext`` whose public
+    constructor does not require it — so Python calls (``path.write_text()``,
+    ``monkeypatch.setattr()``) keep their RFC-0004/5/7 classification instead of
+    regressing to ``unknown`` (Codex P2 #326). The ownership gate keeps using the
+    raw ``caller_lang`` (empty == compatible), so legacy behaviour is unchanged.
+    """
+    lang = ctx.file_languages.get(caller_file, "")
+    if lang:
+        return lang
+    return "python" if not ctx.file_languages else ""
+
+
 def _try_stdlib_method(
     base: str, qualifier: str, caller_file: str, ctx: ResolverContext
 ) -> ResolvedCallee | None:
@@ -234,7 +252,9 @@ def _try_stdlib_method(
     tier never fires (conservative — no false classification).
     """
     caller_lang = ctx.file_languages.get(caller_file, "")
-    if base not in ctx.stdlib_methods.get(caller_lang, frozenset()):
+    if base not in ctx.stdlib_methods.get(
+        _table_language(ctx, caller_file), frozenset()
+    ):
         return None
     if ctx.callee_resolver is not None:
         matches = ctx.callee_resolver.resolve_items(
@@ -274,7 +294,9 @@ def _try_external_method(
     an empty frozenset and the tier never fires.
     """
     caller_lang = ctx.file_languages.get(caller_file, "")
-    if base not in ctx.external_methods.get(caller_lang, frozenset()):
+    if base not in ctx.external_methods.get(
+        _table_language(ctx, caller_file), frozenset()
+    ):
         return None
     if ctx.callee_resolver is not None:
         matches = ctx.callee_resolver.resolve_items(
@@ -322,7 +344,9 @@ def _try_builtin_method(
     # up an empty frozenset and the tier never fires. An empty/unknown language
     # tag also yields an empty table, so untyped callers fall through safely.
     caller_lang = ctx.file_languages.get(caller_file, "")
-    if base not in ctx.builtin_methods.get(caller_lang, frozenset()):
+    if base not in ctx.builtin_methods.get(
+        _table_language(ctx, caller_file), frozenset()
+    ):
         return None
     if ctx.callee_resolver is not None:
         matches = ctx.callee_resolver.resolve_items(

--- a/tree_sitter_analyzer/synapse_resolver/__init__.py
+++ b/tree_sitter_analyzer/synapse_resolver/__init__.py
@@ -227,11 +227,16 @@ def _try_stdlib_method(
     incompatible-language file (e.g. a JavaScript ``split``) must NOT suppress
     the Python stdlib classification — Python ``'x'.split()`` is still stdlib.
     Only a same-/compatible-language project method counts as ownership.
+
+    RFC-0008: the table is selected by the CALLER's language, not hard-coded
+    ``"python"``. A Java caller consults the Java stdlib-method table; a caller
+    whose language has no registered table looks up an empty frozenset and the
+    tier never fires (conservative — no false classification).
     """
-    if base not in ctx.stdlib_methods.get("python", frozenset()):
+    caller_lang = ctx.file_languages.get(caller_file, "")
+    if base not in ctx.stdlib_methods.get(caller_lang, frozenset()):
         return None
     if ctx.callee_resolver is not None:
-        caller_lang = ctx.file_languages.get(caller_file, "")
         matches = ctx.callee_resolver.resolve_items(
             base, "", include_local=False, include_import=False
         )
@@ -263,11 +268,15 @@ def _try_external_method(
 
     Covers pytest, hypothesis, and unittest.mock method names that cannot live in
     the project and would otherwise remain ``unknown``.
+
+    RFC-0008: the table is selected by the CALLER's language (Java consults the
+    JUnit/Mockito/AssertJ table); a language with no registered table looks up
+    an empty frozenset and the tier never fires.
     """
-    if base not in ctx.external_methods.get("python", frozenset()):
+    caller_lang = ctx.file_languages.get(caller_file, "")
+    if base not in ctx.external_methods.get(caller_lang, frozenset()):
         return None
     if ctx.callee_resolver is not None:
-        caller_lang = ctx.file_languages.get(caller_file, "")
         matches = ctx.callee_resolver.resolve_items(
             base, "", include_local=False, include_import=False
         )
@@ -306,14 +315,14 @@ def _try_builtin_method(
     if not qualifier:
         # Bare (unqualified) builtins are already handled by _try_builtin; skip.
         return None
-    # This tier only classifies Python builtins.  A caller in a different
-    # language (JS, TypeScript, …) must not be classified as calling a Python
-    # builtin — leave those edges ``unknown``.  An empty/unknown language tag
-    # is treated as compatible (same convention as languages_compatible).
+    # RFC-0008: gate on TABLE PRESENCE, not a hard-coded ``!= "python"``. Only a
+    # caller whose language registers a qualified-builtin table can match here;
+    # a caller language with no such table (e.g. Java — which has no
+    # monkeypatch.setattr equivalent, static methods are import-resolved) looks
+    # up an empty frozenset and the tier never fires. An empty/unknown language
+    # tag also yields an empty table, so untyped callers fall through safely.
     caller_lang = ctx.file_languages.get(caller_file, "")
-    if caller_lang and caller_lang != "python":
-        return None
-    if base not in ctx.builtin_methods.get("python", frozenset()):
+    if base not in ctx.builtin_methods.get(caller_lang, frozenset()):
         return None
     if ctx.callee_resolver is not None:
         matches = ctx.callee_resolver.resolve_items(

--- a/tree_sitter_analyzer/synapse_resolver/_context.py
+++ b/tree_sitter_analyzer/synapse_resolver/_context.py
@@ -16,6 +16,7 @@ from ._constants import (
     STDLIB_NAMES_PY,
 )
 from ._imports import ImportEntry
+from ._java_constants import EXTERNAL_METHODS_JAVA, STDLIB_METHODS_JAVA
 
 if TYPE_CHECKING:
     from ..ast_cache import ASTCache
@@ -519,8 +520,14 @@ def _build_resolver_context_uncached(cache: ASTCache) -> ResolverContext:
         imports_by_file=imports_by_file,
         builtins={"python": BUILTINS_PY},
         stdlib_modules={"python": STDLIB_NAMES_PY},
-        stdlib_methods={"python": STDLIB_METHODS_PY},
-        external_methods={"python": EXTERNAL_METHODS_PY},
+        stdlib_methods={
+            "python": STDLIB_METHODS_PY,
+            "java": STDLIB_METHODS_JAVA,
+        },
+        external_methods={
+            "python": EXTERNAL_METHODS_PY,
+            "java": EXTERNAL_METHODS_JAVA,
+        },
         builtin_methods={"python": BUILTIN_QUALIFIED_PY},
         callee_resolver=callee_resolver,
         file_languages=file_languages,
@@ -559,6 +566,7 @@ def _maybe_build_java_context(
         file_symbols=file_symbols,
         file_class_methods=file_class_methods,
         global_name_table=global_name_table,
+        file_languages=file_languages,
     )
 
 

--- a/tree_sitter_analyzer/synapse_resolver/_java.py
+++ b/tree_sitter_analyzer/synapse_resolver/_java.py
@@ -26,7 +26,12 @@ import re
 from dataclasses import dataclass, field
 
 from ._imports import ImportEntry
-from ._java_constants import JAVA_LANG_TYPES, is_jdk_prefix
+from ._java_constants import (
+    EXTERNAL_METHODS_JAVA,
+    JAVA_LANG_TYPES,
+    STDLIB_METHODS_JAVA,
+    is_jdk_prefix,
+)
 
 # A ``package a.b.c;`` declaration. ``module_path`` here is reused to
 # carry the package name; ``local_name`` marks the row as a package row.
@@ -142,6 +147,9 @@ class JavaResolverContext:
     file_symbols: dict[str, list[tuple[str, str, int]]] = field(default_factory=dict)
     # simple name -> [(file, symbol_id), ...] project-wide (single-global).
     global_name_table: dict[str, list[tuple[str, int]]] = field(default_factory=dict)
+    # file -> language tag (so the RFC-0008 ownership gate is language-aware:
+    # a Python ``split`` must NOT count as a Java project owner).
+    file_languages: dict[str, str] = field(default_factory=dict)
 
 
 def build_java_context(
@@ -149,6 +157,7 @@ def build_java_context(
     file_symbols: dict[str, list[tuple[str, str, int]]],
     file_class_methods: dict[str, dict[str, dict[str, int]]],
     global_name_table: dict[str, list[tuple[str, int]]],
+    file_languages: dict[str, str] | None = None,
 ) -> JavaResolverContext:
     """Assemble the Java resolution maps from already-loaded cache data.
 
@@ -159,6 +168,7 @@ def build_java_context(
         file_class_methods=file_class_methods,
         file_symbols=file_symbols,
         global_name_table=global_name_table,
+        file_languages=file_languages or {},
     )
 
     for caller_file, entries in imports_by_file.items():
@@ -313,8 +323,48 @@ def resolve_java_callee(
             target_file, sym_id = cands[0]
             return sym_id, "project", target_file
 
+    # 9b. RFC-0008 stdlib METHOD — a bare JDK method name (``add``, ``substring``,
+    #     ``stream``, …) whose receiver type could not be resolved to a project
+    #     file. Classify ``stdlib`` (a JDK method, mirroring Python's stdlib tier)
+    #     when the project owns NO method of that name. The caller here is Java,
+    #     so any project owner is the same language — ownership is the gate that
+    #     preserves shadowing (a project ``add``) and ambiguity (two ``add``s).
+    if simple in STDLIB_METHODS_JAVA and not _project_owns(ctx, simple):
+        return None, "stdlib", ""
+
+    # 9c. RFC-0008 external METHOD — JUnit / Mockito / AssertJ test-framework
+    #     method names (``verify``, ``mock``, ``assertEquals``, …). Runs AFTER
+    #     the stdlib tier so JDK names win. Same project-ownership gate.
+    if simple in EXTERNAL_METHODS_JAVA and not _project_owns(ctx, simple):
+        return None, "external", ""
+
     # 10. unknown.
     return None, "unknown", ""
+
+
+def _project_owns(ctx: JavaResolverContext, simple: str) -> bool:
+    """True when a COMPATIBLE-LANGUAGE (Java) project symbol of name ``simple``
+    exists.
+
+    The RFC-0008 ownership gate: if the project owns the name in Java — even
+    ambiguously (two classes define ``add``) — the stdlib/external method tiers
+    must NOT claim it, preserving shadowing. The gate is LANGUAGE-AWARE
+    (Codex P2 #319 pattern): a same-named symbol in an incompatible-language
+    file (e.g. a Python ``split``) must NOT count as a Java owner, because
+    ``languages_compatible('java', 'python')`` is False — the Java caller cannot
+    resolve the Python method, so it does not suppress the JDK stdlib
+    classification.
+
+    When a file's language is unknown (no tag), it is treated as a possible
+    owner (conservative — same convention as ``languages_compatible``).
+    """
+    from .._language_family import languages_compatible
+
+    for owner_file, _sym_id in ctx.global_name_table.get(simple, []):
+        owner_lang = ctx.file_languages.get(owner_file, "")
+        if not owner_lang or languages_compatible("java", owner_lang):
+            return True
+    return False
 
 
 __all__ = [

--- a/tree_sitter_analyzer/synapse_resolver/_java.py
+++ b/tree_sitter_analyzer/synapse_resolver/_java.py
@@ -277,6 +277,17 @@ def resolve_java_callee(
         head = receiver.split(".", 1)[0]
         tail = receiver.rsplit(".", 1)[-1] if "." in receiver else receiver
 
+        # 4a. fqn-direct (project) — an explicit fully-qualified PROJECT receiver
+        # (``com.proj.Service.m()``) is unambiguous and must resolve to project
+        # BEFORE the type-import step: its simple tail (``Service``) may also be
+        # bound by an unrelated ``import other.lib.Service``, and the import step
+        # would otherwise terminate it ``external`` by tail coincidence (Codex P2
+        # #326, 3rd review). An import affects simple-name references, never an
+        # already-fully-qualified one.
+        fqn_target = ctx.fqn_to_file.get(receiver)
+        if fqn_target:
+            return _lookup_in_file(ctx, fqn_target, simple), "project", fqn_target
+
         # 4. type-import — receiver head is an imported simple class name.
         for type_name in (head, tail):
             fqn = ctx.simple_to_fqn_by_file.get(caller_file, {}).get(type_name)
@@ -301,11 +312,6 @@ def resolve_java_callee(
                 target = ctx.fqn_to_file.get(same_pkg_fqn)
                 if target:
                     return _lookup_in_file(ctx, target, simple), "project", target
-
-        # 6. fqn-direct — receiver itself is a known project FQN.
-        target = ctx.fqn_to_file.get(receiver)
-        if target:
-            return _lookup_in_file(ctx, target, simple), "project", target
 
         # 7. wildcard — receiver type under an ``import a.b.*`` package.
         type_name = head

--- a/tree_sitter_analyzer/synapse_resolver/_java.py
+++ b/tree_sitter_analyzer/synapse_resolver/_java.py
@@ -260,8 +260,13 @@ def resolve_java_callee(
             target = ctx.fqn_to_file.get(owner_fqn)
             if target:
                 return _lookup_in_file(ctx, target, simple), "project", target
-            if is_jdk_prefix(owner_fqn):
-                return None, "external", ""
+            # An explicit static import that binds to a non-project owner is a
+            # terminal EXTERNAL resolution — whether JDK or third-party. This
+            # must win BEFORE the RFC-0008 stdlib-method tier (9b), or a static
+            # import of e.g. ``org.apache.commons.lang3.StringUtils.substring``
+            # would be mislabelled ``stdlib`` just because ``substring`` is in
+            # the JDK table (Codex P2 #326).
+            return None, "external", ""
 
     if receiver and receiver not in ("this", "super"):
         # Two candidate type names from the receiver:
@@ -280,8 +285,13 @@ def resolve_java_callee(
             target = ctx.fqn_to_file.get(fqn)
             if target:
                 return _lookup_in_file(ctx, target, simple), "project", target
-            if is_jdk_prefix(fqn):
-                return None, "external", ""
+            # The receiver type is an explicit import that resolves to a
+            # non-project FQN — a terminal EXTERNAL resolution whether JDK or
+            # third-party. This must win BEFORE the RFC-0008 stdlib-method tier
+            # (9b), or ``StringUtils.substring(s)`` (org.apache.commons) would be
+            # mislabelled ``stdlib`` just because ``substring`` is in the JDK
+            # table (Codex P2 #326).
+            return None, "external", ""
 
         # 5. same-package — receiver type defined in the caller's package.
         caller_pkg = ctx.file_package.get(caller_file, "")

--- a/tree_sitter_analyzer/synapse_resolver/_java_constants.py
+++ b/tree_sitter_analyzer/synapse_resolver/_java_constants.py
@@ -81,143 +81,85 @@ def is_jdk_prefix(fqn: str) -> bool:
 # ``STDLIB_METHODS_PY``).
 #
 # The Java resolver's name/import tiers key on receiver *types* and FQNs; they
-# never match a bare *method* name like ``add`` or ``substring`` on an inferred
-# JDK receiver, so those call edges fall through to ``unknown``. This curated
-# table is consulted by the cascade's language-aware ``_try_stdlib_method``
-# tier — AFTER every project-binding rule — to classify such names as
-# ``stdlib`` when (and only when) the project defines no compatible-language
-# (Java) method of that name. Grouped by owning type for auditability.
-# High-recall, NOT exhaustive; conservative — generic names that projects
-# commonly define are protected by the project-ownership gate anyway, but names
-# that are almost always project-domain (``execute``, ``build``, ``handle``,
-# ``process``, ``run``) are deliberately EXCLUDED to avoid false positives.
+# never match a bare *method* name like ``substring`` or ``containsKey`` on an
+# inferred JDK receiver, so those call edges fall through to ``unknown``. This
+# curated table is consulted by the cascade's language-aware
+# ``_try_stdlib_method`` tier — AFTER every project-binding rule — to classify
+# such names as ``stdlib`` when (and only when) the project defines no
+# compatible-language (Java) method of that name. Grouped by owning type for
+# auditability.
+#
+# CURATION RULE — PRECISION over recall (Codex P2 #326).
+# The name tiers carry NO receiver-type evidence (type inference deferred), and
+# the project-ownership gate only separates *project* from *not-project* — NOT
+# *stdlib* from *third-party/domain*. So precision must come entirely from
+# CURATION: a name is KEPT only if a domain object or popular third-party
+# library is VERY UNLIKELY to define a method of that exact name — i.e. it is
+# distinctively the JDK String / Map / Stream / Optional API.
+#
+# Bare generic verbs that domain & third-party objects routinely define are
+# DELIBERATELY DROPPED, because the tiers cannot tell ``Cache.get`` (Guava, not
+# JDK), ``builder.set``, ``repo.add`` or ``domainStream.map`` apart from a JDK
+# receiver — they would otherwise be mislabelled ``stdlib``. Dropped names:
+# add, addAll, remove, removeAll, removeIf, retainAll, get, set, put, putAll,
+# contains, containsAll, values, iterator, hasNext, next, forEach, toArray,
+# isEmpty, size, clear, merge, indexOf, lastIndexOf, trim, replace, replaceAll,
+# split, concat, matches, map, filter, reduce, sorted, distinct, limit, skip,
+# peek, count, min, max. This mirrors STDLIB_METHODS_PY, which likewise excludes
+# set / map / filter / put as too-commonly-project-defined.
 # ---------------------------------------------------------------------------
 
-# java.util collections (List / Map / Set / Collection / Iterator)
-_JAVA_COLLECTION_METHODS = frozenset(
-    {
-        "add",
-        "addAll",
-        "remove",
-        "removeAll",
-        "removeIf",
-        "retainAll",
-        "get",
-        "set",
-        "put",
-        "putAll",
-        "putIfAbsent",
-        "getOrDefault",
-        "containsKey",
-        "containsValue",
-        "contains",
-        "containsAll",
-        "indexOf",
-        "lastIndexOf",
-        "keySet",
-        "entrySet",
-        "values",
-        "subList",
-        "iterator",
-        "listIterator",
-        "hasNext",
-        "next",
-        "forEach",
-        "stream",
-        "parallelStream",
-        "toArray",
-        "isEmpty",
-        "size",
-        "clear",
-        "computeIfAbsent",
-        "computeIfPresent",
-        "merge",
-    }
-)
+# INTERFACE-METHOD NAMES ARE EXCLUDED WHOLESALE (Codex P2 #326, review P1).
+# ``stream``/``parallelStream``/``collect``/``map``/``filter``… are
+# ``java.util.stream.Stream`` **interface** methods, and
+# ``containsKey``/``keySet``/``entrySet``/``computeIfAbsent``/``getOrDefault``…
+# are ``java.util.Map`` / ``Collection`` **interface** methods. Every reactive
+# library (Reactor ``Flux``/``Mono``), collection wrapper (Guava
+# ``ImmutableList``, Spring Data ``Streamable``), and domain type that
+# implements those interfaces (a ``Registry<K,V> implements Map``, an
+# ``OrderQueue implements Collection``) defines them — and the AST cache does
+# NOT index inherited methods from external interfaces, so ``_project_owns``
+# returns False and the call would be mislabelled ``stdlib``. Without
+# receiver-type evidence at this tier, the ONLY safe names are those that live
+# on a ``final`` JDK type with no common interface or popular-library twin.
 
-# java.lang.String / CharSequence
+# java.lang.String — a ``final`` class, so a domain type can never *be* a
+# String. Only names that are also distinctively String (not on the
+# ``CharSequence`` interface, not adopted by domain value/protocol objects)
+# survive: ``charAt``/``chars`` (CharSequence interface), ``startsWith``/
+# ``endsWith`` (java.nio.file.Path, domain Url/Version), ``getBytes`` (domain
+# Packet/Buffer), ``isBlank`` (domain FormField), ``lines`` (BufferedReader)
+# are all DROPPED. Also DROPPED (review HIGH/MEDIUM): ``toUpperCase``/
+# ``toLowerCase`` (DDD string value objects — ``Email``/``Username``/``Slug``,
+# Spring Data ``SqlIdentifier`` — routinely define them) and ``repeat`` (domain
+# scheduler/animation/rule builders: ``Schedule.repeat(3)``).
 _JAVA_STRING_METHODS = frozenset(
     {
         "substring",
-        "trim",
-        "strip",
         "stripLeading",
         "stripTrailing",
-        "split",
-        "replace",
-        "replaceAll",
         "replaceFirst",
-        "toUpperCase",
-        "toLowerCase",
-        "charAt",
-        "indexOf",
-        "lastIndexOf",
-        "startsWith",
-        "endsWith",
-        "concat",
-        "matches",
-        "chars",
         "codePointAt",
         "toCharArray",
-        "getBytes",
         "intern",
-        "repeat",
-        "lines",
         "formatted",
-        "isBlank",
     }
 )
 
-# java.util.Optional
+# java.util.Optional — a ``final`` class. Keep only names with no vavr ``Option``
+# / domain ``Maybe``/``Result`` twin: vavr uses ``getOrElse``/``getOrElseThrow``
+# (not ``orElseGet``/``orElseThrow``) and has no ``ifPresentOrElse``. ``orElse``
+# and ``isPresent`` (both on vavr ``Option`` and domain optionals) are DROPPED.
 _JAVA_OPTIONAL_METHODS = frozenset(
     {
-        "orElse",
         "orElseGet",
         "orElseThrow",
-        "isPresent",
-        "isEmpty",
         "ifPresent",
         "ifPresentOrElse",
-        "filter",
-        "flatMap",
     }
 )
 
-# java.util.stream.Stream / Collectors
-_JAVA_STREAM_METHODS = frozenset(
-    {
-        "map",
-        "mapToInt",
-        "mapToLong",
-        "mapToObj",
-        "flatMap",
-        "filter",
-        "collect",
-        "reduce",
-        "sorted",
-        "distinct",
-        "limit",
-        "skip",
-        "peek",
-        "anyMatch",
-        "allMatch",
-        "noneMatch",
-        "findFirst",
-        "findAny",
-        "count",
-        "min",
-        "max",
-        "boxed",
-        "toList",
-    }
-)
-
-STDLIB_METHODS_JAVA: frozenset[str] = (
-    _JAVA_COLLECTION_METHODS
-    | _JAVA_STRING_METHODS
-    | _JAVA_OPTIONAL_METHODS
-    | _JAVA_STREAM_METHODS
-)
+STDLIB_METHODS_JAVA: frozenset[str] = _JAVA_STRING_METHODS | _JAVA_OPTIONAL_METHODS
 
 
 # ---------------------------------------------------------------------------
@@ -230,11 +172,22 @@ STDLIB_METHODS_JAVA: frozenset[str] = (
 # language-aware ``_try_external_method`` tier — placed AFTER
 # ``_try_stdlib_method`` — to classify such names ``external`` when (and only
 # when) the project owns no compatible-language method of that name. Grouped by
-# owning library for auditability. Conservative: generic names projects define
-# (``setUp``, ``run``, ``execute``, ``before``, ``after``) are EXCLUDED.
+# owning library for auditability.
+#
+# Same PRECISION lens as STDLIB_METHODS_JAVA (Codex P2 #326, review P1/P2): keep
+# only the ``assertX`` / ``assumeX`` / ``assertThatX`` family — bare static
+# entry-point calls (``assertEquals(a, b)``) that a domain object essentially
+# never defines as an instance method. Every RECEIVER-style Mockito/AssertJ name
+# is DROPPED because the tier sees no receiver and the names collide with
+# production code: ``verify`` (``Signature.verify``/``Certificate.verify``/JWT
+# ``Token.verify``), ``when`` (Spring Security / rule-DSL ``rule.when``), ``mock``
+# / ``spy`` (custom factories), and the fluent ``isEqualTo``/``isInstanceOf``/
+# ``containsExactly``/``hasSize``/``then*``/``do*``/``will*`` (domain value
+# objects, builders, state machines). ``fail``/``given`` likewise stay dropped.
 # ---------------------------------------------------------------------------
 
-# JUnit (4 + 5 Assertions / Assertions API)
+# JUnit 4/5 + AssertJ static assertion entry points (bare ``assertX(...)`` /
+# ``assumeX(...)`` / ``assertThatX(...)`` calls — distinctively the test stack).
 _JUNIT_METHODS = frozenset(
     {
         "assertEquals",
@@ -250,56 +203,15 @@ _JUNIT_METHODS = frozenset(
         "assertDoesNotThrow",
         "assertAll",
         "assertTimeout",
-        "assertThat",  # JUnit/Hamcrest assertThat
-        "fail",
+        "assertThat",  # JUnit/Hamcrest/AssertJ assertThat entry point
+        "assertThatThrownBy",  # AssertJ
+        "assertThatExceptionOfType",  # AssertJ
         "assumeTrue",
         "assumeFalse",
     }
 )
 
-# Mockito
-_MOCKITO_METHODS = frozenset(
-    {
-        "mock",
-        "spy",
-        "when",
-        "verify",
-        "verifyNoInteractions",
-        "verifyNoMoreInteractions",
-        "thenReturn",
-        "thenThrow",
-        "thenAnswer",
-        "thenCallRealMethod",
-        "doReturn",
-        "doThrow",
-        "doAnswer",
-        "doNothing",
-        "given",  # BDDMockito.given
-        "willReturn",
-        "willThrow",
-    }
-)
-
-# AssertJ (fluent assertions)
-_ASSERTJ_METHODS = frozenset(
-    {
-        "assertThatThrownBy",
-        "assertThatExceptionOfType",
-        "isEqualTo",
-        "isNotEqualTo",
-        "isNull",
-        "isNotNull",
-        "isInstanceOf",
-        "containsExactly",
-        "hasSize",
-        "isTrue",
-        "isFalse",
-    }
-)
-
-EXTERNAL_METHODS_JAVA: frozenset[str] = (
-    _JUNIT_METHODS | _MOCKITO_METHODS | _ASSERTJ_METHODS
-)
+EXTERNAL_METHODS_JAVA: frozenset[str] = _JUNIT_METHODS
 
 
 __all__ = [

--- a/tree_sitter_analyzer/synapse_resolver/_java_constants.py
+++ b/tree_sitter_analyzer/synapse_resolver/_java_constants.py
@@ -76,4 +76,236 @@ def is_jdk_prefix(fqn: str) -> bool:
     return any(fqn.startswith(prefix) for prefix in JDK_PACKAGE_PREFIXES)
 
 
-__all__ = ["JAVA_LANG_TYPES", "JDK_PACKAGE_PREFIXES", "is_jdk_prefix"]
+# ---------------------------------------------------------------------------
+# RFC-0008: well-known JDK stdlib METHOD names (the Java analogue of
+# ``STDLIB_METHODS_PY``).
+#
+# The Java resolver's name/import tiers key on receiver *types* and FQNs; they
+# never match a bare *method* name like ``add`` or ``substring`` on an inferred
+# JDK receiver, so those call edges fall through to ``unknown``. This curated
+# table is consulted by the cascade's language-aware ``_try_stdlib_method``
+# tier — AFTER every project-binding rule — to classify such names as
+# ``stdlib`` when (and only when) the project defines no compatible-language
+# (Java) method of that name. Grouped by owning type for auditability.
+# High-recall, NOT exhaustive; conservative — generic names that projects
+# commonly define are protected by the project-ownership gate anyway, but names
+# that are almost always project-domain (``execute``, ``build``, ``handle``,
+# ``process``, ``run``) are deliberately EXCLUDED to avoid false positives.
+# ---------------------------------------------------------------------------
+
+# java.util collections (List / Map / Set / Collection / Iterator)
+_JAVA_COLLECTION_METHODS = frozenset(
+    {
+        "add",
+        "addAll",
+        "remove",
+        "removeAll",
+        "removeIf",
+        "retainAll",
+        "get",
+        "set",
+        "put",
+        "putAll",
+        "putIfAbsent",
+        "getOrDefault",
+        "containsKey",
+        "containsValue",
+        "contains",
+        "containsAll",
+        "indexOf",
+        "lastIndexOf",
+        "keySet",
+        "entrySet",
+        "values",
+        "subList",
+        "iterator",
+        "listIterator",
+        "hasNext",
+        "next",
+        "forEach",
+        "stream",
+        "parallelStream",
+        "toArray",
+        "isEmpty",
+        "size",
+        "clear",
+        "computeIfAbsent",
+        "computeIfPresent",
+        "merge",
+    }
+)
+
+# java.lang.String / CharSequence
+_JAVA_STRING_METHODS = frozenset(
+    {
+        "substring",
+        "trim",
+        "strip",
+        "stripLeading",
+        "stripTrailing",
+        "split",
+        "replace",
+        "replaceAll",
+        "replaceFirst",
+        "toUpperCase",
+        "toLowerCase",
+        "charAt",
+        "indexOf",
+        "lastIndexOf",
+        "startsWith",
+        "endsWith",
+        "concat",
+        "matches",
+        "chars",
+        "codePointAt",
+        "toCharArray",
+        "getBytes",
+        "intern",
+        "repeat",
+        "lines",
+        "formatted",
+        "isBlank",
+    }
+)
+
+# java.util.Optional
+_JAVA_OPTIONAL_METHODS = frozenset(
+    {
+        "orElse",
+        "orElseGet",
+        "orElseThrow",
+        "isPresent",
+        "isEmpty",
+        "ifPresent",
+        "ifPresentOrElse",
+        "filter",
+        "flatMap",
+    }
+)
+
+# java.util.stream.Stream / Collectors
+_JAVA_STREAM_METHODS = frozenset(
+    {
+        "map",
+        "mapToInt",
+        "mapToLong",
+        "mapToObj",
+        "flatMap",
+        "filter",
+        "collect",
+        "reduce",
+        "sorted",
+        "distinct",
+        "limit",
+        "skip",
+        "peek",
+        "anyMatch",
+        "allMatch",
+        "noneMatch",
+        "findFirst",
+        "findAny",
+        "count",
+        "min",
+        "max",
+        "boxed",
+        "toList",
+    }
+)
+
+STDLIB_METHODS_JAVA: frozenset[str] = (
+    _JAVA_COLLECTION_METHODS
+    | _JAVA_STRING_METHODS
+    | _JAVA_OPTIONAL_METHODS
+    | _JAVA_STREAM_METHODS
+)
+
+
+# ---------------------------------------------------------------------------
+# RFC-0008: well-known EXTERNAL (third-party) Java test-framework METHOD names
+# (the Java analogue of ``EXTERNAL_METHODS_PY``).
+#
+# These method names are overwhelmingly associated with the JUnit / Mockito /
+# AssertJ test stack and whose appearance as a bare call edge almost certainly
+# means a third-party library, not a project-defined method. Consulted by the
+# language-aware ``_try_external_method`` tier — placed AFTER
+# ``_try_stdlib_method`` — to classify such names ``external`` when (and only
+# when) the project owns no compatible-language method of that name. Grouped by
+# owning library for auditability. Conservative: generic names projects define
+# (``setUp``, ``run``, ``execute``, ``before``, ``after``) are EXCLUDED.
+# ---------------------------------------------------------------------------
+
+# JUnit (4 + 5 Assertions / Assertions API)
+_JUNIT_METHODS = frozenset(
+    {
+        "assertEquals",
+        "assertNotEquals",
+        "assertTrue",
+        "assertFalse",
+        "assertNull",
+        "assertNotNull",
+        "assertSame",
+        "assertNotSame",
+        "assertArrayEquals",
+        "assertThrows",
+        "assertDoesNotThrow",
+        "assertAll",
+        "assertTimeout",
+        "assertThat",  # JUnit/Hamcrest assertThat
+        "fail",
+        "assumeTrue",
+        "assumeFalse",
+    }
+)
+
+# Mockito
+_MOCKITO_METHODS = frozenset(
+    {
+        "mock",
+        "spy",
+        "when",
+        "verify",
+        "verifyNoInteractions",
+        "verifyNoMoreInteractions",
+        "thenReturn",
+        "thenThrow",
+        "thenAnswer",
+        "thenCallRealMethod",
+        "doReturn",
+        "doThrow",
+        "doAnswer",
+        "doNothing",
+        "given",  # BDDMockito.given
+        "willReturn",
+        "willThrow",
+    }
+)
+
+# AssertJ (fluent assertions)
+_ASSERTJ_METHODS = frozenset(
+    {
+        "assertThatThrownBy",
+        "assertThatExceptionOfType",
+        "isEqualTo",
+        "isNotEqualTo",
+        "isNull",
+        "isNotNull",
+        "isInstanceOf",
+        "containsExactly",
+        "hasSize",
+        "isTrue",
+        "isFalse",
+    }
+)
+
+EXTERNAL_METHODS_JAVA: frozenset[str] = (
+    _JUNIT_METHODS | _MOCKITO_METHODS | _ASSERTJ_METHODS
+)
+
+
+__all__ = [
+    "EXTERNAL_METHODS_JAVA",
+    "JAVA_LANG_TYPES",
+    "JDK_PACKAGE_PREFIXES",
+    "STDLIB_METHODS_JAVA",
+    "is_jdk_prefix",
+]


### PR DESCRIPTION
Implements [RFC-0008](https://github.com/aimasteracc/tree-sitter-analyzer/blob/develop/rfcs/0008-multilang-method-classification.md) for **Java only** (Go/JS deferred to follow-up PRs). Built dev→independent-adversarial-review (separated teams); all 3 reviewers passed after re-running.

## What & why
Extends the RFC-0004/0005/0007 method-classification cascade — until now **Python-only** — to Java, so a Java caller's bare JDK/test-framework method name (`list.add`, `str.substring`, `mock.verify`) resolves to `stdlib`/`external` instead of `unknown`. Gated on the project owning no **compatible-language** method of that name (shadowing + ambiguity preserved; zero mis-wires).

Three tightly-coupled parts, all required for Java method classification to work at all:

1. **`function_extraction._call_info_java`** — extract the method name from `method_invocation`'s `name` field + receiver from `object`. **Latent bug fixed:** the old code took the first `identifier` child = the *receiver*, so `list.add()` recorded `name='list'` and the method name `add` never reached any classification tier.
2. **`_java.resolve_java_callee`** — new tiers 9b (`STDLIB_METHODS_JAVA`) / 9c (`EXTERNAL_METHODS_JAVA`) with a language-aware `_project_owns` gate: a same-named Python symbol does **not** count as a Java owner (`languages_compatible('java','python')` is False), so it cannot suppress a JDK classification (RFC-0004 #319 cross-language pattern).
3. **`synapse_resolver` tiers + `_context`** — generalize the Python tiers from a hard-coded `'python'` table lookup to `caller_lang` dispatch (fixes a latent cross-language bug where a non-Python caller on that path used the Python table) and register the Java tables alongside Python.

## Surface
Index-time classification only. **No CLI/MCP surface change** — read identically by every consumer (three-surface parity unaffected).

## Test plan (RED-first)
- [x] 7 new tests in `tests/unit/test_java_method_resolution.py`: stdlib + external classification, project-method shadowing, ambiguous-name-stays-unknown, and the **mandatory cross-language gate** (a Python-only table name must not classify a Java caller).
- [x] RED verified genuine (reviewer reproduced by neutralizing tiers 9b/9c → positive tests fail; forcing `_project_owns`→False → shadow/ambiguity tests fail).
- [x] Blast-radius green: `pytest -k 'java or function_extraction or synapse or callee or call_graph'` = **1361 passed, 8/8 under xdist** (no regression to the Python path).
- [x] ruff + mypy clean.

## Reviewer findings (separated review team, all triaged)
| finding | severity | action |
|---|---|---|
| scope > spec'd 4 files (added `_java.py`/`function_extraction.py`) | — | **necessary & correct** — Java has its own `resolve_java_callee` path + the call-name extraction was a prerequisite bug |
| 1-in-6 flake under the review harness | P3 | **review-concurrency artifact** — 4 agents ran pytest simultaneously; single xdist invocation is 8/8 green |
| stale tier-9b comment said 'external', returns 'stdlib' | P3 | **fixed** |
| external cross-lang gate test uses a Python-only name | P3 | won't-fix — `_project_owns` is shared with the stdlib path, already covered by the `split` overlapping-name test |

Follow-ups (separate PRs per RFC-0008): Go receiver methods (measure first), JS/TS `Array`/`String`/`Promise` + Jest/Vitest.