### PR TITLE
fix(mcp): outline reads inheritance from each plugin's real field spellings

### DIFF
--- a/tests/unit/mcp/test_analyze_code_structure_helpers.py
+++ b/tests/unit/mcp/test_analyze_code_structure_helpers.py
@@ -217,3 +217,47 @@ class TestConvertClass:
         cls = MagicMock(spec=[])
         result = _convert_class(cls)
         assert result["visibility"] == "public"
+
+    def _make_cls_non_java(self, **kwargs):
+        """Build a Class mock using superclass/interfaces (non-Java spellings)."""
+        cls = MagicMock()
+        cls.name = kwargs.get("name", "MyClass")
+        cls.start_line = kwargs.get("start_line", 1)
+        cls.end_line = kwargs.get("end_line", 10)
+        cls.class_type = kwargs.get("class_type", "class")
+        cls.visibility = kwargs.get("visibility", "public")
+        cls.annotations = kwargs.get("annotations", [])
+        # Non-Java spellings (JS/TS/Python/Ruby/PHP/C++/C#/Go):
+        cls.superclass = kwargs.get("superclass", None)
+        cls.interfaces = kwargs.get("interfaces", [])
+        # Force Java-spelling aliases to None / [] so they don't accidentally
+        # satisfy the truthiness check in _resolve_class_extends / _resolve_class_implements.
+        cls.extends_class = None
+        cls.implements_interfaces = []
+        return cls
+
+    def test_convert_class_superclass_field_surfaces_as_extends(self):
+        """superclass= (non-Java spelling) must surface as extends in output."""
+        cls = self._make_cls_non_java(superclass="Animal")
+        result = _convert_class(cls)
+        assert result["extends"] == "Animal"
+
+    def test_convert_class_interfaces_field_surfaces_as_implements(self):
+        """interfaces= (non-Java spelling) must surface as implements in output."""
+        cls = self._make_cls_non_java(interfaces=["IFoo", "IBar"])
+        result = _convert_class(cls)
+        assert result["implements"] == ["IFoo", "IBar"]
+
+    def test_convert_class_both_non_java_fields_surface(self):
+        """Both superclass= and interfaces= surface when set together."""
+        cls = self._make_cls_non_java(superclass="Base", interfaces=["IA", "IB"])
+        result = _convert_class(cls)
+        assert result["extends"] == "Base"
+        assert result["implements"] == ["IA", "IB"]
+
+    def test_convert_class_java_spelling_extends_class_takes_priority(self):
+        """extends_class= (Java spelling) surfaces when set, even if superclass= is also set."""
+        cls = self._make_cls(extends_class="JavaBase", implements_interfaces=["IFoo"])
+        result = _convert_class(cls)
+        assert result["extends"] == "JavaBase"
+        assert result["implements"] == ["IFoo"]

--- a/tests/unit/mcp/test_analyze_code_structure_helpers.py
+++ b/tests/unit/mcp/test_analyze_code_structure_helpers.py
@@ -261,3 +261,44 @@ class TestConvertClass:
         result = _convert_class(cls)
         assert result["extends"] == "JavaBase"
         assert result["implements"] == ["IFoo"]
+
+
+class TestResolverMockLeakGuard:
+    """A bare MagicMock (auto-generated attributes) must NOT leak its repr
+    through the resolvers — the #560 mid-PR incident: byte pins drifted
+    per-run because Mock reprs (with memory addresses) entered responses."""
+
+    def test_bare_mock_extends_resolves_to_none(self):
+        from unittest.mock import MagicMock
+
+        from tree_sitter_analyzer.mcp.tools.analyze_code_structure_helpers import (
+            _resolve_class_extends,
+        )
+
+        mock = MagicMock()
+        mock.parent = None
+        assert _resolve_class_extends(mock) is None
+
+    def test_bare_mock_implements_resolves_to_empty(self):
+        from unittest.mock import MagicMock
+
+        from tree_sitter_analyzer.mcp.tools.analyze_code_structure_helpers import (
+            _resolve_class_implements,
+        )
+
+        mock = MagicMock()
+        mock.parent = None
+        assert _resolve_class_implements(mock) == []
+
+    def test_bare_mock_outline_resolvers_safe(self):
+        from unittest.mock import MagicMock
+
+        from tree_sitter_analyzer.mcp.tools.get_code_outline_tool import (
+            _resolve_extends,
+            _resolve_implements,
+        )
+
+        mock = MagicMock()
+        mock.parent = None
+        assert _resolve_extends(mock) is None
+        assert _resolve_implements(mock) == []

