### PR TITLE
fix(ratchet): scope loose-assertion gate to added diff lines; include renames

### DIFF
--- a/scripts/check_loose_assertions.py
+++ b/scripts/check_loose_assertions.py
@@ -60,6 +60,7 @@ class Violation(NamedTuple):
     path: str
     lineno: int
     snippet: str
+    end_lineno: int = 0
 
 
 # ---------------------------------------------------------------------------
@@ -169,7 +170,7 @@ def check_file(path: Path) -> list[Violation]:
 
         # Build a short snippet (first line of the assert)
         snippet = source_lines[node.lineno - 1].strip() if source_lines else ""
-        violations.append(Violation(str(path), node.lineno, snippet))
+        violations.append(Violation(str(path), node.lineno, snippet, end))
 
     return violations
 
@@ -179,15 +180,23 @@ def check_file(path: Path) -> list[Violation]:
 # ---------------------------------------------------------------------------
 
 
-def _changed_test_files(base_ref: str) -> list[Path]:
-    """Return changed/added test files (.py) vs *base_ref* from the diff."""
+def _added_line_ranges(base_ref: str) -> dict[str, set[int]]:
+    """Map changed test file (new path) → set of ADDED line numbers.
+
+    Parses ``git diff -U0`` hunk headers so the ratchet can scope violations
+    to lines the PR actually added (Codex P1 on #586: scanning whole changed
+    files re-flagged the 1000+ pre-existing baseline asserts on any touch).
+    ``--diff-filter=AMR`` includes renamed files — additions inside a rename
+    must not evade the gate (Codex P2 on #586); ``+++ b/`` carries the new
+    path for renames.
+    """
     result = subprocess.run(
         [
             "git",
             "diff",
             f"{base_ref}..HEAD",
-            "--name-only",
-            "--diff-filter=AM",
+            "--unified=0",
+            "--diff-filter=AMR",
             "--",
             "tests",
         ],
@@ -195,14 +204,21 @@ def _changed_test_files(base_ref: str) -> list[Path]:
         text=True,
         check=False,
     )
-    paths = []
+    added: dict[str, set[int]] = {}
+    current: str | None = None
     for line in result.stdout.splitlines():
-        p = Path(line.strip())
-        if p.suffix == ".py" and p.exists():
-            # Skip hypothesis property test files (same whitelist as .sh)
-            if not PROPERTY_FILE_RE.search(p.name):
-                paths.append(p)
-    return paths
+        if line.startswith("+++ b/"):
+            current = line[6:]
+            added.setdefault(current, set())
+        elif line.startswith("+++ "):
+            current = None  # /dev/null (deletion) or unexpected form
+        elif line.startswith("@@") and current is not None:
+            m = re.search(r"\+(\d+)(?:,(\d+))?", line)
+            if m:
+                start = int(m.group(1))
+                count = int(m.group(2)) if m.group(2) is not None else 1
+                added[current].update(range(start, start + count))
+    return added
 
 
 # ---------------------------------------------------------------------------
@@ -211,11 +227,27 @@ def _changed_test_files(base_ref: str) -> list[Path]:
 
 
 def check_diff(base_ref: str) -> int:
-    """Run diff-scoped check.  Returns exit code (0 = OK, 1 = violations)."""
-    files = _changed_test_files(base_ref)
+    """Run diff-scoped check.  Returns exit code (0 = OK, 1 = violations).
+
+    A violation counts only when its assert source segment overlaps a line
+    the PR added — pre-existing loose asserts elsewhere in a touched file
+    stay the baseline's problem, not this PR's.
+    """
+    added = _added_line_ranges(base_ref)
     all_violations: list[Violation] = []
-    for f in files:
-        all_violations.extend(check_file(f))
+    for fname, added_lines in added.items():
+        if not added_lines:
+            continue
+        path = Path(fname)
+        if path.suffix != ".py" or not path.exists():
+            continue
+        # Skip hypothesis property test files (same whitelist as .sh)
+        if PROPERTY_FILE_RE.search(path.name):
+            continue
+        for v in check_file(path):
+            end = v.end_lineno or v.lineno
+            if added_lines.intersection(range(v.lineno, end + 1)):
+                all_violations.append(v)
 
     if not all_violations:
         return 0

