### PR TITLE
fix(mcp): restore semantic_classify include_ast_nodes opt-in after shared to_dict change (#694 follow-up)

### DIFF
--- a/tests/unit/test_semantic_classify_tool.py
+++ b/tests/unit/test_semantic_classify_tool.py
@@ -605,3 +605,62 @@ class TestClassifyByteBudget:
         assert has_hunk_detail, (
             "include_ast_nodes=True must populate hunk.old/new details"
         )
+
+    def test_include_ast_nodes_delivers_children_in_hunk_nodes(
+        self, tool: SemanticClassifyTool
+    ):
+        """Regression for #694 follow-up: include_ast_nodes=True must deliver
+        the AST node children; ClassifiedHunk.to_dict() must forward
+        include_children=True to ASTDiffHunk.to_dict().
+
+        Fixture: a single-function signature change — always produces a
+        signature_changed hunk with 5 children in both old and new node (the
+        function's parameter list + body child nodes extracted by tree-sitter).
+        """
+        _OLD = "def greet(name):\n    return f'Hello {name}'\n"
+        _NEW = "def greet(name, greeting='Hello'):\n    return f'{greeting} {name}'\n"
+
+        result = _run(
+            tool,
+            {
+                "mode": "classify_string",
+                "old_source": _OLD,
+                "new_source": _NEW,
+                "language": "python",
+                "output_format": "json",
+                "include_ast_nodes": True,
+            },
+        )
+        assert result["success"] is True
+
+        # Find the signature_changed hunk (always present for this fixture).
+        sig_entries = [
+            e
+            for e in result.get("classifications", [])
+            if e.get("hunk", {}).get("kind") == "signature_changed"
+        ]
+        assert len(sig_entries) == 1, (
+            "Expected exactly 1 signature_changed classification for the greet fixture"
+        )
+
+        hunk = sig_entries[0]["hunk"]
+        old_node = hunk.get("old", {})
+        new_node = hunk.get("new", {})
+
+        # Children MUST be present — this is the gap that #694 broke.
+        assert "children" in old_node, (
+            "hunk.old must contain 'children' when include_ast_nodes=True "
+            "(ClassifiedHunk.to_dict must pass include_children=True)"
+        )
+        assert "children" in new_node, (
+            "hunk.new must contain 'children' when include_ast_nodes=True "
+            "(ClassifiedHunk.to_dict must pass include_children=True)"
+        )
+
+        # Pin exact counts (5 children in both old and new for this fixture).
+        assert len(old_node["children"]) == 5, (
+            f"Expected 5 children in old node, got {len(old_node['children'])}"
+        )
+        assert len(new_node["children"]) == 5, (
+            f"Expected 5 children in new node, got {len(new_node['children'])}"
+        )

--- a/tree_sitter_analyzer/semantic_change_classifier.py
+++ b/tree_sitter_analyzer/semantic_change_classifier.py
@@ -115,7 +115,7 @@ class ClassifiedHunk:
             "risk": _RISK_LEVELS[self.category],
             "confidence": round(self.confidence, 2),
             "reason": self.reason,
-            "hunk": self.hunk.to_dict(),
+            "hunk": self.hunk.to_dict(include_children=True),
         }
 
 


### PR DESCRIPTION
## Summary
Follow-up to #694 (Codex P2). #694 made the shared `ASTNodeInfo.to_dict()` default `include_children=False`. But `ClassifiedHunk.to_dict()` (semantic_change_classifier.py:118) called `hunk.to_dict()` with no args → silently dropped children, so `semantic_classify(include_ast_nodes=True)` returned hunks **without** AST nodes — the opt-in was broken.

**Why the suite missed it:** the byte-budget test only exercises the *default* path (`include_ast_nodes=False`), where `_compact_hunk` strips children anyway. The opt-in path had no test. (This is the second 'shared serializer changed, untested consumer path broke' instance this session — feeding the test-effectiveness discussion.)

## Fix
`ClassifiedHunk.to_dict()` → `self.hunk.to_dict(include_children=True)`. Default path still strips via `_compact_hunk` (byte-pin `4544` unchanged); opt-in path now delivers children. `with_child_count` not forwarded → no `child_count` leak (preserves #543 budget).

## Test (RED-first, exact ==)
`TestClassifyByteBudget::test_include_ast_nodes_delivers_children_in_hunk_nodes` — `include_ast_nodes=True` on a 1-hunk signature change asserts `hunk.old/new["children"]` exist with `len == 5`. Default byte-pin test stays green unchanged.

@codex review