### PR TITLE
fix(nav): ghost caller rows eliminated — call sites attributed or counted

### DIFF
--- a/tests/unit/test_ghost_caller_rows_638.py
+++ b/tests/unit/test_ghost_caller_rows_638.py
@@ -1,0 +1,234 @@
+"""RED-first tests for issue #638: ghost caller rows (name='', line=0).
+
+Root cause (extraction tier): ``_extract_call_edges`` keyed its per-file
+definition spans by bare function name.  Two same-named methods in different
+classes (the hyphae_subscribe_tool.py shape: two ``execute`` methods) collide
+— only the LAST span survives, so calls inside the EARLIER same-named method
+find no containing span and are written as ``caller_name='' / caller_line=0``
+edges.  ``nav action=callers`` then emits the un-navigable ghost row
+``{name: '', line: 0}`` ranked first.
+
+Same defect cloned in the parse tier: ``CallGraph.build`` collected
+``file_funcs`` into a name-keyed dict before ``_find_enclosing_func``.
+
+Query tier decision (#638): genuinely module-level call sites have no
+enclosing function BY DESIGN (the edge writer maps them to a file node).
+The callers tool must never emit them as ghost rows — it excludes them and
+reports ``unattributed_call_sites: N`` so nothing is silently dropped.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tree_sitter_analyzer._ast_extraction import _extract_call_edges
+from tree_sitter_analyzer.ast_cache import ASTCache
+from tree_sitter_analyzer.call_graph import CallGraph
+from tree_sitter_analyzer.core.parser import Parser
+from tree_sitter_analyzer.mcp.tools.callers_tool import CodeGraphCallersTool
+
+# ---------------------------------------------------------------------------
+# Fixture source — minimal hyphae_subscribe_tool.py shape:
+# two classes, each with a same-named method calling fmt(), plus one
+# genuinely module-level call.  Line numbers are load-bearing.
+# ---------------------------------------------------------------------------
+
+_HYPHAE_SHAPE = """\
+def fmt(resp):
+    return resp
+
+
+def helper_a():
+    return 1
+
+
+class SubscribeTool:
+    def get_schema(self):
+        return {}
+
+    def execute(self):
+        resp = helper_a()
+        return fmt(resp)
+
+
+class UnsubscribeTool:
+    def get_schema(self):
+        return {}
+
+    def execute(self):
+        return fmt({})
+
+
+MODULE_DEFAULT = fmt({})
+"""
+
+# Load-bearing line numbers in _HYPHAE_SHAPE:
+_FIRST_EXECUTE_DEF_LINE = 13  # SubscribeTool.execute
+_FIRST_EXECUTE_CALL_LINE = 15  # fmt(resp)
+_SECOND_EXECUTE_DEF_LINE = 22  # UnsubscribeTool.execute
+_SECOND_EXECUTE_CALL_LINE = 23  # fmt({})
+_MODULE_LEVEL_CALL_LINE = 26  # MODULE_DEFAULT = fmt({})
+
+
+def _parse(source: str, language: str = "python"):
+    result = Parser().parse_code(source, language)
+    assert result.success and result.tree is not None, (
+        f"parse failed: {result.error_message}"
+    )
+    return result.tree
+
+
+def _fmt_edges() -> list[dict]:
+    tree = _parse(_HYPHAE_SHAPE)
+    edges = _extract_call_edges(tree, _HYPHAE_SHAPE, "python", {"symbols": []})
+    return [e for e in edges if e["callee_name"] == "fmt"]
+
+
+# ---------------------------------------------------------------------------
+# Unit: _extract_call_edges — duplicate-name spans must not collide
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicateNameSpanAttribution:
+    def test_exact_fmt_edge_count(self) -> None:
+        assert len(_fmt_edges()) == 3
+
+    def test_call_in_first_same_named_method_attributed(self) -> None:
+        """fmt() at line 15 lives inside SubscribeTool.execute (def line 13).
+
+        RED on the name-keyed dict: the second `execute` span overwrites the
+        first, so this call had caller_name='' / caller_line=0 (the #638 ghost).
+        """
+        edge = next(
+            e for e in _fmt_edges() if e["callee_line"] == _FIRST_EXECUTE_CALL_LINE
+        )
+        assert edge["caller_name"] == "execute", (
+            f"expected caller=execute, got {edge['caller_name']!r} — "
+            "call inside the FIRST same-named method lost its attribution"
+        )
+        assert edge["caller_line"] == _FIRST_EXECUTE_DEF_LINE
+
+    def test_call_in_second_same_named_method_attributed(self) -> None:
+        edge = next(
+            e for e in _fmt_edges() if e["callee_line"] == _SECOND_EXECUTE_CALL_LINE
+        )
+        assert edge["caller_name"] == "execute"
+        assert edge["caller_line"] == _SECOND_EXECUTE_DEF_LINE
+
+    def test_module_level_call_unattributed_by_design(self) -> None:
+        """Module-level fmt() at line 26 has no enclosing function.
+
+        Pinned: the extraction layer keeps caller_name='' / caller_line=0 —
+        the edge writer maps these to a file-level node; the QUERY layer is
+        responsible for never surfacing them as ghost caller rows.
+        """
+        edge = next(
+            e for e in _fmt_edges() if e["callee_line"] == _MODULE_LEVEL_CALL_LINE
+        )
+        assert edge["caller_name"] == ""
+        assert edge["caller_line"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Parse tier: CallGraph.build — same name-keyed collision
+# ---------------------------------------------------------------------------
+
+
+class TestCallGraphParseTierAttribution:
+    @pytest.fixture
+    def project(self, tmp_path: Path) -> str:
+        (tmp_path / "sample.py").write_text(_HYPHAE_SHAPE, encoding="utf-8")
+        return str(tmp_path)
+
+    def test_fmt_callers_are_both_execute_methods(self, project: str) -> None:
+        """Callers of fmt at the parse tier resolve to BOTH execute methods.
+
+        RED before the fix: the call at line 15 fell back to the nearest
+        preceding surviving span (helper_a) — a wrong-name attribution.
+        """
+        graph = CallGraph(project)
+        callers = graph.callers_of("fmt")
+        named = {(c["name"], c["line"]) for c in callers}
+        assert ("execute", _FIRST_EXECUTE_DEF_LINE) in named, (
+            f"SubscribeTool.execute missing from callers of fmt: {named}"
+        )
+        assert ("execute", _SECOND_EXECUTE_DEF_LINE) in named
+        assert "helper_a" not in {c["name"] for c in callers}, (
+            f"helper_a never calls fmt — wrong-name attribution: {named}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tool tier: CodeGraphCallersTool over a fresh index (SQL path)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def indexed_project(tmp_path: Path) -> str:
+    (tmp_path / "sample.py").write_text(_HYPHAE_SHAPE, encoding="utf-8")
+    cache = ASTCache(str(tmp_path))
+    try:
+        cache.index_project()
+    finally:
+        cache.close()
+    return str(tmp_path)
+
+
+class TestCallersToolGhostRows:
+    @pytest.mark.asyncio
+    async def test_no_result_row_has_empty_name_or_line_zero(
+        self, indexed_project: str
+    ) -> None:
+        """Structural pin (#638): a caller row is navigable or it is not a row."""
+        tool = CodeGraphCallersTool(indexed_project)
+        result = await tool.execute({"function_name": "fmt", "output_format": "json"})
+        assert result.get("success") is True, f"tool errored: {result}"
+        assert result.get("data_source") == "sql"
+        ghost = [
+            c
+            for c in result.get("callers", [])
+            if not c.get("name") or c.get("line") == 0
+        ]
+        assert ghost == [], f"ghost caller rows leaked to the response: {ghost}"
+
+    @pytest.mark.asyncio
+    async def test_real_call_sites_resolve_to_enclosing_methods(
+        self, indexed_project: str
+    ) -> None:
+        """Both in-method call sites attribute to 'execute'.
+
+        The SQL tier dedups by (file, caller_name), so the two same-named
+        methods collapse into one listed row — the first edge's def line.
+        """
+        tool = CodeGraphCallersTool(indexed_project)
+        result = await tool.execute({"function_name": "fmt", "output_format": "json"})
+        rows = [
+            (c["name"], c["line"])
+            for c in result.get("callers", [])
+            if c["file"].endswith("sample.py")
+        ]
+        assert rows == [("execute", _FIRST_EXECUTE_DEF_LINE)]
+        assert result.get("caller_count") == 1
+
+    @pytest.mark.asyncio
+    async def test_module_level_call_counted_not_emitted(
+        self, indexed_project: str
+    ) -> None:
+        """The module-level fmt() call is excluded with a counted note."""
+        tool = CodeGraphCallersTool(indexed_project)
+        result = await tool.execute({"function_name": "fmt", "output_format": "json"})
+        assert result.get("unattributed_call_sites") == 1
+
+    @pytest.mark.asyncio
+    async def test_no_unattributed_key_when_all_attributed(
+        self, indexed_project: str
+    ) -> None:
+        """helper_a is only called inside a method — no counted note emitted."""
+        tool = CodeGraphCallersTool(indexed_project)
+        result = await tool.execute(
+            {"function_name": "helper_a", "output_format": "json"}
+        )
+        assert result.get("success") is True, f"tool errored: {result}"
+        assert "unattributed_call_sites" not in result

--- a/tests/unit/test_symbols_json_enrichment.py
+++ b/tests/unit/test_symbols_json_enrichment.py
@@ -136,12 +136,12 @@ class TestReturnTypeAndParamsSerialized:
 
 
 class TestExtractorVersionBump:
-    def test_extractor_version_is_10_in_both_sites(self):
-        # v10: #628 — C# function-local variables no longer over-captured.
+    def test_extractor_version_is_11_in_both_sites(self):
+        # v11: #638 — call edges keep ALL same-named definition spans.
         from tree_sitter_analyzer import _ast_cache_indexer, ast_cache
 
-        assert ast_cache._AST_CACHE_EXTRACTOR_VERSION == 10
-        assert _ast_cache_indexer._AST_CACHE_EXTRACTOR_VERSION == 10
+        assert ast_cache._AST_CACHE_EXTRACTOR_VERSION == 11
+        assert _ast_cache_indexer._AST_CACHE_EXTRACTOR_VERSION == 11
 
 
 class TestCodexP2sOn621:

--- a/tree_sitter_analyzer/_ast_cache_indexer.py
+++ b/tree_sitter_analyzer/_ast_cache_indexer.py
@@ -28,7 +28,9 @@ logger = logging.getLogger(__name__)
 # v8: #626 — JS/TS function-local variables no longer over-captured.
 # v9: #626 — Java function-local variables no longer over-captured.
 # v10: #628 — C# function-local variables no longer over-captured.
-_AST_CACHE_EXTRACTOR_VERSION = 10
+# v11: #638 — call edges keep ALL same-named definition spans; calls inside
+#      the earlier of two same-named methods regain their enclosing caller.
+_AST_CACHE_EXTRACTOR_VERSION = 11
 
 
 def check_cache_or_read(

--- a/tree_sitter_analyzer/_ast_extraction.py
+++ b/tree_sitter_analyzer/_ast_extraction.py
@@ -1018,15 +1018,19 @@ def _extract_call_edges(
 
     definitions, calls = walk_tree(tree.root_node, source_code, language)
 
-    # Keyed by name → (start_line, start_col, end_line, end_col, start_line_raw)
+    # (name, start_line, start_col, end_line, end_col, start_line_raw) per
+    # definition.  A LIST, not a name-keyed dict: same-named methods in
+    # different classes (two ``execute`` defs) must keep BOTH spans, or calls
+    # inside the earlier one lose attribution and become ghost
+    # caller_name=''/caller_line=0 edges (issue #638).
     # start_line_raw is kept separately for caller_line output (unchanged API).
-    file_funcs: dict[str, tuple[int, int, int, int, int]] = {}
+    file_funcs: list[tuple[str, int, int, int, int, int]] = []
     for d in definitions:
         sl = d["start_line"]
         sc = d.get("start_col", 0)
         el = d.get("end_line", sl)
         ec = d.get("end_col", 0)
-        file_funcs[d["name"]] = (sl, sc, el, ec, sl)
+        file_funcs.append((d["name"], sl, sc, el, ec, sl))
 
     edges: list[dict[str, Any]] = []
     for call in calls:
@@ -1035,7 +1039,7 @@ def _extract_call_edges(
         caller_name = ""
         caller_line = 0
         best_span: tuple[int, int] | None = None
-        for fname, (sl, sc, el, ec, raw_start) in file_funcs.items():
+        for fname, sl, sc, el, ec, raw_start in file_funcs:
             # Column-aware containment: (call_line, call_col) must be strictly
             # inside [start_point .. end_point] expressed as (line, col) pairs.
             # Uses lexicographic comparison so single-line functions work too.

--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -67,7 +67,9 @@ logger = logging.getLogger(__name__)
 # v8: #626 — JS/TS function-local variables no longer over-captured.
 # v9: #626 — Java function-local variables no longer over-captured.
 # v10: #628 — C# function-local variables no longer over-captured.
-_AST_CACHE_EXTRACTOR_VERSION = 10
+# v11: #638 — call edges keep ALL same-named definition spans; calls inside
+#      the earlier of two same-named methods regain their enclosing caller.
+_AST_CACHE_EXTRACTOR_VERSION = 11
 
 
 class SchemaIntegrityError(RuntimeError):

--- a/tree_sitter_analyzer/call_graph.py
+++ b/tree_sitter_analyzer/call_graph.py
@@ -203,7 +203,11 @@ class CallGraph:
                 self._func_by_file[rel_path].append(ref)
                 qname = ref.qualified_name()
                 self._func_by_qualified[qname] = ref
-                file_funcs[defn["name"]] = ref
+                # Key by name AND start line: same-named methods in different
+                # classes (two ``execute`` defs) must keep BOTH spans for
+                # _find_enclosing_func, or calls inside the earlier one get
+                # mis-attributed to an unrelated preceding function (#638).
+                file_funcs[f"{defn['name']}:{defn['start_line']}"] = ref
 
             per_file.append((rel_path, abs_path, language, file_funcs, calls))
 

--- a/tree_sitter_analyzer/mcp/tools/callers_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/callers_tool.py
@@ -120,9 +120,10 @@ class CodeGraphCallersTool(CodeGraphRelationToolMixin, BaseMCPTool):
             and func_name.rpartition(".")[0]  # non-empty class part
         )
 
+        unattributed_call_sites = 0
         cache = self._try_get_cache()
         if cache is not None and cache.has_call_edges() and not is_qualified:
-            callers = self._sql_native_callers(
+            callers, unattributed_call_sites = self._sql_native_callers(
                 cache, func_name, file_path, include_activation
             )
             data_source = "sql"
@@ -157,6 +158,11 @@ class CodeGraphCallersTool(CodeGraphRelationToolMixin, BaseMCPTool):
             truncated=truncated,
             callers=callers,
         )
+        if unattributed_call_sites:
+            # #638: module-level call sites have no enclosing function — they
+            # are counted here instead of being emitted as un-navigable ghost
+            # rows ({name: '', line: 0}).
+            result["unattributed_call_sites"] = unattributed_call_sites
         if truncated:
             trunc_note = (
                 f"showing {len(callers)} of {total_callers} callers — raise limit, "
@@ -205,8 +211,13 @@ class CodeGraphCallersTool(CodeGraphRelationToolMixin, BaseMCPTool):
         func_name: str,
         file_path: str | None,
         include_activation: bool = False,
-    ) -> list[dict[str, Any]]:
+    ) -> tuple[list[dict[str, Any]], int]:
         """Use SQL-native callers query — O(k) instead of full graph build.
+
+        Returns ``(callers, unattributed_call_sites)``.  Edges without an
+        enclosing function (module-level call sites store
+        ``caller_name='' / caller_line=0``) are never emitted as result rows
+        — they are counted instead (#638 ghost-caller fix).
 
         When ``include_activation`` is True, each entry gets an
         ``activation`` sub-dict carrying ``mod_count_30d`` and
@@ -214,11 +225,15 @@ class CodeGraphCallersTool(CodeGraphRelationToolMixin, BaseMCPTool):
         """
         raw = cache.query_callers(func_name, callee_file=file_path)
         results: list[dict[str, Any]] = []
+        unattributed = 0
         seen: set[str] = set()
         activation_map: dict[tuple[str, int], dict[str, Any]] = {}
         if include_activation:
             activation_map = self._fetch_activation_map(cache)
         for edge in raw:
+            if not edge.get("caller_name"):
+                unattributed += 1
+                continue
             key = f"{edge['caller_file']}:{edge['caller_name']}"
             if key in seen:
                 continue
@@ -247,7 +262,7 @@ class CodeGraphCallersTool(CodeGraphRelationToolMixin, BaseMCPTool):
                     {"mod_count_30d": 0, "last_modified_at": None},
                 )
             results.append(entry)
-        return results
+        return results, unattributed
 
     @staticmethod
     def _enrich_callers_with_resolution(


### PR DESCRIPTION
Closes #638 (dogfood patrol 2026-06-13; the ghost row also triggered the now-fixed #637 TOON header).

## Root cause (_ast_extraction.py:1023-1029, extraction-time)
The per-file definition-span lookup was a NAME-KEYED dict — hyphae_subscribe_tool.py has two `execute` methods, the second span overwrote the first, the line-112 call found no containing span → edge written as `caller_name='' / caller_line=0` → ghost row ranked first. The same defect was cloned in the parse tier (call_graph.py:191/206) where the fallback additionally produced a WRONG-name attribution.

## Fix
- **Extraction**: keep ALL spans (list; parse tier keyed by name:start_line); innermost-span selection (#452/#484 family) unchanged. `_AST_CACHE_EXTRACTOR_VERSION` 10→11 (both sites).
- **Query-time**: genuinely module-level call sites (no enclosing function by design) are now EXCLUDED with a counted note `unattributed_call_sites: N` (only when >0) — never emitted as name:'' line:0. Chose exclusion over a `<module>` pseudo-caller (would ripple through qualified lookup/body-inlining/TOON for marginal value).

## E2E re-run of the original repro
Before: ghost `{name:'', line:0}` first, line-112 site missing. After: ghost rows [], both edges attributed to their real `execute` methods (caller_line 81/143).

## Test plan
- [x] RED-first: 5/9 failed exactly on the predicted bugs → 9 passed; version re-pin 10→11
- [x] Regression: callers/callees/extraction 148 + call-graph 254 + nav/TOON 107 + parity/contracts 205 (-n 0)
- [x] Golden FULL (6c): 96 passed, swift stash-proven pre-existing; ratchet exit=0
- [x] Lead independently re-ran 25 tests + verified both version sites + push diff=0

Two adjacent pre-existing quirks observed, untouched (surgical), filed separately: SQL-tier dedup collapses same-named methods in one file; parse-tier fallback misattributes module-level calls to the nearest preceding function.