### PR TITLE
fix(index): JS/TS function-local variables no longer over-captured

### DIFF
--- a/tests/unit/test_ast_extraction.py
+++ b/tests/unit/test_ast_extraction.py
@@ -1152,3 +1152,18 @@ class TestJsTsLocalVariableContraction:
         # locals must still be captured by this change.
         src = "class A { void m() { int local = 1; } }\n"
         assert self._variables(src, "java") == ["local"]
+
+
+class TestJsTsErrorRegionHardening:
+    """Codex P2 on #629: declarations inside error-recovered regions have
+    undecidable scope — they must not be emitted (better unindexed than a
+    function-local masquerading as a module symbol)."""
+
+    def test_declaration_inside_error_node_not_emitted(self):
+        # Deliberately broken TSX-ish source that forces ERROR recovery at
+        # the point of the declaration.
+        src = "const Comp = () => {\n  const Math = 1;\n  return <div//;\n};\nconst TOP = 2;\n"
+        syms = _symbols_for(src, "typescript")
+        names = [s["name"] for s in syms if s["kind"] == "variable"]
+        assert "Math" not in names
+        assert "TOP" in names

--- a/tests/unit/test_ast_extraction.py
+++ b/tests/unit/test_ast_extraction.py
@@ -1031,3 +1031,124 @@ class TestPhpConstantsGuards:
         )
         assert var is not None
         assert var.name == "FAST"
+
+
+# ---------------------------------------------------------------------------
+# Issue #626: JS/TS function-local variables no longer over-captured
+# ---------------------------------------------------------------------------
+
+
+_JSTS_JS_SRC = """\
+const TOP_CONST = 1;
+let topLet = 2;
+var topVar = 3;
+if (flag) { const ifWrapped = 4; }
+try { const tryWrapped = 5; } catch (e) { const catchLocal = 6; }
+function f() { const localInFunc = 7; var hoisted = 8; }
+const fexpr = function () { const localInFexpr = 9; };
+const arrow = () => { const localInArrow = 10; };
+function* gen() { const localInGen = 11; }
+const genExpr = function* () { const localInGenExpr = 12; };
+class C {
+  m() { const localInMethod = 13; }
+  static { const staticBlockLocal = 14; }
+}
+"""
+
+_JSTS_TS_SRC = """\
+const TOP_CONST = 1;
+let topLet = 2;
+var topVar = 3;
+namespace NS {
+  const nsConst = 4;
+  export const NS_EXPORTED = 5;
+}
+module M { const mConst = 6; }
+declare module "ext" { const ambientConst: number; }
+function f(): void { const localInFunc = 7; }
+class C { m(): void { const localInMethod = 8; } }
+const arrow = (): void => { const localInArrow = 9; };
+"""
+
+
+class TestJsTsLocalVariableContraction:
+    """Issue #626 — JS/TS function-local declarators must NOT reach
+    ast_symbol_rows; module/top-level (incl. if/try-wrapped, #612 guarantee)
+    and TS namespace-level declarators stay kind="variable"."""
+
+    def _variables(self, src: str, lang: str) -> list[str]:
+        return sorted(
+            s["name"] for s in _symbols_for(src, lang) if s["kind"] == "variable"
+        )
+
+    def test_js_exactly_the_module_level_declarators_survive(self):
+        # catchLocal: a module-level catch block is a statement_block outside
+        # any function — kept by design (statement_block deliberately absent
+        # from the scope set, preserving the #612 if/try guarantee).
+        assert self._variables(_JSTS_JS_SRC, "javascript") == [
+            "TOP_CONST",
+            "arrow",
+            "catchLocal",
+            "fexpr",
+            "genExpr",
+            "ifWrapped",
+            "topLet",
+            "topVar",
+            "tryWrapped",
+        ]
+
+    def test_js_function_and_generator_locals_dropped(self):
+        names = self._variables(_JSTS_JS_SRC, "javascript")
+        for local in (
+            "localInFunc",
+            "hoisted",
+            "localInFexpr",
+            "localInGen",
+            "localInGenExpr",
+        ):
+            assert local not in names
+
+    def test_js_arrow_method_and_static_block_locals_dropped(self):
+        names = self._variables(_JSTS_JS_SRC, "javascript")
+        for local in ("localInArrow", "localInMethod", "staticBlockLocal"):
+            assert local not in names
+
+    def test_ts_module_and_namespace_level_declarators_survive(self):
+        assert self._variables(_JSTS_TS_SRC, "typescript") == [
+            "NS_EXPORTED",
+            "TOP_CONST",
+            "ambientConst",
+            "arrow",
+            "mConst",
+            "nsConst",
+            "topLet",
+            "topVar",
+        ]
+
+    def test_ts_locals_dropped(self):
+        names = self._variables(_JSTS_TS_SRC, "typescript")
+        for local in ("localInFunc", "localInMethod", "localInArrow"):
+            assert local not in names
+
+    def test_tsx_maps_to_typescript_language_id(self):
+        # The ast_cache path only ever delivers "javascript"/"typescript" for
+        # this family — .tsx (and .jsx -> "javascript") included — so the
+        # language gate on those two ids covers every indexed file.
+        from tree_sitter_analyzer._lang_extension_map import EXT_TO_LANG
+
+        assert EXT_TO_LANG[".tsx"] == "typescript"
+        assert EXT_TO_LANG[".jsx"] == "javascript"
+
+    def test_tsx_shaped_source_contracts_under_typescript_id(self):
+        # JSX-free .tsx content goes down the identical typescript path.
+        # (Known limitation, NOT pinned: .tsx WITH JSX is parsed by the
+        # typescript grammar — ERROR recovery flattens function bodies, so
+        # locals in broken regions may survive; pre-existing, outside #626.)
+        src = "const TOP = 1;\nfunction Comp() { const inner = 2; }\n"
+        assert self._variables(src, "typescript") == ["TOP"]
+
+    def test_java_locals_unaffected(self):
+        # Java is the separate follow-up PR (#626 part 2) — its function
+        # locals must still be captured by this change.
+        src = "class A { void m() { int local = 1; } }\n"
+        assert self._variables(src, "java") == ["local"]

