### PR TITLE
fix(mcp): enum-mode rejections enumerate valid values (#690)

### DIFF
--- a/tests/unit/mcp/test_enum_error_enumeration.py
+++ b/tests/unit/mcp/test_enum_error_enumeration.py
@@ -1,0 +1,121 @@
+"""Contract: every enum-mode rejection enumerates the valid values (#690).
+
+Background (#690): facade actions that reject a ``mode`` value used to raise a
+bare ``ValueError("Invalid mode: <got>")`` — the agent saw the bad value but
+never the legal set, so it could not self-correct, and ``recovery_hint`` fell
+back to generic boilerplate ("Review the error message and adjust your
+request.") that pointed at a message with nothing to review.
+
+This test pins the fix as a mechanical invariant on two surfaces:
+
+1. **Inner tool ``validate_arguments``** — a bad ``mode`` raises a ``ValueError``
+   whose message carries the canonical ``"Valid values: ..."`` enumeration and
+   actually lists the real valid modes. A regression to a bare raise goes red.
+2. **The real ``handle_call_tool`` boundary** (the #690 headline repro,
+   ``viz action=similarity mode=<bad>``) — the final envelope's ``error`` lists
+   the valid values AND ``recovery_hint`` is the canonical enum hint, not the
+   boilerplate. Asserted through the boundary (not ``execute``) per the audit
+   lesson that ``execute``-level tests miss facade arg-projection seams.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import Mock, patch
+
+import pytest
+
+from tree_sitter_analyzer.mcp.server import TreeSitterAnalyzerMCPServer
+from tree_sitter_analyzer.mcp.tools.ast_cache_tool import ASTCacheTool
+from tree_sitter_analyzer.mcp.tools.auto_index_tool import CodeGraphAutoIndexTool
+from tree_sitter_analyzer.mcp.tools.code_similarity_tool import CodeGraphSimilarityTool
+from tree_sitter_analyzer.mcp.tools.decision_journal_tool import DecisionJournalTool
+from tree_sitter_analyzer.mcp.tools.incremental_sync_tool import (
+    CodeGraphIncrementalSyncTool,
+)
+
+# (tool class, set of modes that MUST appear in the enumerated error).
+# These are the tools whose bare ``Invalid mode: X`` raises were routed through
+# ``invalid_enum_error`` in this change. ``fts_search`` is intentionally absent
+# from ASTCacheTool's enumerated guidance (deprecated alias, J1).
+_ENUM_TOOLS: list[tuple[type, set[str]]] = [
+    (CodeGraphSimilarityTool, {"all", "structural", "textual"}),
+    (CodeGraphIncrementalSyncTool, {"sync", "changes", "status"}),
+    (CodeGraphAutoIndexTool, {"status", "warm", "reset"}),
+    (ASTCacheTool, {"index", "lookup", "search", "stats"}),
+    (DecisionJournalTool, {"record", "get", "search", "supersede"}),
+]
+
+
+@pytest.mark.parametrize("tool_cls, expected_modes", _ENUM_TOOLS)
+def test_invalid_mode_enumerates_valid_values(
+    tool_cls: type, expected_modes: set[str], tmp_path
+) -> None:
+    """A bad ``mode`` raises a ValueError that lists the valid modes (#690)."""
+    tool = tool_cls(str(tmp_path))
+    with pytest.raises(ValueError) as exc_info:
+        tool.validate_arguments({"mode": "definitely-not-a-real-mode"})
+    message = str(exc_info.value)
+    # Canonical enumeration marker — guards against a regression to a bare raise.
+    assert "Valid values:" in message, (
+        f"{tool_cls.__name__} enum error lacks the canonical 'Valid values:' "
+        f"enumeration: {message!r}"
+    )
+    # The actual legal modes must be discoverable in the message.
+    for mode in expected_modes:
+        assert mode in message, (
+            f"{tool_cls.__name__} enum error omits valid mode {mode!r}: {message!r}"
+        )
+    # The bad value is still echoed so the agent knows what was rejected.
+    assert "definitely-not-a-real-mode" in message
+
+
+def _capture_call_tool_handler(server: TreeSitterAnalyzerMCPServer):
+    """Capture the ``handle_call_tool`` closure registered by ``create_server``."""
+    with patch("tree_sitter_analyzer.mcp.server.MCP_AVAILABLE", True):
+        with patch("tree_sitter_analyzer.mcp.server.Server") as mock_server_class:
+            mock_server = Mock()
+            captured: dict = {}
+
+            def capture_decorator(name):
+                def decorator(func):
+                    captured[name] = func
+                    return func
+
+                return decorator
+
+            mock_server.call_tool.return_value = capture_decorator("call_tool")
+            mock_server_class.return_value = mock_server
+            server.create_server()
+            return captured["call_tool"]
+
+
+def test_boundary_enum_error_lists_values_and_canonical_hint(tmp_path) -> None:
+    """#690 headline repro through the real boundary: viz action=similarity with
+    an invalid mode ships an envelope that enumerates valid modes AND carries the
+    canonical enum recovery_hint (not the generic boilerplate)."""
+    src = tmp_path / "x.py"
+    src.write_text("def f():\n    return 1\n")
+    server = TreeSitterAnalyzerMCPServer(str(tmp_path))
+    handler = _capture_call_tool_handler(server)
+
+    res = asyncio.run(
+        handler(
+            "viz",
+            {"action": "similarity", "mode": "summary"},
+        )
+    )
+    body = json.loads(res[0].text)
+
+    assert body.get("success") is False
+    error = body.get("error", "")
+    assert "Valid values:" in error, f"boundary error not enumerated: {error!r}"
+    for mode in ("all", "structural", "textual"):
+        assert mode in error, f"boundary error omits {mode!r}: {error!r}"
+    # #690 second half: recovery_hint must NOT be the dead-end boilerplate.
+    hint = body.get("recovery_hint", "")
+    assert "lists the valid values" in hint, (
+        f"recovery_hint is not the canonical enum hint: {hint!r}"
+    )
+    assert hint != "Review the error message and adjust your request."

--- a/tree_sitter_analyzer/mcp/tools/ast_cache_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/ast_cache_tool.py
@@ -17,6 +17,7 @@ from ...ast_cache import ASTCache
 from ...file_watcher import FileWatcherDaemon
 from ...incremental_sync import IncrementalSync
 from ...utils import setup_logger
+from ._validators import invalid_enum_error
 from .base_tool import BaseMCPTool, _canonicalize_verdict, mirror_summary_line
 
 logger = setup_logger(__name__)
@@ -363,7 +364,10 @@ class ASTCacheTool(BaseMCPTool):
             "watch_status",
         }
         if mode not in valid_modes:
-            raise ValueError(f"Invalid mode: {mode}. Must be one of {valid_modes}")
+            # ``fts_search`` is still accepted above (deprecated alias, J1) but is
+            # intentionally omitted from the enumerated guidance so agents are
+            # steered to the supported ``search`` name.
+            raise invalid_enum_error("mode", mode, sorted(valid_modes - {"fts_search"}))
         if mode in ("lookup", "invalidate") and not arguments.get("file_path"):
             raise ValueError(f"file_path is required for mode '{mode}'")
         if mode in ("search", "fts_search") and not arguments.get("query"):

--- a/tree_sitter_analyzer/mcp/tools/auto_index_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/auto_index_tool.py
@@ -24,6 +24,7 @@ from ..utils.auto_index_guard import (
 )
 from ..utils.format_helper import apply_toon_format_to_response
 from ._response_builder import build_error, build_response
+from ._validators import invalid_enum_error
 from .base_tool import BaseMCPTool
 
 logger = setup_logger(__name__)
@@ -82,8 +83,9 @@ class CodeGraphAutoIndexTool(BaseMCPTool):
 
     def validate_arguments(self, arguments: dict[str, Any]) -> bool:
         mode = arguments.get("mode", "status")
-        if mode not in ("status", "warm", "reset"):
-            raise ValueError(f"Invalid mode: {mode}")
+        valid_modes = ["status", "warm", "reset"]
+        if mode not in valid_modes:
+            raise invalid_enum_error("mode", mode, valid_modes)
         return True
 
     async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:

--- a/tree_sitter_analyzer/mcp/tools/code_similarity_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/code_similarity_tool.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from ...code_similarity import analyze_code_similarity
 from ...utils import setup_logger
+from ._validators import invalid_enum_error
 from .base_tool import BaseMCPTool
 
 logger = setup_logger(__name__)
@@ -99,8 +100,9 @@ class CodeGraphSimilarityTool(BaseMCPTool):
 
     def validate_arguments(self, arguments: dict[str, Any]) -> bool:
         mode = arguments.get("mode", "all")
-        if mode not in ("all", "structural", "textual"):
-            raise ValueError(f"Invalid mode: {mode}")
+        valid_modes = ["all", "structural", "textual"]
+        if mode not in valid_modes:
+            raise invalid_enum_error("mode", mode, valid_modes)
         return True
 
     async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:

--- a/tree_sitter_analyzer/mcp/tools/decision_journal_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/decision_journal_tool.py
@@ -27,6 +27,7 @@ from ...decision_journal import (
     JournalValidationError,
 )
 from ..utils.format_helper import apply_toon_format_to_response
+from ._validators import invalid_enum_error
 from .base_tool import BaseMCPTool, _canonicalize_verdict, mirror_summary_line
 
 _VALID_MODES = ("record", "get", "search", "supersede")
@@ -204,9 +205,7 @@ class DecisionJournalTool(BaseMCPTool):
     def validate_arguments(self, arguments: dict[str, Any]) -> bool:
         mode = arguments.get("mode", "search")
         if mode not in _VALID_MODES:
-            raise ValueError(
-                f"Invalid mode '{mode}'; expected one of: {', '.join(_VALID_MODES)}"
-            )
+            raise invalid_enum_error("mode", mode, list(_VALID_MODES))
         if mode == "record":
             if not arguments.get("title") or not arguments.get("rationale"):
                 raise ValueError("record mode requires title and rationale")

--- a/tree_sitter_analyzer/mcp/tools/incremental_sync_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/incremental_sync_tool.py
@@ -20,6 +20,7 @@ from ...utils import setup_logger
 from ..utils.auto_index_guard import ensure_indexed, is_indexed
 from ..utils.format_helper import apply_toon_format_to_response
 from ._response_builder import build_error, build_response
+from ._validators import invalid_enum_error
 from .base_tool import BaseMCPTool
 
 logger = setup_logger(__name__)
@@ -77,8 +78,9 @@ class CodeGraphIncrementalSyncTool(BaseMCPTool):
 
     def validate_arguments(self, arguments: dict[str, Any]) -> bool:
         mode = arguments.get("mode", "sync")
-        if mode not in ("sync", "changes", "status"):
-            raise ValueError(f"Invalid mode: {mode}")
+        valid_modes = ["sync", "changes", "status"]
+        if mode not in valid_modes:
+            raise invalid_enum_error("mode", mode, valid_modes)
         return True
 
     async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
## What

Closes #690. Five facade-reachable MCP tools rejected an invalid `mode` with a bare `ValueError("Invalid mode: X")` — the agent saw the bad value but never the legal set, so it could not self-correct, and `recovery_hint` fell back to the dead-end boilerplate ("Review the error message…") pointing at a message with nothing to review.

This routes every bare enum-mode raise through the existing `invalid_enum_error()` helper, so each rejection carries the canonical `Invalid mode: 'X'. Valid values: …` enumeration. As a side effect the canonical enum `recovery_hint` now fires (the central classifier keys on the `valid values:` substring), fixing #690's second half too.

## Plane-B line, not a point

This is one coherent line under **面 B (envelope / agent contract)** — *"every enum rejection is self-correctable"* — not a one-off patch of the reported repro. Tools touched:

- `code_similarity` (`viz action=similarity` — the #690 repro)
- `incremental_sync`, `auto_index`, `ast_cache` (`index` facade)
- `decision_journal` (`project action=journal`)

`ast_cache` intentionally omits the deprecated `fts_search` alias (J1) from the enumerated guidance so agents are steered to the supported `search` name (the alias is still accepted at the boundary).

Already-enumerating forms (`Must be 'symbol' or 'file'`, `expected one of: …`) were left as-is — an agent can already self-correct from those; force-normalizing them would be churn risking exact-string test breakage for no agent-facing gain.

## Mechanical invariant (so it can't silently regress)

`tests/unit/mcp/test_enum_error_enumeration.py`:
1. Parametrized `validate_arguments` check — every touched tool's enum error contains `Valid values:` and lists its real valid modes. A regression to a bare raise goes red.
2. A real `handle_call_tool` **boundary** test of the `viz action=similarity` repro — asserts the final envelope's `error` enumerates the values AND `recovery_hint` is the canonical enum hint, not the boilerplate. (Boundary, not `execute`, per the audit lesson that execute-level tests miss facade arg-projection seams.)

## Test plan

- [x] `test_enum_error_enumeration.py` — 6 passed (incl. boundary)
- [x] 1187 passed across the 5 tool suites + `tests/unit/mcp/tools/` + `test_agent_contracts.py`
- [x] ruff / ruff format / mypy clean
- [ ] CI green on all axes
- [ ] Codex review triaged

🤖 Generated with [Claude Code](https://claude.com/claude-code)