### PR TITLE
fix(mcp): guard returns NOT_FOUND for an unknown symbol (no false-safe)

### DIFF
--- a/tests/unit/mcp/test_modification_guard_tool.py
+++ b/tests/unit/mcp/test_modification_guard_tool.py
@@ -136,6 +136,69 @@ class TestModificationGuardToolExecution:
         assert result["total_callers"] == 0
 
     @pytest.mark.asyncio
+    async def test_unknown_symbol_is_not_found_not_safe(
+        self, tool: ModificationGuardTool
+    ) -> None:
+        """Wave 1b (audit edit-08): a symbol that resolves to ZERO occurrences
+        (trace_impact found=False / NOT_FOUND) must NOT be reported as SAFE —
+        that is a dangerous false-safe. It must return verdict=NOT_FOUND."""
+        not_found_trace = {
+            "success": True,
+            "call_count": 0,
+            "usages": [],
+            "found": False,
+            "verdict": "NOT_FOUND",
+        }
+        with patch.object(
+            tool._trace_impact_tool,
+            "execute",
+            new_callable=AsyncMock,
+            return_value=not_found_trace,
+        ):
+            result = await tool.execute(
+                {
+                    "symbol": "this_symbol_does_not_exist_xyz",
+                    "modification_type": "rename",
+                }
+            )
+
+        assert result["success"] is True
+        assert result["verdict"] == "NOT_FOUND"
+        assert result["safety_verdict"] == "NOT_FOUND"
+        assert result["agent_summary"]["verdict"] == "NOT_FOUND"
+        # The dangerous old behavior — never claim SAFE for an unknown symbol.
+        assert result["safety_verdict"] != "SAFE"
+        # agent_summary must carry ``risk`` on EVERY path (no KeyError for
+        # consumers reading agent_summary["risk"] on the NOT_FOUND branch).
+        assert result["agent_summary"]["risk"] == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_known_symbol_zero_callers_is_still_safe_not_notfound(
+        self, tool: ModificationGuardTool
+    ) -> None:
+        """The distinction edit-08 requires: a KNOWN symbol with 0 callers
+        (found=True, no NOT_FOUND verdict) stays SAFE — only an UNKNOWN symbol
+        is NOT_FOUND."""
+        known_zero = {
+            "success": True,
+            "call_count": 0,
+            "usages": [],
+            "found": True,
+        }
+        with patch.object(
+            tool._trace_impact_tool,
+            "execute",
+            new_callable=AsyncMock,
+            return_value=known_zero,
+        ):
+            result = await tool.execute(
+                {"symbol": "definedButUncalled", "modification_type": "delete"}
+            )
+        assert result["safety_verdict"] == "SAFE"
+        assert result["verdict"] == "SAFE"
+        assert result["verdict"] != "NOT_FOUND"
+
+    @pytest.mark.asyncio
     async def test_caution_verdict_few_callers(
         self, tool: ModificationGuardTool
     ) -> None:

--- a/tree_sitter_analyzer/mcp/tools/modification_guard_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/modification_guard_tool.py
@@ -360,10 +360,11 @@ class ModificationGuardTool(BaseMCPTool):
                 "trace_impact for general usage lookup.\n"
                 "\n"
                 "safety_verdict values:\n"
-                "  SAFE     — 0 callers, proceed freely\n"
-                "  CAUTION  — 1-5 callers, review before modifying\n"
-                "  REVIEW   — 6-20 callers, check all call sites\n"
-                "  UNSAFE   — 21+ callers, requires careful planning\n"
+                "  SAFE      — 0 callers, proceed freely\n"
+                "  CAUTION   — 1-5 callers, review before modifying\n"
+                "  REVIEW    — 6-20 callers, check all call sites\n"
+                "  UNSAFE    — 21+ callers, requires careful planning\n"
+                "  NOT_FOUND — symbol unknown to the index (NOT a SAFE result)\n"
                 "\n"
                 "VERDICT INTEGRITY: agent_summary.verdict is a hard gate, not a "
                 "suggestion. It is derived from concrete caller counts in the "
@@ -446,6 +447,16 @@ class ModificationGuardTool(BaseMCPTool):
                 "error": trace_result.get("error", "trace_impact failed"),
             }
 
