### PR TITLE
feat(mcp): RFC-0009 — nav context inline full entry bodies + entry-first ranking

### DIFF
--- a/tests/unit/test_codegraph_context_tool.py
+++ b/tests/unit/test_codegraph_context_tool.py
@@ -1384,3 +1384,72 @@ def test_build_related_symbols_groups_by_file() -> None:
 
     b_group = next(g for g in groups if g["file"] == "b.py")
     assert b_group["symbols"] == ["beta:5"]
+
+
+def test_entry_point_body_inlines_full_under_budget(tmp_path: Path) -> None:
+    """RFC-0009 A: an entry-point symbol whose body fits the entry budget inlines
+    in FULL — no '… more lines' truncation marker — so the agent answers in one
+    call. The old blanket 16-line cap truncated it (RED)."""
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        _build_code_blocks,
+        _node_id,
+    )
+
+    body = "def big():\n" + "".join(f"    x{i} = {i}\n" for i in range(1, 40))
+    f = tmp_path / "big.py"
+    f.write_text(body, encoding="utf-8")  # 'big' spans lines 1..40
+    nodes = [
+        {
+            "id": _node_id("big", "big.py", 1),
+            "name": "big",
+            "file": "big.py",
+            "line": 1,
+            "end_line": 40,
+            "is_entry": True,
+        }
+    ]
+    blocks = _build_code_blocks(nodes, [], 5, str(tmp_path))
+    assert len(blocks) == 1
+    block = blocks[0]
+    assert "more lines" not in block["content"], "entry body was truncated"
+    assert "snippet capped" not in block["content"]
+    assert block["end_line"] == 40, block
+    assert "x39 = 39" in block["content"], "full body not inlined"
+
+
+def test_entry_point_ranked_before_high_degree_noise(tmp_path: Path) -> None:
+    """RFC-0009 B: a task's named entry point gets a code block BEFORE a
+    high-edge-degree non-entry hub (e.g. a cache accessor). The old degree-only
+    ranking put the hub first and could starve the entry of a slot (RED)."""
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        _build_code_blocks,
+        _node_id,
+    )
+
+    f = tmp_path / "m.py"
+    f.write_text(
+        "def answer():\n    return 1\n\n\ndef cache_get():\n    return 2\n",
+        encoding="utf-8",
+    )
+    entry = {
+        "id": _node_id("answer", "m.py", 1),
+        "name": "answer",
+        "file": "m.py",
+        "line": 1,
+        "end_line": 2,
+        "is_entry": True,
+    }
+    noise = {
+        "id": _node_id("cache_get", "m.py", 5),
+        "name": "cache_get",
+        "file": "m.py",
+        "line": 5,
+        "end_line": 6,
+    }
+    # cache_get has high edge degree; answer has none.
+    edges = [{"source": noise["id"], "target": f"x{i}"} for i in range(8)] + [
+        {"source": f"x{i}", "target": noise["id"]} for i in range(8)
+    ]
+    # only ONE block slot — the entry must win it.
+    blocks = _build_code_blocks([noise, entry], edges, 1, str(tmp_path))
+    assert [b["name"] for b in blocks] == ["answer"], blocks

--- a/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
@@ -26,10 +26,19 @@ _STOP_WORDS = frozenset(
     "or through to trace what when where which why with work works".split()
 )
 
-# Inline-body cap per code block. A full function body (the old 40-line window)
-# bloated nav context responses vs peer tools for little added value; the agent
-# gets the signature + head and reads the exact range only if it must.
+# Inline-body cap per code block for TANGENTIAL nodes (pulled in by call-graph
+# expansion, not the task's named symbols). These get signature + head; the agent
+# rarely needs their full body, so RFC-0006's thrift is preserved where it costs
+# no turn.
 _MAX_BLOCK_LINES = 16
+
+# RFC-0009: ENTRY-POINT / task-relevant symbols get their FULL body inlined up to
+# this budget so the agent answers in ONE call instead of a follow-up Read. The
+# blanket 16-line cap was net-negative — it traded a smaller first response for
+# extra turns, and turns dominate end-to-end cost. 160 covers the motivating
+# target (resolve_java_callee, 127 lines) with headroom; tuned against the
+# turn-count measurement in RFC-0009's acceptance criteria.
+_MAX_ENTRY_BODY_LINES = 160
 
 # Cap on edges echoed in the response. Edges are graph wiring for visualization;
 # an answering agent rarely needs the full adjacency list, and 60+ raw edge
