### PR TITLE
fix(mcp): dead_code emits an actionable next_step (health-10)

### DIFF
--- a/tests/unit/test_codegraph_exclusive_tools.py
+++ b/tests/unit/test_codegraph_exclusive_tools.py
@@ -55,6 +55,60 @@ class TestDeadCodeToolExecute:
         assert result["format"] == "toon"
         assert "toon_content" in result
 
+    async def test_emits_actionable_next_step(self, project):
+        # Wave 1b (audit health-10): dead_code must emit a next_step (the boundary
+        # mirrors it into agent_summary.next_step) instead of leaving it empty.
+        tool = DeadCodeTool(str(project))
+        result = await tool.execute({"output_format": "json"})
+        assert result.get("next_step")
+        assert isinstance(result["next_step"], str) and result["next_step"].strip()
+
+    async def test_issues_branch_next_step_has_count_and_guard(
+        self, project, monkeypatch
+    ):
+        # Cover the findings branch deterministically: inject one unused import so
+        # the CAUTION/REVIEW path runs (the project fixture itself yields none).
+        import tree_sitter_analyzer.mcp.tools.dead_code_tool as mod
+        from tree_sitter_analyzer.dead_code_analyzer import (
+            DeadCodeResult,
+            UnusedImport,
+        )
+
+        fake = DeadCodeResult(
+            dead_functions=[],
+            unused_imports=[
+                UnusedImport(
+                    file="m.py", line=1, import_text="import os", unused_names=["os"]
+                )
+            ],
+            unreferenced_variables=[],
+            stats={},
+        )
+        monkeypatch.setattr(mod, "analyze_dead_code", lambda *a, **k: fake)
+        tool = DeadCodeTool(str(project))
+        result = await tool.execute({"output_format": "json"})
+        assert result["verdict"] in ("CAUTION", "REVIEW")
+        assert "1 candidate" in result["next_step"]
+        assert "guard" in result["next_step"]
+
+    async def test_no_issues_branch_next_step(self, project, monkeypatch):
+        # Cover the clean (0-issues) branch deterministically: inject an empty
+        # result so verdict=INFO and the "no dead code" next_step runs.
+        import tree_sitter_analyzer.mcp.tools.dead_code_tool as mod
+        from tree_sitter_analyzer.dead_code_analyzer import DeadCodeResult
+
+        empty = DeadCodeResult(
+            dead_functions=[],
+            unused_imports=[],
+            unreferenced_variables=[],
+            stats={},
+        )
+        monkeypatch.setattr(mod, "analyze_dead_code", lambda *a, **k: empty)
+        tool = DeadCodeTool(str(project))
+        result = await tool.execute({"output_format": "json"})
+        assert result["verdict"] == "INFO"
+        assert "No dead code" in result["next_step"]
+
 
 # ---------------------------------------------------------------------------
 # Dependency Matrix Tool

--- a/tree_sitter_analyzer/mcp/tools/dead_code_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/dead_code_tool.py
@@ -134,12 +134,19 @@ class CodeGraphDeadCodeTool(BaseMCPTool):
 
         total_issues = len(dead_funcs) + len(unused_imports) + len(unref_vars)
 
+        # Wave 1b (audit health-10): emit an actionable next_step. dead_code
+        # previously set none, so the boundary left agent_summary.next_step
+        # empty — an agent saw a REVIEW verdict with N findings and no guidance.
         if total_issues == 0:
             verdict = "INFO"
-        elif total_issues > 20:
-            verdict = "REVIEW"
+            next_step = "No dead code found in scope."
         else:
-            verdict = "CAUTION"
+            verdict = "REVIEW" if total_issues > 20 else "CAUTION"
+            next_step = (
+                f"Review the {total_issues} candidate(s) — static analysis can miss "
+                "dynamic refs (reflection, plugins, __all__). Run edit action=guard "
+                "on a symbol to confirm zero callers before deleting it."
+            )
 
         response: dict[str, Any] = {
             "success": True,
@@ -147,6 +154,7 @@ class CodeGraphDeadCodeTool(BaseMCPTool):
             "mode": mode,
             "project_root": self.project_root,
             "stats": result.stats,
+            "next_step": next_step,
             "dead_functions": [_serialize_dead_function(df) for df in dead_funcs],
             "unused_imports": [_serialize_unused_import(ui) for ui in unused_imports],
             "unreferenced_variables": [_serialize_unref_var(uv) for uv in unref_vars],


### PR DESCRIPTION
## What

Audit **health-10 (MEDIUM)**: `dead_code` returned a `REVIEW` verdict with N findings but set **no `next_step`**, so the boundary left `agent_summary.next_step` empty — an agent saw the verdict with no guidance.

## Fix

Emit a verdict-appropriate `next_step` (the #403 boundary mirror surfaces it into `agent_summary.next_step`):
- INFO (0 issues): "No dead code found in scope."
- CAUTION/REVIEW: review the N candidates; static analysis can miss dynamic refs (reflection/plugins/`__all__`) — run `edit action=guard` to confirm zero callers before deleting.

## Tests

dead_code now emits a non-empty `next_step`. **4601 passed** (full mcp + contracts); ruff + mypy clean. No LOCKED decision touched.

> Note: `import_graph`/`dependency_matrix` share the empty-next_step trait (lower priority, boundary already supplies a valid agent_summary) — left in the backlog.