### PR TITLE
docs(readme): align feature table + quick-start to the 8 facade tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ claude mcp add tree-sitter-analyzer \
   -- uvx --from "tree-sitter-analyzer[mcp]" tree-sitter-analyzer-mcp
 ```
 
-Restart your agent, then say: *"Set the project root to my repo and run codegraph_status."*
+Restart your agent, then say: *"Set the project root to my repo and run the `index` tool with action=status."*
 
 [Other agents (Cursor, Copilot, Cline, Continue, Claude Desktop, Roo Code) →](#-supported-agents)
 
@@ -133,13 +133,13 @@ tree-sitter-analyzer --callees _resolve_entry_points --format json
 
 | Capability | TSA tool | Status |
 |---|---|---|
-| Symbol search (FTS5 + **BM25 ranked**) | `codegraph_symbol_search` | **ahead** — results sorted by relevance score, not file path |
-| Go-to-def / find-refs / call hierarchy in one call | `codegraph_navigate` | PRIMARY entry point |
-| Bulk-fetch N related symbols + relationship map | `codegraph_explore` | parity |
-| Function-level blast radius + risk score | `codegraph_impact` | parity + risk score |
-| Who-calls-X / what-X-calls | `codegraph_callers` / `codegraph_callees` | parity |
-| Index health at-a-glance (+ edge count) | `codegraph_status` | **ahead** — reports `total_edges` for graph density signal |
-| Pre-built call graph cache | `codegraph_autoindex` / `codegraph_full_index` / `codegraph_incremental_sync` | parity |
+| Symbol search (FTS5 + **BM25 ranked**) | `search` action=symbol | **ahead** — results sorted by relevance score, not file path |
+| Go-to-def / find-refs / call hierarchy in one call | `nav` action=navigate | PRIMARY entry point |
+| Bulk-fetch N related symbols + relationship map | `structure` action=explore | parity |
+| Function-level blast radius + risk score | `nav` action=impact | parity + risk score |
+| Who-calls-X / what-X-calls | `nav` action=callers / action=callees | parity |
+| Index health at-a-glance (+ edge count) | `index` action=status | **ahead** — reports `total_edges` for graph density signal |
+| Pre-built call graph cache | `index` action=auto / action=full / action=sync | parity |
 | Tests affected by a change (CLI) | `--affected FILE...` | parity |
 
 ### Tree-sitter Analyzer exclusive
@@ -147,26 +147,26 @@ tree-sitter-analyzer --callees _resolve_entry_points --format json
 | Capability | TSA tool | Note |
 |---|---|---|
 | **BM25-ranked symbol search** | all search tools | relevance_score on every result (min-max normalized: best=1.0, weakest=0.0); sort(by='confidence') in DSL |
-| **Semantic search (133× faster)** | `codegraph_query semantic()` | BM25 pre-filter narrows 40k symbols to ~400 before cosine rerank |
-| **Project A–F health grading** | `check_project_health` | 7 dimensions (size/complexity/deps/coverage/duplication/structure/git-hotspot), no competitor offers this |
+| **Semantic search (133× faster)** | `search` action=chain (`semantic()` DSL) | BM25 pre-filter narrows 40k symbols to ~400 before cosine rerank |
+| **Project A–F health grading** | `health` action=project | 7 dimensions (size/complexity/deps/coverage/duplication/structure/git-hotspot), no competitor offers this |
 | **TOON output** | every tool, `output_format: "toon"` (default) | 50-70 % token saving |
 | **Verdict envelopes** | every tool | `SAFE/CAUTION/UNSAFE/INFO/WARN/ERROR/NOT_FOUND` |
-| **Safe-to-edit gate** | `safe_to_edit` + `modification_guard` | refuses high-risk edits before they happen |
-| **Architectural constraint DSL** | `check_constraints` | "module A cannot import B" → enforced |
-| **Code health (file-level)** | `check_file_health` | block/long-method/smell detection |
-| **Class hierarchy** | `codegraph_class_hierarchy` | type-inheritance tree |
-| **Dependency matrix** | `codegraph_dependency_matrix` | module-coupling matrix |
-| **Dead code** | `codegraph_dead_code` | transitive unreachable analysis |
-| **Complexity heatmap** | `codegraph_complexity_heatmap` | per-fn cyclomatic + project view |
-| **AST-structural clone detection** | `codegraph_similarity` | beyond text similarity |
-| **Mermaid call-graph export** | `codegraph_visualize` | paste-ready in docs |
-| **UML Mermaid export** | `codegraph_uml` | class / package / component / sequence diagrams |
-| **PR review** | `codegraph_pr_review` | AST-diff + semantic classify + blast radius |
+| **Safe-to-edit gate** | `edit` action=safe / action=guard | refuses high-risk edits before they happen |
+| **Architectural constraint DSL** | `edit` action=constraints | "module A cannot import B" → enforced |
+| **Code health (file-level)** | `health` action=file | block/long-method/smell detection |
+| **Class hierarchy** | `structure` action=class_tree | type-inheritance tree |
+| **Dependency matrix** | `health` action=matrix | module-coupling matrix |
+| **Dead code** | `health` action=dead | transitive unreachable analysis |
+| **Complexity heatmap** | `health` action=heatmap | per-fn cyclomatic + project view |
+| **AST-structural clone detection** | `viz` action=similarity | beyond text similarity |
+| **Mermaid call-graph export** | `viz` action=graph | paste-ready in docs |
+| **UML Mermaid export** | `viz` action=uml | class / package / component / sequence diagrams |
+| **PR review** | `edit` action=pr | AST-diff + semantic classify + blast radius |
 | **agent_summary** | every response | next-step hint baked into the envelope |
 | **Synapse cross-file resolver** | internal | import-aware, beats regex guessing |
-| **Temporal activation** | `symbol_lineage` | per-symbol git-modification frequency |
-| **One-shot file orientation** | `smart_context` | health + exports + deps + edit-risk in one call (replaces 3-4 calls) |
-| **Architectural decision journal** | `decision_journal` | persists reasoning across sessions — no competitor exposes this |
+| **Temporal activation** | `nav` action=lineage | per-symbol git-modification frequency |
+| **One-shot file orientation** | `project` action=smart | health + exports + deps + edit-risk in one call (replaces 3-4 calls) |
+| **Architectural decision journal** | `project` action=journal | persists reasoning across sessions — no competitor exposes this |
 
 ### Skills (13 curated workflows)
 
@@ -233,7 +233,7 @@ See **[Supported Agents](#-supported-agents)**. Most clients want this MCP serve
 }
 ```
 
