### PR TITLE
fix(structure): dedup param parsing so compound generics aren't inverted (#576)

### DIFF
--- a/tests/unit/mcp/test_analyze_code_structure_tool_helpers.py
+++ b/tests/unit/mcp/test_analyze_code_structure_tool_helpers.py
@@ -395,3 +395,22 @@ class TestAnalyzeCodeStructureToolGetMethodParameters:
         assert result[0]["type"] == "str"
         assert result[1]["name"] == "param2"
         assert result[1]["type"] == "int"
+
+    def test_get_method_parameters_compound_generic_types(self):
+        """#576: ``name: <generic with spaces>`` must split on the FIRST ':',
+        not whitespace — otherwise ``result: dict[str, Any]`` parsed as
+        name='Any]', type='result: dict[str,'. Covers the modern typed-Python
+        forms (generics, nested brackets, defaults) that whitespace-splitting
+        mangled."""
+        mock_method = MagicMock()
+        mock_method.parameters = [
+            "result: dict[str, Any]",
+            "cb: Callable[[int], str]",
+            "items: list[tuple[int, str]]",
+            'breed: str = "Mixed"',
+        ]
+        result = _get_method_parameters(mock_method)
+        assert result[0] == {"name": "result", "type": "dict[str, Any]"}
+        assert result[1] == {"name": "cb", "type": "Callable[[int], str]"}
+        assert result[2] == {"name": "items", "type": "list[tuple[int, str]]"}
+        assert result[3] == {"name": "breed", "type": "str", "default": '"Mixed"'}

--- a/tree_sitter_analyzer/mcp/tools/analyze_code_structure_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/analyze_code_structure_tool.py
@@ -122,15 +122,16 @@ def _convert_parameters(parameters: Any) -> list[dict[str, str]]:
 
 
 def _parse_string_param(param_str: str) -> dict[str, str]:
-    """Parse a single 'type name' string into a parameter dict."""
-    parts = param_str.strip().split()
-    if len(parts) >= 2:
-        _prefix = parts[:-1]
-        _joined = " ".join(_prefix)
-        return {"name": parts[-1], "type": _joined}
-    if len(parts) == 1:
-        return {"name": "param", "type": parts[0]}
-    return {"name": "param", "type": "Object"}
+    """Parse a single parameter string into a parameter dict.
+
+    #576: this duplicate previously whitespace-split the string, mangling
+    ``result: dict[str, Any]`` into ``name='Any]', type='result: dict[str,'``.
+    Delegate to the shared helper (single source of truth) — it splits on the
+    first ``:`` and handles default values; fall back for the empty case.
+    """
+    from .analyze_code_structure_helpers import _parse_string_parameter
+
+    return _parse_string_parameter(param_str) or {"name": "param", "type": "Object"}
 
 
 def _get_method_parameters(method: Any) -> list[dict[str, str]]:


### PR DESCRIPTION
Closes #576.

## Problem (P2)
`structure analyze` carried a **duplicate** `_parse_string_param` that whitespace-split the parameter string:

```
'result: dict[str, Any]' → ['result:', 'dict[str,', 'Any]']
                         → name='Any]', type='result: dict[str,'
```

Every modern typed-Python param with a space in its generic (`dict[...]`, `Callable[...]`, `Optional[...]`) was inverted.

## Root cause — duplicate-logic drift
The shared helper `_parse_string_parameter` was **already fixed** (splits on the first `:`, handles defaults — the #581 work). The bug survived only in this **dead duplicate** in `analyze_code_structure_tool.py` (reachable via `_get_method_parameters`, which production no longer calls — the live path uses the helper's `get_method_parameters`). So #576's live impact was resolved, but the duplicate was a latent landmine.

## Fix
Delegate the duplicate to the helper — single source of truth, no more drift. (A fuller refactor-cleaner pass could delete the vestigial `_get_method_parameters` cluster entirely; noted as follow-up.)

## RED-first
`test_get_method_parameters_compound_generic_types` pins `dict[str, Any]` / `Callable[[int], str]` / `list[tuple[int, str]]` / default-valued forms; fails against the old whitespace split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)