### PR TITLE
fix(javascript): extract X.prototype.method assignments (closes #791)

### DIFF
--- a/tests/unit/languages/test_js_prototype_methods_791.py
+++ b/tests/unit/languages/test_js_prototype_methods_791.py
@@ -1,0 +1,105 @@
+"""Issue #791: JS prototype-assignment methods silently dropped.
+
+``Animal.prototype.speak = function speak() {...}`` and
+``Animal.prototype.walk = function() {...}`` must be extracted as methods
+of class 'Animal', not silently discarded.
+
+RED-first: this test MUST fail before the fix and pass after it.
+"""
+
+from __future__ import annotations
+
+import pytest
+import tree_sitter_javascript as tsjs
+from tree_sitter import Language, Parser
+
+from tree_sitter_analyzer.languages.javascript_plugin.extractor import (
+    JavaScriptElementExtractor,
+)
+
+
+@pytest.fixture(scope="module")
+def js_parser() -> Parser:
+    return Parser(Language(tsjs.language()))
+
+
+@pytest.fixture(scope="module")
+def prototype_fixture() -> str:
+    return (
+        "\n"
+        "function Animal(name) { this.name = name; }\n"
+        "Animal.prototype.speak = function speak() { return this.name; };\n"
+        "Animal.prototype.walk = function() { return 'walking'; };\n"
+    )
+
+
+@pytest.fixture(scope="module")
+def extracted(js_parser: Parser, prototype_fixture: str):
+    tree = js_parser.parse(bytes(prototype_fixture, "utf-8"))
+    ext = JavaScriptElementExtractor()
+    ext.current_file = "animal.js"
+    ext._file_encoding = "utf-8"
+    functions = ext.extract_functions(tree, prototype_fixture)
+    classes = ext.extract_classes(tree, prototype_fixture)
+    return {"functions": functions, "classes": classes}
+
+
+# ---------------------------------------------------------------------------
+# Core correctness assertions
+# ---------------------------------------------------------------------------
+
+
+def test_method_count(extracted):
+    """Exactly 3 functions: Animal constructor + speak + walk."""
+    assert len(extracted["functions"]) == 3
+
+
+def test_class_count(extracted):
+    """Animal is synthesised as a class via prototype aggregation."""
+    assert len(extracted["classes"]) == 1
+
+
+def test_class_name(extracted):
+    assert extracted["classes"][0].name == "Animal"
+
+
+def test_speak_present(extracted):
+    names = [f.name for f in extracted["functions"]]
+    assert "speak" in names
+
+
+def test_walk_present(extracted):
+    names = [f.name for f in extracted["functions"]]
+    assert "walk" in names
+
+
+def test_speak_is_method(extracted):
+    speak = next(f for f in extracted["functions"] if f.name == "speak")
+    assert speak.is_method is True
+
+
+def test_walk_is_method(extracted):
+    walk = next(f for f in extracted["functions"] if f.name == "walk")
+    assert walk.is_method is True
+
+
+def test_speak_parent_class(extracted):
+    speak = next(f for f in extracted["functions"] if f.name == "speak")
+    assert speak.parent_class == "Animal"
+
+
+def test_walk_parent_class(extracted):
+    walk = next(f for f in extracted["functions"] if f.name == "walk")
+    assert walk.parent_class == "Animal"
+
+
+def test_constructor_not_lost(extracted):
+    """The Animal constructor function must still be extracted."""
+    names = [f.name for f in extracted["functions"]]
+    assert "Animal" in names
+
+
+def test_no_duplicate_names(extracted):
+    """No function name should appear more than once."""
+    names = [f.name for f in extracted["functions"]]
+    assert len(names) == len(set(names))

--- a/tree_sitter_analyzer/languages/javascript_plugin/_function_helpers.py
+++ b/tree_sitter_analyzer/languages/javascript_plugin/_function_helpers.py
@@ -187,6 +187,111 @@ def extract_method(
         raise
 
 
+def extract_prototype_method(
+    node: tree_sitter.Node,
+    extract_parameters: ParameterExtractor,
+    extract_jsdoc: JsdocExtractor,
+    calculate_complexity: ComplexityCalculator,
+    get_node_text: TextExtractor,
+    framework_type: str,
+) -> Function | None:
+    """Extract a prototype-assignment method: ``X.prototype.m = function(){}``.
+
+    AST shape (tree-sitter-javascript):
+        assignment_expression
+            left:  member_expression          <- X.prototype.m
+                       member_expression      <- X.prototype
+                           identifier         <- X
+                           property_identifier <- prototype
+                       property_identifier    <- m  (method name)
+            right: function_expression / arrow_function
+    """
+    try:
+        # Must be a top-level assignment_expression
+        if node.type != "assignment_expression":
+            return None
+
+        left = node.child_by_field_name("left")
+        right = node.child_by_field_name("right")
+
+        if not left or not right:
+            return None
+
+        # left must be a member_expression (X.prototype.m)
+        if left.type != "member_expression":
+            return None
+
+        # Its object must itself be a member_expression (X.prototype)
+        proto_expr = left.child_by_field_name("object")
+        method_prop = left.child_by_field_name("property")
+
+        if not proto_expr or proto_expr.type != "member_expression":
+            return None
+        if not method_prop or method_prop.type != "property_identifier":
+            return None
+
+        # proto_expr.property must be "prototype"
+        proto_prop = proto_expr.child_by_field_name("property")
+        if not proto_prop or get_node_text(proto_prop) != "prototype":
+            return None
+
+        # The class name is proto_expr.object (must be an identifier)
+        class_id = proto_expr.child_by_field_name("object")
+        if not class_id or class_id.type != "identifier":
+            return None
+
+        class_name = get_node_text(class_id)
+        method_name = get_node_text(method_prop)
+
+        # Right-hand side must be a function (named or anonymous) or arrow
+        if right.type not in ("function_expression", "arrow_function"):
+            return None
+
+        # Extract parameters from formal_parameters child
+        parameters: list[str] = []
+        for child in right.children:
+            if child.type == "formal_parameters":
+                parameters = extract_parameters(child)
+            elif child.type == "identifier" and right.type == "arrow_function":
+                # single-param arrow: x => ...
+                parameters = [get_node_text(child)]
+
+        start_line = node.start_point[0] + 1
+        end_line = node.end_point[0] + 1
+        node_text = get_node_text(node)
+        is_async = "async" in node_text
+
+        # If the function_expression has an explicit identifier name (named
+        # function expression), prefer that as the canonical method name.
+        if right.type == "function_expression":
+            for child in right.children:
+                if child.type == "identifier":
+                    method_name = get_node_text(child)
+                    break
+
+        return Function(
+            name=method_name,
+            start_line=start_line,
+            end_line=end_line,
+            raw_text=node_text,
+            language="javascript",
+            parameters=parameters,
+            return_type="unknown",
+            is_async=is_async,
+            is_generator=False,
+            is_arrow=right.type == "arrow_function",
+            is_method=True,
+            is_constructor=False,
+            parent_class=class_name,
+            docstring=extract_jsdoc(start_line),
+            complexity_score=calculate_complexity(right),
+            framework_type=framework_type,
+        )
+    except Exception as e:
+        log_debug(f"Failed to extract prototype method: {e}")
+        return None
+
+
 def _raw_text_for_lines(
     content_lines: list[str],
     start_line: int,

--- a/tree_sitter_analyzer/languages/javascript_plugin/_function_mixin.py
+++ b/tree_sitter_analyzer/languages/javascript_plugin/_function_mixin.py
@@ -11,6 +11,7 @@ from ._function_helpers import (
     extract_function,
     extract_generator_function,
     extract_method,
+    extract_prototype_method,
 )
 
 
@@ -59,6 +60,19 @@ class JavaScriptFunctionExtractionMixin:
         return extract_generator_function(
             node,
             self._parse_function_signature_optimized,
+            self._extract_jsdoc_for_line,
+            self._calculate_complexity_optimized,
+            self._get_node_text_optimized,
+            self.framework_type,
+        )
+
+    def _extract_prototype_method_optimized(
+        self, node: "tree_sitter.Node"
+    ) -> Function | None:
+        """Extract a prototype-assignment method: ``X.prototype.m = function(){}``."""
+        return extract_prototype_method(
+            node,
+            self._extract_parameters,
             self._extract_jsdoc_for_line,
             self._calculate_complexity_optimized,
             self._get_node_text_optimized,

--- a/tree_sitter_analyzer/languages/javascript_plugin/_public_extraction_mixin.py
+++ b/tree_sitter_analyzer/languages/javascript_plugin/_public_extraction_mixin.py
@@ -40,8 +40,40 @@ class JavaScriptPublicExtractionMixin:
             "function",
         )
 
+        # Separate pass: collect prototype-assignment methods.
+        # These are NOT picked up by the traversal above because
+        # `assignment_expression` is only a container node type there;
+        # adding it to `extractors` would also re-process the inner
+        # function_expression and create duplicates.
+        prototype_methods = self._extract_prototype_methods(tree.root_node)
+        functions.extend(prototype_methods)
+
         log_debug(f"Extracted {len(functions)} JavaScript functions")
         return functions
+
+    def _extract_prototype_methods(self, root_node: tree_sitter.Node) -> list[Function]:
+        """Walk top-level expression statements for X.prototype.m = function(){}.
+
+        Only scans the immediate children of the program root (or one level
+        inside export_statement) — prototype assignments are always top-level in
+        practice and this keeps the pass O(n) where n = top-level statements.
+        """
+        methods: list[Function] = []
+        candidates = list(root_node.children)
+        for stmt in candidates:
+            # Unwrap export_statement if needed
+            if stmt.type == "export_statement":
+                inner = stmt.child_by_field_name("declaration")
+                if inner:
+                    stmt = inner
+            if stmt.type != "expression_statement":
+                continue
+            for child in stmt.children:
+                if child.type == "assignment_expression":
+                    method = self._extract_prototype_method_optimized(child)
+                    if method is not None:
+                        methods.append(method)
+        return methods
 
     # Extract elements from AST: extract_classes
     def extract_classes(self, tree: tree_sitter.Tree, source_code: str) -> list[Class]:
@@ -63,8 +95,78 @@ class JavaScriptPublicExtractionMixin:
             "class",
         )
 
+        # Synthesise Class objects for constructors defined via prototype pattern.
+        # Only add a synthetic class when no ES6 class_declaration with the same
+        # name was already found by the traversal above.
+        existing_class_names = {c.name for c in classes}
+        for proto_class in self._extract_prototype_classes(tree.root_node):
+            if proto_class.name not in existing_class_names:
+                classes.append(proto_class)
+                existing_class_names.add(proto_class.name)
+
         log_debug(f"Extracted {len(classes)} JavaScript classes")
         return classes
+
+    def _extract_prototype_classes(self, root_node: tree_sitter.Node) -> list[Class]:
+        """Synthesise Class objects from X.prototype.m assignments.
+
+        Looks for ``function ClassName(...){}`` declarations in the top-level
+        program AND collects class names from prototype assignments.  A synthetic
+        Class is created for each unique class name found only via prototype
+        assignments (i.e. no ES6 class_declaration exists for that name).
+        """
+        # Collect constructor lines from function_declaration nodes
+        constructor_lines: dict[str, int] = {}
+        for stmt in root_node.children:
+            if stmt.type == "function_declaration":
+                # Check if there is a prototype assignment for this name later
+                for id_child in stmt.children:
+                    if id_child.type == "identifier":
+                        name = self._get_node_text_optimized(id_child)
+                        constructor_lines[name] = stmt.start_point[0] + 1
+                        break
+
+        # Collect class names referenced in prototype assignments
+        proto_class_names: dict[str, int] = {}  # name -> first assignment line
+        for stmt in root_node.children:
+            if stmt.type != "expression_statement":
+                continue
+            for child in stmt.children:
+                if child.type != "assignment_expression":
+                    continue
+                left = child.child_by_field_name("left")
+                if not left or left.type != "member_expression":
+                    continue
+                proto_expr = left.child_by_field_name("object")
+                if not proto_expr or proto_expr.type != "member_expression":
+                    continue
+                proto_prop = proto_expr.child_by_field_name("property")
+                if (
+                    not proto_prop
+                    or self._get_node_text_optimized(proto_prop) != "prototype"
+                ):
+                    continue
+                class_id = proto_expr.child_by_field_name("object")
+                if not class_id or class_id.type != "identifier":
+                    continue
+                class_name = self._get_node_text_optimized(class_id)
+                if class_name not in proto_class_names:
+                    proto_class_names[class_name] = stmt.start_point[0] + 1
+
+        synthetic: list[Class] = []
+        for class_name, first_line in proto_class_names.items():
+            start_line = constructor_lines.get(class_name, first_line)
+            synthetic.append(
+                Class(
+                    name=class_name,
+                    start_line=start_line,
+                    end_line=first_line,
+                    raw_text="",
+                    language="javascript",
+                    class_type="class",
+                )
+            )
+        return synthetic
 
     # Extract elements from AST: extract_variables
     def extract_variables(

--- a/tree_sitter_analyzer/models/base.py
+++ b/tree_sitter_analyzer/models/base.py
@@ -88,6 +88,7 @@ class Function(CodeElement):
     is_generator: bool = False
     is_arrow: bool = False
     is_method: bool = False
+    parent_class: str | None = None  # owning class for prototype-assigned methods
     framework_type: str | None = None
     # Python-specific fields
     is_property: bool = False


### PR DESCRIPTION
## Summary

- **Root cause**: `extract_functions` in the JavaScript plugin registered `assignment_expression` only as a container node type (so the traversal descends into it) but never as a target extractor. Classic pre-ES6 prototype-assignment methods — `Animal.prototype.speak = function(){}` — live inside `assignment_expression` nodes and were never visited as extraction targets.
- **Why adding to the traversal map directly would cause duplicates**: the traversal continues into children after calling an extractor. Adding `assignment_expression` to `extractors` would call the extractor on the outer node AND later re-process the inner `function_expression` child, producing two Function objects for the same method.
- **Fix**: a narrow separate pass `_extract_prototype_methods` walks only program-level `expression_statement → assignment_expression` children. A new `extract_prototype_method` helper in `_function_helpers.py` pattern-matches the nested `member_expression` shape (`X.prototype.m`) and emits a `Function` with `is_method=True`, `parent_class='X'`.
- **Class synthesis**: a companion pass `_extract_prototype_classes` synthesises a `Class` object for each unique class name found only via prototype assignments, so `extract_classes` returns `Animal` even when no ES6 `class` declaration exists.
- **Model change**: `Function.parent_class: str | None = None` added to `models/base.py` (under the existing JavaScript-specific comment block). This is a backward-compatible additive change — all existing tests pass.

**Before**: `method_count=1` (constructor only), `class_count=0`  
**After**: `method_count=3`, `class_count=1` (`Animal`)

## Changed files

| File | Change |
|---|---|
| `tree_sitter_analyzer/languages/javascript_plugin/_function_helpers.py` | New `extract_prototype_method()` helper |
| `tree_sitter_analyzer/languages/javascript_plugin/_function_mixin.py` | Expose `_extract_prototype_method_optimized` wrapper |
| `tree_sitter_analyzer/languages/javascript_plugin/_public_extraction_mixin.py` | Hook `_extract_prototype_methods` and `_extract_prototype_classes` into `extract_functions`/`extract_classes` |
| `tree_sitter_analyzer/models/base.py` | Add `parent_class: str | None = None` field to `Function` |
| `tests/unit/languages/test_js_prototype_methods_791.py` | RED-first test with exact-assertion counts (11 tests) |

## Test plan

- [x] RED confirmed before fix: `test_method_count` asserted 3, got 1
- [x] GREEN after fix: all 11 tests in `test_js_prototype_methods_791.py` pass
- [x] No regressions: `tests/unit/languages/ -k "javascript or js"` — 256 passed
- [x] Golden master unchanged (`ModernJavaScript.js` has no prototype patterns)
- [x] `ruff check` clean on all modified files
- [x] `mypy` passes (pre-commit hook)
- [x] 500 core JS + plugin-base tests: all passed

## AST shape matched

```
expression_statement
  assignment_expression
    left: member_expression          <- Animal.prototype.speak
      object: member_expression      <- Animal.prototype
        object: identifier           <- Animal
        property: property_identifier <- prototype
      property: property_identifier  <- speak
    right: function_expression       <- function speak() { ... }
```

## Follow-up issues (out of scope for this PR)

- **#795** — TypeScript enum mislabeled (separate issue, noted here per scope constraint)
- Arrow function prototype assignments (`X.prototype.m = () => {}`) are handled by this fix since `arrow_function` is in the right-hand-side check — no separate ticket needed
- Consider adding prototype patterns to the `ModernJavaScript.js` golden corpus fixture in a follow-up to get regression coverage

Closes #791.