### PR TITLE
fix(mcp): callers/callees full-index hint fires only when index is unbuilt, not on zero-edge projects (#705 follow-up)

### DIFF
--- a/tests/unit/test_callers_callees_tools.py
+++ b/tests/unit/test_callers_callees_tools.py
@@ -513,3 +513,52 @@ class TestEmptyIndexHint:
             f"--full-index hint must NOT appear when index has edges; "
             f"got: {next_step!r}"
         )
+
+    @pytest.mark.asyncio
+    async def test_callers_built_index_zero_edges_no_hint(self, tmp_path) -> None:
+        """#705 follow-up: index IS built (total_files > 0) but the project has
+        no call edges (e.g. a single ``def solo(): return 1``).  NOT_FOUND must
+        NOT carry a --full-index hint — the user already indexed; they just have
+        a project with no calls."""
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        (tmp_path / "solo.py").write_text(
+            "def solo():\n    return 1\n", encoding="utf-8"
+        )
+        cache = ASTCache(str(tmp_path))
+        cache.index_project()
+        assert cache.get_stats()["total_files"] == 1
+        assert not cache.has_call_edges()
+        cache.close()
+
+        tool = CodeGraphCallersTool(str(tmp_path))
+        result = await tool.execute({"function_name": "solo", "output_format": "json"})
+        assert result["verdict"] == "NOT_FOUND"
+        next_step = result.get("next_step", "")
+        assert "--full-index" not in next_step, (
+            f"--full-index hint must NOT appear when the index is built "
+            f"(zero-edge project); got: {next_step!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_callees_built_index_zero_edges_no_hint(self, tmp_path) -> None:
+        """#705 follow-up: same zero-edge scenario for callees."""
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        (tmp_path / "solo.py").write_text(
+            "def solo():\n    return 1\n", encoding="utf-8"
+        )
+        cache = ASTCache(str(tmp_path))
+        cache.index_project()
+        assert cache.get_stats()["total_files"] == 1
+        assert not cache.has_call_edges()
+        cache.close()
+
+        tool = CodeGraphCalleesTool(str(tmp_path))
+        result = await tool.execute({"function_name": "solo", "output_format": "json"})
+        assert result["verdict"] == "NOT_FOUND"
+        next_step = result.get("next_step", "")
+        assert "--full-index" not in next_step, (
+            f"--full-index hint must NOT appear when the index is built "
+            f"(zero-edge project); got: {next_step!r}"
+        )

--- a/tree_sitter_analyzer/mcp/tools/callees_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/callees_tool.py
@@ -123,7 +123,16 @@ class CodeGraphCalleesTool(CodeGraphRelationToolMixin, BaseMCPTool):
             if include_activation:
                 self._enrich_graph_callees_with_activation(callees)
             self._enrich_callees_with_resolution(callees)
-            has_any_call_edges = len(graph.call_edges()) > 0
+            # Suppress the --full-index hint when either:
+            #   (a) the index was built (data_source=="cache") — even if it
+            #       has zero call edges, the user already ran --full-index; or
+            #   (b) the parse fallback itself found call edges — the project
+            #       has calls, so the symbol just isn't there.
+            # Only fire the hint when the index is absent AND the parse found
+            # no edges at all (truly empty/unbuilt state).
+            has_any_call_edges = (
+                self._data_source == "cache" or len(graph.call_edges()) > 0
+            )
 
         warnings_list: list[str] = []
         if _is_stale_resolution(callees):

--- a/tree_sitter_analyzer/mcp/tools/callers_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/callers_tool.py
@@ -134,7 +134,16 @@ class CodeGraphCallersTool(CodeGraphRelationToolMixin, BaseMCPTool):
             callers = graph.callers_of(func_name, file_path)
             data_source = self._data_source
             self._enrich_callers_with_resolution(callers)
-            has_any_call_edges = len(graph.call_edges()) > 0
+            # Suppress the --full-index hint when either:
+            #   (a) the index was built (data_source=="cache") — even if it
+            #       has zero call edges, the user already ran --full-index; or
+            #   (b) the parse fallback itself found call edges — the project
+            #       has calls, so the symbol just isn't there.
+            # Only fire the hint when the index is absent AND the parse found
+            # no edges at all (truly empty/unbuilt state).
+            has_any_call_edges = (
+                self._data_source == "cache" or len(graph.call_edges()) > 0
+            )
 
         warnings_list: list[str] = []
         if _is_stale_resolution(callers):


### PR DESCRIPTION
## Summary
Codex P2 on merged #705. The #705 empty-index hint used `has_any_call_edges = len(graph.call_edges()) > 0`, which conflated *index-not-built* with *index-built-but-zero-edges* (e.g. a single `def solo(): return 1`). A legitimately indexed, edge-free project would be wrongly told to run `--full-index`.

## Fix
Gate the hint on the authoritative built-state signal `_data_source` (set to `"cache"` by `_get_call_graph()` when a live `ASTCache` with `total_files > 0` exists — i.e. the user ran `--full-index`):
```python
has_any_call_edges = (self._data_source == "cache" or len(graph.call_edges()) > 0)
```
The edge-count arm is retained so an unindexed project whose fresh parse DOES find edges still isn't treated as unbuilt (keeps `test_callers_non_empty_index_no_spurious_hint` green). Applied to BOTH callers_tool.py and callees_tool.py.

## Tests (RED-first, exact)
- `test_callers_built_index_zero_edges_no_hint` / `test_callees_built_index_zero_edges_no_hint` — after `ASTCache.index_project()` on a solo-function project (total_files==1, zero edges), `--full-index` NOT in next_step.
- #705's `TestEmptyIndexHint` (unbuilt → hint present) all still green. 44/44 pass; ruff+mypy clean.

@codex review