### PR TITLE
test: ratchet batch-29 — pin 23 loose assertions + 1 timing exemption in top-4 AST-ranked files

### DIFF
--- a/scripts/loose_assertion_baseline.txt
+++ b/scripts/loose_assertion_baseline.txt
@@ -57,7 +57,9 @@
 #   exemptions in top-4 AST-ranked files; property files excluded from baseline).
 #   batch-28 (AST): 567 -> 543, 2026-06-13 (24 exact pins in top-4 AST-ranked
 #   files, no exemptions).
+#   batch-29 (AST): 543 -> 519, 2026-06-13 (23 exact pins + 1 timing exemption
+#   in top-4 AST-ranked files).
 
-BASELINE_COUNT=543
+BASELINE_COUNT=519
 MEASUREMENT_DATE=2026-06-13
 MEASUREMENT_COMMAND="uv run python scripts/check_loose_assertions.py --baseline"

--- a/tests/unit/test_health_scorer.py
+++ b/tests/unit/test_health_scorer.py
@@ -56,8 +56,7 @@ class TestHealthScorer:
         empty = tmp_path / "empty.py"
         empty.write_text("")
         result = scorer.score_file(str(empty))
-        assert result.total >= 0
-        assert result.total <= 100
+        assert result.total == 87.5
 
     def test_score_nonexistent_file(self, scorer):
         """Nonexistent file returns 0 score."""
@@ -67,7 +66,7 @@ class TestHealthScorer:
     def test_score_project(self, scorer):
         """Can score an entire project directory."""
         results = scorer.score_project(str(HEALTH_PROJECT))
-        assert len(results) >= 2, f"Expected >=2 results, got {len(results)}"
+        assert len(results) == 2
         for r in results:
             assert 0 <= r.total <= 100
 
@@ -232,7 +231,7 @@ class TestHealthScorer:
 
         assert {Path(score.file_path).name for score in scores} == {"main.py"}
         assert stats["total_files_scanned"] == 1
-        assert stats["skip_reasons"]["excluded_dir"] >= 2
+        assert stats["skip_reasons"]["excluded_dir"] == 2
 
     def test_large_file_gets_penalized(self, scorer, tmp_path):
         """Files over 500 lines should have lower size score."""
@@ -361,23 +360,24 @@ class TestHealthScorer:
         """All major languages should have CC decision node definitions."""
         from tree_sitter_analyzer.health_scorer import DECISION_NODE_TYPES
 
-        for lang in [
-            "python",
-            "javascript",
-            "typescript",
-            "java",
-            "c",
-            "cpp",
-            "go",
-            "rust",
-            "ruby",
-            "php",
-            "kotlin",
-            "csharp",
-        ]:
+        expected_counts = {
+            "python": 14,
+            "javascript": 11,
+            "typescript": 11,
+            "java": 8,
+            "c": 8,
+            "cpp": 10,
+            "go": 6,
+            "rust": 8,
+            "ruby": 12,
+            "php": 9,
+            "kotlin": 9,
+            "csharp": 10,
+        }
+        for lang, expected in expected_counts.items():
             assert lang in DECISION_NODE_TYPES, f"Missing CC nodes for {lang}"
-            assert len(DECISION_NODE_TYPES[lang]) >= 5, (
-                f"{lang} has too few decision node types"
+            assert len(DECISION_NODE_TYPES[lang]) == expected, (
+                f"{lang} has {len(DECISION_NODE_TYPES[lang])} decision node types, expected {expected}"
             )
 
     def test_duplication_penalizes_repeated_code(self, scorer, tmp_path):
@@ -403,10 +403,8 @@ class TestHealthScorer:
         f = tmp_path / "test.py"
         f.write_text("x = 1\n")
         result = scorer.score_file(str(f))
-        # tmp_path may or may not be in a git repo, so hotspot can be present or absent
-        # Just verify it doesn't crash and score is valid
-        assert result.total >= 0
-        assert result.total <= 100
+        # Single-line file with no complexity/deps/duplication → all dims score 100.0
+        assert result.total == 100.0
 
     def test_git_hotspot_uses_repo_relative_pathspec(self, monkeypatch, tmp_path):
         """Git hotspot should query from repo root with a repo-relative path."""
@@ -474,7 +472,7 @@ class TestHealthScore:
         )
         assert score.file_path == "test.py"
         assert score.total == 75.0
-        assert len(score.dimensions) >= 3
+        assert len(score.dimensions) == 4
 
     def test_health_score_to_dict(self):
         from tree_sitter_analyzer.health_scorer import HealthScore

