### PR TITLE
fix(mcp): hoist verdict to top level in error envelopes

### DIFF
--- a/tests/unit/mcp/test_error_recovery_coverage.py
+++ b/tests/unit/mcp/test_error_recovery_coverage.py
@@ -24,6 +24,18 @@ def _assert_canonical(result: dict) -> None:
     assert result["success"] is False
     assert isinstance(result["agent_summary"], dict)
     assert result["agent_summary"].get("verdict") == "ERROR"
+    # Wave 1a (audit search-01/viz-01/project-02): the verdict MUST be mirrored
+    # to the TOP LEVEL too, exactly as the success path does (search_envelope
+    # normalize_envelope / _mirror_verdict). An agent reading ``result["verdict"]``
+    # — the documented r37w contract — must get a value on errors, not KeyError.
+    assert result.get("verdict") == "ERROR", (
+        "error envelope must hoist verdict to the top level so agents can "
+        "branch on result['verdict'] uniformly across success and error"
+    )
+    assert result["verdict"] == result["agent_summary"]["verdict"], (
+        "top-level verdict must equal agent_summary.verdict (r37w mirror, "
+        "now enforced on the error axis too)"
+    )
 
 
 class TestBuildAgentFriendlyError:
@@ -178,3 +190,40 @@ class TestEnsureCanonicalErrorEnvelope:
         # No envelope keys added when success is True.
         assert "agent_summary" not in result
         assert "summary_line" not in result
+
+    def test_hoists_verdict_to_top_level(self):
+        """Wave 1a: a tool that returns a bare {success: False} dict gets a
+        top-level ``verdict`` mirrored from the canonical agent_summary."""
+        response = {"success": False, "error": "boom", "error_type": "subprocess"}
+        result = ensure_canonical_error_envelope("find_and_grep", response)
+        assert result["verdict"] == "ERROR"
+        assert result["verdict"] == result["agent_summary"]["verdict"]
+
+    def test_preserves_tool_specific_top_level_verdict(self):
+        """A tool that already set a more specific top-level verdict (e.g.
+        NOT_FOUND) keeps it — the hoist must not clobber it with ERROR, and
+        the agent_summary mirrors the same value."""
+        response = {
+            "success": False,
+            "error": "no match",
+            "error_type": "validation",
+            "verdict": "NOT_FOUND",
+        }
+        result = ensure_canonical_error_envelope("query", response)
+        assert result["verdict"] == "NOT_FOUND"
+        assert result["agent_summary"]["verdict"] == "NOT_FOUND"
+
+    def test_na_placeholder_treated_as_missing_verdict(self):
+        """The ``n/a`` post-hook placeholder must NOT be promoted to a
+        top-level verdict — it counts as missing, so the error envelope falls
+        back to ERROR (consistent with _mirror_verdict's sentinel handling)."""
+        response = {
+            "success": False,
+            "error": "boom",
+            "error_type": "internal",
+            "verdict": "n/a",
+            "agent_summary": {"verdict": "n/a"},
+        }
+        result = ensure_canonical_error_envelope("query", response)
+        assert result["verdict"] == "ERROR"
+        assert result["agent_summary"]["verdict"] == "ERROR"

--- a/tree_sitter_analyzer/mcp/server_utils/error_recovery.py
+++ b/tree_sitter_analyzer/mcp/server_utils/error_recovery.py
@@ -9,6 +9,8 @@ the full canonical envelope every tool's success path also produces:
         "success": False,
         "error": "<plain message>",
         "error_type": "<machine kind>",         # validation / file_not_found / ...
