### PR TITLE
test(co_change): windows-skip the wall-clock invariant — develop-wide CI flake

### DIFF
--- a/tests/unit/mcp/tools/test_co_change.py
+++ b/tests/unit/mcp/tools/test_co_change.py
@@ -13,6 +13,7 @@ Key design decisions from the RFC:
 
 from __future__ import annotations
 
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -712,6 +713,16 @@ def test_lru_cache_evicts_at_maxsize() -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=(
+        "fixture builds 10 real git commits; Windows runner subprocess spawn "
+        "is ~1.4s each (14.4s measured on CI 2026-06-11) — the rule-11 "
+        "invariant is the wall-clock of _compute_co_change itself, which the "
+        "linux/macos axes cover; the structural call_count==2 invariant is "
+        "platform-independent and runs everywhere"
+    ),
+)
 def test_real_repo_co_change_under_2s(tmp_path: Path) -> None:  # noqa: F821
     """Rule-11: _compute_co_change on a ~10-commit real git repo completes < 2.0 s.
 


### PR DESCRIPTION
## Summary
`test_real_repo_co_change_under_2s` (merged in #466) blows the 5s per-test budget on Windows runners (14.36s measured — subprocess spawn ~1.4s/commit for the 10-commit fixture), randomly failing the windows axis of EVERY open PR. The wall-clock rule-11 invariant keeps running on linux/macos; the platform-independent structural invariant (call_count==2) runs everywhere. Skip reason documents the measurement.

## Test plan
- [x] 35/35 co_change tests green locally; skipif verified syntactically (sys import added)