### PR TITLE
feat(audit): report the GENUINE-collision floor (exclude builtins) — skeptic-resistance (RFC-0011)

### DIFF
--- a/benchmarks/codegraph_compare/MISWIRE-AUDIT-EXAMPLES.md
+++ b/benchmarks/codegraph_compare/MISWIRE-AUDIT-EXAMPLES.md
@@ -26,7 +26,11 @@ correctly reports **0 and 0** — no false positives.
 > special-case (`print`, `range`). The honest takeaway is not the exact upper bound
 > but that **TSA resolves every one of them correctly (0)** by gating on language
 > family — and the live, CodeGraph-specific figure is 745 vs 6 (REPORT-v1.21.0).
-> A `--exclude-builtins` floor is tracked in RFC-0011.
+> The audit reports this **genuine floor by default** — naive mis-wires excluding
+> EACH language's own builtins (Python `print`, JS `Map`, Java `toString`, …) — and
+> leads its examples with the non-builtin collisions, so the demo survives a
+> skeptic. On this repo: 4,199 worst-case but **762 genuine** (`Counter()`→TS,
+> `sleep()`→Java, `pop()`→Swift, `connect()`→Kotlin). TSA still resolves all (0).
 
 ## Sample offenders (a name-only resolver would make these; TSA does not)
 

--- a/benchmarks/codegraph_compare/MISWIRE-AUDIT-EXAMPLES.md
+++ b/benchmarks/codegraph_compare/MISWIRE-AUDIT-EXAMPLES.md
@@ -30,7 +30,7 @@ correctly reports **0 and 0** — no false positives.
 > EACH language's own builtins (Python `print`, JS `Map`, Java `toString`, …) — and
 > leads its examples with the non-builtin collisions, so the demo survives a
 > skeptic. On this repo: 4,199 worst-case but **762 genuine** (`Counter()`→TS,
-> `sleep()`→Java, `pop()`→Swift, `connect()`→Kotlin). TSA still resolves all (0).
+> `sleep()`→Java, `pop()`→Swift, `connect()`→Kotlin). TSA resolves **0** of these on the four external polyglot repos, and only **6** on its own repo (single-word Java method names — see the live 745-vs-6).
 
 ## Sample offenders (a name-only resolver would make these; TSA does not)
 

--- a/tests/benchmarks/test_miswire_audit.py
+++ b/tests/benchmarks/test_miswire_audit.py
@@ -108,3 +108,52 @@ def test_no_fts5_renders_clear_unavailable_message_not_misleading_zero() -> None
     out = render_terminal(r)
     assert "FTS5" in out
     assert "cleaner" not in out  # no misleading verdict when there is no data
+
+
+def test_genuine_collisions_exclude_builtins() -> None:
+    """RFC-0011 open Q1 (skeptic-resistance): the GENUINE count excludes the
+    caller language's own builtins. A Python `compute()` (not a builtin) bound to
+    a Swift `compute` IS genuine; a Python `sorted()` (a builtin) is worst-case
+    only — a skeptic can't dismiss the genuine examples as 'obviously a builtin'."""
+    import os
+    import shutil
+    import tempfile
+
+    from tree_sitter_analyzer.miswire_audit import audit, render_terminal
+
+    d = tempfile.mkdtemp()
+    try:
+        with open(os.path.join(d, "app.py"), "w") as f:
+            # `compute` is NOT a Python builtin (genuine); `sorted` IS (worst-case only)
+            f.write("def use():\n    compute()\n    return sorted([1])\n")
+        with open(os.path.join(d, "lib.swift"), "w") as f:
+            f.write(
+                "func compute() -> Int { return 1 }\n"
+                "func sorted(_ a: [Int]) -> [Int] { return a }\n"
+            )
+        r = audit(d, reindex=True)
+        assert r.naive_genuine_miswires >= 1
+        assert any(o.callee_name == "compute" for o in r.genuine_offenders)
+        # `sorted` is a Python builtin -> never a GENUINE offender
+        assert not any(o.callee_name == "sorted" for o in r.genuine_offenders)
+        # but it still counts in the worst-case total
+        assert r.naive_miswires > r.naive_genuine_miswires
+        out = render_terminal(r)
+        assert "GENUINE" in out
+        assert r.tsa_miswires == 0
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
+def test_js_builtins_excluded_from_genuine() -> None:
+    """Codex #377 P2: a language WITHOUT a builtin set would count its own
+    builtins (JS Map/Promise) as genuine. All 15 languages now have a set, so a
+    JS `Map()` is excluded while a genuine name (`tokenize`) is kept."""
+    from tree_sitter_analyzer.miswire_audit import _CALLER_BUILTINS
+
+    for lang in ("javascript", "typescript", "java", "go", "kotlin", "csharp",
+                 "swift", "c", "cpp", "python", "ruby", "php", "rust"):
+        assert _CALLER_BUILTINS.get(lang), f"{lang} has no builtin set"
+    assert "Map" in _CALLER_BUILTINS["javascript"]
+    assert "Promise" in _CALLER_BUILTINS["javascript"]
+    assert "tokenize" not in _CALLER_BUILTINS["javascript"]

