### PR TITLE
chore(glama): add glama.json manifest to claim the MCP server listing

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "aimasteracc"
+  ]
+}


### PR DESCRIPTION
## What
Add a `glama.json` manifest at repo root declaring `aimasteracc` as maintainer.

```json
{
  "$schema": "https://glama.ai/mcp/schemas/server.json",
  "maintainers": ["aimasteracc"]
}
```

## Why
The Glama listing's **Server Quality Checklist** flags two items this addresses:
- ❌ **No glama.json** → ✅ added
- ❌ **Author not verified** → enables verification after you authenticate via GitHub on glama.ai

Confirmed from the live `/score` page (fetched manually). Current Glama state: Maintenance **A**, License **A** (MIT), README ✅, but **Profile completion 17%** and the overall **quality score is uncomputed (null)**.

## Important context (owner-only follow-ups — cannot be done from the repo)
The headline gap is **"No Glama release"**, which gates the *entire* quality score (Tool Definition Quality 70% + Server Coherence 30% are both unscored without a release). To unlock it:
1. **Claim** the server + **authenticate via GitHub** (this PR's `glama.json` is the prerequisite for org verification).
2. Create a **Glama release** from the Dockerfile admin page → Deploy → **Make Release**. A `Dockerfile` already ships in this repo.
3. **Sync** the listing — its description is stale ("62 MCP tools"; the project is now 8 facade tools); last sync was 2026-05-31.
4. Optional: seed usage via "Try in Browser", add related servers.

## Scope
Repo-root metadata file only. No effect on the package, MCP server, CLI, or tests.

https://claude.ai/code/session_011MPxBUMohK7B2DW2SrPRgq

---
_Generated by [Claude Code](https://claude.ai/code/session_011MPxBUMohK7B2DW2SrPRgq)_