### PR TITLE
fix(index): C# method-local variables no longer over-captured

### DIFF
--- a/tests/unit/test_ast_extraction.py
+++ b/tests/unit/test_ast_extraction.py
@@ -1249,11 +1249,12 @@ class TestJavaLocalVariableContraction:
         for local in ("lambdaFieldLocal", "staticInitLocal", "instanceInitLocal"):
             assert local not in names
 
-    def test_csharp_locals_unaffected(self):
-        # C# has the same over-capture disease (10 live rows) but is a
-        # separate follow-up per the #626 decision — must NOT be widened here.
+    def test_csharp_locals_now_contracted_too(self):
+        # Re-pinned when the C# follow-up (#628) landed (extractor v10): C#
+        # method locals are dropped as well — full C# surface pinned in
+        # TestCSharpLocalVariableContraction below.
         src = "class A { void M() { int local = 1; } }\n"
-        assert self._variables(src, "csharp") == ["local"]
+        assert self._variables(src, "csharp") == []
 
 
 class TestJavaErrorRegionHardening:
@@ -1267,4 +1268,161 @@ class TestJavaErrorRegionHardening:
         # (live-parse verified) — it must produce no row.
         src = "class A {\n  Runnable r = () -> {\n    int leaked = 1;\n"
         syms = _symbols_for(src, "java")
