### PR TITLE
test: ratchet batch-18 — pin 40 loose assertions in top-4 AST-ranked files

### DIFF
--- a/scripts/loose_assertion_baseline.txt
+++ b/scripts/loose_assertion_baseline.txt
@@ -35,7 +35,9 @@
 #   files).
 #   batch-17 (AST): 933 -> 892, 2026-06-13 (41 flagged pins in top-4
 #   AST-ranked files, plus 2 unflagged <= bounds pinned exact).
+#   batch-18 (AST): 892 -> 852, 2026-06-13 (40 pins in top-4 AST-ranked
+#   files).
 
-BASELINE_COUNT=892
+BASELINE_COUNT=852
 MEASUREMENT_DATE=2026-06-13
 MEASUREMENT_COMMAND="uv run python scripts/check_loose_assertions.py --baseline"

--- a/tests/unit/grammar_coverage/test_corpus_generator.py
+++ b/tests/unit/grammar_coverage/test_corpus_generator.py
@@ -123,7 +123,7 @@ class TestGenerateCorpusByCategory:
     def test_python_corpus_structure(self) -> None:
         """测试 Python 语料库结构"""
         corpus = generate_corpus_by_category("python")
-        assert len(corpus) > 0
+        assert len(corpus) == 5  # 模板表驱动，精确钉死（measured 2026-06-13）
         # 检查是否有函数、类、语句等分类
         assert any("functions" in path for path in corpus.keys())
         assert any("classes" in path for path in corpus.keys())
@@ -147,7 +147,7 @@ class TestGenerateCorpusByCategory:
     def test_javascript_corpus_structure(self) -> None:
         """测试 JavaScript 语料库结构"""
         corpus = generate_corpus_by_category("javascript")
-        assert len(corpus) > 0
+        assert len(corpus) == 6  # 模板表驱动，精确钉死（measured 2026-06-13）
         assert any("functions" in path for path in corpus.keys())
         assert any("classes" in path for path in corpus.keys())
 
@@ -160,7 +160,7 @@ class TestGenerateCorpusByCategory:
     def test_java_corpus_structure(self) -> None:
         """测试 Java 语料库结构"""
         corpus = generate_corpus_by_category("java")
-        assert len(corpus) > 0
+        assert len(corpus) == 4  # 模板表驱动，精确钉死（measured 2026-06-13）
         assert any("methods" in path or "classes" in path for path in corpus.keys())
 
     def test_java_corpus_file_extensions(self) -> None:
@@ -185,7 +185,10 @@ class TestSaveCorpusFiles:
             saved_paths = save_corpus_files("python", corpus, tmpdir)
             assert len(saved_paths) == 1
             assert saved_paths[0].exists()
-            assert saved_paths[0].read_text(encoding="utf-8") == corpus["functions/test.py"]
+            assert (
+                saved_paths[0].read_text(encoding="utf-8")
+                == corpus["functions/test.py"]
+            )
 
     def test_save_multiple_files(self) -> None:
         """测试保存多个文件"""
@@ -227,8 +230,9 @@ class TestGenerateAndSaveCorpus:
             paths, success, failed = generate_and_save_corpus(
                 "python", tmpdir, validate=True
             )
-            assert len(paths) > 0
-            assert success > 0
+            # 5 个模板文件全部生成且全部通过验证（measured 2026-06-13）
+            assert len(paths) == 5
+            assert success == 5
             assert all(path.exists() for path in paths)
 
     def test_javascript_end_to_end(self) -> None:
@@ -237,8 +241,9 @@ class TestGenerateAndSaveCorpus:
             paths, success, failed = generate_and_save_corpus(
                 "javascript", tmpdir, validate=True
             )
-            assert len(paths) > 0
-            assert success > 0
+            # 6 个模板文件全部生成且全部通过验证（measured 2026-06-13）
+            assert len(paths) == 6
+            assert success == 6
             assert all(path.exists() for path in paths)
 
     def test_java_end_to_end(self) -> None:
@@ -247,8 +252,9 @@ class TestGenerateAndSaveCorpus:
             paths, success, failed = generate_and_save_corpus(
                 "java", tmpdir, validate=True
             )
