### PR TITLE
test: ratchet batch-34 — pin 5 loose assertions in test_logging.py (439→434)

### DIFF
--- a/scripts/loose_assertion_baseline.txt
+++ b/scripts/loose_assertion_baseline.txt
@@ -68,7 +68,13 @@
 #   in top-4 AST-ranked files, no timing exemptions).
 #   batch-33 (AST): 459 -> 439, 2026-06-13 (20 exact pins in top-4 AST-ranked
 #   files, no exemptions; loop assert restructured to per-pattern dict).
+#   batch-34 (AST): 439 -> 434, 2026-06-13 (5 exact pins in test_logging.py;
+#   batch deliberately small — the next-ranked files were poor targets this
+#   round: integration_tests.py has 6 pre-existing failures (table_output
+#   missing from CSV TOON, filed separately) so its asserts are unreachable,
+#   and the CLI-output files need content-invariant pins, not byte counts that
+#   vary by platform temp-stem length — both deferred to batch-35).
 
-BASELINE_COUNT=439
+BASELINE_COUNT=434
 MEASUREMENT_DATE=2026-06-13
 MEASUREMENT_COMMAND="uv run python scripts/check_loose_assertions.py --baseline"

--- a/tests/unit/utils/test_logging.py
+++ b/tests/unit/utils/test_logging.py
@@ -93,7 +93,7 @@ class TestSetupLogger:
         logger = setup_logger(name="test_logger_handlers")
         assert logger.name == "test_logger_handlers"
         # Test logger should have handlers cleared
-        assert len(logger.handlers) > 0
+        assert len(logger.handlers) == 1
 
     @pytest.mark.skipif(
         sys.platform == "win32",
@@ -116,7 +116,7 @@ class TestSetupLogger:
             ):
                 logger = setup_logger(name=logger_name)
                 # Should have at least one handler
-                assert len(logger.handlers) >= 1
+                assert len(logger.handlers) == 2
 
     @pytest.mark.skipif(
         sys.platform == "win32",
@@ -142,7 +142,9 @@ class TestSetupLogger:
                 file_handlers = [
                     h for h in logger.handlers if isinstance(h, logging.FileHandler)
                 ]
-                assert len(file_handlers) >= 0  # May or may not have file handler
+                assert (
+                    len(file_handlers) == 1
+                )  # File logging enabled: expect 1 file handler
 
     @pytest.mark.skipif(
         sys.platform == "win32",
@@ -169,7 +171,9 @@ class TestSetupLogger:
                 file_handlers = [
                     h for h in logger.handlers if isinstance(h, logging.FileHandler)
                 ]
-                assert len(file_handlers) >= 0  # May or may not have file handler
+                assert (
+                    len(file_handlers) == 1
+                )  # File logging enabled: expect 1 file handler
 
 
 class TestSafeStreamHandler:
@@ -669,7 +673,7 @@ class TestCreatePerformanceLogger:
     def test_create_performance_logger_handler(self):
         """测试性能日志器处理器"""
         logger = create_performance_logger("test_perf_handler")
-        assert len(logger.handlers) > 0
+        assert len(logger.handlers) == 1
 
     def test_create_performance_logger_inherits_root_level(self):
         """Perf logger inherits root level (no hard-coded DEBUG).


### PR DESCRIPTION
Pins 5 handler-count assertions in `test_logging.py` to exact measured values (`== 1`/`== 2`), all verified by the green run (66 passed).

**Deliberately small (5, not ~20):** this round's next-ranked files were poor targets and are deferred to batch-35:
- `integration_tests.py` has **6 pre-existing failures** (CSV TOON response missing `table_output` — filed as a separate bug) → its loose asserts are unreachable, can't be measured by a green run.
- The CLI-output files (`test_cli_queries`, `test_cli_table_partial_query`) need **content-invariant** assertions, not byte counts that vary by platform temp-stem length.

Quality over count — per the exact-assertion lock, every pin here is a measured fact from a passing test, not a guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)