### PR TITLE
fix(search): kind parameter discoverable in facade schema

### DIFF
--- a/tests/unit/mcp/tools/test_facade_tool.py
+++ b/tests/unit/mcp/tools/test_facade_tool.py
@@ -525,5 +525,42 @@ def test_search_facade_symbol_action_does_not_raise_strict(tmp_path: Any) -> Non
     assert "success" in result
 
 
+def test_search_facade_schema_declares_kind_with_enum() -> None:
+    """#640: ``kind`` worked at runtime (additionalProperties) but was absent
+    from the search facade's public inputSchema — schema-reading agents could
+    not discover kind=constant filtering. The facade must declare ``kind``
+    with the authoritative enum, sourced from the symbol-search inner tool so
+    facade/inner/CLI can never drift apart."""
+    from tree_sitter_analyzer.mcp.tools.search_facade import build_search_facade
+    from tree_sitter_analyzer.mcp.tools.symbol_search_tool import SYMBOL_SEARCH_KINDS
+
+    # The authoritative enum: exactly the kinds _extract_symbols emits into
+    # ast_symbol_rows (function/method/class/variable/import/constant) plus
+    # the "any" no-filter default. Exact pin — extraction changes must re-pin.
+    assert SYMBOL_SEARCH_KINDS == (
+        "function",
+        "method",
+        "class",
+        "variable",
+        "import",
+        "constant",
+        "any",
+    )
+
+    facade = build_search_facade(project_root=None)
+    schema = facade.get_tool_schema()
+    props = schema["properties"]
+    assert "kind" in props
+    assert props["kind"]["enum"] == list(SYMBOL_SEARCH_KINDS)
+    assert props["kind"]["type"] == "string"
+    # LOCKED facade convention (#397 family): required is exactly ["action"]
+    # — runtime-resolved params are NEVER added to required.
+    assert schema["required"] == ["action"]
+    # The inner symbol tool's own enum must carry the same authoritative set.
+    inner = facade.action_map["symbol"]
+    inner_kind = inner.get_tool_schema()["properties"]["kind"]
+    assert inner_kind["enum"] == list(SYMBOL_SEARCH_KINDS)
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tree_sitter_analyzer/cli/argument_groups/_analysis_codegraph.py
+++ b/tree_sitter_analyzer/cli/argument_groups/_analysis_codegraph.py
@@ -9,9 +9,13 @@ from __future__ import annotations
 import argparse
 
 # Keep the CLI default in lock-step with the tool's runtime default (MCP/CLI
-# parity — Codex P2 on #297).
+# parity — Codex P2 on #297). Same for the kind enum (#640: constant/method
+# were filterable at runtime but rejected by the stale hand-copied choices).
 from ...mcp.tools.symbol_search_tool import (
     DEFAULT_SYMBOL_SEARCH_LIMIT as _DEFAULT_SYMBOL_SEARCH_LIMIT,
+)
+from ...mcp.tools.symbol_search_tool import (
+    SYMBOL_SEARCH_KINDS as _SYMBOL_SEARCH_KINDS,
 )
 
 
@@ -102,7 +106,7 @@ def _add_mcp_codegraph_map_options(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--symbol-search-kind",
-        choices=["function", "class", "variable", "import", "any"],
+        choices=list(_SYMBOL_SEARCH_KINDS),
         default="any",
         help="Symbol kind filter for --symbol-search (default: any)",
     )

--- a/tree_sitter_analyzer/mcp/tools/facade_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/facade_tool.py
@@ -126,6 +126,13 @@ class FacadeTool(BaseMCPTool):
         Optional MCP annotations dict. A facade spanning read + mutating
         actions cannot honestly declare a single ``readOnlyHint``; callers
         pass the honest (usually non-read-only) set or omit it.
