### PR TITLE
test: ratchet batch-24 — pin 32 loose assertions in top-4 AST-ranked files

### DIFF
--- a/scripts/loose_assertion_baseline.txt
+++ b/scripts/loose_assertion_baseline.txt
@@ -47,7 +47,9 @@
 #   exemptions in top-4 AST-ranked files).
 #   batch-23 (AST): 711 -> 679, 2026-06-13 (32 exact pins in top-4
 #   AST-ranked files, no exemptions).
+#   batch-24 (AST): 679 -> 647, 2026-06-13 (32 exact pins in top-4
+#   AST-ranked files, no exemptions).
 
-BASELINE_COUNT=679
+BASELINE_COUNT=647
 MEASUREMENT_DATE=2026-06-13
 MEASUREMENT_COMMAND="uv run python scripts/check_loose_assertions.py --baseline"

--- a/tests/unit/languages/test_markdown_plugin_extract.py
+++ b/tests/unit/languages/test_markdown_plugin_extract.py
@@ -224,8 +224,9 @@ class TestExtractInlineHTML:
         )
         elems = []
         ext._extract_inline_html(root, elems)
-        assert len(elems) >= 1
-        assert any(e.element_type == "html_inline" for e in elems)
+        # <span> and </span> each produce one html_inline element
+        assert len(elems) == 2
+        assert all(e.element_type == "html_inline" for e in elems)
 
     def test_inline_html_br_tag(self):
         ext = _setup_extractor("text<br>more")
@@ -331,8 +332,9 @@ class TestExtractPipeTables:
         assert len(tables) == 1
         assert tables[0].element_type == "table"
         assert tables[0].type == "table"
-        assert tables[0].row_count >= 1
-        assert tables[0].column_count >= 1
+        # header row + one data row (separator excluded); two columns a/b
+        assert tables[0].row_count == 2
+        assert tables[0].column_count == 2
 
     def test_pipe_table_no_pipe_node(self):
         ext = _setup_extractor("plain")
@@ -364,7 +366,7 @@ class TestExtractEmphasisElements:
         elems = []
         ext._extract_emphasis_elements(root, elems)
         bold = [e for e in elems if e.element_type == "strong_emphasis"]
-        assert len(bold) >= 1
+        assert len(bold) == 1
         assert bold[0].text == "bold text"
 
     def test_bold_underscore(self):
@@ -383,7 +385,7 @@ class TestExtractEmphasisElements:
         elems = []
         ext._extract_emphasis_elements(root, elems)
         bold = [e for e in elems if e.element_type == "strong_emphasis"]
-        assert len(bold) >= 1
+        assert len(bold) == 1
 
     def test_italic(self):
         ext = _setup_extractor("*italic text*")
@@ -401,7 +403,7 @@ class TestExtractEmphasisElements:
         elems = []
         ext._extract_emphasis_elements(root, elems)
         italic = [e for e in elems if e.element_type == "emphasis"]
-        assert len(italic) >= 1
+        assert len(italic) == 1
         assert italic[0].text == "italic text"
 
     def test_italic_underscore(self):
@@ -420,7 +422,7 @@ class TestExtractEmphasisElements:
         elems = []
         ext._extract_emphasis_elements(root, elems)
         italic = [e for e in elems if e.element_type == "emphasis"]
-        assert len(italic) >= 1
+        assert len(italic) == 1
 
     def test_no_inline(self):
         ext = _setup_extractor("plain")
@@ -451,7 +453,7 @@ class TestExtractStrikethrough:
         )
         elems = []
         ext._extract_strikethrough_elements(root, elems)
-        assert len(elems) >= 1
+        assert len(elems) == 1
         assert elems[0].element_type == "strikethrough"
         assert elems[0].text == "struck text"
 

--- a/tests/unit/test_code_similarity.py
+++ b/tests/unit/test_code_similarity.py
@@ -104,10 +104,11 @@ class TestDetectTextualClonesCached:
     def test_finds_clones_via_cache(self, cached_clone_project):
         cache, root = cached_clone_project
         groups = detect_textual_clones_cached(cache, root, min_lines=3)
-        assert len(groups) >= 1
+        # exactly one clone pair: process_data / handle_records
+        assert len(groups) == 1
         group = groups[0]
         assert group.method == "textual_cached"
