### PR TITLE
fix(mcp): cap impact caller/callee lists to bound payload (nav-08)

### DIFF
--- a/tests/unit/test_codegraph_impact_tool.py
+++ b/tests/unit/test_codegraph_impact_tool.py
@@ -8,6 +8,7 @@ import pytest
 
 from tree_sitter_analyzer.call_graph import FunctionRef
 from tree_sitter_analyzer.mcp.tools.codegraph_impact_tool import (
+    _MAX_LISTED,
     CodeGraphImpactTool,
     _blast_radius_for_functions,
     _compute_risk_score,
@@ -218,3 +219,40 @@ class TestCodeGraphImpactTool:
         assert result["success"] is True
         assert result["mode"] == "risk_score"
         assert "score" in result
+
+
+class TestFunctionImpactListCap:
+    """Wave 1b (audit nav-08): function_impact must cap the EMITTED caller/callee
+    lists so a hub function does not serialise a ~70k-char payload that overflows
+    the tool-result token budget. Full counts + a truncation flag are kept."""
+
+    def _graph_with_n_direct_callers(self, n: int) -> MagicMock:
+        graph = MagicMock()
+        hub = _make_func("hub")
+        graph.resolve_targets.return_value = [hub]
+        # direct_callers / direct_callees come from callers_of/callees_of (dicts).
+        graph.callers_of.return_value = [
+            {"name": f"c{i}", "file": f"f{i}.py", "line": i} for i in range(n)
+        ]
+        graph.callees_of.return_value = []
+        # transitive + risk walk the *_refs_of edges — keep them empty/minimal.
+        graph.caller_refs_of.return_value = []
+        graph.callee_refs_of.return_value = []
+        return graph
+
+    def test_direct_callers_capped_but_count_is_full(self):
+        tool = CodeGraphImpactTool()
+        graph = self._graph_with_n_direct_callers(_MAX_LISTED + 10)
+        result = tool._function_impact(graph, "hub", None, 5)
+        assert len(result["direct_callers"]) == _MAX_LISTED
+        assert result["direct_caller_count"] == _MAX_LISTED + 10
+        assert result["lists_truncated"] is True
+        assert result["listed_cap"] == _MAX_LISTED
+
+    def test_small_lists_not_truncated(self):
+        tool = CodeGraphImpactTool()
+        graph = self._graph_with_n_direct_callers(3)
+        result = tool._function_impact(graph, "hub", None, 5)
+        assert len(result["direct_callers"]) == 3
+        assert result["direct_caller_count"] == 3
+        assert result["lists_truncated"] is False

--- a/tree_sitter_analyzer/mcp/tools/codegraph_impact_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_impact_tool.py
@@ -27,6 +27,12 @@ logger = setup_logger(__name__)
 
 _MAX_TRANSITIVE = 200
 _MAX_DEPTH = 10
+# Wave 1b (audit nav-08): cap the EMITTED caller/callee lists. The full counts
+# are kept (direct_*/transitive_*_count), but a hub like create_tool_registry
+# otherwise serialises ~70k chars of caller/callee dicts and overflows the
+# tool-result token budget. The agent gets a representative head + the true
+# counts + a truncation flag; the full list is one callers/callees call away.
+_MAX_LISTED = 50
 
 
 def _compute_transitive_callers(
@@ -419,19 +425,29 @@ class CodeGraphImpactTool(BaseMCPTool):
         cross_file_callers = len(caller_files - {self_file})
         cross_file_callees = len(callee_files - {self_file})
 
+        # Wave 1b (audit nav-08): emit a capped head of each list; the full
+        # counts below stay accurate so the agent sees the true blast radius.
+        lists_truncated = (
+            len(direct_callers) > _MAX_LISTED
+            or len(direct_callees) > _MAX_LISTED
+            or len(transitive_callers) > _MAX_LISTED
+            or len(transitive_callees) > _MAX_LISTED
+        )
         return {
             "function": func_name,
             "file": self_file,
-            "direct_callers": direct_callers,
-            "direct_callees": direct_callees,
-            "transitive_callers": transitive_callers,
-            "transitive_callees": transitive_callees,
+            "direct_callers": direct_callers[:_MAX_LISTED],
+            "direct_callees": direct_callees[:_MAX_LISTED],
+            "transitive_callers": transitive_callers[:_MAX_LISTED],
+            "transitive_callees": transitive_callees[:_MAX_LISTED],
             "direct_caller_count": len(direct_callers),
             "direct_callee_count": len(direct_callees),
             "transitive_caller_count": len(transitive_callers),
             "transitive_callee_count": len(transitive_callees),
             "cross_file_caller_files": cross_file_callers,
             "cross_file_callee_files": cross_file_callees,
+            "lists_truncated": lists_truncated,
+            "listed_cap": _MAX_LISTED,
             "risk": risk,
         }
 


### PR DESCRIPTION
## What

Audit finding **nav-08 (MEDIUM, token-cost)**: `nav action=impact` (function_impact mode) on a hub like `create_tool_registry` serialised a **~70k-char payload** (full direct + transitive caller/callee dict lists, uncapped) — overflowing the tool-result token budget. Only the transitive *computation* was capped (`_MAX_TRANSITIVE`), not the *emitted* lists.

## Fix

Emit a capped head (`_MAX_LISTED=50`) of each of the four lists while keeping the **accurate full counts** (`direct_*`/`transitive_*_count`) plus a `lists_truncated` flag and `listed_cap`. The agent still sees the true blast radius (counts) and a representative sample; the full list is one `callers`/`callees` call away.

## Measured

`create_tool_registry` impact payload **69,660 → 20,285 chars (−71%)**; counts preserved; `lists_truncated=true`; verdict unchanged.

## Tests

RED-first: list capped at \_MAX_LISTED while count stays full + `lists_truncated` true; small lists not truncated. **4617 passed** across tests/unit/mcp + impact + call_graph + contracts + nav_facade; ruff + mypy clean.

## Review

Independent review: opencode (codex rate-limited until Jun 11). Scope: codegraph_impact_tool.py. No LOCKED decision touched.