### PR TITLE
test: ratchet batch-20 — pin 36 loose assertions in top-4 AST-ranked files

### DIFF
--- a/scripts/loose_assertion_baseline.txt
+++ b/scripts/loose_assertion_baseline.txt
@@ -39,7 +39,9 @@
 #   files).
 #   batch-19 (AST): 852 -> 816, 2026-06-13 (35 exact pins + 1 timing
 #   exemption in top-4 AST-ranked files).
+#   batch-20 (AST): 816 -> 780, 2026-06-13 (36 pins in top-4 AST-ranked
+#   files).
 
-BASELINE_COUNT=816
+BASELINE_COUNT=780
 MEASUREMENT_DATE=2026-06-13
 MEASUREMENT_COMMAND="uv run python scripts/check_loose_assertions.py --baseline"

--- a/tests/integration/cli/test_cli_advanced_summary_structure.py
+++ b/tests/integration/cli/test_cli_advanced_summary_structure.py
@@ -2,6 +2,7 @@
 """CLI tests: --advanced, --summary, and --structure options."""
 
 import contextlib
+import json
 import sys
 from io import StringIO
 from pathlib import Path
@@ -35,7 +36,17 @@ class TestCLIAdvancedOptions:
             main()
 
         output = mock_stdout.getvalue()
-        assert len(output) > 0
+        data = json.loads(output)
+        assert data["success"] is True
+        assert data["language"] == "java"
+        assert data["line_count"] == 25
+        assert data["class_count"] == 1
+        assert data["method_count"] == 2
+        assert data["field_count"] == 1
+        assert data["import_count"] == 1
+        assert (
+            data["element_count"] == 6
+        )  # 2 methods + class + field + import + package
 
     def test_advanced_option_text_output(self, monkeypatch, sample_java_file):
         sample_dir = str(Path(sample_java_file).parent)
@@ -59,7 +70,8 @@ class TestCLIAdvancedOptions:
             main()
 
         output = mock_stdout.getvalue()
-        assert len(output) > 0
+        assert "--- Advanced Analysis Results ---" in output
+        assert "Lines: 25" in output
 
         assert "Classes: 1" in output
         assert "Methods: 2" in output
@@ -166,7 +178,15 @@ class TestCLIAdvancedOptions:
             main()
 
         output = mock_stdout.getvalue()
-        assert len(output) > 0
+        data = json.loads(output)
+        assert data["success"] is True
+        assert data["line_count"] == 25
+        assert data["class_count"] == 1
+        assert data["method_count"] == 2
+        assert data["field_count"] == 1
+        assert data["import_count"] == 1
+        assert data["element_count"] == 6
+        assert data["node_count"] == 76  # tree-sitter-java 0.23.5
 
     def test_statistics_option_json(self, monkeypatch, sample_java_file):
         sample_dir = str(Path(sample_java_file).parent)
@@ -191,7 +211,15 @@ class TestCLIAdvancedOptions:
             main()
 
         output = mock_stdout.getvalue()
-        assert len(output) > 0
+        data = json.loads(output)
+        assert data["success"] is True
+        assert data["line_count"] == 25
+        assert data["class_count"] == 1
+        assert data["method_count"] == 2
+        assert data["field_count"] == 1
+        assert data["import_count"] == 1
+        assert data["element_count"] == 6
+        assert data["node_count"] == 76  # tree-sitter-java 0.23.5
 
 
 class TestCLISummaryOption:
@@ -212,7 +240,17 @@ class TestCLISummaryOption:
             main()
 
         output = mock_stdout.getvalue()
-        assert len(output) > 0
+        data = json.loads(output)
+        assert data["success"] is True
+        assert [c["name"] for c in data["summary"]["classes"]] == ["TestClass"]
+        assert [m["name"] for m in data["summary"]["methods"]] == [
+            "TestClass",
+            "getField1",
+        ]
+        assert (
+            "classes=1 methods=2 fields=0 imports=0 types=classes,methods"
+            in data["summary_line"]
+        )
 
     def test_summary_option_specific_types(self, monkeypatch, sample_java_file):
         sample_dir = str(Path(sample_java_file).parent)