-After restart: *"Set the project root to my repo and call codegraph_status."*
+After restart: *"Set the project root to my repo and call the `index` tool with action=status."*
 
 ---
 
@@ -242,7 +242,7 @@ After restart: *"Set the project root to my repo and call codegraph_status."*
 ```
 Source code → tree-sitter parse → SQLite + FTS5 index (.ast-cache/index.db)
                                          ↓
-        codegraph_navigate / codegraph_explore / codegraph_callers / ...
+        nav (navigate) / structure (explore) / nav (callers) / ...
                                          ↓
                             TOON-compressed envelope
                             (verdict + agent_summary + data)
@@ -250,7 +250,7 @@ Source code → tree-sitter parse → SQLite + FTS5 index (.ast-cache/index.db)
                               MCP client / CLI consumer
 ```
 
-The index is built lazily on first query, refreshed on file change via a content-hash diff (`codegraph_incremental_sync`). All 8 tools read from the same `.ast-cache/`, so a query and its follow-up share work.
+The index is built lazily on first query, refreshed on file change via a content-hash diff (`index` action=sync). All 8 tools read from the same `.ast-cache/`, so a query and its follow-up share work.
 
 ---
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -29,7 +29,7 @@ claude mcp add tree-sitter-analyzer \
   -- uvx --from "tree-sitter-analyzer[mcp]" tree-sitter-analyzer-mcp
 ```
 
-エージェントを再起動し、こう伝える: 「プロジェクト ルートを私のリポジトリに設定して、codegraph_status を呼んでください。」
+エージェントを再起動し、こう伝える: 「プロジェクト ルートを私のリポジトリに設定して、`index` ツールを action=status で呼んでください。」
 
 [その他のエージェント (Cursor / Copilot / Cline / Continue / Claude Desktop / Roo Code) →](#-対応エージェント)
 
@@ -98,13 +98,13 @@ tree-sitter-analyzer --callees _resolve_entry_points --format json
 
 | 能力 | TSA ツール | ステータス |
 |---|---|---|
-| シンボル検索 (FTS5 + **BM25 ランク付け**) | `codegraph_symbol_search` | **優位** — 関連スコア順にソート |
-| go-to-def / find-refs / コール階層を 1 回の呼び出しで | `codegraph_navigate` | PRIMARY エントリポイント |
-| 関連シンボル N 個のソース + 関係マップを一括取得 | `codegraph_explore` | 同等 |
-| 関数レベル blast radius + リスク スコア | `codegraph_impact` | 同等 + リスク スコア |
-| X を呼ぶのは誰 / X は何を呼ぶ | `codegraph_callers` / `codegraph_callees` | 同等 |
-| インデックス健全性 (+ エッジ数) | `codegraph_status` | **優位** — `total_edges` でグラフ密度を把握 |
-| 事前構築コール グラフ キャッシュ | `codegraph_autoindex` / `codegraph_full_index` / `codegraph_incremental_sync` | 同等 |
+| シンボル検索 (FTS5 + **BM25 ランク付け**) | `search` action=symbol | **優位** — 関連スコア順にソート |
+| go-to-def / find-refs / コール階層を 1 回の呼び出しで | `nav` action=navigate | PRIMARY エントリポイント |
+| 関連シンボル N 個のソース + 関係マップを一括取得 | `structure` action=explore | 同等 |
+| 関数レベル blast radius + リスク スコア | `nav` action=impact | 同等 + リスク スコア |
+| X を呼ぶのは誰 / X は何を呼ぶ | `nav` action=callers / action=callees | 同等 |
+| インデックス健全性 (+ エッジ数) | `index` action=status | **優位** — `total_edges` でグラフ密度を把握 |
+| 事前構築コール グラフ キャッシュ | `index` action=auto / action=full / action=sync | 同等 |
 | 変更の影響を受けるテスト (CLI) | `--affected FILE...` | 同等 |
 
 ### Tree-sitter Analyzer 独占機能
@@ -112,26 +112,26 @@ tree-sitter-analyzer --callees _resolve_entry_points --format json
 | 能力 | TSA ツール | 説明 |
 |---|---|---|
 | **BM25 ランク付き検索** | 全検索ツール | min-max 正規化 relevance_score (最適=1.0 / 最弱=0.0); DSL で sort(by='confidence') |
-| **セマンティック検索 (133× 高速化)** | `codegraph_query semantic()` | BM25 で 40k シンボル→約 400 に絞り込んでコサイン再ランク |
-| **プロジェクト A-F 健全性グレーディング** | `check_project_health` | 7 次元 (サイズ/複雑度/依存/カバレッジ/重複/構造/git)、競合に対応無し |
+| **セマンティック検索 (133× 高速化)** | `search` action=chain (`semantic()` DSL) | BM25 で 40k シンボル→約 400 に絞り込んでコサイン再ランク |
+| **プロジェクト A-F 健全性グレーディング** | `health` action=project | 7 次元 (サイズ/複雑度/依存/カバレッジ/重複/構造/git)、競合に対応無し |
 | **TOON 出力** | 全ツール、デフォルト `output_format: "toon"` | 50-70% トークン節約 |
 | **Verdict エンベロープ** | 全ツール | `SAFE/CAUTION/UNSAFE/INFO/WARN/ERROR/NOT_FOUND` |
-| **Safe-to-edit ゲート** | `safe_to_edit` + `modification_guard` | 高リスク編集前に拒否 |
-| **アーキテクチャ制約 DSL** | `check_constraints` | 「モジュール A は B に依存禁止」→ 強制 |
-| **ファイル レベル健全性** | `check_file_health` | ブロック / 長メソッド / コード スメル検出 |
-| **クラス階層** | `codegraph_class_hierarchy` | 型継承ツリー |
-| **依存マトリクス** | `codegraph_dependency_matrix` | モジュール結合マトリクス |
-| **デッド コード** | `codegraph_dead_code` | 推移的到達不能解析 |
-| **複雑度ヒート マップ** | `codegraph_complexity_heatmap` | 関数別循環的複雑度 + プロジェクト ビュー |
-| **AST 構造的クローン検出** | `codegraph_similarity` | テキスト類似度を超える |
-| **Mermaid コール グラフ エクスポート** | `codegraph_visualize` | ドキュメントへ直接貼付 |
-| **UML Mermaid エクスポート** | `codegraph_uml` | class / package / component / sequence 図 |
-| **PR レビュー** | `codegraph_pr_review` | AST diff + セマンティック分類 + blast radius |
+| **Safe-to-edit ゲート** | `edit` action=safe / action=guard | 高リスク編集前に拒否 |
+| **アーキテクチャ制約 DSL** | `edit` action=constraints | 「モジュール A は B に依存禁止」→ 強制 |
+| **ファイル レベル健全性** | `health` action=file | ブロック / 長メソッド / コード スメル検出 |
+| **クラス階層** | `structure` action=class_tree | 型継承ツリー |
+| **依存マトリクス** | `health` action=matrix | モジュール結合マトリクス |
+| **デッド コード** | `health` action=dead | 推移的到達不能解析 |
+| **複雑度ヒート マップ** | `health` action=heatmap | 関数別循環的複雑度 + プロジェクト ビュー |
+| **AST 構造的クローン検出** | `viz` action=similarity | テキスト類似度を超える |
+| **Mermaid コール グラフ エクスポート** | `viz` action=graph | ドキュメントへ直接貼付 |
+| **UML Mermaid エクスポート** | `viz` action=uml | class / package / component / sequence 図 |
+| **PR レビュー** | `edit` action=pr | AST diff + セマンティック分類 + blast radius |
 | **agent_summary** | 全応答 | エンベロープに次ステップ ヒントを内蔵 |
 | **Synapse クロスファイル リゾルバ** | 内部 | import-aware、正規表現推測より強力 |
-| **時間的アクティベーション** | `symbol_lineage` | シンボル別 git 修正頻度 |
-| **1 回のファイル把握** | `smart_context` | 健全性 + エクスポート + 依存 + 編集リスクを 1 コールで (3-4 コールを代替) |
-| **アーキテクチャ意思決定ジャーナル** | `decision_journal` | セッション間で推論を永続化 — 他に提供しているツールは無い |
+| **時間的アクティベーション** | `nav` action=lineage | シンボル別 git 修正頻度 |
+| **1 回のファイル把握** | `project` action=smart | 健全性 + エクスポート + 依存 + 編集リスクを 1 コールで (3-4 コールを代替) |
+| **アーキテクチャ意思決定ジャーナル** | `project` action=journal | セッション間で推論を永続化 — 他に提供しているツールは無い |
 
 ### Skills (13 のキュレーション済みワークフロー)
 
@@ -197,7 +197,7 @@ uv add "tree-sitter-analyzer[all,mcp]"
 }
 ```
 
