### PR TITLE
fix(search): definitions rank first, duplicate import rows folded (#443)

### DIFF
--- a/tests/unit/test_symbol_search_tool.py
+++ b/tests/unit/test_symbol_search_tool.py
@@ -273,43 +273,52 @@ class TestCodeGraphSymbolSearchExecution:
             cache.close()
 
             tool = CodeGraphSymbolSearchTool(str(project))
-            result = await tool.execute(
-                {"query": "apply_toon_format", "output_format": "json"}
-            )
+            # Windows: the tool's lazy ASTCache holds index.db open —
+            # TemporaryDirectory cleanup needs it closed (WinError 32).
+            try:
+                result = await tool.execute(
+                    {"query": "apply_toon_format", "output_format": "json"}
+                )
 
-            assert result["success"] is True
-            results = result["results"]
+                assert result["success"] is True
+                results = result["results"]
 
-            # Should have exactly 2 entries: 1 definition + 1 folded import
-            assert len(results) == 2, (
-                f"Expected 2 results (1 def + 1 folded import), "
-                f"got {len(results)}: {[r['name'] for r in results]}"
-            )
+                # Should have exactly 2 entries: 1 definition + 1 folded import
+                assert len(results) == 2, (
+                    f"Expected 2 results (1 def + 1 folded import), "
+                    f"got {len(results)}: {[r['name'] for r in results]}"
+                )
 
-            # First result is the definition
-            definition = results[0]
-            assert definition["kind"] == "function", (
-                f"First result should be function definition, got {definition['kind']}"
-            )
-            assert definition["file"].endswith("core.py"), (
-                f"Definition should be in core.py, got {definition['file']}"
-            )
-            assert definition.get("import_count") is None, (
-                "Definition should not have import_count"
-            )
+                # First result is the definition
+                definition = results[0]
+                assert definition["kind"] == "function", (
+                    f"First result should be function definition, got {definition['kind']}"
+                )
+                assert definition["file"].endswith("core.py"), (
+                    f"Definition should be in core.py, got {definition['file']}"
+                )
+                assert definition.get("import_count") is None, (
+                    "Definition should not have import_count"
+                )
 
-            # Second result is folded imports
-            import_entry = results[1]
-            assert import_entry["kind"] == "import", (
-                f"Second result should be import kind, got {import_entry['kind']}"
-            )
-            assert import_entry.get("import_count") == 7, (
-                f"Import entry should have import_count==7, got {import_entry.get('import_count')}"
-            )
-            assert len(import_entry.get("import_files", [])) == 7, (
-                f"Folded import should track all 7 importing files, "
-                f"got {len(import_entry.get('import_files', []))}"
-            )
+                # Second result is folded imports
+                import_entry = results[1]
+                assert import_entry["kind"] == "import", (
+                    f"Second result should be import kind, got {import_entry['kind']}"
+                )
+                assert import_entry.get("import_count") == 7, (
+                    f"Import entry should have import_count==7, got {import_entry.get('import_count')}"
+                )
+                assert len(import_entry.get("import_files", [])) == 7, (
+                    f"Folded import should track all 7 importing files, "
+                    f"got {len(import_entry.get('import_files', []))}"
+                )
+                # Codex P2: file_count must include every folded import file
+                # (7 importers + 1 definition file = 8).
+                assert result["file_count"] == 8
+            finally:
+                if tool._cache is not None:
+                    tool._cache.close()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_symbol_search_tool.py
+++ b/tests/unit/test_symbol_search_tool.py
@@ -241,6 +241,76 @@ class TestCodeGraphSymbolSearchExecution:
                 "FTS5 results must be sorted by relevance_score descending"
             )
 
