### PR TITLE
feat(mcp): RFC-0009 C — drop generic-verb candidates when a specific symbol is named

### DIFF
--- a/tests/unit/test_codegraph_context_tool.py
+++ b/tests/unit/test_codegraph_context_tool.py
@@ -1532,10 +1532,6 @@ def test_non_dot_qualified_generic_methods_are_kept() -> None:
     assert "dispatch" in _extract_symbol_candidates(
         "does resolve_callee invoke dispatch() here"
     )
-    # Go/path-style qualifier (slash) also counts as explicit
-    assert "parse" in _extract_symbol_candidates(
-        "trace pkg/parser/parse alongside resolve_callee"
-    )
     # bare prose verb is still dropped when a specific symbol co-occurs
     assert "dispatch" not in _extract_symbol_candidates(
         "how does resolve_callee dispatch a Java call to resolve_java_callee"
@@ -1551,8 +1547,23 @@ def test_lowercase_qualified_anchor_still_drops_bare_verb() -> None:
         _extract_symbol_candidates,
     )
 
-    cands = _extract_symbol_candidates("trace pkg/parser/parse dispatch")
+    cands = _extract_symbol_candidates("trace obj->parse dispatch")
     assert "parse" in cands, cands
     assert "dispatch" not in cands, cands
     # sole-signal control: no anchor at all -> nothing dropped
     assert "dispatch" in _extract_symbol_candidates("find the dispatch function")
+
+
+def test_file_path_does_not_anchor_filter() -> None:
+    """RFC-0009 C / Codex P2 #333 (6th round): an ordinary file path mentioned in
+    the task ('… in src/parser/utils.py') must NOT count as a symbol anchor — '/'
+    is a path separator, not a qualifier — so a bare verb that is the user's real
+    request is preserved (sole-signal behaviour)."""
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        _extract_symbol_candidates,
+    )
+
+    cands = _extract_symbol_candidates(
+        "find the dispatch function in src/parser/utils.py"
+    )
+    assert "dispatch" in cands, cands

--- a/tests/unit/test_codegraph_context_tool.py
+++ b/tests/unit/test_codegraph_context_tool.py
@@ -1581,7 +1581,9 @@ def test_snake_or_camel_path_components_do_not_anchor_filter() -> None:
     assert "dispatch" in _extract_symbol_candidates(
         "find dispatch in tree_sitter_analyzer/mcp_tools.py"
     )
-    assert "dispatch" in _extract_symbol_candidates("find dispatch in src/UserService.py")
+    assert "dispatch" in _extract_symbol_candidates(
+        "find dispatch in src/UserService.py"
+    )
     # control: a genuine snake_case symbol (not in a path) DOES anchor + drop bare verb
     assert "dispatch" not in _extract_symbol_candidates(
         "how does resolve_callee dispatch a call"

--- a/tests/unit/test_codegraph_context_tool.py
+++ b/tests/unit/test_codegraph_context_tool.py
@@ -1453,3 +1453,33 @@ def test_entry_point_ranked_before_high_degree_noise(tmp_path: Path) -> None:
     # only ONE block slot — the entry must win it.
     blocks = _build_code_blocks([noise, entry], edges, 1, str(tmp_path))
     assert [b["name"] for b in blocks] == ["answer"], blocks
+
+
+def test_generic_verbs_dropped_when_specific_candidate_present() -> None:
+    """RFC-0009 C: a bare generic verb ('dispatch') is dropped from candidates
+    when the task also names a specific snake_case/CamelCase symbol — it only
+    matches unrelated event dispatchers and wastes entry-point slots. The old
+    tokeniser kept it (RED)."""
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        _extract_symbol_candidates,
+    )
+
+    cands = _extract_symbol_candidates(
+        "how does resolve_callee dispatch a Java call to resolve_java_callee"
+    )
+    assert "dispatch" not in cands, cands
+    # the specific symbols the task is actually about are preserved
+    assert "resolve_callee" in cands
+    assert "resolve_java_callee" in cands
+
+
+def test_generic_verb_kept_when_sole_signal() -> None:
+    """RFC-0009 C is conservative: when a generic verb is the ONLY signal (no
+    specific symbol named), it is KEPT so 'find the dispatch function' still
+    resolves to the dispatch symbol."""
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        _extract_symbol_candidates,
+    )
+
+    cands = _extract_symbol_candidates("find the dispatch function")
+    assert "dispatch" in cands, cands

