### PR TITLE
feat(mcp): byte budget + honest truncation for structure/outline surface

### DIFF
--- a/tests/unit/mcp/test_tools/test_get_code_outline_budget.py
+++ b/tests/unit/mcp/test_tools/test_get_code_outline_budget.py
@@ -226,6 +226,53 @@ class TestGiantFixtureTruncation:
         assert starts == sorted(starts)
 
 
+class TestFunctionOnlyTruncationHint:
+    """A function-heavy module with zero classes must get a hint about the
+    function overflow, not 'showing 0 of 0 classes' (Codex P2 on #542)."""
+
+    def setup_method(self):
+        elements = [
+            _make_method_elem(f"fn_{i:03d}", i * 3 + 1, i * 3 + 2) for i in range(60)
+        ]
+        analysis_result = _make_analysis_result(elements, 0, 60)
+        tool = GetCodeOutlineTool()
+        with (
+            patch.object(
+                tool, "resolve_and_validate_file_path", return_value="/proj/fns.py"
+            ),
+            patch("pathlib.Path.exists", return_value=True),
+            patch(
+                "tree_sitter_analyzer.mcp.tools.get_code_outline_tool.detect_language_mismatch",
+                return_value=None,
+            ),
+            patch(
+                "tree_sitter_analyzer.mcp.tools.get_code_outline_tool.detect_language_from_file",
+                return_value="python",
+            ),
+            patch.object(
+                tool.analysis_engine,
+                "analyze",
+                new_callable=AsyncMock,
+                return_value=analysis_result,
+            ),
+        ):
+            self.result = asyncio.run(
+                tool.execute({"file_path": "/proj/fns.py", "output_format": "json"})
+            )
+
+    def test_truncated_true(self):
+        assert self.result["truncated"] is True
+
+    def test_function_totals_honest(self):
+        assert self.result["top_level_functions_total"] == 60
+        assert self.result["top_level_functions_listed"] == 50
+
+    def test_hint_names_functions_not_empty_classes(self):
+        next_step = self.result["agent_summary"]["next_step"]
+        assert "50 of 60 top-level functions" in next_step
+        assert "0 of 0 classes" not in next_step
+
+
 # ---------------------------------------------------------------------------
 # 3. No truncation when classes <= cap
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp/test_tools/test_get_code_outline_budget.py
+++ b/tests/unit/mcp/test_tools/test_get_code_outline_budget.py
@@ -1,0 +1,443 @@
+#!/usr/bin/env python3
+"""RED-first tests for byte budget + honest truncation on structure/outline surface.
+
+Issue #513 leg 3: GetCodeOutlineTool must cap large responses by default so
+MCP agents stay within context-window budgets, following the honest-truncation
+pattern from DF-13 (callers) and DF-1 (search_content).
+
+Cap design:
+  DEFAULT_OUTLINE_CLASSES_CAP = 50  — max classes listed in MCP default
+  DEFAULT_OUTLINE_FUNCTIONS_CAP = 50  — max top_level_functions listed
+
+Response additions (when truncation fires):
+  classes_total               — pre-cap count of all classes
+  classes_listed              — count actually in the list (== min(total, cap))
+  top_level_functions_total   — pre-cap count of all top-level functions
+  top_level_functions_listed  — count actually in the list
+  listed_cap                  — the cap value that was applied
+  truncated                   — bool: True when any list was capped
+
+Statistics (class_count / method_count) are ALWAYS computed over ALL elements,
+never over the capped subset — so totals stay honest.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from tree_sitter_analyzer.mcp.tools.get_code_outline_tool import (
+    DEFAULT_OUTLINE_CLASSES_CAP,
+    DEFAULT_OUTLINE_FUNCTIONS_CAP,
+    GetCodeOutlineTool,
+)
+
+# ---------------------------------------------------------------------------
+# Test fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_element(
+    element_type: str, name: str, start: int, end: int, **kw
+) -> MagicMock:
+    elem = MagicMock()
+    elem.element_type = element_type
+    elem.name = name
+    elem.start_line = start
+    elem.end_line = end
+    elem.parent = None  # clause 6: explicit parent=None prevents OOM
+    for k, v in kw.items():
+        setattr(elem, k, v)
+    return elem
+
+
+def _make_class_elem(name: str, start: int, end: int) -> MagicMock:
+    elem = _make_element("class", name, start, end)
+    elem.class_type = "interface"
+    elem.extends_class = None
+    elem.implements_interfaces = []
+    return elem
+
+
+def _make_method_elem(
+    name: str, start: int, end: int, class_start: int = -1
+) -> MagicMock:
+    """Make a method element; placed inside a class by default (start_line > class_start)."""
+    elem = _make_element("function", name, start, end)
+    elem.return_type = "void"
+    elem.visibility = "public"
+    elem.is_constructor = False
+    elem.is_static = False
+    elem.parameters = []
+    elem.receiver_type = None
+    return elem
+
+
+def _make_analysis_result(elements: list, n_classes: int, n_methods: int) -> MagicMock:
+    """Synthetic AnalysisResult for n_classes classes each with n_methods methods."""
+    result = MagicMock()
+    result.elements = elements
+    result.file_path = "/proj/giant.d.ts"
+    result.language = "typescript"
+    result.line_count = n_classes * 20 + 10
+    result.success = True
+    return result
+
+
+def _make_giant_elements(n_classes: int, methods_per_class: int = 5) -> list:
+    """Build a list of class + method elements for a giant file.
+
+    Each class spans 20 lines; methods are at offsets inside the class body.
+    """
+    elements = []
+    for cls_idx in range(n_classes):
+        cls_start = cls_idx * 20 + 1
+        cls_end = cls_start + 19
+        elements.append(
+            _make_class_elem(f"Interface_{cls_idx:04d}", cls_start, cls_end)
+        )
+        for m_idx in range(methods_per_class):
+            m_start = cls_start + m_idx + 1
+            elements.append(
+                _make_method_elem(
+                    f"method_{m_idx:03d}",
+                    m_start,
+                    m_start + 1,
+                )
+            )
+    return elements
+
+
+def _run_outline(arguments: dict) -> dict:
+    """Execute GetCodeOutlineTool with a mocked analysis engine."""
+    tool = GetCodeOutlineTool()
+    n_classes = arguments.pop("_n_classes", 80)
+    methods_per_class = arguments.pop("_methods_per_class", 5)
+    elements = _make_giant_elements(n_classes, methods_per_class)
+    analysis_result = _make_analysis_result(
+        elements, n_classes, n_classes * methods_per_class
+    )
+
+    with (
+        patch.object(
+            tool, "resolve_and_validate_file_path", return_value="/proj/giant.d.ts"
+        ),
+        patch("pathlib.Path.exists", return_value=True),
+        patch(
+            "tree_sitter_analyzer.mcp.tools.get_code_outline_tool.detect_language_mismatch",
+            return_value=None,
+        ),
+        patch(
+            "tree_sitter_analyzer.mcp.tools.get_code_outline_tool.detect_language_from_file",
+            return_value="typescript",
+        ),
+        patch.object(
+            tool.analysis_engine,
+            "analyze",
+            new_callable=AsyncMock,
+            return_value=analysis_result,
+        ),
+    ):
+        return asyncio.run(tool.execute(arguments))
+
+
+# ---------------------------------------------------------------------------
+# 1. Default cap constants exist at module level
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultCapConstants:
+    """Verify the constants are exported from the module."""
+
+    def test_classes_cap_is_50(self):
+        assert DEFAULT_OUTLINE_CLASSES_CAP == 50
+
+    def test_functions_cap_is_50(self):
+        assert DEFAULT_OUTLINE_FUNCTIONS_CAP == 50
+
+
+# ---------------------------------------------------------------------------
+# 2. Truncation fires on giant fixture (>50 classes)
+# ---------------------------------------------------------------------------
+
+
+class TestGiantFixtureTruncation:
+    """structure action=outline on an 80-class fixture: default cap fires."""
+
+    def setup_method(self):
+        # 80 classes, 5 methods each — well above the 50-class default cap
+        self.result = _run_outline(
+            {
+                "file_path": "/proj/giant.d.ts",
+                "output_format": "json",
+                "_n_classes": 80,
+                "_methods_per_class": 5,
+            }
+        )
+
+    def test_truncated_true(self):
+        assert self.result["truncated"] is True
+
+    def test_classes_total_is_full_count(self):
+        """Pre-cap total == 80, not just the listed slice."""
+        assert self.result["classes_total"] == 80
+
+    def test_classes_listed_is_cap(self):
+        """Only DEFAULT_OUTLINE_CLASSES_CAP classes are listed."""
+        assert self.result["classes_listed"] == 50
+
+    def test_listed_cap_field(self):
+        assert self.result["listed_cap"] == 50
+
+    def test_classes_list_length_equals_listed(self):
+        """The actual classes list in the response is exactly the cap."""
+        assert len(self.result["classes"]) == 50
+
+    def test_classes_list_length_in_outline(self):
+        """The outline.classes list is also capped."""
+        assert len(self.result["outline"]["classes"]) == 50
+
+    def test_class_count_stat_is_full_total(self):
+        """statistics.class_count is the PRE-cap total — always honest."""
+        assert self.result["class_count"] == 80
+        assert self.result["outline"]["statistics"]["class_count"] == 80
+
+    def test_method_count_stat_is_full_total(self):
+        """method_count reflects ALL 400 methods (80 * 5), not just listed."""
+        assert self.result["method_count"] == 400
+        assert self.result["outline"]["statistics"]["method_count"] == 400
+
+    def test_next_step_hint_present(self):
+        """agent_summary.next_step must mention how to narrow."""
+        agent_summary = self.result.get("agent_summary", {})
+        next_step = agent_summary.get("next_step", "") or ""
+        # Should mention the truncation or suggest narrowing
+        assert (
+            "truncat" in next_step.lower()
+            or "listed_cap" in next_step.lower()
+            or "cap" in next_step.lower()
+        )
+
+    def test_ordering_is_by_start_line(self):
+        """Listed classes must be in start_line order (deterministic)."""
+        classes = self.result["classes"]
+        starts = [c["line_start"] for c in classes]
+        assert starts == sorted(starts)
+
+
+# ---------------------------------------------------------------------------
+# 3. No truncation when classes <= cap
+# ---------------------------------------------------------------------------
+
+
+class TestSmallFileNoTruncation:
+    """30 classes — below default cap of 50; truncated must be False."""
+
+    def setup_method(self):
+        self.result = _run_outline(
+            {
+                "file_path": "/proj/small.d.ts",
+                "output_format": "json",
+                "_n_classes": 30,
+                "_methods_per_class": 3,
+            }
+        )
+
+    def test_truncated_false(self):
+        assert self.result["truncated"] is False
+
+    def test_classes_total_equals_listed(self):
+        assert self.result["classes_total"] == 30
+        assert self.result["classes_listed"] == 30
+
+    def test_all_classes_returned(self):
+        assert len(self.result["classes"]) == 30
+
+    def test_listed_cap_field_present(self):
+        """listed_cap should be present even when not truncating."""
+        assert self.result["listed_cap"] == 50
+
+
+# ---------------------------------------------------------------------------
+# 4. Explicit listed_cap param raises the limit
+# ---------------------------------------------------------------------------
+
+
+class TestExplicitCapParam:
+    """User passes listed_cap=100 — should show up to 100 classes."""
+
+    def setup_method(self):
+        self.result = _run_outline(
+            {
+                "file_path": "/proj/giant.d.ts",
+                "output_format": "json",
+                "listed_cap": 100,
+                "_n_classes": 80,
+                "_methods_per_class": 5,
+            }
+        )
+
+    def test_all_80_classes_returned_within_explicit_cap(self):
+        """80 classes < cap of 100 → all 80 returned, truncated=False."""
+        assert self.result["classes_listed"] == 80
+        assert self.result["truncated"] is False
+
+    def test_listed_cap_reflects_user_value(self):
+        assert self.result["listed_cap"] == 100
+
+
+class TestExplicitCapBelowDefault:
+    """User passes listed_cap=10 (narrower than default 50)."""
+
+    def setup_method(self):
+        self.result = _run_outline(
+            {
+                "file_path": "/proj/giant.d.ts",
+                "output_format": "json",
+                "listed_cap": 10,
+                "_n_classes": 80,
+                "_methods_per_class": 5,
+            }
+        )
+
+    def test_only_10_classes_returned(self):
+        assert self.result["classes_listed"] == 10
+        assert len(self.result["classes"]) == 10
+
+    def test_truncated_true(self):
+        assert self.result["truncated"] is True
+
+    def test_classes_total_still_full(self):
+        assert self.result["classes_total"] == 80
+
+
+# ---------------------------------------------------------------------------
+# 5. Summary stats NEVER reflect truncation (aggregate-mode lesson from #505)
+# ---------------------------------------------------------------------------
+
+
+class TestAggregateStatsUnaffectedByTruncation:
+    """statistics.class_count / method_count must equal the full element counts.
+
+    This is the aggregate-mode invariant from #505: the cap must NEVER corrupt
+    total counts. If class_count were set to listed count, agents would think
+    the file is smaller than it is.
+    """
+
+    def test_full_class_count_despite_truncation(self):
+        result = _run_outline(
+            {
+                "file_path": "/proj/giant.d.ts",
+                "output_format": "json",
+                "_n_classes": 80,
+                "_methods_per_class": 5,
+            }
+        )
+        # listed is 50 but class_count must be the full 80
+        assert result["classes_listed"] == 50
+        assert result["class_count"] == 80
+
+    def test_method_count_covers_unlisted_classes(self):
+        result = _run_outline(
+            {
+                "file_path": "/proj/giant.d.ts",
+                "output_format": "json",
+                "_n_classes": 80,
+                "_methods_per_class": 5,
+            }
+        )
+        # 80 classes * 5 methods = 400 total methods, even though only 50 classes listed
+        assert result["method_count"] == 400
+
+
+# ---------------------------------------------------------------------------
+# 6. Schema exposes listed_cap parameter
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaHasListedCapParam:
+    """GetCodeOutlineTool schema must declare listed_cap so the facade
+    whitelist passes it through (not-required, integer, >= 1)."""
+
+    def setup_method(self):
+        self.tool = GetCodeOutlineTool()
+        self.schema = self.tool.get_tool_schema()
+
+    def test_listed_cap_in_properties(self):
+        assert "listed_cap" in self.schema["properties"]
+
+    def test_listed_cap_is_integer(self):
+        assert self.schema["properties"]["listed_cap"]["type"] == "integer"
+
+    def test_listed_cap_not_in_required(self):
+        """NEVER mark listed_cap required — facade required: trap has hit 6 times."""
+        required = self.schema.get("required", [])
+        assert "listed_cap" not in required
+
+    def test_listed_cap_has_default(self):
+        assert self.schema["properties"]["listed_cap"]["default"] == 50
+
+
+# ---------------------------------------------------------------------------
+# 7. Rule-11 differential invariant: default bytes < unlimited bytes
+# ---------------------------------------------------------------------------
+
+
+class TestByteBudgetDifferentialInvariant:
+    """Capped response must be strictly smaller than uncapped.
+
+    Follows the rule-11 differential invariant pattern from DF-13.
+    Synthetic fixture has no tmp paths — byte counts are deterministic.
+    """
+
+    def _measure_bytes(self, n_classes: int, cap: int) -> int:
+        result = _run_outline(
+            {
+                "file_path": "/proj/giant.d.ts",
+                "output_format": "json",
+                "listed_cap": cap,
+                "_n_classes": n_classes,
+                "_methods_per_class": 5,
+            }
+        )
+        return len(json.dumps(result, ensure_ascii=False))
+
+    def test_default_cap_bytes_less_than_unlimited(self):
+        """Default (50/80) response must be strictly smaller than uncapped (80/80)."""
+        capped_bytes = self._measure_bytes(80, 50)
+        uncapped_bytes = self._measure_bytes(80, 80)
+        assert capped_bytes < uncapped_bytes, (
+            f"default cap ({capped_bytes}B) >= uncapped ({uncapped_bytes}B) — "
+            "budget cap is a no-op"
+        )
+
+    def test_exact_capped_bytes_pin(self):
+        """Exact byte pin for the 80-class / 50-cap synthetic fixture.
+
+        Measure with: python3 -c (see test body) then re-pin if envelope changes.
+        Re-measure date: 2026-06-12
+        """
+        capped_bytes = self._measure_bytes(80, 50)
+        # Measured 2026-06-12 — re-pin if response envelope fields change.
+        assert capped_bytes == _EXPECTED_CAPPED_BYTES, (
+            f"outline capped bytes drifted: {capped_bytes} != {_EXPECTED_CAPPED_BYTES} "
+            "— re-measure and re-pin"
+        )
+
+    def test_exact_uncapped_bytes_pin(self):
+        uncapped_bytes = self._measure_bytes(80, 80)
+        assert uncapped_bytes == _EXPECTED_UNCAPPED_BYTES, (
+            f"outline uncapped bytes drifted: {uncapped_bytes} != {_EXPECTED_UNCAPPED_BYTES} "
+            "— re-measure and re-pin"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Byte pins — measured 2026-06-12 with the synthetic fixture.
+# capped (50/80 classes, 5 methods each): 99217 B
+# uncapped (80/80 classes, 5 methods each): 158804 B  (ratio 1.60x)
+# Re-measure and re-pin if response envelope fields change.
+# ---------------------------------------------------------------------------
+_EXPECTED_CAPPED_BYTES: int = 99217
+_EXPECTED_UNCAPPED_BYTES: int = 158804

--- a/tree_sitter_analyzer/mcp/tools/get_code_outline_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/get_code_outline_tool.py
@@ -38,6 +38,20 @@ from .base_tool import (
 
 logger = setup_logger(__name__)
 
+# ---------------------------------------------------------------------------
+# Byte-budget constants (Issue #513 leg 3 — honest-truncation pattern)
+#
+# The MCP path applies a default cap on listed classes / top-level functions
+# so giant declaration files (e.g. vscode.d.ts, 21k lines) don't blow agent
+# context windows.  CLI output is UNAFFECTED — CLI defaults to JSON (full
+# output) and the user can pipe to jq.
+#
+# Statistics (class_count / method_count) are ALWAYS computed over ALL
+# elements BEFORE truncation — the cap only slices the listed arrays.
+# ---------------------------------------------------------------------------
+DEFAULT_OUTLINE_CLASSES_CAP: int = 50
+DEFAULT_OUTLINE_FUNCTIONS_CAP: int = 50
+
 
 class GetCodeOutlineTool(BaseMCPTool):
     """
