### PR TITLE
fix(php): use statements extracted as imports

### DIFF
--- a/tests/golden_masters/full/php_sample_full.md
+++ b/tests/golden_masters/full/php_sample_full.md
@@ -1,5 +1,11 @@
 # Sample.php
 
+## Imports
+```php
+import App\Contracts\UserInterface
+import App\Traits\Timestampable
+```
+
 ## Classes Overview
 | Class | Type | Visibility | Lines | Methods | Fields |
 |-------|------|------------|-------|---------|--------|

--- a/tests/golden_masters/plugins/php.json
+++ b/tests/golden_masters/plugins/php.json
@@ -2,9 +2,10 @@
   "counts_by_type": {
     "Class": 5,
     "Function": 21,
+    "Import": 2,
     "Variable": 9
   },
-  "element_total": 35,
+  "element_total": 37,
   "names_by_type": {
     "Class": [
       "App\\Models\\AdminUser",
@@ -35,6 +36,10 @@
       "setId",
       "updateProfile"
     ],
+    "Import": [
+      "App\\Contracts\\UserInterface",
+      "App\\Traits\\Timestampable"
+    ],
     "Variable": [
       "createdAt",
       "email",
@@ -50,6 +55,7 @@
   "types": [
     "Class",
     "Function",
+    "Import",
     "Variable"
   ]
 }

--- a/tests/golden_masters/toon/php_sample_toon.toon
+++ b/tests/golden_masters/toon/php_sample_toon.toon
@@ -42,12 +42,15 @@ fields:
     instanceCount,,(31,31)
     permissions,,(127,127)
     logs,,(163,163)
-imports: []
+imports:
+  [2]{name,module_name,statement,is_static,is_wildcard,line_range(a,b),imported_names,raw_text}:
+    "App\\Contracts\\UserInterface","App\\Contracts\\UserInterface","import App\\Contracts\\UserInterface",false,false,(5,5),[],"import App\\Contracts\\UserInterface"
+    "App\\Traits\\Timestampable","App\\Traits\\Timestampable","import App\\Traits\\Timestampable",false,false,(6,6),[],"import App\\Traits\\Timestampable"
 statistics:
   class_count: 5
   method_count: 21
   field_count: 9
-  import_count: 0
+  import_count: 2
   total_lines: 0
 effective_table: toon
 requested_table: toon

--- a/tests/unit/languages/test_php_plugin.py
+++ b/tests/unit/languages/test_php_plugin.py
@@ -831,3 +831,57 @@ class TestPHPMethodNameClean:
         user_method_names = {f.name for f in user_methods}
         assert "__construct" in user_method_names
         assert "createUser" in user_method_names
+
+
+class _PhpStubNode:
+    """Minimal tree-sitter node stand-in (explicit parent, no auto-chains)."""
+
+    def __init__(self, type_, children=(), fields=None, parent=None):
+        self.type = type_
+        self.children = list(children)
+        self._fields = fields or {}
+        self.parent = parent
+        self.start_point = (0, 0)
+        self.end_point = (0, 0)
+
+    def child_by_field_name(self, name):
+        return self._fields.get(name)
+
+
+class TestPhpUseClauseGuards:
+    """Cover the defensive directions codecov flagged on #619: nameless
+    clauses return None and are dropped by both extraction loops; the
+    field fast-path is honored when a grammar provides it."""
+
+    @staticmethod
+    def _helpers():
+        from tree_sitter_analyzer.languages import php_helpers
+
+        return php_helpers
+
+    def test_nameless_clause_returns_none(self):
+        h = self._helpers()
+        clause = _PhpStubNode("namespace_use_clause", children=[])
+        assert h._build_use_clause_import(clause, clause, lambda n: "x") is None
+
+    def test_name_field_fast_path_used(self):
+        h = self._helpers()
+        name = _PhpStubNode("qualified_name")
+        clause = _PhpStubNode("namespace_use_clause", fields={"name": name})
+        imp = h._build_use_clause_import(clause, clause, lambda n: "App\\X")
+        assert imp is not None
+        assert imp.name == "App\\X"
+
+    def test_nameless_clause_dropped_by_simple_loop(self):
+        h = self._helpers()
+        clause = _PhpStubNode("namespace_use_clause", children=[])
+        decl = _PhpStubNode("namespace_use_declaration", children=[clause])
+        assert h.extract_use_statement(decl, lambda n: "x") == []
+
+    def test_nameless_clause_dropped_by_group_loop(self):
+        h = self._helpers()
+        clause = _PhpStubNode("namespace_use_clause", children=[])
+        group = _PhpStubNode("namespace_use_group", children=[clause])
+        prefix = _PhpStubNode("namespace_name")
+        decl = _PhpStubNode("namespace_use_declaration", children=[prefix, group])
+        assert h.extract_use_statement(decl, lambda n: "p") == []

--- a/tests/unit/languages/test_php_plugin.py
+++ b/tests/unit/languages/test_php_plugin.py
@@ -570,27 +570,62 @@ class TestPHPImportExtraction:
     """Test PHP import (use statement) extraction."""
 
     def test_extract_simple_use(self):
-        """Test extraction of simple use statements."""
+        """Test extraction of simple use statements (#617)."""
         plugin = PHPPlugin()
         tree = get_tree_for_code(SIMPLE_CLASS_CODE, plugin)
         extractor = plugin.create_extractor()
         imports = extractor.extract_imports(tree, SIMPLE_CLASS_CODE)
 
-        # The PHP extractor does NOT extract `use` statements as imports —
-        # measured 0 with tree-sitter-php 0.24.1 (known extraction gap).
-        # If import extraction is implemented, this must be re-pinned.
-        assert imports == []
+        # SIMPLE_CLASS_CODE has exactly 2 top-level `use` statements.
+        # The class-body `use HasTimestamps;` (trait use) is composition,
+        # NOT an import — it must stay excluded.
+        assert [(i.name, i.alias) for i in imports] == [
+            ("App\\Contracts\\UserInterface", None),
+            ("App\\Traits\\HasTimestamps", None),
+        ]
 
-    def test_extract_aliased_use(self):
-        """Test extraction of aliased use statements."""
+    def test_extract_group_function_const_use(self):
+        """Group, function, and const use forms are extracted (#617)."""
         plugin = PHPPlugin()
         tree = get_tree_for_code(USE_STATEMENTS_CODE, plugin)
         extractor = plugin.create_extractor()
         imports = extractor.extract_imports(tree, USE_STATEMENTS_CODE)
 
-        # The PHP extractor does NOT extract `use` statements (incl. aliased
-        # ones) — measured 0 with tree-sitter-php 0.24.1 (known gap).
-        # If import extraction is implemented, this must be re-pinned.
+        # USE_STATEMENTS_CODE: 5 use declarations → 6 imports (the group
+        # `use App\Services\{UserService, PostService};` yields one per
+        # member, each prefixed with the group namespace).
+        assert [(i.name, i.alias) for i in imports] == [
+            ("App\\Models\\User", None),
+            ("App\\Models\\Post", "BlogPost"),
+            ("App\\Services\\UserService", None),
+            ("App\\Services\\PostService", None),
+            ("App\\Helpers\\formatDate", None),
+            ("App\\Constants\\APP_VERSION", None),
+        ]
+
+    def test_extract_aliased_use(self):
+        """Test extraction of aliased use statements (#617)."""
+        plugin = PHPPlugin()
+        tree = get_tree_for_code(USE_STATEMENTS_CODE, plugin)
+        extractor = plugin.create_extractor()
+        imports = extractor.extract_imports(tree, USE_STATEMENTS_CODE)
+
+        # `use App\Models\Post as BlogPost;` — name keeps the original FQN,
+        # alias carries the local binding (same convention as Python's
+        # `import x as y`: original in name/module_name, bound name in alias).
+        aliased = [i for i in imports if i.alias is not None]
+        assert len(aliased) == 1
+        assert aliased[0].name == "App\\Models\\Post"
+        assert aliased[0].alias == "BlogPost"
+        assert aliased[0].module_name == "App\\Models\\Post"
+
+    def test_trait_use_not_an_import(self):
+        """Class-body `use TraitName;` is composition, not an import (#617)."""
+        plugin = PHPPlugin()
+        code = "<?php\nclass A {\n    use TraitName;\n}\n"
+        tree = get_tree_for_code(code, plugin)
+        extractor = plugin.create_extractor()
+        imports = extractor.extract_imports(tree, code)
         assert imports == []
 
     def test_extract_imports_empty_tree(self):
@@ -603,17 +638,14 @@ class TestPHPImportExtraction:
         assert imports == []
 
     def test_import_line_numbers(self):
-        """Test that import line numbers are correct."""
+        """Test that import line numbers are correct (#617)."""
         plugin = PHPPlugin()
         tree = get_tree_for_code(SIMPLE_CLASS_CODE, plugin)
         extractor = plugin.create_extractor()
         imports = extractor.extract_imports(tree, SIMPLE_CLASS_CODE)
 
-        # imports is empty (use-statement extraction gap, tree-sitter-php
-        # 0.24.1), so the previous all(...) line-number checks were vacuously
-        # true. Pin the actual result; re-pin real line-number checks once
-        # import extraction lands.
-        assert imports == []
+        # SIMPLE_CLASS_CODE: the two use statements sit on lines 4 and 5.
+        assert [(i.start_line, i.end_line) for i in imports] == [(4, 4), (5, 5)]
 
 
 class TestPHPNamespaceHandling:
@@ -688,10 +720,10 @@ class TestPHPPluginAnalyzeFile:
         assert result.success is True
         assert result.language == "php"
         assert result.file_path == str(php_file)
-        # SIMPLE_CLASS_CODE yields exactly 6 elements: 1 class (User),
-        # 3 functions (__construct/getName/getAge), 2 variables (name/age)
-        # (measured with tree-sitter-php 0.24.1)
-        assert len(result.elements) == 6
+        # SIMPLE_CLASS_CODE yields exactly 8 elements: 1 class (User),
+        # 3 functions (__construct/getName/getAge), 2 variables (name/age),
+        # 2 imports (UserInterface/HasTimestamps — extracted since #617).
+        assert len(result.elements) == 8
 
 
 class TestPHPIntegration:
@@ -722,11 +754,15 @@ class TestPHPIntegration:
 
         # COMPLEX_CLASS_CODE measured with tree-sitter-php 0.24.1:
         # 2 classes (BaseService/UserService), 6 functions, 4 properties,
-        # 0 imports (use-statement extraction gap).
+        # 3 imports (use statements, extracted since #617).
         assert len(classes) == 2
         assert len(functions) == 6
         assert len(variables) == 4
-        assert imports == []
+        assert [i.name for i in imports] == [
+            "App\\Repositories\\UserRepository",
+            "App\\Events\\UserCreated",
+            "Psr\\Log\\LoggerInterface",
+        ]
 
     def test_node_counting(self):
         """Test node counting functionality."""

--- a/tree_sitter_analyzer/languages/php_helpers.py
+++ b/tree_sitter_analyzer/languages/php_helpers.py
@@ -85,18 +85,40 @@ def extract_use_statement(
     node: Any,
     get_node_text: Callable[..., str],
 ) -> list[Import]:
-    """Extract use statement elements.
+    """Extract use statement elements from a ``namespace_use_declaration``.
 
     r37co (dogfood): extracted per-clause logic to flatten nesting 7 → 3.
+
+    #617: handles the declaration shapes of tree-sitter-php 0.24:
+    - simple/function/const/aliased use → direct ``namespace_use_clause``
+      children;
+    - group use (``use App\\Models\\{User, Post};``) → clauses nested inside
+      a ``namespace_use_group``, prefixed by the sibling ``namespace_name``.
+
+    Class-body trait use (``use TraitName;``) parses as ``use_declaration``,
+    a different node type, and is intentionally NOT an import — it is
+    composition, not a namespace binding.
     """
     imports: list[Import] = []
     try:
+        group_prefix = ""
         for child in node.children:
-            if child.type != "namespace_use_clause":
-                continue
-            imp = _build_use_clause_import(node, child, get_node_text)
-            if imp is not None:
-                imports.append(imp)
+            if child.type == "namespace_name":
+                # Group-use form: the shared namespace prefix.
+                group_prefix = get_node_text(child)
+            elif child.type == "namespace_use_clause":
+                imp = _build_use_clause_import(node, child, get_node_text)
+                if imp is not None:
+                    imports.append(imp)
+            elif child.type == "namespace_use_group":
+                for clause in child.children:
+                    if clause.type != "namespace_use_clause":
+                        continue
+                    imp = _build_use_clause_import(
+                        node, clause, get_node_text, prefix=group_prefix
+                    )
+                    if imp is not None:
+                        imports.append(imp)
     except Exception as e:
         log_error(f"Error extracting use statement: {e}")
     return imports
@@ -106,19 +128,38 @@ def _build_use_clause_import(
     use_node: Any,
     clause_node: Any,
     get_node_text: Callable[..., str],
+    prefix: str = "",
 ) -> Import | None:
-    """Build one ``Import`` from a ``namespace_use_clause`` node."""
+    """Build one ``Import`` from a ``namespace_use_clause`` node.
+
+    #617 root cause: tree-sitter-php 0.24 exposes the imported name as a
+    plain ``qualified_name``/``name`` child (there is no ``name`` field on
+    the clause) — the old ``child_by_field_name("name")`` lookup always
+    returned ``None``, so PHP files reported 0 imports. Keep the field
+    lookup as a fast path for grammars that do provide it, fall back to
+    child iteration (the alias ``name`` always follows ``as``, so the
+    first match in document order is the imported name, never the alias).
+    """
     name_node = clause_node.child_by_field_name("name")
-    if not name_node:
+    if name_node is None:
+        for child in clause_node.children:
+            if child.type in ("qualified_name", "name"):
+                name_node = child
+                break
+    if name_node is None:
         return None
     alias_node = clause_node.child_by_field_name("alias")
     alias = get_node_text(alias_node) if alias_node else None
+    name = get_node_text(name_node)
+    if prefix:
+        name = f"{prefix}\\{name}"
     return Import(
-        name=get_node_text(name_node),
+        name=name,
         start_line=use_node.start_point[0] + 1,
         end_line=use_node.end_point[0] + 1,
         alias=alias,
         is_wildcard=False,
+        module_name=name,
     )
 
 


### PR DESCRIPTION
Closes #617 (found by ratchet batch-19's gap pins — the old `>= 0` asserts were vacuously green over this for their entire life).

## Root cause
`_build_use_clause_import` did `child_by_field_name("name")` — that field never exists on `namespace_use_clause` in tree-sitter-php 0.24, so PHP imports were 0 forever. Group-use clauses (nested in `namespace_use_group`) were additionally never reached.

## Fix (php_helpers.py, surgical)
- Name lookup falls back to first `qualified_name`/`name` child (alias `name` always follows `as` — document order safe); group use expands prefix + one Import per member; alias convention matches Python (`import x as y`: FQN in name, binding in alias)
- **Trait `use` inside class bodies is NOT an import** — composition, different node type (`use_declaration`), pinned by test

## Test plan
- [x] RED-first: 6 failed pre-fix → 51 passed; batch-19's gap pins consciously re-pinned (old→new table in report)
- [x] Goldens BOTH halves (5-kind): php.json +Import:2 / full +Imports section / toon import_count 0→2 / compact+csv byte-identical (don't render imports) — every line traced
- [x] Ratchet exit=0 (rebased over #616); ruff clean
- [x] Lead independently re-ran 51 tests + live probe (simple/group/alias all extract, alias=O)

Noted not fixed: `MAX_USERS` class const = PHP half of the constants family (#610/#612/#613).