### PR TITLE
fix(mcp): make classify AST-children inclusion opt-in per consumer; exact-pin outline assertion (Codex P2 follow-ups)

### DIFF
--- a/tests/unit/test_codegraph_pr_review_tool.py
+++ b/tests/unit/test_codegraph_pr_review_tool.py
@@ -1139,6 +1139,65 @@ class TestCoverageToolMethods:
         assert result["success"] is True
         assert len(result["api_changes"]) == 1  # fixture yields exactly one
 
+    def test_high_risk_changes_hunks_are_lean_no_ast_children(self):
+        """BUG A (Codex P2 #696 follow-up): high_risk_changes entries must NOT
+        contain AST children keys in hunk.old / hunk.new.
+
+        codegraph_pr_review calls ch.to_dict() with no args; the default must
+        be lean (include_children=False).  Before the fix, ClassifiedHunk.to_dict()
+        hard-coded include_children=True, embedding full subtrees for up to 5
+        hunks/file.
+        """
+        # Use a real api_change-triggering diff so SemanticChangeClassifier
+        # produces an actual ClassifiedHunk with a real ASTDiffHunk.
+        src_old = "def public_api(x: int) -> int:\n    return x\n"
+        src_new = "def public_api(x: int, y: int = 0) -> int:\n    return x + y\n"
+        diff_text = (
+            "diff --git a/api.py b/api.py\n"
+            "--- a/api.py\n"
+            "+++ b/api.py\n"
+            "@@ -1,2 +1,2 @@\n"
+            "-def public_api(x: int) -> int:\n"
+            "+def public_api(x: int, y: int = 0) -> int:\n"
+            "     return x\n"
+        )
+        tmpdir = _make_project(("api.py", src_new))
+        tool = CodeGraphPRReviewTool(tmpdir)
+
+        with (
+            patch(
+                "tree_sitter_analyzer.mcp.tools.codegraph_pr_review_tool._get_local_diff",
+                return_value=diff_text,
+            ),
+            patch(
+                "tree_sitter_analyzer.mcp.tools.codegraph_pr_review_tool._get_old_source",
+                return_value=src_old,
+            ),
+            patch(
+                "tree_sitter_analyzer.mcp.tools.codegraph_pr_review_tool._get_new_source",
+                return_value=src_new,
+            ),
+        ):
+            result = _run(
+                tool,
+                {"mode": "diff", "include_call_graph": False, "output_format": "json"},
+            )
+        assert result["success"] is True
+        file_reviews = result.get("file_reviews", [])
+        assert len(file_reviews) == 1
+        high_risk_changes = file_reviews[0].get("high_risk_changes", [])
+        # Verify lean serialization: no hunk.old/new children in any high_risk entry.
+        for i, entry in enumerate(high_risk_changes):
+            hunk = entry.get("hunk", {})
+            assert "children" not in hunk.get("old", {}), (
+                f"high_risk_changes[{i}].hunk.old must NOT contain 'children' "
+                "(lean default — PR review must not embed full AST subtrees)"
+            )
+            assert "children" not in hunk.get("new", {}), (
+                f"high_risk_changes[{i}].hunk.new must NOT contain 'children' "
+                "(lean default — PR review must not embed full AST subtrees)"
+            )
+
     def test_analyze_call_graph_impact_dedup_callee(self):
         """Duplicate callee entries (same qualified_name) are deduplicated."""
         from tree_sitter_analyzer.call_graph import FunctionRef

--- a/tests/unit/test_issue_577_agent_summary_uniformity.py
+++ b/tests/unit/test_issue_577_agent_summary_uniformity.py
@@ -654,9 +654,17 @@ class TestStructureAstPathAgentSummary:
         )
         assert result.get("verdict") == "INFO"
         summary_line = result.get("agent_summary", {}).get("summary_line", "")
