### PR TITLE
fix(csharp): populate receiver_type on all C# methods/properties/constructors

### DIFF
--- a/tests/unit/languages/test_csharp_plugin_elements.py
+++ b/tests/unit/languages/test_csharp_plugin_elements.py
@@ -525,6 +525,58 @@ class TestCSharpFunctionExtraction:
         # Method with if/for/while/switch should have higher complexity_score
         assert calculate.complexity_score >= 1
 
+    def test_methods_carry_parent_class(self):
+        """[TDD] #766 — every C# method/property/constructor must expose its owning
+        type via receiver_type so the table formatter can set parent_class.
+
+        Before the fix all members had receiver_type=None.
+        After the fix each member must carry the name of its enclosing class,
+        interface, or struct.
+        """
+        src = """\
+namespace MyApp
+{
+    public class User
+    {
+        public int Id { get; set; }
+        public User(int id) { Id = id; }
+        public void UpdateEmail(string email) { }
+    }
+
+    public interface IUserRepository
+    {
+        User GetById(int id);
+    }
+
+    public struct UserSettings
+    {
+        public bool IsActive { get; set; }
+        public UserSettings(bool active) { IsActive = active; }
+    }
+}
+"""
+        plugin = CSharpPlugin()
+        tree = get_tree_for_code(src, plugin)
+        functions = plugin.extractor.extract_functions(tree, src)
+
+        by_name = {f.name: f for f in functions}
+
+        assert by_name["Id"].receiver_type == "User"
+        assert by_name["UpdateEmail"].receiver_type == "User"
+        assert by_name["GetById"].receiver_type == "IUserRepository"
+        assert by_name["IsActive"].receiver_type == "UserSettings"
+
+        user_ctors = [f for f in functions if f.name == "User"]
+        assert len(user_ctors) == 1
+        assert user_ctors[0].receiver_type == "User"
+
+        us_ctors = [f for f in functions if f.name == "UserSettings"]
+        assert len(us_ctors) == 1
+        assert us_ctors[0].receiver_type == "UserSettings"
+
+        missing = [f.name for f in functions if f.receiver_type is None]
+        assert missing == [], f"These members are missing receiver_type: {missing}"
+
 
 class TestCSharpVariableExtraction:
     """Test C# variable/field extraction."""

--- a/tree_sitter_analyzer/languages/csharp_helpers.py
+++ b/tree_sitter_analyzer/languages/csharp_helpers.py
@@ -6,6 +6,34 @@ from typing import Any
 from ..models import Class, Function, Import, Variable
 from ..utils import log_error
 
+_OWNING_TYPE_NODES = frozenset(
+    {
+        "class_declaration",
+        "interface_declaration",
+        "struct_declaration",
+        "record_declaration",
+        "enum_declaration",
+    }
+)
+
+
+def find_owning_class_name(
+    node: Any,
+    get_node_text: Callable[..., str],
+) -> str | None:
+    """Walk up node.parent to find the enclosing class/interface/struct/record.
+
+    Returns the bare type name, or None when the member is at module scope.
+    """
+    parent = getattr(node, "parent", None)
+    while parent is not None:
+        if parent.type in _OWNING_TYPE_NODES:
+            name_node = parent.child_by_field_name("name")
+            if name_node:
+                return get_node_text(name_node)
+        parent = getattr(parent, "parent", None)
+    return None
+
 
 def determine_visibility(modifiers: list[str]) -> str:
     """Determine visibility from C# modifiers."""

--- a/tree_sitter_analyzer/languages/csharp_plugin.py
+++ b/tree_sitter_analyzer/languages/csharp_plugin.py
@@ -67,6 +67,9 @@ from .csharp_helpers import (
 from .csharp_helpers import (
     extract_using_directive as _extract_using_standalone,
 )
+from .csharp_helpers import (
+    find_owning_class_name as _find_owning_class_name,
+)
 
 
 def _traverse_nodes(root_node: tree_sitter.Node) -> Iterator[tree_sitter.Node]:
@@ -277,14 +280,23 @@ class CSharpElementExtractor(ElementExtractor):
             if node.type == "method_declaration":
                 func = self._extract_method(node)
                 if func:
+                    func.receiver_type = _find_owning_class_name(
+                        node, self._get_node_text_optimized
+                    )
                     functions.append(func)
             elif node.type == "constructor_declaration":
                 func = self._extract_constructor(node)
                 if func:
+                    func.receiver_type = _find_owning_class_name(
+                        node, self._get_node_text_optimized
+                    )
                     functions.append(func)
             elif node.type == "property_declaration":
                 func = self._extract_property(node)
                 if func:
+                    func.receiver_type = _find_owning_class_name(
+                        node, self._get_node_text_optimized
+                    )
                     functions.append(func)
 
         # Sort by start line for deterministic output


### PR DESCRIPTION
## Root cause

`CSharpElementExtractor.extract_functions()` did a flat AST traversal with `_traverse_iterative()` and never tracked which class/interface/struct/record each member node was nested inside. As a result, all three helper functions (`extract_method_declaration`, `extract_constructor_declaration`, `extract_property_declaration`) returned `Function` objects with `receiver_type=None`.

The `_convert_function_element()` in `table_command.py` maps `receiver_type → parent_class` in the output dict (line 370-372). So all 19 members of `examples/Sample.cs` had `parent_class=None` in every output format.

## Fix (3 files, 92 lines added)

**`tree_sitter_analyzer/languages/csharp_helpers.py`** — adds `find_owning_class_name(node, get_node_text)`: walks `node.parent` until it hits a `class_declaration` / `interface_declaration` / `struct_declaration` / `record_declaration` / `enum_declaration` node and returns its identifier text. Returns `None` at module scope (correct for top-level functions, which C# doesn't have but the extractor should be safe anyway).

**`tree_sitter_analyzer/languages/csharp_plugin.py`** — imports `find_owning_class_name` and calls it once per member (method, constructor, property) right after the helper returns the `Function` object, setting `func.receiver_type` before appending to the list.

**`tests/unit/languages/test_csharp_plugin_elements.py`** — adds `TestCSharpFunctionExtraction::test_methods_carry_parent_class`: exact-pin assertions for `User.Id`, `User.UpdateEmail`, `IUserRepository.GetById`, `UserSettings.IsActive`, both constructors (`User`, `UserSettings`), plus a zero-tolerance invariant (`missing == []`) so any future member that drops receiver_type causes a hard failure.

## Test plan

- [x] RED-first: new test failed before the fix (`receiver_type=None`)
- [x] GREEN after fix
- [x] All 250 existing C# tests passed
- [x] All 309 C# tests from `--change-impact` verification command passed
- [x] Golden master test `test_plugin_golden_master[csharp-Sample.cs]` passed (golden tracks counts/names only, not receiver_type — no golden update needed)
- [x] All pre-commit hooks passed (ruff, mypy, bandit, secrets)

## Follow-up (out of scope for this PR)

Issue #767 (C# namespace dropped from qualified names) is a separate bug and should be fixed in its own PR.

Closes #766