@@ -235,7 +273,18 @@ class TestCLISummaryOption:
             main()
 
         output = mock_stdout.getvalue()
-        assert len(output) > 0
+        data = json.loads(output)
+        assert data["success"] is True
+        assert [c["name"] for c in data["summary"]["classes"]] == ["TestClass"]
+        assert [m["name"] for m in data["summary"]["methods"]] == [
+            "TestClass",
+            "getField1",
+        ]
+        assert [f["name"] for f in data["summary"]["fields"]] == ["field1"]
+        assert (
+            "classes=1 methods=2 fields=1 imports=0 types=classes,methods,fields"
+            in data["summary_line"]
+        )
 
     def test_summary_option_json(self, monkeypatch, sample_java_file):
         sample_dir = str(Path(sample_java_file).parent)
@@ -259,7 +308,17 @@ class TestCLISummaryOption:
             main()
 
         output = mock_stdout.getvalue()
-        assert len(output) > 0
+        data = json.loads(output)
+        assert data["success"] is True
+        assert [c["name"] for c in data["summary"]["classes"]] == ["TestClass"]
+        assert [m["name"] for m in data["summary"]["methods"]] == [
+            "TestClass",
+            "getField1",
+        ]
+        assert (
+            "classes=1 methods=2 fields=0 imports=0 types=classes,methods"
+            in data["summary_line"]
+        )
 
     def test_summary_option_analysis_failure(self, monkeypatch, sample_java_file):
         sample_dir = str(Path(sample_java_file).parent)
@@ -323,7 +382,16 @@ class TestCLIStructureOption:
             main()
 
         output = mock_stdout.getvalue()
-        assert len(output) > 0
+        data = json.loads(output)
+        assert data["success"] is True
+        assert data["statistics"] == {
+            "class_count": 1,
+            "method_count": 2,
+            "field_count": 1,
+            "import_count": 1,
+            "total_lines": 25,
+            "annotation_count": 0,
+        }
 
     def test_structure_option_text(self, monkeypatch, sample_java_file):
         sample_dir = str(Path(sample_java_file).parent)
@@ -347,7 +415,14 @@ class TestCLIStructureOption:
             main()
 
         output = mock_stdout.getvalue()
-        assert len(output) > 0
+        assert "--- Structure Analysis Results ---" in output
+        assert "Package: com.example.test" in output
+        assert "Classes: 1" in output
+        assert "Methods: 2" in output
+        assert "Fields: 1" in output
+        assert "Imports: 1" in output
+        assert "Total lines: 25" in output
+        assert "- getField1" in output
 
     def test_structure_option_analysis_failure(self, monkeypatch, sample_java_file):
         sample_dir = str(Path(sample_java_file).parent)

--- a/tests/integration/cli/test_cli_core.py
+++ b/tests/integration/cli/test_cli_core.py
@@ -2,6 +2,7 @@
 """Core CLI tests — advanced options, summary, structure, table formatting."""
 
 import contextlib
+import json
 import sys
 from io import StringIO
 from pathlib import Path
@@ -36,7 +37,17 @@ class TestCLIAdvancedOptions:
             main()
 
         output = mock_stdout.getvalue()
-        assert len(output) > 0
+        data = json.loads(output)
+        assert data["success"] is True
+        assert data["language"] == "java"
+        assert data["line_count"] == 25
+        assert data["class_count"] == 1
+        assert data["method_count"] == 2
+        assert data["field_count"] == 1
+        assert data["import_count"] == 1
+        assert (
+            data["element_count"] == 6
+        )  # 2 methods + class + field + import + package
 
     def test_advanced_option_text_output(self, monkeypatch, sample_java_file):
         """Test --advanced option with text output"""
@@ -61,7 +72,8 @@ class TestCLIAdvancedOptions:
             main()
 
         output = mock_stdout.getvalue()
-        assert len(output) > 0
+        assert "--- Advanced Analysis Results ---" in output
+        assert "Lines: 25" in output
 
         # Verify specific content - should show correct element counts
         assert "Classes: 1" in output
@@ -186,7 +198,15 @@ class TestCLIAdvancedOptions:
             main()
 
         output = mock_stdout.getvalue()
