### PR TITLE
fix(mcp): stop silent wrong-mode fallbacks in cache + imports (#575)

### DIFF
--- a/docs/api/facade-actions.md
+++ b/docs/api/facade-actions.md
@@ -67,7 +67,7 @@ Reading the tables:
 | `deps` | `file_path`, `mode`, `output_format` | `success`*, `verdict`*, `agent_summary`, `error` + action payload | `--dependencies` |
 | `file` | `file_path`*, `compact_only`, `language`, `output_format` | `success`*, `verdict`*, `agent_summary`, `error` + action payload | `--file-health` |
 | `heatmap` | `directory`, `file_path`, `function_name` (`symbol` aliases `function_name`), `language`, `max_files`, `mode`, `output_format` | `success`*, `verdict`*, `agent_summary`, `error` + action payload | `--codegraph-complexity-heatmap` |
-| `imports` | `mode`*, `file_path`, `max_depth`, `output_format` | `success`*, `verdict`*, `agent_summary`, `error` + action payload | `--import-graph` |
+| `imports` | `file_path`, `max_depth`, `mode`, `output_format` | `success`*, `verdict`*, `agent_summary`, `error` + action payload | `--import-graph` |
 | `matrix` | `mode`*, `file_path`, `output_format`, `threshold`, `top_k` | `success`*, `verdict`*, `agent_summary`, `error` + action payload | `--dependency-matrix` |
 | `overview` | `max_coupled_files`, `max_dead`, `max_entry_points`, `max_hubs`, `output_format` | `success`*, `verdict`*, `agent_summary`, `error` + action payload | `--codegraph-overview` |
 | `patterns` | `file_path`*, `categories`, `output_format`, `severity_threshold` | `success`*, `verdict`*, `agent_summary`, `error` + action payload | `--code-patterns` |
@@ -110,7 +110,7 @@ Reading the tables:
 | --- | --- | --- | --- |
 | `auto` | `max_files`, `mode`, `output_format` | `success`*, `verdict`*, `agent_summary`, `error` + action payload | `--autoindex` |
 | `build` | `add_notes`, `roots` | `success`*, `verdict`*, `agent_summary`, `error` + action payload | `--build-project-index` |
-| `cache` | `backend`, `file_path`, `force`, `include_activation`, `language`, `limit`, `max_files`, `mode`, `poll_interval`, `query` | `success`*, `verdict`*, `agent_summary`, `error` + action payload | `--ast-cache` |
+| `cache` | `backend`, `file_path`, `force`, `include_activation`, `language`, `limit`, `max_files`, `mode`, `poll_interval`, `query`, `symbol` | `success`*, `verdict`*, `agent_summary`, `error` + action payload | `--ast-cache` |
 | `full` | `include_activation`, `max_files`, `mode`, `output_format`, `resolve_synapse` | `success`*, `verdict`*, `agent_summary`, `error` + action payload | `--full-index` |
 | `status` | `include_lag`, `output_format` | `success`*, `verdict`*, `agent_summary`, `error` + action payload | `--codegraph-status` |
 | `sync` | `max_files`, `mode`, `output_format` | `success`*, `verdict`*, `agent_summary`, `error` + action payload | `--incremental-sync` |

--- a/tests/unit/test_ast_cache_tool.py
+++ b/tests/unit/test_ast_cache_tool.py
@@ -76,6 +76,11 @@ class TestGetToolSchema:
         assert ASTCacheTool._resolve_mode({}) == "stats"
         assert ASTCacheTool._resolve_mode({"mode": "stats", "query": "Foo"}) == "stats"
 
+    def test_symbol_declared_in_schema(self):
+        # #575: symbol (the facade's canonical id) must be a declared param so
+        # the facade whitelist forwards it instead of stripping it → stats.
+        assert "symbol" in ASTCacheTool().get_tool_schema()["properties"]
+
     def test_valid_modes(self):
         tool = ASTCacheTool()
         schema = tool.get_tool_schema()
@@ -99,6 +104,32 @@ class TestGetToolSchema:
             "watch_stop",
             "watch_status",
         }
