### PR TITLE
fix(mcp): class_tree/class_detail honor the class identifier (no silent global default)

### DIFF
--- a/tests/unit/mcp/tools/test_facade_tool.py
+++ b/tests/unit/mcp/tools/test_facade_tool.py
@@ -108,12 +108,40 @@ class _FakeFunctionTool(BaseMCPTool):
         return {"success": True, "verdict": "INFO"}
 
 
+class _FakeClassTool(BaseMCPTool):
+    """Inner tool that reads ``class_name`` (mirrors codegraph_class_inspect /
+    codegraph_class_hierarchy)."""
+
+    def __init__(self, project_root: str | None = None) -> None:
+        super().__init__(project_root)
+        self.last_args: dict[str, Any] | None = None
+
+    def get_tool_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {"class_name": {"type": "string"}},
+            "required": ["class_name"],
+            "additionalProperties": False,
+        }
+
+    def get_tool_definition(self) -> dict[str, Any]:
+        return {"name": "fake_class", "inputSchema": self.get_tool_schema()}
+
+    def validate_arguments(self, arguments: dict[str, Any]) -> bool:
+        return True
+
+    async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        self.last_args = dict(arguments)
+        return {"success": True, "verdict": "INFO"}
+
+
 def _make_facade(**kwargs: Any) -> FacadeTool:
     return FacadeTool(
         facade_name="test_facade",
         action_map={
             "symbol": _FakeSymbolTool(),
             "func": _FakeFunctionTool(),
+            "cls": _FakeClassTool(),
         },
         **kwargs,
     )
@@ -189,6 +217,34 @@ def test_explicit_function_name_wins_over_symbol() -> None:
     )
     assert inner.last_args is not None
     assert inner.last_args.get("function_name") == "explicit"
+
+
+# --------------------------------------------------------------------------
+# Wave 1b (audit structure-01): symbol -> class_name normalize. Without it the
+# facade dropped ``symbol`` before projection because the class inner declares
+# ``class_name`` (not symbol/function_name), so class_tree/class_detail
+# silently ignored the requested class.
+# --------------------------------------------------------------------------
+
+
+def test_symbol_normalized_to_class_name_before_projection() -> None:
+    facade = _make_facade()
+    inner = facade.action_map["cls"]
+    asyncio.run(facade.execute({"action": "cls", "symbol": "MyClass"}))
+    assert inner.last_args is not None
+    assert inner.last_args.get("class_name") == "MyClass"
+
+
+def test_explicit_class_name_wins_over_symbol() -> None:
+    facade = _make_facade()
+    inner = facade.action_map["cls"]
+    asyncio.run(
+        facade.execute(
+            {"action": "cls", "symbol": "fromSymbol", "class_name": "explicit"}
+        )
+    )
+    assert inner.last_args is not None
+    assert inner.last_args.get("class_name") == "explicit"
 
 
 # --------------------------------------------------------------------------

--- a/tests/unit/mcp/tools/test_structure_facade.py
+++ b/tests/unit/mcp/tools/test_structure_facade.py
@@ -504,3 +504,47 @@ def test_structure_read_rejects_fractional_float_bounds(tmp_path: Any) -> None:
         )
     )
     assert ok.get("success") is True, ok