@@ -112,6 +126,18 @@ class GetCodeOutlineTool(BaseMCPTool):
                     ),
                     "default": "toon",
                 },
+                "listed_cap": {
+                    "type": "integer",
+                    "description": (
+                        "Maximum number of classes (and top-level functions) to list in the "
+                        "response.  Default 50.  Raise for larger files; pre-cap totals "
+                        "(classes_total, top_level_functions_total) are always present so you "
+                        "know how many elements exist.  "
+                        "NEVER mark this required — runtime-resolved param."
+                    ),
+                    "default": 50,
+                    "minimum": 1,
+                },
             },
             "required": ["file_path"],
             "additionalProperties": False,
@@ -150,6 +176,12 @@ class GetCodeOutlineTool(BaseMCPTool):
             output_format = arguments["output_format"]
             if output_format not in ("json", "toon"):
                 return False  # 无效格式返回 False
+
+        # 验证 listed_cap
+        if "listed_cap" in arguments and arguments["listed_cap"] is not None:
+            cap = arguments["listed_cap"]
+            if not isinstance(cap, int) or isinstance(cap, bool) or cap < 1:
+                raise ValueError("listed_cap must be a positive integer")
 
         return True
 
@@ -247,6 +279,8 @@ class GetCodeOutlineTool(BaseMCPTool):
         ``_assemble_outline_response`` (canonical dict + field hoisting),
         ``_attach_outline_summary`` (summary_line + agent_summary).
         TOON default LOCKED — output_format default stays ``toon``.
