### PR TITLE
fix(toon): heterogeneous arrays no longer drop fields silently

### DIFF
--- a/tests/unit/formatters/test_toon_heterogeneous_637.py
+++ b/tests/unit/formatters/test_toon_heterogeneous_637.py
@@ -1,0 +1,94 @@
+"""Issue #637 — TOON encoder silently dropped fields absent from a
+heterogeneous array's first row.
+
+The array-table header was built from ``items[0].keys()`` only
+(``_handle_array_table`` / ``_infer_schema``), and ``_handle_dict_key``
+routed ANY first-item-is-dict list into the table path without the
+homogeneity check that ``_handle_list_start`` carries.  Result: a ghost
+first row without ``body`` erased every later caller's ``body`` — the
+"token-efficient" format was silently LOSSY.
+
+Fix shape (option a): the table schema is the UNION of all rows' keys in
+first-seen order; rows missing a key render an empty cell.  Homogeneous
+arrays are byte-identical to the pre-fix output (union of identical key
+sets == first row's keys).
+
+All pins are exact ``==`` (user-locked rule — no substring-only/loose
+assertions for deterministic encoder output).
+"""
+
+from tree_sitter_analyzer.formatters.toon_encoder import ToonEncoder
+from tree_sitter_analyzer.formatters.toon_formatter import ToonFormatter
+
+
+class TestHeterogeneousArrayLosslessness:
+    """Fields present in ANY row must appear in the TOON output."""
+
+    def test_issue_637_minimal_repro_body_survives(self) -> None:
+        """The lead-verified repro: second row's ``body`` must survive."""
+        out = ToonFormatter().format(
+            {"results": [{"a": 1}, {"a": 2, "body": "IMPORTANT"}]}
+        )
+        assert out == "results:\n  [2]{a,body}:\n    1,\n    2,IMPORTANT"
+
+    def test_union_schema_first_seen_order(self) -> None:
+        """Union keeps first-seen key order across rows."""
+        out = ToonEncoder().encode({"rows": [{"b": 1}, {"a": 2}]})
+        assert out == "rows:\n  [2]{b,a}:\n    1,\n    ,2"
+
+    def test_empty_dict_first_row_no_longer_erases_table(self) -> None:
+        """Pre-fix: schema from ``{}`` was empty → EVERY field of every row
+        was dropped (``[2]{}:`` with blank rows). Union recovers them."""
+        out = ToonEncoder().encode({"rows": [{}, {"a": 1}]})
+        assert out == "rows:\n  [2]{a}:\n    \n    1"
+
+    def test_nested_heterogeneous_array(self) -> None:
+        """Heterogeneous arrays inside nested dicts go through the same
+        dict-key route and must also be lossless."""
+        out = ToonEncoder().encode({"outer": {"rows": [{"x": 1}, {"x": 2, "y": 3}]}})
+        assert out == "outer:\n  rows:\n    [2]{x,y}:\n      1,\n      2,3"
+
+    def test_dict_column_annotation_from_first_row_having_key(self) -> None:
+        """Schema annotation (``key{subkeys}``) must come from the first row
+        that HAS the key, not blindly from row 0 (which may lack it)."""
+        out = ToonEncoder().encode(
+            {"rows": [{"a": 1}, {"a": 2, "meta": {"x": 1, "y": 2}}]}
+        )
+        assert out == "rows:\n  [2]{a,meta{x,y}}:\n    1,\n    2,(1,2)"
+
+    def test_mixed_dict_and_scalar_list_encodes_inline_not_crash(self) -> None:
+        """A list whose first item is a dict but later items are scalars must
+        NOT enter the table path (pre-fix: AttributeError → JSON fallback)."""
+        out = ToonEncoder().encode({"rows": [{"a": 1}, "x"]})
+        assert out == "rows: [{a:1},x]"
+
+    def test_infer_schema_is_union(self) -> None:
+        schema = ToonEncoder()._infer_schema([{"a": 1}, {"a": 2, "b": 3}])
+        assert schema == ["a", "b"]
+
+    def test_public_encode_array_table_heterogeneous(self) -> None:
+        """Public convenience API infers the union schema too."""
+        out = ToonEncoder().encode_array_table([{"a": 1}, {"b": 2}])
+        assert out == "[2]{a,b}:\n  1,\n  ,2"
+
+
+class TestHomogeneousArraysUnchanged:
+    """The token-efficiency story: homogeneous tables are byte-identical."""
+
+    def test_homogeneous_table_byte_identical_pin(self) -> None:
+        """Byte-pin captured on develop dbda9a3e BEFORE the #637 fix —
+        must not change by a single byte."""
+        out = ToonEncoder().encode({"results": [{"a": 1, "b": 2}, {"a": 3, "b": 4}]})
+        assert out == "results:\n  [2]{a,b}:\n    1,2\n    3,4"
+
+    def test_homogeneous_formatter_entry_byte_identical_pin(self) -> None:
+        out = ToonFormatter().format(
+            {"results": [{"name": "f", "line": 1}, {"name": "g", "line": 2}]}
+        )
+        assert out == "results:\n  [2]{name,line}:\n    f,1\n    g,2"
+
+    def test_top_level_heterogeneous_list_stays_inline(self) -> None:
+        """``_handle_list_start``'s mixed-key inline form (already lossless)
+        is intentionally preserved — pin so the routing doesn't drift."""
+        out = ToonEncoder().encode([{"a": 1}, {"b": 2}])
+        assert out == "[{a:1},{b:2}]"