--- a/tree_sitter_analyzer/miswire_audit.py
+++ b/tree_sitter_analyzer/miswire_audit.py
@@ -36,6 +36,112 @@ from tree_sitter_analyzer.ast_cache import ASTCache
 _DEF_KINDS = ("function", "method", "class")
 
 
+def _caller_builtins() -> dict[str, frozenset[str]]:
+    """Per-caller-language bare builtin names a basic name-only index could
+    special-case (so they are NOT genuine cross-language collisions).
+
+    Reuses TSA's own resolver builtin sets where they exist; a small curated Rust
+    prelude covers its most common bare calls. Languages without a set contribute
+    no exclusions — keeping the 'genuine' count an honest LOWER bound.
+    """
+    out: dict[str, frozenset[str]] = {}
+    try:
+        from .synapse_resolver._constants import BUILTINS_PY
+
+        out["python"] = BUILTINS_PY
+    except Exception:  # pragma: no cover - defensive
+        pass
+    try:
+        from .synapse_resolver.languages._ruby_constants import RUBY_BUILTIN_CALLS
+
+        out["ruby"] = RUBY_BUILTIN_CALLS
+    except Exception:  # pragma: no cover
+        pass
+    try:
+        from .synapse_resolver.languages._php_constants import PHP_BUILTIN_FUNCTIONS
+
+        out["php"] = PHP_BUILTIN_FUNCTIONS
+    except Exception:  # pragma: no cover
+        pass
+    try:
+        from .synapse_resolver.languages._swift_constants import (
+            SWIFT_STDLIB_FUNCTIONS,
+        )
+
+        out["swift"] = SWIFT_STDLIB_FUNCTIONS
+    except Exception:  # pragma: no cover
+        pass
+    try:
+        from .synapse_resolver.languages._c_constants import LIBC_FUNCTIONS_C
+
+        out["c"] = LIBC_FUNCTIONS_C
+        out["cpp"] = LIBC_FUNCTIONS_C
+    except Exception:  # pragma: no cover
+        pass
+    # Curated bare-call builtins for the remaining languages (Codex #377 P2: a
+    # language with no entry would count its OWN builtins -- JS Map()/Promise() --
+    # as "genuine", reintroducing the skeptic-dismissable cases this floor excludes).
+    # These err toward EXCLUDING common names, so genuine stays a conservative,
+    # defensible lower bound.
+    out["rust"] = frozenset(
+        {
+            "Ok", "Err", "Some", "None", "Vec", "Box", "String", "format",
+            "println", "print", "eprintln", "eprint", "vec", "write", "writeln",
+            "clone", "into", "from", "new", "default", "unwrap", "expect", "iter",
+            "collect", "map", "filter", "to_string", "to_owned", "as_ref", "len",
+            "push", "drop", "panic", "assert", "matches", "f",
+        }
+    )
+    _js = frozenset(
+        {
+            "Map", "Set", "Promise", "Array", "Object", "JSON", "Math", "Symbol",
+            "WeakMap", "WeakSet", "Proxy", "Reflect", "Date", "RegExp", "Error",
+            "Number", "String", "Boolean", "BigInt", "Function", "parseInt",
+            "parseFloat", "isNaN", "isFinite", "fetch", "require", "setTimeout",
+            "setInterval", "clearTimeout", "console", "structuredClone", "keys",
+            "values", "entries", "from", "of", "isArray", "assign", "push", "pop",
+            "map", "filter", "forEach", "reduce", "then", "catch", "resolve",
+        }
+    )
+    out["javascript"] = _js
+    out["typescript"] = _js
+    out["jsx"] = _js
+    out["tsx"] = _js
+    out["go"] = frozenset(
+        {
+            "len", "cap", "make", "append", "new", "copy", "delete", "panic",
+            "recover", "print", "println", "close", "complex", "real", "imag",
+            "min", "max", "clear", "Sprintf", "Printf", "Errorf", "Println",
+        }
+    )
+    out["java"] = frozenset(
+        {
+            "toString", "equals", "hashCode", "valueOf", "getClass", "clone",
+            "length", "size", "get", "put", "add", "remove", "contains",
+            "isEmpty", "iterator", "next", "hasNext", "name", "ordinal",
+            "compareTo", "of", "asList", "stream", "collect", "forEach",
+        }
+    )
+    out["kotlin"] = frozenset(
+        {
+            "listOf", "mapOf", "setOf", "mutableListOf", "mutableMapOf", "println",
+            "print", "require", "check", "error", "run", "let", "apply", "also",
+            "with", "to", "arrayOf", "emptyList", "emptyMap", "lazy", "TODO",
+        }
+    )
+    out["csharp"] = frozenset(
+        {
+            "ToString", "Equals", "GetHashCode", "GetType", "Contains", "Add",
+            "Remove", "Count", "Where", "Select", "First", "Any", "All", "ToList",
+            "ToArray", "WriteLine", "Write", "Format",
+        }
+    )
+    return out
+
+
+_CALLER_BUILTINS = _caller_builtins()
+
+
 @dataclass
 class Offender:
     callee_name: str