+
+
+class TestSymbolAliasesQuery:
+    """#575: `cache symbol=X` must search for the symbol, not silently fall back
+    to stats (the facade stripped symbol → no query → mode=stats → wrong answer)."""
+
+    def test_symbol_aliases_query_into_search_mode(self, tmp_path):
+        import asyncio
+
+        (tmp_path / "m.py").write_text(
+            "class Widget:\n    def go(self):\n        pass\n"
+        )
+        tool = ASTCacheTool(project_root=str(tmp_path))
+        asyncio.run(tool.execute({"mode": "index"}))  # build the cache
+        result = asyncio.run(tool.execute({"symbol": "Widget"}))
+        assert result["mode"] == "search"
+        assert result["query"] == "Widget"
+
+    def test_explicit_query_wins_over_symbol(self, tmp_path):
+        import asyncio
+
+        (tmp_path / "m.py").write_text("class Widget:\n    pass\n")
+        tool = ASTCacheTool(project_root=str(tmp_path))
+        asyncio.run(tool.execute({"mode": "index"}))
+        result = asyncio.run(tool.execute({"symbol": "Widget", "query": "other"}))
+        assert result["query"] == "other"
 
 
 class TestValidateArguments:

--- a/tests/unit/test_import_graph_tool.py
+++ b/tests/unit/test_import_graph_tool.py
@@ -221,3 +221,29 @@ class TestToonFormat:
         with patch.object(tool, "_get_graph", return_value=mock_graph):
             result = await tool.execute({"mode": "summary", "output_format": "toon"})
         assert "toon_content" in result
+
+
+class TestModeInferenceFromFilePath:
+    """#575: `imports file_path=X` without mode= must infer 'deps' (what that
+    file imports), not silently default to the project 'summary' that ignores
+    file_path — 'answered a different question than asked'."""
+
+    def test_file_path_infers_deps(self):
+        assert CodeGraphImportGraphTool._effective_mode({"file_path": "x.py"}) == "deps"
+
+    def test_no_file_path_is_summary(self):
+        assert CodeGraphImportGraphTool._effective_mode({}) == "summary"
+
+    def test_explicit_mode_wins_over_inference(self):
+        assert (
+            CodeGraphImportGraphTool._effective_mode(
+                {"mode": "cycles", "file_path": "x.py"}
+            )
+            == "cycles"
+        )
+
+    def test_mode_not_required_in_schema(self):
+        # #575: reconcile the required-with-default contradiction — mode has a
+        # default and is inferred, so it must NOT be in required.
+        defn = CodeGraphImportGraphTool().get_tool_definition()
+        assert "mode" not in defn["inputSchema"]["required"]