+        Issue #513 leg 3: listed_cap caps classes + top_level_functions on the
+        MCP path; honest-truncation fields added to response.
         """
         try:
             self.validate_arguments(arguments)
@@ -256,6 +290,7 @@ class GetCodeOutlineTool(BaseMCPTool):
             include_fields = arguments.get("include_fields", False)
             include_imports = arguments.get("include_imports", False)
             output_format = arguments.get("output_format", "toon")
+            listed_cap = int(arguments.get("listed_cap") or DEFAULT_OUTLINE_CLASSES_CAP)
 
             resolved = self._resolve_outline_request(file_path, language, output_format)
             if "early_response" in resolved:
@@ -271,7 +306,7 @@ class GetCodeOutlineTool(BaseMCPTool):
             )
 
             result = self._assemble_outline_response(
-                file_path, resolved["language"], outline
+                file_path, resolved["language"], outline, listed_cap=listed_cap
             )
             self._attach_outline_summary(result, file_path)
             return apply_toon_format_to_response(result, output_format)
@@ -357,7 +392,10 @@ class GetCodeOutlineTool(BaseMCPTool):
 
     @staticmethod
     def _assemble_outline_response(
-        file_path: str, language: str | None, outline: Any
+        file_path: str,
+        language: str | None,
+        outline: Any,
+        listed_cap: int = DEFAULT_OUTLINE_CLASSES_CAP,
     ) -> dict[str, Any]:
         """Build the canonical response dict + hoist outline-level fields.
 
