### PR TITLE
fix: innermost-container method ownership for nested classes/namespaces/modules

### DIFF
--- a/tests/unit/test_api_result_helpers.py
+++ b/tests/unit/test_api_result_helpers.py
@@ -307,3 +307,16 @@ class TestLocalFunctionStaysUnowned:
         method = _make_elem("doWork", cls_name="Function", start_line=5, end_line=20)
         d = element_to_dict(method, [cls, bare, method])
         assert d["class_name"] == "Outer"
+
+    def test_span_less_class_is_skipped_in_find_class_name(self):
+        """A class-like element without line attrs (guard line) is skipped."""
+
+        class BareClass:
+            pass
+
+        bare = BareClass()
+        bare.__class__.__name__ = "Class"
+        bare.name = "Ghost"
+        cls = _make_elem("Outer", cls_name="Class", start_line=1, end_line=30)
+        method = _make_elem("doWork", cls_name="Function", start_line=5, end_line=20)
+        assert find_class_name(method, [bare, cls]) == "Outer"

--- a/tests/unit/test_api_result_helpers.py
+++ b/tests/unit/test_api_result_helpers.py
@@ -278,3 +278,19 @@ class TestCodeAnalysisError:
     def test_empty_language(self):
         result = code_analysis_error("", RuntimeError("fail"))
         assert result["language_info"]["language"] == "unknown"
+
+
+class TestLocalFunctionStaysUnowned:
+    """Codex P2 on #570: a function nested inside another FUNCTION's span
+    (local helper) is deliberately unowned — line containment in a class
+    must not ownerize it."""
+
+    def test_local_function_gets_no_class_name(self):
+        cls = _make_elem("Outer", cls_name="Class", start_line=1, end_line=30)
+        method = _make_elem("doWork", cls_name="Function", start_line=5, end_line=20)
+        local = _make_elem("inner", cls_name="Function", start_line=8, end_line=12)
+        elements = [cls, method, local]
+        d = element_to_dict(local, elements)
+        assert "class_name" not in d
+        d2 = element_to_dict(method, elements)
+        assert d2["class_name"] == "Outer"

--- a/tests/unit/test_api_result_helpers.py
+++ b/tests/unit/test_api_result_helpers.py
@@ -123,12 +123,55 @@ class TestFindClassName:
         cls = _make_elem(cls_name="Class", start_line=1, end_line=10)
         assert find_class_name(method, [cls]) == "foo"
 
-    def test_multiple_classes_picks_first(self):
+    def test_multiple_classes_picks_innermost(self):
+        """When method is inside two classes, the innermost (smallest span) wins."""
         method = _make_elem(start_line=8, end_line=10)
+        # cls1 span=11 (outer), cls2 span=7 (inner) — cls2 must win
         cls1 = _make_elem(name="A", cls_name="Class", start_line=1, end_line=12)
         cls2 = _make_elem(name="B", cls_name="Class", start_line=3, end_line=10)
