### PR TITLE
test: ratchet batch-14 — pin 56 loose assertions in top-4 AST-ranked files

### DIFF
--- a/scripts/loose_assertion_baseline.txt
+++ b/scripts/loose_assertion_baseline.txt
@@ -24,7 +24,12 @@
 # The AST count is the authoritative baseline going forward.
 # The count must only decrease (or stay equal). Each Layer-2 batch PR
 # re-measures and lowers it. Numbers are MEASURED, never hand-derived.
+#
+# History:
+#   batch-14 (AST): 1083 -> 1026, 2026-06-12 (56 pins in top-4 AST-ranked
+#   files; pre-batch measure on base ca8e9927 was 1082 — develop had
+#   already dropped 1 since the 1083 recording).
 
-BASELINE_COUNT=1083
+BASELINE_COUNT=1026
 MEASUREMENT_DATE=2026-06-12
 MEASUREMENT_COMMAND="uv run python scripts/check_loose_assertions.py --baseline"

--- a/tests/integration/mcp/test_user_story_2_integration.py
+++ b/tests/integration/mcp/test_user_story_2_integration.py
@@ -40,6 +40,7 @@ class TestUserStory2Integration:
             (project_root / "config").mkdir()
 
             # Python ファイル
+            # newline="\n" pins byte lengths cross-platform (content_length asserts)
             (project_root / "src" / "main.py").write_text(
                 """#!/usr/bin/env python3
 \"\"\"
@@ -98,7 +99,8 @@ def main():
 
 if __name__ == "__main__":
     main()
-"""
+""",
+                newline="\n",
             )
 
             # JavaScript ファイル
@@ -167,7 +169,8 @@ class FileManager {
 }
 
 module.exports = { FileManager };
-"""
+""",
+                newline="\n",
             )
 
             # テストファイル
@@ -242,7 +245,8 @@ class TestDataProcessor:
         assert len(saved_data) == 1
         assert saved_data[0]["id"] == 1
 
-"""
+""",
+                newline="\n",
             )
 
             # 設定ファイル
@@ -269,7 +273,8 @@ class TestDataProcessor:
     "file": "app.log",
     "max_size": "10MB"
   }
-}"""
+}""",
+                newline="\n",
             )
 
             # README ファイル
@@ -337,7 +342,8 @@ python -m pytest tests/
 - [ ] Create web interface
 - [ ] Add performance monitoring
 - [ ] Implement data validation
-"""
+""",
+                newline="\n",
             )
 
             # .gitignore ファイル
@@ -388,7 +394,8 @@ logs/
 *.tmp
 *.temp
 temp/
-"""
+""",
+                newline="\n",
             )
 
             yield str(project_root)
@@ -445,7 +452,7 @@ temp/
         assert "file_path" in result
         assert "partial_content_result" in result
         # JSON形式では構造化されたデータが返される
-        assert result["content_length"] > 0
+        assert result["content_length"] == 258
 
     @pytest.mark.asyncio
     async def test_list_files_basic_search(self, list_files_tool):
@@ -456,7 +463,7 @@ temp/
         )
 
         assert result["success"] is True
-        assert result["count"] >= 2  # main.py, test_main.py
+        assert result["count"] == 2  # main.py, test_main.py
 
         # Python ファイルのみが含まれることを確認
         for file_info in result["results"]:
@@ -478,7 +485,7 @@ temp/
         )
 
         assert result["success"] is True
-        assert result["count"] >= 3  # main.py, utils.js, test_main.py
+        assert result["count"] == 3  # main.py, utils.js, test_main.py
 
         # 指定された拡張子のみが含まれることを確認
         for file_info in result["results"]:
@@ -495,7 +502,9 @@ temp/
         assert result["success"] is True
         assert result["count_only"] is True
         assert "total_count" in result
-        assert result["total_count"] >= 5  # 複数ファイルが存在
+        assert (
+            result["total_count"] == 9
+        )  # 6 ファイル + src/tests/docs/config 以下のエントリ
 
     @pytest.mark.asyncio
     async def test_search_content_basic(self, search_tool):
@@ -506,7 +515,7 @@ temp/
         )
 
         assert result["success"] is True
-        assert result["count"] >= 2  # DataProcessor, FileManager
+        assert result["count"] == 2  # DataProcessor, FileManager
 
         # 検索結果の構造確認
         for match in result["results"]:
@@ -529,7 +538,9 @@ temp/
         )
 
         assert result["success"] is True
-        assert result["count"] >= 5  # 複数のメソッド定義
+        assert (
+            result["count"] == 5
+        )  # __init__, load_data, process_data, save_results, main
 
         # 正規表現マッチの確認
         for match in result["results"]:
@@ -547,7 +558,7 @@ temp/
         assert result["count_only"] is True
         assert "total_matches" in result
         assert "file_counts" in result
-        assert result["total_matches"] >= 1  # README.mdにTODOが存在
+        assert result["total_matches"] == 2  # src/main.py と README.md に1件ずつ
 
     @pytest.mark.asyncio
     async def test_search_content_total_only(self, search_tool):
@@ -558,7 +569,7 @@ temp/
 
         # total_onlyモードでは数値のみが返される
         assert isinstance(result, int)
-        assert result >= 2  # 複数のimport文が存在
+        assert result == 3  # import os / import sys / from typing import
 
     @pytest.mark.asyncio
     async def test_workflow_file_discovery_and_analysis(
@@ -578,7 +589,7 @@ temp/
 
         assert files_result["success"] is True
         python_files = [f["path"] for f in files_result["results"]]
-        assert len(python_files) >= 1
+        assert len(python_files) == 1  # src/main.py
 
         # Step 2: クラス定義を検索 (use JSON output_format for test assertions)
         search_result = await search_tool.execute(
@@ -586,7 +597,7 @@ temp/
         )
 
         assert search_result["success"] is True
-        assert search_result["count"] >= 1
+        assert search_result["count"] == 1  # class DataProcessor
 
         # Step 3: 見つかったクラスの詳細を抽出
         class_match = search_result["results"][0]
@@ -622,7 +633,7 @@ temp/
         )
 
         assert todo_result["success"] is True
-        assert todo_result["count"] >= 1
+        assert todo_result["count"] == 2  # src/main.py と README.md
 
         # Step 2: TODO周辺のコードを詳細抽出
         for match in todo_result["results"][:2]:  # 最初の2つのTODOを分析
@@ -660,7 +671,7 @@ temp/
         )
 
         assert config_files["success"] is True
-        assert config_files["count"] >= 1
+        assert config_files["count"] == 1  # settings.json
 
         # Step 2: 設定値を検索
         for config_file in config_files["results"]:
@@ -764,7 +775,7 @@ temp/
         )
 
         assert search_result["success"] is True
-        assert search_result["count"] >= 1
+        assert search_result["count"] == 2  # DataProcessor, FileManager
 
         # ファイル出力機能が動作することを確認
         assert "output_file" in search_result
@@ -790,7 +801,7 @@ temp/
         # ファイル出力機能が正常に動作することを確認
         # suppress_outputが有効な場合、ファイルに保存され、file_savedがTrueになる
         assert extract_result["file_saved"] is True
-        assert extract_result["content_length"] > 0
+        assert extract_result["content_length"] == 420
 
 
 if __name__ == "__main__":

--- a/tests/unit/core/test_queries_javascript_enhanced.py
+++ b/tests/unit/core/test_queries_javascript_enhanced.py
@@ -27,7 +27,7 @@ class TestEnhancedJavaScriptQueries:
     def test_javascript_queries_structure(self) -> None:
         """Test JAVASCRIPT_QUERIES dictionary structure"""
         assert isinstance(JAVASCRIPT_QUERIES, dict)
-        assert len(JAVASCRIPT_QUERIES) > 50  # Should have many queries now
+        assert len(JAVASCRIPT_QUERIES) == 78
 
         # Test essential modern JavaScript queries exist
         essential_queries = [
@@ -58,20 +58,24 @@ class TestEnhancedJavaScriptQueries:
         for query_name in essential_queries:
             assert query_name in JAVASCRIPT_QUERIES
             assert isinstance(JAVASCRIPT_QUERIES[query_name], str)
-            assert len(JAVASCRIPT_QUERIES[query_name].strip()) > 0
+        # Shortest essential query body, measured exactly (non-empty invariant)
+        assert min(len(JAVASCRIPT_QUERIES[q].strip()) for q in essential_queries) == 26
 
     def test_javascript_query_descriptions(self) -> None:
         """Test JAVASCRIPT_QUERY_DESCRIPTIONS dictionary"""
         assert isinstance(JAVASCRIPT_QUERY_DESCRIPTIONS, dict)
-        assert len(JAVASCRIPT_QUERY_DESCRIPTIONS) > 50
+        assert len(JAVASCRIPT_QUERY_DESCRIPTIONS) == 78
 
         # Test that all queries have descriptions
         for query_name in JAVASCRIPT_QUERIES:
             assert query_name in JAVASCRIPT_QUERY_DESCRIPTIONS
             description = JAVASCRIPT_QUERY_DESCRIPTIONS[query_name]
             assert isinstance(description, str)
-            assert len(description) > 0
             assert "search" in description.lower()
+        # Shortest description, measured exactly (non-empty invariant)
+        assert (
+            min(len(JAVASCRIPT_QUERY_DESCRIPTIONS[q]) for q in JAVASCRIPT_QUERIES) == 15
+        )
 
     def test_get_javascript_query_valid(self) -> None:
         """Test getting valid JavaScript queries"""
@@ -103,7 +107,7 @@ class TestEnhancedJavaScriptQueries:
         """Test getting valid query descriptions"""
         desc = get_javascript_query_description("function")
         assert isinstance(desc, str)
-        assert len(desc) > 0
+        assert desc == "Search JavaScript function declarations"
 
         desc = get_javascript_query_description("async_function")
         assert "async" in desc.lower()
@@ -117,7 +121,7 @@ class TestEnhancedJavaScriptQueries:
         """Test getting list of available JavaScript queries"""
         queries = get_available_javascript_queries()
         assert isinstance(queries, list)
-        assert len(queries) > 50
+        assert len(queries) == 78
 
         # Test essential queries are included
         essential = [
@@ -133,7 +137,7 @@ class TestEnhancedJavaScriptQueries:
     def test_all_queries_integration(self) -> None:
         """Test ALL_QUERIES integration with enhanced queries"""
         assert isinstance(ALL_QUERIES, dict)
-        assert len(ALL_QUERIES) > 60  # Should include both new and legacy queries
+        assert len(ALL_QUERIES) == 87  # 78 enhanced + 9 legacy-only
 
         # Test new queries are included
         new_queries = [
@@ -157,7 +161,8 @@ class TestEnhancedJavaScriptQueries:
             assert "query" in query_data
             assert "description" in query_data
             assert isinstance(query_data["query"], str)
-            assert len(query_data["query"]) > 0
+        # Shortest legacy query body, measured exactly (non-empty invariant)
+        assert min(len(ALL_QUERIES[q]["query"]) for q in legacy_queries) == 150
 
     def test_function_queries_comprehensive(self) -> None:
         """Test comprehensive function query coverage"""
@@ -273,8 +278,8 @@ class TestEnhancedJavaScriptQueries:
 
         for query_name in modern_queries:
             assert query_name in JAVASCRIPT_QUERIES
-            query = JAVASCRIPT_QUERIES[query_name]
-            assert len(query.strip()) > 0
+        # Shortest modern query body, measured exactly (non-empty invariant)
+        assert min(len(JAVASCRIPT_QUERIES[q].strip()) for q in modern_queries) == 32
 
     def test_jsx_queries(self) -> None:
         """Test JSX-related queries"""
@@ -301,8 +306,8 @@ class TestEnhancedJavaScriptQueries:
 
         for query_name in framework_queries:
             assert query_name in JAVASCRIPT_QUERIES
-            query = JAVASCRIPT_QUERIES[query_name]
-            assert len(query.strip()) > 0
+        # Shortest framework query body, measured exactly (non-empty invariant)
+        assert min(len(JAVASCRIPT_QUERIES[q].strip()) for q in framework_queries) == 112
 
     def test_control_flow_queries(self) -> None:
         """Test control flow queries"""
@@ -383,8 +388,8 @@ class TestEnhancedJavaScriptQueries:
 
         for query_name in advanced_queries:
             assert query_name in JAVASCRIPT_QUERIES
-            query = JAVASCRIPT_QUERIES[query_name]
-            assert len(query.strip()) > 0
+        # Shortest advanced query body, measured exactly (non-empty invariant)
+        assert min(len(JAVASCRIPT_QUERIES[q].strip()) for q in advanced_queries) == 78
 
     def test_name_extraction_queries(self) -> None:
         """Test name-only extraction queries"""
@@ -398,6 +403,9 @@ class TestEnhancedJavaScriptQueries:
 
     def test_query_consistency_with_descriptions(self) -> None:
         """Test consistency between queries and descriptions"""
+        # Shortest query/description across the whole library, measured exactly
+        assert min(len(q.strip()) for q in JAVASCRIPT_QUERIES.values()) == 16
+        assert min(len(d.strip()) for d in JAVASCRIPT_QUERY_DESCRIPTIONS.values()) == 15
         for query_name in JAVASCRIPT_QUERIES:
             assert query_name in JAVASCRIPT_QUERY_DESCRIPTIONS
 
@@ -407,8 +415,6 @@ class TestEnhancedJavaScriptQueries:
             # Basic consistency checks
             assert isinstance(query, str)
             assert isinstance(description, str)
-            assert len(query.strip()) > 0
-            assert len(description.strip()) > 0
 
             # Description should be relevant to query name
             if "function" in query_name:
@@ -446,8 +452,9 @@ class TestEnhancedJavaScriptQueries:
         for query_name in modern_queries:
             query = get_query(query_name)
             assert isinstance(query, str)
-            assert len(query) > 0
             assert query == JAVASCRIPT_QUERIES[query_name]
+        # Shortest of the three, measured exactly (non-empty invariant)
+        assert min(len(get_query(q)) for q in modern_queries) == 118
 
     def test_list_queries_includes_all(self) -> None:
         """Test that list_queries includes all available queries"""

--- a/tests/unit/test_project_graph.py
+++ b/tests/unit/test_project_graph.py
@@ -44,8 +44,8 @@ class TestImportExtraction:
         # We expect at least: utils, models.user, models.base, pkg.submodule
         # (os, sys, pathlib are stdlib/external)
         found_internal = {r for r in resolved if "." in r or "/" in r}
-        assert len(found_internal) >= 3, (
-            f"Expected >=3 internal imports, got {found_internal}"
+        assert len(found_internal) == 4, (
+            f"Expected exactly 4 internal imports, got {found_internal}"
         )
 
     def test_extract_python_imports_from_utils(self):
@@ -157,26 +157,32 @@ class TestDependencyGraph:
     def test_build_python_graph(self, py_graph):
         """Graph should contain all .py files in the project."""
         nodes = py_graph.nodes()
-        assert len(nodes) > 0, "Graph should have nodes"
-        # Should include main.py, utils.py, models/__init__.py, models/base.py, models/user.py, pkg/submodule.py
-        assert len(nodes) >= 4, f"Expected >=4 nodes, got {len(nodes)}: {nodes}"
+        # main.py, utils.py, models/__init__.py, models/base.py,
+        # models/user.py, pkg/__init__.py, pkg/submodule.py
+        assert len(nodes) == 7, f"Expected 7 nodes, got {len(nodes)}: {nodes}"
 
     def test_build_js_graph(self, js_graph):
         """Graph should contain JS files."""
         nodes = js_graph.nodes()
-        assert len(nodes) >= 2, f"Expected >=2 nodes, got {len(nodes)}"
+        # index.js, src/base.js, src/formatter.js, src/models/user.js, src/utils.js
+        assert len(nodes) == 5, f"Expected 5 nodes, got {len(nodes)}: {nodes}"
 
     def test_get_dependencies_of_file(self, py_graph):
         """Query what a specific file depends on."""
         deps = py_graph.dependencies_of("main.py")
-        assert len(deps) > 0, f"main.py should depend on other files, got {deps}"
+        assert deps == [
+            "models/__init__.py",
+            "models/user.py",
+            "pkg/__init__.py",
+            "utils.py",
+        ], f"main.py dependencies changed: {deps}"
 
     def test_get_dependents_of_file(self, py_graph):
         """Query what files depend on a specific file."""
         # utils.py is imported by main.py
         dependents = py_graph.dependents_of("utils.py")
-        assert len(dependents) >= 1, (
-            f"utils.py should have dependents, got {dependents}"
+        assert dependents == ["main.py"], (
+            f"utils.py should be imported by main.py only, got {dependents}"
         )
 
     def test_leaf_file_has_no_dependents(self, py_graph):
@@ -357,7 +363,7 @@ class TestSymbolInDegree:
             assert key in result, f"existing key {key} dropped from to_dict()"
         # New additive key is present and non-negative.
         assert "symbol_index_size" in result
-        assert result["symbol_index_size"] >= 0
+        assert result["symbol_index_size"] == 9
 
     def test_G3_find_cycles_unchanged(self, py_graph):
         # PY_PROJECT has an intentional cycle (used by TestCycleDetection).
@@ -403,8 +409,8 @@ class TestCycleDetection:
     def test_detect_cycles(self, py_graph):
         """Should detect the cycle between main.py and pkg/submodule.py."""
         cycles = py_graph.find_cycles()
-        # submodule.py imports from main.py, and main.py imports from submodule.py
-        assert len(cycles) > 0, f"Expected cycles in {PY_PROJECT}, got none"
+        # models/base.py participates in the fixture's intentional cycle
+        assert len(cycles) == 1, f"Expected 1 cycle in {PY_PROJECT}, got {cycles}"
 
 
 # ============================================================
@@ -431,19 +437,27 @@ class TestBlastRadius:
         """Changing a leaf file → impact propagates to its dependents."""
         # Changing models/base.py should affect user.py and main.py
         impacted = radius.forward("models/base.py")
-        assert len(impacted) >= 2, f"Expected >=2 impacted files, got {impacted}"
+        assert impacted == {"main.py", "models/user.py", "pkg/submodule.py"}, (
+            f"Expected 3 impacted files, got {impacted}"
+        )
 
     def test_blast_radius_reverse(self, radius):
         """To understand what influences a file → trace reverse dependencies."""
         # What does main.py depend on?
         dependencies = radius.reverse("main.py")
-        assert len(dependencies) > 0, f"Expected >0 reverse deps, got {dependencies}"
+        assert dependencies == {
+            "models/__init__.py",
+            "models/base.py",
+            "models/user.py",
+            "pkg/__init__.py",
+            "utils.py",
+        }, f"Expected 5 reverse deps, got {dependencies}"
 
     def test_blast_radius_leaf_file_forward(self, radius):
         """Changing utils.py (no internal deps, imported by main) → only main is impacted."""
         impacted = radius.forward("utils.py")
-        assert len(impacted) >= 1, (
-            f"utils.py change should impact at least main.py, got {impacted}"
+        assert impacted == {"main.py", "pkg/submodule.py"}, (
+            f"utils.py change should impact main.py and pkg/submodule.py, got {impacted}"
         )
 
     def test_blast_radius_nonexistent_file(self, radius):
@@ -543,7 +557,7 @@ class TestDependencyGraphPublicAPI:
         for v in deps.values():
             v.clear()
         # Graph's internal state should be unaffected
-        assert any(len(v) > 0 for v in tiny.all_deps().values()), (
+        assert tiny.all_deps() == {"a.py": {"b.py"}, "b.py": {"c.py"}}, (
             "all_deps() must return independent copies, not shared references"
         )
 
@@ -576,7 +590,7 @@ class TestDependencyGraphPublicAccessors:
     def test_has_node_true_for_existing_node(self, small_graph):
         """has_node() returns True for a file that is in the graph."""
         nodes = small_graph.nodes()
-        assert len(nodes) >= 1
+        assert len(nodes) == 2  # a.py, b.py
         assert small_graph.has_node(nodes[0]) is True
 
     def test_has_node_false_for_missing_node(self, small_graph):
@@ -593,7 +607,7 @@ class TestDependencyGraphPublicAccessors:
 
     def test_node_count_nonzero(self, small_graph):
         """A non-empty project has at least one node."""
-        assert small_graph.node_count() >= 1
+        assert small_graph.node_count() == 2  # a.py, b.py
 
 
 # ============================================================

--- a/tests/unit/test_symbol_resolver.py
+++ b/tests/unit/test_symbol_resolver.py
@@ -58,7 +58,7 @@ class TestSymbolResolverEngine:
         cache = ASTCache(str(indexed_project))
         resolver = SymbolResolver(cache)
         result = resolver.resolve("handle_request")
-        assert len(result.definitions) >= 1
+        assert len(result.definitions) == 1
         assert result.definitions[0].name == "handle_request"
         assert result.definitions[0].kind == "function"
         assert "app.py" in result.definitions[0].file
@@ -68,7 +68,7 @@ class TestSymbolResolverEngine:
         cache = ASTCache(str(indexed_project))
         resolver = SymbolResolver(cache)
         result = resolver.resolve("UserService")
-        assert len(result.definitions) >= 1
+        assert len(result.definitions) == 1
         assert result.definitions[0].name == "UserService"
         assert result.definitions[0].kind == "class"
         cache.close()
@@ -77,7 +77,7 @@ class TestSymbolResolverEngine:
         cache = ASTCache(str(indexed_project))
         resolver = SymbolResolver(cache)
         result = resolver.resolve("get_user")
-        assert len(result.definitions) >= 1
+        assert len(result.definitions) == 1
         assert result.definitions[0].name == "get_user"
         cache.close()
 
@@ -114,7 +114,7 @@ class TestSymbolResolverEngine:
         cache = Cache()
         resolver = SymbolResolver(cache)
         result = resolver.resolve("APP_NAME")
-        assert len(result.definitions) >= 1
+        assert len(result.definitions) == 1
         assert result.definitions[0].name == "APP_NAME"
         assert result.definitions[0].kind == "variable"
 
@@ -131,8 +131,8 @@ class TestSymbolResolverEngine:
         result = resolver.resolve("UserService")
         d = result.to_dict()
         assert d["symbol"] == "UserService"
-        assert d["definition_count"] >= 1
-        assert len(d["definitions"]) >= 1
+        assert d["definition_count"] == 1
+        assert len(d["definitions"]) == 1
         assert "file" in d["definitions"][0]
         cache.close()
 
@@ -140,8 +140,8 @@ class TestSymbolResolverEngine:
         cache = ASTCache(str(indexed_project))
         resolver = SymbolResolver(cache)
         result = resolver.find_references("get_user")
-        assert len(result.definitions) >= 1
-        assert len(result.references) >= 0
+        assert len(result.definitions) == 1
+        assert len(result.references) == 1
         d = result.to_dict()
         assert d["symbol"] == "get_user"
         assert "reference_count" in d
@@ -151,7 +151,7 @@ class TestSymbolResolverEngine:
         cache = ASTCache(str(indexed_project))
         resolver = SymbolResolver(cache)
         result = resolver.resolve("UserService.get_user")
-        assert len(result.definitions) >= 1
+        assert len(result.definitions) == 1
         assert result.definitions[0].name == "get_user"
         cache.close()
 
@@ -231,8 +231,8 @@ class TestCodeGraphSymbolResolveExecution:
         )
         assert result["success"] is True
         assert result["symbol"] == "UserService"
-        assert result["definition_count"] >= 1
-        assert len(result["definitions"]) >= 1
+        assert result["definition_count"] == 1
+        assert len(result["definitions"]) == 1
         assert "file" in result["definitions"][0]
 
     async def test_references_mode(self, indexed_project):
@@ -241,8 +241,8 @@ class TestCodeGraphSymbolResolveExecution:
             {"symbol": "get_user", "mode": "references", "output_format": "json"}
         )
         assert result["success"] is True
-        assert result["definition_count"] >= 1
-        assert "reference_count" in result
+        assert result["definition_count"] == 1
+        assert result["reference_count"] == 1
         assert "references" in result
 
     async def test_nonexistent_symbol(self, indexed_project):
@@ -271,7 +271,7 @@ class TestCodeGraphSymbolResolveExecution:
         tool = CodeGraphSymbolResolveTool(str(indexed_project))
         result = await tool.execute({"symbol": "format_user", "output_format": "json"})
         assert result["success"] is True
-        assert result["definition_count"] >= 1
+        assert result["definition_count"] == 1
         defs = result["definitions"]
         assert any("utils.py" in d["file"] for d in defs)
 
@@ -279,6 +279,6 @@ class TestCodeGraphSymbolResolveExecution:
         tool = CodeGraphSymbolResolveTool(str(indexed_project))
         result = await tool.execute({"symbol": "User", "output_format": "json"})
         assert result["success"] is True
-        assert result["definition_count"] >= 1
+        assert result["definition_count"] == 1
         defs = result["definitions"]
         assert any("models.py" in d["file"] for d in defs)


### PR DESCRIPTION
## Summary
Loose-assertion ratchet batch 14 — first batch ranked by the new AST counter (#586). Top-4 files (14 violations each), every `>=`/`> N` pinned to the measured exact value:

| File | Pins |
|---|---|
| tests/unit/test_symbol_resolver.py | 14 |
| tests/unit/test_project_graph.py | 14 |
| tests/unit/core/test_queries_javascript_enhanced.py | 14 |
| tests/integration/mcp/test_user_story_2_integration.py | 14 |

Baseline: **1083 → 1026** (recorded; clean develop actually measures 1082 on this base — the 1-count drift is documented in the baseline history line, true batch delta = 56).

Contract 5b notes: no dead-branch mocks found; byte-count pins guarded with `write_text(..., newline="\n")` (6 fixtures); zero exemption markers; several pins upgraded to exact list/set equality.

## Test plan
- [x] All 4 files re-run individually `-n 0`: 22/51/27/15 passed
- [x] `check_file` per-file re-run: 0 violations each
- [x] `check_loose_assertions.py origin/develop` exit=0
- [x] `--baseline` measures 1026 == recorded (lead independently re-verified)