### PR TITLE
test: ratchet batch-19 — pin 36 loose assertions in top-4 AST-ranked files

### DIFF
--- a/scripts/loose_assertion_baseline.txt
+++ b/scripts/loose_assertion_baseline.txt
@@ -37,7 +37,9 @@
 #   AST-ranked files, plus 2 unflagged <= bounds pinned exact).
 #   batch-18 (AST): 892 -> 852, 2026-06-13 (40 pins in top-4 AST-ranked
 #   files).
+#   batch-19 (AST): 852 -> 816, 2026-06-13 (35 exact pins + 1 timing
+#   exemption in top-4 AST-ranked files).
 
-BASELINE_COUNT=852
+BASELINE_COUNT=816
 MEASUREMENT_DATE=2026-06-13
 MEASUREMENT_COMMAND="uv run python scripts/check_loose_assertions.py --baseline"

--- a/tests/unit/grammar_coverage/test_auto_discovery.py
+++ b/tests/unit/grammar_coverage/test_auto_discovery.py
@@ -40,7 +40,9 @@ def python_report(engine: AutoDiscoveryEngine, python_corpus: str) -> CoverageGa
 def test_get_all_node_types_python(engine: AutoDiscoveryEngine) -> None:
     types = engine.get_all_node_types("python")
     assert isinstance(types, list)
-    assert len(types) >= 50, f"Expected >= 50 node types, got {len(types)}"
+    # Python grammar exposes exactly 129 named node types
+    # (measured with tree-sitter-python 0.23.6)
+    assert len(types) == 129, f"Expected 129 node types, got {len(types)}"
 
 
 def test_get_all_node_types_is_sorted(engine: AutoDiscoveryEngine) -> None:
@@ -71,7 +73,9 @@ def test_get_all_node_types_unsupported_language(engine: AutoDiscoveryEngine) ->
 
 def test_get_all_node_types_typescript(engine: AutoDiscoveryEngine) -> None:
     types = engine.get_all_node_types("typescript")
-    assert len(types) >= 80
+    # TypeScript grammar exposes exactly 191 named node types
+    # (measured with tree-sitter-typescript 0.23.2)
+    assert len(types) == 191
 
 
 # ---------------------------------------------------------------------------
@@ -82,9 +86,12 @@ def test_get_all_node_types_typescript(engine: AutoDiscoveryEngine) -> None:
 def test_get_all_field_names_python(engine: AutoDiscoveryEngine) -> None:
     fields = engine.get_all_field_names("python")
     assert isinstance(fields, list)
-    assert len(fields) > 5
+    # Python grammar exposes exactly 31 field names
+    # (measured with tree-sitter-python 0.23.6)
+    assert len(fields) == 31
     # Python should have common fields
-    assert "name" in fields or "body" in fields
+    assert "name" in fields
+    assert "body" in fields
 
 
 def test_get_all_field_names_unavailable_language(engine: AutoDiscoveryEngine) -> None:
@@ -157,7 +164,9 @@ def test_enumerate_syntax_paths_returns_list(
 ) -> None:
     paths = engine.enumerate_syntax_paths("python", python_corpus)
     assert isinstance(paths, list)
