### PR TITLE
fix(formatters): apply CSV control-char sanitizer to the two remaining writers

### DIFF
--- a/tests/unit/formatters/test_csv_control_char_safety_remaining.py
+++ b/tests/unit/formatters/test_csv_control_char_safety_remaining.py
@@ -1,0 +1,160 @@
+"""CSV control-character safety for the two remaining CSV writers.
+
+Companion to ``test_csv_control_char_safety.py``, covering the two writers that
+PR #381 left out:
+
+1. ``BaseTableFormatter._format_csv`` (the public ``format_type="csv"`` path,
+   exercised here via ``PythonTableFormatter``). It previously used
+   ``escapechar="\\"`` — which doubled literal backslashes in ordinary fields
+   (Windows paths, regex) — now switched to the strip-via-``csv_safe_row``
+   approach.
+2. ``_legacy_table_formatter_csv.format_csv`` (the ``--table csv`` CLI path).
+
+Guards the same Python 3.10 vs 3.11+ ``csv`` divergence: on 3.10 a NULL byte
+raises ``_csv.Error: need to escape, but no escapechar set`` and a bare ``\\r``
+is written unquoted (producing an unreadable CSV). These tests assert the
+contract version-independently — RED on Python 3.10 before the fix, GREEN after.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+
+import pytest
+
+from tree_sitter_analyzer._legacy_table_formatter_csv import (
+    format_csv as legacy_format_csv,
+)
+from tree_sitter_analyzer.formatters.python_formatter import PythonTableFormatter
+
+# Control chars that trip a no-escapechar csv.writer on Python 3.10.
+CONTROL_NAMES = ["\x00", "\x00abc", "a\x00b", "\x01\x02"]
+# CR variants: a bare \r is emitted unquoted on 3.10 -> unreadable CSV.
+CR_NAMES = ["a\rb", "a\r\nb", "\r", "line1\rline2"]
+
+
+def _base_csv(name: str) -> str:
+    """Run ``name`` through the base_formatter CSV path (method + field)."""
+    data = {
+        "classes": [],
+        "methods": [
+            {
+                "name": name,
+                "return_type": "void",
+                "parameters": [],
+                "visibility": "public",
+                "line_range": {"start": 1, "end": 2},
+            }
+        ],
+        "fields": [
+            {
+                "name": name,
+                "type": "int",
+                "visibility": "private",
+                "line_range": {"start": 3, "end": 3},
+            }
+        ],
+    }
+    return PythonTableFormatter(format_type="csv").format_structure(data)
+
+
+def _legacy_csv(name: str) -> str:
+    """Run ``name`` through the legacy ``--table csv`` path (class/method/field)."""
+    data = {
+        "classes": [
+            {
+                "type": "class",
+                "name": name,
+                "visibility": "public",
+                "modifiers": [],
+                "line_range": {"start": 1, "end": 9},
+            }
+        ],
+        "methods": [
+            {
+                "name": name,
+                "return_type": "void",
+                "parameters": [],
+                "visibility": "public",
+                "line_range": {"start": 2, "end": 3},
+            }
+        ],
+        "fields": [
+            {
+                "name": name,
+                "type": "int",
+                "visibility": "private",
+                "line_range": {"start": 4, "end": 4},
+            }
+        ],
+    }
+    return legacy_format_csv(data)
+
+
+# --- base_formatter (_format_csv) -----------------------------------------
+
+
+@pytest.mark.parametrize("name", CONTROL_NAMES)
+def test_base_formatter_handles_control_chars(name: str) -> None:
+    """base_formatter CSV must serialize a control-char name without raising."""
+    result = _base_csv(name)
+    assert isinstance(result, str)
+    assert len(result) > 0
+
+
+@pytest.mark.parametrize("name", CR_NAMES)
+def test_base_formatter_output_is_readable_with_cr(name: str) -> None:
+    """base_formatter CSV must round-trip through csv.reader for CR-laden names."""
+    result = _base_csv(name)
+    rows = list(csv.reader(io.StringIO(result)))
+    assert len(rows) >= 2  # header + at least one data row
+    assert "\r" not in result
+
+
+def test_base_formatter_preserves_backslashes() -> None:
+    """Literal backslashes must NOT be doubled (the escapechar regression)."""
+    result = _base_csv(r"C:\tmp\Foo")
+    assert r"C:\tmp\Foo" in result
+    assert r"C:\\tmp" not in result
+
+
+def test_base_formatter_preserves_regex_backslashes() -> None:
+    """A regex-like name keeps its backslashes intact."""
+    result = _base_csv(r"\d+\w*")
+    assert r"\d+\w*" in result
+    assert r"\\d" not in result
+
+
+# --- legacy --table csv (format_csv) --------------------------------------
+
+
+@pytest.mark.parametrize("name", CONTROL_NAMES)
+def test_legacy_csv_handles_control_chars(name: str) -> None:
+    """legacy CSV must serialize a control-char name without raising."""
+    result = _legacy_csv(name)
+    assert isinstance(result, str)
+    assert len(result) > 0
+
+
+@pytest.mark.parametrize("name", CR_NAMES)
+def test_legacy_csv_output_is_readable_with_cr(name: str) -> None:
+    """legacy CSV must round-trip through csv.reader for CR-laden names."""
+    result = _legacy_csv(name)
+    rows = list(csv.reader(io.StringIO(result)))
+    assert len(rows) >= 2  # header + at least one data row
+    assert "\r" not in result
+
+
+def test_legacy_csv_preserves_backslashes() -> None:
+    """Literal backslashes must NOT be doubled in the legacy path."""
+    result = _legacy_csv(r"C:\tmp\Foo")
+    assert r"C:\tmp\Foo" in result
+    assert r"C:\\tmp" not in result
+
+
+def test_legacy_csv_preserves_regex_backslashes() -> None:
+    """A regex-like name keeps its backslashes intact in the legacy path."""
+    result = _legacy_csv(r"\d+\w*")
+    assert r"\d+\w*" in result
+    assert r"\\d" not in result

--- a/tree_sitter_analyzer/_legacy_table_formatter_csv.py
+++ b/tree_sitter_analyzer/_legacy_table_formatter_csv.py
@@ -7,6 +7,18 @@ import io
 from typing import Any
 
 
+def _csv_safe_row(row: list[Any]) -> list[Any]:
+    """Sanitize a CSV row, importing the shared helper lazily.
+
+    Importing ``tree_sitter_analyzer.formatters`` at module load time creates a
+    circular import (formatters.__init__ -> formatter_registry -> ... -> this
+    module), so the helper is imported on first use instead.
+    """
+    from tree_sitter_analyzer.formatters._csv_safety import csv_safe_row
+
+    return csv_safe_row(row)
+
+
 def format_csv(data: dict[str, Any]) -> str:
     """Format structure data as legacy CSV output."""
     output = io.StringIO()
@@ -27,16 +39,18 @@ def format_csv(data: dict[str, Any]) -> str:
 
     for cls in data.get("classes", []) or []:
         writer.writerow(
-            [
-                str(cls.get("type", "class")),
-                str(cls.get("name", "Unknown")),
-                "",
-                "",
-                str(cls.get("visibility", "public")),
-                "false",
-                "true" if "final" in cls.get("modifiers", []) else "false",
-                cls.get("line_range", {}).get("start", 0),
-            ]
+            _csv_safe_row(
+                [
+                    str(cls.get("type", "class")),
+                    str(cls.get("name", "Unknown")),
+                    "",
+                    "",
+                    str(cls.get("visibility", "public")),
+                    "false",
+                    "true" if "final" in cls.get("modifiers", []) else "false",
+                    cls.get("line_range", {}).get("start", 0),
+                ]
+            )
         )
 
     for method in data.get("methods", []):
@@ -59,16 +73,18 @@ def _write_csv_method_row(writer: Any, method: dict[str, Any]) -> None:
     is_final = "final" in modifiers or method.get("is_final", False)
 
     writer.writerow(
-        [
-            "constructor" if method.get("is_constructor", False) else "method",
-            str(method.get("name", "")),
-            str(method.get("return_type", "void")),
-            _csv_parameters(method.get("parameters", [])),
-            str(method.get("visibility", "public")),
-            "true" if is_static else "false",
-            "true" if is_final else "false",
-            method.get("line_range", {}).get("start", 0),
-        ]
+        _csv_safe_row(
+            [
+                "constructor" if method.get("is_constructor", False) else "method",
+                str(method.get("name", "")),
+                str(method.get("return_type", "void")),
+                _csv_parameters(method.get("parameters", [])),
+                str(method.get("visibility", "public")),
+                "true" if is_static else "false",
+                "true" if is_final else "false",
+                method.get("line_range", {}).get("start", 0),
+            ]
+        )
     )
 
 
@@ -79,16 +95,18 @@ def _write_csv_field_row(writer: Any, field: dict[str, Any]) -> None:
     is_final = "final" in modifiers or field.get("is_final", False)
 
     writer.writerow(
-        [
-            "field",
-            str(field.get("name", "")),
-            str(field.get("type", "Object")),
-            "",
-            str(field.get("visibility", "private")),
-            "true" if is_static else "false",
-            "true" if is_final else "false",
-            field.get("line_range", {}).get("start", 0),
-        ]
+        _csv_safe_row(
+            [
+                "field",
+                str(field.get("name", "")),
+                str(field.get("type", "Object")),
+                "",
+                str(field.get("visibility", "private")),
+                "true" if is_static else "false",
+                "true" if is_final else "false",
+                field.get("line_range", {}).get("start", 0),
+            ]
+        )
     )
 
 

--- a/tree_sitter_analyzer/formatters/base_formatter.py
+++ b/tree_sitter_analyzer/formatters/base_formatter.py
@@ -8,6 +8,8 @@ import io
 from abc import ABC, abstractmethod
 from typing import Any
 
+from ._csv_safety import csv_safe_row
+
 
 class BaseFormatter(ABC):
     """Base class for language-specific formatters"""
@@ -150,20 +152,26 @@ class BaseTableFormatter(BaseFormatter):
         """CSV format (common implementation).
 
         r37dk (dogfood): flattened nesting 6 → 3 by extracting per-row
