### PR TITLE
test: pin exact assertions — batch 6 (tests/unit/languages) + ratchet baseline down

### DIFF
--- a/scripts/loose_assertion_baseline.txt
+++ b/scripts/loose_assertion_baseline.txt
@@ -10,6 +10,6 @@
 # The count must only decrease (or stay equal). Each Layer-2 batch PR
 # re-measures and lowers it. Numbers are MEASURED, never hand-derived.
 
-BASELINE_COUNT=1600
+BASELINE_COUNT=1525
 MEASUREMENT_DATE=2026-06-12
 MEASUREMENT_COMMAND="grep -rEn \"assert .*(>= [0-9]|> 0([^0-9]|\$))\" tests/ --include=\"*.py\" | grep -v \"ratchet: nondeterministic\" | wc -l"

--- a/tests/unit/languages/test_cpp_plugin_coverage_boost_core.py
+++ b/tests/unit/languages/test_cpp_plugin_coverage_boost_core.py
@@ -35,8 +35,8 @@ def test_cpp_plugin_basic(plugin):
     tree = _parse(code)
     elements_dict = plugin.extract_elements(tree, code)
     assert elements_dict is not None
-    assert len(elements_dict["functions"]) > 0
-    assert len(elements_dict["classes"]) > 0
+    assert len(elements_dict["functions"]) == 2
+    assert len(elements_dict["classes"]) == 1
 
     names = [e.name for e in elements_dict["functions"]]
     assert "my_method" in names
@@ -70,9 +70,9 @@ def test_union_extraction(extractor):
     code = "union Data { int i; float f; char c; };\n"
     tree = _parse(code)
     classes = extractor.extract_classes(tree, code)
-    assert len(classes) >= 1
+    assert len(classes) == 1
     unions = [c for c in classes if c.class_type == "union"]
-    assert len(unions) >= 1
+    assert len(unions) == 1
     assert unions[0].name == "Data"
 
 
@@ -81,7 +81,7 @@ def test_namespace_extraction(extractor):
     code = "namespace physics { double gravity = 9.8; }\n"
     tree = _parse(code)
     packages = extractor.extract_packages(tree, code)
-    assert len(packages) >= 1
+    assert len(packages) == 1
     assert packages[0].name == "physics"
 
 
@@ -90,7 +90,7 @@ def test_using_declaration_import(extractor):
     code = "using namespace std;\n"
     tree = _parse(code)
     imports = extractor.extract_imports(tree, code)
-    assert len(imports) >= 1
+    assert len(imports) == 1
     assert any("using" in i.import_statement for i in imports)
 
 
@@ -99,7 +99,7 @@ def test_alias_declaration_import(extractor):
     code = "using IntVec = vector<int>;\n"
     tree = _parse(code)
     imports = extractor.extract_imports(tree, code)
-    assert len(imports) >= 1
+    assert len(imports) == 1
     assert any("IntVec" in i.name for i in imports)
 
 
@@ -141,7 +141,7 @@ def test_pure_virtual_function(extractor):
     tree = _parse(code)
     funcs = extractor.extract_functions(tree, code)
     area_funcs = [f for f in funcs if f.name == "area"]
-    assert len(area_funcs) >= 1
+    assert len(area_funcs) == 1
 
 
 # --- Static and const modifiers ---
@@ -149,9 +149,9 @@ def test_static_const_modifiers(extractor):
     code = "class Config { public: static const int MAX_SIZE = 100; };\n"
     tree = _parse(code)
     variables = extractor.extract_variables(tree, code)
-    assert len(variables) >= 1
+    assert len(variables) == 1
     max_var = [v for v in variables if v.name == "MAX_SIZE"]
-    assert len(max_var) >= 1
+    assert len(max_var) == 1
     assert max_var[0].is_static is True
     assert max_var[0].is_constant is True
 
@@ -161,7 +161,7 @@ def test_global_variable(extractor):
     code = "int counter = 0;\nstatic double pi = 3.14;\n"
     tree = _parse(code)
     variables = extractor.extract_variables(tree, code)
