### PR TITLE
feat(docker): containerize the MCP server (stdio)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,32 @@
+# Keep the build context (and image) small and the build reproducible.
+.git
+.github
+.gitignore
+.claude
+.codegraph
+.ast-cache
+
+# Tests, benchmarks, docs, RFCs — not needed to run the MCP server.
+tests
+benchmarks
+docs
+rfcs
+examples
+
+# Python caches and local envs.
+__pycache__
+*.pyc
+*.pyo
+.pytest_cache
+.mypy_cache
+.ruff_cache
+.venv
+venv
+*.egg-info
+build
+dist
+
+# Editor / OS noise.
+.vscode
+.idea
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,13 @@
 # by anyone who wants to run the MCP server in a container.
 #
 # Build:  docker build -t tree-sitter-analyzer-mcp .
-# Run:    docker run --rm -i -v "$PWD:/work" -w /work tree-sitter-analyzer-mcp
-#         (the server speaks MCP over stdio; -i keeps stdin open)
+# Run:    docker run --rm -i --user "$(id -u):$(id -g)" \
+#             -v "$PWD:/work" -w /work tree-sitter-analyzer-mcp
+#         (the server speaks MCP over stdio; -i keeps stdin open. --user runs
+#         as the host UID/GID so the .ast-cache, decision journal, and any
+#         `edit`/`refactor` writes under the bind-mounted repo are owned by you,
+#         not root. Glama-style introspection needs no bind mount, so the bare
+#         image is fine there.)
 FROM python:3.12-slim
 
 # Prebuilt tree-sitter wheels mean no compiler is needed on the slim image.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Containerized tree-sitter-analyzer MCP server (stdio transport).
+#
+# Built from the repo source so the image always matches the committed code.
+# Used by MCP indexers (e.g. Glama) to launch and introspect the server, and
+# by anyone who wants to run the MCP server in a container.
+#
+# Build:  docker build -t tree-sitter-analyzer-mcp .
+# Run:    docker run --rm -i -v "$PWD:/work" -w /work tree-sitter-analyzer-mcp
+#         (the server speaks MCP over stdio; -i keeps stdin open)
+FROM python:3.12-slim
+
+# Prebuilt tree-sitter wheels mean no compiler is needed on the slim image.
+ENV PIP_NO_CACHE_DIR=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+WORKDIR /app
+COPY . /app
+
+# Install the package with the MCP extra from the local source.
+RUN pip install ".[mcp]"
+
+# The MCP server entry point speaks JSON-RPC over stdio.
+ENTRYPOINT ["tree-sitter-analyzer-mcp"]


### PR DESCRIPTION
## What

Adds a `Dockerfile` (built from repo source, `python:3.12-slim` base) and `.dockerignore` so the tree-sitter-analyzer MCP server can run in a container. The `tree-sitter-analyzer-mcp` entry point speaks MCP over stdio.

## Why

- **MCP indexers (Glama) need it.** Glama evaluates a server by launching it in a container and running an introspection request; without a Dockerfile TSA shows "not tested / cannot be installed" and the awesome-mcp-servers listing (#7583 upstream) can't earn a quality score. This is the artifact that requirement needs.
- **Self-hosting.** Users who want the MCP server in a container now have a first-class path.

## Verification

Docker isn't available in the dev/CI sandbox, so the image build wasn't run here. The build's two real steps were validated directly instead:
- `pip install ".[mcp]"` from source resolves (this is how the dev env and the PyPI wheel are produced).
- An **isolated** install of `tree-sitter-analyzer[mcp]==1.21.0` launches `tree-sitter-analyzer-mcp` and answers `initialize` + `tools/list` over stdio — **9 facade tools** returned. That's exactly the introspection Glama performs.

```Dockerfile
FROM python:3.12-slim
WORKDIR /app
COPY . /app
RUN pip install ".[mcp]"
ENTRYPOINT ["tree-sitter-analyzer-mcp"]
```

If the repo has a docker-build CI lane, it will exercise the actual build on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)