### PR TITLE
fix(mcp): verdict-aware summary_line synthesis (#672)

### DIFF
--- a/tests/unit/mcp/test_error_recovery_coverage.py
+++ b/tests/unit/mcp/test_error_recovery_coverage.py
@@ -281,3 +281,66 @@ class TestSuccessEnvelopeNextStepMirror:
         result = ensure_canonical_success_envelope("nav", response)
         # Contract unchanged when there is nothing to mirror.
         assert result["agent_summary"]["next_step"] == ""
+
+
+class TestSynthesizedSummaryLineIsVerdictAware:
+    """#672/#678: when no summary_line / agent_summary.summary_line / identifier
+    is present, the synthesized fallback must reflect the verdict — never claim
+    ``"ok"`` on any non-success verdict (WARN/ERROR/NOT_FOUND/CAUTION/REVIEW/
+    UNSAFE; e.g. index action=status on an empty cache, or viz action=similarity
+    returning CAUTION), which lies to an agent that gates on summary_line. Only
+    the success-like allowlist (INFO/SAFE) keeps ``"ok"``."""
+
+    def test_warn_verdict_does_not_say_ok(self):
+        response = {"success": True, "verdict": "WARN", "indexed": False}
+        result = ensure_canonical_success_envelope("index", response)
+        assert result["summary_line"] == "index: warn"
+        assert result["agent_summary"]["summary_line"] == "index: warn"
+
+    def test_not_found_verdict_suffix(self):
+        response = {"success": True, "verdict": "NOT_FOUND"}
+        result = ensure_canonical_success_envelope("nav", response)
+        assert result["summary_line"] == "nav: not found"
+
+    def test_error_verdict_suffix(self):
+        response = {"success": True, "verdict": "ERROR"}
+        result = ensure_canonical_success_envelope("search", response)
+        assert result["summary_line"] == "search: error"
+
+    def test_caution_review_unsafe_verdicts_are_not_ok(self):
+        # Codex #678 P2: the security/quality verdicts must not fall through to
+        # "ok" — they're the exact cases an agent must NOT read as success.
+        for verdict, expected in (
+            ("CAUTION", "viz: caution"),
+            ("REVIEW", "viz: review"),
+            ("UNSAFE", "viz: unsafe"),
+        ):
+            response = {"success": True, "verdict": verdict}
+            result = ensure_canonical_success_envelope("viz", response)
+            assert result["summary_line"] == expected
+
+    def test_info_and_safe_verdicts_still_ok(self):
+        # Regression: the success-like allowlist keeps the "ok" suffix.
+        for verdict in ("INFO", "SAFE"):
+            response = {"success": True, "verdict": verdict}
+            result = ensure_canonical_success_envelope("structure", response)
+            assert result["summary_line"] == "structure: ok"
+
+    def test_verdict_read_from_agent_summary_when_top_level_absent(self):
+        response = {"success": True, "agent_summary": {"verdict": "WARN"}}
+        result = ensure_canonical_success_envelope("health", response)
+        assert result["summary_line"] == "health: warn"
+
+    def test_identifier_still_wins_over_verdict_suffix(self):
+        # When an identifier field is present it takes precedence — the verdict
+        # suffix is only the no-identifier fallback.
+        response = {"success": True, "verdict": "WARN", "file_path": "mod.py"}
+        result = ensure_canonical_success_envelope("structure", response)
+        assert result["summary_line"] == "structure: mod.py"
+
+    def test_no_verdict_no_identifier_falls_back_to_ok(self):
+        # No verdict anywhere and no identifier → the suffix is "ok" (the
+        # success-like default), with no agent_summary verdict to read either.
+        response = {"success": True}
+        result = ensure_canonical_success_envelope("nav", response)
+        assert result["summary_line"] == "nav: ok"

--- a/tree_sitter_analyzer/mcp/server_utils/error_recovery.py
+++ b/tree_sitter_analyzer/mcp/server_utils/error_recovery.py
@@ -400,6 +400,32 @@ def ensure_canonical_success_envelope(
     return response
 
 
+# #672/#678: the no-identifier summary-line suffix is "ok" ONLY for success-like
+# verdicts (or an absent verdict). Every other canonical verdict — WARN, ERROR,
+# NOT_FOUND, CAUTION, REVIEW, UNSAFE, and anything added later — gets its own
+# lowercased suffix, via an ALLOWLIST (not a denylist), so a new non-success
+# verdict can never silently synthesize a lying "<tool>: ok" (Codex #678 P2:
+# viz action=similarity can return CAUTION/REVIEW with no identifier).
+_SUCCESS_LIKE_VERDICTS: frozenset[str] = frozenset({"INFO", "SAFE", "OK", "SUCCESS"})
+
+
+def _verdict_suffix(response: dict[str, Any]) -> str:
+    """Pick the no-identifier summary-line suffix from the response verdict.
+
+    Reads the top-level ``verdict`` first, then ``agent_summary.verdict``.
+    Returns ``"ok"`` for a success-like or absent verdict; otherwise the
+    verdict lowercased (``NOT_FOUND`` -> ``"not found"``).
+    """
+    verdict = response.get("verdict")
+    if not isinstance(verdict, str) or not verdict:
+        agent_summary = response.get("agent_summary")
+        if isinstance(agent_summary, dict):
+            verdict = agent_summary.get("verdict")
+    if not isinstance(verdict, str) or not verdict or verdict in _SUCCESS_LIKE_VERDICTS:
+        return "ok"
+    return verdict.lower().replace("_", " ")
+
+
 def _populate_summary_line(
     response: dict[str, Any],
     tool_name: str,
@@ -434,9 +460,14 @@ def _populate_summary_line(
             break
     if identifier_value is None:
         _identifier_key, identifier_value = _pick_identifier(arguments)
-    synthesized = (
-        f"{tool_name}: {identifier_value}" if identifier_value else f"{tool_name}: ok"
-    )
+    if identifier_value:
+        synthesized = f"{tool_name}: {identifier_value}"
+    else:
+        # #672: the fallback suffix MUST reflect the verdict — saying "ok" on a
+        # WARN/ERROR/NOT_FOUND response (e.g. index action=status with an empty
+        # cache) lies to an agent that gates on summary_line. Only success-like
+        # verdicts (or none) get "ok".
+        synthesized = f"{tool_name}: {_verdict_suffix(response)}"
     response["summary_line"] = synthesized
     return synthesized
 


### PR DESCRIPTION
Closes #672.

## Problem
The canonical-envelope summary-line synthesizer (`error_recovery.py`) appended `": ok"` **regardless of verdict**. A WARN/ERROR/NOT_FOUND response with no `summary_line` / `agent_summary.summary_line` / identifier — e.g. `index action=status` on an empty cache — got a synthesized `"<tool>: ok"` that contradicts its own `verdict: WARN` and misleads an agent that gates on `summary_line`.

## Fix
Add a `_verdict_suffix` helper mapping `WARN`/`ERROR`/`NOT_FOUND` → `warning`/`error`/`not found`; success-like or absent verdicts keep `"ok"`. Reads the top-level `verdict` first, then `agent_summary.verdict`. Identifier-based summary lines (`<tool>: <file_path>`) are unchanged and still take precedence.

## RED-first
`TestSynthesizedSummaryLineIsVerdictAware`: WARN/ERROR/NOT_FOUND honest suffixes, INFO-stays-ok regression, agent_summary-verdict read, identifier-precedence, and no-verdict→ok fallback. The 4 verdict tests fail without the fix; new lines fully covered.

## Scope note
This fixes the verdict-blind "ok" (the visible lie). The secondary observation in #672 — that a facade can strip the *inner* tool's rich agent_summary before this synthesizer runs (forcing the fallback at all) — is a separate, deeper investigation left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)