### PR TITLE
fix(nav): context filters stop-words, ranks production over examples, honest next_step (#441)

### DIFF
--- a/tests/unit/test_codegraph_context_tool.py
+++ b/tests/unit/test_codegraph_context_tool.py
@@ -1861,3 +1861,48 @@ def test_wants_tests_skips_non_prod_demotion() -> None:
     k_prod = _entry_rank_v2(prod_entry, ["parse"], True)
     assert k_test[0] == k_prod[0] == 0
     assert k_test[1] == k_prod[1] == 0
+
+
+# ─── codecov §11: cover the new helper branches directly ─────────────────────
+
+
+def test_is_non_prod_file_branches() -> None:
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        _is_non_prod_file,
+    )
+
+    assert _is_non_prod_file("") == 0
+    assert _is_non_prod_file("pkg/mod.py") == 0
+    assert _is_non_prod_file("examples/demo.py") == 1
+    assert _is_non_prod_file("scripts/run.py") == 1
+    assert _is_non_prod_file("a\\corpus\\f.py") == 1  # windows separators
+
+
+def test_next_step_lean_non_prod_only_warns() -> None:
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        _next_step_lean,
+    )
+
+    eps = [{"name": "demo_fn", "file": "examples/demo.py"}]
+    msg = _next_step_lean(True, True, entry_points=eps)
+    assert "non-production" in msg
+    assert "demo_fn" in msg and "examples/demo.py" in msg
+
+
+def test_next_step_lean_entry_points_without_code() -> None:
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        _next_step_lean,
+    )
+
+    msg = _next_step_lean(False, True, entry_points=[{"name": "x", "file": "pkg/a.py"}])
+    assert "include_graph=true" in msg
+
+
+def test_next_step_lean_production_anchor() -> None:
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        _next_step_lean,
+    )
+
+    eps = [{"name": "handle_call_tool", "file": "pkg/server.py"}]
+    msg = _next_step_lean(True, True, entry_points=eps)
+    assert "handle_call_tool" in msg

--- a/tests/unit/test_codegraph_context_tool.py
+++ b/tests/unit/test_codegraph_context_tool.py
@@ -1795,3 +1795,69 @@ def test_next_step_references_top_symbol_when_production_match_found(
             f"next_step should mention the top symbol ({top_name!r}) or "
             f"code_blocks; got: {next_step!r}"
         )
+
+
+# ─── Codex review on #487: stop-word filter must keep explicit symbols ────────
+
+
+def test_quoted_stop_word_token_kept_as_candidate() -> None:
+    """`Request`/`Response` in backticks are explicit symbol refs."""
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        _extract_symbol_candidates,
+    )
+
+    out = _extract_symbol_candidates("trace `Request` to `Response`")
+    assert out == ["Request", "Response"]
+
+
+def test_capitalized_stop_word_kept_unquoted() -> None:
+    """Capitalised Server is symbol-shaped even unquoted."""
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        _extract_symbol_candidates,
+    )
+
+    out = _extract_symbol_candidates("how does Server dispatch work")
+    assert "Server" in out
+    assert "server" not in out
+
+
+def test_plain_lowercase_stop_word_still_filtered() -> None:
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        _extract_symbol_candidates,
+    )
+
+    out = _extract_symbol_candidates("which tool is the right one for the server")
+    assert "server" not in out
+    assert "tool" not in out
+
+
+def test_wants_tests_skips_non_prod_demotion() -> None:
+    """Codex P2: test-intent queries must not demote tests/ via non_prod_tier."""
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import _entry_rank_v2
+
+    test_entry = {
+        "hit": {
+            "file": "tests/test_parser.py",
+            "name": "test_parse",
+            "kind": "function",
+            "line": 1,
+        },
+        "matches": 1,
+        "best_rank": 0,
+    }
+    prod_entry = {
+        "hit": {
+            "file": "pkg/parser.py",
+            "name": "parse",
+            "kind": "function",
+            "line": 1,
+        },
+        "matches": 1,
+        "best_rank": 0,
+    }
+    # With wants_tests=True the test file must NOT rank strictly after prod
+    # on the tier dimensions (first two key elements equal).
+    k_test = _entry_rank_v2(test_entry, ["parse"], True)
+    k_prod = _entry_rank_v2(prod_entry, ["parse"], True)
+    assert k_test[0] == k_prod[0] == 0
+    assert k_test[1] == k_prod[1] == 0