--- a/tests/unit/test_javascript_method_resolution.py
+++ b/tests/unit/test_javascript_method_resolution.py
@@ -495,3 +495,97 @@ def test_no_cross_language_builtin_suppression_ignores_foreign_owner() -> None:
         "builtin",
         "",
     )
+
+
+# ---------------------------------------------------------------------------
+# Issue #626 — shadow gate narrowed to module-scope variables (approved as a
+# precision gain): function-local declarators no longer reach
+# ast_symbol_rows, so the project-wide JS builtin-shadow set sees module-
+# level shadows only.
+# ---------------------------------------------------------------------------
+def _index_js(tmp_path, files: dict[str, str]):
+    """Index *files* into a tmp project; return a row-factory sqlite conn."""
+    import sqlite3
+
+    from tree_sitter_analyzer.ast_cache import ASTCache
+
+    for name, body in files.items():
+        (tmp_path / name).write_text(body)
+    cache = ASTCache(str(tmp_path))
+    try:
+        cache.index_project()
+    finally:
+        cache.close()
+    conn = sqlite3.connect(str(tmp_path / ".ast-cache" / "index.db"))
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def test_shadow_set_from_cache_is_module_scope_only(tmp_path) -> None:
+    """SET-CONSTRUCTION pin through the real cache (#626): a module-level
+    ``const Math = {...}`` enters the shadow set; a function-local
+    ``const Map = ...`` no longer does (before #626 both did)."""
+    from tree_sitter_analyzer.synapse_resolver.languages.javascript import (
+        _js_shadowed_globals_from_conn,
+    )
+
+    conn = _index_js(
+        tmp_path,
+        {
+            "app.js": (
+                "const Math = { max(x) { return x; } };\n"
+                "function f() { const Map = 1; }\n"
+            ),
+        },
+    )
+    try:
+        assert _js_shadowed_globals_from_conn(conn, {}) == frozenset({"Math"})
+    finally:
+        conn.close()
+
+
+def test_module_level_variable_shadow_still_suppresses_builtin(tmp_path) -> None:
+    """FULL INDEX PATH (#626 keep-side): module-scope ``const Math = {...}``
+    must still suppress the terminal ``builtin`` tier for ``Math.max()``."""
+    conn = _index_js(
+        tmp_path,
+        {
+            "app.js": (
+                "const Math = { max(x) { return x; } };\n"
+                "function g() { Math.max(1); }\n"
+            ),
+        },
+    )
+    try:
+        rows = conn.execute(
+            "SELECT callee_resolution FROM edges "
+            "WHERE kind = 'calls' AND callee_name = 'max'"
+        ).fetchall()
+    finally:
+        conn.close()
+    res = [r["callee_resolution"] for r in rows]
+    assert res, "expected a Math.max() edge"
+    assert "builtin" not in res
+
+
+def test_function_local_shadow_no_longer_suppresses_builtin(tmp_path) -> None:
+    """FULL INDEX PATH (#626 precision gain): a function-local ``const Math``
+    in ANOTHER file used to suppress builtin classification project-wide
+    (the set is file-insensitive); after the contraction ``Math.max()``
+    classifies ``builtin`` again."""
+    conn = _index_js(
+        tmp_path,
+        {
+            "shadow.js": "function f() { const Math = { max(x) { return x; } }; }\n",
+            "caller.js": "function g() { Math.max(1); }\n",
+        },
+    )
+    try:
+        rows = conn.execute(
+            "SELECT callee_resolution FROM edges "
+            "WHERE kind = 'calls' AND callee_name = 'max'"
+        ).fetchall()
+    finally:
+        conn.close()
+    res = [r["callee_resolution"] for r in rows]
+    assert res == ["builtin"]

