### PR TITLE
fix(structure): stop masking unparseable-language failures as empty-success (Theme D)

### DIFF
--- a/tests/unit/mcp/test_structure_unparseable_language.py
+++ b/tests/unit/mcp/test_structure_unparseable_language.py
@@ -50,3 +50,55 @@ async def test_analyze_structure_does_not_mask_unparseable_language() -> None:
     with pytest.raises(Exception) as exc_info:
         await tool.execute({"file_path": UNPARSEABLE_FILE, "output_format": "json"})
     assert "unsupported language" in str(exc_info.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_structure_boundary_classifies_as_language_unsupported() -> None:
+    """The MCP boundary must surface an honest ``language_unsupported`` ERROR
+    envelope (verdict=ERROR, success=False) — not a masked empty-success — for
+    every structure action on an unparseable-language file.
+
+    This exercises the true client surface (``_dispatch_tool`` + the canonical
+    envelope normalizers), so it catches both the masking regression AND any
+    error_type misclassification the per-tool ``pytest.raises`` checks miss.
+    """
+    from tree_sitter_analyzer.mcp.server import TreeSitterAnalyzerMCPServer
+    from tree_sitter_analyzer.mcp.server_utils.error_recovery import (
+        build_agent_friendly_error,
+        ensure_canonical_error_envelope,
+        ensure_canonical_success_envelope,
+    )
+    from tree_sitter_analyzer.mcp.server_utils.tool_registration import (
+        _dispatch_tool,
+    )
+
+    server = TreeSitterAnalyzerMCPServer(project_root=".")
+    server._ensure_registry()
+    server._initialization_complete = True
+
+    async def boundary(name: str, args: dict) -> dict:
+        try:
+            result = await _dispatch_tool(server, name, args)
+            if isinstance(result, dict) and result.get("success") is False:
+                return ensure_canonical_error_envelope(name, result, arguments=args)
+            if isinstance(result, dict):
+                return ensure_canonical_success_envelope(name, result, arguments=args)
+            return result
+        except Exception as e:  # noqa: BLE001 — mirrors handle_call_tool
+            return build_agent_friendly_error(name, e, arguments=args)
+
+    for action in ("outline", "analyze"):
+        env = await boundary(
+            "structure",
+            {
+                "action": action,
+                "file_path": UNPARSEABLE_FILE,
+                "output_format": "json",
+            },
+        )
+        verdict = env.get("verdict") or (env.get("agent_summary") or {}).get("verdict")
+        assert env.get("success") is False, f"{action}: masked as success"
+        assert verdict == "ERROR", f"{action}: verdict={verdict!r}"
+        assert env.get("error_type") == "language_unsupported", (
+            f"{action}: error_type={env.get('error_type')!r}"
+        )

--- a/tests/unit/mcp/test_structure_unparseable_language.py
+++ b/tests/unit/mcp/test_structure_unparseable_language.py
@@ -1,0 +1,52 @@
+"""Structure tools must NOT mask an unparseable-language parse failure
+as an empty-success result.
+
+Regression for the Theme-D dogfood finding (2026-06-09): a ``.scala`` file
+is extension-mapped to language ``scala`` by ``language_detector`` but no
+``tree-sitter-scala`` grammar is installed, so the parse fails. The analysis
+engine correctly returns ``AnalysisResult(success=False, ...)``, but the MCP
+structure tools only checked ``result is None`` and then fabricated a
+``{"success": True, "total_lines": 0, ... "0 classes, 0 methods"}`` envelope.
+
+That lies to an AI agent: it reports a real, non-empty Scala file as a healthy
+empty file and even suggests ``extract_code_section`` for non-existent methods.
+The CLI errors honestly on the same file (``Unsupported language: scala``), so
+this is also a CLI<->MCP parity violation.
+
+The fix: both structure tools must honor ``analysis_result.success`` and
+propagate the failure so the MCP boundary maps it to a ``language_unsupported``
+error envelope (the same path Bash already gets).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tree_sitter_analyzer.mcp.tools.analyze_code_structure_tool import (
+    AnalyzeCodeStructureTool,
+)
+from tree_sitter_analyzer.mcp.tools.get_code_outline_tool import GetCodeOutlineTool
+
+# A real, non-empty golden corpus file whose language (scala) is detected but
+# whose tree-sitter grammar is not installed -> parse fails.
+UNPARSEABLE_FILE = "tests/golden/corpus_scala.scala"
+
+
+@pytest.mark.asyncio
+async def test_outline_does_not_mask_unparseable_language() -> None:
+    """get_code_outline must not report a failed parse as empty-success."""
+    tool = GetCodeOutlineTool(project_root=".")
+    with pytest.raises(Exception) as exc_info:
+        await tool.execute({"file_path": UNPARSEABLE_FILE, "output_format": "json"})
+    # The propagated message must let the boundary classify it as
+    # ``language_unsupported`` (substring match in error_recovery).
+    assert "unsupported language" in str(exc_info.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_analyze_structure_does_not_mask_unparseable_language() -> None:
+    """analyze (structure) must not report a failed parse as empty-success."""
+    tool = AnalyzeCodeStructureTool(project_root=".")
+    with pytest.raises(Exception) as exc_info:
+        await tool.execute({"file_path": UNPARSEABLE_FILE, "output_format": "json"})
+    assert "unsupported language" in str(exc_info.value).lower()

--- a/tree_sitter_analyzer/mcp/tools/analyze_code_structure_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/analyze_code_structure_tool.py
@@ -622,6 +622,16 @@ class AnalyzeCodeStructureTool(BaseMCPTool):
         if result is None:
             _msg = _ANALYZE_ERR_PREFIX + _file_path
             raise RuntimeError(_msg)
+        # Theme-D fix: honor the engine's ``success=False`` (parse failure for a
+        # detected-but-unparseable language) instead of fabricating an
+        # empty-success structure. Propagating ``error_message`` lets the MCP
+        # boundary classify it as ``language_unsupported`` — the same honest
+        # error the CLI returns — rather than masking it as "0 elements".
+        if getattr(result, "success", True) is False:
+            raise ValueError(
+                getattr(result, "error_message", None)
+                or (_ANALYZE_ERR_PREFIX + _file_path)
+            )
         return result
 
     def _save_output(

--- a/tree_sitter_analyzer/mcp/tools/analyze_code_structure_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/analyze_code_structure_tool.py
@@ -628,7 +628,12 @@ class AnalyzeCodeStructureTool(BaseMCPTool):
         # boundary classify it as ``language_unsupported`` — the same honest
         # error the CLI returns — rather than masking it as "0 elements".
         if getattr(result, "success", True) is False:
-            raise ValueError(
+            # RuntimeError (not ValueError): a parse failure is an internal
+            # condition, not a caller-validation error. The "Unsupported
+            # language" substring still maps to ``language_unsupported`` at the
+            # boundary; the ``error_message is None`` fallback maps to
+            # ``internal`` instead of the misleading ``validation``.
+            raise RuntimeError(
                 getattr(result, "error_message", None)
                 or (_ANALYZE_ERR_PREFIX + _file_path)
             )

--- a/tree_sitter_analyzer/mcp/tools/get_code_outline_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/get_code_outline_tool.py
@@ -332,6 +332,19 @@ class GetCodeOutlineTool(BaseMCPTool):
             analysis_result = await self.analysis_engine.analyze(request)
         if analysis_result is None:
             raise RuntimeError(f"Failed to analyze file: {original_path}")
+        # Theme-D fix: the engine returns ``AnalysisResult(success=False)`` when
+        # the parse fails (e.g. a detected-but-unparseable language whose
+        # tree-sitter grammar is not installed). Honor that flag instead of
+        # building an empty-success outline that lies to the agent ("0 classes,
+        # 0 methods" for a real, non-empty file). Propagating the engine's
+        # ``error_message`` lets the MCP boundary classify it (a message
+        # containing "Unsupported language" maps to ``language_unsupported``),
+        # matching the honest error the CLI already returns for the same file.
+        if getattr(analysis_result, "success", True) is False:
+            raise ValueError(
+                getattr(analysis_result, "error_message", None)
+                or f"Failed to analyze file: {original_path}"
+            )
         return analysis_result
 
     @staticmethod

--- a/tree_sitter_analyzer/mcp/tools/get_code_outline_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/get_code_outline_tool.py
@@ -341,7 +341,14 @@ class GetCodeOutlineTool(BaseMCPTool):
         # containing "Unsupported language" maps to ``language_unsupported``),
         # matching the honest error the CLI already returns for the same file.
         if getattr(analysis_result, "success", True) is False:
-            raise ValueError(
+            # RuntimeError (not ValueError): a parse failure is an internal
+            # condition, not a caller-validation error. When the engine's
+            # message contains "Unsupported language" the boundary still maps
+            # it to ``language_unsupported`` (substring match wins over the
+            # exception type); the degenerate ``error_message is None`` case
+            # then falls back to ``internal`` rather than the misleading
+            # ``validation`` classification.
+            raise RuntimeError(
                 getattr(analysis_result, "error_message", None)
                 or f"Failed to analyze file: {original_path}"
             )


### PR DESCRIPTION
## Problem (dogfood Theme D — confirmed with hard evidence, 2026-06-09)

The MCP \`structure\` tools report a **non-empty, unparseable file as a healthy empty file** — silent phantom data an LLM consumer cannot detect.

Reproduce (before this PR), MCP boundary on a real golden corpus file:
```
structure action=outline file=tests/golden/corpus_scala.scala
 -> {"success": true, "verdict": "INFO", "total_lines": 0,
     "summary_line": "...0 classes, 0 methods, 0 fields",
     "agent_summary": {"next_step": "extract_code_section for the method you need ..."}}
```
Scala is **not parseable at all** (`.scala` is extension-mapped by `language_detector`, but `tree-sitter-scala` is not installed). The engine returns `AnalysisResult(success=False, error_message="Unsupported language: scala")` **honestly** — but the structure tools only checked `result is None`, ignored `.success`, and fabricated a `success:true / 0-symbols` envelope (even pointing the agent at non-existent methods). This poisons every downstream decision built on structure (`safe_to_edit`, `dependencies`, `health`).

It is also a **CLI↔MCP parity violation**: the CLI already errors honestly on the same file (`ERROR: Analysis failed: Unsupported language: scala`).

## Root cause

`get_code_outline_tool._run_outline_analysis` and `analyze_code_structure_tool._analyze_structure` both did `result = await analyze(request); if result is None: raise; return result` — never honoring the engine's documented `success=False` flag.

## Fix

Both tools now propagate `analysis_result.success == False` by raising with the engine's `error_message`. The MCP boundary maps a message containing "Unsupported language" to `error_type=language_unsupported` — the exact honest `ERROR` envelope Bash already gets. **Legitimately-empty files** (parse succeeds, 0 elements) still return `success:true` — verified.

After:
```
SCALA outline/analyze -> success=False verdict=ERROR error_type=language_unsupported
JAVA  outline/analyze -> success=True  verdict=INFO   (8 classes, 26 methods)  # unaffected
empty .py             -> success=True                                          # unaffected
```

## Tests

- RED-first regression: `tests/unit/mcp/test_structure_unparseable_language.py` (failed before, passes after).
- Full suite green: **18530 passed, 92 skipped, 1 xfailed**. `ruff` + `mypy` clean.

## Scope / not in this PR

This is the **systemic masking fix** (Theme D core). Two related, *separately-tracked* items are intentionally out of scope:
- Installing `tree-sitter-scala` / `tree-sitter-bash` grammars to actually *support* those languages (feature; bash/scala are already listed as `SCAFFOLDS_WITHOUT_EXT` in `test_lang_extension_map.py`).
- Adding `.sh` → bash extension wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)