### PR TITLE
Fix co-change cache window handling

### DIFF
--- a/tests/unit/mcp/tools/test_co_change.py
+++ b/tests/unit/mcp/tools/test_co_change.py
@@ -231,6 +231,67 @@ def test_cache_hit_skips_subprocess() -> None:
     assert result1["co_changed_files"] == result2["co_changed_files"]
 
 
+def test_cache_key_includes_result_shaping_parameters() -> None:
+    """Changing max_commits/min_shared/max_results must trigger a fresh log walk."""
+    small_window = [(_sha(i), ["src/handler.py"]) for i in range(5)]
+    large_window = [(_sha(i), ["src/handler.py", "src/schema.py"]) for i in range(12)]
+    head_sha = "ca" * 20
+
+    with patch(
+        "tree_sitter_analyzer.mcp.tools.utils.co_change._run_git"
+    ) as mock_run_git:
+        mock_run_git.side_effect = [
+            (0, head_sha),
+            (0, _make_git_log(small_window)),
+            (0, head_sha),
+            (0, _make_git_log(large_window)),
+        ]
+        _CO_CHANGE_CACHE.clear()
+        result1 = _compute_co_change(
+            "/fake/repo",
+            "src/handler.py",
+            max_commits=5,
+            min_shared=3,
+            max_results=20,
+        )
+        result2 = _compute_co_change(
+            "/fake/repo",
+            "src/handler.py",
+            max_commits=500,
+            min_shared=4,
+            max_results=1,
+        )
+
+    assert mock_run_git.call_count == 4
+    assert result1["commits_analyzed"] == 5
+    assert result1["window"] == "last 5 commits"
+    assert result2["commits_analyzed"] == 12
+    assert result2["window"] == "last 500 commits"
+    assert result2["co_changed_files"] == [
+        {"file": "src/schema.py", "shared_commits": 12, "lift": 1.0}
+    ]
+
+
+def test_git_log_walks_from_head_explicitly() -> None:
+    """Detached worktrees must walk history reachable from HEAD, not a branch ref."""
+    commits = [(_sha(i), ["src/handler.py"]) for i in range(3)]
+    head_sha = "cb" * 20
+
+    with patch(
+        "tree_sitter_analyzer.mcp.tools.utils.co_change._run_git"
+    ) as mock_run_git:
+        mock_run_git.side_effect = [
+            (0, head_sha),
+            (0, _make_git_log(commits)),
+        ]
+        _CO_CHANGE_CACHE.clear()
+        _compute_co_change("/fake/repo", "src/handler.py", max_commits=10)
+
+    log_args = mock_run_git.call_args_list[1].args[0]
+    assert "HEAD" in log_args
+    assert log_args[-1] == "HEAD"
+
+
 # ---------------------------------------------------------------------------
 # 4. min_shared filter
 # ---------------------------------------------------------------------------
@@ -717,15 +778,17 @@ def test_lru_cache_evicts_at_maxsize() -> None:
 
     # Fill to exactly maxsize
     for i in range(_CO_CHANGE_CACHE_MAXSIZE):
-        _co_change_cache_put((f"/repo{i}", "f.py", f"sha{i:040x}"), sentinel)
+        _co_change_cache_put(
+            (f"/repo{i}", "f.py", f"sha{i:040x}", 500, 3, 20), sentinel
+        )
 
     assert len(_CO_CHANGE_CACHE) == _CO_CHANGE_CACHE_MAXSIZE
 
     # One more entry must evict the oldest
-    _co_change_cache_put(("/repo_new", "f.py", "a" * 40), sentinel)
+    _co_change_cache_put(("/repo_new", "f.py", "a" * 40, 500, 3, 20), sentinel)
     assert len(_CO_CHANGE_CACHE) == _CO_CHANGE_CACHE_MAXSIZE
     # oldest key evicted
-    assert ("/repo0", "f.py", f"{'0' * 40}") not in _CO_CHANGE_CACHE
+    assert ("/repo0", "f.py", f"{'0' * 40}", 500, 3, 20) not in _CO_CHANGE_CACHE
 
     _CO_CHANGE_CACHE.clear()
 

