### PR TITLE
fix(nav): callers/callees emit agent_summary + mirrored verdict (#546 seam 3, #577 leftover)

### DIFF
--- a/tests/unit/test_callers_callees_tools.py
+++ b/tests/unit/test_callers_callees_tools.py
@@ -562,3 +562,151 @@ class TestEmptyIndexHint:
             f"--full-index hint must NOT appear when the index is built "
             f"(zero-edge project); got: {next_step!r}"
         )
+
+
+class TestAgentSummaryCallers:
+    """#546 seam 3 / #577 leftover: callers must emit agent_summary with
+    verdict + summary_line + next_step, mirroring the top-level verdict."""
+
+    @pytest.mark.asyncio
+    async def test_callers_has_agent_summary_found(self, tiny_project_root) -> None:
+        """INFO case: foo calls bar → bar has 1 caller (foo).
+        agent_summary must be present and summary_line must report count == 1.
+        Top-level verdict must mirror agent_summary.verdict.
+        """
+        tool = CodeGraphCallersTool(tiny_project_root)
+        result = await tool.execute({"function_name": "bar", "output_format": "json"})
+        assert result["verdict"] == "INFO"
+        agent_summary = result.get("agent_summary")
+        assert isinstance(agent_summary, dict), "agent_summary must be a dict"
+        assert agent_summary.get("verdict") in (
+            "INFO",
+            "NOT_FOUND",
+            "CAUTION",
+            "REVIEW",
+            "ERROR",
+        )
+        assert result["verdict"] == agent_summary["verdict"], (
+            "top-level verdict must mirror agent_summary.verdict"
+        )
+        summary_line = agent_summary.get("summary_line", "")
+        assert isinstance(summary_line, str) and summary_line, (
+            "summary_line must be non-empty"
+        )
+        # Extract the count from summary_line — fixture has exactly 1 caller (foo→bar).
+        import re
+
+        m = re.search(r"(\d+)\s+caller", summary_line)
+        assert m is not None, (
+            f"summary_line must mention caller count; got: {summary_line!r}"
+        )
+        assert int(m.group(1)) == 1, (
+            f"summary_line must report TRUE count 1, got {m.group(1)!r} in {summary_line!r}"
+        )
+        next_step = agent_summary.get("next_step", "")
+        assert isinstance(next_step, str) and next_step, "next_step must be non-empty"
+
+    @pytest.mark.asyncio
+    async def test_callers_has_agent_summary_not_found(self, tiny_project_root) -> None:
+        """NOT_FOUND case: unknown symbol → agent_summary present, verdict NOT_FOUND."""
+        tool = CodeGraphCallersTool(tiny_project_root)
+        result = await tool.execute(
+            {"function_name": "zzz_nonexistent_xyz", "output_format": "json"}
+        )
+        assert result["verdict"] == "NOT_FOUND"
+        agent_summary = result.get("agent_summary")
+        assert isinstance(agent_summary, dict), (
+            "agent_summary must be present even on NOT_FOUND"
+        )
+        assert agent_summary["verdict"] == "NOT_FOUND"
+        assert result["verdict"] == agent_summary["verdict"]
+        summary_line = agent_summary.get("summary_line", "")
+        assert isinstance(summary_line, str) and summary_line
+
+    @pytest.mark.asyncio
+    async def test_callers_verdict_mirrors_agent_summary(
+        self, tiny_project_root
+    ) -> None:
+        """Top-level verdict must always equal agent_summary.verdict (N4/r37u pattern)."""
+        tool = CodeGraphCallersTool(tiny_project_root)
+        for fn in ("bar", "foo", "zzz_nonexistent_xyz"):
+            result = await tool.execute({"function_name": fn, "output_format": "json"})
+            agent_summary = result.get("agent_summary", {})
+            assert result.get("verdict") == agent_summary.get("verdict"), (
+                f"verdict mismatch for {fn!r}: "
+                f"top={result.get('verdict')!r} summary={agent_summary.get('verdict')!r}"
+            )
+
+
+class TestAgentSummaryCallees:
+    """#546 seam 3 / #577 leftover: callees must emit agent_summary with
+    verdict + summary_line + next_step, mirroring the top-level verdict."""
+
+    @pytest.mark.asyncio
+    async def test_callees_has_agent_summary_found(self, tiny_project_root) -> None:
+        """INFO case: foo calls bar → foo has 1 callee (bar).
+        agent_summary must be present and summary_line must report count == 1.
+        Top-level verdict must mirror agent_summary.verdict.
+        """
+        tool = CodeGraphCalleesTool(tiny_project_root)
+        result = await tool.execute({"function_name": "foo", "output_format": "json"})
+        assert result["verdict"] == "INFO"
+        agent_summary = result.get("agent_summary")
+        assert isinstance(agent_summary, dict), "agent_summary must be a dict"
+        assert agent_summary.get("verdict") in (
+            "INFO",
+            "NOT_FOUND",
+            "CAUTION",
+            "REVIEW",
+            "ERROR",
+        )
+        assert result["verdict"] == agent_summary["verdict"], (
+            "top-level verdict must mirror agent_summary.verdict"
+        )
+        summary_line = agent_summary.get("summary_line", "")
+        assert isinstance(summary_line, str) and summary_line, (
+            "summary_line must be non-empty"
+        )
+        # Extract the count from summary_line — fixture has exactly 1 callee (foo→bar).
+        import re
+
+        m = re.search(r"(\d+)\s+(?:callee|function)", summary_line)
+        assert m is not None, (
+            f"summary_line must mention callee count; got: {summary_line!r}"
+        )
+        assert int(m.group(1)) == 1, (
+            f"summary_line must report TRUE count 1, got {m.group(1)!r} in {summary_line!r}"
+        )
+        next_step = agent_summary.get("next_step", "")
+        assert isinstance(next_step, str) and next_step, "next_step must be non-empty"
+
+    @pytest.mark.asyncio
+    async def test_callees_has_agent_summary_not_found(self, tiny_project_root) -> None:
+        """NOT_FOUND case: unknown symbol → agent_summary present, verdict NOT_FOUND."""
+        tool = CodeGraphCalleesTool(tiny_project_root)
+        result = await tool.execute(
+            {"function_name": "zzz_nonexistent_xyz", "output_format": "json"}
+        )
+        assert result["verdict"] == "NOT_FOUND"
+        agent_summary = result.get("agent_summary")
+        assert isinstance(agent_summary, dict), (
+            "agent_summary must be present even on NOT_FOUND"
+        )
+        assert agent_summary["verdict"] == "NOT_FOUND"
+        assert result["verdict"] == agent_summary["verdict"]
+        summary_line = agent_summary.get("summary_line", "")
+        assert isinstance(summary_line, str) and summary_line
+
+    @pytest.mark.asyncio
+    async def test_callees_verdict_mirrors_agent_summary(
+        self, tiny_project_root
+    ) -> None:
+        """Top-level verdict must always equal agent_summary.verdict (N4/r37u pattern)."""
+        tool = CodeGraphCalleesTool(tiny_project_root)
+        for fn in ("foo", "bar", "zzz_nonexistent_xyz"):
+            result = await tool.execute({"function_name": fn, "output_format": "json"})
+            agent_summary = result.get("agent_summary", {})
+            assert result.get("verdict") == agent_summary.get("verdict"), (
+                f"verdict mismatch for {fn!r}: "
+                f"top={result.get('verdict')!r} summary={agent_summary.get('verdict')!r}"
+            )

