### PR TITLE
test: pin exact assertions — batch 8 (tests/unit/languages) + ratchet baseline down

### DIFF
--- a/scripts/loose_assertion_baseline.txt
+++ b/scripts/loose_assertion_baseline.txt
@@ -10,6 +10,6 @@
 # The count must only decrease (or stay equal). Each Layer-2 batch PR
 # re-measures and lowers it. Numbers are MEASURED, never hand-derived.
 
-BASELINE_COUNT=1452
+BASELINE_COUNT=1411
 MEASUREMENT_DATE=2026-06-12
 MEASUREMENT_COMMAND="grep -rEn \"assert .*(>= [0-9]|> 0([^0-9]|\$))\" tests/ --include=\"*.py\" | grep -v \"ratchet: nondeterministic\" | wc -l"

--- a/tests/unit/languages/test_cpp_plugin_coverage_boost_advanced.py
+++ b/tests/unit/languages/test_cpp_plugin_coverage_boost_advanced.py
@@ -27,8 +27,8 @@ def test_function_multiple_parameters(extractor):
     tree = _parse(code)
     funcs = extractor.extract_functions(tree, code)
     add_funcs = [f for f in funcs if f.name == "add"]
-    assert len(add_funcs) >= 1
-    assert len(add_funcs[0].parameters) >= 2
+    assert len(add_funcs) == 1
+    assert len(add_funcs[0].parameters) == 3
 
 
 # --- Variadic parameter ---
@@ -37,7 +37,7 @@ def test_variadic_function(extractor):
     tree = _parse(code)
     funcs = extractor.extract_functions(tree, code)
     printf_funcs = [f for f in funcs if f.name == "printf"]
-    assert len(printf_funcs) >= 1
+    assert len(printf_funcs) == 1
 
 
 # --- Full qualified name with namespace ---
@@ -48,7 +48,7 @@ def test_qualified_name_with_namespace(extractor):
     tree = _parse(code)
     classes = extractor.extract_classes(tree, code)
     color_classes = [c for c in classes if c.name == "Color"]
