### PR TITLE
test: ratchet batch-23 — pin 32 loose assertions in top-4 AST-ranked files

### DIFF
--- a/scripts/loose_assertion_baseline.txt
+++ b/scripts/loose_assertion_baseline.txt
@@ -45,7 +45,9 @@
 #   files).
 #   batch-22 (AST): 744 -> 711, 2026-06-13 (30 exact pins + 3 timing
 #   exemptions in top-4 AST-ranked files).
+#   batch-23 (AST): 711 -> 679, 2026-06-13 (32 exact pins in top-4
+#   AST-ranked files, no exemptions).
 
-BASELINE_COUNT=711
+BASELINE_COUNT=679
 MEASUREMENT_DATE=2026-06-13
 MEASUREMENT_COMMAND="uv run python scripts/check_loose_assertions.py --baseline"

--- a/tests/unit/core/test_queries_cpp.py
+++ b/tests/unit/core/test_queries_cpp.py
@@ -64,7 +64,7 @@ class TestCppQueries:
         """Test getting all queries"""
         all_queries = get_all_queries()
         assert isinstance(all_queries, dict)
-        assert len(all_queries) > 0
+        assert len(all_queries) == 52
         assert "class" in all_queries
         assert "query" in all_queries["class"]
         assert "description" in all_queries["class"]
@@ -73,7 +73,7 @@ class TestCppQueries:
         """Test listing all query names"""
         query_names = list_queries()
         assert isinstance(query_names, list)
-        assert len(query_names) > 0
+        assert len(query_names) == 52
         assert "class" in query_names
         assert "function" in query_names
 
@@ -81,45 +81,52 @@ class TestCppQueries:
         """Test getting available C++ queries"""
         available_queries = get_available_cpp_queries()
         assert isinstance(available_queries, list)
-        assert len(available_queries) > 0
+        assert len(available_queries) == 47
         assert "class" in available_queries
         assert "function" in available_queries
 
     def test_cpp_queries_structure(self) -> None:
         """Test CPP_QUERIES dictionary structure"""
         assert isinstance(CPP_QUERIES, dict)
-        assert len(CPP_QUERIES) > 0
+        assert len(CPP_QUERIES) == 47
 
-        essential_queries = [
-            "class",
-            "struct",
-            "enum",
-            "function",
-            "namespace",
-            "template",
-            "include",
-            "variable",
-        ]
-        for query_name in essential_queries:
+        # Exact stripped lengths (update when query strings change)
+        essential_query_lens = {
+            "class": 24,
+            "struct": 26,
+            "enum": 22,
+            "function": 31,
+            "namespace": 33,
+            "template": 32,
+            "include": 26,
+            "variable": 23,
+        }
+        for query_name, expected_len in essential_query_lens.items():
             assert query_name in CPP_QUERIES
             assert isinstance(CPP_QUERIES[query_name], str)
-            assert len(CPP_QUERIES[query_name].strip()) > 0
+            assert len(CPP_QUERIES[query_name].strip()) == expected_len
 
     def test_cpp_query_descriptions_structure(self) -> None:
         """Test CPP_QUERY_DESCRIPTIONS dictionary structure"""
         assert isinstance(CPP_QUERY_DESCRIPTIONS, dict)
-        assert len(CPP_QUERY_DESCRIPTIONS) > 0
+        assert len(CPP_QUERY_DESCRIPTIONS) == 47
 
-        essential_queries = ["class", "function", "namespace", "template"]
-        for query_name in essential_queries:
+        # Exact stripped lengths (update when descriptions change)
+        essential_description_lens = {
+            "class": 30,
+            "function": 32,
+            "namespace": 33,
+            "template": 33,
+        }
+        for query_name, expected_len in essential_description_lens.items():
             assert query_name in CPP_QUERY_DESCRIPTIONS
             assert isinstance(CPP_QUERY_DESCRIPTIONS[query_name], str)
