### PR TITLE
fix(deadcode): exclude hidden/vendored dot-dirs from dead-code walks (F2)

### DIFF
--- a/tests/unit/test_dead_code_analyzer.py
+++ b/tests/unit/test_dead_code_analyzer.py
@@ -295,3 +295,38 @@ class TestDeadCodeErrorHandling:
         result = analyze_dead_code(str(tmp_path), max_files=10)
 
         assert result.stats["total_functions"] >= 1
+
+
+def test_excludes_dot_prefixed_vendored_dirs(tmp_path):
+    """F2 regression: dead-code analysis must not walk into hidden/vendored
+    dot-dirs (.benchmark-repos, .ast-cache). Cloned target repos there are not
+    the project's own code and were polluting unused-imports / unreferenced
+    variables output."""
+    from tree_sitter_analyzer.dead_code_analyzer import (
+        find_unreferenced_variables,
+        find_unused_imports,
+    )
+
+    # project's own file: an unreferenced module-level variable
+    (tmp_path / "own.py").write_text("UNUSED_VAR = 1\n\n\ndef f():\n    return 2\n")
+    # vendored / hidden tree that must be ignored (its LEAKED_VAR must NOT surface)
+    vendored = tmp_path / ".benchmark-repos" / "excalidraw"
+    vendored.mkdir(parents=True)
+    (vendored / "App.py").write_text("LEAKED_VAR = 9\n\n\ndef g():\n    return 3\n")
+
+    variables = find_unreferenced_variables(str(tmp_path))
+    var_files = {v.file.replace("\\", "/") for v in variables}
+    var_names = {v.name for v in variables}
+
+    # F2: the vendored dot-dir tree must be excluded entirely.
+    assert not any(".benchmark-repos" in f for f in var_files), var_files
+    assert "LEAKED_VAR" not in var_names, var_names
+    # ...but the project's OWN code is still analyzed (analysis not broken).
+    assert any("own.py" in f for f in var_files), var_files
+    assert "UNUSED_VAR" in var_names, var_names
+
+    # also sanity-check the imports walk doesn't surface the vendored tree.
+    imports = find_unused_imports(str(tmp_path))
+    assert not any(".benchmark-repos" in i.file.replace("\\", "/") for i in imports), [
+        i.file for i in imports
+    ]

--- a/tree_sitter_analyzer/dead_code_analyzer.py
+++ b/tree_sitter_analyzer/dead_code_analyzer.py
@@ -17,8 +17,10 @@ and the core parser for import/variable extraction.
 
 from __future__ import annotations
 
+import os
 import re
 from collections import deque
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -52,21 +54,25 @@ _EXCLUDE_DIRS = {
 }
 
 
-def _is_excluded_path(p: Path, root: Path) -> bool:
-    """True when any path component BELOW ``root`` is an excluded dir or is
-    hidden (dot-prefixed).
+def _iter_candidate_files(root: Path) -> Iterator[Path]:
+    """Yield files under ``root``, PRUNING excluded and hidden (dot-prefixed)
+    directories so large vendored / generated trees never get walked.
 
