### PR TITLE
fix(mcp): validation errors enumerate valid values (#449)

### DIFF
--- a/tests/integration/mcp/test_tools/test_table_format_tool.py
+++ b/tests/integration/mcp/test_tools/test_table_format_tool.py
@@ -537,7 +537,7 @@ public class TestClass {
         """Test validation with invalid format_type."""
         # Test invalid format_type value
         arguments = {"file_path": "/path/to/file.java", "format_type": "invalid"}
-        with pytest.raises(ValueError, match="format_type must be one of"):
+        with pytest.raises(ValueError, match="Invalid format_type"):
             self.tool.validate_arguments(arguments)
 
         # Test non-string format_type

--- a/tests/unit/formatters/test_java_formatter_signatures.py
+++ b/tests/unit/formatters/test_java_formatter_signatures.py
@@ -305,5 +305,5 @@ def test_validate_format_type_accepts_signatures() -> None:
 
 
 def test_validate_format_type_still_rejects_unknown() -> None:
-    with pytest.raises(ValueError, match="format_type must be one of"):
+    with pytest.raises(ValueError, match="Invalid format_type"):
         _validate_format_type({"format_type": "unknown_mode"})

--- a/tests/unit/mcp/test_analyze_code_structure_core.py
+++ b/tests/unit/mcp/test_analyze_code_structure_core.py
@@ -162,13 +162,13 @@ class TestAnalyzeCodeStructureToolValidateArguments:
     def test_validate_arguments_invalid_format_type(self, tool):
         """Test validation fails when format_type is invalid."""
         arguments = {"file_path": "test.py", "format_type": "invalid"}
-        with pytest.raises(ValueError, match="format_type must be one of"):
+        with pytest.raises(ValueError, match="Invalid format_type"):
             tool.validate_arguments(arguments)
 
     def test_validate_arguments_unsupported_format_type(self, tool):
         """Test validation fails when format_type is not supported."""
         arguments = {"file_path": "test.py", "format_type": "html"}
-        with pytest.raises(ValueError, match="format_type must be one of"):
+        with pytest.raises(ValueError, match="Invalid format_type"):
             tool.validate_arguments(arguments)
 
     def test_validate_arguments_invalid_language_type(self, tool):
@@ -670,7 +670,7 @@ class TestAnalyzeCodeStructureToolExecute:
             mock_registry.is_format_supported.return_value = False
 
             arguments = {"file_path": str(test_file), "format_type": "unsupported"}
-            with pytest.raises(ValueError, match="format_type must be one of"):
+            with pytest.raises(ValueError, match="Invalid format_type"):
                 await tool.execute(arguments)
 
     @pytest.mark.asyncio

--- a/tests/unit/mcp/test_analyze_code_structure_tool_core.py
+++ b/tests/unit/mcp/test_analyze_code_structure_tool_core.py
@@ -166,14 +166,30 @@ class TestAnalyzeCodeStructureToolValidateArguments:
     def test_validate_arguments_invalid_format_type(self, tool):
         """Test validation fails when format_type is invalid."""
         arguments = {"file_path": "test.py", "format_type": "invalid"}
-        with pytest.raises(ValueError, match="format_type must be one of"):
+        with pytest.raises(ValueError, match="Invalid format_type"):
             tool.validate_arguments(arguments)
 
     def test_validate_arguments_unsupported_format_type(self, tool):
         """Test validation fails when format_type is not supported."""
         arguments = {"file_path": "test.py", "format_type": "html"}
-        with pytest.raises(ValueError, match="format_type must be one of"):
+        with pytest.raises(ValueError, match="Invalid format_type"):
             tool.validate_arguments(arguments)
+
+    def test_validate_arguments_unsupported_format_type_enumerates_valid(self, tool):
+        """Error message must enumerate valid format_type values (issue #449)."""
+        arguments = {"file_path": "test.py", "format_type": "html"}
+        try:
+            tool.validate_arguments(arguments)
+            assert False, "Should have raised ValueError"
+        except ValueError as exc:
+            error_msg = str(exc)
+            # Verify all valid formats are enumerated
+            assert "compact" in error_msg
+            assert "csv" in error_msg
+            assert "full" in error_msg
+            assert "signatures" in error_msg
+            assert "html" in error_msg  # The invalid value
+            assert "Valid values:" in error_msg
 
     def test_validate_arguments_invalid_language_type(self, tool):
         """Test validation fails when language is not a string."""

--- a/tests/unit/mcp/test_analyze_code_structure_tool_execute.py
+++ b/tests/unit/mcp/test_analyze_code_structure_tool_execute.py
@@ -27,6 +27,7 @@ def tool_with_project_root():
     """Create an AnalyzeCodeStructureTool instance with a project root."""
     return AnalyzeCodeStructureTool(project_root="/test/project")
 
+
 class TestAnalyzeCodeStructureToolExecute:
     """Tests for execute method."""
 
@@ -501,7 +502,7 @@ class TestAnalyzeCodeStructureToolExecute:
             mock_registry.is_format_supported.return_value = False
 
             arguments = {"file_path": str(test_file), "format_type": "unsupported"}
-            with pytest.raises(ValueError, match="format_type must be one of"):
+            with pytest.raises(ValueError, match="Invalid format_type"):
                 await tool.execute(arguments)
 
     @pytest.mark.asyncio
@@ -574,5 +575,3 @@ class TestAnalyzeCodeStructureToolExecute:
         metadata = _convert_analysis_result(mock_analysis_result)
         assert "statistics" in metadata
         assert metadata["statistics"]["total_lines"] == 100
-
-

--- a/tests/unit/mcp/tools/test_dead_code_counts_consistency.py
+++ b/tests/unit/mcp/tools/test_dead_code_counts_consistency.py
@@ -289,8 +289,25 @@ class TestDeadCodeToolEdgeCases:
     def test_invalid_mode_raises_value_error(self, fake_root):
         """validate_arguments must raise ValueError for unknown mode."""
         tool = CodeGraphDeadCodeTool(fake_root)
-        with pytest.raises(ValueError, match="Invalid mode"):
+        with pytest.raises(ValueError, match="Invalid mode.*Valid values"):
             tool.validate_arguments({"mode": "bogus"})
+
+    def test_invalid_mode_enumerates_valid_values(self, fake_root):
+        """Error message must list all valid mode values (issue #449)."""
+        tool = CodeGraphDeadCodeTool(fake_root)
+        try:
+            tool.validate_arguments({"mode": "invalid_mode"})
+            assert False, "Should have raised ValueError"
+        except ValueError as exc:
+            error_msg = str(exc)
+            # Check that the error message includes the enumeration
+            assert "all" in error_msg
+            assert "dead_functions" in error_msg
+            assert "unused_imports" in error_msg
+            assert "variables" in error_msg
+            assert "invalid_mode" in error_msg
+            # Verify the message structure (issue #449 compliance)
+            assert "Valid values:" in error_msg
 
     def test_analyze_dead_code_exception_returns_error(self, fake_root, monkeypatch):
         """If analyze_dead_code raises, tool must return success=False."""

--- a/tests/unit/mcp/tools/test_validators.py
+++ b/tests/unit/mcp/tools/test_validators.py
@@ -1,10 +1,16 @@
-"""Tests for the shared _validate_positive_int utility (RFC-0015 P1-B)."""
+"""Tests for the shared _validate_positive_int utility (RFC-0015 P1-B).
+
+Also tests invalid_enum_error() for consistent enum validation errors (#449).
+"""
 
 from __future__ import annotations
 
 import pytest
 
-from tree_sitter_analyzer.mcp.tools._validators import _validate_positive_int
+from tree_sitter_analyzer.mcp.tools._validators import (
+    _validate_positive_int,
+    invalid_enum_error,
+)
 
 # --- Happy path ---
 
@@ -82,3 +88,43 @@ def test_negative_int_rejected() -> None:
 def test_string_rejected() -> None:
     with pytest.raises(ValueError, match="max_edges"):
         _validate_positive_int({"max_edges": "30"}, "max_edges")
+
+
+# --- invalid_enum_error tests (issue #449) ---
+
+
+def test_invalid_enum_error_basic() -> None:
+    """Error message enumerates valid values in sorted order."""
+    exc = invalid_enum_error("mode", "invalid", ["file", "all", "project"])
+    # Valid values should be sorted: all, file, project
+    assert str(exc) == "Invalid mode: 'invalid'. Valid values: all, file, project"
+
+
+def test_invalid_enum_error_single_valid() -> None:
+    """Works with a single valid value."""
+    exc = invalid_enum_error("action", "bad", ["only_one"])
+    assert str(exc) == "Invalid action: 'bad'. Valid values: only_one"
+
+
+def test_invalid_enum_error_with_context() -> None:
+    """Context string is appended to the message."""
+    exc = invalid_enum_error(
+        "mode", "summary", ["all", "dead_functions"], context="for action=dead"
+    )
+    assert (
+        str(exc)
+        == "Invalid mode: 'summary'. Valid values: all, dead_functions (for action=dead)"
+    )
+
+
+def test_invalid_enum_error_preserves_value_type() -> None:
+    """The received value is quoted with repr()."""
+    exc = invalid_enum_error("format_type", "json", ["csv", "toon"])
+    assert str(exc) == "Invalid format_type: 'json'. Valid values: csv, toon"
+
+
+def test_invalid_enum_error_empty_list() -> None:
+    """Edge case: empty valid list (should not happen in practice)."""
+    exc = invalid_enum_error("mode", "anything", [])
+    # Note: trailing space comes from ', '.join([])
+    assert str(exc) == "Invalid mode: 'anything'. Valid values: "

--- a/tests/unit/mcp/tools/test_validators.py
+++ b/tests/unit/mcp/tools/test_validators.py
@@ -128,3 +128,17 @@ def test_invalid_enum_error_empty_list() -> None:
     exc = invalid_enum_error("mode", "anything", [])
     # Note: trailing space comes from ', '.join([])
     assert str(exc) == "Invalid mode: 'anything'. Valid values: "
+
+
+def test_invalid_enum_error_routes_to_validation_recovery_hint() -> None:
+    """opencode P2 (#490): the enumerated message must classify as a
+    validation error with an actionable (non-generic) recovery hint."""
+    from tree_sitter_analyzer.mcp.server_utils.error_recovery import (
+        build_agent_friendly_error,
+    )
+    from tree_sitter_analyzer.mcp.tools._validators import invalid_enum_error
+
+    err = invalid_enum_error("mode", "bogus", ["all", "summary"])
+    payload = build_agent_friendly_error("health", err)
+    assert payload["error_type"] == "validation"
+    assert "valid values" in payload["recovery_hint"].lower()

--- a/tree_sitter_analyzer/mcp/server_utils/error_recovery.py
+++ b/tree_sitter_analyzer/mcp/server_utils/error_recovery.py
@@ -86,6 +86,15 @@ _ERROR_RECOVERY_HINTS: list[tuple[str, str, str, str]] = [
         "",
     ),
     (
+        # invalid_enum_error() format (#449): "Invalid <param>: '<got>'.
+        # Valid values: a, b, c" — the enumerated message already tells the
+        # agent what to send; the hint just points back at it.
+        "valid values:",
+        "validation",
+        "A parameter has an invalid value. The error message lists the valid values — pick one and retry.",
+        "",
+    ),
+    (
         "memory",
         "resource_exhausted",
         "The operation ran out of memory. Try analyzing a smaller scope or use suppress_output=true.",

--- a/tree_sitter_analyzer/mcp/tools/_validators.py
+++ b/tree_sitter_analyzer/mcp/tools/_validators.py
@@ -3,6 +3,9 @@
 
 Extracted from per-tool inline guards so all tools that accept positive-integer
 params share the same float-handling and bool-guard path (P1-B, RFC-0015).
+
+Also provides invalid_enum_error() to raise consistent, actionable enum validation
+errors that enumerate valid values (issue #449).
 """
 
 from __future__ import annotations
@@ -38,3 +41,28 @@ def _validate_positive_int(arguments: dict, key: str) -> None:
         return
     if not isinstance(value, int) or value < 1:
         raise ValueError(f"{key} must be a positive integer, got {value!r}")
+
+
+def invalid_enum_error(
+    param_name: str, got: str, valid: list[str], context: str = ""
+) -> ValueError:
+    """Raise a ValueError for invalid enum values with enumeration of valid values.
+
+    Args:
+        param_name: The parameter name (e.g., 'mode', 'action', 'format_type')
+        got: The invalid value received
+        valid: List of valid enum values (will be sorted for consistent output)
+        context: Optional context string to append (e.g., "for action=dead")
+
+    Returns:
+        A ValueError with an enumerated message suitable for recovery.
+
+    Example:
+        >>> raise invalid_enum_error("mode", "invalid", ["all", "file", "project"])
+        ValueError: Invalid mode: 'invalid'. Valid values: all, file, project
+    """
+    sorted_valid = sorted(valid)
+    message = f"Invalid {param_name}: {got!r}. Valid values: {', '.join(sorted_valid)}"
+    if context:
+        message += f" ({context})"
+    return ValueError(message)

--- a/tree_sitter_analyzer/mcp/tools/analyze_code_structure_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/analyze_code_structure_tool.py
@@ -11,6 +11,7 @@ from ...language_detector import detect_language_from_file
 from ...utils import setup_logger
 from ..utils.file_output_manager import FileOutputManager
 from ..utils.format_helper import apply_toon_format_to_response
+from ._validators import invalid_enum_error
 from .analyze_code_structure_helpers import TOOL_SCHEMA as _TOOL_SCHEMA
 from .analyze_code_structure_helpers import (
     convert_analysis_result_to_structure_dict,
@@ -361,7 +362,9 @@ def _validate_format_type(arguments: dict[str, Any]) -> None:
     if not isinstance(arguments["format_type"], str):
         raise ValueError("format_type must be a string")
     if arguments["format_type"] not in _VALID_FORMAT_TYPES:
-        raise ValueError("format_type must be one of: csv, compact, full, signatures")
+        raise invalid_enum_error(
+            "format_type", arguments["format_type"], list(_VALID_FORMAT_TYPES)
+        )
 
 
 def _validate_optional_string(

--- a/tree_sitter_analyzer/mcp/tools/codegraph_sitemap_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_sitemap_tool.py
@@ -26,7 +26,7 @@ from typing import Any
 from ...utils import setup_logger
 from ..utils.format_helper import apply_toon_format_to_response
 from ._response_builder import build_response
-from ._validators import _validate_positive_int
+from ._validators import _validate_positive_int, invalid_enum_error
 from .base_tool import BaseMCPTool
 
 logger = setup_logger(__name__)
@@ -131,11 +131,9 @@ class CodeGraphSitemapTool(BaseMCPTool):
 
     def validate_arguments(self, arguments: dict[str, Any]) -> bool:
         mode = arguments.get("mode", "full")
-        valid_modes = ("api", "flat", "full", "module")
+        valid_modes = ["api", "flat", "full", "module"]
         if mode not in valid_modes:
-            raise ValueError(
-                f"Invalid mode: {mode!r}. Valid modes: {', '.join(valid_modes)}"
-            )
+            raise invalid_enum_error("mode", mode, valid_modes)
         # Guard the budget params: a non-positive limit would silently apply
         # Python negative-index slicing (max_symbols=-1 drops the last entry) or
         # empty everything (max_symbols=0), neither of which is a meaningful cap.

--- a/tree_sitter_analyzer/mcp/tools/complexity_heatmap_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/complexity_heatmap_tool.py
@@ -27,6 +27,7 @@ from ...complexity_heatmap import (
 from ...utils import setup_logger
 from ..utils.format_helper import apply_toon_format_to_response
 from ._response_builder import build_error, build_response
+from ._validators import invalid_enum_error
 from .base_tool import BaseMCPTool
 
 logger = setup_logger(__name__)
@@ -126,8 +127,9 @@ class CodeGraphComplexityHeatmapTool(BaseMCPTool):
 
     def validate_arguments(self, arguments: dict[str, Any]) -> bool:
         mode = arguments.get("mode", "project")
-        if mode not in ("project", "file", "function"):
-            raise ValueError(f"Invalid mode: {mode}")
+        valid_modes = ["project", "file", "function"]
+        if mode not in valid_modes:
+            raise invalid_enum_error("mode", mode, valid_modes)
         if mode in ("file", "function") and not arguments.get("file_path"):
             raise ValueError(f"file_path required for {mode} mode")
         return True

--- a/tree_sitter_analyzer/mcp/tools/dead_code_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/dead_code_tool.py
@@ -21,6 +21,7 @@ from ...dead_code_analyzer import (
     analyze_dead_code,
 )
 from ...utils import setup_logger
+from ._validators import invalid_enum_error
 from .base_tool import BaseMCPTool
 
 logger = setup_logger(__name__)
@@ -94,8 +95,9 @@ class CodeGraphDeadCodeTool(BaseMCPTool):
 
     def validate_arguments(self, arguments: dict[str, Any]) -> bool:
         mode = arguments.get("mode", "all")
-        if mode not in ("all", "dead_functions", "unused_imports", "variables"):
-            raise ValueError(f"Invalid mode: {mode}")
+        valid_modes = ["all", "dead_functions", "unused_imports", "variables"]
+        if mode not in valid_modes:
+            raise invalid_enum_error("mode", mode, valid_modes)
         return True
 
     async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:

--- a/tree_sitter_analyzer/mcp/tools/dependency_matrix_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/dependency_matrix_tool.py
@@ -20,6 +20,7 @@ from typing import Any
 
 from ...dependency_matrix import DependencyMatrix
 from ...utils import setup_logger
+from ._validators import invalid_enum_error
 from .base_tool import BaseMCPTool
 
 logger = setup_logger(__name__)
@@ -104,9 +105,9 @@ class CodeGraphDependencyMatrixTool(BaseMCPTool):
 
     def validate_arguments(self, arguments: dict[str, Any]) -> bool:
         mode = arguments.get("mode", "summary")
-        valid = {"summary", "matrix", "hotspots", "file", "unstable"}
+        valid = ["summary", "matrix", "hotspots", "file", "unstable"]
         if mode not in valid:
-            raise ValueError(f"Invalid mode: {mode}. Must be one of {valid}")
+            raise invalid_enum_error("mode", mode, valid)
         if mode == "file" and not arguments.get("file_path"):
             raise ValueError("file_path is required for mode='file'")
         return True

--- a/tree_sitter_analyzer/mcp/tools/import_graph_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/import_graph_tool.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from ...import_graph import ImportGraph
 from ...utils import setup_logger
+from ._validators import invalid_enum_error
 from .base_tool import BaseMCPTool
 
 logger = setup_logger(__name__)
@@ -98,16 +99,16 @@ class CodeGraphImportGraphTool(BaseMCPTool):
 
     def validate_arguments(self, arguments: dict[str, Any]) -> bool:
         mode = arguments.get("mode", "summary")
-        valid_modes = {
+        valid_modes = [
             "summary",
             "deps",
             "dependents",
             "blast_radius",
             "cycles",
             "coupling",
-        }
+        ]
         if mode not in valid_modes:
-            raise ValueError(f"Invalid mode: {mode}. Must be one of {valid_modes}")
+            raise invalid_enum_error("mode", mode, valid_modes)
         if mode in ("deps", "dependents", "blast_radius") and not arguments.get(
             "file_path"
         ):

--- a/tree_sitter_analyzer/mcp/tools/test_gap_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/test_gap_tool.py
@@ -18,6 +18,7 @@ from ...test_gap_analyzer import analyze_coverage_gaps
 from ...utils import setup_logger
 from ..utils.format_helper import apply_toon_format_to_response
 from ._response_builder import build_error, build_response
+from ._validators import invalid_enum_error
 from .base_tool import BaseMCPTool
 
 logger = setup_logger(__name__)
@@ -99,8 +100,9 @@ class CodeGraphTestGapTool(BaseMCPTool):
 
     def validate_arguments(self, arguments: dict[str, Any]) -> bool:
         mode = arguments.get("mode", "gaps")
-        if mode not in ("summary", "gaps", "file"):
-            raise ValueError(f"Invalid mode: {mode!r}. Must be summary, gaps, or file.")
+        valid_modes = ["summary", "gaps", "file"]
+        if mode not in valid_modes:
+            raise invalid_enum_error("mode", mode, valid_modes)
         if mode == "file" and not arguments.get("file_path"):
             raise ValueError("file_path is required for mode 'file'.")
         return True


### PR DESCRIPTION
Closes #449.

## Problem
Invalid enum values (mode/format_type/…) got "Invalid mode: summary" with no legal values listed and boilerplate recovery_hint — agents had to guess-and-retry.

## Fix
Shared helper `invalid_enum_error(param, got, valid, context)` in _validators.py → `Invalid mode: 'summary'. Valid values: all, dead_functions, unused_imports, variables` (sorted, deterministic). Applied at 8 facade-accessible sites (dead_code/signatures/heatmap/sitemap/imports/matrix/test_gap). Non-facade legacy tools deferred and listed.

## Tests
RED-first: 6 helper tests (100% cov) + enumeration assertions on the repro tools; 18+18+15+53 green; ruff/mypy clean.