### PR TITLE
feat(resolver): Swift callee resolver + extraction — closes the CodeGraph Swift narrative

### DIFF
--- a/tests/unit/test_swift_method_resolution.py
+++ b/tests/unit/test_swift_method_resolution.py
@@ -1,0 +1,123 @@
+"""Swift per-language callee resolver + extraction activation (RFC-0010 wave 3).
+
+Includes the poetic moat case: the exact Python-sorted()->Swift-func-sorted
+mis-wire that CodeGraph produces must NOT happen here, in either direction.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+
+from tree_sitter_analyzer.ast_cache import ASTCache
+from tree_sitter_analyzer.function_extraction import _CALL_NODE_TYPES, _FUNC_DEF_TYPES
+from tree_sitter_analyzer.synapse_resolver._registry import (
+    get_language_resolver,
+    registered_languages,
+)
+from tree_sitter_analyzer.synapse_resolver.languages.swift import (
+    SwiftResolverContext,
+    resolve_swift_callee,
+)
+
+
+def _ctx(file_symbols=None, file_languages=None, global_name_table=None):
+    return SwiftResolverContext(
+        file_symbols=file_symbols or {},
+        file_languages=file_languages or {},
+        global_name_table=global_name_table or {},
+    )
+
+
+def test_swift_registered_and_wired() -> None:
+    assert "swift" in registered_languages()
+    assert get_language_resolver("swift") is not None
+    assert _CALL_NODE_TYPES.get("swift") == {"call_expression"}
+    assert "function_declaration" in _FUNC_DEF_TYPES["swift"]
+
+
+def test_bare_local_call_resolves() -> None:
+    ctx = _ctx(file_symbols={"a.swift": [("greet", "function", 7)]})
+    assert resolve_swift_callee("greet", "greet", "a.swift", ctx) == (
+        7,
+        "local",
+        "a.swift",
+    )
+
+
+def test_self_method_unique_binds_ambiguous_unknown() -> None:
+    ctx = _ctx(file_symbols={"a.swift": [("m", "method", 3)]})
+    assert resolve_swift_callee("m", "self.m", "a.swift", ctx) == (
+        3,
+        "local",
+        "a.swift",
+    )
+    # two same-named methods -> ambiguous -> unknown
+    ctx2 = _ctx(file_symbols={"a.swift": [("m", "method", 3), ("m", "method", 9)]})
+    assert resolve_swift_callee("m", "self.m", "a.swift", ctx2) == (None, "unknown", "")
+    # self.X where X is only a free function -> not a member -> unknown
+    ctx3 = _ctx(file_symbols={"a.swift": [("m", "function", 3)]})
+    assert resolve_swift_callee("m", "self.m", "a.swift", ctx3) == (None, "unknown", "")
+
+
+def test_stdlib_global_classified_but_shadow_wins() -> None:
+    assert resolve_swift_callee("print", "print", "a.swift", _ctx()) == (
+        None,
+        "stdlib",
+        "",
+    )
+    # a project Swift `print` suppresses the stdlib tier
+    ctx = _ctx(
+        global_name_table={"print": [("b.swift", 5)]},
+        file_languages={"b.swift": "swift"},
+    )
+    assert resolve_swift_callee("print", "print", "a.swift", ctx) == (
+        None,
+        "unknown",
+        "",
+    )
+
+
+def test_moat_python_owner_never_suppresses_or_binds() -> None:
+    # a Python `print` must NOT count as a Swift owner (stdlib stays classified)
+    ctx = _ctx(
+        global_name_table={"print": [("p.py", 5)]},
+        file_languages={"p.py": "python"},
+    )
+    assert resolve_swift_callee("print", "print", "a.swift", ctx) == (
+        None,
+        "stdlib",
+        "",
+    )
+
+
+def test_poetic_moat_end_to_end() -> None:
+    """Index a Swift file defining `sorted` + a Python file calling sorted();
+    neither binds across the language boundary (the CodeGraph failure)."""
+    d = tempfile.mkdtemp()
+    try:
+        with open(os.path.join(d, "s.swift"), "w") as f:
+            f.write(
+                "func sorted(_ a: [Int]) -> [Int] { return a }\n"
+                "func run() { let x = sorted([3,1]); print(x) }\n"
+            )
+        with open(os.path.join(d, "p.py"), "w") as f:
+            f.write("def use():\n    return sorted([3,1])\n")
+        cache = ASTCache(d)
+        cache.index_project()
+        conn = cache.get_conn()
+        rows = conn.execute(
+            "SELECT language, callee_name, callee_resolved_file "
+            "FROM edges WHERE kind='calls' AND callee_name='sorted'"
+        ).fetchall()
+        assert rows, "no sorted() edges"
+        for r in rows:
+            # a swift caller must not resolve into a .py file and vice-versa
+            if r["language"] == "swift":
+                assert not str(r["callee_resolved_file"]).endswith(".py")
+            if r["language"] == "python":
+                assert not str(r["callee_resolved_file"]).endswith(".swift")
+        cache.close()
+    finally:
+        shutil.rmtree(d, ignore_errors=True)

--- a/tests/unit/test_swift_method_resolution.py
+++ b/tests/unit/test_swift_method_resolution.py
@@ -118,6 +118,15 @@ def test_poetic_moat_end_to_end() -> None:
                 assert not str(r["callee_resolved_file"]).endswith(".py")
             if r["language"] == "python":
                 assert not str(r["callee_resolved_file"]).endswith(".swift")
+        # Discriminating: Swift print() must classify 'stdlib' via resolve_swift_callee.
+        # The Python cascade would instead call it 'builtin' (print is in BUILTINS_PY),
+        # so this assertion fails if the Swift resolver is not actually invoked.
+        prints = conn.execute(
+            "SELECT callee_resolution FROM edges "
+            "WHERE kind='calls' AND language='swift' AND callee_name='print'"
+        ).fetchall()
+        assert prints, "no swift print() edge"
+        assert all(r["callee_resolution"] == "stdlib" for r in prints)
         cache.close()
     finally:
         shutil.rmtree(d, ignore_errors=True)

--- a/tree_sitter_analyzer/function_extraction.py
+++ b/tree_sitter_analyzer/function_extraction.py
@@ -23,6 +23,7 @@ _CALL_NODE_TYPES = {
         "member_call_expression",
         "scoped_call_expression",
     },
+    "swift": {"call_expression"},
 }
 
 _FUNC_DEF_TYPES = {
@@ -38,6 +39,7 @@ _FUNC_DEF_TYPES = {
     "kotlin": {"function_declaration"},
     "ruby": {"method", "singleton_method"},
     "php": {"function_definition", "method_declaration"},
+    "swift": {"function_declaration", "protocol_function_declaration"},
 }
 
 # ---------------------------------------------------------------------------
@@ -123,6 +125,7 @@ _FUNC_NAME_DISPATCH: dict[str, Callable] = {
     "kotlin": _func_name_field,
     "ruby": _func_name_field,
     "php": _func_name_field,
+    "swift": _func_name_field,
 }
 
 # ---------------------------------------------------------------------------
@@ -286,6 +289,9 @@ _CALL_DISPATCH: dict[str, Callable] = {
     "kotlin": _call_info_kotlin,
     "ruby": _call_info_ruby,
     "php": _call_info_php,
+    # Swift call_expression: callee is the first child (simple_identifier or
+    # navigation_expression) — same shape as Kotlin.
+    "swift": _call_info_kotlin,
 }
 
 # ---------------------------------------------------------------------------

--- a/tree_sitter_analyzer/function_extraction.py
+++ b/tree_sitter_analyzer/function_extraction.py
@@ -39,7 +39,9 @@ _FUNC_DEF_TYPES = {
     "kotlin": {"function_declaration"},
     "ruby": {"method", "singleton_method"},
     "php": {"function_definition", "method_declaration"},
-    "swift": {"function_declaration", "protocol_function_declaration"},
+    # protocol stubs have no body + duplicate the impl name -> last-writer-wins
+    # in file_funcs would steal caller attribution; keep only concrete defs.
+    "swift": {"function_declaration"},
 }
 
 # ---------------------------------------------------------------------------

--- a/tree_sitter_analyzer/synapse_resolver/languages/_swift_constants.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/_swift_constants.py
@@ -1,0 +1,36 @@
+"""Conservative Swift stdlib classification data (RFC-0010).
+
+Precision over recall (the RFC-0008 lesson). The tier holds ONLY near-exclusive
+Swift global free functions — the handful that are overwhelmingly the standard
+library and very unlikely to be a user's own top-level function. Overloaded
+generic names (``map``, ``filter``, ``sorted``, ``abs``, ``min``, ``max``,
+``zip``, ``swap``) are deliberately EXCLUDED: they are common method/closure
+names and classifying them risks the exact same-name mis-classification this
+project exists to beat. An unknown edge is correct; a wrong one is not.
+"""
+
+from __future__ import annotations
+
+#: Near-exclusive Swift standard-library GLOBAL functions (no receiver). These
+#: are diagnostics / control-flow built-ins that projects almost never redefine
+#: as a free function.
+SWIFT_STDLIB_FUNCTIONS: frozenset[str] = frozenset(
+    {
+        "print",
+        "debugPrint",
+        "dump",
+        "assert",
+        "assertionFailure",
+        "precondition",
+        "preconditionFailure",
+        "fatalError",
+    }
+)
+
+
+def is_swift_stdlib_function(name: str) -> bool:
+    """True for a bare (receiver-less) near-exclusive Swift stdlib global fn."""
+    return name in SWIFT_STDLIB_FUNCTIONS
+
+
+__all__ = ["SWIFT_STDLIB_FUNCTIONS", "is_swift_stdlib_function"]

--- a/tree_sitter_analyzer/synapse_resolver/languages/swift.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/swift.py
@@ -1,0 +1,187 @@
+"""Swift resolver registration (RFC-0010).
+
+A SAFE, self-contained per-language callee resolver for Swift. It:
+
+* resolves SAME-FILE / SAME-LANGUAGE local calls from ``file_symbols`` (bare
+  free-function calls and ``self.method`` / ``Self.method`` calls), and
+* classifies a tiny, CONSERVATIVE std tier — a curated set of near-exclusive
+  Swift global functions (``print``, ``assert``, ``fatalError``, …) — as
+  ``stdlib``, and
+* returns ``unknown`` for everything else.
+
+THE MOAT (the #1 correctness requirement): this resolver NEVER binds a Swift
+callee to a symbol in a different language's file. This is the exact failure
+mode that makes a name-only indexer wire Python ``sorted()`` to a Swift
+``func sorted`` — here, every binding is gated by ``languages_compatible`` and
+local resolution only ever consults the caller's OWN file. A same-name symbol in
+another language (or another Swift file, absent type evidence) is left
+``unknown``, never wired across.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .._registry import register_language
+from ._swift_constants import is_swift_stdlib_function
+
+_SELF_RECEIVERS = frozenset({"self", "Self"})
+
+
+class SwiftResolverContext:
+    """Per-index Swift resolution maps (built once per pass).
+
+    All file keys are project-relative paths, matching the ``edges`` table. Only
+    cross-language-safe maps are retained; no global single-name table is used to
+    BIND a callee (it feeds the language-aware ownership gate only).
+    """
+
+    __slots__ = ("file_languages", "file_symbols", "global_name_table")
+
+    def __init__(
+        self,
+        *,
+        file_symbols: dict[str, list[tuple[str, str, int]]],
+        file_languages: dict[str, str],
+        global_name_table: dict[str, list[tuple[str, int]]],
+    ) -> None:
+        self.file_symbols = file_symbols
+        self.file_languages = file_languages
+        self.global_name_table = global_name_table
+
+
+def build_swift_resolver_context(
+    *,
+    imports_by_file: dict[str, Any],
+    file_languages: dict[str, str],
+    file_symbols: dict[str, Any],
+    global_name_table: dict[str, Any],
+    file_class_methods: Any,  # zero-arg thunk -> class->method map (lazy, unused)
+    **_ignored: Any,
+) -> SwiftResolverContext | None:
+    """Build the Swift context, or ``None`` when no Swift file is indexed.
+
+    Zero cost for non-Swift projects (gated on ``file_languages``). Same-file
+    methods are recovered from ``file_symbols`` (kind ``method``/``function``),
+    so the costly class→method thunk is never materialised.
+    """
+    if not any(lang == "swift" for lang in file_languages.values()):
+        return None
+    return SwiftResolverContext(
+        file_symbols=file_symbols,
+        file_languages=file_languages,
+        global_name_table=global_name_table,
+    )
+
+
+def _split_receiver(callee_full: str, callee_name: str) -> tuple[str, str]:
+    """Return ``(receiver, simple_name)`` from a Swift call's full name.
+
+    Swift qualifies with ``.`` (``self.greet``, ``obj.process``, ``Type.make``).
+    The receiver is the text before the final dot; a bare call has no receiver.
+    """
+    full = callee_full or callee_name
+    if "." in full:
+        receiver, simple = full.rsplit(".", 1)
+        return receiver, simple
+    return "", full or callee_name
+
+
+def _lookup_in_file(
+    ctx: SwiftResolverContext, file_path: str, simple: str
+) -> int | None:
+    """Return the symbol id of a same-file ``simple`` def, or ``None``."""
+    for name, kind, sym_id in ctx.file_symbols.get(file_path, []):
+        if name == simple and kind in ("function", "method", "class"):
+            return sym_id
+    return None
+
+
+def _lookup_unique_method_in_file(
+    ctx: SwiftResolverContext, file_path: str, simple: str
+) -> int | None:
+    """Return the symbol id of a same-file ``simple`` METHOD def, but ONLY when it
+    is unique in the file.
+
+    ``self.foo`` must bind to a member, never a free function, and never guess
+    when two types in the same file both define ``foo`` (→ ``unknown``). Mirrors
+    the Rust/Kotlin receiver guard.
+    """
+    matches = [
+        sym_id
+        for name, kind, sym_id in ctx.file_symbols.get(file_path, [])
+        if name == simple and kind == "method"
+    ]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _project_owns(ctx: SwiftResolverContext, simple: str) -> bool:
+    """True when a COMPATIBLE-LANGUAGE (Swift) project symbol named ``simple``
+    exists — the language-aware RFC-0008 ownership gate.
+
+    A same-named symbol in an incompatible-language file (a Python ``print``)
+    must NOT count as a Swift owner, so it neither suppresses the std tier nor is
+    ever bound. An untagged file is treated as a possible owner (conservative).
+    """
+    from ..._language_family import languages_compatible
+
+    for owner_file, _sym_id in ctx.global_name_table.get(simple, []):
+        owner_lang = ctx.file_languages.get(owner_file, "")
+        if not owner_lang or languages_compatible("swift", owner_lang):
+            return True
+    return False
+
+
+def resolve_swift_callee(
+    callee_name: str,
+    callee_full: str,
+    caller_file: str,
+    ctx: SwiftResolverContext,
+) -> tuple[int | None, str, str]:
+    """Resolve one Swift call edge.
+
+    Returns ``(symbol_id, resolution, resolved_file)`` where ``resolution`` is one
+    of ``local`` / ``stdlib`` / ``unknown``. ``project``/``external`` are not
+    emitted in this first wave — cross-file binding needs type/import resolution
+    not yet available, and guessing would cross the moat; ``unknown`` is correct.
+    """
+    receiver, simple = _split_receiver(callee_full, callee_name)
+
+    # 1a. local (bare call) — a receiver-less call resolves to a same-file def in
+    #     the caller's OWN file only (the moat holds).
+    if receiver == "":
+        sym_id = _lookup_in_file(ctx, caller_file, simple)
+        if sym_id is not None:
+            return sym_id, "local", caller_file
+
+    # 1b. local (self-qualified) — ``self.foo`` / ``Self.foo``. Bind only to a
+    #     UNIQUE same-file method (never a free function, never an ambiguous
+    #     cross-type guess). Resolution stays in the caller's own file.
+    elif receiver in _SELF_RECEIVERS:
+        sym_id = _lookup_unique_method_in_file(ctx, caller_file, simple)
+        if sym_id is not None:
+            return sym_id, "local", caller_file
+
+    # 2. std global fn (terminal stdlib) — a near-exclusive Swift global function
+    #    called WITHOUT a receiver, and only when the project does not own a
+    #    compatible-language symbol of that name (project shadowing wins).
+    if (
+        receiver == ""
+        and is_swift_stdlib_function(simple)
+        and not _project_owns(ctx, simple)
+    ):
+        return None, "stdlib", ""
+
+    # 3. unknown — everything else (cross-file calls, receiver calls on unknown
+    #    types, ambiguous names) is left unresolved rather than risk a mis-bind.
+    return None, "unknown", ""
+
+
+register_language("swift", build_swift_resolver_context, resolve_swift_callee)
+
+
+__all__ = [
+    "SwiftResolverContext",
+    "build_swift_resolver_context",
+    "resolve_swift_callee",
+]


### PR DESCRIPTION
Adds a complete, **active** Swift language to the correctness moat (resolver + extraction in one PR). **The poetic case**: CodeGraph's flagship failure (REPORT-v1.21.0) wires **299** Python `sorted()` callers to a Swift `func sorted`. TSA now handles Swift correctly AND refuses that exact mis-wire.

## Verified end-to-end
A Swift file defining `sorted` + a Python file calling `sorted()`:
| caller | callee | resolves to |
|---|---|---|
| Swift | `sorted([3,1])` | **local** (its own same-file def) |
| Swift | `print(x)` | **stdlib** |
| Python | `sorted([3,1])` | **builtin** (NOT the Swift func) |

**0 cross-language mis-wires, both directions.**

- `languages/swift.py` + `_swift_constants.py`: self-contained, conservative stdlib (8 near-exclusive globals), every binding gated by `languages_compatible('swift', owner)`.
- Node types verified empirically against tree-sitter-swift. 6 RED-first tests incl the poetic moat; **FULL suite 18419 passed**; ruff+mypy clean. **Active languages: 12 → 13.**

⚠️ Codex rate-limited — independent adversarial review running in parallel.