### PR TITLE
fix(mcp): list_files honors the 'path' alias (no silent whole-project listing)

### DIFF
--- a/tests/unit/mcp/test_list_files_tool_init_and_def.py
+++ b/tests/unit/mcp/test_list_files_tool_init_and_def.py
@@ -57,11 +57,16 @@ class TestGetToolDefinition:
         assert "required" in schema
 
     def test_required_fields(self, tool):
+        # Wave 1b (audit project-05): ``roots`` is no longer schema-required.
+        # It is optional — synthesised from the ``path`` alias or defaulted to
+        # project_root — and validate_arguments enforces the real rules. A
+        # required ``roots`` contradicted the ``path`` alias and made strict MCP
+        # clients reject a valid ``{path: X}`` call before dispatch.
         definition = tool.get_tool_definition()
         schema = definition["inputSchema"]
         required = schema.get("required", [])
-        assert "roots" in required
-        assert len(required) == 1
+        assert "roots" not in required
+        assert required == []
 
     def test_roots_property(self, tool):
         definition = tool.get_tool_definition()

--- a/tests/unit/mcp/tools/test_list_files_path_alias.py
+++ b/tests/unit/mcp/tools/test_list_files_path_alias.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Wave 1b (audit project-05): ``list_files`` honors the ``path`` alias.
+
+The project facade's ``files`` action advertises a ``path`` param, but the inner
+``ListFilesTool`` reads ``roots``. Before this fix the facade whitelist dropped
+``path`` and the tool silently fell back to the project root — so
+``files path=nonexistent_dir`` returned the WHOLE project (a confident wrong
+answer). ``path`` is now a first-class single-directory alias for ``roots`` and
+a non-existent directory is rejected, never silently widened to the whole tree.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tree_sitter_analyzer.mcp.tools.list_files_tool import ListFilesTool
+
+
+def test_path_is_declared_in_schema() -> None:
+    """``path`` must be in the inner schema or the facade whitelist drops it."""
+    tool = ListFilesTool()
+    assert "path" in tool.get_tool_schema()["properties"]
+
+
+def test_path_maps_to_roots_when_roots_absent(tmp_path) -> None:
+    tool = ListFilesTool(str(tmp_path))
+    args = {"path": str(tmp_path)}
+    tool.validate_arguments(args)
+    assert args["roots"] == [str(tmp_path)]
+
+
+def test_explicit_roots_wins_over_path(tmp_path) -> None:
+    tool = ListFilesTool(str(tmp_path))
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    args = {"path": str(tmp_path), "roots": [str(sub)]}
+    tool.validate_arguments(args)
+    assert args["roots"] == [str(sub)]
+
+
+def test_empty_path_is_rejected_not_silently_widened(tmp_path) -> None:
+    """Review issue 2: an explicit-but-empty ``path`` must be a user error, NOT
+    a silent fallback to scanning the whole project (the project-05 bug class)."""
+    tool = ListFilesTool(str(tmp_path))
+    with pytest.raises(ValueError, match="path must be a non-empty string"):
+        tool.validate_arguments({"path": ""})
+
+
+def test_consumed_path_alias_is_removed(tmp_path) -> None:
+    """Once mapped to roots, the ``path`` alias is popped so it never lingers
+    into fd-command building or the echoed response."""
+    tool = ListFilesTool(str(tmp_path))
+    args = {"path": str(tmp_path)}
+    tool.validate_arguments(args)
+    assert "path" not in args
+    assert args["roots"] == [str(tmp_path)]
+
+
+@pytest.mark.asyncio
+async def test_nonexistent_path_is_rejected_not_silently_widened(tmp_path) -> None:
+    """A non-existent ``path`` must surface an error — NOT silently fall back to
+    the project root and return the whole tree (the project-05 bug)."""
+    tool = ListFilesTool(str(tmp_path))
+    with pytest.raises(Exception) as exc:
+        await tool.execute({"path": "nonexistent_dir_zzz", "output_format": "json"})
+    # The failure must reference the bad directory, proving the filter was
+    # honored rather than dropped.
+    assert "nonexistent_dir_zzz" in str(exc.value)

