### PR TITLE
test: ratchet batch-15 — pin 49 loose assertions in top-4 AST-ranked files

### DIFF
--- a/scripts/loose_assertion_baseline.txt
+++ b/scripts/loose_assertion_baseline.txt
@@ -29,7 +29,9 @@
 #   batch-14 (AST): 1083 -> 1026, 2026-06-12 (56 pins in top-4 AST-ranked
 #   files; pre-batch measure on base ca8e9927 was 1082 — develop had
 #   already dropped 1 since the 1083 recording).
+#   batch-15 (AST): 1026 -> 977, 2026-06-13 (49 pins in top-4 AST-ranked
+#   files).
 
-BASELINE_COUNT=1026
-MEASUREMENT_DATE=2026-06-12
+BASELINE_COUNT=977
+MEASUREMENT_DATE=2026-06-13
 MEASUREMENT_COMMAND="uv run python scripts/check_loose_assertions.py --baseline"

--- a/tests/unit/languages/test_csharp_plugin_enhanced.py
+++ b/tests/unit/languages/test_csharp_plugin_enhanced.py
@@ -206,7 +206,7 @@ class TestCSharpClassRecognition:
         tree = get_tree_for_code(COMPLEX_STRUCTURE_CODE, plugin)
         classes = plugin.extractor.extract_classes(tree, COMPLEX_STRUCTURE_CODE)
 
-        assert len(classes) >= 1
+        assert len(classes) == 4
         entity_class = next((c for c in classes if c.name == "BaseEntity"), None)
         assert entity_class is not None
         assert "abstract" in entity_class.modifiers
@@ -312,7 +312,7 @@ class TestCSharpMethodRecognition:
         functions = plugin.extractor.extract_functions(tree, ASYNC_CODE)
 
         async_methods = [f for f in functions if "Async" in f.name]
-        assert len(async_methods) >= 2
+        assert len(async_methods) == 3
         assert "GetDataAsync" in [f.name for f in async_methods]
 
     def test_extract_generic_method(self):
@@ -322,7 +322,7 @@ class TestCSharpMethodRecognition:
         functions = plugin.extractor.extract_functions(tree, GENERIC_CODE)
 
         # Should find methods with generic type parameters
-        assert len(functions) >= 3
+        assert len(functions) == 4
 
     def test_method_return_type(self):
         """Test that method return type is extracted."""
@@ -368,8 +368,8 @@ class TestCSharpMethodRecognition:
             (f for f in functions if f.name == "CalculateTotal"), None
         )
         assert calculate_total is not None
-        # Method with LINQ should have some complexity
-        assert calculate_total.complexity_score >= 1
+        # Single-statement LINQ body: base complexity only
+        assert calculate_total.complexity_score == 1
 
     def test_extract_interface_method(self):
         """Test extraction of interface methods."""
@@ -378,7 +378,7 @@ class TestCSharpMethodRecognition:
         functions = plugin.extractor.extract_functions(tree, INTERFACE_CODE)
 
         # Should find methods in interfaces
-        assert len(functions) >= 5
+        assert len(functions) == 5
 
 
 class TestCSharpPropertyRecognition:
@@ -534,7 +534,7 @@ class TestCSharpInterfaceRecognition:
         functions = plugin.extractor.extract_functions(tree, INTERFACE_CODE)
 
         # Should find methods in interfaces
-        assert len(functions) >= 5
+        assert len(functions) == 5
 
     def test_interface_visibility(self):
         """Test that interfaces have public visibility."""
@@ -613,7 +613,7 @@ class TestCSharpComplexStructures:
         classes = plugin.extractor.extract_classes(tree, COMPLEX_STRUCTURE_CODE)
 
         # Just verify extraction works
-        assert len(classes) >= 1
+        assert len(classes) == 4
 
     def test_extract_class_with_operators(self):
         """Test extraction of class with operators (if present)."""
@@ -622,7 +622,7 @@ class TestCSharpComplexStructures:
         classes = plugin.extractor.extract_classes(tree, COMPLEX_STRUCTURE_CODE)
 
         # Just verify extraction works