-        assert len(group.functions) >= 2
+        assert len(group.functions) == 2
 
     def test_no_clones_returns_empty(self, tmp_path):
         project = tmp_path / "unique"
@@ -118,7 +119,8 @@ class TestDetectTextualClonesCached:
         cache.index_project(max_files=100)
         try:
             groups = detect_textual_clones_cached(cache, str(project), min_lines=2)
-            assert all(len(g.functions) >= 2 for g in groups)
+            # the two functions are distinct — no clone groups at all
+            assert groups == []
         finally:
             cache.close()
 
@@ -137,7 +139,7 @@ class TestDetectStructuralClonesCached:
     def test_finds_structural_clones(self, cached_clone_project):
         cache, root = cached_clone_project
         groups = detect_structural_clones_cached(cache, root, min_lines=3)
-        assert len(groups) >= 1
+        assert len(groups) == 1
         group = groups[0]
         assert group.method == "structural_cached"
         assert group.similarity == 1.0
@@ -160,12 +162,15 @@ class TestExtractCachedFunctions:
     def test_extracts_from_cache(self, cached_clone_project):
         cache, root = cached_clone_project
         functions = _extract_cached_functions(cache, root, min_lines=3)
-        assert len(functions) >= 2
+        # min_lines=3 keeps process_data/handle_records, drops unique_logic
+        assert len(functions) == 2
+        assert {f[1] for f in functions} == {"process_data", "handle_records"}
         for _file_path, name, start, end, lang, body in functions:
             assert name
-            assert start > 0
-            assert end >= start
-            assert lang
+            # both fixture functions span lines 1-7 of their module
+            assert start == 1
+            assert end == 7
+            assert lang == "python"
             assert body
 
     def test_min_lines_filter(self, cached_clone_project):
@@ -192,13 +197,13 @@ class TestAnalyzeCodeSimilarityWithCache:
     def test_structural_only_cached(self, cached_clone_project):
         _, root = cached_clone_project
         result = analyze_code_similarity(root, mode="structural", min_lines=3)
-        assert len(result.groups) >= 1
+        assert len(result.groups) == 1
         assert all(g.method == "structural_cached" for g in result.groups)
 
     def test_textual_only_cached(self, cached_clone_project):
         _, root = cached_clone_project
         result = analyze_code_similarity(root, mode="textual", min_lines=3)
-        assert len(result.groups) >= 1
+        assert len(result.groups) == 1
         assert all(g.method == "textual_cached" for g in result.groups)
 
     def test_no_cache_falls_back_gracefully(self, tmp_path):

--- a/tests/unit/test_cross_file_backfill.py
+++ b/tests/unit/test_cross_file_backfill.py
@@ -68,8 +68,12 @@ class TestBackfillCrossFileEdges:
         assert "resolved" in result
         assert "unchanged" in result
         assert "errors" in result
-        assert result["total"] >= 0
-        assert result["resolved"] >= 0
+        # index_project already backfilled, so this second pass is a no-op:
+        # all 9 call edges are visited, none newly resolved.
+        assert result["total"] == 9
+        assert result["resolved"] == 0
+        assert result["unchanged"] == 9
+        assert result["errors"] == 0
 
     def test_backfill_writes_resolved_file(self, multi_file_project):
         _project, cache = multi_file_project
@@ -79,7 +83,7 @@ class TestBackfillCrossFileEdges:
             "SELECT callee_name, callee_resolved_file FROM edges "
             "WHERE kind = 'calls' AND callee_resolved_file != ''"
         ).fetchall()
-        assert len(rows) > 0
+        assert len(rows) == 6
         resolved_names = {r["callee_name"] for r in rows}
         assert "format_user" in resolved_names or "handle_request" in resolved_names
 
@@ -87,9 +91,10 @@ class TestBackfillCrossFileEdges:
         _project, cache = multi_file_project
         cache.backfill_cross_file_edges()
         stats = cache.get_cross_file_stats()
-        assert stats["total"] >= 0
-        assert stats["resolved"] >= 0
-        assert stats["cross_file"] >= 0
+        # 9 call edges; 6 resolve to a file, 3 of those land in another file
+        assert stats["total"] == 9
+        assert stats["resolved"] == 6
+        assert stats["cross_file"] == 3
         assert "pct" in stats
 
     def test_query_callers_uses_resolved_file(self, multi_file_project):
