### PR TITLE
fix(mcp): project metrics dead-code key mismatch — stop reporting every function as dead (F1)

### DIFF
--- a/tests/unit/test_codegraph_metrics_tool.py
+++ b/tests/unit/test_codegraph_metrics_tool.py
@@ -119,3 +119,54 @@ class TestExecuteWithCache:
         assert result["cache"]["total_files"] == 42
         assert result["cache"]["total_symbols"] == 1000
         assert result["cache_indexed"] is True
+
+
+class TestCallGraphMetricsSanity:
+    """F1 regression: project metrics must not degenerate to 'every function is
+    both an entry point AND dead code'. Root cause was a key mismatch —
+    all_functions() dicts key the path under 'file', but the metric collector
+    read 'file_path', so every function string had an empty path and never
+    matched the call-edge keys (real paths), making callers/callees maps useless.
+    """
+
+    def _index(self, tmp_path):
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        proj = tmp_path / "pkg"
+        proj.mkdir(parents=True, exist_ok=True)
+        (proj / "__init__.py").write_text("# pkg\n")
+        (proj / "a.py").write_text(
+            "def helper():\n    return 1\n\ndef caller():\n    return helper()\n"
+        )
+        (proj / "b.py").write_text("def other():\n    return 2\n")
+        cache = ASTCache(str(tmp_path))
+        cache.index_project()
+        return cache
+
+    def test_dead_code_candidates_never_equals_total(self, tmp_path):
+        cache = self._index(tmp_path)
+        tool = CodeGraphMetricsTool(str(tmp_path))
+        m = tool._collect_call_graph_metrics(cache)
+        assert m["status"] == "computed", m
+        total = m["total_functions"]
+        assert total >= 2, m
+        # The bug made all three equal to total. A real graph with a call edge
+        # (caller -> helper) must classify helper as NON-dead and NON-entry.
+        assert m["dead_code_candidates"] < total, (
+            f"every function flagged dead ({m['dead_code_candidates']}/{total}) "
+            "— F1 key-mismatch regression"
+        )
+        assert m["entry_points"] < total, m
+        assert m["total_call_edges"] > 0, m
+
+    def test_files_with_functions_reflects_real_paths(self, tmp_path):
+        cache = self._index(tmp_path)
+        tool = CodeGraphMetricsTool(str(tmp_path))
+        m = tool._collect_call_graph_metrics(cache)
+        # The bug collapsed every function path to "" -> files_with_functions == 1
+        # regardless of how many files define functions. a.py and b.py both
+        # define functions, so a correct collector reports >= 2 distinct files.
+        assert m["files_with_functions"] >= 2, (
+            f"files_with_functions={m['files_with_functions']} — paths collapsed "
+            "to empty string (F1 key-mismatch regression)"
+        )

--- a/tree_sitter_analyzer/mcp/tools/codegraph_metrics_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_metrics_tool.py
@@ -197,8 +197,14 @@ class CodeGraphMetricsTool(BaseMCPTool):
             cg.build()
 
             func_dicts = cg.all_functions()
+            # NOTE: FunctionRef.to_dict() keys the path under "file" (NOT
+            # "file_path"). Reading the wrong key made every function string an
+            # empty path "::name" that never matched the real-path call-edge keys
+            # below, degenerating to entry_points == dead == total_functions and
+            # files_with_functions == 1 (F1 trust-breaker). Keep these keys in
+            # sync with FunctionRef.to_dict() in call_graph.py.
             functions: list[str] = [
-                f"{f.get('file_path', '')}::{f.get('name', '')}" for f in func_dicts
+                f"{f.get('file', '')}::{f.get('name', '')}" for f in func_dicts
             ]
             call_edges: list[tuple[str, str]] = [
                 (


### PR DESCRIPTION
## The trust-breaker (found by dogfooding)
`project action=metrics` / `overview` reported call-graph stats where **every function was simultaneously an entry point AND dead code**: `entry_points == dead_code_candidates == total_functions == 28239`, `files_with_functions == 1`, and `suggested_next_steps: "28239 dead code candidates found"`. An agent's first orienting call thus told it the entire codebase is dead — directly refuting TSA's core "trust the graph" thesis — while the dedicated `health action=dead` tool correctly reported **1372**. Two surfaces disagreed 20×.

## Root cause (one character)
`CachedCallGraph.all_functions()` dicts key the path under `"file"` (`FunctionRef.to_dict`, [call_graph.py:90](../blob/develop/tree_sitter_analyzer/call_graph.py)), but `_collect_call_graph_metrics` read `f.get('file_path','')`. Every function string became `"::name"` (empty path) and never matched the real-path call-edge keys, so `callers_map`/`callees_map` stayed empty → every function had 0 callers (entry) and 0 callees (dead).

## Fix
`'file_path'` → `'file'` (one line, + a comment pinning the key to `FunctionRef.to_dict`). On the TSA repo: **28239/28239/28239/1 → entry 19335 / dead 3394 / files 1666** (sane).

## Test plan (RED-first)
- [x] `TestCallGraphMetricsSanity`: indexes a 2-file project where `caller()` calls `helper()`; asserts `dead_code_candidates < total_functions`, `entry_points < total`, and `files_with_functions >= 2`. Verified RED on the old key, GREEN on the fix (independent reviewer reproduced).
- [x] Independent adversarial review: pass, 0 findings. Confirmed no same-class bug elsewhere (`call_graph_impact.py` already uses `"file"`).
- [x] 15 file tests + 573 blast-radius pass; ruff + mypy clean.

## Scope / follow-up
Surgical one-char fix only. The metric's naive dead-code count (3394: no-callers-AND-no-callees) still differs from `health action=dead` (1372: transitive reachability + test filtering) because they are different engines — **converging the two surfaces onto one engine is a separate follow-up** (panel's NEXT wave), not required to remove the trust-breaker.

Found via a dogfood + expert-panel sweep; this is item #1 ("the one thing") of the TSA summit roadmap.