### PR TITLE
feat(resolver): conservative C# callee resolver (RFC-0010 second wave)

### DIFF
--- a/tests/unit/test_csharp_method_resolution.py
+++ b/tests/unit/test_csharp_method_resolution.py
@@ -1,0 +1,565 @@
+"""Unit + integration tests for the C# resolver (RFC-0010 second wave).
+
+Covers the conservative cascade in
+``synapse_resolver/languages/csharp.py``: ``System.``-qualified stdlib
+classification, the near-exclusive BCL static-type qualifier tier (shadow-gated
+by ``_project_owns``), local same-file resolution, single-global project
+resolution, the empty bare-method-name tiers, and — MANDATORY — the
+no-cross-language-mis-wire moat (a callee whose name also exists in a non-C#
+file must NEVER bind to that file).
+"""
+
+from __future__ import annotations
+
+from tree_sitter_analyzer.ast_cache import ASTCache
+from tree_sitter_analyzer.synapse_resolver import ResolverContext, resolve_callee
+from tree_sitter_analyzer.synapse_resolver._context import build_resolver_context
+from tree_sitter_analyzer.synapse_resolver._registry import get_language_resolver
+from tree_sitter_analyzer.synapse_resolver.languages._csharp_constants import (
+    BCL_STATIC_TYPES_CSHARP,
+    EXTERNAL_METHODS_CSHARP,
+    STDLIB_METHODS_CSHARP,
+    is_system_qualifier,
+)
+from tree_sitter_analyzer.synapse_resolver.languages.csharp import (
+    CSharpResolverContext,
+    build_csharp_context,
+    resolve_csharp_callee,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _build_ctx() -> CSharpResolverContext:
+    """Greeter.cs + Helper.cs + a same-named Python symbol elsewhere.
+
+    ``Greeter.cs`` defines a local ``World`` method, a ``Run`` method and a
+    ``Greeter`` class. ``Helper.cs`` defines a project-unique ``ComputeTotal``.
+    A Python file also defines ``Run`` (the cross-language collision the moat
+    test exercises).
+    """
+    greeter = "src/Greeter.cs"
+    helper = "src/Helper.cs"
+    py = "scripts/util.py"
+    file_symbols = {
+        greeter: [
+            ("Greeter", "class", 1),
+            ("Hello", "method", 2),
+            ("Run", "method", 3),
+            ("World", "method", 4),
+        ],
+        helper: [
+            ("Helper", "class", 10),
+            ("ComputeTotal", "method", 11),
+        ],
+        py: [("Run", "function", 99)],
+    }
+    global_name_table = {
+        "Hello": [(greeter, 2)],
+        # ``Run`` is defined in BOTH a C# file and a Python file — ambiguous
+        # across languages. The C# caller must only ever see the C# one.
+        "Run": [(greeter, 3), (py, 99)],
+        "World": [(greeter, 4)],
+        # ``ComputeTotal`` is the single project-wide (C#) definition.
+        "ComputeTotal": [(helper, 11)],
+        # ``OnlyPython`` lives ONLY in the Python file.
+        "OnlyPython": [(py, 99)],
+        "Greeter": [(greeter, 1)],
+    }
+    file_languages = {greeter: "csharp", helper: "csharp", py: "python"}
+    ctx = build_csharp_context(
+        imports_by_file={},
+        file_languages=file_languages,
+        file_symbols=file_symbols,
+        global_name_table=global_name_table,
+        file_class_methods=lambda: {},
+    )
+    assert ctx is not None
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# build_csharp_context gating
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCSharpContext:
+    def test_returns_none_when_no_csharp_file(self) -> None:
+        ctx = build_csharp_context(
+            imports_by_file={},
+            file_languages={"a.py": "python", "b.go": "go"},
+            file_symbols={},
+            global_name_table={},
+            file_class_methods=lambda: {},
+        )
+        assert ctx is None
+
+    def test_builds_when_csharp_present(self) -> None:
+        ctx = build_csharp_context(
+            imports_by_file={},
+            file_languages={"a.cs": "csharp"},
+            file_symbols={},
+            global_name_table={},
+            file_class_methods=lambda: {},
+        )
+        assert isinstance(ctx, CSharpResolverContext)
+
+    def test_does_not_call_class_methods_thunk(self) -> None:
+        calls: list[int] = []
+
+        def thunk() -> dict[str, object]:
+            calls.append(1)
+            return {}
+
+        build_csharp_context(
+            imports_by_file={},
+            file_languages={"a.cs": "csharp"},
+            file_symbols={},
+            global_name_table={},
+            file_class_methods=thunk,
+        )
+        assert calls == []  # conservative cascade never needs the class map
+
+
+# ---------------------------------------------------------------------------
+# System.* fully-qualified stdlib tier
+# ---------------------------------------------------------------------------
+
+
+class TestSystemQualifier:
+    def test_fully_qualified_system_console_is_stdlib(self) -> None:
+        ctx = _build_ctx()
+        sym, res, f = resolve_csharp_callee(
+            "WriteLine", "System.Console.WriteLine", "src/Greeter.cs", ctx
+        )
+        assert (sym, res, f) == (None, "stdlib", "")
+
+    def test_nested_system_namespace_is_stdlib(self) -> None:
+        ctx = _build_ctx()
+        _sym, res, _f = resolve_csharp_callee(
+            "Select",
+            "System.Linq.Enumerable.Select",
+            "src/Greeter.cs",
+            ctx,
+        )
+        assert res == "stdlib"
+
+    def test_is_system_qualifier_helper(self) -> None:
+        assert is_system_qualifier("System")
+        assert is_system_qualifier("System.Console")
+        assert is_system_qualifier("System.Linq.Enumerable")
+        assert not is_system_qualifier("")
+        assert not is_system_qualifier("Console")
+        # A user namespace that merely starts with the letters "System" must NOT
+        # match — the check is on the ``System.`` token boundary.
+        assert not is_system_qualifier("Systemx")
+        assert not is_system_qualifier("MySystem")
+        assert not is_system_qualifier("SystemExt")
+
+
+# ---------------------------------------------------------------------------
+# BCL static-type qualifier tier (shadow-gated)
+# ---------------------------------------------------------------------------
+
+
+class TestBclStaticTypeTier:
+    def test_bare_console_writeline_is_stdlib(self) -> None:
+        ctx = _build_ctx()
+        sym, res, f = resolve_csharp_callee(
+            "WriteLine", "Console.WriteLine", "src/Greeter.cs", ctx
+        )
+        assert (sym, res, f) == (None, "stdlib", "")
+
+    def test_bare_string_format_is_stdlib(self) -> None:
+        ctx = _build_ctx()
+        _sym, res, _f = resolve_csharp_callee(
+            "Format", "String.Format", "src/Greeter.cs", ctx
+        )
+        assert res == "stdlib"
+
+    def test_bare_math_max_is_stdlib(self) -> None:
+        ctx = _build_ctx()
+        _sym, res, _f = resolve_csharp_callee("Max", "Math.Max", "src/Greeter.cs", ctx)
+        assert res == "stdlib"
+
+    def test_project_owned_static_type_shadows_bcl(self) -> None:
+        """If the project itself defines a class named ``Console`` (a same-
+        language symbol), the bare ``Console.WriteLine`` claim must be
+        SUPPRESSED — shadowing preserved, the call stays ``unknown``.
+        """
+        greeter = "src/Greeter.cs"
+        mine = "src/Console.cs"
+        ctx = build_csharp_context(
+            imports_by_file={},
+            file_languages={greeter: "csharp", mine: "csharp"},
+            file_symbols={
+                greeter: [("Hello", "method", 1)],
+                mine: [("Console", "class", 7)],
+            },
+            global_name_table={"Console": [(mine, 7)]},
+            file_class_methods=lambda: {},
+        )
+        assert ctx is not None
+        _sym, res, _f = resolve_csharp_callee(
+            "WriteLine", "Console.WriteLine", greeter, ctx
+        )
+        assert res == "unknown"
+
+    def test_foreign_language_console_does_not_shadow_bcl(self) -> None:
+        """A same-named symbol in a NON-C# file must NOT shadow the BCL claim —
+        ``languages_compatible('csharp', 'python')`` is False, so a Python
+        ``Console`` is not a C# owner and ``Console.WriteLine`` stays stdlib.
+        """
+        greeter = "src/Greeter.cs"
+        py = "scripts/console.py"
+        ctx = build_csharp_context(
+            imports_by_file={},
+            file_languages={greeter: "csharp", py: "python"},
+            file_symbols={
+                greeter: [("Hello", "method", 1)],
+                py: [("Console", "class", 7)],
+            },
+            global_name_table={"Console": [(py, 7)]},
+            file_class_methods=lambda: {},
+        )
+        assert ctx is not None
+        _sym, res, _f = resolve_csharp_callee(
+            "WriteLine", "Console.WriteLine", greeter, ctx
+        )
+        assert res == "stdlib"
+
+    def test_non_bcl_static_type_is_unknown(self) -> None:
+        ctx = _build_ctx()
+        _sym, res, _f = resolve_csharp_callee(
+            "Frobnicate", "MyHelper.Frobnicate", "src/Greeter.cs", ctx
+        )
+        assert res == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# local + project resolution
+# ---------------------------------------------------------------------------
+
+
+class TestLocalAndProject:
+    def test_local_bare_method(self) -> None:
+        ctx = _build_ctx()
+        sym, res, f = resolve_csharp_callee("Run", "Run", "src/Greeter.cs", ctx)
+        assert res == "local"
+        assert f == "src/Greeter.cs"
+        assert sym == 3
+
+    def test_this_qualified_member_is_local(self) -> None:
+        ctx = _build_ctx()
+        sym, res, f = resolve_csharp_callee(
+            "World", "this.World", "src/Greeter.cs", ctx
+        )
+        assert res == "local"
+        assert f == "src/Greeter.cs"
+        assert sym == 4
+
+    def test_single_global_project(self) -> None:
+        ctx = _build_ctx()
+        # ``ComputeTotal`` is defined once, in another C# file -> project.
+        sym, res, f = resolve_csharp_callee(
+            "ComputeTotal", "ComputeTotal", "src/Greeter.cs", ctx
+        )
+        assert res == "project"
+        assert f == "src/Helper.cs"
+        assert sym == 11
+
+    def test_instance_receiver_is_unknown(self) -> None:
+        ctx = _build_ctx()
+        # ``obj.DoThing()`` — receiver is a variable, not a resolvable type.
+        _sym, res, _f = resolve_csharp_callee(
+            "DoThing", "obj.DoThing", "src/Greeter.cs", ctx
+        )
+        assert res == "unknown"
+
+    def test_truly_unknown_name(self) -> None:
+        ctx = _build_ctx()
+        _sym, res, _f = resolve_csharp_callee(
+            "Nonexistent", "Nonexistent", "src/Greeter.cs", ctx
+        )
+        assert res == "unknown"
+
+    def test_empty_method_tiers(self) -> None:
+        # The bare-method-name tiers are intentionally empty (RFC-0008).
+        assert STDLIB_METHODS_CSHARP == frozenset()
+        assert EXTERNAL_METHODS_CSHARP == frozenset()
+        # The BCL static-type set is non-empty but conservative.
+        assert "Console" in BCL_STATIC_TYPES_CSHARP
+        assert "Math" in BCL_STATIC_TYPES_CSHARP
+
+
+# ---------------------------------------------------------------------------
+# Explicit self/base-receiver semantics (wave-1 Codex P2 lesson)
+# ---------------------------------------------------------------------------
+
+
+class TestSelfReceiver:
+    """An explicit ``this.`` / ``base.`` receiver asserts the target is a
+    member. The resolver must NOT downgrade that into binding a cross-file
+    global (``project``) — only a same-file member may bind.
+    """
+
+    def test_this_call_does_not_bind_cross_file_global(self) -> None:
+        # ``this.ComputeTotal`` — ``ComputeTotal`` is a single project-wide
+        # global in ANOTHER file. A member call must not bind it: ``unknown``.
+        ctx = _build_ctx()
+        sym, res, f = resolve_csharp_callee(
+            "ComputeTotal", "this.ComputeTotal", "src/Greeter.cs", ctx
+        )
+        assert res == "unknown"
+        assert f == ""
+        assert sym is None
+
+    def test_base_call_binds_same_file_member(self) -> None:
+        ctx = _build_ctx()
+        sym, res, f = resolve_csharp_callee(
+            "World", "base.World", "src/Greeter.cs", ctx
+        )
+        assert res == "local"
+        assert sym == 4
+
+    def test_ambiguous_self_member_stays_unknown(self) -> None:
+        """When >1 class in the file defines the member name, a ``this.`` call
+        cannot be proven to target the caller's class -> ``unknown``."""
+        multi = "src/Multi.cs"
+        file_symbols = {
+            multi: [
+                ("A", "class", 1),
+                ("Dispatch", "method", 2),  # A.Dispatch
+                ("Dispatch", "method", 3),  # B.Dispatch — same simple name
+                ("Solo", "method", 4),  # A.Solo — single owner class
+                ("B", "class", 5),
+            ],
+        }
+        file_class_methods = {
+            multi: {
+                "A": {"Dispatch": 2, "Solo": 4},
+                "B": {"Dispatch": 3},
+            }
+        }
+        ctx = build_csharp_context(
+            imports_by_file={},
+            file_languages={multi: "csharp"},
+            file_symbols=file_symbols,
+            global_name_table={
+                "Dispatch": [(multi, 2), (multi, 3)],
+                "Solo": [(multi, 4)],
+            },
+            file_class_methods=lambda: file_class_methods,
+        )
+        assert ctx is not None
+        sym, res, f = resolve_csharp_callee("Dispatch", "this.Dispatch", multi, ctx)
+        assert (sym, res, f) == (None, "unknown", "")
+        # The single-owner member still binds.
+        sym, res, f = resolve_csharp_callee("Solo", "this.Solo", multi, ctx)
+        assert res == "local"
+        assert sym == 4
+
+
+# ---------------------------------------------------------------------------
+# THE MOAT — no cross-language mis-wire (MANDATORY)
+# ---------------------------------------------------------------------------
+
+
+class TestNoCrossLanguageMisWire:
+    def test_ambiguous_name_resolves_to_csharp_def_not_python(self) -> None:
+        """``Run`` exists in BOTH a .cs and a .py file.
+
+        A C# caller must resolve to the SAME-FILE C# definition (local),
+        never the Python file.
+        """
+        ctx = _build_ctx()
+        sym, res, f = resolve_csharp_callee("Run", "Run", "src/Greeter.cs", ctx)
+        assert f != "scripts/util.py"
+        assert f == "src/Greeter.cs"
+        assert res == "local"
+        assert sym == 3
+
+    def test_python_only_symbol_is_never_bound(self) -> None:
+        """``OnlyPython`` exists ONLY in a Python file.
+
+        The C# caller must NOT bind to it — the language-compat gate drops the
+        sole candidate, so the result is ``unknown`` with NO resolved file.
+        This is the exact CodeGraph failure this project exists to beat.
+        """
+        ctx = _build_ctx()
+        sym, res, f = resolve_csharp_callee(
+            "OnlyPython", "OnlyPython", "src/Greeter.cs", ctx
+        )
+        assert res == "unknown"
+        assert f == ""
+        assert sym is None
+
+    def test_ambiguous_global_foreign_plus_self_stays_csharp(self) -> None:
+        """``Run`` has (Greeter.cs, util.py); called from a 3rd C# file.
+
+        From Helper.cs (no local ``Run``): the Python candidate is gated out,
+        leaving exactly one same-language candidate (Greeter.cs) -> project,
+        never the .py file.
+        """
+        ctx = _build_ctx()
+        sym, res, f = resolve_csharp_callee("Run", "Run", "src/Helper.cs", ctx)
+        assert f != "scripts/util.py"
+        assert res == "project"
+        assert f == "src/Greeter.cs"
+        assert sym == 3
+
+
+# ---------------------------------------------------------------------------
+# Registry + dispatch integration through the public resolve_callee
+# ---------------------------------------------------------------------------
+
+
+class TestRegistrationAndDispatch:
+    def test_csharp_is_registered(self) -> None:
+        resolver = get_language_resolver("csharp")
+        assert resolver is not None
+        assert resolver.language == "csharp"
+
+    def test_resolve_callee_dispatches_to_csharp(self) -> None:
+        cs_ctx = _build_ctx()
+        ctx = ResolverContext(
+            project_root=".",
+            cache=None,
+            file_languages={
+                "src/Greeter.cs": "csharp",
+                "src/Helper.cs": "csharp",
+                "scripts/util.py": "python",
+            },
+            lang_contexts={"csharp": cs_ctx},
+        )
+        # System.* qualifier through the public entry point.
+        resolved = resolve_callee(
+            "WriteLine",
+            "src/Greeter.cs",
+            ctx,
+            callee_full="System.Console.WriteLine",
+        )
+        assert resolved.resolution == "stdlib"
+
+        # Single-global project resolution through the public entry point.
+        resolved = resolve_callee(
+            "ComputeTotal",
+            "src/Greeter.cs",
+            ctx,
+            callee_full="ComputeTotal",
+        )
+        assert resolved.resolution == "project"
+        assert resolved.resolved_file == "src/Helper.cs"
+
+    def test_resolve_callee_moat_through_public_api(self) -> None:
+        cs_ctx = _build_ctx()
+        ctx = ResolverContext(
+            project_root=".",
+            cache=None,
+            file_languages={
+                "src/Greeter.cs": "csharp",
+                "scripts/util.py": "python",
+            },
+            lang_contexts={"csharp": cs_ctx},
+        )
+        resolved = resolve_callee(
+            "OnlyPython", "src/Greeter.cs", ctx, callee_full="OnlyPython"
+        )
+        assert resolved.resolution == "unknown"
+        assert resolved.resolved_file == ""
+
+
+# ---------------------------------------------------------------------------
+# Real-index integration — drive the FULL pipeline: write real .cs/.py files,
+# index them with ASTCache, build the resolver context the way production does,
+# and exercise resolve_csharp_callee against the context the index actually
+# produced (NOT a fabricated map). The C# symbol walker DOES populate
+# class/method rows (unlike C++), so the local tier fires end-to-end here.
+# ---------------------------------------------------------------------------
+
+
+def _index_and_build(tmp_path, files: dict[str, str]):
+    """Write ``files`` into ``tmp_path``, index them, return (cache, cs_ctx).
+
+    The cache is returned OPEN — the C# local tier consults the lazy
+    class-methods thunk (which reads the DB), so resolution must happen before
+    the connection is closed. Callers close the cache when done.
+    """
+    project = tmp_path / "proj"
+    project.mkdir()
+    for rel, body in files.items():
+        (project / rel).write_text(body)
+    cache = ASTCache(str(project))
+    cache.index_project(max_files=100)
+    resolver_ctx = build_resolver_context(cache)
+    return cache, resolver_ctx.lang_context("csharp")
+
+
+_REAL_CS = (
+    "using System;\n"
+    "namespace App {\n"
+    "  public class Greeter {\n"
+    "    public void Hello() {\n"
+    '      Console.WriteLine("hi");\n'
+    "      Helper();\n"
+    "      this.World();\n"
+    "    }\n"
+    "    private void Helper() { }\n"
+    "    public void World() { }\n"
+    "  }\n"
+    "}\n"
+)
+# A Python file defining the SAME bare name ``Helper`` — the cross-language
+# collision the moat must never bind a C# caller to.
+_REAL_PY = "def Helper():\n    return 2\n"
+
+
+class TestRealIndexIntegration:
+    def test_csharp_context_is_built_from_real_index(self, tmp_path) -> None:
+        cache, cs_ctx = _index_and_build(tmp_path, {"Greeter.cs": _REAL_CS})
+        try:
+            assert cs_ctx is not None
+            assert isinstance(cs_ctx, CSharpResolverContext)
+            assert cs_ctx.file_languages.get("Greeter.cs") == "csharp"
+        finally:
+            cache.close()
+
+    def test_system_qualifier_resolves_on_real_index(self, tmp_path) -> None:
+        cache, cs_ctx = _index_and_build(tmp_path, {"Greeter.cs": _REAL_CS})
+        try:
+            sym, res, f = resolve_csharp_callee(
+                "WriteLine", "Console.WriteLine", "Greeter.cs", cs_ctx
+            )
+            assert (sym, res, f) == (None, "stdlib", "")
+        finally:
+            cache.close()
+
+    def test_local_method_resolves_on_real_index(self, tmp_path) -> None:
+        """The C# walker DOES record methods, so an unqualified same-file call
+        resolves ``local`` end-to-end (no xfail needed, unlike C++)."""
+        cache, cs_ctx = _index_and_build(tmp_path, {"Greeter.cs": _REAL_CS})
+        try:
+            sym, res, f = resolve_csharp_callee(
+                "Helper", "Helper", "Greeter.cs", cs_ctx
+            )
+            assert res == "local"
+            assert f == "Greeter.cs"
+        finally:
+            cache.close()
+
+    def test_moat_holds_on_real_index(self, tmp_path) -> None:
+        """A C# caller's ``Helper`` call must never bind to the same-named
+        Python ``Helper`` definition on a real index."""
+        cache, cs_ctx = _index_and_build(
+            tmp_path, {"Greeter.cs": _REAL_CS, "util.py": _REAL_PY}
+        )
+        try:
+            _sym, _res, f = resolve_csharp_callee(
+                "Helper", "Helper", "Greeter.cs", cs_ctx
+            )
+            assert f != "util.py"
+            assert not f.endswith(".py")
+        finally:
+            cache.close()

--- a/tree_sitter_analyzer/synapse_resolver/languages/_csharp_constants.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/_csharp_constants.py
@@ -1,0 +1,105 @@
+"""Conservative stdlib classification tiers for the C# resolver (RFC-0010).
+
+The RFC-0008 lesson is MANDATORY here: a name is classified into a stdlib tier
+ONLY when it is (near-)exclusively that BCL API and very unlikely to be a
+user-defined symbol. Two signals carry the C# stdlib tier, in descending order
+of confidence:
+
+1. A **fully-qualified ``System.`` namespace prefix** (``System.Console.WriteLine``,
+   ``System.Linq.Enumerable.Select``). This is the C# analogue of C++'s
+   ``std::`` — ``namespace System`` is reserved BCL territory and user code never
+   legitimately owns it, so the qualifier alone is near-unspoofable evidence.
+   Handled by :func:`is_system_qualifier` (no shadow gate needed).
+
+2. A small, hand-audited set of **bare BCL static-type heads**
+   (``Console.WriteLine``, ``Math.Max``, ``Convert.ToInt32``,
+   ``Enumerable.Select``, ``String.Format``). These are static types whose
+   members are called through the TYPE NAME (not an instance), and whose names
+   are very unlikely to be a user class. This tier IS shadow-gated in
+   ``csharp.py``: if the project itself defines a same-language symbol of that
+   name (``class Console { ... }``), the BCL claim is suppressed (precision over
+   recall). Pruned HARD — common domain names (``File``, ``Path``, ``Directory``,
+   ``Task``, ``Environment``, ``Guid``) are LEFT OUT because they collide with
+   real project types; their calls stay ``unknown`` (an unknown edge is correct,
+   a mis-classified one is a moat breach).
+
+The **bare-method-name** tiers (``STDLIB_METHODS_CSHARP`` /
+``EXTERNAL_METHODS_CSHARP``) are INTENTIONALLY EMPTY: without receiver-type
+inference, a bare method name (``Add`` / ``Select`` / ``ToString`` / ``Contains``)
+collides massively with user methods. An empty tier is correct (RFC-0010).
+"""
+
+from __future__ import annotations
+
+#: The fully-qualified BCL root namespace. A call whose qualifier begins with
+#: this token (``System``, ``System.Console``, ``System.Linq.Enumerable``) is
+#: platform-provided, never project code — the C# analogue of ``std::``. The
+#: check is on the ``System.`` token boundary so a user namespace that merely
+#: starts with the letters ``System`` (``SystemExt``, ``MySystem``) does NOT
+#: match.
+SYSTEM_NAMESPACE_ROOT: str = "System"
+
+#: Bare BCL static-type heads classified ``stdlib`` when a call is qualified by
+#: one of them (``Console.WriteLine``) AND the project does not itself define a
+#: compatible-language symbol of that name (shadow gate in ``csharp.py``). Each
+#: entry is a static (or static-method-bearing) BCL type whose members are
+#: idiomatically called through the type name and whose name is near-exclusively
+#: the BCL type. Deliberately tiny: when in doubt a type is LEFT OUT.
+#:
+#:   Console     — ``Console.WriteLine`` / ``Console.ReadLine``; never a domain class.
+#:   Math        — ``Math.Max`` / ``Math.Floor``; a static math facade.
+#:   Convert     — ``Convert.ToInt32`` / ``Convert.ToBase64String``; BCL converter.
+#:   Enumerable  — ``Enumerable.Select`` / ``Enumerable.Range``; the LINQ statics.
+#:   String      — ``String.Format`` / ``String.IsNullOrEmpty``; the ``string``
+#:                 alias type, effectively reserved (user code does not define a
+#:                 type named ``String``).
+#:
+#: NOT included (collide with common domain types): File, Path, Directory, Task,
+#: Environment, Guid, Encoding, Regex, DateTime, TimeSpan, Tuple.
+BCL_STATIC_TYPES_CSHARP: frozenset[str] = frozenset(
+    {
+        "Console",
+        "Math",
+        "Convert",
+        "Enumerable",
+        "String",
+    }
+)
+
+#: Bare *method/function* names classified ``stdlib`` on an UNRESOLVED receiver.
+#: INTENTIONALLY EMPTY (see module docstring): without receiver-type evidence,
+#: every candidate (``ToString``/``Add``/``Select``/``Contains`` …) collides
+#: with user methods. Precision over recall — an unknown edge is correct.
+STDLIB_METHODS_CSHARP: frozenset[str] = frozenset()
+
+#: Bare names classified ``external`` (third-party). INTENTIONALLY EMPTY for the
+#: first PR: C# has no single dominant third-party library whose bare method
+#: names are safe to hardcode without receiver evidence. Stays empty until a
+#: safe set is proven.
+EXTERNAL_METHODS_CSHARP: frozenset[str] = frozenset()
+
+
+def is_system_qualifier(qualifier: str) -> bool:
+    """True when ``qualifier`` is the BCL ``System`` namespace (or a child).
+
+    ``qualifier`` is the receiver/namespace portion of a call's full name
+    (``System`` from ``System.WriteLine``; ``System.Console`` from
+    ``System.Console.WriteLine``). The match is on the ``System.`` token
+    boundary so a user namespace that merely starts with the letters ``System``
+    (``SystemExt``, ``MySystem``) is correctly rejected. ``System`` by itself
+    (the bare root) matches.
+    """
+    if not qualifier:
+        return False
+    return qualifier == SYSTEM_NAMESPACE_ROOT or qualifier.startswith(
+        SYSTEM_NAMESPACE_ROOT + "."
+    )
+
+
+__all__ = [
+    "BCL_STATIC_TYPES_CSHARP",
+    "EXTERNAL_METHODS_CSHARP",
+    "STDLIB_METHODS_CSHARP",
+    "SYSTEM_NAMESPACE_ROOT",
+    "is_system_qualifier",
+]

--- a/tree_sitter_analyzer/synapse_resolver/languages/csharp.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/csharp.py
@@ -1,0 +1,294 @@
+"""C# resolver registration (RFC-0010, second wave).
+
+Self-contained, conservative, SAFE per-language callee resolver for C#
+(``.cs``). It REPLACES the Python cascade for C# callers, so it must not
+regress: when unsure it returns ``unknown``.
+
+Resolution order (mirrors the spirit of the C++ resolver, equally cautious):
+
+1. **System.* qualifier** — a call qualified by the fully-qualified BCL root
+   namespace (``System.Console.WriteLine``, ``System.Linq.Enumerable.Select``)
+   is ``stdlib``. ``System.`` is the canonical, near-unspoofable signal — user
+   code never owns ``namespace System``. This wins first and needs no shadow
+   gate.
+2. **local** — no receiver (a bare method/function call) or an explicit
+   ``this``/``base`` receiver whose simple name is defined in the caller's OWN
+   file. A ``this``/``base`` member call binds only when exactly ONE class in
+   the file owns that method name (else the caller's class is unprovable →
+   unknown).
+3. **project (single-global)** — exactly one same-language project-wide
+   definition of an UNQUALIFIED name. The single-definition gate avoids the
+   ambiguity that wrecks method-name precision. Excluded for ``this``/``base``
+   member calls (a member call can never reach a cross-file global).
+4. **BCL static-type qualifier tier** — a bare static-type-qualified call
+   (``Console.WriteLine``, ``Math.Max``, ``String.Format``) is ``stdlib`` ONLY
+   when the project does not itself define a compatible-language symbol of that
+   type name (shadowing preserved). See ``_csharp_constants``.
+5. **stdlib / external METHOD tiers** — consulted only when the project owns no
+   compatible-language symbol of that name. **Both are EMPTY for this PR** (C#
+   bare method names collide too heavily with user code to classify safely).
+6. **unknown** — everything else (instance-receiver calls, qualified calls into
+   non-System / non-BCL types, ambiguous names).
+
+THE MOAT (never cross-language bind): every project binding is gated by
+``languages_compatible('csharp', owner_lang)``. C# is its own family (no
+directional/symmetric compat with any other tag), so a Python / Java / Go
+symbol that merely shares a name resolves to ``unknown`` (or a same-language
+def), NEVER the foreign file. The ``System.*`` and BCL tiers resolve to
+``stdlib`` only — never to a project file.
+
+The cascade returns a plain ``(symbol_id, resolution, resolved_file)`` tuple;
+the package ``__init__`` wraps it into a ``ResolvedCallee``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from ..._language_family import languages_compatible
+from .._registry import register_language
+from ._csharp_constants import (
+    BCL_STATIC_TYPES_CSHARP,
+    EXTERNAL_METHODS_CSHARP,
+    STDLIB_METHODS_CSHARP,
+    is_system_qualifier,
+)
+
+#: Extension-derived language tag this resolver owns (``.cs`` -> ``csharp``).
+_CSHARP_LANG: str = "csharp"
+
+#: Receiver tokens that denote the current/base object (a member call), not a
+#: separate type/namespace. A call qualified only by one of these is treated as
+#: a local member call.
+_SELF_RECEIVERS: frozenset[str] = frozenset({"this", "base"})
+
+#: Symbol kinds a bare (no-receiver) call may bind to in its own file: a method,
+#: a free function (top-level statements / local functions), or a class
+#: (constructor-style call).
+_LOCAL_KINDS: frozenset[str] = frozenset({"function", "method", "class"})
+#: Symbol kinds an explicit-self (``this.`` / ``base.``) call may bind to. The
+#: receiver PROVES the target is a member, so only ``method`` qualifies — a
+#: same-file class or free function is NOT a valid member-call target.
+_MEMBER_KINDS: frozenset[str] = frozenset({"method"})
+
+
+@dataclass
+class CSharpResolverContext:
+    """Per-index C# resolution maps (built once per pass).
+
+    All file keys are project-relative paths, matching the ``edges`` table.
+    Only the maps the conservative cascade needs are kept; everything else is
+    deliberately omitted to stay minimal and SAFE.
+    """
+
+    # file -> [(name, kind, symbol_id), ...] (shared cross-language map; we only
+    # ever read the CALLER file's own entry for a ``local`` match).
+    file_symbols: dict[str, list[tuple[str, str, int]]] = field(default_factory=dict)
+    # simple name -> [(file, symbol_id), ...] project-wide (single-global).
+    global_name_table: dict[str, list[tuple[str, int]]] = field(default_factory=dict)
+    # file -> language tag (so every project binding is language-gated: the
+    # moat — a same-name symbol in another language must NOT be bound).
+    file_languages: dict[str, str] = field(default_factory=dict)
+    # LAZY thunk -> {file: {class_name: {method_name: symbol_id}}}. Used only to
+    # disambiguate a ``this``/``base`` member call when a file declares >1 class
+    # owning the same method name: the caller's class is not threaded through the
+    # resolver, so a name owned by >1 class is ambiguous and stays unknown. Held
+    # as a thunk so non-C# projects and member-free workloads pay nothing — it is
+    # materialised at most once, on the first member-call disambiguation.
+    class_methods_thunk: Callable[[], dict[str, Any]] | None = None
+    # Memoised result of ``class_methods_thunk`` (None until first use).
+    _class_methods: dict[str, Any] | None = field(default=None, repr=False)
+
+    def member_owner_class_count(self, file_path: str, method_name: str) -> int:
+        """Return how many classes in ``file_path`` define ``method_name``.
+
+        Drives the conservative member-call gate: a ``this``/``base`` call may
+        bind a same-file ``method`` only when this count is exactly 1. A count of
+        0 (owner-class map silent on the name) means "no ambiguity evidence" and
+        the plain same-file lookup stands. The thunk is materialised lazily and
+        memoised, so non-member workloads never pay for it.
+        """
+        if self.class_methods_thunk is None:
+            return 0
+        if self._class_methods is None:
+            self._class_methods = self.class_methods_thunk() or {}
+        per_class = self._class_methods.get(file_path, {})
+        return sum(1 for methods in per_class.values() if method_name in methods)
+
+
+def build_csharp_context(
+    *,
+    imports_by_file: dict[str, Any],
+    file_languages: dict[str, str],
+    file_symbols: dict[str, Any],
+    global_name_table: dict[str, Any],
+    file_class_methods: Callable[[], dict[str, Any]],  # lazy thunk
+    **_ignored: Any,
+) -> CSharpResolverContext | None:
+    """Build the C# context, or ``None`` when no C# file is indexed.
+
+    Zero cost for non-C# projects (gated on ``file_languages``). The lazy
+    ``file_class_methods`` thunk is STORED but deliberately NOT called here — it
+    is materialised at most once, on the first ``this``/``base`` member call that
+    needs owner-class disambiguation (a file declaring >1 class with a colliding
+    method name). The plain local / single-global tiers never touch it, so a
+    project with no such ambiguity still pays nothing for the class/method map.
+    """
+    if not any(lang == _CSHARP_LANG for lang in file_languages.values()):
+        return None
+    return CSharpResolverContext(
+        file_symbols=file_symbols,
+        global_name_table=global_name_table,
+        file_languages=file_languages,
+        class_methods_thunk=file_class_methods,
+    )
+
+
+def _split_qualifier(callee_full: str, callee_name: str) -> tuple[str, str]:
+    """Return ``(qualifier, simple_name)`` from a C# call's full name.
+
+    C# member access is the single ``.`` operator; the LAST ``.`` separates the
+    qualifier from the call name. ``System.Console.WriteLine`` ->
+    ``("System.Console", "WriteLine")``; ``this.World`` -> ``("this", "World")``;
+    bare ``Helper`` -> ``("", "Helper")``.
+    """
+    full = callee_full or callee_name
+    if not full:
+        return "", callee_name
+    if "." in full:
+        qualifier, simple = full.rsplit(".", 1)
+        return qualifier, simple or callee_name
+    return "", full
+
+
+def _lookup_in_file(
+    ctx: CSharpResolverContext,
+    file_path: str,
+    simple: str,
+    kinds: frozenset[str],
+) -> int | None:
+    """Resolve ``simple`` to a same-file symbol of an allowed ``kind``.
+
+    OWNER-CLASS GATE: when the matched symbol is a ``method`` and the file
+    declares more than one class that defines a method of this name, the
+    resolver cannot prove which class a ``this``/``base`` call targets (the
+    caller's class is not threaded through). Binding either is a false ``local``
+    edge, so the ambiguous method is SKIPPED. A ``function`` / ``class`` symbol
+    is file-scoped (no owning class), so the gate never applies to it. Count 0
+    means "no ambiguity evidence" and the plain match stands.
+    """
+    ambiguous_method = (
+        "method" in kinds and ctx.member_owner_class_count(file_path, simple) > 1
+    )
+    for name, kind, sym_id in ctx.file_symbols.get(file_path, []):
+        if name != simple or kind not in kinds:
+            continue
+        if kind == "method" and ambiguous_method:
+            # Skip the class-ambiguous method, but keep scanning: an unqualified
+            # call may still bind a file-scoped free function / class of the
+            # same name (those are not class-owned, so unaffected by the gate).
+            continue
+        return sym_id
+    return None
+
+
+def _project_owns(ctx: CSharpResolverContext, simple: str) -> bool:
+    """True when a COMPATIBLE-LANGUAGE project symbol of name ``simple`` exists.
+
+    The RFC-0008 ownership gate, language-aware: a same-named symbol in an
+    incompatible-language file (e.g. a Python ``Console``) must NOT count as a C#
+    owner — ``languages_compatible('csharp', 'python')`` is False — so it neither
+    suppresses a BCL classification nor gets bound. An untagged file is treated
+    as a possible owner (conservative).
+    """
+    for owner_file, _sym_id in ctx.global_name_table.get(simple, []):
+        owner_lang = ctx.file_languages.get(owner_file, "")
+        if not owner_lang or languages_compatible(_CSHARP_LANG, owner_lang):
+            return True
+    return False
+
+
+def resolve_csharp_callee(
+    callee_name: str,
+    callee_full: str,
+    caller_file: str,
+    ctx: CSharpResolverContext,
+) -> tuple[int | None, str, str]:
+    """Resolve one C# call edge.
+
+    Returns ``(symbol_id, resolution, resolved_file)`` where ``resolution`` is
+    one of ``local`` / ``project`` / ``stdlib`` / ``external`` / ``unknown``.
+    Conservative by design: when unsure, ``unknown`` is the correct (moat-safe)
+    answer — never a cross-language bind.
+    """
+    qualifier, simple = _split_qualifier(callee_full, callee_name)
+    is_unqualified = qualifier == ""
+    is_self_receiver = qualifier in _SELF_RECEIVERS
+
+    # 1. System.* qualifier — fully-qualified BCL namespace. This wins first:
+    #    the qualifier is unambiguous evidence and never a project binding (user
+    #    code never owns ``namespace System``).
+    if is_system_qualifier(qualifier):
+        return None, "stdlib", ""
+
+    # 2. local — resolved in the caller's OWN file. An UNQUALIFIED call may bind
+    #    any local symbol (method / free function / class). An explicit SELF
+    #    receiver (``this.`` / ``base.``) asserts the target is a member, so it
+    #    may bind ONLY a same-file ``method`` — never a class or free function.
+    if is_unqualified or is_self_receiver:
+        kinds = _LOCAL_KINDS if is_unqualified else _MEMBER_KINDS
+        sym_id = _lookup_in_file(ctx, caller_file, simple, kinds)
+        if sym_id is not None:
+            return sym_id, "local", caller_file
+
+    # 3. project (single-global) — exactly one same-language project-wide
+    #    definition of an UNQUALIFIED name. THE MOAT: gate every candidate by
+    #    language compatibility so a foreign-language same-name symbol is never
+    #    bound; if the sole candidate is foreign, fall through to unknown. An
+    #    explicit SELF receiver is EXCLUDED here: a ``this.`` member call can
+    #    never reach a cross-file global, so binding one would be a false edge.
+    if is_unqualified:
+        compatible = [
+            (target_file, sym_id)
+            for target_file, sym_id in ctx.global_name_table.get(simple, [])
+            if languages_compatible(
+                _CSHARP_LANG, ctx.file_languages.get(target_file, "")
+            )
+        ]
+        if len(compatible) == 1:
+            target_file, sym_id = compatible[0]
+            return sym_id, "project", target_file
+
+    # 4. BCL static-type qualifier tier — a bare static-type-qualified call
+    #    (``Console.WriteLine``, ``Math.Max``) whose qualifier head is a
+    #    near-exclusive BCL static type AND the project does not itself define a
+    #    compatible-language symbol of that name (shadowing preserved). The head,
+    #    not the tail, is the type (``Console`` in ``Console.WriteLine``).
+    if not is_unqualified and not is_self_receiver:
+        head = qualifier.split(".", 1)[0]
+        if head in BCL_STATIC_TYPES_CSHARP and not _project_owns(ctx, head):
+            return None, "stdlib", ""
+
+    # 5. stdlib / external METHOD tiers — empty for this PR, but wired so a
+    #    future safe set classifies only when the project owns no
+    #    compatible-language symbol of that name (preserves shadowing).
+    if simple in STDLIB_METHODS_CSHARP and not _project_owns(ctx, simple):
+        return None, "stdlib", ""
+    if simple in EXTERNAL_METHODS_CSHARP and not _project_owns(ctx, simple):
+        return None, "external", ""
+
+    # 6. unknown — instance-receiver calls, non-System / non-BCL qualified calls,
+    #    and ambiguous unqualified names. ``unknown`` is correct: never a mis-wire.
+    return None, "unknown", ""
+
+
+register_language("csharp", build_csharp_context, resolve_csharp_callee)
+
+
+__all__ = [
+    "CSharpResolverContext",
+    "build_csharp_context",
+    "resolve_csharp_callee",
+]


### PR DESCRIPTION
## Summary

Self-contained, **SAFE**, per-language callee resolver for **C# (`.cs`)** — RFC-0010 second wave. **New-files-only**: auto-discovered via `languages/__init__`, no existing file edited (zero merge-conflict / worktree-race risk).

Files:
- `tree_sitter_analyzer/synapse_resolver/languages/csharp.py`
- `tree_sitter_analyzer/synapse_resolver/languages/_csharp_constants.py`
- `tests/unit/test_csharp_method_resolution.py`

## Cascade (conservative, moat-safe)

1. **`System.*` fully-qualified BCL namespace** → `stdlib`. The C# analogue of C++ `std::` — `namespace System` is reserved, never project code, so no shadow gate is needed.
2. **local** — same-file `method` / free function / `class`. A `this.`/`base.` member call binds only an **unambiguous** (single-owner-class) same-file method; a name owned by >1 class in the file stays `unknown` (caller's class is unprovable).
3. **project (single-global)** — exactly **one same-language** project-wide definition of an unqualified name. Excluded for `this.`/`base.` member calls.
4. **BCL static-type qualifier tier** — `Console` / `Math` / `Convert` / `Enumerable` / `String` qualified calls → `stdlib`, **shadow-gated** by `_project_owns`: a *same-language* project (or untagged) symbol of that type name suppresses the claim. Pruned HARD — `File`/`Path`/`Directory`/`Task`/`Environment`/`Guid` are deliberately LEFT OUT (collide with domain types).
5/6. **bare-method tiers EMPTY** (RFC-0008): without receiver-type inference, bare C# method names (`Add`/`Select`/`ToString`) collide too heavily to classify. Everything else → `unknown`.

## THE MOAT — never cross-language bind

Every project binding is gated by `languages_compatible('csharp', owner_lang)`. C# is its own family (no symmetric/directional compat with any other tag), so a Python/Java/Go symbol that merely shares a name resolves to `unknown` or a same-language def — **never** the foreign file.

## Tests (RED-first)

31 new tests, including the **mandatory no-cross-language-mis-wire** suite (unit + public-API dispatch + real-index). Real-index integration drives the full `ASTCache` pipeline: the C# symbol walker records methods/classes, so the `local` tier fires **end-to-end** (no xfail needed, unlike C++).

- Targeted: `tests/unit/test_csharp_method_resolution.py` → 31 passed
- Regression `-k 'resolver or synapse or registry'` → **375 passed, 2 skipped** (Java byte-parity intact)
- `ruff check` + `ruff format --check` + `mypy` clean on new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)