### PR TITLE
fix(health): scope test_gap target_file during the walk, before max_files (#713 Codex P2)

### DIFF
--- a/tests/unit/test_test_gap_tool.py
+++ b/tests/unit/test_test_gap_tool.py
@@ -273,3 +273,25 @@ class TestFilePathScoping:
         # The two responses must NOT be identical (the #693 trap).
         assert scoped["gap_count"] != whole["gap_count"]
         assert all("alpha.py" in g["file"] for g in scoped["gaps"])
+
+    def test_target_file_found_beyond_max_files_walk_order(self, tmp_path):
+        """Codex #713 P2: a scoped target later than max_files in walk order must
+        still be found. Filtering after the cap returned 0 symbols; pushing the
+        filter into the walk fixes it."""
+        pkg = tmp_path / "pkg"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text("")
+        # 20 production files that sort BEFORE the target alphabetically.
+        for i in range(20):
+            (pkg / f"a_mod{i:02d}.py").write_text(f"def fn{i}():\n    pass\n")
+        # The target sorts last and has 2 symbols.
+        (pkg / "zzz_target.py").write_text(
+            "def t_one():\n    pass\n\ndef t_two():\n    pass\n"
+        )
+        # max_files=5 would exhaust the production budget on a_mod00..04 before
+        # ever reaching zzz_target.py — the old post-cap filter returned 0.
+        scoped = analyze_coverage_gaps(
+            str(tmp_path), max_files=5, target_file="zzz_target.py"
+        )
+        assert scoped.total_production_symbols == 2
+        assert scoped.summary["production_files"] == 1

--- a/tree_sitter_analyzer/test_gap_analyzer.py
+++ b/tree_sitter_analyzer/test_gap_analyzer.py
@@ -269,6 +269,7 @@ def _collect_files(
     project_root: str,
     language_filter: str | None = None,
     max_files: int = 1000,
+    target_file: str | None = None,
 ) -> list[tuple[str, str, bool]]:
     """Collect source files under *project_root*.
 
@@ -284,6 +285,13 @@ def _collect_files(
     files cannot exhaust the budget and prevent the main package from being
     scanned.  Test files are never capped — they are all collected regardless
     of count.
+
+    When *target_file* is given, production files whose path does NOT contain
+    it are skipped during the walk — BEFORE the ``max_files`` budget is
+    consumed — so a scoped request always finds its target regardless of the
+    file's walk-order position (Codex #713 P2: filtering after the cap would
+    silently return 0 symbols for a target later than ``max_files`` in the
+    walk). Test files stay unfiltered for naming-convention matching.
     """
     results: list[tuple[str, str, bool]] = []
     prod_count = 0
@@ -310,6 +318,11 @@ def _collect_files(
             # regardless of their individual filename.
             is_test = in_non_prod or _is_test_file(full)
             if not is_test:
+                # #713: a scoped request only wants production symbols from the
+                # target file — skip every other production file BEFORE the cap
+                # so walk order can't drop the target.
+                if target_file and target_file not in full:
+                    continue
                 # Production budget exhausted: keep walking so that test files
                 # appearing later in os.walk order (e.g. app/ before tests/)
                 # are still collected for naming-convention matching — an
@@ -775,19 +788,17 @@ def analyze_coverage_gaps(
         else {}
     )
 
-    all_files = _collect_files(project_root, language_filter, max_files)
+    # #693/#713: scope production analysis to a single file when requested. The
+    # filter is pushed INTO _collect_files so it runs during the walk, before
+    # the max_files cap (Codex #713 P2: a post-cap filter silently returned 0
+    # symbols for a target later than max_files in walk order). It still happens
+    # BEFORE complexity scoring, gap classification, and the max_gaps cap, so
+    # every reported number (total_production_symbols / coverage_pct /
+    # production_files / gaps) reflects just that file. Test files stay
+    # unfiltered so naming-convention coverage still matches the whole suite.
+    all_files = _collect_files(project_root, language_filter, max_files, target_file)
     prod_files = [(f, lang) for f, lang, t in all_files if not t]
     test_files = [(f, lang) for f, lang, t in all_files if t]
-
-    # #693: scope production analysis to a single file when requested, BEFORE
-    # complexity scoring, gap classification, and the max_gaps cap — so every
-    # reported number (total_production_symbols / coverage_pct / production_files
-    # / gaps) reflects just that file, not a project-wide figure with the
-    # requested path silently ignored. Substring match mirrors the tool's
-    # mode=file filter. Test files stay unfiltered so naming-convention coverage
-    # still matches across the whole suite.
-    if target_file:
-        prod_files = [(f, lang) for f, lang in prod_files if target_file in f]
 
     prod_symbols: list[ProductionSymbol] = []
     for fpath, lang in prod_files:


### PR DESCRIPTION
## What

Follow-up to #713 — addresses the **Codex P2** on that PR.

The #693 `file_path` filter ran **after** `_collect_files(..., max_files)`, so a scoped request only searched the first `max_files` production files and silently returned `0` symbols when the target sorted later in walk order. With the default `max_files=1000`, `health action=test_gap mode=gaps file_path=...` on a large repo could report a real file as empty / fully covered.

## Fix

Push the `target_file` filter **into** `_collect_files` so non-matching production files are skipped *during the walk*, before the cap is consumed — the target is found regardless of its walk-order position. The now-redundant post-collection filter is removed (single source of truth).

## Test plan

- [x] New test: a target sorting last, `max_files=5` (budget exhausted on `a_mod00..04` long before the target) still yields its 2 symbols / 1 production file. Fails on the old post-cap filter.
- [x] 55 passed (`test_test_gap_tool.py` + `test_test_gap_analyzer.py`)
- [x] ruff / ruff format / mypy clean
- [ ] CI green
- [ ] Codex review triaged

## Codex #713 triage

| Finding | Verdict | Action |
|---|---|---|
| P2: apply file filter before max_files caps | **Real** | Fixed here — filter moved into the walk |

🤖 Generated with [Claude Code](https://claude.com/claude-code)