-        result = find_class_name(method, [cls1, cls2])
-        assert result in ("A", "foo")
+        assert find_class_name(method, [cls1, cls2]) == "B"
+
+    # --- Issue #532: nested-container innermost-wins ---
+
+    def test_nested_container_innermost_wins(self):
+        """Method inside nested class → innermost (smallest span) class wins."""
+        # Outer: lines 1-20 (span=19), Inner: lines 5-10 (span=5)
+        # method on line 7 is inside BOTH — must get Inner.
+        method = _make_elem(name="m", start_line=7, end_line=8)
+        outer = _make_elem(name="Outer", cls_name="Class", start_line=1, end_line=20)
+        inner = _make_elem(name="Inner", cls_name="Class", start_line=5, end_line=10)
+        # Outer listed first (as plugins typically emit outer before inner)
+        assert find_class_name(method, [outer, inner]) == "Inner"
+
+    def test_nested_namespace_innermost_wins(self):
+        """TS namespace wrapping a class: method inside class → class, not namespace."""
+        # Namespace (class_type=namespace): lines 1-18
+        # BatchProcessor class: lines 3-17
+        # method on line 5
+        method = _make_elem(name="process", start_line=5, end_line=7)
+        namespace = _make_elem(
+            name="DataProcessing", cls_name="Class", start_line=1, end_line=18
+        )
+        cls = _make_elem(
+            name="BatchProcessor", cls_name="Class", start_line=3, end_line=17
+        )
+        # namespace listed first (as TypeScript extractor emits outer first)
+        assert find_class_name(method, [namespace, cls]) == "BatchProcessor"
+
+    def test_java_method_in_inner_class_gets_class_name(self):
+        """element_to_dict sets class_name for a function inside a nested class
+        even when is_method is not explicitly True (Java plugin doesn't set it)."""
+        inner_class = _make_elem(
+            name="InnerClass", cls_name="Class", start_line=3, end_line=7
+        )
+        method = _make_elem(
+            name="innerMethod",
+            cls_name="Function",
+            start_line=4,
+            end_line=6,
+        )
+        result = element_to_dict(method, all_elements=[inner_class, method])
+        assert result["class_name"] == "InnerClass"
 
 
 class TestFileAnalysisResult:

--- a/tests/unit/test_api_result_helpers.py
+++ b/tests/unit/test_api_result_helpers.py
@@ -294,3 +294,16 @@ class TestLocalFunctionStaysUnowned:
         assert "class_name" not in d
         d2 = element_to_dict(method, elements)
         assert d2["class_name"] == "Outer"
+
+    def test_span_less_sibling_is_skipped(self):
+        """Elements without line attrs (line 70 guard) don't break containment."""
+
+        class Bare:
+            pass
+
+        bare = Bare()
+        bare.__class__.__name__ = "Function"
+        cls = _make_elem("Outer", cls_name="Class", start_line=1, end_line=30)
+        method = _make_elem("doWork", cls_name="Function", start_line=5, end_line=20)
+        d = element_to_dict(method, [cls, bare, method])
+        assert d["class_name"] == "Outer"

--- a/tests/unit/test_ast_extraction.py
+++ b/tests/unit/test_ast_extraction.py
@@ -357,3 +357,114 @@ class TestCDeclaratorName:
             children=[SimpleNamespace(type="(", children=[])],
         )
         assert _c_declarator_name(paren, "", 0) is None