-            assert len(CPP_QUERY_DESCRIPTIONS[query_name].strip()) > 0
+            assert len(CPP_QUERY_DESCRIPTIONS[query_name].strip()) == expected_len
 
     def test_all_queries_structure(self) -> None:
         """Test ALL_QUERIES dictionary structure"""
         assert isinstance(ALL_QUERIES, dict)
-        assert len(ALL_QUERIES) > 0
+        assert len(ALL_QUERIES) == 52
 
         for query_data in ALL_QUERIES.values():
             assert isinstance(query_data, dict)

--- a/tests/unit/languages/test_csharp_plugin_elements.py
+++ b/tests/unit/languages/test_csharp_plugin_elements.py
@@ -399,13 +399,15 @@ public class Ctrl : ControllerBase {
         classes = plugin.extractor.extract_classes(tree, SIMPLE_CLASS_CODE)
 
         person_class = classes[0]
-        # Constructor should be in methods list
+        # Constructors are surfaced via extract_functions (see
+        # test_extract_constructor), NOT attached to class.methods —
+        # exact current behavior: empty list here.
         constructor_names = [
             m.name
             for m in person_class.methods
             if "Person" in m.name or m.name == "__init__"
         ]
-        assert len(constructor_names) >= 0  # Might be 0 if not extracted
+        assert constructor_names == []
 
     def test_extract_empty_tree(self):
         """Test extraction with empty/None tree."""
@@ -464,9 +466,9 @@ class TestCSharpFunctionExtraction:
 
         add_item = next((f for f in functions if f.name == "AddItem"), None)
         assert add_item is not None
-        # Should have 'item' parameter
+        # Parameters are stored as raw "type name" strings
         param_names = [p.name if hasattr(p, "name") else p for p in add_item.parameters]
-        assert len(param_names) >= 0  # Parameter extraction may vary
+        assert param_names == ["OrderItem item"]
 
     def test_extract_constructor(self):
         """Test constructor extraction."""
@@ -478,8 +480,8 @@ class TestCSharpFunctionExtraction:
         constructors = [
             f for f in functions if f.name == "Person" or ".ctor" in str(f.raw_text)
         ]
-        # Constructor should exist
-        assert len(constructors) >= 0  # Extraction behavior may vary
+        # Exactly one constructor (Person) is extracted
+        assert [c.name for c in constructors] == ["Person"]
 
     def test_extract_method_modifiers(self):
         """Test extraction of method modifiers."""
@@ -522,8 +524,9 @@ class TestCSharpFunctionExtraction:
 
         calculate = next((f for f in functions if f.name == "Calculate"), None)
         assert calculate is not None
-        # Method with if/for/while/switch should have higher complexity_score
-        assert calculate.complexity_score >= 1
+        # CONTROL_FLOW_CODE's if/else-if/for/while/switch/catch sum to
+        # exactly 7 (update when fixture or complexity rules change)
+        assert calculate.complexity_score == 7
 
 
 class TestCSharpVariableExtraction:
@@ -620,9 +623,9 @@ class TestCSharpImportExtraction:
         tree = get_tree_for_code(COMPLEX_CLASS_CODE, plugin)
         imports = plugin.extractor.extract_imports(tree, COMPLEX_CLASS_CODE)
 
-        # Should find static using for System.Math
+        # Exactly one static using: System.Math
         static_imports = [i for i in imports if i.is_static]
-        assert len(static_imports) >= 0  # May have static import
+        assert [i.name for i in static_imports] == ["System.Math"]
 
     def test_extract_imports_empty_tree(self):
         """Test import extraction with empty tree."""
@@ -636,8 +639,9 @@ class TestCSharpImportExtraction:
         tree = get_tree_for_code(SIMPLE_CLASS_CODE, plugin)
         imports = plugin.extractor.extract_imports(tree, SIMPLE_CLASS_CODE)
 
-        assert all(i.start_line > 0 for i in imports)
-        assert all(i.end_line >= i.start_line for i in imports)
+        # SIMPLE_CLASS_CODE's two using directives sit on lines 2-3
+        assert [i.start_line for i in imports] == [2, 3]
+        assert [i.end_line for i in imports] == [2, 3]
 
 
 class TestCSharpPropertyExtraction:
@@ -677,8 +681,9 @@ class TestCSharpComplexityCalculation:
 
         calculate = next((f for f in functions if f.name == "Calculate"), None)
         assert calculate is not None
-        # if, else if, else, for, while, switch, try/catch all add complexity
-        assert calculate.complexity_score >= 5
+        # if, else if, for, while, switch cases, catch add up to exactly 7
+        # (update when CONTROL_FLOW_CODE or the complexity rules change)
+        assert calculate.complexity_score == 7
 
     def test_simple_method_low_complexity(self):
         """Test that simple method has low complexity."""
@@ -735,8 +740,9 @@ class TestCSharpExtractorHelpers:
         extractor = CSharpElementExtractor()
 
         nodes = list(extractor._traverse_iterative(tree.root_node))
-        assert len(nodes) > 0
-        # Should traverse all nodes in the tree
+        # Full traversal of SIMPLE_CLASS_CODE's tree yields exactly 98 nodes
+        # (update on tree-sitter-c-sharp grammar bumps)
+        assert len(nodes) == 98
 
     def test_cache_invalidation(self):
         """Test that source code is properly set between extractions."""

--- a/tests/unit/languages/test_html_plugin_accuracy.py
+++ b/tests/unit/languages/test_html_plugin_accuracy.py
@@ -1,6 +1,5 @@
 """HTML plugin tests — query accuracy."""
 
-
 from tests.unit.languages._html_test_data import (
     ATTRIBUTE_CODE,
     FORM_CODE,
@@ -21,10 +20,45 @@ class TestHtmlQueryAccuracy:
         tree = get_tree_for_code(TAG_CODE, plugin)
         elements = plugin.create_extractor().extract_html_elements(tree, TAG_CODE)
 
-        # Should not extract non-tag elements
-        for element in elements:
-            assert element.tag_name is not None
-            assert len(element.tag_name) > 0
+        # Should not extract non-tag elements — exact full tag list of
+        # TAG_CODE in document order (update when the fixture changes)
+        assert [e.tag_name for e in elements] == [
+            "div",
+            "header",
+            "h1",
+            "nav",
+            "ul",
+            "li",
+            "a",
+            "li",
+            "a",
+            "li",
+            "a",
+            "main",
+            "section",
+            "h2",
+            "p",
+            "article",
+            "h3",
+            "p",
+            "aside",
+            "h4",
+            "p",
+            "footer",
+            "p",
+            "p",
+            "strong",
+            "em",
+            "p",
+            "mark",
+            "del",
+            "p",
+            "ins",
+            "sub",
+            "p",
+            "sup",
+            "small",
+        ]
 
     def test_attribute_query_accuracy(self):
         """Test that attribute query accurately identifies attributes."""
@@ -45,9 +79,9 @@ class TestHtmlQueryAccuracy:
         tree = get_tree_for_code(FORM_CODE, plugin)
         elements = plugin.create_extractor().extract_html_elements(tree, FORM_CODE)
 
-        # Should find form elements
+        # FORM_CODE contains exactly one <form>
         form_elements = [e for e in elements if e.tag_name == "form"]
-        assert len(form_elements) >= 1
+        assert len(form_elements) == 1
 
     def test_table_query_accuracy(self):
         """Test that table query accurately identifies table elements."""
@@ -55,9 +89,9 @@ class TestHtmlQueryAccuracy:
         tree = get_tree_for_code(TABLE_CODE, plugin)
         elements = plugin.create_extractor().extract_html_elements(tree, TABLE_CODE)
 
-        # Should find table elements
+        # TABLE_CODE contains exactly two <table> elements
         table_elements = [e for e in elements if e.tag_name == "table"]
-        assert len(table_elements) >= 1
+        assert len(table_elements) == 2
 
     def test_link_query_accuracy(self):
         """Test that link query accurately identifies links."""
@@ -67,9 +101,9 @@ class TestHtmlQueryAccuracy:
             tree, LINK_IMAGE_CODE
         )
 
-        # Should find anchor tags
+        # LINK_IMAGE_CODE contains exactly five <a> elements
         a_elements = [e for e in elements if e.tag_name == "a"]
-        assert len(a_elements) >= 1
+        assert len(a_elements) == 5
 
     def test_image_query_accuracy(self):
         """Test that image query accurately identifies images."""
@@ -79,9 +113,9 @@ class TestHtmlQueryAccuracy:
             tree, LINK_IMAGE_CODE
         )
 
