### PR TITLE
fix(outline): nested functions are not top-level — span-containment ownership

### DIFF
--- a/tests/golden_masters/compact/c_sample_compact.md
+++ b/tests/golden_masters/compact/c_sample_compact.md
@@ -3,7 +3,7 @@
 ## Info
 | Property | Value |
 |----------|-------|
-| Methods | 11 |
+| Methods | 10 |
 | Fields | 15 |
 
 ## Methods
@@ -11,7 +11,6 @@
 |--------|-----|---|---|----|----|
 | SQUARE | (x):macro | + | 12-13 | 1 | - |
 | LOG | (msg):macro | + | 16-17 | 1 | - |
-| LOG | (msg):macro | + | 18-19 | 1 | - |
 | add | (i,i):i | + | 86-88 | 1 | - |
 | multiply | (i,i):i | + | 91-93 | 1 | - |
 | process_array | (int[],size_t):void | + | 96-100 | 2 | - |

--- a/tests/golden_masters/csv/c_sample_csv.csv
+++ b/tests/golden_masters/csv/c_sample_csv.csv
@@ -16,7 +16,6 @@ Field,CONSTANT_VALUE,CONSTANT_VALUE:int,public,65-65,,-
 Field,external_value,external_value:int,public,66-66,,-
 Method,SQUARE,(param:x):macro,public,12-13,1,-
 Method,LOG,(param:msg):macro,public,16-17,1,-
-Method,LOG,(param:msg):macro,public,18-19,1,-
 Method,add,"(a:int, b:int):int",public,86-88,1,-
 Method,multiply,"(a:int, b:int):int [static]",public,91-93,1,-
 Method,process_array,"(arr:int[], len:size_t):void",public,96-100,2,-

--- a/tests/golden_masters/full/c_sample_full.md
+++ b/tests/golden_masters/full/c_sample_full.md
@@ -53,7 +53,6 @@
 |--------|-----------|-----|-------|------|----|----|
 | SQUARE | (param:x):macro | + | 12-13 | 5-6 | 1 | - |
 | LOG | (param:msg):macro | + | 16-17 | 5-6 | 1 | - |
-| LOG | (param:msg):macro | + | 18-19 | 5-6 | 1 | - |
 | add | (a:int, b:int):int | + | 86-88 | 5-6 | 1 | - |
 | multiply | (a:int, b:int):int [static] | + | 91-93 | 5-6 | 1 | - |
 | process_array | (arr:int[], len:size_t):void | + | 96-100 | 5-6 | 2 | - |

