### PR TITLE
fix(kotlin): method ownership — is_method/receiver_type (Theme A)

### DIFF
--- a/tests/unit/languages/test_kotlin_method_receiver.py
+++ b/tests/unit/languages/test_kotlin_method_receiver.py
@@ -1,0 +1,164 @@
+"""Theme-A (Kotlin) regression: class/object method ownership.
+
+2026-06-11 quality-audit finding DF-18: Kotlin functions inside classes were
+extracted with ``is_method=False`` and ``receiver_type=None`` — an agent
+could not tell ``feed`` belongs to ``Dog``.
+
+Semantics pinned here:
+- any fun inside a ``class_declaration`` or ``object_declaration`` gets
+  ``receiver_type`` = the owning type name, ``is_method=True``
+  (Kotlin instance methods always have an implicit ``this``);
+- fun inside ``companion object`` gets ``receiver_type`` = the enclosing
+  class name, ``is_method=False`` (companion funs are effectively static);
+- top-level fun: ``receiver_type=None``, ``is_method=False``;
+- extension fun (``fun String.shout()``): ``receiver_type='String'``,
+  ``is_method=True`` (documented choice — extension funs behave like
+  methods on the receiver type from the call-site's perspective).
+
+Node types confirmed by live parse (2026-06-11):
+  class member: function_declaration → class_body → class_declaration
+  companion member: function_declaration → class_body → companion_object
+                     → class_body → class_declaration
+  object member: function_declaration → class_body → object_declaration
+  extension: user_type + '.' + identifier siblings in function_declaration
+"""
+
+from __future__ import annotations
+
+import tree_sitter
+import tree_sitter_kotlin
+
+from tree_sitter_analyzer.languages.kotlin_helpers import extract_kotlin_function
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_language() -> tree_sitter.Language:
+    caps_or_lang = tree_sitter_kotlin.language()
+    if hasattr(caps_or_lang, "__class__") and "Language" in str(type(caps_or_lang)):
+        return caps_or_lang
+    return tree_sitter.Language(caps_or_lang)
+
+
+def _parse(source: str) -> tree_sitter.Tree:
+    lang = _build_language()
+    parser = tree_sitter.Parser()
+    if hasattr(parser, "set_language"):
+        parser.set_language(lang)
+    else:
+        parser = tree_sitter.Parser(lang)
+    return parser.parse(source.encode("utf-8"))
+
+
+def _functions(source: str) -> dict[str, object]:
+    """Return a name→Function dict parsed from *source*."""
+    tree = _parse(source)
+    results = {}
+
+    def _visit(node: tree_sitter.Node) -> None:
+        if node.type == "function_declaration":
+            func = extract_kotlin_function(node, _node_text, "")
+            if func:
+                results[func.name] = func
+        for child in node.children:
+            _visit(child)
+
+    src_bytes = source.encode("utf-8")
+
+    def _node_text(n: tree_sitter.Node) -> str:
+        return src_bytes[n.start_byte : n.end_byte].decode("utf-8", errors="replace")
+
+    _visit(tree.root_node)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+_CLASS_SRC = """\
+class Dog(val name: String) {
+    fun feed(food: String): Unit {
+        println(food)
+    }
+
+    fun bark(): String = "Woof"
+
+    companion object {
+        fun create(): Dog = Dog("Buddy")
+    }
+}
+
+object Singleton {
+    fun doSomething(): Int = 42
+}
+
+fun topLevelFun(x: Int): Int = x + 1
+
+fun String.shout(): String = this.uppercase()
+"""
+
+
+def test_class_method_gets_receiver_type() -> None:
+    """fun inside a class_declaration → receiver_type = class name, is_method=True."""
+    funcs = _functions(_CLASS_SRC)
+    assert funcs["feed"].receiver_type == "Dog", f"got {funcs['feed'].receiver_type!r}"
+    assert funcs["feed"].is_method is True
+
+
+def test_class_method_bark_gets_receiver_type() -> None:
+    funcs = _functions(_CLASS_SRC)
+    assert funcs["bark"].receiver_type == "Dog"
+    assert funcs["bark"].is_method is True
+
+
+def test_companion_object_fun_is_not_instance_method() -> None:
+    """companion object funs are static-like — receiver_type = enclosing class,
+    is_method=False (no implicit this on a companion fun call)."""
+    funcs = _functions(_CLASS_SRC)
+    assert funcs["create"].receiver_type == "Dog", (
+        f"got {funcs['create'].receiver_type!r}"
+    )
+    assert funcs["create"].is_method is False
+
+
+def test_object_declaration_member_gets_receiver_type() -> None:
+    """fun inside an object_declaration → receiver_type = object name, is_method=True."""
+    funcs = _functions(_CLASS_SRC)
+    assert funcs["doSomething"].receiver_type == "Singleton"
+    assert funcs["doSomething"].is_method is True
+
+
+def test_top_level_fun_is_unowned() -> None:
+    funcs = _functions(_CLASS_SRC)
+    assert funcs["topLevelFun"].receiver_type is None
+    assert funcs["topLevelFun"].is_method is False
+
+
+def test_extension_fun_receiver_type_and_is_method() -> None:
+    """``fun String.shout()`` — receiver_type='String', is_method=True.
+
+    Semantic choice: extension funs behave like methods on the receiver
+    type from the call-site's perspective, so is_method=True communicates
+    that agents should model ``str.shout()`` rather than ``shout(str)``.
+    The receiver_type is read from the ``user_type`` node sibling before
+    the ``.`` in the function declaration node.
+    """
+    funcs = _functions(_CLASS_SRC)
+    assert funcs["shout"].receiver_type == "String", (
+        f"got {funcs['shout'].receiver_type!r}"
+    )
+    assert funcs["shout"].is_method is True
+
+
+def test_receiver_survives_api_serialization() -> None:
+    """End-to-end Theme-A (Kotlin): the serializer allowlist must carry
+    the receiver binding to API consumers."""
+    from tree_sitter_analyzer._api_result_helpers import element_to_dict
+
+    funcs = _functions(_CLASS_SRC)
+    feed = element_to_dict(funcs["feed"])
+    assert feed["receiver_type"] == "Dog"
+    assert feed["is_method"] is True