-            assert len(paths) > 0
-            assert success > 0
+            # 4 个模板文件全部生成且全部通过验证（measured 2026-06-13）
+            assert len(paths) == 4
+            assert success == 4
             assert all(path.exists() for path in paths)
 
     def test_without_validation(self) -> None:
@@ -257,7 +263,7 @@ class TestGenerateAndSaveCorpus:
             paths, success, failed = generate_and_save_corpus(
                 "python", tmpdir, validate=False
             )
-            assert len(paths) > 0
+            assert len(paths) == 5  # 5 个模板文件（measured 2026-06-13）
             assert success == 0  # No validation performed
             assert failed == 0
 
@@ -285,9 +291,9 @@ class TestCorpusValidation:
             ]
             clean_code = "\n".join(code_lines)
             if clean_code.strip():  # 只验证非空代码
-                assert validate_generated_code(
-                    "python", clean_code
-                ), f"Invalid code in {relative_path}"
+                assert validate_generated_code("python", clean_code), (
+                    f"Invalid code in {relative_path}"
+                )
 
     def test_all_javascript_templates_valid(self) -> None:
         """测试所有 JavaScript 模板都是有效的"""
@@ -298,9 +304,9 @@ class TestCorpusValidation:
             ]
             clean_code = "\n".join(code_lines)
             if clean_code.strip():
-                assert validate_generated_code(
-                    "javascript", clean_code
-                ), f"Invalid code in {relative_path}"
+                assert validate_generated_code("javascript", clean_code), (
+                    f"Invalid code in {relative_path}"
+                )
 
     def test_all_java_templates_valid(self) -> None:
         """测试所有 Java 模板都是有效的"""
@@ -311,6 +317,6 @@ class TestCorpusValidation:
             ]
             clean_code = "\n".join(code_lines)
             if clean_code.strip():
-                assert validate_generated_code(
-                    "java", clean_code
-                ), f"Invalid code in {relative_path}"
+                assert validate_generated_code("java", clean_code), (
+                    f"Invalid code in {relative_path}"
+                )

--- a/tests/unit/grammar_coverage/test_introspector.py
+++ b/tests/unit/grammar_coverage/test_introspector.py
@@ -10,6 +10,32 @@ from tree_sitter_analyzer.grammar_coverage.introspector import (
     get_structural_types,
 )
 
+# Exact (total, extractable, structural) node-type counts per language,
+# measured 2026-06-13 against the grammar wheel versions locked in uv.lock
+# (CI installs the same set via `uv sync --all-extras`). A grammar version
+# bump that shifts a count MUST go red here and force a conscious re-pin.
+# "json" is absent: loader.is_language_available("json") is False, so the
+# loops below skip it.
+EXPECTED_GRAMMAR_COUNTS = {
+    "python": (129, 25, 104),
+    "javascript": (122, 25, 98),
+    "typescript": (191, 30, 162),
+    "go": (110, 30, 80),
+    "rust": (185, 20, 165),
+    "java": (142, 30, 112),
+    "cpp": (256, 43, 213),
+    "c": (160, 21, 139),
+    "csharp": (239, 44, 195),
+    "ruby": (157, 4, 156),
+    "php": (177, 35, 142),
+    "swift": (191, 29, 162),
+    "kotlin": (116, 9, 107),
+    "scala": (153, 15, 138),
+    "bash": (85, 10, 75),
+    "yaml": (161, 0, 161),
+    "sql": (527, 7, 520),
+}
+
 
 class TestGetAllNodeTypes:
     """测试从 tree-sitter 语法中提取所有节点类型。"""
@@ -36,8 +62,8 @@ class TestGetAllNodeTypes:
         for expected in expected_types:
             assert expected in node_types, f"Missing {expected}"
 
-        # 验证节点数量合理（Python 语法约 100+ 命名节点）
-        assert len(node_types) > 50, f"Too few node types: {len(node_types)}"
+        # 验证节点数量（精确钉死，见 EXPECTED_GRAMMAR_COUNTS 测量说明）
+        assert len(node_types) == 129, f"Node type count drifted: {len(node_types)}"
 
     def test_javascript_node_extraction(self) -> None:
         """测试 JavaScript 语言的节点类型提取。"""
