### PR TITLE
fix(structure): module-level constants visible in structure surfaces

### DIFF
--- a/tests/unit/languages/test_python_module_constants.py
+++ b/tests/unit/languages/test_python_module_constants.py
@@ -204,3 +204,31 @@ class TestStructureSurfaceSeesModuleConstants:
         # do not leak into the class fields list.
         (settings_cls,) = (c for c in result["classes"] if c["name"] == "Settings")
         assert [f["name"] for f in settings_cls["fields"]] == ["TIMEOUT"]
+
+
+class TestOutlineTopLevelFields:
+    """Codex P2 on #645: field_count included module constants but no
+    rendered outline section showed them — top_level_fields closes the gap."""
+
+    def test_outline_surfaces_module_constants(self, tmp_path):
+        import asyncio
+
+        from tree_sitter_analyzer.mcp.tools.get_code_outline_tool import (
+            GetCodeOutlineTool,
+        )
+
+        p = tmp_path / "consts.py"
+        p.write_text(
+            "MAX_RETRIES = 3\n\n\nclass C:\n    TIMEOUT = 5\n\n    def m(self):\n        return 1\n",
+            newline="\n",
+        )
+        tool = GetCodeOutlineTool(str(tmp_path))
+        result = asyncio.run(
+            tool.execute({"file_path": str(p), "output_format": "json"})
+        )
+        top = result["top_level_fields"]
+        assert [f["name"] for f in top] == ["MAX_RETRIES"]
+        cls_fields = result["classes"][0].get("fields")
+        if cls_fields is not None:
+            assert [f["name"] for f in cls_fields] == ["TIMEOUT"]
+        assert result["field_count"] == 2

