### PR TITLE
fix(mcp): find_references excludes only check parts below project root (#699 follow-up)

### DIFF
--- a/tests/unit/mcp/test_query_symbol_search.py
+++ b/tests/unit/mcp/test_query_symbol_search.py
@@ -276,6 +276,21 @@ class TestCollectSourceFilesExcludes:
         # Exact count: only the one real source file is present
         assert len(collected) == 1
 
+    def test_project_root_under_dotted_ancestor_still_collects(self, tmp_path):
+        # Codex P2 (#699): the exclude check must look only at parts BELOW the
+        # root. A project whose root lives under a dotted/excluded-named ancestor
+        # (e.g. ~/.local/share/proj, /build/proj) must NOT exclude all its files.
+        root = tmp_path / ".local" / "build" / "proj"  # dotted + excluded ancestors
+        real = root / "pkg" / "real.py"
+        real.parent.mkdir(parents=True)
+        real.write_text("class Widget:\n    pass\n")
+
+        collected = _collect_source_files(root)
+        # The dotted/excluded ANCESTOR names are above the root, so the one real
+        # file below the root is still collected.
+        assert [str(p) for p in collected] == [str(real)]
+        assert len(collected) == 1
+
     def test_find_references_skips_dotdir_vendors(self, tmp_path):
         """find_references must not scan files inside dotdirs (budget pollution)."""
         real, _dot_decoy, _nm_decoy, root = self._make_tree(tmp_path)

--- a/tree_sitter_analyzer/mcp/tools/query_symbol_search.py
+++ b/tree_sitter_analyzer/mcp/tools/query_symbol_search.py
@@ -178,7 +178,14 @@ def _collect_source_files(root: Path) -> list[Path]:
     source_files: list[Path] = []
     for ext in _SYMBOL_SEARCH_EXTS:
         for f in root.rglob(f"*{ext}"):
-            parts = f.parts
+            # Codex P2 (#699): check only the parts BELOW the project root.
+            # Using ``f.parts`` (absolute) wrongly excludes the whole project
+            # when the root itself lives under a dotted/excluded-named ancestor
+            # (e.g. a checkout at ``~/.local/share/proj`` or ``/build/proj``).
+            try:
+                parts = f.relative_to(root).parts
+            except ValueError:  # pragma: no cover - rglob(root) only yields descendants
+                parts = f.parts
             if any(part in EXCLUDE_DIRS for part in parts):
                 continue
             if any(part.startswith(".") for part in parts):


### PR DESCRIPTION
## Summary
Codex P2 on #699. My #699 fix checked `f.parts` (absolute) against `EXCLUDE_DIRS` + dotdir-prefix. But if the project root itself lives under a dotted or excluded-named ancestor (e.g. a checkout at `~/.local/share/proj`, `/build/proj`, `/work/.cache/proj`), every file's absolute parts include that ancestor → **all files excluded → find_references returns nothing for the whole project.**

## Fix
Check `f.relative_to(root).parts` (parts BELOW the root) instead of absolute `f.parts`. Ancestor directory names above the root no longer matter. `ValueError` fallback for the (rglob-impossible) not-under-root case.

## Test (RED-first, exact ==, mutation-verified)
`test_project_root_under_dotted_ancestor_still_collects` — root at `tmp/.local/build/proj` (dotted + excluded-named ancestors), one real file below; asserts `collected == [real]`. Mutation check confirmed: old `f.parts` collects **0** (the bug), new `relative_to(root)` collects **1**. 60 tests pass (query_symbol_search + symbol_lineage); ruff + mypy clean.

@codex review