### PR TITLE
docs(audit): pre-seed miswire-audit results on real repos (RFC-0011 generalization)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Token cost is one axis; a code-intelligence tool's *first* job is a **correct gr
 > uvx --from "tree-sitter-analyzer" miswire-audit .
 > ```
 > It indexes your code and prints how many call edges a name-only resolver (the design most indexes use) *would* mis-wire across a language boundary vs how many TSA does — with the offending edges listed (`Python sorted() → Swift func at file:line`). Add `--card` for a shareable scorecard.
+>
+> **Real runs:** on [HuggingFace `tokenizers`](benchmarks/codegraph_compare/results/miswire-audit-examples.md) (Rust+Python+JS+TS) a name-only resolver would mis-wire **1,259** call edges (incl. a JS `tokenize()` → Rust def) — TSA: **0**. On a single-language repo (`gin`, Go) both are **0** — no false positives. [More examples →](benchmarks/codegraph_compare/results/miswire-audit-examples.md)
 
 Concretely:
 


### PR DESCRIPTION
Proves the `miswire-audit` **generalizes** beyond TSA's own repo (the strategy team's #1 leading indicator) + seeds the README with real results:
- **huggingface/tokenizers** (Rust+Python+JS+TS): name-only would mis-wire **1,259** edges (incl. JS `tokenize()` → Rust def); TSA **0** — **1259× cleaner**.
- **gin** (Go, single language): **0 and 0** — no false positives on mono-lang (credibility).
- **this repo**: 4,199 name-only vs 6 TSA.

Committed under `benchmarks/codegraph_compare/results/` + linked from the README CTA. Docs-only, self-verified.