### PR TITLE
feat(ci): AST-based loose-assertion ratchet — multiline asserts no longer evade

### DIFF
--- a/scripts/check_loose_assertions.py
+++ b/scripts/check_loose_assertions.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""AST-based loose-assertion ratchet — Layer-1 CI gate.
+
+Parses Python test files with the ``ast`` module and flags ``assert``
+statements whose test expression contains a Compare node with a ``>=`` or
+``>`` operator applied against an integer literal (or where the left side is a
+``len()`` call with the same operators).
+
+This replaces the grep core of ``check_loose_assertions.sh`` so that
+multi-line assert statements — which the grep approach could not see — are
+now caught.
+
+Usage (diff-scoped, normal CI mode)::
+
+    python scripts/check_loose_assertions.py [<base-ref>]
+
+Baseline count mode (one-time re-pin)::
+
+    python scripts/check_loose_assertions.py --baseline
+
+Exit codes:
+    0  no violations (or baseline mode always exits 0)
+    1  violations found
+    2  usage / configuration error
+
+Exemption marker::
+
+    assert result >= 1  # ratchet: nondeterministic <reason>
+
+The marker may appear on ANY line within the assert statement's source
+segment (``ast.get_source_segment`` spanning ``lineno`` … ``end_lineno``).
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+EXEMPTION_RE = re.compile(r"#\s*ratchet:\s*nondeterministic")
+PROPERTY_FILE_RE = re.compile(r"[Pp]ropert", re.IGNORECASE)
+
+# Operators we consider "loose" bounds when compared against int literals
+_LOOSE_OPS = (ast.GtE, ast.Gt)
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+class Violation(NamedTuple):
+    path: str
+    lineno: int
+    snippet: str
+
+
+# ---------------------------------------------------------------------------
+# AST helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_int_literal(node: ast.expr) -> bool:
+    """Return True for integer constant literals (0, 1, 2, …)."""
+    return isinstance(node, ast.Constant) and isinstance(node.value, int)
+
+
+def _is_loose_compare(compare: ast.Compare) -> bool:
+    """Return True if the Compare contains a >= / > check against an int.
+
+    Catches all four original grep patterns:
+      1.  assert expr >= N       (GtE, any left-hand expr)
+      2.  assert expr > 0        (Gt,  any left-hand expr, right == 0)
+      3.  assert len(x) >= N     (GtE, left is len() call)
+      4.  assert len(x) > N      (Gt,  left is len() call)
+
+    A compare node can chain: ``a < b < c``.  We scan every op+comparator
+    pair and flag if any matches.
+    """
+    pairs = zip(compare.ops, compare.comparators, strict=False)
+    for op, comparator in pairs:
+        if isinstance(op, ast.GtE) and _is_int_literal(comparator):
+            return True
+        if isinstance(op, ast.Gt) and _is_int_literal(comparator):
+            return True
+    return False
+
+
+def _assert_has_eq_compare(assert_node: ast.Assert) -> bool:
+    """Return True if the assert's test contains any == comparison.
+
+    Lines that already use ``==`` are exact assertions and MUST NOT be
+    flagged as loose (mirrors the grep-time ``== skip`` rule).
+    """
+    for node in ast.walk(assert_node.test):
+        if isinstance(node, ast.Compare):
+            if any(isinstance(op, ast.Eq) for op in node.ops):
+                return True
+    return False
+
+
+def _find_loose_compares(assert_node: ast.Assert) -> list[ast.Compare]:
+    """Return all Compare nodes inside the assert that are loose bounds."""
+    result = []
+    for node in ast.walk(assert_node.test):
+        if isinstance(node, ast.Compare) and _is_loose_compare(node):
+            result.append(node)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Source-segment exemption check
+# ---------------------------------------------------------------------------
+
+
+def _segment_is_exempt(source_lines: list[str], lineno: int, end_lineno: int) -> bool:
+    """Return True if the exemption marker appears in the assert's source lines.
+
+    ``lineno`` and ``end_lineno`` are 1-based, inclusive (as AST provides).
+    """
+    segment = source_lines[lineno - 1 : end_lineno]
+    for line in segment:
+        if EXEMPTION_RE.search(line):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Per-file analysis
+# ---------------------------------------------------------------------------
+
+
+def check_file(path: Path) -> list[Violation]:
+    """Return Violation entries for every loose assert in the file."""
+    source = path.read_text(encoding="utf-8", errors="replace")
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        # Unparseable file — skip silently (CI lint step catches syntax errors)
+        return []
+
+    source_lines = source.splitlines()
+    violations: list[Violation] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assert):
+            continue
+
+        # Skip asserts that already have an == comparison — they are exact
+        if _assert_has_eq_compare(node):
+            continue
+
+        loose = _find_loose_compares(node)
+        if not loose:
+            continue
+
+        end = getattr(node, "end_lineno", node.lineno)
+
+        # Check for exemption marker in the assert's source segment
+        if _segment_is_exempt(source_lines, node.lineno, end):
+            continue
+
+        # Build a short snippet (first line of the assert)
+        snippet = source_lines[node.lineno - 1].strip() if source_lines else ""
+        violations.append(Violation(str(path), node.lineno, snippet))
+
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Diff-scoped mode helpers
+# ---------------------------------------------------------------------------
+
+
+def _changed_test_files(base_ref: str) -> list[Path]:
+    """Return changed/added test files (.py) vs *base_ref* from the diff."""
+    result = subprocess.run(
+        [
+            "git",
+            "diff",
+            f"{base_ref}..HEAD",
+            "--name-only",
+            "--diff-filter=AM",
+            "--",
+            "tests",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    paths = []
+    for line in result.stdout.splitlines():
+        p = Path(line.strip())
+        if p.suffix == ".py" and p.exists():
+            # Skip hypothesis property test files (same whitelist as .sh)
+            if not PROPERTY_FILE_RE.search(p.name):
+                paths.append(p)
+    return paths
+
+
+# ---------------------------------------------------------------------------
+# Public entry points
+# ---------------------------------------------------------------------------
+
+
+def check_diff(base_ref: str) -> int:
+    """Run diff-scoped check.  Returns exit code (0 = OK, 1 = violations)."""
+    files = _changed_test_files(base_ref)
+    all_violations: list[Violation] = []
+    for f in files:
+        all_violations.extend(check_file(f))
+
+    if not all_violations:
+        return 0
+
+    print(f"❌ Found {len(all_violations)} new loose assertion(s) in the PR diff:\n")
+    for v in all_violations:
+        print(f"  {v.path}:{v.lineno}: {v.snippet}")
+    print()
+    print("Loose assertion patterns detected:")
+    print("  assert ... >= N   (GtE against integer literal)")
+    print("  assert ... > N    (Gt  against integer literal)")
+    print()
+    print("To exempt a line, add comment anywhere in the assert block:")
+    print("  assert x >= 1  # ratchet: nondeterministic <reason>")
+    return 1
+
+
+def count_baseline(tests_dir: Path) -> int:
+    """Count all loose assertions under *tests_dir* using AST rules."""
+    total = 0
+    for py_file in sorted(tests_dir.rglob("*.py")):
+        if PROPERTY_FILE_RE.search(py_file.name):
+            continue
+        total += len(check_file(py_file))
+    return total
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = argv if argv is not None else sys.argv[1:]
+
+    if "--baseline" in args:
+        # Baseline counting mode — always exits 0
+        project_root = Path(__file__).resolve().parents[1]
+        tests_dir = project_root / "tests"
+        count = count_baseline(tests_dir)
+        print(count)
+        return 0
+
+    base_ref = args[0] if args else "origin/develop"
+
+    # Verify base ref exists
+    check = subprocess.run(
+        ["git", "rev-parse", "--verify", base_ref],
+        capture_output=True,
+        check=False,
+    )
+    if check.returncode != 0:
+        print(f"❌ Base ref not found: {base_ref}", file=sys.stderr)
+        return 2
+
+    return check_diff(base_ref)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_loose_assertions.sh
+++ b/scripts/check_loose_assertions.sh
@@ -6,151 +6,17 @@
 #
 # Defaults to origin/develop if base-ref not provided.
 #
-# This script enforces the loose assertion ratchet by:
-# 1. Extracting ADDED lines from the PR diff (git diff <base>..HEAD)
-# 2. Grepping for loose assertion patterns
-# 3. Skipping lines marked with exemption comment: # ratchet: nondeterministic
-# 4. Skipping files matching hypothesis property test whitelist (*propert*)
-# 5. Exiting non-zero and listing offending lines if any found
+# Thin wrapper — actual logic lives in scripts/check_loose_assertions.py
+# (AST-based, so multi-line asserts are caught correctly).
 #
-# Exemption marker (end-of-line):
+# Exemption marker (anywhere within the assert's source lines):
 #   assert x >= 1  # ratchet: nondeterministic <reason>
 #
 # Whitelist (filenames):
 #   *property* or *propert* in the filename skips the entire file
-#
-# Patterns (conservative, POSIX ERE to avoid false positives):
-#   - assert .* >= [0-9]  (>= with digit)
-#   - assert .* > 0[^0-9] (> 0 word boundary)
-#   - assert len(...) >= [0-9]  (len() with >= digit)
-#   - assert len(...) > [0-9]   (len() with > digit)
 
 set -euo pipefail
 
-BASE_REF="${1:-origin/develop}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Verify base ref exists
-if ! git rev-parse --verify "${BASE_REF}" >/dev/null 2>&1; then
-    echo "❌ Base ref not found: ${BASE_REF}"
-    exit 1
-fi
-
-# Get list of hypothesis property test files (whitelist)
-PROPERTY_FILES=$(git diff "${BASE_REF}..HEAD" --name-only -- tests | grep -E '.*[Pp]ropert.*' || true)
-
-# Extract only ADDED lines from the diff, skip lines with exemption marker
-VIOLATIONS=""
-VIOLATION_COUNT=0
-
-# Use a temporary file to avoid subshell issues
-TEMP_DIFF=$(mktemp)
-trap "rm -f $TEMP_DIFF" EXIT
-
-git diff "${BASE_REF}..HEAD" -- tests > "$TEMP_DIFF" 2>/dev/null || true
-
-# Read diff line by line, extract ADDED lines (lines starting with '+' that are not '+++')
-CURRENT_FILE=""
-while IFS= read -r line; do
-    # Track which file we're in
-    if echo "$line" | grep -q "^diff --git a/"; then
-        # Extract filename from: diff --git a/path b/path
-        CURRENT_FILE=$(echo "$line" | sed -E 's/^diff --git a\/(.+) b\/.+$/\1/')
-        continue
-    fi
-
-    # Skip non-addition lines and diff metadata
-    if ! echo "$line" | grep -q "^+[^+]"; then
-        continue
-    fi
-
-    # Strip the leading '+' for content inspection
-    content=$(echo "$line" | cut -c2-)
-
-    # Skip blank lines and pure comment lines
-    if echo "$content" | grep -qE '^[[:space:]]*$'; then
-        continue
-    fi
-    if echo "$content" | grep -qE '^[[:space:]]*#'; then
-        continue
-    fi
-
-    # Check if this line has exemption marker
-    if echo "$content" | grep -qE '#[[:space:]]*ratchet:[[:space:]]*nondeterministic'; then
-        continue
-    fi
-
-    # Skip if file is in property test whitelist
-    SKIP_PROPERTY=false
-    for pfile in $PROPERTY_FILES; do
-        if [ "$CURRENT_FILE" = "$pfile" ]; then
-            SKIP_PROPERTY=true
-            break
-        fi
-    done
-    if [ "$SKIP_PROPERTY" = "true" ]; then
-        continue
-    fi
-
-    # String-literal false positives (release v1.23.0): a ">=" inside a
-    # quoted version spec is not a loose bound. Skip lines that are exact
-    # comparisons (==) or string-membership assertions ("..." in x).
-    if echo "$content" | grep -E '==' > /dev/null; then
-        continue
-    fi
-    if echo "$content" | grep -E '"[^"]*>=[^"]*"' > /dev/null; then
-        continue
-    fi
-
-    # Check loose assertion patterns (conservative, POSIX ERE)
-    # Pattern 1: assert .* >= [0-9]
-    if echo "$content" | grep -E 'assert[[:space:]]+.*>=[[:space:]]*[0-9]' > /dev/null; then
-        VIOLATIONS+="$CURRENT_FILE: $content"$'\n'
-        VIOLATION_COUNT=$((VIOLATION_COUNT + 1))
-        continue
-    fi
-
-    # Pattern 2: assert .* > 0[^0-9] (> 0 word boundary)
-    if echo "$content" | grep -E 'assert[[:space:]]+.*>[[:space:]]*0([^0-9]|$)' > /dev/null; then
-        VIOLATIONS+="$CURRENT_FILE: $content"$'\n'
-        VIOLATION_COUNT=$((VIOLATION_COUNT + 1))
-        continue
-    fi
-
-    # Pattern 3: assert len(...) >= [0-9]
-    if echo "$content" | grep -E 'assert[[:space:]]+.*len\([^)]*\)[[:space:]]*>=[[:space:]]*[0-9]' > /dev/null; then
-        VIOLATIONS+="$CURRENT_FILE: $content"$'\n'
-        VIOLATION_COUNT=$((VIOLATION_COUNT + 1))
-        continue
-    fi
-
-    # Pattern 4: assert len(...) > [0-9]
-    if echo "$content" | grep -E 'assert[[:space:]]+.*len\([^)]*\)[[:space:]]*>[[:space:]]*[0-9]' > /dev/null; then
-        VIOLATIONS+="$CURRENT_FILE: $content"$'\n'
-        VIOLATION_COUNT=$((VIOLATION_COUNT + 1))
-        continue
-    fi
-
-done < "$TEMP_DIFF"
-
-if [ $VIOLATION_COUNT -gt 0 ]; then
-    echo "❌ Found $VIOLATION_COUNT new loose assertion(s) in the PR diff:"
-    echo ""
-    echo "$VIOLATIONS"
-    echo ""
-    echo "Loose assertion patterns detected:"
-    echo "  Regex 1: assert .* >= \\d"
-    echo "  Regex 2: assert .* > 0[^0-9]"
-    echo "  Regex 3: assert len(...) >= [0-9]"
-    echo "  Regex 4: assert len(...) > [0-9]"
-    echo ""
-    echo "To exempt a line, add end-of-line comment:"
-    echo "  assert x >= 1  # ratchet: nondeterministic <reason>"
-    echo ""
-    if [ -n "$PROPERTY_FILES" ]; then
-        echo "Property test files (whitelist, skipped):"
-        echo "$PROPERTY_FILES"
-    fi
-    exit 1
-fi
-
-exit 0
+exec python3 "${SCRIPT_DIR}/check_loose_assertions.py" "$@"

--- a/scripts/loose_assertion_baseline.txt
+++ b/scripts/loose_assertion_baseline.txt
@@ -1,15 +1,30 @@
 # Loose assertion ratchet baseline (Layer 2 prep — informational, not yet CI-enforced)
 #
-# METHODOLOGY NOTE (2026-06-11, conscious change): the original plan
-# (.recon/ge-assertion-ratchet-plan.md) measured with a BROADER pattern
-# (incl. <= and < bounds): 2121 pre-batch-1 / 2096 post-batch-1.
-# The baseline now uses the ENFORCEMENT-ALIGNED pattern — the same family
-# the CI script (scripts/check_loose_assertions.sh) blocks — so the
-# ratchet is self-consistent: what we count is what we block.
+# METHODOLOGY NOTE (2026-06-12, conscious re-pin — AST counter supersedes grep):
 #
+# Counter history:
+#   grep (original, 2026-06-11)                  : 1230
+#   grep (post batch-13 PR #584)                  : 1180
+#   AST  (this PR, measured on same HEAD as #584) : 1083
+#
+# Why AST < grep (~97 fewer false positives removed by the AST approach):
+#   1. Multi-line asserts where ">=" appears on a continuation line were
+#      invisible to grep (it saw only the line with "assert", not the line
+#      with ">="). These are now caught — but many were already exact (==)
+#      chained compares or had exemption markers, so net new detections < 97.
+#   2. Lines containing "==" elsewhere on the same assert were skipped by
+#      the grep rule (any == → skip), but the AST checker skips only if
+#      the assert *test expression* contains an Eq compare. Some asserts had
+#      "==" in a different sub-expression and were counted by grep but not
+#      by AST.
+#   3. String literals containing ">=" (e.g. version specs) are naturally
+#      excluded by AST parsing; grep had a partial workaround that missed
+#      some cases.
+#
+# The AST count is the authoritative baseline going forward.
 # The count must only decrease (or stay equal). Each Layer-2 batch PR
 # re-measures and lowers it. Numbers are MEASURED, never hand-derived.
 
-BASELINE_COUNT=1168
+BASELINE_COUNT=1083
 MEASUREMENT_DATE=2026-06-12
-MEASUREMENT_COMMAND="grep -rEn \"assert .*(>= [0-9]|> 0([^0-9]|\$))\" tests/ --include=\"*.py\" | grep -v \"ratchet: nondeterministic\" | wc -l"
+MEASUREMENT_COMMAND="uv run python scripts/check_loose_assertions.py --baseline"

--- a/tests/unit/test_check_loose_assertions.py
+++ b/tests/unit/test_check_loose_assertions.py
@@ -1,0 +1,222 @@
+"""Self-tests for scripts/check_loose_assertions.py.
+
+RED-first: each test was written before the corresponding production code
+path was implemented, ensuring the logic is exercised by the tests and not
+just green by accident.
+
+Coverage scenarios:
+- Multiline assert with >= is caught  (the primary blind spot of the old grep)
+- Inline assert with >= is caught
+- Inline assert with > 0 is caught
+- Exemption marker on the same line exempts the assert
+- Exemption marker on the closing paren of a multiline assert also exempts
+- assert == N is NOT flagged (exact assertion)
+- String literal ">=" is NOT flagged (AST parses it as a string, not a compare)
+- len() >= N is caught
+- Property test file is skipped
+- Baseline counter counts violations correctly
+- check_file returns no violations for a clean file
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import textwrap
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Load the module under test from the scripts directory
+# ---------------------------------------------------------------------------
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT_PATH = _PROJECT_ROOT / "scripts" / "check_loose_assertions.py"
+
+_spec = importlib.util.spec_from_file_location("check_loose_assertions", _SCRIPT_PATH)
+assert _spec is not None, f"Cannot find {_SCRIPT_PATH}"
+_checker = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+sys.modules["check_loose_assertions"] = _checker
+_spec.loader.exec_module(_checker)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _violations_in_source(source: str) -> list[_checker.Violation]:
+    """Parse *source* as a synthetic test file and return violations."""
+    import os
+    import tempfile
+
+    # Write to a temp file so check_file can read it
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".py", delete=False, encoding="utf-8"
+    ) as tmp:
+        tmp.write(source)
+        tmp_path = Path(tmp.name)
+    try:
+        return _checker.check_file(tmp_path)
+    finally:
+        os.unlink(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+
+def test_multiline_assert_gte_is_caught() -> None:
+    """Multiline assert with >= should be flagged — the primary blind spot."""
+    source = textwrap.dedent("""\
+        def test_example():
+            result = [1, 2, 3]
+            assert (
+                len(result)
+                >= 2
+            )
+    """)
+    violations = _violations_in_source(source)
+    assert len(violations) == 1
+
+
+def test_inline_assert_gte_is_caught() -> None:
+    source = textwrap.dedent("""\
+        def test_example():
+            count = 5
+            assert count >= 1
+    """)
+    violations = _violations_in_source(source)
+    assert len(violations) == 1
+
+
+def test_inline_assert_gt_zero_is_caught() -> None:
+    source = textwrap.dedent("""\
+        def test_example():
+            count = 5
+            assert count > 0
+    """)
+    violations = _violations_in_source(source)
+    assert len(violations) == 1
+
+
+def test_len_gte_is_caught() -> None:
+    source = textwrap.dedent("""\
+        def test_example():
+            items = [1, 2, 3]
+            assert len(items) >= 1
+    """)
+    violations = _violations_in_source(source)
+    assert len(violations) == 1
+
+
+def test_exemption_marker_on_same_line_exempts() -> None:
+    """# ratchet: nondeterministic on the assert line should suppress it."""
+    source = textwrap.dedent("""\
+        def test_example():
+            count = 5
+            assert count >= 1  # ratchet: nondeterministic timing-sensitive
+    """)
+    violations = _violations_in_source(source)
+    assert len(violations) == 0
+
+
+def test_exemption_marker_on_closing_paren_of_multiline_exempts() -> None:
+    """Marker on the closing line of a multiline assert should also exempt."""
+    source = textwrap.dedent("""\
+        def test_example():
+            result = [1, 2, 3]
+            assert (
+                len(result)
+                >= 2
+            )  # ratchet: nondeterministic depends on platform
+    """)
+    violations = _violations_in_source(source)
+    assert len(violations) == 0
+
+
+def test_exact_equality_assert_not_flagged() -> None:
+    """assert x == N is an exact assertion — must never be flagged."""
+    source = textwrap.dedent("""\
+        def test_example():
+            count = 5
+            assert count == 5
+    """)
+    violations = _violations_in_source(source)
+    assert len(violations) == 0
+
+
+def test_string_literal_gte_not_flagged() -> None:
+    """A '>=' inside a string literal is not a loose comparison."""
+    source = textwrap.dedent("""\
+        def test_example():
+            assert "requires >= 3.10" in "requires >= 3.10"
+    """)
+    violations = _violations_in_source(source)
+    assert len(violations) == 0
+
+
+def test_clean_file_returns_no_violations(tmp_path: Path) -> None:
+    clean = tmp_path / "test_clean.py"
+    clean.write_text(
+        textwrap.dedent("""\
+            def test_exact():
+                assert 1 + 1 == 2
+
+            def test_negative():
+                assert not False
+        """),
+        encoding="utf-8",
+    )
+    assert _checker.check_file(clean) == []
+
+
+def test_baseline_counter_counts_violations(tmp_path: Path) -> None:
+    """count_baseline should return the exact number of loose asserts."""
+    # Two files, three violations total (one file has 2, other has 1)
+    (tmp_path / "test_a.py").write_text(
+        textwrap.dedent("""\
+            def test_one():
+                assert x >= 1
+
+            def test_two():
+                assert y > 0
+        """),
+        encoding="utf-8",
+    )
+    (tmp_path / "test_b.py").write_text(
+        textwrap.dedent("""\
+            def test_three():
+                assert len(z) >= 3
+        """),
+        encoding="utf-8",
+    )
+    assert _checker.count_baseline(tmp_path) == 3
+
+
+def test_property_file_skipped_in_baseline(tmp_path: Path) -> None:
+    """Files matching *propert* (case-insensitive) should be skipped."""
+    (tmp_path / "test_property_something.py").write_text(
+        textwrap.dedent("""\
+            def test_prop():
+                assert x >= 1
+        """),
+        encoding="utf-8",
+    )
+    assert _checker.count_baseline(tmp_path) == 0
+
+
+def test_multiple_violations_in_one_file() -> None:
+    source = textwrap.dedent("""\
+        def test_a():
+            assert count >= 1
+
+        def test_b():
+            assert result > 0
+
+        def test_c():
+            assert len(items) >= 2
+    """)
+    violations = _violations_in_source(source)
+    assert len(violations) == 3


### PR DESCRIPTION
Closes the ratchet-blindspot tech-debt issue (multiline assert evasion found during #558).

## What changed

`check_loose_assertions.sh` → 4-line wrapper over a new Python AST checker (same CLI contract: diff-scoped, baseline mode, exit codes, exemption marker — the workflow step is byte-identical). Assert nodes' test expressions are inspected for GtE/Gt against int literals; the `# ratchet: nondeterministic` marker now works ANYWHERE within the assert's source segment (the batch-11 marker-placement dance is over).

## Baseline conscious re-pin: 1180 (grep) → 1083 (AST), methodology note in the file

AST catches ~multiline evaders the grep missed, AND drops grep's false skips (asserts with `==` elsewhere on the line were skipped wholesale; version-spec strings excluded naturally). Net −97.

## Verification

- 12 RED→GREEN self-tests (multiline caught, closing-paren marker exempts, ==/string not flagged, property-file skip, exact counter)
- Clean-tree run vs origin/develop: exit 0 (pasted); synthetic bad diff: exit 1 with the finding (pasted)
- Workflow untouched