--- a/tests/unit/test_codegraph_context_tool.py
+++ b/tests/unit/test_codegraph_context_tool.py
@@ -1483,3 +1483,16 @@ def test_generic_verb_kept_when_sole_signal() -> None:
 
     cands = _extract_symbol_candidates("find the dispatch function")
     assert "dispatch" in cands, cands
+
+
+def test_quoted_generic_verb_is_kept_as_explicit_symbol() -> None:
+    """RFC-0009 C / Codex P2 #333: a generic verb the user QUOTED (`` `dispatch` ``)
+    is an explicit symbol name and must survive the generic-verb filter even when
+    a snake_case symbol co-occurs — only BARE generic verbs are dropped."""
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        _extract_symbol_candidates,
+    )
+
+    cands = _extract_symbol_candidates("trace resolve_callee through `dispatch`")
+    assert "dispatch" in cands, cands
+    assert "resolve_callee" in cands

--- a/tests/unit/test_codegraph_context_tool.py
+++ b/tests/unit/test_codegraph_context_tool.py
@@ -1567,3 +1567,22 @@ def test_file_path_does_not_anchor_filter() -> None:
         "find the dispatch function in src/parser/utils.py"
     )
     assert "dispatch" in cands, cands
+
+
+def test_snake_or_camel_path_components_do_not_anchor_filter() -> None:
+    """RFC-0009 C / Codex P2 #333 (7th round): a file path whose components are
+    snake_case/CamelCase ('tree_sitter_analyzer/mcp_tools.py', 'src/UserService.py')
+    must NOT count those components as symbol anchors — they are scope/location —
+    so a bare verb that is the user's real request survives."""
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        _extract_symbol_candidates,
+    )
+
+    assert "dispatch" in _extract_symbol_candidates(
+        "find dispatch in tree_sitter_analyzer/mcp_tools.py"
+    )
+    assert "dispatch" in _extract_symbol_candidates("find dispatch in src/UserService.py")
+    # control: a genuine snake_case symbol (not in a path) DOES anchor + drop bare verb
+    assert "dispatch" not in _extract_symbol_candidates(
+        "how does resolve_callee dispatch a call"
+    )

--- a/tests/unit/test_codegraph_context_tool.py
+++ b/tests/unit/test_codegraph_context_tool.py
@@ -1511,3 +1511,28 @@ def test_qualified_generic_method_is_kept() -> None:
     assert "handle" in cands, cands
     assert "fetch" in cands, cands
     assert "UserService" in cands
+
+
+def test_non_dot_qualified_generic_methods_are_kept() -> None:
+    """RFC-0009 C / Codex P2 #333 (3rd round): C++/Rust/PHP-style qualifiers
+    (``Class::handle``, ``obj->fetch``) and called verbs (``dispatch()``) name a
+    method explicitly and must survive the generic-verb filter, just like dot
+    qualifiers and quotes. One post-hoc check against the task text covers all
+    qualifier syntaxes."""
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        _extract_symbol_candidates,
+    )
+
+    assert "handle" in _extract_symbol_candidates(
+        "trace MyClass::handle alongside resolve_callee"
+    )
+    assert "fetch" in _extract_symbol_candidates(
+        "trace obj->fetch alongside resolve_callee"
+    )
+    assert "dispatch" in _extract_symbol_candidates(
+        "does resolve_callee invoke dispatch() here"
+    )
+    # bare prose verb is still dropped when a specific symbol co-occurs
+    assert "dispatch" not in _extract_symbol_candidates(
+        "how does resolve_callee dispatch a Java call to resolve_java_callee"
+    )

--- a/tests/unit/test_codegraph_context_tool.py
+++ b/tests/unit/test_codegraph_context_tool.py
@@ -1532,6 +1532,10 @@ def test_non_dot_qualified_generic_methods_are_kept() -> None:
     assert "dispatch" in _extract_symbol_candidates(
         "does resolve_callee invoke dispatch() here"
     )
