### PR TITLE
test: ratchet batch-16 — pin 44 loose assertions in top-4 AST-ranked files

### DIFF
--- a/scripts/loose_assertion_baseline.txt
+++ b/scripts/loose_assertion_baseline.txt
@@ -31,7 +31,9 @@
 #   already dropped 1 since the 1083 recording).
 #   batch-15 (AST): 1026 -> 977, 2026-06-13 (49 pins in top-4 AST-ranked
 #   files).
+#   batch-16 (AST): 977 -> 933, 2026-06-13 (44 pins in top-4 AST-ranked
+#   files).
 
-BASELINE_COUNT=977
+BASELINE_COUNT=933
 MEASUREMENT_DATE=2026-06-13
 MEASUREMENT_COMMAND="uv run python scripts/check_loose_assertions.py --baseline"

--- a/tests/unit/formatters/test_formatters_comprehensive.py
+++ b/tests/unit/formatters/test_formatters_comprehensive.py
@@ -49,7 +49,10 @@ class TestBaseTableFormatter:
         formatter = TestFormatter()
         newline = formatter._get_platform_newline()
         assert isinstance(newline, str)
-        assert len(newline) > 0
+        # Platform-binary pin mirroring the implementation branch (os.name)
+        import os
+
+        assert newline == ("\r\n" if os.name == "nt" else "\n")
 
     def test_newline_conversion(self):
         """Test newline conversion functionality."""
@@ -192,7 +195,8 @@ class TestJavaTableFormatter:
 
         result = formatter.format_structure(structure_data)
         assert isinstance(result, str)
-        assert len(result) > 0
+        # Normalize platform newlines (Windows CRLF) before the exact pin
+        assert len(result.replace("\r\n", "\n")) == 253
 
     def test_format_java_structure_with_methods_and_fields(self):
         """Test formatting Java structure with methods and fields."""
@@ -228,7 +232,7 @@ class TestJavaTableFormatter:
 
         result = formatter.format_structure(data)
         assert isinstance(result, str)
-        assert len(result) > 0
+        assert len(result.replace("\r\n", "\n")) == 259
 
     def test_format_java_structure_compact(self):
         """Test formatting Java structure in compact format."""
@@ -247,7 +251,7 @@ class TestJavaTableFormatter:
 
         result = formatter.format_structure(structure_data)
         assert isinstance(result, str)
-        assert len(result) > 0
+        assert len(result.replace("\r\n", "\n")) == 131
 
     def test_format_java_structure_csv(self):
         """Test formatting Java structure in CSV format."""
@@ -265,7 +269,7 @@ class TestJavaTableFormatter:
 
         result = formatter.format_structure(structure_data)
         assert isinstance(result, str)
-        assert len(result) > 0
+        assert len(result.replace("\r\n", "\n")) == 51
 
 
 class TestPythonTableFormatter:
@@ -307,7 +311,7 @@ class TestPythonTableFormatter:
 
         result = formatter.format_structure(structure_data)
         assert isinstance(result, str)
-        assert len(result) > 0
+        assert len(result.replace("\r\n", "\n")) == 177
 
     def test_format_python_structure_with_functions_and_classes(self):
         """Test formatting complex Python structure."""
@@ -347,7 +351,7 @@ class TestPythonTableFormatter:
 
         result = formatter.format_structure(data)
         assert isinstance(result, str)
-        assert len(result) > 0
+        assert len(result.replace("\r\n", "\n")) == 385
 
     def test_format_python_structure_compact(self):
         """Test formatting Python structure in compact format."""
@@ -360,7 +364,7 @@ class TestPythonTableFormatter:
 
         result = formatter.format_structure(structure_data)
         assert isinstance(result, str)
-        assert len(result) > 0
+        assert len(result.replace("\r\n", "\n")) == 199
 
     def test_format_python_structure_csv(self):
         """Test formatting Python structure in CSV format."""
@@ -373,7 +377,7 @@ class TestPythonTableFormatter:
 
         result = formatter.format_structure(structure_data)
         assert isinstance(result, str)
-        assert len(result) > 0
+        assert len(result.replace("\r\n", "\n")) == 51
 
 
 class TestFormatterErrorHandling:
@@ -464,7 +468,7 @@ class TestFormatterIntegration:
         result = formatter.format_structure(java_data)
 
         assert isinstance(result, str)
-        assert len(result) > 0
+        assert len(result.replace("\r\n", "\n")) == 294
 
     def test_all_format_types_produce_output(self):
         """Test that all format types produce valid output."""
@@ -481,6 +485,16 @@ class TestFormatterIntegration:
         format_types = ["full", "compact", "csv"]
         languages = ["java", "python"]
 
+        # Exact newline-normalized output length per (language, format_type)
+        expected_lengths = {
+            ("java", "full"): 204,
+            ("java", "compact"): 93,
+            ("java", "csv"): 51,
+            ("python", "full"): 174,
+            ("python", "compact"): 199,
+            ("python", "csv"): 51,
+        }
+
         for language in languages:
             for format_type in format_types:
                 formatter = FormatterRegistry.get_formatter_for_language(
@@ -489,4 +503,7 @@ class TestFormatterIntegration:
                 result = formatter.format_structure(test_data)
 
                 assert isinstance(result, str)
-                assert len(result) >= 0  # Allow empty string for some formats
+                assert (
+                    len(result.replace("\r\n", "\n"))
+                    == expected_lengths[(language, format_type)]
+                )

--- a/tests/unit/languages/test_css_plugin_enhanced_features.py
+++ b/tests/unit/languages/test_css_plugin_enhanced_features.py
@@ -371,7 +371,7 @@ class TestCssAnimationRecognition:
         elements = plugin.create_extractor().extract_css_rules(tree, ANIMATION_CODE)
 
         keyframes = [e for e in elements if e.selector.startswith("@keyframes")]
-        assert len(keyframes) >= 1
+        assert len(keyframes) == 3
 
     def test_extract_multiple_keyframes(self):
         """Test extraction of multiple @keyframes."""
@@ -380,7 +380,7 @@ class TestCssAnimationRecognition:
         elements = plugin.create_extractor().extract_css_rules(tree, ANIMATION_CODE)
 
         keyframes = [e for e in elements if e.selector.startswith("@keyframes")]
-        assert len(keyframes) >= 3
+        assert len(keyframes) == 3
 
     def test_extract_keyframes_name(self):
         """Test that keyframes name is captured."""
@@ -414,7 +414,7 @@ class TestCssAnimationRecognition:
         transition_elements = [
             e for e in elements if "transition" in str(e.raw_text).lower()
         ]
-        assert len(transition_elements) >= 1
+        assert len(transition_elements) == 2
 
     def test_keyframes_keyframes(self):
         """Test that keyframes percentages are captured."""
@@ -503,7 +503,7 @@ class TestCssComplexStructures:
         )
 
         import_elements = [e for e in elements if e.selector.startswith("@import")]
-        assert len(import_elements) >= 0
+        assert len(import_elements) == 1
 
     def test_extract_layer_rules(self):
         """Test extraction of @layer rules."""
@@ -514,7 +514,7 @@ class TestCssComplexStructures:
         )
 
         layer_elements = [e for e in elements if e.selector.startswith("@layer")]
-        assert len(layer_elements) >= 0
+        assert len(layer_elements) == 3
 
     def test_extract_grid_template_areas(self):
         """Test extraction of grid-template-areas."""
@@ -565,7 +565,7 @@ class TestCssComplexStructures:
         )
 
         not_selectors = [e for e in elements if ":not(" in e.selector]
-        assert len(not_selectors) >= 0
+        assert len(not_selectors) == 1
 
 
 class TestCssQueryAccuracy:
@@ -577,9 +577,21 @@ class TestCssQueryAccuracy:
         tree = get_tree_for_code(SELECTOR_CODE, plugin)
         elements = plugin.create_extractor().extract_css_rules(tree, SELECTOR_CODE)
 
-        for element in elements:
-            assert element.selector is not None
-            assert len(element.selector) > 0
+        assert [e.selector for e in elements] == [
+            "body",
+            ".class-selector",
+            "#id-selector",
+            'input[type="text"]',
+            'a[href^="https"]',
+            "a:hover",
+            "input:focus",
+            "p::before",
+            "p::after",
+            "div p",
+            "div > p",
+            "div + p",
+            "div ~ p",
+        ]
 
     def test_property_query_accuracy(self):
         """Test that property query accurately identifies properties."""
