### PR TITLE
test: exact-assertion rule (locked) — replace >= pins with == in new wiring tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,19 @@
 - Keep files under 500 lines
 - Validate input at system boundaries
 
+### Exact assertions only — no `>=` / approximate test assertions
+
+**🔒 LOCKED BY USER (2026-06-10):** 「测试拒绝大于等于这样的约等不严谨的测试」。
+Count/measurement assertions in tests MUST pin the **exact** expected value
+(`== 11`), never a loose bound (`>= 10`, `> 0`, `<= 100`) that lets drift pass
+silently. If an upstream change (e.g. a grammar-version bump) shifts the
+number, the test SHOULD go red and force a conscious re-pin with the new
+measured value — an approximate green is a false green. Reviewer suggestions
+to "relax to a lower bound for resilience" are REJECTED under this rule.
+Legitimate exceptions are rare and only where the value is genuinely
+nondeterministic (timing, memory) — and then the test should assert a
+documented invariant, not a hand-waved bound on a deterministic count.
+
 ## Deliberate design decisions — do NOT "fix" these
 
 These look like inconsistencies in a dogfood pass, but they are intentional and reflect the project's design priorities. Reverting them costs real value. **If a dogfood agent proposes any of the items below as a "finding", REJECT the finding and link the agent back to this section.**

--- a/tests/unit/mcp/test_structure_unparseable_language.py
+++ b/tests/unit/mcp/test_structure_unparseable_language.py
@@ -119,8 +119,8 @@ async def test_structure_boundary_classifies_as_language_unsupported() -> None:
 
             inner.analysis_engine.analyze = _fake_analyze  # type: ignore[attr-defined]
             patched += 1
-    assert patched >= 2, (
-        f"expected to patch outline+analyze inner tools, patched {patched}"
+    assert patched == 2, (
+        f"expected to patch exactly the outline+analyze inner tools, patched {patched}"
     )
 
     async def boundary(name: str, args: dict) -> dict:

--- a/tests/unit/test_bash_language_wiring.py
+++ b/tests/unit/test_bash_language_wiring.py
@@ -61,9 +61,10 @@ def test_bash_corpus_extracts_functions() -> None:
     tree = parser.parse(src)
     elements = plugin.extract_elements(tree, src.decode())
     # corpus_bash_expected.json records 11 function_definition nodes.
-    # Lower bound (not ==) so minor grammar-version drift doesn't flake;
-    # the golden corpus test pins the exact histogram.
-    assert len(elements["functions"]) >= 10
+    # Exact pin (user rule 2026-06-10: no >=-style approximate assertions) —
+    # a grammar-version bump that changes this count MUST fail the test and
+    # force a conscious re-pin, not pass silently.
+    assert len(elements["functions"]) == 11
 
 
 def test_ast_cache_indexes_sh_file() -> None:
@@ -77,7 +78,7 @@ def test_ast_cache_indexes_sh_file() -> None:
         cache.index_project()
         conn = cache.get_conn()
         count = conn.execute("SELECT COUNT(*) FROM ast_symbol_rows").fetchone()[0]
-        assert count >= 11, f"expected >=11 bash symbols indexed, got {count}"
+        assert count == 11, f"expected exactly 11 bash symbols indexed, got {count}"
         cache.close()
     finally:
         shutil.rmtree(d, ignore_errors=True)

--- a/tests/unit/test_scala_language_wiring.py
+++ b/tests/unit/test_scala_language_wiring.py
@@ -70,12 +70,13 @@ def test_scala_corpus_extracts_symbols() -> None:
     tree = parser.parse(src)
     assert not tree.root_node.has_error, "corpus must parse cleanly"
     elements = plugin.extract_elements(tree, src.decode())
-    # Validated 2026-06-10 against tree-sitter-scala 0.26: 66 functions,
-    # 33 classes, 3 imports. Assert lower bounds so minor grammar-version
-    # drift doesn't flake the suite.
-    assert len(elements["functions"]) >= 50
-    assert len(elements["classes"]) >= 25
-    assert len(elements["imports"]) >= 3
+    # Validated 2026-06-10 against tree-sitter-scala 0.26. Exact pins
+    # (user rule 2026-06-10: no >=-style approximate assertions) — a
+    # grammar-version bump that changes these counts MUST fail the test
+    # and force a conscious re-pin, not pass silently.
+    assert len(elements["functions"]) == 66
+    assert len(elements["classes"]) == 33
+    assert len(elements["imports"]) == 3
 
 
 def test_ast_cache_indexes_scala_file() -> None:
@@ -89,7 +90,7 @@ def test_ast_cache_indexes_scala_file() -> None:
         cache.index_project()
         conn = cache.get_conn()
         count = conn.execute("SELECT COUNT(*) FROM ast_symbol_rows").fetchone()[0]
-        assert count >= 50, f"expected >=50 scala symbols indexed, got {count}"
+        assert count == 86, f"expected exactly 86 scala symbols indexed, got {count}"
         cache.close()
     finally:
         shutil.rmtree(d, ignore_errors=True)


### PR DESCRIPTION
## What

**User-locked rule (2026-06-10):**「测试拒绝大于等于这样的约等不严谨的测试」— tests must reject `>=`-style approximate assertions. A deterministic count pinned with a loose lower bound lets upstream drift (e.g. a grammar-version bump) pass silently as a **false green**; an exact pin forces the test red and a conscious re-pin with the newly measured value.

## Changes

- **CLAUDE.md**: new locked Rules entry *"Exact assertions only — no `>=` / approximate test assertions"* (reviewer suggestions to relax-for-resilience are REJECTED under this rule).
- `test_bash_language_wiring.py`: `functions >= 10` → `== 11`; `indexed >= 11` → `== 11`
- `test_scala_language_wiring.py`: `functions >= 50` → `== 66`; `classes >= 25` → `== 33`; `imports >= 3` → `== 3`; `indexed >= 50` → `== 86` (freshly measured)
- `test_structure_unparseable_language.py`: `patched >= 2` → `== 2`

This **reverses adversarial-review Finding 5** from the #416 review (which suggested relaxing `== 11` → `>= 10` for drift-resilience) — overruled by the user rule.

## Out of scope (tracked)

Repo-wide legacy sweep: **1124** pre-existing `>=`/`<=` numeric assertions in `tests/` predate this rule — a separate triage/audit (many may be legitimately nondeterministic; each needs a verdict, not a blind rewrite).

Full suite green: **18549 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)