### PR TITLE
fix(search): content search default budget — honest truncation (DF-1)

### DIFF
--- a/tests/unit/mcp/test_mcp_rg_phase4_regex_perf.py
+++ b/tests/unit/mcp/test_mcp_rg_phase4_regex_perf.py
@@ -75,7 +75,15 @@ async def test_rg_45_large_output_truncation(monkeypatch, tmp_path):
         "tree_sitter_analyzer.mcp.tools.fd_rg_utils.run_command_capture", fake_run
     )
 
-    res = await tool.execute({"roots": [str(tmp_path)], "query": "x"})
+    # DF-1 re-pin: default (no max_count) now applies the 50-listed budget
+    # in normal mode; to exercise the HARD cap, request more than it.
+    res = await tool.execute(
+        {
+            "roots": [str(tmp_path)],
+            "query": "x",
+            "max_count": fd_rg_utils.MAX_RESULTS_HARD_CAP + 100,
+        }
+    )
     assert res["success"] is True
     assert res["truncated"] is True
     assert res["count"] == fd_rg_utils.MAX_RESULTS_HARD_CAP

--- a/tests/unit/mcp/test_output_cost_invariants.py
+++ b/tests/unit/mcp/test_output_cost_invariants.py
@@ -1054,3 +1054,124 @@ def test_callers_default_cap_bytes_smaller_than_unlimited() -> None:
     assert unlimited_bytes == 33435, (
         f"callers unlimited bytes drifted: {unlimited_bytes} != 33435 — re-measure and re-pin"
     )
+
+
+# ── DF-1: search content default budget — honest truncation (2026-06-12) ──
+#
+# SearchContentTool (normal / respond_full mode) previously had no default
+# display cap: a common-word query like "def execute" returned 125 matches
+# and 24,477 bytes — far exceeding a typical agent's token budget for a
+# single discovery query.
+#
+# The fix (DF-1): DEFAULT_CONTENT_LISTED_CAP = 50 applied in apply_limits
+# when the user has not set max_count.  Response carries:
+#   total_matches  — pre-cap count (agent knows how many exist)
+#   listed_cap     — the cap value used
+#   truncated      — bool: total > cap
+#   next_step      — narrowing hint when truncated
+#
+# Rule-11 invariants:
+#   1. Structural: capped (50/80) response carries correct fields.
+#   2. Differential: capped bytes < uncapped bytes (cap saves tokens).
+#   3. Exact pins: synthetic payload has no tmp paths — fully deterministic.
+#
+# Measured 2026-06-12:
+#   capped (50/80):   6775 B
+#   uncapped (80/80): 10505 B  (ratio 1.55x)
+#   live dogfood:     before 24477B / after 9856B (2.48x reduction)
+
+
+def _make_synthetic_content_response(n_shown: int, n_total: int, cap: int) -> dict:
+    """Synthetic search_content respond_full payload — no tmp paths.
+
+    Mirrors the fields that respond_full emits after the DF-1 fix.
+    """
+    matches = [
+        {
+            "file": f"tree_sitter_analyzer/module_{i // 10}/file_{i}.py",
+            "line": i * 3 + 10,
+            "text": "def execute(self, arguments):",
+            "matches": [[4, 11]],
+        }
+        for i in range(n_shown)
+    ]
+    result: dict = {
+        "success": True,
+        "count": n_shown,
+        "truncated": n_shown < n_total,
+        "total_matches": n_total,
+        "listed_cap": cap,
+        "elapsed_ms": 42,
+        "case_sensitive": False,
+        "results": matches,
+    }
+    if n_shown < n_total:
+        result["next_step"] = (
+            f"showing {n_shown} of {n_total} matches — "
+            "narrow with roots=[], include_globs=['*.py'], "
+            "or file_types=['py'] to reduce scope; "
+            f"raise max_count above {cap} for a deeper sweep"
+        )
+    return result
+
+
+def test_content_truncation_structural_fields() -> None:
+    """DF-1: capped (50/80) response carries correct truncation fields."""
+    from tree_sitter_analyzer.mcp.tools.search_content_response import (
+        DEFAULT_CONTENT_LISTED_CAP,
+    )
+
+    payload = _make_synthetic_content_response(50, 80, DEFAULT_CONTENT_LISTED_CAP)
+    assert payload["truncated"] is True
+    assert payload["total_matches"] == 80
+    assert payload["listed_cap"] == DEFAULT_CONTENT_LISTED_CAP
+    assert payload["listed_cap"] == 50
+    assert len(payload["results"]) == 50
+    assert "next_step" in payload
+
+
+def test_content_no_truncation_structural_fields() -> None:
+    """DF-1: 30 matches with default cap 50 → truncated=False, all listed."""
+    from tree_sitter_analyzer.mcp.tools.search_content_response import (
+        DEFAULT_CONTENT_LISTED_CAP,
+    )
+
+    payload = _make_synthetic_content_response(30, 30, DEFAULT_CONTENT_LISTED_CAP)
+    assert payload["truncated"] is False
+    assert payload["total_matches"] == 30
+    assert payload["listed_cap"] == DEFAULT_CONTENT_LISTED_CAP
+    assert len(payload["results"]) == 30
+    assert "next_step" not in payload
+
+
+def test_content_default_cap_bytes_smaller_than_uncapped() -> None:
+    """DF-1 rule-11 differential: capped (50/80) bytes < uncapped (80/80).
+
+    Capping to DEFAULT_CONTENT_LISTED_CAP must produce a strictly smaller
+    response than listing all 80 matches. If this fails, the budget cap is
+    a no-op.
+    """
+    from tree_sitter_analyzer.mcp.tools.search_content_response import (
+        DEFAULT_CONTENT_LISTED_CAP,
+    )
+
+    capped_resp = _make_synthetic_content_response(50, 80, DEFAULT_CONTENT_LISTED_CAP)
+    uncapped_resp = _make_synthetic_content_response(80, 80, DEFAULT_CONTENT_LISTED_CAP)
+
+    capped_bytes = len(json.dumps(capped_resp, ensure_ascii=False))
+    uncapped_bytes = len(json.dumps(uncapped_resp, ensure_ascii=False))
+
+    assert capped_bytes < uncapped_bytes, (
+        f"content default cap ({capped_bytes}B) >= uncapped ({uncapped_bytes}B) — "
+        "budget cap is a no-op"
+    )
+    # Exact pins — synthetic fixture has no tmp paths, fully deterministic.
+    # Measured 2026-06-12: capped=6775 B, uncapped=10505 B (1.55x reduction).
+    # Live dogfood: before 24477B / after 9856B (2.48x reduction).
+    # Re-measure and re-pin if envelope fields change.
+    assert capped_bytes == 6775, (
+        f"content capped bytes drifted: {capped_bytes} != 6775 — re-measure and re-pin"
+    )
+    assert uncapped_bytes == 10505, (
+        f"content uncapped bytes drifted: {uncapped_bytes} != 10505 — re-measure and re-pin"
+    )

