### PR TITLE
fix(scala): expression-body defs no longer claim Unit return

### DIFF
--- a/tests/unit/languages/test_scala_expression_body_return.py
+++ b/tests/unit/languages/test_scala_expression_body_return.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Scala expression-body defs must not claim ``Unit`` (issue #594).
+
+``def get(key: String) = "legacy"`` used to extract ``return_type="Unit"``.
+The expression body infers ``String``; claiming ``Unit`` is actively wrong.
+Same family as the Kotlin fix for #591/#593 — the contract mirrors
+``test_kotlin_expression_body_return.py`` exactly:
+
+* explicit return type → use it (unchanged)
+* block body ``{ ... }`` with no explicit type → ``Unit`` (correct, kept)
+* expression body ``= <expr>`` with no explicit type:
+  - trivial literal → its pinned type (String / Int / Boolean / Double)
+  - anything else (calls, suffixed/hex numbers, null, blocks) → ``""``
+    (empty = unknown; matches the Go plugin's absent-return-type
+    convention in ``_go_common_helpers.extract_return_type``)
+
+Live-verified Scala node shapes (tree-sitter-scala): expression body is a
+direct ``=`` child followed by the expression node; ``string`` covers both
+``"x"`` and raw ``\"\"\"x\"\"\"``; ``integer_literal`` covers ``42``/``42L``/
+``0xFF``; floats are ``floating_point_literal``.
+"""
+
+from __future__ import annotations
+
+import tree_sitter
+import tree_sitter_scala
+
+from tree_sitter_analyzer.languages.scala_plugin import ScalaElementExtractor
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse(source: str) -> tree_sitter.Tree:
+    lang = tree_sitter.Language(tree_sitter_scala.language())
+    parser = tree_sitter.Parser(lang)
+    return parser.parse(source.encode("utf-8"))
+
+
+def _functions(source: str) -> dict[str, object]:
+    """Return a name→Function dict parsed from *source*."""
+    extractor = ScalaElementExtractor()
+    return {fn.name: fn for fn in extractor.extract_functions(_parse(source), source)}
+
+
+_SRC = """\
+def str() = "legacy"
+def integer = 42
+def truthy = true
+def falsy = false
+def dbl = 3.14
+def call = compute()
+def longLit = 42L
+def hexLit = 0xFF
+def nullLit = null
+def exprBlock = { 1 }
+def explicit: String = "x"
+def block() { println("hi") }
+def blockTyped(): Int = { 1 }
+"""
+
+_FUNCS = _functions(_SRC)
+
+
+# ---------------------------------------------------------------------------
+# Expression body, trivial literal → pinned literal type
+# ---------------------------------------------------------------------------
+
+
+def test_expression_body_string_literal_is_string() -> None:
+    assert _FUNCS["str"].return_type == "String"
+
+
+def test_expression_body_integer_literal_is_int() -> None:
+    assert _FUNCS["integer"].return_type == "Int"
+
+
+def test_expression_body_true_is_boolean() -> None:
+    assert _FUNCS["truthy"].return_type == "Boolean"
+
+
+def test_expression_body_false_is_boolean() -> None:
+    assert _FUNCS["falsy"].return_type == "Boolean"
+
+
+def test_expression_body_float_literal_is_double() -> None:
+    assert _FUNCS["dbl"].return_type == "Double"
+
+
+def test_expression_body_raw_string_is_string() -> None:
+    # Codex P2 on the Kotlin twin (#593): raw/multiline strings are the
+    # same trivial String case. In Scala both share the ``string`` node.
+    funcs = _functions('def raw = """x"""')
+    assert funcs["raw"].return_type == "String"
+
+
+# ---------------------------------------------------------------------------
+# Expression body, non-trivial → "" (unknown), never Unit
+# ---------------------------------------------------------------------------
+
+
+def test_expression_body_call_is_unknown_not_unit() -> None:
+    assert _FUNCS["call"].return_type == ""
+
+
+def test_expression_body_long_suffix_is_unknown() -> None:
+    # 42L is an integer_literal but NOT an Int; honesty: emit unknown.
+    assert _FUNCS["longLit"].return_type == ""
+
+
+def test_expression_body_hex_literal_is_unknown() -> None:
+    assert _FUNCS["hexLit"].return_type == ""
+
+
+def test_expression_body_null_is_unknown() -> None:
+    assert _FUNCS["nullLit"].return_type == ""
+
+
+def test_expression_body_block_expr_is_unknown() -> None:
+    # ``def f = { 1 }`` — expression body whose expr is a block; not a
+    # trivial literal, so unknown (and definitely not Unit).
+    assert _FUNCS["exprBlock"].return_type == ""
+
+
+# ---------------------------------------------------------------------------
+# Unchanged behavior: explicit type and block body
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_return_type_unchanged() -> None:
+    assert _FUNCS["explicit"].return_type == "String"
+
+
+def test_block_body_without_type_stays_unit() -> None:
+    # Scala 2 procedure syntax ``def block() { ... }`` → Unit (correct).
+    assert _FUNCS["block"].return_type == "Unit"
+
+
+def test_block_body_with_explicit_type_unchanged() -> None:
+    assert _FUNCS["blockTyped"].return_type == "Int"
+
+
+def test_abstract_def_without_body_stays_unit() -> None:
+    # No ``=`` and no block (trait member) → Unit default kept.
+    funcs = _functions("trait I { def render(): Unit; def bare() }")
+    assert funcs["bare"].return_type == "Unit"
+
+
+# ---------------------------------------------------------------------------
+# Issue #594 reproducer: the exact sample from the report
+# ---------------------------------------------------------------------------
+
+
+def test_issue_594_reproducer_class_method() -> None:
+    funcs = _functions(
+        """\
+class LegacyUserManager {
+  def get(key: String) = "legacy"
+}
+"""
+    )
+    assert funcs["get"].return_type == "String"
+
+
+def test_malformed_expression_body_returns_unknown() -> None:
+    # Defensive: ``=`` as the last child (no expression after it). Real
+    # parses turn this into an ERROR node, so drive the helper directly
+    # with explicit stub nodes (never MagicMock — unbounded attr chains).
+    class _Stub:
+        def __init__(self, type_: str, children: list) -> None:
+            self.type = type_
+            self.children = children
+            self.child_count = len(children)
+            self.parent = None
+
+    eq = _Stub("=", [])
+    fn = _Stub("function_definition", [_Stub("def", []), _Stub("identifier", []), eq])
+    extractor = ScalaElementExtractor()
+    assert extractor._scala_expression_body_type(fn) == ""

--- a/tests/unit/languages/test_scala_expression_body_return.py
+++ b/tests/unit/languages/test_scala_expression_body_return.py
@@ -178,3 +178,28 @@ def test_malformed_expression_body_returns_unknown() -> None:
     fn = _Stub("function_definition", [_Stub("def", []), _Stub("identifier", []), eq])
     extractor = ScalaElementExtractor()
     assert extractor._scala_expression_body_type(fn) == ""
+
+
+def test_indented_block_single_literal_infers_type():
+    """Codex P2 on #597: `def f =` followed by an indented literal wraps the
+    RHS in an indented_block — same trivial literal case."""
+    src = "class C {\n  def f =\n    " + '"x"' + "\n}\n"
+    funcs = _functions(src)
+    assert funcs["f"].return_type == "String"
+
+
+def test_indented_block_multi_statement_is_unknown():
+    src = "class C {\n  def f =\n    println(1)\n    2\n}\n"
+    funcs = _functions(src)
+    assert funcs["f"].return_type == ""
+
+
+def test_negative_int_literal_is_int():
+    """Codex P2 on #597: `-1` is a single integer_literal node; Scala infers Int."""
+    funcs = _functions("class C { def neg = -1 }")
+    assert funcs["neg"].return_type == "Int"
+
+
+def test_negative_suffixed_literal_is_unknown():
+    funcs = _functions("class C { def neg = -1L }")
+    assert funcs["neg"].return_type == ""

--- a/tree_sitter_analyzer/languages/scala_plugin.py
+++ b/tree_sitter_analyzer/languages/scala_plugin.py
@@ -464,14 +464,23 @@ class ScalaElementExtractor(ElementExtractor):
                 break
         if expr is None:
             return None  # block body or abstract def → Unit default is correct
+        if expr.type == "indented_block":
+            # `def f =\n  "x"` wraps the RHS in an indented_block (Codex P2
+            # on #597); a single-expression block is the same literal case.
+            named = [c for c in expr.children if c.is_named and c.type != "comment"]
+            if len(named) != 1:
+                return ""
+            expr = named[0]
         if expr.type == "string":
             return "String"
         if expr.type == "floating_point_literal":
             return "Double"
         if expr.type == "integer_literal":
-            # Only pure-digit literals are Int; 42L / 0xFF etc. stay unknown.
+            # Signed decimal literals (`-1`) are a single integer_literal node
+            # and infer Int (Codex P2 on #597); 42L / 0xFF etc. stay unknown.
             text = self._get_node_text(expr)
-            return "Int" if text.isdigit() else ""
+            digits = text[1:] if text[:1] in ("-", "+") else text
+            return "Int" if digits.isdigit() else ""
         if expr.type == "boolean_literal":
             return "Boolean"
         return ""

--- a/tree_sitter_analyzer/languages/scala_plugin.py
+++ b/tree_sitter_analyzer/languages/scala_plugin.py
@@ -427,8 +427,54 @@ class ScalaElementExtractor(ElementExtractor):
 
         For variable declarations use ``_scala_type_after_colon(node, "Inferred")``
         instead — function return types want ``Unit`` as the missing-type sentinel.
+
+        Issue #594: ``def get(key: String) = "legacy"`` must not claim
+        Unit — the expression body infers the type. Full inference is a
+        non-goal; pin trivial literals, otherwise emit "" (unknown,
+        matching the Go plugin's absent-return-type convention). Block
+        bodies / abstract defs without an explicit type really are
+        Unit-defaulted — keep. Mirrors the Kotlin fix for #591/#593.
         """
-        return self._scala_type_after_colon(node, "Unit")
+        if any(child.type == ":" for child in node.children):
+            return self._scala_type_after_colon(node, "Unit")
+        inferred = self._scala_expression_body_type(node)
+        if inferred is not None:
+            return inferred
+        return "Unit"
+
+    def _scala_expression_body_type(self, node: tree_sitter.Node) -> str | None:
+        """Infer the return type of an expression-body def (issue #594).
+
+        Returns:
+            * ``None`` — no expression body (block body or abstract def);
+              caller keeps the ``Unit`` default, which is correct there.
+            * a pinned literal type (``String``/``Int``/``Boolean``/``Double``)
+              for trivial literal bodies (Scala's ``string`` node covers
+              raw triple-quoted strings too — live-verified node shapes).
+            * ``""`` (unknown) for any other expression body — honest "no
+              claim", never a fabricated ``Unit``.
+        """
+        children = node.children
+        expr = None
+        for i, child in enumerate(children):
+            if child.type == "=":
+                if i + 1 >= len(children):
+                    return ""  # malformed: '=' with nothing after it
+                expr = children[i + 1]
+                break
+        if expr is None:
+            return None  # block body or abstract def → Unit default is correct
+        if expr.type == "string":
+            return "String"
+        if expr.type == "floating_point_literal":
+            return "Double"
+        if expr.type == "integer_literal":
+            # Only pure-digit literals are Int; 42L / 0xFF etc. stay unknown.
+            text = self._get_node_text(expr)
+            return "Int" if text.isdigit() else ""
+        if expr.type == "boolean_literal":
+            return "Boolean"
+        return ""
 
     def _scala_type_after_colon(self, node: tree_sitter.Node, default: str) -> str:
         """Scan ``node.children`` for ``:`` and return the next sibling text.


### PR DESCRIPTION
Closes #594 (same family as the merged Kotlin fix #593).

## Summary
`def get(key: String) = "legacy"` reported `return_type=Unit` — live-confirmed (the issue was filed from code reading; the pod reproduced it first). Mirrors the #593 contract exactly:
- explicit type / block body → unchanged (Unit stays correct for block bodies)
- expression body + trivial literal → String/Int/Double/Boolean — `string` in tree-sitter-scala covers raw `"""x"""` too, so the Kotlin Codex-P2 raw-string gap cannot recur here
- suffixed/hex ints (`42L`/`0xFF`), calls, blocks → `""` (unknown, honesty over fabrication)

## Test plan
- [x] RED-first: 13 failed pre-fix, 4 unchanged-behavior pins green → GREEN 17/17
- [x] Regression: languages -k scala 142 passed (-n 0)
- [x] Goldens: zero scala golden surfaces render return types (no plugins/scala.json, no scala table goldens; corpus histogram + 86-symbol wiring pin unaffected — verified, both suites green)
- [x] Ratchet exit=0

Lead independently spot-checked live: get→String, n→Int, f(call)→'', raw→String, explicit→Long, block→Unit, 42L→''.