### PR TITLE
test: ratchet batch-28 — pin 24 loose assertions in top-4 AST-ranked files

### DIFF
--- a/scripts/loose_assertion_baseline.txt
+++ b/scripts/loose_assertion_baseline.txt
@@ -55,7 +55,9 @@
 #   AST-ranked files, no exemptions).
 #   batch-27 (AST): 591 -> 567, 2026-06-13 (14 exact pins + 10 timing/environment/hypothesis
 #   exemptions in top-4 AST-ranked files; property files excluded from baseline).
+#   batch-28 (AST): 567 -> 543, 2026-06-13 (24 exact pins in top-4 AST-ranked
+#   files, no exemptions).
 
-BASELINE_COUNT=567
+BASELINE_COUNT=543
 MEASUREMENT_DATE=2026-06-13
 MEASUREMENT_COMMAND="uv run python scripts/check_loose_assertions.py --baseline"

--- a/tests/unit/languages/test_go_queries.py
+++ b/tests/unit/languages/test_go_queries.py
@@ -24,7 +24,7 @@ class TestGoQueriesDict:
 
     def test_go_queries_not_empty(self):
         """GO_QUERIES should not be empty."""
-        assert len(GO_QUERIES) > 0
+        assert len(GO_QUERIES) == 31
 
     def test_all_queries_are_strings(self):
         """All query values should be strings."""
@@ -110,7 +110,7 @@ class TestGoQueryDescriptions:
 
     def test_descriptions_not_empty(self):
         """GO_QUERY_DESCRIPTIONS should not be empty."""
-        assert len(GO_QUERY_DESCRIPTIONS) > 0
+        assert len(GO_QUERY_DESCRIPTIONS) == 31
 
     def test_all_descriptions_are_strings(self):
         """All description values should be strings."""
@@ -156,7 +156,7 @@ class TestGetGoQueryDescription:
         """get_go_query_description should return description for valid name."""
         result = get_go_query_description("function")
         assert isinstance(result, str)
-        assert len(result) > 0
+        assert len(result) == 32
 
     def test_get_all_descriptions(self):
         """get_go_query_description should work for all defined queries."""
@@ -179,7 +179,7 @@ class TestAllQueries:
 
     def test_all_queries_not_empty(self):
         """ALL_QUERIES should not be empty."""
-        assert len(ALL_QUERIES) > 0
+        assert len(ALL_QUERIES) == 38
 
     def test_all_queries_structure(self):
         """ALL_QUERIES should have correct structure."""
@@ -249,7 +249,7 @@ class TestListQueries:
     def test_not_empty(self):
         """list_queries should not be empty."""
         result = list_queries()
-        assert len(result) > 0
+        assert len(result) == 38
 
     def test_contains_all_query_names(self):
         """list_queries should contain all query names."""
@@ -269,7 +269,7 @@ class TestGetAvailableGoQueries:
     def test_not_empty(self):
         """get_available_go_queries should not be empty."""
         result = get_available_go_queries()
-        assert len(result) > 0
+        assert len(result) == 31
 
     def test_contains_all_query_names(self):
         """get_available_go_queries should contain all GO_QUERIES names."""

--- a/tests/unit/languages/test_rust_queries.py
+++ b/tests/unit/languages/test_rust_queries.py
@@ -24,7 +24,7 @@ class TestRustQueriesDict:
 
     def test_rust_queries_not_empty(self):
         """RUST_QUERIES should not be empty."""
-        assert len(RUST_QUERIES) > 0
+        assert len(RUST_QUERIES) == 24
 
     def test_all_queries_are_strings(self):
         """All query values should be strings."""
@@ -110,7 +110,7 @@ class TestRustQueryDescriptions:
 
     def test_descriptions_not_empty(self):
         """RUST_QUERY_DESCRIPTIONS should not be empty."""
-        assert len(RUST_QUERY_DESCRIPTIONS) > 0
+        assert len(RUST_QUERY_DESCRIPTIONS) == 24
 
     def test_all_descriptions_are_strings(self):
         """All description values should be strings."""
@@ -156,7 +156,7 @@ class TestGetRustQueryDescription:
         """get_rust_query_description should return description for valid name."""
         result = get_rust_query_description("fn")
         assert isinstance(result, str)
-        assert len(result) > 0
+        assert len(result) == 34
 
     def test_get_all_descriptions(self):
         """get_rust_query_description should work for all defined queries."""
@@ -179,7 +179,7 @@ class TestAllQueries:
 
     def test_all_queries_not_empty(self):
         """ALL_QUERIES should not be empty."""
-        assert len(ALL_QUERIES) > 0
+        assert len(ALL_QUERIES) == 29
 
     def test_all_queries_structure(self):
         """ALL_QUERIES should have correct structure."""
@@ -247,7 +247,7 @@ class TestListQueries:
     def test_not_empty(self):
         """list_queries should not be empty."""
         result = list_queries()
-        assert len(result) > 0
+        assert len(result) == 29
 
     def test_contains_all_query_names(self):
         """list_queries should contain all query names."""
@@ -267,7 +267,7 @@ class TestGetAvailableRustQueries:
     def test_not_empty(self):
         """get_available_rust_queries should not be empty."""
         result = get_available_rust_queries()
-        assert len(result) > 0
+        assert len(result) == 24
 
     def test_contains_all_query_names(self):
         """get_available_rust_queries should contain all RUST_QUERIES names."""

