### PR TITLE
fix(params): default-valued parameters extracted in JS/Python

### DIFF
--- a/tests/golden_masters/compact/python_sample_compact.md
+++ b/tests/golden_masters/compact/python_sample_compact.md
@@ -23,10 +23,10 @@
 | __init__ | (Any,str,str):Any | + | 34-36 | 1 | - |
 | make_sound | (Any):str | + | 39-41 | 1 | - |
 | describe | (Any):str | + | 43-45 | 1 | - |
-| __init__ | (Any,str):Any | + | 51-53 | 1 | - |
+| __init__ | (Any,str,str = "Mixed"):Any | + | 51-53 | 1 | - |
 | make_sound | (Any):str | + | 55-57 | 1 | - |
 | fetch | (Any,str):str | + | 59-61 | 1 | - |
-| __init__ | (Any,str):Any | + | 67-69 | 1 | - |
+| __init__ | (Any,str,bool = True):Any | + | 67-69 | 1 | - |
 | make_sound | (Any):str | + | 71-73 | 1 | - |
 | purr | ():str | + | 76-78 | 1 | - |
 | fetch_data | (str):dict[str, any] | + | 81-87 | 3 | - |

--- a/tests/golden_masters/csv/python_sample_csv.csv
+++ b/tests/golden_masters/csv/python_sample_csv.csv
@@ -5,10 +5,10 @@ Method,greet,(self:Any):str,public,26-28,2,-
 Constructor,__init__,"(self:Any, name:str, species:str):Any",public,34-36,1,-
 Method,make_sound,(self:Any):str,public,39-41,1,-
 Method,describe,(self:Any):str,public,43-45,1,-
-Constructor,__init__,"(self:Any, name:str):Any",public,51-53,1,-
+Constructor,__init__,"(self:Any, name:str, breed:str = """"Mixed""""):Any",public,51-53,1,-
 Method,make_sound,(self:Any):str,public,55-57,1,-
 Method,fetch,"(self:Any, item:str):str",public,59-61,1,-
-Constructor,__init__,"(self:Any, name:str):Any",public,67-69,1,-
+Constructor,__init__,"(self:Any, name:str, indoor:bool = True):Any",public,67-69,1,-
 Method,make_sound,(self:Any):str,public,71-73,1,-
 Method,purr,():str [static],public,76-78,1,-
 Method,fetch_data,"(url:str):dict[str, any]",public,81-87,3,-

--- a/tests/golden_masters/full/python_sample_full.md
+++ b/tests/golden_masters/full/python_sample_full.md
@@ -35,7 +35,7 @@ from functools import reduce
 ### Public Methods
 | Method | Signature | Vis | Lines | Cx | Doc |
 |--------|-----------|-----|-------|----|----| 
-| __init__ | (self:Any, name:str):Any | + | 51-53 | 1 | - |
+| __init__ | (self:Any, name:str, breed:str = "Mixed"):Any | + | 51-53 | 1 | - |
 | make_sound | (self:Any):str | + | 55-57 | 1 | Dogs bark. |
 | fetch | (self:Any, item:str):str | + | 59-61 | 1 | Dogs can fetch items. |
 
@@ -43,7 +43,7 @@ from functools import reduce
 ### Public Methods
 | Method | Signature | Vis | Lines | Cx | Doc |
 |--------|-----------|-----|-------|----|----| 
-| __init__ | (self:Any, name:str):Any | + | 67-69 | 1 | - |
+| __init__ | (self:Any, name:str, indoor:bool = True):Any | + | 67-69 | 1 | - |
 | make_sound | (self:Any):str | + | 71-73 | 1 | Cats meow. |
 | purr | ():str [static] | + | 76-78 | 1 | Cats can purr. |
 

--- a/tests/unit/languages/test_parameter_extraction_theme_e_residual.py
+++ b/tests/unit/languages/test_parameter_extraction_theme_e_residual.py
@@ -410,3 +410,40 @@ class TestBashParamStructuralNa:
         proc = next((f for f in fns if f.name == "process"), None)
         assert proc is not None, "process not found"
         assert proc.parameters == []
