### PR TITLE
fix(languages): honest install-state for extras grammars — error carries the fix, show-supported-languages reports installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ uv run python check_quality.py --new-code-only  # quality gate
 
 | Symptom | Fix |
 |---|---|
-| `unsupported language` on `.swift / .kt / .rb / .php / .cs` | Update to ≥ 1.12.x — the 5-language gap was patched in commit `50e99a8f`. |
+| `unsupported language` on `.swift / .kt / .rb / .php / .cs` | Update to ≥ 1.12.x — the 5-language gap was patched in commit `50e99a8f`. Grammar modules for extras-gated languages are not bundled in the base install; run `pip install "tree-sitter-analyzer[swift]"` (or `kotlin`, `ruby`, `php`, `csharp`) to add them. |
 | MCP server doesn't appear in client | `TREE_SITTER_PROJECT_ROOT` must be **absolute**; restart the client after config edit. |
 | `database is locked` | Stop any other process holding `.ast-cache/index.db`; if persistent, `rm -rf .ast-cache && tree-sitter-analyzer --autoindex`. |
 | Slow first call | First call builds the index. Subsequent calls are sub-second. Run `--full-index` upfront to amortise. |

--- a/README_ja.md
+++ b/README_ja.md
@@ -398,7 +398,7 @@ uv run python check_quality.py --new-code-only  # 品質ゲート
 
 | 症状 | 修正 |
 |---|---|
-| `.swift / .kt / .rb / .php / .cs` で `unsupported language` | ≥ 1.12.x へ更新 — 5 言語 gap は commit `50e99a8f` で修正済み |
+| `.swift / .kt / .rb / .php / .cs` で `unsupported language` | ≥ 1.12.x へ更新 — 5 言語 gap は commit `50e99a8f` で修正済み。extras 区分の文法モジュールはベースインストールに同梱されません。`pip install "tree-sitter-analyzer[swift]"`(または `kotlin`、`ruby`、`php`、`csharp`)で追加してください |
 | MCP サーバーがクライアントに表示されない | `TREE_SITTER_PROJECT_ROOT` は**絶対パス**必須; 設定編集後にクライアント再起動 |
 | `database is locked` | `.ast-cache/index.db` を保持する他プロセスを停止; 継続する場合は `rm -rf .ast-cache && tree-sitter-analyzer --autoindex` |
 | 初回呼び出しが遅い | 初回はインデックスを構築。後続はサブ秒。事前に `--full-index` を実行すれば償却可能 |

--- a/README_zh.md
+++ b/README_zh.md
@@ -400,7 +400,7 @@ uv run python check_quality.py --new-code-only  # 质量闸门
 
 | 症状 | 修复 |
 |---|---|
-| `.swift / .kt / .rb / .php / .cs` 显示 `unsupported language` | 升级到 ≥ 1.12.x — 5 语言 gap 已在 commit `50e99a8f` 中修复 |
+| `.swift / .kt / .rb / .php / .cs` 显示 `unsupported language` | 升级到 ≥ 1.12.x — 5 语言 gap 已在 commit `50e99a8f` 中修复。extras 门控语言的语法模块不随基础安装捆绑;运行 `pip install "tree-sitter-analyzer[swift]"`(或 `kotlin`、`ruby`、`php`、`csharp`)补装 |
 | MCP 服务在客户端中不出现 | `TREE_SITTER_PROJECT_ROOT` 必须是**绝对路径**；编辑配置后重启客户端 |
 | `database is locked` | 关闭其他占用 `.ast-cache/index.db` 的进程；持续存在则 `rm -rf .ast-cache && tree-sitter-analyzer --autoindex` |
 | 首次调用慢 | 首次调用会建索引。后续亚秒。预先跑 `--full-index` 即可分摊 |

--- a/tests/unit/core/test_grammar_install_hints.py
+++ b/tests/unit/core/test_grammar_install_hints.py
@@ -240,7 +240,16 @@ class TestParserErrorMessageCarriesHint:
         parser._loader = FakeLoader()
         parser._encoding_manager = None  # won't be reached
 