--- a/tests/unit/test_codegraph_overview_tool.py
+++ b/tests/unit/test_codegraph_overview_tool.py
@@ -109,7 +109,7 @@ class TestCodeGraphOverviewToolExecute:
         assert "entry_point_count" in summary
         assert "dead_code_count" in summary
         assert "max_call_depth" in summary
-        assert summary["function_count"] > 0
+        assert summary["function_count"] == 15
 
     @pytest.mark.asyncio
     async def test_execute_entry_points(self, tool):
@@ -197,8 +197,8 @@ class TestFindHubFunctions:
         graph = tool.get_call_graph()
         graph.build()
         hubs = _find_hub_functions(graph, 100)
-        for hub in hubs:
-            assert hub["caller_count"] >= 3
+        # The python_project fixture has no functions called by 3+ callers.
+        assert len(hubs) == 0
 
     def test_hub_caller_files_are_sampled(self):
         hub = FunctionRef("hub.py", "hub", 1, "python")
@@ -237,7 +237,7 @@ class TestComputeDepthDistribution:
         assert "max_depth" in dist
         assert "avg_depth" in dist
         assert "distribution" in dist
-        assert dist["max_depth"] >= 0
+        assert dist["max_depth"] == 2
 
     def test_handles_cycles_without_recursive_explosion(self):
         a = FunctionRef("graph.py", "a", 1, "python")
@@ -282,7 +282,7 @@ class TestComputeDepthDistribution:
 
         assert dist["max_depth"] == dist["depth_cap"]
         assert dist["capped"] is True
-        assert dist["distribution"]["depth_10+"] >= 1
+        assert dist["distribution"]["depth_10+"] == 3
 
 
 class TestComputeModuleCoupling:
@@ -290,6 +290,6 @@ class TestComputeModuleCoupling:
         graph = tool.get_call_graph()
         graph.build()
         coupling = _compute_module_coupling(graph, 100)
-        for c in coupling:
-            assert c["outgoing_calls"] > 0
-            assert c["target_files"] > 0
+        assert len(coupling) == 1
+        assert coupling[0]["outgoing_calls"] == 4
+        assert coupling[0]["target_files"] == 2

--- a/tests/unit/test_cross_file_resolver.py
+++ b/tests/unit/test_cross_file_resolver.py
@@ -86,7 +86,7 @@ class TestCrossFileResolverBuild:
         resolver.build()
         assert "format_user" in resolver._functions_by_name
         assert "handle_request" in resolver._functions_by_name
-        assert len(resolver._functions_by_name["format_user"]) >= 1
+        assert len(resolver._functions_by_name["format_user"]) == 1
 
     def test_import_index_populated(self, multi_file_project):
         _project, cache = multi_file_project
@@ -105,7 +105,7 @@ class TestCrossFileResolution:
         resolver = CrossFileResolver(cache)
         resolver.build()
         results = resolver.resolve_callee("_find_user", "services.py")
-        assert len(results) >= 1
+        assert len(results) == 1
         assert any("services.py" in r[0] for r in results)
         assert results[0][1] == 1.0
 
@@ -114,7 +114,7 @@ class TestCrossFileResolution:
         resolver = CrossFileResolver(cache)
         resolver.build()
         results = resolver.resolve_callee("format_user", "services.py")
-        assert len(results) >= 1
+        assert len(results) == 1
         assert any("utils.py" in r[0] for r in results)
 
     def test_resolve_callee_with_confidence(self, multi_file_project):
@@ -122,15 +122,15 @@ class TestCrossFileResolution:
         resolver = CrossFileResolver(cache)
         resolver.build()
         results = resolver.resolve_callee("format_user", "services.py")
-        assert len(results) >= 1
-        assert results[0][1] >= 0.9
+        assert len(results) == 1
+        assert results[0][1] == 0.9
 
     def test_resolve_cross_file_via_import(self, multi_file_project):
         _project, cache = multi_file_project
         resolver = CrossFileResolver(cache)
         resolver.build()
         results = resolver.resolve_callee("handle_request", "main.py")
-        assert len(results) >= 1
+        assert len(results) == 1
         assert any("services.py" in r[0] for r in results)
 
     def test_find_caller_function(self, multi_file_project):
@@ -152,8 +152,8 @@ class TestCrossFileResolution:
         resolver = CrossFileResolver(cache)
         resolver.build()
         name, line = resolver.find_caller_function(999, "services.py")
-        assert name != ""
-        assert line > 0
+        assert name == "handle_request"
+        assert line == 12
 
     def test_find_caller_function_unknown_file(self, multi_file_project):
         _project, cache = multi_file_project


### PR DESCRIPTION
## Summary
Loose-assertion ratchet batch 28. Top-4 (8-way tie at 6, lexicographic):

| File | Pins |
|---|---|
| tests/unit/languages/test_go_queries.py | 6 |
| tests/unit/languages/test_rust_queries.py | 6 |
| tests/unit/test_codegraph_overview_tool.py | 6 |
| tests/unit/test_cross_file_resolver.py | 6 |

Baseline: **567 → 543** (= exactly 24, **zero exemptions**, lead re-verified live).

Highlights: go/rust query registry counts pinned (31/24); a dead-branch hub loop (vacuously-true for-loop) restructured to `assert len(hubs) == 0` pinning the real measured fact; cross-file resolver `>= 0.9` confidence → `== 0.9` (fixed source constant for imported callees), `line > 0` → `== 12`, name pinned exact.

## Test plan
- [x] All 4 files individually `-n 0`: 43/43/27/22 passed
- [x] Diff gate exit=0
- [x] `--baseline` measures 543 == recorded (lead independently re-verified)