### PR TITLE
fix(search): hyphae select reports index state — 0 from empty index is not 'no matches' (#491)

### DIFF
--- a/tests/unit/hyphae/test_select_tool.py
+++ b/tests/unit/hyphae/test_select_tool.py
@@ -43,6 +43,10 @@ class _FakeCache:
             ]
         return []
 
+    def get_stats(self):
+        # Ready index with 2 files
+        return {"total_files": 2, "total_symbols": 2}
+
 
 class _FakeCacheWithManyCallers:
     """Cache that returns ``n`` callers (default 150 > cap of 100)."""
@@ -80,6 +84,10 @@ class _FakeCacheWithManyCallers:
                 for i in range(150)
             ]
         return []
+
+    def get_stats(self):
+        # Ready index with many files
+        return {"total_files": self._n, "total_symbols": self._n}
 
 
 def _tool():
@@ -213,3 +221,139 @@ def test_duplicate_symbols_across_selectors_deduped() -> None:
     assert len(out) == 10
     assert ev.total_matches() == 10
     assert ev.was_truncated() is False
+
+
+# ─── Issue #491: Index state detection ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_empty_index_reports_missing_state() -> None:
+    """Empty index (no files) → count:0 + index_state:missing + next_step warns."""
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        # Create a project with empty cache (no indexed files yet)
+        tool = HyphaeSelectTool(tmp_dir)
+        # Initialize the cache but don't index anything
+        result = await tool.execute({"selector": ".function", "output_format": "json"})
+
+        assert result["success"] is True
+        assert result["count"] == 0
+        assert "index_state" in result
+        assert result["index_state"] in ("missing", "empty")
+        assert "index missing" in result["agent_summary"]["next_step"].lower()
+
+
+@pytest.mark.asyncio
+async def test_zero_matches_on_ready_index_is_not_a_warning() -> None:
+    """Zero matches on a ready index → count:0 + index_state:ready + normal next_step."""
+    tool = _tool()
+    result = await tool.execute({"selector": ".nonexistent", "output_format": "json"})
+
+    assert result["success"] is True
+    assert result["count"] == 0
+    # The test cache is considered "ready" because it has symbols
+    # (via the FakeCache mock that returns data from get_functions)
+    # The next_step should NOT say "index missing"
+    assert "index_state" in result
+    assert result["index_state"] == "ready"
+    assert "index missing" not in result["agent_summary"]["next_step"].lower()
+    assert result["agent_summary"]["verdict"] == "NOT_FOUND"
+
+
+@pytest.mark.asyncio
+async def test_valid_matches_on_ready_index_succeeds() -> None:
+    """Valid matches on ready index → count>0 + index_state:ready + info verdict."""
+    tool = _tool()
+    result = await tool.execute(
+        {"selector": ".method:calls(#UserRepo)", "output_format": "json"}
+    )
+
+    assert result["success"] is True
+    assert result["count"] == 1
+    assert result["index_state"] == "ready"
+    assert result["agent_summary"]["verdict"] == "INFO"
+    assert "index missing" not in result["agent_summary"]["next_step"].lower()
+
+
+@pytest.mark.asyncio
+async def test_truncated_results_show_narrowing_hint_on_ready_index() -> None:
+    """Truncated results on ready index → next_step mentions narrowing."""
+    t = HyphaeSelectTool("/tmp")
+    t._cache = _FakeCacheWithManyCallers()
+    result = await t.execute(
+        {"selector": ".function:calls(#Target)", "output_format": "json"}
+    )
+
+    assert result["success"] is True
+    assert result["truncated"] is True
+    assert result["index_state"] == "ready"
+    assert result["agent_summary"]["verdict"] == "INFO"
+    assert "narrow" in result["agent_summary"]["next_step"].lower()
+
+
+class _EmptyCache:
+    """A cache that reports zero indexed files (empty)."""
+
+    def get_functions(self):
+        return []
+
+    def search_symbols_cascade(self, query, limit=100):
+        return []
+
+    def get_symbols_by_kind(self, kind, limit=50000):
+        return []
+
+    def query_edges(self, kind, caller_name=None, callee_name=None, limit=10000):
+        return []
+
+    def get_stats(self):
+        # Empty index: 0 files
+        return {"total_files": 0, "total_symbols": 0}
+
+
+@pytest.mark.asyncio
+async def test_any_selector_on_empty_index_warns() -> None:
+    """Any selector on empty index → warns about missing index."""
+    tool = HyphaeSelectTool("/tmp")
+    tool._cache = _EmptyCache()
+    result = await tool.execute({"selector": ".function", "output_format": "json"})
+
+    assert result["success"] is True
+    assert result["count"] == 0
+    assert result["index_state"] == "empty"
+    assert result["agent_summary"]["verdict"] == "WARN"
+    assert "index missing" in result["agent_summary"]["next_step"].lower()
+
+
+class _BrokenCache:
+    """A cache that raises an exception on get_stats."""
+
+    def get_functions(self):
+        return []
+
+    def search_symbols_cascade(self, query, limit=100):
+        return []
+
+    def get_symbols_by_kind(self, kind, limit=50000):
+        return []
+
+    def query_edges(self, kind, caller_name=None, callee_name=None, limit=10000):
+        return []
+
+    def get_stats(self):
+        raise RuntimeError("Cache corrupted")
+
+
+@pytest.mark.asyncio
+async def test_selector_on_missing_cache_warns() -> None:
+    """Selector on missing/broken cache → warns about missing index."""
+    tool = HyphaeSelectTool("/tmp")
+    tool._cache = _BrokenCache()
+    result = await tool.execute({"selector": ".function", "output_format": "json"})
+
+    assert result["success"] is True
+    assert result["count"] == 0
+    assert result["index_state"] == "missing"
+    assert result["agent_summary"]["verdict"] == "WARN"
+    assert "index missing" in result["agent_summary"]["next_step"].lower()

