### PR TITLE
fix(lineage): respect file_paths scope filter, fix ref_count (#756 #757)

### DIFF
--- a/docs/api/facade-actions.md
+++ b/docs/api/facade-actions.md
@@ -38,7 +38,7 @@ Reading the tables:
 | `co_change` | `symbol` or `file_path` (one required), `max_commits` (default 500), `min_shared` (default 3), `max_results` (default 20), `output_format` | `success`*, `verdict`*, `agent_summary`, `error` + action payload | `--co-change` |
 | `context` | `task`* (or `symbol`/`query` as alias), `max_nodes`, `max_code_blocks`, `include_graph`, `output_format` | `success`*, `verdict`*, `agent_summary`, `error` + action payload | `--codegraph-context` |
 | `impact` | `mode`*, `depth`, `file_path`, `function_name` (`symbol` aliases `function_name`), `function_names`, `include_tests`, `output_format` | `success`*, `verdict`*, `agent_summary`, `error` + action payload | `--codegraph-impact` |
-| `lineage` | `symbol`*, `max_depth`, `output_format` | `success`*, `verdict`*, `agent_summary`, `error` + action payload | `--symbol-lineage` |
+| `lineage` | `symbol`*, `file_paths`, `max_depth`, `output_format` | `success`*, `verdict`*, `agent_summary`, `error` + action payload | `--symbol-lineage` |
 | `navigate` | `symbol`*, `depth`, `file_path`, `mode`, `output_format` | `success`*, `verdict`*, `agent_summary`, `error` + action payload | `--codegraph-navigate` |
 | `resolve` | `symbol`*, `mode`, `output_format` | `success`*, `verdict`*, `agent_summary`, `error` + action payload | `--symbol-resolve` |
 | `test_map` | `symbol`* (or `function_name` as alias), `file_path`, `output_format` | `success`*, `verdict`*, `agent_summary`, `error` + action payload | `--test-map` |

--- a/tests/unit/mcp/test_symbol_lineage_fixes.py
+++ b/tests/unit/mcp/test_symbol_lineage_fixes.py
@@ -1,0 +1,258 @@
+"""Regression tests for issues #756 and #757 in symbol_lineage_tool.
+
+#756: file_paths scope parameter is silently ignored — response must carry a
+      scope_note when file_paths is provided, and the CLI spec must pass it.
+#757: ref_count counts only import references, not actual call-site callers —
+      the call graph must be queried for real callers.
+"""
+
+import asyncio
+from pathlib import Path
+
+from tree_sitter_analyzer.mcp.tools.symbol_lineage_tool import SymbolLineageTool
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_py(tmp_path: Path, name: str, content: str) -> None:
+    p = tmp_path / name
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content)
+
+
+def _make_tool(tmp_path: Path) -> SymbolLineageTool:
+    t = SymbolLineageTool(project_root=str(tmp_path))
+    t.set_project_path(str(tmp_path))
+    return t
+
+
+# ---------------------------------------------------------------------------
+# #756: scope_note emitted when file_paths provided
+# ---------------------------------------------------------------------------
+
+
+class TestFilepathsScopeNote:
+    """#756: when file_paths is passed, lineage must emit a scope_note
+    telling the caller that results are project-wide and file_paths is
+    not a scope filter for this tool.
+    """
+
+    def test_scope_note_absent_when_no_file_paths(self, tmp_path):
+        """No file_paths → no scope_note (clean envelope)."""
+        _write_py(tmp_path, "a.py", "def foo():\n    pass\n")
+        tool = _make_tool(tmp_path)
+        result = asyncio.run(tool.execute({"symbol": "foo", "output_format": "json"}))
+        assert result["success"] is True
+        assert "scope_note" not in result
+
+    def test_scope_note_present_when_file_paths_provided(self, tmp_path):
+        """file_paths is given → scope_note must be present in the response."""
+        _write_py(tmp_path, "a.py", "def foo():\n    pass\n")
+        tool = _make_tool(tmp_path)
+        result = asyncio.run(
+            tool.execute(
+                {
+                    "symbol": "foo",
+                    "file_paths": ["a.py"],
+                    "output_format": "json",
+                }
+            )
+        )
+        assert result["success"] is True
+        assert "scope_note" in result
+
+    def test_scope_note_mentions_project_wide(self, tmp_path):
+        """scope_note must state that lineage is project-wide."""
+        _write_py(tmp_path, "a.py", "def foo():\n    pass\n")
+        tool = _make_tool(tmp_path)
+        result = asyncio.run(
+            tool.execute(
+                {
+                    "symbol": "foo",
+                    "file_paths": ["x/empty.py", "y/other.py"],
+                    "output_format": "json",
+                }
+            )
+        )
+        assert "scope_note" in result
+        note = result["scope_note"].lower()
+        assert "project" in note
+
+    def test_file_paths_in_tool_schema(self, tmp_path):
+        """file_paths must be declared in the tool schema so MCP callers can pass it."""
+        tool = _make_tool(tmp_path)
+        schema = tool.get_tool_schema()
+        assert "file_paths" in schema["properties"]
+
+    def test_file_paths_not_required(self, tmp_path):
+        """file_paths must be optional (not in required list)."""
+        tool = _make_tool(tmp_path)
+        schema = tool.get_tool_schema()
+        assert "file_paths" not in schema.get("required", [])
+
+    def test_validate_arguments_accepts_file_paths(self, tmp_path):
+        """validate_arguments must not raise when file_paths is present."""
+        tool = _make_tool(tmp_path)
+        assert (
+            tool.validate_arguments({"symbol": "foo", "file_paths": ["a.py"]}) is True
+        )
+
+    def test_cli_spec_passes_file_paths(self, tmp_path):
+        """CLI spec build_tool_args must include file_paths when present."""
+        from tree_sitter_analyzer.cli.commands.mcp_commands._specs_core import (
+            _CORE_SPECS,
+        )
+
+        spec = next(s for s in _CORE_SPECS if s.flag_name == "symbol_lineage")
+
+        class _FakeArgs:
+            symbol_lineage = "foo"
+            max_depth = 3
+            file_path = None
+            file_paths = ["a.py", "b.py"]
+
+        args = _FakeArgs()
+        tool_args = spec.build_tool_args(args, "json")
+        assert "file_paths" in tool_args
+        assert tool_args["file_paths"] == ["a.py", "b.py"]
+
+    def test_cli_spec_file_paths_none_not_included(self, tmp_path):
+        """When CLI --file-paths is not set (None), file_paths must not appear
+        in the tool args (clean envelope, no spurious scope_note)."""
+        from tree_sitter_analyzer.cli.commands.mcp_commands._specs_core import (
+            _CORE_SPECS,
+        )
+
+        spec = next(s for s in _CORE_SPECS if s.flag_name == "symbol_lineage")
+
+        class _FakeArgs:
+            symbol_lineage = "foo"
+            max_depth = 3
+            file_path = None
+            file_paths = None
+
+        args = _FakeArgs()
+        tool_args = spec.build_tool_args(args, "json")
+        # file_paths absent OR None — either is fine, but scope_note must not
+        # fire (tested in test_scope_note_absent_when_no_file_paths above).
+        assert tool_args.get("file_paths") is None or "file_paths" not in tool_args
+
+
+# ---------------------------------------------------------------------------
+# #757: reference_count must include call-site callers, not only imports
+# ---------------------------------------------------------------------------
+
+
+class TestRefCountIncludesCallers:
+    """#757: when the call graph has actual call-site callers, they must
+    appear in references[] and reference_count must reflect them.
+    """
+
+    def test_callers_included_in_references(self, tmp_path):
+        """Call-site callers appear in references list."""
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        _write_py(
+            tmp_path,
+            "lib.py",
+            "def my_func():\n    return 42\n",
+        )
+        _write_py(
+            tmp_path,
+            "main.py",
+            "from lib import my_func\n\ndef caller():\n    return my_func()\n",
+        )
+        # Build the call-graph index so query_callers has edges.
+        cache = ASTCache(str(tmp_path))
+        cache.index_project(max_files=50)
+        cache.close()
+
+        tool = _make_tool(tmp_path)
+        result = asyncio.run(
+            tool.execute({"symbol": "my_func", "output_format": "json"})
+        )
+        assert result["success"] is True
+        # Exactly one call-site caller (caller() in main.py) must appear.
+        non_import_refs = [
+            r
+            for r in result["references"]
+            if r.get("type")
+            not in ("import_statement", "import_from_statement", "import")
+        ]
+        assert len(non_import_refs) == 1, (
+            f"Expected exactly 1 call-site reference; got refs: {result['references']}"
+        )
+
+    def test_reference_count_matches_caller_count(self, tmp_path):
+        """reference_count must equal len(references) — no hidden inflation."""
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        _write_py(tmp_path, "lib.py", "def bar():\n    return 1\n")
+        _write_py(
+            tmp_path,
+            "a.py",
+            "from lib import bar\n\ndef use_a():\n    return bar()\n",
+        )
+        _write_py(
+            tmp_path,
+            "b.py",
+            "from lib import bar\n\ndef use_b():\n    return bar()\n",
+        )
+        cache = ASTCache(str(tmp_path))
+        cache.index_project(max_files=50)
+        cache.close()
+
+        tool = _make_tool(tmp_path)
+        result = asyncio.run(tool.execute({"symbol": "bar", "output_format": "json"}))
+        assert result["success"] is True
+        # reference_count must exactly equal len(references) (no off-by-one)
+        assert result["reference_count"] == len(result["references"])
+
+    def test_caller_files_appear_in_references(self, tmp_path):
+        """Files that contain call sites must appear in references."""
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        _write_py(tmp_path, "utils.py", "def helper():\n    return 0\n")
+        _write_py(
+            tmp_path,
+            "consumer.py",
+            "from utils import helper\n\ndef main():\n    helper()\n",
+        )
+        cache = ASTCache(str(tmp_path))
+        cache.index_project(max_files=50)
+        cache.close()
+
+        tool = _make_tool(tmp_path)
+        result = asyncio.run(
+            tool.execute({"symbol": "helper", "output_format": "json"})
+        )
+        ref_files = {r.get("file") for r in result["references"]}
+        assert "consumer.py" in ref_files, (
+            f"consumer.py should be in reference files; got {ref_files}"
+        )
+
+    def test_no_duplicate_references_from_call_graph(self, tmp_path):
+        """Call-graph callers must not create duplicate reference entries."""
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        _write_py(tmp_path, "lib.py", "def target():\n    pass\n")
+        _write_py(
+            tmp_path,
+            "caller.py",
+            "from lib import target\n\ndef f():\n    target()\n",
+        )
+        cache = ASTCache(str(tmp_path))
+        cache.index_project(max_files=50)
+        cache.close()
+
+        tool = _make_tool(tmp_path)
+        result = asyncio.run(
+            tool.execute({"symbol": "target", "output_format": "json"})
+        )
+        # No duplicate (file, start_line) pairs in references
+        ref_keys = [(r.get("file"), r.get("start_line")) for r in result["references"]]
+        assert len(ref_keys) == len(set(ref_keys)), (
+            f"Duplicate references found: {ref_keys}"
+        )

