### PR TITLE
feat(resolver): TypeScript per-language callee resolver (RFC-0010 first wave)

### DIFF
--- a/tests/unit/test_typescript_method_resolution.py
+++ b/tests/unit/test_typescript_method_resolution.py
@@ -285,6 +285,55 @@ def test_integration_import_shadow_suppresses_builtin(tmp_path: Path) -> None:
     )
 
 
+def test_integration_import_shadow_no_project_symbol_suppresses_builtin(
+    tmp_path: Path,
+) -> None:
+    """FULL INDEX PATH (Codex P2 #4): ``import { Map } from 'immutable'`` with NO
+    project class named ``Map``. The TS plugin stores the import's raw statement
+    under the ``text`` field (not ``name``/``source``), so the shadow set must be
+    built from ``text``. Without that, ``Map.of()`` is wrongly ``builtin`` because
+    the ``global_name_table`` path can't save it either (no project ``Map``)."""
+    db = _index(
+        tmp_path,
+        {
+            "svc.ts": (
+                "import { Map } from 'immutable';\n"
+                "class Service {\n"
+                "  run(): void { Map.of(1); }\n"
+                "}\n"
+            ),
+        },
+    )
+    res = _resolution_for(db, "of")
+    assert res, "expected a Map.of() edge"
+    assert "builtin" not in res, (
+        f"import-shadowed Map.of (no project symbol) must NOT classify builtin; "
+        f"got {res}"
+    )
+
+
+def test_integration_default_import_shadow_suppresses_builtin(tmp_path: Path) -> None:
+    """FULL INDEX PATH (Codex P2 #4): a default import ``import Promise from
+    'bluebird'`` (statement stored under ``text``) shadows the ``Promise`` global;
+    ``Promise.all()`` must NOT classify ``builtin``."""
+    db = _index(
+        tmp_path,
+        {
+            "svc.ts": (
+                "import Promise from 'bluebird';\n"
+                "class Service {\n"
+                "  run(): void { Promise.all([]); }\n"
+                "}\n"
+            ),
+        },
+    )
+    res = _resolution_for(db, "all")
+    assert res, "expected a Promise.all() edge"
+    assert "builtin" not in res, (
+        f"default-import-shadowed Promise.all must NOT classify builtin; got {res}"
+    )
+
+
 def test_integration_variable_shadow_suppresses_builtin(tmp_path: Path) -> None:
     """FULL INDEX PATH: ``const Promise = require('bluebird')`` shadows the
     ``Promise`` global; ``Promise.all()`` must NOT classify ``builtin``."""

--- a/tests/unit/test_typescript_method_resolution.py
+++ b/tests/unit/test_typescript_method_resolution.py
@@ -72,9 +72,10 @@ def _ctx(
     file_languages: dict[str, str] | None = None,
     global_name_table: dict[str, list[tuple[str, int]]] | None = None,
     file_class_methods: dict[str, dict[str, dict[str, int]]] | None = None,
+    imports_by_file: dict[str, list] | None = None,
 ):
     return build_typescript_resolver_context(
-        imports_by_file={},
+        imports_by_file=imports_by_file or {},
         file_languages=file_languages or {"a.ts": "typescript"},
         file_symbols=file_symbols or {},
         global_name_table=global_name_table or {},
@@ -177,6 +178,135 @@ def test_no_cross_language_bind_for_global_object_owner() -> None:
     )
     assert resolution == "builtin"
     assert resolved_file != "py_console.py"
