### PR TITLE
test(typescript): cover extract_namespace branches + ambient module support

### DIFF
--- a/tests/unit/languages/test_typescript_namespace_extraction.py
+++ b/tests/unit/languages/test_typescript_namespace_extraction.py
@@ -81,3 +81,63 @@ def test_top_level_kinds_unchanged() -> None:
     assert found.get("Standalone") == "class"
     names = _extract_function_names()
     assert "run" in names
+
+
+def test_nested_namespace_name() -> None:
+    """``namespace A.B { }`` carries a nested_identifier name."""
+    extractor = TypeScriptElementExtractor()
+    lang = tree_sitter.Language(language_typescript())
+    parser = tree_sitter.Parser(lang)
+    src = "namespace A.B { export const x = 1; }\n"
+    classes = extractor.extract_classes(parser.parse(src.encode()), src)
+    names = {c.name: c.class_type for c in classes}
+    assert names.get("A.B") == "namespace"
+
+
+def test_ambient_string_module_name() -> None:
+    """``declare module "pkg" { }`` carries a string name — quotes stripped."""
+    extractor = TypeScriptElementExtractor()
+    lang = tree_sitter.Language(language_typescript())
+    parser = tree_sitter.Parser(lang)
+    src = 'declare module "my-pkg" { export function f(): void; }\n'
+    classes = extractor.extract_classes(parser.parse(src.encode()), src)
+    names = {c.name: c.class_type for c in classes}
+    assert names.get("my-pkg") == "namespace"
+
+
+def test_nameless_namespace_node_returns_none() -> None:
+    """A namespace node with no name child must be skipped, not crash."""
+    from unittest.mock import Mock
+
+    from tree_sitter_analyzer.languages.typescript_plugin._class_helpers import (
+        extract_namespace,
+    )
+
+    node = Mock()
+    node.start_point = (0, 0)
+    node.end_point = (0, 10)
+    node.children = []
+    assert (
+        extract_namespace(node, lambda n: "", lambda line: None, lambda n: False, "")
+        is None
+    )
+
+
+def test_namespace_extractor_exception_returns_none() -> None:
+    """An exploding node must be caught and yield None (error path)."""
+    from unittest.mock import Mock
+
+    from tree_sitter_analyzer.languages.typescript_plugin._class_helpers import (
+        extract_namespace,
+    )
+
+    node = Mock()
+    node.start_point = (0, 0)
+    node.end_point = (0, 10)
+    type(node).children = property(
+        lambda self: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+    assert (
+        extract_namespace(node, lambda n: "", lambda line: None, lambda n: False, "")
+        is None
+    )

--- a/tree_sitter_analyzer/languages/typescript_plugin/_traversal_helpers.py
+++ b/tree_sitter_analyzer/languages/typescript_plugin/_traversal_helpers.py
@@ -88,6 +88,9 @@ def _container_node_types() -> set[str]:
         "expression_statement",
         "internal_module",
         "module",
+        # ``declare module "pkg" {}`` wraps the module node in an
+        # ambient_declaration.
+        "ambient_declaration",
     }
 
 


### PR DESCRIPTION
Follow-up to #421 — its `codecov/patch` gate flagged uncovered branches of the new `extract_namespace` (and per project practice from #409/#412, coverage gaps get closed with real tests; I also note #421 was merged while that gate was red — process slip, fixed here and a no-batch-merge rule recorded).

## Changes

- **4 new tests**: nested namespace name (`namespace A.B`), nameless-node → `None` path, exception → `None` path, and ambient `declare module "pkg"` string-name path.
- The ambient test **exposed a real residual gap**: `ambient_declaration` was not in the traversal container whitelist, so `declare module "pkg" { ... }` (and everything inside) was *still* invisible after #421. Whitelisted now; the quote-stripping in `extract_namespace` handles the string name.

Full suite green: **18562 passed**. `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)