### PR TITLE
feat(resolver): self-contained SAFE JavaScript callee resolver (RFC-0010)

### DIFF
--- a/tests/unit/test_javascript_method_resolution.py
+++ b/tests/unit/test_javascript_method_resolution.py
@@ -129,6 +129,27 @@ def test_bare_call_to_same_file_function_is_local() -> None:
     )
 
 
+def test_bare_call_does_not_bind_to_same_file_method() -> None:
+    """A bare ``render()`` (no receiver) in a file whose only same-name symbol is
+    a class METHOD must NOT bind: a method needs an owning receiver, and in a
+    multi-class file the flat ``file_symbols`` scan cannot prove the method
+    belongs to the caller's class. Consistent with the bare-callable-kind gate
+    used by the project tier — a bare same-file call binds only a top-level
+    ``function`` (Codex P2 #346, line 235 follow-through)."""
+    ctx = _ctx(
+        file_languages={"app.js": "javascript"},
+        file_symbols={
+            "app.js": [("run", "method", 1), ("render", "method", 2)],
+        },
+        file_class_methods={"app.js": {"A": {"run": 1}, "B": {"render": 2}}},
+    )
+    assert resolve_javascript_callee("render", "render", "app.js", ctx) == (
+        None,
+        "unknown",
+        "",
+    )
+
+
 def test_self_receiver_does_not_bind_to_same_file_helper() -> None:
     """Codex P2 #346: in browser/worker JS, ``self`` is the global scope
     (``Window.self`` / ``WorkerGlobalScope.self``), NOT the current object.
@@ -185,6 +206,48 @@ def test_this_method_does_not_bind_across_sibling_classes() -> None:
         None,
         "unknown",
         "",
+    )
+
+
+def test_this_method_does_not_bind_sibling_via_file_symbols() -> None:
+    """Codex P2 #346 (line 235): real resolver contexts populate ``file_symbols``
+    with EVERY method in the file, including sibling-class methods. For
+    ``class A { run() { this.render(); } } class B { render() {} }`` the flat
+    ``file_symbols`` scan would find ``B.render`` (kind ``method``) and bind
+    ``this.render`` from ``A.run`` to it as ``local`` — bypassing the
+    single-class ambiguity guard. A ``this.``-qualified call is a METHOD call; it
+    must NOT short-circuit through the flat same-file symbol lookup. With 2+
+    classes it stays ``unknown``."""
+    ctx = _ctx(
+        file_languages={"app.js": "javascript"},
+        # As a real context would: both class methods are present as flat rows.
+        file_symbols={
+            "app.js": [("run", "method", 1), ("render", "method", 2)],
+        },
+        file_class_methods={
+            "app.js": {"A": {"run": 1}, "B": {"render": 2}},
+        },
+    )
+    assert resolve_javascript_callee("render", "this.render", "app.js", ctx) == (
+        None,
+        "unknown",
+        "",
+    )
+
+
+def test_this_method_single_class_binds_even_with_flat_symbols() -> None:
+    """The single-class case must still bind via ``file_class_methods`` even when
+    the flat ``file_symbols`` row for the method is present — proving the bind
+    comes from the unambiguous class path, not the flat scan."""
+    ctx = _ctx(
+        file_languages={"app.js": "javascript"},
+        file_symbols={"app.js": [("render", "method", 11)]},
+        file_class_methods={"app.js": {"Widget": {"render": 11}}},
+    )
+    assert resolve_javascript_callee("render", "this.render", "app.js", ctx) == (
+        11,
+        "local",
+        "app.js",
     )
 
 

--- a/tests/unit/test_javascript_method_resolution.py
+++ b/tests/unit/test_javascript_method_resolution.py
@@ -29,6 +29,7 @@ def _ctx(
     file_class_methods=None,
     global_name_table=None,
     file_languages=None,
+    shadowed_globals=None,
 ):
     """Build a JS resolver context from explicit maps (thunk-style fcm)."""
     return build_javascript_context(
@@ -37,6 +38,7 @@ def _ctx(
         file_symbols=file_symbols or {},
         global_name_table=global_name_table or {},
         file_class_methods=lambda: file_class_methods or {},
+        js_shadowed_globals=shadowed_globals,
     )
 
 
@@ -46,6 +48,17 @@ def _ctx(
 def test_javascript_is_registered() -> None:
     assert "javascript" in registered_languages()
     assert get_language_resolver("javascript") is not None
+
+
+def test_jsx_is_registered() -> None:
+    """Codex P2 #346: ``.jsx`` files are tagged ``"jsx"`` by the detector, and
+    ``resolve_callee`` looks up the registry by that exact language string. If
+    only ``"javascript"`` is registered, JSX callers bypass this SAFE resolver
+    and fall through to the Python cascade (e.g. a bare ``len()`` in a ``.jsx``
+    file would be mis-classified as a Python builtin). The ``jsx`` dialect must
+    route to the same resolver so it stays conservative."""
+    assert "jsx" in registered_languages()
+    assert get_language_resolver("jsx") is not None
 
 
 # ---------------------------------------------------------------------------
@@ -69,6 +82,38 @@ def test_build_returns_context_when_js_file_indexed() -> None:
     assert ctx is not None
 
 
+def test_build_returns_context_when_only_jsx_file_indexed() -> None:
+    """Codex P2 #346: a project containing only ``.jsx`` files (tagged ``"jsx"``)
+    must still build the JS context — otherwise JSX callers get no resolver."""
+    ctx = _ctx(file_languages={"App.jsx": "jsx"})
+    assert ctx is not None
+
+
+def test_jsx_caller_bare_call_stays_unknown_not_python_builtin() -> None:
+    """Codex P2 #346: the canonical bug — a bare ``len()`` in a JSX file. With
+    the JS resolver active for ``jsx``, an unowned bare name stays ``unknown``
+    (conservative) instead of leaking to the Python cascade as a builtin."""
+    ctx = _ctx(file_languages={"App.jsx": "jsx"})
+    assert resolve_javascript_callee("len", "len", "App.jsx", ctx) == (
+        None,
+        "unknown",
+        "",
+    )
+
+
+def test_jsx_local_resolution_works() -> None:
+    """A same-file bare call inside a ``.jsx`` file resolves ``local``."""
+    ctx = _ctx(
+        file_languages={"App.jsx": "jsx"},
+        file_symbols={"App.jsx": [("renderRow", "function", 12)]},
+    )
+    assert resolve_javascript_callee("renderRow", "renderRow", "App.jsx", ctx) == (
+        12,
+        "local",
+        "App.jsx",
+    )
+
+
 # ---------------------------------------------------------------------------
 # local — same-file resolution
 # ---------------------------------------------------------------------------
@@ -81,6 +126,34 @@ def test_bare_call_to_same_file_function_is_local() -> None:
         7,
         "local",
         "app.js",
+    )
+
+
+def test_self_receiver_does_not_bind_to_same_file_helper() -> None:
+    """Codex P2 #346: in browser/worker JS, ``self`` is the global scope
+    (``Window.self`` / ``WorkerGlobalScope.self``), NOT the current object.
+    ``self.foo()`` must NOT bind to a same-file helper named ``foo`` — that is a
+    concrete wrong edge. The conservative result is ``unknown``."""
+    ctx = _ctx(
+        file_languages={"worker.js": "javascript"},
+        file_symbols={"worker.js": [("postMessage", "function", 4)]},
+    )
+    assert resolve_javascript_callee(
+        "postMessage", "self.postMessage", "worker.js", ctx
+    ) == (None, "unknown", "")
+
+
+def test_self_receiver_does_not_bind_to_same_file_method() -> None:
+    """``self.render()`` must not bind a same-file class method ``render`` —
+    ``self`` is global scope in JS, not ``this``."""
+    ctx = _ctx(
+        file_languages={"app.js": "javascript"},
+        file_class_methods={"app.js": {"Widget": {"render": 11}}},
+    )
+    assert resolve_javascript_callee("render", "self.render", "app.js", ctx) == (
+        None,
+        "unknown",
+        "",
     )
 
 
@@ -150,6 +223,34 @@ def test_project_shadow_of_builtin_receiver_suppresses_builtin() -> None:
     )
     sid, res, _ = resolve_javascript_callee("max", "Math.max", "geo.js", ctx)
     assert res != "builtin"
+
+
+def test_variable_shadow_of_builtin_receiver_suppresses_builtin() -> None:
+    """Codex P2 #346: ``const Math = { max() {} }; Math.max()``. The shadow is a
+    ``kind='variable'`` row, which the shared ``global_name_table`` (built from
+    function/method/class only) never sees. The resolver must consult the
+    JS-family variable shadows too — otherwise ``Math.max`` is wrongly marked
+    terminal ``builtin`` even though the project owns the receiver."""
+    ctx = _ctx(
+        file_languages={"geo.js": "javascript"},
+        shadowed_globals={"Math"},
+    )
+    sid, res, _ = resolve_javascript_callee("max", "Math.max", "geo.js", ctx)
+    assert res != "builtin"
+
+
+def test_variable_shadow_only_blocks_the_shadowed_receiver() -> None:
+    """A variable shadow of ``Math`` must NOT suppress an unrelated builtin
+    (``JSON.parse``) — the gate is per-receiver-name, not global."""
+    ctx = _ctx(
+        file_languages={"app.js": "javascript"},
+        shadowed_globals={"Math"},
+    )
+    assert resolve_javascript_callee("parse", "JSON.parse", "app.js", ctx) == (
+        None,
+        "builtin",
+        "",
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_javascript_method_resolution.py
+++ b/tests/unit/test_javascript_method_resolution.py
@@ -1,0 +1,245 @@
+"""RFC-0010 first wave: JavaScript per-language callee resolver.
+
+Unit-level tests that drive ``resolve_javascript_callee`` against a hand-built
+context (no full index needed). They assert the four guarantees of a SAFE,
+self-contained resolver:
+
+* same-file ``local`` resolution from ``file_symbols`` / ``file_class_methods``,
+* CONSERVATIVE ``builtin`` classification on the FULL dotted call name only,
+* ``project`` resolution gated to the JS family, and
+* the MOAT: a callee whose name also exists in another language's file must
+  NEVER bind to that file — it stays ``unknown`` (or the JS same-file def).
+"""
+
+from __future__ import annotations
+
+from tree_sitter_analyzer.synapse_resolver._registry import (
+    get_language_resolver,
+    registered_languages,
+)
+from tree_sitter_analyzer.synapse_resolver.languages.javascript import (
+    build_javascript_context,
+    resolve_javascript_callee,
+)
+
+
+def _ctx(
+    *,
+    file_symbols=None,
+    file_class_methods=None,
+    global_name_table=None,
+    file_languages=None,
+):
+    """Build a JS resolver context from explicit maps (thunk-style fcm)."""
+    return build_javascript_context(
+        imports_by_file={},
+        file_languages=file_languages or {},
+        file_symbols=file_symbols or {},
+        global_name_table=global_name_table or {},
+        file_class_methods=lambda: file_class_methods or {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# registration / discovery
+# ---------------------------------------------------------------------------
+def test_javascript_is_registered() -> None:
+    assert "javascript" in registered_languages()
+    assert get_language_resolver("javascript") is not None
+
+
+# ---------------------------------------------------------------------------
+# gating — zero cost for non-JS projects
+# ---------------------------------------------------------------------------
+def test_build_returns_none_when_no_js_file_indexed() -> None:
+    ctx = build_javascript_context(
+        imports_by_file={},
+        file_languages={"a.py": "python", "B.java": "java"},
+        file_symbols={},
+        global_name_table={},
+        file_class_methods=lambda: (_ for _ in ()).throw(
+            AssertionError("thunk must NOT be forced for a non-JS index")
+        ),
+    )
+    assert ctx is None
+
+
+def test_build_returns_context_when_js_file_indexed() -> None:
+    ctx = _ctx(file_languages={"app.js": "javascript"})
+    assert ctx is not None
+
+
+# ---------------------------------------------------------------------------
+# local — same-file resolution
+# ---------------------------------------------------------------------------
+def test_bare_call_to_same_file_function_is_local() -> None:
+    ctx = _ctx(
+        file_languages={"app.js": "javascript"},
+        file_symbols={"app.js": [("helper", "function", 7)]},
+    )
+    assert resolve_javascript_callee("helper", "helper", "app.js", ctx) == (
+        7,
+        "local",
+        "app.js",
+    )
+
+
+def test_this_method_call_is_local_via_class_methods() -> None:
+    ctx = _ctx(
+        file_languages={"app.js": "javascript"},
+        file_class_methods={"app.js": {"Widget": {"render": 11}}},
+    )
+    assert resolve_javascript_callee("render", "this.render", "app.js", ctx) == (
+        11,
+        "local",
+        "app.js",
+    )
+
+
+# ---------------------------------------------------------------------------
+# builtin — namespaced globals, full-name match only
+# ---------------------------------------------------------------------------
+def test_namespaced_builtin_classifies_as_builtin() -> None:
+    ctx = _ctx(file_languages={"app.js": "javascript"})
+    assert resolve_javascript_callee("parse", "JSON.parse", "app.js", ctx) == (
+        None,
+        "builtin",
+        "",
+    )
+    assert resolve_javascript_callee("keys", "Object.keys", "app.js", ctx) == (
+        None,
+        "builtin",
+        "",
+    )
+
+
+def test_bare_builtin_method_name_is_not_builtin() -> None:
+    """A bare ``parse`` / ``keys`` (no namespace) must NOT classify as builtin —
+    every domain object defines such names; only the dotted form is safe."""
+    ctx = _ctx(file_languages={"app.js": "javascript"})
+    assert resolve_javascript_callee("parse", "parse", "app.js", ctx) == (
+        None,
+        "unknown",
+        "",
+    )
+    # ``users.map(...)`` — a domain array method, not Array.from — stays unknown.
+    assert resolve_javascript_callee("map", "users.map", "app.js", ctx) == (
+        None,
+        "unknown",
+        "",
+    )
+
+
+def test_console_log_is_not_builtin() -> None:
+    """``console`` is a commonly shadowed domain logger name; deliberately not
+    in the builtin table, so ``console.log`` stays unknown (conservative)."""
+    ctx = _ctx(file_languages={"app.js": "javascript"})
+    assert resolve_javascript_callee("log", "console.log", "app.js", ctx) == (
+        None,
+        "unknown",
+        "",
+    )
+
+
+def test_project_shadow_of_builtin_receiver_suppresses_builtin() -> None:
+    """If the project owns a JS object literally named ``Math``, ``Math.max``
+    is no longer a safe builtin — it could be the project's Math."""
+    ctx = _ctx(
+        file_languages={"geo.js": "javascript"},
+        global_name_table={"Math": [("geo.js", 3)]},
+    )
+    sid, res, _ = resolve_javascript_callee("max", "Math.max", "geo.js", ctx)
+    assert res != "builtin"
+
+
+# ---------------------------------------------------------------------------
+# project — single JS-family global
+# ---------------------------------------------------------------------------
+def test_single_js_global_resolves_to_project() -> None:
+    ctx = _ctx(
+        file_languages={"a.js": "javascript", "b.js": "javascript"},
+        global_name_table={"compute": [("b.js", 99)]},
+    )
+    assert resolve_javascript_callee("compute", "compute", "a.js", ctx) == (
+        99,
+        "project",
+        "b.js",
+    )
+
+
+def test_ts_family_global_is_resolvable_from_js_caller() -> None:
+    """JS/TS are one interop family — a single ``.ts`` global is a valid bind."""
+    ctx = _ctx(
+        file_languages={"a.js": "javascript", "b.ts": "typescript"},
+        global_name_table={"compute": [("b.ts", 5)]},
+    )
+    sid, res, target = resolve_javascript_callee("compute", "compute", "a.js", ctx)
+    assert (sid, res, target) == (5, "project", "b.ts")
+
+
+def test_ambiguous_global_stays_unknown() -> None:
+    """Two JS definitions of the same bare name → unknown (no guess)."""
+    ctx = _ctx(
+        file_languages={
+            "a.js": "javascript",
+            "b.js": "javascript",
+            "c.js": "javascript",
+        },
+        global_name_table={"compute": [("b.js", 1), ("c.js", 2)]},
+    )
+    assert resolve_javascript_callee("compute", "compute", "a.js", ctx) == (
+        None,
+        "unknown",
+        "",
+    )
+
+
+# ---------------------------------------------------------------------------
+# THE MOAT — mandatory no-cross-language-mis-wire test
+# ---------------------------------------------------------------------------
+def test_no_cross_language_mis_wire_global() -> None:
+    """A bare callee whose ONLY project definition lives in a Python file must
+    NOT bind to that Python file — it stays ``unknown``. (Same name, foreign
+    language: the exact CodeGraph failure this project exists to beat.)"""
+    ctx = _ctx(
+        file_languages={"a.js": "javascript", "util.py": "python"},
+        # ``parse`` is defined ONLY in Python — a JS caller must not bind it.
+        global_name_table={"parse": [("util.py", 42)]},
+    )
+    assert resolve_javascript_callee("parse", "parse", "a.js", ctx) == (
+        None,
+        "unknown",
+        "",
+    )
+
+
+def test_no_cross_language_mis_wire_prefers_js_same_name() -> None:
+    """When the name exists in BOTH a JS file and a foreign file, only the JS
+    definition is eligible — the resolver binds the JS one, never the foreign
+    file, and never reports the foreign file as the target."""
+    ctx = _ctx(
+        file_languages={
+            "a.js": "javascript",
+            "b.js": "javascript",
+            "Service.java": "java",
+        },
+        global_name_table={"handle": [("b.js", 8), ("Service.java", 100)]},
+    )
+    sid, res, target = resolve_javascript_callee("handle", "handle", "a.js", ctx)
+    # Exactly one JS-family owner (b.js) → bound; the Java file is filtered out.
+    assert (sid, res, target) == (8, "project", "b.js")
+    assert target != "Service.java"
+
+
+def test_no_cross_language_builtin_suppression_ignores_foreign_owner() -> None:
+    """A foreign-language symbol named ``Math`` must NOT suppress the JS builtin
+    ``Math.max`` — only a JS-family ``Math`` shadows it."""
+    ctx = _ctx(
+        file_languages={"app.js": "javascript", "Math.java": "java"},
+        global_name_table={"Math": [("Math.java", 1)]},
+    )
+    assert resolve_javascript_callee("max", "Math.max", "app.js", ctx) == (
+        None,
+        "builtin",
+        "",
+    )

