### PR TITLE
feat(nav): flag stale lineage hierarchy when source is newer than the index (#692)

### DIFF
--- a/tests/unit/mcp/test_symbol_lineage_tool.py
+++ b/tests/unit/mcp/test_symbol_lineage_tool.py
@@ -256,6 +256,107 @@ class TestInheritanceLineage:
         assert result["success"] is True
         assert "hierarchy" not in result
 
+    def test_hierarchy_flags_stale_after_source_edit_without_reindex(
+        self, tool, tmp_path
+    ):
+        """#692: index_stale=True when source is newer than the AST index."""
+        import os
+        import time
+
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        _write_py(
+            tmp_path, "base.py", "class Base:\n    def run(self):\n        pass\n"
+        )
+        sub_path = tmp_path / "sub.py"
+        _write_py(
+            tmp_path,
+            "sub.py",
+            "from base import Base\nclass Sub(Base):\n    pass\n",
+        )
+        # Build the index so hierarchy is populated.
+        ASTCache(str(tmp_path)).index_project(max_files=50)
+
+        # Bump sub.py's mtime to AFTER the index was written, WITHOUT re-indexing.
+        # Use a deterministic future timestamp to avoid timing races.
+        future_ns = int(time.time() * 1e9) + 10_000_000_000  # 10 seconds ahead
+        future_s = future_ns / 1e9
+        os.utime(str(sub_path), (future_s, future_s))
+
+        # The tool must re-build the dep graph (source mtime changed) so
+        # _dep_graph_fingerprint.max_mtime_ns reflects the bumped mtime.
+        # Force cache invalidation by resetting the tool state.
+        tool._dep_graph = None
+        tool._dep_graph_fingerprint = None
+        tool._symbol_cache = {}
+
+        result = asyncio.run(tool.execute({"symbol": "Base", "output_format": "json"}))
+        hier = result["hierarchy"]
+        # Stale row still reported (the index still has Sub).
+        assert hier["subclass_count"] == 1
+        # Freshness flag must be present and True.
+        assert hier["index_stale"] is True
+        assert "index_hint" in hier
+
+    def test_hierarchy_not_stale_when_index_fresh(self, tool, tmp_path):
+        """#692: index_stale=False immediately after indexing (no source edits)."""
+        import os
+        import time
+
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        _write_py(
+            tmp_path, "base.py", "class Base:\n    def run(self):\n        pass\n"
+        )
+        _write_py(
+            tmp_path,
+            "sub.py",
+            "from base import Base\nclass Sub(Base):\n    pass\n",
+        )
+        # Set source mtimes to a point in the past so index is guaranteed newer.
+        past_s = time.time() - 60
+        for name in ("base.py", "sub.py"):
+            p = str(tmp_path / name)
+            os.utime(p, (past_s, past_s))
+
+        # Build the index AFTER setting source mtimes to the past.
+        ASTCache(str(tmp_path)).index_project(max_files=50)
+
+        result = asyncio.run(tool.execute({"symbol": "Base", "output_format": "json"}))
+        hier = result["hierarchy"]
+        assert hier["subclass_count"] == 1
+        # Index is fresh: stale flag must be False, hint must be absent.
+        assert hier["index_stale"] is False
+        assert "index_hint" not in hier
+
+    def test_hierarchy_stale_uses_fingerprint_fallback_when_graph_missing(
+        self, tool, tmp_path
+    ):
+        """#692: when the dep-graph fingerprint is absent (graph build failed) the
+        freshness check falls back to compute_graph_fingerprint directly."""
+        import os
+        import time
+
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        _write_py(tmp_path, "base.py", "class Base:\n    pass\n")
+        _write_py(
+            tmp_path, "sub.py", "from base import Base\nclass Sub(Base):\n    pass\n"
+        )
+        past_s = time.time() - 60
+        for name in ("base.py", "sub.py"):
+            os.utime(str(tmp_path / name), (past_s, past_s))
+        ASTCache(str(tmp_path)).index_project(max_files=50)
+
+        # Force the fallback: no cached dep-graph fingerprint available.
+        tool._dep_graph_fingerprint = None
+        hier = tool._hierarchy_for("Base")
+        assert hier is not None
+        assert hier["subclass_count"] == 1
+        # Source mtimes are in the past, index is newer → fresh via the fallback.
+        assert hier["index_stale"] is False
+        assert "index_hint" not in hier
+
 
 class TestR37uTopLevelVerdictMirror:
     """r37u dogfood: ``--symbol-lineage`` envelope used to omit top-level

--- a/tree_sitter_analyzer/mcp/tools/symbol_lineage_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/symbol_lineage_tool.py
@@ -505,13 +505,33 @@ class SymbolLineageTool(BaseMCPTool):
             # (WinError 32: index.db locked at tmp teardown otherwise).
             if cache is not None:
                 cache.close()
-        return {
+        # #692: freshness signal — compare source max mtime against index mtime.
+        # Prefer the already-computed dep-graph fingerprint (avoids a second
+        # tree walk); fall back to compute_graph_fingerprint if not available.
+        if self._dep_graph_fingerprint is not None:
+            source_max_mtime_ns = self._dep_graph_fingerprint.max_mtime_ns
+        else:
+            source_max_mtime_ns = compute_graph_fingerprint(
+                str(self.project_root)
+            ).max_mtime_ns
+        index_mtime_ns = self._index_signature()
+        # Treat index_mtime_ns == 0 as stale (hierarchy was built from an
+        # in-memory cache; we can't verify freshness without a real index file).
+        stale = source_max_mtime_ns > index_mtime_ns or index_mtime_ns == 0
+        hier: dict[str, Any] = {
             "subclasses": subs[:_HIER_LIMIT],
             "subclass_count": len(subs),
             "subclasses_truncated": len(subs) > _HIER_LIMIT,
             "superclasses": supers,
             "superclass_count": len(supers),
+            "index_stale": stale,
         }
+        if stale:
+            hier["index_hint"] = (
+                "Source changed since last index; run project_index/index"
+                " action=auto to refresh inheritance."
+            )
+        return hier
 
     @staticmethod
     def _assemble_lineage_response(


### PR DESCRIPTION
## Summary
Closes #692 (P3, follow-up to #688/#568). `nav action=lineage` builds its `hierarchy` block from the persisted AST index, while `references` come from a LIVE re-scan — so if source is edited without re-indexing, the hierarchy can list stale rows (e.g. a deleted subclass) with no signal. This adds an honest freshness flag (no expensive auto-reindex).

## Fix
In `_hierarchy_for`: compare source max mtime (reuses the already-computed `_dep_graph_fingerprint.max_mtime_ns` — no second tree walk; falls back to `compute_graph_fingerprint` if the graph build failed) against `_index_signature()` (index db+wal+shm mtime). When source is newer:
- `hierarchy["index_stale"] = True` (always present as a bool — mirrors `subclasses_truncated` for contract stability)
- `hierarchy["index_hint"]` = run project_index to refresh (present only when stale, keeps the fresh path lean)

## Tests (RED-first, exact ==, deterministic mtimes via os.utime)
- `test_hierarchy_flags_stale_after_source_edit_without_reindex` — index built, `sub.py` mtime bumped +10s, no re-index → `index_stale is True`, `subclass_count == 1` (the stale row is still counted — that's the point).
- `test_hierarchy_not_stale_when_index_fresh` — source mtimes −60s, fresh index → `index_stale is False`, `index_hint` absent, `subclass_count == 1`.
36/36 lineage + 9/9 graph-cache tests pass; ruff + mypy clean. CLI parity: response fields flow through `--symbol-lineage` unfiltered.

@codex review