--- a/tests/unit/hyphae/test_select_tool.py
+++ b/tests/unit/hyphae/test_select_tool.py
@@ -364,3 +364,16 @@ async def test_selector_on_missing_cache_warns() -> None:
     assert result["index_state"] == "missing"
     assert result["agent_summary"]["verdict"] == "WARN"
     assert "index missing" in result["agent_summary"]["next_step"].lower()
+
+
+@pytest.mark.asyncio
+async def test_ready_zero_matches_reports_indexed_file_count() -> None:
+    """opencode P2 (#497): partial cache classifies ready — the indexed-file
+    count must be surfaced so 0 matches is judgeable (original #491 repro)."""
+    tool = _tool()
+    result = await tool.execute({"selector": ".nonexistent", "output_format": "json"})
+    assert result["index_state"] == "ready"
+    assert result["indexed_files"] == 2  # FakeCache reports total_files=2
+    next_step = result["agent_summary"]["next_step"]
+    assert "indexed file(s)" in next_step
+    assert "run index action=auto to complete the index" in next_step

--- a/tests/unit/hyphae/test_select_tool.py
+++ b/tests/unit/hyphae/test_select_tool.py
@@ -234,14 +234,21 @@ async def test_empty_index_reports_missing_state() -> None:
     with tempfile.TemporaryDirectory() as tmp_dir:
         # Create a project with empty cache (no indexed files yet)
         tool = HyphaeSelectTool(tmp_dir)
-        # Initialize the cache but don't index anything
-        result = await tool.execute({"selector": ".function", "output_format": "json"})
+        # Windows: close the tool's lazy ASTCache before TemporaryDirectory
+        # cleanup — an open index.db handle is WinError 32 (#492 precedent).
+        try:
+            result = await tool.execute(
+                {"selector": ".function", "output_format": "json"}
+            )
 
-        assert result["success"] is True
-        assert result["count"] == 0
-        assert "index_state" in result
-        assert result["index_state"] in ("missing", "empty")
-        assert "index missing" in result["agent_summary"]["next_step"].lower()
+            assert result["success"] is True
+            assert result["count"] == 0
+            assert "index_state" in result
+            assert result["index_state"] in ("missing", "empty")
+            assert "index missing" in result["agent_summary"]["next_step"].lower()
+        finally:
+            if tool._cache is not None:
+                tool._cache.close()
 
 
 @pytest.mark.asyncio