@@ -600,7 +612,7 @@ class TestCssQueryAccuracy:
         elements = plugin.create_extractor().extract_css_rules(tree, MEDIA_QUERY_CODE)
 
         media_queries = [e for e in elements if e.selector.startswith("@media")]
-        assert len(media_queries) >= 4
+        assert len(media_queries) == 4
 
     def test_keyframes_query_accuracy(self):
         """Test that keyframes query accurately identifies animations."""
@@ -609,7 +621,7 @@ class TestCssQueryAccuracy:
         elements = plugin.create_extractor().extract_css_rules(tree, ANIMATION_CODE)
 
         keyframes = [e for e in elements if e.selector.startswith("@keyframes")]
-        assert len(keyframes) >= 3
+        assert len(keyframes) == 3
 
     def test_variable_query_accuracy(self):
         """Test that variable query accurately identifies variables."""
@@ -647,9 +659,14 @@ class TestCssQueryAccuracy:
         tree = get_tree_for_code(PROPERTY_CODE, plugin)
         elements = plugin.create_extractor().extract_css_rules(tree, PROPERTY_CODE)
 
-        for element in elements:
-            assert element.start_line > 0
-            assert element.end_line >= element.start_line
+        assert [(e.start_line, e.end_line) for e in elements] == [
+            (3, 7),
+            (10, 17),
+            (20, 29),
+            (32, 39),
+            (42, 49),
+            (52, 57),
+        ]
 
     def test_element_classification_accuracy(self):
         """Test that element classification is accurate."""
@@ -658,7 +675,7 @@ class TestCssQueryAccuracy:
         elements = plugin.create_extractor().extract_css_rules(tree, PROPERTY_CODE)
 
         layout_elements = [e for e in elements if e.element_class == "layout"]
-        assert len(layout_elements) >= 1
+        assert len(layout_elements) == 1
 
         text_element = next((e for e in elements if e.selector == ".text"), None)
         if text_element:

--- a/tests/unit/languages/test_yaml_plugin_structure.py
+++ b/tests/unit/languages/test_yaml_plugin_structure.py
@@ -163,7 +163,7 @@ class TestYAMLKeyPairRecognition:
         elements = plugin.extractor.extract_yaml_elements(tree, KEY_VALUE_CODE)
 
         mapping_elements = [e for e in elements if e.element_type == "mapping"]
-        assert len(mapping_elements) >= 1
+        assert len(mapping_elements) == 12
 
     def test_extract_string_value(self):
         """Test extraction of string value."""
@@ -257,7 +257,7 @@ class TestYAMLListRecognition:
         elements = plugin.extractor.extract_yaml_elements(tree, LIST_CODE)
 
         sequence_elements = [e for e in elements if e.element_type == "sequence"]
-        assert len(sequence_elements) >= 1
+        assert len(sequence_elements) == 8
 
     def test_extract_list_of_strings(self):
         """Test extraction of list of strings."""
@@ -320,7 +320,7 @@ class TestYAMLNestedStructureRecognition:
         tree = get_tree_for_code(NESTED_STRUCTURE_CODE, plugin)
         elements = plugin.extractor.extract_yaml_elements(tree, NESTED_STRUCTURE_CODE)
 
-        assert len(elements) >= 5
+        assert len(elements) == 28
 
     def test_extract_person_structure(self):
         """Test extraction of person structure."""
@@ -348,7 +348,7 @@ class TestYAMLNestedStructureRecognition:
         tree = get_tree_for_code(NESTED_STRUCTURE_CODE, plugin)
         elements = plugin.extractor.extract_yaml_elements(tree, NESTED_STRUCTURE_CODE)
 
-        assert len(elements) >= 10
+        assert len(elements) == 28
 
     def test_extract_config_structure(self):
         """Test extraction of config structure."""
@@ -367,7 +367,7 @@ class TestYAMLNestedStructureRecognition:
         elements = plugin.extractor.extract_yaml_elements(tree, NESTED_STRUCTURE_CODE)
 
         nested_elements = [e for e in elements if e.nesting_level > 0]
