### PR TITLE
docs: index lifecycle guide + UML diagram family in features (audit gaps 2+5)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,8 @@ For the project overview and install-and-go instructions, see the
 |---|---|
 | [installation.md](installation.md) | Install via pip/uv, system dependencies (fd, ripgrep) |
 | [cli-reference.md](cli-reference.md) | All CLI flags and commands |
-| [features.md](features.md) | Feature overview |
+| [features.md](features.md) | Feature overview (languages, token optimisation, UML diagrams) |
+| [index-lifecycle.md](index-lifecycle.md) | Index operations: build / full / sync / auto, partial-cache trap, health check |
 | [smart-workflow.md](smart-workflow.md) | The SMART five-step workflow for AI-assisted analysis |
 
 ## Output Formats

--- a/docs/features.md
+++ b/docs/features.md
@@ -288,6 +288,81 @@ For AI assistants with token limits, Tree-sitter Analyzer provides multiple opti
 | **Methods** | Instance, class, singleton | |
 | **Blocks** | Block, Proc, Lambda | |
 
+## UML / Mermaid Diagrams
+
+TSA exports Mermaid diagrams from indexed project intelligence via
+`viz action=uml` (MCP) or `--uml` (CLI). Six diagram types are shipped.
+
+### Diagram types
+
+| Type | What it renders | Key params |
+|---|---|---|
+| `class` | Inheritance graph — classes, superclasses, subclasses | `file_path`, `class_name`, `include_tests`, `--uml-no-external-bases` |
+| `package` | Module dependency graph grouped by directory depth | `package_depth` (default: 2) |
+| `component` | Import-level component dependencies | `max_edges` |
+| `sequence` | Call-path trace between two functions | `source`, `target` (both required) |
+| `activity` | Per-function control-flow graph (CFG) built from the AST | `function_name` (required), `file_path`, `max_nodes` |
+| `state` | FSM approximation from enum definitions and match/switch statements | `file_path`, `max_nodes` |
+
+`activity` and `state` re-parse the source file at query time (disk read +
+tree-sitter parse, typically < 50 ms). All other types read from the index.
+
+### Scoping parameters
+
+| Param | Applies to | Effect |
+|---|---|---|
+| `file_path` / `--uml-file-path` | `class`, `activity`, `state` | Limit to classes or functions in this file |
+| `class_name` / `--uml-class-name` | `class` | Show the named class plus its immediate superclasses and subclasses |
+| `function_name` / `--uml-function` | `activity` | Required: function to graph (bare name or `module.function`) |
+| `include_tests` / `--uml-include-tests` | `class`, `package`, `component` | Include test-corpus classes (default: excluded) |
+| `max_nodes` / `--uml-max-nodes` | `activity`, `state` | Cap on CFG/FSM nodes (default: 50); `truncated=true` when exceeded |
+
+### CLI examples
+
+```bash
+# Whole-project class diagram
+uv run python -m tree_sitter_analyzer --uml class
+
+# Class diagram for one file (excludes external base classes)
+uv run python -m tree_sitter_analyzer --uml class \
+  --uml-file-path tree_sitter_analyzer/mcp/tools/base_tool.py \
+  --uml-no-external-bases
+
+# Neighbourhood subgraph for one class
+uv run python -m tree_sitter_analyzer --uml class \
+  --uml-class-name BaseMCPTool
+
+# Call-path sequence diagram
+uv run python -m tree_sitter_analyzer --uml sequence \
+  --uml-source execute --uml-target build_response
+
+# Per-function CFG (activity diagram)
+uv run python -m tree_sitter_analyzer --uml activity \
+  --uml-function execute \
+  --uml-file-path tree_sitter_analyzer/mcp/tools/uml_tool.py
+
+# Enum/match FSM state diagram
+uv run python -m tree_sitter_analyzer --uml state \
+  --uml-file-path tree_sitter_analyzer/mcp/tools/uml_tool.py
+
+# Package dependency map
+uv run python -m tree_sitter_analyzer --uml package --uml-package-depth 2
+```
+
+### MCP equivalent
+
+```json
+{ "action": "uml", "diagram": "class", "file_path": "src/models.py" }
+{ "action": "uml", "diagram": "activity", "function_name": "execute", "file_path": "src/tool.py" }
+{ "action": "uml", "diagram": "sequence", "source": "handle_call", "target": "build_response" }
+```
+
+All diagrams require the AST index (`index action=status` to check; `index
+action=auto mode=warm` to build). `activity` and `state` additionally need
+`file_path` to locate the source.
+
+---
+
 ## Output Formats
 
 All languages support the following output formats:

--- a/docs/index-lifecycle.md
+++ b/docs/index-lifecycle.md
@@ -1,0 +1,189 @@
+# Index Lifecycle Guide
+
+> **The #1 user trap:** per-query CLI calls (e.g. `--callees`) build only a
+> small on-demand partial cache. Cross-project queries — Hyphae selectors,
+> symbol search across the whole project, callers/callees trees — need the
+> **full** index. Build it once; sync after edits.
+
+---
+
+## Two Separate Indexes
+
+TSA maintains two distinct caches:
+
+| Cache | Location | Built by | Purpose |
+|---|---|---|---|
+| AST symbol index | `.ast-cache/index.db` (SQLite) | `action=full`, `action=auto`, `action=sync` | Symbol definitions, call edges, type info — used by callers/callees, search, Hyphae selectors |
+| Project structure index | `.tree-sitter-cache/project-index.json` | `action=build` | Directory/language map, entry points, README excerpt — used by `project` facade |
+
+Both directories are listed in `.gitignore` and are never committed.
+
+---
+
+## The Four Index Operations
+
+### `action=build` — cold-build the project structure index
+
+Scans the file tree, detects languages, finds entry points, extracts a README
+excerpt, and writes `.tree-sitter-cache/project-index.json`.
+
+**Use when:** starting fresh on a new project, or after large directory
+restructures. This is the lighter of the two indexes (seconds, not minutes).
+
+MCP:
+```json
+{ "action": "build" }
+```
+
+CLI equivalent:
+```bash
+uv run python -m tree_sitter_analyzer --build-project-index
+```
+
+---
+
+### `action=full` — complete AST reindex
+
+Forces a full re-parse of every source file in the project and rebuilds
+`.ast-cache/index.db` from scratch. Equivalent to `--full-index` on the CLI.
+
+**Use when:** after a `git pull`, rebase, or large refactor — any time many
+files changed and you want guaranteed consistency.
+
+MCP:
+```json
+{ "action": "full" }
+```
+
+CLI equivalent:
+```bash
+uv run python -m tree_sitter_analyzer --full-index
+# Force full (skip incremental heuristic):
+uv run python -m tree_sitter_analyzer --full-index --full-index-mode full
+```
+
+---
+
+### `action=sync` — fast incremental sync
+
+Compares each file's SHA-256 content hash against the stored value. Only files
+whose hash differs are re-parsed. Typically completes in seconds on large repos.
+
+**Use when:** after editing a few files — the everyday post-edit operation.
+
+MCP:
+```json
+{ "action": "sync" }
+```
+
+CLI equivalent:
+```bash
+uv run python -m tree_sitter_analyzer --incremental-sync
+```
+
+To preview what would be re-indexed without writing:
+```bash
+uv run python -m tree_sitter_analyzer --incremental-sync --incremental-sync-mode changes
+```
+
+---
+
+### `action=auto` — transparent background warming
+
+Checks whether the index is warm and triggers indexing if not. Other
+codegraph tools call this internally on first use; `action=auto` gives
+explicit control. Modes: `status` (read-only check), `warm` (index if not
+warm — idempotent), `reset` (force re-index on next access).
+
+**Use when:** you want to pre-warm the cache before a batch of queries, or
+check/reset the auto-index guard without running a full reindex.
+
+MCP:
+```json
+{ "action": "auto", "mode": "warm" }
+```
+
+CLI equivalent:
+```bash
+uv run python -m tree_sitter_analyzer --autoindex --autoindex-mode warm
+```
+
+---
+
+## `action=status` — health check
+
+Returns: indexed yes/no, total files, total symbols, FTS5 availability, lag
+vs newest source file, and error indicators. Run this before any navigation
+query to decide whether to warm the cache first.
+
+MCP:
+```json
+{ "action": "status" }
+```
+
+CLI equivalent:
+```bash
+uv run python -m tree_sitter_analyzer --ast-cache --ast-cache-mode stats
+```
+
+---
+
+## The Trap: Partial Cache vs Full Index
+
+Per-query CLI calls like `--callees MyClass.method` build **only** a partial,
+on-demand cache covering the files needed to answer that single query. This
+cache may hold only tens of files out of thousands.
+
+**Queries that require the full index:**
+
+- Hyphae selectors (`search action=subscribe` / `search action=query`)
+- Project-wide symbol search (`search action=symbol`)
+- Caller/callee trees spanning more than the immediate file
+
+**What you see with a partial or missing index:**
+
+Since PR #497, the Hyphae selector tool returns an explicit
+`index_state` field and a `WARN` verdict when the index is absent or empty:
+
+```
+Index missing, empty, or unreadable. Run the `index` tool with
+action=auto to build the cache (if this persists, check
+.ast-cache permissions).
+```
+
+When the index is present but small (e.g. only 1 file indexed from a
+previous on-demand call), the tool reports the actual `indexed_files` count so
+you can judge whether zero results mean "no matches" or "index incomplete".
+
+**Decision guide:**
+
+```
+Editing a few files?        → action=sync   (fast, content-hash diff)
+Just pulled / rebased?      → action=full   (full reindex for consistency)
+First time on project?      → action=full   (then action=build for structure)
+Hyphae/search returning 0?  → action=status → if missing, action=auto mode=warm
+```
+
+---
+
+## Lag and Consistency
+
+The file-watcher debounces ~500 ms after writes. Do not re-query the index
+immediately after editing a file in the same CLI invocation — the index
+reflects the state at parse time.
+
+`action=status` includes a `lag_seconds` field showing the gap between the
+newest source mtime and the cache timestamp. A lag above a few minutes on an
+active codebase is a sign to run `action=sync`.
+
+---
+
+## Quick Reference
+
+| Goal | MCP | CLI |
+|---|---|---|
+| Check index health | `index action=status` | `--ast-cache --ast-cache-mode stats` |
+| Cold-build project structure | `index action=build` | `--build-project-index` |
+| Full reindex (post-pull) | `index action=full` | `--full-index` |
+| Incremental sync (post-edit) | `index action=sync` | `--incremental-sync` |
+| Pre-warm / auto-index | `index action=auto mode=warm` | `--autoindex --autoindex-mode warm` |