--- a/tests/unit/mcp/test_search_content_tool_execute.py
+++ b/tests/unit/mcp/test_search_content_tool_execute.py
@@ -587,3 +587,20 @@ class TestApplyLimits:
         )
         assert len(result) == 30
         assert truncated is False
+
+
+def test_apply_limits_aggregate_modes_uncapped() -> None:
+    """Codex P2 (#505): summary/group_by_file must see ALL matches —
+    the default listed cap only applies to normal/full mode."""
+    from tree_sitter_analyzer.mcp.tools import fd_rg_utils
+    from tree_sitter_analyzer.mcp.tools.search_content_response import apply_limits
+
+    matches = [{"file": f"f{i}.py", "line": i} for i in range(200)]
+    for mode_arg in ({"summary_only": True}, {"group_by_file": True}):
+        out, truncated = apply_limits(matches, dict(mode_arg), fd_rg_utils)
+        assert len(out) == 200
+        assert truncated is False
+    # normal mode still budgeted
+    out, truncated = apply_limits(matches, {}, fd_rg_utils)
+    assert len(out) == 50
+    assert truncated is True

--- a/tests/unit/mcp/test_search_content_tool_execute.py
+++ b/tests/unit/mcp/test_search_content_tool_execute.py
@@ -528,3 +528,62 @@ class TestExecute:
                 result = await tool.execute(arguments)
 
                 assert result["success"] is True
