### PR TITLE
feat(resolver): conservative Ruby callee resolver (RFC-0010 second wave)

### DIFF
--- a/tests/unit/test_ruby_method_resolution.py
+++ b/tests/unit/test_ruby_method_resolution.py
@@ -1,0 +1,383 @@
+"""RFC-0010 second wave: Ruby per-language callee resolver.
+
+Unit-level tests that drive ``resolve_ruby_callee`` against a hand-built context
+(no full index needed). They assert the four guarantees of a SAFE,
+self-contained resolver:
+
+* same-file ``local`` resolution from ``file_symbols`` / ``file_class_methods``
+  (Ruby ``self`` IS the current object, so ``self.foo`` binds via the
+  single-class gate; bare ``foo`` binds via the flat top-level scan),
+* CONSERVATIVE ``builtin`` classification on the FULL dotted call name only,
+* ``project`` resolution gated to Ruby, and
+* the MOAT: a callee whose name also exists in another language's file must
+  NEVER bind to that file — it stays ``unknown`` (or the Ruby same-file def).
+"""
+
+from __future__ import annotations
+
+from tree_sitter_analyzer.synapse_resolver._registry import (
+    get_language_resolver,
+    registered_languages,
+)
+from tree_sitter_analyzer.synapse_resolver.languages.ruby import (
+    build_ruby_context,
+    resolve_ruby_callee,
+)
+
+
+def _ctx(
+    *,
+    file_symbols=None,
+    file_class_methods=None,
+    global_name_table=None,
+    file_languages=None,
+):
+    """Build a Ruby resolver context from explicit maps (thunk-style fcm)."""
+    return build_ruby_context(
+        imports_by_file={},
+        file_languages=file_languages or {},
+        file_symbols=file_symbols or {},
+        global_name_table=global_name_table or {},
+        file_class_methods=lambda: file_class_methods or {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# registration / discovery
+# ---------------------------------------------------------------------------
+def test_ruby_is_registered() -> None:
+    assert "ruby" in registered_languages()
+    assert get_language_resolver("ruby") is not None
+
+
+# ---------------------------------------------------------------------------
+# gating — zero cost for non-Ruby projects
+# ---------------------------------------------------------------------------
+def test_build_returns_none_when_no_ruby_file_indexed() -> None:
+    ctx = build_ruby_context(
+        imports_by_file={},
+        file_languages={"a.py": "python", "B.java": "java"},
+        file_symbols={},
+        global_name_table={},
+        file_class_methods=lambda: (_ for _ in ()).throw(
+            AssertionError("thunk must NOT be forced for a non-Ruby index")
+        ),
+    )
+    assert ctx is None
+
+
+def test_build_returns_context_when_ruby_file_indexed() -> None:
+    ctx = _ctx(file_languages={"app.rb": "ruby"})
+    assert ctx is not None
+
+
+# ---------------------------------------------------------------------------
+# local — same-file resolution
+# ---------------------------------------------------------------------------
+def test_bare_call_to_same_file_function_is_local() -> None:
+    ctx = _ctx(
+        file_languages={"app.rb": "ruby"},
+        file_symbols={"app.rb": [("helper", "function", 7)]},
+    )
+    assert resolve_ruby_callee("helper", "helper", "app.rb", ctx) == (
+        7,
+        "local",
+        "app.rb",
+    )
+
+
+def test_bare_call_does_not_bind_to_same_file_method() -> None:
+    """A bare ``render`` (no receiver) in a file whose only same-name symbol is a
+    class METHOD must NOT bind: a method needs an owning receiver, and in a
+    multi-class file the flat ``file_symbols`` scan cannot prove the method
+    belongs to the caller's class. A bare same-file call binds only a top-level
+    ``function``."""
+    ctx = _ctx(
+        file_languages={"app.rb": "ruby"},
+        file_symbols={
+            "app.rb": [("run", "method", 1), ("render", "method", 2)],
+        },
+        file_class_methods={"app.rb": {"A": {"run": 1}, "B": {"render": 2}}},
+    )
+    assert resolve_ruby_callee("render", "render", "app.rb", ctx) == (
+        None,
+        "unknown",
+        "",
+    )
+
+
+def test_unknown_bare_name_stays_unknown() -> None:
+    """A bare call with no same-file def and no project owner stays ``unknown``
+    (conservative) — never leaks into the Python cascade as a builtin."""
+    ctx = _ctx(file_languages={"app.rb": "ruby"})
+    assert resolve_ruby_callee("puts", "puts", "app.rb", ctx) == (
+        None,
+        "unknown",
+        "",
+    )
+
+
+# ---------------------------------------------------------------------------
+# local — self.<method> (Ruby self IS the current object)
+# ---------------------------------------------------------------------------
+def test_self_method_call_is_local_via_class_methods() -> None:
+    """In Ruby ``self`` is the current object, so ``self.render`` in a single-class
+    file resolves ``local`` (unlike JS, where ``self`` is the global scope)."""
+    ctx = _ctx(
+        file_languages={"app.rb": "ruby"},
+        file_class_methods={"app.rb": {"Widget": {"render": 11}}},
+    )
+    assert resolve_ruby_callee("render", "self.render", "app.rb", ctx) == (
+        11,
+        "local",
+        "app.rb",
+    )
+
+
+def test_self_method_does_not_bind_across_sibling_classes() -> None:
+    """``class A; def run; self.render; end; end; class B; def render; end; end``.
+    The caller ``A#run`` does NOT define ``render``; only the SIBLING class ``B``
+    does. Without the caller's enclosing class we cannot prove ``self.render`` is
+    a call on ``A``, so binding it to ``B#render`` is a concrete wrong edge. With
+    two+ classes in the file, ``self.<method>`` must stay ``unknown``."""
+    ctx = _ctx(
+        file_languages={"app.rb": "ruby"},
+        file_class_methods={
+            "app.rb": {"A": {"run": 1}, "B": {"render": 2}},
+        },
+    )
+    assert resolve_ruby_callee("render", "self.render", "app.rb", ctx) == (
+        None,
+        "unknown",
+        "",
+    )
+
+
+def test_self_method_does_not_bind_sibling_via_file_symbols() -> None:
+    """Real resolver contexts populate ``file_symbols`` with EVERY method in the
+    file, including sibling-class methods. A ``self.``-qualified call is a METHOD
+    call; it must NOT short-circuit through the flat same-file symbol lookup.
+    With 2+ classes it stays ``unknown``."""
+    ctx = _ctx(
+        file_languages={"app.rb": "ruby"},
+        file_symbols={
+            "app.rb": [("run", "method", 1), ("render", "method", 2)],
+        },
+        file_class_methods={
+            "app.rb": {"A": {"run": 1}, "B": {"render": 2}},
+        },
+    )
+    assert resolve_ruby_callee("render", "self.render", "app.rb", ctx) == (
+        None,
+        "unknown",
+        "",
+    )
+
+
+def test_self_method_single_class_binds_even_with_flat_symbols() -> None:
+    """The single-class case must still bind via ``file_class_methods`` even when
+    the flat ``file_symbols`` row for the method is present — proving the bind
+    comes from the unambiguous class path, not the flat scan."""
+    ctx = _ctx(
+        file_languages={"app.rb": "ruby"},
+        file_symbols={"app.rb": [("render", "method", 11)]},
+        file_class_methods={"app.rb": {"Widget": {"render": 11}}},
+    )
+    assert resolve_ruby_callee("render", "self.render", "app.rb", ctx) == (
+        11,
+        "local",
+        "app.rb",
+    )
+
+
+# ---------------------------------------------------------------------------
+# builtin — namespaced core calls, full-name match only
+# ---------------------------------------------------------------------------
+def test_namespaced_builtin_classifies_as_builtin() -> None:
+    ctx = _ctx(file_languages={"app.rb": "ruby"})
+    assert resolve_ruby_callee("sqrt", "Math.sqrt", "app.rb", ctx) == (
+        None,
+        "builtin",
+        "",
+    )
+    assert resolve_ruby_callee("sin", "Math.sin", "app.rb", ctx) == (
+        None,
+        "builtin",
+        "",
+    )
+
+
+def test_bare_builtin_method_name_is_not_builtin() -> None:
+    """A bare ``sqrt`` (no namespace) must NOT classify as builtin — every domain
+    object can define such names; only the dotted form is safe."""
+    ctx = _ctx(file_languages={"app.rb": "ruby"})
+    assert resolve_ruby_callee("sqrt", "sqrt", "app.rb", ctx) == (
+        None,
+        "unknown",
+        "",
+    )
+    # ``vec.log(...)`` — a domain method, not Math.log — stays unknown.
+    assert resolve_ruby_callee("log", "vec.log", "app.rb", ctx) == (
+        None,
+        "unknown",
+        "",
+    )
+
+
+def test_puts_is_not_builtin() -> None:
+    """``puts`` is a ubiquitous bare ``Kernel`` name that every object/DSL can
+    define; deliberately not in the builtin tier, so it stays ``unknown``."""
+    ctx = _ctx(file_languages={"app.rb": "ruby"})
+    assert resolve_ruby_callee("puts", "Kernel.puts", "app.rb", ctx) == (
+        None,
+        "unknown",
+        "",
+    )
+
+
+def test_project_shadow_of_builtin_receiver_suppresses_builtin() -> None:
+    """If the project owns a Ruby constant literally named ``Math``, ``Math.sqrt``
+    is no longer a safe builtin — it could be the project's Math."""
+    ctx = _ctx(
+        file_languages={"geo.rb": "ruby"},
+        global_name_table={"Math": [("geo.rb", 3)]},
+    )
+    _sid, res, _ = resolve_ruby_callee("sqrt", "Math.sqrt", "geo.rb", ctx)
+    assert res != "builtin"
+
+
+# ---------------------------------------------------------------------------
+# project — single Ruby global
+# ---------------------------------------------------------------------------
+def test_single_ruby_global_resolves_to_project() -> None:
+    ctx = _ctx(
+        file_languages={"a.rb": "ruby", "b.rb": "ruby"},
+        global_name_table={"compute": [("b.rb", 99)]},
+        file_symbols={"b.rb": [("compute", "function", 99)]},
+    )
+    assert resolve_ruby_callee("compute", "compute", "a.rb", ctx) == (
+        99,
+        "project",
+        "b.rb",
+    )
+
+
+def test_bare_call_does_not_bind_to_a_method_global() -> None:
+    """A BARE ``render`` (no receiver) cannot call a class METHOD — methods need
+    an owning receiver. The lone Ruby owner of ``render`` here is a *method* on a
+    class in another file, so the bare call must NOT bind to it; it stays
+    ``unknown`` rather than wiring a wrong cross-file edge."""
+    ctx = _ctx(
+        file_languages={"a.rb": "ruby", "widget.rb": "ruby"},
+        global_name_table={"render": [("widget.rb", 50)]},
+        file_symbols={"widget.rb": [("render", "method", 50)]},
+    )
+    assert resolve_ruby_callee("render", "render", "a.rb", ctx) == (
+        None,
+        "unknown",
+        "",
+    )
+
+
+def test_bare_call_does_not_bind_to_a_class_global() -> None:
+    """A bare ``Widget`` whose only owner is a *class* is a constant reference, not
+    a plain call; conservatively it is not a bare-callable project target, so it
+    stays ``unknown`` rather than binding to the class symbol."""
+    ctx = _ctx(
+        file_languages={"a.rb": "ruby", "widget.rb": "ruby"},
+        global_name_table={"Widget": [("widget.rb", 60)]},
+        file_symbols={"widget.rb": [("Widget", "class", 60)]},
+    )
+    assert resolve_ruby_callee("Widget", "Widget", "a.rb", ctx) == (
+        None,
+        "unknown",
+        "",
+    )
+
+
+def test_bare_call_binds_to_a_function_global() -> None:
+    """The complement: a bare call whose lone Ruby owner is a top-level
+    *function* IS a valid bare-callable project target and binds."""
+    ctx = _ctx(
+        file_languages={"a.rb": "ruby", "util.rb": "ruby"},
+        global_name_table={"compute": [("util.rb", 70)]},
+        file_symbols={"util.rb": [("compute", "function", 70)]},
+    )
+    assert resolve_ruby_callee("compute", "compute", "a.rb", ctx) == (
+        70,
+        "project",
+        "util.rb",
+    )
+
+
+def test_ambiguous_global_stays_unknown() -> None:
+    """Two Ruby definitions of the same bare name → unknown (no guess)."""
+    ctx = _ctx(
+        file_languages={"a.rb": "ruby", "b.rb": "ruby", "c.rb": "ruby"},
+        global_name_table={"compute": [("b.rb", 1), ("c.rb", 2)]},
+        file_symbols={
+            "b.rb": [("compute", "function", 1)],
+            "c.rb": [("compute", "function", 2)],
+        },
+    )
+    assert resolve_ruby_callee("compute", "compute", "a.rb", ctx) == (
+        None,
+        "unknown",
+        "",
+    )
+
+
+# ---------------------------------------------------------------------------
+# THE MOAT — mandatory no-cross-language-mis-wire test
+# ---------------------------------------------------------------------------
+def test_no_cross_language_mis_wire_global() -> None:
+    """A bare callee whose ONLY project definition lives in a Python file must
+    NOT bind to that Python file — it stays ``unknown``. (Same name, foreign
+    language: the exact CodeGraph failure this project exists to beat.)"""
+    ctx = _ctx(
+        file_languages={"a.rb": "ruby", "util.py": "python"},
+        # ``parse`` is defined ONLY in Python — a Ruby caller must not bind it.
+        global_name_table={"parse": [("util.py", 42)]},
+        file_symbols={"util.py": [("parse", "function", 42)]},
+    )
+    assert resolve_ruby_callee("parse", "parse", "a.rb", ctx) == (
+        None,
+        "unknown",
+        "",
+    )
+
+
+def test_no_cross_language_mis_wire_prefers_ruby_same_name() -> None:
+    """When the name exists in BOTH a Ruby file and a foreign file, only the Ruby
+    definition is eligible — the resolver binds the Ruby one, never the foreign
+    file, and never reports the foreign file as the target."""
+    ctx = _ctx(
+        file_languages={
+            "a.rb": "ruby",
+            "b.rb": "ruby",
+            "Service.java": "java",
+        },
+        global_name_table={"handle": [("b.rb", 8), ("Service.java", 100)]},
+        file_symbols={
+            "b.rb": [("handle", "function", 8)],
+            "Service.java": [("handle", "method", 100)],
+        },
+    )
+    sid, res, target = resolve_ruby_callee("handle", "handle", "a.rb", ctx)
+    # Exactly one Ruby owner (b.rb) → bound; the Java file is filtered out.
+    assert (sid, res, target) == (8, "project", "b.rb")
+    assert target != "Service.java"
+
+
+def test_no_cross_language_builtin_suppression_ignores_foreign_owner() -> None:
+    """A foreign-language symbol named ``Math`` must NOT suppress the Ruby builtin
+    ``Math.sqrt`` — only a Ruby ``Math`` shadows it."""
+    ctx = _ctx(
+        file_languages={"app.rb": "ruby", "Math.java": "java"},
+        global_name_table={"Math": [("Math.java", 1)]},
+    )
+    assert resolve_ruby_callee("sqrt", "Math.sqrt", "app.rb", ctx) == (
+        None,
+        "builtin",
+        "",
+    )

--- a/tree_sitter_analyzer/synapse_resolver/languages/_ruby_constants.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/_ruby_constants.py
@@ -1,0 +1,70 @@
+"""Conservative builtin name tier for the Ruby resolver (RFC-0010 second wave).
+
+These literal sets live outside the resolver logic so the resolver module stays
+small and the tables are auditable in isolation.
+
+CURATION RULE — PRECISION over recall (the RFC-0008 Java lesson, applied to
+Ruby). Ruby method names are *extremely* overloaded: ``puts``, ``require``,
+``raise``, ``new``, ``call``, ``each``, ``map``, ``to_s`` and friends are
+defined or re-opened by every gem, DSL, and domain object. Ruby's open classes
+and ubiquitous monkey-patching mean even a "core" bare name carries NO proof
+that a given call hits the core API rather than a user redefinition. The Ruby
+resolver has no receiver-type evidence and no symbol-level import graph
+(``require`` loads *files*, not named symbols), so the only thing it can prove
+is the FULL dotted call name.
+
+Therefore a call is KEPT in the ``builtin`` tier ONLY if it is a **dotted,
+namespaced call whose receiver is a Ruby core module that user code almost never
+re-creates with the SAME method** — currently the ``Math`` module's pure
+numeric helpers (``Math.sqrt``, ``Math.sin`` …). ``Math`` is a frozen core
+module; a domain object literally named ``Math`` carrying ``sqrt``/``sin`` is
+vanishingly rare, and these calls are near-exclusively the core API.
+
+DELIBERATELY EXCLUDED (an EMPTY tier for these is correct):
+  * Bare ``puts`` / ``print`` / ``p`` / ``require`` / ``require_relative`` /
+    ``raise`` / ``loop`` / ``freeze`` / ``new`` / ``call`` — bare ``Kernel``/
+    core names with no namespace; every object can define them, and a bare name
+    carries no proof it is the core method (it may be a same-file private
+    method, which the ``local`` tier handles, or a user override).
+  * ``File.*`` / ``JSON.*`` / ``Time.*`` / ``Hash.*`` / ``Array.*`` — ``File``,
+    ``JSON``, ``Time`` etc. are commonly shadowed by domain constants, gems
+    (``require 'json'`` swaps implementations), and Rails/ActiveSupport
+    re-openings, so the FULL name is not near-exclusively the core API.
+
+Matching is on the FULL dotted call name (``<receiver>.<method>``), never on the
+bare method name. An empty match is acceptable: everything that is not a
+recognised namespaced core call stays ``local`` (same-file) or ``unknown`` —
+never mis-classified into another language's file.
+"""
+
+from __future__ import annotations
+
+# Namespaced Ruby core calls. The KEY is the exact dotted call name
+# (receiver + "." + method) as it appears in a call edge's full name; only an
+# exact full-name match classifies as ``builtin``. Restricted to the ``Math``
+# core module: a frozen module of pure numeric helpers that user code almost
+# never re-creates with the same method name. The instance/bare forms of any of
+# these names (``round`` on a Float, a bare ``sqrt``) are NOT here — only the
+# ``Math.``-namespaced static forms.
+RUBY_BUILTIN_CALLS: frozenset[str] = frozenset(
+    {
+        "Math.sqrt",
+        "Math.cbrt",
+        "Math.sin",
+        "Math.cos",
+        "Math.tan",
+        "Math.asin",
+        "Math.acos",
+        "Math.atan",
+        "Math.atan2",
+        "Math.exp",
+        "Math.log",
+        "Math.log2",
+        "Math.log10",
+        "Math.hypot",
+        "Math.pow",
+    }
+)
+
+
+__all__ = ["RUBY_BUILTIN_CALLS"]

--- a/tree_sitter_analyzer/synapse_resolver/languages/ruby.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/ruby.py
@@ -1,0 +1,248 @@
+"""Ruby callee resolver (RFC-0010 second wave).
+
+A self-contained, SAFE per-language resolver for ``.rb`` files. It REPLACES the
+generic Python cascade for Ruby callers, so it must not regress: when unsure, it
+returns ``unknown`` (never a wrong binding).
+
+What it resolves:
+
+* **local** — a same-file call whose simple name is defined in the caller file.
+  Two distinct same-scope forms, each by a SEPARATE path:
+    * a bare ``foo`` / ``foo()`` call (no receiver) → a top-level ``function``
+      (module/private method) defined in the caller file, via the flat
+      ``file_symbols`` scan.
+    * ``self.foo`` — a method call on the caller's own object. Bound ONLY through
+      the unambiguous single-class gate (``file_class_methods`` with exactly one
+      class), so ``self.render`` never binds to a sibling class's ``render``.
+* **project** — a bare name with exactly ONE project-wide definition that lives
+  in a Ruby file, AND that definition is a bare-callable kind (a top-level
+  ``function``). The single-global rule, gated by language so a same-named
+  Python/Java symbol is never bound.
+* **builtin** — a namespaced Ruby core call (``Math.sqrt`` …) matched on the
+  FULL dotted call name. Terminal — outside the project, never re-scanned.
+  Suppressed when the project itself owns the receiver name in a Ruby file.
+* **unknown** — everything else (the conservative default).
+
+THE MOAT — this resolver NEVER binds a callee to a symbol in a non-Ruby file.
+Cross-language same-name collisions resolve to ``unknown`` (or the Ruby
+same-file definition), never to the foreign file. That is the exact CodeGraph
+failure this project exists to beat.
+
+Ruby vs JavaScript note: in Ruby ``self`` IS the current object (so ``self.foo``
+is the canonical same-object method call, handled like Java's ``this``). Ruby
+has no ``this`` keyword. ``require`` / ``require_relative`` load *files*, not
+named symbols, so there is no symbol-level import tier — method resolution is
+purely local / single-global / namespaced-core, which is why this resolver is
+shaped on the JavaScript resolver rather than the import-driven Java one.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..._language_family import languages_compatible
+from .._registry import register_language
+from ._ruby_constants import RUBY_BUILTIN_CALLS
+
+#: The language tag the detector assigns to ``.rb`` files. Ruby is NOT part of
+#: any interop family (see ``_language_family._LANGUAGE_FAMILIES``), so the
+#: ownership / project gates only ever bind to another ``"ruby"`` file — the
+#: moat is enforced by ``languages_compatible("ruby", owner_lang)`` returning
+#: True only for ``"ruby"`` (or empty/unknown).
+_RUBY_LANG = "ruby"
+
+#: Symbol kinds that a BARE call (no receiver) can legally target. A top-level
+#: ``function`` (a Ruby module method / top-level ``def`` / private method) is
+#: callable bare; a class ``method`` is NOT a valid bare-call target across
+#: files (it needs an owning receiver), and a ``class``/``module`` used bare is
+#: a constant reference, not a plain call. ``global_name_table`` drops the kind,
+#: so the project tier cross-checks ``file_symbols`` and only binds a
+#: bare-callable kind — otherwise ``render`` wires to a same-named method
+#: elsewhere (the JS resolver's Codex P2 #346 lesson, applied to Ruby).
+_BARE_CALLABLE_KINDS: frozenset[str] = frozenset({"function"})
+
+
+class RubyResolverContext:
+    """Per-index Ruby resolution maps (built once per pass).
+
+    Holds only the shared cross-language maps the resolver consults. All file
+    keys are project-relative paths, matching the ``edges`` table.
+    """
+
+    __slots__ = (
+        "file_symbols",
+        "file_class_methods",
+        "global_name_table",
+        "file_languages",
+    )
+
+    def __init__(
+        self,
+        *,
+        file_symbols: dict[str, list[tuple[str, str, int]]],
+        file_class_methods: dict[str, dict[str, dict[str, int]]],
+        global_name_table: dict[str, list[tuple[str, int]]],
+        file_languages: dict[str, str],
+    ) -> None:
+        self.file_symbols = file_symbols
+        self.file_class_methods = file_class_methods
+        self.global_name_table = global_name_table
+        self.file_languages = file_languages
+
+
+def build_ruby_context(
+    *,
+    imports_by_file: dict[str, Any],
+    file_languages: dict[str, str],
+    file_symbols: dict[str, Any],
+    global_name_table: dict[str, Any],
+    file_class_methods: Any,  # lazy thunk -> class->method map
+    **_ignored: Any,
+) -> RubyResolverContext | None:
+    """Build the Ruby context, or ``None`` when no ``.rb`` file is indexed.
+
+    Zero cost for non-Ruby projects: gated on ``file_languages`` BEFORE the lazy
+    ``file_class_methods`` thunk is forced, so a Python/Java-only index never
+    pays to materialise the class-method map for Ruby.
+    """
+    if not any(lang == _RUBY_LANG for lang in file_languages.values()):
+        return None
+    fcm = file_class_methods() if callable(file_class_methods) else file_class_methods
+    return RubyResolverContext(
+        file_symbols=file_symbols,
+        file_class_methods=fcm or {},
+        global_name_table=global_name_table,
+        file_languages=file_languages,
+    )
+
+
+def _split_receiver(full_name: str, bare_name: str) -> tuple[str, str]:
+    """Return ``(receiver, simple_name)`` from a Ruby call's full name."""
+    full = full_name or bare_name
+    if "." in full:
+        receiver, simple = full.rsplit(".", 1)
+        return receiver, simple
+    return "", full or bare_name
+
+
+def _lookup_in_file(
+    ctx: RubyResolverContext, file_path: str, simple: str
+) -> int | None:
+    """Symbol id of a same-file BARE-CALLABLE named ``simple`` in ``file_path``.
+
+    Restricted to a top-level ``function`` (see ``_BARE_CALLABLE_KINDS``): a bare
+    ``foo`` is the only same-scope form routed here, and a bare call cannot
+    target a class ``method`` (it needs an owning receiver). Real resolver
+    contexts populate ``file_symbols`` with EVERY method in the file, so matching
+    ``method`` here would bind a bare ``render`` to a sibling class's method — a
+    concrete wrong edge. ``self.<method>`` is bound separately through the
+    unambiguous single-class gate, not here.
+    """
+    for name, kind, sym_id in ctx.file_symbols.get(file_path, []):
+        if name == simple and kind in _BARE_CALLABLE_KINDS:
+            return sym_id
+    return None
+
+
+def _owner_kind(ctx: RubyResolverContext, owner_file: str, sym_id: int) -> str:
+    """Kind (``function``/``method``/``class``) of ``sym_id`` in ``owner_file``.
+
+    Recovered from ``file_symbols`` because the shared ``global_name_table``
+    carries only ``(file, id)`` and drops the kind. Returns ``""`` when the owner
+    row is not present (so the caller treats it conservatively).
+    """
+    for _name, kind, sid in ctx.file_symbols.get(owner_file, []):
+        if sid == sym_id:
+            return kind
+    return ""
+
+
+def _ruby_project_owns(ctx: RubyResolverContext, simple: str) -> bool:
+    """True when a RUBY project symbol is named ``simple``.
+
+    Language-aware ownership gate: a same-named symbol in an incompatible
+    language (a Python ``sqrt``, a Java ``log``) does NOT count, so it can never
+    suppress a builtin classification. Ruby is in no interop family, so only a
+    ``"ruby"`` owner (or an empty/unknown tag) qualifies — the moat.
+    """
+    for owner_file, _sym_id in ctx.global_name_table.get(simple, []):
+        owner_lang = ctx.file_languages.get(owner_file, "")
+        if languages_compatible(_RUBY_LANG, owner_lang):
+            return True
+    return False
+
+
+def resolve_ruby_callee(
+    bare_name: str,
+    full_name: str,
+    caller_file: str,
+    lang_ctx: RubyResolverContext,
+) -> tuple[int | None, str, str]:
+    """Resolve one Ruby call edge.
+
+    Returns ``(symbol_id, resolution, resolved_file)`` where ``resolution`` is
+    one of ``local`` / ``project`` / ``builtin`` / ``unknown``. Conservative by
+    construction: anything not provably one of the first three is ``unknown``.
+    """
+    ctx = lang_ctx
+    receiver, simple = _split_receiver(full_name, bare_name)
+
+    # 1. local — a call into the caller's own file. The two same-scope forms are
+    #    resolved by SEPARATE paths because they have different binding rules:
+    #
+    #    * bare ``foo`` (no receiver) — never a cross-receiver method call, so
+    #      the flat ``file_symbols`` scan is safe: it can only legitimately hit a
+    #      same-file top-level ``function`` (a module/private method).
+    #    * ``self.foo`` — a METHOD call on the caller's own object. In Ruby
+    #      ``self`` IS the current object, but a flat ``file_symbols`` scan must
+    #      NOT be used: real contexts populate ``file_symbols`` with EVERY method
+    #      in the file (sibling classes included), so a flat lookup of
+    #      ``self.render`` from ``A#run`` would find a SIBLING ``B#render`` and
+    #      bind a concrete wrong edge. It may bind ONLY through
+    #      ``file_class_methods`` AND only when the file defines exactly ONE class
+    #      (so ``self`` is unambiguous). With 2+ classes we lack the caller's
+    #      enclosing class → stay ``unknown``.
+    if receiver == "":
+        sym_id = _lookup_in_file(ctx, caller_file, simple)
+        if sym_id is not None:
+            return sym_id, "local", caller_file
+    elif receiver == "self":
+        classes = ctx.file_class_methods.get(caller_file, {})
+        if len(classes) == 1:
+            ((_cls, methods),) = classes.items()
+            mid = methods.get(simple)
+            if mid is not None:
+                return mid, "local", caller_file
+
+    # 2. builtin — a namespaced Ruby core call matched on the FULL dotted name
+    #    (``Math.sqrt`` …). Terminal: outside the project. Suppressed if the
+    #    project itself owns the receiver name in a Ruby file (a domain constant
+    #    literally named ``Math`` shadowing the core module).
+    if receiver:
+        full = full_name or f"{receiver}.{simple}"
+        head = receiver.split(".", 1)[0]
+        if full in RUBY_BUILTIN_CALLS and not _ruby_project_owns(ctx, head):
+            return None, "builtin", ""
+
+    # 3. project — exactly one Ruby project-wide definition of a BARE name, AND
+    #    that definition must be a bare-callable kind (a top-level ``function``).
+    #    A class ``method`` is not callable without a receiver and a bare
+    #    ``class``/``module`` name is a constant reference, not a plain call.
+    #    Gated by language so a same-name Python/Java symbol is never bound (the
+    #    MOAT).
+    if not receiver:
+        ruby_cands = [
+            (owner_file, sym_id)
+            for owner_file, sym_id in ctx.global_name_table.get(simple, [])
+            if languages_compatible(_RUBY_LANG, ctx.file_languages.get(owner_file, ""))
+            and _owner_kind(ctx, owner_file, sym_id) in _BARE_CALLABLE_KINDS
+        ]
+        if len(ruby_cands) == 1:
+            target_file, sym_id = ruby_cands[0]
+            return sym_id, "project", target_file
+
+    # 4. unknown — the conservative default. Never a cross-language binding.
+    return None, "unknown", ""
+
+
+register_language(_RUBY_LANG, build_ruby_context, resolve_ruby_callee)


### PR DESCRIPTION
## Summary

New-files-only per-language **Ruby** callee resolver for RFC-0010's second wave. It replaces the generic Python cascade for `.rb` callers with a SAFE, self-contained resolver that never regresses — `unknown` when unsure, never a wrong binding.

Auto-discovered via `languages/__init__` (pkgutil) — **no existing file is edited**, so it lands without merge conflicts or worktree races alongside the other second-wave language PRs.

## Resolution tiers

| Tier | Rule |
|---|---|
| **local** | bare `foo()` → same-file top-level `function` (via `file_symbols`); `self.foo` → single-class gate. In Ruby `self` IS the current object (handled like Java's `this`), so `self.foo` binds only when the file defines exactly ONE class — never to a sibling class's method. |
| **project** | a bare name with exactly ONE Ruby-family project definition of a bare-callable kind (top-level `function`). Class/method/module globals are excluded (need a receiver / are constants). |
| **builtin** | namespaced Ruby-core call matched on the FULL dotted name. **Restricted to the frozen `Math` module** (`Math.sqrt`, `Math.sin`, …) — precision over recall per RFC-0008. Suppressed when the project owns the receiver name in a Ruby file. |
| **unknown** | conservative default. |

## THE MOAT (the #1 requirement)

This resolver **never binds a callee to a symbol in a non-Ruby file**. Ruby is in no interop family, so `languages_compatible("ruby", owner_lang)` only admits another `ruby` (or empty/unknown) owner. A same-name Python/Java symbol stays `unknown`. The mandatory no-cross-language-mis-wire test (`test_no_cross_language_mis_wire_global` + 2 companions) locks this in.

## Conservative builtin tier rationale

Ruby method names are extremely overloaded (open classes, monkey-patching, DSLs). Bare `puts`/`require`/`raise`/`new`/`each` carry no proof of being the core API, so they are **deliberately excluded** — an empty tier for them is correct. Only the `Math.`-namespaced static forms are kept (a frozen core module user code rarely re-creates with the same method).

## Tests (RED-first)

- 22 unit tests in `tests/unit/test_ruby_method_resolution.py`, including the mandatory cross-language moat tests, the `self`-method single-class / sibling-ambiguity guards, the bare-callable-kind gate, and the builtin shadow-suppression gate.
- RED verified: removing `ruby.py` makes the suite error (`ModuleNotFoundError`).
- Resolver regression green: `uv run pytest tests/ -k 'resolver or synapse or registry'` → 375 passed, 2 skipped (Java byte-parity intact).
- `ruff check` / `ruff format --check` / `mypy` clean on the new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)