### PR TITLE
fix(go): interface method signatures extracted and owned by their interface

### DIFF
--- a/tests/golden_masters/compact/go_sample_compact.md
+++ b/tests/golden_masters/compact/go_sample_compact.md
@@ -10,6 +10,8 @@
 ## Funcs
 | Func | Sig | V | L | Doc |
 |------|-----|---|---|-----|
+| Read | (1):(n in | E | 55-55 | - |
+| Write | (1):(n in | E | 61-61 | - |
 | NewService | (2):*Ser | E | 80-86 | - |
 | Name | (0):s | E | 89-91 | - |
 | IsRunning | (0):b | E | 94-98 | - |

--- a/tests/golden_masters/csv/go_sample_csv.csv
+++ b/tests/golden_masters/csv/go_sample_csv.csv
@@ -8,6 +8,8 @@ Field,StatusRunning,StatusRunning:None,public,38-38,,-
 Field,StatusCompleted,StatusCompleted:None,public,39-39,,-
 Field,StatusFailed,StatusFailed:None,public,40-40,,-
 Field,lastErr,lastErr:error,private,281-281,,-
+Method,Read,"([]byte:p):(n int, err error)",public,55-55,1,-
+Method,Write,"([]byte:p):(n int, err error)",public,61-61,1,-
 Method,NewService,"(string:name, *Config:config):*Service",public,80-86,1,-
 Method,Name,():string,public,89-91,1,-
 Method,IsRunning,():bool,public,94-98,1,-

--- a/tests/golden_masters/full/go_sample_full.md
+++ b/tests/golden_masters/full/go_sample_full.md
@@ -42,6 +42,8 @@ import ""time""
 ## Functions
 | Func | Signature | Vis | Lines | Doc |
 |------|-----------|-----|-------|-----|
+| Read | ({'name': '[]byte', 'type': 'p'}) (n int, err error) | exported | 55-55 | - |
+| Write | ({'name': '[]byte', 'type': 'p'}) (n int, err error) | exported | 61-61 | - |
 | NewService | ({'name': 'string', 'type': 'name'}, {'name': '*Config', 'type': 'config'}) *Service | exported | 80-86 | - |
 | Name | () string | exported | 89-91 | - |
 | IsRunning | () bool | exported | 94-98 | - |

--- a/tests/golden_masters/plugins/go.json
+++ b/tests/golden_masters/plugins/go.json
@@ -1,12 +1,12 @@
 {
   "counts_by_type": {
     "Class": 10,
-    "Function": 18,
+    "Function": 20,
     "Import": 5,
     "Package": 1,
     "Variable": 9
   },
-  "element_total": 43,
+  "element_total": 45,
   "names_by_type": {
     "Class": [
       "Config",
@@ -27,12 +27,14 @@
       "NewService",
       "NewWorkerPool",
       "ProcessData",
+      "Read",
       "Shutdown",
       "Start",
       "Stop",
       "Submit",
       "WithRetry",
       "WithTimeout",
+      "Write",
       "process",
       "run",
       "stop",

--- a/tests/golden_masters/toon/go_sample_toon.toon
+++ b/tests/golden_masters/toon/go_sample_toon.toon
@@ -16,7 +16,9 @@ classes:
     Handler,public,(251,251)
     Middleware,public,(254,254)
 methods:
-  [18]{name,visibility,line_range(a,b)}:
+  [20]{name,visibility,line_range(a,b)}:
+    Read,public,(55,55)
+    Write,public,(61,61)
     NewService,public,(80,86)
     Name,public,(89,91)
     IsRunning,public,(94,98)
@@ -55,7 +57,7 @@ imports:
     time,time,"\"time\"",false,false,(17,17),[],"\"time\""
 statistics:
   class_count: 10
-  method_count: 18
+  method_count: 20
   field_count: 9
   import_count: 5
   total_lines: 293

--- a/tests/unit/languages/test_go_class_method_association.py
+++ b/tests/unit/languages/test_go_class_method_association.py
@@ -451,9 +451,19 @@ class TestGoSampleIntegration:
         assert len(outline["top_level_functions"]) == 7
 
     def test_total_method_count_unchanged(self) -> None:
-        """statistics.method_count still equals 18 (unchanged — all methods counted)."""
+        """statistics.method_count == 20: 18 receiver methods + Reader.Read and
+        Writer.Write interface signatures (owned via receiver_type since #588)."""
         outline = self._build_outline_for_go_sample()
-        assert outline["statistics"]["method_count"] == 18
+        assert outline["statistics"]["method_count"] == 20
+
+    def test_interface_method_signatures_nested_under_interface(self) -> None:
+        """#588: Reader/Writer interfaces own their method signatures."""
+        outline = self._build_outline_for_go_sample()
+        by_name = {c["name"]: c for c in outline["classes"]}
+        assert [m["name"] for m in by_name["Reader"]["methods"]] == ["Read"]
+        assert [m["name"] for m in by_name["Writer"]["methods"]] == ["Write"]
+        # Embedding-only interface gains no phantom methods.
+        assert by_name["ReadWriter"]["methods"] == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/languages/test_go_interface_methods_588.py
+++ b/tests/unit/languages/test_go_interface_methods_588.py
@@ -1,0 +1,198 @@
+"""Issue #588 — Go interface method signatures owned by their interface.
+
+Before this fix: ``type Reader interface { Read(p []byte) (n int, err error) }``
+reported methods=[] because ``method_elem`` children of ``interface_type`` were
+never extracted — an agent asking "what methods does Reader require" got an
+empty interface.
+
+After this fix: each ``method_elem`` is emitted as a Function with
+``receiver_type`` = the interface name (the innermost-span ownership convention
+from #532/#474), ``is_method=True``, and real parameters/return type.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("tree_sitter_go", reason="tree-sitter-go not installed")
+
+
+def _extract(src: str):
+    """Run the Go plugin's function + class extraction over ``src``."""
+    import tree_sitter
+    import tree_sitter_go
+
+    from tree_sitter_analyzer.languages.go_plugin import GoElementExtractor
+
+    lang = tree_sitter.Language(tree_sitter_go.language())
+    parser = tree_sitter.Parser(lang)
+    tree = parser.parse(src.encode())
+    extractor = GoElementExtractor()
+    return (
+        extractor.extract_functions(tree, src),
+        extractor.extract_classes(tree, src),
+    )
+
+
+class TestReaderInterfaceMethod:
+    """Single-method interface: signature fully extracted and owned."""
+
+    SRC = (
+        "package main\n"
+        "\n"
+        "// Reader is an interface for reading data.\n"
+        "type Reader interface {\n"
+        "\t// Read reads data into the provided buffer.\n"
+        "\tRead(p []byte) (n int, err error)\n"
+        "}\n"
+    )
+
+    def test_read_signature_extracted_and_owned(self) -> None:
+        functions, classes = self._parsed()
+        assert len(functions) == 1, f"got {[f.name for f in functions]}"
+        read = functions[0]
+        assert read.name == "Read"
+        assert read.parameters == ["p []byte"]
+        assert read.return_type == "(n int, err error)"
+        assert read.receiver_type == "Reader"
+        assert read.is_method is True
+        assert read.receiver is None  # interface signatures have no receiver var
+        assert read.visibility == "public"
+        # span lands inside the interface so find_class_name containment works
+        assert read.start_line == 6
+        assert read.end_line == 6
+
+    def test_interface_class_still_extracted(self) -> None:
+        _, classes = self._parsed()
+        assert len(classes) == 1
+        assert classes[0].name == "Reader"
+        assert classes[0].class_type == "interface"
+
+    def _parsed(self):
+        return _extract(self.SRC)
+
+
+class TestReadWriterEmbeddingNoPhantoms:
+    """Embedding-only interface: embeds preserved, zero phantom methods."""
+
+    SRC = "package main\ntype ReadWriter interface {\n\tReader\n\tWriter\n}\n"
+
+    def test_no_phantom_methods(self) -> None:
+        functions, _ = _extract(self.SRC)
+        assert len(functions) == 0, f"got {[f.name for f in functions]}"
+
+    def test_embedding_still_reflected(self) -> None:
+        _, classes = _extract(self.SRC)
+        assert len(classes) == 1
+        assert classes[0].interfaces == ["Reader", "Writer"]
+
+
+class TestEmptyInterface:
+    """``type Empty interface {}`` emits no functions."""
+
+    def test_no_methods(self) -> None:
+        functions, classes = _extract("package main\ntype Empty interface {}\n")
+        assert len(functions) == 0
+        assert len(classes) == 1
+        assert classes[0].name == "Empty"
+
+
+class TestAnonymousInterfaceParamIgnored:
+    """An anonymous ``interface{ ... }`` in a parameter is NOT a named owner."""
+
+    SRC = (
+        "package main\n"
+        "func Use(r interface{ Close() error }) error {\n"
+        "\treturn r.Close()\n"
+        "}\n"
+    )
+
+    def test_only_the_real_function_extracted(self) -> None:
+        functions, _ = _extract(self.SRC)
+        assert [f.name for f in functions] == ["Use"]
+
+
+class TestGuardBranches:
+    """Defensive guards in extract_go_interface_methods (direct unit calls)."""
+
+    @staticmethod
+    def _node(node_type: str, fields: dict | None = None, children: list | None = None):
+        from unittest.mock import MagicMock
+
+        node = MagicMock()
+        node.parent = None  # MagicMock parent chains are an OOM hazard
+        node.type = node_type
+        node.children = children or []
+        node.child_by_field_name.side_effect = (fields or {}).get
+        return node
+
+    def _extract(self, spec_node):
+        from tree_sitter_analyzer.languages._go_function_helpers import (
+            extract_go_interface_methods,
+        )
+
+        return extract_go_interface_methods(spec_node, lambda n: "", [])
+
+    def test_missing_name_or_type_field_returns_empty(self) -> None:
+        spec = self._node("type_spec", fields={"type": self._node("interface_type")})
+        assert self._extract(spec) == []
+
+    def test_non_interface_type_spec_returns_empty(self) -> None:
+        spec = self._node(
+            "type_spec",
+            fields={
+                "name": self._node("type_identifier"),
+                "type": self._node("struct_type"),
+            },
+        )
+        assert self._extract(spec) == []
+
+    def test_empty_interface_name_text_returns_empty(self) -> None:
+        spec = self._node(
+            "type_spec",
+            fields={
+                "name": self._node("type_identifier"),
+                "type": self._node("interface_type"),
+            },
+        )
+        # get_node_text returns "" for every node → name guard fires
+        assert self._extract(spec) == []
+
+    def test_nameless_method_elem_skipped(self) -> None:
+        from tree_sitter_analyzer.languages._go_function_helpers import (
+            extract_go_interface_methods,
+        )
+
+        bad_elem = self._node("method_elem")  # no "name" field
+        iface = self._node("interface_type", children=[bad_elem])
+        spec = self._node(
+            "type_spec",
+            fields={"name": self._node("type_identifier"), "type": iface},
+        )
+        result = extract_go_interface_methods(spec, lambda n: "R", [])
+        assert result == []
+
+    def test_exception_returns_empty(self) -> None:
+        from unittest.mock import MagicMock
+
+        from tree_sitter_analyzer.languages._go_function_helpers import (
+            extract_go_interface_methods,
+        )
+
+        spec = MagicMock()
+        spec.parent = None
+        spec.child_by_field_name.side_effect = RuntimeError("boom")
+        assert extract_go_interface_methods(spec, lambda n: "", []) == []
+
+
+class TestAliasToInterface:
+    """``type R = interface{ M() }`` (type_alias) also owns its signatures."""
+
+    SRC = "package main\ntype R = interface{ M() }\n"
+
+    def test_alias_interface_method_owned(self) -> None:
+        functions, _ = _extract(self.SRC)
+        assert len(functions) == 1
+        assert functions[0].name == "M"
+        assert functions[0].receiver_type == "R"
+        assert functions[0].is_method is True

--- a/tree_sitter_analyzer/languages/_go_function_helpers.py
+++ b/tree_sitter_analyzer/languages/_go_function_helpers.py
@@ -53,6 +53,50 @@ def extract_go_method(
         return None
 
 
+def extract_go_interface_methods(
+    type_spec_node: Any,
+    get_node_text: Callable[..., str],
+    content_lines: list[str],
+) -> list[Function]:
+    """Extract interface method signatures as Functions owned by the interface.
+
+    ``type Reader interface { Read(p []byte) (n int, err error) }`` emits
+    ``method_elem`` children under ``interface_type``; each carries the same
+    ``name``/``parameters``/``result`` fields a function declaration does, so
+    the shared builder applies directly.  Ownership follows the receiver_type
+    convention used for struct methods (#532/#474): receiver_type = the
+    interface name, receiver stays None (signatures have no receiver var).
+    Embedded interfaces are ``type_elem`` nodes and are deliberately skipped
+    (no phantom methods — issue #588).
+    """
+    try:
+        name_node = type_spec_node.child_by_field_name("name")
+        type_node = type_spec_node.child_by_field_name("type")
+        if name_node is None or type_node is None:
+            return []
+        if type_node.type != "interface_type":
+            return []
+        interface_name = get_node_text(name_node)
+        if not interface_name:
+            return []
+
+        methods: list[Function] = []
+        for child in type_node.children:
+            if child.type != "method_elem":
+                continue
+            method_name = _go_function_name(child, get_node_text)
+            if not method_name:
+                continue
+            func = _build_go_function(method_name, child, get_node_text, content_lines)
+            func.receiver_type = interface_name
+            func.is_method = True
+            methods.append(func)
+        return methods
+    except Exception as e:
+        log_error(f"Error extracting Go interface methods: {e}")
+        return []
+
+
 def _go_function_name(node: Any, get_node_text: Callable[..., str]) -> str | None:
     name_node = node.child_by_field_name("name")
     if not name_node:

--- a/tree_sitter_analyzer/languages/go_helpers.py
+++ b/tree_sitter_analyzer/languages/go_helpers.py
@@ -6,7 +6,11 @@ from ._go_common_helpers import (
     extract_parameters,
     extract_return_type,
 )
-from ._go_function_helpers import extract_go_function, extract_go_method
+from ._go_function_helpers import (
+    extract_go_function,
+    extract_go_interface_methods,
+    extract_go_method,
+)
 from ._go_import_helpers import (
     _extract_import_declaration,
     extract_import_spec,
@@ -25,6 +29,7 @@ __all__ = [
     "extract_docstring",
     "extract_embedded_types",
     "extract_go_function",
+    "extract_go_interface_methods",
     "extract_go_method",
     "extract_go_package",
     "extract_go_type_spec",

--- a/tree_sitter_analyzer/languages/go_plugin.py
+++ b/tree_sitter_analyzer/languages/go_plugin.py
@@ -31,6 +31,9 @@ from .go_helpers import (
     extract_go_function as _extract_func_standalone,
 )
 from .go_helpers import (
+    extract_go_interface_methods as _extract_iface_methods_standalone,
+)
+from .go_helpers import (
     extract_go_method as _extract_method_standalone,
 )
 from .go_helpers import (
@@ -81,6 +84,10 @@ class GoElementExtractor(ElementExtractor):
         extractors = {
             "function_declaration": self._extract_function,
             "method_declaration": self._extract_method,
+            # Interface method signatures (method_elem) — owned by their
+            # interface via receiver_type (#588).
+            "type_spec": self._extract_interface_methods,
+            "type_alias": self._extract_interface_methods,
         }
 
         self._traverse_and_extract(tree.root_node, extractors, functions)
@@ -230,6 +237,13 @@ class GoElementExtractor(ElementExtractor):
     def _extract_method(self, node: tree_sitter.Node) -> Function | None:
         """Extract method declaration (function with receiver)"""
         return _extract_method_standalone(node, self._get_node_text, self.content_lines)
+
+    # Extract elements from AST: _extract_interface_methods
+    def _extract_interface_methods(self, node: tree_sitter.Node) -> list[Function]:
+        """Extract interface method signatures owned by the interface (#588)"""
+        return _extract_iface_methods_standalone(
+            node, self._get_node_text, self.content_lines
+        )
 
     # Extract elements from AST: _extract_parameters
     def _extract_parameters(self, node: tree_sitter.Node) -> list[str]:


### PR DESCRIPTION
Closes #588 (split from #538 scope-B).

## Summary
`type Reader interface { Read(p []byte) (n int, err error) }` reported methods=[] — `method_elem` nodes inside `interface_type` were never extracted. Now each emits a Function with `receiver_type` = interface name (innermost-span ownership convention, #532/#474), `is_method=True`. Embedded interfaces (`type_elem`) skipped — no phantoms. `type_alias` interfaces included (mirrors extract_type_declaration).

method_elem carries the same name/parameters/result fields as function_declaration, so the existing shared builders apply — the fix is one new helper + dispatch entries.

## Test plan
- [x] RED-first: 2 failed pre-fix → 12 passed (pins: params `["p []byte"]`, return `"(n int, err error)"`, receiver_type Reader; ReadWriter zero phantoms; empty/anonymous interfaces; 5 guard stubs with explicit parent=None)
- [x] Regression 44 + association 25 + golden suites 78+18 passed (-n 0)
- [x] Goldens both halves regenerated: go.json Function 18→20 (+Read +Write from examples/sample.go), tables +2 rows, toon counts 18→20 — every line traced
- [x] Conscious re-pin: method_count 18→20 with docstring
- [x] Ratchet exit=0; new lines patch-covered; ruff/mypy clean

Lead independently spot-checked live: Read → receiver_type=Reader, params/return exact, no ReadWriter phantoms.