+
+
+# ---------------------------------------------------------------------------
+# Issue #532: nested-container method ownership (Ruby + Rust)
+# ---------------------------------------------------------------------------
+
+
+def _symbols_for(source: str, lang: str) -> list[dict]:
+    """Parse source and return all symbols from _extract_symbols."""
+
+    from tree_sitter_analyzer._ast_extraction import _extract_symbols
+    from tree_sitter_analyzer.core.parser import Parser
+
+    result = Parser().parse_code(source, lang)
+    if not result.success or result.tree is None:
+        return []
+    syms = _extract_symbols(result.tree, source, lang)
+    return syms["symbols"]
+
+
+class TestNestedContainerMethodOwnership:
+    """Issue #532 — methods inside nested containers must be attributed to
+    the INNERMOST container in the symbols DB path (_walk_for_symbols)."""
+
+    # ---- Ruby ----
+
+    def test_ruby_module_nested_class_methods_attributed_correctly(self):
+        """Methods inside a class nested in a module must get the CLASS as
+        their owner, not the module, AND must appear at all (Ruby ``method``
+        node type was missing from _FUNCTION_LIKE)."""
+        code = """\
+module Authentication
+  class User
+    def initialize(name)
+      @name = name
+    end
+    def full_name
+      @name
+    end
+  end
+  class AdminUser
+    def login
+      true
+    end
+  end
+end
+"""
+        syms = _symbols_for(code, "ruby")
+        methods = [s for s in syms if s["kind"] in ("function", "method")]
+        classes = {s["name"] for s in syms if s["kind"] == "class"}
+
+        # Classes must be visible
+        assert "User" in classes
+        assert "AdminUser" in classes
+
+        # Methods must be extracted (was 0 before fix — "method" missing from _FUNCTION_LIKE)
+        assert len(methods) == 3
+
+        # Each method must be attributed to its direct owner class, NOT the module
+        owners = {m["name"]: m.get("class") for m in methods}
+        assert owners.get("initialize") == "User"
+        assert owners.get("full_name") == "User"
+        assert owners.get("login") == "AdminUser"
+
+    # ---- Rust ----
+
+    def test_rust_impl_generic_methods_attributed_to_struct(self):
+        """Methods inside impl<T> Container<T> must be attributed to Container,
+        not left unowned (_find_parent_class must read impl_item's type field)."""
+        code = """\
+pub struct Container<T> {
+    items: Vec<T>,
+}
+
+impl<T> Container<T> {
+    pub fn new() -> Self {
+        Container { items: Vec::new() }
+    }
+    pub fn push(&mut self, item: T) {
+        self.items.push(item);
+    }
+}
+"""
+        syms = _symbols_for(code, "rust")
+        methods = [s for s in syms if s["kind"] in ("function", "method")]
+
+        # Both functions must appear
+        assert len(methods) == 2
+
+        # Both must be attributed to Container (stripped of generics)
+        owners = {m["name"]: m.get("class") for m in methods}
+        assert owners.get("new") == "Container"
+        assert owners.get("push") == "Container"
+
+    def test_rust_plain_impl_methods_attributed_to_struct(self):
+        """Plain impl User (no generics) must attribute methods to User."""
+        code = """\
+struct User {
+    name: String,
+}
+
+impl User {
+    fn greet(&self) -> String {
+        format!("Hello, {}", self.name)
+    }
+}
+"""
+        syms = _symbols_for(code, "rust")
+        methods = [s for s in syms if s["kind"] in ("function", "method")]
+        assert len(methods) == 1
+        assert methods[0].get("class") == "User"

