### PR TITLE
docs(readme): add the run-on-your-repo miswire-audit CTA after the 745-vs-6 proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,15 @@ Token cost is one axis; a code-intelligence tool's *first* job is a **correct gr
 | CodeGraph | **745** | 38,103 | 1.96 % |
 | **Tree-sitter Analyzer** | **6** | 114,160 | **0.005 %** |
 
-**~390× cleaner on cross-language correctness, while resolving 3× more call edges.** CodeGraph's mis-wires span 17 language pairs (python→swift **408**, python→typescript 195, python→ruby 81, …); TSA's 6 are all `java→python/php` from single-word Java method names. Concretely:
+**~390× cleaner on cross-language correctness, while resolving 3× more call edges.** CodeGraph's mis-wires span 17 language pairs (python→swift **408**, python→typescript 195, python→ruby 81, …); TSA's 6 are all `java→python/php` from single-word Java method names.
+
+> **Don't trust this table — run it on your own repo (no CodeGraph install needed):**
+> ```bash
+> uvx --from "tree-sitter-analyzer" miswire-audit .
+> ```
+> It indexes your code and prints how many call edges a name-only resolver (the design most indexes use) *would* mis-wire across a language boundary vs how many TSA does — with the offending edges listed (`Python sorted() → Swift func at file:line`). Add `--card` for a shareable scorecard.
+
+Concretely:
 
 | call (Python `_resolve_entry_points` / `build_response`) | CodeGraph | TSA |
 |---|---|---|


### PR DESCRIPTION
RFC-0011 README surgery: right after the live head-to-head (CodeGraph 745 vs TSA 6), invite the reader to **stop trusting the table** and run `uvx --from tree-sitter-analyzer miswire-audit .` on their OWN repo. Converts third-party proof into self-serve, falsifiable proof — the canonical OSS dev-tool breakout pattern. Docs-only, self-verified.