### PR TITLE
docs(rfc): sync ROADMAP + RFC statuses to shipped code reality

### DIFF
--- a/rfcs/0008-multilang-method-classification.md
+++ b/rfcs/0008-multilang-method-classification.md
@@ -1,9 +1,9 @@
 # RFC-0008: Multi-language method classification — beyond Python
 
-- **Status**: draft
+- **Status**: draft — Java implemented (#326, on develop); Go/JS/TS pending
 - **Author(s)**: @aimasteracc
 - **Created**: 2026-06-06
-- **Last updated**: 2026-06-06
+- **Last updated**: 2026-06-07
 - **Tracking issue**: TBD
 - **Affected source paths**:
   - `tree_sitter_analyzer/synapse_resolver/_constants.py` (per-language method tables)
@@ -165,13 +165,13 @@ No surface change. Computed at index time, read identically by CLI and MCP.
 
 ## Acceptance criteria
 
-- [ ] `STDLIB_METHODS_JAVA` / `_GO` / `_JS` (+ external/builtin where apt), grouped + commented
-- [ ] cascade tiers dispatch on `caller_lang` (not hard-coded Python)
-- [ ] language-aware ownership gate preserved per language (shadowing + ambiguity)
-- [ ] per-language RED-first unit tests + cross-language gate test
+- [~] `STDLIB_METHODS_JAVA` / `_GO` / `_JS` (+ external/builtin where apt), grouped + commented — Java done (#326: `STDLIB_METHODS_JAVA`, `EXTERNAL_METHODS_JAVA`); Go/JS pending
+- [x] cascade tiers dispatch on `caller_lang` (not hard-coded Python) — #326
+- [~] language-aware ownership gate preserved per language (shadowing + ambiguity) — Java done (#326); Go/JS pending
+- [~] per-language RED-first unit tests + cross-language gate test — Java done (#326: 7 tests + cross-language gate); Go/JS pending
 - [ ] dogfood on a Java or Go repo shows a measurable classified-share rise
-- [ ] CLI/MCP parity unaffected; full suite green
-- [ ] Docs/CODEMAPS + RFC status -> implemented
+- [x] CLI/MCP parity unaffected; full suite green — #326 (1361 passed)
+- [ ] Docs/CODEMAPS + RFC status -> implemented (flips when Go/JS/TS land)
 
 ## What this RFC does NOT do (deferred)
 

--- a/rfcs/0009-nav-context-self-sufficiency.md
+++ b/rfcs/0009-nav-context-self-sufficiency.md
@@ -1,6 +1,6 @@
 # RFC-0009: `nav context` self-sufficiency — answer in one call, close the turn gap
 
-- **Status**: accepted — A (full entry bodies) + B (entry-first ranking) implemented (#330/#331, on develop); C + measured turn-drop pending
+- **Status**: accepted — A/B/C implemented (#330/#331/#333, on develop); measured turn-drop pending (gated on the benchmark integrity fix + N≥5 re-run)
 - **Author(s)**: @aimasteracc
 - **Created**: 2026-06-07
 - **Last updated**: 2026-06-07
@@ -146,7 +146,7 @@ the same task across both surfaces.
 - [x] Sub-budget entry-point bodies inline in full (A); long tail truncates; the
       127-line motivating target inlines fully at the chosen budget — #331
 - [x] Named entry points always get blocks before high-degree noise (B) — #331
-- [ ] Query tokenisation no longer surfaces generic-verb false entry points (C)
+- [x] Query tokenisation no longer surfaces generic-verb false entry points (C) — #333
 - [ ] **MEASURED turn drop**: re-run the gin routing-trace benchmark
       (symmetric warm cache, n≥5, separate cache_read/cache_creation/output/turns
       columns — per `feedback_benchmark-cost-analysis-rigor`); turns-to-answer

--- a/rfcs/0009-nav-context-self-sufficiency.md
+++ b/rfcs/0009-nav-context-self-sufficiency.md
@@ -1,6 +1,6 @@
 # RFC-0009: `nav context` self-sufficiency — answer in one call, close the turn gap
 
-- **Status**: accepted
+- **Status**: accepted — A (full entry bodies) + B (entry-first ranking) implemented (#330/#331, on develop); C + measured turn-drop pending
 - **Author(s)**: @aimasteracc
 - **Created**: 2026-06-07
 - **Last updated**: 2026-06-07
@@ -143,9 +143,9 @@ the same task across both surfaces.
   a stale-index artifact — assert freshness in the fixture).
 
 ## Acceptance criteria
-- [ ] Sub-budget entry-point bodies inline in full (A); long tail truncates; the
-      127-line motivating target inlines fully at the chosen budget
-- [ ] Named entry points always get blocks before high-degree noise (B)
+- [x] Sub-budget entry-point bodies inline in full (A); long tail truncates; the
+      127-line motivating target inlines fully at the chosen budget — #331
+- [x] Named entry points always get blocks before high-degree noise (B) — #331
 - [ ] Query tokenisation no longer surfaces generic-verb false entry points (C)
 - [ ] **MEASURED turn drop**: re-run the gin routing-trace benchmark
       (symmetric warm cache, n≥5, separate cache_read/cache_creation/output/turns

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -65,4 +65,4 @@ number; if two RFCs collide on a number in flight, the later-merged one renames.
 | [0006](0006-context-progressive-disclosure.md) | Context progressive disclosure — lean nav context, opt-in graph | implemented |
 | [0007](0007-builtin-method-resolution.md) | Builtin method resolution — classify qualified-builtin method calls | implemented |
 | [0008](0008-multilang-method-classification.md) | Multi-language method classification — beyond Python | draft (Java implemented #326; Go/JS/TS pending) |
-| [0009](0009-nav-context-self-sufficiency.md) | nav context self-sufficiency — answer in one call | accepted (A/B implemented #330/#331; C + measured turn-drop pending) |
+| [0009](0009-nav-context-self-sufficiency.md) | nav context self-sufficiency — answer in one call | accepted (A/B/C implemented #330/#331/#333; measured turn-drop pending) |

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -57,6 +57,12 @@ number; if two RFCs collide on a number in flight, the later-merged one renames.
 
 | RFC | Title | Status |
 |---|---|---|
-| [0001](0001-reactive-push.md) | Reactive push — virtual-DOM last mile | draft |
-| [0002](0002-callee-resolution.md) | Callee resolution — bare names to resolved symbols | draft |
-| [0003](0003-coverage-aware-test-gap.md) | Coverage-aware test-gap analysis — consume coverage.json, graph-enrich gaps | draft |
+| [0001](0001-reactive-push.md) | Reactive push — virtual-DOM last mile | implemented |
+| [0002](0002-callee-resolution.md) | Callee resolution — bare names to resolved symbols | implemented |
+| [0003](0003-coverage-aware-test-gap.md) | Coverage-aware test-gap analysis — consume coverage.json, graph-enrich gaps | implemented |
+| [0004](0004-stdlib-method-resolution.md) | Stdlib method resolution — classify bare stdlib method names | implemented |
+| [0005](0005-external-method-resolution.md) | External-library method resolution — classify bare external method names | implemented |
+| [0006](0006-context-progressive-disclosure.md) | Context progressive disclosure — lean nav context, opt-in graph | implemented |
+| [0007](0007-builtin-method-resolution.md) | Builtin method resolution — classify qualified-builtin method calls | implemented |
+| [0008](0008-multilang-method-classification.md) | Multi-language method classification — beyond Python | draft (Java implemented #326; Go/JS/TS pending) |
+| [0009](0009-nav-context-self-sufficiency.md) | nav context self-sufficiency — answer in one call | accepted (A/B implemented #330/#331; C + measured turn-drop pending) |

--- a/rfcs/ROADMAP-beyond-codegraph.md
+++ b/rfcs/ROADMAP-beyond-codegraph.md
@@ -12,7 +12,7 @@ the prioritized path to becoming the default agent code-intelligence layer.
 | FTS production-first | yes | test-mock shadows | TSA ahead |
 | edges_by_kind status | yes | none | TSA exclusive |
 | token / context call | ~6.6k (was 12.7k) | ~4.4k | gap 2.9x to 1.5x; near parity |
-| nav context self-sufficiency | A+B shipped (RFC-0009, #330/#331) | n/a | full entry bodies + entry-first ranking; C + measured turn-drop pending |
+| nav context self-sufficiency | A/B/C shipped (RFC-0009, #330/#331/#333) | n/a | full entry bodies + entry-first ranking + generic-verb candidate filter; measured turn-drop pending (gated on benchmark) |
 | reactive push | implemented (RFC-0001, #336 surfaced) | none | TSA exclusive |
 
 TSA's thesis is now defensible: correct + complete + nearly as cheap, with
@@ -60,6 +60,6 @@ on-thesis ("agents know before they touch").
 - docs-only changes now skip the heavy matrix (CI smart-routing, #323).
 
 ## Next action
-RFC-0008 Java (#326) and RFC-0009 A/B (#330/#331) have landed on develop. Next:
+RFC-0008 Java (#326) and RFC-0009 A/B/C (#330/#331/#333) have landed on develop. Next:
 P0 (benchmark) to retire the "CG is cheaper" caveat with evidence, and continue
 P1 (RFC-0008 Go/JS/TS) for the remaining polyglot reach.

--- a/rfcs/ROADMAP-beyond-codegraph.md
+++ b/rfcs/ROADMAP-beyond-codegraph.md
@@ -12,7 +12,8 @@ the prioritized path to becoming the default agent code-intelligence layer.
 | FTS production-first | yes | test-mock shadows | TSA ahead |
 | edges_by_kind status | yes | none | TSA exclusive |
 | token / context call | ~6.6k (was 12.7k) | ~4.4k | gap 2.9x to 1.5x; near parity |
-| reactive push | wired (RFC-0001) | none | TSA exclusive |
+| nav context self-sufficiency | A+B shipped (RFC-0009, #330/#331) | n/a | full entry bodies + entry-first ranking; C + measured turn-drop pending |
+| reactive push | implemented (RFC-0001, #336 surfaced) | none | TSA exclusive |
 
 TSA's thesis is now defensible: correct + complete + nearly as cheap, with
 capabilities CG lacks. The remaining work is to make each lead decisive and
@@ -28,11 +29,12 @@ If TSA is now within ~1.1x of CG (or cheaper), the "CG is cheaper" caveat can be
 retired with evidence. This converts a hedge into a headline. (Needs API budget;
 user has authorized spend.)
 
-### P1 — RFC-0008 multi-language method classification (spec drafted)
-The 83.9% to 96.5% classification win is Python-only. Extend the cascade tiers to
+### P1 — RFC-0008 multi-language method classification (Java shipped; Go/JS/TS remaining)
+The 83.9% to 96.5% classification win was Python-only. Extend the cascade tiers to
 Java/Go/JS/TS so polyglot repos get the same resolved-graph completeness. One PR
-per language (Java first — _java_constants.py exists). Blocked on #324 merging
-first (shared synapse_resolver). Largest single lever for non-Python users.
+per language. **Java shipped** (#326 — stdlib/external tiers + method-call name
+extraction, on develop); Go/JS/TS still pending. Largest single lever for
+non-Python users.
 
 ### P2 — File-level resolution of stdlib/builtin methods (RFC-0004 phase 2)
 Today stdlib/external/builtin methods are classified but not file-resolved.
@@ -41,9 +43,10 @@ p.write_text() at pathlib, raising the file-resolution rate and enabling
 "jump to the stdlib def" for agents. Precision-sensitive; gate hard.
 
 ### P3 — Reactive push as a demoed differentiator
-RFC-0001 is wired but invisible. Add a CLI watch --subscribe mode + a recorded
-demo (edit a file, agent receives resource_updated, re-reads the changed set).
-No competitor has this; make it legible.
+RFC-0001 is **implemented** (subscription registry + watch→push bridge + resource
+read; #336 surfaced it in the MCP differentiators) but still under-demoed. Add a
+CLI watch --subscribe mode + a recorded demo (edit a file, agent receives
+resource_updated, re-reads the changed set). No competitor has this; make it legible.
 
 ### P4 — Resolution confidence signal
 Expose per-edge callee_resolution + a confidence so agents can trust/distrust a
@@ -57,5 +60,6 @@ on-thesis ("agents know before they touch").
 - docs-only changes now skip the heavy matrix (CI smart-routing, #323).
 
 ## Next action
-Ship v1.21.0 (push release/v1.21.0), merge the 4 in-flight quality PRs after
-Codex triage, then start P0 (benchmark) + P1 (RFC-0008 Java) in parallel.
+RFC-0008 Java (#326) and RFC-0009 A/B (#330/#331) have landed on develop. Next:
+P0 (benchmark) to retire the "CG is cheaper" caveat with evidence, and continue
+P1 (RFC-0008 Go/JS/TS) for the remaining polyglot reach.


### PR DESCRIPTION
## What

Sync `rfcs/ROADMAP-beyond-codegraph.md` and `rfcs/README.md` so the **Status** column matches the code actually merged on `develop`. The project was **under-claiming** shipped wins. Docs-only — no code touched.

## Why

Three statuses were stale or understated:

| RFC | Was advertised | Reality (merged on develop) | Now stated as |
|---|---|---|---|
| **RFC-0008** multi-lang method classification | ROADMAP P1 "spec drafted"; README Index absent | **Java shipped** (#326: stdlib/external tiers + method-call name extraction) | "Java implemented #326; Go/JS/TS pending" — no over-claim |
| **RFC-0009** nav context self-sufficiency | invisible in ROADMAP | **A + B shipped** (#330 spec, #331 full entry bodies + entry-first ranking) | "A/B implemented #330/#331; C + measured turn-drop pending" |
| **RFC-0001** reactive push | README Index "draft"; ROADMAP P3 "wired but invisible" | **implemented** (all acceptance criteria already `[x]`; #336 surfaced it in MCP differentiators) | "implemented" |

## Changes

- **ROADMAP**: P1 updated (Java shipped, Go/JS/TS remaining); added a "nav context self-sufficiency" row to the *where we stand* table; P3 + the reactive-push row reflect RFC-0001 implemented; "Next action" updated (Java/AB landed, next is benchmark + Go/JS/TS).
- **rfcs/README.md Index**: was stale at 0001-0003 all marked `draft`. Extended to cover **0001-0009**, each status taken from the RFC file's own `Status` line.
- **RFC-0008 / RFC-0009 files**: Status line + acceptance checkboxes annotated to reflect partial shipping precisely (Java-only / A+B-only), with PR refs. Unshipped criteria left unchecked.

## No over-claim

Every flipped status is backed by a merged PR (#326, #330, #331, #336). Partial work (RFC-0008 Go/JS/TS, RFC-0009 C + measured turn-drop) is explicitly called out as pending, not hidden.

## Test plan

- Docs-only: no docs-assertion test exists for these narrative/index markdown files. CI routes `rfcs/*.md` to the lightweight docs-check (verified `test_ci_routing.py` green, 9/9).
- `git diff --check` clean; ruff/mypy N/A (no Python touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)