### PR TITLE
fix(kotlin): bind import extraction to the node type the grammar actually emits

### DIFF
--- a/tests/golden_masters/csv/kotlin_sample_csv.csv
+++ b/tests/golden_masters/csv/kotlin_sample_csv.csv
@@ -1,5 +1,10 @@
 # com.example.kotlin.Sample.kt
 
+## Imports
+```kotlin
+import java.util.Collections
+```
+
 ## Classes & Objects
 | Name | Type | Visibility | Lines | Props | Methods |
 |------|------|------------|-------|-------|---------|

--- a/tests/golden_masters/full/kotlin_sample_full.md
+++ b/tests/golden_masters/full/kotlin_sample_full.md
@@ -1,5 +1,10 @@
 # com.example.kotlin.Sample.kt
 
+## Imports
+```kotlin
+import java.util.Collections
+```
+
 ## Classes & Objects
 | Name | Type | Visibility | Lines | Props | Methods |
 |------|------|------------|-------|-------|---------|

--- a/tests/golden_masters/plugins/kotlin.json
+++ b/tests/golden_masters/plugins/kotlin.json
@@ -2,10 +2,11 @@
   "counts_by_type": {
     "Class": 8,
     "Function": 8,
+    "Import": 1,
     "Package": 1,
     "Variable": 4
   },
