### PR TITLE
feat(synapse): RFC-0010 Kotlin per-language callee resolver

### DIFF
--- a/tests/unit/test_kotlin_method_resolution.py
+++ b/tests/unit/test_kotlin_method_resolution.py
@@ -1,0 +1,374 @@
+"""RFC-0010 Kotlin resolver — SAFE, self-contained per-language callee resolution.
+
+Kotlin call-edge extraction is not yet wired into ``function_extraction.py``
+(only python / js / ts / java / go / c / cpp appear in ``_CALL_NODE_TYPES``), so
+a real ``index_project`` run produces zero Kotlin ``calls`` edges and the
+resolver is never invoked end-to-end. These tests therefore drive the resolver's
+CONTRACT SURFACE directly: build the context from synthetic ``file_symbols`` /
+``global_name_table`` / ``file_languages`` maps (the shapes
+``_build_resolver_context_uncached`` passes) and call ``resolve_kotlin_callee`` —
+the same function the registry dispatch in ``synapse_resolver/__init__.py`` calls.
+
+The resolver is deliberately CONSERVATIVE (RFC-0008 lesson): it resolves
+same-file / same-language local calls (bare top-level functions, and
+``this.``/``super.`` member calls only when the method name is unique in the
+file), classifies a tiny set of auto-imported stdlib TOP-LEVEL functions
+(``listOf`` / ``println`` / ``require``) gated on project non-ownership, and
+returns ``unknown`` for everything else. An empty/strict tier is correct — a
+mis-classification is the failure this machinery exists to prevent.
+
+THE MOAT (the #1 requirement): a Kotlin callee is NEVER bound to a symbol in a
+different language's file — including a Java file, because Kotlin and Java are
+not one ``languages_compatible`` family.
+"""
+
+from __future__ import annotations
+
+from tree_sitter_analyzer.synapse_resolver.languages.kotlin import (
+    build_kotlin_resolver_context,
+    resolve_kotlin_callee,
+)
+
+
+def _thunk(value: dict[str, dict[str, dict[str, int]]] | None = None):
+    """A zero-arg lazy file_class_methods thunk (the registry passes a callable)."""
+
+    def _inner() -> dict[str, dict[str, dict[str, int]]]:
+        return value or {}
+
+    return _inner
+
+
+def _ctx(
+    *,
+    file_symbols: dict[str, list[tuple[str, str, int]]],
+    file_languages: dict[str, str],
+    global_name_table: dict[str, list[tuple[str, int]]] | None = None,
+    file_class_methods: dict[str, dict[str, dict[str, int]]] | None = None,
+):
+    """Build a Kotlin resolver context the way the registry would."""
+    if global_name_table is None:
+        global_name_table = {}
+        for fp, syms in file_symbols.items():
+            for name, _kind, sid in syms:
+                global_name_table.setdefault(name, []).append((fp, sid))
+    return build_kotlin_resolver_context(
+        imports_by_file={},
+        file_languages=file_languages,
+        file_symbols=file_symbols,
+        global_name_table=global_name_table,
+        file_class_methods=_thunk(file_class_methods),
+    )
+
+
+# ---------------------------------------------------------------------------
+# opt-out: no Kotlin file indexed -> None (zero cost)
+# ---------------------------------------------------------------------------
+def test_build_context_returns_none_when_no_kotlin_file() -> None:
+    ctx = build_kotlin_resolver_context(
+        imports_by_file={},
+        file_languages={"app.py": "python", "Service.java": "java"},
+        file_symbols={},
+        global_name_table={},
+        file_class_methods=_thunk(),
+    )
+    assert ctx is None, "no Kotlin file -> opt out so non-Kotlin projects pay nothing"
+
+
+def test_build_context_built_when_kotlin_file_present() -> None:
+    ctx = _ctx(
+        file_symbols={"Main.kt": [("helper", "function", 1)]},
+        file_languages={"Main.kt": "kotlin"},
+    )
+    assert ctx is not None
+
+
+# ---------------------------------------------------------------------------
+# (a) local same-file / same-language resolution
+# ---------------------------------------------------------------------------
+def test_local_top_level_function_resolves_local() -> None:
+    """A bare call to a top-level function defined in the same file -> local."""
+    ctx = _ctx(
+        file_symbols={"Main.kt": [("helperFn", "function", 7)]},
+        file_languages={"Main.kt": "kotlin"},
+    )
+    sym_id, resolution, resolved_file = resolve_kotlin_callee(
+        "helperFn", "helperFn", "Main.kt", ctx
+    )
+    assert resolution == "local"
+    assert sym_id == 7
+    assert resolved_file == "Main.kt"
+
+
+def test_this_method_resolves_local_when_unique() -> None:
+    """``this.helper()`` -> the same-file ``helper`` method (local) when unique."""
+    ctx = _ctx(
+        file_symbols={"Main.kt": [("helper", "method", 11)]},
+        file_languages={"Main.kt": "kotlin"},
+    )
+    sym_id, resolution, resolved_file = resolve_kotlin_callee(
+        "helper", "this.helper", "Main.kt", ctx
+    )
+    assert resolution == "local"
+    assert sym_id == 11
+    assert resolved_file == "Main.kt"
+
+
+def test_super_method_resolves_local_when_unique() -> None:
+    """``super.helper()`` is also a member call -> unique same-file method."""
+    ctx = _ctx(
+        file_symbols={"Main.kt": [("helper", "method", 12)]},
+        file_languages={"Main.kt": "kotlin"},
+    )
+    sym_id, resolution, _ = resolve_kotlin_callee(
+        "helper", "super.helper", "Main.kt", ctx
+    )
+    assert resolution == "local"
+    assert sym_id == 12
+
+
+def test_this_method_ambiguous_across_classes_stays_unknown() -> None:
+    """Codex P2: ``this.helper()`` must NOT bind when the SAME file defines
+    ``helper`` in two different classes. No caller-owner class is threaded
+    through the resolver, so binding the first row would corrupt the edge."""
+    ctx = _ctx(
+        file_symbols={
+            "Main.kt": [
+                ("helper", "method", 11),  # class A { fun helper }
+                ("call", "method", 12),  # class B { fun call -> this.helper() }
+                ("helper", "method", 13),  # class B { fun helper }
+            ]
+        },
+        file_languages={"Main.kt": "kotlin"},
+        file_class_methods={
+            "Main.kt": {
+                "A": {"helper": 11},
+                "B": {"call": 12, "helper": 13},
+            }
+        },
+    )
+    sym_id, resolution, resolved_file = resolve_kotlin_callee(
+        "helper", "this.helper", "Main.kt", ctx
+    )
+    assert resolution == "unknown", (
+        "an ambiguous this.method across multiple classes must NOT bind to the "
+        f"first row; got {resolution} -> sym_id={sym_id}"
+    )
+    assert sym_id is None
+    assert resolved_file == ""
+
+
+def test_this_method_does_not_bind_to_top_level_function() -> None:
+    """A receiver-qualified ``this.helper()`` must NOT bind to a top-level FREE
+    FUNCTION named ``helper`` (``kind='function'``). A ``this``/``super``
+    receiver can only mean a member method."""
+    ctx = _ctx(
+        file_symbols={"Main.kt": [("helper", "function", 7)]},  # a top-level fn only
+        file_languages={"Main.kt": "kotlin"},
+    )
+    sym_id, resolution, resolved_file = resolve_kotlin_callee(
+        "helper", "this.helper", "Main.kt", ctx
+    )
+    assert resolution == "unknown"
+    assert sym_id is None
+    assert resolved_file == ""
+
+
+def test_unknown_local_name_stays_unknown() -> None:
+    """A bare name with no same-file definition and no stdlib signature -> unknown."""
+    ctx = _ctx(
+        file_symbols={"Main.kt": [("helper", "function", 1)]},
+        file_languages={"Main.kt": "kotlin"},
+    )
+    _sym_id, resolution, _ = resolve_kotlin_callee("mystery", "mystery", "Main.kt", ctx)
+    assert resolution == "unknown"
+
+
+def test_bare_call_does_not_guess_other_file_same_language() -> None:
+    """A bare call whose name is defined only in ANOTHER Kotlin file -> unknown
+    (no single-global binding — only the caller's own file is consulted)."""
+    ctx = _ctx(
+        file_symbols={
+            "Other.kt": [("helper", "function", 50)],
+            "Main.kt": [("caller", "function", 51)],
+        },
+        file_languages={"Other.kt": "kotlin", "Main.kt": "kotlin"},
+    )
+    sym_id, resolution, resolved_file = resolve_kotlin_callee(
+        "helper", "helper", "Main.kt", ctx
+    )
+    assert resolution == "unknown"
+    assert sym_id is None
+    assert resolved_file == ""
+
+
+# ---------------------------------------------------------------------------
+# (b) conservative stdlib tier — auto-imported bare top-level functions
+# ---------------------------------------------------------------------------
+def test_bare_listof_classifies_stdlib() -> None:
+    """``listOf()`` is an auto-imported stdlib builder -> stdlib."""
+    ctx = _ctx(
+        file_symbols={"Main.kt": [("caller", "function", 1)]},
+        file_languages={"Main.kt": "kotlin"},
+    )
+    _sym_id, resolution, _ = resolve_kotlin_callee("listOf", "listOf", "Main.kt", ctx)
+    assert resolution == "stdlib", f"listOf must be stdlib; got {resolution}"
+
+
+def test_bare_println_classifies_stdlib() -> None:
+    ctx = _ctx(
+        file_symbols={"Main.kt": [("caller", "function", 1)]},
+        file_languages={"Main.kt": "kotlin"},
+    )
+    _sym_id, resolution, _ = resolve_kotlin_callee("println", "println", "Main.kt", ctx)
+    assert resolution == "stdlib"
+
+
+def test_bare_require_classifies_stdlib() -> None:
+    ctx = _ctx(
+        file_symbols={"Main.kt": [("caller", "function", 1)]},
+        file_languages={"Main.kt": "kotlin"},
+    )
+    _sym_id, resolution, _ = resolve_kotlin_callee("require", "require", "Main.kt", ctx)
+    assert resolution == "stdlib"
+
+
+def test_local_def_shadows_stdlib_bare_function() -> None:
+    """A project top-level ``fun println(...)`` in the caller file shadows the
+    stdlib claim: a bare ``println()`` resolves LOCAL, never stdlib."""
+    ctx = _ctx(
+        file_symbols={"Main.kt": [("println", "function", 3)]},
+        file_languages={"Main.kt": "kotlin"},
+    )
+    sym_id, resolution, _ = resolve_kotlin_callee("println", "println", "Main.kt", ctx)
+    assert resolution == "local"
+    assert sym_id == 3
+
+
+def test_project_owns_stdlib_name_in_other_kotlin_file_suppresses_stdlib() -> None:
+    """If the project defines ``listOf`` as a function in ANOTHER Kotlin file, the
+    stdlib claim is suppressed (project owns the name) but the caller's own file
+    has no def -> unknown, never a cross-file bind."""
+    ctx = _ctx(
+        file_symbols={
+            "Util.kt": [("listOf", "function", 30)],
+            "Main.kt": [("caller", "function", 31)],
+        },
+        file_languages={"Util.kt": "kotlin", "Main.kt": "kotlin"},
+    )
+    sym_id, resolution, resolved_file = resolve_kotlin_callee(
+        "listOf", "listOf", "Main.kt", ctx
+    )
+    assert resolution == "unknown"
+    assert sym_id is None
+    assert resolved_file != "Util.kt"
+
+
+def test_receiver_method_call_stays_unknown() -> None:
+    """A receiver method call (``items.map`` — receiver type not inferable) -> unknown.
+    Bare-method-name tiers are intentionally empty (RFC-0008 precision lesson)."""
+    ctx = _ctx(
+        file_symbols={"Main.kt": [("caller", "function", 1)]},
+        file_languages={"Main.kt": "kotlin"},
+    )
+    _sym_id, resolution, _ = resolve_kotlin_callee("map", "items.map", "Main.kt", ctx)
+    assert resolution == "unknown"
+
+
+def test_qualified_stdlib_name_on_receiver_stays_unknown() -> None:
+    """A stdlib NAME used as a member call (``something.listOf``) is NOT the bare
+    auto-imported function — the bare-function tier requires a receiver-less call,
+    so a receiver-qualified ``listOf`` stays unknown (no false stdlib claim)."""
+    ctx = _ctx(
+        file_symbols={"Main.kt": [("caller", "function", 1)]},
+        file_languages={"Main.kt": "kotlin"},
+    )
+    _sym_id, resolution, _ = resolve_kotlin_callee(
+        "listOf", "factory.listOf", "Main.kt", ctx
+    )
+    assert resolution == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# (THE MOAT) no cross-language mis-wire — MANDATORY
+# ---------------------------------------------------------------------------
+def test_no_cross_language_mis_wire_to_java_symbol() -> None:
+    """CRITICAL: a Kotlin callee whose bare name also exists as a symbol in a
+    JAVA file must NEVER bind to that Java file. Kotlin and Java are not one
+    ``languages_compatible`` family, so even on the JVM the moat is absolute.
+
+    ``helper`` is defined in BOTH a Java file and a Kotlin file. A Kotlin caller
+    in ``Other.kt`` (which does NOT define ``helper``) must resolve to ``unknown``
+    — never wired to the Java ``helper`` symbol."""
+    file_symbols = {
+        "Service.java": [("helper", "method", 100)],
+        "Lib.kt": [("helper", "function", 200)],
+        "Other.kt": [("caller", "function", 300)],
+    }
+    ctx = _ctx(
+        file_symbols=file_symbols,
+        file_languages={
+            "Service.java": "java",
+            "Lib.kt": "kotlin",
+            "Other.kt": "kotlin",
+        },
+    )
+    sym_id, resolution, resolved_file = resolve_kotlin_callee(
+        "helper", "helper", "Other.kt", ctx
+    )
+    assert resolved_file != "Service.java", (
+        "Kotlin caller must never bind to a Java symbol (the moat); "
+        f"got resolved_file={resolved_file!r}"
+    )
+    assert sym_id != 100
+    assert resolution == "unknown"
+
+
+def test_no_cross_language_mis_wire_to_python_symbol() -> None:
+    """A bare Kotlin call whose name exists ONLY in a Python file -> unknown,
+    never bound to the Python file."""
+    file_symbols = {
+        "app.py": [("compute", "function", 100)],
+        "Main.kt": [("caller", "function", 200)],
+    }
+    ctx = _ctx(
+        file_symbols=file_symbols,
+        file_languages={"app.py": "python", "Main.kt": "kotlin"},
+    )
+    sym_id, resolution, resolved_file = resolve_kotlin_callee(
+        "compute", "compute", "Main.kt", ctx
+    )
+    assert resolved_file != "app.py"
+    assert sym_id != 100
+    assert resolution == "unknown"
+
+
+def test_stdlib_name_collision_with_java_symbol_still_stdlib() -> None:
+    """A Kotlin bare ``listOf()`` must classify stdlib even though a Java file
+    defines a ``listOf`` symbol — the Java symbol is invisible to the Kotlin
+    caller (``languages_compatible('kotlin', 'java')`` is False), so it does not
+    suppress the stdlib tier."""
+    file_symbols = {
+        "Factory.java": [("listOf", "method", 100)],
+        "Main.kt": [("caller", "function", 200)],
+    }
+    ctx = _ctx(
+        file_symbols=file_symbols,
+        file_languages={"Factory.java": "java", "Main.kt": "kotlin"},
+    )
+    _sym_id, resolution, resolved_file = resolve_kotlin_callee(
+        "listOf", "listOf", "Main.kt", ctx
+    )
+    assert resolution == "stdlib"
+    assert resolved_file != "Factory.java"
+
+
+# ---------------------------------------------------------------------------
+# registration wiring
+# ---------------------------------------------------------------------------
+def test_kotlin_is_registered() -> None:
+    """Importing the languages package registers 'kotlin' in the registry."""
+    import tree_sitter_analyzer.synapse_resolver.languages as _languages  # noqa: F401
+    from tree_sitter_analyzer.synapse_resolver._registry import registered_languages
+
+    assert "kotlin" in registered_languages()

