### PR TITLE
fix(structure): class_detail delivers full contract — fields, visibility, extends, no closures (#455)

### DIFF
--- a/tests/unit/mcp/tools/test_class_inspect_tool.py
+++ b/tests/unit/mcp/tools/test_class_inspect_tool.py
@@ -406,7 +406,7 @@ class TestEdgeCases:
         assert response["success"] is True
         # fields should be empty (OSError fallback) but rest of response is intact
         assert response["fields"] == []
-        assert len(response["methods"]) > 0  # methods still work
+        assert len(response["methods"]) == 4  # methods still work (Animal pin)
 
     def test_class_with_duplicate_self_assignments_deduplicated(
         self, tmp_path: Path
@@ -854,3 +854,29 @@ def test_base_mcp_tool_fields_extracted_from_delegated_init() -> None:
     vis = {f["name"]: f["visibility"] for f in fields}
     assert vis["_project_root"] == "protected"
     assert vis["security_validator"] == "public"
+
+
+def test_annotation_only_fields_extracted() -> None:
+    """Codex P2 (#482): dataclass/Pydantic required fields have no '='.
+
+    ``name: str`` (annotation-only) must be reported as a class field."""
+    from tree_sitter_analyzer.mcp.tools.class_inspect_tool import (
+        _extract_fields_from_source,
+    )
+
+    src = (
+        "class Config:\n"
+        "    name: str\n"
+        "    retries: int = 3\n"
+        "    _token: str\n"
+        "\n"
+        "    def ping(self) -> None:\n"
+        "        pass\n"
+    )
+    fields = _extract_fields_from_source(src, "Config", 1, 7)
+    names = [f["name"] for f in fields]
+    assert names == ["name", "retries", "_token"]
+    vis = {f["name"]: f["visibility"] for f in fields}
+    assert vis["_token"] == "protected"
+    kinds = {f["name"]: f["kind"] for f in fields}
+    assert kinds == {"name": "class", "retries": "class", "_token": "class"}

--- a/tests/unit/mcp/tools/test_class_inspect_tool.py
+++ b/tests/unit/mcp/tools/test_class_inspect_tool.py
@@ -826,3 +826,31 @@ class TestEdgeCases:
         field_names = [f["name"] for f in response["fields"]]
         assert field_names.count("shared_name") == 1
         assert "unique" in field_names
+
+
+# ─── Issue #455 repro guard: fields found outside __init__ ───────────────────
+
+
+def test_base_mcp_tool_fields_extracted_from_delegated_init() -> None:
+    """BaseMCPTool assigns self.* in _apply_project_root, not __init__.
+
+    The issue's own repro class must yield non-empty fields — an
+    __init__-only scan returns [] here (the original gap)."""
+    from tree_sitter_analyzer.mcp.tools.class_inspect_tool import (
+        _extract_fields_from_source,
+    )
+
+    src = open("tree_sitter_analyzer/mcp/tools/base_tool.py").read()
+    fields = _extract_fields_from_source(src, "BaseMCPTool", 282, 686)
+    names = [f["name"] for f in fields]
+    assert names == [
+        "_project_root",
+        "_project_root_initialized",
+        "security_validator",
+        "path_resolver",
+    ]
+    kinds = {f["name"]: f["kind"] for f in fields}
+    assert kinds["security_validator"] == "instance"
+    vis = {f["name"]: f["visibility"] for f in fields}
+    assert vis["_project_root"] == "protected"
+    assert vis["security_validator"] == "public"

--- a/tests/unit/mcp/tools/test_class_inspect_tool.py
+++ b/tests/unit/mcp/tools/test_class_inspect_tool.py
@@ -1,0 +1,828 @@
+#!/usr/bin/env python3
+"""Tests for ClassInspectTool — full contract: fields, visibility, extends, no closures.
+
+Issue #455: class_detail was returning only a flat method list.
+This test suite pins the full contract using a synthetic fixture class.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import textwrap
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tree_sitter_analyzer.mcp.tools.class_inspect_tool import ClassInspectTool
+
+# ---------------------------------------------------------------------------
+# Synthetic fixture source
+# ---------------------------------------------------------------------------
+
+FIXTURE_SOURCE = textwrap.dedent('''\
+    """Synthetic fixture class for class_inspect contract tests."""
+
+    from abc import ABC
+
+
+    class Animal(ABC):
+        """Base animal class."""
+
+        kingdom: str = "Animalia"
+
+        def __init__(self, name: str, weight: float) -> None:
+            self.name = name
+            self._weight = weight
+            self.__secret = "hidden"  # pragma: allowlist secret
+
+        def speak(self) -> str:
+            return ""
+
+        def _internal(self) -> None:
+            pass
+
+        def __dunder_method(self) -> None:
+            pass
+
+
+    class Dog(Animal):
+        """Dog extends Animal."""
+
+        breed_count: int = 0
+
+        def __init__(self, name: str, weight: float, breed: str) -> None:
+            super().__init__(name, weight)
+            self.breed = breed
+            self._tag = "dog"
+
+        def speak(self) -> str:
+            return "Woof"
+
+        def _fetch(self) -> None:
+            def _nested_closure() -> None:
+                pass
+            _nested_closure()
+
+        @staticmethod
+        def info() -> str:
+            return "Dog"
+''')
+
+
+def _run(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Fixture file setup
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def fixture_file(tmp_path: Path) -> Path:
+    """Write the synthetic fixture source to a temp file and return its path."""
+    p = tmp_path / "fixture_animals.py"
+    p.write_text(FIXTURE_SOURCE, encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Helper: run class_detail via ClassInspectTool with a real index
+# ---------------------------------------------------------------------------
+
+
+def _run_class_detail(
+    fixture_file: Path,
+    class_name: str,
+) -> dict[str, Any]:
+    """Index the fixture file and execute ClassInspectTool against it."""
+    from tree_sitter_analyzer.ast_cache import ASTCache
+
+    project_root = str(fixture_file.parent)
+    tool = ClassInspectTool(project_root)
+
+    # Build the AST cache for the fixture file using the public API
+    cache = ASTCache(project_root)
+    result = cache.index_file(str(fixture_file), language="python")
+    assert result.get("status") in ("ok", "indexed", "unchanged"), (
+        f"Cache index failed: {result}"
+    )
+
+    response = _run(tool.execute({"class_name": class_name, "output_format": "json"}))
+    assert response["success"] is True, f"Tool failed: {response}"
+    return response
+
+
+# ---------------------------------------------------------------------------
+# Tests for Animal (base class with no extends in project, direct ABC parent)
+# ---------------------------------------------------------------------------
+
+
+class TestAnimalClassContract:
+    def test_extends_contains_abc(self, fixture_file: Path) -> None:
+        """Animal(ABC) → extends = ['ABC']"""
+        r = _run_class_detail(fixture_file, "Animal")
+        assert r["extends"] == ["ABC"]
+
+    def test_method_list_exact(self, fixture_file: Path) -> None:
+        """Exact set of methods on Animal — no phantom symbols."""
+        r = _run_class_detail(fixture_file, "Animal")
+        names = [m["name"] for m in r["methods"]]
+        assert names == ["__init__", "speak", "_internal", "__dunder_method"]
+
+    def test_method_visibility_public(self, fixture_file: Path) -> None:
+        r = _run_class_detail(fixture_file, "Animal")
+        method_map = {m["name"]: m["visibility"] for m in r["methods"]}
+        assert method_map["__init__"] == "public"
+        assert method_map["speak"] == "public"
+
+    def test_method_visibility_protected(self, fixture_file: Path) -> None:
+        r = _run_class_detail(fixture_file, "Animal")
+        method_map = {m["name"]: m["visibility"] for m in r["methods"]}
+        assert method_map["_internal"] == "protected"
+
+    def test_method_visibility_private(self, fixture_file: Path) -> None:
+        r = _run_class_detail(fixture_file, "Animal")
+        method_map = {m["name"]: m["visibility"] for m in r["methods"]}
+        assert method_map["__dunder_method"] == "private"
+
+    def test_fields_class_level(self, fixture_file: Path) -> None:
+        """Animal has class-level field kingdom: str = 'Animalia'"""
+        r = _run_class_detail(fixture_file, "Animal")
+        field_names = [f["name"] for f in r["fields"]]
+        assert "kingdom" in field_names
+
+    def test_fields_instance_from_init(self, fixture_file: Path) -> None:
+        """Animal.__init__ sets self.name, self._weight, self.__secret"""
+        r = _run_class_detail(fixture_file, "Animal")
+        field_names = [f["name"] for f in r["fields"]]
+        assert "name" in field_names
+        assert "_weight" in field_names
+        assert "__secret" in field_names
+
+    def test_fields_visibility_public(self, fixture_file: Path) -> None:
+        r = _run_class_detail(fixture_file, "Animal")
+        field_map = {f["name"]: f["visibility"] for f in r["fields"]}
+        assert field_map["name"] == "public"
+        assert field_map["kingdom"] == "public"
+
+    def test_fields_visibility_protected(self, fixture_file: Path) -> None:
+        r = _run_class_detail(fixture_file, "Animal")
+        field_map = {f["name"]: f["visibility"] for f in r["fields"]}
+        assert field_map["_weight"] == "protected"
+
+    def test_fields_visibility_private(self, fixture_file: Path) -> None:
+        r = _run_class_detail(fixture_file, "Animal")
+        field_map = {f["name"]: f["visibility"] for f in r["fields"]}
+        assert field_map["__secret"] == "private"  # pragma: allowlist secret
+
+    def test_field_count_exact(self, fixture_file: Path) -> None:
+        """Animal has exactly 4 fields: kingdom + name + _weight + __secret"""
+        r = _run_class_detail(fixture_file, "Animal")
+        assert len(r["fields"]) == 4
+
+    def test_method_count_exact(self, fixture_file: Path) -> None:
+        """Animal has exactly 4 methods."""
+        r = _run_class_detail(fixture_file, "Animal")
+        assert r["method_count"] == 4
+
+
+# ---------------------------------------------------------------------------
+# Tests for Dog (subclass — inherits from Animal)
+# ---------------------------------------------------------------------------
+
+
+class TestDogClassContract:
+    def test_extends_contains_animal(self, fixture_file: Path) -> None:
+        """Dog(Animal) → extends = ['Animal']"""
+        r = _run_class_detail(fixture_file, "Dog")
+        assert r["extends"] == ["Animal"]
+
+    def test_no_closure_in_methods(self, fixture_file: Path) -> None:
+        """_nested_closure defined inside _fetch must NOT appear in methods."""
+        r = _run_class_detail(fixture_file, "Dog")
+        names = [m["name"] for m in r["methods"]]
+        assert "_nested_closure" not in names
+
+    def test_method_list_exact_dog(self, fixture_file: Path) -> None:
+        """Dog has exactly: __init__, speak, _fetch, info"""
+        r = _run_class_detail(fixture_file, "Dog")
+        names = [m["name"] for m in r["methods"]]
+        assert names == ["__init__", "speak", "_fetch", "info"]
+
+    def test_method_count_exact_dog(self, fixture_file: Path) -> None:
+        r = _run_class_detail(fixture_file, "Dog")
+        assert r["method_count"] == 4
+
+    def test_speak_is_override(self, fixture_file: Path) -> None:
+        """speak is defined in Animal → Dog.speak is_override=True"""
+        r = _run_class_detail(fixture_file, "Dog")
+        method_map = {m["name"]: m for m in r["methods"]}
+        assert method_map["speak"]["is_override"] is True
+
+    def test_info_is_not_override(self, fixture_file: Path) -> None:
+        """info is new in Dog → is_override=False"""
+        r = _run_class_detail(fixture_file, "Dog")
+        method_map = {m["name"]: m for m in r["methods"]}
+        assert method_map["info"]["is_override"] is False
+
+    def test_dog_fields_class_level(self, fixture_file: Path) -> None:
+        r = _run_class_detail(fixture_file, "Dog")
+        field_names = [f["name"] for f in r["fields"]]
+        assert "breed_count" in field_names
+
+    def test_dog_fields_instance(self, fixture_file: Path) -> None:
+        r = _run_class_detail(fixture_file, "Dog")
+        field_names = [f["name"] for f in r["fields"]]
+        assert "breed" in field_names
+        assert "_tag" in field_names
+
+    def test_dog_field_count_exact(self, fixture_file: Path) -> None:
+        """Dog has exactly 3 fields: breed_count + breed + _tag"""
+        r = _run_class_detail(fixture_file, "Dog")
+        assert len(r["fields"]) == 3
+
+    def test_inherited_members_present(self, fixture_file: Path) -> None:
+        """Animal is in same project → inherited_methods must be populated."""
+        r = _run_class_detail(fixture_file, "Dog")
+        assert "inherited_methods" in r
+        inherited_names = [m["name"] for m in r["inherited_methods"]]
+        assert "speak" in inherited_names
+
+    def test_field_line_numbers_positive(self, fixture_file: Path) -> None:
+        r = _run_class_detail(fixture_file, "Dog")
+        for f in r["fields"]:
+            assert f["line"] > 0
+
+    def test_method_line_numbers_positive(self, fixture_file: Path) -> None:
+        r = _run_class_detail(fixture_file, "Dog")
+        for m in r["methods"]:
+            assert m["line"] > 0
+
+
+# ---------------------------------------------------------------------------
+# Regression: BaseMCPTool — _wrapped must not appear
+# ---------------------------------------------------------------------------
+
+
+class TestBaseMCPToolClosureRegression:
+    def test_wrapped_closure_not_in_methods(self, tmp_path: Path) -> None:
+        """_wrapped is a local closure inside __init_subclass__, not a real method.
+
+        This guards the specific defect reported in issue #455.
+        We create a minimal file that reproduces the pattern.
+        """
+        src = textwrap.dedent("""\
+            import functools
+
+
+            class ToolBase:
+                @classmethod
+                def __init_subclass__(cls, **kwargs):
+                    super().__init_subclass__(**kwargs)
+                    original = cls.__dict__.get("execute")
+                    if original is None:
+                        return
+
+                    @functools.wraps(original)
+                    async def _wrapped(self, arguments):
+                        return await original(self, arguments)
+
+                    cls.execute = _wrapped
+
+                async def execute(self, arguments):
+                    raise NotImplementedError
+        """)
+        p = tmp_path / "tool_base.py"
+        p.write_text(src, encoding="utf-8")
+
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        project_root = str(tmp_path)
+        cache = ASTCache(project_root)
+        result = cache.index_file(str(p), language="python")
+        assert result.get("status") in ("ok", "indexed", "unchanged"), (
+            f"Index failed: {result}"
+        )
+
+        tool = ClassInspectTool(project_root)
+        response = _run(
+            tool.execute({"class_name": "ToolBase", "output_format": "json"})
+        )
+        assert response["success"] is True
+
+        names = [m["name"] for m in response["methods"]]
+        assert "_wrapped" not in names, (
+            "_wrapped is a closure inside __init_subclass__, not a class method"
+        )
+        assert "execute" in names
+        assert "__init_subclass__" in names
+
+
+# ---------------------------------------------------------------------------
+# Edge-case / defensive-branch coverage
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_not_found_class_returns_not_found_verdict(self, tmp_path: Path) -> None:
+        """Asking for a class that doesn't exist returns NOT_FOUND verdict."""
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        project_root = str(tmp_path)
+        ASTCache(project_root)  # Ensure cache is created
+        tool = ClassInspectTool(project_root)
+        response = _run(
+            tool.execute(
+                {"class_name": "NonExistentClass9999", "output_format": "json"}
+            )
+        )
+        assert response["success"] is True
+        assert response["verdict"] == "NOT_FOUND"
+        assert response["methods"] == []
+        assert response["fields"] == []
+        assert response["extends"] == []
+
+    def test_get_cache_raises_without_project_root(self) -> None:
+        """_get_cache raises ValueError when project_root is None."""
+        import pytest
+
+        tool = ClassInspectTool(None)
+        with pytest.raises(ValueError, match="Project root"):
+            tool._get_cache()
+
+    def test_validate_arguments_raises_for_empty_class_name(self) -> None:
+        """validate_arguments raises ValueError for empty class_name."""
+        import pytest
+
+        tool = ClassInspectTool(None)
+        with pytest.raises(ValueError, match="class_name"):
+            tool.validate_arguments({"class_name": ""})
+
+    def test_class_with_no_indexed_parent_returns_inherited_unavailable(
+        self, tmp_path: Path
+    ) -> None:
+        """A class whose only parent is an external library has inherited.available=False."""
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        src = "from external_lib import ExternalBase\n\nclass MyTool(ExternalBase):\n    def run(self) -> None:\n        pass\n"
+        p = tmp_path / "my_tool.py"
+        p.write_text(src, encoding="utf-8")
+
+        project_root = str(tmp_path)
+        cache = ASTCache(project_root)
+        result = cache.index_file(str(p), language="python")
+        assert result.get("status") in ("ok", "indexed", "unchanged")
+
+        tool = ClassInspectTool(project_root)
+        response = _run(tool.execute({"class_name": "MyTool", "output_format": "json"}))
+        assert response["success"] is True
+        # ExternalBase is not indexed → inherited should be unavailable
+        assert "inherited" in response
+        assert response["inherited"]["available"] is False
+
+    def test_fields_oserror_falls_back_to_empty(
+        self, tmp_path: Path, fixture_file: Path
+    ) -> None:
+        """When the source file cannot be read, fields returns empty list without crashing."""
+        from unittest.mock import patch
+
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        project_root = str(fixture_file.parent)
+        cache = ASTCache(project_root)
+        result = cache.index_file(str(fixture_file), language="python")
+        assert result.get("status") in ("ok", "indexed", "unchanged")
+
+        tool = ClassInspectTool(project_root)
+
+        # Patch open to simulate an OSError
+        with patch("builtins.open", side_effect=OSError("no permission")):
+            response = _run(
+                tool.execute({"class_name": "Animal", "output_format": "json"})
+            )
+
+        assert response["success"] is True
+        # fields should be empty (OSError fallback) but rest of response is intact
+        assert response["fields"] == []
+        assert len(response["methods"]) > 0  # methods still work
+
+    def test_class_with_duplicate_self_assignments_deduplicated(
+        self, tmp_path: Path
+    ) -> None:
+        """Duplicate self.x = ... in __init__ must produce exactly one field entry."""
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        src = textwrap.dedent("""\
+            class Dup:
+                def __init__(self) -> None:
+                    self.x = 1
+                    self.x = 2  # duplicate — same name
+
+                def do(self) -> None:
+                    pass
+        """)
+        p = tmp_path / "dup.py"
+        p.write_text(src, encoding="utf-8")
+
+        project_root = str(tmp_path)
+        cache = ASTCache(project_root)
+        result = cache.index_file(str(p), language="python")
+        assert result.get("status") in ("ok", "indexed", "unchanged")
+
+        tool = ClassInspectTool(project_root)
+        response = _run(tool.execute({"class_name": "Dup", "output_format": "json"}))
+        assert response["success"] is True
+
+        field_names = [f["name"] for f in response["fields"]]
+        assert field_names.count("x") == 1
+
+    def test_class_with_comment_lines_in_body(self, tmp_path: Path) -> None:
+        """Comment lines in class body must not produce spurious fields."""
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        src = textwrap.dedent("""\
+            class Commented:
+                # This is just a comment = not a field
+                value: int = 42
+
+                def run(self) -> None:
+                    pass
+        """)
+        p = tmp_path / "commented.py"
+        p.write_text(src, encoding="utf-8")
+
+        project_root = str(tmp_path)
+        cache = ASTCache(project_root)
+        result = cache.index_file(str(p), language="python")
+        assert result.get("status") in ("ok", "indexed", "unchanged")
+
+        tool = ClassInspectTool(project_root)
+        response = _run(
+            tool.execute({"class_name": "Commented", "output_format": "json"})
+        )
+        assert response["success"] is True
+
+        field_names = [f["name"] for f in response["fields"]]
+        # Only 'value' should be a field, not "This"
+        assert field_names == ["value"]
+
+    def test_class_init_at_end_of_class(self, tmp_path: Path) -> None:
+        """Class where __init__ is the last method — init_end detected at class end."""
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        src = textwrap.dedent("""\
+            class LastInit:
+                class_var: int = 0
+
+                def helper(self) -> None:
+                    pass
+
+                def __init__(self) -> None:
+                    self.data = "hello"
+        """)
+        p = tmp_path / "last_init.py"
+        p.write_text(src, encoding="utf-8")
+
+        project_root = str(tmp_path)
+        cache = ASTCache(project_root)
+        result = cache.index_file(str(p), language="python")
+        assert result.get("status") in ("ok", "indexed", "unchanged")
+
+        tool = ClassInspectTool(project_root)
+        response = _run(
+            tool.execute({"class_name": "LastInit", "output_format": "json"})
+        )
+        assert response["success"] is True
+
+        field_names = [f["name"] for f in response["fields"]]
+        assert "data" in field_names
+        assert "class_var" in field_names
+
+    def test_class_attr_same_name_as_instance_attr_deduped(
+        self, tmp_path: Path
+    ) -> None:
+        """Class attr 'value' and self.value = ... in __init__ → only one 'value' field."""
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        src = textwrap.dedent("""\
+            class SameName:
+                value: int = 0  # class-level
+
+                def __init__(self) -> None:
+                    self.value = 42  # instance level — same name, should dedup
+
+                def run(self) -> None:
+                    pass
+        """)
+        p = tmp_path / "same_name.py"
+        p.write_text(src, encoding="utf-8")
+
+        project_root = str(tmp_path)
+        cache = ASTCache(project_root)
+        result = cache.index_file(str(p), language="python")
+        assert result.get("status") in ("ok", "indexed", "unchanged")
+
+        tool = ClassInspectTool(project_root)
+        response = _run(
+            tool.execute({"class_name": "SameName", "output_format": "json"})
+        )
+        assert response["success"] is True
+
+        field_names = [f["name"] for f in response["fields"]]
+        assert field_names.count("value") == 1
+
+    def test_class_init_followed_by_decorator(self, tmp_path: Path) -> None:
+        """__init__ followed by @staticmethod — init_end must be set before the decorator."""
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        src = textwrap.dedent("""\
+            class Deco:
+                def __init__(self) -> None:
+                    self.x = 1
+
+                @staticmethod
+                def factory() -> "Deco":
+                    return Deco()
+        """)
+        p = tmp_path / "deco.py"
+        p.write_text(src, encoding="utf-8")
+
+        project_root = str(tmp_path)
+        cache = ASTCache(project_root)
+        result = cache.index_file(str(p), language="python")
+        assert result.get("status") in ("ok", "indexed", "unchanged")
+
+        tool = ClassInspectTool(project_root)
+        response = _run(tool.execute({"class_name": "Deco", "output_format": "json"}))
+        assert response["success"] is True
+
+        field_names = [f["name"] for f in response["fields"]]
+        assert field_names == ["x"]
+
+    def test_override_source_not_found_no_overrides_from_key(
+        self, tmp_path: Path
+    ) -> None:
+        """Method that 'overrides' a base only in hierarchy but base has no indexed methods.
+
+        Exercises the path where _find_override_source returns None —
+        overrides_from key must not appear in the method entry.
+        """
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        # Create a child class that overrides a method from an external (unindexed) parent
+        # by declaring the parent in a separate file that won't be indexed
+        src = textwrap.dedent("""\
+            from abc import ABC, abstractmethod
+
+
+            class GrandBase(ABC):
+                @abstractmethod
+                def do(self) -> None:
+                    pass
+
+
+            class Child(GrandBase):
+                def do(self) -> None:
+                    pass
+        """)
+        p = tmp_path / "hierarchy.py"
+        p.write_text(src, encoding="utf-8")
+
+        project_root = str(tmp_path)
+        cache = ASTCache(project_root)
+        result = cache.index_file(str(p), language="python")
+        assert result.get("status") in ("ok", "indexed", "unchanged")
+
+        tool = ClassInspectTool(project_root)
+        response = _run(tool.execute({"class_name": "Child", "output_format": "json"}))
+        assert response["success"] is True
+
+        method_map = {m["name"]: m for m in response["methods"]}
+        assert "do" in method_map
+        # do overrides GrandBase.do — is_override must be True
+        assert method_map["do"]["is_override"] is True
+        # overrides_from must be present (GrandBase is indexed)
+        assert method_map["do"].get("overrides_from") == "GrandBase"
+
+    def test_collect_class_info_exception_returns_none(self) -> None:
+        """_collect_class_info catches Exception from bad conn and returns None."""
+        from unittest.mock import MagicMock
+
+        tool = ClassInspectTool(None)
+        bad_cache = MagicMock()
+        bad_cache.get_conn.side_effect = Exception("db error")
+
+        result = tool._collect_class_info(bad_cache, "SomeClass")
+        assert result is None
+
+    def test_collect_raw_methods_exception_returns_empty(self) -> None:
+        """_collect_raw_methods catches Exception from bad conn and returns []."""
+        from unittest.mock import MagicMock
+
+        tool = ClassInspectTool(None)
+        bad_cache = MagicMock()
+        bad_cache.get_conn.side_effect = Exception("db error")
+
+        result = tool._collect_raw_methods(bad_cache, "SomeClass")
+        assert result == []
+
+    def test_parent_method_names_exception_returns_empty_set(self) -> None:
+        """_parent_method_names catches Exception from bad conn and returns set()."""
+        from unittest.mock import MagicMock
+
+        from tree_sitter_analyzer.class_hierarchy import ClassHierarchy
+
+        tool = ClassInspectTool(None)
+        bad_cache = MagicMock()
+        bad_cache.get_conn.side_effect = Exception("db error")
+
+        # Need a hierarchy that thinks there are ancestors
+        mock_hier = MagicMock(spec=ClassHierarchy)
+        mock_hier.superclasses_of.return_value = [{"name": "ParentClass"}]
+
+        result = tool._parent_method_names(mock_hier, "ChildClass", bad_cache)
+        assert result == set()
+
+    def test_find_override_source_exception_returns_none(self) -> None:
+        """_find_override_source catches Exception from bad conn and returns None."""
+        from unittest.mock import MagicMock
+
+        from tree_sitter_analyzer.class_hierarchy import ClassHierarchy
+
+        tool = ClassInspectTool(None)
+        bad_cache = MagicMock()
+        bad_cache.get_conn.side_effect = Exception("db error")
+
+        mock_hier = MagicMock(spec=ClassHierarchy)
+        mock_hier.superclasses_of.return_value = [{"name": "ParentClass"}]
+
+        result = tool._find_override_source(mock_hier, "Child", "do", bad_cache)
+        assert result is None
+
+    def test_collect_inherited_methods_exception_returns_unavailable(self) -> None:
+        """_collect_inherited_methods handles db exception gracefully."""
+        from unittest.mock import MagicMock
+
+        from tree_sitter_analyzer.class_hierarchy import ClassHierarchy
+
+        tool = ClassInspectTool(None)
+        bad_cache = MagicMock()
+        bad_cache.get_conn.side_effect = Exception("db error")
+
+        mock_hier = MagicMock(spec=ClassHierarchy)
+        mock_hier.superclasses_of.return_value = [{"name": "ParentClass"}]
+
+        result = tool._collect_inherited_methods(mock_hier, "Child", bad_cache)
+        assert result["available"] is False
+        assert "cache query failed" in result["reason"]
+
+    def test_collect_inherited_methods_no_ancestors_returns_unavailable(self) -> None:
+        """_collect_inherited_methods with no ancestors returns unavailable."""
+        from unittest.mock import MagicMock
+
+        from tree_sitter_analyzer.class_hierarchy import ClassHierarchy
+
+        tool = ClassInspectTool(None)
+        mock_cache = MagicMock()
+        mock_hier = MagicMock(spec=ClassHierarchy)
+        mock_hier.superclasses_of.return_value = []
+
+        result = tool._collect_inherited_methods(mock_hier, "IsolatedClass", mock_cache)
+        assert result["available"] is False
+        assert "no ancestors" in result["reason"]
+
+    def test_class_with_class_attr_after_init(self, tmp_path: Path) -> None:
+        """Class attribute at indent 4 AFTER __init__ body — exercises 141->False branch."""
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        src = textwrap.dedent("""\
+            class TrailingAttr:
+                def __init__(self) -> None:
+                    self.x = 1
+                CONST = 99
+
+                def run(self) -> None:
+                    pass
+        """)
+        p = tmp_path / "trailing.py"
+        p.write_text(src, encoding="utf-8")
+
+        project_root = str(tmp_path)
+        cache = ASTCache(project_root)
+        result = cache.index_file(str(p), language="python")
+        assert result.get("status") in ("ok", "indexed", "unchanged")
+
+        tool = ClassInspectTool(project_root)
+        response = _run(
+            tool.execute({"class_name": "TrailingAttr", "output_format": "json"})
+        )
+        assert response["success"] is True
+
+        field_names = [f["name"] for f in response["fields"]]
+        assert "x" in field_names
+        assert "CONST" in field_names
+
+    def test_find_override_source_no_ancestors_returns_none(self) -> None:
+        """_find_override_source returns None when class has no ancestors."""
+        from unittest.mock import MagicMock
+
+        from tree_sitter_analyzer.class_hierarchy import ClassHierarchy
+
+        tool = ClassInspectTool(None)
+        mock_cache = MagicMock()
+        mock_hier = MagicMock(spec=ClassHierarchy)
+        mock_hier.superclasses_of.return_value = []
+
+        result = tool._find_override_source(
+            mock_hier, "BaseClass", "method", mock_cache
+        )
+        assert result is None
+
+    def test_find_override_source_method_not_in_ancestor_returns_none(self) -> None:
+        """_find_override_source returns None when method not found in any ancestor's methods."""
+        from unittest.mock import MagicMock
+
+        from tree_sitter_analyzer.class_hierarchy import ClassHierarchy
+
+        tool = ClassInspectTool(None)
+
+        # Set up a mock cache that returns ancestor with different methods
+        mock_conn = MagicMock()
+        rows = [
+            {
+                "symbols_json": '{"symbols": [{"kind": "method", "name": "other_method", "class": "AncClass"}]}'
+            }
+        ]
+        mock_conn.execute.return_value.fetchall.return_value = rows
+        mock_cache = MagicMock()
+        mock_cache.get_conn.return_value = mock_conn
+
+        mock_hier = MagicMock(spec=ClassHierarchy)
+        mock_hier.superclasses_of.return_value = [{"name": "AncClass"}]
+
+        result = tool._find_override_source(
+            mock_hier, "Child", "target_method", mock_cache
+        )
+        assert result is None
+
+    def test_collect_inherited_methods_no_methods_for_ancestor(self) -> None:
+        """_collect_inherited_methods returns unavailable when ancestor has no methods."""
+        from unittest.mock import MagicMock
+
+        from tree_sitter_analyzer.class_hierarchy import ClassHierarchy
+
+        tool = ClassInspectTool(None)
+
+        # Conn returns rows with no methods for the ancestor
+        mock_conn = MagicMock()
+        rows = [
+            {"symbols_json": '{"symbols": [{"kind": "class", "name": "ParentClass"}]}'}
+        ]
+        mock_conn.execute.return_value.fetchall.return_value = rows
+        mock_cache = MagicMock()
+        mock_cache.get_conn.return_value = mock_conn
+
+        mock_hier = MagicMock(spec=ClassHierarchy)
+        mock_hier.superclasses_of.return_value = [{"name": "ParentClass"}]
+
+        result = tool._collect_inherited_methods(mock_hier, "Child", mock_cache)
+        assert result["available"] is False
+        assert "ParentClass" in result["reason"]
+
+    def test_class_attr_same_as_init_attr_dedup_via_field_scan(
+        self, tmp_path: Path
+    ) -> None:
+        """Class attribute name matches self.name in __init__ — produces exactly one field.
+
+        Exercises the 163->149 branch (attr already in seen, instance scan skips).
+        """
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        src = textwrap.dedent("""\
+            class Both:
+                shared_name: str = "cls"
+
+                def __init__(self) -> None:
+                    self.shared_name = "instance"
+                    self.unique = True
+
+                def go(self) -> None:
+                    pass
+        """)
+        p = tmp_path / "both.py"
+        p.write_text(src, encoding="utf-8")
+
+        project_root = str(tmp_path)
+        cache = ASTCache(project_root)
+        result = cache.index_file(str(p), language="python")
+        assert result.get("status") in ("ok", "indexed", "unchanged")
+
+        tool = ClassInspectTool(project_root)
+        response = _run(tool.execute({"class_name": "Both", "output_format": "json"}))
+        assert response["success"] is True
+
+        field_names = [f["name"] for f in response["fields"]]
+        assert field_names.count("shared_name") == 1
+        assert "unique" in field_names

--- a/tree_sitter_analyzer/mcp/tools/class_inspect_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/class_inspect_tool.py
@@ -131,8 +131,11 @@ def _extract_fields_from_source(
             continue
         if stripped.startswith("#"):
             continue
-        # Match: name = ... or name: type = ...
-        m = re.match(r"([A-Za-z_]\w*)(?:\s*:\s*[^=\n]+)?\s*=\s*", stripped)
+        # Match: name = ... / name: type = ... / annotation-only name: type
+        # (dataclass / Pydantic required fields have no default value)
+        m = re.match(
+            r"([A-Za-z_]\w*)(?:\s*:\s*[^=\n]+?)?\s*=\s*[^=]", stripped
+        ) or re.match(r"([A-Za-z_]\w*)\s*:\s*[^=\n]+$", stripped)
         if m and not m.group(1).startswith("__"):
             # Skip dunder class attributes (likely __slots__, __doc__ etc)
             attr_name = m.group(1)

--- a/tree_sitter_analyzer/mcp/tools/class_inspect_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/class_inspect_tool.py
@@ -104,7 +104,9 @@ def _extract_fields_from_source(
 
     Scans the class body (lines class_start..class_end) for:
     1. Class-level assignments at 4-space indent: ``name = ...``
-    2. Self-assignments in __init__ body: ``self.name = ...``
+    2. Self-assignments anywhere in the class body: ``self.name = ...``
+       (not just __init__ — e.g. BaseMCPTool delegates its attribute
+       writes to ``_apply_project_root``, the very repro of issue #455)
 
     Returns a list of field dicts: {name, line, visibility, kind}
     where kind is "class" or "instance".
@@ -114,44 +116,6 @@ def _extract_fields_from_source(
 
     fields: list[dict[str, Any]] = []
     seen: set[str] = set()
-
-    # Find __init__ line range within the class body
-    init_start_rel: int | None = None
-    init_end_rel: int | None = None
-    in_init = False
-    init_indent: int | None = None
-
-    for rel_i, line in enumerate(class_lines):
-        stripped = line.lstrip()
-        indent = len(line) - len(stripped)
-
-        if stripped.startswith("def __init__") and indent == 4:
-            in_init = True
-            init_start_rel = rel_i
-            init_indent = indent
-            continue
-
-        if in_init:
-            if not stripped:
-                # blank line inside function — continue
-                continue
-            # End of __init__ when we hit another def/class at same or lower indent
-            if (
-                indent <= (init_indent or 4)
-                and stripped
-                and not stripped.startswith("#")
-            ):
-                # Check if it's a new method/class definition at the class level
-                if (
-                    stripped.startswith("def ")
-                    or stripped.startswith("class ")
-                    or stripped.startswith("@")
-                ):
-                    init_end_rel = rel_i - 1
-                    in_init = False
-
-    if in_init:
-        init_end_rel = len(class_lines) - 1
 
     # 1. Class-level attributes: lines at indent == 4, assignment, not starting with def/class/@
     for rel_i, line in enumerate(class_lines):
@@ -184,24 +148,23 @@ def _extract_fields_from_source(
                     }
                 )
 
-    # 2. Instance attributes from __init__ body
-    if init_start_rel is not None and init_end_rel is not None:
-        init_body_lines = class_lines[init_start_rel : init_end_rel + 1]
-        for rel_i, line in enumerate(init_body_lines):
-            m = re.match(r"\s+self\.([A-Za-z_]\w*)\s*=\s*", line)
-            if m:
-                attr_name = m.group(1)
-                if attr_name not in seen:
-                    seen.add(attr_name)
-                    abs_line = class_start + init_start_rel + rel_i
-                    fields.append(
-                        {
-                            "name": attr_name,
-                            "line": abs_line,
-                            "visibility": _compute_visibility(attr_name),
-                            "kind": "instance",
-                        }
-                    )
+    # 2. Instance attributes: self.x = ... anywhere in the class body
+    # (annotated assignments ``self.x: T = ...`` included)
+    for rel_i, line in enumerate(class_lines):
+        m = re.match(r"\s+self\.([A-Za-z_]\w*)(?:\s*:\s*[^=\n]+)?\s*=\s*", line)
+        if m:
+            attr_name = m.group(1)
+            if attr_name not in seen:
+                seen.add(attr_name)
+                abs_line = class_start + rel_i
+                fields.append(
+                    {
+                        "name": attr_name,
+                        "line": abs_line,
+                        "visibility": _compute_visibility(attr_name),
+                        "kind": "instance",
+                    }
+                )
 
     fields.sort(key=lambda f: f["line"])
     return fields

--- a/tree_sitter_analyzer/mcp/tools/class_inspect_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/class_inspect_tool.py
@@ -1,14 +1,25 @@
 #!/usr/bin/env python3
 """
-Class Inspect MCP Tool — method inventory for a single class.
+Class Inspect MCP Tool — full class contract inspection.
 
-Reports all methods defined in a class (not inherited), and for each
-method indicates whether it is an override of a parent-class method.
+Reports for a single class:
+- extends: direct base class names
+- fields: class-level attributes and self.* instance attributes (with visibility)
+- methods: direct class-body functions only (closures excluded), with visibility
+           and override detection
+- inherited_methods: methods from the nearest in-project ancestor (if resolvable)
+
+Visibility convention (Python):
+  __name (dunder)  → private
+  _name            → protected
+  name             → public
 """
 
 from __future__ import annotations
 
 import json
+import os
+import re
 from typing import Any
 
 from ...ast_cache import ASTCache
@@ -18,17 +29,195 @@ from .base_tool import BaseMCPTool
 
 logger = setup_logger(__name__)
 
+# Regex patterns for Python field extraction from source text
+# Class-level attribute: <identifier>: ... = ... OR <UPPER_IDENT> = ... at class body
+_CLS_ATTR_RE = re.compile(
+    r"^    ([A-Za-z_]\w*)(?:\s*:\s*[^=\n]+)?\s*=\s*",
+    re.MULTILINE,
+)
+# Instance attribute in __init__: self.<name> = ...
+_SELF_ATTR_RE = re.compile(
+    r"^\s+self\.([A-Za-z_]\w*)\s*=\s*",
+    re.MULTILINE,
+)
+
+
+def _compute_visibility(name: str) -> str:
+    """Derive Python visibility from name convention.
+
+    __name (two leading underscores, no trailing)  → private
+    _name  (one leading underscore)                → protected
+    otherwise                                      → public
+
+    Note: dunder methods (__init__, __str__) are considered public by
+    Python convention, even though they start with double underscores on
+    both sides. We treat them as public here because they ARE part of the
+    public interface.
+    """
+    if name.startswith("__") and name.endswith("__"):
+        # dunder / special method — public by Python convention
+        return "public"
+    if name.startswith("__"):
+        return "private"
+    if name.startswith("_"):
+        return "protected"
+    return "public"
+
+
+def _filter_closures(
+    raw_methods: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Remove closures — functions whose line range is fully contained within
+    another method's line range in the same file.
+
+    Algorithm: for each method m, if there exists another method `outer`
+    (same file) where outer.line <= m.line and outer.end_line >= m.end_line
+    and outer != m, then m is a closure/nested function and is excluded.
+    """
+    result: list[dict[str, Any]] = []
+    for i, m in enumerate(raw_methods):
+        m_file = m["file"]
+        m_start = m["line"]
+        m_end = m["end_line"]
+        is_closure = False
+        for j, outer in enumerate(raw_methods):
+            if i == j:
+                continue
+            if outer["file"] != m_file:
+                continue
+            # m is fully inside outer
+            if outer["line"] <= m_start and outer["end_line"] >= m_end:
+                is_closure = True
+                break
+        if not is_closure:
+            result.append(m)
+    return result
+
+
+def _extract_fields_from_source(
+    source: str,
+    class_name: str,
+    class_start: int,
+    class_end: int,
+) -> list[dict[str, Any]]:
+    """Extract class-level and instance attributes from source text.
+
+    Scans the class body (lines class_start..class_end) for:
+    1. Class-level assignments at 4-space indent: ``name = ...``
+    2. Self-assignments in __init__ body: ``self.name = ...``
+
+    Returns a list of field dicts: {name, line, visibility, kind}
+    where kind is "class" or "instance".
+    """
+    lines = source.splitlines()
+    class_lines = lines[class_start - 1 : class_end]
+
+    fields: list[dict[str, Any]] = []
+    seen: set[str] = set()
+
+    # Find __init__ line range within the class body
+    init_start_rel: int | None = None
+    init_end_rel: int | None = None
+    in_init = False
+    init_indent: int | None = None
+
+    for rel_i, line in enumerate(class_lines):
+        stripped = line.lstrip()
+        indent = len(line) - len(stripped)
+
+        if stripped.startswith("def __init__") and indent == 4:
+            in_init = True
+            init_start_rel = rel_i
+            init_indent = indent
+            continue
+
+        if in_init:
+            if not stripped:
+                # blank line inside function — continue
+                continue
+            # End of __init__ when we hit another def/class at same or lower indent
+            if (
+                indent <= (init_indent or 4)
+                and stripped
+                and not stripped.startswith("#")
+            ):
+                # Check if it's a new method/class definition at the class level
+                if (
+                    stripped.startswith("def ")
+                    or stripped.startswith("class ")
+                    or stripped.startswith("@")
+                ):
+                    init_end_rel = rel_i - 1
+                    in_init = False
+
+    if in_init:
+        init_end_rel = len(class_lines) - 1
+
+    # 1. Class-level attributes: lines at indent == 4, assignment, not starting with def/class/@
+    for rel_i, line in enumerate(class_lines):
+        stripped = line.lstrip()
+        indent = len(line) - len(stripped)
+        if indent != 4:
+            continue
+        if (
+            stripped.startswith("def ")
+            or stripped.startswith("class ")
+            or stripped.startswith("@")
+        ):
+            continue
+        if stripped.startswith("#"):
+            continue
+        # Match: name = ... or name: type = ...
+        m = re.match(r"([A-Za-z_]\w*)(?:\s*:\s*[^=\n]+)?\s*=\s*", stripped)
+        if m and not m.group(1).startswith("__"):
+            # Skip dunder class attributes (likely __slots__, __doc__ etc)
+            attr_name = m.group(1)
+            if attr_name not in seen:
+                seen.add(attr_name)
+                abs_line = class_start + rel_i
+                fields.append(
+                    {
+                        "name": attr_name,
+                        "line": abs_line,
+                        "visibility": _compute_visibility(attr_name),
+                        "kind": "class",
+                    }
+                )
+
+    # 2. Instance attributes from __init__ body
+    if init_start_rel is not None and init_end_rel is not None:
+        init_body_lines = class_lines[init_start_rel : init_end_rel + 1]
+        for rel_i, line in enumerate(init_body_lines):
+            m = re.match(r"\s+self\.([A-Za-z_]\w*)\s*=\s*", line)
+            if m:
+                attr_name = m.group(1)
+                if attr_name not in seen:
+                    seen.add(attr_name)
+                    abs_line = class_start + init_start_rel + rel_i
+                    fields.append(
+                        {
+                            "name": attr_name,
+                            "line": abs_line,
+                            "visibility": _compute_visibility(attr_name),
+                            "kind": "instance",
+                        }
+                    )
+
+    fields.sort(key=lambda f: f["line"])
+    return fields
+
 
 class ClassInspectTool(BaseMCPTool):
-    """Inspect the methods defined in a single class, with override detection."""
+    """Inspect a single class: fields, methods (no closures), visibility, extends."""
 
     def get_tool_definition(self) -> dict[str, Any]:
         return {
             "name": "codegraph_class_inspect",
             "description": (
-                "List all methods defined directly on a class (not inherited). "
-                "For each method, reports whether it overrides a parent-class method "
-                "and which parent introduced it. "
+                "Detailed class inspection: fields (class-level + instance), "
+                "methods (direct only — closures excluded), visibility for each, "
+                "base classes (extends), and inherited methods from the nearest "
+                "in-project ancestor when resolvable. "
                 "Requires ast_cache index to be built first."
             ),
             "inputSchema": self.get_tool_schema(),
@@ -69,10 +258,41 @@ class ClassInspectTool(BaseMCPTool):
             raise ValueError("Project root not set. Call set_project_path first.")
         return ASTCache(self.project_root)
 
-    def _collect_methods(
+    def _collect_class_info(
+        self, cache: ASTCache, class_name: str
+    ) -> dict[str, Any] | None:
+        """Return the raw class symbol dict for class_name (first match)."""
+        try:
+            conn = cache.get_conn()
+            rows = conn.execute(
+                "SELECT file_path, symbols_json FROM ast_index"
+            ).fetchall()
+        except Exception:
+            return None
+
+        for row in rows:
+            try:
+                symbols = json.loads(row["symbols_json"])
+            except (json.JSONDecodeError, TypeError):
+                continue
+            for sym in symbols.get("symbols", []):
+                if sym.get("kind") == "class" and sym.get("name") == class_name:
+                    return {
+                        "file": row["file_path"],
+                        "line": sym.get("line", 0),
+                        "end_line": sym.get("end_line", 0),
+                        "parents": sym.get("parents", []),
+                    }
+        return None
+
+    def _collect_raw_methods(
         self, cache: ASTCache, class_name: str
     ) -> list[dict[str, Any]]:
-        """Return all methods whose enclosing class matches class_name."""
+        """Return ALL method/function symbols whose enclosing class is class_name.
+
+        This includes closures — caller is responsible for filtering via
+        :func:`_filter_closures`.
+        """
         try:
             conn = cache.get_conn()
             rows = conn.execute(
@@ -151,7 +371,6 @@ class ClassInspectTool(BaseMCPTool):
         except Exception:
             return None
 
-        # Build map: ancestor_class -> set of method names
         ancestor_methods: dict[str, set[str]] = {}
         for row in rows:
             try:
@@ -170,6 +389,90 @@ class ClassInspectTool(BaseMCPTool):
                 return str(ancestor)
         return None
 
+    def _collect_fields(
+        self,
+        cache: ASTCache,
+        class_info: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        """Extract class-level and instance fields by scanning source.
+
+        Falls back to [] when the file cannot be read.
+        """
+        file_path: str = class_info["file"]
+        class_start: int = class_info["line"]
+        class_end: int = class_info["end_line"]
+
+        # Resolve to absolute path
+        project_root = self.project_root or ""
+        abs_path = (
+            file_path
+            if os.path.isabs(file_path)
+            else os.path.join(project_root, file_path)
+        )
+
+        try:
+            source = open(abs_path, encoding="utf-8", errors="replace").read()
+        except OSError:
+            return []
+
+        return _extract_fields_from_source(
+            source, class_info.get("name", ""), class_start, class_end
+        )
+
+    def _collect_inherited_methods(
+        self,
+        hierarchy: ClassHierarchy,
+        class_name: str,
+        cache: ASTCache,
+    ) -> dict[str, Any]:
+        """Collect inherited methods from the nearest in-project ancestor.
+
+        Returns:
+          {"available": True, "methods": [...]}  when the parent is indexed
+          {"available": False, "reason": "..."}  when it cannot be resolved
+        """
+        ancestors = hierarchy.superclasses_of(class_name)
+        if not ancestors:
+            return {"available": False, "reason": "no ancestors found in index"}
+
+        # nearest ancestor = first in BFS order
+        nearest = ancestors[0]
+        ancestor_name = nearest["name"]
+
+        try:
+            conn = cache.get_conn()
+            rows = conn.execute("SELECT symbols_json FROM ast_index").fetchall()
+        except Exception:
+            return {"available": False, "reason": "cache query failed"}
+
+        inherited: list[dict[str, Any]] = []
+        for row in rows:
+            try:
+                symbols = json.loads(row["symbols_json"])
+            except (json.JSONDecodeError, TypeError):
+                continue
+            for sym in symbols.get("symbols", []):
+                if sym.get("kind") not in ("function", "method"):
+                    continue
+                if sym.get("class") == ancestor_name:
+                    inherited.append(
+                        {
+                            "name": sym.get("name", ""),
+                            "defined_in": ancestor_name,
+                        }
+                    )
+
+        if not inherited:
+            return {
+                "available": False,
+                "reason": (
+                    f"ancestor '{ancestor_name}' found in hierarchy but has no "
+                    "indexed methods (external library or unindexed file)"
+                ),
+            }
+
+        return {"available": True, "methods": inherited}
+
     async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
         self.validate_arguments(arguments)
 
@@ -182,29 +485,40 @@ class ClassInspectTool(BaseMCPTool):
 
         # Check the class is known
         if class_name not in hierarchy._classes:  # noqa: SLF001
-            response: dict[str, Any] = {
+            not_found: dict[str, Any] = {
                 "success": True,
                 "verdict": "NOT_FOUND",
                 "class_name": class_name,
                 "message": f"Class '{class_name}' not found in AST index.",
                 "methods": [],
                 "method_count": 0,
+                "fields": [],
+                "extends": [],
             }
             from ..utils.format_helper import apply_toon_format_to_response
 
-            return apply_toon_format_to_response(response, output_format)
+            return apply_toon_format_to_response(not_found, output_format)
 
+        # Collect class metadata (parents, file, line range)
+        class_info = self._collect_class_info(cache, class_name)
+        extends: list[str] = class_info["parents"] if class_info else []
+
+        # Collect all raw method symbols, then filter closures
+        raw_methods = self._collect_raw_methods(cache, class_name)
+        direct_methods = _filter_closures(raw_methods)
+
+        # Override detection
         parent_method_names = self._parent_method_names(hierarchy, class_name, cache)
-        raw_methods = self._collect_methods(cache, class_name)
 
         methods: list[dict[str, Any]] = []
-        for m in raw_methods:
+        for m in direct_methods:
             is_override = m["name"] in parent_method_names
             entry: dict[str, Any] = {
                 "name": m["name"],
                 "line": m["line"],
                 "end_line": m["end_line"],
                 "file": m["file"],
+                "visibility": _compute_visibility(m["name"]),
                 "is_override": is_override,
             }
             if is_override:
@@ -215,13 +529,32 @@ class ClassInspectTool(BaseMCPTool):
                     entry["overrides_from"] = src
             methods.append(entry)
 
-        response = {
+        # Fields
+        fields: list[dict[str, Any]] = []
+        if class_info:
+            class_info["name"] = class_name
+            fields = self._collect_fields(cache, class_info)
+
+        # Inherited members
+        inherited_result = self._collect_inherited_methods(hierarchy, class_name, cache)
+
+        response: dict[str, Any] = {
             "success": True,
             "verdict": "INFO",
             "class": class_name,
+            "extends": extends,
             "method_count": len(methods),
             "methods": methods,
+            "fields": fields,
         }
+
+        if inherited_result.get("available"):
+            response["inherited_methods"] = inherited_result["methods"]
+        else:
+            response["inherited"] = {
+                "available": False,
+                "reason": inherited_result.get("reason", "unknown"),
+            }
 
         from ..utils.format_helper import apply_toon_format_to_response
 


### PR DESCRIPTION
Closes #455.

## What was missing (vs the advertised "fields, methods, visibility, inherited members")
Response had only a flat method list. Now delivers:
- **extends**: base class list from the AST cache's `parents`
- **fields**: class-level attrs + `self.x` instance attrs scanned across the WHOLE class body (not just `__init__` — BaseMCPTool, the issue's own repro, delegates writes to `_apply_project_root`; an init-only scan returned `[]`; guard test pins its exact 4 fields)
- **visibility** on every method/field (public / protected `_x` / private `__x`, dunder=public)
- **inherited_methods**: from nearest in-project ancestor when indexed; otherwise honest `inherited: {available: false, reason}` — no faking
- **closure fix**: `_wrapped` (local closure inside `__init_subclass__`) no longer listed as a method — line-range containment filter

## Tests
48 RED-first tests (25 RED initially) incl. the BaseMCPTool repro guard; tools dir 946 passed; contracts 53 passed; ruff clean; class_inspect_tool.py coverage 95.3%.