### PR TITLE
fix(params): Theme E — Kotlin no-op, Go/PHP variadics, C++ packs

### DIFF
--- a/tests/golden_masters/compact/go_sample_compact.md
+++ b/tests/golden_masters/compact/go_sample_compact.md
@@ -25,6 +25,6 @@
 | worker | (0):- | u | 229-234 | - |
 | Submit | (1):- | E | 237-239 | - |
 | Shutdown | (0):- | E | 242-245 | - |
-| Chain | (0):Middl | E | 257-264 | - |
+| Chain | (1):Middl | E | 257-264 | - |
 | WithTimeout | (1):Middl | E | 267-275 | - |
 | WithRetry | (1):Middl | E | 278-293 | - |

--- a/tests/golden_masters/compact/kotlin_sample_compact.md
+++ b/tests/golden_masters/compact/kotlin_sample_compact.md
@@ -13,9 +13,9 @@
 |----|-----|---|---|---|-----|
 | display | (0):String | pub | - | 16-16 | - |
 | summary | (0):String | pub | - | 18-20 | - |
-| getUser | (0):User? | pub | - | 33-35 | - |
-| fetchUserAsync | (0):Result<User> | pub | - | 37-40 | - |
+| getUser | (1):User? | pub | - | 33-35 | - |
+| fetchUserAsync | (1):Result<User> | pub | - | 37-40 | - |
 | display | (0):String | pub | - | 42-44 | - |
 | toTitleCase | (0):String | pub | - | 52-54 | - |
 | get | (0) | pub | - | 59-59 | - |
-| main | (0) | pub | - | 62-65 | - |
+| main | (1) | pub | - | 62-65 | - |

--- a/tests/golden_masters/csv/go_sample_csv.csv
+++ b/tests/golden_masters/csv/go_sample_csv.csv
@@ -23,6 +23,6 @@ Method,Start,():,public,221-226,1,-
 Method,worker,():,private,229-234,1,-
 Method,Submit,(func():job):,public,237-239,1,-
 Method,Shutdown,():,public,242-245,1,-
-Method,Chain,():Middleware,public,257-264,1,-
+Method,Chain,(...Middleware:middlewares):Middleware,public,257-264,1,-
 Method,WithTimeout,(time.Duration:timeout):Middleware,public,267-275,1,-
 Method,WithRetry,(int:maxRetries):Middleware,public,278-293,1,-

--- a/tests/golden_masters/csv/kotlin_sample_csv.csv
+++ b/tests/golden_masters/csv/kotlin_sample_csv.csv
@@ -17,12 +17,12 @@
 |----------|-----------|-----|-------|---------|-----|
 | display | fun(): String | pub | 16-16 | - | - |
 | summary | fun(): String | pub | 18-20 | - | - |
-| getUser | fun(): User? | pub | 33-35 | - | - |
-| fetchUserAsync | fun(): Result<User> | pub | 37-40 | - | - |
+| getUser | fun(id: Long): User? | pub | 33-35 | - | - |
+| fetchUserAsync | fun(id: Long): Result<User> | pub | 37-40 | - | - |
 | display | fun(): String | pub | 42-44 | - | - |
 | toTitleCase | fun(): String | pub | 52-54 | - | - |
 | get | fun() | pub | 59-59 | - | - |
-| main | fun() | pub | 62-65 | - | - |
+| main | fun(args: Array<String>) | pub | 62-65 | - | - |
 
 ## Properties
 | Name | Type | Vis | Kind | Line | Doc |

--- a/tests/golden_masters/full/go_sample_full.md
+++ b/tests/golden_masters/full/go_sample_full.md
@@ -56,7 +56,7 @@ import ""time""
 | worker | () | unexported | 229-234 | - |
 | Submit | ({'name': 'func()', 'type': 'job'}) | exported | 237-239 | - |
 | Shutdown | () | exported | 242-245 | - |
-| Chain | () Middleware | exported | 257-264 | - |
+| Chain | ({'name': '...Middleware', 'type': 'middlewares'}) Middleware | exported | 257-264 | - |
 | WithTimeout | ({'name': 'time.Duration', 'type': 'timeout'}) Middleware | exported | 267-275 | - |
 | WithRetry | ({'name': 'int', 'type': 'maxRetries'}) Middleware | exported | 278-293 | - |
 

