### PR TITLE
fix(html): self-closing tags no longer captured twice

### DIFF
--- a/tests/unit/languages/test_html_plugin_coverage_boost.py
+++ b/tests/unit/languages/test_html_plugin_coverage_boost.py
@@ -356,19 +356,40 @@ class TestRealParsingPaths:
         """Lines 168-179: self_closing_tag node type"""
         tree = _parse_html("<br/>")
         elements = extractor.extract_html_elements(tree, "<br/>")
-        # Exact current behavior: the self_closing_tag is captured twice
-        # (element node + self_closing_tag node) -> 2 entries
-        assert [e.tag_name for e in elements] == ["br", "br"]
+        # #632: the element node wraps the self_closing_tag child; only the
+        # parent element is captured (the child would be a duplicate) -> 1 entry
+        assert [e.tag_name for e in elements] == ["br"]
 
     def test_input_with_boolean_attribute(self, extractor):
         """Lines 295-337: boolean attribute (attribute_name only, no value)"""
         tree = _parse_html("<input disabled checked/>")
         elements = extractor.extract_html_elements(tree, "<input disabled checked/>")
-        # Exact current behavior: self-closing input captured twice
-        # (element node + self_closing_tag node) -> 2 entries
-        assert [e.tag_name for e in elements] == ["input", "input"]
+        # #632: self-closing input captured once (parent element only; the
+        # self_closing_tag child is skipped as a duplicate) -> 1 entry
+        assert [e.tag_name for e in elements] == ["input"]
         assert "disabled" in elements[0].attributes
         assert "checked" in elements[0].attributes
+
+    def test_self_closing_dedup_issue_632(self, extractor):
+        """#632: self-closing tags yield exactly one entry each.
+
+        tree-sitter-html wraps self_closing_tag inside an element node
+        (element is the parent, self_closing_tag the child carrying
+        tag_name/attributes); the walk must not capture both.
+        """
+        code = '<div><br/><input type="text"/></div>'
+        tree = _parse_html(code)
+        elements = extractor.extract_html_elements(tree, code)
+        assert [e.tag_name for e in elements] == ["div", "br", "input"]
+        # The surviving capture (parent element) still carries the attributes
+        assert elements[2].attributes == {"type": "text"}
+
+    def test_void_element_without_slash_issue_632(self, extractor):
+        """#632: void elements WITHOUT a slash (<br>) parse as
+        element > start_tag (no self_closing_tag node) -> exactly 1 entry."""
+        tree = _parse_html("<br>")
+        elements = extractor.extract_html_elements(tree, "<br>")
+        assert [e.tag_name for e in elements] == ["br"]
 
     def test_input_with_unquoted_attribute_value(self, extractor):
         """Line 319: attribute_value child (not quoted_attribute_value)"""

--- a/tree_sitter_analyzer/languages/html_plugin.py
+++ b/tree_sitter_analyzer/languages/html_plugin.py
@@ -239,6 +239,12 @@ class HtmlElementExtractor(ElementExtractor):
         elements.append(element)
         if hasattr(node, "children"):
             for child in node.children:
+                # #632: an element node wraps its self_closing_tag child
+                # (element > self_closing_tag); the parent capture above
+                # already carries the tag_name/attributes extracted from
+                # that child, so walking it would duplicate the entry.
+                if getattr(child, "type", None) == "self_closing_tag":
+                    continue
                 self._traverse_for_html_elements(child, elements, source_code, element)
         return True
 


### PR DESCRIPTION
Closes #632 (found by ratchet batch-23's pins).

## Root cause
tree-sitter-html wraps every self-closing tag as `element > self_closing_tag` (parent/child); `_is_html_element_node` matches BOTH types, so the walk captured the parent (whose helpers already extract tag_name/attributes by descending into the child) then recursed and captured the child again — `<br/>` yielded 2 entries.

## Fix (6 lines)
Skip `self_closing_tag` children at the recursion site — the parent capture carries the attributes. The type stays in `_is_html_element_node` so unwrapped self_closing_tags (error-recovery trees) still extract.

Void elements without slash (`<br>`, `<img src=...>`) live-parsed: `element > start_tag`, no self_closing_tag node, already 1 entry — pinned.

## Test plan
- [x] RED-first: 3 failed pre-fix; batch-23's `== 2` pins consciously flipped to `== 1` (comments cite #632); new exact-list + attribute-survival + void-element pins
- [x] 5 HTML test files 105 passed (-n 0); accuracy/tags_attrs needed zero re-pins (no slash-form fixtures)
- [x] Goldens: zero `/>` in html sample — no regen needed; golden FULL suites 96 passed (swift fail stash-proven pre-existing)
- [x] Ratchet exit=0; lead independently re-ran 45 tests + push diff=0