### PR TITLE
fix(mcp): smart_context applies the syntax gate — no grade=A/SAFE on unparseable files (#754)

### DIFF
--- a/tests/unit/mcp/test_smart_context_tool.py
+++ b/tests/unit/mcp/test_smart_context_tool.py
@@ -149,6 +149,37 @@ class TestSmartContextTool:
         assert "health" in result
 
 
+class TestSmartContextSyntaxGate:
+    """#754: smart_context blended file_health + risk but bypassed the shared
+    syntax gate (it called HealthScorer.score_file directly), so a file that
+    fails to parse scored grade=A / verdict=SAFE — a false green telling an agent
+    it was safe to edit unparseable code. It must short-circuit to the canonical
+    syntax_error envelope like the sibling detection tools.
+    """
+
+    def test_parse_broken_file_is_error_not_safe(self, tool, tmp_path):
+        bad = tmp_path / "broken.py"
+        bad.write_text("def broken(:\n    x =\nclass  :\n")
+        result = _run(tool.execute({"file_path": "broken.py", "output_format": "json"}))
+        assert result.get("verdict") == "ERROR"
+        assert result.get("signal") == "syntax_error"
+        next_step = (result.get("agent_summary") or {}).get("next_step", "").lower()
+        assert "proceed" not in next_step
+        # Shape parity: the happy-path keys are preserved (degraded), so a
+        # consumer reading result["health"]["grade"] etc. does not KeyError.
+        assert result["health"]["grade"] == "N/A"
+        for key in ("exports", "structure", "dependencies", "tests", "language"):
+            assert key in result, key
+
+    def test_clean_file_is_not_gated(self, tool, tmp_path):
+        good = tmp_path / "clean.py"
+        good.write_text("def ok():\n    return 1\n")
+        result = _run(tool.execute({"file_path": "clean.py", "output_format": "json"}))
+        assert result.get("verdict") != "ERROR"
+        assert result.get("signal") != "syntax_error"
+        assert "health" in result
+
+
 class TestExportExtraction:
     def test_extracts_class(self):
         # models.py was decomposed into models/ package; use base.py as the canonical

--- a/tree_sitter_analyzer/mcp/tools/smart_context_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/smart_context_tool.py
@@ -25,6 +25,7 @@ from .utils.element_extractor import (
     get_all_exports,
     get_structure,
 )
+from .utils.parse_validity import is_file_parse_broken, syntax_error_envelope
 from .utils.test_discovery import find_test_files
 
 logger = setup_logger(__name__)
@@ -149,13 +150,28 @@ class SmartContextTool(BaseMCPTool):
         self.validate_arguments(arguments)
         file_path = arguments["file_path"]
         output_format = arguments.get("output_format", "toon")
+        from ..utils.format_helper import apply_toon_format_to_response
+
+        # #754: smart_context blends file_health + risk signals but called
+        # HealthScorer.score_file directly, bypassing the shared syntax gate the
+        # sibling detection tools (file_health / safe_to_edit / code_patterns)
+        # use. A file that fails to parse then scored grade=A / verdict=SAFE — a
+        # false green that tells an agent it is safe to edit unparseable code.
+        # Apply the same gate: short-circuit to the canonical syntax_error
+        # envelope before any misleading grade is computed.
+        resolved = self.resolve_and_validate_file_path(file_path)
+        language = detect_language_from_file(resolved)
+        if is_file_parse_broken(resolved, language):
+            result = _build_syntax_error_result(
+                resolved, language, self.project_root, output_format
+            )
+            return apply_toon_format_to_response(result, output_format)
+
         profile = self._build_profile(file_path)
         result = _build_smart_context_result(profile)
         # Echo the requested output_format so agents can audit envelope
         # parity across tools without consulting the call site.
         result["output_format"] = output_format
-        from ..utils.format_helper import apply_toon_format_to_response
-
         return apply_toon_format_to_response(result, output_format)
 
     # _build_profile: implementation
@@ -267,6 +283,59 @@ def _build_smart_context_result(profile: SmartContextProfile) -> dict[str, Any]:
             ),
         }
     )
+
+
+def _build_syntax_error_result(
+    resolved: str,
+    language: str | None,
+    project_root: str | None,
+    output_format: str,
+) -> dict[str, Any]:
+    """#754: syntax-error short-circuit that preserves the happy-path key shape.
+
+    Returns the canonical ``syntax_error_envelope`` (verdict=ERROR /
+    signal=syntax_error) but overlays smart_context's normal top-level keys with
+    degraded values (grade="N/A", empty exports/structure/deps/tests) so a
+    consumer that reads e.g. ``result["health"]["grade"]`` on a broken file does
+    not KeyError — mirroring how ``file_health`` degrades rather than dropping
+    fields.
+    """
+    rel = _to_relative(resolved, project_root or ".")
+    envelope = syntax_error_envelope(
+        rel, tool="smart_context", output_format=output_format
+    )
+    # is_file_parse_broken already read this file successfully, so a plain read
+    # here is safe — matches _build_profile's own un-guarded read.
+    line_count = len(
+        Path(resolved).read_text(encoding="utf-8", errors="replace").splitlines()
+    )
+    envelope.update(
+        {
+            "file_path": rel,
+            "line_count": line_count,
+            "language": language or "unknown",
+            "health": {
+                "grade": "N/A",
+                "score": 0.0,
+                "signal": "unparseable",
+                "weakest_dimension": "syntax",
+            },
+            "exports": [],
+            "structure": [],
+            "dependencies": {
+                "imports_count": 0,
+                "imported_by_count": 0,
+                "imports_sample": [],
+                "imported_by_sample": [],
+            },
+            "tests": [],
+            "edit_risk": "dangerous",
+            "recommendation": (
+                "File fails to parse — fix syntax before further analysis."
+            ),
+        }
+    )
+    return envelope
 
 
 # _build_agent_summary: implementation


### PR DESCRIPTION
Closes #754 (P1, edit-safety false-green family with #798/#780).

## Root cause
`smart_context` blends file_health + risk signals but calls `HealthScorer.score_file` **directly**, bypassing the shared syntax-validity gate that the sibling detection tools (`file_health` / `safe_to_edit` / `code_patterns`) already apply at their boundary. tree-sitter is permissive, so a file that fails to parse still yields a "clean" tree → `grade=A, score=100, verdict=SAFE, next_step="proceed with edit"`. That is a false green telling an agent it is safe to edit unparseable code.

## Fix (surgical, reuses existing infra)
Short-circuit `execute()` through the canonical `syntax_error_envelope` (verdict=ERROR, signal=syntax_error, "fix syntax before further analysis") via the existing `is_file_parse_broken` helper — before any grade is computed. Identical pattern to the sibling tools; clean files are unaffected.

## Verification
- Repro (RED): a syntax-error `.py` returned `grade=A / score=100 / verdict=SAFE`. After: `verdict=ERROR / signal=syntax_error`, no grade-A, no "proceed" advice; a clean file stays `SAFE`.
- New `TestSmartContextSyntaxGate` (broken→ERROR, clean→ungated). Logic verified directly (the shared local test guard was contended by a concurrent run; CI runs the full suite). ruff + mypy clean.
- Found by the parallel dogfood audit (round 3, #754); fixed by the QA arm joining the dev effort. Independent opencode review to follow.