### PR TITLE
fix(mcp): accept output_format as a universal envelope param (#651)

### DIFF
--- a/tests/unit/mcp/test_base_mcp_tool_contract.py
+++ b/tests/unit/mcp/test_base_mcp_tool_contract.py
@@ -141,3 +141,44 @@ class TestBaseMCPToolContract:
             f"{_tool_id(tool)}: output_format.default must be 'toon', got {default!r}. "
             "See CLAUDE.md §1: MCP defaults to TOON — LOCKED."
         )
+
+
+class TestUniversalOutputFormatParam:
+    """#651: output_format is a universal envelope param. enforce_strict_params
+    must accept it even when a tool's schema omits it (modification_guard and
+    batch_search rejected it with ValueError), so an agent can set it uniformly
+    across every call — while still rejecting genuinely-unknown keys."""
+
+    def test_output_format_accepted_when_schema_omits_it(self) -> None:
+        from tree_sitter_analyzer.mcp.utils.schema_strictness import (
+            enforce_strict_params,
+        )
+
+        # modification_guard's schema (no output_format) — must NOT raise.
+        schema = {
+            "properties": {"symbol": {}, "modification_type": {}, "file_path": {}}
+        }
+        enforce_strict_params(
+            "modification_guard",
+            schema,
+            {"symbol": "x", "file_path": "f", "output_format": "json"},
+        )
+
+    def test_genuinely_unknown_param_still_rejected(self) -> None:
+        from tree_sitter_analyzer.mcp.utils.schema_strictness import (
+            enforce_strict_params,
+        )
+
+        schema = {"properties": {"symbol": {}}}
+        with pytest.raises(ValueError, match="unknown parameter 'bogus'"):
+            enforce_strict_params("t", schema, {"symbol": "x", "bogus": 1})
+
+    @pytest.mark.parametrize("tool", TOOLS, ids=_tool_id)
+    def test_every_contract_tool_accepts_output_format(self, tool: object) -> None:
+        from tree_sitter_analyzer.mcp.utils.schema_strictness import (
+            enforce_strict_params,
+        )
+
+        schema = tool.get_tool_definition().get("inputSchema")
+        # Must not raise for any tool, whether or not output_format is declared.
+        enforce_strict_params(_tool_id(tool), schema, {"output_format": "json"})

--- a/tree_sitter_analyzer/mcp/utils/schema_strictness.py
+++ b/tree_sitter_analyzer/mcp/utils/schema_strictness.py
@@ -33,6 +33,13 @@ from __future__ import annotations
 import difflib
 from typing import Any
 
+#: Universal envelope-control params accepted at every tool boundary even when
+#: an individual tool's schema omits them (#651). ``output_format`` selects the
+#: TOON-vs-JSON envelope and is honoured by every formatting tool; tools with a
+#: single output shape accept-and-ignore it rather than hard-erroring, so an
+#: agent can set it uniformly across all calls without a tool-specific failure.
+_UNIVERSAL_ENVELOPE_PARAMS: frozenset[str] = frozenset({"output_format"})
+
 
 def enforce_strict_params(
     tool_name: str,
@@ -86,7 +93,11 @@ def enforce_strict_params(
         return
 
     known: list[str] = list(properties.keys())
-    unknown = [key for key in arguments if key not in properties]
+    unknown = [
+        key
+        for key in arguments
+        if key not in properties and key not in _UNIVERSAL_ENVELOPE_PARAMS
+    ]
     if not unknown:
         return
 


### PR DESCRIPTION
Closes #651.

## Problem
`output_format` is the universal TOON-vs-JSON envelope control — accepted by search/nav/structure/health/index/viz actions across hundreds of probes. But the strict-param guard (`enforce_strict_params`) rejected it on tools whose schema omits it (`modification_guard`, `batch_search`):

```
edit action=guard {..., output_format: json} → ValueError: unknown parameter 'output_format'
```

An agent that sets `output_format` uniformly (the reasonable default for a token-budget-aware client) fails *only* on these tools, with no hint the param is simply unwired there — the mirror image of the #515/#529/#540 facade-doc-drift family.

## Fix
Whitelist `output_format` at the single choke point (`enforce_strict_params`) via a `_UNIVERSAL_ENVELOPE_PARAMS` set. Every tool now accepts it — formatting tools honour it, single-shape tools accept-and-ignore — while genuinely-unknown params still raise with the did-you-mean hint. One central fix covers all 25+ tools consistently.

## RED-first
`TestUniversalOutputFormatParam`: `output_format` accepted when the schema omits it (the modification_guard case), a bogus param still rejected, and a per-tool contract asserting every BaseMCPTool accepts `output_format` without raising. The first test fails without the fix; verified `modification_guard` accepts it end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)