### PR TITLE
fix(edit): guard modification_type discoverable in schema; checklist numbering sequential

### DIFF
--- a/tests/unit/mcp/test_safe_to_edit_tool.py
+++ b/tests/unit/mcp/test_safe_to_edit_tool.py
@@ -293,3 +293,88 @@ class TestHelperFunctions:
             str(PROJECT_ROOT),
         )
         assert isinstance(tests, list)
+
+
+# ---------------------------------------------------------------------------
+# Issue #641 — pre_edit_checklist numbering must be sequential (no gap)
+# ---------------------------------------------------------------------------
+
+
+class TestChecklistSequentialNumbering:
+    """build_checklist must emit 1, 2, 3, 4, ... without skipping any number.
+
+    Bug: when downstream_count == 0, item 4 is absent but items for
+    rename/refactor/health were hardcoded as 5/6. This left gaps like
+    [1, 2, 3, 5] in the rendered checklist.
+    """
+
+    def _checklist(self, **kwargs):
+        from tree_sitter_analyzer.mcp.tools.utils.safe_to_edit_risk import (
+            build_checklist,
+        )
+
+        return build_checklist(**kwargs)
+
+    def test_rename_no_downstream_sequential(self):
+        """rename + 0 downstream: must be [1, 2, 3, 4], not [1, 2, 3, 5]."""
+        items = self._checklist(
+            risk="safe",
+            downstream_count=0,
+            has_tests=True,
+            test_files=["tests/test_foo.py"],
+            edit_type="rename",
+        )
+        numbers = [item.split(".")[0] for item in items]
+        assert numbers == ["1", "2", "3", "4"]
+
+    def test_refactor_no_downstream_sequential(self):
+        """refactor + 0 downstream: must be [1, 2, 3, 4], not [1, 2, 3, 5]."""
+        items = self._checklist(
+            risk="safe",
+            downstream_count=0,
+            has_tests=True,
+            test_files=["tests/test_foo.py"],
+            edit_type="refactor",
+        )
+        numbers = [item.split(".")[0] for item in items]
+        assert numbers == ["1", "2", "3", "4"]
+
+    def test_rename_with_downstream_sequential(self):
+        """rename + 2 downstream: must be [1, 2, 3, 4, 5]."""
+        items = self._checklist(
+            risk="safe",
+            downstream_count=2,
+            has_tests=True,
+            test_files=["tests/test_foo.py"],
+            edit_type="rename",
+        )
+        numbers = [item.split(".")[0] for item in items]
+        assert numbers == ["1", "2", "3", "4", "5"]
+
+    def test_health_grade_no_downstream_sequential(self):
+        """poor health (D) + 0 downstream + no edit_type addon: [1, 2, 3, 4]."""
+        items = self._checklist(
+            risk="caution",
+            downstream_count=0,
+            has_tests=False,
+            test_files=[],
+            edit_type="fix_bug",
+            health_grade="D",
+            file_path="src/foo.py",
+        )
+        numbers = [item.split(".")[0] for item in items]
+        assert numbers == ["1", "2", "3", "4"]
+
+    def test_rename_downstream_and_health_sequential(self):
+        """rename + downstream + poor health: [1, 2, 3, 4, 5, 6]."""
+        items = self._checklist(
+            risk="caution",
+            downstream_count=3,
+            has_tests=True,
+            test_files=["tests/test_foo.py"],
+            edit_type="rename",
+            health_grade="D",
+            file_path="src/foo.py",
+        )
+        numbers = [item.split(".")[0] for item in items]
+        assert numbers == ["1", "2", "3", "4", "5", "6"]

