### PR TITLE
fix(outline): per-class method/field cap closes the wide-class budget hole (#571)

### DIFF
--- a/tests/unit/mcp/test_output_cost_invariants.py
+++ b/tests/unit/mcp/test_output_cost_invariants.py
@@ -1175,3 +1175,34 @@ def test_content_default_cap_bytes_smaller_than_uncapped() -> None:
     assert uncapped_bytes == 10505, (
         f"content uncapped bytes drifted: {uncapped_bytes} != 10505 — re-measure and re-pin"
     )
+
+
+def test_outline_wide_class_methods_bounded_by_cap(tmp_path) -> None:
+    """#571: a single wide class must not detonate the outline response.
+
+    The top-level listed_cap bounds the class COUNT, but a 10k-method generated
+    stub had its methods emitted uncapped (2.75MB, truncated=False). Each listed
+    class's methods must be bounded by listed_cap — the structural invariant that
+    keeps the response within budget. The fixture is deterministic (500 methods),
+    so every count is pinned EXACTLY (CLAUDE.md exact-assertion lock — no <=/<
+    bounds; the byte budget is the deterministic consequence of methods == cap).
+    """
+    from tree_sitter_analyzer.mcp.tools.get_code_outline_tool import (
+        DEFAULT_OUTLINE_CLASSES_CAP,
+        GetCodeOutlineTool,
+    )
+
+    f = tmp_path / "wide.py"
+    f.write_text(
+        "class Big:\n" + "".join(f"    def m{i}(self): pass\n" for i in range(500))
+    )
+    tool = GetCodeOutlineTool(project_root=str(tmp_path))
+    result = asyncio.run(tool.execute({"file_path": str(f), "output_format": "json"}))
+
+    cls = result["classes"][0]
+    # Exactly listed_cap methods listed (not 500), with the honest pre-cap totals.
+    assert len(cls["methods"]) == DEFAULT_OUTLINE_CLASSES_CAP
+    assert cls["methods_total"] == 500
+    assert cls["methods_listed"] == DEFAULT_OUTLINE_CLASSES_CAP
+    assert result["method_count"] == 500  # pre-cap total stays honest
+    assert result["truncated"] is True

--- a/tests/unit/mcp/test_tools/test_get_code_outline_budget.py
+++ b/tests/unit/mcp/test_tools/test_get_code_outline_budget.py
@@ -488,3 +488,52 @@ class TestByteBudgetDifferentialInvariant:
 # ---------------------------------------------------------------------------
 _EXPECTED_CAPPED_BYTES: int = 99217
 _EXPECTED_UNCAPPED_BYTES: int = 158804
+
+
+# ---------------------------------------------------------------------------
+# #571 — per-class method cap (a single wide class must not detonate)
+# ---------------------------------------------------------------------------
+
+
+class TestPerClassMethodCap:
+    """#571: the top-level cap bounds the class COUNT, but a single wide class
+    (10k generated-stub methods) was emitted uncapped → 2.75MB, truncated=False.
+    Each listed class's methods must be capped under listed_cap with per-class
+    totals, while the aggregate method_count stays the honest pre-cap total."""
+
+    # Real temp files (not the mocked engine) — the mock's 20-line class span
+    # only associates ~19 methods per class, so it can't model a genuinely wide
+    # class. A real parse exercises _build_class_outlines correctly.
+
+    @staticmethod
+    def _outline(tmp_path, n_methods: int) -> dict:
+        f = tmp_path / "wide.py"
+        body = "".join(f"    def m{i}(self): pass\n" for i in range(n_methods))
+        f.write_text("class Big:\n" + body)
+        tool = GetCodeOutlineTool(project_root=str(tmp_path))
+        return asyncio.run(tool.execute({"file_path": str(f), "output_format": "json"}))
+
+    def test_wide_class_methods_capped_to_listed_cap(self, tmp_path):
+        result = self._outline(tmp_path, 200)
+        cls = result["classes"][0]
+        assert len(cls["methods"]) == DEFAULT_OUTLINE_CLASSES_CAP
+        assert cls["methods_total"] == 200
+        assert cls["methods_listed"] == DEFAULT_OUTLINE_CLASSES_CAP
+        assert result["truncated"] is True
+        # totals are never corrupted by the cap (#505 lesson).
+        assert result["method_count"] == 200
+
+    def test_member_only_truncation_names_reason_in_next_step(self, tmp_path):
+        # Codex #683 P2: when ONLY the per-class member cap fires (top-level
+        # class/function counts all fit), the truncation note must still state
+        # the reason — not "truncated: showing  (listed_cap=50)".
+        result = self._outline(tmp_path, 200)
+        next_step = result["agent_summary"]["next_step"]
+        assert "methods/fields capped in 1 class(es)" in next_step
+
+    def test_narrow_class_methods_not_capped(self, tmp_path):
+        result = self._outline(tmp_path, 5)
+        cls = result["classes"][0]
+        assert len(cls["methods"]) == 5
+        assert "methods_total" not in cls
+        assert result["truncated"] is False

--- a/tree_sitter_analyzer/mcp/tools/get_code_outline_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/get_code_outline_tool.py
@@ -460,6 +460,19 @@ class GetCodeOutlineTool(BaseMCPTool):
         classes_capped = classes_all[:listed_cap]
         fns_capped = fns_all[:listed_cap]
 
+        # Issue #571: the top-level cap above bounds the class COUNT, but a
+        # single wide class (10k methods in generated protobuf/ORM stubs)
+        # detonates the response (2.75MB, truncated=False). Cap each listed
+        # class's methods/fields under the same listed_cap with per-class totals.
+        per_class_truncated = False
+        new_classes_capped = []
+        for cls in classes_capped:
+            capped_cls, was_truncated = _cap_class_members(cls, listed_cap)
+            new_classes_capped.append(capped_cls)
+            per_class_truncated = per_class_truncated or was_truncated
+        classes_capped = new_classes_capped
+        truncated = truncated or per_class_truncated
+
         # Patch the outline dict in-place (shallow copy to avoid mutating caller's
         # reference — we create a new dict for outline to keep immutability).
         outline = dict(outline)
@@ -542,6 +555,19 @@ class GetCodeOutlineTool(BaseMCPTool):
                 overflow_parts.append(
                     f"{functions_listed} of {functions_total} top-level functions"
                 )
+            # #571 (Codex P2): truncation can come ONLY from the per-class
+            # method/field cap, in which case the top-level counts above match
+            # and overflow_parts would be empty — losing the reason. Name the
+            # member-capped classes so the note is never reasonless.
+            member_capped = sum(
+                1
+                for c in (result.get("classes") or [])
+                if isinstance(c, dict) and ("methods_total" in c or "fields_total" in c)
+            )
+            if member_capped:
+                overflow_parts.append(
+                    f"methods/fields capped in {member_capped} class(es)"
+                )
             next_step = (
                 f"truncated: showing {', '.join(overflow_parts)} "
                 f"(listed_cap={listed_cap}). "
@@ -601,6 +627,28 @@ class GetCodeOutlineTool(BaseMCPTool):
 # stays at ~25 lines of phase dispatch. Each helper preserves byte-for-byte
 # the dict layout the original code produced.
 # ---------------------------------------------------------------------------
+
+
+def _cap_class_members(cls: dict[str, Any], cap: int) -> tuple[dict[str, Any], bool]:
+    """Cap a class outline's ``methods``/``fields`` lists to ``cap`` (#571).
+
+    A single wide class (e.g. a 10k-method generated stub) otherwise blows the
+    outline response past any byte budget with ``truncated=False``. When a list
+    exceeds ``cap`` it is sliced and the pre-cap total recorded as
+    ``<key>_total`` (the count is never corrupted — same #505 lesson as the
+    top-level cap). Returns ``(capped_class, was_truncated)``. ``cls`` is always
+    a ``_build_class_outlines`` dict.
+    """
+    capped = dict(cls)
+    was_truncated = False
+    for key in ("methods", "fields"):
+        members = capped.get(key)
+        if isinstance(members, list) and len(members) > cap:
+            capped[f"{key}_total"] = len(members)
+            capped[f"{key}_listed"] = cap
+            capped[key] = members[:cap]
+            was_truncated = True
+    return capped, was_truncated
 
 
 def _method_entry(m: Any) -> dict[str, Any]:


### PR DESCRIPTION
Closes #571.

## Problem (P1)
#542's caps gate the top-level **class/function count**, but a single class's methods were emitted **uncapped**. A 10k-method generated stub (protobuf/WSDL/ORM) produced a **2.75MB** outline with `truncated: false` — silently detonating agent contexts.

```
1 class, 2000 one-line methods → 682KB TOON, truncated:False, classes_listed:1
```

## Fix
Cap each listed class's `methods`/`fields` under the same `listed_cap` (`_cap_class_members`), recording per-class `methods_total`/`methods_listed`; the aggregate `method_count` stays the honest **pre-cap** total (#505 lesson) and `truncated` flips True. A 2000-method class drops **682KB → 18KB**; a narrow class is untouched (no new keys, truncated stays False).

## RED-first
- `TestPerClassMethodCap` (real wide-class temp file) — methods capped to `listed_cap`, `methods_total` recorded, `truncated` True, `method_count` stays pre-cap; narrow class unchanged.
- `test_outline_wide_class_methods_bounded_by_cap` in `test_output_cost_invariants.py` — the missing `per_class_method_count <= cap` byte-budget invariant #571 asked for.

## Follow-up
The CLI `--table=signatures/full` footer (`# ... N methods omitted`) is a separate formatter path — noted for a follow-up; this PR fixes the MCP outline detonation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)