### PR TITLE
test mcp facade stdio envelopes

### DIFF
--- a/tests/e2e/test_tool_functional.py
+++ b/tests/e2e/test_tool_functional.py
@@ -19,11 +19,141 @@ Design contract
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from tests.e2e.conftest import MCPClient, initialized
 
 pytestmark = pytest.mark.e2e
+
+FACADE_WIRE_CASES = [
+    (
+        "search",
+        {
+            "action": "grep",
+            "query": "MCP_INFO",
+            "roots": ["tree_sitter_analyzer/mcp"],
+            "include_globs": ["__init__.py"],
+            "output_format": "json",
+        },
+    ),
+    (
+        "nav",
+        {
+            "action": "test_map",
+            "symbol": "build_nav_facade",
+            "file_path": "tree_sitter_analyzer/mcp/tools/nav_facade.py",
+            "output_format": "json",
+        },
+    ),
+    (
+        "structure",
+        {
+            "action": "read",
+            "file_path": "tree_sitter_analyzer/__init__.py",
+            "start_line": 1,
+            "end_line": 3,
+            "output_format": "json",
+        },
+    ),
+    (
+        "health",
+        {
+            "action": "file",
+            "file_path": "tree_sitter_analyzer/__init__.py",
+            "output_format": "json",
+        },
+    ),
+    (
+        "edit",
+        {
+            "action": "safe",
+            "file_path": "tree_sitter_analyzer/__init__.py",
+            "output_format": "json",
+        },
+    ),
+    ("project", {"action": "tools", "output_format": "json"}),
+    ("index", {"action": "status", "output_format": "json"}),
+    (
+        "viz",
+        {
+            "action": "similarity",
+            "mode": "textual",
+            "min_lines": 200,
+            "max_groups": 1,
+            "include_bodies": False,
+            "output_format": "json",
+        },
+    ),
+]
+
+EXPECTED_FACADE_NAMES = [
+    "edit",
+    "health",
+    "index",
+    "nav",
+    "project",
+    "search",
+    "structure",
+    "viz",
+]
+
+
+def _json_text_payload(response: dict) -> dict:
+    """Return the JSON payload embedded in a JSON-RPC tools/call response."""
+    assert "error" not in response, response.get("error")
+    result = response["result"]
+    assert result["isError"] is False
+    content = result["content"]
+    assert len(content) == 1
+    assert content[0]["type"] == "text"
+    payload = json.loads(content[0]["text"])
+    assert isinstance(payload, dict)
+    return payload
+
+
+def _assert_agent_wire_envelope(payload: dict, facade_name: str) -> None:
+    """Assert the envelope an MCP stdio client actually receives."""
+    payload_dump = json.dumps(payload, sort_keys=True)
+    assert payload["success"] is True, f"{facade_name} failed: {payload_dump}"
+    assert isinstance(payload["verdict"], str), f"{facade_name}: {payload_dump}"
+    assert payload["verdict"] != "", f"{facade_name}: {payload_dump}"
+    assert isinstance(payload["agent_summary"], dict), f"{facade_name}: {payload_dump}"
+    agent_summary = payload["agent_summary"]
+    assert isinstance(agent_summary["summary_line"], str), (
+        f"{facade_name}: {payload_dump}"
+    )
+    assert agent_summary["summary_line"] != "", f"{facade_name}: {payload_dump}"
+    assert isinstance(agent_summary["verdict"], str), f"{facade_name}: {payload_dump}"
+    assert agent_summary["verdict"] != "", f"{facade_name}: {payload_dump}"
+    assert "traceback" not in json.dumps(payload).lower(), facade_name
+
+
+class TestFacadeWireContract:
+    @pytest.mark.parametrize(
+        ("facade_name", "arguments"),
+        FACADE_WIRE_CASES,
+        ids=[facade_name for facade_name, _ in FACADE_WIRE_CASES],
+    )
+    def test_all_facades_have_stdio_tools_call_envelopes(
+        self, mcp_server: MCPClient, facade_name: str, arguments: dict
+    ) -> None:
+        """Issue #691: cover the real client→stdio→tools/call boundary.
+
+        Unit tests that call ``tool.execute()`` directly cannot catch JSON-RPC
+        framing, facade dispatch, MCP content wrapping, or serialization bugs.
+        This test drives every public facade once over the actual stdio wire.
+        """
+        client = initialized(mcp_server)
+        response = client.call(facade_name, arguments, timeout=25.0)
+        payload = _json_text_payload(response)
+        _assert_agent_wire_envelope(payload, facade_name)
+
+    def test_facade_wire_cases_cover_all_public_facades(self) -> None:
+        covered_facades = sorted(facade_name for facade_name, _ in FACADE_WIRE_CASES)
+        assert covered_facades == EXPECTED_FACADE_NAMES
+
 
 # ---------------------------------------------------------------------------
 # safe_to_edit


### PR DESCRIPTION
Fixes #691.

## Summary
- add a real MCP stdio wire-contract E2E that calls all 8 public facade tools through JSON-RPC tools/call
- assert each response has a successful MCP envelope, JSON text payload, top-level verdict, and agent summary
- keep the check focused in the existing E2E harness instead of expanding local full-suite load

## Notes
The original issue count is partly stale because develop already has stdio E2E helpers and smoke tests. The remaining gap was that not every public facade had a direct stdio tools/call envelope contract, so envelope regressions could still slip through focused execute()-style tests.

## Verification
- nice -n 10 uv run pytest tests/e2e/test_tool_functional.py::TestFacadeWireContract::test_all_facades_have_stdio_tools_call_envelopes -n 0 -q
- nice -n 10 uv run pytest tests/e2e/test_tool_functional.py -n 0 -q
- uv run ruff check tests/e2e/test_tool_functional.py
- git diff --check
- uv run python -m tree_sitter_analyzer --change-impact --format json
