### PR TITLE
ci: make CODECOV_TOKEN optional so Dependabot PRs don't startup_failure

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -4,8 +4,12 @@
 # Triggers: Called by branch-specific workflows
 # Jobs:
 #   - test-matrix: Runs tests across Python versions and OS platforms
-# Secrets Required:
-#   - CODECOV_TOKEN: For coverage upload
+# Secrets (optional):
+#   - CODECOV_TOKEN: For coverage upload. NOT required — Dependabot PRs run
+#     without access to Actions secrets, and a `required: true` declaration
+#     fails workflow-call validation before any job starts (startup_failure,
+#     ~2s, zero steps). The upload step already sets fail_ci_if_error: false,
+#     so an absent token degrades gracefully to a skipped/no-op upload.
 
 name: Reusable Test Workflow
 
@@ -32,7 +36,9 @@ on:
 
     secrets:
       CODECOV_TOKEN:
-        required: true
+        # Optional so Dependabot PRs (no Actions-secret access) don't hit a
+        # workflow-call startup_failure. Real PRs/releases still inherit it.
+        required: false
 
 jobs:
   test-matrix-pr:


### PR DESCRIPTION
## Problem

Every Dependabot PR's **Test Suite** fails in ~2s with **zero steps** on all four axes (ubuntu 3.11/3.13, windows, macos), across multiple run attempts — e.g. #386 (codecov-action 6→7) and #387 (hatchling bump). Route CI, Code Quality, and E2E all pass; only Test Suite fails, then Quality Gate fails because it `needs: [test]`.

## Root cause

`reusable-test.yml` declared:
```yaml
    secrets:
      CODECOV_TOKEN:
        required: true
```

Dependabot PRs run with a **read-only token and no access to Actions secrets**. With `secrets: inherit` in `ci.yml`, the required-secret check fails **workflow-call validation before any job starts** → a `startup_failure` that surfaces as a 2s, no-step job on every matrix axis. `reusable-quality.yml` and `reusable-build.yml` declare no required secret, which is exactly why only Test Suite failed for Dependabot.

## Fix

Flip the declaration to `required: false` (one shared-infra file, 9 lines incl. doc comments).

- **Real PRs / release / hotfix**: still inherit the token → coverage uploads unchanged.
- **Dependabot PRs**: tests now execute; the upload step already sets `fail_ci_if_error: false`, so an absent token degrades gracefully to a no-op upload.

## Verification

- `yaml.safe_load` valid; pre-commit actionlint + "Workflow Consistency Tests" pass.
- `tests/integration/workflows/test_workflow_properties.py` → 8 passed.
- No test asserts on the secret being `required: true`.

After merge, re-run CI on #386/#387 to confirm Test Suite goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)