### PR TITLE
fix(nav): blast_radius accepts singular param + labels transitive cap; FunctionRef propagation regression-guarded

### DIFF
--- a/tests/unit/test_codegraph_impact_tool.py
+++ b/tests/unit/test_codegraph_impact_tool.py
@@ -470,3 +470,200 @@ class TestImpactTestPartition:
         names = {r["name"] for r in result}
         assert "real_dep" in names
         assert "fake_dep" in names
+
+
+# ---------------------------------------------------------------------------
+# #656 — blast_radius transitive propagation (FunctionRef dict-key identity)
+# ---------------------------------------------------------------------------
+
+
+class TestBlastRadiusPropagation:
+    """#656: blast_radius must propagate transitively, not just return the seed.
+
+    The graph walks caller_refs_of(current) where *current* may come from a
+    previous iteration's caller list.  With __hash__/__eq__ keyed on
+    (file_path, name, start_line), a FunctionRef VALUE retrieved from _callers
+    can be used as a KEY for the next-level lookup even if it is a different
+    object instance — the dict lookup succeeds because hashes match.
+    """
+
+    def test_transitive_caller_chain_propagates(self):
+        """Seed←B←C: total_affected_functions == 3 (seed + 2 transitive callers)."""
+        seed = _make_func("seed", "a.py")
+        b = _make_func("b", "b.py", 5)
+        c = _make_func("c", "c.py", 10)
+
+        graph = MagicMock()
+        graph.resolve_targets.return_value = [seed]
+        callers_map = {seed: [b], b: [c], c: []}
+        callees_map = {seed: [], b: [], c: []}
+        graph.caller_refs_of.side_effect = lambda f: callers_map.get(f, [])
+        graph.callee_refs_of.side_effect = lambda f: callees_map.get(f, [])
+
+        result = _blast_radius_for_functions(graph, ["seed"], depth=5)
+        assert result["total_affected_functions"] == 3
+
+    def test_four_direct_callers_are_all_counted(self):
+        """seed with 4 direct callers: total_affected_functions == 5 (seed + 4)."""
+        seed = _make_func("seed", "core.py")
+        callers = [_make_func(f"c{i}", f"mod{i}.py", i + 10) for i in range(4)]
+
+        graph = MagicMock()
+        graph.resolve_targets.return_value = [seed]
+        callers_map: dict = {seed: callers}
+        for c in callers:
+            callers_map[c] = []
+        callees_map: dict = {seed: []}
+        for c in callers:
+            callees_map[c] = []
+        graph.caller_refs_of.side_effect = lambda f: callers_map.get(f, [])
+        graph.callee_refs_of.side_effect = lambda f: callees_map.get(f, [])
+
+        result = _blast_radius_for_functions(graph, ["seed"], depth=5)
+        assert result["total_affected_functions"] == 5
+
+
+# ---------------------------------------------------------------------------
+# #657 — singular function_name accepted as alias for blast_radius
+# ---------------------------------------------------------------------------
+
+
+class TestBlastRadiusSingularAlias:
+    """#657: blast_radius should accept function_name (singular) and wrap it."""
+
+    def test_validate_accepts_singular_function_name(self):
+        """validate_arguments must NOT raise when function_name (singular) is given."""
+        tool = CodeGraphImpactTool()
+        # Should not raise
+        assert tool.validate_arguments({"mode": "blast_radius", "function_name": "foo"})
+
+    def test_validate_still_raises_when_both_absent(self):
+        """validate_arguments must still raise when neither name form is provided."""
+        tool = CodeGraphImpactTool()
+        with pytest.raises(ValueError, match="function_names is required"):
+            tool.validate_arguments({"mode": "blast_radius"})
+
+    @pytest.mark.asyncio
+    async def test_execute_singular_wraps_to_list(self):
+        """execute with function_name=X for blast_radius passes [X] to blast fn."""
+        tool = CodeGraphImpactTool(project_root="/tmp/nonexistent")
+        seed = _make_func("solo_fn", "x.py")
+        mock_graph = MagicMock()
+        mock_graph.resolve_targets.return_value = [seed]
+        mock_graph.caller_refs_of.return_value = []
+        mock_graph.callee_refs_of.return_value = []
+        with patch.object(tool, "get_call_graph", return_value=mock_graph):
+            result = await tool.execute(
+                {
+                    "mode": "blast_radius",
+                    "function_name": "solo_fn",  # singular, not function_names
+                    "output_format": "json",
+                }
+            )
+        assert result["success"] is True
+        assert result["mode"] == "blast_radius"
+        # seed only: total_affected_functions == 1
+        assert result["total_affected_functions"] == 1
+
+    def test_schema_mentions_blast_radius_function_names(self):
+        """Schema description for function_names must reference blast_radius mode."""
+        tool = CodeGraphImpactTool()
+        schema = tool.get_tool_schema()
+        desc = schema["properties"]["function_names"]["description"]
+        assert "blast_radius" in desc
+
+    def test_schema_describes_singular_alias(self):
+        """function_name schema description must mention blast_radius alias."""
+        tool = CodeGraphImpactTool()
+        schema = tool.get_tool_schema()
+        desc = schema["properties"]["function_name"]["description"]
+        # Must document that singular is accepted for blast_radius too
+        assert "blast_radius" in desc
+
+
+# ---------------------------------------------------------------------------
+# #658 — transitive_count_is_capped flag when _MAX_TRANSITIVE cap hit
+# ---------------------------------------------------------------------------
+
+
+class TestTransitiveCapFlag:
+    """#658: transitive_caller_count == _MAX_TRANSITIVE must expose is_capped flag."""
+
+    def _graph_with_n_transitive_callers(self, n: int) -> MagicMock:
+        """Return a mock graph whose BFS yields exactly n unique callers."""
+
+        graph = MagicMock()
+        hub = _make_func("hub", "hub.py")
+        graph.resolve_targets.return_value = [hub]
+        callers = [_make_func(f"c{i}", f"f{i}.py", i) for i in range(n)]
+        # All callers are direct (depth 1), no second-level callers.
+        callers_map: dict = {hub: callers}
+        for c in callers:
+            callers_map[c] = []
+        graph.caller_refs_of.side_effect = lambda f: callers_map.get(f, [])
+        graph.callee_refs_of.return_value = []
+        graph.callers_of.return_value = [c.to_dict() for c in callers]
+        graph.callees_of.return_value = []
+        graph.call_chain.return_value = []
+        return graph
+
+    def test_capped_flag_absent_below_limit(self):
+        """transitive_count_is_capped absent when caller count < _MAX_TRANSITIVE."""
+        from tree_sitter_analyzer.mcp.tools.codegraph_impact_tool import _MAX_TRANSITIVE
+
+        tool = CodeGraphImpactTool()
+        n = _MAX_TRANSITIVE - 1
+        graph = self._graph_with_n_transitive_callers(n)
+        result = tool._function_impact(graph, "hub", None, 10)
+        assert result["transitive_caller_count"] == n
+        assert "transitive_count_is_capped" not in result
+
+    def test_capped_flag_present_at_limit(self):
+        """transitive_count_is_capped: True when transitive_caller_count == _MAX_TRANSITIVE."""
+        from tree_sitter_analyzer.mcp.tools.codegraph_impact_tool import _MAX_TRANSITIVE
+
+        tool = CodeGraphImpactTool()
+        n = _MAX_TRANSITIVE
+        graph = self._graph_with_n_transitive_callers(n)
+        result = tool._function_impact(graph, "hub", None, 10)
+        assert result["transitive_caller_count"] == _MAX_TRANSITIVE
+        assert result["transitive_count_is_capped"] is True
+
+    def _graph_with_n_transitive_callees(self, n: int) -> MagicMock:
+        """Return a mock graph whose callee BFS yields exactly n unique callees."""
+
+        graph = MagicMock()
+        hub = _make_func("hub", "hub.py")
+        graph.resolve_targets.return_value = [hub]
+        callees = [_make_func(f"d{i}", f"g{i}.py", i) for i in range(n)]
+        callees_map: dict = {hub: callees}
+        for d in callees:
+            callees_map[d] = []
+        graph.callee_refs_of.side_effect = lambda f: callees_map.get(f, [])
+        graph.caller_refs_of.return_value = []
+        graph.callers_of.return_value = []
+        graph.callees_of.return_value = [d.to_dict() for d in callees]
+        graph.call_chain.return_value = []
+        return graph
+
+    def test_callee_capped_flag_absent_below_limit(self):
+        """transitive_callee_count_is_capped absent when callee count < _MAX_TRANSITIVE."""
+        from tree_sitter_analyzer.mcp.tools.codegraph_impact_tool import _MAX_TRANSITIVE
+
+        tool = CodeGraphImpactTool()
+        n = _MAX_TRANSITIVE - 1
+        graph = self._graph_with_n_transitive_callees(n)
+        result = tool._function_impact(graph, "hub", None, 10)
+        assert result["transitive_callee_count"] == n
+        assert "transitive_callee_count_is_capped" not in result
+
+    def test_callee_capped_flag_present_at_limit(self):
+        """transitive_callee_count_is_capped: True when count == _MAX_TRANSITIVE."""
+        from tree_sitter_analyzer.mcp.tools.codegraph_impact_tool import _MAX_TRANSITIVE
+
+        tool = CodeGraphImpactTool()
+        n = _MAX_TRANSITIVE
+        graph = self._graph_with_n_transitive_callees(n)
+        result = tool._function_impact(graph, "hub", None, 10)
+        assert result["transitive_callee_count"] == _MAX_TRANSITIVE
+        assert result["transitive_callee_count_is_capped"] is True

