### PR TITLE
feat(kotlin): class-kind fidelity — annotation/data/enum/sealed (Theme I)

### DIFF
--- a/tests/golden_masters/csv/kotlin_sample_csv.csv
+++ b/tests/golden_masters/csv/kotlin_sample_csv.csv
@@ -3,11 +3,11 @@
 ## Classes & Objects
 | Name | Type | Visibility | Lines | Props | Methods |
 |------|------|------------|-------|-------|---------|
-| User | class | public | 8-13 | 0 | 0 |
+| User | data | public | 8-13 | 0 | 0 |
 | Displayable | interface | public | 15-21 | 0 | 2 |
-| Result | class | public | 23-26 | 0 | 0 |
-| Success | class | public | 24-24 | 0 | 0 |
-| Error | class | public | 25-25 | 0 | 0 |
+| Result | sealed | public | 23-26 | 0 | 0 |
+| Success | data | public | 24-24 | 0 | 0 |
+| Error | data | public | 25-25 | 0 | 0 |
 | UserManager | class | public | 28-45 | 1 | 3 |
 | Config | object | public | 47-50 | 2 | 0 |
 | LegacyUserManager | class | public | 57-60 | 0 | 1 |

--- a/tests/golden_masters/full/kotlin_sample_full.md
+++ b/tests/golden_masters/full/kotlin_sample_full.md
@@ -3,11 +3,11 @@
 ## Classes & Objects
 | Name | Type | Visibility | Lines | Props | Methods |
 |------|------|------------|-------|-------|---------|
-| User | class | public | 8-13 | 0 | 0 |
+| User | data | public | 8-13 | 0 | 0 |
 | Displayable | interface | public | 15-21 | 0 | 2 |
-| Result | class | public | 23-26 | 0 | 0 |
-| Success | class | public | 24-24 | 0 | 0 |
-| Error | class | public | 25-25 | 0 | 0 |
+| Result | sealed | public | 23-26 | 0 | 0 |
+| Success | data | public | 24-24 | 0 | 0 |
+| Error | data | public | 25-25 | 0 | 0 |
 | UserManager | class | public | 28-45 | 1 | 3 |
 | Config | object | public | 47-50 | 2 | 0 |
 | LegacyUserManager | class | public | 57-60 | 0 | 1 |

--- a/tests/unit/languages/test_kotlin_class_kind_fidelity.py
+++ b/tests/unit/languages/test_kotlin_class_kind_fidelity.py
@@ -1,0 +1,81 @@
+"""Theme-I regression: Kotlin class-kind fidelity.
+
+2026-06-10 quality-audit finding: ``extract_kotlin_class_or_object`` only
+distinguished class/interface/object, so ``annotation class`` / ``data class``
+/ ``enum class`` / ``sealed class`` all surfaced as ``class_type="class"`` —
+an agent could not tell a DTO from an enum from an annotation in outlines
+(Java reports enum/annotation/record kinds correctly; Kotlin lagged).
+
+Known UPSTREAM limitation (documented, not fixed here): tree-sitter-kotlin
+1.1.0 mis-parses an *annotated* ``annotation class`` (e.g. ``@Target(...)
+annotation class X``) as an ``annotated_expression`` instead of a
+``class_declaration``, so such declarations cannot be extracted at all until
+the grammar is fixed. Plain ``annotation class X`` parses fine and is covered
+here.
+"""
+
+from __future__ import annotations
+
+import tree_sitter
+import tree_sitter_kotlin
+
+from tree_sitter_analyzer.languages.kotlin_plugin import KotlinElementExtractor
+
+KOTLIN_SRC = """\
+package demo
+
+annotation class Audited(val value: String = "")
+
+class Container {
+    annotation class Nested
+
+    data class Point(val x: Int, val y: Int)
+
+    enum class Color { RED, GREEN }
+
+    sealed class State
+
+    object Singleton
+
+    fun use() {}
+}
+
+interface Shape { fun area(): Double }
+"""
+
+
+def _extract_classes() -> dict[str, str]:
+    lang = tree_sitter.Language(tree_sitter_kotlin.language())
+    parser = tree_sitter.Parser(lang)
+    tree = parser.parse(KOTLIN_SRC.encode())
+    extractor = KotlinElementExtractor()
+    classes = extractor.extract_classes(tree, KOTLIN_SRC)
+    return {c.name: c.class_type for c in classes}
+
+
+def test_annotation_class_kind() -> None:
+    found = _extract_classes()
+    assert found.get("Audited") == "annotation", f"got {found.get('Audited')!r}"
+    assert found.get("Nested") == "annotation", f"got {found.get('Nested')!r}"
+
+
+def test_data_class_kind() -> None:
+    found = _extract_classes()
+    assert found.get("Point") == "data", f"got {found.get('Point')!r}"
+
+
+def test_enum_class_kind() -> None:
+    found = _extract_classes()
+    assert found.get("Color") == "enum", f"got {found.get('Color')!r}"
+
+
+def test_sealed_class_kind() -> None:
+    found = _extract_classes()
+    assert found.get("State") == "sealed", f"got {found.get('State')!r}"
+
+
+def test_plain_kinds_unchanged() -> None:
+    found = _extract_classes()
+    assert found.get("Container") == "class"
+    assert found.get("Shape") == "interface"
+    assert found.get("Singleton") == "object"