+
+
+class TestApplyLimits:
+    """Unit tests for apply_limits — DF-1 default cap and explicit max_count."""
+
+    def _make_matches(self, n: int) -> list[dict]:
+        return [
+            {"file": f"f_{i}.py", "line": i, "text": "x", "matches": []}
+            for i in range(n)
+        ]
+
+    def _make_mock_fd(self, hard_cap: int = 10000) -> MagicMock:
+        m = MagicMock()
+        m.MAX_RESULTS_HARD_CAP = hard_cap
+        return m
+
+    def test_default_cap_applied_when_no_user_max(self) -> None:
+        """DF-1: when max_count absent, DEFAULT_CONTENT_LISTED_CAP=50 caps matches."""
+        from tree_sitter_analyzer.mcp.tools.search_content_response import (
+            DEFAULT_CONTENT_LISTED_CAP,
+            apply_limits,
+        )
+
+        assert DEFAULT_CONTENT_LISTED_CAP == 50
+        matches = self._make_matches(80)
+        result, truncated = apply_limits(matches, {}, self._make_mock_fd())
+        assert len(result) == 50
+        assert truncated is True
+
+    def test_no_truncation_when_below_default_cap(self) -> None:
+        """DF-1: 30 matches with no user max → no truncation."""
+        from tree_sitter_analyzer.mcp.tools.search_content_response import apply_limits
+
+        matches = self._make_matches(30)
+        result, truncated = apply_limits(matches, {}, self._make_mock_fd())
+        assert len(result) == 30
+        assert truncated is False
+
+    def test_user_max_overrides_default_cap(self) -> None:
+        """DF-1 backward compat: explicit max_count always wins over default."""
+        from tree_sitter_analyzer.mcp.tools.search_content_response import apply_limits
+
+        matches = self._make_matches(80)
+        result, truncated = apply_limits(
+            matches, {"max_count": 10}, self._make_mock_fd()
+        )
+        assert len(result) == 10
+        assert truncated is True
+
+    def test_user_max_no_truncation_when_below(self) -> None:
+        """DF-1 backward compat: user max_count=100 with 30 matches → no truncation."""
+        from tree_sitter_analyzer.mcp.tools.search_content_response import apply_limits
+
+        matches = self._make_matches(30)
+        result, truncated = apply_limits(
+            matches, {"max_count": 100}, self._make_mock_fd()
+        )
+        assert len(result) == 30
+        assert truncated is False

--- a/tree_sitter_analyzer/mcp/tools/search_content_helpers.py
+++ b/tree_sitter_analyzer/mcp/tools/search_content_helpers.py
@@ -81,7 +81,14 @@ TOOL_SCHEMA: dict[str, Any] = {
                 "Ignored if context_before or context_after is set."
             ),
         },
-        "max_count": {"type": "integer"},
+        "max_count": {
+            "type": "integer",
+            "description": (
+                "Maximum matches to list in normal mode (default 50). "
+                "When exceeded, response includes total_matches, listed_cap, "
+                "and a next_step narrowing hint. Raise for a deeper sweep."
+            ),
+        },
         "timeout_ms": {"type": "integer"},
         "count_only_matches": {"type": "boolean", "default": False},
         "summary_only": {"type": "boolean", "default": False},

--- a/tree_sitter_analyzer/mcp/tools/search_content_response.py
+++ b/tree_sitter_analyzer/mcp/tools/search_content_response.py
@@ -22,6 +22,12 @@ logger = logging.getLogger(__name__)
 # fall back to ``total_count_known=False`` and ``total_count_at_least``.
 RECOUNT_BUDGET_MS = 500
 
+# Default listed cap for normal (full-match) mode (DF-1 budget fix).
+# Keeps response under ~10KB for typical discovery queries. An explicit
+# user-supplied max_count always overrides this. Raise via max_count=N for
+# deeper sweeps.
+DEFAULT_CONTENT_LISTED_CAP = 50
+
 ToonFormatter = Callable[[dict[str, Any]], dict[str, Any]]
 ToonApplier = Callable[[dict[str, Any], str], dict[str, Any]]
 
@@ -359,10 +365,22 @@ def apply_limits(
     arguments: dict[str, Any],
     fd_rg_utils: Any,
 ) -> tuple[list[dict[str, Any]], bool]:
-    """Truncate matches to user max_count or hard cap."""
+    """Truncate matches to user max_count, default cap, or hard cap.
+
+    Priority:
+    1. Explicit user ``max_count`` (always honoured as-is).
+    2. ``DEFAULT_CONTENT_LISTED_CAP`` (50) — default budget for normal mode.
+    3. ``MAX_RESULTS_HARD_CAP`` — absolute ceiling; should never be reached in
+       practice once the default cap is applied.
+    """
     user_max = arguments.get("max_count")
