### PR TITLE
fix(cli): --check-constraints no longer crashes on duplicate violation PKs (#544)

### DIFF
--- a/tests/unit/cli/test_constraint_check_command.py
+++ b/tests/unit/cli/test_constraint_check_command.py
@@ -498,6 +498,56 @@ class TestRunAndPersist:
         assert "OLD" not in rule_ids
         assert "NEW" in rule_ids
 
+    def test_duplicate_pk_violations_do_not_crash_persist(self, tmp_path):
+        """Regression for #544: two violations with the same PK must not crash.
+
+        If ``evaluate()`` returns two ``Violation`` objects that share the
+        same ``(rule_id, caller_file, caller_line, callee_name)`` PRIMARY
+        KEY (e.g., one call site resolved to two ``callee_file`` targets),
+        the old ``executemany`` would raise
+        ``UNIQUE constraint failed: ast_constraint_violations.rule_id, ...``.
+
+        After the fix the persist path must succeed and write exactly 1 row
+        (the dedup is in ``evaluate()``, so ``_run_and_persist`` receives a
+        clean list — this test verifies the full stack from mock to DB).
+        """
+        db = self._db_with_edges(tmp_path)
+        # Two violations with identical PK but different callee_file.
+        dup_v1 = _v(
+            rule_id="R1",
+            caller_file="a.py",
+            caller_line=10,
+            callee_name="bar",
+            callee_file="b.py",
+            detected_at=1,
+        )
+        dup_v2 = _v(
+            rule_id="R1",
+            caller_file="a.py",
+            caller_line=10,
+            callee_name="bar",
+            callee_file="c.py",
+            detected_at=1,
+        )
+
+        # We intentionally bypass the real evaluate() and inject the two
+        # duplicates directly to test the persist layer in isolation.
+        with patch(_EVALUATE, return_value=[dup_v1, dup_v2]):
+            # Must NOT raise sqlite3.IntegrityError.
+            violations, edge_count = _run_and_persist(db, ["c"])
+
+        conn = sqlite3.connect(str(db))
+        rows = conn.execute(
+            "SELECT rule_id, caller_file, caller_line, callee_name "
+            "FROM ast_constraint_violations"
+        ).fetchall()
+        conn.close()
+        # Exactly 1 row persisted (PK is unique); the constraint did not crash.
+        assert len(rows) == 1, (
+            f"Expected exactly 1 persisted row after dedup, got {len(rows)}: {rows}"
+        )
+        assert rows[0] == ("R1", "a.py", 10, "bar")
+
 
 # ---------------------------------------------------------------------------
 # _run_tool

--- a/tests/unit/test_constraint_dsl.py
+++ b/tests/unit/test_constraint_dsl.py
@@ -493,3 +493,111 @@ class TestEvaluator:
             f"budget is 500 ms. See spec — constraint checking runs on "
             f"every change_impact call and must stay cheap."
         )
+
+    def test_duplicate_pk_violations_deduplicated(self, tmp_path: Path) -> None:
+        """evaluate() dedupes violations that share the same PK.
+
+        Regression test for #544: when the ``edges`` table contains two rows
+        for the same call site (same caller_file, caller_line, callee_name)
+        but with different ``callee_resolved_file`` values (e.g., because the
+        same call was indexed twice via different resolution paths), both rows
+        can match the same constraint rule and produce two ``Violation``
+        objects with identical ``(rule_id, caller_file, caller_line,
+        callee_name)`` — which is the PRIMARY KEY of
+        ``ast_constraint_violations``.  The old code's ``executemany`` would
+        then crash with ``UNIQUE constraint failed``.
+
+        Fix: evaluate() must deduplicate on PK before returning so the persist
+        path always receives at most one Violation per PK tuple.
+
+        The test asserts that exactly 1 violation is returned (not 2) so the
+        pin is tight and drift raises the test rather than silently passing
+        with a loose bound.
+        """
+        import json as _json
+
+        from tree_sitter_analyzer.constraints import evaluate, load_constraints
+        from tree_sitter_analyzer.graph.edge_store import (
+            EDGE_STORE_SCHEMA,
+            EdgeKind,
+            symbol_node,
+        )
+
+        project = _stage_constraints_file(tmp_path, "dogfood_minimal.yml")
+        db_path = project / ".ast-cache" / "index.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Build two edges with identical (caller_file, caller_line, callee_name)
+        # but different callee_resolved_file — simulating a call site that was
+        # resolved to two targets by different indexing passes.
+        caller_file = "tree_sitter_analyzer/mcp/x.py"
+        caller_name = "do_thing"
+        caller_line = 42
+        callee_name = "cli_helper"
+        callee_file_a = "tree_sitter_analyzer/cli/y.py"
+        callee_file_b = "tree_sitter_analyzer/cli/z.py"
+
+        conn = sqlite3.connect(str(db_path))
+        try:
+            conn.executescript(EDGE_STORE_SCHEMA)
+            for callee_file in (callee_file_a, callee_file_b):
+                source = symbol_node(caller_file, caller_name, caller_line)
+                target = symbol_node(callee_file, callee_name, 0)
+                metadata = _json.dumps(
+                    {
+                        "language": "python",
+                        "caller_name": caller_name,
+                        "caller_line": caller_line,
+                        "callee_name": callee_name,
+                        "callee_full": callee_name,
+                        "callee_resolution": "project",
+                        "callee_resolved_file": callee_file,
+                    },
+                    ensure_ascii=False,
+                    sort_keys=True,
+                )
+                conn.execute(
+                    "INSERT OR REPLACE INTO edges "
+                    "(source_node_id, target_node_id, kind, line, provenance, "
+                    " metadata, caller_name, callee_name, file_path, caller_line, "
+                    " callee_full, callee_line, language, callee_resolution, "
+                    " callee_resolved_file) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        source,
+                        target,
+                        EdgeKind.CALLS.value,
+                        caller_line,
+                        "tree-sitter",
+                        metadata,
+                        caller_name,
+                        callee_name,
+                        caller_file,
+                        caller_line,
+                        callee_name,
+                        0,
+                        "python",
+                        "project",
+                        callee_file,
+                    ),
+                )
+            conn.commit()
+
+            constraints = load_constraints(str(project))
+            # Must NOT raise — two same-PK violations must be deduplicated.
+            violations = evaluate(constraints, conn)
+        finally:
+            conn.close()
+
+        # Exactly 1 violation: the PK is (rule_id, caller_file, caller_line,
+        # callee_name).  Two edges with the same call site are ONE violation,
+        # not two.  The exact count is pinned so drift raises the test.
+        assert len(violations) == 1, (
+            f"Expected exactly 1 violation after PK deduplication, "
+            f"got {len(violations)}: {violations}"
+        )
+        v = violations[0]
+        assert v.rule_id == "dogfood-mcp-no-cli"
+        assert v.caller_file == caller_file
+        assert v.caller_line == caller_line
+        assert v.callee_name == callee_name

