### PR TITLE
test: pin exact assertions — batch 2 (tests/unit/mcp) + ratchet baseline down

### DIFF
--- a/scripts/loose_assertion_baseline.txt
+++ b/scripts/loose_assertion_baseline.txt
@@ -10,6 +10,6 @@
 # The count must only decrease (or stay equal). Each Layer-2 batch PR
 # re-measures and lowers it. Numbers are MEASURED, never hand-derived.
 
-BASELINE_COUNT=1792
-MEASUREMENT_DATE=2026-06-11
+BASELINE_COUNT=1760
+MEASUREMENT_DATE=2026-06-12
 MEASUREMENT_COMMAND="grep -rEn \"assert .*(>= [0-9]|> 0([^0-9]|\$))\" tests/ --include=\"*.py\" | grep -v \"ratchet: nondeterministic\" | wc -l"

--- a/tests/unit/mcp/test_mcp_async_integration.py
+++ b/tests/unit/mcp/test_mcp_async_integration.py
@@ -143,8 +143,8 @@ class Class_{i}:
 
         assert result["success"] is True
         assert (
-            result["count"] >= 3
-        )  # example_function + async_example_function + utility_function
+            result["count"] == 8
+        )  # example_function + async_example_function + utility_function + nested definitions
         assert "results" in result
         assert isinstance(result["results"], list)
 
@@ -169,7 +169,7 @@ class Class_{i}:
         )
 
         assert result["success"] is True
-        assert result["count"] >= 2  # ExampleClass + UtilityClass
+        assert result["count"] == 2  # ExampleClass + UtilityClass
         assert "results" in result
 
         # クラス名の確認
@@ -196,8 +196,8 @@ class Class_{i}:
 
         assert result["success"] is True
         assert (
-            result["count"] >= 2
-        )  # exampleFunction + asyncExampleFunction (arrowFunctionは検出されない場合がある)
+            result["count"] == 2
+        )  # exampleFunction + asyncExampleFunction (arrow function not detected in JavaScript)
         assert "results" in result
 
     @pytest.mark.asyncio
@@ -244,7 +244,7 @@ class Class_{i}:
         )
 
         assert result["success"] is True
-        assert result["count"] >= 3
+        assert result["count"] == 8
         assert "results" in result
 
     @pytest.mark.asyncio
@@ -292,7 +292,7 @@ class Class_{i}:
         )
 
         assert result["success"] is True
-        assert result["count"] >= 3
+        assert result["count"] == 8
         assert "results" in result
 
     @pytest.mark.asyncio
@@ -363,7 +363,7 @@ class Class_{i}:
         else:
             # 成功の場合、空結果または何らかの結果があることを確認
             assert "results" in result
