### PR TITLE
feat(synapse): SAFE per-language C callee resolver (RFC-0010)

### DIFF
--- a/tests/unit/test_c_method_resolution.py
+++ b/tests/unit/test_c_method_resolution.py
@@ -1,0 +1,507 @@
+"""Unit + integration tests for the C resolver (RFC-0010 second wave).
+
+Covers the conservative cascade in
+``synapse_resolver/languages/c.py``: local same-file resolution, single-global
+project resolution, the conservative libc free-function tier (shadowed by
+project ownership), and — MANDATORY — the no-cross-language-mis-wire moat
+(a callee whose name also exists in a non-C file must NOT bind to that file).
+
+C is simpler than C++: there are no namespaces (no ``std::`` qualifier), no
+member methods to disambiguate by class. A C call is either an unqualified free
+function, a struct field access (``->`` / ``.`` on a value — never a resolvable
+free function), or a libc free function. The moat is also DIRECTIONAL: a C
+caller must NEVER bind to a C++ definition (``languages_compatible('c', 'cpp')``
+is False), while a C caller MAY resolve another C file / C-tagged ``.h`` header.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tree_sitter_analyzer.ast_cache import ASTCache
+from tree_sitter_analyzer.synapse_resolver import ResolverContext, resolve_callee
+from tree_sitter_analyzer.synapse_resolver._context import build_resolver_context
+from tree_sitter_analyzer.synapse_resolver._registry import get_language_resolver
+from tree_sitter_analyzer.synapse_resolver.languages._c_constants import (
+    LIBC_FUNCTIONS_C,
+    is_libc_function,
+)
+from tree_sitter_analyzer.synapse_resolver.languages.c import (
+    CResolverContext,
+    build_c_context,
+    resolve_c_callee,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _build_ctx() -> CResolverContext:
+    """service.c + helper.c, with a same-named Python symbol elsewhere.
+
+    ``helper.c`` defines a project-unique ``compute_total``. ``service.c``
+    defines a local ``run`` and ``parse``. A Python file also defines ``parse``
+    (the cross-language collision used by the moat test). ``malloc`` is a libc
+    function NOT owned by the project.
+    """
+    service = "src/service.c"
+    helper = "src/helper.c"
+    py = "scripts/util.py"
+    file_symbols = {
+        service: [
+            ("run", "function", 2),
+            ("parse", "function", 3),
+        ],
+        helper: [
+            ("compute_total", "function", 11),
+        ],
+        py: [("parse", "function", 99)],
+    }
+    global_name_table = {
+        "run": [(service, 2)],
+        # ``parse`` is defined in BOTH a C file and a Python file — ambiguous
+        # across languages. The C caller must only ever see the C one.
+        "parse": [(service, 3), (py, 99)],
+        # ``compute_total`` is the single project-wide (C) definition.
+        "compute_total": [(helper, 11)],
+        # ``only_python`` lives ONLY in the Python file.
+        "only_python": [(py, 99)],
+    }
+    file_languages = {service: "c", helper: "c", py: "python"}
+    return build_c_context(
+        imports_by_file={},
+        file_languages=file_languages,
+        file_symbols=file_symbols,
+        global_name_table=global_name_table,
+        file_class_methods=lambda: {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_c_context gating
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCContext:
+    def test_returns_none_when_no_c_file(self) -> None:
+        ctx = build_c_context(
+            imports_by_file={},
+            file_languages={"a.py": "python", "b.go": "go"},
+            file_symbols={},
+            global_name_table={},
+            file_class_methods=lambda: {},
+        )
+        assert ctx is None
+
+    def test_builds_when_c_present(self) -> None:
+        ctx = build_c_context(
+            imports_by_file={},
+            file_languages={"a.c": "c"},
+            file_symbols={},
+            global_name_table={},
+            file_class_methods=lambda: {},
+        )
+        assert isinstance(ctx, CResolverContext)
+
+    def test_cpp_only_project_does_not_build_c_context(self) -> None:
+        # A pure-C++ project must NOT spin up a C context: the C resolver only
+        # drives callers whose own file is tagged ``c``.
+        ctx = build_c_context(
+            imports_by_file={},
+            file_languages={"a.cpp": "cpp"},
+            file_symbols={},
+            global_name_table={},
+            file_class_methods=lambda: {},
+        )
+        assert ctx is None
+
+
+# ---------------------------------------------------------------------------
+# libc free-function tier
+# ---------------------------------------------------------------------------
+
+
+class TestLibcTier:
+    def test_malloc_is_stdlib(self) -> None:
+        ctx = _build_ctx()
+        sym, res, f = resolve_c_callee("malloc", "malloc", "src/service.c", ctx)
+        assert (sym, res, f) == (None, "stdlib", "")
+
+    def test_printf_is_stdlib(self) -> None:
+        ctx = _build_ctx()
+        _sym, res, _f = resolve_c_callee("printf", "printf", "src/service.c", ctx)
+        assert res == "stdlib"
+
+    def test_memcpy_is_stdlib(self) -> None:
+        ctx = _build_ctx()
+        _sym, res, _f = resolve_c_callee("memcpy", "memcpy", "src/service.c", ctx)
+        assert res == "stdlib"
+
+    def test_project_shadows_libc_name(self) -> None:
+        """If the project defines a function whose name collides with a libc
+        name, the project owns it — libc classification is suppressed.
+
+        ``compute_total`` is not libc, but to prove shadowing we add a project
+        function named ``malloc`` and confirm it no longer classifies stdlib.
+        """
+        service = "src/service.c"
+        ctx = build_c_context(
+            imports_by_file={},
+            file_languages={service: "c"},
+            file_symbols={service: [("malloc", "function", 7)]},
+            global_name_table={"malloc": [(service, 7)]},
+            file_class_methods=lambda: {},
+        )
+        # Same-file local wins first; the libc tier never even runs here.
+        sym, res, f = resolve_c_callee("malloc", "malloc", service, ctx)
+        assert res == "local"
+        assert sym == 7
+
+    def test_project_shadows_libc_from_other_file(self) -> None:
+        """A project ``malloc`` in ANOTHER C file shadows the libc tier too.
+
+        Called from a third C file with no local ``malloc``: the single-global
+        project tier binds the project definition, NOT libc.
+        """
+        a = "src/a.c"
+        b = "src/b.c"
+        ctx = build_c_context(
+            imports_by_file={},
+            file_languages={a: "c", b: "c"},
+            file_symbols={a: [("malloc", "function", 7)], b: []},
+            global_name_table={"malloc": [(a, 7)]},
+            file_class_methods=lambda: {},
+        )
+        sym, res, f = resolve_c_callee("malloc", "malloc", b, ctx)
+        assert res == "project"
+        assert f == a
+        assert sym == 7
+
+    def test_is_libc_function_helper(self) -> None:
+        assert is_libc_function("malloc")
+        assert is_libc_function("printf")
+        assert is_libc_function("memcpy")
+        assert not is_libc_function("")
+        assert not is_libc_function("my_custom_fn")
+        # Conservatively pruned names that collide with user code must NOT be
+        # in the libc set (precision over recall).
+        assert not is_libc_function("free")
+        assert not is_libc_function("open")
+        assert not is_libc_function("read")
+        assert not is_libc_function("write")
+        assert not is_libc_function("close")
+        assert not is_libc_function("find")
+        assert not is_libc_function("sort")
+
+    def test_libc_set_is_nonempty_and_lowercase(self) -> None:
+        # The set is deliberately small but must carry the high-confidence core.
+        assert LIBC_FUNCTIONS_C
+        assert "malloc" in LIBC_FUNCTIONS_C
+        assert "strlen" in LIBC_FUNCTIONS_C
+
+
+# ---------------------------------------------------------------------------
+# local + project resolution
+# ---------------------------------------------------------------------------
+
+
+class TestLocalAndProject:
+    def test_local_free_function(self) -> None:
+        ctx = _build_ctx()
+        sym, res, f = resolve_c_callee("run", "run", "src/service.c", ctx)
+        assert res == "local"
+        assert f == "src/service.c"
+        assert sym == 2
+
+    def test_single_global_project(self) -> None:
+        ctx = _build_ctx()
+        # ``compute_total`` is defined once, in another C file -> project.
+        sym, res, f = resolve_c_callee(
+            "compute_total", "compute_total", "src/service.c", ctx
+        )
+        assert res == "project"
+        assert f == "src/helper.c"
+        assert sym == 11
+
+    def test_struct_field_receiver_is_unknown(self) -> None:
+        ctx = _build_ctx()
+        # ``obj->do_thing()`` — receiver is a struct value / function pointer
+        # field, not a resolvable free function. Conservative: unknown.
+        _sym, res, _f = resolve_c_callee(
+            "do_thing", "obj->do_thing", "src/service.c", ctx
+        )
+        assert res == "unknown"
+
+    def test_dot_receiver_is_unknown(self) -> None:
+        ctx = _build_ctx()
+        _sym, res, _f = resolve_c_callee(
+            "do_thing", "obj.do_thing", "src/service.c", ctx
+        )
+        assert res == "unknown"
+
+    def test_truly_unknown_name(self) -> None:
+        ctx = _build_ctx()
+        _sym, res, _f = resolve_c_callee(
+            "nonexistent", "nonexistent", "src/service.c", ctx
+        )
+        assert res == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# THE MOAT — no cross-language mis-wire (MANDATORY)
+# ---------------------------------------------------------------------------
+
+
+class TestNoCrossLanguageMisWire:
+    def test_ambiguous_name_resolves_to_c_def_not_python(self) -> None:
+        """``parse`` exists in BOTH a .c and a .py file.
+
+        A C caller must resolve to the SAME-FILE C definition (local), never
+        the Python file. Either way the resolved file must be C.
+        """
+        ctx = _build_ctx()
+        sym, res, f = resolve_c_callee("parse", "parse", "src/service.c", ctx)
+        assert f != "scripts/util.py"
+        assert f == "src/service.c"
+        assert res == "local"
+        assert sym == 3
+
+    def test_python_only_symbol_is_never_bound(self) -> None:
+        """``only_python`` exists ONLY in a Python file.
+
+        The C caller must NOT bind to it — the language-compat gate drops the
+        sole candidate, so the result is ``unknown`` with NO resolved file.
+        This is the exact CodeGraph failure this project exists to beat.
+        """
+        ctx = _build_ctx()
+        sym, res, f = resolve_c_callee(
+            "only_python", "only_python", "src/service.c", ctx
+        )
+        assert res == "unknown"
+        assert f == ""
+        assert sym is None
+
+    def test_ambiguous_global_foreign_plus_self_stays_c(self) -> None:
+        """A name with one C and one Python global, called from a 3rd C file.
+
+        ``parse`` has (service.c, py). Called from helper.c (no local
+        ``parse``): the Python candidate is gated out, leaving exactly one
+        same-language candidate (service.c) -> project, never the .py file.
+        """
+        ctx = _build_ctx()
+        sym, res, f = resolve_c_callee("parse", "parse", "src/helper.c", ctx)
+        assert f != "scripts/util.py"
+        assert res == "project"
+        assert f == "src/service.c"
+        assert sym == 3
+
+    def test_c_caller_never_binds_cpp_definition(self) -> None:
+        """DIRECTIONAL MOAT: a C caller must NEVER bind a C++ definition.
+
+        ``languages_compatible('c', 'cpp')`` is False (pure-C → C++ is a
+        foreign binding). ``cpp_only`` lives only in a .cpp file, so a C caller
+        must leave it ``unknown`` — even though it is the sole global candidate.
+        """
+        c_file = "src/main.c"
+        cpp_file = "src/widget.cpp"
+        ctx = build_c_context(
+            imports_by_file={},
+            file_languages={c_file: "c", cpp_file: "cpp"},
+            file_symbols={
+                c_file: [("main", "function", 1)],
+                cpp_file: [("cpp_only", "function", 50)],
+            },
+            global_name_table={"cpp_only": [(cpp_file, 50)]},
+            file_class_methods=lambda: {},
+        )
+        sym, res, f = resolve_c_callee("cpp_only", "cpp_only", c_file, ctx)
+        assert res == "unknown"
+        assert f == ""
+        assert sym is None
+        assert not f.endswith(".cpp")
+
+
+# ---------------------------------------------------------------------------
+# C-header same-tag compat (C resolves its own .h headers, indexed as ``c``)
+# ---------------------------------------------------------------------------
+
+
+class TestCHeaderCompat:
+    def test_c_resolves_c_header_symbol(self) -> None:
+        """A C caller MAY resolve a symbol declared in a C-tagged header.
+
+        ``.h`` files are indexed as ``c``, so this is a same-tag binding — not
+        a cross-language one. (The directional gate only blocks c -> cpp.)
+        """
+        c_file = "src/main.c"
+        c_header = "include/api.h"
+        ctx = build_c_context(
+            imports_by_file={},
+            file_languages={c_file: "c", c_header: "c"},
+            file_symbols={
+                c_file: [("main", "function", 1)],
+                c_header: [("c_api_init", "function", 5)],
+            },
+            global_name_table={"c_api_init": [(c_header, 5)]},
+            file_class_methods=lambda: {},
+        )
+        assert ctx is not None
+        sym, res, f = resolve_c_callee("c_api_init", "c_api_init", c_file, ctx)
+        assert res == "project"
+        assert f == c_header
+        assert sym == 5
+
+
+# ---------------------------------------------------------------------------
+# Registry + dispatch integration through the public resolve_callee
+# ---------------------------------------------------------------------------
+
+
+class TestRegistrationAndDispatch:
+    def test_c_is_registered(self) -> None:
+        resolver = get_language_resolver("c")
+        assert resolver is not None
+        assert resolver.language == "c"
+
+    def test_resolve_callee_dispatches_to_c(self) -> None:
+        c_ctx = _build_ctx()
+        ctx = ResolverContext(
+            project_root=".",
+            cache=None,
+            file_languages={
+                "src/service.c": "c",
+                "src/helper.c": "c",
+                "scripts/util.py": "python",
+            },
+            lang_contexts={"c": c_ctx},
+        )
+        # libc tier through the public entry point.
+        resolved = resolve_callee("malloc", "src/service.c", ctx, callee_full="malloc")
+        assert resolved.resolution == "stdlib"
+
+        # Single-global project resolution through the public entry point.
+        resolved = resolve_callee(
+            "compute_total",
+            "src/service.c",
+            ctx,
+            callee_full="compute_total",
+        )
+        assert resolved.resolution == "project"
+        assert resolved.resolved_file == "src/helper.c"
+
+    def test_resolve_callee_moat_through_public_api(self) -> None:
+        c_ctx = _build_ctx()
+        ctx = ResolverContext(
+            project_root=".",
+            cache=None,
+            file_languages={
+                "src/service.c": "c",
+                "scripts/util.py": "python",
+            },
+            lang_contexts={"c": c_ctx},
+        )
+        resolved = resolve_callee(
+            "only_python", "src/service.c", ctx, callee_full="only_python"
+        )
+        assert resolved.resolution == "unknown"
+        assert resolved.resolved_file == ""
+
+
+# ---------------------------------------------------------------------------
+# Real-index integration — drive the FULL pipeline: write real .c/.py files,
+# index them with ASTCache, build the resolver context the way production does,
+# and exercise resolve_c_callee against the context the index actually produced.
+#
+# As with the C++ resolver, the production symbol maps come from the generic
+# ``_ast_extraction._walk_for_symbols`` walker; tree-sitter C function
+# definitions expose their identifier under ``function_declarator`` rather than
+# a direct ``name`` field, so ordinary C free functions may be absent from
+# ``ast_symbol_rows``. The maps-INDEPENDENT libc tier and THE MOAT hold
+# regardless and are asserted here; the local-tier production gap is captured by
+# a strict xfail that flips to PASS once the shared walker recovers C symbols.
+# ---------------------------------------------------------------------------
+
+
+def _index_and_build(tmp_path, files: dict[str, str]):
+    """Write ``files`` into ``tmp_path``, index them, return (root, c_ctx)."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    for rel, body in files.items():
+        (project / rel).write_text(body)
+    cache = ASTCache(str(project))
+    try:
+        cache.index_project(max_files=100)
+        resolver_ctx = build_resolver_context(cache)
+    finally:
+        cache.close()
+    return project, resolver_ctx.lang_context("c")
+
+
+_REAL_C = (
+    "#include <stdlib.h>\n"
+    "#include <string.h>\n"
+    "int helper(void) { return 1; }\n"
+    "int run(void) {\n"
+    "    void *p = malloc(8);\n"
+    "    return helper();\n"
+    "}\n"
+)
+# A Python file defining the SAME bare name ``helper`` — the cross-language
+# collision the moat must never bind a C caller to.
+_REAL_PY = "def helper():\n    return 2\n"
+
+
+class TestRealIndexIntegration:
+    def test_c_context_is_built_from_real_index(self, tmp_path) -> None:
+        """A parsed ``.c`` file yields a non-None C resolver context."""
+        _root, c_ctx = _index_and_build(tmp_path, {"service.c": _REAL_C})
+        assert c_ctx is not None
+        assert isinstance(c_ctx, CResolverContext)
+        # The language map MUST tag the indexed file as c — this is what gates
+        # every project binding (the moat).
+        assert c_ctx.file_languages.get("service.c") == "c"
+
+    def test_libc_tier_resolves_on_real_index(self, tmp_path) -> None:
+        """``malloc`` -> ``stdlib`` end-to-end (maps-independent tier).
+
+        This tier reads only the bare name and the project-ownership gate, so it
+        works regardless of whether the symbol walker recovered any C
+        definitions — proving the resolver does real, correct work on a
+        production index. (No project ``malloc`` here, so it is not shadowed.)
+        """
+        _root, c_ctx = _index_and_build(tmp_path, {"service.c": _REAL_C})
+        sym, res, f = resolve_c_callee("malloc", "malloc", "service.c", c_ctx)
+        assert (sym, res, f) == (None, "stdlib", "")
+
+    def test_moat_holds_on_real_index(self, tmp_path) -> None:
+        """THE MOAT on a REAL index: a C caller's ``helper`` call must never
+        bind to the same-named Python ``helper`` definition."""
+        _root, c_ctx = _index_and_build(
+            tmp_path, {"service.c": _REAL_C, "util.py": _REAL_PY}
+        )
+        _sym, _res, f = resolve_c_callee("helper", "helper", "service.c", c_ctx)
+        assert f != "util.py"
+        assert not f.endswith(".py")
+
+    @pytest.mark.xfail(
+        reason=(
+            "Known production gap: the shared generic symbol walker "
+            "(_ast_extraction._walk_for_symbols) gates on "
+            "child_by_field_name('name'), which tree-sitter C "
+            "function_definition nodes do not expose (the identifier lives "
+            "under function_declarator), so ordinary C free functions are "
+            "absent from ast_symbol_rows and the local/single-global tiers "
+            "cannot fire. Root cause lives in the shared extractor, out of "
+            "this resolver's scope; this xfail is the regression target so the "
+            "tier flips to PASS once the walker recovers C symbols."
+        ),
+        strict=True,
+    )
+    def test_local_free_function_resolves_on_real_index(self, tmp_path) -> None:
+        """When the extractor populates C symbols, an unqualified call to a
+        same-file free function (``helper``) must resolve ``local``."""
+        _root, c_ctx = _index_and_build(tmp_path, {"service.c": _REAL_C})
+        _sym, res, f = resolve_c_callee("helper", "helper", "service.c", c_ctx)
+        assert res == "local"
+        assert f == "service.c"

