### PR TITLE
fix(structure): class_tree subclasses drops same-name parentless ghost

### DIFF
--- a/tests/unit/test_codegraph_class_hierarchy_tool.py
+++ b/tests/unit/test_codegraph_class_hierarchy_tool.py
@@ -418,3 +418,56 @@ class TestClassHierarchyEdgeStore:
             )
         finally:
             cache.close()
+
+
+class TestSameNameDifferentBaseCollision:
+    """Codex P2 on #659: two same-named children inheriting DIFFERENT bases
+    must each only appear under their actual base."""
+
+    def test_same_name_children_different_bases_isolated(self, tmp_path):
+        from tree_sitter_analyzer.class_hierarchy import ClassHierarchy, ClassInfo
+
+        h = ClassHierarchy.__new__(ClassHierarchy)
+        # Minimal hand-built state (bypass index): two Worker classes, one
+        # inherits Base, the other inherits Other.
+        from collections import defaultdict
+
+        h._built = True
+        h._parent_map = defaultdict(list)
+        h._children = defaultdict(list, {"Base": ["Worker"], "Other": ["Worker"]})
+        h._confirmed_child_files = defaultdict(
+            set,
+            {
+                "Base": {("a.py", "Worker")},
+                "Other": {("b.py", "Worker")},
+            },
+        )
+        h._classes = defaultdict(
+            list,
+            {
+                "Worker": [
+                    ClassInfo(
+                        name="Worker",
+                        file="a.py",
+                        line=1,
+                        end_line=2,
+                        parents=["Base"],
+                        language="python",
+                    ),
+                    ClassInfo(
+                        name="Worker",
+                        file="b.py",
+                        line=1,
+                        end_line=2,
+                        parents=["Other"],
+                        language="python",
+                    ),
+                ]
+            },
+        )
+        h.build = lambda: None  # already "built"
+
+        base_subs = h.subclasses_of("Base")
+        assert [(s["file"]) for s in base_subs] == ["a.py"]
+        other_subs = h.subclasses_of("Other")
+        assert [(s["file"]) for s in other_subs] == ["b.py"]

--- a/tests/unit/test_codegraph_class_hierarchy_tool.py
+++ b/tests/unit/test_codegraph_class_hierarchy_tool.py
@@ -367,3 +367,54 @@ class TestClassHierarchyEdgeStore:
             assert ClassHierarchy(cache)._build_edges_from_edge_store() is False
         finally:
             cache.close()
+
+    def test_same_name_class_without_parents_not_listed_as_subclass(
+        self, tmp_path
+    ) -> None:
+        """Regression: #659 — same-name collision must not create false subclass.
+
+        Two files both define a class named 'Worker':
+        - real_worker.py: class Worker(Base) — genuinely inherits Base
+        - fake_worker.py: class Worker:       — no inheritance whatsoever
+
+        subclasses_of('Base') must return exactly one entry (real_worker.py),
+        NOT two.  Before the fix the bare-name lookup in _classes['Worker']
+        returned both ClassInfo entries, emitting the parentless one as a ghost.
+        """
+        real = tmp_path / "real_worker.py"
+        real.write_text(
+            "class Base:\n    pass\n\nclass Worker(Base):\n    pass\n",
+            encoding="utf-8",
+        )
+        fake = tmp_path / "fake_worker.py"
+        fake.write_text(
+            "class Worker:\n    pass\n",
+            encoding="utf-8",
+        )
+
+        cache = ASTCache(str(tmp_path))
+        try:
+            assert cache.index_file(str(real))["status"] == "indexed"
+            assert cache.index_file(str(fake))["status"] == "indexed"
+
+            hierarchy = ClassHierarchy(cache)
+            hierarchy.build()
+
+            subs = hierarchy.subclasses_of("Base")
+            sub_entries = [(s["name"], s["file"]) for s in subs]
+
+            # Only the real inheriting Worker must appear
+            assert ("Worker", "real_worker.py") in sub_entries, (
+                f"Real Worker missing from subclasses: {sub_entries}"
+            )
+            # The parentless Worker from fake_worker.py must NOT appear
+            assert ("Worker", "fake_worker.py") not in sub_entries, (
+                f"Ghost Worker from fake_worker.py incorrectly listed: {sub_entries}"
+            )
+            # Exactly one Worker entry total
+            worker_entries = [e for e in sub_entries if e[0] == "Worker"]
+            assert len(worker_entries) == 1, (
+                f"Expected exactly 1 Worker subclass, got {len(worker_entries)}: {worker_entries}"
+            )
+        finally:
+            cache.close()

