### PR TITLE
fix(test-isolation): eliminate PluggyTeardownRaisedWarning flake in per-test budget enforcer

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -518,13 +518,26 @@ def verify_test_isolation():
 SLOW_TEST_BUDGET_S: float = 5.0
 
 
-@pytest.hookimpl(hookwrapper=True)
+@pytest.hookimpl(wrapper=True)
 def pytest_runtest_call(item):
     """Enforce per-test wall-time budget for unit tests.
 
     Skipped under integration / performance markers and when the test
     is explicitly tagged ``slow_ok``. Integration tests have their own
     looser thresholds; performance tests are timed elsewhere.
+
+    Implemented as a *new-style* ``wrapper=True`` hook (not the legacy
+    ``hookwrapper=True``). The distinction is load-bearing for CI
+    stability: with the old style, calling ``pytest.fail()`` in the
+    post-``yield`` block raises *inside* an old-style hookwrapper
+    teardown, which pluggy reports as ``PluggyTeardownRaisedWarning``.
+    Because ``pytest.ini`` runs with ``filterwarnings = error`` that
+    warning is escalated to a hard error that ``--reruns`` cannot clear
+    — producing intermittent failures on slow CI workers where an
+    otherwise-fast unit test brushes past the budget under xdist
+    scheduling contention. New-style wrappers raise the failure
+    directly through the normal call outcome (no pluggy warning), so the
+    budget failure is a clean, rerunnable test failure.
     """
     import time
 
@@ -534,19 +547,19 @@ def pytest_runtest_call(item):
         or "integration" in item.keywords
     )
     started = time.monotonic()
-    outcome = yield
+    # With wrapper=True, ``yield`` returns the wrapped hook's result and
+    # re-raises the test's own exception here if the test failed. When
+    # the test already failed, that exception propagates straight out of
+    # ``yield`` (skipping the budget check below), so we never double-fail
+    # a test that raised on its own.
+    result = yield
     elapsed = time.monotonic() - started
 
     # Only enforce on unit tests (tests/unit/...). Other suites are
     # allowed to take longer.
     is_unit = "/tests/unit/" in str(item.fspath).replace("\\", "/")
 
-    if (
-        is_unit
-        and not opted_out
-        and outcome.excinfo is None  # don't double-fail on already-failing tests
-        and elapsed > SLOW_TEST_BUDGET_S
-    ):
+    if is_unit and not opted_out and elapsed > SLOW_TEST_BUDGET_S:
         pytest.fail(
             f"Unit test exceeded per-test budget: {elapsed:.2f}s > "
             f"{SLOW_TEST_BUDGET_S:.1f}s.\n"
@@ -560,3 +573,6 @@ def pytest_runtest_call(item):
             f"@pytest.mark.slow_ok with a justifying comment.",
             pytrace=False,
         )
+
+    # New-style wrappers must return the wrapped hook's result.
+    return result


### PR DESCRIPTION
## Problem

8 tests across two clusters intermittently fail under parallel xdist (different worker packing / ordering) while passing on rerun and in the full CI matrix — blocking every recent release.

**Cluster A** (`PluggyTeardownRaisedWarning`, seen windows-3.12 + ubuntu-3.10):
1. `test_gitignore_detector_comprehensive.py::...test_performance_with_large_directory_structure`
2. `test_nav_facade.py::test_navigate_action_no_strict_leak`
3. `test_benchmark_harness.py::...test_warm_index_skips_when_db_has_rows`

**Cluster B** (failed windows-3.11 PR-fast; full windows-3.11 matrix passed on the same commit):
4-5. `test_safe_to_edit_unsafe_verdict.py::...test_safe_to_edit_emits_{CAUTION,UNSAFE}_on_*_violation`
6-7. `test_ast_cache_mode_used.py::test_{default_index_reports_incremental,force_index_reports_full}_mode`
8. `test_unresolved_refs_cache_parity.py::test_cached_candidate_lookup_matches_uncached_byte_for_byte`

## Root cause (single, shared by both clusters)

The per-test wall-time budget enforcer in `tests/conftest.py` (`pytest_runtest_call`) was an **old-style** `@pytest.hookimpl(hookwrapper=True)` that calls `pytest.fail()` in its post-`yield` block.

Under pluggy, an exception raised in an *old-style* hookwrapper teardown is reported as `PluggyTeardownRaisedWarning` (pluggy `_callers.py::_warn_teardown_exception`, reached only via `run_old_style_hookwrapper`). Because `pytest.ini` runs with `filterwarnings = error`, that warning is escalated to a hard error that `--reruns` cannot clear.

On slow CI workers, an otherwise-fast unit test can brush past the `SLOW_TEST_BUDGET_S = 5.0s` threshold purely from xdist scheduling contention. The budget then fires `pytest.fail()` → pluggy warning → non-rerunnable error. The 8 named tests are exactly the moderately-heavy unit tests (real DependencyGraph build, full `index_project`, full unresolved-refs resolve pass, 100-dir tree walk) most likely to cross 5s under load.

This also explains the asymmetry: `--dist=loadfile` packs workers differently between the PR-fast subset and the full matrix, so the same heavy test crosses the budget on one axis but not the other (Cluster B's "5 failed PR-fast, full matrix green"). The Cluster B tests have deterministic assertions + per-test `tmp_path` DBs — they cannot fail on a state leak; the only way they fail is this teardown-warning escalation.

## Fix

Convert the enforcer to the **new-style** `@pytest.hookimpl(wrapper=True)`. New-style wrappers raise the budget failure through the normal call outcome (pluggy `_multicall` re-raises it, no `_warn_teardown_exception` path), so a spurious budget trip is now a **clean, rerunnable** test failure that `--reruns=2` absorbs. Behaviour is otherwise identical:
- slow unit tests still fail with the same message,
- genuine test failures still surface their own assertion (no double-fail — the test's exception propagates straight out of `yield`),
- `slow_ok` / `performance` / `integration` still opt out.

One-file diff, no production code touched, no locked design decision touched.

## Repro → green evidence

- Budget enforcer probe under `-W error`: slow test → clean `Failed` (not `PluggyTeardownRaisedWarning`); genuine failure → own `AssertionError`; fast test → pass.
- All 8 named tests + their 6 files: **10× under xdist with `reruns=0`, 128 passed each, zero warnings**.
- Full unit suite: **16968 passed, 110 skipped, 2 xfailed** — identical to clean `origin/develop` (4 pre-existing swift-grammar env failures present on both trees, unrelated to this change).
- `ruff`, `ruff format`, `mypy`, `detect-secrets`, and all pre-commit hooks: pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)