--- a/docs/index-lifecycle.md
+++ b/docs/index-lifecycle.md
@@ -52,14 +52,21 @@ files changed and you want guaranteed consistency.
 
 MCP:
 ```json
-{ "action": "full" }
+{ "action": "full", "mode": "full" }
+```
+
+> ⚠️ Without `"mode": "full"` the tool **defaults to `incremental`** — unchanged-but-stale rows survive. For a guaranteed from-scratch rebuild always pass the mode explicitly.
+
+```json
+{ "action": "full" }   // mode defaults to "incremental"
 ```
 
 CLI equivalent:
 ```bash
-uv run python -m tree_sitter_analyzer --full-index
-# Force full (skip incremental heuristic):
+# Guaranteed full rebuild (recommended after pull/rebase):
 uv run python -m tree_sitter_analyzer --full-index --full-index-mode full
+# Bare --full-index defaults to --full-index-mode incremental:
+uv run python -m tree_sitter_analyzer --full-index
 ```
 
 ---
@@ -123,6 +130,8 @@ MCP:
 
 CLI equivalent:
 ```bash
+uv run python -m tree_sitter_analyzer --codegraph-status   # indexed? schema version, FTS5, cache lag
+# Raw AST-cache stats (lower level, no health verdict):
 uv run python -m tree_sitter_analyzer --ast-cache --ast-cache-mode stats
 ```
 


### PR DESCRIPTION
## Summary

- **docs/index-lifecycle.md** (new, 189 lines): documents the #1 user trap — the difference between the small on-demand partial cache built by per-query CLI calls vs the full project index required for Hyphae selectors and cross-project symbol search. Covers all four `index` actions (build/full/sync/auto), where `.ast-cache/index.db` lives, content-hash diff lag, and `action=status` as the health check. PR #497 explicit error hint is cited and cross-checked in source.
- **docs/features.md** (extended): adds a UML/Mermaid subsection documenting all six diagram types now shipped (class/package/component/sequence/activity/state), scoping params, CLI examples, and MCP equivalents.
- **docs/README.md**: both docs registered in the index table.

## Verification

- All 14 documented CLI flags confirmed present in `--help` (verified with `uv run python -m tree_sitter_analyzer --help`)
- `uv run pytest tests/integration/docs -q` → 21 passed, 5 skipped
- `git show --stat` diff matches exactly the 3 files changed
- Both docs are under 250 lines

## Test plan

- [ ] `uv run pytest tests/integration/docs -q` passes on reviewer's machine
- [ ] `uv run python -m tree_sitter_analyzer --help | python3 -c "import sys; s=sys.stdin.read(); [print('OK:', f) for f in ['--uml','--uml-file-path','--uml-function','--uml-include-tests','--uml-max-nodes','--full-index','--incremental-sync','--autoindex','--build-project-index'] if f in s]"` prints all 9 flags
- [ ] Links in docs/index-lifecycle.md resolve (no anchors, all paths relative)