### PR TITLE
test: pin exact assertions — batch 10 (core/heatmap) + ratchet baseline down

### DIFF
--- a/scripts/loose_assertion_baseline.txt
+++ b/scripts/loose_assertion_baseline.txt
@@ -10,6 +10,6 @@
 # The count must only decrease (or stay equal). Each Layer-2 batch PR
 # re-measures and lowers it. Numbers are MEASURED, never hand-derived.
 
-BASELINE_COUNT=1380
+BASELINE_COUNT=1332
 MEASUREMENT_DATE=2026-06-12
 MEASUREMENT_COMMAND="grep -rEn \"assert .*(>= [0-9]|> 0([^0-9]|\$))\" tests/ --include=\"*.py\" | grep -v \"ratchet: nondeterministic\" | wc -l"

--- a/tests/unit/core/test_query_code_cross_language_compatibility.py
+++ b/tests/unit/core/test_query_code_cross_language_compatibility.py
@@ -155,8 +155,8 @@ public class JavaClass {
             assert functions_results is not None, (
                 "functions query should return results"
             )
-            assert len(function_results) > 0, "Should find JavaScript functions"
-            assert len(functions_results) > 0, "Should find JavaScript functions"
+            assert len(function_results) == 2, "Should find JavaScript functions"
+            assert len(functions_results) == 23, "Should find JavaScript functions"
 
             # Test class queries
             class_results = await query_service.execute_query(
@@ -168,8 +168,8 @@ public class JavaClass {
 
             assert class_results is not None, "class query should return results"
             assert classes_results is not None, "classes query should return results"
-            assert len(class_results) > 0, "Should find JavaScript classes"
-            assert len(classes_results) > 0, "Should find JavaScript classes"
+            assert len(class_results) == 1, "Should find JavaScript classes"
+            assert len(classes_results) == 3, "Should find JavaScript classes"
 
             # Test method queries (this was the original bug)
             method_results = await query_service.execute_query(
@@ -181,8 +181,8 @@ public class JavaClass {
 
             assert method_results is not None, "method query should return results"
             assert methods_results is not None, "methods query should return results"
-            assert len(method_results) > 0, "Should find JavaScript methods"
-            assert len(methods_results) > 0, "Should find JavaScript methods"
+            assert len(method_results) == 12, "Should find JavaScript methods"
+            assert len(methods_results) == 12, "Should find JavaScript methods"
 
         finally:
             os.unlink(temp_file)
@@ -205,8 +205,8 @@ public class JavaClass {
             assert functions_results is not None, (
                 "functions query should return results"
             )
-            assert len(function_results) > 0, "Should find TypeScript functions"
-            assert len(functions_results) > 0, "Should find TypeScript functions"
+            assert len(function_results) == 19, "Should find TypeScript functions"
+            assert len(functions_results) == 19, "Should find TypeScript functions"
 
             # Test class queries
             class_results = await query_service.execute_query(
@@ -218,8 +218,8 @@ public class JavaClass {
 
             assert class_results is not None, "class query should return results"
             assert classes_results is not None, "classes query should return results"
-            assert len(class_results) > 0, "Should find TypeScript classes"
-            assert len(classes_results) > 0, "Should find TypeScript classes"
+            assert len(class_results) == 3, "Should find TypeScript classes"
+            assert len(classes_results) == 3, "Should find TypeScript classes"
 
             # Test interface queries (TypeScript specific)
             interface_results = await query_service.execute_query(
@@ -235,8 +235,8 @@ public class JavaClass {
             assert interfaces_results is not None, (
                 "interfaces query should return results"
             )
-            assert len(interface_results) > 0, "Should find TypeScript interfaces"
-            assert len(interfaces_results) > 0, "Should find TypeScript interfaces"
+            assert len(interface_results) == 3, "Should find TypeScript interfaces"
+            assert len(interfaces_results) == 3, "Should find TypeScript interfaces"
 
             # Test type queries (TypeScript specific)
             type_results = await query_service.execute_query(
@@ -248,8 +248,8 @@ public class JavaClass {
 
             assert type_results is not None, "type query should return results"
             assert types_results is not None, "types query should return results"
-            assert len(type_results) > 0, "Should find TypeScript types"
-            assert len(types_results) > 0, "Should find TypeScript types"
+            assert len(type_results) == 3, "Should find TypeScript types"
+            assert len(types_results) == 3, "Should find TypeScript types"
 
         finally:
             os.unlink(temp_file)
@@ -272,8 +272,8 @@ public class JavaClass {
             assert functions_results is not None, (
                 "functions query should return results"
             )
-            assert len(function_results) > 0, "Should find Python functions"
-            assert len(functions_results) > 0, "Should find Python functions"
+            assert len(function_results) == 4, "Should find Python functions"
+            assert len(functions_results) == 32, "Should find Python functions"
 
             # Test class queries
             class_results = await query_service.execute_query(
@@ -285,8 +285,8 @@ public class JavaClass {
 
             assert class_results is not None, "class query should return results"
             assert classes_results is not None, "classes query should return results"
-            assert len(class_results) > 0, "Should find Python classes"
-            assert len(classes_results) > 0, "Should find Python classes"
+            assert len(class_results) == 1, "Should find Python classes"
+            assert len(classes_results) == 3, "Should find Python classes"
 
             # Test import queries
             import_results = await query_service.execute_query(
@@ -298,8 +298,8 @@ public class JavaClass {
 
             assert import_results is not None, "import query should return results"
             assert imports_results is not None, "imports query should return results"
-            assert len(import_results) > 0, "Should find Python imports"
-            assert len(imports_results) > 0, "Should find Python imports"
+            assert len(import_results) == 1, "Should find Python imports"
+            assert len(imports_results) == 5, "Should find Python imports"
 
         finally:
             os.unlink(temp_file)
@@ -320,8 +320,8 @@ public class JavaClass {
 
             assert method_results is not None, "method query should return results"
             assert methods_results is not None, "methods query should return results"
-            assert len(method_results) > 0, "Should find Java methods"
-            assert len(methods_results) > 0, "Should find Java methods"
+            assert len(method_results) == 3, "Should find Java methods"
+            assert len(methods_results) == 3, "Should find Java methods"
 
             # Test class queries
             class_results = await query_service.execute_query(
@@ -333,8 +333,8 @@ public class JavaClass {
 
             assert class_results is not None, "class query should return results"
             assert classes_results is not None, "classes query should return results"
-            assert len(class_results) > 0, "Should find Java classes"
-            assert len(classes_results) > 0, "Should find Java classes"
+            assert len(class_results) == 1, "Should find Java classes"
+            assert len(classes_results) == 1, "Should find Java classes"
 
         finally:
             os.unlink(temp_file)
@@ -357,7 +357,7 @@ public class JavaClass {
 
             # Should not be None or empty
             assert results is not None, "functions query should not return None"
-            assert len(results) > 0, "functions query should find results"
+            assert len(results) == 23, "functions query should find results"
 
             # Should find multiple function types
             function_types = {result.get("node_type") for result in results}
@@ -368,7 +368,7 @@ public class JavaClass {
             }
 
             # Should find at least some of the expected function types
-            assert len(function_types.intersection(expected_types)) > 0, (
+            assert len(function_types.intersection(expected_types)) == 3, (
                 f"Should find function types, got: {function_types}"
             )
 
@@ -395,6 +395,13 @@ public class JavaClass {
             (self.PYTHON_CODE, ".py", "python", "functions"),
             (self.JAVA_CODE, ".java", "java", "methods"),
         ]
+        # Exact counts over the inline fixtures above (deterministic)
+        expected_counts = {
+            ("javascript", "functions"): 23,
+            ("typescript", "functions"): 19,
+            ("python", "functions"): 32,
+            ("java", "methods"): 3,
+        }
 
         for code, extension, language, query_key in test_cases:
             temp_file = self.create_temp_file(code, extension)
@@ -407,7 +414,9 @@ public class JavaClass {
                 assert results is not None, (
                     f"{language} {query_key} should return results"
                 )
-                assert len(results) > 0, f"{language} {query_key} should find results"
+                assert len(results) == expected_counts[(language, query_key)], (
+                    f"{language} {query_key} should find results"
+                )
 
                 # Check result structure consistency
                 for result in results:
@@ -429,7 +438,7 @@ public class JavaClass {
 
             # Should work even if tree-sitter query fails and falls back to manual execution
             assert results is not None, "Manual fallback should work"
-            assert len(results) > 0, "Manual fallback should find results"
+            assert len(results) == 23, "Manual fallback should find results"
 
             # Verify that the manual execution correctly identifies JavaScript functions
             node_types = {result.get("node_type") for result in results}
@@ -442,7 +451,7 @@ public class JavaClass {
             }
             found_types = node_types.intersection(expected_manual_types)
 
-            assert len(found_types) > 0, (
+            assert len(found_types) == 3, (
                 f"Manual execution should find function types, got: {node_types}"
             )
 

--- a/tests/unit/test_complexity_heatmap.py
+++ b/tests/unit/test_complexity_heatmap.py
@@ -68,7 +68,7 @@ def indexed_complex_project(complex_project):
 
     cache = ASTCache(str(complex_project))
     result = cache.index_project()
-    assert result["indexed"] >= 2
+    assert result["indexed"] == 4
     cache.close()
     return complex_project
 
@@ -85,10 +85,10 @@ class TestComplexityEngine:
         from tree_sitter_analyzer.complexity_heatmap import analyze_file_complexity
 
         funcs = analyze_file_complexity(str(complex_project / "complex.py"), "python")
-        assert len(funcs) >= 3
+        assert len(funcs) == 3
         nested = [f for f in funcs if f.name == "deeply_nested"]
         assert len(nested) == 1
-        assert nested[0].complexity >= 6
+        assert nested[0].complexity == 8
 
     def test_class_method_detection(self, complex_project):
         from tree_sitter_analyzer.complexity_heatmap import analyze_file_complexity
@@ -97,7 +97,7 @@ class TestComplexityEngine:
         process = [f for f in funcs if f.name == "process"]
         assert len(process) == 1
         assert process[0].class_name == "DataProcessor"
-        assert process[0].complexity >= 3
+        assert process[0].complexity == 5
 
     def test_empty_file(self, complex_project):
         from tree_sitter_analyzer.complexity_heatmap import analyze_file_complexity
@@ -109,10 +109,10 @@ class TestComplexityEngine:
         from tree_sitter_analyzer.complexity_heatmap import analyze_file_complexity
 
         funcs = analyze_file_complexity(str(complex_project / "mixed.js"), "javascript")
-        assert len(funcs) >= 1
+        assert len(funcs) == 1
         fetch = [f for f in funcs if f.name == "fetchData"]
         assert len(fetch) == 1
-        assert fetch[0].complexity >= 3
+        assert fetch[0].complexity == 5
 
     def test_risk_bands(self):
         from tree_sitter_analyzer.complexity_heatmap import _risk_band
@@ -130,9 +130,9 @@ class TestComplexityEngine:
         from tree_sitter_analyzer.complexity_heatmap import analyze_project_heatmap
 
         heatmap = analyze_project_heatmap(str(complex_project))
-        assert heatmap["total_files_analyzed"] >= 2
-        assert heatmap["total_functions"] >= 3
-        assert heatmap["total_cyclomatic_complexity"] > 0
+        assert heatmap["total_files_analyzed"] == 3
+        assert heatmap["total_functions"] == 6
+        assert heatmap["total_cyclomatic_complexity"] == 21
         assert "risk_distribution" in heatmap
         assert "top_hotspots" in heatmap
         assert "file_heatmaps" in heatmap
@@ -153,7 +153,7 @@ class TestComplexityEngine:
         from tree_sitter_analyzer.complexity_heatmap import analyze_project_heatmap
 
         heatmap = analyze_project_heatmap(str(complex_project), directory_filter=".")
-        assert heatmap["total_files_analyzed"] >= 1
+        assert heatmap["total_files_analyzed"] == 3
 
     def test_decision_points_populated(self, complex_project):
         from tree_sitter_analyzer.complexity_heatmap import analyze_file_complexity
@@ -175,10 +175,10 @@ class TestCacheBackedComplexity:
         funcs = analyze_file_complexity_from_cache(
             cache, str(indexed_complex_project / "complex.py")
         )
-        assert len(funcs) >= 3
+        assert len(funcs) == 3
         nested = [f for f in funcs if f.name == "deeply_nested"]
         assert len(nested) == 1
-        assert nested[0].complexity >= 6
+        assert nested[0].complexity == 8
         cache.close()
 
     def test_cache_backed_fallback(self, complex_project):
@@ -201,8 +201,8 @@ class TestCacheBackedComplexity:
 
         cache = ASTCache(str(indexed_complex_project))
         heatmap = analyze_project_heatmap(str(indexed_complex_project), cache=cache)
-        assert heatmap["total_files_analyzed"] >= 2
-        assert heatmap["total_functions"] >= 3
+        assert heatmap["total_files_analyzed"] == 3
+        assert heatmap["total_functions"] == 6
         cache.close()
 
 
@@ -220,7 +220,7 @@ class TestComplexityHeatmapTool:
         result = await tool.execute({"mode": "project", "output_format": "json"})
         assert result["success"] is True
         assert result["mode"] == "project"
-        assert result["total_functions"] >= 3
+        assert result["total_functions"] == 6
         assert "risk_distribution" in result
         assert "risk_bands" in result
         assert result["verdict"] in ("INFO", "REVIEW")
@@ -237,7 +237,7 @@ class TestComplexityHeatmapTool:
         )
         assert result["success"] is True
         assert result["mode"] == "file"
-        assert result["function_count"] >= 3
+        assert result["function_count"] == 3
         assert "functions" in result
         for fn in result["functions"]:
             assert "complexity" in fn
@@ -257,7 +257,7 @@ class TestComplexityHeatmapTool:
         assert result["success"] is True
         assert result["mode"] == "function"
         assert result["name"] == "deeply_nested"
-        assert result["complexity"] >= 6
+        assert result["complexity"] == 8
         assert "decision_points" in result
 
     @pytest.mark.asyncio
@@ -329,11 +329,13 @@ class TestComplexityCLI:
 
         from tree_sitter_analyzer.cli_main import main
 
+        # Pass --project-root so the heatmap scans the tmp fixture, not os.getcwd()
         monkeypatch.setattr(
             sys,
             "argv",
             [
                 "tsa",
+                "--project-root",
                 str(indexed_complex_project),
                 "--codegraph-complexity-heatmap",
                 "--format",
@@ -348,7 +350,7 @@ class TestComplexityCLI:
         data = json.loads(buf.getvalue())
         assert data["success"] is True
         assert data["mode"] == "project"
-        assert data["total_functions"] > 0
+        assert data["total_functions"] == 6
         assert "risk_distribution" in data
 
     @pytest.mark.skipif(
@@ -383,7 +385,7 @@ class TestComplexityCLI:
         data = json.loads(buf.getvalue())
         assert data["success"] is True
         assert data["mode"] == "file"
-        assert data["function_count"] > 0
+        assert data["function_count"] == 3
         assert "deeply_nested" in {f["name"] for f in data["functions"]}
 
     @pytest.mark.skipif(
@@ -421,4 +423,4 @@ class TestComplexityCLI:
         assert data["success"] is True
         assert data["mode"] == "function"
         assert data["name"] == "deeply_nested"
-        assert data["complexity"] > 1
+        assert data["complexity"] == 8


### PR DESCRIPTION
## Summary

Layer-2 loose-assertion cleanup, batch 10. 48 enforcement-pattern hits → exact pins, **0 exemptions**; ratchet baseline 1380 → 1332 (−48 exactly, pre/post measured).

| File | Hits → Remaining |
|---|---|
| tests/unit/core/test_query_code_cross_language_compatibility.py | 29 → 0 |
| tests/unit/test_complexity_heatmap.py | 19 → 0 |

## Hard-step B catch: live-repo count pinned down

`test_cli_project_mode` passed the fixture dir as a positional file arg while `project_root` defaulted to `os.getcwd()` — the LIVE repo. The loose `total_functions > 0` was green over 3,866 live-repo functions instead of the fixture's 6. Fixed with `--project-root <fixture>` and pinned `== 6` — the test now actually tests its fixture.

## Notable pins

- Cross-language query counts pinned per language (JS 23-capture quirk documented, TS 19, PY 32, JAVA 3...) — grammar-bump drift now goes red by design
- Complexity values pinned exactly (deeply_nested==8, process==5, total==21) across engine/cache/MCP/CLI surfaces

## Test plan

- [x] 7/7 cross-language + 26/26 heatmap green (`-n 0`)
- [x] Ratchet exits 0; baseline 1332 (lead spot-checked both files — 0 residual)