### PR TITLE
fix(python,structure): nested return_type bleed + class_tree mode aliases/validation

### DIFF
--- a/tests/unit/test_bugs_792_802_803.py
+++ b/tests/unit/test_bugs_792_802_803.py
@@ -1,0 +1,185 @@
+"""
+RED tests for bugs #792, #802, #803.
+
+#792 — Python: parent function inherits nested function's return_type.
+#802 — class_tree mode=supers/parents/subs aliases not recognized.
+#803 — 'Unknown mode' errors classified as 'internal' not 'validation',
+        and the error message doesn't enumerate valid modes.
+"""
+
+from __future__ import annotations
+
+import pytest
+import tree_sitter
+
+from tree_sitter_analyzer.languages.python_plugin import (
+    PythonElementExtractor,
+    PythonPlugin,
+)
+from tree_sitter_analyzer.mcp.tools.class_hierarchy_tool import ClassHierarchyTool
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_python(code: str):
+    """Parse Python source with tree-sitter and return the tree."""
+    plugin = PythonPlugin()
+    language = plugin.get_tree_sitter_language()
+    parser = tree_sitter.Parser()
+    if hasattr(parser, "set_language"):
+        parser.set_language(language)
+    elif hasattr(parser, "language"):
+        parser.language = language
+    else:
+        parser = tree_sitter.Parser(language)
+    return parser.parse(code.encode("utf-8"))
+
+
+def _stub_tool(tmp_path) -> ClassHierarchyTool:
+    """Build a ClassHierarchyTool with a minimal stub hierarchy."""
+    from tree_sitter_analyzer.class_hierarchy import ClassHierarchy, ClassInfo
+
+    tool = ClassHierarchyTool(str(tmp_path))
+
+    hierarchy = ClassHierarchy(cache=None)
+    for name, parents in {"Child": ["Parent"], "Parent": []}.items():
+        hierarchy._classes[name].append(
+            ClassInfo(
+                name=name,
+                file="m.py",
+                line=1,
+                end_line=2,
+                language="python",
+                parents=parents,
+            )
+        )
+        for p in parents:
+            hierarchy._parent_map[name].append(p)
+            hierarchy._children[p].append(name)
+    hierarchy._built = True
+    tool._hierarchy = hierarchy
+    return tool
+
+
+# ---------------------------------------------------------------------------
+# Bug #792 — nested function's return_type must NOT bleed to parent
+# ---------------------------------------------------------------------------
+
+
+class TestNestedFunctionReturnTypeBleed:
+    """#792: outer() has no annotation; inner() -> str must not bleed."""
+
+    SOURCE = """\
+def outer(x):
+    def inner(y) -> str:
+        return str(y)
+    return inner(x)
+"""
+
+    def test_outer_does_not_inherit_inner_return_type(self):
+        """outer() has no annotation — its return_type must NOT be 'str'
+        (inherited from inner).  The builder defaults unannotated functions to
+        'Any', so the expected value is 'Any' not 'str'."""
+        extractor = PythonElementExtractor()
+        tree = _parse_python(self.SOURCE)
+        functions = extractor.extract_functions(tree, self.SOURCE)
+        outer_funcs = [f for f in functions if f.name == "outer"]
+        assert len(outer_funcs) == 1, f"Expected 1 outer function, got {outer_funcs}"
+        outer_return = outer_funcs[0].return_type
+        assert outer_return != "str", (
+            f"outer.return_type must NOT be 'str' (inherited from inner), got {outer_return!r}"
+        )
+        # The builder converts None -> 'Any' for unannotated Python functions.
+        assert outer_return == "Any", (
+            f"outer.return_type should be 'Any' (unannotated), got {outer_return!r}"
+        )
+
+    def test_inner_return_type_is_preserved(self):
+        """Inner function's own annotation must still be captured correctly."""
+        extractor = PythonElementExtractor()
+        tree = _parse_python(self.SOURCE)
+        functions = extractor.extract_functions(tree, self.SOURCE)
+        inner_funcs = [f for f in functions if f.name == "inner"]
+        assert len(inner_funcs) == 1, f"Expected 1 inner function, got {inner_funcs}"
+        assert inner_funcs[0].return_type == "str", (
+            f"inner.return_type should be 'str', got {inner_funcs[0].return_type!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Bug #802 — mode aliases: supers, parents, subs
+# ---------------------------------------------------------------------------
+
+
+class TestClassTreeModeAliases:
+    """#802: mode=supers/parents must be treated as mode=superclasses;
+    mode=subs must be treated as mode=subclasses."""
+
+    @pytest.mark.asyncio
+    async def test_mode_supers_is_alias_for_superclasses(self, tmp_path):
+        tool = _stub_tool(tmp_path)
+        result = await tool.execute(
+            {"mode": "supers", "class_name": "Child", "output_format": "json"}
+        )
+        assert result.get("success") is True, f"Expected success, got: {result}"
+        assert result.get("mode") == "superclasses", (
+            f"mode should be 'superclasses', got {result.get('mode')!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_mode_parents_is_alias_for_superclasses(self, tmp_path):
+        tool = _stub_tool(tmp_path)
+        result = await tool.execute(
+            {"mode": "parents", "class_name": "Child", "output_format": "json"}
+        )
+        assert result.get("success") is True, f"Expected success, got: {result}"
+        assert result.get("mode") == "superclasses", (
+            f"mode should be 'superclasses', got {result.get('mode')!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_mode_subs_is_alias_for_subclasses(self, tmp_path):
+        tool = _stub_tool(tmp_path)
+        result = await tool.execute(
+            {"mode": "subs", "class_name": "Parent", "output_format": "json"}
+        )
+        assert result.get("success") is True, f"Expected success, got: {result}"
+        assert result.get("mode") == "subclasses", (
+            f"mode should be 'subclasses', got {result.get('mode')!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Bug #803 — unknown mode error must be validation, list valid modes
+# ---------------------------------------------------------------------------
+
+
+class TestClassTreeUnknownModeValidation:
+    """#803: unknown mode returns error with error_type='validation' and
+    a message that enumerates valid modes."""
+
+    @pytest.mark.asyncio
+    async def test_unknown_mode_error_lists_valid_modes(self, tmp_path):
+        tool = _stub_tool(tmp_path)
+        result = await tool.execute(
+            {"mode": "bogus_mode", "class_name": "Child", "output_format": "json"}
+        )
+        assert result.get("success") is False, f"Expected failure, got: {result}"
+        error_msg = result.get("error", "")
+        assert "Valid modes" in error_msg, (
+            f"Error message should list valid modes, got: {error_msg!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_unknown_mode_error_type_is_validation(self, tmp_path):
+        tool = _stub_tool(tmp_path)
+        result = await tool.execute(
+            {"mode": "bogus_mode", "class_name": "Child", "output_format": "json"}
+        )
+        assert result.get("success") is False
+        error_type = result.get("error_type", "")
+        assert error_type == "validation", (
+            f"error_type should be 'validation', got {error_type!r}"
+        )

--- a/tree_sitter_analyzer/languages/python_plugin/_function_extractor_mixin.py
+++ b/tree_sitter_analyzer/languages/python_plugin/_function_extractor_mixin.py
@@ -157,10 +157,19 @@ class PythonFunctionExtractionMixin:
             return None
 
     def _extract_return_type_from_node(self, node: Any, source_code: str) -> str | None:
-        """Extract return type annotation from function node."""
+        """Extract return type annotation from function node.
+
+        Only the *def line* (first line of the node text) is scanned for
+        ``->``.  Scanning the full body text causes nested-function annotations
+        (e.g. ``inner(y) -> str``) to bleed into the parent function's
+        ``return_type`` when the parent has no annotation (#792).
+        """
         node_text = self._get_node_text_optimized(node)
-        if "->" in node_text:
-            parts = node_text.split("->")
+        # Restrict to the first line only — the def signature ends at the ':'
+        # that closes the header; everything after is the function body.
+        def_line = node_text.split("\n")[0]
+        if "->" in def_line:
+            parts = def_line.split("->")
             if len(parts) > 1:
                 return_part = parts[1].split(":")[0].strip()
                 return_type = return_part.replace("\n", " ").strip()

--- a/tree_sitter_analyzer/languages/python_plugin/_signature_helpers.py
+++ b/tree_sitter_analyzer/languages/python_plugin/_signature_helpers.py
@@ -92,10 +92,20 @@ def _extract_superclass_names(argument_list_node: Any) -> list[str]:
 
 
 def _return_type_from_signature_text(node_text: str) -> str | None:
-    if "->" not in node_text:
+    """Extract the return-type annotation from a Python function's text.
+
+    Only the first line (the def line) is inspected so that a nested
+    function's annotation (e.g. ``inner(y) -> str``) cannot bleed into the
+    parent's return type when the parent has no annotation (#792).
+    """
+    # Restrict to the first line — the function signature ends at the ':'
+    # that closes the header; the body (including any nested functions with
+    # their own '->') starts on subsequent lines.
+    first_line = node_text.split("\n")[0]
+    if "->" not in first_line:
         return None
 
-    parts = node_text.split("->")
+    parts = first_line.split("->")
     if len(parts) <= 1:
         return None
 

--- a/tree_sitter_analyzer/mcp/tools/class_hierarchy_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/class_hierarchy_tool.py
@@ -112,8 +112,23 @@ class ClassHierarchyTool(BaseMCPTool):
             "additionalProperties": False,
         }
 
-    @staticmethod
-    def _resolve_mode(arguments: dict[str, Any]) -> str:
+    # Canonical mode names and short aliases (#802).
+    _MODE_ALIASES: dict[str, str] = {
+        "supers": "superclasses",
+        "parents": "superclasses",
+        "subs": "subclasses",
+    }
+    _VALID_MODES: tuple[str, ...] = (
+        "subclasses",
+        "superclasses",
+        "tree",
+        "impact",
+        "all",
+        "summary",
+    )
+
+    @classmethod
+    def _resolve_mode(cls, arguments: dict[str, Any]) -> str:
         """Effective query mode.
 
         When the caller did not specify a mode, default to a CLASS-SCOPED view
@@ -123,11 +138,15 @@ class ClassHierarchyTool(BaseMCPTool):
         mode ignores ``class_name`` and returns a confident project-wide result
         for a class that may not even exist. ``tree`` instead returns
         ``NOT_FOUND`` for an unknown class.
+
+        Short aliases (``supers``, ``parents``, ``subs``) are normalised to
+        their canonical forms (#802).
         """
         mode = arguments.get("mode")
-        if mode:
-            return str(mode)
-        return "tree" if arguments.get("class_name") else "summary"
+        if not mode:
+            return "tree" if arguments.get("class_name") else "summary"
+        mode = str(mode)
+        return cls._MODE_ALIASES.get(mode, mode)
 
     def validate_arguments(self, arguments: dict[str, Any]) -> bool:
         mode = self._resolve_mode(arguments)
@@ -245,9 +264,11 @@ class ClassHierarchyTool(BaseMCPTool):
                 **hierarchy.summary(),
             }
         else:
+            valid = ", ".join(self._VALID_MODES)
             response = {
                 "success": False,
-                "error": f"Unknown mode: {mode}",
+                "error": f"Unknown mode: '{mode}'. Valid modes: {valid}",
+                "error_type": "validation",
                 "verdict": "ERROR",
             }
 


### PR DESCRIPTION
## Summary

- **#792** — Python extractor: outer function with no return annotation was inheriting `return_type='str'` from a nested inner function (`inner(y) -> str`). Root cause: `_return_type_from_signature_text` and `_extract_return_type_from_node` both split the **full function body text** on `->`, which includes the body and any nested function annotations. Fix: restrict the scan to the **first line** of `node_text` only (the `def` line), so nested function annotations never bleed into the parent's return type.

- **#802** — `class_tree mode=supers` / `mode=parents` / `mode=subs` returned `Unknown mode`. Fix: add `_MODE_ALIASES` dict in `ClassHierarchyTool._resolve_mode` mapping `supers → superclasses`, `parents → superclasses`, `subs → subclasses`.

- **#803** — Unknown mode errors in `class_tree` returned no `error_type` field and gave no hint of valid modes. Fix: the `else` branch now sets `error_type="validation"` and formats the message as `"Unknown mode: '...'. Valid modes: subclasses, superclasses, tree, impact, all, summary"`.

## Files changed

- `tree_sitter_analyzer/languages/python_plugin/_signature_helpers.py` — `_return_type_from_signature_text` scans first line only
- `tree_sitter_analyzer/languages/python_plugin/_function_extractor_mixin.py` — `_extract_return_type_from_node` scans first line only
- `tree_sitter_analyzer/mcp/tools/class_hierarchy_tool.py` — `_MODE_ALIASES`, updated `_resolve_mode`, validation error with `error_type` and valid-modes list
- `tests/unit/test_bugs_792_802_803.py` — 7 new tests (6 were RED before the fix, 1 for inner preservation)

## Test plan

- [x] 7 new tests all GREEN (`tests/unit/test_bugs_792_802_803.py`)
- [x] 225 Python language unit tests GREEN (`tests/unit/languages/ -k python`)
- [x] 28 class hierarchy tests GREEN (`tests/unit/test_codegraph_class_hierarchy_tool.py`)
- [x] 569 structure/hierarchy/class tests GREEN
- [x] Python golden master regression passes unchanged
- [x] Pre-commit hooks (ruff, mypy, bandit) all pass
- [ ] Pre-existing `test_swift_full_table_matches_golden_master` failure — confirmed pre-existing on `develop` before this branch, unrelated to Python/class-hierarchy changes

Closes #792, closes #802, closes #803