### PR TITLE
feat(index): Rust const/static items indexed as symbols

### DIFF
--- a/tests/unit/test_ast_extraction.py
+++ b/tests/unit/test_ast_extraction.py
@@ -688,3 +688,127 @@ class TestGoPackageConstants:
         syms = _symbols_for(src, "go")
         consts = sorted(s["name"] for s in syms if s["kind"] == "constant")
         assert consts == ["KindA", "KindB", "Typed"]
+
+
+# ---------------------------------------------------------------------------
+# Issue #613: Rust const/static items indexed as kind="constant"
+# ---------------------------------------------------------------------------
+
+
+_RUST_CONST_SRC = """\
+const MAX: u32 = 10;
+
+static GLOBAL: &str = "x";
+
+static mut COUNTER: i32 = 0;
+
+const lowercase_const: u32 = 4;
+
+mod m {
+    const NESTED: u32 = 1;
+    static NESTED_STATIC: u8 = 2;
+}
+
+fn f() {
+    const LOCAL_CONST: u32 = 9;
+    static LOCAL_STATIC: u32 = 8;
+    let _ = LOCAL_CONST;
+}
+
+struct S;
+
+impl S {
+    const ASSOC: u32 = 5;
+
+    fn m(&self) {
+        const METHOD_CONST: u32 = 1;
+        let _ = METHOD_CONST;
+    }
+}
+
+trait T {
+    const TRAIT_CONST: u32 = 6;
+}
+"""
+
+
+class TestRustConstants:
+    """Issue #613 — Rust const_item/static_item must reach ast_symbol_rows as
+    kind="constant" (ALL names — Rust const/static are language-level
+    constants/globals, the compiler lints non-upper-case ones, so no
+    name-pattern gate; mirrors the Go const reasoning from #615).
+    Function-locals must not appear. Associated consts (impl/trait body) ARE
+    captured: unlike Python class attributes (mutable state, excluded by
+    #612), a Rust associated const is a compiler-enforced constant
+    referenceable as ``Type::CONST`` — the ``enclosed`` mechanism captures
+    them naturally because impl/trait bodies are not function scopes."""
+
+    def _constants(self) -> dict[str, dict]:
+        syms = _symbols_for(_RUST_CONST_SRC, "rust")
+        return {s["name"]: s for s in syms if s["kind"] == "constant"}
+
+    def test_exactly_the_eight_constants_extracted(self):
+        consts = self._constants()
+        assert sorted(consts) == [
+            "ASSOC",
+            "COUNTER",
+            "GLOBAL",
+            "MAX",
+            "NESTED",
+            "NESTED_STATIC",
+            "TRAIT_CONST",
+            "lowercase_const",
+        ]
+
+    def test_module_scope_const_and_static_lines_pinned(self):
+        consts = self._constants()
+        assert consts["MAX"]["line"] == 1
+        assert consts["MAX"]["end_line"] == 1
+        assert consts["GLOBAL"]["line"] == 3
+        assert consts["GLOBAL"]["end_line"] == 3
+        assert all(c["language"] == "rust" for c in consts.values())
+
+    def test_static_mut_captured(self):
+        # `static mut` is still a crate-level global the compiler names in
+        # SCREAMING_SNAKE; mirroring Go consts, no mutability gate.
+        assert self._constants()["COUNTER"]["line"] == 5
+
+    def test_lowercase_const_included_no_pattern_gate(self):
+        # Rust const/static are constants by definition — rustc lints
+        # non_upper_case_globals, so a name-pattern gate adds nothing.
+        assert "lowercase_const" in self._constants()
+
+    def test_mod_nested_const_and_static_captured(self):
+        # mod bodies are declaration_list (module scope), consistent with
+        # the #596 mod-container treatment — NESTED/NESTED_STATIC count.
+        consts = self._constants()
+        assert consts["NESTED"]["line"] == 10
+        assert consts["NESTED_STATIC"]["line"] == 11
+
+    def test_function_local_const_and_static_excluded(self):
+        consts = self._constants()
+        assert "LOCAL_CONST" not in consts
+        assert "LOCAL_STATIC" not in consts
+        assert "METHOD_CONST" not in consts
+
+    def test_associated_consts_captured_decision_pinned(self):
+        # Decision (#613): associated consts in impl/trait bodies ARE
+        # captured — compiler-enforced constants addressable as S::ASSOC /
+        # T::TRAIT_CONST, not mutable attributes.
+        consts = self._constants()
+        assert consts["ASSOC"]["line"] == 23
+        assert consts["TRAIT_CONST"]["line"] == 32
+
+    def test_closure_local_const_excluded(self):
+        src = (
+            "fn outer() {\n"
+            "    let c = |x: i32| {\n"
+            "        const CLOSURE_CONST: i32 = 1;\n"
+            "        x + CLOSURE_CONST\n"
+            "    };\n"
+            "    let _ = c;\n"
+            "}\n"
+        )
+        syms = _symbols_for(src, "rust")
+        consts = sorted(s["name"] for s in syms if s["kind"] == "constant")
+        assert consts == []

