### PR TITLE
fix(mcp): coerce structure read line/column bounds to int (broken read escape hatch)

### DIFF
--- a/tests/unit/mcp/tools/test_structure_facade.py
+++ b/tests/unit/mcp/tools/test_structure_facade.py
@@ -423,3 +423,56 @@ def test_annotations_set_correctly() -> None:
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))
+
+
+# ---------------------------------------------------------------------------
+# 12. read coercion — string line/column bounds (undeclared additionalProperties)
+#     must be int-coerced at the facade boundary, not TypeError downstream.
+# ---------------------------------------------------------------------------
+def test_structure_read_coerces_string_bounds(tmp_path: Any) -> None:
+    """Agents pass start_line/end_line as strings (the flat facade schema does
+    not type them). The single-file read route must coerce them to int, not let
+    ``str < int`` TypeError reach the agent — the documented escape hatch must
+    actually work.
+    """
+    f = tmp_path / "sample.py"
+    f.write_text("a = 1\nb = 2\nc = 3\nd = 4\ne = 5\n")
+    facade = build_structure_facade(project_root=str(tmp_path))
+
+    result = asyncio.run(
+        facade.execute(
+            {
+                "action": "read",
+                "file_path": str(f),
+                "start_line": "2",  # STRING, as an MCP client delivers it
+                "end_line": "4",
+                "output_format": "json",
+            }
+        )
+    )
+
+    assert result.get("success") is True, result
+    # Must not be the pre-fix TypeError envelope.
+    assert "'<' not supported" not in str(result.get("error", "")), result
+
+
+def test_structure_read_rejects_non_numeric_bounds(tmp_path: Any) -> None:
+    """A genuinely non-numeric bound raises a CLEAR ValueError (caught at the MCP
+    boundary into an error envelope) rather than a cryptic ``str < int`` TypeError
+    from deep in extract_code_section. Mirrors the existing _read_route raise for
+    missing args."""
+    f = tmp_path / "sample.py"
+    f.write_text("a = 1\nb = 2\n")
+    facade = build_structure_facade(project_root=str(tmp_path))
+
+    with pytest.raises(ValueError, match="must be integers"):
+        asyncio.run(
+            facade.execute(
+                {
+                    "action": "read",
+                    "file_path": str(f),
+                    "start_line": "not-a-number",
+                    "output_format": "json",
+                }
+            )
+        )

--- a/tests/unit/mcp/tools/test_structure_facade.py
+++ b/tests/unit/mcp/tools/test_structure_facade.py
@@ -476,3 +476,31 @@ def test_structure_read_rejects_non_numeric_bounds(tmp_path: Any) -> None:
                 }
             )
         )
+
+
+def test_structure_read_rejects_fractional_float_bounds(tmp_path: Any) -> None:
+    """Codex P3 #328: a fractional numeric bound (start_line=2.9) must be
+    rejected, not silently truncated to 2. Integral floats (2.0) still coerce."""
+    f = tmp_path / "sample.py"
+    f.write_text("a = 1\nb = 2\nc = 3\n")
+    facade = build_structure_facade(project_root=str(tmp_path))
+
+    # fractional -> clear ValueError, never a truncated read
+    with pytest.raises(ValueError, match="must be integers"):
+        asyncio.run(
+            facade.execute({"action": "read", "file_path": str(f), "start_line": 2.9})
+        )
+
+    # integral float -> coerces cleanly
+    ok = asyncio.run(
+        facade.execute(
+            {
+                "action": "read",
+                "file_path": str(f),
+                "start_line": 2.0,
+                "end_line": 3.0,
+                "output_format": "json",
+            }
+        )
+    )
+    assert ok.get("success") is True, ok

--- a/tree_sitter_analyzer/mcp/tools/structure_facade.py
+++ b/tree_sitter_analyzer/mcp/tools/structure_facade.py
@@ -164,10 +164,21 @@ def build_structure_facade(project_root: str | None = None) -> FacadeTool:
         # extract_code_section does ``str < int`` comparisons -> TypeError. This
         # made the documented single-file read escape hatch fail 100% of the time.
         def _as_int(value: Any) -> Any:
-            if value is None or isinstance(value, int):
+            if value is None or isinstance(value, bool):
                 return value
+            if isinstance(value, int):
+                return value
+            # A fractional JSON number (start_line=2.9) is a malformed bound, not
+            # something to silently truncate — enforce the integer-only contract
+            # (Codex P3 on #328). Integral floats (2.0) coerce cleanly.
+            if isinstance(value, float):
+                if value.is_integer():
+                    return int(value)
+                raise ValueError(
+                    f"read action: line/column bounds must be integers, got {value!r}"
+                )
             try:
-                return int(value)
+                return int(str(value))  # base-10 integer strings only ("88")
             except (TypeError, ValueError) as exc:
                 raise ValueError(
                     f"read action: line/column bounds must be integers, got {value!r}"

--- a/tree_sitter_analyzer/mcp/tools/structure_facade.py
+++ b/tree_sitter_analyzer/mcp/tools/structure_facade.py
@@ -158,12 +158,27 @@ def build_structure_facade(project_root: str | None = None) -> FacadeTool:
         if "file_path" not in args or "start_line" not in args:
             raise ValueError("read action requires file_path and start_line")
 
+        # Coerce line/column bounds to int at the facade boundary. They arrive as
+        # strings when an agent passes them as undeclared additionalProperties
+        # (the flat facade schema does not type them), and the downstream
+        # extract_code_section does ``str < int`` comparisons -> TypeError. This
+        # made the documented single-file read escape hatch fail 100% of the time.
+        def _as_int(value: Any) -> Any:
+            if value is None or isinstance(value, int):
+                return value
+            try:
+                return int(value)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"read action: line/column bounds must be integers, got {value!r}"
+                ) from exc
+
         full_args: dict[str, Any] = {
             "file_path": args["file_path"],
-            "start_line": args["start_line"],
-            "end_line": args.get("end_line"),
-            "start_column": args.get("start_column"),
-            "end_column": args.get("end_column"),
+            "start_line": _as_int(args["start_line"]),
+            "end_line": _as_int(args.get("end_line")),
+            "start_column": _as_int(args.get("start_column")),
+            "end_column": _as_int(args.get("end_column")),
             "format": args.get("format", "text"),
             "output_file": args.get("output_file"),
             "suppress_output": args.get("suppress_output", False),


### PR DESCRIPTION
## Bug (found by dogfooding the trace task)
The server instructions document `structure action=read` (single-file: `file_path + start_line`) as the fallback when nav context doesn't inline the line you need. But it **failed 100% of the time**: the flat facade schema doesn't type `start_line`/`end_line`/columns, so an agent passes them as `additionalProperties` **strings**, and `extract_code_section` does `str < int` → `TypeError: '<' not supported between instances of 'str' and 'int'`. The agent burns a turn on the error, then falls back to raw `Read` — a direct contributor to TSA's turn-count/cost gap vs CodeGraph.

Reproduced live via MCP:
`structure action=read file_path=… start_line=88 end_line=92` → `TypeError: '<' not supported…`

## Fix
Int-coerce the four numeric bounds in `_read_route` (the facade boundary — where agent input is validated), with a clear `ValueError` on genuinely non-numeric input (consistent with the existing missing-args raise two lines above). End-to-end after the fix: string bounds `'88'`/`'92'` return the lines.

## Test plan (RED-first)
- [x] `test_structure_read_coerces_string_bounds`: string bounds → success. **Verified RED** on the un-coerced path (reverting the coercion reproduces the TypeError failure), GREEN with the fix.
- [x] `test_structure_read_rejects_non_numeric_bounds`: clear ValueError, not a cryptic downstream TypeError.
- [x] 30 structure-facade tests pass; ruff + mypy clean.

NOW-wave item #2 of the TSA summit roadmap (after [#327](https://github.com/aimasteracc/tree-sitter-analyzer/pull/327) F1). Both are on-by-default leaks that an agent hits on a normal trace task.