--- a/tests/unit/test_symbols_json_enrichment.py
+++ b/tests/unit/test_symbols_json_enrichment.py
@@ -136,12 +136,12 @@ class TestReturnTypeAndParamsSerialized:
 
 
 class TestExtractorVersionBump:
-    def test_extractor_version_is_7_in_both_sites(self):
-        # v7: #624 — PHP const declarations extracted as kind="constant".
+    def test_extractor_version_is_8_in_both_sites(self):
+        # v8: #626 — JS/TS function-local variables no longer over-captured.
         from tree_sitter_analyzer import _ast_cache_indexer, ast_cache
 
-        assert ast_cache._AST_CACHE_EXTRACTOR_VERSION == 7
-        assert _ast_cache_indexer._AST_CACHE_EXTRACTOR_VERSION == 7
+        assert ast_cache._AST_CACHE_EXTRACTOR_VERSION == 8
+        assert _ast_cache_indexer._AST_CACHE_EXTRACTOR_VERSION == 8
 
 
 class TestCodexP2sOn621:

--- a/tests/unit/test_typescript_method_resolution.py
+++ b/tests/unit/test_typescript_method_resolution.py
@@ -453,3 +453,49 @@ def test_integration_no_cross_language_mis_wire(tmp_path: Path) -> None:
             "(cross-language mis-wire — the CodeGraph failure)"
         )
         assert r["callee_resolution"] in ("local", "project", "unknown")
+
+
+# ---------------------------------------------------------------------------
+# Issue #626 — per-file TS shadow map narrowed to module/namespace-scope
+# variables (approved as a precision gain): function-local declarators no
+# longer reach symbols_json, so they stop suppressing the builtin tier.
+# ---------------------------------------------------------------------------
+def test_shadow_locals_from_cache_are_module_scope_only(tmp_path: Path) -> None:
+    """SET-CONSTRUCTION pin through the real cache (#626): module-level
+    ``const Promise`` stays in the per-file shadow map; the function-local
+    ``const Map`` no longer does (before #626 both did)."""
+    from tree_sitter_analyzer.synapse_resolver.languages.typescript import (
+        _build_shadow_locals,
+    )
+
+    db = _index(
+        tmp_path,
+        {
+            "svc.ts": ("const Promise = 1;\nfunction f(): void { const Map = 1; }\n"),
+        },
+    )
+    conn = sqlite3.connect(db)
+    conn.row_factory = sqlite3.Row
+    try:
+        assert _build_shadow_locals(conn) == {"svc.ts": {"Promise"}}
+    finally:
+        conn.close()
+
+
+def test_function_local_shadow_no_longer_suppresses_builtin(tmp_path: Path) -> None:
+    """FULL INDEX PATH (#626 precision gain): ``function f() { const Math = 1 }``
+    no longer shadows the ``Math`` global — ``Math.random()`` elsewhere in the
+    file classifies ``builtin`` again (module-level shadows still suppress,
+    pinned by test_shadow_locals_from_cache_are_module_scope_only +
+    test_variable_shadow_suppresses_builtin)."""
+    db = _index(
+        tmp_path,
+        {
+            "svc.ts": (
+                "function f(): void { const Math = 1; }\n"
+                "function g(): void { Math.random(); }\n"
+            ),
+        },
+    )
+    res = _resolution_for(db, "random")
+    assert res == ["builtin"]