--- a/tests/unit/test_ast_extraction.py
+++ b/tests/unit/test_ast_extraction.py
@@ -812,3 +812,28 @@ class TestRustConstants:
         syms = _symbols_for(src, "rust")
         consts = sorted(s["name"] for s in syms if s["kind"] == "constant")
         assert consts == []
+
+
+class TestRustConstantsCodexP2s:
+    """Codex P2s on #618: block-local nested consts and anonymous const _."""
+
+    def _constant_names(self, src: str) -> list[str]:
+        syms = _symbols_for(src, "rust")
+        return [s["name"] for s in syms if s["kind"] == "constant"]
+
+    def test_const_initializer_block_inner_const_excluded(self):
+        src = "const OUTER: i32 = { const INNER: i32 = 1; INNER };\n"
+        assert self._constant_names(src) == ["OUTER"]
+
+    def test_anonymous_const_skipped(self):
+        src = "const _: usize = 1;\nconst REAL: usize = 2;\n"
+        assert self._constant_names(src) == ["REAL"]
+
+    def test_python_if_wrapped_module_constant_still_captured(self):
+        """Guard the #612 guarantee the language-gated scope sets protect:
+        Python if-wrapped module constants stay captured even though Rust's
+        scope set now contains "block"."""
+        src = "import sys\nif sys.platform == 'win32':\n    SEP = chr(92)\n"
+        syms = _symbols_for(src, "python")
+        names = [s["name"] for s in syms if s["kind"] == "constant"]
+        assert names == ["SEP"]

--- a/tree_sitter_analyzer/_ast_cache_indexer.py
+++ b/tree_sitter_analyzer/_ast_cache_indexer.py
@@ -22,7 +22,8 @@ logger = logging.getLogger(__name__)
 # Extractor version constant — kept in sync with ast_cache.py.
 # v3: #610 — Python module-level constants extracted as kind="constant".
 # v4: #613 — Go package-level const/var specs extracted as kind="constant".