+        assert [s["name"] for s in syms if s["kind"] == "variable"] == []
+
+
+# ---------------------------------------------------------------------------
+# Issue #628 (C#): function-local variables no longer over-captured
+# ---------------------------------------------------------------------------
+
+
+_CSHARP_628_SRC = """\
+using System;
+
+int topLevelVar = 1;
+var topLevelVar2 = "x";
+if (topLevelVar > 0) { int topLevelIfLocal = 2; }
+try { int topTryLocal = 3; } catch (Exception e) { int topCatchLocal = 4; }
+
+interface IFace {
+    const int IFACE_CONST = 99;
+}
+
+record Rec(int X) {
+    public static readonly int REC_CONST = 7;
+}
+
+class A {
+    const int CONST_FIELD = 1;
+    static readonly int STATIC_READONLY = 2;
+    int plainField = 3;
+    static int staticField = 4;
+    public int AccessorProp {
+        get { int accessorLocal = 60; return accessorLocal; }
+    }
+    public int this[int idx] {
+        get { int indexerLocal = 61; return indexerLocal; }
+    }
+    public event EventHandler Ev {
+        add { int evAddLocal = 62; }
+        remove { }
+    }
+    public static A operator +(A a, A b) { int opLocal = 63; return a; }
+    public static implicit operator int(A a) { int convLocal = 64; return 0; }
+    Action fieldLambda = () => { int lambdaFieldLocal = 8; };
+    Action fieldAnonMethod = delegate () { int anonMethodLocal = 9; };
+
+    static A() { int staticCtorLocal = 10; }
+    A() { int ctorLocal = 11; }
+    ~A() { int dtorLocal = 12; }
+
+    void M() {
+        int methodLocal = 20;
+        for (int i = 0; i < 3; i++) { int loopBody = 21; }
+        try { int tryLocal = 22; } catch (Exception e) { int catchLocal = 23; }
+        int LocalFunc() {
+            int localFuncLocal = 24;
+            return localFuncLocal;
+        }
+        Action lam = () => { int lambdaLocal = 25; };
+    }
+}
+"""
+
+
+class TestCSharpLocalVariableContraction:
+    """Issue #628 — C# method/ctor/dtor/local-fn/lambda/accessor/operator
+    locals must NOT reach ast_symbol_rows; class/interface/record fields
+    (const, static readonly, plain) stay kind="variable". Unlike Java (#630),
+    ``block`` is NOT in the scope set: C# top-level statements put blocks at
+    compilation-unit level (live-parse: ``block < if_statement <
+    global_statement``), so a block-keyed set would drop if/try-wrapped
+    top-level declarators and break the #612 module-scope guarantee. Fields
+    are safe regardless: they route ``declaration_list > field_declaration``
+    and never through any function-like node (live-parse verified)."""
+
+    def _variables(self, src: str, lang: str) -> list[str]:
+        return sorted(
+            s["name"] for s in _symbols_for(src, lang) if s["kind"] == "variable"
+        )
+
+    def test_csharp_exactly_fields_constants_and_top_level_survive(self):
+        assert self._variables(_CSHARP_628_SRC, "csharp") == [
+            "CONST_FIELD",
+            "IFACE_CONST",
+            "REC_CONST",
+            "STATIC_READONLY",
+            "fieldAnonMethod",
+            "fieldLambda",
+            "plainField",
+            "staticField",
+            "topCatchLocal",
+            "topLevelIfLocal",
+            "topLevelVar",
+            "topLevelVar2",
+            "topTryLocal",
+        ]
+
+    def test_csharp_method_ctor_dtor_and_local_fn_locals_dropped(self):
+        names = self._variables(_CSHARP_628_SRC, "csharp")
+        for local in (
+            "methodLocal",
+            "i",
+            "loopBody",
+            "tryLocal",
+            "catchLocal",
+            "localFuncLocal",
+            "lam",
+            "lambdaLocal",
+            "ctorLocal",
+            "staticCtorLocal",
+            "dtorLocal",
+        ):
+            assert local not in names
+
+    def test_csharp_lambda_accessor_and_operator_locals_dropped(self):
+        # lambdaFieldLocal/anonMethodLocal sit in lambdas hanging off FIELD
+        # initializers — the only shapes where lambda_expression /
+        # anonymous_method_expression (not a method) is the gating scope
+        # node; the field holders themselves stay captured. accessor bodies
+        # (property/indexer/event) gate via accessor_declaration; operator
+        # bodies via (conversion_)operator_declaration.
+        names = self._variables(_CSHARP_628_SRC, "csharp")
+        for local in (
+            "lambdaFieldLocal",
+            "anonMethodLocal",
+            "accessorLocal",
+            "indexerLocal",
+            "evAddLocal",
+            "opLocal",
+            "convLocal",
+        ):
+            assert local not in names
+
+    def test_csharp_top_level_statement_vars_kept(self):
+        # C# 9 top-level statements ARE the program's module scope —
+        # plain, if-wrapped, and try-wrapped declarators all stay captured
+        # (mirrors the #612 if/try-wrapped module-level guarantee).
+        names = self._variables(_CSHARP_628_SRC, "csharp")
+        for kept in (
+            "topLevelVar",
+            "topLevelVar2",
+            "topLevelIfLocal",
+            "topTryLocal",
+            "topCatchLocal",
+        ):
+            assert kept in names
+
+
+class TestCSharpErrorRegionHardening:
+    """#629 ERROR-hardening precedent applied to C#: declarations inside
+    error-recovered regions have undecidable scope — they must not be emitted
+    (better unindexed than a lambda local masquerading as a field)."""
+
+    def test_declaration_inside_error_node_not_emitted(self):
+        # Unterminated lambda-in-field shatters the class into an ERROR node;
+        # 'leaked' currently surfaces as ERROR > local_declaration_statement
+        # (live-parse verified) — it must produce no row.
+        src = "class A {\n  Action r = () => {\n    int leaked = 1;\n"
+        syms = _symbols_for(src, "csharp")
         assert [s["name"] for s in syms if s["kind"] == "variable"] == []

--- a/tests/unit/test_symbols_json_enrichment.py
+++ b/tests/unit/test_symbols_json_enrichment.py
@@ -136,12 +136,12 @@ class TestReturnTypeAndParamsSerialized:
 
 
 class TestExtractorVersionBump:
-    def test_extractor_version_is_9_in_both_sites(self):
-        # v9: #626 — Java function-local variables no longer over-captured.
+    def test_extractor_version_is_10_in_both_sites(self):
+        # v10: #628 — C# function-local variables no longer over-captured.
         from tree_sitter_analyzer import _ast_cache_indexer, ast_cache
 