+    # Go/path-style qualifier (slash) also counts as explicit
+    assert "parse" in _extract_symbol_candidates(
+        "trace pkg/parser/parse alongside resolve_callee"
+    )
     # bare prose verb is still dropped when a specific symbol co-occurs
     assert "dispatch" not in _extract_symbol_candidates(
         "how does resolve_callee dispatch a Java call to resolve_java_callee"

--- a/tests/unit/test_codegraph_context_tool.py
+++ b/tests/unit/test_codegraph_context_tool.py
@@ -1496,3 +1496,18 @@ def test_quoted_generic_verb_is_kept_as_explicit_symbol() -> None:
     cands = _extract_symbol_candidates("trace resolve_callee through `dispatch`")
     assert "dispatch" in cands, cands
     assert "resolve_callee" in cands
+
+
+def test_qualified_generic_method_is_kept() -> None:
+    """RFC-0009 C / Codex P2 #333 (re-review): a generic verb that is the METHOD
+    of a qualified symbol (``UserService.handle``, ``Database.fetch``) is named
+    deliberately and must survive the filter — the tokenizer splits the qualified
+    token, so the method part must count as explicit, not bare."""
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        _extract_symbol_candidates,
+    )
+
+    cands = _extract_symbol_candidates("trace UserService.handle to Database.fetch")
+    assert "handle" in cands, cands
+    assert "fetch" in cands, cands
+    assert "UserService" in cands

--- a/tests/unit/test_codegraph_context_tool.py
+++ b/tests/unit/test_codegraph_context_tool.py
@@ -1588,3 +1588,19 @@ def test_snake_or_camel_path_components_do_not_anchor_filter() -> None:
     assert "dispatch" not in _extract_symbol_candidates(
         "how does resolve_callee dispatch a call"
     )
+
+
+def test_windows_path_components_do_not_anchor_filter() -> None:
+    """RFC-0009 C / Codex P2 #333 (8th round): Windows-style paths (backslash
+    separators, drive letters) must be recognised as paths too, so their
+    snake_case/CamelCase directory components don't anchor the filter."""
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        _extract_symbol_candidates,
+    )
+
+    assert "dispatch" in _extract_symbol_candidates(
+        r"find dispatch in src\tree_sitter_analyzer\mcp_tools.py"
+    )
+    assert "dispatch" in _extract_symbol_candidates(
+        r"find dispatch in C:\repo\src\UserService\handler.py"
+    )

--- a/tests/unit/test_codegraph_context_tool.py
+++ b/tests/unit/test_codegraph_context_tool.py
@@ -1540,3 +1540,19 @@ def test_non_dot_qualified_generic_methods_are_kept() -> None:
     assert "dispatch" not in _extract_symbol_candidates(
         "how does resolve_callee dispatch a Java call to resolve_java_callee"
     )
+
+
+def test_lowercase_qualified_anchor_still_drops_bare_verb() -> None:
+    """RFC-0009 C / Codex P2 #333 (5th round): when the only anchor is an
+    explicitly-named ALL-LOWERCASE symbol (``pkg/parser/parse``), the filter must
+    still run and drop a co-occurring bare prose verb. The guard counts
+    explicitly-named tokens as anchors, not just snake_case/CamelCase ones."""
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        _extract_symbol_candidates,
+    )
+
+    cands = _extract_symbol_candidates("trace pkg/parser/parse dispatch")
+    assert "parse" in cands, cands
+    assert "dispatch" not in cands, cands
+    # sole-signal control: no anchor at all -> nothing dropped
+    assert "dispatch" in _extract_symbol_candidates("find the dispatch function")

--- a/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
@@ -596,19 +596,9 @@ def _extract_symbol_candidates(task: str) -> list[str]:
     )
     seen: set[str] = set()
     out: list[str] = []
-    explicit: set[str] = set()
     for raw in tokens:
-        # A token is EXPLICIT (the user named it deliberately) when it is either
-        # quoted (`` `dispatch` ``, Codex P2 #333) OR part of a qualified symbol
-        # (`UserService.handle` → the method `handle` is named, Codex P2 #333).
-        # Explicit tokens count as specific and are never dropped by the C filter
-        # below — only truly BARE generic verbs are. The regex captures quotes, so
-        # detect before strip; a qualified token is one whose raw splits into >1.
-        was_quoted = bool(raw) and raw[0] in "`\"'"
         raw = raw.strip("`\"'")
-        parts = re.split(r"[.:\->]+", raw)
-        is_qualified = len([p for p in parts if p.strip("_.,;:!?()[]{}")]) > 1
-        for part in parts:
+        for part in re.split(r"[.:\->]+", raw):
             token = part.strip("_.,;:!?()[]{}")
             if not token:
                 continue
@@ -619,23 +609,39 @@ def _extract_symbol_candidates(task: str) -> list[str]:
                 "_" in token or any(ch.isupper() for ch in token) or len(token) >= 4
             ):
                 continue
-            if was_quoted or is_qualified:
-                explicit.add(token)
             if token not in seen:
                 seen.add(token)
                 out.append(token)
 
-    # RFC-0009 C: when the task names a specific symbol (snake_case / CamelCase /
-    # explicitly quoted / qualified method), drop bare generic-verb candidates
-    # ("dispatch", "handle") — they only match unrelated event dispatchers /
-    # handlers and waste entry-point slots. Keep them when they are the ONLY
-    # signal, when quoted, or when qualified (e.g. UserService.handle).
+    # RFC-0009 C: when the task names a specific symbol (snake_case / CamelCase),
+    # drop bare generic-verb candidates ("dispatch", "handle") — they only match
+    # unrelated event dispatchers / handlers and waste entry-point slots. Keep
+    # them when they are the ONLY signal, OR when the user named one EXPLICITLY in
+    # the task — quoted (`` `dispatch` ``), qualified (``Foo.handle``, ``C::handle``,
+    # ``obj->fetch``), or called (``dispatch(``). We check the original task text
+    # rather than the fragmented tokens because the tokeniser regex already splits
+    # on ``::`` / ``->`` (Codex P2 #333, three rounds: quoted, dot-qualified, then
+    # ``::`` / ``->`` qualified — one robust check now covers all qualifier syntaxes).
     def _is_specific(tok: str) -> bool:
-        return "_" in tok or any(ch.isupper() for ch in tok) or tok in explicit
+        return "_" in tok or any(ch.isupper() for ch in tok)
+
+    def _named_explicitly(verb: str) -> bool:
+        pattern = (
+            r"(?:[`'\"]|\.|::|->)\s*"
+            + re.escape(verb)
+            + r"\b|\b"
+            + re.escape(verb)
+            + r"\s*\("
+        )
+        return bool(re.search(pattern, task, re.IGNORECASE))
 
     if any(_is_specific(tok) for tok in out):
         out = [
-            tok for tok in out if _is_specific(tok) or tok.lower() not in _GENERIC_VERBS
+            tok
+            for tok in out
+            if _is_specific(tok)
+            or tok.lower() not in _GENERIC_VERBS
+            or _named_explicitly(tok)
         ]
     return out
 

--- a/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
@@ -626,8 +626,13 @@ def _extract_symbol_candidates(task: str) -> list[str]:
         return "_" in tok or any(ch.isupper() for ch in tok)
 
     def _named_explicitly(verb: str) -> bool:
+        # A generic verb is "named explicitly" (and kept) when it is preceded by a
+        # quote or any qualifier separator — ``.`` (Foo.handle), ``::`` (C++/Rust
+        # Parser::parse), ``->`` (obj->fetch), or ``/`` (Go/path pkg/parser/parse)
+        # — or when it is called (``verb(``). One check over the raw task covers
+        # every qualifier syntax the tokeniser regex fragments (Codex P2 #333).
         pattern = (
-            r"(?:[`'\"]|\.|::|->)\s*"
+            r"(?:[`'\"]|\.|::|->|/)\s*"
             + re.escape(verb)
             + r"\b|\b"
             + re.escape(verb)

--- a/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
@@ -640,7 +640,12 @@ def _extract_symbol_candidates(task: str) -> list[str]:
         )
         return bool(re.search(pattern, task, re.IGNORECASE))
 