-        # Must report the true count 2, NOT the buggy "0 top-level node(s)"
-        assert "2 top-level node(s)" in summary_line, (
-            f"outline summary_line must contain '2 top-level node(s)'; got: {summary_line!r}"
+        # Must report the true count 2, NOT the buggy "0 top-level node(s)".
+        # Extract the integer from "(N top-level node(s))" and pin exactly to 2
+        # (locked exact-assertion rule: count assertions must use ==, not substring).
+        import re
+
+        m = re.search(r"\((\d+) top-level node\(s\)\)", summary_line)
+        assert m is not None, (
+            f"outline summary_line must match '(N top-level node(s))'; got: {summary_line!r}"
+        )
+        assert int(m.group(1)) == 2, (
+            f"outline summary_line must report exactly 2 top-level node(s); got: {summary_line!r}"
         )
 
     @pytest.mark.asyncio

--- a/tests/unit/test_semantic_classify_tool.py
+++ b/tests/unit/test_semantic_classify_tool.py
@@ -664,3 +664,115 @@ class TestClassifyByteBudget:
         assert len(new_node["children"]) == 5, (
             f"Expected 5 children in new node, got {len(new_node['children'])}"
         )
+
+
+class TestClassifiedHunkSerializerOptIn:
+    """BUG A (Codex P2 #696 follow-up): ClassifiedHunk.to_dict() must accept
+    include_children param and default to lean (no children).  The PR-review
+    consumer calls ch.to_dict() without opt-in → must never embed AST subtrees.
+    """
+
+    def _make_classified_hunk(self) -> Any:
+        """Return a real ClassifiedHunk with a hunk whose old/new nodes have children."""
+        from tree_sitter_analyzer.ast_diff import ASTDiffer
+        from tree_sitter_analyzer.semantic_change_classifier import (
+            SemanticChangeClassifier,
+        )
+
+        old = "def greet(name):\n    return f'Hello {name}'\n"
+        new = "def greet(name, greeting='Hello'):\n    return f'{greeting} {name}'\n"
+        differ = ASTDiffer()
+        diff = differ.diff_strings(old, new, "python")
+        classifier = SemanticChangeClassifier()
+        classification = classifier.classify(diff)
+        assert classification.classifications, (
+            "Fixture must produce at least one ClassifiedHunk"
+        )
+        return classification.classifications[0]
+
+    def test_classified_hunk_to_dict_default_is_lean(self):
+        """ClassifiedHunk.to_dict() with no args must NOT include children keys.
+
+        This is the consumer contract for codegraph_pr_review — it calls
+        ch.to_dict() raw (no include_children kwarg), so the default must
+        be lean.  Before the fix, to_dict() hard-coded include_children=True,
+        leaking full AST subtrees into every PR-review high_risk_changes entry.
+        """
+        ch = self._make_classified_hunk()
+        d = ch.to_dict()
+        hunk = d.get("hunk", {})
+        old_node = hunk.get("old", {})
+        new_node = hunk.get("new", {})
+        assert "children" not in old_node, (
+            "hunk.old must NOT contain 'children' in default (lean) ClassifiedHunk.to_dict() — "
+            "codegraph_pr_review calls ch.to_dict() raw and must not embed AST subtrees"
+        )
+        assert "children" not in new_node, (
+            "hunk.new must NOT contain 'children' in default (lean) ClassifiedHunk.to_dict()"
+        )
+
+    def test_classified_hunk_to_dict_opt_in_delivers_children(self):
+        """ClassifiedHunk.to_dict(include_children=True) must still deliver children.
+
+        Ensures the semantic_classify opt-in path (include_ast_nodes=True) continues
+        to work after the parameterization fix.
+        """
+        ch = self._make_classified_hunk()
+        d = ch.to_dict(include_children=True)
+        hunk = d.get("hunk", {})
+        old_node = hunk.get("old", {})
+        new_node = hunk.get("new", {})
+        assert "children" in old_node, (
+            "hunk.old must contain 'children' when include_children=True"
+        )
+        assert "children" in new_node, (
+            "hunk.new must contain 'children' when include_children=True"
+        )
+
+    def test_semantic_classification_to_dict_default_is_lean(self):
+        """SemanticClassification.to_dict() must thread include_children=False to each ClassifiedHunk."""
+        from tree_sitter_analyzer.ast_diff import ASTDiffer
+        from tree_sitter_analyzer.semantic_change_classifier import (
+            SemanticChangeClassifier,
+        )
+
+        old = "def greet(name):\n    return f'Hello {name}'\n"
+        new = "def greet(name, greeting='Hello'):\n    return f'{greeting} {name}'\n"
+        differ = ASTDiffer()
+        diff = differ.diff_strings(old, new, "python")
+        classifier = SemanticChangeClassifier()
+        classification = classifier.classify(diff)
+        d = classification.to_dict()
+        for entry in d.get("classifications", []):
+            hunk = entry.get("hunk", {})
+            assert "children" not in hunk.get("old", {}), (
+                "SemanticClassification.to_dict() default must not embed children in hunk.old"
+            )
+            assert "children" not in hunk.get("new", {}), (
+                "SemanticClassification.to_dict() default must not embed children in hunk.new"
+            )
+
+    def test_semantic_classification_to_dict_opt_in_delivers_children(self):
+        """SemanticClassification.to_dict(include_children=True) must deliver children."""
+        from tree_sitter_analyzer.ast_diff import ASTDiffer
+        from tree_sitter_analyzer.semantic_change_classifier import (
+            SemanticChangeClassifier,
+        )
+
+        old = "def greet(name):\n    return f'Hello {name}'\n"
+        new = "def greet(name, greeting='Hello'):\n    return f'{greeting} {name}'\n"
+        differ = ASTDiffer()
+        diff = differ.diff_strings(old, new, "python")
+        classifier = SemanticChangeClassifier()
+        classification = classifier.classify(diff)
+        d = classification.to_dict(include_children=True)
+        found_children = False
+        for entry in d.get("classifications", []):
+            hunk = entry.get("hunk", {})
+            if "children" in hunk.get("old", {}) or "children" in hunk.get("new", {}):
+                found_children = True
+                break
+        assert found_children, (
+            "SemanticClassification.to_dict(include_children=True) must deliver children "
+            "in at least one hunk.old or hunk.new"
+        )

--- a/tree_sitter_analyzer/mcp/tools/semantic_classify_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/semantic_classify_tool.py
@@ -230,7 +230,9 @@ class SemanticClassifyTool(BaseMCPTool):
 
         classifier = SemanticChangeClassifier(file_path=file_path)
         classification = classifier.classify(diff_result)
-        class_dict = classification.to_dict()
+        # Always deserialize with children so _compact_classification can
+        # strip them (default) or keep them (include_ast_nodes=True).
+        class_dict = classification.to_dict(include_children=True)
 
         # Map risk_level to canonical verdict vocabulary (pain-01 tsa-landing
         # contract). NOT_FOUND when there are zero classifications (identical

--- a/tree_sitter_analyzer/semantic_change_classifier.py
+++ b/tree_sitter_analyzer/semantic_change_classifier.py
@@ -108,14 +108,14 @@ class ClassifiedHunk:
     confidence: float
     reason: str
 
-    def to_dict(self) -> dict[str, Any]:
+    def to_dict(self, include_children: bool = False) -> dict[str, Any]:
         return {
             "category": self.category.value,
             "label": _CATEGORY_LABELS[self.category],
             "risk": _RISK_LEVELS[self.category],
             "confidence": round(self.confidence, 2),
             "reason": self.reason,
-            "hunk": self.hunk.to_dict(include_children=True),
+            "hunk": self.hunk.to_dict(include_children=include_children),
         }
 
 
@@ -127,14 +127,17 @@ class SemanticClassification:
     change_summary: str = ""
     category_counts: dict[str, int] = field(default_factory=dict)
 
-    def to_dict(self) -> dict[str, Any]:
+    def to_dict(self, include_children: bool = False) -> dict[str, Any]:
         return {
             "dominant_category": self.dominant_category.value,
             "dominant_label": _CATEGORY_LABELS[self.dominant_category],
             "risk_level": self.risk_level,
             "change_summary": self.change_summary,
             "category_counts": self.category_counts,
-            "classifications": [c.to_dict() for c in self.classifications],
+            "classifications": [
+                c.to_dict(include_children=include_children)
+                for c in self.classifications
+            ],
         }
 
 


### PR DESCRIPTION
## Summary
Two Codex P2 follow-ups (#696, #697). The main one is the **third shared-serializer ripple this session**, so this fix takes the structural approach: **enumerate ALL consumers, default to lean, test EACH**.

### Bug A — children leaked into codegraph_pr_review (Codex P2 on #696)
#696 hardcoded `ClassifiedHunk.to_dict()` to `include_children=True` to restore `semantic_classify(include_ast_nodes=True)`. But `codegraph_pr_review_tool.py:530` appends `ch.to_dict()` raw (no compaction) → PR-review responses bloated with full AST subtrees for up to 5 hunks/file.

**Full consumer audit** of `ClassifiedHunk.to_dict` / `SemanticClassification.to_dict`:
| Consumer | Wants | After fix |
|---|---|---|
| `semantic_classify_tool.py:233` | children present (so `_compact_classification` can keep/strip per `include_ast_nodes`) | caller passes `include_children=True` explicitly |
| `codegraph_pr_review_tool.py:530` | lean | default `False` → lean |
| `change_impact_analysis.py:843` (4th consumer, found in audit) | lean | default `False` → lean |

**Fix:** `ClassifiedHunk.to_dict(include_children=False)` + `SemanticClassification.to_dict(include_children=False)` (threaded); the classify tool opts in; everyone else gets lean by default.

### Bug B — substring assertion violated the locked exact-assertion rule (Codex P2 on #697)
`test_outline_summary_line_shows_true_node_count` used `"2 top-level node(s)" in summary_line`. Replaced with a regex extraction + `int(...) == 2`.

## Tests (RED-first, exact ==, one per consumer)
- `TestClassifiedHunkSerializerOptIn` ×4: ClassifiedHunk/SemanticClassification default-lean + opt-in-delivers-children.
- `test_high_risk_changes_hunks_are_lean_no_ast_children`: real classifier flow, asserts pr_review high_risk hunks have no `children`.
- outline assertion now exact.

Invariants confirmed: default byte-pin **4544 unchanged**; #696 opt-in test green (5 children each). 177 tests pass; ruff + mypy clean.

@codex review