--- a/tree_sitter_analyzer/synapse_resolver/languages/_c_constants.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/_c_constants.py
@@ -1,0 +1,103 @@
+"""Conservative libc free-function tier for the C resolver (RFC-0010).
+
+The RFC-0008 lesson is MANDATORY here: a bare name is classified ``stdlib``
+ONLY when it is (near-)exclusively a libc API and very unlikely to be a
+user-defined function. C has NO namespace qualifier (no ``std::`` analogue) and
+no member-method dispatch, so the *only* classified tier is this libc
+free-function name set — and even then every hit is gated on the project NOT
+owning a same-named C function (project shadowing wins, see ``c.py``).
+
+PRUNING RATIONALE (precision over recall — an ``unknown`` edge is never a
+mis-wire, an over-broad name set is a moat breach):
+
+INCLUDED — near-exclusively libc, rarely a user function name:
+  * allocation:   ``malloc`` / ``calloc`` / ``realloc`` (but NOT ``free`` —
+    ``free`` is an extremely common user method/function name, e.g. a custom
+    allocator's ``free`` or a resource ``free``; dropping it is mandatory).
+  * formatted IO: the ``printf`` family (``printf`` / ``fprintf`` /
+    ``sprintf`` / ``snprintf`` / ``vsnprintf``) — unspoofably libc.
+  * memory ops:   ``memcpy`` / ``memmove`` / ``memset`` / ``memcmp`` — the
+    ``mem*`` family is libc-owned by convention.
+  * string ops:   ``strlen`` / ``strcmp`` / ``strncmp`` / ``strcpy`` /
+    ``strncpy`` / ``strcat`` / ``strncat`` / ``strdup`` / ``strchr`` /
+    ``strrchr`` / ``strstr`` — the ``str*`` family is near-exclusively libc.
+  * stdio file:   the ``f*`` stdio variants (``fopen`` / ``fclose`` /
+    ``fread`` / ``fwrite`` / ``fseek`` / ``ftell`` / ``fgets`` / ``fputs`` /
+    ``fflush``) — the ``f``-prefix disambiguates from generic user verbs.
+
+EXCLUDED — collide too heavily with ordinary user code:
+  * ``free`` — common user "free this resource" function.
+  * bare POSIX verbs ``open`` / ``close`` / ``read`` / ``write`` / ``send`` /
+    ``recv`` — ubiquitous user method names.
+  * generic verbs ``find`` / ``sort`` / ``init`` / ``exit`` / ``abort`` /
+    ``puts`` / ``gets`` / ``getc`` / ``putc`` — too easily user helpers.
+
+An empty tier would also be correct; this small high-confidence core is the
+conservative middle ground. Everything not in the set stays ``project`` /
+``local`` / ``unknown``.
+"""
+
+from __future__ import annotations
+
+# Bare libc free-function names classified ``stdlib`` when the project does NOT
+# own a same-named C function. Deliberately small and high-confidence — see the
+# module docstring for the include/exclude rationale.
+LIBC_FUNCTIONS_C: frozenset[str] = frozenset(
+    {
+        # allocation (NOT ``free`` — common user name)
+        "malloc",
+        "calloc",
+        "realloc",
+        # formatted IO — the printf family
+        "printf",
+        "fprintf",
+        "sprintf",
+        "snprintf",
+        "vsnprintf",
+        # memory ops — the mem* family
+        "memcpy",
+        "memmove",
+        "memset",
+        "memcmp",
+        # string ops — the str* family
+        "strlen",
+        "strcmp",
+        "strncmp",
+        "strcpy",
+        "strncpy",
+        "strcat",
+        "strncat",
+        "strdup",
+        "strchr",
+        "strrchr",
+        "strstr",
+        # stdio file ops — the f* variants (f-prefix disambiguates from verbs)
+        "fopen",
+        "fclose",
+        "fread",
+        "fwrite",
+        "fseek",
+        "ftell",
+        "fgets",
+        "fputs",
+        "fflush",
+    }
+)
+
+
+def is_libc_function(name: str) -> bool:
+    """True when ``name`` is a conservatively-classified libc free function.
+
+    A pure membership check against :data:`LIBC_FUNCTIONS_C`. The caller is
+    responsible for the project-ownership shadow gate (a project-defined C
+    function of the same name must win over this classification).
+    """
+    if not name:
+        return False
+    return name in LIBC_FUNCTIONS_C
+
+
+__all__ = [
+    "LIBC_FUNCTIONS_C",
+    "is_libc_function",
+]