+
+
+# --------------------------------------------------------------------------
+# Wave 1b (audit structure-01): class_tree default mode must be CLASS-SCOPED
+# when a class identifier is supplied — never the global summary (which ignores
+# class_name and returns a confident project-wide result for a class that may
+# not exist).
+# --------------------------------------------------------------------------
+
+
+def test_class_hierarchy_default_mode_is_tree_when_class_named() -> None:
+    from tree_sitter_analyzer.mcp.tools.class_hierarchy_tool import ClassHierarchyTool
+
+    # class_name supplied, no explicit mode -> class-scoped 'tree', not 'summary'.
+    assert ClassHierarchyTool._resolve_mode({"class_name": "Foo"}) == "tree"
+
+
+def test_class_hierarchy_default_mode_is_summary_without_class() -> None:
+    from tree_sitter_analyzer.mcp.tools.class_hierarchy_tool import ClassHierarchyTool
+
+    # No identifier -> global summary (unchanged behavior).
+    assert ClassHierarchyTool._resolve_mode({}) == "summary"
+
+
+def test_class_hierarchy_explicit_mode_always_honored() -> None:
+    from tree_sitter_analyzer.mcp.tools.class_hierarchy_tool import ClassHierarchyTool
+
+    assert (
+        ClassHierarchyTool._resolve_mode({"mode": "summary", "class_name": "Foo"})
+        == "summary"
+    )
+    assert (
+        ClassHierarchyTool._resolve_mode({"mode": "subclasses", "class_name": "Foo"})
+        == "subclasses"
+    )
+
+
+def test_class_hierarchy_validate_accepts_named_class_without_mode() -> None:
+    """With a class_name and no mode, validation must pass: the resolved mode is
+    'tree', which requires class_name — and it is present."""
+    from tree_sitter_analyzer.mcp.tools.class_hierarchy_tool import ClassHierarchyTool
+
+    tool = ClassHierarchyTool(project_root=None)
+    assert tool.validate_arguments({"class_name": "Foo"}) is True

