### PR TITLE
fix(languages): is_constructor for Python/Ruby/PHP/Scala/C++ keyword constructors

### DIFF
--- a/tests/golden_masters/csv/cpp_sample_csv.csv
+++ b/tests/golden_masters/csv/cpp_sample_csv.csv
@@ -10,8 +10,8 @@ Field,static_value,static_value:int,private,170-170,,-
 Field,APP_NAME,APP_NAME:string,public,171-171,,-
 Field,MAX_SIZE,MAX_SIZE:int,public,172-172,,-
 Method,max,"(a:T, b:T):T",public,25-27,2,-
-Method,Container,():void,public,33-33,1,-
-Method,Container,(value:T):void,public,34-34,1,-
+Constructor,Container,():void,public,33-33,1,-
+Constructor,Container,(value:T):void,public,34-34,1,-
 Method,~Container,():void,public,35-35,1,-
 Method,get,():T,public,37-37,2,-
 Method,set,(value:T):void,public,38-41,1,-
@@ -20,9 +20,9 @@ Method,~Shape,():void,public,75-75,1,-
 Method,area,():double,public,78-78,1,-
 Method,perimeter,():double,public,79-79,1,-
 Method,name,():string,public,82-82,1,-
-Method,Rectangle,"(w:double, h:double):void",public,89-89,1,-
-Method,Rectangle,(other:const Rectangle&):void,public,92-92,1,-
-Method,Rectangle,(other:Rectangle&&):void,public,95-98,1,-
+Constructor,Rectangle,"(w:double, h:double):void",public,89-89,1,-
+Constructor,Rectangle,(other:const Rectangle&):void,public,92-92,1,-
+Constructor,Rectangle,(other:Rectangle&&):void,public,95-98,1,-
 Method,~Rectangle,():void,public,101-101,1,-
 Method,area,():double,public,104-104,1,-
 Method,perimeter,():double,public,105-105,1,-
@@ -33,7 +33,7 @@ Method,operator==,(other:const Rectangle&):bool,public,113-115,1,-
 Method,square,(side:double):Rectangle [static],public,118-120,1,-
 Method,print,():void,public,136-136,1,-
 Method,~Printable,():void,public,137-137,1,-
-Method,Circle,(r:double):void,public,142-142,1,-
+Constructor,Circle,(r:double):void,public,142-142,1,-
 Method,area,():double,public,144-144,1,-
 Method,perimeter,():double,public,145-145,1,-
 Method,name,():string,public,146-146,1,-

--- a/tests/golden_masters/csv/python_sample_csv.csv
+++ b/tests/golden_masters/csv/python_sample_csv.csv
@@ -2,13 +2,13 @@ Type,Name,Signature,Visibility,Lines,Complexity,Doc
 Field,email,email:str | None,private,19-19,,None
 Method,__post_init__,(self:Any):Any,public,21-24,2,-
 Method,greet,(self:Any):str,public,26-28,2,-
-Method,__init__,"(self:Any, name:str, species:str):Any",public,34-36,1,-
+Constructor,__init__,"(self:Any, name:str, species:str):Any",public,34-36,1,-
 Method,make_sound,(self:Any):str,public,39-41,1,-
 Method,describe,(self:Any):str,public,43-45,1,-
-Method,__init__,"(self:Any, name:str):Any",public,51-53,1,-
+Constructor,__init__,"(self:Any, name:str):Any",public,51-53,1,-
 Method,make_sound,(self:Any):str,public,55-57,1,-
 Method,fetch,"(self:Any, item:str):str",public,59-61,1,-
-Method,__init__,"(self:Any, name:str):Any",public,67-69,1,-
+Constructor,__init__,"(self:Any, name:str):Any",public,67-69,1,-
 Method,make_sound,(self:Any):str,public,71-73,1,-
 Method,purr,():str [static],public,76-78,1,-
 Method,fetch_data,"(url:str):dict[str, any]",public,81-87,3,-

