### PR TITLE
fix(health): test_gap honors file_path in every mode (#693)

### DIFF
--- a/tests/unit/test_test_gap_tool.py
+++ b/tests/unit/test_test_gap_tool.py
@@ -215,3 +215,61 @@ class TestPackageScopeCollectFiles:
         result = analyze_coverage_gaps(str(tmp_path), max_files=1000)
         # Only real_func is a production symbol; sample_func (×3) must not appear
         assert result.total_production_symbols == 1
+
+
+class TestFilePathScoping:
+    """Issue #693: file_path must scope the analysis, not be a silent no-op."""
+
+    def _two_file_project(self, tmp_path):
+        """Two production files with distinct symbol counts, no matching tests."""
+        pkg = tmp_path / "pkg"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text("")
+        # alpha.py: 3 functions
+        (pkg / "alpha.py").write_text(
+            "def a_one():\n    pass\n\ndef a_two():\n    pass\n\n"
+            "def a_three():\n    pass\n"
+        )
+        # beta.py: 1 function
+        (pkg / "beta.py").write_text("def b_one():\n    pass\n")
+        return tmp_path
+
+    def test_target_file_scopes_analyzer_totals(self, tmp_path):
+        """analyze_coverage_gaps(target_file=...) counts only that file's symbols."""
+        project = self._two_file_project(tmp_path)
+        full = analyze_coverage_gaps(str(project), max_files=1000)
+        scoped = analyze_coverage_gaps(
+            str(project), max_files=1000, target_file="alpha.py"
+        )
+        # 3 (alpha) + 1 (beta) project-wide; alpha.py alone has exactly 3.
+        assert full.total_production_symbols == 4
+        assert scoped.total_production_symbols == 3
+        assert scoped.summary["production_files"] == 1
+        assert {g.symbol.file_path for g in scoped.gaps} == {
+            str(project / "pkg" / "alpha.py")
+        }
+
+    def test_target_file_default_none_is_project_wide(self, tmp_path):
+        """Omitting target_file keeps the existing project-wide behavior."""
+        project = self._two_file_project(tmp_path)
+        assert (
+            analyze_coverage_gaps(str(project), max_files=1000).total_production_symbols
+            == 4
+        )
+
+    @pytest.mark.asyncio
+    async def test_file_path_honored_in_gaps_mode(self, tool, tmp_path):
+        """#693 core: file_path in the default (gaps) mode scopes the result —
+        it used to be echoed but silently ignored, so the body was identical
+        regardless of the path."""
+        project = self._two_file_project(tmp_path)
+        tool.set_project_path(str(project))
+        whole = await tool.execute({"mode": "gaps", "output_format": "json"})
+        scoped = await tool.execute(
+            {"mode": "gaps", "file_path": "alpha.py", "output_format": "json"}
+        )
+        assert whole["total_production_symbols"] == 4
+        assert scoped["total_production_symbols"] == 3
+        # The two responses must NOT be identical (the #693 trap).
+        assert scoped["gap_count"] != whole["gap_count"]
+        assert all("alpha.py" in g["file"] for g in scoped["gaps"])

--- a/tree_sitter_analyzer/mcp/tools/test_gap_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/test_gap_tool.py
@@ -38,7 +38,12 @@ TOOL_SCHEMA: dict[str, Any] = {
         },
         "file_path": {
             "type": "string",
-            "description": "File path for mode 'file' (relative to project root).",
+            "description": (
+                "Scope the analysis to one file (substring match, relative to "
+                "project root). Required for mode 'file'; in 'gaps'/'summary' it "
+                "narrows every reported figure (coverage_pct, totals, gaps) to "
+                "that file instead of the whole project."
+            ),
         },
         "language": {
             "type": "string",
@@ -130,6 +135,10 @@ class CodeGraphTestGapTool(BaseMCPTool):
                 max_files=max_files,
                 max_gaps=max_gaps,
                 include_covered=include_covered,
+                # #693: honor file_path in EVERY mode (not just mode=file).
+                # Previously it was echoed in summary_line but silently dropped
+                # in mode=gaps/summary — a no-op that looked scoped but wasn't.
+                target_file=target_file,
             )
         except Exception as exc:
             logger.error("test_gap analysis failed: %s", exc)

--- a/tree_sitter_analyzer/test_gap_analyzer.py
+++ b/tree_sitter_analyzer/test_gap_analyzer.py
@@ -742,6 +742,7 @@ def analyze_coverage_gaps(
     max_files: int = 1000,
     max_gaps: int = 50,
     include_covered: bool = False,
+    target_file: str | None = None,
 ) -> CoverageGapResult:
     """Analyse test coverage gaps.
 
@@ -749,6 +750,12 @@ def analyze_coverage_gaps(
     the function uses runtime coverage data as the ground truth for whether a
     symbol is covered. Falls back to naming-convention matching when coverage
     data is absent or malformed (RFC-0003 criteria 1,2,3,4,5).
+
+    When *target_file* is given, the production-symbol scope is filtered to
+    files whose path contains it (substring match), BEFORE the ``max_gaps``
+    cap — so ``total_production_symbols``/``coverage_pct``/``gaps`` all reflect
+    just that file. Test files stay unfiltered so naming-convention coverage
+    still matches across the suite (#693: ``file_path`` must not be a no-op).
     """
     # RFC-0003 criterion 4: auto-discover coverage.json at project root
     if coverage_json is None:
@@ -771,6 +778,16 @@ def analyze_coverage_gaps(
     all_files = _collect_files(project_root, language_filter, max_files)
     prod_files = [(f, lang) for f, lang, t in all_files if not t]
     test_files = [(f, lang) for f, lang, t in all_files if t]
+
+    # #693: scope production analysis to a single file when requested, BEFORE
+    # complexity scoring, gap classification, and the max_gaps cap — so every
+    # reported number (total_production_symbols / coverage_pct / production_files
+    # / gaps) reflects just that file, not a project-wide figure with the
+    # requested path silently ignored. Substring match mirrors the tool's
+    # mode=file filter. Test files stay unfiltered so naming-convention coverage
+    # still matches across the whole suite.
+    if target_file:
+        prod_files = [(f, lang) for f, lang in prod_files if target_file in f]
 
     prod_symbols: list[ProductionSymbol] = []
     for fpath, lang in prod_files:


### PR DESCRIPTION
## What

Closes #693. `health action=test_gap` echoed `file_path` into `summary_line` but silently dropped it in `mode=gaps`/`mode=summary` — it only filtered in `mode=file`. So an agent asking *"what's untested in `server.py`?"* (default mode=gaps) got **project-wide** gaps that **looked** scoped but weren't — the body was byte-identical regardless of the path.

**Bug 2 of #693** (default scope missing the real package → misleading `14.9%` / 121-symbol headline) was **already fixed upstream**: verified the analyzer now scans the whole `tree_sitter_analyzer/` package (8015 symbols, 41.6%, 736 prod files). This PR fixes the remaining **Bug 1** (the `file_path` no-op).

## How

Add an optional `target_file` to `analyze_coverage_gaps` that filters the production-file scope **before** complexity scoring, gap classification, and the `max_gaps` cap — so `total_production_symbols` / `coverage_pct` / `production_files` / `gaps` all reflect just that file, in **any** mode. Test files stay unfiltered so naming-convention coverage still matches across the whole suite. The tool passes `file_path` through as `target_file`, and the schema description now says `file_path` scopes the analysis (required for mode=file; narrows the figures in gaps/summary).

`target_file` defaults to `None` → existing project-wide behavior is byte-for-byte unchanged (the analyzer's project-wide total assertions stay green).

## Why scope in the analyzer, not post-filter in the tool

The tool's old `mode=file` filter ran on the **already-capped** 50-gap list — a file's gaps beyond the cap were invisible. Filtering in the analyzer before the cap makes file-scoped numbers correct (and fixes that latent mode=file incompleteness too).

## Test plan

- [x] analyzer-level scoping: `target_file=alpha.py` → 3 symbols / 1 prod file vs 4 project-wide
- [x] #693 core repro: `file_path` in gaps mode yields a different, scoped body (not the identical-body trap)
- [x] default-None project-wide invariant unchanged
- [x] 54 passed (`test_test_gap_tool.py` + `test_test_gap_analyzer.py`), 23 passed (`test_health_facade.py`)
- [x] ruff / ruff format / mypy clean
- [ ] CI green on all axes
- [ ] Codex review triaged

🤖 Generated with [Claude Code](https://claude.com/claude-code)