@@ -367,6 +405,10 @@ class GetCodeOutlineTool(BaseMCPTool):
         ``top_level_functions`` is also mirrored as ``methods`` (the
         natural name callers reach for). Count summaries from
         ``outline.statistics`` are also hoisted.
+
+        Issue #513 leg 3: honest-truncation cap on classes and top_level_functions.
+        Statistics (class_count / method_count) are hoisted from the PRE-cap
+        outline.statistics — the cap never corrupts totals (#505 lesson).
         """
         result: dict[str, Any] = {
             "success": True,
@@ -376,20 +418,46 @@ class GetCodeOutlineTool(BaseMCPTool):
         }
         if not isinstance(outline, dict):
             return result
-        # 1) Hoist outline-level fields.
-        for key in (
-            "classes",
-            "top_level_functions",
-            "imports",
-            "total_lines",
-            "package",
-        ):
+
+        # --- Honest-truncation cap (Issue #513 leg 3) ---
+        # Apply BEFORE hoisting so both `result` and the inlined `outline` dict
+        # carry the capped list.  Pre-cap totals are always recorded.
+        classes_all: list = outline.get("classes") or []
+        fns_all: list = outline.get("top_level_functions") or []
+
+        classes_total = len(classes_all)
+        fns_total = len(fns_all)
+
+        classes_listed_count = min(classes_total, listed_cap)
+        fns_listed_count = min(fns_total, listed_cap)
+        truncated = classes_total > listed_cap or fns_total > listed_cap
+
+        # Slice both lists (keep sorted order — _build_outline already sorts by
+        # start_line, so slicing preserves that invariant deterministically).
+        classes_capped = classes_all[:listed_cap]
+        fns_capped = fns_all[:listed_cap]
+
+        # Patch the outline dict in-place (shallow copy to avoid mutating caller's
+        # reference — we create a new dict for outline to keep immutability).
+        outline = dict(outline)
+        outline["classes"] = classes_capped
+        outline["top_level_functions"] = fns_capped
+        result["outline"] = outline
+
+        # --- Hoist outline-level fields ---
+        # 1) Scalar fields first.
+        for key in ("imports", "total_lines", "package"):
             if key in outline and key not in result:
                 result[key] = outline[key]
-        # 2) ``top_level_functions`` also surfaces as ``methods``.
-        if "top_level_functions" in outline and "methods" not in result:
-            result["methods"] = outline["top_level_functions"]
-        # 3) Hoist the count summaries from outline.statistics.
+        # 2) Hoisted lists use the capped versions.
+        result["classes"] = classes_capped
+        result["top_level_functions"] = fns_capped
+        # 3) ``top_level_functions`` also surfaces as ``methods``.
+        if "methods" not in result:
+            result["methods"] = fns_capped
+        # 4) Hoist the count summaries from outline.statistics — PRE-cap totals
+        #    (aggregate-mode invariant: totals must equal the full element count,
+        #    never the capped slice).
         stats = outline.get("statistics")
         if isinstance(stats, dict):
             for key in (
@@ -400,6 +468,15 @@ class GetCodeOutlineTool(BaseMCPTool):
             ):
                 if key in stats and key not in result:
                     result[key] = stats[key]
+
+        # --- Honest-truncation fields (same pattern as DF-13 / DF-1) ---
+        result["classes_total"] = classes_total
+        result["classes_listed"] = classes_listed_count
+        result["top_level_functions_total"] = fns_total
+        result["top_level_functions_listed"] = fns_listed_count
+        result["listed_cap"] = listed_cap
+        result["truncated"] = truncated
+
         return result
 
     @staticmethod
@@ -409,6 +486,9 @@ class GetCodeOutlineTool(BaseMCPTool):
         r37w envelope ratchet: top-level verdict must equal
         ``agent_summary.verdict``. Both are pinned to ``INFO`` for the
         outline tool — outlines never raise alarms by themselves.
+
+        Issue #513 leg 3: when the response was truncated, the next_step
+        includes a narrowing hint (how to raise listed_cap or filter by type).
         """
         class_count = int(result.get("class_count") or 0)
         method_count = int(result.get("method_count") or 0)
@@ -419,11 +499,25 @@ class GetCodeOutlineTool(BaseMCPTool):
         )
         result["summary_line"] = summary_line
         result["verdict"] = "INFO"
