### PR TITLE
docs(claude): codify 4 subagent engineering principles (Karpathy, adapted)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,38 @@ All inter-agent state lives in a shared memory namespace (`memory_store` / `memo
 - **Name agents** — `name: "role"` makes them addressable by the lead even though they cannot address each other.
 - **After spawning**: STOP, tell user what's running, wait for completion notifications. No polling.
 
+### Subagent engineering principles (dev/research briefs)
+
+Every **dev / research / fix** subagent brief MUST also carry these four principles
+(adapted from Karpathy's LLM-coding-pitfalls list). The key adaptation for this
+project: the audience for "ask / surface" is the **lead**, never the end user —
+and an uncertain agent picks a reasonable default, flags it, and **keeps going**
+(a subagent has no inbox; pausing = wasted run). Do NOT send these to **review**
+subagents — they must stay adversarial truth-seekers, not style-followers.
+
+1. **Think before coding (report to the lead, never block).** In your final
+   return, state your assumptions explicitly; if multiple interpretations exist,
+   list them and pick one *with a reason* (don't pick silently); surface any
+   inconsistency or simpler approach you notice. If something is unclear, assume
+   the most reasonable default, finish the task, and note *"assumed X — lead,
+   correct if wrong."* Never stop the pipeline waiting for a human.
+2. **Simplicity first.** Minimum code that solves the task, nothing speculative —
+   no features/abstractions/config/impossible-case error handling that weren't
+   asked for. If 200 lines could be 50, rewrite it.
+3. **Surgical changes.** Touch only what the task needs; every changed line
+   traces to the task. Don't "improve" adjacent code/comments/formatting, don't
+   refactor what isn't broken, match existing style. Clean up only the orphans
+   *your* change created; pre-existing dead code you only *mention*, never delete
+   (unless asked). Reinforces the focused-PR rule.
+4. **Goal-driven execution.** Turn the task into a verifiable goal: write the
+   failing test first (RED), then implement to green; for multi-step work, state
+   a brief `step → verify` plan. Strong success criteria let you loop
+   independently; weak ones ("make it work") force round-trips.
+
+The lead also honors 2–4; for principle 1 the lead's "report" audience is the
+investor's node-level Chinese briefing — but the lead likewise never pauses for
+permission.
+
 ### Spawning example (memory-as-bus)
 
 ```javascript


### PR DESCRIPTION
## What

Investor-approved adoption of the four [Karpathy LLM-coding-pitfalls](https://github.com/aimasteracc/andrej-karpathy-skills) principles into the **subagent dispatch spec** (CLAUDE.md → Agent Comms → Spawning rules), next to the existing degraded-mode requirement.

## The key adaptation (why not install the upstream plugin as-is)

The upstream guideline's principle 1 ("if uncertain, **ask the user**" / "bias toward caution over speed") directly conflicts with this project's locked operating model (autonomous non-stop drive, don't interrupt the investor). So the adopted version:
- routes ask/surface to the **lead**, never the end user;
- has an uncertain agent **pick a reasonable default, flag it, and keep going** (a subagent has no inbox — pausing wastes the run);
- applies to **dev/research/fix** briefs only — **NOT review** subagents (they must stay adversarial truth-seekers, not style-followers).

The other three (Simplicity / Surgical / Goal-driven=RED-first) reinforce rules we already hold (focused PRs, minimal-diff, TDD) — now explicit in the brief spec so every spawned agent carries them.

## Scope

Docs-only — CLAUDE.md governance addition. No code. One focused change.