### PR TITLE
fix: high-severity silent-failure and extraction bugs across analyzers and MCP tools

### DIFF
--- a/tests/golden_masters/compact/kotlin_sample_compact.md
+++ b/tests/golden_masters/compact/kotlin_sample_compact.md
@@ -6,7 +6,7 @@
 | Package | com.example.kotlin |
 | Classes | 8 |
 | Functions | 12 |
-| Properties | 4 |
+| Properties | 3 |
 
 ## Functions
 | Fn | Sig | V | S | L | Doc |

--- a/tests/golden_masters/csv/go_sample_csv.csv
+++ b/tests/golden_masters/csv/go_sample_csv.csv
@@ -8,6 +8,19 @@ Field,StatusRunning,StatusRunning:None,public,38-38,,-
 Field,StatusCompleted,StatusCompleted:None,public,39-39,,-
 Field,StatusFailed,StatusFailed:None,public,40-40,,-
 Field,lastErr,lastErr:error,private,281-281,,-
+Field,Host,Host:string,public,45-45,,-
+Field,Port,Port:int,public,46-46,,-
+Field,Timeout,Timeout:time.Duration,public,47-47,,-
+Field,Debug,Debug:bool,public,48-48,,-
+Field,metadata,metadata:map[string]string,private,49-49,,-
+Field,name,name:string,private,72-72,,-
+Field,config,config:*Config,private,73-73,,-
+Field,running,running:bool,private,74-74,,-
+Field,mu,mu:sync.RWMutex,private,75-75,,-
+Field,done,done:chan struct{},private,76-76,,-
+Field,workers,workers:int,private,207-207,,-
+Field,jobs,jobs:chan func(),private,208-208,,-
+Field,wg,wg:sync.WaitGroup,private,209-209,,-
 Method,Read,"([]byte:p):(n int, err error)",public,55-55,1,-
 Method,Write,"([]byte:p):(n int, err error)",public,61-61,1,-
 Method,NewService,"(string:name, *Config:config):*Service",public,80-86,1,-

--- a/tests/golden_masters/csv/kotlin_sample_csv.csv
+++ b/tests/golden_masters/csv/kotlin_sample_csv.csv
@@ -36,7 +36,6 @@ import java.util.Collections
 ## Properties
 | Name | Type | Vis | Kind | Line | Doc |
 |------|------|-----|------|------|-----|
-| unknown | Inferred | pub | - | 30 | - |
-| unknown | Inferred | pub | - | 48 | - |
-| unknown | Inferred | pub | - | 49 | - |
-| unknown | Inferred | pub | - | 63 | - |
+| userCount | Inferred | pub | - | 30 | - |
+| MAX_USERS | Inferred | pub | - | 48 | - |
+| version | Inferred | pub | - | 49 | - |

--- a/tests/golden_masters/full/go_sample_full.md
+++ b/tests/golden_masters/full/go_sample_full.md
@@ -75,3 +75,16 @@ import ""time""
 | StatusCompleted | - | exported | 39 |
 | StatusFailed | - | exported | 40 |
 | lastErr | error | unexported | 281 |
+| Host | string | exported | 45 |
+| Port | int | exported | 46 |
+| Timeout | time.Duration | exported | 47 |
+| Debug | bool | exported | 48 |
+| metadata | map[string]string | unexported | 49 |
+| name | string | unexported | 72 |
+| config | *Config | unexported | 73 |
+| running | bool | unexported | 74 |
+| mu | sync.RWMutex | unexported | 75 |
+| done | chan struct{} | unexported | 76 |
+| workers | int | unexported | 207 |
+| jobs | chan func() | unexported | 208 |
+| wg | sync.WaitGroup | unexported | 209 |

--- a/tests/golden_masters/full/kotlin_sample_full.md
+++ b/tests/golden_masters/full/kotlin_sample_full.md
@@ -36,7 +36,6 @@ import java.util.Collections
 ## Properties
 | Name | Type | Vis | Kind | Line | Doc |
 |------|------|-----|------|------|-----|
-| unknown | Inferred | pub | - | 30 | - |
-| unknown | Inferred | pub | - | 48 | - |
-| unknown | Inferred | pub | - | 49 | - |
-| unknown | Inferred | pub | - | 63 | - |
+| userCount | Inferred | pub | - | 30 | - |
+| MAX_USERS | Inferred | pub | - | 48 | - |
+| version | Inferred | pub | - | 49 | - |

--- a/tests/golden_masters/toon/go_sample_toon.toon
+++ b/tests/golden_masters/toon/go_sample_toon.toon
@@ -38,7 +38,7 @@ methods:
     WithTimeout,public,(267,275)
     WithRetry,public,(278,293)
 fields:
-  [9]{name,type,line_range(a,b)}:
+  [22]{name,type,line_range(a,b)}:
     ErrNotFound,,(21,21)
     DefaultTimeout,,(24,24)
     MaxRetries,,(28,28)
@@ -48,6 +48,19 @@ fields:
     StatusCompleted,,(39,39)
     StatusFailed,,(40,40)
     lastErr,,(281,281)
+    Host,,(45,45)
+    Port,,(46,46)
+    Timeout,,(47,47)
+    Debug,,(48,48)
+    metadata,,(49,49)
+    name,,(72,72)
+    config,,(73,73)
+    running,,(74,74)
+    mu,,(75,75)
+    done,,(76,76)
+    workers,,(207,207)
+    jobs,,(208,208)
+    wg,,(209,209)
 imports:
   [5]{name,module_name,statement,is_static,is_wildcard,line_range(a,b),imported_names,raw_text}:
     context,context,"\"context\"",false,false,(13,13),[],"\"context\""
@@ -58,7 +71,7 @@ imports:
 statistics:
   class_count: 10
   method_count: 20
-  field_count: 9
+  field_count: 22
   import_count: 5
   total_lines: 293
 effective_table: toon

--- a/tests/golden_masters/toon/kotlin_sample_toon.toon
+++ b/tests/golden_masters/toon/kotlin_sample_toon.toon
@@ -28,18 +28,17 @@ methods:
     get,public,(59,59)
     main,public,(62,65)
 fields:
-  [4]{name,type,line_range(a,b)}:
-    unknown,,(30,31)
-    unknown,,(48,48)
-    unknown,,(49,49)
-    unknown,,(63,63)
+  [3]{name,type,line_range(a,b)}:
+    userCount,,(30,31)
+    MAX_USERS,,(48,48)
+    version,,(49,49)
 imports:
   [1]{name,module_name,statement,is_static,is_wildcard,line_range(a,b),imported_names,raw_text}:
     java.util.Collections,java.util.Collections,import java.util.Collections,false,false,(3,3),[],import java.util.Collections
 statistics:
   class_count: 8
   method_count: 12