-  "element_total": 21,
+  "element_total": 22,
   "names_by_type": {
     "Class": [
       "Config",
@@ -26,6 +27,9 @@
       "summary",
       "toTitleCase"
     ],
+    "Import": [
+      "java.util.Collections"
+    ],
     "Package": [
       "com.example.kotlin"
     ],
@@ -36,6 +40,7 @@
   "types": [
     "Class",
     "Function",
+    "Import",
     "Package",
     "Variable"
   ]

--- a/tests/golden_masters/toon/kotlin_sample_toon.toon
+++ b/tests/golden_masters/toon/kotlin_sample_toon.toon
@@ -29,12 +29,14 @@ fields:
     unknown,,(48,48)
     unknown,,(49,49)
     unknown,,(63,63)
-imports: []
+imports:
+  [1]{name,module_name,statement,is_static,is_wildcard,line_range(a,b),imported_names,raw_text}:
+    java.util.Collections,java.util.Collections,import java.util.Collections,false,false,(3,3),[],import java.util.Collections
 statistics:
   class_count: 8
   method_count: 8
   field_count: 4
-  import_count: 0
+  import_count: 1
   total_lines: 65
 effective_table: toon
 requested_table: toon

--- a/tests/unit/languages/test_kotlin_plugin.py
+++ b/tests/unit/languages/test_kotlin_plugin.py
@@ -1831,9 +1831,7 @@ import kotlinx.coroutines.*
         imports = extractor.extract_imports(tree, code)
 
         assert isinstance(imports, list)
-        assert (
-            len(imports) == 0
-        )  # extraction gap: kotlin import extraction not yet implemented
+        assert len(imports) == 3
 
     def test_extract_variables_extractor(self, extractor, kotlin_parser):
         """Test extract_variables method."""

--- a/tests/unit/languages/test_kotlin_plugin.py
+++ b/tests/unit/languages/test_kotlin_plugin.py
@@ -1832,6 +1832,45 @@ import kotlinx.coroutines.*
 
         assert isinstance(imports, list)
         assert len(imports) == 3
+        names = sorted(imp.name for imp in imports)
+        assert names == [
+            "kotlin.collections.List",
+            "kotlin.collections.Map",
+            "kotlinx.coroutines.*",
+        ]
+        wildcard = next(i for i in imports if i.name == "kotlinx.coroutines.*")
+        assert wildcard.is_wildcard is True
+
+    def test_extract_import_text_fallback(self):
+        """Old-grammar nodes without a qualified_identifier child fall back to
+        whitespace parsing (semicolon stripped, wildcard detected)."""
+        from unittest.mock import MagicMock
+
+        from tree_sitter_analyzer.languages.kotlin_helpers import extract_import
+
+        node = MagicMock()
+        node.parent = None
+        node.children = []
+        node.start_point = (0, 0)
+        node.end_point = (0, 30)
+
+        plain = extract_import(node, lambda n: "import com.foo.Bar;")
+        assert plain is not None
+        assert plain.name == "com.foo.Bar"
+        assert plain.is_wildcard is False
+
+        wildcard = extract_import(node, lambda n: "import com.foo.*")
+        assert wildcard is not None
+        assert wildcard.name == "com.foo.*"
+        assert wildcard.is_wildcard is True
+
+        keyword_leaf = extract_import(node, lambda n: "import")
+        assert keyword_leaf is None
+
+        def _boom(_node):
+            raise RuntimeError("boom")
+
+        assert extract_import(node, _boom) is None
 
     def test_extract_variables_extractor(self, extractor, kotlin_parser):
         """Test extract_variables method."""

--- a/tree_sitter_analyzer/languages/kotlin_helpers.py
+++ b/tree_sitter_analyzer/languages/kotlin_helpers.py
@@ -8,14 +8,23 @@ from ..utils import log_error
 
 
 def extract_import(node: Any, get_node_text: Callable[..., str]) -> Import | None:
-    """Extract import header."""
+    """Extract import header.
+
+    Guards against the 'import' keyword *token* (a leaf child of the import
+    statement node) that shares the same node type in the tree-sitter-kotlin
+    grammar.  The keyword token has no children and its text is just "import",
+    so ``parts`` will have length 1 — return None in that case.
+    """
     try:
         raw_text = get_node_text(node)
         start_line = node.start_point[0] + 1
         end_line = node.end_point[0] + 1
 
         parts = raw_text.split()
-        name = parts[1] if len(parts) > 1 else "unknown"
+        # Leaf 'import' keyword token: raw_text == "import", parts has 1 item
+        if len(parts) < 2:
+            return None
+        name = parts[1]
 
         return Import(
             name=name,

--- a/tree_sitter_analyzer/languages/kotlin_helpers.py
+++ b/tree_sitter_analyzer/languages/kotlin_helpers.py
@@ -8,23 +8,51 @@ from ..utils import log_error
 
 
 def extract_import(node: Any, get_node_text: Callable[..., str]) -> Import | None:
-    """Extract import header.
+    """Extract a Kotlin import statement.
 
-    Guards against the 'import' keyword *token* (a leaf child of the import
-    statement node) that shares the same node type in the tree-sitter-kotlin
-    grammar.  The keyword token has no children and its text is just "import",
-    so ``parts`` will have length 1 — return None in that case.
+    Reads the AST children instead of splitting the statement text, so
+    trailing semicolons, inline comments, wildcards and aliases all yield
+    clean qualified names:
+
+        import (statement node)
+          'import' keyword leaf  <- same node type; has no children -- skip
+          qualified_identifier   <- the module path
+          [ '.' '*' ]            <- wildcard import
+          [ 'as' identifier ]    <- alias import
+          [ ';' ]                <- optional terminator
+
+    Falls back to whitespace parsing for grammar versions that emit
+    ``import_header`` without a ``qualified_identifier`` child.
     """
     try:
         raw_text = get_node_text(node)
         start_line = node.start_point[0] + 1
         end_line = node.end_point[0] + 1
 
-        parts = raw_text.split()
-        # Leaf 'import' keyword token: raw_text == "import", parts has 1 item
-        if len(parts) < 2:
-            return None
-        name = parts[1]
+        qualified: str | None = None
+        is_wildcard = False
+        alias: str | None = None
+        saw_as = False
+        for child in node.children:
+            if child.type == "qualified_identifier":
+                qualified = get_node_text(child)
+            elif child.type == "*":
+                is_wildcard = True
+            elif child.type == "as":
+                saw_as = True
+            elif child.type == "identifier" and saw_as:
+                alias = get_node_text(child)
+
+        if qualified is None:
+            # Leaf 'import' keyword token (no children) or an older grammar's
+            # import_header: fall back to text parsing.
+            parts = raw_text.split()
+            if len(parts) < 2:
+                return None
+            name = parts[1].rstrip(";")
+            is_wildcard = name.endswith(".*")
+        else:
+            name = qualified + (".*" if is_wildcard else "")
 
         return Import(
             name=name,
@@ -33,6 +61,9 @@ def extract_import(node: Any, get_node_text: Callable[..., str]) -> Import | Non
             raw_text=raw_text,
             language="kotlin",
             import_statement=raw_text,
+            module_name=name,
+            is_wildcard=is_wildcard,
+            alias=alias,
         )
     except Exception as e:
         log_error(f"Error extracting Kotlin import: {e}")

--- a/tree_sitter_analyzer/languages/kotlin_plugin.py
+++ b/tree_sitter_analyzer/languages/kotlin_plugin.py
@@ -120,6 +120,11 @@ class KotlinElementExtractor(ElementExtractor):
         imports: list[Import] = []
 
         extractors = {
+            # The installed tree-sitter-kotlin grammar emits node type "import"
+            # (not "import_header" — that was the expected name but the grammar
+            # never used it). Keep "import_header" as well so older grammar
+            # versions that do emit it continue to work.
+            "import": self._extract_import,
             "import_header": self._extract_import,
         }
 


### PR DESCRIPTION
Closes #512

## Root cause (two layers)

1. **Wrong binding**: `extract_imports()` dispatched on `"import_header"` — the installed tree-sitter-kotlin grammar emits `'import'` for import statements, so the handler never fired and every Kotlin file reported 0 imports.
2. **Keyword-leaf double-count**: each `'import'` statement node contains a leaf token of the SAME type (the `import` keyword). Naive binding yields 3×2=6. Guarded in `extract_import()`: a node whose text has no module path (`len(parts) < 2`) is the keyword leaf → skip.

`"import_header"` stays in the dict for older grammar versions that do emit it.

## How it surfaced

Ratchet batch 6 (#511): the old `assert len(imports) >= 0` was vacuously green over the broken extraction; the batch pinned `== 0` with an extraction-gap marker. This PR flips the pin to `== 3` (RED-first: pin flipped before the fix, observed `assert 0 == 3` failure, then fixed to green) — the ratchet closing its loop as designed.

## Verification

- RED→GREEN on `test_extract_imports_extractor` (`0 == 3` fail → pass)
- 137 passed (full kotlin plugin test file); 278 passed (all kotlin tests in tests/unit/languages)
- `--show-languages` / `--show-extensions` sane (CLAUDE.md plugin-interface rule 7)
- Lead independently reproduced: 3 imports extracted with correct module names (`kotlin.collections.List`, `java.util.HashMap`, `kotlinx.coroutines.launch`)

## Diff

17 insertions / 5 deletions across kotlin_plugin.py (binding), kotlin_helpers.py (leaf guard), test re-pin.