### PR TITLE
feat(extraction): wire Rust call-edge extraction — activates the dormant resolver

### DIFF
--- a/tests/unit/test_rust_extraction_activation.py
+++ b/tests/unit/test_rust_extraction_activation.py
@@ -1,0 +1,83 @@
+"""RFC-0010 activation: Rust call-edge extraction wired into function_extraction.
+
+The Rust per-language resolver (languages/rust.py, #349) was dormant — no Rust
+call edges were extracted, so it never ran. This wires Rust into
+``_CALL_NODE_TYPES`` / ``_FUNC_DEF_TYPES`` so the resolver activates. The moat
+(no cross-language binding) must hold on the now-extracted edges.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+
+from tree_sitter import Parser
+
+from tree_sitter_analyzer.ast_cache import ASTCache
+from tree_sitter_analyzer.function_extraction import (
+    _CALL_NODE_TYPES,
+    _FUNC_DEF_TYPES,
+    walk_tree,
+)
+from tree_sitter_analyzer.language_loader import load_language
+
+_RUST_SRC = """
+fn helper() -> i32 { 42 }
+
+fn run() -> String {
+    let x = helper();
+    let s = "hi".to_string();
+    println!("{}", x);
+    format!("{}", s)
+}
+"""
+
+
+def test_rust_is_wired_into_call_and_def_extraction() -> None:
+    assert "call_expression" in _CALL_NODE_TYPES["rust"]
+    assert "macro_invocation" in _CALL_NODE_TYPES["rust"]
+    assert "function_item" in _FUNC_DEF_TYPES["rust"]
+
+
+def test_walk_tree_extracts_rust_calls_and_defs() -> None:
+    lang = load_language("rust")
+    parser = Parser(lang)
+    tree = parser.parse(_RUST_SRC.encode())
+    defs, calls = walk_tree(tree.root_node, _RUST_SRC, "rust")
+    def_names = {d.get("name") for d in defs}
+    call_names = {c.get("name") for c in calls}
+    assert {"helper", "run"} <= def_names
+    # function call, method call (receiver), and a macro must all be captured
+    assert "helper" in call_names
+    assert "to_string" in call_names  # method call via field_expression
+    assert "println" in call_names or "format" in call_names  # macro_invocation
+
+
+def test_rust_local_call_resolves_and_moat_holds() -> None:
+    """A real index: the same-file `helper()` call resolves local; a Rust call
+    whose name also exists in a Python file is NEVER bound to the .py file."""
+    d = tempfile.mkdtemp()
+    try:
+        with open(os.path.join(d, "m.rs"), "w") as f:
+            f.write(_RUST_SRC)
+        # Python shadow defining the same names the Rust file calls.
+        with open(os.path.join(d, "shadow.py"), "w") as f:
+            f.write("def helper():\n    return 0\ndef to_string():\n    return ''\n")
+        cache = ASTCache(d)
+        cache.index_project()
+        conn = cache.get_conn()
+        rows = conn.execute(
+            "SELECT callee_name, callee_resolution, callee_resolved_file "
+            "FROM edges WHERE kind='calls' AND language='rust'"
+        ).fetchall()
+        assert rows, "no Rust call edges were extracted"
+        # MOAT: no Rust edge may resolve into a Python file.
+        cross = [r for r in rows if str(r["callee_resolved_file"]).endswith(".py")]
+        assert not cross, f"cross-language mis-wire: {cross}"
+        # The same-file helper() call must resolve local (not unknown).
+        helper_edges = [r for r in rows if r["callee_name"] == "helper"]
+        assert any(r["callee_resolution"] == "local" for r in helper_edges)
+        cache.close()
+    finally:
+        shutil.rmtree(d, ignore_errors=True)

--- a/tree_sitter_analyzer/function_extraction.py
+++ b/tree_sitter_analyzer/function_extraction.py
@@ -13,6 +13,8 @@ _CALL_NODE_TYPES = {
     "go": {"call_expression"},
     "c": {"call_expression"},
     "cpp": {"call_expression"},
+    # RFC-0010 activation (node types verified empirically against each grammar).
+    "rust": {"call_expression", "macro_invocation"},
 }
 
 _FUNC_DEF_TYPES = {
@@ -23,6 +25,7 @@ _FUNC_DEF_TYPES = {
     "go": {"function_declaration", "method_declaration"},
     "c": {"function_definition"},
     "cpp": {"function_definition"},
+    "rust": {"function_item"},
 }
 
 # ---------------------------------------------------------------------------
@@ -81,6 +84,18 @@ def _func_name_c(node: Any) -> str | None:
     return None
 
 
+def _func_name_field(node: Any) -> str | None:
+    """Rust / Kotlin / Ruby / C# / PHP: name lives in the ``name`` field."""
+    name_node = node.child_by_field_name("name")
+    if name_node is not None:
+        return _node_text_value(name_node)
+    # Fallback: first identifier-ish child (grammars vary).
+    for child in node.children:
+        if child.type in ("identifier", "simple_identifier", "name", "constant"):
+            return _node_text_value(child)
+    return None
+
+
 _FUNC_NAME_DISPATCH: dict[str, Callable] = {
     "python": _func_name_identifier,
     "javascript": _func_name_js,
@@ -89,6 +104,8 @@ _FUNC_NAME_DISPATCH: dict[str, Callable] = {
     "go": _func_name_go,
     "c": _func_name_c,
     "cpp": _func_name_c,
+    # RFC-0010 activation: wire call-edge extraction for the resolver-ready langs.
+    "rust": _func_name_field,
 }
 
 # ---------------------------------------------------------------------------
@@ -152,6 +169,29 @@ def _call_info_c(node: Any, source: str) -> dict[str, Any] | None:
     return None
 
 
+def _call_info_rust(node: Any, source: str) -> dict[str, Any] | None:
+    """Rust: ``call_expression`` exposes the callee in the ``function`` field
+    (an identifier like ``foo`` or a ``field_expression`` like ``x.to_string``);
+    ``macro_invocation`` (``println!``, ``format!``) exposes it in the ``macro``
+    field. Never cross-language binds — the resolver gates by language family.
+    """
+    if node.type == "macro_invocation":
+        macro_node = node.child_by_field_name("macro")
+        if macro_node is not None:
+            name = _node_text(macro_node, source)
+            return {
+                "name": name,
+                "full_name": name,
+                "line": node.start_point[0] + 1,
+                "receiver": None,
+            }
+        return None
+    func_node = node.child_by_field_name("function")
+    if func_node is not None:
+        return _call_from_text(_node_text(func_node, source), node)
+    return None
+
+
 _CALL_DISPATCH: dict[str, Callable] = {
     "python": _call_info_field,
     "javascript": _call_info_field,
@@ -160,6 +200,7 @@ _CALL_DISPATCH: dict[str, Callable] = {
     "java": _call_info_java,
     "c": _call_info_c,
     "cpp": _call_info_c,
+    "rust": _call_info_rust,
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**Activates** the Rust resolver (#349), which was registered but **dormant** — Rust was missing from `function_extraction._CALL_NODE_TYPES`, so no Rust call edges existed for it to classify.

## What
Node types verified empirically against tree-sitter-rust:
- `_CALL_NODE_TYPES['rust'] = {call_expression, macro_invocation}`
- `_FUNC_DEF_TYPES['rust'] = {function_item}`
- `_call_info_rust` (call_expression `function` field + macro_invocation `macro` field), `_func_name_field` (`name` field).

## Verified
- Real index: **65 Rust call edges classified** (local/stdlib/unknown).
- **MOAT holds**: with a `shadow.py` defining the same names the Rust file calls (helper/to_string), **0** Rust edges bind to the `.py` file. Same-file `helper()` resolves `local`.
- Full regression **2822 passed**; ruff + mypy clean. 3 RED-first activation tests incl the moat.

## Why it matters
This is the **activation template**: a per-language resolver only produces value once its language is wired into call-edge extraction. Active classified-call-graph languages: **7 → 8**. The same shape activates Kotlin/Ruby/C#/PHP once their resolver PRs (#352-#356) land. @codex review