### PR TITLE
test: ratchet batch-33 — pin 20 loose assertions in top-4 AST-ranked files

### DIFF
--- a/scripts/loose_assertion_baseline.txt
+++ b/scripts/loose_assertion_baseline.txt
@@ -66,7 +66,9 @@
 #   reconciled on merge — both batches' 40 pins now in develop).
 #   batch-32 (AST): 479 -> 459, 2026-06-13 (18 exact pins + 2 truthy-set pins
 #   in top-4 AST-ranked files, no timing exemptions).
+#   batch-33 (AST): 459 -> 439, 2026-06-13 (20 exact pins in top-4 AST-ranked
+#   files, no exemptions; loop assert restructured to per-pattern dict).
 
-BASELINE_COUNT=459
+BASELINE_COUNT=439
 MEASUREMENT_DATE=2026-06-13
 MEASUREMENT_COMMAND="uv run python scripts/check_loose_assertions.py --baseline"

--- a/tests/unit/languages/test_yaml_plugin.py
+++ b/tests/unit/languages/test_yaml_plugin.py
@@ -35,7 +35,7 @@ class TestYAMLPlugin:
         plugin = YAMLPlugin()
         queries = plugin.get_queries()
         assert isinstance(queries, dict)
-        assert len(queries) > 0
+        assert len(queries) == 31
         assert "document" in queries
         assert "block_mapping" in queries
 
@@ -120,7 +120,7 @@ enabled: true
 
         assert result.success
         assert result.language == "yaml"
-        assert len(result.elements) > 0
+        assert len(result.elements) == 4
 
     async def test_analyze_yaml_with_anchors(self, tmp_path) -> None:
         """Test analyzing YAML with anchors and aliases."""
@@ -147,7 +147,7 @@ production:
         anchors = [
             e for e in result.elements if getattr(e, "element_type", "") == "anchor"
         ]
-        assert len(anchors) >= 1
+        assert len(anchors) == 1
 
     async def test_analyze_multi_document_yaml(self, tmp_path) -> None:
         """Test analyzing multi-document YAML."""
@@ -170,7 +170,7 @@ doc2: value2
         documents = [
             e for e in result.elements if getattr(e, "element_type", "") == "document"
         ]
-        assert len(documents) >= 2
+        assert len(documents) == 2
 
     async def test_analyze_yaml_with_sequences(self, tmp_path) -> None:
         """Test analyzing YAML with sequences."""
@@ -194,4 +194,4 @@ items:
         sequences = [
             e for e in result.elements if getattr(e, "element_type", "") == "sequence"
         ]
-        assert len(sequences) >= 1
+        assert len(sequences) == 1

--- a/tests/unit/security/test_regex_checker.py
+++ b/tests/unit/security/test_regex_checker.py
@@ -34,7 +34,7 @@ class TestRegexSafetyCheckerInitialization:
 
     def test_dangerous_patterns_list(self):
         """测试危险模式列表"""
-        assert len(RegexSafetyChecker.DANGEROUS_PATTERNS) > 0
+        assert len(RegexSafetyChecker.DANGEROUS_PATTERNS) == 13
         assert isinstance(RegexSafetyChecker.DANGEROUS_PATTERNS, list)
         assert all(isinstance(p, str) for p in RegexSafetyChecker.DANGEROUS_PATTERNS)
 
@@ -350,7 +350,7 @@ class TestAnalyzeComplexity:
         checker = RegexSafetyChecker()
         metrics = checker.analyze_complexity(r"a+b*c?")
         assert metrics["quantifiers"] == 3
-        assert metrics["complexity_score"] > 0
+        assert metrics["complexity_score"] == 6
 
     def test_analyze_complexity_with_groups(self):
         """测试带分组的模式复杂度分析"""
@@ -382,7 +382,7 @@ class TestAnalyzeComplexity:
         metrics = checker.analyze_complexity(r"^test[a-z]+\.py$")
 
         # Verify score is calculated and positive
-        assert metrics["complexity_score"] > 0
+        assert metrics["complexity_score"] == 4
         # Verify individual metrics are calculated correctly
         # Pattern: ^test[a-z]+\.py$ has length 16
         assert metrics["length"] == 16
@@ -620,7 +620,7 @@ class TestIntegration:
 
         # Analyze complexity
         metrics = checker.analyze_complexity(r"^test[a-z]+\.py$")
-        assert metrics["length"] > 0
+        assert metrics["length"] == 16
 
         # Create safe pattern
         pattern = checker.create_safe_pattern(r"^test[a-z]+\.py$")
@@ -651,15 +651,15 @@ class TestIntegration:
         """测试复杂度分析工作流"""
         checker = RegexSafetyChecker()
 
-        patterns = [
-            r"simple",
-            r"test[a-z]+",
-            r"^(test|demo)+[a-z]{3}$",
-            r"(?P<name>[a-z]+)(?P<value>\d+)",
-        ]
+        pattern_expected_scores = {
+            r"simple": 0,
+            r"test[a-z]+": 4,
+            r"^(test|demo)+[a-z]{3}$": 11,
+            r"(?P<name>[a-z]+)(?P<value>\d+)": 15,
+        }
 
-        for pattern in patterns:
+        for pattern, expected_score in pattern_expected_scores.items():
             metrics = checker.analyze_complexity(pattern)
             assert "length" in metrics
             assert "complexity_score" in metrics
-            assert metrics["complexity_score"] >= 0
+            assert metrics["complexity_score"] == expected_score

