### PR TITLE
fix(rust): mod blocks extracted as container elements

### DIFF
--- a/tests/golden_masters/plugins/rust.json
+++ b/tests/golden_masters/plugins/rust.json
@@ -3,9 +3,10 @@
     "Class": 5,
     "Function": 9,
     "Import": 1,
+    "Package": 1,
     "Variable": 6
   },
-  "element_total": 21,
+  "element_total": 22,
   "names_by_type": {
     "Class": [
       "BorrowedItem",
@@ -26,6 +27,9 @@
     "Import": [
       "use std::collections::HashMap;"
     ],
+    "Package": [
+      "sample_module"
+    ],
     "Variable": [
       "active",
       "email",
@@ -39,6 +43,7 @@
     "Class",
     "Function",
     "Import",
+    "Package",
     "Variable"
   ]
 }

--- a/tests/golden_masters/toon/rust_sample_toon.toon
+++ b/tests/golden_masters/toon/rust_sample_toon.toon
@@ -1,6 +1,8 @@
 file_path: examples/sample.rs
 language: rust
-package: null
+package:
+  name: sample_module
+  line_range: (2, 88)
 classes:
   [5]{name,visibility,line_range(a,b)}:
     User,pub,(7,12)

--- a/tests/unit/languages/test_rust_mod_container_589.py
+++ b/tests/unit/languages/test_rust_mod_container_589.py
@@ -1,0 +1,191 @@
+"""Issue #589 — Rust ``mod`` blocks captured as container elements (RED→GREEN).
+
+``mod sample_module { ... }`` previously produced no container element: items
+inside were extracted but the module itself was invisible. The fix mirrors the
+C++ namespace → Package convention (`extract_cpp_namespaces` →
+``extract_packages`` on the extractor, wired into ``analyze_file`` /
+``extract_elements``).
+
+Decision (documented): declaration-only ``mod tests;`` (no body) IS emitted,
+with its span being the declaration line itself. Rationale: it is the only
+trace of the file-module mapping in lib.rs/mod.rs — skipping it reproduces the
+exact invisibility this issue fixes; and a one-line span cannot mis-claim
+nested items under the innermost-span ownership rule.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+
+def _rust_lang():
+    try:
+        import tree_sitter
+        import tree_sitter_rust
+
+        return tree_sitter.Language(tree_sitter_rust.language())
+    except Exception:
+        return None
+
+
+pytestmark = pytest.mark.skipif(
+    _rust_lang() is None, reason="tree-sitter-rust not available"
+)
+
+
+def _parse(src: str):
+    import tree_sitter
+
+    return tree_sitter.Parser(_rust_lang()).parse(src.encode())
+
+
+NAMED_MOD_SRC = (
+    "pub mod sample_module {\n"
+    "    pub struct User {\n"
+    "        pub id: u64,\n"
+    "    }\n"
+    "\n"
+    "    pub fn helper() -> u64 {\n"
+    "        42\n"
+    "    }\n"
+    "}\n"
+)
+
+
+def test_named_mod_extracted_as_package() -> None:
+    """A named mod block must yield exactly one Package-like container."""
+    from tree_sitter_analyzer.languages.rust_plugin import RustElementExtractor
+
+    packages = RustElementExtractor().extract_packages(
+        _parse(NAMED_MOD_SRC), NAMED_MOD_SRC
+    )
+
+    assert len(packages) == 1
+    pkg = packages[0]
+    assert pkg.name == "sample_module"
+    assert pkg.element_type == "package"
+    assert pkg.language == "rust"
+    assert pkg.start_line == 1
+    assert pkg.end_line == 9
+
+
+def test_nested_items_still_extracted() -> None:
+    """Items inside the mod stay owned/extracted exactly as before."""
+    from tree_sitter_analyzer.languages.rust_plugin import RustElementExtractor
+
+    extractor = RustElementExtractor()
+    tree = _parse(NAMED_MOD_SRC)
+
+    functions = extractor.extract_functions(tree, NAMED_MOD_SRC)
+    assert len(functions) == 1
+    assert functions[0].name == "helper"
+
+    classes = extractor.extract_classes(tree, NAMED_MOD_SRC)
+    assert len(classes) == 1
+    assert classes[0].name == "User"
+
+
+def test_empty_mod_extracted() -> None:
+    """``mod empty {}`` still emits its container."""
+    from tree_sitter_analyzer.languages.rust_plugin import RustElementExtractor
+
+    src = "mod empty {}\n"
+    packages = RustElementExtractor().extract_packages(_parse(src), src)
+
+    assert len(packages) == 1
+    assert packages[0].name == "empty"
+    assert packages[0].start_line == 1
+    assert packages[0].end_line == 1
+
+
+def test_declaration_only_mod_emitted_with_declaration_span() -> None:
+    """``mod tests;`` (body=None) is emitted; span == the declaration line."""
+    from tree_sitter_analyzer.languages.rust_plugin import RustElementExtractor
+
+    src = "mod tests;\n"
+    packages = RustElementExtractor().extract_packages(_parse(src), src)
+
+    assert len(packages) == 1
+    assert packages[0].name == "tests"
+    assert packages[0].start_line == 1
+    assert packages[0].end_line == 1
+
+
+def test_nested_mods_both_extracted() -> None:
+    """Nested mod blocks each emit a container."""
+    from tree_sitter_analyzer.languages.rust_plugin import RustElementExtractor
+
+    src = "mod outer {\n    mod inner {}\n}\n"
+    packages = RustElementExtractor().extract_packages(_parse(src), src)
+
+    assert len(packages) == 2
+    assert [p.name for p in packages] == ["outer", "inner"]
+    assert (packages[0].start_line, packages[0].end_line) == (1, 3)
+    assert (packages[1].start_line, packages[1].end_line) == (2, 2)
+
+
+class _NamelessModNode:
+    """Stub mod_item with no name field (grammar ERROR recovery shape)."""
+
+    type = "mod_item"
+    parent = None  # explicit: never let a mock auto-generate a parent chain
+    children: list = []
+
+    def child_by_field_name(self, _field: str):
+        return None
+
+
+class _ExplodingModNode:
+    """Stub mod_item whose name lookup raises (defensive except branch)."""
+
+    type = "mod_item"
+    parent = None
+    children: list = []
+
+    def child_by_field_name(self, _field: str):
+        raise RuntimeError("boom")
+
+
+def test_nameless_mod_node_yields_none() -> None:
+    from tree_sitter_analyzer.languages.rust_plugin import RustElementExtractor
+
+    assert RustElementExtractor()._extract_mod_package(_NamelessModNode()) is None
+
+
+def test_exploding_mod_node_yields_none() -> None:
+    from tree_sitter_analyzer.languages.rust_plugin import RustElementExtractor
+
+    assert RustElementExtractor()._extract_mod_package(_ExplodingModNode()) is None
+
+
+def test_plugin_extract_elements_carries_packages_key() -> None:
+    """RustPlugin.extract_elements exposes the 'packages' group (go/kotlin parity)."""
+    from tree_sitter_analyzer.languages.rust_plugin import RustPlugin
+
+    result = RustPlugin().extract_elements(_parse(NAMED_MOD_SRC), NAMED_MOD_SRC)
+
+    assert "packages" in result
+    assert len(result["packages"]) == 1
+    assert result["packages"][0].name == "sample_module"
+
+
+def test_analyze_file_includes_package_element(tmp_path) -> None:
+    """analyze_file surfaces the mod container in the flat element list."""
+    from tree_sitter_analyzer.core.request import AnalysisRequest
+    from tree_sitter_analyzer.languages.rust_plugin import RustPlugin
+    from tree_sitter_analyzer.models import Package
+
+    rs_file = tmp_path / "lib.rs"
+    rs_file.write_text(NAMED_MOD_SRC, encoding="utf-8", newline="\n")
+
+    result = asyncio.run(
+        RustPlugin().analyze_file(str(rs_file), AnalysisRequest(file_path=str(rs_file)))
+    )
+
+    packages = [e for e in result.elements if isinstance(e, Package)]
+    assert len(packages) == 1
+    assert packages[0].name == "sample_module"
+    # functions(1) + classes(1) + variables(1: id field) + imports(0) + packages(1)
+    assert len(result.elements) == 4

--- a/tests/unit/languages/test_rust_mod_container_589.py
+++ b/tests/unit/languages/test_rust_mod_container_589.py
@@ -31,7 +31,8 @@ def _rust_lang():
 
 
 pytestmark = pytest.mark.skipif(
-    _rust_lang() is None, reason="tree-sitter-rust not available"
+    _rust_lang() is None,
+    reason="tree-sitter-rust not available; tracked: optional local grammar dependency",
 )
 
 

--- a/tree_sitter_analyzer/languages/rust_plugin.py
+++ b/tree_sitter_analyzer/languages/rust_plugin.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from ..models import AnalysisResult
 
 from ..encoding_utils import extract_text_slice, safe_encode
-from ..models import Class, Function, Import, Variable
+from ..models import Class, Function, Import, Package, Variable
 from ..plugins.base import ElementExtractor, LanguagePlugin
 from ..utils import log_debug, log_error
 
@@ -157,6 +157,47 @@ class RustElementExtractor(ElementExtractor):
 
         log_debug(f"Extracted {len(imports)} Rust imports")
         return imports
+
+    def extract_packages(
+        self, tree: tree_sitter.Tree, source_code: str
+    ) -> list[Package]:
+        """Extract Rust ``mod`` blocks as Package containers (issue #589).
+
+        Mirrors the C++ namespace → Package convention. Declaration-only
+        mods (``mod tests;`` — no body) are emitted too: their span is the
+        declaration line, which is the only trace of the file-module
+        mapping and cannot mis-claim nested items.
+        """
+        self.source_code = source_code
+        self.content_lines = source_code.split("\n")
+        self._reset_caches()
+
+        packages: list[Package] = []
+        self._traverse_and_extract(
+            tree.root_node,
+            {"mod_item": self._extract_mod_package},
+            packages,
+        )
+
+        log_debug(f"Extracted {len(packages)} Rust modules")
+        return packages
+
+    def _extract_mod_package(self, node: tree_sitter.Node) -> Package | None:
+        """Build a Package element from a ``mod_item`` node."""
+        try:
+            name_node = node.child_by_field_name("name")
+            if name_node is None:
+                return None
+            return Package(
+                name=self._get_node_text(name_node),
+                start_line=node.start_point[0] + 1,
+                end_line=node.end_point[0] + 1,
+                raw_text=self._get_node_text(node),
+                language="rust",
+            )
+        except Exception as e:
+            log_error(f"Error extracting Rust mod as package: {e}")
+            return None
 
     def _extract_import(self, node: tree_sitter.Node) -> Import | None:
         """Extract import statement (use declaration)"""
@@ -722,6 +763,7 @@ class RustPlugin(LanguagePlugin):
             all_elements.extend(extractor.extract_classes(tree, file_content))
             all_elements.extend(extractor.extract_variables(tree, file_content))
             all_elements.extend(extractor.extract_imports(tree, file_content))
+            all_elements.extend(extractor.extract_packages(tree, file_content))
 
             node_count = (
                 self._count_tree_nodes(tree.root_node) if tree and tree.root_node else 0
@@ -807,6 +849,7 @@ class RustPlugin(LanguagePlugin):
                 "classes": extractor.extract_classes(tree, source_code),
                 "variables": extractor.extract_variables(tree, source_code),
                 "imports": extractor.extract_imports(tree, source_code),
+                "packages": extractor.extract_packages(tree, source_code),
             }
 
             return result


### PR DESCRIPTION
Closes #589 (split from #538 scope-B).

## Summary
`mod sample_module { ... }` produced no container element. New `extract_packages` emits a Package per `mod_item` (mirrors the C++ namespace → Package convention): inline mods with body span, declaration-only `mod tests;` with its single line (it's the only trace of the file-module mapping in lib.rs — skipping it reproduces the invisibility this issue fixes). Nested mods each emit their own Package. No parent walks — no depth-cap surface.

## Test plan
- [x] RED-first: 6 failed pre-fix → 9 passed; regression across all rust test files 164 passed (-n 0)
- [x] Goldens both halves: rust.json +Package(sample_module) element_total 21→22; toon `package: null` → `{name: sample_module, line_range: (2, 88)}` (verified against examples/sample.rs); full/compact/csv byte-identical (rust table views don't render package metadata) — regenerated and confirmed
- [x] Ratchet exit=0; all new lines patch-covered (guards via stubs with explicit parent=None)
- [x] Rebased onto develop after #592 landed mid-task; gates re-run green

Lead independently spot-checked live: nested `outer`/`inner` both Packages with correct spans, `mod decl_only;` single-line span, nested fn still extracted.