@@ -86,7 +112,11 @@ class TestGetAllNodeTypes:
             if not loader.is_language_available(language):
                 continue  # skip languages not installed in this environment
             node_types = get_all_node_types(language)
-            assert len(node_types) > 0, f"No node types for {language}"
+            expected_total = EXPECTED_GRAMMAR_COUNTS[language][0]
+            assert len(node_types) == expected_total, (
+                f"Node type count drifted for {language}: "
+                f"{len(node_types)} != {expected_total}"
+            )
             assert node_types == sorted(node_types)
 
 
@@ -212,9 +242,9 @@ class TestGetStructuralTypes:
             all_set = set(all_types)
 
             # 所有节点都应该被分类到至少一个类别
-            assert all_set.issubset(
-                covered
-            ), f"Uncovered nodes in {language}: {all_set - covered}"
+            assert all_set.issubset(covered), (
+                f"Uncovered nodes in {language}: {all_set - covered}"
+            )
 
 
 class TestGetLanguageSummary:
@@ -242,10 +272,10 @@ class TestGetLanguageSummary:
         assert len(summary["extractable_types"]) == summary["extractable_count"]
         assert len(summary["structural_types"]) == summary["structural_count"]
 
-        # 验证计数合理性
-        assert summary["total_count"] > 0
-        assert summary["extractable_count"] > 0
-        assert summary["structural_count"] > 0
+        # 验证计数（精确钉死，见 EXPECTED_GRAMMAR_COUNTS 测量说明）
+        assert summary["total_count"] == 129
+        assert summary["extractable_count"] == 25
+        assert summary["structural_count"] == 104
 
     def test_all_languages_summary(self) -> None:
         """测试所有支持语言的摘要生成。"""
@@ -258,17 +288,22 @@ class TestGetLanguageSummary:
                 continue  # skip languages not installed in this environment
             summary = get_language_summary(language)
 
-            assert summary["total_count"] > 0, f"No types for {language}"
+            expected = EXPECTED_GRAMMAR_COUNTS[language]
+            assert summary["total_count"] == expected[0], (
+                f"Total count drifted for {language}: {summary['total_count']}"
+            )
 
-            # 数据格式语言可能没有可提取节点
+            # 数据格式语言可能没有可提取节点（yaml 钉死为 0）
             if language not in DATA_FORMAT_LANGUAGES:
-                assert (
-                    summary["extractable_count"] > 0
-                ), f"No extractable types for {language}"
+                assert summary["extractable_count"] == expected[1], (
+                    f"Extractable count drifted for {language}: "
+                    f"{summary['extractable_count']}"
+                )
 
-            assert (
-                summary["structural_count"] > 0
-            ), f"No structural types for {language}"
+            assert summary["structural_count"] == expected[2], (
+                f"Structural count drifted for {language}: "
+                f"{summary['structural_count']}"
+            )
 
             # 验证数据一致性
             assert len(summary["all_types"]) == summary["total_count"]
@@ -350,23 +385,25 @@ class TestCrossLanguageConsistency:
             summary = get_language_summary(language)
 
             # 语法节点数通常在 10-600 之间（SQL 有 527 个节点）
-            assert (
-                10 <= summary["total_count"] <= 600
-            ), f"Unusual node count for {language}: {summary['total_count']}"
+            assert 10 <= summary["total_count"] <= 600, (
+                f"Unusual node count for {language}: {summary['total_count']}"
+            )
 
             # 数据格式语言可能没有可提取节点（它们主要是结构性节点）
+            expected = EXPECTED_GRAMMAR_COUNTS[language]
             if language in DATA_FORMAT_LANGUAGES:
                 # YAML 和 JSON 可能没有传统意义上的"可提取"节点
-                # 但应该有总节点数
-                assert summary["total_count"] > 0
+                # 但总节点数精确钉死
+                assert summary["total_count"] == expected[0]
             else:
-                # 编程语言必须有可提取节点
-                assert (
-                    summary["extractable_count"] > 0
-                ), f"No extractable types for {language}"
+                # 编程语言的可提取节点数精确钉死
+                assert summary["extractable_count"] == expected[1], (
+                    f"Extractable count drifted for {language}: "
+                    f"{summary['extractable_count']}"
+                )
 
                 # 可提取节点占比通常在 0.5%-50% 之间
                 ratio = summary["extractable_count"] / summary["total_count"]