-    assert len(color_classes) >= 1
+    assert len(color_classes) == 1
     cc = color_classes[0]
     assert (
         cc.full_qualified_name == "gfx::Color"
@@ -63,7 +63,7 @@ def test_deleted_method(extractor):
     tree = _parse(code)
     funcs = extractor.extract_functions(tree, code)
     nc_funcs = [f for f in funcs if f.name and "NonCopy" in f.name]
-    assert len(nc_funcs) >= 1
+    assert len(nc_funcs) == 1
 
 
 # --- Defaulted method (= default) ---
@@ -73,7 +73,7 @@ def test_defaulted_method(extractor):
     funcs = extractor.extract_functions(tree, code)
     assert isinstance(funcs, list)
     defaults_funcs = [f for f in funcs if f.name and "Defaults" in f.name]
-    assert len(defaults_funcs) >= 1
+    assert len(defaults_funcs) == 1
     # default modifier is extracted via field_declaration path
 
 
@@ -83,7 +83,7 @@ def test_protected_access_specifier(extractor):
     tree = _parse(code)
     funcs = extractor.extract_functions(tree, code)
     thing_funcs = [f for f in funcs if f.name == "do_thing"]
-    assert len(thing_funcs) >= 1
+    assert len(thing_funcs) == 1
     assert thing_funcs[0].visibility == "protected"
 
 
@@ -123,7 +123,7 @@ def test_field_init_declarator_identifier(extractor):
     tree = _parse(code)
     variables = extractor.extract_variables(tree, code)
     val_vars = [v for v in variables if v.name == "val"]
-    assert len(val_vars) >= 1
+    assert len(val_vars) == 1
     assert val_vars[0].variable_type == "int"
 
 
@@ -142,7 +142,7 @@ def test_virtual_const_function(extractor):
     tree = _parse(code)
     funcs = extractor.extract_functions(tree, code)
     area_funcs = [f for f in funcs if f.name == "area"]
-    assert len(area_funcs) >= 1
+    assert len(area_funcs) == 1
     assert "virtual" in (area_funcs[0].modifiers or [])
     assert "pure_virtual" in (area_funcs[0].modifiers or [])
 
@@ -153,8 +153,8 @@ def test_for_range_complexity(extractor):
     tree = _parse(code)
     funcs = extractor.extract_functions(tree, code)
     sum_funcs = [f for f in funcs if f.name == "sum_items"]
-    assert len(sum_funcs) >= 1
-    assert sum_funcs[0].complexity_score > 1
+    assert len(sum_funcs) == 1
+    assert sum_funcs[0].complexity_score == 2
 
 
 # --- Switch statement complexity ---
@@ -163,8 +163,8 @@ def test_switch_complexity(extractor):
     tree = _parse(code)
     funcs = extractor.extract_functions(tree, code)
     grade_funcs = [f for f in funcs if f.name == "grade"]
-    assert len(grade_funcs) >= 1
-    assert grade_funcs[0].complexity_score > 1
+    assert len(grade_funcs) == 1
+    assert grade_funcs[0].complexity_score == 5
 
 
 # --- Catch clause complexity ---
@@ -175,8 +175,8 @@ def test_try_catch_complexity(extractor):
     tree = _parse(code)
     funcs = extractor.extract_functions(tree, code)
     safe_funcs = [f for f in funcs if f.name == "safe_op"]
-    assert len(safe_funcs) >= 1
-    assert safe_funcs[0].complexity_score > 1
+    assert len(safe_funcs) == 1
+    assert safe_funcs[0].complexity_score == 2
 
 
 # --- _get_access_specifier with node not in field_declaration_list ---
@@ -237,7 +237,7 @@ def test_count_tree_nodes_with_children(plugin):
     code = "class Foo { int x; void bar() {} };\n"
     tree = _parse(code)
     count = plugin._count_tree_nodes(tree.root_node)
-    assert count > 5
+    assert count == 22
 
 
 # --- Extract with doxygen comment on class ---
@@ -246,7 +246,7 @@ def test_doxygen_comment_on_class(extractor):
     tree = _parse(code)
     classes = extractor.extract_classes(tree, code)
     dc = [c for c in classes if c.name == "DocClass"]
-    assert len(dc) >= 1
+    assert len(dc) == 1
     assert dc[0].docstring is not None
     assert "documented" in dc[0].docstring
 
@@ -256,7 +256,7 @@ def test_namespace_identifier_node(extractor):
     code = "namespace my_lib { int val = 42; }\n"
     tree = _parse(code)
     packages = extractor.extract_packages(tree, code)
-    assert len(packages) >= 1
+    assert len(packages) == 1
     assert packages[0].name == "my_lib"
 
 
@@ -273,7 +273,7 @@ def test_deeply_nested_blocks(extractor):
     tree = _parse(code)
     funcs = extractor.extract_functions(tree, code)
     main_funcs = [f for f in funcs if f.name == "main"]
-    assert len(main_funcs) >= 1
+    assert len(main_funcs) == 1
 
 
 # --- Static field declaration ---
@@ -282,7 +282,7 @@ def test_static_field_declaration(extractor):
     tree = _parse(code)
     variables = extractor.extract_variables(tree, code)
     count_vars = [v for v in variables if v.name == "count"]
-    assert len(count_vars) >= 1
+    assert len(count_vars) == 1
     assert count_vars[0].is_static is True
 
 
@@ -295,7 +295,8 @@ def test_lambda_expression(extractor):
     lambda_funcs = [
         f for f in funcs if f.name is not None and "operator" in (f.name or "")
     ]
-    assert len(lambda_funcs) >= 0  # Just exercise the extractor path
+    # extraction gap: lambda expressions are not extracted as named functions; operator() not emitted
+    assert len(lambda_funcs) == 0
 
 
 # --- Include fallback regex extraction ---
@@ -303,7 +304,7 @@ def test_include_fallback_regex_direct(extractor):
     """Test _extract_includes_fallback with system and local includes."""
     code = '#include <iostream>\n#include "myheader.h"\n'
     imports = extractor._extract_includes_fallback(code)
-    assert len(imports) >= 2
+    assert len(imports) == 2
     names = [i.name for i in imports]
     assert "iostream" in names
     assert "myheader.h" in names
@@ -313,7 +314,7 @@ def test_include_fallback_regex_direct(extractor):
 def test_include_fallback_system_only(extractor):
     code = "#include <vector>\n#include <string>\n"
     imports = extractor._extract_includes_fallback(code)
-    assert len(imports) >= 2
+    assert len(imports) == 2
     names = [i.name for i in imports]
     assert "vector" in names
     assert "string" in names
@@ -339,7 +340,7 @@ async def test_analyze_file_cpp(plugin, tmp_path):
     result = await plugin.analyze_file(str(cpp_file), SimpleNamespace())
     assert result is not None
     assert result.language == "cpp"
-    assert result.line_count > 0
+    assert result.line_count == 8
 
 
 # --- Include fallback triggered when tree-sitter misses includes ---
@@ -351,7 +352,7 @@ def test_extract_imports_fallback_path(extractor):
     # We need to ensure the extraction path exercises the code.
     imports = extractor.extract_imports(tree, code)
     # Just verify imports are extracted (either via tree-sitter or regex)
-    assert len(imports) >= 1
+    assert len(imports) == 1
 
 
 # --- _extract_function_optimized error handling ---

--- a/tests/unit/languages/test_css_plugin_enhanced_selectors.py
+++ b/tests/unit/languages/test_css_plugin_enhanced_selectors.py
@@ -306,10 +306,16 @@ class TestCssSelectorRecognition:
         extractor = plugin.create_extractor()
         elements = extractor.extract_css_rules(tree, SELECTOR_CODE)
 
+        # Match bracketed attribute selectors so prefix-match operators
+        # ([href^=...]) count too — a literal 'href=' substring misses them
         attr_selectors = [
-            e for e in elements if "type=" in e.selector or "href=" in e.selector
+            e for e in elements if "[type=" in e.selector or "[href^=" in e.selector
         ]
-        assert len(attr_selectors) == 1
+        assert len(attr_selectors) == 2
+        assert sorted(e.selector for e in attr_selectors) == [
+            'a[href^="https"]',
+            'input[type="text"]',
+        ]
 
     def test_extract_pseudo_class_selector(self):
         """Test extraction of pseudo-class selector."""

--- a/tests/unit/languages/test_css_plugin_enhanced_selectors.py
+++ b/tests/unit/languages/test_css_plugin_enhanced_selectors.py
@@ -277,7 +277,7 @@ class TestCssSelectorRecognition:
         elements = extractor.extract_css_rules(tree, SELECTOR_CODE)
 
         class_selectors = [e for e in elements if e.selector == ".class-selector"]
-        assert len(class_selectors) >= 0
+        assert len(class_selectors) == 1
 
     def test_extract_id_selector(self):
         """Test extraction of ID selector."""
@@ -287,7 +287,7 @@ class TestCssSelectorRecognition:
         elements = extractor.extract_css_rules(tree, SELECTOR_CODE)
 
         id_selectors = [e for e in elements if e.selector == "#id-selector"]
-        assert len(id_selectors) >= 0
+        assert len(id_selectors) == 1
 
     def test_extract_element_selector(self):
         """Test extraction of element selector."""
@@ -297,7 +297,7 @@ class TestCssSelectorRecognition:
         elements = extractor.extract_css_rules(tree, SELECTOR_CODE)
 
         element_selectors = [e for e in elements if e.selector == "body"]
-        assert len(element_selectors) >= 0
+        assert len(element_selectors) == 1
 
     def test_extract_attribute_selector(self):
         """Test extraction of attribute selector."""
@@ -309,7 +309,7 @@ class TestCssSelectorRecognition:
         attr_selectors = [
             e for e in elements if "type=" in e.selector or "href=" in e.selector
         ]
-        assert len(attr_selectors) >= 0
+        assert len(attr_selectors) == 1
 
     def test_extract_pseudo_class_selector(self):
         """Test extraction of pseudo-class selector."""
@@ -321,7 +321,7 @@ class TestCssSelectorRecognition:
         pseudo_selectors = [
             e for e in elements if ":hover" in e.selector or ":focus" in e.selector
         ]
-        assert len(pseudo_selectors) >= 0
+        assert len(pseudo_selectors) == 2
 
     def test_extract_pseudo_element_selector(self):
         """Test extraction of pseudo-element selector."""
@@ -333,7 +333,7 @@ class TestCssSelectorRecognition:
         pseudo_element_selectors = [
             e for e in elements if "::before" in e.selector or "::after" in e.selector
         ]
-        assert len(pseudo_element_selectors) >= 0
+        assert len(pseudo_element_selectors) == 2
 
     def test_extract_combinator_selector(self):
         """Test extraction of combinator selector."""
@@ -350,7 +350,7 @@ class TestCssSelectorRecognition:
             or "+" in e.selector
             or "~" in e.selector
         ]
