### PR TITLE
fix(constraints): skip builtin/stdlib callee names to clear #780 phantom violations

### DIFF
--- a/tests/unit/test_constraint_dsl.py
+++ b/tests/unit/test_constraint_dsl.py
@@ -403,6 +403,112 @@ class TestEvaluator:
             f"Excepted caller must produce zero violations, got: {violations}"
         )
 
+    @pytest.mark.parametrize(
+        "phantom_name",
+        [
+            "update",  # dict.update / set.update — _DICT_LIST_SET_METHODS
+            "execute",  # sqlite3.Cursor.execute — DB-API standard
+            "append",  # list.append
+            "get",  # dict.get / Mapping.get
+        ],
+    )
+    def test_builtin_like_callee_name_does_not_phantom_violate(
+        self, tmp_path: Path, phantom_name: str
+    ) -> None:
+        """A bare builtin/stdlib method name bound cross-file by the resolver
+        to a forbidden-zone file must NOT trigger a constraint violation.
+
+        Reproduces #780: ``--check-constraints`` fabricated 14 phantom
+        ``error`` violations because the callee resolver bound bare names
+        like ``dict.update()`` and ``cursor.execute(sql)`` to arbitrary
+        project files that happened to define a method of the same name.
+        The evaluator trusts ``callee_resolved_file``; without a denylist
+        of builtin-like names, every ``foo.update(...)`` call where ``foo``
+        is a dict/list/set becomes a phantom cross-file edge.
+
+        The fix is defensive (evaluator-side): when ``callee_name`` is a
+        known builtin/stdlib method name, skip the edge regardless of what
+        ``callee_resolved_file`` claims. The deeper resolver-side fix is
+        tracked separately.
+        """
+        from tree_sitter_analyzer.constraints import (
+            evaluate,
+            load_constraints,
+        )
+
+        project = _stage_constraints_file(tmp_path, "dogfood_minimal.yml")
+        db_path = project / ".ast-cache" / "index.db"
+        _build_call_edges_db(
+            db_path,
+            rows=[
+                (
+                    "caller_fn",
+                    "tree_sitter_analyzer/mcp/x.py",  # caller in forbidden-from zone
+                    42,
+                    phantom_name,  # bare builtin-like name — dict.update, etc.
+                    phantom_name,
+                    "tree_sitter_analyzer/cli/y.py",  # phantom resolved file in forbidden-to zone
+                ),
+            ],
+        )
+
+        constraints = load_constraints(str(project))
+        conn = sqlite3.connect(str(db_path))
+        try:
+            violations = evaluate(constraints, conn)
+        finally:
+            conn.close()
+
+        assert violations == [], (
+            f"Bare builtin-like name {phantom_name!r} must not produce a "
+            f"phantom violation, got: {violations}"
+        )
+
+    def test_real_callee_name_still_violates_after_builtin_filter(
+        self, tmp_path: Path
+    ) -> None:
+        """Regression guard: a real project-defined method name crossing the
+        forbidden boundary must STILL trigger a violation after the
+        builtin-like denylist ships.
+
+        Without this test, an over-eager "skip common names" fix could
+        silently swallow real architectural drift — e.g. an MCP module
+        directly importing a CLI helper named ``run_cli_command``.
+        """
+        from tree_sitter_analyzer.constraints import (
+            evaluate,
+            load_constraints,
+        )
+
+        project = _stage_constraints_file(tmp_path, "dogfood_minimal.yml")
+        db_path = project / ".ast-cache" / "index.db"
+        _build_call_edges_db(
+            db_path,
+            rows=[
+                (
+                    "bridge",
+                    "tree_sitter_analyzer/mcp/x.py",
+                    7,
+                    "run_cli_command",  # NOT a builtin — real project method
+                    "run_cli_command",
+                    "tree_sitter_analyzer/cli/y.py",
+                ),
+            ],
+        )
+
+        constraints = load_constraints(str(project))
+        conn = sqlite3.connect(str(db_path))
+        try:
+            violations = evaluate(constraints, conn)
+        finally:
+            conn.close()
+
+        assert len(violations) == 1, (
+            f"Real project method must still trigger, got: {len(violations)} "
+            f"violations: {violations}"
+        )
+        assert violations[0].callee_name == "run_cli_command"
+
     @pytest.mark.slow_ok
     def test_eval_perf_on_synthetic_edges_under_500ms(self, tmp_path: Path) -> None:
         """50k edges × 5 rules in <500 ms.

--- a/tree_sitter_analyzer/constraints/evaluator.py
+++ b/tree_sitter_analyzer/constraints/evaluator.py
@@ -28,10 +28,52 @@ import sqlite3
 import time
 from collections.abc import Iterator
 
+from ..synapse_resolver._constants import _DICT_LIST_SET_METHODS
 from .parser import _CompiledConstraint, compile_constraints
 from .schema import Constraint, Violation
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# #780 — phantom-resistant callee name denylist (defensive evaluator gate).
+#
+# The callee resolver is supposed to classify bare stdlib method calls
+# (``dict.update()``, ``cursor.execute(sql)``) and NOT bind them to a
+# project file. In practice it still does for some paths, producing
+# phantom CALLS edges where ``callee_resolved_file`` lands in a
+# forbidden architectural zone. The evaluator trusts that field, so
+# every ``foo.update(...)`` call where ``foo`` happens to share a name
+# with an MCP/CLI method becomes a false ``error`` violation —
+# ``--check-constraints`` reported 14 phantom violations project-wide,
+# forcing an UNSAFE verdict with zero real forbidden edges.
+#
+# Defense-in-depth: skip any edge whose ``callee_name`` is a known
+# builtin/stdlib method name. The deeper resolver-side fix (classify
+# bare names as ``stdlib`` and leave ``callee_resolved_file`` empty) is
+# tracked separately; this gate keeps the agent trust surface honest
+# in the meantime and stays correct even if the resolver regresses.
+#
+# Sourced from ``synapse_resolver._constants._DICT_LIST_SET_METHODS``
+# (already declared stdlib over there) plus the DB-API cursor methods
+# deliberately excluded from ``EXTERNAL_METHODS`` because projects
+# commonly define their own ``execute``.
+# ---------------------------------------------------------------------------
+_SQL_CURSOR_METHODS: frozenset[str] = frozenset(
+    {
+        "execute",
+        "executemany",
+        "executescript",
+        "commit",
+        "rollback",
+        "fetchone",
+        "fetchall",
+        "fetchmany",
+    }
+)
+_PHANTOM_RESISTANT_CALLEE_NAMES: frozenset[str] = (
+    _DICT_LIST_SET_METHODS | _SQL_CURSOR_METHODS
+)
 
 
 def evaluate(
@@ -93,6 +135,15 @@ def _iter_violations(
         if not callee_file:
             # Unresolved cross-file call — MVP skips it to avoid noisy
             # false positives on dynamic / external symbols.
+            continue
+        if callee_name in _PHANTOM_RESISTANT_CALLEE_NAMES:
+            # #780 defensive gate: bare builtin/stdlib method name
+            # (dict.update, cursor.execute, ...). The callee resolver
+            # may have bound it to a project file purely on name
+            # collision; skip so we do not emit a phantom violation.
+            # Real project methods that happen to share these names
+            # remain enforceable via an explicit import edge / stricter
+            # resolver tier — not via bare-name binding.
             continue
         for cc in compiled:
             if cc.from_re.fullmatch(caller_file) is None:


### PR DESCRIPTION
## Summary
- Add a defensive evaluator gate that skips CALLS edges whose `callee_name` is in `_PHANTOM_RESISTANT_CALLEE_NAMES` (union of `_DICT_LIST_SET_METHODS` and a new `_SQL_CURSOR_METHODS`).
- Fixes #780: `--check-constraints` fabricated 14 phantom `error` violations project-wide because the callee resolver bound bare builtin/stdlib method calls (`dict.update()`, `cursor.execute(sql)`) to arbitrary project files that happened to define a method of the same name.

## Root Cause
The callee resolver is supposed to classify bare stdlib method calls and NOT bind them to a project file. In practice it still does for some paths, producing phantom CALLS edges where `callee_resolved_file` lands in a forbidden architectural zone. The evaluator trusts `callee_resolved_file` and faithfully reports each phantom edge as a violation. With 3 active constraints over a 125k-edge call graph, every `foo.update(...)` / `cursor.execute(sql)` where the resolver picked a forbidden-zone file became a false `error` — forcing an overall UNSAFE verdict with zero real forbidden edges.

This is a defense-in-depth fix at the evaluator gate. The deeper resolver-side fix (classify bare names as `stdlib` and leave `callee_resolved_file` empty) is tracked separately and is the next P1 follow-up.

## Validation
- **RED-first tests** (added to `tests/unit/test_constraint_dsl.py::TestEvaluator`):
  - `test_builtin_like_callee_name_does_not_phantom_violate` — parametrised over `update` / `execute` / `append` / `get`
  - `test_real_callee_name_still_violates_after_builtin_filter` — regression guard so the gate does not over-filter real violations
- `uv run pytest tests/unit/hyphae/test_evaluator.py tests/unit/test_constraint_dsl.py -q` → 38 passed
- `uv run pytest tests/unit/test_constraint_dsl.py tests/unit/cli/test_constraint_check_command.py tests/unit/mcp/tools/test_constraint_check_tool.py --cov=tree_sitter_analyzer/constraints --cov-report=json -q` → 85 passed
- `uv run ruff check tree_sitter_analyzer/constraints/evaluator.py tests/unit/test_constraint_dsl.py` → All checks passed
- `uv run python scripts/check_patch_coverage.py --base origin/develop --coverage-json coverage.json` → Patch coverage gate passed: no added executable misses
- **Dogfood**: `uv run python -m tree_sitter_analyzer --check-constraints --format json` → violations **14 → 0**, verdict **UNSAFE → SAFE**, same set of 125,810 evaluated edges

## Dogfood impact
This unblocks agent-trust on `edit action=constraints` / `edit action=pr` / `safe_to_edit` — these tools previously returned `UNSAFE` on a clean tree, making every PR review unreliable. With the fix, the constraint system correctly returns `SAFE` on a tree with zero real forbidden edges.

## Follow-ups (tracked separately)
- Deeper resolver-side fix: classify bare builtin/stdlib names as `stdlib` and leave `callee_resolved_file` empty (so the gate becomes belt-and-suspenders rather than load-bearing).
- Audit `_SQL_CURSOR_METHODS` against other DB-API surfaces (psycopg2, SQLAlchemy session) once the resolver fix lands.

Refs #780.