### PR TITLE
fix(trust): dogfood DF-8/9/10/11 — honest index status, real next_step, .py hints

### DIFF
--- a/tests/unit/mcp/test_project_overview_tool.py
+++ b/tests/unit/mcp/test_project_overview_tool.py
@@ -440,7 +440,8 @@ class TestOverviewNextStep:
 
     def test_healthy_project(self) -> None:
         step = _overview_next_step({}, True)
-        assert "tool_routing" in step
+        # DF-10: verify next_step uses CLI-friendly guidance, not MCP-specific tool_routing
+        assert "check_project_health" in step
 
 
 class TestTopLanguage:
@@ -538,6 +539,26 @@ class TestBuildSmartHint:
         }
         hint = _build_smart_hint(result)
         assert "health is good" in hint
+
+    def test_language_to_extension_mapping(self) -> None:
+        # DF-11: verify language names map to correct file extensions in hints
+        result = {
+            "health_summary": [{"file": "a.py", "grade": "A", "score": 90}],
+            "language_distribution": {"python": 5},
+            "largest_source_files": [{"path": "a.py", "lines": 100}],
+        }
+        hint = _build_smart_hint(result)
+        assert ".py file" in hint
+
+    def test_language_to_extension_mapping_java(self) -> None:
+        # DF-11: verify Java maps to .java
+        result = {
+            "health_summary": [{"file": "App.java", "grade": "A", "score": 90}],
+            "language_distribution": {"java": 10},
+            "largest_source_files": [{"path": "App.java", "lines": 100}],
+        }
+        hint = _build_smart_hint(result)
+        assert ".java file" in hint
 
 
 class TestBuildAgentSummary:

--- a/tests/unit/mcp/test_project_overview_tool.py
+++ b/tests/unit/mcp/test_project_overview_tool.py
@@ -440,8 +440,13 @@ class TestOverviewNextStep:
 
     def test_healthy_project(self) -> None:
         step = _overview_next_step({}, True)
-        # DF-10: verify next_step uses CLI-friendly guidance, not MCP-specific tool_routing
-        assert "check_project_health" in step
+        # DF-10: next_step must point at the response's own tool_routing map
+        # (a real field this tool returns) with concrete examples — not a
+        # bare tool-name the CLI surface doesn't have.
+        assert step == (
+            "Pick the next query from the tool_routing map in this response "
+            "(e.g. health for grades, structure for outlines)."
+        )
 
 
 class TestTopLanguage:

--- a/tests/unit/test_ast_cache_tool.py
+++ b/tests/unit/test_ast_cache_tool.py
@@ -254,7 +254,9 @@ class TestExecute:
     @pytest.mark.asyncio
     async def test_index_project(self, tool_with_mock_cache):
         tool, mock_cache = tool_with_mock_cache
-        mock_cache.index_project.return_value = {"files_indexed": 50}
+        mock_cache.index_project.return_value = {"indexed": 50}
+        # DF-9: verify get_stats is called to retrieve total symbol count
+        mock_cache.get_stats.return_value = {"total_symbols": 100, "total_files": 50}
         result = await tool.execute({"mode": "index", "max_files": 100, "force": True})
         assert result["success"] is True
         mock_cache.index_project.assert_called_once_with(
@@ -262,6 +264,8 @@ class TestExecute:
             force=True,
             include_activation=False,
         )
+        # DF-9: verify summary includes the symbol count
+        assert "symbols=100" in result["summary_line"]
 
     @pytest.mark.asyncio
     async def test_index_project_can_include_activation(self, tool_with_mock_cache):

--- a/tests/unit/test_codegraph_autoindex_tool.py
+++ b/tests/unit/test_codegraph_autoindex_tool.py
@@ -76,3 +76,13 @@ class TestExecute:
             {"mode": "reset", "output_format": "json"}
         )
         assert result["success"] is True
+
+    async def test_warm_mode_returns_indexed_true(self, tool_with_root):
+        # DF-8: verify warm mode returns indexed=true and cache_stats after successful index
+        result = await tool_with_root.execute(
+            {"mode": "warm", "max_files": 100, "output_format": "json"}
+        )
+        assert result["success"] is True
+        assert result["indexed"] is True
+        assert result["cache_stats"] is not None
+        assert isinstance(result["cache_stats"], dict)

--- a/tree_sitter_analyzer/mcp/tools/ast_cache_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/ast_cache_tool.py
@@ -425,8 +425,9 @@ class ASTCacheTool(BaseMCPTool):
             )
             files_indexed_fallback = result.get("files_indexed", 0)
             indexed_files = int(result.get("indexed", files_indexed_fallback) or 0)