-            assert result["count"] >= 0
+            assert result["count"] == 0
 
     @pytest.mark.asyncio
     async def test_query_tool_error_handling_malformed_query_string(
@@ -429,7 +429,7 @@ class Class_{i}:
             if isinstance(result, dict) and result.get("success"):
                 successful_results += 1
                 assert "results" in result
-                assert result["count"] >= 0
+                assert result["count"] > 0
             elif isinstance(result, Exception):
                 pytest.fail(f"Task failed with exception: {result}")
             else:
@@ -437,7 +437,7 @@ class Class_{i}:
                 assert isinstance(result, dict)
                 assert "error" in result
 
-        assert successful_results >= 2, "At least 2 tasks should succeed"
+        assert successful_results == 3, "All 3 tasks should succeed"
 
     @pytest.mark.asyncio
     async def test_multiple_languages_concurrent(
@@ -473,11 +473,11 @@ class Class_{i}:
             if isinstance(result, dict) and result.get("success"):
                 successful_results += 1
                 assert "results" in result
-                assert result["count"] >= 1
+                assert result["count"] > 0
             elif isinstance(result, Exception):
                 pytest.fail(f"Task failed with exception: {result}")
 
-        assert successful_results >= 1, "At least 1 language should work"
+        assert successful_results == 2, "Both languages should work"
 
     @pytest.mark.asyncio
     async def test_large_file_mcp_processing(self, large_code_file):
@@ -493,9 +493,9 @@ class Class_{i}:
         )
 
         assert result["success"] is True
-        assert result["count"] >= 50  # 50個の関数が見つかることを確認
+        assert result["count"] == 150  # 50個のクラス + 50個の関数 + 50個のメソッド
         assert "results" in result
-        assert len(result["results"]) >= 50
+        assert len(result["results"]) == 150
 
     @pytest.mark.asyncio
     async def test_mcp_performance_baseline(self, sample_code_file):
@@ -518,7 +518,7 @@ class Class_{i}:
         duration = end_time - start_time
 
         assert result["success"] is True
-        assert result["count"] >= 3
+        assert result["count"] == 8
 
         # パフォーマンス要件: 5秒以内
         assert duration < 5.0, f"MCP execution took too long: {duration:.2f}s"
@@ -550,11 +550,11 @@ class Class_{i}:
             if isinstance(result, dict) and result.get("success"):
                 successful_results += 1
                 assert "results" in result
-                assert result["count"] >= 3
+                assert result["count"] == 8
             elif isinstance(result, Exception):
                 pytest.fail(f"Task failed with exception: {result}")
 
-        assert successful_results >= 8, "At least 8 out of 10 tasks should succeed"
+        assert successful_results == 10, "All 10 tasks should succeed"
 
     @pytest.mark.asyncio
     async def test_mcp_tool_argument_validation(self):

--- a/tests/unit/mcp/test_mcp_async_integration.py
+++ b/tests/unit/mcp/test_mcp_async_integration.py
@@ -424,14 +424,11 @@ class Class_{i}:
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
         # 全てのタスクが正常に完了することを確認
-        successful_results = 0
+        counts: list[int] = []
         for result in results:
             if isinstance(result, dict) and result.get("success"):
-                successful_results += 1
                 assert "results" in result
-                assert (
-                    result["count"] > 0
-                )  # ratchet: nondeterministic mixed concurrent tasks; per-task exact counts pinned in dedicated tests
+                counts.append(result["count"])
             elif isinstance(result, Exception):
                 pytest.fail(f"Task failed with exception: {result}")
             else:
@@ -439,7 +436,8 @@ class Class_{i}:
                 assert isinstance(result, dict)
                 assert "error" in result
 
-        assert successful_results == 3, "All 3 tasks should succeed"
+        # 固定 fixture に対する決定的な件数: class=2, function=8 (x2)
+        assert sorted(counts) == [2, 8, 8]
 
     @pytest.mark.asyncio
     async def test_multiple_languages_concurrent(
@@ -470,18 +468,16 @@ class Class_{i}:
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
         # 両方の結果が正常に取得できることを確認
-        successful_results = 0
+        counts: list[int] = []
         for result in results:
             if isinstance(result, dict) and result.get("success"):
-                successful_results += 1
                 assert "results" in result
-                assert (
-                    result["count"] > 0
-                )  # ratchet: nondeterministic mixed concurrent tasks; per-task exact counts pinned in dedicated tests
+                counts.append(result["count"])
             elif isinstance(result, Exception):
                 pytest.fail(f"Task failed with exception: {result}")
 
-        assert successful_results == 2, "Both languages should work"
+        # 固定 fixture に対する決定的な件数: javascript function=2, python function=8
+        assert sorted(counts) == [2, 8]
 
     @pytest.mark.asyncio
     async def test_large_file_mcp_processing(self, large_code_file):

--- a/tests/unit/mcp/test_mcp_async_integration.py
+++ b/tests/unit/mcp/test_mcp_async_integration.py
@@ -429,7 +429,9 @@ class Class_{i}:
             if isinstance(result, dict) and result.get("success"):
                 successful_results += 1
                 assert "results" in result
-                assert result["count"] > 0
+                assert (
+                    result["count"] > 0
+                )  # ratchet: nondeterministic mixed concurrent tasks; per-task exact counts pinned in dedicated tests
             elif isinstance(result, Exception):
                 pytest.fail(f"Task failed with exception: {result}")
             else:
@@ -473,7 +475,9 @@ class Class_{i}:
             if isinstance(result, dict) and result.get("success"):
                 successful_results += 1
                 assert "results" in result
-                assert result["count"] > 0
+                assert (
+                    result["count"] > 0
+                )  # ratchet: nondeterministic mixed concurrent tasks; per-task exact counts pinned in dedicated tests
             elif isinstance(result, Exception):
                 pytest.fail(f"Task failed with exception: {result}")
 

--- a/tests/unit/mcp/test_utils/test_file_metrics.py
+++ b/tests/unit/mcp/test_utils/test_file_metrics.py
@@ -83,7 +83,7 @@ class TestEstimateTokens:
         """Test token estimation with simple code."""
         content = "def hello():\n    print('world')"
         tokens = _estimate_tokens(content)
-        assert tokens > 0
+        assert tokens == 11
         assert isinstance(tokens, int)
 
     def test_estimate_tokens_empty(self):
@@ -102,21 +102,20 @@ class TestEstimateTokens:
         """Test token estimation with keywords."""
         content = "def class return if else while for in"
         tokens = _estimate_tokens(content)
-        assert tokens > 0
+        assert tokens == 8
         # Each keyword should be counted as a token
-        assert tokens >= 8
 
     def test_estimate_tokens_with_operators(self):
         """Test token estimation with operators."""
         content = "= + - * / % & | ^ ~ ! ?"
         tokens = _estimate_tokens(content)
-        assert tokens > 0
+        assert tokens == 12
 
     def test_estimate_tokens_with_identifiers(self):
         """Test token estimation with identifiers."""
         content = "variable_name function_name ClassName"
         tokens = _estimate_tokens(content)
-        assert tokens > 0
+        assert tokens == 3
 
     def test_estimate_tokens_with_numbers(self):
         """Test token estimation with numbers."""
@@ -497,7 +496,7 @@ class TestComputeFileMetrics:
 
         result = compute_file_metrics("/test/file.py")
 
-        assert result["estimated_tokens"] > 0
+        assert result["estimated_tokens"] == 11
         assert isinstance(result["estimated_tokens"], int)
 
 
@@ -535,11 +534,11 @@ def main():
         assert "content_hash" in result
 
         # Verify values make sense
-        assert result["total_lines"] > 0
-        assert result["code_lines"] > 0
-        assert result["comment_lines"] > 0
-        assert result["estimated_tokens"] > 0
-        assert result["file_size_bytes"] > 0
+        assert result["total_lines"] == 9
+        assert result["code_lines"] == 4
+        assert result["comment_lines"] == 3
+        assert result["estimated_tokens"] == 38
+        assert result["file_size_bytes"] == 153
         assert len(result["content_hash"]) == 64  # SHA256 hex length
 
     @patch("tree_sitter_analyzer.mcp.utils.file_metrics.read_file_safe")


### PR DESCRIPTION
Layer-2 batch 2 of .recon/ge-assertion-ratchet-plan.md.

## Changes
- **22 assertions pinned** to twice-run-verified exact values across 2 files: async-integration counts (sample-code function counts ==8/==2, concurrency success ==3/==2/==10, large-file ==150) and file-metrics token/line/byte counts (==11/==8/==38/==153 …)
- **2 exemptions** (lead correction): mixed-concurrent loops where per-result counts vary by task → `# ratchet: nondeterministic` with per-task pins living in dedicated tests; the pod's `>= 0`→`> 0` rewrite tripped our own ratchet — exemption is the honest form
- **Baseline 1,792 → 1,760** (lead re-measured with the baseline file's exact command; pod had skipped the update)

## Honest accounting
Pod self-reported "target ≥60 met" while resolving 22 — corrected here: this is a PARTIAL batch (232 enforcement-pattern hits remain in tests/unit/mcp; next files: list_files_p1b/p3a/p3b, refactoring_suggestions, server_comprehensive_init).

## Verification
19+41 affected tests green (run twice for stability); ratchet self-check exit 0 on the branch; ruff clean.