### PR TITLE
feat(resolver): conservative PHP callee resolver (RFC-0010 second wave)

### DIFF
--- a/tests/unit/test_php_method_resolution.py
+++ b/tests/unit/test_php_method_resolution.py
@@ -1,0 +1,459 @@
+"""RFC-0010 second wave: the PHP per-language callee resolver.
+
+PHP calls come in several syntactic shapes the resolver must classify
+correctly without ever guessing:
+
+* bare / same-file       — ``helper()`` resolves to a same-file ``function``.
+* namespaced free call   — ``\\App\\helper()`` / ``App\\helper()`` resolve on the
+  last segment as a same-file free function (the ``\\`` split is a namespace,
+  not a class/instance receiver).
+* global built-in        — ``strlen()`` / ``array_map()`` / ``json_encode()``
+  classify as ``builtin`` ONLY when the project does not itself define a free
+  function of that name (shadowing preserved).
+* self method call       — ``$this->m()`` / ``self::m()`` / ``static::m()`` /
+  ``parent::m()`` bind ``local`` ONLY when exactly ONE class in the caller file
+  defines ``m`` (the enclosing class is not carried by the edge → ambiguous
+  across classes stays ``unknown``).
+* receiver call          — ``Foo::bar()`` (static) / ``$obj->bar()`` (instance)
+  / ``App\\Util::run()`` carry a class type the edge does not record; the
+  resolver must NEVER guess a same-name method elsewhere → ``unknown``.
+
+The mandatory moat assertion: a callee whose bare name also exists as a symbol
+in ANOTHER language's file must NEVER bind to that file — PHP only ever resolves
+``local`` against its own (same-language) caller file, and the built-in shadow
+gate is language-aware so a same-named Python symbol never suppresses (nor is
+bound by) the PHP classification.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from tree_sitter_analyzer.ast_cache import ASTCache
+from tree_sitter_analyzer.synapse_resolver import ResolvedCallee, resolve_callee
+from tree_sitter_analyzer.synapse_resolver import languages as _languages
+from tree_sitter_analyzer.synapse_resolver._context import ResolverContext
+from tree_sitter_analyzer.synapse_resolver._registry import (
+    get_language_resolver,
+    registered_languages,
+)
+from tree_sitter_analyzer.synapse_resolver.languages.php import (
+    PhpResolverContext,
+    build_php_context,
+    resolve_php_callee,
+)
+
+
+# ---------------------------------------------------------------------------
+# Registration / discovery
+# ---------------------------------------------------------------------------
+def test_php_is_registered_via_discovery() -> None:
+    """Dropping ``languages/php.py`` auto-registers the PHP resolver — no edit
+    to any shared file."""
+    assert "php" in registered_languages()
+    assert get_language_resolver("php") is not None
+    assert "php" in {
+        m.name
+        for m in __import__("pkgutil").iter_modules(_languages.__path__)
+        if not m.name.startswith("_")
+    }
+
+
+# ---------------------------------------------------------------------------
+# build_php_context gating (zero cost when no PHP file is indexed)
+# ---------------------------------------------------------------------------
+def test_build_context_returns_none_without_php_files() -> None:
+    ctx = build_php_context(
+        imports_by_file={},
+        file_languages={"a.py": "python"},
+        file_symbols={},
+        global_name_table={},
+        file_class_methods=lambda: {},
+    )
+    assert ctx is None
+
+
+def test_build_context_built_when_php_file_present() -> None:
+    ctx = build_php_context(
+        imports_by_file={},
+        file_languages={"app.php": "php"},
+        file_symbols={"app.php": [("helper", "function", 7)]},
+        global_name_table={"helper": [("app.php", 7)]},
+        file_class_methods=lambda: {},
+    )
+    assert isinstance(ctx, PhpResolverContext)
+    assert "app.php" in ctx.file_symbols
+
+
+def test_build_context_does_not_force_thunk_for_non_php() -> None:
+    """The lazy class-method thunk must NOT be forced when no PHP file exists."""
+    forced = {"hit": False}
+
+    def _thunk() -> dict:
+        forced["hit"] = True
+        return {}
+
+    ctx = build_php_context(
+        imports_by_file={},
+        file_languages={"a.py": "python"},
+        file_symbols={},
+        global_name_table={},
+        file_class_methods=_thunk,
+    )
+    assert ctx is None
+    assert forced["hit"] is False
+
+
+# ---------------------------------------------------------------------------
+# Direct resolver unit tests
+# ---------------------------------------------------------------------------
+def _ctx(
+    symbols: dict[str, list[tuple[str, str, int]]],
+    *,
+    class_methods: dict[str, dict[str, dict[str, int]]] | None = None,
+    global_table: dict[str, list[tuple[str, int]]] | None = None,
+    languages: dict[str, str] | None = None,
+) -> PhpResolverContext:
+    """Build a PHP context for unit tests.
+
+    ``global_table`` defaults to one derived from ``symbols`` so the built-in
+    shadow gate sees the project's own free functions; ``languages`` defaults to
+    tagging every file ``php``.
+    """
+    if global_table is None:
+        global_table = {}
+        for fp, syms in symbols.items():
+            for name, _kind, sym_id in syms:
+                global_table.setdefault(name, []).append((fp, sym_id))
+    if languages is None:
+        languages = dict.fromkeys(symbols, "php")
+    built = build_php_context(
+        imports_by_file={},
+        file_languages=languages,
+        file_symbols=symbols,
+        global_name_table=global_table,
+        file_class_methods=lambda: class_methods or {},
+    )
+    assert built is not None
+    return built
+
+
+def test_same_file_free_function_resolves_local() -> None:
+    ctx = _ctx({"app.php": [("helper", "function", 7), ("main", "function", 11)]})
+    sym_id, resolution, resolved = resolve_php_callee(
+        "helper", "helper", "app.php", ctx
+    )
+    assert (sym_id, resolution, resolved) == (7, "local", "app.php")
+
+
+def test_namespaced_free_call_resolves_local_on_last_segment() -> None:
+    """``\\App\\helper`` (namespace ``\\`` split) resolves to a same-file free
+    function ``helper`` — a namespace prefix is not a class/instance receiver."""
+    ctx = _ctx({"app.php": [("helper", "function", 7)]})
+    sym_id, resolution, resolved = resolve_php_callee(
+        "helper", "\\App\\helper", "app.php", ctx
+    )
+    assert (sym_id, resolution, resolved) == (7, "local", "app.php")
+
+
+def test_relative_namespaced_free_call_resolves_local() -> None:
+    ctx = _ctx({"app.php": [("helper", "function", 7)]})
+    sym_id, resolution, resolved = resolve_php_callee(
+        "helper", "App\\helper", "app.php", ctx
+    )
+    assert (sym_id, resolution, resolved) == (7, "local", "app.php")
+
+
+def test_builtin_bare_function_classifies_builtin() -> None:
+    ctx = _ctx({"app.php": [("main", "function", 11)]})
+    sym_id, resolution, resolved = resolve_php_callee(
+        "strlen", "strlen", "app.php", ctx
+    )
+    assert (sym_id, resolution, resolved) == (None, "builtin", "")
+
+
+def test_builtin_array_map_classifies_builtin() -> None:
+    ctx = _ctx({"app.php": [("main", "function", 11)]})
+    _sym, resolution, _file = resolve_php_callee(
+        "array_map", "array_map", "app.php", ctx
+    )
+    assert resolution == "builtin"
+
+
+def test_builtin_json_encode_classifies_builtin() -> None:
+    ctx = _ctx({"app.php": [("main", "function", 11)]})
+    _sym, resolution, _file = resolve_php_callee(
+        "json_encode", "json_encode", "app.php", ctx
+    )
+    assert resolution == "builtin"
+
+
+def test_project_free_function_shadows_builtin() -> None:
+    """A project free function named like a built-in (``count``) shadows it —
+    the same-file ``local`` resolution wins, never ``builtin`` (precision)."""
+    ctx = _ctx({"app.php": [("count", "function", 3), ("main", "function", 11)]})
+    sym_id, resolution, resolved = resolve_php_callee("count", "count", "app.php", ctx)
+    assert (sym_id, resolution, resolved) == (3, "local", "app.php")
+
+
+def test_project_owns_builtin_name_in_other_php_file_suppresses_builtin() -> None:
+    """A project free function named ``count`` in ANOTHER php file shadows the
+    built-in for a caller that does not define it locally — stays ``unknown``
+    rather than ``builtin`` (the project owns the name)."""
+    ctx = _ctx(
+        {
+            "caller.php": [("main", "function", 11)],
+            "lib.php": [("count", "function", 3)],
+        }
+    )
+    sym_id, resolution, resolved = resolve_php_callee(
+        "count", "count", "caller.php", ctx
+    )
+    assert (sym_id, resolution, resolved) == (None, "unknown", "")
+
+
+def test_this_method_call_unique_class_resolves_local() -> None:
+    """``$this->process`` binds to the single class defining ``process``."""
+    ctx = _ctx(
+        {"app.php": [("process", "method", 9)]},
+        class_methods={"app.php": {"Service": {"process": 9, "run": 5}}},
+    )
+    sym_id, resolution, resolved = resolve_php_callee(
+        "process", "$this->process", "app.php", ctx
+    )
+    assert (sym_id, resolution, resolved) == (9, "local", "app.php")
+
+
+def test_self_static_call_unique_class_resolves_local() -> None:
+    ctx = _ctx(
+        {"app.php": [("make", "method", 4)]},
+        class_methods={"app.php": {"Factory": {"make": 4}}},
+    )
+    sym_id, resolution, resolved = resolve_php_callee(
+        "make", "self::make", "app.php", ctx
+    )
+    assert (sym_id, resolution, resolved) == (4, "local", "app.php")
+
+
+def test_this_method_call_ambiguous_across_classes_stays_unknown() -> None:
+    """Two classes in one file both define ``save`` — the caller's enclosing
+    class is not carried by the edge, so ``$this->save`` is ambiguous and must
+    stay ``unknown`` (never the file-wide first match)."""
+    ctx = _ctx(
+        {"app.php": [("save", "method", 5)]},
+        class_methods={
+            "app.php": {"A": {"save": 5}, "B": {"save": 9}},
+        },
+    )
+    sym_id, resolution, resolved = resolve_php_callee(
+        "save", "$this->save", "app.php", ctx
+    )
+    assert (sym_id, resolution, resolved) == (None, "unknown", "")
+
+
+def test_parent_call_resolves_unique_class_method() -> None:
+    ctx = _ctx(
+        {"app.php": [("boot", "method", 7)]},
+        class_methods={"app.php": {"Base": {"boot": 7}}},
+    )
+    _sym, resolution, _file = resolve_php_callee("boot", "parent::boot", "app.php", ctx)
+    assert resolution == "local"
+
+
+def test_static_receiver_call_stays_unknown() -> None:
+    """``Foo::bar`` — ``Foo`` is a class whose definition the edge does not
+    resolve to a type here; the resolver must NOT guess a same-name ``bar``."""
+    ctx = _ctx(
+        {"app.php": [("bar", "method", 5)]},
+        class_methods={"app.php": {"Other": {"bar": 5}}},
+    )
+    sym_id, resolution, resolved = resolve_php_callee("bar", "Foo::bar", "app.php", ctx)
+    assert (sym_id, resolution, resolved) == (None, "unknown", "")
+
+
+def test_namespaced_static_receiver_call_stays_unknown() -> None:
+    """``App\\Util::run`` is a static RECEIVER call (last separator ``::``), NOT
+    a namespaced free function — it must stay ``unknown`` even though the
+    receiver text contains a ``\\`` namespace."""
+    ctx = _ctx(
+        {"app.php": [("run", "function", 5)]},
+    )
+    sym_id, resolution, resolved = resolve_php_callee(
+        "run", "App\\Util::run", "app.php", ctx
+    )
+    assert (sym_id, resolution, resolved) == (None, "unknown", "")
+
+
+def test_instance_receiver_call_stays_unknown() -> None:
+    """``$obj->bar`` — receiver is a variable whose class type the edge does not
+    carry. Never guess a same-name method elsewhere."""
+    ctx = _ctx(
+        {"app.php": [("bar", "method", 5)]},
+        class_methods={"app.php": {"Other": {"bar": 5}}},
+    )
+    sym_id, resolution, resolved = resolve_php_callee(
+        "bar", "$obj->bar", "app.php", ctx
+    )
+    assert (sym_id, resolution, resolved) == (None, "unknown", "")
+
+
+def test_bare_name_not_in_file_and_not_builtin_stays_unknown() -> None:
+    ctx = _ctx({"app.php": [("main", "function", 11)]})
+    sym_id, resolution, resolved = resolve_php_callee(
+        "missing", "missing", "app.php", ctx
+    )
+    assert (sym_id, resolution, resolved) == (None, "unknown", "")
+
+
+def test_bare_call_does_not_bind_sibling_method() -> None:
+    """A bare ``render()`` must NOT bind to a same-file class ``method`` named
+    ``render`` (a method needs a receiver) — only a top-level ``function``."""
+    ctx = _ctx({"app.php": [("render", "method", 5)]})
+    sym_id, resolution, resolved = resolve_php_callee(
+        "render", "render", "app.php", ctx
+    )
+    assert (sym_id, resolution, resolved) == (None, "unknown", "")
+
+
+def test_external_tier_is_empty() -> None:
+    """The PHP external tier is intentionally empty (RFC-0008 precision)."""
+    from tree_sitter_analyzer.synapse_resolver.languages._php_constants import (
+        EXTERNAL_FUNCTIONS_PHP,
+    )
+
+    assert EXTERNAL_FUNCTIONS_PHP == frozenset()
+
+
+# ---------------------------------------------------------------------------
+# Integration through the registry dispatch (resolve_callee)
+# ---------------------------------------------------------------------------
+def test_resolve_callee_routes_php_to_php_resolver() -> None:
+    php_ctx = _ctx({"app.php": [("helper", "function", 7)]})
+    ctx = ResolverContext(
+        project_root=".",
+        cache=None,
+        file_languages={"app.php": "php"},
+        lang_contexts={"php": php_ctx},
+    )
+    res = resolve_callee("helper", "app.php", ctx, "helper")
+    assert isinstance(res, ResolvedCallee)
+    assert (res.callee_symbol_id, res.resolution, res.resolved_file) == (
+        7,
+        "local",
+        "app.php",
+    )
+
+
+def test_resolve_callee_php_builtin_through_registry() -> None:
+    php_ctx = _ctx({"app.php": [("main", "function", 11)]})
+    ctx = ResolverContext(
+        project_root=".",
+        cache=None,
+        file_languages={"app.php": "php"},
+        lang_contexts={"php": php_ctx},
+    )
+    res = resolve_callee("strlen", "app.php", ctx, "strlen")
+    assert res.resolution == "builtin"
+
+
+# ---------------------------------------------------------------------------
+# THE MOAT — no cross-language mis-wire (MANDATORY)
+# ---------------------------------------------------------------------------
+def test_no_cross_language_mis_wire_direct() -> None:
+    """A PHP caller's bare ``helper`` must NEVER resolve to a Python file that
+    happens to define ``helper``. The PHP resolver only consults its own caller
+    file (same-language by construction)."""
+    ctx = build_php_context(
+        imports_by_file={},
+        file_languages={"app.php": "php", "util.py": "python"},
+        # Python file defines `helper`; the PHP caller file does NOT.
+        file_symbols={"util.py": [("helper", "function", 3)]},
+        global_name_table={"helper": [("util.py", 3)]},
+        file_class_methods=lambda: {},
+    )
+    assert ctx is not None
+    sym_id, resolution, resolved = resolve_php_callee(
+        "helper", "helper", "app.php", ctx
+    )
+    # MUST NOT bind to util.py — stays unknown.
+    assert (sym_id, resolution, resolved) == (None, "unknown", "")
+    assert resolved != "util.py"
+
+
+def test_no_cross_language_builtin_name_not_suppressed_by_python() -> None:
+    """A Python symbol named ``count`` must NOT suppress PHP's ``count`` built-in
+    classification (the shadow gate is language-aware). PHP has no interop family
+    with Python, so a Python ``count`` is not a PHP owner."""
+    ctx = build_php_context(
+        imports_by_file={},
+        file_languages={"app.php": "php", "util.py": "python"},
+        file_symbols={"util.py": [("count", "function", 3)]},
+        global_name_table={"count": [("util.py", 3)]},
+        file_class_methods=lambda: {},
+    )
+    assert ctx is not None
+    sym_id, resolution, resolved = resolve_php_callee("count", "count", "app.php", ctx)
+    # The Python `count` is NOT a PHP owner → builtin classification stands,
+    # and the resolver NEVER binds to util.py.
+    assert (sym_id, resolution, resolved) == (None, "builtin", "")
+    assert resolved != "util.py"
+
+
+def test_no_cross_language_mis_wire_end_to_end(tmp_path: Path) -> None:
+    """Index a polyglot repo where ``helper`` exists as a Python def AND as a
+    PHP free function in separate files. Build the real resolver context from
+    the index and assert the PHP caller's bare ``helper`` resolves to the PHP
+    file's own symbol id (same-language) — NEVER the Python file. This proves
+    the moat holds through the production context builder, not just a hand-built
+    context."""
+    (tmp_path / "py").mkdir()
+    (tmp_path / "py" / "helpers.py").write_text("def helper(s):\n    return len(s)\n")
+    (tmp_path / "app.php").write_text(
+        "<?php\n"
+        "namespace App;\n\n"
+        "function helper($s) {\n"
+        "    return strlen($s);\n"
+        "}\n\n"
+        "function main() {\n"
+        "    return helper('hi');\n"
+        "}\n"
+    )
+    cache = ASTCache(str(tmp_path))
+    try:
+        cache.index_project()
+        from tree_sitter_analyzer.synapse_resolver._context import (
+            build_resolver_context,
+        )
+
+        rctx = build_resolver_context(cache)
+    finally:
+        cache.close()
+
+    # The PHP file's own `helper` symbol id (looked up from the index).
+    db = str(tmp_path / ".ast-cache" / "index.db")
+    conn = sqlite3.connect(db)
+    conn.row_factory = sqlite3.Row
+    try:
+        php_helper = conn.execute(
+            "SELECT id FROM ast_symbol_rows "
+            "WHERE name = 'helper' AND file_path = 'app.php'"
+        ).fetchone()
+        py_helper = conn.execute(
+            "SELECT id FROM ast_symbol_rows "
+            "WHERE name = 'helper' AND file_path = 'py/helpers.py'"
+        ).fetchone()
+    finally:
+        conn.close()
+    assert php_helper is not None and py_helper is not None
+
+    res = resolve_callee("helper", "app.php", rctx, "helper")
+    # Same-language bind only: the PHP caller resolves to app.php's helper,
+    # NEVER the Python file's helper.
+    assert res.resolved_file != "py/helpers.py"
+    assert res.callee_symbol_id != py_helper["id"]
+    assert (res.callee_symbol_id, res.resolution, res.resolved_file) == (
+        php_helper["id"],
+        "local",
+        "app.php",
+    )

--- a/tree_sitter_analyzer/synapse_resolver/languages/_php_constants.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/_php_constants.py
@@ -1,0 +1,195 @@
+"""Conservative classification tiers for the PHP resolver (RFC-0010, 2nd wave).
+
+The RFC-0008 lesson is MANDATORY here: a name belongs in a classified tier ONLY
+when it is (near-)exclusively that API and is unlikely to be a project symbol.
+The PHP resolver carries NO receiver-type inference, so it classifies on the
+SAFEST available signal and nothing more.
+
+For PHP that signal is a **bare, unqualified, global free-function call**.
+PHP's standard library is exposed as thousands of *global* functions
+(``strlen``, ``count``, ``array_map``, ``json_encode``, ``preg_match`` …) that
+live in the root namespace and are called WITHOUT a receiver. This is the one
+PHP call shape where a name match is a relatively safe classification signal:
+
+* A ``Foo::bar()`` static call or a ``$obj->bar()`` instance call has a receiver
+  whose class type the edge does not carry — classifying those by bare method
+  name would mis-wire domain calls (the exact CodeGraph failure this project
+  beats). They stay ``unknown``.
+* A bare ``foo()`` call is either a project free function (resolved ``local`` by
+  the caller-file symbol table FIRST) or a global built-in. Only a curated,
+  unambiguous set of built-ins is classified ``builtin``.
+
+PRECISION over recall (the mandate):
+
+* ``PHP_BUILTIN_FUNCTIONS`` is a HAND-AUDITED subset of PHP's global functions,
+  deliberately limited to names a project almost never shadows with its own
+  free function. Generic-looking names that a domain layer legitimately defines
+  as a helper (``get`` / ``set`` / ``add`` / ``filter`` / ``map`` / ``find`` /
+  ``log`` / ``format`` / ``validate``) are EXCLUDED — they would mis-classify a
+  project helper as a built-in.
+* The ``local`` tier always wins first: a project free function named ``count``
+  shadows the built-in (checked before this set is consulted), so even a listed
+  name stays ``local``/``unknown`` when the project owns it.
+* ``EXTERNAL_FUNCTIONS_PHP`` is intentionally EMPTY: PHP third-party libraries
+  expose their API through *namespaced classes and methods*, not distinctive
+  global free functions, so there is no bare name that is (near-)exclusively one
+  third-party library. Everything non-local, non-builtin stays ``unknown``.
+
+An EMPTY-er tier is always safe: names just stay ``local`` / ``unknown``, never
+cross-wired.
+"""
+
+from __future__ import annotations
+
+#: Hand-audited PHP global built-in free functions. A BARE (unqualified, no
+#: receiver) call to one of these classifies as ``builtin`` — but ONLY when the
+#: project does not itself define a free function of that name (the ``local`` /
+#: ownership gate runs first, so a domain helper shadowing a built-in stays
+#: project-owned). These are core-language functions whose names a project very
+#: rarely reuses as a free function. When in doubt a name is LEFT OUT (it then
+#: stays ``unknown`` — never guessed in).
+PHP_BUILTIN_FUNCTIONS: frozenset[str] = frozenset(
+    {
+        # strings
+        "strlen",
+        "strpos",
+        "stripos",
+        "strrpos",
+        "substr",
+        "str_replace",
+        "str_repeat",
+        "str_pad",
+        "str_split",
+        "str_contains",
+        "str_starts_with",
+        "str_ends_with",
+        "strtolower",
+        "strtoupper",
+        "ucfirst",
+        "ucwords",
+        "trim",
+        "ltrim",
+        "rtrim",
+        "sprintf",
+        "vsprintf",
+        "number_format",
+        "nl2br",
+        "htmlspecialchars",
+        "htmlentities",
+        "strip_tags",
+        "wordwrap",
+        "mb_strlen",
+        "mb_substr",
+        "mb_strtolower",
+        "mb_strtoupper",
+        # arrays
+        "array_map",
+        "array_filter",
+        "array_reduce",
+        "array_merge",
+        "array_keys",
+        "array_values",
+        "array_search",
+        "array_key_exists",
+        "array_combine",
+        "array_flip",
+        "array_slice",
+        "array_splice",
+        "array_diff",
+        "array_intersect",
+        "array_unique",
+        "array_reverse",
+        "array_column",
+        "array_fill",
+        "array_pad",
+        "array_chunk",
+        "array_push",
+        "array_pop",
+        "array_shift",
+        "array_unshift",
+        "in_array",
+        "implode",
+        "explode",
+        "compact",
+        "extract",
+        "ksort",
+        "krsort",
+        "asort",
+        "arsort",
+        "usort",
+        "uasort",
+        "uksort",
+        # JSON / serialization
+        "json_encode",
+        "json_decode",
+        "serialize",
+        "unserialize",
+        "base64_encode",
+        "base64_decode",
+        # regex
+        "preg_match",
+        "preg_match_all",
+        "preg_replace",
+        "preg_replace_callback",
+        "preg_split",
+        "preg_quote",
+        # math
+        "abs",
+        "ceil",
+        "floor",
+        "round",
+        "intdiv",
+        "fmod",
+        "pow",
+        "sqrt",
+        "intval",
+        "floatval",
+        # type / variable
+        "is_array",
+        "is_string",
+        "is_int",
+        "is_integer",
+        "is_float",
+        "is_bool",
+        "is_null",
+        "is_numeric",
+        "is_callable",
+        "is_object",
+        "is_iterable",
+        "gettype",
+        "settype",
+        "isset",
+        "empty",
+        "var_dump",
+        "var_export",
+        "print_r",
+        # functional / misc core
+        "call_user_func",
+        "call_user_func_array",
+        "func_get_args",
+        "func_num_args",
+        "function_exists",
+        "class_exists",
+        "method_exists",
+        "property_exists",
+        "interface_exists",
+        "get_class",
+        "get_parent_class",
+        "instanceof",
+        "spl_autoload_register",
+        # array count / iteration (count is core, very rarely shadowed)
+        "count",
+        "sizeof",
+        "iterator_to_array",
+    }
+)
+
+#: Intentionally EMPTY (RFC-0008 / RFC-0010): no PHP bare free-function name is
+#: (near-)exclusively one third-party library — PHP libraries expose their API
+#: through namespaced classes/methods, not distinctive global functions. So
+#: everything that is neither a same-file local nor a curated built-in stays
+#: ``unknown`` rather than risk a mis-classification. An empty tier is correct.
+EXTERNAL_FUNCTIONS_PHP: frozenset[str] = frozenset()
+
+
+__all__ = ["EXTERNAL_FUNCTIONS_PHP", "PHP_BUILTIN_FUNCTIONS"]

--- a/tree_sitter_analyzer/synapse_resolver/languages/php.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/php.py
@@ -1,0 +1,264 @@
+r"""PHP callee resolver (RFC-0010, second wave).
+
+Self-contained and SAFE. It REPLACES the Python cascade for PHP callers
+(``file_languages == "php"``) without regressing: it resolves SAME-FILE/
+SAME-LANGUAGE local calls, classifies a curated set of global built-in free
+functions as ``builtin``, and returns ``unknown`` for everything else.
+
+PHP call shapes and how each is handled:
+
+* **bare ``foo()``** (no receiver) — a free-function call. Resolved ``local`` to
+  a same-file ``function``/``class`` definition first; else, if ``foo`` is a
+  curated global built-in NOT shadowed by a project free function, ``builtin``;
+  else ``unknown``. A namespaced free call (``\App\foo`` / ``App\foo``) is
+  treated as bare on its LAST segment.
+* **``$this->m()`` / ``self::m()`` / ``static::m()`` / ``parent::m()``** — a
+  method call on the current object/class. Bound ``local`` ONLY when exactly one
+  class in the caller file defines ``m`` (the caller's enclosing class is not
+  carried by the edge, so an ambiguous name across two classes stays
+  ``unknown`` — never the file-wide first match, the wave-1 Codex P2 lesson).
+* **``Foo::m()`` (static) / ``$obj->m()`` (instance)** — a receiver call whose
+  class type the edge does not carry. Never guessed → ``unknown``.
+
+THE MOAT — never cross-language bind. The resolver only ever consults the
+CALLER file's own ``file_symbols`` / ``file_class_methods`` for a ``local``
+match and never looks up a symbol in another file, so a same-named symbol in a
+different language's file can never be bound. Built-in classification produces
+no symbol/file at all. PHP has no interop family (``languages_compatible`` is
+True only for the identical tag), so even the ownership/shadow gate is
+same-language by construction.
+
+Conservative tiers only (the RFC-0008 lesson): the bare built-in set is a small
+hand-audited list of global functions a project almost never shadows; the
+external tier is EMPTY. Receiver-qualified method names stay ``unknown``.
+
+Contract (RFC-0010): the module ends with
+``register_language("php", build_php_context, resolve_php_callee)``.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from ..._language_family import languages_compatible
+from .._registry import register_language
+from ._php_constants import PHP_BUILTIN_FUNCTIONS
+
+#: ``file_languages`` tag for every ``.php`` file.
+_PHP_LANG = "php"
+
+#: Receivers that mean "the current object / class" — a class-scoped method
+#: call. The caller's enclosing class is NOT available to the resolver, so these
+#: bind only through the unambiguous single-class gate (never the file-wide
+#: first match). A BARE (empty) receiver is handled separately: a bare ``foo()``
+#: is a free-function call, not a class-method call.
+_SELF_RECEIVERS = frozenset({"$this", "this", "self", "static", "parent"})
+
+#: Symbol kinds a bare ``foo()`` call can legally target: a top-level
+#: ``function``. A ``class`` is a construction (``new Foo()``), not a plain
+#: call, and a ``method`` needs an owning receiver — matching either here would
+#: bind a bare ``render()`` to a sibling class's method (a concrete wrong edge).
+_BARE_CALLABLE_KINDS = frozenset({"function"})
+
+#: Separators that can appear between a PHP receiver and the call name in the
+#: edge's full name: ``::`` (static / class-const), ``->`` (instance), ``\``
+#: (namespace), and ``.`` (a normalised form some extractors emit). We split on
+#: the LAST occurrence of any of these so ``App\Util::run`` -> receiver
+#: ``App\Util``, name ``run`` and ``\App\helper`` -> receiver ``\App``, name
+#: ``helper``.
+_RECEIVER_SPLIT = re.compile(r"(?:::|->|\\|\.)")
+
+
+@dataclass
+class PhpResolverContext:
+    """Per-index PHP resolution maps (built once per pass).
+
+    Holds only the shared cross-language maps the resolver consults. All file
+    keys are project-relative paths, matching the ``edges`` table. The resolver
+    reads only the CALLER file's own entries for a ``local`` match, so carrying
+    the full maps is safe.
+    """
+
+    # file -> [(name, kind, symbol_id), ...] (shared cross-language map).
+    file_symbols: dict[str, list[tuple[str, str, int]]] = field(default_factory=dict)
+    # file -> {class -> {method -> symbol_id}} (shared cross-language map).
+    file_class_methods: dict[str, dict[str, dict[str, int]]] = field(
+        default_factory=dict
+    )
+    # simple name -> [(file, symbol_id), ...] project-wide (single-global). Used
+    # ONLY by the built-in shadow gate (a project free function shadows a
+    # built-in of the same name); never to bind a project symbol.
+    global_name_table: dict[str, list[tuple[str, int]]] = field(default_factory=dict)
+    # file -> language tag (so the shadow gate stays language-aware).
+    file_languages: dict[str, str] = field(default_factory=dict)
+
+
+def build_php_context(
+    *,
+    imports_by_file: dict[str, Any],
+    file_languages: dict[str, str],
+    file_symbols: dict[str, Any],
+    global_name_table: dict[str, Any],
+    file_class_methods: Any,  # zero-arg thunk -> class->method map (lazy)
+    **_ignored: Any,
+) -> PhpResolverContext | None:
+    """Build the PHP context, or ``None`` when no PHP file is indexed.
+
+    Zero cost for non-PHP projects: gated on ``file_languages`` BEFORE the lazy
+    ``file_class_methods`` thunk is forced, so a Python/Java-only index never
+    pays to materialise the class-method map for PHP.
+    """
+    if not any(lang == _PHP_LANG for lang in file_languages.values()):
+        return None
+    fcm = file_class_methods() if callable(file_class_methods) else file_class_methods
+    return PhpResolverContext(
+        file_symbols=file_symbols,
+        file_class_methods=fcm or {},
+        global_name_table=global_name_table,
+        file_languages=file_languages,
+    )
+
+
+def _split_receiver(callee_full: str, callee_name: str) -> tuple[str, str, str]:
+    """Return ``(receiver, simple_name, separator)`` from a PHP call's full name.
+
+    Splits on the LAST of ``::`` / ``->`` / ``\\`` / ``.``; ``separator`` is the
+    matched text of that LAST split (``""`` for a bare name), which tells the
+    resolver the call SHAPE — a ``\\``-terminated split is a namespace-qualified
+    FREE function, whereas ``::``/``->`` is a class/instance RECEIVER call:
+
+    * ``helper``            -> ``("", "helper", "")``          (bare free fn)
+    * ``\\App\\helper``      -> ``("\\App", "helper", "\\")``     (namespaced free fn)
+    * ``$this->process``    -> ``("$this", "process", "->")``  (instance self-call)
+    * ``self::make``        -> ``("self", "make", "::")``      (static self-call)
+    * ``Foo::bar``          -> ``("Foo", "bar", "::")``        (static receiver)
+    * ``App\\Util::run``     -> ``("App\\Util", "run", "::")``   (ns static receiver)
+    * ``$obj->bar``         -> ``("$obj", "bar", "->")``       (instance receiver)
+    """
+    full = callee_full or callee_name
+    matches = list(_RECEIVER_SPLIT.finditer(full))
+    if matches:
+        last = matches[-1]
+        receiver = full[: last.start()]
+        simple = full[last.end() :]
+        return receiver, (simple or callee_name), last.group(0)
+    return "", full or callee_name, ""
+
+
+def _lookup_in_file(ctx: PhpResolverContext, file_path: str, simple: str) -> int | None:
+    """Symbol id of a same-file BARE-CALLABLE named ``simple`` in ``file_path``.
+
+    Restricted to a top-level ``function`` (see ``_BARE_CALLABLE_KINDS``): a bare
+    ``foo()`` cannot legitimately target a class ``method`` (needs a receiver)
+    nor a ``class`` (that is construction). Real resolver contexts populate
+    ``file_symbols`` with EVERY method in the file, so matching ``method`` here
+    would bind a bare call to a sibling class's method — a wrong edge.
+    """
+    for name, kind, sym_id in ctx.file_symbols.get(file_path, []):
+        if name == simple and kind in _BARE_CALLABLE_KINDS:
+            return sym_id
+    return None
+
+
+def _unique_class_method(
+    ctx: PhpResolverContext, file_path: str, simple: str
+) -> int | None:
+    """Symbol id when EXACTLY ONE class in ``file_path`` defines ``simple``.
+
+    For a ``$this``/``self``/``static``/``parent`` call the caller's enclosing
+    class is not available to the resolver, so a name defined by two classes in
+    the same file is ambiguous. Conservatively resolve only the unambiguous
+    (single-owner) case — never the file-wide first match, which would mis-bind
+    ``B.bar -> A.foo`` (wave-1 Codex P2 lesson)."""
+    found: int | None = None
+    for methods in ctx.file_class_methods.get(file_path, {}).values():
+        mid = methods.get(simple)
+        if mid is None:
+            continue
+        if found is not None and found != mid:
+            return None  # defined by >1 class — ambiguous, stay unknown.
+        found = mid
+    return found
+
+
+def _project_owns_function(ctx: PhpResolverContext, simple: str) -> bool:
+    """True when a SAME-LANGUAGE (PHP) project symbol named ``simple`` exists.
+
+    The shadow gate for the built-in tier: if the project itself defines a free
+    function (or any symbol) named like a built-in, the ``builtin``
+    classification must NOT claim it. The gate is LANGUAGE-AWARE — a same-named
+    symbol in another language's file (a Python ``count``) does NOT count,
+    because ``languages_compatible("php", "python")`` is False (PHP has no
+    interop family). Unknown-language owner files are treated as possible owners
+    (conservative)."""
+    for owner_file, _sym_id in ctx.global_name_table.get(simple, []):
+        owner_lang = ctx.file_languages.get(owner_file, "")
+        if not owner_lang or languages_compatible(_PHP_LANG, owner_lang):
+            return True
+    return False
+
+
+def resolve_php_callee(
+    callee_name: str,
+    callee_full: str,
+    caller_file: str,
+    lang_ctx: PhpResolverContext,
+) -> tuple[int | None, str, str]:
+    """Resolve one PHP call edge.
+
+    Returns ``(symbol_id, resolution, resolved_file)`` where ``resolution`` is
+    one of ``local`` / ``builtin`` / ``unknown``. Conservative by construction:
+    anything not provably a same-file local call or a curated built-in is
+    ``unknown`` — never a cross-language bind.
+    """
+    ctx = lang_ctx
+    receiver, simple, separator = _split_receiver(callee_full, callee_name)
+
+    # 1. local — a bare free-function call. This is either a truly bare name
+    #    (no separator) OR a namespace-qualified free call whose LAST separator
+    #    is ``\`` (``\App\helper`` / ``App\helper``): a namespace path is NOT a
+    #    class/instance receiver, so the call targets a top-level free function.
+    #    A ``::``/``->`` split is a RECEIVER call and is intentionally excluded
+    #    here (even when the receiver text contains a ``\`` namespace, e.g.
+    #    ``App\Util::run``). The file-wide symbol lookup is safe because a bare
+    #    call can only target a top-level ``function`` (``_BARE_CALLABLE_KINDS``).
+    if separator in ("", "\\"):
+        sym_id = _lookup_in_file(ctx, caller_file, simple)
+        if sym_id is not None:
+            return sym_id, "local", caller_file
+        # 2. builtin — a bare global built-in free function the project does not
+        #    itself define (shadowing preserved). No project-wide single-name
+        #    bind: that is exactly where cross-file / cross-language mis-wires
+        #    creep in, so an unresolved bare name that is not a curated built-in
+        #    stays ``unknown``.
+        if simple in PHP_BUILTIN_FUNCTIONS and not _project_owns_function(ctx, simple):
+            return None, "builtin", ""
+        return None, "unknown", ""
+
+    # 1b. local — ``$this``/``self``/``static``/``parent`` method call: class-
+    #     scoped. Resolve ONLY when exactly one class in the file defines the
+    #     method (the caller's enclosing class is not carried by the edge). An
+    #     ambiguous name (two classes) or a top-level function stays ``unknown``.
+    if receiver in _SELF_RECEIVERS:
+        mid = _unique_class_method(ctx, caller_file, simple)
+        if mid is not None:
+            return mid, "local", caller_file
+        return None, "unknown", ""
+
+    # 3. unknown — a ``Foo::bar`` static or ``$obj->bar`` instance call whose
+    #    class type the edge does not carry. Never guessed: classifying these by
+    #    bare method name would mis-wire domain calls (the CodeGraph failure this
+    #    project beats).
+    return None, "unknown", ""
+
+
+register_language(_PHP_LANG, build_php_context, resolve_php_callee)
+
+
+__all__ = [
+    "PhpResolverContext",
+    "build_php_context",
+    "resolve_php_callee",
+]


