### PR TITLE
fix(sync): iterative _count_nodes + per-file RecursionError catch

### DIFF
--- a/tests/unit/test_ast_extraction.py
+++ b/tests/unit/test_ast_extraction.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock
 from tree_sitter_analyzer._ast_extraction import (
     _content_hash,
     _count_decision_points,
+    _count_nodes,
     _extract_call_edges,
     _extract_parent_classes,
     _has_fts5,
@@ -1426,3 +1427,46 @@ class TestCSharpErrorRegionHardening:
         src = "class A {\n  Action r = () => {\n    int leaked = 1;\n"
         syms = _symbols_for(src, "csharp")
         assert [s["name"] for s in syms if s["kind"] == "variable"] == []
+
+
+# ---------------------------------------------------------------------------
+# _count_nodes — iterative implementation (Issue #805)
+# ---------------------------------------------------------------------------
+
+
+class _FakeNode:
+    """Minimal stand-in for a tree-sitter Node."""
+
+    def __init__(self, children=None):
+        self.children = children or []
+
+
+class TestCountNodes:
+    def test_single_node_returns_1(self):
+        assert _count_nodes(_FakeNode()) == 1
+
+    def test_flat_children(self):
+        root = _FakeNode([_FakeNode(), _FakeNode(), _FakeNode()])
+        assert _count_nodes(root) == 4
+
+    def test_nested_tree(self):
+        #   root
+        #   ├── a
+        #   │   └── c
+        #   └── b
+        root = _FakeNode(
+            [
+                _FakeNode([_FakeNode()]),
+                _FakeNode(),
+            ]
+        )
+        assert _count_nodes(root) == 4
+
+    def test_deep_chain_does_not_raise(self):
+        """A chain 2000 levels deep must not raise RecursionError (issue #805)."""
+        # Build a chain: root → child → grandchild → … (2000 levels)
+        node = _FakeNode()
+        for _ in range(2000):
+            node = _FakeNode([node])
+        # Must not raise; exact count is 2001 (2000 wrappers + original leaf).
+        assert _count_nodes(node) == 2001

--- a/tests/unit/test_incremental_sync.py
+++ b/tests/unit/test_incremental_sync.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import time
+from unittest.mock import patch
 
 import pytest
 
@@ -203,3 +204,61 @@ class TestContentHashComparison:
         os.utime(str(main_py), times=None)
         result = sync.sync()
         assert result.updated_files == 0
+
+
+class TestRecursionErrorHandling:
+    """Issue #805: RecursionError from deeply-nested AST must not abort sync."""
+
+    def test_recursion_error_in_one_file_does_not_abort_sync(self, project, cache):
+        """A RecursionError in index_file must be caught per-file; sibling files
+        must still be indexed and the error count must equal exactly 1."""
+        src = project / "src"
+        # pathological.py triggers RecursionError; good.py must still be indexed.
+        (src / "pathological.py").write_text("x = 1\n")
+        (src / "good.py").write_text("def ok(): pass\n")
+
+        original_index_file = cache.index_file
+
+        def _boom_on_pathological(path, language=None):
+            if "pathological" in path:
+                raise RecursionError("maximum recursion depth exceeded")
+            return original_index_file(path, language)
+
+        sync = IncrementalSync(cache)
+        with patch.object(cache, "index_file", side_effect=_boom_on_pathological):
+            result = sync.sync()
+
+        # Exactly 1 file must have errored — not more, not less.
+        assert result.errors == 1
+        # The total new-file attempts includes all files; the pathological one
+        # is counted as an attempt but ends in error.
+        # good.py (+ the original 3 fixtures) must have been attempted and
+        # succeeded; the pathological file must appear in details as an error.
+        error_details = [d for d in result.details if d.get("status") == "error"]
+        assert len(error_details) == 1
+        assert "pathological" in error_details[0]["file"]
+        # The error detail must carry exception type and message (Issue #806).
+        assert "RecursionError" in error_details[0].get("error_type", "")
+        assert error_details[0].get("error_message") != ""
+
+    def test_recursion_error_detail_has_file_attribution(self, project, cache):
+        """Error envelope must contain file path (Issue #806 partial fix)."""
+        src = project / "src"
+        (src / "deep_nest.py").write_text("y = 2\n")
+
+        original_index_file = cache.index_file
+
+        def _boom(path, language=None):
+            if "deep_nest" in path:
+                raise RecursionError("max depth")
+            return original_index_file(path, language)
+
+        sync = IncrementalSync(cache)
+        with patch.object(cache, "index_file", side_effect=_boom):
+            result = sync.sync()
+
+        error_details = [d for d in result.details if d.get("status") == "error"]
+        assert len(error_details) == 1
+        detail = error_details[0]
+        assert "deep_nest" in detail["file"]
+        assert detail.get("error_type") == "RecursionError"

--- a/tree_sitter_analyzer/_ast_extraction.py
+++ b/tree_sitter_analyzer/_ast_extraction.py
@@ -653,9 +653,14 @@ def _node_text(node: Any, source: str) -> str:
 
 
 def _count_nodes(node: Any) -> int:
-    count = 1
-    for child in node.children:
-        count += _count_nodes(child)
+    """Count AST nodes iteratively to avoid RecursionError on deeply-nested trees."""
+    count = 0
+    stack = [node]
+    while stack:
+        current = stack.pop()
+        count += 1
+        for child in current.children:
+            stack.append(child)
     return count
 
 

--- a/tree_sitter_analyzer/incremental_sync.py
+++ b/tree_sitter_analyzer/incremental_sync.py
@@ -233,7 +233,24 @@ class IncrementalSync:
         # "unknown"). Previously this was a single ``action`` field that
         # confusingly read ``action: "indexed", status: "skipped"`` for files
         # the cache refused. ``action`` is preserved as a back-compat alias.
-        index_result = self._cache.index_file(abs_path)
+        try:
+            index_result = self._cache.index_file(abs_path)
+        except RecursionError as exc:
+            # Issue #805: deeply-nested AST triggers unbounded recursion.
+            # Catch per-file so the rest of the sync continues.
+            logger.error(
+                "RecursionError indexing %s (AST too deeply nested): %s",
+                rel_path,
+                exc,
+            )
+            return {
+                "file": rel_path,
+                "considered": "indexed",
+                "action": "indexed",
+                "status": "error",
+                "error_type": type(exc).__name__,
+                "error_message": str(exc),
+            }
         status = index_result.get("status", "unknown")
         return {
             "file": rel_path,
@@ -249,7 +266,23 @@ class IncrementalSync:
         conn: sqlite3.Connection,
     ) -> dict[str, Any]:
         self._cache.invalidate(abs_path)
-        index_result = self._cache.index_file(abs_path)
+        try:
+            index_result = self._cache.index_file(abs_path)
+        except RecursionError as exc:
+            # Issue #805: same guard for re-index path.
+            logger.error(
+                "RecursionError re-indexing %s (AST too deeply nested): %s",
+                rel_path,
+                exc,
+            )
+            return {
+                "file": rel_path,
+                "considered": "updated",
+                "action": "updated",
+                "status": "error",
+                "error_type": type(exc).__name__,
+                "error_message": str(exc),
+            }
         status = index_result.get("status", "unknown")
         return {
             "file": rel_path,


### PR DESCRIPTION
## Root cause

`_count_nodes` in `_ast_extraction.py` used unbounded recursion — one
recursive call per AST child with no depth cap. On deeply-nested trees
(TypeScript/Rust deeply-nested generics, heavily-macro-expanded C, or any
file with 1000+ nesting levels) this raises `RecursionError`. Because
`_index_new_file` in `incremental_sync.py` had no `try/except` around
`self._cache.index_file()`, the exception propagated all the way up through
`_index_or_reindex_files` → `sync()`, aborting the entire sync **before
`conn.commit()`** — leaving all valid sibling files unindexed (#805).

## Fix approach

**Fix 1 — `_ast_extraction.py`:** convert `_count_nodes` to an iterative
stack-based loop. No recursion at all; depth is bounded by heap, not the call
stack. The iterative approach is already used by `_count_decision_points` in
the same file (good precedent).

**Fix 2 — `incremental_sync.py`:** wrap `self._cache.index_file()` in both
`_index_new_file` and `_reindex_modified` with `except RecursionError`. A
bad file gets logged with its path + exception type/message, the detail dict
carries `status: "error"`, `error_type`, and `error_message` fields
(addressing #806 — error envelope now has file attribution), `result.errors`
is incremented, and processing continues for all remaining files.

## Does this fix #809?

Yes. #809 reports that TypeScript and Rust extractors crash on deeply-nested
generic types. Both call `_extract_symbols` → `_count_nodes(root)`. Fix 1
eliminates the recursion in `_count_nodes`, so those crashes are resolved by
the same change. Noted in commit message.

## Does this fix #806?

Partially. The P1 crash (#805) was the priority. While in `incremental_sync.py`
the error detail now carries `file`, `error_type`, and `error_message` — the
three fields called out in #806. Full error-envelope uniformity across all
error paths in the cache layer is a separate, larger task.

## Test plan

- [x] RED first: `TestRecursionErrorHandling` confirmed failing before fix
  (RecursionError propagated unhandled, aborting sync)
- [x] GREEN after fix: all 6 new tests pass
- [x] `TestCountNodes::test_deep_chain_does_not_raise`: 2000-level chain
  completes without RecursionError, returns exact count 2001
- [x] `TestRecursionErrorHandling::test_recursion_error_in_one_file_does_not_abort_sync`:
  pathological file → `result.errors == 1`, `error_details[0]["file"]` contains
  "pathological", `error_type == "RecursionError"`
- [x] `TestRecursionErrorHandling::test_recursion_error_detail_has_file_attribution`:
  error envelope includes file path and error_type
- [x] 208 existing tests pass (test_incremental_sync + test_ast_extraction + test_ast_cache)
- [x] change-impact verification command: 137 pass
- [x] ruff/mypy/bandit clean

Closes #805; closes #809 (same root cause, same fix).