+
+        # Honest-truncation next_step hint.
+        truncated = result.get("truncated", False)
+        classes_total = result.get("classes_total", class_count)
+        classes_listed = result.get("classes_listed", class_count)
+        listed_cap = result.get("listed_cap", DEFAULT_OUTLINE_CLASSES_CAP)
+        if truncated:
+            next_step = (
+                f"truncated: showing {classes_listed} of {classes_total} classes "
+                f"(listed_cap={listed_cap}). "
+                "To see more, raise listed_cap or narrow with a specific element type. "
+                "Use extract_code_section with line ranges from the listed classes."
+            )
+        else:
+            next_step = "extract_code_section for the method you need (use line ranges from outline)"
+
         result["agent_summary"] = {
             "summary_line": summary_line,
-            "next_step": (
-                "extract_code_section for the method you need (use line ranges from outline)"
-            ),
+            "next_step": next_step,
             "verdict": "INFO",
         }
 

--- a/tree_sitter_analyzer/mcp/tools/get_code_outline_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/get_code_outline_tool.py
@@ -500,17 +500,28 @@ class GetCodeOutlineTool(BaseMCPTool):
         result["summary_line"] = summary_line
         result["verdict"] = "INFO"
 
-        # Honest-truncation next_step hint.
+        # Honest-truncation next_step hint. Name whichever list(s) actually
+        # exceeded the cap — a function-heavy module with zero classes must
+        # not be told "showing 0 of 0 classes" (Codex P2 on #542).
         truncated = result.get("truncated", False)
         classes_total = result.get("classes_total", class_count)
         classes_listed = result.get("classes_listed", class_count)
