### PR TITLE
feat(index): Go package-level constants indexed as symbols

### DIFF
--- a/tests/unit/test_ast_extraction.py
+++ b/tests/unit/test_ast_extraction.py
@@ -561,3 +561,130 @@ class TestPythonModuleConstants:
         # Non-simple targets (tuple unpacking) are excluded by the scope rule.
         syms = _symbols_for("X_A, Y_B = 1, 2\n", "python")
         assert [s for s in syms if s["kind"] == "constant"] == []
+
+
+# ---------------------------------------------------------------------------
+# Issue #613: Go package-level constants indexed as kind="constant"
+# ---------------------------------------------------------------------------
+
+
+_GO_CONST_SRC = """\
+package main
+
+const A = 1
+
+const (
+	B = 2
+	C = 3
+)
+
+const lowercaseConst = 4
+
+var MAX_RETRIES = 5
+
+var lowercase_var = "x"
+
+var (
+	GROUP_VAR = 1
+	other     = 2
+)
+
+var _ = sideEffect()
+
+func f() {
+	const LOCAL_CONST = 9
+	var LOCAL_VAR = 10
+	_ = LOCAL_CONST
+	_ = LOCAL_VAR
+}
+"""
+
+
+class TestGoPackageConstants:
+    """Issue #613 — Go package-level const specs (all of them — Go consts are
+    constants by compiler definition) and const-style package vars must reach
+    ast_symbol_rows as kind="constant"; function-locals must not."""
+
+    def _constants(self) -> dict[str, dict]:
+        syms = _symbols_for(_GO_CONST_SRC, "go")
+        return {s["name"]: s for s in syms if s["kind"] == "constant"}
+
+    def test_exactly_the_six_package_constants_extracted(self):
+        consts = self._constants()
+        assert sorted(consts) == [
+            "A",
+            "B",
+            "C",
+            "GROUP_VAR",
+            "MAX_RETRIES",
+            "lowercaseConst",
+        ]
+
+    def test_grouped_const_block_captures_both_names_lines_pinned(self):
+        consts = self._constants()
+        assert consts["B"]["line"] == 6
+        assert consts["B"]["end_line"] == 6
+        assert consts["C"]["line"] == 7
+        assert consts["C"]["end_line"] == 7
+        assert all(c["language"] == "go" for c in consts.values())
+
+    def test_lowercase_const_included_no_pattern_gate(self):
+        # Go consts are constants by definition (compiler-enforced
+        # immutability) — no const-style name gate, unlike package vars.
+        assert "lowercaseConst" in self._constants()
+
+    def test_package_var_const_style_included(self):
+        consts = self._constants()
+        assert consts["MAX_RETRIES"]["line"] == 12
+        assert consts["GROUP_VAR"]["line"] == 17
+
+    def test_lowercase_package_var_excluded(self):
+        # Package vars are mutable state; only const-style names (the author
+        # signalling a constant by convention) count — asymmetry vs const.
+        syms = _symbols_for(_GO_CONST_SRC, "go")
+        assert [s["kind"] for s in syms if s.get("name") == "lowercase_var"] == []
+        assert [s["kind"] for s in syms if s.get("name") == "other"] == []
+
+    def test_blank_identifier_excluded(self):
+        # `var _ = sideEffect()` — the blank identifier is not referenceable.
+        assert "_" not in self._constants()
+
+    def test_function_local_const_and_var_excluded(self):
+        consts = self._constants()
+        assert "LOCAL_CONST" not in consts
+        assert "LOCAL_VAR" not in consts
+
+    def test_method_and_func_literal_locals_excluded(self):
+        src = (
+            "package main\n\n"
+            "type S struct{}\n\n"
+            "func (s S) m() {\n"
+            "\tconst METHOD_CONST = 1\n"
+            "\t_ = METHOD_CONST\n"
+            "}\n\n"
+            "var F = func() {\n"
+            "\tconst CLOSURE_CONST = 2\n"
+            "\t_ = CLOSURE_CONST\n"
+            "}\n"
+        )
+        syms = _symbols_for(src, "go")
+        consts = sorted(s["name"] for s in syms if s["kind"] == "constant")
+        assert consts == []
+
+    def test_multi_name_const_spec_captures_all_names(self):
+        syms = _symbols_for("package main\n\nconst P1, Q2 = 1, 2\n", "go")
+        consts = sorted(s["name"] for s in syms if s["kind"] == "constant")
+        assert consts == ["P1", "Q2"]
+
+    def test_typed_const_and_iota_block_captured(self):
+        src = (
+            "package main\n\n"
+            "const Typed int = 7\n\n"
+            "const (\n"
+            "\tKindA = iota\n"
+            "\tKindB\n"
+            ")\n"
+        )
+        syms = _symbols_for(src, "go")
+        consts = sorted(s["name"] for s in syms if s["kind"] == "constant")
+        assert consts == ["KindA", "KindB", "Typed"]

