### PR TITLE
fix(mcp): cache search no-match message + query-default mode (index-05/10)

### DIFF
--- a/tests/unit/test_ast_cache_tool.py
+++ b/tests/unit/test_ast_cache_tool.py
@@ -60,11 +60,21 @@ class TestGetToolDefinition:
 class TestGetToolSchema:
     """Tests for get_tool_schema."""
 
-    def test_schema_has_required_mode(self):
+    def test_mode_is_optional_in_schema(self):
+        # Wave 1b (audit index-10): mode is resolved at runtime (search when a
+        # query is supplied, else stats), so it must NOT be required — else a
+        # strict MCP client rejects a valid {query: X} call before dispatch.
         tool = ASTCacheTool()
         schema = tool.get_tool_schema()
         assert "mode" in schema["properties"]
-        assert "mode" in schema["required"]
+        assert "mode" not in schema.get("required", [])
+
+    def test_resolve_mode_defaults_to_search_with_query(self):
+        # index-10: cache query=X with no mode searches instead of silently
+        # returning stats and dropping the query.
+        assert ASTCacheTool._resolve_mode({"query": "Foo"}) == "search"
+        assert ASTCacheTool._resolve_mode({}) == "stats"
+        assert ASTCacheTool._resolve_mode({"mode": "stats", "query": "Foo"}) == "stats"
 
     def test_valid_modes(self):
         tool = ASTCacheTool()
@@ -189,6 +199,33 @@ class TestExecute:
         result = await tool.execute({"mode": "search", "query": "MyClass"})
         assert result["count"] == 1
         assert result["query"] == "MyClass"
+
+    @pytest.mark.asyncio
+    async def test_empty_search_with_fts5_says_no_match_not_populate(
+        self, tool_with_mock_cache
+    ):
+        """Wave 1b (audit index-05): an empty result while FTS5 is available is a
+        genuine no-match — guide to broaden, NOT 'populate the FTS index'."""
+        tool, mock_cache = tool_with_mock_cache
+        mock_cache.fts_search.return_value = []
+        mock_cache.fts_search_ranked.return_value = []
+        mock_cache.fts5_available = True
+        result = await tool.execute({"mode": "search", "query": "zzznomatch"})
+        assert result["count"] == 0
+        ns = result["agent_summary"]["next_step"]
+        assert "No symbols match" in ns
+        assert "populate" not in ns.lower()
+
+    @pytest.mark.asyncio
+    async def test_empty_search_without_fts5_says_rebuild(self, tool_with_mock_cache):
+        """index-05: when FTS5 is unavailable, the rebuild hint is correct."""
+        tool, mock_cache = tool_with_mock_cache
+        mock_cache.fts_search.return_value = []
+        mock_cache.fts_search_ranked.return_value = []
+        mock_cache.fts5_available = False
+        result = await tool.execute({"mode": "search", "query": "zzznomatch"})
+        assert result["count"] == 0
+        assert "FTS5 unavailable" in result["agent_summary"]["next_step"]
 
     @pytest.mark.asyncio
     async def test_fts_search_mode(self, tool_with_mock_cache):

--- a/tree_sitter_analyzer/mcp/tools/ast_cache_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/ast_cache_tool.py
@@ -316,12 +316,29 @@ class ASTCacheTool(BaseMCPTool):
                     ),
                 },
             },
-            "required": ["mode"],
+            # Wave 1b (audit index-10): ``mode`` is resolved at runtime
+            # (defaults to ``search`` when a query is supplied, else ``stats``),
+            # so it is NOT required — a required ``mode`` made strict MCP clients
+            # reject a valid ``{query: X}`` call before dispatch.
+            "required": [],
             "additionalProperties": False,
         }
 
+    @staticmethod
+    def _resolve_mode(arguments: dict[str, Any]) -> str:
+        """Effective mode.
+
+        Wave 1b (audit index-10): ``cache query=X`` with no explicit mode used to
+        default to ``stats`` and silently drop the query. Default to ``search``
+        when a query is supplied (the obvious intent), else ``stats``.
+        """
+        mode = arguments.get("mode")
+        if mode:
+            return str(mode)
+        return "search" if arguments.get("query") else "stats"
+
     def validate_arguments(self, arguments: dict[str, Any]) -> bool:
-        mode = arguments.get("mode", "stats")
+        mode = self._resolve_mode(arguments)
         # ``fts_search`` is a deprecated alias for ``search`` — it remains
         # accepted at the validate boundary so existing MCP callers do not
         # break, but it is no longer in the schema enum (J1).
@@ -354,7 +371,7 @@ class ASTCacheTool(BaseMCPTool):
         / J8 / K7 contracts preserved exactly.
         """
         self.validate_arguments(arguments)
-        mode = arguments.get("mode", "stats")
+        mode = self._resolve_mode(arguments)
 
         # Watch modes are dispatched before the cache is materialised so
         # ``watch_status`` / ``watch_stop`` can answer "no watcher yet"
@@ -465,11 +482,23 @@ class ASTCacheTool(BaseMCPTool):
             f"ast_cache {mode} query={query!r} "
             f"results={len(results)} fts5={fts5_available}"
         )
-        next_step = (
-            "ast_cache mode=lookup file_path=<result.file> for the full entry"
-            if results
-            else "ast_cache mode=index to populate the FTS index first"
-        )
+        # Wave 1b (audit index-05): only tell the agent to (re)build the index
+        # when FTS is actually unavailable. When FTS5 is available an empty
+        # result is a genuine no-match — don't mislead with "populate the index".
+        if results:
+            next_step = (
+                "ast_cache mode=lookup file_path=<result.file> for the full entry"
+            )
+        elif not fts5_available:
+            next_step = (
+                "FTS5 unavailable — ast_cache mode=index to (re)build the index, "
+                "then retry the search"
+            )
+        else:
+            next_step = (
+                f"No symbols match {query!r} — broaden the term, or use "
+                "search action=symbol / codegraph_symbol_search to discover names"
+            )
         payload: dict[str, Any] = {
             "query": query,
             "results": results,


### PR DESCRIPTION
## What

Two MEDIUM findings on `ast_cache` (index facade `cache` action):

- **index-05 (accuracy):** an empty search emitted *"ast_cache mode=index to populate the FTS index first"* even when `fts5_available` and the index is populated — misleading. Now: FTS unavailable → rebuild hint; FTS available + empty → *"no symbols match \<query\>, broaden / use search action=symbol"*.
- **index-10 (overclaim):** `cache query=X` with no mode defaulted to `stats` and **silently dropped the query**. `_resolve_mode` now defaults to `search` when a query is supplied (else `stats`); `required:["mode"]`→`[]` (runtime-resolved, same class as #397/#399/#405).

## Verified

e2e: `cache query=create_tool_registry` → search **with results**; empty search → no-match guidance (not "populate"). **4612 passed** (full mcp + contracts); ruff + mypy clean. No LOCKED decision touched.