### PR TITLE
fix(typescript): abstract classes extract members — abstract_class_declaration + abstract_method_signature (#459)

### DIFF
--- a/tests/golden_masters/plugins/typescript.json
+++ b/tests/golden_masters/plugins/typescript.json
@@ -1,11 +1,11 @@
 {
   "counts_by_type": {
     "Class": 30,
-    "Function": 44,
+    "Function": 48,
     "Import": 5,
     "Variable": 31
   },
-  "element_total": 110,
+  "element_total": 114,
   "names_by_type": {
     "Class": [
       "AdminUser",
@@ -55,6 +55,7 @@
       "fetchMultipleData",
       "findAll",
       "findById",
+      "getId",
       "getInstance",
       "getProperty",
       "greet",
@@ -73,6 +74,7 @@
       "save",
       "setupEventHandlers",
       "simulateApiCall",
+      "updateTimestamp",
       "validate"
     ],
     "Import": [

--- a/tests/unit/core/test_queries_typescript_abstract_method.py
+++ b/tests/unit/core/test_queries_typescript_abstract_method.py
@@ -1,0 +1,137 @@
+"""Codex P2 — abstract_method_signature reaches FUNCTIONS/SIGNATURES query path.
+
+Issue #459 surfaced that ``abstract_method_signature`` was registered only in
+``extract_functions()`` (the plugin extractor path) but NOT in:
+
+  * ``FUNCTIONS`` query string (used by ``--query functions`` / ``search action=symbol``)
+  * ``SIGNATURES`` query string (used by ``--query signatures``)
+  * ``TypeScriptPlugin.get_element_categories()`` (walked by plugin_category_captures)
+
+This file pins those three invariants with RED-first assertions.
+All three assertions must stay exact (== N), per CLAUDE.md locked rule.
+"""
+
+from __future__ import annotations
+
+import tree_sitter
+from tree_sitter_typescript import language_typescript
+
+from tree_sitter_analyzer.languages.typescript_plugin.plugin import TypeScriptPlugin
+from tree_sitter_analyzer.queries import typescript as ts_queries
+from tree_sitter_analyzer.utils.tree_sitter_compat import TreeSitterQueryCompat
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+_ABSTRACT_SRC = """\
+abstract class Base {
+    abstract validate(): boolean;
+    public abstract doThing(x: string): void;
+    protected abstract transform(n: number): string;
+}
+"""
+
+
+def _lang() -> tree_sitter.Language:
+    return tree_sitter.Language(language_typescript())
+
+
+def _parse(src: str) -> tree_sitter.Tree:
+    lang = _lang()
+    parser = tree_sitter.Parser(lang)
+    return parser.parse(src.encode())
+
+
+def _run_query(query_string: str, src: str) -> list[tuple[object, str]]:
+    """Execute a tree-sitter query string against *src* and return captures."""
+    tree = _parse(src)
+    return TreeSitterQueryCompat.safe_execute_query(
+        _lang(), query_string, tree.root_node, fallback_result=[]
+    )
+
+
+# ---------------------------------------------------------------------------
+# I-1  FUNCTIONS query must capture abstract_method_signature nodes
+# ---------------------------------------------------------------------------
+
+
+def test_functions_query_contains_abstract_method_signature_pattern() -> None:
+    """FUNCTIONS string must reference abstract_method_signature so the query
+    path can capture abstract method declarations without a body."""
+    assert "abstract_method_signature" in ts_queries.FUNCTIONS, (
+        "FUNCTIONS query is missing abstract_method_signature — "
+        "--query functions returns no captures for abstract-only members"
+    )
+
+
+def test_functions_query_captures_abstract_methods_exact_count() -> None:
+    """Running FUNCTIONS against a 3-abstract-method snippet must yield exactly 3
+    captures whose capture-name is 'abstract.method' (or similar function group)."""
+    captures = _run_query(ts_queries.FUNCTIONS, _ABSTRACT_SRC)
+    # Filter to captures that correspond to abstract_method_signature nodes
+    abstract_captures = [
+        (node, cap)
+        for node, cap in captures
+        if node.type == "abstract_method_signature"
+    ]
+    assert len(abstract_captures) == 3, (
+        f"Expected 3 abstract_method_signature captures from FUNCTIONS query, "
+        f"got {len(abstract_captures)}: {[(n.text[:40], c) for n, c in abstract_captures]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# I-2  SIGNATURES query must capture abstract_method_signature nodes
+# ---------------------------------------------------------------------------
+
+
+def test_signatures_query_contains_abstract_method_signature_pattern() -> None:
+    """SIGNATURES string must reference abstract_method_signature."""
+    assert "abstract_method_signature" in ts_queries.SIGNATURES, (
+        "SIGNATURES query is missing abstract_method_signature"
+    )
+
+
+def test_signatures_query_captures_abstract_methods_exact_count() -> None:
+    """Running SIGNATURES against the 3-abstract-method snippet must yield
+    exactly 3 captures for abstract_method_signature nodes."""
+    captures = _run_query(ts_queries.SIGNATURES, _ABSTRACT_SRC)
+    abstract_captures = [
+        (node, cap)
+        for node, cap in captures
+        if node.type == "abstract_method_signature"
+    ]
+    assert len(abstract_captures) == 3, (
+        f"Expected 3 abstract_method_signature captures from SIGNATURES query, "
+        f"got {len(abstract_captures)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# I-3  get_element_categories() must list abstract_method_signature
+# ---------------------------------------------------------------------------
+
+
+def test_get_element_categories_method_includes_abstract_method_signature() -> None:
+    """TypeScriptPlugin.get_element_categories()['method'] must include
+    'abstract_method_signature' so plugin_category_captures finds them."""
+    plugin = TypeScriptPlugin()
+    cats = plugin.get_element_categories()
+    method_types = cats.get("method", [])
+    assert "abstract_method_signature" in method_types, (
+        f"'abstract_method_signature' missing from get_element_categories()['method']; "
+        f"got {method_types}"
+    )
+
+
+def test_get_element_categories_signature_includes_abstract_method_signature() -> None:
+    """TypeScriptPlugin.get_element_categories()['signature'] must include
+    'abstract_method_signature' so signature-category queries find them."""
+    plugin = TypeScriptPlugin()
+    cats = plugin.get_element_categories()
+    sig_types = cats.get("signature", [])
+    assert "abstract_method_signature" in sig_types, (
+        f"'abstract_method_signature' missing from get_element_categories()['signature']; "
+        f"got {sig_types}"
+    )

--- a/tests/unit/languages/test_typescript_abstract_class.py
+++ b/tests/unit/languages/test_typescript_abstract_class.py
@@ -1,0 +1,168 @@
+"""Issue #459 regression: TypeScript abstract class members extracted.
+
+Theme I — container missing members.  An ``abstract class`` parses as
+``abstract_class_declaration`` (not ``class_declaration``), and its abstract
+methods parse as ``abstract_method_signature`` (not ``method_signature``).
+Neither node type was handled, so abstract classes appeared as containers
+with empty ``methods:[]`` in structure outlines.
+"""
+
+from __future__ import annotations
+
+import tree_sitter
+from tree_sitter_typescript import language_typescript
+
+from tree_sitter_analyzer.languages.typescript_plugin.extractor import (
+    TypeScriptElementExtractor,
+)
+
+# ─── Source fixture ──────────────────────────────────────────────────────────
+
+ABSTRACT_CLASS_SRC = """\
+abstract class BaseEntity {
+    constructor(private id: string) {}
+    abstract validate(): boolean;
+    protected updateTimestamp(): void {}
+    public getId(): string { return this.id; }
+}
+
+class Concrete extends BaseEntity {
+    validate(): boolean { return true; }
+}
+
+interface IFoo {
+    bar(): void;
+}
+"""
+
+
+def _parse(src: str = ABSTRACT_CLASS_SRC) -> tree_sitter.Tree:
+    lang = tree_sitter.Language(language_typescript())
+    parser = tree_sitter.Parser(lang)
+    return parser.parse(src.encode())
+
+
+def _extract_classes(src: str = ABSTRACT_CLASS_SRC) -> dict[str, str]:
+    extractor = TypeScriptElementExtractor()
+    return {c.name: c.class_type for c in extractor.extract_classes(_parse(src), src)}
+
+
+def _extract_function_names(src: str = ABSTRACT_CLASS_SRC) -> list[str]:
+    extractor = TypeScriptElementExtractor()
+    return [f.name for f in extractor.extract_functions(_parse(src), src)]
+
+
+# ─── Class-level tests ───────────────────────────────────────────────────────
+
+
+def test_abstract_class_extracted_with_correct_type() -> None:
+    """Abstract class itself must be extracted as class_type='abstract_class'."""
+    found = _extract_classes()
+    assert found.get("BaseEntity") == "abstract_class", f"got {sorted(found)}"
+
+
+def test_concrete_class_still_extracted() -> None:
+    """Regular class inside same file must not be affected."""
+    found = _extract_classes()
+    assert found.get("Concrete") == "class", f"got {sorted(found)}"
+
+
+def test_interface_still_extracted() -> None:
+    """Interface inside same file must not be affected."""
+    found = _extract_classes()
+    assert found.get("IFoo") == "interface", f"got {sorted(found)}"
+
+
+# ─── Method-level tests ──────────────────────────────────────────────────────
+
+
+def test_abstract_class_yields_four_methods() -> None:
+    """BaseEntity has exactly 4 members: constructor, validate, updateTimestamp, getId.
+
+    NOTE: The fixture also has a Concrete subclass with its own ``validate``
+    method, so ``validate`` appears twice in the full file extraction.  We
+    assert all four names are present (set coverage) plus that the unambiguous
+    names (constructor, updateTimestamp, getId) appear exactly once.
+    """
+    names = _extract_function_names()
+    abstract_methods = {"constructor", "validate", "updateTimestamp", "getId"}
+    found = set(names) & abstract_methods
+    assert found == abstract_methods, f"missing {abstract_methods - found}; got {names}"
+    assert names.count("constructor") == 1
+    # validate appears in both BaseEntity (abstract) and Concrete (concrete)
+    assert names.count("validate") == 2
+    assert names.count("updateTimestamp") == 1
+    assert names.count("getId") == 1
+
+
+def test_abstract_method_signature_extracted() -> None:
+    """``abstract validate()`` (abstract_method_signature node) must appear in functions."""
+    names = _extract_function_names()
+    assert "validate" in names, f"abstract method missing; got {names}"
+
+
+def test_constructor_in_abstract_class_extracted() -> None:
+    """``constructor`` (method_definition inside abstract class) must be extracted."""
+    names = _extract_function_names()
+    assert "constructor" in names, f"constructor missing; got {names}"
+
+
+def test_protected_method_in_abstract_class_extracted() -> None:
+    """``protected updateTimestamp()`` (method_definition) must be extracted."""
+    names = _extract_function_names()
+    assert "updateTimestamp" in names, f"protected method missing; got {names}"
+
+
+def test_public_method_in_abstract_class_extracted() -> None:
+    """``public getId()`` (method_definition) must be extracted."""
+    names = _extract_function_names()
+    assert "getId" in names, f"public method missing; got {names}"
+
+
+def test_concrete_class_methods_still_extracted() -> None:
+    """Concrete subclass method must still be extracted."""
+    names = _extract_function_names()
+    assert "validate" in names  # from Concrete too (deduplication not expected here)
+
+
+def test_interface_method_still_extracted() -> None:
+    """Interface method (method_signature) must still be extracted."""
+    names = _extract_function_names()
+    assert "bar" in names, f"interface method missing; got {names}"
+
+
+# ─── Exact-count assertions (Theme A — no approximate bounds) ────────────────
+
+
+def test_exact_method_count_for_base_entity_abstract_methods_only() -> None:
+    """Isolated snippet with only the two abstract members — exact count == 2."""
+    src = """\
+abstract class Minimal {
+    abstract alpha(): void;
+    abstract beta(): string;
+}
+"""
+    names = _extract_function_names(src)
+    assert names.count("alpha") == 1
+    assert names.count("beta") == 1
+    assert len(names) == 2
+
+
+def test_visibility_on_abstract_method_signature() -> None:
+    """abstract_method_signature carries visibility from the node text."""
+    extractor = TypeScriptElementExtractor()
+    src = """\
+abstract class V {
+    public abstract pub(): void;
+    protected abstract prot(): void;
+    private abstract priv(): void;
+    abstract implicit(): void;
+}
+"""
+    tree = _parse(src)
+    funcs = extractor.extract_functions(tree, src)
+    by_name = {f.name: f for f in funcs}
+    assert by_name["pub"].visibility == "public"
+    assert by_name["prot"].visibility == "protected"
+    assert by_name["priv"].visibility == "private"
+    assert by_name["implicit"].visibility == "public"

--- a/tests/unit/languages/test_typescript_abstract_class.py
+++ b/tests/unit/languages/test_typescript_abstract_class.py
@@ -166,3 +166,73 @@ abstract class V {
     assert by_name["prot"].visibility == "protected"
     assert by_name["priv"].visibility == "private"
     assert by_name["implicit"].visibility == "public"
+
+
+# ─── extract_abstract_method_signature defensive branches ────────────────────
+
+
+def _abstract_sig_node() -> tree_sitter.Node:
+    """Return the abstract_method_signature node from the fixture parse."""
+    tree = _parse()
+
+    def find(node: tree_sitter.Node) -> tree_sitter.Node | None:
+        if node.type == "abstract_method_signature":
+            return node
+        for child in node.children:
+            hit = find(child)
+            if hit is not None:
+                return hit
+        return None
+
+    node = find(tree.root_node)
+    assert node is not None
+    return node
+
+
+def test_abstract_signature_parse_returning_none_yields_none() -> None:
+    from tree_sitter_analyzer.languages.typescript_plugin._function_helpers import (
+        extract_abstract_method_signature,
+    )
+
+    result = extract_abstract_method_signature(
+        _abstract_sig_node(),
+        parse_signature=lambda node: None,
+        extract_tsdoc=lambda line: "",
+        get_node_text=lambda node: "",
+        framework_type="",
+    )
+    assert result is None
+
+
+def test_abstract_signature_nameless_parse_yields_none() -> None:
+    from tree_sitter_analyzer.languages.typescript_plugin._function_helpers import (
+        extract_abstract_method_signature,
+    )
+
+    nameless = (None, [], False, False, False, False, False, "void", "public", None)
+    result = extract_abstract_method_signature(
+        _abstract_sig_node(),
+        parse_signature=lambda node: nameless,
+        extract_tsdoc=lambda line: "",
+        get_node_text=lambda node: "",
+        framework_type="",
+    )
+    assert result is None
+
+
+def test_abstract_signature_parse_raising_yields_none() -> None:
+    from tree_sitter_analyzer.languages.typescript_plugin._function_helpers import (
+        extract_abstract_method_signature,
+    )
+
+    def boom(node: tree_sitter.Node) -> None:
+        raise RuntimeError("synthetic parse failure")
+
+    result = extract_abstract_method_signature(
+        _abstract_sig_node(),
+        parse_signature=boom,
+        extract_tsdoc=lambda line: "",
+        get_node_text=lambda node: "",
+        framework_type="",
+    )
+    assert result is None

--- a/tree_sitter_analyzer/languages/typescript_plugin/_function_helpers.py
+++ b/tree_sitter_analyzer/languages/typescript_plugin/_function_helpers.py
@@ -219,6 +219,65 @@ def extract_method_signature(
         return None
 
 
+def extract_abstract_method_signature(
+    node: tree_sitter.Node,
+    parse_signature: MethodSignatureParser,
+    extract_tsdoc: TsdocExtractor,
+    get_node_text: TextExtractor,
+    framework_type: str,
+) -> Function | None:
+    """Extract abstract method signature from an abstract class.
+
+    Issue #459 (Theme I): ``abstract_method_signature`` nodes carry an
+    accessibility_modifier child (public/protected/private) that is absent
+    from interface ``method_signature`` nodes.  Unlike
+    ``extract_method_signature`` we preserve ``visibility`` here.
+    """
+    try:
+        start_line = node.start_point[0] + 1
+        end_line = node.end_point[0] + 1
+
+        method_info = parse_signature(node)
+        if not method_info:
+            return None
+
+        (
+            name,
+            parameters,
+            is_async,
+            is_static,
+            _is_getter,
+            _is_setter,
+            _is_constructor,
+            return_type,
+            visibility,
+            _generics,
+        ) = method_info
+        if name is None:
+            return None
+
+        return Function(
+            name=name,
+            start_line=start_line,
+            end_line=end_line,
+            raw_text=get_node_text(node),
+            language="typescript",
+            parameters=parameters,
+            return_type=return_type or "any",
+            is_async=is_async,
+            is_static=is_static,
+            docstring=extract_tsdoc(start_line),
+            complexity_score=0,
+            is_arrow=False,
+            is_method=True,
+            framework_type=framework_type,
+            visibility=visibility,
+        )
+    except Exception as e:
+        log_debug(f"Failed to extract abstract method signature info: {e}")
+        return None
+
+
 def extract_generator_function(
     node: tree_sitter.Node,
     parse_signature: FunctionSignatureParser,

--- a/tree_sitter_analyzer/languages/typescript_plugin/_traversal_helpers.py
+++ b/tree_sitter_analyzer/languages/typescript_plugin/_traversal_helpers.py
@@ -71,6 +71,7 @@ def _container_node_types() -> set[str]:
         "statement_block",
         "object_type",
         "class_declaration",
+        "abstract_class_declaration",
         "interface_declaration",
         "function_declaration",
         "method_definition",

--- a/tree_sitter_analyzer/languages/typescript_plugin/extractor.py
+++ b/tree_sitter_analyzer/languages/typescript_plugin/extractor.py
@@ -33,6 +33,7 @@ from ._class_helpers import (
     extract_type_alias,
 )
 from ._function_helpers import (
+    extract_abstract_method_signature,
     extract_arrow_function,
     extract_function,
     extract_generator_function,
@@ -115,6 +116,10 @@ class TypeScriptElementExtractor(ElementExtractor):
             "method_definition": self._extract_method_optimized,
             "generator_function_declaration": self._extract_generator_function_optimized,
             "method_signature": self._extract_method_signature_optimized,
+            # Issue #459 (Theme I): abstract methods inside abstract classes use
+            # a distinct node type.  Visibility (public/protected/private) must
+            # be preserved so we use a dedicated handler.
+            "abstract_method_signature": self._extract_abstract_method_signature_optimized,
         }
 
         self._traverse_and_extract_iterative(
@@ -283,6 +288,18 @@ class TypeScriptElementExtractor(ElementExtractor):
     ) -> Function | None:
         """Extract method signature information from interfaces"""
         return extract_method_signature(
+            node,
+            self._parse_method_signature_optimized,
+            self._extract_tsdoc_for_line,
+            self._get_node_text_optimized,
+            self.framework_type,
+        )
+
+    def _extract_abstract_method_signature_optimized(
+        self, node: "tree_sitter.Node"
+    ) -> Function | None:
+        """Extract abstract method signature from an abstract class (preserves visibility)."""
+        return extract_abstract_method_signature(
             node,
             self._parse_method_signature_optimized,
             self._extract_tsdoc_for_line,

--- a/tree_sitter_analyzer/languages/typescript_plugin/plugin.py
+++ b/tree_sitter_analyzer/languages/typescript_plugin/plugin.py
@@ -236,9 +236,13 @@ class TypeScriptPlugin(LanguagePlugin):
                 "method_definition",
             ],
             "arrow_function": ["arrow_function"],
-            "method": ["method_definition", "method_signature"],
+            "method": [
+                "method_definition",
+                "method_signature",
+                "abstract_method_signature",
+            ],
             "constructor": ["method_definition"],
-            "signature": ["method_signature"],
+            "signature": ["method_signature", "abstract_method_signature"],
             # Class-related categories
             "class": ["class_declaration", "abstract_class_declaration"],
             "interface": ["interface_declaration"],

--- a/tree_sitter_analyzer/queries/typescript.py
+++ b/tree_sitter_analyzer/queries/typescript.py
@@ -29,6 +29,11 @@ FUNCTIONS = """
     parameters: (formal_parameters) @function.params
     return_type: (type_annotation)? @function.return_type
     body: (statement_block) @function.body) @method.definition
+
+(abstract_method_signature
+    name: (property_identifier) @function.name
+    parameters: (formal_parameters) @function.params
+    return_type: (type_annotation)? @function.return_type) @abstract.method
 """
 
 # Class declarations
@@ -150,6 +155,11 @@ SIGNATURES = """
     name: (_) @method.name
     parameters: (formal_parameters) @method.params
     return_type: (type_annotation)? @method.return_type) @method.signature
+
+(abstract_method_signature
+    name: (property_identifier) @method.name
+    parameters: (formal_parameters) @method.params
+    return_type: (type_annotation)? @method.return_type) @abstract.method.signature
 
 (construct_signature
     parameters: (formal_parameters) @constructor.params


### PR DESCRIPTION
Closes #459.

## Root cause (two independent gaps, both required)
1. `abstract_class_declaration` missing from `_container_node_types()` — traversal skipped abstract class bodies entirely
2. `abstract_method_signature` missing from the extractor map — abstract method members were silently dropped

## Fix
- _traversal_helpers.py: +`abstract_class_declaration` container type (1 line)
- _function_helpers.py: `extract_abstract_method_signature()` preserving visibility
- extractor.py: register the node type

## Evidence
BaseEntity (examples/ComprehensiveTypeScript.ts:123-143) before → `methods: []`; after → `constructor` (public), `validate` (public/abstract), `updateTimestamp` (protected), `getId` (public) — exactly 4.

## Tests
12 new tests (RED-first: 6 failed before fix) in tests/unit/languages/test_typescript_abstract_class.py; tests/unit/languages/ green; ruff clean; `--show-languages`/`--show-extensions` sanity-checked (rule 7).