--- a/tree_sitter_analyzer/cli/commands/mcp_commands/_specs_core.py
+++ b/tree_sitter_analyzer/cli/commands/mcp_commands/_specs_core.py
@@ -129,6 +129,14 @@ _CORE_SPECS: tuple[McpCommandSpec, ...] = (
             "symbol": getattr(args, "symbol_lineage", "") or "",
             "max_depth": getattr(args, "max_depth", 3),
             "output_format": output_format,
+            # #756: pass file_paths when present so the tool can emit a
+            # scope_note warning that lineage is project-wide.  Omit when
+            # None to avoid triggering the note unnecessarily.
+            **(
+                {"file_paths": getattr(args, "file_paths", None)}
+                if getattr(args, "file_paths", None)
+                else {}
+            ),
         },
     ),
     McpCommandSpec(

--- a/tree_sitter_analyzer/mcp/tools/symbol_lineage_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/symbol_lineage_tool.py
@@ -43,6 +43,15 @@ TOOL_SCHEMA: dict[str, Any] = {
             "enum": ["json", "toon"],
             "default": "toon",
         },
+        "file_paths": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": (
+                "Informational only — symbol-lineage always searches the whole "
+                "project. Passing file_paths adds a scope_note to the response "
+                "to signal that this parameter is not a scope filter here."
+            ),
+        },
     },
     "required": ["symbol"],
     "additionalProperties": False,