--- a/tree_sitter_analyzer/mcp/tools/callees_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/callees_tool.py
@@ -180,6 +180,28 @@ class CodeGraphCalleesTool(CodeGraphRelationToolMixin, BaseMCPTool):
         if next_step:
             result["next_step"] = next_step
 
+        # #546 seam 3 / #577 leftover: uniform agent_summary across all nav actions.
+        verdict = result.get("verdict", "NOT_FOUND")
+        if verdict == "NOT_FOUND":
+            as_summary_line = f"callees: {func_name!r} calls 0 function(s)"
+            as_next_step = result.get("next_step") or (
+                f"No callees found for '{func_name}'. "
+                "Check spelling or run --full-index to build the call graph."
+            )
+        else:
+            as_summary_line = (
+                f"callees: {func_name!r} calls {total_callees} function(s)"
+            )
+            as_next_step = result.get("next_step") or (
+                "Review callees above, run tests for dependencies, "
+                "or use nav action=callee_tree for the full call tree."
+            )
+        result["agent_summary"] = {
+            "summary_line": as_summary_line,
+            "verdict": verdict,
+            "next_step": as_next_step,
+        }
+
         from ..utils.format_helper import apply_toon_format_to_response
 
         return apply_toon_format_to_response(result, output_format)

--- a/tree_sitter_analyzer/mcp/tools/callers_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/callers_tool.py
@@ -196,6 +196,26 @@ class CodeGraphCallersTool(CodeGraphRelationToolMixin, BaseMCPTool):
         if next_step:
             result["next_step"] = next_step
 
+        # #546 seam 3 / #577 leftover: uniform agent_summary across all nav actions.
+        verdict = result.get("verdict", "NOT_FOUND")
+        if verdict == "NOT_FOUND":
+            as_summary_line = f"callers: {func_name!r} has 0 caller(s)"
+            as_next_step = result.get("next_step") or (
+                f"No callers found for '{func_name}'. "
+                "Check spelling or run --full-index to build the call graph."
+            )
+        else:
+            as_summary_line = f"callers: {func_name!r} has {total_callers} caller(s)"
+            as_next_step = result.get("next_step") or (
+                "Review callers above, run tests for affected paths, "
+                "or use nav action=caller_tree for the full blast-radius."
+            )
+        result["agent_summary"] = {
+            "summary_line": as_summary_line,
+            "verdict": verdict,
+            "next_step": as_next_step,
+        }
+
         from ..utils.format_helper import apply_toon_format_to_response
 
         return apply_toon_format_to_response(result, output_format)


### PR DESCRIPTION
## Summary
Advances **face B (envelope contract consistency)**. The #577 sweep added `agent_summary` to 7 facade actions but missed `callers`/`callees` — core nav tools agents drive on. Verified live on fresh develop: both returned NO `agent_summary`. (#546 seam 3 + #577 leftover.)

## Fix
Mirror the #577/#695 pattern (template: `codegraph_navigate_tool`): add `agent_summary = {summary_line, verdict, next_step}` to both `callers_tool.py` and `callees_tool.py`:
- summary_line reports the TRUE count (`total_callers`/`total_callees`, pre-truncation): `callers: 'fn' has N caller(s)`.
- verdict canonical (INFO/NOT_FOUND), mirrored to top-level `verdict` (N4 pattern).
- next_step reuses the existing hint (truncation / full-index) or a canonical default.

## Tests (RED-first, content-asserting, exact ==)
6 tests in `TestAgentSummaryCallers`/`TestAgentSummaryCallees`: agent_summary present (found + not-found), count pinned `== 1` via regex on summary_line (not substring-only — #697 lesson), top-level==agent_summary.verdict mirror. 6 RED→GREEN. 65 envelope/agent contract tests pass unchanged.

**Scope note:** #546 seams 1/2/4/5 (test-surface union, guard caller-count mislabel, change-impact null traps, test_map truncation) are the harder cross-tool fact-consistency seams — deliberate/RFC assessment, not this PR.

@codex review