### PR TITLE
test: pin exact assertions — batch 13 + ratchet baseline down

### DIFF
--- a/scripts/loose_assertion_baseline.txt
+++ b/scripts/loose_assertion_baseline.txt
@@ -10,6 +10,6 @@
 # The count must only decrease (or stay equal). Each Layer-2 batch PR
 # re-measures and lowers it. Numbers are MEASURED, never hand-derived.
 
-BASELINE_COUNT=1230
+BASELINE_COUNT=1168
 MEASUREMENT_DATE=2026-06-12
 MEASUREMENT_COMMAND="grep -rEn \"assert .*(>= [0-9]|> 0([^0-9]|\$))\" tests/ --include=\"*.py\" | grep -v \"ratchet: nondeterministic\" | wc -l"

--- a/tests/unit/core/test_queries_typescript.py
+++ b/tests/unit/core/test_queries_typescript.py
@@ -18,79 +18,79 @@ class TestTypeScriptQueries:
         """Test that FUNCTIONS query is defined"""
         assert hasattr(ts_queries, "FUNCTIONS")
         assert isinstance(ts_queries.FUNCTIONS, str)
-        assert len(ts_queries.FUNCTIONS.strip()) > 0
+        assert len(ts_queries.FUNCTIONS.strip()) == 1058
 
     def test_classes_query_exists(self):
         """Test that CLASSES query is defined"""
         assert hasattr(ts_queries, "CLASSES")
         assert isinstance(ts_queries.CLASSES, str)
-        assert len(ts_queries.CLASSES.strip()) > 0
+        assert len(ts_queries.CLASSES.strip()) == 346
 
     def test_interfaces_query_exists(self):
         """Test that INTERFACES query is defined"""
         assert hasattr(ts_queries, "INTERFACES")
         assert isinstance(ts_queries.INTERFACES, str)
-        assert len(ts_queries.INTERFACES.strip()) > 0
+        assert len(ts_queries.INTERFACES.strip()) == 193
 
     def test_type_aliases_query_exists(self):
         """Test that TYPE_ALIASES query is defined"""
         assert hasattr(ts_queries, "TYPE_ALIASES")
         assert isinstance(ts_queries.TYPE_ALIASES, str)
-        assert len(ts_queries.TYPE_ALIASES.strip()) > 0
+        assert len(ts_queries.TYPE_ALIASES.strip()) == 157
 
     def test_enums_query_exists(self):
         """Test that ENUMS query is defined"""
         assert hasattr(ts_queries, "ENUMS")
         assert isinstance(ts_queries.ENUMS, str)
-        assert len(ts_queries.ENUMS.strip()) > 0
+        assert len(ts_queries.ENUMS.strip()) == 103
 
     def test_variables_query_exists(self):
         """Test that VARIABLES query is defined"""
         assert hasattr(ts_queries, "VARIABLES")
         assert isinstance(ts_queries.VARIABLES, str)
-        assert len(ts_queries.VARIABLES.strip()) > 0
+        assert len(ts_queries.VARIABLES.strip()) == 389
 
     def test_imports_query_exists(self):
         """Test that IMPORTS query is defined"""
         assert hasattr(ts_queries, "IMPORTS")
         assert isinstance(ts_queries.IMPORTS, str)
-        assert len(ts_queries.IMPORTS.strip()) > 0
+        assert len(ts_queries.IMPORTS.strip()) == 501
 
     def test_exports_query_exists(self):
         """Test that EXPORTS query is defined"""
         assert hasattr(ts_queries, "EXPORTS")
         assert isinstance(ts_queries.EXPORTS, str)
-        assert len(ts_queries.EXPORTS.strip()) > 0
+        assert len(ts_queries.EXPORTS.strip()) == 249
 
     def test_decorators_query_exists(self):
         """Test that DECORATORS query is defined"""
         assert hasattr(ts_queries, "DECORATORS")
         assert isinstance(ts_queries.DECORATORS, str)