-    assert len(paths) > 0
+    # BUILTIN_CORPUS["python"] yields exactly 57 unique syntax paths at the
+    # default max_depth (measured with tree-sitter-python 0.23.6)
+    assert len(paths) == 57
 
 
 def test_enumerate_syntax_paths_format(
@@ -189,7 +198,9 @@ def test_enumerate_syntax_paths_max_depth(
 # ---------------------------------------------------------------------------
 
 
-def test_analyze_coverage_gap_has_required_keys(python_report: CoverageGapReport) -> None:
+def test_analyze_coverage_gap_has_required_keys(
+    python_report: CoverageGapReport,
+) -> None:
     assert python_report.language == "python"
     assert isinstance(python_report.total_node_types, int)
     assert isinstance(python_report.discovered_node_types, list)
@@ -199,20 +210,27 @@ def test_analyze_coverage_gap_has_required_keys(python_report: CoverageGapReport
     assert isinstance(python_report.elapsed_ms, float)
 
 
-def test_analyze_coverage_gap_coverage_positive(python_report: CoverageGapReport) -> None:
+def test_analyze_coverage_gap_coverage_positive(
+    python_report: CoverageGapReport,
+) -> None:
     assert python_report.coverage_rate > 0.0
     assert python_report.coverage_rate <= 100.0
 
 
-def test_analyze_coverage_gap_total_types_positive(python_report: CoverageGapReport) -> None:
-    assert python_report.total_node_types > 0
+def test_analyze_coverage_gap_total_types_positive(
+    python_report: CoverageGapReport,
+) -> None:
+    # Equals the Python grammar's 129 named node types
+    # (measured with tree-sitter-python 0.23.6)
+    assert python_report.total_node_types == 129
 
 
 def test_analyze_coverage_gap_consistency(python_report: CoverageGapReport) -> None:
     # discovered + missing should be consistent with total grammar types
     discovered_set = set(python_report.discovered_node_types)
-    # discovered_set should be non-empty if total > 0
-    assert len(discovered_set) > 0
+    # BUILTIN_CORPUS["python"] discovers exactly 73 distinct node types
+    # (measured with tree-sitter-python 0.23.6)
+    assert len(discovered_set) == 73
 
 
 def test_analyze_coverage_gap_is_ok(python_report: CoverageGapReport) -> None:
@@ -235,7 +253,7 @@ def test_analyze_coverage_gap_unavailable_language(engine: AutoDiscoveryEngine) 
 
 def test_analyze_coverage_gap_elapsed_ms(python_report: CoverageGapReport) -> None:
     # Should complete reasonably fast
-    assert python_report.elapsed_ms > 0
+    assert python_report.elapsed_ms > 0  # ratchet: nondeterministic wall-clock timing
     assert python_report.elapsed_ms < 10_000  # 10 seconds absolute upper bound
 
 
@@ -247,7 +265,24 @@ def test_analyze_coverage_gap_elapsed_ms(python_report: CoverageGapReport) -> No
 def test_analyze_all_languages_no_crash(engine: AutoDiscoveryEngine) -> None:
     results = engine.analyze_all_languages()
     assert isinstance(results, dict)
-    assert len(results) > 0
+    # BUILTIN_CORPUS covers exactly these 14 languages (full grammar set
+    # installed via `uv sync --all-extras`)
+    assert set(results.keys()) == {
+        "c",
+        "cpp",
+        "csharp",
+        "go",
+        "java",
+        "javascript",
+        "kotlin",
+        "php",
+        "python",
+        "ruby",
+        "rust",
+        "sql",
+        "typescript",
+        "yaml",
+    }
 
 
 def test_analyze_all_languages_contains_python(engine: AutoDiscoveryEngine) -> None:
@@ -277,7 +312,10 @@ def test_generate_report_not_empty(engine: AutoDiscoveryEngine) -> None:
     results = engine.analyze_all_languages(["python"])
     report = engine.generate_report(results)
     assert isinstance(report, str)
-    assert len(report) > 100
+    # The python-only report renders exactly 40 lines; byte length is NOT
+    # pinnable (the "Analysis time" line embeds wall-clock ms)
+    # (measured with tree-sitter-python 0.23.6)
+    assert len(report.splitlines()) == 40
 
 
 def test_generate_report_contains_language(engine: AutoDiscoveryEngine) -> None:

--- a/tests/unit/languages/test_html_plugin_tags_attrs.py
+++ b/tests/unit/languages/test_html_plugin_tags_attrs.py
@@ -1,6 +1,5 @@
 """HTML plugin tests — tag and attribute recognition."""
 
-
 from tests.unit.languages._html_test_data import (
     ATTRIBUTE_CODE,
     TAG_CODE,
@@ -19,7 +18,9 @@ class TestHtmlTagRecognition:
         elements = plugin.create_extractor().extract_html_elements(tree, TAG_CODE)
 
         structure_tags = [e for e in elements if e.element_class == "structure"]
-        assert len(structure_tags) >= 0
+        # TAG_CODE has exactly 8 structure-class elements: div, header, nav,
+        # main, section, article, aside, footer (tree-sitter-html 0.23.2)
+        assert len(structure_tags) == 8
 
     def test_extract_heading_tags(self):
         """Test extraction of heading tags."""
@@ -28,7 +29,9 @@ class TestHtmlTagRecognition:
         elements = plugin.create_extractor().extract_html_elements(tree, TAG_CODE)
 
         heading_tags = [e for e in elements if e.element_class == "heading"]
-        assert len(heading_tags) >= 0
+        # TAG_CODE has exactly 4 headings: h1-h4 (tree-sitter-html 0.23.2)
+        assert len(heading_tags) == 4
+        assert {e.tag_name for e in heading_tags} == {"h1", "h2", "h3", "h4"}
 
     def test_extract_text_tags(self):
         """Test extraction of text tags."""
@@ -37,7 +40,10 @@ class TestHtmlTagRecognition:
         elements = plugin.create_extractor().extract_html_elements(tree, TAG_CODE)
 
         text_tags = [e for e in elements if e.element_class == "text"]
-        assert len(text_tags) >= 0
+        # TAG_CODE has exactly 19 text-class elements: 8 <p>, 3 <a>, and the
+        # 8 inline tags strong/em/mark/del/ins/sub/sup/small
+        # (tree-sitter-html 0.23.2)
+        assert len(text_tags) == 19
 
     def test_extract_div_tag(self):
         """Test extraction of div tag."""
@@ -46,7 +52,8 @@ class TestHtmlTagRecognition:
         elements = plugin.create_extractor().extract_html_elements(tree, TAG_CODE)
 
         div_elements = [e for e in elements if e.tag_name == "div"]
-        assert len(div_elements) >= 1
+        # TAG_CODE has exactly 1 <div> (tree-sitter-html 0.23.2)
+        assert len(div_elements) == 1
 
     def test_extract_span_tag(self):
         """Test extraction of span tag."""
@@ -55,7 +62,9 @@ class TestHtmlTagRecognition:
         elements = plugin.create_extractor().extract_html_elements(tree, TAG_CODE)
 
         span_elements = [e for e in elements if e.tag_name == "span"]
-        assert len(span_elements) >= 0
+        # TAG_CODE contains NO <span> — the old `>= 0` was vacuously true.
+        # Pin the actual count; re-pin if a span is added to the fixture.
+        assert len(span_elements) == 0
 
     def test_extract_paragraph_tag(self):
         """Test extraction of paragraph tag."""
@@ -64,7 +73,8 @@ class TestHtmlTagRecognition:
         elements = plugin.create_extractor().extract_html_elements(tree, TAG_CODE)
 
         p_elements = [e for e in elements if e.tag_name == "p"]
-        assert len(p_elements) >= 1
+        # TAG_CODE has exactly 8 <p> elements (tree-sitter-html 0.23.2)
+        assert len(p_elements) == 8
 
     def test_extract_list_tags(self):
         """Test extraction of list tags."""
@@ -74,8 +84,9 @@ class TestHtmlTagRecognition:
 
         ul_elements = [e for e in elements if e.tag_name == "ul"]
         li_elements = [e for e in elements if e.tag_name == "li"]
-        assert len(ul_elements) >= 1
-        assert len(li_elements) >= 1
+        # TAG_CODE has exactly 1 <ul> with 3 <li> (tree-sitter-html 0.23.2)
+        assert len(ul_elements) == 1
+        assert len(li_elements) == 3
 
     def test_extract_inline_tags(self):
         """Test extraction of inline tags."""
@@ -89,7 +100,19 @@ class TestHtmlTagRecognition:
             if e.tag_name
             in ["strong", "em", "mark", "del", "ins", "sub", "sup", "small"]
         ]
-        assert len(inline_tags) >= 0
+        # TAG_CODE has exactly one of each of the 8 inline tags
+        # (tree-sitter-html 0.23.2)
+        assert len(inline_tags) == 8
+        assert {e.tag_name for e in inline_tags} == {
+            "strong",
+            "em",
+            "mark",
+            "del",
+            "ins",
+            "sub",
+            "sup",
+            "small",
+        }
 
 
 class TestHtmlAttributeRecognition:
@@ -214,5 +237,3 @@ class TestHtmlAttributeRecognition:
             assert "id" in div_with_multiple.attributes
             assert "class" in div_with_multiple.attributes
             assert "data-id" in div_with_multiple.attributes
-
-

--- a/tests/unit/languages/test_php_plugin.py
+++ b/tests/unit/languages/test_php_plugin.py
@@ -500,14 +500,15 @@ class TestPHPVariableExtraction:
         extractor = plugin.create_extractor()
         variables = extractor.extract_variables(tree, COMPLEX_CLASS_CODE)
 
-        # Check for any constants or variables
-        # Constant extraction may vary based on tree-sitter-php version
-        assert isinstance(variables, list)
-        # At minimum, properties should be extracted
-        if len(variables) > 0:
-            # Verify we get some class properties
-            var_names = [v.name for v in variables]
-            assert len(var_names) > 0
+        # COMPLEX_CLASS_CODE yields exactly 4 properties (measured with
+        # tree-sitter-php 0.24.1). The MAX_USERS class constant is NOT
+        # extracted — known constant-extraction gap.
+        assert [v.name for v in variables] == [
+            "logger",
+            "repository",
+            "instanceCount",
+            "serviceName",
+        ]
 
     def test_extract_static_property(self):
         """Test extraction of static property."""
@@ -575,10 +576,10 @@ class TestPHPImportExtraction:
         extractor = plugin.create_extractor()
         imports = extractor.extract_imports(tree, SIMPLE_CLASS_CODE)
 
-        # Use statement extraction should return a list
-        assert isinstance(imports, list)
-        # We expect to find some imports
-        assert len(imports) >= 0  # May be 0 if tree-sitter-php doesn't extract them
+        # The PHP extractor does NOT extract `use` statements as imports —
+        # measured 0 with tree-sitter-php 0.24.1 (known extraction gap).
+        # If import extraction is implemented, this must be re-pinned.
+        assert imports == []
 
     def test_extract_aliased_use(self):
         """Test extraction of aliased use statements."""
@@ -587,12 +588,10 @@ class TestPHPImportExtraction:
         extractor = plugin.create_extractor()
         imports = extractor.extract_imports(tree, USE_STATEMENTS_CODE)
 
-        # Check for aliased import
-        next(
-            (i for i in imports if i.alias == "BlogPost" or "BlogPost" in str(i)), None
-        )
-        # May be extracted depending on tree-sitter-php version
-        assert len(imports) >= 0
+        # The PHP extractor does NOT extract `use` statements (incl. aliased
+        # ones) — measured 0 with tree-sitter-php 0.24.1 (known gap).
+        # If import extraction is implemented, this must be re-pinned.
+        assert imports == []
 
     def test_extract_imports_empty_tree(self):
         """Test import extraction with empty code."""
@@ -610,8 +609,11 @@ class TestPHPImportExtraction:
         extractor = plugin.create_extractor()
         imports = extractor.extract_imports(tree, SIMPLE_CLASS_CODE)
 
-        assert all(i.start_line > 0 for i in imports)
-        assert all(i.end_line >= i.start_line for i in imports)
+        # imports is empty (use-statement extraction gap, tree-sitter-php
+        # 0.24.1), so the previous all(...) line-number checks were vacuously
+        # true. Pin the actual result; re-pin real line-number checks once
+        # import extraction lands.
+        assert imports == []
 
 
 class TestPHPNamespaceHandling:
@@ -686,7 +688,10 @@ class TestPHPPluginAnalyzeFile:
         assert result.success is True
         assert result.language == "php"
         assert result.file_path == str(php_file)
-        assert len(result.elements) > 0
+        # SIMPLE_CLASS_CODE yields exactly 6 elements: 1 class (User),
+        # 3 functions (__construct/getName/getAge), 2 variables (name/age)
+        # (measured with tree-sitter-php 0.24.1)
+        assert len(result.elements) == 6
 
 
 class TestPHPIntegration:
@@ -715,10 +720,13 @@ class TestPHPIntegration:
         variables = extractor.extract_variables(tree, COMPLEX_CLASS_CODE)
         imports = extractor.extract_imports(tree, COMPLEX_CLASS_CODE)
 
-        assert len(classes) > 0
-        assert len(functions) > 0
-        assert len(variables) > 0
-        assert isinstance(imports, list)
+        # COMPLEX_CLASS_CODE measured with tree-sitter-php 0.24.1:
+        # 2 classes (BaseService/UserService), 6 functions, 4 properties,
+        # 0 imports (use-statement extraction gap).
+        assert len(classes) == 2
+        assert len(functions) == 6
+        assert len(variables) == 4
+        assert imports == []
 
     def test_node_counting(self):
         """Test node counting functionality."""
@@ -726,7 +734,9 @@ class TestPHPIntegration:
         tree = get_tree_for_code(SIMPLE_CLASS_CODE, plugin)
 
         count = plugin._count_nodes(tree.root_node)
-        assert count > 0
+        # SIMPLE_CLASS_CODE parses to exactly 160 nodes
+        # (measured with tree-sitter-php 0.24.1)
+        assert count == 160
 
 
 class TestPHPMethodNameClean:

--- a/tests/unit/languages/test_swift_plugin_enhanced.py
+++ b/tests/unit/languages/test_swift_plugin_enhanced.py
@@ -204,7 +204,10 @@ class TestSwiftExtensionExtraction:
             tree, SWIFT_EXTENSIONS_SAMPLE
         )
         ext_classes = [c for c in classes if c.class_type == "extension"]
-        assert len(ext_classes) >= 1
+        # SWIFT_EXTENSIONS_SAMPLE declares exactly 2 extensions: User, Collection
+        # (measured with tree-sitter-swift 0.7.2)
+        assert len(ext_classes) == 2
+        assert {c.name for c in ext_classes} == {"User", "Collection"}
 
     def test_extension_functions(self, plugin: SwiftPlugin) -> None:
         tree = _swift_parser().parse(SWIFT_EXTENSIONS_SAMPLE.encode("utf-8"))
@@ -241,7 +244,10 @@ class TestSwiftEnumExtraction:
         tree = _swift_parser().parse(SWIFT_ENUMS_SAMPLE.encode("utf-8"))
         classes = plugin.create_extractor().extract_classes(tree, SWIFT_ENUMS_SAMPLE)
         enum_types = [c for c in classes if c.class_type == "enum"]
-        assert len(enum_types) >= 1
+        # SWIFT_ENUMS_SAMPLE declares exactly 2 enums: NetworkError, Expr
+        # (measured with tree-sitter-swift 0.7.2)
+        assert len(enum_types) == 2
+        assert {c.name for c in enum_types} == {"NetworkError", "Expr"}
 
     def test_enum_with_interfaces(self, plugin: SwiftPlugin) -> None:
         tree = _swift_parser().parse(SWIFT_ENUMS_SAMPLE.encode("utf-8"))
@@ -315,7 +321,9 @@ class TestSwiftNestedDeclarations:
             tree, SWIFT_NESTED_SAMPLE
         )
         inits = [f for f in functions if f.is_constructor]
-        assert len(inits) >= 1
+        # SWIFT_NESTED_SAMPLE declares exactly 1 init (ViewModel.init)
+        # (measured with tree-sitter-swift 0.7.2)
+        assert len(inits) == 1
 
     def test_private_function(self, plugin: SwiftPlugin) -> None:
         tree = _swift_parser().parse(SWIFT_NESTED_SAMPLE.encode("utf-8"))
@@ -347,7 +355,14 @@ class TestSwiftProtocols:
             tree, SWIFT_PROTOCOLS_SAMPLE
         )
         protocols = [c for c in classes if c.class_type == "protocol"]
