### PR TITLE
fix(mcp): safe_to_edit summary_line carries the escalated verdict (#781)

### DIFF
--- a/tests/unit/mcp/tools/test_safe_to_edit_unsafe_verdict.py
+++ b/tests/unit/mcp/tools/test_safe_to_edit_unsafe_verdict.py
@@ -215,6 +215,42 @@ class TestSafeToEditConstraintIntegration:
             f"Got risk_factors: {risk_factors}"
         )
 
+    def test_summary_line_matches_escalated_verdict(self, tmp_path: Path) -> None:
+        """#781: an escalated verdict must reach the summary_line too.
+
+        Before the fix, a constraint escalation patched ``summary["verdict"]``
+        to UNSAFE but left ``summary_line`` built from the un-escalated base
+        verdict, so the one-line decision surface read verdict=CAUTION/SAFE
+        while the structured verdict said UNSAFE — a gating disagreement that
+        can let an unsafe edit slip through.
+        """
+        project = _scaffold_min_project(tmp_path)
+        _stage_dogfood_constraints(project)
+
+        db_path = project / ".ast-cache" / "index.db"
+        _init_violations_db(db_path)
+        _seed_violation(
+            db_path,
+            rule_id="mcp-no-cli",
+            caller_file=TARGET_FILE_REL,
+            severity="error",
+            caller_line=2,
+        )
+
+        tool = _make_safe_to_edit_tool(project)
+        result = _run(
+            tool.execute({"file_path": TARGET_FILE_REL, "output_format": "json"})
+        )
+
+        verdict = result["verdict"]
+        assert verdict == "UNSAFE", verdict
+        summary = result["agent_summary"]
+        assert summary["verdict"] == verdict
+        assert f"verdict={verdict}" in summary["summary_line"], summary["summary_line"]
+        # The mirrored top-level summary_line must be present and agree too.
+        assert "summary_line" in result, sorted(result)
+        assert f"verdict={verdict}" in result["summary_line"], result["summary_line"]
+
     def test_safe_to_edit_emits_CAUTION_on_warn_violation(self, tmp_path: Path) -> None:
         """Only warn-severity → CAUTION (not the legacy ``REVIEW``).
 

--- a/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
@@ -182,11 +182,9 @@ def _format_safe_to_edit_result(
     if fixture_fact.is_fixture:
         risk_factors.append(_fixture_risk_factor(fixture_fact, context.file_path))
     recommendation = _format_recommendation(risk, facts, workflow)
-    summary = build_agent_summary(workflow_context, workflow)
-    # Promote agent_summary.verdict when constraint violations escalate
-    # beyond the risk-level-derived verdict.
-    if verdict != base_verdict:
-        summary["verdict"] = verdict
+    # #781: pass the (possibly escalated) verdict so summary_line AND
+    # summary["verdict"] are both built from it — never a CAUTION/UNSAFE split.
+    summary = build_agent_summary(workflow_context, workflow, verdict_override=verdict)
     return {
         "success": True,
         "file_path": context.file_path,
@@ -317,6 +315,7 @@ def _format_recommendation(
 def build_agent_summary(
     context: AgentWorkflowContext,
     workflow: dict[str, Any],
+    verdict_override: str | None = None,
 ) -> dict[str, Any]:
     """Build the compact first-read decision summary for agents.
 
@@ -324,11 +323,20 @@ def build_agent_summary(
     cross-tool envelope contract (``TestEnvelopeContractSnapshot``) is
     satisfied. ``mirror_summary_line`` then copies the line to the
     top-level envelope for direct callers that bypass the dispatch hook.
+
+    #781: ``verdict_override`` lets the caller pass an escalated verdict (from a
+    constraint-violation or fixture promotion) so it flows into BOTH the
+    ``summary_line`` and ``summary["verdict"]`` — the one-line decision surface
+    must never disagree with the structured verdict.
     """
     before = workflow["before_edit_commands"]
     after = workflow["after_edit_commands"]
     boundary = workflow["queue_boundary_commands"]
-    verdict = _risk_to_verdict(context.risk)
+    # verdict_override is a floor-raiser (escalation), never a downgrade:
+    # _max_verdict keeps the more severe of the risk-derived base and the
+    # override (and tolerates a None override), so a future caller can't use it
+    # to silently lower the verdict below the risk level.
+    verdict = _max_verdict(_risk_to_verdict(context.risk), verdict_override)
     summary_line = (
         f"{context.file_path} risk={context.risk} verdict={verdict} "
         f"health={context.health_grade} "


### PR DESCRIPTION
Closes #781 (P2, edit-safety verdict-consistency).

## Root cause
When a constraint-violation/fixture escalation raised the verdict above the risk-derived base (CAUTION/SAFE → UNSAFE via `_max_verdict`), the caller patched `summary["verdict"]` but `build_agent_summary` had already baked the **un-escalated** base verdict into `summary_line`. So `agent_summary.summary_line` (and the mirrored top-level `summary_line`) read `verdict=CAUTION` while the structured `verdict` said `UNSAFE` — a one-line-vs-structured gating disagreement that can let an unsafe edit slip through.

## Fix (single source of truth)
`build_agent_summary` gains a `verdict_override` param so the final (possibly escalated) verdict flows into **both** `summary_line` and `summary["verdict"]`; the partial post-hoc patch is dropped. Non-escalated calls are unchanged (`override == base`).

## Verification
- Repro (RED): an error-severity violation escalates a low-risk file → `verdict=UNSAFE` but `summary_line` said `verdict=SAFE`. After: `summary_line` reads `verdict=UNSAFE`, matching `agent_summary.verdict` and the top-level verdict.
- New `test_summary_line_matches_escalated_verdict` (reuses the existing seed-violation scaffold). Verified end-to-end via the real tool; full suite in CI (local guard contended by a concurrent run). ruff + mypy clean.
- Found by the parallel dogfood audit (round 2, #781); fixed by the QA arm joining the dev effort. Independent opencode review to follow.

Note: the *reason* server.py escalates in the original repro is the phantom constraint violations of #780 — but this fix is orthogonal: after ANY escalation (real or not), summary_line must match the verdict.