-        assert len(ts_queries.DECORATORS.strip()) > 0
+        assert len(ts_queries.DECORATORS.strip()) == 365
 
     def test_generics_query_exists(self):
         """Test that GENERICS query is defined"""
         assert hasattr(ts_queries, "GENERICS")
         assert isinstance(ts_queries.GENERICS, str)
-        assert len(ts_queries.GENERICS.strip()) > 0
+        assert len(ts_queries.GENERICS.strip()) == 186
 
     def test_signatures_query_exists(self):
         """Test that SIGNATURES query is defined"""
         assert hasattr(ts_queries, "SIGNATURES")
         assert isinstance(ts_queries.SIGNATURES, str)
-        assert len(ts_queries.SIGNATURES.strip()) > 0
+        assert len(ts_queries.SIGNATURES.strip()) == 655
 
     def test_comments_query_exists(self):
         """Test that COMMENTS query is defined"""
         assert hasattr(ts_queries, "COMMENTS")
         assert isinstance(ts_queries.COMMENTS, str)
-        assert len(ts_queries.COMMENTS.strip()) > 0
+        assert len(ts_queries.COMMENTS.strip()) == 18
 
     def test_all_queries_dict_exists(self):
         """Test that ALL_QUERIES dictionary is defined"""
         assert hasattr(ts_queries, "ALL_QUERIES")
         assert isinstance(ts_queries.ALL_QUERIES, dict)
-        assert len(ts_queries.ALL_QUERIES) > 0
+        assert len(ts_queries.ALL_QUERIES) == 83
 
     def test_all_queries_structure(self):
         """Test the structure of ALL_QUERIES dictionary"""
@@ -104,8 +104,10 @@ class TestTypeScriptQueries:
             assert "description" in query_data
             assert isinstance(query_data["query"], str)
             assert isinstance(query_data["description"], str)
-            assert len(query_data["query"].strip()) > 0
-            assert len(query_data["description"].strip()) > 0
+
+        # Pin minimum observed lengths (exact facts; update when query strings change)
+        assert min(len(d["query"].strip()) for d in queries.values()) == 18
+        assert min(len(d["description"].strip()) for d in queries.values()) == 18
 
     def test_expected_queries_present(self):
         """Test that expected TypeScript queries are present"""
@@ -286,7 +288,7 @@ class TestTypeScriptQueries:
 
         query_names = ts_queries.list_queries()
         assert isinstance(query_names, list)
-        assert len(query_names) > 0
+        assert len(query_names) == 83
 
         # Should match keys in ALL_QUERIES
         expected_names = list(ts_queries.ALL_QUERIES.keys())

--- a/tests/unit/languages/test_html_plugin_forms_tables.py
+++ b/tests/unit/languages/test_html_plugin_forms_tables.py
@@ -1,6 +1,5 @@
 """HTML plugin tests — forms and tables."""
 
