### PR TITLE
feat(audit): miswire-audit — run-on-your-repo cross-language correctness demo (RFC-0011)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -301,6 +301,8 @@ all = [
 tree-sitter-analyzer = "tree_sitter_analyzer.cli_main:main"
 # MCP server entry point
 tree-sitter-analyzer-mcp = "tree_sitter_analyzer.mcp.server:main_sync"
+# Mis-Wire Audit — run-on-your-repo cross-language correctness demo
+miswire-audit = "tree_sitter_analyzer.miswire_audit:main"
 # Legacy aliases for backward compatibility
 code-analyzer = "tree_sitter_analyzer.cli_main:main"
 java-analyzer = "tree_sitter_analyzer.cli_main:main"

--- a/rfcs/0011-miswire-audit.md
+++ b/rfcs/0011-miswire-audit.md
@@ -1,0 +1,94 @@
+# RFC-0011: Mis-Wire Audit — the run-on-your-repo correctness demo
+
+- **Status**: accepted — console entrypoint + module + tests shipped (this PR); CLI subcommand + pre-seed + README surgery tracked below
+- **Author(s)**: TSA strategy team (4-lens panel + chair, 2026-06-08)
+- **Created**: 2026-06-08
+- **Affected surfaces**: new console entrypoint `miswire-audit`; `tree_sitter_analyzer/miswire_audit.py`; `tests/benchmarks/test_miswire_audit.py`
+
+## Summary
+
+Ship `miswire-audit <repo-or-path>` — a single command that runs TSA's
+cross-language correctness check on the **reader's own repository** and prints a
+stark, personalized verdict: how many call edges a **name-only resolver** (the
+design CodeGraph and most code indexes use) *would* mis-wire across a language
+boundary, versus how many TSA actually does. No CodeGraph install required.
+
+    uvx --from tree-sitter-analyzer miswire-audit .
+    # → "a name-only resolver would mis-wire 4,199 call edges in YOUR repo;
+    #    TSA mis-wires 6 — 700× cleaner. Here are 5: Python sorted() → Swift func …"
+
+## Motivation
+
+TSA has **won** the correctness axis and **proven** it: on both tools' live
+indexes of TSA's own repo, CodeGraph makes 745 cross-language call-graph
+mis-wires vs TSA's 6 — ~390× cleaner (REPORT-v1.21.0 addendum 2). But that proof
+is *illegible*: it lives as a static table about TSA analysing TSA's own source,
+which a reader must **trust**. The strategy team (growth, DX, competitive, moat
+lenses) unanimously concluded the highest-leverage next move is to convert
+"trust my table" into "watch it find wrong edges in code **you** wrote" — the
+canonical OSS dev-tool breakout pattern (ruff, biome, oxc, sqlfluff all broke out
+on a run-it-on-your-code benchmark, never on blog claims). A self-serve,
+falsifiable, screenshot-worthy audit is simultaneously the demo, the Show HN
+submission, the comparison page, and the SEO/social asset — and it is the one
+format where "more correct" mechanically becomes "more known," because skeptics
+reproduce it on their own code and amplify it.
+
+## Detailed design
+
+`audit(project_root)` indexes the repo with TSA, then for every `calls` edge:
+
+- **TSA mis-wire**: the edge's `callee_resolved_file` is in a language
+  *incompatible* with the caller (the real, measured cross-language bind). TSA's
+  family-gated resolver keeps this ~0.
+- **Name-only mis-wire (modeled, no CodeGraph install)**: the callee name has a
+  same-name definition in the index but **none** in a compatible language — so a
+  resolver that binds by name alone has only a cross-language def to choose, and
+  wires across the boundary. This is the worst case for the name-only design.
+
+Output: total edges, the name-only count + rate, TSA's count + rate, the
+multiplier, and the top-N **distinct** offending names (`Python sorted() → Swift
+func at file:line`). A `--card` flag emits a copy-paste markdown/social card.
+
+### Honesty (a locked project value)
+
+The modeled name-only figure is an **upper bound for the name-only design**, NOT
+CodeGraph's exact count (CodeGraph does *some* language handling — 745 < the
+4,199 pure-name-only bound on TSA's repo). The output therefore says "**a
+name-only resolver** would mis-wire up to N" and points to REPORT-v1.21.0 for the
+**live, CodeGraph-specific** 745-vs-6. We never label the modeled number as
+CodeGraph's measured count — one debunk-able claim destroys the trust the proof
+exists to build.
+
+## Three-Surface (CLI ↔ MCP) parity
+
+This is a **distribution/demo artifact**, not a code-intelligence query, so it
+ships first as a console entrypoint (`miswire-audit`). Parity follow-ups (below):
+a `tree-sitter-analyzer miswire-audit` CLI subcommand and, if demanded, a thin
+MCP `viz action=miswire_audit` so an agent can self-audit a repo. The core
+resolution logic it reports on already has full CLI↔MCP parity (the resolver).
+
+## Test plan (RED-first)
+
+- [x] A planted polyglot fixture (Python `sorted()` caller + Swift `func sorted`)
+      → the name-only model flags `sorted → swift`; TSA mis-wires 0.
+- [x] A clean single-language repo → 0 and 0.
+- [x] Rendering is honest: says "NAME-ONLY resolver", points to REPORT-v1.21.0,
+      never claims "CodeGraph would mis-wire N".
+
+## Acceptance criteria
+
+- [x] `miswire-audit <path>` console entrypoint; module under the package;
+      ruff+mypy clean; 3 RED-first tests green.
+- [ ] `tree-sitter-analyzer miswire-audit` CLI subcommand (parity follow-up).
+- [ ] Pre-seed `--card` results for 5 well-known repos under
+      `benchmarks/codegraph_compare/results/` so the README shows results before
+      anyone clones.
+- [ ] README surgery: make the `miswire-audit` one-liner the first runnable block
+      above the fold; lead with the scorecard.
+
+## Open questions
+
+1. Should the name-only model exclude language builtins (Python `print`) to be
+   even more conservative? Current "up to N / worst case" framing is honest; a
+   `--exclude-builtins` mode could show the floor too.
+2. MCP facade for agent self-audit — only if demanded.

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -67,3 +67,4 @@ number; if two RFCs collide on a number in flight, the later-merged one renames.
 | [0008](0008-multilang-method-classification.md) | Multi-language method classification — beyond Python | implemented (Python+Java; Go/JS/TS/C++/Rust via RFC-0010 #346-#350) |
 | [0009](0009-nav-context-self-sufficiency.md) | nav context self-sufficiency — answer in one call | accepted (A/B/C implemented #330/#331/#333; measured turn-drop pending) |
 | [0010](0010-resolver-language-registry.md) | Resolver language registry — scale the correctness moat to N languages | implemented (foundation #345; first wave go/js/ts/cpp/rust #346-#350) |
+| [0011](0011-miswire-audit.md) | Mis-Wire Audit — the run-on-your-repo correctness demo | accepted (console entrypoint shipped; CLI subcommand + pre-seed + README surgery tracked) |

--- a/tests/benchmarks/test_miswire_audit.py
+++ b/tests/benchmarks/test_miswire_audit.py
@@ -73,3 +73,27 @@ def test_render_terminal_and_card_are_honest() -> None:
         assert "CodeGraph would mis-wire" not in term
     finally:
         shutil.rmtree(d, ignore_errors=True)
+
+
+def test_symbols_json_fallback_when_no_ast_symbol_rows() -> None:
+    """Codex #369 L74: on no-FTS5 builds ast_symbol_rows is absent; the audit
+    must fall back to ast_index.symbols_json and still find the collision."""
+    from tree_sitter_analyzer.miswire_audit import _iter_symbol_defs
+
+    d = _planted_polyglot()
+    try:
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        cache = ASTCache(d)
+        cache.index_project()
+        conn = cache.get_conn()
+        # simulate a no-FTS5 build: drop the table the primary path uses
+        conn.execute("DROP TABLE IF EXISTS ast_symbol_rows")
+        defs = _iter_symbol_defs(conn)
+        names = {n for n, _f, _l in defs}
+        # the Swift `sorted` def must still be discoverable via symbols_json
+        assert "sorted" in names, names
+        assert any(lang == "swift" for _n, _f, lang in defs)
+        cache.close()
+    finally:
+        shutil.rmtree(d, ignore_errors=True)

--- a/tests/benchmarks/test_miswire_audit.py
+++ b/tests/benchmarks/test_miswire_audit.py
@@ -1,0 +1,75 @@
+"""RED-first tests for the Mis-Wire Audit (the run-on-your-repo correctness demo).
+
+The audit models what a name-only resolver WOULD mis-wire (bind a call to a
+same-named definition in another language) and contrasts it with what TSA
+actually resolves. The cross-language MOAT means TSA's count must stay ~0.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+
+from tree_sitter_analyzer.miswire_audit import audit, render_card, render_terminal
+
+
+def _planted_polyglot() -> str:
+    """A tiny repo with a same-name collision: a Python `sorted()` caller and a
+    Swift `func sorted` — the exact CodeGraph flagship mis-wire."""
+    d = tempfile.mkdtemp()
+    with open(os.path.join(d, "app.py"), "w") as f:
+        f.write("def use():\n    return sorted([3, 1, 2])\n")
+    with open(os.path.join(d, "lib.swift"), "w") as f:
+        f.write("func sorted(_ a: [Int]) -> [Int] { return a }\n")
+    return d
+
+
+def test_audit_flags_name_only_miswire_but_tsa_does_not() -> None:
+    d = _planted_polyglot()
+    try:
+        r = audit(d, reindex=True)
+        # a name-only resolver would wire Python sorted() -> the Swift func sorted
+        assert r.naive_miswires >= 1, r
+        assert any(
+            o.callee_name == "sorted" and o.callee_lang == "swift"
+            for o in r.naive_offenders
+        ), r.naive_offenders
+        # TSA refuses that cross-language bind — Python sorted() stays builtin
+        assert r.tsa_miswires == 0, r
+        # the headline multiplier is meaningful
+        assert r.multiplier >= 1
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
+def test_audit_clean_repo_reports_zero_for_both() -> None:
+    """A single-language repo with no cross-language collisions -> 0 and 0."""
+    d = tempfile.mkdtemp()
+    try:
+        with open(os.path.join(d, "a.py"), "w") as f:
+            f.write("def helper():\n    return 1\ndef run():\n    return helper()\n")
+        r = audit(d, reindex=True)
+        assert r.tsa_miswires == 0
+        # helper() resolves locally; no foreign same-name def exists
+        assert r.naive_miswires == 0
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
+def test_render_terminal_and_card_are_honest() -> None:
+    """The output must NOT claim the name-only number is CodeGraph's exact count
+    (it is the worst-case for the name-only design); it must point to the live
+    head-to-head for the CodeGraph-specific figure."""
+    d = _planted_polyglot()
+    try:
+        r = audit(d, reindex=True)
+        term = render_terminal(r)
+        card = render_card(r)
+        assert "NAME-ONLY resolver" in term
+        assert "REPORT-v1.21.0.md" in term  # honest pointer to the live comparison
+        assert "name-only resolver" in card.lower()
+        # never label the modeled number as CodeGraph's measured count
+        assert "CodeGraph would mis-wire" not in term
+    finally:
+        shutil.rmtree(d, ignore_errors=True)

--- a/tree_sitter_analyzer/miswire_audit.py
+++ b/tree_sitter_analyzer/miswire_audit.py
@@ -13,8 +13,8 @@ do from TSA's own index (the same-name heuristic, validated in
 ``benchmarks/codegraph_compare/REPORT-v1.21.0.md``), and contrasts it with what
 TSA actually resolves.
 
-    uv run python -m scripts.miswire_audit .            # audit the current repo
-    uv run python -m scripts.miswire_audit /path/to/repo --card
+    uvx --from tree-sitter-analyzer miswire-audit .       # audit the current repo
+    uv run python -m tree_sitter_analyzer.miswire_audit /path --card
 
 Output: total call edges, how many a name-only resolver WOULD mis-wire across a
 language boundary, how many TSA mis-wires, the multiplier, and the top offending
@@ -24,6 +24,7 @@ edges (file:line, caller-lang → callee-lang).
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 from collections import defaultdict
 from dataclasses import dataclass, field
@@ -64,31 +65,58 @@ class AuditResult:
         return self.naive_miswires / self.tsa_miswires
 
 
-def _name_to_langs(conn: Any) -> dict[str, set[str]]:
-    """Map each defined symbol name -> the set of languages that define it."""
-    out: dict[str, set[str]] = defaultdict(set)
-    placeholders = ",".join("?" for _ in _DEF_KINDS)
-    rows = conn.execute(
-        f"SELECT name, language FROM ast_symbol_rows WHERE kind IN ({placeholders})",
-        _DEF_KINDS,
-    ).fetchall()
-    for r in rows:
-        out[r["name"]].add(r["language"])
-    return out
+def _iter_symbol_defs(conn: Any) -> list[tuple[str, str, str]]:
+    """Yield ``(name, file_path, language)`` for every function/method/class def.
+
+    Prefers the ``ast_symbol_rows`` table. On SQLite builds WITHOUT FTS5,
+    ``ASTCache`` does not create that table (Codex review #369), so we fall back
+    to parsing ``ast_index.symbols_json`` — which always exists — keeping the
+    audit functional in those supported environments.
+    """
+    import sqlite3
+
+    try:
+        # kinds are module constants, not user input — a literal IN clause keeps
+        # bandit happy (no string-built SQL) and is exactly equivalent.
+        rows = conn.execute(
+            "SELECT name, file_path, language FROM ast_symbol_rows "
+            "WHERE kind IN ('function', 'method', 'class')"
+        ).fetchall()
+        return [(r["name"], r["file_path"], r["language"]) for r in rows]
+    except sqlite3.OperationalError:
+        pass  # ast_symbol_rows absent (no-FTS5 build) — fall back below.
+
+    import json
+
+    defs: list[tuple[str, str, str]] = []
+    for r in conn.execute(
+        "SELECT file_path, language, symbols_json FROM ast_index"
+    ).fetchall():
+        raw = r["symbols_json"]
+        if not raw:
+            continue
+        try:
+            payload = json.loads(raw)
+        except (ValueError, TypeError):
+            continue
+        for sym in payload.get("symbols", []):
+            if sym.get("kind") in _DEF_KINDS and sym.get("name"):
+                defs.append((sym["name"], r["file_path"], r["language"]))
+    return defs
 
 
-def _name_to_file_lang(conn: Any) -> dict[str, list[tuple[str, str]]]:
-    """Map each defined name -> [(file, language), ...] for offender examples."""
-    out: dict[str, list[tuple[str, str]]] = defaultdict(list)
-    placeholders = ",".join("?" for _ in _DEF_KINDS)
-    rows = conn.execute(
-        f"SELECT name, file_path, language FROM ast_symbol_rows "
-        f"WHERE kind IN ({placeholders})",
-        _DEF_KINDS,
-    ).fetchall()
-    for r in rows:
-        out[r["name"]].append((r["file_path"], r["language"]))
-    return out
+def _build_name_maps(
+    conn: Any, present: set[str] | None
+) -> tuple[dict[str, set[str]], dict[str, list[tuple[str, str]]]]:
+    """Build name->languages and name->[(file,lang)] from current-repo defs."""
+    name_langs: dict[str, set[str]] = defaultdict(set)
+    name_files: dict[str, list[tuple[str, str]]] = defaultdict(list)
+    for name, file_path, language in _iter_symbol_defs(conn):
+        if present is not None and file_path not in present:
+            continue  # skip stale rows for files no longer on disk (Codex #369)
+        name_langs[name].add(language)
+        name_files[name].append((file_path, language))
+    return name_langs, name_files
 
 
 def audit(project_root: str, *, reindex: bool = True, top: int = 5) -> AuditResult:
@@ -111,8 +139,17 @@ def audit(project_root: str, *, reindex: bool = True, top: int = 5) -> AuditResu
                 "SELECT file_path, language FROM ast_index"
             ).fetchall()
         }
-        name_langs = _name_to_langs(conn)
-        name_files = _name_to_file_lang(conn)
+        # Codex #369: an incremental reindex does NOT purge rows for files that
+        # were deleted since a prior index, so the cache can carry stale
+        # definitions/edges. Restrict the audit to files that still exist on
+        # disk, so `miswire-audit .` reflects the CURRENT repo regardless of a
+        # stale .ast-cache (the slow alternative — a full clean rebuild — would
+        # punish every run).
+        present = {
+            f for f in file_lang if os.path.exists(os.path.join(project_root, f))
+        }
+        file_lang = {f: lang for f, lang in file_lang.items() if f in present}
+        name_langs, name_files = _build_name_maps(conn, present)
 
         edges = conn.execute(
             "SELECT callee_name, language AS caller_lang, callee_resolved_file, "
@@ -121,6 +158,9 @@ def audit(project_root: str, *, reindex: bool = True, top: int = 5) -> AuditResu
         ).fetchall()
 
         for e in edges:
+            # skip edges whose caller file no longer exists (stale cache rows)
+            if e["caller_file"] not in present:
+                continue
             result.total_call_edges += 1
             caller_lang = e["caller_lang"]
             name = e["callee_name"]
@@ -135,8 +175,14 @@ def audit(project_root: str, *, reindex: bool = True, top: int = 5) -> AuditResu
                     result.tsa_miswires += 1
                     if len(result.tsa_offenders) < top:
                         result.tsa_offenders.append(
-                            Offender(name, e["caller_file"], caller_lang,
-                                     resolved, rlang, e["callee_line"] or 0)
+                            Offender(
+                                name,
+                                e["caller_file"],
+                                caller_lang,
+                                resolved,
+                                rlang,
+                                e["callee_line"] or 0,
+                            )
                         )
 
             # --- Naive name-only model (what CodeGraph-style indexes do): a call
@@ -158,8 +204,14 @@ def audit(project_root: str, *, reindex: bool = True, top: int = 5) -> AuditResu
                         for df, dl in name_files.get(name, []):
                             if not languages_compatible(caller_lang, dl):
                                 result.naive_offenders.append(
-                                    Offender(name, e["caller_file"], caller_lang,
-                                             df, dl, e["callee_line"] or 0)
+                                    Offender(
+                                        name,
+                                        e["caller_file"],
+                                        caller_lang,
+                                        df,
+                                        dl,
+                                        e["callee_line"] or 0,
+                                    )
                                 )
                                 break
         return result

--- a/tree_sitter_analyzer/miswire_audit.py
+++ b/tree_sitter_analyzer/miswire_audit.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Mis-Wire Audit — run TSA's cross-language correctness check on ANY repo.
+
+The point: a name-only code-intelligence index (the common design — CodeGraph
+included) binds a call to *any* definition that shares the callee's name, even
+when that definition is in a different language. So a Python ``sorted()`` call
+gets wired to a Swift ``func sorted`` if Swift is the only ``sorted`` definition
+in the tree. TSA gates every binding by language family, so it does not.
+
+This audit makes that difference legible on YOUR OWN code, in one command, with
+**no CodeGraph install required**: it models what a name-only resolver *would*
+do from TSA's own index (the same-name heuristic, validated in
+``benchmarks/codegraph_compare/REPORT-v1.21.0.md``), and contrasts it with what
+TSA actually resolves.
+
+    uv run python -m scripts.miswire_audit .            # audit the current repo
+    uv run python -m scripts.miswire_audit /path/to/repo --card
+
+Output: total call edges, how many a name-only resolver WOULD mis-wire across a
+language boundary, how many TSA mis-wires, the multiplier, and the top offending
+edges (file:line, caller-lang → callee-lang).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Any
+
+from tree_sitter_analyzer._language_family import languages_compatible
+from tree_sitter_analyzer.ast_cache import ASTCache
+
+_DEF_KINDS = ("function", "method", "class")
+
+
+@dataclass
+class Offender:
+    callee_name: str
+    caller_file: str
+    caller_lang: str
+    callee_file: str
+    callee_lang: str
+    line: int
+
+
+@dataclass
+class AuditResult:
+    project_root: str
+    total_call_edges: int = 0
+    resolvable_edges: int = 0
+    naive_miswires: int = 0
+    tsa_miswires: int = 0
+    naive_offenders: list[Offender] = field(default_factory=list)
+    tsa_offenders: list[Offender] = field(default_factory=list)
+    languages: dict[str, int] = field(default_factory=dict)
+
+    @property
+    def multiplier(self) -> float:
+        """How many times cleaner TSA is (naive / TSA), guarded for 0."""
+        if self.tsa_miswires == 0:
+            return float(self.naive_miswires) if self.naive_miswires else 1.0
+        return self.naive_miswires / self.tsa_miswires
+
+
+def _name_to_langs(conn: Any) -> dict[str, set[str]]:
+    """Map each defined symbol name -> the set of languages that define it."""
+    out: dict[str, set[str]] = defaultdict(set)
+    placeholders = ",".join("?" for _ in _DEF_KINDS)
+    rows = conn.execute(
+        f"SELECT name, language FROM ast_symbol_rows WHERE kind IN ({placeholders})",
+        _DEF_KINDS,
+    ).fetchall()
+    for r in rows:
+        out[r["name"]].add(r["language"])
+    return out
+
+
+def _name_to_file_lang(conn: Any) -> dict[str, list[tuple[str, str]]]:
+    """Map each defined name -> [(file, language), ...] for offender examples."""
+    out: dict[str, list[tuple[str, str]]] = defaultdict(list)
+    placeholders = ",".join("?" for _ in _DEF_KINDS)
+    rows = conn.execute(
+        f"SELECT name, file_path, language FROM ast_symbol_rows "
+        f"WHERE kind IN ({placeholders})",
+        _DEF_KINDS,
+    ).fetchall()
+    for r in rows:
+        out[r["name"]].append((r["file_path"], r["language"]))
+    return out
+
+
+def audit(project_root: str, *, reindex: bool = True, top: int = 5) -> AuditResult:
+    """Run the mis-wire audit against ``project_root`` using TSA's index."""
+    cache = ASTCache(project_root)
+    if reindex:
+        cache.index_project()
+    conn = cache.get_conn()
+    try:
+        result = AuditResult(project_root=project_root)
+        result.languages = {
+            r["language"]: r["n"]
+            for r in conn.execute(
+                "SELECT language, COUNT(*) n FROM ast_index GROUP BY language"
+            ).fetchall()
+        }
+        file_lang = {
+            r["file_path"]: r["language"]
+            for r in conn.execute(
+                "SELECT file_path, language FROM ast_index"
+            ).fetchall()
+        }
+        name_langs = _name_to_langs(conn)
+        name_files = _name_to_file_lang(conn)
+
+        edges = conn.execute(
+            "SELECT callee_name, language AS caller_lang, callee_resolved_file, "
+            "file_path AS caller_file, callee_line "
+            "FROM edges WHERE kind='calls' AND callee_name != ''"
+        ).fetchall()
+
+        for e in edges:
+            result.total_call_edges += 1
+            caller_lang = e["caller_lang"]
+            name = e["callee_name"]
+
+            # --- TSA's actual resolution: cross-language only if it bound a file
+            #     in an incompatible language (the real, measured mis-wire). ---
+            resolved = e["callee_resolved_file"]
+            if resolved:
+                result.resolvable_edges += 1
+                rlang = file_lang.get(resolved)
+                if rlang and not languages_compatible(caller_lang, rlang):
+                    result.tsa_miswires += 1
+                    if len(result.tsa_offenders) < top:
+                        result.tsa_offenders.append(
+                            Offender(name, e["caller_file"], caller_lang,
+                                     resolved, rlang, e["callee_line"] or 0)
+                        )
+
+            # --- Naive name-only model (what CodeGraph-style indexes do): a call
+            #     binds to a same-name definition regardless of language. It
+            #     mis-wires when a same-name def exists but NONE is in a
+            #     compatible language — so the only binding choice crosses the
+            #     boundary (exactly the live-measured Python sorted()->Swift case).
+            defs = name_langs.get(name)
+            if defs:
+                has_compatible = any(
+                    languages_compatible(caller_lang, dl) for dl in defs
+                )
+                if not has_compatible:
+                    result.naive_miswires += 1
+                    # show DISTINCT callee names (not 5× the same one) so the
+                    # breadth of collisions is visible.
+                    seen_names = {o.callee_name for o in result.naive_offenders}
+                    if len(result.naive_offenders) < top and name not in seen_names:
+                        for df, dl in name_files.get(name, []):
+                            if not languages_compatible(caller_lang, dl):
+                                result.naive_offenders.append(
+                                    Offender(name, e["caller_file"], caller_lang,
+                                             df, dl, e["callee_line"] or 0)
+                                )
+                                break
+        return result
+    finally:
+        cache.close()
+
+
+def _fmt_pct(n: int, total: int) -> str:
+    return f"{(100.0 * n / total):.2f}%" if total else "0.00%"
+
+
+def render_terminal(r: AuditResult) -> str:
+    lines: list[str] = []
+    lines.append("")
+    lines.append("  ── TSA Mis-Wire Audit " + "─" * 38)
+    langs = ", ".join(f"{k}:{v}" for k, v in sorted(r.languages.items()))
+    lines.append(f"  repo: {r.project_root}")
+    lines.append(f"  languages indexed: {langs}")
+    lines.append(f"  call edges analysed: {r.total_call_edges:,}")
+    lines.append("")
+    lines.append(
+        f"  ❌ a NAME-ONLY resolver would mis-wire up to "
+        f"{r.naive_miswires:,} call edges across a language boundary "
+        f"({_fmt_pct(r.naive_miswires, r.total_call_edges)}) — binding a call to a "
+        f"same-named definition in another language"
+    )
+    lines.append(
+        f"  ✅ Tree-sitter Analyzer mis-wires {r.tsa_miswires:,} "
+        f"({_fmt_pct(r.tsa_miswires, r.total_call_edges)})"
+    )
+    if r.naive_miswires and r.tsa_miswires < r.naive_miswires:
+        lines.append("")
+        lines.append(f"     → TSA is {r.multiplier:.0f}× cleaner on YOUR code.")
+    lines.append("")
+    lines.append(
+        "  (the name-only figure is the worst case for a name-only index — the "
+        "design CodeGraph and most indexes use. A live head-to-head vs CodeGraph "
+        "specifically — 745 vs 6 on TSA's repo — is in"
+    )
+    lines.append("   benchmarks/codegraph_compare/REPORT-v1.21.0.md.)")
+    lines.append("")
+    if r.naive_offenders:
+        lines.append("  cross-language mis-wires a name-only index would make here:")
+        for o in r.naive_offenders:
+            lines.append(
+                f"    • {o.caller_lang} caller `{o.callee_name}()` "
+                f"→ {o.callee_lang} def in {o.callee_file} "
+                f"(at {o.caller_file}:{o.line})"
+            )
+    else:
+        lines.append("  (no cross-language same-name collisions in this repo)")
+    lines.append("  " + "─" * 60)
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render_card(r: AuditResult) -> str:
+    """A copy-paste markdown social card."""
+    mult = f"{r.multiplier:.0f}×" if r.naive_miswires else "—"
+    out = [
+        "### 🧬 TSA Mis-Wire Audit",
+        "",
+        f"Repo: `{r.project_root.split('/')[-1] or r.project_root}` · "
+        f"{r.total_call_edges:,} call edges · {len(r.languages)} languages",
+        "",
+        "| resolver | cross-language mis-wires | rate |",
+        "|---|---|---|",
+        f"| a name-only resolver (worst case) | **{r.naive_miswires:,}** | "
+        f"{_fmt_pct(r.naive_miswires, r.total_call_edges)} |",
+        f"| **Tree-sitter Analyzer** | **{r.tsa_miswires:,}** | "
+        f"{_fmt_pct(r.tsa_miswires, r.total_call_edges)} |",
+        "",
+        f"**{mult} cleaner** — run it on your repo: "
+        "`uvx --from tree-sitter-analyzer miswire-audit .`",
+        "",
+        "_Name-only is the design most code indexes (incl. CodeGraph) use. Live "
+        "head-to-head vs CodeGraph: 745 vs 6 — see REPORT-v1.21.0.md._",
+    ]
+    return "\n".join(out)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="miswire-audit",
+        description="Audit cross-language call-graph mis-wires in any repo "
+        "(no CodeGraph install needed).",
+    )
+    parser.add_argument("path", nargs="?", default=".", help="repo path (default: .)")
+    parser.add_argument("--card", action="store_true", help="emit a markdown card")
+    parser.add_argument("--top", type=int, default=5, help="offenders to show")
+    parser.add_argument(
+        "--no-reindex", action="store_true", help="reuse the existing .ast-cache"
+    )
+    args = parser.parse_args(argv)
+
+    result = audit(args.path, reindex=not args.no_reindex, top=args.top)
+    # Human-readable goes to stdout (this IS the machine output of the tool).
+    print(render_terminal(result))
+    if args.card:
+        print(render_card(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**Strategy-team decision** (4-lens panel — growth/DX/competitive/moat — + chair, unanimous): convert the won-but-illegible correctness moat into a **self-serve, falsifiable artifact** that runs on the reader's OWN repo. The canonical OSS dev-tool breakout pattern (ruff/biome/oxc/sqlfluff broke out on run-it-on-your-code, not blog claims).

```
uvx --from tree-sitter-analyzer miswire-audit .
```
On TSA's own repo:
> ❌ a NAME-ONLY resolver would mis-wire up to **4,199** call edges (3.68%) — Python `sorted()` → Swift func, `Counter()` → TS, `sum()` → TS, …
> ✅ Tree-sitter Analyzer mis-wires **6** (0.01%) → **700× cleaner on YOUR code.**

**No CodeGraph install needed** — it models the name-only design flaw from TSA's own index.

### Honesty (locked project value)
The modeled figure is the **worst case for the name-only DESIGN**, NOT CodeGraph's exact count (745 < 4199 — CodeGraph does *some* language handling). Output says "a name-only resolver" and points to REPORT-v1.21.0 for the live CodeGraph-specific **745-vs-6**. Never labels it "CodeGraph would mis-wire N" — one debunk-able claim destroys trust.

### Ships
- `tree_sitter_analyzer/miswire_audit.py` + `miswire-audit` console entrypoint (uvx-installable).
- 3 RED-first tests (planted polyglot fixture, clean repo, honest rendering); ruff+mypy clean; 166 contract/doc tests green.
- **RFC-0011** with acceptance criteria. Follow-ups tracked: CLI subcommand, pre-seed 5 famous repos, README surgery (make the one-liner the first above-the-fold block).

Focused PR (the audit core). Codex rate-limited; small self-contained demo tool with deterministic tests + honest framing.