-        # Should find img tags
+        # LINK_IMAGE_CODE contains exactly four <img> elements
         img_elements = [e for e in elements if e.tag_name == "img"]
-        assert len(img_elements) >= 1
+        assert len(img_elements) == 4
 
     def test_no_false_positives(self):
         """Test that queries don't produce false positives."""
@@ -112,9 +146,82 @@ class TestHtmlQueryAccuracy:
         tree = get_tree_for_code(TAG_CODE, plugin)
         elements = plugin.create_extractor().extract_html_elements(tree, TAG_CODE)
 
-        for element in elements:
-            assert element.start_line > 0
-            assert element.end_line >= element.start_line
+        # Exact 1-based line spans for TAG_CODE's 35 elements in document
+        # order (update when the fixture changes)
+        assert [e.start_line for e in elements] == [
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            8,
+            9,
+            9,
+            10,
+            10,
+            14,
+            15,
+            16,
+            17,
+            19,
+            20,
+            21,
+            23,
+            24,
+            25,
+            28,
+            29,
+            34,
+            34,
+            34,
+            35,
+            35,
+            35,
+            36,
+            36,
+            36,
+            37,
+            37,
+            37,
+        ]
+        assert [e.end_line for e in elements] == [
+            31,
+            13,
+            5,
+            12,
+            11,
+            8,
+            8,
+            9,
+            9,
+            10,
+            10,
+            27,
+            18,
+            16,
+            17,
+            22,
+            20,
+            21,
+            26,
+            24,
+            25,
+            30,
+            29,
+            34,
+            34,
+            34,
+            35,
+            35,
+            35,
+            36,
+            36,
+            36,
+            37,
+            37,
+            37,
+        ]
 
     def test_element_classification_accuracy(self):
         """Test that element classification is accurate."""
