### PR TITLE
fix(index): Java method-local variables no longer over-captured

### DIFF
--- a/tests/unit/test_ast_extraction.py
+++ b/tests/unit/test_ast_extraction.py
@@ -1147,11 +1147,12 @@ class TestJsTsLocalVariableContraction:
         src = "const TOP = 1;\nfunction Comp() { const inner = 2; }\n"
         assert self._variables(src, "typescript") == ["TOP"]
 
-    def test_java_locals_unaffected(self):
-        # Java is the separate follow-up PR (#626 part 2) — its function
-        # locals must still be captured by this change.
+    def test_java_locals_now_contracted_too(self):
+        # Re-pinned when the Java half of #626 landed (extractor v9): Java
+        # method locals are dropped as well — full Java surface pinned in
+        # TestJavaLocalVariableContraction below.
         src = "class A { void m() { int local = 1; } }\n"
-        assert self._variables(src, "java") == ["local"]
+        assert self._variables(src, "java") == []
 
 
 class TestJsTsErrorRegionHardening:
@@ -1167,3 +1168,103 @@ class TestJsTsErrorRegionHardening:
         names = [s["name"] for s in syms if s["kind"] == "variable"]
         assert "Math" not in names
         assert "TOP" in names
+
+
+# ---------------------------------------------------------------------------
+# Issue #626 (Java half): function-local variables no longer over-captured
+# ---------------------------------------------------------------------------
+
+
+_JAVA_626_SRC = """\
+interface Iface {
+    int IFACE_CONST = 99;
+}
+
+record Rec(int x) {
+    static final int REC_CONST = 7;
+    Rec {
+        int compactCtorLocal = 100;
+    }
+}
+
+class A {
+    static final int STATIC_FINAL = 1;
+    int plainField = 2;
+    static int staticField = 3;
+    Runnable fieldLambda = () -> { int lambdaFieldLocal = 4; };
+
+    static { int staticInitLocal = 5; }
+    { int instanceInitLocal = 6; }
+    A() { int ctorLocal = 7; }
+
+    void m() {
+        int local = 10;
+        for (int i = 0; i < 3; i++) { int loopBody = 11; }
+        try { int tryLocal = 12; } catch (Exception e) { int catchLocal = 13; }
+    }
+}
+"""
+
+
+class TestJavaLocalVariableContraction:
+    """Issue #626 (Java half) — method/ctor/compact-ctor/lambda/initializer
+    locals must NOT reach ast_symbol_rows; class fields (incl. record
+    constants) and interface constants stay kind="variable". Fields are safe
+    from the ``block`` scope node: they route ``class_body >
+    field_declaration`` and never through a ``block`` (live-parse verified)."""
+
+    def _variables(self, src: str, lang: str) -> list[str]:
+        return sorted(
+            s["name"] for s in _symbols_for(src, lang) if s["kind"] == "variable"
+        )
+
+    def test_java_exactly_fields_and_constants_survive(self):
+        assert self._variables(_JAVA_626_SRC, "java") == [
+            "IFACE_CONST",
+            "REC_CONST",
+            "STATIC_FINAL",
+            "fieldLambda",
+            "plainField",
+            "staticField",
+        ]
+
+    def test_java_method_ctor_and_compact_ctor_locals_dropped(self):
+        names = self._variables(_JAVA_626_SRC, "java")
+        for local in (
+            "local",
+            "i",
+            "loopBody",
+            "tryLocal",
+            "catchLocal",
+            "ctorLocal",
+            "compactCtorLocal",
+        ):
+            assert local not in names
+
+    def test_java_lambda_and_initializer_locals_dropped(self):
+        # lambdaFieldLocal sits in a lambda hanging off a FIELD initializer —
+        # the only shape where ``lambda_expression`` (not method/block) is the
+        # gating scope node; the field holder itself stays captured.
+        names = self._variables(_JAVA_626_SRC, "java")
+        for local in ("lambdaFieldLocal", "staticInitLocal", "instanceInitLocal"):
+            assert local not in names
+
+    def test_csharp_locals_unaffected(self):
+        # C# has the same over-capture disease (10 live rows) but is a
+        # separate follow-up per the #626 decision — must NOT be widened here.
+        src = "class A { void M() { int local = 1; } }\n"
+        assert self._variables(src, "csharp") == ["local"]
+
+
+class TestJavaErrorRegionHardening:
+    """#629 ERROR-hardening precedent applied to Java: declarations inside
+    error-recovered regions have undecidable scope — they must not be emitted
+    (better unindexed than a lambda local masquerading as a field)."""
+
+    def test_declaration_inside_error_node_not_emitted(self):
+        # Unterminated lambda-in-field shatters the class into an ERROR node;
+        # 'leaked' currently surfaces as ERROR > local_variable_declaration
+        # (live-parse verified) — it must produce no row.
+        src = "class A {\n  Runnable r = () -> {\n    int leaked = 1;\n"
+        syms = _symbols_for(src, "java")
+        assert [s["name"] for s in syms if s["kind"] == "variable"] == []