--- a/tests/unit/test_javascript_method_resolution.py
+++ b/tests/unit/test_javascript_method_resolution.py
@@ -169,6 +169,39 @@ def test_this_method_call_is_local_via_class_methods() -> None:
     )
 
 
+def test_this_method_does_not_bind_across_sibling_classes() -> None:
+    """Codex P2 #346: ``class A { run() { this.render(); } } class B { render(){} }``.
+    The caller ``A.run`` does NOT define ``render``; only the SIBLING class ``B``
+    does. Without the caller's enclosing class we cannot prove ``this.render`` is
+    a call on ``A``, so binding it to ``B.render`` is a concrete wrong edge. With
+    two+ classes in the file, ``this.<method>`` must stay ``unknown``."""
+    ctx = _ctx(
+        file_languages={"app.js": "javascript"},
+        file_class_methods={
+            "app.js": {"A": {"run": 1}, "B": {"render": 2}},
+        },
+    )
+    assert resolve_javascript_callee("render", "this.render", "app.js", ctx) == (
+        None,
+        "unknown",
+        "",
+    )
+
+
+def test_this_method_single_class_still_binds() -> None:
+    """Sanity: with exactly ONE class in the file, ``this.<method>`` is
+    unambiguous — ``this`` can only be that class — so the local bind holds."""
+    ctx = _ctx(
+        file_languages={"app.js": "javascript"},
+        file_class_methods={"app.js": {"Widget": {"render": 11}}},
+    )
+    assert resolve_javascript_callee("render", "this.render", "app.js", ctx) == (
+        11,
+        "local",
+        "app.js",
+    )
+
+
 # ---------------------------------------------------------------------------
 # builtin — namespaced globals, full-name match only
 # ---------------------------------------------------------------------------