--- a/tests/unit/test_call_path.py
+++ b/tests/unit/test_call_path.py
@@ -199,7 +199,7 @@ class TestCallPathFinderForward:
         result = finder.find_path("main", "bar", direction="forward")
         assert result.source == "main"
         assert result.target == "bar"
-        assert len(result.paths) >= 1
+        assert len(result.paths) == 1
         assert result.data_source == "sql"
         if result.paths:
             assert result.paths[0].total_hops == 2
@@ -214,7 +214,7 @@ class TestCallPathFinderForward:
         cache = _make_cache_with_edges(tmp_path, _DIAMOND_EDGES)
         finder = CallPathFinder(str(tmp_path), cache=cache)
         result = finder.find_path("main", "bar", direction="forward")
-        assert len(result.paths) >= 2
+        assert len(result.paths) == 2
 
     def test_max_depth_respected(self, tmp_path):
         cache = _make_cache_with_edges(tmp_path, _LINEAR_EDGES)
@@ -234,7 +234,7 @@ class TestCallPathFinderBackward:
         cache = _make_cache_with_edges(tmp_path, _LINEAR_EDGES)
         finder = CallPathFinder(str(tmp_path), cache=cache)
         result = finder.find_path("main", "bar", direction="backward")
-        assert len(result.paths) >= 1
+        assert len(result.paths) == 1
 
     def test_no_path_backward(self, tmp_path):
         cache = _make_cache_with_edges(tmp_path, _LINEAR_EDGES)
@@ -248,13 +248,13 @@ class TestCallPathFinderBidirectional:
         cache = _make_cache_with_edges(tmp_path, _LINEAR_EDGES)
         finder = CallPathFinder(str(tmp_path), cache=cache)
         result = finder.find_path("main", "bar", direction="bidirectional")
-        assert len(result.paths) >= 1
+        assert len(result.paths) == 1
 
     def test_diamond_bidirectional(self, tmp_path):
         cache = _make_cache_with_edges(tmp_path, _DIAMOND_EDGES)
         finder = CallPathFinder(str(tmp_path), cache=cache)
         result = finder.find_path("main", "bar", direction="bidirectional")
-        assert len(result.paths) >= 1
+        assert len(result.paths) == 2
 
     def test_same_function(self, tmp_path):
         cache = _make_cache_with_edges(tmp_path, _LINEAR_EDGES)

--- a/tests/unit/test_test_gap_analyzer.py
+++ b/tests/unit/test_test_gap_analyzer.py
@@ -66,7 +66,7 @@ class TestExtractTestTargets:
 
     def test_with_keyword(self):
         targets = _extract_test_targets("test_parse_raises_error")
-        assert len(targets) > 0
+        assert len(targets) == 2
 
 
 class TestRiskBand:
@@ -90,7 +90,7 @@ class TestPriorityScore:
     def test_simple_function(self):
         sym = _make_prod("foo")
         score = _priority_score(sym)
-        assert score >= 0
+        assert score == 0
 
     def test_class_bonus(self):
         cls = _make_prod("MyClass", kind="class")
@@ -162,8 +162,8 @@ class TestAnalyzeCoverageGaps:
     def test_finds_uncovered_symbols(self, project_with_gaps):
         result = analyze_coverage_gaps(str(project_with_gaps))
         assert isinstance(result, CoverageGapResult)
-        assert result.total_production_symbols >= 1
-        assert result.gap_count >= 1
+        assert result.total_production_symbols == 4
+        assert result.gap_count == 3
         assert 0 <= result.coverage_pct <= 100
 
     def test_coverage_percentage(self, project_with_gaps):
@@ -179,19 +179,15 @@ class TestAnalyzeCoverageGaps:
             assert isinstance(gap.suggestion, str)
 
     def test_language_filter(self, project_with_gaps):
-        result = analyze_coverage_gaps(
-            str(project_with_gaps), language_filter="python"
-        )
-        assert result.total_production_symbols >= 1
+        result = analyze_coverage_gaps(str(project_with_gaps), language_filter="python")
+        assert result.total_production_symbols == 4
 
     def test_max_gaps(self, project_with_gaps):
         result = analyze_coverage_gaps(str(project_with_gaps), max_gaps=1)
         assert len(result.gaps) <= 1
 
     def test_include_covered(self, project_with_gaps):
-        result = analyze_coverage_gaps(
-            str(project_with_gaps), include_covered=True
-        )
+        result = analyze_coverage_gaps(str(project_with_gaps), include_covered=True)
         assert isinstance(result.covered, list)
 
     def test_empty_project(self, tmp_path):


### PR DESCRIPTION
Pins 20 loose assertions (`>=`/`>` against integer literals) to exact measured values across the top-4 AST-ranked deterministic test files, driving BASELINE_COUNT 459 → 439.

## Files (5 pins each, 0 exemptions)
- `tests/unit/languages/test_yaml_plugin.py` — queries==31, elements==4, anchors==1, documents==2, sequences==1
- `tests/unit/security/test_regex_checker.py` — DANGEROUS_PATTERNS==13, complexity scores ==6/==4, length==16, per-pattern score dict
- `tests/unit/test_call_path.py` — path counts ==1/==2 (linear/diamond × forward/backward/bidirectional)
- `tests/unit/test_test_gap_analyzer.py` — targets==2, score==0, production_symbols==4, gap_count==3

Every value MEASURED by running the test (not guessed). `--baseline` prints 439; ratchet checker exits 0 on the diff. All 4 files: 139 passed (-n 0).

Per the exact-assertion lock — counts pin the exact value so an upstream change goes red and forces a conscious re-pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)