-        assert len(nested_elements) >= 1
+        assert len(nested_elements) == 25
 
 
 @pytest.mark.skipif(not YAML_AVAILABLE, reason="tree-sitter-yaml not installed")
@@ -381,7 +381,7 @@ class TestYAMLAnchorAliasRecognition:
         elements = plugin.extractor.extract_yaml_elements(tree, ANCHOR_ALIAS_CODE)
 
         anchor_elements = [e for e in elements if e.element_type == "anchor"]
-        assert len(anchor_elements) >= 1
+        assert len(anchor_elements) == 3
 
     def test_extract_alias(self):
         """Test extraction of alias."""
@@ -390,7 +390,7 @@ class TestYAMLAnchorAliasRecognition:
         elements = plugin.extractor.extract_yaml_elements(tree, ANCHOR_ALIAS_CODE)
 
         alias_elements = [e for e in elements if e.element_type == "alias"]
-        assert len(alias_elements) >= 1
+        assert len(alias_elements) == 6
 
     def test_extract_defaults_anchor(self):
         """Test extraction of defaults anchor."""
@@ -409,7 +409,7 @@ class TestYAMLAnchorAliasRecognition:
         elements = plugin.extractor.extract_yaml_elements(tree, ANCHOR_ALIAS_CODE)
 
         alias_usage_elements = [e for e in elements if e.alias_target is not None]
-        assert len(alias_usage_elements) >= 1
+        assert len(alias_usage_elements) == 6
 
     def test_extract_merge_key(self):
         """Test extraction of merge key (<<)."""
@@ -418,7 +418,7 @@ class TestYAMLAnchorAliasRecognition:
         elements = plugin.extractor.extract_yaml_elements(tree, ANCHOR_ALIAS_CODE)
 
         merge_elements = [e for e in elements if "<<" in str(e.raw_text)]
-        assert len(merge_elements) >= 1
+        assert len(merge_elements) == 13
 
     def test_extract_multiple_anchors(self):
         """Test extraction of multiple anchors."""
@@ -427,7 +427,7 @@ class TestYAMLAnchorAliasRecognition:
         elements = plugin.extractor.extract_yaml_elements(tree, ANCHOR_ALIAS_CODE)
 
         anchor_elements = [e for e in elements if e.element_type == "anchor"]
-        assert len(anchor_elements) >= 2
+        assert len(anchor_elements) == 3
 
     def test_extract_anchor_in_list(self):
         """Test extraction of anchor in list."""
@@ -436,4 +436,4 @@ class TestYAMLAnchorAliasRecognition:
         elements = plugin.extractor.extract_yaml_elements(tree, ANCHOR_ALIAS_CODE)
 
         anchor_elements = [e for e in elements if e.element_type == "anchor"]
-        assert len(anchor_elements) >= 1
+        assert len(anchor_elements) == 3

--- a/tests/unit/test_ast_diff.py
+++ b/tests/unit/test_ast_diff.py
@@ -152,7 +152,7 @@ class TestDiffStrings:
         old = "def foo():\n    pass\n"
         new = "def foo():\n    pass\n\ndef bar():\n    pass\n"
         result = differ.diff_strings(old, new, "python")
-        assert result.summary_stats["added"] >= 1
+        assert result.summary_stats["added"] == 1
         added_kinds = [
             h.node_kind for h in result.hunks if h.diff_kind == DiffKind.NODE_ADDED
         ]
@@ -162,43 +162,43 @@ class TestDiffStrings:
         old = "def foo():\n    pass\n\ndef bar():\n    pass\n"
         new = "def foo():\n    pass\n"
         result = differ.diff_strings(old, new, "python")
-        assert result.summary_stats["removed"] >= 1
+        assert result.summary_stats["removed"] == 1
 
     def test_changed_body(self, differ):
         old = "def greet():\n    print('hello')\n"
         new = "def greet():\n    print('world')\n"
         result = differ.diff_strings(old, new, "python")
-        assert len(result.hunks) > 0
+        assert len(result.hunks) == 11
         body_hunks = [h for h in result.hunks if h.diff_kind == DiffKind.BODY_CHANGED]