@@ -122,10 +229,11 @@ class TestHtmlQueryAccuracy:
         tree = get_tree_for_code(TAG_CODE, plugin)
         elements = plugin.create_extractor().extract_html_elements(tree, TAG_CODE)
 
-        # Structure elements should be classified as structure
+        # Exactly 8 structure elements: div, header, nav, main, section,
+        # article, aside, footer
         structure_elements = [e for e in elements if e.element_class == "structure"]
-        assert len(structure_elements) >= 1
+        assert len(structure_elements) == 8
 
-        # Heading elements should be classified as heading
+        # Exactly 4 heading elements: h1, h2, h3, h4
         heading_elements = [e for e in elements if e.element_class == "heading"]
-        assert len(heading_elements) >= 1
+        assert len(heading_elements) == 4

--- a/tests/unit/languages/test_html_plugin_coverage_boost.py
+++ b/tests/unit/languages/test_html_plugin_coverage_boost.py
@@ -296,8 +296,14 @@ class TestHtmlPluginAnalyzeFile:
                 result = await plugin.analyze_file(temp_path, Mock())
                 assert result.success is True
                 assert result.language == "html"
-                assert len(result.elements) > 0
-                assert result.elements[0].tag_name == "html"
+                # html, head, title, body, p — exactly 5 elements
+                assert [e.tag_name for e in result.elements] == [
+                    "html",
+                    "head",
+                    "title",
+                    "body",
+                    "p",
+                ]
         finally:
             os.unlink(temp_path)
 
@@ -333,10 +339,7 @@ class TestRealParsingPaths:
         """Lines 123-137: extract_html_elements with real tree-sitter parse"""
         tree = _parse_html("<div><p>hello</p></div>")
         elements = extractor.extract_html_elements(tree, "<div><p>hello</p></div>")