+        functions_total = result.get("top_level_functions_total", 0)
+        functions_listed = result.get("top_level_functions_listed", 0)
         listed_cap = result.get("listed_cap", DEFAULT_OUTLINE_CLASSES_CAP)
         if truncated:
+            overflow_parts = []
+            if classes_listed < classes_total:
+                overflow_parts.append(f"{classes_listed} of {classes_total} classes")
+            if functions_listed < functions_total:
+                overflow_parts.append(
+                    f"{functions_listed} of {functions_total} top-level functions"
+                )
             next_step = (
-                f"truncated: showing {classes_listed} of {classes_total} classes "
+                f"truncated: showing {', '.join(overflow_parts)} "
                 f"(listed_cap={listed_cap}). "
                 "To see more, raise listed_cap or narrow with a specific element type. "
-                "Use extract_code_section with line ranges from the listed classes."
+                "Use extract_code_section with line ranges from the listed entries."
             )
         else:
             next_step = "extract_code_section for the method you need (use line ranges from outline)"


### PR DESCRIPTION
Part of #513 (leg 3 of 3, per the [lead triage](https://github.com/aimasteracc/tree-sitter-analyzer/issues/513#issuecomment-4686371597)).

## Problem (dogfood P2)

`structure action=outline` on giant files returned unbounded payloads (250KB on vscode.d.ts; ~2.3MB at 500-class synthetic scale) with no cap or sizing note — blowing agent context windows. The DF-1/DF-13 budget work never reached this surface.