-
 from tests.unit.languages._html_test_data import (
     FORM_CODE,
     TABLE_CODE,
@@ -19,7 +18,7 @@ class TestHtmlFormRecognition:
         elements = plugin.create_extractor().extract_html_elements(tree, FORM_CODE)
 
         form_elements = [e for e in elements if e.tag_name == "form"]
-        assert len(form_elements) >= 1
+        assert len(form_elements) == 1
 
     def test_extract_input_tags(self):
         """Test extraction of input tags."""
@@ -28,7 +27,7 @@ class TestHtmlFormRecognition:
         elements = plugin.create_extractor().extract_html_elements(tree, FORM_CODE)
 
         input_elements = [e for e in elements if e.tag_name == "input"]
-        assert len(input_elements) >= 1
+        assert len(input_elements) == 6
 
     def test_extract_text_input(self):
         """Test extraction of text input."""
@@ -113,7 +112,7 @@ class TestHtmlFormRecognition:
         elements = plugin.create_extractor().extract_html_elements(tree, FORM_CODE)
 
         select_elements = [e for e in elements if e.tag_name == "select"]
-        assert len(select_elements) >= 1
+        assert len(select_elements) == 1
 
     def test_extract_option_tags(self):
         """Test extraction of option tags."""
@@ -122,7 +121,7 @@ class TestHtmlFormRecognition:
         elements = plugin.create_extractor().extract_html_elements(tree, FORM_CODE)
 
         option_elements = [e for e in elements if e.tag_name == "option"]
-        assert len(option_elements) >= 1
+        assert len(option_elements) == 3
 
     def test_extract_textarea_tag(self):
         """Test extraction of textarea tag."""
@@ -131,7 +130,7 @@ class TestHtmlFormRecognition:
         elements = plugin.create_extractor().extract_html_elements(tree, FORM_CODE)
 
         textarea_elements = [e for e in elements if e.tag_name == "textarea"]
-        assert len(textarea_elements) >= 1
+        assert len(textarea_elements) == 1
 
     def test_extract_button_tag(self):
         """Test extraction of button tag."""
@@ -140,7 +139,7 @@ class TestHtmlFormRecognition:
         elements = plugin.create_extractor().extract_html_elements(tree, FORM_CODE)
 
         button_elements = [e for e in elements if e.tag_name == "button"]
-        assert len(button_elements) >= 1
+        assert len(button_elements) == 2
 
     def test_extract_label_tag(self):
         """Test extraction of label tag."""
@@ -149,7 +148,7 @@ class TestHtmlFormRecognition:
         elements = plugin.create_extractor().extract_html_elements(tree, FORM_CODE)
 
         label_elements = [e for e in elements if e.tag_name == "label"]
-        assert len(label_elements) >= 1
+        assert len(label_elements) == 8
 
 
 class TestHtmlTableRecognition:
@@ -162,7 +161,7 @@ class TestHtmlTableRecognition:
         elements = plugin.create_extractor().extract_html_elements(tree, TABLE_CODE)
 
         table_elements = [e for e in elements if e.tag_name == "table"]
-        assert len(table_elements) >= 1
+        assert len(table_elements) == 2
 
     def test_extract_thead_tag(self):
         """Test extraction of thead tag."""
@@ -171,7 +170,7 @@ class TestHtmlTableRecognition:
         elements = plugin.create_extractor().extract_html_elements(tree, TABLE_CODE)
 
         thead_elements = [e for e in elements if e.tag_name == "thead"]
-        assert len(thead_elements) >= 1
+        assert len(thead_elements) == 2
 
     def test_extract_tbody_tag(self):
         """Test extraction of tbody tag."""
@@ -180,7 +179,7 @@ class TestHtmlTableRecognition:
         elements = plugin.create_extractor().extract_html_elements(tree, TABLE_CODE)
 
         tbody_elements = [e for e in elements if e.tag_name == "tbody"]
-        assert len(tbody_elements) >= 1
+        assert len(tbody_elements) == 2
 
     def test_extract_tfoot_tag(self):
         """Test extraction of tfoot tag."""
@@ -189,7 +188,7 @@ class TestHtmlTableRecognition:
         elements = plugin.create_extractor().extract_html_elements(tree, TABLE_CODE)
 
         tfoot_elements = [e for e in elements if e.tag_name == "tfoot"]
-        assert len(tfoot_elements) >= 1
+        assert len(tfoot_elements) == 1
 
     def test_extract_tr_tag(self):
         """Test extraction of tr tag."""
@@ -198,7 +197,7 @@ class TestHtmlTableRecognition:
         elements = plugin.create_extractor().extract_html_elements(tree, TABLE_CODE)
 
         tr_elements = [e for e in elements if e.tag_name == "tr"]
-        assert len(tr_elements) >= 1
+        assert len(tr_elements) == 7
 
     def test_extract_th_tag(self):
         """Test extraction of th tag."""
@@ -207,7 +206,7 @@ class TestHtmlTableRecognition:
         elements = plugin.create_extractor().extract_html_elements(tree, TABLE_CODE)
 
         th_elements = [e for e in elements if e.tag_name == "th"]
-        assert len(th_elements) >= 1
+        assert len(th_elements) == 6
 
     def test_extract_td_tag(self):
         """Test extraction of td tag."""
@@ -216,7 +215,7 @@ class TestHtmlTableRecognition:
         elements = plugin.create_extractor().extract_html_elements(tree, TABLE_CODE)
 
         td_elements = [e for e in elements if e.tag_name == "td"]
-        assert len(td_elements) >= 1
+        assert len(td_elements) == 13
 
     def test_extract_caption_tag(self):
         """Test extraction of caption tag."""
@@ -225,7 +224,7 @@ class TestHtmlTableRecognition:
         elements = plugin.create_extractor().extract_html_elements(tree, TABLE_CODE)
 
         caption_elements = [e for e in elements if e.tag_name == "caption"]
-        assert len(caption_elements) >= 0
+        assert len(caption_elements) == 1
 
     def test_extract_table_attributes(self):
         """Test extraction of table attributes."""
@@ -241,5 +240,3 @@ class TestHtmlTableRecognition:
                 "id" in table_with_attrs.attributes
                 or "class" in table_with_attrs.attributes
             )