--- a/tests/golden_masters/full/kotlin_sample_full.md
+++ b/tests/golden_masters/full/kotlin_sample_full.md
@@ -17,12 +17,12 @@
 |----------|-----------|-----|-------|---------|-----|
 | display | fun(): String | pub | 16-16 | - | - |
 | summary | fun(): String | pub | 18-20 | - | - |
-| getUser | fun(): User? | pub | 33-35 | - | - |
-| fetchUserAsync | fun(): Result<User> | pub | 37-40 | - | - |
+| getUser | fun(id: Long): User? | pub | 33-35 | - | - |
+| fetchUserAsync | fun(id: Long): Result<User> | pub | 37-40 | - | - |
 | display | fun(): String | pub | 42-44 | - | - |
 | toTitleCase | fun(): String | pub | 52-54 | - | - |
 | get | fun() | pub | 59-59 | - | - |
-| main | fun() | pub | 62-65 | - | - |
+| main | fun(args: Array<String>) | pub | 62-65 | - | - |
 
 ## Properties
 | Name | Type | Vis | Kind | Line | Doc |

--- a/tests/unit/languages/test_parameter_extraction_theme_e.py
+++ b/tests/unit/languages/test_parameter_extraction_theme_e.py
@@ -1,0 +1,418 @@
+"""Theme E — Parameter Extraction Hardening.
+
+RED-first tests for:
+  - Kotlin: function_value_parameters node type (not a named field), plus vararg prefix
+  - Go: variadic_parameter_declaration (numbers ...int) silently dropped
+  - PHP: variadic_parameter (method + function contexts)
+  - C++: variadic_parameter_declaration emits full text, not bare "..."
+
+Uses real tree-sitter parses — no mocks.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("tree_sitter_kotlin")
+pytest.importorskip("tree_sitter_go")
+pytest.importorskip("tree_sitter_php")
+pytest.importorskip("tree_sitter_cpp")
+
+import tree_sitter
+import tree_sitter_cpp
+import tree_sitter_go
+import tree_sitter_kotlin
+import tree_sitter_php
+
+# ---------------------------------------------------------------------------
+# Helpers — one parser per language
+# ---------------------------------------------------------------------------
+
+
+def _kotlin_parser() -> tree_sitter.Parser:
+    return tree_sitter.Parser(tree_sitter.Language(tree_sitter_kotlin.language()))
+
+
+def _go_parser() -> tree_sitter.Parser:
+    return tree_sitter.Parser(tree_sitter.Language(tree_sitter_go.language()))
+
+
+def _php_parser() -> tree_sitter.Parser:
+    return tree_sitter.Parser(tree_sitter.Language(tree_sitter_php.language_php()))
+
+
+def _cpp_parser() -> tree_sitter.Parser:
+    return tree_sitter.Parser(tree_sitter.Language(tree_sitter_cpp.language()))
+
+
+# ---------------------------------------------------------------------------
+# Kotlin — extract_kotlin_parameters
+# ---------------------------------------------------------------------------
+
+
+class TestKotlinParameterExtraction:
+    """Theme E: Kotlin parameters were all empty because child_by_field_name
+    ('parameters') returns None — the grammar uses function_value_parameters
+    as a child type, not a named field."""
+
+    def test_three_params_including_vararg_count(self):
+        """greet(name, age, vararg tags) must yield exactly 3 parameters."""
+        from tree_sitter_analyzer.languages.kotlin_helpers import (
+            extract_kotlin_parameters,
+        )
+
+        code = "fun greet(name: String, age: Int, vararg tags: String): Unit {}"
+        parser = _kotlin_parser()
+        tree = parser.parse(code.encode())
+        func_node = tree.root_node.children[0]
+
+        def get_text(n: object) -> str:
+            return bytes(n.text).decode()  # type: ignore[attr-defined]
+
+        params = extract_kotlin_parameters(func_node, get_text)
+        assert len(params) == 3
+
+    def test_three_params_names_and_types(self):
+        """Each parameter must carry its name and type."""
+        from tree_sitter_analyzer.languages.kotlin_helpers import (
+            extract_kotlin_parameters,
+        )
+
+        code = "fun greet(name: String, age: Int, vararg tags: String): Unit {}"
+        parser = _kotlin_parser()
+        tree = parser.parse(code.encode())
+        func_node = tree.root_node.children[0]
+
+        def get_text(n: object) -> str:
+            return bytes(n.text).decode()  # type: ignore[attr-defined]
+
+        params = extract_kotlin_parameters(func_node, get_text)
+        assert params[0] == "name: String"
+        assert params[1] == "age: Int"
+        # vararg prefix must be visible
+        assert "tags" in params[2]
+        assert "String" in params[2]
+        assert "vararg" in params[2]
+
+    def test_two_regular_params_count(self):
+        """Functions without vararg still work after the fix."""
+        from tree_sitter_analyzer.languages.kotlin_helpers import (
+            extract_kotlin_parameters,
+        )
+
+        code = "fun add(a: Int, b: Int): Int {}"
+        parser = _kotlin_parser()
+        tree = parser.parse(code.encode())
+        func_node = tree.root_node.children[0]
+
+        def get_text(n: object) -> str:
+            return bytes(n.text).decode()  # type: ignore[attr-defined]
+
+        params = extract_kotlin_parameters(func_node, get_text)
+        assert len(params) == 2
+
+    def test_zero_params(self):
+        """Functions with no parameters yield an empty list."""
+        from tree_sitter_analyzer.languages.kotlin_helpers import (
+            extract_kotlin_parameters,
+        )
+
+        code = "fun hello(): Unit {}"
+        parser = _kotlin_parser()
+        tree = parser.parse(code.encode())
+        func_node = tree.root_node.children[0]
+
+        def get_text(n: object) -> str:
+            return bytes(n.text).decode()  # type: ignore[attr-defined]
+
+        params = extract_kotlin_parameters(func_node, get_text)
+        assert len(params) == 0
+
+
+# ---------------------------------------------------------------------------
+# Go — extract_parameters in _go_common_helpers.py
+# ---------------------------------------------------------------------------
+
+
+class TestGoVariadicParameterExtraction:
+    """Theme E: variadic_parameter_declaration (e.g. numbers ...int)
+    was silently dropped — only parameter_declaration was collected."""
+
+    def test_variadic_sum_count(self):
+        """func sum(a int, numbers ...int) must yield exactly 2 parameters."""
+        from tree_sitter_analyzer.languages._go_common_helpers import (
+            extract_parameters,
+        )
+
+        code = "func sum(a int, numbers ...int) int { return 0 }"
+        parser = _go_parser()
+        tree = parser.parse(code.encode())
+        func_node = tree.root_node.children[0]
+
+        def get_text(n: object) -> str:
+            return bytes(n.text).decode()  # type: ignore[attr-defined]
+
+        params = extract_parameters(func_node, get_text)
+        assert len(params) == 2
+
+    def test_variadic_sum_contains_variadic_param(self):
+        """The variadic parameter text must contain 'numbers' and '...'."""
+        from tree_sitter_analyzer.languages._go_common_helpers import (
+            extract_parameters,
+        )
+
+        code = "func sum(a int, numbers ...int) int { return 0 }"
+        parser = _go_parser()
+        tree = parser.parse(code.encode())
+        func_node = tree.root_node.children[0]
+
+        def get_text(n: object) -> str:
+            return bytes(n.text).decode()  # type: ignore[attr-defined]
+
+        params = extract_parameters(func_node, get_text)
+        assert params[0] == "a int"
+        variadic_param = params[1]
+        assert "numbers" in variadic_param
+        assert "..." in variadic_param
+
+    def test_regular_params_unchanged(self):
+        """Regular (non-variadic) parameters still work."""
+        from tree_sitter_analyzer.languages._go_common_helpers import (
+            extract_parameters,
+        )
+
+        code = "func add(x int, y int) int { return x + y }"
+        parser = _go_parser()
+        tree = parser.parse(code.encode())
+        func_node = tree.root_node.children[0]
+
+        def get_text(n: object) -> str:
+            return bytes(n.text).decode()  # type: ignore[attr-defined]
+
+        params = extract_parameters(func_node, get_text)
+        assert len(params) == 2
+
+    def test_only_variadic_param(self):
+        """func with only a variadic param must yield exactly 1 parameter."""
+        from tree_sitter_analyzer.languages._go_common_helpers import (
+            extract_parameters,
+        )
+
+        code = "func printAll(args ...string) { }"
+        parser = _go_parser()
+        tree = parser.parse(code.encode())
+        func_node = tree.root_node.children[0]
+
+        def get_text(n: object) -> str:
+            return bytes(n.text).decode()  # type: ignore[attr-defined]
+
+        params = extract_parameters(func_node, get_text)
+        assert len(params) == 1
+        assert "args" in params[0]
+        assert "..." in params[0]
+
+
+# ---------------------------------------------------------------------------
+# PHP — variadic_parameter in extract_php_method_element and
+#       extract_php_function_element
+# ---------------------------------------------------------------------------
+
+
+class TestPHPVariadicParameterExtraction:
+    """Theme E: variadic_parameter (e.g. ...$parts) was silently dropped
+    in both extract_php_method_element and extract_php_function_element."""
+
+    def test_method_variadic_count(self):
+        """Method format(string $sep, ...$parts) must yield exactly 2 params."""
+        from tree_sitter_analyzer.languages.php_helpers import (
+            extract_modifiers,
+            extract_php_method_element,
+        )
+
+        code = b"<?php class F { public function format(string $sep, ...$parts): string {} }"
+        parser = _php_parser()
+        tree = parser.parse(code)
+
+        # navigate to method_declaration
+        cls_decl = tree.root_node.children[1]  # class_declaration
+        decl_list = cls_decl.children[2]  # declaration_list
+        method_node = decl_list.children[1]  # method_declaration
+
+        def get_text(n: object) -> str:
+            return bytes(n.text).decode()  # type: ignore[attr-defined]
+
+        def extract_mod(n: object) -> list[str]:
+            return extract_modifiers(n, get_text)
+
+        def extract_attr(_n: object) -> list[dict]:
+            return []
+
+        result = extract_php_method_element(
+            method_node,
+            "F",
+            get_text,
+            extract_mod,
+            extract_attr,
+        )
+        assert result is not None
+        assert len(result.parameters) == 2
+
+    def test_method_variadic_text_contains_parts(self):
+        """The variadic param entry must mention '$parts' or 'parts'."""
+        from tree_sitter_analyzer.languages.php_helpers import (
+            extract_modifiers,
+            extract_php_method_element,
+        )
+
+        code = b"<?php class F { public function format(string $sep, ...$parts): string {} }"
+        parser = _php_parser()
+        tree = parser.parse(code)
+
+        cls_decl = tree.root_node.children[1]
+        decl_list = cls_decl.children[2]
+        method_node = decl_list.children[1]
+
+        def get_text(n: object) -> str:
+            return bytes(n.text).decode()  # type: ignore[attr-defined]
+
+        def extract_mod(n: object) -> list[str]:
+            return extract_modifiers(n, get_text)
+
+        def extract_attr(_n: object) -> list[dict]:
+            return []
+
+        result = extract_php_method_element(
+            method_node,
+            "F",
+            get_text,
+            extract_mod,
+            extract_attr,
+        )
+        assert result is not None
+        variadic_texts = [p for p in result.parameters if "parts" in p]
+        assert len(variadic_texts) == 1
+
+    def test_function_variadic_count(self):
+        """Free function implode(string $sep, ...$parts) must yield 2 params."""
+        from tree_sitter_analyzer.languages.php_helpers import (
+            extract_php_function_element,
+        )
+
+        code = b"<?php function implode(string $sep, ...$parts): string { return ''; }"
+        parser = _php_parser()
+        tree = parser.parse(code)
+
+        func_node = tree.root_node.children[1]  # function_definition
+
+        def get_text(n: object) -> str:
+            return bytes(n.text).decode()  # type: ignore[attr-defined]
+
+        result = extract_php_function_element(func_node, "", get_text)
+        assert result is not None
+        assert len(result.parameters) == 2
+
+    def test_function_variadic_text_contains_parts(self):
+        """The variadic param entry must include '...$parts' or 'parts'."""
+        from tree_sitter_analyzer.languages.php_helpers import (
+            extract_php_function_element,
+        )
+
+        code = b"<?php function implode(string $sep, ...$parts): string { return ''; }"
+        parser = _php_parser()
+        tree = parser.parse(code)
+
+        func_node = tree.root_node.children[1]
+
+        def get_text(n: object) -> str:
+            return bytes(n.text).decode()  # type: ignore[attr-defined]
+
+        result = extract_php_function_element(func_node, "", get_text)
+        assert result is not None
+        variadic_texts = [p for p in result.parameters if "parts" in p]
+        assert len(variadic_texts) == 1
+
+
+# ---------------------------------------------------------------------------
+# C++ — variadic_parameter_declaration emits full text, not bare "..."
+# ---------------------------------------------------------------------------
+
+
+class TestCppVariadicParameterExtraction:
+    """Theme E (C++): _cpp_signature_helpers.extract_parameters previously
+    appended the literal string '...' for variadic_parameter_declaration nodes
+    instead of the actual node text (e.g. 'Args... args').
+
+    This is a leaf-level node-type change — no type-resolver pipeline involved.
+    """
+
+    def test_template_variadic_full_text(self):
+        """template variadic param 'Args... args' must appear as full text,
+        not a bare '...'."""
+        from tree_sitter_analyzer.languages._cpp_signature_helpers import (
+            extract_parameters,
+        )
+
+        code = b"template <typename... Args> void foo(Args... args) {}"
+        parser = _cpp_parser()
+        tree = parser.parse(code)
+
+        # Navigate: template_declaration -> function_definition ->
+        # function_declarator -> parameter_list
+        template_decl = tree.root_node.children[0]
+        func_def = template_decl.children[2]  # function_definition
+        # find parameter_list via function_declarator
+        func_declarator = None
+        for child in func_def.children:
+            if child.type == "function_declarator":
+                func_declarator = child
+                break
+        assert func_declarator is not None
+        param_list = None
+        for child in func_declarator.children:
+            if child.type == "parameter_list":
+                param_list = child
+                break
+        assert param_list is not None
+
+        def get_text(n: object) -> str:
+            return bytes(n.text).decode()  # type: ignore[attr-defined]
+
+        params = extract_parameters(param_list, get_text)
+        assert len(params) == 1
+        # Must include the actual parameter text, not the bare "..."
+        assert params[0] != "..."
+        assert "args" in params[0]
+
+    def test_c_style_variadic_printf(self):
+        """C-style printf(const char* fmt, ...) variadic: '...' node type is
+        different (just '...') — verify it is preserved or captured."""
+        from tree_sitter_analyzer.languages._cpp_signature_helpers import (
+            extract_parameters,
+        )
+
+        code = b"int printf(const char* fmt, ...);"
+        parser = _cpp_parser()
+        tree = parser.parse(code)
+
+        # Navigate to parameter_list
+        decl = tree.root_node.children[0]
+
+        def find_param_list(node: object) -> object | None:
+            if hasattr(node, "type") and node.type == "parameter_list":  # type: ignore[union-attr]
+                return node
+            for child in getattr(node, "children", []):
+                result = find_param_list(child)
+                if result is not None:
+                    return result
+            return None
+
+        param_list = find_param_list(decl)
+        assert param_list is not None
+
+        def get_text(n: object) -> str:
+            return bytes(n.text).decode()  # type: ignore[attr-defined]
+
+        params = extract_parameters(param_list, get_text)
+        # fmt is a regular parameter_declaration
+        assert len(params) == 2
+        assert "fmt" in params[0]

--- a/tests/unit/languages/test_parameter_extraction_theme_e.py
+++ b/tests/unit/languages/test_parameter_extraction_theme_e.py
@@ -87,12 +87,7 @@ class TestKotlinParameterExtraction:
             return bytes(n.text).decode()  # type: ignore[attr-defined]
 
         params = extract_kotlin_parameters(func_node, get_text)
-        assert params[0] == "name: String"
-        assert params[1] == "age: Int"
-        # vararg prefix must be visible
-        assert "tags" in params[2]
-        assert "String" in params[2]
-        assert "vararg" in params[2]
+        assert params == ["name: String", "age: Int", "vararg tags: String"]
 
     def test_two_regular_params_count(self):
         """Functions without vararg still work after the fix."""
@@ -170,10 +165,7 @@ class TestGoVariadicParameterExtraction:
             return bytes(n.text).decode()  # type: ignore[attr-defined]
 
         params = extract_parameters(func_node, get_text)
-        assert params[0] == "a int"
-        variadic_param = params[1]
-        assert "numbers" in variadic_param
-        assert "..." in variadic_param
+        assert params == ["a int", "numbers ...int"]
 
     def test_regular_params_unchanged(self):
         """Regular (non-variadic) parameters still work."""
@@ -207,9 +199,7 @@ class TestGoVariadicParameterExtraction:
             return bytes(n.text).decode()  # type: ignore[attr-defined]
 
         params = extract_parameters(func_node, get_text)
-        assert len(params) == 1
-        assert "args" in params[0]
-        assert "..." in params[0]
+        assert params == ["args ...string"]
 
 
 # ---------------------------------------------------------------------------
@@ -415,4 +405,93 @@ class TestCppVariadicParameterExtraction:
         params = extract_parameters(param_list, get_text)
         # fmt is a regular parameter_declaration
         assert len(params) == 2
-        assert "fmt" in params[0]
+        assert params[0] == "const char* fmt"
+        # C-style variadic node is just "..." — must be captured exactly
+        assert params[1] == "..."
+
+
+# ---------------------------------------------------------------------------
+# P3 edge-case additions (adversarial review follow-up)
+# ---------------------------------------------------------------------------
+
+
+class TestPHPByReferenceVariadic:
+    """PHP by-reference variadic: function join(string &...$parts)
+    The variadic_parameter node text must be captured verbatim."""
+
+    def test_by_reference_variadic_text(self):
+        """function join(string &...$parts) → parameter text is '&...$parts'
+        (full variadic_parameter node text captured)."""
+        from tree_sitter_analyzer.languages.php_helpers import (
+            extract_php_function_element,
+        )
+
+        code = b"<?php function join(string &...$parts): string { return ''; }"
+        parser = _php_parser()
+        tree = parser.parse(code)
+
+        func_node = tree.root_node.children[1]  # function_definition
+
+        def get_text(n: object) -> str:
+            return bytes(n.text).decode()  # type: ignore[attr-defined]
+
+        result = extract_php_function_element(func_node, "", get_text)
+        assert result is not None
+        assert result.parameters == ["string &...$parts"]
+
+
+class TestKotlinDefaultValue:
+    """Kotlin default value: fun f(x: Int = 5)
+    Current behavior drops the default expression; this test pins that intent."""
+
+    def test_default_value_dropped(self):
+        """fun f(x: Int = 5) → ['x: Int']
+        Pins existing behavior: the '= 5' default initializer is dropped.
+        This is intentional — parameters carry name+type, not initializers."""
+        from tree_sitter_analyzer.languages.kotlin_helpers import (
+            extract_kotlin_parameters,
+        )
+
+        code = "fun f(x: Int = 5) {}"
+        parser = _kotlin_parser()
+        tree = parser.parse(code.encode())
+        func_node = tree.root_node.children[0]
+
+        def get_text(n: object) -> str:
+            return bytes(n.text).decode()  # type: ignore[attr-defined]
+
+        params = extract_kotlin_parameters(func_node, get_text)
+        # Pins current intentional behavior: default expression '= 5' is dropped.
+        assert params == ["x: Int"]
+
+
+class TestCppCStyleVariadicExact:
+    """C-style variadic '...' in printf must appear as the exact string '...'."""
+
+    def test_c_style_variadic_exact_string(self):
+        """int printf(const char* fmt, ...) → params[1] == '...' (exact)."""
+        from tree_sitter_analyzer.languages._cpp_signature_helpers import (
+            extract_parameters,
+        )
+
+        code = b"int printf(const char* fmt, ...);"
+        parser = _cpp_parser()
+        tree = parser.parse(code)
+
+        def find_param_list(node: object) -> object | None:
+            if hasattr(node, "type") and node.type == "parameter_list":  # type: ignore[union-attr]
+                return node
+            for child in getattr(node, "children", []):
+                result = find_param_list(child)
+                if result is not None:
+                    return result
+            return None
+
+        param_list = find_param_list(tree.root_node.children[0])
+        assert param_list is not None
+
+        def get_text(n: object) -> str:
+            return bytes(n.text).decode()  # type: ignore[attr-defined]
+
+        params = extract_parameters(param_list, get_text)
+        assert params[1] == "..."

--- a/tree_sitter_analyzer/languages/_cpp_signature_helpers.py
+++ b/tree_sitter_analyzer/languages/_cpp_signature_helpers.py
@@ -63,7 +63,13 @@ def extract_parameters(
     params_node: Any,
     get_node_text: Callable[..., str],
 ) -> list[str]:
-    """Extract function parameters."""
+    """Extract function parameters.
+
+    Theme E (2026-06-10): ``variadic_parameter_declaration`` now emits the
+    full node text (e.g. ``Args... args``) instead of a bare ``"..."``.
+    C-style variadic (bare ``...`` token, node type ``"..."``) is also
+    captured so that e.g. ``printf(const char* fmt, ...)`` yields two params.
+    """
     parameters: list[str] = []
     for child in params_node.children:
         if child.type in (
@@ -72,6 +78,8 @@ def extract_parameters(
         ):
             parameters.append(get_node_text(child))
         elif child.type == "variadic_parameter_declaration":
+            parameters.append(get_node_text(child))
+        elif child.type == "...":
             parameters.append("...")
     return parameters
 

--- a/tree_sitter_analyzer/languages/_go_common_helpers.py
+++ b/tree_sitter_analyzer/languages/_go_common_helpers.py
@@ -6,12 +6,19 @@ from typing import Any
 
 
 def extract_parameters(node: Any, get_node_text: Callable[..., str]) -> list[str]:
-    """Extract function/method parameters."""
+    """Extract function/method parameters.
+
+    Theme E (2026-06-10): also capture ``variadic_parameter_declaration``
+    nodes (e.g. ``numbers ...int``) which were previously silently dropped.
+    """
     parameters: list[str] = []
     params_node = node.child_by_field_name("parameters")
     if params_node:
         for child in params_node.children:
-            if child.type == "parameter_declaration":
+            if child.type in (
+                "parameter_declaration",
+                "variadic_parameter_declaration",
+            ):
                 parameters.append(get_node_text(child))
     return parameters
 

--- a/tree_sitter_analyzer/languages/kotlin_helpers.py
+++ b/tree_sitter_analyzer/languages/kotlin_helpers.py
@@ -47,17 +47,38 @@ def extract_kotlin_parameters(
     """Extract Kotlin function parameters.
 
     r37dt (dogfood): flatten nesting 6 → 3 via ``_kotlin_parameter_pair``.
