### PR TITLE
fix(cpp): qualified out-of-scope definitions keep their qualifier

### DIFF
--- a/tests/golden_masters/full/cpp_sample_full.md
+++ b/tests/golden_masters/full/cpp_sample_full.md
@@ -108,7 +108,7 @@ using StringList = vector<string>;
 ## Global Functions
 | Method | Signature | Vis | Lines | Cols | Cx | Doc |
 |--------|-----------|-----|-------|------|----|----|
-| max | (a:T, b:T):T | + | 25-27 | 5-6 | 2 | - |
+| math::max | (a:T, b:T):T | + | 25-27 | 5-6 | 2 | - |
 | operator<< | (os:ostream&, c:const Circle&):ostream& | + | 160-163 | 5-6 | 1 | - |
 | swap_values | (a:T&, b:T&):void | + | 176-180 | 5-6 | 1 | - |
 | add | (a:int, 0:int b =):int | + | 185-187 | 5-6 | 1 | - |

--- a/tests/unit/languages/test_cpp_qualified_names.py
+++ b/tests/unit/languages/test_cpp_qualified_names.py
@@ -1,0 +1,205 @@
+"""C++ qualified-name ownership (#590).
+
+``int math::max(...)`` defined OUTSIDE the ``namespace math { }`` block and
+``T max(...)`` defined INSIDE it are the same logical symbol — both must
+extract to the SAME representation: bare ``name`` + the owner in
+``receiver_type`` (house convention, same as Go/Rust receivers #429/#474 and
+field owners #535).
+"""
+
+import pytest
+import tree_sitter
+import tree_sitter_cpp
+
+from tree_sitter_analyzer.formatters.cpp_formatter import CppTableFormatter
+from tree_sitter_analyzer.languages.cpp_plugin import CppElementExtractor
+
+
+@pytest.fixture
+def extractor() -> CppElementExtractor:
+    return CppElementExtractor()
+
+
+def _parse(code: str):
+    lang = tree_sitter.Language(tree_sitter_cpp.language())
+    parser = tree_sitter.Parser(lang)
+    return parser.parse(code.encode("utf-8"))
+
+
+def _functions(extractor, code):
+    return extractor.extract_functions(_parse(code), code)
+
+
+def _one(funcs, name):
+    matches = [f for f in funcs if f.name == name]
+    assert len(matches) == 1, f"expected exactly one {name!r}, got {matches}"
+    return matches[0]
+
+
+# --- (a) function defined INSIDE the namespace block -----------------------
+
+
+def test_in_namespace_function_gets_namespace_receiver(extractor):
+    code = "namespace math {\nint min(int a, int b) { return a < b ? a : b; }\n}\n"
+    func = _one(_functions(extractor, code), "min")
+    assert func.receiver_type == "math"
+
+
+def test_in_namespace_template_function_gets_namespace_receiver(extractor):
+    # The literal sweep-N3 case (examples/sample.cpp): template fn in namespace.
+    code = (
+        "namespace math {\n"
+        "template<typename T>\n"
+        "T max(T a, T b) { return (a > b) ? a : b; }\n"
+        "}\n"
+    )
+    func = _one(_functions(extractor, code), "max")
+    assert func.receiver_type == "math"
+
+
+# --- (b) qualified function defined OUTSIDE the namespace block ------------
+
+
+def test_out_of_namespace_qualified_function_splits_qualifier(extractor):
+    code = (
+        "namespace math { int max(int a, int b); }\n"
+        "int math::max(int a, int b) { return a > b ? a : b; }\n"
+    )
+    funcs = [f for f in _functions(extractor, code) if f.start_line == 2]
+    assert len(funcs) == 1
+    assert funcs[0].name == "max"
+    assert funcs[0].receiver_type == "math"
+
+
+def test_definition_styles_converge_to_same_representation(extractor):
+    inside = _one(
+        _functions(
+            extractor, "namespace math {\nint max(int a, int b) { return a; }\n}\n"
+        ),
+        "max",
+    )
+    outside_funcs = _functions(extractor, "int math::max(int a, int b) { return a; }\n")
+    assert len(outside_funcs) == 1
+    outside = outside_funcs[0]
+    assert (inside.name, inside.receiver_type) == ("max", "math")
+    assert (outside.name, outside.receiver_type) == ("max", "math")
+
+
+# --- (c) qualified out-of-class method definitions --------------------------
+
+
+def test_out_of_class_qualified_method_splits_qualifier(extractor):
+    code = "void math::Foo::bar() { }\n"
+    funcs = _functions(extractor, code)
+    assert len(funcs) == 1
+    assert funcs[0].name == "bar"
+    assert funcs[0].receiver_type == "math::Foo"
+
+
+def test_out_of_class_constructor_is_flagged(extractor):
+    code = "math::Foo::Foo() { }\n"
+    funcs = _functions(extractor, code)
+    assert len(funcs) == 1
+    assert funcs[0].name == "Foo"
+    assert funcs[0].receiver_type == "math::Foo"
+    assert funcs[0].is_constructor is True
+
+
+def test_out_of_class_destructor_is_not_constructor(extractor):
+    code = "math::Foo::~Foo() { }\n"
+    funcs = _functions(extractor, code)
+    assert len(funcs) == 1
+    assert funcs[0].name == "~Foo"
+    assert funcs[0].receiver_type == "math::Foo"
+    assert funcs[0].is_constructor is False
+
+
+def test_out_of_class_method_inside_enclosing_namespace_composes(extractor):
+    code = "namespace outer {\nvoid Foo::bar() { }\n}\n"
+    func = _one(_functions(extractor, code), "bar")
+    assert func.receiver_type == "outer::Foo"
+
+
+# --- guards: representations that must NOT change ---------------------------
+
+
+def test_in_class_method_keeps_bare_name_and_no_receiver(extractor):
+    code = "namespace math {\nclass Foo {\npublic:\n    void bar() {}\n};\n}\n"
+    func = _one(_functions(extractor, code), "bar")
+    assert func.receiver_type is None
+
+
+def test_global_function_has_no_receiver(extractor):
+    func = _one(
+        _functions(extractor, "int square(int x) { return x * x; }\n"), "square"
+    )
+    assert func.receiver_type is None
+
+
+def test_conversion_operator_name_is_not_split(extractor):
+    code = (
+        'class Money {\npublic:\n    operator std::string() const { return ""; }\n};\n'
+    )
+    func = _one(_functions(extractor, code), "operator std::string")
+    assert func.receiver_type is None
+
+
+def test_anonymous_namespace_contributes_no_receiver(extractor):
+    func = _one(_functions(extractor, "namespace {\nvoid hidden() { }\n}\n"), "hidden")
+    assert func.receiver_type is None
+
+
+def test_nested_namespaces_join_outer_to_inner(extractor):
+    code = "namespace a {\nnamespace b {\nvoid f() { }\n}\n}\n"
+    func = _one(_functions(extractor, code), "f")
+    assert func.receiver_type == "a::b"
+
+
+def test_cpp17_nested_namespace_specifier(extractor):
+    code = "namespace a::b {\nvoid g() { }\n}\n"
+    func = _one(_functions(extractor, code), "g")
+    assert func.receiver_type == "a::b"
+
+
+def test_namespace_name_accepts_str_text_nodes():
+    # Defensive branch parity with _cpp_containing_class_name: node.text may
+    # already be str on mocked/alternative node implementations.
+    from tree_sitter_analyzer.languages._cpp_element_helpers import _cpp_namespace_name
+
+    class _NameNode:
+        type = "namespace_identifier"
+        text = "math"
+        parent = None
+
+    class _NsNode:
+        children = (_NameNode(),)
+        parent = None
+
+    assert _cpp_namespace_name(_NsNode()) == "math"
+
+
+# --- table surface: Global Functions rows show the qualified owner ----------
+
+
+def test_full_table_global_functions_show_qualified_name(extractor):
+    code = (
+        "namespace math {\n"
+        "int min(int a, int b) { return a < b ? a : b; }\n"
+        "}\n"
+        "void math::Foo::bar() { }\n"
+    )
+
+    class _Result:
+        def __init__(self, elements, file_path):
+            self.elements = elements
+            self.file_path = file_path
+            self.language = "cpp"
+            self.line_count = 4
+
+    elements = list(_functions(extractor, code))
+    formatter = CppTableFormatter()
+    table = formatter.format_analysis_result(_Result(elements, "qualified.cpp"), "full")
+    rows = [line for line in table.splitlines() if line.startswith("| math::")]
+    assert len(rows) == 2
+    assert rows[0].startswith("| math::min |")
+    assert rows[1].startswith("| math::Foo::bar |")

