### PR TITLE
fix(search): cascade re-sort dropped test-file demotion for conceptual queries

### DIFF
--- a/tests/unit/test_ast_cache_cascade_search.py
+++ b/tests/unit/test_ast_cache_cascade_search.py
@@ -136,3 +136,117 @@ def test_cascade_private_fallback_helpers_cover_error_paths() -> None:
     conn.execute("DROP TABLE ast_symbol_rows")
     assert _like_rows(conn, "handle", None, 10) == []
     assert _fuzzy_rows(conn, None, 10) == []
+
+
+# ---------------------------------------------------------------------------
+# Issue #607 — test-file demotion must survive the cascade's final re-sort.
+#
+# fts_search_ranked demotes test files internally, but search_symbols_cascade
+# re-sorted purely by relevance_score, so long descriptive test_* names (which
+# match more conceptual-query tokens, hence better BM25) buried every
+# production symbol below the truncation window.
+# ---------------------------------------------------------------------------
+
+_Q3_STYLE_QUERY = "where are stop words filtered out of search queries"
+
+
+def _make_fts_conn() -> sqlite3.Connection:
+    """In-memory conn with the production FTS5 schema (porter, #604/#606)."""
+    conn = _make_conn()
+    conn.execute(
+        """CREATE VIRTUAL TABLE ast_symbols_fts
+           USING fts5(name, kind, file_path, language, content='',
+                      tokenize='porter unicode61')"""
+    )
+    return conn
+
+
+def _insert_fts(
+    conn: sqlite3.Connection,
+    name: str,
+    kind: str = "function",
+    file_path: str = "app.py",
+    language: str = "python",
+    line: int = 1,
+) -> None:
+    _insert(conn, name, kind=kind, file_path=file_path, language=language, line=line)
+    row_id = conn.execute(
+        "SELECT id FROM ast_symbol_rows WHERE name = ? AND file_path = ? AND line = ?",
+        (name, file_path, line),
+    ).fetchone()["id"]
+    conn.execute(
+        "INSERT INTO ast_symbols_fts(rowid, name, kind, file_path, language) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (row_id, name, kind, file_path, language),
+    )
+
+
+_Q3_STYLE_TEST_NAMES = (
+    "test_stop_words_filtered_out_of_search_queries",
+    "test_stop_word_filter_applies_to_search_query",
+    "test_filtered_stop_words_removed_from_search_queries",
+    "test_search_query_stop_words_filtered",
+    "test_stop_words_are_filtered_from_queries",
+    "test_query_search_filters_out_stop_words",
+)
+
+
+def _seed_q3_style_rows(conn: sqlite3.Connection) -> None:
+    """1 production symbol + 6 test symbols sharing MORE query tokens."""
+    _insert_fts(
+        conn,
+        "filter_stop_words",
+        file_path="tree_sitter_analyzer/search_filters.py",
+    )
+    for i, name in enumerate(_Q3_STYLE_TEST_NAMES, start=1):
+        _insert_fts(
+            conn,
+            name,
+            file_path="tests/unit/test_search_filters.py",
+            line=i * 10,
+        )
+
+
+def test_cascade_conceptual_query_promotes_production_above_tests() -> None:
+    """#607 RED: top-`limit` window must not be saturated by test symbols."""
+    from tree_sitter_analyzer._ast_cache_search import search_symbols_cascade
+    from tree_sitter_analyzer.utils.test_detection import is_test_file
+
+    conn = _make_fts_conn()
+    _seed_q3_style_rows(conn)
+
+    out = search_symbols_cascade(conn, _Q3_STYLE_QUERY, limit=5)
+
+    assert len(out) == 5
+    assert out[0]["name"] == "filter_stop_words"
+    assert [is_test_file(str(r["file"])) for r in out] == [
+        False,
+        True,
+        True,
+        True,
+        True,
+    ]
+
+
+def test_cascade_test_intent_query_keeps_test_symbols_on_top() -> None:
+    """Counter-direction pin: a query that asks about tests is NOT demoted."""
+    from tree_sitter_analyzer._ast_cache_search import search_symbols_cascade
+    from tree_sitter_analyzer.utils.test_detection import is_test_file
+
+    conn = _make_fts_conn()
+    _seed_q3_style_rows(conn)
+
+    out = search_symbols_cascade(
+        conn, "tests for stop words filtered out of search queries", limit=5
+    )
+
+    assert len(out) == 5
+    # query_wants_tests('tests ...') is True -> no demotion: the descriptive
+    # test_* names keep their better BM25 rank, exactly as before the fix.
+    assert [is_test_file(str(r["file"])) for r in out] == [
+        True,
+        True,
+        True,
+        True,
+        True,
+    ]

