### PR TITLE
feat(index): module-level constants indexed as symbols

### DIFF
--- a/tests/unit/test_ast_extraction.py
+++ b/tests/unit/test_ast_extraction.py
@@ -468,3 +468,96 @@ impl User {
         methods = [s for s in syms if s["kind"] in ("function", "method")]
         assert len(methods) == 1
         assert methods[0].get("class") == "User"
+
+
+# ---------------------------------------------------------------------------
+# Issue #610: Python module-level constants indexed as kind="constant"
+# ---------------------------------------------------------------------------
+
+
+_CONST_SRC = """\
+_STOP_WORDS = frozenset({"the"})
+CONFIG: dict = {}
+__version__ = "1.0"
+logger = get_logger()
+paths: list = []
+bare_decl: int
+
+if True:
+    WRAPPED_FLAG = 1
+
+
+class Settings:
+    TIMEOUT = 30
+
+
+def setup():
+    RETRIES = 3
+"""
+
+
+class TestPythonModuleConstants:
+    """Issue #610 — module-level const-style / annotated / dunder assignments
+    must reach ast_symbol_rows as kind="constant"."""
+
+    def _constants(self) -> dict[str, dict]:
+        syms = _symbols_for(_CONST_SRC, "python")
+        return {s["name"]: s for s in syms if s["kind"] == "constant"}
+
+    def test_exactly_the_five_module_constants_extracted(self):
+        consts = self._constants()
+        assert sorted(consts) == [
+            "CONFIG",
+            "WRAPPED_FLAG",
+            "_STOP_WORDS",
+            "__version__",
+            "paths",
+        ]
+
+    def test_const_style_name_lines_pinned(self):
+        consts = self._constants()
+        assert consts["_STOP_WORDS"]["line"] == 1
+        assert consts["_STOP_WORDS"]["end_line"] == 1
+        assert consts["CONFIG"]["line"] == 2
+        assert consts["__version__"]["line"] == 3
+        assert consts["WRAPPED_FLAG"]["line"] == 9
+        assert all(c["language"] == "python" for c in consts.values())
+
+    def test_annotated_lowercase_assignment_extracted(self):
+        # `paths: list = []` — annotated module assignment counts even when
+        # the name is not const-style (deliberate typed API surface).
+        assert "paths" in self._constants()
+
+    def test_lowercase_unannotated_assignment_not_extracted(self):
+        # `logger = get_logger()` — mutable module state, excluded by scope rule.
+        syms = _symbols_for(_CONST_SRC, "python")
+        logger_kinds = [s["kind"] for s in syms if s.get("name") == "logger"]
+        assert logger_kinds == []
+
+    def test_bare_annotation_without_value_not_extracted(self):
+        # `bare_decl: int` has no right-hand side — not a definition site.
+        assert "bare_decl" not in self._constants()
+
+    def test_class_body_all_caps_not_extracted(self):
+        # Settings.TIMEOUT is a class attribute, not a module constant.
+        assert "TIMEOUT" not in self._constants()
+
+    def test_function_body_all_caps_not_extracted(self):
+        # RETRIES lives in a function body — module-level only.
+        assert "RETRIES" not in self._constants()
+
+    def test_non_python_assignment_unaffected(self):
+        # JS module-level const keeps its pre-existing kind="variable" path.
+        syms = _symbols_for("const MAX_SIZE = 10;\n", "javascript")
+        kinds = {s["name"]: s["kind"] for s in syms if "name" in s}
+        assert kinds == {"MAX_SIZE": "variable"}
+
+    def test_chained_assignment_captures_both_names(self):
+        syms = _symbols_for("A_ONE = B_TWO = 5\n", "python")
+        consts = sorted(s["name"] for s in syms if s["kind"] == "constant")
+        assert consts == ["A_ONE", "B_TWO"]
+
+    def test_tuple_target_not_extracted(self):
+        # Non-simple targets (tuple unpacking) are excluded by the scope rule.
+        syms = _symbols_for("X_A, Y_B = 1, 2\n", "python")
+        assert [s for s in syms if s["kind"] == "constant"] == []

--- a/tests/unit/test_status_kind_language_breakdown.py
+++ b/tests/unit/test_status_kind_language_breakdown.py
@@ -183,6 +183,19 @@ class TestGetStatsBreakdowns:
         # classification engineer may reclassify some entries.
         assert by_kind.get("function", 0) >= 1
 
+    def test_symbols_by_kind_includes_constant_bucket(self) -> None:
+        """Issue #610 — kind='constant' rows (Python module constants) must
+        surface as their own symbols_by_kind bucket."""
+        rows = [
+            ("MAX_RETRIES", "constant", "python"),
+            ("_STOP_WORDS", "constant", "python"),
+            ("my_func", "function", "python"),
+        ]
+        conn = _make_conn_with_symbols(rows)
+        stats = get_stats(conn, fts5_available=True, db_path=":memory:")
+        by_kind = stats["symbols_by_kind"]
+        assert by_kind.get("constant") == 2, f"expected constant=2, got {by_kind}"
+
     def test_degrade_gracefully_when_fts5_unavailable(self) -> None:
         """When fts5_available=False, symbols_by_kind/by_language are empty dicts."""
         conn = _make_conn_with_symbols([("ClassA", "class", "python")])

--- a/tests/unit/test_symbol_resolver.py
+++ b/tests/unit/test_symbol_resolver.py
@@ -282,3 +282,51 @@ class TestCodeGraphSymbolResolveExecution:
         assert result["definition_count"] == 1
         defs = result["definitions"]
         assert any("models.py" in d["file"] for d in defs)
+
+
+# ---------------------------------------------------------------------------
+# Issue #610: module-level constants are go-to-definition-able
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def constant_project(tmp_path):
+    project = tmp_path / "proj610"
+    project.mkdir()
+    (project / "consts.py").write_text(
+        '_STOP_WORDS = frozenset({"the"})\nMAX_RETRIES: int = 5\n__version__ = "1.0"\n'
+    )
+    (project / "main.py").write_text(
+        "from consts import _STOP_WORDS\n\ndef use_it():\n    return _STOP_WORDS\n"
+    )
+    cache = ASTCache(str(project))
+    cache.index_project(max_files=10)
+    cache.close()
+    return project
+
+
+class TestConstantNavigation:
+    """Issue #610 — kind=constant rows must be searchable AND navigable."""
+
+    def test_resolve_constant_definition(self, constant_project):
+        cache = ASTCache(str(constant_project))
+        resolver = SymbolResolver(cache)
+        result = resolver.resolve("_STOP_WORDS")
+        assert len(result.definitions) == 1
+        d = result.definitions[0]
+        assert d.name == "_STOP_WORDS"
+        assert d.kind == "constant"
+        assert d.file == "consts.py"
+        assert d.line == 1
+        cache.close()
+
+    def test_find_defs_in_file_kind_filter_includes_constant(self, constant_project):
+        # nav action=navigate import-following path goes through
+        # _find_defs_in_file, whose kind filter historically excluded constants.
+        cache = ASTCache(str(constant_project))
+        resolver = SymbolResolver(cache)
+        defs = resolver._find_defs_in_file("consts.py", "MAX_RETRIES")
+        assert len(defs) == 1
+        assert defs[0].kind == "constant"
+        assert defs[0].line == 2
+        cache.close()

--- a/tree_sitter_analyzer/_ast_cache_indexer.py
+++ b/tree_sitter_analyzer/_ast_cache_indexer.py
@@ -20,7 +20,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Extractor version constant — kept in sync with ast_cache.py.
-_AST_CACHE_EXTRACTOR_VERSION = 2
+# v3: #610 — Python module-level constants extracted as kind="constant".
+_AST_CACHE_EXTRACTOR_VERSION = 3
 
 
 def check_cache_or_read(

--- a/tree_sitter_analyzer/_ast_extraction.py
+++ b/tree_sitter_analyzer/_ast_extraction.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import sqlite3
 from typing import Any
 
@@ -199,6 +200,45 @@ _VAR_DECL_LIKE = frozenset(
         "let_declaration",
     }
 )
+
+# Issue #610 — Python module-level constants. tree-sitter-python emits
+# ``assignment`` nodes (with a ``left`` field, not ``name``), so they never
+# matched _VAR_DECL_LIKE and were invisible to ast_symbol_rows. Scope rule
+# (approved on #610): module-scope simple assignments whose target is
+# const-style (``^_?[A-Z][A-Z0-9_]+$``), annotated (``x: T = ...``), or a
+# dunder (``^__\w+__$``) — emitted as kind="constant".
+_PY_CONST_NAME = re.compile(r"^_?[A-Z][A-Z0-9_]+$")
+_PY_DUNDER_NAME = re.compile(r"^__\w+__$")
+
+# Node types that open a non-module scope: an ``assignment`` nested under any
+# of these is a class attribute or function local, not a module constant.
+_PY_SCOPE_BODY_NODES = frozenset({"function_definition", "class_definition"})
+
+
+def _python_module_constant(node: Any, source: str) -> dict[str, Any] | None:
+    """Return a kind="constant" symbol for a module-scope Python assignment,
+    or None when the node does not match the #610 scope rule.
+
+    The caller guarantees module scope (no enclosing function/class body);
+    this helper checks target shape and naming/annotation rules only.
+    """
+    left = node.child_by_field_name("left")
+    if left is None or left.type != "identifier":
+        return None  # tuple/attribute/subscript targets are out of scope
+    if node.child_by_field_name("right") is None:
+        return None  # bare annotation (``x: int``) — not a definition site
+    name = _node_text(left, source)
+    annotated = node.child_by_field_name("type") is not None
+    if not (annotated or _PY_CONST_NAME.match(name) or _PY_DUNDER_NAME.match(name)):
+        return None
+    return {
+        "kind": "constant",
+        "name": name,
+        "line": node.start_point[0] + 1,
+        "end_line": node.end_point[0] + 1,
+        "language": "python",
+    }
+
 
 _COMPLEXITY_NODE_TYPES: dict[str, set[str]] = {
     "python": {
@@ -500,7 +540,15 @@ def _walk_for_symbols(
     symbols: list[dict[str, Any]],
     language: str,
     depth: int = 0,
+    enclosed: bool = False,
 ) -> None:
+    """Walk the AST collecting symbol dicts.
+
+    ``enclosed`` tracks (top-down, no parent walking) whether *node* sits
+    inside a Python function/class body — module-constant capture (#610)
+    must fire at module scope only, including ``if``/``try``-wrapped
+    module-level assignments.
+    """
     if depth > 20:
         return
     node_type = node.type
@@ -568,8 +616,13 @@ def _walk_for_symbols(
                     "language": language,
                 }
             )
+    elif node_type == "assignment" and language == "python" and not enclosed:
+        const_sym = _python_module_constant(node, source)
+        if const_sym is not None:
+            symbols.append(const_sym)
+    child_enclosed = enclosed or node_type in _PY_SCOPE_BODY_NODES
     for child in node.children:
-        _walk_for_symbols(child, source, symbols, language, depth + 1)
+        _walk_for_symbols(child, source, symbols, language, depth + 1, child_enclosed)
 
 
 def _extract_symbols(tree: Any, source_code: str, language: str) -> dict[str, Any]:

--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -59,7 +59,8 @@ from .project_graph import _language_from_ext
 
 logger = logging.getLogger(__name__)
 
-_AST_CACHE_EXTRACTOR_VERSION = 2
+# v3: #610 — Python module-level constants extracted as kind="constant".
+_AST_CACHE_EXTRACTOR_VERSION = 3
 
 
 class SchemaIntegrityError(RuntimeError):

--- a/tree_sitter_analyzer/codegraph_query_backend.py
+++ b/tree_sitter_analyzer/codegraph_query_backend.py
@@ -8,7 +8,8 @@ from typing import Any
 
 from .semantic_search import SemanticSymbolSearch
 
-_DEFINITION_KINDS = frozenset({"function", "class", "method", "variable"})
+# #610: "constant" — Python module-level constants are definition sites.
+_DEFINITION_KINDS = frozenset({"function", "class", "method", "variable", "constant"})
 
 
 class CodeGraphQueryBackend:
@@ -91,7 +92,7 @@ class CodeGraphQueryBackend:
             rows = conn.execute(
                 """SELECT name, kind, file_path, language, line, end_line
                    FROM ast_symbol_rows
-                   WHERE name = ? AND kind IN ('function', 'class', 'method', 'variable')
+                   WHERE name = ? AND kind IN ('function', 'class', 'method', 'variable', 'constant')
                    ORDER BY file_path, line""",
                 (symbol,),
             ).fetchall()

--- a/tree_sitter_analyzer/symbol_resolver.py
+++ b/tree_sitter_analyzer/symbol_resolver.py
@@ -26,7 +26,8 @@ from .codegraph_query_backend import CodeGraphQueryBackend
 
 logger = logging.getLogger(__name__)
 
-_DEFINITION_KINDS = frozenset({"function", "class", "method", "variable"})
+# #610: "constant" — Python module-level constants are definition sites.
+_DEFINITION_KINDS = frozenset({"function", "class", "method", "variable", "constant"})
 
 _REFERENCE_KINDS = frozenset({"function", "class", "method", "variable"})
 
@@ -344,7 +345,7 @@ class SymbolResolver:
         rows = conn.execute(
             """SELECT name, kind, file_path, language, line, end_line
                FROM ast_symbol_rows
-               WHERE file_path = ? AND name = ? AND kind IN ('function', 'class', 'method')
+               WHERE file_path = ? AND name = ? AND kind IN ('function', 'class', 'method', 'constant')
                ORDER BY line""",
             (file_path, name),
         ).fetchall()


### PR DESCRIPTION
Closes #610 (scope study + approved decision in the issue thread; found via RFC-0016 pilot Q3).

## Summary
Python module-level assignments now index as **kind=constant** when the target matches `^_?[A-Z][A-Z0-9_]+$` ∪ annotated-with-value ∪ `__dunder__`. `_STOP_WORDS`, `TOON_CONTROL_SURFACE`, `CANONICAL_VERDICTS`, `LEGACY_TOOL_MAP` — all previously unfindable — now searchable AND go-to-definition-able.

- `_walk_for_symbols` gains a top-down `enclosed` scope parameter (no parent walks — zero Mock-OOM surface); reads the `left` field (tree-sitter-python has no `name` field on assignment)
- `_AST_CACHE_EXTRACTOR_VERSION` 2→3 (both sites) — existing caches re-extract cleanly
- kind=constant lights up the pre-existing dead ranking weight `_KIND_BONUS["constant"]`
- Definition-kind filters extended in symbol_resolver AND codegraph_query_backend (the study cited only the former; resolve() routes through the latter — caught by the RED test staying red)
- Bare annotations (`x: int` no value) excluded — declaration, not definition (pinned)
- Cost (measured, this repo): 1,916 constant rows ≈ +3.9% / study's microbenchmark ~719 KB (0.33% of index.db)

## Test plan
- [x] RED-first: 6 failed pre-impl → 13 new tests green; negative pins (lowercase/class-body/function-body/tuple/bare-annotation excluded)
- [x] Regression 248 + golden -k python 8 (zero drift) + count-pin suites 172 + ast_cache family 60 (-n 0)
- [x] E2E probe: fresh index → `search action=symbol _STOP_WORDS` returns the constant (match_tier=exact) — pasted in issue-thread report
- [x] Zero re-pins needed; ruff clean; ratchet exit=0
- [x] Lead independently re-ran 70 tests + verified both version-bump sites + push diff=0

Follow-ups (filed next): Go/Rust same-shape gap; symbols_json serialization enrichment (RFC-0016 prerequisite).