--- a/tests/unit/test_symbols_json_enrichment.py
+++ b/tests/unit/test_symbols_json_enrichment.py
@@ -136,12 +136,12 @@ class TestReturnTypeAndParamsSerialized:
 
 
 class TestExtractorVersionBump:
-    def test_extractor_version_is_8_in_both_sites(self):
-        # v8: #626 — JS/TS function-local variables no longer over-captured.
+    def test_extractor_version_is_9_in_both_sites(self):
+        # v9: #626 — Java function-local variables no longer over-captured.
         from tree_sitter_analyzer import _ast_cache_indexer, ast_cache
 
-        assert ast_cache._AST_CACHE_EXTRACTOR_VERSION == 8
-        assert _ast_cache_indexer._AST_CACHE_EXTRACTOR_VERSION == 8
+        assert ast_cache._AST_CACHE_EXTRACTOR_VERSION == 9
+        assert _ast_cache_indexer._AST_CACHE_EXTRACTOR_VERSION == 9
 
 
 class TestCodexP2sOn621:

--- a/tree_sitter_analyzer/_ast_cache_indexer.py
+++ b/tree_sitter_analyzer/_ast_cache_indexer.py
@@ -26,7 +26,8 @@ logger = logging.getLogger(__name__)
 # v6: #614 — docstring/return_type/params serialized into symbols_json.
 # v7: #624 — PHP const declarations extracted as kind="constant".
 # v8: #626 — JS/TS function-local variables no longer over-captured.
-_AST_CACHE_EXTRACTOR_VERSION = 8
+# v9: #626 — Java function-local variables no longer over-captured.
+_AST_CACHE_EXTRACTOR_VERSION = 9
 
 
 def check_cache_or_read(

--- a/tree_sitter_analyzer/_ast_extraction.py
+++ b/tree_sitter_analyzer/_ast_extraction.py
@@ -358,6 +358,34 @@ _JSTS_SCOPE_BODY_NODES = frozenset(
     }
 )
 
+# Issue #626 (Java half) — same over-capture disease: every Java
+# ``variable_declarator`` became a kind="variable" row, so method/ctor/
+# lambda/initializer locals polluted FTS and symbol search (−69% Java
+# variable rows on the in-repo corpus). Class fields and interface constants
+# stay captured: they route ``class_body > field_declaration`` /
+# ``interface_body > constant_declaration`` and NEVER through any node in
+# this set — ``block`` is safe for Java because fields never sit inside a
+# block node (live-parse verified), while the instance initializer is a bare
+# ``block`` child of ``class_body``, which is exactly why ``block`` is here.
+# ``constructor_declaration`` gates ctor locals (their body is a
+# ``constructor_body``, not a ``block``); ``compact_constructor_declaration``
+# covers record compact ctors; ``lambda_expression`` covers lambdas hanging
+# off FIELD initializers (lambdas in methods are already inside the method).
+# ``ERROR`` per the #629 hardening precedent: declarations inside
+# error-recovered regions have undecidable scope — better unindexed than a
+# lambda local masquerading as a field.
+_JAVA_SCOPE_BODY_NODES = frozenset(
+    {
+        "method_declaration",
+        "constructor_declaration",
+        "compact_constructor_declaration",
+        "lambda_expression",
+        "static_initializer",
+        "block",
+        "ERROR",
+    }
+)
+
 
 def _php_constants(node: Any, source: str) -> list[dict[str, Any]]:
     """Return kind="constant" symbols for a PHP const_declaration, one row
@@ -761,9 +789,10 @@ def _walk_for_symbols(
     ``enclosed`` tracks (top-down, no parent walking) whether *node* sits
     inside a Python function/class body (#610), a Go function body (#613),
     a Rust function/closure body (#613), a PHP function/closure body
-    (#624), or a JS/TS function/method/static-block body (#626) —
+    (#624), a JS/TS function/method/static-block body (#626), or a Java
+    method/ctor/lambda/initializer body (#626 Java half) —
     module/package-constant capture must fire at top-level scope only,
-    including ``if``/``try``-wrapped module-level assignments, and JS/TS
+    including ``if``/``try``-wrapped module-level assignments, and JS/TS/Java
     function-local declarators must NOT produce kind="variable" rows.
     """
     if depth > 20:
@@ -841,11 +870,12 @@ def _walk_for_symbols(
     elif (
         node_type in _VAR_DECL_LIKE
         and name_node is not None
-        # #626: JS/TS function-local declarators are not cross-file symbols —
-        # skip them. The ast_cache path only ever delivers the language ids
-        # "javascript"/"typescript" for this family (.jsx → "javascript",
-        # .tsx → "typescript"), so gating on those two ids is complete.
-        and not (language in ("javascript", "typescript") and enclosed)
+        # #626: JS/TS/Java function-local declarators are not cross-file
+        # symbols — skip them. The ast_cache path only ever delivers the
+        # language ids "javascript"/"typescript"/"java" for this family
+        # (.jsx → "javascript", .tsx → "typescript", .java → "java"), so
+        # gating on these ids is complete.
+        and not (language in ("javascript", "typescript", "java") and enclosed)
     ):
         name = _node_text(name_node, source)
         if not name.startswith("_") or depth < 3:
@@ -896,6 +926,7 @@ def _walk_for_symbols(
             language in ("javascript", "typescript")
             and node_type in _JSTS_SCOPE_BODY_NODES
         )
+        or (language == "java" and node_type in _JAVA_SCOPE_BODY_NODES)
     )
     for child in node.children:
         _walk_for_symbols(child, source, symbols, language, depth + 1, child_enclosed)

--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -65,7 +65,8 @@ logger = logging.getLogger(__name__)
 # v6: #614 — docstring/return_type/params serialized into symbols_json.
 # v7: #624 — PHP const declarations extracted as kind="constant".
 # v8: #626 — JS/TS function-local variables no longer over-captured.
-_AST_CACHE_EXTRACTOR_VERSION = 8
+# v9: #626 — Java function-local variables no longer over-captured.
+_AST_CACHE_EXTRACTOR_VERSION = 9
 
 
 class SchemaIntegrityError(RuntimeError):


### PR DESCRIPTION
Java half of #626 — completes the approved contraction (JS/TS merged as #629; C# tracked as #628).

## Summary
`_JAVA_SCOPE_BODY_NODES = {method_declaration, constructor_declaration, compact_constructor_declaration, lambda_expression, static_initializer, block, ERROR}` gates the `_VAR_DECL_LIKE` branch for java. Live-parse verified: instance initializers are bare `block`s under class_body while `field_declaration` rows never route through any block (so `block` is safe); constructor bodies are `constructor_body` nodes — `constructor_declaration` is what gates ctor locals. ERROR-region hardening mirrors #629 (live-probed: a shattered lambda-in-field WAS leaking a local row).

- KEEP: class fields, static finals, interface constants, record fields (e2e probe: exactly 4 rows, locals [])
- DROP: method/ctor/compact-ctor/lambda/static-init/instance-init locals (−69.3% on the in-repo corpus per the study)
- `_AST_CACHE_EXTRACTOR_VERSION` 8→9 (both sites)
- **No shadow-semantics change**: Java has no builtin-shadow mechanism (grep-verified — only JS/TS consume kind=variable shadow sets)
- C# explicitly NOT widened (pinned: csharp locals still captured — #628's scope decision)

## Test plan
- [x] RED-first: 4 new tests failed pre-fix → 218 + 103 regression passed (-n 0)
- [x] Golden FULL suites: 96 passed, swift fail = pre-existing (stash-proven) — zero drift
- [x] Conscious re-pins: version 8→9; JS/TS-era `java_locals_unaffected` flipped to `now_contracted_too`
- [x] Ratchet exit=0; ruff clean
- [x] Lead independently re-ran 110 tests + verified both version sites + push diff=0