--- a/tree_sitter_analyzer/synapse_resolver/languages/c.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/c.py
@@ -1,0 +1,219 @@
+"""C resolver registration (RFC-0010 second wave).
+
+Self-contained, conservative, SAFE per-language callee resolver for C
+(``.c`` / ``.h``). It REPLACES the Python cascade for C callers, so it must not
+regress: when unsure it returns ``unknown``.
+
+C is structurally SIMPLER than C++ — and that simplicity shapes the cascade:
+
+* **No namespace qualifier tier.** C has no ``std::`` analogue, so there is no
+  unspoofable namespace signal. The only classified tier is a conservative
+  libc free-function name set (``_c_constants``), gated on project ownership.
+* **No member-method dispatch.** C has no classes/methods; a ``a->b`` or ``a.b``
+  call is a struct-field / function-pointer access on a *value*, whose target
+  type the resolver cannot prove. Any such qualified call stays ``unknown``.
+
+Resolution order (most-specific first):
+
+1. **local** — an UNQUALIFIED call whose simple name is a free function defined
+   in the caller's OWN file.
+2. **project (single-global)** — exactly one same-language project-wide
+   definition of an unqualified name. The single-definition gate avoids the
+   ambiguity that wrecks name precision.
+3. **libc** — an unqualified name in the conservative libc set, but ONLY when
+   the project owns no compatible-language function of that name (project
+   shadowing wins; classified ``stdlib``).
+4. **unknown** — everything else (struct-field / function-pointer calls through
+   a receiver, and unqualified names with no local / single-global / libc hit,
+   or an ambiguous multi-global name).
+
+THE MOAT: a C callee is NEVER bound to a symbol in an incompatible-language
+file. ``languages_compatible('c', owner_lang)`` gates every project binding.
+For C this gate is DIRECTIONAL and asymmetric (see ``_language_family``): a C
+caller resolves only ``c`` (including ``.h`` headers, indexed as ``c``) — it
+must NOT bind a ``cpp`` / ``objc`` / Python / Go definition that merely shares a
+name (``languages_compatible('c', 'cpp')`` is False; the C++ side of the
+relation is one-directional). A foreign same-name symbol stays ``unknown``.
+
+KNOWN UPSTREAM DEPENDENCY (shared with the C++ resolver): the ``local`` and
+single-global ``project`` tiers read ``file_symbols`` / ``global_name_table``,
+populated from ``ast_symbol_rows`` by the shared generic symbol walker
+(``_ast_extraction._walk_for_symbols``). That walker records a function-like
+node only when it exposes ``child_by_field_name('name')`` — but a tree-sitter C
+``function_definition`` exposes its identifier under ``function_declarator``,
+so ordinary C free functions are currently ABSENT from those maps. Until the
+shared extractor recovers C symbols, the local / single-global tiers stay
+dormant on a real index and such calls fall through to the libc tier or
+``unknown`` (SAFE — never a mis-wire). The maps-independent libc tier and THE
+MOAT hold regardless; both are covered by ``TestRealIndexIntegration`` in
+``tests/unit/test_c_method_resolution.py``, and the dormant local tier has a
+``strict`` xfail there that flips to a hard PASS the moment the extractor is
+fixed (the fix lives in the shared walker, out of this module's scope).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from ..._language_family import languages_compatible
+from .._registry import register_language
+from ._c_constants import LIBC_FUNCTIONS_C
+
+#: Extension-derived language tags this resolver owns. Only ``c`` — this module
+#: drives callers whose own file is tagged ``c`` (``.c`` and ``.h`` headers,
+#: which the detector tags ``c``). C++ / ObjC callers use their own resolvers.
+_C_LANGS: frozenset[str] = frozenset({"c"})
+
+#: C access operators that introduce a receiver/qualifier. A call carrying any
+#: of these is a struct-field / function-pointer access through a value, whose
+#: target type C does not let us prove statically -> always ``unknown``.
+_ACCESS_OPERATORS: tuple[str, ...] = ("->", ".")
+
+
+@dataclass
+class CResolverContext:
+    """Per-index C resolution maps (built once per pass).
+
+    All file keys are project-relative paths, matching the ``edges`` table.
+    Only the maps the conservative cascade needs are kept; everything else is
+    deliberately omitted to stay minimal and SAFE.
+    """
+
+    # file -> [(name, kind, symbol_id), ...] (shared cross-language map).
+    file_symbols: dict[str, list[tuple[str, str, int]]] = field(default_factory=dict)
+    # simple name -> [(file, symbol_id), ...] project-wide (single-global).
+    global_name_table: dict[str, list[tuple[str, int]]] = field(default_factory=dict)
+    # file -> language tag (so every project binding is language-gated: the
+    # moat — a same-name symbol in another language must NOT be bound).
+    file_languages: dict[str, str] = field(default_factory=dict)
+
+
+def build_c_context(
+    *,
+    imports_by_file: dict[str, Any],
+    file_languages: dict[str, str],
+    file_symbols: dict[str, Any],
+    global_name_table: dict[str, Any],
+    file_class_methods: Callable[[], dict[str, Any]],  # lazy thunk (unused)
+    **_ignored: Any,
+) -> CResolverContext | None:
+    """Build the C context, or ``None`` when no C file is indexed.
+
+    Zero cost for non-C projects (gated on ``file_languages``). C has no
+    member-method dispatch, so the ``file_class_methods`` lazy thunk is accepted
+    for contract compatibility but never stored or called — there is no
+    owner-class ambiguity to disambiguate.
+    """
+    if not any(lang in _C_LANGS for lang in file_languages.values()):
+        return None
+    return CResolverContext(
+        file_symbols=file_symbols,
+        global_name_table=global_name_table,
+        file_languages=file_languages,
+    )
+
+
+def _has_receiver(callee_full: str, callee_name: str) -> bool:
+    """True when the call carries a struct-field / pointer access operator.
+
+    A C call like ``obj->method`` or ``cfg.handler`` accesses a field on a value
+    whose type the resolver cannot prove. Such calls are not free-function
+    calls, so they must NOT bind a same-name free function -> ``unknown``. A
+    bare ``free_fn`` carries no access operator and is treated as unqualified.
+    """
+    full = callee_full or callee_name
+    return any(op in full for op in _ACCESS_OPERATORS)
+
+
+#: Symbol kinds a bare (no-receiver) C call may bind to in its own file. C has
+#: only free functions at call sites; ``function`` is the sole valid kind.
+_LOCAL_KINDS: frozenset[str] = frozenset({"function"})
+
+
+def _lookup_in_file(
+    ctx: CResolverContext,
+    file_path: str,
+    simple: str,
+) -> int | None:
+    """Resolve ``simple`` to a same-file free ``function`` symbol, or ``None``."""
+    for name, kind, sym_id in ctx.file_symbols.get(file_path, []):
+        if name == simple and kind in _LOCAL_KINDS:
+            return sym_id
+    return None
+
+
+def _project_owns(ctx: CResolverContext, simple: str) -> bool:
+    """True when a COMPATIBLE-LANGUAGE project symbol of name ``simple`` exists.
+
+    The RFC-0008 ownership gate, language-aware: a same-named symbol in an
+    incompatible-language file (e.g. a Python ``printf`` or a C++ ``malloc``)
+    must NOT count as a C owner — ``languages_compatible('c', ...)`` is False
+    for those — so it neither suppresses the libc classification nor gets bound.
+    An untagged file is treated as a possible owner (conservative).
+    """
+    for owner_file, _sym_id in ctx.global_name_table.get(simple, []):
+        owner_lang = ctx.file_languages.get(owner_file, "")
+        if not owner_lang or languages_compatible("c", owner_lang):
+            return True
+    return False
+
+
+def resolve_c_callee(
+    callee_name: str,
+    callee_full: str,
+    caller_file: str,
+    ctx: CResolverContext,
+) -> tuple[int | None, str, str]:
+    """Resolve one C call edge.
+
+    Returns ``(symbol_id, resolution, resolved_file)`` where ``resolution`` is
+    one of ``local`` / ``project`` / ``stdlib`` / ``unknown``.
+    """
+    # A receiver-qualified call (``obj->fn`` / ``cfg.fn``) accesses a struct
+    # field / function pointer whose target type C does not let us prove. It is
+    # not a free-function call, so it must never bind one -> unknown.
+    if _has_receiver(callee_full, callee_name):
+        return None, "unknown", ""
+
+    simple = callee_name
+
+    # 1. local — an unqualified call resolved to a same-file free function.
+    sym_id = _lookup_in_file(ctx, caller_file, simple)
+    if sym_id is not None:
+        return sym_id, "local", caller_file
+
+    # 2. project (single-global) — exactly one same-language project-wide
+    #    definition. THE MOAT: gate every candidate by language compatibility so
+    #    a foreign-language same-name symbol is never bound; if the sole
+    #    candidate is foreign, fall through (eventually to unknown).
+    compatible = [
+        (target_file, candidate_id)
+        for target_file, candidate_id in ctx.global_name_table.get(simple, [])
+        if languages_compatible("c", ctx.file_languages.get(target_file, ""))
+    ]
+    if len(compatible) == 1:
+        target_file, candidate_id = compatible[0]
+        return candidate_id, "project", target_file
+
+    # 3. libc tier — a conservative libc free-function name, classified
+    #    ``stdlib`` ONLY when the project owns no compatible-language function of
+    #    that name (project shadowing wins).
+    if simple in LIBC_FUNCTIONS_C and not _project_owns(ctx, simple):
+        return None, "stdlib", ""
+
+    # 4. unknown — receiver calls (handled above), ambiguous multi-global names,
+    #    and names with no local / single-global / libc hit. ``unknown`` is
+    #    correct: never a mis-wire.
+    return None, "unknown", ""
+
+
+__all__ = [
+    "CResolverContext",
+    "build_c_context",
+    "resolve_c_callee",
+]
+
+
+register_language("c", build_c_context, resolve_c_callee)


### PR DESCRIPTION
## Summary

Adds a self-contained, conservative, **SAFE** per-language callee resolver for **C** (`.c` / `.h`) under RFC-0010's second wave. It REPLACES the generic Python cascade for C callers without regressing — when unsure it returns `unknown`.

**New-files-only** (the `languages/` package auto-discovers the module, so no existing file is edited):
- `tree_sitter_analyzer/synapse_resolver/languages/c.py`
- `tree_sitter_analyzer/synapse_resolver/languages/_c_constants.py`
- `tests/unit/test_c_method_resolution.py`

## Cascade (most-specific first)

1. **local** — an unqualified call to a same-file free `function`.
2. **project (single-global)** — exactly one same-language project-wide definition of the name.
3. **libc (`stdlib`)** — a conservative libc free-function name, classified only when the project owns **no** compatible-language function of that name (project shadowing wins).
4. **unknown** — receiver-qualified calls (`obj->fn` / `cfg.fn` — struct-field / function-pointer access whose target type C does not let us prove), ambiguous multi-global names, and everything else.

## THE MOAT — no cross-language mis-wire

Every project binding is gated by `languages_compatible('c', owner_lang)`, which for C is **directional and asymmetric**: a C caller resolves only `c` (including `.h` headers, indexed as `c`) and must **NEVER** bind a `cpp` / `objc` / Python / Go definition that merely shares a name (`languages_compatible('c', 'cpp')` is `False`). A mandatory no-cross-language test covers this, including the directional `c → cpp` case.

## Conservative tiers (RFC-0008 lesson)

C has **no namespace qualifier** (no `std::` analogue) and **no member-method dispatch**, so unlike the C++ resolver there is no namespace tier and no owner-class map. The libc tier is intentionally tiny and high-confidence — `malloc`/`calloc`/`realloc`, the `printf` family, the `mem*` and `str*` families, and the `f*` stdio variants — while pruning collision-prone names (`free`, `open`, `read`, `write`, `close`, `find`, `sort`). An `unknown` edge is never a mis-wire.

## Test plan

- **26 pass + 1 strict xfail.** The xfail nails the known shared-extractor production gap (tree-sitter C `function_definition` exposes its identifier under `function_declarator`, so the generic `_walk_for_symbols` walker omits C free functions; the local tier flips to a hard PASS once that is fixed — root cause is out of this resolver's scope).
- RED-first, including the **mandatory** no-cross-language-mis-wire test (`TestNoCrossLanguageMisWire`, incl. directional `c → cpp`).
- Real-index integration: maps-independent libc tier + moat asserted on a freshly-parsed `.c` + `.py` index.
- `ruff check` + `ruff format --check` + `mypy` clean on all new files.
- Resolver regression suite green: `pytest tests/ -k 'resolver or synapse or registry'` → 375 passed, 2 skipped (Java byte-parity intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)