-  field_count: 4
+  field_count: 3
   import_count: 1
   total_lines: 65
 effective_table: toon

--- a/tests/unit/cli/test_advanced_command.py
+++ b/tests/unit/cli/test_advanced_command.py
@@ -443,6 +443,79 @@ class TestR37yCanonicalEnvelope:
         # mode=stats appears so callers can distinguish stats vs full mode.
         assert "mode=stats" in captured["summary_line"]
 
+    # -- H1 regression tests (REQ-E-001) --
+
+    def test_h1_syntax_error_file_emits_error_envelope_json(self, command):
+        """H1-CLI: broken file must emit parse-error envelope in JSON mode, not fabricated structure."""
+        import os
+        import tempfile  # noqa: E401
+
+        command.args.output_format = "json"
+        command.args.statistics = False
+
+        with tempfile.NamedTemporaryFile(
+            suffix=".py", mode="w", delete=False, encoding="utf-8"
+        ) as f:
+            f.write("def foo(:\n")  # intentional syntax error
+            broken = f.name
+
+        try:
+            command.args.file_path = broken
+            captured: dict[str, object] = {}
+            with (
+                patch(
+                    "tree_sitter_analyzer.mcp.tools.utils.parse_validity.is_file_parse_broken",
+                    return_value=True,
+                ),
+                patch(
+                    "tree_sitter_analyzer.cli.commands.advanced_command.output_json",
+                    side_effect=lambda d: captured.update(d),
+                ),
+            ):
+                import asyncio
+
+                rc = asyncio.run(command.execute_async("python"))
+            assert rc == 0
+            assert captured.get("verdict") == "ERROR", (
+                f"H1-CLI: expected verdict=ERROR for broken file, got {captured.get('verdict')}"
+            )
+            assert captured.get("signal") == "syntax_error", (
+                f"H1-CLI: expected signal=syntax_error, got {captured.get('signal')}"
+            )
+            # Must not return fabricated methods
+            assert "methods" not in captured or not captured["methods"]
+        finally:
+            os.unlink(broken)
+
+    def test_h1_clean_file_is_not_affected(self, command, mock_analysis_result):
+        """H1-CLI: clean file must proceed normally (not short-circuited)."""
+        command.args.output_format = "json"
+        command.args.statistics = False
+        command.args.file_path = "/some/clean.py"
+
+        full_captured: dict[str, object] = {}
+        with (
+            patch(
+                "tree_sitter_analyzer.mcp.tools.utils.parse_validity.is_file_parse_broken",
+                return_value=False,
+            ),
+            patch.object(
+                command,
+                "analyze_file",
+                return_value=mock_analysis_result,
+            ),
+            patch(
+                "tree_sitter_analyzer.cli.commands.advanced_command.output_json",
+                side_effect=lambda d: full_captured.update(d),
+            ),
+        ):
+            import asyncio
+
+            rc = asyncio.run(command.execute_async("python"))
+        assert rc == 0
+        # The clean file's normal output must have verdict=INFO (not ERROR)
+        assert full_captured.get("verdict") == "INFO"
+
     def test_full_mode_label_differs_from_stats(self, command, mock_analysis_result):
         """summary_line carries mode= label to distinguish dispatch paths."""
         command.args = MagicMock()

--- a/tests/unit/languages/test_go_plugin.py
+++ b/tests/unit/languages/test_go_plugin.py
@@ -368,6 +368,44 @@ class TestGoPluginIntegration:
 
 
 @pytest.mark.asyncio
+async def test_h2_struct_fields_extracted() -> None:
+    """H2 regression: struct fields must appear as Variable(element_type=field) elements.
+
+    Previously GoPlugin.analyze_file never called extract_struct_fields_as_variables
+    so field_count was always 0 for Go structs.
+    """
+    try:
+        import tree_sitter_go  # noqa: F401
+    except ImportError:
+        pytest.skip("tree-sitter-go not installed")
+
+    plugin = GoPlugin()
+    code = "package geo\n\ntype Point struct { X int; Y int }\n"
+
+    with patch(
+        "tree_sitter_analyzer.encoding_utils.read_file_safe",
+        return_value=(code, "utf-8"),
+    ):
+        result = await plugin.analyze_file("point.go", None)
+
+    assert result is not None
+    from tree_sitter_analyzer.models import Variable
+    fields = [
+        e for e in result.elements
+        if isinstance(e, Variable) and getattr(e, "element_type", "") == "variable"
+        and e.name in ("X", "Y")
+    ]
+    assert len(fields) == 2, (
+        f"Expected 2 struct fields (X, Y), got {[e.name for e in fields]}"
+    )
+    field_count = sum(
+        1 for e in result.elements
+        if isinstance(e, Variable) and e.name in ("X", "Y")
+    )
+    assert field_count == 2
+
+
+@pytest.mark.asyncio
 async def test_full_flow_go() -> None:
     """Basic integration test with sample code."""
     try:

--- a/tests/unit/languages/test_kotlin_plugin.py
+++ b/tests/unit/languages/test_kotlin_plugin.py
@@ -2478,3 +2478,91 @@ fun processUser() {
         result = plugin.extract_elements(tree, code)
         assert "functions" in result
         assert "classes" in result
+
+
+# ---------------------------------------------------------------------------
+# H4 regression tests (REQ-E-004 / REQ-E-005)
+# ---------------------------------------------------------------------------
+
+
+class TestH4KotlinPropertyNameAndLocalExclusion:
+    """H4 regression: property name extraction and local val exclusion.
+
+    H4-A: tree-sitter-kotlin uses ``identifier`` inside variable_declaration;
+          ``child_by_field_name("name")`` returns None → name was "unknown".
+    H4-B: local val/var inside a function body was counted as a class field.
+    """
+
+    @pytest.fixture
+    def kotlin_parser(self):
+        import tree_sitter
+        import tree_sitter_kotlin
+
+        language = tree_sitter.Language(tree_sitter_kotlin.language())
+        return tree_sitter.Parser(language)
+
+    def test_class_property_name_is_not_unknown(self, kotlin_parser):
+        """H4-A: class-level val name must not be 'unknown'."""
+        from tree_sitter_analyzer.languages.kotlin_helpers import (
+            extract_kotlin_property,
+        )
+
+        code = "class C {\n    val dx: Int = 0\n}\n"
+        tree = kotlin_parser.parse(code.encode("utf-8"))
+
+        # Walk tree to find property_declaration nodes
+        found_names: list[str] = []
+
+        def walk(node: object) -> None:
+            from tree_sitter import Node  # noqa: PLC0415
+            assert isinstance(node, Node)
+            if node.type == "property_declaration":
+                prop = extract_kotlin_property(node, lambda n: n.text.decode("utf-8", errors="replace"))
+                if prop is not None:
+                    found_names.append(prop.name)
+            for child in node.children:
+                walk(child)
+
+        walk(tree.root_node)
+        assert len(found_names) == 1, f"Expected exactly one property, got {found_names}"
+        assert "unknown" not in found_names, (
+            f"H4-A regression: property names should not be 'unknown', got {found_names}"
+        )
+        assert "dx" in found_names, f"Expected 'dx' in {found_names}"
+
+    def test_function_local_val_is_excluded(self, kotlin_parser):
+        """H4-B: val inside function body must not be returned as a Variable."""
+        from tree_sitter_analyzer.languages.kotlin_helpers import (
+            extract_kotlin_property,
+        )
+
+        code = (
+            "class C {\n"
+            "    val classField: Int = 1\n"
+            "    fun doStuff() {\n"
+            "        val local = 42\n"
+            "    }\n"
+            "}\n"
+        )
+        tree = kotlin_parser.parse(code.encode("utf-8"))
+
+        extracted: list[object] = []
+
+        def walk(node: object) -> None:
+            from tree_sitter import Node  # noqa: PLC0415
+            assert isinstance(node, Node)
+            if node.type == "property_declaration":
+                prop = extract_kotlin_property(node, lambda n: n.text.decode("utf-8", errors="replace"))
+                if prop is not None:
+                    extracted.append(prop)
+            for child in node.children:
+                walk(child)
+
+        walk(tree.root_node)
+        names = [p.name for p in extracted]  # type: ignore[union-attr]
+        assert "local" not in names, (
+            f"H4-B regression: function-local val 'local' must not be extracted, got {names}"
+        )
+        assert "classField" in names, (
+            f"H4-B: class-level 'classField' must still be extracted, got {names}"
+        )

--- a/tests/unit/mcp/tools/test_class_inspect_tool.py
+++ b/tests/unit/mcp/tools/test_class_inspect_tool.py
@@ -326,11 +326,23 @@ class TestBaseMCPToolClosureRegression:
 
 class TestEdgeCases:
     def test_not_found_class_returns_not_found_verdict(self, tmp_path: Path) -> None:
-        """Asking for a class that doesn't exist returns NOT_FOUND verdict."""
+        """Asking for a class that doesn't exist returns NOT_FOUND verdict.
+
+        H7 update: the index must be non-empty for NOT_FOUND to trigger (an
+        empty index returns NEEDS_INDEX instead — see H7 regression tests).
+        We index a real file so the index is populated, then ask for a class
+        that doesn't exist.
+        """
         from tree_sitter_analyzer.ast_cache import ASTCache
 
         project_root = str(tmp_path)
-        ASTCache(project_root)  # Ensure cache is created
+        # Create and index a real file so the index is non-empty
+        src = tmp_path / "dummy.py"
+        src.write_text("class Dummy:\n    pass\n", encoding="utf-8")
+        cache = ASTCache(project_root)
+        idx_result = cache.index_file(str(src), language="python")
+        assert idx_result.get("status") in ("ok", "indexed", "unchanged")
+
         tool = ClassInspectTool(project_root)
         response = _run(
             tool.execute(
@@ -1087,3 +1099,53 @@ class TestSameNameClassScoped:
         r = self._run_widget(tmp_path, a, b)
         assert r["method_count"] == 1
         assert [m["name"] for m in r["methods"]] == ["render"]
+
+
+# ---------------------------------------------------------------------------
+# H7 regression: NEEDS_INDEX when index is not built (REQ-E-008)
+# ---------------------------------------------------------------------------
+
+
+def test_h7_needs_index_when_no_index_built(tmp_path: Path) -> None:
+    """H7 regression: class_detail must return NEEDS_INDEX verdict when the
+    AST index has not been built (empty ast_index table), instead of a
+    spurious NOT_FOUND with method_count=0 for every class name.
+    """
+    tool = ClassInspectTool(str(tmp_path))
+    response = _run(tool.execute({"class_name": "MyClass", "output_format": "json"}))
+
+    assert response["success"] is True, f"Expected success=True, got {response}"
+    assert response["verdict"] == "NEEDS_INDEX", (
+        f"H7 regression: expected NEEDS_INDEX for unbuilt index, got verdict={response.get('verdict')}"
+    )
+    assert response["method_count"] == 0
+    assert "agent_summary" in response
+    assert response["agent_summary"]["verdict"] == "NEEDS_INDEX"
+    # next_step must guide agent to build the index
+    next_step = response["agent_summary"].get("next_step", "")
+    assert "index" in next_step.lower(), (
+        f"H7: next_step must mention 'index', got '{next_step}'"
+    )
+
+
+def test_h7_normal_lookup_after_index_built(tmp_path: Path) -> None:
+    """H7 follow-up: after indexing, class_detail returns the real class (not NEEDS_INDEX)."""
+    from tree_sitter_analyzer.ast_cache import ASTCache
+
+    src = tmp_path / "animals.py"
+    src.write_text(
+        "class Animal:\n    def speak(self) -> str:\n        return ''\n",
+        encoding="utf-8",
+    )
+    cache = ASTCache(str(tmp_path))
+    result = cache.index_file(str(src), language="python")
+    assert result.get("status") in ("ok", "indexed", "unchanged")
+
+    tool = ClassInspectTool(str(tmp_path))
+    response = _run(tool.execute({"class_name": "Animal", "output_format": "json"}))
+
+    assert response["success"] is True
+    assert response["verdict"] != "NEEDS_INDEX", (
+        "H7: after indexing, verdict must not be NEEDS_INDEX"
+    )
+    assert response["verdict"] == "INFO"

--- a/tests/unit/mcp/tools/test_h5_find_and_grep_dedup.py
+++ b/tests/unit/mcp/tools/test_h5_find_and_grep_dedup.py
@@ -1,0 +1,198 @@
+"""H5 regression tests: find_and_grep deduplication via exact file paths.
+
+H5 bug: fd discovers files and the old code passed parent directories + filename
+globs to ripgrep.  When the same filename exists in a parent dir AND a subdir,
+rg would match in both, producing double-counted results.
+
+Fix: pass exact deduplicated file paths as positional arguments to rg, not parent
+dirs.  ripgrep does not support --files-from; positional args are the correct API.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Unit tests for build_rg_command_from_arguments (no rg subprocess)
+# ---------------------------------------------------------------------------
+
+
+def test_build_rg_command_uses_file_paths_not_roots() -> None:
+    """H5: build_rg_command_from_arguments must pass file_paths, not roots."""
+    from tree_sitter_analyzer.mcp.tools.find_and_grep_execution import (
+        build_rg_command_from_arguments,
+    )
+
+    files = ["/repo/a/foo.py", "/repo/b/bar.py"]
+    args = {
+        "query": "TODO",
+        "case": "smart",
+    }
+    cmd = build_rg_command_from_arguments(args, files)
+
+    # The query must appear in the command
+    assert "TODO" in cmd, f"query not found in cmd: {cmd}"
+
+    # The exact file paths must appear as positional args after the query
+    query_idx = cmd.index("TODO")
+    positional = cmd[query_idx + 1 :]
+    assert "/repo/a/foo.py" in positional, f"file path not in positional args: {cmd}"
+    assert "/repo/b/bar.py" in positional, f"file path not in positional args: {cmd}"
+
+    # No parent directory should appear as a root
+    assert "/repo/a" not in cmd, f"parent dir leaked into cmd: {cmd}"
+    assert "/repo/b" not in cmd, f"parent dir leaked into cmd: {cmd}"
+
+
+def test_build_rg_command_deduplicates_paths() -> None:
+    """H5: duplicate file paths are deduplicated before passing to rg."""
+    from tree_sitter_analyzer.mcp.tools.find_and_grep_execution import (
+        build_rg_command_from_arguments,
+    )
+
+    files = ["/repo/a/foo.py", "/repo/a/foo.py", "/repo/b/bar.py"]
+    args = {"query": "TODO", "case": "smart"}
+    cmd = build_rg_command_from_arguments(args, files)
+
+    query_idx = cmd.index("TODO")
+    positional = cmd[query_idx + 1 :]
+    assert positional.count("/repo/a/foo.py") == 1, (
+        f"H5: duplicate paths not deduplicated: {positional}"
+    )
+
+
+def test_fd_rg_utils_build_rg_command_file_paths_param() -> None:
+    """H5: build_rg_command accepts file_paths and appends them after query."""
+    from tree_sitter_analyzer.mcp.tools.fd_rg_utils import build_rg_command
+
+    cmd = build_rg_command(
+        query="FIXME",
+        case="smart",
+        fixed_strings=False,
+        word=False,
+        multiline=False,
+        include_globs=None,
+        exclude_globs=None,
+        follow_symlinks=False,
+        hidden=False,
+        no_ignore=False,
+        max_filesize=None,
+        context_before=None,
+        context_after=None,
+        encoding=None,
+        max_count=None,
+        timeout_ms=None,
+        roots=None,
+        file_paths=["/a/foo.py", "/b/bar.py"],
+    )
+    query_idx = cmd.index("FIXME")
+    assert cmd[query_idx + 1 :] == ["/a/foo.py", "/b/bar.py"], (
+        f"file_paths not appended correctly: {cmd}"
+    )
+
+
+def test_fd_rg_utils_roots_ignored_when_file_paths_given() -> None:
+    """H5: when file_paths is provided, roots must be ignored to avoid double-counting."""
+    from tree_sitter_analyzer.mcp.tools.fd_rg_utils import build_rg_command
+
+    cmd = build_rg_command(
+        query="TODO",
+        case=None,
+        fixed_strings=False,
+        word=False,
+        multiline=False,
+        include_globs=None,
+        exclude_globs=None,
+        follow_symlinks=False,
+        hidden=False,
+        no_ignore=False,
+        max_filesize=None,
+        context_before=None,
+        context_after=None,
+        encoding=None,
+        max_count=None,
+        timeout_ms=None,
+        roots=["/repo"],
+        file_paths=["/repo/sub/foo.py"],
+    )
+    # roots="/repo" must NOT appear; only /repo/sub/foo.py should be in positional
+    assert "/repo" not in cmd[cmd.index("TODO") + 1 :] or "/repo/sub/foo.py" in cmd, (
+        f"roots leaked despite file_paths being provided: {cmd}"
+    )
+    query_idx = cmd.index("TODO")
+    positional = cmd[query_idx + 1 :]
+    assert "/repo/sub/foo.py" in positional
+
+
+# ---------------------------------------------------------------------------
+# Integration test with real rg subprocess
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    shutil.which("rg") is None,
+    reason="ripgrep (rg) not installed — skipping real-subprocess test",
+)
+def test_h5_real_rg_no_double_count(tmp_path: Path) -> None:
+    """H5 integration: rg receives exact file paths and does NOT double-count.
+
+    Layout:
+        tmp/foo.py         (contains 1 TODO)
+        tmp/sub/foo.py     (contains 1 TODO)
+        tmp/other.py       (contains 1 TODO)
+
+    fd discovers 3 files.  The old code passed [tmp, tmp/sub] as roots with
+    glob ``foo.py``, which caused rg to match tmp/foo.py twice (once via tmp
+    root and once via tmp/sub root) — total 5 matches instead of 3.
+
+    The fix passes exact paths; rg must return exactly 3 matches.
+    """
+    # Create files
+    (tmp_path / "foo.py").write_text("# TODO: fix this\n", encoding="utf-8")
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "foo.py").write_text("# TODO: fix that\n", encoding="utf-8")
+    (tmp_path / "other.py").write_text("# TODO: fix other\n", encoding="utf-8")
+
+    files = [
+        str(tmp_path / "foo.py"),
+        str(sub / "foo.py"),
+        str(tmp_path / "other.py"),
+    ]
+
+    from tree_sitter_analyzer.mcp.tools.find_and_grep_execution import (
+        build_rg_command_from_arguments,
+    )
+
+    args = {
+        "query": "TODO",
+        "case": "smart",
+        "fixed_strings": False,
+    }
+    cmd = build_rg_command_from_arguments(args, files)
+
+    proc = subprocess.run(cmd, capture_output=True, timeout=10)  # noqa: S603
+    # rc 0 = matches found, rc 1 = no matches
+    assert proc.returncode in (0, 1), (
+        f"rg failed (rc={proc.returncode}): {proc.stderr.decode()}"
+    )
+
+    import json
+
+    matches = []
+    for line in proc.stdout.splitlines():
+        try:
+            event = json.loads(line)
+            if event.get("type") == "match":
+                matches.append(event)
+        except (json.JSONDecodeError, KeyError):
+            continue
+
+    assert len(matches) == 3, (
+        f"H5 regression: expected 3 matches (one per file), got {len(matches)}. "
+        f"Matches: {[m['data']['path'] for m in matches]}"
+    )

--- a/tests/unit/mcp/tools/test_h6_uml_verdict.py
+++ b/tests/unit/mcp/tools/test_h6_uml_verdict.py
@@ -1,0 +1,120 @@
+"""H6 regression tests: viz uml verdict for single node (no edges).
+
+H6 bug: a diagram with nodes but no edges returned verdict=NOT_FOUND because
+the logic was ``"INFO" if diagram.edges else "NOT_FOUND"``.
+
+Fix: verdict is INFO when ``not_found==False AND node_count >= 1``, regardless
+of whether the diagram has edges.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+
+class _FakeDiagram:
+    """Minimal diagram object mirroring the interface used in CodeGraphUMLTool."""
+
+    def __init__(
+        self,
+        *,
+        edges: list | None = None,
+        nodes: list | None = None,
+        metadata: dict | None = None,
+    ) -> None:
+        self.edges = edges or []
+        self.nodes = nodes or []
+        self.metadata = metadata or {}
+
+    def to_dict(self) -> dict:
+        return {
+            "nodes": [str(n) for n in self.nodes],
+            "edges": [str(e) for e in self.edges],
+            "metadata": self.metadata,
+        }
+
+
+def _run_uml_execute(diagram: _FakeDiagram) -> dict:
+    """Invoke CodeGraphUMLTool.execute with a pre-baked diagram, patching the exporter."""
+    from tree_sitter_analyzer.mcp.tools.uml_tool import CodeGraphUMLTool
+
+    tool = CodeGraphUMLTool(project_root="/fake")
+
+    # Build a mock exporter that returns our fake diagram for any diagram type
+    mock_exporter = MagicMock()
+    mock_exporter.class_diagram.return_value = diagram
+
+    # Patch CodeGraphVisualizationHub so it returns our mock exporter
+    mock_hub = MagicMock()
+    mock_hub.uml_exporter.return_value = mock_exporter
+
+    with patch(
+        "tree_sitter_analyzer.mcp.tools.uml_tool.CodeGraphVisualizationHub",
+        return_value=mock_hub,
+    ):
+        return asyncio.run(
+            tool.execute(
+                {
+                    "diagram": "class",
+                    "class_name": "MyClass",
+                    "output_format": "json",
+                }
+            )
+        )
+
+
+def test_h6_single_class_no_edges_returns_info() -> None:
+    """H6 regression: a diagram with 1 node and 0 edges must return INFO, not NOT_FOUND."""
+    diagram = _FakeDiagram(
+        nodes=["MyClass"],
+        edges=[],
+        metadata={"not_found": False},
+    )
+    result = _run_uml_execute(diagram)
+
+    assert result.get("verdict") == "INFO", (
+        f"H6 regression: single node diagram should return INFO, got {result.get('verdict')}"
+    )
+
+
+def test_h6_no_nodes_no_edges_returns_not_found() -> None:
+    """H6: when neither nodes nor edges are present, NOT_FOUND must be returned."""
+    diagram = _FakeDiagram(
+        nodes=[],
+        edges=[],
+        metadata={"not_found": False},
+    )
+    result = _run_uml_execute(diagram)
+
+    assert result.get("verdict") == "NOT_FOUND", (
+        f"H6: empty diagram (no nodes or edges) should return NOT_FOUND, got {result.get('verdict')}"
+    )
+
+
+def test_h6_not_found_flag_overrides_nodes() -> None:
+    """H6: when not_found==True in metadata, verdict must be NOT_FOUND even with nodes."""
+    diagram = _FakeDiagram(
+        nodes=["SomeClass"],
+        edges=[],
+        metadata={"not_found": True},
+    )
+    result = _run_uml_execute(diagram)
+
+    assert result.get("verdict") == "NOT_FOUND", (
+        f"H6: not_found=True should still yield NOT_FOUND, got {result.get('verdict')}"
+    )
+
+
+def test_h6_edges_present_returns_info() -> None:
+    """H6: existing test must still pass — edges also trigger INFO."""
+    diagram = _FakeDiagram(
+        nodes=["ClassA", "ClassB"],
+        edges=[("ClassA", "ClassB")],
+        metadata={"not_found": False},
+    )
+    result = _run_uml_execute(diagram)
+
+    assert result.get("verdict") == "INFO", (
+        f"H6: diagram with edges should return INFO, got {result.get('verdict')}"
+    )

--- a/tree_sitter_analyzer/cli/commands/advanced_command.py
+++ b/tree_sitter_analyzer/cli/commands/advanced_command.py
@@ -17,7 +17,11 @@ from ...constants import (
     get_element_type,
     is_element_of_type,
 )
-from ...output_manager import output_data, output_json, output_section
+from ...mcp.tools.utils.parse_validity import (
+    is_file_parse_broken,
+    syntax_error_envelope,
+)
+from ...output_manager import output_data, output_error, output_json, output_section
 from .advanced_command_helpers import calculate_file_metrics
 from .base_command import BaseCommand
 
@@ -180,6 +184,15 @@ class AdvancedCommand(BaseCommand):
     """Command for advanced analysis."""
 
     async def execute_async(self, language: str) -> int:
+        # H1 (REQ-E-001): detect syntax errors before proceeding with analysis.
+        # Tree-sitter builds a partial AST for any input; without this gate the
+        # CLI returns fabricated structure data for files that fail to parse.
+        # Mirrors the same short-circuit added to MCP analyze_code_structure_tool.
+        file_path = getattr(self.args, "file_path", "") or ""
+        if is_file_parse_broken(file_path, language):
+            self._output_syntax_error(file_path)
+            return 0
+
         analysis_result = await self.analyze_file(language)
         if not analysis_result:
             return 1
@@ -190,6 +203,32 @@ class AdvancedCommand(BaseCommand):
             self._output_full_analysis(analysis_result)
 
         return 0
+
+    def _output_syntax_error(self, file_path: str) -> None:
+        """Emit canonical syntax-error envelope when the file fails to parse.
+
+        H1 (REQ-E-001): consistent with MCP analyze_code_structure short-circuit.
+        success=True / verdict=WARN / signal=syntax_error / parse_errors=True.
+        """
+        output_format = getattr(self.args, "output_format", "text")
+        envelope = syntax_error_envelope(
+            file_path,
+            tool="advanced_command",
+            output_format=output_format,
+        )
+        if output_format == "json":
+            output_json(envelope)
+            return
+        if output_format == "toon" and _toon_available:
+            use_tabs = getattr(self.args, "toon_use_tabs", False)
+            formatter = ToonFormatter(use_tabs=use_tabs)
+            print(formatter.format(envelope))
+            return
+        # Text / fallback — emit to stderr so stdout stays unpolluted
+        output_error(
+            f"Syntax error detected in '{file_path}': "
+            "file fails to parse — fix syntax before further analysis"
+        )
 
     def _calculate_file_metrics(self, file_path: str, language: str) -> dict[str, int]:
         """

--- a/tree_sitter_analyzer/languages/_go_type_helpers.py
+++ b/tree_sitter_analyzer/languages/_go_type_helpers.py
@@ -154,3 +154,60 @@ def _iter_type_specs(node: Any) -> list[Any]:
     return [
         child for child in node.children if child.type in ("type_spec", "type_alias")
     ]
+
+
+def _extract_field_name(field: Any, get_node_text: Callable[..., str]) -> str:
+    """Return the name of a struct field node.
+
+    Named field:    field_identifier is the first named child.
+    Embedded field: type_identifier / qualified_type gives the type name,
+                    which is also used as the field name (Go convention).
+    """
+    for child in field.children:
+        if child.type == "field_identifier":
+            return get_node_text(child)
+    # Embedded (anonymous) field: fall back to type name.
+    for child in field.children:
+        if child.type in ("type_identifier", "qualified_type", "pointer_type"):
+            return get_node_text(child)
+    return "unknown"
+
+
+def _extract_field_type(field: Any, get_node_text: Callable[..., str]) -> str:
+    """Return the type text of a struct field node, skipping the name."""
+    skip_types = {"field_identifier", "comment", "tag_literal"}
+    for child in field.children:
+        if child.type not in skip_types:
+            return get_node_text(child)
+    return ""
+
+
+def extract_struct_fields(
+    struct_node: Any,
+    get_node_text: Callable[..., str],
+) -> "list[Any]":
+    """Extract named and embedded fields from a Go struct_type node.
+
+    H2 (REQ-U-002): Returns a list of Variable objects so the caller can
+    append them to the AnalysisResult.elements list.  This matches the
+    Java pattern where fields are top-level Variable elements with
+    element_type='variable'.
+    """
+    from ..models import Variable
+
+    fields = []
+    for field in _iter_struct_fields(struct_node):
+        name = _extract_field_name(field, get_node_text)
+        type_text = _extract_field_type(field, get_node_text)
+        fields.append(
+            Variable(
+                name=name,
+                start_line=field.start_point[0] + 1,
+                end_line=field.end_point[0] + 1,
+                raw_text=get_node_text(field),
+                variable_type=type_text,
+                visibility=go_visibility(name),
+                element_type="variable",
+            )
+        )
+    return fields

--- a/tree_sitter_analyzer/languages/go_plugin.py
+++ b/tree_sitter_analyzer/languages/go_plugin.py
@@ -269,6 +269,37 @@ class GoElementExtractor(ElementExtractor):
             node, self._get_node_text, self.content_lines
         )
 
+    # Extract elements from AST: extract_struct_fields_as_variables
+    def extract_struct_fields_as_variables(
+        self, tree: tree_sitter.Tree, source_code: str
+    ) -> list[Variable]:
+        """Extract struct field declarations as Variable elements.
+
+        H2 (REQ-U-002): Walk the AST and collect field_declaration nodes
+        inside struct_type bodies.  Returns Variable objects so they appear
+        in AnalysisResult.elements and are counted by field_count.
+        """
+        from ._go_type_helpers import extract_struct_fields
+
+        self.source_code = source_code
+        self.content_lines = source_code.split("\n")
+        fields: list[Variable] = []
+        self._collect_struct_fields(tree.root_node, fields, extract_struct_fields)
+        return fields
+
+    def _collect_struct_fields(
+        self,
+        node: Any,
+        results: list[Variable],
+        extract_fn: Any,
+    ) -> None:
+        """Recursively walk the AST and collect struct fields."""
+        if node.type == "struct_type":
+            results.extend(extract_fn(node, self._get_node_text))
+            return  # do not descend into struct — fields are already collected
+        for child in node.children:
+            self._collect_struct_fields(child, results, extract_fn)
+
     # Extract elements from AST: _extract_embedded_types
     def _extract_embedded_types(self, struct_node: tree_sitter.Node) -> list[str]:
         """Extract embedded types from struct"""
@@ -457,6 +488,12 @@ class GoPlugin(LanguagePlugin):
             all_elements.extend(extractor.extract_functions(tree, file_content))
             all_elements.extend(extractor.extract_classes(tree, file_content))
             all_elements.extend(extractor.extract_variables(tree, file_content))
+            # H2 (REQ-U-002): extract struct fields as Variable elements so
+            # field_count is populated (Java-consistent behaviour).
+            if isinstance(extractor, GoElementExtractor):
+                all_elements.extend(
+                    extractor.extract_struct_fields_as_variables(tree, file_content)
+                )
 
             node_count = (
                 self._count_tree_nodes(tree.root_node) if tree and tree.root_node else 0

--- a/tree_sitter_analyzer/languages/kotlin_helpers.py
+++ b/tree_sitter_analyzer/languages/kotlin_helpers.py
@@ -599,7 +599,12 @@ def _extract_kotlin_property_name(
 
     r37ci (dogfood): extracted from ``extract_kotlin_property`` so the
     three lookup forms (``name`` field / ``variable_declaration`` /
-    ``simple_identifier``) read as a flat chain.
+    ``simple_identifier`` / ``identifier``) read as a flat chain.
+
+    H4-A (REQ-E-004): tree-sitter-kotlin uses ``identifier`` (not
+    ``simple_identifier``) inside ``variable_declaration`` for property
+    names.  Both node types are now accepted so the fix works across
+    grammar versions.
     """
     name_node = node.child_by_field_name("name")
     if name_node:
@@ -607,11 +612,33 @@ def _extract_kotlin_property_name(
     for child in node.children:
         if child.type == "variable_declaration":
             for grandchild in child.children:
-                if grandchild.type == "simple_identifier":
+                if grandchild.type in ("simple_identifier", "identifier"):
                     return str(get_node_text(grandchild))
-        elif child.type == "simple_identifier":
+        elif child.type in ("simple_identifier", "identifier"):
             return str(get_node_text(child))
     return "unknown"
+
+
+def _is_inside_function_body(node: Any) -> bool:
+    """Return True if *node* is nested inside a ``function_declaration``.
+
+    H4-B (REQ-E-005): Only function-local vals are excluded.  Top-level vals
+    (parent chain reaches ``source_file`` first) are kept as-is.
+
+    Depth-capped at 256 to match ``_kotlin_owning_type`` safety guard.
+    """
+    parent = node.parent
+    for _ in range(256):
+        if parent is None:
+            return False
+        if parent.type == "source_file":
+            return False
+        if parent.type in ("class_declaration", "object_declaration", "companion_object"):
+            return False
+        if parent.type in ("function_declaration", "anonymous_function"):
+            return True
+        parent = parent.parent
+    return False
 
 
 # Extract elements from AST: extract_kotlin_property
@@ -619,8 +646,18 @@ def extract_kotlin_property(
     node: Any,
     get_node_text: Callable[..., str],
 ) -> Variable | None:
-    """Extract Kotlin property declaration."""
+    """Extract Kotlin property declaration.
+
+    H4-B (REQ-E-005): local ``val``/``var`` declarations inside a
+    ``function_declaration`` body must not be returned as variables.
+    Top-level and class-level vals are kept.  Companion-object vals are
+    class-level constants and are also kept.
+    """
     try:
+        # H4-B: skip properties that are local to a function body.
+        if _is_inside_function_body(node):
+            return None
+
         is_val = False
         is_var = False
         text = get_node_text(node)

--- a/tree_sitter_analyzer/mcp/tools/class_inspect_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/class_inspect_tool.py
@@ -498,6 +498,21 @@ class ClassInspectTool(BaseMCPTool):
 
         return {"available": True, "methods": inherited}
 
+    def _is_index_empty(self, cache: ASTCache) -> bool:
+        """Return True when ast_index table is absent or has no rows.
+
+        H7 (REQ-E-008): Detects the case where `index full` has not been
+        run yet so the tool can return NEEDS_INDEX instead of a spurious
+        NOT_FOUND for every class.
+        """
+        try:
+            conn = cache.get_conn()
+            count = conn.execute("SELECT COUNT(*) FROM ast_index").fetchone()[0]
+            return bool(count == 0)
+        except Exception:
+            # Table does not exist or DB not accessible — treat as empty.
+            return True
+
     async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
         self.validate_arguments(arguments)
 
@@ -505,6 +520,32 @@ class ClassInspectTool(BaseMCPTool):
         output_format: str = arguments.get("output_format", "toon")
 
         cache = self._get_cache()
+
+        # H7 (REQ-E-008): Detect an unbuilt index before trying to resolve
+        # the class — otherwise every class looks like NOT_FOUND.
+        if self._is_index_empty(cache):
+            from ..utils.format_helper import apply_toon_format_to_response
+
+            needs_index: dict[str, Any] = {
+                "success": True,
+                "verdict": "NEEDS_INDEX",
+                "class_name": class_name,
+                "message": (
+                    "AST index is not built yet. "
+                    "Run 'index full' to build it."
+                ),
+                "methods": [],
+                "method_count": 0,
+                "fields": [],
+                "extends": [],
+                "agent_summary": {
+                    "verdict": "NEEDS_INDEX",
+                    "summary_line": "AST index not found — run index full first",
+                    "next_step": "run index full to build the ast cache",
+                },
+            }
+            return apply_toon_format_to_response(needs_index, output_format)
+
         hierarchy = ClassHierarchy(cache)
         hierarchy.build()
 

--- a/tree_sitter_analyzer/mcp/tools/fd_rg_utils.py
+++ b/tree_sitter_analyzer/mcp/tools/fd_rg_utils.py
@@ -283,7 +283,8 @@ def build_rg_command(
     max_count: int | None,
     timeout_ms: int | None,
     roots: list[str] | None,
-    files_from: str | None,
+    files_from: str | None = None,
+    file_paths: list[str] | None = None,
     count_only_matches: bool = False,
     # rg-native power flags added 2026-05-23 after the capability audit
     # (docs/internal/RG_FD_GAP_AUDIT.md). All default to off / None so
@@ -409,7 +410,20 @@ def build_rg_command(
 
     cmd.append(query)
 
-    if roots:
+    # H5 fix (REQ-U-006): ripgrep does NOT support --files-from.
+    # The correct way to pass an exact file list is as positional arguments.
+    # When file_paths is provided, deduplicate (preserving order) and append
+    # them after the query.  roots is ignored so fd's exact file list is
+    # used without directory-expansion double-counting.
+    if file_paths:
+        seen: set[str] = set()
+        deduped: list[str] = []
+        for p in file_paths:
+            if p not in seen:
+                seen.add(p)
+                deduped.append(p)
+        cmd += deduped
+    elif roots:
         cmd += roots
 
     return cmd

--- a/tree_sitter_analyzer/mcp/tools/find_and_grep_execution.py
+++ b/tree_sitter_analyzer/mcp/tools/find_and_grep_execution.py
@@ -142,10 +142,18 @@ def build_rg_command_from_arguments(
     arguments: dict[str, Any],
     files: list[str],
 ) -> list[str]:
-    """Build the ripgrep command for the discovered files."""
-    parent_dirs, file_globs = _build_rg_targets(files)
-    combined_globs = (arguments.get("include_globs") or []) + file_globs
+    """Build the ripgrep command for the discovered files.
+
+    H5 fix (REQ-U-006): Pass exact file paths as positional arguments to rg.
+    ripgrep does NOT support --files-from; appending deduplicated paths after
+    the query is the correct way to eliminate parent-dir double-counting.
+
+    For very large file lists the caller should use
+    ``build_rg_commands_batched`` which chunks the list to avoid OS
+    command-line length limits and merges results.
+    """
     no_ignore = bool(arguments.get("no_ignore", False))
+    include_globs = arguments.get("include_globs") or []
 
     return fd_rg_utils.build_rg_command(
         query=arguments["query"],
@@ -153,7 +161,7 @@ def build_rg_command_from_arguments(
         fixed_strings=bool(arguments.get("fixed_strings", False)),
         word=bool(arguments.get("word", False)),
         multiline=bool(arguments.get("multiline", False)),
-        include_globs=combined_globs,
+        include_globs=include_globs,
         exclude_globs=arguments.get("exclude_globs"),
         follow_symlinks=bool(arguments.get("follow_symlinks", False)),
         hidden=bool(arguments.get("hidden", False)),
@@ -164,11 +172,79 @@ def build_rg_command_from_arguments(
         encoding=arguments.get("encoding"),
         max_count=arguments.get("max_count"),
         timeout_ms=arguments.get("timeout_ms"),
-        roots=list(parent_dirs),
-        files_from=None,
+        roots=None,
+        file_paths=files,
         count_only_matches=bool(arguments.get("count_only_matches", False))
         or bool(arguments.get("total_only", False)),
     )
+
+
+# OS command-line length limit guard: on Windows the practical limit is
+# ~8 191 characters; on Linux/macOS ~2 MB.  Use a conservative path-budget
+# (characters, not bytes) so we never hit the limit on any platform.
+_RG_PATH_CHUNK_CHARS = 6000
+
+
+def build_rg_commands_batched(
+    arguments: dict[str, Any],
+    files: list[str],
+    *,
+    count_only: bool = False,
+) -> list[list[str]]:
+    """Split a large file list into batches and return one rg command per batch.
+
+    Each batch's total path length stays under ``_RG_PATH_CHUNK_CHARS`` so we
+    never exceed OS command-line limits.  For small lists this returns a single
+    command identical to ``build_rg_command_from_arguments``.
+    """
+    if not files:
+        return []
+
+    batches: list[list[str]] = []
+    current_batch: list[str] = []
+    current_len = 0
+
+    for path in files:
+        path_len = len(path) + 1  # +1 for the space separator
+        if current_batch and current_len + path_len > _RG_PATH_CHUNK_CHARS:
+            batches.append(current_batch)
+            current_batch = [path]
+            current_len = path_len
+        else:
+            current_batch.append(path)
+            current_len += path_len
+
+    if current_batch:
+        batches.append(current_batch)
+
+    no_ignore = bool(arguments.get("no_ignore", False))
+    include_globs = arguments.get("include_globs") or []
+
+    cmds: list[list[str]] = []
+    for batch in batches:
+        cmd = fd_rg_utils.build_rg_command(
+            query=arguments["query"],
+            case=arguments.get("case", "smart"),
+            fixed_strings=bool(arguments.get("fixed_strings", False)),
+            word=bool(arguments.get("word", False)),
+            multiline=bool(arguments.get("multiline", False)),
+            include_globs=include_globs,
+            exclude_globs=arguments.get("exclude_globs"),
+            follow_symlinks=bool(arguments.get("follow_symlinks", False)),
+            hidden=bool(arguments.get("hidden", False)),
+            no_ignore=no_ignore,
+            max_filesize=arguments.get("max_filesize"),
+            context_before=arguments.get("context_before"),
+            context_after=arguments.get("context_after"),
+            encoding=arguments.get("encoding"),
+            max_count=arguments.get("max_count"),
+            timeout_ms=arguments.get("timeout_ms"),
+            roots=None,
+            file_paths=batch,
+            count_only_matches=count_only,
+        )
+        cmds.append(cmd)
+    return cmds
 
 
 def build_rg_error_response(err: bytes, rc: int) -> dict[str, Any]:
@@ -215,10 +291,12 @@ def build_rg_recount_command(
     and ``count_only_matches=True`` so the response counts every match (no
     per-file truncation). Used to compute the honest pre-truncation total
     when ``apply_match_limits`` truncated the primary pass.
+
+    H5 fix (REQ-U-006): Passes exact file paths as positional arguments to
+    eliminate double-counting.  No temp file needed.
     """
-    parent_dirs, file_globs = _build_rg_targets(files)
-    combined_globs = (arguments.get("include_globs") or []) + file_globs
     no_ignore = bool(arguments.get("no_ignore", False))
+    include_globs = arguments.get("include_globs") or []
 
     return fd_rg_utils.build_rg_command(
         query=arguments["query"],
@@ -226,7 +304,7 @@ def build_rg_recount_command(
         fixed_strings=bool(arguments.get("fixed_strings", False)),
         word=bool(arguments.get("word", False)),
         multiline=bool(arguments.get("multiline", False)),
-        include_globs=combined_globs,
+        include_globs=include_globs,
         exclude_globs=arguments.get("exclude_globs"),
         follow_symlinks=bool(arguments.get("follow_symlinks", False)),
         hidden=bool(arguments.get("hidden", False)),
@@ -237,8 +315,8 @@ def build_rg_recount_command(
         encoding=arguments.get("encoding"),
         max_count=None,
         timeout_ms=arguments.get("timeout_ms"),
-        roots=list(parent_dirs),
-        files_from=None,
+        roots=None,
+        file_paths=files,
         count_only_matches=True,
     )
 

--- a/tree_sitter_analyzer/mcp/tools/uml_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/uml_tool.py
@@ -242,8 +242,15 @@ class CodeGraphUMLTool(BaseMCPTool):
             # P2-1: an unknown class_name is NOT_FOUND even if the project has
             # edges; agents must distinguish "no such class" from "no neighbours".
             not_found = diagram.metadata.get("not_found", False)
+            # H6 (REQ-E-007): A diagram with nodes but no edges is still INFO
+            # (e.g. a single standalone class). Only flag NOT_FOUND when the
+            # target was genuinely absent (not_found==True) OR when neither
+            # nodes nor edges were produced.
+            node_count = len(diagram.nodes) if hasattr(diagram, "nodes") else 0
             verdict = (
-                "NOT_FOUND" if not_found else ("INFO" if diagram.edges else "NOT_FOUND")
+                "NOT_FOUND"
+                if not_found
+                else ("INFO" if (diagram.edges or node_count >= 1) else "NOT_FOUND")
             )
         response = build_response(verdict=verdict, **diagram.to_dict())
         return apply_toon_format_to_response(response, output_format)


### PR DESCRIPTION
## Summary

Fixes seven high-severity correctness bugs where analysis silently returned wrong or fabricated results with `success=true`, so a consumer could not tell a real result from a failure. Each fix has a regression test.

| Area | Bug | Fix |
|---|---|---|
| parse errors (CLI + MCP) | broken-syntax / wrong-language / binary files returned `verdict=INFO` with fabricated structure | surface `verdict=ERROR` / `signal=syntax_error` (both CLI `--advanced` and MCP `analyze_code_structure`, consistent with the health facade) |
| Go | `field_count` always `0`; struct fields never extracted | extract struct fields as fields |
| C# | method `return_type` always `"void"` | read the return type from the correct grammar field |
| Kotlin | property names `"unknown"`; function-local `val`s counted as class fields | extract names correctly; exclude function-local vals from field counts (companion-object vals preserved) |
| find_and_grep | matches in subdirectories double-counted | pass explicit deduplicated file paths to ripgrep instead of parent-dir + filename glob |
| viz uml | single class with no edges mislabeled `NOT_FOUND` | return `verdict=INFO` when a class is found with `node_count >= 1` |
| class_detail | existing class reported as phantom-empty `NOT_FOUND` before the AST index is built | return an explicit `NEEDS_INDEX` state directing the caller to build the index |

## Test plan

- [x] Regression test added for each of the seven fixes
- [x] Real-subprocess ripgrep integration test added for `find_and_grep` (mocked tests alone could not catch an invalid rg flag)
- [x] `uv run pytest tests/unit/mcp/test_find_and_grep_tool_execute.py tests/unit/cli/test_advanced_command.py tests/unit/mcp/test_analyze_code_structure_tool_execute.py` → 65 passed
- [x] Manual CLI/MCP verification of acceptance criteria (broken file → `verdict=ERROR` on both CLI and MCP; Go `field_count`; C# `return_type`; `find_and_grep` count matches `search_content`; uml/class_detail verdicts)
- [x] No regressions in the touched language and MCP test suites (pre-existing unrelated failures unchanged)

## Notes

- Scope is limited to the seven high-severity bugs; lower-severity findings are tracked separately.
- README claim corrections are intentionally not part of this PR.