-        assert len(protocols) >= 1
+        # SWIFT_PROTOCOLS_SAMPLE declares exactly 3 protocols:
+        # Drawable, Observable, ModernFeature (measured with tree-sitter-swift 0.7.2)
+        assert len(protocols) == 3
+        assert {c.name for c in protocols} == {
+            "Drawable",
+            "Observable",
+            "ModernFeature",
+        }
 
     def test_protocol_properties(self, plugin: SwiftPlugin) -> None:
         tree = _swift_parser().parse(SWIFT_PROTOCOLS_SAMPLE.encode("utf-8"))
@@ -374,8 +389,11 @@ class TestSwiftProtocols:
             tree, SWIFT_PROTOCOLS_SAMPLE
         )
         modern = next((c for c in classes if c.name == "ModernFeature"), None)
-        if modern is not None:
-            assert "Drawable" in modern.interfaces or len(modern.interfaces) >= 1
+        # ModernFeature IS extracted and inherits exactly Drawable
+        # (measured with tree-sitter-swift 0.7.2) — the old `if modern is not
+        # None` guard plus `... or len(...) >= 1` was a near-vacuous check.
+        assert modern is not None
+        assert modern.interfaces == ["Drawable"]
 
 
 @pytest.mark.skipif(
@@ -456,7 +474,9 @@ class TestSwiftPropertyWrappers:
             tree, SWIFT_PROPERTY_WRAPPERS_SAMPLE
         )
         inits = [f for f in functions if f.is_constructor]
