### PR TITLE
test: ratchet batch-21 — pin 36 loose assertions in top-4 AST-ranked files

### DIFF
--- a/scripts/loose_assertion_baseline.txt
+++ b/scripts/loose_assertion_baseline.txt
@@ -41,7 +41,9 @@
 #   exemption in top-4 AST-ranked files).
 #   batch-20 (AST): 816 -> 780, 2026-06-13 (36 pins in top-4 AST-ranked
 #   files).
+#   batch-21 (AST): 780 -> 744, 2026-06-13 (36 pins in top-4 AST-ranked
+#   files).
 
-BASELINE_COUNT=780
+BASELINE_COUNT=744
 MEASUREMENT_DATE=2026-06-13
 MEASUREMENT_COMMAND="uv run python scripts/check_loose_assertions.py --baseline"

--- a/tests/unit/core/test_queries_javascript_extended.py
+++ b/tests/unit/core/test_queries_javascript_extended.py
@@ -17,28 +17,28 @@ class TestJavaScriptExtendedQueries:
 
     def test_query_count_comprehensive(self):
         """Test that JavaScript has comprehensive query coverage"""
-        # JavaScript should have 85+ queries
-        assert len(js_queries.ALL_QUERIES) >= 85
+        assert len(js_queries.ALL_QUERIES) == 87
         print(f"Total JavaScript queries: {len(js_queries.ALL_QUERIES)}")
 
     def test_function_queries_comprehensive(self):
         """Test comprehensive function query coverage"""
-        function_queries = [
-            "function",
-            "function_declaration",
-            "function_expression",
-            "arrow_function",
-            "method_definition",
-            "async_function",
-            "generator_function",
-        ]
+        # Exact stripped query-source lengths (update when query strings change)
+        function_query_lens = {
+            "function": 32,
+            "function_declaration": 176,
+            "function_expression": 175,
+            "arrow_function": 108,
+            "method_definition": 177,
+            "async_function": 201,
+            "generator_function": 184,
+        }
 
-        for query_name in function_queries:
+        for query_name, expected_len in function_query_lens.items():
             assert query_name in js_queries.ALL_QUERIES
             query_data = js_queries.ALL_QUERIES[query_name]
             assert "query" in query_data
             assert "description" in query_data
-            assert len(query_data["query"].strip()) > 0
+            assert len(query_data["query"].strip()) == expected_len
 
     def test_class_queries_comprehensive(self):
         """Test comprehensive class query coverage"""
@@ -201,8 +201,15 @@ class TestJavaScriptExtendedQueries:
             # Check content
             assert isinstance(query_data["query"], str)
             assert isinstance(query_data["description"], str)
-            assert len(query_data["query"].strip()) > 0
-            assert len(query_data["description"].strip()) > 0
+
+        # Pin minimum observed lengths (exact facts; update when query strings change)
+        assert (
+            min(len(d["query"].strip()) for d in js_queries.ALL_QUERIES.values()) == 16
+        )
+        assert (
+            min(len(d["description"].strip()) for d in js_queries.ALL_QUERIES.values())
+            == 15
+        )
 
     def test_query_syntax_validation(self):
         """Test basic syntax validation for queries"""
@@ -256,11 +263,13 @@ class TestJavaScriptExtendedQueries:
         for query_name, query_data in js_queries.ALL_QUERIES.items():
             description = query_data["description"]
 
-            # Description should be meaningful
-            assert len(description) > 10, f"Description for {query_name} is too short"
             assert not description.lower().startswith("todo"), (
                 f"Description for {query_name} appears to be a placeholder"
             )
+
+        # Pin minimum observed description length (exact fact; update when
+        # descriptions change)
+        assert min(len(d["description"]) for d in js_queries.ALL_QUERIES.values()) == 15
 
     def test_utility_functions(self):
         """Test utility functions"""
@@ -268,19 +277,19 @@ class TestJavaScriptExtendedQueries:
         if hasattr(js_queries, "get_query"):
             functions_query = js_queries.get_query("functions")
             assert isinstance(functions_query, str)
-            assert len(functions_query) > 0
+            assert len(functions_query) == 658
 
         # Test get_all_queries function
         if hasattr(js_queries, "get_all_queries"):
             all_queries = js_queries.get_all_queries()
             assert isinstance(all_queries, dict)
-            assert len(all_queries) >= 85
+            assert len(all_queries) == 87
 
         # Test list_queries function
         if hasattr(js_queries, "list_queries"):
             query_names = js_queries.list_queries()
             assert isinstance(query_names, list)
-            assert len(query_names) >= 85
+            assert len(query_names) == 87
 
     def test_consistency_with_constants(self):
         """Test consistency between constants and ALL_QUERIES"""