-        assert len(combinator_selectors) >= 0
+        assert len(combinator_selectors) == 4
 
     def test_selector_complexity(self):
         """Test that complex selectors are handled."""
@@ -362,7 +362,7 @@ class TestCssSelectorRecognition:
         complex_selectors = [
             e for e in elements if ":" in e.selector and " " in e.selector
         ]
-        assert len(complex_selectors) >= 0
+        assert len(complex_selectors) == 1
 
 
 class TestCssPropertyRecognition:
@@ -376,7 +376,7 @@ class TestCssPropertyRecognition:
         elements = extractor.extract_css_rules(tree, PROPERTY_CODE)
 
         layout_elements = [e for e in elements if e.element_class == "layout"]
-        assert len(layout_elements) >= 0
+        assert len(layout_elements) == 1
 
     def test_extract_typography_properties(self):
         """Test extraction of typography properties."""
@@ -454,7 +454,7 @@ class TestCssRuleRecognition:
         tree = get_tree_for_code(SELECTOR_CODE, plugin)
         elements = plugin.create_extractor().extract_css_rules(tree, SELECTOR_CODE)
 
-        assert len(elements) >= 1
+        assert len(elements) == 13
 
     def test_extract_multiple_rules(self):
         """Test extraction of multiple CSS rules."""