--- a/tests/unit/mcp/test_toon_losslessness_637.py
+++ b/tests/unit/mcp/test_toon_losslessness_637.py
@@ -1,0 +1,160 @@
+"""Issue #637 — TOON losslessness invariant at the handle_call_tool boundary.
+
+Rule-11 deliverable: the claim "TOON carries the same information as JSON"
+must be an executable invariant, not prose.  This test drives the REAL
+``handle_call_tool`` closure (NOT ``tool.execute`` — the boundary-order
+trap from RFC-0012) with ``nav action=callers`` and asserts STRUCTURALLY
+that every key present in ANY row of any list-of-dicts in the JSON payload
+appears in the TOON response.  No field-name denylist/allowlist — past
+TOON fixes that patched symptom lists were 假修复 (fake fixes).
+
+The scenario mirrors the real offender: the first caller row is a "ghost"
+without ``body`` while later rows carry one.  Pre-fix, the table header
+was built from the ghost row's keys and every ``body`` vanished.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from tree_sitter_analyzer.mcp.server import TreeSitterAnalyzerMCPServer
+
+
+def _capture_call_tool_handler(server: TreeSitterAnalyzerMCPServer):
+    """Capture the ``handle_call_tool`` closure registered by ``create_server``.
+
+    Mirrors ``test_nav_impact_boundary.py`` / ``test_toon_compact_only.py``.
+    """
+    with patch("tree_sitter_analyzer.mcp.server.MCP_AVAILABLE", True):
+        with patch("tree_sitter_analyzer.mcp.server.Server") as mock_server_class:
+            mock_server = Mock()
+            captured: dict = {}
+
+            def capture_decorator(name):
+                def decorator(func):
+                    captured[name] = func
+                    return func
+
+                return decorator
+
+            mock_server.call_tool.return_value = capture_decorator("call_tool")
+            mock_server_class.return_value = mock_server
+            server.create_server()
+            return captured["call_tool"]
+
+
+_CALLERS = [
+    # Ghost first row — NO body (the real-offender shape from #637).
+    {"name": "ghost_caller", "file": "src/ghost.py", "line": 1, "language": "python"},
+    {"name": "caller_two", "file": "src/two.py", "line": 20, "language": "python"},
+    {"name": "caller_three", "file": "src/three.py", "line": 30, "language": "python"},
+]
+
+_BODIES = {
+    # Multiline body exercises quoted-escape; the marker token itself has no
+    # TOON special characters so it must survive escaping verbatim.
+    "caller_two": "def caller_two():\n    return target()  # BODY2_MARKER_xyzzy",
+    "caller_three": "BODY3_MARKER_xyzzy",
+}
+
+
+def _fake_inline_neighbor_bodies(
+    project_root: str, cache: Any, neighbors: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Deterministic stand-in for symbol_body_inline.inline_neighbor_bodies:
+    attach bodies to rows 2-3, leave the ghost row coordinate-only."""
+    out = []
+    for record in neighbors:
+        new_record = dict(record)
+        body = _BODIES.get(record.get("name", ""))
+        if body is not None:
+            new_record["body"] = body
+        out.append(new_record)
+    return out
+
+
+def _iter_row_dicts(node: Any):
+    """Yield every dict that appears inside any list, at any depth."""
+    if isinstance(node, dict):
+        for value in node.values():
+            yield from _iter_row_dicts(value)
+    elif isinstance(node, list):
+        for item in node:
+            if isinstance(item, dict):
+                yield item
+            yield from _iter_row_dicts(item)
+
+
+async def _call(handler, output_format: str) -> dict[str, Any]:
+    mock_graph = MagicMock()
+    mock_graph.callers_of.return_value = [dict(c) for c in _CALLERS]
+    with (
+        patch(
+            "tree_sitter_analyzer.mcp.tools.callers_tool"
+            ".CodeGraphCallersTool._try_get_cache",
+            return_value=None,
+        ),
+        patch(
+            "tree_sitter_analyzer.mcp.tools.callers_tool"
+            ".CodeGraphCallersTool._get_call_graph",
+            return_value=mock_graph,
+        ),
+        patch(
+            "tree_sitter_analyzer.mcp.tools.symbol_body_inline.inline_neighbor_bodies",
+            side_effect=_fake_inline_neighbor_bodies,
+        ),
+    ):
+        raw = await handler(
+            "nav",
+            {
+                "action": "callers",
+                "function_name": "target_fn",
+                "output_format": output_format,
+            },
+        )
+    return json.loads(raw[0].text)
+
+
+class TestToonLosslessnessInvariant:
+    """Structural ⊇ invariant: TOON output covers the JSON payload."""
+
+    @pytest.mark.asyncio
+    async def test_heterogeneous_rows_lossless_through_boundary(self, tmp_path) -> None:
+        server = TreeSitterAnalyzerMCPServer(str(tmp_path))
+        handler = _capture_call_tool_handler(server)
+
+        json_body = await _call(handler, "json")
+        toon_body = await _call(handler, "toon")
+
+        # --- Scenario self-check: the JSON payload IS heterogeneous. -------
+        assert json_body["success"] is True
+        rows = json_body["callers"]
+        assert [("body" in r) for r in rows] == [False, True, True]
+
+        # --- The invariant (structural, no field-name list): every key of
+        # every row dict anywhere in the JSON payload appears in the TOON
+        # response text. ----------------------------------------------------
+        assert toon_body["format"] == "toon"
+        toon_text = toon_body["toon_content"]
+        all_row_keys: set[str] = set()
+        for row in _iter_row_dicts(json_body):
+            all_row_keys.update(row.keys())
+        missing = sorted(k for k in all_row_keys if k not in toon_text)
+        assert missing == []
+
+        # --- Value-level spot pins: the bodies (the data that vanished in
+        # #637) are recoverable from toon_content, exactly once each. -------
+        assert toon_text.count("BODY2_MARKER_xyzzy") == 1
+        assert toon_text.count("BODY3_MARKER_xyzzy") == 1
+        assert toon_text.count("ghost_caller") == 1
+
+        # --- Header pin: union schema in first-seen order (ghost row keys +
+        # enrichment keys + body appended by the inliner). -------------------
+        expected_header = (
+            "[3]{name,file,line,language,callee_resolution,callee_resolved_file,body}:"
+        )
+        assert toon_text.count(expected_header) == 1