--- a/tree_sitter_analyzer/mcp/tools/codegraph_impact_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_impact_tool.py
@@ -361,12 +361,20 @@ class CodeGraphImpactTool(BaseMCPTool):
                 },
                 "function_name": {
                     "type": "string",
-                    "description": "Target function name (required for function_impact and risk_score)",
+                    "description": (
+                        "Target function name. Required for function_impact and "
+                        "risk_score modes. Also accepted as a singular alias for "
+                        "blast_radius (wrap in list automatically)."
+                    ),
                 },
                 "function_names": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "List of function names for blast_radius mode",
+                    "description": (
+                        "List of function names for blast_radius mode. "
+                        "Use function_names (plural) for blast_radius; "
+                        "function_name (singular) is also accepted and wrapped."
+                    ),
                 },
                 "file_path": {
                     "type": "string",
@@ -405,8 +413,12 @@ class CodeGraphImpactTool(BaseMCPTool):
             "function_name"
         ):
             raise ValueError(f"function_name is required for mode '{mode}'")
-        if mode == "blast_radius" and not arguments.get("function_names"):
-            raise ValueError("function_names is required for blast_radius mode")
+        if mode == "blast_radius":
+            # Accept function_names (plural) OR function_name (singular alias).
+            if not arguments.get("function_names") and not arguments.get(
+                "function_name"
+            ):
+                raise ValueError("function_names is required for blast_radius mode")
         return True
 
     async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