-        result = parser.parse_code("let x = 1", "swift")
+        # Patch the parser-module probe: CI environments install the swift
+        # grammar, so the real importlib probe would take the bare-error
+        # branch there while the hint branch fires locally — pin the seam.
+        from unittest.mock import patch
+
+        with patch(
+            "tree_sitter_analyzer.core.parser.is_grammar_installed",
+            return_value=False,
+        ):
+            result = parser.parse_code("let x = 1", "swift")
         assert result.success is False
         assert result.error_message is not None
         assert "pip install" in result.error_message, (

--- a/tests/unit/core/test_grammar_install_hints.py
+++ b/tests/unit/core/test_grammar_install_hints.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""
+Tests for grammar install hints (Issue #537).
+
+RED-first: these tests define the expected behaviour for Leg 1 (error message)
+and Leg 2 (install-state probe). They must fail before the implementation lands.
+"""
+
+import importlib.util
+from argparse import Namespace
+from unittest.mock import patch
+
+from tree_sitter_analyzer.language_loader import (
+    LanguageLoader,
+    grammar_install_hint,
+)
+
+
+class TestGrammarInstallHint:
+    """Leg 1: grammar_install_hint() returns the correct pip-install instruction."""
+
+    def test_swift_hint_contains_extras_name(self):
+        hint = grammar_install_hint("swift")
+        assert hint is not None
+        # Must mention the extras group name
+        assert "swift" in hint
+        # Must be a pip install instruction
+        assert "pip install" in hint
+
+    def test_kotlin_hint_contains_extras_name(self):
+        hint = grammar_install_hint("kotlin")
+        assert hint is not None
+        assert "kotlin" in hint
+        assert "pip install" in hint
+
+    def test_python_hint_contains_extras_name(self):
+        hint = grammar_install_hint("python")
+        assert hint is not None
+        assert "python" in hint
+        assert "pip install" in hint
+
+    def test_unknown_language_hint_is_none(self):
+        """A language not in LANGUAGE_MODULES has no hint."""
+        assert grammar_install_hint("unknown_lang_xyz") is None
+
+    def test_hint_format_uses_tree_sitter_analyzer_bracket(self):
+        """Hints must use the canonical 'pip install tree-sitter-analyzer[<extra>]' form."""
+        hint = grammar_install_hint("swift")
+        assert "tree-sitter-analyzer[swift]" in hint
+
+    def test_rust_hint_format(self):
+        hint = grammar_install_hint("rust")
+        assert "tree-sitter-analyzer[rust]" in hint
+
+    def test_go_hint_format(self):
+        hint = grammar_install_hint("go")
+        assert "tree-sitter-analyzer[go]" in hint
+
+    def test_csharp_hint_format(self):
+        hint = grammar_install_hint("csharp")
+        assert hint is not None
+        assert "pip install" in hint
+
+    def test_all_loader_languages_have_a_hint(self):
+        """Every language in LANGUAGE_MODULES must have a hint (extras or package)."""
+        loader = LanguageLoader()
+        no_hint = [
+            lang
+            for lang in loader.LANGUAGE_MODULES
+            if grammar_install_hint(lang) is None
+        ]
+        assert no_hint == [], f"Languages missing install hint: {no_hint}"
+
+
+class TestGrammarInstalledField:
+    """Leg 2: ShowLanguagesCommand adds installed: bool to each language entry."""
+
+    def test_json_output_has_installed_field(self):
+        """Each language dict in the JSON envelope must have an 'installed' key."""
+        from tree_sitter_analyzer.cli.info_commands import ShowLanguagesCommand
+
+        args = Namespace(output_format="json", format="json")
+        cmd = ShowLanguagesCommand(args)
+        captured: dict = {}
+        with patch(
+            "tree_sitter_analyzer.cli.info_commands.output_json",
+            side_effect=lambda d: captured.update(d) if isinstance(d, dict) else None,
+        ):
+            rc = cmd.execute()
+        assert rc == 0
+        assert "languages" in captured
+        for entry in captured["languages"]:
+            assert "installed" in entry, (
+                f"Entry for {entry.get('language')} missing 'installed' field"
+            )
+            assert isinstance(entry["installed"], bool)
+
+    def test_installed_true_for_available_grammar(self):
+        """Languages whose grammar module is importable must have installed=True."""
+        from tree_sitter_analyzer.cli.info_commands import ShowLanguagesCommand
+
+        args = Namespace(output_format="json", format="json")
+        cmd = ShowLanguagesCommand(args)
+        captured: dict = {}
+        with patch(
+            "tree_sitter_analyzer.cli.info_commands.output_json",
+            side_effect=lambda d: captured.update(d) if isinstance(d, dict) else None,
+        ):
+            cmd.execute()
+
+        # python grammar IS installed in this test env
+        python_entry = next(
+            (e for e in captured["languages"] if e["language"] == "python"), None
+        )
+        assert python_entry is not None
+        assert python_entry["installed"] is True
+
+    def test_installed_false_for_missing_grammar(self):
+        """Languages whose grammar module is not importable must have installed=False."""
+        from tree_sitter_analyzer.cli.info_commands import ShowLanguagesCommand
+
+        args = Namespace(output_format="json", format="json")
+        cmd = ShowLanguagesCommand(args)
+        captured: dict = {}
+
+        # Patch find_spec to simulate tree_sitter_swift not installed
+        original_find_spec = importlib.util.find_spec
+
+        def patched_find_spec(name, *args, **kwargs):
+            if name == "tree_sitter_swift":
+                return None
+            return original_find_spec(name, *args, **kwargs)
+
+        with (
+            patch("importlib.util.find_spec", side_effect=patched_find_spec),
+            patch(
+                "tree_sitter_analyzer.cli.info_commands.output_json",
+                side_effect=lambda d: (
+                    captured.update(d) if isinstance(d, dict) else None
+                ),
+            ),
+        ):
+            cmd.execute()
+
+        swift_entry = next(
+            (e for e in captured["languages"] if e["language"] == "swift"), None
+        )
+        assert swift_entry is not None
+        assert swift_entry["installed"] is False
+
+    def test_install_hint_field_present_for_missing_grammar(self):
+        """Entries with installed=False must also carry an 'install_hint' key."""
+        from tree_sitter_analyzer.cli.info_commands import ShowLanguagesCommand
+
+        args = Namespace(output_format="json", format="json")
+        cmd = ShowLanguagesCommand(args)
+        captured: dict = {}
+
+        original_find_spec = importlib.util.find_spec
+
+        def patched_find_spec(name, *args, **kwargs):
+            if name == "tree_sitter_swift":
+                return None
+            return original_find_spec(name, *args, **kwargs)
+
+        with (
+            patch("importlib.util.find_spec", side_effect=patched_find_spec),
+            patch(
+                "tree_sitter_analyzer.cli.info_commands.output_json",
+                side_effect=lambda d: (
+                    captured.update(d) if isinstance(d, dict) else None
+                ),
+            ),
+        ):
+            cmd.execute()
+
+        swift_entry = next(
+            (e for e in captured["languages"] if e["language"] == "swift"), None
+        )
+        assert swift_entry is not None
+        assert "install_hint" in swift_entry
+        assert swift_entry["install_hint"] is not None
+        assert "pip install" in swift_entry["install_hint"]
+
+    def test_text_output_marks_not_installed(self):
+        """Text output must visually flag languages whose grammar is missing."""
+        from tree_sitter_analyzer.cli.info_commands import ShowLanguagesCommand
+
+        args = Namespace(output_format="text", format=None)
+        cmd = ShowLanguagesCommand(args)
+        text_lines: list[str] = []
+
+        original_find_spec = importlib.util.find_spec
+
+        def patched_find_spec(name, *args, **kwargs):
+            if name == "tree_sitter_swift":
+                return None
+            return original_find_spec(name, *args, **kwargs)
+
+        with (
+            patch("importlib.util.find_spec", side_effect=patched_find_spec),
+            patch(
+                "tree_sitter_analyzer.cli.info_commands.output_list",
+                side_effect=lambda msg: text_lines.append(msg),
+            ),
+        ):
+            rc = cmd.execute()
+
+        assert rc == 0
+        swift_lines = [line for line in text_lines if "swift" in line.lower()]
+        assert len(swift_lines) == 1
+        combined = " ".join(swift_lines)
+        # Must contain some indicator of not-installed state
+        assert any(
+            marker in combined.lower()
+            for marker in ["not installed", "pip install", "[not installed]"]
+        )
+
+
+class TestParserErrorMessageCarriesHint:
+    """Leg 1: parser.parse_code returns an error message with pip install hint
+    when the grammar module is not installed."""
+
+    def test_parse_code_error_message_contains_hint_for_grammar_missing(self):
+        """When grammar module is absent, error_message must contain install hint."""
+        from tree_sitter_analyzer.core.parser import Parser
+
+        parser = Parser.__new__(Parser)
+
+        # Build a minimal mock loader that says swift is unavailable
+        class FakeLoader:
+            def is_language_available(self, lang):
+                return False
+
+            def create_parser_safely(self, lang):
+                return None
+
+            LANGUAGE_MODULES = {"swift": "tree_sitter_swift"}
+
+        parser._loader = FakeLoader()
+        parser._encoding_manager = None  # won't be reached
+
+        result = parser.parse_code("let x = 1", "swift")
+        assert result.success is False
+        assert result.error_message is not None
+        assert "pip install" in result.error_message, (
+            f"Expected pip install hint in: {result.error_message!r}"
+        )
+        assert "swift" in result.error_message.lower()

--- a/tree_sitter_analyzer/cli/info_commands.py
+++ b/tree_sitter_analyzer/cli/info_commands.py
@@ -5,10 +5,12 @@ Information Commands for CLI
 Commands that display information without requiring file analysis.
 """
 
+import importlib.util
 from abc import ABC, abstractmethod
 from argparse import Namespace
 
 from ..language_detector import detect_language_from_file, detector
+from ..language_loader import grammar_install_hint
 from ..output_manager import (
     output_data,
     output_error,
@@ -18,6 +20,18 @@ from ..output_manager import (
 )
 from ..query_loader import query_loader
 from .output_format import wants_json_output as _wants_json_output  # noqa: F401
+
+
+def _grammar_installed(language: str) -> bool:
+    """Probe grammar module availability without importing it."""
+    from ..language_loader import LanguageLoader
+
+    module_name = LanguageLoader.LANGUAGE_MODULES.get(language)
+    if module_name is None:
+        # Languages without a grammar module (e.g. json uses its own plugin path)
+        # are treated as installed (they won't raise a ModuleNotFoundError).
+        return True
+    return importlib.util.find_spec(module_name) is not None
 
 
 class InfoCommand(ABC):
@@ -307,12 +321,17 @@ class ShowLanguagesCommand(InfoCommand):
         languages_info = []
         for language in detector.get_supported_languages():
             info = detector.get_language_info(language)
-            languages_info.append(
-                {
-                    "language": language,
-                    "extensions": list(info["extensions"]),
-                }
-            )
+            installed = _grammar_installed(language)
+            entry: dict = {
+                "language": language,
+                "extensions": list(info["extensions"]),
+                "installed": installed,
+            }
+            if not installed:
+                hint = grammar_install_hint(language)
+                if hint:
+                    entry["install_hint"] = hint
+            languages_info.append(entry)
 
         if _wants_json_output(self.args):
             summary_line = f"show_supported_languages: {len(languages_info)} languages"
@@ -341,7 +360,14 @@ class ShowLanguagesCommand(InfoCommand):
             extensions = ", ".join(exts[:5])
             if len(exts) > 5:
                 extensions += f", ... ({len(exts) - 5} more)"
-            output_list(f"  {entry['language']:<12} - Extensions: {extensions}")
+            if entry["installed"]:
+                output_list(f"  {entry['language']:<12} - Extensions: {extensions}")
+            else:
+                hint = entry.get("install_hint", "")
+                output_list(
+                    f"  {entry['language']:<12} - Extensions: {extensions}"
+                    f"  [not installed — {hint}]"
+                )
         return 0
 
 

--- a/tree_sitter_analyzer/cli/info_commands.py
+++ b/tree_sitter_analyzer/cli/info_commands.py
@@ -22,16 +22,23 @@ from ..query_loader import query_loader
 from .output_format import wants_json_output as _wants_json_output  # noqa: F401
 
 
-def _grammar_installed(language: str) -> bool:
-    """Probe grammar module availability without importing it."""
+def _grammar_install_state(language: str) -> tuple[bool, str | None]:
+    """Probe grammar availability without importing it.
+
+    Returns ``(installed, hint)``. Languages with no loader mapping at all
+    (e.g. ``json``) are reported NOT installed — the parser surface rejects
+    them (``Unsupported language``), so claiming ``installed: true`` would
+    be the same false advertising this command is being fixed for
+    (Codex P2 on #559).
+    """
     from ..language_loader import LanguageLoader
 
     module_name = LanguageLoader.LANGUAGE_MODULES.get(language)
     if module_name is None:
-        # Languages without a grammar module (e.g. json uses its own plugin path)
-        # are treated as installed (they won't raise a ModuleNotFoundError).
-        return True
-    return importlib.util.find_spec(module_name) is not None
+        return False, "no grammar loader mapping — parser surface unavailable"
+    if importlib.util.find_spec(module_name) is not None:
+        return True, None
+    return False, grammar_install_hint(language)
 
 
 class InfoCommand(ABC):
@@ -318,42 +325,51 @@ class ShowLanguagesCommand(InfoCommand):
     """Command to show supported languages."""
 
     def execute(self) -> int:
-        languages_info = []
-        for language in detector.get_supported_languages():
-            info = detector.get_language_info(language)
-            installed = _grammar_installed(language)
-            entry: dict = {
-                "language": language,
-                "extensions": list(info["extensions"]),
-                "installed": installed,
-            }
-            if not installed:
-                hint = grammar_install_hint(language)
-                if hint:
-                    entry["install_hint"] = hint
-            languages_info.append(entry)
-
+        languages_info = [
+            self._build_language_entry(language)
+            for language in detector.get_supported_languages()
+        ]
         if _wants_json_output(self.args):
-            summary_line = f"show_supported_languages: {len(languages_info)} languages"
-            output_json(
-                {
-                    "success": True,
-                    "languages": languages_info,
-                    "language_count": len(languages_info),
-                    "summary_line": summary_line,
-                    "verdict": "INFO",
-                    "agent_summary": {
-                        "summary_line": summary_line,
-                        "next_step": (
-                            "Pass --language=<name> + --list-queries to see that "
-                            "language's available query keys."
-                        ),
-                        "verdict": "INFO",
-                    },
-                }
-            )
-            return 0
+            return self._emit_json(languages_info)
+        return self._emit_text(languages_info)
 
+    @staticmethod
+    def _build_language_entry(language: str) -> dict:
+        info = detector.get_language_info(language)
+        installed, hint = _grammar_install_state(language)
+        entry: dict = {
+            "language": language,
+            "extensions": list(info["extensions"]),
+            "installed": installed,
+        }
+        if hint:
+            entry["install_hint"] = hint
+        return entry
+
+    @staticmethod
+    def _emit_json(languages_info: list[dict]) -> int:
+        summary_line = f"show_supported_languages: {len(languages_info)} languages"
+        output_json(
+            {
+                "success": True,
+                "languages": languages_info,
+                "language_count": len(languages_info),
+                "summary_line": summary_line,
+                "verdict": "INFO",
+                "agent_summary": {
+                    "summary_line": summary_line,
+                    "next_step": (
+                        "Pass --language=<name> + --list-queries to see that "
+                        "language's available query keys."
+                    ),
+                    "verdict": "INFO",
+                },
+            }
+        )
+        return 0
+
+    @staticmethod
+    def _emit_text(languages_info: list[dict]) -> int:
         output_list("Supported languages:")
         for entry in languages_info:
             exts = entry["extensions"]

--- a/tree_sitter_analyzer/core/parser.py
+++ b/tree_sitter_analyzer/core/parser.py
@@ -16,7 +16,7 @@ from cachetools import LRUCache
 from tree_sitter import Tree
 
 from ..encoding_utils import EncodingManager
-from ..language_loader import get_loader
+from ..language_loader import get_loader, grammar_install_hint, is_grammar_installed
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -270,7 +270,11 @@ class Parser:
         try:
             # Check if language is supported
             if not self.is_language_supported(language):
-                err_msg = f"Unsupported language: {language}"
+                hint = grammar_install_hint(language)
+                if hint and not is_grammar_installed(language):
+                    err_msg = hint
+                else:
+                    err_msg = f"Unsupported language: {language}"
                 return ParseResult(
                     tree=None,
                     source_code=source_code,

--- a/tree_sitter_analyzer/language_loader.py
+++ b/tree_sitter_analyzer/language_loader.py
@@ -7,6 +7,7 @@ and lazy loading for optimal performance.
 """
 
 import importlib
+import importlib.util
 import threading
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -325,3 +326,67 @@ def create_parser_safely(language: str) -> Optional["Parser"]:
 def load_language(language: str) -> Optional["Language"]:
     """言語をロード"""
     return get_loader().load_language(language)
+
+
+# ---------------------------------------------------------------------------
+# Install hints — map each language (or alias) to its pyproject extras group.
+# Aliases that share a grammar (tsx→typescript, cs→csharp, yml→yaml) use their
+# canonical extras name so the hint is unambiguous.
+# ---------------------------------------------------------------------------
+_GRAMMAR_EXTRAS: dict[str, str] = {
+    "java": "java",
+    "javascript": "javascript",
+    "typescript": "typescript",
+    "tsx": "typescript",  # shares tree-sitter-typescript
+    "python": "python",
+    "c": "c",
+    "cpp": "cpp",
+    "rust": "rust",
+    "go": "go",
+    "markdown": "markdown",
+    "sql": "sql",
+    "csharp": "csharp",
+    "cs": "csharp",  # alias
+    "html": "html",
+    "css": "css",
+    "yaml": "yaml",
+    "yml": "yaml",  # alias
+    "php": "php",
+    "ruby": "ruby",
+    "kotlin": "kotlin",
+    "swift": "swift",
+    "bash": "bash",
+    "scala": "scala",
+}
+
+
+def grammar_install_hint(language: str) -> str | None:
+    """Return a pip-install instruction for a language's grammar, or None.
+
+    If the language is unknown (not in LANGUAGE_MODULES and not an alias),
+    returns None.  Otherwise returns a string like:
+        'Swift grammar not installed — pip install "tree-sitter-analyzer[swift]"'
+
+    The caller can use importlib.util.find_spec to check whether the grammar
+    is actually missing before surfacing this hint to the user.
+    """
+    extras = _GRAMMAR_EXTRAS.get(language)
+    if extras is None:
+        return None
+    display = language.upper() if len(language) <= 3 else language.capitalize()
+    return (
+        f"{display} grammar not installed — "
+        f'pip install "tree-sitter-analyzer[{extras}]"'
+    )
+
+
+def is_grammar_installed(language: str) -> bool:
+    """Return True if the grammar module for *language* can be found.
+
+    Uses importlib.util.find_spec (no import, safe for fast probing).
+    Returns False for unknown languages.
+    """
+    module_name = LanguageLoader.LANGUAGE_MODULES.get(language)
+    if module_name is None:
+        return False
+    return importlib.util.find_spec(module_name) is not None


### PR DESCRIPTION
Closes #537 (P1, QC-sweep takeover — peer session silent >12h on its issue batch)

## Problem

Fresh base install: swift listed as supported everywhere, but `sample.swift` → bare `RuntimeError: Unsupported language: swift` (grammar lives in the `[swift]` extra). No hint anywhere that one pip command fixes it.

## Fix (honesty, not repackaging — extras layout untouched)

1. **Error carries the fix**: missing-grammar parse errors now read `Swift grammar not installed — pip install "tree-sitter-analyzer[swift]"` (`grammar_install_hint()` in language_loader, extras names read from the real pyproject layout)
2. **`--show-supported-languages` reports install-state**: per-language `installed: bool` + `install_hint` via `importlib.util.find_spec` probe (no import); text mode marks `[not installed — ...]`. Backward-compatible (fields added, none removed). Also the first tests EVER for info_commands (CLAUDE.md rule-7's zero-test warning) — coverage 96.21%
3. **README**: troubleshooting row now names the extras install command; ja/zh synced (lead review caught the en-only edit)

## Verification

- 14 RED→GREEN tests (monkeypatched find_spec — nothing uninstalled); 112 narrow-suite green
- Lead independently verified the swift row: `{"installed": false, "install_hint": "... pip install \"tree-sitter-analyzer[swift]\""}`
- rule-7 checks sane; ratchet exit 0