### PR TITLE
fix(structure): surface @abstractmethod + scope class_detail to file

### DIFF
--- a/tests/unit/mcp/tools/test_class_inspect_tool.py
+++ b/tests/unit/mcp/tools/test_class_inspect_tool.py
@@ -879,3 +879,190 @@ def test_annotation_only_fields_extracted() -> None:
     assert vis["_token"] == "protected"
     kinds = {f["name"]: f["kind"] for f in fields}
     assert kinds == {"name": "class", "retries": "class", "_token": "class"}
+
+
+# ─── Issue #660: helpers unit tests ─────────────────────────────────────────
+
+
+def test_is_method_abstract_at_line_one() -> None:
+    """Method defined at line 1 has no preceding lines — must return False (no IndexError)."""
+    from tree_sitter_analyzer.mcp.tools.class_inspect_tool import _is_method_abstract
+
+    result = _is_method_abstract(["def foo() -> None: ...\n"], def_line_1indexed=1)
+    assert result is False
+
+
+def test_is_method_abstract_abc_qualified() -> None:
+    """@abc.abstractmethod (qualified form) must also be detected."""
+    from tree_sitter_analyzer.mcp.tools.class_inspect_tool import _is_method_abstract
+
+    lines = ["    @abc.abstractmethod\n", "    def bar(self) -> None: ...\n"]
+    assert _is_method_abstract(lines, def_line_1indexed=2) is True
+
+
+def test_read_source_lines_io_error_returns_empty() -> None:
+    """_read_source_lines returns [] when the file does not exist."""
+    from tree_sitter_analyzer.mcp.tools.class_inspect_tool import _read_source_lines
+
+    result = _read_source_lines("nonexistent_file_xyz.py", "/tmp")
+    assert result == []
+
+
+# ─── Issue #660: @abstractmethod surfaced + same-name class scoping ──────────
+
+
+ABSTRACT_FIXTURE_SOURCE = textwrap.dedent("""\
+    from abc import ABC, abstractmethod
+
+
+    class Shape(ABC):
+        \"\"\"Abstract base for shapes.\"\"\"
+
+        @abstractmethod
+        def area(self) -> float:
+            \"\"\"Return area.\"\"\"
+            ...
+
+        @abstractmethod
+        def perimeter(self) -> float:
+            \"\"\"Return perimeter.\"\"\"
+            ...
+
+        def describe(self) -> str:
+            \"\"\"Non-abstract method.\"\"\"
+            return f"shape"
+""")
+
+SAME_NAME_FIXTURE_A = textwrap.dedent("""\
+    class Widget:
+        def render(self) -> str:
+            return "A"
+""")
+
+SAME_NAME_FIXTURE_B = textwrap.dedent("""\
+    class Widget:
+        def paint(self) -> str:
+            return "B"
+
+        def resize(self) -> None:
+            pass
+""")
+
+
+class TestAbstractMethodSurfaced:
+    """Issue #660 (A): @abstractmethod must appear as is_abstract=True in method entries."""
+
+    @pytest.fixture()
+    def abstract_file(self, tmp_path: Path) -> Path:
+        p = tmp_path / "shapes.py"
+        p.write_text(ABSTRACT_FIXTURE_SOURCE, encoding="utf-8", newline="\n")
+        return p
+
+    def _run_shape(self, abstract_file: Path) -> dict[str, Any]:
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        project_root = str(abstract_file.parent)
+        cache = ASTCache(project_root)
+        result = cache.index_file(str(abstract_file), language="python")
+        assert result.get("status") in ("ok", "indexed", "unchanged"), (
+            f"Index failed: {result}"
+        )
+        tool = ClassInspectTool(project_root)
+        response = _run(tool.execute({"class_name": "Shape", "output_format": "json"}))
+        assert response["success"] is True, f"Tool failed: {response}"
+        return response
+
+    def test_abstract_method_is_abstract_true(self, abstract_file: Path) -> None:
+        """area() decorated with @abstractmethod → is_abstract=True in method entry."""
+        r = self._run_shape(abstract_file)
+        method_map = {m["name"]: m for m in r["methods"]}
+        assert method_map["area"]["is_abstract"] is True
+
+    def test_abstract_method_perimeter_is_abstract_true(
+        self, abstract_file: Path
+    ) -> None:
+        """perimeter() also abstract → is_abstract=True."""
+        r = self._run_shape(abstract_file)
+        method_map = {m["name"]: m for m in r["methods"]}
+        assert method_map["perimeter"]["is_abstract"] is True
+
+    def test_non_abstract_method_is_abstract_false(self, abstract_file: Path) -> None:
+        """describe() is NOT decorated → is_abstract=False (or absent, defaulting False)."""
+        r = self._run_shape(abstract_file)
+        method_map = {m["name"]: m for m in r["methods"]}
+        assert method_map["describe"].get("is_abstract", False) is False
+
+    def test_method_count_exact(self, abstract_file: Path) -> None:
+        """Shape has exactly 3 methods: area, perimeter, describe."""
+        r = self._run_shape(abstract_file)
+        assert r["method_count"] == 3
+
+    def test_toon_output_contains_is_abstract(self, abstract_file: Path) -> None:
+        """TOON toon_content blob must include the is_abstract flag."""
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        project_root = str(abstract_file.parent)
+        cache = ASTCache(project_root)
+        cache.index_file(str(abstract_file), language="python")
+        tool = ClassInspectTool(project_root)
+        response = _run(tool.execute({"class_name": "Shape", "output_format": "toon"}))
+        assert response.get("format") == "toon"
+        toon_blob = response.get("toon_content", "")
+        assert "is_abstract" in toon_blob
+
+
+class TestSameNameClassScoped:
+    """Issue #660: when two files define a class with the same name, class_detail
+    must only show methods from the file where the class is indexed.
+    """
+
+    @pytest.fixture()
+    def two_widget_files(self, tmp_path: Path) -> tuple[Path, Path]:
+        a = tmp_path / "widget_a.py"
+        b = tmp_path / "widget_b.py"
+        a.write_text(SAME_NAME_FIXTURE_A, encoding="utf-8", newline="\n")
+        b.write_text(SAME_NAME_FIXTURE_B, encoding="utf-8", newline="\n")
+        return a, b
+
+    def _run_widget(
+        self,
+        tmp_path: Path,
+        file_a: Path,
+        file_b: Path,
+    ) -> dict[str, Any]:
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        project_root = str(tmp_path)
+        cache = ASTCache(project_root)
+        for fp in (file_a, file_b):
+            result = cache.index_file(str(fp), language="python")
+            assert result.get("status") in ("ok", "indexed", "unchanged"), (
+                f"Index failed: {result}"
+            )
+        tool = ClassInspectTool(project_root)
+        response = _run(tool.execute({"class_name": "Widget", "output_format": "json"}))
+        assert response["success"] is True
+        return response
+
+    def test_methods_not_merged_across_files(
+        self, two_widget_files: tuple[Path, Path], tmp_path: Path
+    ) -> None:
+        """Widget in widget_a.py has render(); Widget in widget_b.py has paint()+resize().
+        class_detail must NOT merge them into a single 3-method list."""
+        a, b = two_widget_files
+        r = self._run_widget(tmp_path, a, b)
+        # The result must be exactly ONE Widget's methods, not all three
+        assert len(r["methods"]) != 3, (
+            "class_detail merged both Widget classes — must scope to one file"
+        )
+
+    def test_method_count_is_one_or_two(
+        self, two_widget_files: tuple[Path, Path], tmp_path: Path
+    ) -> None:
+        """First indexed Widget (widget_a.py) has 1 method; class_detail returns 1."""
+        a, b = two_widget_files
+        r = self._run_widget(tmp_path, a, b)
+        # widget_a.py's Widget has 1 method (render)
+        # widget_b.py's Widget has 2 methods (paint, resize)
+        # Either is acceptable (first-match), but NOT 3 (merged)
+        assert r["method_count"] in (1, 2)