-        builders (``_csv_field_row`` / ``_csv_method_row``). Output bytes
-        unchanged — same columns, same order, same escapechar settings.
+        builders (``_csv_field_row`` / ``_csv_method_row``).
+
+        Data rows are sanitized with ``csv_safe_row``: Python 3.10's
+        ``csv.writer`` raises ``_csv.Error: need to escape, but no escapechar
+        set`` on a NULL byte and emits a bare ``\\r`` unquoted (producing an
+        unreadable CSV). The previous ``escapechar="\\"`` silenced the NULL
+        error but doubled literal backslashes in ordinary fields (Windows
+        paths, regex), a format regression. Stripping the unrepresentable
+        controls instead leaves the dialect — and backslashes — untouched.
         """
         output = io.StringIO()
-        # Set escapechar to handle special characters that cannot be quoted (like null bytes in some envs)
-        writer = csv.writer(output, lineterminator="\n", escapechar="\\")
+        writer = csv.writer(output, lineterminator="\n")
 
         writer.writerow(
             ["Type", "Name", "Signature", "Visibility", "Lines", "Complexity", "Doc"]
         )
         for field in data.get("fields", []):
-            writer.writerow(self._csv_field_row(field))
+            writer.writerow(csv_safe_row(self._csv_field_row(field)))
         for method in data.get("methods", []):
-            writer.writerow(self._csv_method_row(method))
+            writer.writerow(csv_safe_row(self._csv_method_row(method)))
 
         csv_content = output.getvalue()
         csv_content = csv_content.replace("\r\n", "\n").replace("\r", "\n")


### PR DESCRIPTION
## What

PR #381 added `tree_sitter_analyzer/formatters/_csv_safety.py` (`csv_safe_row` / `csv_safe_cell`) and applied it to the CSV writers it touched, but left **two writers unguarded** against the Python 3.10 `csv` divergence. This finishes the same coherent concern so **every** CSV writer is py3.10-safe.

The two remaining writers:

1. **`formatters/base_formatter.py` → `_format_csv`** (the public `format_type="csv"` path used by every `BaseTableFormatter` subclass). Previously used `csv.writer(..., escapechar="\\")`. The `escapechar` **doubled literal backslashes** in ordinary fields (`C:\tmp` → `C:\\tmp`) — a format regression for Windows paths and regex strings that Codex flagged on #381. Removed `escapechar` and wrapped each data row (`_csv_field_row` / `_csv_method_row` results) with `csv_safe_row`.
2. **`_legacy_table_formatter_csv.py` → `format_csv`** (the `--table csv` CLI path). Wrapped its class/method/field data rows with `csv_safe_row`. Imported lazily inside a small `_csv_safe_row` wrapper to avoid a `formatters`-package circular import (`formatters.__init__` → `formatter_registry` → … → this module).

Headers are constant string literals — **not** sanitized; only data rows.

## Why

On **Python 3.10**, `csv.writer` with no `escapechar`:
- (a) raises `_csv.Error: need to escape, but no escapechar set` on a NULL byte, and
- (b) writes a bare `\r` **unquoted**, so the CSV fails to read back (`new-line character seen in unquoted field`).

Python 3.11+ does neither. Setting `escapechar="\\"` silences (a) but doubles backslashes — the wrong fix. The right fix is the sanitizer: it strips C0/DEL controls + bare CR, preserves `\t`/`\n`, and leaves the dialect (and backslashes) untouched.

## Real Python 3.10 verification

Ran CR / lone-CR / CRLF / NUL / a Windows-path name (`C:\tmp\Foo`) / a regex name (`\d+\w*`) through **both** writers on real CPython 3.10.20:

```
PY 3.10.20
ALL CHECKS PASSED: both writers round-trip, no bare CR, backslashes not doubled
```

Asserting, for every input and both writers: (a) `csv.reader` round-trips with no exception, (b) no bare `\r` in output, (c) backslashes are NOT doubled (`C:\\tmp` absent).

## Tests

- New focused file `tests/unit/formatters/test_csv_control_char_safety_remaining.py` mirroring the #381 pattern: parametrized control-char + CR round-trip + backslash-preservation assertions for **both** writers. RED on py3.10 before the fix, GREEN after.

## Golden masters stayed green

The sanitizer is a no-op on normal input, so output bytes are unchanged for normal data:

```
uv run pytest tests/integration/core/test_golden_master_regression.py -q -k csv
18 passed
```

Also green: full `tests/unit/formatters/` (2058 passed), legacy/table formatter suite (289 passed), `ruff`, `mypy`, and all pre-commit hooks (bandit, detect-secrets, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)