### PR TITLE
feat(mcp): fuzzy "did you mean" suggestion on invalid facade action

### DIFF
--- a/tests/unit/mcp/tools/test_facade_tool.py
+++ b/tests/unit/mcp/tools/test_facade_tool.py
@@ -283,6 +283,38 @@ def test_unknown_action_error_string_enumerates_valid_actions() -> None:
     assert error.index("func") < error.index("symbol")
 
 
+def test_unknown_action_close_to_valid_suggests_did_you_mean() -> None:
+    """TURN-SAVER: a typo'd action close to a valid one self-heals in-band.
+
+    When the unknown action is a near-miss of a registered action
+    (e.g. ``symbl`` -> ``symbol``), the error message prepends a
+    ``did you mean: <closest>`` hint so an agent can correct the typo
+    without a wasted discovery turn. The full valid-action list is still
+    enumerated for the case where the suggestion is wrong."""
+    facade = _make_facade()
+    result = asyncio.run(facade.execute({"action": "symbl", "query": "Foo"}))
+    error = result["error"]
+    assert "did you mean: symbol" in error
+    # The full valid-action list is still present (suggestion is additive).
+    assert "func" in error
+    assert "symbol" in error
+    # The structured envelope also surfaces the suggestion for programmatic use.
+    assert result["suggestion"] == "symbol"
+
+
+def test_far_off_unknown_action_has_no_spurious_suggestion() -> None:
+    """A far-off action yields no ``did you mean`` hint (no false suggestion),
+    but still enumerates the valid actions."""
+    facade = _make_facade()
+    result = asyncio.run(facade.execute({"action": "zzqqxx", "query": "Foo"}))
+    error = result["error"]
+    assert "did you mean" not in error
+    # Valid actions are still listed so the agent can recover.
+    assert "func" in error
+    assert "symbol" in error
+    assert result.get("suggestion") is None
+
+
 # --------------------------------------------------------------------------
 # G3 rebind propagation
 # --------------------------------------------------------------------------

--- a/tree_sitter_analyzer/mcp/tools/facade_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/facade_tool.py
@@ -54,6 +54,7 @@ truth.
 
 from __future__ import annotations
 
+import difflib
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -255,15 +256,40 @@ class FacadeTool(BaseMCPTool):
     def _available_actions(self) -> list[str]:
         return sorted(set(self.action_map) | set(self.bespoke_map))
 
-    def _action_error(self, message: str) -> dict[str, Any]:
-        """Return a canonical error envelope listing available actions."""
-        available = self._available_actions()
-        summary_line = f"{self.facade_name}: {message}"
-        next_step = (
-            f"Set action to one of: {', '.join(available)}."
-            if available
-            else "No actions are registered on this facade."
+    def _closest_action(self, action: str) -> str | None:
+        """Return the single closest valid action to ``action`` (a likely
+        typo), or ``None`` when nothing is close enough.
+
+        Uses ``difflib.get_close_matches`` over the registered actions so a
+        near-miss like ``navigte`` self-heals to ``navigate`` in-band, saving
+        an agent a wasted discovery turn. A far-off action yields ``None`` (no
+        spurious suggestion)."""
+        matches = difflib.get_close_matches(
+            action, self._available_actions(), n=1, cutoff=0.6
         )
+        return matches[0] if matches else None
+
+    def _action_error(
+        self, message: str, suggestion: str | None = None
+    ) -> dict[str, Any]:
+        """Return a canonical error envelope listing available actions.
+
+        When ``suggestion`` is set (the closest valid action to a typo'd
+        unknown action), it is prepended to the ``error`` message as a
+        ``did you mean: <suggestion>`` hint and surfaced in the envelope under
+        ``suggestion`` for programmatic recovery. The full valid-action list is
+        still enumerated regardless, so a wrong suggestion never strands the
+        agent."""
+        available = self._available_actions()
+        if suggestion is not None:
+            message = f"did you mean: {suggestion}? {message}"
+        summary_line = f"{self.facade_name}: {message}"
+        if suggestion is not None:
+            next_step = f"Did you mean action {suggestion!r}? Else set action to one of: {', '.join(available)}."
+        elif available:
+            next_step = f"Set action to one of: {', '.join(available)}."
+        else:
+            next_step = "No actions are registered on this facade."
         return {
             "success": False,
             "verdict": "ERROR",
@@ -271,6 +297,7 @@ class FacadeTool(BaseMCPTool):
             "error": message,
             "facade": self.facade_name,
             "available_actions": available,
+            "suggestion": suggestion,
             "summary_line": summary_line,
             "agent_summary": {
                 "verdict": "ERROR",
@@ -305,8 +332,10 @@ class FacadeTool(BaseMCPTool):
 
         available = self._available_actions()
         valid = ", ".join(available) if available else "(none registered)"
+        suggestion = self._closest_action(action)
         return self._action_error(
-            f"unknown action {action!r}; valid actions are: {valid}"
+            f"unknown action {action!r}; valid actions are: {valid}",
+            suggestion=suggestion,
         )
 
     # -- schema / definition ----------------------------------------------


### PR DESCRIPTION
## What

When a facade `action` is unknown but a near-miss of a registered action (e.g. `action='navigte'` -> `navigate`, `action='symbl'` -> `symbol`), the error now prepends a `did you mean: <closest>` hint and surfaces it under a structured `suggestion` envelope key.

Builds directly on #334 (which made an invalid action *enumerate* the valid actions). This goes one step further: it self-heals an agent typo **in-band**, saving a wasted retry/discovery turn — a TURN-SAVER that attacks the turn-count cost driver.

## How

- New `FacadeTool._closest_action(action)` uses `difflib.get_close_matches(..., n=1, cutoff=0.6)` over the registered actions.
- `_action_error(message, suggestion=None)` prepends `did you mean: <suggestion>?` to the error message and adds `suggestion` to the envelope + `agent_summary.next_step`.
- The unknown-action dispatch branch computes the closest match and passes it through.
- The full valid-action list is **still enumerated** regardless, so a wrong suggestion never strands the agent.

## Behaviour

```
action='navigte' -> error: "did you mean: navigate? unknown action 'navigte'; valid actions are: ..."
                    suggestion: "navigate"
action='zzqqxx'  -> error: "unknown action 'zzqqxx'; valid actions are: ..."  (no spurious hint)
                    suggestion: None
```

## Tests (RED-first)

- `test_unknown_action_close_to_valid_suggests_did_you_mean` — near-miss yields the hint + full list + structured `suggestion`.
- `test_far_off_unknown_action_has_no_spurious_suggestion` — far-off action: no hint, list still present, `suggestion is None`.
- RED verified by reverting the implementation (the did-you-mean assertion fails for the right reason without it).
- All 204 facade tests pass; `ruff check` + `ruff format --check` clean; `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