--- a/tree_sitter_analyzer/mcp/tools/hyphae_select_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/hyphae_select_tool.py
@@ -109,7 +109,12 @@ class HyphaeSelectTool(BaseMCPTool):
                 "symbols": [],
             }
 
-        evaluator = Evaluator(self._get_cache(), max_results=max_results)
+        cache = self._get_cache()
+
+        # Detect index state cheaply: check if cache has any indexed files
+        index_state = self._detect_index_state(cache)
+
+        evaluator = Evaluator(cache, max_results=max_results)
         matches = evaluator.eval(ast)
         symbols = [
             {
@@ -125,18 +130,34 @@ class HyphaeSelectTool(BaseMCPTool):
         truncated = evaluator.was_truncated()
         total_matches = evaluator.total_matches()
 
-        # Build next_step based on truncation
-        if truncated:
+        # Build next_step based on index state and result count
+        if index_state != "ready":
+            # Index is missing or empty — 0 doesn't mean "no matches", it means "not indexed"
+            next_step = (
+                "Index missing or empty. Run the `index` tool with action=auto "
+                "to build the cache."
+            )
+            verdict = "WARN"
+        elif truncated:
             next_step = (
                 f"Results truncated at {max_results} of {total_matches} matches. "
                 "Narrow the selector with :in(path), [file=], [language=], or :not(...) "
                 "to reduce results, or raise max_results."
             )
+            verdict = "INFO"
+        elif len(symbols) == 0:
+            # Zero matches on a ready index — selector didn't match anything
+            next_step = (
+                "No matches found. Check your selector or try a broader search "
+                "(e.g., remove :in(path) or [file=] filters)."
+            )
+            verdict = "NOT_FOUND"
         else:
             next_step = (
                 "Answer from these symbols, or refine the selector "
                 "(add :in(path) / [file=] / :not(...) to narrow)."
             )
+            verdict = "INFO"
 
         result: dict[str, Any] = {
             "success": True,
@@ -145,9 +166,10 @@ class HyphaeSelectTool(BaseMCPTool):
             "total_matches": total_matches,
             "truncated": truncated,
             "symbols": symbols,
+            "index_state": index_state,
             "agent_summary": {
                 "summary_line": f"hyphae_select: {len(symbols)} symbols for {selector!r}",
-                "verdict": "INFO" if symbols else "NOT_FOUND",
+                "verdict": verdict,
                 "next_step": next_step,
             },
         }
@@ -155,3 +177,19 @@ class HyphaeSelectTool(BaseMCPTool):
         from ..utils.format_helper import apply_toon_format_to_response
 
         return apply_toon_format_to_response(result, output_format)
+
+    def _detect_index_state(self, cache: Any) -> str:
+        """Determine index state: missing, empty, or ready.
+
+        Reuses the same check as codegraph_status_tool:
+        - missing: cache file doesn't exist or can't be opened
+        - empty: cache exists but has no indexed files (total_files == 0)
+        - ready: cache exists and has indexed files (total_files > 0)
+        """
+        try:
+            stats = cache.get_stats()
+            if stats and stats.get("total_files", 0) > 0:
+                return "ready"
+            return "empty"
+        except Exception:
+            return "missing"

--- a/tree_sitter_analyzer/mcp/tools/hyphae_select_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/hyphae_select_tool.py
@@ -46,7 +46,7 @@ class HyphaeSelectTool(BaseMCPTool):
                 "[file=]/[language=]/[class=]/[kind=]; combinators A > B / A B / "
                 "A ~ B. Example: '.class:implements(#Writeable):in(server/)'. "
                 "Unknown pseudo-classes raise an error (no silent pass-through). "
-                "Requires ast_cache index (run index action=warm)."
+                "Requires ast_cache index (run index action=warm). Response carries index_state (missing|empty|ready) + indexed_files; a missing/empty index returns verdict WARN (0 means 'not indexed', not 'no matches')."
             ),
             "inputSchema": self.get_tool_schema(),
             "annotations": {
@@ -112,7 +112,7 @@ class HyphaeSelectTool(BaseMCPTool):
         cache = self._get_cache()
 
         # Detect index state cheaply: check if cache has any indexed files
-        index_state = self._detect_index_state(cache)
+        index_state, indexed_files = self._detect_index_state(cache)
 
         evaluator = Evaluator(cache, max_results=max_results)
         matches = evaluator.eval(ast)
@@ -134,8 +134,9 @@ class HyphaeSelectTool(BaseMCPTool):
         if index_state != "ready":
             # Index is missing or empty — 0 doesn't mean "no matches", it means "not indexed"
             next_step = (
-                "Index missing or empty. Run the `index` tool with action=auto "
-                "to build the cache."
+                "Index missing, empty, or unreadable. Run the `index` tool with "
+                "action=auto to build the cache (if this persists, check "
+                ".ast-cache permissions)."
             )
             verdict = "WARN"
         elif truncated:
@@ -146,10 +147,16 @@ class HyphaeSelectTool(BaseMCPTool):
             )
             verdict = "INFO"
         elif len(symbols) == 0:
-            # Zero matches on a ready index — selector didn't match anything
+            # Zero matches on a ready index — selector didn't match anything.
+            # Honest coverage (opencode P2 on #497): an on-demand partial cache
+            # (e.g. 1 file indexed) still classifies as "ready"; reporting the
+            # indexed-file count lets the agent judge whether 0 means "no
+            # matches" or "index incomplete" — the original #491 repro case.
             next_step = (
-                "No matches found. Check your selector or try a broader search "
-                "(e.g., remove :in(path) or [file=] filters)."
+                f"No matches found across {indexed_files} indexed file(s). "
+                "Check your selector or try a broader search (remove :in(path) "
+                "or [file=] filters). If the project should contain more files, "
+                "run index action=auto to complete the index."
             )
             verdict = "NOT_FOUND"
         else:
@@ -167,6 +174,7 @@ class HyphaeSelectTool(BaseMCPTool):
             "truncated": truncated,
             "symbols": symbols,
             "index_state": index_state,
+            "indexed_files": indexed_files,
             "agent_summary": {
                 "summary_line": f"hyphae_select: {len(symbols)} symbols for {selector!r}",
                 "verdict": verdict,
@@ -178,18 +186,22 @@ class HyphaeSelectTool(BaseMCPTool):
 
         return apply_toon_format_to_response(result, output_format)
 
-    def _detect_index_state(self, cache: Any) -> str:
-        """Determine index state: missing, empty, or ready.
+    def _detect_index_state(self, cache: Any) -> tuple[str, int]:
+        """Determine (index_state, indexed_files).
 
-        Reuses the same check as codegraph_status_tool:
-        - missing: cache file doesn't exist or can't be opened
+        Reuses the same check as codegraph_status_tool (one cheap sqlite
+        count per call):
+        - missing: cache file doesn't exist or can't be opened/read
         - empty: cache exists but has no indexed files (total_files == 0)
-        - ready: cache exists and has indexed files (total_files > 0)
+        - ready: cache exists and has indexed files (total_files > 0) —
+          NOTE this includes on-demand PARTIAL caches; the indexed_files
+          count is surfaced so consumers can judge coverage honestly.
         """
         try:
             stats = cache.get_stats()
-            if stats and stats.get("total_files", 0) > 0:
-                return "ready"
-            return "empty"
+            total = int((stats or {}).get("total_files", 0) or 0)
+            if total > 0:
+                return "ready", total
+            return "empty", 0
         except Exception:
-            return "missing"
+            return "missing", 0


### PR DESCRIPTION
Closes #491.

## Problem
select on an empty/partial index returned silent `count: 0` + "Answer from these symbols" — an agent on an unindexed project read "no callers" instead of "index isn't built".

## Fix
- `index_state` field: missing / empty / ready (detection mirrors status tool's `truly_indexed` pattern — total_files > 0)
- State-routed next_step: not-ready → WARN "Index missing or empty — run index action=auto"; ready+0 → NOT_FOUND with selector hints (legit zero, no false alarm); ready+truncated/matches → existing hints

## Tests
6 RED-first exact-pin (empty→WARN, ready-zero→NOT_FOUND no false alarm, missing-cache exception path…); 55 hyphae + 53 contracts green; coverage 92.4%; ruff clean.