+
+
+# ---------------------------------------------------------------------------
+# Codex P2 (PR #347): this/super must resolve within the CALLER's class, never
+# bleed across class boundaries in the same file.
+# ---------------------------------------------------------------------------
+def test_this_receiver_does_not_bind_other_class_method() -> None:
+    """``class A { foo(){} } class B { bar(){ this.foo(); } foo(){} }``.
+
+    Two classes in one file each define ``foo``. A ``this.foo()`` in ``B`` is
+    ambiguous from the resolver's seat (no enclosing-class signal is passed), so
+    binding it to *either* class's ``foo`` would risk the wrong edge
+    (``B.bar -> A.foo``). Conservative: stay ``unknown`` rather than mis-wire.
+    """
+    ctx = _ctx(
+        file_symbols={"a.ts": []},
+        file_class_methods={"a.ts": {"A": {"foo": 1}, "B": {"foo": 2, "bar": 3}}},
+    )
+    sym_id, resolution, resolved_file = resolve_typescript_callee(
+        "foo", "this.foo", "a.ts", ctx
+    )
+    assert resolution == "unknown", (
+        f"ambiguous this.foo across two classes must stay unknown; got {resolution}"
+    )
+    assert sym_id is None
+    assert resolved_file == ""
+
+
+def test_this_receiver_does_not_fall_back_to_free_function() -> None:
+    """``this.foo()`` must NOT bind a top-level free function ``foo`` — a
+    method call on the instance is not the same symbol as a module function.
+    The file-wide symbol scan (which would grab the free function) must not run
+    for a ``this``/``super`` receiver."""
+    ctx = _ctx(file_symbols={"a.ts": [("foo", "function", 5)]})
+    sym_id, resolution, _file = resolve_typescript_callee(
+        "foo", "this.foo", "a.ts", ctx
+    )
+    assert resolution == "unknown", (
+        f"this.foo must not bind a free function foo; got {resolution}"
+    )
+    assert sym_id is None
+
+
+def test_this_receiver_single_class_still_resolves() -> None:
+    """When exactly ONE class in the file defines the method, ``this.foo()`` is
+    unambiguous and still resolves ``local`` (no regression of the happy path)."""
+    ctx = _ctx(
+        file_symbols={"a.ts": []},
+        file_class_methods={"a.ts": {"Service": {"run": 11}}},
+    )
+    sym_id, resolution, resolved_file = resolve_typescript_callee(
+        "run", "this.run", "a.ts", ctx
+    )
+    assert (sym_id, resolution, resolved_file) == (11, "local", "a.ts")
+
+
+# ---------------------------------------------------------------------------
+# Codex P2 (PR #347): honor variable/import shadowing for TS globals.
+# ---------------------------------------------------------------------------
+def test_import_shadows_builtin_global_name() -> None:
+    """``import { Map } from './map'; Map.of(...)`` — the imported local name
+    ``Map`` shadows the JS built-in global, so the call must NOT classify
+    ``builtin``. The shadowing gate consults import local-names, not only the
+    function/method/class ``global_name_table``."""
+    from tree_sitter_analyzer.synapse_resolver._imports import ImportEntry
+
+    ctx = _ctx(
+        imports_by_file={
+            "a.ts": [
+                ImportEntry(
+                    file_path="a.ts",
+                    language="typescript",
+                    module_path="./map",
+                    local_name="Map",
+                )
+            ]
+        },
+    )
+    _sym, resolution, _file = resolve_typescript_callee("of", "Map.of", "a.ts", ctx)
+    assert resolution != "builtin", (
+        f"imported Map shadows the global; must not be builtin; got {resolution}"
+    )
+
+
+def test_aliased_import_shadows_builtin_global_name() -> None:
+    """``import Promise from 'bluebird'`` bound under local name ``Promise``
+    shadows the global ``Promise``; ``Promise.all(...)`` stays non-builtin."""
+    from tree_sitter_analyzer.synapse_resolver._imports import ImportEntry
+
+    ctx = _ctx(
+        imports_by_file={
+            "a.ts": [
+                ImportEntry(
+                    file_path="a.ts",
+                    language="typescript",
+                    module_path="bluebird",
+                    local_name="Promise",
+                )
+            ]
+        },
+    )
+    _sym, resolution, _file = resolve_typescript_callee(
+        "all", "Promise.all", "a.ts", ctx
+    )
+    assert resolution != "builtin"
+
+
+def test_import_in_other_file_does_not_shadow() -> None:
+    """An import of ``Map`` in a DIFFERENT file must not suppress the ``builtin``
+    classification in ``a.ts`` (shadowing is per-file/file-local)."""
+    from tree_sitter_analyzer.synapse_resolver._imports import ImportEntry
+
+    ctx = _ctx(
+        file_languages={"a.ts": "typescript", "b.ts": "typescript"},
+        imports_by_file={
+            "b.ts": [
+                ImportEntry(
+                    file_path="b.ts",
+                    language="typescript",
+                    module_path="./map",
+                    local_name="Map",
+                )
+            ]
+        },
+    )
+    _sym, resolution, _file = resolve_typescript_callee("of", "Map.of", "a.ts", ctx)
+    assert resolution == "builtin", (
+        f"an import in b.ts must not shadow a.ts's Map; got {resolution}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_typescript_method_resolution.py
+++ b/tests/unit/test_typescript_method_resolution.py
@@ -1,0 +1,267 @@
+"""RFC-0010 first-wave RED-first: the TypeScript per-language resolver.
+
+The TypeScript resolver REPLACES the Python cascade for ``.ts``/``.tsx`` callers
+(``file_languages == "typescript"``). It must:
+
+* resolve SAME-FILE/SAME-LANGUAGE local calls (no receiver or ``this``/``super``)
+  from its context's ``file_symbols`` — never regressing the local edges the
+  Python fallback used to produce;
+* classify a call whose receiver head is a DISTINCTIVE JS/TS global object
+  (``console``/``JSON``/``Math``/``Object``/``Promise``/…) as ``builtin`` — but
+  ONLY when the project defines no compatible-language (TS/JS) symbol of that
+  global name (shadowing preserved);
+* keep CONSERVATIVE bare-method-name tiers (the RFC-0008 lesson: an over-broad
+  table mis-classifies domain methods) — generic names like ``substring`` /
+  ``push`` / ``map`` stay ``unknown``;
+* return ``unknown`` for everything else.
+
+THE MOAT (mandatory): a callee whose name also exists as a symbol in ANOTHER
+language's file must NEVER bind to that other-language file — it resolves to the
+same-language definition or stays ``unknown``. ``languages_compatible`` treats
+JS/TS as one family but Python as incompatible.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from tree_sitter_analyzer.ast_cache import ASTCache
+from tree_sitter_analyzer.synapse_resolver.languages.typescript import (
+    build_typescript_resolver_context,
+    resolve_typescript_callee,
+)
+
+
+# ---------------------------------------------------------------------------
+# integration helpers (index real files, read classified edges back)
+# ---------------------------------------------------------------------------
+def _index(tmp_path: Path, files: dict[str, str]) -> str:
+    for name, body in files.items():
+        target = tmp_path / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(body)
+    cache = ASTCache(str(tmp_path))
+    try:
+        cache.index_project()
+    finally:
+        cache.close()
+    return str(tmp_path / ".ast-cache" / "index.db")
+
+
+def _resolution_for(db_path: str, callee_name: str) -> list[str]:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT callee_resolution FROM edges "
+            "WHERE kind = 'calls' AND callee_name = ?",
+            (callee_name,),
+        ).fetchall()
+        return [r["callee_resolution"] for r in rows]
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# unit: direct resolver calls against a hand-built context
+# ---------------------------------------------------------------------------
+def _ctx(
+    *,
+    file_symbols: dict[str, list[tuple[str, str, int]]] | None = None,
+    file_languages: dict[str, str] | None = None,
+    global_name_table: dict[str, list[tuple[str, int]]] | None = None,
+    file_class_methods: dict[str, dict[str, dict[str, int]]] | None = None,
+):
+    return build_typescript_resolver_context(
+        imports_by_file={},
+        file_languages=file_languages or {"a.ts": "typescript"},
+        file_symbols=file_symbols or {},
+        global_name_table=global_name_table or {},
+        file_class_methods=lambda: file_class_methods or {},
+    )
+
+
+def test_build_context_none_when_no_typescript_file() -> None:
+    """Zero cost for non-TS projects: gated on ``file_languages``."""
+    ctx = build_typescript_resolver_context(
+        imports_by_file={},
+        file_languages={"a.py": "python"},
+        file_symbols={},
+        global_name_table={},
+        file_class_methods=lambda: {},
+    )
+    assert ctx is None
+
+
+def test_build_context_present_for_tsx() -> None:
+    """A ``.tsx`` file (tagged ``typescript``) builds a context."""
+    ctx = build_typescript_resolver_context(
+        imports_by_file={},
+        file_languages={"a.tsx": "typescript"},
+        file_symbols={},
+        global_name_table={},
+        file_class_methods=lambda: {},
+    )
+    assert ctx is not None
+
+
+def test_local_no_receiver_resolves_same_file() -> None:
+    ctx = _ctx(file_symbols={"a.ts": [("helper", "function", 7)]})
+    sym_id, resolution, resolved_file = resolve_typescript_callee(
+        "helper", "helper", "a.ts", ctx
+    )
+    assert (sym_id, resolution, resolved_file) == (7, "local", "a.ts")
+
+
+def test_local_this_receiver_resolves_class_method() -> None:
+    ctx = _ctx(
+        file_symbols={"a.ts": []},
+        file_class_methods={"a.ts": {"Service": {"run": 11}}},
+    )
+    sym_id, resolution, resolved_file = resolve_typescript_callee(
+        "run", "this.run", "a.ts", ctx
+    )
+    assert (sym_id, resolution, resolved_file) == (11, "local", "a.ts")
+
+
+def test_global_object_receiver_classifies_builtin() -> None:
+    ctx = _ctx()
+    _sym, resolution, _file = resolve_typescript_callee(
+        "log", "console.log", "a.ts", ctx
+    )
+    assert resolution == "builtin"
+
+
+def test_json_receiver_classifies_builtin() -> None:
+    ctx = _ctx()
+    _sym, resolution, _file = resolve_typescript_callee(
+        "stringify", "JSON.stringify", "a.ts", ctx
+    )
+    assert resolution == "builtin"
+
+
+def test_bare_generic_method_stays_unknown() -> None:
+    """``s.substring(2)`` — ``substring`` is a domain-collidable bare method name
+    with a non-distinctive receiver; conservative tier keeps it ``unknown``."""
+    ctx = _ctx()
+    _sym, resolution, _file = resolve_typescript_callee(
+        "substring", "s.substring", "a.ts", ctx
+    )
+    assert resolution == "unknown"
+
+
+def test_project_shadows_builtin_global_name() -> None:
+    """If the project defines a TS symbol named ``Math`` (a distinctive global),
+    ``Math.random()`` must NOT be claimed ``builtin`` (shadowing preserved)."""
+    ctx = _ctx(
+        file_languages={"a.ts": "typescript", "math.ts": "typescript"},
+        global_name_table={"Math": [("math.ts", 99)]},
+    )
+    _sym, resolution, _file = resolve_typescript_callee(
+        "random", "Math.random", "a.ts", ctx
+    )
+    assert resolution != "builtin"
+
+
+def test_no_cross_language_bind_for_global_object_owner() -> None:
+    """THE MOAT: a Python file owning a symbol named ``console`` must NOT
+    suppress the TS ``builtin`` classification (Python is incompatible), and must
+    NEVER be bound as the resolved file."""
+    ctx = _ctx(
+        file_languages={"a.ts": "typescript", "py_console.py": "python"},
+        global_name_table={"console": [("py_console.py", 3)]},
+    )
+    _sym, resolution, resolved_file = resolve_typescript_callee(
+        "log", "console.log", "a.ts", ctx
+    )
+    assert resolution == "builtin"
+    assert resolved_file != "py_console.py"
+
+
+# ---------------------------------------------------------------------------
+# integration: through the full index + resolve_callee pipeline
+# ---------------------------------------------------------------------------
+def test_integration_local_call_resolves(tmp_path: Path) -> None:
+    db = _index(
+        tmp_path,
+        {
+            "svc.ts": (
+                "function helper(x: number): number { return x + 1; }\n"
+                "class Service {\n"
+                "  run(): number { return helper(1); }\n"
+                "}\n"
+            )
+        },
+    )
+    res = _resolution_for(db, "helper")
+    assert res, "expected a helper() edge"
+    assert "local" in res, f"local TS call must resolve local; got {res}"
+
+
+def test_integration_console_log_classifies_builtin(tmp_path: Path) -> None:
+    db = _index(
+        tmp_path,
+        {"svc.ts": ("class Service {\n  run(): void { console.log('hi'); }\n}\n")},
+    )
+    res = _resolution_for(db, "log")
+    assert res, "expected a log() edge"
+    assert "builtin" in res, f"console.log must classify builtin; got {res}"
+    assert "unknown" not in res
+
+
+def test_integration_bare_method_stays_unknown(tmp_path: Path) -> None:
+    db = _index(
+        tmp_path,
+        {
+            "svc.ts": (
+                "class Service {\n  run(s: string): void { s.substring(2); }\n}\n"
+            )
+        },
+    )
+    res = _resolution_for(db, "substring")
+    assert res, "expected a substring() edge"
+    assert "builtin" not in res
+    assert "stdlib" not in res
+    assert "unknown" in res, (
+        f"bare s.substring (domain-collidable) must stay unknown; got {res}"
+    )
+
+
+def test_integration_no_cross_language_mis_wire(tmp_path: Path) -> None:
+    """MANDATORY no-cross-language-mis-wire test.
+
+    A TS ``helper()`` call and a Python ``def helper`` coexist. The TS caller's
+    ``helper`` must resolve to the TypeScript ``svc.ts`` definition (``local``),
+    NEVER to the Python ``other.py`` file — the exact CodeGraph failure this
+    project exists to beat.
+    """
+    db = _index(
+        tmp_path,
+        {
+            "svc.ts": (
+                "function helper(x: number): number { return x + 1; }\n"
+                "class Service {\n"
+                "  run(): number { return helper(1); }\n"
+                "}\n"
+            ),
+            "other.py": "def helper():\n    return 1\n",
+        },
+    )
+    conn = sqlite3.connect(db)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT callee_resolution, callee_resolved_file FROM edges "
+            "WHERE kind = 'calls' AND callee_name = 'helper' "
+            "AND file_path = 'svc.ts'",
+        ).fetchall()
+    finally:
+        conn.close()
+    assert rows, "expected a TS helper() edge from svc.ts"
+    for r in rows:
+        assert r["callee_resolved_file"] != "other.py", (
+            "TS helper() must NEVER bind to the Python other.py definition "
+            "(cross-language mis-wire — the CodeGraph failure)"
+        )
+        assert r["callee_resolution"] in ("local", "project", "unknown")

--- a/tests/unit/test_typescript_method_resolution.py
+++ b/tests/unit/test_typescript_method_resolution.py
@@ -72,14 +72,15 @@ def _ctx(
     file_languages: dict[str, str] | None = None,
     global_name_table: dict[str, list[tuple[str, int]]] | None = None,
     file_class_methods: dict[str, dict[str, dict[str, int]]] | None = None,
-    imports_by_file: dict[str, list] | None = None,
+    shadow_locals: dict[str, set[str]] | None = None,
 ):
     return build_typescript_resolver_context(
-        imports_by_file=imports_by_file or {},
+        imports_by_file={},
         file_languages=file_languages or {"a.ts": "typescript"},
         file_symbols=file_symbols or {},
         global_name_table=global_name_table or {},
         file_class_methods=lambda: file_class_methods or {},
+        shadow_locals=shadow_locals,
     )
 
 
@@ -181,49 +182,31 @@ def test_no_cross_language_bind_for_global_object_owner() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Codex P2 (PR #347): this/super must resolve within the CALLER's class, never
-# bleed across class boundaries in the same file.
+# Codex P2 #1 — this/super must resolve within the caller's class, never bind
+# to an unrelated class's same-named method elsewhere in the file.
 # ---------------------------------------------------------------------------
-def test_this_receiver_does_not_bind_other_class_method() -> None:
+def test_this_method_ambiguous_across_classes_stays_unknown() -> None:
     """``class A { foo(){} } class B { bar(){ this.foo(); } foo(){} }``.
 
-    Two classes in one file each define ``foo``. A ``this.foo()`` in ``B`` is
-    ambiguous from the resolver's seat (no enclosing-class signal is passed), so
-    binding it to *either* class's ``foo`` would risk the wrong edge
-    (``B.bar -> A.foo``). Conservative: stay ``unknown`` rather than mis-wire.
-    """
+    Without the caller's enclosing class, ``this.foo()`` is ambiguous between
+    ``A.foo`` and ``B.foo``. The resolver must NOT bind ``B.bar -> A.foo`` (the
+    file-wide first-match bug); it stays ``unknown`` (conservative: precision
+    over recall)."""
     ctx = _ctx(
-        file_symbols={"a.ts": []},
-        file_class_methods={"a.ts": {"A": {"foo": 1}, "B": {"foo": 2, "bar": 3}}},
+        # file_symbols carries A.foo FIRST — the broken file-wide lookup would
+        # return it for B's ``this.foo()``.
+        file_symbols={"a.ts": [("foo", "method", 5), ("foo", "method", 8)]},
+        file_class_methods={"a.ts": {"A": {"foo": 5}, "B": {"foo": 8, "bar": 7}}},
     )
     sym_id, resolution, resolved_file = resolve_typescript_callee(
         "foo", "this.foo", "a.ts", ctx
     )
-    assert resolution == "unknown", (
-        f"ambiguous this.foo across two classes must stay unknown; got {resolution}"
-    )
-    assert sym_id is None
-    assert resolved_file == ""
+    assert (sym_id, resolution, resolved_file) == (None, "unknown", "")
 
 
-def test_this_receiver_does_not_fall_back_to_free_function() -> None:
-    """``this.foo()`` must NOT bind a top-level free function ``foo`` — a
-    method call on the instance is not the same symbol as a module function.
-    The file-wide symbol scan (which would grab the free function) must not run
-    for a ``this``/``super`` receiver."""
-    ctx = _ctx(file_symbols={"a.ts": [("foo", "function", 5)]})
-    sym_id, resolution, _file = resolve_typescript_callee(
-        "foo", "this.foo", "a.ts", ctx
-    )
-    assert resolution == "unknown", (
-        f"this.foo must not bind a free function foo; got {resolution}"
-    )
-    assert sym_id is None
-
-
-def test_this_receiver_single_class_still_resolves() -> None:
-    """When exactly ONE class in the file defines the method, ``this.foo()`` is
-    unambiguous and still resolves ``local`` (no regression of the happy path)."""
+def test_this_method_unambiguous_resolves_local() -> None:
+    """When exactly one class in the file defines the method, ``this.foo()``
+    resolves ``local`` (single owner — no ambiguity)."""
     ctx = _ctx(
         file_symbols={"a.ts": []},
         file_class_methods={"a.ts": {"Service": {"run": 11}}},
@@ -234,79 +217,105 @@ def test_this_receiver_single_class_still_resolves() -> None:
     assert (sym_id, resolution, resolved_file) == (11, "local", "a.ts")
 
 
-# ---------------------------------------------------------------------------
-# Codex P2 (PR #347): honor variable/import shadowing for TS globals.
-# ---------------------------------------------------------------------------
-def test_import_shadows_builtin_global_name() -> None:
-    """``import { Map } from './map'; Map.of(...)`` — the imported local name
-    ``Map`` shadows the JS built-in global, so the call must NOT classify
-    ``builtin``. The shadowing gate consults import local-names, not only the
-    function/method/class ``global_name_table``."""
-    from tree_sitter_analyzer.synapse_resolver._imports import ImportEntry
-
+def test_this_method_never_falls_through_to_top_level_function() -> None:
+    """``this.helper()`` must NOT bind to a top-level ``function helper`` — a
+    method call through ``this`` is class-scoped, not module-scoped."""
     ctx = _ctx(
-        imports_by_file={
-            "a.ts": [
-                ImportEntry(
-                    file_path="a.ts",
-                    language="typescript",
-                    module_path="./map",
-                    local_name="Map",
-                )
-            ]
-        },
+        file_symbols={"a.ts": [("helper", "function", 3)]},
+        file_class_methods={"a.ts": {}},
     )
-    _sym, resolution, _file = resolve_typescript_callee("of", "Map.of", "a.ts", ctx)
-    assert resolution != "builtin", (
-        f"imported Map shadows the global; must not be builtin; got {resolution}"
+    sym_id, resolution, resolved_file = resolve_typescript_callee(
+        "helper", "this.helper", "a.ts", ctx
     )
+    assert (sym_id, resolution, resolved_file) == (None, "unknown", "")
 
 
-def test_aliased_import_shadows_builtin_global_name() -> None:
-    """``import Promise from 'bluebird'`` bound under local name ``Promise``
-    shadows the global ``Promise``; ``Promise.all(...)`` stays non-builtin."""
-    from tree_sitter_analyzer.synapse_resolver._imports import ImportEntry
-
-    ctx = _ctx(
-        imports_by_file={
-            "a.ts": [
-                ImportEntry(
-                    file_path="a.ts",
-                    language="typescript",
-                    module_path="bluebird",
-                    local_name="Promise",
-                )
-            ]
-        },
-    )
+# ---------------------------------------------------------------------------
+# Codex P2 #2/#3 — variable/import shadowing of a builtin global name must
+# suppress the builtin classification (gate also honors non-function locals).
+# ---------------------------------------------------------------------------
+def test_variable_shadow_suppresses_builtin() -> None:
+    """``const Promise = require('bluebird'); Promise.all(...)`` — ``Promise`` is
+    shadowed by a local variable, so the call must NOT classify ``builtin``."""
+    ctx = _ctx(shadow_locals={"a.ts": {"Promise"}})
     _sym, resolution, _file = resolve_typescript_callee(
         "all", "Promise.all", "a.ts", ctx
     )
     assert resolution != "builtin"
 
 
-def test_import_in_other_file_does_not_shadow() -> None:
-    """An import of ``Map`` in a DIFFERENT file must not suppress the ``builtin``
-    classification in ``a.ts`` (shadowing is per-file/file-local)."""
-    from tree_sitter_analyzer.synapse_resolver._imports import ImportEntry
+def test_import_shadow_suppresses_builtin() -> None:
+    """``import { Map } from './map'; Map.of(...)`` — ``Map`` is shadowed by an
+    import binding, so the call must NOT classify ``builtin``."""
+    ctx = _ctx(shadow_locals={"a.ts": {"Map"}})
+    _sym, resolution, _file = resolve_typescript_callee("of", "Map.of", "a.ts", ctx)
+    assert resolution != "builtin"
 
-    ctx = _ctx(
-        file_languages={"a.ts": "typescript", "b.ts": "typescript"},
-        imports_by_file={
-            "b.ts": [
-                ImportEntry(
-                    file_path="b.ts",
-                    language="typescript",
-                    module_path="./map",
-                    local_name="Map",
-                )
-            ]
+
+def test_shadow_local_is_file_scoped() -> None:
+    """A shadow in ``other.ts`` must NOT suppress the builtin in ``a.ts``."""
+    ctx = _ctx(shadow_locals={"other.ts": {"Math"}})
+    _sym, resolution, _file = resolve_typescript_callee(
+        "random", "Math.random", "a.ts", ctx
+    )
+    assert resolution == "builtin"
+
+
+def test_integration_import_shadow_suppresses_builtin(tmp_path: Path) -> None:
+    """FULL INDEX PATH (Codex P2 #3): ``import { Map } from './map'`` shadows the
+    ``Map`` global. ``Map.of()`` must NOT be classified ``builtin`` even though
+    ``ast_imports`` is empty for TS — the resolver builds the shadow set from the
+    TS symbol rows itself."""
+    db = _index(
+        tmp_path,
+        {
+            "svc.ts": (
+                "import { Map } from './map';\n"
+                "class Service {\n"
+                "  run(): void { Map.of(1); }\n"
+                "}\n"
+            ),
+            "map.ts": "export class Map { static of(x: number): void {} }\n",
         },
     )
-    _sym, resolution, _file = resolve_typescript_callee("of", "Map.of", "a.ts", ctx)
-    assert resolution == "builtin", (
-        f"an import in b.ts must not shadow a.ts's Map; got {resolution}"
+    res = _resolution_for(db, "of")
+    assert res, "expected a Map.of() edge"
+    assert "builtin" not in res, (
+        f"import-shadowed Map.of must NOT classify builtin; got {res}"
     )
+
+
+def test_integration_variable_shadow_suppresses_builtin(tmp_path: Path) -> None:
+    """FULL INDEX PATH: ``const Promise = require('bluebird')`` shadows the
+    ``Promise`` global; ``Promise.all()`` must NOT classify ``builtin``."""
+    db = _index(
+        tmp_path,
+        {
+            "svc.ts": (
+                "const Promise = require('bluebird');\n"
+                "class Service {\n"
+                "  run(): void { Promise.all([]); }\n"
+                "}\n"
+            ),
+        },
+    )
+    res = _resolution_for(db, "all")
+    assert res, "expected a Promise.all() edge"
+    assert "builtin" not in res, (
+        f"variable-shadowed Promise.all must NOT classify builtin; got {res}"
+    )
+
+
+def test_integration_unshadowed_global_still_builtin(tmp_path: Path) -> None:
+    """Guard: an UN-shadowed ``Math.max()`` must still classify ``builtin`` — the
+    shadow gate must not over-suppress."""
+    db = _index(
+        tmp_path,
+        {"svc.ts": ("class Service {\n  run(): void { Math.max(1, 2); }\n}\n")},
+    )
+    res = _resolution_for(db, "max")
+    assert res, "expected a Math.max() edge"
+    assert "builtin" in res, f"unshadowed Math.max must classify builtin; got {res}"
 
 
 # ---------------------------------------------------------------------------

--- a/tree_sitter_analyzer/synapse_resolver/languages/_typescript_constants.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/_typescript_constants.py
@@ -1,0 +1,78 @@
+"""Conservative classification tiers for the TypeScript resolver (RFC-0010).
+
+The TypeScript resolver carries NO receiver-type inference, so — per the
+RFC-0008 Java lesson — classification keys on the SAFEST available signal and
+nothing more. For JS/TS that signal is a **distinctive global-object receiver
+head**: a call whose receiver's first segment is a built-in global namespace
+object (``console.log``, ``JSON.stringify``, ``Math.max``) is overwhelmingly the
+JS runtime, because user code essentially never names a variable ``console`` /
+``JSON`` / ``Math``. Such names resolve ``builtin``.
+
+PRECISION over recall (the mandate). Two things are DELIBERATELY excluded:
+
+* **Bare method-name tiers are EMPTY.** Generic JS method names — ``map`` /
+  ``filter`` / ``forEach`` / ``push`` / ``substring`` / ``then`` / ``get`` —
+  are routinely defined by domain objects, third-party collections, promises,
+  and value objects. With no receiver-type evidence, classifying them ``stdlib``
+  / ``external`` would mis-wire domain calls (the exact CodeGraph failure this
+  project beats). They stay ``unknown`` — which is correct.
+* **Ambiguous global names are excluded from the receiver set.** Only global
+  objects that are essentially never shadowed by a user variable are listed.
+  ``window`` / ``document`` / ``global`` / ``process`` are common DOM/Node
+  globals BUT are also frequently re-bound (mock ``window``, a ``process``
+  domain entity), so they are omitted to stay conservative.
+
+An EMPTY-er tier is always safe: everything just stays ``local`` / ``project`` /
+``unknown``, never cross-wired.
+"""
+
+from __future__ import annotations
+
+# Distinctive built-in global NAMESPACE objects. A call ``X.method(...)`` whose
+# receiver head ``X`` is one of these is the JS/TS runtime built-in, classified
+# ``builtin`` — but only when the project owns no compatible-language (TS/JS)
+# symbol of that name (shadowing gate). These names are intentionally limited to
+# global objects that a user variable almost never collides with; common-but-
+# shadowable globals (``window``/``document``/``process``/``global``) are
+# excluded on purpose to keep precision high.
+TYPESCRIPT_GLOBAL_OBJECTS: frozenset[str] = frozenset(
+    {
+        "console",
+        "JSON",
+        "Math",
+        "Object",
+        "Array",
+        "Number",
+        "String",
+        "Boolean",
+        "Symbol",
+        "Reflect",
+        "Promise",
+        "Proxy",
+        "BigInt",
+        "Date",
+        "RegExp",
+        "Map",
+        "Set",
+        "WeakMap",
+        "WeakSet",
+        "Intl",
+        "Atomics",
+        "ArrayBuffer",
+        "DataView",
+        "Int8Array",
+        "Uint8Array",
+        "Uint8ClampedArray",
+        "Int16Array",
+        "Uint16Array",
+        "Int32Array",
+        "Uint32Array",
+        "Float32Array",
+        "Float64Array",
+        "BigInt64Array",
+        "BigUint64Array",
+    }
+)
+
+
+__all__ = ["TYPESCRIPT_GLOBAL_OBJECTS"]

--- a/tree_sitter_analyzer/synapse_resolver/languages/typescript.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/typescript.py
@@ -32,8 +32,10 @@ from ._typescript_constants import TYPESCRIPT_GLOBAL_OBJECTS
 #: ``file_languages`` tag for every ``.ts``/``.tsx``/``.mts``/``.cts`` file.
 _TYPESCRIPT_LANG = "typescript"
 
-#: Receivers that mean "the current object" — a no-receiver-style local call.
-_SELF_RECEIVERS = ("", "this", "super")
+#: Instance receivers — a method call on the enclosing object. ``this``/``super``
+#: must resolve WITHIN the caller's class (Codex P2 #347): they never bind a
+#: top-level free function, and never bleed across class boundaries in the file.
+_THIS_RECEIVERS = ("this", "super")
 
 
 @dataclass
@@ -54,6 +56,9 @@ class TypeScriptResolverContext:
     global_name_table: dict[str, list[tuple[str, int]]] = field(default_factory=dict)
     # file -> language tag (so the ownership gate is language-aware).
     file_languages: dict[str, str] = field(default_factory=dict)
+    # file -> {local_name, ...} bound by an import in THAT file. A local name
+    # bound here shadows the same-named JS global (Codex P2 #347), per-file.
+    import_locals_by_file: dict[str, frozenset[str]] = field(default_factory=dict)
 
 
 def build_typescript_resolver_context(
@@ -79,7 +84,29 @@ def build_typescript_resolver_context(
         file_class_methods=fcm or {},
         global_name_table=global_name_table,
         file_languages=file_languages,
+        import_locals_by_file=_import_locals(imports_by_file),
     )
+
+
+def _import_locals(
+    imports_by_file: dict[str, Any],
+) -> dict[str, frozenset[str]]:
+    """Collect, per file, the set of local names bound by an import.
+
+    These names shadow same-named JS/TS globals in that file. The bound local
+    name is recorded — e.g. ``import { Map } from './x'`` binds ``Map`` and
+    ``import { Map as M } from './x'`` binds ``M`` (the ``local_name``). A name
+    appearing as an import local is treated as project-owned for the shadowing
+    gate (Codex P2 #347).
+    """
+    out: dict[str, set[str]] = {}
+    for file_path, entries in (imports_by_file or {}).items():
+        names = out.setdefault(file_path, set())
+        for entry in entries or []:
+            local = getattr(entry, "local_name", "") or ""
+            if local and local != "*":
+                names.add(local)
+    return {fp: frozenset(names) for fp, names in out.items()}
 
 
 def _split_receiver(callee_full: str, callee_name: str) -> tuple[str, str]:
@@ -91,26 +118,71 @@ def _split_receiver(callee_full: str, callee_name: str) -> tuple[str, str]:
     return "", full or callee_name
 
 
-def _lookup_in_file(
+def _lookup_free_symbol(
     ctx: TypeScriptResolverContext, file_path: str, simple: str
 ) -> int | None:
+    """A bare ``foo()`` call: a top-level free ``function`` or ``class`` in the
+    same file. Methods are deliberately excluded — a bare name does not name an
+    instance method without a receiver, and including methods would let a
+    no-receiver call grab an unrelated class's method (Codex P2 #347)."""
     for name, kind, sym_id in ctx.file_symbols.get(file_path, []):
-        if name == simple and kind in ("function", "method", "class"):
+        if name == simple and kind in ("function", "class"):
             return sym_id
     return None
 
 
-def _project_owns(ctx: TypeScriptResolverContext, simple: str) -> bool:
-    """True when a COMPATIBLE-LANGUAGE (TS/JS-family) project symbol named
-    ``simple`` exists.
+def _lookup_this_method(
+    ctx: TypeScriptResolverContext, file_path: str, simple: str
+) -> int | None:
+    """Resolve a ``this``/``super`` method call WITHIN the caller's class.
 
-    The shadowing gate: if the project owns the name in a JS/TS-family file, the
-    ``builtin`` global-object classification must NOT claim it. The gate is
-    LANGUAGE-AWARE — a same-named symbol in an incompatible-language file (a
-    Python ``console``) does NOT count, because
-    ``languages_compatible("typescript", "python")`` is False. Files with an
-    unknown language tag are treated as possible owners (conservative).
+    The resolver is not handed the caller's enclosing-class name, so it cannot
+    pick a class directly. It binds ONLY when the method name is UNAMBIGUOUS —
+    exactly one class in the file defines it. When two classes both define
+    ``foo`` (``class A { foo(){} } class B { bar(){ this.foo(); } foo(){} }``),
+    binding either would risk the wrong edge (``B.bar -> A.foo``), so it stays
+    ``unknown`` (Codex P2 #347). It never consults the file-wide free-symbol
+    scan: a ``this.foo()`` is not a free function ``foo``.
     """
+    found: int | None = None
+    for methods in ctx.file_class_methods.get(file_path, {}).values():
+        mid = methods.get(simple)
+        if mid is None:
+            continue
+        if found is not None and found != mid:
+            return None  # ambiguous across classes — conservative unknown.
+        found = mid
+    return found
+
+
+def _name_is_shadowed(
+    ctx: TypeScriptResolverContext, caller_file: str, simple: str
+) -> bool:
+    """True when ``simple`` is shadowed for ``caller_file`` so the ``builtin``
+    global-object classification must NOT claim it.
+
+    Two shadowing sources are consulted:
+
+    * **Project-defined symbols** (``global_name_table``) in a COMPATIBLE-LANGUAGE
+      (TS/JS-family) file. The gate is LANGUAGE-AWARE — a same-named symbol in an
+      incompatible-language file (a Python ``console``) does NOT count, because
+      ``languages_compatible("typescript", "python")`` is False. Files with an
+      unknown language tag are treated as possible owners (conservative). This is
+      THE MOAT: an incompatible-language owner never suppresses or binds.
+    * **Import locals in the caller's own file** (Codex P2 #347): a name bound by
+      an import in this file — ``import { Map } from './map'``,
+      ``import Promise from 'bluebird'`` — rebinds the global LOCALLY, so
+      ``Map.of`` / ``Promise.all`` must stay non-``builtin``. An import in a
+      *different* file does not shadow this file's global.
+
+    The variable case (``const Map = require('./map')``) is not yet detectable —
+    the resolver context carries no variable symbols — and stays a conservative
+    known limitation; it can only over-classify toward ``builtin``, never
+    mis-bind cross-language.
+    """
+    if simple in ctx.import_locals_by_file.get(caller_file, frozenset()):
+        return True
+
     from ..._language_family import languages_compatible
 
     for owner_file, _sym_id in ctx.global_name_table.get(simple, []):
@@ -135,26 +207,33 @@ def resolve_typescript_callee(
     """
     receiver, simple = _split_receiver(callee_full, callee_name)
 
-    # 1. local — no receiver (or ``this``/``super``): a same-file definition.
-    if receiver in _SELF_RECEIVERS:
-        sym_id = _lookup_in_file(ctx, caller_file, simple)
+    # 1. local (instance) — ``this.foo()`` / ``super.foo()``: a method call on the
+    #    enclosing object. Resolve WITHIN the caller's class only — never a
+    #    top-level free function, never another class's same-named method when
+    #    ambiguous (Codex P2 #347). Otherwise ``unknown``.
+    if receiver in _THIS_RECEIVERS:
+        mid = _lookup_this_method(ctx, caller_file, simple)
+        if mid is not None:
+            return mid, "local", caller_file
+        return None, "unknown", ""
+
+    # 2. local (bare) — no receiver: a same-file top-level ``function``/``class``.
+    if receiver == "":
+        sym_id = _lookup_free_symbol(ctx, caller_file, simple)
         if sym_id is not None:
             return sym_id, "local", caller_file
-        # 1b. this/super methods captured in the class-method map.
-        for _cls, methods in ctx.file_class_methods.get(caller_file, {}).items():
-            mid = methods.get(simple)
-            if mid is not None:
-                return mid, "local", caller_file
         # A bare unresolved call stays unknown — NO global single-name binding,
         # because that is exactly where cross-language mis-wires creep in.
         return None, "unknown", ""
 
-    # 2. builtin — receiver head is a distinctive JS/TS global object
-    #    (``console``/``JSON``/``Math``…). Gated on the project NOT owning that
-    #    global name as a compatible-language symbol (shadowing preserved). The
-    #    head, not the tail, is the global ("console" in "console.log").
+    # 3. builtin — receiver head is a distinctive JS/TS global object
+    #    (``console``/``JSON``/``Math``…). Gated on the global name NOT being
+    #    shadowed (a compatible-language project symbol OR an import local in this
+    #    file). The head, not the tail, is the global ("console" in "console.log").
     head = receiver.split(".", 1)[0]
-    if head in TYPESCRIPT_GLOBAL_OBJECTS and not _project_owns(ctx, head):
+    if head in TYPESCRIPT_GLOBAL_OBJECTS and not _name_is_shadowed(
+        ctx, caller_file, head
+    ):
         return None, "builtin", ""
 
     # 3. unknown — no confident same-language resolution. Conservative tiers keep

--- a/tree_sitter_analyzer/synapse_resolver/languages/typescript.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/typescript.py
@@ -67,8 +67,9 @@ class TypeScriptResolverContext:
 
 
 #: Binding names introduced by a TS ``import`` statement. The TS plugin stores
-#: the *raw statement text* as the ``import`` symbol's name (``ast_imports`` is
-#: empty for TS — Codex P2 #3), so the resolver extracts the bound locals itself.
+#: the *raw statement text* under the ``import`` symbol's ``text`` field
+#: (``ast_imports`` is empty for TS — Codex P2 #3), so the resolver extracts the
+#: bound locals itself.
 _IMPORT_DEFAULT_RE = re.compile(r"import\s+([A-Za-z_$][\w$]*)\s*(?:,|\s+from\b)")
 _IMPORT_NAMESPACE_RE = re.compile(r"import\s+\*\s+as\s+([A-Za-z_$][\w$]*)")
 _IMPORT_NAMED_BLOCK_RE = re.compile(r"\{([^}]*)\}")
@@ -126,7 +127,13 @@ def _build_shadow_locals(conn: Any) -> dict[str, set[str]]:
                 if name:
                     names.add(name)
             elif kind == "import":
-                statement = sym.get("name") or sym.get("source") or ""
+                # The generic AST extractor emits TS imports as
+                # ``{"kind": "import", "text": "<raw statement>"}`` — the bound
+                # locals live in ``text``, NOT ``name``/``source`` (Codex P2 #4).
+                # ``name``/``source`` are kept as fallbacks for other emitters.
+                statement = (
+                    sym.get("text") or sym.get("name") or sym.get("source") or ""
+                )
                 names |= _import_binding_names(statement)
         if names:
             out[row["file_path"]] = names

--- a/tree_sitter_analyzer/synapse_resolver/languages/typescript.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/typescript.py
@@ -23,6 +23,8 @@ resolve_typescript_callee)``.
 
 from __future__ import annotations
 
+import json
+import re
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -32,10 +34,10 @@ from ._typescript_constants import TYPESCRIPT_GLOBAL_OBJECTS
 #: ``file_languages`` tag for every ``.ts``/``.tsx``/``.mts``/``.cts`` file.
 _TYPESCRIPT_LANG = "typescript"
 
-#: Instance receivers — a method call on the enclosing object. ``this``/``super``
-#: must resolve WITHIN the caller's class (Codex P2 #347): they never bind a
-#: top-level free function, and never bleed across class boundaries in the file.
-_THIS_RECEIVERS = ("this", "super")
+#: Receivers that mean "the current object" — a class-scoped ``this``/``super``
+#: method call. A *bare* (empty) receiver is handled separately because a bare
+#: ``foo()`` is a module-level function call, not a class-method call.
+_SELF_RECEIVERS = ("this", "super")
 
 
 @dataclass
@@ -56,9 +58,79 @@ class TypeScriptResolverContext:
     global_name_table: dict[str, list[tuple[str, int]]] = field(default_factory=dict)
     # file -> language tag (so the ownership gate is language-aware).
     file_languages: dict[str, str] = field(default_factory=dict)
-    # file -> {local_name, ...} bound by an import in THAT file. A local name
-    # bound here shadows the same-named JS global (Codex P2 #347), per-file.
-    import_locals_by_file: dict[str, frozenset[str]] = field(default_factory=dict)
+    # file -> {names shadowed by a local variable / import binding}. These are
+    # NOT in ``global_name_table`` (which is function/method/class-only), so the
+    # builtin gate consults this map too — ``const Promise = require('bluebird')``
+    # or ``import { Map } from './map'`` must suppress the ``builtin`` claim
+    # (Codex P2 #2/#3). File-scoped: a shadow in one file does not affect another.
+    shadow_locals: dict[str, set[str]] = field(default_factory=dict)
+
+
+#: Binding names introduced by a TS ``import`` statement. The TS plugin stores
+#: the *raw statement text* as the ``import`` symbol's name (``ast_imports`` is
+#: empty for TS — Codex P2 #3), so the resolver extracts the bound locals itself.
+_IMPORT_DEFAULT_RE = re.compile(r"import\s+([A-Za-z_$][\w$]*)\s*(?:,|\s+from\b)")
+_IMPORT_NAMESPACE_RE = re.compile(r"import\s+\*\s+as\s+([A-Za-z_$][\w$]*)")
+_IMPORT_NAMED_BLOCK_RE = re.compile(r"\{([^}]*)\}")
+_IMPORT_NAMED_ITEM_RE = re.compile(
+    r"[A-Za-z_$][\w$]*\s+as\s+([A-Za-z_$][\w$]*)|([A-Za-z_$][\w$]*)"
+)
+
+
+def _import_binding_names(statement: str) -> set[str]:
+    """Extract the local binding names introduced by one TS ``import`` line.
+
+    Handles ``import D from 'm'`` (default), ``import * as N from 'm'``
+    (namespace), and ``import { A, B as C } from 'm'`` (named, honoring ``as``).
+    The *local* name is what shadows a global, so ``B as C`` binds ``C``.
+    """
+    names: set[str] = set()
+    m = _IMPORT_NAMESPACE_RE.search(statement)
+    if m:
+        names.add(m.group(1))
+    m = _IMPORT_DEFAULT_RE.search(statement)
+    if m:
+        names.add(m.group(1))
+    block = _IMPORT_NAMED_BLOCK_RE.search(statement)
+    if block:
+        for item in _IMPORT_NAMED_ITEM_RE.finditer(block.group(1)):
+            names.add(item.group(1) or item.group(2))
+    names.discard("from")
+    names.discard("type")
+    return names
+
+
+def _build_shadow_locals(conn: Any) -> dict[str, set[str]]:
+    """Build file -> {variable / import binding names} for every TS file.
+
+    These names are NOT in ``global_name_table`` (function/method/class-only) yet
+    they legitimately shadow a builtin global (``const Map = ...`` / ``import {
+    Map }``). The builtin gate consults this map so shadowed calls stay
+    ``unknown``/project-owned instead of being mis-classified ``builtin``.
+    """
+    out: dict[str, set[str]] = {}
+    try:
+        rows = conn.execute("SELECT file_path, symbols_json FROM ast_index").fetchall()
+    except Exception:  # nosec B110 — missing-table tolerance, mirrors _context.py.
+        return out
+    for row in rows:
+        try:
+            symbols = json.loads(row["symbols_json"])
+        except (json.JSONDecodeError, TypeError, KeyError):
+            continue
+        names: set[str] = set()
+        for sym in symbols.get("symbols", []):
+            kind = sym.get("kind")
+            if kind == "variable":
+                name = sym.get("name")
+                if name:
+                    names.add(name)
+            elif kind == "import":
+                statement = sym.get("name") or sym.get("source") or ""
+                names |= _import_binding_names(statement)
+        if names:
+            out[row["file_path"]] = names
+    return out
 
 
 def build_typescript_resolver_context(
@@ -68,45 +140,30 @@ def build_typescript_resolver_context(
     file_symbols: dict[str, Any],
     global_name_table: dict[str, Any],
     file_class_methods: Any,  # zero-arg thunk -> class->method map (lazy)
+    conn: Any = None,
+    shadow_locals: dict[str, set[str]] | None = None,
     **_ignored: Any,
 ) -> TypeScriptResolverContext | None:
     """Build the TS context, or ``None`` when no TypeScript file is indexed.
 
     Zero cost for non-TS projects (gated on ``file_languages``). The
     ``file_class_methods`` thunk is only invoked when a TS file is present, so a
-    Python/Java-only project pays nothing.
+    Python/Java-only project pays nothing. ``shadow_locals`` is derived from the
+    DB ``conn`` (TS ``import``/``variable`` rows) at build time; tests may inject
+    it directly.
     """
     if not any(lang == _TYPESCRIPT_LANG for lang in file_languages.values()):
         return None
     fcm = file_class_methods() if callable(file_class_methods) else file_class_methods
+    if shadow_locals is None:
+        shadow_locals = _build_shadow_locals(conn) if conn is not None else {}
     return TypeScriptResolverContext(
         file_symbols=file_symbols,
         file_class_methods=fcm or {},
         global_name_table=global_name_table,
         file_languages=file_languages,
-        import_locals_by_file=_import_locals(imports_by_file),
+        shadow_locals=shadow_locals,
     )
-
-
-def _import_locals(
-    imports_by_file: dict[str, Any],
-) -> dict[str, frozenset[str]]:
-    """Collect, per file, the set of local names bound by an import.
-
-    These names shadow same-named JS/TS globals in that file. The bound local
-    name is recorded — e.g. ``import { Map } from './x'`` binds ``Map`` and
-    ``import { Map as M } from './x'`` binds ``M`` (the ``local_name``). A name
-    appearing as an import local is treated as project-owned for the shadowing
-    gate (Codex P2 #347).
-    """
-    out: dict[str, set[str]] = {}
-    for file_path, entries in (imports_by_file or {}).items():
-        names = out.setdefault(file_path, set())
-        for entry in entries or []:
-            local = getattr(entry, "local_name", "") or ""
-            if local and local != "*":
-                names.add(local)
-    return {fp: frozenset(names) for fp, names in out.items()}
 
 
 def _split_receiver(callee_full: str, callee_name: str) -> tuple[str, str]:
@@ -118,73 +175,59 @@ def _split_receiver(callee_full: str, callee_name: str) -> tuple[str, str]:
     return "", full or callee_name
 
 
-def _lookup_free_symbol(
+def _lookup_in_file(
     ctx: TypeScriptResolverContext, file_path: str, simple: str
 ) -> int | None:
-    """A bare ``foo()`` call: a top-level free ``function`` or ``class`` in the
-    same file. Methods are deliberately excluded — a bare name does not name an
-    instance method without a receiver, and including methods would let a
-    no-receiver call grab an unrelated class's method (Codex P2 #347)."""
     for name, kind, sym_id in ctx.file_symbols.get(file_path, []):
-        if name == simple and kind in ("function", "class"):
+        if name == simple and kind in ("function", "method", "class"):
             return sym_id
     return None
 
 
-def _lookup_this_method(
+def _unique_class_method(
     ctx: TypeScriptResolverContext, file_path: str, simple: str
 ) -> int | None:
-    """Resolve a ``this``/``super`` method call WITHIN the caller's class.
+    """Return the symbol id when EXACTLY ONE class in ``file_path`` defines a
+    method named ``simple``; otherwise ``None``.
 
-    The resolver is not handed the caller's enclosing-class name, so it cannot
-    pick a class directly. It binds ONLY when the method name is UNAMBIGUOUS —
-    exactly one class in the file defines it. When two classes both define
-    ``foo`` (``class A { foo(){} } class B { bar(){ this.foo(); } foo(){} }``),
-    binding either would risk the wrong edge (``B.bar -> A.foo``), so it stays
-    ``unknown`` (Codex P2 #347). It never consults the file-wide free-symbol
-    scan: a ``this.foo()`` is not a free function ``foo``.
-    """
+    For a ``this``/``super`` call the caller's enclosing class is not available
+    to the resolver, so a name defined by two classes in the same file is
+    ambiguous. Conservatively we resolve only the unambiguous (single-owner)
+    case — never the file-wide first match, which would mis-bind ``B.bar ->
+    A.foo`` (Codex P2 #1)."""
     found: int | None = None
     for methods in ctx.file_class_methods.get(file_path, {}).values():
         mid = methods.get(simple)
         if mid is None:
             continue
         if found is not None and found != mid:
-            return None  # ambiguous across classes — conservative unknown.
+            return None  # defined by >1 class — ambiguous, stay unknown.
         found = mid
     return found
 
 
-def _name_is_shadowed(
-    ctx: TypeScriptResolverContext, caller_file: str, simple: str
+def _project_owns(
+    ctx: TypeScriptResolverContext, simple: str, caller_file: str
 ) -> bool:
-    """True when ``simple`` is shadowed for ``caller_file`` so the ``builtin``
-    global-object classification must NOT claim it.
+    """True when a COMPATIBLE-LANGUAGE (TS/JS-family) project symbol named
+    ``simple`` exists, OR the caller file shadows ``simple`` with a local
+    variable / import binding.
 
-    Two shadowing sources are consulted:
+    The shadowing gate: if the project owns the name in a JS/TS-family file, the
+    ``builtin`` global-object classification must NOT claim it. The gate is
+    LANGUAGE-AWARE — a same-named symbol in an incompatible-language file (a
+    Python ``console``) does NOT count, because
+    ``languages_compatible("typescript", "python")`` is False. Files with an
+    unknown language tag are treated as possible owners (conservative).
 
-    * **Project-defined symbols** (``global_name_table``) in a COMPATIBLE-LANGUAGE
-      (TS/JS-family) file. The gate is LANGUAGE-AWARE — a same-named symbol in an
-      incompatible-language file (a Python ``console``) does NOT count, because
-      ``languages_compatible("typescript", "python")`` is False. Files with an
-      unknown language tag are treated as possible owners (conservative). This is
-      THE MOAT: an incompatible-language owner never suppresses or binds.
-    * **Import locals in the caller's own file** (Codex P2 #347): a name bound by
-      an import in this file — ``import { Map } from './map'``,
-      ``import Promise from 'bluebird'`` — rebinds the global LOCALLY, so
-      ``Map.of`` / ``Promise.all`` must stay non-``builtin``. An import in a
-      *different* file does not shadow this file's global.
-
-    The variable case (``const Map = require('./map')``) is not yet detectable —
-    the resolver context carries no variable symbols — and stays a conservative
-    known limitation; it can only over-classify toward ``builtin``, never
-    mis-bind cross-language.
+    Variable / import shadows (``const Promise = ...`` / ``import { Map }``) are
+    file-scoped and never appear in ``global_name_table``, so they are consulted
+    via ``shadow_locals`` for the CALLER file only (Codex P2 #2/#3).
     """
-    if simple in ctx.import_locals_by_file.get(caller_file, frozenset()):
-        return True
-
     from ..._language_family import languages_compatible
 
+    if simple in ctx.shadow_locals.get(caller_file, set()):
+        return True
     for owner_file, _sym_id in ctx.global_name_table.get(simple, []):
         owner_lang = ctx.file_languages.get(owner_file, "")
         if not owner_lang or languages_compatible(_TYPESCRIPT_LANG, owner_lang):
@@ -207,33 +250,36 @@ def resolve_typescript_callee(
     """
     receiver, simple = _split_receiver(callee_full, callee_name)
 
-    # 1. local (instance) — ``this.foo()`` / ``super.foo()``: a method call on the
-    #    enclosing object. Resolve WITHIN the caller's class only — never a
-    #    top-level free function, never another class's same-named method when
-    #    ambiguous (Codex P2 #347). Otherwise ``unknown``.
-    if receiver in _THIS_RECEIVERS:
-        mid = _lookup_this_method(ctx, caller_file, simple)
-        if mid is not None:
-            return mid, "local", caller_file
-        return None, "unknown", ""
-
-    # 2. local (bare) — no receiver: a same-file top-level ``function``/``class``.
+    # 1. local — bare receiver: a same-file top-level function/method/class def.
+    #    A bare ``foo()`` is module-scoped, so the file-wide symbol lookup is
+    #    correct here (it cannot mis-bind to another class — methods on ``this``
+    #    are handled separately below).
     if receiver == "":
-        sym_id = _lookup_free_symbol(ctx, caller_file, simple)
+        sym_id = _lookup_in_file(ctx, caller_file, simple)
         if sym_id is not None:
             return sym_id, "local", caller_file
         # A bare unresolved call stays unknown — NO global single-name binding,
         # because that is exactly where cross-language mis-wires creep in.
         return None, "unknown", ""
 
-    # 3. builtin — receiver head is a distinctive JS/TS global object
-    #    (``console``/``JSON``/``Math``…). Gated on the global name NOT being
-    #    shadowed (a compatible-language project symbol OR an import local in this
-    #    file). The head, not the tail, is the global ("console" in "console.log").
+    # 1b. local — ``this``/``super`` method: class-scoped. The caller's enclosing
+    #     class is NOT available to the resolver, so resolve ONLY when exactly one
+    #     class in the file defines the method. An ambiguous name (two classes) or
+    #     a top-level function (not a method) stays ``unknown`` — never the
+    #     file-wide first match that would mis-bind ``B.bar -> A.foo`` (P2 #1).
+    if receiver in _SELF_RECEIVERS:
+        mid = _unique_class_method(ctx, caller_file, simple)
+        if mid is not None:
+            return mid, "local", caller_file
+        return None, "unknown", ""
+
+    # 2. builtin — receiver head is a distinctive JS/TS global object
+    #    (``console``/``JSON``/``Math``…). Gated on the project NOT owning that
+    #    global name as a compatible-language symbol OR shadowing it with a local
+    #    variable / import binding (shadowing preserved). The head, not the tail,
+    #    is the global ("console" in "console.log").
     head = receiver.split(".", 1)[0]
-    if head in TYPESCRIPT_GLOBAL_OBJECTS and not _name_is_shadowed(
-        ctx, caller_file, head
-    ):
+    if head in TYPESCRIPT_GLOBAL_OBJECTS and not _project_owns(ctx, head, caller_file):
         return None, "builtin", ""
 
     # 3. unknown — no confident same-language resolution. Conservative tiers keep

--- a/tree_sitter_analyzer/synapse_resolver/languages/typescript.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/typescript.py
@@ -1,0 +1,177 @@
+"""TypeScript per-language callee resolver (RFC-0010, first wave).
+
+Self-contained and SAFE. Replaces the Python cascade for ``.ts``/``.tsx`` callers
+(``file_languages == "typescript"``) without regressing: it resolves SAME-FILE/
+SAME-LANGUAGE local calls, classifies a small, distinctive set of built-in global
+objects as ``builtin``, and returns ``unknown`` for everything else.
+
+THE MOAT — never cross-language bind. ``_project_owns`` is language-aware: a
+same-named symbol in an incompatible-language file (e.g. a Python ``console``)
+never counts as an owner and is never bound, because
+``languages_compatible("typescript", "python")`` is False. JS/TS dialects are one
+family, so a ``.js`` owner does count (gradual-migration repos cross-import).
+
+Conservative tiers only (the RFC-0008 lesson): the bare-method-name stdlib/
+external tables are EMPTY by design — generic JS method names (``map``/``push``/
+``substring``/``then``) collide with domain methods and, without receiver-type
+inference, would be mis-classified. They stay ``unknown``, which is correct.
+
+Contract (RFC-0010): the module ends with
+``register_language("typescript", build_typescript_resolver_context,
+resolve_typescript_callee)``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .._registry import register_language
+from ._typescript_constants import TYPESCRIPT_GLOBAL_OBJECTS
+
+#: ``file_languages`` tag for every ``.ts``/``.tsx``/``.mts``/``.cts`` file.
+_TYPESCRIPT_LANG = "typescript"
+
+#: Receivers that mean "the current object" — a no-receiver-style local call.
+_SELF_RECEIVERS = ("", "this", "super")
+
+
+@dataclass
+class TypeScriptResolverContext:
+    """Per-index TypeScript resolution maps (built once per pass).
+
+    Only the shared, already-loaded cache structures are kept; the resolver does
+    no extra indexing. All file keys are project-relative paths.
+    """
+
+    # file -> [(name, kind, symbol_id), ...] (shared cross-language map).
+    file_symbols: dict[str, list[tuple[str, str, int]]] = field(default_factory=dict)
+    # file -> {class -> {method -> symbol_id}} (shared cross-language map).
+    file_class_methods: dict[str, dict[str, dict[str, int]]] = field(
+        default_factory=dict
+    )
+    # simple name -> [(file, symbol_id), ...] project-wide (single-global).
+    global_name_table: dict[str, list[tuple[str, int]]] = field(default_factory=dict)
+    # file -> language tag (so the ownership gate is language-aware).
+    file_languages: dict[str, str] = field(default_factory=dict)
+
+
+def build_typescript_resolver_context(
+    *,
+    imports_by_file: dict[str, Any],
+    file_languages: dict[str, str],
+    file_symbols: dict[str, Any],
+    global_name_table: dict[str, Any],
+    file_class_methods: Any,  # zero-arg thunk -> class->method map (lazy)
+    **_ignored: Any,
+) -> TypeScriptResolverContext | None:
+    """Build the TS context, or ``None`` when no TypeScript file is indexed.
+
+    Zero cost for non-TS projects (gated on ``file_languages``). The
+    ``file_class_methods`` thunk is only invoked when a TS file is present, so a
+    Python/Java-only project pays nothing.
+    """
+    if not any(lang == _TYPESCRIPT_LANG for lang in file_languages.values()):
+        return None
+    fcm = file_class_methods() if callable(file_class_methods) else file_class_methods
+    return TypeScriptResolverContext(
+        file_symbols=file_symbols,
+        file_class_methods=fcm or {},
+        global_name_table=global_name_table,
+        file_languages=file_languages,
+    )
+
+
+def _split_receiver(callee_full: str, callee_name: str) -> tuple[str, str]:
+    """Return ``(receiver, simple_name)`` from a TS call's full name."""
+    full = callee_full or callee_name
+    if "." in full:
+        receiver, simple = full.rsplit(".", 1)
+        return receiver, simple
+    return "", full or callee_name
+
+
+def _lookup_in_file(
+    ctx: TypeScriptResolverContext, file_path: str, simple: str
+) -> int | None:
+    for name, kind, sym_id in ctx.file_symbols.get(file_path, []):
+        if name == simple and kind in ("function", "method", "class"):
+            return sym_id
+    return None
+
+
+def _project_owns(ctx: TypeScriptResolverContext, simple: str) -> bool:
+    """True when a COMPATIBLE-LANGUAGE (TS/JS-family) project symbol named
+    ``simple`` exists.
+
+    The shadowing gate: if the project owns the name in a JS/TS-family file, the
+    ``builtin`` global-object classification must NOT claim it. The gate is
+    LANGUAGE-AWARE — a same-named symbol in an incompatible-language file (a
+    Python ``console``) does NOT count, because
+    ``languages_compatible("typescript", "python")`` is False. Files with an
+    unknown language tag are treated as possible owners (conservative).
+    """
+    from ..._language_family import languages_compatible
+
+    for owner_file, _sym_id in ctx.global_name_table.get(simple, []):
+        owner_lang = ctx.file_languages.get(owner_file, "")
+        if not owner_lang or languages_compatible(_TYPESCRIPT_LANG, owner_lang):
+            return True
+    return False
+
+
+def resolve_typescript_callee(
+    callee_name: str,
+    callee_full: str,
+    caller_file: str,
+    ctx: TypeScriptResolverContext,
+) -> tuple[int | None, str, str]:
+    """Resolve one TypeScript call edge.
+
+    Returns ``(symbol_id, resolution, resolved_file)`` where ``resolution`` is
+    one of ``local`` / ``builtin`` / ``unknown``. Conservative by design: every
+    path that is not a confident same-file local call or a distinctive built-in
+    global-object call returns ``unknown`` — never a cross-language bind.
+    """
+    receiver, simple = _split_receiver(callee_full, callee_name)
+
+    # 1. local — no receiver (or ``this``/``super``): a same-file definition.
+    if receiver in _SELF_RECEIVERS:
+        sym_id = _lookup_in_file(ctx, caller_file, simple)
+        if sym_id is not None:
+            return sym_id, "local", caller_file
+        # 1b. this/super methods captured in the class-method map.
+        for _cls, methods in ctx.file_class_methods.get(caller_file, {}).items():
+            mid = methods.get(simple)
+            if mid is not None:
+                return mid, "local", caller_file
+        # A bare unresolved call stays unknown — NO global single-name binding,
+        # because that is exactly where cross-language mis-wires creep in.
+        return None, "unknown", ""
+
+    # 2. builtin — receiver head is a distinctive JS/TS global object
+    #    (``console``/``JSON``/``Math``…). Gated on the project NOT owning that
+    #    global name as a compatible-language symbol (shadowing preserved). The
+    #    head, not the tail, is the global ("console" in "console.log").
+    head = receiver.split(".", 1)[0]
+    if head in TYPESCRIPT_GLOBAL_OBJECTS and not _project_owns(ctx, head):
+        return None, "builtin", ""
+
+    # 3. unknown — no confident same-language resolution. Conservative tiers keep
+    #    bare-method names (``substring``/``push``/``map``) out of any classified
+    #    bucket; they remain ``unknown`` rather than risk a domain mis-wire.
+    return None, "unknown", ""
+
+
+register_language(
+    _TYPESCRIPT_LANG,
+    build_typescript_resolver_context,
+    resolve_typescript_callee,
+)
+
+
+__all__ = [
+    "TypeScriptResolverContext",
+    "build_typescript_resolver_context",
+    "resolve_typescript_callee",
+]


### PR DESCRIPTION
## Summary

First-wave RFC-0010 per-language resolver for **TypeScript** (`.ts`/`.tsx`/`.mts`/`.cts`). **New-files-only** — zero edits to any existing file; the `languages/` auto-discovery registers it.

Files added:
- `tree_sitter_analyzer/synapse_resolver/languages/typescript.py` — `build_typescript_resolver_context` (gated on a TS file being indexed → zero cost for non-TS projects) + `resolve_typescript_callee`, ending in `register_language("typescript", ...)`.
- `tree_sitter_analyzer/synapse_resolver/languages/_typescript_constants.py` — `TYPESCRIPT_GLOBAL_OBJECTS` (underscore prefix → auto-discovery skips it).
- `tests/unit/test_typescript_method_resolution.py` — 13 RED-first tests.

## What it resolves (self-contained + SAFE)

- **local** — no-receiver / `this`/`super` calls, looked up in the caller file's `file_symbols` and class-method map (same-file, same-language).
- **builtin** — a call whose receiver *head* is a distinctive JS/TS global namespace object (`console.log`, `JSON.stringify`, `Math.max`, `Object.keys`, `Promise.all`, …), behind a **language-aware shadowing gate** (`_project_owns`): only when the project owns no compatible-language (TS/JS-family) symbol of that global name.
- **unknown** — everything else.

## Conservative tiers (the RFC-0008 lesson)

The bare-method-name stdlib/external tables are **EMPTY by design**. Generic JS method names (`map`/`filter`/`push`/`substring`/`then`/`get`) collide with domain/third-party methods and, with no receiver-type inference, would be mis-classified. They stay `unknown` — which is correct. The only classified tier keys on distinctive global *objects* a user almost never shadows; common-but-shadowable globals (`window`/`document`/`process`/`global`) are deliberately excluded.

## THE MOAT — never cross-language bind

`_project_owns` is language-aware via `languages_compatible`. A same-name symbol in an incompatible-language file (e.g. a Python `console`/`helper`) is **never** bound and never suppresses the TS classification. JS/TS dialects are one family (gradual-migration repos cross-import `.js`/`.ts`).

**Mandatory no-cross-language-mis-wire test** (`test_integration_no_cross_language_mis_wire`): a TS `helper()` call coexisting with a Python `def helper` resolves to the `.ts` definition, **never** to `other.py` — the exact CodeGraph failure this project exists to beat.

## Verification

- RED-first: tests written first, confirmed failing for the right reason (module missing), then GREEN. RED re-verified by reverting the `builtin` path → the 4 builtin tests fail, rest pass.
- `ruff check` + `ruff format --check` + `mypy` clean on all new files.
- 13/13 new tests green; registry discovery test (`test_every_language_module_registers_a_resolver`) auto-validates the new module; Java + full synapse-resolver suites (177 tests total) green — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)