### PR TITLE
fix(go): receiver/receiver_type reach the API consumer (Theme A)

### DIFF
--- a/tests/unit/languages/test_go_receiver_serialization.py
+++ b/tests/unit/languages/test_go_receiver_serialization.py
@@ -1,0 +1,55 @@
+"""Theme-A regression: Go method receiver reaches the API consumer.
+
+2026-06-10 quality-audit finding: GoElementExtractor fills
+``receiver``/``receiver_type`` correctly (verified: receiver='c',
+receiver_type='*Counter'), but ``element_to_dict``'s
+``_OPTIONAL_ELEM_FIELDS`` allowlist dropped both — an agent saw
+``is_method: True`` but could never tell WHICH type the method belongs
+to. Same serializer-allowlist bug class as the ``interfaces`` drop
+(#424).
+"""
+
+from __future__ import annotations
+
+import tree_sitter
+import tree_sitter_go
+
+from tree_sitter_analyzer._api_result_helpers import element_to_dict
+from tree_sitter_analyzer.languages.go_plugin import GoElementExtractor
+
+GO_SRC = """\
+package main
+
+type Counter struct{ n int }
+
+func (c *Counter) Inc() { c.n++ }
+func (c Counter) Get() int { return c.n }
+func Standalone() {}
+"""
+
+
+def _functions():
+    lang = tree_sitter.Language(tree_sitter_go.language())
+    parser = tree_sitter.Parser(lang)
+    tree = parser.parse(GO_SRC.encode())
+    extractor = GoElementExtractor()
+    return {f.name: f for f in extractor.extract_functions(tree, GO_SRC)}
+
+
+def test_extractor_fills_receiver() -> None:
+    """The extractor layer was always correct — pin it."""
+    funcs = _functions()
+    assert funcs["Inc"].receiver == "c"
+    assert funcs["Inc"].receiver_type == "*Counter"
+    assert funcs["Get"].receiver_type == "Counter"
+    assert funcs["Standalone"].receiver is None
+
+
+def test_receiver_survives_api_serialization() -> None:
+    """The serializer allowlist must pass receiver/receiver_type through."""
+    funcs = _functions()
+    inc = element_to_dict(funcs["Inc"])
+    assert inc.get("receiver") == "c"
+    assert inc.get("receiver_type") == "*Counter"
+    standalone = element_to_dict(funcs["Standalone"])
+    assert "receiver" not in standalone or standalone.get("receiver") is None

--- a/tests/unit/languages/test_go_receiver_serialization.py
+++ b/tests/unit/languages/test_go_receiver_serialization.py
@@ -52,4 +52,7 @@ def test_receiver_survives_api_serialization() -> None:
     assert inc.get("receiver") == "c"
     assert inc.get("receiver_type") == "*Counter"
     standalone = element_to_dict(funcs["Standalone"])
-    assert "receiver" not in standalone or standalone.get("receiver") is None
+    # Function dataclass defaults receiver=None, so the field is always
+    # present (as None) for non-methods — pin that exact behavior.
+    assert standalone["receiver"] is None
+    assert standalone["receiver_type"] is None

--- a/tree_sitter_analyzer/_api_result_helpers.py
+++ b/tree_sitter_analyzer/_api_result_helpers.py
@@ -22,6 +22,11 @@ _OPTIONAL_ELEM_FIELDS = [
     # Theme-C (2026-06-10): implements/mixins were collected by plugins but
     # dropped here — agents never saw them.
     "interfaces",
+    # Theme-A (2026-06-10): Go/Rust receiver binding — extractors filled
+    # these but the allowlist dropped them; agents saw is_method=True with
+    # no way to tell WHICH type owns the method.
+    "receiver",
+    "receiver_type",
     "class_type",
     "visibility",
     "modifiers",


### PR DESCRIPTION
## Summary
Quality-audit Theme-A finding: the Go extractor was **always correct** (`receiver='c'`, `receiver_type='*Counter'`) — but `element_to_dict`'s `_OPTIONAL_ELEM_FIELDS` allowlist dropped both fields. Agents saw `is_method=True` with no way to tell WHICH type owns the method. Same serializer-allowlist bug class as the interfaces drop fixed in #424 (Theme C).

## Change
- `_api_result_helpers.py`: add `receiver` + `receiver_type` to the allowlist (+5 lines).
- `tests/unit/languages/test_go_receiver_serialization.py`: RED-first end-to-end test pinning that the fields survive serialization to the API consumer.

## Cross-language note
This shared allowlist path also carries Rust once #428 (Rust extractor-side fix: impl fns weren't even marked `is_method`) merges — the two PRs together close Theme-A for both languages.

## Test plan
- [x] RED-first serialization test
- [x] Full suite green locally after rebase onto develop (conflict with #424's `interfaces` entry resolved — both kept): **18595 passed, 90 skipped, 1 xfailed**