### PR TITLE
test: ratchet batch-25 — pin 28 loose assertions in top-4 AST-ranked files

### DIFF
--- a/scripts/loose_assertion_baseline.txt
+++ b/scripts/loose_assertion_baseline.txt
@@ -49,7 +49,9 @@
 #   AST-ranked files, no exemptions).
 #   batch-24 (AST): 679 -> 647, 2026-06-13 (32 exact pins in top-4
 #   AST-ranked files, no exemptions).
+#   batch-25 (AST): 647 -> 619, 2026-06-13 (28 exact pins in top-4
+#   AST-ranked files, no exemptions).
 
-BASELINE_COUNT=647
+BASELINE_COUNT=619
 MEASUREMENT_DATE=2026-06-13
 MEASUREMENT_COMMAND="uv run python scripts/check_loose_assertions.py --baseline"

--- a/tests/integration/mcp/test_user_story_1_integration.py
+++ b/tests/integration/mcp/test_user_story_1_integration.py
@@ -491,8 +491,8 @@ if __name__ == '__main__':
         assert "summary" in scale_result
 
         summary = scale_result["summary"]
-        assert summary["classes"] >= 1
-        assert summary["methods"] >= 3
+        assert summary["classes"] == 1
+        assert summary["methods"] == 6
 
         # Step 2: Analyze code structure (use JSON format for test assertions)
         structure_args = {
@@ -512,8 +512,8 @@ if __name__ == '__main__':
         assert "table_output" in structure_result
 
         metadata = structure_result["metadata"]
-        assert metadata["classes_count"] >= 1
-        assert metadata["methods_count"] >= 3
+        assert metadata["classes_count"] == 1
+        assert metadata["methods_count"] == 6
 
         # Step 3: Verify integration consistency
         # Scale and structure results should be consistent
@@ -542,7 +542,7 @@ if __name__ == '__main__':
 
         # Verify this is a large file
         file_metrics = scale_result["file_metrics"]
-        assert file_metrics["total_lines"] > 100  # Should be a large file
+        assert file_metrics["total_lines"] == 315  # py_large fixture line count
 
         # Step 2: Structure analysis with token optimization
         # Test without output_file first to verify basic functionality (use JSON format)
@@ -561,7 +561,9 @@ if __name__ == '__main__':
         # Test token optimization by checking if suppress_output would work
         # (Note: actual file output testing may require different approach)
         table_output = structure_result["table_output"]
-        assert len(table_output) > 100  # Should have substantial content
+        # Content pin (not byte-length: the temp-file stem appears in the
+        # header line, so byte length varies per run)
+        assert table_output.count("\n") == 38
         assert "ProcessorInterface" in table_output  # Adjust based on actual content
 
     @pytest.mark.asyncio
@@ -723,7 +725,9 @@ if __name__ == '__main__':
         # Should provide detailed structure table
         assert "table_output" in structure_result
         table_output = structure_result["table_output"]
-        assert len(table_output) > 100  # Should be substantial
+        # Content pin (not byte-length: the temp-file stem appears in the
+        # header line, so byte length varies per run)
+        assert table_output.count("\n") == 31
 
         # US1-AC3: Analysis completes within 3 seconds for typical files
         # (Tested in test_performance_requirements)

--- a/tests/integration/mcp/test_user_story_3_query_integration.py
+++ b/tests/integration/mcp/test_user_story_3_query_integration.py
@@ -545,12 +545,12 @@ asyncio.run(main())
 
         assert result["success"] is True
         assert "results" in result
-        assert result["count"] > 0
+        assert result["count"] == 11
 
         method_names = [
             r["content"] for r in result["results"] if "initialize" in r["content"]
         ]
-        assert len(method_names) > 0
+        assert len(method_names) == 5
         print(f"✓ Javaメソッドクエリテスト成功: {result['count']}個のメソッド検出")
 
     @pytest.mark.asyncio
@@ -569,7 +569,7 @@ asyncio.run(main())
 
         assert result["success"] is True
         assert "captures" in result
-        assert result["total_count"] > 0
+        assert result["total_count"] == 6
 
         if "interface" in result["captures"]:
             interfaces = result["captures"]["interface"]["items"]
@@ -597,7 +597,7 @@ asyncio.run(main())
         )
 
         assert result["success"] is True