--- a/tests/unit/mcp/tools/test_class_inspect_tool.py
+++ b/tests/unit/mcp/tools/test_class_inspect_tool.py
@@ -900,6 +900,26 @@ def test_is_method_abstract_abc_qualified() -> None:
     assert _is_method_abstract(lines, def_line_1indexed=2) is True
 
 
+def test_is_method_abstract_comment_between_decorator_and_def() -> None:
+    """Codex P2 on #665: a comment between @abstractmethod and def must not
+    stop the upward scan — the decorator is still detected."""
+    from tree_sitter_analyzer.mcp.tools.class_inspect_tool import _is_method_abstract
+
+    lines = [
+        "    @abstractmethod\n",
+        "    # explain why this is abstract\n",
+        "    def bar(self) -> None: ...\n",
+    ]
+    assert _is_method_abstract(lines, def_line_1indexed=3) is True
+
+
+def test_is_method_abstract_blank_line_between_decorator_and_def() -> None:
+    from tree_sitter_analyzer.mcp.tools.class_inspect_tool import _is_method_abstract
+
+    lines = ["    @abstractmethod\n", "\n", "    def bar(self) -> None: ...\n"]
+    assert _is_method_abstract(lines, def_line_1indexed=3) is True
+
+
 def test_read_source_lines_io_error_returns_empty() -> None:
     """_read_source_lines returns [] when the file does not exist."""
     from tree_sitter_analyzer.mcp.tools.class_inspect_tool import _read_source_lines
