### PR TITLE
feat(java): extract record and annotation-type declarations (Theme I)

### DIFF
--- a/tests/unit/languages/test_java_record_annotation_extraction.py
+++ b/tests/unit/languages/test_java_record_annotation_extraction.py
@@ -1,0 +1,82 @@
+"""Theme-I regression: Java ``record`` and ``@interface`` (annotation type)
+declarations must appear in extraction output.
+
+2026-06-10 quality-audit finding: the extractor registration map and
+``_CLASS_TYPE_MAP`` only listed ``class_declaration`` / ``interface_declaration``
+/ ``enum_declaration``, so ``record_declaration`` and
+``annotation_type_declaration`` nodes (both top-level and nested) were silently
+dropped from outlines — an agent asking for the structure of a modern Java
+file never saw its records or annotation types.
+"""
+
+from __future__ import annotations
+
+import tree_sitter
+import tree_sitter_java
+
+from tree_sitter_analyzer.languages.java_plugin import JavaElementExtractor
+
+JAVA_SRC = """\
+package demo;
+
+public class Container {
+    public record Point(int x, int y) {
+        public double dist() { return Math.sqrt(x * x + y * y); }
+    }
+
+    public @interface Audited {
+        String value() default "";
+    }
+
+    public enum Color { RED, GREEN }
+
+    void use() {}
+}
+
+record TopLevelRecord(String name, int age) {}
+
+@interface TopLevelAnno { int level(); }
+"""
+
+
+def _extract_classes() -> dict[str, str]:
+    lang = tree_sitter.Language(tree_sitter_java.language())
+    parser = tree_sitter.Parser(lang)
+    tree = parser.parse(JAVA_SRC.encode())
+    extractor = JavaElementExtractor()
+    classes = extractor.extract_classes(tree, JAVA_SRC)
+    return {c.name: c.class_type for c in classes}
+
+
+def test_record_declarations_extracted() -> None:
+    found = _extract_classes()
+    assert "Point" in found, f"nested record missing; got {sorted(found)}"
+    assert "TopLevelRecord" in found, f"top-level record missing; got {sorted(found)}"
+    assert found["Point"] == "record"
+    assert found["TopLevelRecord"] == "record"
+
+
+def test_annotation_type_declarations_extracted() -> None:
+    found = _extract_classes()
+    assert "Audited" in found, f"nested @interface missing; got {sorted(found)}"
+    assert "TopLevelAnno" in found, f"top-level @interface missing; got {sorted(found)}"
+    assert found["Audited"] == "annotation"
+    assert found["TopLevelAnno"] == "annotation"
+
+
+def test_existing_kinds_unchanged() -> None:
+    """The graduation must not disturb class/enum extraction."""
+    found = _extract_classes()
+    assert found.get("Container") == "class"
+    assert found.get("Color") == "enum"
+
+
+def test_record_method_still_extracted() -> None:
+    """Methods inside a record body must be visible as functions."""
+    lang = tree_sitter.Language(tree_sitter_java.language())
+    parser = tree_sitter.Parser(lang)
+    tree = parser.parse(JAVA_SRC.encode())
+    extractor = JavaElementExtractor()
+    functions = extractor.extract_functions(tree, JAVA_SRC)
+    names = {f.name for f in functions}
+    assert "dist" in names, f"record method missing; got {sorted(names)}"

--- a/tree_sitter_analyzer/languages/_java_element_helpers.py
+++ b/tree_sitter_analyzer/languages/_java_element_helpers.py
@@ -10,6 +10,9 @@ _CLASS_TYPE_MAP = {
     "class_declaration": "class",
     "interface_declaration": "interface",
     "enum_declaration": "enum",
+    # Theme-I (2026-06-10): record / annotation-type containers.
+    "record_declaration": "record",
+    "annotation_type_declaration": "annotation",
 }
 
 

--- a/tree_sitter_analyzer/languages/_java_traversal_helpers.py
+++ b/tree_sitter_analyzer/languages/_java_traversal_helpers.py
@@ -12,6 +12,12 @@ _JAVA_CONTAINER_NODES = {
     "class_declaration",
     "interface_declaration",
     "enum_declaration",
+    # Theme-I (2026-06-10): descend into records and annotation types so
+    # their members (e.g. a record's methods) are reachable. A record's body
+    # is a plain ``class_body``; annotation types use ``annotation_type_body``.
+    "record_declaration",
+    "annotation_type_declaration",
+    "annotation_type_body",
     "method_declaration",
     "constructor_declaration",
     "block",

--- a/tree_sitter_analyzer/languages/java_plugin.py
+++ b/tree_sitter_analyzer/languages/java_plugin.py
@@ -165,6 +165,10 @@ class JavaElementExtractor(ElementExtractor):
             "class_declaration": self._extract_class_optimized,
             "interface_declaration": self._extract_class_optimized,
             "enum_declaration": self._extract_class_optimized,
+            # Theme-I (2026-06-10): records and annotation types were silently
+            # dropped from outlines — modern Java DTOs/annotations invisible.
+            "record_declaration": self._extract_class_optimized,
+            "annotation_type_declaration": self._extract_class_optimized,
         }
 
         self._traverse_and_extract_iterative(


### PR DESCRIPTION
## Problem (Theme-I quality-audit finding, CLI-verified)

`record_declaration` and `annotation_type_declaration` nodes — **top-level AND nested** — were silently dropped from Java extraction. A modern Java file's records/DTOs and custom annotations were invisible in outlines, and **methods inside record bodies were also lost** because the traversal whitelist (`_JAVA_CONTAINER_NODES`) pruned at the unregistered container.

Repro (before): a file with `record Point`, `@interface Audited`, `record TopLevelRecord`, `@interface TopLevelAnno` → extraction returns only `Container(class)`, `Color(enum)`, `Shape(interface)`; the record's `dist()` method is missing too.

## Fix — three one-map changes

| File | Change |
|---|---|
| `java_plugin.py` extractors | register `record_declaration` + `annotation_type_declaration` → `_extract_class_optimized` |
| `_java_element_helpers.py` `_CLASS_TYPE_MAP` | `"record"` / `"annotation"` class kinds |
| `_java_traversal_helpers.py` `_JAVA_CONTAINER_NODES` | descend into `record_declaration` / `annotation_type_declaration` / `annotation_type_body` (a record's body is a plain `class_body`) |

## After (E2E CLI)

```
classes: Container(class), Point(record), Audited(annotation), Color(enum),
         Shape(interface), TopLevelRecord(record), TopLevelAnno(annotation)
functions: dist, area, use   # record-body method now visible
```

## Tests

RED-first `tests/unit/languages/test_java_record_annotation_extraction.py`: nested+top-level records, nested+top-level `@interface`, record-body methods, and class/enum extraction untouched. Failed 3/4 before the fix; all pass after.

Full suite green: **18537 passed**. `ruff` + `mypy` clean. (Note: java_plugin.py is a known negative-fixture for some tests — changes here are additive map entries only, no refactoring; full suite confirms no fixture breakage.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)