### PR TITLE
docs(rfc): RFC-0016 rejected — embedding pilot NO-GO at deployment scale

### DIFF
--- a/rfcs/0016-semantic-symbol-search.md
+++ b/rfcs/0016-semantic-symbol-search.md
@@ -1,6 +1,9 @@
 # RFC-0016: Semantic symbol search (brute-force-first, sqlite-vec deferred)
 
-- **Status**: draft (revision 2 — rewritten after adversarial panel round 1)
+- **Status**: rejected (data-driven, 2026-06-13 — embedding pilot at deployment
+  scale scored 2/5 on the conceptual-gap gate; full chain: stemming #606,
+  demotion #609, BM25-docstring #621 all measured first; pilot report
+  `.recon/rfc0016-pilot-step2-embeddings.md`, decision thread #517)
 - **Author(s)**: lead (autonomous), on behalf of dogfood evidence in #517
 - **Created**: 2026-06-13
 - **Last updated**: 2026-06-13
@@ -325,6 +328,31 @@ versions; its prior-art value is SQL ergonomics, not ANN.
 - `nav action=context` semantic rerank (phase-2, pilot-gated).
 - Body-content embeddings; cross-repo federation; replacing BM25 anywhere;
   auto-building on first connect. (Unchanged.)
+
+## Outcome (2026-06-13, closing note)
+
+The pilot ran exactly as specified and returned **NO-GO at deployment scale**:
+semantic top-5 hit 2/5 of the conceptual-gap gate set at 37,876 symbols
+(vs 4/5 on the 1k pilot corpus — the gap between the two IS the lesson:
+**retrieval pilots need deployment-size distractor sets**, a 1k corpus
+overstates recall by construction). Other recorded findings:
+
+- The hybrid spec in this RFC is actively harmful as written (1/10): the
+  exact-name leg promoted bare symbols named `format`/`search`/`a`. Any
+  future revival must gate the lexical leg on identifier quality.
+- Vectors added exactly +2 conceptual wins over post-#609 BM25 (union 7/10
+  vs 5/10) — one short of the gate, against the full onnx/tokenizer/model-
+  distribution platform surface the round-1 panel costed.
+- The flagship miss (`handle_call_tool`: generic name + no docstring) is
+  unreachable by ANY retrieval layer — that is a naming/documentation
+  problem, not a search problem.
+- Measured (Rule 11): 1,821 symbols/s embed throughput, 1,536 B/symbol,
+  ~18 ms query p50 @ 38k — the engineering was viable; the recall wasn't.
+
+What this rejection does NOT undo: phase 0 stemming (#606), the cascade
+demotion fix (#609), constants indexing (#610/#612/#613/#615/#618), and
+docstring serialization (#621) all shipped on their own merits during the
+measurement chain.
 
 ## Open questions
 

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -72,7 +72,7 @@ number; if two RFCs collide on a number in flight, the later-merged one renames.
 | [0013](0013-facade-dropped-param-visibility.md) | Facade dropped-parameter visibility — `ignored_params` surface | accepted |
 | [0014](0014-instant-edit-safety.md) | Instant edit safety — test-noise partition, test-map, and co-change | accepted (Phase A #461; Phase B #463; Phase C #466; integration test + DF-16 dogfood deferred) |
 | [0015](0015-instant-uml-family.md) | Instant UML family — scoping fixes + activity/state diagrams | implemented (Phase 1 #462; P2-A #472; P2-B #475; v1.23.0) |
-| [0016](0016-semantic-symbol-search.md) | Semantic symbol search via sqlite-vec in `.ast-cache` | draft (#517) |
+| [0016](0016-semantic-symbol-search.md) | Semantic symbol search via sqlite-vec in `.ast-cache` | rejected (data-driven; pilot NO-GO at deployment scale, #517) |
 
 ## Roadmap
 


### PR DESCRIPTION
Closes the RFC-0016 decision loop (#517 closes with this).

Pilot (.recon/rfc0016-pilot-step2-embeddings.md, MiniLM, this repo):
| arm | conceptual gate {M2,Q2,Q4,Q5,Q6} | total |
|---|---|---|
| BM25 develop (post-#609) | 0/5 | 5/10 |
| semantic @ 1k corpus | 4/5 | 7/10 |
| **semantic @ 37,876 symbols (deployment)** | **2/5** | 3/10 (5/10 with demotion) |
| RFC hybrid as specified | 1/5 | **1/10 — actively harmful** |

Vectors net +2 conceptual wins vs the platform surface the round-1 panel costed → NO-GO. The 1k→full flip is the recorded pilot-design lesson (deployment-size distractors or it didn't happen). Everything that shipped during the measurement chain (#606/#609/#612/#613/#621) stands on its own merits.

Engineering viability was confirmed (1.8k symbols/s, 1.5KB/symbol, 18ms p50) — recall wasn't. Status: draft → rejected; revival requires a new RFC citing this data.