### PR TITLE
fix(nav): co_change honest verdict — small-sample guard + filtered-evidence visibility (#469)

### DIFF
--- a/tests/unit/mcp/tools/test_co_change.py
+++ b/tests/unit/mcp/tools/test_co_change.py
@@ -1549,12 +1549,10 @@ def test_adequate_sample_filtered_candidates_next_step_says_filtered() -> None:
 
     next_step: str = result["agent_summary"]["next_step"]
     assert "Safe to edit in isolation" not in next_step
-    # Must surface the filtered count somehow
-    assert (
-        "3" in next_step
-        or "filtered" in next_step.lower()
-        or "below" in next_step.lower()
-    )
+    # Exact pin (Codex P2): the filtered-candidate COUNT must be surfaced —
+    # the deterministic fixture filters exactly 3 candidates.
+    assert result["candidates_below_threshold"] == 3
+    assert "3 candidate(s) were filtered" in next_step
 
 
 # ---------------------------------------------------------------------------
@@ -1597,3 +1595,33 @@ async def test_nav_facade_co_change_carries_candidates_below_threshold() -> None
 
     assert result["success"] is True
     assert "candidates_below_threshold" in result
+
+
+# ---------------------------------------------------------------------------
+# 36. Codex P2 (#495): coupled peers from a too-small sample carry the
+#     small-sample caveat instead of bypassing the guard.
+# ---------------------------------------------------------------------------
+
+
+def test_coupled_peers_small_sample_carries_caveat():
+    """n=3 with a peer meeting min_shared=3 must lead with the caution."""
+    commits = [(_sha(i), ["a.py", "b.py"]) for i in range(3)]
+    git_log_out = _make_git_log(commits)
+    head_sha = "b" * 40
+
+    with patch(
+        "tree_sitter_analyzer.mcp.tools.utils.co_change._run_git"
+    ) as mock_run_git:
+        mock_run_git.side_effect = [
+            (0, head_sha),
+            (0, git_log_out),
+        ]
+        _CO_CHANGE_CACHE.clear()
+        result = _compute_co_change("/fake/repo", "a.py")
+
+    assert result["commits_analyzed"] == 3
+    files = [c["file"] for c in result["co_changed_files"]]
+    assert files == ["b.py"]
+    next_step = result["agent_summary"]["next_step"]
+    assert next_step.startswith("Caution: small sample (n=3 commits")
+    assert "statistically unreliable" in next_step

--- a/tests/unit/mcp/tools/test_co_change.py
+++ b/tests/unit/mcp/tools/test_co_change.py
@@ -173,6 +173,28 @@ def test_no_git_repo_returns_empty() -> None:
     assert result["co_changed_files"] == []
 
 
+def test_git_log_failure_after_head_returns_empty() -> None:
+    """HEAD rev-parse succeeds but git log fails -> graceful empty result.
+
+    Covers the rc_log != 0 path (line 188-190): different from the HEAD-failure
+    path -- here git is available but log subprocess fails (e.g. shallow clone).
+    """
+    head_sha = "a1" * 20
+    with patch(
+        "tree_sitter_analyzer.mcp.tools.utils.co_change._run_git"
+    ) as mock_run_git:
+        mock_run_git.side_effect = [
+            (0, head_sha),  # rev-parse HEAD succeeds
+            (128, ""),  # git log fails (e.g. shallow clone error)
+        ]
+        _CO_CHANGE_CACHE.clear()
+        result = _compute_co_change("/shallow/repo", "src/foo.py")
+
+    assert result["success"] is True
+    assert result["commits_analyzed"] == 0
+    assert result["co_changed_files"] == []
+
+
 # ---------------------------------------------------------------------------
 # 3. Cache: second call with same (project, file, HEAD) skips subprocess
 # ---------------------------------------------------------------------------
@@ -1301,3 +1323,277 @@ def test_handle_nav_actions_returns_none_when_no_flags() -> None:
 
     result = handle_nav_actions(args, ctx)
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# 31. Small-sample guard: n < MIN_COMMITS_FOR_COUPLING_ANALYSIS
+#     When commits_analyzed < floor, next_step must say "insufficient history"
+#     and NEVER say "Safe to edit in isolation".
+# ---------------------------------------------------------------------------
+
+
+def test_small_sample_guard_insufficient_history_next_step() -> None:
+    """n=3 commits -> next_step must contain 'insufficient history' and NOT 'Safe to edit'.
+
+    Exact chosen minimum: 10 commits (MIN_COMMITS_FOR_COUPLING_ANALYSIS).
+    Rationale: association lift P(A∩B)/(P(A)·P(B)) is statistically
+    meaningless at n<10; a null result at n=3 must not claim independence.
+    The verdict/next_step must acknowledge it: no evidence ≠ evidence of absence.
+    """
+    # 3 commits, target in all 3, no peer meets min_shared=3 -> coupled=[]
+    # BUT n=3 < 10 -> must say "insufficient history", NOT "Safe to edit in isolation"
+    commits = [
+        (_sha(0), ["src/target.py", "src/peer_a.py"]),
+        (_sha(1), ["src/target.py", "src/peer_b.py"]),
+        (_sha(2), ["src/target.py"]),  # solo
+    ]
+    git_log_out = _make_git_log(commits)
+    head_sha = "31" * 20
+
+    with patch(
+        "tree_sitter_analyzer.mcp.tools.utils.co_change._run_git"
+    ) as mock_run_git:
+        mock_run_git.side_effect = [
+            (0, head_sha),
+            (0, git_log_out),
+        ]
+        _CO_CHANGE_CACHE.clear()
+        result = _compute_co_change(
+            "/fake/repo", "src/target.py", max_commits=500, min_shared=3
+        )
+
+    assert result["success"] is True
+    assert result["commits_analyzed"] == 3
+    next_step: str = result["agent_summary"]["next_step"]
+    assert "insufficient history" in next_step.lower()
+    assert "Safe to edit in isolation" not in next_step
+
+
+def test_small_sample_guard_adequate_sample_may_say_safe() -> None:
+    """n=10 commits AND no candidates at all -> 'Safe to edit in isolation' IS allowed.
+
+    The guard only blocks the safe verdict when the sample is too small.
+    An adequate sample with truly no co-changing peers may conclude safety.
+    """
+    # 10 commits, target always solo -> coupled=[], but n=10 >= 10
+    commits = [(_sha(i), ["src/target.py"]) for i in range(10)]
+    git_log_out = _make_git_log(commits)
+    head_sha = "32" * 20
+
+    with patch(
+        "tree_sitter_analyzer.mcp.tools.utils.co_change._run_git"
+    ) as mock_run_git:
+        mock_run_git.side_effect = [
+            (0, head_sha),
+            (0, git_log_out),
+        ]
+        _CO_CHANGE_CACHE.clear()
+        result = _compute_co_change(
+            "/fake/repo", "src/target.py", max_commits=500, min_shared=3
+        )
+
+    assert result["success"] is True
+    assert result["commits_analyzed"] == 10
+    next_step: str = result["agent_summary"]["next_step"]
+    assert "Safe to edit in isolation" in next_step
+
+
+# ---------------------------------------------------------------------------
+# 32. Filtered-evidence visibility: candidates_below_threshold
+#     Empty co_changed_files with nonzero below-threshold candidates must
+#     carry candidates_below_threshold == exact count in the result.
+# ---------------------------------------------------------------------------
+
+
+def test_candidates_below_threshold_exact_count() -> None:
+    """Adequate sample (n=20) but peers below min_shared=3 -> candidates_below_threshold.
+
+    3 peers each share exactly 2 commits with target (< min_shared=3 -> filtered).
+    candidates_below_threshold must be exactly 3.
+    co_changed_files must be empty (none cleared the threshold).
+    """
+    # 20 total commits: target in all 20
+    # peer_a, peer_b, peer_c each share exactly 2 commits with target
+    commits: list[tuple[str, list[str]]] = []
+    # Commits 0-1: target + peer_a
+    commits.append((_sha(0), ["src/target.py", "src/peer_a.py"]))
+    commits.append((_sha(1), ["src/target.py", "src/peer_a.py"]))
+    # Commits 2-3: target + peer_b
+    commits.append((_sha(2), ["src/target.py", "src/peer_b.py"]))
+    commits.append((_sha(3), ["src/target.py", "src/peer_b.py"]))
+    # Commits 4-5: target + peer_c
+    commits.append((_sha(4), ["src/target.py", "src/peer_c.py"]))
+    commits.append((_sha(5), ["src/target.py", "src/peer_c.py"]))
+    # Commits 6-19: target solo
+    for i in range(6, 20):
+        commits.append((_sha(i), ["src/target.py"]))
+
+    git_log_out = _make_git_log(commits)
+    head_sha = "33" * 20
+
+    with patch(
+        "tree_sitter_analyzer.mcp.tools.utils.co_change._run_git"
+    ) as mock_run_git:
+        mock_run_git.side_effect = [
+            (0, head_sha),
+            (0, git_log_out),
+        ]
+        _CO_CHANGE_CACHE.clear()
+        result = _compute_co_change(
+            "/fake/repo", "src/target.py", max_commits=500, min_shared=3
+        )
+
+    assert result["success"] is True
+    assert result["co_changed_files"] == []
+    assert result["candidates_below_threshold"] == 3
+
+
+def test_candidates_below_threshold_zero_when_no_peers_at_all() -> None:
+    """No peers at all -> candidates_below_threshold must be exactly 0."""
+    # 15 commits, target always solo
+    commits = [(_sha(i), ["src/target.py"]) for i in range(15)]
+    git_log_out = _make_git_log(commits)
+    head_sha = "34" * 20
+
+    with patch(
+        "tree_sitter_analyzer.mcp.tools.utils.co_change._run_git"
+    ) as mock_run_git:
+        mock_run_git.side_effect = [
+            (0, head_sha),
+            (0, git_log_out),
+        ]
+        _CO_CHANGE_CACHE.clear()
+        result = _compute_co_change(
+            "/fake/repo", "src/target.py", max_commits=500, min_shared=3
+        )
+
+    assert result["success"] is True
+    assert result["candidates_below_threshold"] == 0
+
+
+def test_candidates_below_threshold_mixed_above_and_below() -> None:
+    """peer_a cleared threshold (shared=5), peer_b filtered (shared=2).
+    candidates_below_threshold == 1 (only peer_b); co_changed_files has peer_a.
+    """
+    # 20 commits total
+    # peer_a: shared=5 with target -> above min_shared=3 -> in co_changed_files
+    # peer_b: shared=2 with target -> below min_shared=3 -> counted in candidates_below_threshold
+    commits: list[tuple[str, list[str]]] = []
+    # Commits 0-4: target + peer_a (5 shared)
+    for i in range(5):
+        commits.append((_sha(i), ["src/target.py", "src/peer_a.py"]))
+    # Commits 5-6: target + peer_b (2 shared)
+    commits.append((_sha(5), ["src/target.py", "src/peer_b.py"]))
+    commits.append((_sha(6), ["src/target.py", "src/peer_b.py"]))
+    # Commits 7-19: target solo
+    for i in range(7, 20):
+        commits.append((_sha(i), ["src/target.py"]))
+
+    git_log_out = _make_git_log(commits)
+    head_sha = "35" * 20
+
+    with patch(
+        "tree_sitter_analyzer.mcp.tools.utils.co_change._run_git"
+    ) as mock_run_git:
+        mock_run_git.side_effect = [
+            (0, head_sha),
+            (0, git_log_out),
+        ]
+        _CO_CHANGE_CACHE.clear()
+        result = _compute_co_change(
+            "/fake/repo", "src/target.py", max_commits=500, min_shared=3
+        )
+
+    assert result["success"] is True
+    assert len(result["co_changed_files"]) == 1
+    assert result["co_changed_files"][0]["file"] == "src/peer_a.py"
+    assert result["candidates_below_threshold"] == 1
+
+
+# ---------------------------------------------------------------------------
+# 33. Filtered-evidence next_step: adequate sample with filtered candidates
+#     must say "filtered" / acknowledge sub-threshold signals exist.
+# ---------------------------------------------------------------------------
+
+
+def test_adequate_sample_filtered_candidates_next_step_says_filtered() -> None:
+    """Adequate n=20, co_changed_files=[], candidates_below_threshold=3 ->
+    next_step must NOT say 'Safe to edit in isolation'.
+    It must acknowledge the filtered evidence.
+    """
+    # Same setup as test_candidates_below_threshold_exact_count
+    commits: list[tuple[str, list[str]]] = []
+    commits.append((_sha(0), ["src/target.py", "src/peer_a.py"]))
+    commits.append((_sha(1), ["src/target.py", "src/peer_a.py"]))
+    commits.append((_sha(2), ["src/target.py", "src/peer_b.py"]))
+    commits.append((_sha(3), ["src/target.py", "src/peer_b.py"]))
+    commits.append((_sha(4), ["src/target.py", "src/peer_c.py"]))
+    commits.append((_sha(5), ["src/target.py", "src/peer_c.py"]))
+    for i in range(6, 20):
+        commits.append((_sha(i), ["src/target.py"]))
+
+    git_log_out = _make_git_log(commits)
+    head_sha = "36" * 20
+
+    with patch(
+        "tree_sitter_analyzer.mcp.tools.utils.co_change._run_git"
+    ) as mock_run_git:
+        mock_run_git.side_effect = [
+            (0, head_sha),
+            (0, git_log_out),
+        ]
+        _CO_CHANGE_CACHE.clear()
+        result = _compute_co_change(
+            "/fake/repo", "src/target.py", max_commits=500, min_shared=3
+        )
+
+    next_step: str = result["agent_summary"]["next_step"]
+    assert "Safe to edit in isolation" not in next_step
+    # Must surface the filtered count somehow
+    assert (
+        "3" in next_step
+        or "filtered" in next_step.lower()
+        or "below" in next_step.lower()
+    )
+
+
+# ---------------------------------------------------------------------------
+# 34. CLI parity: result carries candidates_below_threshold when dispatched
+#     through nav facade (not just _compute_co_change directly).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_nav_facade_co_change_carries_candidates_below_threshold() -> None:
+    """nav facade co_change result must include candidates_below_threshold field."""
+    # 20 commits, 2 sub-threshold peers
+    commits: list[tuple[str, list[str]]] = []
+    for i in range(2):
+        commits.append((_sha(i), ["src/target.py", "src/peer_a.py"]))
+    for i in range(2, 4):
+        commits.append((_sha(i), ["src/target.py", "src/peer_b.py"]))
+    for i in range(4, 20):
+        commits.append((_sha(i), ["src/target.py"]))
+
+    git_log_out = _make_git_log(commits)
+    head_sha = "37" * 20
+
+    with patch(
+        "tree_sitter_analyzer.mcp.tools.utils.co_change._run_git"
+    ) as mock_run_git:
+        mock_run_git.side_effect = [
+            (0, head_sha),
+            (0, git_log_out),
+        ]
+        _CO_CHANGE_CACHE.clear()
+        facade = build_nav_facade(project_root=None)
+        result = await facade.execute(
+            {
+                "action": "co_change",
+                "file_path": "src/target.py",
+                "output_format": "json",
+            }
+        )
+
+    assert result["success"] is True
+    assert "candidates_below_threshold" in result

--- a/tree_sitter_analyzer/mcp/tools/utils/co_change.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/co_change.py
@@ -101,12 +101,20 @@ def _build_co_change_summary(
     if coupled:
         top = coupled[0]["file"]
         lift = coupled[0]["lift"]
-        return {
-            "next_step": (
-                f"When editing {target_file}, also review {top} (lift={lift}).  "
-                f"{len(coupled)} co-changed peer(s) total."
-            ),
-        }
+        next_step = (
+            f"When editing {target_file}, also review {top} (lift={lift}).  "
+            f"{len(coupled)} co-changed peer(s) total."
+        )
+        # Codex P2 (#495): coupled peers found from a too-small sample are
+        # still statistically unreliable — lead with the caveat instead of
+        # bypassing the guard via this early return.
+        if commits_analyzed < MIN_COMMITS_FOR_COUPLING_ANALYSIS:
+            next_step = (
+                f"Caution: small sample (n={commits_analyzed} commits, minimum "
+                f"is {MIN_COMMITS_FOR_COUPLING_ANALYSIS}) — coupling signals "
+                f"below are statistically unreliable.  " + next_step
+            )
+        return {"next_step": next_step}
 
     # No coupled files above threshold.
     if commits_analyzed < MIN_COMMITS_FOR_COUPLING_ANALYSIS:

--- a/tree_sitter_analyzer/mcp/tools/utils/co_change.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/co_change.py
@@ -34,6 +34,13 @@ from .change_impact_git import _run_git
 _CO_CHANGE_CACHE_MAXSIZE = 256
 _CO_CHANGE_CACHE: OrderedDict[tuple[str, str, str], dict[str, Any]] = OrderedDict()
 
+# Minimum commits touching the target file required before the result may
+# claim "Safe to edit in isolation".  Below this floor the null-result is
+# statistically meaningless: a 3-commit sample cannot prove independence.
+# Chosen at 10: association lift P(A∩B)/(P(A)·P(B)) is unreliable at n<10
+# (RFC-0014 §honesty, issue #469).
+MIN_COMMITS_FOR_COUPLING_ANALYSIS = 10
+
 
 def _co_change_cache_get(
     key: tuple[str, str, str],
@@ -79,21 +86,55 @@ def _empty_co_change_result(target_file: str, max_commits: int) -> dict[str, Any
 def _build_co_change_summary(
     target_file: str,
     coupled: list[dict[str, Any]],
+    commits_analyzed: int,
+    candidates_below_threshold: int,
 ) -> dict[str, Any]:
-    """Build the agent_summary dict for a co_change result."""
-    if not coupled:
+    """Build the agent_summary dict for a co_change result.
+
+    Honesty layering (issue #469):
+    1. Small-sample guard: n < MIN_COMMITS_FOR_COUPLING_ANALYSIS -> say
+       "insufficient history"; NEVER "Safe to edit in isolation".
+    2. Filtered-evidence visibility: empty co_changed_files with nonzero
+       candidates_below_threshold -> acknowledge filtered signals exist.
+    3. "Safe to edit in isolation" only when: n >= floor AND no candidates.
+    """
+    if coupled:
+        top = coupled[0]["file"]
+        lift = coupled[0]["lift"]
         return {
             "next_step": (
-                f"{target_file} has no strongly coupled peer files in this window.  "
-                "Safe to edit in isolation."
+                f"When editing {target_file}, also review {top} (lift={lift}).  "
+                f"{len(coupled)} co-changed peer(s) total."
             ),
         }
-    top = coupled[0]["file"]
-    lift = coupled[0]["lift"]
+
+    # No coupled files above threshold.
+    if commits_analyzed < MIN_COMMITS_FOR_COUPLING_ANALYSIS:
+        return {
+            "next_step": (
+                f"Insufficient history for coupling analysis "
+                f"(n={commits_analyzed} commits in window, minimum is "
+                f"{MIN_COMMITS_FOR_COUPLING_ANALYSIS}).  "
+                "Treat as unknown, not safe — the sample is too small to "
+                "distinguish no coupling from undetected coupling."
+            ),
+        }
+
+    if candidates_below_threshold > 0:
+        return {
+            "next_step": (
+                f"{target_file} has no strongly coupled peers above the "
+                f"co-occurrence threshold, but {candidates_below_threshold} "
+                f"candidate(s) were filtered as below-threshold weak signals.  "
+                "Review those manually before editing in isolation."
+            ),
+        }
+
+    # Adequate sample AND truly no candidates at all.
     return {
         "next_step": (
-            f"When editing {target_file}, also review {top} (lift={lift}).  "
-            f"{len(coupled)} co-changed peer(s) total."
+            f"{target_file} has no strongly coupled peer files in this window.  "
+            "Safe to edit in isolation."
         ),
     }
 
@@ -199,11 +240,16 @@ def _compute_co_change(
     target_freq_count = len(target_shas)
 
     coupled: list[dict[str, Any]] = []
+    candidates_below_threshold = 0
     for peer, peer_all_shas in file_commit_sets.items():
         # shared = commits where BOTH target and peer changed
         shared_shas = target_shas & peer_all_shas
         shared = len(shared_shas)
         if shared < min_shared:
+            # Count peers that co-changed but didn't clear the threshold
+            # (shared >= 1 means there was genuine co-change, just too rare).
+            if shared >= 1:
+                candidates_below_threshold += 1
             continue
         peer_freq_count = len(peer_all_shas)  # peer's TOTAL commits in this window
         denom = target_freq_count * peer_freq_count
@@ -220,15 +266,19 @@ def _compute_co_change(
     coupled.sort(key=lambda x: (-x["lift"], -x["shared_commits"]))
     truncated = len(coupled) > max_results
     top = coupled[:max_results]
+    commits_analyzed = len(target_shas)
 
     result = {
         "success": True,
         "target": target_file,
-        "commits_analyzed": len(target_shas),
+        "commits_analyzed": commits_analyzed,
         "window": f"last {max_commits} commits",
         "co_changed_files": top,
+        "candidates_below_threshold": candidates_below_threshold,
         "truncated": truncated,
-        "agent_summary": _build_co_change_summary(target_file, top),
+        "agent_summary": _build_co_change_summary(
+            target_file, top, commits_analyzed, candidates_below_threshold
+        ),
     }
     _co_change_cache_put(cache_key, result)
     return result


### PR DESCRIPTION
Closes #469.

## Problem
n=3 commit sample → confident "Safe to edit in isolation", while the same window contained co-change evidence silently filtered by support/lift thresholds — overclaiming verdict from a filtered void.

## Fix (honesty layering, not threshold fiddling)
- `MIN_COMMITS_FOR_COUPLING_ANALYSIS = 10` (documented: lift is statistically forced-null below; a no-peer result at n<10 carries no signal)
- `candidates_below_threshold`: peers that co-changed but didn't clear min_shared — empty list + nonzero count reads "filtered", not "none"
- Verdict matrix: n<10 → "Insufficient history (n=N)… treat as unknown, not safe"; adequate n + filtered candidates → weak-signal warning; **"Safe to edit in isolation" ONLY when adequate n AND zero candidates**

## Dogfood (issue's exact repro)
Before: `n=3, co_changed_files: [], "Safe to edit in isolation"` → After: `n=5, candidates_below_threshold: 14, "Insufficient history… treat as unknown"`

## Tests
6 RED-first exact-pin (incl. facade parity); 43/43 co_change + 53 contracts green; coverage 97.62%; ruff clean.