### PR TITLE
refactor: single-source constants.EXCLUDE_DIRS for vendored/cache dir exclusion

### DIFF
--- a/tests/unit/test_dead_code_analyzer.py
+++ b/tests/unit/test_dead_code_analyzer.py
@@ -330,3 +330,50 @@ def test_excludes_dot_prefixed_vendored_dirs(tmp_path):
     assert not any(".benchmark-repos" in i.file.replace("\\", "/") for i in imports), [
         i.file for i in imports
     ]
+
+
+# ---------------------------------------------------------------------------
+# Canonical EXCLUDE_DIRS single-source (centralize-exclude-dirs)
+# ---------------------------------------------------------------------------
+
+
+def test_exclude_dirs_is_canonical_constant() -> None:
+    """dead_code_analyzer must source its excluded-dir set from the single
+    canonical ``constants.EXCLUDE_DIRS`` rather than defining its own private
+    copy that can drift. The module-level name must BE the canonical object."""
+    from tree_sitter_analyzer import dead_code_analyzer
+    from tree_sitter_analyzer.constants import EXCLUDE_DIRS
+
+    assert dead_code_analyzer._EXCLUDE_DIRS is EXCLUDE_DIRS
+
+
+def test_exclude_dirs_covers_previously_excluded_dirs() -> None:
+    """Migrating to the canonical constant must not lose any directory that
+    dead_code_analyzer previously excluded — the canonical set is the union,
+    so every historical entry is still covered (behavior unchanged)."""
+    from tree_sitter_analyzer.dead_code_analyzer import _EXCLUDE_DIRS
+
+    # The exact set dead_code_analyzer carried before centralization.
+    previously_excluded = {
+        "node_modules",
+        ".git",
+        "__pycache__",
+        ".venv",
+        "venv",
+        ".tox",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        "dist",
+        "build",
+        "htmlcov",
+        ".cache",
+        ".eggs",
+        ".idea",
+        ".vscode",
+        ".claude",
+    }
+    missing = previously_excluded - set(_EXCLUDE_DIRS)
+    assert not missing, (
+        f"canonical EXCLUDE_DIRS dropped previously-excluded dirs: {missing}"
+    )

--- a/tree_sitter_analyzer/dead_code_analyzer.py
+++ b/tree_sitter_analyzer/dead_code_analyzer.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from typing import Any
 
 from .call_graph import CachedCallGraph, CallGraph, FunctionRef
+from .constants import EXCLUDE_DIRS
 from .core.parser import Parser
 from .import_extractors import walk_imports
 from .project_graph import _language_from_ext
@@ -33,25 +34,14 @@ from .utils import setup_logger
 
 logger = setup_logger(__name__)
 
-_EXCLUDE_DIRS = {
-    "node_modules",
-    ".git",
-    "__pycache__",
-    ".venv",
-    "venv",
-    ".tox",
-    ".mypy_cache",
-    ".pytest_cache",
-    ".ruff_cache",
-    "dist",
-    "build",
-    "htmlcov",
-    ".cache",
-    ".eggs",
-    ".idea",
-    ".vscode",
-    ".claude",
-}
+# Single-source the excluded-dir set from the canonical ``constants.EXCLUDE_DIRS``
+# rather than carrying a private near-duplicate that drifts. The canonical set is
+# a strict superset of the dirs this module historically excluded, so every
+# previously-pruned tree is still pruned (behavior unchanged) — it just also
+# covers the vendored/build dirs (vendor, target, obj, Pods, ...) that this
+# walker should skip too. Dot-prefixed dirs are pruned separately via the
+# ``startswith(".")`` check in ``_iter_candidate_files``.
+_EXCLUDE_DIRS = EXCLUDE_DIRS
 
 
 def _iter_candidate_files(root: Path) -> Iterator[Path]:


### PR DESCRIPTION
## What

`dead_code_analyzer.py` defined its own private `_EXCLUDE_DIRS` set that duplicated — and was a strict subset of — the canonical `constants.EXCLUDE_DIRS` frozenset. This PR migrates the one consumer to import the canonical constant so the excluded-directory policy lives in **one** place and can't drift.

## Why

The set of vendored/cache/build dir names (`node_modules`, `.git`, `__pycache__`, `.venv`, `dist`, `build`, `.ast-cache`, ...) was duplicated. `constants.EXCLUDE_DIRS` already existed as the canonical source; `dead_code_analyzer` carried a near-duplicate. Single-sourcing prevents the two from diverging.

## Behavior

- The canonical set is a **strict superset** of the dirs `dead_code_analyzer` previously excluded, so every historical entry is still pruned — **behavior unchanged** for those dirs.
- It additionally covers vendored/build dirs the walker should already skip (`vendor`, `target`, `obj`, `Pods`, `out`, `bower_components`, ...).
- Dot-prefixed dirs remain pruned via the existing `startswith(".")` check in `_iter_candidate_files`.

## Scope guard

Only `dead_code_analyzer` (one consumer) is migrated to keep the diff focused and safe. `SecurityValidator` / `PathResolver` / `BaseMCPTool` / the plugin registry are **untouched** (CLAUDE.md locks).

## Tests (RED-first)

- `test_exclude_dirs_is_canonical_constant` — asserts `dead_code_analyzer._EXCLUDE_DIRS IS constants.EXCLUDE_DIRS`.
- `test_exclude_dirs_covers_previously_excluded_dirs` — asserts the canonical set still covers every dir the module historically excluded.

Verified RED (reverted impl → `is`-identity test fails), then GREEN. Full `tests/unit/test_dead_code_analyzer.py` (33 tests) passes. `ruff check` + `ruff format --check` + `mypy` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)