### PR TITLE
fix(index): reclaim AST cache storage after full rebuild (#579)

### DIFF
--- a/tests/unit/test_ast_cache_maintenance.py
+++ b/tests/unit/test_ast_cache_maintenance.py
@@ -1,0 +1,179 @@
+"""Tests for AST cache SQLite storage maintenance (#579)."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+from tree_sitter_analyzer._ast_cache_maintenance import (
+    get_db_storage_stats,
+    reclaim_storage_after_full_rebuild,
+)
+from tree_sitter_analyzer.ast_cache import ASTCache
+
+
+class _Row:
+    def __init__(self, value: int) -> None:
+        self._value = value
+
+    def __getitem__(self, index: int) -> int:
+        assert index == 0
+        return self._value
+
+
+class _Cursor:
+    def __init__(self, value: int) -> None:
+        self._value = value
+
+    def fetchone(self) -> _Row:
+        return _Row(self._value)
+
+
+class _FakeConn:
+    def __init__(self, *, free_pages: int, auto_vacuum: int) -> None:
+        self.commands: list[str] = []
+        self.commits = 0
+        self.free_pages = free_pages
+        self.auto_vacuum = auto_vacuum
+
+    def execute(self, sql: str) -> _Cursor:
+        self.commands.append(sql)
+        if sql == "PRAGMA page_size":
+            return _Cursor(4096)
+        if sql == "PRAGMA page_count":
+            return _Cursor(11)
+        if sql == "PRAGMA freelist_count":
+            return _Cursor(self.free_pages)
+        if sql == "PRAGMA auto_vacuum":
+            return _Cursor(self.auto_vacuum)
+        if sql == "PRAGMA auto_vacuum=INCREMENTAL":
+            self.auto_vacuum = 2
+            return _Cursor(0)
+        if sql == "VACUUM":
+            self.free_pages = 0
+            return _Cursor(0)
+        if sql == "PRAGMA incremental_vacuum(8)":
+            self.free_pages = 0
+            return _Cursor(0)
+        raise AssertionError(f"unexpected SQL: {sql}")
+
+    def commit(self) -> None:
+        self.commits += 1
+
+
+def test_get_db_storage_stats_reports_exact_page_counters() -> None:
+    conn = _FakeConn(free_pages=3, auto_vacuum=0)
+
+    stats = get_db_storage_stats(conn, "/missing/index.db")  # type: ignore[arg-type]
+
+    assert stats == {
+        "db_path": "/missing/index.db",
+        "db_size_bytes": 45056,
+        "db_page_size": 4096,
+        "db_page_count": 11,
+        "db_free_pages": 3,
+        "db_free_bytes": 12288,
+        "db_auto_vacuum_mode": 0,
+    }
+
+
+def test_reclaim_storage_skips_when_free_pages_are_below_threshold() -> None:
+    conn = _FakeConn(free_pages=4, auto_vacuum=0)
+
+    result = reclaim_storage_after_full_rebuild(  # type: ignore[arg-type]
+        conn, "/missing/index.db", min_free_pages=5
+    )
+
+    assert result["action"] == "skipped"
+    assert result["reason"] == "below_threshold"
+    assert result["before"]["db_free_pages"] == 4
+    assert result["after"]["db_free_pages"] == 4
+    assert conn.commits == 0
+    assert conn.commands == [
+        "PRAGMA page_size",
+        "PRAGMA page_count",
+        "PRAGMA freelist_count",
+        "PRAGMA auto_vacuum",
+    ]
+
+
+def test_reclaim_storage_vacuums_legacy_auto_vacuum_none_db() -> None:
+    conn = _FakeConn(free_pages=8, auto_vacuum=0)
+
+    result = reclaim_storage_after_full_rebuild(  # type: ignore[arg-type]
+        conn, "/missing/index.db", min_free_pages=5
+    )
+
+    assert result["action"] == "enable_incremental_vacuum"
+    assert result["before"]["db_free_pages"] == 8
+    assert result["before"]["db_auto_vacuum_mode"] == 0
+    assert result["after"]["db_free_pages"] == 0
+    assert result["after"]["db_auto_vacuum_mode"] == 2
+    assert conn.commits == 2
+    assert "PRAGMA auto_vacuum=INCREMENTAL" in conn.commands
+    assert "VACUUM" in conn.commands
+
+
+def test_reclaim_storage_uses_incremental_vacuum_when_enabled() -> None:
+    conn = _FakeConn(free_pages=8, auto_vacuum=2)
+
+    result = reclaim_storage_after_full_rebuild(  # type: ignore[arg-type]
+        conn, "/missing/index.db", min_free_pages=5
+    )
+
+    assert result["action"] == "incremental_vacuum"
+    assert result["before"]["db_free_pages"] == 8
+    assert result["after"]["db_free_pages"] == 0
+    assert conn.commits == 2
+    assert "PRAGMA incremental_vacuum(8)" in conn.commands
+
+
+class _BrokenConn(_FakeConn):
+    def execute(self, sql: str) -> _Cursor:
+        if sql == "VACUUM":
+            raise sqlite3.DatabaseError("disk is busy")
+        return super().execute(sql)
+
+
+def test_reclaim_storage_reports_errors_without_raising() -> None:
+    conn = _BrokenConn(free_pages=8, auto_vacuum=0)
+
+    result = reclaim_storage_after_full_rebuild(  # type: ignore[arg-type]
+        conn, "/missing/index.db", min_free_pages=5
+    )
+
+    assert result["action"] == "error"
+    assert result["error"] == "disk is busy"
+    assert result["before"]["db_free_pages"] == 8
+    assert result["after"]["db_free_pages"] == 8
+
+
+def test_index_project_force_includes_db_maintenance(tmp_path, monkeypatch) -> None:
+    import tree_sitter_analyzer.ast_cache as ast_cache_mod
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "main.py").write_text("def hello():\n    return 1\n", encoding="utf-8")
+    cache = ASTCache(str(tmp_path))
+    try:
+        cache.index_project(workers=0)
+        observed: dict[str, Any] = {}
+
+        def _fake_reclaim(conn, db_path):
+            observed["db_path"] = db_path
+            return {"action": "skipped", "reason": "below_threshold"}
+
+        monkeypatch.setattr(
+            ast_cache_mod, "_reclaim_storage_after_full_rebuild", _fake_reclaim
+        )
+
+        result = cache.index_project(force=True, workers=0)
+
+        assert result["indexed"] == 1
+        assert result["db_maintenance"] == {
+            "action": "skipped",
+            "reason": "below_threshold",
+        }
+        assert observed["db_path"] == cache.db_path
+    finally:
+        cache.close()

--- a/tests/unit/test_codegraph_status_tool.py
+++ b/tests/unit/test_codegraph_status_tool.py
@@ -121,6 +121,41 @@ class TestExecuteWithIndex:
         assert result["lag_seconds"] is None
 
     @pytest.mark.asyncio
+    async def test_storage_counters_are_surfaced(self, tool_with_root, tmp_path):
+        cache_dir = tmp_path / ".ast-cache"
+        cache_dir.mkdir()
+        (cache_dir / "index.db").write_bytes(b"sqlite3-fake")
+
+        mock_cache = MagicMock()
+        mock_cache.get_stats.return_value = {
+            "total_files": 2,
+            "total_symbols": 3,
+            "total_edges": 4,
+            "fts5_available": True,
+            "db_size_bytes": 45056,
+            "db_page_size": 4096,
+            "db_page_count": 11,
+            "db_free_pages": 3,
+            "db_free_bytes": 12288,
+            "db_auto_vacuum_mode": 0,
+        }
+
+        with patch(
+            "tree_sitter_analyzer.ast_cache.ASTCache",
+            return_value=mock_cache,
+        ):
+            result = await tool_with_root.execute(
+                {"output_format": "json", "include_lag": False}
+            )
+
+        assert result["db_size_bytes"] == 45056
+        assert result["db_page_size"] == 4096
+        assert result["db_page_count"] == 11
+        assert result["db_free_pages"] == 3
+        assert result["db_free_bytes"] == 12288
+        assert result["db_auto_vacuum_mode"] == 0
+
+    @pytest.mark.asyncio
     async def test_total_edges_reported_for_graph_density(
         self, tool_with_root, tmp_path
     ):

--- a/tree_sitter_analyzer/_ast_cache_maintenance.py
+++ b/tree_sitter_analyzer/_ast_cache_maintenance.py
@@ -1,0 +1,97 @@
+"""SQLite storage maintenance helpers for the AST cache."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from typing import Any
+
+SQLITE_AUTO_VACUUM_NONE = 0
+SQLITE_AUTO_VACUUM_INCREMENTAL = 2
+
+# Default SQLite page size is 4096 bytes, so this catches ~2 MiB+ freelists.
+DEFAULT_VACUUM_MIN_FREE_PAGES = 512
+
+
+def _pragma_int(conn: sqlite3.Connection, pragma_name: str) -> int:
+    row = conn.execute(f"PRAGMA {pragma_name}").fetchone()
+    return int(row[0]) if row is not None else 0
+
+
+def get_db_storage_stats(
+    conn: sqlite3.Connection, db_path: str
+) -> dict[str, int | str]:
+    """Return exact SQLite file/page/free-list storage counters."""
+    page_size = _pragma_int(conn, "page_size")
+    page_count = _pragma_int(conn, "page_count")
+    free_pages = _pragma_int(conn, "freelist_count")
+    auto_vacuum_mode = _pragma_int(conn, "auto_vacuum")
+    logical_size = page_size * page_count
+    try:
+        db_size_bytes = os.path.getsize(db_path)
+    except OSError:
+        db_size_bytes = logical_size
+    return {
+        "db_path": db_path,
+        "db_size_bytes": int(db_size_bytes),
+        "db_page_size": page_size,
+        "db_page_count": page_count,
+        "db_free_pages": free_pages,
+        "db_free_bytes": free_pages * page_size,
+        "db_auto_vacuum_mode": auto_vacuum_mode,
+    }
+
+
+def reclaim_storage_after_full_rebuild(
+    conn: sqlite3.Connection,
+    db_path: str,
+    *,
+    min_free_pages: int = DEFAULT_VACUUM_MIN_FREE_PAGES,
+) -> dict[str, Any]:
+    """Reclaim freelist pages after a force rebuild when the waste is material.
+
+    Legacy cache DBs were created with ``auto_vacuum=NONE``. Incremental vacuum
+    cannot reclaim those pages until SQLite rewrites the DB once, so the first
+    qualifying legacy rebuild enables incremental mode and runs ``VACUUM``.
+    Newer DBs in incremental mode use ``PRAGMA incremental_vacuum``.
+    """
+    before = get_db_storage_stats(conn, db_path)
+    if int(before["db_free_pages"]) < min_free_pages:
+        return {
+            "action": "skipped",
+            "reason": "below_threshold",
+            "min_free_pages": min_free_pages,
+            "before": before,
+            "after": before,
+        }
+
+    try:
+        conn.commit()
+        free_pages = int(before["db_free_pages"])
+        auto_vacuum_mode = int(before["db_auto_vacuum_mode"])
+        if auto_vacuum_mode == SQLITE_AUTO_VACUUM_INCREMENTAL:
+            conn.execute(f"PRAGMA incremental_vacuum({free_pages})")
+            action = "incremental_vacuum"
+        else:
+            if auto_vacuum_mode == SQLITE_AUTO_VACUUM_NONE:
+                conn.execute("PRAGMA auto_vacuum=INCREMENTAL")
+                action = "enable_incremental_vacuum"
+            else:
+                action = "vacuum"
+            conn.execute("VACUUM")
+        conn.commit()
+        after = get_db_storage_stats(conn, db_path)
+        return {
+            "action": action,
+            "min_free_pages": min_free_pages,
+            "before": before,
+            "after": after,
+        }
+    except sqlite3.DatabaseError as exc:
+        return {
+            "action": "error",
+            "error": str(exc),
+            "min_free_pages": min_free_pages,
+            "before": before,
+            "after": before,
+        }

--- a/tree_sitter_analyzer/_ast_cache_query.py
+++ b/tree_sitter_analyzer/_ast_cache_query.py
@@ -12,6 +12,7 @@ import logging
 import sqlite3
 from typing import TYPE_CHECKING, Any, cast
 
+from ._ast_cache_maintenance import get_db_storage_stats
 from .utils.test_detection import query_wants_tests, rank_tier
 
 if TYPE_CHECKING:
@@ -376,9 +377,9 @@ def get_stats(
         "symbols_by_kind": symbols_by_kind,
         "symbols_by_language": symbols_by_language,
         "edges_by_kind": edges_by_kind,
-        "db_path": db_path,
         "fts5_available": bool(fts5_available),
     }
+    stats.update(get_db_storage_stats(conn, db_path))
     if fts5_available:
         stats["fts_indexed_symbols"] = total_symbols
     return stats

--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -39,6 +39,9 @@ from ._ast_cache_helpers import (
     _make_error_entry,
     _project_index_activation_enabled,
 )
+from ._ast_cache_maintenance import (
+    reclaim_storage_after_full_rebuild as _reclaim_storage_after_full_rebuild,
+)
 from ._ast_cache_schema import (
     EXPECTED_SCHEMA_VERSIONS as _EXPECTED_SCHEMA_VERSIONS,
     SQL_GET_SCHEMA_VERSION as _SQL_GET_SCHEMA_VERSION,
@@ -360,6 +363,10 @@ class ASTCache:
             stats["workers"] = workers
             if stats["indexed"] > 0:
                 self._post_index_backfill(stats)
+            if force:
+                stats["db_maintenance"] = _reclaim_storage_after_full_rebuild(
+                    conn, self.db_path
+                )
             return stats
         finally:
             if force:

--- a/tree_sitter_analyzer/mcp/tools/codegraph_status_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_status_tool.py
@@ -48,6 +48,15 @@ _LAG_SKIP_DIRS = frozenset(
     }
 )
 
+_DB_STORAGE_KEYS = (
+    "db_size_bytes",
+    "db_page_size",
+    "db_page_count",
+    "db_free_pages",
+    "db_free_bytes",
+    "db_auto_vacuum_mode",
+)
+
 
 class CodeGraphStatusTool(BaseMCPTool):
     """MCP Tool for index health at-a-glance (CodeGraph parity)."""
@@ -172,6 +181,7 @@ class CodeGraphStatusTool(BaseMCPTool):
             # #578: only emit the flag when truthy (don't emit false scalars).
             if rebuilding:
                 result["index_rebuilding"] = True
+            result.update(_storage_fields(stats))
             # Item 1: omit schema_version when None (don't emit null scalars)
             if stats and stats.get("schema_version") is not None:
                 result["schema_version"] = stats.get("schema_version")
@@ -234,6 +244,7 @@ class CodeGraphStatusTool(BaseMCPTool):
         # #578: only emit the flag when truthy (don't emit false scalars).
         if rebuilding:
             result["index_rebuilding"] = True
+        result.update(_storage_fields(stats))
         # Item 1: omit schema_version when None (don't emit null scalars)
         if stats and stats.get("schema_version") is not None:
             result["schema_version"] = stats.get("schema_version")
@@ -340,3 +351,13 @@ class CodeGraphStatusTool(BaseMCPTool):
                 if newest is None or m > newest:
                     newest = m
         return newest
+
+
+def _storage_fields(stats: dict[str, Any] | None) -> dict[str, int]:
+    if not stats:
+        return {}
+    fields: dict[str, int] = {}
+    for key in _DB_STORAGE_KEYS:
+        if key in stats and stats[key] is not None:
+            fields[key] = int(stats[key])
+    return fields


### PR DESCRIPTION
## Summary
Fixes #579 by reclaiming SQLite freelist growth after forced AST cache rebuilds and surfacing database storage counters in `codegraph_status`.

## Root Cause
Full index rebuilds delete and reinsert AST cache rows, but legacy cache DBs use `PRAGMA auto_vacuum=0`, so SQLite keeps freed pages on the freelist and the `index.db` file grows across logically idempotent rebuilds.

## Changes
- Add `tree_sitter_analyzer/_ast_cache_maintenance.py` for exact SQLite page/free-list metrics and post-rebuild maintenance.
- Run maintenance after `ASTCache.index_project(force=True)`: skip below threshold, run `VACUUM` once for legacy `auto_vacuum=NONE`, and use `PRAGMA incremental_vacuum` when incremental mode is already enabled.
- Include `db_size_bytes`, `db_page_size`, `db_page_count`, `db_free_pages`, `db_free_bytes`, and `db_auto_vacuum_mode` in `codegraph_status`.
- Add focused unit coverage for storage stats, reclaim decisions, error degradation, and status surfacing.

## Validation
- `uv run pytest tests/unit/test_ast_cache_maintenance.py tests/unit/test_codegraph_status_tool.py -q` -> 26 passed
- `uv run pytest tests/integration/test_ast_cache_lifecycle.py tests/unit/mcp/test_ast_cache_watch_modes.py tests/unit/test_ast_cache.py tests/unit/test_ast_cache_bfs.py tests/unit/test_ast_cache_cascade_search.py tests/unit/test_ast_cache_mode_used.py tests/unit/test_ast_cache_tool.py tests/unit/test_ast_cache_utf8_bug.py tests/unit/test_codegraph_status_tool.py -q` -> 195 passed
- `uv run pytest tests/unit/test_ast_cache_maintenance.py tests/unit/test_codegraph_status_tool.py tests/unit/test_ast_cache.py --cov=tree_sitter_analyzer --cov-report=json -q` -> 110 passed
- `uv run python scripts/check_patch_coverage.py --base origin/develop --coverage-json coverage.json` -> passed
- `uv run pytest -q` -> 20209 passed, 89 skipped, 8 xfailed, 1 rerun in 106.57s
- `uv run ruff check ...` -> passed
- `uv run mypy ...` -> passed
- `git diff --check` -> passed