@@ -353,9 +362,8 @@ class TestJavaScriptQueryComparison:
         """Test that JavaScript has comprehensive coverage"""
         js_count = len(js_queries.ALL_QUERIES)
 
-        # JavaScript should have 85+ queries
-        assert js_count >= 85, (
-            f"JavaScript should have at least 85 queries, got {js_count}"
+        assert js_count == 87, (
+            f"JavaScript should have exactly 87 queries, got {js_count}"
         )
 
     def test_javascript_vs_typescript_features(self):

--- a/tests/unit/core/test_queries_python.py
+++ b/tests/unit/core/test_queries_python.py
@@ -54,7 +54,7 @@ class TestPythonQueries:
         """Test getting all queries"""
         all_queries = get_all_queries()
         assert isinstance(all_queries, dict)
-        assert len(all_queries) > 0
+        assert len(all_queries) == 88
         assert "functions" in all_queries
         assert "query" in all_queries["functions"]
         assert "description" in all_queries["functions"]
@@ -63,14 +63,14 @@ class TestPythonQueries:
         """Test listing all query names"""
         query_names = list_queries()
         assert isinstance(query_names, list)
-        assert len(query_names) > 0
+        assert len(query_names) == 88
         assert "functions" in query_names
         assert "classes" in query_names
 
     def test_all_queries_structure(self) -> None:
         """Test ALL_QUERIES dictionary structure"""
         assert isinstance(ALL_QUERIES, dict)
-        assert len(ALL_QUERIES) > 0
+        assert len(ALL_QUERIES) == 88
 
         # Test essential queries exist
         essential_queries = ["functions", "classes", "variables", "imports", "comments"]
@@ -83,10 +83,17 @@ class TestPythonQueries:
 
     def test_query_constants(self) -> None:
         """Test that query constants are properly defined"""
-        constants = [FUNCTIONS, CLASSES, VARIABLES, IMPORTS, COMMENTS]
-        for constant in constants:
+        # Exact stripped lengths (update when query strings change)
+        constant_lens = [
+            (FUNCTIONS, 315),
+            (CLASSES, 156),
+            (VARIABLES, 322),
+            (IMPORTS, 445),
+            (COMMENTS, 66),
+        ]
+        for constant, expected_len in constant_lens:
             assert isinstance(constant, str)
-            assert len(constant.strip()) > 0
+            assert len(constant.strip()) == expected_len
 
     def test_functions_query(self) -> None:
         """Test functions query content"""
@@ -118,10 +125,13 @@ class TestPythonQueries:
         for _query_name, query_data in ALL_QUERIES.items():
             description = query_data["description"]
             assert isinstance(description, str)
-            assert len(description) > 0
             assert (
                 "search" in description.lower()
             )  # All descriptions should mention "search"
+
+        # Pin minimum observed description length (exact fact; update when
+        # descriptions change)
+        assert min(len(d["description"]) for d in ALL_QUERIES.values()) == 16
 
     def test_query_consistency(self) -> None:
         """Test consistency between constants and ALL_QUERIES"""
@@ -171,25 +181,26 @@ class TestGetPythonQuery:
         assert "function_definition" in query
 
     def test_valid_query_various_names(self) -> None:
-        names = [
-            "class_definition",
-            "async_function",
-            "lambda",
-            "constructor",
-            "import_from",
-            "decorator_call",
-            "try_statement",
-            "list_comprehension",
-            "type_hint",
-            "match_statement",
-            "f_string",
-            "django_model",
-            "dataclass",
-        ]
-        for name in names:
+        # Exact stripped query-source lengths (update when query strings change)
+        name_lens = {
+            "class_definition": 156,
+            "async_function": 183,
+            "lambda": 114,
+            "constructor": 199,
+            "import_from": 126,
+            "decorator_call": 148,
+            "try_statement": 181,
+            "list_comprehension": 186,
+            "type_hint": 68,
+            "match_statement": 34,
+            "f_string": 66,
+            "django_model": 235,
+            "dataclass": 229,
+        }
+        for name, expected_len in name_lens.items():
             query = get_python_query(name)
             assert isinstance(query, str)
-            assert len(query.strip()) > 0
+            assert len(query.strip()) == expected_len
 
     def test_invalid_query_name_raises(self) -> None:
         with pytest.raises(ValueError) as exc_info:
@@ -209,13 +220,16 @@ class TestGetPythonQueryDescription:
     def test_known_query_description(self) -> None:
         desc = get_python_query_description("function")
         assert isinstance(desc, str)
-        assert len(desc) > 0
+        assert desc == "Search Python function definitions"
 
     def test_all_descriptions_are_strings(self) -> None:
         for name in PYTHON_QUERIES:
             desc = get_python_query_description(name)
             assert isinstance(desc, str)
-            assert len(desc) > 0
+
+        # Pin minimum observed description length (exact fact; update when
+        # descriptions change)
+        assert min(len(get_python_query_description(n)) for n in PYTHON_QUERIES) == 16
 
     def test_unknown_query_returns_default(self) -> None:
         desc = get_python_query_description("totally_fake_query")
@@ -228,7 +242,7 @@ class TestGetAvailablePythonQueries:
     def test_returns_list(self) -> None:
         result = get_available_python_queries()
         assert isinstance(result, list)
-        assert len(result) > 0
+        assert len(result) == 70
 
     def test_contains_essential_queries(self) -> None:
         result = set(get_available_python_queries())

--- a/tests/unit/core/test_queries_typescript_extended.py
+++ b/tests/unit/core/test_queries_typescript_extended.py
@@ -17,20 +17,21 @@ class TestTypeScriptExtendedQueries:
 
     def test_new_function_queries(self):
         """Test new function-specific queries"""
-        function_queries = [
-            "function_declaration",
-            "arrow_function",
-            "method_definition",
-            "async_function",
-        ]
+        # Exact stripped (query, description) lengths (update when strings change)
+        function_query_lens = {
+            "function_declaration": (236, 33),
+            "arrow_function": (156, 27),
+            "method_definition": (221, 30),
+            "async_function": (257, 34),
+        }
 
-        for query_name in function_queries:
+        for query_name, (query_len, desc_len) in function_query_lens.items():
             assert query_name in ts_queries.ALL_QUERIES
             query_data = ts_queries.ALL_QUERIES[query_name]
             assert "query" in query_data
             assert "description" in query_data
-            assert len(query_data["query"].strip()) > 0
-            assert len(query_data["description"].strip()) > 0
+            assert len(query_data["query"].strip()) == query_len
+            assert len(query_data["description"].strip()) == desc_len
 
     def test_new_class_queries(self):
         """Test new class-specific queries"""
@@ -225,8 +226,7 @@ class TestTypeScriptExtendedQueries:
 
     def test_query_count(self):
         """Test that we have the expected number of queries"""
-        # We should have 82 queries total
-        assert len(ts_queries.ALL_QUERIES) >= 80
+        assert len(ts_queries.ALL_QUERIES) == 83
         print(f"Total TypeScript queries: {len(ts_queries.ALL_QUERIES)}")
 
     def test_all_queries_have_valid_structure(self):
@@ -241,12 +241,15 @@ class TestTypeScriptExtendedQueries:
             # Check content
             assert isinstance(query_data["query"], str)
             assert isinstance(query_data["description"], str)
-            assert len(query_data["query"].strip()) > 0
-            assert len(query_data["description"].strip()) > 0
 
             # Check description quality
-            assert len(query_data["description"]) > 10
             assert not query_data["description"].lower().startswith("todo")
+
+        # Pin minimum observed lengths (exact facts; update when strings change)
+        queries = ts_queries.ALL_QUERIES
+        assert min(len(d["query"].strip()) for d in queries.values()) == 18
+        assert min(len(d["description"].strip()) for d in queries.values()) == 18
+        assert min(len(d["description"]) for d in queries.values()) == 18
 
     def test_query_syntax_basic_validation(self):
         """Test basic syntax validation for queries"""
@@ -341,11 +344,12 @@ class TestTypeScriptExtendedQueries:
 
     def test_query_descriptions_meaningful(self):
         """Test that query descriptions are meaningful and specific"""
+        # Pin minimum observed description length (exact fact; update when
+        # descriptions change)
+        assert min(len(d["description"]) for d in ts_queries.ALL_QUERIES.values()) == 18
+
         for query_name, query_data in ts_queries.ALL_QUERIES.items():
             description = query_data["description"]
-
-            # Should be descriptive
-            assert len(description) > 15
 
             # Should contain action word
             action_words = ["search", "find", "extract", "match", "locate"]
@@ -377,7 +381,7 @@ class TestTypeScriptExtendedQueries:
 
         # Test get_all_queries function
         all_queries = ts_queries.get_all_queries()
-        assert len(all_queries) >= 80
+        assert len(all_queries) == 83
         assert "union_type" in all_queries
         assert "as_expression" in all_queries
 
@@ -396,9 +400,8 @@ class TestTypeScriptQueryComparison:
         """Test that TypeScript has more queries than JavaScript"""
         ts_count = len(ts_queries.ALL_QUERIES)
 
-        # TypeScript should have significantly more queries due to type system
-        assert ts_count >= 80, (
-            f"TypeScript should have at least 80 queries, got {ts_count}"
+        assert ts_count == 83, (
+            f"TypeScript should have exactly 83 queries, got {ts_count}"
         )
 
         # Check TypeScript-specific features not in JavaScript

--- a/tests/unit/formatters/test_javascript_formatter_robustness.py
+++ b/tests/unit/formatters/test_javascript_formatter_robustness.py
@@ -44,7 +44,7 @@ class TestJavaScriptFormatterRobustness:
 
         # Should handle empty data gracefully
         assert isinstance(result, str)
-        assert len(result) > 0
+        assert result == "# Unknown"
 
     def test_format_compact_with_empty_data(self, formatter):
         """Test compact formatting with completely empty data"""
@@ -54,7 +54,16 @@ class TestJavaScriptFormatterRobustness:
 
         # Should handle empty data gracefully
         assert isinstance(result, str)
-        assert len(result) > 0
+        assert result == (
+            "# Unknown\n"
+            "\n"
+            "## Info\n"
+            "| Property | Value |\n"
+            "|----------|-------|\n"
+            "| Package |  |\n"
+            "| Methods | 0 |\n"
+            "| Fields | 0 |"
+        )
 
     def test_format_csv_with_empty_data(self, formatter):
         """Test CSV formatting with completely empty data"""
@@ -64,7 +73,7 @@ class TestJavaScriptFormatterRobustness:
 
         # Should handle empty data gracefully
         assert isinstance(result, str)
-        assert len(result) > 0
+        assert result == "Type,Name,Signature,Visibility,Lines,Complexity,Doc"
 
     def test_format_json_with_empty_data(self, formatter):
         """Test JSON formatting with completely empty data"""
@@ -74,7 +83,7 @@ class TestJavaScriptFormatterRobustness:
 
         # Should handle empty data gracefully
         assert isinstance(result, str)
-        assert len(result) > 0
+        assert result == "{}"
 
     def test_format_with_none_values(self, formatter):
         """Test formatting with None values in data"""
@@ -90,9 +99,9 @@ class TestJavaScriptFormatterRobustness:
 
         result = formatter._format_full_table(data)
 
-        # Should handle None values gracefully
+        # Should handle None values gracefully (same fallback as empty data)
         assert isinstance(result, str)
-        assert len(result) > 0
+        assert result == "# Unknown"
 
     def test_format_with_malformed_data(self, formatter):
         """Test formatting with malformed data structures"""
@@ -266,7 +275,7 @@ class TestJavaScriptFormatterRobustness:
         # Should complete within reasonable time (5 seconds)
         assert end_time - start_time < 5.0
         assert isinstance(result, str)
-        assert len(result) > 0
+        assert len(result) == 3124  # exact output size for this fixed dataset
 
         # Test compact table formatting
         start_time = time.time()
@@ -276,7 +285,7 @@ class TestJavaScriptFormatterRobustness:
         # Should complete within reasonable time (5 seconds)
         assert end_time - start_time < 5.0
         assert isinstance(result, str)
-        assert len(result) > 0
+        assert len(result) == 105  # exact output size for this fixed dataset
 
     def test_unicode_handling(self, formatter):
         """Test handling of Unicode characters in data"""
@@ -311,7 +320,8 @@ class TestJavaScriptFormatterRobustness:
         # Should handle special characters without errors
         result = formatter._format_full_table(special_data)
         assert isinstance(result, str)
-        assert len(result) > 0
+        assert len(result) == 217  # exact output size for this fixed dataset
+        assert 'Class"quote' in result
 
     def test_memory_usage_with_repeated_calls(self, formatter):
         """Test memory usage with repeated formatting calls"""
@@ -382,7 +392,7 @@ class TestJavaScriptFormatterRobustness:
             if status == "success":
                 success_count += 1
                 assert isinstance(result, str)
-                assert len(result) > 0
+                assert len(result) == 196  # exact output size for this fixed dataset
 
         # All threads should succeed
         assert success_count == 5


### PR DESCRIPTION
## Summary
Loose-assertion ratchet batch 21. Top-4 (5-way tie at 9; lexicographic tie-break per batch-20 precedent):

| File | Pins |
|---|---|
| tests/unit/core/test_queries_javascript_extended.py | 9 |
| tests/unit/core/test_queries_python.py | 9 |
| tests/unit/core/test_queries_typescript_extended.py | 9 |
| tests/unit/formatters/test_javascript_formatter_robustness.py | 9 |

Baseline: **780 → 744** (= exactly 36, lead re-verified live).

Highlights: registry counts pinned (87/88/83/70); fixed-list query loops → expected-length dicts; whole-registry loops → count+min exact form (in-repo pattern); formatter empty-input outputs pinned as full strings, large datasets by exact length; zero exemptions; no new skips.

## Test plan
- [x] All 4 files individually `-n 0`: 24/49/27/18 passed (re-run post-ruff-format)
- [x] Diff gate exit=0
- [x] `--baseline` measures 744 == recorded (lead independently re-verified)