--- a/tests/unit/languages/test_python_module_constants.py
+++ b/tests/unit/languages/test_python_module_constants.py
@@ -1,0 +1,206 @@
+"""Issue #639 — module-level constants visible on the structure surface.
+
+#612 made the ast_cache walker emit kind="constant" rows for Python
+module-level assignments (const-style ∪ annotated-with-value ∪ dunder,
+module scope only), so ``search action=symbol`` sees them — but the
+structure surface (analyze/outline/signatures) walks the PLUGIN path,
+whose ``extract_variables`` only ever emitted class attributes.
+
+These tests pin plugin-path parity: the Python plugin emits module
+constants as Variable elements (``is_constant=True``) under the exact
+#612 scope rule, and the structure/outline tools surface them as fields.
+Fixture and negative pins mirror ``tests/unit/test_ast_extraction.py``
+(TestPythonModuleConstants).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tree_sitter_analyzer.core.parser import Parser
+from tree_sitter_analyzer.languages.python_plugin._element_builders import (
+    extract_module_constants,
+)
+from tree_sitter_analyzer.languages.python_plugin.extractor import (
+    PythonElementExtractor,
+)
+from tree_sitter_analyzer.mcp.tools.analyze_code_structure_tool import (
+    AnalyzeCodeStructureTool,
+)
+from tree_sitter_analyzer.mcp.tools.get_code_outline_tool import GetCodeOutlineTool
+
+# Mirrors _CONST_SRC in tests/unit/test_ast_extraction.py (#610/#612 rule):
+# 5 module constants + 1 class attribute; logger / bare_decl / RETRIES are
+# negative pins.
+_SRC = """\
+_STOP_WORDS = frozenset({"the"})
+CONFIG: dict = {}
+__version__ = "1.0"
+logger = get_logger()
+paths: list = []
+bare_decl: int
+
+if True:
+    WRAPPED_FLAG = 1
+
+
+class Settings:
+    TIMEOUT = 30
+
+    def method(self):
+        RETRIES = 3
+        return RETRIES
+"""
+
+_MODULE_CONSTANT_NAMES = [
+    "CONFIG",
+    "WRAPPED_FLAG",
+    "_STOP_WORDS",
+    "__version__",
+    "paths",
+]
+
+
+def _variables() -> list:
+    result = Parser().parse_code(_SRC, "python")
+    assert result.success and result.tree is not None
+    return PythonElementExtractor().extract_variables(result.tree, _SRC)
+
+
+class TestPluginModuleConstants:
+    """Plugin path: extract_variables emits module constants (#612 parity)."""
+
+    def test_exactly_the_five_module_constants_extracted(self):
+        consts = [v for v in _variables() if v.is_constant]
+        assert sorted(v.name for v in consts) == _MODULE_CONSTANT_NAMES
+
+    def test_total_variable_count_is_six(self):
+        # 5 module constants + 1 class attribute (TIMEOUT).
+        assert len(_variables()) == 6
+
+    def test_class_attribute_unchanged(self):
+        # TIMEOUT stays a class attribute: extracted, NOT flagged constant.
+        timeout = [v for v in _variables() if v.name == "TIMEOUT"]
+        assert len(timeout) == 1
+        assert timeout[0].is_constant is False
+
+    def test_function_local_not_extracted(self):
+        # RETRIES lives in a function body — module-level only (#612 rule).
+        assert "RETRIES" not in {v.name for v in _variables()}
+
+    def test_lowercase_unannotated_not_extracted(self):
+        # `logger = get_logger()` — mutable module state, excluded.
+        assert "logger" not in {v.name for v in _variables()}
+
+    def test_bare_annotation_not_extracted(self):
+        # `bare_decl: int` has no right-hand side — not a definition site.
+        assert "bare_decl" not in {v.name for v in _variables()}
+
+    def test_constant_lines_pinned(self):
+        by_name = {v.name: v for v in _variables() if v.is_constant}
+        assert (by_name["_STOP_WORDS"].start_line, by_name["_STOP_WORDS"].end_line) == (
+            1,
+            1,
+        )
+        assert by_name["CONFIG"].start_line == 2
+        assert by_name["__version__"].start_line == 3
+        assert by_name["paths"].start_line == 5
+        assert by_name["WRAPPED_FLAG"].start_line == 9
+
+    def test_constant_types_and_visibility(self):
+        by_name = {v.name: v for v in _variables() if v.is_constant}
+        assert by_name["CONFIG"].variable_type == "dict"
+        assert by_name["paths"].variable_type == "list"
+        assert by_name["_STOP_WORDS"].variable_type is None
+        assert by_name["_STOP_WORDS"].visibility == "private"
+        assert by_name["__version__"].visibility == "magic"
+        assert by_name["CONFIG"].visibility == "public"
+
+    def test_variables_sorted_by_line(self):
+        lines = [v.start_line for v in _variables()]
+        assert lines == sorted(lines)
+
+    def test_chained_assignment_captures_both_names(self):
+        result = Parser().parse_code("A_ONE = B_TWO = 5\n", "python")
+        names = sorted(
+            v.name
+            for v in PythonElementExtractor().extract_variables(
+                result.tree, "A_ONE = B_TWO = 5\n"
+            )
+        )
+        assert names == ["A_ONE", "B_TWO"]
+
+    def test_none_tree_yields_no_constants(self):
+        assert extract_module_constants(None, "") == []
+
+    def test_constant_extraction_failure_degrades_to_class_attrs(self, monkeypatch):
+        # The module-constant walk failing must not take down class-attribute
+        # extraction (mirrors the existing degradation contract).
+        import tree_sitter_analyzer.languages.python_plugin._class_extractor_mixin as mixin_mod
+
+        def _boom(tree, source):
+            raise RuntimeError("forced failure")
+
+        monkeypatch.setattr(mixin_mod, "extract_module_constants", _boom)
+        result = Parser().parse_code(_SRC, "python")
+        names = [
+            v.name
+            for v in PythonElementExtractor().extract_variables(result.tree, _SRC)
+        ]
+        assert names == ["TIMEOUT"]
+
+
+class TestStructureSurfaceSeesModuleConstants:
+    """structure action=analyze / outline expose the constants as fields."""
+
+    @pytest.mark.asyncio
+    async def test_analyze_fields_contain_module_constants(self, tmp_path):
+        test_file = tmp_path / "mod_consts.py"
+        test_file.write_text(_SRC, newline="\n")
+        tool = AnalyzeCodeStructureTool()
+        result = await tool.execute(
+            {
+                "file_path": str(test_file),
+                "format_type": "full",
+                "output_format": "json",
+            }
+        )
+        assert result["success"] is True
+        field_names = sorted(f["name"] for f in result["fields"])
+        assert field_names == sorted([*_MODULE_CONSTANT_NAMES, "TIMEOUT"])
+        assert result["metadata"]["fields_count"] == 6
+
+    @pytest.mark.asyncio
+    async def test_analyze_fields_exclude_locals_and_mutables(self, tmp_path):
+        test_file = tmp_path / "mod_consts.py"
+        test_file.write_text(_SRC, newline="\n")
+        tool = AnalyzeCodeStructureTool()
+        result = await tool.execute(
+            {
+                "file_path": str(test_file),
+                "format_type": "full",
+                "output_format": "json",
+            }
+        )
+        field_names = {f["name"] for f in result["fields"]}
+        assert "RETRIES" not in field_names
+        assert "logger" not in field_names
+        assert "bare_decl" not in field_names
+
+    @pytest.mark.asyncio
+    async def test_outline_field_count_includes_module_constants(self, tmp_path):
+        test_file = tmp_path / "mod_consts.py"
+        test_file.write_text(_SRC, newline="\n")
+        tool = GetCodeOutlineTool()
+        result = await tool.execute(
+            {
+                "file_path": str(test_file),
+                "include_fields": True,
+                "output_format": "json",
+            }
+        )
+        assert result["field_count"] == 6
+        # Class outline keeps exactly its own attribute — module constants
+        # do not leak into the class fields list.
+        (settings_cls,) = (c for c in result["classes"] if c["name"] == "Settings")
+        assert [f["name"] for f in settings_cls["fields"]] == ["TIMEOUT"]

--- a/tree_sitter_analyzer/languages/python_plugin/_class_extractor_mixin.py
+++ b/tree_sitter_analyzer/languages/python_plugin/_class_extractor_mixin.py
@@ -7,6 +7,7 @@ from typing import Any
 from ...models import Class, Variable
 from ...utils import log_debug, log_warning
 from ...utils.tree_sitter_compat import get_node_text_safe
+from ._element_builders import extract_module_constants
 from ._extractor_helpers import (
     ClassBodyQueryRuntime,
     ClassBuildInput,
@@ -44,7 +45,7 @@ class PythonClassExtractionMixin:
         return classes
 
     def extract_variables(self, tree: Any, source_code: str) -> list[Variable]:
-        """Extract Python variable definitions (class attributes only)."""
+        """Extract Python variables: class attributes + module constants (#639)."""
         variables: list[Variable] = []
 
         try:
@@ -70,6 +71,14 @@ class PythonClassExtractionMixin:
         except Exception as exc:
             log_warning(f"Could not extract Python class attributes: {exc}")
 
+        try:
+            # Issue #639 — structure-surface parity with the #612 ast_cache
+            # rule: module-level constants are fields too.
+            variables.extend(extract_module_constants(tree, source_code))
+        except Exception as exc:
+            log_warning(f"Could not extract Python module constants: {exc}")
+
+        variables.sort(key=lambda v: v.start_line)
         return variables
 
     def _extract_class_optimized(self, node: Any) -> Class | None:

--- a/tree_sitter_analyzer/languages/python_plugin/_element_builders.py
+++ b/tree_sitter_analyzer/languages/python_plugin/_element_builders.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from ..._ast_extraction import _PY_SCOPE_BODY_NODES, _python_module_constant
 from ...models import Class, Function, Variable
 from ...utils import log_warning
 
@@ -60,6 +61,51 @@ def _class_attribute_name_and_type(left_part: str) -> tuple[str, str | None]:
 
     name_part, type_part = left_part.split(":", 1)
     return name_part.strip(), type_part.strip()
+
+
+def extract_module_constants(tree: Any, source_code: str) -> list[Variable]:
+    """Extract module-level constants as Variable elements (issue #639).
+
+    Plugin-path parity with the #612 ast_cache scope rule (shared via
+    :func:`tree_sitter_analyzer._ast_extraction._python_module_constant`):
+    an ``assignment`` not enclosed by any function/class body whose target
+    is a plain identifier matching const-style ∪ annotated-with-value ∪
+    dunder. Only ``function_definition``/``class_definition`` close module
+    scope — if/try-wrapped module assignments stay captured, and chained
+    targets (``A = B = 1``) yield one row per nested assignment.
+    """
+    constants: list[Variable] = []
+    if tree is None or tree.root_node is None:
+        return constants
+    stack = [tree.root_node]
+    while stack:
+        node = stack.pop()
+        if node.type in _PY_SCOPE_BODY_NODES:
+            continue
+        if node.type == "assignment":
+            sym = _python_module_constant(node, source_code)
+            if sym is not None:
+                constants.append(_build_module_constant(node, sym, source_code))
+        stack.extend(reversed(node.children))
+    return constants
+
+
+def _build_module_constant(
+    node: Any, sym: dict[str, Any], source_code: str
+) -> Variable:
+    type_node = node.child_by_field_name("type")
+    vtype = node_raw_text(type_node, source_code) if type_node is not None else None
+    return Variable(
+        name=sym["name"],
+        start_line=sym["line"],
+        end_line=sym["end_line"],
+        raw_text=node_raw_text(node, source_code),
+        language="python",
+        variable_type=vtype,
+        field_type=vtype,
+        is_constant=True,
+        visibility=_function_visibility(sym["name"]),
+    )
 
 
 @dataclass(slots=True)

--- a/tree_sitter_analyzer/mcp/tools/get_code_outline_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/get_code_outline_tool.py
@@ -264,6 +264,21 @@ class GetCodeOutlineTool(BaseMCPTool):
                 "import_count": len(imports),
             },
         }
