### PR TITLE
fix(mcp): cap navigate call-hierarchy lists to bound payload (nav-08b)

### DIFF
--- a/tests/unit/test_codegraph_navigate_tool.py
+++ b/tests/unit/test_codegraph_navigate_tool.py
@@ -144,6 +144,29 @@ class TestExecuteHierarchy:
         assert "bar" in names
         assert "baz" in names
 
+    @pytest.mark.asyncio
+    async def test_hierarchy_lists_capped_but_counts_full(self, tool):
+        """Wave 1b (audit nav-08b): emitted caller/callee lists are capped so a
+        hub does not overflow the token budget; counts stay accurate."""
+        from tree_sitter_analyzer.mcp.tools.codegraph_navigate_tool import _MAX_LISTED
+
+        mock_graph = MagicMock()
+        mock_graph.build.return_value = None
+        mock_graph.callers_of.return_value = [
+            {"name": f"c{i}", "file": f"f{i}.py", "line": i, "language": "python"}
+            for i in range(_MAX_LISTED + 12)
+        ]
+        mock_graph.callees_of.return_value = []
+        with patch.object(tool, "get_call_graph", return_value=mock_graph):
+            result = await tool.execute(
+                {"symbol": "hub", "mode": "hierarchy", "depth": 1}
+            )
+        h = result["hierarchy"]
+        assert len(h["callers"]) == _MAX_LISTED
+        assert h["caller_count"] == _MAX_LISTED + 12
+        assert h["lists_truncated"] is True
+        assert h["listed_cap"] == _MAX_LISTED
+
 
 class TestExecuteFull:
     @pytest.mark.asyncio

--- a/tree_sitter_analyzer/mcp/tools/codegraph_navigate_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_navigate_tool.py
@@ -29,6 +29,11 @@ from .base_tool import BaseMCPTool
 logger = setup_logger(__name__)
 
 _MAX_TRANSITIVE = 50
+# Wave 1b (audit nav-08b, sibling of nav-08): cap the EMITTED caller/callee
+# lists. Counts stay accurate; a hub otherwise serialises a large payload that
+# overflows the tool-result token budget. _MAX_TRANSITIVE caps the walk;
+# _MAX_LISTED caps what is serialised back.
+_MAX_LISTED = 50
 
 
 class CodeGraphNavigateTool(BaseMCPTool):
@@ -320,21 +325,35 @@ class CodeGraphNavigateTool(BaseMCPTool):
             for c in direct_callees
         ]
 
+        # Wave 1b (audit nav-08b): emit a capped head of each list; the counts
+        # stay accurate so the agent sees the true call hierarchy size.
+        truncated = len(callers) > _MAX_LISTED or len(callees) > _MAX_LISTED
         result: dict[str, Any] = {
             "caller_count": len(callers),
             "callees_count": len(callees),
-            "callers": callers,
-            "callees": callees,
+            "callers": callers[:_MAX_LISTED],
+            "callees": callees[:_MAX_LISTED],
         }
 
         if max_depth > 1:
-            result["transitive_callers"] = _transitive_callers(
+            transitive_callers = _transitive_callers(
                 graph, symbol, file_path, max_depth
             )
-            result["transitive_callees"] = _transitive_callees(
+            transitive_callees = _transitive_callees(
                 graph, symbol, file_path, max_depth
             )
+            truncated = (
+                truncated
+                or len(transitive_callers) > _MAX_LISTED
+                or len(transitive_callees) > _MAX_LISTED
+            )
+            result["transitive_caller_count"] = len(transitive_callers)
+            result["transitive_callee_count"] = len(transitive_callees)
+            result["transitive_callers"] = transitive_callers[:_MAX_LISTED]
+            result["transitive_callees"] = transitive_callees[:_MAX_LISTED]
 
+        result["lists_truncated"] = truncated
+        result["listed_cap"] = _MAX_LISTED
         return result
 
 


### PR DESCRIPTION
## What

**nav-08b** — sibling of nav-08 (#404), surfaced by that PR's independent review. `codegraph_navigate_tool._call_hierarchy` emitted the full `callers`/`callees` (and `transitive_*`) lists **uncapped**, so a hub symbol overflows the tool-result token budget — the same class nav-08 fixed in the impact tool.

## Fix

Emit a capped head (`_MAX_LISTED=50`) of each list, keep accurate counts (`caller_count`/`callees_count` + new `transitive_*_count`), add `lists_truncated` + `listed_cap`. `_MAX_TRANSITIVE` still caps the walk; `_MAX_LISTED` caps the emission.

## Tests

RED-first: 60-caller hub → list capped at 50, count stays 60, `lists_truncated=true`. **4603 passed** (full mcp + contracts); ruff + mypy clean. No LOCKED decision touched.