### PR TITLE
feat(index): PHP constants indexed as symbols

### DIFF
--- a/tests/golden_masters/compact/php_sample_compact.md
+++ b/tests/golden_masters/compact/php_sample_compact.md
@@ -5,7 +5,7 @@
 |----------|-------|
 | Namespace |  |
 | Methods | 21 |
-| Fields | 9 |
+| Fields | 12 |
 
 ## Methods
 | Method | Sig | V | L | Cx | Doc |

--- a/tests/golden_masters/csv/php_sample_csv.csv
+++ b/tests/golden_masters/csv/php_sample_csv.csv
@@ -1,4 +1,7 @@
 Type,Name,Signature,Visibility,Lines,Complexity,Doc
+Field,User::STATUS_ACTIVE,User::STATUS_ACTIVE:const,public,20-20,,-
+Field,User::STATUS_INACTIVE,User::STATUS_INACTIVE:const,public,21-21,,-
+Field,User::MAX_LOGIN_ATTEMPTS,User::MAX_LOGIN_ATTEMPTS:const,private,22-22,,-
 Field,User::id,User::id:int,private,25-25,,-
 Field,User::username,User::username:string,public,26-26,,-
 Field,User::email,User::email:string,public,27-27,,-

--- a/tests/golden_masters/full/php_sample_full.md
+++ b/tests/golden_masters/full/php_sample_full.md
@@ -9,7 +9,7 @@ import App\Traits\Timestampable
 ## Classes Overview
 | Class | Type | Visibility | Lines | Methods | Fields |
 |-------|------|------------|-------|---------|--------|
-| App\Models\User | class | public | 13-120 | 10 | 7 |
+| App\Models\User | class | public | 13-120 | 10 | 10 |
 | App\Models\AdminUser | class | public | 125-146 | 3 | 1 |
 | App\Models\UserRepositoryInterface | interface | public | 151-156 | 3 | 0 |
 | App\Models\Loggable | trait | public | 161-177 | 2 | 1 |
@@ -19,6 +19,9 @@ import App\Traits\Timestampable
 ### Fields
 | Name | Type | Vis | Modifiers | Line | Doc |
 |------|------|-----|-----------|------|-----|
+| User::STATUS_ACTIVE | const | + | public,static | 20 | - |
+| User::STATUS_INACTIVE | const | + | public,static | 21 | - |
+| User::MAX_LOGIN_ATTEMPTS | const | - | private,static | 22 | - |
 | User::id | int | - | private | 25 | - |
 | User::username | string | + | public | 26 | - |
 | User::email | string | + | public | 27 | - |

--- a/tests/golden_masters/plugins/php.json
+++ b/tests/golden_masters/plugins/php.json
@@ -3,9 +3,9 @@
     "Class": 5,
     "Function": 21,
     "Import": 2,
-    "Variable": 9
+    "Variable": 12
   },
