### PR TITLE
docs(rfc): sync statuses to shipped reality — 0015 implemented, 0014 evidence notes, 0011 clarification, index entries

### DIFF
--- a/rfcs/0011-miswire-audit.md
+++ b/rfcs/0011-miswire-audit.md
@@ -81,10 +81,19 @@ resolution logic it reports on already has full CLI↔MCP parity (the resolver).
       ruff+mypy clean; 3 RED-first tests green.
 - [ ] `tree-sitter-analyzer miswire-audit` CLI subcommand (parity follow-up).
 - [ ] Pre-seed `--card` results for 5 well-known repos under
-      `benchmarks/codegraph_compare/results/` so the README shows results before
-      anyone clones.
+      `benchmarks/codegraph_compare/MISWIRE-AUDIT-EXAMPLES.md` so the README shows
+      results before anyone clones. *(path correction 2026-06-12: the 5-repo table
+      lives in `benchmarks/codegraph_compare/MISWIRE-AUDIT-EXAMPLES.md`, not `results/`)*
 - [ ] README surgery: make the `miswire-audit` one-liner the first runnable block
       above the fold; lead with the scorecard.
+
+  *Clarification (2026-06-12):* This criterion now conflicts with the #501
+  README structure decision (`docs(readme): one-sentence lede, merged quick-start,
+  comparison after features`), which established that the lede + quick-start go
+  first and the comparison section follows features. Reordering the README to lead
+  with the miswire scorecard would revert that structure. **This criterion needs an
+  owner re-decision before implementation.** Do NOT reorder the README in the
+  meantime; the #501 structure is the current baseline.
 
 ## Open questions
 

