### PR TITLE
fix(constraints): filter phantom violations via import-reachability guard (#780)

### DIFF
--- a/tests/unit/test_constraint_dsl.py
+++ b/tests/unit/test_constraint_dsl.py
@@ -149,6 +149,42 @@ def _build_call_edges_db(
         conn.close()
 
 
+def _populate_ast_imports(
+    db_path: Path,
+    rows: list[tuple[str, str]],
+) -> None:
+    """Insert rows into ``ast_imports`` in the given DB.
+
+    Each tuple is ``(file_path, module_path)``.  The table is created if
+    absent so this helper can be called on a DB built by
+    ``_build_call_edges_db`` (which only creates the ``edges`` schema).
+    """
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS ast_imports (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                file_path   TEXT NOT NULL,
+                language    TEXT NOT NULL DEFAULT 'python',
+                module_path TEXT NOT NULL,
+                local_name  TEXT NOT NULL DEFAULT '',
+                is_relative INTEGER NOT NULL DEFAULT 0,
+                is_star     INTEGER NOT NULL DEFAULT 0,
+                alias_of    TEXT NOT NULL DEFAULT '',
+                line        INTEGER NOT NULL DEFAULT 0
+            )
+            """
+        )
+        conn.executemany(
+            "INSERT INTO ast_imports (file_path, module_path) VALUES (?, ?)",
+            rows,
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
 # ---------------------------------------------------------------------------
 # Parser tests
 # ---------------------------------------------------------------------------
@@ -601,3 +637,113 @@ class TestEvaluator:
         assert v.caller_file == caller_file
         assert v.caller_line == caller_line
         assert v.callee_name == callee_name
+
+    def test_phantom_bare_name_resolution_skipped_when_no_import(
+        self, tmp_path: Path
+    ) -> None:
+        """Regression #780: bare-name callee resolved to forbidden module is
+        SKIPPED when the caller has no import from that module.
+
+        Scenario mirrors the real bug: ``_hash_one_file`` in a core file
+        calls ``sha256_hash.update()``.  The synapse resolver resolves
+        ``update`` to ``file_health_blocks.py`` (a forbidden mcp module)
+        because both define a method named ``update``.  The caller imports
+        only ``hashlib`` — no ``mcp`` import at all.  The evaluator must
+        NOT flag this as a constraint violation.
+        """
+        from tree_sitter_analyzer.constraints import evaluate, load_constraints
+
+        project = _stage_constraints_file(tmp_path, "dogfood_minimal.yml")
+        db_path = project / ".ast-cache" / "index.db"
+
+        # Edge: core/_hash_one_file calls update(), resolver wrongly sets
+        # callee_resolved_file to an mcp module.
+        _build_call_edges_db(
+            db_path,
+            rows=[
+                (
+                    "_hash_one_file",  # caller_name
+                    "tree_sitter_analyzer/core/analysis_session.py",  # caller_file
+                    188,  # caller_line
+                    "update",  # callee_name
+                    "sha256_hash.update",  # callee_full
+                    "tree_sitter_analyzer/mcp/tools/utils/file_health_blocks.py",  # callee_file (WRONG resolution)
+                ),
+            ],
+        )
+
+        # Populate ast_imports: analysis_session.py imports only hashlib,
+        # NOT file_health_blocks or any mcp module.
+        _populate_ast_imports(
+            db_path,
+            rows=[
+                ("tree_sitter_analyzer/core/analysis_session.py", "hashlib"),
+                ("tree_sitter_analyzer/core/analysis_session.py", "json"),
+                ("tree_sitter_analyzer/core/analysis_session.py", "pathlib"),
+            ],
+        )
+
+        constraints = load_constraints(str(project))
+        conn = sqlite3.connect(str(db_path))
+        try:
+            violations = evaluate(constraints, conn)
+        finally:
+            conn.close()
+
+        assert len(violations) == 0, (
+            f"Expected 0 violations (phantom bare-name resolution must be filtered), "
+            f"got {len(violations)}: {violations}"
+        )
+
+    def test_real_violation_not_filtered_when_import_present(
+        self, tmp_path: Path
+    ) -> None:
+        """Regression #780: a genuine cross-boundary call IS flagged when the
+        caller actually imports from the forbidden module.
+
+        Ensures the import-reachability guard does not over-filter real
+        violations — only phantom bare-name resolutions are suppressed.
+        """
+        from tree_sitter_analyzer.constraints import evaluate, load_constraints
+
+        project = _stage_constraints_file(tmp_path, "dogfood_minimal.yml")
+        db_path = project / ".ast-cache" / "index.db"
+
+        # Edge: mcp/x.py calls cli_helper() which is genuinely in cli/y.py.
+        _build_call_edges_db(
+            db_path,
+            rows=[
+                (
+                    "do_thing",  # caller_name
+                    "tree_sitter_analyzer/mcp/x.py",  # caller_file
+                    42,  # caller_line
+                    "cli_helper",  # callee_name
+                    "cli_helper",  # callee_full
+                    "tree_sitter_analyzer/cli/y.py",  # callee_file (REAL violation)
+                ),
+            ],
+        )
+
+        # mcp/x.py really does import from cli/y — this is the genuine case.
+        _populate_ast_imports(
+            db_path,
+            rows=[
+                ("tree_sitter_analyzer/mcp/x.py", "tree_sitter_analyzer.cli.y"),
+            ],
+        )
+
+        constraints = load_constraints(str(project))
+        conn = sqlite3.connect(str(db_path))
+        try:
+            violations = evaluate(constraints, conn)
+        finally:
+            conn.close()
+
+        assert len(violations) == 1, (
+            f"Expected exactly 1 real violation (import IS present), "
+            f"got {len(violations)}: {violations}"
+        )
+        v = violations[0]
+        assert v.rule_id == "dogfood-mcp-no-cli"
+        assert v.caller_file == "tree_sitter_analyzer/mcp/x.py"
+        assert v.callee_file == "tree_sitter_analyzer/cli/y.py"

--- a/tree_sitter_analyzer/constraints/evaluator.py
+++ b/tree_sitter_analyzer/constraints/evaluator.py
@@ -19,6 +19,14 @@ Design contract:
 
 * The function is pure: it never writes to the DB. The MCP tool layer
   owns the write-through into ``ast_constraint_violations``.
+
+* Import-reachability guard (#780): a resolved callee file is only flagged
+  as a constraint violation when the caller actually imports the callee's
+  module.  Without this guard, bare-name resolutions (e.g. ``update`` or
+  ``execute``) can be matched to same-named methods in forbidden modules
+  even when the caller has no import relationship to those modules.  When
+  ``ast_imports`` is absent (e.g. test fixtures) the guard is skipped and
+  the evaluator falls back to the pre-guard behaviour.
 """
 
 from __future__ import annotations
@@ -47,6 +55,8 @@ def evaluate(
     Edge-skip rules:
         * No callee file at all → skip (unresolved cross-file call).
         * Exception list matches the caller → skip (whitelisted seam).
+        * Callee not reachable via caller's imports → skip (phantom
+          bare-name resolution; see #780).
 
     Yields a :class:`Violation` for every (rule, edge) pair where the
     caller matches ``from_glob``, the callee file matches ``to_glob``,
@@ -86,6 +96,7 @@ def _iter_violations(
     but deterministic and the PK is the same violation regardless).
     """
     seen: set[tuple[str, str, int, str]] = set()
+    import_index = _build_import_index(db_conn)
     select_sql = _build_select_sql(db_conn)
     cursor = db_conn.execute(select_sql)
     for row in cursor:
@@ -100,6 +111,15 @@ def _iter_violations(
             if cc.to_re.fullmatch(callee_file) is None:
                 continue
             if _is_excepted(caller_file, cc):
+                continue
+            # Import-reachability guard (#780): skip phantom resolutions
+            # where the callee lives in a forbidden module the caller never
+            # actually imports. Same-file calls always pass this check.
+            if (
+                import_index is not None
+                and caller_file != callee_file
+                and not _callee_is_imported(caller_file, callee_file, import_index)
+            ):
                 continue
             pk = (
                 cc.constraint.id,
@@ -132,6 +152,75 @@ def _is_excepted(caller_file: str, compiled: _CompiledConstraint) -> bool:
         if exc_re.fullmatch(caller_file) is not None:
             return True
     return False
+
+
+def _build_import_index(
+    db_conn: sqlite3.Connection,
+) -> dict[str, set[str]] | None:
+    """Build a lookup of {file_path: set(module_path_suffixes)} from ast_imports.
+
+    Returns ``None`` when the ``ast_imports`` table is absent (e.g. in
+    test fixtures that only populate the ``edges`` table) so callers can
+    skip the import-reachability guard and fall back to pre-guard behaviour.
+
+    The set stored per file is the union of the raw module_path and its
+    terminal component (the basename after the last ``.`` or ``/``).
+    This handles both absolute imports (``tree_sitter_analyzer.mcp.x``)
+    and relative imports (``.x``) with a single membership test.
+    """
+    try:
+        cursor = db_conn.execute("SELECT file_path, module_path FROM ast_imports")
+    except sqlite3.OperationalError:
+        # Table absent (test fixture, fresh DB) — degrade gracefully.
+        return None
+
+    index: dict[str, set[str]] = {}
+    for file_path, module_path in cursor:
+        if not file_path or not module_path:
+            continue
+        entry = index.setdefault(file_path, set())
+        # Store full module_path (handles absolute imports).
+        entry.add(module_path)
+        # Also store the terminal component so relative imports like
+        # '.file_health_blocks' and absolute ones both match via the
+        # basename 'file_health_blocks'.
+        terminal = module_path.lstrip(".").rsplit(".", 1)[-1]
+        if terminal:
+            entry.add(terminal)
+    return index
+
+
+def _callee_is_imported(
+    caller_file: str,
+    callee_file: str,
+    import_index: dict[str, set[str]],
+) -> bool:
+    """Return True when the caller's import set covers the callee's module.
+
+    Converts ``callee_file`` (a relative project path like
+    ``tree_sitter_analyzer/mcp/tools/utils/file_health_blocks.py``) to:
+
+    * A full dotted module path: ``tree_sitter_analyzer.mcp.tools.utils.file_health_blocks``
+    * A terminal component: ``file_health_blocks``
+
+    Then checks whether any entry in the caller's import set matches
+    either form — covering both absolute and relative imports.
+
+    Returns ``True`` (caller imports callee) when the import_index has no
+    entry for the caller, so that files not recorded in ast_imports (e.g.
+    languages not yet extracted) do not produce false negatives.
+    """
+    caller_imports = import_index.get(caller_file)
+    if caller_imports is None:
+        # No import data for caller → assume reachable to avoid false negatives.
+        return True
+
+    # Derive module identifiers from the callee's file path.
+    without_ext = callee_file.removesuffix(".py")
+    full_module = without_ext.replace("/", ".")
+    terminal = without_ext.rsplit("/", 1)[-1]
+
+    return full_module in caller_imports or terminal in caller_imports
 
 
 def _build_select_sql(db_conn: sqlite3.Connection) -> str:


### PR DESCRIPTION
## Summary

- Adds an import-reachability guard in `_iter_violations` (constraints evaluator).
- Before flagging a CALLS edge as a constraint violation, verifies the callee's module appears in the caller's `ast_imports` rows.
- Phantom resolutions (where `callee_resolved_file` lands in a forbidden zone due to bare-name collision) are suppressed; real violations (where the caller genuinely imports the forbidden module) still fire.
- When `ast_imports` is absent (test fixtures, fresh DB), the guard degrades gracefully to pre-fix behavior.

## Root Cause

The callee resolver bound bare calls like `sha256_hash.update()` or `self.execute()` to ANY project symbol with that name — regardless of whether the caller's file actually imports the callee's module. This produced phantom `callee_resolved_file` values pointing to forbidden modules.

For example:
- `core/analysis_session.py` imports only `hashlib`, `json`, etc.
- The resolver matched its `sha256_hash.update()` call to `mcp/tools/utils/file_health_blocks.py` (which also has a method named `update`).
- The evaluator trusts `callee_resolved_file` and flagged this as a `core-must-not-import-mcp` violation.
- Zero real forbidden imports exist; all 14 violations were phantom.

## Fix approach

Rather than a callee-name denylist (which requires ongoing maintenance as new stdlib/builtin methods encounter this), the fix checks **import reachability**: `callee_resolved_file` → dotted module path → is it in the caller's `ast_imports`? This works for any bare-name collision regardless of the method name.

## Test plan

- `test_phantom_bare_name_resolution_skipped_when_no_import` — asserts `violations == 0` when an `update` call is wrongly resolved to a forbidden module the caller doesn't import. Exact count `== 0`.
- `test_real_violation_not_filtered_when_import_present` — asserts `violations == 1` when the caller DOES import from the forbidden module. Regression guard. Exact count `== 1`.
- All 12 `test_constraint_dsl.py` tests pass (10 existing + 2 new).
- All 97 constraint-related tests pass across the unit suite.
- Dogfood: `--check-constraints` on the live index → violations 14 → **0**, verdict UNSAFE → **SAFE**, 125,810 edges evaluated.

## Note on PR #826

PR #826 (`fix/check-constraints-phantom-method-names-780`) takes a denylist approach (block known stdlib callee names). This PR uses import-reachability — more general, no denylist to maintain. Lead should pick one; both fix the immediate symptom.

Closes #780.