@@ -260,6 +293,7 @@ def test_single_js_global_resolves_to_project() -> None:
     ctx = _ctx(
         file_languages={"a.js": "javascript", "b.js": "javascript"},
         global_name_table={"compute": [("b.js", 99)]},
+        file_symbols={"b.js": [("compute", "function", 99)]},
     )
     assert resolve_javascript_callee("compute", "compute", "a.js", ctx) == (
         99,
@@ -268,11 +302,61 @@ def test_single_js_global_resolves_to_project() -> None:
     )
 
 
+def test_bare_call_does_not_bind_to_a_method_global() -> None:
+    """Codex P2 #346: ``global_name_table`` holds every function/method/class,
+    but a BARE ``render()`` (no receiver/import) cannot call a class METHOD —
+    methods need an owning receiver. The lone JS-family owner of ``render`` here
+    is a *method* on a class in another file, so the bare call must NOT bind to
+    it; it stays ``unknown`` rather than wiring a wrong cross-file edge."""
+    ctx = _ctx(
+        file_languages={"a.js": "javascript", "widget.js": "javascript"},
+        global_name_table={"render": [("widget.js", 50)]},
+        file_symbols={"widget.js": [("render", "method", 50)]},
+    )
+    assert resolve_javascript_callee("render", "render", "a.js", ctx) == (
+        None,
+        "unknown",
+        "",
+    )
+
+
+def test_bare_call_does_not_bind_to_a_class_global() -> None:
+    """A bare ``Widget()`` whose only owner is a *class* is a construction, not a
+    plain function call; conservatively it is not a bare-callable project target,
+    so it stays ``unknown`` rather than binding to the class symbol."""
+    ctx = _ctx(
+        file_languages={"a.js": "javascript", "widget.js": "javascript"},
+        global_name_table={"Widget": [("widget.js", 60)]},
+        file_symbols={"widget.js": [("Widget", "class", 60)]},
+    )
+    assert resolve_javascript_callee("Widget", "Widget", "a.js", ctx) == (
+        None,
+        "unknown",
+        "",
+    )
+
+
+def test_bare_call_binds_to_a_function_global() -> None:
+    """The complement of the above: a bare call whose lone JS-family owner is a
+    top-level *function* IS a valid bare-callable project target and binds."""
+    ctx = _ctx(
+        file_languages={"a.js": "javascript", "util.js": "javascript"},
+        global_name_table={"compute": [("util.js", 70)]},
+        file_symbols={"util.js": [("compute", "function", 70)]},
+    )
+    assert resolve_javascript_callee("compute", "compute", "a.js", ctx) == (
+        70,
+        "project",
+        "util.js",
+    )
+
+
 def test_ts_family_global_is_resolvable_from_js_caller() -> None:
     """JS/TS are one interop family — a single ``.ts`` global is a valid bind."""
     ctx = _ctx(
         file_languages={"a.js": "javascript", "b.ts": "typescript"},
         global_name_table={"compute": [("b.ts", 5)]},
+        file_symbols={"b.ts": [("compute", "function", 5)]},
     )
     sid, res, target = resolve_javascript_callee("compute", "compute", "a.js", ctx)
     assert (sid, res, target) == (5, "project", "b.ts")
