### PR TITLE
test: ratchet batch-26 — pin 28 loose assertions in top-4 AST-ranked files

### DIFF
--- a/scripts/loose_assertion_baseline.txt
+++ b/scripts/loose_assertion_baseline.txt
@@ -51,7 +51,9 @@
 #   AST-ranked files, no exemptions).
 #   batch-25 (AST): 647 -> 619, 2026-06-13 (28 exact pins in top-4
 #   AST-ranked files, no exemptions).
+#   batch-26 (AST): 619 -> 591, 2026-06-13 (28 exact pins in top-4
+#   AST-ranked files, no exemptions).
 
-BASELINE_COUNT=619
+BASELINE_COUNT=591
 MEASUREMENT_DATE=2026-06-13
 MEASUREMENT_COMMAND="uv run python scripts/check_loose_assertions.py --baseline"

--- a/tests/unit/core/test_engine.py
+++ b/tests/unit/core/test_engine.py
@@ -78,7 +78,7 @@ class TestAnalysisEngine:
             assert result.success
             assert result.language == "java"
             assert result.file_path == temp_file
-            assert len(result.elements) > 0
+            assert len(result.elements) == 3
         finally:
             os.unlink(temp_file)
 
@@ -103,7 +103,7 @@ class Greeter:
         assert result.success
         assert result.language == "python"
         assert result.file_path == "string"  # Default filename for code analysis
-        assert len(result.elements) > 0
+        assert len(result.elements) == 5
 
         element_types = [elem.element_type for elem in result.elements]
         assert "import" in element_types
@@ -189,7 +189,7 @@ class TestUnifiedEngineSyncAnalysis:
         result = engine.analyze_sync(request)
         assert result.success is True
         assert result.language == "java"
-        assert len(result.elements) >= 2  # Class and Method
+        assert len(result.elements) == 2  # Class and Method
 
 
 class TestUnifiedEngineAnalyzeCode:
@@ -229,7 +229,7 @@ class TestUnifiedEngineQueryExecution:
         result = engine.analyze_sync(request)
         assert result.success is True
         assert "function" in result.query_results
-        assert len(result.query_results["function"]) > 0
+        assert len(result.query_results["function"]) == 1
 
 
 class TestUnifiedEngineNonexistentFile:
@@ -355,8 +355,7 @@ class TestUnifiedAnalysisEnginePluginManagement:
         engine = UnifiedAnalysisEngine()
         languages = engine.get_supported_languages()
         assert isinstance(languages, list)
-        # Should at least have some languages
-        assert len(languages) > 0
+        assert len(languages) == 25
 
     def test_plugin_manager_property(self):
         """Test accessing plugin manager property."""
@@ -387,8 +386,7 @@ class TestUnifiedAnalysisEngineCacheManagement:
         engine = UnifiedAnalysisEngine()
         stats = engine.get_cache_stats()
         assert isinstance(stats, dict)
-        # Should have at least some stats keys
-        assert len(stats) > 0
+        assert len(stats) == 12
 
     def test_cache_service_property(self):
         """Test accessing cache service property."""
@@ -1367,7 +1365,7 @@ class TestAnalysisEnginePerformanceExtended:
 
             # Check that some analyses completed
             successful_results = [r for r in results if isinstance(r, AnalysisResult)]
-            assert len(successful_results) >= 0  # At least some should succeed
+            assert len(successful_results) == 5
 
     @pytest.mark.slow  # exceeds conftest 5s per-test budget on Windows CI
     @pytest.mark.asyncio

--- a/tests/unit/core/test_language_detector_html_css.py
+++ b/tests/unit/core/test_language_detector_html_css.py
@@ -83,7 +83,7 @@ class TestHtmlCssLanguageDetection:
 
         # Test content patterns
         patterns = self.detector.content_patterns.get("html", [])
-        assert len(patterns) > 0
+        assert len(patterns) == 8
 
         # Check that HTML patterns match
         html_score = 0
@@ -93,7 +93,7 @@ class TestHtmlCssLanguageDetection:
             if re.search(pattern, html_content, re.MULTILINE):
                 html_score += weight
 
-        assert html_score > 0
+        assert html_score == 2.1
 
     def test_css_content_detection(self):
         """Test CSS content-based detection"""
