### PR TITLE
fix(inheritance): Ruby '<'-token superclass, PHP extends, serializer drop (Theme C)

### DIFF
--- a/tests/unit/languages/test_ruby_php_inheritance.py
+++ b/tests/unit/languages/test_ruby_php_inheritance.py
@@ -1,0 +1,109 @@
+"""Theme-C regression: Ruby and PHP inheritance capture.
+
+2026-06-10 quality-audit finding, CLI-verified:
+- Ruby: ``_find_ruby_superclass`` returned ``children[0]`` of the
+  ``superclass`` node — which is the ``<`` OPERATOR TOKEN, not the name.
+  ``class Dog < Animal`` reported ``superclass="<"`` (wrong data, worse
+  than missing).
+- PHP: ``extends`` / ``implements`` were never extracted — ``class Dog
+  extends Animal implements Walkable`` reported superclass=None,
+  interfaces=None.
+"""
+
+from __future__ import annotations
+
+import tree_sitter
+import tree_sitter_php
+import tree_sitter_ruby
+
+from tree_sitter_analyzer.languages.php_plugin import PHPElementExtractor
+from tree_sitter_analyzer.languages.ruby_plugin import RubyElementExtractor
+
+RUBY_SRC = """\
+class Animal; end
+
+module Walkable; end
+
+class Dog < Animal
+  include Walkable
+  def bark; end
+end
+
+class Scoped < Base::Animal
+end
+"""
+
+PHP_SRC = """\
+<?php
+interface Walkable {}
+interface Runnable {}
+class Animal {}
+class Dog extends Animal implements Walkable, Runnable {
+    public function bark() {}
+}
+"""
+
+
+def _ruby_classes() -> dict[str, object]:
+    lang = tree_sitter.Language(tree_sitter_ruby.language())
+    parser = tree_sitter.Parser(lang)
+    tree = parser.parse(RUBY_SRC.encode())
+    extractor = RubyElementExtractor()
+    return {c.name: c for c in extractor.extract_classes(tree, RUBY_SRC)}
+
+
+def _php_classes() -> dict[str, object]:
+    lang = tree_sitter.Language(tree_sitter_php.language_php())
+    parser = tree_sitter.Parser(lang)
+    tree = parser.parse(PHP_SRC.encode())
+    extractor = PHPElementExtractor()
+    return {c.name: c for c in extractor.extract_classes(tree, PHP_SRC)}
+
+
+def test_ruby_superclass_is_name_not_operator() -> None:
+    found = _ruby_classes()
+    assert found["Dog"].superclass == "Animal", (
+        f"got {found['Dog'].superclass!r} (the '<' operator bug)"
+    )
+
+
+def test_ruby_scoped_superclass() -> None:
+    found = _ruby_classes()
+    assert found["Scoped"].superclass == "Base::Animal", (
+        f"got {found['Scoped'].superclass!r}"
+    )
+
+
+def test_ruby_no_superclass_stays_none() -> None:
+    found = _ruby_classes()
+    assert found["Animal"].superclass is None
+
+
+def test_php_extends_captured() -> None:
+    found = _php_classes()
+    assert found["Dog"].superclass == "Animal", f"got {found['Dog'].superclass!r}"
+
+
+def test_php_implements_captured() -> None:
+    found = _php_classes()
+    assert found["Dog"].interfaces == ["Walkable", "Runnable"], (
+        f"got {found['Dog'].interfaces!r}"
+    )
+
+
+def test_php_no_inheritance_stays_empty() -> None:
+    found = _php_classes()
+    assert found["Animal"].superclass is None
+    assert not found["Animal"].interfaces
+
+
+def test_interfaces_survive_api_serialization() -> None:
+    """Theme-C tail: plugins collected interfaces but element_to_dict dropped
+    them (field missing from _OPTIONAL_ELEM_FIELDS) — agents never saw
+    implements/mixins for ANY language."""
+    from tree_sitter_analyzer._api_result_helpers import element_to_dict
+
+    dog = _php_classes()["Dog"]
+    as_dict = element_to_dict(dog)
+    assert as_dict.get("superclass") == "Animal"
+    assert as_dict.get("interfaces") == ["Walkable", "Runnable"]