--- a/tests/golden_masters/plugins/c.json
+++ b/tests/golden_masters/plugins/c.json
@@ -1,11 +1,11 @@
 {
   "counts_by_type": {
     "Class": 6,
-    "Function": 11,
+    "Function": 10,
     "Import": 3,
     "Variable": 15
   },
-  "element_total": 35,
+  "element_total": 34,
   "names_by_type": {
     "Class": [
       "Color",

--- a/tests/golden_masters/plugins/javascript.json
+++ b/tests/golden_masters/plugins/javascript.json
@@ -11,6 +11,8 @@
       "ModernComponent"
     ],
     "Function": [
+      "#logActivity",
+      "#validateData",
       "<anonymous>",
       "FunctionalComponent",
       "blockArrow",

--- a/tests/golden_masters/toon/c_sample_toon.toon
+++ b/tests/golden_masters/toon/c_sample_toon.toon
@@ -10,10 +10,9 @@ classes:
     Number,public,(46,50)
     Person,public,(53,56)
 methods:
-  [11]{name,visibility,line_range(a,b)}:
+  [10]{name,visibility,line_range(a,b)}:
     SQUARE,public,(12,13)
     LOG,public,(16,17)
-    LOG,public,(18,19)
     add,public,(86,88)
     multiply,public,(91,93)
     process_array,public,(96,100)
@@ -46,7 +45,7 @@ imports:
     local_header.h,local_header.h,"#include \"local_header.h\"\n",false,false,(9,9),[],"#include \"local_header.h\"\n"
 statistics:
   class_count: 6
-  method_count: 11
+  method_count: 10
   field_count: 15
   import_count: 3
   total_lines: 161

--- a/tests/unit/languages/test_c_plugin.py
+++ b/tests/unit/languages/test_c_plugin.py
@@ -624,3 +624,40 @@ class TestCPluginLegacyTests:
 
         out = await p.analyze_file(path, ar)
         assert out is not None
+
+
+# ---------------------------------------------------------------------------
+# Issue #534 — C macro deduplication across #ifdef / #else branches (Scope B)
+# ---------------------------------------------------------------------------
+
+
+class TestCMacroDeduplication:
+    """Macros defined identically in both #ifdef and #else branches appear once."""
+
+    def test_macro_not_duplicated_across_ifdef_else(self) -> None:
+        """SQUARE and LOG must appear exactly once even when defined in both
+        #ifdef and #else branches (Issue #534 Scope B)."""
+        import tree_sitter
+
+        p = CPlugin()
+        lang = p.get_tree_sitter_language()
+        parser = tree_sitter.Parser(lang)
+        code = (
+            "#include <stdio.h>\n"
+            "int add(int a, int b) { return a + b; }\n"
+            "#ifdef DEBUG\n"
+            "#define SQUARE(x) ((x) * (x))\n"
+            "#define LOG(msg) printf(msg)\n"
+            "#else\n"
+            "#define SQUARE(x) ((x) * (x))\n"
+            "#define LOG(msg) printf(msg)\n"
+            "#endif\n"
+        )
+        tree = parser.parse(bytes(code, "utf-8"))
+        extractor = p.extractor
+        fns = extractor.extract_functions(tree, code)
+        macro_names = [f.name for f in fns if f.return_type == "macro"]
+        assert macro_names.count("SQUARE") == 1, f"SQUARE duplicated: {macro_names}"
+        assert macro_names.count("LOG") == 1, f"LOG duplicated: {macro_names}"
+        # Total: 1 real function + 2 macros = 3
+        assert len(fns) == 3

--- a/tests/unit/languages/test_c_plugin.py
+++ b/tests/unit/languages/test_c_plugin.py
@@ -661,3 +661,31 @@ class TestCMacroDeduplication:
         assert macro_names.count("LOG") == 1, f"LOG duplicated: {macro_names}"
         # Total: 1 real function + 2 macros = 3
         assert len(fns) == 3
+
+
+class TestMacroRedefinitionSurvives:
+    """Codex P2 on #566: same-name dedup must NOT swallow a legitimate
+    #undef + #define redefinition outside any shared conditional."""
+
+    CODE = """
+#define SQUARE(x) ((x) * (x))
+int use1(void) { return SQUARE(2); }
+#undef SQUARE
+#define SQUARE(x) ((x) + (x))
+int use2(void) { return SQUARE(3); }
+"""
+
+    def test_both_definitions_extracted(self):
+        import tree_sitter
+        import tree_sitter_c
+
+        from tree_sitter_analyzer.languages.c_plugin import CElementExtractor
+
+        lang = tree_sitter.Language(tree_sitter_c.language())
+        parser = tree_sitter.Parser(lang)
+        tree = parser.parse(self.CODE.encode())
+        extractor = CElementExtractor()
+        functions = extractor.extract_functions(tree, self.CODE)
+        squares = [f for f in functions if f.name == "SQUARE"]
+        assert len(squares) == 2
+        assert len(functions) == 4  # 2 macros + use1 + use2

--- a/tests/unit/languages/test_c_plugin_coverage_boost.py
+++ b/tests/unit/languages/test_c_plugin_coverage_boost.py
@@ -332,12 +332,13 @@ def test_extract_macros_inside_ifdef_branches(plugin):
     assert "GUARD_VALUE" in var_names, "#ifndef branch was skipped"
     assert "MODE" in var_names, "#if/#elif branches were skipped"
 
-    # Function-like macros from #ifdef and #else branches — both should
-    # be picked up (tree-sitter parses both branches of a conditional).
-    assert "LOG" in fn_names, "#ifdef/#else macro_function branches were skipped"
+    # Function-like macro from #ifdef branch must be captured (Issue #534
+    # Scope B: duplicates from #else branch are now deduplicated — only
+    # the first definition, from the #ifdef branch, is kept).
+    assert "LOG" in fn_names, "#ifdef/#else macro_function branch was skipped"
     log_macros = [f for f in funcs if f.name == "LOG"]
-    assert len(log_macros) == 2, (
-        f"expected two LOG definitions (#ifdef and #else), got {len(log_macros)}"
+    assert len(log_macros) == 1, (
+        f"expected exactly one LOG definition (deduplicated), got {len(log_macros)}"
     )
 
 

--- a/tests/unit/languages/test_javascript_plugin_extraction.py
+++ b/tests/unit/languages/test_javascript_plugin_extraction.py
@@ -455,3 +455,31 @@ class TestGetNodeTextMultiLine:
 
         assert "line one content" in result
         assert "line two content" in result
+
+
+# ---------------------------------------------------------------------------
+# Issue #534 — JS private method name (Scope A2)
+# ---------------------------------------------------------------------------
+
+
+class TestPrivateMethodNameExtraction:
+    """Private class fields (#name) must produce a non-empty name — not ''."""
+
+    def test_private_method_name_is_not_empty(self, plugin):
+        """#logActivity must be extracted as 'logActivity', not empty string."""
+        import tree_sitter
+
+        lang = plugin.get_tree_sitter_language()
+        parser = tree_sitter.Parser(lang)
+        code = "class Logger {\n    #logActivity(msg) { console.log(msg); }\n    normalMethod() {}\n}\n"
+        tree = parser.parse(bytes(code, "utf-8"))
+        extractor = plugin.extractor
+        fns = extractor.extract_functions(tree, code)
+        # normalMethod is definitely present; #logActivity should have a non-empty name
+        method_names = [f.name for f in fns if f.is_method]
+        assert "#logActivity" in method_names or "logActivity" in method_names, (
+            f"Expected private method name in {method_names!r}, got empty string"
+        )
+        # No method should have an empty name
+        empty_names = [f.name for f in fns if f.name == ""]
+        assert empty_names == [], f"Methods with empty names: {empty_names!r}"

--- a/tests/unit/mcp/test_tools/test_get_code_outline_tool.py
+++ b/tests/unit/mcp/test_tools/test_get_code_outline_tool.py
@@ -260,6 +260,49 @@ class TestBuildOutlineBasic:
         assert outline["top_level_functions"][0]["name"] == "main"
         assert len(outline["classes"][0]["methods"]) == 1
 
+    # --- Issue #534: nested functions must NOT appear in top_level_functions ---
+
+    def test_nested_function_not_in_top_level(self):
+        """Issue #534: functions nested inside another function are not top-level.
+
+        my_decorator (lines 3-7) contains wrapper (lines 5-6).
+        top_level_fn (lines 10-11) is truly top-level.
+        Only top_level_fn should appear in top_level_functions.
+        """
+        # outer function
+        outer_fn = self._make_method_elem("my_decorator", 3, 7)
+        # nested function strictly inside outer_fn
+        nested_fn = self._make_method_elem("wrapper", 5, 6)
+        # truly top-level function (no enclosing function)
+        top_fn = self._make_method_elem("top_level_fn", 10, 11)
+        elements = [outer_fn, nested_fn, top_fn]
+        result = _make_analysis_result(elements=elements)
+
+        with self._patch_is_element_of_type():
+            outline = self.tool._build_outline(result, False, False)
+
+        top_names = [f["name"] for f in outline["top_level_functions"]]
+        assert top_names == ["my_decorator", "top_level_fn"]
+        assert "wrapper" not in top_names
+
+    def test_nested_function_same_start_not_promoted(self):
+        """Issue #534: a function starting at the same line as its outer function
+        but ending strictly inside it is still nested (edge case for span check)."""
+        outer_fn = self._make_method_elem("outer", 5, 10)
+        # starts same line as outer, ends inside — strictly contained
+        nested_fn = self._make_method_elem("inner", 6, 9)
+        top_fn = self._make_method_elem("standalone", 20, 25)
+        elements = [outer_fn, nested_fn, top_fn]
+        result = _make_analysis_result(elements=elements)
+
+        with self._patch_is_element_of_type():
+            outline = self.tool._build_outline(result, False, False)
+
+        top_names = [f["name"] for f in outline["top_level_functions"]]
+        assert "inner" not in top_names
+        assert "outer" in top_names
+        assert "standalone" in top_names
+
     def test_package_extracted(self):
         """package 元素应被提取到 outline.package。"""
         pkg = self._make_pkg_elem("com.example.service")

--- a/tree_sitter_analyzer/languages/c_plugin.py
+++ b/tree_sitter_analyzer/languages/c_plugin.py
@@ -126,6 +126,21 @@ class CElementExtractor(ElementExtractor):
             tree.root_node, extractors, functions, "function"
         )
 
+        # Issue #534 (Scope B): preproc_function_def macros are emitted once
+        # per #ifdef / #else branch because both branches are traversed (the
+        # traversal intentionally descends into both to catch macros defined
+        # only inside an #ifdef block).  Deduplicate by name, keeping the
+        # first occurrence (which comes from the #ifdef / #if branch).
+        seen_macro_names: set[str] = set()
+        deduped: list[Function] = []
+        for fn in functions:
+            if fn.return_type == "macro":
+                if fn.name in seen_macro_names:
+                    continue
+                seen_macro_names.add(fn.name)
+            deduped.append(fn)
+        functions = deduped
+
         log_debug(f"Extracted {len(functions)} C functions")
         return functions
 

--- a/tree_sitter_analyzer/languages/c_plugin.py
+++ b/tree_sitter_analyzer/languages/c_plugin.py
@@ -129,15 +129,38 @@ class CElementExtractor(ElementExtractor):
         # Issue #534 (Scope B): preproc_function_def macros are emitted once
         # per #ifdef / #else branch because both branches are traversed (the
         # traversal intentionally descends into both to catch macros defined
-        # only inside an #ifdef block).  Deduplicate by name, keeping the
-        # first occurrence (which comes from the #ifdef / #if branch).
-        seen_macro_names: set[str] = set()
+        # only inside an #ifdef block).  Collapse same-name macros ONLY when
+        # they sit inside the SAME preproc conditional (sibling branches) —
+        # a later legitimate redefinition (#undef + #define elsewhere) must
+        # survive (Codex P2 on #566).
+        conditional_ranges: list[tuple[int, int]] = []
+        stack = [tree.root_node]
+        while stack:
+            n = stack.pop()
+            if n.type in ("preproc_if", "preproc_ifdef"):
+                conditional_ranges.append((n.start_point[0] + 1, n.end_point[0] + 1))
+            stack.extend(n.children)
+
+        def _innermost_conditional(line: int) -> int | None:
+            best: int | None = None
+            best_span = -1
+            for i, (s, e) in enumerate(conditional_ranges):
+                if s <= line <= e:
+                    span = e - s
+                    if best is None or span < best_span:
+                        best, best_span = i, span
+            return best
+
+        seen_macro_keys: set[tuple[str, int]] = set()
         deduped: list[Function] = []
         for fn in functions:
             if fn.return_type == "macro":
-                if fn.name in seen_macro_names:
-                    continue
-                seen_macro_names.add(fn.name)
+                cond = _innermost_conditional(fn.start_line)
+                if cond is not None:
+                    key = (fn.name, cond)
+                    if key in seen_macro_keys:
+                        continue
+                    seen_macro_keys.add(key)
             deduped.append(fn)
         functions = deduped
 

--- a/tree_sitter_analyzer/languages/javascript_plugin/_function_mixin.py
+++ b/tree_sitter_analyzer/languages/javascript_plugin/_function_mixin.py
@@ -103,7 +103,10 @@ class JavaScriptFunctionExtractionMixin:
             is_static = "static" in node_text
 
             for child in node.children:
-                if child.type == "property_identifier":
+                if child.type in ("property_identifier", "private_property_identifier"):
+                    # private_property_identifier covers JS private fields (#name)
+                    # Issue #534: previously only property_identifier was checked,
+                    # so private methods like #logActivity yielded name="".
                     name = self._get_node_text_optimized(child)
                     is_constructor = name == "constructor"
                 elif child.type == "formal_parameters":

--- a/tree_sitter_analyzer/mcp/tools/get_code_outline_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/get_code_outline_tool.py
@@ -235,10 +235,18 @@ class GetCodeOutlineTool(BaseMCPTool):
             for cls in classes
         ]
         class_names = [getattr(cls, "name", "") for cls in classes]
+        # Build function span ranges so nested functions can be excluded from
+        # top_level_functions.  A function is top-level only when NO other
+        # function's span strictly contains it (Issue #534 — span containment).
+        fn_spans = [
+            (getattr(m, "start_line", 0), getattr(m, "end_line", 0))
+            for m in all_methods
+        ]
         top_level_fns = [
             _method_entry(m)
-            for m in all_methods
+            for i, m in enumerate(all_methods)
             if not _in_class_ranges(m, class_ranges, class_names)
+            and not _in_function_spans(i, fn_spans)
         ]
         top_level_fns.sort(key=lambda x: x["line_start"])
 
@@ -660,6 +668,35 @@ def _in_class_ranges(
             rt = _normalize_receiver_type(getattr(method, "receiver_type", None))
             if rt is not None and rt == class_names[i]:
                 return True
+    return False
+
+
+def _in_function_spans(
+    fn_idx: int,
+    fn_spans: list[tuple[int, int]],
+) -> bool:
+    """Return True iff function at ``fn_idx`` is strictly nested inside another.
+
+    A function is nested when another function's span contains it entirely:
+    ``other_start <= fn_start and fn_end <= other_end`` and the spans are not
+    identical (prevents false-positive when two functions share the same lines,
+    e.g. a one-liner or same-line arrow functions).
+
+    Issue #534: without this check, decorator-helper functions (Python
+    ``wrapper`` inside ``my_decorator``), curried inner lambdas (TS), and Scala
+    ``loop`` all leaked into ``top_level_functions``.
+    """
+    fn_start, fn_end = fn_spans[fn_idx]
+    for j, (other_start, other_end) in enumerate(fn_spans):
+        if j == fn_idx:
+            continue
+        # fn is contained within other (non-identical spans)
+        if (
+            other_start <= fn_start
+            and fn_end <= other_end
+            and (other_start, other_end) != (fn_start, fn_end)
+        ):
+            return True
     return False
 
 


### PR DESCRIPTION
Closes #534 (P2, QC-sweep)

## Three root causes, three surgical fixes

| Scope | Root cause | Fix |
|---|---|---|
| A (shared — covers Python/TS/Scala/JS nesting) | `_build_outline` excluded class-owned functions from top_level_functions but never checked FUNCTION-span containment — #484's innermost-span rule covered call edges, not outline placement | `_in_function_spans()`: a function strictly inside another function's span is not top-level |
| A2 (JS) | `#privateMethod` name node is `private_property_identifier`; the mixin only matched `property_identifier` → `name=""` | accept both node types |
| B (C) | macros inside BOTH #ifdef branches extracted twice (processed_nodes dedups by node id, not name) | post-extraction name-dedup for `return_type == "macro"` |

## Verification

- RED→GREEN per case (wrapper/inner-lambda exclusion, `#logActivity` named, SQUARE count 2→1); one batch-7 pin consciously re-pinned (`== 2` → `== 1` for the ifdef macro test)
- Lead independently verified: decorator `wrapper` no longer in top_level_functions
- Goldens: c (5 kinds — macro dedup) + javascript plugin json (+2 recovered private methods); #542 byte pins unmoved (mock fixture has no nesting)
- 8,426 tests pass (2 pre-existing Swift-grammar fails unrelated); ratchet exit 0