--- a/tests/unit/mcp/tools/test_edit_facade.py
+++ b/tests/unit/mcp/tools/test_edit_facade.py
@@ -548,6 +548,87 @@ if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))
 
 
+# ---------------------------------------------------------------------------
+# Issue #641 — edit facade schema must expose modification_type with enum
+# for action=guard discoverability (extra_public_params, NOT required:[])
+# ---------------------------------------------------------------------------
+
+
+def test_edit_facade_schema_has_modification_type_property() -> None:
+    """Schema must declare modification_type so schema-reading agents see it.
+
+    Before fix: modification_type was only reachable via additionalProperties
+    (invisible to schema inspection). After fix: it appears in properties with
+    the authoritative enum — matching the inner ModificationGuardTool schema.
+    """
+    from tree_sitter_analyzer.mcp.tools.edit_facade import build_edit_facade
+
+    facade = build_edit_facade(project_root=None)
+    schema = facade.get_tool_schema()
+    props = schema["properties"]
+    assert "modification_type" in props, (
+        "modification_type must be declared in the edit facade's public schema "
+        "(not hidden behind additionalProperties)"
+    )
+
+
+def test_edit_facade_modification_type_has_enum() -> None:
+    """modification_type property must carry the full authoritative enum."""
+    from tree_sitter_analyzer.mcp.tools.edit_facade import build_edit_facade
+    from tree_sitter_analyzer.mcp.tools.modification_guard_tool import (
+        MODIFICATION_TYPES,
+    )
+
+    facade = build_edit_facade(project_root=None)
+    schema = facade.get_tool_schema()
+    prop = schema["properties"]["modification_type"]
+    assert "enum" in prop, "modification_type must declare an enum"
+    assert set(prop["enum"]) == set(MODIFICATION_TYPES), (
+        "facade modification_type enum must match the inner tool's MODIFICATION_TYPES constant"
+    )
+
+
+def test_edit_facade_modification_type_NOT_in_required() -> None:
+    """modification_type must NOT be in facade required[] (runtime-resolved param).
+
+    LOCKED convention: runtime-required params are described in the description
+    text, not in schema required: [] — this prevents the facade validator from
+    rejecting calls before routing (facade required only lists 'action').
+    """
+    from tree_sitter_analyzer.mcp.tools.edit_facade import build_edit_facade
+
+    facade = build_edit_facade(project_root=None)
+    schema = facade.get_tool_schema()
+    assert "modification_type" not in schema.get("required", []), (
+        "modification_type must NOT appear in facade required[] "
+        "(runtime-resolved param — locked convention, #397 family)"
+    )
+
+
+def test_edit_facade_guard_description_marks_modification_type_required() -> None:
+    """action=guard description must mark modification_type as required (e.g. with *).
+
+    Before fix: the description listed 'Params: symbol, modification_type,
+    file_path' without any required marker — agents had no signal that omitting
+    modification_type triggers an error on the first call.
+    """
+    from tree_sitter_analyzer.mcp.tools.edit_facade import _EDIT_DESCRIPTION
+
+    # The guard line must mark modification_type as required (trailing * or explicit note)
+    guard_lines = [
+        line for line in _EDIT_DESCRIPTION.splitlines() if "action=guard" in line
+    ]
+    assert guard_lines, "edit facade description must have an action=guard line"
+    guard_line = guard_lines[0]
+    assert (
+        "modification_type*" in guard_line
+        or "modification_type (required" in guard_line
+    ), (
+        f"action=guard description line must mark modification_type as required "
+        f"(e.g. 'modification_type*'); got: {guard_line!r}"
+    )
+
+
 def test_action_pr_without_mode_or_pr_url_fails_loudly() -> None:
     """Codex P1 (#483): facade action=pr with NO explicit mode must not
     fall back to the inner's diff default and return empty success.

--- a/tree_sitter_analyzer/mcp/tools/edit_facade.py
+++ b/tree_sitter_analyzer/mcp/tools/edit_facade.py
@@ -59,7 +59,8 @@ _EDIT_DESCRIPTION = (
     "- action=safe — pre-edit safety gate: is this file safe to edit right now? "
     "Returns SAFE/UNSAFE verdict. Params: file_path, edit_type, output_format.\n"
     "- action=guard — blast-radius guard BEFORE touching a symbol: how many callers, "
-    "what test coverage, what risk level. Params: symbol, modification_type, file_path.\n"
+    "what test coverage, what risk level. "
+    "Params: symbol* (required), modification_type* (required), file_path.\n"
     "- action=impact — post-edit dependency blast-radius scan combining git diff + "
     "dependency graph: affected files, must-run tests, risk verdict (SAFE/REVIEW/WARN). "
     "Call after every non-trivial edit. Params: scope_paths, output_format.\n"
@@ -99,6 +100,7 @@ def build_edit_facade(project_root: str | None = None) -> FacadeTool:
     from .ast_diff_tool import ASTDiffTool
     from .change_impact_tool import ChangeImpactTool
     from .codegraph_pr_review_tool import CodeGraphPRReviewTool
+    from .modification_guard_tool import MODIFICATION_TYPES
 
     class _PRReviewViaFacade(CodeGraphPRReviewTool):
         """Facade ``action=pr`` implies ``mode=pr``.
@@ -138,6 +140,21 @@ def build_edit_facade(project_root: str | None = None) -> FacadeTool:
         description=_EDIT_DESCRIPTION,
         annotations=_EDIT_ANNOTATIONS,
         project_root=project_root,
+        # #641: modification_type is required for action=guard but was only
+        # reachable via additionalProperties — invisible to schema-reading
+        # agents. Surface it with the authoritative enum from the inner tool
+        # so facade/inner never drift. Never added to required[] (runtime-
+        # resolved param convention, locked #397 family).
+        extra_public_params={
+            "modification_type": {
+                "type": "string",
+                "enum": list(MODIFICATION_TYPES),
+                "description": (
+                    "Required for action=guard: type of planned modification. "
+                    "One of: " + ", ".join(MODIFICATION_TYPES) + "."
+                ),
+            },
+        },
     )
     # No bespoke inners to register (G3 rebind is automatic for action_map).
     return facade

--- a/tree_sitter_analyzer/mcp/tools/modification_guard_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/modification_guard_tool.py
@@ -46,6 +46,17 @@ _VERDICT_TO_RISK: dict[str, str] = {
     "UNSAFE": "high",
 }
 