@@ -1056,13 +1076,14 @@ class TestSameNameClassScoped:
             "class_detail merged both Widget classes — must scope to one file"
         )
 
-    def test_method_count_is_one_or_two(
+    def test_method_count_is_exactly_one(
         self, two_widget_files: tuple[Path, Path], tmp_path: Path
     ) -> None:
-        """First indexed Widget (widget_a.py) has 1 method; class_detail returns 1."""
+        """Deterministic first-match (ast_index ORDER BY file_path): widget_a.py
+        sorts before widget_b.py, so class_detail returns widget_a's Widget
+        with exactly its 1 method (render) — never 3 (merged), never 2
+        (widget_b). Exact pin per the locked exact-assertion rule (Codex P1)."""
         a, b = two_widget_files
         r = self._run_widget(tmp_path, a, b)
-        # widget_a.py's Widget has 1 method (render)
-        # widget_b.py's Widget has 2 methods (paint, resize)
-        # Either is acceptable (first-match), but NOT 3 (merged)
-        assert r["method_count"] in (1, 2)
+        assert r["method_count"] == 1
+        assert [m["name"] for m in r["methods"]] == ["render"]

--- a/tree_sitter_analyzer/mcp/tools/class_inspect_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/class_inspect_tool.py
@@ -195,11 +195,13 @@ def _is_method_abstract(source_lines: list[str], def_line_1indexed: int) -> bool
             break
         line = source_lines[check_idx]
         stripped = line.strip()
-        if not stripped or stripped == "":
+        # Blank lines and comments may sit between stacked decorators and the
+        # def (Codex P2 on #665) — skip them, keep scanning upward.
+        if not stripped or stripped.startswith("#"):
             continue
         if _ABSTRACTMETHOD_PATTERN.match(line):
             return True
-        # If we hit a non-decorator, non-blank line, stop scanning upward
+        # A non-decorator, non-blank, non-comment line ends the decorator block.
         if not stripped.startswith("@"):
             break
     return False
@@ -278,7 +280,7 @@ class ClassInspectTool(BaseMCPTool):
         try:
             conn = cache.get_conn()
             rows = conn.execute(
-                "SELECT file_path, symbols_json FROM ast_index"
+                "SELECT file_path, symbols_json FROM ast_index ORDER BY file_path"
             ).fetchall()
         except Exception:
             return None
@@ -316,7 +318,7 @@ class ClassInspectTool(BaseMCPTool):
         try:
             conn = cache.get_conn()
             rows = conn.execute(
-                "SELECT file_path, symbols_json FROM ast_index"
+                "SELECT file_path, symbols_json FROM ast_index ORDER BY file_path"
             ).fetchall()
         except Exception:
             return []

--- a/tree_sitter_analyzer/mcp/tools/class_inspect_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/class_inspect_tool.py
@@ -173,6 +173,53 @@ def _extract_fields_from_source(
     return fields
 
 
+# Decorator patterns that mark a method as abstract in Python.
+_ABSTRACTMETHOD_PATTERN = re.compile(r"^\s*@(?:abc\.)?abstractmethod\s*$")
+
+
+def _is_method_abstract(source_lines: list[str], def_line_1indexed: int) -> bool:
+    """Return True if the line immediately before *def_line_1indexed* is ``@abstractmethod``.
+
+    *def_line_1indexed* is the 1-based line number of the ``def`` keyword.
+    Looks at the preceding line (and up to 3 lines back to handle stacked
+    decorators like ``@property`` + ``@abstractmethod``).
+
+    Falls back to False when the line is out of range or no match is found.
+    """
+    # Convert to 0-based index
+    def_idx = def_line_1indexed - 1
+    # Scan up to 4 preceding lines (covers stacked decorators)
+    for offset in range(1, 5):
+        check_idx = def_idx - offset
+        if check_idx < 0:
+            break
+        line = source_lines[check_idx]
+        stripped = line.strip()
+        if not stripped or stripped == "":
+            continue
+        if _ABSTRACTMETHOD_PATTERN.match(line):
+            return True
+        # If we hit a non-decorator, non-blank line, stop scanning upward
+        if not stripped.startswith("@"):
+            break
+    return False
+
+
+def _read_source_lines(file_path: str, project_root: str) -> list[str]:
+    """Read and return source lines for *file_path*, resolved against *project_root*.
+
+    Returns [] on any IO error so callers can safely fall back.
+    """
+    abs_path = (
+        file_path if os.path.isabs(file_path) else os.path.join(project_root, file_path)
+    )
+    try:
+        with open(abs_path, encoding="utf-8", errors="replace") as fh:
+            return fh.readlines()
+    except OSError:
+        return []
+
+
 class ClassInspectTool(BaseMCPTool):
     """Inspect a single class: fields, methods (no closures), visibility, extends."""
 
@@ -252,9 +299,16 @@ class ClassInspectTool(BaseMCPTool):
         return None
 
     def _collect_raw_methods(
-        self, cache: ASTCache, class_name: str
+        self,
+        cache: ASTCache,
+        class_name: str,
+        file_path: str | None = None,
     ) -> list[dict[str, Any]]:
-        """Return ALL method/function symbols whose enclosing class is class_name.
+        """Return method/function symbols whose enclosing class is class_name.
+
+        When *file_path* is given only symbols from that file are returned,
+        preventing same-named classes in different files from being merged
+        (issue #660).
 
         This includes closures — caller is responsible for filtering via
         :func:`_filter_closures`.
@@ -269,6 +323,9 @@ class ClassInspectTool(BaseMCPTool):
 
         methods: list[dict[str, Any]] = []
         for row in rows:
+            # When a file_path scope is requested, skip other files.
+            if file_path is not None and row["file_path"] != file_path:
+                continue
             try:
                 symbols = json.loads(row["symbols_json"])
             except (json.JSONDecodeError, TypeError):
@@ -469,9 +526,19 @@ class ClassInspectTool(BaseMCPTool):
         class_info = self._collect_class_info(cache, class_name)
         extends: list[str] = class_info["parents"] if class_info else []
 
+        # Scope method collection to the same file as the class definition
+        # to prevent same-named classes across files from being merged (#660).
+        class_file: str | None = class_info["file"] if class_info else None
+
         # Collect all raw method symbols, then filter closures
-        raw_methods = self._collect_raw_methods(cache, class_name)
+        raw_methods = self._collect_raw_methods(cache, class_name, file_path=class_file)
         direct_methods = _filter_closures(raw_methods)
+
+        # Read source once for is_abstract detection (falls back to [] on IO error)
+        project_root = self.project_root or ""
+        source_lines: list[str] = (
+            _read_source_lines(class_file, project_root) if class_file else []
+        )
 
         # Override detection
         parent_method_names = self._parent_method_names(hierarchy, class_name, cache)
@@ -479,6 +546,9 @@ class ClassInspectTool(BaseMCPTool):
         methods: list[dict[str, Any]] = []
         for m in direct_methods:
             is_override = m["name"] in parent_method_names
+            is_abstract = (
+                _is_method_abstract(source_lines, m["line"]) if source_lines else False
+            )
             entry: dict[str, Any] = {
                 "name": m["name"],
                 "line": m["line"],
@@ -486,6 +556,7 @@ class ClassInspectTool(BaseMCPTool):
                 "file": m["file"],
                 "visibility": _compute_visibility(m["name"]),
                 "is_override": is_override,
+                "is_abstract": is_abstract,
             }
             if is_override:
                 src = self._find_override_source(


### PR DESCRIPTION
Closes #660 (dogfood patrol round 2, P3).

## Diagnosis (live class_detail on LanguagePlugin)
Three same-named LanguagePlugin classes (core/analysis_engine.py, plugins/__init__.py, plugins/base.py) → `_collect_raw_methods()` had no file scope → merged 17 methods instead of 4. Plus `@abstractmethod` never surfaced (decorators not in the AST cache) and `overrides_from` absent (overrides undetected while methods merged).

## Fix (query-side only, no extractor bump)
- **File-scoping** (the root bug): `_collect_raw_methods()` gains a `file_path` param; execute() passes the resolved class file so only that class's methods are returned (4, not 17)
- **is_abstract**: `_is_method_abstract()` scans up to 4 preceding source lines for `@abstractmethod`/`@abc.abstractmethod` at query time — agents can now tell required-to-implement from optional-override
- Once scoped, `overrides_from` flows through correctly in JSON + TOON blob

Deferred (noted): the explicit TOON column-header gap for overrides_from is tracked in #643 (needs TOON schema work).

## Test plan
- [x] RED-first: 5 failed (3 KeyError is_abstract, 2 wrong method count) → 59 passed (-n 0)
- [x] Coverage 95% on class_inspect_tool.py; golden FULL (6c) 96 passed, swift known-env; ratchet exit=0
- [x] Lead independently re-ran 59 tests + push diff=0