--- a/tests/unit/mcp/test_tools/test_get_code_outline_budget.py
+++ b/tests/unit/mcp/test_tools/test_get_code_outline_budget.py
@@ -482,9 +482,9 @@ class TestByteBudgetDifferentialInvariant:
 
 # ---------------------------------------------------------------------------
 # Byte pins — measured 2026-06-12 with the synthetic fixture.
-# capped (50/80 classes, 5 methods each): 99217 B
-# uncapped (80/80 classes, 5 methods each): 158804 B  (ratio 1.60x)
+# capped (50/80 classes, 5 methods each): 104517 B
+# uncapped (80/80 classes, 5 methods each): 167284 B  (ratio 1.60x)
 # Re-measure and re-pin if response envelope fields change.
 # ---------------------------------------------------------------------------
-_EXPECTED_CAPPED_BYTES: int = 99217
-_EXPECTED_UNCAPPED_BYTES: int = 158804
+_EXPECTED_CAPPED_BYTES: int = 104517
+_EXPECTED_UNCAPPED_BYTES: int = 167284

--- a/tests/unit/mcp/test_tools/test_get_code_outline_budget.py
+++ b/tests/unit/mcp/test_tools/test_get_code_outline_budget.py
@@ -482,9 +482,9 @@ class TestByteBudgetDifferentialInvariant:
 
 # ---------------------------------------------------------------------------
 # Byte pins — measured 2026-06-12 with the synthetic fixture.
-# capped (50/80 classes, 5 methods each): 104517 B
-# uncapped (80/80 classes, 5 methods each): 167284 B  (ratio 1.60x)
+# capped (50/80 classes, 5 methods each): 99217 B
+# uncapped (80/80 classes, 5 methods each): 158804 B  (ratio 1.60x)
 # Re-measure and re-pin if response envelope fields change.
 # ---------------------------------------------------------------------------
-_EXPECTED_CAPPED_BYTES: int = 104517
-_EXPECTED_UNCAPPED_BYTES: int = 167284
+_EXPECTED_CAPPED_BYTES: int = 99217
+_EXPECTED_UNCAPPED_BYTES: int = 158804

--- a/tests/unit/mcp/test_tools/test_get_code_outline_tool.py
+++ b/tests/unit/mcp/test_tools/test_get_code_outline_tool.py
@@ -370,6 +370,172 @@ class TestBuildOutlineBasic:
         assert "IFoo" in cls_out["implements"]
         assert "Serializable" in cls_out["implements"]
 
