### PR TITLE
fix(bench): per-invocation session_id so re-runs don't overwrite raw artifacts

### DIFF
--- a/benchmarks/codegraph_compare/adapters/claude_runner.py
+++ b/benchmarks/codegraph_compare/adapters/claude_runner.py
@@ -4,8 +4,8 @@ No separate API key required — uses the current Claude Code session's
 authentication (keychain / OAuth).
 
 Writes:
-  - results_dir/raw/<run_id>_prompt.txt          — the full prompt sent to the agent
-  - results_dir/raw/<run_id>_result.jsonl        — raw JSONL response from the agent CLI
+  - results_dir/raw/<session_id>__<run_id>_prompt.txt    — the full prompt sent to the agent
+  - results_dir/raw/<session_id>__<run_id>_result.jsonl  — raw JSONL response from the agent CLI
   - results_dir/runs.jsonl                       — one JSONL line per trial (appended)
 """
 
@@ -454,15 +454,27 @@ def run_one(
     model: str | None = None,
     agent_backend: str = "claude",
     dry_run: bool = False,
+    session_id: str = "",
 ) -> dict:
     """Run one benchmark trial via the configured agent CLI.
 
     Writes prompt + raw result to results_dir/raw/, appends to runs.jsonl.
+
+    ``session_id`` uniquifies the raw artifact filenames so repeated benchmark
+    invocations of the same (question, arm, repeat) do NOT overwrite each other's
+    raw transcripts — without it, cost data from an earlier run was silently lost
+    on re-run, which made n>1 measurement impossible. Generated once per
+    ``cmd_run`` / ``cmd_run_matrix`` invocation and threaded in; defaults to a UTC
+    timestamp when called standalone. ``run_id`` stays the logical grouping key
+    for analysis; ``session_id`` only distinguishes invocations.
     """
     if agent_backend not in {"claude", "codex"}:
         raise ValueError("agent_backend must be one of: claude, codex")
     model = model or _DEFAULT_MODELS[agent_backend]
     run_id = _make_run_id(question_id, arm_id, repeat, agent_backend)
+    if not session_id:
+        session_id = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+    artifact_stem = f"{session_id}__{run_id}"
     started_at = datetime.now(timezone.utc).isoformat()
     started_perf = time.perf_counter()
 
@@ -497,7 +509,7 @@ def run_one(
     # Persist prompt
     raw_dir = results_dir / "raw"
     raw_dir.mkdir(parents=True, exist_ok=True)
-    prompt_path = raw_dir / f"{run_id}_prompt.txt"
+    prompt_path = raw_dir / f"{artifact_stem}_prompt.txt"
     prompt_path.write_text(full_prompt, encoding="utf-8")
 
     # Build agent CLI command. Claude has stronger tool allowlisting; Codex
@@ -520,7 +532,7 @@ def run_one(
     stream_lines: list[str] = []
 
     if dry_run:
-        result_path = raw_dir / f"{run_id}_result.jsonl"
+        result_path = raw_dir / f"{artifact_stem}_result.jsonl"
         answer = "DRY_RUN"
         result_path.write_text("", encoding="utf-8")
     else:
@@ -548,7 +560,7 @@ def run_one(
             stream_lines = [ln for ln in proc.stdout.splitlines() if ln.strip()]
 
             # Save raw stream
-            result_path = raw_dir / f"{run_id}_result.jsonl"
+            result_path = raw_dir / f"{artifact_stem}_result.jsonl"
             result_path.write_text(proc.stdout, encoding="utf-8")
 
             if proc.returncode != 0 and not proc.stdout.strip():
@@ -603,6 +615,7 @@ def run_one(
 
     record: dict = {
         "run_id": run_id,
+        "session_id": session_id,
         "repo": repo_path.name,
         "question_id": question_id,
         "arm": arm_id,
@@ -622,7 +635,7 @@ def run_one(
         "index_queries": index_queries,
         "answer": answer,
         "citations": _extract_citations(answer, repo_path),
-        "transcript_path": str(raw_dir / f"{run_id}_result.jsonl"),
+        "transcript_path": str(raw_dir / f"{artifact_stem}_result.jsonl"),
         "error": error,
         "agent_backend": agent_backend,
         "model": model,

--- a/benchmarks/codegraph_compare/run.py
+++ b/benchmarks/codegraph_compare/run.py
@@ -376,7 +376,7 @@ def cmd_run(args: argparse.Namespace) -> int:
         model=args.model,
         agent_backend=args.agent_backend,
         dry_run=getattr(args, "dry_run", False),
-        session_id=datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ"),
+        session_id=datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ"),
     )
 
     # Print result summary
@@ -428,7 +428,7 @@ def cmd_run_matrix(args: argparse.Namespace) -> int:
 
     # One session id per matrix invocation so repeated runs don't overwrite each
     # other's raw transcripts (cost data must survive re-runs for n>1 analysis).
-    session_id = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    session_id = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
 
     RESULTS_DIR.mkdir(parents=True, exist_ok=True)
 

--- a/benchmarks/codegraph_compare/run.py
+++ b/benchmarks/codegraph_compare/run.py
@@ -32,6 +32,7 @@ import json
 import sys
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import NoReturn
 
@@ -375,6 +376,7 @@ def cmd_run(args: argparse.Namespace) -> int:
         model=args.model,
         agent_backend=args.agent_backend,
         dry_run=getattr(args, "dry_run", False),
+        session_id=datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ"),
     )
 
     # Print result summary
@@ -423,6 +425,10 @@ def cmd_run_matrix(args: argparse.Namespace) -> int:
         from adapters.claude_runner import run_one  # noqa: PLC0415
     except ImportError:
         _die("Could not import adapters or adapters.claude_runner.")
+
+    # One session id per matrix invocation so repeated runs don't overwrite each
+    # other's raw transcripts (cost data must survive re-runs for n>1 analysis).
+    session_id = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
 
     RESULTS_DIR.mkdir(parents=True, exist_ok=True)
 
@@ -497,6 +503,7 @@ def cmd_run_matrix(args: argparse.Namespace) -> int:
                             model=args.model,
                             agent_backend=args.agent_backend,
                             dry_run=args.dry_run,
+                            session_id=session_id,
                         )
                         status = "DRY_RUN" if record["answer"] == "DRY_RUN" else "ok"
                         print(

--- a/benchmarks/codegraph_compare/schemas.py
+++ b/benchmarks/codegraph_compare/schemas.py
@@ -39,6 +39,11 @@ class RunRecord:
     model: str = ""
     cached_input_tokens: int = 0
     reasoning_output_tokens: int = 0
+    # Per-invocation id (one per cmd_run / cmd_run_matrix) that uniquifies raw
+    # artifact filenames so repeated runs of the same run_id don't overwrite each
+    # other. run_id stays the logical grouping key; session_id distinguishes
+    # invocations. Optional so older runs.jsonl records still validate.
+    session_id: str = ""
 
     @classmethod
     def make_id(

--- a/tests/unit/test_benchmark_harness.py
+++ b/tests/unit/test_benchmark_harness.py
@@ -577,3 +577,29 @@ class TestRunIdUniqueness:
         assert len(results_files) == 2, results_files
         assert any("SESS_A" in n for n in results_files)
         assert any("SESS_B" in n for n in results_files)
+
+    def test_run_record_with_session_id_validates_against_schema(self, tmp_path):
+        """Codex P2 #332: the new session_id field must NOT break RunRecord's
+        extra='forbid' schema — fresh runner output has to validate."""
+        from benchmarks.codegraph_compare.adapters import RunConfig
+        from benchmarks.codegraph_compare.adapters.claude_runner import run_one
+        from benchmarks.codegraph_compare.schemas import RunRecord
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        cfg = RunConfig(arm_id="native-only", repo_path=repo, system_prompt="sys")
+        record = run_one(
+            question_id="q1",
+            question_prompt="trace it",
+            arm_id="native-only",
+            repo_path=repo,
+            repeat=0,
+            run_config=cfg,
+            results_dir=tmp_path / "results",
+            agent_backend="claude",
+            dry_run=True,
+            session_id="SESS_X",
+        )
+        # Must not raise — session_id is now a declared optional field.
+        validated = RunRecord(**record)
+        assert validated.session_id == "SESS_X"

--- a/tests/unit/test_benchmark_harness.py
+++ b/tests/unit/test_benchmark_harness.py
@@ -536,3 +536,44 @@ class TestCodeGraphCompareEvaluator:
 
         assert record["evaluated_with_llm"] is False
         assert record["overall"] == 3.0
+
+
+class TestRunIdUniqueness:
+    """Raw benchmark artifacts must survive re-runs: a per-invocation session_id
+    keeps repeated runs of the same (question, arm, repeat) from overwriting each
+    other's transcript — without it, n>1 cost measurement loses earlier data."""
+
+    def test_session_id_uniquifies_raw_artifacts(self, tmp_path):
+        from benchmarks.codegraph_compare.adapters import RunConfig
+        from benchmarks.codegraph_compare.adapters.claude_runner import run_one
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        results = tmp_path / "results"
+        cfg = RunConfig(arm_id="native-only", repo_path=repo, system_prompt="sys")
+
+        common = {
+            "question_id": "q1",
+            "question_prompt": "trace it",
+            "arm_id": "native-only",
+            "repo_path": repo,
+            "repeat": 0,
+            "run_config": cfg,
+            "results_dir": results,
+            "agent_backend": "claude",
+            "dry_run": True,
+        }
+        r1 = run_one(**common, session_id="SESS_A")
+        r2 = run_one(**common, session_id="SESS_B")
+
+        # Same logical run_id (grouping key) ...
+        assert r1["run_id"] == r2["run_id"]
+        # ... but DISTINCT session ids + distinct raw artifact paths (no overwrite).
+        assert r1["session_id"] == "SESS_A"
+        assert r2["session_id"] == "SESS_B"
+        assert r1["transcript_path"] != r2["transcript_path"]
+        raw = results / "raw"
+        results_files = sorted(p.name for p in raw.glob("*_result.jsonl"))
+        assert len(results_files) == 2, results_files
+        assert any("SESS_A" in n for n in results_files)
+        assert any("SESS_B" in n for n in results_files)


### PR DESCRIPTION
## Bug (cost-analysis-rigor lesson, 2026-06-07)
`benchmarks/codegraph_compare` wrote raw transcripts as `{run_id}_result.jsonl` where `run_id = question__arm__backend__repeat` — **stable across invocations**, so a second benchmark run of the same trial **overwrote** the first's raw transcript. n>1 cost measurement was impossible (earlier samples silently lost) — the exact blocker for RFC-0009's *measured turn-drop* acceptance gate.

## Fix
`run_one` takes a `session_id` (one per `cmd_run`/`cmd_run_matrix` invocation, UTC-timestamp default), prefixed into the raw artifact filenames (`{session_id}__{run_id}_*.{txt,jsonl}`) and recorded in `runs.jsonl`. `run_id` stays the logical grouping key for analysis; `session_id` only distinguishes invocations.

## Test plan (RED-first)
- [x] `test_session_id_uniquifies_raw_artifacts`: two dry-run trials, same `run_id`, different `session_id` → **two distinct** raw files (verified RED on the old `{run_id}` filename).
- [x] 32 harness tests pass; ruff clean.

NOW-wave item #4. **Unblocks** the RFC-0009 n≥5 benchmark measurement (the cost-moat acceptance gate).