--- a/tests/unit/languages/test_cpp_qualified_names.py
+++ b/tests/unit/languages/test_cpp_qualified_names.py
@@ -203,3 +203,45 @@ def test_full_table_global_functions_show_qualified_name(extractor):
     assert len(rows) == 2
     assert rows[0].startswith("| math::min |")
     assert rows[1].startswith("| math::Foo::bar |")
+
+
+# --- Codex P2s on #598 ------------------------------------------------------
+
+
+def test_typed_namespace_same_name_fn_not_constructor(extractor):
+    """int math::math() has a return type (a `type` field child) — a
+    namespace function sharing the namespace's name, not a constructor."""
+    code = (
+        "namespace math { int math(); class Foo { public: Foo(); }; }\n"
+        "int math::math() { return 0; }\n"
+        "math::Foo::Foo() { }\n"
+    )
+    funcs = list(_functions(extractor, code))
+    ns_fn = [f for f in funcs if f.receiver_type == "math" and f.name == "math"]
+    assert len(ns_fn) == 1
+    assert ns_fn[0].is_constructor is False
+    ctor = [f for f in funcs if f.receiver_type == "math::Foo" and f.name == "Foo"]
+    assert len(ctor) == 1
+    assert ctor[0].is_constructor is True
+
+
+def test_outline_method_entry_carries_receiver_type(extractor):
+    """The outline surface must not orphan out-of-class definitions: a
+    receiver-bound Function outlines with its owner attached."""
+    from tree_sitter_analyzer.mcp.tools.get_code_outline_tool import _method_entry
+
+    code = "namespace math { class Foo { public: void bar(); }; }\nvoid math::Foo::bar() { }\n"
+    funcs = list(_functions(extractor, code))
+    bound = [f for f in funcs if f.receiver_type == "math::Foo"]
+    assert len(bound) == 1
+    entry = _method_entry(bound[0])
+    assert entry["name"] == "bar"
+    assert entry["receiver_type"] == "math::Foo"
+
+
+def test_outline_method_entry_omits_receiver_when_unbound(extractor):
+    from tree_sitter_analyzer.mcp.tools.get_code_outline_tool import _method_entry
+
+    funcs = list(_functions(extractor, "int plain() { return 1; }\n"))
+    entry = _method_entry(_one(funcs, "plain"))
+    assert "receiver_type" not in entry

