### PR TITLE
fix(c,cpp): nested struct extraction, typedef dedup, anonymous container naming (#751 #752 #753)

### DIFF
--- a/tests/golden_masters/full/c_sample_full.md
+++ b/tests/golden_masters/full/c_sample_full.md
@@ -14,6 +14,8 @@
 | Status | enum | public | 27-31 | 0 | 0 |
 | Point | struct | public | 34-37 | 0 | 2 |
 | Rectangle | struct | public | 40-43 | 0 | 2 |
+| Point | struct | public | 41-41 | 0 | 1 |
+| Point | struct | public | 42-42 | 0 | 1 |
 | Number | union | public | 46-50 | 0 | 3 |
 | Person | struct | public | 53-56 | 0 | 2 |
 
@@ -31,6 +33,18 @@
 | Name | Type | Vis | Modifiers | Line | Doc |
 |------|------|-----|-----------|------|-----|
 | top_left | struct Point | + |  | 41 | - |
+| bottom_right | struct Point | + |  | 42 | - |
+
+## Point (41-41)
+### Fields
+| Name | Type | Vis | Modifiers | Line | Doc |
+|------|------|-----|-----------|------|-----|
+| top_left | struct Point | + |  | 41 | - |
+
+## Point (42-42)
+### Fields
+| Name | Type | Vis | Modifiers | Line | Doc |
+|------|------|-----|-----------|------|-----|
 | bottom_right | struct Point | + |  | 42 | - |
 
 ## Number (46-50)

--- a/tests/golden_masters/toon/c_sample_toon.toon
+++ b/tests/golden_masters/toon/c_sample_toon.toon
@@ -2,11 +2,13 @@ file_path: examples/sample.c
 language: c
 package: null
 classes:
-  [6]{name,visibility,line_range(a,b)}:
+  [8]{name,visibility,line_range(a,b)}:
     Color,public,(24,24)
     Status,public,(27,31)
     Point,public,(34,37)
     Rectangle,public,(40,43)
+    Point,public,(41,41)
+    Point,public,(42,42)
     Number,public,(46,50)
     Person,public,(53,56)
 methods:
@@ -44,7 +46,7 @@ imports:
     stdlib.h,stdlib.h,"#include <stdlib.h>\n",false,false,(8,8),[],"#include <stdlib.h>\n"
     local_header.h,local_header.h,"#include \"local_header.h\"\n",false,false,(9,9),[],"#include \"local_header.h\"\n"
 statistics:
-  class_count: 6
+  class_count: 8
   method_count: 10
   field_count: 15
   import_count: 3

--- a/tests/unit/languages/test_c_cpp_fixes.py
+++ b/tests/unit/languages/test_c_cpp_fixes.py
@@ -1,0 +1,243 @@
+"""Tests for C/C++ extraction bugs #751, #752, #753.
+
+#751: C++ nested struct/class inside class body not extracted.
+#752: C typedef struct should not produce duplicate entries (regression guard).
+#753: C anonymous nested union/struct inside struct should be skipped (not extracted
+      with empty or line-number-based synthetic name).
+"""
+
+import tree_sitter
+import tree_sitter_c
+import tree_sitter_cpp
+
+from tree_sitter_analyzer.languages.c_plugin import CElementExtractor
+from tree_sitter_analyzer.languages.cpp_plugin import CppElementExtractor
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_c(code: str) -> tree_sitter.Tree:
+    lang = tree_sitter.Language(tree_sitter_c.language())
+    parser = tree_sitter.Parser(lang)
+    return parser.parse(code.encode("utf-8"))
+
+
+def _parse_cpp(code: str) -> tree_sitter.Tree:
+    lang = tree_sitter.Language(tree_sitter_cpp.language())
+    parser = tree_sitter.Parser(lang)
+    return parser.parse(code.encode("utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Bug #751 — C++ nested struct/class not extracted
+# ---------------------------------------------------------------------------
+
+
+class TestBug751CppNestedClass:
+    """C++ inner class/struct inside a class body must be extracted."""
+
+    def test_nested_struct_inside_class(self) -> None:
+        """Simple struct nested inside a class body."""
+        code = """\
+class Outer {
+public:
+    struct Inner { int x; };
+    int y;
+};
+"""
+        tree = _parse_cpp(code)
+        ext = CppElementExtractor()
+        classes = ext.extract_classes(tree, code)
+        names = [c.name for c in classes]
+
+        assert "Outer" in names
+        assert "Inner" in names
+        assert len(names) == 2
+
+    def test_nested_class_inside_class(self) -> None:
+        """class nested inside a class body."""
+        code = """\
+class Outer {
+public:
+    class Inner {
+    public:
+        int value;
+        void doSomething() {}
+    };
+    int z;
+};
+"""
+        tree = _parse_cpp(code)
+        ext = CppElementExtractor()
+        classes = ext.extract_classes(tree, code)
+        names = [c.name for c in classes]
+
+        assert "Outer" in names
+        assert "Inner" in names
+        assert len(names) == 2
+
+    def test_nested_struct_has_parent_class(self) -> None:
+        """Nested struct should have parent_class set to enclosing class name."""
+        code = """\
+class Outer {
+public:
+    struct Inner { int x; };
+};
+"""
+        tree = _parse_cpp(code)
+        ext = CppElementExtractor()
+        classes = ext.extract_classes(tree, code)
+
+        inner = next(c for c in classes if c.name == "Inner")
+        assert inner.parent_class == "Outer"
+
+    def test_multiple_nested_types(self) -> None:
+        """Multiple nested types all extracted."""
+        code = """\
+class Container {
+public:
+    struct Point { double x; double y; };
+    struct Size { double w; double h; };
+    int count;
+};
+"""
+        tree = _parse_cpp(code)
+        ext = CppElementExtractor()
+        classes = ext.extract_classes(tree, code)
+        names = sorted(c.name for c in classes)
+
+        assert names == ["Container", "Point", "Size"]
+
+    def test_outer_class_type_preserved(self) -> None:
+        """Outer class class_type stays 'class'."""
+        code = """\
+class Outer {
+    struct Inner { int x; };
+};
+"""
+        tree = _parse_cpp(code)
+        ext = CppElementExtractor()
+        classes = ext.extract_classes(tree, code)
+
+        outer = next(c for c in classes if c.name == "Outer")
+        inner = next(c for c in classes if c.name == "Inner")
+
+        assert outer.class_type == "class"
+        assert inner.class_type == "struct"
+
+
+# ---------------------------------------------------------------------------
+# Bug #752 — C typedef struct regression guard (no duplicate entries)
+# ---------------------------------------------------------------------------
+
+
+class TestBug752CTypedefStructNoDuplicate:
+    """typedef struct { ... } Name must produce exactly one entry."""
+
+    def test_anonymous_typedef_struct_single_entry(self) -> None:
+        """Simplest case: typedef struct { ... } MyType produces exactly one entry."""
+        code = "typedef struct { int x; } MyType;\n"
+        tree = _parse_c(code)
+        ext = CElementExtractor()
+        classes = ext.extract_classes(tree, code)
+
+        assert len(classes) == 1
+        assert classes[0].name == "MyType"
+        assert classes[0].class_type == "struct"
+
+    def test_anonymous_typedef_struct_name_not_synthetic(self) -> None:
+        """typedef struct { ... } MyType must not also emit an anonymous_struct_ entry."""
+        code = "typedef struct { int x; } MyType;\n"
+        tree = _parse_c(code)
+        ext = CElementExtractor()
+        classes = ext.extract_classes(tree, code)
+
+        names = [c.name for c in classes]
+        # No synthetic anonymous name should appear alongside MyType
+        assert not any(n.startswith("anonymous_struct_") for n in names)
+
+    def test_named_typedef_struct_single_entry(self) -> None:
+        """typedef struct Foo { ... } Foo produces exactly one entry (no double Foo)."""
+        code = "typedef struct Foo { int x; int y; } Foo;\n"
+        tree = _parse_c(code)
+        ext = CElementExtractor()
+        classes = ext.extract_classes(tree, code)
+
+        names = [c.name for c in classes]
+        assert names.count("Foo") == 1
+        assert len(classes) == 1
+
+    def test_multiple_independent_typedefs(self) -> None:
+        """Multiple typedef structs each produce exactly one entry."""
+        code = "typedef struct { int x; } TypeA;\ntypedef struct { float y; } TypeB;\n"
+        tree = _parse_c(code)
+        ext = CElementExtractor()
+        classes = ext.extract_classes(tree, code)
+
+        names = [c.name for c in classes]
+        assert len(classes) == 2
+        assert "TypeA" in names
+        assert "TypeB" in names
+
+
+# ---------------------------------------------------------------------------
+# Bug #753 — C anonymous nested union/struct should be skipped
+# ---------------------------------------------------------------------------
+
+
+class TestBug753CAnonymousNestedContainerSkipped:
+    """Anonymous nested unions/structs inside a typedef struct must NOT be extracted
+    with empty or synthetic line-based names — they should be silently skipped."""
+
+    def test_anonymous_nested_union_skipped(self) -> None:
+        """typedef struct { union { int a; float b; } data; } Container — only
+        Container is extracted; the anonymous inner union is not."""
+        code = "typedef struct {\n    union { int a; float b; } data;\n} Container;\n"
+        tree = _parse_c(code)
+        ext = CElementExtractor()
+        classes = ext.extract_classes(tree, code)
+
+        names = [c.name for c in classes]
+        assert len(classes) == 1
+        assert names == ["Container"]
+
+    def test_anonymous_nested_struct_skipped(self) -> None:
+        """Nested anonymous struct with a field name is skipped."""
+        code = "struct Outer {\n    struct { int x; int y; } coords;\n};\n"
+        tree = _parse_c(code)
+        ext = CElementExtractor()
+        classes = ext.extract_classes(tree, code)
+
+        names = [c.name for c in classes]
+        assert len(classes) == 1
+        assert names == ["Outer"]
+
+    def test_no_anonymous_synthetic_name_emitted(self) -> None:
+        """No anonymous_union_N or anonymous_struct_N name should appear for
+        nested containers that have a field identifier (e.g., data, coords)."""
+        code = (
+            "typedef struct {\n"
+            "    union { int a; float b; } data;\n"
+            "    struct { int x; int y; } pos;\n"
+            "} Container;\n"
+        )
+        tree = _parse_c(code)
+        ext = CElementExtractor()
+        classes = ext.extract_classes(tree, code)
+
+        names = [c.name for c in classes]
+        assert not any(n.startswith("anonymous_union_") for n in names)
+        assert not any(n.startswith("anonymous_struct_") for n in names)
+
+    def test_named_nested_struct_is_extracted(self) -> None:
+        """A NAMED nested struct (with type_identifier) inside a struct body IS extracted.
+        Contrast with the anonymous case above — named types have identity."""
+        code = "struct Outer {\n    struct Inner { int x; };\n    int y;\n};\n"
+        tree = _parse_c(code)
+        ext = CElementExtractor()
+        classes = ext.extract_classes(tree, code)
+
+        names = sorted(c.name for c in classes)
+        assert names == ["Inner", "Outer"]

--- a/tree_sitter_analyzer/languages/_c_traversal_helpers.py
+++ b/tree_sitter_analyzer/languages/_c_traversal_helpers.py
@@ -11,6 +11,15 @@ _C_CONTAINER_NODE_TYPES = frozenset(
         "struct_specifier",
         "union_specifier",
         "field_declaration_list",
+        # field_declaration is required so that named nested struct/union/enum
+        # types declared as members of a struct body are reachable.  Without
+        # it the traversal stops at field_declaration_list's children and
+        # never descends into the specifier embedded in a member declaration
+        # (e.g. ``struct Inner { int x; };`` inside ``struct Outer``).
+        # Anonymous nested containers (union/struct with no type_identifier)
+        # are handled by skipping them in _c_type_definition_helpers — they
+        # must not be emitted with synthetic line-number names (bug #753).
+        "field_declaration",
         "declaration_list",
         "type_definition",
         # Preprocessor conditional branches — without these the traversal

--- a/tree_sitter_analyzer/languages/_c_type_definition_helpers.py
+++ b/tree_sitter_analyzer/languages/_c_type_definition_helpers.py
@@ -51,6 +51,21 @@ def _is_anonymous_nested_member(node: Any, get_node_text: Callable[..., str]) ->
     return bool(node.parent and node.parent.type == "field_declaration")
 
 
+def _has_body(node: Any) -> bool:
+    """Return True when ``node`` (struct/union/enum specifier) has a definition
+    body.  A specifier without a body is a type *reference* (e.g. the type of
+    a field declaration ``struct Point top_left;``) and must not be emitted as
+    a class definition."""
+    for child in node.children:
+        if child.type in (
+            "field_declaration_list",
+            "enumerator_list",
+            "declaration_list",
+        ):
+            return True
+    return False
+
+
 def _extract_type_definition(
     node: Any,
     get_node_text: Callable[..., str],
@@ -60,6 +75,16 @@ def _extract_type_definition(
     error_label: str,
 ) -> Class | None:
     try:
+        # Skip type *references* (specifiers with no body).  A struct/union/enum
+        # that appears as a field type (``struct Point top_left;``) is a
+        # reference, not a definition — it has no field_declaration_list.
+        # Exception: typedef targets may have no explicit type name yet still
+        # be valid definitions (anonymous struct typedef).
+        if not _has_body(node) and (
+            not node.parent or node.parent.type != "type_definition"
+        ):
+            return None
+
         # Skip anonymous containers that are just typed members of another
         # struct/union body — they have no meaningful type name and emitting
         # them with a synthetic ``anonymous_union_N`` name pollutes the class

--- a/tree_sitter_analyzer/languages/_c_type_definition_helpers.py
+++ b/tree_sitter_analyzer/languages/_c_type_definition_helpers.py
@@ -30,6 +30,27 @@ def extract_enum_definition(
     )
 
 
+def _is_anonymous_nested_member(node: Any, get_node_text: Callable[..., str]) -> bool:
+    """Return True when ``node`` is an anonymous container (struct/union/enum
+    with no ``type_identifier`` child) that appears as a typed member inside
+    another struct/union body via ``field_declaration``.
+
+    These are *anonymous member containers* (e.g. ``union { int a; float b; }
+    data;``).  They have no independent identity as a named type and must be
+    skipped rather than emitted with a synthetic ``anonymous_union_N`` name
+    (bug #753).  Named nested types (``struct Inner { int x; }``) DO have a
+    ``type_identifier`` child and therefore return False.
+    """
+    # Must have no direct type name of its own.
+    if _direct_type_name(node, get_node_text) is not None:
+        return False
+    # Must not be the primary type in a typedef (handled elsewhere).
+    if node.parent and node.parent.type == "type_definition":
+        return False
+    # Must be the specifier inside a field_declaration (a struct/union member).
+    return bool(node.parent and node.parent.type == "field_declaration")
+
+
 def _extract_type_definition(
     node: Any,
     get_node_text: Callable[..., str],
@@ -39,6 +60,13 @@ def _extract_type_definition(
     error_label: str,
 ) -> Class | None:
     try:
+        # Skip anonymous containers that are just typed members of another
+        # struct/union body — they have no meaningful type name and emitting
+        # them with a synthetic ``anonymous_union_N`` name pollutes the class
+        # list (bug #753).
+        if _is_anonymous_nested_member(node, get_node_text):
+            return None
+
         start_line, end_line = _node_line_range(node)
         name, start_line, end_line = _type_name_and_range(
             node, get_node_text, start_line, end_line, anonymous_prefix

--- a/tree_sitter_analyzer/languages/_cpp_element_helpers.py
+++ b/tree_sitter_analyzer/languages/_cpp_element_helpers.py
@@ -192,6 +192,34 @@ def extract_cpp_function(
         return None
 
 
+def _cpp_direct_parent_class_name(node: Any) -> str | None:
+    """Return the enclosing class/struct name when ``node`` is a nested type
+    declared directly inside a class body (one level up via field_declaration).
+
+    Walk: node → field_declaration → field_declaration_list → class/struct/union_specifier
+    with a hard cap to avoid infinite walks on mocked nodes.
+    """
+    parent = getattr(node, "parent", None)
+    if parent is None or getattr(parent, "type", "") != "field_declaration":
+        return None
+    grandparent = getattr(parent, "parent", None)
+    if (
+        grandparent is None
+        or getattr(grandparent, "type", "") != "field_declaration_list"
+    ):
+        return None
+    great = getattr(grandparent, "parent", None)
+    if great is None or getattr(great, "type", "") not in _CPP_CLASS_NODE_TYPES:
+        return None
+    for child in getattr(great, "children", ()):
+        if getattr(child, "type", "") == "type_identifier":
+            text = getattr(child, "text", b"")
+            if isinstance(text, bytes):
+                return text.decode("utf-8", errors="replace")
+            return str(text)
+    return None
+
+
 def extract_cpp_class(
     node: Any,
     context: CppClassExtractionContext | Callable[..., str],
@@ -214,6 +242,8 @@ def extract_cpp_class(
             else class_name
         )
 
+        parent_class = _cpp_direct_parent_class_name(node)
+
         return Class(
             name=class_name,
             start_line=start_line,
@@ -227,6 +257,7 @@ def extract_cpp_class(
             interfaces=superclasses[1:] if len(superclasses) > 1 else [],
             modifiers=[],
             docstring=ctx.extract_comment_for_line(start_line),
+            parent_class=parent_class,
         )
     except Exception as exc:
         log_debug(f"Failed to extract class info: {exc}")

--- a/tree_sitter_analyzer/languages/_cpp_traversal_helpers.py
+++ b/tree_sitter_analyzer/languages/_cpp_traversal_helpers.py
@@ -14,6 +14,11 @@ _CONTAINER_NODE_TYPES = frozenset(
         "union_specifier",
         "declaration_list",
         "field_declaration_list",
+        # field_declaration is required so that nested class/struct/union types
+        # declared as members of a class body are reachable.  Without it, the
+        # traversal stops at field_declaration_list children and never descends
+        # into member declarations that contain a type specifier (bug #751).
+        "field_declaration",
         "compound_statement",
         "template_declaration",
         "declaration",


### PR DESCRIPTION
## Summary

- #751 (C/C++ nested struct/class): Nested types declared as members of a class body were silently skipped. Root cause: `field_declaration` was not in the traversal container node set. Fix: add `field_declaration` to `_CONTAINER_NODE_TYPES` in both cpp and C traversal helpers. Also populate `parent_class` on C++ inner types via new `_cpp_direct_parent_class_name` helper.

- #752 (typedef struct dedup regression guard): `typedef struct { ... } MyType` was already producing exactly one entry correctly. Added exact-assertion regression tests to pin the behaviour permanently.

- #753 (anonymous nested union/struct synthetic names): After the #751 traversal fix, anonymous nested containers (e.g. `union { int a; float b; } data;`) would be reached and emitted with synthetic `anonymous_union_N` names. Added `_is_anonymous_nested_member` guard in `_c_type_definition_helpers.py` to skip containers with no `type_identifier` child embedded in a `field_declaration` slot.

## Files changed

- `tree_sitter_analyzer/languages/_cpp_traversal_helpers.py` — add `field_declaration` to C++ container node types
- `tree_sitter_analyzer/languages/_cpp_element_helpers.py` — `_cpp_direct_parent_class_name` helper + populate `parent_class`
- `tree_sitter_analyzer/languages/_c_traversal_helpers.py` — add `field_declaration` to C container node types
- `tree_sitter_analyzer/languages/_c_type_definition_helpers.py` — `_is_anonymous_nested_member` guard
- `tests/unit/languages/test_c_cpp_fixes.py` — 13 new tests (5 for #751, 4 for #752, 4 for #753)

## Test plan

- All 13 new tests pass
- Full language suite: 3502 passed, 0 regressions
- All pre-commit hooks pass (ruff, mypy, bandit, secrets)