@@ -135,7 +135,7 @@ body {
 
         # Test content patterns
         patterns = self.detector.content_patterns.get("css", [])
-        assert len(patterns) > 0
+        assert len(patterns) == 8
 
         # Check that CSS patterns match
         css_score = 0
@@ -145,7 +145,7 @@ body {
             if re.search(pattern, css_content, re.MULTILINE):
                 css_score += weight
 
-        assert css_score > 0
+        assert round(css_score, 1) == 1.8
 
     def test_html_css_supported_languages(self):
         """Test that HTML and CSS are in supported languages"""
@@ -273,7 +273,7 @@ class TestHtmlCssContentPatterns:
             if re.search(pattern, content, re.MULTILINE):
                 matched_patterns += 1
 
-        assert matched_patterns > 0
+        assert matched_patterns == 5
 
     def test_css_selector_patterns(self):
         """Test CSS selector pattern matching"""
@@ -287,7 +287,7 @@ class TestHtmlCssContentPatterns:
             if re.search(pattern, content, re.MULTILINE):
                 matched_patterns += 1
 
-        assert matched_patterns > 0
+        assert matched_patterns == 4
 
     def test_css_at_rule_patterns(self):
         """Test CSS at-rule pattern matching"""
@@ -301,7 +301,7 @@ class TestHtmlCssContentPatterns:
             if "@" in pattern and re.search(pattern, content, re.MULTILINE):
                 at_rule_matches += 1
 
-        assert at_rule_matches > 0
+        assert at_rule_matches == 3
 
 
 if __name__ == "__main__":

--- a/tests/unit/core/test_queries_javascript.py
+++ b/tests/unit/core/test_queries_javascript.py
@@ -47,7 +47,7 @@ class TestJavaScriptQueries:
         """Test getting all queries"""
         all_queries = get_all_queries()
         assert isinstance(all_queries, dict)
-        assert len(all_queries) > 0
+        assert len(all_queries) == 87
         assert "functions" in all_queries
         assert "query" in all_queries["functions"]
         assert "description" in all_queries["functions"]
@@ -56,14 +56,14 @@ class TestJavaScriptQueries:
         """Test listing all query names"""
         query_names = list_queries()
         assert isinstance(query_names, list)
-        assert len(query_names) > 0
+        assert len(query_names) == 87
         assert "functions" in query_names
         assert "classes" in query_names
 
     def test_all_queries_structure(self) -> None:
         """Test ALL_QUERIES dictionary structure"""
         assert isinstance(ALL_QUERIES, dict)
-        assert len(ALL_QUERIES) > 0
+        assert len(ALL_QUERIES) == 87
 
         # Test essential queries exist
         essential_queries = ["functions", "classes", "variables", "imports", "exports"]
@@ -77,9 +77,9 @@ class TestJavaScriptQueries:
     def test_query_constants(self) -> None:
         """Test that query constants are properly defined"""
         constants = [FUNCTIONS, CLASSES, VARIABLES, IMPORTS, EXPORTS, OBJECTS, COMMENTS]
-        for constant in constants:
-            assert isinstance(constant, str)
-            assert len(constant.strip()) > 0
+        assert len(constants) == 7
+        assert all(isinstance(c, str) for c in constants)
+        assert min(len(c.strip()) for c in constants) == 18
 
     def test_functions_query(self) -> None:
         """Test functions query content"""
@@ -123,13 +123,11 @@ class TestJavaScriptQueries:
 
     def test_query_descriptions(self) -> None:
         """Test that all queries have meaningful descriptions"""
-        for _query_name, query_data in ALL_QUERIES.items():
-            description = query_data["description"]
-            assert isinstance(description, str)
-            assert len(description) > 0
-            assert (
-                "search" in description.lower()
-            )  # All descriptions should mention "search"
+        descriptions = [qd["description"] for qd in ALL_QUERIES.values()]
+        assert len(descriptions) == 87
+        assert all(isinstance(d, str) for d in descriptions)
+        assert min(len(d) for d in descriptions) == 15
+        assert all("search" in d.lower() for d in descriptions)
 
     def test_query_consistency(self) -> None:
         """Test consistency between constants and ALL_QUERIES"""
@@ -152,10 +150,10 @@ class TestJavaScriptQueryFunctions:
         assert "function_declaration" in result
 
     def test_get_javascript_query_all_keys(self) -> None:
-        for key in JAVASCRIPT_QUERIES:
-            result = get_javascript_query(key)
-            assert isinstance(result, str)
-            assert len(result.strip()) > 0
+        results = [get_javascript_query(key) for key in JAVASCRIPT_QUERIES]
+        assert len(results) == 78
+        assert all(isinstance(r, str) for r in results)
+        assert min(len(r.strip()) for r in results) == 16
 
     def test_get_javascript_query_invalid_raises(self) -> None:
         with pytest.raises(
@@ -172,10 +170,10 @@ class TestJavaScriptQueryFunctions:
         assert get_javascript_query_description("zzz_missing") == "No description"
 
     def test_get_javascript_query_description_all_keys(self) -> None:
-        for key in JAVASCRIPT_QUERIES:
-            desc = get_javascript_query_description(key)
-            assert isinstance(desc, str)
-            assert len(desc) > 0
+        descs = [get_javascript_query_description(key) for key in JAVASCRIPT_QUERIES]
+        assert len(descs) == 78
+        assert all(isinstance(d, str) for d in descs)
+        assert min(len(d) for d in descs) == 15
 
     def test_get_query_through_all_queries(self) -> None:
         for key in ALL_QUERIES:

--- a/tests/unit/languages/test_markdown_plugin_coverage.py
+++ b/tests/unit/languages/test_markdown_plugin_coverage.py
@@ -78,7 +78,7 @@ class TestExtractFootnoteElements:
         footnotes = []
         ext._extract_footnote_elements(root, footnotes)
         refs = [f for f in footnotes if f.element_type == "footnote_reference"]
-        assert len(refs) >= 1
+        assert len(refs) == 1
         assert refs[0].text == "1"
 
     def test_footnote_definition(self):
@@ -97,7 +97,7 @@ class TestExtractFootnoteElements:
         footnotes = []
         ext._extract_footnote_elements(root, footnotes)
         defs = [f for f in footnotes if f.element_type == "footnote_definition"]
-        assert len(defs) >= 1
+        assert len(defs) == 1
         assert defs[0].text == "footnote content"
 
     def test_footnote_no_match(self):
@@ -139,7 +139,7 @@ class TestExtractInlineImages:
         )
         images = []
         ext._extract_inline_images(root, images)
-        assert len(images) >= 1
+        assert len(images) == 1
         assert images[0].element_type == "image"
         assert images[0].url == "img.png"
         assert images[0].alt_text == "alt"
@@ -179,7 +179,7 @@ class TestExtractImageRefDefs:
         )
         images = []
         ext._extract_image_reference_definitions(root, images)
-        assert len(images) >= 1
+        assert len(images) == 1
         assert any(i.element_type == "image_reference_definition" for i in images)
 
     def test_image_ref_by_url_extension(self):
@@ -200,7 +200,7 @@ class TestExtractImageRefDefs:
         )
         images = []
         ext._extract_image_reference_definitions(root, images)
