### PR TITLE
fix(mcp): classify defaults to classify_file when given a file_path (edit-10)

### DIFF
--- a/tests/unit/test_semantic_classify_tool.py
+++ b/tests/unit/test_semantic_classify_tool.py
@@ -24,11 +24,31 @@ class TestSemanticClassifyToolDefinition:
         defn = tool.get_tool_definition()
         assert defn["name"] == "semantic_classify"
 
-    def test_schema_requires_mode(self, tool: SemanticClassifyTool):
+    def test_mode_is_optional_in_schema(self, tool: SemanticClassifyTool):
+        # Wave 1b (audit edit-10): mode is resolved at runtime (defaults to
+        # classify_file when file_path is given), so it must NOT be required —
+        # else a strict MCP client rejects a valid {file_path: X} call.
         schema = tool.get_tool_schema()
         assert "mode" in schema["properties"]
-        assert "required" in schema
-        assert "mode" in schema["required"]
+        assert "mode" not in schema.get("required", [])
+
+    def test_resolve_mode_defaults(self, tool: SemanticClassifyTool):
+        assert tool._resolve_mode({"file_path": "x.py"}) == "classify_file"
+        assert (
+            tool._resolve_mode({"old_source": "a", "new_source": "b"})
+            == "classify_string"
+        )
+        assert tool._resolve_mode({}) == "classify_string"
+        # explicit mode always wins
+        assert (
+            tool._resolve_mode({"mode": "classify_string", "file_path": "x.py"})
+            == "classify_string"
+        )
+
+    def test_file_path_only_does_not_demand_sources(self, tool: SemanticClassifyTool):
+        # The edit-10 bug: classify file_path=X raised "old_source... required".
+        # With the file-default it validates as classify_file instead.
+        assert tool.validate_arguments({"file_path": "some/file.py"}) is True
 
 
 class TestSemanticClassifyValidation:

--- a/tree_sitter_analyzer/mcp/tools/edit_facade.py
+++ b/tree_sitter_analyzer/mcp/tools/edit_facade.py
@@ -13,7 +13,7 @@ impact        ``analyze_change_impact``       Post-edit dependency blast-radius 
 refactor      ``refactoring_suggestions``     Refactoring opportunities for a file
 constraints   ``check_constraints``           Constraint violations in the project
 pr            ``codegraph_pr_review``         AI review of a PR diff via CodeGraph
-classify      ``semantic_classify``           Semantic classification of a symbol/file
+classify      ``semantic_classify``           Semantic change classification (file git-diff or code strings)
 ast_diff      ``ast_diff``                    Structural diff of two AST snapshots
 ============  ==============================  ================================
 
@@ -71,8 +71,11 @@ _EDIT_DESCRIPTION = (
     "- action=pr — AI review of a PR diff via codegraph: structural issues, "
     "blast-radius, test-coverage gaps (codegraph_pr_review equivalent). "
     "Params: pr_url or diff (see inner schema).\n"
-    "- action=classify — semantic classification of a symbol or file: domain, "
-    "layer, responsibility. Params: file_path or symbol, output_format.\n"
+    "- action=classify — semantic change classification: classify a file's diff "
+    "between git refs (file_path [+ old_ref/new_ref]) or two code strings "
+    "(old_source + new_source + language). With only file_path, defaults to the "
+    "file/git-ref mode. Params: file_path | old_source+new_source+language, "
+    "output_format.\n"
     "- action=ast_diff — structural AST diff between two snapshots/versions of "
     "a file: added/removed/changed nodes. Params: file_path, before, after or "
     "git ref params (see inner schema).\n"

--- a/tree_sitter_analyzer/mcp/tools/semantic_classify_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/semantic_classify_tool.py
@@ -102,12 +102,37 @@ class SemanticClassifyTool(BaseMCPTool):
                     "default": "toon",
                 },
             },
-            "required": ["mode"],
+            # Wave 1b (audit edit-10): ``mode`` is resolved at runtime
+            # (_resolve_mode defaults to classify_file when a file_path is
+            # given), so it is NOT required. Declaring it required made strict
+            # MCP clients reject a valid ``{file_path: X}`` call before dispatch.
+            "required": [],
             "additionalProperties": False,
         }
 
+    @staticmethod
+    def _resolve_mode(arguments: dict[str, Any]) -> str:
+        """Effective mode.
+
+        Wave 1b (audit edit-10): the facade advertises ``classify`` as taking a
+        ``file_path``, but the default mode was ``classify_string`` (which needs
+        ``old_source``/``new_source``), so ``classify file_path=X`` failed with
+        "old_source and new_source are required". When no mode is given, default
+        to ``classify_file`` if a ``file_path`` was supplied (and not an explicit
+        old/new string pair), else the string-diff default.
+        """
+        mode = arguments.get("mode")
+        if mode:
+            return str(mode)
+        has_string_pair = bool(arguments.get("old_source")) and bool(
+            arguments.get("new_source")
+        )
+        if arguments.get("file_path") and not has_string_pair:
+            return "classify_file"
+        return "classify_string"
+
     def validate_arguments(self, arguments: dict[str, Any]) -> bool:
-        mode = arguments.get("mode", "classify_string")
+        mode = self._resolve_mode(arguments)
         if mode == "classify_string":
             if (
                 arguments.get("old_source") is None
@@ -126,7 +151,7 @@ class SemanticClassifyTool(BaseMCPTool):
     async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
         self.validate_arguments(arguments)
 
-        mode = arguments.get("mode", "classify_string")
+        mode = self._resolve_mode(arguments)
         output_format = arguments.get("output_format", "toon")
         differ = self._get_differ()
 


### PR DESCRIPTION
## What

Audit finding **edit-10 (MEDIUM)**: the edit facade advertises `classify` as taking a `file_path`, but the inner default mode was `classify_string` (which needs `old_source`/`new_source`), so `edit action=classify file_path=X` failed with *"old_source and new_source are required"*. The facade also over-claimed a `symbol` param that classify has no mode for.

## Fix (mirrors structure-01's `_resolve_mode`)

- `_resolve_mode` defaults to `classify_file` when a `file_path` is supplied (and no explicit old/new string pair); explicit mode always wins; string-diff stays the default otherwise. Used in validate + execute.
- schema `required: ["mode"]` → `[]` (mode is runtime-resolved; the old required made strict MCP clients reject a valid `{file_path: X}` — same class as #397/#399).
- facade description corrected: `classify` takes `file_path` (git-diff) **or** `old_source+new_source+language`; dropped the unsupported `symbol` claim.

## Verified

`classify file_path=X` validates as classify_file (no spurious error); old/new → classify_string; explicit mode honored. **4603 passed** (full mcp + contracts, per the amend-rerun lesson); ruff + mypy clean.

## Review

Independent review: opencode (codex rate-limited until Jun 11). Scope: semantic_classify_tool.py + edit_facade.py description. No LOCKED decision touched.