-  "element_total": 37,
+  "element_total": 40,
   "names_by_type": {
     "Class": [
       "App\\Models\\AdminUser",
@@ -41,6 +41,9 @@
       "App\\Traits\\Timestampable"
     ],
     "Variable": [
+      "MAX_LOGIN_ATTEMPTS",
+      "STATUS_ACTIVE",
+      "STATUS_INACTIVE",
       "createdAt",
       "email",
       "id",

--- a/tests/golden_masters/toon/php_sample_toon.toon
+++ b/tests/golden_masters/toon/php_sample_toon.toon
@@ -32,7 +32,10 @@ methods:
     "App\\Models\\createUser",public,(203,206)
     "App\\Models\\hashPassword",public,(211,214)
 fields:
-  [9]{name,type,line_range(a,b)}:
+  [12]{name,type,line_range(a,b)}:
+    STATUS_ACTIVE,,(20,20)
+    STATUS_INACTIVE,,(21,21)
+    MAX_LOGIN_ATTEMPTS,,(22,22)
     id,,(25,25)
     username,,(26,26)
     email,,(27,27)
@@ -49,7 +52,7 @@ imports:
 statistics:
   class_count: 5
   method_count: 21
-  field_count: 9
+  field_count: 12
   import_count: 2
   total_lines: 0
 effective_table: toon

--- a/tests/unit/languages/test_php_plugin.py
+++ b/tests/unit/languages/test_php_plugin.py
@@ -909,3 +909,29 @@ class TestPhpUseClauseGuards:
         prefix = _PhpStubNode("namespace_name")
         decl = _PhpStubNode("namespace_use_declaration", children=[prefix, group])
         assert h.extract_use_statement(decl, lambda n: "p") == []
+
+
+class TestPhpEnumConstantOwnership:
+    """Codex P2 on #625: enums may declare consts — without enum_declaration
+    in the parent tracking they emit receiver_type=None (global lookalike)."""
+
+    CODE = """<?php
+enum Suit
+{
+    case Hearts;
+    const ENUM_C = "wild";
+}
+"""
+
+    def test_enum_const_carries_enum_receiver(self):
+        import tree_sitter
+        import tree_sitter_php
+
+        from tree_sitter_analyzer.languages.php_plugin import PHPElementExtractor
+
+        lang = tree_sitter.Language(tree_sitter_php.language_php())
+        tree = tree_sitter.Parser(lang).parse(self.CODE.encode())
+        variables = PHPElementExtractor().extract_variables(tree, self.CODE)
+        consts = [v for v in variables if v.name == "ENUM_C"]
+        assert len(consts) == 1
+        assert consts[0].receiver_type == "Suit"

--- a/tests/unit/languages/test_php_plugin.py
+++ b/tests/unit/languages/test_php_plugin.py
@@ -500,15 +500,38 @@ class TestPHPVariableExtraction:
         extractor = plugin.create_extractor()
         variables = extractor.extract_variables(tree, COMPLEX_CLASS_CODE)
 
-        # COMPLEX_CLASS_CODE yields exactly 4 properties (measured with
-        # tree-sitter-php 0.24.1). The MAX_USERS class constant is NOT
-        # extracted — known constant-extraction gap.
+        # COMPLEX_CLASS_CODE yields 4 properties + the MAX_USERS class
+        # constant (gap fixed by #624: const_element carries no ``name``
+        # field, so the field lookup dropped every const silently).
         assert [v.name for v in variables] == [
             "logger",
             "repository",
+            "MAX_USERS",
             "instanceCount",
             "serviceName",
         ]
+        max_users = next(v for v in variables if v.name == "MAX_USERS")
+        assert max_users.is_constant is True
+        assert max_users.is_static is True
+        assert max_users.is_final is True
+        assert max_users.visibility == "public"
+        assert max_users.variable_type == "const"
+        assert max_users.receiver_type == "UserService"
+        assert max_users.start_line == 21
+
+    def test_extract_top_level_const(self):
+        """#624 — top-level const reaches extract_variables too (the plugin
+        walks the whole tree, so the same name-field fix covers it)."""
+        plugin = PHPPlugin()
+        code = "<?php\nconst MAX = 1;\nconst A = 1, B = 2;\n"
+        tree = get_tree_for_code(code, plugin)
+        extractor = plugin.create_extractor()
+        variables = extractor.extract_variables(tree, code)
+
+        assert [v.name for v in variables] == ["MAX", "A", "B"]
+        top = next(v for v in variables if v.name == "MAX")
+        assert top.is_constant is True
+        assert top.receiver_type is None
 
     def test_extract_static_property(self):
         """Test extraction of static property."""
@@ -753,11 +776,12 @@ class TestPHPIntegration:
         imports = extractor.extract_imports(tree, COMPLEX_CLASS_CODE)
 
         # COMPLEX_CLASS_CODE measured with tree-sitter-php 0.24.1:
-        # 2 classes (BaseService/UserService), 6 functions, 4 properties,
+        # 2 classes (BaseService/UserService), 6 functions, 5 variables
+        # (4 properties + the MAX_USERS class const, extracted since #624),
         # 3 imports (use statements, extracted since #617).
         assert len(classes) == 2
         assert len(functions) == 6
-        assert len(variables) == 4
+        assert len(variables) == 5
         assert [i.name for i in imports] == [
             "App\\Repositories\\UserRepository",
             "App\\Events\\UserCreated",

--- a/tests/unit/test_ast_extraction.py
+++ b/tests/unit/test_ast_extraction.py
@@ -837,3 +837,157 @@ class TestRustConstantsCodexP2s:
         syms = _symbols_for(src, "python")
         names = [s["name"] for s in syms if s["kind"] == "constant"]
         assert names == ["SEP"]
+
+
+# ---------------------------------------------------------------------------
+# Issue #624: PHP const declarations indexed as kind="constant"
+# ---------------------------------------------------------------------------
+
+
+_PHP_CONST_SRC = """\
+<?php
+const MAX = 1;
+
+const A = 1, B = 2;
+
+define('LEGACY_MODE', true);
+
+class Config {
+    const MAX_USERS = 1000;
+    public const X = 2;
+    final public const FLAG = 5;
+}
+
+interface Shape {
+    const SIDES = 0;
+}
+
+trait Loggable {
+    const TRAIT_C = 4;
+}
+
+enum Suit: int {
+    case Hearts = 1;
+    const ENUM_C = 9;
+}
+
+function f() {
+    const ILLEGAL_LOCAL = 7;
+    define('RUNTIME_FLAG', 1);
+}
+
+$pad = new class {
+    const ANON_C = 3;
+};
+"""
+
+
+class TestPhpConstants:
+    """Issue #624 — PHP const declarations must reach ast_symbol_rows as
+    kind="constant" (ALL names — PHP ``const`` is compiler-enforced
+    immutable, no name-pattern gate; mirrors the Go #615 / Rust #618
+    reasoning). Class/interface/trait/enum consts ARE captured: addressable
+    as ``Config::MAX_USERS``, like Rust associated consts — their bodies are
+    declaration_list / enum_declaration_list nodes, so the ``enclosed``
+    mechanism keeps them naturally. ``define()`` calls are
+    function_call_expression nodes (runtime registration, not declarations)
+    and stay out — as do function-body consts (illegal PHP that
+    tree-sitter-php still parses as const_declaration)."""
+
+    def _constants(self) -> dict[str, dict]:
+        syms = _symbols_for(_PHP_CONST_SRC, "php")
+        return {s["name"]: s for s in syms if s["kind"] == "constant"}
+
+    def test_exactly_the_ten_constants_extracted(self):
+        consts = self._constants()
+        assert sorted(consts) == [
+            "A",
+            "ANON_C",
+            "B",
+            "ENUM_C",
+            "FLAG",
+            "MAX",
+            "MAX_USERS",
+            "SIDES",
+            "TRAIT_C",
+            "X",
+        ]
+
+    def test_top_level_const_lines_pinned(self):
+        consts = self._constants()
+        assert consts["MAX"]["line"] == 2
+        assert consts["MAX"]["end_line"] == 2
+        assert all(c["language"] == "php" for c in consts.values())
+
+    def test_multi_element_declaration_one_row_each(self):
+        # `const A = 1, B = 2;` — one const_declaration, two const_element
+        # children; each element is its own row (mirrors Go spec handling).
+        consts = self._constants()
+        assert consts["A"]["line"] == 4
+        assert consts["B"]["line"] == 4
+
+    def test_class_consts_captured_decision_pinned(self):
+        # Decision (#624): class consts ARE captured — compiler-enforced
+        # constants addressable as Config::MAX_USERS, like Rust associated
+        # consts (#618), unlike the mutable Python class attributes #612
+        # excludes. Modifiers (public / final public) do not change capture.
+        consts = self._constants()
+        assert consts["MAX_USERS"]["line"] == 9
+        assert consts["X"]["line"] == 10
+        assert consts["FLAG"]["line"] == 11
+
+    def test_interface_trait_enum_consts_captured(self):
+        consts = self._constants()
+        assert consts["SIDES"]["line"] == 15
+        assert consts["TRAIT_C"]["line"] == 19
+        assert consts["ENUM_C"]["line"] == 24
+
+    def test_enum_case_is_not_a_const_row(self):
+        # enum cases are enum_case nodes, not const_element — a different
+        # construct, out of #624 scope (no kind="constant" row).
+        assert "Hearts" not in self._constants()
+
+    def test_define_calls_excluded_decision_pinned(self):
+        # Decision (#624): define() is a function_call_expression — runtime
+        # registration whose name is a string argument (possibly dynamic),
+        # not a declaration. Not indexed.
+        consts = self._constants()
+        assert "LEGACY_MODE" not in consts
+        assert "RUNTIME_FLAG" not in consts
+
+    def test_function_body_const_excluded(self):
+        # PHP has no function-scope const (compile error), but
+        # tree-sitter-php parses it permissively as const_declaration —
+        # the enclosed gate must keep it out.
+        assert "ILLEGAL_LOCAL" not in self._constants()
+
+    def test_top_level_anonymous_class_const_captured(self):
+        # Decision (#624): a top-level anonymous-class const is still a
+        # compiler-enforced class const (addressable via the instance);
+        # captured. Inside a function body it is excluded like any other
+        # function-enclosed const (next test).
+        assert self._constants()["ANON_C"]["line"] == 33
+
+    def test_closure_and_function_nested_consts_excluded(self):
+        src = (
+            "<?php\n"
+            "$c = function () {\n"
+            "    const CLOSURE_LOCAL = 1;\n"
+            "};\n"
+            "function g() {\n"
+            "    $y = new class {\n"
+            "        const FN_ANON = 2;\n"
+            "    };\n"
+            "}\n"
+        )
+        syms = _symbols_for(src, "php")
+        assert [s["name"] for s in syms if s["kind"] == "constant"] == []
+
+    def test_braced_namespace_const_captured(self):
+        # Braced namespace bodies are compound_statement nodes — the scope
+        # gate uses function/closure node types (not compound_statement)
+        # precisely so namespace-scope consts stay captured.
+        src = "<?php\nnamespace App {\n    const NS_CONST = 1;\n}\n"
+        syms = _symbols_for(src, "php")
+        names = [s["name"] for s in syms if s["kind"] == "constant"]
+        assert names == ["NS_CONST"]

--- a/tests/unit/test_ast_extraction.py
+++ b/tests/unit/test_ast_extraction.py
@@ -991,3 +991,43 @@ class TestPhpConstants:
         syms = _symbols_for(src, "php")
         names = [s["name"] for s in syms if s["kind"] == "constant"]
         assert names == ["NS_CONST"]
+
+
+class _PhpStubNode:
+    """Minimal node stand-in (explicit parent, no MagicMock chains)."""
+
+    def __init__(self, type_, children=(), fields=None):
+        self.type = type_
+        self.children = list(children)
+        self._fields = fields or {}
+        self.parent = None
+        self.start_point = (0, 0)
+        self.end_point = (0, 0)
+
+    def child_by_field_name(self, name):
+        return self._fields.get(name)
+
+
+class TestPhpConstantsGuards:
+    """Cover defensive branches unreachable from valid PHP source (codecov)."""
+
+    def test_nameless_const_element_skipped(self):
+        from tree_sitter_analyzer._ast_extraction import _php_constants
+
+        nameless = _PhpStubNode("const_element", children=[])
+        decl = _PhpStubNode("const_declaration", children=[nameless])
+        assert _php_constants(decl, "") == []
+
+    def test_php_helper_name_field_fast_path(self):
+        from tree_sitter_analyzer.languages.php_helpers import (
+            _build_php_constant_variable,
+        )
+
+        name = _PhpStubNode("name")
+        element = _PhpStubNode("const_element", fields={"name": name})
+        decl = _PhpStubNode("const_declaration", children=[element])
+        var = _build_php_constant_variable(
+            decl, element, "", lambda n: "FAST", lambda n: [], lambda n: []
+        )
+        assert var is not None
+        assert var.name == "FAST"

--- a/tests/unit/test_symbols_json_enrichment.py
+++ b/tests/unit/test_symbols_json_enrichment.py
@@ -136,11 +136,12 @@ class TestReturnTypeAndParamsSerialized:
 
 
 class TestExtractorVersionBump:
-    def test_extractor_version_is_6_in_both_sites(self):
+    def test_extractor_version_is_7_in_both_sites(self):
+        # v7: #624 — PHP const declarations extracted as kind="constant".
         from tree_sitter_analyzer import _ast_cache_indexer, ast_cache
 
-        assert ast_cache._AST_CACHE_EXTRACTOR_VERSION == 6
-        assert _ast_cache_indexer._AST_CACHE_EXTRACTOR_VERSION == 6
+        assert ast_cache._AST_CACHE_EXTRACTOR_VERSION == 7
+        assert _ast_cache_indexer._AST_CACHE_EXTRACTOR_VERSION == 7
 
 
 class TestCodexP2sOn621:

--- a/tree_sitter_analyzer/_ast_cache_indexer.py
+++ b/tree_sitter_analyzer/_ast_cache_indexer.py
@@ -24,7 +24,8 @@ logger = logging.getLogger(__name__)
 # v4: #613 — Go package-level const/var specs extracted as kind="constant".
 # v5: #613 — Rust const/static items extracted as kind="constant".
 # v6: #614 — docstring/return_type/params serialized into symbols_json.
-_AST_CACHE_EXTRACTOR_VERSION = 6
+# v7: #624 — PHP const declarations extracted as kind="constant".
+_AST_CACHE_EXTRACTOR_VERSION = 7
 
 
 def check_cache_or_read(

--- a/tree_sitter_analyzer/_ast_extraction.py
+++ b/tree_sitter_analyzer/_ast_extraction.py
@@ -291,6 +291,62 @@ _RUST_CONST_LIKE = frozenset({"const_item", "static_item"})
 # scope — and deliberately absent.
 _RUST_SCOPE_BODY_NODES = frozenset({"function_item", "closure_expression", "block"})
 
+# Issue #624 — PHP const declarations, same shape as #610/#615/#618.
+# tree-sitter-php emits ``const_declaration`` (the node type already sits in
+# _VAR_DECL_LIKE via Go's grammar) but the names live on ``const_element``
+# children which carry NO ``name`` field — the identifier is a bare ``name``
+# child — so the _VAR_DECL_LIKE name gate never matched and no rows were
+# produced. ALL names are captured — PHP ``const`` is compiler-enforced
+# immutable, so no const-style name gate (mirrors the Go/Rust reasoning).
+# Class/interface/trait/enum consts ARE captured (deliberate): addressable as
+# ``Config::MAX_USERS`` like Rust associated consts; their bodies are
+# declaration_list / enum_declaration_list nodes, not function scopes, so the
+# ``enclosed`` mechanism keeps them naturally. ``define()`` calls are
+# function_call_expression nodes — runtime registration whose name is a
+# string argument, not a declaration — and stay out of scope.
+
+# Nodes that open a function scope in PHP (PHP analogue of the other
+# _*_SCOPE_BODY_NODES sets, feeding the same top-down ``enclosed`` flag).
+# PHP has no legal function-scope const, but tree-sitter-php parses one
+# permissively as const_declaration, so the gate is still required. Braced
+# namespace bodies are ``compound_statement`` nodes — the gate keys on the
+# function/closure declaration node types (not compound_statement) precisely
+# so namespace-scope consts stay captured.
+_PHP_SCOPE_BODY_NODES = frozenset(
+    {
+        "function_definition",
+        "method_declaration",
+        "anonymous_function",
+        "arrow_function",
+    }
+)
+
+
+def _php_constants(node: Any, source: str) -> list[dict[str, Any]]:
+    """Return kind="constant" symbols for a PHP const_declaration, one row
+    per ``const_element`` (``const A = 1, B = 2;`` yields two rows).
+
+    The caller guarantees the declaration is not enclosed in a function
+    body (#624 scope rule).
+    """
+    out: list[dict[str, Any]] = []
+    for child in node.children:
+        if child.type != "const_element":
+            continue
+        name_node = next((c for c in child.children if c.type == "name"), None)
+        if name_node is None:
+            continue
+        out.append(
+            {
+                "kind": "constant",
+                "name": _node_text(name_node, source),
+                "line": child.start_point[0] + 1,
+                "end_line": child.end_point[0] + 1,
+                "language": "php",
+            }
+        )
+    return out
+
 
 def _python_module_constant(node: Any, source: str) -> dict[str, Any] | None:
     """Return a kind="constant" symbol for a module-scope Python assignment,
@@ -667,9 +723,9 @@ def _walk_for_symbols(
 
     ``enclosed`` tracks (top-down, no parent walking) whether *node* sits
     inside a Python function/class body (#610), a Go function body (#613),
-    or a Rust function/closure body (#613) — module/package-constant capture
-    must fire at top-level scope only, including ``if``/``try``-wrapped
-    module-level assignments.
+    a Rust function/closure body (#613), or a PHP function/closure body
+    (#624) — module/package-constant capture must fire at top-level scope
+    only, including ``if``/``try``-wrapped module-level assignments.
     """
     if depth > 20:
         return
@@ -778,6 +834,8 @@ def _walk_for_symbols(
                 "language": "rust",
             }
         )
+    elif node_type == "const_declaration" and language == "php" and not enclosed:
+        symbols.extend(_php_constants(node, source))
     # Language-gated: Rust needs "block" in its scope set (const-initializer
     # block expressions, Codex P2 on #618), but Python's if/try bodies are
     # also "block" nodes — a shared set would break the #612 guarantee that
@@ -786,6 +844,7 @@ def _walk_for_symbols(
         (language == "python" and node_type in _PY_SCOPE_BODY_NODES)
         or (language == "go" and node_type in _GO_SCOPE_BODY_NODES)
         or (language == "rust" and node_type in _RUST_SCOPE_BODY_NODES)
+        or (language == "php" and node_type in _PHP_SCOPE_BODY_NODES)
     )
     for child in node.children:
         _walk_for_symbols(child, source, symbols, language, depth + 1, child_enclosed)

--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -63,7 +63,8 @@ logger = logging.getLogger(__name__)
 # v4: #613 — Go package-level const/var specs extracted as kind="constant".
 # v5: #613 — Rust const/static items extracted as kind="constant".
 # v6: #614 — docstring/return_type/params serialized into symbols_json.
-_AST_CACHE_EXTRACTOR_VERSION = 6
+# v7: #624 — PHP const declarations extracted as kind="constant".
+_AST_CACHE_EXTRACTOR_VERSION = 7
 
 
 class SchemaIntegrityError(RuntimeError):

--- a/tree_sitter_analyzer/languages/php_helpers.py
+++ b/tree_sitter_analyzer/languages/php_helpers.py
@@ -465,7 +465,13 @@ def _build_php_constant_variable(
     visibility: str,
 ) -> Variable | None:
     """Build a ``Variable`` from one ``const_element`` AST child."""
+    # tree-sitter-php const_element carries NO ``name`` field — the
+    # identifier is a bare ``name`` child (#624; the field lookup silently
+    # dropped every const). Keep the field lookup first for grammar
+    # forward-compatibility, then fall back to the child scan.
     name_node = element_node.child_by_field_name("name")
+    if name_node is None:
+        name_node = next((c for c in element_node.children if c.type == "name"), None)
     if name_node is None:
         return None
     name = get_node_text(name_node)

--- a/tree_sitter_analyzer/languages/php_plugin.py
+++ b/tree_sitter_analyzer/languages/php_plugin.py
@@ -311,12 +311,15 @@ class PHPElementExtractor(ElementExtractor):
                 var_elems = self._extract_constant_elements(node, parent_class)
                 variables.extend(var_elems)
 
-            # Track parent class
+            # Track parent class — enums may declare consts too (Codex P2
+            # on #625): without enum_declaration here, an enum const emits
+            # with receiver_type=None and masquerades as a global.
             new_parent = parent_class
             if node.type in (
                 "class_declaration",
                 "interface_declaration",
                 "trait_declaration",
+                "enum_declaration",
             ):
                 name_node = node.child_by_field_name("name")
                 if name_node:


### PR DESCRIPTION
Closes #624 — PHP half of the constants family (#612 Python / #615 Go / #618 Rust), plus the plugin-surface MAX_USERS gap noted in #619.

## Root cause (both surfaces, same family as #617/#619)
`const_element` has NO `name` field in tree-sitter-php — the walker's name-field gate made `const_declaration` (already in _VAR_DECL_LIKE) permanently invisible, and the plugin's `_build_php_constant_variable` silently dropped every class const the same way.

## Scope (mirrors the family precedents, each pinned)
- Top-level const: ALL names (compiler-enforced, Go reasoning)
- Class/interface/trait/enum consts: captured (`Config::MAX_USERS`, Rust associated-const reasoning)
- Function-body consts excluded via `_PHP_SCOPE_BODY_NODES` (keyed on function node types so braced-namespace consts stay captured); `define()` skipped (runtime call, dynamic names); multi-element declarations → one row each
- `_AST_CACHE_EXTRACTOR_VERSION` 6→7 (both sites); plugin surface fixed in 6 lines (field-then-child-scan, #617 pattern)

## Test plan
- [x] RED-first: 7+2 failed pre-fix → all green; regression 258 + edge_store 22 + golden -k php (-n 0)
- [x] Conscious re-pins: class-const names 4→5, variables 4→5, version 6→7; golden php.json Variable 9→12 (+exactly the 3 Sample.php consts) — every line explained
- [x] E2E probe: 5 constant rows, define()/fn-body leakage = 0 — pasted
- [x] Ratchet exit=0; ruff/mypy clean
- [x] Lead independently re-ran 134 tests + verified both version sites + push diff=0