--- a/tests/unit/languages/test_ruby_php_inheritance.py
+++ b/tests/unit/languages/test_ruby_php_inheritance.py
@@ -107,3 +107,19 @@ def test_interfaces_survive_api_serialization() -> None:
     as_dict = element_to_dict(dog)
     assert as_dict.get("superclass") == "Animal"
     assert as_dict.get("interfaces") == ["Walkable", "Runnable"]
+
+
+def test_php_interface_multi_extends_all_parents_captured() -> None:
+    """Review fix: ``interface I extends A, B`` must keep ALL parents —
+    the first pass routed only base_classes[0] to superclass and silently
+    dropped the rest (worse: it looked like single inheritance)."""
+    lang = tree_sitter.Language(tree_sitter_php.language_php())
+    parser = tree_sitter.Parser(lang)
+    src = "<?php\ninterface I extends A, B, C {}\n"
+    extractor = PHPElementExtractor()
+    classes = {
+        c.name: c for c in extractor.extract_classes(parser.parse(src.encode()), src)
+    }
+    iface = classes["I"]
+    assert iface.superclass is None
+    assert iface.interfaces == ["A", "B", "C"]

--- a/tests/unit/languages/test_ruby_php_inheritance.py
+++ b/tests/unit/languages/test_ruby_php_inheritance.py
@@ -123,3 +123,36 @@ def test_php_interface_multi_extends_all_parents_captured() -> None:
     iface = classes["I"]
     assert iface.superclass is None
     assert iface.interfaces == ["A", "B", "C"]
+
+
+def test_php_class_multi_extends_anomaly_preserved() -> None:
+    """``class C extends A, B`` is invalid PHP but parses error-tolerantly
+    with both names in base_clause — the extras are preserved in interfaces
+    rather than silently dropped."""
+    lang = tree_sitter.Language(tree_sitter_php.language_php())
+    parser = tree_sitter.Parser(lang)
+    src = "<?php\nclass C extends A, B {}\n"
+    extractor = PHPElementExtractor()
+    classes = {
+        c.name: c for c in extractor.extract_classes(parser.parse(src.encode()), src)
+    }
+    assert classes["C"].superclass == "A"
+    assert classes["C"].interfaces == ["B"]
+
+
+def test_ruby_superclass_with_only_operator_returns_none() -> None:
+    """Degenerate superclass node containing ONLY the '<' token (malformed
+    source) must yield None, not crash or return garbage."""
+    from unittest.mock import Mock
+
+    from tree_sitter_analyzer.languages.ruby_plugin import RubyElementExtractor
+
+    extractor = RubyElementExtractor()
+    op = Mock()
+    op.type = "<"
+    sup = Mock()
+    sup.type = "superclass"
+    sup.children = [op]
+    cls = Mock()
+    cls.children = [sup]
+    assert extractor._find_ruby_superclass(cls) is None

