### PR TITLE
fix(scale): honor parse-failure on Java paths of scale/universal analyze tools (Theme-D follow-up)

### DIFF
--- a/tests/unit/mcp/test_scale_tools_honest_parse_failure.py
+++ b/tests/unit/mcp/test_scale_tools_honest_parse_failure.py
@@ -1,0 +1,64 @@
+"""Scale/universal analyze tools must honor the engine's parse-failure flag
+on their Java code-paths instead of masking it as an empty-success result.
+
+Follow-up to PR #414 (Theme-D). The structure facade was fixed there; this
+covers the same masking class in the Java branches of:
+  - ``analyze_scale_tool.AnalyzeScaleTool._run_structural_analysis``
+  - ``universal_analyze_tool.UniversalAnalyzeTool._analyze_advanced``
+
+Both only checked ``result is None`` and then proceeded, so a
+``AnalysisResult(success=False, ...)`` from the engine was stamped
+``success: True`` with zero counts. The Java grammar is installed, so this is
+only reachable by a real engine failure (read error, etc.) — exercised here by
+mocking the engine to return ``success=False``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tree_sitter_analyzer.models.result import AnalysisResult
+
+
+def _failed_result() -> AnalysisResult:
+    return AnalysisResult(
+        file_path="examples/Sample.java",
+        language="java",
+        success=False,
+        error_message="Failed to parse file: examples/Sample.java",
+        elements=[],
+    )
+
+
+@pytest.mark.asyncio
+async def test_scale_tool_java_path_honors_parse_failure() -> None:
+    from tree_sitter_analyzer.mcp.tools.analyze_scale_tool import AnalyzeScaleTool
+
+    tool = AnalyzeScaleTool(project_root=".")
+
+    async def _fake_analyze(_request):  # noqa: ANN001
+        return _failed_result()
+
+    tool.analysis_engine.analyze = _fake_analyze  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError):
+        await tool._run_structural_analysis(
+            "examples/Sample.java", "java", include_details=True
+        )
+
+
+@pytest.mark.asyncio
+async def test_universal_tool_advanced_path_honors_parse_failure() -> None:
+    from tree_sitter_analyzer.mcp.tools.universal_analyze_tool import (
+        UniversalAnalyzeTool,
+    )
+
+    tool = UniversalAnalyzeTool(project_root=".")
+
+    async def _fake_analyze(_request):  # noqa: ANN001
+        return _failed_result()
+
+    tool.analysis_engine.analyze = _fake_analyze  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError):
+        await tool._analyze_advanced("examples/Sample.java", "java", "structure", {})

--- a/tree_sitter_analyzer/mcp/tools/analyze_scale_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/analyze_scale_tool.py
@@ -264,6 +264,11 @@ class AnalyzeScaleTool(BaseMCPTool):
             result = await _engine.analyze(request)
             if result is None:
                 raise RuntimeError(fail_prefix)
+            # Theme-D parity: honor the engine's parse-failure flag instead of
+            # masking it as an empty-success overview (matches the non-Java
+            # branch below and the structure-facade fix in PR #414).
+            if not result.success:
+                raise RuntimeError(result.error_message or fail_prefix)
             return result, self._extract_structural_overview(result)
 
         request = AnalysisRequest(

--- a/tree_sitter_analyzer/mcp/tools/universal_analyze_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/universal_analyze_tool.py
@@ -345,6 +345,14 @@ class UniversalAnalyzeTool(BaseMCPTool):
         result = await self.analysis_engine.analyze(request)
         if result is None:
             raise RuntimeError(f"Failed to analyze file: {file_path}")
+        # Theme-D parity: honor the engine's parse-failure flag instead of
+        # stamping ``success: True`` onto a failed analysis (matches the
+        # structure-facade fix in PR #414).
+        if not result.success:
+            raise RuntimeError(
+                getattr(result, "error_message", None)
+                or f"Failed to analyze file: {file_path}"
+            )
 
         base: dict[str, Any] = {
             "success": True,


### PR DESCRIPTION
Follow-up to #414. Closes the remaining masking in the **Theme-D** class found by the independent adversarial review of #414 (Findings 1 & 2).

## Problem
Two MCP tools ignored the engine's `success=False` flag on their **Java code-paths**:
- `analyze_scale_tool._run_structural_analysis` (Java branch) — only `if result is None`, then proceeds; `build_analysis_result` hardcodes `success:True`.
- `universal_analyze_tool._analyze_advanced` — only `if result is None`, then `base = {"success": True, ...}`.

So an `AnalysisResult(success=False)` from the engine was stamped `success:true` with zero counts — the same lie-to-the-agent masking #414 fixed for the structure facade. The Java grammar is installed, so this is only reachable by a *real* engine failure (read/encoding error, etc.), but it is a latent defect of the same class.

(The **non-Java** branch of `_run_structural_analysis` already had the correct `if not universal_result.success: raise` guard — this PR brings the Java branch to parity.)

## Fix
Both now `raise RuntimeError(error_message)` when `result.success is False`. The MCP boundary then produces an honest ERROR envelope instead of a fabricated empty-success.

## Tests
RED-first `tests/unit/mcp/test_scale_tools_honest_parse_failure.py` (mocks the engine to return `success=False`; **fails before** the fix, passes after). Full suite green (**18530 passed**). `ruff` + `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)