### PR TITLE
fix(toon): inline-key fallback for divergent nested-dict cells (#643)

### DIFF
--- a/tests/unit/formatters/test_toon_heterogeneous_637.py
+++ b/tests/unit/formatters/test_toon_heterogeneous_637.py
@@ -56,6 +56,24 @@ class TestHeterogeneousArrayLosslessness:
         )
         assert out == "rows:\n  [2]{a,meta{x,y}}:\n    1,\n    2,(1,2)"
 
+    def test_issue_643_divergent_nested_subkeys_encode_inline(self) -> None:
+        """#643: a dict cell whose subkeys DIVERGE from the header sample must
+        encode self-describing ``(k:v)`` — not values-only ``(v1,v2)`` that
+        would be positionally mis-read. Header samples ``meta{x,y}`` from row 0;
+        row 1's ``{x,z}`` cannot reuse that annotation without losing ``z``."""
+        out = ToonEncoder().encode(
+            {"rows": [{"meta": {"x": 1, "y": 2}}, {"meta": {"x": 3, "z": 9}}]}
+        )
+        assert out == "rows:\n  [2]{meta{x,y}}:\n    (1,2)\n    (x:3,z:9)"
+
+    def test_issue_643_matching_nested_subkeys_stay_compact(self) -> None:
+        """Regression: cells whose subkeys MATCH the header sample keep the
+        compact values-only form (the token-efficient common case)."""
+        out = ToonEncoder().encode(
+            {"rows": [{"meta": {"x": 1, "y": 2}}, {"meta": {"x": 3, "y": 4}}]}
+        )
+        assert out == "rows:\n  [2]{meta{x,y}}:\n    (1,2)\n    (3,4)"
+
     def test_mixed_dict_and_scalar_list_encodes_inline_not_crash(self) -> None:
         """A list whose first item is a dict but later items are scalars must
         NOT enter the table path (pre-fix: AttributeError → JSON fallback)."""

--- a/tree_sitter_analyzer/formatters/_toon_encoder_table_helpers.py
+++ b/tree_sitter_analyzer/formatters/_toon_encoder_table_helpers.py
@@ -73,9 +73,30 @@ def encode_array_table_lines(
             indent_str,
             encode_value,
             seen_ids,
+            _sample_dict_subkeys(items, schema),
         )
     )
     return lines
+
+
+def _sample_dict_subkeys(
+    items: list[dict[str, Any]],
+    schema: list[str],
+) -> dict[str, tuple[str, ...]]:
+    """Per dict-valued column, the subkeys sampled for the header annotation.
+
+    The header (``build_table_schema_parts``) annotates a dict column from the
+    first row that has the key, e.g. ``meta{x,y}``. A row cell is encoded
+    compactly (values-only ``(v1,v2)``) only when its dict keys match this
+    sample; divergent cells fall back to inline ``(k:v,...)`` so a row with
+    different subkeys is not positionally mis-read against the sample (#643).
+    """
+    result: dict[str, tuple[str, ...]] = {}
+    for key in schema:
+        sample_value = next((item[key] for item in items if key in item), None)
+        if isinstance(sample_value, dict):
+            result[key] = tuple(sample_value.keys())
+    return result
 
 
 def build_table_schema_parts(
@@ -108,12 +129,20 @@ def encode_table_rows(
     indent_str: str,
     encode_value: EncodeValue,
     seen_ids: set[int],
+    expected_subkeys: dict[str, tuple[str, ...]] | None = None,
 ) -> list[str]:
     """Encode table rows using an existing value encoder and circular-ref set."""
+    expected_subkeys = expected_subkeys or {}
     return [
         f"{indent_str}  "
         + delimiter.join(
-            _encode_table_cell(item.get(key, ""), delimiter, encode_value, seen_ids)
+            _encode_table_cell(
+                item.get(key, ""),
+                delimiter,
+                encode_value,
+                seen_ids,
+                expected_subkeys.get(key),
+            )
             for key in schema
         )
         for item in items
@@ -125,13 +154,26 @@ def _encode_table_cell(
     delimiter: str,
     encode_value: EncodeValue,
     seen_ids: set[int],
+    expected_subkeys: tuple[str, ...] | None = None,
 ) -> str:
-    """Encode a single TOON table cell."""
+    """Encode a single TOON table cell.
+
+    A dict cell whose keys match the column's header sample (``expected_subkeys``)
+    is encoded compactly as values-only ``(v1,v2)`` — the keys are read off the
+    header. A dict whose keys DIVERGE from the sample (different/extra/missing
+    subkeys) is encoded self-describing as ``(k1:v1,k2:v2)`` so its values are
+    not positionally mis-attributed to the header's subkeys (#643).
+    """
     if isinstance(value, tuple | list) and len(value) == 2:
         return f"({value[0]},{value[1]})"
     if isinstance(value, dict):
-        dict_values = delimiter.join(
-            str(encode_value(v, seen_ids)) for v in value.values()
+        if expected_subkeys is not None and tuple(value.keys()) == expected_subkeys:
+            dict_values = delimiter.join(
+                str(encode_value(v, seen_ids)) for v in value.values()
+            )
+            return f"({dict_values})"
+        inline = delimiter.join(
+            f"{k}:{encode_value(v, seen_ids)}" for k, v in value.items()
         )
-        return f"({dict_values})"
+        return f"({inline})"
     return encode_value(value, seen_ids)


### PR DESCRIPTION
Closes #643.

## Problem
A nested-dict table column annotates its header from one sampled row (`meta{x,y}`), then encoded **every** row's dict cell as values-only `(v1,v2)`. A row whose dict had different subkeys than the sample was positionally mis-read:

```
rows: [{meta:{x:1,y:2}}, {meta:{x:3,z:9}}]
header: meta{x,y}   (sampled from row 0)
row 1:  (3,9)       ← reads as y=9 under meta{x,y}; the 'z' key is lost, 9 mis-attributed
```

The #637 losslessness invariant covered row keys + leaf values but not this nested sub-schema divergence (noted as a residual in #637).

## Fix
Encode a dict cell compactly (values-only `(v1,v2)`) **only** when its keys match the column's header sample; cells with divergent / extra / missing subkeys fall back to self-describing inline `(k1:v1,k2:v2)`:

```
row 1: (x:3,z:9)    ← self-describing, lossless
```

The compact common case (and its token savings) is unchanged — only genuinely-divergent cells pay the inline cost. Fully contained in `_toon_encoder_table_helpers.py`.

## RED-first
- `test_issue_643_divergent_nested_subkeys_encode_inline` — divergent `{x,z}` → inline (fails without the fix).
- `test_issue_643_matching_nested_subkeys_stay_compact` — matching `{x,y}` → compact (regression guard).
- 100 passed across the TOON encoder + #637 losslessness suites (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)