--- a/tests/unit/test_project_graph_coverage.py
+++ b/tests/unit/test_project_graph_coverage.py
@@ -197,7 +197,7 @@ class TestDependencyGraphResolvePaths:
 
         graph = DependencyGraph(str(proj))
         edges = graph.edges()
-        assert len(edges) >= 1, f"Expected edges, got {edges}"
+        assert len(edges) == 1, f"Expected 1 edge, got {edges}"
 
     def test_ts_resolve(self, tmp_path):
         proj = tmp_path / "ts_proj"
@@ -206,12 +206,12 @@ class TestDependencyGraphResolvePaths:
         (proj / "lib.ts").write_text("export function bar() {}\n")
 
         graph = DependencyGraph(str(proj))
-        assert len(graph.edges()) >= 1
+        assert len(graph.edges()) == 1
 
     def test_go_resolve_from_fixture(self):
         graph = DependencyGraph(str(GO_PROJECT))
         nodes = graph.nodes()
-        assert len(nodes) >= 3, f"Expected >=3 Go nodes, got {nodes}"
+        assert len(nodes) == 3, f"Expected 3 Go nodes, got {nodes}"
 
     def test_go_absolute_import_no_resolve(self, tmp_path):
         proj = tmp_path / "go_proj2"
@@ -229,7 +229,7 @@ class TestDependencyGraphResolvePaths:
 
         graph = DependencyGraph(str(proj))
         nodes = graph.nodes()
-        assert len(nodes) >= 2
+        assert len(nodes) == 2
 
     def test_cpp_resolve_include(self, tmp_path):
         proj = tmp_path / "cpp_proj"
@@ -239,7 +239,7 @@ class TestDependencyGraphResolvePaths:
 
         graph = DependencyGraph(str(proj))
         edges = graph.edges()
-        assert len(edges) >= 1, f"Expected CPP edges, got {edges}"
+        assert len(edges) == 1, f"Expected 1 CPP edge, got {edges}"
 
     def test_java_resolve_package(self, tmp_path):
         proj = tmp_path / "java_proj"
@@ -252,7 +252,7 @@ class TestDependencyGraphResolvePaths:
 
         graph = DependencyGraph(str(proj))
         edges = graph.edges()
-        assert len(edges) >= 1, f"Expected Java edges, got {edges}"
+        assert len(edges) == 1, f"Expected 1 Java edge, got {edges}"
 
     def test_excluded_dirs_skipped(self, tmp_path):
         proj = tmp_path / "mixed_proj"

--- a/tests/unit/test_route_detector_cache.py
+++ b/tests/unit/test_route_detector_cache.py
@@ -25,13 +25,13 @@ class TestRouteCachePersistence:
         d1 = RouteDetector(str(flask_project))
         first = d1.detect_all()
         s1 = d1.cache_stats()
-        assert s1["misses"] >= 1
+        assert s1["misses"] == 1
         assert s1["hits"] == 0
 
         d2 = RouteDetector(str(flask_project))
         second = d2.detect_all()
         s2 = d2.cache_stats()
