### PR TITLE
fix(kotlin): expression-body functions no longer claim Unit return

### DIFF
--- a/tests/golden_masters/compact/kotlin_sample_compact.md
+++ b/tests/golden_masters/compact/kotlin_sample_compact.md
@@ -21,5 +21,5 @@
 | fetchUserAsync | (1):Result<User> | pub | - | 37-40 | - |
 | display | (0):String | pub | - | 42-44 | - |
 | toTitleCase | (0):String | pub | - | 52-54 | - |
-| get | (0) | pub | - | 59-59 | - |
+| get | (0):String | pub | - | 59-59 | - |
 | main | (1) | pub | - | 62-65 | - |

--- a/tests/golden_masters/csv/kotlin_sample_csv.csv
+++ b/tests/golden_masters/csv/kotlin_sample_csv.csv
@@ -30,7 +30,7 @@ import java.util.Collections
 | fetchUserAsync | fun(id: Long): Result<User> | pub | 37-40 | - | - |
 | display | fun(): String | pub | 42-44 | - | - |
 | toTitleCase | fun(): String | pub | 52-54 | - | - |
-| get | fun() | pub | 59-59 | - | - |
+| get | fun(): String | pub | 59-59 | - | - |
 | main | fun(args: Array<String>) | pub | 62-65 | - | - |
 
 ## Properties

--- a/tests/golden_masters/full/kotlin_sample_full.md
+++ b/tests/golden_masters/full/kotlin_sample_full.md
@@ -30,7 +30,7 @@ import java.util.Collections
 | fetchUserAsync | fun(id: Long): Result<User> | pub | 37-40 | - | - |
 | display | fun(): String | pub | 42-44 | - | - |
 | toTitleCase | fun(): String | pub | 52-54 | - | - |
-| get | fun() | pub | 59-59 | - | - |
+| get | fun(): String | pub | 59-59 | - | - |
 | main | fun(args: Array<String>) | pub | 62-65 | - | - |
 
 ## Properties