+    async def test_definition_ranks_first_imports_folded(self):
+        """Issue #443: definitions rank first, duplicate imports folded to one.
+
+        A symbol with 1 definition + N imports should return:
+        - First result: the definition (kind != import)
+        - Second result: folded imports (kind=import, import_count==N)
+        """
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project = Path(tmpdir)
+
+            # 1 real definition
+            (project / "core.py").write_text(
+                "def apply_toon_format(data):\n    return data\n"
+            )
+
+            # 7 files that import the same function
+            for i in range(7):
+                (project / f"importer_{i}.py").write_text(
+                    f"from core import apply_toon_format\n"
+                    f"\n"
+                    f"def use_it_{i}():\n"
+                    f"    return apply_toon_format('test')\n"
+                )
+
+            cache = ASTCache(str(project))
+            cache.index_project(max_files=100)
+            cache.close()
+
+            tool = CodeGraphSymbolSearchTool(str(project))
+            result = await tool.execute(
+                {"query": "apply_toon_format", "output_format": "json"}
+            )
+
+            assert result["success"] is True
+            results = result["results"]
+
+            # Should have exactly 2 entries: 1 definition + 1 folded import
+            assert len(results) == 2, (
+                f"Expected 2 results (1 def + 1 folded import), "
+                f"got {len(results)}: {[r['name'] for r in results]}"
+            )
+
+            # First result is the definition
+            definition = results[0]
+            assert definition["kind"] == "function", (
+                f"First result should be function definition, got {definition['kind']}"
+            )
+            assert definition["file"].endswith("core.py"), (
+                f"Definition should be in core.py, got {definition['file']}"
+            )
+            assert definition.get("import_count") is None, (
+                "Definition should not have import_count"
+            )
+
+            # Second result is folded imports
+            import_entry = results[1]
+            assert import_entry["kind"] == "import", (
+                f"Second result should be import kind, got {import_entry['kind']}"
+            )
+            assert import_entry.get("import_count") == 7, (
+                f"Import entry should have import_count==7, got {import_entry.get('import_count')}"
+            )
+            assert len(import_entry.get("import_files", [])) == 7, (
+                f"Folded import should track all 7 importing files, "
+                f"got {len(import_entry.get('import_files', []))}"
+            )
+
 
 @pytest.mark.asyncio
 class TestCodeGraphSymbolSearchNoCache:

--- a/tree_sitter_analyzer/mcp/tools/symbol_search_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/symbol_search_tool.py
@@ -128,6 +128,8 @@ class CodeGraphSymbolSearchTool(BaseMCPTool):
         raw_results = self._search(cache, query, language, kind, limit)
 
         results = self._apply_kind_filter(raw_results, kind)
+        # Issue #443: fold duplicate imports and rank definitions first
+        results = self._fold_and_rank_results(results)
         self._add_source_context(results)
         # P2: inline a short verbatim body for the top matches so the agent
         # judges relevance from content, not coordinates — no Read per hit.
@@ -445,3 +447,52 @@ class CodeGraphSymbolSearchTool(BaseMCPTool):
         except OSError:
             return ""
         return ""
+
+    def _fold_and_rank_results(
+        self, results: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        """Issue #443: fold duplicate imports, rank definitions first.
+
+        Returns a new list where:
+        1. Non-import kinds (function, class, method, variable) come first
+        2. Imports are folded: duplicate imports of the same symbol become a
+           single entry with import_count and import_files list
+        3. Within each group, original order/ranking is preserved
+        """
+        if not results:
+            return results
+
+        non_imports: list[dict[str, Any]] = []
+        imports_by_name: dict[str, dict[str, Any]] = {}
+
+        for result in results:
+            if result.get("kind") == "import":
+                # Fold imports by name
+                name = result.get("name", "")
+                if name not in imports_by_name:
+                    # Create folded entry: copy the result but prepare for accumulation
+                    imports_by_name[name] = {
+                        "name": name,
+                        "kind": "import",
+                        "import_files": [result.get("file", "")],
+                        "import_count": 1,
+                        # Keep first file, code, line for reference
+                        "file": result.get("file", ""),
+                        "code": result.get("code", ""),
+                        "line": result.get("line", 0),
+                        "end_line": result.get("end_line", 0),
+                        "language": result.get("language", ""),
+                        "relevance_score": result.get("relevance_score", 0.0),
+                    }
+                else:
+                    # Accumulate additional import file
+                    file = result.get("file", "")
+                    if file not in imports_by_name[name]["import_files"]:
+                        imports_by_name[name]["import_files"].append(file)
+                    imports_by_name[name]["import_count"] += 1
+            else:
+                non_imports.append(result)
+
+        # Combine: definitions first, then folded imports
+        folded_imports = list(imports_by_name.values())
+        return non_imports + folded_imports

--- a/tree_sitter_analyzer/mcp/tools/symbol_search_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/symbol_search_tool.py
@@ -137,6 +137,11 @@ class CodeGraphSymbolSearchTool(BaseMCPTool):
 
         by_file: dict[str, int] = {}
         for r in results:
+            # A folded import row represents ALL its importing files —
+            # count each of them so file_count agrees with import_files
+            # (Codex P2 on #492).
+            for extra_fp in r.get("import_files", []):
+                by_file[extra_fp] = by_file.get(extra_fp, 0) + 0
             fp = r.get("file", "")
             by_file[fp] = by_file.get(fp, 0) + 1
 


### PR DESCRIPTION
Closes #443.

## Problem
Searching a symbol returned the one real definition buried under 7 near-identical import rows (one per importing file).

## Fix
`_fold_and_rank_results()`: definitions (non-import kinds) rank first; duplicate import rows for the same symbol fold into ONE entry with `import_count` + `import_files` — imports are folded with a count, never silently dropped.

## Tests
RED-first exact pin: 1 definition + 7 imports → exactly 2 results, definition first, `import_count == 7`; 34/34 tool tests + 53 contracts green; ruff clean.