--- a/tests/unit/languages/test_is_constructor_531.py
+++ b/tests/unit/languages/test_is_constructor_531.py
@@ -1,0 +1,246 @@
+"""Issue #531 — is_constructor for Python/__init__, Ruby/initialize,
+PHP/__construct, Scala/def-this, and C++ keyword constructors.
+
+Each test class:
+  - uses a live tree-sitter parse (real grammar, real AST nodes)
+  - pins is_constructor is True for the known constructor
+  - pins is_constructor is False for a regular method
+  - for C++: also pins the destructor as False
+
+No mocks are used for the node tree — test_kw4b_rules require live node
+parent chains to actually exercise the parent-walk logic.
+"""
+
+from __future__ import annotations
+
+import pytest
+import tree_sitter
+
+from tree_sitter_analyzer.languages._cpp_plugin_analysis_helpers import (
+    create_cpp_parser,
+)
+from tree_sitter_analyzer.languages.cpp_plugin import CppPlugin
+from tree_sitter_analyzer.languages.php_plugin import PHPPlugin
+from tree_sitter_analyzer.languages.python_plugin.plugin import (
+    PythonElementExtractor,
+    PythonPlugin,
+)
+from tree_sitter_analyzer.languages.ruby_plugin import RubyPlugin
+from tree_sitter_analyzer.languages.scala_plugin import (
+    ScalaPlugin,
+)
+
+# ---------------------------------------------------------------------------
+# Python
+# ---------------------------------------------------------------------------
+
+_PYTHON_SRC = """\
+class Animal:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def make_sound(self) -> str:
+        return ""
+
+
+def __init__() -> None:
+    # module-level __init__ — NOT a constructor
+    pass
+"""
+
+
+class TestPythonIsConstructor:
+    """__init__ inside a class → True; outside → False."""
+
+    @pytest.fixture
+    def extractor(self) -> PythonElementExtractor:
+        return PythonElementExtractor()
+
+    @pytest.fixture
+    def functions(self, extractor: PythonElementExtractor):
+        plugin = PythonPlugin()
+        lang = plugin.get_tree_sitter_language()
+        assert lang is not None, "tree-sitter Python grammar unavailable"
+        parser = tree_sitter.Parser(lang)
+        tree = parser.parse(_PYTHON_SRC.encode())
+        return extractor.extract_functions(tree, _PYTHON_SRC)
+
+    def test_init_in_class_is_constructor_true(self, functions) -> None:
+        init_in_class = [
+            f for f in functions if f.name == "__init__" and f.is_constructor
+        ]
+        assert len(init_in_class) == 1
+
+    def test_regular_method_is_constructor_false(self, functions) -> None:
+        make_sound = next(f for f in functions if f.name == "make_sound")
+        assert make_sound.is_constructor is False
+
+    def test_module_level_init_is_constructor_false(self, functions) -> None:
+        # There are 2 __init__ functions; the module-level one must be False
+        module_inits = [
+            f for f in functions if f.name == "__init__" and not f.is_constructor
+        ]
+        assert len(module_inits) == 1
+
+
+# ---------------------------------------------------------------------------
+# Ruby
+# ---------------------------------------------------------------------------
+
+_RUBY_SRC = """\
+class User
+  def initialize(username, email)
+    @username = username
+    @email = email
+  end
+
+  def authenticate(password)
+    true
+  end
+end
+"""
+
+
+class TestRubyIsConstructor:
+    """initialize → True; regular method → False."""
+
+    @pytest.fixture
+    def functions(self):
+        plugin = RubyPlugin()
+        lang = plugin.get_tree_sitter_language()
+        assert lang is not None, "tree-sitter Ruby grammar unavailable"
+        parser = tree_sitter.Parser(lang)
+        tree = parser.parse(_RUBY_SRC.encode())
+        extractor = plugin.create_extractor()
+        return extractor.extract_functions(tree, _RUBY_SRC)
+
+    def test_initialize_is_constructor_true(self, functions) -> None:
+        init = next(f for f in functions if f.name == "initialize")
+        assert init.is_constructor is True
+
+    def test_regular_method_is_constructor_false(self, functions) -> None:
+        auth = next(f for f in functions if f.name == "authenticate")
+        assert auth.is_constructor is False
+
+
+# ---------------------------------------------------------------------------
+# PHP
+# ---------------------------------------------------------------------------
+
+_PHP_SRC = """\
+<?php
+class User {
+    public function __construct(string $username, string $email) {
+        $this->username = $username;
+    }
+
+    public function authenticate(string $password): bool {
+        return true;
+    }
+}
+
+function standaloneFunc(string $x): void {}
+?>"""
+
+
+class TestPhpIsConstructor:
+    """__construct → True; regular method → False; standalone function → None/False."""
+
+    @pytest.fixture
+    def functions(self):
+        plugin = PHPPlugin()
+        lang = plugin.get_tree_sitter_language()
+        assert lang is not None, "tree-sitter PHP grammar unavailable"
+        parser = tree_sitter.Parser(lang)
+        tree = parser.parse(_PHP_SRC.encode())
+        extractor = plugin.create_extractor()
+        return extractor.extract_functions(tree, _PHP_SRC)
+
+    def test_construct_is_constructor_true(self, functions) -> None:
+        ctor = next(f for f in functions if f.name == "__construct")
+        assert ctor.is_constructor is True
+
+    def test_regular_method_is_constructor_false(self, functions) -> None:
+        auth = next(f for f in functions if f.name == "authenticate")
+        assert auth.is_constructor is False
+
+
+# ---------------------------------------------------------------------------
+# Scala
+# ---------------------------------------------------------------------------
+
+_SCALA_SRC = """\
+class Point(x: Double, y: Double) {
+  def this(x: Double) = this(x, 0.0)
+  def distance(other: Point): Double = 0.0
+}
+"""
+
+
+class TestScalaIsConstructor:
+    """def this(...) → True; regular method → False."""
+
+    @pytest.fixture
+    def functions(self):
+        plugin = ScalaPlugin()
+        lang = plugin.get_tree_sitter_language()
+        assert lang is not None, "tree-sitter Scala grammar unavailable"
+        parser = tree_sitter.Parser(lang)
+        tree = parser.parse(_SCALA_SRC.encode())
+        extractor = plugin.create_extractor()
+        return extractor.extract_functions(tree, _SCALA_SRC)
+
+    def test_def_this_is_constructor_true(self, functions) -> None:
+        ctor = next(f for f in functions if f.name == "this")
+        assert ctor.is_constructor is True
+
+    def test_regular_method_is_constructor_false(self, functions) -> None:
+        dist = next(f for f in functions if f.name == "distance")
+        assert dist.is_constructor is False
+
+
+# ---------------------------------------------------------------------------
+# C++
+# ---------------------------------------------------------------------------
+
+_CPP_SRC = """\
+class Rectangle {
+public:
+    Rectangle(double w, double h) {}
+    ~Rectangle() {}
+    void foo() {}
+};
+
+void global_func() {}
+"""
+
+
+class TestCppIsConstructor:
+    """Constructor (name == class name) → True; destructor → False; regular → False."""
+
+    @pytest.fixture
+    def functions(self):
+        plugin = CppPlugin()
+        lang = plugin.get_tree_sitter_language()
+        assert lang is not None, "tree-sitter C++ grammar unavailable"
+        parser, failure = create_cpp_parser(lang, "test.cpp", _CPP_SRC)
+        assert failure is None, f"C++ parser creation failed: {failure}"
+        tree = parser.parse(_CPP_SRC.encode())
+        extractor = plugin.create_extractor()
+        return extractor.extract_functions(tree, _CPP_SRC)
+
+    def test_constructor_is_constructor_true(self, functions) -> None:
+        ctor = next(f for f in functions if f.name == "Rectangle" and f.is_constructor)
+        assert ctor.is_constructor is True
+
+    def test_destructor_is_constructor_false(self, functions) -> None:
+        dtor = next(f for f in functions if f.name == "~Rectangle")
+        assert dtor.is_constructor is False
+
+    def test_regular_method_is_constructor_false(self, functions) -> None:
+        foo = next(f for f in functions if f.name == "foo")
+        assert foo.is_constructor is False
+
+    def test_global_function_is_constructor_false(self, functions) -> None:
+        gfunc = next(f for f in functions if f.name == "global_func")
+        assert gfunc.is_constructor is False

