### PR TITLE
docs(mcp): surface the reactive-push + edges_by_kind differentiators

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,13 @@ The remaining ~4% `unknown` is dominated by genuinely-unresolvable dynamic dispa
 
 > **Symbol kinds, too.** TSA classifies class members as `kind=method` (20,348 method rows on this repo) — `search action=symbol kind=method` returns them; CodeGraph parity, not a stub. The `index status` payload breaks symbols down by kind and language and edges by kind (`edges_by_kind` — a breakdown CodeGraph does not surface).
 
+### Reactive push + edge-kind breakdown — two things CodeGraph can't do
+
+CodeGraph (and most one-shot indexers) only answer on poll: you ask, it replies with a snapshot, and you re-ask to learn whether anything changed. TSA exposes two capabilities that close that loop:
+
+- **Reactive push / subscription ([RFC-0001](rfcs/0001-reactive-push.md), implemented).** `search action=subscribe` registers a Hyphae selector and returns a `tsa://hyphae/{selector}` MCP resource URI. When the watched code changes, the server emits a resource-updated notification — the agent re-reads the resource instead of polling. `search action=unsubscribe` cancels it. CodeGraph has no push or subscription channel.
+- **`edges_by_kind` in `index action=status`.** Status returns a per-edge-kind count (calls / extends / implements / imports …), not just a single `total_edges` — so an agent can read the graph's shape (how call-heavy vs inheritance-heavy a repo is) before drilling in. CodeGraph surfaces only a flat total.
+
 Reproduce the correctness fixes on any repo both tools have indexed:
 
 ```bash

--- a/tests/e2e/test_mcp_smoke.py
+++ b/tests/e2e/test_mcp_smoke.py
@@ -75,6 +75,10 @@ class TestStartup:
         assert "action=callee_tree" in instructions
         assert "codegraph_symbol_search" not in instructions
         assert "codegraph_navigate" not in instructions
+        # CodeGraph-differentiator capabilities must stay advertised: reactive
+        # push (RFC-0001) and the per-edge-kind index breakdown.
+        assert "action=subscribe" in instructions
+        assert "edges_by_kind" in instructions
 
     def test_repeated_headless_initialize_stays_under_budget(
         self, mcp_server_factory: Any

--- a/tests/unit/mcp/test_server_helpers.py
+++ b/tests/unit/mcp/test_server_helpers.py
@@ -30,6 +30,13 @@ def test_build_initialization_options_includes_agent_routing_instructions():
     assert "codegraph_symbol_search" not in instructions
     assert "codegraph_navigate" not in instructions
 
+    # Differentiators vs CodeGraph that must stay legible in the routing map
+    # (docs-reactive-push-visibility): reactive push / subscription (RFC-0001)
+    # and the per-edge-kind breakdown in the index status output. If these
+    # mentions regress, agents lose the two capabilities CodeGraph lacks.
+    assert "action=subscribe" in instructions
+    assert "edges_by_kind" in instructions
+
     # The 8 real facade tools must never be described by a non-existent name.
     real_facades = {
         "search",

--- a/tree_sitter_analyzer/mcp/_server_helpers.py
+++ b/tree_sitter_analyzer/mcp/_server_helpers.py
@@ -67,8 +67,21 @@ The 8 tools: nav, search, structure, health, edit, project, index, viz.
 | Text/content search | search action=content |
 | Class/file structure, overview, signatures | structure |
 | Is the index ready / how big? | index action=status |
+| Edge-kind breakdown of the graph | index action=status (edges_by_kind) |
+| Get pushed when results change | search action=subscribe |
 | File / module dependency questions | nav action=impact / structure |
 | File discovery | project / search |
+
+## Differentiators (capabilities grep / one-shot indexers lack)
+
+- **Reactive push (RFC-0001)** — `search action=subscribe` registers a Hyphae
+  selector and hands back a `tsa://hyphae/{selector}` resource URI. When the
+  watched code changes, the server emits a resource-updated notification, so you
+  re-read the resource instead of re-querying on a poll. `search
+  action=unsubscribe` cancels it. This is live subscription, not a snapshot.
+- **`edges_by_kind`** — `index action=status` returns a per-edge-kind count
+  (calls / extends / implements / imports …), not just a single total. Use it to
+  see the graph's shape before drilling in.
 
 ## Default chain for "how does X work / trace a flow" (FOLLOW THIS)
 


### PR DESCRIPTION
## What & why

TSA has two real differentiators vs CodeGraph that were **not advertised** in the MCP server-instructions routing map or the README:

1. **Reactive push / subscription** — `search action=subscribe` / `unsubscribe` + the `tsa://hyphae/{selector}` resource ([RFC-0001](rfcs/0001-reactive-push.md), status=implemented). CodeGraph has no push/subscription channel.
2. **`edges_by_kind`** in `index action=status` — a per-edge-kind breakdown (calls / extends / implements / imports …), not just a flat total.

This PR makes both legible to agents and humans.

## Changes (docs / strings ONLY — no tool behavior change)

- `tree_sitter_analyzer/mcp/_server_helpers.py` — add a concise **Differentiators** section + two routing-table rows to the `## TSA MCP Routing` instructions string.
- `README.md` — add a short **"Reactive push + edge-kind breakdown"** subsection under *How TSA compares to CodeGraph*.
- `tests/unit/mcp/test_server_helpers.py` + `tests/e2e/test_mcp_smoke.py` — assert the live instructions contain `action=subscribe` and `edges_by_kind`, so the docs cannot silently regress.

## Verification

- RED-first: added the substring assertions, confirmed they fail on `develop`, then implemented; reverted the impl once to re-confirm RED, restored.
- `ruff check` + `ruff format --check` clean on touched files; `mypy` clean on `_server_helpers.py`.
- Green: `test_server_helpers`, `test_mcp_smoke::TestStartup::test_initialize_includes_agent_routing_instructions`, all `-k readme` tests (incl. README <500 lines + counts-match-registry), and `test_docs_links` (new RFC-0001 link validated).

Both differentiator claims were verified against the live code: `search action=subscribe`/`unsubscribe` route to `HyphaeSubscribeTool`/`HyphaeUnsubscribeTool` (RFC-0001), and `edges_by_kind` is emitted by `codegraph_status_tool`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)