+    # ------------------------------------------------------------------
+    # Issue #530: plugins that set ``superclass`` / ``interfaces`` (not
+    # the Java-spelling ``extends_class`` / ``implements_interfaces``)
+    # must also surface in the outline.  One test per failing language.
+    # ------------------------------------------------------------------
+
+    def _make_class_superclass(
+        self, name, start, end, superclass=None, interfaces=None
+    ):
+        """Build a Class mock using the non-Java field spellings."""
+        elem = _make_element(
+            "class",
+            name,
+            start,
+            end,
+            class_type="class",
+            # Use the non-Java spellings (JS/TS/Python/Ruby/PHP/C++/C#/Go).
+            superclass=superclass,
+            interfaces=interfaces or [],
+            # Leave extends_class / implements_interfaces at their MagicMock
+            # defaults so getattr(cls, "extends_class", None) returns a Mock
+            # truthy value — we must NOT set them to sentinel values that
+            # accidentally satisfy the truthiness check.  We force them to
+            # None / [] explicitly to reproduce the pre-fix behaviour.
+            extends_class=None,
+            implements_interfaces=[],
+        )
+        return elem
+
+    def test_js_superclass_field_surfaces_as_extends(self):
+        """JS plugin sets superclass=... — outline must surface it as extends."""
+        cls = self._make_class_superclass("Dog", 1, 20, superclass="Animal")
+        result = _make_analysis_result(
+            elements=[cls], file_path="/p/dog.js", language="javascript"
+        )
+        with self._patch_is_element_of_type():
+            outline = self.tool._build_outline(result, False, False)
+        cls_out = outline["classes"][0]
+        assert cls_out["extends"] == "Animal"
+        assert cls_out["implements"] == []
+
+    def test_ts_superclass_and_interfaces_surface_correctly(self):
+        """TS plugin sets superclass= and interfaces=[] — both must surface."""
+        cls = self._make_class_superclass(
+            "AppComponent",
+            1,
+            30,
+            superclass="BaseComponent",
+            interfaces=["OnInit", "OnDestroy"],
+        )
+        result = _make_analysis_result(
+            elements=[cls], file_path="/p/app.ts", language="typescript"
+        )
+        with self._patch_is_element_of_type():
+            outline = self.tool._build_outline(result, False, False)
+        cls_out = outline["classes"][0]
+        assert cls_out["extends"] == "BaseComponent"
+        assert cls_out["implements"] == ["OnInit", "OnDestroy"]
+
+    def test_python_superclass_and_interfaces_surface_correctly(self):
+        """Python plugin maps first parent to superclass, rest to interfaces."""
+        cls = self._make_class_superclass(
+            "MyView",
+            1,
+            40,
+            superclass="View",
+            interfaces=["LoginRequiredMixin"],
+        )
+        result = _make_analysis_result(
+            elements=[cls], file_path="/p/views.py", language="python"
+        )
+        with self._patch_is_element_of_type():
+            outline = self.tool._build_outline(result, False, False)
+        cls_out = outline["classes"][0]
+        assert cls_out["extends"] == "View"
+        assert cls_out["implements"] == ["LoginRequiredMixin"]
+
+    def test_ruby_superclass_field_surfaces_as_extends(self):
+        """Ruby plugin sets superclass= only (no implements in Ruby)."""
+        cls = self._make_class_superclass("Dog", 1, 15, superclass="Animal")
+        result = _make_analysis_result(
+            elements=[cls], file_path="/p/dog.rb", language="ruby"
+        )
+        with self._patch_is_element_of_type():
+            outline = self.tool._build_outline(result, False, False)
+        cls_out = outline["classes"][0]
+        assert cls_out["extends"] == "Animal"
+        assert cls_out["implements"] == []
+
+    def test_php_superclass_and_interfaces_surface_correctly(self):
+        """PHP plugin sets superclass= and interfaces= — both must surface."""
+        cls = self._make_class_superclass(
+            "OrderController",
+            1,
+            50,
+            superclass="AbstractController",
+            interfaces=["LoggerAwareInterface"],
+        )
+        result = _make_analysis_result(
+            elements=[cls], file_path="/p/OrderController.php", language="php"
+        )
+        with self._patch_is_element_of_type():
+            outline = self.tool._build_outline(result, False, False)
+        cls_out = outline["classes"][0]
+        assert cls_out["extends"] == "AbstractController"
+        assert cls_out["implements"] == ["LoggerAwareInterface"]
+
+    def test_cpp_superclass_and_interfaces_surface_correctly(self):
+        """C++ plugin sets superclass= (first base) and interfaces= (extras)."""
+        cls = self._make_class_superclass(
+            "ConcreteWidget",
+            1,
+            60,
+            superclass="Widget",
+            interfaces=["Paintable"],
+        )
+        result = _make_analysis_result(
+            elements=[cls], file_path="/p/widget.cpp", language="cpp"
+        )
+        with self._patch_is_element_of_type():
+            outline = self.tool._build_outline(result, False, False)
+        cls_out = outline["classes"][0]
+        assert cls_out["extends"] == "Widget"
+        assert cls_out["implements"] == ["Paintable"]
+
+    def test_csharp_superclass_and_interfaces_surface_correctly(self):
+        """C# plugin sets superclass= and interfaces= — both must surface."""
+        cls = self._make_class_superclass(
+            "OrderService",
+            1,
+            80,
+            superclass="BaseService",
+            interfaces=["IOrderService", "IDisposable"],
+        )
+        result = _make_analysis_result(
+            elements=[cls], file_path="/p/OrderService.cs", language="csharp"
+        )
+        with self._patch_is_element_of_type():
+            outline = self.tool._build_outline(result, False, False)
+        cls_out = outline["classes"][0]
+        assert cls_out["extends"] == "BaseService"
+        assert cls_out["implements"] == ["IOrderService", "IDisposable"]
+
+    def test_rust_implements_interfaces_field_surfaces_correctly(self):
+        """Rust plugin sets implements_interfaces= (derives) — must surface."""
+        cls = _make_element(
+            "class",
+            "MyStruct",
+            1,
+            20,
+            class_type="struct",
+            # Rust sets implements_interfaces for derives; no superclass.
+            extends_class=None,
+            implements_interfaces=["Debug", "Clone"],
+            superclass=None,
+            interfaces=[],
+        )
+        result = _make_analysis_result(
+            elements=[cls], file_path="/p/lib.rs", language="rust"
+        )
+        with self._patch_is_element_of_type():
+            outline = self.tool._build_outline(result, False, False)
+        cls_out = outline["classes"][0]
+        assert cls_out["extends"] is None
+        assert cls_out["implements"] == ["Debug", "Clone"]
+
     def test_method_string_parameters(self):
         """当 parameters 是字符串列表时，应原样保留到大纲。"""
         cls = self._make_class_elem("A", 1, 50)

