### PR TITLE
fix(mcp): analyze emits canonical INFO verdict, not off-ladder 'n/a' (structure-07)

### DIFF
--- a/tests/unit/mcp/test_analyze_code_structure_tool_helpers.py
+++ b/tests/unit/mcp/test_analyze_code_structure_tool_helpers.py
@@ -15,6 +15,7 @@ from tree_sitter_analyzer.mcp.tools.analyze_code_structure_helpers import (
 )
 from tree_sitter_analyzer.mcp.tools.analyze_code_structure_tool import (
     AnalyzeCodeStructureTool,
+    _attach_agent_summary,
     _build_next_steps,
     _convert_parameters,
     _format_table,
@@ -22,6 +23,7 @@ from tree_sitter_analyzer.mcp.tools.analyze_code_structure_tool import (
     _get_method_modifiers,
     _get_method_parameters,
 )
+from tree_sitter_analyzer.mcp.tools.tool_response import CANONICAL_VERDICTS
 
 
 @pytest.fixture
@@ -30,10 +32,27 @@ def tool():
     return AnalyzeCodeStructureTool()
 
 
+def test_attach_agent_summary_emits_canonical_info_verdict():
+    """Wave 1b (audit structure-07): a successful structural analysis must emit
+    the canonical INFO verdict, not the off-ladder "n/a" placeholder (which is
+    not in CANONICAL_VERDICTS and an agent branching on verdict cannot read)."""
+    response: dict = {"success": True}
+    _attach_agent_summary(
+        response,
+        MagicMock(),  # _ExecutionOptions — unused by the verdict path
+        {"classes_count": 1, "methods_count": 2, "fields_count": 0, "total_lines": 10},
+        [],
+    )
+    assert response["verdict"] == "INFO"
+    assert response["verdict"] in CANONICAL_VERDICTS
+    assert response["agent_summary"]["verdict"] == "INFO"
+
+
 @pytest.fixture
 def tool_with_project_root():
     """Create an AnalyzeCodeStructureTool instance with a project root."""
     return AnalyzeCodeStructureTool(project_root="/test/project")
+
 
 class TestAnalyzeCodeStructureHelpers:
     """Tests for module-level analyze_code_structure helpers."""

--- a/tree_sitter_analyzer/mcp/tools/analyze_code_structure_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/analyze_code_structure_tool.py
@@ -288,7 +288,11 @@ def _attach_agent_summary(
     )
     response["summary_line"] = summary_line
     # r37x (envelope ratchet): top-level verdict mirror (r37u contract).
-    response["verdict"] = "n/a"
+    # Wave 1b (audit structure-07): a successful structural analysis is
+    # informational with no risk judgment — emit the canonical INFO, not the
+    # off-ladder "n/a" placeholder (not in CANONICAL_VERDICTS), which an agent
+    # branching on verdict cannot interpret.
+    response["verdict"] = "INFO"
     response["agent_summary"] = {
         "summary_line": summary_line,
         "next_step": (
@@ -296,7 +300,7 @@ def _attach_agent_summary(
             if next_steps
             else "Call query_code or extract_code_section for deeper detail."
         ),
-        "verdict": "n/a",
+        "verdict": "INFO",
     }
 
 


### PR DESCRIPTION
## What

Audit finding **structure-07 (MEDIUM, verdict-ladder)**: `structure action=analyze` returned `verdict='n/a'` (lowercase) at both top level and `agent_summary`. `n/a` is the internal *not-set* sentinel and is **not** in `CANONICAL_VERDICTS` (`{SAFE,CAUTION,REVIEW,UNSAFE,INFO,WARN,ERROR,NOT_FOUND}`) — an agent branching on `verdict` gets an unreadable value.

## Fix

A successful structural analysis is informational with no risk judgment, so `_attach_agent_summary` emits the canonical **INFO** at both surfaces.

## Verified

e2e: `analyze` verdict=`INFO` ∈ CANONICAL_VERDICTS. **4585 passed** (full mcp + contracts); ruff + mypy clean. No test pinned the old `n/a`. No LOCKED decision touched.