-    Scoping to below-root (via ``relative_to``) avoids matching a dot-component
-    in the absolute prefix (e.g. a checkout under ``~/.local``). The dot-prefix
-    rule mirrors the indexer's scope so vendored / generated trees the explicit
-    list misses — ``.benchmark-repos`` (cloned target repos), ``.ast-cache`` —
-    don't pollute dead-code analysis with code that isn't the project's own.
+    Uses ``os.walk`` + in-place ``dirnames[:]`` pruning — the same approach as
+    the CallGraph / ASTCache walkers — rather than filtering ``rglob`` results.
+    Filtering rglob still enumerates every descendant of an excluded tree before
+    it can be skipped, so a large cloned repo (``.benchmark-repos/excalidraw``)
+    or cache (``.ast-cache``) made the walk slow/hang on the exact trees this
+    exclusion is meant to skip (Codex P2 #329). Pruning never descends into them.
+    The dot-prefix rule mirrors the indexer's scope; pruning ``dirnames`` is
+    inherently below-root, so the absolute prefix is never matched.
     """
-    try:
-        rel_parts = Path(p).relative_to(root).parts
-    except ValueError:
-        rel_parts = Path(p).parts
-    return any(part in _EXCLUDE_DIRS or part.startswith(".") for part in rel_parts)
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [
+            d for d in dirnames if d not in _EXCLUDE_DIRS and not d.startswith(".")
+        ]
+        for filename in filenames:
+            yield Path(dirpath) / filename
 
 
 _KNOWN_ENTRY_PATTERNS = {
@@ -241,21 +247,18 @@ def find_unused_imports(
     results: list[UnusedImport] = []
 
     source_files: list[tuple[Path, str]] = []
-    for p in root.rglob("*"):
-        if _is_excluded_path(p, root):
-            continue
-        if p.is_file():
-            lang = _language_from_ext(str(p))
-            if lang and lang in (
-                "python",
-                "javascript",
-                "typescript",
-                "go",
-                "java",
-                "c",
-                "cpp",
-            ):
-                source_files.append((p, lang))
+    for p in _iter_candidate_files(root):
+        lang = _language_from_ext(str(p))
+        if lang and lang in (
+            "python",
+            "javascript",
+            "typescript",
+            "go",
+            "java",
+            "c",
+            "cpp",
+        ):
+            source_files.append((p, lang))
         if len(source_files) >= max_files:
             break
 
@@ -365,13 +368,10 @@ def find_unreferenced_variables(
     results: list[UnreferencedVariable] = []
 
     source_files: list[tuple[Path, str]] = []
-    for p in root.rglob("*"):
-        if _is_excluded_path(p, root):
-            continue
-        if p.is_file():
-            lang = _language_from_ext(str(p))
-            if lang and lang in ("python", "javascript", "typescript", "go", "java"):
-                source_files.append((p, lang))
+    for p in _iter_candidate_files(root):
+        lang = _language_from_ext(str(p))
+        if lang and lang in ("python", "javascript", "typescript", "go", "java"):
+            source_files.append((p, lang))
         if len(source_files) >= max_files:
             break
 

--- a/tree_sitter_analyzer/dead_code_analyzer.py
+++ b/tree_sitter_analyzer/dead_code_analyzer.py
@@ -51,6 +51,24 @@ _EXCLUDE_DIRS = {
     ".claude",
 }
 
+
+def _is_excluded_path(p: Path, root: Path) -> bool:
+    """True when any path component BELOW ``root`` is an excluded dir or is
+    hidden (dot-prefixed).
+
+    Scoping to below-root (via ``relative_to``) avoids matching a dot-component
+    in the absolute prefix (e.g. a checkout under ``~/.local``). The dot-prefix
+    rule mirrors the indexer's scope so vendored / generated trees the explicit
+    list misses — ``.benchmark-repos`` (cloned target repos), ``.ast-cache`` —
+    don't pollute dead-code analysis with code that isn't the project's own.
+    """
+    try:
+        rel_parts = Path(p).relative_to(root).parts
+    except ValueError:
+        rel_parts = Path(p).parts
+    return any(part in _EXCLUDE_DIRS or part.startswith(".") for part in rel_parts)
+
+
 _KNOWN_ENTRY_PATTERNS = {
     "python": re.compile(
         r"^(main|__main__|setup|run|app|create_app|wsgi|asgi"
@@ -224,7 +242,7 @@ def find_unused_imports(
 
     source_files: list[tuple[Path, str]] = []
     for p in root.rglob("*"):
-        if any(part in _EXCLUDE_DIRS for part in p.parts):
+        if _is_excluded_path(p, root):
             continue
         if p.is_file():
             lang = _language_from_ext(str(p))
@@ -348,7 +366,7 @@ def find_unreferenced_variables(
 
     source_files: list[tuple[Path, str]] = []
     for p in root.rglob("*"):
-        if any(part in _EXCLUDE_DIRS for part in p.parts):
+        if _is_excluded_path(p, root):
             continue
         if p.is_file():
             lang = _language_from_ext(str(p))


### PR DESCRIPTION
## Bug (found by dogfooding)
`health action=dead` reported dozens of `.benchmark-repos/excalidraw/*.tsx` unreferenced variables — vendored target repos, not TSA's own code. `dead_code_analyzer` walks the filesystem directly with an explicit `_EXCLUDE_DIRS` allowlist (`node_modules`, `.git`, …) that simply **missed** `.benchmark-repos/` and `.ast-cache/`. This made TSA's self-analysis untrustworthy and inflated the walk — a credibility leak for a "trust the graph" product, on the agent's dead-code call.

## Fix
A shared `_is_excluded_path(p, root)` helper skips any path component **below root** that is in `_EXCLUDE_DIRS` **or is hidden (dot-prefixed)** — mirroring the indexer's effective scope (the index already excludes these; only this separate filesystem walk didn't), so every `.foo/` tree is ignored, not just hand-listed ones. Scoped to below-root via `relative_to` so a checkout under `~/.local` isn't wholly excluded. De-dups the identical skip predicate across both walks.

## Re-dogfood
On the TSA repo: `.benchmark-repos` unreferenced-variable count **dozens → 0** (total 329 → 329 own-code, 0 vendored).

## Test plan (RED-first)
- [x] `test_excludes_dot_prefixed_vendored_dirs`: a `.benchmark-repos/excalidraw/App.py` `LEAKED_VAR` is excluded while the project's own `UNUSED_VAR` is still detected (analysis not broken). **Verified RED** on the old predicate.
- [x] 31 dead-code tests pass; ruff + mypy clean.

NOW-wave item #3 of the TSA summit roadmap (after #327 F1 merged, #328 structure read).