+# Authoritative enum for the modification_type parameter.
+# Used by get_tool_schema, validate_arguments, and the edit facade's
+# extra_public_params — single source so they can never drift.
+MODIFICATION_TYPES: tuple[str, ...] = (
+    "behavior_change",
+    "delete",
+    "refactor",
+    "rename",
+    "signature_change",
+)
+
 CRITICAL_NODES_FILE = ".tree-sitter-cache/critical_nodes.json"
 
 
@@ -305,13 +316,7 @@ class ModificationGuardTool(BaseMCPTool):
                 },
                 "modification_type": {
                     "type": "string",
-                    "enum": [
-                        "rename",
-                        "signature_change",
-                        "delete",
-                        "behavior_change",
-                        "refactor",
-                    ],
+                    "enum": list(MODIFICATION_TYPES),
                     "description": "Type of modification you plan to make.",
                 },
                 "file_path": {
@@ -405,13 +410,7 @@ class ModificationGuardTool(BaseMCPTool):
             )
 
         modification_type = arguments.get("modification_type")
-        valid_types = {
-            "rename",
-            "signature_change",
-            "delete",
-            "behavior_change",
-            "refactor",
-        }
+        valid_types = set(MODIFICATION_TYPES)
         if not modification_type or modification_type not in valid_types:
             raise ValueError(
                 f"modification_type must be one of: {', '.join(sorted(valid_types))}"

--- a/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_risk.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_risk.py
@@ -41,26 +41,37 @@ def build_checklist(
     file_path: str = "",
     project_root: str | Path | None = None,
 ) -> list[str]:
-    """Build a pre-edit checklist for the AI agent."""
-    items = [_risk_instruction(risk)]
-    items.extend(_test_instructions(has_tests, test_files, project_root))
+    """Build a pre-edit checklist for the AI agent.
+
+    Items are numbered sequentially (1, 2, 3, …) after filtering — items whose
+    condition is False are simply absent, so the remaining items are always
+    contiguous. Previously items 4/5/6 were hardcoded, causing gaps like
+    [1, 2, 3, 5] when downstream_count == 0 (issue #641).
+    """
+    raw: list[str] = [_risk_instruction(risk)]
+    raw.extend(_test_instructions(has_tests, test_files, project_root))
 
     if downstream_count > 0:
-        items.append(
-            f"4. {downstream_count} downstream file(s) - verify imports still resolve"
+        raw.append(
+            f"{downstream_count} downstream file(s) - verify imports still resolve"
         )
     if edit_type == "rename":
-        items.append(
-            "5. After rename: run find_and_grep(old_name) to find all references"
-        )
+        raw.append("After rename: run find_and_grep(old_name) to find all references")
     if edit_type == "refactor":
-        items.append("5. Keep public API signatures unchanged during refactor")
+        raw.append("Keep public API signatures unchanged during refactor")
     if health_grade in ("D", "F") and file_path:
-        items.append(
-            f"6. File is grade {health_grade} - run refactoring_suggestions(file_path='{file_path}') for extraction plans"
+        raw.append(
+            f"File is grade {health_grade} - run refactoring_suggestions(file_path='{file_path}') for extraction plans"
         )
 
-    return items
+    # Strip any pre-existing leading "N. " prefixes from helper functions so
+    # renumbering is idempotent, then apply sequential 1-based numbers.
+    import re as _re
+
+    def _strip_number(text: str) -> str:
+        return _re.sub(r"^\d+\.\s*", "", text)
+
+    return [f"{i}. {_strip_number(item)}" for i, item in enumerate(raw, start=1)]
 
 
 def _add_downstream_factor(factors: list[RiskFactor], forward_count: int) -> int:


### PR DESCRIPTION
Closes #641 (dogfood patrol P3).

## Fix 1 — modification_type discoverability
`edit action=guard` requires modification_type at runtime (enum behavior_change/delete/refactor/rename/signature_change) but the facade schema didn't declare it (relied on additionalProperties). Now:
- `MODIFICATION_TYPES` extracted as a module-level constant — single source for both `get_tool_schema()` and `validate_arguments()` (was hand-duplicated in two places)
- edit facade declares it in `extra_public_params` with the enum + "Required for action=guard" description (the #640/kind precedent); `required:[]` untouched (#397 lock, pinned)
- facade-actions.md regenerated — content unchanged (generator already sourced the inner schema)

## Fix 2 — checklist numbering (cosmetic)
`build_checklist` hardcoded numbers 4/5/6; when downstream_count==0 item 4 was dropped leaving gaps `[1,2,3,5]`. Now `enumerate(raw, start=1)` after stripping any pre-existing prefixes → always contiguous.

## Test plan
- [x] RED-first: 6 failed pre-fix → green; required-lock pin; checklist sequential pin
- [x] Regression: edit/guard/facade/schema 676 + agent_contracts 53 + safe_to_edit/edit_facade 69 (-n 0)
- [x] Golden FULL (6c): 96 passed, swift known-env; ratchet exit=0
- [x] Lead independently verified live schema (modification_type + enum present, required untouched) + push diff=0