### PR TITLE
fix(mcp): symbol search exposes canonical 'count' key (search-06)

### DIFF
--- a/tests/unit/test_symbol_search_tool.py
+++ b/tests/unit/test_symbol_search_tool.py
@@ -80,6 +80,14 @@ class TestCodeGraphSymbolSearchExecution:
         names = [r["name"] for r in result["results"]]
         assert "UserService" in names
 
+    async def test_exposes_canonical_count_key(self, indexed_project):
+        # Wave 1b (audit search-06): symbol search must also expose the stable
+        # canonical `count` key (already emitted by search action=content) so an
+        # agent can read the result count consistently across both actions.
+        tool = CodeGraphSymbolSearchTool(str(indexed_project))
+        result = await tool.execute({"query": "UserService", "output_format": "json"})
+        assert result["count"] == result["match_count"]
+
     async def test_fuzzy_match(self, indexed_project):
         tool = CodeGraphSymbolSearchTool(str(indexed_project))
         result = await tool.execute({"query": "~user", "output_format": "json"})

--- a/tree_sitter_analyzer/mcp/tools/symbol_search_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/symbol_search_tool.py
@@ -145,6 +145,11 @@ class CodeGraphSymbolSearchTool(BaseMCPTool):
             "verdict": "INFO" if results else "NOT_FOUND",
             "query": query,
             "match_count": len(results),
+            # Wave 1b (audit search-06): expose ``count`` too — it is the stable
+            # canonical result-count key already emitted by search action=content,
+            # so an agent can read ``count`` consistently across both search
+            # actions. ``match_count`` stays for back-compat.
+            "count": len(results),
             "file_count": len(by_file),
             "results": results,
             "data_source": "fts5" if cache.fts5_available else "linear_scan",


### PR DESCRIPTION
## What

Audit **search-06 (MEDIUM, naming)**: `search action=symbol` emitted only `match_count` while `search action=content` emits `count` (+ `total_matches`) — **no stable canonical count key** across the two search actions.

## Fix (additive — no rename, no breakage)

Add `count` (= `match_count`) to symbol search so an agent can read `count` consistently across both actions. `match_count` stays for back-compat.

## Verified

e2e: `symbol` → `count`=`match_count`; `content` → `count`; both expose `count`. **4619 passed** (full mcp + contracts); ruff + mypy clean. No keys renamed, no consumer breaks. No LOCKED decision touched.

> The `navigate` `callees_count`/`caller_count` plural-vs-singular split (opencode observation) is a separate backlog item.