-                assert (
-                    0.005 <= ratio <= 0.5
-                ), f"Unusual extractable ratio for {language}: {ratio:.2%} ({summary['extractable_count']}/{summary['total_count']})"
+                assert 0.005 <= ratio <= 0.5, (
+                    f"Unusual extractable ratio for {language}: {ratio:.2%} ({summary['extractable_count']}/{summary['total_count']})"
+                )

--- a/tests/unit/languages/test_css_plugin.py
+++ b/tests/unit/languages/test_css_plugin.py
@@ -175,11 +175,13 @@ h1 {
             # Analyze the file
             result = await self.plugin.analyze_file(temp_path, request)
 
-            # Verify results
+            # Verify results. Exact pins measured on the inline fixture:
+            # 34 lines; 7 elements = body/.container/h1 + @media + its 2
+            # nested rules + @keyframes.
             assert result.success
             assert result.language == "css"
-            assert result.line_count > 0
-            assert len(result.elements) > 0
+            assert result.line_count == 34
+            assert len(result.elements) == 7
             assert result.source_code == css_content
 
             # Check that we have at least one element
@@ -223,7 +225,7 @@ class TestCssExtractAtRuleName:
         elements = self.extractor.extract_css_rules(tree, css_code)
 
         keyframes = [e for e in elements if e.selector.startswith("@keyframes")]
-        assert len(keyframes) >= 1
+        assert len(keyframes) == 1  # fixture declares exactly 1 @keyframes
         assert keyframes[0].selector == "@keyframes fadeIn"
         assert keyframes[0].name == "@keyframes fadeIn"
 
@@ -237,7 +239,7 @@ class TestCssExtractAtRuleName:
         elements = self.extractor.extract_css_rules(tree, css_code)
 
         media_queries = [e for e in elements if e.selector.startswith("@media")]
-        assert len(media_queries) >= 1
+        assert len(media_queries) == 1  # fixture declares exactly 1 @media
         assert media_queries[0].selector == "@media (max-width: 768px)"
         assert media_queries[0].name == "@media (max-width: 768px)"
 
@@ -251,7 +253,7 @@ class TestCssExtractAtRuleName:
         elements = self.extractor.extract_css_rules(tree, css_code)
 
         media_queries = [e for e in elements if e.selector.startswith("@media")]
-        assert len(media_queries) >= 1
+        assert len(media_queries) == 1  # fixture declares exactly 1 @media
         assert "screen" in media_queries[0].selector
         assert "min-width" in media_queries[0].selector
 
@@ -265,7 +267,7 @@ class TestCssExtractAtRuleName:
         elements = self.extractor.extract_css_rules(tree, css_code)
 
         media_queries = [e for e in elements if e.selector.startswith("@media")]
-        assert len(media_queries) >= 1
+        assert len(media_queries) == 1  # fixture declares exactly 1 @media
         assert "min-width" in media_queries[0].selector
         assert "max-width" in media_queries[0].selector
 
@@ -279,7 +281,7 @@ class TestCssExtractAtRuleName:
         elements = self.extractor.extract_css_rules(tree, css_code)
 
         media_queries = [e for e in elements if e.selector.startswith("@media")]
-        assert len(media_queries) >= 1
+        assert len(media_queries) == 1  # fixture declares exactly 1 @media
         assert "prefers-color-scheme" in media_queries[0].selector
         assert "dark" in media_queries[0].selector
 
@@ -293,7 +295,7 @@ class TestCssExtractAtRuleName:
         elements = self.extractor.extract_css_rules(tree, css_code)
 
         media_queries = [e for e in elements if e.selector.startswith("@media")]
-        assert len(media_queries) >= 1
+        assert len(media_queries) == 1  # fixture declares exactly 1 @media
         assert media_queries[0].selector == "@media print"
 
     def test_extract_multiple_keyframes(self):
@@ -318,7 +320,7 @@ class TestCssExtractAtRuleName:
         elements = self.extractor.extract_css_rules(tree, css_code)
 
         keyframes = [e for e in elements if e.selector.startswith("@keyframes")]
-        assert len(keyframes) >= 3
+        assert len(keyframes) == 3  # fixture declares exactly 3 @keyframes
 
         names = [e.name for e in keyframes]
         assert "@keyframes fadeIn" in names
@@ -534,7 +536,10 @@ class TestCssPluginAnalyzeFallback:
                     result = await plugin.analyze_file(temp_path, MockRequest())
                     assert result.success
                     assert result.language == "css"
-                    assert len(result.elements) >= 1
+                    # The regex fallback parser extracts 1 element from the
+                    # 2-rule fixture (measured live; documents the degraded
+                    # path's actual recall, not a hoped-for bound).
+                    assert len(result.elements) == 1
         finally:
             Path(temp_path).unlink()
 

--- a/tests/unit/languages/test_java_query_validation.py
+++ b/tests/unit/languages/test_java_query_validation.py
@@ -108,7 +108,9 @@ class TestMatchPredicateFix:
     def test_spring_controller_finds_owner_controller(self, petclinic_server):
         """spring_controller must find @Controller annotated OwnerController."""
         results = query(petclinic_server, OWNER_CONTROLLER, "spring_controller")
-        assert len(results) >= 1, (
+        # 1 @Controller match x 3 captures (spring_controller, annotation_name,
+        # controller_name) — measured on upstream HEAD 2026-06-13.
+        assert len(results) == 3, (
             f"spring_controller query must find OwnerController (@Controller). "
             f"Got {len(results)} results. "
             "Bug: #match? predicate not applied in tree-sitter 0.25 QueryCursor."
@@ -121,7 +123,9 @@ class TestMatchPredicateFix:
     def test_jpa_entity_finds_vet(self, petclinic_server):
         """jpa_entity must find @Entity annotated Vet class."""
         results = query(petclinic_server, VET, "jpa_entity")
-        assert len(results) >= 1, (
+        # 1 @Entity match x 3 captures (jpa_entity, annotation_name,
+        # entity_name) — measured on upstream HEAD 2026-06-13.
+        assert len(results) == 3, (
             f"jpa_entity query must find Vet (@Entity). Got {len(results)} results. "
             "Bug: #match? predicate silently returns 0."
         )
@@ -129,7 +133,8 @@ class TestMatchPredicateFix:
     def test_jpa_entity_finds_owner(self, petclinic_server):
         """jpa_entity must find @Entity annotated Owner class."""
         results = query(petclinic_server, OWNER, "jpa_entity")
-        assert len(results) >= 1, (
+        # 1 @Entity match x 3 captures — measured on upstream HEAD 2026-06-13.
+        assert len(results) == 3, (
             f"jpa_entity query must find Owner (@Entity). Got {len(results)} results."
         )
 
@@ -165,20 +170,25 @@ class TestSpringBeanQuery:
     def test_spring_bean_finds_cache_advisor(self, spring_server):
         """spring_bean must find @Bean methods in ProxyCachingConfiguration."""
         results = query(spring_server, PROXY_CACHING, "spring_bean")
-        assert len(results) >= 1, (
+        # 3 @Bean matches x 3 captures (spring_bean, annotation_name,
+        # method_name) — measured on upstream HEAD 2026-06-13.
+        assert len(results) == 9, (
             f"ProxyCachingConfiguration has 3 @Bean methods (cacheAdvisor, "
             f"cacheOperationSource, cacheInterceptor). Got {len(results)}. "
             "Query 'spring_bean' not yet implemented."
         )
-        assert len(results) >= 3, (
-            f"Expected ≥3 @Bean methods, got {len(results)}: "
-            f"{[r.get('content', '')[:40] for r in results]}"
+        bean_captures = [r for r in results if r.get("capture_name") == "spring_bean"]
+        assert len(bean_captures) == 3, (
+            f"Expected exactly 3 @Bean methods, got {len(bean_captures)}: "
+            f"{[r.get('content', '')[:40] for r in bean_captures]}"
         )
 
     def test_spring_configuration_finds_proxy_caching(self, spring_server):
         """spring_configuration must find @Configuration classes."""
         results = query(spring_server, PROXY_CACHING, "spring_configuration")
-        assert len(results) >= 1, (
+        # 1 @Configuration match x 3 captures (spring_configuration,
+        # annotation_name, class_name) — measured on upstream HEAD 2026-06-13.
+        assert len(results) == 3, (
             f"ProxyCachingConfiguration is @Configuration. Got {len(results)}. "
             "Query 'spring_configuration' not yet implemented."
         )
@@ -193,8 +203,13 @@ class TestSpringBeanQuery:
         if not tx_file.exists():
             pytest.skip("Transaction file not found")
         results = query(spring_server, tx_file, "spring_transactional")
-        assert len(results) >= 0, "Query should not crash"
-        # The file itself may not have @Transactional but the query must not error
+        # The `>= 0` form was a tautology. The file declares no @Transactional
+        # methods (it *parses* the annotation) — measured 0 matches on
+        # upstream HEAD 2026-06-13; the query must not error.
+        assert len(results) == 0, (
+            f"AnnotationTransactionAttributeSource has no @Transactional "
+            f"methods. Got {len(results)} results."
+        )
 
 
 @pytest.mark.skipif(not PETCLINIC_BASE.exists(), reason="spring-petclinic not cloned")
@@ -210,8 +225,10 @@ class TestJUnit5Queries:
         if not test_file.exists():
             pytest.skip("Test file not found")
         results = query(petclinic_server, test_file, "junit5_test")
-        assert len(results) >= 1, (
-            f"OwnerControllerTests has @Test methods. Got {len(results)}. "
+        # 13 @Test methods x 3 captures (junit5_test, annotation_name,
+        # method_name) — measured on upstream HEAD 2026-06-13.
+        assert len(results) == 39, (
+            f"OwnerControllerTests has 13 @Test methods. Got {len(results)}. "
             "Query 'junit5_test' not yet implemented."
         )
 
@@ -223,8 +240,10 @@ class TestConcurrencyQueries:
     def test_volatile_field_finds_caffeine_fields(self, caffeine_server):
         """volatile_field must find volatile fields in BoundedLocalCache."""
         results = query(caffeine_server, BOUNDED_LOCAL_CACHE, "volatile_field")
-        assert len(results) >= 1, (
-            f"BoundedLocalCache has volatile fields. Got {len(results)}. "
+        # 2 volatile fields x 3 captures (volatile_field, modifier,
+        # field_name) — measured on upstream HEAD 2026-06-13.
+        assert len(results) == 6, (
+            f"BoundedLocalCache has 2 volatile fields. Got {len(results)}. "
             "Query 'volatile_field' not yet implemented."
         )
 
@@ -267,7 +286,9 @@ public record Point(int x, int y) {
         os.unlink(tmp_path)
 
         results = r.get("results", [])
-        assert len(results) >= 1, (
+        # 1 record match x 2 captures (record_declaration, record_name) —
+        # measured locally 2026-06-13 (this test has no external-repo gate).
+        assert len(results) == 2, (
             f"Should find 'Point' record declaration. Got {len(results)}. "
             "Query 'record_declaration' not yet implemented."
         )


### PR DESCRIPTION
## Summary
Loose-assertion ratchet batch 18. Top-4 files by AST counter (10 pins each):

| File | Pins |
|---|---|
| tests/unit/languages/test_java_query_validation.py | 10 |
| tests/unit/languages/test_css_plugin.py | 10 |
| tests/unit/grammar_coverage/test_introspector.py | 10 |
| tests/unit/grammar_coverage/test_corpus_generator.py | 10 |

Baseline: **892 → 852** (= exactly 40, lead re-verified live).

Notes:
- **Java query pins carry an honest caveat**: those tests are skipif-gated on `/workspaces` clones absent locally AND in CI (risk surface today = 0). Values measured against upstream HEAD 2026-06-13 (source+date in comments). If someone's clone snapshot differs, the red forces a conscious re-pin — recorded intent, not hidden.
- test_introspector gains a module-level `EXPECTED_GRAMMAR_COUNTS` table pinned to uv.lock grammar versions — a grammar bump goes RED by design (locked exact-assertion rule).
- CSS/corpus pins all from live inline-fixture measurement; zero exemption markers.

## Test plan
- [x] All 4 files individually `-n 0`: 1+10skip / 43 / 18 / 35 passed (re-run post-ruff-format)
- [x] Diff gate exit=0
- [x] `--baseline` measures 852 == recorded (lead independently re-verified)