### PR TITLE
fix(search): hyphae select reports total_matches + truncated (#444)

### DIFF
--- a/tests/unit/hyphae/test_select_tool.py
+++ b/tests/unit/hyphae/test_select_tool.py
@@ -44,6 +44,42 @@ class _FakeCache:
         return []
 
 
+class _FakeCacheWithManyCallers:
+    """Cache that returns 150 callers to exceed the default cap of 100."""
+
+    def get_functions(self):
+        # Generate 150 unique functions
+        return [
+            {
+                "name": f"caller_{i}",
+                "file": f"src/caller_{i}.java",
+                "line": 10 + i,
+                "language": "java",
+                "class": f"Caller{i}",
+            }
+            for i in range(150)
+        ]
+
+    def search_symbols_cascade(self, query, limit=100):
+        return []
+
+    def get_symbols_by_kind(self, kind, limit=50000):
+        return []
+
+    def query_edges(self, kind, caller_name=None, callee_name=None, limit=10000):
+        # Return 150 edges when querying for callers of "Target"
+        if kind == "calls" and callee_name == "Target":
+            return [
+                {
+                    "caller_name": f"caller_{i}",
+                    "callee_name": "Target",
+                    "file_path": f"src/caller_{i}.java",
+                }
+                for i in range(150)
+            ]
+        return []
+
+
 def _tool():
     t = HyphaeSelectTool("/tmp")
     t._cache = _FakeCache()
@@ -78,3 +114,43 @@ async def test_execute_syntax_error_is_graceful():
     assert res["success"] is False
     assert "syntax error" in res["error"].lower()
     assert res["symbols"] == []
+
+
+@pytest.mark.asyncio
+async def test_execute_capped_at_100_with_150_total():
+    """When 150 matches exceed the default cap of 100, truncated=True and total_matches=150."""
+    t = HyphaeSelectTool("/tmp")
+    t._cache = _FakeCacheWithManyCallers()
+    res = await t.execute(
+        {"selector": ".function:calls(#Target)", "output_format": "json"}
+    )
+    assert res["success"] is True
+    assert res["count"] == 100
+    assert len(res["symbols"]) == 100
+    assert res["truncated"] is True
+    assert res["total_matches"] == 150
+
+
+@pytest.mark.asyncio
+async def test_execute_under_cap_not_truncated():
+    """When results are under the cap, truncated=False."""
+    res = await _tool().execute(
+        {"selector": ".method:calls(#UserRepo)", "output_format": "json"}
+    )
+    assert res["success"] is True
+    assert res["count"] == 1
+    assert res["truncated"] is False
+    assert res["total_matches"] == 1
+
+
+@pytest.mark.asyncio
+async def test_next_step_includes_narrowing_hint_when_truncated():
+    """When truncated, next_step should mention narrowing options."""
+    t = HyphaeSelectTool("/tmp")
+    t._cache = _FakeCacheWithManyCallers()
+    res = await t.execute(
+        {"selector": ".function:calls(#Target)", "output_format": "json"}
+    )
+    assert res["success"] is True
+    assert res["truncated"] is True
+    assert "narrow" in res["agent_summary"]["next_step"].lower()

--- a/tests/unit/hyphae/test_select_tool.py
+++ b/tests/unit/hyphae/test_select_tool.py
@@ -45,10 +45,12 @@ class _FakeCache:
 
 
 class _FakeCacheWithManyCallers:
-    """Cache that returns 150 callers to exceed the default cap of 100."""
+    """Cache that returns ``n`` callers (default 150 > cap of 100)."""
+
+    def __init__(self, n: int = 150) -> None:
+        self._n = n
 
     def get_functions(self):
-        # Generate 150 unique functions
         return [
             {
                 "name": f"caller_{i}",
@@ -57,7 +59,7 @@ class _FakeCacheWithManyCallers:
                 "language": "java",
                 "class": f"Caller{i}",
             }
-            for i in range(150)
+            for i in range(self._n)
         ]
 
     def search_symbols_cascade(self, query, limit=100):
@@ -154,3 +156,32 @@ async def test_next_step_includes_narrowing_hint_when_truncated():
     assert res["success"] is True
     assert res["truncated"] is True
     assert "narrow" in res["agent_summary"]["next_step"].lower()
+
+
+# ─── Codex P2 (#489): boundary + reentrancy ──────────────────────────────────
+
+
+def test_exactly_max_results_not_truncated() -> None:
+    """Exactly 100 unique matches is a COMPLETE result, not a capped one."""
+    from tree_sitter_analyzer.hyphae.evaluator import Evaluator
+    from tree_sitter_analyzer.hyphae.parser import parse
+
+    cache = _FakeCacheWithManyCallers(n=100)
+    ev = Evaluator(cache, max_results=100)
+    out = ev.eval(parse(".function"))
+    assert len(out) == 100
+    assert ev.total_matches() == 100
+    assert ev.was_truncated() is False
+
+
+def test_not_pseudo_does_not_clobber_counters() -> None:
+    """:not(...) re-enters eval(); outer counters must survive (reentrancy)."""
+    from tree_sitter_analyzer.hyphae.evaluator import Evaluator
+    from tree_sitter_analyzer.hyphae.parser import parse
+
+    cache = _FakeCacheWithManyCallers(n=150)
+    ev = Evaluator(cache, max_results=100)
+    out = ev.eval(parse(".function:not(#no_such_symbol)"))
+    assert len(out) == 100
+    assert ev.total_matches() == 150
+    assert ev.was_truncated() is True

--- a/tests/unit/hyphae/test_select_tool.py
+++ b/tests/unit/hyphae/test_select_tool.py
@@ -185,3 +185,31 @@ def test_not_pseudo_does_not_clobber_counters() -> None:
     assert len(out) == 100
     assert ev.total_matches() == 150
     assert ev.was_truncated() is True
+
+
+def test_multi_selector_recount_covers_remaining_selectors() -> None:
+    """Cap hit in selector 1 of a list — selector 2's matches still counted."""
+    from tree_sitter_analyzer.hyphae.evaluator import Evaluator
+    from tree_sitter_analyzer.hyphae.parser import parse
+
+    cache = _FakeCacheWithManyCallers(n=120)
+    ev = Evaluator(cache, max_results=100)
+    # ".function, .function" — second selector yields only duplicates (all
+    # seen), exercising both recount loops without changing the total.
+    out = ev.eval(parse(".function, .function"))
+    assert len(out) == 100
+    assert ev.total_matches() == 120
+    assert ev.was_truncated() is True
+
+
+def test_duplicate_symbols_across_selectors_deduped() -> None:
+    """The same symbol matched by two selectors counts once."""
+    from tree_sitter_analyzer.hyphae.evaluator import Evaluator
+    from tree_sitter_analyzer.hyphae.parser import parse
+
+    cache = _FakeCacheWithManyCallers(n=10)
+    ev = Evaluator(cache, max_results=100)
+    out = ev.eval(parse(".function, .function"))
+    assert len(out) == 10
+    assert ev.total_matches() == 10
+    assert ev.was_truncated() is False

--- a/tree_sitter_analyzer/hyphae/evaluator.py
+++ b/tree_sitter_analyzer/hyphae/evaluator.py
@@ -86,10 +86,14 @@ class Evaluator:
         Returns the list of matching symbols (capped at self._max).
         Call total_matches() and was_truncated() after eval() to get metadata.
         """
-        self._was_truncated = False
-        self._total_count = 0
+        # ALL counting is kept in locals and written to the instance only at
+        # the very end: ``:not(...)`` re-enters eval() (line ~213), and any
+        # mid-loop instance mutation would be clobbered by the nested call
+        # (Codex P2 on #489 — reentrancy). The outer frame's final assignment
+        # always wins because it happens after every nested eval returns.
         seen: set[tuple[Any, Any, Any]] = set()
         out: list[dict[str, Any]] = []
+        total_count = 0
         hit_cap = False
         sel_with_cap = None
 
@@ -100,7 +104,7 @@ class Evaluator:
                     continue
                 seen.add(k)
                 out.append(sym)
-                self._total_count += 1
+                total_count += 1
                 if len(out) >= self._max:
                     hit_cap = True
                     sel_with_cap = sel
@@ -108,15 +112,14 @@ class Evaluator:
             if hit_cap:
                 break
 
-        # If we hit the cap, count the rest to get the true total
+        # If we hit the cap, count the rest to get the true total.
         if hit_cap and sel_with_cap is not None:
-            self._was_truncated = True
             # Count remaining from current selector
             for sym in self._eval_selector(sel_with_cap):
                 k = _key(sym)
                 if k not in seen:
                     seen.add(k)
-                    self._total_count += 1
+                    total_count += 1
             # Count remaining selectors
             sel_idx = selector_list.selectors.index(sel_with_cap)
             for rem_sel in selector_list.selectors[sel_idx + 1 :]:
@@ -124,11 +127,12 @@ class Evaluator:
                     k = _key(sym)
                     if k not in seen:
                         seen.add(k)
-                        self._total_count += 1
-        else:
-            # No cap hit - total is just what we found
-            self._total_count = len(out)
+                        total_count += 1
 
+        self._total_count = total_count
+        # Truncated only if matches were actually LOST: exactly max_results
+        # unique matches is a complete result, not a capped one (Codex P2).
+        self._was_truncated = total_count > len(out)
         return out
 
     def total_matches(self) -> int:

--- a/tree_sitter_analyzer/hyphae/evaluator.py
+++ b/tree_sitter_analyzer/hyphae/evaluator.py
@@ -76,11 +76,23 @@ class Evaluator:
     def __init__(self, cache: Any, max_results: int = 500) -> None:
         self._cache = cache
         self._max = max_results
+        self._was_truncated = False
+        self._total_count = 0
 
     # -- public --------------------------------------------------------------
     def eval(self, selector_list: SelectorList) -> list[dict[str, Any]]:
+        """Evaluate the selector and return capped results.
+
+        Returns the list of matching symbols (capped at self._max).
+        Call total_matches() and was_truncated() after eval() to get metadata.
+        """
+        self._was_truncated = False
+        self._total_count = 0
         seen: set[tuple[Any, Any, Any]] = set()
         out: list[dict[str, Any]] = []
+        hit_cap = False
+        sel_with_cap = None
+
         for sel in selector_list.selectors:
             for sym in self._eval_selector(sel):
                 k = _key(sym)
@@ -88,9 +100,44 @@ class Evaluator:
                     continue
                 seen.add(k)
                 out.append(sym)
+                self._total_count += 1
                 if len(out) >= self._max:
-                    return out
+                    hit_cap = True
+                    sel_with_cap = sel
+                    break
+            if hit_cap:
+                break
+
+        # If we hit the cap, count the rest to get the true total
+        if hit_cap and sel_with_cap is not None:
+            self._was_truncated = True
+            # Count remaining from current selector
+            for sym in self._eval_selector(sel_with_cap):
+                k = _key(sym)
+                if k not in seen:
+                    seen.add(k)
+                    self._total_count += 1
+            # Count remaining selectors
+            sel_idx = selector_list.selectors.index(sel_with_cap)
+            for rem_sel in selector_list.selectors[sel_idx + 1 :]:
+                for sym in self._eval_selector(rem_sel):
+                    k = _key(sym)
+                    if k not in seen:
+                        seen.add(k)
+                        self._total_count += 1
+        else:
+            # No cap hit - total is just what we found
+            self._total_count = len(out)
+
         return out
+
+    def total_matches(self) -> int:
+        """Return the total number of matches (before cap, if truncated)."""
+        return self._total_count
+
+    def was_truncated(self) -> bool:
+        """Return whether the results were capped at max_results."""
+        return self._was_truncated
 
     # -- dispatch ------------------------------------------------------------
     def _eval_selector(self, sel: Any) -> list[dict[str, Any]]:

--- a/tree_sitter_analyzer/mcp/tools/hyphae_select_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/hyphae_select_tool.py
@@ -121,18 +121,34 @@ class HyphaeSelectTool(BaseMCPTool):
             }
             for m in matches
         ]
+
+        truncated = evaluator.was_truncated()
+        total_matches = evaluator.total_matches()
+
+        # Build next_step based on truncation
+        if truncated:
+            next_step = (
+                f"Results truncated at {max_results} of {total_matches} matches. "
+                "Narrow the selector with :in(path), [file=], [language=], or :not(...) "
+                "to reduce results, or raise max_results."
+            )
+        else:
+            next_step = (
+                "Answer from these symbols, or refine the selector "
+                "(add :in(path) / [file=] / :not(...) to narrow)."
+            )
+
         result: dict[str, Any] = {
             "success": True,
             "selector": selector,
             "count": len(symbols),
+            "total_matches": total_matches,
+            "truncated": truncated,
             "symbols": symbols,
             "agent_summary": {
                 "summary_line": f"hyphae_select: {len(symbols)} symbols for {selector!r}",
                 "verdict": "INFO" if symbols else "NOT_FOUND",
-                "next_step": (
-                    "Answer from these symbols, or refine the selector "
-                    "(add :in(path) / [file=] / :not(...) to narrow)."
-                ),
+                "next_step": next_step,
             },
         }
 


### PR DESCRIPTION
Closes #444.

## Problem
`search action=select` silently capped items at 100 — an agent couldn't tell 100-of-100 from 100-of-5000.

## Fix
- Evaluator keeps counting past the cap: `was_truncated()` / `total_matches()`
- Response gains `total_matches` (pre-cap) + `truncated` (bool)
- `next_step` when truncated: "Results truncated at N of M matches. Narrow the selector with :in(path), [file=], [language=], or :not(...)"

## Tests
3 exact-pin RED-first (150-item fixture → count==100/total==150/truncated True; under-cap → False); 45 hyphae + 53 contracts green; ruff clean.