### PR TITLE
test: ratchet batch-17 — pin 41 loose assertions in top-4 AST-ranked files

### DIFF
--- a/scripts/loose_assertion_baseline.txt
+++ b/scripts/loose_assertion_baseline.txt
@@ -33,7 +33,9 @@
 #   files).
 #   batch-16 (AST): 977 -> 933, 2026-06-13 (44 pins in top-4 AST-ranked
 #   files).
+#   batch-17 (AST): 933 -> 892, 2026-06-13 (41 flagged pins in top-4
+#   AST-ranked files, plus 2 unflagged <= bounds pinned exact).
 
-BASELINE_COUNT=933
+BASELINE_COUNT=892
 MEASUREMENT_DATE=2026-06-13
 MEASUREMENT_COMMAND="uv run python scripts/check_loose_assertions.py --baseline"

--- a/tests/integration/core/test_analyze_scale_tool_file_output.py
+++ b/tests/integration/core/test_analyze_scale_tool_file_output.py
@@ -28,6 +28,7 @@ class TestAnalyzeScaleToolFileOutput:
 
             # Create a comprehensive Java test file (since analyze_scale_tool works best with Java)
             java_file = project_path / "ComplexSample.java"
+            # newline="\n" pins byte counts cross-platform (Windows CRLF inflation)
             java_file.write_text(
                 """package com.example.complex;
 
@@ -159,7 +160,8 @@ public class ComplexSample {
         ACTIVE, INACTIVE, PENDING
     }
 }
-"""
+""",
+                newline="\n",
             )
 
             # Create a Python test file
@@ -239,7 +241,8 @@ def main():
 
 if __name__ == "__main__":
     main()
-"""
+""",
+                newline="\n",
             )
 
             yield str(project_path)
@@ -249,6 +252,17 @@ if __name__ == "__main__":
         """Create AnalyzeScaleTool instance"""
         return AnalyzeScaleTool(project_root=temp_project_dir)
 
+    @staticmethod
+    def _named_annotation(name):
+        """Annotation mock with a real .name string.
+
+        MagicMock(name=...) sets the mock's repr name, NOT the .name
+        attribute — the old inline form leaked MagicMocks into the output.
+        """
+        ann = MagicMock()
+        ann.name = name
+        return ann
+
     def create_mock_analysis_result(self, file_type="java"):
         """Create mock analysis result"""
         mock_result = MagicMock()
@@ -256,11 +270,14 @@ if __name__ == "__main__":
         mock_result.error_message = None
 
         if file_type == "java":
-            # Mock Java elements
+            # Mock Java elements. element_type drives the production
+            # classifier (constants.get_element_type) — without it the
+            # mocks fell into a dead branch and every count stayed 0.
             mock_elements = []
 
             # Mock class element
             mock_class = MagicMock()
+            mock_class.element_type = "class"
             mock_class.name = "ComplexSample"
             mock_class.class_type = "class"
             mock_class.start_line = 12
@@ -269,13 +286,14 @@ if __name__ == "__main__":
             mock_class.extends_class = None
             mock_class.implements_interfaces = []
             mock_class.annotations = [
-                MagicMock(name="Component"),
-                MagicMock(name="Service"),
+                self._named_annotation("Component"),
+                self._named_annotation("Service"),
             ]
             mock_elements.append(mock_class)
 
             # Mock method elements
             mock_method1 = MagicMock()
+            mock_method1.element_type = "function"
             mock_method1.name = "complexCalculation"
             mock_method1.start_line = 30
             mock_method1.end_line = 65
@@ -285,10 +303,11 @@ if __name__ == "__main__":
             mock_method1.complexity_score = 15  # High complexity
             mock_method1.is_constructor = False
             mock_method1.is_static = False
-            mock_method1.annotations = [MagicMock(name="Transactional")]
+            mock_method1.annotations = [self._named_annotation("Transactional")]
             mock_elements.append(mock_method1)
 
             mock_method2 = MagicMock()
+            mock_method2.element_type = "function"
             mock_method2.name = "recursiveHelper"
             mock_method2.start_line = 67
             mock_method2.end_line = 75
@@ -303,6 +322,7 @@ if __name__ == "__main__":
 
             # Mock field elements
             mock_field = MagicMock()
+            mock_field.element_type = "variable"
             mock_field.name = "items"
             mock_field.field_type = "List<String>"
             mock_field.start_line = 15
@@ -494,10 +514,19 @@ if __name__ == "__main__":
             structural = result["structural_overview"]
             assert "complexity_hotspots" in structural
 
-            # Should detect high complexity method
+            # Should detect the one high-complexity method (score 15 >= 8
+            # threshold). The old `if hotspots:` guard was a dead branch
+            # while the mock lacked element_type — pin the full entry.
             hotspots = structural["complexity_hotspots"]
-            if hotspots:  # If any hotspots detected
-                assert any(hotspot["complexity"] > 10 for hotspot in hotspots)
+            assert hotspots == [
+                {
+                    "type": "method",
+                    "name": "complexCalculation",
+                    "complexity": 15,
+                    "start_line": 30,
+                    "end_line": 65,
+                }
+            ]
 
     @pytest.mark.asyncio
     async def test_llm_guidance_generation(self, analyze_scale_tool, temp_project_dir):
@@ -649,13 +678,14 @@ if __name__ == "__main__":
 
             result = await analyze_scale_tool.execute(arguments)
 
-            # Check file metrics are calculated
+            # Check file metrics are calculated (exact pins on the fixture
+            # file, byte-stable via newline="\n" in the fixture writes)
             metrics = result["file_metrics"]
-            assert metrics["total_lines"] > 0
-            assert metrics["code_lines"] > 0
-            assert metrics["estimated_tokens"] > 0
-            assert metrics["file_size_bytes"] > 0
-            assert metrics["file_size_kb"] > 0
+            assert metrics["total_lines"] == 130
+            assert metrics["code_lines"] == 101
+            assert metrics["estimated_tokens"] == 641
+            assert metrics["file_size_bytes"] == 3371
+            assert metrics["file_size_kb"] == 3.29
 
             # Check that total lines equals sum of components
             assert metrics["total_lines"] == (
@@ -717,11 +747,12 @@ if __name__ == "__main__":
             assert "llm_guidance" in result
             assert "detailed_analysis" in result
 
-            # Verify all components are properly populated
-            assert result["file_metrics"]["total_lines"] > 0
-            assert result["summary"]["classes"] >= 0
-            assert result["summary"]["methods"] >= 0
-            assert len(result["structural_overview"]["classes"]) >= 0
+            # Verify all components are properly populated (the >= 0 forms
+            # were tautologies that hid the mock's dead-branch zeros)
+            assert result["file_metrics"]["total_lines"] == 130
+            assert result["summary"]["classes"] == 1
+            assert result["summary"]["methods"] == 2
+            assert len(result["structural_overview"]["classes"]) == 1
             assert result["llm_guidance"]["size_category"] in [
                 "small",
                 "medium",

--- a/tests/unit/core/test_query_loader.py
+++ b/tests/unit/core/test_query_loader.py
@@ -39,7 +39,7 @@ def test_load_language_queries_java():
     """Test loading Java queries"""
     queries = query_loader.load_language_queries("java")
     assert isinstance(queries, dict)
-    assert len(queries) > 0
+    assert len(queries) == 71
 
     # Should have common queries
     assert "functions" in queries or "method" in queries
@@ -50,7 +50,7 @@ def test_load_language_queries_javascript():
     """Test loading JavaScript queries"""
     queries = query_loader.load_language_queries("javascript")
     assert isinstance(queries, dict)
-    assert len(queries) > 0
+    assert len(queries) == 87
 
     # Should have expected query types
     expected_queries = ["functions", "classes", "variables", "imports"]
@@ -62,7 +62,7 @@ def test_load_language_queries_python():
     """Test loading Python queries"""
     queries = query_loader.load_language_queries("python")
     assert isinstance(queries, dict)
-    assert len(queries) > 0
+    assert len(queries) == 88
 
     # Should have Python-specific queries
     expected_queries = ["functions", "classes", "imports", "decorators"]
@@ -74,7 +74,7 @@ def test_load_language_queries_typescript():
     """Test loading TypeScript queries"""
     queries = query_loader.load_language_queries("typescript")
     assert isinstance(queries, dict)
-    assert len(queries) > 0
+    assert len(queries) == 83
 
     # Should have TypeScript-specific queries
     expected_queries = ["functions", "classes", "interfaces", "type_aliases"]
@@ -91,17 +91,16 @@ def test_load_language_queries_unknown():
 
 def test_get_query_valid():
     """Test getting a valid query"""
-    # Test with Java
+    # Test with Java (the `if not None` guard was a dead branch: both
+    # languages ship a "functions" query, so assert the live values directly)
     java_query = query_loader.get_query("java", "functions")
-    if java_query is not None:
-        assert isinstance(java_query, str)
-        assert len(java_query) > 0
+    assert isinstance(java_query, str)
+    assert len(java_query) == 38
 
     # Test with JavaScript
     js_query = query_loader.get_query("javascript", "functions")
-    if js_query is not None:
-        assert isinstance(js_query, str)
-        assert len(js_query) > 0
+    assert isinstance(js_query, str)
+    assert len(js_query) == 658
 
 
 def test_get_query_invalid():
@@ -115,11 +114,9 @@ def test_get_query_invalid():
 
 def test_get_query_description():
     """Test getting query descriptions"""
-    # Test with valid query
+    # Test with valid query (guard removed: the description exists, pin it)
     desc = query_loader.get_query_description("javascript", "functions")
-    if desc is not None:
-        assert isinstance(desc, str)
-        assert len(desc) > 0
+    assert desc == "Search all function declarations, expressions, and methods"
 
     # Test with invalid query
     desc = query_loader.get_query_description("java", "nonexistent")
@@ -128,29 +125,33 @@ def test_get_query_description():
 
 def test_list_queries_for_language():
     """Test listing queries for specific languages"""
-    for language in ["java", "javascript", "python", "typescript"]:
+    # All four languages are supported, so the former `if supported` guard
+    # was a dead branch — pin the exact per-language query counts instead.
+    expected_counts = {"java": 71, "javascript": 87, "python": 88, "typescript": 83}
+    for language, expected in expected_counts.items():
+        assert language in query_loader.list_supported_languages()
         queries = query_loader.list_queries(language)
         assert isinstance(queries, list)
-        # Each language should have at least some queries
-        if language in query_loader.list_supported_languages():
-            assert len(queries) > 0
+        assert len(queries) == expected
 
 
 def test_get_common_queries():
     """Test getting common queries across languages"""
     common = query_loader.get_common_queries()
     assert isinstance(common, list)
+    assert len(common) == 4
 
-    # Should include functions and classes since we added aliases
-    if len(common) > 0:
-        # Common queries should exist in multiple languages
-        for query_name in common:
-            languages_with_query = []
-            for lang in query_loader.list_supported_languages():
-                if query_name in query_loader.list_queries(lang):
-                    languages_with_query.append(lang)
-            # Should be in at least 2 languages to be "common"
-            assert len(languages_with_query) >= 2
+    # Common queries should exist in multiple languages; pin the exact
+    # per-query language counts (sorted) instead of a loose >= 2 bound.
+    lang_counts = sorted(
+        sum(
+            1
+            for lang in query_loader.list_supported_languages()
+            if query_name in query_loader.list_queries(lang)
+        )
+        for query_name in common
+    )
+    assert lang_counts == [12, 13, 13, 13]
 
 
 def test_is_language_supported_function():
@@ -164,25 +165,34 @@ def test_is_language_supported_function():
 
 def test_get_all_queries_for_language():
     """Test getting all queries with descriptions"""
-    for language in ["java", "javascript", "python"]:
-        if query_loader.is_language_supported(language):
-            all_queries = query_loader.get_all_queries_for_language(language)
-            assert isinstance(all_queries, dict)
+    # All three languages are supported (former guard was a dead branch);
+    # pin exact query counts and the exact minimum query-string length.
+    expected = {"java": (71, 34), "javascript": (87, 20), "python": (88, 28)}
+    for language, (expected_count, expected_min_len) in expected.items():
+        assert query_loader.is_language_supported(language)
+        all_queries = query_loader.get_all_queries_for_language(language)
+        assert isinstance(all_queries, dict)
+        assert len(all_queries) == expected_count
 
-            for _query_name, (query_string, description) in all_queries.items():
-                assert isinstance(query_string, str)
-                assert isinstance(description, str)
-                assert len(query_string) > 0
+        lengths = []
+        for _query_name, (query_string, description) in all_queries.items():
+            assert isinstance(query_string, str)
+            assert isinstance(description, str)
+            lengths.append(len(query_string))
+        assert min(lengths) == expected_min_len
 
 
 def test_refresh_cache():
     """Test cache refresh functionality"""
+    # Start from a clean cache so the pinned count is order-independent
+    query_loader.refresh_cache()
+
     # Load some queries first
     query_loader.load_language_queries("java")
     query_loader.load_language_queries("javascript")
 
-    # Cache should have entries
-    assert len(query_loader._loaded_queries) > 0
+    # Cache should have exactly the two languages just loaded
+    assert len(query_loader._loaded_queries) == 2
 
     # Refresh cache
     query_loader.refresh_cache()

--- a/tests/unit/test_incremental_sync.py
+++ b/tests/unit/test_incremental_sync.py
@@ -71,7 +71,7 @@ class TestSyncModifiedFile:
         main_py.write_text("def goodbye():\n    pass\n")
         os.utime(str(main_py), times=None)
         result = sync.sync()
-        assert result.updated_files >= 1
+        assert result.updated_files == 1
         assert any("main.py" in d["file"] for d in result.details)
 
     def test_reindexes_modified_content(self, sync, cache, project):
@@ -93,7 +93,7 @@ class TestSyncDeletedFile:
         sync.sync()
         (project / "src" / "helper.js").unlink()
         result = sync.sync()
-        assert result.deleted_files >= 1
+        assert result.deleted_files == 1
         assert any("helper.js" in d["file"] for d in result.details)
 
     def test_removes_deleted_from_cache(self, sync, cache, project):
@@ -109,7 +109,7 @@ class TestSyncNewFile:
         sync.sync()
         (project / "src" / "new_module.py").write_text("def fresh():\n    pass\n")
         result = sync.sync()
-        assert result.new_files >= 1
+        assert result.new_files == 1
         assert any("new_module.py" in d["file"] for d in result.details)
 
 
@@ -123,9 +123,9 @@ class TestSyncMixedChanges:
         main_py.write_text("def updated():\n    pass\n")
         os.utime(str(main_py), times=None)
         result = sync.sync()
-        assert result.new_files >= 1
-        assert result.deleted_files >= 1
-        assert result.updated_files >= 1
+        assert result.new_files == 1
+        assert result.deleted_files == 1
+        assert result.updated_files == 1
 
 
 class TestSyncMaxFiles:
@@ -133,14 +133,14 @@ class TestSyncMaxFiles:
         (project / "src" / "extra1.py").write_text("x = 1\n")
         (project / "src" / "extra2.py").write_text("y = 2\n")
         result = sync.sync(max_files=2)
-        assert result.scanned <= 2
+        assert result.scanned == 2
 
 
 class TestSyncCallback:
     def test_callback_receives_details(self, sync, cache, project):
         received = []
         sync.sync(callback=lambda d: received.append(d))
-        assert len(received) >= 3
+        assert len(received) == 3
 
 
 class TestGetChanges:
@@ -164,19 +164,19 @@ class TestGetChanges:
         main_py.write_text("def changed():\n    pass\n")
         os.utime(str(main_py), times=None)
         changes = sync.get_changes()
-        assert len(changes["modified"]) >= 1
+        assert len(changes["modified"]) == 1
 
     def test_get_changes_detects_deletion(self, sync, cache, project):
         sync.sync()
         (project / "src" / "helper.js").unlink()
         changes = sync.get_changes()
-        assert len(changes["deleted"]) >= 1
+        assert len(changes["deleted"]) == 1
 
     def test_get_changes_detects_new_file(self, sync, cache, project):
         sync.sync()
         (project / "src" / "brand_new.py").write_text("z = 3\n")
         changes = sync.get_changes()
-        assert len(changes["new"]) >= 1
+        assert len(changes["new"]) == 1
 
 
 class TestSyncResultDict:

--- a/tests/unit/test_unreachable_code.py
+++ b/tests/unit/test_unreachable_code.py
@@ -39,16 +39,19 @@ def _write_py(tmp_path: Path, name: str, code: str) -> str:
 class TestIsFalseLiteral:
     def test_python_false(self, mocker):
         node = mocker.MagicMock()
+        node.parent = None  # tree-sitter Node mocks: no MagicMock parent chain
         node.text = b"False"
         assert _is_false_literal(node, "") is True
 
     def test_js_false(self, mocker):
         node = mocker.MagicMock()
+        node.parent = None  # tree-sitter Node mocks: no MagicMock parent chain
         node.text = b"false"
         assert _is_false_literal(node, "") is True
 
     def test_null_is_false(self, mocker):
         node = mocker.MagicMock()
+        node.parent = None  # tree-sitter Node mocks: no MagicMock parent chain
         node.text = b"null"
         assert _is_false_literal(node, "") is True
 
@@ -57,6 +60,7 @@ class TestIsFalseLiteral:
 
     def test_truthy_value_returns_false(self, mocker):
         node = mocker.MagicMock()
+        node.parent = None  # tree-sitter Node mocks: no MagicMock parent chain
         node.text = b"x"
         assert _is_false_literal(node, "") is False
 
@@ -64,16 +68,19 @@ class TestIsFalseLiteral:
 class TestIsTrueLiteral:
     def test_python_true(self, mocker):
         node = mocker.MagicMock()
+        node.parent = None  # tree-sitter Node mocks: no MagicMock parent chain
         node.text = b"True"
         assert _is_true_literal(node, "") is True
 
     def test_js_true(self, mocker):
         node = mocker.MagicMock()
+        node.parent = None  # tree-sitter Node mocks: no MagicMock parent chain
         node.text = b"true"
         assert _is_true_literal(node, "") is True
 
     def test_integer_one(self, mocker):
         node = mocker.MagicMock()
+        node.parent = None  # tree-sitter Node mocks: no MagicMock parent chain
         node.text = b"1"
         assert _is_true_literal(node, "") is True
 
@@ -82,6 +89,7 @@ class TestIsTrueLiteral:
 
     def test_false_value_returns_false(self, mocker):
         node = mocker.MagicMock()
+        node.parent = None  # tree-sitter Node mocks: no MagicMock parent chain
         node.text = b"False"
         assert _is_true_literal(node, "") is False
 
@@ -107,7 +115,7 @@ class TestAnalyzeFileUnreachable:
         assert isinstance(result, UnreachableCodeResult)
         assert result.errors == 0
         assert result.unreachable_blocks == []
-        assert result.functions_analyzed >= 1
+        assert result.functions_analyzed == 1
 
     def test_code_after_return_is_flagged(self, tmp_path):
         path = _write_py(
@@ -121,7 +129,7 @@ class TestAnalyzeFileUnreachable:
         )
         result = analyze_file_unreachable(path)
         assert result.errors == 0
-        assert len(result.unreachable_blocks) >= 1
+        assert len(result.unreachable_blocks) == 1
         reasons = [b.reason for b in result.unreachable_blocks]
         assert any("return" in r for r in reasons)
 
@@ -176,12 +184,12 @@ class TestAnalyzeFileUnreachable:
         f = tmp_path / "data.xyz"
         f.write_bytes(b"nothing")
         result = analyze_file_unreachable(str(f))
-        assert result.errors >= 1
+        assert result.errors == 1
         assert result.language == "unknown"
 
     def test_nonexistent_file_returns_error(self, tmp_path):
         result = analyze_file_unreachable(str(tmp_path / "missing.py"))
-        assert result.errors >= 1
+        assert result.errors == 1
 
     def test_language_override(self, tmp_path):
         path = _write_py(
@@ -249,8 +257,8 @@ class TestAnalyzeFileUnreachable:
         """,
         )
         result = analyze_file_unreachable(path)
