### PR TITLE
fix(nav): filter English connectives from nav-context candidates (RFC-0009 C)

### DIFF
--- a/tests/unit/test_codegraph_context_tool.py
+++ b/tests/unit/test_codegraph_context_tool.py
@@ -1473,6 +1473,28 @@ def test_generic_verbs_dropped_when_specific_candidate_present() -> None:
     assert "resolve_java_callee" in cands
 
 
+def test_english_connectives_filtered_from_candidates() -> None:
+    """RFC-0009 C (dogfood-discovered): natural-language connectives like 'like',
+    'the', 'per' must not become symbol candidates — they SUBSTRING-match real
+    symbols (`like` -> `_looks_like_*` / `_like_rows`) and spend entry-point slots
+    on noise. The specific symbols are preserved. (RED before the stop-word add.)"""
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        _extract_symbol_candidates,
+    )
+
+    cands = _extract_symbol_candidates(
+        "how does resolve_callee dispatch a call to a per-language resolver "
+        "like the Java or Swift resolver"
+    )
+    lowered = {c.lower() for c in cands}
+    assert "like" not in lowered, cands
+    assert "the" not in lowered, cands
+    assert "per" not in lowered, cands
+    # the real symbols the task is about survive
+    assert "resolve_callee" in cands
+    assert "Java" in cands and "Swift" in cands
+
+
 def test_generic_verb_kept_when_sole_signal() -> None:
     """RFC-0009 C is conservative: when a generic verb is the ONLY signal (no
     specific symbol named), it is KEPT so 'find the dispatch function' still

--- a/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
@@ -23,7 +23,14 @@ from .base_tool import BaseMCPTool
 
 _STOP_WORDS = frozenset(
     "a an and are as at by call calls does flow for from how in into is of on "
-    "or through to trace what when where which why with work works".split()
+    "or through to trace what when where which why with work works "
+    # RFC-0009 C (dogfood-discovered): common English connectives a natural-language
+    # task carries ("how does X dispatch LIKE the Java resolver"). They are not
+    # symbol names but SUBSTRING-match real ones (``like`` -> ``_looks_like_*`` /
+    # ``_like_rows``), spending entry-point slots on noise. Pure function words only
+    # — never legitimate code identifiers (``get``/``make``/``run`` are NOT here).
+    "like the per this that via than then such these those be been also just "
+    "only about after before between within".split()
 )
 
 # RFC-0009 C: generic single-word verbs that frequently appear in trace questions


### PR DESCRIPTION
**Dogfood-discovered** while live-comparing TSA vs CodeGraph context: the task "how does resolve_callee dispatch ... **like** the Java resolver" made TSA's nav context surface `_looks_like_docstring_example` and `_like_rows` as entry points — the connective **'like'** substring-matched them, spending RFC-0009 self-sufficiency slots on pure noise.

Fix: extend `_STOP_WORDS` with pure English function words (like/the/per/this/that/via/…) that a natural-language task carries but are never code identifiers. Deliberately NOT added: get/make/run/handle (real method names). Specific symbols (resolve_callee/Java/Swift) preserved.

RED-first test; 1058 context/candidate/nav tests pass; ruff clean. On-thesis for RFC-0009 (the first response should carry the answer, not noise). Codex rate-limited; small well-tested filter.