--- a/tests/unit/test_codegraph_context_tool.py
+++ b/tests/unit/test_codegraph_context_tool.py
@@ -1626,3 +1626,172 @@ def test_windows_path_components_do_not_anchor_filter() -> None:
     assert "dispatch" in _extract_symbol_candidates(
         r"find dispatch in C:\repo\src\UserService\handler.py"
     )
+
+
+# ---------------------------------------------------------------------------
+# Issue #441 — stop-words / generic nouns, examples/ ranking, honest next_step
+# ---------------------------------------------------------------------------
+
+
+def test_generic_nouns_and_stop_words_not_candidates() -> None:
+    """Issue #441 sub-1: common stop-words and generic code-nouns ('server',
+    'right', 'action', 'call', 'code', 'file', 'tool') must not appear as
+    symbol candidates for a natural-language task.
+
+    Before fix: _extract_symbol_candidates returned
+    ['MCP', 'server', 'tool', 'right', 'facade', 'action'] for the issue repro
+    task — noise terms that waste entry-point slots on unrelated symbols.
+    """
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        _extract_symbol_candidates,
+    )
+
+    task = "how does the MCP server route a tool call to the right facade action"
+    cands = _extract_symbol_candidates(task)
+    lowered = {c.lower() for c in cands}
+
+    # Generic nouns / stop-words must be absent
+    assert "server" not in lowered, f"'server' leaked into candidates: {cands}"
+    assert "right" not in lowered, f"'right' leaked into candidates: {cands}"
+    assert "action" not in lowered, f"'action' leaked into candidates: {cands}"
+    assert "tool" not in lowered, f"'tool' leaked into candidates: {cands}"
+    assert "call" not in lowered, f"'call' leaked into candidates: {cands}"
+
+    # Substantive word 'facade' is present in the codebase and should survive
+    assert "facade" in lowered, f"'facade' was dropped from candidates: {cands}"
+
+
+def test_examples_and_scripts_ranked_below_production() -> None:
+    """Issue #441 sub-2: entry points from examples/, scripts/, corpus/ must
+    rank BELOW production code of equal relevance.
+
+    Before fix: examples/file_output_factory_demo.py dominated because
+    _entry_rank_v2 only demoted test files, not examples/scripts/corpus.
+    """
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        CodeGraphContextTool,
+    )
+
+    class MixedCache:
+        def fts_search_ranked(self, candidate: str, limit: int):
+            # Return examples/ and scripts/ hits before production; ranking
+            # must invert them so production wins.
+            return [
+                {
+                    "name": "route_tool_call",
+                    "kind": "function",
+                    "file": "examples/demo.py",
+                    "line": 5,
+                },
+                {
+                    "name": "route_tool_call",
+                    "kind": "function",
+                    "file": "scripts/sync_version.py",
+                    "line": 10,
+                },
+                {
+                    "name": "route_tool_call",
+                    "kind": "function",
+                    "file": "tree_sitter_analyzer/mcp/server.py",
+                    "line": 200,
+                },
+            ]
+
+    tool = CodeGraphContextTool(str(__import__("pathlib").Path.cwd()))
+    tool._cache = MixedCache()
+
+    hits = tool._resolve_entry_points(["route_tool_call"], limit=10)
+    files = [h["file"] for h in hits]
+
+    # Production file must appear before examples/ and scripts/
+    prod_idx = files.index("tree_sitter_analyzer/mcp/server.py")
+    examples_idx = files.index("examples/demo.py")
+    scripts_idx = files.index("scripts/sync_version.py")
+    assert prod_idx < examples_idx, (
+        f"production must rank before examples/; got order: {files}"
+    )
+    assert prod_idx < scripts_idx, (
+        f"production must rank before scripts/; got order: {files}"
+    )
+
+
+def test_next_step_honest_when_only_non_prod_matches(tmp_path: Path) -> None:
+    """Issue #441 sub-3: next_step must not tell the agent to 'Answer from
+    code_blocks now' when the only matches are examples/scripts — that
+    misleads the agent into answering a production question from demo code.
+
+    We verify the honest-guidance branch: when code blocks exist but ALL
+    entry points are from non-production directories, next_step must
+    reference the actual symbols/files found and suggest a refined search,
+    NOT say 'Answer from code_blocks now.'
+    """
+    import asyncio
+
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        CodeGraphContextTool,
+    )
+
+    # Write a small demo file in examples/ so code blocks are actually built
+    ex_dir = tmp_path / "examples"
+    ex_dir.mkdir()
+    (ex_dir / "demo.py").write_text(
+        "def route_tool_call():\n    return 'demo'\n", encoding="utf-8"
+    )
+    from tree_sitter_analyzer.ast_cache import ASTCache
+
+    cache = ASTCache(str(tmp_path))
+    cache.index_project(max_files=20)
+    cache.close()
+
+    tool = CodeGraphContextTool(str(tmp_path))
+    result = asyncio.run(
+        tool.execute(
+            {
+                "task": "how does the MCP server route a tool call to the right facade action",
+                "output_format": "json",
+            }
+        )
+    )
+
+    next_step = result["agent_summary"]["next_step"]
+    # Must NOT tell agent to answer from demo code
+    assert "Answer from code_blocks now" not in next_step, (
+        f"next_step misled agent to answer from non-prod code: {next_step!r}"
+    )
+
+
+def test_next_step_references_top_symbol_when_production_match_found(
+    indexed_project: Path,
+) -> None:
+    """Issue #441 sub-3: when production matches are found, next_step should
+    reference the actual top symbol or file name — not a generic 'Answer now'
+    that gives no grounding. The key invariant: next_step must be non-empty
+    and must vary based on what was actually found (not a template string).
+    """
+    import asyncio
+
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        CodeGraphContextTool,
+    )
+
+    tool = CodeGraphContextTool(str(indexed_project))
+    result = asyncio.run(
+        tool.execute(
+            {
+                "task": "trace handle_request to UserService.get_user",
+                "output_format": "json",
+            }
+        )
+    )
+
+    next_step = result["agent_summary"]["next_step"]
+    assert next_step, "next_step must not be empty"
+    # next_step must reference the top symbol or file found (not a blank template)
+    entry_points = result.get("entry_points", [])
+    if entry_points:
+        top_name = entry_points[0].get("name", "")
+        # next_step references the top entry point name so agent knows what was found
+        assert top_name in next_step or "code_blocks" in next_step, (
+            f"next_step should mention the top symbol ({top_name!r}) or "
+            f"code_blocks; got: {next_step!r}"
+        )