-
-

--- a/tests/unit/languages/test_html_plugin_links_scripts.py
+++ b/tests/unit/languages/test_html_plugin_links_scripts.py
@@ -1,6 +1,5 @@
 """HTML plugin tests — links, images, scripts, styles, complex structures."""
 
-
 from tests.unit.languages._html_test_data import (
     COMPLEX_STRUCTURE_CODE,
     LINK_IMAGE_CODE,
@@ -22,7 +21,7 @@ class TestHtmlLinkImageRecognition:
         )
 
         a_elements = [e for e in elements if e.tag_name == "a"]
-        assert len(a_elements) >= 1
+        assert len(a_elements) == 5
 
     def test_extract_external_link(self):
         """Test extraction of external link."""
@@ -96,7 +95,7 @@ class TestHtmlLinkImageRecognition:
         )
 
         img_elements = [e for e in elements if e.tag_name == "img"]
-        assert len(img_elements) >= 1
+        assert len(img_elements) == 4
 
     def test_extract_image_with_alt(self):
         """Test extraction of image with alt text."""
@@ -149,7 +148,7 @@ class TestHtmlLinkImageRecognition:
         )
 
         picture_elements = [e for e in elements if e.tag_name == "picture"]
-        assert len(picture_elements) >= 0
+        assert len(picture_elements) == 1
 
     def test_extract_svg_tag(self):
         """Test extraction of svg tag."""
@@ -160,7 +159,7 @@ class TestHtmlLinkImageRecognition:
         )
 
         svg_elements = [e for e in elements if e.tag_name == "svg"]
-        assert len(svg_elements) >= 0
+        assert len(svg_elements) == 1
 
 
 class TestHtmlScriptStyleRecognition:
@@ -175,7 +174,7 @@ class TestHtmlScriptStyleRecognition:
         )
 
         script_elements = [e for e in elements if e.tag_name == "script"]
-        assert len(script_elements) >= 1
+        assert len(script_elements) == 3
 
     def test_extract_style_tag(self):
         """Test extraction of style tag."""
@@ -186,7 +185,7 @@ class TestHtmlScriptStyleRecognition:
         )
 
         style_elements = [e for e in elements if e.tag_name == "style"]
-        assert len(style_elements) >= 1
+        assert len(style_elements) == 1
 
     def test_extract_link_tag(self):
         """Test extraction of link tag."""
@@ -197,7 +196,7 @@ class TestHtmlScriptStyleRecognition:
         )
 
         link_elements = [e for e in elements if e.tag_name == "link"]
-        assert len(link_elements) >= 1
+        assert len(link_elements) == 1
 
     def test_extract_meta_tag(self):
         """Test extraction of meta tag."""
@@ -208,7 +207,7 @@ class TestHtmlScriptStyleRecognition:
         )
 
         meta_elements = [e for e in elements if e.tag_name == "meta"]
-        assert len(meta_elements) >= 1
+        assert len(meta_elements) == 6
 
     def test_extract_title_tag(self):
         """Test extraction of title tag."""