--- a/tests/unit/languages/test_is_constructor_531.py
+++ b/tests/unit/languages/test_is_constructor_531.py
@@ -244,3 +244,60 @@ class TestCppIsConstructor:
     def test_global_function_is_constructor_false(self, functions) -> None:
         gfunc = next(f for f in functions if f.name == "global_func")
         assert gfunc.is_constructor is False
+
+
+class TestDecoratedPythonConstructor:
+    """Codex P2 on #567: decorated_definition sits between the function and
+    the class block — @trace def __init__ must still flag."""
+
+    def test_decorated_init_is_constructor(self):
+        import tree_sitter
+        import tree_sitter_python
+
+        from tree_sitter_analyzer.languages.python_plugin import (
+            PythonElementExtractor,
+        )
+
+        code = b"""
+def trace(fn):
+    return fn
+
+class A:
+    @trace
+    def __init__(self):
+        pass
+"""
+        lang = tree_sitter.Language(tree_sitter_python.language())
+        tree = tree_sitter.Parser(lang).parse(code)
+        fns = PythonElementExtractor().extract_functions(tree, code.decode())
+        init = [f for f in fns if f.name == "__init__"]
+        assert len(init) == 1
+        assert init[0].is_constructor is True
+
+
+class TestCppHeaderConstructorDeclaration:
+    """Codex P2 on #567: body-less constructor declarations in headers go
+    through the field_declaration path and must flag too."""
+
+    def test_header_declaration_is_constructor(self):
+        import tree_sitter
+        import tree_sitter_cpp
+
+        from tree_sitter_analyzer.languages.cpp_plugin import CppElementExtractor
+
+        code = b"""
+class Rectangle {
+public:
+    Rectangle(double w, double h);
+    double area();
+};
+"""
+        lang = tree_sitter.Language(tree_sitter_cpp.language())
+        tree = tree_sitter.Parser(lang).parse(code)
+        fns = CppElementExtractor().extract_functions(tree, code.decode())
+        ctor = [f for f in fns if f.name == "Rectangle"]
+        area = [f for f in fns if f.name == "area"]
+        assert len(ctor) == 1
+        assert ctor[0].is_constructor is True
+        assert len(area) == 1
+        assert area[0].is_constructor is False

