### PR TITLE
feat(bash): wire Bash language support end-to-end

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,7 @@ all-languages = [
     "tree-sitter-php>=0.23.0,<0.25.0",  # PHP language support for web applications
     "tree-sitter-ruby>=0.23.0,<0.25.0",  # Ruby language support for Rails and scripting
     "tree-sitter-yaml>=0.7.0",  # YAML language support for configuration files
+    "tree-sitter-bash>=0.23.0,<0.26.0",  # Bash/shell script support
 ]
 
 # MCP server support

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ dependencies = [
     "pyyaml>=6.0",
     "pathspec>=0.12.1",
     "anthropic>=0.104.1",
+    "tree-sitter-bash>=0.23.0",
 ]
 
 # Add C# to optional dependencies

--- a/tests/unit/cli/test_info_commands.py
+++ b/tests/unit/cli/test_info_commands.py
@@ -207,8 +207,9 @@ class TestQ3SupportedExtensionsParity:
         "extension",
         [
             ".scala",
-            ".sh",
-            ".bash",
+            # ".sh" / ".bash" graduated 2026-06-10: tree-sitter-bash is now a
+            # declared dependency and the extensions are wired end-to-end (see
+            # test_bash_language_wiring.py + test_core_extensions_still_advertised).
             ".lua",
             ".hs",
             ".dart",
@@ -226,10 +227,10 @@ class TestQ3SupportedExtensionsParity:
     )
     def test_orphan_extensions_not_advertised(self, detector_instance, extension):
         """Orphan-plugin / no-parser extensions must NOT appear in the
-        ``--show-supported-extensions`` output. ``scala_plugin.py`` and
-        ``bash_plugin.py`` ship in the source tree as work-in-progress, but
-        until the underlying tree-sitter dependency is wired in we must not
-        advertise their extensions to users."""
+        ``--show-supported-extensions`` output. ``scala_plugin.py`` ships in
+        the source tree as work-in-progress, but until the underlying
+        tree-sitter dependency is wired in we must not advertise its
+        extensions to users."""
         extensions = detector_instance.get_supported_extensions()
         assert extension not in extensions, (
             f"Extension {extension!r} is still advertised as supported but "
@@ -255,6 +256,9 @@ class TestQ3SupportedExtensionsParity:
             ".kt",
             ".swift",
             ".cs",
+            ".sh",
+            ".bash",
+            ".zsh",
             ".html",
             ".css",
             ".json",

--- a/tests/unit/test_bash_language_wiring.py
+++ b/tests/unit/test_bash_language_wiring.py
@@ -1,0 +1,81 @@
+"""Bash language wiring — graduation test for the SCAFFOLDS_WITHOUT_EXT TODO.
+
+2026-06-10: tree-sitter-bash grammar added as a dependency and ``.sh`` /
+``.bash`` / ``.zsh`` wired across the three extension maps
+(``language_detector`` / ``_lang_extension_map`` / ``file_handler``) plus the
+``language_loader`` module map. Before this, every shell file was either
+undetectable (CLI: "Could not detect language") or — worse — would have been
+masked as an empty-success by the structure tools (Theme D, fixed in #414).
+
+These tests pin the full chain: extension → detection → grammar load →
+extraction → ast_cache indexing.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+
+import pytest
+
+CORPUS = "tests/golden/corpus_bash.sh"
+
+
+@pytest.mark.parametrize("ext", [".sh", ".bash", ".zsh"])
+def test_extension_detects_bash(ext: str) -> None:
+    from tree_sitter_analyzer.language_detector import detect_language_from_file
+
+    assert detect_language_from_file(f"script{ext}") == "bash"
+
+
+def test_lang_extension_map_has_bash() -> None:
+    from tree_sitter_analyzer._lang_extension_map import EXT_TO_LANG
+
+    assert EXT_TO_LANG.get(".sh") == "bash"
+    assert EXT_TO_LANG.get(".bash") == "bash"
+    assert EXT_TO_LANG.get(".zsh") == "bash"
+
+
+def test_loader_provides_bash_language() -> None:
+    from tree_sitter_analyzer.language_loader import loader
+
+    assert loader.is_language_available("bash"), (
+        "tree-sitter-bash must be importable (declared dependency)"
+    )
+    assert loader.load_language("bash") is not None
+
+
+def test_bash_corpus_extracts_functions() -> None:
+    """The golden bash corpus must yield its function definitions."""
+    import tree_sitter
+
+    from tree_sitter_analyzer.languages.bash_plugin import BashPlugin
+
+    plugin = BashPlugin()
+    lang = plugin.get_tree_sitter_language()
+    assert lang is not None
+    parser = tree_sitter.Parser(lang)
+    with open(CORPUS, "rb") as f:
+        src = f.read()
+    tree = parser.parse(src)
+    elements = plugin.extract_elements(tree, src.decode())
+    # corpus_bash_expected.json records 11 function_definition nodes.
+    assert len(elements["functions"]) == 11
+
+
+def test_ast_cache_indexes_sh_file() -> None:
+    """The project indexer must index .sh files without errors."""
+    from tree_sitter_analyzer.ast_cache import ASTCache
+
+    d = tempfile.mkdtemp()
+    try:
+        shutil.copy(CORPUS, os.path.join(d, "deploy.sh"))
+        cache = ASTCache(d)
+        cache.index_project()
+        conn = cache.get_conn()
+        count = conn.execute("SELECT COUNT(*) FROM ast_symbol_rows").fetchone()[0]
+        assert count >= 11, f"expected >=11 bash symbols indexed, got {count}"
+        cache.close()
+    finally:
+        shutil.rmtree(d, ignore_errors=True)

--- a/tests/unit/test_bash_language_wiring.py
+++ b/tests/unit/test_bash_language_wiring.py
@@ -61,7 +61,9 @@ def test_bash_corpus_extracts_functions() -> None:
     tree = parser.parse(src)
     elements = plugin.extract_elements(tree, src.decode())
     # corpus_bash_expected.json records 11 function_definition nodes.
-    assert len(elements["functions"]) == 11
+    # Lower bound (not ==) so minor grammar-version drift doesn't flake;
+    # the golden corpus test pins the exact histogram.
+    assert len(elements["functions"]) >= 10
 
 
 def test_ast_cache_indexes_sh_file() -> None:

--- a/tests/unit/test_lang_extension_map.py
+++ b/tests/unit/test_lang_extension_map.py
@@ -37,7 +37,9 @@ PLUGIN_DIR = Path("tree_sitter_analyzer/languages")
 SCAFFOLDS_WITHOUT_EXT: set[str] = {
     # Code-targeted plugins waiting for ext wiring (tree-sitter parsers
     # available on PyPI; plugin scaffolds in place; needs validation pass).
-    "bash",
+    # NOTE: "bash" graduated 2026-06-10 — tree-sitter-bash dep added,
+    # .sh/.bash/.zsh wired in language_detector + _lang_extension_map +
+    # file_handler.
     "scala",
     "json",
     # Data / markup plugins. Reachable via the CLI single-file path

--- a/tree_sitter_analyzer/_lang_extension_map.py
+++ b/tree_sitter_analyzer/_lang_extension_map.py
@@ -40,6 +40,7 @@ from pathlib import Path
 # so diffs are obvious in code review.
 EXT_TO_LANG: dict[str, str] = {
     # Code languages — symbol-bearing, used by call graph + impact tools.
+    ".bash": "bash",
     ".c": "c",
     ".cc": "cpp",
     ".cpp": "cpp",
@@ -57,6 +58,7 @@ EXT_TO_LANG: dict[str, str] = {
     ".py": "python",
     ".rb": "ruby",
     ".rs": "rust",
+    ".sh": "bash",
     ".swift": "swift",
     # .swiftinterface — module-interface files emitted by
     # `swiftc -emit-module-interface`. Syntactically a subset of Swift,
@@ -66,6 +68,7 @@ EXT_TO_LANG: dict[str, str] = {
     ".swiftinterface": "swift",
     ".ts": "typescript",
     ".tsx": "typescript",
+    ".zsh": "bash",
     # NOTE: ``.css / .html / .md / .sql / .yaml / .yml`` have plugins
     # but are intentionally NOT wired here — their indexing path through
     # the ast_cache is not fully exercised yet (see

--- a/tree_sitter_analyzer/file_handler.py
+++ b/tree_sitter_analyzer/file_handler.py
@@ -60,6 +60,9 @@ def detect_language_from_extension(file_path: str) -> str:
         ".scala": "scala",
         ".swift": "swift",
         ".swiftinterface": "swift",
+        ".sh": "bash",
+        ".bash": "bash",
+        ".zsh": "bash",
     }
 
     return extension_map.get(extension, "unknown")

--- a/tree_sitter_analyzer/language_detector.py
+++ b/tree_sitter_analyzer/language_detector.py
@@ -55,6 +55,10 @@ class LanguageDetector:
         ".go": "go",
         ".rb": "ruby",
         ".php": "php",
+        # Shell スクリプト(BashPlugin が .zsh も bash 文法で解析する)
+        ".sh": "bash",
+        ".bash": "bash",
+        ".zsh": "bash",
         ".kt": "kotlin",
         ".kts": "kotlin",
         ".swift": "swift",
@@ -135,6 +139,7 @@ class LanguageDetector:
         "php",
         "ruby",
         "swift",
+        "bash",
         "markdown",
         "html",
         "css",

--- a/tree_sitter_analyzer/language_loader.py
+++ b/tree_sitter_analyzer/language_loader.py
@@ -66,6 +66,7 @@ class LanguageLoader:
         "ruby": "tree_sitter_ruby",
         "kotlin": "tree_sitter_kotlin",
         "swift": "tree_sitter_swift",
+        "bash": "tree_sitter_bash",
     }
 
     # TypeScript特別処理（TypeScriptとTSX）

--- a/uv.lock
+++ b/uv.lock
@@ -2763,6 +2763,7 @@ dependencies = [
     { name = "psutil" },
     { name = "pyyaml" },
     { name = "tree-sitter" },
+    { name = "tree-sitter-bash" },
     { name = "tree-sitter-c" },
     { name = "tree-sitter-c-sharp" },
     { name = "tree-sitter-cpp" },
@@ -3124,6 +3125,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5.0" },
     { name = "ruff", marker = "extra == 'full'", specifier = ">=0.5.0" },
     { name = "tree-sitter", specifier = ">=0.25.0" },
+    { name = "tree-sitter-bash", specifier = ">=0.23.0" },
     { name = "tree-sitter-c", specifier = ">=0.20.0" },
     { name = "tree-sitter-c", marker = "extra == 'all'", specifier = ">=0.20.0,<0.25.0" },
     { name = "tree-sitter-c", marker = "extra == 'all-languages'", specifier = ">=0.20.0,<0.25.0" },
@@ -3261,6 +3263,22 @@ dev = [
     { name = "types-pyyaml" },
     { name = "types-requests", specifier = ">=2.32.4.20250913" },
     { name = "types-toml", specifier = ">=0.10.8.20240310" },
+]
+
+[[package]]
+name = "tree-sitter-bash"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/0e/f0108be910f1eef6499eabce517e79fe3b12057280ed398da67ce2426cba/tree_sitter_bash-0.25.1.tar.gz", hash = "sha256:bfc0bdaa77bc1e86e3c6652e5a6e140c40c0a16b84185c2b63ad7cd809b88f14", size = 419703, upload-time = "2025-12-02T17:01:08.849Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/8e/37e7364d9c9c58da89e05c510671d8c45818afd7b31c6939ab72f8dc6c04/tree_sitter_bash-0.25.1-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:0e6235f59e366d220dde7d830196bed597d01e853e44d8ccd1a82c5dd2500acf", size = 194160, upload-time = "2025-12-02T17:00:59.047Z" },
+    { url = "https://files.pythonhosted.org/packages/23/bb/2d2cfbb1f89aaeb1ec892624f069d92d058d06bb66f16b9ec9fb5873ab60/tree_sitter_bash-0.25.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:f4a34a6504c7c5b2a9b8c5c4065531dea19ca2c35026e706cf2eeeebe2c92512", size = 202659, upload-time = "2025-12-02T17:01:00.275Z" },
+    { url = "https://files.pythonhosted.org/packages/25/f0/1bb25519be27460255d3899db677313cfa1e6306988fbf456a3d7e211bbb/tree_sitter_bash-0.25.1-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e76c4cfb20b076552406782b7f8c2a3946835993df0a44df006de54b7030c7dc", size = 230596, upload-time = "2025-12-02T17:01:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/22/9f70bc3d3b942ab9fc0f89c1dc9e087519a3a94f64ae6b7377aae3a7a0f0/tree_sitter_bash-0.25.1-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3f484c4bb8796cde7a87ca351e6116f09653edac0eb3c6d238566359dd28b117", size = 231981, upload-time = "2025-12-02T17:01:02.859Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/c3/f1540e42cd41b323c6821e45e52e1aed6ed386209aad52db996f05703963/tree_sitter_bash-0.25.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:5e76af6df46d958c7f5b6d5884c9743218e3902a00ccb493ec92728b1084430b", size = 228364, upload-time = "2025-12-02T17:01:03.997Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a0/c3050a6277dfcac8c480f514dc4fe49f3f65f0eac68b4702cbaca2584e85/tree_sitter_bash-0.25.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a3332d71c7b7d5f78259b19d02d0ea111fcb82b72712ee4a93aaa5b226d3f0a8", size = 230074, upload-time = "2025-12-02T17:01:05.05Z" },
+    { url = "https://files.pythonhosted.org/packages/71/0f/203fe6b27211387f4b9ba8c4a321567ca4ded2624dae6ccdbd2b6e940e17/tree_sitter_bash-0.25.1-cp310-abi3-win_amd64.whl", hash = "sha256:52a6802d9218f86278aa3e8b459c3abdad67eed0fde1f9f13aca5b6c634217a6", size = 195574, upload-time = "2025-12-02T17:01:06.412Z" },
+    { url = "https://files.pythonhosted.org/packages/47/75/4ca1a9fabd8fb5aea78cea70f7837ce4dbf2afae115f62051e5fa99cba1c/tree_sitter_bash-0.25.1-cp310-abi3-win_arm64.whl", hash = "sha256:59115057ec2bae319e8082ff29559861045002964c3431ccb0fc92aa4bc9bccb", size = 191196, upload-time = "2025-12-02T17:01:07.486Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2820,6 +2820,7 @@ all = [
     { name = "types-psutil" },
 ]
 all-languages = [
+    { name = "tree-sitter-bash" },
     { name = "tree-sitter-c" },
     { name = "tree-sitter-c-sharp" },
     { name = "tree-sitter-cpp" },
@@ -3126,6 +3127,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'full'", specifier = ">=0.5.0" },
     { name = "tree-sitter", specifier = ">=0.25.0" },
     { name = "tree-sitter-bash", specifier = ">=0.23.0" },
+    { name = "tree-sitter-bash", marker = "extra == 'all-languages'", specifier = ">=0.23.0,<0.26.0" },
     { name = "tree-sitter-c", specifier = ">=0.20.0" },
     { name = "tree-sitter-c", marker = "extra == 'all'", specifier = ">=0.20.0,<0.25.0" },
     { name = "tree-sitter-c", marker = "extra == 'all-languages'", specifier = ">=0.20.0,<0.25.0" },


### PR DESCRIPTION
## What

Graduates **bash** from `SCAFFOLDS_WITHOUT_EXT` — a tracked TODO ("tree-sitter parsers available on PyPI; plugin scaffolds in place; needs validation pass"). `BashPlugin` (805 lines, full function extractor) already shipped; only the grammar dependency and extension wiring were missing, so **every shell file was undetectable** — TSA could not see its own 13 `.sh` scripts. This also extends the documented moat: codegraph does not index bash at all.

## Wiring (one entry per layer)

The layers must agree — the Scala phantom-empty bug fixed in #414 came precisely from these maps disagreeing:

| Layer | Change |
|---|---|
| `pyproject.toml` | `tree-sitter-bash>=0.23.0` dependency |
| `language_detector.py` | `.sh/.bash/.zsh → bash` + `"bash"` in `SUPPORTED_LANGUAGES` |
| `language_loader.py` | `LANGUAGE_MODULES["bash"] = tree_sitter_bash` |
| `_lang_extension_map.py` | `EXT_TO_LANG` entries (ast_cache indexer path) |
| `file_handler.py` | CLI single-file path entries |

## Verified end-to-end

- CLI `--advanced` on `corpus_bash.sh`: success, **11 functions**, 570 lines
- CLI on `scripts/branch-guard.sh` (own dogfood): success
- MCP `structure` outline/analyze: `"0 classes, 11 methods"` (honest data, was `language_unsupported` error before)
- `ast_cache` indexes `.sh`: 11 symbols + FTS rows, zero errors
- Golden corpus test `[bash]` **auto-activated** and passes (node-type histogram)
- `--show-supported-languages` / `--show-supported-extensions` sane (CLAUDE.md rule 7 check)

## Tests

- New `tests/unit/test_bash_language_wiring.py` pins the full chain (detection → grammar load → extraction → indexing).
- Updated the two inverse-guard tests whose own docstrings scoped them to "**until** the tree-sitter dependency is wired in": removed `.sh`/`.bash` from orphan-extensions, added `.sh`/`.bash`/`.zsh` to core-extensions-advertised.
- Removed `"bash"` from `SCAFFOLDS_WITHOUT_EXT` (with graduation note).

Full suite green: **18539 passed**. `ruff` + `mypy` clean.

## Out of scope (tracked follow-ups)

- bash **variable extraction** (explicit phase-stub in the plugin — Theme-E quality item)
- bash **call-edge extraction** (RFC-0010 resolver registry wave; README's "13 languages" claim is about the call-graph registry and remains accurate)
- **scala** graduation (needs tree-sitter-scala validation pass — next PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)