--- a/tree_sitter_analyzer/mcp/tools/utils/co_change.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/co_change.py
@@ -16,8 +16,9 @@ without target, making it a common file (low lift).  ``total_commits`` is the
 ACTUAL number of unique commit SHAs seen in the parsed log (not ``max_commits``),
 so a 43-commit repo with max_commits=500 gets the true lift (RFC-0014 INFO fix).
 
-Results are keyed by (project_root, target_file, HEAD) for zero-cost repeat
-calls within one MCP session (LRU maxsize=256).
+Results are keyed by (project_root, target_file, HEAD, max_commits, min_shared,
+max_results) for zero-cost repeat calls within one MCP session (LRU
+maxsize=256).
 """
 
 from __future__ import annotations
@@ -28,11 +29,12 @@ from typing import Any
 from ....utils.test_detection import is_test_file
 from .change_impact_git import _run_git
 
-# Module-level LRU cache keyed by (project_root, target_file, HEAD_sha).
+# Module-level LRU cache keyed by parameters that affect result shape/content.
 # Invalidated when HEAD advances; no persistent storage.
 # maxsize=256: bounds memory in long-running MCP sessions (RFC-0014 §P3-2).
 _CO_CHANGE_CACHE_MAXSIZE = 256
-_CO_CHANGE_CACHE: OrderedDict[tuple[str, str, str], dict[str, Any]] = OrderedDict()
+CoChangeCacheKey = tuple[str, str, str, int, int, int]
+_CO_CHANGE_CACHE: OrderedDict[CoChangeCacheKey, dict[str, Any]] = OrderedDict()
 
 # Minimum commits touching the target file required before the result may
 # claim "Safe to edit in isolation".  Below this floor the null-result is
@@ -43,7 +45,7 @@ MIN_COMMITS_FOR_COUPLING_ANALYSIS = 10
 
 
 def _co_change_cache_get(
-    key: tuple[str, str, str],
+    key: CoChangeCacheKey,
 ) -> dict[str, Any] | None:
     """LRU get: move hit to end (most-recently-used)."""
     if key not in _CO_CHANGE_CACHE:
@@ -53,7 +55,7 @@ def _co_change_cache_get(
 
 
 def _co_change_cache_put(
-    key: tuple[str, str, str],
+    key: CoChangeCacheKey,
     value: dict[str, Any],
 ) -> None:
     """LRU put: evict oldest entry if at capacity."""
@@ -176,7 +178,14 @@ def _compute_co_change(
         return _empty_co_change_result(target_file, max_commits)
 
     head_sha = head_raw.strip()
-    cache_key = (project_root, target_file, head_sha)
+    cache_key = (
+        project_root,
+        target_file,
+        head_sha,
+        max_commits,
+        min_shared,
+        max_results,
+    )
     cached = _co_change_cache_get(cache_key)
     if cached is not None:
         return cached
@@ -188,6 +197,7 @@ def _compute_co_change(
             f"--max-count={max_commits}",
             "--pretty=format:%H",
             "--name-only",
+            "HEAD",
         ],
         cwd=project_root,
     )


### PR DESCRIPTION
## Summary
- include max_commits, min_shared, and max_results in the co-change cache key so repeated calls on the same HEAD cannot reuse stale result shapes
- make the git log walk explicitly start from HEAD for detached worktree compatibility
- add regression coverage for the --co-change-max-commits no-op reported in #547

Fixes #547

## Verification
- nice -n 10 uv run pytest tests/unit/mcp/tools/test_co_change.py -n 0 -q
- uv run ruff check tree_sitter_analyzer/mcp/tools/utils/co_change.py tests/unit/mcp/tools/test_co_change.py
- nice -n 10 uv run pytest tests/unit/mcp/tools/test_co_change.py -n 0 -q --cov=tree_sitter_analyzer --cov-report=json
- nice -n 10 uv run python scripts/check_patch_coverage.py --base origin/develop --coverage-json coverage.json
- git diff --check
- nice -n 10 uv run python -m tree_sitter_analyzer --co-change tree_sitter_analyzer/mcp/tools/utils/co_change.py --co-change-max-commits 5 --format json
- nice -n 10 uv run python -m tree_sitter_analyzer --co-change tree_sitter_analyzer/mcp/tools/utils/co_change.py --co-change-max-commits 500 --format json