--- a/tree_sitter_analyzer/_ast_cache_indexer.py
+++ b/tree_sitter_analyzer/_ast_cache_indexer.py
@@ -25,7 +25,8 @@ logger = logging.getLogger(__name__)
 # v5: #613 — Rust const/static items extracted as kind="constant".
 # v6: #614 — docstring/return_type/params serialized into symbols_json.
 # v7: #624 — PHP const declarations extracted as kind="constant".
-_AST_CACHE_EXTRACTOR_VERSION = 7
+# v8: #626 — JS/TS function-local variables no longer over-captured.
+_AST_CACHE_EXTRACTOR_VERSION = 8
 
 
 def check_cache_or_read(

--- a/tree_sitter_analyzer/_ast_extraction.py
+++ b/tree_sitter_analyzer/_ast_extraction.py
@@ -321,6 +321,38 @@ _PHP_SCOPE_BODY_NODES = frozenset(
     }
 )
 
+# Issue #626 — JS/TS function-local variables were OVER-captured: every
+# ``variable_declarator`` with a ``name`` field became a kind="variable" row
+# regardless of scope, so function locals (``const id = req.params.id``)
+# polluted FTS and symbol search (−57% JS / −54% TS variable rows on the
+# in-repo corpus). Inverse of the constants family (#612/#615/#618/#625):
+# the same language-gated top-down ``enclosed`` flag, used here to SKIP rows
+# instead of adding them. Module/top-level declarators stay captured —
+# const+let+var, NO const-style name gate (this is a contraction of the
+# pre-existing kind="variable" contract, not a constants feature).
+#
+# ``statement_block`` is deliberately ABSENT: module-level ``if``/``try``
+# bodies are statement_blocks outside any function node — including it would
+# break the #612 guarantee that if/try-wrapped module declarators stay
+# captured. TS namespace bodies (``internal_module`` / ``module`` /
+# ``ambient_declaration``) are not function scopes either, so namespace-level
+# declarators stay captured naturally (PHP #624 namespace precedent).
+# ``function`` is the anonymous-function-expression node of older grammar
+# versions; in current grammars it only matches the bare ``function`` keyword
+# token, which is harmless (keyword tokens have no children).
+_JSTS_SCOPE_BODY_NODES = frozenset(
+    {
+        "function_declaration",
+        "function_expression",
+        "function",
+        "arrow_function",
+        "method_definition",
+        "generator_function",
+        "generator_function_declaration",
+        "class_static_block",
+    }
+)
+
 
 def _php_constants(node: Any, source: str) -> list[dict[str, Any]]:
     """Return kind="constant" symbols for a PHP const_declaration, one row
@@ -723,9 +755,11 @@ def _walk_for_symbols(
 
     ``enclosed`` tracks (top-down, no parent walking) whether *node* sits
     inside a Python function/class body (#610), a Go function body (#613),
-    a Rust function/closure body (#613), or a PHP function/closure body
-    (#624) — module/package-constant capture must fire at top-level scope
-    only, including ``if``/``try``-wrapped module-level assignments.
+    a Rust function/closure body (#613), a PHP function/closure body
+    (#624), or a JS/TS function/method/static-block body (#626) —
+    module/package-constant capture must fire at top-level scope only,
+    including ``if``/``try``-wrapped module-level assignments, and JS/TS
+    function-local declarators must NOT produce kind="variable" rows.
     """
     if depth > 20:
         return
@@ -799,7 +833,15 @@ def _walk_for_symbols(
                 "language": language,
             }
         )
