### PR TITLE
fix(cpp): base classes captured — no base_specifier wrapper in ts-cpp 0.23 (Theme C)

### DIFF
--- a/tests/unit/languages/test_cpp_base_classes.py
+++ b/tests/unit/languages/test_cpp_base_classes.py
@@ -30,6 +30,9 @@ struct S : Base {};
 template <typename T> class Box {};
 class Wrap : public Box<int> {};
 
+namespace NS { class NBase {}; }
+class Q : public NS::NBase {};
+
 class Plain {};
 """
 
@@ -60,6 +63,11 @@ def test_struct_base_captured() -> None:
 def test_template_base_captured() -> None:
     found = _classes()
     assert found["Wrap"].superclass == "Box<int>", f"got {found['Wrap'].superclass!r}"
+
+
+def test_qualified_base_captured() -> None:
+    found = _classes()
+    assert found["Q"].superclass == "NS::NBase", f"got {found['Q'].superclass!r}"
 
 
 def test_no_base_stays_none() -> None:

--- a/tests/unit/languages/test_cpp_base_classes.py
+++ b/tests/unit/languages/test_cpp_base_classes.py
@@ -65,3 +65,22 @@ def test_template_base_captured() -> None:
 def test_no_base_stays_none() -> None:
     found = _classes()
     assert found["Plain"].superclass is None
+
+
+def test_legacy_base_specifier_wrapper_still_handled() -> None:
+    """Older tree-sitter-cpp grammars wrap each base in a base_specifier
+    node — the compatibility branch must still collect names from it."""
+    from unittest.mock import Mock
+
+    from tree_sitter_analyzer.languages._cpp_variable_helpers import (
+        extract_base_classes,
+    )
+
+    name = Mock()
+    name.type = "type_identifier"
+    spec = Mock()
+    spec.type = "base_specifier"
+    spec.children = [name]
+    clause = Mock()
+    clause.children = [spec]
+    assert extract_base_classes(clause, lambda n: "Base") == ["Base"]

--- a/tests/unit/languages/test_cpp_base_classes.py
+++ b/tests/unit/languages/test_cpp_base_classes.py
@@ -1,0 +1,67 @@
+"""Theme-C regression: C++ base classes (extends) capture.
+
+2026-06-10 adversarial-review finding (PR #424 review, task 4):
+``class D : public B`` reported superclass=None. Root cause:
+``extract_base_classes`` searched the ``base_class_clause`` for
+``base_specifier`` children, but tree-sitter-cpp 0.23 puts the
+``access_specifier`` / ``type_identifier`` tokens DIRECTLY under the
+clause — there is no ``base_specifier`` wrapper, so the loop matched
+nothing for every C++ class.
+"""
+
+from __future__ import annotations
+
+import tree_sitter
+import tree_sitter_cpp
+
+from tree_sitter_analyzer.languages.cpp_plugin import CppElementExtractor
+
+CPP_SRC = """\
+class Base {};
+class Mixin {};
+
+class D : public Base, private Mixin {
+public:
+    void run() {}
+};
+
+struct S : Base {};
+
+template <typename T> class Box {};
+class Wrap : public Box<int> {};
+
+class Plain {};
+"""
+
+
+def _classes():
+    lang = tree_sitter.Language(tree_sitter_cpp.language())
+    parser = tree_sitter.Parser(lang)
+    tree = parser.parse(CPP_SRC.encode())
+    extractor = CppElementExtractor()
+    return {c.name: c for c in extractor.extract_classes(tree, CPP_SRC)}
+
+
+def test_single_public_base_captured() -> None:
+    found = _classes()
+    assert found["D"].superclass == "Base", f"got {found['D'].superclass!r}"
+
+
+def test_multiple_bases_preserved() -> None:
+    found = _classes()
+    assert found["D"].interfaces == ["Mixin"], f"got {found['D'].interfaces!r}"
+
+
+def test_struct_base_captured() -> None:
+    found = _classes()
+    assert found["S"].superclass == "Base", f"got {found['S'].superclass!r}"
+
+
+def test_template_base_captured() -> None:
+    found = _classes()
+    assert found["Wrap"].superclass == "Box<int>", f"got {found['Wrap'].superclass!r}"
+
+
+def test_no_base_stays_none() -> None:
+    found = _classes()
+    assert found["Plain"].superclass is None

--- a/tests/unit/languages/test_cpp_plugin_coverage_boost_core.py
+++ b/tests/unit/languages/test_cpp_plugin_coverage_boost_core.py
@@ -128,8 +128,10 @@ def test_class_inheritance(extractor):
     tree = _parse(code)
     classes = extractor.extract_classes(tree, code)
     derived = [c for c in classes if c.name == "Derived"]
-    assert len(derived) >= 1
-    # base_class_clause is parsed but grammar lacks base_specifier children
+    assert len(derived) == 1
+    # ts-cpp 0.23 puts base names directly under base_class_clause (no
+    # base_specifier wrapper) — captured since the Theme-C fix.
+    assert derived[0].superclass == "Base"
     assert derived[0].raw_text is not None
 
 

--- a/tree_sitter_analyzer/languages/_cpp_variable_helpers.py
+++ b/tree_sitter_analyzer/languages/_cpp_variable_helpers.py
@@ -24,13 +24,24 @@ class _VariableParts:
     modifiers: list[str] = field(default_factory=list)
 
 
+_BASE_NAME_NODE_TYPES = ("type_identifier", "template_type", "qualified_identifier")
+
+
 def extract_base_classes(node: Any, get_node_text: Callable[..., str]) -> list[str]:
-    """Extract base class names from base_class_clause."""
+    """Extract base class names from base_class_clause.
+
+    Theme-C (2026-06-10): tree-sitter-cpp 0.23 puts the access_specifier /
+    type_identifier tokens DIRECTLY under ``base_class_clause`` — there is
+    no ``base_specifier`` wrapper, so the old wrapper-only loop matched
+    nothing and ``class D : public B`` reported superclass=None for every
+    C++ class. Accept both shapes (wrapper kept for older grammars).
+    """
     base_classes: list[str] = []
     for child in node.children:
-        if child.type != "base_specifier":
-            continue
-        base_classes.extend(_base_specifier_names(child, get_node_text))
+        if child.type == "base_specifier":
+            base_classes.extend(_base_specifier_names(child, get_node_text))
+        elif child.type in _BASE_NAME_NODE_TYPES:
+            base_classes.append(get_node_text(child))
     return base_classes
 
 
@@ -38,7 +49,7 @@ def _base_specifier_names(node: Any, get_node_text: Callable[..., str]) -> list[
     return [
         get_node_text(child)
         for child in node.children
-        if child.type in ("type_identifier", "template_type")
+        if child.type in _BASE_NAME_NODE_TYPES
     ]
 
 


### PR DESCRIPTION
## Problem (adversarial-review finding from the #424 review)

`class D : public B` reported `superclass=None` — **for every C++ class**. `extract_base_classes` searched `base_class_clause` for `base_specifier` children, but tree-sitter-cpp 0.23 puts the `access_specifier`/`type_identifier` tokens **directly under the clause** (no wrapper), so the loop matched nothing.

## Fix

`_cpp_variable_helpers.extract_base_classes`: accept both shapes — direct `type_identifier`/`template_type`/`qualified_identifier` children (current grammar) and the `base_specifier` wrapper (older grammars). Class assembly already routed `[0]→superclass`, rest→`interfaces`, so only the clause parse needed fixing.

## After

```
class D : public Base, private Mixin  ->  superclass=Base, interfaces=[Mixin]
struct S : Base                       ->  superclass=Base
class Wrap : public Box<int>          ->  superclass=Box<int>
```

RED-first tests (4 failed before; exact pins per locked rule). Full suite green: **18573 passed**. `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)