-_AST_CACHE_EXTRACTOR_VERSION = 4
+# v5: #613 — Rust const/static items extracted as kind="constant".
+_AST_CACHE_EXTRACTOR_VERSION = 5
 
 
 def check_cache_or_read(

--- a/tree_sitter_analyzer/_ast_extraction.py
+++ b/tree_sitter_analyzer/_ast_extraction.py
@@ -289,7 +289,7 @@ _RUST_CONST_LIKE = frozenset({"const_item", "static_item"})
 # _PY_SCOPE_BODY_NODES / _GO_SCOPE_BODY_NODES, feeding the same top-down
 # ``enclosed`` flag). mod/impl/trait bodies are ``declaration_list`` — module
 # scope — and deliberately absent.
-_RUST_SCOPE_BODY_NODES = frozenset({"function_item", "closure_expression"})
+_RUST_SCOPE_BODY_NODES = frozenset({"function_item", "closure_expression", "block"})
 
 
 def _python_module_constant(node: Any, source: str) -> dict[str, Any] | None:
@@ -705,6 +705,9 @@ def _walk_for_symbols(
         and language == "rust"
         and not enclosed
         and name_node is not None
+        # `const _: usize = ...;` compile-time assertions: `_` is not a
+        # referenceable symbol (Codex P2 on #618; mirrors the Go blank rule)
+        and _node_text(name_node, source) != "_"
     ):
         symbols.append(
             {
@@ -715,11 +718,14 @@ def _walk_for_symbols(
                 "language": "rust",
             }
         )
-    child_enclosed = (
-        enclosed
-        or node_type in _PY_SCOPE_BODY_NODES
-        or node_type in _GO_SCOPE_BODY_NODES
-        or node_type in _RUST_SCOPE_BODY_NODES
+    # Language-gated: Rust needs "block" in its scope set (const-initializer
+    # block expressions, Codex P2 on #618), but Python's if/try bodies are
+    # also "block" nodes — a shared set would break the #612 guarantee that
+    # if/try-wrapped module assignments stay captured.
+    child_enclosed = enclosed or (
+        (language == "python" and node_type in _PY_SCOPE_BODY_NODES)
+        or (language == "go" and node_type in _GO_SCOPE_BODY_NODES)
+        or (language == "rust" and node_type in _RUST_SCOPE_BODY_NODES)
     )
     for child in node.children:
         _walk_for_symbols(child, source, symbols, language, depth + 1, child_enclosed)

--- a/tree_sitter_analyzer/_ast_extraction.py
+++ b/tree_sitter_analyzer/_ast_extraction.py
@@ -270,6 +270,28 @@ def _go_package_constants(node: Any, source: str) -> list[dict[str, Any]]:
     return out
 
 
+# Issue #613 — Rust const/static items, same shape as #610/#615. tree-sitter-
+# rust emits ``const_item``/``static_item`` (with a ``name`` field), but
+# neither type is in _VAR_DECL_LIKE (which carries Go's ``const_declaration``,
+# not Rust's node names), so they never produced rows. ALL names are captured
+# — Rust const/static are language-level constants/globals (rustc lints
+# non_upper_case_globals), so no const-style name gate is needed; this mirrors
+# the Go const reasoning. ``static mut`` counts too: still a named crate-level
+# global. Associated consts in impl/trait bodies ARE captured (deliberate):
+# they are compiler-enforced constants addressable as ``Type::CONST``, unlike
+# the Python class attributes #612 excludes — and impl/trait bodies are
+# ``declaration_list`` nodes, not function scopes, so the ``enclosed``
+# mechanism keeps them naturally.
+_RUST_CONST_LIKE = frozenset({"const_item", "static_item"})
+
+# Nodes that open a function scope in Rust: const/static items nested under
+# any of these are function-locals, not module constants (Rust analogue of
+# _PY_SCOPE_BODY_NODES / _GO_SCOPE_BODY_NODES, feeding the same top-down
+# ``enclosed`` flag). mod/impl/trait bodies are ``declaration_list`` — module
+# scope — and deliberately absent.
+_RUST_SCOPE_BODY_NODES = frozenset({"function_item", "closure_expression"})
+
+
 def _python_module_constant(node: Any, source: str) -> dict[str, Any] | None:
     """Return a kind="constant" symbol for a module-scope Python assignment,
     or None when the node does not match the #610 scope rule.
@@ -600,9 +622,10 @@ def _walk_for_symbols(
     """Walk the AST collecting symbol dicts.
 
     ``enclosed`` tracks (top-down, no parent walking) whether *node* sits
-    inside a Python function/class body (#610) or a Go function body (#613)
-    — module/package-constant capture must fire at top-level scope only,
-    including ``if``/``try``-wrapped module-level assignments.
+    inside a Python function/class body (#610), a Go function body (#613),
+    or a Rust function/closure body (#613) — module/package-constant capture
+    must fire at top-level scope only, including ``if``/``try``-wrapped
+    module-level assignments.
     """
     if depth > 20:
         return
@@ -677,10 +700,26 @@ def _walk_for_symbols(
             symbols.append(const_sym)
     elif node_type in _GO_CONST_LIKE and language == "go" and not enclosed:
         symbols.extend(_go_package_constants(node, source))
+    elif (
+        node_type in _RUST_CONST_LIKE
+        and language == "rust"
+        and not enclosed
+        and name_node is not None
+    ):
+        symbols.append(
+            {
+                "kind": "constant",
+                "name": _node_text(name_node, source),
+                "line": node.start_point[0] + 1,
+                "end_line": node.end_point[0] + 1,
+                "language": "rust",
+            }
+        )
     child_enclosed = (
         enclosed
         or node_type in _PY_SCOPE_BODY_NODES
         or node_type in _GO_SCOPE_BODY_NODES
+        or node_type in _RUST_SCOPE_BODY_NODES
     )
     for child in node.children:
         _walk_for_symbols(child, source, symbols, language, depth + 1, child_enclosed)

--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -61,7 +61,8 @@ logger = logging.getLogger(__name__)
 
 # v3: #610 — Python module-level constants extracted as kind="constant".
 # v4: #613 — Go package-level const/var specs extracted as kind="constant".
-_AST_CACHE_EXTRACTOR_VERSION = 4
+# v5: #613 — Rust const/static items extracted as kind="constant".
+_AST_CACHE_EXTRACTOR_VERSION = 5
 
 
 class SchemaIntegrityError(RuntimeError):


### PR DESCRIPTION
Rust half of #613 — completes the issue (Go half merged via #615; mirrors Python #612).

## Summary
`const_item`/`static_item` carry a `name` field but were never in `_VAR_DECL_LIKE` (it lists Go's node names) — 0 rows. Now a dedicated branch (mirroring #615) emits **kind=constant**:
- ALL names, no pattern gate (rustc enforces `non_upper_case_globals`; language-level constants/globals)
- `static mut` included; **associated consts (impl/trait) captured** — compiler-enforced, addressable as `Type::CONST`, unlike the mutable Python class attributes #612 excludes
- Function/closure locals excluded via `_RUST_SCOPE_BODY_NODES = {function_item, closure_expression}` — deliberately NOT `block` (shared cross-grammar; would break #612's if/try-wrapped module-assignment guarantee)
- mod-nested captured (consistent with #596 mod containers)
- `_AST_CACHE_EXTRACTOR_VERSION` 4→5 (both sites)

## Test plan
- [x] RED-first: 6 failed pre-fix → 8 new tests green; regression battery 212 passed; golden -k rust zero drift (-n 0)
- [x] E2E probe (tmp Rust project → ASTCache → SQL): 5 constant rows (incl. static mut, mod-nested, associated), locals 0 — pasted in report
- [x] New lines 100% covered; ruff/mypy clean; ratchet exit=0 (rebased over #616 mid-task)
- [x] Lead independently re-ran 64 tests + verified both version-bump sites + push diff=0