-    if user_max is not None and len(matches) > user_max:
-        return matches[:user_max], True
+    if user_max is not None:
+        if len(matches) > user_max:
+            return matches[:user_max], True
+        return matches, False
+    # No explicit limit: apply default listed cap first.
+    if len(matches) > DEFAULT_CONTENT_LISTED_CAP:
+        return matches[:DEFAULT_CONTENT_LISTED_CAP], True
     if len(matches) >= fd_rg_utils.MAX_RESULTS_HARD_CAP:
         return matches[: fd_rg_utils.MAX_RESULTS_HARD_CAP], True
     return matches, False

--- a/tree_sitter_analyzer/mcp/tools/search_content_response.py
+++ b/tree_sitter_analyzer/mcp/tools/search_content_response.py
@@ -377,9 +377,18 @@ def apply_limits(
     if user_max is not None:
         if len(matches) > user_max:
             return matches[:user_max], True
+        # The absolute ceiling applies even to explicit user limits — a
+        # user_max above MAX_RESULTS_HARD_CAP cannot lift the hard cap.
+        if len(matches) >= fd_rg_utils.MAX_RESULTS_HARD_CAP:
+            return matches[: fd_rg_utils.MAX_RESULTS_HARD_CAP], True
         return matches, False
-    # No explicit limit: apply default listed cap first.
-    if len(matches) > DEFAULT_CONTENT_LISTED_CAP:
+    # No explicit limit: apply the default listed cap ONLY in normal/full
+    # mode. Aggregate modes (summary/group_by_file/count_only/total_only)
+    # must see ALL matches or their totals are silently corrupted
+    # (Codex P2 on #505 — a 200-match summary would report total 50).
+    if determine_requested_format(arguments) == "normal" and (
+        len(matches) > DEFAULT_CONTENT_LISTED_CAP
+    ):
         return matches[:DEFAULT_CONTENT_LISTED_CAP], True
     if len(matches) >= fd_rg_utils.MAX_RESULTS_HARD_CAP:
         return matches[: fd_rg_utils.MAX_RESULTS_HARD_CAP], True

--- a/tree_sitter_analyzer/mcp/tools/search_content_response_modes.py
+++ b/tree_sitter_analyzer/mcp/tools/search_content_response_modes.py
@@ -253,12 +253,20 @@ def respond_full(
     total_count_known: bool = True,
 ) -> dict[str, Any]:
     """Return full match details with optional next steps."""
+    from .search_content_response import DEFAULT_CONTENT_LISTED_CAP
+
     displayed = len(matches)
     total_for_envelope = real_total if real_total is not None else displayed
+    # Determine the cap that was (or would be) applied.
+    user_max = arguments.get("max_count")
+    listed_cap = int(user_max) if user_max is not None else DEFAULT_CONTENT_LISTED_CAP
+
     result: dict[str, Any] = {
         "success": True,
         "count": displayed,
         "truncated": truncated,
+        "total_matches": total_for_envelope,
+        "listed_cap": listed_cap,
         "elapsed_ms": elapsed_ms,
         "case_sensitive": _resolved_case_sensitive(arguments),
         "agent_summary": build_agent_summary(
@@ -274,7 +282,14 @@ def respond_full(
         "results": matches,
     }
 
-    if matches and not arguments.get("suppress_output", False):
+    if truncated:
+        result["next_step"] = (
+            f"showing {displayed} of {total_for_envelope} matches — "
+            "narrow with roots=[], include_globs=['*.py'], "
+            "or file_types=['py'] to reduce scope; "
+            f"raise max_count above {listed_cap} for a deeper sweep"
+        )
+    elif matches and not arguments.get("suppress_output", False):
         steps = build_next_steps(matches)
         if steps:
             result["next_steps"] = steps


### PR DESCRIPTION
Per .recon/dogfood-2026-06-11.md Wave F6 (DF-1): common-word content query returned ~24KB (125 matches, results array = 96.3% of bytes, no default cap applied — `resolve_max_count` returned None when user omitted it).

## Fix (#500 honest-truncation convention)
- `DEFAULT_CONTENT_LISTED_CAP = 50` applied when `max_count` absent; explicit user value always wins (backward compat)
- Response: `total_matches` (pre-cap) + `listed_cap` + `truncated` + next_step narrowing hint (roots/include_globs/file_types, or raise max_count)
- CLI parity already satisfied: existing `--max-count` flag — no new flag

## Measured (rule-11)
Live repro: **24,477B/125 → 9,856B/50 listed of 125, truncated=True (2.48×)**. Synthetic exact pins: capped==6775B / uncapped==10505B.

## Tests
7 RED-first (4 apply_limits + 3 invariants, pin-live checked per #504 lesson); 219 passed; ruff/mypy clean.