-        assert result["count"] > 0
+        assert result["count"] == 18
 
         class_contents = [r["content"] for r in result["results"]]
         class_names = []
@@ -626,14 +626,19 @@ asyncio.run(main())
         )
 
         assert result["success"] is True
+        assert result["count"] == 4
 
-        if result["count"] > 0:
-            constructor_found = any(
-                "constructor" in r["content"].lower() for r in result["results"]
-            )
-            assert (
-                constructor_found or result["count"] > 0
-            )
+        # 恒真陷阱 fixed: the old `constructor_found or result["count"] > 0`
+        # inside `if result["count"] > 0` was vacuously true — and the live
+        # value of constructor_found is False (Java constructor source never
+        # contains the literal "constructor"). Pin the real declarations.
+        constructor_names = [r["content"].split("(")[0] for r in result["results"]]
+        assert constructor_names == [
+            "public ComplexService",
+            "public ComplexService",
+            "public ServiceException",
+            "public ServiceException",
+        ]
 
         print(f"✓ カスタムクエリテスト成功: {result['count']}個の結果")
 
@@ -714,7 +719,7 @@ asyncio.run(main())
         with open(output_file, encoding="utf-8") as f:
             file_content = json.load(f)
             assert "results" in file_content
-            assert len(file_content["results"]) > 0
+            assert len(file_content["results"]) == 104
 
         print(
             f"✓ ファイル出力最適化テスト成功: {result['count']}個の結果を{output_file.name}に保存"
@@ -735,7 +740,7 @@ asyncio.run(main())
         )
 
         assert result["success"] is True
-        assert result["total_count"] > 0
+        assert result["total_count"] == 12
 
         if "header" in result["captures"]:
             headers = result["captures"]["header"]["items"]

--- a/tests/unit/cli/test_info_commands.py
+++ b/tests/unit/cli/test_info_commands.py
@@ -360,7 +360,7 @@ class TestR37adListQueriesJsonEnvelope:
         assert captured.get("scope") == "single_language"
         assert isinstance(captured.get("queries"), list)
         assert isinstance(captured.get("query_count"), int)
-        assert captured["query_count"] > 0
+        assert captured["query_count"] == 88
         agent_summary = captured.get("agent_summary")
         assert isinstance(agent_summary, dict)
         assert agent_summary["verdict"] == "INFO"
@@ -388,8 +388,8 @@ class TestR37adListQueriesJsonEnvelope:
         assert captured.get("scope") == "all_languages"
         assert captured.get("language") is None
         assert isinstance(captured.get("languages"), list)
-        assert captured["language_count"] > 0
-        assert captured["query_count"] > 0
+        assert captured["language_count"] == 17
+        assert captured["query_count"] == 948
         assert captured["agent_summary"]["verdict"] == "INFO"
 
     def test_list_queries_text_path_preserved(self):
@@ -410,7 +410,8 @@ class TestR37adListQueriesJsonEnvelope:
             rc = cmd.execute()
         assert rc == 0
         assert mock_json.call_count == 0, "text mode must not call output_json"
-        assert mock_list.call_count > 0
+        # One header line + one line per python query key (88)
+        assert mock_list.call_count == 89
 
 
 class TestR37aeRemainingInfoCommandsJsonEnvelope:
@@ -490,7 +491,7 @@ class TestR37aeRemainingInfoCommandsJsonEnvelope:
         assert captured.get("success") is True
         assert captured.get("verdict") == "INFO"
         assert isinstance(captured.get("languages"), list)
-        assert captured.get("language_count", 0) > 0
+        assert captured.get("language_count") == 21
         # Each language entry must have the documented shape.
         sample = captured["languages"][0]
         assert "language" in sample
@@ -514,7 +515,7 @@ class TestR37aeRemainingInfoCommandsJsonEnvelope:
         assert captured.get("success") is True
         assert captured.get("verdict") == "INFO"
         assert isinstance(captured.get("extensions"), list)
-        assert captured.get("extension_count", 0) > 0
+        assert captured.get("extension_count") == 51
 
     def test_show_languages_text_path_preserved(self):
         """Text default must still go through output_list (backward compat)."""
@@ -531,4 +532,5 @@ class TestR37aeRemainingInfoCommandsJsonEnvelope:
             rc = cmd.execute()
         assert rc == 0
         assert mock_json.call_count == 0
