### PR TITLE
feat(resolver): RFC-0010 first-wave Go callee resolver (new-files-only)

### DIFF
--- a/tests/unit/test_go_method_resolution.py
+++ b/tests/unit/test_go_method_resolution.py
@@ -198,6 +198,56 @@ def test_aliased_stdlib_import_resolves_under_alias() -> None:
     assert resolution == "stdlib"
 
 
+# ---------------------------------------------------------------------------
+# Codex P2 (finding 2): comments in a Go import block must be stripped before
+# the import matcher runs, or a commented-out stdlib path leaks a spurious
+# qualifier and a same-named variable is falsely classified as stdlib.
+# ---------------------------------------------------------------------------
+def test_line_comment_in_import_block_is_not_an_import() -> None:
+    """A ``// "net/http"`` line comment inside a grouped import must NOT be
+    parsed as a real import spec — only ``fmt`` is actually imported."""
+    from tree_sitter_analyzer.synapse_resolver.languages._go_constants import (
+        parse_go_import_block,
+    )
+
+    raw = 'import (\n\t"fmt"\n\t// "net/http"\n)'
+    assert parse_go_import_block(raw) == {"fmt": "fmt"}
+
+
+def test_trailing_line_comment_after_spec_is_not_an_import() -> None:
+    """A trailing ``// "net/http"`` after a real ``"fmt"`` import must be
+    ignored — the commented path is not imported."""
+    from tree_sitter_analyzer.synapse_resolver.languages._go_constants import (
+        parse_go_import_block,
+    )
+
+    raw = 'import "fmt" // "net/http"'
+    assert parse_go_import_block(raw) == {"fmt": "fmt"}
+
+
+def test_block_comment_in_import_block_is_not_an_import() -> None:
+    """A ``/* "net/http" */`` block comment must be stripped before matching —
+    the commented stdlib path must not leak an ``http`` qualifier."""
+    from tree_sitter_analyzer.synapse_resolver.languages._go_constants import (
+        parse_go_import_block,
+    )
+
+    raw = 'import (\n\t"fmt"\n\t/* "net/http" */\n)'
+    assert parse_go_import_block(raw) == {"fmt": "fmt"}
+
+
+def test_commented_import_does_not_enable_stdlib_qualifier() -> None:
+    """End-to-end of finding 2 through the resolver: a ``// "net/http"`` comment
+    next to a real ``"fmt"`` import must leave a later ``http.Get`` ``unknown`` —
+    the commented path is not real import evidence."""
+    ctx = _ctx(
+        {"main.go": [("main", "function", 11)]},
+        imports={"main.go": 'import (\n\t"fmt"\n\t// "net/http"\n)'},
+    )
+    _sym, resolution, _file = resolve_go_callee("Get", "http.Get", "main.go", ctx)
+    assert resolution == "unknown"
+
+
 def test_receiver_method_call_stays_unknown() -> None:
     """``s.Run()`` — ``s`` is a local variable whose struct type the edge does
     not carry. The resolver must NOT guess a same-name ``Run`` elsewhere."""

--- a/tests/unit/test_go_method_resolution.py
+++ b/tests/unit/test_go_method_resolution.py
@@ -80,13 +80,39 @@ def test_build_context_built_when_go_file_present() -> None:
 # ---------------------------------------------------------------------------
 # Direct resolver unit tests
 # ---------------------------------------------------------------------------
-def _ctx(symbols: dict[str, list[tuple[str, str, int]]]) -> GoResolverContext:
+def _ctx(
+    symbols: dict[str, list[tuple[str, str, int]]],
+    *,
+    imports: dict[str, str] | None = None,
+) -> GoResolverContext:
+    """Build a Go context for unit tests.
+
+    ``imports`` maps a file path to its raw Go import-block text (exactly the
+    string the indexer stores as a ``kind='import'`` symbol). When omitted, the
+    helper synthesises a permissive import block that imports every stdlib
+    package name referenced by the test as a qualifier — so a test that does
+    NOT care about import-gating keeps classifying stdlib calls as before.
+    """
+    if imports is None:
+        # Permissive default: import every canonical stdlib package so legacy
+        # stdlib-classification tests still see import evidence.
+        from tree_sitter_analyzer.synapse_resolver.languages._go_constants import (
+            STDLIB_PACKAGES_GO,
+        )
+
+        block = (
+            "import (\n"
+            + "".join(f'\t"{p}"\n' for p in sorted(STDLIB_PACKAGES_GO))
+            + ")"
+        )
+        imports = dict.fromkeys(symbols, block)
     built = build_go_resolver_context(
         imports_by_file={},
         file_languages=dict.fromkeys(symbols, "go"),
         file_symbols=symbols,
         global_name_table={},
         file_class_methods=lambda: {},
+        go_import_blocks=imports,
     )
     assert built is not None
     return built
@@ -99,7 +125,10 @@ def test_same_file_func_resolves_local() -> None:
 
 
 def test_stdlib_package_call_classifies_stdlib() -> None:
-    ctx = _ctx({"main.go": [("main", "function", 11)]})
+    ctx = _ctx(
+        {"main.go": [("main", "function", 11)]},
+        imports={"main.go": 'import "fmt"'},
+    )
     sym_id, resolution, resolved = resolve_go_callee(
         "Println", "fmt.Println", "main.go", ctx
     )
@@ -107,9 +136,64 @@ def test_stdlib_package_call_classifies_stdlib() -> None:
 
 
 def test_strings_package_call_classifies_stdlib() -> None:
-    ctx = _ctx({"main.go": [("helper", "function", 7)]})
+    ctx = _ctx(
+        {"main.go": [("helper", "function", 7)]},
+        imports={"main.go": 'import "strings"'},
+    )
     _sym, resolution, _file = resolve_go_callee(
         "ToUpper", "strings.ToUpper", "main.go", ctx
+    )
+    assert resolution == "stdlib"
+
+
+def test_stdlib_qualifier_without_import_stays_unknown() -> None:
+    """Codex P2: a receiver whose name collides with a stdlib package
+    (``var http Client; http.Get()``) but which is NOT imported must stay
+    ``unknown`` — the stdlib tier requires import evidence, never just a
+    name match."""
+    ctx = _ctx(
+        {"main.go": [("main", "function", 11)]},
+        imports={"main.go": 'import "fmt"'},  # http NOT imported
+    )
+    sym_id, resolution, resolved = resolve_go_callee("Get", "http.Get", "main.go", ctx)
+    assert (sym_id, resolution, resolved) == (None, "unknown", "")
+
+
+def test_blank_import_does_not_enable_stdlib_qualifier() -> None:
+    """A blank import (``_ "net/http"``) is side-effect only — the package
+    name is NOT usable as a qualifier, so ``http.Get`` stays ``unknown``."""
+    ctx = _ctx(
+        {"main.go": [("main", "function", 11)]},
+        imports={"main.go": 'import (\n\t_ "net/http"\n)'},
+    )
+    _sym, resolution, _file = resolve_go_callee("Get", "http.Get", "main.go", ctx)
+    assert resolution == "unknown"
+
+
+def test_aliased_stdlib_import_uses_alias_not_package_name() -> None:
+    """``jsonx "encoding/json"`` makes ``jsonx`` the qualifier; a bare
+    ``json.Marshal`` is therefore NOT imported and stays ``unknown`` (json is
+    not in STDLIB set anyway, but the alias must not leak the package name)."""
+    ctx = _ctx(
+        {"main.go": [("main", "function", 11)]},
+        imports={"main.go": 'import (\n\tstrs "strings"\n)'},
+    )
+    # `strs` is the local qualifier; a bare `strings.X` is not imported.
+    _sym, resolution, _file = resolve_go_callee(
+        "ToUpper", "strings.ToUpper", "main.go", ctx
+    )
+    assert resolution == "unknown"
+
+
+def test_aliased_stdlib_import_resolves_under_alias() -> None:
+    """The alias qualifier itself resolves to stdlib when it aliases a stdlib
+    package (``strs "strings"`` → ``strs.ToUpper`` is stdlib)."""
+    ctx = _ctx(
+        {"main.go": [("main", "function", 11)]},
+        imports={"main.go": 'import (\n\tstrs "strings"\n)'},
+    )
+    _sym, resolution, _file = resolve_go_callee(
+        "ToUpper", "strs.ToUpper", "main.go", ctx
     )
     assert resolution == "stdlib"
 
