### PR TITLE
fix(docs): CTA command actually works — miswire-audit isn't in the published PyPI release

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,10 @@ Restart your agent, then say: *"Set the project root to my repo and run the `ind
 **See the correctness edge on your own repo** — no install, no CodeGraph (it re-indexes first; seconds on a small repo, a minute or two on a large one):
 
 ```bash
-uvx --from "tree-sitter-analyzer" miswire-audit .
+uvx --from "git+https://github.com/aimasteracc/tree-sitter-analyzer@develop" miswire-audit .
 ```
+
+_(installs the latest from source until the next PyPI release ships the `miswire-audit` entry point; then `uvx --from tree-sitter-analyzer miswire-audit .`)_
 
 It prints how many call edges a name-only code index (the design most tools use) *would* mis-wire across a language boundary — e.g. a Python `sorted()` wired to a Swift `func sorted` — versus how many TSA does (≈0). On [HuggingFace `tokenizers`](benchmarks/codegraph_compare/MISWIRE-AUDIT-EXAMPLES.md): **1,259 → 0**.
 
@@ -72,7 +74,7 @@ Token cost is one axis; a code-intelligence tool's *first* job is a **correct gr
 
 > **Don't trust this table — run it on your own repo (no CodeGraph install needed):**
 > ```bash
-> uvx --from "tree-sitter-analyzer" miswire-audit .
+> uvx --from "git+https://github.com/aimasteracc/tree-sitter-analyzer@develop" miswire-audit .
 > ```
 > It indexes your code and prints how many call edges a name-only resolver (the design most indexes use) *would* mis-wire across a language boundary vs how many TSA does — with the offending edges listed (`Python sorted() → Swift func at file:line`). Add `--card` for a shareable scorecard.
 >

--- a/README_ja.md
+++ b/README_ja.md
@@ -36,7 +36,7 @@ claude mcp add tree-sitter-analyzer \
 **自分のリポジトリで correctness の差を 1 コマンドで確認**(インストール不要・CodeGraph 不要、最初に再インデックスします):
 
 ```bash
-uvx --from "tree-sitter-analyzer" miswire-audit .
+uvx --from "git+https://github.com/aimasteracc/tree-sitter-analyzer@develop" miswire-audit .
 ```
 
 name-only な code index(多くのツールが採る設計)なら、何件の呼び出しを言語をまたいで誤結線するか(例: Python の `sorted()` → Swift の func)vs TSA が何件かを表示します。実証: [HuggingFace `tokenizers`](benchmarks/codegraph_compare/MISWIRE-AUDIT-EXAMPLES.md) で name-only は **1,259 件**(JS `tokenize()` → Rust 等)、TSA は **0**。ruff **7557×**、polars **9016×**。単一言語リポ(gin/Go)は両方 **0** で誤検知なし。

--- a/README_zh.md
+++ b/README_zh.md
@@ -37,7 +37,7 @@ claude mcp add tree-sitter-analyzer \
 **用一条命令在你自己的仓库上验证 correctness 优势**（无需安装、无需 CodeGraph，会先重建索引）：
 
 ```bash
-uvx --from "tree-sitter-analyzer" miswire-audit .
+uvx --from "git+https://github.com/aimasteracc/tree-sitter-analyzer@develop" miswire-audit .
 ```
 
 它会显示一个 name-only 代码索引（多数工具的设计）会把多少调用跨语言错连（例如 Python 的 `sorted()` → Swift 的 func），对比 TSA 的数量。实测：[HuggingFace `tokenizers`](benchmarks/codegraph_compare/MISWIRE-AUDIT-EXAMPLES.md) 上 name-only 为 **1,259 处**（含 JS `tokenize()` → Rust），TSA 为 **0**。ruff **7557×**、polars **9016×**。单语言仓库（gin/Go）两者均为 **0**，无误报。

--- a/benchmarks/codegraph_compare/MISWIRE-AUDIT-EXAMPLES.md
+++ b/benchmarks/codegraph_compare/MISWIRE-AUDIT-EXAMPLES.md
@@ -2,7 +2,7 @@
 
 Real `miswire-audit` runs on public repos (no CodeGraph install — TSA models the
 name-only design from its own index). Reproduce on any tree:
-`uvx --from "tree-sitter-analyzer" miswire-audit <path>`.
+`uvx --from "git+https://github.com/aimasteracc/tree-sitter-analyzer@develop" miswire-audit <path>`.
 
 ## Summary
 


### PR DESCRIPTION
**CRITICAL conversion-blocker.** Every README/examples/description CTA tells users to run `uvx --from tree-sitter-analyzer miswire-audit .` — but the published PyPI release is **1.20.0 (2026-06-03)** and miswire-audit was added **this session on develop**, so it is NOT in the published package. The headline 'run it on your repo' command **fails for every new user** (and `uvx --from git+...` defaults to `main`, which also lacks it). The entire run-on-your-repo strategy breaks at first contact.

**Fix:** all 5 CTAs now use the verified-working source install `uvx --from "git+...@develop" miswire-audit .` + a note that the clean PyPI form lands with the next release.

**Bigger issue flagged:** the WHOLE session's work (13-language correctness, the audit, all fixes) is on develop, unreleased — users still get 1.20.0. The proper fix is a **PyPI release**, which I'm flagging for your authorization (a public release is an investor-gated action). Docs-only; tests green.