--- a/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
@@ -634,13 +634,19 @@ def _extract_symbol_candidates(task: str) -> list[str]:
     seen: set[str] = set()
     out: list[str] = []
     for raw in tokens:
+        # Quoted/backticked tokens are EXPLICIT symbol references — a stop
+        # word filter must never eat `Request` / "server" (Codex P1 on #487).
+        was_quoted = raw[:1] in "`\"'"
         raw = raw.strip("`\"'")
         for part in re.split(r"[.:\->]+", raw):
             token = part.strip("_.,;:!?()[]{}")
             if not token:
                 continue
             lowered = token.lower()
-            if lowered in _STOP_WORDS or len(token) < 3:
+            # Capitalised (Server) or non-lowercase (HTTPServer, snake_case
+            # with caps) tokens are symbol-shaped, not prose — keep them.
+            is_plain_prose = token == lowered and not was_quoted
+            if (lowered in _STOP_WORDS and is_plain_prose) or len(token) < 3:
                 continue
             if not (
                 "_" in token or any(ch.isupper() for ch in token) or len(token) >= 4
@@ -1035,7 +1041,10 @@ def _entry_rank_v2(
     """
     hit = entry["hit"]
     file_path = hit.get("file", "")
-    non_prod_tier = _is_non_prod_file(file_path)
+    # Test-intent queries must not demote test/spec/benchmark paths via the
+    # non-prod tier either (Codex P2 on #487) — the tier exists to stop
+    # examples/ from crowding out production, not to bury requested tests.
+    non_prod_tier = 0 if wants_tests else _is_non_prod_file(file_path)
     test_tier = 0 if wants_tests else _is_test_file(file_path)
     kind_rank = 0 if hit.get("kind") in {"class", "function", "method"} else 1
     name_match = _name_match_score(hit.get("name", ""), candidates)

--- a/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
@@ -16,6 +16,7 @@ import re
 import time
 from typing import Any
 
+from ...test_gap_analyzer import _NON_PROD_DIRS as _SHARED_NON_PROD_DIRS
 from ...utils.test_detection import is_test_file as _shared_is_test_file
 from ...utils.test_detection import query_wants_tests as _task_wants_tests
 from ._codegraph_explore_helpers import extract_snippet_from_lines, read_file_lines
@@ -30,7 +31,14 @@ _STOP_WORDS = frozenset(
     # ``_like_rows``), spending entry-point slots on noise. Pure function words only
     # — never legitimate code identifiers (``get``/``make``/``run`` are NOT here).
     "like the per this that via than then such these those be been also just "
-    "only about after before between within".split()
+    "only about after before between within "
+    # Issue #441: generic nouns that appear in natural-language task phrasing
+    # ("how does the MCP SERVER route a TOOL CALL to the RIGHT FACADE ACTION")
+    # but are NOT plausible symbol names — they match hundreds of unrelated
+    # symbols and waste every entry-point slot. Kept to an explicit small set:
+    # never add words that are legitimate identifiers in common frameworks.
+    "server client action call right tool type item node list data code file "
+    "request response result output input value kind line".split()
 )
 
 # RFC-0009 C: generic single-word verbs that frequently appear in trace questions
@@ -351,7 +359,9 @@ class CodeGraphContextTool(BaseMCPTool):
                         f"{len(code_blocks)} code blocks"
                     ),
                     "verdict": verdict,
-                    "next_step": _next_step_lean(bool(code_blocks), bool(entry_points)),
+                    "next_step": _next_step_lean(
+                        bool(code_blocks), bool(entry_points), entry_points
+                    ),
                 },
                 "elapsed_ms": int((time.perf_counter() - started) * 1000),
             }
@@ -926,6 +936,24 @@ def _is_test_file(file_path: str) -> int:
     return 1 if _shared_is_test_file(file_path) else 0
 
 
+def _is_non_prod_file(file_path: str) -> int:
+    """Rank-tier: 1 when the file lives under a non-production directory.
+
+    Issue #441: examples/, scripts/, corpus/, fixtures/ etc. dominated
+    entry_points because only test files were demoted. Production code is
+    the primary audience for architecture questions; non-prod files are only
+    surfaced when NO production match exists.
+
+    Uses the shared ``_SHARED_NON_PROD_DIRS`` set from ``test_gap_analyzer``
+    (single source of truth — import rather than duplicate).
+    """
+    if not file_path:
+        return 0
+    # Normalise to forward slashes for consistent splitting on all platforms.
+    parts = file_path.replace("\\", "/").split("/")
+    return 1 if any(p in _SHARED_NON_PROD_DIRS for p in parts) else 0
+
+
 def _entry_rank(hit: dict[str, Any]) -> tuple[int, int, str, int]:
     file_path = hit.get("file", "")
     is_test = _is_test_file(file_path)
@@ -984,12 +1012,21 @@ def _entry_rank_v2(
     entry: dict[str, Any],
     candidates: list[str],
     wants_tests: bool = False,
-) -> tuple[int, int, int, int, int, str, int]:
+) -> tuple[int, int, int, int, int, int, str, int]:
     """Relevance-aware ranking key for an aggregated entry-point hit.
 
-    Order of precedence: non-test before test, definition kinds before refs,
-    MORE matched task words first, MORE candidate hits first, better BM25
-    rank, then file/line for a stable tie-break.
+    Order of precedence:
+      1. non-prod tier (production code < examples/scripts/corpus)
+      2. non-test before test (unless wants_tests)
+      3. definition kinds before refs
+      4. MORE matched task words first
+      5. MORE candidate hits first
+      6. better BM25 rank
+      7. file/line for a stable tie-break
+
+    Issue #441: added non-prod tier so examples/ and scripts/ entries always
+    rank below production code of equal relevance — they are surfaced only
+    when no production match exists.
 
     When ``wants_tests`` is set (the task itself asks about tests/specs), the
     test-demotion tier is disabled so relevant test symbols are not pushed
@@ -997,16 +1034,19 @@ def _entry_rank_v2(
     and "X tests" must be allowed to return test code (Codex P2 #291).
     """
     hit = entry["hit"]
-    test_tier = 0 if wants_tests else _is_test_file(hit.get("file", ""))
+    file_path = hit.get("file", "")
+    non_prod_tier = _is_non_prod_file(file_path)
+    test_tier = 0 if wants_tests else _is_test_file(file_path)
     kind_rank = 0 if hit.get("kind") in {"class", "function", "method"} else 1
     name_match = _name_match_score(hit.get("name", ""), candidates)
     return (
+        non_prod_tier,
         test_tier,
         kind_rank,
         -name_match,
         -int(entry.get("matches", 0)),
         int(entry.get("best_rank", 0)),
-        hit.get("file", ""),
+        file_path,
         int(hit.get("line", 0) or 0),
     )
 
@@ -1029,15 +1069,45 @@ def _next_step(has_code: bool, has_entry_points: bool) -> str:
     return "Try codegraph_symbol_search with an exact symbol name or broaden the task."
 
 
-def _next_step_lean(has_code: bool, has_entry_points: bool) -> str:
+def _next_step_lean(
+    has_code: bool,
+    has_entry_points: bool,
+    entry_points: list[dict[str, Any]] | None = None,
+) -> str:
     """Next-step hint for the lean (default) response path.
 
     Always names the ``include_graph=true`` flag so the agent knows the full
     call graph is available on re-request — the progressive-disclosure contract.
+
+    Issue #441: when code_blocks exist but ALL entry points are from non-prod
+    directories (examples/, scripts/, corpus/ …), the agent must NOT be told
+    to "Answer from code_blocks now" — that would mislead it into answering a
+    production question from demo/script code. Instead surface the top found
+    symbol and suggest a refined search focused on the production package.
     """
     if has_code:
+        # Check whether ALL matched entry points are from non-production dirs.
+        # If so, warn the agent and suggest a refined search rather than
+        # "answer now" — production queries should not be answered from demos.
+        if entry_points and all(
+            _is_non_prod_file(ep.get("file", "")) for ep in entry_points
+        ):
+            top = entry_points[0]
+            top_name = top.get("name", "")
+            top_file = top.get("file", "")
+            return (
+                f"Matches found only in non-production files (e.g. {top_name!r} "
+                f"in {top_file!r}). These are examples/scripts, not the "
+                "production implementation. Use search action=symbol or "
+                "search action=content with a more specific term to find the "
+                "production code. For the full call graph add include_graph=true."
+            )
+        # Production (or mixed) matches: name the top entry point so the agent
+        # has grounding rather than a blank "answer now" with no reference.
+        top_name = entry_points[0].get("name", "") if entry_points else ""
+        anchor = f" (starting from {top_name!r})" if top_name else ""
         return (
-            "Answer from code_blocks now. "
+            f"Answer from code_blocks now{anchor}. "
             "For the full call graph (nodes/edges) add include_graph=true."
         )
     if has_entry_points:


### PR DESCRIPTION
Closes #441.

## Three sub-fixes
1. **Stop-words**: small explicit frozenset of generic code nouns (server/tool/action/file/...) — issue repro candidates go `['MCP','server','tool','right','facade','action']` → `['MCP','facade']`
2. **entry_points ranking**: `non_prod_tier` added as first sort dimension; production always outranks examples//scripts//corpus/ at equal relevance. Non-prod set IMPORTED from test_gap_analyzer.\_NON_PROD_DIRS (#479's authoritative list — shared, not duplicated)
3. **next_step honesty**: non-prod-only matches → explicit warning naming the files + suggests search action=symbol; production matches → anchored with the top symbol name

## Tests
4 RED-first exact-pin tests; 56 narrow + 968 tools + 53 contracts green; ruff clean; codegraph_context_tool.py coverage 95.99%.