### PR TITLE
fix(queries): Python FUNCTIONS no longer double-captures every function (#557)

### DIFF
--- a/tests/integration/mcp/test_user_story_3_query_integration.py
+++ b/tests/integration/mcp/test_user_story_3_query_integration.py
@@ -719,7 +719,9 @@ asyncio.run(main())
         with open(output_file, encoding="utf-8") as f:
             file_content = json.load(f)
             assert "results" in file_content
-            assert len(file_content["results"]) == 104
+            assert (
+                len(file_content["results"]) == 52
+            )  # was 104 (double-captured before #557); 52 is the correct single-capture count
 
         print(
             f"✓ ファイル出力最適化テスト成功: {result['count']}個の結果を{output_file.name}に保存"

--- a/tests/unit/core/test_queries_python.py
+++ b/tests/unit/core/test_queries_python.py
@@ -85,7 +85,7 @@ class TestPythonQueries:
         """Test that query constants are properly defined"""
         # Exact stripped lengths (update when query strings change)
         constant_lens = [
-            (FUNCTIONS, 315),
+            (FUNCTIONS, 159),
             (CLASSES, 156),
             (VARIABLES, 322),
             (IMPORTS, 445),
@@ -375,3 +375,54 @@ class TestPythonQueriesDictCompleteness:
         ]
         for cat in categories:
             assert cat in PYTHON_QUERIES
+
+
+class TestFunctionsQueryNoDuplicate:
+    """Regression test: FUNCTIONS query must not double-capture every function.
+
+    Bug #557: the second pattern (@function.async) was byte-identical to the
+    first (@function.definition), so every function_definition node matched
+    BOTH patterns, doubling all captures.  After the fix the query must yield
+    exactly N captures for a fixture with N function definitions.
+    """
+
+    def test_functions_query_no_double_capture(self) -> None:
+        """FUNCTIONS query yields exactly 3 captures for a 3-function fixture."""
+        try:
+            import tree_sitter_python
+            from tree_sitter import Language, Parser
+
+            from tree_sitter_analyzer.utils.tree_sitter_compat import (
+                TreeSitterQueryCompat,
+            )
+        except ImportError:
+            pytest.skip("tree-sitter or tree_sitter_python not available")
+
+        py_language = Language(tree_sitter_python.language())
+        parser = Parser(py_language)
+
+        # 3 function definitions: 2 sync + 1 async
+        code = b"def foo():\n    pass\n\ndef bar():\n    pass\n\nasync def baz():\n    pass\n"
+        tree = parser.parse(code)
+
+        from tree_sitter_analyzer.queries.python import FUNCTIONS
+
+        captures = TreeSitterQueryCompat.safe_execute_query(
+            py_language, FUNCTIONS, tree.root_node
+        )
+
+        # Count only the primary/anchor captures (function.definition or
+        # function.async) — one per function definition.  After the fix only
+        # @function.definition exists and each function produces exactly 1.
+        anchor_captures = [
+            name
+            for _node, name in captures
+            if name in ("function.definition", "function.async")
+        ]
+        assert len(anchor_captures) == 3  # was 6 before fix (double-capture bug)
+
+    def test_functions_query_no_async_capture_name(self) -> None:
+        """After the fix @function.async capture no longer exists in FUNCTIONS."""
+        from tree_sitter_analyzer.queries.python import FUNCTIONS
+
+        assert "@function.async" not in FUNCTIONS

--- a/tests/unit/core/test_queries_python.py
+++ b/tests/unit/core/test_queries_python.py
@@ -396,7 +396,10 @@ class TestFunctionsQueryNoDuplicate:
                 TreeSitterQueryCompat,
             )
         except ImportError:
-            pytest.skip("tree-sitter or tree_sitter_python not available")
+            pytest.skip(
+                "tree-sitter or tree_sitter_python not available; "
+                "tracked: optional tree-sitter grammar dependency"
+            )
 
         py_language = Language(tree_sitter_python.language())
         parser = Parser(py_language)

--- a/tests/unit/core/test_query_code_cross_language_compatibility.py
+++ b/tests/unit/core/test_query_code_cross_language_compatibility.py
@@ -273,7 +273,9 @@ public class JavaClass {
                 "functions query should return results"
             )
             assert len(function_results) == 4, "Should find Python functions"
-            assert len(functions_results) == 32, "Should find Python functions"
+            assert len(functions_results) == 16, (
+                "Should find Python functions"
+            )  # was 32 (double-captured before #557); 16 is the correct single-capture count
 
             # Test class queries
             class_results = await query_service.execute_query(
@@ -399,7 +401,10 @@ public class JavaClass {
         expected_counts = {
             ("javascript", "functions"): 23,
             ("typescript", "functions"): 19,
-            ("python", "functions"): 32,
+            (
+                "python",
+                "functions",
+            ): 16,  # was 32 (double-captured before #557); 16 is the correct single-capture count
             ("java", "methods"): 3,
         }
 

--- a/tree_sitter_analyzer/queries/python.py
+++ b/tree_sitter_analyzer/queries/python.py
@@ -16,11 +16,6 @@ FUNCTIONS = """
     name: (identifier) @function.name
     parameters: (parameters) @function.params
     body: (block) @function.body) @function.definition
-
-(function_definition
-    name: (identifier) @function.name
-    parameters: (parameters) @function.params
-    body: (block) @function.body) @function.async
 """
 
 # Class definitions


### PR DESCRIPTION
## Summary
Fixes #557 (face A — extraction correctness). The Python `FUNCTIONS` query had a verbatim-duplicate pattern: `@function.async` was byte-identical to `@function.definition` (same `function_definition name/params/body`) and did NOT filter for async — so it matched **every** function, double-capturing all of them in the `functions` query output.

**Proof (3-function fixture incl. 1 async):** anchor captures 6→3, total (node,capture) tuples 24→12.

## Fix
`grep` confirmed **zero consumers** of `@function.async` anywhere → it was a copy-paste duplicate. Removed the second pattern (simplest correct fix). Verified no other `queries/*.py` module carries the same duplicate (Python-only).

## Tests (RED-first, exact ==)
`TestFunctionsQueryNoDuplicate`:
- `test_functions_query_no_double_capture` — anchor count `== 3` (was 6).
- `test_functions_query_no_async_capture_name` — `@function.async` absent.
FUNCTIONS stripped-length pin re-pinned 315→159 (the query shrank). 51 query tests + 1048 verification suite green; Python golden unaffected; ruff+mypy clean. (Swift golden failure is a pre-existing env flake — missing tree-sitter-swift wheel, identical on base.)

@codex review