### PR TITLE
fix(audit): graceful no-FTS5 degradation (Codex #369 L158 follow-up)

### DIFF
--- a/tests/benchmarks/test_miswire_audit.py
+++ b/tests/benchmarks/test_miswire_audit.py
@@ -97,3 +97,14 @@ def test_symbols_json_fallback_when_no_ast_symbol_rows() -> None:
         cache.close()
     finally:
         shutil.rmtree(d, ignore_errors=True)
+
+
+def test_no_fts5_renders_clear_unavailable_message_not_misleading_zero() -> None:
+    """Codex #369 L158: on no-FTS5 builds TSA writes no call edges; the audit must
+    say so plainly, NOT print a misleading '0 mis-wires / 0× cleaner' verdict."""
+    from tree_sitter_analyzer.miswire_audit import AuditResult, render_terminal
+
+    r = AuditResult(project_root=".", call_edges_available=False)
+    out = render_terminal(r)
+    assert "FTS5" in out
+    assert "cleaner" not in out  # no misleading verdict when there is no data

--- a/tree_sitter_analyzer/miswire_audit.py
+++ b/tree_sitter_analyzer/miswire_audit.py
@@ -56,6 +56,9 @@ class AuditResult:
     naive_offenders: list[Offender] = field(default_factory=list)
     tsa_offenders: list[Offender] = field(default_factory=list)
     languages: dict[str, int] = field(default_factory=dict)
+    # False on SQLite builds without FTS5, where index_project() does not write
+    # call edges (Codex #369 L158) — the audit cannot measure mis-wires there.
+    call_edges_available: bool = True
 
     @property
     def multiplier(self) -> float:
@@ -157,6 +160,12 @@ def audit(project_root: str, *, reindex: bool = True, top: int = 5) -> AuditResu
             "FROM edges WHERE kind='calls' AND callee_name != ''"
         ).fetchall()
 
+        # Codex #369 L158: on SQLite builds WITHOUT FTS5, index_project() does not
+        # write call edges, so `edges` is empty and a "0 mis-wires" verdict would
+        # be misleading. Flag it so the renderer can say so plainly instead.
+        if not edges and not bool(getattr(cache, "fts5_available", True)):
+            result.call_edges_available = False
+
         for e in edges:
             # skip edges whose caller file no longer exists (stale cache rows)
             if e["caller_file"] not in present:
@@ -230,6 +239,16 @@ def render_terminal(r: AuditResult) -> str:
     langs = ", ".join(f"{k}:{v}" for k, v in sorted(r.languages.items()))
     lines.append(f"  repo: {r.project_root}")
     lines.append(f"  languages indexed: {langs}")
+    if not r.call_edges_available:
+        lines.append("")
+        lines.append(
+            "  ⚠ this Python's SQLite has no FTS5, so TSA did not produce call "
+            "edges — the mis-wire audit needs them. Use a Python built with "
+            "SQLite FTS5 (the default for python.org / most distros) and re-run."
+        )
+        lines.append("  " + "─" * 60)
+        lines.append("")
+        return "\n".join(lines)
     lines.append(f"  call edges analysed: {r.total_call_edges:,}")
     lines.append("")
     lines.append(


### PR DESCRIPTION
Follow-up to the merged #369, addressing Codex's L158 (P2). On SQLite builds without FTS5, `index_project()` writes no call edges, so the audit saw an empty edges table and would print a misleading `0 mis-wires / 0× cleaner`. Now it flags `call_edges_available=False` (empty edges + no FTS5) and renders a clear *use an FTS5 build* message instead of a bogus verdict. New test; ruff+mypy+bandit clean; 5 tests green; normal FTS5 audit unchanged.

Triage of the other re-anchored comment (L126, stale-cache rows): already addressed in #369 by filtering the audit to files present on disk (non-destructive, equivalent to a purge — deleted-file offenders are excluded). @codex review