### PR TITLE
chore: correct pyproject description — 8 facade tools, drop disproven benchmark claim

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "tree-sitter-analyzer"
 version = "1.20.0"
-description = "MCP code-intelligence server for AI agents — beats CodeGraph on 6-repo head-to-head benchmark median. 63 MCP tools, 13 curated skills, TOON output, 100% local."
+description = "MCP code-intelligence server for AI agents — a more complete and more correct call graph with classified, cross-file edges. 8 facade MCP tools, 13 curated skills, TOON-compressed output, 100% local."
 readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "MIT"}

--- a/tests/integration/docs/test_pyproject_description_truth.py
+++ b/tests/integration/docs/test_pyproject_description_truth.py
@@ -44,8 +44,11 @@ def test_description_advertises_registry_tool_count() -> None:
     """The tool count in the description equals the registry-measured count."""
     description = _description()
     count = _registry_tool_count()
-    assert f"{count} facade MCP tools" in description, (
-        f"Description should advertise '{count} facade MCP tools'; got: {description!r}"
+    # Word-boundary match on the COUNT digit so a stale '18 facade MCP tools'
+    # cannot pass on the substring '8 facade MCP tools' (Codex P3 #339).
+    assert re.search(rf"\b{count} facade MCP tools\b", description), (
+        f"Description should advertise '{count} facade MCP tools' as a whole "
+        f"number; got: {description!r}"
     )
 
 

--- a/tests/integration/docs/test_pyproject_description_truth.py
+++ b/tests/integration/docs/test_pyproject_description_truth.py
@@ -1,0 +1,70 @@
+"""Guard the PyPI-visible ``pyproject.toml`` description against stale or
+disproven marketing claims.
+
+The ``[project].description`` field renders on the PyPI project page, so it is
+a public credibility surface. This test pins three invariants:
+
+1. The advertised MCP tool count matches the registry-measured value
+   (``create_tool_registry``), not a stale hand-written number.
+2. The withdrawn "beats CodeGraph on the benchmark median" claim — which the
+   README itself retracts — never reappears.
+3. The legacy ``63 MCP tools`` count (pre-facade consolidation) is gone.
+
+If the facade count changes, update the description and this test together —
+the same discipline ``test_agent_contracts`` applies to the 8-facade surface.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+import tomllib
+
+PROJECT_ROOT = Path(__file__).parent.parent.parent.parent
+PYPROJECT_PATH = PROJECT_ROOT / "pyproject.toml"
+
+
+def _description() -> str:
+    data = tomllib.loads(PYPROJECT_PATH.read_text(encoding="utf-8"))
+    return data["project"]["description"]
+
+
+def _registry_tool_count() -> int:
+    sys.path.insert(0, str(PROJECT_ROOT))
+    from tree_sitter_analyzer.mcp._tool_registry import create_tool_registry
+
+    tools, _ = create_tool_registry(str(PROJECT_ROOT))
+    return len(tools)
+
+
+def test_description_advertises_registry_tool_count() -> None:
+    """The tool count in the description equals the registry-measured count."""
+    description = _description()
+    count = _registry_tool_count()
+    assert f"{count} facade MCP tools" in description, (
+        f"Description should advertise '{count} facade MCP tools'; got: {description!r}"
+    )
+
+
+def test_description_drops_disproven_benchmark_claim() -> None:
+    """The withdrawn 'beats CodeGraph median' claim must not reappear.
+
+    The README itself retracts the median-win claim and concedes CodeGraph is
+    currently cheaper, so the public-facing description must not assert it.
+    """
+    description = _description().lower()
+    assert "beats codegraph" not in description, (
+        "Description must not claim it beats CodeGraph — the benchmark claim "
+        "was withdrawn (see README)."
+    )
+    assert not re.search(r"benchmark\s+median", description), (
+        "Description must not assert a benchmark-median win."
+    )
+
+
+def test_description_drops_legacy_tool_count() -> None:
+    """The pre-facade '63 MCP tools' count must not survive."""
+    description = _description()
+    assert "63 MCP tools" not in description, (
+        "Description still advertises the legacy 63-tool count; should be 8 facades."
+    )

--- a/tests/integration/docs/test_pyproject_description_truth.py
+++ b/tests/integration/docs/test_pyproject_description_truth.py
@@ -18,7 +18,10 @@ import re
 import sys
 from pathlib import Path
 
-import tomllib
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # Python 3.10 — tomllib landed in 3.11; tomli is a conditional dep.
+    import tomli as tomllib
 
 PROJECT_ROOT = Path(__file__).parent.parent.parent.parent
 PYPROJECT_PATH = PROJECT_ROOT / "pyproject.toml"


### PR DESCRIPTION
## Why

The PyPI-visible \`[project].description\` in \`pyproject.toml\` (line 8) was a **credibility hole**: it advertised claims the project itself has disproven.

| Stale claim | Reality (project's own sources) |
| --- | --- |
| \`63 MCP tools\` | Registry exposes exactly **8 facade tools** (\`create_tool_registry\`), and the README says \"8 MCP tools (down from 63)\". |
| \`beats CodeGraph on 6-repo head-to-head benchmark median\` | The README **retracts** the median-win claim and concedes CodeGraph is currently cheaper. |

PyPI shoppers were reading a marketing line the project retracted internally.

## What

- **Rewrite the description** to be truthful and lead with the defensible **correctness** positioning:
  > MCP code-intelligence server for AI agents — a more complete and more correct call graph with classified, cross-file edges. 8 facade MCP tools, 13 curated skills, TOON-compressed output, 100% local.
  - \`8 facade MCP tools\` — registry-measured (matches \`test_tool_registry\` / \`test_agent_contracts\`, README).
  - \`13 curated skills\` — matches README.
  - Dropped the withdrawn \"beats CodeGraph median\" claim.
- **New guard test** \`tests/integration/docs/test_pyproject_description_truth.py\`:
  - Pins the advertised tool count to the registry-measured value.
  - Fails if \"beats CodeGraph\" / \"benchmark median\" / \"63 MCP tools\" reappear.

\`tree_sitter_analyzer/__init__.py\` carries no stale benchmark/count claims (generic architecture docstring) — left untouched. The internal \`[tool.mcp].description\` (line 624) is not PyPI-visible and has no disproven claims — out of scope.

## Counts (authoritative, per CLAUDE.md)

\`\`\`
$ uv run python -c "from tree_sitter_analyzer.mcp._tool_registry import create_tool_registry; t,_=create_tool_registry('.'); print(len(t))"
8
\`\`\`

## Test plan

- RED-first: ran the new test against the old description — 3 failures (legacy 63 count, benchmark-median claim, wrong tool count). Restored the fix → 3 pass.
- \`test_tool_registry\` + \`test_readme_structure\` still green (9 passed, 5 skipped).
- \`ruff check\` + \`ruff format --check\` + \`mypy\` clean on touched files. Pre-commit passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)