-再起動後: 「プロジェクト ルートを私のリポジトリに設定して、codegraph_status を呼んでください。」
+再起動後: 「プロジェクト ルートを私のリポジトリに設定して、`index` ツールを action=status で呼んでください。」
 
 ---
 
@@ -206,7 +206,7 @@ uv add "tree-sitter-analyzer[all,mcp]"
 ```
 ソース コード → tree-sitter 解析 → SQLite + FTS5 インデックス (.ast-cache/index.db)
                                           ↓
-       codegraph_navigate / codegraph_explore / codegraph_callers / ...
+       nav (navigate) / structure (explore) / nav (callers) / ...
                                           ↓
                             TOON 圧縮エンベロープ
                             (verdict + agent_summary + データ)
@@ -214,7 +214,7 @@ uv add "tree-sitter-analyzer[all,mcp]"
                                MCP クライアント / CLI 消費者
 ```
 
-インデックスは最初のクエリで遅延構築され、ファイル変更時はコンテンツ ハッシュ差分で増分更新 (`codegraph_incremental_sync`)。8 個のファサード全てが同じ `.ast-cache/` を共有し、クエリとフォローアップは作業を共有する。
+インデックスは最初のクエリで遅延構築され、ファイル変更時はコンテンツ ハッシュ差分で増分更新 (`index` action=sync)。8 個のファサード全てが同じ `.ast-cache/` を共有し、クエリとフォローアップは作業を共有する。
 
 ---
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -30,7 +30,7 @@ claude mcp add tree-sitter-analyzer \
   -- uvx --from "tree-sitter-analyzer[mcp]" tree-sitter-analyzer-mcp
 ```
 
-重启 agent，对它说："设置项目根目录到我的仓库，然后调用 codegraph_status。"
+重启 agent，对它说："设置项目根目录到我的仓库，然后用 `index` 工具调用 action=status。"
 
 [其他 agent（Cursor / Copilot / Cline / Continue / Claude Desktop / Roo Code）→](#-支持的-agent)
 
@@ -99,13 +99,13 @@ tree-sitter-analyzer --callees _resolve_entry_points --format json
 
 | 能力 | TSA 工具 | 状态 |
 |---|---|---|
-| 符号搜索（FTS5 + **BM25 排名**） | `codegraph_symbol_search` | **领先** — 结果按相关性分数排序 |
-| go-to-def / find-refs / 调用层级 一次调用 | `codegraph_navigate` | PRIMARY 入口 |
-| 批量获取 N 个相关符号 + 关系图 | `codegraph_explore` | 对位 |
-| 函数级 blast radius + 风险评分 | `codegraph_impact` | 对位 + 风险评分 |
-| 谁调用 X / X 调用谁 | `codegraph_callers` / `codegraph_callees` | 对位 |
-| 索引健康一览（含边数统计） | `codegraph_status` | **领先** — 提供 `total_edges` 图密度信号 |
-| 预建调用图缓存 | `codegraph_autoindex` / `codegraph_full_index` / `codegraph_incremental_sync` | 对位 |
+| 符号搜索（FTS5 + **BM25 排名**） | `search` action=symbol | **领先** — 结果按相关性分数排序 |
+| go-to-def / find-refs / 调用层级 一次调用 | `nav` action=navigate | PRIMARY 入口 |
+| 批量获取 N 个相关符号 + 关系图 | `structure` action=explore | 对位 |
+| 函数级 blast radius + 风险评分 | `nav` action=impact | 对位 + 风险评分 |
+| 谁调用 X / X 调用谁 | `nav` action=callers / action=callees | 对位 |
+| 索引健康一览（含边数统计） | `index` action=status | **领先** — 提供 `total_edges` 图密度信号 |
+| 预建调用图缓存 | `index` action=auto / action=full / action=sync | 对位 |
 | 受变更影响的测试（CLI） | `--affected FILE...` | 对位 |
 
 ### Tree-sitter Analyzer 独占
@@ -113,26 +113,26 @@ tree-sitter-analyzer --callees _resolve_entry_points --format json
 | 能力 | TSA 工具 | 说明 |
 |---|---|---|
 | **BM25 排名搜索** | 所有搜索工具 | min-max 标准化 relevance_score（最佳=1.0/最弱=0.0）；DSL 支持 sort(by='confidence') |
-| **语义搜索（133× 加速）** | `codegraph_query semantic()` | BM25 预过滤将 40k 符号收窄至 ~400 再做余弦重排 |
-| **项目 A-F 健康评级** | `check_project_health` | 7 维度（体积/复杂度/依赖/覆盖率/重复/结构/git热点），竞品无对位 |
+| **语义搜索（133× 加速）** | `search` action=chain（`semantic()` DSL） | BM25 预过滤将 40k 符号收窄至 ~400 再做余弦重排 |
+| **项目 A-F 健康评级** | `health` action=project | 7 维度（体积/复杂度/依赖/覆盖率/重复/结构/git热点），竞品无对位 |
 | **TOON 输出** | 所有工具，默认 `output_format: "toon"` | 50-70% token 节省 |
 | **Verdict 信封** | 所有工具 | `SAFE/CAUTION/UNSAFE/INFO/WARN/ERROR/NOT_FOUND` |
-| **Safe-to-edit 闸门** | `safe_to_edit` + `modification_guard` | 高风险编辑前拒绝 |
-| **架构约束 DSL** | `check_constraints` | "模块 A 不能依赖 B" → 强制执行 |
-| **文件级健康度** | `check_file_health` | 代码块/长方法/坏味道检测 |
-| **类继承层级** | `codegraph_class_hierarchy` | 类型继承树 |
-| **依赖矩阵** | `codegraph_dependency_matrix` | 模块耦合矩阵 |
-| **死代码** | `codegraph_dead_code` | 传递不可达分析 |
-| **复杂度热点** | `codegraph_complexity_heatmap` | 单函数圈复杂度 + 项目视图 |
-| **AST 结构克隆检测** | `codegraph_similarity` | 超越文本相似度 |
-| **Mermaid 调用图导出** | `codegraph_visualize` | 直接粘贴进文档 |
-| **UML Mermaid 导出** | `codegraph_uml` | class / package / component / sequence 图 |
-| **PR 评审** | `codegraph_pr_review` | AST diff + 语义分类 + blast radius |
+| **Safe-to-edit 闸门** | `edit` action=safe / action=guard | 高风险编辑前拒绝 |
+| **架构约束 DSL** | `edit` action=constraints | "模块 A 不能依赖 B" → 强制执行 |
+| **文件级健康度** | `health` action=file | 代码块/长方法/坏味道检测 |
+| **类继承层级** | `structure` action=class_tree | 类型继承树 |
+| **依赖矩阵** | `health` action=matrix | 模块耦合矩阵 |
+| **死代码** | `health` action=dead | 传递不可达分析 |
+| **复杂度热点** | `health` action=heatmap | 单函数圈复杂度 + 项目视图 |
+| **AST 结构克隆检测** | `viz` action=similarity | 超越文本相似度 |
+| **Mermaid 调用图导出** | `viz` action=graph | 直接粘贴进文档 |
+| **UML Mermaid 导出** | `viz` action=uml | class / package / component / sequence 图 |
+| **PR 评审** | `edit` action=pr | AST diff + 语义分类 + blast radius |
 | **agent_summary** | 所有响应 | 下一步提示内嵌于信封 |
 | **Synapse 跨文件解析** | 内部 | import-aware，胜过正则猜测 |
-| **时间激活度** | `symbol_lineage` | 每个符号的 git 修改频率 |
-| **单次文件定向** | `smart_context` | 健康度 + 导出符号 + 依赖 + 编辑风险一次调用（替代 3-4 次调用） |
-| **架构决策日志** | `decision_journal` | 跨会话持久化推理 — 竞品均无此能力 |
+| **时间激活度** | `nav` action=lineage | 每个符号的 git 修改频率 |
+| **单次文件定向** | `project` action=smart | 健康度 + 导出符号 + 依赖 + 编辑风险一次调用（替代 3-4 次调用） |
+| **架构决策日志** | `project` action=journal | 跨会话持久化推理 — 竞品均无此能力 |
 
 ### Skills（13 个精选工作流）
 
@@ -198,7 +198,7 @@ uv add "tree-sitter-analyzer[all,mcp]"
 }
 ```
 