--- a/tree_sitter_analyzer/mcp/tools/list_files_helpers.py
+++ b/tree_sitter_analyzer/mcp/tools/list_files_helpers.py
@@ -46,6 +46,17 @@ TOOL_SCHEMA: dict[str, Any] = {
             "items": {"type": "string"},
             "description": "Search dirs",
         },
+        # Wave 1b (audit project-05): single-directory alias. The project
+        # facade's ``files`` action advertises ``path``; without this property
+        # the facade whitelist dropped it before the inner saw it, so the
+        # filter was silently ignored and the whole project was listed. When
+        # supplied (and ``roots`` is not), ``path`` becomes the single root and
+        # is existence-validated like any root (a missing dir -> error, never
+        # an unfiltered project walk).
+        "path": {
+            "type": "string",
+            "description": "Single directory to list (alias for roots=[path]).",
+        },
         # Filename pattern (supports glob if glob=true)
         "pattern": {
             "type": "string",
@@ -154,8 +165,13 @@ TOOL_SCHEMA: dict[str, Any] = {
             "description": "If true with output_file, suppress detailed output",
         },
     },
-    # roots is the only required field
-    "required": ["roots"],
+    # Wave 1b (audit project-05, review): nothing is strictly required at the
+    # schema layer — ``roots`` is optional (falls back to project_root, or is
+    # synthesised from the ``path`` alias) and validate_arguments enforces the
+    # real rules. Declaring ``roots`` required contradicted the ``path`` alias
+    # and made strict MCP clients reject a valid ``{path: X}`` call before
+    # dispatch.
+    "required": [],
     "additionalProperties": False,
 }
 

--- a/tree_sitter_analyzer/mcp/tools/list_files_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/list_files_tool.py
@@ -136,6 +136,21 @@ class ListFilesTool(BaseMCPTool):
         rewriting it to ``[project_root]`` masked typos and made the
         downstream ``_validate_roots`` check unreachable.
         """
+        # Wave 1b (audit project-05): ``path`` is a single-directory alias for
+        # ``roots``. Map it BEFORE the roots resolution so a caller-supplied
+        # scope is actually honored (and existence-validated downstream),
+        # instead of being dropped and silently falling back to project_root —
+        # which made ``files path=nonexistent_dir`` return the whole project.
+        # An explicit-but-empty ``path`` is a user error (O7), NOT a silent
+        # fallback to scanning the whole project — that would re-introduce the
+        # very bug this fixes. ``pop`` so the consumed alias never lingers.
+        if "path" in arguments and "roots" not in arguments:
+            path_value = arguments.pop("path")
+            if not path_value or not isinstance(path_value, str):
+                raise ValueError(
+                    "path must be a non-empty string (or omit it to scan project_root)"
+                )
+            arguments["roots"] = [path_value]
         if "roots" not in arguments:
             if not self.project_root:
                 raise ValueError(


### PR DESCRIPTION
## What

Wave 1b of the zero-defect MCP audit. **Audit finding project-05 (HIGH, independently verified)**: the project facade's `files` action advertises a `path` param, but the inner `ListFilesTool` reads `roots`. The facade whitelist dropped `path` before the inner saw it, so the tool silently fell back to the project root — `files path=nonexistent_dir` returned the **whole project** (total_count 2290), a confident wrong answer with **zero effect** from the filter.

## Fix

- Declare `path` in the list_files schema (so it survives facade projection).
- Map `path` → `roots=[path]` before root resolution; explicit `roots` still wins.
- A root that doesn't exist is already rejected by `resolve_and_validate_directory_path(must_exist=True)`, so a bad `path` now surfaces an error at the MCP boundary instead of widening to the whole tree.

## Verified e2e on the real index

| call | before | after |
|---|---|---|
| `files path=tree_sitter_analyzer/mcp` | 2290 (ignored filter) | **205** (scoped) |
| `files path=nonexistent_dir` | 2290 | error envelope (not a listing) |
| `files` (no path) | 2290 | 2290 (unchanged) |

## Tests

`path` in schema; `path`→`roots` mapping; explicit-roots-wins; non-existent path rejected (references the bad dir, proving the filter was honored). **4524 passed / 0 fail** across tests/unit/mcp; ruff + mypy clean.

## Review

Independent review pending (opencode + adversarial agent; codex rate-limited until Jun 11). Scope: list_files_tool.py + list_files_helpers.py. No LOCKED decision touched.