--- a/tree_sitter_analyzer/languages/_cpp_element_helpers.py
+++ b/tree_sitter_analyzer/languages/_cpp_element_helpers.py
@@ -29,6 +29,45 @@ class CppClassExtractionContext:
     extract_comment_for_line: Callable[[int], str | None]
 
 
+_CPP_CLASS_NODE_TYPES = frozenset({"class_specifier", "struct_specifier"})
+_CPP_CLASS_PARENT_WALK_LIMIT = 12
+
+
+def _cpp_containing_class_name(node: Any) -> str | None:
+    """Walk the parent chain (capped) to find the enclosing C++ class name.
+
+    Returns the ``type_identifier`` text of the nearest ``class_specifier``
+    or ``struct_specifier`` ancestor, or ``None`` when the function is not
+    inside a class body.  The depth cap prevents infinite walks on mocked
+    or malformed nodes.
+    """
+    current = getattr(node, "parent", None)
+    depth = 0
+    while current is not None and depth < _CPP_CLASS_PARENT_WALK_LIMIT:
+        if getattr(current, "type", "") in _CPP_CLASS_NODE_TYPES:
+            for child in getattr(current, "children", ()):
+                if getattr(child, "type", "") == "type_identifier":
+                    text = getattr(child, "text", b"")
+                    if isinstance(text, bytes):
+                        return text.decode("utf-8", errors="replace")
+                    return str(text)
+            return None
+        current = getattr(current, "parent", None)
+        depth += 1
+    return None
+
+
+def _is_cpp_constructor(name: str, node: Any) -> bool:
+    """Return True when ``name`` matches the enclosing class name (constructor).
+
+    Destructor names start with ``~``, so ``~Rectangle != Rectangle`` → False.
+    """
+    if not name or name.startswith("~"):
+        return False
+    class_name = _cpp_containing_class_name(node)
+    return class_name is not None and name == class_name
+
+
 def extract_cpp_function(
     node: Any,
     context: CppFunctionExtractionContext | Callable[..., str],
@@ -62,6 +101,7 @@ def extract_cpp_function(
             visibility=visibility,
             docstring=ctx.extract_comment_for_line(start_line),
             complexity_score=ctx.calculate_complexity(node),
+            is_constructor=_is_cpp_constructor(name, node),
         )
     except (AttributeError, ValueError, TypeError) as exc:
         log_debug(f"Failed to extract function info: {exc}")

--- a/tree_sitter_analyzer/languages/_cpp_field_function_helpers.py
+++ b/tree_sitter_analyzer/languages/_cpp_field_function_helpers.py
@@ -47,6 +47,10 @@ def extract_function_from_field_declaration(
 
         start_line = node.start_point[0] + 1
         is_global = ctx.is_global_scope(node)
+        # Header-only constructor DECLARATIONS come through this path too
+        # (Codex P2 on #567) — same name-vs-enclosing-class rule.
+        from ._cpp_element_helpers import _is_cpp_constructor
+
         return Function(
             name=parts.name,
             start_line=start_line,
@@ -61,6 +65,7 @@ def extract_function_from_field_declaration(
             ),
             docstring=ctx.extract_comment_for_line(start_line),
             complexity_score=1,
+            is_constructor=_is_cpp_constructor(parts.name, node),
         )
     except Exception as exc:
         log_debug(f"Failed to extract function from field declaration: {exc}")
@@ -166,6 +171,10 @@ def extract_function_declaration(
         if not name:
             return None
 
+        # Header-only constructor declarations reach this path (Codex P2 on
+        # #567) — same name-vs-enclosing-class rule as definitions.
+        from ._cpp_element_helpers import _is_cpp_constructor
+
         return Function(
             name=name,
             start_line=node.start_point[0] + 1,
@@ -175,6 +184,7 @@ def extract_function_declaration(
             parameters=parameters,
             return_type="void",
             modifiers=[],
+            is_constructor=_is_cpp_constructor(name, node),
         )
     except Exception as exc:
         log_debug(f"Failed to extract function declaration: {exc}")

--- a/tree_sitter_analyzer/languages/php_helpers.py
+++ b/tree_sitter_analyzer/languages/php_helpers.py
@@ -267,6 +267,7 @@ def extract_php_method_element(
             modifiers=modifiers,
             annotations=[{"name": attr["name"]} for attr in attributes],
             receiver_type=parent_class if parent_class else None,
+            is_constructor=name == "__construct",
         )
     except Exception as e:
         log_error(f"Error extracting method element: {e}")

--- a/tree_sitter_analyzer/languages/python_plugin/_element_builders.py
+++ b/tree_sitter_analyzer/languages/python_plugin/_element_builders.py
@@ -75,6 +75,7 @@ class FunctionBuildInput:
     docstring: str
     complexity_score: int
     framework_type: str
+    is_constructor: bool = False
 
 
 def build_function_element(data: FunctionBuildInput) -> Function:
@@ -101,6 +102,7 @@ def build_function_element(data: FunctionBuildInput) -> Function:
         framework_type=data.framework_type,
         is_property="property" in data.decorators,
         is_classmethod="classmethod" in data.decorators,
+        is_constructor=data.is_constructor,
     )
 
 

--- a/tree_sitter_analyzer/languages/python_plugin/_function_extractor_mixin.py
+++ b/tree_sitter_analyzer/languages/python_plugin/_function_extractor_mixin.py
@@ -23,6 +23,22 @@ from ._extractor_helpers import (
 )
 
 
+def _is_python_constructor(name: str, node: Any) -> bool:
+    """Return True when ``name`` is ``__init__`` and the node lives inside a class body.
+
+    The parent chain for a method is: function_definition → block → class_definition.
+    A module-level ``def __init__()`` has only ``module`` above its immediate parent.
+    """
+    if name != "__init__":
+        return False
+    parent = getattr(node, "parent", None)
+    return (
+        parent is not None
+        and getattr(parent, "type", "") == "block"
+        and getattr(getattr(parent, "parent", None), "type", "") == "class_definition"
+    )
+
+
 class PythonFunctionExtractionMixin:
     def extract_functions(self, tree: Any, source_code: str) -> list[Function]:
         """Extract Python function definitions with comprehensive details."""
@@ -74,6 +90,7 @@ class PythonFunctionExtractionMixin:
                     docstring=docstring,
                     complexity_score=complexity_score,
                     framework_type=self.framework_type,
+                    is_constructor=_is_python_constructor(name, node),
                 )
             )
         except Exception as exc:

--- a/tree_sitter_analyzer/languages/python_plugin/_function_extractor_mixin.py
+++ b/tree_sitter_analyzer/languages/python_plugin/_function_extractor_mixin.py
@@ -26,12 +26,17 @@ from ._extractor_helpers import (
 def _is_python_constructor(name: str, node: Any) -> bool:
     """Return True when ``name`` is ``__init__`` and the node lives inside a class body.
 
-    The parent chain for a method is: function_definition → block → class_definition.
-    A module-level ``def __init__()`` has only ``module`` above its immediate parent.
+    The parent chain for a method is: function_definition → block →
+    class_definition — with an optional ``decorated_definition`` between the
+    function and the block when the method carries decorators (Codex P2 on
+    #567: ``@trace\\ndef __init__`` must still flag).
+    A module-level ``def __init__()`` has only ``module`` above it.
     """
     if name != "__init__":
         return False
     parent = getattr(node, "parent", None)
+    if getattr(parent, "type", "") == "decorated_definition":
+        parent = getattr(parent, "parent", None)
     return (
         parent is not None
         and getattr(parent, "type", "") == "block"

--- a/tree_sitter_analyzer/languages/ruby_plugin.py
+++ b/tree_sitter_analyzer/languages/ruby_plugin.py
@@ -327,6 +327,7 @@ class RubyElementExtractor(ElementExtractor):
                 modifiers=[],
                 annotations=[],
                 receiver_type=parent_class if parent_class else None,
+                is_constructor=name == "initialize",
             )
         except Exception as e:
             log_error(f"Error extracting method element: {e}")

--- a/tree_sitter_analyzer/languages/scala_plugin.py
+++ b/tree_sitter_analyzer/languages/scala_plugin.py
@@ -391,6 +391,7 @@ class ScalaElementExtractor(ElementExtractor):
                 return_type=return_type,
                 visibility=visibility,
                 docstring=docstring,
+                is_constructor=name == "this",
             )
 
         except Exception as e:


### PR DESCRIPTION
Closes #531 (P2, QC-sweep)

## Scope (lead-decided)

Unambiguous keyword constructors only: Python `__init__` (class-scoped — module-level `def __init__()` stays False), Ruby `initialize`, PHP `__construct`, Scala `def this(...)`, C++ same-name methods (destructors `~Name` stay False, ≤12-level parent walk with the OOM-lesson cap). **Deliberately skipped**: Go `New*` / Rust `fn new` (convention → a separate is_factory flag is a product decision); **Scope B reported**: Kotlin primary constructors are an extraction gap (`primary_constructor` node not in the dispatch map) — follow-up material, not a flag bug.

## Verification

- 13 new live-parse tests (exact `is True`/`is False` pins incl. negative cases); 89+192+102 plugin suites green; 2151 formatter tests green
- Lead independently verified Python: class `__init__`→True, sibling method→False, module-level `__init__`→False
- Goldens unchanged (they track names/counts, not the flag) — verified, no regeneration needed
- Zero re-pins required (no existing test pinned the False states); ratchet exit 0