-        assert result.functions_analyzed >= 2
-        assert len(result.unreachable_blocks) >= 2
+        assert result.functions_analyzed == 2
+        assert len(result.unreachable_blocks) == 2
 
     def test_nested_function_detected(self, tmp_path):
         path = _write_py(
@@ -265,9 +273,10 @@ class TestAnalyzeFileUnreachable:
         """,
         )
         result = analyze_file_unreachable(path)
-        assert result.functions_analyzed >= 1
+        # both outer and inner are analyzed
+        assert result.functions_analyzed == 2
         # inner has unreachable code
-        assert len(result.unreachable_blocks) >= 1
+        assert len(result.unreachable_blocks) == 1
 
     def test_severity_is_warning_for_after_return(self, tmp_path):
         path = _write_py(
@@ -314,7 +323,7 @@ class TestAnalyzeProjectUnreachable:
         """,
         )
         results = analyze_project_unreachable(str(tmp_path))
-        assert len(results) >= 1
+        assert len(results) == 1
         assert results[0].unreachable_blocks
 
     def test_test_files_excluded_by_default(self, tmp_path):
@@ -346,7 +355,7 @@ class TestAnalyzeProjectUnreachable:
             encoding="utf-8",
         )
         results = analyze_project_unreachable(str(tmp_path), include_test_files=True)