+    Theme E (2026-06-10): tree-sitter-kotlin exposes the parameter list as a
+    child node of type ``function_value_parameters``, not as a named field
+    ``"parameters"`` — ``child_by_field_name("parameters")`` always returned
+    None, leaving every Kotlin function with zero parameters.  Scan children
+    for the correct node type.  Also track ``parameter_modifiers`` (e.g.
+    ``vararg``) immediately preceding a ``parameter`` node and prepend the
+    modifier text to the emitted parameter string.
     """
     parameters: list[str] = []
-    params_node = node.child_by_field_name("parameters")
+    params_node = None
+    for child in node.children:
+        if child.type == "function_value_parameters":
+            params_node = child
+            break
     if params_node is None:
         return parameters
+    pending_modifier: str = ""
     for child in params_node.children:
-        if child.type != "parameter":
-            continue
-        param_name, param_type = _kotlin_parameter_pair(child, get_node_text)
-        if param_name:
-            parameters.append(f"{param_name}: {param_type or 'Any'}")
+        if child.type == "parameter_modifiers":
+            pending_modifier = get_node_text(child)
+        elif child.type == "parameter":
+            param_name, param_type = _kotlin_parameter_pair(child, get_node_text)
+            if param_name:
+                if pending_modifier:
+                    parameters.append(
+                        f"{pending_modifier} {param_name}: {param_type or 'Any'}"
+                    )
+                else:
+                    parameters.append(f"{param_name}: {param_type or 'Any'}")
+            pending_modifier = ""
+        else:
+            pending_modifier = ""
     return parameters
 
 
@@ -66,17 +87,22 @@ def _kotlin_parameter_pair(
 ) -> tuple[str, str]:
     """Return ``(name, type)`` from a Kotlin ``parameter`` AST node.
 