--- a/tests/unit/languages/test_kotlin_expression_body_return.py
+++ b/tests/unit/languages/test_kotlin_expression_body_return.py
@@ -183,3 +183,11 @@ class LegacyUserManager {
 """
     )
     assert funcs["get"].return_type == "String"
+
+
+def test_expression_body_raw_string_is_string():
+    """Codex P2 on #593: multiline_string_literal ("raw strings") are the
+    same trivial String case as string_literal."""
+    source = "fun raw() = " + '"""' + "x" + '"""'
+    funcs = _functions(source)
+    assert funcs["raw"].return_type == "String"

--- a/tests/unit/languages/test_kotlin_expression_body_return.py
+++ b/tests/unit/languages/test_kotlin_expression_body_return.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Kotlin expression-body return types must not claim ``Unit`` (issue #591).
+
+``fun get(key: String) = "legacy"`` used to extract ``return_type="Unit"``.
+The expression body infers ``String``; claiming ``Unit`` is actively wrong.
+
+Minimum honest contract (full type inference is a NON-goal, per the
+honesty-over-fabrication precedent from #537):
+
+* explicit return type → use it (unchanged)
+* block body ``{ ... }`` with no explicit type → ``Unit`` (correct, kept)
+* expression body ``= <expr>`` with no explicit type:
+  - trivial literal → its pinned type (String / Int / Boolean / Double)
+  - anything else → ``""`` (empty = unknown; matches the Go plugin's
+    absent-return-type convention in ``_go_common_helpers.extract_return_type``)
+"""
+
+from __future__ import annotations
+
+import tree_sitter
+import tree_sitter_kotlin
+
+from tree_sitter_analyzer.languages.kotlin_helpers import extract_kotlin_function
+
+# ---------------------------------------------------------------------------
+# Helpers (same parse harness as test_kotlin_method_receiver.py)
+# ---------------------------------------------------------------------------
+
+
+def _build_language() -> tree_sitter.Language:
+    caps_or_lang = tree_sitter_kotlin.language()
+    if hasattr(caps_or_lang, "__class__") and "Language" in str(type(caps_or_lang)):
+        return caps_or_lang
+    return tree_sitter.Language(caps_or_lang)
+
+
+def _parse(source: str) -> tree_sitter.Tree:
+    lang = _build_language()
+    parser = tree_sitter.Parser()
+    if hasattr(parser, "set_language"):
+        parser.set_language(lang)
+    else:
+        parser = tree_sitter.Parser(lang)
+    return parser.parse(source.encode("utf-8"))
+
+
+def _functions(source: str) -> dict[str, object]:
+    """Return a name→Function dict parsed from *source*."""
+    tree = _parse(source)
+    results: dict[str, object] = {}
+    src_bytes = source.encode("utf-8")
+
+    def _node_text(n: tree_sitter.Node) -> str:
+        return src_bytes[n.start_byte : n.end_byte].decode("utf-8", errors="replace")
+
+    def _visit(node: tree_sitter.Node) -> None:
+        if node.type == "function_declaration":
+            func = extract_kotlin_function(node, _node_text, "")
+            if func:
+                results[func.name] = func
+        for child in node.children:
+            _visit(child)
+
+    _visit(tree.root_node)
+    return results
+
+
+_SRC = """\
+fun str() = "legacy"
+fun integer() = 42
+fun truthy() = true
+fun falsy() = false
+fun dbl() = 3.14
+fun call() = compute()
+fun longLit() = 42L
+fun nullLit() = null
+fun explicit(): String = "x"
+fun block() { println("hi") }
+fun blockTyped(): Int { return 1 }
+"""
+
+_FUNCS = _functions(_SRC)
+
+
+# ---------------------------------------------------------------------------
+# Expression body, trivial literal → pinned literal type
+# ---------------------------------------------------------------------------
+
+
+def test_expression_body_string_literal_is_string() -> None:
+    assert _FUNCS["str"].return_type == "String"
+
+
+def test_expression_body_integer_literal_is_int() -> None:
+    assert _FUNCS["integer"].return_type == "Int"
+
+
+def test_expression_body_true_is_boolean() -> None:
+    assert _FUNCS["truthy"].return_type == "Boolean"
+
+
+def test_expression_body_false_is_boolean() -> None:
+    assert _FUNCS["falsy"].return_type == "Boolean"
+
+
+def test_expression_body_float_literal_is_double() -> None:
+    assert _FUNCS["dbl"].return_type == "Double"
+
+
+# ---------------------------------------------------------------------------
+# Expression body, non-trivial → "" (unknown), never Unit
+# ---------------------------------------------------------------------------
+
+
+def test_expression_body_call_is_unknown_not_unit() -> None:
+    assert _FUNCS["call"].return_type == ""
+
+
+def test_expression_body_long_suffix_is_unknown() -> None:
+    # 42L is a number_literal but NOT an Int; honesty: emit unknown.
+    assert _FUNCS["longLit"].return_type == ""
+
+
+def test_expression_body_null_is_unknown() -> None:
+    assert _FUNCS["nullLit"].return_type == ""
+
+
+# ---------------------------------------------------------------------------
+# Unchanged behavior: explicit type and block body
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_return_type_unchanged() -> None:
+    assert _FUNCS["explicit"].return_type == "String"
+
+
+def test_block_body_without_type_stays_unit() -> None:
+    assert _FUNCS["block"].return_type == "Unit"
+
+
+def test_block_body_with_explicit_type_unchanged() -> None:
+    assert _FUNCS["blockTyped"].return_type == "Int"
+
+
+# ---------------------------------------------------------------------------
+# Issue #591 reproducer: the exact sample from the report
+# ---------------------------------------------------------------------------
+
+
+def test_abstract_fun_without_body_stays_unit() -> None:
+    # No function_body child at all (interface member) → Unit default kept.
+    funcs = _functions("interface I { fun render() }")
+    assert funcs["render"].return_type == "Unit"
+
+
+def test_malformed_expression_body_returns_unknown() -> None:
+    # Defensive: a function_body holding only '=' (no expression). Real
+    # parses turn this into an ERROR node, so drive the helper directly
+    # with explicit stub nodes (never MagicMock — unbounded attr chains).
+    from tree_sitter_analyzer.languages.kotlin_helpers import (
+        _kotlin_expression_body_type,
+    )
+
+    class _Stub:
+        def __init__(self, type_: str, children: list) -> None:
+            self.type = type_
+            self.children = children
+            self.child_count = len(children)
+            self.parent = None
+
+    eq = _Stub("=", [])
+    body = _Stub("function_body", [eq])
+    fn = _Stub("function_declaration", [body])
+    assert _kotlin_expression_body_type(fn, lambda n: "") == ""
+
+
+def test_issue_591_reproducer_class_method() -> None:
+    funcs = _functions(
+        """\
+class LegacyUserManager {
+    fun get(key: String) = "legacy"
+}
+"""
+    )
+    assert funcs["get"].return_type == "String"

--- a/tree_sitter_analyzer/languages/kotlin_helpers.py
+++ b/tree_sitter_analyzer/languages/kotlin_helpers.py
@@ -235,6 +235,45 @@ def _kotlin_owning_type(node: Any) -> tuple[str | None, bool]:
     return None, False
 
 
+def _kotlin_expression_body_type(
+    node: Any,
+    get_node_text: Callable[..., str],
+) -> str | None:
+    """Infer the return type of an expression-body function (issue #591).
+
+    Returns:
+        * ``None`` — no expression body (block body or abstract fun);
+          caller keeps the ``Unit`` default, which is correct there.
+        * a pinned literal type (``String``/``Int``/``Boolean``/``Double``)
+          for trivial literal bodies.
+        * ``""`` (unknown) for any other expression body — honest "no
+          claim", never a fabricated ``Unit``.
+    """
+    body = None
+    for child in node.children:
+        if child.type == "function_body":
+            body = child
+            break
+    if body is None or body.child_count == 0 or body.children[0].type != "=":
+        return None  # block body or no body → Unit default is correct
+    if body.child_count < 2:
+        return ""
+    expr = body.children[1]
+    if expr.type == "string_literal":
+        return "String"
+    if expr.type == "float_literal":
+        return "Double"
+    if expr.type == "number_literal":
+        # Only pure-digit literals are Int; 42L / 0xFF etc. stay unknown.
+        text = get_node_text(expr)
+        return "Int" if text.isdigit() else ""
+    if expr.type in ("boolean_literal", "identifier"):
+        if get_node_text(expr) in ("true", "false"):
+            return "Boolean"
+        return ""
+    return ""
+
+
 def extract_kotlin_function(
     node: Any,
     get_node_text: Callable[..., str],
@@ -266,11 +305,22 @@ def extract_kotlin_function(
         parameters = extract_kotlin_parameters(node, get_node_text)
 
         return_type = "Unit"
+        explicit_type = False
         for i, child in enumerate(node.children):
             if child.type == ":":
                 if i + 1 < len(node.children):
                     return_type = get_node_text(node.children[i + 1])
+                    explicit_type = True
                 break
+        if not explicit_type:
+            # Issue #591: ``fun get() = "legacy"`` must not claim Unit — the
+            # expression body infers the type. Full inference is a non-goal;
+            # pin trivial literals, otherwise emit "" (unknown, matching the
+            # Go plugin's absent-return-type convention). Block bodies
+            # ``{ ... }`` without an explicit type really are Unit — keep.
+            inferred = _kotlin_expression_body_type(node, get_node_text)
+            if inferred is not None:
+                return_type = inferred
 
         visibility = "public"
         is_suspend = False

--- a/tree_sitter_analyzer/languages/kotlin_helpers.py
+++ b/tree_sitter_analyzer/languages/kotlin_helpers.py
@@ -259,7 +259,7 @@ def _kotlin_expression_body_type(
     if body.child_count < 2:
         return ""
     expr = body.children[1]
-    if expr.type == "string_literal":
+    if expr.type in ("string_literal", "multiline_string_literal"):
         return "String"
     if expr.type == "float_literal":
         return "Double"


### PR DESCRIPTION
Closes #591 (split from #538 scope-B).

## Summary
`fun get(key: String) = "legacy"` reported `return_type=Unit` — the Unit default applied whenever no explicit `:` type exists, but expression bodies infer their type. Claiming Unit was actively wrong.

**Fix** (honesty over fabrication, #537 precedent — no full inference):
- expression body + trivial literal → literal type (String / Int / Double / Boolean)
- expression body + anything else (calls, `42L`, `0xFF`) → `""` (unknown; matches the Go plugin convention, and the formatter suppresses the empty suffix)
- explicit type / block body → unchanged (Unit stays correct for block bodies)

## Test plan
- [x] RED-first: 9 expression-body cases failed pre-fix, 3 baseline cases green
- [x] GREEN: 14/14 new tests; kotlin regression 164 + 126 + formatter 37 all passed (-n 0)
- [x] Goldens: full/compact/csv each change exactly 1 line (`Sample.kt` `get` → `fun(): String`); toon/plugins-json legitimately byte-identical (no return_type in those surfaces)
- [x] Ratchet gate exit=0; new code fully patch-covered (stub nodes with explicit parent=None)

Lead independently spot-checked live: `get→'String' n→'Int' f(call)→'' explicit→'Long' block→'Unit'`.

Note: Scala has the same Unit-sentinel bug (`_scala_return_type`) — tracked separately.