@@ -325,6 +409,10 @@ def test_no_cross_language_mis_wire_prefers_js_same_name() -> None:
             "Service.java": "java",
         },
         global_name_table={"handle": [("b.js", 8), ("Service.java", 100)]},
+        file_symbols={
+            "b.js": [("handle", "function", 8)],
+            "Service.java": [("handle", "method", 100)],
+        },
     )
     sid, res, target = resolve_javascript_callee("handle", "handle", "a.js", ctx)
     # Exactly one JS-family owner (b.js) → bound; the Java file is filtered out.

--- a/tree_sitter_analyzer/synapse_resolver/_javascript_constants.py
+++ b/tree_sitter_analyzer/synapse_resolver/_javascript_constants.py
@@ -1,0 +1,86 @@
+"""Conservative builtin / stdlib name tiers for the JavaScript resolver.
+
+RFC-0010 first wave. These literal sets are kept out of the resolver logic so
+the resolver module stays small and the tables are auditable in isolation.
+
+CURATION RULE — PRECISION over recall (the RFC-0008 Java lesson, applied to JS).
+JavaScript has no receiver-type evidence at this tier and no import-graph step
+in the first-wave resolver, so a bare callee name (``log``, ``map``, ``get``…)
+carries no proof that it is the global/builtin API rather than a user method.
+The project-ownership gate only separates *project* from *not-project* — it does
+NOT separate *builtin* from *user-defined-with-the-same-name*. Therefore a name
+is KEPT here ONLY if it is a **dotted, namespaced global** call whose receiver is
+itself a JS built-in object (``JSON.parse``, ``Object.keys``, ``Math.max``) —
+i.e. the FULL call name (receiver + method) is near-exclusively the JS builtin
+API and extremely unlikely to be a user-defined object of the same name.
+
+Bare method names (``map``/``filter``/``forEach``/``then``/``get``/``set``/
+``push``/``log`` without a namespace) are DELIBERATELY EXCLUDED: every array,
+promise, collection wrapper, logger, and domain object defines them, and the
+tier cannot tell ``users.map(...)`` (a domain array) from a builtin. Even
+``console.log`` is excluded — ``console`` is routinely shadowed by a domain
+logger/façade named ``console`` and ``log`` is a ubiquitous user method.
+
+An EMPTY result for a given call is correct and acceptable: everything that is
+not a recognised namespaced builtin stays ``local`` (same-file) or ``unknown``,
+never mis-classified into another language's file. Matching is on the FULL
+dotted call name (``<receiver>.<method>``), never on the bare method name.
+"""
+
+from __future__ import annotations
+
+# Namespaced JS global/builtin calls. The KEY is the exact dotted call name
+# (receiver + "." + method) as it appears in a call edge's full name; only an
+# exact full-name match classifies as ``builtin``. Receivers chosen are global
+# singletons that a user object almost never re-creates with the SAME method:
+#   * ``JSON`` — the global JSON object (parse/stringify).
+#   * ``Math`` — the global Math object (pure numeric helpers).
+#   * ``Object`` / ``Array`` / ``Number`` — global constructors used as
+#     namespaces for static helpers (``Object.keys``, ``Array.isArray``,
+#     ``Number.isNaN``); the STATIC forms are distinctively builtin, unlike the
+#     instance methods that share their bare names.
+#   * ``Promise`` — static combinators (``Promise.all``/``race``/``resolve``).
+#
+# Bare-name instance methods (``push``/``map``/``keys`` on an arbitrary object)
+# are NOT here — only the namespaced static forms above. ``console.*`` is
+# excluded on purpose (``console`` is a commonly shadowed domain logger name).
+JS_BUILTIN_CALLS: frozenset[str] = frozenset(
+    {
+        "JSON.parse",
+        "JSON.stringify",
+        "Math.max",
+        "Math.min",
+        "Math.abs",
+        "Math.floor",
+        "Math.ceil",
+        "Math.round",
+        "Math.random",
+        "Math.sqrt",
+        "Math.pow",
+        "Object.keys",
+        "Object.values",
+        "Object.entries",
+        "Object.assign",
+        "Object.freeze",
+        "Object.create",
+        "Object.getPrototypeOf",
+        "Object.defineProperty",
+        "Array.isArray",
+        "Array.from",
+        "Array.of",
+        "Number.isNaN",
+        "Number.isInteger",
+        "Number.isFinite",
+        "Number.parseInt",
+        "Number.parseFloat",
+        "Promise.all",
+        "Promise.allSettled",
+        "Promise.race",
+        "Promise.any",
+        "Promise.resolve",
+        "Promise.reject",
+    }
+)
+
+
+__all__ = ["JS_BUILTIN_CALLS"]