--- a/tests/unit/test_symbol_search_conceptual_demotion.py
+++ b/tests/unit/test_symbol_search_conceptual_demotion.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Issue #607 — conceptual queries through CodeGraphSymbolSearchTool.
+
+Reproduces the RFC-0016 pilot Q3 failure shape end-to-end: long descriptive
+``test_*`` names share more conceptual-query tokens than any production
+symbol, so they win the raw BM25 race. ``fts_search_ranked`` demotes test
+files, but ``search_symbols_cascade`` re-sorted purely by relevance_score and
+truncated, so the tool's own ``_demote_test_files`` received an all-test
+window with nothing left to promote.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tree_sitter_analyzer.ast_cache import ASTCache
+from tree_sitter_analyzer.mcp.tools.symbol_search_tool import CodeGraphSymbolSearchTool
+
+_Q3_STYLE_QUERY = "where are stop words filtered out of search queries"
+
+_PROD_SOURCE = "def filter_stop_words(query):\n    return query\n"
+
+_TEST_SOURCE = (
+    "def test_stop_words_filtered_out_of_search_queries():\n    pass\n\n"
+    "def test_stop_word_filter_applies_to_search_query():\n    pass\n\n"
+    "def test_filtered_stop_words_removed_from_search_queries():\n    pass\n\n"
+    "def test_search_query_stop_words_filtered():\n    pass\n\n"
+    "def test_stop_words_are_filtered_from_queries():\n    pass\n\n"
+    "def test_query_search_filters_out_stop_words():\n    pass\n"
+)
+
+
+@pytest.fixture
+def q3_shaped_project(tmp_path):
+    """1 production symbol + 6 token-richer test symbols (pilot Q3 shape)."""
+    project = tmp_path / "proj"
+    test_dir = project / "tests" / "unit"
+    test_dir.mkdir(parents=True)
+
+    (project / "search_filters.py").write_text(_PROD_SOURCE, newline="\n")
+    (test_dir / "test_search_filters.py").write_text(_TEST_SOURCE, newline="\n")
+
+    cache = ASTCache(str(project))
+    cache.index_project(max_files=100)
+    cache.close()
+    return project
+
+
+class TestConceptualQueryTestDemotion:
+    @pytest.mark.asyncio
+    async def test_production_symbol_tops_conceptual_query(self, q3_shaped_project):
+        """#607 RED: top-5 was all test functions; production must rank first."""
+        tool = CodeGraphSymbolSearchTool(str(q3_shaped_project))
+        result = await tool.execute(
+            {"query": _Q3_STYLE_QUERY, "limit": 5, "output_format": "json"}
+        )
+
+        assert result["success"] is True
+        assert result["match_count"] == 5
+        names = [r["name"] for r in result["results"]]
+        assert names[0] == "filter_stop_words"
+        assert [n.startswith("test_") for n in names] == [
+            False,
+            True,
+            True,
+            True,
+            True,
+        ]
+
+    @pytest.mark.asyncio
+    async def test_test_intent_query_still_surfaces_test_symbols(
+        self, q3_shaped_project
+    ):
+        """Counter-direction pin: explicit test-seeking queries keep tests on top."""
+        tool = CodeGraphSymbolSearchTool(str(q3_shaped_project))
+        result = await tool.execute(
+            {
+                "query": "tests for stop words filtered out of search queries",
+                "limit": 5,
+                "output_format": "json",
+            }
+        )
+
+        assert result["success"] is True
+        assert result["match_count"] == 5
+        names = [r["name"] for r in result["results"]]
+        assert [n.startswith("test_") for n in names] == [
+            True,
+            True,
+            True,
+            True,
+            True,
+        ]