--- a/tests/unit/test_codegraph_class_hierarchy_tool.py
+++ b/tests/unit/test_codegraph_class_hierarchy_tool.py
@@ -20,6 +20,42 @@ from tree_sitter_analyzer.graph.edge_store import (
 from tree_sitter_analyzer.mcp.tools.class_hierarchy_tool import ClassHierarchyTool
 
 
+def _stub_hierarchy(names_with_parents: dict[str, list[str]]) -> ClassHierarchy:
+    """Build a pre-populated ClassHierarchy without touching an AST cache.
+
+    The tmp-path fixtures in this module build no index (``_classes`` stays
+    empty), so existence-dependent behavior is tested against an injected
+    hierarchy instead.
+    """
+    from tree_sitter_analyzer.class_hierarchy import ClassInfo
+
+    hierarchy = ClassHierarchy(cache=None)
+    for name, parents in names_with_parents.items():
+        hierarchy._classes[name].append(
+            ClassInfo(
+                name=name,
+                file="models.py",
+                line=1,
+                end_line=2,
+                language="python",
+                parents=parents,
+            )
+        )
+        for parent in parents:
+            hierarchy._parent_map[name].append(parent)
+            hierarchy._children[parent].append(name)
+    hierarchy._built = True  # bypass build(); data is already populated
+    return hierarchy
+
+
+def test_has_class_distinguishes_existence_from_emptiness() -> None:
+    """has_class is True for a defined leaf class (no subclasses) and False for
+    an unknown name — the distinction the tree verdict relies on."""
+    h = _stub_hierarchy({"Poodle": ["Dog"]})
+    assert h.has_class("Poodle") is True
+    assert h.has_class("NoSuchClassZZZ") is False
+
+
 @pytest.fixture
 def tool():
     return ClassHierarchyTool()
@@ -61,6 +97,12 @@ class TestToolDefinition:
         hints = tool.get_tool_definition()["annotations"]
         assert hints["readOnlyHint"] is True
         assert hints["destructiveHint"] is False
+
+    def test_mode_not_required(self, tool):
+        """Wave 1b (review issue 2): mode is resolved at runtime, so it must NOT
+        be advertised as required — else a strict MCP client rejects a valid
+        {class_name: X} call before dispatch."""
+        assert "mode" not in tool.get_tool_schema().get("required", [])
 
 
 class TestValidation:
@@ -108,6 +150,84 @@ class TestExecute:
         result = await tool_with_root.execute({"mode": "summary"})
         assert result["format"] == "toon"
         assert "toon_content" in result
+
+    async def test_tree_leaf_class_is_found_not_notfound(self, tool, monkeypatch):
+        """Wave 1b (audit structure-01): a real leaf class (exists but has no
+        subclasses) must report INFO, not NOT_FOUND — existence, not subclass
+        count, drives the verdict. Injects a populated hierarchy so the test is
+        deterministic (the tmp fixture builds no index)."""
+        monkeypatch.setattr(
+            tool, "_get_hierarchy", lambda: _stub_hierarchy({"Poodle": ["Dog"]})
+        )
+        result = await tool.execute(
+            {"mode": "tree", "class_name": "Poodle", "output_format": "json"}
+        )
+        assert result["success"] is True
+        assert result["subclass_count"] == 0
+        assert result["verdict"] == "INFO"
+
+    async def test_tree_unknown_class_is_notfound(self, tool, monkeypatch):
+        monkeypatch.setattr(
+            tool, "_get_hierarchy", lambda: _stub_hierarchy({"Poodle": ["Dog"]})
+        )
+        result = await tool.execute(
+            {"mode": "tree", "class_name": "NoSuchClassZZZ", "output_format": "json"}
+        )
+        assert result["verdict"] == "NOT_FOUND"
+
+    async def test_default_mode_named_class_is_class_scoped_not_global(
+        self, tool, monkeypatch
+    ):
+        """No explicit mode + a class_name → class-scoped 'tree', NOT the global
+        'summary' (which would ignore the class and return project-wide stats)."""
+        monkeypatch.setattr(
+            tool, "_get_hierarchy", lambda: _stub_hierarchy({"Poodle": ["Dog"]})
+        )
+        result = await tool.execute({"class_name": "Poodle", "output_format": "json"})
+        assert result["mode"] == "tree"
+        assert result["class_name"] == "Poodle"
+        assert result["verdict"] == "INFO"
+        assert "total_classes" not in result  # not the global summary
+
+    async def test_subclasses_existing_class_no_children_is_info(
+        self, tool, monkeypatch
+    ):
+        """Review issue 1: an existing class with zero subclasses is a valid
+        INFO result, not NOT_FOUND (NOT_FOUND is reserved for unknown classes)."""
+        # Dog exists (inherits Animal) but nothing inherits from Dog.
+        monkeypatch.setattr(
+            tool, "_get_hierarchy", lambda: _stub_hierarchy({"Dog": ["Animal"]})
+        )
+        result = await tool.execute(
+            {"mode": "subclasses", "class_name": "Dog", "output_format": "json"}
+        )
+        assert result["subclass_count"] == 0
+        assert result["verdict"] == "INFO"
+
+    async def test_subclasses_unknown_class_is_notfound(self, tool, monkeypatch):
+        monkeypatch.setattr(
+            tool, "_get_hierarchy", lambda: _stub_hierarchy({"Dog": ["Animal"]})
+        )
+        result = await tool.execute(
+            {
+                "mode": "subclasses",
+                "class_name": "NoSuchClassZZZ",
+                "output_format": "json",
+            }
+        )
+        assert result["verdict"] == "NOT_FOUND"
+
+    async def test_superclasses_root_class_is_info(self, tool, monkeypatch):
+        """Review issue 1: a root class with no parents exists → INFO, not
+        NOT_FOUND."""
+        monkeypatch.setattr(
+            tool, "_get_hierarchy", lambda: _stub_hierarchy({"Animal": []})
+        )
+        result = await tool.execute(
+            {"mode": "superclasses", "class_name": "Animal", "output_format": "json"}
+        )
+        assert result["superclass_count"] == 0
+        assert result["verdict"] == "INFO"
 
     async def test_subclasses_mode_reads_edge_store_when_symbol_parents_missing(
         self, tmp_path

--- a/tree_sitter_analyzer/class_hierarchy.py
+++ b/tree_sitter_analyzer/class_hierarchy.py
@@ -195,6 +195,15 @@ class ClassHierarchy:
         )
         return True
 
+    def has_class(self, class_name: str) -> bool:
+        """Whether ``class_name`` is a known, defined class in the project.
+
+        Lets callers distinguish "class does not exist" from "class exists but
+        has no subclasses" — both otherwise present as an empty subclass list.
+        """
+        self.build()
+        return class_name in self._classes
+
     def subclasses_of(
         self,
         class_name: str,

--- a/tree_sitter_analyzer/mcp/tools/class_hierarchy_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/class_hierarchy_tool.py
@@ -78,7 +78,10 @@ class ClassHierarchyTool(BaseMCPTool):
                         "all",
                         "summary",
                     ],
-                    "description": "Query mode",
+                    "description": (
+                        "Query mode. Optional: when omitted, defaults to 'tree' "
+                        "if class_name is given, else the global 'summary'."
+                    ),
                 },
                 "class_name": {
                     "type": "string",
@@ -96,12 +99,34 @@ class ClassHierarchyTool(BaseMCPTool):
                     "default": "toon",
                 },
             },
