### PR TITLE
fix(parse): surface outline parse and encoding signals (#707)

### DIFF
--- a/tests/unit/cli/test_outline_cli.py
+++ b/tests/unit/cli/test_outline_cli.py
@@ -284,6 +284,28 @@ class TestOutlineDispatch:
 class TestOutlineMcpCliParity:
     """CLI path and MCP GetCodeOutlineTool.execute must agree on core schema keys."""
 
+    @staticmethod
+    def _run_cli_outline(target: Path, project_root: Path) -> dict:
+        from tree_sitter_analyzer.cli.special_commands import _handle_outline
+
+        cli_result_holder: list = []
+        ctx = _make_context(
+            asyncio_run=asyncio.run,
+            output_json=lambda d: cli_result_holder.append(d),
+        )
+        args = SimpleNamespace(
+            outline=str(target),
+            outline_listed_cap=50,
+            project_root=str(project_root),
+            format="json",
+            output_format="json",
+            quiet=False,
+        )
+        rc = _handle_outline(args, ctx)
+        assert rc == 0
+        assert len(cli_result_holder) == 1
+        return cli_result_holder[0]
+
     def test_core_schema_keys_match_mcp_output(self, tmp_path: Path) -> None:
         """CLI JSON output contains the same core keys as MCP execute response."""
         from tree_sitter_analyzer.mcp.tools.get_code_outline_tool import (
@@ -361,6 +383,64 @@ class TestOutlineMcpCliParity:
             assert "methods" in cls
             assert "extends" in cls
             assert "implements" in cls
+
+    def test_parse_error_signal_keys_match_mcp_output(self, tmp_path: Path) -> None:
+        """#707: CLI must preserve outline parse-error signals from MCP."""
+        from tree_sitter_analyzer.mcp.tools.get_code_outline_tool import (
+            GetCodeOutlineTool,
+        )
+
+        target = tmp_path / "evil.py"
+        target.write_text("class Foo { public: int x; void bar() {} };\n")
+
+        tool = GetCodeOutlineTool(project_root=str(tmp_path))
+        mcp_result = asyncio.run(
+            tool.execute({"file_path": str(target), "output_format": "json"})
+        )
+        cli_result = self._run_cli_outline(target, tmp_path)
+
+        signal_keys = ("verdict", "parse_errors", "encoding_warning")
+        mcp_signals = {key: mcp_result.get(key) for key in signal_keys}
+        cli_signals = {key: cli_result.get(key) for key in signal_keys}
+        assert mcp_signals == {
+            "verdict": "WARN",
+            "parse_errors": True,
+            "encoding_warning": None,
+        }
+        assert cli_signals == mcp_signals
+
+    def test_encoding_signal_keys_match_mcp_output(self, tmp_path: Path) -> None:
+        """#707: CLI must preserve non-UTF8 outline signals from MCP."""
+        from tree_sitter_analyzer.mcp.tools.get_code_outline_tool import (
+            GetCodeOutlineTool,
+        )
+
+        target = tmp_path / "latin1.py"
+        target.write_bytes("def café():\n    return 'ok'\n".encode("cp1252"))
+
+        tool = GetCodeOutlineTool(project_root=str(tmp_path))
+        mcp_result = asyncio.run(
+            tool.execute({"file_path": str(target), "output_format": "json"})
+        )
+        cli_result = self._run_cli_outline(target, tmp_path)
+
+        signal_keys = (
+            "verdict",
+            "encoding_warning",
+            "encoding_warnings",
+            "non_utf8_bytes",
+            "null_bytes",
+        )
+        mcp_signals = {key: mcp_result.get(key) for key in signal_keys}
+        cli_signals = {key: cli_result.get(key) for key in signal_keys}
+        assert mcp_signals == {
+            "verdict": "WARN",
+            "encoding_warning": True,
+            "encoding_warnings": ["non_utf8_bytes"],
+            "non_utf8_bytes": True,
+            "null_bytes": None,
+        }
+        assert cli_signals == mcp_signals
 
 
 class TestBareOutlineValidation(TestOutlineDispatch):

--- a/tests/unit/mcp/test_parse_validity_diagnostics.py
+++ b/tests/unit/mcp/test_parse_validity_diagnostics.py
@@ -1,0 +1,83 @@
+"""Focused tests for parse/encoding diagnostics used by outline tools."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tree_sitter_analyzer.mcp.tools.get_code_outline_tool import GetCodeOutlineTool
+from tree_sitter_analyzer.mcp.tools.utils import parse_validity
+
+
+def test_file_byte_diagnostics_ignores_missing_and_empty_files(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.py"
+    empty = tmp_path / "empty.py"
+    empty.write_bytes(b"")
+
+    assert parse_validity._file_byte_diagnostics(str(missing)) == {}
+    assert parse_validity._file_byte_diagnostics(str(empty)) == {}
+
+
+def test_file_byte_diagnostics_degrades_on_read_error(
+    tmp_path: Path, monkeypatch
+) -> None:
+    target = tmp_path / "unreadable.py"
+    target.write_text("def ok():\n    return 1\n", encoding="utf-8")
+
+    def _raise_os_error(self: Path) -> bytes:
+        raise OSError("cannot read")
+
+    monkeypatch.setattr(Path, "read_bytes", _raise_os_error)
+
+    assert parse_validity._file_byte_diagnostics(str(target)) == {}
+
+
+def test_file_byte_diagnostics_reports_decode_replacement(
+    tmp_path: Path, monkeypatch
+) -> None:
+    target = tmp_path / "bad.py"
+    target.write_bytes(b"\xff")
+    monkeypatch.setattr(
+        parse_validity.EncodingManager,
+        "detect_encoding",
+        lambda raw, path: "bad-codec",
+    )
+    monkeypatch.setattr(
+        parse_validity.EncodingManager,
+        "safe_decode",
+        lambda raw, encoding: "replacement \ufffd",
+    )
+
+    assert parse_validity._file_byte_diagnostics(str(target)) == {
+        "non_utf8_bytes": True,
+        "decode_replacement": True,
+        "encoding_warning": True,
+        "encoding_warnings": ["non_utf8_bytes", "decode_replacement"],
+        "detected_encoding": "bad-codec",
+    }
+
+
+def test_decode_replacement_falls_back_when_safe_decode_raises(monkeypatch) -> None:
+    def _raise_decode_error(raw: bytes, encoding: str) -> str:
+        raise RuntimeError("decoder failed")
+
+    monkeypatch.setattr(
+        parse_validity.EncodingManager,
+        "safe_decode",
+        _raise_decode_error,
+    )
+
+    assert parse_validity._decode_replacement_used(b"\xff", "bad-codec") is True
+
+
+def test_attach_input_diagnostics_tolerates_non_dict_agent_summary(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "latin1.py"
+    target.write_bytes("def café():\n    return 'ok'\n".encode("cp1252"))
+    result = {"language": "python", "agent_summary": "not-a-dict"}
+
+    GetCodeOutlineTool._attach_input_diagnostics(result, str(target))
+
+    assert result["verdict"] == "WARN"
+    assert result["encoding_warning"] is True
+    assert result["agent_summary"] == "not-a-dict"

--- a/tests/unit/mcp/test_tools/test_get_code_outline_tool.py
+++ b/tests/unit/mcp/test_tools/test_get_code_outline_tool.py
@@ -806,6 +806,49 @@ class TestGetCodeOutlineToolExecute:
         assert "fields" in response["outline"]["classes"][0]
         assert response["outline"]["classes"][0]["fields"][0]["name"] == "count"
 
+    @pytest.mark.asyncio
+    async def test_wrong_language_file_flags_parse_errors(self, tmp_path):
+        """#707: outline must not return phantom symbols as a clean INFO."""
+        target = tmp_path / "evil.py"
+        target.write_text("class Foo { public: int x; void bar() {} };\n")
+
+        tool = GetCodeOutlineTool(project_root=str(tmp_path))
+        result = await tool.execute({"file_path": "evil.py", "output_format": "json"})
+
+        assert result["parse_errors"] is True
+        assert result["verdict"] == "WARN"
+        assert result["agent_summary"]["verdict"] == "WARN"
+
+    @pytest.mark.asyncio
+    async def test_non_utf8_file_flags_encoding_warning(self, tmp_path):
+        """#707: non-UTF8 source must carry an explicit encoding signal."""
+        target = tmp_path / "latin1.py"
+        target.write_bytes("def café():\n    return 'ok'\n".encode("cp1252"))
+
+        tool = GetCodeOutlineTool(project_root=str(tmp_path))
+        result = await tool.execute({"file_path": "latin1.py", "output_format": "json"})
+
+        assert result["encoding_warning"] is True
+        assert result["non_utf8_bytes"] is True
+        assert result["encoding_warnings"] == ["non_utf8_bytes"]
+        assert result["verdict"] == "WARN"
+        assert result["agent_summary"]["verdict"] == "WARN"
+
+    @pytest.mark.asyncio
+    async def test_null_byte_file_flags_encoding_warning(self, tmp_path):
+        """#707: raw NUL bytes affect line spans, so outline must warn."""
+        target = tmp_path / "nul.py"
+        target.write_bytes(b"def outer():\n    value = 1\x00\n    return value\n")
+
+        tool = GetCodeOutlineTool(project_root=str(tmp_path))
+        result = await tool.execute({"file_path": "nul.py", "output_format": "json"})
+
+        assert result["encoding_warning"] is True
+        assert result["null_bytes"] is True
+        assert result["encoding_warnings"] == ["null_bytes"]
+        assert result["verdict"] == "WARN"
+        assert result["agent_summary"]["verdict"] == "WARN"
+
 
 # ---------------------------------------------------------------------------
 # 工具定义测试

--- a/tree_sitter_analyzer/mcp/tools/get_code_outline_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/get_code_outline_tool.py
@@ -53,6 +53,26 @@ DEFAULT_OUTLINE_CLASSES_CAP: int = 50
 DEFAULT_OUTLINE_FUNCTIONS_CAP: int = 50
 
 
+def _outline_diagnostics_next_step(diagnostics: dict[str, Any]) -> str:
+    """Return the next action for parse/encoding diagnostic warnings."""
+    if diagnostics.get("parse_errors"):
+        return (
+            "Parse errors detected — outline symbols may be phantom "
+            "(wrong language for the file extension, or corrupt source). "
+            "Verify the file's language before trusting this outline."
+        )
+    warnings = diagnostics.get("encoding_warnings") or []
+    if "null_bytes" in warnings:
+        return (
+            "Raw NUL bytes detected — line spans may be unreliable. "
+            "Inspect or clean the source bytes before trusting this outline."
+        )
+    return (
+        "Non-UTF8 or replacement-decoded source detected — verify the file "
+        "encoding before trusting names and line spans from this outline."
+    )
+
+
 class GetCodeOutlineTool(BaseMCPTool):
     """
     MCP Tool: get_code_outline
@@ -332,6 +352,7 @@ class GetCodeOutlineTool(BaseMCPTool):
                 file_path, resolved["language"], outline, listed_cap=listed_cap
             )
             self._attach_outline_summary(result, file_path)
+            self._attach_input_diagnostics(result, resolved["resolved_path"])
             return apply_toon_format_to_response(result, output_format)
 
         except Exception as e:
@@ -582,6 +603,21 @@ class GetCodeOutlineTool(BaseMCPTool):
             "next_step": next_step,
             "verdict": "INFO",
         }
+
+    @staticmethod
+    def _attach_input_diagnostics(result: dict[str, Any], resolved_path: str) -> None:
+        """Attach parse/encoding warnings to a successful outline response."""
+        from .utils.parse_validity import file_input_diagnostics
+
+        diagnostics = file_input_diagnostics(resolved_path, result.get("language"))
+        if not diagnostics:
+            return
+        result.update(diagnostics)
+        result["verdict"] = "WARN"
+        agent_summary = result.get("agent_summary")
+        if isinstance(agent_summary, dict):
+            agent_summary["verdict"] = "WARN"
+            agent_summary["next_step"] = _outline_diagnostics_next_step(diagnostics)
 
     def get_tool_definition(self) -> dict[str, Any]:
         """返回 MCP tool 定义。"""

--- a/tree_sitter_analyzer/mcp/tools/utils/parse_validity.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/parse_validity.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from ....encoding_utils import EncodingManager
+
 # N9 (round-28 dogfood): null bytes inside Python (and other) string
 # literals are perfectly legal source — ``x = "\x00"`` compiles and runs.
 # Tree-sitter, however, treats the raw 0x00 byte as a tokenizer error
@@ -159,6 +161,82 @@ def is_file_parse_broken(file_path: str, language: str | None = None) -> bool:
     return True
 
 
+def file_input_diagnostics(
+    file_path: str,
+    language: str | None = None,
+) -> dict[str, Any]:
+    """Return parse/encoding signals for symbol-returning tools.
+
+    ``is_file_parse_broken`` deliberately suppresses raw-NUL false positives
+    when replacing NUL bytes with spaces yields a clean parse. That is correct
+    for the strict ``syntax_error`` gate, but outline-style navigation still
+    needs to warn: raw NUL bytes and non-UTF8 fallback decoding can shift symbol
+    spans or names while still producing a superficially successful outline.
+    """
+    diagnostics: dict[str, Any] = {}
+    byte_diagnostics = _file_byte_diagnostics(file_path)
+    diagnostics.update(byte_diagnostics)
+    if is_file_parse_broken(file_path, language):
+        diagnostics["parse_errors"] = True
+    return diagnostics
+
+
+def _file_byte_diagnostics(file_path: str) -> dict[str, Any]:
+    path = Path(file_path)
+    if not path.is_file():
+        return {}
+    try:
+        raw_bytes = path.read_bytes()
+    except OSError:
+        return {}
+    if not raw_bytes:
+        return {}
+
+    detected_encoding = EncodingManager.detect_encoding(raw_bytes, str(path))
+    warnings: list[str] = []
+    diagnostics: dict[str, Any] = {}
+
+    if not _is_utf8_decodable(raw_bytes):
+        warnings.append("non_utf8_bytes")
+        diagnostics["non_utf8_bytes"] = True
+
+    if _decode_replacement_used(raw_bytes, detected_encoding):
+        warnings.append("decode_replacement")
+        diagnostics["decode_replacement"] = True
+
+    if b"\x00" in raw_bytes:
+        warnings.append("null_bytes")
+        diagnostics["null_bytes"] = True
+
+    if not warnings:
+        return {}
+    diagnostics["encoding_warning"] = True
+    diagnostics["encoding_warnings"] = warnings
+    diagnostics["detected_encoding"] = detected_encoding
+    return diagnostics
+
+
+def _is_utf8_decodable(raw_bytes: bytes) -> bool:
+    try:
+        raw_bytes.decode("utf-8")
+    except UnicodeDecodeError:
+        return False
+    return True
+
+
+def _decode_replacement_used(raw_bytes: bytes, detected_encoding: str) -> bool:
+    try:
+        raw_bytes.decode(detected_encoding)
+        return False
+    except (LookupError, UnicodeDecodeError):
+        pass
+    try:
+        decoded = EncodingManager.safe_decode(raw_bytes, detected_encoding)
+    except Exception:
+        decoded = raw_bytes.decode("utf-8", errors="replace")
+    return "\ufffd" in decoded
+
+
 def _is_null_byte_false_positive(file_path: str, language: str) -> bool:
     """Return ``True`` when ``file_path``'s ``has_error`` is caused only
     by raw 0x00 bytes — not by an actual syntax error.
@@ -248,6 +326,7 @@ def syntax_error_envelope(
 
 
 __all__ = [
+    "file_input_diagnostics",
     "is_parse_broken",
     "is_file_parse_broken",
     "syntax_error_envelope",


### PR DESCRIPTION
## Summary
Closes #707 by extending parse/encoding honesty to `get_code_outline`, so outline-style symbol navigation no longer returns a clean `INFO` result for broken or byte-suspicious files.

## Root Cause
`analyze_code_structure` already used shared parse-validity checks, but `get_code_outline` had its own success path. A wrong-language file such as C++ source saved as `.py` could produce phantom outline symbols without `parse_errors` or a warning verdict. Non-UTF8 bytes and raw NUL bytes also had no explicit signal on outline responses.

## Changes
- Add shared `file_input_diagnostics()` in `parse_validity` for symbol-returning tools.
- Attach diagnostics to successful `get_code_outline` responses and downgrade the envelope to `WARN` when needed.
- Surface `parse_errors`, `encoding_warning`, `encoding_warnings`, `non_utf8_bytes`, `decode_replacement`, `null_bytes`, and `detected_encoding` where applicable.
- Add MCP coverage for wrong-language, non-UTF8, and raw-NUL outline paths.
- Add CLI↔MCP parity coverage so `--outline` preserves the same signal fields.

## Validation
- RED first: new #707 tests failed on missing `parse_errors` / `encoding_warning` fields before implementation.
- `nice -n 15 uv run pytest tests/unit/cli/test_outline_cli.py tests/unit/mcp/test_tools/test_get_code_outline_tool.py tests/unit/mcp/test_tools/test_get_code_outline_tool_toon.py -n 2 -q` -> 82 passed
- `uv run pytest tests/unit/cli/test_outline_cli.py tests/unit/mcp/test_tools/test_get_code_outline_tool.py tests/unit/mcp/test_tools/test_get_code_outline_tool_toon.py tests/unit/mcp/test_analyze_code_structure_tool_core.py --cov=tree_sitter_analyzer --cov-report=json -q` -> 112 passed
- `uv run python scripts/check_patch_coverage.py --base origin/develop --coverage-json coverage.json` -> passed
- `uv run ruff check ...` -> passed
- `uv run mypy ...` -> passed
- `git diff --check` -> passed

Note: I did not rerun the local full suite after the user's machine-impact feedback. An earlier full-suite attempt in this fresh worktree failed on unrelated environment/perf issues, including missing optional `tree_sitter_swift`; this PR relies on focused local gates plus GitHub CI for broad validation.