--- a/tree_sitter_analyzer/cli/argument_groups/_analysis_graph_nav.py
+++ b/tree_sitter_analyzer/cli/argument_groups/_analysis_graph_nav.py
@@ -403,8 +403,11 @@ def _add_mcp_graph_nav_options(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--import-graph-mode",
         choices=["summary", "deps", "dependents", "blast_radius", "cycles", "coupling"],
-        default="summary",
-        help="Mode for --import-graph (default: summary)",
+        default=None,
+        help=(
+            "Mode for --import-graph. Omit to infer: 'deps' when "
+            "--import-graph-file is given, else 'summary' (#575)."
+        ),
     )
     parser.add_argument(
         "--import-graph-file",

--- a/tree_sitter_analyzer/cli/commands/mcp_commands/_specs_extended.py
+++ b/tree_sitter_analyzer/cli/commands/mcp_commands/_specs_extended.py
@@ -161,7 +161,10 @@ _EXTENDED_SPECS: tuple[McpCommandSpec, ...] = (
         tool_attr="CodeGraphImportGraphTool",
         label="File-level import dependency graph (CodeGraph parity)",
         build_tool_args=lambda args, output_format: {
-            "mode": getattr(args, "import_graph_mode", "summary") or "summary",
+            # #575/Codex P2: pass the user's mode, else None so the tool infers
+            # it from file_path (deps) — forcing "summary" here ignored
+            # --import-graph-file and broke MCP/CLI parity.
+            "mode": getattr(args, "import_graph_mode", None),
             "file_path": getattr(args, "import_graph_file", None)
             or getattr(args, "file_path", None),
             "max_depth": getattr(args, "import_graph_max_depth", 10),

--- a/tree_sitter_analyzer/mcp/tools/ast_cache_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/ast_cache_tool.py
@@ -275,6 +275,13 @@ class ASTCacheTool(BaseMCPTool):
                     "type": "string",
                     "description": "Symbol search query (for search mode)",
                 },
+                "symbol": {
+                    "type": "string",
+                    "description": (
+                        "Alias for query (the facade's canonical identifier); "
+                        "searching for this symbol (#575)."
+                    ),
+                },
                 "limit": {
                     "type": "integer",
                     "description": "Max results for search (default: 100)",
@@ -370,6 +377,12 @@ class ASTCacheTool(BaseMCPTool):
         each of the 7 modes into a focused ``_handle_*`` method. M15 / J1
         / J8 / K7 contracts preserved exactly.
         """
+        # #575: ``symbol`` is the facade's canonical identifier; accept it as an
+        # alias for ``query`` so ``index action=cache symbol=X`` searches for the
+        # symbol instead of silently falling back to ``stats`` (the facade used
+        # to strip ``symbol`` → no query → mode=stats → wrong answer, no hint).
+        if arguments.get("symbol") and not arguments.get("query"):
+            arguments = {**arguments, "query": arguments["symbol"]}
         self.validate_arguments(arguments)
         mode = self._resolve_mode(arguments)
 

--- a/tree_sitter_analyzer/mcp/tools/import_graph_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/import_graph_tool.py
@@ -74,7 +74,10 @@ class CodeGraphImportGraphTool(BaseMCPTool):
                         "cycles",
                         "coupling",
                     ],
-                    "description": "Operation mode (default: summary)",
+                    "description": (
+                        "Operation mode. Inferred when omitted: 'deps' if "
+                        "file_path is given, else 'summary' (#575)."
+                    ),
                     "default": "summary",
                 },
                 "file_path": {
@@ -93,12 +96,25 @@ class CodeGraphImportGraphTool(BaseMCPTool):
                     "default": "toon",
                 },
             },
-            "required": ["mode"],
+            # #575: mode is NOT required — it has a default and is inferred from
+            # file_path (the required-with-default contradiction is reconciled).
+            "required": [],
             "additionalProperties": False,
         }
 
+    @staticmethod
+    def _effective_mode(arguments: dict[str, Any]) -> str:
+        """#575: resolve the mode when omitted. A bare ``file_path`` means the
+        agent wants that file's imports (``deps``), not the project ``summary``
+        that ignores file_path — answering a different question than asked.
+        """
+        explicit = arguments.get("mode")
+        if explicit:
+            return str(explicit)
+        return "deps" if arguments.get("file_path") else "summary"
+
     def validate_arguments(self, arguments: dict[str, Any]) -> bool:
-        mode = arguments.get("mode", "summary")
+        mode = self._effective_mode(arguments)
         valid_modes = [
             "summary",
             "deps",
@@ -118,7 +134,7 @@ class CodeGraphImportGraphTool(BaseMCPTool):
     async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
         self.validate_arguments(arguments)
 
-        mode = arguments.get("mode", "summary")
+        mode = self._effective_mode(arguments)
         output_format = arguments.get("output_format", "toon")
         graph = self._get_graph()
 


### PR DESCRIPTION
Closes #575.

Two *'answered a different question than asked'* failures — worse than errors because the agent gets a confident wrong answer with no diagnostic.

## 1. `index action=cache symbol=X` → stats instead of symbol search
The facade whitelisted `symbol` away (the inner ASTCacheTool only declared `query`), so `mode` fell to `stats` and the agent got **index statistics** instead of symbol results. Fix: ASTCacheTool declares `symbol` and aliases it to `query` (the facade's canonical id) — `cache symbol=X` now searches (`mode=search`); an explicit `query` still wins.

## 2. `health action=imports file_path=X` (no mode) → summary, ignoring file_path
`execute()` defaulted to `summary` (which ignores file_path), and `required:['mode']` contradicted the `default:'summary'`. Fix: `_effective_mode` infers `deps` (what the file imports) when `file_path` is present, else `summary`; explicit mode wins; `mode` removed from `required` (it has a default + inference — the #529 required-with-default lesson).

## RED-first
- `TestSymbolAliasesQuery` — cache `symbol`→search, explicit `query` wins.
- `TestModeInferenceFromFilePath` — file_path→deps, none→summary, explicit wins, mode not required.

Both fail without the fix; 222 tests green across the cache/import_graph/contracts suites (the `required` change is safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)