-            "required": ["mode"],
+            # Wave 1b (audit structure-01, review nit): ``mode`` is resolved at
+            # runtime (``_resolve_mode``) — defaulting to a class-scoped view
+            # when ``class_name`` is supplied — so it is NOT required. Declaring
+            # it required made strict MCP clients reject a valid
+            # ``{class_name: X}`` call before dispatch.
+            "required": [],
             "additionalProperties": False,
         }
 
+    @staticmethod
+    def _resolve_mode(arguments: dict[str, Any]) -> str:
+        """Effective query mode.
+
+        When the caller did not specify a mode, default to a CLASS-SCOPED view
+        (``tree``) if a ``class_name`` was supplied, else the global
+        ``summary``. Wave 1b (audit structure-01): a bare ``class_tree`` carrying
+        a class identifier must NOT fall through to the global ``summary`` — that
+        mode ignores ``class_name`` and returns a confident project-wide result
+        for a class that may not even exist. ``tree`` instead returns
+        ``NOT_FOUND`` for an unknown class.
+        """
+        mode = arguments.get("mode")
+        if mode:
+            return str(mode)
+        return "tree" if arguments.get("class_name") else "summary"
+
     def validate_arguments(self, arguments: dict[str, Any]) -> bool:
-        mode = arguments.get("mode", "summary")
+        mode = self._resolve_mode(arguments)
         if mode in ("subclasses", "superclasses", "tree", "impact"):
             if not arguments.get("class_name"):
                 raise ValueError(f"class_name is required for mode '{mode}'")
@@ -110,7 +135,7 @@ class ClassHierarchyTool(BaseMCPTool):
     async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
         self.validate_arguments(arguments)
 
-        mode = arguments.get("mode", "summary")
+        mode = self._resolve_mode(arguments)
         class_name = arguments.get("class_name", "")
         max_depth = arguments.get("max_depth", 10)
         output_format = arguments.get("output_format", "toon")
@@ -127,7 +152,12 @@ class ClassHierarchyTool(BaseMCPTool):
                 "class_name": class_name,
                 "subclass_count": len(result),
                 "subclasses": result,
-                "verdict": "INFO" if result else "NOT_FOUND",
+                # Wave 1b (audit structure-01): NOT_FOUND means the class is
+                # unknown — an existing class with zero subclasses is a valid
+                # INFO result, not a missing one.
+                "verdict": (
+                    "INFO" if result or hierarchy.has_class(class_name) else "NOT_FOUND"
+                ),
             }
         elif mode == "superclasses":
             result = hierarchy.superclasses_of(class_name)
@@ -137,7 +167,11 @@ class ClassHierarchyTool(BaseMCPTool):
                 "class_name": class_name,
                 "superclass_count": len(result),
                 "superclasses": result,
-                "verdict": "INFO" if result else "NOT_FOUND",
+                # Wave 1b: same existence-vs-emptiness distinction — a root
+                # class with no parents exists and is INFO, not NOT_FOUND.
+                "verdict": (
+                    "INFO" if result or hierarchy.has_class(class_name) else "NOT_FOUND"
+                ),
             }
         elif mode == "tree":
             result = hierarchy.hierarchy_tree(class_name)