-    assert len(variables) >= 1
+    assert len(variables) == 2
     names = [v.name for v in variables]
     assert "counter" in names
 
@@ -181,11 +181,11 @@ def test_visibility_in_class(extractor):
     tree = _parse(code)
     funcs = extractor.extract_functions(tree, code)
     show_funcs = [f for f in funcs if f.name == "show"]
-    assert len(show_funcs) >= 1
+    assert len(show_funcs) == 1
     assert show_funcs[0].visibility == "public"
 
     internal_funcs = [f for f in funcs if f.name == "internal"]
-    assert len(internal_funcs) >= 1
+    assert len(internal_funcs) == 1
     assert internal_funcs[0].visibility == "protected"
 
 
@@ -195,7 +195,7 @@ def test_struct_default_visibility(extractor):
     tree = _parse(code)
     variables = extractor.extract_variables(tree, code)
     x_vars = [v for v in variables if v.name == "x"]
-    assert len(x_vars) >= 1
+    assert len(x_vars) == 1
     assert x_vars[0].visibility == "public"
 
 
@@ -215,7 +215,7 @@ def test_triple_slash_comment(extractor):
     tree = _parse(code)
     funcs = extractor.extract_functions(tree, code)
     sum_funcs = [f for f in funcs if f.name == "sum"]
-    assert len(sum_funcs) >= 1
+    assert len(sum_funcs) == 1
     assert sum_funcs[0].docstring is not None
     assert "Computes" in sum_funcs[0].docstring
 
@@ -234,8 +234,8 @@ def test_complexity_with_control_flow(extractor):
     tree = _parse(code)
     funcs = extractor.extract_functions(tree, code)
     classify = [f for f in funcs if f.name == "classify"]
-    assert len(classify) >= 1
-    assert classify[0].complexity_score > 1
+    assert len(classify) == 1
+    assert classify[0].complexity_score == 5
 
 
 # --- Qualified identifier function name (namespace-qualified) ---
@@ -251,7 +251,7 @@ def test_qualified_function(extractor):
     tree = _parse(code)
     funcs = extractor.extract_functions(tree, code)
     bar_funcs = [f for f in funcs if f.name == "bar"]
-    assert len(bar_funcs) >= 1
+    assert len(bar_funcs) == 1
 
 
 # --- extract_elements with None tree ---
@@ -269,7 +269,7 @@ def test_count_tree_nodes(plugin):
     code = "int main() { return 0; }\n"
     tree = _parse(code)
     count = plugin._count_tree_nodes(tree.root_node)
-    assert count >= 1
+    assert count == 15
 
 
 def test_count_tree_nodes_none(plugin):
@@ -281,7 +281,7 @@ def test_variable_with_init_declarator(extractor):
     code = "int x = 42;\n"
     tree = _parse(code)
     variables = extractor.extract_variables(tree, code)
-    assert len(variables) >= 1
+    assert len(variables) == 1
     assert variables[0].name == "x"
     assert variables[0].variable_type == "int"
 
@@ -292,7 +292,7 @@ def test_field_with_init_declarator(extractor):
     tree = _parse(code)
     variables = extractor.extract_variables(tree, code)
     val_vars = [v for v in variables if v.name == "val"]
-    assert len(val_vars) >= 1
+    assert len(val_vars) == 1
 
 
 # --- Destructor function name ---
@@ -301,7 +301,7 @@ def test_destructor_extraction(extractor):
     tree = _parse(code)
     funcs = extractor.extract_functions(tree, code)
     dtor_funcs = [f for f in funcs if f.name and "~" in f.name]
-    assert len(dtor_funcs) >= 1
+    assert len(dtor_funcs) == 1
 
 
 # --- Const qualified method ---
@@ -310,7 +310,7 @@ def test_const_method(extractor):
     tree = _parse(code)
     funcs = extractor.extract_functions(tree, code)
     get_funcs = [f for f in funcs if f.name == "get"]
-    assert len(get_funcs) >= 1
+    assert len(get_funcs) == 1
 
 
 # --- Static global variable is private visibility ---