-        assert len(images) >= 1
+        assert len(images) == 1
         assert images[0].url == "photo.png"
 
     def test_image_ref_no_match(self):
@@ -242,7 +242,7 @@ class TestExtractInlineLinks:
         )
         links = []
         ext._extract_inline_links(root, links)
-        assert len(links) >= 1
+        assert len(links) == 1
         assert links[0].element_type == "link"
         assert links[0].url == "https://example.com"
 
@@ -268,7 +268,7 @@ class TestExtractInlineLinks:
         )
         links = []
         ext._extract_inline_links(root, links)
-        assert len(links) >= 1
+        assert len(links) == 1
         assert links[0].title == "title"
 
 


### PR DESCRIPTION
## Summary
Loose-assertion ratchet batch 26. Top-4 eligible (callers/ghost-caller files excluded — parallel pod active there):

| File | Pins |
|---|---|
| tests/unit/core/test_engine.py | 7 |
| tests/unit/core/test_language_detector_html_css.py | 7 |
| tests/unit/core/test_queries_javascript.py | 7 |
| tests/unit/languages/test_markdown_plugin_coverage.py | 7 |

Baseline: **619 → 591** (= exactly 28, lead re-verified live).

Highlights: `css_score` float pinned via `round(.., 1) == 1.8` (FP-representation-safe exact fact); JS query loop bodies vectorized to `min(len(x) for x in coll) == N` (preserves the all-non-empty invariant with an exact pin); zero exemptions.

## Test plan
- [x] All 4 files individually `-n 0`: 87+1skip/17/26/22 passed
- [x] Diff gate exit=0
- [x] `--baseline` measures 591 == recorded (lead independently re-verified)