### PR TITLE
fix(viz): uml NOT_FOUND honesty — index-resolved activity + partial-state INFO verdict (#477, #480)

### DIFF
--- a/tests/unit/test_uml_activity.py
+++ b/tests/unit/test_uml_activity.py
@@ -1484,7 +1484,9 @@ def test_activity_diagram_no_file_path_index_unique_resolves(tmp_path) -> None:
     # Unique hit: must resolve and succeed (no NOT_FOUND verdict)
     assert result.metadata.get("verdict") is None  # success path has no verdict key
     assert result.mermaid.startswith("flowchart TD")
-    assert len(result.nodes) > 0  # CFG was built
+    # Exact pin (Codex P2 + CLAUDE.md rule): unique_fn's CFG is deterministic
+    # — start, condition, return 1, return 0.  Measured 2026-06-11.
+    assert len(result.nodes) == 4
 
 
 def test_activity_diagram_no_file_path_index_not_found_message(tmp_path) -> None:
@@ -1536,3 +1538,38 @@ def test_activity_diagram_no_file_path_index_ambiguous_lists_files(
     next_step = result.metadata.get("next_step", "")
     # Must name at least one of the candidate files
     assert "mod1.py" in next_step or "mod2.py" in next_step or "candidates" in next_step
+
+
+def test_activity_index_lookup_ignores_non_python_same_name(tmp_path) -> None:
+    """Codex P2 (#498): a same-name JS symbol must not make the Python
+    lookup ambiguous — the CFG builder is Python-only."""
+    src = tmp_path / "mod.py"
+    src.write_text("def handle(x):\n    return x\n")
+
+    from tree_sitter_analyzer.uml_export import UMLExporter
+
+    class PolyglotCache:
+        def search_symbols(self, query: str, language: str | None = None) -> list:
+            return [
+                {
+                    "name": "handle",
+                    "kind": "function",
+                    "file": str(src),
+                    "language": "python",
+                },
+                {
+                    "name": "handle",
+                    "kind": "function",
+                    "file": "web/app.js",
+                    "language": "javascript",
+                },
+            ]
+
+        def close(self) -> None:
+            pass
+
+    exporter = UMLExporter(str(tmp_path), cache=PolyglotCache())
+    result = exporter.activity_diagram("handle", file_path=None)
+    assert result.metadata.get("verdict") is None  # resolved, not ambiguous
+    assert result.mermaid.startswith("flowchart TD")
+    assert len(result.nodes) == 2  # start + return (measured 2026-06-11)

--- a/tests/unit/test_uml_activity.py
+++ b/tests/unit/test_uml_activity.py
@@ -1191,13 +1191,25 @@ def test_is_neighbourhood_center_none_returns_false() -> None:
 
 
 def test_activity_diagram_no_file_path_returns_not_found(tmp_path) -> None:
-    """activity_diagram with file_path=None returns NOT_FOUND (lines 508→515, 517)."""
+    """activity_diagram with file_path=None AND no index hit returns NOT_FOUND.
+
+    When the function is not found in the index and no file_path is given,
+    verdict=NOT_FOUND with message distinguishing "not in index" from "file required".
+    """
     from tree_sitter_analyzer.uml_export import UMLExporter
 
-    exporter = UMLExporter(str(tmp_path))
+    class FakeCache:
+        def search_symbols(self, query: str, language: str | None = None) -> list:
+            return []  # no index hits
+
+        def close(self) -> None:
+            pass
+
+    exporter = UMLExporter(str(tmp_path), cache=FakeCache())
     result = exporter.activity_diagram("f", file_path=None)
     assert result.metadata.get("verdict") == "NOT_FOUND"
-    assert "file_path" in result.metadata.get("next_step", "")
+    next_step = result.metadata.get("next_step", "")
+    assert "not found in the index" in next_step or "not in index" in next_step
 
 
 def test_activity_diagram_relative_file_path(tmp_path) -> None:
@@ -1438,3 +1450,89 @@ def test_handle_if_no_else_false_live_has_non_condition(tmp_path) -> None:
     labels = {e.label for e in edges_from_cond}
     assert "True" in labels
     assert "False" in labels
+
+
+# ---------------------------------------------------------------------------
+# #477: index-resolved activity — STRONG option
+# Without file_path, resolve via AST index; distinguish found/ambiguous/absent.
+# ---------------------------------------------------------------------------
+
+
+def test_activity_diagram_no_file_path_index_unique_resolves(tmp_path) -> None:
+    """RED → GREEN (#477 STRONG): unique index hit → resolve file and build CFG.
+
+    When file_path is absent but the function is uniquely indexed, the exporter
+    resolves the file from the index and proceeds to build the diagram instead
+    of returning NOT_FOUND.
+    """
+    src = tmp_path / "mod.py"
+    src.write_text("def unique_fn(x):\n    if x:\n        return 1\n    return 0\n")
+
+    from tree_sitter_analyzer.uml_export import UMLExporter
+
+    class FakeCache:
+        def search_symbols(self, query: str, language: str | None = None) -> list:
+            if query == "unique_fn":
+                return [{"name": "unique_fn", "kind": "function", "file": str(src)}]
+            return []
+
+        def close(self) -> None:
+            pass
+
+    exporter = UMLExporter(str(tmp_path), cache=FakeCache())
+    result = exporter.activity_diagram("unique_fn", file_path=None)
+    # Unique hit: must resolve and succeed (no NOT_FOUND verdict)
+    assert result.metadata.get("verdict") is None  # success path has no verdict key
+    assert result.mermaid.startswith("flowchart TD")
+    assert len(result.nodes) > 0  # CFG was built
+
+
+def test_activity_diagram_no_file_path_index_not_found_message(tmp_path) -> None:
+    """RED → GREEN (#477 STRONG): no index hit → NOT_FOUND with 'not found in the index'.
+
+    Distinct from "file_path required" — the message must say the function
+    is absent from the index, not that file_path is missing.
+    """
+    from tree_sitter_analyzer.uml_export import UMLExporter
+
+    class FakeCache:
+        def search_symbols(self, query: str, language: str | None = None) -> list:
+            return []
+
+        def close(self) -> None:
+            pass
+
+    exporter = UMLExporter(str(tmp_path), cache=FakeCache())
+    result = exporter.activity_diagram("no_such_fn_zz", file_path=None)
+    assert result.metadata.get("verdict") == "NOT_FOUND"
+    next_step = result.metadata.get("next_step", "")
+    # Must distinguish from the "file_path required" message
+    assert "not_found_in_index" in next_step or "not found in the index" in next_step
+
+
+def test_activity_diagram_no_file_path_index_ambiguous_lists_files(
+    tmp_path,
+) -> None:
+    """RED → GREEN (#477 STRONG): multiple index hits → NOT_FOUND with candidate files.
+
+    When a function name matches in multiple files, agent must see the file list
+    so it can supply the right file_path. Bare NOT_FOUND is insufficient.
+    """
+    from tree_sitter_analyzer.uml_export import UMLExporter
+
+    class FakeCache:
+        def search_symbols(self, query: str, language: str | None = None) -> list:
+            return [
+                {"name": "my_func", "kind": "function", "file": "a/mod1.py"},
+                {"name": "my_func", "kind": "function", "file": "b/mod2.py"},
+            ]
+
+        def close(self) -> None:
+            pass
+
+    exporter = UMLExporter(str(tmp_path), cache=FakeCache())
+    result = exporter.activity_diagram("my_func", file_path=None)
+    assert result.metadata.get("verdict") == "NOT_FOUND"
+    next_step = result.metadata.get("next_step", "")
+    # Must name at least one of the candidate files
+    assert "mod1.py" in next_step or "mod2.py" in next_step or "candidates" in next_step

--- a/tests/unit/test_uml_state.py
+++ b/tests/unit/test_uml_state.py
@@ -518,8 +518,17 @@ def test_state_diagram_note_in_metadata(tmp_path: Path) -> None:
     assert "parsed from current file content" in diagram.metadata["note"]
 
 
-def test_state_diagram_zero_transitions_not_found(tmp_path: Path) -> None:
-    """Zero transitions → verdict='NOT_FOUND' in metadata (honesty rule)."""
+def test_state_diagram_zero_transitions_info(tmp_path: Path) -> None:
+    """Zero transitions but states found → verdict='INFO' in metadata (#480 fix).
+
+    RE-PINNED from NOT_FOUND → INFO (consciously):
+    RFC-0015 §P2-B's "honesty rule" intent was "don't fake a diagram"; the mermaid
+    suppression of [*]--> lines already serves that goal. A partial result (states
+    found, zero transitions) is not "not found" — an agent branching on verdict
+    would discard the 19 extracted states. INFO + note preserves the useful
+    partial result while the mermaid header/note guards remain honest.
+    True NOT_FOUND is reserved for zero states (class not found at all).
+    """
     src = tmp_path / "static.py"
     src.write_text(
         textwrap.dedent("""\
@@ -535,7 +544,8 @@ def test_state_diagram_zero_transitions_not_found(tmp_path: Path) -> None:
 
     exporter = UMLExporter(str(tmp_path))
     diagram = exporter.state_diagram(class_name="Status", file_path=str(src))
-    assert diagram.metadata.get("verdict") == "NOT_FOUND"
+    # RE-PINNED: was NOT_FOUND, now INFO (states found, no transitions)
+    assert diagram.metadata.get("verdict") == "INFO"
     assert "next_step" in diagram.metadata
 
 
@@ -949,15 +959,19 @@ def test_uml_max_nodes_cli_mcp_default_parity() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Section J: P3a — NOT_FOUND mermaid suppresses [*] --> lines
+# Section J: P3a — INFO (zero-transitions) mermaid suppresses [*] --> lines
+# RE-PINNED: was NOT_FOUND, now INFO (#480 fix — states found, no transitions
+# is a partial result, not "not found").
 # ---------------------------------------------------------------------------
 
 
-def test_not_found_state_diagram_no_initial_edges(tmp_path: Path) -> None:
-    """NOT_FOUND state diagram mermaid must NOT contain '[*] -->' lines.
+def test_info_zero_transition_state_diagram_no_initial_edges(tmp_path: Path) -> None:
+    """INFO (zero-transition) state diagram mermaid must NOT contain '[*] -->' lines.
 
-    An agent reading only mermaid would see a structurally-valid diagram if
-    initial-state edges were emitted; the %% NOTE guard must be present instead.
+    RE-PINNED from NOT_FOUND → INFO (#480): the mermaid honesty rule (suppress
+    initial-state lines when no transitions detected) is preserved. The %% NOTE
+    guard must still be present. An agent reading only mermaid still sees an
+    honest "no transitions detected" note rather than a fake diagram.
     """
     src = tmp_path / "static.py"
     src.write_text(
@@ -975,16 +989,21 @@ def test_not_found_state_diagram_no_initial_edges(tmp_path: Path) -> None:
     exporter = UMLExporter(str(tmp_path))
     diagram = exporter.state_diagram(class_name="Status", file_path=str(src))
 
-    # Verify NOT_FOUND verdict
-    assert diagram.metadata.get("verdict") == "NOT_FOUND"
-    # Must contain the honesty NOTE guard
+    # RE-PINNED: was NOT_FOUND, now INFO (states found, zero transitions)
+    assert diagram.metadata.get("verdict") == "INFO"
+    # Mermaid honesty guard must still be present
     assert "%% NOTE" in diagram.mermaid
-    # Must NOT contain any initial-state transition lines
+    # Must NOT contain any initial-state transition lines (mermaid suppression preserved)
     assert "[*] -->" not in diagram.mermaid
 
 
-def test_not_found_state_diagram_mermaid_starts_with_header(tmp_path: Path) -> None:
-    """NOT_FOUND mermaid output starts with 'stateDiagram-v2' header."""
+def test_info_zero_transition_state_diagram_mermaid_starts_with_header(
+    tmp_path: Path,
+) -> None:
+    """INFO (zero-transition) mermaid output starts with 'stateDiagram-v2' header.
+
+    RE-PINNED from NOT_FOUND → INFO (#480).
+    """
     src = tmp_path / "static2.py"
     src.write_text(
         textwrap.dedent("""\
@@ -1000,8 +1019,47 @@ def test_not_found_state_diagram_mermaid_starts_with_header(tmp_path: Path) -> N
     exporter = UMLExporter(str(tmp_path))
     diagram = exporter.state_diagram(class_name="State", file_path=str(src))
 
-    assert diagram.metadata.get("verdict") == "NOT_FOUND"
+    # RE-PINNED: was NOT_FOUND, now INFO (#480)
+    assert diagram.metadata.get("verdict") == "INFO"
     assert diagram.mermaid.startswith("stateDiagram-v2")
+
+
+def test_state_diagram_true_not_found_zero_states(tmp_path: Path) -> None:
+    """TRUE NOT_FOUND = zero states: class not found in file at all.
+
+    This pins the contract that NOT_FOUND is only for node_count==0 (#480).
+    A missing class or no enum → verdict=NOT_FOUND.
+    """
+    src = tmp_path / "no_enum.py"
+    src.write_text("class Plain:\n    pass\n")
+
+    from tree_sitter_analyzer.uml_export import UMLExporter
+
+    exporter = UMLExporter(str(tmp_path))
+    diagram = exporter.state_diagram(file_path=str(src))
+    assert diagram.metadata.get("verdict") == "NOT_FOUND"
+
+
+def test_state_diagram_non_python_file_not_found_mentions_language(
+    tmp_path: Path,
+) -> None:
+    """Non-Python file (TypeScript) → NOT_FOUND with language coverage note (#480).
+
+    State extraction is Python-only. A bare NOT_FOUND on a .ts file reads as
+    a bug, not a scope limit. The next_step must mention language support or
+    Python scope.
+    """
+    ts_file = tmp_path / "State.ts"
+    ts_file.write_text("enum UserRole { Admin = 'admin', User = 'user' }\n")
+
+    from tree_sitter_analyzer.uml_export import UMLExporter
+
+    exporter = UMLExporter(str(tmp_path))
+    diagram = exporter.state_diagram(file_path=str(ts_file))
+    assert diagram.metadata.get("verdict") == "NOT_FOUND"
+    next_step = diagram.metadata.get("next_step", "")
+    # Must mention Python-only scope or language limitation
+    assert "python" in next_step.lower() or "language" in next_step.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tree_sitter_analyzer/uml_export.py
+++ b/tree_sitter_analyzer/uml_export.py
@@ -306,6 +306,69 @@ class UMLExporter:
 
         return ASTCache(self.project_root), True
 
+    def _resolve_function_file(self, function_name: str) -> str | None:
+        """Look up *function_name* in the AST index and return a unique file path.
+
+        Returns:
+            Absolute path string if exactly one match; ``None`` otherwise
+            (not found OR ambiguous — caller handles both via
+            ``_activity_not_found_no_file``).
+
+        Stores the search results on ``self._last_activity_index_hits`` so that
+        ``_activity_not_found_no_file`` can compose a richer message without a
+        second query.
+        """
+        cache, should_close = self._open_cache()
+        try:
+            hits = cache.search_symbols(function_name)
+        finally:
+            if should_close:
+                cache.close()
+        # Filter to exact name matches with a file (avoid partial BM25 hits)
+        exact = [h for h in hits if h.get("name") == function_name and h.get("file")]
+        self._last_activity_index_hits: list[dict[str, Any]] = exact
+        if len(exact) == 1:
+            raw = exact[0]["file"]
+            p = Path(raw)
+            return str(p) if p.is_absolute() else str(Path(self.project_root) / raw)
+        return None
+
+    def _activity_not_found_no_file(self, function_name: str) -> UMLDiagram:
+        """Return a descriptive NOT_FOUND when index lookup for *function_name* fails.
+
+        Distinguishes three cases:
+        - not in index at all
+        - ambiguous (multiple files) — lists candidate files
+        """
+        hits: list[dict[str, Any]] = getattr(self, "_last_activity_index_hits", [])
+        if not hits:
+            next_step = (
+                f"activity diagram: '{function_name}' not found in the index; "
+                "verify the project is indexed and the function name is correct, "
+                "or supply --uml-file-path / file_path directly"
+            )
+        else:
+            # Ambiguous: list candidate files (max 5 for brevity)
+            candidates = [h.get("file", "") for h in hits[:5]]
+            cand_list = ", ".join(f"'{c}'" for c in candidates)
+            next_step = (
+                f"activity diagram: '{function_name}' found in multiple files "
+                f"({cand_list}{'...' if len(hits) > 5 else ''}); "
+                "pass file_path to select the correct one"
+            )
+        return UMLDiagram(
+            diagram_type="activity",
+            mermaid_type="flowchart",
+            mermaid="flowchart TD\n",
+            nodes=[],
+            edges=[],
+            metadata={
+                "diagram_type": "activity",
+                "verdict": "NOT_FOUND",
+                "next_step": next_step,
+            },
+        )
+
     def class_diagram(
         self,
         max_edges: int = 80,
@@ -546,22 +609,15 @@ class UMLExporter:
                 resolved_path = str(Path(self.project_root) / p)
 
         if resolved_path is None:
-            # No file_path given: NOT_FOUND — require file_path for activity
-            return UMLDiagram(
-                diagram_type="activity",
-                mermaid_type="flowchart",
-                mermaid="flowchart TD\n",
-                nodes=[],
-                edges=[],
-                metadata={
-                    "diagram_type": "activity",
-                    "verdict": "NOT_FOUND",
-                    "next_step": (
-                        "activity diagram requires file_path to locate the function; "
-                        "provide the source file path"
-                    ),
-                },
-            )
+            # No file_path given: attempt to resolve via the AST index (#477 STRONG).
+            # Look up function_name in the index to distinguish:
+            #   a) unique hit  → resolve file and proceed
+            #   b) ambiguous   → NOT_FOUND with candidate file list
+            #   c) not in index → NOT_FOUND with "not found in index" message
+            resolved_path = self._resolve_function_file(function_name)
+            if resolved_path is None:
+                # Index lookup failed — return descriptive NOT_FOUND
+                return self._activity_not_found_no_file(function_name)
 
         cfg = build_activity_cfg(function_name, resolved_path, max_nodes)
 
@@ -689,11 +745,13 @@ class UMLExporter:
         Static approximation: enum members become states; match/case patterns
         with return <Enum>.<Member> become transitions.
 
-        Honesty rules:
+        Honesty rules (#480 update):
         - metadata["analysis_kind"] == "static_approximation" always.
         - metadata["note"] records that parsing is done from current file content.
-        - zero detected transitions → verdict="NOT_FOUND" with next_step.
-        - missing file / class → verdict="NOT_FOUND" with next_step.
+        - states found, zero transitions → verdict="INFO" with next_step note
+          (partial result — enum members extracted but FSM pattern not recognised).
+        - zero states (class missing / no enum found / file absent) → verdict="NOT_FOUND".
+        - Language coverage: Python-only; non-Python files emit a language note.
 
         Cost: ONE disk read + ONE tree-sitter parse (rule-11 invariant).
         """
@@ -753,6 +811,13 @@ class UMLExporter:
                 },
             )
 
+        # Language coverage: state extraction is Python-only (#480).
+        # Non-Python files (e.g. .ts, .java) will fail the no-enum check below,
+        # but the message should explain the scope limit, not just say "check
+        # for an Enum subclass" (which is meaningless for TypeScript).
+        _py_extensions = {".py", ".pyw"}
+        _file_is_python = Path(resolved_path).suffix.lower() in _py_extensions
+
         result = build_state_result(
             file_path=resolved_path,
             class_name=class_name,
@@ -768,6 +833,17 @@ class UMLExporter:
         base_metadata["file_path"] = resolved_path
 
         if result.error:
+            if not _file_is_python:
+                next_step_msg = (
+                    f"state diagram: state extraction supports Python only; "
+                    f"'{Path(resolved_path).name}' is not a Python file. "
+                    "Pass a .py file that contains an Enum subclass."
+                )
+            else:
+                next_step_msg = (
+                    f"state diagram: {result.error}; "
+                    "check that the file exists and contains an Enum subclass"
+                )
             return UMLDiagram(
                 diagram_type="state",
                 mermaid_type="stateDiagram-v2",
@@ -777,19 +853,18 @@ class UMLExporter:
                 metadata={
                     **base_metadata,
                     "verdict": "NOT_FOUND",
-                    "next_step": (
-                        f"state diagram: {result.error}; "
-                        "check that the file exists and contains an Enum subclass"
-                    ),
+                    "next_step": next_step_msg,
                 },
             )
 
-        # Zero transitions → NOT_FOUND (honesty rule from RFC-0015 §P2-B).
-        # Suppress [*] --> X initial-state lines in the NOT_FOUND mermaid output:
-        # an agent reading only `mermaid` would see a structurally-valid diagram
-        # and might not check metadata.verdict — emit only the header + NOTE guard.
+        # Zero transitions but states found → INFO (#480 fix).
+        # A partial result (states extracted, FSM pattern not recognised) is not
+        # "not found". Use INFO so agents can consume the extracted enum members.
+        # The mermaid [*]--> lines are still suppressed (mermaid honesty rule):
+        # an agent reading only `mermaid` would see a structurally-valid diagram;
+        # emitting only the header + NOTE guard keeps the mermaid honest.
         if not result.transitions:
-            not_found_mermaid = (
+            info_mermaid = (
                 "stateDiagram-v2\n"
                 "%% NOTE: state diagram is a static approximation.\n"
                 "%% Guard conditions, timers, and exception-driven transitions are not captured.\n"
@@ -798,14 +873,15 @@ class UMLExporter:
             return UMLDiagram(
                 diagram_type="state",
                 mermaid_type="stateDiagram-v2",
-                mermaid=not_found_mermaid,
+                mermaid=info_mermaid,
                 nodes=result.states,
                 edges=[],
                 metadata={
                     **base_metadata,
-                    "verdict": "NOT_FOUND",
+                    "verdict": "INFO",
                     "next_step": (
-                        "state diagram found no enum members or match-pattern transitions; "
+                        f"state diagram: {len(result.states)} enum member(s) extracted "
+                        "as states but no match-pattern transitions were found; "
                         "the class may not encode a finite-state machine in a pattern "
                         "this heuristic recognises"
                     ),

--- a/tree_sitter_analyzer/uml_export.py
+++ b/tree_sitter_analyzer/uml_export.py
@@ -324,8 +324,20 @@ class UMLExporter:
         finally:
             if should_close:
                 cache.close()
-        # Filter to exact name matches with a file (avoid partial BM25 hits)
-        exact = [h for h in hits if h.get("name") == function_name and h.get("file")]
+        # Filter to exact name matches with a file (avoid partial BM25 hits).
+        # Python-only (Codex P2 on #498): the CFG builder is Python-only, so a
+        # same-name JS/Go symbol must not make the lookup "ambiguous" — and a
+        # JS-only hit must not be offered as a CFG target. Also restrict to
+        # function-like kinds so a same-name class/variable doesn't collide.
+        _FUNC_KINDS = {"function", "method", None, ""}
+        exact = [
+            h
+            for h in hits
+            if h.get("name") == function_name
+            and h.get("file")
+            and (h.get("language") or "python") == "python"
+            and (h.get("kind") in _FUNC_KINDS)
+        ]
         self._last_activity_index_hits: list[dict[str, Any]] = exact
         if len(exact) == 1:
             raw = exact[0]["file"]


### PR DESCRIPTION
Closes #477. Closes #480.

## #477 (STRONG option)
Activity without file_path now resolves the function via ASTCache.search_symbols (sub-ms): unique index hit → resolve file and build CFG on the first call. Distinguished NOT_FOUNDs: "not in the index — verify or supply file_path" vs ambiguous-hit guidance. Dogfood: `apply_toon_format_to_response` without file_path went NOT_FOUND/0 → **INFO/10-node CFG**.

## #480
- 19 extracted states + 0 transitions → **INFO** (canonical verdict, partial result is not "not found") + count-aware next_step; mermaid honesty guard preserved; NOT_FOUND reserved for zero states
- Language coverage disclosed: non-Python file → "state extraction supports Python only; X is not a Python file"
- RFC-0015 zero-transition tests consciously re-pinned (rationale in diff: the honesty rule's intent was don't-fake-the-diagram — mermaid suppression handles that; verdict upgrade is compatible)

## Tests
7 RED-first + 4 conscious re-pins; 286/286 green; uml_export.py coverage 99.62%; ruff clean.