--- a/tests/unit/languages/test_kotlin_method_receiver.py
+++ b/tests/unit/languages/test_kotlin_method_receiver.py
@@ -162,3 +162,94 @@ def test_receiver_survives_api_serialization() -> None:
     feed = element_to_dict(funcs["feed"])
     assert feed["receiver_type"] == "Dog"
     assert feed["is_method"] is True
+
+
+# ---------------------------------------------------------------------------
+# P1 — local functions falsely attributed (adversarial review fix)
+# ---------------------------------------------------------------------------
+
+_LOCAL_FUN_SRC = """\
+class Outer {
+    fun outer() {
+        fun inner() {}
+    }
+}
+"""
+
+_ANON_OBJECT_SRC = """\
+class C {
+    fun m() {
+        val r = object : Runnable {
+            override fun run() {}
+        }
+    }
+}
+"""
+
+
+def test_local_fun_inside_method_is_unowned() -> None:
+    """P1: ``inner`` declared inside a method body must NOT be attributed to Outer.
+
+    The walk must stop (return no-owner) when it crosses a
+    ``function_declaration`` boundary before finding a class.
+    receiver_type=None, is_method=False (exact).
+    """
+    funcs = _functions(_LOCAL_FUN_SRC)
+    assert "inner" in funcs, f"inner not found; found: {list(funcs)}"
+    assert funcs["inner"].receiver_type is None, f"got {funcs['inner'].receiver_type!r}"
+    assert funcs["inner"].is_method is False
+
+
+def test_anon_object_override_inside_method_is_unowned() -> None:
+    """P1: ``run`` inside an anonymous object literal in a method must NOT be
+    attributed to C.  Walk stops at ``object_literal`` boundary.
+    receiver_type=None, is_method=False (exact).
+    """
+    funcs = _functions(_ANON_OBJECT_SRC)
+    assert "run" in funcs, f"run not found; found: {list(funcs)}"
+    assert funcs["run"].receiver_type is None, f"got {funcs['run'].receiver_type!r}"
+    assert funcs["run"].is_method is False
+
+
+# ---------------------------------------------------------------------------
+# P2a — nullable extension receiver (adversarial review fix)
+# ---------------------------------------------------------------------------
+
+_NULLABLE_EXT_SRC = """\
+fun String?.safe(): String = this ?: ""
+"""
+
+
+def test_nullable_extension_receiver_type() -> None:
+    """P2a: ``fun String?.safe()`` -> receiver_type='String?', is_method=True."""
+    funcs = _functions(_NULLABLE_EXT_SRC)
+    assert "safe" in funcs, f"safe not found; found: {list(funcs)}"
+    assert funcs["safe"].receiver_type == "String?", (
+        f"got {funcs['safe'].receiver_type!r}"
+    )
+    assert funcs["safe"].is_method is True
+
+
+# ---------------------------------------------------------------------------
+# P2b — companion is_static (adversarial review fix)
+# ---------------------------------------------------------------------------
+
+_COMPANION_STATIC_SRC = """\
+class Box {
+    companion object {
+        fun empty(): Box = Box()
+    }
+}
+"""
+
+
+def test_companion_fun_is_static() -> None:
+    """P2b: companion fun -> is_method=False, is_static=True,
+    receiver_type == enclosing class name (exact).
+    """
+    funcs = _functions(_COMPANION_STATIC_SRC)
+    assert "empty" in funcs, f"empty not found; found: {list(funcs)}"
+    f = funcs["empty"]
+    assert f.receiver_type == "Box", f"got {f.receiver_type!r}"
+    assert f.is_method is False
+    assert f.is_static is True