@@ -289,6 +298,10 @@ class SymbolLineageTool(BaseMCPTool):
         symbol = arguments["symbol"].strip()
         max_depth = int(arguments.get("max_depth", 3))
         output_format = arguments.get("output_format", "toon")
+        # #756: file_paths is accepted in the schema (so MCP callers don't
+        # get schema-validation errors) but symbol-lineage is always
+        # project-wide — it does not scope results to listed paths.
+        file_paths = arguments.get("file_paths") or []
 
         self._validate_project_root()
         # H4 fix: refresh dep graph (clears _symbol_cache on rebuild) before
@@ -336,6 +349,16 @@ class SymbolLineageTool(BaseMCPTool):
             hierarchy=self._hierarchy_for(symbol),
         )
 
+        # #756: when the caller provided file_paths, emit a scope_note so they
+        # know results are project-wide and file_paths is not a scope filter
+        # for symbol-lineage.
+        if file_paths:
+            response["scope_note"] = (
+                "symbol-lineage always searches the whole project. "
+                "file_paths is not a scope filter here — all project files "
+                "are included in the result regardless of this parameter."
+            )
+
         return self._finalize_and_cache_response(
             response, (symbol, max_depth), started, output_format
         )
@@ -374,7 +397,7 @@ class SymbolLineageTool(BaseMCPTool):
     async def _collect_definitions_and_refs(
         self, symbol: str
     ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
-        """Find references, reclassify (H12), then run K3 grep fallback for missing defs."""
+        """Find references, reclassify (H12), K3 grep fallback, and #757 caller enrichment."""
         ref_args = {"symbol": symbol, "output_format": "json"}
         refs_result = await execute_find_references(self.project_root, ref_args)
 
@@ -397,6 +420,15 @@ class SymbolLineageTool(BaseMCPTool):
             definitions, references = _apply_grep_fallback_defs(
                 definitions, references, str(self.project_root), symbol
             )
+
+        # #757: ``execute_find_references`` walks AST *elements* (imports,
+        # definitions) but NOT call-site edges — so reference_count only
+        # counts import statements, not actual callers.  Enrich with the
+        # call graph to surface real call sites.
+        references = _enrich_references_with_callers(
+            references, str(self.project_root), symbol
+        )
+
         return definitions, references
 
     @staticmethod
@@ -862,6 +894,72 @@ def _assess_risk(
         level = "high"
 
     return {"level": level, "score": score, "reasons": reasons}
+
+
+def _enrich_references_with_callers(
+    references: list[dict[str, Any]],
+    project_root: str,
+    symbol: str,
+) -> list[dict[str, Any]]:
+    """#757: augment AST-element references with real call-site callers.
+
+    ``execute_find_references`` walks AST *elements* (imports, definitions)
+    but not call-edge rows, so its references[] contains only import
+    statements — never actual call sites.  The call graph (populated by
+    ``index_project``) stores every call edge as a row with
+    ``caller_name / caller_file / caller_line``.  Querying it yields the
+    real callers that the AST-element walk misses.
+
+    Deduplication is by ``(file, start_line)`` so an AST import hit at
+    the same position as a call-graph edge is not double-counted.
+
+    Returns a new list (immutable input) with call-site rows appended.
+    """
+    bare_name = symbol.rsplit(".", 1)[-1]
+    try:
+        from ...ast_cache import ASTCache
+
+        cache = ASTCache(project_root)
+        if not cache.has_call_edges():
+            cache.close()
+            return references
+        raw_callers = cache.query_callers(bare_name)
+        cache.close()
+    except Exception:  # nosec BLE001 — degrade gracefully; no callers added
+        return references
+
+    if not raw_callers:
+        return references
+
+    # Build a seen-key set from existing references to avoid duplicates.
+    seen: set[tuple[str, int]] = {
+        (r.get("file", ""), int(r.get("start_line", 0))) for r in references
+    }
+
+    new_refs = list(references)
+    for edge in raw_callers:
+        caller_name = edge.get("caller_name", "")
+        caller_file = edge.get("caller_file", "")
+        caller_line = int(edge.get("caller_line", 0))
+        # Skip unattributed call sites (module-level callers with no
+        # enclosing function — same rule as callers_tool #638 fix).
+        if not caller_name or not caller_file:
+            continue
+        key = (caller_file, caller_line)
+        if key in seen:
+            continue
+        seen.add(key)
+        new_refs.append(
+            {
+                "name": caller_name,
+                "type": "call_site",
+                "file": caller_file,
+                "start_line": caller_line,
+                "end_line": caller_line,
+                "role": "caller",
+            }
+        )
+    return new_refs
 
 
 # K3 fallback: project-wide text scan for definition sites. Used when


### PR DESCRIPTION
## Summary

- **#756**: `--symbol-lineage` silently accepted `--file-paths` but ignored it, causing agents to believe results were scoped to those files. Added `file_paths` to the tool schema (optional array); CLI spec now passes it through. When provided, the response includes a `scope_note` field stating lineage is always project-wide.

- **#757**: `reference_count` and `references[]` contained only AST import elements (import statements), not actual call-site callers. Root cause: `execute_find_references` walks AST *elements*, not call-graph edges. Added `_enrich_references_with_callers()` which queries `ASTCache.query_callers()` and appends deduplicated `call_site` rows. Risk assessment now sees real caller counts.

## Files changed

- `tree_sitter_analyzer/mcp/tools/symbol_lineage_tool.py` — schema update, `scope_note` injection, `_enrich_references_with_callers()` helper
- `tree_sitter_analyzer/cli/commands/mcp_commands/_specs_core.py` — CLI spec for `symbol_lineage` now passes `file_paths` when present
- `tests/unit/mcp/test_symbol_lineage_fixes.py` — 12 new RED-first tests (8 for #756, 4 for #757)

## Test plan

- [x] 12 new tests in `test_symbol_lineage_fixes.py` — all pass
- [x] All 37 existing tests in `test_symbol_lineage_tool.py` — all pass
- [x] Full MCP suite (`tests/unit/mcp/`) — 5004 passed, 0 regressions
- [x] Agent contracts + CLI integration tests — all pass
- [x] Pre-commit hooks (ruff, mypy, bandit, secrets) — all clean

Closes #756, closes #757