--- a/tests/unit/test_check_loose_assertions.py
+++ b/tests/unit/test_check_loose_assertions.py
@@ -220,3 +220,124 @@ def test_multiple_violations_in_one_file() -> None:
     """)
     violations = _violations_in_source(source)
     assert len(violations) == 3
+
+
+# ---------------------------------------------------------------------------
+# Diff-scoped mode (Codex P1/P2 on #586)
+# ---------------------------------------------------------------------------
+
+
+def _git(repo: Path, *args: str) -> str:
+    import subprocess
+
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    (repo / "tests").mkdir(parents=True)
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "t")
+    return repo
+
+
+def test_preexisting_loose_assert_not_flagged_on_unrelated_edit(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Codex P1: touching a file must not re-flag its baseline asserts."""
+    repo = _make_repo(tmp_path)
+    f = repo / "tests" / "test_sample.py"
+    f.write_text(
+        "def test_old():\n    assert len([1]) >= 0\n\n\ndef test_other():\n    assert 1 == 1\n",
+        newline="\n",
+    )
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "base")
+    base = _git(repo, "rev-parse", "HEAD")
+
+    # Unrelated edit: change the exact assert only
+    f.write_text(
+        "def test_old():\n    assert len([1]) >= 0\n\n\ndef test_other():\n    assert 2 == 2\n",
+        newline="\n",
+    )
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "unrelated edit")
+
+    monkeypatch.chdir(repo)
+    assert _checker.check_diff(base) == 0
+
+
+def test_added_loose_assert_is_flagged(tmp_path: Path, monkeypatch) -> None:
+    repo = _make_repo(tmp_path)
+    f = repo / "tests" / "test_sample.py"
+    f.write_text("def test_a():\n    assert 1 == 1\n", newline="\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "base")
+    base = _git(repo, "rev-parse", "HEAD")
+
+    f.write_text(
+        "def test_a():\n    assert 1 == 1\n\n\ndef test_new():\n    assert len([1]) >= 1\n",
+        newline="\n",
+    )
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "adds loose assert")
+
+    monkeypatch.chdir(repo)
+    assert _checker.check_diff(base) == 1
+
+
+def test_renamed_file_with_added_loose_assert_is_flagged(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Codex P2: --diff-filter must include renames (new path scanned)."""
+    repo = _make_repo(tmp_path)
+    f = repo / "tests" / "test_old_name.py"
+    f.write_text("def test_a():\n    assert 1 == 1\n", newline="\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "base")
+    base = _git(repo, "rev-parse", "HEAD")
+
+    _git(repo, "mv", "tests/test_old_name.py", "tests/test_new_name.py")
+    new = repo / "tests" / "test_new_name.py"
+    new.write_text(
+        "def test_a():\n    assert 1 == 1\n\n\ndef test_new():\n    assert len([1]) > 0\n",
+        newline="\n",
+    )
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "rename + loose assert")
+
+    monkeypatch.chdir(repo)
+    assert _checker.check_diff(base) == 1
+
+
+def test_multiline_assert_partially_touched_is_flagged(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Editing any line of an existing multiline loose assert re-flags it —
+    touching a loose assert means fixing it."""
+    repo = _make_repo(tmp_path)
+    f = repo / "tests" / "test_sample.py"
+    f.write_text(
+        "def test_a():\n    assert (\n        len([1]) >= 1\n    )\n",
+        newline="\n",
+    )
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "base")
+    base = _git(repo, "rev-parse", "HEAD")
+
+    f.write_text(
+        "def test_a():\n    assert (\n        len([1, 2]) >= 1\n    )\n",
+        newline="\n",
+    )
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "edits inside the loose assert")
+
+    monkeypatch.chdir(repo)
+    assert _checker.check_diff(base) == 1


### PR DESCRIPTION
## Summary

Follow-up to the Codex review on #586 (both findings verified live before fixing):

- **P1 (live-confirmed on #585)**: `check_diff` scanned entire changed files, so a one-line re-pin in `test_kotlin_plugin.py` re-flagged an unrelated pre-existing baseline assert and failed CI. Violations now count only when the assert's source segment (`lineno..end_lineno`) overlaps a line the PR actually added (parsed from `git diff -U0` hunk headers).
- **P2**: `--diff-filter=AM` omitted renamed files — a rename+edit could smuggle a loose assertion past the gate. Now `AMR`; `+++ b/` carries the new path for renames.

Deliberate behavior: editing any line *inside* an existing multiline loose assert still flags it — touching a loose assert means fixing it.

## Test plan
- [x] 4 new git-fixture self-tests: unrelated-edit passes (P1), added assert flagged, rename+add flagged (P2), multiline partial-touch flagged
- [x] 16/16 self-tests green (`-n 0`)
- [x] Live sanity: checker exit=0 on this branch vs origin/develop; ruff + mypy clean