### PR TITLE
fix(mcp): test_gap defaults to TOON like every other MCP tool (health-03)

### DIFF
--- a/tests/unit/test_test_gap_tool.py
+++ b/tests/unit/test_test_gap_tool.py
@@ -41,6 +41,19 @@ class TestCodeGraphTestGapTool:
         assert "gaps" in mode_enum
         assert "file" in mode_enum
 
+    def test_output_format_defaults_to_toon(self, tool):
+        # Wave 1b (audit health-03): MCP default is TOON (CLAUDE.md §1).
+        # test_gap was the lone tool defaulting to json.
+        schema = tool.get_tool_schema()
+        assert schema["properties"]["output_format"]["default"] == "toon"
+
+    @pytest.mark.asyncio
+    async def test_default_output_is_toon_formatted(self, tool, project_with_code):
+        tool.set_project_path(str(project_with_code))
+        result = await tool.execute({"mode": "summary"})
+        assert result.get("format") == "toon"
+        assert "toon_content" in result
+
     def test_validate_no_mode(self):
         t = CodeGraphTestGapTool()
         assert t.validate_arguments({})
@@ -74,10 +87,12 @@ class TestCodeGraphTestGapTool:
     @pytest.mark.asyncio
     async def test_execute_file_mode(self, tool, project_with_code):
         tool.set_project_path(str(project_with_code))
-        result = await tool.execute({
-            "mode": "file",
-            "file_path": "service.py",
-        })
+        result = await tool.execute(
+            {
+                "mode": "file",
+                "file_path": "service.py",
+            }
+        )
         assert result["success"] is True
 
     @pytest.mark.asyncio

--- a/tree_sitter_analyzer/mcp/tools/test_gap_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/test_gap_tool.py
@@ -70,7 +70,10 @@ TOOL_SCHEMA: dict[str, Any] = {
         "output_format": {
             "type": "string",
             "enum": ["json", "toon", "summary", "total_only"],
-            "default": "json",
+            # Wave 1b (audit health-03): default to TOON like every other MCP
+            # tool (CLAUDE.md §1 — MCP defaults to TOON). test_gap was the lone
+            # tool defaulting to json, so its envelope lacked format/toon_content.
+            "default": "toon",
         },
     },
     "required": [],
@@ -113,7 +116,7 @@ class CodeGraphTestGapTool(BaseMCPTool):
         max_files = arguments.get("max_files", 1000)
         max_gaps = arguments.get("max_gaps", 50)
         include_covered = arguments.get("include_covered", False)
-        output_format = arguments.get("output_format", "json")
+        output_format = arguments.get("output_format", "toon")
         target_file = arguments.get("file_path") or None
         coverage_json = arguments.get("coverage_json") or None
 


### PR DESCRIPTION
## What

Audit **health-03 (MEDIUM, envelope-consistency)**: `test_gap` was the **lone MCP tool defaulting `output_format` to `json`** (schema + runtime), so its envelope lacked `format`/`toon_content` while every other health action returned `format=toon`. This also diverged from the **LOCKED MCP-TOON default** (CLAUDE.md §1).

## Fix

Default `output_format` to `toon` (schema + runtime). The tool already calls `apply_toon_format_to_response`, so it now TOON-wraps by default like its siblings.

## Verified

e2e: `test_gap` → `format=toon` + `toon_content`. **4597 passed** (full mcp + contracts); ruff + mypy clean. **Aligns with** §1 (does not touch the lock — restores consistency with it).