### PR DESCRIPTION
## Summary

RFC-0010 second wave: a self-contained, SAFE, **new-files-only** per-language callee resolver for **PHP** (`.php`). Auto-discovered via `languages/__init__` — no edit to any shared file, so it lands without merge/worktree races.

### What it resolves
- **local** — same-file bare free-function calls (incl. namespaced `\App\helper` / `App\helper`, resolved on the last segment) via the caller file's own `file_symbols`; `$this->m()` / `self::m()` / `static::m()` / `parent::m()` method calls bound **only** through the unambiguous single-class gate (the caller's enclosing class is not carried by the edge, so a name defined by two classes stays `unknown` — never the file-wide first match).
- **builtin** — a curated, hand-audited set of PHP **global free functions** (`strlen`, `array_map`, `json_encode`, `count`, `preg_match`, `in_array`, `sprintf`, …) classified only when the project does not itself define a free function of that name (shadowing preserved).
- **unknown** — everything else: `Foo::bar` static / `$obj->bar` instance / `App\Util::run` namespaced-static receiver calls (the class type the edge does not record), ambiguous self-methods, and unresolved bare names. The **external** tier is intentionally **empty** (PHP libraries expose namespaced classes/methods, not distinctive global functions — RFC-0008 precision-over-recall).

### THE MOAT — never cross-language bind
The resolver only ever consults the **caller file's own** maps for a `local` match and never looks up a symbol in another file. The built-in shadow gate is **language-aware** via `languages_compatible` — PHP has no interop family, so a same-named Python/Java symbol never suppresses (nor is bound by) PHP classification. A **mandatory** no-cross-language-mis-wire test covers this both directly and **end-to-end through the production `build_resolver_context`** (a polyglot repo where `helper` exists as both a Python def and a PHP free function — the PHP caller resolves to `app.php`'s symbol id, never `py/helpers.py`).

### Conservative-tier note (PHP has no index-time call edges yet)
PHP symbols (functions/methods/classes) are indexed, but the synapse call-edge extractor does not currently emit `calls` edges for PHP, so the resolver activates whenever such edges appear and is fully unit- + registry-dispatch-tested now (no DB-edge dependency for correctness).

## Test plan
- [x] RED-verified: the 27 tests fail (`ModuleNotFoundError`) without `php.py`, pass with it.
- [x] Mandatory no-cross-language-mis-wire test (direct + end-to-end via production context builder).
- [x] `ruff check` + `ruff format --check` + `mypy` clean on all 3 new files.
- [x] Resolver regression green: `pytest tests/ -k 'resolver or synapse or registry'` → **377 passed, 2 skipped** (Java byte-parity intact).
- [x] `git show --stat HEAD` = new-files-only (3 files, +918, −0).

## Files (new only)
- `tree_sitter_analyzer/synapse_resolver/languages/php.py`
- `tree_sitter_analyzer/synapse_resolver/languages/_php_constants.py`
- `tests/unit/test_php_method_resolution.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
