### PR TITLE
fix(index): warn graph readers during full rebuild (#578)

### DIFF
--- a/tests/unit/test_callers_callees_tools.py
+++ b/tests/unit/test_callers_callees_tools.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 import pytest
 
+from tree_sitter_analyzer import _ast_cache_build_state as build_state
+from tree_sitter_analyzer.ast_cache import ASTCache
 from tree_sitter_analyzer.mcp.tools.callees_tool import CodeGraphCalleesTool
 from tree_sitter_analyzer.mcp.tools.callers_tool import CodeGraphCallersTool
 from tree_sitter_analyzer.mcp.tools.codegraph_relation_tool import (
@@ -492,6 +494,64 @@ class TestEmptyIndexHint:
             f"next_step should mention --full-index when call graph is empty; "
             f"got: {next_step!r}"
         )
+
+    @pytest.mark.asyncio
+    async def test_callers_rebuild_marker_warns_without_phantom_count(
+        self, tmp_path
+    ) -> None:
+        (tmp_path / "sample.py").write_text(
+            "def foo():\n    bar()\n\ndef bar():\n    return 1\n",
+            encoding="utf-8",
+        )
+        cache = ASTCache(str(tmp_path))
+        try:
+            cache.index_project(workers=0)
+            build_state.mark_build_in_progress(cache.get_conn())
+
+            tool = CodeGraphCallersTool(str(tmp_path))
+            result = await tool.execute(
+                {"function_name": "bar", "output_format": "json"}
+            )
+        finally:
+            build_state.clear_build_in_progress(cache.get_conn())
+            cache.close()
+
+        assert result["verdict"] == "WARN"
+        assert result["index_rebuilding"] is True
+        assert result["data_source"] == "cache_rebuilding"
+        assert "caller_count" not in result
+        assert "callers" not in result
+        assert "--full-index" not in result["next_step"]
+        assert result["agent_summary"]["verdict"] == "WARN"
+
+    @pytest.mark.asyncio
+    async def test_callees_rebuild_marker_warns_without_phantom_count(
+        self, tmp_path
+    ) -> None:
+        (tmp_path / "sample.py").write_text(
+            "def foo():\n    bar()\n\ndef bar():\n    return 1\n",
+            encoding="utf-8",
+        )
+        cache = ASTCache(str(tmp_path))
+        try:
+            cache.index_project(workers=0)
+            build_state.mark_build_in_progress(cache.get_conn())
+
+            tool = CodeGraphCalleesTool(str(tmp_path))
+            result = await tool.execute(
+                {"function_name": "foo", "output_format": "json"}
+            )
+        finally:
+            build_state.clear_build_in_progress(cache.get_conn())
+            cache.close()
+
+        assert result["verdict"] == "WARN"
+        assert result["index_rebuilding"] is True
+        assert result["data_source"] == "cache_rebuilding"
+        assert "callee_count" not in result
+        assert "callees" not in result
+        assert "--full-index" not in result["next_step"]
+        assert result["agent_summary"]["verdict"] == "WARN"
 
     @pytest.mark.asyncio
     async def test_callers_non_empty_index_no_spurious_hint(

--- a/tests/unit/test_codegraph_class_hierarchy_tool.py
+++ b/tests/unit/test_codegraph_class_hierarchy_tool.py
@@ -6,6 +6,7 @@ import json
 
 import pytest
 
+from tree_sitter_analyzer import _ast_cache_build_state as build_state
 from tree_sitter_analyzer.ast_cache import ASTCache
 from tree_sitter_analyzer.class_hierarchy import ClassHierarchy
 from tree_sitter_analyzer.graph import edge_store as edge_store_module
@@ -216,6 +217,36 @@ class TestExecute:
             }
         )
         assert result["verdict"] == "NOT_FOUND"
