### PR TITLE
fix(mcp): change_impact reconciles top-level verdict with agent_summary (#782)

### DIFF
--- a/tests/unit/test_change_impact_response.py
+++ b/tests/unit/test_change_impact_response.py
@@ -3,6 +3,7 @@
 from tree_sitter_analyzer.mcp.tools.utils.change_impact_response import (
     AgentSummaryContext,
     ChangeImpactResponseContext,
+    apply_scope_validation,
     attach_queue_ledger,
     build_agent_summary,
     build_agent_summary_only_response,
@@ -569,3 +570,86 @@ class TestBuildChangeImpactResponse:
         )
         response = build_change_impact_response(ctx)
         assert response["affected_files"] == []
+
+
+class TestVerdictReconciliation782:
+    """#782: top-level verdict and agent_summary.verdict must agree (more
+    severe wins) within one change-impact response — never INFO at one surface
+    while the other says REVIEW/UNSAFE.
+    """
+
+    def test_changed_files_lift_top_level_to_review(self):
+        # top=INFO (risk-derived) but changed_count>0 makes agent content-aware
+        # REVIEW; the top level must lift to REVIEW too.
+        result = {"verdict": "INFO", "changed_count": 20, "agent_summary": {}}
+        apply_scope_validation(result, [])
+        assert result["verdict"] == "REVIEW"
+        assert result["agent_summary"]["verdict"] == "REVIEW"
+
+    def test_constraint_escalation_is_not_downgraded(self):
+        # a constraint-escalated UNSAFE top level must survive and lift the
+        # agent_summary too (never downgrade to the content-aware REVIEW).
+        result = {
+            "verdict": "UNSAFE",
+            "changed_count": 5,
+            "agent_summary": {"verdict": "REVIEW"},
+        }
+        apply_scope_validation(result, [])
+        assert result["verdict"] == "UNSAFE"
+        assert result["agent_summary"]["verdict"] == "UNSAFE"
+
+    def test_no_changes_stays_benign_and_agrees(self):
+        result = {"verdict": "INFO", "changed_count": 0, "agent_summary": {}}
+        apply_scope_validation(result, [])
+        assert result["verdict"] == result["agent_summary"]["verdict"]
+
+    def test_reconcile_no_ops_when_a_verdict_is_missing(self):
+        # Early-return guard: a blank/missing verdict on either side must not
+        # crash and must leave the populated side intact (mirror fills the gap).
+        result = {"agent_summary": {}}
+        apply_scope_validation(result, [])  # no verdict either side → no-op
+        result2 = {"verdict": "REVIEW", "changed_count": 3, "agent_summary": {}}
+        # agent_summary gets REVIEW (changed>0); top already REVIEW → agree
+        apply_scope_validation(result2, [])
+        assert result2["verdict"] == result2["agent_summary"]["verdict"] == "REVIEW"
+
+    def test_compact_response_preserves_reconciled_verdict(self):
+        # The compact (agent_summary_only) path recomputes the top-level verdict
+        # from risk_level; it must NOT discard the reconciliation (#782 P1).
+        result = {
+            "verdict": "INFO",
+            "risk_level": "low",
+            "changed_count": 20,
+            "agent_summary": {},
+        }
+        apply_scope_validation(result, [])
+        compact = build_agent_summary_only_response(result)
+        assert compact["verdict"] == "REVIEW"
+        assert compact["agent_summary"]["verdict"] == "REVIEW"
+
+    def test_compact_response_keeps_constraint_unsafe(self):
+        result = {
+            "verdict": "UNSAFE",
+            "risk_level": "low",
+            "changed_count": 5,
+            "agent_summary": {"verdict": "REVIEW"},
+        }
+        apply_scope_validation(result, [])
+        compact = build_agent_summary_only_response(result)
+        assert compact["verdict"] == "UNSAFE"
+        assert compact["agent_summary"]["verdict"] == "UNSAFE"
+
+
+def test_verdict_severity_rank_matches_journal_rank():
+    """#782 drift guard: the locally-duplicated severity rank must stay
+    byte-identical to change_impact_tool._JOURNAL_VERDICT_RANK (duplicated only
+    to avoid a circular import).
+    """
+    from tree_sitter_analyzer.mcp.tools.change_impact_tool import (
+        _JOURNAL_VERDICT_RANK,
+    )
+    from tree_sitter_analyzer.mcp.tools.utils.change_impact_response import (
+        _VERDICT_SEVERITY,
+    )
+
+    assert _VERDICT_SEVERITY == _JOURNAL_VERDICT_RANK

--- a/tree_sitter_analyzer/mcp/tools/utils/change_impact_response.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/change_impact_response.py
@@ -51,6 +51,48 @@ CHANGE_IMPACT_VERDICT_CLEAN = "SAFE"
 CHANGE_IMPACT_VERDICT_REVIEW = "REVIEW"
 CHANGE_IMPACT_VERDICT_WARN = "WARN"
 
+# #782: the top-level ``verdict`` (risk-derived, possibly constraint-escalated)
+# and ``agent_summary["verdict"]`` (content-aware: SAFE/REVIEW/WARN) are computed
+# independently and could disagree (e.g. top=INFO while agent=REVIEW for a
+# changed_count>0 diff). ``mirror_summary_line`` only fills a *missing* verdict,
+# not a divergent one, so we reconcile them to the MORE SEVERE here. Kept in sync
+# with ``change_impact_tool._JOURNAL_VERDICT_RANK`` (duplicated to avoid a
+# circular import: that module imports this one).
+_VERDICT_SEVERITY: dict[str, int] = {
+    "SAFE": 0,
+    "INFO": 0,
+    "NOT_FOUND": 0,
+    "CAUTION": 1,
+    "REVIEW": 2,
+    "WARN": 3,
+    "ERROR": 4,
+    "UNSAFE": 5,
+}
+
+
+def _reconcile_envelope_verdict(
+    result: dict[str, Any], agent_summary: dict[str, Any]
+) -> None:
+    """Force top-level ``verdict`` and ``agent_summary["verdict"]`` to agree.
+
+    Picks the more severe of the two by :data:`_VERDICT_SEVERITY` (never a
+    downgrade — a constraint-escalated UNSAFE top-level survives, and a
+    content-aware REVIEW lifts a stale INFO top-level). Ties keep the top-level
+    value. No-ops when either side is missing — ``mirror_summary_line`` then
+    fills the gap as before.
+    """
+    top = result.get("verdict")
+    agent = agent_summary.get("verdict")
+    if not (isinstance(top, str) and top) or not (isinstance(agent, str) and agent):
+        return
+    final = (
+        agent
+        if _VERDICT_SEVERITY.get(agent, 0) > _VERDICT_SEVERITY.get(top, 0)
+        else top
+    )
+    result["verdict"] = final
+    agent_summary["verdict"] = final
+
 
 @dataclass(frozen=True)
 class AgentSummaryContext:
@@ -168,6 +210,11 @@ def build_agent_summary_only_response(result: dict[str, Any]) -> dict[str, Any]:
         value = result.get(key, summary.get(key))
         if value:
             response[key] = value
+    # #782: the compact builder recomputes the top-level verdict from risk_level
+    # above, which would discard the reconciliation apply_scope_validation did on
+    # the full result. Re-reconcile so the compact path — the surface gating
+    # agents read most — never ships top=INFO while agent_summary=REVIEW/UNSAFE.
+    _reconcile_envelope_verdict(response, summary)
     return response
 
 
@@ -499,6 +546,9 @@ def apply_scope_validation(
         )
         agent_summary.setdefault("verdict", default_verdict)
 
+    # #782: the top-level and agent_summary verdicts were computed by separate
+    # steps; force them to agree (more severe wins) before mirror_summary_line.
+    _reconcile_envelope_verdict(result, agent_summary)
     return result
 
 


### PR DESCRIPTION
Closes #782 (P2, edit-impact verdict-consistency).

## Root cause
The top-level `verdict` (risk-derived, possibly constraint-escalated) and `agent_summary["verdict"]` (content-aware: SAFE/REVIEW/WARN by `changed_count`) are computed by independent steps. `mirror_summary_line` only fills a **missing** verdict, not a divergent one — so a `changed_count>0` diff shipped top-level `verdict=INFO` while `agent_summary` said `REVIEW`. An agent gating on the top level sees "benign"; one gating on the decision surface sees "needs review" — for the identical call.

## Fix (scoped to change_impact)
Reconcile both to the **more severe** (by a verdict-severity rank) at the end of `apply_scope_validation`, which runs before `mirror_summary_line` in every change-impact path. Never downgrades: a constraint-escalated `UNSAFE` top level survives and lifts `agent_summary`; a content-aware `REVIEW` lifts a stale `INFO`. Ties keep the top-level value, so the `changed_count==0` benign case is unchanged.

Deliberately **not** changing the shared `base_tool.mirror_summary_line` (it has the same latent both-present-divergent gap, but that's high blast radius across every tool — a candidate follow-up). The rank is duplicated locally to avoid a circular import (`change_impact_tool` imports this module).

## Verification
- `TestVerdictReconciliation782`: changed>0 → both `REVIEW`; constraint `UNSAFE` not downgraded; changed==0 stays benign + agrees. Verified directly (3 scenarios); full suite in CI. ruff + mypy clean.
- Found by the parallel dogfood audit (round 2, #782). Independent opencode review to follow.