@@ -319,7 +319,7 @@ def test_static_global_private_visibility(extractor):
     tree = _parse(code)
     variables = extractor.extract_variables(tree, code)
     ctr_vars = [v for v in variables if v.name == "internal_counter"]
-    assert len(ctr_vars) >= 1
+    assert len(ctr_vars) == 1
     assert ctr_vars[0].visibility == "private"
 
 
@@ -340,7 +340,7 @@ def test_function_declaration(extractor):
     tree = _parse(code)
     funcs = extractor.extract_functions(tree, code)
     init_funcs = [f for f in funcs if f.name == "initialize"]
-    assert len(init_funcs) >= 1
+    assert len(init_funcs) == 1
     assert init_funcs[0].return_type == "void"
 
 
@@ -359,7 +359,7 @@ def test_mixed_includes(extractor):
     code = '#include <iostream>\n#include "utils.h"\n'
     tree = _parse(code)
     imports = extractor.extract_imports(tree, code)
-    assert len(imports) >= 2
+    assert len(imports) == 2
 
 
 # --- Fallback regex for includes ---
@@ -378,7 +378,7 @@ def test_reference_return_function(extractor):
     tree = _parse(code)
     funcs = extractor.extract_functions(tree, code)
     ref_funcs = [f for f in funcs if f.name == "get_ref"]
-    assert len(ref_funcs) >= 1
+    assert len(ref_funcs) == 1
 
 
 # --- Pointer declarator (pointer return type) ---
@@ -387,7 +387,7 @@ def test_pointer_return_function(extractor):
     tree = _parse(code)
     funcs = extractor.extract_functions(tree, code)
     ptr_funcs = [f for f in funcs if f.name == "create_ptr"]
-    assert len(ptr_funcs) >= 1
+    assert len(ptr_funcs) == 1
 
 
 # --- Operator overloading ---
@@ -396,7 +396,7 @@ def test_operator_function(extractor):
     tree = _parse(code)
     funcs = extractor.extract_functions(tree, code)
     op_funcs = [f for f in funcs if f.name and "operator" in f.name]
-    assert len(op_funcs) >= 1
+    assert len(op_funcs) == 1
 
 
 # --- Nested namespace ---
@@ -414,7 +414,7 @@ def test_class_default_visibility(extractor):
     tree = _parse(code)
     variables = extractor.extract_variables(tree, code)
     val_vars = [v for v in variables if v.name == "value"]
-    assert len(val_vars) >= 1
+    assert len(val_vars) == 1
     assert val_vars[0].visibility == "private"
 
 
@@ -432,7 +432,7 @@ def test_variable_template_type(extractor):
     code = "vector<int> nums;\n"
     tree = _parse(code)
     variables = extractor.extract_variables(tree, code)
-    assert len(variables) >= 1
+    assert len(variables) == 1
     assert "vector" in (variables[0].variable_type or "")
 
 
@@ -442,7 +442,7 @@ def test_function_with_static(extractor):
     tree = _parse(code)
     funcs = extractor.extract_functions(tree, code)
     helper_funcs = [f for f in funcs if f.name == "helper"]
-    assert len(helper_funcs) >= 1
+    assert len(helper_funcs) == 1
     assert helper_funcs[0].is_static is True
 
 
@@ -458,5 +458,5 @@ def test_template_struct(extractor):
     tree = _parse(code)
     classes = extractor.extract_classes(tree, code)
     holders = [c for c in classes if c.name == "Holder"]
-    assert len(holders) >= 1
+    assert len(holders) == 1
     assert "template" in (holders[0].modifiers or [])

