### PR TITLE
fix(languages): container/typing gaps digest — Go alias+embedding, Rust trait abstracts, Python ABC, TS abstract flag

### DIFF
--- a/tests/golden_masters/compact/go_sample_compact.md
+++ b/tests/golden_masters/compact/go_sample_compact.md
@@ -5,7 +5,7 @@
 |----------|-------|
 | Package | sample |
 | Funcs | 0 |
-| Types | 9 |
+| Types | 10 |
 
 ## Funcs
 | Func | Sig | V | L | Doc |

--- a/tests/golden_masters/compact/python_sample_compact.md
+++ b/tests/golden_masters/compact/python_sample_compact.md
@@ -11,7 +11,7 @@
 | Class | Type | Lines |
 |-------|------|-------|
 | Person | class | 14-28 |
-| Animal | class | 31-45 |
+| Animal | abstract_class | 31-45 |
 | Dog | class | 48-61 |
 | Cat | class | 64-78 |
 

--- a/tests/golden_masters/compact/rust_sample_compact.md
+++ b/tests/golden_masters/compact/rust_sample_compact.md
@@ -4,12 +4,13 @@
 | Property | Value |
 |----------|-------|
 | Structs | 5 |
-| Functions | 8 |
+| Functions | 9 |
 | Lines | 0 |
 
 ## Functions
 | Fn | Sig | V | A | L | Doc |
 |----|-----|---|---|---|-----|
+| display | (1)->String | public | - | 25-25 | - |
 | summary | (1)->String | public | - | 27-29 | - |
 | new | (3)->Self | public | - | 34-41 | - |
 | deactivate | (1) | public | - | 44-46 | - |

--- a/tests/golden_masters/csv/rust_sample_csv.csv
+++ b/tests/golden_masters/csv/rust_sample_csv.csv
@@ -12,6 +12,7 @@
 ## Functions
 | Function | Signature | Vis | Async | Lines | Doc |
 |----------|-----------|-----|-------|-------|-----|
+| display | fn({'name': 'self', 'type': 'Any'}) -> String | public | - | 25-25 | - |
 | summary | fn({'name': 'self', 'type': 'Any'}) -> String | public | - | 27-29 | - |
 | new | fn({'name': 'id', 'type': 'u64'}, {'name': 'username', 'type': 'String'}, {'name': 'email', 'type': 'String'}) -> Self | public | - | 34-41 | - |
 | deactivate | fn({'name': 'self', 'type': 'Any'}) | public | - | 44-46 | - |

--- a/tests/golden_masters/full/go_sample_full.md
+++ b/tests/golden_masters/full/go_sample_full.md
@@ -5,7 +5,7 @@
 |----------|-------|
 | Package | sample |
 | Functions | 0 |
-| Types | 9 |
+| Types | 10 |
 | Variables | 0 |
 
 ## Imports
@@ -35,6 +35,7 @@ import ""time""
 | Name | Visibility | Lines |
 |------|------------|-------|
 | Status | exported | 33-33 |
+| StringSlice | exported | 248-248 |
 | Handler | exported | 251-251 |
 | Middleware | exported | 254-254 |
 

--- a/tests/golden_masters/full/python_sample_full.md
+++ b/tests/golden_masters/full/python_sample_full.md
@@ -12,7 +12,7 @@ from functools import reduce
 | Class | Type | Visibility | Lines | Methods | Fields |
 |-------|------|------------|-------|---------|--------|
 | Person | class | public | 14-28 | 2 | 1 |
-| Animal | class | public | 31-45 | 3 | 0 |
+| Animal | abstract_class | public | 31-45 | 3 | 0 |
 | Dog | class | public | 48-61 | 3 | 0 |
 | Cat | class | public | 64-78 | 3 | 0 |
 

--- a/tests/golden_masters/full/rust_sample_full.md
+++ b/tests/golden_masters/full/rust_sample_full.md
@@ -12,6 +12,7 @@
 ## Functions
 | Function | Signature | Vis | Async | Lines | Doc |
 |----------|-----------|-----|-------|-------|-----|
+| display | fn({'name': 'self', 'type': 'Any'}) -> String | public | - | 25-25 | - |
 | summary | fn({'name': 'self', 'type': 'Any'}) -> String | public | - | 27-29 | - |
 | new | fn({'name': 'id', 'type': 'u64'}, {'name': 'username', 'type': 'String'}, {'name': 'email', 'type': 'String'}) -> Self | public | - | 34-41 | - |
 | deactivate | fn({'name': 'self', 'type': 'Any'}) | public | - | 44-46 | - |

