### PR TITLE
fix(index): persist rebuild-in-progress marker so reads stop lying mid-rebuild (#578)

### DIFF
--- a/tests/unit/test_ast_cache_build_state.py
+++ b/tests/unit/test_ast_cache_build_state.py
@@ -1,0 +1,293 @@
+"""Persisted "full rebuild in progress" marker (#578).
+
+A ``--full-index --full-index-mode full`` rebuild does ``DELETE FROM ast_index``
++ ``commit`` up front, then re-populates in bounded 500-file batches (the "A4"
+RSS guard in ``_commit_index_results``). Because the batched re-insert commits
+incrementally over the ~70 s rebuild, a concurrent reader on another connection
+(or process) sees the committed-but-empty / half-filled table and returns
+``success: true`` with phantom-empty data (``caller_count: 0`` when the real
+answer is 50).
+
+The single-big-transaction "atomic swap" cannot be used here — it would revive
+the exact OOM that A4's bounded-batch commit was added to prevent. So the fix is
+a persisted, cross-connection marker: the rebuild stamps a single sqlite meta
+row before the DELETE and clears it after re-population, and readers consult it
+to warn instead of trusting the half-built table.
+
+These tests pin the marker contract RED-first.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from tree_sitter_analyzer import _ast_cache_build_state as bs
+from tree_sitter_analyzer.ast_cache import ASTCache
+from tree_sitter_analyzer.mcp.tools.codegraph_status_tool import CodeGraphStatusTool
+
+
+def test_build_state_helpers_degrade_on_missing_table() -> None:
+    """No ast_build_state table → safe defaults, no raise; mark creates it."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    try:
+        # Absent table → not building, clear is a no-op, neither raises.
+        assert bs.build_in_progress(conn) is False
+        bs.clear_build_in_progress(conn)  # must not raise
+
+        # mark creates the table and persists a building row.
+        bs.mark_build_in_progress(conn)
+        assert bs.build_in_progress(conn) is True
+
+        # clear flips it back off.
+        bs.clear_build_in_progress(conn)
+        assert bs.build_in_progress(conn) is False
+    finally:
+        conn.close()
+
+
+def test_build_state_helpers_degrade_on_readonly_db(tmp_path: Path) -> None:
+    """Write failures (read-only DB) must be swallowed — the marker never raises.
+
+    The whole point of the marker is to make reads *safer*; it must never become
+    a new failure source. A read-only connection makes every write path
+    (CREATE/INSERT in mark, UPDATE in clear) raise OperationalError.
+    """
+    db = tmp_path / "ro.db"
+    sqlite3.connect(str(db)).close()  # materialise an empty db file
+    conn = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    try:
+        bs.mark_build_in_progress(conn)  # CREATE/INSERT on RO db → swallowed
+        bs.clear_build_in_progress(conn)  # UPDATE on RO db → swallowed
+        assert bs.build_in_progress(conn) is False
+    finally:
+        conn.close()
+
+
+def test_build_in_progress_false_when_row_absent() -> None:
+    """Table present but no id=1 row → not building (don't assume a row)."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    try:
+        conn.execute(
+            "CREATE TABLE ast_build_state "
+            "(id INTEGER PRIMARY KEY, building INTEGER NOT NULL, "
+            "started_at REAL NOT NULL, pid INTEGER NOT NULL)"
+        )
+        conn.commit()
+        assert bs.build_in_progress(conn) is False
+    finally:
+        conn.close()
+
+
+def test_build_in_progress_is_stale_after_ttl() -> None:
+    """A crashed rebuild that never cleared must not wedge readers forever.
+
+    An in-progress marker older than ``ttl_seconds`` is treated as stale
+    (the process that set it died), so readers stop warning and trust the
+    cache again.
+    """
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    try:
+        bs.mark_build_in_progress(conn)
+        assert bs.build_in_progress(conn) is True
+
+        # Backdate the marker far past any plausible rebuild duration.
+        conn.execute("UPDATE ast_build_state SET started_at = 1.0 WHERE id = 1")
+        conn.commit()
+
+        assert bs.build_in_progress(conn) is False
+        # A fresh short TTL also reports stale.
+        assert bs.build_in_progress(conn, ttl_seconds=1) is False
+    finally:
+        conn.close()
+
+
+def test_build_in_progress_stale_when_rebuilder_pid_is_dead() -> None:
+    """Crashed rebuild (pid gone) is stale immediately, before the TTL backstop.
+
+    pid 0 is never a live process, so _pid_alive(0) is False — the row is fresh
+    (started_at = now, within TTL) yet still reported not-in-progress.
+    """
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    try:
+        bs.mark_build_in_progress(conn)
+        assert bs.build_in_progress(conn) is True
+        conn.execute("UPDATE ast_build_state SET pid = 0 WHERE id = 1")
+        conn.commit()
+        assert bs.build_in_progress(conn) is False
+    finally:
+        conn.close()
+
+
+def test_pid_alive_branches(monkeypatch) -> None:
+    """_pid_alive maps os.kill outcomes correctly: gone→False, EPERM→alive."""
+    assert bs._pid_alive(0) is False  # non-positive pid is never alive
+
+    monkeypatch.setattr(bs.os, "kill", lambda *a: None)
+    assert bs._pid_alive(4321) is True  # signal 0 succeeded → running
+
+    def _gone(*a):
+        raise ProcessLookupError
+
+    monkeypatch.setattr(bs.os, "kill", _gone)
+    assert bs._pid_alive(4321) is False  # no such process → crashed
+
+    def _eperm(*a):
+        raise PermissionError
+
+    monkeypatch.setattr(bs.os, "kill", _eperm)
+    assert bs._pid_alive(4321) is True  # exists, owned by another user
+
+
+def test_build_in_progress_stale_when_timestamp_is_in_the_future() -> None:
+    """A clock that stepped backward (NTP) must not make a marker fresh forever."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    try:
+        bs.mark_build_in_progress(conn)
+        conn.execute(
+            "UPDATE ast_build_state SET started_at = ? WHERE id = 1",
+            (time.time() + 86_400,),
+        )
+        conn.commit()
+        assert bs.build_in_progress(conn) is False
+    finally:
+        conn.close()
+
+
+def _project(root: Path) -> None:
+    (root / "a.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+    (root / "b.py").write_text(
+        "from a import f\n\n\ndef g():\n    return f()\n", encoding="utf-8"
+    )
+
+
+def test_full_rebuild_sets_marker_during_empty_window_and_clears_after(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """force=True must mark building across the DELETE→repopulate window.
+
+    The marker is asserted at the moment ``_commit_index_results`` runs — by
+    then the up-front ``DELETE FROM ast_index`` has already committed an empty
+    table, which is precisely the window a concurrent reader would observe.
+    After ``index_project`` returns, the marker is cleared.
+    """
+    _project(tmp_path)
+    cache = ASTCache(str(tmp_path))
+
+    # Warm the cache so a subsequent force=True is a genuine rebuild.
+    cache.index_project(max_files=10, workers=0)
+    assert bs.build_in_progress(cache.get_conn()) is False
+
+    import tree_sitter_analyzer.ast_cache as ast_cache_mod
+
+    real_commit = ast_cache_mod._commit_index_results
+    observed: dict[str, bool] = {}
+
+    def _spy_commit(conn, *args, **kwargs):
+        # Mid-rebuild: table was DELETE'd + committed empty, not yet refilled.
+        observed["building_mid_rebuild"] = bs.build_in_progress(conn)
+        observed["empty_mid_rebuild"] = (
+            conn.execute("SELECT COUNT(*) FROM ast_index").fetchone()[0] == 0
+        )
+        return real_commit(conn, *args, **kwargs)
+
+    monkeypatch.setattr(ast_cache_mod, "_commit_index_results", _spy_commit)
+
+    cache.index_project(max_files=10, workers=0, force=True)
+
+    assert observed.get("empty_mid_rebuild") is True, "DELETE should empty the table"
+    assert observed.get("building_mid_rebuild") is True, (
+        "marker must be set during the empty rebuild window"
+    )
+    # Cleared on the way out.
+    assert bs.build_in_progress(cache.get_conn()) is False
+
+
+def test_marker_cleared_when_delete_phase_raises(tmp_path: Path, monkeypatch) -> None:
+    """P2 regression: a failure in the DELETE/commit phase must not leak the marker.
+
+    The MARK+DELETE+commit trio lives inside the try, so if the up-front DELETE
+    raises (e.g. SQLITE_FULL), the finally still clears the marker. Otherwise a
+    healthy cache would report ``index_rebuilding`` for the whole TTL window.
+    """
+    _project(tmp_path)
+    cache = ASTCache(str(tmp_path))
+    cache.index_project(max_files=10, workers=0)
+
+    real_conn = cache.get_conn()
+
+    class _RaiseOnDelete:
+        """Proxy that fails the ast_index DELETE but delegates everything else."""
+
+        def execute(self, sql, *args, **kwargs):
+            if isinstance(sql, str) and "DELETE FROM ast_index" in sql:
+                raise sqlite3.OperationalError("simulated SQLITE_FULL")
+            return real_conn.execute(sql, *args, **kwargs)
+
+        def __getattr__(self, name):
+            return getattr(real_conn, name)
+
+    monkeypatch.setattr(cache, "_get_conn", lambda: _RaiseOnDelete())
+
+    with pytest.raises(sqlite3.OperationalError):
+        cache.index_project(max_files=10, workers=0, force=True)
+
+    # The marker (written via the proxy → real db before the DELETE) must be
+    # cleared by the finally, despite the abort. Check on the real connection.
+    assert bs.build_in_progress(real_conn) is False
+
+
+@pytest.mark.asyncio
+async def test_status_warns_when_rebuilding_with_partial_index(tmp_path: Path) -> None:
+    """A nonempty-but-rebuilding cache → status WARN + index_rebuilding flag.
+
+    The marker is persisted, so the status tool's *separate* connection sees it
+    — this is the cross-connection contract that makes phantom-empty reads
+    detectable at all.
+    """
+    _project(tmp_path)
+    cache = ASTCache(str(tmp_path))
+    cache.index_project(max_files=10, workers=0)
+    bs.mark_build_in_progress(cache.get_conn())
+
+    tool = CodeGraphStatusTool(str(tmp_path))
+    result = await tool.execute({"output_format": "json", "include_lag": False})
+
+    assert result["index_rebuilding"] is True
+    assert result["verdict"] == "WARN"
+    assert "rebuild" in result["agent_summary"]["next_step"].lower()
+
+
+@pytest.mark.asyncio
+async def test_status_distinguishes_rebuild_from_missing_index(tmp_path: Path) -> None:
+    """Mid-rebuild empty table must NOT read as 'index missing — run index'.
+
+    Returning the generic missing-index hint here would make an agent kick off
+    a *second* rebuild on top of the running one.
+    """
+    _project(tmp_path)
+    cache = ASTCache(str(tmp_path))
+    cache.index_project(max_files=10, workers=0)
+    # Simulate the mid-rebuild empty window: rows gone, marker set.
+    conn = cache.get_conn()
+    conn.execute("DELETE FROM ast_index")
+    conn.commit()
+    bs.mark_build_in_progress(conn)
+
+    tool = CodeGraphStatusTool(str(tmp_path))
+    result = await tool.execute({"output_format": "json", "include_lag": False})
+
+    assert result["index_rebuilding"] is True
+    assert result["verdict"] == "WARN"
+    hint = result["agent_summary"]["next_step"].lower()
+    assert "rebuild in progress" in hint
+    assert "missing or empty" not in hint

--- a/tree_sitter_analyzer/_ast_cache_build_state.py
+++ b/tree_sitter_analyzer/_ast_cache_build_state.py
@@ -1,0 +1,151 @@
+"""Persisted "full rebuild in progress" marker for the AST cache (#578).
+
+A ``--full-index --full-index-mode full`` rebuild does ``DELETE FROM ast_index``
++ ``commit`` up front, then re-populates in bounded 500-file batches (the "A4"
+RSS guard in :func:`_ast_cache_helpers._commit_index_results`). Those batched
+re-inserts commit incrementally over the ~70 s rebuild, so a reader on another
+connection — or another process — sees the committed-but-empty / half-filled
+table and returns ``success: true`` with phantom-empty data.
+
+A single big transaction wrapping the whole rebuild would remove the window but
+revive the exact OOM that A4's bounded-batch commit exists to prevent, so it is
+not an option. Instead the rebuild stamps a single sqlite meta row before the
+DELETE and clears it after re-population; readers consult it and warn rather
+than trusting a half-built table.
+
+The marker is persisted (visible to every connection, including other
+processes) and self-expiring: a rebuild that crashes without clearing the row
+leaves a marker that goes *stale* after ``ttl_seconds`` so readers are never
+wedged into permanent "rebuilding" warnings.
+
+This mirrors the ``ast_resolve_state`` single-row idiom in
+:mod:`tree_sitter_analyzer._ast_cache_unresolved`.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+import time
+
+logger = logging.getLogger(__name__)
+
+# Liveness is decided primarily by the recorded rebuilder pid (below); this TTL
+# is only a backstop for the cases pid-liveness can't cover — pid reuse, or a
+# (non-default) cache shared across machines. Set well above any plausible
+# single rebuild so it never expires a genuinely-running one: a 20k-file repo on
+# a slow/contended host can take many minutes (the ~70 s in #578 was a small
+# repo). Kept finite so a wedged marker still self-heals eventually.
+_DEFAULT_TTL_SECONDS = 3600.0
+
+# Tolerance for a marker timestamp that sits slightly in the future (minor clock
+# skew). Beyond this the clock stepped backward (NTP) and the marker is bogus.
+_CLOCK_SKEW_GRACE_SECONDS = 60.0
+
+_CREATE_DDL = (
+    "CREATE TABLE IF NOT EXISTS ast_build_state ("
+    "id INTEGER PRIMARY KEY, "
+    "building INTEGER NOT NULL, "
+    "started_at REAL NOT NULL, "
+    "pid INTEGER NOT NULL)"
+)
+
+
+def _pid_alive(pid: int) -> bool:
+    """Best-effort: is a process with this pid running on THIS machine?
+
+    The ``.ast-cache`` db is local to the checkout, so the rebuilder and any
+    concurrent reader share a machine — a dead pid means the rebuild crashed,
+    and the marker is stale *immediately* (no waiting for the TTL backstop).
+    Signal 0 probes existence without delivering anything.
+    """
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # exists, just owned by another user
+    except OSError:  # pragma: no cover — be conservative, assume alive
+        return True
+    return True
+
+
+def mark_build_in_progress(conn: sqlite3.Connection) -> None:
+    """Stamp the single-row marker that a full rebuild has started.
+
+    Best-effort: on write failure (lock contention, transient I/O) this logs and
+    returns rather than raising — the marker must never become a *new* failure
+    source. The caller then proceeds without a marker, degrading to the pre-#578
+    behaviour (readers may see the transient empty window) rather than aborting
+    the rebuild outright, which would be a worse "can't rebuild under
+    contention" failure mode.
+    """
+    try:
+        conn.execute(_CREATE_DDL)
+        conn.execute(
+            "INSERT INTO ast_build_state (id, building, started_at, pid) "
+            "VALUES (1, 1, ?, ?) "
+            "ON CONFLICT(id) DO UPDATE SET "
+            "building = excluded.building, "
+            "started_at = excluded.started_at, "
+            "pid = excluded.pid",
+            (time.time(), os.getpid()),
+        )
+        conn.commit()
+    except sqlite3.OperationalError:
+        logger.debug("could not mark build-in-progress", exc_info=True)
+
+
+def clear_build_in_progress(conn: sqlite3.Connection) -> None:
+    """Clear the marker after a rebuild finishes (or aborts cleanly)."""
+    try:
+        conn.execute("UPDATE ast_build_state SET building = 0 WHERE id = 1")
+        conn.commit()
+    except sqlite3.OperationalError:
+        logger.debug("could not clear build-in-progress", exc_info=True)
+
+
+def build_in_progress(
+    conn: sqlite3.Connection, *, ttl_seconds: float = _DEFAULT_TTL_SECONDS
+) -> bool:
+    """True iff a full rebuild is actively in progress.
+
+    Returns ``False`` when the marker table/row is absent, when the flag is off,
+    or when the marker is *stale*. Staleness is decided by, in order:
+
+    * **clock skew** — a ``started_at`` more than ``_CLOCK_SKEW_GRACE_SECONDS``
+      in the future means the wall clock stepped backward (NTP); the marker is
+      bogus, not fresh-forever.
+    * **TTL backstop** — older than ``ttl_seconds`` (covers pid reuse and the
+      non-default cross-machine cache case).
+    * **pid liveness** — the recorded rebuilder pid is no longer running, so the
+      rebuild crashed; stale immediately rather than after the full TTL.
+
+    Never raises.
+    """
+    try:
+        row = conn.execute(
+            "SELECT building, started_at, pid FROM ast_build_state WHERE id = 1"
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return False
+    if row is None:
+        return False
+    if isinstance(row, sqlite3.Row):
+        building, started_at, pid = row["building"], row["started_at"], row["pid"]
+    else:
+        building, started_at, pid = row[0], row[1], row[2]
+    if not building:
+        return False
+    now = time.time()
+    started = float(started_at)
+    if started > now + _CLOCK_SKEW_GRACE_SECONDS:
+        return False  # clock stepped backward — bogus future timestamp
+    if (now - started) >= ttl_seconds:
+        return False  # TTL backstop for a wedged/crashed marker
+    if not _pid_alive(int(pid)):
+        return False  # rebuilder process gone — crashed, stale now
+    return True

--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -29,6 +29,10 @@ from ._ast_cache_query import (
     search_symbols_linear as _search_symbols_linear,
 )
 from ._ast_cache_search import search_symbols_cascade as _search_symbols_cascade
+from ._ast_cache_build_state import (
+    clear_build_in_progress as _clear_build_in_progress,
+    mark_build_in_progress as _mark_build_in_progress,
+)
 from ._ast_cache_helpers import (
     _build_function_entry,
     _commit_index_results,
@@ -317,31 +321,49 @@ class ASTCache:
                 "unresolved_refs_backfill": unresolved,
                 "activation_enabled": activation_enabled,
             }
-        if force:
+        try:
+            if force:
+                # #578: a full rebuild empties ast_index up front (the DELETE
+                # below commits), then re-populates in bounded batches over
+                # ~70 s. Stamp a persisted marker across that window so
+                # concurrent readers on other connections/processes warn
+                # instead of trusting the half-built table. MARK + DELETE live
+                # INSIDE the try so the finally clears the marker even if the
+                # DELETE/commit itself raises (e.g. SQLITE_FULL) — otherwise a
+                # failed rebuild would leave a stuck marker until TTL expiry.
+                conn = self._get_conn()
+                _mark_build_in_progress(conn)
+                conn.execute("DELETE FROM ast_index")
+                conn.commit()
+            stats, candidates, count = self._walk_and_partition(
+                max_files, force, activation_enabled
+            )
+            workers = self._resolve_worker_count(workers, candidates)
+            if workers and workers >= 2 and len(candidates) >= 2:
+                results = self._index_parallel(candidates, workers)
+            else:
+                results = [
+                    _worker_index_file((p, self.project_root, lang))
+                    for p, lang in candidates
+                ]
             conn = self._get_conn()
-            conn.execute("DELETE FROM ast_index")
-            conn.commit()
-        stats, candidates, count = self._walk_and_partition(
-            max_files, force, activation_enabled
-        )
-        workers = self._resolve_worker_count(workers, candidates)
-        if workers and workers >= 2 and len(candidates) >= 2:
-            results = self._index_parallel(candidates, workers)
-        else:
-            results = [
-                _worker_index_file((p, self.project_root, lang))
-                for p, lang in candidates
-            ]
-        conn = self._get_conn()
-        indexed_at = datetime.now(timezone.utc).isoformat()
-        _commit_index_results(
-            conn, results, stats, self._insert_index_row, indexed_at, activation_enabled
-        )
-        stats["total_files"] = count
-        stats["workers"] = workers
-        if stats["indexed"] > 0:
-            self._post_index_backfill(stats)
-        return stats
+            indexed_at = datetime.now(timezone.utc).isoformat()
+            _commit_index_results(
+                conn,
+                results,
+                stats,
+                self._insert_index_row,
+                indexed_at,
+                activation_enabled,
+            )
+            stats["total_files"] = count
+            stats["workers"] = workers
+            if stats["indexed"] > 0:
+                self._post_index_backfill(stats)
+            return stats
+        finally:
+            if force:
+                _clear_build_in_progress(self._get_conn())
 
     def _walk_and_partition(
         self, max_files: int, force: bool, activation_enabled: bool

--- a/tree_sitter_analyzer/mcp/tools/codegraph_status_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_status_tool.py
@@ -10,6 +10,7 @@ it is, and where to look. Replaces 3-4 separate tool calls.
 from __future__ import annotations
 
 import os
+import sqlite3
 from typing import Any
 
 from ...utils import setup_logger
@@ -133,11 +134,21 @@ class CodeGraphStatusTool(BaseMCPTool):
         # Empty cache (file exists, 0 files) is still WARN — agent should warm.
         truly_indexed = bool(stats and stats.get("total_files", 0) > 0)
 
+        # #578: a full rebuild empties ast_index mid-flight. Distinguish that
+        # transient empty/partial state from a genuinely missing index so the
+        # agent retries instead of kicking off a redundant rebuild.
+        rebuilding = self._is_rebuilding() if cache_exists else False
+
         if not truly_indexed:
             hint = (
                 "Index missing or empty. Run the `index` tool with action=auto "
                 "to build the cache."
             )
+            if rebuilding:
+                hint = (
+                    "Full rebuild in progress — the index is transiently empty. "
+                    "Do NOT start another index; retry status/nav shortly."
+                )
             result = build_response(
                 verdict="WARN",
                 project_root=self.project_root,
@@ -149,11 +160,18 @@ class CodeGraphStatusTool(BaseMCPTool):
                 cache_path=cache_path if cache_exists else None,
                 hint=hint,
                 agent_summary={
-                    "summary_line": "codegraph_status: index missing or empty",
+                    "summary_line": (
+                        "codegraph_status: full rebuild in progress (transient)"
+                        if rebuilding
+                        else "codegraph_status: index missing or empty"
+                    ),
                     "next_step": hint,
                     "verdict": "WARN",
                 },
             )
+            # #578: only emit the flag when truthy (don't emit false scalars).
+            if rebuilding:
+                result["index_rebuilding"] = True
             # Item 1: omit schema_version when None (don't emit null scalars)
             if stats and stats.get("schema_version") is not None:
                 result["schema_version"] = stats.get("schema_version")
@@ -171,13 +189,21 @@ class CodeGraphStatusTool(BaseMCPTool):
                 "Index is healthy but stale (>5 min). Run action=sync first, "
                 "then proceed with nav/search"
             )
+        if rebuilding:
+            # #578: nonempty but a rebuild is replacing rows — counts are partial.
+            next_step = (
+                "Full rebuild in progress — counts are partial and changing. "
+                "Wait for it to finish before trusting nav/search results."
+            )
 
         total_files = int(stats.get("total_files", 0)) if stats else 0
         total_symbols = int(stats.get("total_symbols", 0)) if stats else 0
         total_edges = int(stats.get("total_edges", 0)) if stats else 0
 
+        # #578: a rebuild replacing rows makes counts untrustworthy → WARN.
+        verdict = "WARN" if rebuilding else "INFO"
         result = build_response(
-            verdict="INFO",
+            verdict=verdict,
             project_root=self.project_root,
             indexed=True,
             total_files=total_files,
@@ -202,13 +228,47 @@ class CodeGraphStatusTool(BaseMCPTool):
                     f"{total_edges} edges"
                 ),
                 "next_step": next_step,
-                "verdict": "INFO",
+                "verdict": verdict,
             },
         )
+        # #578: only emit the flag when truthy (don't emit false scalars).
+        if rebuilding:
+            result["index_rebuilding"] = True
         # Item 1: omit schema_version when None (don't emit null scalars)
         if stats and stats.get("schema_version") is not None:
             result["schema_version"] = stats.get("schema_version")
         return apply_toon_format_to_response(result, output_format)
+
+    def _is_rebuilding(self) -> bool:
+        """True while a full rebuild is replacing the cache (#578).
+
+        Reads the persisted marker via a throwaway connection to the real cache
+        db — deliberately not through ASTCache, to stay consistent with this
+        tool's short-lived, handle-closing style and to avoid a migration just
+        to check one flag. Never raises.
+        """
+        if not self.project_root:  # pragma: no cover — execute() guarantees it
+            return False
+        db_path = os.path.join(self.project_root, ".ast-cache", "index.db")
+        if not os.path.exists(
+            db_path
+        ):  # pragma: no cover — caller gates on cache_exists
+            return False
+        try:
+            from ..._ast_cache_build_state import build_in_progress
+
+            conn = sqlite3.connect(db_path, timeout=2)
+            try:
+                return bool(build_in_progress(conn))
+            finally:
+                conn.close()
+        except Exception:
+            # Degrade *open* (assume not rebuilding): a 2 s SELECT timeout under
+            # the very write contention that makes rebuilds slow would land
+            # here, so the WARN is best-effort, not a guarantee. Better to miss
+            # a warning than to wedge status behind a slow lock.
+            logger.debug("rebuilding check failed", exc_info=True)
+            return False
 
     def _safe_get_stats(self) -> dict[str, Any] | None:
         # Always close the SQLite handle — this tool is read-only and


### PR DESCRIPTION
## Summary
Closes the read-side of #578 (P2): during a full `--full-index` rebuild, concurrent reads on another connection/process saw the committed-but-empty / half-filled `ast_index` table and returned `success: true` with phantom-empty data (`caller_count: 0` when the real answer is 50). The index exists and lies — #491 trust family at its worst.

## Root cause
`ASTCache.index_project(force=True)` does `DELETE FROM ast_index` + `commit()` up front, then re-populates in **bounded 500-file batches** (`_commit_index_results`, the "A4" RSS/OOM guard). The batched re-insert commits incrementally over the ~70 s rebuild, so the empty/partial state is visible to every other connection during that window.

## Why not the "obvious" atomic fix
Wrapping the whole rebuild in one transaction (so WAL readers see the old snapshot until a single commit) would remove the window — but revive the exact OOM that A4's bounded-batch commit was added to prevent (7.9k-file Java repos). So that path is out by design; the marker is the safe route.

## Change
- **New `_ast_cache_build_state.py`** — persisted single-row marker (mirrors the `ast_resolve_state` idiom). Cross-connection/cross-process visible, and **self-expiring via TTL** so a crashed rebuild never wedges readers into permanent "rebuilding" warnings.
- **`index_project` force path** — stamps the marker before the DELETE, clears it in `try/finally` after re-population (covers the error path too).
- **First consumer — `index action=status`** — reports `index_rebuilding: true` + verdict `WARN`, and distinguishes the transient mid-rebuild empty window from a genuinely missing index (which would otherwise tell an agent to start a *second* rebuild). Also gives #708 the authoritative "build in progress" signal it asked for.

## Scope / follow-up
Deliberately focused per PR-hygiene. The read-family rollout (callers / callees / class-hierarchy emitting `WARN index_rebuilding` instead of phantom `NOT_FOUND`) is a separate follow-up PR — those readers are decentralized and bundling them here would make this a kitchen sink. **#578 fully closes with both PRs.**

## Test plan
- [x] `tests/unit/test_ast_cache_build_state.py` — marker unit + missing-table degrade + TTL staleness (crash recovery) + mid-rebuild window contract (asserts marker set while table is empty, cleared after) + status surfacing for both partial and empty windows, via a **separate connection** to pin the cross-connection contract.
- [x] change-impact focused command (194) green; full suite `uv run pytest -q` = 20195 passed (1 unrelated startup-latency flake: `test_repeated_headless_initialize_stays_under_budget`, passes isolated in 1.16s — load-induced under 20k parallel tests, untouched by this change).
- [x] ruff + mypy clean; patch-coverage gate: no added executable misses; CLI parity smoke (`--codegraph-status`) OK, field correctly omitted on the non-rebuilding path.