### PR TITLE
Fix preflight chain coherence

### DIFF
--- a/tests/unit/mcp/test_modification_guard_tool.py
+++ b/tests/unit/mcp/test_modification_guard_tool.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -216,6 +216,11 @@ class TestModificationGuardToolExecution:
 
         assert result["safety_verdict"] == "CAUTION"
         assert result["total_callers"] == 3
+        assert result["ripgrep_occurrences"] == 3
+        assert result["count_unit"] == "ripgrep_occurrences"
+        assert "callers=3" not in result["summary_line"]
+        assert "ripgrep_occurrences=3" in result["summary_line"]
+        assert "count_caveat" in result
 
     @pytest.mark.asyncio
     async def test_review_verdict_many_callers(
@@ -254,6 +259,94 @@ class TestModificationGuardToolExecution:
 
         assert result["safety_verdict"] == "UNSAFE"
         assert result["total_callers"] == 25
+        assert result["impact_badge"] == "🚨 HIGH IMPACT — 25 RIPGREP OCCURRENCES"
+        assert "source ripgrep occurrence(s)" in result["impact_guidance"]
+
+    @pytest.mark.asyncio
+    async def test_ast_caller_count_surfaced_when_file_path_given(
+        self, tool: ModificationGuardTool
+    ) -> None:
+        """Guard exposes AST caller count alongside trace-derived occurrences."""
+        usages = [{"file": f"src/file{i}.py"} for i in range(25)]
+        with (
+            patch.object(
+                tool._trace_impact_tool,
+                "execute",
+                new_callable=AsyncMock,
+                return_value=_trace_result(25, usages),
+            ),
+            patch.object(
+                tool,
+                "_try_ast_caller_count",
+                new_callable=AsyncMock,
+                return_value=11,
+            ) as mock_ast_count,
+        ):
+            result = await tool.execute(
+                {
+                    "symbol": "bigFunc",
+                    "modification_type": "delete",
+                    "file_path": "src/big.py",
+                }
+            )
+
+        mock_ast_count.assert_awaited_once_with("bigFunc", "src/big.py")
+        assert result["ripgrep_occurrences"] == 25
+        assert result["ast_caller_count"] == 11
+
+    @pytest.mark.asyncio
+    async def test_try_ast_caller_count_calls_codegraph_tool(
+        self, tool: ModificationGuardTool
+    ) -> None:
+        """AST reconciliation uses callers_tool and returns its integer count."""
+        fake_callers_tool = Mock()
+        fake_callers_tool.execute = AsyncMock(return_value={"caller_count": 7})
+
+        with patch(
+            "tree_sitter_analyzer.mcp.tools.callers_tool.CodeGraphCallersTool",
+            return_value=fake_callers_tool,
+        ) as callers_cls:
+            count = await tool._try_ast_caller_count("sharedFunc", "src/shared.py")
+
+        callers_cls.assert_called_once_with(tool.project_root)
+        fake_callers_tool.execute.assert_awaited_once_with(
+            {
+                "function_name": "sharedFunc",
+                "file_path": "src/shared.py",
+                "limit": 1,
+                "output_format": "json",
+            }
+        )
+        assert count == 7
+
+    @pytest.mark.asyncio
+    async def test_try_ast_caller_count_returns_none_on_tool_error(
+        self, tool: ModificationGuardTool
+    ) -> None:
+        """AST reconciliation is best-effort and must not fail the guard."""
+        with patch(
+            "tree_sitter_analyzer.mcp.tools.callers_tool.CodeGraphCallersTool",
+            side_effect=RuntimeError("index unavailable"),
+        ):
+            count = await tool._try_ast_caller_count("sharedFunc", "src/shared.py")
+
+        assert count is None
+
+    @pytest.mark.asyncio
+    async def test_try_ast_caller_count_ignores_non_integer_count(
+        self, tool: ModificationGuardTool
+    ) -> None:
+        """Only integer caller_count values are surfaced."""
+        fake_callers_tool = Mock()
+        fake_callers_tool.execute = AsyncMock(return_value={"caller_count": "many"})
+
+        with patch(
+            "tree_sitter_analyzer.mcp.tools.callers_tool.CodeGraphCallersTool",
+            return_value=fake_callers_tool,
+        ):
+            count = await tool._try_ast_caller_count("sharedFunc", "src/shared.py")
+
+        assert count is None
 
     @pytest.mark.asyncio
     async def test_required_actions_populated_for_unsafe(

--- a/tests/unit/mcp/test_test_discovery.py
+++ b/tests/unit/mcp/test_test_discovery.py
@@ -2,6 +2,7 @@
 
 import tempfile
 from pathlib import Path
+from typing import Any
 
 from tree_sitter_analyzer.mcp.tools.utils.test_discovery import (
     detect_language_from_ext,
@@ -535,6 +536,111 @@ class TestFindTestFilesJava:
 
             results = find_test_files(str(source), tmp)
             assert any("CalculatorTest.java" in r for r in results)
+
+
+class TestFindTestFilesPythonPublicSymbolReferences:
+    def test_finds_tests_referencing_public_symbols_even_when_filename_differs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "src" / "format_helper.py"
+            source.parent.mkdir(parents=True)
+            source.write_text(
+                "def apply_toon_format_to_response(data):\n"
+                "    return data\n\n"
+                "def _private_helper():\n"
+                "    return None\n",
+                encoding="utf-8",
+            )
+
+            exact_test = root / "tests" / "test_output_cost_invariants.py"
+            exact_test.parent.mkdir(parents=True)
+            exact_test.write_text(
+                "from src.format_helper import apply_toon_format_to_response\n\n"
+                "def test_budget():\n"
+                "    assert apply_toon_format_to_response({}) == {}\n",
+                encoding="utf-8",
+            )
+            private_only = root / "tests" / "test_private_only.py"
+            private_only.write_text(
+                "def test_private_name_text():\n"
+                "    assert '_private_helper' in 'doc only'\n",
+                encoding="utf-8",
+            )
+
+            results = find_test_files(str(source), tmp)
+
+            assert "tests/test_output_cost_invariants.py" in results
+            assert "tests/test_private_only.py" not in results
+
+    def test_symbol_reference_scan_skips_unreadable_test_files(self, monkeypatch):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "src" / "format_helper.py"
+            source.parent.mkdir(parents=True)
+            source.write_text(
+                "def apply_toon_format_to_response(data):\n    return data\n",
+                encoding="utf-8",
+            )
+
+            readable = root / "tests" / "test_output_cost_invariants.py"
+            unreadable = root / "tests" / "test_unreadable.py"
+            readable.parent.mkdir(parents=True)
+            readable.write_text(
+                "def test_budget():\n"
+                "    assert apply_toon_format_to_response({}) == {}\n",
+                encoding="utf-8",
+            )
+            unreadable.write_text(
+                "def test_unreadable():\n"
+                "    assert apply_toon_format_to_response({}) == {}\n",
+                encoding="utf-8",
+            )
+
+            original_read_text = Path.read_text
+
+            def fake_read_text(path: Path, *args: Any, **kwargs: Any) -> str:
+                if path == unreadable:
+                    raise OSError("permission denied")
+                return original_read_text(path, *args, **kwargs)
+
+            monkeypatch.setattr(Path, "read_text", fake_read_text)
+
+            results = find_test_files(str(source), tmp)
+
+            assert "tests/test_output_cost_invariants.py" in results
+            assert "tests/test_unreadable.py" not in results
+
+    def test_symbol_reference_scan_treats_unreadable_source_as_no_symbols(
+        self, monkeypatch
+    ):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "src" / "format_helper.py"
+            source.parent.mkdir(parents=True)
+            source.write_text(
+                "def apply_toon_format_to_response(data):\n    return data\n",
+                encoding="utf-8",
+            )
+            test = root / "tests" / "test_output_cost_invariants.py"
+            test.parent.mkdir(parents=True)
+            test.write_text(
+                "def test_budget():\n"
+                "    assert apply_toon_format_to_response({}) == {}\n",
+                encoding="utf-8",
+            )
+
+            original_read_text = Path.read_text
+
+            def fake_read_text(path: Path, *args: Any, **kwargs: Any) -> str:
+                if path == source:
+                    raise OSError("permission denied")
+                return original_read_text(path, *args, **kwargs)
+
+            monkeypatch.setattr(Path, "read_text", fake_read_text)
+
+            results = find_test_files(str(source), tmp)
+
+            assert "tests/test_output_cost_invariants.py" not in results
 
 
 class TestFindTestFilesGo:

--- a/tests/unit/mcp/tools/test_nav_facade_test_map.py
+++ b/tests/unit/mcp/tools/test_nav_facade_test_map.py
@@ -16,7 +16,7 @@ import pytest
 
 from tree_sitter_analyzer.call_graph import FunctionRef
 from tree_sitter_analyzer.mcp.tools.codegraph_impact_tool import CodeGraphImpactTool
-from tree_sitter_analyzer.mcp.tools.nav_facade import build_nav_facade
+from tree_sitter_analyzer.mcp.tools.nav_facade import _MAX_TEST_MAP, build_nav_facade
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -112,6 +112,9 @@ async def test_test_map_returns_test_files_and_functions() -> None:
     assert "tests/test_a.py::test_case_2" in result["test_functions"]
     assert "tests/test_b.py::test_case_3" in result["test_functions"]
     assert result["truncated"] is False
+    assert result["agent_summary"]["next_step"].startswith(
+        "Run per-file tests: pytest tests/test_a.py tests/test_b.py."
+    )
 
 
 @pytest.mark.asyncio
@@ -220,7 +223,15 @@ async def test_test_map_truncated_flag_set_when_cap_reached() -> None:
     assert result["unique_function_count"] == 51
     assert result["truncated"] is True
     # test_functions list is capped at 50
-    assert len(result["test_functions"]) == 50
+    assert len(result["test_functions"]) == _MAX_TEST_MAP
+    assert (
+        f"Listed {_MAX_TEST_MAP} of 51 test function(s)"
+        in result["agent_summary"]["next_step"]
+    )
+    assert (
+        "test_files contains the complete file-level surface"
+        in result["agent_summary"]["next_step"]
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_change_impact_response.py
+++ b/tests/unit/test_change_impact_response.py
@@ -196,6 +196,41 @@ class TestBuildAgentSummaryOnlyResponse:
         assert response["affected_count"] == 3
         assert response["next_step"] == "Run tests"
 
+    def test_agent_summary_only_does_not_emit_contradictory_legacy_scalars(self):
+        """Compact mode must not expose stale top-level fields that fight summary."""
+        result = {
+            "success": True,
+            "mode": "diff",
+            "scope_paths": [],
+            "scope_filtered": False,
+            "agent_summary": {
+                "risk": "high",
+                "changed_count": 1,
+                "affected_count": 8,
+                "tests_to_run_count": 2,
+                "changed_preview": ["tree_sitter_analyzer/example.py"],
+                "next_step": "Run verification",
+                "verification_command": "uv run pytest tests/unit/test_example.py -q",
+                "stop_condition": "focused tests pass",
+            },
+            "risk_level": "high",
+            "changed_count": 1,
+            "affected_count": 8,
+            "tests_to_run_count": 2,
+        }
+
+        response = build_agent_summary_only_response(result)
+
+        assert response["risk_level"] == "high"
+        assert response["changed_count"] == 1
+        assert response["verification_command"] == (
+            "uv run pytest tests/unit/test_example.py -q"
+        )
+        assert "pytest_required" not in response
+        assert "changed_files" not in response
+        assert "changed_preview" not in response
+        assert "impact_level" not in response
+
 
 class TestAttachQueueLedger:
     """Tests for attach_queue_ledger."""

--- a/tree_sitter_analyzer/mcp/tools/modification_guard_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/modification_guard_tool.py
@@ -94,10 +94,12 @@ def _build_agent_summary(
         "symbol": symbol,
         "modification_type": modification_type,
         "total_callers": total_callers,
+        "ripgrep_occurrences": total_callers,
+        "count_unit": "ripgrep_occurrences",
         "recommendation": proceed_recommendation,
         "stop_condition": (
-            f"safety_verdict resolves to SAFE or all {total_callers} caller(s) "
-            "have been reviewed/updated."
+            f"safety_verdict resolves to SAFE or all {total_callers} ripgrep "
+            "occurrence(s) have been reconciled with AST callers or reviewed."
         ),
     }
 
@@ -120,18 +122,19 @@ def _next_step_for_verdict(
         return f"Proceed with {modification_type} for '{symbol}'."
     if safety_verdict == "CAUTION":
         return (
-            f"Run batch_search(['{symbol}']) to review {total_callers} caller(s), "
-            "then proceed with the edit."
+            f"Run batch_search(['{symbol}']) to review {total_callers} ripgrep "
+            "occurrence(s), then compare nav action=callers before editing."
         )
     if safety_verdict == "REVIEW":
         return (
-            f"Audit all {total_callers} call sites via batch_search(['{symbol}']) "
-            "before changing the signature."
+            f"Audit all {total_callers} ripgrep occurrence(s) via "
+            f"batch_search(['{symbol}']) and compare nav action=callers before "
+            "changing the signature."
         )
     # UNSAFE / anything else: highest caution
     return (
         f"Do NOT modify '{symbol}' yet — plan a deprecation strategy and "
-        f"update all {total_callers} call sites atomically."
+        f"reconcile all {total_callers} ripgrep occurrence(s) with AST callers."
     )
 
 
@@ -152,17 +155,20 @@ def _build_proceed_recommendation(
         return f"No callers found for '{symbol}'. Safe to {modification_type}."
     if safety_verdict == "CAUTION":
         return (
-            f"Review {total_callers} caller(s) before proceeding. "
-            f"Use batch_search(['{symbol}']) to inspect usage patterns."
+            f"Review {total_callers} ripgrep occurrence(s) before proceeding. "
+            f"Use batch_search(['{symbol}']) and nav action=callers to inspect "
+            "usage patterns."
         )
     if safety_verdict == "REVIEW":
         return (
-            f"Check all {total_callers} call sites before modifying. "
-            f"Use batch_search(['{symbol}']) to see all usage patterns."
+            f"Check all {total_callers} ripgrep occurrence(s) before modifying. "
+            f"Use batch_search(['{symbol}']) and nav action=callers to see all "
+            "usage patterns."
         )
     return (
-        f"Review all {total_callers} callers first. "
-        f"Use batch_search(['{symbol}']) to see all usage patterns."
+        f"Review all {total_callers} ripgrep occurrence(s) first. "
+        f"Use batch_search(['{symbol}']) and nav action=callers to see all usage "
+        "patterns."
     )
 
 
@@ -190,12 +196,31 @@ def _format_modification_summary_line(
     parts = [
         symbol,
         rank_str,
-        f"callers={total_callers}",
+        f"ripgrep_occurrences={total_callers}",
         f"verdict={final_verdict}",
     ]
     if pr_str:
         parts.insert(2, pr_str)
     return format_summary_line(*parts)
+
+
+def _guard_impact_badge(impact: dict[str, Any], total_callers: int) -> str:
+    """Render guard impact with the correct unit for its trace-derived count."""
+    badge = str(impact["badge"])
+    if total_callers > 20:
+        return f"🚨 HIGH IMPACT — {total_callers} RIPGREP OCCURRENCES"
+    return badge
+
+
+def _guard_impact_guidance(impact: dict[str, Any], total_callers: int) -> str:
+    """Render guard guidance without calling trace occurrences AST callers."""
+    if total_callers == 0:
+        return str(impact["guidance"])
+    return (
+        f"{total_callers} source ripgrep occurrence(s) found after filtering. "
+        "Compare ast_caller_count or nav action=callers for AST direct caller "
+        "fan-in before changing signatures."
+    )
 
 
 def _load_critical_nodes(project_root: str | None) -> list[dict[str, Any]]:
@@ -237,7 +262,9 @@ def _build_required_actions(
         actions.append("No callers found — safe to proceed.")
         return actions
 
-    actions.append(f"Review all {total_callers} call site(s) before modifying.")
+    actions.append(
+        f"Review all {total_callers} ripgrep occurrence(s) before modifying."
+    )
     actions.append(f"Use batch_search to find callers: ['{symbol}']")
 
     if modification_type in ("rename", "signature_change"):
@@ -457,6 +484,7 @@ class ModificationGuardTool(BaseMCPTool):
             return self._build_not_found_result(symbol, modification_type)
 
         total_callers = trace_result.get("call_count", 0)
+        ast_caller_count = await self._try_ast_caller_count(symbol, file_path)
         impact = _get_impact_level(total_callers)
         impact_level = impact["level"]
         safety_verdict = _VERDICT_MAP.get(impact_level, "REVIEW")
@@ -482,6 +510,7 @@ class ModificationGuardTool(BaseMCPTool):
             safety_verdict=safety_verdict,
             required_actions=required_actions,
             proceed_recommendation=proceed_recommendation,
+            ast_caller_count=ast_caller_count,
         )
 
         self._apply_pagerank_boost(result, symbol, safety_verdict)
@@ -547,6 +576,28 @@ class ModificationGuardTool(BaseMCPTool):
         result = await self._trace_impact_tool.execute(trace_args)
         return result  # type: ignore[no-any-return]
 
+    async def _try_ast_caller_count(
+        self, symbol: str, file_path: str | None
+    ) -> int | None:
+        """Best-effort AST caller count for guard/callers count reconciliation."""
+        if not file_path:
+            return None
+        try:
+            from .callers_tool import CodeGraphCallersTool
+
+            callers_tool = CodeGraphCallersTool(self.project_root)
+            args: dict[str, Any] = {
+                "function_name": symbol,
+                "file_path": file_path,
+                "limit": 1,
+                "output_format": "json",
+            }
+            result = await callers_tool.execute(args)
+        except Exception:  # nosec B110 - guard still returns trace evidence
+            return None
+        caller_count = result.get("caller_count")
+        return caller_count if isinstance(caller_count, int) else None
+
     @staticmethod
     def _build_initial_result(
         *,
@@ -559,16 +610,24 @@ class ModificationGuardTool(BaseMCPTool):
         safety_verdict: str,
         required_actions: list[Any],
         proceed_recommendation: str,
+        ast_caller_count: int | None = None,
     ) -> dict[str, Any]:
         """Canonical safety report — incl. ``count`` alias + ``verdict`` alias."""
-        return {
+        result: dict[str, Any] = {
             "success": True,
             "symbol": symbol,
             "modification_type": modification_type,
             "impact_level": impact_level,
-            "impact_badge": impact["badge"],
-            "impact_guidance": impact["guidance"],
+            "impact_badge": _guard_impact_badge(impact, total_callers),
+            "impact_guidance": _guard_impact_guidance(impact, total_callers),
             "total_callers": total_callers,
+            "ripgrep_occurrences": total_callers,
+            "count_unit": "ripgrep_occurrences",
+            "count_caveat": (
+                "modification_guard counts source ripgrep occurrences after "
+                "comment/import/string filtering; compare ast_caller_count or "
+                "nav action=callers for graph-derived direct caller fan-in."
+            ),
             # ``count`` is the cross-tool canonical alias.
             "count": total_callers,
             "callers_by_file": callers_by_file,
@@ -580,6 +639,9 @@ class ModificationGuardTool(BaseMCPTool):
             # ``recommendation`` aligns with safe_to_edit / file_health naming.
             "recommendation": proceed_recommendation,
         }
+        if ast_caller_count is not None:
+            result["ast_caller_count"] = ast_caller_count
+        return result
 
     def _apply_pagerank_boost(
         self, result: dict[str, Any], symbol: str, safety_verdict: str

--- a/tree_sitter_analyzer/mcp/tools/nav_facade.py
+++ b/tree_sitter_analyzer/mcp/tools/nav_facade.py
@@ -50,6 +50,39 @@ from .facade_tool import FacadeTool
 # RFC-0014 Phase B: cap for test_map test_functions list (matches _MAX_LISTED).
 _MAX_TEST_MAP = 50
 
+
+def _test_map_next_step(
+    test_files: list[str],
+    *,
+    listed_function_count: int,
+    unique_function_count: int,
+    truncated: bool,
+) -> str:
+    """Build an honest next step for ``nav action=test_map``.
+
+    The result carries every test file but caps ``test_functions``. Recommend
+    per-file pytest runs so agents do not mistake a capped function preview for
+    the complete verification surface.
+    """
+    if not test_files:
+        return (
+            "No test coverage found via call-graph edges. "
+            "Consider running pytest --cov to detect coverage."
+        )
+
+    command = f"pytest {' '.join(test_files)}"
+    if truncated:
+        return (
+            f"Run per-file tests: {command}. Listed {listed_function_count} of "
+            f"{unique_function_count} test function(s); test_files contains the "
+            "complete file-level surface."
+        )
+    return (
+        f"Run per-file tests: {command}. Covers {unique_function_count} "
+        "test function(s)."
+    )
+
+
 _NAV_ANNOTATIONS: dict[str, Any] = {
     "readOnlyHint": True,
     "destructiveHint": False,
@@ -303,6 +336,7 @@ def build_nav_facade(project_root: str | None = None) -> FacadeTool:
                     test_file_set.add(ref.file_path)
 
         test_funcs_sorted = sorted(test_funcs)
+        test_files_sorted = sorted(test_file_set)
         unique_function_count = len(test_funcs_sorted)
         truncated = unique_function_count > _MAX_TEST_MAP
         capped = test_funcs_sorted[:_MAX_TEST_MAP]
@@ -312,17 +346,17 @@ def build_nav_facade(project_root: str | None = None) -> FacadeTool:
         result: dict = {
             "success": True,
             "symbol": symbol,
-            "test_files": sorted(test_file_set),
+            "test_files": test_files_sorted,
             "test_functions": capped,
             "edge_count": total_edge_count,
             "unique_function_count": unique_function_count,
             "truncated": truncated,
             "agent_summary": {
-                "next_step": (
-                    f"Run: pytest {' '.join(capped[:5])}"
-                    if capped
-                    else "No test coverage found via call-graph edges. "
-                    "Consider running pytest --cov to detect coverage."
+                "next_step": _test_map_next_step(
+                    test_files_sorted,
+                    listed_function_count=len(capped),
+                    unique_function_count=unique_function_count,
+                    truncated=truncated,
                 ),
             },
         }

--- a/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
@@ -358,7 +358,7 @@ def build_agent_workflow(context: AgentWorkflowContext) -> dict[str, Any]:
     """Build a machine-friendly edit workflow for autonomous agents."""
     default_command = detect_default_test_command(context.project_root)
     focused_command = (
-        build_test_command(default_command, context.test_files[:3])
+        build_test_command(default_command, context.test_files)
         if context.has_tests
         else ""
     )

--- a/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_risk.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_risk.py
@@ -229,7 +229,7 @@ def _test_instructions(
     """Return checklist items for test coverage."""
     default_command = detect_default_test_command(project_root)
     if has_tests:
-        test_command = build_test_command(default_command, test_files[:3])
+        test_command = build_test_command(default_command, test_files)
         return [
             f"2. Run existing tests FIRST: {test_command}",
             f"3. Run same verification AFTER editing: {test_command}",

--- a/tree_sitter_analyzer/mcp/tools/utils/test_discovery.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/test_discovery.py
@@ -6,6 +6,7 @@ Finds test files for a given source file using language-specific naming
 conventions (test_*.py, *Test.java, *_test.go, etc.).
 """
 
+import re
 from pathlib import Path
 
 from .test_discovery_languages import find_language_specific_tests
@@ -115,6 +116,7 @@ def find_test_files(
 
     _find_pattern_tests(root, stem, patterns, test_dirs, results)
     _find_colocated_tests(p, stem, patterns, root, results)
+    _find_symbol_reference_tests(p, language, root, results)
     find_language_specific_tests(
         p,
         stem,
@@ -197,3 +199,51 @@ def _add_result(results: list[str], candidate: Path, root: Path) -> None:
     rel = rel.replace("\\", "/")
     if rel not in results:
         results.append(rel)
+
+
+def _find_symbol_reference_tests(
+    source_path: Path,
+    language: str,
+    root: Path,
+    results: list[str],
+) -> None:
+    """Union proximity matches with tests that reference public source symbols."""
+    if language != "python" or not source_path.exists():
+        return
+    symbols = _python_public_symbols(source_path)
+    if not symbols:
+        return
+    symbol_re = re.compile(
+        r"\b(?:" + "|".join(re.escape(sym) for sym in symbols) + r")\b"
+    )
+    matches: list[tuple[int, str, Path]] = []
+    for test_dir in _TEST_DIRS.get("python", ["tests"]):
+        base = root / test_dir
+        if not base.is_dir():
+            continue
+        for candidate in base.rglob("test_*.py"):
+            try:
+                text = candidate.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            hit_count = len(symbol_re.findall(text))
+            if hit_count:
+                matches.append((-hit_count, candidate.as_posix(), candidate))
+    for _, _, candidate in sorted(matches):
+        _add_result(results, candidate, root)
+
+
+def _python_public_symbols(source_path: Path) -> list[str]:
+    """Extract public Python def/class names with a cheap line-based scan."""
+    try:
+        text = source_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+    symbols: list[str] = []
+    for match in re.finditer(
+        r"^\s*(?:async\s+def|def|class)\s+([A-Za-z_]\w*)\b", text, re.M
+    ):
+        name = match.group(1)
+        if not name.startswith("_") and name not in symbols:
+            symbols.append(name)
+    return symbols


### PR DESCRIPTION
## Summary
- make safe_to_edit union proximity tests with public-symbol reference tests and use the full capped test-file surface in verification commands/checklists
- make nav test_map next_step recommend per-file tests and explicitly state function-list truncation
- make modification_guard report trace-derived counts as ripgrep_occurrences, add count caveats, and surface ast_caller_count when file_path is available
- add a change-impact compact-response regression so top-level legacy null/empty fields cannot contradict agent_summary truth
- add regression coverage for the pre-flight chain seams from #546

Fixes #546

## Verification
- nice -n 10 uv run pytest tests/unit/mcp/test_change_impact_tool.py tests/unit/mcp/test_change_impact_tool_execute_and_mapping.py tests/unit/mcp/test_change_impact_tool_git_and_verification.py tests/unit/mcp/test_modification_guard_tool.py tests/unit/mcp/test_safe_to_edit_tool.py tests/unit/mcp/test_test_discovery.py tests/unit/mcp/tools/test_nav_facade.py tests/unit/mcp/tools/test_nav_facade_test_map.py tests/unit/mcp/tools/test_safe_to_edit_dependency_view.py tests/unit/mcp/tools/test_safe_to_edit_unsafe_verdict.py tests/unit/test_change_impact_analysis.py tests/unit/test_change_impact_cached_graph.py tests/unit/test_change_impact_git.py tests/unit/test_change_impact_response.py -n 0 -q
- same focused command with --cov=tree_sitter_analyzer --cov-report=json
- nice -n 10 uv run python scripts/check_patch_coverage.py --base origin/develop --coverage-json coverage.json
- uv run ruff check touched files
- git diff --check
- CLI dogfood: safe_to_edit / test_map / callers / modification_guard / change-impact for apply_toon_format_to_response