+        "verdict": "ERROR",                      # top-level mirror (Wave 1a) —
+                                                 # equals agent_summary.verdict
         "agent_summary": {
             "summary_line": "<one line>",
             "next_step":    "<concrete suggestion>",
@@ -197,6 +199,11 @@ def _build_envelope(
         # Backward-compatible alias kept for callers that pinned this name.
         "error_category": error_type,
         "recovery_hint": recovery_hint,
+        # Wave 1a (audit search-01/viz-01/project-02): mirror verdict to the
+        # TOP LEVEL — not just inside agent_summary — so an agent reading
+        # ``result["verdict"]`` (the r37w contract) gets a value on errors,
+        # exactly as it does on the success path.
+        "verdict": "ERROR",
         "agent_summary": {
             "summary_line": summary_line,
             "next_step": recovery_hint,
@@ -253,6 +260,7 @@ _CANONICAL_KEYS: tuple[str, ...] = (
     "success",
     "error",
     "error_type",
+    "verdict",  # Wave 1a: top-level verdict is now part of the canonical shape
     "agent_summary",
     "summary_line",
 )
@@ -433,6 +441,17 @@ def _populate_agent_summary_block(
     return agent_summary
 
 
+def _real_verdict(value: Any) -> str | None:
+    """Return ``value`` only if it is a *real* verdict.
+
+    ``"n/a"`` is the canonical post-hook placeholder for "no verdict set"
+    (see :func:`_mirror_verdict`), so it — like ``""``/``None`` — counts as
+    missing. Keeps the error-path verdict resolution consistent with the
+    success-path mirror logic.
+    """
+    return value if isinstance(value, str) and value and value != "n/a" else None
+
+
 def _mirror_verdict(response: dict[str, Any], agent_summary: dict[str, Any]) -> None:
     """Mirror ``verdict`` between top-level and ``agent_summary`` (M10).
 
@@ -526,7 +545,18 @@ def ensure_canonical_error_envelope(
         agent_summary = {}
     agent_summary.setdefault("summary_line", summary_line)
     agent_summary.setdefault("next_step", recovery_hint)
-    agent_summary.setdefault("verdict", "ERROR")
+    # Wave 1a (audit search-01/viz-01/project-02): verdict must be present at
+    # BOTH the top level and in agent_summary, and the two must agree. Prefer
+    # a real verdict the tool already set (top level first, then agent_summary)
+    # so a specific verdict like NOT_FOUND is preserved; the "n/a" placeholder
+    # counts as missing (consistent with _mirror_verdict); otherwise ERROR.
+    verdict = (
+        _real_verdict(response.get("verdict"))
+        or _real_verdict(agent_summary.get("verdict"))
+        or "ERROR"
+    )
+    response["verdict"] = verdict
+    agent_summary["verdict"] = verdict
     response["agent_summary"] = agent_summary
 
     return response


### PR DESCRIPTION
## What

Wave 1a of the zero-defect MCP audit. **Audit findings search-01 / viz-01 / project-02 (HIGH, independently verified)**: MCP **error** responses expose `verdict` only inside `agent_summary`, while **success** responses carry it at the top level (via `search_envelope.normalize_envelope` / `_mirror_verdict`). An agent reading `result["verdict"]` — the documented r37w contract — gets a value on success/not-found but `KeyError`/`None` on **every error**, so it cannot branch on verdict uniformly across the success/error axis.

## Fix

Both error-envelope builders in `error_recovery.py` now mirror `verdict` to the top level:
- **`_build_envelope`** (exception path → `build_agent_friendly_error`): adds top-level `"verdict": "ERROR"`.
- **`ensure_canonical_error_envelope`** (tool-returned `{success: False}` path): resolves a *real* verdict (top-level → agent_summary → else `ERROR`) and sets **both** surfaces to it, so a tool-specific verdict like `NOT_FOUND` is preserved and the two surfaces always agree. The `"n/a"` placeholder counts as missing, consistent with `_mirror_verdict`.

`format` is intentionally **not** hoisted (TOON-wrapper artifact, undefined on errors — avoids touching the LOCKED TOON default).

## Tests (RED-first)

- Upgraded the shared `_assert_canonical` guard to require top-level `verdict` **and** top==agent_summary equality → made all error-envelope tests RED, then GREEN.
- Added: top-level hoist, tool-specific `NOT_FOUND` preservation, and `n/a`-placeholder fallback.
- **4567 passed / 0 fail** across `tests/unit/mcp/` + `tests/unit/test_agent_contracts.py`; ruff + mypy clean.

## Review

Independent adversarial review (separate `code-reviewer` agent): **APPROVE-WITH-NITS**, 0 must-fix; both LOW nits (docstring example, `n/a` sentinel) fixed in this PR. Local `codex review` was unavailable (usage limit until Jun 11).

## Scope

`error_recovery.py` only. No LOCKED design decision touched. One focused fix.