### PR TITLE
fix(structure): surface tree-sitter parse errors in analyze (#572)

### DIFF
--- a/tests/unit/mcp/test_analyze_code_structure_tool_core.py
+++ b/tests/unit/mcp/test_analyze_code_structure_tool_core.py
@@ -214,3 +214,40 @@ class TestAnalyzeCodeStructureToolValidateArguments:
         arguments = {"file_path": "test.py", "suppress_output": "true"}
         with pytest.raises(ValueError, match="suppress_output must be a boolean"):
             tool.validate_arguments(arguments)
+
+
+@pytest.mark.asyncio
+class TestAnalyzeSurfacesParseErrors:
+    """#572: a wrong-language / corrupt file must not be reported as a clean
+    INFO with phantom symbols. tree-sitter's parse error is surfaced as
+    parse_errors + verdict WARN so an agent doesn't trust the garbage."""
+
+    async def test_wrong_language_file_flags_parse_errors(self, tmp_path):
+        # C++ source in a .py file parses with errors (phantom 'public' class).
+        f = tmp_path / "evil.py"
+        f.write_text("class Foo { public: int x; void bar() {} };\n")
+        tool = AnalyzeCodeStructureTool(project_root=str(tmp_path))
+        result = await tool.execute({"file_path": str(f), "output_format": "json"})
+        assert result["parse_errors"] is True
+        assert result["verdict"] == "WARN"
+        assert result["agent_summary"]["verdict"] == "WARN"
+
+    async def test_valid_file_has_no_parse_errors_flag(self, tmp_path):
+        # Regression: a clean parse keeps the INFO envelope, no parse_errors key.
+        f = tmp_path / "good.py"
+        f.write_text("class Foo:\n    def bar(self):\n        return 1\n")
+        tool = AnalyzeCodeStructureTool(project_root=str(tmp_path))
+        result = await tool.execute({"file_path": str(f), "output_format": "json"})
+        assert "parse_errors" not in result
+        assert result["verdict"] == "INFO"
+
+    async def test_relative_file_path_with_project_root_still_flags(self, tmp_path):
+        # Codex #682 P1: a project-relative file_path (the common MCP shape) must
+        # use the resolved path for the validity check. The raw "evil.py" does
+        # not exist from the pytest cwd, so a check against file_path would skip
+        # and report the phantom symbols as clean.
+        (tmp_path / "evil.py").write_text("class Foo { public: int x; };\n")
+        tool = AnalyzeCodeStructureTool(project_root=str(tmp_path))
+        result = await tool.execute({"file_path": "evil.py", "output_format": "json"})
+        assert result["parse_errors"] is True
+        assert result["verdict"] == "WARN"

--- a/tree_sitter_analyzer/mcp/tools/analyze_code_structure_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/analyze_code_structure_tool.py
@@ -259,7 +259,42 @@ def _build_success_response(
     # post-hook (and direct ``execute()`` callers) see populated envelope
     # keys. Round-16b dogfood saw both as ``None`` here.
     _attach_agent_summary(response, options, metadata, next_steps)
+    _attach_parse_validity(response, options)
     return response
+
+
+def _attach_parse_validity(
+    response: dict[str, Any],
+    options: _ExecutionOptions,
+) -> None:
+    """#572: surface tree-sitter parse errors so a wrong-language or corrupt
+    file (e.g. C++ source in a ``.py``) is not reported as a clean ``INFO``
+    with phantom symbols an agent then trusts. When the file's parse has an
+    ``ERROR`` node, flag ``parse_errors`` and downgrade the verdict to ``WARN``.
+
+    Uses the cached ``Parser`` (LRU), so this reuses the parse the analysis
+    already did rather than incurring a fresh one. Only set on the broken path
+    — a clean parse leaves the INFO envelope untouched.
+    """
+    from .utils.parse_validity import is_file_parse_broken
+
+    # Use the resolved (absolute) path, not the raw file_path — with an MCP
+    # project_root + a project-relative file_path, is_file_parse_broken's
+    # Path(...).is_file() would fail on the relative path and skip the check
+    # (Codex #682 P1).
+    if not is_file_parse_broken(options.resolved_path, options.language):
+        return
+    response["parse_errors"] = True
+    response["verdict"] = "WARN"
+    # _attach_agent_summary (called just before) always sets agent_summary as a
+    # dict, so override its verdict + next_step directly.
+    agent_summary = response["agent_summary"]
+    agent_summary["verdict"] = "WARN"
+    agent_summary["next_step"] = (
+        "Parse errors detected — the extracted symbols may be phantom "
+        "(wrong language for the file extension, or corrupt source). "
+        "Verify the file's language before trusting this structure."
+    )
 
 
 def _safe_int(value: Any) -> int:


### PR DESCRIPTION
Closes #572 (manifestations #1 + #4).

## Problem (P1 — trust)
A wrong-language or corrupt file parsed *clean*: `structure analyze` on C++ source in a `.py` returned `success:true, verdict:INFO`, a **phantom class named `public`**, and zero warnings — so an agent builds inferences on garbage. tree-sitter's `root.has_error` was never surfaced; **success itself was the mask** (the audit memory's 'MCP掩盖success:False' lesson, one level deeper).

## Fix
After a successful structure analysis, check parse validity via the existing `is_file_parse_broken` helper — which reuses the **cached** `Parser` (LRU), so this is a cache hit, not a fresh parse. When the tree has ERROR nodes: set `parse_errors: true` + `verdict: WARN` + an `agent_summary.next_step` warning the symbols may be phantom. A clean parse leaves the INFO envelope untouched (no new key).

## Scope
Covers #572 manifestations **#1 (wrong-language)** and **#4 (invalid syntax)** — the core 'phantom symbols look valid' trust bug. Manifestations **#2 (non-UTF8 encoding)** and **#3 (NUL-byte end_line)** have distinct nuances (the null-byte false-positive guard *intentionally* excludes #3 — null bytes are legal in string literals) and are noted as follow-ups rather than forced into this fix.

## RED-first
`TestAnalyzeSurfacesParseErrors`: C++-in-.py → `parse_errors:true` + `verdict:WARN` (fails without the fix); a valid file → `INFO`, no `parse_errors` key (regression). 82 passed across the analyze + agent-contracts suites (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)