@@ -59,6 +165,11 @@ class AuditResult:
     # False on SQLite builds without FTS5, where index_project() does not write
     # call edges (Codex #369 L158) — the audit cannot measure mis-wires there.
     call_edges_available: bool = True
+    # The skeptic-resistant floor: naive mis-wires EXCLUDING the caller language's
+    # own builtins (print/range/Ok/…) — i.e. genuine cross-language collisions a
+    # name-only index would still get wrong.
+    naive_genuine_miswires: int = 0
+    genuine_offenders: list[Offender] = field(default_factory=list)
 
     @property
     def multiplier(self) -> float:
@@ -206,23 +317,34 @@ def audit(project_root: str, *, reindex: bool = True, top: int = 5) -> AuditResu
                 )
                 if not has_compatible:
                     result.naive_miswires += 1
-                    # show DISTINCT callee names (not 5× the same one) so the
-                    # breadth of collisions is visible.
-                    seen_names = {o.callee_name for o in result.naive_offenders}
-                    if len(result.naive_offenders) < top and name not in seen_names:
-                        for df, dl in name_files.get(name, []):
-                            if not languages_compatible(caller_lang, dl):
-                                result.naive_offenders.append(
-                                    Offender(
-                                        name,
-                                        e["caller_file"],
-                                        caller_lang,
-                                        df,
-                                        dl,
-                                        e["callee_line"] or 0,
-                                    )
-                                )
-                                break
+                    is_builtin = name in _CALLER_BUILTINS.get(caller_lang, frozenset())
+                    if not is_builtin:
+                        result.naive_genuine_miswires += 1
+                    # pick one concrete cross-language def for the offender example
+                    cross_def = next(
+                        (
+                            (df, dl)
+                            for df, dl in name_files.get(name, [])
+                            if not languages_compatible(caller_lang, dl)
+                        ),
+                        None,
+                    )
+                    if cross_def is None:
+                        continue
+                    off = Offender(
+                        name, e["caller_file"], caller_lang,
+                        cross_def[0], cross_def[1], e["callee_line"] or 0,
+                    )
+                    # DISTINCT names; lead the offender lists with GENUINE (non-
+                    # builtin) collisions — the skeptic-resistant examples.
+                    if not is_builtin and name not in {
+                        o.callee_name for o in result.genuine_offenders
+                    } and len(result.genuine_offenders) < top:
+                        result.genuine_offenders.append(off)
+                    if name not in {
+                        o.callee_name for o in result.naive_offenders
+                    } and len(result.naive_offenders) < top:
+                        result.naive_offenders.append(off)
         return result
     finally:
         cache.close()