--- a/tree_sitter_analyzer/formatters/_cpp_formatter_convert_mixin.py
+++ b/tree_sitter_analyzer/formatters/_cpp_formatter_convert_mixin.py
@@ -227,6 +227,7 @@ class CppTableFormatterConvertMixin:
 
         return {
             "name": getattr(element, "name", str(element)),
+            "receiver_type": getattr(element, "receiver_type", None),
             "visibility": visibility,
             "return_type": getattr(element, "return_type", "Any"),
             "parameters": processed_params,

--- a/tree_sitter_analyzer/formatters/_cpp_formatter_helpers.py
+++ b/tree_sitter_analyzer/formatters/_cpp_formatter_helpers.py
@@ -179,8 +179,20 @@ def _append_global_functions(
     lines.append("| Method | Signature | Vis | Lines | Cols | Cx | Doc |")
     lines.append("|--------|-----------|-----|-------|------|----|----|")
     for method in global_methods:
-        lines.append(formatter.format_method_row(method))
+        lines.append(formatter.format_method_row(_owner_qualified(method)))
     lines.append("")
+
+
+def _owner_qualified(method: dict[str, Any]) -> dict[str, Any]:
+    """Display copy with the owner prefixed (#590): ``math`` + ``max`` → ``math::max``.
+
+    Lexically global rows would otherwise show a bare ``max``/``bar`` and the
+    namespace/class association would be invisible at the table surface.
+    """
+    receiver = method.get("receiver_type")
+    if not receiver:
+        return method
+    return {**method, "name": f"{receiver}::{method.get('name', '')}"}
 
 
 def _append_global_variables(

--- a/tree_sitter_analyzer/languages/_cpp_element_helpers.py
+++ b/tree_sitter_analyzer/languages/_cpp_element_helpers.py
@@ -72,7 +72,13 @@ def _is_cpp_constructor(name: str, node: Any, qualifier: str | None = None) -> b
     if not name or name.startswith("~"):
         return False
     if qualifier is not None:
-        return qualifier.rsplit("::", 1)[-1] == name
+        if qualifier.rsplit("::", 1)[-1] != name:
+            return False
+        # Constructors carry no return type, so their function_definition
+        # has no `type` field child; a namespace function that merely shares
+        # the namespace's name (`int math::math()`) does (Codex P2 on #598).
+        get_field = getattr(node, "child_by_field_name", None)
+        return get_field is None or get_field("type") is None
     class_name = _cpp_containing_class_name(node)
     return class_name is not None and name == class_name
 

--- a/tree_sitter_analyzer/languages/_cpp_element_helpers.py
+++ b/tree_sitter_analyzer/languages/_cpp_element_helpers.py
@@ -31,6 +31,10 @@ class CppClassExtractionContext:
 
 _CPP_CLASS_NODE_TYPES = frozenset({"class_specifier", "struct_specifier"})
 _CPP_CLASS_PARENT_WALK_LIMIT = 12
+_CPP_NAMESPACE_PARENT_WALK_LIMIT = 16
+_CPP_NAMESPACE_NAME_NODE_TYPES = frozenset(
+    {"namespace_identifier", "nested_namespace_specifier", "identifier"}
+)
 
 
 def _cpp_containing_class_name(node: Any) -> str | None:
@@ -57,15 +61,79 @@ def _cpp_containing_class_name(node: Any) -> str | None:
     return None
 
 
-def _is_cpp_constructor(name: str, node: Any) -> bool:
+def _is_cpp_constructor(name: str, node: Any, qualifier: str | None = None) -> bool:
     """Return True when ``name`` matches the enclosing class name (constructor).
 
     Destructor names start with ``~``, so ``~Rectangle != Rectangle`` → False.
+    For qualified out-of-class definitions (#590) the owner comes from the
+    declarator (``math::Foo::Foo``), not the parent chain — the constructor
+    test is then ``qualifier tail == name``.
     """
     if not name or name.startswith("~"):
         return False
+    if qualifier is not None:
+        return qualifier.rsplit("::", 1)[-1] == name
     class_name = _cpp_containing_class_name(node)
     return class_name is not None and name == class_name
+
+
+def _cpp_namespace_name(ns_node: Any) -> str | None:
+    """Name of a ``namespace_definition`` node (None for anonymous namespaces)."""
+    for child in getattr(ns_node, "children", ()):
+        if getattr(child, "type", "") in _CPP_NAMESPACE_NAME_NODE_TYPES:
+            text = getattr(child, "text", b"")
+            if isinstance(text, bytes):
+                return text.decode("utf-8", errors="replace")
+            return str(text)
+    return None
+
+
+def _cpp_enclosing_namespace(node: Any) -> str | None:
+    """Join enclosing namespace names outer→inner (``a::b``), or None.
+
+    Walks the parent chain with a depth cap (same MagicMock/malformed-node
+    rationale as ``_cpp_containing_class_name``).
+    """
+    parts: list[str] = []
+    current = getattr(node, "parent", None)
+    depth = 0
+    while current is not None and depth < _CPP_NAMESPACE_PARENT_WALK_LIMIT:
+        if getattr(current, "type", "") == "namespace_definition":
+            name = _cpp_namespace_name(current)
+            if name:
+                parts.append(name)
+        current = getattr(current, "parent", None)
+        depth += 1
+    if not parts:
+        return None
+    return "::".join(reversed(parts))
+
+
+def _cpp_split_qualified_name(name: str) -> tuple[str | None, str]:
+    """Split ``math::Foo::bar`` → (``math::Foo``, ``bar``).
+
+    Conversion-operator names (``operator std::string``) are never split —
+    their ``::`` belongs to the cast-target type, not an owner qualifier.
+    """
+    if "::" in name and not name.startswith("operator "):
+        qualifier, bare = name.rsplit("::", 1)
+        return qualifier, bare
+    return None, name
+
+
+def _cpp_receiver_type(node: Any, qualifier: str | None) -> str | None:
+    """Owner of a function: declarator qualifier + enclosing namespaces (#590).
+
+    In-class members keep ``None`` — their owner already travels through the
+    class section nesting (existing convention), so a namespace-only receiver
+    (``math`` for a method of ``math::Foo``) would be misleading.
+    """
+    if _cpp_containing_class_name(node) is not None:
+        return qualifier
+    namespace = _cpp_enclosing_namespace(node)
+    if not namespace:
+        return qualifier
+    return f"{namespace}::{qualifier}" if qualifier else namespace
 
 
 def extract_cpp_function(
@@ -81,6 +149,12 @@ def extract_cpp_function(
             return None
 
         name, return_type, parameters, modifiers = function_info
+        # #590: names stay bare, the owner travels in receiver_type (same
+        # convention as Go/Rust receivers #429/#474). ``int math::max(...)``
+        # outside the namespace block and ``int max(...)`` inside it converge
+        # to the same representation: name="max", receiver_type="math".
+        qualifier, name = _cpp_split_qualified_name(name)
+        receiver_type = _cpp_receiver_type(node, qualifier)
         start_line = node.start_point[0] + 1
         end_line = node.end_point[0] + 1
         is_global = ctx.is_global_scope(node)
@@ -101,7 +175,8 @@ def extract_cpp_function(
             visibility=visibility,
             docstring=ctx.extract_comment_for_line(start_line),
             complexity_score=ctx.calculate_complexity(node),
-            is_constructor=_is_cpp_constructor(name, node),
+            is_constructor=_is_cpp_constructor(name, node, qualifier),
+            receiver_type=receiver_type,
         )
     except (AttributeError, ValueError, TypeError) as exc:
         log_debug(f"Failed to extract function info: {exc}")

--- a/tree_sitter_analyzer/mcp/tools/get_code_outline_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/get_code_outline_tool.py
@@ -596,7 +596,7 @@ def _method_entry(m: Any) -> dict[str, Any]:
             f"{getattr(p, 'type', 'Object')} {getattr(p, 'name', 'param')}"
             for p in params
         ]
-    return {
+    entry = {
         "name": getattr(m, "name", "unknown"),
         "return_type": getattr(m, "return_type", "void"),
         "parameters": param_list,
@@ -606,6 +606,14 @@ def _method_entry(m: Any) -> dict[str, Any]:
         "line_start": getattr(m, "start_line", 0),
         "line_end": getattr(m, "end_line", 0),
     }
+    # Owner of out-of-class/receiver-bound definitions (#590, Codex P2 on
+    # #598): without this, `void math::Foo::bar()` outlines as a bare `bar`
+    # with no trace of its owner. Additive, only present when bound — same
+    # Theme-A convention as #429/#474.
+    receiver = getattr(m, "receiver_type", None)
+    if receiver:
+        entry["receiver_type"] = receiver
+    return entry
 
 
 def _field_entry(f: Any) -> dict[str, Any]:


### PR DESCRIPTION
Closes #590 (split from #538 scope-B, sweep N3).

## Summary
Diagnosis nuance (live-parsed): the qualifier wasn't literally dropped — `math::max` kept it in the NAME while in-namespace `min` lost the association entirely, so two definition styles of the same logical symbol diverged. Fix converges all forms on the house convention (names stay bare, owner travels in `receiver_type` — #429/#474/#535):

| Case | Before | After |
|---|---|---|
| in-namespace fn | `min`, recv=None | `min`, recv=`math` |
| out-of-ns `math::max` | `math::max`, recv=None | `max`, recv=`math` |
| out-of-class `math::Foo::bar` | `math::Foo::bar`, recv=None | `bar`, recv=`math::Foo` |
| out-of-class ctor `math::Foo::Foo` | is_constructor=false | true (#567 family) |

Conversion operators (`operator std::string`) never split; anonymous namespaces skipped; C++17 `namespace a::b` supported; parent walk depth-capped. Full-table surface displays `math::max` (the sweep's observation point). In-class members keep recv=None (owner travels via class nesting — full Rust-parity receivers would be a larger follow-up).

## Test plan
- [x] RED-first 11 failed → GREEN 16; full relevant sweep 527 passed + agent contracts 53 (-n 0)
- [x] Goldens both halves: cpp.json zero diff (bare-name snapshots); full table 1 line `| max |`→`| math::max |`; csv/toon byte-identical after newline-artifact restore
- [x] Ratchet exit=0 (rebased over #592); patch lines covered; change-impact risk=none

Lead independently spot-checked live: all six cases above reproduce exactly.