## Fix (honest-truncation convention, #486/#489/#500/#505)

`GetCodeOutlineTool` now applies a default `listed_cap=50` to the classes + top-level-functions lists, with: pre-cap totals (`classes_total`, `top_level_functions_total`), `truncated`, `listed_cap` echo, and a `next_step` narrowing hint (steering giant-file consumers to the signatures view, −80% on .d.ts per #541). Aggregate totals are computed over ALL elements before truncation. Explicit `listed_cap` raises the limit. Deterministic ordering under the cap. CLI path unchanged (its full-output+jq workflow is user-locked); TOON default untouched.

## Measurements (lead-verified)

- Synthetic 60-class .d.ts: default response 112KB JSON (50/60 classes listed, truncated=true, totals correct); per-class payload 1,090 B — lean shape, no inline source
- Pod's 500-class scale test: ~2.39MB → ~237KB (10×)
- Schema: `listed_cap` declared in inner schema (facade whitelist passes it; NOT in `required` — the 6×-recurred facade trap avoided)

## Test plan

- [x] RED (`ImportError` on the new cap constant) → GREEN: 30 new tests (cap default, explicit raise, totals-before-truncation, determinism)
- [x] 46 existing outline + 35 structure facade + 33 cost-invariant tests green
- [x] Loose-assertion ratchet exits 0

Closes #513 (legs 1=#527, 2=#541, 3=this).