### PR TITLE
test: pin exact assertions — batch 4 (tests/unit/mcp) + ratchet baseline down

### DIFF
--- a/scripts/loose_assertion_baseline.txt
+++ b/scripts/loose_assertion_baseline.txt
@@ -10,6 +10,6 @@
 # The count must only decrease (or stay equal). Each Layer-2 batch PR
 # re-measures and lowers it. Numbers are MEASURED, never hand-derived.
 
-BASELINE_COUNT=1688
+BASELINE_COUNT=1632
 MEASUREMENT_DATE=2026-06-12
 MEASUREMENT_COMMAND="grep -rEn \"assert .*(>= [0-9]|> 0([^0-9]|\$))\" tests/ --include=\"*.py\" | grep -v \"ratchet: nondeterministic\" | wc -l"

--- a/tests/unit/mcp/test_mcp_find_and_grep_fd_simulation_p1.py
+++ b/tests/unit/mcp/test_mcp_find_and_grep_fd_simulation_p1.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from tree_sitter_analyzer.mcp.tools.find_and_grep_tool import FindAndGrepTool
@@ -41,19 +43,19 @@ async def test_fd_02_multi_file_search(tmp_path, monkeypatch):
     tool = ListFilesTool(str(tmp_path))
 
     async def fake_run(cmd, cwd=None, timeout=None, timeout_ms=None):
-        # Check which directories are being searched
-        roots = []
-        for i, arg in enumerate(cmd):
-            if i > 0 and not arg.startswith("-") and arg != "fd" and "." not in arg:
-                roots.append(arg)
+        # realpath both sides: macOS tmp_path is /private/var/... while the
+        # command builder may carry the /var/... alias — naive membership
+        # differs by platform (same trap as fd_56)
+        resolved = {os.path.realpath(str(arg)) for arg in cmd}
 
         files = []
-        if str(tmp_path / "dir1") in roots or not roots:
-            files.append(str(tmp_path / "dir1" / "file1.txt"))
-        if str(tmp_path / "dir2") in roots or not roots:
-            files.append(str(tmp_path / "dir2" / "file2.txt"))
-        if str(tmp_path / "dir3") in roots or not roots:
-            files.append(str(tmp_path / "dir3" / "file3.txt"))
+        for dirname, filename in (
+            ("dir1", "file1.txt"),
+            ("dir2", "file2.txt"),
+            ("dir3", "file3.txt"),
+        ):
+            if os.path.realpath(str(tmp_path / dirname)) in resolved:
+                files.append(str(tmp_path / dirname / filename))
 
         out = "\n".join(files).encode()
         return 0, out, b""
@@ -76,7 +78,8 @@ async def test_fd_02_multi_file_search(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] == 0
+    # All three roots match → one file from each directory
+    assert result["count"] == 3
 
 
 @pytest.mark.asyncio
@@ -127,8 +130,10 @@ async def test_fd_04_explicit_root_path(tmp_path, monkeypatch):
     tool = ListFilesTool(str(tmp_path))
 
     async def fake_run(cmd, cwd=None, timeout=None, timeout_ms=None):
-        # Check if searching in subdir specifically
-        if str(tmp_path / "root" / "subdir") in cmd:
+        # Check if searching in subdir specifically. realpath both sides:
+        # macOS /private/var vs /var alias (same trap as fd_56).
+        subdir_real = os.path.realpath(str(tmp_path / "root" / "subdir"))
+        if any(os.path.realpath(str(arg)) == subdir_real for arg in cmd):
             files = [str(tmp_path / "root" / "subdir" / "file.txt")]
         else:
             files = [
@@ -149,7 +154,8 @@ async def test_fd_04_explicit_root_path(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] == 2
+    # Subdir root matches → only the file inside subdir
+    assert result["count"] == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcp/test_mcp_find_and_grep_fd_simulation_p1.py
+++ b/tests/unit/mcp/test_mcp_find_and_grep_fd_simulation_p1.py
@@ -239,10 +239,8 @@ async def test_fd_07_and_bad_pattern_simulation(tmp_path, monkeypatch):
         }
     )
 
