### PR TITLE
feat(resolver): conservative C++ callee resolver (RFC-0010 first wave)

### DIFF
--- a/tests/unit/test_cpp_method_resolution.py
+++ b/tests/unit/test_cpp_method_resolution.py
@@ -9,7 +9,11 @@ external method tiers, and — MANDATORY — the no-cross-language-mis-wire moat
 
 from __future__ import annotations
 
+import pytest
+
+from tree_sitter_analyzer.ast_cache import ASTCache
 from tree_sitter_analyzer.synapse_resolver import ResolverContext, resolve_callee
+from tree_sitter_analyzer.synapse_resolver._context import build_resolver_context
 from tree_sitter_analyzer.synapse_resolver._registry import get_language_resolver
 from tree_sitter_analyzer.synapse_resolver.languages._cpp_constants import (
     is_stdlib_qualifier,
@@ -417,3 +421,133 @@ class TestRegistrationAndDispatch:
         )
         assert resolved.resolution == "unknown"
         assert resolved.resolved_file == ""
+
+
+# ---------------------------------------------------------------------------
+# Real-index integration (Codex PR #348 P2) — drive the FULL pipeline:
+# write real .cpp/.py files, index them with ASTCache, build the resolver
+# context the way production does, and exercise resolve_cpp_callee against the
+# context the index actually produced (NOT a fabricated map).
+#
+# Why this matters: the unit suites above feed hand-built maps. Codex flagged
+# that the production maps come from ``ast_symbol_rows`` via the generic
+# ``_ast_extraction._walk_for_symbols`` walker, whose ``child_by_field_name
+# ('name')`` gate misses tree-sitter C++ functions/methods (their identifier
+# lives under ``function_declarator``), so the local/single-global tiers could
+# silently never fire in production while the unit tests stayed green. These
+# integration tests assert the behaviour on a REAL parsed index:
+#   * the maps-INDEPENDENT stdlib-qualifier tier works end-to-end, and
+#   * THE MOAT holds on a real index — a same-named foreign-language symbol is
+#     never bound, regardless of how many C++ symbols the walker recovered.
+# A separate xfail nails the current local-tier production gap as an explicit
+# regression target for the extractor fix (root cause lives in the shared
+# walker, out of this resolver's scope).
+# ---------------------------------------------------------------------------
+
+
+def _index_and_build(tmp_path, files: dict[str, str]):
+    """Write ``files`` into ``tmp_path``, index them, return (root, cpp_ctx)."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    for rel, body in files.items():
+        (project / rel).write_text(body)
+    cache = ASTCache(str(project))
+    try:
+        cache.index_project(max_files=100)
+        resolver_ctx = build_resolver_context(cache)
+    finally:
+        cache.close()
+    return project, resolver_ctx.lang_context("cpp")
+
+
+_REAL_CPP = (
+    "#include <algorithm>\n"
+    "int helper() { return 1; }\n"
+    "struct Calc {\n"
+    "    int run() {\n"
+    "        std::sort(nullptr, nullptr);\n"
+    "        return this->helper();\n"
+    "    }\n"
+    "};\n"
+)
+# A Python file defining the SAME bare name ``helper`` — the cross-language
+# collision the moat must never bind a C++ caller to.
+_REAL_PY = "def helper():\n    return 2\n"
+
+
+class TestRealIndexIntegration:
+    def test_cpp_context_is_built_from_real_index(self, tmp_path) -> None:
+        """A parsed ``.cpp`` file yields a non-None C++ resolver context."""
+        _root, cpp_ctx = _index_and_build(tmp_path, {"service.cpp": _REAL_CPP})
+        assert cpp_ctx is not None
+        assert isinstance(cpp_ctx, CppResolverContext)
+        # The language map MUST tag the indexed file as cpp — this is what gates
+        # every project binding (the moat). If it were absent the moat could not
+        # discriminate languages.
+        assert cpp_ctx.file_languages.get("service.cpp") == "cpp"
+
+    def test_stdlib_qualifier_resolves_on_real_index(self, tmp_path) -> None:
+        """``std::sort`` -> ``stdlib`` end-to-end (maps-independent tier).
+
+        This tier reads only the call's qualifier, so it works regardless of
+        whether the symbol walker recovered any C++ definitions — proving the
+        resolver does real, correct work on a production index.
+        """
+        _root, cpp_ctx = _index_and_build(tmp_path, {"service.cpp": _REAL_CPP})
+        sym, res, f = resolve_cpp_callee("sort", "std::sort", "service.cpp", cpp_ctx)
+        assert (sym, res, f) == (None, "stdlib", "")
+
+    def test_moat_holds_on_real_index(self, tmp_path) -> None:
+        """THE MOAT on a REAL index: a C++ caller's ``helper`` call must never
+        bind to the same-named Python ``helper`` definition.
+
+        Whatever the walker recovered for C++, the language-compat gate must
+        keep the Python file out: the result is the C++ same-language def or
+        ``unknown`` — NEVER ``util.py``. This is the CodeGraph failure we beat.
+        """
+        _root, cpp_ctx = _index_and_build(
+            tmp_path, {"service.cpp": _REAL_CPP, "util.py": _REAL_PY}
+        )
+        _sym, _res, f = resolve_cpp_callee("helper", "helper", "service.cpp", cpp_ctx)
+        assert f != "util.py"
+        assert not f.endswith(".py")
+
+    def test_this_member_call_never_mis_binds_on_real_index(self, tmp_path) -> None:
+        """``this->helper`` on a real index resolves to a C++ member or stays
+        ``unknown`` — it must never bind a free function or a foreign file."""
+        _root, cpp_ctx = _index_and_build(
+            tmp_path, {"service.cpp": _REAL_CPP, "util.py": _REAL_PY}
+        )
+        sym, res, f = resolve_cpp_callee(
+            "helper", "this->helper", "service.cpp", cpp_ctx
+        )
+        # Conservative: a same-file member ('method') is the only valid bind;
+        # anything else stays unknown. Either way, never a .py file.
+        assert not f.endswith(".py")
+        if res == "local":
+            # If bound, it must be a same-file member, never the free function.
+            assert f == "service.cpp"
+        else:
+            assert (sym, res, f) == (None, "unknown", "")
+
+    @pytest.mark.xfail(
+        reason=(
+            "Known production gap: the shared generic symbol walker "
+            "(_ast_extraction._walk_for_symbols) gates on "
+            "child_by_field_name('name'), which tree-sitter C++ "
+            "function_definition nodes do not expose (the identifier lives "
+            "under function_declarator), so ordinary C++ free functions are "
+            "absent from ast_symbol_rows and the local/single-global tiers "
+            "cannot fire. Root cause lives in the shared extractor, out of "
+            "this resolver's scope; this xfail is the regression target so the "
+            "tier flips to PASS once the walker recovers C++ symbols."
+        ),
+        strict=True,
+    )
+    def test_local_free_function_resolves_on_real_index(self, tmp_path) -> None:
+        """When the extractor populates C++ symbols, an unqualified call to a
+        same-file free function (``helper``) must resolve ``local``."""
+        _root, cpp_ctx = _index_and_build(tmp_path, {"service.cpp": _REAL_CPP})
+        _sym, res, f = resolve_cpp_callee("helper", "helper", "service.cpp", cpp_ctx)
+        assert res == "local"
+        assert f == "service.cpp"

--- a/tests/unit/test_cpp_method_resolution.py
+++ b/tests/unit/test_cpp_method_resolution.py
@@ -40,6 +40,10 @@ def _build_ctx() -> CppResolverContext:
             ("Service", "class", 1),
             ("run", "function", 2),
             ("parse", "function", 3),
+            # A real same-file METHOD (member). An explicit-``this`` call MAY
+            # bind to this member; it must NEVER bind to the free functions
+            # (``run`` / ``parse``) or the class above.
+            ("dispatch", "method", 4),
         ],
         helper: [
             ("Helper", "class", 10),
@@ -160,11 +164,27 @@ class TestLocalAndProject:
         assert f == "src/service.cpp"
         assert sym == 2
 
-    def test_this_qualified_is_local(self) -> None:
+    def test_this_qualified_member_is_local(self) -> None:
+        """An explicit ``this->`` call MAY bind to a same-file MEMBER.
+
+        ``dispatch`` is a same-file ``method``; the implicit-/explicit-this
+        receiver proves the target is a member, so binding to it is correct.
+        """
         ctx = _build_ctx()
-        _sym, res, f = resolve_cpp_callee("run", "this->run", "src/service.cpp", ctx)
+        sym, res, f = resolve_cpp_callee(
+            "dispatch", "this->dispatch", "src/service.cpp", ctx
+        )
         assert res == "local"
         assert f == "src/service.cpp"
+        assert sym == 4
+
+    def test_implicit_this_member_is_local(self) -> None:
+        """An unqualified call may also resolve to a same-file member."""
+        ctx = _build_ctx()
+        sym, res, f = resolve_cpp_callee("dispatch", "dispatch", "src/service.cpp", ctx)
+        assert res == "local"
+        assert f == "src/service.cpp"
+        assert sym == 4
 
     def test_single_global_project(self) -> None:
         ctx = _build_ctx()
@@ -197,6 +217,71 @@ class TestLocalAndProject:
             "nonexistent", "nonexistent", "src/service.cpp", ctx
         )
         assert res == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Explicit self-receiver semantics (Codex PR #348 P2)
+# ---------------------------------------------------------------------------
+
+
+class TestExplicitSelfReceiver:
+    """An explicit ``this->`` / ``self`` receiver asserts the target is a
+    member (or inherited member). The conservative resolver must NOT downgrade
+    that into binding a bare free function (same-file ``local`` via a
+    ``function`` symbol) or a cross-file global (``project``). If it cannot
+    prove a member target, it stays ``unknown`` — an unknown edge is correct;
+    a free-function/global mis-bind is a moat-class failure.
+    """
+
+    def test_this_call_does_not_bind_same_file_free_function(self) -> None:
+        # ``this->run`` — ``run`` is a same-file FREE FUNCTION (kind=function),
+        # not a member. A ``this->`` call can never reach a free function, so
+        # the resolver must stay ``unknown``, not record a false ``local``.
+        ctx = _build_ctx()
+        sym, res, f = resolve_cpp_callee("run", "this->run", "src/service.cpp", ctx)
+        assert res == "unknown"
+        assert f == ""
+        assert sym is None
+
+    def test_this_call_does_not_bind_same_file_class(self) -> None:
+        # ``this->Service`` — a class symbol is not a member method either.
+        ctx = _build_ctx()
+        sym, res, f = resolve_cpp_callee(
+            "Service", "this->Service", "src/service.cpp", ctx
+        )
+        assert res == "unknown"
+        assert sym is None
+
+    def test_this_call_does_not_bind_cross_file_global(self) -> None:
+        # ``this->compute_total`` — ``compute_total`` is a single project-wide
+        # global in ANOTHER file. A member call must not bind a cross-file
+        # global, so the project (single-global) tier is skipped: ``unknown``.
+        ctx = _build_ctx()
+        sym, res, f = resolve_cpp_callee(
+            "compute_total", "this->compute_total", "src/service.cpp", ctx
+        )
+        assert res == "unknown"
+        assert f == ""
+        assert sym is None
+
+    def test_self_receiver_variants_do_not_bind_free_function(self) -> None:
+        # The other self tokens (``self``, ``(*this)``, ``*this``) follow the
+        # same rule — never bind a free function for a member call.
+        ctx = _build_ctx()
+        for recv in ("self", "(*this)", "*this"):
+            sym, res, f = resolve_cpp_callee(
+                "run", f"{recv}->run", "src/service.cpp", ctx
+            )
+            assert res == "unknown", recv
+            assert sym is None, recv
+
+    def test_unqualified_free_function_still_binds_local(self) -> None:
+        # Regression guard: an UNQUALIFIED call (no receiver) may still bind a
+        # same-file free function — only the explicit-self path is tightened.
+        ctx = _build_ctx()
+        sym, res, f = resolve_cpp_callee("run", "run", "src/service.cpp", ctx)
+        assert res == "local"
+        assert sym == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cpp_method_resolution.py
+++ b/tests/unit/test_cpp_method_resolution.py
@@ -1,0 +1,334 @@
+"""Unit + integration tests for the C++ resolver (RFC-0010 first wave).
+
+Covers the conservative cascade in
+``synapse_resolver/languages/cpp.py``: stdlib-qualifier classification, local
+same-file resolution, single-global project resolution, the empty stdlib/
+external method tiers, and — MANDATORY — the no-cross-language-mis-wire moat
+(a callee whose name also exists in a non-C++ file must NOT bind to that file).
+"""
+
+from __future__ import annotations
+
+from tree_sitter_analyzer.synapse_resolver import ResolverContext, resolve_callee
+from tree_sitter_analyzer.synapse_resolver._registry import get_language_resolver
+from tree_sitter_analyzer.synapse_resolver.languages._cpp_constants import (
+    is_stdlib_qualifier,
+)
+from tree_sitter_analyzer.synapse_resolver.languages.cpp import (
+    CppResolverContext,
+    build_cpp_context,
+    resolve_cpp_callee,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _build_ctx() -> CppResolverContext:
+    """service.cpp + helper.cpp, with a same-named Python symbol elsewhere.
+
+    ``helper.cpp`` defines a project-unique ``compute_total``. ``service.cpp``
+    defines a local ``run`` and ``parse``. A Python file also defines ``parse``
+    (the cross-language collision used by the moat test).
+    """
+    service = "src/service.cpp"
+    helper = "src/helper.cpp"
+    py = "scripts/util.py"
+    file_symbols = {
+        service: [
+            ("Service", "class", 1),
+            ("run", "function", 2),
+            ("parse", "function", 3),
+        ],
+        helper: [
+            ("Helper", "class", 10),
+            ("compute_total", "function", 11),
+        ],
+        py: [("parse", "function", 99)],
+    }
+    global_name_table = {
+        "run": [(service, 2)],
+        # ``parse`` is defined in BOTH a C++ file and a Python file — ambiguous
+        # across languages. The C++ caller must only ever see the C++ one.
+        "parse": [(service, 3), (py, 99)],
+        # ``compute_total`` is the single project-wide (C++) definition.
+        "compute_total": [(helper, 11)],
+        # ``only_python`` lives ONLY in the Python file.
+        "only_python": [(py, 99)],
+    }
+    file_languages = {service: "cpp", helper: "cpp", py: "python"}
+    return build_cpp_context(
+        imports_by_file={},
+        file_languages=file_languages,
+        file_symbols=file_symbols,
+        global_name_table=global_name_table,
+        file_class_methods=lambda: {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_cpp_context gating
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCppContext:
+    def test_returns_none_when_no_cpp_file(self) -> None:
+        ctx = build_cpp_context(
+            imports_by_file={},
+            file_languages={"a.py": "python", "b.go": "go"},
+            file_symbols={},
+            global_name_table={},
+            file_class_methods=lambda: {},
+        )
+        assert ctx is None
+
+    def test_builds_when_cpp_present(self) -> None:
+        ctx = build_cpp_context(
+            imports_by_file={},
+            file_languages={"a.cpp": "cpp"},
+            file_symbols={},
+            global_name_table={},
+            file_class_methods=lambda: {},
+        )
+        assert isinstance(ctx, CppResolverContext)
+
+    def test_does_not_call_class_methods_thunk(self) -> None:
+        calls: list[int] = []
+
+        def thunk() -> dict[str, object]:
+            calls.append(1)
+            return {}
+
+        build_cpp_context(
+            imports_by_file={},
+            file_languages={"a.cpp": "cpp"},
+            file_symbols={},
+            global_name_table={},
+            file_class_methods=thunk,
+        )
+        assert calls == []  # conservative cascade never needs the class map
+
+
+# ---------------------------------------------------------------------------
+# stdlib-qualifier tier
+# ---------------------------------------------------------------------------
+
+
+class TestStdlibQualifier:
+    def test_std_sort_is_stdlib(self) -> None:
+        ctx = _build_ctx()
+        sym, res, f = resolve_cpp_callee("sort", "std::sort", "src/service.cpp", ctx)
+        assert (sym, res, f) == (None, "stdlib", "")
+
+    def test_std_make_unique_is_stdlib(self) -> None:
+        ctx = _build_ctx()
+        _sym, res, _f = resolve_cpp_callee(
+            "make_unique", "std::make_unique", "src/service.cpp", ctx
+        )
+        assert res == "stdlib"
+
+    def test_nested_std_namespace_is_stdlib(self) -> None:
+        ctx = _build_ctx()
+        _sym, res, _f = resolve_cpp_callee(
+            "now", "std::chrono::now", "src/service.cpp", ctx
+        )
+        assert res == "stdlib"
+
+    def test_is_stdlib_qualifier_helper(self) -> None:
+        assert is_stdlib_qualifier("std")
+        assert is_stdlib_qualifier("std::chrono")
+        assert is_stdlib_qualifier("__gnu_cxx")
+        assert not is_stdlib_qualifier("")
+        assert not is_stdlib_qualifier("mylib")
+        # A user namespace that merely starts with the letters "std" must NOT
+        # match — the prefix check is on the ``std::`` token boundary.
+        assert not is_stdlib_qualifier("stdx")
+        assert not is_stdlib_qualifier("mystd")
+
+
+# ---------------------------------------------------------------------------
+# local + project resolution
+# ---------------------------------------------------------------------------
+
+
+class TestLocalAndProject:
+    def test_local_free_function(self) -> None:
+        ctx = _build_ctx()
+        sym, res, f = resolve_cpp_callee("run", "run", "src/service.cpp", ctx)
+        assert res == "local"
+        assert f == "src/service.cpp"
+        assert sym == 2
+
+    def test_this_qualified_is_local(self) -> None:
+        ctx = _build_ctx()
+        _sym, res, f = resolve_cpp_callee("run", "this->run", "src/service.cpp", ctx)
+        assert res == "local"
+        assert f == "src/service.cpp"
+
+    def test_single_global_project(self) -> None:
+        ctx = _build_ctx()
+        # ``compute_total`` is defined once, in another C++ file -> project.
+        sym, res, f = resolve_cpp_callee(
+            "compute_total", "compute_total", "src/service.cpp", ctx
+        )
+        assert res == "project"
+        assert f == "src/helper.cpp"
+        assert sym == 11
+
+    def test_instance_receiver_is_unknown(self) -> None:
+        ctx = _build_ctx()
+        # ``obj->doThing()`` — receiver is a variable, not a resolvable type.
+        _sym, res, _f = resolve_cpp_callee(
+            "doThing", "obj->doThing", "src/service.cpp", ctx
+        )
+        assert res == "unknown"
+
+    def test_non_stdlib_qualified_is_unknown(self) -> None:
+        ctx = _build_ctx()
+        _sym, res, _f = resolve_cpp_callee(
+            "frobnicate", "mylib::frobnicate", "src/service.cpp", ctx
+        )
+        assert res == "unknown"
+
+    def test_truly_unknown_name(self) -> None:
+        ctx = _build_ctx()
+        _sym, res, _f = resolve_cpp_callee(
+            "nonexistent", "nonexistent", "src/service.cpp", ctx
+        )
+        assert res == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# THE MOAT — no cross-language mis-wire (MANDATORY)
+# ---------------------------------------------------------------------------
+
+
+class TestNoCrossLanguageMisWire:
+    def test_ambiguous_name_resolves_to_cpp_def_not_python(self) -> None:
+        """``parse`` exists in BOTH a .cpp and a .py file.
+
+        A C++ caller must resolve to the SAME-FILE C++ definition (local),
+        never the Python file. After removing the Python candidate the C++ one
+        is the single same-language global, but here it is also same-file, so
+        the local tier wins. Either way the resolved file must be C++.
+        """
+        ctx = _build_ctx()
+        sym, res, f = resolve_cpp_callee("parse", "parse", "src/service.cpp", ctx)
+        assert f != "scripts/util.py"
+        assert f == "src/service.cpp"
+        assert res == "local"
+        assert sym == 3
+
+    def test_python_only_symbol_is_never_bound(self) -> None:
+        """``only_python`` exists ONLY in a Python file.
+
+        The C++ caller must NOT bind to it — the language-compat gate drops the
+        sole candidate, so the result is ``unknown`` with NO resolved file.
+        This is the exact CodeGraph failure this project exists to beat.
+        """
+        ctx = _build_ctx()
+        sym, res, f = resolve_cpp_callee(
+            "only_python", "only_python", "src/service.cpp", ctx
+        )
+        assert res == "unknown"
+        assert f == ""
+        assert sym is None
+
+    def test_ambiguous_global_only_foreign_plus_self_stays_cpp(self) -> None:
+        """A name with one C++ and one Python global, called from a 3rd C++ file.
+
+        ``parse`` has (service.cpp, py). Called from helper.cpp (no local
+        ``parse``): the Python candidate is gated out, leaving exactly one
+        same-language candidate (service.cpp) -> project, never the .py file.
+        """
+        ctx = _build_ctx()
+        sym, res, f = resolve_cpp_callee("parse", "parse", "src/helper.cpp", ctx)
+        assert f != "scripts/util.py"
+        assert res == "project"
+        assert f == "src/service.cpp"
+        assert sym == 3
+
+
+# ---------------------------------------------------------------------------
+# C-header directional compat (cpp -> c is legitimate, the one cross-tag case)
+# ---------------------------------------------------------------------------
+
+
+class TestCHeaderCompat:
+    def test_cpp_resolves_c_header_symbol(self) -> None:
+        """A C++ caller MAY resolve a symbol defined in a C-tagged header."""
+        cpp_file = "src/main.cpp"
+        c_header = "include/api.h"
+        ctx = build_cpp_context(
+            imports_by_file={},
+            file_languages={cpp_file: "cpp", c_header: "c"},
+            file_symbols={
+                cpp_file: [("main", "function", 1)],
+                c_header: [("c_api_init", "function", 5)],
+            },
+            global_name_table={"c_api_init": [(c_header, 5)]},
+            file_class_methods=lambda: {},
+        )
+        assert ctx is not None
+        sym, res, f = resolve_cpp_callee("c_api_init", "c_api_init", cpp_file, ctx)
+        assert res == "project"
+        assert f == c_header
+        assert sym == 5
+
+
+# ---------------------------------------------------------------------------
+# Registry + dispatch integration through the public resolve_callee
+# ---------------------------------------------------------------------------
+
+
+class TestRegistrationAndDispatch:
+    def test_cpp_is_registered(self) -> None:
+        resolver = get_language_resolver("cpp")
+        assert resolver is not None
+        assert resolver.language == "cpp"
+
+    def test_resolve_callee_dispatches_to_cpp(self) -> None:
+        cpp_ctx = _build_ctx()
+        ctx = ResolverContext(
+            project_root=".",
+            cache=None,
+            file_languages={
+                "src/service.cpp": "cpp",
+                "src/helper.cpp": "cpp",
+                "scripts/util.py": "python",
+            },
+            lang_contexts={"cpp": cpp_ctx},
+        )
+        # stdlib qualifier through the public entry point.
+        resolved = resolve_callee(
+            "sort", "src/service.cpp", ctx, callee_full="std::sort"
+        )
+        assert resolved.resolution == "stdlib"
+
+        # Single-global project resolution through the public entry point.
+        resolved = resolve_callee(
+            "compute_total",
+            "src/service.cpp",
+            ctx,
+            callee_full="compute_total",
+        )
+        assert resolved.resolution == "project"
+        assert resolved.resolved_file == "src/helper.cpp"
+
+    def test_resolve_callee_moat_through_public_api(self) -> None:
+        cpp_ctx = _build_ctx()
+        ctx = ResolverContext(
+            project_root=".",
+            cache=None,
+            file_languages={
+                "src/service.cpp": "cpp",
+                "scripts/util.py": "python",
+            },
+            lang_contexts={"cpp": cpp_ctx},
+        )
+        resolved = resolve_callee(
+            "only_python", "src/service.cpp", ctx, callee_full="only_python"
+        )
+        assert resolved.resolution == "unknown"
+        assert resolved.resolved_file == ""

--- a/tests/unit/test_cpp_method_resolution.py
+++ b/tests/unit/test_cpp_method_resolution.py
@@ -289,6 +289,98 @@ class TestExplicitSelfReceiver:
 
 
 # ---------------------------------------------------------------------------
+# Multi-class owner scoping (Codex PR #348 P2, cpp.py:210)
+#
+# When ONE .cpp file declares more than one class and both define a method of
+# the same name, a self-receiver / implicit-this member call cannot be proven
+# to target the caller's own class (the resolver is not handed the caller's
+# enclosing class). Binding it to "whichever class happens to be in the file"
+# is a false ``local`` edge — exactly the no-miswire breach Codex flagged. The
+# conservative rule: a member call binds a same-file ``method`` ONLY when that
+# method name is owned by EXACTLY ONE class in the file; otherwise ``unknown``.
+# ---------------------------------------------------------------------------
+
+
+def _build_multiclass_ctx() -> CppResolverContext:
+    """One .cpp file with TWO classes that each define ``dispatch``.
+
+    ``A::dispatch`` (id 2) and ``B::dispatch`` (id 3) collide by simple name.
+    ``A::solo`` (id 4) is owned by exactly one class. The ``file_class_methods``
+    map carries the owner-class breakdown the resolver needs to detect the
+    ambiguity; ``file_symbols`` (name, kind, id) alone cannot.
+    """
+    multi = "src/multi.cpp"
+    file_symbols = {
+        multi: [
+            ("A", "class", 1),
+            ("dispatch", "method", 2),  # A::dispatch
+            ("dispatch", "method", 3),  # B::dispatch — same simple name
+            ("solo", "method", 4),  # A::solo — single owner class
+            ("B", "class", 5),
+            ("free_fn", "function", 6),  # file-scoped free function
+        ],
+    }
+    global_name_table = {
+        "dispatch": [(multi, 2), (multi, 3)],
+        "solo": [(multi, 4)],
+        "free_fn": [(multi, 6)],
+    }
+    file_languages = {multi: "cpp"}
+    file_class_methods = {
+        multi: {
+            "A": {"dispatch": 2, "solo": 4},
+            "B": {"dispatch": 3},
+        }
+    }
+    return build_cpp_context(
+        imports_by_file={},
+        file_languages=file_languages,
+        file_symbols=file_symbols,
+        global_name_table=global_name_table,
+        file_class_methods=lambda: file_class_methods,
+    )
+
+
+class TestMultiClassOwnerScoping:
+    def test_self_call_to_ambiguous_member_stays_unknown(self) -> None:
+        # ``this->dispatch`` — ``dispatch`` is a method in BOTH A and B in this
+        # file. The resolver cannot prove the caller's class, so binding either
+        # one is a false ``local``. It must stay ``unknown``.
+        ctx = _build_multiclass_ctx()
+        sym, res, f = resolve_cpp_callee(
+            "dispatch", "this->dispatch", "src/multi.cpp", ctx
+        )
+        assert res == "unknown"
+        assert f == ""
+        assert sym is None
+
+    def test_implicit_this_call_to_ambiguous_member_stays_unknown(self) -> None:
+        # The same ambiguity applies to an unqualified (implicit-this) call to a
+        # member owned by >1 class: it cannot bind a single ``method``.
+        ctx = _build_multiclass_ctx()
+        sym, res, f = resolve_cpp_callee("dispatch", "dispatch", "src/multi.cpp", ctx)
+        assert res == "unknown"
+        assert sym is None
+
+    def test_self_call_to_single_owner_member_still_binds(self) -> None:
+        # ``this->solo`` — ``solo`` is owned by exactly one class (A), so the
+        # member call is unambiguous and binds ``local`` to that method.
+        ctx = _build_multiclass_ctx()
+        sym, res, f = resolve_cpp_callee("solo", "this->solo", "src/multi.cpp", ctx)
+        assert res == "local"
+        assert f == "src/multi.cpp"
+        assert sym == 4
+
+    def test_unqualified_free_function_unaffected_by_method_ambiguity(self) -> None:
+        # A FREE function is file-scoped (no owning class), so the multi-class
+        # method ambiguity must not suppress it: an unqualified call still binds.
+        ctx = _build_multiclass_ctx()
+        sym, res, f = resolve_cpp_callee("free_fn", "free_fn", "src/multi.cpp", ctx)
+        assert res == "local"
+        assert sym == 6
+
+
+# ---------------------------------------------------------------------------
 # THE MOAT — no cross-language mis-wire (MANDATORY)
 # ---------------------------------------------------------------------------
 

--- a/tree_sitter_analyzer/synapse_resolver/languages/_cpp_constants.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/_cpp_constants.py
@@ -1,0 +1,69 @@
+"""Conservative stdlib / external name tiers for the C++ resolver (RFC-0010).
+
+The RFC-0008 lesson is MANDATORY here: method-name classification without
+receiver-type inference has a low precision ceiling, so a name is included in a
+classified tier ONLY when it is (near-)exclusively that stdlib API and very
+unlikely to be a user-defined method. For C++ this is even harsher than Java —
+nearly every "stdlib container" method (``push_back``, ``size``, ``begin``,
+``insert``, ``find``, ``at``, ``emplace``…) is routinely defined by user
+containers, ranges, and domain wrappers, and free functions like ``move`` /
+``swap`` / ``sort`` collide with project helpers. So the bare-method-name
+stdlib tier is **intentionally EMPTY**: everything stays ``project`` / ``local``
+/ ``unknown`` unless it carries the unambiguous ``std::`` qualifier (handled in
+``cpp.py`` by the qualified-namespace prefix tier — not by these name sets).
+
+An empty tier is correct and acceptable: an ``unknown`` edge is never a
+mis-wire, whereas an over-broad name set would mis-classify user methods — the
+exact CodeGraph failure this project exists to beat.
+"""
+
+from __future__ import annotations
+
+# Namespace-qualifier prefixes that are (near-)certainly the C++ standard
+# library. A call whose receiver/qualifier begins with one of these (e.g.
+# ``std::sort``, ``std::make_unique``, ``std::chrono::now``, ``__gnu_cxx::…``)
+# is platform-provided, never project code. ``std::`` is the canonical, almost
+# unspoofable signal — user code does not define members under ``namespace std``
+# (doing so is undefined behaviour). Kept deliberately tiny: only namespaces a
+# project would never own.
+STDLIB_NAMESPACE_PREFIXES: tuple[str, ...] = (
+    "std::",
+    "__gnu_cxx::",
+    "__cxx11::",
+)
+
+# Bare *method/function* names classified ``stdlib`` on an UNRESOLVED receiver.
+# INTENTIONALLY EMPTY (see module docstring): without receiver-type evidence,
+# every candidate (``push_back``, ``size``, ``begin``, ``c_str``, ``move`` …)
+# collides with user containers / wrappers / free helpers. Precision over
+# recall — an unknown edge is correct; a mis-classified one is a moat breach.
+STDLIB_METHODS_CPP: frozenset[str] = frozenset()
+
+# Bare names classified ``external`` (third-party). INTENTIONALLY EMPTY for the
+# first PR: C++ has no single dominant third-party library whose bare method
+# names are safe to hardcode the way JUnit's ``assertX`` family is for Java
+# (GoogleTest's ``EXPECT_*`` / ``ASSERT_*`` are macros, not call edges, and
+# do not appear as resolvable callees). Stays empty until a safe set is proven.
+EXTERNAL_METHODS_CPP: frozenset[str] = frozenset()
+
+
+def is_stdlib_qualifier(qualifier: str) -> bool:
+    """True when ``qualifier`` begins with a known C++ stdlib namespace prefix.
+
+    ``qualifier`` is the receiver/namespace portion of a call's full name
+    (e.g. ``std`` from ``std::sort`` or ``std::chrono`` from
+    ``std::chrono::now``). The check is prefix-based so nested stdlib
+    namespaces (``std::chrono``, ``std::filesystem``) are covered.
+    """
+    if not qualifier:
+        return False
+    normalized = qualifier if qualifier.endswith("::") else qualifier + "::"
+    return any(normalized.startswith(prefix) for prefix in STDLIB_NAMESPACE_PREFIXES)
+
+
+__all__ = [
+    "EXTERNAL_METHODS_CPP",
+    "STDLIB_METHODS_CPP",
+    "STDLIB_NAMESPACE_PREFIXES",
+    "is_stdlib_qualifier",
+]

--- a/tree_sitter_analyzer/synapse_resolver/languages/cpp.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/cpp.py
@@ -1,0 +1,210 @@
+"""C++ resolver registration (RFC-0010 first wave).
+
+Self-contained, conservative, SAFE per-language callee resolver for C++
+(``.cpp`` / ``.cc`` / ``.h`` / ``.hpp``). It REPLACES the Python cascade for
+C++ callers, so it must not regress: when unsure it returns ``unknown``.
+
+Resolution order (mirrors the spirit of the Java cascade, far more cautious):
+
+1. **stdlib qualifier** — a call qualified by a standard-library namespace
+   (``std::sort``, ``std::make_unique``, ``std::chrono::now``) is ``stdlib``.
+   ``std::`` is the canonical, near-unspoofable signal — user code never owns
+   ``namespace std``.
+2. **local** — no receiver / qualifier (a free function or implicit-``this``
+   member call) whose simple name is defined in the caller's OWN file.
+3. **project (single-global)** — exactly one same-language project-wide
+   definition of an unqualified name. The single-definition gate avoids the
+   ambiguity that wrecks method-name precision.
+4. **stdlib / external method tiers** — consulted only when the project owns
+   no compatible-language method of that name. **Both tiers are empty for the
+   first PR** (see ``_cpp_constants``): C++ bare method names collide too
+   heavily with user code to classify safely.
+5. **unknown** — everything else (instance-receiver calls, qualified calls
+   into non-stdlib namespaces, ambiguous names).
+
+THE MOAT: a C++ callee is NEVER bound to a symbol in an incompatible-language
+file. ``languages_compatible('cpp', owner_lang)`` gates every project binding,
+so a Python / Java / Go symbol that merely shares a name resolves to
+``unknown`` (or a same-language def), never the foreign file. C++ MAY resolve
+``c`` headers (directional family compat), which is the one legitimate
+cross-tag case.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from ..._language_family import languages_compatible
+from .._registry import register_language
+from ._cpp_constants import (
+    EXTERNAL_METHODS_CPP,
+    STDLIB_METHODS_CPP,
+    is_stdlib_qualifier,
+)
+
+#: Extension-derived language tags this resolver owns. ``c`` is intentionally
+#: NOT here (pure-C callers use the Python fallback / C handling); this module
+#: only drives callers whose own file is tagged ``cpp``.
+_CPP_LANGS: frozenset[str] = frozenset({"cpp"})
+
+#: Receiver tokens that denote the current object (an implicit-``this`` call),
+#: not a separate type/namespace. A call qualified only by one of these is
+#: treated as a local member call.
+_SELF_RECEIVERS: frozenset[str] = frozenset({"this", "self", "(*this)", "*this"})
+
+
+@dataclass
+class CppResolverContext:
+    """Per-index C++ resolution maps (built once per pass).
+
+    All file keys are project-relative paths, matching the ``edges`` table.
+    Only the maps the conservative cascade needs are kept; everything else is
+    deliberately omitted to stay minimal and SAFE.
+    """
+
+    # file -> [(name, kind, symbol_id), ...] (shared cross-language map).
+    file_symbols: dict[str, list[tuple[str, str, int]]] = field(default_factory=dict)
+    # simple name -> [(file, symbol_id), ...] project-wide (single-global).
+    global_name_table: dict[str, list[tuple[str, int]]] = field(default_factory=dict)
+    # file -> language tag (so every project binding is language-gated: the
+    # moat — a same-name symbol in another language must NOT be bound).
+    file_languages: dict[str, str] = field(default_factory=dict)
+
+
+def build_cpp_context(
+    *,
+    imports_by_file: dict[str, Any],
+    file_languages: dict[str, str],
+    file_symbols: dict[str, Any],
+    global_name_table: dict[str, Any],
+    file_class_methods: Any,  # lazy thunk — unused by the conservative cascade
+    **_ignored: Any,
+) -> CppResolverContext | None:
+    """Build the C++ context, or ``None`` when no C++ file is indexed.
+
+    Zero cost for non-C++ projects (gated on ``file_languages``). The lazy
+    ``file_class_methods`` thunk is deliberately NOT called — the conservative
+    cascade resolves locals from ``file_symbols`` and projects from the single
+    global table, so no class/method map is needed.
+    """
+    if not any(lang in _CPP_LANGS for lang in file_languages.values()):
+        return None
+    return CppResolverContext(
+        file_symbols=file_symbols,
+        global_name_table=global_name_table,
+        file_languages=file_languages,
+    )
+
+
+def _split_qualifier(callee_full: str, callee_name: str) -> tuple[str, str]:
+    """Return ``(qualifier, simple_name)`` from a C++ call's full name.
+
+    Splits on the C++ access operators ``::`` (scope), ``->`` (pointer), and
+    ``.`` (member) — whichever is the LAST separator wins, so the qualifier is
+    everything before the final access and the simple name is the trailing
+    identifier. ``std::chrono::now`` -> ``("std::chrono", "now")``;
+    ``obj->run`` -> ``("obj", "run")``; ``free_fn`` -> ``("", "free_fn")``.
+    """
+    full = callee_full or callee_name
+    if not full:
+        return "", callee_name
+    # Find the last access operator; ``::`` and ``->`` are two chars, ``.`` one.
+    best_idx = -1
+    best_len = 0
+    for sep in ("::", "->", "."):
+        idx = full.rfind(sep)
+        if idx > best_idx:
+            best_idx = idx
+            best_len = len(sep)
+    if best_idx < 0:
+        return "", full
+    qualifier = full[:best_idx]
+    simple = full[best_idx + best_len :]
+    return qualifier, simple or callee_name
+
+
+def _lookup_in_file(ctx: CppResolverContext, file_path: str, simple: str) -> int | None:
+    for name, kind, sym_id in ctx.file_symbols.get(file_path, []):
+        if name == simple and kind in ("function", "method", "class"):
+            return sym_id
+    return None
+
+
+def _project_owns(ctx: CppResolverContext, simple: str) -> bool:
+    """True when a COMPATIBLE-LANGUAGE project symbol of name ``simple`` exists.
+
+    The RFC-0008 ownership gate, language-aware: a same-named symbol in an
+    incompatible-language file (e.g. a Python ``sort``) must NOT count as a C++
+    owner — ``languages_compatible('cpp', 'python')`` is False — so it neither
+    suppresses a stdlib/external classification nor gets bound. An untagged
+    file is treated as a possible owner (conservative).
+    """
+    for owner_file, _sym_id in ctx.global_name_table.get(simple, []):
+        owner_lang = ctx.file_languages.get(owner_file, "")
+        if not owner_lang or languages_compatible("cpp", owner_lang):
+            return True
+    return False
+
+
+def resolve_cpp_callee(
+    callee_name: str,
+    callee_full: str,
+    caller_file: str,
+    ctx: CppResolverContext,
+) -> tuple[int | None, str, str]:
+    """Resolve one C++ call edge.
+
+    Returns ``(symbol_id, resolution, resolved_file)`` where ``resolution`` is
+    one of ``local`` / ``project`` / ``stdlib`` / ``external`` / ``unknown``.
+    """
+    qualifier, simple = _split_qualifier(callee_full, callee_name)
+
+    # 1. stdlib qualifier — ``std::...`` and friends are terminal stdlib. This
+    #    wins first: the qualifier is unambiguous evidence and never a project
+    #    binding (user code never owns ``namespace std``).
+    if is_stdlib_qualifier(qualifier):
+        return None, "stdlib", ""
+
+    # 2. local — no qualifier (free function / implicit-this member) or an
+    #    explicit self receiver, resolved in the caller's OWN file.
+    if qualifier in ("", *_SELF_RECEIVERS):
+        sym_id = _lookup_in_file(ctx, caller_file, simple)
+        if sym_id is not None:
+            return sym_id, "local", caller_file
+
+    # 3. project (single-global) — exactly one same-language project-wide
+    #    definition of an unqualified name. THE MOAT: gate every candidate by
+    #    language compatibility so a foreign-language same-name symbol is never
+    #    bound; if the sole candidate is foreign, fall through to unknown.
+    if qualifier in ("", *_SELF_RECEIVERS):
+        compatible = [
+            (target_file, sym_id)
+            for target_file, sym_id in ctx.global_name_table.get(simple, [])
+            if languages_compatible("cpp", ctx.file_languages.get(target_file, ""))
+        ]
+        if len(compatible) == 1:
+            target_file, sym_id = compatible[0]
+            return sym_id, "project", target_file
+
+    # 4. stdlib / external METHOD tiers — empty for the first PR, but wired so
+    #    a future safe set classifies only when the project owns no
+    #    compatible-language method of that name (preserves shadowing).
+    if simple in STDLIB_METHODS_CPP and not _project_owns(ctx, simple):
+        return None, "stdlib", ""
+    if simple in EXTERNAL_METHODS_CPP and not _project_owns(ctx, simple):
+        return None, "external", ""
+
+    # 5. unknown — instance-receiver calls, non-stdlib qualified calls, and
+    #    ambiguous unqualified names. ``unknown`` is correct: never a mis-wire.
+    return None, "unknown", ""
+
+
+__all__ = [
+    "CppResolverContext",
+    "build_cpp_context",
+    "resolve_cpp_callee",
+]
+
+
+register_language("cpp", build_cpp_context, resolve_cpp_callee)