-重启 agent 后："设置项目根目录到我的仓库，然后调用 codegraph_status。"
+重启 agent 后："设置项目根目录到我的仓库，然后用 `index` 工具调用 action=status。"
 
 ---
 
@@ -207,7 +207,7 @@ uv add "tree-sitter-analyzer[all,mcp]"
 ```
 源代码 → tree-sitter 解析 → SQLite + FTS5 索引 (.ast-cache/index.db)
                                     ↓
-   codegraph_navigate / codegraph_explore / codegraph_callers / ...
+   nav (navigate) / structure (explore) / nav (callers) / ...
                                     ↓
                        TOON 压缩信封
                        (verdict + agent_summary + 数据)
@@ -215,7 +215,7 @@ uv add "tree-sitter-analyzer[all,mcp]"
                        MCP 客户端 / CLI 消费者
 ```
 
-索引首次查询时懒构建，文件变更时通过内容哈希增量刷新（`codegraph_incremental_sync`）。所有 8 个工具共享同一份 `.ast-cache/`，查询与跟进调用共享工作量。
+索引首次查询时懒构建，文件变更时通过内容哈希增量刷新（`index` action=sync）。所有 8 个工具共享同一份 `.ast-cache/`，查询与跟进调用共享工作量。
 
 ---
 