-    if any(_is_specific(tok) for tok in out):
+    # The filter only runs when the task has a strong anchor — a specific symbol
+    # (snake_case/CamelCase) OR an explicitly-named one (quoted/qualified/called),
+    # even if all-lowercase (Codex P2 #333, 5th round: ``trace pkg/parser/parse
+    # dispatch`` anchors on the qualified ``parse`` yet has no _is_specific token,
+    # so the bare prose ``dispatch`` must still be droppable).
+    if any(_is_specific(tok) or _named_explicitly(tok) for tok in out):
         out = [
             tok
             for tok in out

--- a/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
@@ -45,17 +45,21 @@ _GENERIC_VERBS = frozenset(
 # src/parser/utils.py", "tree_sitter_analyzer/mcp_tools.py") is location, NOT a
 # symbol request — but its components ("parser", "tree_sitter_analyzer",
 # "UserService") otherwise look like specific anchors and wrongly trigger the
-# generic-verb filter, dropping the user's real bare verb (Codex #333 6th/7th
-# rounds). This matches a whitespace token that contains ``/`` or ends in a code
-# file extension; its components are excluded from anchor detection.
+# generic-verb filter, dropping the user's real bare verb (Codex #333 6th/7th/8th
+# rounds). This matches a whitespace token that contains a path separator (``/``
+# OR Windows ``\``) or ends in a code file extension; its components are excluded
+# from anchor detection.
 _CODE_FILE_EXT = (
     "py|pyi|js|jsx|ts|tsx|go|rs|java|kt|kts|c|h|hpp|cpp|cc|cs|rb|php|swift|"
     "scala|m|mm|sh|sql|lua|dart|ex|exs|clj|hs|ml"
 )
 _PATH_FRAGMENT_RE = re.compile(
-    rf"[\w.\-]*/[\w./\-]*|\b[\w\-]+\.(?:{_CODE_FILE_EXT})\b",
+    rf"[\w.\-]*[\\/][\w.\\/\-]*|\b[\w\-]+\.(?:{_CODE_FILE_EXT})\b",
     re.IGNORECASE,
 )
+# Separators a path fragment is split into components on: ``/`` ``\`` ``.`` ``:``
+# (drive letters) and ``-``.
+_PATH_COMPONENT_SPLIT = re.compile(r"[\\/.:\-]+")
 
 # Inline-body cap per code block for TANGENTIAL nodes (pulled in by call-graph
 # expansion, not the task's named symbols). These get signature + head; the agent
@@ -667,7 +671,7 @@ def _extract_symbol_candidates(task: str) -> list[str]:
     # the filter run and drop the user's real bare verb.
     path_tokens: set[str] = set()
     for match in _PATH_FRAGMENT_RE.finditer(task):
-        for part in re.split(r"[/.\-]+", match.group(0)):
+        for part in _PATH_COMPONENT_SPLIT.split(match.group(0)):
             cleaned = part.strip("_")
             if cleaned:
                 path_tokens.add(part)

--- a/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
@@ -41,6 +41,22 @@ _GENERIC_VERBS = frozenset(
     "lookup parse load store update fetch".split()
 )
 
+# RFC-0009 C: a file path mentioned to SCOPE a task ("find dispatch in
+# src/parser/utils.py", "tree_sitter_analyzer/mcp_tools.py") is location, NOT a
+# symbol request — but its components ("parser", "tree_sitter_analyzer",
+# "UserService") otherwise look like specific anchors and wrongly trigger the
+# generic-verb filter, dropping the user's real bare verb (Codex #333 6th/7th
+# rounds). This matches a whitespace token that contains ``/`` or ends in a code
+# file extension; its components are excluded from anchor detection.
+_CODE_FILE_EXT = (
+    "py|pyi|js|jsx|ts|tsx|go|rs|java|kt|kts|c|h|hpp|cpp|cc|cs|rb|php|swift|"
+    "scala|m|mm|sh|sql|lua|dart|ex|exs|clj|hs|ml"
+)
+_PATH_FRAGMENT_RE = re.compile(
+    rf"[\w.\-]*/[\w./\-]*|\b[\w\-]+\.(?:{_CODE_FILE_EXT})\b",
+    re.IGNORECASE,
+)
+
 # Inline-body cap per code block for TANGENTIAL nodes (pulled in by call-graph
 # expansion, not the task's named symbols). These get signature + head; the agent
 # rarely needs their full body, so RFC-0006's thrift is preserved where it costs
@@ -645,12 +661,31 @@ def _extract_symbol_candidates(task: str) -> list[str]:
         )
         return bool(re.search(pattern, task, re.IGNORECASE))
 
+    # Components of any file PATH mentioned to scope the task are location, not
+    # symbol anchors (Codex #333 6th/7th rounds) — exclude them so a path like
+    # ``src/UserService.py`` or ``tree_sitter_analyzer/mcp_tools.py`` does not make
+    # the filter run and drop the user's real bare verb.
+    path_tokens: set[str] = set()
+    for match in _PATH_FRAGMENT_RE.finditer(task):
+        for part in re.split(r"[/.\-]+", match.group(0)):
+            cleaned = part.strip("_")
+            if cleaned:
+                path_tokens.add(part)
+                path_tokens.add(cleaned)
+
+    def _is_anchor(tok: str) -> bool:
+        # A real anchor is a specific/explicit symbol that is NOT merely a file
+        # path component.
+        if tok in path_tokens:
+            return False
+        return _is_specific(tok) or _named_explicitly(tok)
+
     # The filter only runs when the task has a strong anchor — a specific symbol
     # (snake_case/CamelCase) OR an explicitly-named one (quoted/qualified/called),
-    # even if all-lowercase (Codex P2 #333, 5th round: ``trace pkg/parser/parse
-    # dispatch`` anchors on the qualified ``parse`` yet has no _is_specific token,
-    # so the bare prose ``dispatch`` must still be droppable).
-    if any(_is_specific(tok) or _named_explicitly(tok) for tok in out):
+    # even if all-lowercase (Codex P2 #333, 5th round: ``trace obj->parse dispatch``
+    # anchors on the qualified ``parse`` yet has no _is_specific token, so the bare
+    # prose ``dispatch`` must still be droppable).
+    if any(_is_anchor(tok) for tok in out):
         out = [
             tok
             for tok in out

--- a/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
@@ -596,7 +596,13 @@ def _extract_symbol_candidates(task: str) -> list[str]:
     )
     seen: set[str] = set()
     out: list[str] = []
+    quoted: set[str] = set()
     for raw in tokens:
+        # A token written in back-ticks / quotes is an EXPLICIT symbol name the
+        # user chose deliberately — even a lowercase generic verb (`` `dispatch` ``)
+        # should then count as specific and never be dropped by the C filter below
+        # (Codex P2 #333). The regex captures the quotes, so detect before strip.
+        was_quoted = bool(raw) and raw[0] in "`\"'"
         raw = raw.strip("`\"'")
         for part in re.split(r"[.:\->]+", raw):
             token = part.strip("_.,;:!?()[]{}")
@@ -609,16 +615,19 @@ def _extract_symbol_candidates(task: str) -> list[str]:
                 "_" in token or any(ch.isupper() for ch in token) or len(token) >= 4
             ):
                 continue