--- a/tests/golden_masters/plugins/go.json
+++ b/tests/golden_masters/plugins/go.json
@@ -1,12 +1,12 @@
 {
   "counts_by_type": {
-    "Class": 9,
+    "Class": 10,
     "Function": 18,
     "Import": 5,
     "Package": 1,
     "Variable": 9
   },
-  "element_total": 42,
+  "element_total": 43,
   "names_by_type": {
     "Class": [
       "Config",
@@ -16,6 +16,7 @@
       "Reader",
       "Service",
       "Status",
+      "StringSlice",
       "WorkerPool",
       "Writer"
     ],

--- a/tests/golden_masters/plugins/rust.json
+++ b/tests/golden_masters/plugins/rust.json
@@ -1,11 +1,11 @@
 {
   "counts_by_type": {
     "Class": 5,
-    "Function": 8,
+    "Function": 9,
     "Import": 1,
     "Variable": 6
   },
-  "element_total": 20,
+  "element_total": 21,
   "names_by_type": {
     "Class": [
       "BorrowedItem",

--- a/tests/golden_masters/toon/go_sample_toon.toon
+++ b/tests/golden_masters/toon/go_sample_toon.toon
@@ -4,7 +4,7 @@ package:
   name: sample
   line_range: (10, 10)
 classes:
-  [9]{name,visibility,line_range(a,b)}:
+  [10]{name,visibility,line_range(a,b)}:
     Status,public,(33,33)
     Config,public,(44,50)
     Reader,public,(53,56)
@@ -12,6 +12,7 @@ classes:
     ReadWriter,public,(65,68)
     Service,public,(71,77)
     WorkerPool,public,(206,210)
+    StringSlice,public,(248,248)
     Handler,public,(251,251)
     Middleware,public,(254,254)
 methods:
@@ -53,7 +54,7 @@ imports:
     sync,sync,"\"sync\"",false,false,(16,16),[],"\"sync\""
     time,time,"\"time\"",false,false,(17,17),[],"\"time\""
 statistics:
-  class_count: 9
+  class_count: 10
   method_count: 18
   field_count: 9
   import_count: 5

--- a/tests/golden_masters/toon/rust_sample_toon.toon
+++ b/tests/golden_masters/toon/rust_sample_toon.toon
@@ -9,7 +9,8 @@ classes:
     Container,pub,(67,69)
     BorrowedItem,pub,(77,79)
 methods:
-  [8]{name,visibility,line_range(a,b)}:
+  [9]{name,visibility,line_range(a,b)}:
+    display,private,(25,25)
     summary,private,(27,29)
     new,pub,(34,41)
     deactivate,pub,(44,46)
@@ -31,7 +32,7 @@ imports:
     "use std::collections::HashMap;",,"use std::collections::HashMap;",false,false,(3,3),[],"use std::collections::HashMap;"
 statistics:
   class_count: 5
-  method_count: 8
+  method_count: 9
   field_count: 6
   import_count: 1
   total_lines: 93

--- a/tests/unit/test_container_typing_gaps_538.py
+++ b/tests/unit/test_container_typing_gaps_538.py
@@ -305,3 +305,208 @@ class TestGoAliasNonContainerType:
         alias = [c for c in classes if c.name == "StringSlice"]
         assert len(alias) == 1
         assert alias[0].interfaces == []
+
+
+class TestRustExternSignatureNotAbstract:
+    """Codex P2 on #583: extern-block foreign fns also emit
+    function_signature_item — they are FFI declarations, not trait methods."""
+
+    CODE = """
+extern "C" {
+    fn puts(s: *const u8) -> i32;
+}
+
+trait Greet {
+    fn hello(&self) -> String;
+}
+"""
+
+    def test_extern_fn_excluded_trait_fn_kept(self):
+        import tree_sitter
+        import tree_sitter_rust
+
+        from tree_sitter_analyzer.languages.rust_plugin import RustElementExtractor
+
+        lang = tree_sitter.Language(tree_sitter_rust.language())
+        tree = tree_sitter.Parser(lang).parse(self.CODE.encode())
+        funcs = RustElementExtractor().extract_functions(tree, self.CODE)
+        names = [f.name for f in funcs]
+        assert "puts" not in names
+        trait_fns = [f for f in funcs if f.name == "hello"]
+        assert len(trait_fns) == 1
+        assert trait_fns[0].is_abstract is True
+
+
+class TestPythonQualifiedAbcBase:
+    """Codex P2 on #583: ``class Animal(abc.ABC)`` must classify as
+    abstract_class even without an @abstractmethod in the body."""
+
+    CODE = """import abc
+
+
+class Animal(abc.ABC):
+    pass
+
+
+class Dog(Animal, abc.ABC):
+    pass
+"""
+
+    @pytest.fixture
+    def classes(self, tmp_path):
+        import asyncio
+
+        from tree_sitter_analyzer.core.analysis_engine import get_analysis_engine
+
+        p = tmp_path / "abc_sample.py"
+        p.write_text(self.CODE, newline="\n")
+        result = asyncio.run(get_analysis_engine().analyze_file(str(p)))
+        return [e for e in result.elements if type(e).__name__ == "Class"]
+
+    def test_qualified_abc_is_abstract(self, classes):
+        animal = next(c for c in classes if c.name == "Animal")
+        assert animal.class_type == "abstract_class"
+        assert animal.superclass == "abc.ABC"
+
+    def test_qualified_abc_in_interfaces(self, classes):
+        dog = next(c for c in classes if c.name == "Dog")
+        assert dog.class_type == "abstract_class"
+        assert dog.superclass == "Animal"
+        assert dog.interfaces == ["abc.ABC"]
+
+
+class TestRustTraitSignatureSelfForms:
+    """Cover _find_self_parameter branches for trait signatures (codecov)."""
+
+    CODE = """
+trait Consume {
+    fn take(self: Box<Self>) -> String;
+    fn peek(&self) -> i32;
+}
+"""
+
+    def test_typed_self_parameter_binds_receiver(self):
+        import tree_sitter
+        import tree_sitter_rust
+
+        from tree_sitter_analyzer.languages.rust_plugin import RustElementExtractor
+
+        lang = tree_sitter.Language(tree_sitter_rust.language())
+        tree = tree_sitter.Parser(lang).parse(self.CODE.encode())
+        funcs = RustElementExtractor().extract_functions(tree, self.CODE)
+        take = next(f for f in funcs if f.name == "take")
+        assert take.is_abstract is True
+        peek = next(f for f in funcs if f.name == "peek")
+        assert peek.is_abstract is True
+
+
+class _RustStubNode:
+    """Minimal tree-sitter node stand-in (explicit parent, no auto-chains)."""
+
+    def __init__(
+        self, type_: str = "function_signature_item", parent=None, fields=None
+    ):
+        self.type = type_
+        self.parent = parent
+        self._fields = fields or {}
+
+    def child_by_field_name(self, name):
+        return self._fields.get(name)
+
+
+class TestRustSignatureStubFallbacks:
+    """Cover guard branches unreachable from valid Rust source (codecov)."""
+
+    @staticmethod
+    def _extractor():
+        from tree_sitter_analyzer.languages.rust_plugin import RustElementExtractor
+
+        return RustElementExtractor()
+
+    def test_no_params_node_returns_none(self):
+        node = _RustStubNode(parent=None)
+        assert self._extractor()._find_self_parameter(node) is None
+
+    def test_nameless_signature_in_trait_returns_none(self):
+        trait = _RustStubNode(type_="trait_item", parent=None)
+        body = _RustStubNode(type_="declaration_list", parent=trait)
+        node = _RustStubNode(parent=body)
+        assert self._extractor()._extract_function_signature(node) is None
+
+    def test_orphan_node_not_inside_trait(self):
+        node = _RustStubNode(parent=None)
+        assert self._extractor()._inside_trait(node) is False
+
+
+class TestRustFindSelfParameterDirect:
+    """Cover the typed-self ``parameter`` branch of _find_self_parameter,
+    unreachable through trait signatures (no impl owner there) — codecov."""
+
+    def _signature_node(self, code: str):
+        import tree_sitter
+        import tree_sitter_rust
+
+        lang = tree_sitter.Language(tree_sitter_rust.language())
+        tree = tree_sitter.Parser(lang).parse(code.encode())
+        stack = [tree.root_node]
+        while stack:
+            n = stack.pop()
+            if n.type == "function_signature_item":
+                return n
+            stack.extend(n.children)
+        raise AssertionError("no function_signature_item parsed")
+
+    def _extractor(self, code: str):
+        from tree_sitter_analyzer.languages.rust_plugin import RustElementExtractor
+
+        ex = RustElementExtractor()
+        ex.source_code = code
+        ex._content_bytes = code.encode()
+        return ex
+
+    def test_boxed_self_parameter_found(self):
+        code = "trait T { fn take(self: Box<Self>); }"
+        node = self._signature_node(code)
+        ex = self._extractor(code)
+        assert ex._find_self_parameter(node) == "self: Box<Self>"
+
+    def test_plain_typed_parameter_is_not_self(self):
+        code = "trait T { fn take(x: i32); }"
+        node = self._signature_node(code)
+        ex = self._extractor(code)
+        assert ex._find_self_parameter(node) is None
+
+
+class TestRustSignatureArrowPrefixStrip:
+    """Cover the defensive '->' strip (mirrors function_item handler) — codecov."""
+
+    def test_arrow_prefixed_return_type_stripped(self):
+        from tree_sitter_analyzer.languages.rust_plugin import RustElementExtractor
+
+        content = b"x-> i32"
+
+        class _SpanStub(_RustStubNode):
+            def __init__(self, type_, parent=None, fields=None, span=(0, 0)):
+                super().__init__(type_, parent=parent, fields=fields)
+                self.start_byte, self.end_byte = span
+                self.start_point = (0, self.start_byte)
+                self.end_point = (0, self.end_byte)
+                self.children = []
+
+        trait = _SpanStub("trait_item")
+        body = _SpanStub("declaration_list", parent=trait)
+        name = _SpanStub("identifier", span=(0, 1))
+        ret = _SpanStub("type", span=(1, 7))
+        node = _SpanStub(
+            "function_signature_item",
+            parent=body,
+            fields={"name": name, "return_type": ret, "parameters": None},
+            span=(0, 7),
+        )
+
+        ex = RustElementExtractor()
+        ex.source_code = content.decode()
+        ex._content_bytes = content
+        func = ex._extract_function_signature(node)
+        assert func is not None
+        assert func.return_type == "i32"

--- a/tests/unit/test_container_typing_gaps_538.py
+++ b/tests/unit/test_container_typing_gaps_538.py
@@ -510,3 +510,59 @@ class TestRustSignatureArrowPrefixStrip:
         func = ex._extract_function_signature(node)
         assert func is not None
         assert func.return_type == "i32"
+
+
+class TestRustSignatureGuardEdges:
+    """Cover depth-cap exhaustion and the extractor except branch (codecov)."""
+
+    def test_self_referencing_parent_chain_hits_depth_cap(self):
+        from tree_sitter_analyzer.languages.rust_plugin import RustElementExtractor
+
+        node = _RustStubNode(parent=None)
+        node.parent = node  # cycle: never None, never a terminator type
+        assert RustElementExtractor()._inside_trait(node) is False
+
+    def test_node_error_inside_trait_returns_none(self):
+        from tree_sitter_analyzer.languages.rust_plugin import RustElementExtractor
+
+        class _ExplodingName(_RustStubNode):
+            def child_by_field_name(self, name):
+                raise RuntimeError("boom")
+
+        trait = _RustStubNode(type_="trait_item", parent=None)
+        body = _RustStubNode(type_="declaration_list", parent=trait)
+        node = _ExplodingName(parent=body)
+        assert RustElementExtractor()._extract_function_signature(node) is None
+
+
+class TestGoStructInterfacesNoneNode:
+    """Cover the type_node=None early return (codecov branch)."""
+
+    def test_none_type_node_returns_empty(self):
+        from tree_sitter_analyzer.languages._go_type_helpers import (
+            _go_struct_interfaces,
+        )
+
+        assert _go_struct_interfaces(None, lambda n: "") == []
+
+
+class TestPythonNodeHelpersQualifiedBase:
+    """Cover the attribute branch in the _node_helpers superclass path
+    (the fallback extractor path, not exercised by the engine tests)."""
+
+    def test_attribute_base_extracted(self):
+        import tree_sitter
+        import tree_sitter_python
+
+        from tree_sitter_analyzer.languages.python_plugin._node_helpers import (
+            extract_superclasses_from_node,
+        )
+
+        code = "class A(abc.ABC, Base):\n    pass\n"
+        lang = tree_sitter.Language(tree_sitter_python.language())
+        tree = tree_sitter.Parser(lang).parse(code.encode())
+        class_node = tree.root_node.children[0]
+        assert extract_superclasses_from_node(class_node, code) == [
+            "abc.ABC",
+            "Base",
+        ]

--- a/tests/unit/test_container_typing_gaps_538.py
+++ b/tests/unit/test_container_typing_gaps_538.py
@@ -1,0 +1,261 @@
+"""Issue #538 — per-language container/typing gap fixes (RED→GREEN).
+
+Covers the six items from the sweep digest:
+1. Go: ``type X = []string`` alias present as class_type="type_alias"
+2. Go: interface embedding reflected in Class.interfaces
+3. Rust: trait abstract method (function_signature_item) extracted with is_abstract=True
+4. Python: ``class Animal(ABC)`` → class_type="abstract_class"
+5. TS: ``abstract validate()`` → is_abstract=True on the Function
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers: language availability guards
+# ---------------------------------------------------------------------------
+def _go_lang():
+    try:
+        import tree_sitter
+        import tree_sitter_go
+
+        return tree_sitter.Language(tree_sitter_go.language())
+    except Exception:
+        return None
+
+
+def _rust_lang():
+    try:
+        import tree_sitter
+        import tree_sitter_rust
+
+        return tree_sitter.Language(tree_sitter_rust.language())
+    except Exception:
+        return None
+
+
+def _ts_lang():
+    try:
+        import tree_sitter
+        import tree_sitter_typescript
+
+        return tree_sitter.Language(tree_sitter_typescript.language_typescript())
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Go — type alias
+# ---------------------------------------------------------------------------
+@pytest.mark.skipif(_go_lang() is None, reason="tree-sitter-go not available")
+def test_go_type_alias_extracted() -> None:
+    """``type StringSlice = []string`` must be extracted as class_type='type_alias'.
+
+    Before fix: _iter_type_specs only iterated 'type_spec' children, so
+    'type_alias' siblings were silently dropped (issue #538 N1).
+    """
+    from tree_sitter import Parser
+
+    from tree_sitter_analyzer.languages._go_type_helpers import extract_type_declaration
+
+    lang = _go_lang()
+    parser = Parser(lang)
+    src = "package main\ntype StringSlice = []string\n"
+    tree = parser.parse(src.encode())
+
+    def get_text(n):
+        return n.text.decode("utf-8", errors="replace") if n.text else ""
+
+    def find(node, t, out):
+        if node.type == t:
+            out.append(node)
+        for c in node.children:
+            find(c, t, out)
+
+    decls: list = []
+    find(tree.root_node, "type_declaration", decls)
+    assert len(decls) == 1, "expected exactly 1 type_declaration"
+
+    results = extract_type_declaration(decls[0], get_text, src.split("\n"))
+    assert len(results) == 1, f"expected 1 Class, got {len(results)}"
+    cls = results[0]
+    assert cls.name == "StringSlice"
+    assert cls.class_type == "type_alias"
+
+
+# ---------------------------------------------------------------------------
+# Go — interface embedding
+# ---------------------------------------------------------------------------
+@pytest.mark.skipif(_go_lang() is None, reason="tree-sitter-go not available")
+def test_go_interface_embedding_reflected() -> None:
+    """Embedded interfaces in a composite interface must appear in Class.interfaces.
+
+    Before fix: _go_struct_interfaces only handled struct_type; interface
+    type_elem children were never visited (issue #538 N5).
+    """
+    from tree_sitter import Parser
+
+    from tree_sitter_analyzer.languages._go_type_helpers import extract_type_declaration
+
+    lang = _go_lang()
+    parser = Parser(lang)
+    src = "package main\ntype ReadWriter interface {\n    Reader\n    Writer\n}\n"
+    tree = parser.parse(src.encode())
+
+    def get_text(n):
+        return n.text.decode("utf-8", errors="replace") if n.text else ""
+
+    def find(node, t, out):
+        if node.type == t:
+            out.append(node)
+        for c in node.children:
+            find(c, t, out)
+
+    decls: list = []
+    find(tree.root_node, "type_declaration", decls)
+    assert len(decls) == 1
+
+    results = extract_type_declaration(decls[0], get_text, src.split("\n"))
+    assert len(results) == 1
+    cls = results[0]
+    assert cls.class_type == "interface"
+    assert "Reader" in cls.interfaces
+    assert "Writer" in cls.interfaces
+    assert len(cls.interfaces) == 2
+
+
+# ---------------------------------------------------------------------------
+# Rust — trait abstract method
+# ---------------------------------------------------------------------------
+@pytest.mark.skipif(_rust_lang() is None, reason="tree-sitter-rust not available")
+def test_rust_trait_abstract_method_extracted() -> None:
+    """A trait required-method (no body) must be extracted with is_abstract=True.
+
+    Before fix: extract_functions only traversed 'function_item' (has body);
+    'function_signature_item' (no body, ends with ';') was silently skipped
+    (issue #538, Rust N2).
+    """
+    from tree_sitter import Parser
+
+    from tree_sitter_analyzer.languages.rust_plugin import RustElementExtractor
+
+    lang = _rust_lang()
+    parser = Parser(lang)
+    src = (
+        "trait Displayable {\n"
+        "    fn display(&self);\n"
+        "\n"
+        "    fn summary(&self) -> String {\n"
+        '        String::from("default")\n'
+        "    }\n"
+        "}\n"
+    )
+    tree = parser.parse(src.encode())
+    extractor = RustElementExtractor()
+    fns = extractor.extract_functions(tree, src)
+
+    names = {f.name for f in fns}
+    assert "display" in names, f"abstract method 'display' not extracted; got {names}"
+    assert "summary" in names, (
+        f"default-impl method 'summary' not extracted; got {names}"
+    )
+
+    by_name = {f.name: f for f in fns}
+    assert by_name["display"].is_abstract is True
+    assert by_name["summary"].is_abstract is False
+    assert len(fns) == 2
+
+
+# ---------------------------------------------------------------------------
+# Python — ABC → abstract_class
+# ---------------------------------------------------------------------------
+def test_python_abc_class_type_is_abstract_class() -> None:
+    """``class Animal(ABC)`` must produce class_type='abstract_class'.
+
+    Before fix: build_class_element hard-coded class_type='class' for all
+    classes; is_abstract was set but class_type stayed 'class' (issue #538).
+    """
+    from tree_sitter_analyzer.languages.python_plugin._element_builders import (
+        ClassBuildInput,
+        build_class_element,
+    )
+
+    data = ClassBuildInput(
+        name="Animal",
+        start_line=1,
+        end_line=5,
+        raw_text="class Animal(ABC):\n    pass",
+        superclasses=["ABC"],
+        decorators=[],
+        docstring=None,
+        current_module="",
+        framework_type="",
+    )
+    cls = build_class_element(data)
+    assert cls.class_type == "abstract_class"
+    assert cls.is_abstract is True
+
+
+def test_python_non_abc_class_type_unchanged() -> None:
+    """A plain class without ABC must remain class_type='class'."""
+    from tree_sitter_analyzer.languages.python_plugin._element_builders import (
+        ClassBuildInput,
+        build_class_element,
+    )
+
+    data = ClassBuildInput(
+        name="Dog",
+        start_line=1,
+        end_line=3,
+        raw_text="class Dog(Animal):\n    pass",
+        superclasses=["Animal"],
+        decorators=[],
+        docstring=None,
+        current_module="",
+        framework_type="",
+    )
+    cls = build_class_element(data)
+    assert cls.class_type == "class"
+    assert cls.is_abstract is False
+
+
+# ---------------------------------------------------------------------------
+# TypeScript — abstract method is_abstract flag
+# ---------------------------------------------------------------------------
+@pytest.mark.skipif(_ts_lang() is None, reason="tree-sitter-typescript not available")
+def test_ts_abstract_method_has_is_abstract_true() -> None:
+    """``abstract validate(): boolean`` inside an abstract class must carry
+    is_abstract=True on the extracted Function.
+
+    Before fix: extract_abstract_method_signature returned a Function without
+    setting is_abstract=True (issue #538, TS N5).
+    """
+    from tree_sitter import Parser
+
+    from tree_sitter_analyzer.languages.typescript_plugin.extractor import (
+        TypeScriptElementExtractor,
+    )
+
+    lang = _ts_lang()
+    parser = Parser(lang)
+    src = (
+        "abstract class Shape {\n"
+        "    abstract validate(): boolean;\n"
+        "    describe(): string {\n"
+        "        return 'shape';\n"
+        "    }\n"
+        "}\n"
+    )
+    tree = parser.parse(src.encode())
+    extractor = TypeScriptElementExtractor()
+    fns = extractor.extract_functions(tree, src)
+
+    by_name = {f.name: f for f in fns}
+    assert "validate" in by_name, (
+        f"abstract method 'validate' missing; got {list(by_name)}"
+    )
+    assert by_name["validate"].is_abstract is True
+    assert by_name["describe"].is_abstract is False
+    assert len(fns) == 2

--- a/tests/unit/test_container_typing_gaps_538.py
+++ b/tests/unit/test_container_typing_gaps_538.py
@@ -259,3 +259,49 @@ def test_ts_abstract_method_has_is_abstract_true() -> None:
     assert by_name["validate"].is_abstract is True
     assert by_name["describe"].is_abstract is False
     assert len(fns) == 2
+
+
+class TestRustAbstractSignatureReturnType:
+    """Cover the -> return-type branch of function_signature_item (codecov)."""
+
+    CODE = """
+trait Displayable {
+    fn display(&self) -> String;
+    fn plain(&self);
+}
+"""
+
+    def test_signature_with_return_type(self):
+        import tree_sitter
+        import tree_sitter_rust
+
+        from tree_sitter_analyzer.languages.rust_plugin import RustElementExtractor
+
+        lang = tree_sitter.Language(tree_sitter_rust.language())
+        tree = tree_sitter.Parser(lang).parse(self.CODE.encode())
+        fns = RustElementExtractor().extract_functions(tree, self.CODE)
+        disp = [f for f in fns if f.name == "display"]
+        plain = [f for f in fns if f.name == "plain"]
+        assert len(disp) == 1
+        assert disp[0].return_type == "String"
+        assert len(plain) == 1
+        assert plain[0].return_type == "()"
+
+
+class TestGoAliasNonContainerType:
+    """Cover the neither-struct-nor-interface fallback (codecov)."""
+
+    CODE = "package p\n\ntype StringSlice = []string\n"
+
+    def test_alias_to_slice_extracts(self):
+        import tree_sitter
+        import tree_sitter_go
+
+        from tree_sitter_analyzer.languages.go_plugin import GoElementExtractor
+
+        lang = tree_sitter.Language(tree_sitter_go.language())
+        tree = tree_sitter.Parser(lang).parse(self.CODE.encode())
+        classes = GoElementExtractor().extract_classes(tree, self.CODE)
+        alias = [c for c in classes if c.name == "StringSlice"]
+        assert len(alias) == 1
+        assert alias[0].interfaces == []

--- a/tree_sitter_analyzer/languages/_go_type_helpers.py
+++ b/tree_sitter_analyzer/languages/_go_type_helpers.py
@@ -107,9 +107,30 @@ def _go_struct_interfaces(
     type_node: Any | None,
     get_node_text: Callable[..., str],
 ) -> list[str]:
-    if not type_node or type_node.type != "struct_type":
+    if not type_node:
         return []
-    return extract_embedded_types(type_node, get_node_text)
+    if type_node.type == "struct_type":
+        return extract_embedded_types(type_node, get_node_text)
+    if type_node.type == "interface_type":
+        return _go_interface_embedded(type_node, get_node_text)
+    return []
+
+
+def _go_interface_embedded(
+    interface_node: Any,
+    get_node_text: Callable[..., str],
+) -> list[str]:
+    """Extract embedded interface names from an interface_type node.
+
+    ``type ReadWriter interface { Reader; Writer }`` emits ``type_elem``
+    children whose single child is the embedded type identifier.  These are
+    the interface embedding constraints (N5 in issue #538).
+    """
+    return [
+        get_node_text(child)
+        for child in interface_node.children
+        if child.type == "type_elem" and get_node_text(child).strip()
+    ]
 
 
 def extract_type_declaration(
@@ -130,4 +151,6 @@ def extract_type_declaration(
 
 
 def _iter_type_specs(node: Any) -> list[Any]:
-    return [child for child in node.children if child.type == "type_spec"]
+    return [
+        child for child in node.children if child.type in ("type_spec", "type_alias")
+    ]

--- a/tree_sitter_analyzer/languages/python_plugin/_element_builders.py
+++ b/tree_sitter_analyzer/languages/python_plugin/_element_builders.py
@@ -156,13 +156,14 @@ class ClassBuildInput:
 
 
 def build_class_element(data: ClassBuildInput) -> Class:
+    is_abstract = "ABC" in data.superclasses or "abstractmethod" in data.raw_text
     return Class(
         name=data.name,
         start_line=data.start_line,
         end_line=data.end_line,
         raw_text=data.raw_text,
         language="python",
-        class_type="class",
+        class_type="abstract_class" if is_abstract else "class",
         superclass=data.superclasses[0] if data.superclasses else None,
         interfaces=data.superclasses[1:] if len(data.superclasses) > 1 else [],
         docstring=data.docstring,
@@ -171,7 +172,7 @@ def build_class_element(data: ClassBuildInput) -> Class:
         package_name=data.current_module,
         framework_type=data.framework_type,
         is_dataclass="dataclass" in data.decorators,
-        is_abstract="ABC" in data.superclasses or "abstractmethod" in data.raw_text,
+        is_abstract=is_abstract,
         is_exception=_is_exception_class(data.superclasses),
     )
 

--- a/tree_sitter_analyzer/languages/python_plugin/_element_builders.py
+++ b/tree_sitter_analyzer/languages/python_plugin/_element_builders.py
@@ -156,7 +156,11 @@ class ClassBuildInput:
 
 
 def build_class_element(data: ClassBuildInput) -> Class:
-    is_abstract = "ABC" in data.superclasses or "abstractmethod" in data.raw_text
+    # Accept both bare ABC and qualified abc.ABC (Codex P2 on #583)
+    is_abstract = (
+        any(s == "ABC" or s.endswith(".ABC") for s in data.superclasses)
+        or "abstractmethod" in data.raw_text
+    )
     return Class(
         name=data.name,
         start_line=data.start_line,

--- a/tree_sitter_analyzer/languages/python_plugin/_node_helpers.py
+++ b/tree_sitter_analyzer/languages/python_plugin/_node_helpers.py
@@ -85,7 +85,8 @@ def _extract_superclass_arguments(
 ) -> list[str]:
     superclasses = []
     for arg in argument_list_node.children:
-        if arg.type == "identifier":
+        # "attribute" covers qualified bases such as abc.ABC (Codex P2 on #583)
+        if arg.type in ("identifier", "attribute"):
             superclasses.append(get_node_text_safe(arg, source_code))
     return superclasses
 

--- a/tree_sitter_analyzer/languages/python_plugin/_signature_helpers.py
+++ b/tree_sitter_analyzer/languages/python_plugin/_signature_helpers.py
@@ -82,7 +82,8 @@ def _extract_superclass_names(argument_list_node: Any) -> list[str]:
 
     superclasses = []
     for child in argument_list_node.children:
-        if child.type != "identifier":
+        # "attribute" covers qualified bases such as abc.ABC (Codex P2 on #583)
+        if child.type not in ("identifier", "attribute"):
             continue
         superclass_name = _decode_optional_text(child)
         if superclass_name:

--- a/tree_sitter_analyzer/languages/rust_plugin.py
+++ b/tree_sitter_analyzer/languages/rust_plugin.py
@@ -314,6 +314,24 @@ class RustElementExtractor(ElementExtractor):
             log_error(f"Error extracting Rust function: {e}")
             return None
 
+    def _inside_trait(self, node: tree_sitter.Node) -> bool:
+        """True when *node* sits inside a ``trait_item`` body.
+
+        Depth-capped for the same reason as ``_find_impl_owner`` (MagicMock
+        endless-parent-chain OOM, 2026-06-10). ``impl_item`` / ``foreign_mod_item``
+        terminate the walk early: a signature inside them is not trait-required.
+        """
+        parent = node.parent
+        for _ in range(256):
+            if parent is None:
+                return False
+            if parent.type == "trait_item":
+                return True
+            if parent.type in ("impl_item", "foreign_mod_item"):
+                return False
+            parent = parent.parent
+        return False
+
     def _find_impl_owner(self, node: tree_sitter.Node) -> str | None:
         """Return the impl target type name for a fn nested in an impl block.
 
@@ -366,8 +384,16 @@ class RustElementExtractor(ElementExtractor):
         no default implementation — they end with ``;`` rather than a block.
         The ``function_item`` handler covers default-impl methods; this one
         covers the missing half (issue #538, Rust N2).
+
+        ``extern`` blocks also emit ``function_signature_item`` for foreign
+        function declarations — those are linked FFI APIs, not trait-required
+        methods, so only nodes inside a ``trait_item`` are extracted here
+        (Codex P2 on #583).
         """
         try:
+            if not self._inside_trait(node):
+                return None
+
             name_node = node.child_by_field_name("name")
             if not name_node:
                 return None

--- a/tree_sitter_analyzer/languages/rust_plugin.py
+++ b/tree_sitter_analyzer/languages/rust_plugin.py
@@ -426,14 +426,10 @@ class RustElementExtractor(ElementExtractor):
             )
             func.is_abstract = True
 
-            owner = self._find_impl_owner(node)
-            if owner:
-                func.receiver_type = owner
-                self_param = self._find_self_parameter(node)
-                if self_param:
-                    func.receiver = self_param
-                    func.is_method = True
-
+            # No receiver binding here: _inside_trait guarantees the node is
+            # trait-contained, and _find_impl_owner only matches impl_item —
+            # trait-body declarations carry no impl owner (same as the
+            # function_item path for trait default methods).
             return func
         except Exception as e:
             log_error(f"Error extracting Rust abstract function: {e}")

--- a/tree_sitter_analyzer/languages/rust_plugin.py
+++ b/tree_sitter_analyzer/languages/rust_plugin.py
@@ -64,10 +64,14 @@ class RustElementExtractor(ElementExtractor):
 
         functions: list[Function] = []
 
-        # Use tree traversal to find function_item
+        # Use tree traversal to find function_item (implemented) and
+        # function_signature_item (abstract / trait-required method with no body).
         self._traverse_and_extract(
             tree.root_node,
-            {"function_item": self._extract_function},
+            {
+                "function_item": self._extract_function,
+                "function_signature_item": self._extract_function_signature,
+            },
             functions,
         )
 
@@ -354,6 +358,60 @@ class RustElementExtractor(ElementExtractor):
                 if pattern is not None and self._get_node_text(pattern) == "self":
                     return self._get_node_text(child)
         return None
+
+    def _extract_function_signature(self, node: tree_sitter.Node) -> Function | None:
+        """Extract a trait abstract method (``function_signature_item``).
+
+        These are required-method declarations inside a trait body that carry
+        no default implementation — they end with ``;`` rather than a block.
+        The ``function_item`` handler covers default-impl methods; this one
+        covers the missing half (issue #538, Rust N2).
+        """
+        try:
+            name_node = node.child_by_field_name("name")
+            if not name_node:
+                return None
+
+            name = self._get_node_text(name_node)
+            start_line = node.start_point[0] + 1
+            end_line = node.end_point[0] + 1
+            parameters = self._extract_rust_parameters(
+                node.child_by_field_name("parameters")
+            )
+            return_type = "()"
+            ret_node = node.child_by_field_name("return_type")
+            if ret_node:
+                return_type = self._get_node_text(ret_node)
+                if return_type.startswith("->"):
+                    return_type = return_type[2:].strip()
+
+            visibility = self._extract_visibility(node)
+            raw_text = self._get_node_text(node)
+
+            func = Function(
+                name=name,
+                start_line=start_line,
+                end_line=end_line,
+                raw_text=raw_text,
+                language="rust",
+                parameters=parameters,
+                return_type=return_type,
+                visibility=visibility,
+            )
+            func.is_abstract = True
+
+            owner = self._find_impl_owner(node)
+            if owner:
+                func.receiver_type = owner
+                self_param = self._find_self_parameter(node)
+                if self_param:
+                    func.receiver = self_param
+                    func.is_method = True
+
+            return func
+        except Exception as e:
+            log_error(f"Error extracting Rust abstract function: {e}")
+            return None
 
     def _extract_struct(self, node: tree_sitter.Node) -> Class | None:
         """Extract struct information"""

--- a/tree_sitter_analyzer/languages/typescript_plugin/_function_helpers.py
+++ b/tree_sitter_analyzer/languages/typescript_plugin/_function_helpers.py
@@ -266,6 +266,7 @@ def extract_abstract_method_signature(
             return_type=return_type or "any",
             is_async=is_async,
             is_static=is_static,
+            is_abstract=True,
             docstring=extract_tsdoc(start_line),
             complexity_score=0,
             is_arrow=False,


### PR DESCRIPTION
Closes #538 (P3, QC-sweep digest — per-item verdicts)

| Item | Verdict |
|---|---|
| Go `type X = []string` alias | FIXED (`type_alias` accepted in `_iter_type_specs`) |
| Go interface embedding | FIXED (`_go_interface_embedded` → interfaces) |
| Rust trait abstract methods | FIXED (`function_signature_item` handler, is_abstract=True) |
| Python `class Animal(ABC)` | FIXED (class_type=abstract_class, mirrors TS) |
| TS `abstract validate()` | FIXED (is_abstract=True, one line) |
| C++ namespace capture | FALSE POSITIVE (already a Package; live-verified) |
| Go interface method nesting / Rust mod container / C++ qualifier / Kotlin Unit inference | Scope-B (each >20 lines; follow-ups listed in issue close) |

6 RED→GREEN inline tests; Go/Rust plugin goldens regenerated (Class 9→10, Function 8→9 — exactly the recovered symbols); 2,582 unit tests green; ratchet exit 0.