### PR TITLE
feat(mcp): invalid facade action errors enumerate the valid actions

### DIFF
--- a/tests/unit/mcp/tools/test_facade_tool.py
+++ b/tests/unit/mcp/tools/test_facade_tool.py
@@ -267,6 +267,22 @@ def test_unknown_action_returns_error_envelope() -> None:
     assert "symbol" in str(result)
 
 
+def test_unknown_action_error_string_enumerates_valid_actions() -> None:
+    """F4 DX: the bare ``error`` string itself (not just the envelope's
+    ``available_actions`` list) must enumerate the sorted valid actions so an
+    agent that only logs the message can still recover without a wasted turn."""
+    facade = _make_facade()
+    result = asyncio.run(facade.execute({"action": "nope", "query": "Foo"}))
+    error = result["error"]
+    # The unknown action that was supplied is echoed back...
+    assert "nope" in error
+    # ...and the sorted list of valid actions appears verbatim in the message.
+    assert "func" in error
+    assert "symbol" in error
+    # Sorted order is part of the contract (stable, scannable).
+    assert error.index("func") < error.index("symbol")
+
+
 # --------------------------------------------------------------------------
 # G3 rebind propagation
 # --------------------------------------------------------------------------

--- a/tree_sitter_analyzer/mcp/tools/facade_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/facade_tool.py
@@ -303,7 +303,11 @@ class FacadeTool(BaseMCPTool):
             projected = self._project_args(inner, arguments)
             return await inner.execute(projected)
 
-        return self._action_error(f"unknown action {action!r}")
+        available = self._available_actions()
+        valid = ", ".join(available) if available else "(none registered)"
+        return self._action_error(
+            f"unknown action {action!r}; valid actions are: {valid}"
+        )
 
     # -- schema / definition ----------------------------------------------
 


### PR DESCRIPTION
## What

When an MCP facade (nav/search/structure/health/edit/project/index/viz) receives an unknown `action`, the `error` **string** now enumerates the sorted valid actions:

```
unknown action 'nope'; valid actions are: callees, callers, call_path, context, ...
```

Previously the message was a bare `unknown action 'nope'`. The error envelope already carried `available_actions` and an `agent_summary.next_step` hint, but an agent that only logs/reads the `error` string got no recovery hint and wasted a turn (dogfood finding **F4**).

## Why

High-DX, low-risk. Agents that guess a wrong action immediately see the valid set in the message itself, no extra round-trip.

## Scope

- `tree_sitter_analyzer/mcp/tools/facade_tool.py`: the central unknown-action dispatch path in `FacadeTool.execute` now builds the message from `_available_actions()` (sorted union of `action_map` + `bespoke_map` keys). `validate_arguments` already enumerated actions; this brings the runtime-dispatch path to parity.
- No change to TOON defaults, `BaseMCPTool.__init__`, PathResolver, SecurityValidator, or the plugin registry.

## Test plan (RED-first)

- Added `test_unknown_action_error_string_enumerates_valid_actions`: asserts the supplied action is echoed and the sorted valid-action list (`func` before `symbol`) appears verbatim in `result["error"]`.
- Verified RED by reverting the impl (test fails: bare message lacks the action list), then GREEN.
- Full `tests/unit/mcp/tools/test_facade_tool.py` — 19 passed.
- `ruff check` + `ruff format --check` + `mypy` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)