--- a/tree_sitter_analyzer/synapse_resolver/languages/javascript.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/javascript.py
@@ -32,7 +32,21 @@ from .._javascript_constants import JS_BUILTIN_CALLS
 from .._registry import register_language
 
 #: Receivers that denote a same-file call rather than an external object.
-_SELF_RECEIVERS: frozenset[str] = frozenset({"", "this", "self"})
+#: ``self`` is DELIBERATELY EXCLUDED — in browser/worker JavaScript ``self`` is
+#: the global scope (``Window.self`` / ``WorkerGlobalScope.self``), not the
+#: current object. Treating ``self.foo()`` as a same-file call would bind it to
+#: any local helper named ``foo`` — a concrete wrong edge. Only ``this`` (and a
+#: bare call) denote the caller's own scope (Codex P2 #346).
+_SELF_RECEIVERS: frozenset[str] = frozenset({"", "this"})
+
+#: JS-family dialects this resolver claims. ``.jsx`` files are tagged ``"jsx"``
+#: by the language detector and ``resolve_callee`` dispatches by that exact
+#: string, so the resolver registers under every JS-family dialect it serves —
+#: otherwise JSX callers bypass this SAFE resolver and leak into the Python
+#: cascade (e.g. a bare ``len()`` mis-classified as a Python builtin). TS/TSX
+#: have their own resolvers; this module owns ``javascript`` and ``jsx`` only
+#: (Codex P2 #346).
+_JS_DIALECTS: tuple[str, ...] = ("javascript", "jsx")
 
 
 class JavaScriptResolverContext:
@@ -47,6 +61,7 @@ class JavaScriptResolverContext:
         "file_class_methods",
         "global_name_table",
         "file_languages",
+        "shadowed_globals",
     )
 
     def __init__(
@@ -56,11 +71,47 @@ class JavaScriptResolverContext:
         file_class_methods: dict[str, dict[str, dict[str, int]]],
         global_name_table: dict[str, list[tuple[str, int]]],
         file_languages: dict[str, str],
+        shadowed_globals: frozenset[str],
     ) -> None:
         self.file_symbols = file_symbols
         self.file_class_methods = file_class_methods
         self.global_name_table = global_name_table
         self.file_languages = file_languages