-        assert len(classes) >= 1
+        assert len(classes) == 4
 
     def test_extract_generic_constraints(self):
         """Test extraction of generic type constraints."""
@@ -657,9 +657,12 @@ class TestCSharpQueryAccuracy:
         classes = plugin.extractor.extract_classes(tree, COMPLEX_STRUCTURE_CODE)
 
         # Should not extract non-class elements
-        for cls in classes:
-            assert cls.name is not None
-            assert len(cls.name) > 0
+        assert [c.name for c in classes] == [
+            "BaseEntity",
+            "Order",
+            "OrderItem",
+            "OrderEventArgs",
+        ]
 
     def test_method_query_accuracy(self):
         """Test that method query accurately identifies methods."""
@@ -668,9 +671,18 @@ class TestCSharpQueryAccuracy:
         functions = plugin.extractor.extract_functions(tree, COMPLEX_STRUCTURE_CODE)
 
         # Should not extract non-method elements
-        for func in functions:
-            assert func.name is not None
-            assert len(func.name) > 0
+        assert [f.name for f in functions] == [
+            "Id",
+            "CreatedAt",
+            "TotalOrders",
+            "Order",
+            "CalculateTotal",
+            "CompareTo",
+            "Name",
+            "Price",
+            "Quantity",
+            "Order",
+        ]
 
     def test_property_query_accuracy(self):
         """Test that property query accurately identifies properties."""
@@ -747,9 +759,12 @@ class TestCSharpQueryAccuracy:
         tree = get_tree_for_code(COMPLEX_STRUCTURE_CODE, plugin)
         classes = plugin.extractor.extract_classes(tree, COMPLEX_STRUCTURE_CODE)
 
-        for cls in classes:
-            assert cls.start_line > 0
-            assert cls.end_line >= cls.start_line
+        assert [(c.name, c.start_line, c.end_line) for c in classes] == [
+            ("BaseEntity", 8, 13),
+            ("Order", 15, 37),
+            ("OrderItem", 39, 44),
+            ("OrderEventArgs", 46, 49),
+        ]
 
     def test_complexity_calculation_accuracy(self):
         """Test that complexity calculation is accurate."""
@@ -761,5 +776,5 @@ class TestCSharpQueryAccuracy:
             (f for f in functions if f.name == "CalculateTotal"), None
         )
         assert calculate_total is not None
-        # LINQ query should have reasonable complexity
-        assert calculate_total.complexity_score >= 1
+        # Single-statement LINQ body: base complexity only
+        assert calculate_total.complexity_score == 1