@@ -238,6 +322,42 @@ def test_no_cross_language_mis_wire_end_to_end(tmp_path: Path) -> None:
         # The moat: a Go caller must NEVER bind to the Python helpers.py.
         assert r["callee_resolved_file"] != "py/helpers.py"
         assert r["callee_resolution"] in ("stdlib", "unknown")
+
+
+def test_end_to_end_variable_named_like_stdlib_stays_unknown(tmp_path: Path) -> None:
+    """Codex P2 end-to-end: a local variable named ``http`` (no ``net/http``
+    import) calling ``http.Get`` must NOT be classified as stdlib — only
+    ``fmt`` is imported, so ``http`` is a variable receiver and stays
+    ``unknown``."""
+    (tmp_path / "main.go").write_text(
+        "package main\n\n"
+        'import "fmt"\n\n'
+        "type Client struct{}\n\n"
+        "func (c Client) Get(s string) string { return s }\n\n"
+        "func main() {\n"
+        "\tvar http Client\n"
+        '\tfmt.Println(http.Get("x"))\n'
+        "}\n"
+    )
+    cache = ASTCache(str(tmp_path))
+    try:
+        cache.index_project()
+    finally:
+        cache.close()
+    db = str(tmp_path / ".ast-cache" / "index.db")
+    conn = sqlite3.connect(db)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT callee_name, callee_resolution FROM edges "
+            "WHERE kind = 'calls' AND language = 'go' AND callee_name = 'Get'"
+        ).fetchall()
+    finally:
+        conn.close()
+    assert rows, "expected a Go http.Get edge"
+    for r in rows:
+        # http is a variable, not the imported package → must stay unknown.
+        assert r["callee_resolution"] == "unknown"
 
 
 def test_end_to_end_go_stdlib_and_local(tmp_path: Path) -> None:

--- a/tests/unit/test_go_method_resolution.py
+++ b/tests/unit/test_go_method_resolution.py
@@ -1,0 +1,276 @@
+"""RFC-0010 first wave: the Go per-language callee resolver.
+
+Go calls come in two syntactic shapes the resolver must classify
+correctly without ever guessing:
+
+* bare / same-file       — ``helper()`` resolves to a same-file ``func``.
+* package-qualified call  — ``fmt.Println`` / ``strings.Split`` classify as
+  ``stdlib`` ONLY when the qualifier is a conservative stdlib package name
+  that the project does not itself define (shadowing preserved).
+* receiver method call    — ``s.Run()`` (receiver is a *variable*, its type
+  is not inferable from the edge) stays ``unknown``; the resolver never
+  guesses a cross-struct/cross-file binding.
+
+The mandatory moat assertion: a callee whose bare name also exists as a
+symbol in ANOTHER language's file must NEVER bind to that file — Go only
+ever resolves ``local`` against its own (same-language) caller file.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from tree_sitter_analyzer.ast_cache import ASTCache
+from tree_sitter_analyzer.synapse_resolver import ResolvedCallee, resolve_callee
+from tree_sitter_analyzer.synapse_resolver import languages as _languages
+from tree_sitter_analyzer.synapse_resolver._context import ResolverContext
+from tree_sitter_analyzer.synapse_resolver._registry import (
+    get_language_resolver,
+    registered_languages,
+)
+from tree_sitter_analyzer.synapse_resolver.languages.go import (
+    GoResolverContext,
+    build_go_resolver_context,
+    resolve_go_callee,
+)
+
+
+# ---------------------------------------------------------------------------
+# Registration / discovery
+# ---------------------------------------------------------------------------
+def test_go_is_registered_via_discovery() -> None:
+    """Dropping ``languages/go.py`` auto-registers the Go resolver — no edit to
+    any shared file."""
+    assert "go" in registered_languages()
+    assert get_language_resolver("go") is not None
+    assert "go" in {
+        m.name
+        for m in __import__("pkgutil").iter_modules(_languages.__path__)
+        if not m.name.startswith("_")
+    }
+
+
+# ---------------------------------------------------------------------------
+# build_go_resolver_context gating (zero cost when no Go file is indexed)
+# ---------------------------------------------------------------------------
+def test_build_context_returns_none_without_go_files() -> None:
+    ctx = build_go_resolver_context(
+        imports_by_file={},
+        file_languages={"a.py": "python"},
+        file_symbols={},
+        global_name_table={},
+        file_class_methods=lambda: {},
+    )
+    assert ctx is None
+
+
+def test_build_context_built_when_go_file_present() -> None:
+    ctx = build_go_resolver_context(
+        imports_by_file={},
+        file_languages={"main.go": "go"},
+        file_symbols={"main.go": [("helper", "function", 7)]},
+        global_name_table={"helper": [("main.go", 7)]},
+        file_class_methods=lambda: {},
+    )
+    assert isinstance(ctx, GoResolverContext)
+    assert "main.go" in ctx.file_symbols
+
+
+# ---------------------------------------------------------------------------
+# Direct resolver unit tests
+# ---------------------------------------------------------------------------
+def _ctx(symbols: dict[str, list[tuple[str, str, int]]]) -> GoResolverContext:
+    built = build_go_resolver_context(
+        imports_by_file={},
+        file_languages=dict.fromkeys(symbols, "go"),
+        file_symbols=symbols,
+        global_name_table={},
+        file_class_methods=lambda: {},
+    )
+    assert built is not None
+    return built
+
+
+def test_same_file_func_resolves_local() -> None:
+    ctx = _ctx({"main.go": [("helper", "function", 7), ("main", "function", 11)]})
+    sym_id, resolution, resolved = resolve_go_callee("helper", "helper", "main.go", ctx)
+    assert (sym_id, resolution, resolved) == (7, "local", "main.go")
+
+
+def test_stdlib_package_call_classifies_stdlib() -> None:
+    ctx = _ctx({"main.go": [("main", "function", 11)]})
+    sym_id, resolution, resolved = resolve_go_callee(
+        "Println", "fmt.Println", "main.go", ctx
+    )
+    assert (sym_id, resolution, resolved) == (None, "stdlib", "")
+
+
+def test_strings_package_call_classifies_stdlib() -> None:
+    ctx = _ctx({"main.go": [("helper", "function", 7)]})
+    _sym, resolution, _file = resolve_go_callee(
+        "ToUpper", "strings.ToUpper", "main.go", ctx
+    )
+    assert resolution == "stdlib"
+
+
+def test_receiver_method_call_stays_unknown() -> None:
+    """``s.Run()`` — ``s`` is a local variable whose struct type the edge does
+    not carry. The resolver must NOT guess a same-name ``Run`` elsewhere."""
+    ctx = _ctx({"svc.go": [("Run", "function", 5), ("Start", "function", 9)]})
+    sym_id, resolution, resolved = resolve_go_callee("Run", "s.Run", "svc.go", ctx)
+    assert (sym_id, resolution, resolved) == (None, "unknown", "")
+
+
+def test_unknown_package_qualifier_stays_unknown() -> None:
+    """A non-stdlib package qualifier (third-party / domain) is conservatively
+    left ``unknown`` — never mis-classified as stdlib/external."""
+    ctx = _ctx({"main.go": [("main", "function", 11)]})
+    sym_id, resolution, resolved = resolve_go_callee(
+        "NewClient", "redis.NewClient", "main.go", ctx
+    )
+    assert (sym_id, resolution, resolved) == (None, "unknown", "")
+
+
+def test_project_shadows_stdlib_package_name() -> None:
+    """If the project itself defines a symbol named like a stdlib package
+    (e.g. a ``fmt`` func), a ``fmt.X`` call must NOT be claimed as stdlib —
+    precision over recall."""
+    ctx = _ctx({"main.go": [("fmt", "function", 3), ("main", "function", 11)]})
+    _sym, resolution, _file = resolve_go_callee("X", "fmt.X", "main.go", ctx)
+    assert resolution != "stdlib"
+
+
+def test_bare_name_not_in_file_stays_unknown() -> None:
+    ctx = _ctx({"main.go": [("main", "function", 11)]})
+    sym_id, resolution, resolved = resolve_go_callee(
+        "missing", "missing", "main.go", ctx
+    )
+    assert (sym_id, resolution, resolved) == (None, "unknown", "")
+
+
+# ---------------------------------------------------------------------------
+# Integration through the registry dispatch (resolve_callee)
+# ---------------------------------------------------------------------------
+def test_resolve_callee_routes_go_to_go_resolver() -> None:
+    go_ctx = _ctx({"main.go": [("helper", "function", 7)]})
+    ctx = ResolverContext(
+        project_root=".",
+        cache=None,
+        file_languages={"main.go": "go"},
+        lang_contexts={"go": go_ctx},
+    )
+    res = resolve_callee("helper", "main.go", ctx, "helper")
+    assert isinstance(res, ResolvedCallee)
+    assert (res.callee_symbol_id, res.resolution, res.resolved_file) == (
+        7,
+        "local",
+        "main.go",
+    )
+
+
+def test_resolve_callee_go_stdlib_through_registry() -> None:
+    go_ctx = _ctx({"main.go": [("main", "function", 11)]})
+    ctx = ResolverContext(
+        project_root=".",
+        cache=None,
+        file_languages={"main.go": "go"},
+        lang_contexts={"go": go_ctx},
+    )
+    res = resolve_callee("Println", "main.go", ctx, "fmt.Println")
+    assert res.resolution == "stdlib"
+
+
+# ---------------------------------------------------------------------------
+# THE MOAT — no cross-language mis-wire
+# ---------------------------------------------------------------------------
+def test_no_cross_language_mis_wire_direct() -> None:
+    """A Go caller's bare ``helper`` must NEVER resolve to a Python file that
+    happens to define ``helper``. The Go resolver only consults its own caller
+    file (same-language by construction)."""
+    ctx = build_go_resolver_context(
+        imports_by_file={},
+        file_languages={"main.go": "go", "util.py": "python"},
+        # Python file defines `helper`; the Go caller file does NOT.
+        file_symbols={"util.py": [("helper", "function", 3)]},
+        global_name_table={"helper": [("util.py", 3)]},
+        file_class_methods=lambda: {},
+    )
+    assert ctx is not None
+    sym_id, resolution, resolved = resolve_go_callee("helper", "helper", "main.go", ctx)
+    # MUST NOT bind to util.py — stays unknown.
+    assert (sym_id, resolution, resolved) == (None, "unknown", "")
+    assert resolved != "util.py"
+
+
+def test_no_cross_language_mis_wire_end_to_end(tmp_path: Path) -> None:
+    """Index a polyglot repo where ``ToUpper`` exists as a Python def AND is
+    called package-qualified from Go (``strings.ToUpper``). The Go edge must
+    classify as ``stdlib`` (or unknown) — NEVER bind to the Python file."""
+    (tmp_path / "py").mkdir()
+    (tmp_path / "py" / "helpers.py").write_text(
+        "def ToUpper(s):\n    return s.upper()\n"
+    )
+    (tmp_path / "app.go").write_text(
+        "package main\n\n"
+        'import (\n\t"fmt"\n\t"strings"\n)\n\n'
+        "func main() {\n"
+        '\tfmt.Println(strings.ToUpper("hi"))\n'
+        "}\n"
+    )
+    cache = ASTCache(str(tmp_path))
+    try:
+        cache.index_project()
+    finally:
+        cache.close()
+    db = str(tmp_path / ".ast-cache" / "index.db")
+    conn = sqlite3.connect(db)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT callee_resolution, callee_resolved_file FROM edges "
+            "WHERE kind = 'calls' AND callee_name = 'ToUpper' AND language = 'go'"
+        ).fetchall()
+    finally:
+        conn.close()
+    assert rows, "expected a Go strings.ToUpper edge"
+    for r in rows:
+        # The moat: a Go caller must NEVER bind to the Python helpers.py.
+        assert r["callee_resolved_file"] != "py/helpers.py"
+        assert r["callee_resolution"] in ("stdlib", "unknown")
+
+
+def test_end_to_end_go_stdlib_and_local(tmp_path: Path) -> None:
+    """Full index: a same-file func call stays ``local``; a stdlib
+    package-qualified call becomes ``stdlib``."""
+    (tmp_path / "main.go").write_text(
+        "package main\n\n"
+        'import (\n\t"fmt"\n\t"strings"\n)\n\n'
+        "func helper(s string) string {\n"
+        "\treturn strings.ToUpper(s)\n"
+        "}\n\n"
+        "func main() {\n"
+        '\tfmt.Println(helper("hi"))\n'
+        "}\n"
+    )
+    cache = ASTCache(str(tmp_path))
+    try:
+        cache.index_project()
+    finally:
+        cache.close()
+    db = str(tmp_path / ".ast-cache" / "index.db")
+    conn = sqlite3.connect(db)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = {
+            r["callee_name"]: r["callee_resolution"]
+            for r in conn.execute(
+                "SELECT callee_name, callee_resolution FROM edges "
+                "WHERE kind = 'calls' AND language = 'go'"
+            ).fetchall()
+        }
+    finally:
+        conn.close()
+    assert rows.get("helper") == "local"
+    assert rows.get("ToUpper") == "stdlib"
+    assert rows.get("Println") == "stdlib"

--- a/tests/unit/test_go_method_resolution.py
+++ b/tests/unit/test_go_method_resolution.py
@@ -94,15 +94,17 @@ def _ctx(
     NOT care about import-gating keeps classifying stdlib calls as before.
     """
     if imports is None:
-        # Permissive default: import every canonical stdlib package so legacy
-        # stdlib-classification tests still see import evidence.
+        # Permissive default: import every canonical stdlib path so legacy
+        # stdlib-classification tests still see import evidence. Built from the
+        # FULL canonical paths (``net/http`` …) — the import-evidence gate
+        # validates the whole path, not the final segment (Codex P2 finding 3).
         from tree_sitter_analyzer.synapse_resolver.languages._go_constants import (
-            STDLIB_PACKAGES_GO,
+            STDLIB_IMPORT_PATHS_GO,
         )
 
         block = (
             "import (\n"
-            + "".join(f'\t"{p}"\n' for p in sorted(STDLIB_PACKAGES_GO))
+            + "".join(f'\t"{p}"\n' for p in sorted(STDLIB_IMPORT_PATHS_GO))
             + ")"
         )
         imports = dict.fromkeys(symbols, block)
@@ -245,6 +247,62 @@ def test_commented_import_does_not_enable_stdlib_qualifier() -> None:
         imports={"main.go": 'import (\n\t"fmt"\n\t// "net/http"\n)'},
     )
     _sym, resolution, _file = resolve_go_callee("Get", "http.Get", "main.go", ctx)
+    assert resolution == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Codex P2 (finding 3): the import-evidence gate must validate the FULL
+# canonical stdlib import path, not just the final path segment. A third-party
+# module whose last segment collides with a stdlib package name
+# (``github.com/acme/json`` ends in ``json``; ``example.com/fmt`` ends in
+# ``fmt``) must NOT count as stdlib import evidence.
+# ---------------------------------------------------------------------------
+def test_third_party_path_ending_in_stdlib_name_is_not_import_evidence() -> None:
+    """``import jsonx "github.com/acme/json"`` must NOT register ``json`` (nor
+    the alias) as stdlib import evidence — the imported path is third-party."""
+    from tree_sitter_analyzer.synapse_resolver.languages._go_constants import (
+        parse_go_import_block,
+    )
+
+    assert parse_go_import_block('import jsonx "github.com/acme/json"') == {}
+
+
+def test_third_party_plain_import_ending_in_stdlib_name_is_not_evidence() -> None:
+    """A plain ``import "example.com/fmt"`` ends in ``fmt`` but is third-party —
+    the full path is not the Go standard library, so no evidence is recorded."""
+    from tree_sitter_analyzer.synapse_resolver.languages._go_constants import (
+        parse_go_import_block,
+    )
+
+    assert parse_go_import_block('import "example.com/fmt"') == {}
+
+
+def test_canonical_stdlib_subpath_is_import_evidence() -> None:
+    """Genuine multi-segment stdlib paths (``net/http``, ``encoding/json``,
+    ``path/filepath``) ARE evidence and map their final segment qualifier."""
+    from tree_sitter_analyzer.synapse_resolver.languages._go_constants import (
+        parse_go_import_block,
+    )
+
+    raw = 'import (\n\t"net/http"\n\t"encoding/json"\n\t"path/filepath"\n)'
+    assert parse_go_import_block(raw) == {
+        "http": "http",
+        "json": "json",
+        "filepath": "filepath",
+    }
+
+
+def test_third_party_subpath_collision_through_resolver_stays_unknown() -> None:
+    """End-to-end of finding 3: a file importing only ``github.com/acme/json``
+    (alias ``jsonx``) calling ``jsonx.Marshal`` must stay ``unknown`` — the
+    third-party path is not stdlib evidence."""
+    ctx = _ctx(
+        {"main.go": [("main", "function", 11)]},
+        imports={"main.go": 'import jsonx "github.com/acme/json"'},
+    )
+    _sym, resolution, _file = resolve_go_callee(
+        "Marshal", "jsonx.Marshal", "main.go", ctx
+    )
     assert resolution == "unknown"
 
 

--- a/tree_sitter_analyzer/synapse_resolver/languages/_go_constants.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/_go_constants.py
@@ -22,6 +22,8 @@ than risk a mis-classification. An empty tier is correct (RFC-0010).
 
 from __future__ import annotations
 
+import re
+
 #: Canonical Go standard-library top-level package names. Kept deliberately
 #: small and unambiguous — each is a well-known stdlib package whose short
 #: identifier is very unlikely to collide with a project-defined symbol. When