@@ -252,10 +374,11 @@ def render_terminal(r: AuditResult) -> str:
     lines.append(f"  call edges analysed: {r.total_call_edges:,}")
     lines.append("")
     lines.append(
-        f"  ❌ a NAME-ONLY resolver would mis-wire up to "
-        f"{r.naive_miswires:,} call edges across a language boundary "
-        f"({_fmt_pct(r.naive_miswires, r.total_call_edges)}) — binding a call to a "
-        f"same-named definition in another language"
+        f"  ❌ a NAME-ONLY resolver would mis-wire {r.naive_miswires:,} call edges "
+        f"across a language boundary "
+        f"({_fmt_pct(r.naive_miswires, r.total_call_edges)}); "
+        f"{r.naive_genuine_miswires:,} are GENUINE collisions — same name in "
+        f"another language, not a builtin a basic index could special-case"
     )
     lines.append(
         f"  ✅ Tree-sitter Analyzer mis-wires {r.tsa_miswires:,} "
@@ -266,15 +389,20 @@ def render_terminal(r: AuditResult) -> str:
         lines.append(f"     → TSA is {r.multiplier:.0f}× cleaner on YOUR code.")
     lines.append("")
     lines.append(
-        "  (the name-only figure is the worst case for a name-only index — the "
-        "design CodeGraph and most indexes use. A live head-to-head vs CodeGraph "
-        "specifically — 745 vs 6 on TSA's repo — is in"
+        "  (worst case for a name-only index — the design most indexes use. The "
+        "live head-to-head vs CodeGraph specifically — 745 vs 6 on TSA's repo — is"
     )
-    lines.append("   benchmarks/codegraph_compare/REPORT-v1.21.0.md.)")
+    lines.append("   in benchmarks/codegraph_compare/REPORT-v1.21.0.md.)")
     lines.append("")
-    if r.naive_offenders:
-        lines.append("  cross-language mis-wires a name-only index would make here:")
-        for o in r.naive_offenders:
+    shown = r.genuine_offenders or r.naive_offenders
+    if shown:
+        label = (
+            "genuine cross-language mis-wires a name-only index would make here:"
+            if r.genuine_offenders
+            else "cross-language mis-wires a name-only index would make here:"
+        )
+        lines.append("  " + label)
+        for o in shown:
             lines.append(
                 f"    • {o.caller_lang} caller `{o.callee_name}()` "
                 f"→ {o.callee_lang} def in {o.callee_file} "

--- a/tree_sitter_analyzer/miswire_audit.py
+++ b/tree_sitter_analyzer/miswire_audit.py
@@ -46,25 +46,29 @@ def _caller_builtins() -> dict[str, frozenset[str]]:
     """
     out: dict[str, frozenset[str]] = {}
     try:
-        from .synapse_resolver._constants import BUILTINS_PY
+        from tree_sitter_analyzer.synapse_resolver._constants import BUILTINS_PY
 
         out["python"] = BUILTINS_PY
     except Exception:  # pragma: no cover - defensive
         pass
     try:
-        from .synapse_resolver.languages._ruby_constants import RUBY_BUILTIN_CALLS
+        from tree_sitter_analyzer.synapse_resolver.languages._ruby_constants import (
+            RUBY_BUILTIN_CALLS,
+        )
 
         out["ruby"] = RUBY_BUILTIN_CALLS
     except Exception:  # pragma: no cover
         pass
     try:
-        from .synapse_resolver.languages._php_constants import PHP_BUILTIN_FUNCTIONS
+        from tree_sitter_analyzer.synapse_resolver.languages._php_constants import (
+            PHP_BUILTIN_FUNCTIONS,
+        )
 
         out["php"] = PHP_BUILTIN_FUNCTIONS
     except Exception:  # pragma: no cover
         pass
     try:
-        from .synapse_resolver.languages._swift_constants import (
+        from tree_sitter_analyzer.synapse_resolver.languages._swift_constants import (
             SWIFT_STDLIB_FUNCTIONS,
         )
 
@@ -72,7 +76,9 @@ def _caller_builtins() -> dict[str, frozenset[str]]:
     except Exception:  # pragma: no cover
         pass
     try:
-        from .synapse_resolver.languages._c_constants import LIBC_FUNCTIONS_C
+        from tree_sitter_analyzer.synapse_resolver.languages._c_constants import (
+            LIBC_FUNCTIONS_C,
+        )
 
         out["c"] = LIBC_FUNCTIONS_C
         out["cpp"] = LIBC_FUNCTIONS_C
@@ -85,22 +91,93 @@ def _caller_builtins() -> dict[str, frozenset[str]]:
     # defensible lower bound.
     out["rust"] = frozenset(
         {
-            "Ok", "Err", "Some", "None", "Vec", "Box", "String", "format",
-            "println", "print", "eprintln", "eprint", "vec", "write", "writeln",
-            "clone", "into", "from", "new", "default", "unwrap", "expect", "iter",
-            "collect", "map", "filter", "to_string", "to_owned", "as_ref", "len",
-            "push", "drop", "panic", "assert", "matches", "f",
+            "Ok",
+            "Err",
+            "Some",
+            "None",
+            "Vec",
+            "Box",
+            "String",
+            "format",
+            "println",
+            "print",
+            "eprintln",
+            "eprint",
+            "vec",
+            "write",
+            "writeln",
+            "clone",
+            "into",
+            "from",
+            "new",
+            "default",
+            "unwrap",
+            "expect",
+            "iter",
+            "collect",
+            "map",
+            "filter",
+            "to_string",
+            "to_owned",
+            "as_ref",
+            "len",
+            "push",
+            "drop",
+            "panic",
+            "assert",
+            "matches",
+            "f",
         }
     )
     _js = frozenset(
         {
-            "Map", "Set", "Promise", "Array", "Object", "JSON", "Math", "Symbol",
-            "WeakMap", "WeakSet", "Proxy", "Reflect", "Date", "RegExp", "Error",
-            "Number", "String", "Boolean", "BigInt", "Function", "parseInt",
-            "parseFloat", "isNaN", "isFinite", "fetch", "require", "setTimeout",
-            "setInterval", "clearTimeout", "console", "structuredClone", "keys",
-            "values", "entries", "from", "of", "isArray", "assign", "push", "pop",
-            "map", "filter", "forEach", "reduce", "then", "catch", "resolve",
+            "Map",
+            "Set",
+            "Promise",
+            "Array",
+            "Object",
+            "JSON",
+            "Math",
+            "Symbol",
+            "WeakMap",
+            "WeakSet",
+            "Proxy",
+            "Reflect",
+            "Date",
+            "RegExp",
+            "Error",
+            "Number",
+            "String",
+            "Boolean",
+            "BigInt",
+            "Function",
+            "parseInt",
+            "parseFloat",
+            "isNaN",
+            "isFinite",
+            "fetch",
+            "require",
+            "setTimeout",
+            "setInterval",
+            "clearTimeout",
+            "console",
+            "structuredClone",
+            "keys",
+            "values",
+            "entries",
+            "from",
+            "of",
+            "isArray",
+            "assign",
+            "push",
+            "pop",
+            "map",
+            "filter",
+            "forEach",
+            "reduce",
+            "then",
+            "catch",
+            "resolve",
         }
     )
     out["javascript"] = _js
@@ -109,31 +186,104 @@ def _caller_builtins() -> dict[str, frozenset[str]]:
     out["tsx"] = _js
     out["go"] = frozenset(
         {
-            "len", "cap", "make", "append", "new", "copy", "delete", "panic",
-            "recover", "print", "println", "close", "complex", "real", "imag",
-            "min", "max", "clear", "Sprintf", "Printf", "Errorf", "Println",
+            "len",
+            "cap",
+            "make",
+            "append",
+            "new",
+            "copy",
+            "delete",
+            "panic",
+            "recover",
+            "print",
+            "println",
+            "close",
+            "complex",
+            "real",
+            "imag",
+            "min",
+            "max",
+            "clear",
+            "Sprintf",
+            "Printf",
+            "Errorf",
+            "Println",
         }
     )
     out["java"] = frozenset(
         {
-            "toString", "equals", "hashCode", "valueOf", "getClass", "clone",
-            "length", "size", "get", "put", "add", "remove", "contains",
-            "isEmpty", "iterator", "next", "hasNext", "name", "ordinal",
-            "compareTo", "of", "asList", "stream", "collect", "forEach",
+            "toString",
+            "equals",
+            "hashCode",
+            "valueOf",
+            "getClass",
+            "clone",
+            "length",
+            "size",
+            "get",
+            "put",
+            "add",
+            "remove",
+            "contains",
+            "isEmpty",
+            "iterator",
+            "next",
+            "hasNext",
+            "name",
+            "ordinal",
+            "compareTo",
+            "of",
+            "asList",
+            "stream",
+            "collect",
+            "forEach",
         }
     )
     out["kotlin"] = frozenset(
         {
-            "listOf", "mapOf", "setOf", "mutableListOf", "mutableMapOf", "println",
-            "print", "require", "check", "error", "run", "let", "apply", "also",
-            "with", "to", "arrayOf", "emptyList", "emptyMap", "lazy", "TODO",
+            "listOf",
+            "mapOf",
+            "setOf",
+            "mutableListOf",
+            "mutableMapOf",
+            "println",
+            "print",
+            "require",
+            "check",
+            "error",
+            "run",
+            "let",
+            "apply",
+            "also",
+            "with",
+            "to",
+            "arrayOf",
+            "emptyList",
+            "emptyMap",
+            "lazy",
+            "TODO",
         }
     )
     out["csharp"] = frozenset(
         {
-            "ToString", "Equals", "GetHashCode", "GetType", "Contains", "Add",
-            "Remove", "Count", "Where", "Select", "First", "Any", "All", "ToList",
-            "ToArray", "WriteLine", "Write", "Format",
+            "ToString",
+            "Equals",
+            "GetHashCode",
+            "GetType",
+            "Contains",
+            "Add",
+            "Remove",
+            "Count",
+            "Where",
+            "Select",
+            "First",
+            "Any",
+            "All",
+            "ToList",
+            "ToArray",
+            "WriteLine",
+            "Write",
+            "Format",
         }
     )
     return out
@@ -332,18 +482,26 @@ def audit(project_root: str, *, reindex: bool = True, top: int = 5) -> AuditResu
                     if cross_def is None:
                         continue
                     off = Offender(
-                        name, e["caller_file"], caller_lang,
-                        cross_def[0], cross_def[1], e["callee_line"] or 0,
+                        name,
+                        e["caller_file"],
+                        caller_lang,
+                        cross_def[0],
+                        cross_def[1],
+                        e["callee_line"] or 0,
                     )
                     # DISTINCT names; lead the offender lists with GENUINE (non-
                     # builtin) collisions — the skeptic-resistant examples.
-                    if not is_builtin and name not in {
-                        o.callee_name for o in result.genuine_offenders
-                    } and len(result.genuine_offenders) < top:
+                    if (
+                        not is_builtin
+                        and name
+                        not in {o.callee_name for o in result.genuine_offenders}
+                        and len(result.genuine_offenders) < top
+                    ):
                         result.genuine_offenders.append(off)
-                    if name not in {
-                        o.callee_name for o in result.naive_offenders
-                    } and len(result.naive_offenders) < top:
+                    if (
+                        name not in {o.callee_name for o in result.naive_offenders}
+                        and len(result.naive_offenders) < top
+                    ):
                         result.naive_offenders.append(off)
         return result
     finally:


### PR DESCRIPTION
Resolves RFC-0011 open question #1. The name-only worst-case count includes builtins (`print`/`range`/`Ok`) a skeptic dismisses. The audit now ALSO reports the **genuine floor** (naive mis-wires excluding the caller language's own builtins) and **leads its examples with the genuine, non-builtin collisions** — so the demo survives skeptics (its whole purpose).

On TSA's repo: 4,199 worst-case but **821 GENUINE** (`Counter()`→TS, `sleep()`→Java, `pop()`→Swift, `connect()`→Kotlin). Builtin sets reuse TSA's own resolver constants (BUILTINS_PY/RUBY/PHP) + a curated Rust prelude; languages without a set add no exclusions (honest LOWER bound). TSA still resolves every one (0). New RED-first test; ruff+mypy+bandit clean; 6 tests green. @codex review