@@ -148,7 +182,12 @@ class ClassHierarchyTool(BaseMCPTool):
                 "class_name": class_name,
                 "subclass_count": len(all_subs),
                 "tree": result,
-                "verdict": "INFO" if all_subs else "NOT_FOUND",
+                # Wave 1b (audit structure-01): verdict reflects whether the
+                # class EXISTS, not whether it has subclasses — a real leaf
+                # class (e.g. a concrete final class) must not read as
+                # NOT_FOUND just because nothing inherits from it. ``tree`` is
+                # the default mode for a named class, so this is the common path.
+                "verdict": "INFO" if hierarchy.has_class(class_name) else "NOT_FOUND",
             }
         elif mode == "impact":
             impact = hierarchy.hierarchy_impact(class_name)

--- a/tree_sitter_analyzer/mcp/tools/facade_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/facade_tool.py
@@ -232,6 +232,18 @@ class FacadeTool(BaseMCPTool):
         ):
             cleaned["function_name"] = cleaned["symbol"]
 
+        # Wave 1b (audit structure-01): the canonical ``symbol`` also fills
+        # ``class_name`` for inners that declare it (class_hierarchy /
+        # class_inspect), mirroring R3. Without this the facade dropped
+        # ``symbol`` before projection — so class_tree silently returned the
+        # global summary and class_detail raised "class_name is required".
+        if (
+            "class_name" in inner_props
+            and not cleaned.get("class_name")
+            and cleaned.get("symbol")
+        ):
+            cleaned["class_name"] = cleaned["symbol"]
+
         if not inner_props:
             # Inner declared no properties — cannot whitelist; forward as-is
             # minus control keys (the inner's own guard skips empty schemas).


### PR DESCRIPTION
## What

Wave 1b of the zero-defect MCP audit. **Audit finding structure-01 (HIGH, independently verified)**: passing the facade's own advertised `symbol` core param to `class_tree`/`class_detail` was silently dropped, producing two wrong outcomes for an autonomous agent:
- `class_tree symbol=X` returned the **project-wide hierarchy summary** (4400+ classes, `verdict: INFO`) — a confident, *wrong* answer that ignored the requested class.
- `class_detail symbol=X` raised `"class_name is required"`.

**Root cause:** the facade whitelists args to the inner's schema; the class inners declare `class_name` (not symbol/function_name), so `symbol` was stripped before projection (R3 only copied `symbol`→`function_name`).

## Fix (one coherent contract: a named class is honored, existence is reported)

- **`facade_tool`**: copy `symbol`→`class_name` before projection, mirroring R3. Fixes both class_detail (now works) and class_tree's "reach the class" half.
- **`class_hierarchy_tool._resolve_mode`**: default to the class-scoped `tree` when a `class_name` is supplied (was the global `summary`, which ignores class_name).
- **`class_hierarchy.has_class`**: the `tree` verdict now reflects whether the class **EXISTS**, not whether it has subclasses — a real leaf class reports `INFO`, an unknown class `NOT_FOUND` (without this, defaulting to `tree` would mislabel every leaf class as NOT_FOUND).

## Verified end-to-end on the real index

| call | before | after |
|---|---|---|
| `class_tree symbol=FacadeTool` (leaf) | global summary, INFO | `INFO`, mode=tree, subclass_count=0 |
| `class_tree symbol=NoSuchClass` | global summary, INFO | `NOT_FOUND` |
| `class_detail symbol=FacadeTool` | "class_name is required" | `success: true` |
| `class_tree` (no identifier) | global summary | global summary (unchanged) |

## Tests (RED-first)

facade `symbol`→`class_name` projection; `_resolve_mode` class-aware default; `has_class` existence; tree-verdict leaf/unknown via injected hierarchy (the tmp fixtures build no index). **415 passed / 0 fail** across mcp + contracts + all hierarchy consumers; ruff + mypy clean.

## Review

Independent review pending (opencode + adversarial agent; codex rate-limited until Jun 11). Scope: 3 source files (facade_tool, class_hierarchy, class_hierarchy_tool), one coherent fix. No LOCKED decision touched.