+        # Module-level constants/fields (outside every class span) — without
+        # this, field_count includes them but no rendered section shows them
+        # (Codex P2 on #645; the #639 dogfood ask was to SEE them). Emitted
+        # only when non-empty (token budget; byte-pin tests stay untouched
+        # for constant-free files).
+        top_level_fields = sorted(
+            (
+                _field_entry(f)
+                for f in all_fields
+                if not _in_class_ranges(f, class_ranges, class_names)
+            ),
+            key=lambda x: x["line_start"],
+        )
+        if top_level_fields:
+            outline["top_level_fields"] = top_level_fields
         if include_imports:
             outline["imports"] = [
                 getattr(imp, "import_statement", getattr(imp, "name", ""))
@@ -460,6 +475,8 @@ class GetCodeOutlineTool(BaseMCPTool):
         # 2) Hoisted lists use the capped versions.
         result["classes"] = classes_capped
         result["top_level_functions"] = fns_capped
+        if outline.get("top_level_fields"):
+            result["top_level_fields"] = outline["top_level_fields"]
         # 3) ``top_level_functions`` also surfaces as ``methods``.
         if "methods" not in result:
             result["methods"] = fns_capped


### PR DESCRIPTION
Closes #639 (dogfood patrol 2026-06-13: search saw the new constants, structure was blind).

## Decision: plugin-path parity (smaller blast radius, evidenced)
Option (b) — structure reading cache rows — rejected: structure actions parse via the plugin and work with NO index today; (b) would couple 3 actions to cache availability. Option (a): one extraction-site change covers analyze/outline/signatures automatically (all derive fields from Variable elements).

**No scope-rule drift possible**: `extract_module_constants()` IMPORTS `_python_module_constant` + `_PY_SCOPE_BODY_NODES` from `_ast_extraction` (the #612 single source) — const-style ∪ annotated-with-value ∪ dunder, module-level only, if/try-wrapped captured. Constants carry `is_constant=True` (class attributes unchanged False, pinned).

## Test plan
- [x] RED-first: 8 failed pre-fix → 15 passed (exact name/line/visibility pins + #612-mirror negative pins: locals/lowercase/bare-decl excluded)
- [x] Regression: languages 3483 + structure/outline/signatures 316+44 + mcp full 4867 + contracts/formatters 2505 (-n 0)
- [x] Golden acceptance FULL (6c): 96 passed, zero golden lines changed (examples/sample.py has no module assignments — grep-evidenced); swift fail stash-proven pre-existing
- [x] Patch coverage 100% of new lines; ratchet exit=0 (6d rebase); ruff/mypy clean
- [x] Lead independently re-ran 15 tests + live engine probe (MAX_RETRIES/_LIMIT is_constant=True, function-local absent) + push diff=0