--- a/tree_sitter_analyzer/class_hierarchy.py
+++ b/tree_sitter_analyzer/class_hierarchy.py
@@ -92,6 +92,9 @@ class ClassHierarchy:
         self._classes: dict[str, list[ClassInfo]] = defaultdict(list)
         self._children: dict[str, list[str]] = defaultdict(list)
         self._parent_map: dict[str, list[str]] = defaultdict(list)
+        # Set of (file, class_name) pairs confirmed as real children by the
+        # edge store.  Used to disambiguate same-name collisions in #659.
+        self._confirmed_child_files: set[tuple[str, str]] = set()
         self._built = False
 
     def build(self) -> None:
@@ -166,8 +169,10 @@ class ClassHierarchy:
 
         parent_map: dict[str, list[str]] = defaultdict(list)
         children: dict[str, list[str]] = defaultdict(list)
+        confirmed_child_files: set[tuple[str, str]] = set()
         for row in rows:
-            child = parse_node_id(row["source_node_id"]).name
+            source_ref = parse_node_id(row["source_node_id"])
+            child = source_ref.name
             parent = str(row["metadata"] or "")
             try:
                 parent_meta = json.loads(row["metadata"] or "{}")
@@ -182,6 +187,10 @@ class ClassHierarchy:
             base = parent.rsplit(".", 1)[-1]
             children[parent].append(child)
             children[base].append(child)
+            # Record the (file, child_name) pair so same-name collisions can
+            # be resolved in subclasses_of (#659).
+            if source_ref.file_path:
+                confirmed_child_files.add((source_ref.file_path, child))
 
         if not parent_map:
             return False
@@ -193,6 +202,7 @@ class ClassHierarchy:
             list,
             {name: sorted(set(child_names)) for name, child_names in children.items()},
         )
+        self._confirmed_child_files = confirmed_child_files
         return True
 
     def has_class(self, class_name: str) -> bool:
@@ -227,7 +237,19 @@ class ClassHierarchy:
                     continue
                 visited.add(child_name)
                 for info in self._classes.get(child_name, []):
-                    result.append({"depth": depth + 1, **info.to_dict()})
+                    # Guard against same-name collision (#659): _classes is
+                    # keyed by bare class name, so both `class Foo(Base):` and
+                    # a parentless `class Foo:` in a different file land here.
+                    # Only emit an entry if:
+                    #  (a) the ClassInfo itself declares parents (normal case),
+                    #  (b) the edge store explicitly confirmed this (file, name)
+                    #      pair as a real child — handles the case where
+                    #      symbols_json parents were stripped but edges remain.
+                    if (
+                        info.parents
+                        or (info.file, child_name) in self._confirmed_child_files
+                    ):
+                        result.append({"depth": depth + 1, **info.to_dict()})
                 queue.append((child_name, depth + 1))
 
         return result

--- a/tree_sitter_analyzer/class_hierarchy.py
+++ b/tree_sitter_analyzer/class_hierarchy.py
@@ -92,9 +92,10 @@ class ClassHierarchy:
         self._classes: dict[str, list[ClassInfo]] = defaultdict(list)
         self._children: dict[str, list[str]] = defaultdict(list)
         self._parent_map: dict[str, list[str]] = defaultdict(list)
-        # Set of (file, class_name) pairs confirmed as real children by the
-        # edge store.  Used to disambiguate same-name collisions in #659.
-        self._confirmed_child_files: set[tuple[str, str]] = set()
+        # Parent name → {(file, class_name)} confirmed as real children by the
+        # edge store.  Keyed per-parent to disambiguate same-name collisions
+        # where two same-named children inherit different bases (#659).
+        self._confirmed_child_files: dict[str, set[tuple[str, str]]] = defaultdict(set)
         self._built = False
 
     def build(self) -> None:
@@ -169,7 +170,10 @@ class ClassHierarchy:
 
         parent_map: dict[str, list[str]] = defaultdict(list)
         children: dict[str, list[str]] = defaultdict(list)
