### PR TITLE
fix(resolution): evidence-inverted builtin-receiver gate (#447)

### DIFF
--- a/tests/unit/test_builtin_receiver_gate.py
+++ b/tests/unit/test_builtin_receiver_gate.py
@@ -1,16 +1,30 @@
-"""Regression test: builtin-receiver gate — dict.get must NOT bind to a project .get.
+"""Regression + new-design tests: inverted builtin-receiver gate.
 
-Issue #447: callee_tree binds ``result.get("format")`` (a dict.get() call) to
-``SearchCache.get`` because the second-pass resolver (_choose_candidate path) lacks
-the builtin-method guard that the synapse cascade already has.
+Issue #447 (original): callee_tree bound ``result.get("format")`` (a dict.get()
+call) to ``SearchCache.get`` because path 2 (_choose_candidate) lacked the
+builtin-receiver guard that synapse path 1 already had.
 
-The conservative policy (consistent with issue spec): when the receiver is an
-unidentifiable variable (not imported, not self/cls) AND the method name is in
-STDLIB_METHODS_PY, leave the call unresolved rather than bind it to a project symbol.
+Adversarial P1 (live-confirmed over-gating): the OLD gate fired on ANY
+non-self/cls receiver whose bare method name was in STDLIB_METHODS_PY — losing
+CORRECT edges for untyped receivers (``store.get()`` with unique project
+DataStore.get was blocked; ``unknown > correct`` violated).
+
+NEW DESIGN (inverted): the gate fires ONLY when the receiver is POSITIVELY
+inferred as a builtin type by the extractor:
+  - ``result = {}`` / ``result = dict()`` → callee_full rewritten to
+    ``dict.get``; qualifier == "dict" IS in BUILTIN_TYPE_NAMES_PY → blocked.
+  - ``store`` (untyped param) → qualifier == "store" NOT in BUILTIN_TYPE_NAMES_PY
+    → allowed through to unique-method binding.
 
 Tests:
-1. RED (bug repro): dict.get with project-owned .get → NOT project-resolved to SearchCache
-2. Counter-case: actual SearchCache import + instance.get() → DOES bind to SearchCache.get
+1. RED (bug repro, inference-provable builtin): ``result = {}; result.get()`` in
+   a file that does NOT import SearchCache → must NOT bind to SearchCache.get.
+2. Counter-case: explicit SearchCache import + sc.get() → DOES bind.
+3. NEW: untyped param receiver ``store.get()`` with unique DataStore.get →
+   MUST bind (restores P1-regressed case).
+4. NEW: self._store.get() where DataStore.get is unique → MUST bind.
+5. NEW: module-level singleton CACHE.get() where CacheStore.get is unique →
+   MUST bind (the CACHE singleton case is P3).
 """
 
 from __future__ import annotations
@@ -52,13 +66,12 @@ def _edges_for(db_path: str, callee_name: str) -> list[dict]:
 
 
 def test_dict_get_does_not_bind_to_project_search_cache_get(tmp_path: Path) -> None:
-    """Bug repro #447: result.get("format") in a file that does NOT import SearchCache
-    must not be resolved to SearchCache.get.
+    """Bug repro #447 (adjusted for new-design): ``result = {}; result.get()`` in
+    a file that does NOT import SearchCache must not be resolved to SearchCache.get.
 
-    The project defines SearchCache.get (so the project-ownership gate in
-    _try_stdlib_method correctly prevents stdlib classification by synapse).
-    The second-pass resolver (_choose_candidate) must also NOT bind this to a
-    project symbol — it must stay unresolved (unknown or stdlib).
+    The extractor infers ``result`` has type ``dict`` (from the literal assignment),
+    rewrites callee_full to ``dict.get``, so qualifier == "dict" is in
+    BUILTIN_TYPE_NAMES_PY and the gate fires correctly.  ``unknown > wrong``.
     """
     db = _index(
         tmp_path,
@@ -69,9 +82,12 @@ def test_dict_get_does_not_bind_to_project_search_cache_get(tmp_path: Path) -> N
                 "    def get(self, cache_key: str):\n"
                 "        return None\n"
             ),