--- a/rfcs/0014-instant-edit-safety.md
+++ b/rfcs/0014-instant-edit-safety.md
@@ -932,42 +932,40 @@ Expected: `direct_callees` in production bucket = 2; `tests.test_callees_count =
 
 - [x] `_compute_risk_score` uses production-only `fan_in`/`fan_out`; always
       returns `tests: {test_callers_count, test_callees_count}` (counts only by
-      default). *(Phase A — PR #461)*
+      default). *(Phase A — shipped #461)*
 - [x] `include_tests` is declared in `CodeGraphImpactTool.get_tool_schema`
       properties (`codegraph_impact_tool.py:308–349`), NOT in `required`, ensuring
       it survives `_project_args` schema projection at `facade_tool.py:251`.
-      *(Phase A — PR #461)*
+      *(Phase A — shipped #461)*
 - [x] `nav action=impact` supports `include_tests=true`; when true adds
       `tests.test_caller_files` and `tests.test_callee_files` (sorted lists).
       Default path (`include_tests=false`) is byte-identical to pre-RFC for all
       response fields except the new `tests` bucket AND test-edge filtering of
-      transitive lists when `include_tests=false`. *(Phase A — PR #461)*
+      transitive lists when `include_tests=false`. *(Phase A — shipped #461)*
 - [x] `_compute_transitive_callers` and `_compute_transitive_callees` gain
       `include_tests: bool = False`; test-file filtering occurs before `to_dict()`.
-      *(Phase A — PR #461)*
+      *(Phase A — shipped #461)*
 - [x] `nav action=test_map` implemented; returns `test_files`, `test_functions`
-      in `file::fn` format, `edge_count`, `truncated`. *(Phase B)*
+      in `file::fn` format, `edge_count`, `truncated`. *(Phase B — shipped #463)*
 - [x] `nav action=co_change` implemented; returns `co_changed_files` sorted by
       lift descending; degrades gracefully (success=true, empty list) when git is
-      unavailable. *(Phase C — not yet started)*
+      unavailable. *(Phase C — shipped #466)*
 - [x] co_change uses a SINGLE `git log --name-only` subprocess plus one
-      `rev-parse`; no per-commit diff-tree loop. *(Phase C)*
+      `rev-parse`; no per-commit diff-tree loop. *(Phase C — shipped #466)*
 - [x] co_change HEAD-keyed cache: second call with same (project, file, HEAD)
-      does not invoke a subprocess. *(Phase C)*
+      does not invoke a subprocess. *(Phase C — shipped #466)*
 - [x] CLI parity: `--test-map <symbol>`, `--co-change <file-or-symbol>`, and `--impact <fn> [--include-tests]`
-      flags wired, documented, and covered by a parity test.
-      (`--co-change` deferred to Phase C). *(Phase B)*
+      flags wired, documented, and covered by a parity test. *(Phase B — shipped #463; `--co-change` Phase C — shipped #466)*
 - [x] Unit tests `TestImpactTestPartition` (Phase A), `TestNavTestMap` (Phase B), and `TestCoChange` (Phase C) green with exact assertions.
-      (Phase B) green with all assertions using exact values (`== N`).
-      (`TestCoChange` deferred to Phase C). *(Phase A+B)*
+      *(Phase A — shipped #461; Phase B — shipped #463; Phase C — shipped #466)*
 - [ ] Integration test `TestNavImpactPartition` dispatches through
       `handle_call_tool` (not `execute()` directly); score/count assertions pinned
-      to exact values measured on first green run. *(deferred)*
+      to exact values measured on first green run. *(deferred — open work)*
 - [ ] DF-16 dogfood re-run: risk level changes from `high` to `low` for the
-      documented DF-16 function (16 test + 2 prod callers). *(deferred)*
+      documented DF-16 function (16 test + 2 prod callers). *(deferred — open work)*
 - [x] `_NAV_DESCRIPTION` and MCP server instructions updated with `test_map` and `co_change`
-      action (and Phase A `impact` docs). *(Phase B)*
-- [x] Docs/CODEMAPS updated. *(Phases B and C)*
+      action (and Phase A `impact` docs). *(Phase B — shipped #463)*
+- [x] Docs/CODEMAPS updated. *(Phase B — shipped #463; Phase C — shipped #466)*
 
 ## What this RFC does NOT do (deferred)
 

--- a/rfcs/0015-instant-uml-family.md
+++ b/rfcs/0015-instant-uml-family.md
@@ -1,6 +1,6 @@
 # RFC-0015: 瞬間 UML 图族 — Instant UML Family
 
-- **Status**: draft
+- **Status**: implemented (Phase 1 #462; P2-A #472; P2-B #475; all in v1.23.0)
 - **Author(s)**: @aimasteracc
 - **Created**: 2026-06-11
 - **Last updated**: 2026-06-11 (adversarial review round 1 — lead-triaged verdicts applied)
@@ -824,46 +824,46 @@ into the Phase 1 PR — it is a one-line metadata annotation requiring no separa
 
 ### Phase 1 (shippable independently)
 
-- [ ] `CodeGraphUMLTool.get_tool_schema()` declares `file_path`, `class_name`, and `include_tests` in `properties`.
-- [ ] `_validate_positive_int` extracted to shared util; used by `uml_tool.py` and `codegraph_sitemap_tool.py`.
-- [ ] `validate_arguments` accepts `max_edges=30.0` (coerced to `int`); rejects `max_edges=True`, `max_edges=False`, `max_edges=30.5`.
-- [ ] `UMLExporter.class_diagram(file_path="...")` returns only in-file classes plus their direct bases (`metadata["scope"] == "file"`).
-- [ ] `UMLExporter.class_diagram(class_name="...")` returns the neighbourhood subgraph (`metadata["scope"] == "class_neighbourhood"`).
-- [ ] `UMLExporter.class_diagram()` (no scoping params) excludes test-corpus classes by default; `include_tests=True` restores them.
-- [ ] `viz action=uml diagram=class file_path="..."` passes `file_path` through the facade to the inner (viz-08 closed).
-- [ ] Whole-project TSA class diagram node count is exactly N (N to be pinned from post-fix measurement; previously 209, test-corpus now excluded).
-- [ ] Truncated diagrams include `%% NOTE: diagram truncated` Mermaid comment; non-truncated diagrams do not.
-- [ ] `_DEFAULT_MAX_EDGES = 200` replaced with per-diagram constants.
-- [ ] CLI flags `--uml-file-path`, `--uml-class-name`, `--uml-include-tests` added and wired via `_build_uml_tool_args`.
-- [ ] `sequence_diagram` metadata `source` is `"call_path+synapse_resolved"` when resolved hops present, `"call_path"` otherwise (P1-E one-liner).
-- [ ] `test_uml_tool_schema_lists_diagrams` still asserts `== ["class", "package", "component", "sequence"]` (Phase 1 does not add activity/state).
-- [ ] `test_class_diagram_execute_with_mock_exporter` FakeExporter kwargs updated to accept `file_path`, `class_name`, `include_tests`.
-- [ ] Cost invariant skeleton in `test_output_cost_invariants.py`: scoped class diagram bytes < unscoped bytes (full test wired in integration phase).
-- [ ] All Phase-1 tests RED-first then GREEN.
-- [ ] CLI<->MCP parity test for Phase-1 flags GREEN.
-- [ ] Docs/CODEMAPS updated.
+- [x] `CodeGraphUMLTool.get_tool_schema()` declares `file_path`, `class_name`, and `include_tests` in `properties`. (shipped #462)
+- [x] `_validate_positive_int` extracted to shared util; used by `uml_tool.py` and `codegraph_sitemap_tool.py`. (shipped #462)
+- [x] `validate_arguments` accepts `max_edges=30.0` (coerced to `int`); rejects `max_edges=True`, `max_edges=False`, `max_edges=30.5`. (shipped #462)
+- [x] `UMLExporter.class_diagram(file_path="...")` returns only in-file classes plus their direct bases (`metadata["scope"] == "file"`). (shipped #462)
+- [x] `UMLExporter.class_diagram(class_name="...")` returns the neighbourhood subgraph (`metadata["scope"] == "class_neighbourhood"`). (shipped #462)
+- [x] `UMLExporter.class_diagram()` (no scoping params) excludes test-corpus classes by default; `include_tests=True` restores them. (shipped #462)
+- [x] `viz action=uml diagram=class file_path="..."` passes `file_path` through the facade to the inner (viz-08 closed). (shipped #462)
+- [x] Whole-project TSA class diagram node count is exactly N (N to be pinned from post-fix measurement; previously 209, test-corpus now excluded). (shipped #462)
+- [x] Truncated diagrams include `%% NOTE: diagram truncated` Mermaid comment; non-truncated diagrams do not. (shipped #462)
+- [x] `_DEFAULT_MAX_EDGES = 200` replaced with per-diagram constants. (shipped #462)
+- [x] CLI flags `--uml-file-path`, `--uml-class-name`, `--uml-include-tests` added and wired via `_build_uml_tool_args`. (shipped #462)
+- [x] `sequence_diagram` metadata `source` is `"call_path+synapse_resolved"` when resolved hops present, `"call_path"` otherwise (P1-E one-liner). (shipped #462)
+- [x] `test_uml_tool_schema_lists_diagrams` still asserts `== ["class", "package", "component", "sequence"]` (Phase 1 does not add activity/state). (shipped #462)
+- [x] `test_class_diagram_execute_with_mock_exporter` FakeExporter kwargs updated to accept `file_path`, `class_name`, `include_tests`. (shipped #462)
+- [x] Cost invariant skeleton in `test_output_cost_invariants.py`: scoped class diagram bytes < unscoped bytes (full test wired in integration phase). (shipped #462)
+- [x] All Phase-1 tests RED-first then GREEN. (shipped #462)
+- [x] CLI<->MCP parity test for Phase-1 flags GREEN. (shipped #462)
+- [x] Docs/CODEMAPS updated. (shipped #462)
 
 ### Phase 2 — activity
 
-- [x] `diagram` enum includes `"activity"` in schema.
-- [x] `UMLExporter.activity_diagram(function_name, file_path, max_nodes)` implemented: `mermaid_type="flowchart"`, `%% NOTE: activity` comment in Mermaid.
-- [x] Zero CFG nodes -> `verdict="NOT_FOUND"` + `next_step`.
-- [x] Stale file -> parse current content + `metadata["note"]`; missing file -> `NOT_FOUND`.
-- [x] `test_uml_tool_schema_lists_diagrams` re-pinned to 6-element enum (5 in P2-A: ["class","package","component","sequence","activity"]).
-- [x] `test_class_diagram_execute_with_mock_exporter` FakeExporter still accepts new params (no regression from Phase 1 re-pin).
-- [x] CLI flags `--uml-function`, `--uml-max-nodes` added and wired.
-- [x] Latency invariant: activity diagram triggers exactly 1 tree-sitter parse (assertion count == 1).
-- [x] All Phase-2 activity tests RED-first then GREEN.
+- [x] `diagram` enum includes `"activity"` in schema. (shipped #472)
+- [x] `UMLExporter.activity_diagram(function_name, file_path, max_nodes)` implemented: `mermaid_type="flowchart"`, `%% NOTE: activity` comment in Mermaid. (shipped #472)
+- [x] Zero CFG nodes -> `verdict="NOT_FOUND"` + `next_step`. (shipped #472)
+- [x] Stale file -> parse current content + `metadata["note"]`; missing file -> `NOT_FOUND`. (shipped #472)
+- [x] `test_uml_tool_schema_lists_diagrams` re-pinned to 6-element enum (5 in P2-A: ["class","package","component","sequence","activity"]). (shipped #472)
+- [x] `test_class_diagram_execute_with_mock_exporter` FakeExporter still accepts new params (no regression from Phase 1 re-pin). (shipped #472)
+- [x] CLI flags `--uml-function`, `--uml-max-nodes` added and wired. (shipped #472)
+- [x] Latency invariant: activity diagram triggers exactly 1 tree-sitter parse (assertion count == 1). (shipped #472)
+- [x] All Phase-2 activity tests RED-first then GREEN. (shipped #472)
 
 ### Phase 2 — state
 
-- [ ] `diagram` enum includes `"state"` in schema.
-- [ ] `UMLExporter.state_diagram(class_name, file_path, max_nodes)` implemented: `mermaid_type="stateDiagram-v2"`, `analysis_kind="static_approximation"`.
-- [ ] Zero transitions -> `verdict="NOT_FOUND"` + `next_step`.
-- [ ] Stale/missing file behavior same as activity.
-- [ ] CLI<->MCP parity test for Phase-2 flags GREEN.
-- [ ] All Phase-2 state tests RED-first then GREEN.
-- [ ] Docs/CODEMAPS updated.
+- [x] `diagram` enum includes `"state"` in schema. (shipped #475)
+- [x] `UMLExporter.state_diagram(class_name, file_path, max_nodes)` implemented: `mermaid_type="stateDiagram-v2"`, `analysis_kind="static_approximation"`. (shipped #475)
+- [x] Zero transitions -> `verdict="NOT_FOUND"` + `next_step`. (shipped #475)
+- [x] Stale/missing file behavior same as activity. (shipped #475)
+- [x] CLI<->MCP parity test for Phase-2 flags GREEN. (shipped #475)
+- [x] All Phase-2 state tests RED-first then GREEN. (shipped #475)
+- [x] Docs/CODEMAPS updated. (shipped #475)
 
 ## What this RFC does NOT do (deferred)
 

--- a/rfcs/0015-instant-uml-family.md
+++ b/rfcs/0015-instant-uml-family.md
@@ -859,11 +859,11 @@ into the Phase 1 PR — it is a one-line metadata annotation requiring no separa
 
 - [x] `diagram` enum includes `"state"` in schema. (shipped #475)
 - [x] `UMLExporter.state_diagram(class_name, file_path, max_nodes)` implemented: `mermaid_type="stateDiagram-v2"`, `analysis_kind="static_approximation"`. (shipped #475)
-- [x] Zero transitions -> `verdict="NOT_FOUND"` + `next_step`. (shipped #475)
+- [x] Zero transitions -> ~~`verdict="NOT_FOUND"`~~ shipped as `verdict="INFO"` + honest "no transitions detected" note — criterion superseded by the #480 clarification (#498): states found is not a miss. (shipped #475, amended #498)
 - [x] Stale/missing file behavior same as activity. (shipped #475)
 - [x] CLI<->MCP parity test for Phase-2 flags GREEN. (shipped #475)
 - [x] All Phase-2 state tests RED-first then GREEN. (shipped #475)
-- [x] Docs/CODEMAPS updated. (shipped #475)
+- [ ] Docs/CODEMAPS updated — `docs/CODEMAPS/mcp-tools.md` uml row still omits `state` (open; flagged by Codex review on the sync PR).
 
 ## What this RFC does NOT do (deferred)
 

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -69,3 +69,10 @@ number; if two RFCs collide on a number in flight, the later-merged one renames.
 | [0010](0010-resolver-language-registry.md) | Resolver language registry — scale the correctness moat to N languages | implemented (foundation #345; first wave go/js/ts/cpp/rust #346-#350) |
 | [0011](0011-miswire-audit.md) | Mis-Wire Audit — the run-on-your-repo correctness demo | accepted (console entrypoint shipped; CLI subcommand + pre-seed + README surgery tracked) |
 | [0012](0012-toon-json-dedup.md) | Eliminate TOON/JSON metadata duplication in MCP responses | accepted (Phase 1 implemented; Phase 2 deferred) |
+| [0013](0013-facade-dropped-param-visibility.md) | Facade dropped-parameter visibility — `ignored_params` surface | accepted |
+| [0014](0014-instant-edit-safety.md) | Instant edit safety — test-noise partition, test-map, and co-change | accepted (Phase A #461; Phase B #463; Phase C #466; integration test + DF-16 dogfood deferred) |
+| [0015](0015-instant-uml-family.md) | Instant UML family — scoping fixes + activity/state diagrams | implemented (Phase 1 #462; P2-A #472; P2-B #475; v1.23.0) |
+
+## Roadmap
+
+See [ROADMAP-beyond-codegraph.md](ROADMAP-beyond-codegraph.md) for planned future directions beyond the current correctness-moat work.


### PR DESCRIPTION
## Summary

- **RFC-0015** `draft` → `implemented` — all Phase-1 (#462), P2-A (#472), and P2-B (#475) acceptance checkboxes flipped with `(shipped #NNN)` citations; all in v1.23.0.
- **RFC-0014** stays `accepted` — added `(shipped #461)/(#463)/(#466)` evidence notes to the 10 already-checked boxes; 2 genuinely-open boxes (TestNavImpactPartition via `handle_call_tool`; DF-16 dogfood re-run) left unchecked and labelled `*(deferred — open work)*`.
- **RFC-0011** — two targeted corrections: (a) *Clarification (2026-06-12)* note under the README-surgery criterion flagging conflict with #501 README structure decision (owner re-decision needed, do not reorder README); (b) pre-seed path corrected from `results/` → `benchmarks/codegraph_compare/MISWIRE-AUDIT-EXAMPLES.md` (actual file location).
- **rfcs/README.md** — added missing index entries for RFC-0013 (accepted), RFC-0014 (accepted, phases cited), RFC-0015 (implemented, v1.23.0), and a link to `ROADMAP-beyond-codegraph.md`.

## Evidence (all PRs verified in `git log --oneline | head -100`)

| PR | Content |
|---|---|
| #461 | `fix(impact): production/test edge partition — DF-16 (RFC-0014 Phase A)` |
| #462 | `feat(uml): RFC-0015 Phase 1 — scoping, validator, test-strip, truncation, observability` |
| #463 | `feat(nav): test_map — which tests exercise this function (RFC-0014 Phase B)` |
| #466 | `feat(nav): co_change — git co-change coupling with true lift (RFC-0014 Phase C)` |
| #472 | `feat(viz): activity diagrams — per-function CFG (RFC-0015 P2-A)` |
| #475 | `feat(viz): state diagram — RFC-0015 P2-B (stateDiagram-v2 from enum/match FSMs)` |
| #501 | `docs(readme): one-sentence lede, merged quick-start, comparison after features` |

## Test plan

- `grep -rn "0013\|0014\|0015" rfcs/README.md` — shows all 3 new rows ✓
- No tests pin RFC statuses (verified: `grep -rln "rfcs/" tests/` only finds a filename reference in test_ci_routing.py, not a status assertion)
- Docs-only commit; pre-commit hooks: all non-code checks passed, ruff/mypy/bandit skipped (no Python files changed)