--- a/tree_sitter_analyzer/languages/kotlin_helpers.py
+++ b/tree_sitter_analyzer/languages/kotlin_helpers.py
@@ -140,6 +140,25 @@ def extract_kotlin_function(
 
 
 # Extract elements from AST: extract_kotlin_class_or_object
+_KOTLIN_CLASS_KIND_MODIFIERS = frozenset({"enum", "annotation", "data", "sealed"})
+
+
+def _refine_kotlin_class_kind(node: Any, get_node_text: Callable[..., str]) -> str:
+    """Return the declaration kind from the class_modifier, if any.
+
+    ``enum class`` / ``annotation class`` / ``data class`` / ``sealed class``
+    carry their kind as a ``class_modifier`` token under ``modifiers``.
+    """
+    for child in node.children:
+        if child.type != "modifiers":
+            continue
+        for modifier in child.children:
+            text = get_node_text(modifier)
+            if text in _KOTLIN_CLASS_KIND_MODIFIERS:
+                return str(text)
+    return "class"
+
+
 def extract_kotlin_class_or_object(
     node: Any,
     kind: str,
@@ -173,6 +192,14 @@ def extract_kotlin_class_or_object(
                     break
                 elif child.type == "class":
                     break
+            # Theme-I (2026-06-10): class-kind fidelity. The grammar exposes
+            # the declaration kind as a ``class_modifier`` inside ``modifiers``
+            # ("enum class" / "annotation class" / "data class" /
+            # "sealed class"); without this an agent could not tell a DTO from
+            # an enum from an annotation in outlines. "inner" / "open" etc.
+            # are nesting/inheritance modifiers, not kinds — left as "class".
+            if kind == "class":
+                kind = _refine_kotlin_class_kind(node, get_node_text)
 
         raw_text = get_node_text(node)
 


### PR DESCRIPTION
## Problem (Theme-I quality-audit finding, CLI-verified)

`extract_kotlin_class_or_object` only distinguished class/interface/object, so `annotation class` / `data class` / `enum class` / `sealed class` **all surfaced as `class_type="class"`** — an agent could not tell a DTO from an enum from an annotation in outlines. (Java reports enum/annotation/record kinds correctly after #418; Kotlin lagged.)

## Fix

Read the declaration kind from the grammar's `class_modifier` token under `modifiers` (`enum`/`annotation`/`data`/`sealed`); nesting/inheritance modifiers (`inner`/`open`/…) stay `"class"`. One new helper `_refine_kotlin_class_kind` in `kotlin_helpers.py`.

## After (E2E CLI)

```
Audited(annotation), Nested(annotation), Point(data), Color(enum),
State(sealed), Container(class), Shape(interface), Singleton(object)
```

Golden masters regenerated (`kotlin_sample` full+csv): `User→data`, `Result→sealed`, `Success/Error→data` — **the golden diff IS the fidelity improvement** (old masters pinned the wrong kinds).

## Documented upstream limitation (NOT fixed here)

tree-sitter-kotlin 1.1.0 (latest on PyPI) mis-parses an **annotated** `annotation class` (e.g. `@Target(...) annotation class X`, any layout) as `annotated_expression`, not `class_declaration` — verified with isolated grammar runs; `@Serializable data class` is fine, only the `annotation` soft keyword triggers it. Such declarations are unextractable until the upstream grammar fixes the ambiguity; a plugin-side regex workaround would violate correctness-first. Plain `annotation class` works and is covered by tests.

## Tests

RED-first `tests/unit/languages/test_kotlin_class_kind_fidelity.py` (4 failed before, all pass after; plain kinds pinned unchanged). Full suite green: **18544 passed**. `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)