+            if was_quoted:
+                quoted.add(token)
             if token not in seen:
                 seen.add(token)
                 out.append(token)
 
-    # RFC-0009 C: when the task names a specific symbol (snake_case / CamelCase),
-    # drop bare generic-verb candidates ("dispatch", "handle") — they only match
-    # unrelated event dispatchers / handlers and waste entry-point slots. Keep
-    # them when they are the ONLY signal (no specific candidate present).
+    # RFC-0009 C: when the task names a specific symbol (snake_case / CamelCase /
+    # explicitly quoted), drop bare generic-verb candidates ("dispatch", "handle")
+    # — they only match unrelated event dispatchers / handlers and waste
+    # entry-point slots. Keep them when they are the ONLY signal (no specific
+    # candidate present) or when the user quoted them explicitly.
     def _is_specific(tok: str) -> bool:
-        return "_" in tok or any(ch.isupper() for ch in tok)
+        return "_" in tok or any(ch.isupper() for ch in tok) or tok in quoted
 
     if any(_is_specific(tok) for tok in out):
         out = [

--- a/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
@@ -596,15 +596,19 @@ def _extract_symbol_candidates(task: str) -> list[str]:
     )
     seen: set[str] = set()
     out: list[str] = []
-    quoted: set[str] = set()
+    explicit: set[str] = set()
     for raw in tokens:
-        # A token written in back-ticks / quotes is an EXPLICIT symbol name the
-        # user chose deliberately — even a lowercase generic verb (`` `dispatch` ``)
-        # should then count as specific and never be dropped by the C filter below
-        # (Codex P2 #333). The regex captures the quotes, so detect before strip.
+        # A token is EXPLICIT (the user named it deliberately) when it is either
+        # quoted (`` `dispatch` ``, Codex P2 #333) OR part of a qualified symbol
+        # (`UserService.handle` → the method `handle` is named, Codex P2 #333).
+        # Explicit tokens count as specific and are never dropped by the C filter
+        # below — only truly BARE generic verbs are. The regex captures quotes, so
+        # detect before strip; a qualified token is one whose raw splits into >1.
         was_quoted = bool(raw) and raw[0] in "`\"'"
         raw = raw.strip("`\"'")
-        for part in re.split(r"[.:\->]+", raw):
+        parts = re.split(r"[.:\->]+", raw)
+        is_qualified = len([p for p in parts if p.strip("_.,;:!?()[]{}")]) > 1
+        for part in parts:
             token = part.strip("_.,;:!?()[]{}")
             if not token:
                 continue
@@ -615,19 +619,19 @@ def _extract_symbol_candidates(task: str) -> list[str]:
                 "_" in token or any(ch.isupper() for ch in token) or len(token) >= 4
             ):
                 continue
-            if was_quoted:
-                quoted.add(token)
+            if was_quoted or is_qualified:
+                explicit.add(token)
             if token not in seen:
                 seen.add(token)
                 out.append(token)
 
     # RFC-0009 C: when the task names a specific symbol (snake_case / CamelCase /
-    # explicitly quoted), drop bare generic-verb candidates ("dispatch", "handle")
-    # — they only match unrelated event dispatchers / handlers and waste
-    # entry-point slots. Keep them when they are the ONLY signal (no specific
-    # candidate present) or when the user quoted them explicitly.
+    # explicitly quoted / qualified method), drop bare generic-verb candidates
+    # ("dispatch", "handle") — they only match unrelated event dispatchers /
+    # handlers and waste entry-point slots. Keep them when they are the ONLY
+    # signal, when quoted, or when qualified (e.g. UserService.handle).
     def _is_specific(tok: str) -> bool:
-        return "_" in tok or any(ch.isupper() for ch in tok) or tok in quoted
+        return "_" in tok or any(ch.isupper() for ch in tok) or tok in explicit
 
     if any(_is_specific(tok) for tok in out):
         out = [

--- a/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
@@ -627,12 +627,17 @@ def _extract_symbol_candidates(task: str) -> list[str]:
 
     def _named_explicitly(verb: str) -> bool:
         # A generic verb is "named explicitly" (and kept) when it is preceded by a
-        # quote or any qualifier separator — ``.`` (Foo.handle), ``::`` (C++/Rust
-        # Parser::parse), ``->`` (obj->fetch), or ``/`` (Go/path pkg/parser/parse)
-        # — or when it is called (``verb(``). One check over the raw task covers
-        # every qualifier syntax the tokeniser regex fragments (Codex P2 #333).
+        # quote or an unambiguous symbol-member operator — ``.`` (Foo.handle),
+        # ``::`` (C++/Rust Parser::parse), ``->`` (obj->fetch) — or when it is
+        # called (``verb(``). NOTE: ``/`` is deliberately NOT a qualifier here.
+        # It was tried (Codex #333 4th round, for Go-style pkg/parser/parse) but
+        # ``/`` is dominantly a FILE-PATH separator in real tasks, so it made an
+        # ordinary path like ``src/parser/utils.py`` anchor the filter and wrongly
+        # drop the user's actual bare verb in e.g. "find the dispatch function in
+        # src/parser/utils.py" (Codex #333 6th round — the common case wins over
+        # the rare package-qualified-symbol case).
         pattern = (
-            r"(?:[`'\"]|\.|::|->|/)\s*"
+            r"(?:[`'\"]|\.|::|->)\s*"
             + re.escape(verb)
             + r"\b|\b"
             + re.escape(verb)

--- a/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
@@ -26,6 +26,21 @@ _STOP_WORDS = frozenset(
     "or through to trace what when where which why with work works".split()
 )
 
+# RFC-0009 C: generic single-word verbs that frequently appear in trace questions
+# ("how does X dispatch / handle a request") but ALSO name many unrelated symbols
+# (event dispatchers, request handlers). When the task carries a more specific
+# candidate (a snake_case / CamelCase / quoted symbol), these BARE verbs are
+# dropped — they only spend entry-point slots on wrong symbols. They are KEPT
+# when they are the only signal in the task, so "find the dispatch function"
+# still works. Conservative: precision over recall on entry-point selection.
+# Note: snake_case/CamelCase names like ``resolve_callee`` are NOT affected —
+# only bare lowercase verb tokens match this set.
+_GENERIC_VERBS = frozenset(
+    "dispatch dispatcher handle handler process processor run runner execute "
+    "executor get set send receive emit notify invoke route resolve register "
+    "lookup parse load store update fetch".split()
+)
+
 # Inline-body cap per code block for TANGENTIAL nodes (pulled in by call-graph
 # expansion, not the task's named symbols). These get signature + head; the agent
 # rarely needs their full body, so RFC-0006's thrift is preserved where it costs
@@ -597,6 +612,18 @@ def _extract_symbol_candidates(task: str) -> list[str]:
             if token not in seen:
                 seen.add(token)
                 out.append(token)
+
+    # RFC-0009 C: when the task names a specific symbol (snake_case / CamelCase),
+    # drop bare generic-verb candidates ("dispatch", "handle") — they only match
+    # unrelated event dispatchers / handlers and waste entry-point slots. Keep
+    # them when they are the ONLY signal (no specific candidate present).
+    def _is_specific(tok: str) -> bool:
+        return "_" in tok or any(ch.isupper() for ch in tok)
+
+    if any(_is_specific(tok) for tok in out):
+        out = [
+            tok for tok in out if _is_specific(tok) or tok.lower() not in _GENERIC_VERBS
+        ]
     return out
 
 


### PR DESCRIPTION
Completes [RFC-0009](https://github.com/aimasteracc/tree-sitter-analyzer/blob/develop/rfcs/0009-nav-context-self-sufficiency.md)'s third root-cause fix (A + B landed in #331).

## Problem (root cause C)
`nav context`'s tokeniser turned bare generic verbs (`dispatch`, `handle`, `run`) into entry-point candidates, which matched unrelated event dispatchers / request handlers and spent code-block slots on wrong symbols. The dogfood `resolve_callee dispatch → resolve_java_callee` surfaced `health_notifier.dispatch` + `file_watcher` dispatchers as noise.

## Fix
When the task ALSO names a specific symbol (snake_case / CamelCase), drop bare generic-verb candidates. Keep them when they're the ONLY signal (`find the dispatch function` still resolves). Conservative — snake_case/CamelCase names are never affected.

| task | candidates |
|---|---|
| `resolve_callee dispatch → resolve_java_callee` | dispatch **dropped**, resolve_callee/resolve_java_callee kept |
| `find the dispatch function` | dispatch **kept** (sole signal) |
| `UserService … handle … Database` | handle **dropped**, anchors kept |

## Test plan (RED-first)
- [x] `test_generic_verbs_dropped_when_specific_candidate_present` (RED on old tokeniser)
- [x] `test_generic_verb_kept_when_sole_signal` (conservative guard)
- [x] 44 context tests pass; ruff + mypy clean

RFC-0009 A/B/C now all landed; remaining = the n≥5 benchmark turn-drop measurement (unblocked by #332 run-id fix).