### PR TITLE
fix(mcp): explore accepts symbol alias + surfaces next_step (structure-03/06)

### DIFF
--- a/tests/unit/test_codegraph_explore_tool.py
+++ b/tests/unit/test_codegraph_explore_tool.py
@@ -87,10 +87,22 @@ class TestToolDefinition:
         assert ann["idempotentHint"] is True
         assert ann["openWorldHint"] is False
 
-    def test_schema_requires_query(self, tool):
+    def test_schema_query_and_symbol_alias_not_required(self, tool):
+        # Wave 1b (audit structure-06): query may arrive via the `symbol` alias,
+        # so neither is schema-required; validate_arguments enforces the rule.
         schema = tool.get_tool_schema()
         assert "query" in schema["properties"]
-        assert schema["required"] == ["query"]
+        assert "symbol" in schema["properties"]
+        assert "query" not in schema.get("required", [])
+
+    def test_symbol_alias_maps_to_query(self, tool):
+        args = {"symbol": "FooBar"}
+        assert tool.validate_arguments(args) is True
+        assert args["query"] == "FooBar"
+
+    def test_missing_query_and_symbol_raises(self, tool):
+        with pytest.raises(ValueError, match="query is required"):
+            tool.validate_arguments({})
 
     def test_schema_strict_no_additional_properties(self, tool):
         assert tool.get_tool_schema()["additionalProperties"] is False

--- a/tree_sitter_analyzer/mcp/tools/codegraph_explore_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_explore_tool.py
@@ -72,6 +72,13 @@ _EXPLORE_SCHEMA: dict[str, Any] = {
                 "sentence."
             ),
         },
+        # Wave 1b (audit structure-06): accept the facade's canonical
+        # ``symbol`` as an alias for ``query``. Declared here so the facade
+        # whitelist does not drop it before this tool can map it.
+        "symbol": {
+            "type": "string",
+            "description": "Alias for query (single symbol name).",
+        },
         "maxFiles": {
             "type": "integer",
             "default": 12,
@@ -98,7 +105,10 @@ _EXPLORE_SCHEMA: dict[str, Any] = {
             "description": "Output format (default: toon)",
         },
     },
-    "required": ["query"],
+    # Wave 1b (audit structure-06): not strictly required — ``query`` may arrive
+    # via the ``symbol`` alias, which validate_arguments normalises. A required
+    # ``query`` made strict MCP clients reject a valid ``{symbol: X}`` call.
+    "required": [],
     "additionalProperties": False,
 }
 
@@ -281,6 +291,10 @@ def _handle_no_resolved(
         relationship_map={},
         stats=s,
         hint=_HINT_NOT_FOUND,
+        # Wave 1b (audit structure-03): also expose the hint as the canonical
+        # top-level next_step so the MCP boundary mirrors it into
+        # agent_summary.next_step (agents read next_step, not hint).
+        next_step=_HINT_NOT_FOUND,
     )
     return apply_toon_format_to_response(result, output_format)
 
@@ -374,9 +388,14 @@ class CodeGraphExploreTool(BaseMCPTool):
         return _EXPLORE_SCHEMA
 
     def validate_arguments(self, arguments: dict[str, Any]) -> bool:
+        # Wave 1b (audit structure-06): map the canonical ``symbol`` alias to
+        # ``query`` so ``explore symbol=X`` works instead of raising
+        # "query is required" (the facade's core param is ``symbol``).
+        if not arguments.get("query") and arguments.get("symbol"):
+            arguments["query"] = arguments["symbol"]
         query = arguments.get("query")
         if not isinstance(query, str) or not query.strip():
-            raise ValueError("query is required")
+            raise ValueError("query is required (or pass it as `symbol`)")
         return True
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## What

Two MEDIUM findings on the `explore` tool, both fixed locally in the tool (no facade-wide change):

- **structure-06 (accuracy):** explore's identifier param is `query`, but the facade's canonical core param is `symbol` — the whitelist dropped it, so `explore symbol=X` raised *"query is required"*. Fix: declare `symbol` in the schema (survives projection), relax `required:["query"]`→`[]`, and map `symbol`→`query` in validate_arguments (same pattern as structure-01 / edit-10 / list_files).
- **structure-03 (next_step):** the NOT_FOUND response carried guidance only in `hint`, so the #403 boundary mirror (top-level `next_step` → `agent_summary.next_step`) never fired. Fix: emit `next_step` alongside `hint`.

## Verified

e2e: `explore symbol=create_tool_registry` → INFO (no "query is required"); NOT_FOUND → `agent_summary.next_step` populated. **4617 passed** (full mcp + contracts); ruff + mypy clean. No LOCKED decision touched.