-    Iterates the parameter node's children looking for a
-    ``simple_identifier`` (name) and a type-like node (``user_type`` or
-    any node whose ``type`` string contains ``"type"``). Empty strings
-    default when either part is missing; caller fills ``"Any"`` for
-    blank types.
+    Iterates the parameter node's children looking for a name node
+    (``simple_identifier`` or ``identifier`` — grammar version-dependent)
+    and a type-like node (``user_type`` or any node whose ``type`` string
+    contains ``"type"``). Empty strings default when either part is missing;
+    caller fills ``"Any"`` for blank types.
+
+    Theme E (2026-06-10): tree-sitter-kotlin emits ``identifier`` (not
+    ``simple_identifier``) for parameter names in the tested grammar version;
+    accept both so the helper works across grammar versions.
     """
     param_name = ""
     param_type = ""
     for grandchild in parameter_node.children:
-        if grandchild.type == "simple_identifier":
-            param_name = get_node_text(grandchild)
+        if grandchild.type in ("simple_identifier", "identifier"):
+            if not param_name:  # first identifier is the name
+                param_name = get_node_text(grandchild)
         elif "type" in grandchild.type or grandchild.type == "user_type":
             param_type = get_node_text(grandchild)
     return param_name, param_type

--- a/tree_sitter_analyzer/languages/php_helpers.py
+++ b/tree_sitter_analyzer/languages/php_helpers.py
@@ -242,7 +242,11 @@ def extract_php_method_element(
         params_node = node.child_by_field_name("parameters")
         if params_node:
             for param in params_node.children:
-                if param.type in ("simple_parameter", "property_promotion_parameter"):
+                if param.type in (
+                    "simple_parameter",
+                    "property_promotion_parameter",
+                    "variadic_parameter",  # Theme E (2026-06-10): ...$arg
+                ):
                     parameters.append(get_node_text(param))
 
         return_type = "void"
@@ -286,7 +290,10 @@ def extract_php_function_element(
         params_node = node.child_by_field_name("parameters")
         if params_node:
             for param in params_node.children:
-                if param.type == "simple_parameter":
+                if param.type in (
+                    "simple_parameter",
+                    "variadic_parameter",  # Theme E (2026-06-10): ...$arg
+                ):
                     parameters.append(get_node_text(param))
 
         return_type = "void"


### PR DESCRIPTION
## Summary
Quality-audit **Theme E (parameter loss)** hardening — the last 'total extractor failure' class:

- **Kotlin (total no-op)**: `child_by_field_name("parameters")` always returned None — tree-sitter-kotlin exposes `function_value_parameters` as a child node TYPE, not a named field. Every Kotlin function had empty parameters. Plus a second bug unmasked by the fix: parameter names emit `identifier`, the code matched only `simple_identifier`. Plus `vararg` modifier (sibling node) now prepended correctly.
- **Go**: `variadic_parameter_declaration` (`numbers ...int`) silently dropped by the shared functions/methods helper.
- **PHP**: `variadic_parameter` (`...$parts`, incl. by-ref `&...$parts`) absent from both method and function extractors.
- **C++**: template packs (`Args&&... args`) were flattened to `"..."`; now full text. Bare C-style `...` token captured as `"..."`.

## Review
Adversarial review (opencode): **0 P1**, six live-parse attack scenarios passed (mid-list vararg no modifier-leak, defaults, grouped Go params, rvalue-ref packs, by-ref PHP variadic). 3 P2 (substring assertions → exact `==` per locked rule) + 3 P3 (edge coverage) fixed in aaffa6b7.

## Test plan
- [x] RED-first: 17 tests in `tests/unit/languages/test_parameter_extraction_theme_e.py`, real parses, zero mocks, exact assertions
- [x] languages dir single-process run green (1 pre-existing local-only Swift golden failure verified present on develop baseline; develop CI green — separate investigation)