-        assert ast_cache._AST_CACHE_EXTRACTOR_VERSION == 9
-        assert _ast_cache_indexer._AST_CACHE_EXTRACTOR_VERSION == 9
+        assert ast_cache._AST_CACHE_EXTRACTOR_VERSION == 10
+        assert _ast_cache_indexer._AST_CACHE_EXTRACTOR_VERSION == 10
 
 
 class TestCodexP2sOn621:

--- a/tree_sitter_analyzer/_ast_cache_indexer.py
+++ b/tree_sitter_analyzer/_ast_cache_indexer.py
@@ -27,7 +27,8 @@ logger = logging.getLogger(__name__)
 # v7: #624 — PHP const declarations extracted as kind="constant".
 # v8: #626 — JS/TS function-local variables no longer over-captured.
 # v9: #626 — Java function-local variables no longer over-captured.
-_AST_CACHE_EXTRACTOR_VERSION = 9
+# v10: #628 — C# function-local variables no longer over-captured.
+_AST_CACHE_EXTRACTOR_VERSION = 10
 
 
 def check_cache_or_read(

--- a/tree_sitter_analyzer/_ast_extraction.py
+++ b/tree_sitter_analyzer/_ast_extraction.py
@@ -386,6 +386,44 @@ _JAVA_SCOPE_BODY_NODES = frozenset(
     }
 )
 
+# Issue #628 (C#) — same over-capture disease as #626: every C#
+# ``variable_declarator`` became a kind="variable" row, so method/ctor/
+# dtor/local-fn/lambda/accessor/operator locals polluted FTS and symbol
+# search. Class/interface/record fields (const, static readonly, plain)
+# stay captured: they route ``declaration_list > field_declaration`` and
+# NEVER through any node in this set (live-parse verified).
+#
+# Unlike Java, ``block`` is deliberately ABSENT: C# top-level statements
+# (C# 9 top-level programs) put blocks at compilation-unit level
+# (``block < if_statement < global_statement``), so a block-keyed set
+# would drop if/try-wrapped top-level declarators and break the #612
+# module-scope guarantee. Function-keying is complete anyway: every
+# local's ancestry passes through one of these declaration nodes.
+# ``accessor_declaration`` gates property/indexer/event get/set/init/
+# add/remove bodies (their bodies are plain ``block``s);
+# ``local_function_statement`` is itself redundant under a method but
+# kept for explicitness (and gates top-level local functions);
+# ``lambda_expression`` / ``anonymous_method_expression`` cover lambdas
+# and ``delegate`` bodies hanging off FIELD initializers (lambdas in
+# methods are already inside the method). ``ERROR`` per the #629
+# hardening precedent: declarations inside error-recovered regions have
+# undecidable scope — better unindexed than a local masquerading as a
+# field.
+_CSHARP_SCOPE_BODY_NODES = frozenset(
+    {
+        "method_declaration",
+        "constructor_declaration",
+        "destructor_declaration",
+        "operator_declaration",
+        "conversion_operator_declaration",
+        "local_function_statement",
+        "accessor_declaration",
+        "lambda_expression",
+        "anonymous_method_expression",
+        "ERROR",
+    }
+)
+
 
 def _php_constants(node: Any, source: str) -> list[dict[str, Any]]:
     """Return kind="constant" symbols for a PHP const_declaration, one row
@@ -789,11 +827,13 @@ def _walk_for_symbols(
     ``enclosed`` tracks (top-down, no parent walking) whether *node* sits
     inside a Python function/class body (#610), a Go function body (#613),
     a Rust function/closure body (#613), a PHP function/closure body
-    (#624), a JS/TS function/method/static-block body (#626), or a Java
-    method/ctor/lambda/initializer body (#626 Java half) —
+    (#624), a JS/TS function/method/static-block body (#626), a Java
+    method/ctor/lambda/initializer body (#626 Java half), or a C#
+    method/ctor/dtor/local-fn/lambda/accessor/operator body (#628) —
     module/package-constant capture must fire at top-level scope only,
-    including ``if``/``try``-wrapped module-level assignments, and JS/TS/Java
-    function-local declarators must NOT produce kind="variable" rows.
+    including ``if``/``try``-wrapped module-level assignments, and
+    JS/TS/Java/C# function-local declarators must NOT produce
+    kind="variable" rows.
     """
     if depth > 20:
         return