-        assert len(elements) >= 2
-        tag_names = [e.tag_name for e in elements]
-        assert "div" in tag_names
-        assert "p" in tag_names
+        assert [e.tag_name for e in elements] == ["div", "p"]
 
     def test_extract_html_elements_exception_path(self, extractor):
         """Lines 134-135: top-level exception in extract_html_elements"""
@@ -353,14 +356,17 @@ class TestRealParsingPaths:
         """Lines 168-179: self_closing_tag node type"""
         tree = _parse_html("<br/>")
         elements = extractor.extract_html_elements(tree, "<br/>")
-        assert len(elements) >= 1
-        assert elements[0].tag_name == "br"
+        # Exact current behavior: the self_closing_tag is captured twice
+        # (element node + self_closing_tag node) -> 2 entries
+        assert [e.tag_name for e in elements] == ["br", "br"]
 
     def test_input_with_boolean_attribute(self, extractor):
         """Lines 295-337: boolean attribute (attribute_name only, no value)"""
         tree = _parse_html("<input disabled checked/>")
         elements = extractor.extract_html_elements(tree, "<input disabled checked/>")
-        assert len(elements) >= 1
+        # Exact current behavior: self-closing input captured twice
+        # (element node + self_closing_tag node) -> 2 entries
+        assert [e.tag_name for e in elements] == ["input", "input"]
         assert "disabled" in elements[0].attributes
         assert "checked" in elements[0].attributes
 
@@ -368,7 +374,7 @@ class TestRealParsingPaths:
         """Line 319: attribute_value child (not quoted_attribute_value)"""
         tree = _parse_html("<input type=text>")
         elements = extractor.extract_html_elements(tree, "<input type=text>")
-        assert len(elements) >= 1
+        assert [e.tag_name for e in elements] == ["input"]
         assert elements[0].attributes.get("type") == "text"
 
     def test_div_with_quoted_attributes(self, extractor):
@@ -377,7 +383,7 @@ class TestRealParsingPaths:
         elements = extractor.extract_html_elements(
             tree, '<div class="container" id="main">hi</div>'
         )
-        assert len(elements) >= 1
+        assert [e.tag_name for e in elements] == ["div"]
         assert elements[0].attributes.get("class") == "container"
         assert elements[0].attributes.get("id") == "main"
 
@@ -387,10 +393,10 @@ class TestRealParsingPaths:
         tree = _parse_html(code)
         elements = extractor.extract_html_elements(tree, code)
         div_elems = [e for e in elements if e.tag_name == "div"]
-        assert len(div_elems) >= 1
+        assert len(div_elems) == 1
         div = div_elems[0]
-        assert len(div.children) >= 1
-        assert div.children[0].tag_name == "span"
+        # The div has exactly one child: the span
+        assert [c.tag_name for c in div.children] == ["span"]
 
     def test_classify_all_categories(self, extractor):
         """Lines 339-347: _classify_element for all categories"""


### PR DESCRIPTION
## Summary
Loose-assertion ratchet batch 23. Top-4 (8-way tie at 8, lexicographic):

| File | Pins |
|---|---|
| tests/unit/core/test_queries_cpp.py | 8 |
| tests/unit/languages/test_csharp_plugin_elements.py | 8 |
| tests/unit/languages/test_html_plugin_accuracy.py | 8 |
| tests/unit/languages/test_html_plugin_coverage_boost.py | 8 |

Baseline: **711 → 679** (= exactly 32, zero exemptions, lead re-verified live).

Highlights: cpp query registry counts pinned (52/47) + stripped-len dicts; HTML 35-tag full-list + exact line lists; `>= 0` vacuous asserts upgraded to strongest measured facts.

**Product quirk found while pinning** (pinned as-is per ratchet discipline, filed separately): the HTML extractor captures self-closing tags TWICE (element node + self_closing_tag node) — `<br/>` yields 2 entries.

## Test plan
- [x] All 4 files individually `-n 0`: 23/41/10/33 passed (re-run post-ruff-format)
- [x] Diff gate exit=0
- [x] `--baseline` measures 679 == recorded (lead independently re-verified)