### PR TITLE
docs(readme): hero section — lead with cross-language correctness + agent-native (面 G Tier-1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,20 @@
 
 **English** | **[日本語](README_ja.md)** | **[简体中文](README_zh.md)**
 
-Code intelligence for AI agents: a pre-indexed, token-efficient MCP server — **8 MCP tools** + CLI, 100% local.
+[![PyPI](https://img.shields.io/pypi/v/tree-sitter-analyzer.svg)](https://pypi.org/project/tree-sitter-analyzer/) [![Python](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://python.org) [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE) [![Coverage](https://codecov.io/gh/aimasteracc/tree-sitter-analyzer/branch/main/graph/badge.svg)](https://codecov.io/gh/aimasteracc/tree-sitter-analyzer) [![Stars](https://img.shields.io/github/stars/aimasteracc/tree-sitter-analyzer.svg?style=social)](https://github.com/aimasteracc/tree-sitter-analyzer) [![Works with Claude Code · Cursor · MCP](https://img.shields.io/badge/works%20with-Claude%20Code%20%C2%B7%20Cursor%20%C2%B7%20MCP-6f42c1.svg)](#supported-agents)
 
-* **Instant structural answers.** Who calls this? What would break? Generate a UML diagram. One call returns the whole answer — no grep loop.
-* **Token-budget aware.** TOON output cuts bulk/tabular payload by ~50-70% vs raw JSON ([measured invariant](tests/unit/mcp/test_output_cost_invariants.py)); RFC-0012 measured 0.52× ratio on representative decision tools.
-* **Edit safely.** `edit action=safe` + `edit action=impact` + constraint DSL gate every modification before it happens; [≈0 cross-language mis-wires](benchmarks/codegraph_compare/MISWIRE-AUDIT-EXAMPLES.md) in the call graph.
+**Code intelligence AI agents can trust** — correct cross-language structure across 20+ languages, agent-native (MCP + CLI).
 
-> **100% local** means the index lives in `.ast-cache/` inside your repo, no telemetry, no remote calls. Every MCP response + CLI output is generated locally from the SQLite+FTS5 cache.
+TSA indexes your codebase with tree-sitter and serves correct call graphs, symbol search, and structural queries to AI coding agents — locally, with no telemetry.
+
+**Why it's different:**
+* **Cross-language correctness is the moat.** A name-only index wires Python `sorted()` to a Swift `func sorted`. TSA doesn't. ~390× fewer cross-language call-graph mis-wires than alternatives ([reproducible audit](benchmarks/codegraph_compare/MISWIRE-AUDIT-EXAMPLES.md)).
+* **Built agent-native.** 8 MCP tools, TOON output (~50-70% smaller than JSON on bulk responses), verdict envelopes, and 13 curated Skills — designed for Claude Code, Cursor, and any MCP client.
+* **Broad and correctly classified.** 13 languages with full call-graph indexing (Python · Go · Rust · Java · JS · TS · C · C++ · C# · Swift · Kotlin · Ruby · PHP), 8 more symbol-indexed or CLI-reachable.
+
+> **Proof:** on HuggingFace `tokenizers` (Rust+Python+JS+TS), a name-only resolver mis-wires **1,259** call edges — TSA: **0**. Run it on your repo in seconds: `uvx --from tree-sitter-analyzer miswire-audit .`
 
 > Upgrading from v1.x? See [docs/MIGRATION.md](docs/MIGRATION.md).
-
-[![PyPI](https://img.shields.io/pypi/v/tree-sitter-analyzer.svg)](https://pypi.org/project/tree-sitter-analyzer/)
-[![Python Version](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://python.org)
-[![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-19300%20passed-brightgreen.svg)](#quality--testing)
-[![Coverage](https://codecov.io/gh/aimasteracc/tree-sitter-analyzer/branch/main/graph/badge.svg)](https://codecov.io/gh/aimasteracc/tree-sitter-analyzer)
-[![GitHub Stars](https://img.shields.io/github/stars/aimasteracc/tree-sitter-analyzer.svg?style=social)](https://github.com/aimasteracc/tree-sitter-analyzer)
 
 ---
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -2,22 +2,20 @@
 
 **[English](README.md)** | **日本語** | **[简体中文](README_zh.md)**
 
-AI エージェントのためのコード インテリジェンス: 事前インデックス済みのトークン効率の良い MCP サーバー — **8 MCP ツール** + CLI、100% ローカル動作。
+[![PyPI](https://img.shields.io/pypi/v/tree-sitter-analyzer.svg)](https://pypi.org/project/tree-sitter-analyzer/) [![Python](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://python.org) [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE) [![Coverage](https://codecov.io/gh/aimasteracc/tree-sitter-analyzer/branch/main/graph/badge.svg)](https://codecov.io/gh/aimasteracc/tree-sitter-analyzer) [![Stars](https://img.shields.io/github/stars/aimasteracc/tree-sitter-analyzer.svg?style=social)](https://github.com/aimasteracc/tree-sitter-analyzer) [![対応: Claude Code · Cursor · MCP](https://img.shields.io/badge/対応-Claude%20Code%20%C2%B7%20Cursor%20%C2%B7%20MCP-6f42c1.svg)](#supported-agents)
 
-* **即時の構造的回答。** 誰がこれを呼ぶ？何が壊れる？UML 図を生成。1 回の呼び出しで全ての答えが返る — grep ループ不要。
-* **トークン バジェット意識。** TOON 出力は bulk/tabular ペイロードを生 JSON 比 ~50-70% 削減（[実測済み不変量](tests/unit/mcp/test_output_cost_invariants.py); RFC-0012 で代表的な決定ツールにて 0.52× を計測）。
-* **安全な編集。** `edit action=safe` + `edit action=impact` + 制約 DSL が全ての変更を事前にゲート; コール グラフの[異言語誤結線 ≈0](benchmarks/codegraph_compare/MISWIRE-AUDIT-EXAMPLES.md)。
+**AI エージェントが信頼できるコード インテリジェンス** — 20+ 言語にわたる正確なクロスランゲージ構造解析、エージェントネイティブ設計（MCP + CLI）。
 
-> **100% ローカル** とは、インデックスがリポジトリ内の `.ast-cache/` に保存され、テレメトリや外部呼び出しが一切ないことを意味します。全 MCP レスポンスおよび CLI 出力は SQLite+FTS5 キャッシュからローカルで生成されます。
+TSA は tree-sitter でコードベースをインデックスし、正確なコール グラフ・シンボル検索・構造クエリを AI コーディング エージェントへ提供します — 完全ローカル、テレメトリなし。AI エージェントのためのコード インテリジェンス: 事前インデックス済みのトークン効率の良い MCP サーバー — **8 MCP ツール** + CLI、100% ローカル動作。
+
+**なぜ違うのか：**
+* **クロスランゲージ正確性がモート（堀）。** 名前照合のみのインデックスは Python `sorted()` を Swift `func sorted` に結線する。TSA はしない。競合ツール比 ~390× 少ないクロスランゲージ誤結線（[再現可能な監査](benchmarks/codegraph_compare/MISWIRE-AUDIT-EXAMPLES.md)）。
+* **エージェントネイティブ。** **8 MCP ツール**、TOON 出力（bulk レスポンスが JSON より ~50-70% 小さい）、verdict エンベロープ、13 のキュレーテッド Skills — Claude Code・Cursor・任意の MCP クライアント向け設計。
+* **広くかつ正確に分類。** 13 言語のフルコールグラフ インデックス（Python · Go · Rust · Java · JS · TS · C · C++ · C# · Swift · Kotlin · Ruby · PHP）、他 8 言語はシンボル インデックスまたは CLI 経由でアクセス可。
+
+> **実測値：** HuggingFace `tokenizers`（Rust+Python+JS+TS）において名前照合リゾルバは **1,259** コール エッジを誤結線 — TSA は **0**。自分のリポジトリで確認: `uvx --from tree-sitter-analyzer miswire-audit .`
 
 > v1.x からの移行は [docs/MIGRATION.md](docs/MIGRATION.md) を参照。
-
-[![PyPI](https://img.shields.io/pypi/v/tree-sitter-analyzer.svg)](https://pypi.org/project/tree-sitter-analyzer/)
-[![Python Version](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://python.org)
-[![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-19300%20passed-brightgreen.svg)](#-品質とテスト)
-[![Coverage](https://codecov.io/gh/aimasteracc/tree-sitter-analyzer/branch/main/graph/badge.svg)](https://codecov.io/gh/aimasteracc/tree-sitter-analyzer)
-[![GitHub Stars](https://img.shields.io/github/stars/aimasteracc/tree-sitter-analyzer.svg?style=social)](https://github.com/aimasteracc/tree-sitter-analyzer)
 
 ---
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -2,22 +2,20 @@
 
 **[English](README.md)** | **[日本語](README_ja.md)** | **简体中文**
 
-专为 AI agent 而生的代码情报：预建索引、token 高效的 MCP 服务器 — **8 个 MCP 工具** + CLI，100% 本地运行。
+[![PyPI](https://img.shields.io/pypi/v/tree-sitter-analyzer.svg)](https://pypi.org/project/tree-sitter-analyzer/) [![Python](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://python.org) [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE) [![Coverage](https://codecov.io/gh/aimasteracc/tree-sitter-analyzer/branch/main/graph/badge.svg)](https://codecov.io/gh/aimasteracc/tree-sitter-analyzer) [![Stars](https://img.shields.io/github/stars/aimasteracc/tree-sitter-analyzer.svg?style=social)](https://github.com/aimasteracc/tree-sitter-analyzer) [![适配 Claude Code · Cursor · MCP](https://img.shields.io/badge/适配-Claude%20Code%20%C2%B7%20Cursor%20%C2%B7%20MCP-6f42c1.svg)](#supported-agents)
 
-* **即时结构化解答。** 谁调用这个？改了会破坏什么？生成 UML 图。一次调用返回完整答案 — 无需 grep 循环。
-* **token 预算意识。** TOON 输出将 bulk/tabular 载荷相比原始 JSON 削减 ~50-70%（[可执行不变量](tests/unit/mcp/test_output_cost_invariants.py)；RFC-0012 在代表性决策工具上实测比值 0.52×）。
-* **安全编辑。** `edit action=safe` + `edit action=impact` + 约束 DSL 在每次修改前把关；调用图[跨语言错连 ≈0](benchmarks/codegraph_compare/MISWIRE-AUDIT-EXAMPLES.md)。
+**AI agent 可以信赖的代码情报** — 跨 20+ 语言的正确结构分析，为 agent 原生设计（MCP + CLI）。
 
-> **100% 本地**意味着索引保存在你仓库内的 `.ast-cache/` 中，无遥测、无远程调用。所有 MCP 响应和 CLI 输出均从本地 SQLite+FTS5 缓存生成。
+TSA 使用 tree-sitter 索引你的代码库，向 AI 编程 agent 提供正确的调用图、符号搜索与结构查询 — 完全本地，零遥测。专为 AI agent 而生的代码情报：预建索引、token 高效的 MCP 服务器 — **8 个 MCP 工具** + CLI，100% 本地运行。
+
+**为什么不同：**
+* **跨语言正确性是护城河。** 名称匹配式索引会把 Python `sorted()` 连到 Swift `func sorted`。TSA 不会。比同类工具少约 390× 的跨语言调用图错连（[可复现审计](benchmarks/codegraph_compare/MISWIRE-AUDIT-EXAMPLES.md)）。
+* **为 agent 原生设计。** 8 个 MCP 工具，TOON 输出（bulk 响应比 JSON 小约 50-70%），verdict 信封，13 个精选 Skills — 专为 Claude Code、Cursor 和任何 MCP 客户端设计。
+* **广度与正确性兼备。** 13 种语言全量调用图索引（Python · Go · Rust · Java · JS · TS · C · C++ · C# · Swift · Kotlin · Ruby · PHP），另有 8 种语言符号索引或 CLI 可达。
+
+> **数据证明：** 在 HuggingFace `tokenizers`（Rust+Python+JS+TS）上，名称匹配式解析器会错连 **1,259** 条调用边 — TSA：**0**。在你自己的仓库上运行：`uvx --from tree-sitter-analyzer miswire-audit .`
 
 > 从 v1.x 升级？见 [docs/MIGRATION.md](docs/MIGRATION.md)。
-
-[![PyPI](https://img.shields.io/pypi/v/tree-sitter-analyzer.svg)](https://pypi.org/project/tree-sitter-analyzer/)
-[![Python Version](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://python.org)
-[![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-19300%20passed-brightgreen.svg)](#-质量与测试)
-[![Coverage](https://codecov.io/gh/aimasteracc/tree-sitter-analyzer/branch/main/graph/badge.svg)](https://codecov.io/gh/aimasteracc/tree-sitter-analyzer)
-[![GitHub Stars](https://img.shields.io/github/stars/aimasteracc/tree-sitter-analyzer.svg?style=social)](https://github.com/aimasteracc/tree-sitter-analyzer)
 
 ---
 


### PR DESCRIPTION
## Summary
面 G (growth) Tier-1: restructure the README top into a positioning-led HERO. Stars flat at 36 vs ~5k/mo downloads = a discovery/conversion problem; the README is the landing page. Owner-approved.

## Changes (all 3 READMEs, EN/zh/ja)
- One-line hook: **'Code intelligence AI agents can trust'** — cross-language correctness + agent-native.
- Badge row incl. a 'Works with Claude Code · Cursor · MCP' agent-native signal. **Removed a static `tests-19300` badge** (rots; kept dynamic codecov).
- 3 differentiation bullets (correctness moat / agent-native / breadth) + a concrete proof point (mis-wire audit 1,259→0, with the real `uvx ... miswire-audit` CTA).
- All numbers registry-sourced or pre-existing verified benchmark data; flows into the existing #705 py3.10 Get-Started.

## Tests
README.md 475 lines (<500 ✓), zh 432, ja 429. `test_readme_structure.py` 12 passed, `test_readme_counts_match_registry` passed. Docs-only.

@codex review