-    # Should handle bad patterns gracefully
-    assert (
-        result["success"] is False or result["count"] >= 0
-    )  # ratchet: nondeterministic — success=False short-circuits; count key absent on error path
+    # Invalid regex makes fd exit non-zero — the tool must report failure
+    assert result["success"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcp/test_mcp_find_and_grep_fd_simulation_p1.py
+++ b/tests/unit/mcp/test_mcp_find_and_grep_fd_simulation_p1.py
@@ -76,7 +76,7 @@ async def test_fd_02_multi_file_search(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 0
+    assert result["count"] == 0
 
 
 @pytest.mark.asyncio
@@ -149,7 +149,7 @@ async def test_fd_04_explicit_root_path(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 0
+    assert result["count"] == 2
 
 
 @pytest.mark.asyncio
@@ -185,7 +185,7 @@ async def test_fd_05_and_basic_simulation(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 0
+    assert result["count"] == 0
 
 
 @pytest.mark.asyncio
@@ -212,7 +212,7 @@ async def test_fd_06_and_empty_pattern_simulation(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 0
+    assert result["count"] == 0
 
 
 @pytest.mark.asyncio
@@ -240,7 +240,9 @@ async def test_fd_07_and_bad_pattern_simulation(tmp_path, monkeypatch):
     )
 
     # Should handle bad patterns gracefully
-    assert result["success"] is False or result["count"] >= 0
+    assert (
+        result["success"] is False or result["count"] >= 0
+    )  # ratchet: nondeterministic — success=False short-circuits; count key absent on error path
 
 
 @pytest.mark.asyncio
@@ -319,7 +321,7 @@ async def test_fd_09_and_plus_extension(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 0
+    assert result["count"] == 0
 
 
 @pytest.mark.asyncio
@@ -352,4 +354,4 @@ async def test_fd_10_and_plus_type(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 0
+    assert result["count"] == 0

--- a/tests/unit/mcp/test_mcp_find_and_grep_p2.py
+++ b/tests/unit/mcp/test_mcp_find_and_grep_p2.py
@@ -54,7 +54,7 @@ async def test_fd_11_and_plus_glob(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 0
+    assert result["count"] == 0
 
 
 @pytest.mark.asyncio
@@ -94,7 +94,7 @@ async def test_fd_12_and_plus_fixed_strings(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 0
+    assert result["count"] == 0
 
 
 @pytest.mark.asyncio
@@ -139,7 +139,7 @@ async def test_fd_13_and_plus_ignore_case(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 0
+    assert result["count"] == 0
 
 
 @pytest.mark.asyncio
@@ -170,7 +170,7 @@ async def test_fd_14_and_plus_case_sensitive(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 0
+    assert result["count"] == 0
 
 
 @pytest.mark.asyncio
@@ -217,7 +217,7 @@ async def test_fd_15_and_plus_full_path(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 0
+    assert result["count"] == 0
 
 
 @pytest.mark.asyncio
@@ -246,7 +246,7 @@ async def test_fd_59_exec_command_simulation(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 2
+    assert result["count"] == 2
 
 
 @pytest.mark.asyncio
@@ -274,7 +274,7 @@ async def test_fd_60_exec_multi_command_simulation(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 2
+    assert result["count"] == 2
 
 
 @pytest.mark.asyncio
@@ -302,7 +302,7 @@ async def test_fd_61_exec_batch_simulation(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 5
+    assert result["count"] == 5
 
 
 @pytest.mark.asyncio
@@ -335,7 +335,7 @@ async def test_fd_62_exec_batch_multi_simulation(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 3
+    assert result["count"] == 3
 
 
 @pytest.mark.asyncio
@@ -394,4 +394,4 @@ async def test_fd_64_exec_with_separator_simulation(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 2
+    assert result["count"] == 2

--- a/tests/unit/mcp/test_mcp_list_files_symlinks_p2.py
+++ b/tests/unit/mcp/test_mcp_list_files_symlinks_p2.py
@@ -71,7 +71,9 @@ async def test_fd_44_follow_symlinks(tmp_path, monkeypatch):
     )
 
     assert result1["success"] is True
-    assert result1["count"] >= 3
+    assert (
+        result1["count"] >= 3
+    )  # ratchet: nondeterministic — 3 without symlinks (Windows), 5 with symlinks (macOS/Linux)
 
     # Test following symlinks
     result2 = await tool.execute(
@@ -84,7 +86,9 @@ async def test_fd_44_follow_symlinks(tmp_path, monkeypatch):
     )
 
     assert result2["success"] is True
-    assert result2["count"] >= 3
+    assert (
+        result2["count"] >= 3
+    )  # ratchet: nondeterministic — 3 without symlinks (Windows), 6 with symlinks (macOS/Linux)
 
 
 @pytest.mark.asyncio
@@ -118,7 +122,7 @@ async def test_fd_45_file_system_boundaries(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 3
+    assert result["count"] == 3
 
 
 @pytest.mark.asyncio
@@ -164,7 +168,9 @@ async def test_fd_46_follow_broken_symlink(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 0
+    assert (
+        result["count"] >= 0
+    )  # ratchet: nondeterministic — 1 without broken symlink (Windows), 2 with broken symlink (macOS/Linux)
 
 
 @pytest.mark.asyncio
@@ -210,7 +216,7 @@ async def test_fd_47_symlink_as_root(tmp_path, monkeypatch):
         )
 
     assert result["success"] is True
-    assert result["count"] >= 0
+    assert result["count"] == 1
 
 
 @pytest.mark.asyncio
@@ -256,7 +262,9 @@ async def test_fd_48_symlink_and_absolute_path(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 2
+    assert (
+        result["count"] >= 2
+    )  # ratchet: nondeterministic — 2 without symlinks (Windows), 3 with symlinks (macOS/Linux)
 
 
 @pytest.mark.asyncio
@@ -297,4 +305,4 @@ async def test_fd_49_symlink_as_absolute_root(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 0
+    assert result["count"] == 1

--- a/tests/unit/mcp/test_mcp_list_files_symlinks_p2.py
+++ b/tests/unit/mcp/test_mcp_list_files_symlinks_p2.py
@@ -71,9 +71,8 @@ async def test_fd_44_follow_symlinks(tmp_path, monkeypatch):
     )
 
     assert result1["success"] is True
-    assert (
-        result1["count"] >= 3
-    )  # ratchet: nondeterministic — 3 without symlinks (Windows), 5 with symlinks (macOS/Linux)
+    # Two-point platform pin: 3 without symlinks (Windows), 5 with (macOS/Linux)
+    assert result1["count"] in (3, 5)
 
     # Test following symlinks
     result2 = await tool.execute(
@@ -86,9 +85,8 @@ async def test_fd_44_follow_symlinks(tmp_path, monkeypatch):
     )
 
     assert result2["success"] is True
-    assert (
-        result2["count"] >= 3
-    )  # ratchet: nondeterministic — 3 without symlinks (Windows), 6 with symlinks (macOS/Linux)
+    # Two-point platform pin: 3 without symlinks (Windows), 6 with (macOS/Linux)
+    assert result2["count"] in (3, 6)
 
 
 @pytest.mark.asyncio
@@ -168,9 +166,8 @@ async def test_fd_46_follow_broken_symlink(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert (
-        result["count"] >= 0
-    )  # ratchet: nondeterministic — 1 without broken symlink (Windows), 2 with broken symlink (macOS/Linux)
+    # Two-point platform pin: 1 without broken symlink (Windows), 2 with (macOS/Linux)
+    assert result["count"] in (1, 2)
 
 
 @pytest.mark.asyncio
@@ -262,9 +259,8 @@ async def test_fd_48_symlink_and_absolute_path(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert (
-        result["count"] >= 2
-    )  # ratchet: nondeterministic — 2 without symlinks (Windows), 3 with symlinks (macOS/Linux)
+    # Two-point platform pin: 2 without symlinks (Windows), 3 with (macOS/Linux)
+    assert result["count"] in (2, 3)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcp/test_mcp_search_content_fd_compat.py
+++ b/tests/unit/mcp/test_mcp_search_content_fd_compat.py
@@ -1,6 +1,5 @@
 """MCP search content fd-compat tests — extracted from test_mcp_search_content_p1."""
 
-
 import pytest
 
 from tree_sitter_analyzer.mcp.tools.list_files_tool import ListFilesTool
@@ -32,16 +31,24 @@ async def test_fd_01_simple_search(tmp_path, monkeypatch):
 
     async def fake_run(cmd, cwd=None, timeout=None, timeout_ms=None):
         pattern = None
+        import os
+
         for _i, arg in enumerate(cmd):
-            if arg not in [
-                "-a",
-                "-H",
-                "-I",
-                "-L",
-                "--color",
-                "never",
-                "fd",
-            ] and not arg.startswith("-"):
+            if (
+                arg
+                not in [
+                    "-a",
+                    "-H",
+                    "-I",
+                    "-L",
+                    "--color",
+                    "never",
+                    "fd",
+                ]
+                and not arg.startswith("-")
+                and not arg.isdigit()
+                and not os.path.isabs(arg)
+            ):
                 pattern = arg
                 break
 
@@ -52,6 +59,24 @@ async def test_fd_01_simple_search(tmp_path, monkeypatch):
         elif pattern == "d.foo":
             files = [str(tmp_path / "one" / "two" / "three" / "d.foo")]
         elif pattern == "foo":
+            files = [
+                str(tmp_path / "a.foo"),
+                str(tmp_path / "one" / "b.foo"),
+                str(tmp_path / "one" / "two" / "c.foo"),
+                str(tmp_path / "one" / "two" / "C.Foo2"),
+                str(tmp_path / "one" / "two" / "three" / "d.foo"),
+                str(tmp_path / "one" / "two" / "three" / "directory_foo"),
+            ]
+        elif pattern in ("*.foo", None):
+            # glob pattern — return all .foo files
+            files = [
+                str(tmp_path / "a.foo"),
+                str(tmp_path / "one" / "b.foo"),
+                str(tmp_path / "one" / "two" / "c.foo"),
+                str(tmp_path / "one" / "two" / "C.Foo2"),
+                str(tmp_path / "one" / "two" / "three" / "d.foo"),
+            ]
+        elif pattern == "*":
             files = [
                 str(tmp_path / "a.foo"),
                 str(tmp_path / "one" / "b.foo"),
@@ -74,19 +99,19 @@ async def test_fd_01_simple_search(tmp_path, monkeypatch):
         {"roots": [str(tmp_path)], "pattern": "a.foo", "output_format": "json"}
     )
     assert result1["success"] is True
-    assert result1["count"] >= 0
+    assert result1["count"] == 1
 
     result2 = await tool.execute(
         {"roots": [str(tmp_path)], "pattern": "*.foo", "glob": True}
     )
     assert result2["success"] is True
-    assert result2["count"] >= 0
+    assert result2["count"] == 5
 
     result3 = await tool.execute(
         {"roots": [str(tmp_path)], "pattern": "*", "glob": True}
     )
     assert result3["success"] is True
-    assert result3["count"] >= 0
+    assert result3["count"] == 6
 
 
 @pytest.mark.unit
@@ -112,7 +137,7 @@ async def test_fd_16_empty_pattern(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 2
+    assert result["count"] == 2
 
 
 @pytest.mark.unit
@@ -153,7 +178,7 @@ async def test_fd_17_regex_searches(tmp_path, monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["count"] >= 2
+    assert result["count"] == 2
 
 
 @pytest.mark.unit
@@ -196,11 +221,11 @@ async def test_fd_18_smart_case_search(tmp_path, monkeypatch):
     )
 
     assert result1["success"] is True
-    assert result1["count"] >= 2
+    assert result1["count"] == 3
 
     result2 = await tool.execute(
         {"roots": [str(tmp_path)], "pattern": "Test", "output_format": "json"}
     )
 
     assert result2["success"] is True
-    assert result2["count"] >= 1
+    assert result2["count"] == 1

--- a/tests/unit/mcp/test_server_edge_cases.py
+++ b/tests/unit/mcp/test_server_edge_cases.py
@@ -192,7 +192,7 @@ if True
 
         # Should still return metrics even for malformed code
         assert "metrics" in result
-        assert result["metrics"]["lines_total"] > 0
+        assert result["metrics"]["lines_total"] == 11
 
     @pytest.mark.asyncio
     async def test_analyze_with_encoding_issues(self, temp_project_dir):
@@ -234,7 +234,7 @@ if True
         result = await server._analyze_code_scale(arguments)
 
         assert result["metrics"]["lines_total"] == 3
-        assert result["metrics"]["lines_code"] >= 2
+        assert result["metrics"]["lines_code"] == 2
 
 
 class TestMCPServerFileMetricsEdgeCases:
@@ -252,7 +252,7 @@ class TestMCPServerFileMetricsEdgeCases:
         metrics = server._calculate_file_metrics(str(test_file), "python")
 
         # Should handle mixed line endings gracefully
-        assert metrics["total_lines"] > 0
+        assert metrics["total_lines"] == 4
 
     def test_calculate_metrics_with_only_comments(self, temp_project_dir):
         """Test file metrics with only comments."""
@@ -280,7 +280,7 @@ class TestMCPServerFileMetricsEdgeCases:
 
         metrics = server._calculate_file_metrics(str(test_file), "python")
 
-        assert metrics["blank_lines"] >= 4
+        assert metrics["blank_lines"] == 6
         assert metrics["code_lines"] == 0
         assert metrics["comment_lines"] == 0
 
@@ -304,8 +304,8 @@ function test() {
 
         metrics = server._calculate_file_metrics(str(test_file), "javascript")
 
-        assert metrics["comment_lines"] > 0
-        assert metrics["code_lines"] > 0
+        assert metrics["comment_lines"] == 8
+        assert metrics["code_lines"] == 1
 
     def test_calculate_metrics_with_nested_comments(self, temp_project_dir):
         """Test file metrics with nested comment patterns."""
@@ -325,8 +325,8 @@ function test() {
 
         metrics = server._calculate_file_metrics(str(test_file), "javascript")
 
-        assert metrics["comment_lines"] >= 4
-        assert metrics["code_lines"] >= 3
+        assert metrics["comment_lines"] == 4
+        assert metrics["code_lines"] == 3
 
 
 class TestMCPServerToolHandlingEdgeCases:

--- a/tests/unit/mcp/test_tools/_test_read_partial_tool_batch_core_mixins.py
+++ b/tests/unit/mcp/test_tools/_test_read_partial_tool_batch_core_mixins.py
@@ -86,7 +86,9 @@ class ReadPartialToolExecuteBatchValidationMixin:
         assert result["count_files"] == 1
         # Check if results key exists
         if "results" in result:
-            assert len(result["results"][0]["errors"]) > 0
+            assert (
+                len(result["results"][0]["errors"]) > 0
+            )  # ratchet: nondeterministic — 'results' key absent in TOON output; branch never executes in default format
 
     @pytest.mark.asyncio
     async def test_execute_batch_invalid_file_path(self):
@@ -99,7 +101,9 @@ class ReadPartialToolExecuteBatchValidationMixin:
         result = await tool._execute_batch(args)
         assert result["count_files"] == 1
         if "results" in result:
-            assert len(result["results"][0]["errors"]) > 0
+            assert (
+                len(result["results"][0]["errors"]) > 0
+            )  # ratchet: nondeterministic — 'results' key absent in TOON output; branch never executes in default format
 
     @pytest.mark.asyncio
     async def test_execute_batch_invalid_sections(self):
@@ -112,7 +116,9 @@ class ReadPartialToolExecuteBatchValidationMixin:
         result = await tool._execute_batch(args)
         assert result["count_files"] == 1
         if "results" in result:
-            assert len(result["results"][0]["errors"]) > 0
+            assert (
+                len(result["results"][0]["errors"]) > 0
+            )  # ratchet: nondeterministic — 'results' key absent in TOON output; branch never executes in default format
 
     @pytest.mark.asyncio
     async def test_execute_batch_too_many_sections_per_file(self):
@@ -163,7 +169,9 @@ class ReadPartialToolExecuteBatchProcessingMixin:
             result = await tool._execute_batch(args)
         assert result["count_files"] == 1
         if "results" in result:
-            assert len(result["results"][0]["errors"]) > 0
+            assert (
+                len(result["results"][0]["errors"]) > 0
+            )  # ratchet: nondeterministic — 'results' key absent in TOON output; branch never executes in default format
 
     @pytest.mark.asyncio
     async def test_execute_batch_invalid_section_entry(self):
@@ -189,7 +197,9 @@ class ReadPartialToolExecuteBatchProcessingMixin:
                 result = await tool._execute_batch(args)
             assert result["count_files"] == 1
             if "results" in result:
-                assert len(result["results"][0]["errors"]) > 0
+                assert (
+                    len(result["results"][0]["errors"]) > 0
+                )  # ratchet: nondeterministic — 'results' key absent in TOON output; branch never executes in default format
         finally:
             if test_file.exists():
                 test_file.unlink()
@@ -218,7 +228,9 @@ class ReadPartialToolExecuteBatchProcessingMixin:
                 result = await tool._execute_batch(args)
             assert result["count_files"] == 1
             if "results" in result:
-                assert len(result["results"][0]["errors"]) > 0
+                assert (
+                    len(result["results"][0]["errors"]) > 0
+                )  # ratchet: nondeterministic — 'results' key absent in TOON output; branch never executes in default format
         finally:
             if test_file.exists():
                 test_file.unlink()
@@ -247,7 +259,9 @@ class ReadPartialToolExecuteBatchProcessingMixin:
                 result = await tool._execute_batch(args)
             assert result["count_files"] == 1
             if "results" in result:
-                assert len(result["results"][0]["errors"]) > 0
+                assert (
+                    len(result["results"][0]["errors"]) > 0
+                )  # ratchet: nondeterministic — 'results' key absent in TOON output; branch never executes in default format
         finally:
             if test_file.exists():
                 test_file.unlink()
@@ -277,10 +291,11 @@ class ReadPartialToolExecuteBatchProcessingMixin:
                 result = await tool._execute_batch(args)
             assert result["success"] is True
             assert result["count_files"] == 1
-            # count_sections may be less than expected if some sections fail
-            assert result["count_sections"] >= 1
+            assert result["count_sections"] == 2
             if "results" in result:
-                assert len(result["results"][0]["sections"]) >= 1
+                assert (
+                    len(result["results"][0]["sections"]) >= 1
+                )  # ratchet: nondeterministic — 'results' key absent in TOON output; branch never executes in default format
         finally:
             if test_file.exists():
                 test_file.unlink()

--- a/tests/unit/mcp/test_tools/_test_read_partial_tool_batch_core_mixins.py
+++ b/tests/unit/mcp/test_tools/_test_read_partial_tool_batch_core_mixins.py
@@ -80,15 +80,13 @@ class ReadPartialToolExecuteBatchValidationMixin:
     async def test_execute_batch_invalid_request_entry(self):
         """Test that batch mode handles invalid request entries."""
         tool = ReadPartialTool()
-        args = {"requests": ["not a dict"], "fail_fast": False}
+        # output_format=json keeps 'results' as a top-level key (TOON folds it
+        # into toon_content), so the error assertion actually executes
+        args = {"requests": ["not a dict"], "fail_fast": False, "output_format": "json"}
         result = await tool._execute_batch(args)
         assert result["success"] is False
         assert result["count_files"] == 1
-        # Check if results key exists
-        if "results" in result:
-            assert (
-                len(result["results"][0]["errors"]) > 0
-            )  # ratchet: nondeterministic — 'results' key absent in TOON output; branch never executes in default format
+        assert len(result["results"][0]["errors"]) == 1
 
     @pytest.mark.asyncio
     async def test_execute_batch_invalid_file_path(self):
@@ -97,13 +95,11 @@ class ReadPartialToolExecuteBatchValidationMixin:
         args = {
             "requests": [{"file_path": "", "sections": [{"start_line": 1}]}],
             "fail_fast": False,
+            "output_format": "json",
         }
         result = await tool._execute_batch(args)
         assert result["count_files"] == 1
-        if "results" in result:
-            assert (
-                len(result["results"][0]["errors"]) > 0
-            )  # ratchet: nondeterministic — 'results' key absent in TOON output; branch never executes in default format
+        assert len(result["results"][0]["errors"]) == 1
 
     @pytest.mark.asyncio
     async def test_execute_batch_invalid_sections(self):
@@ -112,13 +108,11 @@ class ReadPartialToolExecuteBatchValidationMixin:
         args = {
             "requests": [{"file_path": "test.py", "sections": "not a list"}],
             "fail_fast": False,
+            "output_format": "json",
         }
         result = await tool._execute_batch(args)
         assert result["count_files"] == 1
-        if "results" in result:
-            assert (
-                len(result["results"][0]["errors"]) > 0
-            )  # ratchet: nondeterministic — 'results' key absent in TOON output; branch never executes in default format
+        assert len(result["results"][0]["errors"]) == 1
 
     @pytest.mark.asyncio
     async def test_execute_batch_too_many_sections_per_file(self):
@@ -136,15 +130,28 @@ class ReadPartialToolExecuteBatchValidationMixin:
     async def test_execute_batch_too_many_sections_per_file_with_truncate(self):
         """Test that batch mode truncates sections when allow_truncate=True."""
         tool = ReadPartialTool()
-        sections = [{"start_line": i} for i in range(60)]
+        test_content = "\n".join(f"line{i}" for i in range(1, 61))
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+            f.write(test_content)
+            f.flush()
+            test_file = Path(f.name)
+
+        sections = [{"start_line": i} for i in range(1, 61)]
         args = {
             "requests": [{"file_path": "test.py", "sections": sections}],
             "allow_truncate": True,
+            "output_format": "json",
         }
-        result = await tool._execute_batch(args)
-        assert result["truncated"] is True
-        if "results" in result:
+        try:
+            with patch.object(
+                tool, "resolve_and_validate_file_path", return_value=str(test_file)
+            ):
+                result = await tool._execute_batch(args)
+            assert result["truncated"] is True
             assert len(result["results"][0]["sections"]) == 50  # max_sections_per_file
+        finally:
+            if test_file.exists():
+                test_file.unlink()
 
 
 class ReadPartialToolExecuteBatchProcessingMixin:
@@ -159,6 +166,7 @@ class ReadPartialToolExecuteBatchProcessingMixin:
                 {"file_path": "nonexistent.py", "sections": [{"start_line": 1}]}
             ],
             "fail_fast": False,
+            "output_format": "json",
         }
         with (
             patch.object(
@@ -168,10 +176,7 @@ class ReadPartialToolExecuteBatchProcessingMixin:
         ):
             result = await tool._execute_batch(args)
         assert result["count_files"] == 1
-        if "results" in result:
-            assert (
-                len(result["results"][0]["errors"]) > 0
-            )  # ratchet: nondeterministic — 'results' key absent in TOON output; branch never executes in default format
+        assert len(result["results"][0]["errors"]) == 1
 
     @pytest.mark.asyncio
     async def test_execute_batch_invalid_section_entry(self):
@@ -188,6 +193,7 @@ class ReadPartialToolExecuteBatchProcessingMixin:
         args = batch_args(
             batch_request("test_data.py", ["not a dict"]),
             fail_fast=False,
+            output_format="json",
         )
 
         try:
@@ -196,10 +202,7 @@ class ReadPartialToolExecuteBatchProcessingMixin:
             ):
                 result = await tool._execute_batch(args)
             assert result["count_files"] == 1
-            if "results" in result:
-                assert (
-                    len(result["results"][0]["errors"]) > 0
-                )  # ratchet: nondeterministic — 'results' key absent in TOON output; branch never executes in default format
+            assert len(result["results"][0]["errors"]) == 1
         finally:
             if test_file.exists():
                 test_file.unlink()
@@ -219,6 +222,7 @@ class ReadPartialToolExecuteBatchProcessingMixin:
         args = batch_args(
             batch_request("test_data.py", [{"start_line": 0}]),
             fail_fast=False,
+            output_format="json",
         )
 
         try:
@@ -227,10 +231,7 @@ class ReadPartialToolExecuteBatchProcessingMixin:
             ):
                 result = await tool._execute_batch(args)
             assert result["count_files"] == 1
-            if "results" in result:
-                assert (
-                    len(result["results"][0]["errors"]) > 0
-                )  # ratchet: nondeterministic — 'results' key absent in TOON output; branch never executes in default format
+            assert len(result["results"][0]["errors"]) == 1
         finally:
             if test_file.exists():
                 test_file.unlink()
@@ -250,6 +251,7 @@ class ReadPartialToolExecuteBatchProcessingMixin:
         args = batch_args(
             batch_request("test_data.py", [{"start_line": 10, "end_line": 5}]),
             fail_fast=False,
+            output_format="json",
         )
 
         try:
@@ -258,10 +260,7 @@ class ReadPartialToolExecuteBatchProcessingMixin:
             ):
                 result = await tool._execute_batch(args)
             assert result["count_files"] == 1
-            if "results" in result:
-                assert (
-                    len(result["results"][0]["errors"]) > 0
-                )  # ratchet: nondeterministic — 'results' key absent in TOON output; branch never executes in default format
+            assert len(result["results"][0]["errors"]) == 1
         finally:
             if test_file.exists():
                 test_file.unlink()
@@ -282,7 +281,7 @@ class ReadPartialToolExecuteBatchProcessingMixin:
             {"start_line": 1, "end_line": 2, "label": "section1"},
             {"start_line": 4, "end_line": 5, "label": "section2"},
         ]
-        args = batch_args(batch_request("test_data.py", sections))
+        args = batch_args(batch_request("test_data.py", sections), output_format="json")
 
         try:
             with patch.object(
@@ -292,10 +291,7 @@ class ReadPartialToolExecuteBatchProcessingMixin:
             assert result["success"] is True
             assert result["count_files"] == 1
             assert result["count_sections"] == 2
-            if "results" in result:
-                assert (
-                    len(result["results"][0]["sections"]) >= 1
-                )  # ratchet: nondeterministic — 'results' key absent in TOON output; branch never executes in default format
+            assert len(result["results"][0]["sections"]) == 2
         finally:
             if test_file.exists():
                 test_file.unlink()

--- a/tests/unit/mcp/tools/test_batch_executor_execute.py
+++ b/tests/unit/mcp/tools/test_batch_executor_execute.py
@@ -36,7 +36,10 @@ class TestExecuteBatch:
             tool,
             {
                 "requests": [
-                    {"file_path": "a.py", "sections": [{"start_line": 1, "end_line": 2}]}
+                    {
+                        "file_path": "a.py",
+                        "sections": [{"start_line": 1, "end_line": 2}],
+                    }
                 ]
             },
             read_fn,
@@ -55,7 +58,7 @@ class TestExecuteBatch:
             lambda *a: "",
         )
         assert result["success"] is False
-        assert result["errors_summary"]["errors"] >= 1
+        assert result["errors_summary"]["errors"] == 1
 
     @pytest.mark.asyncio
     async def test_non_dict_request_entry(self):
@@ -65,7 +68,7 @@ class TestExecuteBatch:
             {"requests": ["not_a_dict"]},
             lambda *a: "",
         )
-        assert result["errors_summary"]["errors"] >= 1
+        assert result["errors_summary"]["errors"] == 1
 
     @pytest.mark.asyncio
     async def test_fail_fast_on_invalid_entry(self):
@@ -115,7 +118,7 @@ class TestExecuteBatch:
             },
             lambda *a: "",
         )
-        assert result["errors_summary"]["errors"] >= 1
+        assert result["errors_summary"]["errors"] == 1
 
     @pytest.mark.asyncio
     async def test_invalid_start_line_in_section(self, tmp_path):
@@ -134,7 +137,7 @@ class TestExecuteBatch:
             },
             lambda *a: "",
         )
-        assert result["errors_summary"]["errors"] >= 1
+        assert result["errors_summary"]["errors"] == 1
 
     @pytest.mark.asyncio
     async def test_invalid_end_line_in_section(self, tmp_path):
@@ -155,7 +158,7 @@ class TestExecuteBatch:
             },
             lambda *a: "",
         )
-        assert result["errors_summary"]["errors"] >= 1
+        assert result["errors_summary"]["errors"] == 1
 
     @pytest.mark.asyncio
     async def test_empty_content_counts_as_error(self, tmp_path):
@@ -174,7 +177,7 @@ class TestExecuteBatch:
             },
             lambda *a: "",
         )
-        assert result["errors_summary"]["errors"] >= 1
+        assert result["errors_summary"]["errors"] == 1
 
     @pytest.mark.asyncio
     async def test_fail_fast_on_section_limit(self, tmp_path):
@@ -201,9 +204,7 @@ class TestExecuteBatch:
         f.write_text("line\n" * 300)
         tool = self._make_tool(str(f))
         limit = BATCH_LIMITS["max_sections_total"]
-        sections = [
-            {"start_line": i + 1, "end_line": i + 1} for i in range(limit + 5)
-        ]
+        sections = [{"start_line": i + 1, "end_line": i + 1} for i in range(limit + 5)]
         result = await execute_batch(
             tool,
             {
@@ -303,9 +304,7 @@ class TestExecuteBatch:
             return "content_b"
 
         tool = MagicMock()
-        tool.resolve_and_validate_file_path.side_effect = lambda p: str(
-            tmp_path / p
-        )
+        tool.resolve_and_validate_file_path.side_effect = lambda p: str(tmp_path / p)
         result = await execute_batch(
             tool,
             {
@@ -333,7 +332,7 @@ class TestExecuteBatch:
             },
             lambda *a: "content",
         )
-        assert result["errors_summary"]["errors"] >= 1
+        assert result["errors_summary"]["errors"] == 1
 
     @pytest.mark.asyncio
     async def test_label_preserved_in_section_result(self, tmp_path):
@@ -396,7 +395,7 @@ class TestExecuteBatch:
             },
             lambda r, s, e: "   ",
         )
-        assert result["errors_summary"]["errors"] >= 1
+        assert result["errors_summary"]["errors"] == 1
 
     @pytest.mark.asyncio
     async def test_content_bytes_limit_exceeded(self, tmp_path):
@@ -452,7 +451,12 @@ class TestExecuteBatch:
                     "requests": [
                         {
                             "file_path": "a.py",
-                            "sections": [{"start_line": 1, "end_line": BATCH_LIMITS["max_total_lines"] + 1}],
+                            "sections": [
+                                {
+                                    "start_line": 1,
+                                    "end_line": BATCH_LIMITS["max_total_lines"] + 1,
+                                }
+                            ],
                         }
                     ]
                 },


### PR DESCRIPTION
## Summary

Layer-2 loose-assertion cleanup, batch 4 (plan: .recon/ge-assertion-ratchet-plan.md). 56 enforcement-pattern hits across 7 files → exact pins; ratchet baseline 1688 → 1632.

| File | Hits → Remaining |
|---|---|
| test_mcp_find_and_grep_p2.py | 10 → 0 |
| test_tools/_test_read_partial_tool_batch_core_mixins.py | 9 → 0 |
| tools/test_batch_executor_execute.py | 8 → 0 |
| test_server_edge_cases.py | 8 → 0 |
| test_mcp_search_content_fd_compat.py | 7 → 0 |
| test_mcp_list_files_symlinks_p2.py | 7 → 0 |
| test_mcp_find_and_grep_fd_simulation_p1.py | 7 → 0 |

Two commits: pod pass (968be951) + lead review pass (9d7698d9). The lead pass eliminated ALL exemption markers the pod had added — final exemption count in this PR: **0**.

## Dead branches made live (the #504/#508 lesson, applied again)

- **read_partial batch mixins (9 sites)**: `if "results" in result:` guards never fired because TOON (default) folds `results` into `toon_content`. That's a dead branch, not nondeterminism — tests now pass `output_format="json"`, guards dropped, pinned `errors == 1` / `sections == 2`. The truncate test's `== 50` was a fantasy pin behind the dead guard (target file never existed → live value was sections=0/errors=1); it now uses a real 60-line file so the 50-cap is genuinely exercised.
- **find_and_grep fd_01 (pod pass)**: mock mistook `--max-results 2000`'s value for the pattern → else-branch returned empty; mock now skips digits/absolute paths, pins are live (1/5/6).
- **fd_07**: `success is False or count >= 0` is vacuous → `success is False`.

## Platform-dependent counts → two-point pins (no hand-waved bounds)

symlinks_p2 (4 sites): `>= N` replaced with exact two-point sets — `in (3, 5)` / `in (3, 6)` / `in (1, 2)` / `in (2, 3)` (Windows without symlink support vs macOS/Linux with). Every admissible value is pinned; drift outside the set goes red on the respective CI platform.

## Test plan

- [x] All 7 files + 2 aggregator consumers green (`-n 0`, per-file sequential; 199 tests)
- [x] `bash scripts/check_loose_assertions.sh origin/develop` exits 0
- [x] Baseline re-measured: 1632 (enforcement-aligned command, lead-verified independently)