@@ -611,6 +620,10 @@ def _nodes_from_hits(
         if len(nodes) >= max_nodes:
             break
         node = _node_from_ref(hit)
+        # RFC-0009: these are the task's named entry points (vs nodes added later
+        # by call-graph expansion). Mark them so _build_code_blocks ranks them
+        # first and inlines their full body.
+        node["is_entry"] = True
         key = (node["name"], node.get("file", ""), node.get("line", 0))
         if key in seen:
             continue
@@ -694,7 +707,17 @@ def _build_code_blocks(
     if max_code_blocks <= 0:
         return []
     degrees = _edge_degrees(nodes, edges)
-    ranked = sorted(nodes, key=lambda n: (-degrees.get(n["id"], 0), n.get("line", 0)))
+    # RFC-0009: rank the task's named entry points FIRST (before graph-centrality),
+    # so the answer symbol always gets a block ahead of a high-degree hub like a
+    # cache accessor. Within each tier, fall back to edge-degree then line.
+    ranked = sorted(
+        nodes,
+        key=lambda n: (
+            not n.get("is_entry", False),
+            -degrees.get(n["id"], 0),
+            n.get("line", 0),
+        ),
+    )
     blocks: list[dict[str, Any]] = []
     seen_files_lines: set[tuple[str, int]] = set()
     for node in ranked:
@@ -718,15 +741,16 @@ def _build_code_blocks(
             continue
         raw_end = int(node.get("end_line", 0) or 0)
         end_known = raw_end >= start_line
+        # RFC-0009: entry-point / task-relevant symbols inline their FULL body up
+        # to _MAX_ENTRY_BODY_LINES so the agent answers in one call; tangential
+        # (expansion) nodes keep the small _MAX_BLOCK_LINES cap (RFC-0006 thrift).
+        block_cap = _MAX_ENTRY_BODY_LINES if node.get("is_entry") else _MAX_BLOCK_LINES
         # Nodes from call-graph expansion (callees/callers) often have no
         # end_line; fall back to the cap window for those.
-        full_end = raw_end if end_known else start_line + _MAX_BLOCK_LINES - 1
-        # Cap the inline body to _MAX_BLOCK_LINES. A full 40-line function body
-        # per block made nav context responses 2-4x larger than peers for no
-        # added value — the agent needs the signature + head of the body to
-        # locate and understand the symbol, then reads the exact range only if
-        # it must. Long bodies get a truncation marker pointing at the rest.
-        capped_end = min(full_end, start_line + _MAX_BLOCK_LINES - 1)
+        full_end = raw_end if end_known else start_line + block_cap - 1
+        # Long bodies still get a truncation marker pointing at the rest, so the
+        # agent can read on for the rare over-budget function.
+        capped_end = min(full_end, start_line + block_cap - 1)
         capped_end = min(capped_end, len(lines))
         content = extract_snippet_from_lines(lines, start_line, capped_end)
         if not content:
@@ -746,7 +770,7 @@ def _build_code_blocks(
             # (Codex P2 on #293: the old fallback silently dropped lines 25+).
             content = (
                 content.rstrip("\n")
-                + f"\n    # … snippet capped at {_MAX_BLOCK_LINES} lines; "
+                + f"\n    # … snippet capped at {block_cap} lines; "
                 f"end unknown — read {file_path}:{capped_end + 1}+ if needed\n"
             )
         blocks.append(


### PR DESCRIPTION
Implements [RFC-0009](https://github.com/aimasteracc/tree-sitter-analyzer/blob/develop/rfcs/0009-nav-context-self-sufficiency.md) parts **A + B** — the core self-sufficiency fix that closes TSA's turn-count gap vs CodeGraph (its only measured deficit).

## What & why
`nav context` is the documented PRIMARY call, but a dogfood (`resolve_callee → resolve_java_callee`) showed its response **did not contain the answer**, forcing follow-up reads — the turn explosion. Two fixes to `_build_code_blocks`:

- **A — two-tier body budget**: entry-point / task-named symbols inline their FULL body up to `_MAX_ENTRY_BODY_LINES=160` (covers the 127-line motivating target); tangential expansion nodes keep the 16-line cap. The blanket 16-line cap was **net-negative** — smaller first response, but extra turns, and turns dominate end-to-end cost.
- **B — entry-first ranking**: named entry points get a code block BEFORE high-degree hubs (a cache accessor was beating the actual dispatcher, which got no block). Entry nodes marked `is_entry=True` in `_nodes_from_hits`.

## Dogfood (before → after)
| | before | after |
|---|---|---|
| `resolve_java_callee` body | 16 lines + '… 80 more' | **full 127 lines inline** |
| `resolve_callee` dispatcher | **absent** | present |
| `_route_cache.get` noise | present | **gone** |

→ the task is now answerable in **one call**.

## Test plan (RED-first)
- [x] `test_entry_point_body_inlines_full_under_budget` — full body, no truncation marker (verified RED on the 16-line cap)
- [x] `test_entry_point_ranked_before_high_degree_noise` — entry wins the slot vs a high-degree hub (verified RED on degree-only ranking)
- [x] 42 context tests pass; ruff + mypy clean

## Scope / follow-ups (per RFC-0009, tracked)
- **C** query tokenisation (de-noise generic verbs like 'dispatch' that still match unrelated event dispatchers) — separate PR.
- The **n≥5 benchmark turn-drop measurement** (the RFC's final acceptance gate) — depends on the benchmark run-id infra fix landing first. RFC stays `accepted` until C + measurement complete.