--- a/tests/unit/languages/test_kotlin_method_receiver.py
+++ b/tests/unit/languages/test_kotlin_method_receiver.py
@@ -25,6 +25,8 @@ Node types confirmed by live parse (2026-06-11):
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 import tree_sitter
 import tree_sitter_kotlin
 
@@ -253,3 +255,324 @@ def test_companion_fun_is_static() -> None:
     assert f.receiver_type == "Box", f"got {f.receiver_type!r}"
     assert f.is_method is False
     assert f.is_static is True
+
+
+# ---------------------------------------------------------------------------
+# Coverage: _kotlin_extension_receiver edge cases (real parses)
+# ---------------------------------------------------------------------------
+
+_NESTED_CLASS_OWNER_SRC = """\
+class Outer {
+    class Inner {
+        fun method() {}
+    }
+}
+"""
+
+_ENUM_CLASS_WITH_MEMBER_SRC = """\
+enum class Color {
+    RED, GREEN, BLUE;
+
+    fun describe(): String = name
+}
+"""
+
+_EXT_REC_NULLABLE_FOLLOWED_BY_DOT = """\
+fun String?.ext(): String = this ?: ""
+"""
+
+_EXT_REC_USER_TYPE_FOLLOWED_BY_DOT = """\
+fun List.first(): Any = this.get(0)
+"""
+
+
+def test_nested_class_member_gets_inner_owner() -> None:
+    """fun inside nested Inner class → receiver_type = Inner (the immediate owner,
+    not the outer Outer class)."""
+    funcs = _functions(_NESTED_CLASS_OWNER_SRC)
+    assert "method" in funcs
+    assert funcs["method"].receiver_type == "Inner", (
+        f"got {funcs['method'].receiver_type!r}"
+    )
+
+
+def test_enum_class_member_gets_enum_owner() -> None:
+    """fun inside enum class body → receiver_type = enum name, is_method=True.
+    The walk passes through enum_class_body without stopping."""
+    funcs = _functions(_ENUM_CLASS_WITH_MEMBER_SRC)
+    assert "describe" in funcs
+    assert funcs["describe"].receiver_type == "Color", (
+        f"got {funcs['describe'].receiver_type!r}"
+    )
+    assert funcs["describe"].is_method is True
+
+
+def test_extension_receiver_with_nullable_type_and_dot() -> None:
+    """_kotlin_extension_receiver identifies nullable_type followed by '.' as
+    extension receiver."""
+    funcs = _functions(_EXT_REC_NULLABLE_FOLLOWED_BY_DOT)
+    assert "ext" in funcs
+    assert funcs["ext"].receiver_type == "String?", (
+        f"got {funcs['ext'].receiver_type!r}"
+    )
+
+
+def test_extension_receiver_with_user_type_and_dot() -> None:
+    """_kotlin_extension_receiver identifies user_type followed by '.' as
+    extension receiver."""
+    funcs = _functions(_EXT_REC_USER_TYPE_FOLLOWED_BY_DOT)
+    assert "first" in funcs
+    assert funcs["first"].receiver_type == "List", (
+        f"got {funcs['first'].receiver_type!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Coverage: _kotlin_owning_type (unit tests with mocks)
+# ---------------------------------------------------------------------------
+
+
+def test_kotlin_owning_type_parent_none_depth_zero() -> None:
+    """_kotlin_owning_type with node.parent = None → (None, False)."""
+    from tree_sitter_analyzer.languages.kotlin_helpers import _kotlin_owning_type
+
+    node = MagicMock()
+    node.parent = None
+    result = _kotlin_owning_type(node)
+    assert result == (None, False), f"got {result!r}"
+
+
+def test_kotlin_owning_type_source_file_boundary() -> None:
+    """_kotlin_owning_type stops at source_file → (None, False)."""
+    from tree_sitter_analyzer.languages.kotlin_helpers import _kotlin_owning_type
+
+    node = MagicMock()
+    source_file = MagicMock()
+    source_file.type = "source_file"
+    source_file.parent = None
+    node.parent = source_file
+    result = _kotlin_owning_type(node)
+    assert result == (None, False), f"got {result!r}"
+
+
+def test_kotlin_owning_type_local_function_boundary() -> None:
+    """_kotlin_owning_type stops at function_declaration → (None, False).
+    Local functions inside a method must not be attributed to the enclosing class."""
+    from tree_sitter_analyzer.languages.kotlin_helpers import _kotlin_owning_type
+
+    node = MagicMock()
+    func_decl = MagicMock()
+    func_decl.type = "function_declaration"
+    class_decl = MagicMock()
+    class_decl.type = "class_declaration"
+    node.parent = func_decl
+    func_decl.parent = class_decl
+    class_decl.parent = None
+
+    result = _kotlin_owning_type(node)
+    assert result == (None, False), (
+        f"got {result!r} — walk should stop at function_declaration"
+    )
+
+
+def test_kotlin_owning_type_object_literal_boundary() -> None:
+    """_kotlin_owning_type stops at object_literal → (None, False).
+    Overrides inside anonymous objects must not be attributed to the enclosing class."""
+    from tree_sitter_analyzer.languages.kotlin_helpers import _kotlin_owning_type
+
+    node = MagicMock()
+    obj_lit = MagicMock()
+    obj_lit.type = "object_literal"
+    func_decl = MagicMock()
+    func_decl.type = "function_declaration"
+    node.parent = obj_lit
+    obj_lit.parent = func_decl
+    func_decl.parent = None
+
+    result = _kotlin_owning_type(node)
+    assert result == (None, False), (
+        f"got {result!r} — walk should stop at object_literal"
+    )
+
+
+def test_kotlin_owning_type_class_declaration_with_name_field() -> None:
+    """_kotlin_owning_type finds class owner via child_by_field_name('name')."""
+    from tree_sitter_analyzer.languages.kotlin_helpers import _kotlin_owning_type
+
+    node = MagicMock()
+    class_decl = MagicMock()
+    class_decl.type = "class_declaration"
+    class_decl.parent = None
+
+    name_node = MagicMock()
+    name_node.text = b"MyClass"
+    class_decl.child_by_field_name.return_value = name_node
+
+    node.parent = class_decl
+    result = _kotlin_owning_type(node)
+    assert result == ("MyClass", False), f"got {result!r}"
+
+
+def test_kotlin_owning_type_class_declaration_name_via_identifier_scan() -> None:
+    """_kotlin_owning_type falls back to scanning children for 'identifier'
+    when child_by_field_name('name') returns None."""
+    from tree_sitter_analyzer.languages.kotlin_helpers import _kotlin_owning_type
+
+    node = MagicMock()
+    class_decl = MagicMock()
+    class_decl.type = "class_declaration"
+    class_decl.parent = None
+
+    class_decl.child_by_field_name.return_value = None
+    name_child = MagicMock()
+    name_child.type = "identifier"
+    name_child.text = b"ClassViaIdent"
+    other_child = MagicMock()
+    other_child.type = "other"
+    class_decl.children = [other_child, name_child]
+
+    node.parent = class_decl
+    result = _kotlin_owning_type(node)
+    assert result == ("ClassViaIdent", False), f"got {result!r}"
+
+
+def test_kotlin_owning_type_class_declaration_no_name_found() -> None:
+    """_kotlin_owning_type returns (None, False) when class has no name field
+    and no identifier child."""
+    from tree_sitter_analyzer.languages.kotlin_helpers import _kotlin_owning_type
+
+    node = MagicMock()
+    class_decl = MagicMock()
+    class_decl.type = "class_declaration"
+    class_decl.parent = None
+    class_decl.child_by_field_name.return_value = None
+    class_decl.children = []
+
+    node.parent = class_decl
+    result = _kotlin_owning_type(node)
+    assert result == (None, False), f"got {result!r}"
+
+
+def test_kotlin_owning_type_object_declaration_owner() -> None:
+    """_kotlin_owning_type finds object owner."""
+    from tree_sitter_analyzer.languages.kotlin_helpers import _kotlin_owning_type
+
+    node = MagicMock()
+    obj_decl = MagicMock()
+    obj_decl.type = "object_declaration"
+    obj_decl.parent = None
+    name_node = MagicMock()
+    name_node.text = b"SingletonObj"
+    obj_decl.child_by_field_name.return_value = name_node
+
+    node.parent = obj_decl
+    result = _kotlin_owning_type(node)
+    assert result == ("SingletonObj", False), f"got {result!r}"
+
+
+def test_kotlin_owning_type_companion_object_walks_further() -> None:
+    """_kotlin_owning_type marks in_companion=True and continues walking
+    past companion_object to find the enclosing class."""
+    from tree_sitter_analyzer.languages.kotlin_helpers import _kotlin_owning_type
+
+    node = MagicMock()
+    companion = MagicMock()
+    companion.type = "companion_object"
+
+    class_decl = MagicMock()
+    class_decl.type = "class_declaration"
+    class_decl.parent = None
+    class_name = MagicMock()
+    class_name.text = b"Box"
+    class_decl.child_by_field_name.return_value = class_name
+
+    node.parent = companion
+    companion.parent = class_decl
+
+    result = _kotlin_owning_type(node)
+    assert result == ("Box", True), (
+        f"got {result!r} — should return enclosing class with is_companion=True"
+    )
+
+
+def test_kotlin_owning_type_depth_cap() -> None:
+    """_kotlin_owning_type is capped at 256 iterations to prevent unbounded loops
+    on non-conforming node objects (e.g. circular parent chains or MagicMock)."""
+    from tree_sitter_analyzer.languages.kotlin_helpers import _kotlin_owning_type
+
+    node = MagicMock()
+    current = node
+    for i in range(260):
+        parent = MagicMock()
+        parent.type = f"unknown_{i}"
+        parent.parent = None if i == 259 else MagicMock()
+        current.parent = parent
+        current = parent
+
+    result = _kotlin_owning_type(node)
+    assert result == (None, False), (
+        f"got {result!r} — depth cap at 256 should terminate the loop and return (None, False)"
+    )
+
+
+def test_kotlin_owning_type_unicode_name_handling() -> None:
+    """_kotlin_owning_type safely decodes non-UTF8 bytes in name_node.text."""
+    from tree_sitter_analyzer.languages.kotlin_helpers import _kotlin_owning_type
+
+    node = MagicMock()
+    class_decl = MagicMock()
+    class_decl.type = "class_declaration"
+    class_decl.parent = None
+    name_node = MagicMock()
+    name_node.text = b"\xff\xfe"
+    class_decl.child_by_field_name.return_value = name_node
+
+    node.parent = class_decl
+    result = _kotlin_owning_type(node)
+    assert result[0] is not None, f"got {result!r}"
+    assert result[1] is False
+
+
+def test_kotlin_owning_type_decode_attribute_error() -> None:
+    """_kotlin_owning_type handles AttributeError when name_node.text
+    doesn't have a decode method."""
+    from tree_sitter_analyzer.languages.kotlin_helpers import _kotlin_owning_type
+
+    node = MagicMock()
+    class_decl = MagicMock()
+    class_decl.type = "class_declaration"
+    class_decl.parent = None
+    name_node = MagicMock()
+    # Simulate a text attribute that doesn't have .decode() method
+    name_node.text = "StringInsteadOfBytes"  # str, not bytes
+    class_decl.child_by_field_name.return_value = name_node
+
+    node.parent = class_decl
+    result = _kotlin_owning_type(node)
+    # Should fall back to str(name_node.text)
+    assert result == ("StringInsteadOfBytes", False), f"got {result!r}"
+
+
+def test_kotlin_owning_type_decode_unicode_error() -> None:
+    """_kotlin_owning_type handles UnicodeDecodeError when name_node.text
+    contains invalid UTF-8."""
+    from tree_sitter_analyzer.languages.kotlin_helpers import _kotlin_owning_type
+
+    node = MagicMock()
+    class_decl = MagicMock()
+    class_decl.type = "class_declaration"
+    class_decl.parent = None
+    name_node = MagicMock()
+    # Create a mock that raises UnicodeDecodeError when .decode is called
+    name_node.text = MagicMock()
+    name_node.text.decode.side_effect = UnicodeDecodeError(
+        "utf-8", b"\x80", 0, 1, "invalid start byte"
+    )
+
+    class_decl.child_by_field_name.return_value = name_node
+
+    node.parent = class_decl
+    result = _kotlin_owning_type(node)
+    # Should fall back to str(name_node.text)
+    assert result[0] is not None, f"got {result!r}"
+    assert result[1] is False

--- a/tests/unit/languages/test_kotlin_properties.py
+++ b/tests/unit/languages/test_kotlin_properties.py
@@ -54,6 +54,10 @@ def kotlin_function_nodes(draw):
     # Create mock node
     node = MagicMock()
     node.type = "function_declaration"
+    # Mock safety: set parent=None so _kotlin_owning_type depth-capped walk
+    # terminates immediately instead of following MagicMock's infinite
+    # auto-generated attribute chain (2026-06-11 OOM guard).
+    node.parent = None
     node.start_point = (draw(st.integers(0, 100)), 0)
     node.end_point = (node.start_point[0] + 5, 0)
     node.start_byte = 0

--- a/tests/unit/languages/test_kotlin_properties.py
+++ b/tests/unit/languages/test_kotlin_properties.py
@@ -125,6 +125,10 @@ def kotlin_class_nodes(draw):
 
     node = MagicMock()
     node.type = "class_declaration" if kind != "object" else "object_declaration"
+    # P3b (2026-06-11 adversarial review): set parent=None so any future
+    # walk of the parent chain terminates immediately instead of following
+    # MagicMock's infinite auto-generated attribute chain (OOM defense).
+    node.parent = None
     node.start_point = (draw(st.integers(0, 100)), 0)
     node.end_point = (node.start_point[0] + 3, 0)
     node.start_byte = 0

--- a/tree_sitter_analyzer/languages/kotlin_helpers.py
+++ b/tree_sitter_analyzer/languages/kotlin_helpers.py
@@ -128,8 +128,11 @@ def _kotlin_extension_receiver(
     for i, child in enumerate(children):
         if child.type == "function_value_parameters":
             break
-        if child.type == "user_type":
+        if child.type in ("user_type", "nullable_type"):
             # Check next non-error sibling is '.'
+            # P2a (2026-06-11 adversarial review): ``fun String?.safe()``
+            # emits a ``nullable_type`` node (not ``user_type``) before the
+            # dot — return its full text including the trailing '?'.
             if i + 1 < len(children) and children[i + 1].type == ".":
                 return get_node_text(child)
     return None
@@ -145,9 +148,18 @@ def _kotlin_owning_type(node: Any) -> tuple[str | None, bool]:
       ``class_declaration`` and return (name, True)
     - ``source_file`` or None → (None, False)
 
-    The walk is depth-capped at 256 to prevent unbounded loops on
-    non-conforming node objects (e.g. MagicMock infinite parent chains
-    that caused a 140 GB OOM on 2026-06-10).
+    Boundary nodes that abort the walk with (None, False):
+    - ``function_declaration``: local functions declared inside a method
+      body must not be attributed to the outer class.
+    - ``object_literal``: ``override fun`` inside an anonymous
+      ``object : Runnable { ... }`` inside a method belongs to the
+      anonymous object, not the enclosing class.
+
+    The walk traverses through ``enum_class_body`` without stopping —
+    enum entries can contain method declarations that belong to the enum.
+
+    Depth-capped at 256 to prevent unbounded loops on non-conforming node
+    objects (e.g. MagicMock infinite parent chains — 140 GB OOM 2026-06-10).
     """
     parent = node.parent
     in_companion = False
@@ -155,6 +167,10 @@ def _kotlin_owning_type(node: Any) -> tuple[str | None, bool]:
         if parent is None:
             return None, False
         if parent.type == "source_file":
+            return None, False
+        # P1 (2026-06-11 adversarial review): local funs and anonymous-object
+        # overrides must not be attributed to the outer enclosing class.
+        if parent.type in ("function_declaration", "object_literal"):
             return None, False
         if parent.type == "companion_object":
             in_companion = True
@@ -257,6 +273,12 @@ def extract_kotlin_function(
             if owner is not None:
                 func.receiver_type = owner
                 func.is_method = not is_companion
+                # P2b (2026-06-11 adversarial review): companion funs are
+                # static-like (no implicit ``this``); flag them so agents
+                # can distinguish them from instance methods, matching
+                # Java/C#/etc. conventions for companion/static members.
+                if is_companion:
+                    func.is_static = True
 
         return func
 

--- a/tree_sitter_analyzer/languages/kotlin_helpers.py
+++ b/tree_sitter_analyzer/languages/kotlin_helpers.py
@@ -108,6 +108,77 @@ def _kotlin_parameter_pair(
     return param_name, param_type
 
 
+def _kotlin_extension_receiver(
+    node: Any, get_node_text: Callable[..., str]
+) -> str | None:
+    """Return the extension receiver type name, or None.
+
+    ``fun String.shout()`` parses as:
+        function_declaration
+          user_type  ← receiver type
+          .
+          identifier ← function name
+          …
+
+    We detect the pattern by scanning children for a ``user_type`` node
+    that is immediately followed by a ``.`` child before any
+    ``function_value_parameters`` node.
+    """
+    children = list(node.children)
+    for i, child in enumerate(children):
+        if child.type == "function_value_parameters":
+            break
+        if child.type == "user_type":
+            # Check next non-error sibling is '.'
+            if i + 1 < len(children) and children[i + 1].type == ".":
+                return get_node_text(child)
+    return None
+
+
+def _kotlin_owning_type(node: Any) -> tuple[str | None, bool]:
+    """Walk the parent chain and return ``(owner_name, is_companion)``.
+
+    Traversal stops at the first owning declaration:
+    - ``class_declaration`` → (name, False) for regular class members
+    - ``object_declaration`` → (name, False) for object members
+    - ``companion_object`` → walk further to the enclosing
+      ``class_declaration`` and return (name, True)
+    - ``source_file`` or None → (None, False)
+
+    The walk is depth-capped at 256 to prevent unbounded loops on
+    non-conforming node objects (e.g. MagicMock infinite parent chains
+    that caused a 140 GB OOM on 2026-06-10).
+    """
+    parent = node.parent
+    in_companion = False
+    for _ in range(256):
+        if parent is None:
+            return None, False
+        if parent.type == "source_file":
+            return None, False
+        if parent.type == "companion_object":
+            in_companion = True
+        elif parent.type in ("class_declaration", "object_declaration"):
+            name_node = parent.child_by_field_name("name")
+            if name_node is None:
+                for child in parent.children:
+                    if child.type == "identifier":
+                        name_node = child
+                        break
+            if name_node is not None:
+                # Use node.text if available (real tree-sitter nodes),
+                # otherwise fall back to a callable get_node_text is not
+                # in scope here, so we rely on node.text directly.
+                try:
+                    name = name_node.text.decode("utf-8", errors="replace")
+                except (AttributeError, UnicodeDecodeError):
+                    name = str(name_node.text)
+                return name, in_companion
+            return None, False
+        parent = parent.parent
+    return None, False
+
+
 def extract_kotlin_function(
     node: Any,
     get_node_text: Callable[..., str],
@@ -124,6 +195,14 @@ def extract_kotlin_function(
                 if child.type == "simple_identifier":
                     name = get_node_text(child)
                     break
+            # Extension funs: name identifier follows the '.' after receiver type
+            if name == "anonymous":
+                children = list(node.children)
+                for i, child in enumerate(children):
+                    if child.type == "." and i + 1 < len(children):
+                        if children[i + 1].type == "identifier":
+                            name = get_node_text(children[i + 1])
+                            break
 
         start_line = node.start_point[0] + 1
         end_line = node.end_point[0] + 1
@@ -158,6 +237,27 @@ def extract_kotlin_function(
             visibility=visibility,
         )
         func.is_suspend = is_suspend
+
+        # Theme-A (2026-06-11): class/object ownership. Functions inside
+        # ``class Dog { fun feed() }`` were flattened to top-level with no
+        # receiver_type — an agent could not tell ``feed`` belongs to ``Dog``.
+        #
+        # Resolution order:
+        # 1. Extension receiver: ``fun String.shout()`` → receiver_type='String',
+        #    is_method=True (declared explicitly in the function signature).
+        # 2. Owning class/object via parent walk:
+        #    - class/object member → receiver_type=owner, is_method=True
+        #    - companion object member → receiver_type=enclosing class, is_method=False
+        ext_receiver = _kotlin_extension_receiver(node, get_node_text)
+        if ext_receiver is not None:
+            func.receiver_type = ext_receiver
+            func.is_method = True
+        else:
+            owner, is_companion = _kotlin_owning_type(node)
+            if owner is not None:
+                func.receiver_type = owner
+                func.is_method = not is_companion
+
         return func
 
     except Exception as e:


### PR DESCRIPTION
## Summary
Dogfood DF-18: Kotlin functions inside classes had `is_method=False`, `receiver_type=None` — an agent couldn't tell `feed` belongs to `Dog` (params were fixed in #431; ownership wasn't). Mirrors the Rust fix (#428), OOM-hardened (depth-capped walk, mock parent=None).

Semantics: class/object/interface/enum member → `is_method=True` + `receiver_type=TypeName` (innermost); companion fun → `is_static=True`, `is_method=False`, `receiver_type=EnclosingClass` (consistent with Java/C# statics); extension `fun String.shout()` / nullable `fun String?.safe()` → method with receiver text; local fns + anonymous-object overrides inside methods → unowned (walk stops at function/object_literal boundaries).

## Review chain (dev ≠ review)
opencode hung → reviewer-agent fallback (chain tier 3). Verdict BLOCK: 1 P1 (local fns falsely attributed to outer class — zero existing test coverage, caught by live-parse attack) + 2 P2 (nullable extension receiver dropped; companion missing is_static) + 2 P3. All fixed RED-first.

## Test plan
- [x] 11 tests in test_kotlin_method_receiver.py (7 original + 4 review-driven), real parses, exact assertions
- [x] languages dir: 3241 passed (1 pre-existing local-only Swift golden skip, unrelated)
- [x] Kotlin golden masters unchanged (table output doesn't render these fields)