--- a/tree_sitter_analyzer/synapse_resolver/languages/_kotlin_constants.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/_kotlin_constants.py
@@ -1,0 +1,114 @@
+"""Conservative stdlib name tiers for the Kotlin resolver (RFC-0010).
+
+The RFC-0008 lesson is MANDATORY here: classification without receiver-type
+inference has a low precision ceiling, so a name lands in a classified tier ONLY
+when it is (near-)exclusively that stdlib API and very unlikely to be a
+user-defined function. Two facts shape the Kotlin curation:
+
+* Kotlin auto-imports the ``kotlin`` / ``kotlin.collections`` / ``kotlin.io``
+  packages, so a small set of stdlib TOP-LEVEL functions are callable *bare*
+  (no ``import`` line, no receiver) — ``listOf()``, ``println()``,
+  ``require()``. These appear as receiver-less call edges, exactly the shape a
+  same-file project function would, so the tier is gated on the project NOT
+  owning the name (``_project_owns`` in ``kotlin.py``): a project ``fun
+  println(...)`` shadows the stdlib claim and the call stays ``local``/unknown.
+
+* A bare-method-name tier (``map`` / ``filter`` / ``forEach`` / ``first`` …) is
+  **intentionally EMPTY**. Those are receiver-style extension/member calls whose
+  receiver type the call edge does not carry, and every one of them collides
+  with user methods and domain DSLs (Kotlin's builder/DSL idiom defines exactly
+  such names). Without receiver-type evidence they would be mis-classified, so
+  they stay ``unknown`` — an unknown edge is never a mis-wire.
+
+Kotlin/Java interop is real, but per the conservative mandate it is NOT modelled
+here: Kotlin and Java are not one ``languages_compatible`` family, so a Kotlin
+caller never binds a Java symbol (and vice-versa). That keeps the moat absolute;
+adding cross-JVM resolution would need import/type evidence this tier lacks.
+
+Kept in a dedicated module so the literal sets stay out of the resolver logic
+and the file-size rule is honoured.
+"""
+
+from __future__ import annotations
+
+# Stdlib TOP-LEVEL functions that Kotlin AUTO-IMPORTS (the ``kotlin``,
+# ``kotlin.collections``, ``kotlin.io``, ``kotlin.text`` default-import set), so
+# they are routinely called BARE — no ``import`` line and no receiver. Each name
+# here is (near-)exclusively the Kotlin stdlib builder/intrinsic and is very
+# unlikely to be re-defined as a user TOP-LEVEL function; if a project DOES
+# define one, the ``_project_owns`` gate in ``kotlin.py`` suppresses the stdlib
+# claim (shadowing preserved → precision over recall).
+#
+# CURATION RULE — only collection/array builders, the standard I/O intrinsics,
+# and the contract intrinsics whose names projects essentially never reuse as a
+# free function. Deliberately EXCLUDED: ``run`` / ``let`` / ``apply`` / ``also``
+# / ``with`` / ``use`` (scope functions — extension calls on a receiver, not bare
+# builders, and ``run``/``with`` are common project verbs), ``to`` (the Pair
+# infix — collides with the English word), ``lazy`` / ``repeat`` (common domain
+# names). An empty-leaning set beats a false positive.
+STDLIB_BARE_FUNCTIONS_KOTLIN: frozenset[str] = frozenset(
+    {
+        # collection builders (kotlin.collections, auto-imported)
+        "listOf",
+        "mutableListOf",
+        "emptyList",
+        "setOf",
+        "mutableSetOf",
+        "emptySet",
+        "mapOf",
+        "mutableMapOf",
+        "emptyMap",
+        "arrayListOf",
+        "hashMapOf",
+        "hashSetOf",
+        "linkedMapOf",
+        "linkedSetOf",
+        "sortedMapOf",
+        "sortedSetOf",
+        # array builders (kotlin, auto-imported)
+        "arrayOf",
+        "arrayOfNulls",
+        "emptyArray",
+        "booleanArrayOf",
+        "byteArrayOf",
+        "charArrayOf",
+        "shortArrayOf",
+        "intArrayOf",
+        "longArrayOf",
+        "floatArrayOf",
+        "doubleArrayOf",
+        # I/O intrinsics (kotlin.io, auto-imported)
+        "println",
+        "print",
+        "readLine",
+        # contract intrinsics (kotlin, auto-imported) — distinctive stdlib names
+        "require",
+        "requireNotNull",
+        "check",
+        "checkNotNull",
+        "error",
+        # number/range helpers projects essentially never re-define bare
+        "TODO",
+    }
+)
+
+# Bare *method* names classified ``stdlib`` on an UNRESOLVED receiver.
+# INTENTIONALLY EMPTY (see module docstring): without receiver-type evidence,
+# every candidate (``map`` / ``filter`` / ``forEach`` / ``first`` / ``isEmpty``
+# …) collides with user members and Kotlin DSL builders. Precision over recall —
+# an unknown edge is correct; a mis-classified one is a moat breach.
+STDLIB_METHODS_KOTLIN: frozenset[str] = frozenset()
+
+# Bare names classified ``external`` (third-party). INTENTIONALLY EMPTY: Kotlin
+# has no single dominant third-party library whose bare call names are safe to
+# hardcode, and many candidates (``test`` from kotlin.test, ``shouldBe`` from
+# Kotest) are receiver-style or collide with user code. Stays empty until a safe
+# set is proven.
+EXTERNAL_METHODS_KOTLIN: frozenset[str] = frozenset()
+
+
+__all__ = [
+    "EXTERNAL_METHODS_KOTLIN",
+    "STDLIB_BARE_FUNCTIONS_KOTLIN",
+    "STDLIB_METHODS_KOTLIN",
+]