-        assert len(inits) >= 1
+        # SWIFT_PROPERTY_WRAPPERS_SAMPLE declares exactly 1 init (Clamped.init)
+        # (measured with tree-sitter-swift 0.7.2)
+        assert len(inits) == 1
 
     def test_property_wrapper_computed(self, plugin: SwiftPlugin) -> None:
         tree = _swift_parser().parse(SWIFT_PROPERTY_WRAPPERS_SAMPLE.encode("utf-8"))
@@ -525,7 +545,9 @@ class TestSwiftModuleLevelFunctions:
         result = _analysis_result("test.swift", "struct Foo {}", tree, elements_dict)
         assert result.file_path == "test.swift"
         assert result.language == "swift"
-        assert result.node_count > 0
+        # "struct Foo {}" parses to exactly 7 nodes
+        # (measured with tree-sitter-swift 0.7.2)
+        assert result.node_count == 7
 
     @pytest.mark.skipif(
         not TREE_SITTER_SWIFT_AVAILABLE,
@@ -545,7 +567,9 @@ class TestSwiftModuleLevelFunctions:
         language = tree_sitter.Language(tree_sitter_swift.language())
         tree = _parse_swift_source(language, "let x = 1")
         count = _count_tree_nodes(tree.root_node)
-        assert count >= 1
+        # "let x = 1" parses to exactly 8 nodes
+        # (measured with tree-sitter-swift 0.7.2)
+        assert count == 8
 
 
 @pytest.mark.skipif(
@@ -562,7 +586,9 @@ class TestSwiftAnalyzerIntegration:
         result = await plugin.analyze_file(str(source), Mock())
         assert result.success is True
         assert result.language == "swift"
-        assert result.node_count > 0
+        # SWIFT_NESTED_SAMPLE parses to exactly 270 nodes
+        # (measured with tree-sitter-swift 0.7.2)
+        assert result.node_count == 270
         element_names = {e.name for e in result.elements}
         assert "ViewModel" in element_names
 


### PR DESCRIPTION
## Summary
Loose-assertion ratchet batch 19. Top-4 (8-way tie at 9 violations; tie-break documented):

| File | Pins |
|---|---|
| tests/unit/languages/test_swift_plugin_enhanced.py | 9 |
| tests/unit/languages/test_php_plugin.py | 9 |
| tests/unit/languages/test_html_plugin_tags_attrs.py | 9 |
| tests/unit/grammar_coverage/test_auto_discovery.py | 8 + 1 exemption |

Baseline: **852 → 816** (lead re-verified live). One exemption marker total (`elapsed_ms > 0` — genuine wall-clock, passes the 3-question test); the report-length pin was made deterministic via splitlines (byte length embeds timing).

**Product finding while pinning**: PHP extractor returns 0 imports even with `use` statements present — pinned as `imports == []` with gap-documented comments (forces conscious re-pin when extraction lands); filed separately.

Grammar-version-dependent pins carry provenance comments (swift 0.7.2 / php 0.24.1 / html 0.23.2) — grammar bumps go RED by design.

## Test plan
- [x] All 4 files individually `-n 0`: 44/49/17/40 passed (re-run post-ruff-format)
- [x] Diff gate exit=0 (pre- and post-commit)
- [x] `--baseline` measures 816 == recorded (lead independently re-verified)