@@ -122,7 +127,8 @@ class TestBackfillCrossFileEdges:
         stats = cache.index_project(max_files=100)
         assert "cross_file_backfill" in stats
         bf = stats["cross_file_backfill"]
-        assert bf["total"] >= 0
+        # single call edge: main -> helper
+        assert bf["total"] == 1
         cache.close()
 
 
@@ -139,4 +145,4 @@ class TestCrossFileStats:
     def test_stats_after_indexing(self, multi_file_project):
         _project, cache = multi_file_project
         stats = cache.get_cross_file_stats()
-        assert stats["total"] > 0
+        assert stats["total"] == 9

--- a/tests/unit/test_dependency_matrix.py
+++ b/tests/unit/test_dependency_matrix.py
@@ -70,9 +70,10 @@ class TestDependencyMatrixBuild:
 
         assert "a.py" in result.modules
         assert "b.py" in result.modules
-        assert len(result.coupling_pairs) >= 1
-        assert result.coupling_pairs[0].import_count >= 1
-        assert result.coupling_pairs[0].call_count >= 1
+        # one a.py<->b.py pair from 1 import + 1 resolved call edge
+        assert len(result.coupling_pairs) == 1
+        assert result.coupling_pairs[0].import_count == 1
+        assert result.coupling_pairs[0].call_count == 1
 
     def test_build_empty_cache(self, tmp_path):
         mock_cache = MagicMock()
@@ -142,9 +143,10 @@ class TestDependencyMatrixBuild:
             dm = DependencyMatrix(str(tmp_path))
             top = dm.most_coupled(top_k=2)
 
-        assert len(top) <= 2
-        if len(top) >= 1:
-            assert top[0].score > 0
+        # three coupled pairs exist; top_k=2 keeps a-b (score 4.0) and b-c (3.0)
+        assert len(top) == 2
+        assert top[0].score == 4.0
+        assert top[1].score == 3.0
 
     def test_unstable_modules(self, tmp_path):
         mock_cache = MagicMock()
@@ -176,8 +178,8 @@ class TestDependencyMatrixBuild:
             dm = DependencyMatrix(str(tmp_path))
             s = dm.summary()
 
-        assert s["module_count"] >= 2
-        assert s["coupling_pair_count"] >= 1
+        assert s["module_count"] == 2
+        assert s["coupling_pair_count"] == 1
 
     def test_high_coupling_pairs(self, tmp_path):
         mock_cache = MagicMock()
@@ -197,7 +199,8 @@ class TestDependencyMatrixBuild:
             dm = DependencyMatrix(str(tmp_path))
             result = dm.build()
 
-        assert len(result.high_coupling_pairs) >= 1
+        # all five a{i}.py<->b.py pairs (5 imports + 1 call each) rank as high
+        assert len(result.high_coupling_pairs) == 5
 
 
 class TestDependencyMatrixSelfCallFilter:
@@ -282,4 +285,4 @@ class TestDependencyMatrixCrossFileIntegration:
         entry = dm.coupling_between("a.py", "b.py")
 
         assert entry is not None
-        assert entry.call_count >= 1, "cross-file call edge must be counted"
+        assert entry.call_count == 1, "the single bar->foo call edge must be counted"


### PR DESCRIPTION
## Summary
Loose-assertion ratchet batch 24. Top-4 (4-way tie at 8, lexicographic; html files excluded per the parallel #632 fix — none ranked anyway):

| File | Pins |
|---|---|
| tests/unit/languages/test_markdown_plugin_extract.py | 8 |
| tests/unit/test_code_similarity.py | 8 |
| tests/unit/test_cross_file_backfill.py | 8 |
| tests/unit/test_dependency_matrix.py | 8 |

Baseline: **679 → 647** (= exactly 32, zero exemptions, lead re-verified live).

Highlights: 恒真 `all(... for g in [])` trap pinned to the live fact (`groups == []`); an `if len(top) >= 1:` guard that let the assert go vacuous replaced with `len(top) == 2` + exact scores (4.0/3.0); second-backfill idempotence pinned as the live value with explanatory comment (resolved==0 is the no-op re-run, not a dead branch).

## Test plan
- [x] All 4 files individually `-n 0`: 29/19/8/18 passed
- [x] Diff gate exit=0
- [x] `--baseline` measures 647 == recorded (lead independently re-verified)