--- a/tree_sitter_analyzer/synapse_resolver/languages/kotlin.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/kotlin.py
@@ -1,0 +1,273 @@
+"""Kotlin callee resolver (RFC-0010, second wave).
+
+Self-contained and SAFE — it REPLACES the Python cascade for Kotlin callers
+(``file_languages == "kotlin"``; ``.kt`` / ``.kts`` files), so it must never
+regress: when unsure it returns ``unknown``. Its jobs are:
+
+1. **local (bare call)** — a receiver-less call (``helper()``) to a top-level
+   function / class defined in the CALLER's OWN file. Same file == same language
+   by construction, so this can never cross-bind.
+2. **local (``this``/``super`` member call)** — a ``this.helper()`` /
+   ``super.helper()`` call binds a same-file ``method`` row ONLY when exactly one
+   method of that name exists in the file (the owner-class map disambiguates). An
+   ambiguous name (two classes in the file define it) stays ``unknown`` — the
+   resolver carries no caller-owner class (Codex P2 wave-1 lesson). A receiver
+   call NEVER binds a top-level function.
+3. **stdlib** — a bare (receiver-less) call to one of a tiny set of
+   AUTO-IMPORTED Kotlin stdlib top-level functions (``listOf`` / ``println`` /
+   ``require`` …), gated on the project NOT owning that name in a
+   compatible-language file (shadowing preserved). See ``_kotlin_constants``.
+4. **unknown** — everything else: receiver method calls on a variable
+   (``items.map`` — the receiver type the edge does not carry), cross-file
+   project calls, qualified third-party calls, ambiguous names.
+
+THE MOAT (the #1 correctness requirement): a Kotlin callee is NEVER bound to a
+symbol in a different language's file. The ``local`` tiers only ever consult the
+caller's OWN file; the stdlib-ownership gate is language-aware via
+``languages_compatible``. Critically, Kotlin and Java are NOT one
+``languages_compatible`` family, so even on the JVM a Kotlin caller never binds a
+Java symbol (and a Java ``listOf`` never suppresses Kotlin's stdlib tier). Real
+Kotlin/Java interop would need import/type evidence this resolver does not carry;
+modelling it would risk the exact cross-language mis-wire this machinery exists
+to beat, so it is deliberately out of scope — ``unknown`` is the safe answer.
+
+NOTE: Kotlin call-edge extraction is not yet enabled in
+``function_extraction._CALL_NODE_TYPES`` (python/js/ts/java/go/c/cpp only), so a
+real index produces no Kotlin ``calls`` edges and this resolver is dormant
+end-to-end until that (separate, out-of-scope) extractor change lands. The
+resolver is correct and tested at its contract surface now, so it activates with
+zero further work the moment Kotlin edges are produced.
+
+Contract (RFC-0010): the module ends with
+``register_language("kotlin", build_kotlin_resolver_context,
+resolve_kotlin_callee)``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from ..._language_family import languages_compatible
+from .._registry import register_language
+from ._kotlin_constants import STDLIB_BARE_FUNCTIONS_KOTLIN
+
+#: ``file_languages`` tag for every ``.kt`` / ``.kts`` file.
+_KOTLIN_LANG = "kotlin"
+
+#: Receiver tokens that denote the current object (a member call), not a separate
+#: variable/type. A call qualified only by one of these is a class-scoped method
+#: call resolved against the caller's own file.
+_SELF_RECEIVERS: frozenset[str] = frozenset({"this", "super"})
+
+#: Symbol kinds a bare (receiver-less) call may bind to in its own file: a
+#: top-level function or a class (constructor-style call).
+_LOCAL_KINDS: frozenset[str] = frozenset({"function", "method", "class"})
+
+
+@dataclass
+class KotlinResolverContext:
+    """Per-index Kotlin resolution maps (built once per pass).
+
+    All file keys are project-relative paths, matching the ``edges`` table. Only
+    the maps the conservative cascade needs are kept; everything else is omitted
+    to stay minimal and SAFE.
+    """
+
+    # file -> [(name, kind, symbol_id), ...] (shared cross-language map; only the
+    # CALLER file's own entry is ever read for a local bind).
+    file_symbols: dict[str, list[tuple[str, str, int]]] = field(default_factory=dict)
+    # simple name -> [(file, symbol_id), ...] project-wide. Used ONLY by the
+    # language-aware ownership gate (never to BIND a callee), so a same-name
+    # symbol in another file is never wired across.
+    global_name_table: dict[str, list[tuple[str, int]]] = field(default_factory=dict)
+    # file -> language tag (so the stdlib-ownership gate is language-aware: the
+    # moat — a same-name symbol in another language must NOT suppress/bind).
+    file_languages: dict[str, str] = field(default_factory=dict)
+    # LAZY thunk -> {file: {class_name: {method_name: symbol_id}}}. Used only to
+    # disambiguate a ``this``/``super`` member call when a file declares >1 class
+    # with a colliding method name. Held as a thunk + memoised so non-member
+    # workloads pay nothing.
+    class_methods_thunk: Callable[[], dict[str, Any]] | None = None
+    _class_methods: dict[str, Any] | None = field(default=None, repr=False)
+
+    def member_owner_class_count(self, file_path: str, method_name: str) -> int:
+        """Return how many classes in ``file_path`` define ``method_name``.
+
+        Drives the conservative member-call gate: a ``this``/``super`` call may
+        bind a same-file ``method`` only when this count is exactly 1. A count of
+        0 means the owner-class map did not record it (e.g. an unpopulated map);
+        callers treat 0 as "no class-ambiguity evidence" and fall back to a plain
+        unique-method scan. The thunk is materialised lazily and memoised.
+        """
+        if self.class_methods_thunk is None:
+            return 0
+        if self._class_methods is None:
+            self._class_methods = self.class_methods_thunk() or {}
+        per_class = self._class_methods.get(file_path, {})
+        return sum(1 for methods in per_class.values() if method_name in methods)
+
+
+def build_kotlin_resolver_context(
+    *,
+    imports_by_file: dict[str, Any],
+    file_languages: dict[str, str],
+    file_symbols: dict[str, Any],
+    global_name_table: dict[str, Any],
+    file_class_methods: Callable[[], dict[str, Any]],  # lazy thunk
+    **_ignored: Any,
+) -> KotlinResolverContext | None:
+    """Build the Kotlin context, or ``None`` when no Kotlin file is indexed.
+
+    Zero cost for non-Kotlin projects (gated on ``file_languages``). The lazy
+    ``file_class_methods`` thunk is STORED but NOT called here — it is
+    materialised at most once, on the first ``this``/``super`` member call that
+    needs owner-class disambiguation. The bare-local and stdlib tiers never touch
+    it, so a project with no such ambiguity pays nothing for the class map.
+    """
+    if not any(lang == _KOTLIN_LANG for lang in file_languages.values()):
+        return None
+    return KotlinResolverContext(
+        file_symbols=file_symbols,
+        global_name_table=global_name_table,
+        file_languages=file_languages,
+        class_methods_thunk=file_class_methods,
+    )
+
+
+def _split_receiver(callee_full: str, callee_name: str) -> tuple[str, str]:
+    """Return ``(receiver, simple_name)`` from a Kotlin call's full name.
+
+    Kotlin uses ``.`` for both member access (``this.helper``) and qualified
+    references (``factory.build``). The receiver is everything before the final
+    dot; the simple name is the trailing identifier. A bare ``helper`` ->
+    ``("", "helper")``.
+    """
+    full = callee_full or callee_name
+    if "." in full:
+        receiver, simple = full.rsplit(".", 1)
+        return receiver, simple
+    return "", full or callee_name
+
+
+def _lookup_bare_in_file(
+    ctx: KotlinResolverContext, file_path: str, simple: str
+) -> int | None:
+    """Return the symbol id of a same-file top-level ``function``/``class`` (or a
+    ``method``) named ``simple`` in ``file_path``, or ``None``.
+
+    A bare receiver-less call may legitimately reach a top-level function, a
+    class constructor, or — in a single-class file — an implicit-receiver member.
+    A Kotlin file cannot declare two top-level functions of one name, so the
+    first match is the unique def.
+    """
+    for name, kind, sym_id in ctx.file_symbols.get(file_path, []):
+        if name == simple and kind in _LOCAL_KINDS:
+            return sym_id
+    return None
+
+
+def _lookup_unique_method_in_file(
+    ctx: KotlinResolverContext, file_path: str, simple: str
+) -> int | None:
+    """Return the symbol id of a same-file ``method`` named ``simple``, but ONLY
+    when it is unambiguous; otherwise ``None``.
+
+    Codex P2 (wave-1 lesson): a ``this.helper()`` / ``super.helper()`` call
+    carries no caller-owner class, so when two classes in the file both define
+    ``helper`` the receiver is ambiguous and must NOT bind. Disambiguation uses
+    the owner-class map (count of classes defining the name); when that map is
+    silent (count 0) we fall back to counting ``method`` rows so a genuinely
+    unique method still binds. ONLY ``method`` rows are candidates — a
+    ``this``/``super`` receiver can never mean a top-level function.
+    """
+    if ctx.member_owner_class_count(file_path, simple) > 1:
+        return None  # owned by >1 class — ambiguous, stay unknown.
+    matches = [
+        sym_id
+        for name, kind, sym_id in ctx.file_symbols.get(file_path, [])
+        if name == simple and kind == "method"
+    ]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _project_owns(ctx: KotlinResolverContext, simple: str, caller_file: str) -> bool:
+    """True when a COMPATIBLE-LANGUAGE (Kotlin) project symbol named ``simple``
+    exists.
+
+    The RFC-0008 ownership gate, language-aware: a same-named symbol in an
+    incompatible-language file (a Java / Python ``listOf``) must NOT count as a
+    Kotlin owner — ``languages_compatible('kotlin', 'java')`` is False — so it
+    neither suppresses the stdlib tier nor gets bound. An untagged file is
+    treated as a possible owner (conservative). The caller file is included via
+    the global table, so a same-file top-level def shadows the stdlib name.
+    """
+    for owner_file, _sym_id in ctx.global_name_table.get(simple, []):
+        owner_lang = ctx.file_languages.get(owner_file, "")
+        if not owner_lang or languages_compatible(_KOTLIN_LANG, owner_lang):
+            return True
+    return False
+
+
+def resolve_kotlin_callee(
+    callee_name: str,
+    callee_full: str,
+    caller_file: str,
+    ctx: KotlinResolverContext,
+) -> tuple[int | None, str, str]:
+    """Resolve one Kotlin call edge.
+
+    Returns ``(symbol_id, resolution, resolved_file)`` where ``resolution`` is
+    one of ``local`` / ``stdlib`` / ``unknown``. Conservative by design: every
+    path that is not a confident same-file local call or a distinctive
+    auto-imported stdlib builder returns ``unknown`` — never a cross-language
+    bind.
+    """
+    receiver, simple = _split_receiver(callee_full, callee_name)
+
+    # 1. local — bare (receiver-less) call. A top-level function / class def, or a
+    #    single-class implicit-receiver member, in the CALLER's OWN file. This
+    #    wins before the stdlib tier so a project ``fun println()`` shadows the
+    #    stdlib classification.
+    if receiver == "":
+        sym_id = _lookup_bare_in_file(ctx, caller_file, simple)
+        if sym_id is not None:
+            return sym_id, "local", caller_file
+        # 2. stdlib — a bare auto-imported stdlib builder (``listOf`` / ``println``
+        #    / ``require``) NOT owned by a compatible-language project symbol.
+        #    Gated on import-free auto-imports only; a project def already won
+        #    above (and ``_project_owns`` re-checks cross-file ownership).
+        if simple in STDLIB_BARE_FUNCTIONS_KOTLIN and not _project_owns(
+            ctx, simple, caller_file
+        ):
+            return None, "stdlib", ""
+        # A bare unresolved call stays unknown — NO global single-name binding,
+        # because that is exactly where cross-language mis-wires creep in.
+        return None, "unknown", ""
+
+    # 3. local — ``this``/``super`` member call. The caller's enclosing class is
+    #    NOT available, so bind only an UNAMBIGUOUS same-file ``method`` row
+    #    (never a top-level function; never when two classes define the name).
+    if receiver in _SELF_RECEIVERS:
+        mid = _lookup_unique_method_in_file(ctx, caller_file, simple)
+        if mid is not None:
+            return mid, "local", caller_file
+        return None, "unknown", ""
+
+    # 4. unknown — a receiver-qualified call on a variable / type
+    #    (``items.map`` / ``factory.listOf``). The receiver type is not carried by
+    #    the edge, so we never guess: bare-method-name tiers are intentionally
+    #    empty (RFC-0008 precision lesson). A qualified stdlib NAME is NOT the
+    #    bare auto-imported function, so it does not classify stdlib here.
+    return None, "unknown", ""
+
+
+register_language(_KOTLIN_LANG, build_kotlin_resolver_context, resolve_kotlin_callee)
+
+
+__all__ = [
+    "KotlinResolverContext",
+    "build_kotlin_resolver_context",
+    "resolve_kotlin_callee",
+]


### PR DESCRIPTION
## Summary

Adds a self-contained, SAFE per-language callee resolver for **Kotlin** (`.kt`/`.kts`), RFC-0010 second wave. **New-files-only** — registered via the auto-discovery registry, so no existing file is edited.

New files:
- `tree_sitter_analyzer/synapse_resolver/languages/kotlin.py`
- `tree_sitter_analyzer/synapse_resolver/languages/_kotlin_constants.py`
- `tests/unit/test_kotlin_method_resolution.py`

## Resolution tiers (conservative — `unknown` when unsure)

1. **local (bare)** — receiver-less call to a top-level function / class (or single-class implicit-receiver member) in the **caller's own file**. Same file == same language → cannot cross-bind.
2. **local (`this`/`super`)** — member call binds a same-file `method` row **only when unambiguous** (one class defines the name). Two classes defining it → `unknown` (no caller-owner class is threaded through — wave-1 Codex P2 lesson). A receiver call never binds a top-level function.
3. **stdlib** — a tiny set of auto-imported bare stdlib builders (`listOf`/`println`/`require`/…), gated on the project not owning the name in a compatible-language file (shadowing preserved).
4. **unknown** — receiver method calls on a variable (`items.map` — receiver type not carried), cross-file project calls, qualified third-party calls.

## THE MOAT — never cross-language bind

A Kotlin callee is **never** bound to a symbol in another language's file. Local tiers consult only the caller's own file; the stdlib gate is language-aware via `languages_compatible`. Critically, **Kotlin and Java are not one `languages_compatible` family**, so a Kotlin caller never binds a Java symbol and a Java `listOf` never suppresses Kotlin's stdlib tier. Real Kotlin/Java interop would need import/type evidence this resolver doesn't carry — deliberately out of scope.

Mandatory no-cross-language-mis-wire tests included: vs **Java** (same JVM, same name) and vs **Python**.

## Conservative tiers (RFC-0008 lesson)

Bare-method-name `STDLIB_METHODS_KOTLIN` / `EXTERNAL_METHODS_KOTLIN` sets are **intentionally empty** — Kotlin DSL/builder idiom reuses exactly such names; without receiver-type evidence they'd mis-classify. The bare auto-imported top-level builder set is the only classified tier.

## Note on activation

Kotlin call-edge extraction is not yet enabled in `function_extraction._CALL_NODE_TYPES` (python/js/ts/java/go/c/cpp only), so the resolver is **dormant end-to-end** until that separate extractor change lands — same as the merged Rust resolver. It's correct and tested at its contract surface now and activates with zero further work once Kotlin edges are produced.

## Verification

- `ruff check` + `ruff format --check` + `mypy` clean on all new files.
- `tests/unit/test_kotlin_method_resolution.py` — 20 passed (RED-first verified before implementation).
- Resolver regression `uv run pytest tests/ -k 'resolver or synapse or registry'` — 375 passed, 2 skipped (Java byte-parity intact).
- `git show --stat HEAD` — new-files-only (3 files, +761, 0 modifications).

🤖 Generated with [Claude Code](https://claude.com/claude-code)