--- a/tree_sitter_analyzer/synapse_resolver/languages/cpp.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/cpp.py
@@ -48,6 +48,7 @@ fixed (the fix lives in the shared walker, out of this module's scope).
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -86,6 +87,33 @@ class CppResolverContext:
     # file -> language tag (so every project binding is language-gated: the
     # moat — a same-name symbol in another language must NOT be bound).
     file_languages: dict[str, str] = field(default_factory=dict)
+    # LAZY thunk -> {file: {class_name: {method_name: symbol_id}}}. Used only to
+    # disambiguate a member call when a file declares >1 class: if a method name
+    # is owned by more than one class in the file, the resolver cannot prove
+    # which class an implicit-/explicit-this call targets, so it stays unknown
+    # (no caller-class is threaded through the resolver signature). Held as a
+    # thunk so non-C++ projects and member-free workloads pay nothing — it is
+    # materialised at most once, on the first member-call disambiguation.
+    class_methods_thunk: Callable[[], dict[str, Any]] | None = None
+    # Memoised result of ``class_methods_thunk`` (None until first use).
+    _class_methods: dict[str, Any] | None = field(default=None, repr=False)
+
+    def member_owner_class_count(self, file_path: str, method_name: str) -> int:
+        """Return how many classes in ``file_path`` define ``method_name``.
+
+        Drives the conservative member-call gate: a self-/implicit-this call may
+        bind a same-file ``method`` only when this count is exactly 1. A count of
+        0 means the owner-class map did not record it (e.g. a file-scoped symbol
+        or an unpopulated map); callers treat 0 as "no class-ambiguity evidence"
+        and fall back to the plain same-file lookup. The thunk is materialised
+        lazily and memoised, so non-member workloads never pay for it.
+        """
+        if self.class_methods_thunk is None:
+            return 0
+        if self._class_methods is None:
+            self._class_methods = self.class_methods_thunk() or {}
+        per_class = self._class_methods.get(file_path, {})
+        return sum(1 for methods in per_class.values() if method_name in methods)
 
 
 def build_cpp_context(
@@ -94,15 +122,17 @@ def build_cpp_context(
     file_languages: dict[str, str],
     file_symbols: dict[str, Any],
     global_name_table: dict[str, Any],
-    file_class_methods: Any,  # lazy thunk — unused by the conservative cascade
+    file_class_methods: Callable[[], dict[str, Any]],  # lazy thunk
     **_ignored: Any,
 ) -> CppResolverContext | None:
     """Build the C++ context, or ``None`` when no C++ file is indexed.
 
     Zero cost for non-C++ projects (gated on ``file_languages``). The lazy
-    ``file_class_methods`` thunk is deliberately NOT called — the conservative
-    cascade resolves locals from ``file_symbols`` and projects from the single
-    global table, so no class/method map is needed.
+    ``file_class_methods`` thunk is STORED but deliberately NOT called here — it
+    is materialised at most once, on the first member-call that needs owner-class
+    disambiguation (a file declaring >1 class with a colliding method name). The
+    plain local / single-global tiers never touch it, so a project with no such
+    ambiguity still pays nothing for the class/method map.
     """
     if not any(lang in _CPP_LANGS for lang in file_languages.values()):
         return None
@@ -110,6 +140,7 @@ def build_cpp_context(
         file_symbols=file_symbols,
         global_name_table=global_name_table,
         file_languages=file_languages,
+        class_methods_thunk=file_class_methods,
     )
 
 
@@ -156,9 +187,30 @@ def _lookup_in_file(
     simple: str,
     kinds: frozenset[str],
 ) -> int | None:
+    """Resolve ``simple`` to a same-file symbol of an allowed ``kind``.
+
+    OWNER-CLASS GATE (Codex PR #348 P2): when the matched symbol is a
+    ``method`` and the file declares more than one class that defines a method
+    of this name, the resolver cannot prove which class an implicit-/explicit-
+    this call targets (no caller-class is threaded through). Binding either one
+    would be a false ``local`` edge, so the ambiguous method is SKIPPED. A
+    ``function`` / ``class`` symbol is file-scoped (no owning class), so the
+    gate never applies to it. Count 0 (owner-class map silent on this name)
+    means "no ambiguity evidence" and the plain match stands — conservative
+    because a genuinely class-ambiguous method is recorded under >1 class.
+    """
+    ambiguous_method = (
+        "method" in kinds and ctx.member_owner_class_count(file_path, simple) > 1
+    )
     for name, kind, sym_id in ctx.file_symbols.get(file_path, []):
-        if name == simple and kind in kinds:
-            return sym_id
+        if name != simple or kind not in kinds:
+            continue
+        if kind == "method" and ambiguous_method:
+            # Skip the class-ambiguous method, but keep scanning: an unqualified
+            # call may still bind a file-scoped free function / class of the
+            # same name (those are not class-owned, so unaffected by the gate).
+            continue
+        return sym_id
     return None
 
 

--- a/tree_sitter_analyzer/synapse_resolver/languages/cpp.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/cpp.py
@@ -28,6 +28,22 @@ so a Python / Java / Go symbol that merely shares a name resolves to
 ``unknown`` (or a same-language def), never the foreign file. C++ MAY resolve
 ``c`` headers (directional family compat), which is the one legitimate
 cross-tag case.
+
+KNOWN UPSTREAM DEPENDENCY (Codex PR #348 P2): the ``local`` and single-global
+``project`` tiers read ``file_symbols`` / ``global_name_table``, which are
+populated from the ``ast_symbol_rows`` table by the *shared* generic symbol
+walker (``_ast_extraction._walk_for_symbols``). That walker records a
+function-like node only when it exposes ``child_by_field_name('name')`` — but a
+tree-sitter C++ ``function_definition`` exposes its identifier under
+``function_declarator`` instead, so ordinary C++ free functions / methods are
+currently ABSENT from those maps. Until the shared extractor recovers C++
+symbols, the local / single-global tiers stay dormant on a real index and such
+calls fall through to ``unknown`` (SAFE — never a mis-wire). The
+maps-independent stdlib-qualifier tier and THE MOAT hold regardless; both are
+covered by ``TestRealIndexIntegration`` in
+``tests/unit/test_cpp_method_resolution.py``, and the dormant local tier has a
+``strict`` xfail there that flips to a hard PASS the moment the extractor is
+fixed (the fix lives in the shared walker, out of this module's scope).
 """
 
 from __future__ import annotations

--- a/tree_sitter_analyzer/synapse_resolver/languages/cpp.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/cpp.py
@@ -124,9 +124,24 @@ def _split_qualifier(callee_full: str, callee_name: str) -> tuple[str, str]:
     return qualifier, simple or callee_name
 
 
-def _lookup_in_file(ctx: CppResolverContext, file_path: str, simple: str) -> int | None:
+#: Symbol kinds a bare (no-receiver) call may bind to in its own file: a free
+#: function, a member method, or a class (constructor-style call).
+_LOCAL_KINDS: frozenset[str] = frozenset({"function", "method", "class"})
+#: Symbol kinds an explicit-self (``this->`` / ``self``) call may bind to. The
+#: receiver PROVES the target is a member, so only ``method`` qualifies — a
+#: same-file free function or class is NOT a valid member-call target, and
+#: binding one would be a false ``local`` edge.
+_MEMBER_KINDS: frozenset[str] = frozenset({"method"})
+
+
+def _lookup_in_file(
+    ctx: CppResolverContext,
+    file_path: str,
+    simple: str,
+    kinds: frozenset[str],
+) -> int | None:
     for name, kind, sym_id in ctx.file_symbols.get(file_path, []):
-        if name == simple and kind in ("function", "method", "class"):
+        if name == simple and kind in kinds:
             return sym_id
     return None
 
@@ -159,6 +174,8 @@ def resolve_cpp_callee(
     one of ``local`` / ``project`` / ``stdlib`` / ``external`` / ``unknown``.
     """
     qualifier, simple = _split_qualifier(callee_full, callee_name)
+    is_unqualified = qualifier == ""
+    is_self_receiver = qualifier in _SELF_RECEIVERS
 
     # 1. stdlib qualifier — ``std::...`` and friends are terminal stdlib. This
     #    wins first: the qualifier is unambiguous evidence and never a project
@@ -166,18 +183,25 @@ def resolve_cpp_callee(
     if is_stdlib_qualifier(qualifier):
         return None, "stdlib", ""
 
-    # 2. local — no qualifier (free function / implicit-this member) or an
-    #    explicit self receiver, resolved in the caller's OWN file.
-    if qualifier in ("", *_SELF_RECEIVERS):
-        sym_id = _lookup_in_file(ctx, caller_file, simple)
+    # 2. local — resolved in the caller's OWN file. An UNQUALIFIED call may bind
+    #    any local symbol (free function / member / class). An explicit SELF
+    #    receiver (``this->`` / ``self``) asserts the target is a member, so it
+    #    may bind ONLY a same-file ``method`` — never a free function or class.
+    #    If it cannot prove a member target it must NOT fall through to a free
+    #    function; an ``unknown`` edge is correct, a false ``local`` is not.
+    if is_unqualified or is_self_receiver:
+        kinds = _LOCAL_KINDS if is_unqualified else _MEMBER_KINDS
+        sym_id = _lookup_in_file(ctx, caller_file, simple, kinds)
         if sym_id is not None:
             return sym_id, "local", caller_file
 
     # 3. project (single-global) — exactly one same-language project-wide
-    #    definition of an unqualified name. THE MOAT: gate every candidate by
+    #    definition of an UNQUALIFIED name. THE MOAT: gate every candidate by
     #    language compatibility so a foreign-language same-name symbol is never
     #    bound; if the sole candidate is foreign, fall through to unknown.
-    if qualifier in ("", *_SELF_RECEIVERS):
+    #    An explicit SELF receiver is EXCLUDED here: a ``this->`` member call can
+    #    never reach a cross-file global, so binding one would be a false edge.
+    if is_unqualified:
         compatible = [
             (target_file, sym_id)
             for target_file, sym_id in ctx.global_name_table.get(simple, [])


### PR DESCRIPTION
## Summary

RFC-0010 first-wave language: a self-contained, **SAFE** per-language callee resolver for **C++** (`.cpp`/`.cc`/`.h`/`.hpp`). **NEW-FILES-ONLY** — zero edits to any shared file; the `languages/` package auto-discovers and registers it.

New files:
- `tree_sitter_analyzer/synapse_resolver/languages/cpp.py` — `build_cpp_context` + `resolve_cpp_callee`, ending in `register_language("cpp", ...)`.
- `tree_sitter_analyzer/synapse_resolver/languages/_cpp_constants.py` — conservative stdlib namespace prefixes; empty bare-method tiers.
- `tests/unit/test_cpp_method_resolution.py` — 20 RED-first tests.

## Cascade (precision over recall)

1. **stdlib qualifier** — `std::` / `__gnu_cxx::` / `__cxx11::` qualified calls (`std::sort`, `std::make_unique`, `std::chrono::now`) → `stdlib`. `std::` is the near-unspoofable stdlib signal — user code never owns `namespace std`.
2. **local** — unqualified / `this->` calls resolved in the caller's own file.
3. **project** — exactly one **same-language** project-wide definition (single-global).
4. **stdlib/external METHOD tiers** — **intentionally EMPTY** for this first PR. C++ bare method names (`push_back`/`size`/`begin`/`move`/...) collide too heavily with user containers/wrappers to classify safely. An `unknown` edge is correct; a mis-classified one is a moat breach (the RFC-0008 lesson, mandated by RFC-0010).
5. **unknown** — everything else (instance-receiver calls, non-stdlib qualified calls, ambiguous names).

## The moat — never cross-language bind

Every project binding is gated by `languages_compatible('cpp', owner_lang)`, so a same-name symbol in a Python/Java/Go file is **never** bound. The one legitimate cross-tag case (`cpp → c` header, per `_DIRECTED_C_COMPAT`) resolves; the reverse does not. Covered by the **mandatory no-cross-language-mis-wire test** (`only_python` symbol → `unknown`, never the `.py` file; ambiguous `parse` → the C++ def, never the Python one).

## Verification

- RED-first: confirmed tests fail behaviorally when the resolver is stubbed to always-`unknown` (10 behavioral failures), then green with the real impl.
- `ruff check` + `ruff format --check` + `mypy` clean on all 3 new files.
- 20 new tests green; full `tests/unit/synapse_resolver/` + `test_resolver_registry.py` green (no regression). The registry discovery test auto-covers the new module.
- `git show --stat HEAD` confirms NEW-FILES-ONLY (3 files, +613, 0 edits to shared files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)