### PR TITLE
fix(viz): expose similarity bounding params, cap functions per group (#801)

### DIFF
--- a/tests/unit/test_codegraph_similarity_tool.py
+++ b/tests/unit/test_codegraph_similarity_tool.py
@@ -282,7 +282,9 @@ class TestBoundingParams801:
         result = await tool_with_large_group.execute({"output_format": "json"})
         assert result["success"] is True
         groups = result["groups"]
-        assert len(groups) == 1  # 15 identical funcs → exactly 1 clone group
+        assert (
+            len(groups) == 2
+        )  # 15 identical funcs → 1 structural + 1 textual clone group
         for group in groups:
             funcs = group["functions"]
             assert len(funcs) == 10, (
@@ -299,7 +301,9 @@ class TestBoundingParams801:
         )
         assert result["success"] is True
         groups = result["groups"]
-        assert len(groups) == 1  # 15 identical funcs → exactly 1 clone group
+        assert (
+            len(groups) == 2
+        )  # 15 identical funcs → 1 structural + 1 textual clone group
         max_funcs = max(len(g["functions"]) for g in groups)
         assert max_funcs == 15, (
             f"include_bodies=True should return all 15 functions; got max={max_funcs}"

--- a/tests/unit/test_codegraph_similarity_tool.py
+++ b/tests/unit/test_codegraph_similarity_tool.py
@@ -282,7 +282,7 @@ class TestBoundingParams801:
         result = await tool_with_large_group.execute({"output_format": "json"})
         assert result["success"] is True
         groups = result["groups"]
-        assert len(groups) >= 1
+        assert len(groups) == 1  # 15 identical funcs → exactly 1 clone group
         for group in groups:
             funcs = group["functions"]
             assert len(funcs) == 10, (
@@ -299,7 +299,7 @@ class TestBoundingParams801:
         )
         assert result["success"] is True
         groups = result["groups"]
-        assert len(groups) >= 1
+        assert len(groups) == 1  # 15 identical funcs → exactly 1 clone group
         max_funcs = max(len(g["functions"]) for g in groups)
         assert max_funcs == 15, (
             f"include_bodies=True should return all 15 functions; got max={max_funcs}"

--- a/tests/unit/test_codegraph_similarity_tool.py
+++ b/tests/unit/test_codegraph_similarity_tool.py
@@ -214,3 +214,153 @@ class TestFacadeIncludeBodiesSurvivesRouting:
                 assert "snippet" not in func, (
                     "snippet must not appear in facade default (summary) response"
                 )
+
+
+# ---------------------------------------------------------------------------
+# Issue #801 — bounding params + compact cap + type coercion
+# ---------------------------------------------------------------------------
+
+
+def _large_group_fixture_body() -> str:
+    """Generate 15 structurally identical 5-line functions for cap tests."""
+    parts = []
+    for i in range(15):
+        parts.append(
+            f"def func_{i:02d}(x):\n"
+            "    if x > 0:\n"
+            "        y = x * 2\n"
+            "        z = y + 1\n"
+            "        return z\n"
+            "    return 0\n\n"
+        )
+    return "".join(parts)
+
+
+@pytest.fixture
+def tool_with_large_group(tmp_path):
+    """Project with 15 structurally identical functions in one file."""
+    (tmp_path / "large.py").write_text(_large_group_fixture_body())
+    return CodeSimilarityTool(str(tmp_path))
+
+
+@pytest.mark.asyncio
+class TestBoundingParams801:
+    """Issue #801 — max_groups / functions-cap / type coercion."""
+
+    async def test_max_groups_limits_output(self, tool_with_clones):
+        """max_groups=1 must limit the groups list to exactly 1 entry."""
+        result = await tool_with_clones.execute(
+            {"output_format": "json", "max_groups": 1}
+        )
+        assert result["success"] is True
+        assert len(result["groups"]) == 1
+
+    async def test_max_groups_string_coercion(self, tool_with_clones):
+        """max_groups passed as a string (MCP transport) must be coerced to int."""
+        result = await tool_with_clones.execute(
+            {"output_format": "json", "max_groups": "1"}
+        )
+        assert result["success"] is True
+        assert len(result["groups"]) == 1
+
+    async def test_min_lines_string_coercion(self, tool_with_clones):
+        """min_lines passed as string must not crash — coerced to int."""
+        result = await tool_with_clones.execute(
+            {"output_format": "json", "min_lines": "5"}
+        )
+        assert result["success"] is True
+
+    async def test_min_group_size_string_coercion(self, tool_with_clones):
+        """min_group_size passed as string must not crash — coerced to int."""
+        result = await tool_with_clones.execute(
+            {"output_format": "json", "min_group_size": "2"}
+        )
+        assert result["success"] is True
+
+    async def test_compact_large_group_capped_at_10(self, tool_with_large_group):
+        """Compact mode (include_bodies=False) must cap functions[] to 10 entries."""
+        result = await tool_with_large_group.execute({"output_format": "json"})
+        assert result["success"] is True
+        groups = result["groups"]
+        assert len(groups) >= 1
+        for group in groups:
+            funcs = group["functions"]
+            assert len(funcs) == 10, (
+                f"Expected exactly 10 functions (capped); got {len(funcs)}"
+            )
+            assert group.get("truncated") is True, (
+                "truncated flag must be True when functions[] was capped"
+            )
+
+    async def test_include_bodies_true_not_capped(self, tool_with_large_group):
+        """include_bodies=True must NOT cap functions[] — all 15 returned."""
+        result = await tool_with_large_group.execute(
+            {"output_format": "json", "include_bodies": True}
+        )
+        assert result["success"] is True
+        groups = result["groups"]
+        assert len(groups) >= 1
+        max_funcs = max(len(g["functions"]) for g in groups)
+        assert max_funcs == 15, (
+            f"include_bodies=True should return all 15 functions; got max={max_funcs}"
+        )
+
+    async def test_no_truncated_flag_when_under_10(self, tool_with_clones):
+        """When group has <= 10 functions, truncated flag must be absent or False."""
+        result = await tool_with_clones.execute({"output_format": "json"})
+        assert result["success"] is True
+        for group in result["groups"]:
+            assert not group.get("truncated"), (
+                "truncated must not be set when functions count <= 10"
+            )
+
+
+class TestFacadeSchemaExposesSimilarityParams801:
+    """Issue #801 — similarity bounding params must be discoverable in the viz facade schema."""
+
+    def test_viz_facade_schema_exposes_max_groups(self):
+        """max_groups must appear in the viz facade's public schema."""
+        from tree_sitter_analyzer.mcp.tools.viz_facade import build_viz_facade
+
+        facade = build_viz_facade(project_root=None)
+        schema = facade.get_tool_schema()
+        assert "max_groups" in schema["properties"], (
+            "max_groups must be in viz facade schema for agent discoverability"
+        )
+
+    def test_viz_facade_schema_exposes_min_lines(self):
+        """min_lines must appear in the viz facade's public schema."""
+        from tree_sitter_analyzer.mcp.tools.viz_facade import build_viz_facade
+
+        facade = build_viz_facade(project_root=None)
+        schema = facade.get_tool_schema()
+        assert "min_lines" in schema["properties"], (
+            "min_lines must be in viz facade schema for agent discoverability"
+        )
+
+    def test_viz_facade_schema_exposes_min_group_size(self):
+        """min_group_size must appear in the viz facade's public schema."""
+        from tree_sitter_analyzer.mcp.tools.viz_facade import build_viz_facade
+
+        facade = build_viz_facade(project_root=None)
+        schema = facade.get_tool_schema()
+        assert "min_group_size" in schema["properties"], (
+            "min_group_size must be in viz facade schema for agent discoverability"
+        )
+
+
+@pytest.mark.asyncio
+class TestFacadeRoutesSimilarityParams801:
+    """Issue #801 — similarity params must route through the viz facade correctly."""
+
+    async def test_max_groups_via_facade(self, tmp_path):
+        """max_groups=1 passed via viz facade must limit groups to exactly 1."""
+        from tree_sitter_analyzer.mcp.tools.viz_facade import build_viz_facade
+
+        (tmp_path / "a.py").write_text(_large_group_fixture_body())
+        facade = build_viz_facade(str(tmp_path))
+        result = await facade.execute(
+            {"action": "similarity", "output_format": "json", "max_groups": 1}
+        )
+        assert result["success"] is True
+        assert len(result["groups"]) == 1

--- a/tree_sitter_analyzer/mcp/tools/code_similarity_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/code_similarity_tool.py
@@ -115,9 +115,10 @@ class CodeGraphSimilarityTool(BaseMCPTool):
             }
 
         mode = arguments.get("mode", "all")
-        min_lines = arguments.get("min_lines", 5)
-        min_group_size = arguments.get("min_group_size", 2)
-        max_groups = arguments.get("max_groups", 20)
+        # Coerce int params — MCP transport may deliver them as strings (#801).
+        min_lines = int(arguments.get("min_lines", 5))
+        min_group_size = int(arguments.get("min_group_size", 2))
+        max_groups = int(arguments.get("max_groups", 20))
         use_cache = arguments.get("use_cache", True)
         include_bodies = arguments.get("include_bodies", False)
         output_format = arguments.get("output_format", "toon")
@@ -148,12 +149,26 @@ class CodeGraphSimilarityTool(BaseMCPTool):
         else:
             verdict = "CAUTION"
 
+        # Cap functions[] per group in compact mode to prevent token overflow (#801).
+        # include_bodies=True is opt-in for large output; compact default must stay bounded.
+        _COMPACT_FUNCTIONS_CAP = 10
+
+        def _group_to_dict(group: Any) -> dict[str, Any]:
+            d: dict[str, Any] = group.to_dict(include_bodies=include_bodies)
+            if (
+                not include_bodies
+                and len(d.get("functions", [])) > _COMPACT_FUNCTIONS_CAP
+            ):
+                d["functions"] = d["functions"][:_COMPACT_FUNCTIONS_CAP]
+                d["truncated"] = True
+            return d
+
         response: dict[str, Any] = {
             "success": True,
             "verdict": verdict,
             "project_root": self.project_root,
             "stats": result.stats,
-            "groups": [g.to_dict(include_bodies=include_bodies) for g in result.groups],
+            "groups": [_group_to_dict(g) for g in result.groups],
         }
 
         from ..utils.format_helper import apply_toon_format_to_response

--- a/tree_sitter_analyzer/mcp/tools/viz_facade.py
+++ b/tree_sitter_analyzer/mcp/tools/viz_facade.py
@@ -51,6 +51,25 @@ _VIZ_DESCRIPTION = (
 )
 
 
+# Similarity bounding params surfaced explicitly on the viz facade public schema
+# (#801: agents must be able to discover these to bound output size).
+# Wave D token-diet rule: only the most agent-critical params; terse descriptions.
+_VIZ_SIMILARITY_PARAMS: dict[str, dict] = {
+    "max_groups": {
+        "type": "integer",
+        "description": "action=similarity: max clone groups to return (default: 20).",
+    },
+    "min_lines": {
+        "type": "integer",
+        "description": "action=similarity: min function body lines to consider (default: 5).",
+    },
+    "min_group_size": {
+        "type": "integer",
+        "description": "action=similarity: min clone group size to report (default: 2).",
+    },
+}
+
+
 def build_viz_facade(project_root: str | None = None) -> FacadeTool:
     """Construct the ``viz`` facade wired to live inner tool instances.
 
@@ -73,5 +92,6 @@ def build_viz_facade(project_root: str | None = None) -> FacadeTool:
         description=_VIZ_DESCRIPTION,
         annotations=_VIZ_ANNOTATIONS,
         project_root=project_root,
+        extra_public_params=_VIZ_SIMILARITY_PARAMS,
     )
     return facade


### PR DESCRIPTION
## Summary

- **Root cause 1 (schema gap):** `viz` facade schema didn't surface `max_groups`/`min_lines`/`min_group_size` in its public schema. Agents couldn't discover them; passing them via `additionalProperties` worked but crashed with int/str type errors in the inner tool.
- **Root cause 2 (unbounded output):** Compact default (`include_bodies=False`) returned all instances per group — e.g. 59 instances in a single structural group — yielding 59k-char responses rejected with "result exceeds maximum allowed tokens".

### Changes

- **`facade_tool.py`**: Add `extra_public_params` kwarg so any facade can surface action-specific params in its public schema without unioning all inner params (Wave D token-diet stands).
- **`viz_facade.py`**: Register `max_groups`/`min_lines`/`min_group_size` as `extra_public_params` so agents can discover and pass them.
- **`code_similarity_tool.py`**:
  - Coerce `max_groups`/`min_lines`/`min_group_size` to `int` — MCP transport delivers them as strings.
  - Cap `functions[]` per group to **10 entries** in compact mode (`include_bodies=False`), adding `"truncated": true` when capped. `include_bodies=True` is unaffected.

## Test plan

- [x] RED-first: 7 new tests failed before implementation
- [x] GREEN: all 40 tests pass (`tests/unit/test_codegraph_similarity_tool.py` + `tests/unit/mcp/tools/test_viz_facade.py`)
- [x] ruff + mypy clean
- [x] All pre-commit hooks pass

**New assertions (exact, per CLAUDE.md exact-assertion rule):**
- `assert len(result["groups"]) == 1` — max_groups=1 limits output
- `assert len(result["groups"]) == 1` — string "1" coerced to int correctly
- `assert len(funcs) == 10` — compact cap is exactly 10
- `assert group.get("truncated") is True` — truncated flag set when capped
- `assert max_funcs == 15` — include_bodies=True not capped
- `assert "max_groups" in schema["properties"]` — facade schema discoverable

Closes #801