--- a/tree_sitter_analyzer/_api_result_helpers.py
+++ b/tree_sitter_analyzer/_api_result_helpers.py
@@ -50,11 +50,31 @@ def element_to_dict(
             result[field] = getattr(elem, field)
 
     if result["type"] == "function" and all_elements:
-        class_name = find_class_name(elem, all_elements)
-        if class_name is not None:
-            result["class_name"] = class_name
+        # A LOCAL function (innermost container is another function, e.g.
+        # Kotlin `fun inner` inside a method) is deliberately unowned —
+        # only class-owned methods get class_name (Codex P2 on #570).
+        if not _contained_in_other_function(elem, all_elements):
+            class_name = find_class_name(elem, all_elements)
+            if class_name is not None:
+                result["class_name"] = class_name
 
     return result
+
+
+def _contained_in_other_function(elem: Any, elements: Sequence[Any]) -> bool:
+    """True when another function's span strictly contains ``elem``'s."""
+    for other in elements:
+        if other is elem or type(other).__name__.lower() != "function":
+            continue
+        if not (hasattr(other, "start_line") and hasattr(other, "end_line")):
+            continue
+        if (
+            other.start_line <= elem.start_line
+            and elem.end_line <= other.end_line
+            and (other.start_line, other.end_line) != (elem.start_line, elem.end_line)
+        ):
+            return True
+    return False
 
 
 def find_class_name(elem: Any, elements: Sequence[Any]) -> str | None:

--- a/tree_sitter_analyzer/_api_result_helpers.py
+++ b/tree_sitter_analyzer/_api_result_helpers.py
@@ -49,23 +49,35 @@ def element_to_dict(
         if hasattr(elem, field):
             result[field] = getattr(elem, field)
 
-    if result.get("is_method") and result["type"] == "function" and all_elements:
-        result["class_name"] = find_class_name(elem, all_elements)
+    if result["type"] == "function" and all_elements:
+        class_name = find_class_name(elem, all_elements)
+        if class_name is not None:
+            result["class_name"] = class_name
 
     return result
 
 
 def find_class_name(elem: Any, elements: Sequence[Any]) -> str | None:
-    """Find the containing class name for a method element."""
+    """Find the containing class name for a method element.
+
+    When multiple classes contain the element's line range (e.g. an inner
+    class nested inside an outer class, or a class inside a namespace), the
+    INNERMOST class — the one with the smallest line span — wins.  This
+    mirrors the single-ownership rule from #474/#484/#532.
+    """
+    best_name: str | None = None
+    best_span: int | None = None
     for other in elements:
-        if (
-            type(other).__name__.lower() == "class"
-            and hasattr(other, "start_line")
-            and hasattr(other, "end_line")
-            and other.start_line <= elem.start_line <= other.end_line
-        ):
-            return other.name
-    return None
+        if type(other).__name__.lower() != "class":
+            continue
+        if not (hasattr(other, "start_line") and hasattr(other, "end_line")):
+            continue
+        if other.start_line <= elem.start_line <= other.end_line:
+            span = other.end_line - other.start_line
+            if best_span is None or span < best_span:
+                best_span = span
+                best_name = other.name
+    return best_name
 
 
 def file_analysis_result(

--- a/tree_sitter_analyzer/_ast_extraction.py
+++ b/tree_sitter_analyzer/_ast_extraction.py
@@ -152,6 +152,11 @@ _FUNCTION_LIKE = frozenset(
         "function_declarator",
         "declaration",
         "init_declarator",
+        # Issue #532: Ruby uses ``method`` / ``singleton_method`` node types;
+        # without these, Ruby methods were invisible in symbols_json so the
+        # class_inspect_tool showed 0 methods for every Ruby class.
+        "method",
+        "singleton_method",
     }
 )
 
@@ -353,12 +358,28 @@ def _count_decision_points(node: Any, language: str) -> dict[str, int]:
 
 
 def _find_parent_class(node: Any, source: str) -> str | None:
+    """Walk up the parent chain to find the innermost enclosing class-like
+    container, returning its name.
+
+    Special cases:
+    - ``impl_item`` (Rust): exposes the implemented type in the ``type``
+      field (e.g. ``Container<T>`` or ``User``), NOT a ``name`` field.
+      Strip any generic parameters so ``Container<T>`` → ``"Container"``.
+    """
     parent = node.parent
     while parent:
         if parent.type in _CLASS_LIKE:
-            name_node = parent.child_by_field_name("name")
-            if name_node:
-                return _node_text(name_node, source)
+            if parent.type == "impl_item":
+                # Rust impl block: the implemented type is in the ``type`` field.
+                type_node = parent.child_by_field_name("type")
+                if type_node is not None:
+                    raw = _node_text(type_node, source)
+                    # Strip generic parameters: "Container<T>" → "Container"
+                    return raw.split("<")[0].strip() or None
+            else:
+                name_node = parent.child_by_field_name("name")
+                if name_node:
+                    return _node_text(name_node, source)
         parent = parent.parent
     return None
 


### PR DESCRIPTION
Closes #532 (P2, QC-sweep — Theme A residual)

## Diagnosis (5 languages, 2 layers)

| Language | Layer | Root cause |
|---|---|---|
| TS | API | `find_class_name` returned the FIRST containing class-like (outermost namespace) instead of innermost |
| Java / Scala | API | `element_to_dict` only attributed when `is_method=True` — only the TS plugin ever sets it |
| Ruby | DB+API | `method`/`singleton_method` node types missing from `_FUNCTION_LIKE` (methods invisible to the walk) |
| Rust | DB+API | `impl_item` has no `name` field — owner read via the `type` field now, generics stripped (`Container<T>`→`Container`) |

## Fix

`find_class_name` picks the smallest containing span (the #474/#484/#485 innermost rule, 4th application); attribution runs for all function elements; Ruby node types added; Rust impl handling added.

## Verification

- 7 RED→GREEN tests (incl. a first-match test consciously renamed+inverted to innermost); 61 green in target files; 3,397 in the wider sweep (pre-existing Swift golden + known dir-isolation failures unrelated)
- Coverage 91.46% / 82.78% (new code fully covered)
- Ratchet exit 0