@@ -870,12 +910,15 @@ def _walk_for_symbols(
     elif (
         node_type in _VAR_DECL_LIKE
         and name_node is not None
-        # #626: JS/TS/Java function-local declarators are not cross-file
-        # symbols — skip them. The ast_cache path only ever delivers the
-        # language ids "javascript"/"typescript"/"java" for this family
-        # (.jsx → "javascript", .tsx → "typescript", .java → "java"), so
-        # gating on these ids is complete.
-        and not (language in ("javascript", "typescript", "java") and enclosed)
+        # #626/#628: JS/TS/Java/C# function-local declarators are not
+        # cross-file symbols — skip them. The ast_cache path only ever
+        # delivers the language ids "javascript"/"typescript"/"java"/
+        # "csharp" for this family (.jsx → "javascript", .tsx →
+        # "typescript", .java → "java", .cs → "csharp"), so gating on
+        # these ids is complete.
+        and not (
+            language in ("javascript", "typescript", "java", "csharp") and enclosed
+        )
     ):
         name = _node_text(name_node, source)
         if not name.startswith("_") or depth < 3:
@@ -927,6 +970,7 @@ def _walk_for_symbols(
             and node_type in _JSTS_SCOPE_BODY_NODES
         )
         or (language == "java" and node_type in _JAVA_SCOPE_BODY_NODES)
+        or (language == "csharp" and node_type in _CSHARP_SCOPE_BODY_NODES)
     )
     for child in node.children:
         _walk_for_symbols(child, source, symbols, language, depth + 1, child_enclosed)

--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -66,7 +66,8 @@ logger = logging.getLogger(__name__)
 # v7: #624 — PHP const declarations extracted as kind="constant".
 # v8: #626 — JS/TS function-local variables no longer over-captured.
 # v9: #626 — Java function-local variables no longer over-captured.
-_AST_CACHE_EXTRACTOR_VERSION = 9
+# v10: #628 — C# function-local variables no longer over-captured.
+_AST_CACHE_EXTRACTOR_VERSION = 10
 
 
 class SchemaIntegrityError(RuntimeError):


### PR DESCRIPTION
Closes #628 — completes the over-capture family (JS/TS #629, Java #630).

## Summary
C# scope set gates the `_VAR_DECL_LIKE` branch: `{method, constructor, destructor, operator, conversion_operator declarations, local_function_statement, accessor_declaration, lambda_expression, anonymous_method_expression, ERROR}`. 27 declaration shapes live-probed.

**The review-worthy decision — `block` deliberately ABSENT (diverges from Java #630)**: C# 9 top-level statements put blocks at compilation-unit level (`block < if_statement < global_statement`); a block-keyed set would drop if/try-wrapped top-level declarators and break the #612 module-scope guarantee. Function-keying is complete — every probed local routes through a set node. Accessor bodies are blocks gated by `accessor_declaration`; field rows never route through any set node (verified).

- KEEP: fields/const/static-readonly/interface+record constants, top-level statement vars (the program's module scope)
- DROP: method/ctor/dtor/operator/local-fn/lambda/anon-method/accessor locals + ERROR regions (leak demonstrated live pre-fix)
- `_AST_CACHE_EXTRACTOR_VERSION` 9→10; **no shadow-semantics change** (grep-verified: only JS/TS consume kind=variable shadow sets)

## Test plan
- [x] RED-first: 5 failed pre-fix → 313 regression passed; #630's csharp pin consciously flipped (cites v10)
- [x] Golden suites: 36 passed, swift fail stash-proven pre-existing — zero drift
- [x] E2E probe: 5 kept rows (fields + top-level), method/lambda locals absent — pasted
- [x] Ratchet exit=0; ruff clean; lead independently re-ran 115 tests + verified both version sites + push diff=0