--- a/tests/unit/languages/test_kotlin_plugin.py
+++ b/tests/unit/languages/test_kotlin_plugin.py
@@ -64,7 +64,7 @@ fun hello() {
         tree = kotlin_parser.parse(code.encode("utf-8"))
         functions = extractor.extract_functions(tree, code)
 
-        assert len(functions) >= 1
+        assert len(functions) == 1
         func = functions[0]
         assert func.name == "hello"
         assert func.language == "kotlin"
@@ -79,7 +79,7 @@ fun greet(name: String, age: Int) {
         tree = kotlin_parser.parse(code.encode("utf-8"))
         functions = extractor.extract_functions(tree, code)
 
-        assert len(functions) >= 1
+        assert len(functions) == 1
         func = functions[0]
         assert func.name == "greet"
         assert (
@@ -96,7 +96,7 @@ fun add(a: Int, b: Int): Int {
         tree = kotlin_parser.parse(code.encode("utf-8"))
         functions = extractor.extract_functions(tree, code)
 
-        assert len(functions) >= 1
+        assert len(functions) == 1
         func = functions[0]
         assert func.name == "add"
 
@@ -110,7 +110,7 @@ suspend fun fetchData(): String {
         tree = kotlin_parser.parse(code.encode("utf-8"))
         functions = extractor.extract_functions(tree, code)
 
-        assert len(functions) >= 1
+        assert len(functions) == 1
         func = functions[0]
         assert func.name == "fetchData"
 
@@ -124,7 +124,7 @@ private fun helper() {
         tree = kotlin_parser.parse(code.encode("utf-8"))
         functions = extractor.extract_functions(tree, code)
 
-        assert len(functions) >= 1
+        assert len(functions) == 1
 
     def test_extract_extension_function(self, extractor, kotlin_parser):
         """Should extract extension function."""
@@ -136,7 +136,7 @@ fun String.hello() {
         tree = kotlin_parser.parse(code.encode("utf-8"))
         functions = extractor.extract_functions(tree, code)
 
-        assert len(functions) >= 1
+        assert len(functions) == 1
 
 
 class TestKotlinElementExtractorClasses:
@@ -167,7 +167,7 @@ class Person {
         tree = kotlin_parser.parse(code.encode("utf-8"))
         classes = extractor.extract_classes(tree, code)
 
-        assert len(classes) >= 1
+        assert len(classes) == 1
         cls = classes[0]
         assert cls.name == "Person"
         assert cls.language == "kotlin"
@@ -180,7 +180,7 @@ data class User(val name: String, val age: Int)
         tree = kotlin_parser.parse(code.encode("utf-8"))
         classes = extractor.extract_classes(tree, code)
 
-        assert len(classes) >= 1
+        assert len(classes) == 1
         cls = classes[0]
         assert cls.name == "User"
 
@@ -194,7 +194,7 @@ class Student : Person() {
         tree = kotlin_parser.parse(code.encode("utf-8"))
         classes = extractor.extract_classes(tree, code)
 
-        assert len(classes) >= 1
+        assert len(classes) == 1
 
     def test_extract_object_declaration(self, extractor, kotlin_parser):
         """Should extract object declaration."""
@@ -208,7 +208,7 @@ object Singleton {
         tree = kotlin_parser.parse(code.encode("utf-8"))
         classes = extractor.extract_classes(tree, code)
 
-        assert len(classes) >= 1
+        assert len(classes) == 1
         obj = classes[0]
         assert obj.name == "Singleton"
 
@@ -224,7 +224,7 @@ class MyClass {
         tree = kotlin_parser.parse(code.encode("utf-8"))
         classes = extractor.extract_classes(tree, code)
 
-        assert len(classes) >= 1
+        assert len(classes) == 1
 
     def test_extract_sealed_class(self, extractor, kotlin_parser):
         """Should extract sealed class."""
@@ -237,7 +237,7 @@ sealed class Result {
         tree = kotlin_parser.parse(code.encode("utf-8"))
         classes = extractor.extract_classes(tree, code)
 
-        assert len(classes) >= 1
+        assert len(classes) == 3
 
 
 class TestKotlinElementExtractorVariables:
@@ -266,7 +266,7 @@ val name: String = "John"
         tree = kotlin_parser.parse(code.encode("utf-8"))
         variables = extractor.extract_variables(tree, code)
 
-        assert len(variables) >= 1
+        assert len(variables) == 1
         var = variables[0]
         # Name extraction may vary
         assert var.language == "kotlin"
@@ -279,7 +279,7 @@ var count: Int = 0
         tree = kotlin_parser.parse(code.encode("utf-8"))
         variables = extractor.extract_variables(tree, code)
 
-        assert len(variables) >= 1
+        assert len(variables) == 1
 
     def test_extract_const_val(self, extractor, kotlin_parser):
         """Should extract const val."""
@@ -289,7 +289,7 @@ const val MAX_SIZE = 100
         tree = kotlin_parser.parse(code.encode("utf-8"))
         variables = extractor.extract_variables(tree, code)
 
-        assert len(variables) >= 1
+        assert len(variables) == 1
 
     def test_extract_lateinit_var(self, extractor, kotlin_parser):
         """Should extract lateinit var."""
@@ -299,7 +299,7 @@ lateinit var adapter: ListAdapter
         tree = kotlin_parser.parse(code.encode("utf-8"))
         variables = extractor.extract_variables(tree, code)
 
-        assert len(variables) >= 1
+        assert len(variables) == 1
 
 
 class TestKotlinElementExtractorImports:
@@ -515,8 +515,8 @@ object UserFactory {
         classes = extractor.extract_classes(tree, code)
         imports = extractor.extract_imports(tree, code)
 
-        assert len(functions) >= 2  # addUser, fetchUsers, createUser
-        assert len(classes) >= 2  # User, UserRepository, UserFactory
+        assert len(functions) == 3  # addUser, fetchUsers, createUser
+        assert len(classes) == 3  # User, UserRepository, UserFactory
         # Import extraction may not be fully implemented
         assert isinstance(imports, list)
 
@@ -530,7 +530,7 @@ fun <T> identity(value: T): T {
         tree = kotlin_parser.parse(code.encode("utf-8"))
         functions = extractor.extract_functions(tree, code)
 
-        assert len(functions) >= 1
+        assert len(functions) == 1
 
     def test_extract_interface(self, extractor, kotlin_parser):
         """Should extract interface."""
@@ -1275,7 +1275,7 @@ fun launchExample() {
         tree = kotlin_parser.parse(code.encode("utf-8"))
         functions = extractor.extract_functions(tree, code)
 
-        assert len(functions) >= 1
+        assert len(functions) == 1
         func_names = [f.name for f in functions]
         assert "launchExample" in func_names
 
@@ -1293,7 +1293,7 @@ suspend fun fetchTwoUsersAsync(): Pair<User, User> = coroutineScope {
         tree = kotlin_parser.parse(code.encode("utf-8"))
         functions = extractor.extract_functions(tree, code)
 
-        assert len(functions) >= 1
+        assert len(functions) == 1
 
     def test_extract_flow_function(self, extractor, kotlin_parser):
         """Should extract function returning Flow."""
@@ -1310,7 +1310,7 @@ fun numberFlow(): Flow<Int> = flow {
         tree = kotlin_parser.parse(code.encode("utf-8"))
         functions = extractor.extract_functions(tree, code)
 
-        assert len(functions) >= 1
+        assert len(functions) == 1
         func_names = [f.name for f in functions]
         assert "numberFlow" in func_names
 
@@ -1342,7 +1342,7 @@ sealed class Result<out T> {
         tree = kotlin_parser.parse(code.encode("utf-8"))
         classes = extractor.extract_classes(tree, code)
 
-        assert len(classes) >= 1
+        assert len(classes) == 4
         class_names = [c.name for c in classes]
         assert "Result" in class_names
 
@@ -1388,7 +1388,7 @@ inline fun measureTime(block: () -> Unit): Long {
         tree = kotlin_parser.parse(code.encode("utf-8"))
         functions = extractor.extract_functions(tree, code)
 
-        assert len(functions) >= 1
+        assert len(functions) == 1
         func_names = [f.name for f in functions]
         assert "measureTime" in func_names
 
@@ -1402,7 +1402,7 @@ inline fun <reified T> isOfType(value: Any): Boolean {
         tree = kotlin_parser.parse(code.encode("utf-8"))
         functions = extractor.extract_functions(tree, code)
 
-        assert len(functions) >= 1
+        assert len(functions) == 1
 
     def test_extract_crossinline_function(self, extractor, kotlin_parser):
         """Should extract function with crossinline parameter."""
@@ -1414,7 +1414,7 @@ inline fun createRunnable(crossinline body: () -> Unit): Runnable {
         tree = kotlin_parser.parse(code.encode("utf-8"))
         functions = extractor.extract_functions(tree, code)
 
-        assert len(functions) >= 1
+        assert len(functions) == 1
 
 
 class TestKotlinCompanionObjects:
@@ -1445,7 +1445,7 @@ class MyClass {
         tree = kotlin_parser.parse(code.encode("utf-8"))
         classes = extractor.extract_classes(tree, code)
 
-        assert len(classes) >= 1
+        assert len(classes) == 1
         class_names = [c.name for c in classes]
         assert "MyClass" in class_names
 
@@ -1461,7 +1461,7 @@ class MyService {
         tree = kotlin_parser.parse(code.encode("utf-8"))
         classes = extractor.extract_classes(tree, code)
 
-        assert len(classes) >= 1
+        assert len(classes) == 1
 
 
 class TestKotlinGenerics:
@@ -1489,7 +1489,7 @@ class Box<T>(val value: T) {
         tree = kotlin_parser.parse(code.encode("utf-8"))
         classes = extractor.extract_classes(tree, code)
 
-        assert len(classes) >= 1
+        assert len(classes) == 1
         class_names = [c.name for c in classes]
         assert "Box" in class_names
 
@@ -1503,7 +1503,7 @@ fun <T> singletonList(item: T): List<T> {
         tree = kotlin_parser.parse(code.encode("utf-8"))
         functions = extractor.extract_functions(tree, code)
 
-        assert len(functions) >= 1
+        assert len(functions) == 1
 
     def test_extract_bounded_generic(self, extractor, kotlin_parser):
         """Should extract class with bounded generic type."""
@@ -1515,7 +1515,7 @@ class NumberBox<T : Number>(val value: T) {
         tree = kotlin_parser.parse(code.encode("utf-8"))
         classes = extractor.extract_classes(tree, code)
 
-        assert len(classes) >= 1
+        assert len(classes) == 1
 
     def test_extract_variance_annotations(self, extractor, kotlin_parser):
         """Should extract class with variance annotations."""
@@ -1531,7 +1531,7 @@ class Consumer<in T> {
         tree = kotlin_parser.parse(code.encode("utf-8"))
         classes = extractor.extract_classes(tree, code)
 
-        assert len(classes) >= 2
+        assert len(classes) == 2
 
 
 class TestKotlinPropertyDelegates:
@@ -1562,7 +1562,7 @@ class HeavyObject {
         tree = kotlin_parser.parse(code.encode("utf-8"))
         classes = extractor.extract_classes(tree, code)
 
-        assert len(classes) >= 1
+        assert len(classes) == 1
         class_names = [c.name for c in classes]
         assert "HeavyObject" in class_names
 
@@ -1580,7 +1580,7 @@ class User {
         tree = kotlin_parser.parse(code.encode("utf-8"))
         classes = extractor.extract_classes(tree, code)
 
-        assert len(classes) >= 1
+        assert len(classes) == 1
 
 
 class TestKotlinAnnotations:
@@ -1610,7 +1610,7 @@ class AnnotatedClass {}
         classes = extractor.extract_classes(tree, code)
 
         # Should detect Fancy as annotation class or AnnotatedClass
-        assert len(classes) >= 1
+        assert len(classes) == 2
 
     def test_extract_function_with_annotations(self, extractor, kotlin_parser):
         """Should extract function with annotations."""
@@ -1628,7 +1628,7 @@ fun newFunction(param: String) {
         tree = kotlin_parser.parse(code.encode("utf-8"))
         functions = extractor.extract_functions(tree, code)
 
-        assert len(functions) >= 2
+        assert len(functions) == 2
 
 
 class TestKotlinNestedClasses:
@@ -1658,7 +1658,7 @@ class Outer {
         tree = kotlin_parser.parse(code.encode("utf-8"))
         classes = extractor.extract_classes(tree, code)
 
-        assert len(classes) >= 1
+        assert len(classes) == 2
         class_names = [c.name for c in classes]
         assert "Outer" in class_names
 
@@ -1676,7 +1676,7 @@ class Outer {
         tree = kotlin_parser.parse(code.encode("utf-8"))
         classes = extractor.extract_classes(tree, code)
 
-        assert len(classes) >= 1
+        assert len(classes) == 2
 
 
 class TestKotlinEnumClasses:
@@ -1704,7 +1704,7 @@ enum class Direction {
         tree = kotlin_parser.parse(code.encode("utf-8"))
         classes = extractor.extract_classes(tree, code)
 
-        assert len(classes) >= 1
+        assert len(classes) == 1
         class_names = [c.name for c in classes]
         assert "Direction" in class_names
 
@@ -1722,7 +1722,7 @@ enum class Color(val rgb: Int) {
         tree = kotlin_parser.parse(code.encode("utf-8"))
         classes = extractor.extract_classes(tree, code)
 
-        assert len(classes) >= 1
+        assert len(classes) == 1
         class_names = [c.name for c in classes]
         assert "Color" in class_names
 
@@ -1831,7 +1831,9 @@ import kotlinx.coroutines.*
         imports = extractor.extract_imports(tree, code)
 
         assert isinstance(imports, list)
-        assert len(imports) >= 0  # May or may not extract depending on implementation
+        assert (
+            len(imports) == 0
+        )  # extraction gap: kotlin import extraction not yet implemented
 
     def test_extract_variables_extractor(self, extractor, kotlin_parser):
         """Test extract_variables method."""
@@ -1946,7 +1948,7 @@ class Level1 {
 
         classes = extractor.extract_classes(tree, code)
 
-        assert len(classes) >= 1
+        assert len(classes) == 4
         class_names = [c.name for c in classes]
         assert "Level1" in class_names
 
@@ -1962,7 +1964,7 @@ fun add(a: String, b: String): String = a + b
         functions = extractor.extract_functions(tree, code)
 
         # Should extract all overloaded functions
-        assert len(functions) >= 3
+        assert len(functions) == 3
         assert all(f.name == "add" for f in functions)
 
 


### PR DESCRIPTION
## Summary

Layer-2 loose-assertion cleanup, batch 6 — first languages batch. 75 enforcement-pattern hits → exact pins, **0 exemptions**; ratchet baseline 1600 → 1525 (−75 exactly).

| File | Hits → Remaining |
|---|---|
| test_kotlin_plugin.py | 43 → 0 |
| test_cpp_plugin_coverage_boost_core.py | 32 → 0 |

These are tree-sitter extraction counts over inline fixtures — the core target of the ratchet program: a grammar-version bump that shifts a count now goes red and forces a conscious re-pin instead of drifting under a `>=`.

## Extraction gap surfaced (the ratchet doing its job)

`test_extract_imports_extractor`: the fixture contains **3 import statements; `extract_imports()` returns 0**. The old `>= 0` was vacuously green over a silently-broken extraction. Pinned `== 0` with an explicit `extraction gap` comment so the fix is forced to re-pin to 3. Lead independently reproduced (handler is wired to `import_header`; current grammar likely emits a different node type). Tracked in a separate issue — plugin fix is out of scope for a test-only PR.

## Hard-step analysis

A (dead branches): none — direct extraction API calls on real parsed trees. B (environment): N/A — inline fixtures, no file I/O or binary checks. C (exemptions): 0.

## Test plan

- [x] Both files green (`-n 0`, sequential; 179 tests) + aggregator consumers (330 tests)
- [x] `bash scripts/check_loose_assertions.sh origin/develop` exits 0
- [x] Baseline re-measured 1525 (lead spot-checked both files — 0 residual)