--- a/tree_sitter_analyzer/_ast_cache_search.py
+++ b/tree_sitter_analyzer/_ast_cache_search.py
@@ -7,6 +7,7 @@ import sqlite3
 from typing import Any
 
 from ._ast_cache_query import fts_search_ranked
+from .utils.test_detection import query_wants_tests, rank_tier
 
 _KIND_BONUS = {
     "class": 0.08,
@@ -31,6 +32,13 @@ def search_symbols_cascade(
     Returned rows include ``match_tier`` plus a rescored ``relevance_score``.
     The fuzzy tier catches small typos and casing/boundary mismatches such as
     ``HandlerFunc`` matching ``handleFunc``.
+
+    Test-file demotion is the PRIMARY sort key (issue #607): the fts5 tier
+    feeds from ``fts_search_ranked`` which already demotes test files, but a
+    final re-sort by pure relevance_score let long descriptive ``test_*``
+    names (better BM25 on conceptual queries) re-bury every production
+    symbol below the truncation window. Demotion is skipped when the query
+    itself asks about tests (``query_wants_tests``).
     """
     query = query.strip()
     if not query or limit <= 0:
@@ -75,8 +83,11 @@ def search_symbols_cascade(
         )
 
     _apply_file_colocation_bonus(results)
+    wants_tests = query_wants_tests(query)
     results.sort(
         key=lambda row: (
+            # Negated because of reverse=True: production (tier 0) first.
+            -rank_tier(str(row.get("file", "")), wants_tests=wants_tests),
             float(row.get("relevance_score", 0.0)),
             _tier_rank(str(row.get("match_tier", ""))),
             str(row.get("name", "")),


### PR DESCRIPTION
Closes #607 (found by the RFC-0016 pilot baseline).

## Root cause (4 hypotheses, each live-verdicted)
`fts_search_ranked` demotes correctly (its output IS production-first), but `search_symbols_cascade` re-sorts purely by `relevance_score` (`_ast_cache_search.py:78-85`) — the first production row dropped to position 21 and `_fts_to_results` truncated to limit before the tool-level demotion saw anything but tests. `query_wants_tests` misfire: refuted. No-production-match: refuted (1,014 prod rows in the raw window). Window saturation: refuted as cause.

## Fix (11 lines)
`rank_tier(file, wants_tests=query_wants_tests(query))` becomes the PRIMARY key of the cascade's final sort; secondary/tertiary unchanged. Both directions pinned: test-intent queries still surface tests first.

## Pilot delta (same fresh 46,935-symbol index)
| Query | before | after |
|---|---|---|
| M1 route-to-facade | NO (top-5 = 5 tests) | **YES** (`legacy_to_facade`) |
| Q2 UML file scope | NO (5 tests) | **YES** (`class_diagram` r2) |
| Q3/Q4/Q7 | NO | still NO — but top-5 test rows 5/5 → **0/5**; residual = genuine vocabulary gaps (Q3's labeled target `_STOP_WORDS` isn't even indexed — module-level variable extraction gap, flagged separately) |
| Q1/Q8 controls | YES | YES unchanged |

Symbol-search target-in-top-5: **2/10 → 4/10**; all-test pollution eliminated on all 5 polluted queries. Side effect: the same cascade feeds nav context and Hyphae #name selectors — their suites green.

## Test plan
- [x] RED-first: cascade-level + end-to-end tests reproduced the all-test top-5, GREEN after; test-intent direction pinned both ways (10/10)
- [x] Regression: 14 FTS/search consumer files 267 passed + fts_fast_path 27 (-n 0)
- [x] ruff/mypy clean; ratchet exit=0; patch coverage 98.86% (1 pre-existing miss)
- [x] Lead independently re-ran 37 tests green + push diff=0