### PR TITLE
fix(project): overview counts respect index exclusions (#445)

### DIFF
--- a/tests/unit/mcp/test_project_overview_tool.py
+++ b/tests/unit/mcp/test_project_overview_tool.py
@@ -19,6 +19,8 @@ from tree_sitter_analyzer.mcp.tools.project_overview_tool import (
     _count_lines,
     _health_opt_in_hint,
     _increment,
+    _is_ignored_by_gitignore,
+    _load_gitignore_patterns,
     _new_scan,
     _overview_next_step,
     _overview_risk,
@@ -204,6 +206,89 @@ class TestScanProject:
 
         assert scan["ext_dist"][".py"] == 1
         assert scan["ext_dist"][".json"] == 1
+
+    def test_scan_respects_gitignore(self, tmp_path) -> None:
+        """Verify that overview respects .gitignore exclusions (#445)."""
+        # Write a visible file
+        _write(tmp_path, "src/app.py", "print('visible')\n")
+        # Write files in a gitignored directory
+        _write(tmp_path, ".benchmark-repos/vscode.d.ts", "// vendored\n")
+        _write(tmp_path, ".benchmark-repos/tokio/CHANGELOG.md", "# changelog\n")
+        # Create .gitignore that excludes .benchmark-repos
+        _write(tmp_path, ".gitignore", ".benchmark-repos/\n")
+
+        scan = _scan_project(tmp_path, max_depth=5)
+
+        # Only visible file should be counted
+        assert scan["lang_dist"] == {"python": 1}
+        # Source files should only include the visible file, not the gitignored ones
+        assert len(scan["source_files"]) == 1
+        assert scan["source_files"][0]["path"] == "src/app.py"
+
+    def test_scan_without_gitignore(self, tmp_path) -> None:
+        """Verify that scanning works when no .gitignore exists."""
+        _write(tmp_path, "app.py", "x = 1\n")
+        _write(tmp_path, "lib/util.py", "y = 2\n")
+
+        scan = _scan_project(tmp_path, max_depth=5)
+
+        assert scan["lang_dist"]["python"] == 2
+        assert len(scan["source_files"]) == 2
+
+    def test_scan_respects_multiple_gitignore_patterns(self, tmp_path) -> None:
+        """Verify that multiple .gitignore patterns work correctly."""
+        _write(tmp_path, "src/app.py", "x = 1\n")
+        _write(tmp_path, "build/output.o", "binary\n")
+        _write(tmp_path, "dist/package.tar", "archive\n")
+        _write(tmp_path, ".gitignore", "build/\ndist/\n")
+
+        scan = _scan_project(tmp_path, max_depth=5)
+
+        assert scan["lang_dist"] == {"python": 1}
+        assert len(scan["source_files"]) == 1
+
+
+class TestGitignoreSupport:
+    def test_load_gitignore_patterns_exists(self, tmp_path) -> None:
+        """Test loading .gitignore when it exists."""
+        _write(tmp_path, ".gitignore", "*.log\ntemp/\n")
+
+        spec = _load_gitignore_patterns(tmp_path)
+
+        assert spec is not None
+        assert _is_ignored_by_gitignore("test.log", spec) is True
+        assert _is_ignored_by_gitignore("temp/file.txt", spec) is True
+        assert _is_ignored_by_gitignore("src/app.py", spec) is False
+
+    def test_load_gitignore_patterns_missing(self, tmp_path) -> None:
+        """Test loading .gitignore when it doesn't exist."""
+        spec = _load_gitignore_patterns(tmp_path)
+
+        assert spec is None
+
+    def test_load_gitignore_patterns_with_comments(self, tmp_path) -> None:
+        """Test that comments and empty lines are skipped."""
+        _write(tmp_path, ".gitignore", "# Comment\n*.log\n\n# Another comment\ntemp/\n")
+
+        spec = _load_gitignore_patterns(tmp_path)
+
+        assert spec is not None
+        assert _is_ignored_by_gitignore("test.log", spec) is True
+        assert _is_ignored_by_gitignore("temp/file.txt", spec) is True
+
+    def test_is_ignored_by_gitignore_none_spec(self) -> None:
+        """Test that None spec never ignores anything."""
+        assert _is_ignored_by_gitignore("any/path.py", None) is False
+
+    def test_is_ignored_by_gitignore_normalization(self, tmp_path) -> None:
+        """Test path normalization with backslashes."""
+        _write(tmp_path, ".gitignore", "vendor/\n")
+
+        spec = _load_gitignore_patterns(tmp_path)
+
+        # Test both forward and backslash paths
+        assert _is_ignored_by_gitignore("vendor/lib.php", spec) is True
+        assert _is_ignored_by_gitignore("vendor\\lib.php", spec) is True
 
 
 class TestAddPathToScan:

--- a/tests/unit/mcp/test_project_overview_tool.py
+++ b/tests/unit/mcp/test_project_overview_tool.py
@@ -722,3 +722,33 @@ class TestEdgeCases:
         result = _run(tool.execute({"max_depth": 5, "output_format": "json"}))
 
         assert result["summary"]["languages_count"] == len(ext_lang)
+
+
+def test_load_gitignore_only_comments_returns_none(tmp_path) -> None:
+    """A .gitignore with only comments/blank lines compiles to None."""
+    from tree_sitter_analyzer.mcp.tools.project_overview_tool import (
+        _load_gitignore_patterns,
+    )
+
+    (tmp_path / ".gitignore").write_text("# only a comment\n\n")
+    assert _load_gitignore_patterns(tmp_path) is None
+
+
+def test_load_gitignore_unreadable_returns_none(tmp_path, monkeypatch) -> None:
+    """A .gitignore that raises on read degrades gracefully to None."""
+    import builtins
+
+    from tree_sitter_analyzer.mcp.tools.project_overview_tool import (
+        _load_gitignore_patterns,
+    )
+
+    (tmp_path / ".gitignore").write_text("build/\n")
+    real_open = builtins.open
+
+    def boom(path, *a, **kw):
+        if str(path).endswith(".gitignore"):
+            raise OSError("synthetic read failure")
+        return real_open(path, *a, **kw)
+
+    monkeypatch.setattr(builtins, "open", boom)
+    assert _load_gitignore_patterns(tmp_path) is None

--- a/tree_sitter_analyzer/mcp/tools/project_overview_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/project_overview_tool.py
@@ -9,6 +9,8 @@ Aggregates language distribution, file counts, and top-level health summary.
 from pathlib import Path
 from typing import Any
 
+import pathspec
+
 from ...utils import setup_logger
 from ._graph_cache_fingerprint import _EXCLUDE_DIRS as _PROJECT_EXCLUDE_DIRS
 from .base_tool import BaseMCPTool
@@ -215,11 +217,61 @@ class ProjectOverviewTool(BaseMCPTool):
         return apply_toon_format_to_response(result, output_format)
 
 
+def _load_gitignore_patterns(root: Path) -> pathspec.PathSpec | None:
+    """Load .gitignore patterns from the project root.
+
+    Returns a pathspec.PathSpec object if .gitignore exists, None otherwise.
+    Uses gitwildmatch syntax to match git's semantics.
+    """
+    gitignore_path = root / ".gitignore"
+    if not gitignore_path.exists():
+        return None
+
+    try:
+        patterns = []
+        with open(gitignore_path, encoding="utf-8") as f:
+            for line in f:
+                line = line.rstrip("\n\r")
+                # Skip empty lines and comments
+                if line and not line.startswith("#"):
+                    patterns.append(line)
+
+        if not patterns:
+            return None
+
+        return pathspec.PathSpec.from_lines("gitwildmatch", patterns)
+    except Exception as e:
+        logger.warning(f"Failed to load .gitignore from {gitignore_path}: {e}")
+        return None
+
+
+def _is_ignored_by_gitignore(
+    rel_path: str, gitignore_spec: pathspec.PathSpec | None
+) -> bool:
+    """Check if a relative path matches any gitignore patterns.
+
+    Args:
+        rel_path: Relative path from project root (use forward slashes)
+        gitignore_spec: Compiled pathspec from .gitignore (None if no .gitignore)
+
+    Returns:
+        True if the path should be ignored, False otherwise
+    """
+    if gitignore_spec is None:
+        return False
+
+    # Normalize to forward slashes for gitignore matching
+    normalized = rel_path.replace("\\", "/")
+    return gitignore_spec.match_file(normalized)
+
+
 def _scan_project(root: Path, max_depth: int) -> dict[str, Any]:
     """Walk the project tree and collect file/directory stats."""
     scan = _new_scan()
+    gitignore_spec = _load_gitignore_patterns(root)
+
     for path in root.rglob("*"):
-        _add_path_to_scan(scan, root, path, max_depth)
+        _add_path_to_scan(scan, root, path, max_depth, gitignore_spec)
     scan["source_files"].sort(key=lambda item: item["lines"], reverse=True)
     return scan
 
@@ -235,15 +287,32 @@ def _new_scan() -> dict[str, Any]:
 
 
 def _add_path_to_scan(
-    scan: dict[str, Any], root: Path, path: Path, max_depth: int
+    scan: dict[str, Any],
+    root: Path,
+    path: Path,
+    max_depth: int,
+    gitignore_spec: pathspec.PathSpec | None = None,
 ) -> None:
-    """Add a path to project scan accumulators when it is in scope."""
+    """Add a path to project scan accumulators when it is in scope.
+
+    Args:
+        scan: Mutable scan accumulator dict
+        root: Project root path
+        path: Path to check and potentially add
+        max_depth: Max directory depth to scan
+        gitignore_spec: Compiled .gitignore patterns (if any)
+    """
     if any(part in _EXCLUDE_DIRS for part in path.parts):
         return
     try:
         rel_path = path.relative_to(root)
     except ValueError:
         return
+
+    # Check if path is ignored by .gitignore
+    if _is_ignored_by_gitignore(str(rel_path), gitignore_spec):
+        return
+
     if len(rel_path.parts) > max_depth:
         return
     if path.is_dir():

--- a/tree_sitter_analyzer/mcp/tools/project_overview_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/project_overview_tool.py
@@ -266,12 +266,33 @@ def _is_ignored_by_gitignore(
 
 
 def _scan_project(root: Path, max_depth: int) -> dict[str, Any]:
-    """Walk the project tree and collect file/directory stats."""
+    """Walk the project tree and collect file/directory stats.
+
+    Uses ``os.walk`` (not ``rglob``) so ignored directories are pruned from
+    the recursion frontier BEFORE descending — a gitignored vendored tree
+    like .benchmark-repos/ must not even be visited (Codex P2 on #493).
+    """
+    import os
+
     scan = _new_scan()
     gitignore_spec = _load_gitignore_patterns(root)
 
-    for path in root.rglob("*"):
-        _add_path_to_scan(scan, root, path, max_depth, gitignore_spec)
+    for dirpath, dirnames, filenames in os.walk(root):
+        rel_dir = os.path.relpath(dirpath, root)
+        keep_dirs = []
+        for d in dirnames:
+            rel = d if rel_dir == "." else f"{rel_dir}/{d}"
+            # match both "dir" and "dir/" forms (pathspec dir patterns)
+            if _is_ignored_by_gitignore(rel, gitignore_spec) or (
+                _is_ignored_by_gitignore(rel + "/", gitignore_spec)
+            ):
+                continue
+            keep_dirs.append(d)
+        dirnames[:] = sorted(keep_dirs)
+        for d in dirnames:
+            _add_path_to_scan(scan, root, Path(dirpath) / d, max_depth, gitignore_spec)
+        for f in sorted(filenames):
+            _add_path_to_scan(scan, root, Path(dirpath) / f, max_depth, gitignore_spec)
     scan["source_files"].sort(key=lambda item: item["lines"], reverse=True)
     return scan
 
@@ -330,7 +351,9 @@ def _add_file_to_scan(scan: dict[str, Any], root: Path, path: Path) -> None:
     if not lang:
         return
     try:
-        rel_path = str(path.relative_to(root))
+        # Forward slashes on every platform — agents must not get
+        # OS-dependent separators in response payloads.
+        rel_path = str(path.relative_to(root)).replace("\\", "/")
         size = path.stat().st_size
         lines = _count_lines(path)
         scan["source_files"].append(


### PR DESCRIPTION
Closes #445.

## Problem
Overview's file/language counts walked the raw filesystem (incl. gitignored .benchmark-repos/) while the index excluded them — one response, two universes (1,885 indexed vs 7,911 counted).

## Fix
`_scan_project` loads .gitignore via the already-present `pathspec` dependency (gitwildmatch — git's actual semantics) once per scan and filters the walk. Graceful degradation when .gitignore missing/malformed; cross-platform path normalization.

## Tests
8 RED-first tests (gitignore loading/comments/None-spec/normalization + scan-level .benchmark-repos simulation); 126 green (73 overview + 53 contracts); ruff/mypy/bandit clean; new functions 95%+ covered.