@@ -219,7 +218,7 @@ class TestHtmlScriptStyleRecognition:
         )
 
         title_elements = [e for e in elements if e.tag_name == "title"]
-        assert len(title_elements) >= 1
+        assert len(title_elements) == 1
 
     def test_extract_script_with_src(self):
         """Test extraction of script with src attribute."""
@@ -272,7 +271,7 @@ class TestHtmlComplexStructures:
         )
 
         # Should find nested elements
-        assert len(elements) >= 10
+        assert len(elements) == 28
 
     def test_extract_parent_child_relationships(self):
         """Test extraction of parent-child relationships."""
@@ -286,7 +285,7 @@ class TestHtmlComplexStructures:
         elements_with_children = [
             e for e in elements if e.children and len(e.children) > 0
         ]
-        assert len(elements_with_children) >= 1
+        assert len(elements_with_children) == 15
 
     def test_extract_multiple_classes(self):
         """Test extraction of elements with multiple classes."""
@@ -302,7 +301,9 @@ class TestHtmlComplexStructures:
             for e in elements
             if e.attributes and "class" in e.attributes and " " in e.attributes["class"]
         ]
-        assert len(elements_with_multiple_classes) >= 0
+        assert (
+            len(elements_with_multiple_classes) == 0
+        )  # extraction gap: no multi-class elements in COMPLEX_STRUCTURE_CODE fixture
 
     def test_extract_doctype(self):
         """Test extraction of DOCTYPE."""
@@ -313,7 +314,7 @@ class TestHtmlComplexStructures:
         )
 
         # DOCTYPE should be captured
-        assert len(elements) >= 1
+        assert len(elements) == 28
 
     def test_extract_html_tag(self):
         """Test extraction of html tag."""
@@ -324,7 +325,7 @@ class TestHtmlComplexStructures:
         )
 
         html_elements = [e for e in elements if e.tag_name == "html"]
-        assert len(html_elements) >= 1
+        assert len(html_elements) == 1
 
     def test_extract_head_tag(self):
         """Test extraction of head tag."""
@@ -335,7 +336,7 @@ class TestHtmlComplexStructures:
         )
 
         head_elements = [e for e in elements if e.tag_name == "head"]
-        assert len(head_elements) >= 1
+        assert len(head_elements) == 1
 
     def test_extract_body_tag(self):
         """Test extraction of body tag."""
@@ -346,6 +347,4 @@ class TestHtmlComplexStructures:
         )
 
         body_elements = [e for e in elements if e.tag_name == "body"]
-        assert len(body_elements) >= 1
-
-
+        assert len(body_elements) == 1

--- a/tests/unit/test_call_graph_integration.py
+++ b/tests/unit/test_call_graph_integration.py
@@ -80,9 +80,9 @@ class TestCallGraphBuild:
         cg = CallGraph(str(PY_PROJECT))
         cg.build()
         s = cg.summary()
-        assert s["function_count"] > 0
-        assert s["call_edge_count"] >= 0
-        assert s["file_count"] > 0
+        assert s["function_count"] == 15
+        assert s["call_edge_count"] == 8
+        assert s["file_count"] == 5
 
 
 class TestCallGraphCallersOf:
@@ -131,12 +131,12 @@ class TestCallChain:
         cg = CallGraph(str(PY_PROJECT))
         cg.build()
         chain = cg.call_chain("main", depth=3)
-        assert len(chain) > 0
+        assert len(chain) == 4
         for edge in chain:
             assert "caller" in edge
             assert "callee" in edge
             assert "depth" in edge
-            assert edge["depth"] >= 1
+            assert edge["depth"] == 1
 
     def test_call_chain_depth_limit(self):
         cg = CallGraph(str(PY_PROJECT))
@@ -167,7 +167,7 @@ class TestCallGraphPythonClassMethods:
         user_service_methods = [
             f for f in funcs if f["name"] in ("get_user", "delete_user", "_fetch")
         ]