--- a/tests/unit/languages/test_kotlin_coverage_boost.py
+++ b/tests/unit/languages/test_kotlin_coverage_boost.py
@@ -37,7 +37,7 @@ fun greet(name: String, age: Int, active: Boolean): String {
 """
         tree = parser.parse(code.encode("utf-8"))
         functions = extractor.extract_functions(tree, code)
-        assert len(functions) >= 1
+        assert len(functions) == 1
         # Check parameters are extracted
         func = functions[0]
         assert func.name == "greet"
@@ -51,7 +51,7 @@ fun process(data: String?, count: Int?): Boolean? {
 """
         tree = parser.parse(code.encode("utf-8"))
         functions = extractor.extract_functions(tree, code)
-        assert len(functions) >= 1
+        assert len(functions) == 1
 
     def test_function_with_lambda_parameter(self, extractor, parser):
         """Test function with lambda parameter."""
@@ -62,7 +62,7 @@ fun execute(callback: (String) -> Unit) {
 """
         tree = parser.parse(code.encode("utf-8"))
         functions = extractor.extract_functions(tree, code)
-        assert len(functions) >= 1
+        assert len(functions) == 1
 
     def test_function_with_vararg(self, extractor, parser):
         """Test function with vararg parameter."""
@@ -73,7 +73,7 @@ fun printAll(vararg items: String) {
 """
         tree = parser.parse(code.encode("utf-8"))
         functions = extractor.extract_functions(tree, code)
-        assert len(functions) >= 1
+        assert len(functions) == 1
 
 
 class TestKotlinExtractorVisibility:
@@ -97,7 +97,7 @@ open class Base {
 """
         tree = parser.parse(code.encode("utf-8"))
         functions = extractor.extract_functions(tree, code)
-        assert len(functions) >= 1
+        assert len(functions) == 1
 
     def test_internal_function(self, extractor, parser):
         """Test internal visibility."""
@@ -106,7 +106,7 @@ internal fun moduleHelper(): String = "internal"
 """
         tree = parser.parse(code.encode("utf-8"))
         functions = extractor.extract_functions(tree, code)
-        assert len(functions) >= 1
+        assert len(functions) == 1
 
     def test_private_class(self, extractor, parser):
         """Test private class."""
@@ -117,7 +117,7 @@ private class Secret {
 """
         tree = parser.parse(code.encode("utf-8"))
         classes = extractor.extract_classes(tree, code)
-        assert len(classes) >= 1
+        assert len(classes) == 1
 
 
 class TestKotlinExtractorProperties:
@@ -234,7 +234,7 @@ fun add(a: Int, b: Int): Int = a + b
 """
         tree = parser.parse(code.encode("utf-8"))
         functions = extractor.extract_functions(tree, code)
-        assert len(functions) >= 1
+        assert len(functions) == 1
 
     def test_class_with_kdoc(self, extractor, parser):
         """Test class with KDoc comment."""
@@ -248,7 +248,7 @@ data class User(val name: String, val age: Int)
 """
         tree = parser.parse(code.encode("utf-8"))
         classes = extractor.extract_classes(tree, code)
-        assert len(classes) >= 1
+        assert len(classes) == 1
 
 
 class TestKotlinExtractorErrorPaths:
@@ -289,6 +289,7 @@ class Broken {
 
         # Mock node with unusual positions
         mock_node = Mock()
+        mock_node.parent = None
         mock_node.start_point = (0, 0)
         mock_node.end_point = (0, 13)
         mock_node.start_byte = 0
@@ -370,7 +371,7 @@ class Service {
 """
         tree = parser.parse(code.encode("utf-8"))
         classes = extractor.extract_classes(tree, code)
-        assert len(classes) >= 1
+        assert len(classes) == 1
         cls = classes[0]
         assert cls.name == "Service"
 
@@ -384,7 +385,7 @@ abstract class Shape {
 """
         tree = parser.parse(code.encode("utf-8"))
         classes = extractor.extract_classes(tree, code)
-        assert len(classes) >= 1
+        assert len(classes) == 1
 
     def test_extract_interface(self, extractor, parser):
         """Test interface extraction."""
@@ -409,7 +410,7 @@ class Circle(val radius: Double) : Shape() {
 """
         tree = parser.parse(code.encode("utf-8"))
         classes = extractor.extract_classes(tree, code)
-        assert len(classes) >= 1
+        assert len(classes) == 1
 
     def test_extract_object_with_methods(self, extractor, parser):
         """Test object declaration with methods."""
@@ -428,7 +429,7 @@ object DatabaseManager {
 """
         tree = parser.parse(code.encode("utf-8"))
         classes = extractor.extract_classes(tree, code)
-        assert len(classes) >= 1
+        assert len(classes) == 1
 
 
 class TestKotlinTextExtractionEdgeCases:
@@ -444,6 +445,7 @@ class TestKotlinTextExtractionEdgeCases:
         extractor.content_lines = ["val x = 1"]
 
         mock_node = Mock()
+        mock_node.parent = None
         mock_node.start_byte = 0
         mock_node.end_byte = 9
         mock_node.start_point = (0, 0)
@@ -465,6 +467,7 @@ class TestKotlinTextExtractionEdgeCases:
         extractor.content_lines = code.split("\n")
 
         mock_node = Mock()
+        mock_node.parent = None
         mock_node.start_byte = 0
         mock_node.end_byte = len(code)
         mock_node.start_point = (0, 0)
@@ -479,6 +482,7 @@ class TestKotlinTextExtractionEdgeCases:
         extractor.content_lines = ["short"]
 
         mock_node = Mock()
+        mock_node.parent = None
         mock_node.start_byte = 100
         mock_node.end_byte = 200
         mock_node.start_point = (10, 0)
@@ -507,6 +511,7 @@ class TestKotlinExtractorExceptionPaths:
 
         # Create a mock node that will cause an exception
         mock_node = Mock()
+        mock_node.parent = None
         mock_node.start_point = Mock(side_effect=Exception("test error"))
 
         result = extractor._extract_function(mock_node)
@@ -518,6 +523,7 @@ class TestKotlinExtractorExceptionPaths:
         extractor.content_lines = []
 
         mock_node = Mock()
+        mock_node.parent = None
         mock_node.start_point = Mock(side_effect=Exception("test error"))
 
         result = extractor._extract_class(mock_node)
@@ -529,6 +535,7 @@ class TestKotlinExtractorExceptionPaths:
         extractor.content_lines = []
 
         mock_node = Mock()
+        mock_node.parent = None
         mock_node.start_point = Mock(side_effect=Exception("test error"))
 
         result = extractor._extract_property(mock_node)
@@ -540,6 +547,7 @@ class TestKotlinExtractorExceptionPaths:
         extractor.content_lines = []
 
         mock_node = Mock()
+        mock_node.parent = None
         mock_node.start_point = Mock(side_effect=Exception("test error"))
 
         result = extractor._extract_import(mock_node)
@@ -551,6 +559,7 @@ class TestKotlinExtractorExceptionPaths:
         extractor.content_lines = ["import"]
 
         mock_node = Mock()
+        mock_node.parent = None
         mock_node.start_point = (0, 0)
         mock_node.end_point = (0, 6)
         mock_node.start_byte = 0
@@ -563,5 +572,6 @@ class TestKotlinExtractorExceptionPaths:
     def test_extract_docstring(self, extractor):
         """Test docstring extraction."""
         mock_node = Mock()
+        mock_node.parent = None
         result = extractor._extract_docstring(mock_node)
         assert result is None

--- a/tests/unit/languages/test_python_plugin_coverage_boost.py
+++ b/tests/unit/languages/test_python_plugin_coverage_boost.py
@@ -47,7 +47,11 @@ def test_python_plugin_basic(plugin):
     tree = _parse(plugin, code)
     elements = plugin.extract_elements(tree, code)
     assert elements is not None
-    assert len(elements) > 0
+    assert len(elements) == 4
+    assert len(elements["functions"]) == 3
+    assert len(elements["classes"]) == 1
+    assert len(elements["imports"]) == 2
+    assert len(elements["variables"]) == 0
 
 
 class TestExtractImportsManual:
@@ -55,7 +59,7 @@ class TestExtractImportsManual:
         code = "import os\nimport sys\n"
         tree = _parse(plugin, code)
         imports = extractor._extract_imports_manual(tree.root_node, code)
-        assert len(imports) >= 2
+        assert len(imports) == 2
         names = [i.name for i in imports]
         assert "os" in names
         assert "sys" in names
@@ -64,7 +68,7 @@ class TestExtractImportsManual:
         code = "from os.path import join, exists\n"
         tree = _parse(plugin, code)
         imports = extractor._extract_imports_manual(tree.root_node, code)
-        assert len(imports) >= 1
+        assert len(imports) == 1
         imp = imports[0]
         assert imp.module_name == "os.path"
         assert "join" in imp.imported_names
@@ -74,7 +78,7 @@ class TestExtractImportsManual:
         code = "from collections import OrderedDict\n"
         tree = _parse(plugin, code)
         imports = extractor._extract_imports_manual(tree.root_node, code)
-        assert len(imports) >= 1
+        assert len(imports) == 1
         assert "collections" in imports[0].module_name
 
     def test_empty_code(self, extractor, plugin):
@@ -104,7 +108,7 @@ class TestExtractPackages:
             plugin = PythonPlugin()
             tree = _parse(plugin, "# test\n")
             packages = extractor.extract_packages(tree, "")
-            assert len(packages) >= 1
+            assert len(packages) == 1
             assert packages[0].name == "mypkg"
 
     def test_no_init_file(self, extractor):
@@ -167,7 +171,7 @@ class TestExtractDecoratorsFromNode:
             return result
 
         func_nodes = find_nodes(tree.root_node, "function_definition")
-        assert len(func_nodes) >= 1
+        assert len(func_nodes) == 1
         decorators = extractor._extract_decorators_from_node(func_nodes[0], code)
         assert "property" in decorators
 
@@ -203,7 +207,7 @@ class TestExtractReturnTypeFromNode:
             return result
 
         func_nodes = find_nodes(tree.root_node, "function_definition")
-        assert len(func_nodes) >= 1
+        assert len(func_nodes) == 1
         ret = extractor._extract_return_type_from_node(func_nodes[0], code)
         assert ret is not None and "str" in ret
 
@@ -277,7 +281,7 @@ class TestExtractFunctionBody:
             return result
 
         func_nodes = find_nodes(tree.root_node, "function_definition")
-        assert len(func_nodes) >= 1
+        assert len(func_nodes) == 1
         body = extractor._extract_function_body(func_nodes[0], code)
         assert "x = 1" in body
 
@@ -296,7 +300,7 @@ class TestExtractSuperclassesFromNode:
             return result
 
         class_nodes = find_nodes(tree.root_node, "class_definition")
-        assert len(class_nodes) >= 1
+        assert len(class_nodes) == 1
         supers = extractor._extract_superclasses_from_node(class_nodes[0], code)
         assert "Base" in supers
 
@@ -326,7 +330,7 @@ class TestCalculateComplexity:
     def test_with_branches(self, extractor):
         body = "if x:\n    pass\nelif y:\n    pass\nfor i in range(10):\n    pass"
         c = extractor._calculate_complexity(body)
-        assert c >= 3
+        assert c == 3
 
 
 class TestExtractDetailedFunctionInfo:
@@ -343,7 +347,7 @@ class TestExtractDetailedFunctionInfo:
             return result
 
         func_nodes = find_nodes(tree.root_node, "function_definition")
-        assert len(func_nodes) >= 1
+        assert len(func_nodes) == 1
         info = extractor._extract_detailed_function_info(
             func_nodes[0], code, is_async=True
         )
@@ -363,7 +367,7 @@ class TestExtractDetailedFunctionInfo:
             return result
 
         func_nodes = find_nodes(tree.root_node, "function_definition")
-        assert len(func_nodes) >= 1
+        assert len(func_nodes) == 1
         info = extractor._extract_detailed_function_info(func_nodes[0], code)
         assert info is not None
         assert info.name == "__init__"
@@ -382,7 +386,7 @@ class TestExtractDetailedFunctionInfo:
             return result
 
         func_nodes = find_nodes(tree.root_node, "function_definition")
-        assert len(func_nodes) >= 1
+        assert len(func_nodes) == 1
         info = extractor._extract_detailed_function_info(func_nodes[0], code)
         assert info is not None
         assert info.name == "_internal"

--- a/tests/unit/test_codegraph_sitemap.py
+++ b/tests/unit/test_codegraph_sitemap.py
@@ -35,7 +35,7 @@ def indexed_project(tmp_path):
 
     cache = ASTCache(str(project))
     result = cache.index_project()
-    assert result["indexed"] >= 2, f"Expected ≥2 indexed files, got {result}"
+    assert result["indexed"] == 3, f"Expected 3 indexed files, got {result}"
     cache.close()
     return project
 
@@ -59,8 +59,8 @@ class TestSitemapTool:
         result = await tool.execute({"mode": "full", "output_format": "json"})
         assert result["success"] is True
         assert result["verdict"] == "INFO"
-        assert result["file_count"] >= 2
-        assert result["total_symbols"] > 0
+        assert result["file_count"] == 3
+        assert result["total_symbols"] == 7
         sitemap = result["sitemap"]
         assert "app" in sitemap
 
@@ -81,7 +81,7 @@ class TestSitemapTool:
         result = await tool.execute({"mode": "module", "output_format": "json"})
         assert result["success"] is True
         modules = result["modules"]
-        assert len(modules) >= 1
+        assert len(modules) == 1
         mod_names = [m["directory"] for m in modules]
         assert any("app" in m for m in mod_names)
 
@@ -91,7 +91,7 @@ class TestSitemapTool:
         result = await tool.execute({"mode": "flat", "output_format": "json"})
         assert result["success"] is True
         counts = result["counts"]
-        assert counts.get("function", 0) > 0
+        assert counts.get("function", 0) == 3
 
     @pytest.mark.asyncio
     async def test_language_filter(self, indexed_project):
@@ -109,7 +109,7 @@ class TestSitemapTool:
             {"mode": "flat", "directory": "app", "output_format": "json"}
         )
         assert result["success"] is True
-        assert result["file_count"] >= 1
+        assert result["file_count"] == 3
 
     @pytest.mark.asyncio
     async def test_empty_cache(self, tmp_path):
@@ -156,7 +156,7 @@ def large_indexed_project(tmp_path):
 
     cache = ASTCache(str(project))
     result = cache.index_project()
-    assert result["indexed"] >= 60, f"Expected ≥60 indexed files, got {result}"
+    assert result["indexed"] == 61, f"Expected 61 indexed files, got {result}"
     cache.close()
     return project
 
@@ -192,7 +192,7 @@ class TestSitemapOutputBudget:
         assert result["truncated"] is True
         assert "max_symbols" in result["truncation_note"]
         # counts still report the true (untruncated) totals.
-        assert result["counts"].get("function", 0) >= 600
+        assert result["counts"].get("function", 0) == 600
 
     @pytest.mark.asyncio
     async def test_api_mode_capped_by_default(self, large_indexed_project):
@@ -205,7 +205,7 @@ class TestSitemapOutputBudget:
         assert result["truncated"] is True
         assert "max_symbols" in result["truncation_note"]
         # The scalar counts reflect the true totals, not the truncated list.
-        assert result["public_function_count"] >= 600
+        assert result["public_function_count"] == 600
 
     @pytest.mark.asyncio
     async def test_max_symbols_param_expands_list(self, large_indexed_project):
@@ -219,7 +219,7 @@ class TestSitemapOutputBudget:
             }
         )
         emitted = sum(len(v) for v in result["symbols_by_kind"].values())
-        assert emitted >= 600, f"expected ≥600 with max_symbols=1000, got {emitted}"
+        assert emitted == 600, f"expected 600 with max_symbols=1000, got {emitted}"
         assert result["truncated"] is False
 
     @pytest.mark.asyncio
@@ -281,7 +281,7 @@ class TestSitemapCLI:
         result = self._run_cli(indexed_project, monkeypatch, "flat")
         assert result["success"] is True
         assert result["file_count"] == 3
-        assert result["counts"].get("function", 0) > 0
+        assert result["counts"].get("function", 0) == 3
 
     def test_cli_api_mode(self, indexed_project, monkeypatch):
         result = self._run_cli(indexed_project, monkeypatch, "api")


### PR DESCRIPTION
## Summary
Loose-assertion ratchet batch 15. Top-4 files by AST counter, every `>=`/`> N` pinned to measured exact values:

| File | Pins |
|---|---|
| tests/unit/languages/test_python_plugin_coverage_boost.py | 13 |
| tests/unit/languages/test_kotlin_coverage_boost.py | 13 |
| tests/unit/languages/test_csharp_plugin_enhanced.py | 12 |
| tests/unit/test_codegraph_sitemap.py | 11 |

Baseline: **1026 → 977** (= exactly 49, lead re-verified live).

Contract 5b notes: 10 Mock tree-sitter nodes in the kotlin file got explicit `parent=None` (OOM rule) before pinning; loop-form asserts upgraded to exact element-list pins (strictly stronger); zero exemption markers; the duplicate `"Order"` in the csharp pinned list is real measured output (constructor + property), pinned as-is.

## Test plan
- [x] All 4 files individually `-n 0`: 32/35/49/21 passed
- [x] Diff gate `check_loose_assertions.py origin/develop` exit=0
- [x] `--baseline` measures 977 == recorded (lead independently re-verified)