@@ -429,9 +441,11 @@ class CodeGraphImpactTool(BaseMCPTool):
                 graph, func_name, file_path, depth, include_tests
             )
         elif mode == "blast_radius":
-            result = _blast_radius_for_functions(
-                graph, arguments["function_names"], file_path, depth
+            # #657: accept function_name (singular) as alias — wrap in list.
+            func_names: list[str] = arguments.get("function_names") or (
+                [arguments["function_name"]] if arguments.get("function_name") else []
             )
+            result = _blast_radius_for_functions(graph, func_names, file_path, depth)
         elif mode == "risk_score":
             if not func_name:
                 raise ValueError("function_name required for risk_score mode")
@@ -490,7 +504,7 @@ class CodeGraphImpactTool(BaseMCPTool):
             or len(transitive_callers) > _MAX_LISTED
             or len(transitive_callees) > _MAX_LISTED
         )
-        return {
+        out: dict[str, Any] = {
             "function": func_name,
             "file": self_file,
             "direct_callers": direct_callers[:_MAX_LISTED],
@@ -507,6 +521,13 @@ class CodeGraphImpactTool(BaseMCPTool):
             "listed_cap": _MAX_LISTED,
             "risk": risk,
         }
+        # #658 honest-truncation: flag when the _MAX_TRANSITIVE cap was hit so
+        # agents don't report the cap (200) as a precise total.
+        if len(transitive_callers) >= _MAX_TRANSITIVE:
+            out["transitive_count_is_capped"] = True
+        if len(transitive_callees) >= _MAX_TRANSITIVE:
+            out["transitive_callee_count_is_capped"] = True
+        return out
 
 
 def _impact_verdict(result: dict[str, Any]) -> str:


### PR DESCRIPTION
Closes #657 and #658; documents #656 (dogfood round 2).

## #657 — singular function_name alias for blast_radius
`validate_arguments` rejected blast_radius calls with only `function_name` (singular) — required `function_names` (plural, undocumented). Now accepts either (singular → wrapped in list); both schema descriptions mention blast_radius mode.

## #658 — transitive cap labeled
`transitive_caller_count=200` was the `_MAX_TRANSITIVE=200` BFS cap presented as exact. Now adds `transitive_count_is_capped: true` (+ symmetric callee flag) ONLY when the cap fires — absent below, per the honest-truncation convention (#444/#448).

## #656 — blast_radius propagation: already correct, regression-guarded
Investigated: `FunctionRef.__hash__/__eq__` (on file_path+name+start_line) are already present (call_graph.py:76-86), so `caller_refs_of` dict lookup works — `CallGraph('.')` propagates to 25,302 affected (not 1). The dogfood's total_affected=1 was almost certainly a stale/edgeless index (BuildProjectIndexTool doesn't populate call edges — only ASTCache.index_project does). Added `TestBlastRadiusPropagation` (transitive chain → 3, four direct callers → 5) as a regression guard so this can't silently break.

## Test plan
- [x] RED-first: 4 failed (singular accept, singular-wraps-list, schema describes, capped-flag-at-limit) → 44 in impact tool + 238 regression passed (-n 0)
- [x] facade-actions.md no regen needed (verified)
- [x] Golden FULL (6c): 96 passed, swift known-env; ratchet exit=0
- [x] Lead independently re-ran 44 tests + push diff=0