-        assert mock_list.call_count > 0
+        # One header line + one line per supported language (21)
+        assert mock_list.call_count == 22

--- a/tests/unit/core/test_async_query_service.py
+++ b/tests/unit/core/test_async_query_service.py
@@ -88,9 +88,8 @@ const arrowFunction = () => {
         # 実際に実行
         result = await result_coro
         assert isinstance(result, list)
-        assert (
-            len(result) >= 4
-        )  # test_function + method + async_function + another_function
+        # test_function + method + async_function + another_function
+        assert len(result) == 4
 
     @pytest.mark.asyncio
     async def test_query_key_execution(self, sample_python_file):
@@ -102,9 +101,8 @@ const arrowFunction = () => {
         )
 
         assert results is not None
-        assert (
-            len(results) >= 4
-        )  # test_function + method + async_function + another_function
+        # test_function + method + async_function + another_function
+        assert len(results) == 4
         assert any(r["capture_name"] == "function" for r in results)
 
         # 関数名の確認
@@ -140,7 +138,9 @@ const arrowFunction = () => {
         )
 
         assert results is not None
-        assert len(results) >= 0  # カスタムクエリの結果は実装依存
+        # 恒真陷阱 fixed: `len(results) >= 0` is always true.
+        # Live fact: the custom query matches the 4 function names.
+        assert len(results) == 4
 
     @pytest.mark.asyncio
     async def test_concurrent_execution(self, sample_python_file):
@@ -167,7 +167,8 @@ const arrowFunction = () => {
         for result in results:
             assert result is not None
             assert isinstance(result, list)
-            assert len(result) >= 1
+        # function / class / function queries on the fixture
+        assert [len(r) for r in results] == [4, 1, 4]
 
     @pytest.mark.asyncio
     async def test_multiple_languages_concurrent(
@@ -279,7 +280,9 @@ const arrowFunction = () => {
             content, encoding = await service._read_file_async(sample_python_file)
             assert isinstance(content, str)
             assert isinstance(encoding, str)
-            assert len(content) > 0
+            # Content pin (not byte-length: tempfile mode="w" newline
+            # translation makes byte counts platform-dependent)
+            assert content.count("def ") == 4
             # ファイル内容が読み込まれていることを確認
             assert "def " in content or "function" in content
 
@@ -307,8 +310,8 @@ def function_{i}():
             )
 
             assert results is not None
-            # 大きなファイルでも結果が返されることを確認（具体的な数は実装依存）
-            assert len(results) >= 10  # 少なくとも10個の要素が見つかることを期待
+            # One capture per generated function
+            assert len(results) == 1000
 
         finally:
             Path(large_file).unlink(missing_ok=True)
@@ -337,5 +340,5 @@ def function_{i}():
             elif isinstance(result, Exception):
                 pytest.fail(f"Task failed with exception: {result}")
 
-        # 大部分のタスクが成功することを確認
-        assert successful_results >= 15  # 20個中15個以上が成功
+        # Exceptions already pytest.fail above, so every task must be a list
+        assert successful_results == 20


### PR DESCRIPTION
## Summary
Loose-assertion ratchet batch 25. Top-4 (8-way tie at 7, lexicographic):

| File | Pins |
|---|---|
| tests/integration/mcp/test_user_story_1_integration.py | 7 |
| tests/integration/mcp/test_user_story_3_query_integration.py | 7 |
| tests/unit/cli/test_info_commands.py | 7 |
| tests/unit/core/test_async_query_service.py | 7 |

Baseline: **647 → 619** (= exactly 28, zero exemptions, lead re-verified live).

Highlights: a 恒真陷阱 (`constructor_found or count > 0` inside `if count > 0`) where `constructor_found` was actually **False** live — replaced with `count == 4` + full-list pin; table-output length pins → newline-count content pins (tempfile stem in header makes bytes run-dependent); info_commands registry counts pinned (88/948/17/21/51 — grammar/plugin additions go consciously RED); tempfile newline-translation guarded via `def `-count pins.

## Test plan
- [x] All 4 files individually `-n 0`: 5+2skip/8/36/15 passed (skips pre-existing, none added)
- [x] Diff gate exit=0
- [x] `--baseline` measures 619 == recorded (lead independently re-verified)