+    extra_public_params:
+        Optional ``{param_name: json_schema_spec}`` of facade-specific params
+        surfaced on THIS facade's public inputSchema in addition to
+        ``_CORE_FACADE_PARAMS`` (#640: ``kind`` worked via
+        additionalProperties but was undiscoverable to schema-reading
+        agents). Use sparingly — one high-value param, never a per-inner
+        union (the Wave D token diet stands). Never added to ``required``.
     """
 
     def __init__(
@@ -137,6 +144,7 @@ class FacadeTool(BaseMCPTool):
         description: str = "",
         annotations: dict[str, Any] | None = None,
         project_root: str | None = None,
+        extra_public_params: dict[str, dict[str, Any]] | None = None,
     ) -> None:
         self.facade_name = facade_name
         self.action_map: dict[str, BaseMCPTool] = dict(action_map)
@@ -147,6 +155,9 @@ class FacadeTool(BaseMCPTool):
         self._bespoke_inners: list[BaseMCPTool] = []
         self._description = description
         self._annotations = annotations
+        self._extra_public_params: dict[str, dict[str, Any]] = dict(
+            extra_public_params or {}
+        )
         # BaseMCPTool.__init__ wires security/path resolver + fires
         # _on_project_root_changed (which forwards to inner instances).
         super().__init__(project_root)
@@ -388,6 +399,9 @@ class FacadeTool(BaseMCPTool):
         }
         # Core shared params — copy specs so callers can't mutate our constants.
         for key, spec in _CORE_FACADE_PARAMS.items():
+            properties[key] = dict(spec)
+        # Facade-specific public params (#640) — declared, never required.
+        for key, spec in self._extra_public_params.items():
             properties[key] = dict(spec)
 
         return {

--- a/tree_sitter_analyzer/mcp/tools/search_facade.py
+++ b/tree_sitter_analyzer/mcp/tools/search_facade.py
@@ -91,7 +91,7 @@ def build_search_facade(project_root: str | None = None) -> FacadeTool:
     from .hyphae_subscribe_tool import HyphaeSubscribeTool, HyphaeUnsubscribeTool
     from .query_tool import QueryTool
     from .search_content_tool import SearchContentTool
-    from .symbol_search_tool import CodeGraphSymbolSearchTool
+    from .symbol_search_tool import SYMBOL_SEARCH_KINDS, CodeGraphSymbolSearchTool
 
     # Inner instance used by the bespoke ``content`` route. It is held so the
     # facade can rebind it on project-root changes (G3) just like action_map
@@ -130,6 +130,17 @@ def build_search_facade(project_root: str | None = None) -> FacadeTool:
         description=_SEARCH_DESCRIPTION,
         annotations=_SEARCH_ANNOTATIONS,
         project_root=project_root,
+        # #640: ``kind`` is high-value for action=symbol (e.g. kind=constant)
+        # but was only reachable via additionalProperties — invisible to
+        # schema-reading agents. Surface it with the authoritative enum,
+        # sourced from the inner tool so facade/inner/CLI never drift.
+        extra_public_params={
+            "kind": {
+                "type": "string",
+                "enum": list(SYMBOL_SEARCH_KINDS),
+                "description": "Symbol kind filter for action=symbol (default: any).",
+            },
+        },
     )
 
     # G3: make the bespoke ``content`` tool rebind with the facade. The

--- a/tree_sitter_analyzer/mcp/tools/symbol_search_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/symbol_search_tool.py
@@ -27,6 +27,22 @@ logger = setup_logger(__name__)
 # the tool schema stay in sync — MCP/CLI parity (Codex P2 on #297).
 DEFAULT_SYMBOL_SEARCH_LIMIT = 15
 
+# Authoritative ``kind`` filter values. Must mirror exactly what
+# ``_extract_symbols`` (tree_sitter_analyzer/_ast_extraction.py) writes into
+# ``ast_symbol_rows`` — function/method/class/variable/import/constant — plus
+# the "any" no-filter default. Exported so the CLI (`--symbol-search-kind`
+# choices) and the ``search`` facade public schema stay in lock-step with this
+# tool's schema (#640: ``kind`` worked at runtime but was undiscoverable).
+SYMBOL_SEARCH_KINDS: tuple[str, ...] = (
+    "function",
+    "method",
+    "class",
+    "variable",
+    "import",
+    "constant",
+    "any",
+)
+
 
 class CodeGraphSymbolSearchTool(BaseMCPTool):
     """MCP Tool for FTS5-powered instant symbol search (CodeGraph parity)."""
@@ -86,7 +102,7 @@ class CodeGraphSymbolSearchTool(BaseMCPTool):
                 },
                 "kind": {
                     "type": "string",
-                    "enum": ["function", "class", "variable", "import", "any"],
+                    "enum": list(SYMBOL_SEARCH_KINDS),
                     "description": "Filter by symbol kind (default: any)",
                     "default": "any",
                 },


### PR DESCRIPTION
Closes #640 (dogfood patrol 2026-06-13).

## Summary
`kind` worked at runtime (additionalProperties) but was absent from the search facade's inputSchema properties — schema-reading agents couldn't discover this week's kind=constant filtering. Now declared with the authoritative enum.

- **Single source of truth**: new `SYMBOL_SEARCH_KINDS = (function, method, class, variable, import, constant, any)` derived from what `_extract_symbols` actually emits; the inner schema's hand-copied stale enum (missing method+constant) and the CLI `--symbol-search-kind` choices both now read the same constant (CLI-MCP parity)
- **Locked convention guarded**: `required == ["action"]` pinned by test (#397 family — kind goes in PROPERTIES only); implemented as a generic `extra_public_params` FacadeTool kwarg so search-specific params don't broadcast into all 8 facade schemas (token diet preserved)
- Issue's facade-doc assumption corrected: the generated facade-actions.md already showed `kind` (generator walks inner schemas) — zero doc diff, drift test green without regeneration

## Test plan
- [x] RED-first: 1 failed (ImportError pre-impl) → green; required-lock pin
- [x] Regression: mcp -k search/facade/schema 728 passed; contracts+drift+symbol_search 93; cli parser suites 513; CLI accepts --symbol-search-kind constant (-n 0)
- [x] Ratchet exit=0; ruff clean
- [x] Lead independently verified live schema (kind present, enum exact, required untouched) + push diff=0