### PR TITLE
fix(skills): teach the 8-facade surface — first-call success for PyPI users (#437)

### DIFF
--- a/.claude/skills/tsa-constraints/SKILL.md
+++ b/.claude/skills/tsa-constraints/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: tsa-constraints
-version: 1.0.0
+version: 2.0.0
 description: |
   Architectural constraint enforcement. Detect forbidden cross-module calls
   ("MCP must not depend on CLI") at index time and gate edits on them. Rules
-  live in YAML at repo root; violations bubble up through safe_to_edit and
-  change_impact as UNSAFE verdicts.
+  live in YAML at repo root; violations bubble up through edit action=safe and
+  edit action=impact as UNSAFE verdicts.
 
   Use when:
   - User asks "does this PR break architecture?"
@@ -33,21 +33,21 @@ allowed-tools:
 
 ## When to use
 
-| Goal                                       | Action                                |
-|--------------------------------------------|---------------------------------------|
-| List current rules                         | Read `architectural-constraints.yml`  |
-| Check repo against rules                   | `check_constraints` (no args)         |
-| Pre-edit gate (includes rule check)        | `safe_to_edit` (auto)                 |
-| Add a new rule                             | Edit YAML + re-run `check_constraints`|
-| Filter violations by severity              | `check_constraints(severity_min="error")` |
-| Filter by path                             | `check_constraints(path_filter="mcp/**")` |
+| Goal                                       | Action                                         |
+|--------------------------------------------|------------------------------------------------|
+| List current rules                         | Read `architectural-constraints.yml`           |
+| Check repo against rules                   | `edit action=constraints` (no args)            |
+| Pre-edit gate (includes rule check)        | `edit action=safe` (auto)                      |
+| Add a new rule                             | Edit YAML + re-run `edit action=constraints`   |
+| Filter violations by severity              | `edit action=constraints severity_min="error"` |
+| Filter by path                             | `edit action=constraints path_filter="mcp/**"` |
 
 ## Procedure
 
 ### One-shot audit
 
 ```
-check_constraints()
+edit action=constraints
 ```
 
 Returns:
@@ -79,7 +79,7 @@ Verdict cascade:
      reason: "<why this is forbidden>"
      exceptions: ["specific/file.py"]   # optional
    ```
-3. Run `check_constraints` to see if existing code violates the new rule
+3. Run `edit action=constraints` to see if existing code violates the new rule
 4. Either: fix the violations OR add them to `exceptions`
 
 ### Reading violations

--- a/.claude/skills/tsa-deps/SKILL.md
+++ b/.claude/skills/tsa-deps/SKILL.md
@@ -73,7 +73,7 @@ Useful as a "first look" right after `tsa-landing`.
 uv run tree-sitter-analyzer <file> --dependencies file_deps
 uv run tree-sitter-analyzer --dependencies summary
 uv run tree-sitter-analyzer --import-graph --language python
-uv run tree-sitter-analyzer --ast-path
+uv run tree-sitter-analyzer --codegraph-sitemap
 ```
 
 ## Anti-patterns

--- a/.claude/skills/tsa-deps/SKILL.md
+++ b/.claude/skills/tsa-deps/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tsa-deps
-version: 1.0.0
+version: 2.0.0
 description: |
   Dependency / import graph analysis. Answer "what does this file import",
   "what imports this module", "what's the project's import topology",
@@ -26,18 +26,18 @@ allowed-tools:
 
 ## Tool routing
 
-| Question                                | Tool                          |
-|-----------------------------------------|-------------------------------|
-| One file's direct deps                  | `analyze_dependencies`        |
-| Project-wide import graph (who imports whom) | `codegraph_import_graph` |
-| Project topology (entry points, hubs)   | `codegraph_sitemap`           |
+| Question                                | Tool                              |
+|-----------------------------------------|-----------------------------------|
+| One file's direct deps                  | `health action=deps`              |
+| Project-wide import graph (who imports whom) | `health action=imports`      |
+| Project topology (entry points, hubs)   | `structure action=sitemap`        |
 
 ## Procedure
 
 ### File-level deps
 
 ```yaml
-analyze_dependencies(file_path: "tree_sitter_analyzer/ast_cache.py", mode: "file_deps")
+health action=deps file_path="tree_sitter_analyzer/ast_cache.py" mode="file_deps"
 # returns: {imports: [...], imported_by: [...], depth: 2}
 ```
 
@@ -49,7 +49,7 @@ analyze_dependencies(file_path: "tree_sitter_analyzer/ast_cache.py", mode: "file
 ### Import graph (project-level)
 
 ```yaml
-codegraph_import_graph(language: "python", limit: 50)
+health action=imports language="python" limit=50
 # returns: ranked list of import hubs + leaves
 ```
 
@@ -61,7 +61,7 @@ Use to find:
 ### Sitemap
 
 ```yaml
-codegraph_sitemap()
+structure action=sitemap
 # returns: {entry_points: [...], hub_modules: [...], leaf_modules: [...]}
 ```
 
@@ -73,7 +73,7 @@ Useful as a "first look" right after `tsa-landing`.
 uv run tree-sitter-analyzer <file> --dependencies file_deps
 uv run tree-sitter-analyzer --dependencies summary
 uv run tree-sitter-analyzer --import-graph --language python
-uv run tree-sitter-analyzer --sitemap
+uv run tree-sitter-analyzer --ast-path
 ```
 
 ## Anti-patterns

--- a/.claude/skills/tsa-edit-safety/SKILL.md
+++ b/.claude/skills/tsa-edit-safety/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tsa-edit-safety
-version: 1.0.0
+version: 2.0.0
 description: |
   Pre-edit safety check using tree-sitter-analyzer. One workflow → verdict
   (SAFE/REVIEW/CAUTION/UNSAFE) + verification command + risk factors → ≤2k
@@ -13,8 +13,9 @@ description: |
   - Asked "is it safe to change X?" or "what breaks if I touch Y?"
   - Before approving a code review
 
-  Workflow: 2-3 parallel MCP calls (safe_to_edit + change_impact + file_health),
-  fold the verdicts, surface the exact `verification_command` and stop_condition.
+  Workflow: 2-3 parallel MCP calls (edit action=safe + edit action=impact +
+  health action=file), fold the verdicts, surface the exact
+  `verification_command` and stop_condition.
 allowed-tools:
   - mcp__tree-sitter-analyzer__edit
   - mcp__tree-sitter-analyzer__health
@@ -45,9 +46,9 @@ allowed-tools:
 
 Call these 3 tools in ONE message:
 
-1. `safe_to_edit` with `file_path: "<the file>"` and `edit_type: "<refactor|rename|delete|bugfix>"`
-2. `analyze_change_impact` with `mode: "staged"` (or `"branch"` if pre-stage), scope to the file
-3. `check_file_health` with `file_path: "<the file>"`
+1. `edit action=safe` with `file_path: "<the file>"` and `edit_type: "<refactor|rename|delete|bugfix>"`
+2. `edit action=impact` with `mode: "staged"` (or `"branch"` if pre-stage), scope to the file
+3. `health action=file` with `file_path: "<the file>"`
 
 ### Step 2 — Read the verdict cascade
 

--- a/.claude/skills/tsa-edit-then-verify/SKILL.md
+++ b/.claude/skills/tsa-edit-then-verify/SKILL.md
@@ -150,7 +150,6 @@ PARALLEL BATCH (one message):
   → edit action=safe file_path="tree_sitter_analyzer/health_scorer.py" edit_type="feature"
   → health action=file file_path="tree_sitter_analyzer/health_scorer.py"
   → project action=smart file_path="tree_sitter_analyzer/health_scorer.py"
-                  query="add new dimension to grading rubric"
 
 Returned:
   edit action=safe:  verdict=REVIEW

--- a/.claude/skills/tsa-edit-then-verify/SKILL.md
+++ b/.claude/skills/tsa-edit-then-verify/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: tsa-edit-then-verify
-version: 1.0.0
+version: 2.0.0
 description: |
   The full edit-and-verify loop mandated by CLAUDE.md and docs/agent-tooling-gap-report.md:58.
-  Pre-edit gate (safe_to_edit + baseline file_health) → LLM edits → post-edit verify
-  (file_health diff + analyze_change_impact + scoped verification_command).
-  Replaces "edit then run the whole pytest suite" (~5 min) with a scoped
-  verification (~30-60s) that only escalates to full suite when risk remains.
+  Pre-edit gate (edit action=safe + baseline health action=file) → LLM edits →
+  post-edit verify (health action=file diff + edit action=impact + scoped
+  verification_command). Replaces "edit then run the whole pytest suite" (~5 min)
+  with a scoped verification (~30-60s) that only escalates to full suite when
+  risk remains.
 
   Use when:
   - About to make any non-trivial edit to a code file in tree-sitter-analyzer
@@ -34,9 +35,9 @@ allowed-tools:
 
 > **Source of authority.** From `docs/agent-tooling-gap-report.md` line 58:
 >
-> > Every feature update must run the self-hosted workflow: `safe_to_edit`
-> > before risky edits, `file_health` on changed files, `change_impact` after
-> > edits, its reported `verification_command`, then the full default suite
+> > Every feature update must run the self-hosted workflow: `edit action=safe`
+> > before risky edits, `health action=file` on changed files, `edit action=impact`
+> > after edits, its reported `verification_command`, then the full default suite
 > > when risk remains.
 >
 > This skill is the **executable form** of that rule. `tsa-edit-safety` only
@@ -62,11 +63,11 @@ the bigger the win — full pytest is ~5 min, scoped verification is typically
 | Skill                       | What it runs                          | Time    | When right |
 |-----------------------------|---------------------------------------|---------|------------|
 | `verify` (global)           | `uv run pytest -q` (15k tests)        | ~5 min  | Pre-commit gate, large refactor |
-| **`tsa-edit-then-verify`**  | scoped `verification_command` from `analyze_change_impact` | **30-60s** | **Every feature update (the mandate)** |
+| **`tsa-edit-then-verify`**  | scoped `verification_command` from `edit action=impact` | **30-60s** | **Every feature update (the mandate)** |
 | `tsa-edit-safety`           | Pre-edit verdict only                 | ~3s     | "Is this safe to touch?" — no edit yet |
 
 The scoped command targets only the tests reachable from the changed symbols,
-via the AST call-graph. That's the whole point — `analyze_change_impact`
+via the AST call-graph. That's the whole point — `edit action=impact`
 returns a `verification_command` that's narrower than `pytest -q` but still
 covers the blast radius the AST sees.
 
@@ -76,12 +77,12 @@ covers the blast radius the AST sees.
 
 Call these in ONE message (parallel tool use):
 
-1. `safe_to_edit` with `file_path: "<file>"` and `edit_type: "<refactor|rename|delete|bugfix|feature>"`
-2. `check_file_health` with `file_path: "<file>"` — **record the grade. This is your baseline.**
+1. `edit action=safe` with `file_path: "<file>"` and `edit_type: "<refactor|rename|delete|bugfix|feature>"`
+2. `health action=file` with `file_path: "<file>"` — **record the grade. This is your baseline.**
 3. (Optional, only if file is unfamiliar to you in this session)
-   `smart_context` with `file_path: "<file>"` and `query: "<what you intend to change>"`
+   `project action=smart` with `file_path: "<file>"` and `query: "<what you intend to change>"`
 
-**Gate the verdict.** From `safe_to_edit.verdict`:
+**Gate the verdict.** From `edit action=safe verdict`:
 - `UNSAFE` → STOP. Surface the `risk_factors`, ask the user how to proceed.
   Do not edit.
 - `CAUTION` → narrow your scope. Write a failing test first if there isn't
@@ -90,8 +91,8 @@ Call these in ONE message (parallel tool use):
   "no tests nearby".
 - `SAFE` → proceed to Phase B.
 
-**Persist the baseline grade.** Note `check_file_health.grade` and
-`check_file_health.score` in your scratch — you will diff against these in
+**Persist the baseline grade.** Note `health action=file grade` and
+`health action=file score` in your scratch — you will diff against these in
 Phase C.
 
 ### Phase B — Edit (out of skill scope)
@@ -108,10 +109,10 @@ and reconsider whether this is really one task or three.
 
 After your last edit, call these in ONE message (parallel tool use):
 
-4. `check_file_health` with `file_path: "<file>"` again
+4. `health action=file` with `file_path: "<file>"` again
    → **diff against Phase A baseline. Grade MUST NOT regress.** (B→C is a
    regression. A→A is fine. F→D is improvement.)
-5. `analyze_change_impact` with `mode: "staged"` (or `mode: "branch"` if you
+5. `edit action=impact` with `mode: "staged"` (or `mode: "branch"` if you
    haven't staged) — returns `verification_command`, `pytest_command`,
    `queue_ledger`, `risk_remains` flag.
 
@@ -124,7 +125,7 @@ After your last edit, call these in ONE message (parallel tool use):
    ```
    Expect 30-60s. If it fails, fix and re-run from step 4.
 
-7. **Only if** `analyze_change_impact.risk_remains == true` (or grade
+7. **Only if** `edit action=impact risk_remains == true` (or grade
    regressed in step 4, or impact reports cross-module reach), run the full
    suite:
    ```bash
@@ -146,17 +147,17 @@ health-grading rubric.
 
 ```
 PARALLEL BATCH (one message):
-  → safe_to_edit(file_path="tree_sitter_analyzer/health_scorer.py", edit_type="feature")
-  → check_file_health(file_path="tree_sitter_analyzer/health_scorer.py")
-  → smart_context(file_path="tree_sitter_analyzer/health_scorer.py",
-                  query="add new dimension to grading rubric")
+  → edit action=safe file_path="tree_sitter_analyzer/health_scorer.py" edit_type="feature"
+  → health action=file file_path="tree_sitter_analyzer/health_scorer.py"
+  → project action=smart file_path="tree_sitter_analyzer/health_scorer.py"
+                  query="add new dimension to grading rubric"
 
 Returned:
-  safe_to_edit:  verdict=REVIEW
+  edit action=safe:  verdict=REVIEW
                  risk_factors=[{factor: "hot_zone", detail: "mod_count_30d=7"}]
                  verification_command="uv run pytest tests/unit/test_health_scorer.py -q"
-  check_file_health: grade=B, score=84, weakest=complexity   ← BASELINE
-  smart_context: top 3 callers = [check_project_health, check_file_health, cli/__main__]
+  health action=file: grade=B, score=84, weakest=complexity   ← BASELINE
+  project action=smart: top 3 callers = [health action=project, health action=file, cli/__main__]
 ```
 
 Verdict is REVIEW + hot_zone — write a test for the new dimension first.
@@ -170,12 +171,12 @@ dimension. Diff is ~40 lines.
 
 ```
 PARALLEL BATCH (one message):
-  → check_file_health(file_path="tree_sitter_analyzer/health_scorer.py")
-  → analyze_change_impact(mode="staged")
+  → health action=file file_path="tree_sitter_analyzer/health_scorer.py"
+  → edit action=impact mode="staged"
 
 Returned:
-  check_file_health: grade=B, score=82, weakest=complexity   ← B→B, no regression ✓
-  analyze_change_impact:
+  health action=file: grade=B, score=82, weakest=complexity   ← B→B, no regression ✓
+  edit action=impact:
     verification_command="uv run pytest tests/unit/test_health_scorer.py
                           tests/unit/test_file_health_blocks.py
                           tests/unit/test_file_health_smells.py -q"
@@ -243,7 +244,7 @@ uv run tree-sitter-analyzer tree_sitter_analyzer/health_scorer.py \
 uv run tree-sitter-analyzer tree_sitter_analyzer/health_scorer.py \
   --file-health --output-format json
 uv run tree-sitter-analyzer tree_sitter_analyzer/health_scorer.py \
-  --smart-context --query "add new dimension" --output-format json
+  --smart-context --output-format json
 ```
 
 Run post-edit (Phase C):
@@ -258,16 +259,16 @@ uv run python -m tree_sitter_analyzer --change-impact \
 
 ## Verdict cascade (Phase A gate)
 
-| `safe_to_edit.verdict` | Action |
-|------------------------|--------|
-| `UNSAFE`               | STOP. Surface risk_factors. Ask user. Do not edit. |
-| `CAUTION`              | Narrow scope. Write test first. Then edit. |
-| `REVIEW`               | Edit OK; write a test first if "no tests nearby". |
-| `SAFE`                 | Proceed to Phase B. |
+| `edit action=safe verdict` | Action |
+|----------------------------|--------|
+| `UNSAFE`                   | STOP. Surface risk_factors. Ask user. Do not edit. |
+| `CAUTION`                  | Narrow scope. Write test first. Then edit. |
+| `REVIEW`                   | Edit OK; write a test first if "no tests nearby". |
+| `SAFE`                     | Proceed to Phase B. |
 
 ## Grade-regression rule (Phase C step 4)
 
-Compare `check_file_health.grade` before vs. after:
+Compare `health action=file grade` before vs. after:
 
 | Before → After | Verdict | Action |
 |----------------|---------|--------|
@@ -283,11 +284,11 @@ Let the user decide.
 
 Run `uv run pytest -q` (full suite, ~5 min) only when ANY of these is true:
 
-- `analyze_change_impact.risk_remains == true`
+- `edit action=impact risk_remains == true`
 - Grade regressed in step 4 (A→B or worse)
 - Edit touched any of: `BaseMCPTool.__init__`, `PathResolver`, `SecurityValidator`, `plugin registry`, `cli/__main__.py`, `mcp/server.py`
 - Edit crossed >3 files
-- `analyze_change_impact.queue_ledger` shows cross-module reach (impact crossing top-level packages)
+- `edit action=impact queue_ledger` shows cross-module reach (impact crossing top-level packages)
 
 Otherwise the scoped `verification_command` from step 6 is the official
 verify gate — no need to burn 5 minutes.
@@ -298,7 +299,7 @@ verify gate — no need to burn 5 minutes.
   and catches `UNSAFE` constraint violations that would waste your Phase B
   effort.
 - **Running `pytest -q` immediately in Phase C** without first calling
-  `analyze_change_impact` — defeats the whole purpose of this skill. The
+  `edit action=impact` — defeats the whole purpose of this skill. The
   scoped command is the point.
 - **Ignoring grade regression** in Phase C step 4 — a B→C regression on a
   hot-zone file is a real signal even if tests pass.

--- a/.claude/skills/tsa-find/SKILL.md
+++ b/.claude/skills/tsa-find/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tsa-find
-version: 1.0.0
+version: 2.0.0
 description: |
   Fast file + content search with code-aware sizing. Replaces Read/Grep/find
   for routine "where is this file" / "grep for X" / "show me lines 10-20 of Y"
@@ -31,20 +31,20 @@ allowed-tools:
 
 ## Tool routing
 
-| Question                                  | Tool                    |
-|-------------------------------------------|-------------------------|
-| Filename pattern only                     | `list_files`            |
-| Content pattern only (regex / literal)    | `search_content`        |
-| Filename pattern AND content              | `find_and_grep`         |
-| Read specific lines of one file           | `extract_code_section`  |
-| "Is this file too big to read fully?"     | `check_code_scale`      |
+| Question                                  | Tool                        |
+|-------------------------------------------|-----------------------------|
+| Filename pattern only                     | `project action=files`      |
+| Content pattern only (regex / literal)    | `search action=content`     |
+| Filename pattern AND content              | `search action=grep`        |
+| Read specific lines of one file           | `structure action=read`     |
+| "Is this file too big to read fully?"     | `health action=scale`       |
 
 ## Procedure
 
 ### Single search
 
 ```yaml
-search_content(pattern: "TODO", path: "tree_sitter_analyzer/", file_pattern: "*.py")
+search action=content query="TODO" roots=["tree_sitter_analyzer/"] include_globs=["*.py"]
 ```
 
 Returns: `matches: [{file, line, content}]` with sized previews. Always
@@ -55,14 +55,14 @@ includes file:line so the agent can cite without reading the file.
 Before reading a large file blind, use:
 
 ```yaml
-check_code_scale(file_path: "tree_sitter_analyzer/ast_cache.py")
-# returns {lines: 2144, size_bytes: 79809, is_large: true, recommendation: "use extract_code_section"}
+health action=scale file_path="tree_sitter_analyzer/ast_cache.py"
+# returns {lines: 2144, size_bytes: 79809, is_large: true, recommendation: "use structure action=read"}
 ```
 
 Then extract only what you need:
 
 ```yaml
-extract_code_section(file_path: "...", start_line: 800, end_line: 870)
+structure action=read file_path="..." start_line=800 end_line=870
 ```
 
 Avoids reading 80KB when you need 2KB.
@@ -70,22 +70,20 @@ Avoids reading 80KB when you need 2KB.
 ### Combined find+grep
 
 ```yaml
-find_and_grep(file_pattern: "test_*.py", content_pattern: "def test_synapse")
+search action=grep file_pattern="test_*.py" content_pattern="def test_synapse"
 # returns: list of test functions matching both criteria
 ```
 
 ## CLI equivalents
 
 ```bash
-uv run tree-sitter-analyzer --list-files --extensions py,yml
-uv run tree-sitter-analyzer --search-content "TODO" --include "*.py"
-uv run tree-sitter-analyzer --find-and-grep "test_*.py" "def test_synapse"
-uv run tree-sitter-analyzer <file> --check-scale
-uv run tree-sitter-analyzer <file> --partial-read --start-line 800 --end-line 870
+uv run tree-sitter-analyzer --project-root . --outline   # list project files
+uv run tree-sitter-analyzer --check-tools                # verify fd/rg available
+uv run tree-sitter-analyzer <file> --partial-read        # sized read with --start-line / --end-line
 ```
 
 ## Anti-patterns
 
 - DON'T `Read` a large file before checking scale — burns tokens
-- DON'T `Bash grep -rn` for things `search_content` handles — slower + noisier
+- DON'T `Bash grep -rn` for things `search action=content` handles — slower + noisier
 - DON'T re-search the same query twice in one session — cache the result mentally

--- a/.claude/skills/tsa-graph/SKILL.md
+++ b/.claude/skills/tsa-graph/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tsa-graph
-version: 1.0.0
+version: 2.0.0
 description: |
   Code archaeology via call graph + symbol resolution. Answer "who calls X",
   "what does Y call", "where is Z defined", "what's the path from A to B" in
@@ -37,19 +37,19 @@ allowed-tools:
 
 Pick the right tool by question shape:
 
-| Question                              | Tool                          |
-|---------------------------------------|-------------------------------|
-| Need search + snippets + callers/callees together? | `codegraph_query` |
-| What does FUNCTION call?              | `codegraph_callees`           |
-| What calls FUNCTION?                  | `codegraph_callers`           |
-| Where is SYMBOL defined?              | `codegraph_symbol_search`     |
-| What references SYMBOL anywhere?      | `codegraph_xref`              |
-| Path from CALLER to CALLEE?           | `codegraph_call_path`         |
-| Resolve "Path" in file X (project or stdlib?) | `codegraph_resolve`   |
-| Need architecture diagram output?     | `codegraph_uml`               |
+| Question                              | Tool                              |
+|---------------------------------------|-----------------------------------|
+| Need search + snippets + callers/callees together? | `search action=chain` |
+| What does FUNCTION call?              | `nav action=callees`              |
+| What calls FUNCTION?                  | `nav action=callers`              |
+| Where is SYMBOL defined?              | `search action=symbol`            |
+| What references SYMBOL anywhere?      | `nav action=xref`                 |
+| Path from CALLER to CALLEE?           | `nav action=call_path`            |
+| Resolve "Path" in file X (project or stdlib?) | `nav action=resolve`    |
+| Need architecture diagram output?     | `viz action=uml`                  |
 
 **Don't use** when:
-- You need the actual *body* of the function → use `extract_code_section`
+- You need the actual *body* of the function → use `structure action=read`
 - You're hunting a string literal in non-source files → use Grep
 
 ## Procedure
@@ -61,30 +61,30 @@ Pick the matching tool, call once. Read the response. Done.
 Example: "what calls `score_file`?"
 
 ```
-codegraph_callers(function_name="score_file", language="python", limit=20)
+nav action=callers function_name="score_file" language="python" limit=20
 ```
 
 Returns: `callers: [{name, file, line, callee_resolution, callee_resolved_file}, ...]`.
-The new `callee_resolution` field tells you `local` / `project` / `stdlib` /
+The `callee_resolution` field tells you `local` / `project` / `stdlib` /
 `unknown` so you can filter out noise.
 
 When a question needs several graph hops plus source snippets, prefer the
 chain surface:
 
 ```
-codegraph_query(query="search('score_file').explore(max_files=3).callers(depth=1).callees(depth=1)")
+search action=chain query="search('score_file').explore(max_files=3).callers(depth=1).callees(depth=1)"
 ```
 
 ### Multi-step case (refactor planning)
 
 Fan out 3 in parallel:
-1. `codegraph_callers` (who depends on this — blast radius)
-2. `codegraph_callees` (what this depends on — what may need updating)
-3. `codegraph_symbol_search` with the symbol name (find aliases / shadows)
+1. `nav action=callers` (who depends on this — blast radius)
+2. `nav action=callees` (what this depends on — what may need updating)
+3. `search action=symbol` with the symbol name (find aliases / shadows)
 
 Then if you need a specific reachability path:
 ```
-codegraph_call_path(from_function="X", to_function="Y", max_depth=10)
+nav action=call_path from_function="X" to_function="Y" max_depth=10
 ```
 
 ## Reading the new resolution fields (Synapse)
@@ -112,12 +112,14 @@ uv run tree-sitter-analyzer --callees <FUNC> --output-format toon
 uv run tree-sitter-analyzer --callers <FUNC> --output-format toon
 uv run tree-sitter-analyzer --symbol-search <NAME> --output-format toon
 uv run tree-sitter-analyzer --codegraph-xref <SYMBOL> --output-format toon
+uv run tree-sitter-analyzer --call-path --call-path-source X --call-path-target Y
+uv run tree-sitter-analyzer --uml class --output-format toon
 ```
 
 ## Anti-patterns
 
-- Don't `grep -rn "def X" tree_sitter_analyzer/` — use `codegraph_symbol_search` (10x faster, precise)
-- Don't read 5 files to trace a call chain — use `codegraph_call_path`
+- Don't `grep -rn "def X" tree_sitter_analyzer/` — use `search action=symbol` (10x faster, precise)
+- Don't read 5 files to trace a call chain — use `nav action=call_path`
 - Don't ignore `callee_resolution` — `unknown` entries are noise, filter them
 
 ## Decision surface

--- a/.claude/skills/tsa-health-watch/SKILL.md
+++ b/.claude/skills/tsa-health-watch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tsa-health-watch
-version: 1.0.0
+version: 2.0.0
 description: |
   Project & file health grading + dead-code detection + watch-daemon for grade
   drops. Answer "how healthy is this codebase", "what's rotting", "which files
@@ -29,14 +29,14 @@ allowed-tools:
 
 ## When to use
 
-| Goal                            | Tool                                |
-|---------------------------------|-------------------------------------|
-| Project portrait + worst files  | `check_project_health`              |
-| One-file deep dive              | `check_file_health`                 |
-| Top hubs + sensory neurons      | `codegraph_overview`                |
-| Find dead functions             | `codegraph_dead_code`               |
-| Complexity hotspots (visualize) | `codegraph_complexity_heatmap`      |
-| Watch & alert on degradation    | `--watch-health` CLI (Bash)         |
+| Goal                            | Tool                                  |
+|---------------------------------|---------------------------------------|
+| Project portrait + worst files  | `health action=project`               |
+| One-file deep dive              | `health action=file`                  |
+| Top hubs + sensory neurons      | `health action=overview`              |
+| Find dead functions             | `health action=dead`                  |
+| Complexity hotspots (visualize) | `health action=heatmap`               |
+| Watch & alert on degradation    | `--watch-health` CLI (Bash)           |
 
 ## Procedure
 
@@ -44,17 +44,17 @@ allowed-tools:
 
 Fan out in one message:
 
-1. `check_project_health` with `max_files: 20` — grade distribution + worst-20
-2. `codegraph_dead_code` with `limit: 50` — pruning candidates
-3. `codegraph_overview` — hub functions + entry points + 0-degree leaves
+1. `health action=project` with `max_files: 20` — grade distribution + worst-20
+2. `health action=dead` with `limit: 50` — pruning candidates
+3. `health action=overview` — hub functions + entry points + 0-degree leaves
 
 Read the verdict. If `D/F` files exist in worst-20, drill into each with
-`check_file_health` to get the per-dimension breakdown + recommendation.
+`health action=file` to get the per-dimension breakdown + recommendation.
 
 ### Single-file investigation
 
 ```
-check_file_health(file_path="<path>")
+health action=file file_path="<path>"
 ```
 
 Returns:
@@ -113,7 +113,7 @@ uv run tree-sitter-analyzer --watch-health --threshold-grade C  # daemon
 ## Anti-patterns
 
 - Don't grade individual files when the question is "which 10 are worst" —
-  use `check_project_health` once instead of N file-health calls.
+  use `health action=project` once instead of N file-health calls.
 - Don't ignore `dimensions` and just look at the grade letter — the
   recommendation lives in the weakest dimension.
 - Don't use `--watch-health` for one-shot checks — it's a long-running daemon.
@@ -121,11 +121,11 @@ uv run tree-sitter-analyzer --watch-health --threshold-grade C  # daemon
 ## Decision surface
 
 ```yaml
-project (when check_project_health):
+project (when health action=project):
   grade_distribution: {A: n, B: n, C: n, D: n, F: n}
   worst_files: [{path, grade, score, weakest_dimension}, ...]
 
-file (when check_file_health):
+file (when health action=file):
   grade: A | B | C | D | F
   score: 0-100
   signal: healthy | moderate_depth | ...

--- a/.claude/skills/tsa-index/SKILL.md
+++ b/.claude/skills/tsa-index/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tsa-index
-version: 1.0.0
+version: 2.0.0
 description: |
   Manage the persistent AST cache / index. Refresh, force-rebuild, inspect
   cache state, diff one file's AST between commits, advise on parser readiness
@@ -29,16 +29,16 @@ allowed-tools:
 
 ## Tool routing
 
-| Goal                                           | Tool                    |
-|------------------------------------------------|-------------------------|
-| Status / stats of the AST cache                | `ast_cache` (mode=status) |
-| Force rebuild                                  | `ast_cache` (mode=force)  |
-| Incremental refresh                            | `ast_cache` (mode=index)  |
-| Watch a directory and auto-refresh             | `ast_cache` (mode=watch_start) |
-| AST-level diff of one file across commits      | `ast_diff`              |
-| First-time index for a freshly-cloned repo     | `codegraph_autoindex`   |
-| Full bulk reindex (large monorepo)             | `codegraph_full_index`  |
-| "Is the python plugin / swift plugin ready"    | `advise_parser_readiness` |
+| Goal                                           | Tool                              |
+|------------------------------------------------|-----------------------------------|
+| Status / stats of the AST cache                | `index action=cache` (mode=status) |
+| Force rebuild                                  | `index action=cache` (mode=force)  |
+| Incremental refresh                            | `index action=cache` (mode=index)  |
+| Watch a directory and auto-refresh             | `index action=cache` (mode=watch_start) |
+| AST-level diff of one file across commits      | `edit action=ast_diff`            |
+| First-time index for a freshly-cloned repo     | `index action=auto`               |
+| Full bulk reindex (large monorepo)             | `index action=full`               |
+| "Is the python plugin / swift plugin ready"    | `project action=parser`           |
 
 ## Procedure
 
@@ -61,7 +61,7 @@ uv run tree-sitter-analyzer --ast-cache --ast-cache-mode index
 For structural change detection (not text):
 
 ```yaml
-ast_diff(file_path: "...", base_ref: "HEAD~5", head_ref: "HEAD")
+edit action=ast_diff file_path="..." base_ref="HEAD~5" head_ref="HEAD"
 # returns: {nodes_added: n, nodes_removed: n, nodes_modified: n,
 #           classification_hints: [...]}
 ```
@@ -71,7 +71,7 @@ Useful for distinguishing pure formatting from real change.
 ### Parser readiness
 
 ```yaml
-advise_parser_readiness(language: "swift")
+project action=parser language="swift"
 # returns: {status: "stable|beta|stub", supported_queries: [...], limitations: [...]}
 ```
 
@@ -82,10 +82,10 @@ Avoid asking "why doesn't swift work" — query this first.
 ```bash
 uv run tree-sitter-analyzer --ast-cache --ast-cache-mode status
 uv run tree-sitter-analyzer --ast-cache --ast-cache-mode force
-uv run tree-sitter-analyzer --ast-diff <file> --base HEAD~5 --head HEAD
-uv run tree-sitter-analyzer parser-readiness swift
-uv run tree-sitter-analyzer --autoindex            # codegraph_autoindex
-uv run tree-sitter-analyzer --full-index           # codegraph_full_index
+uv run tree-sitter-analyzer --ast-diff --ast-diff-file <file> --ast-diff-old-ref HEAD~5 --ast-diff-new-ref HEAD
+uv run tree-sitter-analyzer --parser-readiness swift
+uv run tree-sitter-analyzer --autoindex            # index action=auto
+uv run tree-sitter-analyzer --full-index           # index action=full
 ```
 
 ## Anti-patterns

--- a/.claude/skills/tsa-landing/SKILL.md
+++ b/.claude/skills/tsa-landing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tsa-landing
-version: 1.0.0
+version: 2.0.0
 description: |
   Land in a new (or familiar) codebase using the tree-sitter-analyzer MCP server.
   One workflow → 6 decision surfaces (project_card / entry_points / recent_signals /
@@ -33,7 +33,7 @@ allowed-tools:
 
 **Don't use** when:
 - You already have full context (just continue working)
-- User wants to read source — use `extract_code_section` directly
+- User wants to read source — use `structure action=read` directly
 
 ## Procedure
 
@@ -49,10 +49,10 @@ If `fd` or `rg` missing, stop and tell user how to install.
 
 Call these 4 tools in ONE message (parallel tool use):
 
-1. `get_project_summary` (no args) — project_card + entry_points
-2. `check_project_health` with `max_files: 5` — grade distribution + weakest dimension
-3. `analyze_change_impact` with `mode: "branch"` — recent_signals (last commit, ahead-of-main)
-4. `get_agent_workflow` (no args) — current_phase + recommended_commands
+1. `project action=overview` (no args) — project_card + entry_points
+2. `health action=project` with `max_files: 5` — grade distribution + weakest dimension
+3. `edit action=impact` with `mode: "branch"` — recent_signals (last commit, ahead-of-main)
+4. `project action=workflow` (no args) — current_phase + recommended_commands
 
 ### Step 3 — Fold and emit decision_surface
 
@@ -61,16 +61,16 @@ Combine into single Decision Surface:
 ```jsonc
 {
   "project_card": {
-    "name": <from get_project_summary.project_root basename>,
-    "purpose": <from get_project_summary.summary.purpose if present>,
-    "primary_language": <from get_project_summary.summary.by_language[0].name>,
-    "language_mix": <from get_project_summary.summary.by_language top 3>,
+    "name": <from project action=overview project_root basename>,
+    "purpose": <from project action=overview summary.purpose if present>,
+    "primary_language": <from project action=overview summary.by_language[0].name>,
+    "language_mix": <from project action=overview summary.by_language top 3>,
     "size": {
-      "files": <from get_project_summary.summary.total_files>,
-      "loc": <from get_project_summary.summary.total_lines>
+      "files": <from project action=overview summary.total_files>,
+      "loc": <from project action=overview summary.total_lines>
     }
   },
-  "entry_points": <from get_project_summary.entry_points>,
+  "entry_points": <from project action=overview entry_points>,
   "recent_signals": {
     "last_commit": <git log -1 --oneline via Bash>,
     "ahead_of_origin": <git rev-list --count via Bash>,
@@ -78,24 +78,24 @@ Combine into single Decision Surface:
     "branch": <git branch --show-current via Bash>
   },
   "health": {
-    "verdict": <from check_project_health.verdict>,
-    "risk": <from check_project_health.agent_summary.risk>,
-    "grade_distribution": <from check_project_health.grade_distribution>,
-    "weakest_dimension": <from check_project_health.weakest_dimension>
+    "verdict": <from health action=project verdict>,
+    "risk": <from health action=project agent_summary.risk>,
+    "grade_distribution": <from health action=project grade_distribution>,
+    "weakest_dimension": <from health action=project weakest_dimension>
   },
   "top_files_to_know": [
     "AGENTS.md",
     "CLAUDE.md",
-    <from get_project_summary.entry_points>,
-    <top 3 from check_project_health.top_refactoring_targets>
+    <from project action=overview entry_points>,
+    <top 3 from health action=project top_refactoring_targets>
   ],
   "agent_next_step": {
     "if_asked_what_is_this":
       "Read AGENTS.md (canonical contracts) + docs/CODEMAPS/architecture.md (topology). Stop after 2k tokens.",
     "if_asked_to_add_feature":
-      "Call get_agent_workflow → follow phase_order. Use TDD (write test first).",
+      "Call project action=workflow → follow phase_order. Use TDD (write test first).",
     "if_asked_to_fix_bug":
-      "Call code_patterns(file_path) → refactoring_suggestions(file_path). Cross-ref symbol_lineage if symbol-level.",
+      "Call health action=patterns file_path=<file> → edit action=refactor file_path=<file>. Cross-ref nav action=lineage if symbol-level.",
     "if_asked_about_test_status":
       "Run: uv run pytest -q (5-min cap). Project enforces xdist parallel, ~5min for 15k tests."
   },

--- a/.claude/skills/tsa-pr-review/SKILL.md
+++ b/.claude/skills/tsa-pr-review/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: tsa-pr-review
-version: 1.0.0
+version: 2.0.0
 description: |
   AST-grounded PR / diff review. One workflow → per-file risk ranking, blast
   radius per changed symbol, the exact pytest command to gate merge, any
   architecture-constraint violations, and a final BLOCK / REVIEW / APPROVE
   verdict — in ~1–2k tokens and 4–6 MCP calls.
 
-  Goes beyond a generic LLM diff-read because only TSA's `analyze_change_impact`
+  Goes beyond a generic LLM diff-read because only TSA's `edit action=impact`
   returns a deterministic `verification_command` + `queue_ledger`, and only the
   persisted call graph can enumerate true callers/callees of changed symbols.
   (Per `docs/internal/COMPETITOR_HEAD_TO_HEAD_2026-05-23.md`: CodeGraphContext
@@ -24,9 +24,9 @@ description: |
   - Pre-merge gate in CI / agent loops
   - Right after `/ship` produced a diff and before `/land`
 
-  Workflow: fan-out (pr_review + change_impact + check_constraints) → per-file
-  fan-out (safe_to_edit) → per-symbol fan-out (callers + callees) → fold into
-  a verdict-ranked report.
+  Workflow: fan-out (edit action=pr + edit action=impact + edit action=constraints)
+  → per-file fan-out (edit action=safe) → per-symbol fan-out (nav action=callers
+  + nav action=callees) → fold into a verdict-ranked report.
 allowed-tools:
   - mcp__tree-sitter-analyzer__edit
   - mcp__tree-sitter-analyzer__nav
@@ -55,15 +55,15 @@ allowed-tools:
 
 ## Why this beats a generic LLM diff-read
 
-| Concern                          | LLM-only diff read   | tsa-pr-review                            |
-|----------------------------------|----------------------|------------------------------------------|
-| Classify signature vs body change| Heuristic            | `codegraph_pr_review` AST diff           |
-| Exact tests to run               | Invented / hallucinated | `analyze_change_impact.verification_command` |
-| Caller blast radius              | Grep guess           | `codegraph_callers` from persisted graph |
-| Callee regression surface        | Read N files         | `codegraph_callees` from persisted graph |
-| Architecture rule violations     | None                 | `check_constraints` vs YAML rules        |
-| Per-file pre-merge verdict       | Subjective           | `safe_to_edit` SAFE/REVIEW/CAUTION/UNSAFE|
-| Behaviour on Python 3.14         | n/a                  | Stable (grep-ast crashes, cgc silent-0)  |
+| Concern                          | LLM-only diff read   | tsa-pr-review                               |
+|----------------------------------|----------------------|---------------------------------------------|
+| Classify signature vs body change| Heuristic            | `edit action=pr` AST diff                   |
+| Exact tests to run               | Invented / hallucinated | `edit action=impact verification_command` |
+| Caller blast radius              | Grep guess           | `nav action=callers` from persisted graph   |
+| Callee regression surface        | Read N files         | `nav action=callees` from persisted graph   |
+| Architecture rule violations     | None                 | `edit action=constraints` vs YAML rules     |
+| Per-file pre-merge verdict       | Subjective           | `edit action=safe` SAFE/REVIEW/CAUTION/UNSAFE|
+| Behaviour on Python 3.14         | n/a                  | Stable (grep-ast crashes, cgc silent-0)     |
 
 (Source: `docs/internal/COMPETITOR_HEAD_TO_HEAD_2026-05-23.md` — the 4
 fault-tolerance advantages: oracle-consistent AST, indexed-not-silent,
@@ -75,35 +75,35 @@ Python 3.14-safe, no external DB dependency.)
 
 In one message, call all three:
 
-1. `codegraph_pr_review(mode="staged")` — AST diff classification, per-symbol
+1. `edit action=pr mode="staged"` — AST diff classification, per-symbol
    change category (signature_change / body_change / new_symbol / deletion),
    and per-file changed-symbol list.
-   - For PR URL: `codegraph_pr_review(mode="pr", pr_url="<url>")`
+   - For PR URL: `edit action=pr mode="pr" pr_url="<url>"`
    - For unstaged: `mode="diff"`; for branch-vs-main: `mode="branch"`
-2. `analyze_change_impact(mode="staged")` — returns `verification_command`,
+2. `edit action=impact mode="staged"` — returns `verification_command`,
    `queue_ledger` (in-scope vs out-of-scope dirty files), `pytest_required`,
    and per-file impact rows.
-3. `check_constraints()` — full repo audit against `architectural-constraints.yml`,
+3. `edit action=constraints` — full repo audit against `architectural-constraints.yml`,
    filtered to files the diff touches if you want noise-free output:
-   `check_constraints(path_filter="<glob covering changed files>")`.
+   `edit action=constraints path_filter="<glob covering changed files>"`.
 
 ### Step 2 — Per-file fan-out (parallel, N calls)
 
 For each changed file from Step 1, call:
 
-`safe_to_edit(file_path="<abs>", edit_type="<refactor|rename|delete|bugfix>")`
+`edit action=safe file_path="<abs>" edit_type="<refactor|rename|delete|bugfix>"`
 
 Pick `edit_type` from the dominant change category in Step 1's
-`codegraph_pr_review` output. Returns per-file verdict + `risk_factors`.
+`edit action=pr` output. Returns per-file verdict + `risk_factors`.
 
 ### Step 3 — Per-symbol fan-out (parallel, ≤2N calls)
 
 For each *changed signature* (not body-only) symbol from Step 1, fan out
 two calls:
 
-- `codegraph_callers(function_name="<sym>", language="<lang>", limit=20)`
+- `nav action=callers function_name="<sym>" language="<lang>" limit=20`
   — who depends on this; the blast radius if its signature moved.
-- `codegraph_callees(function_name="<sym>", language="<lang>", limit=20)`
+- `nav action=callees function_name="<sym>" language="<lang>" limit=20`
   — what it calls; the regression surface if its body changed.
 
 Filter callers/callees where `callee_resolution == "stdlib"` or `"unknown"` —
@@ -113,9 +113,9 @@ they're noise for blast-radius scoring (per tsa-graph guidance).
 
 ```
 verdict_precedence (worst wins):
-  - BLOCK   ← any check_constraints violation with severity=error
-              OR any safe_to_edit verdict == UNSAFE
-  - REVIEW  ← any safe_to_edit verdict in {REVIEW, CAUTION}
+  - BLOCK   ← any edit action=constraints violation with severity=error
+              OR any edit action=safe verdict == UNSAFE
+  - REVIEW  ← any edit action=safe verdict in {REVIEW, CAUTION}
               OR pytest_required=true with no nearby tests
               OR signature_change with ≥5 external callers
   - APPROVE ← all per-file verdicts == SAFE,
@@ -140,7 +140,7 @@ git -C /Users/aisheng.yu/git-private/tree-sitter-analyzer diff HEAD~2 HEAD --nam
 
 ```yaml
 # Call 1
-codegraph_pr_review(mode="branch", include_call_graph=true, output_format="json")
+edit action=pr mode="branch" include_call_graph=true
 # returns:
 #   changed_files:
 #     - path: ".../safe_to_edit_tool.py"
@@ -155,7 +155,7 @@ codegraph_pr_review(mode="branch", include_call_graph=true, output_format="json"
 #           category: "body_change"
 
 # Call 2
-analyze_change_impact(mode="branch", agent_summary_only=true)
+edit action=impact mode="branch" agent_summary_only=true
 # returns:
 #   verification_command: "uv run pytest tests/unit/test_safe_to_edit_tool.py
 #                          tests/unit/test_change_impact_tool.py -q"
@@ -165,7 +165,7 @@ analyze_change_impact(mode="branch", agent_summary_only=true)
 #     out_of_scope_dirty: []
 
 # Call 3
-check_constraints(path_filter="tree_sitter_analyzer/mcp/**")
+edit action=constraints path_filter="tree_sitter_analyzer/mcp/**"
 # returns:
 #   verdict: SAFE
 #   violations: []
@@ -174,18 +174,18 @@ check_constraints(path_filter="tree_sitter_analyzer/mcp/**")
 ### Per-file fan-out
 
 ```yaml
-safe_to_edit(file_path=".../safe_to_edit_tool.py", edit_type="refactor")
+edit action=safe file_path=".../safe_to_edit_tool.py" edit_type="refactor"
 # → verdict: REVIEW, risk_factors: [{factor: "high_caller_count", ...}]
-safe_to_edit(file_path=".../change_impact_tool.py", edit_type="bugfix")
+edit action=safe file_path=".../change_impact_tool.py" edit_type="bugfix"
 # → verdict: SAFE
 ```
 
 ### Per-symbol fan-out (only the signature-change)
 
 ```yaml
-codegraph_callers(function_name="_score_risk", language="python", limit=20)
+nav action=callers function_name="_score_risk" language="python" limit=20
 # → 7 callers; 6 in tests/, 1 in cli/commands/mcp_commands.py
-codegraph_callees(function_name="_score_risk", language="python", limit=20)
+nav action=callees function_name="_score_risk" language="python" limit=20
 # → 4 callees; all local (good — no stdlib noise)
 ```
 
@@ -239,7 +239,7 @@ Exit codes mirror `--change-impact` / `--check-constraints`:
 - DO NOT ask the LLM to invent the pytest command — quote
   `verification_command` verbatim. r36 / past incidents confirm hallucinated
   pytest invocations skip the regressions TSA already pinpointed.
-- DO NOT skip `check_constraints` because "the LLM can spot architecture
+- DO NOT skip `edit action=constraints` because "the LLM can spot architecture
   drift". It can't — the rules live in YAML and are evaluated against the
   persisted edge graph.
 - DO NOT run callers/callees on body-only changes. Bodies don't change
@@ -271,7 +271,7 @@ files:
 constraint_violations: [
   {rule_id, caller_file, caller_line, callee_file, severity, reason}
 ]
-verification_command: <copy-paste exact pytest line from change_impact>
+verification_command: <copy-paste exact pytest line from edit action=impact>
 pytest_required: bool
 queue_ledger:
   in_scope: [<path>]

--- a/.claude/skills/tsa-refactor-queue/SKILL.md
+++ b/.claude/skills/tsa-refactor-queue/SKILL.md
@@ -233,7 +233,7 @@ sqlite3 .ast-cache/index.db "
   ORDER BY churn_30d DESC LIMIT 50"
 
 # 5. Per-row enrichment (loop top 5)
-uv run tree-sitter-analyzer <file> --outline --output-format json
+uv run tree-sitter-analyzer <file> --table --output-format json
 uv run tree-sitter-analyzer --callers <SYMBOL> --output-format json
 uv run tree-sitter-analyzer <file> --refactor --output-format json
 ```

--- a/.claude/skills/tsa-refactor-queue/SKILL.md
+++ b/.claude/skills/tsa-refactor-queue/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: tsa-refactor-queue
-version: 1.0.0
+version: 2.0.0
 description: |
   Build a top-N prioritized refactoring queue by intersecting three signals:
   health grade (which files are F/D), temporal churn (which files change
   most often), and dead-code density (which files carry the most unreachable
   symbols). For each candidate the queue surfaces (a) the dimension that
   dragged the grade down, (b) the target symbol, (c) blast radius from
-  `codegraph_callers`, and (d) a concrete action — `split`, `delete dead`,
+  `nav action=callers`, and (d) a concrete action — `split`, `delete dead`,
   or `extract`.
 
   Motivated by `docs/agent-tooling-gap-report.md` "Next High-Value Work" §5:
-  use `check_project_health` output to open focused refactoring slices for
+  use `health action=project` output to open focused refactoring slices for
   the current F-grade files, starting with low-coverage Language Plugin
   extractors and `api.py`.
 
@@ -21,7 +21,7 @@ description: |
   - Engineering planning: "what would 2 weeks of cleanup buy us?"
   - Re-grading after a sprint: "did the queue shrink?"
 
-  Replaces: per-file `check_file_health` loops + spreadsheet ranking
+  Replaces: per-file `health action=file` loops + spreadsheet ranking
   (~25k tokens) with 3 parallel MCP calls + a deterministic rank
   (~3k tokens).
 allowed-tools:
@@ -47,9 +47,9 @@ allowed-tools:
 - After a CI grade-drop alert from `tsa-health-watch` — re-rank with churn
 
 **Don't use** when:
-- You already know the file (one-file deep dive → `check_file_health` or `tsa-edit-safety`)
+- You already know the file (one-file deep dive → `health action=file` or `tsa-edit-safety`)
 - The codebase is brand-new (<2 weeks of git history) — churn signal is noise
-- You want to optimize one hot function — use `tsa-graph` + `refactoring_suggestions` directly
+- You want to optimize one hot function — use `tsa-graph` + `edit action=refactor` directly
 - Shallow clone in CI — `git_state=shallow` makes mod_count_30d unreliable
 
 ## Procedure
@@ -58,16 +58,16 @@ allowed-tools:
 
 Call these in ONE message:
 
-1. `check_project_health` with `min_grade: "D"` and `max_files: 20` — F/D files + per-file `weakest_dimension`
-2. `codegraph_dead_code` with `limit: 200` — symbol-level dead candidates, grouped by file
-3. `codegraph_complexity_heatmap` with `top_n: 20` — complexity-weighted file list (covers structural smell)
+1. `health action=project` with `min_grade: "D"` and `max_files: 20` — F/D files + per-file `weakest_dimension`
+2. `health action=dead` with `limit: 200` — symbol-level dead candidates, grouped by file
+3. `health action=heatmap` with `top_n: 20` — complexity-weighted file list (covers structural smell)
 
 The three responses overlap on file path. Joining on `file_path` gives a
 3-signal table per candidate.
 
 ### Step 2 — Score and rank (deterministic, no LLM needed)
 
-For each file that appears in `check_project_health.worst_files`, compute:
+For each file that appears in `health action=project worst_files`, compute:
 
 ```
 priority = (1 - health_score/100)            # how bad is the grade
@@ -76,11 +76,11 @@ priority = (1 - health_score/100)            # how bad is the grade
 ```
 
 Where:
-- `health_score` ∈ [0,100] from `check_project_health` (lower → worse → bigger weight)
+- `health_score` ∈ [0,100] from `health action=project` (lower → worse → bigger weight)
 - `mod_count_30d_for_file` = sum of `mod_count_30d` across the file's symbols
   (read from `ast_symbol_activation` — see tsa-temporal). `log(1+x)` damps
   pathological churn so a single 50× file doesn't dominate.
-- `dead_symbol_count / total_symbols` = fraction of symbols `codegraph_dead_code`
+- `dead_symbol_count / total_symbols` = fraction of symbols `health action=dead`
   flagged. The `+ 0.1` floor ensures non-dead files can still rank if churn+grade
   alone justify it.
 
@@ -92,11 +92,11 @@ For each of the top 5 files, fan out one more parallel batch:
 
 ```yaml
 # For each candidate file:
-analyze_code_structure(file_path=<f>, format_type="compact")
+structure action=analyze file_path=<f> format_type="compact"
   → list of symbols + complexity + line ranges → pick worst symbol
-codegraph_callers(function_name=<worst_symbol>, include_activation=true, limit=50)
+nav action=callers function_name=<worst_symbol> include_activation=true limit=50
   → blast_radius = len(callers) where callee_resolution in {local, project}
-refactoring_suggestions(file_path=<f>)
+edit action=refactor file_path=<f>
   → action_hint: split | extract | delete | rename
 ```
 
@@ -109,10 +109,10 @@ For each row in the top 5, produce:
   rank: 1
   health_grade: F
   health_score: 42
-  weakest_dimension: complexity        # from check_project_health
+  weakest_dimension: complexity        # from health action=project
   mod_count_30d: 18                     # summed from activation
   dead_symbols: 4 / 67                  # 6.0%
-  target_symbol: api.analyze            # worst from analyze_code_structure
+  target_symbol: api.analyze            # worst from structure action=analyze
   blast_radius: 23                      # local+project callers
   action: split                         # split → extract helpers; delete → prune dead; extract → DRY
   estimated_token_savings: ~8k          # rough: 0.5 * (dead_symbols * 200)
@@ -191,7 +191,7 @@ The `action` column should drive how you ticket the refactor:
 | split   | `weakest_dimension ∈ {size, complexity}` and `blast_radius >= 5` | extract helpers, no public-API change |
 | extract | `weakest_dimension = duplication` or repeated patterns across files | new shared util module |
 | delete  | `dead_symbols / total_symbols > 15%` and `weakest_dimension != git_hotspot` | pure prune PR |
-| rename  | only if `refactoring_suggestions` returns `rename_advised: true` AND blast_radius < 10 | tiny solo PR |
+| rename  | only if `edit action=refactor` returns `rename_advised: true` AND blast_radius < 10 | tiny solo PR |
 
 If two actions tie, prefer `delete` first — it's the cheapest, lowest-risk PR
 and shrinks the next queue automatically.
@@ -233,7 +233,7 @@ sqlite3 .ast-cache/index.db "
   ORDER BY churn_30d DESC LIMIT 50"
 
 # 5. Per-row enrichment (loop top 5)
-uv run tree-sitter-analyzer <file> --structure --output-format json
+uv run tree-sitter-analyzer <file> --outline --output-format json
 uv run tree-sitter-analyzer --callers <SYMBOL> --output-format json
 uv run tree-sitter-analyzer <file> --refactor --output-format json
 ```
@@ -263,8 +263,8 @@ top_5:
     verification_command: <copy-paste exact pytest line>
     note: <one-line caveat>
 provenance:
-  health_call: check_project_health{min_grade=D, max_files=20}
-  dead_call: codegraph_dead_code{limit=200}
+  health_call: health action=project{min_grade=D, max_files=20}
+  dead_call: health action=dead{limit=200}
   churn_source: ast_symbol_activation  # see tsa-temporal
   git_state_seen: [tracked, ...]  # warn if "shallow" appears
 ```

--- a/.claude/skills/tsa-structure/SKILL.md
+++ b/.claude/skills/tsa-structure/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tsa-structure
-version: 1.0.0
+version: 2.0.0
 description: |
   Structural analysis of one file — classes, methods, exports, common patterns,
   semantic classification of a diff. Returns the file's *shape* without reading
@@ -28,19 +28,19 @@ allowed-tools:
 
 ## Tool routing
 
-| Question                                        | Tool                   |
-|-------------------------------------------------|------------------------|
-| Outline / table of classes + methods            | `analyze_code_structure` |
-| Run a tree-sitter query (e.g., all `def` nodes) | `query_code`           |
-| Detect design patterns (singleton, factory, …)  | `code_patterns`        |
-| Classify a diff (refactor vs feature vs fix)    | `semantic_classify`    |
+| Question                                        | Tool                         |
+|-------------------------------------------------|------------------------------|
+| Outline / table of classes + methods            | `structure action=analyze`   |
+| Run a tree-sitter query (e.g., all `def` nodes) | `search action=query`        |
+| Detect design patterns (singleton, factory, …)  | `health action=patterns`     |
+| Classify a diff (refactor vs feature vs fix)    | `edit action=classify`       |
 
 ## Procedure
 
 ### File outline (most common)
 
 ```yaml
-analyze_code_structure(file_path: "tree_sitter_analyzer/health_scorer.py")
+structure action=analyze file_path="tree_sitter_analyzer/health_scorer.py"
 # returns: {classes: [...], functions: [...], imports: [...]}
 ```
 
@@ -55,9 +55,9 @@ uv run tree-sitter-analyzer <file> --table full
 When you need something the built-in tools don't surface:
 
 ```yaml
-query_code(file_path: "...", query_key: "class")
+search action=query file_path="..." query_key="class"
 # OR
-query_code(file_path: "...", query_string: "(decorated_definition) @decorated")
+search action=query file_path="..." query_string="(decorated_definition) @decorated"
 ```
 
 `--list-queries` (CLI) shows all built-in queries available per language.
@@ -65,7 +65,7 @@ query_code(file_path: "...", query_string: "(decorated_definition) @decorated")
 ### Diff classification
 
 ```yaml
-semantic_classify(file_path: "...", before_hash: "abc", after_hash: "def")
+edit action=classify file_path="..." before_hash="abc" after_hash="def"
 # returns: {classification: "refactor|feature|bugfix|test|docs|chore", confidence: 0.92}
 ```
 
@@ -74,7 +74,7 @@ Useful for PR descriptions and CHANGELOG categorization.
 ### Pattern detection
 
 ```yaml
-code_patterns(file_path: "...", patterns: ["singleton", "factory", "observer"])
+health action=patterns file_path="..." patterns=["singleton", "factory", "observer"]
 ```
 
 ## CLI equivalents
@@ -84,11 +84,11 @@ uv run tree-sitter-analyzer <file> --table full           # outline
 uv run tree-sitter-analyzer <file> --query-key class      # built-in query
 uv run tree-sitter-analyzer <file> --query-string "(...)" # custom query
 uv run tree-sitter-analyzer <file> --code-patterns
-uv run tree-sitter-analyzer --semantic-classify <diff-args>
+uv run tree-sitter-analyzer --semantic-classify           # edit action=classify
 ```
 
 ## Anti-patterns
 
 - DON'T read the whole file just to find "what classes are in it" — use the structure tool
-- DON'T write a custom tree-sitter query when `analyze_code_structure` covers it
-- DON'T use semantic_classify on huge multi-purpose commits — split them first
+- DON'T write a custom tree-sitter query when `structure action=analyze` covers it
+- DON'T use `edit action=classify` on huge multi-purpose commits — split them first

--- a/.claude/skills/tsa-temporal/SKILL.md
+++ b/.claude/skills/tsa-temporal/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tsa-temporal
-version: 1.0.0
+version: 2.0.0
 description: |
   Find "hot zones" — symbols modified often in recent git history that need
   extra review attention. Adds temporal context (mod_count_30d / 90d / all)
@@ -27,16 +27,16 @@ allowed-tools:
 
 > Per-symbol modification frequency persisted in `ast_symbol_activation`.
 > Computed from `git log --follow -p -U0` hunk attribution at index time.
-> Symbols with `mod_count_30d >= 5` auto-trigger CAUTION in change_impact.
+> Symbols with `mod_count_30d >= 5` auto-trigger CAUTION in `edit action=impact`.
 
 ## When to use
 
-| Goal                                  | How                                            |
-|---------------------------------------|------------------------------------------------|
-| Hot-zone caller fanout                | `codegraph_callers(..., include_activation=true)` |
-| Hot-zone callee fanout                | `codegraph_callees(..., include_activation=true)` |
-| "Is this commit touching hot zones?"  | `analyze_change_impact` — read `risk_factors`  |
-| Single-file recent churn              | `check_file_health` — read `git_hotspot` dim   |
+| Goal                                  | How                                                         |
+|---------------------------------------|-------------------------------------------------------------|
+| Hot-zone caller fanout                | `nav action=callers function_name="X" include_activation=true` |
+| Hot-zone callee fanout                | `nav action=callees function_name="X" include_activation=true` |
+| "Is this commit touching hot zones?"  | `edit action=impact` — read `risk_factors`                  |
+| Single-file recent churn              | `health action=file` — read `git_hotspot` dim               |
 
 **Don't use** when:
 - The question is static (e.g. "who calls X") — use `tsa-graph` skill
@@ -49,11 +49,7 @@ allowed-tools:
 For each symbol you're about to refactor:
 
 ```
-codegraph_callers(
-  function_name="X",
-  include_activation=true,
-  limit=50
-)
+nav action=callers function_name="X" include_activation=true limit=50
 ```
 
 Returns enriched entries:
@@ -77,7 +73,7 @@ recently — those are the high-risk integration points for your refactor.
 
 ### Change-impact gate (catches hot zones automatically)
 
-`analyze_change_impact` already includes hot-zone detection. Look for this
+`edit action=impact` already includes hot-zone detection. Look for this
 in the risk_factors:
 
 ```yaml
@@ -159,7 +155,7 @@ include_activation=true response addition (per callee/caller entry):
     mod_count_30d: <int>
     last_modified_at: <unix ts | null>
 
-analyze_change_impact addition:
+edit action=impact addition:
   risk_factors: [{factor: "hot_zone", reason: "...mod_count_30d=N...", severity: "caution"}]
   verdict: CAUTION   # bumped from SAFE/REVIEW when hot zone touched
 ```

--- a/tests/unit/cli/test_install_skills.py
+++ b/tests/unit/cli/test_install_skills.py
@@ -540,60 +540,31 @@ class TestSkillContentSync:
         """
         import re
 
-        # Subset of high-impact legacy names — most likely to appear in tool
-        # call positions. Full set in facade_map.LEGACY_TOOL_MAP.
-        LEGACY_CALL_NAMES = [
-            "safe_to_edit",
-            "analyze_change_impact",
-            "check_project_health",
-            "check_file_health",
-            "check_constraints",
-            "codegraph_callers",
-            "codegraph_callees",
-            "codegraph_pr_review",
-            "codegraph_symbol_search",
-            "codegraph_call_path",
-            "analyze_dependencies",
-            "codegraph_import_graph",
-            "codegraph_sitemap",
-            "extract_code_section",
-            "find_and_grep",
-            "search_content",
-            "list_files",
-            "check_code_scale",
-            "analyze_code_structure",
-            "query_code",
-            "code_patterns",
-            "semantic_classify",
-            "refactoring_suggestions",
-            "ast_diff",
-            "codegraph_dead_code",
-            "codegraph_overview",
-            "codegraph_complexity_heatmap",
-            "advise_parser_readiness",
-            "get_agent_workflow",
-            "get_project_summary",
-            "smart_context",
-            "codegraph_autoindex",
-            "codegraph_full_index",
-            "ast_cache",
-            "codegraph_uml",
-        ]
+        from tree_sitter_analyzer.mcp.facade_map import LEGACY_TOOL_MAP
+
+        # Authoritative: every legacy v1.x name, derived dynamically so the
+        # scan can never rot behind facade_map. get_project_summary appeared
+        # in skills but was never in LEGACY_TOOL_MAP — keep it explicitly.
+        legacy_call_names = sorted(set(LEGACY_TOOL_MAP) | {"get_project_summary"})
 
         repo = self._repo_root()
-        bundled_base = repo / "tree_sitter_analyzer" / "skills"
+        scan_bases = [
+            repo / "tree_sitter_analyzer" / "skills",
+            repo / ".claude" / "skills",
+        ]
 
         violations: dict[str, list[str]] = {}
-        for name in self.SKILL_NAMES:
-            skill_path = bundled_base / name / "SKILL.md"
-            content = skill_path.read_text(encoding="utf-8")
-            found = []
-            for legacy in LEGACY_CALL_NAMES:
-                # Match name immediately followed by ( — i.e. a function call
-                if re.search(r"\b" + re.escape(legacy) + r"\s*\(", content):
-                    found.append(legacy)
-            if found:
-                violations[name] = found
+        for base in scan_bases:
+            for name in self.SKILL_NAMES:
+                skill_path = base / name / "SKILL.md"
+                content = skill_path.read_text(encoding="utf-8")
+                found = []
+                for legacy in legacy_call_names:
+                    # Match name immediately followed by ( — a function call
+                    if re.search(r"\b" + re.escape(legacy) + r"\s*\(", content):
+                        found.append(legacy)
+                if found:
+                    violations[f"{base.name}/{name}"] = found
 
         assert violations == {}, (
             "Legacy tool-call names found in bundled skills (issue #437). "

--- a/tests/unit/cli/test_install_skills.py
+++ b/tests/unit/cli/test_install_skills.py
@@ -461,3 +461,142 @@ class TestInstallSkillsErrorHandling:
         assert "Installed:" in captured.err
         # path-separator agnostic (Windows prints backslashes)
         assert str(target / ".claude" / "skills" / "tsa-constraints") in captured.err
+
+
+# ---------------------------------------------------------------------------
+# D1h — content-sync guard: bundled wheel copy == .claude/skills source
+# ---------------------------------------------------------------------------
+
+
+class TestSkillContentSync:
+    """The bundled package copy (tree_sitter_analyzer/skills/) MUST be
+    byte-identical to the .claude/skills/ source of truth.
+
+    If these ever diverge an agent installing the package gets stale content.
+    Added for issue #437 (legacy tool names shipped in the wheel).
+    """
+
+    SKILL_NAMES = [
+        "tsa-constraints",
+        "tsa-deps",
+        "tsa-edit-safety",
+        "tsa-edit-then-verify",
+        "tsa-find",
+        "tsa-graph",
+        "tsa-health-watch",
+        "tsa-index",
+        "tsa-landing",
+        "tsa-pr-review",
+        "tsa-refactor-queue",
+        "tsa-structure",
+        "tsa-temporal",
+    ]
+
+    def _repo_root(self) -> Path:
+        """Locate the repository root relative to this test file."""
+        # tests/unit/cli/test_install_skills.py → three parents up = repo root
+        return Path(__file__).parent.parent.parent.parent
+
+    def test_bundled_content_matches_claude_source_for_all_13_skills(self):
+        """Bundled SKILL.md bytes must equal .claude/skills SKILL.md bytes.
+
+        The bundled copy lives at tree_sitter_analyzer/skills/<name>/SKILL.md.
+        The source-of-truth copy lives at .claude/skills/<name>/SKILL.md.
+        They are synced at authoring time; this test detects drift.
+        """
+        repo = self._repo_root()
+        bundled_base = repo / "tree_sitter_analyzer" / "skills"
+        source_base = repo / ".claude" / "skills"
+
+        mismatches = []
+        for name in self.SKILL_NAMES:
+            bundled_path = bundled_base / name / "SKILL.md"
+            source_path = source_base / name / "SKILL.md"
+
+            assert bundled_path.is_file(), f"Bundled SKILL.md missing: {bundled_path}"
+            assert source_path.is_file(), f"Source SKILL.md missing: {source_path}"
+
+            bundled_bytes = bundled_path.read_bytes()
+            source_bytes = source_path.read_bytes()
+            if bundled_bytes != source_bytes:
+                mismatches.append(name)
+
+        assert mismatches == [], (
+            f"Bundled and .claude/skills copies diverged for: {mismatches}. "
+            "Run: cp .claude/skills/<name>/SKILL.md tree_sitter_analyzer/skills/<name>/SKILL.md "
+            "for each skill in the list."
+        )
+
+    def test_no_legacy_tool_names_in_skills(self):
+        """Installed SKILL.md files must not contain legacy v1.x tool-call syntax.
+
+        Legacy names: bare old-tool-name(...) patterns that the 8-facade MCP
+        server does not register. Agents following these instructions fail on
+        their first call (issue #437).
+
+        The authoritative legacy set is LEGACY_TOOL_MAP keys from facade_map.py
+        plus get_project_summary (was never in LEGACY_TOOL_MAP but appeared
+        in skills). Canonical call form: ``edit action=safe`` not ``safe_to_edit()``.
+        """
+        import re
+
+        # Subset of high-impact legacy names — most likely to appear in tool
+        # call positions. Full set in facade_map.LEGACY_TOOL_MAP.
+        LEGACY_CALL_NAMES = [
+            "safe_to_edit",
+            "analyze_change_impact",
+            "check_project_health",
+            "check_file_health",
+            "check_constraints",
+            "codegraph_callers",
+            "codegraph_callees",
+            "codegraph_pr_review",
+            "codegraph_symbol_search",
+            "codegraph_call_path",
+            "analyze_dependencies",
+            "codegraph_import_graph",
+            "codegraph_sitemap",
+            "extract_code_section",
+            "find_and_grep",
+            "search_content",
+            "list_files",
+            "check_code_scale",
+            "analyze_code_structure",
+            "query_code",
+            "code_patterns",
+            "semantic_classify",
+            "refactoring_suggestions",
+            "ast_diff",
+            "codegraph_dead_code",
+            "codegraph_overview",
+            "codegraph_complexity_heatmap",
+            "advise_parser_readiness",
+            "get_agent_workflow",
+            "get_project_summary",
+            "smart_context",
+            "codegraph_autoindex",
+            "codegraph_full_index",
+            "ast_cache",
+            "codegraph_uml",
+        ]
+
+        repo = self._repo_root()
+        bundled_base = repo / "tree_sitter_analyzer" / "skills"
+
+        violations: dict[str, list[str]] = {}
+        for name in self.SKILL_NAMES:
+            skill_path = bundled_base / name / "SKILL.md"
+            content = skill_path.read_text(encoding="utf-8")
+            found = []
+            for legacy in LEGACY_CALL_NAMES:
+                # Match name immediately followed by ( — i.e. a function call
+                if re.search(r"\b" + re.escape(legacy) + r"\s*\(", content):
+                    found.append(legacy)
+            if found:
+                violations[name] = found
+
+        assert violations == {}, (
+            "Legacy tool-call names found in bundled skills (issue #437). "
+            "Replace with facade+action form (e.g. 'safe_to_edit(' → "
+            "'edit action=safe'). Violations: " + str(violations)
+        )

--- a/tree_sitter_analyzer/skills/tsa-constraints/SKILL.md
+++ b/tree_sitter_analyzer/skills/tsa-constraints/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: tsa-constraints
-version: 1.0.0
+version: 2.0.0
 description: |
   Architectural constraint enforcement. Detect forbidden cross-module calls
   ("MCP must not depend on CLI") at index time and gate edits on them. Rules
-  live in YAML at repo root; violations bubble up through safe_to_edit and
-  change_impact as UNSAFE verdicts.
+  live in YAML at repo root; violations bubble up through edit action=safe and
+  edit action=impact as UNSAFE verdicts.
 
   Use when:
   - User asks "does this PR break architecture?"
@@ -33,21 +33,21 @@ allowed-tools:
 
 ## When to use
 
-| Goal                                       | Action                                |
-|--------------------------------------------|---------------------------------------|
-| List current rules                         | Read `architectural-constraints.yml`  |
-| Check repo against rules                   | `check_constraints` (no args)         |
-| Pre-edit gate (includes rule check)        | `safe_to_edit` (auto)                 |
-| Add a new rule                             | Edit YAML + re-run `check_constraints`|
-| Filter violations by severity              | `check_constraints(severity_min="error")` |
-| Filter by path                             | `check_constraints(path_filter="mcp/**")` |
+| Goal                                       | Action                                         |
+|--------------------------------------------|------------------------------------------------|
+| List current rules                         | Read `architectural-constraints.yml`           |
+| Check repo against rules                   | `edit action=constraints` (no args)            |
+| Pre-edit gate (includes rule check)        | `edit action=safe` (auto)                      |
+| Add a new rule                             | Edit YAML + re-run `edit action=constraints`   |
+| Filter violations by severity              | `edit action=constraints severity_min="error"` |
+| Filter by path                             | `edit action=constraints path_filter="mcp/**"` |
 
 ## Procedure
 
 ### One-shot audit
 
 ```
-check_constraints()
+edit action=constraints
 ```
 
 Returns:
@@ -79,7 +79,7 @@ Verdict cascade:
      reason: "<why this is forbidden>"
      exceptions: ["specific/file.py"]   # optional
    ```
-3. Run `check_constraints` to see if existing code violates the new rule
+3. Run `edit action=constraints` to see if existing code violates the new rule
 4. Either: fix the violations OR add them to `exceptions`
 
 ### Reading violations

--- a/tree_sitter_analyzer/skills/tsa-deps/SKILL.md
+++ b/tree_sitter_analyzer/skills/tsa-deps/SKILL.md
@@ -73,7 +73,7 @@ Useful as a "first look" right after `tsa-landing`.
 uv run tree-sitter-analyzer <file> --dependencies file_deps
 uv run tree-sitter-analyzer --dependencies summary
 uv run tree-sitter-analyzer --import-graph --language python
-uv run tree-sitter-analyzer --ast-path
+uv run tree-sitter-analyzer --codegraph-sitemap
 ```
 
 ## Anti-patterns

--- a/tree_sitter_analyzer/skills/tsa-deps/SKILL.md
+++ b/tree_sitter_analyzer/skills/tsa-deps/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tsa-deps
-version: 1.0.0
+version: 2.0.0
 description: |
   Dependency / import graph analysis. Answer "what does this file import",
   "what imports this module", "what's the project's import topology",
@@ -26,18 +26,18 @@ allowed-tools:
 
 ## Tool routing
 
-| Question                                | Tool                          |
-|-----------------------------------------|-------------------------------|
-| One file's direct deps                  | `analyze_dependencies`        |
-| Project-wide import graph (who imports whom) | `codegraph_import_graph` |
-| Project topology (entry points, hubs)   | `codegraph_sitemap`           |
+| Question                                | Tool                              |
+|-----------------------------------------|-----------------------------------|
+| One file's direct deps                  | `health action=deps`              |
+| Project-wide import graph (who imports whom) | `health action=imports`      |
+| Project topology (entry points, hubs)   | `structure action=sitemap`        |
 
 ## Procedure
 
 ### File-level deps
 
 ```yaml
-analyze_dependencies(file_path: "tree_sitter_analyzer/ast_cache.py", mode: "file_deps")
+health action=deps file_path="tree_sitter_analyzer/ast_cache.py" mode="file_deps"
 # returns: {imports: [...], imported_by: [...], depth: 2}
 ```
 
@@ -49,7 +49,7 @@ analyze_dependencies(file_path: "tree_sitter_analyzer/ast_cache.py", mode: "file
 ### Import graph (project-level)
 
 ```yaml
-codegraph_import_graph(language: "python", limit: 50)
+health action=imports language="python" limit=50
 # returns: ranked list of import hubs + leaves
 ```
 
@@ -61,7 +61,7 @@ Use to find:
 ### Sitemap
 
 ```yaml
-codegraph_sitemap()
+structure action=sitemap
 # returns: {entry_points: [...], hub_modules: [...], leaf_modules: [...]}
 ```
 
@@ -73,7 +73,7 @@ Useful as a "first look" right after `tsa-landing`.
 uv run tree-sitter-analyzer <file> --dependencies file_deps
 uv run tree-sitter-analyzer --dependencies summary
 uv run tree-sitter-analyzer --import-graph --language python
-uv run tree-sitter-analyzer --sitemap
+uv run tree-sitter-analyzer --ast-path
 ```
 
 ## Anti-patterns

--- a/tree_sitter_analyzer/skills/tsa-edit-safety/SKILL.md
+++ b/tree_sitter_analyzer/skills/tsa-edit-safety/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tsa-edit-safety
-version: 1.0.0
+version: 2.0.0
 description: |
   Pre-edit safety check using tree-sitter-analyzer. One workflow → verdict
   (SAFE/REVIEW/CAUTION/UNSAFE) + verification command + risk factors → ≤2k
@@ -13,8 +13,9 @@ description: |
   - Asked "is it safe to change X?" or "what breaks if I touch Y?"
   - Before approving a code review
 
-  Workflow: 2-3 parallel MCP calls (safe_to_edit + change_impact + file_health),
-  fold the verdicts, surface the exact `verification_command` and stop_condition.
+  Workflow: 2-3 parallel MCP calls (edit action=safe + edit action=impact +
+  health action=file), fold the verdicts, surface the exact
+  `verification_command` and stop_condition.
 allowed-tools:
   - mcp__tree-sitter-analyzer__edit
   - mcp__tree-sitter-analyzer__health
@@ -45,9 +46,9 @@ allowed-tools:
 
 Call these 3 tools in ONE message:
 
-1. `safe_to_edit` with `file_path: "<the file>"` and `edit_type: "<refactor|rename|delete|bugfix>"`
-2. `analyze_change_impact` with `mode: "staged"` (or `"branch"` if pre-stage), scope to the file
-3. `check_file_health` with `file_path: "<the file>"`
+1. `edit action=safe` with `file_path: "<the file>"` and `edit_type: "<refactor|rename|delete|bugfix>"`
+2. `edit action=impact` with `mode: "staged"` (or `"branch"` if pre-stage), scope to the file
+3. `health action=file` with `file_path: "<the file>"`
 
 ### Step 2 — Read the verdict cascade
 

--- a/tree_sitter_analyzer/skills/tsa-edit-then-verify/SKILL.md
+++ b/tree_sitter_analyzer/skills/tsa-edit-then-verify/SKILL.md
@@ -150,7 +150,6 @@ PARALLEL BATCH (one message):
   → edit action=safe file_path="tree_sitter_analyzer/health_scorer.py" edit_type="feature"
   → health action=file file_path="tree_sitter_analyzer/health_scorer.py"
   → project action=smart file_path="tree_sitter_analyzer/health_scorer.py"
-                  query="add new dimension to grading rubric"
 
 Returned:
   edit action=safe:  verdict=REVIEW

--- a/tree_sitter_analyzer/skills/tsa-edit-then-verify/SKILL.md
+++ b/tree_sitter_analyzer/skills/tsa-edit-then-verify/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: tsa-edit-then-verify
-version: 1.0.0
+version: 2.0.0
 description: |
   The full edit-and-verify loop mandated by CLAUDE.md and docs/agent-tooling-gap-report.md:58.
-  Pre-edit gate (safe_to_edit + baseline file_health) → LLM edits → post-edit verify
-  (file_health diff + analyze_change_impact + scoped verification_command).
-  Replaces "edit then run the whole pytest suite" (~5 min) with a scoped
-  verification (~30-60s) that only escalates to full suite when risk remains.
+  Pre-edit gate (edit action=safe + baseline health action=file) → LLM edits →
+  post-edit verify (health action=file diff + edit action=impact + scoped
+  verification_command). Replaces "edit then run the whole pytest suite" (~5 min)
+  with a scoped verification (~30-60s) that only escalates to full suite when
+  risk remains.
 
   Use when:
   - About to make any non-trivial edit to a code file in tree-sitter-analyzer
@@ -34,9 +35,9 @@ allowed-tools:
 
 > **Source of authority.** From `docs/agent-tooling-gap-report.md` line 58:
 >
-> > Every feature update must run the self-hosted workflow: `safe_to_edit`
-> > before risky edits, `file_health` on changed files, `change_impact` after
-> > edits, its reported `verification_command`, then the full default suite
+> > Every feature update must run the self-hosted workflow: `edit action=safe`
+> > before risky edits, `health action=file` on changed files, `edit action=impact`
+> > after edits, its reported `verification_command`, then the full default suite
 > > when risk remains.
 >
 > This skill is the **executable form** of that rule. `tsa-edit-safety` only
@@ -62,11 +63,11 @@ the bigger the win — full pytest is ~5 min, scoped verification is typically
 | Skill                       | What it runs                          | Time    | When right |
 |-----------------------------|---------------------------------------|---------|------------|
 | `verify` (global)           | `uv run pytest -q` (15k tests)        | ~5 min  | Pre-commit gate, large refactor |
-| **`tsa-edit-then-verify`**  | scoped `verification_command` from `analyze_change_impact` | **30-60s** | **Every feature update (the mandate)** |
+| **`tsa-edit-then-verify`**  | scoped `verification_command` from `edit action=impact` | **30-60s** | **Every feature update (the mandate)** |
 | `tsa-edit-safety`           | Pre-edit verdict only                 | ~3s     | "Is this safe to touch?" — no edit yet |
 
 The scoped command targets only the tests reachable from the changed symbols,
-via the AST call-graph. That's the whole point — `analyze_change_impact`
+via the AST call-graph. That's the whole point — `edit action=impact`
 returns a `verification_command` that's narrower than `pytest -q` but still
 covers the blast radius the AST sees.
 
@@ -76,12 +77,12 @@ covers the blast radius the AST sees.
 
 Call these in ONE message (parallel tool use):
 
-1. `safe_to_edit` with `file_path: "<file>"` and `edit_type: "<refactor|rename|delete|bugfix|feature>"`
-2. `check_file_health` with `file_path: "<file>"` — **record the grade. This is your baseline.**
+1. `edit action=safe` with `file_path: "<file>"` and `edit_type: "<refactor|rename|delete|bugfix|feature>"`
+2. `health action=file` with `file_path: "<file>"` — **record the grade. This is your baseline.**
 3. (Optional, only if file is unfamiliar to you in this session)
-   `smart_context` with `file_path: "<file>"` and `query: "<what you intend to change>"`
+   `project action=smart` with `file_path: "<file>"` and `query: "<what you intend to change>"`
 
-**Gate the verdict.** From `safe_to_edit.verdict`:
+**Gate the verdict.** From `edit action=safe verdict`:
 - `UNSAFE` → STOP. Surface the `risk_factors`, ask the user how to proceed.
   Do not edit.
 - `CAUTION` → narrow your scope. Write a failing test first if there isn't
@@ -90,8 +91,8 @@ Call these in ONE message (parallel tool use):
   "no tests nearby".
 - `SAFE` → proceed to Phase B.
 
-**Persist the baseline grade.** Note `check_file_health.grade` and
-`check_file_health.score` in your scratch — you will diff against these in
+**Persist the baseline grade.** Note `health action=file grade` and
+`health action=file score` in your scratch — you will diff against these in
 Phase C.
 
 ### Phase B — Edit (out of skill scope)
@@ -108,10 +109,10 @@ and reconsider whether this is really one task or three.
 
 After your last edit, call these in ONE message (parallel tool use):
 
-4. `check_file_health` with `file_path: "<file>"` again
+4. `health action=file` with `file_path: "<file>"` again
    → **diff against Phase A baseline. Grade MUST NOT regress.** (B→C is a
    regression. A→A is fine. F→D is improvement.)
-5. `analyze_change_impact` with `mode: "staged"` (or `mode: "branch"` if you
+5. `edit action=impact` with `mode: "staged"` (or `mode: "branch"` if you
    haven't staged) — returns `verification_command`, `pytest_command`,
    `queue_ledger`, `risk_remains` flag.
 
@@ -124,7 +125,7 @@ After your last edit, call these in ONE message (parallel tool use):
    ```
    Expect 30-60s. If it fails, fix and re-run from step 4.
 
-7. **Only if** `analyze_change_impact.risk_remains == true` (or grade
+7. **Only if** `edit action=impact risk_remains == true` (or grade
    regressed in step 4, or impact reports cross-module reach), run the full
    suite:
    ```bash
@@ -146,17 +147,17 @@ health-grading rubric.
 
 ```
 PARALLEL BATCH (one message):
-  → safe_to_edit(file_path="tree_sitter_analyzer/health_scorer.py", edit_type="feature")
-  → check_file_health(file_path="tree_sitter_analyzer/health_scorer.py")
-  → smart_context(file_path="tree_sitter_analyzer/health_scorer.py",
-                  query="add new dimension to grading rubric")
+  → edit action=safe file_path="tree_sitter_analyzer/health_scorer.py" edit_type="feature"
+  → health action=file file_path="tree_sitter_analyzer/health_scorer.py"
+  → project action=smart file_path="tree_sitter_analyzer/health_scorer.py"
+                  query="add new dimension to grading rubric"
 
 Returned:
-  safe_to_edit:  verdict=REVIEW
+  edit action=safe:  verdict=REVIEW
                  risk_factors=[{factor: "hot_zone", detail: "mod_count_30d=7"}]
                  verification_command="uv run pytest tests/unit/test_health_scorer.py -q"
-  check_file_health: grade=B, score=84, weakest=complexity   ← BASELINE
-  smart_context: top 3 callers = [check_project_health, check_file_health, cli/__main__]
+  health action=file: grade=B, score=84, weakest=complexity   ← BASELINE
+  project action=smart: top 3 callers = [health action=project, health action=file, cli/__main__]
 ```
 
 Verdict is REVIEW + hot_zone — write a test for the new dimension first.
@@ -170,12 +171,12 @@ dimension. Diff is ~40 lines.
 
 ```
 PARALLEL BATCH (one message):
-  → check_file_health(file_path="tree_sitter_analyzer/health_scorer.py")
-  → analyze_change_impact(mode="staged")
+  → health action=file file_path="tree_sitter_analyzer/health_scorer.py"
+  → edit action=impact mode="staged"
 
 Returned:
-  check_file_health: grade=B, score=82, weakest=complexity   ← B→B, no regression ✓
-  analyze_change_impact:
+  health action=file: grade=B, score=82, weakest=complexity   ← B→B, no regression ✓
+  edit action=impact:
     verification_command="uv run pytest tests/unit/test_health_scorer.py
                           tests/unit/test_file_health_blocks.py
                           tests/unit/test_file_health_smells.py -q"
@@ -243,7 +244,7 @@ uv run tree-sitter-analyzer tree_sitter_analyzer/health_scorer.py \
 uv run tree-sitter-analyzer tree_sitter_analyzer/health_scorer.py \
   --file-health --output-format json
 uv run tree-sitter-analyzer tree_sitter_analyzer/health_scorer.py \
-  --smart-context --query "add new dimension" --output-format json
+  --smart-context --output-format json
 ```
 
 Run post-edit (Phase C):
@@ -258,16 +259,16 @@ uv run python -m tree_sitter_analyzer --change-impact \
 
 ## Verdict cascade (Phase A gate)
 
-| `safe_to_edit.verdict` | Action |
-|------------------------|--------|
-| `UNSAFE`               | STOP. Surface risk_factors. Ask user. Do not edit. |
-| `CAUTION`              | Narrow scope. Write test first. Then edit. |
-| `REVIEW`               | Edit OK; write a test first if "no tests nearby". |
-| `SAFE`                 | Proceed to Phase B. |
+| `edit action=safe verdict` | Action |
+|----------------------------|--------|
+| `UNSAFE`                   | STOP. Surface risk_factors. Ask user. Do not edit. |
+| `CAUTION`                  | Narrow scope. Write test first. Then edit. |
+| `REVIEW`                   | Edit OK; write a test first if "no tests nearby". |
+| `SAFE`                     | Proceed to Phase B. |
 
 ## Grade-regression rule (Phase C step 4)
 
-Compare `check_file_health.grade` before vs. after:
+Compare `health action=file grade` before vs. after:
 
 | Before → After | Verdict | Action |
 |----------------|---------|--------|
@@ -283,11 +284,11 @@ Let the user decide.
 
 Run `uv run pytest -q` (full suite, ~5 min) only when ANY of these is true:
 
-- `analyze_change_impact.risk_remains == true`
+- `edit action=impact risk_remains == true`
 - Grade regressed in step 4 (A→B or worse)
 - Edit touched any of: `BaseMCPTool.__init__`, `PathResolver`, `SecurityValidator`, `plugin registry`, `cli/__main__.py`, `mcp/server.py`
 - Edit crossed >3 files
-- `analyze_change_impact.queue_ledger` shows cross-module reach (impact crossing top-level packages)
+- `edit action=impact queue_ledger` shows cross-module reach (impact crossing top-level packages)
 
 Otherwise the scoped `verification_command` from step 6 is the official
 verify gate — no need to burn 5 minutes.
@@ -298,7 +299,7 @@ verify gate — no need to burn 5 minutes.
   and catches `UNSAFE` constraint violations that would waste your Phase B
   effort.
 - **Running `pytest -q` immediately in Phase C** without first calling
-  `analyze_change_impact` — defeats the whole purpose of this skill. The
+  `edit action=impact` — defeats the whole purpose of this skill. The
   scoped command is the point.
 - **Ignoring grade regression** in Phase C step 4 — a B→C regression on a
   hot-zone file is a real signal even if tests pass.

--- a/tree_sitter_analyzer/skills/tsa-find/SKILL.md
+++ b/tree_sitter_analyzer/skills/tsa-find/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tsa-find
-version: 1.0.0
+version: 2.0.0
 description: |
   Fast file + content search with code-aware sizing. Replaces Read/Grep/find
   for routine "where is this file" / "grep for X" / "show me lines 10-20 of Y"
@@ -31,20 +31,20 @@ allowed-tools:
 
 ## Tool routing
 
-| Question                                  | Tool                    |
-|-------------------------------------------|-------------------------|
-| Filename pattern only                     | `list_files`            |
-| Content pattern only (regex / literal)    | `search_content`        |
-| Filename pattern AND content              | `find_and_grep`         |
-| Read specific lines of one file           | `extract_code_section`  |
-| "Is this file too big to read fully?"     | `check_code_scale`      |
+| Question                                  | Tool                        |
+|-------------------------------------------|-----------------------------|
+| Filename pattern only                     | `project action=files`      |
+| Content pattern only (regex / literal)    | `search action=content`     |
+| Filename pattern AND content              | `search action=grep`        |
+| Read specific lines of one file           | `structure action=read`     |
+| "Is this file too big to read fully?"     | `health action=scale`       |
 
 ## Procedure
 
 ### Single search
 
 ```yaml
-search_content(pattern: "TODO", path: "tree_sitter_analyzer/", file_pattern: "*.py")
+search action=content query="TODO" roots=["tree_sitter_analyzer/"] include_globs=["*.py"]
 ```
 
 Returns: `matches: [{file, line, content}]` with sized previews. Always
@@ -55,14 +55,14 @@ includes file:line so the agent can cite without reading the file.
 Before reading a large file blind, use:
 
 ```yaml
-check_code_scale(file_path: "tree_sitter_analyzer/ast_cache.py")
-# returns {lines: 2144, size_bytes: 79809, is_large: true, recommendation: "use extract_code_section"}
+health action=scale file_path="tree_sitter_analyzer/ast_cache.py"
+# returns {lines: 2144, size_bytes: 79809, is_large: true, recommendation: "use structure action=read"}
 ```
 
 Then extract only what you need:
 
 ```yaml
-extract_code_section(file_path: "...", start_line: 800, end_line: 870)
+structure action=read file_path="..." start_line=800 end_line=870
 ```
 
 Avoids reading 80KB when you need 2KB.
@@ -70,22 +70,20 @@ Avoids reading 80KB when you need 2KB.
 ### Combined find+grep
 
 ```yaml
-find_and_grep(file_pattern: "test_*.py", content_pattern: "def test_synapse")
+search action=grep file_pattern="test_*.py" content_pattern="def test_synapse"
 # returns: list of test functions matching both criteria
 ```
 
 ## CLI equivalents
 
 ```bash
-uv run tree-sitter-analyzer --list-files --extensions py,yml
-uv run tree-sitter-analyzer --search-content "TODO" --include "*.py"
-uv run tree-sitter-analyzer --find-and-grep "test_*.py" "def test_synapse"
-uv run tree-sitter-analyzer <file> --check-scale
-uv run tree-sitter-analyzer <file> --partial-read --start-line 800 --end-line 870
+uv run tree-sitter-analyzer --project-root . --outline   # list project files
+uv run tree-sitter-analyzer --check-tools                # verify fd/rg available
+uv run tree-sitter-analyzer <file> --partial-read        # sized read with --start-line / --end-line
 ```
 
 ## Anti-patterns
 
 - DON'T `Read` a large file before checking scale — burns tokens
-- DON'T `Bash grep -rn` for things `search_content` handles — slower + noisier
+- DON'T `Bash grep -rn` for things `search action=content` handles — slower + noisier
 - DON'T re-search the same query twice in one session — cache the result mentally

--- a/tree_sitter_analyzer/skills/tsa-graph/SKILL.md
+++ b/tree_sitter_analyzer/skills/tsa-graph/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tsa-graph
-version: 1.0.0
+version: 2.0.0
 description: |
   Code archaeology via call graph + symbol resolution. Answer "who calls X",
   "what does Y call", "where is Z defined", "what's the path from A to B" in
@@ -37,19 +37,19 @@ allowed-tools:
 
 Pick the right tool by question shape:
 
-| Question                              | Tool                          |
-|---------------------------------------|-------------------------------|
-| Need search + snippets + callers/callees together? | `codegraph_query` |
-| What does FUNCTION call?              | `codegraph_callees`           |
-| What calls FUNCTION?                  | `codegraph_callers`           |
-| Where is SYMBOL defined?              | `codegraph_symbol_search`     |
-| What references SYMBOL anywhere?      | `codegraph_xref`              |
-| Path from CALLER to CALLEE?           | `codegraph_call_path`         |
-| Resolve "Path" in file X (project or stdlib?) | `codegraph_resolve`   |
-| Need architecture diagram output?     | `codegraph_uml`               |
+| Question                              | Tool                              |
+|---------------------------------------|-----------------------------------|
+| Need search + snippets + callers/callees together? | `search action=chain` |
+| What does FUNCTION call?              | `nav action=callees`              |
+| What calls FUNCTION?                  | `nav action=callers`              |
+| Where is SYMBOL defined?              | `search action=symbol`            |
+| What references SYMBOL anywhere?      | `nav action=xref`                 |
+| Path from CALLER to CALLEE?           | `nav action=call_path`            |
+| Resolve "Path" in file X (project or stdlib?) | `nav action=resolve`    |
+| Need architecture diagram output?     | `viz action=uml`                  |
 
 **Don't use** when:
-- You need the actual *body* of the function → use `extract_code_section`
+- You need the actual *body* of the function → use `structure action=read`
 - You're hunting a string literal in non-source files → use Grep
 
 ## Procedure
@@ -61,30 +61,30 @@ Pick the matching tool, call once. Read the response. Done.
 Example: "what calls `score_file`?"
 
 ```
-codegraph_callers(function_name="score_file", language="python", limit=20)
+nav action=callers function_name="score_file" language="python" limit=20
 ```
 
 Returns: `callers: [{name, file, line, callee_resolution, callee_resolved_file}, ...]`.
-The new `callee_resolution` field tells you `local` / `project` / `stdlib` /
+The `callee_resolution` field tells you `local` / `project` / `stdlib` /
 `unknown` so you can filter out noise.
 
 When a question needs several graph hops plus source snippets, prefer the
 chain surface:
 
 ```
-codegraph_query(query="search('score_file').explore(max_files=3).callers(depth=1).callees(depth=1)")
+search action=chain query="search('score_file').explore(max_files=3).callers(depth=1).callees(depth=1)"
 ```
 
 ### Multi-step case (refactor planning)
 
 Fan out 3 in parallel:
-1. `codegraph_callers` (who depends on this — blast radius)
-2. `codegraph_callees` (what this depends on — what may need updating)
-3. `codegraph_symbol_search` with the symbol name (find aliases / shadows)
+1. `nav action=callers` (who depends on this — blast radius)
+2. `nav action=callees` (what this depends on — what may need updating)
+3. `search action=symbol` with the symbol name (find aliases / shadows)
 
 Then if you need a specific reachability path:
 ```
-codegraph_call_path(from_function="X", to_function="Y", max_depth=10)
+nav action=call_path from_function="X" to_function="Y" max_depth=10
 ```
 
 ## Reading the new resolution fields (Synapse)
@@ -112,12 +112,14 @@ uv run tree-sitter-analyzer --callees <FUNC> --output-format toon
 uv run tree-sitter-analyzer --callers <FUNC> --output-format toon
 uv run tree-sitter-analyzer --symbol-search <NAME> --output-format toon
 uv run tree-sitter-analyzer --codegraph-xref <SYMBOL> --output-format toon
+uv run tree-sitter-analyzer --call-path --call-path-source X --call-path-target Y
+uv run tree-sitter-analyzer --uml class --output-format toon
 ```
 
 ## Anti-patterns
 
-- Don't `grep -rn "def X" tree_sitter_analyzer/` — use `codegraph_symbol_search` (10x faster, precise)
-- Don't read 5 files to trace a call chain — use `codegraph_call_path`
+- Don't `grep -rn "def X" tree_sitter_analyzer/` — use `search action=symbol` (10x faster, precise)
+- Don't read 5 files to trace a call chain — use `nav action=call_path`
 - Don't ignore `callee_resolution` — `unknown` entries are noise, filter them
 
 ## Decision surface

--- a/tree_sitter_analyzer/skills/tsa-health-watch/SKILL.md
+++ b/tree_sitter_analyzer/skills/tsa-health-watch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tsa-health-watch
-version: 1.0.0
+version: 2.0.0
 description: |
   Project & file health grading + dead-code detection + watch-daemon for grade
   drops. Answer "how healthy is this codebase", "what's rotting", "which files
@@ -29,14 +29,14 @@ allowed-tools:
 
 ## When to use
 
-| Goal                            | Tool                                |
-|---------------------------------|-------------------------------------|
-| Project portrait + worst files  | `check_project_health`              |
-| One-file deep dive              | `check_file_health`                 |
-| Top hubs + sensory neurons      | `codegraph_overview`                |
-| Find dead functions             | `codegraph_dead_code`               |
-| Complexity hotspots (visualize) | `codegraph_complexity_heatmap`      |
-| Watch & alert on degradation    | `--watch-health` CLI (Bash)         |
+| Goal                            | Tool                                  |
+|---------------------------------|---------------------------------------|
+| Project portrait + worst files  | `health action=project`               |
+| One-file deep dive              | `health action=file`                  |
+| Top hubs + sensory neurons      | `health action=overview`              |
+| Find dead functions             | `health action=dead`                  |
+| Complexity hotspots (visualize) | `health action=heatmap`               |
+| Watch & alert on degradation    | `--watch-health` CLI (Bash)           |
 
 ## Procedure
 
@@ -44,17 +44,17 @@ allowed-tools:
 
 Fan out in one message:
 
-1. `check_project_health` with `max_files: 20` — grade distribution + worst-20
-2. `codegraph_dead_code` with `limit: 50` — pruning candidates
-3. `codegraph_overview` — hub functions + entry points + 0-degree leaves
+1. `health action=project` with `max_files: 20` — grade distribution + worst-20
+2. `health action=dead` with `limit: 50` — pruning candidates
+3. `health action=overview` — hub functions + entry points + 0-degree leaves
 
 Read the verdict. If `D/F` files exist in worst-20, drill into each with
-`check_file_health` to get the per-dimension breakdown + recommendation.
+`health action=file` to get the per-dimension breakdown + recommendation.
 
 ### Single-file investigation
 
 ```
-check_file_health(file_path="<path>")
+health action=file file_path="<path>"
 ```
 
 Returns:
@@ -113,7 +113,7 @@ uv run tree-sitter-analyzer --watch-health --threshold-grade C  # daemon
 ## Anti-patterns
 
 - Don't grade individual files when the question is "which 10 are worst" —
-  use `check_project_health` once instead of N file-health calls.
+  use `health action=project` once instead of N file-health calls.
 - Don't ignore `dimensions` and just look at the grade letter — the
   recommendation lives in the weakest dimension.
 - Don't use `--watch-health` for one-shot checks — it's a long-running daemon.
@@ -121,11 +121,11 @@ uv run tree-sitter-analyzer --watch-health --threshold-grade C  # daemon
 ## Decision surface
 
 ```yaml
-project (when check_project_health):
+project (when health action=project):
   grade_distribution: {A: n, B: n, C: n, D: n, F: n}
   worst_files: [{path, grade, score, weakest_dimension}, ...]
 
-file (when check_file_health):
+file (when health action=file):
   grade: A | B | C | D | F
   score: 0-100
   signal: healthy | moderate_depth | ...

--- a/tree_sitter_analyzer/skills/tsa-index/SKILL.md
+++ b/tree_sitter_analyzer/skills/tsa-index/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tsa-index
-version: 1.0.0
+version: 2.0.0
 description: |
   Manage the persistent AST cache / index. Refresh, force-rebuild, inspect
   cache state, diff one file's AST between commits, advise on parser readiness
@@ -29,16 +29,16 @@ allowed-tools:
 
 ## Tool routing
 
-| Goal                                           | Tool                    |
-|------------------------------------------------|-------------------------|
-| Status / stats of the AST cache                | `ast_cache` (mode=status) |
-| Force rebuild                                  | `ast_cache` (mode=force)  |
-| Incremental refresh                            | `ast_cache` (mode=index)  |
-| Watch a directory and auto-refresh             | `ast_cache` (mode=watch_start) |
-| AST-level diff of one file across commits      | `ast_diff`              |
-| First-time index for a freshly-cloned repo     | `codegraph_autoindex`   |
-| Full bulk reindex (large monorepo)             | `codegraph_full_index`  |
-| "Is the python plugin / swift plugin ready"    | `advise_parser_readiness` |
+| Goal                                           | Tool                              |
+|------------------------------------------------|-----------------------------------|
+| Status / stats of the AST cache                | `index action=cache` (mode=status) |
+| Force rebuild                                  | `index action=cache` (mode=force)  |
+| Incremental refresh                            | `index action=cache` (mode=index)  |
+| Watch a directory and auto-refresh             | `index action=cache` (mode=watch_start) |
+| AST-level diff of one file across commits      | `edit action=ast_diff`            |
+| First-time index for a freshly-cloned repo     | `index action=auto`               |
+| Full bulk reindex (large monorepo)             | `index action=full`               |
+| "Is the python plugin / swift plugin ready"    | `project action=parser`           |
 
 ## Procedure
 
@@ -61,7 +61,7 @@ uv run tree-sitter-analyzer --ast-cache --ast-cache-mode index
 For structural change detection (not text):
 
 ```yaml
-ast_diff(file_path: "...", base_ref: "HEAD~5", head_ref: "HEAD")
+edit action=ast_diff file_path="..." base_ref="HEAD~5" head_ref="HEAD"
 # returns: {nodes_added: n, nodes_removed: n, nodes_modified: n,
 #           classification_hints: [...]}
 ```
@@ -71,7 +71,7 @@ Useful for distinguishing pure formatting from real change.
 ### Parser readiness
 
 ```yaml
-advise_parser_readiness(language: "swift")
+project action=parser language="swift"
 # returns: {status: "stable|beta|stub", supported_queries: [...], limitations: [...]}
 ```
 
@@ -82,10 +82,10 @@ Avoid asking "why doesn't swift work" — query this first.
 ```bash
 uv run tree-sitter-analyzer --ast-cache --ast-cache-mode status
 uv run tree-sitter-analyzer --ast-cache --ast-cache-mode force
-uv run tree-sitter-analyzer --ast-diff <file> --base HEAD~5 --head HEAD
-uv run tree-sitter-analyzer parser-readiness swift
-uv run tree-sitter-analyzer --autoindex            # codegraph_autoindex
-uv run tree-sitter-analyzer --full-index           # codegraph_full_index
+uv run tree-sitter-analyzer --ast-diff --ast-diff-file <file> --ast-diff-old-ref HEAD~5 --ast-diff-new-ref HEAD
+uv run tree-sitter-analyzer --parser-readiness swift
+uv run tree-sitter-analyzer --autoindex            # index action=auto
+uv run tree-sitter-analyzer --full-index           # index action=full
 ```
 
 ## Anti-patterns

--- a/tree_sitter_analyzer/skills/tsa-landing/SKILL.md
+++ b/tree_sitter_analyzer/skills/tsa-landing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tsa-landing
-version: 1.0.0
+version: 2.0.0
 description: |
   Land in a new (or familiar) codebase using the tree-sitter-analyzer MCP server.
   One workflow → 6 decision surfaces (project_card / entry_points / recent_signals /
@@ -33,7 +33,7 @@ allowed-tools:
 
 **Don't use** when:
 - You already have full context (just continue working)
-- User wants to read source — use `extract_code_section` directly
+- User wants to read source — use `structure action=read` directly
 
 ## Procedure
 
@@ -49,10 +49,10 @@ If `fd` or `rg` missing, stop and tell user how to install.
 
 Call these 4 tools in ONE message (parallel tool use):
 
-1. `get_project_summary` (no args) — project_card + entry_points
-2. `check_project_health` with `max_files: 5` — grade distribution + weakest dimension
-3. `analyze_change_impact` with `mode: "branch"` — recent_signals (last commit, ahead-of-main)
-4. `get_agent_workflow` (no args) — current_phase + recommended_commands
+1. `project action=overview` (no args) — project_card + entry_points
+2. `health action=project` with `max_files: 5` — grade distribution + weakest dimension
+3. `edit action=impact` with `mode: "branch"` — recent_signals (last commit, ahead-of-main)
+4. `project action=workflow` (no args) — current_phase + recommended_commands
 
 ### Step 3 — Fold and emit decision_surface
 
@@ -61,16 +61,16 @@ Combine into single Decision Surface:
 ```jsonc
 {
   "project_card": {
-    "name": <from get_project_summary.project_root basename>,
-    "purpose": <from get_project_summary.summary.purpose if present>,
-    "primary_language": <from get_project_summary.summary.by_language[0].name>,
-    "language_mix": <from get_project_summary.summary.by_language top 3>,
+    "name": <from project action=overview project_root basename>,
+    "purpose": <from project action=overview summary.purpose if present>,
+    "primary_language": <from project action=overview summary.by_language[0].name>,
+    "language_mix": <from project action=overview summary.by_language top 3>,
     "size": {
-      "files": <from get_project_summary.summary.total_files>,
-      "loc": <from get_project_summary.summary.total_lines>
+      "files": <from project action=overview summary.total_files>,
+      "loc": <from project action=overview summary.total_lines>
     }
   },
-  "entry_points": <from get_project_summary.entry_points>,
+  "entry_points": <from project action=overview entry_points>,
   "recent_signals": {
     "last_commit": <git log -1 --oneline via Bash>,
     "ahead_of_origin": <git rev-list --count via Bash>,
@@ -78,24 +78,24 @@ Combine into single Decision Surface:
     "branch": <git branch --show-current via Bash>
   },
   "health": {
-    "verdict": <from check_project_health.verdict>,
-    "risk": <from check_project_health.agent_summary.risk>,
-    "grade_distribution": <from check_project_health.grade_distribution>,
-    "weakest_dimension": <from check_project_health.weakest_dimension>
+    "verdict": <from health action=project verdict>,
+    "risk": <from health action=project agent_summary.risk>,
+    "grade_distribution": <from health action=project grade_distribution>,
+    "weakest_dimension": <from health action=project weakest_dimension>
   },
   "top_files_to_know": [
     "AGENTS.md",
     "CLAUDE.md",
-    <from get_project_summary.entry_points>,
-    <top 3 from check_project_health.top_refactoring_targets>
+    <from project action=overview entry_points>,
+    <top 3 from health action=project top_refactoring_targets>
   ],
   "agent_next_step": {
     "if_asked_what_is_this":
       "Read AGENTS.md (canonical contracts) + docs/CODEMAPS/architecture.md (topology). Stop after 2k tokens.",
     "if_asked_to_add_feature":
-      "Call get_agent_workflow → follow phase_order. Use TDD (write test first).",
+      "Call project action=workflow → follow phase_order. Use TDD (write test first).",
     "if_asked_to_fix_bug":
-      "Call code_patterns(file_path) → refactoring_suggestions(file_path). Cross-ref symbol_lineage if symbol-level.",
+      "Call health action=patterns file_path=<file> → edit action=refactor file_path=<file>. Cross-ref nav action=lineage if symbol-level.",
     "if_asked_about_test_status":
       "Run: uv run pytest -q (5-min cap). Project enforces xdist parallel, ~5min for 15k tests."
   },

--- a/tree_sitter_analyzer/skills/tsa-pr-review/SKILL.md
+++ b/tree_sitter_analyzer/skills/tsa-pr-review/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: tsa-pr-review
-version: 1.0.0
+version: 2.0.0
 description: |
   AST-grounded PR / diff review. One workflow → per-file risk ranking, blast
   radius per changed symbol, the exact pytest command to gate merge, any
   architecture-constraint violations, and a final BLOCK / REVIEW / APPROVE
   verdict — in ~1–2k tokens and 4–6 MCP calls.
 
-  Goes beyond a generic LLM diff-read because only TSA's `analyze_change_impact`
+  Goes beyond a generic LLM diff-read because only TSA's `edit action=impact`
   returns a deterministic `verification_command` + `queue_ledger`, and only the
   persisted call graph can enumerate true callers/callees of changed symbols.
   (Per `docs/internal/COMPETITOR_HEAD_TO_HEAD_2026-05-23.md`: CodeGraphContext
@@ -24,9 +24,9 @@ description: |
   - Pre-merge gate in CI / agent loops
   - Right after `/ship` produced a diff and before `/land`
 
-  Workflow: fan-out (pr_review + change_impact + check_constraints) → per-file
-  fan-out (safe_to_edit) → per-symbol fan-out (callers + callees) → fold into
-  a verdict-ranked report.
+  Workflow: fan-out (edit action=pr + edit action=impact + edit action=constraints)
+  → per-file fan-out (edit action=safe) → per-symbol fan-out (nav action=callers
+  + nav action=callees) → fold into a verdict-ranked report.
 allowed-tools:
   - mcp__tree-sitter-analyzer__edit
   - mcp__tree-sitter-analyzer__nav
@@ -55,15 +55,15 @@ allowed-tools:
 
 ## Why this beats a generic LLM diff-read
 
-| Concern                          | LLM-only diff read   | tsa-pr-review                            |
-|----------------------------------|----------------------|------------------------------------------|
-| Classify signature vs body change| Heuristic            | `codegraph_pr_review` AST diff           |
-| Exact tests to run               | Invented / hallucinated | `analyze_change_impact.verification_command` |
-| Caller blast radius              | Grep guess           | `codegraph_callers` from persisted graph |
-| Callee regression surface        | Read N files         | `codegraph_callees` from persisted graph |
-| Architecture rule violations     | None                 | `check_constraints` vs YAML rules        |
-| Per-file pre-merge verdict       | Subjective           | `safe_to_edit` SAFE/REVIEW/CAUTION/UNSAFE|
-| Behaviour on Python 3.14         | n/a                  | Stable (grep-ast crashes, cgc silent-0)  |
+| Concern                          | LLM-only diff read   | tsa-pr-review                               |
+|----------------------------------|----------------------|---------------------------------------------|
+| Classify signature vs body change| Heuristic            | `edit action=pr` AST diff                   |
+| Exact tests to run               | Invented / hallucinated | `edit action=impact verification_command` |
+| Caller blast radius              | Grep guess           | `nav action=callers` from persisted graph   |
+| Callee regression surface        | Read N files         | `nav action=callees` from persisted graph   |
+| Architecture rule violations     | None                 | `edit action=constraints` vs YAML rules     |
+| Per-file pre-merge verdict       | Subjective           | `edit action=safe` SAFE/REVIEW/CAUTION/UNSAFE|
+| Behaviour on Python 3.14         | n/a                  | Stable (grep-ast crashes, cgc silent-0)     |
 
 (Source: `docs/internal/COMPETITOR_HEAD_TO_HEAD_2026-05-23.md` — the 4
 fault-tolerance advantages: oracle-consistent AST, indexed-not-silent,
@@ -75,35 +75,35 @@ Python 3.14-safe, no external DB dependency.)
 
 In one message, call all three:
 
-1. `codegraph_pr_review(mode="staged")` — AST diff classification, per-symbol
+1. `edit action=pr mode="staged"` — AST diff classification, per-symbol
    change category (signature_change / body_change / new_symbol / deletion),
    and per-file changed-symbol list.
-   - For PR URL: `codegraph_pr_review(mode="pr", pr_url="<url>")`
+   - For PR URL: `edit action=pr mode="pr" pr_url="<url>"`
    - For unstaged: `mode="diff"`; for branch-vs-main: `mode="branch"`
-2. `analyze_change_impact(mode="staged")` — returns `verification_command`,
+2. `edit action=impact mode="staged"` — returns `verification_command`,
    `queue_ledger` (in-scope vs out-of-scope dirty files), `pytest_required`,
    and per-file impact rows.
-3. `check_constraints()` — full repo audit against `architectural-constraints.yml`,
+3. `edit action=constraints` — full repo audit against `architectural-constraints.yml`,
    filtered to files the diff touches if you want noise-free output:
-   `check_constraints(path_filter="<glob covering changed files>")`.
+   `edit action=constraints path_filter="<glob covering changed files>"`.
 
 ### Step 2 — Per-file fan-out (parallel, N calls)
 
 For each changed file from Step 1, call:
 
-`safe_to_edit(file_path="<abs>", edit_type="<refactor|rename|delete|bugfix>")`
+`edit action=safe file_path="<abs>" edit_type="<refactor|rename|delete|bugfix>"`
 
 Pick `edit_type` from the dominant change category in Step 1's
-`codegraph_pr_review` output. Returns per-file verdict + `risk_factors`.
+`edit action=pr` output. Returns per-file verdict + `risk_factors`.
 
 ### Step 3 — Per-symbol fan-out (parallel, ≤2N calls)
 
 For each *changed signature* (not body-only) symbol from Step 1, fan out
 two calls:
 
-- `codegraph_callers(function_name="<sym>", language="<lang>", limit=20)`
+- `nav action=callers function_name="<sym>" language="<lang>" limit=20`
   — who depends on this; the blast radius if its signature moved.
-- `codegraph_callees(function_name="<sym>", language="<lang>", limit=20)`
+- `nav action=callees function_name="<sym>" language="<lang>" limit=20`
   — what it calls; the regression surface if its body changed.
 
 Filter callers/callees where `callee_resolution == "stdlib"` or `"unknown"` —
@@ -113,9 +113,9 @@ they're noise for blast-radius scoring (per tsa-graph guidance).
 
 ```
 verdict_precedence (worst wins):
-  - BLOCK   ← any check_constraints violation with severity=error
-              OR any safe_to_edit verdict == UNSAFE
-  - REVIEW  ← any safe_to_edit verdict in {REVIEW, CAUTION}
+  - BLOCK   ← any edit action=constraints violation with severity=error
+              OR any edit action=safe verdict == UNSAFE
+  - REVIEW  ← any edit action=safe verdict in {REVIEW, CAUTION}
               OR pytest_required=true with no nearby tests
               OR signature_change with ≥5 external callers
   - APPROVE ← all per-file verdicts == SAFE,
@@ -140,7 +140,7 @@ git -C /Users/aisheng.yu/git-private/tree-sitter-analyzer diff HEAD~2 HEAD --nam
 
 ```yaml
 # Call 1
-codegraph_pr_review(mode="branch", include_call_graph=true, output_format="json")
+edit action=pr mode="branch" include_call_graph=true
 # returns:
 #   changed_files:
 #     - path: ".../safe_to_edit_tool.py"
@@ -155,7 +155,7 @@ codegraph_pr_review(mode="branch", include_call_graph=true, output_format="json"
 #           category: "body_change"
 
 # Call 2
-analyze_change_impact(mode="branch", agent_summary_only=true)
+edit action=impact mode="branch" agent_summary_only=true
 # returns:
 #   verification_command: "uv run pytest tests/unit/test_safe_to_edit_tool.py
 #                          tests/unit/test_change_impact_tool.py -q"
@@ -165,7 +165,7 @@ analyze_change_impact(mode="branch", agent_summary_only=true)
 #     out_of_scope_dirty: []
 
 # Call 3
-check_constraints(path_filter="tree_sitter_analyzer/mcp/**")
+edit action=constraints path_filter="tree_sitter_analyzer/mcp/**"
 # returns:
 #   verdict: SAFE
 #   violations: []
@@ -174,18 +174,18 @@ check_constraints(path_filter="tree_sitter_analyzer/mcp/**")
 ### Per-file fan-out
 
 ```yaml
-safe_to_edit(file_path=".../safe_to_edit_tool.py", edit_type="refactor")
+edit action=safe file_path=".../safe_to_edit_tool.py" edit_type="refactor"
 # → verdict: REVIEW, risk_factors: [{factor: "high_caller_count", ...}]
-safe_to_edit(file_path=".../change_impact_tool.py", edit_type="bugfix")
+edit action=safe file_path=".../change_impact_tool.py" edit_type="bugfix"
 # → verdict: SAFE
 ```
 
 ### Per-symbol fan-out (only the signature-change)
 
 ```yaml
-codegraph_callers(function_name="_score_risk", language="python", limit=20)
+nav action=callers function_name="_score_risk" language="python" limit=20
 # → 7 callers; 6 in tests/, 1 in cli/commands/mcp_commands.py
-codegraph_callees(function_name="_score_risk", language="python", limit=20)
+nav action=callees function_name="_score_risk" language="python" limit=20
 # → 4 callees; all local (good — no stdlib noise)
 ```
 
@@ -239,7 +239,7 @@ Exit codes mirror `--change-impact` / `--check-constraints`:
 - DO NOT ask the LLM to invent the pytest command — quote
   `verification_command` verbatim. r36 / past incidents confirm hallucinated
   pytest invocations skip the regressions TSA already pinpointed.
-- DO NOT skip `check_constraints` because "the LLM can spot architecture
+- DO NOT skip `edit action=constraints` because "the LLM can spot architecture
   drift". It can't — the rules live in YAML and are evaluated against the
   persisted edge graph.
 - DO NOT run callers/callees on body-only changes. Bodies don't change
@@ -271,7 +271,7 @@ files:
 constraint_violations: [
   {rule_id, caller_file, caller_line, callee_file, severity, reason}
 ]
-verification_command: <copy-paste exact pytest line from change_impact>
+verification_command: <copy-paste exact pytest line from edit action=impact>
 pytest_required: bool
 queue_ledger:
   in_scope: [<path>]

--- a/tree_sitter_analyzer/skills/tsa-refactor-queue/SKILL.md
+++ b/tree_sitter_analyzer/skills/tsa-refactor-queue/SKILL.md
@@ -233,7 +233,7 @@ sqlite3 .ast-cache/index.db "
   ORDER BY churn_30d DESC LIMIT 50"
 
 # 5. Per-row enrichment (loop top 5)
-uv run tree-sitter-analyzer <file> --outline --output-format json
+uv run tree-sitter-analyzer <file> --table --output-format json
 uv run tree-sitter-analyzer --callers <SYMBOL> --output-format json
 uv run tree-sitter-analyzer <file> --refactor --output-format json
 ```

--- a/tree_sitter_analyzer/skills/tsa-refactor-queue/SKILL.md
+++ b/tree_sitter_analyzer/skills/tsa-refactor-queue/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: tsa-refactor-queue
-version: 1.0.0
+version: 2.0.0
 description: |
   Build a top-N prioritized refactoring queue by intersecting three signals:
   health grade (which files are F/D), temporal churn (which files change
   most often), and dead-code density (which files carry the most unreachable
   symbols). For each candidate the queue surfaces (a) the dimension that
   dragged the grade down, (b) the target symbol, (c) blast radius from
-  `codegraph_callers`, and (d) a concrete action — `split`, `delete dead`,
+  `nav action=callers`, and (d) a concrete action — `split`, `delete dead`,
   or `extract`.
 
   Motivated by `docs/agent-tooling-gap-report.md` "Next High-Value Work" §5:
-  use `check_project_health` output to open focused refactoring slices for
+  use `health action=project` output to open focused refactoring slices for
   the current F-grade files, starting with low-coverage Language Plugin
   extractors and `api.py`.
 
@@ -21,7 +21,7 @@ description: |
   - Engineering planning: "what would 2 weeks of cleanup buy us?"
   - Re-grading after a sprint: "did the queue shrink?"
 
-  Replaces: per-file `check_file_health` loops + spreadsheet ranking
+  Replaces: per-file `health action=file` loops + spreadsheet ranking
   (~25k tokens) with 3 parallel MCP calls + a deterministic rank
   (~3k tokens).
 allowed-tools:
@@ -47,9 +47,9 @@ allowed-tools:
 - After a CI grade-drop alert from `tsa-health-watch` — re-rank with churn
 
 **Don't use** when:
-- You already know the file (one-file deep dive → `check_file_health` or `tsa-edit-safety`)
+- You already know the file (one-file deep dive → `health action=file` or `tsa-edit-safety`)
 - The codebase is brand-new (<2 weeks of git history) — churn signal is noise
-- You want to optimize one hot function — use `tsa-graph` + `refactoring_suggestions` directly
+- You want to optimize one hot function — use `tsa-graph` + `edit action=refactor` directly
 - Shallow clone in CI — `git_state=shallow` makes mod_count_30d unreliable
 
 ## Procedure
@@ -58,16 +58,16 @@ allowed-tools:
 
 Call these in ONE message:
 
-1. `check_project_health` with `min_grade: "D"` and `max_files: 20` — F/D files + per-file `weakest_dimension`
-2. `codegraph_dead_code` with `limit: 200` — symbol-level dead candidates, grouped by file
-3. `codegraph_complexity_heatmap` with `top_n: 20` — complexity-weighted file list (covers structural smell)
+1. `health action=project` with `min_grade: "D"` and `max_files: 20` — F/D files + per-file `weakest_dimension`
+2. `health action=dead` with `limit: 200` — symbol-level dead candidates, grouped by file
+3. `health action=heatmap` with `top_n: 20` — complexity-weighted file list (covers structural smell)
 
 The three responses overlap on file path. Joining on `file_path` gives a
 3-signal table per candidate.
 
 ### Step 2 — Score and rank (deterministic, no LLM needed)
 
-For each file that appears in `check_project_health.worst_files`, compute:
+For each file that appears in `health action=project worst_files`, compute:
 
 ```
 priority = (1 - health_score/100)            # how bad is the grade
@@ -76,11 +76,11 @@ priority = (1 - health_score/100)            # how bad is the grade
 ```
 
 Where:
-- `health_score` ∈ [0,100] from `check_project_health` (lower → worse → bigger weight)
+- `health_score` ∈ [0,100] from `health action=project` (lower → worse → bigger weight)
 - `mod_count_30d_for_file` = sum of `mod_count_30d` across the file's symbols
   (read from `ast_symbol_activation` — see tsa-temporal). `log(1+x)` damps
   pathological churn so a single 50× file doesn't dominate.
-- `dead_symbol_count / total_symbols` = fraction of symbols `codegraph_dead_code`
+- `dead_symbol_count / total_symbols` = fraction of symbols `health action=dead`
   flagged. The `+ 0.1` floor ensures non-dead files can still rank if churn+grade
   alone justify it.
 
@@ -92,11 +92,11 @@ For each of the top 5 files, fan out one more parallel batch:
 
 ```yaml
 # For each candidate file:
-analyze_code_structure(file_path=<f>, format_type="compact")
+structure action=analyze file_path=<f> format_type="compact"
   → list of symbols + complexity + line ranges → pick worst symbol
-codegraph_callers(function_name=<worst_symbol>, include_activation=true, limit=50)
+nav action=callers function_name=<worst_symbol> include_activation=true limit=50
   → blast_radius = len(callers) where callee_resolution in {local, project}
-refactoring_suggestions(file_path=<f>)
+edit action=refactor file_path=<f>
   → action_hint: split | extract | delete | rename
 ```
 
@@ -109,10 +109,10 @@ For each row in the top 5, produce:
   rank: 1
   health_grade: F
   health_score: 42
-  weakest_dimension: complexity        # from check_project_health
+  weakest_dimension: complexity        # from health action=project
   mod_count_30d: 18                     # summed from activation
   dead_symbols: 4 / 67                  # 6.0%
-  target_symbol: api.analyze            # worst from analyze_code_structure
+  target_symbol: api.analyze            # worst from structure action=analyze
   blast_radius: 23                      # local+project callers
   action: split                         # split → extract helpers; delete → prune dead; extract → DRY
   estimated_token_savings: ~8k          # rough: 0.5 * (dead_symbols * 200)
@@ -191,7 +191,7 @@ The `action` column should drive how you ticket the refactor:
 | split   | `weakest_dimension ∈ {size, complexity}` and `blast_radius >= 5` | extract helpers, no public-API change |
 | extract | `weakest_dimension = duplication` or repeated patterns across files | new shared util module |
 | delete  | `dead_symbols / total_symbols > 15%` and `weakest_dimension != git_hotspot` | pure prune PR |
-| rename  | only if `refactoring_suggestions` returns `rename_advised: true` AND blast_radius < 10 | tiny solo PR |
+| rename  | only if `edit action=refactor` returns `rename_advised: true` AND blast_radius < 10 | tiny solo PR |
 
 If two actions tie, prefer `delete` first — it's the cheapest, lowest-risk PR
 and shrinks the next queue automatically.
@@ -233,7 +233,7 @@ sqlite3 .ast-cache/index.db "
   ORDER BY churn_30d DESC LIMIT 50"
 
 # 5. Per-row enrichment (loop top 5)
-uv run tree-sitter-analyzer <file> --structure --output-format json
+uv run tree-sitter-analyzer <file> --outline --output-format json
 uv run tree-sitter-analyzer --callers <SYMBOL> --output-format json
 uv run tree-sitter-analyzer <file> --refactor --output-format json
 ```
@@ -263,8 +263,8 @@ top_5:
     verification_command: <copy-paste exact pytest line>
     note: <one-line caveat>
 provenance:
-  health_call: check_project_health{min_grade=D, max_files=20}
-  dead_call: codegraph_dead_code{limit=200}
+  health_call: health action=project{min_grade=D, max_files=20}
+  dead_call: health action=dead{limit=200}
   churn_source: ast_symbol_activation  # see tsa-temporal
   git_state_seen: [tracked, ...]  # warn if "shallow" appears
 ```

--- a/tree_sitter_analyzer/skills/tsa-structure/SKILL.md
+++ b/tree_sitter_analyzer/skills/tsa-structure/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tsa-structure
-version: 1.0.0
+version: 2.0.0
 description: |
   Structural analysis of one file — classes, methods, exports, common patterns,
   semantic classification of a diff. Returns the file's *shape* without reading
@@ -28,19 +28,19 @@ allowed-tools:
 
 ## Tool routing
 
-| Question                                        | Tool                   |
-|-------------------------------------------------|------------------------|
-| Outline / table of classes + methods            | `analyze_code_structure` |
-| Run a tree-sitter query (e.g., all `def` nodes) | `query_code`           |
-| Detect design patterns (singleton, factory, …)  | `code_patterns`        |
-| Classify a diff (refactor vs feature vs fix)    | `semantic_classify`    |
+| Question                                        | Tool                         |
+|-------------------------------------------------|------------------------------|
+| Outline / table of classes + methods            | `structure action=analyze`   |
+| Run a tree-sitter query (e.g., all `def` nodes) | `search action=query`        |
+| Detect design patterns (singleton, factory, …)  | `health action=patterns`     |
+| Classify a diff (refactor vs feature vs fix)    | `edit action=classify`       |
 
 ## Procedure
 
 ### File outline (most common)
 
 ```yaml
-analyze_code_structure(file_path: "tree_sitter_analyzer/health_scorer.py")
+structure action=analyze file_path="tree_sitter_analyzer/health_scorer.py"
 # returns: {classes: [...], functions: [...], imports: [...]}
 ```
 
@@ -55,9 +55,9 @@ uv run tree-sitter-analyzer <file> --table full
 When you need something the built-in tools don't surface:
 
 ```yaml
-query_code(file_path: "...", query_key: "class")
+search action=query file_path="..." query_key="class"
 # OR
-query_code(file_path: "...", query_string: "(decorated_definition) @decorated")
+search action=query file_path="..." query_string="(decorated_definition) @decorated"
 ```
 
 `--list-queries` (CLI) shows all built-in queries available per language.
@@ -65,7 +65,7 @@ query_code(file_path: "...", query_string: "(decorated_definition) @decorated")
 ### Diff classification
 
 ```yaml
-semantic_classify(file_path: "...", before_hash: "abc", after_hash: "def")
+edit action=classify file_path="..." before_hash="abc" after_hash="def"
 # returns: {classification: "refactor|feature|bugfix|test|docs|chore", confidence: 0.92}
 ```
 
@@ -74,7 +74,7 @@ Useful for PR descriptions and CHANGELOG categorization.
 ### Pattern detection
 
 ```yaml
-code_patterns(file_path: "...", patterns: ["singleton", "factory", "observer"])
+health action=patterns file_path="..." patterns=["singleton", "factory", "observer"]
 ```
 
 ## CLI equivalents
@@ -84,11 +84,11 @@ uv run tree-sitter-analyzer <file> --table full           # outline
 uv run tree-sitter-analyzer <file> --query-key class      # built-in query
 uv run tree-sitter-analyzer <file> --query-string "(...)" # custom query
 uv run tree-sitter-analyzer <file> --code-patterns
-uv run tree-sitter-analyzer --semantic-classify <diff-args>
+uv run tree-sitter-analyzer --semantic-classify           # edit action=classify
 ```
 
 ## Anti-patterns
 
 - DON'T read the whole file just to find "what classes are in it" — use the structure tool
-- DON'T write a custom tree-sitter query when `analyze_code_structure` covers it
-- DON'T use semantic_classify on huge multi-purpose commits — split them first
+- DON'T write a custom tree-sitter query when `structure action=analyze` covers it
+- DON'T use `edit action=classify` on huge multi-purpose commits — split them first

--- a/tree_sitter_analyzer/skills/tsa-temporal/SKILL.md
+++ b/tree_sitter_analyzer/skills/tsa-temporal/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tsa-temporal
-version: 1.0.0
+version: 2.0.0
 description: |
   Find "hot zones" — symbols modified often in recent git history that need
   extra review attention. Adds temporal context (mod_count_30d / 90d / all)
@@ -27,16 +27,16 @@ allowed-tools:
 
 > Per-symbol modification frequency persisted in `ast_symbol_activation`.
 > Computed from `git log --follow -p -U0` hunk attribution at index time.
-> Symbols with `mod_count_30d >= 5` auto-trigger CAUTION in change_impact.
+> Symbols with `mod_count_30d >= 5` auto-trigger CAUTION in `edit action=impact`.
 
 ## When to use
 
-| Goal                                  | How                                            |
-|---------------------------------------|------------------------------------------------|
-| Hot-zone caller fanout                | `codegraph_callers(..., include_activation=true)` |
-| Hot-zone callee fanout                | `codegraph_callees(..., include_activation=true)` |
-| "Is this commit touching hot zones?"  | `analyze_change_impact` — read `risk_factors`  |
-| Single-file recent churn              | `check_file_health` — read `git_hotspot` dim   |
+| Goal                                  | How                                                         |
+|---------------------------------------|-------------------------------------------------------------|
+| Hot-zone caller fanout                | `nav action=callers function_name="X" include_activation=true` |
+| Hot-zone callee fanout                | `nav action=callees function_name="X" include_activation=true` |
+| "Is this commit touching hot zones?"  | `edit action=impact` — read `risk_factors`                  |
+| Single-file recent churn              | `health action=file` — read `git_hotspot` dim               |
 
 **Don't use** when:
 - The question is static (e.g. "who calls X") — use `tsa-graph` skill
@@ -49,11 +49,7 @@ allowed-tools:
 For each symbol you're about to refactor:
 
 ```
-codegraph_callers(
-  function_name="X",
-  include_activation=true,
-  limit=50
-)
+nav action=callers function_name="X" include_activation=true limit=50
 ```
 
 Returns enriched entries:
@@ -77,7 +73,7 @@ recently — those are the high-risk integration points for your refactor.
 
 ### Change-impact gate (catches hot zones automatically)
 
-`analyze_change_impact` already includes hot-zone detection. Look for this
+`edit action=impact` already includes hot-zone detection. Look for this
 in the risk_factors:
 
 ```yaml
@@ -159,7 +155,7 @@ include_activation=true response addition (per callee/caller entry):
     mod_count_30d: <int>
     last_modified_at: <unix ts | null>
 
-analyze_change_impact addition:
+edit action=impact addition:
   risk_factors: [{factor: "hot_zone", reason: "...mod_count_30d=N...", severity: "caution"}]
   verdict: CAUTION   # bumped from SAFE/REVIEW when hot zone touched
 ```


### PR DESCRIPTION
## Summary
Fixes #437 (P1): the 13 tsa-* skills we ship in the wheel (#433) taught LEGACY v1.x tool names — a new agent's FIRST call failed on the 8-facade server. The worst possible first-run: we fixed skills delivery, then delivered stale content.

- 38+ legacy references rewritten to facade+action form across all 13 skills; every translated action verified against the live facade registrations
- `.claude/skills/` and bundled `tree_sitter_analyzer/skills/` kept byte-identical, enforced by a new sync test
- New legacy-name scan derives from `LEGACY_TOOL_MAP` dynamically (62 keys; the draft's hardcoded 35-name subset was rot-prone) and scans BOTH copies
- Skills bumped to 2.0.0

## Review chain (dev ≠ review)
Adversarial review verified every MCP translation correct, then caught: 1 P1 (`--ast-path` substituted for `--codegraph-sitemap` — functionally wrong tool) + 2 P2 (`--outline` vs `--table`; hardcoded scan subset) + 1 P3 (phantom `query=` param the facade would silently drop) — **all fixed**.

## Test plan
- [x] 24 install-skills tests incl. byte-sync + dynamic legacy scan (both copies), exact assertions
- [x] 3 live spot-verifications of rewritten examples (constraints/health/callers)
- [x] agent contracts 53/53