-        assert len(results) >= 1
+        assert len(results) == 1
 
     def test_max_files_respected(self, tmp_path):
         for i in range(10):
@@ -360,8 +369,8 @@ class TestAnalyzeProjectUnreachable:
             """,
             )
         results = analyze_project_unreachable(str(tmp_path), max_files=3)
-        # At most 3 files were scanned (only files with findings are returned)
-        assert len(results) <= 3
+        # Exactly 3 files were scanned and every scanned file has findings
+        assert len(results) == 3
 
     def test_excludes_dot_dirs(self, tmp_path):
         hidden = tmp_path / ".git"


### PR DESCRIPTION
## Summary
Loose-assertion ratchet batch 17. Top-4 files by AST counter:

| File | Pins |
|---|---|
| tests/unit/core/test_query_loader.py | 11 |
| tests/unit/test_unreachable_code.py | 10 (+1 `<=` bound) |
| tests/unit/test_incremental_sync.py | 10 (+1 `<=` bound) |
| tests/integration/core/test_analyze_scale_tool_file_output.py | 10 |

Baseline: **933 → 892** (= exactly the 41 flagged pins; the 2 `<=` bounds are outside the AST counter and noted in the history line for auditability — lead re-verified live).

Contract 5b highlights: **real dead-branch mock fixes before pinning** — analyze_scale mocks lacked `element_type` so summary counts were silently 0 and the hotspots guard was dead (now pinned to live values incl. full hotspot-entry); `MagicMock(name=...)` repr-name gotcha fixed via helper; 8 tree-sitter Node mocks got explicit `parent=None`; byte-size pins guarded with `newline="\n"`; query counts pinned as count+min exact facts per language; zero exemptions.

## Test plan
- [x] All 4 files individually `-n 0`: 21/34/19/15 passed
- [x] Diff gate exit=0
- [x] `--baseline` measures 892 == recorded (lead independently re-verified)