-            symbols_fallback = result.get("symbols", 0)
-            symbols = int(result.get("symbol_count", symbols_fallback) or 0)
+            # Get total symbol count from the cache after indexing completes
+            stats = cache.get_stats()
+            symbols = int(stats.get("total_symbols", 0) or 0)
             summary_line = (
                 f"ast_cache index project files={indexed_files} "
                 f"symbols={symbols} force={bool(force)}"

--- a/tree_sitter_analyzer/mcp/tools/auto_index_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/auto_index_tool.py
@@ -158,6 +158,11 @@ class CodeGraphAutoIndexTool(BaseMCPTool):
             project_root=self.project_root,
             indexed=True,
             cache_stats=stats,
+            # keep the long-standing top-level scalars alongside the new
+            # cache_stats dict so existing consumers don't lose them
+            total_files=stats.get("total_files", 0),
+            total_symbols=stats.get("total_symbols", 0),
+            fts5_available=stats.get("fts5_available", False),
         )
         return apply_toon_format_to_response(result, output_format)
 

--- a/tree_sitter_analyzer/mcp/tools/auto_index_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/auto_index_tool.py
@@ -156,9 +156,8 @@ class CodeGraphAutoIndexTool(BaseMCPTool):
         result = build_response(
             verdict="INFO",
             project_root=self.project_root,
-            total_files=stats.get("total_files", 0),
-            total_symbols=stats.get("total_symbols", 0),
-            fts5_available=stats.get("fts5_available", False),
+            indexed=True,
+            cache_stats=stats,
         )
         return apply_toon_format_to_response(result, output_format)
 

--- a/tree_sitter_analyzer/mcp/tools/project_overview_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/project_overview_tool.py
@@ -62,6 +62,9 @@ _LANGUAGE_TO_EXT = {
     "css": "css",
     "yaml": "yaml",
     "markdown": "md",
+    "bash": "sh",
+    "scala": "scala",
+    "json": "json",
 }
 
 _EXCLUDE_DIRS = frozenset(
@@ -527,7 +530,10 @@ def _overview_next_step(result: dict[str, Any], include_health: bool) -> str:
         )
     if not include_health:
         return "Re-run overview with include_health=true or run project-health."
-    return "Run check_project_health for detailed analysis and targeted fixes."
+    return (
+        "Pick the next query from the tool_routing map in this response "
+        "(e.g. health for grades, structure for outlines)."
+    )
 
 
 def _top_language(language_distribution: dict[str, int]) -> str:

--- a/tree_sitter_analyzer/mcp/tools/project_overview_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/project_overview_tool.py
@@ -42,6 +42,28 @@ _SUPPORTED_EXTS = {
     ".md": "markdown",
 }
 
+# Reverse mapping: language name → canonical file extension (for hints/suggestions)
+_LANGUAGE_TO_EXT = {
+    "python": "py",
+    "java": "java",
+    "javascript": "js",
+    "typescript": "ts",
+    "go": "go",
+    "rust": "rs",
+    "kotlin": "kt",
+    "swift": "swift",
+    "csharp": "cs",
+    "ruby": "rb",
+    "php": "php",
+    "c": "c",
+    "cpp": "cpp",
+    "sql": "sql",
+    "html": "html",
+    "css": "css",
+    "yaml": "yaml",
+    "markdown": "md",
+}
+
 _EXCLUDE_DIRS = frozenset(
     _PROJECT_EXCLUDE_DIRS  # canonical: .ast-cache, .tree-sitter-cache, etc.
     | {
@@ -505,7 +527,7 @@ def _overview_next_step(result: dict[str, Any], include_health: bool) -> str:
         )
     if not include_health:
         return "Re-run overview with include_health=true or run project-health."
-    return "Use tool_routing to choose the next focused MCP tool."
+    return "Run check_project_health for detailed analysis and targeted fixes."
 
 
 def _top_language(language_distribution: dict[str, int]) -> str:
@@ -614,8 +636,9 @@ def _build_smart_hint(result: dict[str, Any]) -> str:
         parts.append("Project health is good — all top files are A/B/C grade")
 
     if top_lang:
+        ext = _LANGUAGE_TO_EXT.get(top_lang, top_lang)
         parts.append(
-            f"SMART 'Analyze': analyze_code_structure on any .{top_lang} file for detailed table"
+            f"SMART 'Analyze': analyze_code_structure on any .{ext} file for detailed table"
         )
 
     largest = result.get("largest_source_files", [])


### PR DESCRIPTION
## Summary
Four trust-killer fixes from the 2026-06-11 dogfood round (.recon/dogfood-2026-06-11.md):
- **DF-9**: `--ast-cache index` summary said `symbols=0` while indexing 13 — now reports the real count via the same `get_stats()` the stats action uses.
- **DF-8**: `--autoindex warm` returned `indexed:false, cache_stats:null` after success — now `indexed:true` + full `cache_stats`, keeping the legacy top-level scalars (no silent key removal).
- **DF-10**: next_step said 'Use tool_routing…' (reads like a tool name); now points at the response's own tool_routing map with concrete examples. (Review caught that the first fix would have introduced `check_project_health` — a legacy shim absent from the CLI; corrected.)
- **DF-11**: '.python file' → '.py file' via `_LANGUAGE_TO_EXT` (incl. bash→sh per review).

## Review chain (dev ≠ review)
Adversarial review: 2 P2 (leftover tool_routing literal in stop_condition kept intentionally — it names a real response field; key-removal compat) + 2 P3 — addressed in d845fe20.

## Test plan
- [x] 160 tests green across the 4 touched test files (single-process)