-        assert len(body_hunks) >= 1
+        assert len(body_hunks) == 1
 
     def test_changed_signature(self, differ):
         old = "def add(a, b):\n    return a + b\n"
         new = "def add(a, b, c):\n    return a + b + c\n"
         result = differ.diff_strings(old, new, "python")
-        assert len(result.hunks) > 0
+        assert len(result.hunks) == 22
 
     def test_added_class(self, differ):
         old = "x = 1\n"
         new = "class Foo:\n    pass\n"
         result = differ.diff_strings(old, new, "python")
-        assert result.summary_stats["added"] >= 1
+        assert result.summary_stats["added"] == 1
 
     def test_javascript_diff(self, differ):
         old = "function add(a, b) {\n  return a + b;\n}\n"
         new = "function add(a, b, c) {\n  return a + b + c;\n}\n"
         result = differ.diff_strings(old, new, "javascript")
-        assert len(result.hunks) > 0
+        assert len(result.hunks) == 20
 
     def test_import_added(self, differ):
         old = "def foo():\n    pass\n"
         new = "import os\n\ndef foo():\n    pass\n"
         result = differ.diff_strings(old, new, "python")
-        assert result.summary_stats["added"] >= 1
+        assert result.summary_stats["added"] == 1
 
     def test_both_parse_fail(self, differ):
         result = differ.diff_strings("", "", "python")
-        assert len(result.hunks) >= 0
+        assert len(result.hunks) == 0
 
     def test_to_dict_roundtrip(self, differ):
         old = "def foo():\n    pass\n"
@@ -224,10 +224,10 @@ class TestDiffFiles:
     def test_diff_changed_file(self, differ, tmp_path):
         old_p = tmp_path / "old.py"
         new_p = tmp_path / "new.py"
-        old_p.write_text("def foo():\n    pass\n")
-        new_p.write_text("def foo():\n    return 1\n")
+        old_p.write_text("def foo():\n    pass\n", newline="\n")
+        new_p.write_text("def foo():\n    return 1\n", newline="\n")
         result = differ.diff_files(str(old_p), str(new_p))
-        assert len(result.hunks) > 0
+        assert len(result.hunks) == 11
 
     def test_diff_unsupported_language(self, differ, tmp_path):
         old_p = tmp_path / "old.xyz"
@@ -239,9 +239,9 @@ class TestDiffFiles:
 
     def test_diff_nonexistent_file(self, differ, tmp_path):
         new_p = tmp_path / "new.py"
-        new_p.write_text("def foo():\n    pass\n")
+        new_p.write_text("def foo():\n    pass\n", newline="\n")
         result = differ.diff_files("/nonexistent/file.py", str(new_p))
-        assert result.summary_stats["added"] >= 1
+        assert result.summary_stats["added"] == 1
 
 
 class TestDiffStringPairs:


### PR DESCRIPTION
## Summary
Loose-assertion ratchet batch 16. Top-4 files by AST counter, every `>=`/`> N` pinned to measured exact values:

| File | Pins |
|---|---|
| tests/unit/test_ast_diff.py | 11 |
| tests/unit/languages/test_yaml_plugin_structure.py | 11 |
| tests/unit/languages/test_css_plugin_enhanced_features.py | 11 |
| tests/unit/formatters/test_formatters_comprehensive.py | 11 |

Baseline: **977 → 933** (= exactly 44, lead re-verified live).

Contract 5b notes: byte-relevant fixtures got `newline="\n"`; formatter output lengths pinned after CRLF→LF normalization; `_get_platform_newline` pinned by mirroring the os.name branch; CSS per-element loops upgraded to exact full-list pins (13 selectors verbatim); several vacuous `>= 0` asserts replaced with real measured pins; zero exemption markers. Grammar-sensitive hunk counts pinned exactly per the locked exact-assertion rule — a grammar bump goes RED and forces a conscious re-pin.

## Test plan
- [x] All 4 files individually `-n 0`: 26/27/26/31 passed
- [x] Diff gate exit=0
- [x] `--baseline` measures 933 == recorded (lead independently re-verified)