-    elif node_type in _VAR_DECL_LIKE and name_node is not None:
+    elif (
+        node_type in _VAR_DECL_LIKE
+        and name_node is not None
+        # #626: JS/TS function-local declarators are not cross-file symbols —
+        # skip them. The ast_cache path only ever delivers the language ids
+        # "javascript"/"typescript" for this family (.jsx → "javascript",
+        # .tsx → "typescript"), so gating on those two ids is complete.
+        and not (language in ("javascript", "typescript") and enclosed)
+    ):
         name = _node_text(name_node, source)
         if not name.startswith("_") or depth < 3:
             symbols.append(
@@ -845,6 +887,10 @@ def _walk_for_symbols(
         or (language == "go" and node_type in _GO_SCOPE_BODY_NODES)
         or (language == "rust" and node_type in _RUST_SCOPE_BODY_NODES)
         or (language == "php" and node_type in _PHP_SCOPE_BODY_NODES)
+        or (
+            language in ("javascript", "typescript")
+            and node_type in _JSTS_SCOPE_BODY_NODES
+        )
     )
     for child in node.children:
         _walk_for_symbols(child, source, symbols, language, depth + 1, child_enclosed)

--- a/tree_sitter_analyzer/_ast_extraction.py
+++ b/tree_sitter_analyzer/_ast_extraction.py
@@ -350,6 +350,11 @@ _JSTS_SCOPE_BODY_NODES = frozenset(
         "generator_function",
         "generator_function_declaration",
         "class_static_block",
+        # Declarations inside error-recovered regions have undecidable scope
+        # (.tsx is parsed with the typescript grammar, so JSX can shatter
+        # function bodies into ERROR nodes) — better unindexed than wrong
+        # (Codex P2 on #629; defensive hardening, 4 JSX shapes probed clean).
+        "ERROR",
     }
 )
 

--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -64,7 +64,8 @@ logger = logging.getLogger(__name__)
 # v5: #613 — Rust const/static items extracted as kind="constant".
 # v6: #614 — docstring/return_type/params serialized into symbols_json.
 # v7: #624 — PHP const declarations extracted as kind="constant".
-_AST_CACHE_EXTRACTOR_VERSION = 7
+# v8: #626 — JS/TS function-local variables no longer over-captured.
+_AST_CACHE_EXTRACTOR_VERSION = 8
 
 
 class SchemaIntegrityError(RuntimeError):


### PR DESCRIPTION
JS/TS half of #626 (approved contraction; Java = next PR with v9; C# = #628).

## Summary
JS/TS `variable_declarator` rows were emitted ungated — function-local variables became searchable symbols (~60% of the family's 397 rows were noise). Now the constants-family `enclosed` mechanism gates them: new shared `_JSTS_SCOPE_BODY_NODES` (8 node types incl. class_static_block; `statement_block` deliberately absent — if/try/catch-wrapped module declarators stay captured, pinned per the #612 guarantee). Module/top-level const+let+var and TS namespace-level declarators kept (no name gate — contraction, not a constants feature). `_AST_CACHE_EXTRACTOR_VERSION` 7→8.

**Language-id completeness verified**: cache path only delivers javascript/typescript (.mjs/.cjs/.mts/.cts aren't in EXT_TO_LANG at all — never indexed); gate is complete.

**Builtin-shadow narrowing (#346 semantic change — approved as precision gain)**: the synapse shadow gates consume kind=variable rows; previously a function-local `const Math` ANYWHERE suppressed builtin classification project-wide (file-insensitive). After this PR only module-scope shadows suppress. Pinned through the real cache: module `const Math` still suppresses; function-local one no longer does (exact pins, JS + TS).

Known caveat (documented, not pinned): .tsx parses with the typescript grammar; JSX ERROR-recovery can flatten function bodies so locals in broken regions may survive — pre-existing grammar behavior, outside #626.

## Test plan
- [x] RED-first: 11 failed pre-fix → consolidated narrow run 486 passed (-n 0)
- [x] Golden FULL suites: 96 passed, 1 fail = pre-existing swift local-env (proven by stash-rerun on clean develop) — zero drift
- [x] E2E probe: 7 module/namespace rows kept, local rows [] — pasted; extractor_version 8
- [x] Re-pin: only the version test (7→8); ratchet exit=0; ruff clean
- [x] Lead independently re-ran 104 tests + verified both version sites + push diff=0