--- a/tree_sitter_analyzer/_api_result_helpers.py
+++ b/tree_sitter_analyzer/_api_result_helpers.py
@@ -19,6 +19,9 @@ _OPTIONAL_ELEM_FIELDS = [
     "is_method",
     "complexity_score",
     "superclass",
+    # Theme-C (2026-06-10): implements/mixins were collected by plugins but
+    # dropped here — agents never saw them.
+    "interfaces",
     "class_type",
     "visibility",
     "modifiers",

--- a/tree_sitter_analyzer/languages/php_helpers.py
+++ b/tree_sitter_analyzer/languages/php_helpers.py
@@ -178,6 +178,18 @@ def extract_php_class_element(
 
         # r37dt (dogfood): flatten nesting 6 → 3 via _collect_php_class_bases.
         base_classes, interfaces = _collect_php_class_bases(node, get_node_text)
+        # Theme-C review fix (2026-06-10): ``interface I extends A, B`` puts
+        # ALL parents in base_clause — for an interface they are parent
+        # interfaces, not a single superclass; routing only [0] to superclass
+        # silently dropped the rest. Classes keep first-as-superclass (PHP
+        # classes are single-inheritance; extras would be a parse anomaly and
+        # are preserved in interfaces rather than dropped).
+        if node.type == "interface_declaration":
+            interfaces = base_classes + interfaces
+            base_classes = []
+        elif len(base_classes) > 1:
+            interfaces = base_classes[1:] + interfaces
+            base_classes = base_classes[:1]
 
         full_name = f"{current_namespace}\\{name}" if current_namespace else name
 

--- a/tree_sitter_analyzer/languages/php_helpers.py
+++ b/tree_sitter_analyzer/languages/php_helpers.py
@@ -139,12 +139,21 @@ def _collect_php_class_bases(
     interfaces: list[str] = []
     for child in node.children:
         if child.type == "base_clause":
+            # Theme-C (2026-06-10): tree-sitter-php 0.24 exposes the parent
+            # as plain ``name`` / ``qualified_name`` children (no ``type``
+            # field) — the old field lookup returned None and ``extends``
+            # was silently lost. Keep the field lookup as a fast path for
+            # older grammars, fall back to child iteration.
             base_node = child.child_by_field_name("type")
             if base_node:
                 base_classes.append(get_node_text(base_node))
+            else:
+                for name_node in child.children:
+                    if name_node.type in ("name", "qualified_name"):
+                        base_classes.append(get_node_text(name_node))
         elif child.type == "class_interface_clause":
             for interface_node in child.children:
-                if interface_node.type == "name":
+                if interface_node.type in ("name", "qualified_name"):
                     interfaces.append(get_node_text(interface_node))
     return base_classes, interfaces
 

--- a/tree_sitter_analyzer/languages/ruby_plugin.py
+++ b/tree_sitter_analyzer/languages/ruby_plugin.py
@@ -209,11 +209,16 @@ class RubyElementExtractor(ElementExtractor):
         for child in class_node.children:
             if child.type != "superclass":
                 continue
-            if not child.children:
-                continue
-            superclass_node = child.children[0]
-            text = self._get_node_text_optimized(superclass_node)
-            return str(text) if text else None
+            # Theme-C (2026-06-10): children[0] is the ``<`` OPERATOR token —
+            # the old code returned superclass="<" for every subclass. The
+            # real name is the first non-operator child (a constant, or a
+            # scope_resolution for ``Base::Animal``).
+            for sub in child.children:
+                if sub.type == "<":
+                    continue
+                text = self._get_node_text_optimized(sub)
+                return str(text) if text else None
+            return None
         return None
 
     def extract_functions(


### PR DESCRIPTION
## Problems (Theme-C quality-audit findings, CLI-verified)

1. **Ruby — wrong data, worse than missing**: `_find_ruby_superclass` returned `children[0]` of the `superclass` node — the `<` **operator token**. Every Ruby subclass reported `superclass="<"`.
2. **PHP — extends silently lost**: `base_clause` lookup used `child_by_field_name("type")`, which tree-sitter-php 0.24 doesn't provide → `extends` was `None` for every PHP class (implements survived via a different path).
3. **Cross-language serializer drop**: plugins collected `interfaces` (implements/mixins) but `element_to_dict`'s `_OPTIONAL_ELEM_FIELDS` allowlist omitted the field — **agents never saw implements for ANY language** (Java included).

## Fixes

| File | Change |
|---|---|
| `ruby_plugin.py` | skip the `<` token; take the first constant/`scope_resolution` child (handles `Base::Animal`) |
| `php_helpers.py` | field lookup kept as fast path; fall back to `name`/`qualified_name` child iteration; interface clause accepts `qualified_name` |
| `_api_result_helpers.py` | one-line: add `"interfaces"` to the serializer allowlist |

## After (E2E CLI)

```
Ruby: Dog superclass=Animal          (was "<")
PHP:  Dog superclass=Animal interfaces=[Walkable]   (was None/None)
Java: Dog interfaces=[Walkable]      (previously dropped at serialization)
```

JS verified already correct (extends captured) — the pilot claim was outdated there.

## Tests

RED-first `tests/unit/languages/test_ruby_php_inheritance.py` (3 failed before; exact-pin assertions per locked rule) incl. a serializer-contract test. Full suite green: **18575 passed**. `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)