### PR TITLE
test: ratchet batch-22 — pin 33 loose assertions in top-4 AST-ranked files

### DIFF
--- a/scripts/loose_assertion_baseline.txt
+++ b/scripts/loose_assertion_baseline.txt
@@ -43,7 +43,9 @@
 #   files).
 #   batch-21 (AST): 780 -> 744, 2026-06-13 (36 pins in top-4 AST-ranked
 #   files).
+#   batch-22 (AST): 744 -> 711, 2026-06-13 (30 exact pins + 3 timing
+#   exemptions in top-4 AST-ranked files).
 
-BASELINE_COUNT=744
+BASELINE_COUNT=711
 MEASUREMENT_DATE=2026-06-13
 MEASUREMENT_COMMAND="uv run python scripts/check_loose_assertions.py --baseline"

--- a/tests/integration/cli/test_cli_commands.py
+++ b/tests/integration/cli/test_cli_commands.py
@@ -128,7 +128,7 @@ class TestCLIInfoCommands:
             main()
 
         error_output = mock_stderr.getvalue()
-        assert len(error_output) > 0
+        assert error_output == "ERROR: File path not specified.\n"
 
 
 class TestCLIQueryCommands:
@@ -231,7 +231,9 @@ public class TestClass {
             main()
 
         output = mock_stdout.getvalue()
-        assert len(output) > 0
+        assert '"language": "java"' in output
+        assert '"class_count": 1' in output
+        assert '"method_count": 1' in output
 
     def test_analyze_with_query_key(self, monkeypatch, temp_java_file):
         """Test analyzing file with specific query"""
@@ -255,7 +257,8 @@ public class TestClass {
             main()
 
         output = mock_stdout.getvalue()
-        assert len(output) > 0
+        assert '"match_count": 1' in output
+        assert '"name": "TestClass"' in output
 
     def test_analyze_with_custom_query(self, monkeypatch, temp_java_file):
         """Test analyzing file with custom query string"""
@@ -280,7 +283,9 @@ public class TestClass {
             main()
 
         output = mock_stdout.getvalue()
-        assert len(output) > 0
+        assert '"capture_name": "class-name"' in output
+        assert '"content": "TestClass"' in output
+        assert '"match_count": 1' in output
 
     def test_output_format_json(self, monkeypatch, temp_java_file):
         """Test JSON output format"""
@@ -330,7 +335,9 @@ public class TestClass {
             main()
 
         output = mock_stdout.getvalue()
-        assert len(output) > 0
+        assert "--- Advanced Analysis Results ---" in output
+        assert "Classes: 1" in output
+        assert "Methods: 1" in output
 
 
 class TestCLILanguageHandling:
@@ -359,7 +366,8 @@ class TestCLILanguageHandling:
                 main()
 
             output = mock_stdout.getvalue()
-            assert len(output) > 0
+            assert '"language": "python"' in output
+            assert '"method_count": 1' in output
         finally:
             Path(temp_path).unlink(missing_ok=True)
 
@@ -392,10 +400,13 @@ class TestCLILanguageHandling:
             with contextlib.suppress(SystemExit):
                 main()
 
-            # CLI now emits "Language explicitly specified: java" plus
-            # a usage hint on stderr when no query/--advanced is given.
-            # Accept either stdout (legacy) or stderr (current).
-            assert len(mock_stdout.getvalue()) > 0 or len(mock_stderr.getvalue()) > 0
+            # CLI emits "Language explicitly specified: java" plus a usage
+            # hint on stderr when no query/--advanced is given; stdout is
+            # empty (the machine-readable channel stays clean).
+            assert mock_stdout.getvalue() == ""
+            error_output = mock_stderr.getvalue()
+            assert "Language explicitly specified: java" in error_output
+            assert "Please specify a query or --advanced option" in error_output
         finally:
             Path(temp_path).unlink(missing_ok=True)
 
@@ -447,8 +458,10 @@ class TestCLIErrorHandling:
                 main()
 
             error_output = mock_stderr.getvalue()
-            # This assertion depends on specific error message
-            assert len(error_output) > 0
+            assert (
+                "Query 'invalid_query_key' not found for language 'java'"
+                in error_output
+            )
         finally:
             Path(temp_path).unlink(missing_ok=True)
 

--- a/tests/integration/formatters/test_comprehensive_format_validation.py
+++ b/tests/integration/formatters/test_comprehensive_format_validation.py
@@ -182,11 +182,14 @@ class TestComprehensiveFormatValidation:
             mock_analyzer_function, test_data_sources
         )
 
-        assert results.total_tests > 0
+        # 13 = golden master + schema + spec compliance + format contract +
+        # enhanced assertion phases over 1 data source (exact fact; update
+        # when suite phases change)
+        assert results.total_tests == 13
         # execution_time_seconds可能为0（测试执行非常快时）
-        assert results.execution_time_seconds >= 0
+        assert results.execution_time_seconds >= 0  # ratchet: nondeterministic timing
         assert results.timestamp is not None
-        assert 0 <= results.success_rate <= 100
+        assert results.success_rate == 100.0
 
     def test_mock_analyzer_function_formats(self):
         """Test mock analyzer function produces expected formats"""
@@ -318,8 +321,12 @@ class TestComprehensiveFormatValidation:
         assert "compact" in results
         assert results["full"].success is True
         assert results["compact"].success is True
-        assert results["full"].execution_time_ms >= 0
-        assert results["compact"].execution_time_ms >= 0
+        assert (
+            results["full"].execution_time_ms >= 0
+        )  # ratchet: nondeterministic timing
+        assert (
+            results["compact"].execution_time_ms >= 0
+        )  # ratchet: nondeterministic timing
 
     @pytest.mark.asyncio
     async def test_test_data_manager(self, temp_results_dir):
@@ -334,7 +341,9 @@ class TestComprehensiveFormatValidation:
         assert test_data.metadata.language == "python"
         assert test_data.metadata.complexity_level == "simple"
         assert test_data.source_code is not None
-        assert len(test_data.source_code) > 0
+        # Generated python/simple template has a fixed shape: random name
+        # suffixes are fixed-length (k=5), so the total length is exact
+        assert len(test_data.source_code) == 135
 
         # Store test data
         test_id = manager.repository.store_test_data(test_data)
@@ -438,10 +447,11 @@ class TestFormatRegressionPrevention:
             compact_output = mock_analyzer_function(test_case, "compact")
             csv_output = mock_analyzer_function(test_case, "csv")
 
-            # Basic consistency checks
-            assert len(full_output) > 0
-            assert len(compact_output) > 0
-            assert len(csv_output) > 0
+            # Mock analyzer output is input-independent: exact sizes per
+            # format (update when mock_analyzer_function templates change)
+            assert len(full_output) == 355
+            assert len(compact_output) == 91
+            assert len(csv_output) == 125
 
             # Format-specific checks
             assert "# Analysis Results" in full_output

--- a/tests/unit/core/test_queries_c.py
+++ b/tests/unit/core/test_queries_c.py
@@ -64,7 +64,7 @@ class TestCQueries:
         """Test getting all queries"""
         all_queries = get_all_queries()
         assert isinstance(all_queries, dict)
-        assert len(all_queries) > 0
+        assert len(all_queries) == 54
         assert "function" in all_queries
         assert "query" in all_queries["function"]
         assert "description" in all_queries["function"]
@@ -73,7 +73,7 @@ class TestCQueries:
         """Test listing all query names"""
         query_names = list_queries()
         assert isinstance(query_names, list)
-        assert len(query_names) > 0
+        assert len(query_names) == 54
         assert "function" in query_names
         assert "struct" in query_names
 
@@ -81,45 +81,53 @@ class TestCQueries:
         """Test getting available C queries"""
         available_queries = get_available_c_queries()
         assert isinstance(available_queries, list)
-        assert len(available_queries) > 0
+        assert len(available_queries) == 49
         assert "function" in available_queries
         assert "struct" in available_queries
 
     def test_c_queries_structure(self) -> None:
         """Test C_QUERIES dictionary structure"""
         assert isinstance(C_QUERIES, dict)
-        assert len(C_QUERIES) > 0
+        assert len(C_QUERIES) == 49
 
-        essential_queries = [
-            "function",
-            "struct",
-            "enum",
-            "variable",
-            "include",
-            "define",
-            "typedef",
-            "if_statement",
-        ]
-        for query_name in essential_queries:
+        # Exact stripped lengths (update when query strings change)
+        essential_query_lens = {
+            "function": 31,
+            "struct": 26,
+            "enum": 22,
+            "variable": 23,
+            "include": 26,
+            "define": 21,
+            "typedef": 26,
+            "if_statement": 28,
+        }
+        for query_name, expected_len in essential_query_lens.items():
             assert query_name in C_QUERIES
             assert isinstance(C_QUERIES[query_name], str)
-            assert len(C_QUERIES[query_name].strip()) > 0
+            assert len(C_QUERIES[query_name].strip()) == expected_len
 
     def test_c_query_descriptions_structure(self) -> None:
         """Test C_QUERY_DESCRIPTIONS dictionary structure"""
         assert isinstance(C_QUERY_DESCRIPTIONS, dict)
-        assert len(C_QUERY_DESCRIPTIONS) > 0
+        assert len(C_QUERY_DESCRIPTIONS) == 49
 
-        essential_queries = ["function", "struct", "enum", "variable", "include"]
-        for query_name in essential_queries:
+        # Exact stripped lengths (update when descriptions change)
+        essential_description_lens = {
+            "function": 30,
+            "struct": 29,
+            "enum": 27,
+            "variable": 31,
+            "include": 28,
+        }
+        for query_name, expected_len in essential_description_lens.items():
             assert query_name in C_QUERY_DESCRIPTIONS
             assert isinstance(C_QUERY_DESCRIPTIONS[query_name], str)
-            assert len(C_QUERY_DESCRIPTIONS[query_name].strip()) > 0
+            assert len(C_QUERY_DESCRIPTIONS[query_name].strip()) == expected_len
 
     def test_all_queries_structure(self) -> None:
         """Test ALL_QUERIES dictionary structure"""
         assert isinstance(ALL_QUERIES, dict)
-        assert len(ALL_QUERIES) > 0
+        assert len(ALL_QUERIES) == 54
 
         for query_data in ALL_QUERIES.values():
             assert isinstance(query_data, dict)

--- a/tests/unit/formatters/test_markdown_formatter_helpers.py
+++ b/tests/unit/formatters/test_markdown_formatter_helpers.py
@@ -4,7 +4,6 @@ from tree_sitter_analyzer.formatters.markdown_formatter import MarkdownFormatter
 
 
 class TestFormatTable:
-
     def test_format_table_basic(self):
         formatter = MarkdownFormatter()
         analysis_result = {
@@ -418,7 +417,6 @@ class TestFormatTable:
 
 
 class TestFormatAnalysisResult:
-
     def test_format_analysis_result(self):
         formatter = MarkdownFormatter()
 
@@ -492,7 +490,6 @@ class TestFormatAnalysisResult:
 
 
 class TestCollectImages:
-
     def test_collect_images_basic(self):
         formatter = MarkdownFormatter()
         elements = [
@@ -586,11 +583,11 @@ class TestCollectImages:
 
         images = formatter._collect_images(elements)
 
-        assert len(images) >= 1
+        assert len(images) == 1
+        assert images[0]["alt"] == "Test"
 
 
 class TestCalculateDocumentComplexity:
-
     def test_complexity_simple(self):
         formatter = MarkdownFormatter()
         headers = [{"level": 1}]
@@ -658,7 +655,6 @@ class TestCalculateDocumentComplexity:
 
 
 class TestComputeRobustCounts:
-
     @patch("tree_sitter_analyzer.encoding_utils.read_file_safe")
     def test_compute_robust_counts_basic(self, mock_read):
         formatter = MarkdownFormatter()
@@ -669,20 +665,20 @@ class TestComputeRobustCounts:
 
         counts = formatter._compute_robust_counts_from_file("test.md")
 
-        assert counts["link_count"] >= 1
-        assert counts["image_count"] >= 1
+        assert counts["link_count"] == 1
+        assert counts["image_count"] == 1
 
     @patch("tree_sitter_analyzer.encoding_utils.read_file_safe")
     def test_compute_robust_counts_autolinks(self, mock_read):
         formatter = MarkdownFormatter()
         mock_read.return_value = (
-            "<http://example.com>\n<mailto:test@example.com>",
+            "<http://example.com>\n<mailto:test@example.com>",  # pragma: allowlist secret
             None,
         )
 
         counts = formatter._compute_robust_counts_from_file("test.md")
 
-        assert counts["link_count"] >= 2
+        assert counts["link_count"] == 2
 
     @patch("tree_sitter_analyzer.encoding_utils.read_file_safe")
     def test_compute_robust_counts_reference_links(self, mock_read):
@@ -694,7 +690,7 @@ class TestComputeRobustCounts:
 
         counts = formatter._compute_robust_counts_from_file("test.md")
 
-        assert counts["link_count"] >= 1
+        assert counts["link_count"] == 1
 
     @patch("tree_sitter_analyzer.encoding_utils.read_file_safe")
     def test_compute_robust_counts_image_references(self, mock_read):
@@ -703,7 +699,10 @@ class TestComputeRobustCounts:
 
         counts = formatter._compute_robust_counts_from_file("test.md")
 
-        assert counts["image_count"] >= 1
+        # 2 = the ![Alt][imgref] reference + its used [imgref]: definition
+        # (count_markdown_images counts both; exact fact, update if the
+        # counting rules change)
+        assert counts["image_count"] == 2
 
     @patch("tree_sitter_analyzer.encoding_utils.read_file_safe")
     def test_compute_robust_counts_mixed_content(self, mock_read):
@@ -721,8 +720,11 @@ class TestComputeRobustCounts:
 
         counts = formatter._compute_robust_counts_from_file("test.md")
 
-        assert counts["link_count"] > 0
-        assert counts["image_count"] > 0
+        # links: Link1 inline + Link2 reference + autolink = 3
+        # images: Image1 inline + Image2 reference = 2 (indented [imgref]:
+        # definition lines do not match the ^-anchored definition pattern)
+        assert counts["link_count"] == 3
+        assert counts["image_count"] == 2
 
     @patch("tree_sitter_analyzer.encoding_utils.read_file_safe")
     def test_compute_robust_counts_file_read_error(self, mock_read):
@@ -756,11 +758,11 @@ class TestComputeRobustCounts:
 
         counts = formatter._compute_robust_counts_from_file("test.md")
 
-        assert counts["image_count"] >= 4
+        assert counts["image_count"] == 4
+        assert counts["link_count"] == 1
 
 
 class TestFormatJsonOutput:
-
     def test_format_json_output_basic(self):
         formatter = MarkdownFormatter()
         data = {"key": "value", "number": 42}


### PR DESCRIPTION
## Summary
Loose-assertion ratchet batch 22. Top-4 (1 at 9 + first 3 of a 7-way tie at 8, lexicographic):

| File | Resolved |
|---|---|
| tests/unit/formatters/test_markdown_formatter_helpers.py | 9 pins |
| tests/integration/cli/test_cli_commands.py | 8 pins |
| tests/integration/formatters/test_comprehensive_format_validation.py | 5 pins + 3 timing exemptions |
| tests/unit/core/test_queries_c.py | 8 pins |

Baseline: **744 → 711** (= exactly 33, lead re-verified live).

Highlights: CLI `len(output) > 0` upgraded to exact content pins (temp paths make length pins nondeterministic — content is strictly stronger); a 恒真 `stdout>0 OR stderr>0` replaced with exact message pins; 3 `execution_time >= 0` kept as documented timing exemptions (the legitimate class); markdown image-ref pin measured at the ACTIVATED value (==2, both ref and used definition counted — step A); detect-secrets false-positive on a pre-existing mailto fixture handled with pragma allowlist.

## Test plan
- [x] All 4 files individually `-n 0`: 39/20/16+1skip/19 passed (re-run post-ruff-format; zero new skips)
- [x] Diff gate exit=0
- [x] `--baseline` measures 711 == recorded (lead independently re-verified)