@@ -462,7 +462,7 @@ class TestCssRuleRecognition:
         tree = get_tree_for_code(PROPERTY_CODE, plugin)
         elements = plugin.create_extractor().extract_css_rules(tree, PROPERTY_CODE)
 
-        assert len(elements) >= 5
+        assert len(elements) == 6
 
     def test_rule_selector(self):
         """Test that rule selector is captured."""
@@ -472,7 +472,7 @@ class TestCssRuleRecognition:
 
         for element in elements:
             assert element.selector is not None
-            assert len(element.selector) > 0
+            assert element.selector != ""
 
     def test_rule_properties(self):
         """Test that rule properties are captured."""
@@ -480,9 +480,14 @@ class TestCssRuleRecognition:
         tree = get_tree_for_code(PROPERTY_CODE, plugin)
         elements = plugin.create_extractor().extract_css_rules(tree, PROPERTY_CODE)
 
-        for element in elements:
-            if element.properties:
-                assert len(element.properties) > 0
+        assert sorted(len(e.properties) for e in elements if e.properties) == [
+            3,
+            4,
+            6,
+            6,
+            6,
+            8,
+        ]
 
     def test_rule_line_numbers(self):
         """Test that rule line numbers are accurate."""
@@ -490,8 +495,8 @@ class TestCssRuleRecognition:
         tree = get_tree_for_code(PROPERTY_CODE, plugin)
         elements = plugin.create_extractor().extract_css_rules(tree, PROPERTY_CODE)
 
+        assert sorted(e.start_line for e in elements) == [3, 10, 20, 32, 42, 52]
         for element in elements:
-            assert element.start_line > 0
             assert element.end_line >= element.start_line
 
 
@@ -505,7 +510,7 @@ class TestCssMediaQueryRecognition:
         elements = plugin.create_extractor().extract_css_rules(tree, MEDIA_QUERY_CODE)
 
         media_queries = [e for e in elements if e.selector.startswith("@media")]
-        assert len(media_queries) >= 1
+        assert len(media_queries) == 4
 
     def test_extract_max_width_media_query(self):
         """Test extraction of max-width media query."""
@@ -514,7 +519,7 @@ class TestCssMediaQueryRecognition:
         elements = plugin.create_extractor().extract_css_rules(tree, MEDIA_QUERY_CODE)
 
         max_width_queries = [e for e in elements if "max-width" in e.selector]
-        assert len(max_width_queries) >= 1
+        assert len(max_width_queries) == 2
 
     def test_extract_min_width_media_query(self):
         """Test extraction of min-width media query."""
@@ -523,7 +528,7 @@ class TestCssMediaQueryRecognition:
         elements = plugin.create_extractor().extract_css_rules(tree, MEDIA_QUERY_CODE)
 
         min_width_queries = [e for e in elements if "min-width" in e.selector]
-        assert len(min_width_queries) >= 1
+        assert len(min_width_queries) == 1
 
     def test_extract_combined_media_query(self):
         """Test extraction of combined media query."""
@@ -532,7 +537,7 @@ class TestCssMediaQueryRecognition:
         elements = plugin.create_extractor().extract_css_rules(tree, MEDIA_QUERY_CODE)
 
         combined_queries = [e for e in elements if "and" in e.selector]
-        assert len(combined_queries) >= 1
+        assert len(combined_queries) == 2
 
     def test_extract_print_media_query(self):
         """Test extraction of print media query."""
@@ -541,7 +546,7 @@ class TestCssMediaQueryRecognition:
         elements = plugin.create_extractor().extract_css_rules(tree, MEDIA_QUERY_CODE)
 
         print_queries = [e for e in elements if "print" in e.selector]
-        assert len(print_queries) >= 1
+        assert len(print_queries) == 2
 
     def test_extract_prefers_color_scheme_media_query(self):
         """Test extraction of prefers-color-scheme media query."""
@@ -552,4 +557,4 @@ class TestCssMediaQueryRecognition:
         color_scheme_queries = [
             e for e in elements if "prefers-color-scheme" in e.selector
         ]
-        assert len(color_scheme_queries) >= 1
+        assert len(color_scheme_queries) == 1


### PR DESCRIPTION
## Summary

Layer-2 loose-assertion cleanup, batch 8. 41 enforcement-pattern hits (+3 adjacent `> 1`/`> 5` tightened) → exact pins, **0 exemptions**; ratchet baseline 1452 → 1411 (−41 exactly).

| File | Hits → Remaining |
|---|---|
| test_cpp_plugin_coverage_boost_advanced.py | 21 → 0 |
| test_css_plugin_enhanced_selectors.py | 20 → 0 |

## Highlights

- **Multiset/list pins for loop data** (hard-step D, no equivalent-rewrite dodges): per-rule property counts pinned as `sorted(...) == [3,4,6,6,6,8]`, rule start lines as `== [3,10,20,32,42,52]` — exact facts, not bounds.
- CSS `>= 0` hollow greens (9 sites) now pin real query-match counts (1/2/4/13/6…), incl. the subtle `href^=` ≠ `href=` attribute-filter behavior (verified correct, not a gap).
- C++ lambda test: pod flagged `== 0` as a possible extraction gap; lead review of the test's own comment ("Lambda should NOT be extracted as a regular function") shows this is **design intent**, not a gap — no issue filed.

## Test plan

- [x] 60 tests across both files green (`-n 0`, sequential)
- [x] `bash scripts/check_loose_assertions.sh origin/develop` exits 0
- [x] Baseline re-measured 1411 (lead spot-checked both files — 0 residual)