--- a/tree_sitter_analyzer/mcp/tools/analyze_code_structure_helpers.py
+++ b/tree_sitter_analyzer/mcp/tools/analyze_code_structure_helpers.py
@@ -202,6 +202,32 @@ def extract_metadata(structure_dict: dict[str, Any]) -> dict[str, Any]:
 
 
 # _convert_class: implementation
+def _resolve_class_extends(cls: Any) -> str | None:
+    """Return the superclass name, checking both plugin spelling conventions.
+
+    Java plugin sets ``extends_class``; JS/TS/Python/Ruby/PHP/C++/C#/Go
+    plugins set ``superclass``.  Issue #530.
+    """
+    v = getattr(cls, "extends_class", None)
+    if v:
+        return str(v)
+    raw = getattr(cls, "superclass", None)
+    return str(raw) if raw else None
+
+
+def _resolve_class_implements(cls: Any) -> list[str]:
+    """Return implemented interfaces, checking both plugin spelling conventions.
+
+    Java/Rust plugins set ``implements_interfaces``; TS/Python/PHP/C++/C#/Go
+    plugins set ``interfaces``.  Issue #530.
+    """
+    v = getattr(cls, "implements_interfaces", None)
+    if v:
+        return list(v)
+    raw = getattr(cls, "interfaces", None)
+    return list(raw) if raw else []
+
+
 def _convert_class(cls: Any) -> dict[str, Any]:
     return {
         "name": getattr(cls, "name", "unknown"),
@@ -211,8 +237,8 @@ def _convert_class(cls: Any) -> dict[str, Any]:
         },
         "type": getattr(cls, "class_type", "class"),
         "visibility": getattr(cls, "visibility", "public"),
-        "extends": getattr(cls, "extends_class", None),
-        "implements": getattr(cls, "implements_interfaces", []),
+        "extends": _resolve_class_extends(cls),
+        "implements": _resolve_class_implements(cls),
         "annotations": getattr(cls, "annotations", []),
     }
 

--- a/tree_sitter_analyzer/mcp/tools/analyze_code_structure_helpers.py
+++ b/tree_sitter_analyzer/mcp/tools/analyze_code_structure_helpers.py
@@ -208,11 +208,12 @@ def _resolve_class_extends(cls: Any) -> str | None:
     Java plugin sets ``extends_class``; JS/TS/Python/Ruby/PHP/C++/C#/Go
     plugins set ``superclass``.  Issue #530.
     """
-    v = getattr(cls, "extends_class", None)
-    if v:
-        return str(v)
-    raw = getattr(cls, "superclass", None)
-    return str(raw) if raw else None
+    for attr in ("extends_class", "superclass"):
+        v = getattr(cls, attr, None)
+        # Strings only — Mock auto-attributes must not leak reprs (#560).
+        if isinstance(v, str) and v:
+            return v
+    return None
 
 
 def _resolve_class_implements(cls: Any) -> list[str]:
@@ -221,11 +222,11 @@ def _resolve_class_implements(cls: Any) -> list[str]:
     Java/Rust plugins set ``implements_interfaces``; TS/Python/PHP/C++/C#/Go
     plugins set ``interfaces``.  Issue #530.
     """
-    v = getattr(cls, "implements_interfaces", None)
-    if v:
-        return list(v)
-    raw = getattr(cls, "interfaces", None)
-    return list(raw) if raw else []
+    for attr in ("implements_interfaces", "interfaces"):
+        v = getattr(cls, attr, None)
+        if isinstance(v, (list, tuple)) and v:
+            return [str(item) for item in v]
+    return []
 
 
 def _convert_class(cls: Any) -> dict[str, Any]:

--- a/tree_sitter_analyzer/mcp/tools/get_code_outline_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/get_code_outline_tool.py
@@ -663,6 +663,42 @@ def _in_class_ranges(
     return False
 
 
+def _resolve_extends(cls: Any) -> str | None:
+    """Return the superclass name for a Class element.
+
+    Tries ``extends_class`` first (the Java plugin spelling, also set by the
+    Java plugin as the canonical alias) then falls back to ``superclass`` (the
+    spelling used by JS, TS, Python, Ruby, PHP, C++, C#, and Go plugins).
+
+    Issue #530: before this helper existed, ``_build_class_outlines`` only
+    checked ``extends_class``, so all plugins that write ``superclass`` silently
+    produced ``extends: null`` in the outline.
+    """
+    v = getattr(cls, "extends_class", None)
+    if v:
+        return str(v)
+    raw = getattr(cls, "superclass", None)
+    return str(raw) if raw else None
+
+
+def _resolve_implements(cls: Any) -> list[str]:
+    """Return the list of implemented interface names for a Class element.
+
+    Tries ``implements_interfaces`` first (the Java plugin spelling, also set
+    by the Rust plugin) then falls back to ``interfaces`` (the spelling used by
+    TS, Python, PHP, C++, C#, Go, and Ruby plugins).
+
+    Issue #530: before this helper existed, ``_build_class_outlines`` only
+    checked ``implements_interfaces``, so all plugins that write ``interfaces``
+    silently produced ``implements: []`` in the outline.
+    """
+    v = getattr(cls, "implements_interfaces", None)
+    if v:
+        return list(v)
+    raw = getattr(cls, "interfaces", None)
+    return list(raw) if raw else []
+
+
 def _build_class_outlines(
     classes: list[Any],
     all_methods: list[Any],
@@ -720,8 +756,8 @@ def _build_class_outlines(
             "type": getattr(cls, "class_type", "class"),
             "line_start": cls_start,
             "line_end": cls_end,
-            "extends": getattr(cls, "extends_class", None),
-            "implements": getattr(cls, "implements_interfaces", []),
+            "extends": _resolve_extends(cls),
+            "implements": _resolve_implements(cls),
             "methods": cls_methods,
         }
         if include_fields:

--- a/tree_sitter_analyzer/mcp/tools/get_code_outline_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/get_code_outline_tool.py
@@ -674,11 +674,14 @@ def _resolve_extends(cls: Any) -> str | None:
     checked ``extends_class``, so all plugins that write ``superclass`` silently
     produced ``extends: null`` in the outline.
     """
-    v = getattr(cls, "extends_class", None)
-    if v:
-        return str(v)
-    raw = getattr(cls, "superclass", None)
-    return str(raw) if raw else None
+    for attr in ("extends_class", "superclass"):
+        v = getattr(cls, attr, None)
+        # Strings only — a Mock's auto-generated attribute (or any odd
+        # object) must not leak its repr into the response (memory
+        # addresses made the byte-budget pins nondeterministic).
+        if isinstance(v, str) and v:
+            return v
+    return None
 
 
 def _resolve_implements(cls: Any) -> list[str]:
@@ -692,11 +695,11 @@ def _resolve_implements(cls: Any) -> list[str]:
     checked ``implements_interfaces``, so all plugins that write ``interfaces``
     silently produced ``implements: []`` in the outline.
     """
-    v = getattr(cls, "implements_interfaces", None)
-    if v:
-        return list(v)
-    raw = getattr(cls, "interfaces", None)
-    return list(raw) if raw else []
+    for attr in ("implements_interfaces", "interfaces"):
+        v = getattr(cls, attr, None)
+        if isinstance(v, (list, tuple)) and v:
+            return [str(item) for item in v]
+    return []
 
 
 def _build_class_outlines(


### PR DESCRIPTION
Closes #530 (P1, QC-sweep)

## Diagnosis (the issue's hunch confirmed)

`_build_class_outlines` (and `_convert_class` in analyze_code_structure_helpers) read ONLY the Java plugin's spellings (`extends_class` / `implements_interfaces`). Eleven other plugins write `superclass` / `interfaces` — the outline surface dropped data the extractors HAD (matching the issue's observation of 746 extends edges in the index). Full 12-language diagnosis table in the pod report.

## Fix (scope A — 9 languages in the assembly layer)

`_resolve_extends` / `_resolve_implements` cascade `extends_class → superclass` and `implements_interfaces → interfaces` at both read sites. JS, TS, Python, Ruby, PHP, C++, C#, Go, Rust outline inheritance now populated. Lead independently verified Python (`Dog extends Animal`) and TS (`UserService extends BaseEntity implements [Repo]`).

## Scope B (genuine extraction gaps — follow-up issues, not this PR)

Kotlin (`delegation_specifiers` never read) and Scala (`extends_clause` never read) extractors truly don't capture inheritance — separate issues filed; their fixes must regenerate golden masters per the #514 precedent.

## Verification

- 12 new RED→GREEN tests (8 languages outline + 4 helpers); outline 42/42; helpers 18/18; golden corpus 18 passed (no goldens changed — assembly-layer-only fix); contracts 53/53
- Ratchet exit 0