### PR TITLE
docs(rfc): RFC-0016 — semantic symbol search via sqlite-vec (draft)

### DIFF
--- a/rfcs/0016-semantic-symbol-search.md
+++ b/rfcs/0016-semantic-symbol-search.md
@@ -318,7 +318,10 @@ versions; its prior-art value is SQL ergonomics, not ANN.
 
 ## What this RFC does NOT do (deferred)
 
-- sqlite-vec/ANN indexing (phase-2, behind a measured trigger).
+- sqlite-vec/ANN indexing (phase-2, behind a measured trigger; if adopted,
+  the vec0 column MUST pin `distance_metric=cosine` — the default is L2,
+  which would silently disagree with the phase-1 cosine semantics (Codex P2
+  on #603 rev 1)).
 - `nav action=context` semantic rerank (phase-2, pilot-gated).
 - Body-content embeddings; cross-repo federation; replacing BM25 anywhere;
   auto-building on first connect. (Unchanged.)

--- a/rfcs/0016-semantic-symbol-search.md
+++ b/rfcs/0016-semantic-symbol-search.md
@@ -1,0 +1,236 @@
+# RFC-0016: Semantic symbol search via sqlite-vec in `.ast-cache`
+
+- **Status**: draft
+- **Author(s)**: lead (autonomous), on behalf of dogfood evidence in #517
+- **Created**: 2026-06-13
+- **Last updated**: 2026-06-13
+- **Tracking issue**: #517
+- **Affected source paths** (pin them — reviewers watch for drift here):
+  - `tree_sitter_analyzer/mcp/tools/` (search facade: new `semantic` action)
+  - `tree_sitter_analyzer/core/ast_cache*` (new `symbol_embeddings` virtual table, schema version bump)
+  - `tree_sitter_analyzer/cli_main.py` (new `--search-semantic` flag, CLI twin)
+  - `tests/unit/mcp/`, `tests/integration/` (RED-first suites below)
+
+## Summary
+
+Add an opt-in semantic (vector) symbol search to the existing `.ast-cache`
+SQLite file using the `sqlite-vec` extension: embed each symbol's
+signature + docstring at index time, expose `search action=semantic`
+(MCP) / `--search-semantic` (CLI), and optionally rerank `nav
+action=context` candidates. No new daemon, no storage-engine change — the
+"100% local, zero infra" story stays intact.
+
+## Motivation
+
+BM25-only search dead-ends on **conceptual** queries — measured, not
+hypothetical (#517, #441 residual):
+
+- `nav action=context "how does the MCP server route a tool call to the
+  right facade action"` → candidates are honest post-#487, but
+  `entry_points` is **empty**: `legacy_to_facade` / `handle_call_tool`
+  exist, yet no lexical token reaches them.
+- `search action=symbol` requires knowing a name fragment; "where is
+  request dispatching handled" finds nothing.
+
+Every "how does X work" question that shares no tokens with symbol names
+forces the agent back into grep loops — the exact behavior TSA exists to
+replace. This is the single biggest recall gap left in the dogfood resolution
+program (#441 → #487 closed the stop-word half; this RFC addresses the
+semantic half).
+
+## Detailed design
+
+### Storage (ast_cache schema)
+
+New virtual table in the **same** `.ast-cache` SQLite database:
+
+```sql
+-- requires the sqlite-vec loadable extension
+CREATE VIRTUAL TABLE IF NOT EXISTS symbol_embeddings USING vec0(
+    symbol_id INTEGER PRIMARY KEY,   -- FK → existing symbols rowid
+    embedding FLOAT[384]             -- model-dependent dim, pinned in meta
+);
+CREATE TABLE IF NOT EXISTS embedding_meta (
+    model_id TEXT NOT NULL,          -- e.g. "minilm-l6-v2-onnx"
+    dim INTEGER NOT NULL,
+    built_at TEXT NOT NULL,
+    symbols_embedded INTEGER NOT NULL
+);
+```
+
+- Schema version bumps (existing ast_cache migration convention). Absence of
+  the extension or the table MUST degrade gracefully: `semantic` action
+  returns `verdict=INFO` + `next_step` pointing at the build command — never
+  a crash, never a silent empty result (honesty convention, #537).
+- Embedding input per symbol: `"{kind} {qualified_name}({params}) -> {return_type}\n{docstring}"`
+  — signature line + docstring, capped at N tokens (pinned in implementation).
+
+### Embedding model (Open question 1 — panel decision required)
+
+Two candidate paths, both local-only:
+
+| | A: bundled ONNX MiniLM (all-MiniLM-L6-v2, ~23 MB int8) | B: optional `ollama` / user-provided endpoint |
+|---|---|---|
+| Install | `pip install tree-sitter-analyzer[semantic]` pulls onnxruntime + model | zero new deps; user opts in via config |
+| Cold start | ~100 ms session warmup | depends on user daemon |
+| Licensing | Apache-2 model, redistributable | n/a |
+| Offline | guaranteed | user-managed |
+
+Default proposal: **A** as the `[semantic]` extra (keeps zero-config), with
+B as a config override (`TSA_EMBEDDING_ENDPOINT`). Neither ships in the
+default install — the base wheel stays lean.
+
+### Index build
+
+- `index action=build_semantic` (MCP) / `--build-semantic-index` (CLI):
+  embeds all symbols, batched, resumable; writes `embedding_meta`.
+- Incremental: the existing file-watcher/dirty-file path re-embeds only
+  symbols whose source file changed (delta keyed off the existing symbols
+  table).
+- Build is **never** implicit: first call to `semantic` without an index
+  returns the INFO verdict above. No surprise multi-minute writes.
+
+### Query path
+
+#### MCP surface (facade + action)
+
+```python
+# search facade — new action
+{
+  "action": "semantic",
+  "query": "where is request dispatching handled",   # required
+  "limit": 10,                                        # default 10, capped
+  "output_format": "toon",                            # MCP default, locked
+}
+# → response (TOON_CONTROL_SURFACE-compliant):
+{
+  "verdict": "INFO",
+  "results": [
+    {"symbol": "handle_call_tool", "file": "...", "line": 123,
+     "score": 0.78, "signature": "..."},
+  ],
+  "results_listed": 10, "total_candidates": 40, "truncated": true,
+  "next_step": "nav action=context --query '<top symbol>'"
+}
+```
+
+- KNN via `vec0` `MATCH` with `k = limit * 4` over-fetch, then a cheap
+  lexical-overlap tiebreak so exact-name hits never rank below fuzzy ones
+  (hybrid guard).
+- `nav action=context` gains an optional `rerank: "semantic"` parameter
+  (default off) that reorders its candidate pool by embedding similarity —
+  directly targets the empty-`entry_points` failure.
+
+#### Error handling
+
+| Condition | Behavior |
+|---|---|
+| sqlite-vec extension not loadable | `verdict=ERROR`, message names the missing extra, `next_step` install hint (mirrors #559 Swift grammar honesty) |
+| index absent / stale model_id | `verdict=INFO` + build command |
+| query embeds to zero-vector / model error | `verdict=ERROR`, no fallback to silent BM25 (explicit `fallback:"bm25"` param if the agent wants it) |
+
+#### Concurrency / async
+
+Read path is a plain SQLite read (WAL, same as existing). Build path takes
+the existing writer lock; embedding runs in a thread pool, DB writes batched
+on the loop thread (same pattern as the current index build).
+
+## Three-Surface impact (CLI ↔ MCP parity)
+
+| Surface | Addition |
+|---|---|
+| MCP | `search action=semantic`; `index action=build_semantic`; `nav action=context` `rerank` param |
+| CLI | `--search-semantic <query>` (+ `--limit`); `--build-semantic-index` |
+| Output | MCP defaults TOON (🔒 locked, unchanged); CLI defaults JSON (unchanged) |
+
+Parity test: the registry-driven parity suite gains the two new pairs.
+
+## Drawbacks
+
+- **Index size**: 384-dim float32 ≈ 1.5 KB/symbol → ~30 MB for a 20k-symbol
+  repo (int8 quantization halves-to-quarters this). `.ast-cache` grows
+  noticeably; must stay opt-in.
+- **Build latency**: minutes-scale first build on large repos (CPU ONNX
+  ~1-2k symbols/s expected; needs measurement per Rule 11 — a cost claim
+  without an executable invariant is a belief).
+- **New optional dependency surface**: onnxruntime wheels per-platform;
+  sqlite-vec loadable-extension quirks (notably macOS SIP and Windows DLL
+  paths) need CI coverage on all three OS axes.
+- **Quality ceiling**: signature+docstring embeddings miss body semantics;
+  undocumented symbols embed thin. Mitigation: include leading body comment
+  line (deferred, see non-goals).
+
+## Alternatives
+
+- **A: FTS5 synonym/expansion layer** (no vectors): cheap, but cannot bridge
+  "dispatching" → `handle_call_tool` without hand-curated synonyms; rejected
+  as unmaintainable.
+- **B: external vector DB (LanceDB/qdrant)**: better tooling, but breaks the
+  zero-daemon/single-file story — the moat (#helixdb assessment: local
+  zero-dependency IS the differentiator). Rejected.
+- **C: embed at query time only (no index), brute-force cosine over
+  signatures**: O(n) per query, ~50 ms at 20k symbols — actually viable as a
+  fallback mode and as phase-1 ship vehicle; kept as an explicit option in
+  the implementation plan (build the API first, swap brute-force → vec0
+  index transparently).
+- **D: do nothing**: the #441 residual stays; agents grep-loop on every
+  conceptual query. Rejected by dogfood evidence.
+
+## Prior art
+
+- **codegraph**: `codegraph_context` does lexical + graph expansion, no
+  vectors — same gap.
+- **Sourcegraph Cody / embeddings era**: shipped then partially retreated
+  from repo embeddings due to staleness cost — our incremental dirty-file
+  re-embed addresses the staleness half; their lesson (hybrid lexical+vector
+  beats pure vector) is adopted via the lexical tiebreak.
+- **sqlite-vec** (asg017): the load-bearing dependency; vec0 virtual tables,
+  used in production by several local-first tools.
+
+## Test plan (RED-first)
+
+- Unit: schema migration (version bump, fresh + upgrade); graceful-degrade
+  verdicts (extension missing / index absent / stale model); embedding input
+  formatter (exact pins); hybrid tiebreak ordering (exact-name beats fuzzy).
+- Integration: build → query round-trip on a fixture repo; incremental
+  re-embed after file edit (only dirty file re-embedded — exact count pin);
+  CLI↔MCP parity pair tests.
+- Dogfood acceptance (the motivating queries, pinned as e2e):
+  - "how does the MCP server route a tool call to the right facade action"
+    → `handle_call_tool` (or `legacy_to_facade`) in top-5.
+  - "where is request dispatching handled" → non-empty, top-5 contains a
+    routing symbol.
+- Cost invariants (Rule 11): index bytes/symbol ≤ pinned ceiling; build
+  throughput symbols/s ≥ pinned floor — measured, dated, in
+  `test_output_cost_invariants.py` style.
+
+## Acceptance criteria
+
+- [ ] `search action=semantic` + `--search-semantic` ship behind the
+      `[semantic]` extra, default-off
+- [ ] Graceful-degrade verdicts for all three absence modes
+- [ ] Incremental re-embed on file change (exact-count pinned test)
+- [ ] Both motivating dogfood queries pass top-5 (e2e)
+- [ ] CLI↔MCP parity test green
+- [ ] Cost invariants measured and pinned (size, build throughput)
+- [ ] Docs/CODEMAPS updated (+ facade-actions.md regenerates with the new
+      action, #519 ratchet)
+
+## What this RFC does NOT do (deferred)
+
+- Body-content / comment embeddings (signature+docstring only).
+- Cross-repo or multi-index federation.
+- Replacing BM25 anywhere — `semantic` is additive; existing `symbol` /
+  `content` actions and their defaults are untouched.
+- Auto-building the index on first MCP connect.
+
+## Open questions
+
+1. Embedding model default: bundled ONNX MiniLM (`[semantic]` extra) vs
+   ollama-endpoint-only? (proposal: ONNX default, endpoint override)
+2. Ship phase-1 with brute-force cosine (Alternative C) to decouple API
+   stabilization from sqlite-vec platform risk, swapping the index in
+   phase-2?
+3. Should `nav action=context` rerank become default-on once the index
+   exists, or stay opt-in forever (token-cost neutrality argument)?
+4. int8 quantization from day one, or float32 first + quantize later?

--- a/rfcs/0016-semantic-symbol-search.md
+++ b/rfcs/0016-semantic-symbol-search.md
@@ -1,236 +1,334 @@
-# RFC-0016: Semantic symbol search via sqlite-vec in `.ast-cache`
+# RFC-0016: Semantic symbol search (brute-force-first, sqlite-vec deferred)
 
-- **Status**: draft
+- **Status**: draft (revision 2 — rewritten after adversarial panel round 1)
 - **Author(s)**: lead (autonomous), on behalf of dogfood evidence in #517
 - **Created**: 2026-06-13
 - **Last updated**: 2026-06-13
 - **Tracking issue**: #517
 - **Affected source paths** (pin them — reviewers watch for drift here):
   - `tree_sitter_analyzer/mcp/tools/` (search facade: new `semantic` action)
-  - `tree_sitter_analyzer/core/ast_cache*` (new `symbol_embeddings` virtual table, schema version bump)
+  - `tree_sitter_analyzer/ast_cache.py`, `tree_sitter_analyzer/_ast_cache_schema.py`,
+    `tree_sitter_analyzer/_ast_cache_write.py` (docstring/signature serialization,
+    new `symbol_embeddings` table, schema version bump)
   - `tree_sitter_analyzer/cli_main.py` (new `--search-semantic` flag, CLI twin)
   - `tests/unit/mcp/`, `tests/integration/` (RED-first suites below)
 
+> **Revision 2 note.** Round-1 adversarial review (two independent reviewers,
+> all findings probe-backed) falsified three load-bearing claims of revision 1:
+> the motivating query was NOT broken on HEAD, the specified embedding input
+> does not exist in the cache schema, and the brute-force cost estimate was
+> ~119× too high — which was the only thing making sqlite-vec look necessary
+> for v1. This revision re-measures the motivation, re-scopes phase-1 to
+> brute-force-over-BLOB, demotes sqlite-vec to a measured-need phase-2, and
+> adds a retrieval-quality pilot as an acceptance PRECONDITION. Raw findings:
+> PR #603 review thread.
+
 ## Summary
 
-Add an opt-in semantic (vector) symbol search to the existing `.ast-cache`
-SQLite file using the `sqlite-vec` extension: embed each symbol's
-signature + docstring at index time, expose `search action=semantic`
-(MCP) / `--search-semantic` (CLI), and optionally rerank `nav
-action=context` candidates. No new daemon, no storage-engine change — the
-"100% local, zero infra" story stays intact.
+Add an opt-in semantic (vector) symbol search: embed each symbol's
+signature + docstring at index time into a plain BLOB column in the existing
+`.ast-cache` SQLite file, query via brute-force cosine (measured ~1 ms at
+this repo's 44k symbols), expose `search action=semantic` (MCP) /
+`--search-semantic` (CLI). No new daemon, no loadable extension in phase-1.
+sqlite-vec/ANN indexing is explicitly deferred until a measured need exists.
+A near-free lexical improvement (FTS5 porter stemming) ships first as its own
+change and re-baselines the motivation.
 
-## Motivation
+## Motivation (re-measured 2026-06-13 on HEAD `1cc119b7`)
 
-BM25-only search dead-ends on **conceptual** queries — measured, not
-hypothetical (#517, #441 residual):
+Revision 1 claimed `entry_points` came back **empty** for conceptual queries.
+Re-measured on HEAD, that is **false** for the flagship query — and the real
+failure is worse than emptiness:
 
 - `nav action=context "how does the MCP server route a tool call to the
-  right facade action"` → candidates are honest post-#487, but
-  `entry_points` is **empty**: `legacy_to_facade` / `handle_call_tool`
-  exist, yet no lexical token reaches them.
-- `search action=symbol` requires knowing a name fragment; "where is
-  request dispatching handled" finds nothing.
+  right facade action"` → rank #1 = `legacy_to_facade` (facade_map.py:140).
+  **Already works on BM25.** (#487 fixed more than #517 credited; the issue
+  evidence was captured against a stale index.)
+- `nav action=context "where is request dispatching handled"` → 6
+  entry_points, **all confidently-irrelevant test helpers** that token-match
+  "handled" (`test_symlink_handled`, `_collect_handled_errors`, …) under
+  `verdict=INFO`.
+- `search action=symbol "dispatch*"` → 9 production hits — the gap for this
+  family is **stemming** ("dispatching" ≠ "dispatch" under FTS5's default
+  tokenizer), not semantics.
 
-Every "how does X work" question that shares no tokens with symbol names
-forces the agent back into grep loops — the exact behavior TSA exists to
-replace. This is the single biggest recall gap left in the dogfood resolution
-program (#441 → #487 closed the stop-word half; this RFC addresses the
-semantic half).
+So the measured problem is two-layered:
+
+1. **Stemming gap** — closable for ~zero cost with FTS5's built-in porter
+   tokenizer (one-line `tokenize=` change + reindex). This ships FIRST,
+   independent of this RFC (tracking: see Acceptance precondition 0), and
+   the semantic layer is then justified only by what stemming cannot close.
+2. **Conceptual gap with confidently-wrong results** — "dispatching" never
+   bridges to `handle_call_tool` lexically, and BM25 fills the void with
+   plausible garbage instead of admitting low confidence. The honesty
+   problem (INFO verdict over garbage) is in scope for this RFC: the
+   semantic action must carry a score floor below which it says so.
+
+Reproduction artifacts (Rule 11 — claims carry their commands):
+
+```bash
+# Query 1/2 baseline, run from repo root at 1cc119b7:
+uv run python -c "from tree_sitter_analyzer.mcp.tools.context_tool import ...  # pinned in tests/integration/semantic/test_motivation_baseline.py"
+```
+
+The baseline lives as an executable test, not prose, so motivation drift is
+caught mechanically (the round-1 failure mode).
 
 ## Detailed design
 
-### Storage (ast_cache schema)
+### Phase 0 (separate change, precondition): FTS5 porter stemming
 
-New virtual table in the **same** `.ast-cache` SQLite database:
+One-line tokenizer change + reindex; re-run the motivating queries; record
+which gaps remain. Not part of this RFC's implementation, but its outcome
+re-baselines the pilot below.
+
+### Prerequisite: docstring/signature must reach the cache
+
+**Round-1 P1**: the specified embedding input
+`"{kind} {qualified_name}({params}) -> {return_type}\n{docstring}"` is not
+constructible from today's cache — `ast_index.symbols_json` carries neither
+`docstring` nor `return_type` (0 of 1,885 rows), and `ast_symbol_rows` has
+only name/kind/file/language/lines. The in-memory model HAS these fields
+(`models/base.py:43`); the cache writer drops them.
+
+This RFC therefore includes extending the `symbols_json` serialization with
+`docstring` + `return_type` + `params` (schema version bump; existing repos
+need a full reindex — stated cost, see Drawbacks). Quality reality check
+(measured): only **33%** of production symbols have a substantive (≥10-word)
+docstring; the flagship target `handle_call_tool` has **none**. The pilot
+(below) exists precisely to test whether thin inputs still retrieve.
+
+### Phase 1 storage: plain BLOB column, no extension
 
 ```sql
--- requires the sqlite-vec loadable extension
-CREATE VIRTUAL TABLE IF NOT EXISTS symbol_embeddings USING vec0(
-    symbol_id INTEGER PRIMARY KEY,   -- FK → existing symbols rowid
-    embedding FLOAT[384]             -- model-dependent dim, pinned in meta
+CREATE TABLE IF NOT EXISTS symbol_embeddings (
+    file_path TEXT NOT NULL,          -- enables file-scoped delete (see below)
+    symbol_key TEXT NOT NULL,         -- stable content key, NOT the rowid
+    embedding BLOB NOT NULL,          -- float32[384] (int8 = exactly 1/4, phase-2 option)
+    model_id TEXT NOT NULL,
+    PRIMARY KEY (file_path, symbol_key)
 );
+CREATE INDEX IF NOT EXISTS idx_symbol_embeddings_file
+    ON symbol_embeddings(file_path);
 CREATE TABLE IF NOT EXISTS embedding_meta (
-    model_id TEXT NOT NULL,          -- e.g. "minilm-l6-v2-onnx"
+    id INTEGER PRIMARY KEY CHECK (id = 1),  -- single row, unambiguous staleness
+    model_id TEXT NOT NULL,
     dim INTEGER NOT NULL,
     built_at TEXT NOT NULL,
     symbols_embedded INTEGER NOT NULL
 );
 ```
 
-- Schema version bumps (existing ast_cache migration convention). Absence of
-  the extension or the table MUST degrade gracefully: `semantic` action
-  returns `verdict=INFO` + `next_step` pointing at the build command — never
-  a crash, never a silent empty result (honesty convention, #537).
-- Embedding input per symbol: `"{kind} {qualified_name}({params}) -> {return_type}\n{docstring}"`
-  — signature line + docstring, capped at N tokens (pinned in implementation).
+- **No rowid FK.** Round-1 (both reviewers independently): re-index DELETEs +
+  re-inserts `ast_symbol_rows` with fresh AUTOINCREMENT ids
+  (`_ast_cache_write.py:26-27`; ~4.3k ids already burned on this repo), so a
+  rowid-keyed embedding table dangles after every file edit. Embeddings key
+  on `(file_path, symbol_key)` and the dirty-file path does
+  `DELETE FROM symbol_embeddings WHERE file_path = ?` **in the same
+  transaction** as the symbol-row delete — the exact pattern
+  `ast_symbol_activation` already uses (`_ast_cache_schema.py:96-113`,
+  `_ast_cache_write.py:162-186`).
+- Query path: load all embeddings (memory-mapped read), numpy brute-force
+  cosine. **Measured**: 0.42 ms/query at 20k symbols, **1.03 ms at 44,169
+  (this repo)**; ~25 ms extrapolated at 1M. No ANN needed at any plausible
+  single-repo scale.
+- Note vec0 (sqlite-vec ≤0.1.x) is ALSO a linear scan (no ANN; measured
+  2.38 ms at 20k×384) — phase-2 buys persistence/SQL ergonomics, **not** an
+  algorithmic speedup. Stated here so nobody weighs a phantom benefit.
 
 ### Embedding model (Open question 1 — panel decision required)
 
-Two candidate paths, both local-only:
+Candidates unchanged (A: ONNX MiniLM via `[semantic]` extra; B: endpoint
+override), but round-1 measurements correct the table:
 
-| | A: bundled ONNX MiniLM (all-MiniLM-L6-v2, ~23 MB int8) | B: optional `ollama` / user-provided endpoint |
+| | A: ONNX MiniLM (all-MiniLM-L6-v2) | B: endpoint (`TSA_EMBEDDING_ENDPOINT`) |
 |---|---|---|
-| Install | `pip install tree-sitter-analyzer[semantic]` pulls onnxruntime + model | zero new deps; user opts in via config |
-| Cold start | ~100 ms session warmup | depends on user daemon |
-| Licensing | Apache-2 model, redistributable | n/a |
-| Offline | guaranteed | user-managed |
+| Cold start | **606 ms measured** for `import onnxruntime` alone (1.26.0, M-series) — NOT ~100 ms | user-managed |
+| Platform | onnxruntime 1.26 requires py≥3.11 (project supports 3.10 → pins 1.22); macOS wheels are 14.0+ arm64-only (no current Intel-mac wheel) | n/a |
+| Tokenizer | MiniLM needs WordPiece — onnxruntime does NOT tokenize; requires the `tokenizers` wheel (another platform surface) or a vendored minimal WordPiece impl. **Must be specified before acceptance.** | server side |
+| Model file | pip extras cannot ship the 23 MB model; either a separate model wheel (publishing commitment) or first-run download (**breaks "offline guaranteed" — pick one honestly**) | n/a |
 
-Default proposal: **A** as the `[semantic]` extra (keeps zero-config), with
-B as a config override (`TSA_EMBEDDING_ENDPOINT`). Neither ships in the
-default install — the base wheel stays lean.
+A pinned support table (OS × arch × py → versions) is an acceptance
+deliverable; unsupported combos (Windows-ARM, musllinux, Intel mac) get the
+graceful-degrade verdict, never a crash.
 
 ### Index build
 
-- `index action=build_semantic` (MCP) / `--build-semantic-index` (CLI):
-  embeds all symbols, batched, resumable; writes `embedding_meta`.
-- Incremental: the existing file-watcher/dirty-file path re-embeds only
-  symbols whose source file changed (delta keyed off the existing symbols
-  table).
-- Build is **never** implicit: first call to `semantic` without an index
-  returns the INFO verdict above. No surprise multi-minute writes.
+- `index action=build_semantic` / `--build-semantic-index`: batched,
+  resumable via per-file progress (the `(file_path, symbol_key)` PK makes
+  "which files are embedded under model X" a cheap query — `embedding_meta`
+  alone cannot express this; round-1 P2).
+- Incremental: dirty-file detection already exists
+  (`incremental_sync.py:5-10`, mtime + SHA-256); the delta deletes + re-embeds
+  only that file's rows (same-transaction rule above).
+- **Concurrency (round-1 P2)**: embedding inference runs OUTSIDE DB
+  transactions; writes land in batches of ≤200 rows per transaction with
+  busy-retry (the watcher's 10 s `timeout` + the codebase's
+  silently-pass-on-OperationalError convention means long write transactions
+  can silently DROP watcher re-indexes — batch small, never hold the writer
+  across inference). WAL checkpoint after build completion; `-wal` growth
+  bounded by batch size, not build length.
+- Never implicit; absence modes below.
 
 ### Query path
 
 #### MCP surface (facade + action)
 
 ```python
-# search facade — new action
 {
   "action": "semantic",
-  "query": "where is request dispatching handled",   # required
-  "limit": 10,                                        # default 10, capped
-  "output_format": "toon",                            # MCP default, locked
-}
-# → response (TOON_CONTROL_SURFACE-compliant):
-{
-  "verdict": "INFO",
-  "results": [
-    {"symbol": "handle_call_tool", "file": "...", "line": 123,
-     "score": 0.78, "signature": "..."},
-  ],
-  "results_listed": 10, "total_candidates": 40, "truncated": true,
-  "next_step": "nav action=context --query '<top symbol>'"
+  "query": "where is request dispatching handled",
+  "limit": 10,
+  "output_format": "toon",   # MCP default, locked
 }
 ```
 
-- KNN via `vec0` `MATCH` with `k = limit * 4` over-fetch, then a cheap
-  lexical-overlap tiebreak so exact-name hits never rank below fuzzy ones
-  (hybrid guard).
-- `nav action=context` gains an optional `rerank: "semantic"` parameter
-  (default off) that reorders its candidate pool by embedding similarity —
-  directly targets the empty-`entry_points` failure.
+Response: standard ToolResponse envelope. In TOON mode the control surface
+is the locked `TOON_CONTROL_SURFACE` allowlist — `results`,
+`results_listed`, `total_candidates`, `truncated`, `next_step` live inside
+`toon_content`, NOT at the top level (round-1 caught revision 1's example
+contradicting RFC-0012; this revision states the rule instead of an
+allowlist-violating example). JSON mode carries them top-level as usual.
 
-#### Error handling
+- **Low-confidence honesty**: if the best cosine score < pinned floor, the
+  response says "no confident semantic match" (`verdict=INFO` + explicit
+  `low_confidence: true` in payload) instead of returning garbage — this is
+  the half of the measured problem BM25 cannot express.
+- **Hybrid lexical leg (round-1 P2 — revision 1's tiebreak was
+  unimplementable)**: the candidate pool is the UNION of (a) cosine top
+  `limit*4` and (b) FTS5 exact/prefix name hits for query tokens — so an
+  exact-name symbol whose embedding is thin can never miss the pool. Ranking:
+  exact-name-match group first (ordered by cosine desc, then qualified name
+  asc as total order), then the rest by cosine desc. "Exact-name" :=
+  case-insensitive token == symbol bare name. This is a total order — the
+  exact-pin ordering tests are writable.
+
+#### Error handling (absence modes — round-1 added the first row)
 
 | Condition | Behavior |
 |---|---|
-| sqlite-vec extension not loadable | `verdict=ERROR`, message names the missing extra, `next_step` install hint (mirrors #559 Swift grammar honesty) |
-| index absent / stale model_id | `verdict=INFO` + build command |
-| query embeds to zero-vector / model error | `verdict=ERROR`, no fallback to silent BM25 (explicit `fallback:"bm25"` param if the agent wants it) |
+| `sqlite3` built without extension support (`enable_load_extension` absent — notably python.org/system macOS builds) | phase-1 unaffected (no extension); phase-2 vec0 upgrade refuses with explicit message, stays on BLOB path |
+| `[semantic]` extra not installed | `verdict=ERROR`, names the extra, install hint (#559 convention) |
+| index absent / `embedding_meta.model_id` stale | `verdict=INFO` + build command |
+| model/tokenizer load failure | `verdict=ERROR`; explicit `fallback:"bm25"` opt-in param, never silent fallback |
 
 #### Concurrency / async
 
-Read path is a plain SQLite read (WAL, same as existing). Build path takes
-the existing writer lock; embedding runs in a thread pool, DB writes batched
-on the loop thread (same pattern as the current index build).
+Reads: plain SQLite reads (WAL, thread-local connections as today). Note
+phase-2 vec0 would need per-connection extension loading
+(`ast_cache.py:107-114` creates lazy thread-local connections) — recorded
+here so phase-2 doesn't trip on `no such module: vec0`.
 
 ## Three-Surface impact (CLI ↔ MCP parity)
 
 | Surface | Addition |
 |---|---|
-| MCP | `search action=semantic`; `index action=build_semantic`; `nav action=context` `rerank` param |
+| MCP | `search action=semantic`; `index action=build_semantic` |
 | CLI | `--search-semantic <query>` (+ `--limit`); `--build-semantic-index` |
 | Output | MCP defaults TOON (🔒 locked, unchanged); CLI defaults JSON (unchanged) |
 
-Parity test: the registry-driven parity suite gains the two new pairs.
+(`nav action=context` rerank is deferred to phase-2 — revision 1 bundled it;
+the pilot decides whether it earns its complexity.)
+
+Parity test: the registry-driven parity suite gains the two new pairs; the
+#519 facade-actions drift doc regenerates with the new action.
 
 ## Drawbacks
 
-- **Index size**: 384-dim float32 ≈ 1.5 KB/symbol → ~30 MB for a 20k-symbol
-  repo (int8 quantization halves-to-quarters this). `.ast-cache` grows
-  noticeably; must stay opt-in.
-- **Build latency**: minutes-scale first build on large repos (CPU ONNX
-  ~1-2k symbols/s expected; needs measurement per Rule 11 — a cost claim
-  without an executable invariant is a belief).
-- **New optional dependency surface**: onnxruntime wheels per-platform;
-  sqlite-vec loadable-extension quirks (notably macOS SIP and Windows DLL
-  paths) need CI coverage on all three OS axes.
-- **Quality ceiling**: signature+docstring embeddings miss body semantics;
-  undocumented symbols embed thin. Mitigation: include leading body comment
-  line (deferred, see non-goals).
+- **Full reindex on upgrade**: extending `symbols_json` bumps the schema —
+  every existing repo re-indexes once. Stated, not hidden.
+- **Index size (measured reference)**: this repo = 33.6k embeddable symbols
+  (methods+functions+classes; imports/variables excluded) → **52-68 MB
+  float32** on top of the existing 215 MB index.db (+24-32%). int8 is
+  exactly ¼. Stays opt-in.
+- **Thin inputs**: 33% substantive docstrings in production code (measured);
+  the pilot gates acceptance on whether retrieval works anyway.
+- **New optional dependency surface** (phase-1: onnxruntime + tokenizer
+  path; phase-2 adds sqlite-vec): platform matrix above; sqlite-vec is
+  pre-1.0, single-maintainer, with a ~16-month release gap (0.1.6 2024-11 →
+  0.1.7a13 2026-03) — the BLOB path doubles as the permanent exit ramp.
+- **Build latency**: unmeasured until the pilot (Rule 11: the pilot, not
+  this RFC, produces the pinned number).
 
 ## Alternatives
 
-- **A: FTS5 synonym/expansion layer** (no vectors): cheap, but cannot bridge
-  "dispatching" → `handle_call_tool` without hand-curated synonyms; rejected
-  as unmaintainable.
-- **B: external vector DB (LanceDB/qdrant)**: better tooling, but breaks the
-  zero-daemon/single-file story — the moat (#helixdb assessment: local
-  zero-dependency IS the differentiator). Rejected.
-- **C: embed at query time only (no index), brute-force cosine over
-  signatures**: O(n) per query, ~50 ms at 20k symbols — actually viable as a
-  fallback mode and as phase-1 ship vehicle; kept as an explicit option in
-  the implementation plan (build the API first, swap brute-force → vec0
-  index transparently).
-- **D: do nothing**: the #441 residual stays; agents grep-loop on every
-  conceptual query. Rejected by dogfood evidence.
+- **A: FTS5 porter stemming only**: one line, closes the "dispatching"
+  family. **Adopted as phase 0** — but cannot bridge true vocabulary gaps
+  ("routing" → `handle_call_tool`), and cannot express low-confidence
+  honesty. Insufficient alone IF the pilot shows semantic adds recall on
+  stemmed baselines; the pilot decides.
+- **B: external vector DB**: breaks the zero-daemon single-file moat.
+  Rejected (unchanged).
+- **C: sqlite-vec in v1**: rejected by measurement — vec0 is also a linear
+  scan, brute-force BLOB is ~1 ms at real scale, and the extension drags the
+  entire loadable-extension platform matrix into v1 for zero algorithmic
+  gain. Deferred to phase-2 behind a measured trigger (e.g. >100 ms p95
+  query at some future scale).
+- **D: do nothing**: the confidently-wrong-results failure stays. Rejected,
+  contingent on pilot.
 
 ## Prior art
 
-- **codegraph**: `codegraph_context` does lexical + graph expansion, no
-  vectors — same gap.
-- **Sourcegraph Cody / embeddings era**: shipped then partially retreated
-  from repo embeddings due to staleness cost — our incremental dirty-file
-  re-embed addresses the staleness half; their lesson (hybrid lexical+vector
-  beats pure vector) is adopted via the lexical tiebreak.
-- **sqlite-vec** (asg017): the load-bearing dependency; vec0 virtual tables,
-  used in production by several local-first tools.
+Unchanged from revision 1 (codegraph, Sourcegraph hybrid lesson, sqlite-vec)
+— with the correction that sqlite-vec's vec0 is brute-force in shipped
+versions; its prior-art value is SQL ergonomics, not ANN.
 
-## Test plan (RED-first)
+## Pilot (acceptance precondition — runs BEFORE implementation lands)
 
-- Unit: schema migration (version bump, fresh + upgrade); graceful-degrade
-  verdicts (extension missing / index absent / stale model); embedding input
-  formatter (exact pins); hybrid tiebreak ordering (exact-name beats fuzzy).
-- Integration: build → query round-trip on a fixture repo; incremental
-  re-embed after file edit (only dirty file re-embedded — exact count pin);
-  CLI↔MCP parity pair tests.
-- Dogfood acceptance (the motivating queries, pinned as e2e):
-  - "how does the MCP server route a tool call to the right facade action"
-    → `handle_call_tool` (or `legacy_to_facade`) in top-5.
-  - "where is request dispatching handled" → non-empty, top-5 contains a
-    routing symbol.
-- Cost invariants (Rule 11): index bytes/symbol ≤ pinned ceiling; build
-  throughput symbols/s ≥ pinned floor — measured, dated, in
-  `test_output_cost_invariants.py` style.
+1. Phase 0 stemming change + reindex; re-run both motivating queries; record.
+2. Extend serialization on a branch; embed ~1k symbols (MiniLM via any local
+   runner); run both motivating queries + 10 conceptual queries sampled from
+   real agent transcripts; report top-5 hit rate against hand-labeled
+   targets, on thin (signature-only) vs docstring-bearing symbols separately.
+3. Measure: embed throughput (symbols/s), index bytes/symbol actual, query
+   p95. These become the Rule-11 pinned invariants.
+4. **Go/no-go**: if the pilot's top-5 hit rate on stemmed baseline fails to
+   beat BM25 meaningfully, this RFC is rejected with the data attached —
+   that outcome is explicitly acceptable and cheap (the pilot is ~1 day).
+
+## Test plan (RED-first, post-pilot)
+
+- Unit: schema migration (fresh + upgrade); file-scoped embedding delete in
+  same transaction as symbol delete (exact-count pin after edit); absence
+  modes (4 rows above); embedding input formatter (exact pins); hybrid
+  union + total-order ranking (exact pins, including the thin-embedding
+  exact-name case); low-confidence floor.
+- Integration: build → query round-trip; incremental re-embed (only dirty
+  file re-embedded — exact count); CLI↔MCP parity pair; TOON control-surface
+  compliance via `handle_call_tool` boundary (not `execute` — the RFC-0012
+  lesson).
+- Motivation baseline test: the reproduction commands pinned as an
+  executable test so motivation can never drift from reality again.
+- Cost invariants: pilot numbers pinned in `test_output_cost_invariants.py`
+  style with measurement date.
 
 ## Acceptance criteria
 
-- [ ] `search action=semantic` + `--search-semantic` ship behind the
-      `[semantic]` extra, default-off
-- [ ] Graceful-degrade verdicts for all three absence modes
-- [ ] Incremental re-embed on file change (exact-count pinned test)
-- [ ] Both motivating dogfood queries pass top-5 (e2e)
-- [ ] CLI↔MCP parity test green
-- [ ] Cost invariants measured and pinned (size, build throughput)
-- [ ] Docs/CODEMAPS updated (+ facade-actions.md regenerates with the new
-      action, #519 ratchet)
+- [ ] Phase 0 stemming shipped separately; motivation re-baselined on it
+- [ ] Pilot run, numbers attached, go decision recorded (panel)
+- [ ] Docstring/return_type/params reach `symbols_json` (schema bump + reindex path)
+- [ ] `search action=semantic` + `--search-semantic` behind `[semantic]` extra
+- [ ] File-scoped embedding lifecycle (same-transaction delete) with exact-count tests
+- [ ] All four absence modes verdict-tested
+- [ ] Hybrid union ranking with total order, exact-pin tests
+- [ ] Low-confidence floor behavior tested
+- [ ] CLI↔MCP parity green; #519 facade-actions doc regenerated
+- [ ] Cost invariants measured and pinned (bytes/symbol, symbols/s, query p95)
+- [ ] Docs/CODEMAPS updated
 
 ## What this RFC does NOT do (deferred)
 
-- Body-content / comment embeddings (signature+docstring only).
-- Cross-repo or multi-index federation.
-- Replacing BM25 anywhere — `semantic` is additive; existing `symbol` /
-  `content` actions and their defaults are untouched.
-- Auto-building the index on first MCP connect.
+- sqlite-vec/ANN indexing (phase-2, behind a measured trigger).
+- `nav action=context` semantic rerank (phase-2, pilot-gated).
+- Body-content embeddings; cross-repo federation; replacing BM25 anywhere;
+  auto-building on first connect. (Unchanged.)
 
 ## Open questions
 
-1. Embedding model default: bundled ONNX MiniLM (`[semantic]` extra) vs
-   ollama-endpoint-only? (proposal: ONNX default, endpoint override)
-2. Ship phase-1 with brute-force cosine (Alternative C) to decouple API
-   stabilization from sqlite-vec platform risk, swapping the index in
-   phase-2?
-3. Should `nav action=context` rerank become default-on once the index
-   exists, or stay opt-in forever (token-cost neutrality argument)?
-4. int8 quantization from day one, or float32 first + quantize later?
+1. Embedding model packaging: separate model wheel vs first-run download —
+   which honesty trade-off does the panel prefer? (pip extras cannot bundle
+   the model; "offline guaranteed" dies with download-on-first-run.)
+2. Tokenizer: `tokenizers` wheel dependency vs vendored minimal WordPiece?
+3. Pilot query set: which 10 transcript-sourced conceptual queries? (lead
+   proposes sampling from the dogfood issue corpus #437-#449.)
+4. int8 from day one (¼ size) or float32 first?

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -72,6 +72,7 @@ number; if two RFCs collide on a number in flight, the later-merged one renames.
 | [0013](0013-facade-dropped-param-visibility.md) | Facade dropped-parameter visibility — `ignored_params` surface | accepted |
 | [0014](0014-instant-edit-safety.md) | Instant edit safety — test-noise partition, test-map, and co-change | accepted (Phase A #461; Phase B #463; Phase C #466; integration test + DF-16 dogfood deferred) |
 | [0015](0015-instant-uml-family.md) | Instant UML family — scoping fixes + activity/state diagrams | implemented (Phase 1 #462; P2-A #472; P2-B #475; v1.23.0) |
+| [0016](0016-semantic-symbol-search.md) | Semantic symbol search via sqlite-vec in `.ast-cache` | draft (#517) |
 
 ## Roadmap
 


### PR DESCRIPTION
Tracking issue: #517 (dogfood evidence: #441 residual — conceptual queries dead-end on BM25, entry_points empty). Reopens #601 under a GitFlow-compatible branch name.

## Summary
Draft RFC for opt-in semantic symbol search: sqlite-vec virtual table in the same `.ast-cache` SQLite (no new daemon, 100% local moat intact), `search action=semantic` + `--search-semantic` CLI twin, optional `nav context` rerank.

Key design points for review:
- Embedding input = signature + docstring; graceful-degrade verdicts for extension/index/model absence (#537 honesty convention)
- `[semantic]` pip extra, default install stays lean; ONNX MiniLM default vs ollama endpoint = **Open Q1 (panel)**
- Phase-1 brute-force cosine option (Alt C) to decouple API from sqlite-vec platform risk = **Open Q2**
- Rule-11 cost invariants pinned in the test plan (index bytes/symbol, build throughput)
- Hybrid lexical tiebreak so exact-name hits never lose to fuzzy (Sourcegraph lesson)

Status: **draft** — seeking adversarial review on the open questions before any implementation lands.