-            # format_helper.py does NOT import search_cache; result is a plain dict.
+            # format_helper.py does NOT import search_cache.
+            # result is a LOCAL DICT LITERAL — the extractor infers its type.
             "format_helper.py": (
-                "def apply_toon_format_to_response(result):\n"
+                "def apply_toon_format_to_response(raw_result):\n"
+                "    result = {}\n"
+                "    result['key'] = raw_result\n"
                 "    if result.get('format') != 'toon':\n"
                 "        return result\n"
                 "    if result.get('success') is True:\n"
@@ -104,8 +120,6 @@ def test_dict_get_does_not_bind_to_project_search_cache_get(tmp_path: Path) -> N
 def test_imported_search_cache_get_still_binds(tmp_path: Path) -> None:
     """Counter-case: when the caller IMPORTS SearchCache and uses an instance,
     sc.get() SHOULD bind to SearchCache.get — the gate must not over-block.
-
-    This tests that the fix does not regress legitimate project-symbol resolution.
     """
     db = _index(
         tmp_path,
@@ -138,4 +152,113 @@ def test_imported_search_cache_get_still_binds(tmp_path: Path) -> None:
     assert project_edges, (
         f"sc.get() with explicit SearchCache import must bind to SearchCache.get; "
         f"got {consumer_edges}"
+    )
+
+
+def test_untyped_param_receiver_unique_method_binds(tmp_path: Path) -> None:
+    """P1 adversarial regression: untyped param ``store`` calling ``store.get()``
+    where DataStore.get is the ONLY project ``get`` method must bind to DataStore.get.
+
+    The OLD gate (STDLIB_METHODS_PY match on any receiver) blocked this — lost a
+    correct edge. The new inverted gate only fires when the receiver is positively
+    inferred as a builtin type. ``store`` is a param name, not in
+    BUILTIN_TYPE_NAMES_PY, so it passes through to unique-method binding.
+    """
+    db = _index(
+        tmp_path,
+        {
+            "data_store.py": (
+                "class DataStore:\n    def get(self, key: str):\n        return None\n"
+            ),
+            "processor.py": (
+                "def process(store):\n    value = store.get('key')\n    return value\n"
+            ),
+        },
+    )
+
+    edges = _edges_for(db, "get")
+    proc_edges = [e for e in edges if "processor" in e["file_path"]]
+    assert proc_edges, "expected get() edges in processor.py"
+
+    project_edges = [
+        e
+        for e in proc_edges
+        if e["callee_resolution"] == "project"
+        and "data_store" in (e["callee_resolved_file"] or "")
+    ]
+    assert project_edges, (
+        f"store.get() with unique DataStore.get must bind to DataStore.get "
+        f"(inverted gate must not over-block untyped params); got {proc_edges}"
+    )
+
+
+def test_self_attr_receiver_unique_method_binds(tmp_path: Path) -> None:
+    """P1 adversarial case: ``self._store.get()`` where DataStore.get is unique
+    must bind. ``self._store`` has qualifier ``self._store``; its last segment
+    ``_store`` is not in BUILTIN_TYPE_NAMES_PY, so the gate does not fire.
+    """
+    db = _index(
+        tmp_path,
+        {
+            "data_store.py": (
+                "class DataStore:\n    def get(self, key: str):\n        return None\n"
+            ),
+            "service.py": (
+                "from pkg.data_store import DataStore\n\n"
+                "class MyService:\n"
+                "    def __init__(self):\n"
+                "        self._store = DataStore()\n"
+                "    def fetch(self, key):\n"
+                "        return self._store.get(key)\n"
+            ),
+        },
+    )
+
+    edges = _edges_for(db, "get")
+    svc_edges = [e for e in edges if "service" in e["file_path"]]
+    assert svc_edges, "expected get() edges in service.py"
+
+    project_edges = [
+        e
+        for e in svc_edges
+        if e["callee_resolution"] == "project"
+        and "data_store" in (e["callee_resolved_file"] or "")
+    ]
+    assert project_edges, (
+        f"self._store.get() with DataStore.get must bind; got {svc_edges}"
+    )
+
+
+def test_singleton_receiver_unique_method_binds(tmp_path: Path) -> None:
+    """P3 adversarial case: module-level singleton ``CACHE.get()`` where
+    CacheStore.get is the only project ``get`` — must bind.
+    ``CACHE`` is a module-level name, not a builtin type name.
+    """
+    db = _index(
+        tmp_path,
+        {
+            "cache_store.py": (
+                "class CacheStore:\n    def get(self, key: str):\n        return None\n"
+            ),
+            "cache_client.py": (
+                "from pkg.cache_store import CacheStore\n\n"
+                "CACHE = CacheStore()\n\n"
+                "def lookup(key):\n"
+                "    return CACHE.get(key)\n"
+            ),
+        },
+    )
+
+    edges = _edges_for(db, "get")
+    client_edges = [e for e in edges if "cache_client" in e["file_path"]]
+    assert client_edges, "expected get() edges in cache_client.py"
+
+    project_edges = [
+        e
+        for e in client_edges
+        if e["callee_resolution"] == "project"
+        and "cache_store" in (e["callee_resolved_file"] or "")
+    ]
+    assert project_edges, (
+        f"CACHE.get() singleton with unique CacheStore.get must bind; got {client_edges}"
     )

--- a/tests/unit/test_builtin_receiver_gate.py
+++ b/tests/unit/test_builtin_receiver_gate.py
@@ -1,0 +1,141 @@
+"""Regression test: builtin-receiver gate — dict.get must NOT bind to a project .get.
+
+Issue #447: callee_tree binds ``result.get("format")`` (a dict.get() call) to
+``SearchCache.get`` because the second-pass resolver (_choose_candidate path) lacks
+the builtin-method guard that the synapse cascade already has.
+
+The conservative policy (consistent with issue spec): when the receiver is an
+unidentifiable variable (not imported, not self/cls) AND the method name is in
+STDLIB_METHODS_PY, leave the call unresolved rather than bind it to a project symbol.
+
+Tests:
+1. RED (bug repro): dict.get with project-owned .get → NOT project-resolved to SearchCache
+2. Counter-case: actual SearchCache import + instance.get() → DOES bind to SearchCache.get
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from tree_sitter_analyzer.ast_cache import ASTCache
+
+
+def _index(tmp_path: Path, files: dict[str, str]) -> str:
+    """Index files under tmp_path and return the .ast-cache DB path."""
+    proj = tmp_path / "pkg"
+    proj.mkdir(parents=True, exist_ok=True)
+    (proj / "__init__.py").write_text("# pkg\n")
+    for name, body in files.items():
+        (proj / name).write_text(body)
+    cache = ASTCache(str(tmp_path))
+    try:
+        cache.index_project()
+    finally:
+        cache.close()
+    return str(tmp_path / ".ast-cache" / "index.db")
+
+
+def _edges_for(db_path: str, callee_name: str) -> list[dict]:
+    """Return all CALLS edges for callee_name as dicts."""
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT callee_name, callee_resolution, callee_resolved_file, file_path "
+            "FROM edges WHERE kind = 'calls' AND callee_name = ?",
+            (callee_name,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+def test_dict_get_does_not_bind_to_project_search_cache_get(tmp_path: Path) -> None:
+    """Bug repro #447: result.get("format") in a file that does NOT import SearchCache
+    must not be resolved to SearchCache.get.
+
+    The project defines SearchCache.get (so the project-ownership gate in
+    _try_stdlib_method correctly prevents stdlib classification by synapse).
+    The second-pass resolver (_choose_candidate) must also NOT bind this to a
+    project symbol — it must stay unresolved (unknown or stdlib).
+    """
+    db = _index(
+        tmp_path,
+        {
+            # Project has SearchCache with a .get method — the source of the mis-wire.
+            "search_cache.py": (
+                "class SearchCache:\n"
+                "    def get(self, cache_key: str):\n"
+                "        return None\n"
+            ),
+            # format_helper.py does NOT import search_cache; result is a plain dict.
+            "format_helper.py": (
+                "def apply_toon_format_to_response(result):\n"
+                "    if result.get('format') != 'toon':\n"
+                "        return result\n"
+                "    if result.get('success') is True:\n"
+                "        return result\n"
+                "    return result\n"
+            ),
+        },
+    )
+
+    edges = _edges_for(db, "get")
+    assert edges, "expected call edges for 'get'"
+
+    # None of the dict.get() calls from format_helper.py must resolve to a project
+    # symbol — no callee_resolved_file pointing to search_cache.py.
+    format_helper_edges = [e for e in edges if "format_helper" in e["file_path"]]
+    assert format_helper_edges, "expected get() edges in format_helper.py"
+
+    project_resolved = [
+        e
+        for e in format_helper_edges
+        if e["callee_resolution"] == "project"
+        and "search_cache" in (e["callee_resolved_file"] or "")
+    ]
+    assert project_resolved == [], (
+        f"dict.get() in format_helper.py must NOT bind to SearchCache.get "
+        f"(builtin-receiver gate missing in path 2); got {project_resolved}"
+    )
+
+
+def test_imported_search_cache_get_still_binds(tmp_path: Path) -> None:
+    """Counter-case: when the caller IMPORTS SearchCache and uses an instance,
+    sc.get() SHOULD bind to SearchCache.get — the gate must not over-block.
+
+    This tests that the fix does not regress legitimate project-symbol resolution.
+    """
+    db = _index(
+        tmp_path,
+        {
+            "search_cache.py": (
+                "class SearchCache:\n"
+                "    def get(self, cache_key: str):\n"
+                "        return None\n"
+            ),
+            "consumer.py": (
+                "from pkg.search_cache import SearchCache\n\n"
+                "def use_cache():\n"
+                "    sc = SearchCache()\n"
+                "    return sc.get('key')\n"
+            ),
+        },
+    )
+
+    edges = _edges_for(db, "get")
+    consumer_edges = [e for e in edges if "consumer" in e["file_path"]]
+    assert consumer_edges, "expected get() edges in consumer.py"
+
+    # At least one edge from consumer.py must resolve to search_cache.py
+    project_edges = [
+        e
+        for e in consumer_edges
+        if e["callee_resolution"] == "project"
+        and "search_cache" in (e["callee_resolved_file"] or "")
+    ]
+    assert project_edges, (
+        f"sc.get() with explicit SearchCache import must bind to SearchCache.get; "
+        f"got {consumer_edges}"
+    )

--- a/tree_sitter_analyzer/_ast_cache_unresolved.py
+++ b/tree_sitter_analyzer/_ast_cache_unresolved.py
@@ -634,30 +634,42 @@ def _is_obvious_external(
 ) -> bool:
     """Return True when ``callee_name`` is clearly a stdlib/builtin call.
 
-    Builtin-receiver guard (Issue #447): when ``callee_full`` carries a
-    receiver qualifier (``result.get``, ``data.items``, …) AND the bare
-    method name is in STDLIB_METHODS_PY, the call is almost certainly on a
-    builtin container/string whose type the extractor could not infer.
-    Binding it to a project symbol via ``_choose_candidate`` would produce
-    a same-name mis-wire — the conservative policy is ``unknown > wrong``.
-    This mirrors the ``_try_stdlib_method`` gate already present in synapse
-    (path 1), closing the same hole in path 2.
+    Builtin-receiver gate (inverted, issue #447 adversarial P1): fires ONLY
+    when the receiver qualifier is POSITIVELY inferred as a builtin type name
+    (``dict``, ``list``, ``str``, …) — i.e. the extractor already rewrote the
+    callee to ``dict.get`` because it saw ``result = {}`` or ``result = dict()``.
+    An untyped receiver (``store``, ``cache``, a module singleton) does NOT
+    match BUILTIN_TYPE_NAMES_PY, so its method call is left to ``_choose_candidate``
+    which may bind it to a unique project symbol.
+
+    Path-2 asymmetry (documented): this path has only the stored ``callee_full``
+    string, not the live AST. Therefore the gate is conservative: it checks
+    whether the last qualifier segment is a known builtin type name. This covers
+    the case where the extractor inferred the type (and rewrote callee_full to
+    e.g. ``dict.get``). Literal-expression receivers (``{}.get``) are already
+    resolved to ``stdlib`` by the extractor before this pass runs.
     """
     if language != "python":
         return False
     try:
-        from .synapse_resolver import BUILTINS_PY, STDLIB_METHODS_PY, STDLIB_NAMES_PY
+        from .synapse_resolver import (
+            BUILTIN_TYPE_NAMES_PY,
+            BUILTINS_PY,
+            STDLIB_NAMES_PY,
+        )
     except Exception:  # pragma: no cover
         return False
     base = _base_name(callee_name)
     qualifier = callee_name.split(".", 1)[0]
     if base in BUILTINS_PY or qualifier in STDLIB_NAMES_PY:
         return True
-    # Builtin-receiver gate: a receiver.method() call where method is a
-    # well-known stdlib method name and receiver is not self/cls.
+    # Builtin-receiver gate: fires ONLY when the receiver is a builtin type
+    # name (positively inferred by the extractor). An untyped receiver that
+    # happens to call a method with the same name as a stdlib method is NOT
+    # blocked — it must reach _choose_candidate for unique-project binding.
     if callee_full and "." in callee_full:
         recv = callee_full.rsplit(".", 1)[0].split(".")[-1]  # last segment of receiver
-        if recv not in ("self", "cls") and base in STDLIB_METHODS_PY:
+        if recv in BUILTIN_TYPE_NAMES_PY:
             return True
     return False
 

--- a/tree_sitter_analyzer/_ast_cache_unresolved.py
+++ b/tree_sitter_analyzer/_ast_cache_unresolved.py
@@ -294,7 +294,8 @@ def _call_refs(
         base = _base_name(callee_name)
         if not callee_name or base in local_callables or callee_name in local_callables:
             continue
-        if _is_obvious_external(language, callee_name):
+        callee_full = str(edge.get("callee_full") or "").strip()
+        if _is_obvious_external(language, callee_name, callee_full):
             continue
         caller_name = str(edge.get("caller_name") or "")
         caller_line = _line(edge.get("caller_line"))
@@ -628,16 +629,37 @@ def _call_is_resolved(edge: dict[str, Any]) -> bool:
     return resolution in {"local", "project"} and bool(resolved_file)
 
 
-def _is_obvious_external(language: str, callee_name: str) -> bool:
+def _is_obvious_external(
+    language: str, callee_name: str, callee_full: str = ""
+) -> bool:
+    """Return True when ``callee_name`` is clearly a stdlib/builtin call.
+
+    Builtin-receiver guard (Issue #447): when ``callee_full`` carries a
+    receiver qualifier (``result.get``, ``data.items``, …) AND the bare
+    method name is in STDLIB_METHODS_PY, the call is almost certainly on a
+    builtin container/string whose type the extractor could not infer.
+    Binding it to a project symbol via ``_choose_candidate`` would produce
+    a same-name mis-wire — the conservative policy is ``unknown > wrong``.
+    This mirrors the ``_try_stdlib_method`` gate already present in synapse
+    (path 1), closing the same hole in path 2.
+    """
     if language != "python":
         return False
     try:
-        from .synapse_resolver import BUILTINS_PY, STDLIB_NAMES_PY
+        from .synapse_resolver import BUILTINS_PY, STDLIB_METHODS_PY, STDLIB_NAMES_PY
     except Exception:  # pragma: no cover
         return False
     base = _base_name(callee_name)
     qualifier = callee_name.split(".", 1)[0]
-    return base in BUILTINS_PY or qualifier in STDLIB_NAMES_PY
+    if base in BUILTINS_PY or qualifier in STDLIB_NAMES_PY:
+        return True
+    # Builtin-receiver gate: a receiver.method() call where method is a
+    # well-known stdlib method name and receiver is not self/cls.
+    if callee_full and "." in callee_full:
+        recv = callee_full.rsplit(".", 1)[0].split(".")[-1]  # last segment of receiver
+        if recv not in ("self", "cls") and base in STDLIB_METHODS_PY:
+            return True
+    return False
 
 
 def _local_names(symbol_items: list[dict[str, Any]], kinds: set[str]) -> set[str]:

--- a/tree_sitter_analyzer/callee_resolution.py
+++ b/tree_sitter_analyzer/callee_resolution.py
@@ -169,6 +169,18 @@ class CalleeResolver:
             # false callees (and inlined foreign-language bodies into the
             # response, both wrong and token-bloat). When the source language is
             # unknown, keep the un-gated behaviour.
+            #
+            # Builtin-receiver gate (path 3, issue #447): this path receives only
+            # the bare callee name without the qualifier/receiver context. The
+            # inverted gate (fire only when receiver IS in BUILTIN_TYPE_NAMES_PY)
+            # requires knowing the receiver — unavailable here. However, path 3 is
+            # a bare-name global fallback: it is only reached for UNQUALIFIED calls
+            # (``get()`` with no receiver). Qualified calls (``result.get``,
+            # ``store.get``) have a receiver in callee_full that is processed by
+            # the synapse cascade (path 1) and second-pass resolver (path 2), both
+            # of which carry the inverted gate. Therefore path 3 does not gate on
+            # builtin receiver type — it already lacks the data to do so, and the
+            # callers that reach it have no receiver anyway.
             source_lang = self._source_language(source_file)
             globals_ = [
                 func

--- a/tree_sitter_analyzer/function_extraction.py
+++ b/tree_sitter_analyzer/function_extraction.py
@@ -312,10 +312,36 @@ def walk_tree(node: Any, source: str, language: str) -> tuple[list[dict], list[d
     return definitions, calls
 
 
+# Python tree-sitter right-hand-side node types that indicate a builtin
+# container literal. Maps AST node type -> builtin type name.
+_BUILTIN_LITERAL_NODE_TYPES: dict[str, str] = {
+    "dictionary": "dict",
+    "list": "list",
+    "tuple": "tuple",
+    "set_comprehension": "set",
+    "list_comprehension": "list",
+    "dictionary_comprehension": "dict",
+    "generator_expression": "list",
+}
+
+# Lowercase builtin constructor names whose call expressions produce a known
+# builtin type, e.g. ``dict()`` -> ``"dict"``.
+_BUILTIN_CONSTRUCTOR_NAMES: frozenset[str] = frozenset(
+    {"dict", "list", "set", "tuple", "str", "bytes", "bytearray", "frozenset"}
+)
+
+
 def _collect_local_var_types(
     func_node: Any, source: str, language: str
 ) -> dict[str, tuple[str, int]]:
-    """RFC-0002: infer local variable types from ``var = ClassName(...)``.
+    """RFC-0002: infer local variable types from assignments.
+
+    Handles two patterns:
+    1. ``var = ClassName(...)`` (uppercase) — project class receiver inference.
+    2. ``var = builtin_literal_or_constructor`` — builtin receiver inference,
+       enabling the inverted gate in ``_try_unique_method`` / ``_is_obvious_external``
+       (issue #447 adversarial P1). Recognises ``{}``/``[]``/``()`` literals,
+       comprehensions, and lowercase constructor calls ``dict()``/``list()``/…
 
     Returns ``{var: (class, assign_line)}``. The line makes typing
     flow-sensitive (P2, Codex): a call only takes the type if it appears AT or
@@ -330,17 +356,23 @@ def _collect_local_var_types(
         if getattr(n, "type", None) == "assignment":
             left = n.child_by_field_name("left")
             right = n.child_by_field_name("right")
-            if (
-                left is not None
-                and right is not None
-                and left.type == "identifier"
-                and right.type == "call"
-            ):
-                fn = right.child_by_field_name("function")
-                if fn is not None and fn.type == "identifier":
-                    cls = _node_text(fn, source)
-                    if cls and cls[0].isupper():
-                        types[_node_text(left, source)] = (cls, n.start_point[0] + 1)
+            if left is not None and right is not None and left.type == "identifier":
+                var = _node_text(left, source)
+                line = n.start_point[0] + 1
+                if right.type == "call":
+                    fn = right.child_by_field_name("function")
+                    if fn is not None and fn.type == "identifier":
+                        cls = _node_text(fn, source)
+                        if cls:
+                            if cls[0].isupper():
+                                # Project class: ``var = ClassName(...)``
+                                types[var] = (cls, line)
+                            elif cls in _BUILTIN_CONSTRUCTOR_NAMES:
+                                # Builtin constructor: ``var = dict()`` / ``list()`` …
+                                types[var] = (cls, line)
+                elif right.type in _BUILTIN_LITERAL_NODE_TYPES:
+                    # Builtin literal: ``var = {}`` / ``var = []`` / comprehension
+                    types[var] = (_BUILTIN_LITERAL_NODE_TYPES[right.type], line)
         for c in n.children:
             _walk(c)
 

--- a/tree_sitter_analyzer/synapse_resolver/__init__.py
+++ b/tree_sitter_analyzer/synapse_resolver/__init__.py
@@ -32,6 +32,7 @@ from dataclasses import dataclass
 from .._language_family import languages_compatible
 from ._constants import (
     BUILTIN_QUALIFIED_PY,
+    BUILTIN_TYPE_NAMES_PY,
     BUILTINS_PY,
     EXTERNAL_METHODS_PY,
     STDLIB_METHODS_PY,
@@ -446,12 +447,17 @@ def _try_unique_method(
     """
     if not qualifier or qualifier in ("self", "cls"):
         return None
-    # Builtin-receiver gate: a bare stdlib method name with an unidentifiable
-    # receiver must not be claimed as a project symbol via uniqueness.
-    # Language-aware: only consult the Python stdlib-method table for Python
-    # callers; a Java/JS caller with no registered table looks up an empty
-    # frozenset and the gate is a no-op (conservative).
-    if base in ctx.stdlib_methods.get(_table_language(ctx, caller_file), frozenset()):
+    # Builtin-receiver gate (inverted, issue #447 adversarial P1): only block
+    # when the receiver is POSITIVELY inferred as a builtin container/type —
+    # i.e. the qualifier IS a builtin type name (``dict``, ``list``, ``str``…).
+    # The extractor rewrites ``result.get`` -> ``dict.get`` when it sees
+    # ``result = {}`` or ``result = dict()``, so qualifier carries the
+    # inferred type. An untyped receiver (``store``, ``cache``, a param name)
+    # has a qualifier that is NOT in BUILTIN_TYPE_NAMES_PY and is allowed
+    # through, restoring ``store.get -> DataStore.get`` (unique project method).
+    # Language-aware: only consult the Python table for Python callers.
+    table_lang = _table_language(ctx, caller_file)
+    if table_lang == "python" and qualifier in BUILTIN_TYPE_NAMES_PY:
         return None
     found: tuple[str, int] | None = None
     for file_path, classes in ctx.file_class_methods.items():
@@ -585,6 +591,7 @@ def _is_cross_language(
 
 __all__ = [
     "BUILTIN_QUALIFIED_PY",
+    "BUILTIN_TYPE_NAMES_PY",
     "BUILTINS_PY",
     "EXTERNAL_METHODS_PY",
     "STDLIB_METHODS_PY",

--- a/tree_sitter_analyzer/synapse_resolver/__init__.py
+++ b/tree_sitter_analyzer/synapse_resolver/__init__.py
@@ -423,7 +423,7 @@ def _try_class_method(
 
 
 def _try_unique_method(
-    base: str, qualifier: str, ctx: ResolverContext
+    base: str, qualifier: str, caller_file: str, ctx: ResolverContext
 ) -> ResolvedCallee | None:
     """RFC-0002 Phase 1: receiver method call where the method name is unique.
 
@@ -434,8 +434,24 @@ def _try_unique_method(
     ``cls`` are already handled by ``_try_self_method``, and bare names by the
     global rules above — so this only fires for true receiver method calls the
     earlier rules left unresolved.
+
+    Builtin-receiver guard (Issue #447): when ``base`` is a well-known stdlib
+    method name (``get``, ``append``, ``items``, …) and the receiver type is
+    unknown, the caller is almost certainly using a builtin container/string
+    method, not a project-defined method. Binding it to a project symbol just
+    because it happens to be unique would produce the same-name mis-wire the
+    README claims TSA eliminates. Conservative policy: ``unknown > wrong``.
+    This guard does NOT affect ``_try_class_method`` (receiver type IS known
+    via AST inference) or ``_try_import``/``_try_local`` (explicit import).
     """
     if not qualifier or qualifier in ("self", "cls"):
+        return None
+    # Builtin-receiver gate: a bare stdlib method name with an unidentifiable
+    # receiver must not be claimed as a project symbol via uniqueness.
+    # Language-aware: only consult the Python stdlib-method table for Python
+    # callers; a Java/JS caller with no registered table looks up an empty
+    # frozenset and the gate is a no-op (conservative).
+    if base in ctx.stdlib_methods.get(_table_language(ctx, caller_file), frozenset()):
         return None
     found: tuple[str, int] | None = None
     for file_path, classes in ctx.file_class_methods.items():
@@ -526,7 +542,7 @@ def _resolve_callee_python(
         # (RFC-0002 criterion 2 — shadowing preserved).
         lambda: _try_single_global(base, qualifier, ctx),
         lambda: _try_class_method(base, qualifier, ctx),
-        lambda: _try_unique_method(base, qualifier, ctx),
+        lambda: _try_unique_method(base, qualifier, caller_file, ctx),
         # Builtin is the last NAME resort: only fires when no project binding exists.
         lambda: _try_builtin(base, qualifier, ctx),
         # RFC-0004: stdlib METHOD names (write_text, strip, items, …) — gated on

--- a/tree_sitter_analyzer/synapse_resolver/_constants.py
+++ b/tree_sitter_analyzer/synapse_resolver/_constants.py
@@ -541,8 +541,38 @@ BUILTIN_QUALIFIED_PY: frozenset[str] = frozenset(
 )
 
 
+# ---------------------------------------------------------------------------
+# Python builtin container/type names that the extractor can infer as the
+# receiver type when it sees a literal or constructor assignment, e.g.
+# ``result = {}`` -> receiver type ``dict``, ``items = []`` -> ``list``.
+#
+# Used by ``_try_unique_method`` and ``_is_obvious_external`` to gate the
+# builtin-receiver guard: a qualifier that IS one of these names is positively
+# inferred as a builtin container -- binding its methods to a project symbol is
+# wrong. A qualifier that is NOT here (e.g. ``store``, ``cache``) is an
+# untyped receiver and must be allowed through to normal candidate selection
+# (restores the ``store.get -> DataStore.get`` case, issue #447 adversarial P1).
+# ---------------------------------------------------------------------------
+BUILTIN_TYPE_NAMES_PY: frozenset[str] = frozenset(
+    {
+        "dict",
+        "list",
+        "set",
+        "str",
+        "tuple",
+        "bytes",
+        "bytearray",
+        "frozenset",
+        "int",
+        "float",
+        "bool",
+    }
+)
+
+
 __all__ = [
     "BUILTIN_QUALIFIED_PY",
+    "BUILTIN_TYPE_NAMES_PY",
     "BUILTINS_PY",
     "EXTERNAL_METHODS_PY",
     "STDLIB_METHODS_PY",


### PR DESCRIPTION
## Summary
Fixes #447 (P1): `callee_tree` bound `dict.get` to project `SearchCache.get` — the unique-method binder had no notion of builtin receivers.

**Design (evidence-inverted after review round 1)**: the gate fires ONLY on POSITIVE builtin inference — the extractor now infers builtin types from literal assignments (`result = {}` → `dict`) and lowercase constructors, rewriting `result.get` → `dict.get` at index time; resolution then skips project-binding for `BUILTIN_TYPE_NAMES_PY` qualifiers. Inference silent (untyped param / `self.attr` / module singleton) → original unique-method binding preserved.

Round 1's name-based gate was live-proven to regress correct edges (`store.get()` with unique project `DataStore.get`: project→unknown — "unknown > correct" is never acceptable); all three reviewer counter-cases are now regression tests and GREEN.

**4-path audit**: path 1 (synapse) + path 2 (second-pass) fixed; path 3 (call_graph global fallback) documented inapplicable (no qualifier context; qualified calls handled upstream); path 4 read-only with existing language gate.

## Review chain (dev ≠ review)
Round 1: WARNING→P1 over-gating (live-quantified) → full rework. Provenance protocol followed (offending edge traced to paths 1+2 before fixing).

## Test plan
- [x] 5 regression tests (repro + 3 counter-cases + imported-receiver), exact assertions, clean-reindex verified
- [x] 174 resolution-area tests; tests/unit/mcp/ 4635; contracts 53/53