--- a/tests/integration/docs/test_readme_structure.py
+++ b/tests/integration/docs/test_readme_structure.py
@@ -252,3 +252,41 @@ class TestRequiredSections:
                 missing_sections.append(section)
 
         assert not missing_sections, f"Missing required sections: {missing_sections}"
+
+
+# Matches a stale ``codegraph_<word>`` MCP-tool-name reference (e.g.
+# ``codegraph_status``, ``codegraph_navigate``). Under the current 8-facade
+# schema these tool *names* do not exist — an agent told to call them gets
+# tool-not-found. Legitimate survivors that must NOT match:
+#   * the ``benchmarks/codegraph_compare/`` directory path
+#   * CLI flags like ``--codegraph-impact`` (hyphenated, not a tool name)
+_STALE_TOOL_NAME = re.compile(r"\bcodegraph_(?!compare\b)[a-z][a-z_]*\b")
+
+
+class TestNoStaleFacadeToolNames:
+    """The feature table + quick-start must reference real facade tools.
+
+    The 8 facades are: nav, search, structure, health, edit, project, index,
+    viz. Each takes an ``action=`` parameter. The pre-facade docs referenced
+    ~21 ``codegraph_*`` MCP tool *names* that no longer exist; this test pins
+    them out of all three READMEs.
+    """
+
+    @pytest.mark.parametrize(
+        "readme_path",
+        [README_PATH, README_JA_PATH, README_ZH_PATH],
+        ids=["en", "ja", "zh"],
+    )
+    def test_no_stale_codegraph_tool_names(self, readme_path: Path) -> None:
+        content = get_readme_content(readme_path)
+        hits: list[str] = []
+        for i, line in enumerate(content.splitlines(), 1):
+            for match in _STALE_TOOL_NAME.finditer(line):
+                hits.append(
+                    f"{readme_path.name}:{i}: {match.group(0)} | {line.strip()}"
+                )
+        assert not hits, (
+            "Found stale codegraph_* MCP-tool-name references (these tools no "
+            "longer exist under the 8-facade schema — map each to facade+action, "
+            "e.g. codegraph_status -> index action=status):\n" + "\n".join(hits)
+        )


