### PR TITLE
feat(cpp): extract enum/enum-class and conversion operators (Theme I)

### DIFF
--- a/tests/golden_masters/full/cpp_sample_full.md
+++ b/tests/golden_masters/full/cpp_sample_full.md
@@ -19,6 +19,8 @@ using StringList = vector<string>;
 | Class | Type | Visibility | Lines | Methods | Fields |
 |-------|------|------------|-------|---------|--------|
 | Container | class | public | 31-45 | 5 | 0 |
+| Color | enum | public | 52-52 | 0 | 0 |
+| Status | enum_class | public | 55-59 | 0 | 0 |
 | Point | struct | public | 62-70 | 1 | 2 |
 | Shape | class | public | 73-83 | 4 | 0 |
 | Rectangle | class | public | 86-128 | 11 | 3 |
@@ -35,6 +37,8 @@ using StringList = vector<string>;
 | get | ():T | + | 37-37 | 5-6 | 2 | - |
 | set | (value:T):void | + | 38-41 | 5-6 | 1 | - |
 
+## Color (52-52)
+## Status (55-59)
 ## Point (62-70)
 ### Fields
 | Name | Type | Vis | Modifiers | Line | Doc |

--- a/tests/golden_masters/plugins/cpp.json
+++ b/tests/golden_masters/plugins/cpp.json
@@ -1,20 +1,22 @@
 {
   "counts_by_type": {
-    "Class": 6,
+    "Class": 8,
     "Function": 36,
     "Import": 8,
     "Package": 1,
     "Variable": 10
   },
-  "element_total": 61,
+  "element_total": 63,
   "names_by_type": {
     "Class": [
       "Circle",
+      "Color",
       "Container",
       "Point",
       "Printable",
       "Rectangle",
-      "Shape"
+      "Shape",
+      "Status"
     ],
     "Function": [
       "Circle",

--- a/tests/golden_masters/toon/cpp_sample_toon.toon
+++ b/tests/golden_masters/toon/cpp_sample_toon.toon
@@ -4,8 +4,10 @@ package:
   name: math
   line_range: (18, 47)
 classes:
-  [6]{name,visibility,line_range(a,b)}:
+  [8]{name,visibility,line_range(a,b)}:
     Container,public,(31,45)
+    Color,public,(52,52)
+    Status,public,(55,59)
     Point,public,(62,70)
     Shape,public,(73,83)
     Rectangle,public,(86,128)
@@ -72,7 +74,7 @@ imports:
     "using std::vector;",,"using std::vector;",false,false,(15,15),[],"using std::vector;"
     using StringList = vector<string>;,,using StringList = vector<string>;,false,false,(167,167),[],using StringList = vector<string>;
 statistics:
-  class_count: 6
+  class_count: 8
   method_count: 36
   field_count: 10
   import_count: 8

--- a/tests/unit/languages/test_cpp_enum_conversion_extraction.py
+++ b/tests/unit/languages/test_cpp_enum_conversion_extraction.py
@@ -1,0 +1,65 @@
+"""Theme-I regression: C++ ``enum`` / ``enum class`` and conversion operators.
+
+2026-06-10 quality-audit finding, CLI-verified: ``enum_specifier`` was not
+registered in the class extractor map, so plain enums AND scoped
+``enum class`` declarations were completely invisible in outlines. Conversion
+operators (``operator double() const``) parse as ``function_definition >
+operator_cast`` (no ``function_declarator``), which the signature parser
+couldn't name, so they vanished from the function list while ``operator+``
+(a normal declarator) survived.
+"""
+
+from __future__ import annotations
+
+import tree_sitter
+import tree_sitter_cpp
+
+from tree_sitter_analyzer.languages.cpp_plugin import CppElementExtractor
+
+CPP_SRC = """\
+enum Color { RED, GREEN };
+
+enum class Status : int { OK = 0, FAIL = 1 };
+
+class Meters {
+public:
+    explicit Meters(double v) : value(v) {}
+    operator double() const { return value; }
+    Meters operator+(const Meters& o) const { return Meters(value + o.value); }
+    double get() const { return value; }
+private:
+    double value;
+};
+"""
+
+
+def _extract():
+    lang = tree_sitter.Language(tree_sitter_cpp.language())
+    parser = tree_sitter.Parser(lang)
+    tree = parser.parse(CPP_SRC.encode())
+    extractor = CppElementExtractor()
+    classes = {c.name: c.class_type for c in extractor.extract_classes(tree, CPP_SRC)}
+    functions = {f.name for f in extractor.extract_functions(tree, CPP_SRC)}
+    return classes, functions
+
+
+def test_plain_enum_extracted() -> None:
+    classes, _ = _extract()
+    assert classes.get("Color") == "enum", f"got {sorted(classes)}"
+
+
+def test_enum_class_extracted() -> None:
+    classes, _ = _extract()
+    assert classes.get("Status") == "enum_class", f"got {sorted(classes)}"
+
+
+def test_conversion_operator_extracted() -> None:
+    _, functions = _extract()
+    assert "operator double" in functions, f"got {sorted(functions)}"
+
+
+def test_existing_extraction_unchanged() -> None:
+    classes, functions = _extract()
+    assert classes.get("Meters") == "class"
+    assert "operator+" in functions
+    assert "get" in functions

--- a/tests/unit/languages/test_cpp_enum_conversion_extraction.py
+++ b/tests/unit/languages/test_cpp_enum_conversion_extraction.py
@@ -63,3 +63,37 @@ def test_existing_extraction_unchanged() -> None:
     assert classes.get("Meters") == "class"
     assert "operator+" in functions
     assert "get" in functions
+
+
+def test_enum_extractor_exception_returns_none() -> None:
+    """An exploding node must be caught and yield None (error path).
+
+    The inner class extractor is stubbed to return a truthy result so the
+    explosion happens in the scoped-check loop and the enum extractor's OWN
+    except branch is the one exercised (not the inner extractor's catch).
+    """
+    from unittest.mock import Mock
+
+    extractor = CppElementExtractor()
+    extractor._extract_class_optimized = lambda n: Mock()  # type: ignore[method-assign]
+    node = Mock()
+    type(node).children = property(
+        lambda self: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+    assert extractor._extract_enum_optimized(node) is None
+
+
+def test_operator_cast_without_type_child_yields_no_name() -> None:
+    """operator_cast with no recognizable type child -> parser returns None."""
+    from unittest.mock import Mock
+
+    from tree_sitter_analyzer.languages._cpp_signature_helpers import (
+        parse_function_signature,
+    )
+
+    cast = Mock()
+    cast.type = "operator_cast"
+    cast.children = []  # no _TYPE_NODES_CPP child
+    node = Mock()
+    node.children = [cast]
+    assert parse_function_signature(node, lambda n: "", lambda n: []) is None

--- a/tree_sitter_analyzer/languages/_cpp_signature_helpers.py
+++ b/tree_sitter_analyzer/languages/_cpp_signature_helpers.py
@@ -103,6 +103,17 @@ def _apply_signature_child(
     if child.type == "function_declarator":
         _merge_declarator(parts, child, get_node_text, extract_params_fn)
         return
+    if child.type == "operator_cast":
+        # Theme-I (2026-06-10): conversion operator (``operator double()``).
+        # There is no function_declarator — the cast-target type doubles as
+        # both the name suffix and the return type.
+        for sub in child.children:
+            if sub.type in _TYPE_NODES_CPP:
+                type_text = get_node_text(sub)
+                parts.name = f"operator {type_text}"
+                parts.return_type = type_text
+                break
+        return
     if child.type == "reference_declarator":
         parts.return_type = _append_declarator_symbol(parts.return_type, "&")
         _merge_nested_declarator(parts, child, get_node_text, extract_params_fn)

--- a/tree_sitter_analyzer/languages/cpp_plugin.py
+++ b/tree_sitter_analyzer/languages/cpp_plugin.py
@@ -158,6 +158,9 @@ class CppElementExtractor(ElementExtractor):
             "class_specifier": self._extract_class_optimized,
             "struct_specifier": self._extract_struct_optimized,
             "union_specifier": self._extract_union_optimized,
+            # Theme-I (2026-06-10): plain enums and scoped ``enum class``
+            # were completely invisible in outlines.
+            "enum_specifier": self._extract_enum_optimized,
             "template_declaration": self._extract_template_class,
         }
 
@@ -353,6 +356,24 @@ class CppElementExtractor(ElementExtractor):
             return result
         except Exception as e:
             log_debug(f"Failed to extract union info: {e}")
+            return None
+
+    # Extract elements from AST: _extract_enum_optimized
+    def _extract_enum_optimized(self, node: tree_sitter.Node) -> Class | None:
+        """Extract enum / scoped enum-class information optimized.
+
+        Theme-I (2026-06-10): ``enum_specifier`` carries a ``class`` (or
+        ``struct``) keyword child when scoped — surfaced as ``enum_class``
+        so agents can tell scoped from unscoped enums.
+        """
+        try:
+            result = self._extract_class_optimized(node)
+            if result:
+                scoped = any(c.type in ("class", "struct") for c in node.children)
+                result.class_type = "enum_class" if scoped else "enum"
+            return result
+        except Exception as e:
+            log_debug(f"Failed to extract enum info: {e}")
             return None
 
     # Extract elements from AST: _extract_template_class


### PR DESCRIPTION
## Problem (Theme-I quality-audit finding, CLI-verified)

1. `enum_specifier` was not registered in the class extractor map → **plain enums AND scoped `enum class` declarations were completely invisible** in outlines.
2. Conversion operators (`operator double() const`) parse as `function_definition > operator_cast` (no `function_declarator`), which the signature parser couldn't name → **they vanished from the function list** while `operator+` (a normal declarator) survived.

## Fix

| File | Change |
|---|---|
| `cpp_plugin.py` | register `enum_specifier` → `_extract_enum_optimized` (mirrors struct/union pattern; `enum_class` when a `class`/`struct` keyword child marks it scoped, else `enum`) |
| `_cpp_signature_helpers.py` | `operator_cast` branch in `_apply_signature_child` — name `operator <type>`, return type `<type>` |

## After (E2E CLI)

```
classes: Color(enum), Status(enum_class), Meters(class), Point(struct),
         Number(union), Circle(class), Box(class)
functions: Meters, operator double, operator+, get, area, main
```

## Golden masters

Regenerated cpp sample goldens (plugin json + full/toon tables): diff = **+2 recovered classes** (the two enums that were invisible).

## Tests

RED-first `tests/unit/languages/test_cpp_enum_conversion_extraction.py` (3 failed before; all pass after; existing extraction pinned unchanged — exact assertions per the locked rule). Full suite green: **18558 passed**. `ruff` clean.

This completes the four pilot-flagged Theme-I container gaps: Java records/annotations (#418), Kotlin class-kinds (#419), TS namespaces (#421), C++ enums/conversion operators (this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)