--- a/tree_sitter_analyzer/cli/commands/constraint_check_command.py
+++ b/tree_sitter_analyzer/cli/commands/constraint_check_command.py
@@ -219,7 +219,7 @@ def _run_and_persist(
         now = int(time.time())
         conn.executemany(
             """
-            INSERT INTO ast_constraint_violations
+            INSERT OR IGNORE INTO ast_constraint_violations
                 (rule_id, caller_file, caller_name, caller_line,
                  callee_name, callee_file, severity, detected_at)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?)

--- a/tree_sitter_analyzer/constraints/evaluator.py
+++ b/tree_sitter_analyzer/constraints/evaluator.py
@@ -70,7 +70,22 @@ def _iter_violations(
 
     Split out so the public ``evaluate()`` can wrap it in ``list(...)``
     without paying a generator-overhead penalty inside the hot loop.
+
+    Deduplication: the ``edges`` table can contain multiple rows for the
+    same logical call site (same caller_file + caller_line + callee_name)
+    with different ``callee_resolved_file`` values — e.g., when a call is
+    re-indexed by two resolution passes.  Both rows can match the same
+    constraint and produce ``Violation`` objects with identical PRIMARY
+    KEY ``(rule_id, caller_file, caller_line, callee_name)``.  Inserting
+    both into ``ast_constraint_violations`` would crash with
+    ``UNIQUE constraint failed`` (#544).
+
+    We keep a ``seen`` set and skip any PK tuple already emitted.  The
+    first occurrence wins (edge ordering from the DB is stable within a
+    transaction; the choice of which ``callee_file`` survives is arbitrary
+    but deterministic and the PK is the same violation regardless).
     """
+    seen: set[tuple[str, str, int, str]] = set()
     select_sql = _build_select_sql(db_conn)
     cursor = db_conn.execute(select_sql)
     for row in cursor:
@@ -86,6 +101,15 @@ def _iter_violations(
                 continue
             if _is_excepted(caller_file, cc):
                 continue
+            pk = (
+                cc.constraint.id,
+                caller_file,
+                int(caller_line or 0),
+                callee_name or "",
+            )
+            if pk in seen:
+                continue
+            seen.add(pk)
             yield Violation(
                 rule_id=cc.constraint.id,
                 caller_file=caller_file,

--- a/tree_sitter_analyzer/mcp/tools/constraint_check_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/constraint_check_tool.py
@@ -225,7 +225,7 @@ class ConstraintCheckTool(BaseMCPTool):
             now = int(time.time())
             conn.executemany(
                 """
-                INSERT INTO ast_constraint_violations
+                INSERT OR IGNORE INTO ast_constraint_violations
                     (rule_id, caller_file, caller_name, caller_line,
                      callee_name, callee_file, severity, detected_at)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)


### PR DESCRIPTION
## Summary
Fixes #544 (P1). `uv run python -m tree_sitter_analyzer --check-constraints --format json` crashed on a clean tree — exit 1, no JSON, `sqlite3.IntegrityError: UNIQUE constraint failed: ast_constraint_violations.rule_id, ...` — making the architectural-constraint gate (a README '5 layers of safety' pillar + the tsa-constraints skill) completely unusable.

## Root cause
The `edges` table stores one row per `(source, target, kind, line)`; the same call site resolved to two callee files yields two rows with the same `(rule_id, caller_file, caller_line, callee_name)` PK but different `callee_resolved_file`. Both match a rule → two `Violation` objects with identical PK → bare `executemany INSERT` crashes.

## Fix (no schema change)
- **Primary:** dedupe violations by PK in `evaluator.evaluate()` — two resolution targets for one call site are the *same* violation ('this call site broke rule X'), not two; no data lost (the site is still flagged). Chosen over extending the PK because the PK already captures the semantic.
- **Defense-in-depth:** `INSERT OR IGNORE` at both persist sites (CLI + MCP) guards any future duplicate-injecting path.

## Tests (RED-first, exact ==)
- `test_duplicate_pk_violations_deduplicated` — `len(violations) == 1`.
- `test_duplicate_pk_violations_do_not_crash_persist` — `len(rows) == 1`, no IntegrityError.
Both RED before (got 2 / IntegrityError), GREEN after. **Before:** exit 1 + sqlite error. **After:** `verdict: SAFE, success: True`, valid JSON, exit 0. 80 tests pass; ruff + mypy clean.

@codex review