-        assert len(output) > 0
+        data = json.loads(output)
+        assert data["success"] is True
+        assert data["line_count"] == 25
+        assert data["class_count"] == 1
+        assert data["method_count"] == 2
+        assert data["field_count"] == 1
+        assert data["import_count"] == 1
+        assert data["element_count"] == 6
+        assert data["node_count"] == 76  # tree-sitter-java 0.23.5
 
     def test_statistics_option_json(self, monkeypatch, sample_java_file):
         """Test --statistics option with JSON output"""
@@ -212,7 +232,15 @@ class TestCLIAdvancedOptions:
             main()
 
         output = mock_stdout.getvalue()
-        assert len(output) > 0
+        data = json.loads(output)
+        assert data["success"] is True
+        assert data["line_count"] == 25
+        assert data["class_count"] == 1
+        assert data["method_count"] == 2
+        assert data["field_count"] == 1
+        assert data["import_count"] == 1
+        assert data["element_count"] == 6
+        assert data["node_count"] == 76  # tree-sitter-java 0.23.5
 
 
 class TestCLISummaryOption:
@@ -234,7 +262,17 @@ class TestCLISummaryOption:
             main()
 
         output = mock_stdout.getvalue()
-        assert len(output) > 0
+        data = json.loads(output)
+        assert data["success"] is True
+        assert [c["name"] for c in data["summary"]["classes"]] == ["TestClass"]
+        assert [m["name"] for m in data["summary"]["methods"]] == [
+            "TestClass",
+            "getField1",
+        ]
+        assert (
+            "classes=1 methods=2 fields=0 imports=0 types=classes,methods"
+            in data["summary_line"]
+        )
 
     def test_summary_option_specific_types(self, monkeypatch, sample_java_file):
         """Test --summary option with specific types"""
@@ -258,7 +296,18 @@ class TestCLISummaryOption:
             main()
 
         output = mock_stdout.getvalue()
-        assert len(output) > 0
+        data = json.loads(output)
+        assert data["success"] is True
+        assert [c["name"] for c in data["summary"]["classes"]] == ["TestClass"]
+        assert [m["name"] for m in data["summary"]["methods"]] == [
+            "TestClass",
+            "getField1",
+        ]
+        assert [f["name"] for f in data["summary"]["fields"]] == ["field1"]
+        assert (
+            "classes=1 methods=2 fields=1 imports=0 types=classes,methods,fields"
+            in data["summary_line"]
+        )
 
     def test_summary_option_json(self, monkeypatch, sample_java_file):
         """Test --summary option with JSON output"""
@@ -283,7 +332,17 @@ class TestCLISummaryOption:
             main()
 
         output = mock_stdout.getvalue()
-        assert len(output) > 0
+        data = json.loads(output)
+        assert data["success"] is True
+        assert [c["name"] for c in data["summary"]["classes"]] == ["TestClass"]
+        assert [m["name"] for m in data["summary"]["methods"]] == [
+            "TestClass",
+            "getField1",
+        ]
+        assert (
+            "classes=1 methods=2 fields=0 imports=0 types=classes,methods"
+            in data["summary_line"]
+        )
 
     def test_summary_option_analysis_failure(self, monkeypatch, sample_java_file):
         """Test --summary option when analysis fails"""
@@ -351,7 +410,16 @@ class TestCLIStructureOption:
             main()
 
         output = mock_stdout.getvalue()
-        assert len(output) > 0
+        data = json.loads(output)
+        assert data["success"] is True
+        assert data["statistics"] == {
+            "class_count": 1,
+            "method_count": 2,
+            "field_count": 1,
+            "import_count": 1,
+            "total_lines": 25,
+            "annotation_count": 0,
+        }
 
     def test_structure_option_text(self, monkeypatch, sample_java_file):
         """Test --structure option with text output"""
@@ -376,7 +444,14 @@ class TestCLIStructureOption:
             main()
 
         output = mock_stdout.getvalue()
-        assert len(output) > 0
+        assert "--- Structure Analysis Results ---" in output
+        assert "Package: com.example.test" in output
+        assert "Classes: 1" in output
+        assert "Methods: 2" in output
+        assert "Fields: 1" in output
+        assert "Imports: 1" in output
+        assert "Total lines: 25" in output
+        assert "- getField1" in output
 
     def test_structure_option_analysis_failure(self, monkeypatch, sample_java_file):
         """Test --structure option when analysis fails"""