--- a/tree_sitter_analyzer/formatters/_toon_encoder_table_helpers.py
+++ b/tree_sitter_analyzer/formatters/_toon_encoder_table_helpers.py
@@ -7,6 +7,25 @@ EncodeValue = Callable[[Any, set[int]], str]
 InferSchema = Callable[[list[dict[str, Any]]], list[str]]
 
 
+def union_schema(items: list[dict[str, Any]]) -> list[str]:
+    """Union of all rows' keys, in first-seen order (issue #637).
+
+    A header built from only the first row's keys silently drops every
+    field that later rows carry (e.g. 49 caller ``body`` fields behind a
+    ghost first row).  The union keeps the table lossless; rows missing a
+    key render an empty cell — same representation the row encoder already
+    used for schema keys absent from a row.
+    """
+    schema: list[str] = []
+    seen: set[str] = set()
+    for item in items:
+        for key in item:
+            if key not in seen:
+                seen.add(key)
+                schema.append(key)
+    return schema
+
+
 def encode_public_array_table(
     items: list[dict[str, Any]],
     schema: list[str] | None,
@@ -42,8 +61,8 @@ def encode_array_table_lines(
     encode_value: EncodeValue,
     seen_ids: set[int],
 ) -> list[str]:
-    """Encode a homogeneous array of dictionaries as TOON table lines."""
-    schema_parts = build_table_schema_parts(items[0], schema, delimiter)
+    """Encode an array of dictionaries as TOON table lines."""
+    schema_parts = build_table_schema_parts(items, schema, delimiter)
     schema_str = delimiter.join(schema_parts)
     lines = [f"{indent_str}[{len(items)}]{{{schema_str}}}:"]
     lines.extend(
@@ -60,18 +79,22 @@ def encode_array_table_lines(
 
 
 def build_table_schema_parts(
-    first_item: dict[str, Any],
+    items: list[dict[str, Any]],
     schema: list[str],
     delimiter: str,
 ) -> list[str]:
-    """Build TOON table schema labels with compact nested value annotations."""
+    """Build TOON table schema labels with compact nested value annotations.
+
+    The annotation sample for each key comes from the first row that HAS
+    the key — with a union schema (#637) the first row may lack it.
+    """
     schema_parts: list[str] = []
     for key in schema:
-        first_value = first_item.get(key)
-        if isinstance(first_value, tuple | list) and len(first_value) == 2:
+        sample_value = next((item[key] for item in items if key in item), None)
+        if isinstance(sample_value, tuple | list) and len(sample_value) == 2:
             schema_parts.append(f"{key}(a,b)")
-        elif isinstance(first_value, dict):
-            dict_keys = delimiter.join(first_value.keys())
+        elif isinstance(sample_value, dict):
+            dict_keys = delimiter.join(sample_value.keys())
             schema_parts.append(f"{key}{{{dict_keys}}}")
         else:
             schema_parts.append(key)

--- a/tree_sitter_analyzer/formatters/toon_encoder.py
+++ b/tree_sitter_analyzer/formatters/toon_encoder.py
@@ -18,6 +18,7 @@ from ._toon_encoder_string_helpers import escape_string, needs_quotes
 from ._toon_encoder_table_helpers import (
     encode_array_table_lines,
     encode_public_array_table,
+    union_schema,
 )
 from ._toon_encoder_task_helpers import build_task_handlers
 
@@ -289,8 +290,16 @@ class ToonEncoder:
             # Nested dict
             output.append(f"{indent_str}{key}:")
             stack.append(_Task(_TaskType.ENCODE_DICT_START, value, indent + 1))
-        elif isinstance(value, list) and value and isinstance(value[0], dict):
-            # Homogeneous array of dicts - use table format
+        elif (
+            isinstance(value, list)
+            and value
+            and all(isinstance(item, dict) for item in value)
+        ):
+            # Array of dicts — use table format. The table schema is the
+            # UNION of all rows' keys (issue #637: a first-row-only schema
+            # silently dropped fields later rows carry). Mixed dict/non-dict
+            # lists fall through to the inline form below — they would crash
+            # the row encoder (only dicts have .get).
             output.append(f"{indent_str}{key}:")
             stack.append(_Task(_TaskType.ENCODE_ARRAY_TABLE, value, indent + 1))
         elif (
@@ -332,9 +341,10 @@ class ToonEncoder:
             return
 
         # Use the array-table format ONLY for *homogeneous* dict arrays
-        # (every item is a dict AND shares the same key set). A mixed-key
-        # list like ``[{"a": 1}, {"b": 2}]`` would silently drop entries
-        # under the table schema, so encode those inline instead.
+        # (every item is a dict AND shares the same key set). Mixed-key
+        # lists like ``[{"a": 1}, {"b": 2}]`` keep the (lossless) inline
+        # form at this top-level/list-nested path; dict-valued lists route
+        # through ENCODE_ARRAY_TABLE with a union schema instead (#637).
         if items and all(isinstance(item, dict) for item in items):
             first_keys = tuple(items[0].keys())
             if all(tuple(item.keys()) == first_keys for item in items):
@@ -399,7 +409,9 @@ class ToonEncoder:
         seen_ids.add(obj_id)
 
         try:
-            schema = list(items[0].keys())
+            # Union of all rows' keys — a first-row-only schema silently
+            # dropped fields absent from row 0 (issue #637).
+            schema = union_schema(items)
             indent_str = "  " * indent
             output.extend(
                 encode_array_table_lines(
@@ -666,7 +678,8 @@ class ToonEncoder:
 
         Args:
             items: List of dictionaries with similar keys
-            schema: Optional explicit schema order; if None, inferred from first item
+            schema: Optional explicit schema order; if None, inferred as the
+                union of all items' keys in first-seen order (#637)
             indent: Indentation level
 
         Returns:
@@ -685,7 +698,8 @@ class ToonEncoder:
         """
         Infer common schema from array items.
 
-        Uses the keys from the first item as the schema.
+        Uses the union of all items' keys in first-seen order (#637) —
+        a first-item-only schema silently dropped later rows' extra fields.
 
         Args:
             items: List of dictionaries
@@ -693,11 +707,7 @@ class ToonEncoder:
         Returns:
             List of field names
         """
-        if not items:
-            return []
-
-        # Use first item's keys as schema
-        return list(items[0].keys())
+        return union_schema(items)
 
     def encode_safe(self, data: Any, indent: int = 0) -> str:
         """


### PR DESCRIPTION
Closes #637 (P1, dogfood patrol 2026-06-13; lead-reproduced).

## Root cause
`_handle_dict_key` routed ANY first-item-is-dict list straight into ENCODE_ARRAY_TABLE — the homogeneity check at toon_encoder.py:340 only runs for top-level/list-nested lists, never the universal MCP shape `{'results': [...]}`. `_handle_array_table` built the schema from row 0's keys and the row encoder only visits schema keys → every key absent from row 0 silently vanished. Worst case found while testing: `[{}, {'a':1}]` dropped EVERY field of every row.

## Fix: union-of-keys header (measured)
Schema = union of all rows' keys in first-seen order; missing cells render empty. Mixed dict/scalar lists encode inline (pre-fix: AttributeError → full-JSON fallback). Nested annotations sampled from the first row HAVING the key.

| case | TOON before | TOON after | JSON |
|---|---|---|---|
| heterogeneous (real 49-caller offender) | 2,009 B — **lossy, 0/48 bodies** | 6,559 B, all bodies (71.8% of JSON) | 9,132 B |
| homogeneous | 6,519 B | **byte-identical** | 9,049 B |

The token-efficiency story survives (−28% vs JSON, now honest); the old "win" was deletion. This is §1's "fix the divergence" clause — defaults untouched.

## Losslessness invariant (Rule 11)
New boundary test drives the real `handle_call_tool` closure with the offender shape and STRUCTURALLY asserts every key of every dict in any list at any depth appears in toon_content — no denylist/allowlist (the RFC-0012 假修复 trap).

## Test plan
- [x] RED-first 9 failed → 12/12; encoder/formatter/CLI/MCP suites 142+147+201 passed; **cost invariants hold, nothing relaxed**
- [x] Golden acceptance 78/78, zero byte changes (all goldens homogeneous)
- [x] Patch coverage 96.88% (sole miss pre-existing); ratchet exit=0 (rebased over batch-25)
- [x] Lead independently re-reproduced + re-ran invariant suites + push diff=0

Known residual (pre-existing, out of scope): nested-dict CELL values with divergent subkeys remain positionally ambiguous — filed separately.