+        # Wave 1b (audit edit-08): a symbol that resolves to ZERO occurrences in
+        # the project is UNKNOWN — it must not be reported as SAFE ("no callers,
+        # safe to refactor"), which is a dangerous false-safe for an agent about
+        # to act. trace_impact already flags this (found=False / NOT_FOUND);
+        # distinguish "symbol unknown" from "symbol known, 0 callers".
+        if trace_result.get("found") is False or trace_result.get("verdict") == (
+            "NOT_FOUND"
+        ):
+            return self._build_not_found_result(symbol, modification_type)
+
         total_callers = trace_result.get("call_count", 0)
         impact = _get_impact_level(total_callers)
         impact_level = impact["level"]
@@ -488,6 +499,41 @@ class ModificationGuardTool(BaseMCPTool):
             proceed_recommendation=proceed_recommendation,
             architecture_rank=result.get("architecture_rank"),
         )
+        return mirror_summary_line(result)
+
+    @staticmethod
+    def _build_not_found_result(symbol: str, modification_type: str) -> dict[str, Any]:
+        """Wave 1b (audit edit-08): envelope for a symbol unknown to the index.
+
+        success is True (the guard ran fine) but the verdict is NOT_FOUND, and
+        no SAFE/safety claim is made — the symbol does not exist, so there is
+        nothing to call it safe to modify.
+        """
+        summary_line = f"modification_guard: '{symbol}' not found in project"
+        next_step = (
+            f"'{symbol}' resolves to no definition or reference in the project. "
+            "Verify the name/spelling (search action=symbol) before assuming it "
+            "is safe to modify — this is NOT a SAFE verdict."
+        )
+        result: dict[str, Any] = {
+            "success": True,
+            "symbol": symbol,
+            "modification_type": modification_type,
+            "verdict": "NOT_FOUND",
+            "safety_verdict": "NOT_FOUND",
+            "total_callers": 0,
+            "summary_line": summary_line,
+            "agent_summary": {
+                "summary_line": summary_line,
+                "verdict": "NOT_FOUND",
+                # ``risk`` is part of every guard agent_summary (see
+                # _build_agent_summary) — keep it here too so consumers reading
+                # agent_summary["risk"] never KeyError on the NOT_FOUND path.
+                # "unknown" mirrors trace_impact's NOT_FOUND convention.
+                "risk": "unknown",
+                "next_step": next_step,
+            },
+        }
         return mirror_summary_line(result)
 
     async def _run_trace_impact(


### PR DESCRIPTION
## What

Wave 1b of the zero-defect MCP audit. **Audit finding edit-08 (HIGH, independently verified)**: `edit action=guard` on a symbol that does not exist returned `success:true` + `verdict:SAFE` + *"No callers found … Safe to refactor"* — a dangerous **false-safe**. An agent about to rename/delete a symbol is told it's safe *precisely because the symbol is unknown* (0 callers == 0 occurrences).

## Fix

`trace_impact` already distinguishes "zero textual occurrences" (`found=False` / `verdict=NOT_FOUND`) from "defined, zero callers". The guard now honors that signal:
- **unknown symbol** → `verdict=NOT_FOUND` (success:true), no SAFE claim (new `_build_not_found_result` composes the canonical envelope).
- **known symbol, 0 callers** → still `SAFE` (the distinction edit-08 requires).

## Verified e2e on the real index

| call | before | after |
|---|---|---|
| `guard symbol=this_symbol_does_not_exist_xyz` | SAFE (false-safe) | `NOT_FOUND` |
| `guard symbol=create_tool_registry` (37 callers) | UNSAFE | UNSAFE (unchanged) |

## Tests

RED-first: unknown-symbol→NOT_FOUND, known-zero-callers→SAFE (the distinction), existing SAFE/CAUTION/REVIEW/UNSAFE paths unchanged. **4522 passed / 0 fail** across tests/unit/mcp; ruff + mypy clean.

## Review

Independent review pending (opencode + adversarial agent; codex rate-limited until Jun 11). Scope: modification_guard_tool.py only. No LOCKED decision touched.