### PR DESCRIPTION
## Summary

ONBOARDING BUG fix (docs-only). The **Key Features** table and **Quick-Start** verification in `README.md`, `README_zh.md`, and `README_ja.md` still referenced ~21 pre-facade `codegraph_*` MCP tool **names** (`codegraph_status`, `codegraph_navigate`, `codegraph_symbol_search`, `codegraph_callers`, ...). Under the current **8-facade** schema (`nav, search, structure, health, edit, project, index, viz`) those tool names **do not exist** — an agent told to "call `codegraph_status`" gets **tool-not-found**.

Every stale reference now maps to the correct **facade + action**, verified against the routing dicts in `tree_sitter_analyzer/mcp/tools/*_facade.py`.

## Mapping (verified against facade routing dicts)

| Old name | New |
|---|---|
| `codegraph_status` | `index` action=status |
| `codegraph_navigate` | `nav` action=navigate |
| `codegraph_symbol_search` | `search` action=symbol |
| `codegraph_explore` | `structure` action=explore |
| `codegraph_impact` | `nav` action=impact |
| `codegraph_callers` / `codegraph_callees` | `nav` action=callers / callees |
| `codegraph_autoindex` / `_full_index` / `_incremental_sync` | `index` action=auto / full / sync |
| `codegraph_query semantic()` | `search` action=chain (`semantic()` DSL) |
| `codegraph_class_hierarchy` | `structure` action=class_tree |
| `codegraph_dependency_matrix` / `_dead_code` / `_complexity_heatmap` | `health` action=matrix / dead / heatmap |
| `codegraph_similarity` / `_visualize` / `_uml` | `viz` action=similarity / graph / uml |
| `codegraph_pr_review` | `edit` action=pr |
| `check_project_health` | `health` action=project |
| `safe_to_edit` / `modification_guard` | `edit` action=safe / guard |
| `check_constraints` | `edit` action=constraints |
| `check_file_health` | `health` action=file |
| `symbol_lineage` | `nav` action=lineage |
| `smart_context` | `project` action=smart |
| `decision_journal` | `project` action=journal |

## Preserved (legitimately not facade tools)

- `benchmarks/codegraph_compare/` — real benchmark directory path
- `--codegraph-*` — real hyphenated CLI flags (e.g. `--codegraph-impact`)

## Tests

Adds `TestNoStaleFacadeToolNames` to `tests/integration/docs/test_readme_structure.py` — parametrized over all three READMEs, it fails on any `codegraph_<word>` MCP-tool-name string (excluding the `codegraph_compare` path; hyphenated CLI flags don't match the underscore pattern).

- RED-first verified: reverting the README edits makes all 3 parametrized cases fail with the stale names listed; with the fix they pass.
- `tests/integration/docs/` — 18 passed, 5 skipped.
- `tests/unit/test_agent_contracts.py` (README counts contract) — 53 passed.
- `ruff check` + `ruff format --check` clean; `mypy` clean on the touched test file.

No tool behavior changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
