### PR TITLE
fix(mcp): mirror top-level next_step into agent_summary (batch B)

### DIFF
--- a/tests/unit/mcp/test_error_recovery_coverage.py
+++ b/tests/unit/mcp/test_error_recovery_coverage.py
@@ -14,6 +14,7 @@ aliases.
 from tree_sitter_analyzer.mcp.server_utils.error_recovery import (
     build_agent_friendly_error,
     ensure_canonical_error_envelope,
+    ensure_canonical_success_envelope,
 )
 
 
@@ -227,3 +228,39 @@ class TestEnsureCanonicalErrorEnvelope:
         result = ensure_canonical_error_envelope("query", response)
         assert result["verdict"] == "ERROR"
         assert result["agent_summary"]["verdict"] == "ERROR"
+
+
+class TestSuccessEnvelopeNextStepMirror:
+    """Wave 1b batch B (audit nav-03/04, search-05, project-03, viz-05, health-04):
+    tools that set a rich TOP-LEVEL ``next_step`` left ``agent_summary.next_step``
+    empty. The canonical success envelope must mirror the top-level value so an
+    agent reading ``agent_summary.next_step`` (the documented place) gets the
+    real guidance, not ``""``."""
+
+    def test_top_level_next_step_mirrored_into_agent_summary(self):
+        response = {
+            "success": True,
+            "verdict": "INFO",
+            "next_step": "Answer from the inlined body — no Read needed.",
+        }
+        result = ensure_canonical_success_envelope("nav", response)
+        assert (
+            result["agent_summary"]["next_step"]
+            == "Answer from the inlined body — no Read needed."
+        )
+
+    def test_existing_agent_summary_next_step_is_not_clobbered(self):
+        response = {
+            "success": True,
+            "verdict": "INFO",
+            "next_step": "top-level value",
+            "agent_summary": {"next_step": "tool-specific value"},
+        }
+        result = ensure_canonical_success_envelope("nav", response)
+        assert result["agent_summary"]["next_step"] == "tool-specific value"
+
+    def test_no_next_step_anywhere_stays_empty_string(self):
+        response = {"success": True, "verdict": "INFO"}
+        result = ensure_canonical_success_envelope("nav", response)
+        # Contract unchanged when there is nothing to mirror.
+        assert result["agent_summary"]["next_step"] == ""

--- a/tree_sitter_analyzer/mcp/server_utils/error_recovery.py
+++ b/tree_sitter_analyzer/mcp/server_utils/error_recovery.py
@@ -436,7 +436,16 @@ def _populate_agent_summary_block(
     if not isinstance(agent_summary, dict):
         agent_summary = {}
     agent_summary.setdefault("summary_line", summary_line_value)
-    agent_summary.setdefault("next_step", "")
+    # Wave 1b batch B (audit nav-03/04, search-05, project-03, viz-05, health-04):
+    # many tools set a rich TOP-LEVEL ``next_step`` but leave
+    # ``agent_summary.next_step`` empty. Mirror the top-level value into the
+    # agent_summary (the documented place agents read) rather than defaulting to
+    # "" — only when agent_summary has no real next_step of its own.
+    if not agent_summary.get("next_step"):
+        top_next = response.get("next_step")
+        agent_summary["next_step"] = (
+            top_next if isinstance(top_next, str) and top_next else ""
+        )
     response["agent_summary"] = agent_summary
     return agent_summary
 


### PR DESCRIPTION
## What

Wave 1b **batch B** of the zero-defect audit (MEDIUM findings nav-03/04, search-05, project-03, viz-05, health-04, re-triaged on develop). Many success responses set a rich **top-level** `next_step` but the canonical envelope left `agent_summary.next_step = ""` — so an agent reading `agent_summary.next_step` (the documented place) got nothing.

**Triage correction:** the audit originally framed these as *"agent_summary is None"*. That was a **false positive** from testing `tool.execute()` directly — the MCP boundary (`ensure_canonical_success_envelope`) **does** build the agent_summary dict (RFC-0012's Codex-P2 "test the post-boundary surface" caveat). The real gap is the empty `next_step`, verified post-boundary.

## Fix (one central normalizer change covers all listed tools)

`_populate_agent_summary_block` now mirrors the top-level `next_step` into `agent_summary.next_step` when the latter is empty:
- a tool that set its own `agent_summary.next_step` is **not clobbered**;
- nothing-to-mirror stays `""` (contract unchanged).

## Verified

- e2e post-boundary: nav callers / search symbol now have a populated `agent_summary.next_step`.
- **4584 passed** across tests/unit/mcp + test_agent_contracts (full suite — per the amend-rerun lesson); ruff + mypy clean.

## Review

Independent review pending (opencode + adversarial agent; codex rate-limited until Jun 11). Scope: error_recovery.py central normalizer. No LOCKED decision touched.