### PR TITLE
fix(mcp): find_references walk uses shared EXCLUDE_DIRS + skips dotdirs so scan budget reaches real source (#568)

### DIFF
--- a/tests/unit/mcp/test_query_symbol_search.py
+++ b/tests/unit/mcp/test_query_symbol_search.py
@@ -8,6 +8,7 @@ import pytest
 from tree_sitter_analyzer.mcp.tools.query_symbol_search import (
     _build_match_fn,
     _build_type_filter,
+    _collect_source_files,
     execute_find_references,
     execute_symbol_search,
 )
@@ -235,3 +236,54 @@ class HealthScorer:
         props = TOOL_SCHEMA["properties"]
         assert "find_references" in props
         assert props["find_references"]["type"] == "boolean"
+
+
+class TestCollectSourceFilesExcludes:
+    """#568: _collect_source_files must skip dotdirs AND shared EXCLUDE_DIRS members
+    so the 500-file scan budget is not eaten by vendored/build/dot trees."""
+
+    def _make_tree(self, tmp_path: Path) -> tuple[Path, Path, Path, Path]:
+        """Create a fixture tree with:
+        - pkg/real.py  — real source that MUST be collected
+        - .vendored/decoy.py  — dotdir, must be EXCLUDED
+        - node_modules/decoy.py  — EXCLUDE_DIRS member, must be EXCLUDED
+        Returns (real_file, dotdir_decoy, node_modules_decoy, root).
+        """
+        real = tmp_path / "pkg" / "real.py"
+        real.parent.mkdir(parents=True)
+        real.write_text("class Widget:\n    pass\n")
+
+        dot_dir = tmp_path / ".vendored"
+        dot_dir.mkdir()
+        dot_decoy = dot_dir / "decoy.py"
+        dot_decoy.write_text("class Widget:\n    pass\n")
+
+        nm_dir = tmp_path / "node_modules"
+        nm_dir.mkdir()
+        nm_decoy = nm_dir / "decoy.py"
+        nm_decoy.write_text("class Widget:\n    pass\n")
+
+        return real, dot_decoy, nm_decoy, tmp_path
+
+    def test_excludes_dotdir_and_node_modules(self, tmp_path):
+        real, dot_decoy, nm_decoy, root = self._make_tree(tmp_path)
+        collected = _collect_source_files(root)
+        paths = [str(p) for p in collected]
+
+        assert str(real) in paths, "real source file must be collected"
+        assert str(dot_decoy) not in paths, ".vendored/ dotdir must be excluded"
+        assert str(nm_decoy) not in paths, "node_modules/ must be excluded"
+        # Exact count: only the one real source file is present
+        assert len(collected) == 1
+
+    def test_find_references_skips_dotdir_vendors(self, tmp_path):
+        """find_references must not scan files inside dotdirs (budget pollution)."""
+        real, _dot_decoy, _nm_decoy, root = self._make_tree(tmp_path)
+        result = asyncio.run(
+            execute_find_references(
+                str(root), {"symbol": "Widget", "output_format": "json"}
+            )
+        )
+        assert result["success"] is True
+        # Only the one real file is reachable — files_searched must be exactly 1
+        assert result["files_searched"] == 1

--- a/tree_sitter_analyzer/mcp/tools/query_symbol_search.py
+++ b/tree_sitter_analyzer/mcp/tools/query_symbol_search.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from ...ast_cache import ASTCache
+from ...constants import EXCLUDE_DIRS
 from ...utils import setup_logger
 
 logger = setup_logger(__name__)
@@ -38,24 +39,6 @@ _SYMBOL_SEARCH_EXTS = {
     ".c",
     ".cpp",
 }
-_SYMBOL_SEARCH_EXCLUDE = {
-    "node_modules",
-    ".git",
-    "__pycache__",
-    ".venv",
-    "venv",
-    ".tox",
-    ".mypy_cache",
-    ".pytest_cache",
-    ".ruff_cache",
-    "dist",
-    "build",
-    "htmlcov",
-    ".cache",
-    ".eggs",
-    ".claude",
-}
-
 # r37bc: scan limits — module-level so the file collection helper +
 # response envelope cap stay in sync (was a magic 500 / 50 in 2+ places).
 _SYMBOL_SEARCH_MAX_FILES = 500
@@ -185,11 +168,20 @@ def _resolve_project_root(project_root: str | None) -> Path:
 
 
 def _collect_source_files(root: Path) -> list[Path]:
-    """Walk ``root`` for source files, applying excludes + the 500 cap."""
+    """Walk ``root`` for source files, applying excludes + the 500 cap.
+
+    Uses the shared EXCLUDE_DIRS constant (single source of truth) and also
+    skips any path component that starts with '.' (generic dotdir guard,
+    e.g. .benchmark-repos, .vendored) so vendored/build/dot trees cannot
+    consume the 500-file budget before real source is reached (#568).
+    """
     source_files: list[Path] = []
     for ext in _SYMBOL_SEARCH_EXTS:
         for f in root.rglob(f"*{ext}"):
-            if any(part in _SYMBOL_SEARCH_EXCLUDE for part in f.parts):
+            parts = f.parts
+            if any(part in EXCLUDE_DIRS for part in parts):
+                continue
+            if any(part.startswith(".") for part in parts):
                 continue
             source_files.append(f)
     if len(source_files) > _SYMBOL_SEARCH_MAX_FILES:


### PR DESCRIPTION
## Summary
Fixes #568 defect-2 — `nav action=lineage symbol=BaseMCPTool` returned `reference_count: 0` next to `downstream_file_count: 449` (contradictory for the most-inherited class).

**Root cause:** `_collect_source_files()` (query_symbol_search.py) filtered the `rglob` walk against a local `_SYMBOL_SEARCH_EXCLUDE` set that was a stale, incomplete subset of the canonical `EXCLUDE_DIRS` (missing `target`, `vendor`, `out`, `obj`, `.next`, `Pods`, `.ast-cache`, …) and had no generic dotdir guard. So vendored/build/dotdir trees (e.g. a `.benchmark-repos/` checkout) consumed the 500-file scan budget before the walk reached real source → `files_searched: 500, total_usages: 0` even for a symbol used 70+ times.

## Fix
- Import the shared `EXCLUDE_DIRS` (single source of truth) + skip any path part starting with `.` (same pattern as `_graph_cache_fingerprint.py`).
- Deleted the stale local `_SYMBOL_SEARCH_EXCLUDE` (2 in-file refs, nothing external).

## Tests (RED-first, exact ==)
`TestCollectSourceFilesExcludes`:
- `test_excludes_dotdir_and_node_modules` — tmp tree with `pkg/real.py` + `.vendored/decoy.py` + `node_modules/decoy.py`; asserts `len(collected) == 1`, real present, both decoys absent.
- `test_find_references_skips_dotdir_vendors` — `files_searched == 1`.
(Neither depends on `.benchmark-repos`.) 59 tests pass (query_symbol_search + symbol_lineage); ruff + mypy clean.

Closes #568 (defect-1 was fixed in #688).

@codex review