### PR TITLE
test: pin exact assertions — batch 3 (tests/unit/mcp) + ratchet baseline down

### DIFF
--- a/scripts/loose_assertion_baseline.txt
+++ b/scripts/loose_assertion_baseline.txt
@@ -10,6 +10,6 @@
 # The count must only decrease (or stay equal). Each Layer-2 batch PR
 # re-measures and lowers it. Numbers are MEASURED, never hand-derived.
 
-BASELINE_COUNT=1760
+BASELINE_COUNT=1688
 MEASUREMENT_DATE=2026-06-12
 MEASUREMENT_COMMAND="grep -rEn \"assert .*(>= [0-9]|> 0([^0-9]|\$))\" tests/ --include=\"*.py\" | grep -v \"ratchet: nondeterministic\" | wc -l"

--- a/tests/unit/mcp/test_mcp_fd_rg_utils.py
+++ b/tests/unit/mcp/test_mcp_fd_rg_utils.py
@@ -317,7 +317,7 @@ async def test_fd_67_performance_large_dataset(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 50
+    assert result["count"] == 50
 
 
 @pytest.mark.asyncio
@@ -344,7 +344,7 @@ async def test_fd_68_command_timeout_handling(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 0
+    assert result["count"] == 1
 
 
 @pytest.mark.asyncio
@@ -370,8 +370,8 @@ async def test_fd_69_invalid_regex_handling(tmp_path, monkeypatch):
         {"roots": [str(tmp_path)], "pattern": "[invalid_regex"}  # Invalid regex
     )
 
-    # Should handle gracefully
-    assert result["success"] is False or result["count"] >= 0
+    # Should handle gracefully — fd rejects the pattern; success is False, no count field
+    assert result["success"] is False
 
 
 @pytest.mark.asyncio
@@ -399,7 +399,7 @@ async def test_fd_70_memory_usage_optimization(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 20
+    assert result["count"] == 20
 
 
 @pytest.mark.asyncio
@@ -432,7 +432,7 @@ async def test_fd_71_cross_platform_compatibility(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 2  # Should find files regardless of case
+    assert result["count"] == 3  # Should find files regardless of case
 
 
 @pytest.mark.asyncio
@@ -469,7 +469,7 @@ async def test_fd_72_edge_case_patterns(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 3
+    assert result["count"] == 4
 
 
 @pytest.mark.asyncio
@@ -497,7 +497,7 @@ async def test_fd_73_concurrent_execution_safety(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 2
+    assert result["count"] == 2
 
 
 @pytest.mark.asyncio
@@ -523,7 +523,7 @@ async def test_fd_74_resource_cleanup(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 0
+    assert result["count"] == 1
 
 
 @pytest.mark.asyncio
@@ -552,7 +552,7 @@ async def test_fd_85_invalid_utf8_handling(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 0
+    assert result["count"] == 2
 
 
 @pytest.mark.asyncio
@@ -581,7 +581,7 @@ async def test_fd_87_single_and_multithreaded_execution(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 0
+    assert result["count"] == 5
 
 
 @pytest.mark.asyncio
@@ -675,8 +675,8 @@ async def test_fd_90_error_if_hidden_not_set_and_pattern_starts_with_dot(
         {"roots": [str(tmp_path)], "pattern": ".hidden", "hidden": False}
     )
 
-    # Should handle gracefully (may succeed or fail)
-    assert result1["success"] is False or result1["count"] >= 0
+    # Should handle gracefully — fd rejects pattern starting with dot without -H; success is False
+    assert result1["success"] is False
 
     # Test hidden pattern with hidden flag
     result2 = await tool.execute(

--- a/tests/unit/mcp/test_mcp_list_files_p1b_fd_features.py
+++ b/tests/unit/mcp/test_mcp_list_files_p1b_fd_features.py
@@ -51,7 +51,7 @@ async def test_fd_21_glob_searches(tmp_path, monkeypatch):
     )
 
     assert result1["success"] is True
-    assert result1["count"] >= 2
+    assert result1["count"] == 2
 
     # Test glob pattern for test files
     result2 = await tool.execute(
@@ -59,7 +59,7 @@ async def test_fd_21_glob_searches(tmp_path, monkeypatch):
     )
 
     assert result2["success"] is True
-    assert result2["count"] >= 2
+    assert result2["count"] == 2
 
 
 @pytest.mark.asyncio
@@ -107,7 +107,7 @@ async def test_fd_22_full_path_glob_searches(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 0
+    assert result["count"] == 1
 
 
 @pytest.mark.asyncio
@@ -153,7 +153,7 @@ async def test_fd_23_smart_case_glob_searches(tmp_path, monkeypatch):
     )
 
     assert result1["success"] is True
-    assert result1["count"] >= 3
+    assert result1["count"] == 3
 
     # Test smart case glob (uppercase is exact)
     result2 = await tool.execute(
@@ -161,7 +161,7 @@ async def test_fd_23_smart_case_glob_searches(tmp_path, monkeypatch):
     )
 
     assert result2["success"] is True
-    assert result2["count"] >= 1
+    assert result2["count"] == 1
 
 
 @pytest.mark.asyncio
@@ -203,7 +203,7 @@ async def test_fd_24_case_sensitive_glob_searches(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 2
+    assert result["count"] == 2
 
 
 @pytest.mark.asyncio
@@ -252,7 +252,7 @@ async def test_fd_25_glob_searches_with_extension(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 0
+    assert result["count"] == 1
 
 
 @pytest.mark.asyncio
@@ -290,7 +290,7 @@ async def test_fd_29_hidden_files(tmp_path, monkeypatch):
     )
 
     assert result1["success"] is True
-    assert result1["count"] >= 1
+    assert result1["count"] == 1
 
     # Test with hidden files
     result2 = await tool.execute(
@@ -298,7 +298,7 @@ async def test_fd_29_hidden_files(tmp_path, monkeypatch):
     )
 
     assert result2["success"] is True
-    assert result2["count"] >= 4
+    assert result2["count"] == 4
 
 
 @pytest.mark.asyncio
@@ -330,7 +330,7 @@ async def test_fd_30_hidden_file_attribute(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 2
+    assert result["count"] == 2
 
 
 @pytest.mark.asyncio
@@ -389,7 +389,7 @@ async def test_fd_31_type_filtering(tmp_path, monkeypatch):
     )
 
     assert result1["success"] is True
-    assert result1["count"] >= 2
+    assert result1["count"] == 3
 
     # Test directories only
     result2 = await tool.execute(
@@ -397,7 +397,7 @@ async def test_fd_31_type_filtering(tmp_path, monkeypatch):
     )
 
     assert result2["success"] is True
-    assert result2["count"] >= 1
+    assert result2["count"] == 1
 
 
 @pytest.mark.asyncio
@@ -437,4 +437,4 @@ async def test_fd_32_type_executable(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 0  # May be 0 if no executable support
+    assert result["count"] == 1

--- a/tests/unit/mcp/test_mcp_list_files_p3a_path_output.py
+++ b/tests/unit/mcp/test_mcp_list_files_p3a_path_output.py
@@ -55,7 +55,7 @@ async def test_fd_50_symlink_and_full_path(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 0
+    assert result["count"] == 1
 
 
 @pytest.mark.asyncio
@@ -89,7 +89,7 @@ async def test_fd_51_print0_output_simulation(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 2
+    assert result["count"] == 2
     # Verify structured JSON output
     assert "results" in result
     assert isinstance(result["results"], list)
@@ -134,7 +134,7 @@ async def test_fd_52_absolute_path_output(tmp_path, monkeypatch):
     )
 
     assert result1["success"] is True
-    assert result1["count"] >= 3
+    assert result1["count"] == 3
     # Verify absolute paths
     for item in result1["results"]:
         path = item["path"]
@@ -152,7 +152,7 @@ async def test_fd_52_absolute_path_output(tmp_path, monkeypatch):
     )
 
     assert result2["success"] is True
-    assert result2["count"] >= 3
+    assert result2["count"] == 3
 
 
 @pytest.mark.asyncio
@@ -180,7 +180,7 @@ async def test_fd_53_implicit_absolute_path(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 0
+    assert result["count"] == 1
 
 
 @pytest.mark.asyncio
@@ -215,7 +215,7 @@ async def test_fd_54_normalized_absolute_path(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 0
+    assert result["count"] == 1
 
 
 @pytest.mark.asyncio
@@ -249,7 +249,7 @@ async def test_fd_55_custom_path_separator(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 0
+    assert result["count"] == 1
     # Verify proper path separators
     for item in result["results"]:
         path = item["path"]
@@ -286,7 +286,7 @@ async def test_fd_56_base_directory_output(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 0
+    assert result["count"] == 2
 
 
 @pytest.mark.asyncio
@@ -317,7 +317,7 @@ async def test_fd_57_strip_cwd_prefix(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 0
+    assert result["count"] == 1
 
 
 @pytest.mark.asyncio
@@ -350,7 +350,7 @@ async def test_fd_58_format_output_structured(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 2
+    assert result["count"] == 2
     # Verify structured format
     assert "results" in result
     assert "count" in result
@@ -385,7 +385,7 @@ async def test_fd_65_exec_invalid_utf8_simulation(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 2
+    assert result["count"] == 2
 
 
 @pytest.mark.asyncio
@@ -437,7 +437,7 @@ async def test_fd_38_gitignore_and_fdignore_advanced(tmp_path, monkeypatch):
     )
 
     assert result1["success"] is True
-    assert result1["count"] >= 0  # Allow flexible count
+    assert result1["count"] == 3
 
     # Test without ignore rules
     result2 = await tool.execute(
@@ -445,6 +445,4 @@ async def test_fd_38_gitignore_and_fdignore_advanced(tmp_path, monkeypatch):
     )
 
     assert result2["success"] is True
-    assert result2["count"] >= 0  # Allow flexible count
-
-
+    assert result2["count"] == 7

--- a/tests/unit/mcp/test_mcp_list_files_p3a_path_output.py
+++ b/tests/unit/mcp/test_mcp_list_files_p3a_path_output.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from tree_sitter_analyzer.mcp.tools.list_files_tool import ListFilesTool
@@ -267,8 +269,11 @@ async def test_fd_56_base_directory_output(tmp_path, monkeypatch):
     tool = ListFilesTool(str(tmp_path))
 
     async def fake_run(cmd, cwd=None, timeout=None, timeout_ms=None):
-        # Check if searching from subdir as base
-        if str(tmp_path / "subdir") in cmd:
+        # Check if searching from subdir as base. realpath both sides:
+        # macOS tmp_path is /private/var/... while the command builder may
+        # carry the /var/... alias — naive list membership differs by platform.
+        subdir_real = os.path.realpath(str(tmp_path / "subdir"))
+        if any(os.path.realpath(str(arg)) == subdir_real for arg in cmd):
             files = [str(tmp_path / "subdir" / "file.txt")]
         else:
             files = [str(tmp_path / "subdir"), str(tmp_path / "subdir" / "file.txt")]
@@ -286,7 +291,7 @@ async def test_fd_56_base_directory_output(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] == 2
+    assert result["count"] == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcp/test_mcp_list_files_p3b_filters.py
+++ b/tests/unit/mcp/test_mcp_list_files_p3b_filters.py
@@ -95,7 +95,8 @@ async def test_fd_77_size_filtering_advanced(tmp_path, monkeypatch):
     tool = ListFilesTool(str(tmp_path))
 
     async def fake_run(cmd, cwd=None, timeout=None, timeout_ms=None):
-        if "--size" in cmd:
+        # Production builds size filters as ["-S", "+100b"], not "--size"
+        if "-S" in cmd:
             if "+100b" in cmd:
                 files = [str(tmp_path / "large.txt")]  # Only large files
             elif "-100b" in cmd:
@@ -118,7 +119,7 @@ async def test_fd_77_size_filtering_advanced(tmp_path, monkeypatch):
     )
 
     assert result1["success"] is True
-    assert result1["count"] == 2
+    assert result1["count"] == 1
 
     # Test files smaller than 100 bytes
     result2 = await tool.execute(
@@ -126,7 +127,7 @@ async def test_fd_77_size_filtering_advanced(tmp_path, monkeypatch):
     )
 
     assert result2["success"] is True
-    assert result2["count"] == 2
+    assert result2["count"] == 1
 
 
 @pytest.mark.asyncio
@@ -318,8 +319,13 @@ async def test_fd_84_max_results_advanced(tmp_path, monkeypatch):
         # Simulate max results limiting
         all_files = [str(tmp_path / f"file{i}.txt") for i in range(10)]
 
-        # Check for limit in command
-        files = all_files[:5] if any("limit" in str(arg) for arg in cmd) else all_files
+        # Production passes ["--max-results", "<n>"] (a default cap is
+        # appended even without an explicit limit) — honor the actual value
+        if "--max-results" in cmd:
+            n = int(cmd[cmd.index("--max-results") + 1])
+            files = all_files[:n]
+        else:
+            files = all_files
 
         out = "\n".join(files).encode()
         return 0, out, b""
@@ -328,13 +334,13 @@ async def test_fd_84_max_results_advanced(tmp_path, monkeypatch):
         "tree_sitter_analyzer.mcp.tools.fd_rg_utils.run_command_capture", fake_run
     )
 
-    # Test with limit
+    # Test with limit — the bounded fd pass returns only the requested prefix
     result1 = await tool.execute(
         {"roots": [str(tmp_path)], "pattern": "*", "glob": True, "limit": 5}
     )
 
     assert result1["success"] is True
-    assert result1["count"] == 10
+    assert result1["count"] == 5
 
     # Test without limit
     result2 = await tool.execute(

--- a/tests/unit/mcp/test_mcp_list_files_p3b_filters.py
+++ b/tests/unit/mcp/test_mcp_list_files_p3b_filters.py
@@ -82,7 +82,7 @@ async def test_fd_76_modified_absolute_time(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 0
+    assert result["count"] == 0
 
 
 @pytest.mark.asyncio
@@ -118,7 +118,7 @@ async def test_fd_77_size_filtering_advanced(tmp_path, monkeypatch):
     )
 
     assert result1["success"] is True
-    assert result1["count"] >= 0
+    assert result1["count"] == 2
 
     # Test files smaller than 100 bytes
     result2 = await tool.execute(
@@ -126,7 +126,7 @@ async def test_fd_77_size_filtering_advanced(tmp_path, monkeypatch):
     )
 
     assert result2["success"] is True
-    assert result2["count"] >= 0
+    assert result2["count"] == 2
 
 
 @pytest.mark.asyncio
@@ -160,7 +160,7 @@ async def test_fd_78_no_extension_filter(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 0
+    assert result["count"] == 3
 
 
 @pytest.mark.asyncio
@@ -189,7 +189,7 @@ async def test_fd_79_owner_ignore_all(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 0
+    assert result["count"] == 2
 
 
 @pytest.mark.asyncio
@@ -218,7 +218,7 @@ async def test_fd_80_owner_current_user(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 0
+    assert result["count"] == 2
 
 
 @pytest.mark.asyncio
@@ -246,7 +246,7 @@ async def test_fd_81_owner_current_group(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 0
+    assert result["count"] == 1
 
 
 @pytest.mark.asyncio
@@ -274,7 +274,7 @@ async def test_fd_82_owner_root(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 0  # No root files
+    assert result["count"] == 0
 
 
 @pytest.mark.asyncio
@@ -302,7 +302,7 @@ async def test_fd_83_quiet_mode_simulation(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 0
+    assert result["count"] == 1
 
 
 @pytest.mark.asyncio
@@ -334,7 +334,7 @@ async def test_fd_84_max_results_advanced(tmp_path, monkeypatch):
     )
 
     assert result1["success"] is True
-    assert result1["count"] >= 0
+    assert result1["count"] == 10
 
     # Test without limit
     result2 = await tool.execute(
@@ -342,7 +342,7 @@ async def test_fd_84_max_results_advanced(tmp_path, monkeypatch):
     )
 
     assert result2["success"] is True
-    assert result2["count"] >= 0
+    assert result2["count"] == 10
 
 
 @pytest.mark.asyncio
@@ -376,7 +376,7 @@ async def test_fd_86_list_details_advanced(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 0
+    assert result["count"] == 2
 
     # Verify detailed information is present in successful results
     if result["success"] and result["count"] > 0:

--- a/tests/unit/mcp/test_refactoring_suggestions_tool.py
+++ b/tests/unit/mcp/test_refactoring_suggestions_tool.py
@@ -97,7 +97,7 @@ class TestRefactoringSuggestionsTool:
         )
         suggestions = result["suggestions"]
         long_funcs = [s for s in suggestions if s["name"] == "long_function"]
-        assert len(long_funcs) >= 1
+        assert len(long_funcs) == 1
 
     def test_python_detects_deep_nesting(self, tool):
         result = _run(
@@ -105,7 +105,7 @@ class TestRefactoringSuggestionsTool:
         )
         suggestions = result["suggestions"]
         deep = [s for s in suggestions if s["name"] == "deep_nesting"]
-        assert len(deep) >= 1
+        assert len(deep) == 1
 
     def test_python_detects_large_class(self, tool):
         result = _run(
@@ -113,7 +113,7 @@ class TestRefactoringSuggestionsTool:
         )
         suggestions = result["suggestions"]
         large_classes = [s for s in suggestions if s["name"] == "reduce_class_size"]
-        assert len(large_classes) >= 1
+        assert len(large_classes) == 1
         assert "recipe" in large_classes[0]
         assert "move_methods" in large_classes[0]["recipe"]
 
@@ -131,7 +131,7 @@ class TestRefactoringSuggestionsTool:
         )
         summary = result["summary"]
         assert isinstance(summary, str)
-        assert len(summary) > 0
+        assert len(summary) == 47
 
     def test_agent_summary_surfaces_next_action(self, tool):
         result = _run(
@@ -193,7 +193,7 @@ class TestRefactoringSuggestionsTool:
 
     def test_server_file_analysis(self, tool):
         result = _run(tool.execute({"file_path": SAMPLE_GENERIC}))
-        assert result["total_suggestions"] >= 0
+        assert result["total_suggestions"] == 2
 
     def test_default_no_skeleton(self, tool):
         result = _run(
@@ -229,13 +229,13 @@ class TestRefactoringSuggestionsTool:
             tool.execute({"file_path": SAMPLE_PYTHON, "output_format": "json"})
         )
         with_plans = [s for s in result["suggestions"] if "precise_plan" in s]
-        assert len(with_plans) >= 1
+        assert len(with_plans) == 1
         plan = with_plans[0]["precise_plan"]
         assert "function" in plan
         assert "function_lines" in plan
         assert "helper_module" in plan
         assert "extractions" in plan
-        assert len(plan["extractions"]) >= 1
+        assert len(plan["extractions"]) == 1
 
     def test_precise_plan_extraction_fields(self, tool):
         result = _run(
@@ -248,7 +248,7 @@ class TestRefactoringSuggestionsTool:
             )
         )
         with_plans = [s for s in result["suggestions"] if "precise_plan" in s]
-        assert len(with_plans) >= 1
+        assert len(with_plans) == 1
         ext = with_plans[0]["precise_plan"]["extractions"][0]
         assert "helper_name" in ext
         assert "extract_lines" in ext
@@ -264,17 +264,17 @@ class TestRefactoringSuggestionsTool:
             tool.execute({"file_path": SAMPLE_PYTHON, "output_format": "json"})
         )
         with_plans = [s for s in result["suggestions"] if "precise_plan" in s]
-        assert len(with_plans) >= 1
+        assert len(with_plans) == 1
         plan = with_plans[0]["precise_plan"]
         assert "steps" in plan
-        assert len(plan["steps"]) >= 3
+        assert len(plan["steps"]) == 4
 
     def test_precise_plan_helper_module_name(self, tool):
         result = _run(
             tool.execute({"file_path": SAMPLE_PYTHON, "output_format": "json"})
         )
         with_plans = [s for s in result["suggestions"] if "precise_plan" in s]
-        assert len(with_plans) >= 1
+        assert len(with_plans) == 1
         helper_mod = with_plans[0]["precise_plan"]["helper_module"]
         assert helper_mod.endswith("_helpers.py")
         assert "_java_plugin_helpers.py" in helper_mod
@@ -525,7 +525,7 @@ class TestRefactoringSuggestionsTool:
             )
         )
         with_plans = [s for s in result["suggestions"] if "precise_plan" in s]
-        assert len(with_plans) >= 1
+        assert len(with_plans) == 1
         for ext in with_plans[0]["precise_plan"]["extractions"]:
             import ast
 

--- a/tests/unit/mcp/test_server_comprehensive_init.py
+++ b/tests/unit/mcp/test_server_comprehensive_init.py
@@ -245,10 +245,10 @@ x = 42
 
         metrics = server._calculate_file_metrics(str(test_file), "python")
 
-        assert metrics["total_lines"] > 0
-        assert metrics["code_lines"] > 0
-        assert metrics["comment_lines"] > 0
-        assert metrics["blank_lines"] >= 0
+        assert metrics["total_lines"] == 8
+        assert metrics["code_lines"] == 3
+        assert metrics["comment_lines"] == 2
+        assert metrics["blank_lines"] == 3
 
     def test_calculate_file_metrics_javascript(self, temp_project_dir):
         """Test file metrics calculation for JavaScript file."""
@@ -269,9 +269,9 @@ const x = 42;
 
         metrics = server._calculate_file_metrics(str(test_file), "javascript")
 
-        assert metrics["total_lines"] > 0
-        assert metrics["code_lines"] > 0
-        assert metrics["comment_lines"] > 0
+        assert metrics["total_lines"] == 9
+        assert metrics["code_lines"] == 3
+        assert metrics["comment_lines"] == 4
 
     def test_calculate_file_metrics_java(self, temp_project_dir):
         """Test file metrics calculation for Java file."""
@@ -292,9 +292,9 @@ public class Test {
 
         metrics = server._calculate_file_metrics(str(test_file), "java")
 
-        assert metrics["total_lines"] > 0
-        assert metrics["code_lines"] > 0
-        assert metrics["comment_lines"] > 0
+        assert metrics["total_lines"] == 9
+        assert metrics["code_lines"] == 4
+        assert metrics["comment_lines"] == 4
 
     def test_calculate_file_metrics_multiline_comments(self, temp_project_dir):
         """Test file metrics with complex multiline comments."""
@@ -313,7 +313,7 @@ function test() {
 
         metrics = server._calculate_file_metrics(str(test_file), "javascript")
 
-        assert metrics["comment_lines"] >= 3  # At least 3 comment lines
+        assert metrics["comment_lines"] == 5
 
     def test_calculate_file_metrics_error_handling(self, temp_project_dir):
         """Test file metrics calculation error handling."""


### PR DESCRIPTION
## Summary

Layer-2 loose-assertion cleanup, batch 3 (plan: .recon/ge-assertion-ratchet-plan.md). Pins all 72 enforcement-pattern hits across the 6 highest-density files in tests/unit/mcp to exact measured values — **0 exemptions needed** (every value proved deterministic).

| File | Hits → Remaining |
|---|---|
| test_mcp_list_files_p3a_path_output.py | 13 → 0 |
| test_mcp_list_files_p1b_fd_features.py | 13 → 0 |
| test_refactoring_suggestions_tool.py | 12 → 0 |
| test_mcp_list_files_p3b_filters.py | 12 → 0 |
| test_server_comprehensive_init.py | 11 → 0 |
| test_mcp_fd_rg_utils.py | 11 → 0 |

**Ratchet baseline:** 1760 → 1688 (measured with the baseline file's MEASUREMENT_COMMAND; lead spot-checked 3/6 files independently — 0 residual hits).

## Notable findings while pinning

- **2 dead-branch mocks fixed** (same class as #504's `-S` vs `--size` lesson): fd_77 mock checked `'--size' in cmd` but production passes `-S`; fd_84 mock checked `'limit'` but production passes `--max-results`. Both branches were vacuously falling through — pinned to live measured values.
- **2 vacuous assertions removed**: `assert result["success"] is False or result["count"] >= 0` is always true; simplified to `assert result["success"] is False`.
- macOS path-form traps (`/private/var` vs `/var`) and symlink support caught by RED-first pinning (fd_56, fd_31).

## Test plan

- [x] All 114 tests across the 6 files pass (`-n 0`, per-file sequential)
- [x] `bash scripts/check_loose_assertions.sh origin/develop` exits 0
- [x] Baseline re-measured with the exact enforcement-aligned command (output pasted in pod report)