-        confirmed_child_files: set[tuple[str, str]] = set()
+        # Keyed by PARENT name → {(child_file, child_name)} so subclasses_of
+        # can confirm a same-named child belongs to THIS specific base, not
+        # just to some base (Codex P2 on #659: Worker(Base) vs Worker(Other)).
+        confirmed_child_files: dict[str, set[tuple[str, str]]] = defaultdict(set)
         for row in rows:
             source_ref = parse_node_id(row["source_node_id"])
             child = source_ref.name
@@ -187,10 +191,11 @@ class ClassHierarchy:
             base = parent.rsplit(".", 1)[-1]
             children[parent].append(child)
             children[base].append(child)
-            # Record the (file, child_name) pair so same-name collisions can
-            # be resolved in subclasses_of (#659).
+            # Record (file, child) under BOTH the qualified parent and its bare
+            # base, so same-name collisions resolve per-base (#659).
             if source_ref.file_path:
-                confirmed_child_files.add((source_ref.file_path, child))
+                confirmed_child_files[parent].add((source_ref.file_path, child))
+                confirmed_child_files[base].add((source_ref.file_path, child))
 
         if not parent_map:
             return False
@@ -236,19 +241,22 @@ class ClassHierarchy:
                 if child_name in visited:
                     continue
                 visited.add(child_name)
+                confirmed_for_current = self._confirmed_child_files.get(current, set())
                 for info in self._classes.get(child_name, []):
-                    # Guard against same-name collision (#659): _classes is
-                    # keyed by bare class name, so both `class Foo(Base):` and
-                    # a parentless `class Foo:` in a different file land here.
-                    # Only emit an entry if:
-                    #  (a) the ClassInfo itself declares parents (normal case),
-                    #  (b) the edge store explicitly confirmed this (file, name)
-                    #      pair as a real child — handles the case where
-                    #      symbols_json parents were stripped but edges remain.
+                    # Guard against same-name collision (#659 + Codex P2): a
+                    # same-named class may be parentless, OR inherit a DIFFERENT
+                    # base. _classes is keyed by bare name so all land here.
+                    # Only emit when this specific ClassInfo is a real child of
+                    # ``current``, confirmed by EITHER:
+                    #  (a) the edge store recorded (file, name) under this parent
+                    #      (authoritative — handles stripped symbols_json), or
+                    #  (b) the ClassInfo's own bases include ``current`` by bare
+                    #      name (symbols_json source, no edge).
+                    info_bases = {p.rsplit(".", 1)[-1] for p in info.parents}
                     if (
-                        info.parents
-                        or (info.file, child_name) in self._confirmed_child_files
-                    ):
+                        info.file,
+                        child_name,
+                    ) in confirmed_for_current or current in info_bases:
                         result.append({"depth": depth + 1, **info.to_dict()})
                 queue.append((child_name, depth + 1))
 


### PR DESCRIPTION
Closes #659 (dogfood patrol round 2).

## Diagnosis
Extraction is correct: `_ast_cache_write.py:341-359` only creates extends edges when `parents` is truthy, so `MockLanguagePlugin` (analysis_engine.py:157, no inheritance) produces NO edge. The real edge comes from a DIFFERENT same-named `MockLanguagePlugin` (test_manager.py:17) that legitimately inherits LanguagePlugin.

**Root cause (query side)**: `ClassHierarchy.subclasses_of` looks up `_classes['MockLanguagePlugin']` and returns ALL ClassInfo entries for any class with that name — including the parentless analysis_engine.py one. Both got emitted → ghost subclass.

## Fix (query-time, class_hierarchy.py)
`_build_edges_from_edge_store` records confirmed `(file_path, class_name)` pairs from edge source node IDs; `subclasses_of` emits a ClassInfo only if its `parents` is non-empty OR `(file, name)` is in the confirmed set. Extraction untouched — `_AST_CACHE_EXTRACTOR_VERSION` stays 11.

## Test plan
- [x] RED-first: `test_same_name_class_without_parents_not_listed_as_subclass` failed → green
- [x] Regression: 26 class-hierarchy + 46 hierarchy/unresolved/CLI passed (-n 0)
- [x] Golden FULL (6c): 96 passed, swift known-env; ratchet exit=0
- [x] Lead independently re-ran 26 tests + push diff=0