### PR TITLE
feat(resolver): SAFE Rust per-language callee resolver (RFC-0010)

### DIFF
--- a/tests/unit/test_rust_method_resolution.py
+++ b/tests/unit/test_rust_method_resolution.py
@@ -192,6 +192,69 @@ def test_bare_free_fn_unaffected_by_method_duplicate() -> None:
     assert sym_id == 30
 
 
+def test_self_method_does_not_bind_to_free_function() -> None:
+    """Codex P2 (#2): a receiver-qualified call ``self.helper()`` must NOT bind to a
+    top-level FREE FUNCTION named ``helper``.
+
+    In Rust's symbol rows, both impl methods and top-level free functions are
+    extracted from ``function_item`` nodes; a free fn lands as ``kind='function'``
+    while an impl/trait method lands as ``kind='method'`` (because
+    ``_find_parent_class`` finds the enclosing ``impl_item``). A ``self.`` /
+    ``Self::`` receiver can only mean an impl/trait method, never a free function,
+    so counting ``function`` rows as candidate methods would corrupt the call edge
+    for valid code where the receiver method simply is not the free fn. The
+    conservative answer is ``unknown``."""
+    ctx = _ctx(
+        file_symbols={"lib.rs": [("helper", "function", 7)]},  # a FREE fn only
+        file_languages={"lib.rs": "rust"},
+    )
+    sym_id, resolution, resolved_file = resolve_rust_callee(
+        "helper", "self.helper", "lib.rs", ctx
+    )
+    assert resolution == "unknown", (
+        "self.helper() must not bind to a top-level free fn named helper; "
+        f"got {resolution} -> sym_id={sym_id}"
+    )
+    assert sym_id is None
+    assert resolved_file == ""
+
+
+def test_selfcap_assoc_does_not_bind_to_free_function() -> None:
+    """The ``Self::helper()`` form has the same hazard: a same-file FREE function
+    named ``helper`` (``kind='function'``) is not a candidate for a receiver-
+    qualified associated call and must stay ``unknown``."""
+    ctx = _ctx(
+        file_symbols={"lib.rs": [("helper", "function", 9)]},
+        file_languages={"lib.rs": "rust"},
+    )
+    sym_id, resolution, _ = resolve_rust_callee("helper", "Self::helper", "lib.rs", ctx)
+    assert resolution == "unknown"
+    assert sym_id is None
+
+
+def test_self_method_binds_method_even_when_free_fn_shares_name() -> None:
+    """When BOTH a free fn ``helper`` and exactly one impl METHOD ``helper`` exist in
+    the file, ``self.helper()`` binds to the METHOD row (the free fn is ignored).
+
+    The method name is unique among ``method`` rows (one impl), so this is an
+    unambiguous, safe bind — and it must pick the method, never the free fn."""
+    ctx = _ctx(
+        file_symbols={
+            "lib.rs": [
+                ("helper", "function", 40),  # free fn — must be ignored
+                ("helper", "method", 41),  # the one impl method — the right target
+            ]
+        },
+        file_languages={"lib.rs": "rust"},
+    )
+    sym_id, resolution, resolved_file = resolve_rust_callee(
+        "helper", "self.helper", "lib.rs", ctx
+    )
+    assert resolution == "local"
+    assert sym_id == 41, "must bind the method row, not the free fn row"
+    assert resolved_file == "lib.rs"
+
+
 def test_unknown_local_name_stays_unknown() -> None:
     """A bare name with no same-file definition and no std signature -> unknown."""
     ctx = _ctx(

--- a/tests/unit/test_rust_method_resolution.py
+++ b/tests/unit/test_rust_method_resolution.py
@@ -107,6 +107,91 @@ def test_self_method_resolves_local() -> None:
     assert resolved_file == "lib.rs"
 
 
+def test_self_method_resolves_local_when_method_name_unique() -> None:
+    """``self.helper()`` resolves local only when exactly ONE method named
+    ``helper`` is defined in the file — a single impl, so no owner ambiguity."""
+    ctx = _ctx(
+        file_symbols={
+            "lib.rs": [
+                ("call", "method", 10),
+                ("helper", "method", 11),
+            ]
+        },
+        file_languages={"lib.rs": "rust"},
+    )
+    sym_id, resolution, resolved_file = resolve_rust_callee(
+        "helper", "self.helper", "lib.rs", ctx
+    )
+    assert resolution == "local"
+    assert sym_id == 11
+    assert resolved_file == "lib.rs"
+
+
+def test_self_method_ambiguous_across_impls_stays_unknown() -> None:
+    """Codex P2: ``self.helper()`` must NOT bind when the SAME file defines
+    ``helper`` in two different impl blocks (``impl A`` and ``impl B``).
+
+    The resolver receives no caller-owner type, so it cannot tell which
+    ``helper`` the ``self`` refers to. Binding to whichever row appears first
+    would corrupt the call edge — the exact mis-bind Codex flagged. The
+    conservative answer is ``unknown`` (precision over recall)."""
+    ctx = _ctx(
+        file_symbols={
+            "lib.rs": [
+                ("helper", "method", 11),  # impl A { fn helper }
+                ("call", "method", 12),  # impl B { fn call -> self.helper() }
+                ("helper", "method", 13),  # impl B { fn helper }
+            ]
+        },
+        file_languages={"lib.rs": "rust"},
+    )
+    sym_id, resolution, resolved_file = resolve_rust_callee(
+        "helper", "self.helper", "lib.rs", ctx
+    )
+    assert resolution == "unknown", (
+        "an ambiguous self.method across multiple impls must NOT bind to the "
+        f"first row; got {resolution} -> sym_id={sym_id}"
+    )
+    assert sym_id is None
+    assert resolved_file == ""
+
+
+def test_selfcap_method_ambiguous_across_impls_stays_unknown() -> None:
+    """The ``Self::helper()`` associated-call form has the same ambiguity hazard
+    as ``self.helper()`` and must also stay ``unknown`` when duplicated."""
+    ctx = _ctx(
+        file_symbols={
+            "lib.rs": [
+                ("helper", "method", 21),
+                ("helper", "method", 22),
+            ]
+        },
+        file_languages={"lib.rs": "rust"},
+    )
+    sym_id, resolution, _ = resolve_rust_callee("helper", "Self::helper", "lib.rs", ctx)
+    assert resolution == "unknown"
+    assert sym_id is None
+
+
+def test_bare_free_fn_unaffected_by_method_duplicate() -> None:
+    """A bare free-function call still resolves local even if an unrelated
+    duplicate METHOD name exists — the ambiguity guard targets receiver-qualified
+    (self/Self) calls, and a Rust module cannot define two free fns of one name."""
+    ctx = _ctx(
+        file_symbols={
+            "lib.rs": [
+                ("run", "function", 30),  # the unique free fn we call
+                ("helper", "method", 31),  # duplicate method name, irrelevant
+                ("helper", "method", 32),
+            ]
+        },
+        file_languages={"lib.rs": "rust"},
+    )
+    sym_id, resolution, _ = resolve_rust_callee("run", "run", "lib.rs", ctx)
+    assert resolution == "local"
+    assert sym_id == 30
+
+
 def test_unknown_local_name_stays_unknown() -> None:
     """A bare name with no same-file definition and no std signature -> unknown."""
     ctx = _ctx(

--- a/tests/unit/test_rust_method_resolution.py
+++ b/tests/unit/test_rust_method_resolution.py
@@ -1,0 +1,290 @@
+"""RFC-0010 Rust resolver — SAFE, self-contained per-language callee resolution.
+
+Rust call-edge extraction is not yet wired into ``function_extraction.py`` (only
+python / js / ts / java / go / c / cpp appear in ``_CALL_NODE_TYPES``), so a real
+``index_project`` run produces zero Rust ``calls`` edges and the resolver is never
+invoked end-to-end. These tests therefore drive the resolver's CONTRACT SURFACE
+directly: build the context from synthetic ``file_symbols`` / ``global_name_table``
+/ ``file_languages`` maps (exactly the shapes ``_build_resolver_context_uncached``
+passes) and call ``resolve_rust_callee`` — the same function the registry dispatch
+in ``synapse_resolver/__init__.py`` calls.
+
+The resolver is deliberately CONSERVATIVE (RFC-0008 lesson): it resolves
+same-file / same-language local calls, classifies a tiny set of distinctively-std
+associated-function paths (``Vec::new`` / ``Box::new`` / ``std::``-pathed calls),
+and returns ``unknown`` for everything else. An empty tier is correct — a
+mis-classification is the failure this machinery exists to prevent.
+"""
+
+from __future__ import annotations
+
+from tree_sitter_analyzer.synapse_resolver.languages.rust import (
+    build_rust_resolver_context,
+    resolve_rust_callee,
+)
+
+
+def _thunk(value: dict[str, dict[str, dict[str, int]]] | None = None):
+    """A zero-arg lazy file_class_methods thunk (the registry passes a callable)."""
+
+    def _inner() -> dict[str, dict[str, dict[str, int]]]:
+        return value or {}
+
+    return _inner
+
+
+def _ctx(
+    *,
+    file_symbols: dict[str, list[tuple[str, str, int]]],
+    file_languages: dict[str, str],
+    global_name_table: dict[str, list[tuple[str, int]]] | None = None,
+):
+    """Build a Rust resolver context the way the registry would."""
+    if global_name_table is None:
+        global_name_table = {}
+        for fp, syms in file_symbols.items():
+            for name, _kind, sid in syms:
+                global_name_table.setdefault(name, []).append((fp, sid))
+    return build_rust_resolver_context(
+        imports_by_file={},
+        file_languages=file_languages,
+        file_symbols=file_symbols,
+        global_name_table=global_name_table,
+        file_class_methods=_thunk(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# opt-out: no Rust file indexed -> None (zero cost)
+# ---------------------------------------------------------------------------
+def test_build_context_returns_none_when_no_rust_file() -> None:
+    ctx = build_rust_resolver_context(
+        imports_by_file={},
+        file_languages={"app.py": "python", "Service.java": "java"},
+        file_symbols={},
+        global_name_table={},
+        file_class_methods=_thunk(),
+    )
+    assert ctx is None, "no Rust file -> opt out so non-Rust projects pay nothing"
+
+
+def test_build_context_built_when_rust_file_present() -> None:
+    ctx = _ctx(
+        file_symbols={"lib.rs": [("helper", "function", 1)]},
+        file_languages={"lib.rs": "rust"},
+    )
+    assert ctx is not None
+
+
+# ---------------------------------------------------------------------------
+# (a) local same-file / same-language resolution
+# ---------------------------------------------------------------------------
+def test_local_free_function_resolves_local() -> None:
+    """A bare call to a free function defined in the same file -> local."""
+    ctx = _ctx(
+        file_symbols={"lib.rs": [("helper_fn", "function", 7)]},
+        file_languages={"lib.rs": "rust"},
+    )
+    sym_id, resolution, resolved_file = resolve_rust_callee(
+        "helper_fn", "helper_fn", "lib.rs", ctx
+    )
+    assert resolution == "local"
+    assert sym_id == 7
+    assert resolved_file == "lib.rs"
+
+
+def test_self_method_resolves_local() -> None:
+    """``self.helper()`` -> the same-file ``helper`` method (local)."""
+    ctx = _ctx(
+        file_symbols={"lib.rs": [("helper", "method", 11)]},
+        file_languages={"lib.rs": "rust"},
+    )
+    sym_id, resolution, resolved_file = resolve_rust_callee(
+        "helper", "self.helper", "lib.rs", ctx
+    )
+    assert resolution == "local"
+    assert sym_id == 11
+    assert resolved_file == "lib.rs"
+
+
+def test_unknown_local_name_stays_unknown() -> None:
+    """A bare name with no same-file definition and no std signature -> unknown."""
+    ctx = _ctx(
+        file_symbols={"lib.rs": [("helper", "function", 1)]},
+        file_languages={"lib.rs": "rust"},
+    )
+    _sym_id, resolution, _ = resolve_rust_callee("mystery", "mystery", "lib.rs", ctx)
+    assert resolution == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# (b) conservative std tiers
+# ---------------------------------------------------------------------------
+def test_std_path_call_classifies_stdlib() -> None:
+    """A ``std::``-pathed associated call (``std::mem::swap``) -> stdlib."""
+    ctx = _ctx(
+        file_symbols={"lib.rs": [("caller", "function", 1)]},
+        file_languages={"lib.rs": "rust"},
+    )
+    _sym_id, resolution, _ = resolve_rust_callee(
+        "swap", "std::mem::swap", "lib.rs", ctx
+    )
+    assert resolution == "stdlib", f"std::mem::swap must be stdlib; got {resolution}"
+
+
+def test_core_path_call_classifies_stdlib() -> None:
+    """``core::`` and ``alloc::`` paths are equally part of the std distribution."""
+    ctx = _ctx(
+        file_symbols={"lib.rs": [("caller", "function", 1)]},
+        file_languages={"lib.rs": "rust"},
+    )
+    _sym_id, resolution, _ = resolve_rust_callee(
+        "from", "core::convert::From::from", "lib.rs", ctx
+    )
+    assert resolution == "stdlib"
+
+
+def test_vec_new_associated_fn_classifies_stdlib() -> None:
+    """``Vec::new`` is a distinctively-std associated function -> stdlib."""
+    ctx = _ctx(
+        file_symbols={"lib.rs": [("caller", "function", 1)]},
+        file_languages={"lib.rs": "rust"},
+    )
+    _sym_id, resolution, _ = resolve_rust_callee("new", "Vec::new", "lib.rs", ctx)
+    assert resolution == "stdlib", f"Vec::new must be stdlib; got {resolution}"
+
+
+def test_box_new_associated_fn_classifies_stdlib() -> None:
+    ctx = _ctx(
+        file_symbols={"lib.rs": [("caller", "function", 1)]},
+        file_languages={"lib.rs": "rust"},
+    )
+    _sym_id, resolution, _ = resolve_rust_callee("new", "Box::new", "lib.rs", ctx)
+    assert resolution == "stdlib"
+
+
+def test_bare_new_stays_unknown() -> None:
+    """A bare ``new`` with no std path (could be any project type) -> unknown.
+
+    ``new`` is the single most common associated-fn name in all Rust code; a bare
+    receiver-less ``new`` carries no std evidence, so the conservative tier must
+    NOT claim it (RFC-0008 precision lesson: an empty/strict tier beats a false
+    positive)."""
+    ctx = _ctx(
+        file_symbols={"lib.rs": [("caller", "function", 1)]},
+        file_languages={"lib.rs": "rust"},
+    )
+    _sym_id, resolution, _ = resolve_rust_callee("new", "new", "lib.rs", ctx)
+    assert resolution == "unknown", f"bare new must stay unknown; got {resolution}"
+
+
+def test_unknown_user_type_associated_fn_stays_unknown() -> None:
+    """``MyType::build`` (a project type's associated fn) -> unknown, never stdlib."""
+    ctx = _ctx(
+        file_symbols={"lib.rs": [("caller", "function", 1)]},
+        file_languages={"lib.rs": "rust"},
+    )
+    _sym_id, resolution, _ = resolve_rust_callee(
+        "build", "MyType::build", "lib.rs", ctx
+    )
+    assert resolution == "unknown"
+
+
+def test_project_def_shadows_std_associated_fn() -> None:
+    """If the project defines ``new`` and the call is ``Vec::new`` BUT a same-file
+    ``Vec`` impl exists locally... we still classify by std path only when the
+    project does NOT own the name. A project-owned bare name resolves local first.
+
+    Here a project-defined free fn named ``swap`` must shadow the std tier: a bare
+    same-file ``swap()`` resolves local, never stdlib."""
+    ctx = _ctx(
+        file_symbols={"lib.rs": [("swap", "function", 3)]},
+        file_languages={"lib.rs": "rust"},
+    )
+    sym_id, resolution, _ = resolve_rust_callee("swap", "swap", "lib.rs", ctx)
+    assert resolution == "local"
+    assert sym_id == 3
+
+
+# ---------------------------------------------------------------------------
+# (THE MOAT) no cross-language mis-wire — MANDATORY
+# ---------------------------------------------------------------------------
+def test_no_cross_language_mis_wire_to_other_language_symbol() -> None:
+    """CRITICAL: a Rust callee whose bare name also exists as a symbol in a
+    DIFFERENT language's file must NEVER bind to that other-language file.
+
+    ``helper`` is defined in BOTH a Python file and a Rust file. A Rust caller in
+    ``other.rs`` (which does NOT define ``helper``) must resolve to ``unknown`` —
+    it must not be wired to the Python ``helper`` symbol. This is the exact
+    CodeGraph cross-language false-bind that this resolver exists to beat."""
+    file_symbols = {
+        "app.py": [("helper", "function", 100)],
+        "lib.rs": [("helper", "function", 200)],
+        "other.rs": [("caller", "function", 300)],
+    }
+    ctx = _ctx(
+        file_symbols=file_symbols,
+        file_languages={"app.py": "python", "lib.rs": "rust", "other.rs": "rust"},
+    )
+    sym_id, resolution, resolved_file = resolve_rust_callee(
+        "helper", "helper", "other.rs", ctx
+    )
+    # Must NOT bind to the Python file under any circumstance.
+    assert resolved_file != "app.py", (
+        "Rust caller must never bind to a Python symbol (the moat); "
+        f"got resolved_file={resolved_file!r}"
+    )
+    assert sym_id != 100
+    # ``helper`` is defined in two Rust files (lib.rs + ambiguous) — but the caller
+    # is in other.rs which defines no helper, so a conservative same-file-only
+    # resolver returns unknown rather than guessing a different Rust file.
+    assert resolution == "unknown"
+
+
+def test_cross_language_bare_name_collision_python_only_owner() -> None:
+    """A bare Rust call whose name exists ONLY in a Python file -> unknown, never
+    bound to the Python file (single global candidate in the wrong language)."""
+    file_symbols = {
+        "app.py": [("compute", "function", 100)],
+        "lib.rs": [("caller", "function", 200)],
+    }
+    ctx = _ctx(
+        file_symbols=file_symbols,
+        file_languages={"app.py": "python", "lib.rs": "rust"},
+    )
+    sym_id, resolution, resolved_file = resolve_rust_callee(
+        "compute", "compute", "lib.rs", ctx
+    )
+    assert resolved_file != "app.py"
+    assert sym_id != 100
+    assert resolution == "unknown"
+
+
+def test_std_name_collision_with_python_symbol_still_stdlib() -> None:
+    """A Rust ``std::mem::swap`` must classify stdlib even though a Python file
+    defines a ``swap`` symbol — the Python symbol is invisible to the Rust caller
+    (``languages_compatible`` is False), so it does not suppress the std tier."""
+    file_symbols = {
+        "swapper.py": [("swap", "function", 100)],
+        "lib.rs": [("caller", "function", 200)],
+    }
+    ctx = _ctx(
+        file_symbols=file_symbols,
+        file_languages={"swapper.py": "python", "lib.rs": "rust"},
+    )
+    _sym_id, resolution, resolved_file = resolve_rust_callee(
+        "swap", "std::mem::swap", "lib.rs", ctx
+    )
+    assert resolution == "stdlib"
+    assert resolved_file != "swapper.py"
+
+
+# ---------------------------------------------------------------------------
+# registration wiring
+# ---------------------------------------------------------------------------
+def test_rust_is_registered() -> None:
+    """Importing the languages package registers 'rust' in the registry."""
+    import tree_sitter_analyzer.synapse_resolver.languages as _languages  # noqa: F401
+    from tree_sitter_analyzer.synapse_resolver._registry import registered_languages
+
+    assert "rust" in registered_languages()

--- a/tree_sitter_analyzer/synapse_resolver/_rust_constants.py
+++ b/tree_sitter_analyzer/synapse_resolver/_rust_constants.py
@@ -1,0 +1,94 @@
+"""Rust std-library path prefixes and distinctively-std associated functions.
+
+A Rust call whose ``callee_full`` carries a ``std::`` / ``core::`` / ``alloc::``
+path, or whose receiver is one of a very small set of ``final``-style std types
+whose associated fn is near-exclusively the std API, is tagged ``stdlib`` — a
+*terminal* resolution that keeps it out of the backfill re-scan set.
+
+CURATION RULE — PRECISION over recall (the RFC-0008 Java lesson).
+The Rust resolver carries no trait/type inference at this tier, so a bare
+associated-fn name (``new``/``from``/``with_capacity``) cannot be told apart from
+a project type's identically-named associated fn. Therefore:
+
+* A ``std::``/``core::``/``alloc::``-PATHED call is unambiguous std → kept.
+* A ``Type::fn`` associated call is kept ONLY when ``Type`` is a concrete std
+  container/smart-pointer whose name a project type essentially never reuses
+  (``Vec``/``Box``/``Rc``/``Arc``/``HashMap``/...), AND ``fn`` is a constructor-
+  family name. ``Option``/``Result`` method names (``unwrap``/``map``/``and_then``)
+  are DELIBERATELY EXCLUDED: they are receiver-style instance methods that domain
+  ``Result``-like / monadic types and crates (``anyhow``, ``thiserror`` wrappers)
+  routinely define, and without receiver-type evidence they would be mislabelled.
+* Everything else stays ``unknown``. An empty/strict tier beats a false positive.
+
+Kept in a dedicated module so the literal sets stay out of the resolver logic and
+the file-size rule is honoured.
+"""
+
+from __future__ import annotations
+
+# Path prefixes that are part of the Rust standard distribution. Any
+# fully-pathed call (``std::mem::swap``, ``core::convert::From::from``,
+# ``alloc::vec::Vec::new``) is std-provided, not project code.
+STD_PATH_PREFIXES: frozenset[str] = frozenset(
+    {
+        "std::",
+        "core::",
+        "alloc::",
+    }
+)
+
+# Concrete std container / smart-pointer TYPES whose names a project type
+# essentially never reuses. A ``Type::fn`` associated call where ``Type`` is one
+# of these AND ``fn`` is a constructor-family name (below) classifies stdlib.
+# These are all concrete structs (not traits), so a domain type cannot *be* one.
+_STD_ASSOC_TYPES: frozenset[str] = frozenset(
+    {
+        "Vec",
+        "Box",
+        "Rc",
+        "Arc",
+        "VecDeque",
+        "BinaryHeap",
+        "LinkedList",
+        "HashMap",
+        "BTreeMap",
+        "HashSet",
+        "BTreeSet",
+    }
+)
+
+# Constructor-family associated-fn names. Combined with a std container receiver
+# (above) these are distinctively the std API. ``new``/``with_capacity`` are the
+# canonical container constructors; bare (receiver-less) occurrences of these
+# names are NOT classified — only the ``StdType::name`` qualified form is.
+_STD_ASSOC_FNS: frozenset[str] = frozenset(
+    {
+        "new",
+        "with_capacity",
+        "from_iter",
+        "default",
+    }
+)
+
+
+def is_std_path(callee_full: str) -> bool:
+    """True when ``callee_full`` begins with a std distribution path prefix."""
+    return any(callee_full.startswith(prefix) for prefix in STD_PATH_PREFIXES)
+
+
+def is_std_assoc_call(receiver: str, simple: str) -> bool:
+    """True for a ``StdContainer::ctor`` associated call (``Vec::new``).
+
+    ``receiver`` is the segment before the final ``::`` (already stripped of any
+    leading path), ``simple`` the associated-fn name. Only the curated
+    std-container × constructor-family combination matches; everything else is
+    left to the resolver's ``unknown`` fall-through.
+    """
+    return receiver in _STD_ASSOC_TYPES and simple in _STD_ASSOC_FNS
+
+
+__all__ = [
+    "STD_PATH_PREFIXES",
+    "is_std_assoc_call",
+    "is_std_path",
+]

--- a/tree_sitter_analyzer/synapse_resolver/languages/rust.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/rust.py
@@ -116,27 +116,33 @@ def _lookup_in_file(
 def _lookup_unique_method_in_file(
     ctx: RustResolverContext, file_path: str, simple: str
 ) -> int | None:
-    """Return the symbol id of a same-file ``simple`` def, but ONLY when exactly one
-    method/function of that name exists in the file; otherwise ``None``.
+    """Return the symbol id of a same-file ``simple`` METHOD def, but ONLY when
+    exactly one ``method`` row of that name exists in the file; otherwise ``None``.
 
-    Codex P2 (owner-context safety): a ``self.helper()`` / ``Self::helper()`` call
-    carries no caller-owner type, so the resolver cannot tell which impl block's
+    Codex P2 (#1 — owner-context safety): a ``self.helper()`` / ``Self::helper()``
+    call carries no caller-owner type, so the resolver cannot tell which impl block's
     ``helper`` the receiver refers to. When two impls in the same file both define
     ``helper`` (``impl A { fn helper }`` + ``impl B { fn helper }``), binding to
     whichever row appears first would corrupt the call edge. The conservative answer
     for an ambiguous receiver-qualified method is therefore ``unknown``.
 
-    Both ``method`` and ``function`` rows are counted: an associated fn called via
-    ``Self::ctor()`` can be extracted under either kind, and either one duplicated
-    across impls is ambiguous. This guard runs ONLY on the receiver-qualified
-    (``self``/``Self``/``this``/``super``) path; a bare free-function call keeps
-    ``_lookup_in_file`` (a Rust module cannot define two free fns of one name, so a
-    bare match is never ambiguous and stays unaffected).
+    Codex P2 (#2 — don't bind receiver calls to free functions): ONLY ``method``
+    rows are candidates here, never ``function`` rows. A ``self.``/``Self::``/
+    ``this``/``super`` receiver can only name an impl/trait method; a top-level free
+    ``fn helper()`` is irrelevant to it. In Rust's symbol rows a free function is
+    ``kind='function'`` while an impl/trait method is ``kind='method'`` (the
+    extractor's ``_find_parent_class`` finds the enclosing ``impl_item``/``trait_item``
+    for the latter). Counting ``function`` rows would let a receiver-qualified call
+    mis-bind to an unrelated free function, the exact corruption Codex flagged.
+
+    This guard runs ONLY on the receiver-qualified path; a bare free-function call
+    keeps ``_lookup_in_file`` (a Rust module cannot define two free fns of one name,
+    so a bare match is never ambiguous and stays unaffected).
     """
     matches = [
         sym_id
         for name, kind, sym_id in ctx.file_symbols.get(file_path, [])
-        if name == simple and kind in ("function", "method")
+        if name == simple and kind == "method"
     ]
     return matches[0] if len(matches) == 1 else None
 
@@ -189,10 +195,12 @@ def resolve_rust_callee(
 
     # 1b. local (receiver-qualified) — ``self.helper`` / ``Self::helper`` /
     #     ``this`` / ``super``. The caller-owner type is NOT available to this
-    #     resolver, so we can only safely bind when the method name is UNIQUE in the
-    #     file. If two impls in the same file both define ``helper``, the receiver is
-    #     ambiguous and we leave it ``unknown`` rather than mis-bind to the first row
-    #     (Codex P2). Resolution stays in the caller's OWN file only → the moat holds.
+    #     resolver, so we only bind to a same-file ``method`` row (never a free
+    #     ``function`` row — Codex P2 #2) AND only when that method name is UNIQUE in
+    #     the file (Codex P2 #1). If two impls both define ``helper`` the receiver is
+    #     ambiguous → ``unknown``; if only a free fn ``helper`` exists the receiver
+    #     can't mean it → ``unknown``. Resolution stays in the caller's OWN file only
+    #     → the moat holds.
     elif receiver in ("self", "Self", "this", "super"):
         sym_id = _lookup_unique_method_in_file(ctx, caller_file, simple)
         if sym_id is not None:

--- a/tree_sitter_analyzer/synapse_resolver/languages/rust.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/rust.py
@@ -1,0 +1,188 @@
+"""Rust resolver registration (RFC-0010).
+
+A SAFE, self-contained per-language callee resolver for Rust. It:
+
+* resolves SAME-FILE / SAME-LANGUAGE local calls from ``file_symbols``
+  (bare free-fn calls and ``self.method`` / ``Self::method`` calls), and
+* classifies a tiny, CONSERVATIVE std tier — ``std::``/``core::``/``alloc::``-
+  pathed calls and a curated ``StdContainer::ctor`` set (``Vec::new``,
+  ``Box::new``, …) — as ``stdlib``, and
+* returns ``unknown`` for everything else.
+
+THE MOAT (the #1 correctness requirement): this resolver NEVER binds a Rust
+callee to a symbol in a different language's file. Local resolution only ever
+consults the caller's OWN file; the single-global step is intentionally NOT
+implemented because a same-name symbol in another Rust file (let alone another
+language) is not safe to bind without receiver-type evidence. The std-ownership
+gate is language-aware via ``languages_compatible`` so a Python ``swap`` never
+suppresses Rust's std tier and is never bound.
+
+NOTE: Rust call-edge extraction is not yet enabled in
+``function_extraction._CALL_NODE_TYPES`` (python/js/ts/java/go/c/cpp only), so a
+real index produces no Rust ``calls`` edges and this resolver is dormant
+end-to-end until that (separate, out-of-scope) extractor change lands. The
+resolver is correct and tested at its contract surface now, so it activates with
+zero further work the moment Rust edges are produced.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .._registry import register_language
+from .._rust_constants import is_std_assoc_call, is_std_path
+
+
+class RustResolverContext:
+    """Per-index Rust resolution maps (built once per pass).
+
+    All file keys are project-relative paths, matching the ``edges`` table.
+    Only the cross-language-safe maps are retained; no global single-name table
+    is used for binding (see the module docstring — the moat).
+    """
+
+    __slots__ = ("file_languages", "file_symbols", "global_name_table")
+
+    def __init__(
+        self,
+        *,
+        file_symbols: dict[str, list[tuple[str, str, int]]],
+        file_languages: dict[str, str],
+        global_name_table: dict[str, list[tuple[str, int]]],
+    ) -> None:
+        # file -> [(name, kind, symbol_id), ...] (shared cross-language map).
+        self.file_symbols = file_symbols
+        # file -> language tag (so the std-ownership gate is language-aware).
+        self.file_languages = file_languages
+        # simple name -> [(file, symbol_id), ...] project-wide. Used ONLY by the
+        # language-aware ownership gate (never to BIND a callee), so a same-name
+        # symbol in another file is never wired across.
+        self.global_name_table = global_name_table
+
+
+def build_rust_resolver_context(
+    *,
+    imports_by_file: dict[str, Any],
+    file_languages: dict[str, str],
+    file_symbols: dict[str, Any],
+    global_name_table: dict[str, Any],
+    file_class_methods: Any,  # zero-arg thunk -> class->method map (lazy, unused)
+    **_ignored: Any,
+) -> RustResolverContext | None:
+    """Build the Rust context, or ``None`` when no Rust file is indexed.
+
+    Zero cost for non-Rust projects (gated on ``file_languages``). The lazy
+    ``file_class_methods`` thunk is intentionally NOT called: same-file methods
+    are recovered from ``file_symbols`` (kind ``method``/``function``), so the
+    costly class→method map is never materialised for Rust.
+    """
+    if not any(lang == "rust" for lang in file_languages.values()):
+        return None
+    return RustResolverContext(
+        file_symbols=file_symbols,
+        file_languages=file_languages,
+        global_name_table=global_name_table,
+    )
+
+
+def _split_receiver(callee_full: str, callee_name: str) -> tuple[str, str]:
+    """Return ``(receiver, simple_name)`` from a Rust call's full name.
+
+    Rust paths use ``::`` (``Vec::new``, ``std::mem::swap``) while method calls
+    use ``.`` (``self.helper``). Both separators are handled; the receiver is the
+    text before the final separator, the simple name the text after it.
+    """
+    full = callee_full or callee_name
+    # Prefer the path separator when present anywhere, else the method dot.
+    if "::" in full:
+        receiver, simple = full.rsplit("::", 1)
+        return receiver, simple
+    if "." in full:
+        receiver, simple = full.rsplit(".", 1)
+        return receiver, simple
+    return "", full or callee_name
+
+
+def _lookup_in_file(
+    ctx: RustResolverContext, file_path: str, simple: str
+) -> int | None:
+    """Return the symbol id of a same-file ``simple`` def, or ``None``."""
+    for name, kind, sym_id in ctx.file_symbols.get(file_path, []):
+        if name == simple and kind in ("function", "method", "class"):
+            return sym_id
+    return None
+
+
+def _project_owns(ctx: RustResolverContext, simple: str) -> bool:
+    """True when a COMPATIBLE-LANGUAGE (Rust) project symbol of name ``simple``
+    exists.
+
+    The RFC-0008 ownership gate, language-aware: a same-named symbol in an
+    incompatible-language file (e.g. a Python ``swap``) must NOT count as a Rust
+    owner — ``languages_compatible('rust', 'python')`` is False, so the Rust
+    caller cannot resolve that symbol and it does not suppress the std tier.
+
+    When a file's language is unknown (no tag), it is treated as a possible owner
+    (conservative — same convention as the Java resolver).
+    """
+    from ..._language_family import languages_compatible
+
+    for owner_file, _sym_id in ctx.global_name_table.get(simple, []):
+        owner_lang = ctx.file_languages.get(owner_file, "")
+        if not owner_lang or languages_compatible("rust", owner_lang):
+            return True
+    return False
+
+
+def resolve_rust_callee(
+    callee_name: str,
+    callee_full: str,
+    caller_file: str,
+    ctx: RustResolverContext,
+) -> tuple[int | None, str, str]:
+    """Resolve one Rust call edge.
+
+    Returns ``(symbol_id, resolution, resolved_file)`` where ``resolution`` is one
+    of ``local`` / ``stdlib`` / ``unknown``. ``project`` and ``external`` are not
+    emitted in this first wave: cross-file binding needs trait/use resolution that
+    is not yet available, and guessing would cross the moat — ``unknown`` is the
+    correct, safe answer for an unresolved cross-file call.
+    """
+    receiver, simple = _split_receiver(callee_full, callee_name)
+
+    # 1. local — bare call / ``self``-qualified / ``Self``-qualified, resolved in
+    #    the caller's OWN file only (never another file → the moat holds).
+    if receiver in ("", "self", "Self", "this", "super"):
+        sym_id = _lookup_in_file(ctx, caller_file, simple)
+        if sym_id is not None:
+            return sym_id, "local", caller_file
+
+    # 2. std PATH (terminal stdlib) — ``std::``/``core::``/``alloc::``-pathed call
+    #    (``std::mem::swap``). Unambiguous std; safe regardless of receiver split.
+    if is_std_path(callee_full or callee_name):
+        return None, "stdlib", ""
+
+    # 3. std ASSOCIATED fn (terminal stdlib) — a curated ``StdContainer::ctor``
+    #    (``Vec::new``, ``Box::new``). The receiver tail (last path segment) is the
+    #    type; only the curated container × constructor-family set matches. The
+    #    language-aware ownership gate preserves a project type that shadows the
+    #    name (a project ``new`` defined in Rust suppresses the classification).
+    if receiver:
+        receiver_tail = receiver.rsplit("::", 1)[-1]
+        if is_std_assoc_call(receiver_tail, simple) and not _project_owns(ctx, simple):
+            return None, "stdlib", ""
+
+    # 4. unknown — everything else. A cross-file project call, an unresolved
+    #    associated fn, or a same-name symbol in another file all land here rather
+    #    than risk a cross-language / cross-file mis-bind.
+    return None, "unknown", ""
+
+
+register_language("rust", build_rust_resolver_context, resolve_rust_callee)
+
+
+__all__ = [
+    "RustResolverContext",
+    "build_rust_resolver_context",
+    "resolve_rust_callee",
+]

--- a/tree_sitter_analyzer/synapse_resolver/languages/rust.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/rust.py
@@ -113,6 +113,34 @@ def _lookup_in_file(
     return None
 
 
+def _lookup_unique_method_in_file(
+    ctx: RustResolverContext, file_path: str, simple: str
+) -> int | None:
+    """Return the symbol id of a same-file ``simple`` def, but ONLY when exactly one
+    method/function of that name exists in the file; otherwise ``None``.
+
+    Codex P2 (owner-context safety): a ``self.helper()`` / ``Self::helper()`` call
+    carries no caller-owner type, so the resolver cannot tell which impl block's
+    ``helper`` the receiver refers to. When two impls in the same file both define
+    ``helper`` (``impl A { fn helper }`` + ``impl B { fn helper }``), binding to
+    whichever row appears first would corrupt the call edge. The conservative answer
+    for an ambiguous receiver-qualified method is therefore ``unknown``.
+
+    Both ``method`` and ``function`` rows are counted: an associated fn called via
+    ``Self::ctor()`` can be extracted under either kind, and either one duplicated
+    across impls is ambiguous. This guard runs ONLY on the receiver-qualified
+    (``self``/``Self``/``this``/``super``) path; a bare free-function call keeps
+    ``_lookup_in_file`` (a Rust module cannot define two free fns of one name, so a
+    bare match is never ambiguous and stays unaffected).
+    """
+    matches = [
+        sym_id
+        for name, kind, sym_id in ctx.file_symbols.get(file_path, [])
+        if name == simple and kind in ("function", "method")
+    ]
+    return matches[0] if len(matches) == 1 else None
+
+
 def _project_owns(ctx: RustResolverContext, simple: str) -> bool:
     """True when a COMPATIBLE-LANGUAGE (Rust) project symbol of name ``simple``
     exists.
@@ -150,10 +178,23 @@ def resolve_rust_callee(
     """
     receiver, simple = _split_receiver(callee_full, callee_name)
 
-    # 1. local — bare call / ``self``-qualified / ``Self``-qualified, resolved in
-    #    the caller's OWN file only (never another file → the moat holds).
-    if receiver in ("", "self", "Self", "this", "super"):
+    # 1a. local (bare call) — a receiver-less call resolves to a same-file def in
+    #     the caller's OWN file only (never another file → the moat holds). A Rust
+    #     module cannot define two free fns of one name, so the first match is the
+    #     unique def.
+    if receiver == "":
         sym_id = _lookup_in_file(ctx, caller_file, simple)
+        if sym_id is not None:
+            return sym_id, "local", caller_file
+
+    # 1b. local (receiver-qualified) — ``self.helper`` / ``Self::helper`` /
+    #     ``this`` / ``super``. The caller-owner type is NOT available to this
+    #     resolver, so we can only safely bind when the method name is UNIQUE in the
+    #     file. If two impls in the same file both define ``helper``, the receiver is
+    #     ambiguous and we leave it ``unknown`` rather than mis-bind to the first row
+    #     (Codex P2). Resolution stays in the caller's OWN file only → the moat holds.
+    elif receiver in ("self", "Self", "this", "super"):
+        sym_id = _lookup_unique_method_in_file(ctx, caller_file, simple)
         if sym_id is not None:
             return sym_id, "local", caller_file
 


### PR DESCRIPTION
## Summary

A **SAFE, self-contained, NEW-FILES-ONLY** Rust per-language callee resolver (RFC-0010 first wave). It plugs into the language-registry auto-discovery — **no existing file is edited**.

Three new files:
- `tree_sitter_analyzer/synapse_resolver/languages/rust.py` — registers `rust` via `register_language(...)`.
- `tree_sitter_analyzer/synapse_resolver/_rust_constants.py` — the conservative std path/assoc-fn tiers.
- `tests/unit/test_rust_method_resolution.py` — 16 tests (RED-first).

## What it resolves

- **(a) local** — same-file / same-language calls from `file_symbols`: bare free-fn calls and `self.` / `Self::` methods, resolved in the caller's **own** file only.
- **(b) conservative stdlib tier** — `std::` / `core::` / `alloc::`-pathed calls (`std::mem::swap`) and a tiny curated `StdContainer::ctor` set (`Vec::new`, `Box::new`, `Rc/Arc/HashMap/...::new|with_capacity|from_iter|default`).
- **everything else → `unknown`** (the correct safe answer).

## The moat — never cross-language bind

The #1 requirement. This resolver **never** binds a Rust callee to a symbol in another language's (or even another Rust file's) file:
- No single-global bind step — a same-name symbol elsewhere is left `unknown`.
- The std-ownership gate is **language-aware** via `languages_compatible('rust', ...)`, so a Python `swap` neither suppresses Rust's std tier nor gets bound.

A mandatory `test_no_cross_language_mis_wire_to_other_language_symbol` locks this; reverting the resolver to a naive single-global bind makes it (and the Python-only-owner test) fail.

## Conservative tiers (RFC-0008 lesson)

`Option`/`Result` method names (`unwrap`/`map`/`and_then`) and **bare** ctor names are **deliberately excluded** — without receiver-type evidence they'd collide with domain/monadic types and crates. An empty/strict tier beats a false positive.

## Why the tests drive the contract surface (not full E2E indexing)

Rust call-edge extraction is **not yet enabled** in `function_extraction._CALL_NODE_TYPES` (only python/js/ts/java/go/c/cpp), so a real `index_project` emits **zero** Rust `calls` edges and the resolver is dormant end-to-end. Wiring that extractor is a **separate, shared-file change, out of scope** for this new-files-only PR. The resolver is fully correct and tested at the exact function the registry dispatch calls; it activates with zero further work the moment Rust edges are produced.

## Verification

- `tests/unit/test_rust_method_resolution.py` — 16 passed.
- `tests/unit/test_java_method_resolution.py` + `tests/unit/synapse_resolver/` — 96 passed (no registry regression).
- `ruff check` / `ruff format --check` / `mypy` clean on the new files.
- RED verified by reverting (cross-language bind injection caught by the moat test).
- `git show --stat HEAD`: exactly 3 new files, no shared-file edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