--- a/tree_sitter_analyzer/_ast_cache_indexer.py
+++ b/tree_sitter_analyzer/_ast_cache_indexer.py
@@ -21,7 +21,8 @@ logger = logging.getLogger(__name__)
 
 # Extractor version constant — kept in sync with ast_cache.py.
 # v3: #610 — Python module-level constants extracted as kind="constant".
-_AST_CACHE_EXTRACTOR_VERSION = 3
+# v4: #613 — Go package-level const/var specs extracted as kind="constant".
+_AST_CACHE_EXTRACTOR_VERSION = 4
 
 
 def check_cache_or_read(

--- a/tree_sitter_analyzer/_ast_extraction.py
+++ b/tree_sitter_analyzer/_ast_extraction.py
@@ -207,12 +207,67 @@ _VAR_DECL_LIKE = frozenset(
 # (approved on #610): module-scope simple assignments whose target is
 # const-style (``^_?[A-Z][A-Z0-9_]+$``), annotated (``x: T = ...``), or a
 # dunder (``^__\w+__$``) — emitted as kind="constant".
-_PY_CONST_NAME = re.compile(r"^_?[A-Z][A-Z0-9_]+$")
+# Const-style name pattern, shared by the Python (#610) and Go (#613) rules.
+_CONST_STYLE_NAME = re.compile(r"^_?[A-Z][A-Z0-9_]+$")
 _PY_DUNDER_NAME = re.compile(r"^__\w+__$")
 
 # Node types that open a non-module scope: an ``assignment`` nested under any
 # of these is a class attribute or function local, not a module constant.
 _PY_SCOPE_BODY_NODES = frozenset({"function_definition", "class_definition"})
+
+# Issue #613 — Go package-level constants, same shape as #610. tree-sitter-go
+# puts names on ``const_spec``/``var_spec`` children (repeated ``name`` field);
+# the const_declaration/var_declaration wrappers carry no ``name`` field, so
+# they never produced rows via _VAR_DECL_LIKE.
+_GO_CONST_LIKE = frozenset({"const_declaration", "var_declaration"})
+
+# Nodes that open a function scope in Go: const/var declarations nested under
+# any of these are locals, not package constants (Go analogue of
+# _PY_SCOPE_BODY_NODES, feeding the same top-down ``enclosed`` flag).
+_GO_SCOPE_BODY_NODES = frozenset(
+    {"function_declaration", "method_declaration", "func_literal"}
+)
+
+
+def _go_package_constants(node: Any, source: str) -> list[dict[str, Any]]:
+    """Return kind="constant" symbols for a package-scope Go const/var
+    declaration, or [] when nothing matches the #613 scope rule.
+
+    The caller guarantees package scope (no enclosing function body).
+    Asymmetry (deliberate): every ``const`` spec name is captured — Go consts
+    are constants by definition, the compiler enforces immutability, so no
+    name-pattern gate is needed. A package-level ``var`` is mutable state, so
+    var_spec names count only when const-style (the #612 pattern) — the
+    author signalling a constant by convention (e.g. MAX_RETRIES). The blank
+    identifier ``_`` is skipped — it is not a referenceable name.
+    """
+    require_const_style = node.type == "var_declaration"
+    specs: list[Any] = []
+    for child in node.children:
+        if child.type in ("const_spec", "var_spec"):
+            specs.append(child)
+        elif child.type == "var_spec_list":
+            specs.extend(c for c in child.children if c.type == "var_spec")
+    out: list[dict[str, Any]] = []
+    for spec in specs:
+        for ident in spec.children_by_field_name("name"):
+            if ident.type != "identifier":
+                continue  # separator tokens can appear in the field list
+            name = _node_text(ident, source)
+            if name == "_":
+                continue
+            if require_const_style and not _CONST_STYLE_NAME.match(name):
+                continue
+            out.append(
+                {
+                    "kind": "constant",
+                    "name": name,
+                    "line": spec.start_point[0] + 1,
+                    "end_line": spec.end_point[0] + 1,
+                    "language": "go",
+                }
+            )
+    return out
 
 
 def _python_module_constant(node: Any, source: str) -> dict[str, Any] | None:
@@ -229,7 +284,7 @@ def _python_module_constant(node: Any, source: str) -> dict[str, Any] | None:
         return None  # bare annotation (``x: int``) — not a definition site
     name = _node_text(left, source)
     annotated = node.child_by_field_name("type") is not None
-    if not (annotated or _PY_CONST_NAME.match(name) or _PY_DUNDER_NAME.match(name)):
+    if not (annotated or _CONST_STYLE_NAME.match(name) or _PY_DUNDER_NAME.match(name)):
         return None
     return {
         "kind": "constant",
@@ -545,9 +600,9 @@ def _walk_for_symbols(
     """Walk the AST collecting symbol dicts.
 
     ``enclosed`` tracks (top-down, no parent walking) whether *node* sits
-    inside a Python function/class body — module-constant capture (#610)
-    must fire at module scope only, including ``if``/``try``-wrapped
-    module-level assignments.
+    inside a Python function/class body (#610) or a Go function body (#613)
+    — module/package-constant capture must fire at top-level scope only,
+    including ``if``/``try``-wrapped module-level assignments.
     """
     if depth > 20:
         return
@@ -620,7 +675,13 @@ def _walk_for_symbols(
         const_sym = _python_module_constant(node, source)
         if const_sym is not None:
             symbols.append(const_sym)
-    child_enclosed = enclosed or node_type in _PY_SCOPE_BODY_NODES
+    elif node_type in _GO_CONST_LIKE and language == "go" and not enclosed:
+        symbols.extend(_go_package_constants(node, source))
+    child_enclosed = (
+        enclosed
+        or node_type in _PY_SCOPE_BODY_NODES
+        or node_type in _GO_SCOPE_BODY_NODES
+    )
     for child in node.children:
         _walk_for_symbols(child, source, symbols, language, depth + 1, child_enclosed)
 

--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -60,7 +60,8 @@ from .project_graph import _language_from_ext
 logger = logging.getLogger(__name__)
 
 # v3: #610 — Python module-level constants extracted as kind="constant".
-_AST_CACHE_EXTRACTOR_VERSION = 3
+# v4: #613 — Go package-level const/var specs extracted as kind="constant".
+_AST_CACHE_EXTRACTOR_VERSION = 4
 
 
 class SchemaIntegrityError(RuntimeError):


### PR DESCRIPTION
Go half of #613 (Rust half follows in a separate PR — issue stays open). Mirrors the merged Python fix #612.

## Summary
`const_declaration`/`var_declaration` wrappers carry no `name` field (why the existing `_VAR_DECL_LIKE` branch never fired) — names live on `const_spec`/`var_spec` with a REPEATED name field that leaks comma tokens (filtered by type). Now:
- **const_spec → ALL names** (Go consts are constants by compiler definition — a name-style gate would only add false negatives)
- **var_spec → const-style pattern only** (`^_?[A-Z][A-Z0-9_]+$`): package vars are mutable state; lowercase vars are exactly the FTS noise the #610 study rejected
- Blank identifier `_` skipped (not referenceable); function-locals excluded via the #612 top-down `enclosed` mechanism + `_GO_SCOPE_BODY_NODES`
- `_AST_CACHE_EXTRACTOR_VERSION` 3→4 (both sites)

## Test plan
- [x] RED-first: 6 capture tests failed pre-fix → 56 passed; exclusions pinned (locals, lowercase var, blank, iota continuation captured)
- [x] Regression 186 passed; golden -k go 18 passed zero drift (-n 0)
- [x] E2E probe (tmp Go project → ASTCache → SQL): 4 constant rows, locals/lowercase = 0 rows — pasted in report
- [x] New lines 100% covered; ruff/mypy clean; ratchet exit=0
- [x] Lead independently re-ran 56 tests + verified both version-bump sites + push diff=0