@@ -67,4 +69,64 @@ STDLIB_PACKAGES_GO: frozenset[str] = frozenset(
 EXTERNAL_PACKAGES_GO: frozenset[str] = frozenset()
 
 
-__all__ = ["EXTERNAL_PACKAGES_GO", "STDLIB_PACKAGES_GO"]
+#: One Go ``import`` spec: optional local name (alias / ``.`` / ``_``) on the
+#: SAME line, immediately before a double-quoted module path. Anchored so the
+#: local name must sit right against the quote (``jsonx "encoding/json"``) — a
+#: stray keyword like ``import`` on its own line is never captured as an alias.
+_GO_IMPORT_SPEC = re.compile(r'(?:(?P<local>[A-Za-z_.][\w.]*)[ \t]+)?"(?P<path>[^"]+)"')
+
+#: Strips the leading ``import`` keyword (and an optional ``(``) so the keyword
+#: is never mistaken for an import alias when it abuts the first spec on one
+#: line (``import "fmt"``).
+_GO_IMPORT_KEYWORD = re.compile(r"\bimport\b\s*\(?")
+
+
+def parse_go_import_block(raw: str) -> dict[str, str]:
+    """Parse a Go import-block string into ``{qualifier -> stdlib package}``.
+
+    ``raw`` is the verbatim text the indexer stores for a ``kind='import'``
+    symbol, e.g. ``'import "fmt"'`` or
+    ``'import (\\n\\t"fmt"\\n\\tjsonx "encoding/json"\\n)'``.
+
+    Only STDLIB imports that expose a *usable package qualifier* are returned:
+
+    * a plain import (``"net/http"``) maps the package's final path segment
+      (``http``) to its stdlib head (``http``) — the qualifier used in code;
+    * an aliased import (``jsonx "encoding/json"``) maps the alias (``jsonx``)
+      to the stdlib head (``json``);
+    * blank (``_ "net/http"``) and dot (``. "strings"``) imports are EXCLUDED
+      — they expose no ``pkg.Func`` qualifier, so they must not enable stdlib
+      classification of a same-named variable.
+
+    Non-stdlib imports are excluded too (the stdlib tier is the only consumer).
+    The mapping is conservative by construction: a variable that merely shares
+    a stdlib package's name but is never imported never appears here, so the
+    resolver leaves it ``unknown`` (RFC-0008 precision-over-recall).
+    """
+    out: dict[str, str] = {}
+    # Drop every ``import`` keyword (and trailing ``(``) so it can never be
+    # captured as a same-line alias for the first spec.
+    cleaned = _GO_IMPORT_KEYWORD.sub(" ", raw or "")
+    for m in _GO_IMPORT_SPEC.finditer(cleaned):
+        local = m.group("local")
+        path = m.group("path")
+        if not path:
+            continue
+        # Final path segment is Go's default package identifier.
+        package = path.rsplit("/", 1)[-1]
+        if package not in STDLIB_PACKAGES_GO:
+            continue
+        if local in (".", "_"):
+            # dot import injects names into file scope (no qualifier); blank
+            # import is side-effect only — neither yields a usable ``pkg.Func``.
+            continue
+        qualifier = local if local else package
+        out[qualifier] = package
+    return out
+
+
+__all__ = [
+    "EXTERNAL_PACKAGES_GO",
+    "STDLIB_PACKAGES_GO",
+    "parse_go_import_block",
+]

--- a/tree_sitter_analyzer/synapse_resolver/languages/_go_constants.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/_go_constants.py
@@ -80,6 +80,40 @@ _GO_IMPORT_SPEC = re.compile(r'(?:(?P<local>[A-Za-z_.][\w.]*)[ \t]+)?"(?P<path>[
 #: line (``import "fmt"``).
 _GO_IMPORT_KEYWORD = re.compile(r"\bimport\b\s*\(?")
 
+#: Matches, in priority order, ONE of: an interpreted string literal
+#: (``"..."`` with escapes), a raw string literal (`` `...` ``), a ``//`` line
+#: comment, or a ``/* ... */`` block comment. Alternation order matters — a
+#: string is matched BEFORE a comment so a ``//`` that lives inside a path like
+#: ``"net/http"`` is never mistaken for the start of a comment. Comments are
+#: replaced with a space (so a commented spec leaves no quoted path behind);
+#: string literals are preserved verbatim. Used to strip Go comments before the
+#: import-spec matcher runs (Codex P2: a commented ``// "net/http"`` must not
+#: leak an ``http`` qualifier).
+_GO_STRING_OR_COMMENT = re.compile(
+    r'"(?:\\.|[^"\\])*"'  # interpreted string literal
+    r"|`[^`]*`"  # raw string literal
+    r"|//[^\n]*"  # line comment
+    r"|/\*.*?\*/",  # block comment (non-greedy, spans newlines)
+    re.DOTALL,
+)
+
+
+def _strip_go_comments(raw: str) -> str:
+    """Remove Go ``//`` and ``/* */`` comments, preserving string literals.
+
+    A ``//`` or ``/* */`` that lives INSIDE a double-quoted (or raw) string is
+    not a comment, so the matcher consumes whole string literals first and only
+    replaces genuine comments (with a space). This prevents a commented-out
+    import path (``// "net/http"``) from being matched as a real import spec.
+    """
+
+    def _repl(m: re.Match[str]) -> str:
+        token = m.group(0)
+        # A matched string literal is kept verbatim; a comment becomes a space.
+        return token if token[:1] in ('"', "`") else " "
+
+    return _GO_STRING_OR_COMMENT.sub(_repl, raw)
+
 
 def parse_go_import_block(raw: str) -> dict[str, str]:
     """Parse a Go import-block string into ``{qualifier -> stdlib package}``.
@@ -104,9 +138,12 @@ def parse_go_import_block(raw: str) -> dict[str, str]:
     resolver leaves it ``unknown`` (RFC-0008 precision-over-recall).
     """
     out: dict[str, str] = {}
+    # Strip Go comments FIRST (string-literal aware) so a commented-out spec
+    # (``// "net/http"``) leaves no quoted path for the matcher to capture.
+    uncommented = _strip_go_comments(raw or "")
     # Drop every ``import`` keyword (and trailing ``(``) so it can never be
     # captured as a same-line alias for the first spec.
-    cleaned = _GO_IMPORT_KEYWORD.sub(" ", raw or "")
+    cleaned = _GO_IMPORT_KEYWORD.sub(" ", uncommented)
     for m in _GO_IMPORT_SPEC.finditer(cleaned):
         local = m.group("local")
         path = m.group("path")

--- a/tree_sitter_analyzer/synapse_resolver/languages/_go_constants.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/_go_constants.py
@@ -9,10 +9,19 @@ than the function name. An over-broad set would mis-classify third-party or
 domain calls; precision beats recall, so an ``unknown`` edge is correct and a
 mis-classified one is the exact CodeGraph failure this project avoids.
 
-``STDLIB_PACKAGES_GO`` is therefore a small, hand-audited set of canonical
-Go standard-library top-level package names. A ``pkg.Func`` call classifies
-as ``stdlib`` ONLY when ``pkg`` is in this set AND the project does not itself
-define a symbol named ``pkg`` (shadowing preserved).
+``STDLIB_IMPORT_PATHS_GO`` is therefore a small, hand-audited set of *canonical
+full* Go standard-library import paths (``"fmt"``, ``"net/http"``,
+``"encoding/json"`` …). Import evidence is gated on the **full path**, never on
+the final segment alone: a third-party module whose last segment collides with a
+stdlib name (``github.com/acme/json`` ends in ``json``; ``example.com/fmt`` ends
+in ``fmt``) is NOT the standard library and must not register stdlib evidence
+(Codex P2 finding 3). The in-code qualifier is the path's final segment (or the
+import alias). A ``pkg.Func`` call classifies as ``stdlib`` ONLY when ``pkg`` is
+an actually-imported stdlib qualifier AND the project does not itself define a
+symbol named ``pkg`` (shadowing preserved).
+
+``STDLIB_PACKAGES_GO`` is the derived set of final-segment qualifiers (kept for
+back-compat / introspection); the canonical gate is ``STDLIB_IMPORT_PATHS_GO``.
 
 ``EXTERNAL_PACKAGES_GO`` is intentionally EMPTY for the first PR: there is no
 package qualifier that is (near-)exclusively one third-party library and
@@ -24,11 +33,14 @@ from __future__ import annotations
 
 import re
 
-#: Canonical Go standard-library top-level package names. Kept deliberately
-#: small and unambiguous — each is a well-known stdlib package whose short
-#: identifier is very unlikely to collide with a project-defined symbol. When
-#: in doubt a package is LEFT OUT (stays ``unknown``), never guessed in.
-STDLIB_PACKAGES_GO: frozenset[str] = frozenset(
+#: Canonical *full* Go standard-library import paths. The import-evidence gate
+#: validates against these full paths (NOT the final segment alone), so a
+#: third-party module ending in a stdlib name (``github.com/acme/json``,
+#: ``example.com/fmt``) is correctly excluded (Codex P2 finding 3). Kept
+#: deliberately small and unambiguous — each is a well-known stdlib path whose
+#: final-segment qualifier is very unlikely to collide with a project symbol.
+#: When in doubt a path is LEFT OUT (stays ``unknown``), never guessed in.
+STDLIB_IMPORT_PATHS_GO: frozenset[str] = frozenset(
     {
         "fmt",
         "errors",
@@ -38,29 +50,37 @@ STDLIB_PACKAGES_GO: frozenset[str] = frozenset(
         "bufio",
         "sort",
         "unicode",
+        "unicode/utf8",
         "math",
+        "math/bits",
+        "math/rand",
         "time",
         "context",
         "sync",
+        "sync/atomic",
         "regexp",
         "encoding",
-        "json",
+        "encoding/json",
         "io",
         "os",
         "path",
-        "filepath",
+        "path/filepath",
         "reflect",
         "runtime",
         "flag",
         "log",
         "net",
-        "http",
-        "url",
-        "utf8",
-        "atomic",
-        "rand",
-        "bits",
+        "net/http",
+        "net/url",
     }
+)
+
+#: Derived set of final-segment qualifiers (back-compat / introspection only).
+#: The authoritative import-evidence gate is ``STDLIB_IMPORT_PATHS_GO`` above;
+#: this set must NOT be used to validate import paths (its membership would
+#: re-introduce the final-segment-collision false positive this module fixes).
+STDLIB_PACKAGES_GO: frozenset[str] = frozenset(
+    path.rsplit("/", 1)[-1] for path in STDLIB_IMPORT_PATHS_GO
 )
 
 #: Empty for the first PR — see module docstring. No Go third-party package
@@ -133,9 +153,13 @@ def parse_go_import_block(raw: str) -> dict[str, str]:
       classification of a same-named variable.
 
     Non-stdlib imports are excluded too (the stdlib tier is the only consumer).
-    The mapping is conservative by construction: a variable that merely shares
-    a stdlib package's name but is never imported never appears here, so the
-    resolver leaves it ``unknown`` (RFC-0008 precision-over-recall).
+    Inclusion is gated on the **full canonical import path** matching
+    ``STDLIB_IMPORT_PATHS_GO`` — NOT on the final path segment — so a
+    third-party module whose last segment collides with a stdlib name
+    (``github.com/acme/json``, ``example.com/fmt``) yields no evidence (Codex P2
+    finding 3). The mapping is conservative by construction: a variable that
+    merely shares a stdlib package's name but is never imported never appears
+    here, so the resolver leaves it ``unknown`` (RFC-0008 precision-over-recall).
     """
     out: dict[str, str] = {}
     # Strip Go comments FIRST (string-literal aware) so a commented-out spec
@@ -149,10 +173,13 @@ def parse_go_import_block(raw: str) -> dict[str, str]:
         path = m.group("path")
         if not path:
             continue
+        # Gate on the FULL canonical import path, never the final segment — a
+        # third-party path ending in a stdlib name (``github.com/acme/json``)
+        # must NOT count as stdlib evidence (Codex P2 finding 3).
+        if path not in STDLIB_IMPORT_PATHS_GO:
+            continue
         # Final path segment is Go's default package identifier.
         package = path.rsplit("/", 1)[-1]
-        if package not in STDLIB_PACKAGES_GO:
-            continue
         if local in (".", "_"):
             # dot import injects names into file scope (no qualifier); blank
             # import is side-effect only — neither yields a usable ``pkg.Func``.
@@ -164,6 +191,7 @@ def parse_go_import_block(raw: str) -> dict[str, str]:
 
 __all__ = [
     "EXTERNAL_PACKAGES_GO",
+    "STDLIB_IMPORT_PATHS_GO",
     "STDLIB_PACKAGES_GO",
     "parse_go_import_block",
 ]

--- a/tree_sitter_analyzer/synapse_resolver/languages/_go_constants.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/_go_constants.py
@@ -1,0 +1,70 @@
+"""Conservative Go classification tiers (RFC-0010, first wave).
+
+The RFC-0008 lesson is MANDATORY here: include a name in a classified tier
+ONLY if it is (near-)exclusively that API and unlikely to be a user symbol.
+For Go we classify by the *package qualifier* of a call (``fmt.Println`` →
+package ``fmt``), not by the bare method name — Go stdlib calls are always
+``package.Func`` and the package identifier is a far more reliable signal
+than the function name. An over-broad set would mis-classify third-party or
+domain calls; precision beats recall, so an ``unknown`` edge is correct and a
+mis-classified one is the exact CodeGraph failure this project avoids.
+
+``STDLIB_PACKAGES_GO`` is therefore a small, hand-audited set of canonical
+Go standard-library top-level package names. A ``pkg.Func`` call classifies
+as ``stdlib`` ONLY when ``pkg`` is in this set AND the project does not itself
+define a symbol named ``pkg`` (shadowing preserved).
+
+``EXTERNAL_PACKAGES_GO`` is intentionally EMPTY for the first PR: there is no
+package qualifier that is (near-)exclusively one third-party library and
+never a user import alias, so everything non-stdlib stays ``unknown`` rather
+than risk a mis-classification. An empty tier is correct (RFC-0010).
+"""
+
+from __future__ import annotations
+
+#: Canonical Go standard-library top-level package names. Kept deliberately
+#: small and unambiguous — each is a well-known stdlib package whose short
+#: identifier is very unlikely to collide with a project-defined symbol. When
+#: in doubt a package is LEFT OUT (stays ``unknown``), never guessed in.
+STDLIB_PACKAGES_GO: frozenset[str] = frozenset(
+    {
+        "fmt",
+        "errors",
+        "strings",
+        "strconv",
+        "bytes",
+        "bufio",
+        "sort",
+        "unicode",
+        "math",
+        "time",
+        "context",
+        "sync",
+        "regexp",
+        "encoding",
+        "json",
+        "io",
+        "os",
+        "path",
+        "filepath",
+        "reflect",
+        "runtime",
+        "flag",
+        "log",
+        "net",
+        "http",
+        "url",
+        "utf8",
+        "atomic",
+        "rand",
+        "bits",
+    }
+)
+
+#: Empty for the first PR — see module docstring. No Go third-party package
+#: qualifier is safe to classify as ``external`` without receiver/import
+#: evidence, so everything non-stdlib stays ``unknown``.
+EXTERNAL_PACKAGES_GO: frozenset[str] = frozenset()
+
+
+__all__ = ["EXTERNAL_PACKAGES_GO", "STDLIB_PACKAGES_GO"]

--- a/tree_sitter_analyzer/synapse_resolver/languages/go.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/go.py
@@ -8,8 +8,10 @@ its only jobs are:
    binding is even possible).
 2. **stdlib** — classify a package-qualified call (``fmt.Println``,
    ``strings.Split``) when the qualifier is a conservative canonical stdlib
-   package name AND the project does not itself define that name (shadowing
-   preserved). See :mod:`._go_constants`.
+   package name, is ACTUALLY IMPORTED under that qualifier in the caller file
+   (import evidence — a variable that merely shares a stdlib package's name is
+   not imported and stays ``unknown``), AND the project does not itself define
+   that name (shadowing preserved). See :mod:`._go_constants`.
 3. **unknown** — everything else: receiver method calls (``s.Run()`` — the
    receiver is a variable whose struct type the edge does not carry, so we
    never guess), third-party package calls, and any unresolved bare name.
@@ -30,7 +32,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from .._registry import register_language
-from ._go_constants import STDLIB_PACKAGES_GO
+from ._go_constants import parse_go_import_block
 
 
 @dataclass
@@ -46,6 +48,43 @@ class GoResolverContext:
     # set of names the project defines anywhere — used to let a project symbol
     # SHADOW a stdlib package qualifier (precision over recall).
     project_names: frozenset[str] = field(default_factory=frozenset)
+    # file -> {local package qualifier -> imported stdlib package} for stdlib
+    # imports only. A ``pkg.Func`` call classifies as stdlib ONLY when ``pkg``
+    # is a key here for the CALLER file (import evidence required — a variable
+    # that merely shares a stdlib package's name is NOT imported, so it stays
+    # ``unknown``). Aliases map the alias to the underlying stdlib package;
+    # blank (``_``) and dot (``.``) imports are excluded (not usable as a
+    # qualifier).
+    imported_stdlib_by_file: dict[str, frozenset[str]] = field(default_factory=dict)
+
+
+def _go_import_blocks_from_conn(
+    conn: Any, file_languages: dict[str, str]
+) -> dict[str, str]:
+    """Read each Go file's raw ``import`` text from the AST cache.
+
+    The indexer stores a Go import block (single or grouped) as one
+    ``kind='import'`` symbol whose ``name`` is the verbatim block text. We
+    concatenate all such rows per file so a file with several import blocks is
+    fully covered. Tolerant of a missing/legacy table (returns ``{}``) — the
+    resolver then has no import evidence and conservatively classifies every
+    package-qualified call ``unknown`` (precision over recall).
+    """
+    blocks: dict[str, str] = {}
+    if conn is None:
+        return blocks
+    try:
+        rows = conn.execute(
+            "SELECT file_path, name FROM ast_symbol_rows WHERE kind = 'import'"
+        ).fetchall()
+    except Exception:  # nosec B110 — table-missing tolerance.
+        return blocks
+    for row in rows:
+        file_path = row["file_path"]
+        if file_languages.get(file_path) != "go":
+            continue
+        blocks[file_path] = blocks.get(file_path, "") + "\n" + (row["name"] or "")
+    return blocks
 
 
 def build_go_resolver_context(
@@ -55,6 +94,8 @@ def build_go_resolver_context(
     file_symbols: dict[str, Any],
     global_name_table: dict[str, Any],
     file_class_methods: Any,  # zero-arg thunk -> class->method map (lazy; unused)
+    conn: Any = None,
+    go_import_blocks: dict[str, str] | None = None,
     **_ignored: Any,
 ) -> GoResolverContext | None:
     """Build the Go context, or ``None`` when no Go file is indexed.
@@ -64,6 +105,15 @@ def build_go_resolver_context(
     own entry, so carrying the full map is safe. The class-method thunk is not
     needed (Go receiver types are not inferable from the edge), so it is never
     called — preserving the lazy "pay nothing if you opt out early" property.
+
+    Stdlib classification is gated on **import evidence**: each Go file's raw
+    ``import`` text (a ``kind='import'`` symbol) is parsed into the set of
+    package qualifiers it actually imports. A ``pkg.Func`` call only classifies
+    as stdlib when ``pkg`` is genuinely imported in the caller file — a variable
+    that merely shares a stdlib package's name (``var http Client; http.Get()``
+    with no ``net/http`` import) is NOT imported and stays ``unknown``. Tests may
+    inject ``go_import_blocks`` (file -> raw import text) directly; production
+    reads it from ``conn``.
     """
     if not any(lang == "go" for lang in file_languages.values()):
         return None
@@ -75,9 +125,22 @@ def build_go_resolver_context(
     for symbols in file_symbols.values():
         for name, _kind, _sym_id in symbols:
             project_names.add(name)
+
+    # Per-file imported stdlib qualifiers (import evidence for the stdlib tier).
+    raw_blocks = (
+        go_import_blocks
+        if go_import_blocks is not None
+        else _go_import_blocks_from_conn(conn, file_languages)
+    )
+    imported_stdlib_by_file: dict[str, frozenset[str]] = {
+        file_path: frozenset(parse_go_import_block(raw))
+        for file_path, raw in raw_blocks.items()
+    }
+
     return GoResolverContext(
         file_symbols=file_symbols,
         project_names=frozenset(project_names),
+        imported_stdlib_by_file=imported_stdlib_by_file,
     )
 
 
@@ -128,13 +191,23 @@ def resolve_go_callee(
         # match (could collide across files/languages). Stay unknown.
         return None, "unknown", ""
 
-    # 2. stdlib — a package-qualified call whose package head is a conservative
-    #    canonical stdlib package AND is not shadowed by a project symbol.
+    # 2. stdlib — a package-qualified call whose package head is BOTH a
+    #    conservative canonical stdlib package AND actually imported under that
+    #    qualifier in the CALLER file (import evidence), AND not shadowed by a
+    #    project symbol. Requiring the import distinguishes a real package
+    #    qualifier from a variable receiver that merely shares the name
+    #    (``var http Client; http.Get()`` with no ``net/http`` import → unknown).
     head = qualifier.split(".", 1)[0]
-    if head in STDLIB_PACKAGES_GO and head not in ctx.project_names:
+    # ``imported`` holds the caller file's actually-imported stdlib qualifiers
+    # (plain package names AND aliases). Membership already proves the qualifier
+    # is a stdlib import, so no extra STDLIB_PACKAGES_GO check is needed —
+    # checking it would wrongly reject a valid alias (``strs "strings"``).
+    imported = ctx.imported_stdlib_by_file.get(caller_file, frozenset())
+    if head in imported and head not in ctx.project_names:
         return None, "stdlib", ""
 
     # 3. unknown — receiver method calls (``s.Run`` — type not inferable),
+    #    non-imported names (variables that shadow a stdlib package name),
     #    third-party packages, shadowed names. Never guess.
     return None, "unknown", ""
 

--- a/tree_sitter_analyzer/synapse_resolver/languages/go.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/go.py
@@ -1,0 +1,149 @@
+"""Go callee resolver (RFC-0010, first wave).
+
+Self-contained and SAFE — it REPLACES the Python cascade for Go callers, so
+its only jobs are:
+
+1. **local** — resolve a same-file ``func``/method call against the caller
+   file's own symbols (same-language by construction → no cross-language
+   binding is even possible).
+2. **stdlib** — classify a package-qualified call (``fmt.Println``,
+   ``strings.Split``) when the qualifier is a conservative canonical stdlib
+   package name AND the project does not itself define that name (shadowing
+   preserved). See :mod:`._go_constants`.
+3. **unknown** — everything else: receiver method calls (``s.Run()`` — the
+   receiver is a variable whose struct type the edge does not carry, so we
+   never guess), third-party package calls, and any unresolved bare name.
+
+THE MOAT (never cross-language bind): the resolver only ever consults the
+caller file's own ``file_symbols`` for a ``local`` match and never looks up a
+symbol in another file, so a same-name symbol in a different language's file
+can never be bound. Package-qualified calls resolve to ``stdlib``/``unknown``
+only — never to a project file.
+
+The cascade returns a plain ``(symbol_id, resolution, resolved_file)`` tuple;
+the package ``__init__`` wraps it into a ``ResolvedCallee``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .._registry import register_language
+from ._go_constants import STDLIB_PACKAGES_GO
+
+
+@dataclass
+class GoResolverContext:
+    """Per-index Go resolution maps (built once per pass).
+
+    File keys are project-relative paths, matching the ``edges`` table.
+    """
+
+    # file -> [(name, kind, symbol_id), ...] (shared cross-language map; we
+    # only ever read the CALLER file's own entry, never another file's).
+    file_symbols: dict[str, list[tuple[str, str, int]]] = field(default_factory=dict)
+    # set of names the project defines anywhere — used to let a project symbol
+    # SHADOW a stdlib package qualifier (precision over recall).
+    project_names: frozenset[str] = field(default_factory=frozenset)
+
+
+def build_go_resolver_context(
+    *,
+    imports_by_file: dict[str, Any],
+    file_languages: dict[str, str],
+    file_symbols: dict[str, Any],
+    global_name_table: dict[str, Any],
+    file_class_methods: Any,  # zero-arg thunk -> class->method map (lazy; unused)
+    **_ignored: Any,
+) -> GoResolverContext | None:
+    """Build the Go context, or ``None`` when no Go file is indexed.
+
+    Zero cost for non-Go projects (gated on ``file_languages``). ``file_symbols``
+    is the shared cross-language map; the resolver reads only the caller file's
+    own entry, so carrying the full map is safe. The class-method thunk is not
+    needed (Go receiver types are not inferable from the edge), so it is never
+    called — preserving the lazy "pay nothing if you opt out early" property.
+    """
+    if not any(lang == "go" for lang in file_languages.values()):
+        return None
+    # Project-defined names that may SHADOW a stdlib package qualifier. Union
+    # the global name table with the per-file symbol names so shadowing is
+    # detected regardless of which map a caller populated (the production build
+    # fills both; a direct unit build may pass only file_symbols).
+    project_names = set(global_name_table)
+    for symbols in file_symbols.values():
+        for name, _kind, _sym_id in symbols:
+            project_names.add(name)
+    return GoResolverContext(
+        file_symbols=file_symbols,
+        project_names=frozenset(project_names),
+    )
+
+
+def _split_receiver(callee_full: str, callee_name: str) -> tuple[str, str]:
+    """Return ``(qualifier, simple_name)`` from a Go call's full name.
+
+    ``fmt.Println`` -> ``("fmt", "Println")``; ``s.Run`` -> ``("s", "Run")``;
+    bare ``helper`` -> ``("", "helper")``. For a multi-segment receiver only
+    the LAST dotted segment is the call name; the qualifier is everything
+    before it (e.g. ``a.b.C`` -> ``("a.b", "C")``).
+    """
+    full = callee_full or callee_name
+    if "." in full:
+        qualifier, simple = full.rsplit(".", 1)
+        return qualifier, simple
+    return "", full or callee_name
+
+
+def _lookup_in_file(ctx: GoResolverContext, file_path: str, simple: str) -> int | None:
+    """Find a same-file symbol id for ``simple`` in ``file_path`` only."""
+    for name, kind, sym_id in ctx.file_symbols.get(file_path, []):
+        if name == simple and kind in ("function", "method", "class"):
+            return sym_id
+    return None
+
+
+def resolve_go_callee(
+    callee_name: str,
+    callee_full: str,
+    caller_file: str,
+    ctx: GoResolverContext,
+) -> tuple[int | None, str, str]:
+    """Resolve one Go call edge.
+
+    Returns ``(symbol_id, resolution, resolved_file)`` where ``resolution`` is
+    one of ``local`` / ``stdlib`` / ``unknown``. Conservative by design: when
+    unsure, ``unknown`` is the correct (moat-safe) answer.
+    """
+    qualifier, simple = _split_receiver(callee_full, callee_name)
+
+    # 1. local — a bare call (no qualifier) defined in the CALLER file itself.
+    #    Same file == same language, so this can never cross-bind.
+    if not qualifier:
+        sym_id = _lookup_in_file(ctx, caller_file, simple)
+        if sym_id is not None:
+            return sym_id, "local", caller_file
+        # Bare name not defined in the caller file: do NOT guess a project-wide
+        # match (could collide across files/languages). Stay unknown.
+        return None, "unknown", ""
+
+    # 2. stdlib — a package-qualified call whose package head is a conservative
+    #    canonical stdlib package AND is not shadowed by a project symbol.
+    head = qualifier.split(".", 1)[0]
+    if head in STDLIB_PACKAGES_GO and head not in ctx.project_names:
+        return None, "stdlib", ""
+
+    # 3. unknown — receiver method calls (``s.Run`` — type not inferable),
+    #    third-party packages, shadowed names. Never guess.
+    return None, "unknown", ""
+
+
+register_language("go", build_go_resolver_context, resolve_go_callee)
+
+
+__all__ = [
+    "GoResolverContext",
+    "build_go_resolver_context",
+    "resolve_go_callee",
+]


### PR DESCRIPTION
## Summary

First-wave RFC-0010 per-language callee resolver for **Go** (`.go`). Self-contained, conservative, and **new-files-only** — it plugs into the registry via `languages/` auto-discovery, so **zero existing files are edited** (no merge-conflict / worktree-race surface for parallel language teams).

Three new files:
- `tree_sitter_analyzer/synapse_resolver/languages/go.py` — the resolver + `register_language("go", ...)`.
- `tree_sitter_analyzer/synapse_resolver/languages/_go_constants.py` — conservative classification tiers.
- `tests/unit/test_go_method_resolution.py` — RED-first tests.

## Resolution behaviour

| Go call shape | Example | Resolution |
|---|---|---|
| same-file `func`/method (bare) | `helper()` | `local` (caller file only) |
| stdlib package-qualified | `fmt.Println`, `strings.ToUpper` | `stdlib` |
| third-party package | `redis.NewClient` | `unknown` (conservative) |
| receiver method (var receiver) | `s.Run()` | `unknown` (type not inferable) |
| shadowed stdlib name | project defines `fmt` → `fmt.X` | `unknown` (precision) |

End-to-end re-index dogfood confirms exactly this on a polyglot fixture.

## The moat — never cross-language bind

The resolver only ever consults the **caller file's own** `file_symbols` for a `local` match and never looks up a symbol in another file, so a same-name symbol in a different language's file can **never** be bound. Package-qualified calls resolve to `stdlib`/`unknown` only — never to a project file. Covered by both a direct and an end-to-end **no-cross-language-mis-wire** test (a Go `strings.ToUpper` / bare `helper` never binds to a Python `ToUpper`/`helper`).

## Conservative tiers (RFC-0008 lesson)

`STDLIB_PACKAGES_GO` is a small hand-audited set of canonical Go stdlib package names; classification is by **package qualifier**, not bare method name (far more reliable for Go), and only when the project does not shadow the name. `EXTERNAL_PACKAGES_GO` is **intentionally empty** for this first PR — precision over recall; everything non-stdlib stays `unknown`.

## Verification

- `tests/unit/test_go_method_resolution.py` — 15 tests green; RED verified by reverting the stdlib branch (4 fail) and restoring (15 green).
- `tests/unit/test_resolver_registry.py` + `tests/unit/test_java_method_resolution.py` — 18 green (auto-discovery imports the Go module; no regression).
- `ruff check` + `ruff format --check` + `mypy` clean on the new files (and all pre-commit hooks pass).
- `git show --stat HEAD` confirms only the 3 new files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)