+
+    async def test_rebuild_marker_warns_without_phantom_subclass_count(self, tmp_path):
+        sample = tmp_path / "models.py"
+        sample.write_text(
+            "class Animal:\n    pass\n\nclass Dog(Animal):\n    pass\n",
+            encoding="utf-8",
+        )
+        cache = ASTCache(str(tmp_path))
+        try:
+            cache.index_project(workers=0)
+            build_state.mark_build_in_progress(cache.get_conn())
+
+            tool = ClassHierarchyTool(str(tmp_path))
+            result = await tool.execute(
+                {
+                    "mode": "subclasses",
+                    "class_name": "Animal",
+                    "output_format": "json",
+                }
+            )
+        finally:
+            build_state.clear_build_in_progress(cache.get_conn())
+            cache.close()
+
+        assert result["verdict"] == "WARN"
+        assert result["index_rebuilding"] is True
+        assert "subclass_count" not in result
+        assert "subclasses" not in result
+        assert "--full-index" not in result["next_step"]
+        assert result["agent_summary"]["verdict"] == "WARN"
 
     async def test_superclasses_root_class_is_info(self, tool, monkeypatch):
         """Review issue 1: a root class with no parents exists → INFO, not

--- a/tree_sitter_analyzer/mcp/tools/callees_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/callees_tool.py
@@ -20,6 +20,10 @@ from .codegraph_relation_tool import (
     _is_stale_resolution,
     classify_callee_resolution,
 )
+from .index_rebuild_signal import (
+    is_index_rebuilding,
+    rebuild_in_progress_next_step,
+)
 
 logger = setup_logger(__name__)
 
@@ -107,6 +111,24 @@ class CodeGraphCalleesTool(CodeGraphRelationToolMixin, BaseMCPTool):
         output_format = arguments.get("output_format", "toon")
         include_activation = bool(arguments.get("include_activation", False))
         listed_cap = int(arguments.get("limit", 50))
+
+        if is_index_rebuilding(self.project_root):
+            rebuild_next_step = rebuild_in_progress_next_step()
+            result = build_response(
+                verdict="WARN",
+                data_source="cache_rebuilding",
+                function=func_name,
+                index_rebuilding=True,
+                next_step=rebuild_next_step,
+                agent_summary={
+                    "summary_line": f"callees: {func_name!r} unavailable during full rebuild",
+                    "verdict": "WARN",
+                    "next_step": rebuild_next_step,
+                },
+            )
+            from ..utils.format_helper import apply_toon_format_to_response
+
+            return apply_toon_format_to_response(result, output_format)
 
         cache = self._try_get_cache()
         call_graph_indexed = cache is not None and cache.has_call_edges()

--- a/tree_sitter_analyzer/mcp/tools/callers_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/callers_tool.py
@@ -20,6 +20,10 @@ from .codegraph_relation_tool import (
     _is_stale_resolution,
     classify_callee_resolution,
 )
+from .index_rebuild_signal import (
+    is_index_rebuilding,
+    rebuild_in_progress_next_step,
+)
 
 logger = setup_logger(__name__)
 
@@ -107,6 +111,24 @@ class CodeGraphCallersTool(CodeGraphRelationToolMixin, BaseMCPTool):
         output_format = arguments.get("output_format", "toon")
         include_activation = bool(arguments.get("include_activation", False))
         listed_cap = int(arguments.get("limit", 50))
+
+        if is_index_rebuilding(self.project_root):
+            rebuild_next_step = rebuild_in_progress_next_step()
+            result = build_response(
+                verdict="WARN",
+                data_source="cache_rebuilding",
+                function=func_name,
+                index_rebuilding=True,
+                next_step=rebuild_next_step,
+                agent_summary={
+                    "summary_line": f"callers: {func_name!r} unavailable during full rebuild",
+                    "verdict": "WARN",
+                    "next_step": rebuild_next_step,
+                },
+            )
+            from ..utils.format_helper import apply_toon_format_to_response
+
+            return apply_toon_format_to_response(result, output_format)
 
         # Detect "ClassName.method_name" qualified lookup.  The SQL fast-path
         # stores bare callee names and can't filter by receiver class, so we

--- a/tree_sitter_analyzer/mcp/tools/class_hierarchy_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/class_hierarchy_tool.py
@@ -19,6 +19,10 @@ from ...ast_cache import ASTCache
 from ...class_hierarchy import ClassHierarchy
 from ...utils import setup_logger
 from .base_tool import BaseMCPTool
+from .index_rebuild_signal import (
+    is_index_rebuilding,
+    rebuild_in_progress_next_step,
+)
 
 logger = setup_logger(__name__)
 
@@ -139,6 +143,27 @@ class ClassHierarchyTool(BaseMCPTool):
         class_name = arguments.get("class_name", "")
         max_depth = arguments.get("max_depth", 10)
         output_format = arguments.get("output_format", "toon")
+
+        if is_index_rebuilding(self.project_root):
+            rebuild_next_step = rebuild_in_progress_next_step()
+            rebuild_response = {
+                "success": True,
+                "mode": mode,
+                "class_name": class_name,
+                "verdict": "WARN",
+                "index_rebuilding": True,
+                "next_step": rebuild_next_step,
+                "agent_summary": {
+                    "summary_line": (
+                        f"class_hierarchy: {mode} unavailable during full rebuild"
+                    ),
+                    "verdict": "WARN",
+                    "next_step": rebuild_next_step,
+                },
+            }
+            from ..utils.format_helper import apply_toon_format_to_response
+
+            return apply_toon_format_to_response(rebuild_response, output_format)
 
         hierarchy = self._get_hierarchy()
         hierarchy.build()

--- a/tree_sitter_analyzer/mcp/tools/codegraph_status_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_status_tool.py
@@ -10,7 +10,6 @@ it is, and where to look. Replaces 3-4 separate tool calls.
 from __future__ import annotations
 
 import os
-import sqlite3
 from typing import Any
 
 from ...utils import setup_logger
@@ -18,6 +17,7 @@ from ..utils.auto_index_guard import is_indexed
 from ..utils.format_helper import apply_toon_format_to_response
 from ._response_builder import build_response
 from .base_tool import BaseMCPTool
+from .index_rebuild_signal import is_index_rebuilding
 
 logger = setup_logger(__name__)
 
@@ -254,21 +254,7 @@ class CodeGraphStatusTool(BaseMCPTool):
             db_path
         ):  # pragma: no cover — caller gates on cache_exists
             return False
-        try:
-            from ..._ast_cache_build_state import build_in_progress
-
-            conn = sqlite3.connect(db_path, timeout=2)
-            try:
-                return bool(build_in_progress(conn))
-            finally:
-                conn.close()
-        except Exception:
-            # Degrade *open* (assume not rebuilding): a 2 s SELECT timeout under
-            # the very write contention that makes rebuilds slow would land
-            # here, so the WARN is best-effort, not a guarantee. Better to miss
-            # a warning than to wedge status behind a slow lock.
-            logger.debug("rebuilding check failed", exc_info=True)
-            return False
+        return is_index_rebuilding(self.project_root)
 
     def _safe_get_stats(self) -> dict[str, Any] | None:
         # Always close the SQLite handle — this tool is read-only and

--- a/tree_sitter_analyzer/mcp/tools/index_rebuild_signal.py
+++ b/tree_sitter_analyzer/mcp/tools/index_rebuild_signal.py
@@ -1,0 +1,37 @@
+"""Shared read-side signal for AST cache full rebuild windows (#578)."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+
+
+def is_index_rebuilding(project_root: str | None) -> bool:
+    """Return True when a full AST-cache rebuild marker is active.
+
+    Best-effort and deliberately fail-open. A slow/locked marker read must not
+    block navigation tools; missing the warning is preferable to turning every
+    read into a lock-contention failure.
+    """
+    if not project_root:
+        return False
+    db_path = os.path.join(project_root, ".ast-cache", "index.db")
+    if not os.path.exists(db_path):
+        return False
+    try:
+        from ..._ast_cache_build_state import build_in_progress
+
+        conn = sqlite3.connect(db_path, timeout=2)
+        try:
+            return bool(build_in_progress(conn))
+        finally:
+            conn.close()
+    except Exception:
+        return False
+
+
+def rebuild_in_progress_next_step() -> str:
+    return (
+        "Full rebuild in progress — cached graph rows are transiently empty or "
+        "partial. Do NOT start another index; retry this read shortly."
+    )


### PR DESCRIPTION
## Summary
Closes #578 by extending the rebuild-in-progress signal from `codegraph_status` to the reader paths that previously returned phantom-empty data during a forced full-index rebuild.

## Root Cause
#723 persisted a cross-process rebuild marker and taught `codegraph_status` to warn, but graph readers still consulted the half-rebuilt cache. During the DELETE + bounded reinsert window they could return normal `NOT_FOUND` or partial class counts, which agents interpret as truth.

## Changes
- Add a shared `index_rebuild_signal` helper for best-effort marker reads.
- Short-circuit `codegraph_callers`, `codegraph_callees`, and `codegraph_class_hierarchy` when the marker is active.
- Return `verdict: WARN`, `index_rebuilding: true`, and `data_source: cache_rebuilding` for caller/callee reads instead of phantom 0-count results.
- Avoid returning `caller_count`, `callee_count`, `subclass_count`, or empty result lists on the rebuild warning path.
- Reuse the helper from `codegraph_status` so marker semantics stay centralized.
- Add regression coverage for callers, callees, and class hierarchy rebuild windows.

## Validation
- `uv run pytest tests/unit/test_callers_callees_tools.py tests/unit/test_codegraph_callees_tool.py tests/unit/test_codegraph_class_hierarchy_tool.py tests/unit/test_codegraph_status_tool.py -q` -> 100 passed
- `uv run pytest tests/unit/test_callers_callees_tools.py tests/unit/test_codegraph_callees_tool.py tests/unit/test_codegraph_class_hierarchy_tool.py tests/unit/test_codegraph_status_tool.py --cov=tree_sitter_analyzer --cov-report=json -q` -> 100 passed
- `uv run python scripts/check_patch_coverage.py --base origin/develop --coverage-json coverage.json` -> passed
- `uv run ruff check ...` -> passed
- `uv run mypy ...` -> passed
- `git diff --check` -> passed
- `uv run pytest -q` on clean tree -> 20204 passed, 89 skipped, 8 xfailed, 3 rerun, 1 unrelated startup-budget flake (`test_repeated_headless_initialize_stays_under_budget`, one sample 2.111s > 2.0s)
- isolated rerun of that startup-budget test -> passed