-        assert s2["hits"] >= 1
+        assert s2["hits"] == 1
         assert s2["misses"] == 0
         # Same URL pattern set across runs.
         assert sorted(r.url_pattern for r in first) == sorted(
@@ -55,8 +55,8 @@ class TestRouteCachePersistence:
         assert "/new" in urls
         # The two unchanged files should still be cache hits.
         s = d2.cache_stats()
-        assert s["hits"] >= 1
-        assert s["misses"] >= 1  # the modified app.py
+        assert s["hits"] == 2
+        assert s["misses"] == 1  # the modified app.py
 
     def test_cache_disabled_flag(self, flask_project: Path):
         d = RouteDetector(str(flask_project), cache_enabled=False)
@@ -134,7 +134,9 @@ class TestRouteCachePersistence:
         results = sorted(trial() for _ in range(3))
         cold_med, warm_med = results[1]
         speedup = cold_med / max(warm_med, 1e-6)
-        assert speedup >= 3, (
+        assert (
+            speedup >= 3
+        ), (  # ratchet: nondeterministic wall-clock timing, marked flaky(reruns=2)
             f"Expected >=3x speedup, got {speedup:.1f}x "
             f"(cold={cold_med * 1000:.1f}ms warm={warm_med * 1000:.1f}ms). "
             "PERF-1 contract regressed — cache may be disabled or fast path broken."
@@ -361,7 +363,7 @@ class TestRouteEnvelopeConsistency:
         """
         tool = RouteDetectorTool(str(flask_project))
         result = self._run(tool, {"mode": "summary", "output_format": "json"})
-        assert result["total_routes"] > 0
+        assert result["total_routes"] == 3
         # The critical F4 invariant: list length matches the count claim.
         assert len(result["routes"]) == result["total_routes"]
         # Aggregates derived from the same list so their cardinality matches.

--- a/tests/unit/test_symbol_search_tool.py
+++ b/tests/unit/test_symbol_search_tool.py
@@ -76,7 +76,7 @@ class TestCodeGraphSymbolSearchExecution:
         tool = CodeGraphSymbolSearchTool(str(indexed_project))
         result = await tool.execute({"query": "UserService", "output_format": "json"})
         assert result["success"] is True
-        assert result["match_count"] >= 1
+        assert result["match_count"] == 1
         names = [r["name"] for r in result["results"]]
         assert "UserService" in names
 
@@ -92,7 +92,7 @@ class TestCodeGraphSymbolSearchExecution:
         tool = CodeGraphSymbolSearchTool(str(indexed_project))
         result = await tool.execute({"query": "~user", "output_format": "json"})
         assert result["success"] is True
-        assert result["match_count"] >= 1
+        assert result["match_count"] == 3
 
     async def test_wildcard_match(self, indexed_project):
         tool = CodeGraphSymbolSearchTool(str(indexed_project))
@@ -144,12 +144,12 @@ class TestCodeGraphSymbolSearchExecution:
     async def test_result_has_file_and_line(self, indexed_project):
         tool = CodeGraphSymbolSearchTool(str(indexed_project))
         result = await tool.execute({"query": "UserService", "output_format": "json"})
-        assert result["match_count"] >= 1
+        assert result["match_count"] == 1
         hit = result["results"][0]
         assert "file" in hit
         assert "line" in hit
         assert "code" in hit
-        assert hit["line"] > 0
+        assert hit["line"] == 1
 
     async def test_next_step_points_to_bulk_explore(self, indexed_project):
         tool = CodeGraphSymbolSearchTool(str(indexed_project))
@@ -160,7 +160,7 @@ class TestCodeGraphSymbolSearchExecution:
         """P2: top matches carry an inlined verbatim source body (no Read)."""
         tool = CodeGraphSymbolSearchTool(str(indexed_project))
         result = await tool.execute({"query": "get_user", "output_format": "json"})
-        assert result["match_count"] >= 1
+        assert result["match_count"] == 1
         hit = next(r for r in result["results"] if r["name"] == "get_user")
         assert "body" in hit, "top match must carry inlined body"
         assert "content" in hit["body"]
@@ -197,7 +197,9 @@ class TestCodeGraphSymbolSearchExecution:
         tool = CodeGraphSymbolSearchTool(str(indexed_project))
         result = await tool.execute({"query": "format_user", "output_format": "json"})
         assert result["success"] is True
-        assert result["match_count"] >= 1, "fixture must have a format_user symbol"
+        assert result["match_count"] == 1, (
+            "fixture must have exactly one format_user symbol"
+        )
         # Indexed project always has FTS5 via ASTCache.index_project
         assert result["data_source"] == "fts5", (
             f"expected fts5 data source, got {result['data_source']}"


### PR DESCRIPTION
## Summary
Loose-assertion ratchet batch 29. Top-4 (6 violations each):

| File | Resolved |
|---|---|
| tests/unit/test_health_scorer.py | 6 pins |
| tests/unit/test_project_graph_coverage.py | 6 pins |
| tests/unit/test_route_detector_cache.py | 5 pins + 1 timing exemption |
| tests/unit/test_symbol_search_tool.py | 6 pins |

Baseline: **543 → 519** (= exactly 24, lead re-verified live).

**1 exemption** (justified): `test_route_detector_cache.py:137` `speedup >= 3` — wall-clock timing, test is already `@pytest.mark.flaky(reruns=2)` confirming timing sensitivity → `# ratchet: nondeterministic wall-clock timing, marked flaky`.

Highlights: health-scorer per-language symbol-count loop → exact dict (python=14…csharp=10); fuzzy symbol search `~user` → exact 3 (get_user/_find_user/format_user); empty-file health pinned 87.5; git-hotspot 100.0 verified in AND out of a git repo.

## Test plan
- [x] All 4 files individually `-n 0`: 30/32/17/37 passed
- [x] Diff gate exit=0
- [x] `--baseline` measures 519 == recorded (lead independently re-verified)