@@ -416,5 +491,3 @@ class TestCLIStructureOption:
 
             error_output = mock_stderr.getvalue()
             assert "Analysis failed" in error_output
-
-

--- a/tests/integration/mcp/test_tools/test_analyze_scale_tool.py
+++ b/tests/integration/mcp/test_tools/test_analyze_scale_tool.py
@@ -171,7 +171,9 @@ public class SampleClass {
             assert "fields" in summary
             assert "imports" in summary
             assert summary["classes"] == 1  # SampleClass
-            assert summary["methods"] >= 3  # Constructor + getName + complexCalculation
+            assert summary["methods"] == 3  # Constructor + getName + complexCalculation
+            assert summary["fields"] == 2  # name + value
+            assert summary["imports"] == 2  # List + ArrayList
 
             # Test structural overview
             overview = result["structural_overview"]
@@ -289,21 +291,25 @@ public class Test {
 }
 """
 
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".java", delete=False) as f:
+        # newline="\n" fixes the byte-level pins below across platforms
+        # (Windows CRLF would otherwise inflate file_size_bytes)
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".java", delete=False, newline="\n"
+        ) as f:
             f.write(test_content)
             temp_path = f.name
 
         try:
             metrics = self.tool._calculate_file_metrics(temp_path)
 
-            # Test that metrics are calculated
-            assert metrics["total_lines"] > 0
-            assert metrics["code_lines"] > 0
-            assert metrics["comment_lines"] > 0
-            assert metrics["blank_lines"] >= 0
-            assert metrics["estimated_tokens"] > 0
-            assert metrics["file_size_bytes"] > 0
-            assert metrics["file_size_kb"] > 0
+            # Exact metrics for the 11-line fixture above
+            assert metrics["total_lines"] == 11
+            assert metrics["code_lines"] == 6
+            assert metrics["comment_lines"] == 2
+            assert metrics["blank_lines"] == 3
+            assert metrics["estimated_tokens"] == 40
+            assert metrics["file_size_bytes"] == 178
+            assert metrics["file_size_kb"] == 0.17
 
         finally:
             Path(temp_path).unlink(missing_ok=True)
@@ -402,7 +408,7 @@ public class SimpleClass {
             # Test that we get expected analysis results
             summary = result["summary"]
             assert summary["classes"] == 1
-            assert summary["methods"] >= 1
+            assert summary["methods"] == 1  # simpleMethod
 
         finally:
             Path(temp_path).unlink(missing_ok=True)

--- a/tests/unit/core/test_queries_java.py
+++ b/tests/unit/core/test_queries_java.py
@@ -64,7 +64,7 @@ class TestJavaQueries:
         """Test getting all queries"""
         all_queries = get_all_queries()
         assert isinstance(all_queries, dict)
-        assert len(all_queries) > 0
+        assert len(all_queries) == 70
         assert "class" in all_queries
         assert "query" in all_queries["class"]
         assert "description" in all_queries["class"]
@@ -73,7 +73,7 @@ class TestJavaQueries:
         """Test listing all query names"""
         query_names = list_queries()
         assert isinstance(query_names, list)
-        assert len(query_names) > 0
+        assert len(query_names) == 70
         assert "class" in query_names
         assert "method" in query_names
 
@@ -81,38 +81,50 @@ class TestJavaQueries:
         """Test getting available Java queries"""
         available_queries = get_available_java_queries()
         assert isinstance(available_queries, list)
-        assert len(available_queries) > 0
+        assert len(available_queries) == 65
         assert "class" in available_queries
         assert "method" in available_queries
 
     def test_java_queries_structure(self) -> None:
         """Test JAVA_QUERIES dictionary structure"""
         assert isinstance(JAVA_QUERIES, dict)
-        assert len(JAVA_QUERIES) > 0
+        assert len(JAVA_QUERIES) == 65
 
-        # Test some essential queries exist
-        essential_queries = ["class", "method", "field", "import", "package"]
-        for query_name in essential_queries:
+        # Test some essential queries exist (exact stripped source lengths)
+        essential_query_lens = {
+            "class": 26,
+            "method": 28,
+            "field": 26,
+            "import": 28,
+            "package": 30,
+        }
+        for query_name, expected_len in essential_query_lens.items():
             assert query_name in JAVA_QUERIES
             assert isinstance(JAVA_QUERIES[query_name], str)
-            assert len(JAVA_QUERIES[query_name].strip()) > 0
+            assert len(JAVA_QUERIES[query_name].strip()) == expected_len
 
     def test_java_query_descriptions_structure(self) -> None:
         """Test JAVA_QUERY_DESCRIPTIONS dictionary structure"""
         assert isinstance(JAVA_QUERY_DESCRIPTIONS, dict)
-        assert len(JAVA_QUERY_DESCRIPTIONS) > 0
+        assert len(JAVA_QUERY_DESCRIPTIONS) == 65
 
-        # Test some essential descriptions exist
-        essential_queries = ["class", "method", "field", "import", "package"]
-        for query_name in essential_queries:
+        # Test some essential descriptions exist (exact stripped lengths)
+        essential_description_lens = {
+            "class": 31,
+            "method": 32,
+            "field": 31,
+            "import": 30,
+            "package": 33,
+        }
+        for query_name, expected_len in essential_description_lens.items():
             assert query_name in JAVA_QUERY_DESCRIPTIONS
             assert isinstance(JAVA_QUERY_DESCRIPTIONS[query_name], str)
-            assert len(JAVA_QUERY_DESCRIPTIONS[query_name].strip()) > 0
+            assert len(JAVA_QUERY_DESCRIPTIONS[query_name].strip()) == expected_len
 
     def test_all_queries_structure(self) -> None:
         """Test ALL_QUERIES dictionary structure"""
         assert isinstance(ALL_QUERIES, dict)
-        assert len(ALL_QUERIES) > 0
+        assert len(ALL_QUERIES) == 70
 
         # Test structure of each query entry
         for _query_name, query_data in ALL_QUERIES.items():
@@ -155,18 +167,18 @@ class TestJavaQueries:
 
     def test_detailed_queries(self) -> None:
         """Test detailed information extraction queries"""
-        detailed_queries = [
-            "method_parameters_detailed",
-            "class_inheritance_detailed",
-            "annotation_detailed",
-            "import_detailed",
-            "package_detailed",
-            "constructor_detailed",
-        ]
-        for query_name in detailed_queries:
+        detailed_query_lens = {
+            "method_parameters_detailed": 237,
+            "class_inheritance_detailed": 279,
+            "annotation_detailed": 219,
+            "import_detailed": 109,
+            "package_detailed": 79,
+            "constructor_detailed": 189,
+        }
+        for query_name, expected_len in detailed_query_lens.items():
             assert query_name in JAVA_QUERIES
             query = JAVA_QUERIES[query_name]
-            assert len(query.strip()) > 0
+            assert len(query.strip()) == expected_len
 
     def test_modifier_specific_queries(self) -> None:
         """Test modifier-specific queries"""


### PR DESCRIPTION
## Summary
Loose-assertion ratchet batch 20. Top-4 (8-way tie at 9; lexicographic tie-break documented):

| File | Pins |
|---|---|
| tests/integration/cli/test_cli_advanced_summary_structure.py | 9 |
| tests/integration/cli/test_cli_core.py | 9 |
| tests/integration/mcp/test_tools/test_analyze_scale_tool.py | 9 |
| tests/unit/core/test_queries_java.py | 9 |

Baseline: **816 → 780** (= exactly 36, lead re-verified live).

Highlights: `len(output) > 0` CLI asserts upgraded to parsed-JSON exact pins + full-list name pins + full-dict statistics equality; byte pins guarded with `newline="\n"`; grammar-version-sensitive pins carry provenance (tree-sitter-java 0.23.5 — bumps go consciously RED); query registry counts pinned (65/70); zero exemptions.

## Test plan
- [x] All 4 files individually `-n 0`: 13/13/18/18 passed (re-run post-ruff-format)
- [x] Diff gate exit=0
- [x] `--baseline` measures 780 == recorded (lead independently re-verified)