+        #: Bare names defined as JS-family ``variable``-kind symbols (``const``/
+        #: ``let``/``var``). The shared ``global_name_table`` is built from
+        #: function/method/class rows only, so an object-literal shadow such as
+        #: ``const Math = {...}`` is otherwise invisible to the ownership gate
+        #: (Codex P2 #346).
+        self.shadowed_globals = shadowed_globals
+
+
+def _js_shadowed_globals_from_conn(
+    conn: Any, file_languages: dict[str, str]
+) -> frozenset[str]:
+    """JS-family ``variable``-kind symbol names, for the builtin-shadow gate.
+
+    The shared resolver maps (``global_name_table`` / ``file_symbols``) are built
+    from ``kind IN ('function','method','class')`` only, so an object-literal
+    shadow such as ``const Math = {...}`` never reaches the ownership gate. This
+    single extra query (run once per index pass, JS-projects only) recovers the
+    ``variable`` rows so ``Math.max`` on a shadowed ``Math`` stays out of the
+    terminal ``builtin`` tier (Codex P2 #346). Best-effort: any DB error yields
+    an empty set, degrading to the prior behaviour rather than raising.
+    """
+    if conn is None:
+        return frozenset()
+    try:
+        rows = conn.execute(
+            "SELECT DISTINCT name, language FROM ast_symbol_rows "
+            "WHERE kind = 'variable'"
+        ).fetchall()
+    except Exception:  # nosec B110 — table/fts5 tolerance; degrade to empty.
+        return frozenset()
+    names: set[str] = set()
+    for row in rows:
+        if languages_compatible("javascript", row["language"] or ""):
+            names.add(row["name"])
+    return frozenset(names)
 
 
 def build_javascript_context(
@@ -70,22 +121,31 @@ def build_javascript_context(
     file_symbols: dict[str, Any],
     global_name_table: dict[str, Any],
     file_class_methods: Any,  # lazy thunk -> class->method map
+    conn: Any = None,
+    js_shadowed_globals: Any = None,  # test-injection override
     **_ignored: Any,
 ) -> JavaScriptResolverContext | None:
     """Build the JS context, or ``None`` when no ``.js``/``.jsx`` file is indexed.
 
     Zero cost for non-JavaScript projects: gated on ``file_languages`` BEFORE the
     lazy ``file_class_methods`` thunk is forced, so a Python/Java-only index
-    never pays to materialise the class-method map for JavaScript.
+    never pays to materialise the class-method map for JavaScript. The gate
+    matches every JS-family dialect this resolver serves (``javascript`` /
+    ``jsx``), so a ``.jsx``-only project still builds a context (Codex P2 #346).
     """
-    if not any(lang == "javascript" for lang in file_languages.values()):
+    if not any(lang in _JS_DIALECTS for lang in file_languages.values()):
         return None
     fcm = file_class_methods() if callable(file_class_methods) else file_class_methods
+    if js_shadowed_globals is not None:
+        shadowed = frozenset(js_shadowed_globals)
+    else:
+        shadowed = _js_shadowed_globals_from_conn(conn, file_languages)
     return JavaScriptResolverContext(
         file_symbols=file_symbols,
         file_class_methods=fcm or {},
         global_name_table=global_name_table,
         file_languages=file_languages,
+        shadowed_globals=shadowed,
     )
 
 
@@ -109,12 +169,19 @@ def _lookup_in_file(
 
 
 def _js_project_owns(ctx: JavaScriptResolverContext, simple: str) -> bool:
-    """True when a JS-FAMILY project file defines a symbol named ``simple``.
+    """True when a JS-FAMILY project symbol is named ``simple``.
 
     Language-aware ownership gate: a same-named symbol in an incompatible
     language (a Python ``parse``, a Java ``keys``) does NOT count, so it can
     never suppress a builtin classification or be mis-bound as ``project``.
+
+    Consults BOTH the function/method/class table and the JS-family
+    ``variable`` shadows, so an object-literal namespace such as
+    ``const Math = {...}`` also counts as ownership and suppresses the builtin
+    tier (Codex P2 #346).
     """
+    if simple in ctx.shadowed_globals:
+        return True
     for owner_file, _sym_id in ctx.global_name_table.get(simple, []):
         owner_lang = ctx.file_languages.get(owner_file, "")
         if languages_compatible("javascript", owner_lang):
@@ -137,8 +204,9 @@ def resolve_javascript_callee(
     ctx = lang_ctx
     receiver, simple = _split_receiver(full_name, bare_name)
 
-    # 1. local — no receiver (``foo()``) or ``this``/``self`` (``this.foo()``):
-    #    a call into the caller's own file.
+    # 1. local — no receiver (``foo()``) or ``this`` (``this.foo()``): a call
+    #    into the caller's own file. ``self`` is NOT here — it is the JS global
+    #    scope, not the current object (Codex P2 #346).
     if receiver in _SELF_RECEIVERS:
         sym_id = _lookup_in_file(ctx, caller_file, simple)
         if sym_id is not None:
@@ -176,4 +244,10 @@ def resolve_javascript_callee(
     return None, "unknown", ""
 
 
-register_language("javascript", build_javascript_context, resolve_javascript_callee)
+# Register under every JS-family dialect this resolver serves. ``resolve_callee``
+# dispatches by the caller file's exact language tag, and the language detector
+# tags ``.jsx`` files as ``"jsx"`` — so without the ``jsx`` registration those
+# callers bypass this SAFE resolver and leak into the Python cascade (Codex P2
+# #346). TS/TSX have their own resolvers and are intentionally not claimed here.
+for _dialect in _JS_DIALECTS:
+    register_language(_dialect, build_javascript_context, resolve_javascript_callee)

--- a/tree_sitter_analyzer/synapse_resolver/languages/javascript.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/javascript.py
@@ -168,6 +168,28 @@ def _lookup_in_file(
     return None
 
 
+#: Symbol kinds that a BARE call (no receiver, no import) can legally target.
+#: A top-level ``function`` is callable as ``foo()``; a class ``method`` is NOT
+#: (it needs an owning receiver), and a ``class`` used bare is a construction,
+#: not a plain call. ``global_name_table`` drops the kind, so the project tier
+#: cross-checks ``file_symbols`` and only binds a bare-callable kind — otherwise
+#: ``render()`` wires to a same-named method elsewhere (Codex P2 #346).
+_BARE_CALLABLE_KINDS: frozenset[str] = frozenset({"function"})
+
+
+def _owner_kind(ctx: JavaScriptResolverContext, owner_file: str, sym_id: int) -> str:
+    """Kind (``function``/``method``/``class``) of ``sym_id`` in ``owner_file``.
+
+    Recovered from ``file_symbols`` because the shared ``global_name_table``
+    carries only ``(file, id)`` and drops the kind. Returns ``""`` when the
+    owner row is not present (so the caller can treat it conservatively).
+    """
+    for _name, kind, sid in ctx.file_symbols.get(owner_file, []):
+        if sid == sym_id:
+            return kind
+    return ""
+
+
 def _js_project_owns(ctx: JavaScriptResolverContext, simple: str) -> bool:
     """True when a JS-FAMILY project symbol is named ``simple``.
 
@@ -211,10 +233,20 @@ def resolve_javascript_callee(
         sym_id = _lookup_in_file(ctx, caller_file, simple)
         if sym_id is not None:
             return sym_id, "local", caller_file
-        for _cls, methods in ctx.file_class_methods.get(caller_file, {}).items():
-            mid = methods.get(simple)
-            if mid is not None:
-                return mid, "local", caller_file
+        # ``this.<method>`` may only bind to a class method when the enclosing
+        # class is unambiguous — i.e. the file defines exactly ONE class, so
+        # ``this`` can only be that class. With two+ classes we lack the
+        # caller's enclosing class, and binding ``this.render()`` in ``A`` to a
+        # SIBLING ``B.render`` is a concrete wrong edge; stay ``unknown``
+        # (Codex P2 #346). A bare ``foo()`` (no receiver) is never a method
+        # call, so it never enters this class-method path.
+        if receiver == "this":
+            classes = ctx.file_class_methods.get(caller_file, {})
+            if len(classes) == 1:
+                ((_cls, methods),) = classes.items()
+                mid = methods.get(simple)
+                if mid is not None:
+                    return mid, "local", caller_file
 
     # 2. builtin — a namespaced JS global call matched on the FULL dotted name
     #    (``JSON.parse``, ``Object.keys`` …). Terminal: outside the project.
@@ -226,8 +258,13 @@ def resolve_javascript_callee(
         if full in JS_BUILTIN_CALLS and not _js_project_owns(ctx, head):
             return None, "builtin", ""
 
-    # 3. project — exactly one JS-family project-wide definition of a BARE name.
-    #    Gated by language so a same-name Python/Java symbol is never bound.
+    # 3. project — exactly one JS-family project-wide definition of a BARE name,
+    #    AND that definition must be a bare-callable kind (a top-level
+    #    ``function``). A class ``method`` is not callable without a receiver and
+    #    a bare ``class`` name is a construction, not a plain call — binding
+    #    ``render()`` to a same-named method elsewhere is a wrong cross-file edge
+    #    (Codex P2 #346). Gated by language so a same-name Python/Java symbol is
+    #    never bound (the MOAT).
     if not receiver:
         js_cands = [
             (owner_file, sym_id)
@@ -235,6 +272,7 @@ def resolve_javascript_callee(
             if languages_compatible(
                 "javascript", ctx.file_languages.get(owner_file, "")
             )
+            and _owner_kind(ctx, owner_file, sym_id) in _BARE_CALLABLE_KINDS
         ]
         if len(js_cands) == 1:
             target_file, sym_id = js_cands[0]

--- a/tree_sitter_analyzer/synapse_resolver/languages/javascript.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/javascript.py
@@ -31,13 +31,15 @@ from ..._language_family import languages_compatible
 from .._javascript_constants import JS_BUILTIN_CALLS
 from .._registry import register_language
 
-#: Receivers that denote a same-file call rather than an external object.
-#: ``self`` is DELIBERATELY EXCLUDED — in browser/worker JavaScript ``self`` is
-#: the global scope (``Window.self`` / ``WorkerGlobalScope.self``), not the
-#: current object. Treating ``self.foo()`` as a same-file call would bind it to
-#: any local helper named ``foo`` — a concrete wrong edge. Only ``this`` (and a
-#: bare call) denote the caller's own scope (Codex P2 #346).
-_SELF_RECEIVERS: frozenset[str] = frozenset({"", "this"})
+#: Same-scope receivers handled by the ``local`` tier, each by a DISTINCT path
+#: (see ``resolve_javascript_callee`` step 1):
+#:   * ``""``   — a bare ``foo()`` call: a top-level callable in the caller file.
+#:   * ``this`` — a method call on the caller's own object, bound only through
+#:     the unambiguous single-class gate.
+#: ``self`` is DELIBERATELY ABSENT — in browser/worker JavaScript ``self`` is the
+#: global scope (``Window.self`` / ``WorkerGlobalScope.self``), not the current
+#: object. Treating ``self.foo()`` as a same-file call would bind it to any local
+#: helper named ``foo`` — a concrete wrong edge (Codex P2 #346).
 
 #: JS-family dialects this resolver claims. ``.jsx`` files are tagged ``"jsx"``
 #: by the language detector and ``resolve_callee`` dispatches by that exact
@@ -161,9 +163,19 @@ def _split_receiver(full_name: str, bare_name: str) -> tuple[str, str]:
 def _lookup_in_file(
     ctx: JavaScriptResolverContext, file_path: str, simple: str
 ) -> int | None:
-    """Symbol id of a function/method/class named ``simple`` in ``file_path``."""
+    """Symbol id of a same-file BARE-CALLABLE named ``simple`` in ``file_path``.
+
+    Restricted to a top-level ``function`` (see ``_BARE_CALLABLE_KINDS``): a
+    bare ``foo()`` is the only same-scope form routed here, and a bare call
+    cannot target a class ``method`` (it needs an owning receiver) nor a
+    ``class`` (that is a construction, not a plain call). Real resolver contexts
+    populate ``file_symbols`` with EVERY method in the file, so matching
+    ``method`` here would bind a bare ``render()`` to a sibling class's method —
+    a concrete wrong edge (Codex P2 #346, line 235). ``this.<method>`` is bound
+    separately through the unambiguous single-class gate, not here.
+    """
     for name, kind, sym_id in ctx.file_symbols.get(file_path, []):
-        if name == simple and kind in ("function", "method", "class"):
+        if name == simple and kind in _BARE_CALLABLE_KINDS:
             return sym_id
     return None
 
@@ -226,27 +238,35 @@ def resolve_javascript_callee(
     ctx = lang_ctx
     receiver, simple = _split_receiver(full_name, bare_name)
 
-    # 1. local — no receiver (``foo()``) or ``this`` (``this.foo()``): a call
-    #    into the caller's own file. ``self`` is NOT here — it is the JS global
-    #    scope, not the current object (Codex P2 #346).
-    if receiver in _SELF_RECEIVERS:
+    # 1. local — a call into the caller's own file. ``self`` is NOT here — it is
+    #    the JS global scope, not the current object (Codex P2 #346).
+    #
+    #    The two same-scope forms are resolved by SEPARATE paths because they
+    #    have different binding rules:
+    #
+    #    * bare ``foo()`` (no receiver) — never a method call, so the flat
+    #      ``file_symbols`` scan is safe: it can only legitimately hit a
+    #      same-file ``function``/``class`` (a top-level callable).
+    #    * ``this.foo()`` — a METHOD call. It must NOT go through the flat
+    #      ``file_symbols`` scan: real resolver contexts populate
+    #      ``file_symbols`` with EVERY method in the file (sibling classes
+    #      included), so a flat lookup of ``this.render`` from ``A.run`` would
+    #      find a SIBLING ``B.render`` and bind a concrete wrong edge. It may
+    #      only bind through ``file_class_methods`` AND only when the file
+    #      defines exactly ONE class (so ``this`` is unambiguous). With 2+
+    #      classes we lack the caller's enclosing class → stay ``unknown``
+    #      (Codex P2 #346, line 235).
+    if receiver == "":
         sym_id = _lookup_in_file(ctx, caller_file, simple)
         if sym_id is not None:
             return sym_id, "local", caller_file
-        # ``this.<method>`` may only bind to a class method when the enclosing
-        # class is unambiguous — i.e. the file defines exactly ONE class, so
-        # ``this`` can only be that class. With two+ classes we lack the
-        # caller's enclosing class, and binding ``this.render()`` in ``A`` to a
-        # SIBLING ``B.render`` is a concrete wrong edge; stay ``unknown``
-        # (Codex P2 #346). A bare ``foo()`` (no receiver) is never a method
-        # call, so it never enters this class-method path.
-        if receiver == "this":
-            classes = ctx.file_class_methods.get(caller_file, {})
-            if len(classes) == 1:
-                ((_cls, methods),) = classes.items()
-                mid = methods.get(simple)
-                if mid is not None:
-                    return mid, "local", caller_file
+    elif receiver == "this":
+        classes = ctx.file_class_methods.get(caller_file, {})
+        if len(classes) == 1:
+            ((_cls, methods),) = classes.items()
+            mid = methods.get(simple)
+            if mid is not None:
+                return mid, "local", caller_file
 
     # 2. builtin — a namespaced JS global call matched on the FULL dotted name
     #    (``JSON.parse``, ``Object.keys`` …). Terminal: outside the project.

--- a/tree_sitter_analyzer/synapse_resolver/languages/javascript.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/javascript.py
@@ -1,0 +1,179 @@
+"""JavaScript callee resolver (RFC-0010 first wave).
+
+A self-contained, SAFE per-language resolver for ``.js`` / ``.jsx`` files. It
+REPLACES the generic Python cascade for JavaScript callers, so it must not
+regress: when unsure, it returns ``unknown`` (never a wrong binding).
+
+What it resolves:
+
+* **local** — a same-file call (no receiver, or ``this.``) whose simple name is
+  defined in the caller file (function / method / class). Pulled from the
+  shared ``file_symbols`` / ``file_class_methods`` maps.
+* **project** — a bare name with exactly ONE project-wide definition that lives
+  in a JS-family file (``.js``/``.ts``/``.jsx``/``.tsx``). The single-global
+  rule, gated by language so a same-named Python/Java symbol is never bound.
+* **builtin** — a namespaced JS global call (``JSON.parse``, ``Object.keys``,
+  ``Math.max`` …) matched on the FULL dotted call name. Terminal — outside the
+  project, never re-scanned.
+* **unknown** — everything else (the conservative default).
+
+THE MOAT — this resolver NEVER binds a callee to a symbol in a non-JS-family
+file. Cross-language same-name collisions resolve to ``unknown`` (or the JS
+same-file definition), never to the foreign file. That is the exact CodeGraph
+failure this project exists to beat.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..._language_family import languages_compatible
+from .._javascript_constants import JS_BUILTIN_CALLS
+from .._registry import register_language
+
+#: Receivers that denote a same-file call rather than an external object.
+_SELF_RECEIVERS: frozenset[str] = frozenset({"", "this", "self"})
+
+
+class JavaScriptResolverContext:
+    """Per-index JavaScript resolution maps (built once per pass).
+
+    Holds only the shared cross-language maps the resolver consults. All file
+    keys are project-relative paths, matching the ``edges`` table.
+    """
+
+    __slots__ = (
+        "file_symbols",
+        "file_class_methods",
+        "global_name_table",
+        "file_languages",
+    )
+
+    def __init__(
+        self,
+        *,
+        file_symbols: dict[str, list[tuple[str, str, int]]],
+        file_class_methods: dict[str, dict[str, dict[str, int]]],
+        global_name_table: dict[str, list[tuple[str, int]]],
+        file_languages: dict[str, str],
+    ) -> None:
+        self.file_symbols = file_symbols
+        self.file_class_methods = file_class_methods
+        self.global_name_table = global_name_table
+        self.file_languages = file_languages
+
+
+def build_javascript_context(
+    *,
+    imports_by_file: dict[str, Any],
+    file_languages: dict[str, str],
+    file_symbols: dict[str, Any],
+    global_name_table: dict[str, Any],
+    file_class_methods: Any,  # lazy thunk -> class->method map
+    **_ignored: Any,
+) -> JavaScriptResolverContext | None:
+    """Build the JS context, or ``None`` when no ``.js``/``.jsx`` file is indexed.
+
+    Zero cost for non-JavaScript projects: gated on ``file_languages`` BEFORE the
+    lazy ``file_class_methods`` thunk is forced, so a Python/Java-only index
+    never pays to materialise the class-method map for JavaScript.
+    """
+    if not any(lang == "javascript" for lang in file_languages.values()):
+        return None
+    fcm = file_class_methods() if callable(file_class_methods) else file_class_methods
+    return JavaScriptResolverContext(
+        file_symbols=file_symbols,
+        file_class_methods=fcm or {},
+        global_name_table=global_name_table,
+        file_languages=file_languages,
+    )
+
+
+def _split_receiver(full_name: str, bare_name: str) -> tuple[str, str]:
+    """Return ``(receiver, simple_name)`` from a JS call's full name."""
+    full = full_name or bare_name
+    if "." in full:
+        receiver, simple = full.rsplit(".", 1)
+        return receiver, simple
+    return "", full or bare_name
+
+
+def _lookup_in_file(
+    ctx: JavaScriptResolverContext, file_path: str, simple: str
+) -> int | None:
+    """Symbol id of a function/method/class named ``simple`` in ``file_path``."""
+    for name, kind, sym_id in ctx.file_symbols.get(file_path, []):
+        if name == simple and kind in ("function", "method", "class"):
+            return sym_id
+    return None
+
+
+def _js_project_owns(ctx: JavaScriptResolverContext, simple: str) -> bool:
+    """True when a JS-FAMILY project file defines a symbol named ``simple``.
+
+    Language-aware ownership gate: a same-named symbol in an incompatible
+    language (a Python ``parse``, a Java ``keys``) does NOT count, so it can
+    never suppress a builtin classification or be mis-bound as ``project``.
+    """
+    for owner_file, _sym_id in ctx.global_name_table.get(simple, []):
+        owner_lang = ctx.file_languages.get(owner_file, "")
+        if languages_compatible("javascript", owner_lang):
+            return True
+    return False
+
+
+def resolve_javascript_callee(
+    bare_name: str,
+    full_name: str,
+    caller_file: str,
+    lang_ctx: JavaScriptResolverContext,
+) -> tuple[int | None, str, str]:
+    """Resolve one JavaScript call edge.
+
+    Returns ``(symbol_id, resolution, resolved_file)`` where ``resolution`` is
+    one of ``local`` / ``project`` / ``builtin`` / ``unknown``. Conservative by
+    construction: anything not provably one of the first three is ``unknown``.
+    """
+    ctx = lang_ctx
+    receiver, simple = _split_receiver(full_name, bare_name)
+
+    # 1. local — no receiver (``foo()``) or ``this``/``self`` (``this.foo()``):
+    #    a call into the caller's own file.
+    if receiver in _SELF_RECEIVERS:
+        sym_id = _lookup_in_file(ctx, caller_file, simple)
+        if sym_id is not None:
+            return sym_id, "local", caller_file
+        for _cls, methods in ctx.file_class_methods.get(caller_file, {}).items():
+            mid = methods.get(simple)
+            if mid is not None:
+                return mid, "local", caller_file
+
+    # 2. builtin — a namespaced JS global call matched on the FULL dotted name
+    #    (``JSON.parse``, ``Object.keys`` …). Terminal: outside the project.
+    #    Suppressed if the project itself owns the receiver name in a JS file
+    #    (a domain object literally named ``Math``/``JSON`` shadowing the global).
+    if receiver:
+        full = full_name or f"{receiver}.{simple}"
+        head = receiver.split(".", 1)[0]
+        if full in JS_BUILTIN_CALLS and not _js_project_owns(ctx, head):
+            return None, "builtin", ""
+
+    # 3. project — exactly one JS-family project-wide definition of a BARE name.
+    #    Gated by language so a same-name Python/Java symbol is never bound.
+    if not receiver:
+        js_cands = [
+            (owner_file, sym_id)
+            for owner_file, sym_id in ctx.global_name_table.get(simple, [])
+            if languages_compatible(
+                "javascript", ctx.file_languages.get(owner_file, "")
+            )
+        ]
+        if len(js_cands) == 1:
+            target_file, sym_id = js_cands[0]
+            return sym_id, "project", target_file
+
+    # 4. unknown — the conservative default. Never a cross-language binding.
+    return None, "unknown", ""
+
+
+register_language("javascript", build_javascript_context, resolve_javascript_callee)


### PR DESCRIPTION
## Summary

First-wave RFC-0010 per-language callee resolver for **JavaScript** (`.js` / `.jsx`). **NEW-FILES-ONLY** — auto-discovered via `register_language`, no shared-file edits, so it lands without merge conflicts or worktree races against sibling language PRs.

Modelled on `languages/java.py`. It REPLACES the generic Python cascade for JS callers and is conservative by construction.

### Resolution tiers
- **local** — same-file call (no receiver, or `this.`) resolved from the shared `file_symbols` / `file_class_methods` maps.
- **builtin** — a namespaced JS global call (`JSON.parse`, `Object.keys`, `Math.max`, `Promise.all`, `Array.isArray`, …) matched on the **FULL dotted call name only**. Terminal (outside project). Bare method names (`map`/`get`/`push`/`log`) are **deliberately excluded** — every domain object defines them and the tier has no receiver-type evidence; `console.*` is excluded too (commonly shadowed). Suppressed if the project owns the receiver name in a JS file.
- **project** — a bare name with **exactly one JS-family** project-wide definition (single-global rule).
- **unknown** — the conservative default for everything else.

### THE MOAT — never cross-language bind
The resolver never binds a callee to a non-JS-family file. A callee whose name also exists only in a Python/Java file resolves to `unknown`, never the foreign file — the exact CodeGraph failure this project exists to beat. The ownership/project gates use the language-aware `languages_compatible('javascript', …)` so JS/TS/JSX/TSX interop is preserved while Python/Java is blocked.

## Files (3, all new)
- `tree_sitter_analyzer/synapse_resolver/languages/javascript.py`
- `tree_sitter_analyzer/synapse_resolver/_javascript_constants.py` (conservative `JS_BUILTIN_CALLS` tier)
- `tests/unit/test_javascript_method_resolution.py` (15 tests, incl. mandatory no-cross-language-mis-wire tests)

## Test plan
- RED-first verified (module-absent → ImportError, restored → green).
- `ruff check` + `ruff format --check` + `mypy` clean on the new files (pre-commit hooks green).
- `pytest tests/unit/test_javascript_method_resolution.py tests/unit/test_resolver_registry.py tests/unit/test_java_method_resolution.py` → 33 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)