-        assert len(user_service_methods) >= 1
+        assert len(user_service_methods) == 6
         for m in user_service_methods:
             if "receiver" in m:
                 assert m["receiver"] == "UserService"
@@ -214,7 +214,7 @@ class TestCallGraphJavaProject:
         cg.build()
         funcs = cg.all_functions()
         names = {f["name"] for f in funcs}
-        assert len(names) > 0
+        assert len(names) == 5
 
     def test_java_callers(self):
         cg = CallGraph(str(JAVA_PROJECT))
@@ -333,7 +333,7 @@ class TestCallGraphPublicAdjacencyAPI:
         refs1 = cg.all_function_refs()
         refs1.clear()
         refs2 = cg.all_function_refs()
-        assert len(refs2) > 0
+        assert len(refs2) == 15
 
     def test_all_function_refs_count_matches_all_functions(self):
         cg = CallGraph(str(PY_PROJECT))
@@ -352,7 +352,7 @@ class TestCallGraphPublicAdjacencyAPI:
         cm1 = cg.callers_map()
         cm1.clear()
         cm2 = cg.callers_map()
-        assert len(cm2) > 0
+        assert len(cm2) == 7
 
     def test_callees_map_returns_dict(self):
         cg = CallGraph(str(PY_PROJECT))
@@ -367,7 +367,7 @@ class TestCallGraphPublicAdjacencyAPI:
         cm1 = cg.callees_map()
         cm1.clear()
         cm2 = cg.callees_map()
-        assert len(cm2) > 0
+        assert len(cm2) == 5
 
     def test_functions_by_file_keys_are_strings(self):
         cg = CallGraph(str(PY_PROJECT))
@@ -384,7 +384,7 @@ class TestCallGraphPublicAdjacencyAPI:
         fbf1 = cg.functions_by_file()
         fbf1.clear()
         fbf2 = cg.functions_by_file()
-        assert len(fbf2) > 0
+        assert len(fbf2) == 5
 
     def test_resolve_targets_returns_function_refs(self):
         cg = CallGraph(str(PY_PROJECT))
@@ -406,7 +406,7 @@ class TestCallGraphPublicAdjacencyAPI:
         callers = cg.callers_of("load_data")
         # If symbol exists, both resolve correctly
         if refs:
-            assert len(callers) >= 0  # callers_of may return 0 even if symbol exists
+            assert len(callers) == 1  # main calls load_data
 
 
 class TestCallGraphAllCallEdges:
@@ -425,8 +425,8 @@ class TestCallGraphAllCallEdges:
         cg = CallGraph(str(PY_PROJECT))
         # Graph not yet built — calling all_call_edges() should trigger build.
         # After the call, functions and edges are populated.
-        assert len(cg.all_call_edges()) >= 0
-        assert len(cg.all_functions()) > 0
+        assert len(cg.all_call_edges()) == 8
+        assert len(cg.all_functions()) == 15
 
     def test_all_call_edges_count_matches_summary(self):
         """all_call_edges() count must match the summary call_edge_count."""
@@ -441,4 +441,4 @@ class TestCallGraphAllCallEdges:
         edges1 = cg.all_call_edges()
         edges1.clear()
         edges2 = cg.all_call_edges()
-        assert len(edges2) > 0  # internal list unaffected
+        assert len(edges2) == 8  # internal list unaffected


### PR DESCRIPTION
Layer-2 cleanup batch 13. 62 hits → exact pins, 0 exemptions; baseline 1230 → 1168 (−62, pre/post measured).

| File | Hits → 0 |
|---|---|
| test_html_plugin_links_scripts.py | 16 |
| test_queries_typescript.py | 16 |
| test_call_graph_integration.py | 15 |
| test_html_plugin_forms_tables.py | 15 |

Notable: TS query registry sizes pinned (ALL_QUERIES==83, FUNCTIONS source ==1058 chars); in-loop bounds → out-of-loop min pins (==18); 4 vacuous `>= 0` hollow greens pinned to real values; call-graph integration counts exact (15 fns / 8 edges / 5 files). 124 tests green; ratchet exit 0.