+
+
+class TestStructureConversionOfDefaults:
+    """Codex P2 on #581: get_method_parameters must not whitespace-split
+    'limit = 10' into {'name': '10', 'type': 'limit ='}."""
+
+    def test_js_default_param_parses(self):
+        from tree_sitter_analyzer.mcp.tools.analyze_code_structure_helpers import (
+            _parse_string_parameter,
+        )
+
+        assert _parse_string_parameter("limit = 10") == {
+            "name": "limit",
+            "type": "Any",
+            "default": "10",
+        }
+
+    def test_python_typed_default_parses(self):
+        from tree_sitter_analyzer.mcp.tools.analyze_code_structure_helpers import (
+            _parse_string_parameter,
+        )
+
+        assert _parse_string_parameter('breed: str = "Mixed"') == {
+            "name": "breed",
+            "type": "str",
+            "default": '"Mixed"',
+        }
+
+    def test_legacy_java_form_unchanged(self):
+        from tree_sitter_analyzer.mcp.tools.analyze_code_structure_helpers import (
+            _parse_string_parameter,
+        )
+
+        assert _parse_string_parameter("String name") == {
+            "name": "name",
+            "type": "String",
+        }

--- a/tests/unit/languages/test_parameter_extraction_theme_e_residual.py
+++ b/tests/unit/languages/test_parameter_extraction_theme_e_residual.py
@@ -1,0 +1,412 @@
+"""Theme E residual — Issue #533: default-valued params dropped in JS/Python;
+Bash params structural n/a diagnosis.
+
+RED-first tests for:
+  - JS: assignment_pattern (param = default) in formal_parameters silently dropped
+  - Python: typed_default_parameter (name: type = default) silently dropped
+  - Bash: structural verdict — Bash grammar has no formal param nodes (positional
+    $1/$2 at call time); parameters=[] is correct; this test pins that contract.
+
+Convention chosen (matches C# full-text approach):
+  - JS:     'limit = 10', 'options = {}' (full assignment_pattern text)
+  - Python: 'breed: str = "Mixed"' (full typed_default_parameter text)
+
+Uses real tree-sitter parses — no mocks.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("tree_sitter_javascript")
+pytest.importorskip("tree_sitter_python")
+pytest.importorskip("tree_sitter_bash")
+
+import tree_sitter
+import tree_sitter_bash
+import tree_sitter_javascript
+import tree_sitter_python
+
+# ---------------------------------------------------------------------------
+# Helpers — one parser per language
+# ---------------------------------------------------------------------------
+
+
+def _js_parser() -> tree_sitter.Parser:
+    return tree_sitter.Parser(tree_sitter.Language(tree_sitter_javascript.language()))
+
+
+def _py_parser() -> tree_sitter.Parser:
+    return tree_sitter.Parser(tree_sitter.Language(tree_sitter_python.language()))
+
+
+def _bash_parser() -> tree_sitter.Parser:
+    return tree_sitter.Parser(tree_sitter.Language(tree_sitter_bash.language()))
+
+
+# ---------------------------------------------------------------------------
+# JavaScript — _extract_parameters in _function_mixin.py
+# ---------------------------------------------------------------------------
+
+
+class TestJSDefaultParameterExtraction:
+    """Issue #533 (JS half): assignment_pattern (param = default) was silently
+    dropped from _extract_parameters because only 'identifier', 'rest_parameter',
+    'object_pattern', and 'array_pattern' were handled.
+
+    Fix: treat 'assignment_pattern' the same way — capture full node text.
+    Convention: emit full text, e.g. 'limit = 10', 'options = {}'.
+    """
+
+    def test_fibonacciSequence_only_default_param(self):
+        """function fibonacciSequence(limit = 10) → ['limit = 10'] (1 param)."""
+        from tree_sitter_analyzer.languages.javascript_plugin._function_mixin import (
+            JavaScriptFunctionExtractionMixin,
+        )
+        from tree_sitter_analyzer.languages.javascript_plugin._text_helpers import (
+            get_node_text_optimized,
+        )
+
+        code = "function fibonacciSequence(limit = 10) { return []; }"
+        parser = _js_parser()
+        tree = parser.parse(code.encode())
+
+        content_lines = code.splitlines()
+        cache: dict = {}
+
+        def get_text(node: object) -> str:
+            return get_node_text_optimized(node, content_lines, None, cache, None, None)  # type: ignore[arg-type]
+
+        # Find formal_parameters node
+        func_node = tree.root_node.children[0]  # function_declaration
+        params_node = None
+        for child in func_node.children:
+            if child.type == "formal_parameters":
+                params_node = child
+                break
+        assert params_node is not None
+
+        # Build a minimal extractor-like object with _get_node_text_optimized wired
+        class _MinimalExtractor(JavaScriptFunctionExtractionMixin):
+            def _get_node_text_optimized(self, n: object) -> str:  # type: ignore[override]
+                return get_text(n)
+
+        extractor = _MinimalExtractor()
+        params = extractor._extract_parameters(params_node)
+        assert params == ["limit = 10"]
+
+    def test_processData_mixed_plain_and_default(self):
+        """function processData(items, options = {}) → ['items', 'options = {}']."""
+        from tree_sitter_analyzer.languages.javascript_plugin._function_mixin import (
+            JavaScriptFunctionExtractionMixin,
+        )
+        from tree_sitter_analyzer.languages.javascript_plugin._text_helpers import (
+            get_node_text_optimized,
+        )
+
+        code = "function processData(items, options = {}) { return items; }"
+        parser = _js_parser()
+        tree = parser.parse(code.encode())
+
+        content_lines = code.splitlines()
+        cache: dict = {}
+
+        def get_text(node: object) -> str:
+            return get_node_text_optimized(node, content_lines, None, cache, None, None)  # type: ignore[arg-type]
+
+        func_node = tree.root_node.children[0]
+        params_node = None
+        for child in func_node.children:
+            if child.type == "formal_parameters":
+                params_node = child
+                break
+        assert params_node is not None
+
+        class _MinimalExtractor(JavaScriptFunctionExtractionMixin):
+            def _get_node_text_optimized(self, n: object) -> str:  # type: ignore[override]
+                return get_text(n)
+
+        extractor = _MinimalExtractor()
+        params = extractor._extract_parameters(params_node)
+        assert params == ["items", "options = {}"]
+
+    def test_generateSequence_all_defaults(self):
+        """generateSequence(start = 0, end = 10) → ['start = 0', 'end = 10'] (2 params)."""
+        from tree_sitter_analyzer.languages.javascript_plugin._function_mixin import (
+            JavaScriptFunctionExtractionMixin,
+        )
+        from tree_sitter_analyzer.languages.javascript_plugin._text_helpers import (
+            get_node_text_optimized,
+        )
+
+        code = "function generateSequence(start = 0, end = 10) { return []; }"
+        parser = _js_parser()
+        tree = parser.parse(code.encode())
+
+        content_lines = code.splitlines()
+        cache: dict = {}
+
+        def get_text(node: object) -> str:
+            return get_node_text_optimized(node, content_lines, None, cache, None, None)  # type: ignore[arg-type]
+
+        func_node = tree.root_node.children[0]
+        params_node = None
+        for child in func_node.children:
+            if child.type == "formal_parameters":
+                params_node = child
+                break
+        assert params_node is not None
+
+        class _MinimalExtractor(JavaScriptFunctionExtractionMixin):
+            def _get_node_text_optimized(self, n: object) -> str:  # type: ignore[override]
+                return get_text(n)
+
+        extractor = _MinimalExtractor()
+        params = extractor._extract_parameters(params_node)
+        assert params == ["start = 0", "end = 10"]
+
+    def test_full_plugin_fibonacciSequence_count(self):
+        """End-to-end: fibonacciSequence(limit = 10) function has 1 parameter."""
+        from tree_sitter_analyzer.languages.javascript_plugin.plugin import (
+            JavaScriptPlugin,
+        )
+
+        code = "function fibonacciSequence(limit = 10) { return []; }"
+        plugin = JavaScriptPlugin()
+        extractor = plugin.get_extractor()
+        import tree_sitter as ts
+        import tree_sitter_javascript as tsjs
+
+        lang = ts.Language(tsjs.language())
+        parser = ts.Parser()
+        parser.language = lang
+        tree = parser.parse(code.encode())
+        fns = extractor.extract_functions(tree, code)
+        fibo = next((f for f in fns if f.name == "fibonacciSequence"), None)
+        assert fibo is not None, "fibonacciSequence not found"
+        assert len(fibo.parameters) == 1
+
+    def test_full_plugin_processData_param_list(self):
+        """End-to-end: processData(items, options = {}) yields exactly 2 params."""
+        from tree_sitter_analyzer.languages.javascript_plugin.plugin import (
+            JavaScriptPlugin,
+        )
+
+        code = "function processData(items, options = {}) { return items; }"
+        plugin = JavaScriptPlugin()
+        extractor = plugin.get_extractor()
+        import tree_sitter as ts
+        import tree_sitter_javascript as tsjs
+
+        lang = ts.Language(tsjs.language())
+        parser = ts.Parser()
+        parser.language = lang
+        tree = parser.parse(code.encode())
+        fns = extractor.extract_functions(tree, code)
+        pd = next((f for f in fns if f.name == "processData"), None)
+        assert pd is not None, "processData not found"
+        assert len(pd.parameters) == 2
+
+    def test_full_plugin_processData_param_values(self):
+        """End-to-end: processData params are ['items', 'options = {}']."""
+        from tree_sitter_analyzer.languages.javascript_plugin.plugin import (
+            JavaScriptPlugin,
+        )
+
+        code = "function processData(items, options = {}) { return items; }"
+        plugin = JavaScriptPlugin()
+        extractor = plugin.get_extractor()
+        import tree_sitter as ts
+        import tree_sitter_javascript as tsjs
+
+        lang = ts.Language(tsjs.language())
+        parser = ts.Parser()
+        parser.language = lang
+        tree = parser.parse(code.encode())
+        fns = extractor.extract_functions(tree, code)
+        pd = next((f for f in fns if f.name == "processData"), None)
+        assert pd is not None
+        assert pd.parameters == ["items", "options = {}"]
+
+
+# ---------------------------------------------------------------------------
+# Python — _extract_parameters_from_node_optimized in _core_extractor_mixin.py
+# ---------------------------------------------------------------------------
+
+
+class TestPythonTypedDefaultParameterExtraction:
+    """Issue #533 (Python half): typed_default_parameter (name: type = default)
+    was absent from _PARAMETER_NODE_TYPES in _signature_helpers.py, so any
+    param with a type annotation AND a default (e.g. 'breed: str = "Mixed"')
+    was silently dropped.
+
+    Fix: add 'typed_default_parameter' to _PARAMETER_NODE_TYPES.
+    Convention: emit full node text, e.g. 'breed: str = "Mixed"'.
+    """
+
+    def test_dog_init_three_params(self):
+        """__init__(self, name: str, breed: str = 'Mixed') → 3 params."""
+        from tree_sitter_analyzer.languages.python_plugin.plugin import PythonPlugin
+
+        code = 'def __init__(self, name: str, breed: str = "Mixed"):\n    pass\n'
+        plugin = PythonPlugin()
+        extractor = plugin.get_extractor()
+        import tree_sitter as ts
+        import tree_sitter_python as tspy
+
+        lang = ts.Language(tspy.language())
+        parser = ts.Parser()
+        parser.language = lang
+        tree = parser.parse(code.encode())
+        fns = extractor.extract_functions(tree, code)
+        init = next((f for f in fns if f.name == "__init__"), None)
+        assert init is not None, "__init__ not found"
+        assert len(init.parameters) == 3
+
+    def test_dog_init_param_values(self):
+        """params are ['self', 'name: str', 'breed: str = \"Mixed\"']."""
+        from tree_sitter_analyzer.languages.python_plugin.plugin import PythonPlugin
+
+        code = 'def __init__(self, name: str, breed: str = "Mixed"):\n    pass\n'
+        plugin = PythonPlugin()
+        extractor = plugin.get_extractor()
+        import tree_sitter as ts
+        import tree_sitter_python as tspy
+
+        lang = ts.Language(tspy.language())
+        parser = ts.Parser()
+        parser.language = lang
+        tree = parser.parse(code.encode())
+        fns = extractor.extract_functions(tree, code)
+        init = next((f for f in fns if f.name == "__init__"), None)
+        assert init is not None
+        assert init.parameters == ["self", "name: str", 'breed: str = "Mixed"']
+
+    def test_cat_init_bool_default(self):
+        """__init__(self, name: str, indoor: bool = True) → 3 params."""
+        from tree_sitter_analyzer.languages.python_plugin.plugin import PythonPlugin
+
+        code = "def __init__(self, name: str, indoor: bool = True):\n    pass\n"
+        plugin = PythonPlugin()
+        extractor = plugin.get_extractor()
+        import tree_sitter as ts
+        import tree_sitter_python as tspy
+
+        lang = ts.Language(tspy.language())
+        parser = ts.Parser()
+        parser.language = lang
+        tree = parser.parse(code.encode())
+        fns = extractor.extract_functions(tree, code)
+        init = next((f for f in fns if f.name == "__init__"), None)
+        assert init is not None, "__init__ not found"
+        assert len(init.parameters) == 3
+
+    def test_cat_init_param_values(self):
+        """params are ['self', 'name: str', 'indoor: bool = True']."""
+        from tree_sitter_analyzer.languages.python_plugin.plugin import PythonPlugin
+
+        code = "def __init__(self, name: str, indoor: bool = True):\n    pass\n"
+        plugin = PythonPlugin()
+        extractor = plugin.get_extractor()
+        import tree_sitter as ts
+        import tree_sitter_python as tspy
+
+        lang = ts.Language(tspy.language())
+        parser = ts.Parser()
+        parser.language = lang
+        tree = parser.parse(code.encode())
+        fns = extractor.extract_functions(tree, code)
+        init = next((f for f in fns if f.name == "__init__"), None)
+        assert init is not None
+        assert init.parameters == ["self", "name: str", "indoor: bool = True"]
+
+    def test_untyped_default_still_works(self):
+        """Plain default_parameter (no type) still extracted: def f(x=5) → ['x=5']."""
+        from tree_sitter_analyzer.languages.python_plugin.plugin import PythonPlugin
+
+        code = "def f(x=5):\n    pass\n"
+        plugin = PythonPlugin()
+        extractor = plugin.get_extractor()
+        import tree_sitter as ts
+        import tree_sitter_python as tspy
+
+        lang = ts.Language(tspy.language())
+        parser = ts.Parser()
+        parser.language = lang
+        tree = parser.parse(code.encode())
+        fns = extractor.extract_functions(tree, code)
+        f = next((fn for fn in fns if fn.name == "f"), None)
+        assert f is not None
+        assert len(f.parameters) == 1
+
+    def test_args_kwargs_unaffected(self):
+        """*args/**kwargs are not broken by the fix."""
+        from tree_sitter_analyzer.languages.python_plugin.plugin import PythonPlugin
+
+        code = "def g(*args, **kwargs):\n    pass\n"
+        plugin = PythonPlugin()
+        extractor = plugin.get_extractor()
+        import tree_sitter as ts
+        import tree_sitter_python as tspy
+
+        lang = ts.Language(tspy.language())
+        parser = ts.Parser()
+        parser.language = lang
+        tree = parser.parse(code.encode())
+        fns = extractor.extract_functions(tree, code)
+        g = next((fn for fn in fns if fn.name == "g"), None)
+        assert g is not None
+        assert len(g.parameters) == 2
+
+
+# ---------------------------------------------------------------------------
+# Bash — structural n/a verdict
+# ---------------------------------------------------------------------------
+
+
+class TestBashParamStructuralNa:
+    """Issue #533 (Bash): Bash grammar has no formal parameter nodes.
+    Functions use positional args ($1/$2) at call time — there is nothing
+    for the extractor to capture.  parameters=[] is the correct empty-list
+    sentinel; this test pins that contract and documents why.
+
+    The honest representation is an empty list (n/a), not an error.
+    """
+
+    def test_greet_params_empty(self):
+        """greet() { echo $1 $2; } → parameters == [] (Bash has no formal params)."""
+        from tree_sitter_analyzer.languages.bash_plugin import BashPlugin
+
+        code = 'greet() {\n    echo "Hello $1 $2"\n}\n'
+        plugin = BashPlugin()
+        extractor = plugin.get_extractor()
+        import tree_sitter as ts
+        import tree_sitter_bash as tsbash
+
+        lang = ts.Language(tsbash.language())
+        parser = ts.Parser()
+        parser.language = lang
+        tree = parser.parse(code.encode())
+        fns = extractor.extract_functions(tree, code)
+        greet = next((f for f in fns if f.name == "greet"), None)
+        assert greet is not None, "greet not found"
+        assert greet.parameters == []
+
+    def test_function_keyword_params_empty(self):
+        """function process() { ... } → parameters == [] (same structural reason)."""
+        from tree_sitter_analyzer.languages.bash_plugin import BashPlugin
+
+        code = "function process() {\n    local x=$1\n}\n"
+        plugin = BashPlugin()
+        extractor = plugin.get_extractor()
+        import tree_sitter as ts
+        import tree_sitter_bash as tsbash
+
+        lang = ts.Language(tsbash.language())
+        parser = ts.Parser()
+        parser.language = lang
+        tree = parser.parse(code.encode())
+        fns = extractor.extract_functions(tree, code)
+        proc = next((f for f in fns if f.name == "process"), None)
+        assert proc is not None, "process not found"
+        assert proc.parameters == []

--- a/tests/unit/languages/test_parameter_extraction_theme_e_residual.py
+++ b/tests/unit/languages/test_parameter_extraction_theme_e_residual.py
@@ -447,3 +447,24 @@ class TestStructureConversionOfDefaults:
             "name": "name",
             "type": "String",
         }
+
+    def test_get_method_parameters_string_form(self):
+        from types import SimpleNamespace
+
+        from tree_sitter_analyzer.mcp.tools.analyze_code_structure_helpers import (
+            get_method_parameters,
+        )
+
+        method = SimpleNamespace(parameters=["limit = 10", "name: str", ""])
+        assert get_method_parameters(method) == [
+            {"name": "limit", "type": "Any", "default": "10"},
+            {"name": "name", "type": "str"},
+        ]
+
+    def test_empty_and_blank_param_strings(self):
+        from tree_sitter_analyzer.mcp.tools.analyze_code_structure_helpers import (
+            _parse_string_parameter,
+        )
+
+        assert _parse_string_parameter("") is None
+        assert _parse_string_parameter("   ") is None

--- a/tree_sitter_analyzer/languages/javascript_plugin/_function_mixin.py
+++ b/tree_sitter_analyzer/languages/javascript_plugin/_function_mixin.py
@@ -130,7 +130,14 @@ class JavaScriptFunctionExtractionMixin:
             return None
 
     def _extract_parameters(self, params_node: "tree_sitter.Node") -> list[str]:
-        """Extract function parameters."""
+        """Extract function parameters.
+
+        Handles plain identifiers, rest (...args), destructuring patterns
+        (object/array), and default-valued parameters (assignment_pattern,
+        e.g. ``limit = 10`` or ``options = {}``).  Default-valued params
+        are emitted as full text so API consumers see the default — e.g.
+        ``'limit = 10'``, ``'options = {}'`` (fixes Issue #533).
+        """
         parameters = []
 
         for child in params_node.children:
@@ -143,5 +150,10 @@ class JavaScriptFunctionExtractionMixin:
             elif child.type in ["object_pattern", "array_pattern"]:
                 destructure_text = self._get_node_text_optimized(child)
                 parameters.append(destructure_text)
+            elif child.type == "assignment_pattern":
+                # Default-valued parameter: e.g. "limit = 10", "options = {}".
+                # Emit full node text so the default is visible to API consumers.
+                default_text = self._get_node_text_optimized(child)
+                parameters.append(default_text)
 
         return parameters

--- a/tree_sitter_analyzer/languages/python_plugin/_signature_helpers.py
+++ b/tree_sitter_analyzer/languages/python_plugin/_signature_helpers.py
@@ -10,6 +10,7 @@ _PARAMETER_NODE_TYPES = frozenset(
         "identifier",
         "typed_parameter",
         "default_parameter",
+        "typed_default_parameter",
         "list_splat_pattern",
         "dictionary_splat_pattern",
     }

--- a/tree_sitter_analyzer/mcp/tools/analyze_code_structure_helpers.py
+++ b/tree_sitter_analyzer/mcp/tools/analyze_code_structure_helpers.py
@@ -75,13 +75,47 @@ def get_method_parameters(method: Any) -> list[dict[str, str]]:
     if parameters and isinstance(parameters[0], str):
         result: list[dict[str, str]] = []
         for param_str in parameters:
-            parts = param_str.strip().split()
-            if len(parts) >= 2:
-                result.append({"name": parts[-1], "type": " ".join(parts[:-1])})
-            elif len(parts) == 1:
-                result.append({"name": "param", "type": parts[0]})
+            entry = _parse_string_parameter(param_str)
+            if entry:
+                result.append(entry)
         return result
     return convert_parameters(parameters)
+
+
+def _parse_string_parameter(param_str: str) -> dict[str, str] | None:
+    """Parse one string-form parameter into ``{name, type[, default]}``.
+
+    Handles the default-valued forms #533 introduced (Codex P2 on #581):
+    ``limit = 10`` and ``breed: str = "Mixed"`` must not be whitespace-split
+    into ``{"name": "10", "type": "limit ="}``.
+    """
+    text = param_str.strip()
+    if not text:
+        return None
+    default: str | None = None
+    if "=" in text:
+        head, default = (s.strip() for s in text.split("=", 1))
+    else:
+        head = text
+    if ":" in head:
+        name, ptype = (s.strip() for s in head.split(":", 1))
+    else:
+        parts = head.split()
+        if len(parts) >= 2:
+            name, ptype = parts[-1], " ".join(parts[:-1])
+        elif len(parts) == 1:
+            # bare name (JS) — or bare type for legacy `Type` strings; the
+            # default-bearing form is always a name.
+            if default is not None:
+                name, ptype = parts[0], "Any"
+            else:
+                name, ptype = "param", parts[0]
+        else:
+            return None
+    entry: dict[str, str] = {"name": name, "type": ptype}
+    if default is not None:
+        entry["default"] = default
+    return entry
 
 
 # JSON Schema: input validation for analyze_code_structure tool


### PR DESCRIPTION
Closes #533 (P2, QC-sweep — Theme E residual)

## Root causes (AST-dump confirmed)

- **Python**: `breed: str = \"Mixed\"` parses as `typed_default_parameter` — missing from `_PARAMETER_NODE_TYPES` (untyped `x=5` → `default_parameter` was already there, hence the typed-only drops)
- **JS**: `limit = 10` parses as `assignment_pattern` in formal_parameters — unhandled branch in `_extract_parameters` (destructuring/rest had branches; plain defaults didn't)
- **Bash**: the grammar has NO formal-param nodes (functions use $1/$2) — `parameters=[]` is structurally correct; contract pinned in 2 tests, documented n/a

Convention: emit full node text (the C# precedent) — `limit = 10`, `breed: str = \"Mixed\"`.

## Verification

- 10 RED→GREEN + 4 Bash contract pins; 120 JS + 118 Python plugin tests green
- Python goldens (full/compact/csv) updated — diffs are exactly the two `__init__` signatures gaining their defaults; JS goldens unaffected (fixture has no defaults; verified by run)
- Lead independently verified Sample.py table shows `breed:str = \"Mixed\"` / `indoor:bool = True`
- Coverage: `_function_mixin` 95.60%; ratchet exit 0