### PR TITLE
fix(sql): FUNCTION param extraction, CREATE TABLE AS SELECT capture (#775 #808)

### DIFF
--- a/tests/unit/languages/test_sql_fixes.py
+++ b/tests/unit/languages/test_sql_fixes.py
@@ -1,0 +1,211 @@
+"""
+Tests for SQL extraction bugs:
+  #775 — FUNCTION with params: schema-qualified function produces 0 results
+  #808 — CREATE TABLE ... AS SELECT: drops table (extracts schema name instead)
+
+RED tests written before the fix; each asserts EXACT values (no >= bounds).
+"""
+
+import pytest
+
+try:
+    import tree_sitter
+    import tree_sitter_sql
+
+    TREE_SITTER_SQL_AVAILABLE = True
+except ImportError:
+    TREE_SITTER_SQL_AVAILABLE = False
+
+from tree_sitter_analyzer.languages.sql_plugin import SQLElementExtractor
+from tree_sitter_analyzer.models import SQLFunction, SQLTable
+
+
+def _parse(sql: str):
+    """Return a tree-sitter Tree for the given SQL string."""
+    if not TREE_SITTER_SQL_AVAILABLE:
+        pytest.skip("tree-sitter-sql not installed")
+    parser = tree_sitter.Parser(tree_sitter.Language(tree_sitter_sql.language()))
+    return parser.parse(sql.encode("utf-8"))
+
+
+def _extract(sql: str):
+    """Parse SQL and run extract_sql_elements; return the element list."""
+    tree = _parse(sql)
+    ext = SQLElementExtractor()
+    return ext.extract_sql_elements(tree, sql)
+
+
+# ---------------------------------------------------------------------------
+# Bug #775 — FUNCTION with params: schema-qualified function returns 0 results
+# ---------------------------------------------------------------------------
+
+
+class TestFunctionParamExtraction:
+    """#775: CREATE FUNCTION with parameters must be extracted correctly."""
+
+    def test_simple_function_with_two_params_extracted(self):
+        """A simple (non-schema) function with params returns 1 SQLFunction."""
+        sql = (
+            "CREATE FUNCTION add_nums(a INT, b INT) RETURNS INT\n"
+            "BEGIN\n"
+            "  RETURN a + b;\n"
+            "END;\n"
+        )
+        elements = _extract(sql)
+        functions = [e for e in elements if isinstance(e, SQLFunction)]
+        assert len(functions) == 1
+        assert functions[0].name == "add_nums"
+
+    def test_simple_function_params_names(self):
+        sql = (
+            "CREATE FUNCTION add_nums(a INT, b INT) RETURNS INT\n"
+            "BEGIN\n"
+            "  RETURN a + b;\n"
+            "END;\n"
+        )
+        elements = _extract(sql)
+        functions = [e for e in elements if isinstance(e, SQLFunction)]
+        assert len(functions) == 1
+        param_names = [p.name for p in functions[0].parameters]
+        assert param_names == ["a", "b"]
+
+    def test_simple_function_params_types(self):
+        sql = (
+            "CREATE FUNCTION add_nums(a INT, b INT) RETURNS INT\n"
+            "BEGIN\n"
+            "  RETURN a + b;\n"
+            "END;\n"
+        )
+        elements = _extract(sql)
+        functions = [e for e in elements if isinstance(e, SQLFunction)]
+        assert len(functions) == 1
+        param_types = [p.data_type.upper() for p in functions[0].parameters]
+        assert param_types == ["INT", "INT"]
+
+    def test_schema_qualified_function_is_extracted(self):
+        """#775: schema.function(params) must NOT silently return 0 results."""
+        sql = (
+            "CREATE FUNCTION myschema.get_count(user_id INT, status TEXT) RETURNS INT\n"
+            "BEGIN\n"
+            "  RETURN 1;\n"
+            "END;\n"
+        )
+        elements = _extract(sql)
+        functions = [e for e in elements if isinstance(e, SQLFunction)]
+        assert len(functions) == 1
+
+    def test_schema_qualified_function_name_is_function_not_schema(self):
+        """#775: extracted name must be 'get_count', not 'myschema'."""
+        sql = (
+            "CREATE FUNCTION myschema.get_count(user_id INT, status TEXT) RETURNS INT\n"
+            "BEGIN\n"
+            "  RETURN 1;\n"
+            "END;\n"
+        )
+        elements = _extract(sql)
+        functions = [e for e in elements if isinstance(e, SQLFunction)]
+        assert len(functions) == 1
+        assert functions[0].name == "get_count"
+
+    def test_schema_qualified_function_params_extracted(self):
+        """#775: schema-qualified function must carry its parameters."""
+        sql = (
+            "CREATE FUNCTION myschema.get_count(user_id INT, status TEXT) RETURNS INT\n"
+            "BEGIN\n"
+            "  RETURN 1;\n"
+            "END;\n"
+        )
+        elements = _extract(sql)
+        functions = [e for e in elements if isinstance(e, SQLFunction)]
+        assert len(functions) == 1
+        param_names = [p.name for p in functions[0].parameters]
+        assert param_names == ["user_id", "status"]
+
+    def test_function_with_mixed_param_types(self):
+        """Function with INT and TEXT params — both captured."""
+        sql = (
+            "CREATE FUNCTION foo(param1 INT, param2 TEXT) RETURNS INT\n"
+            "BEGIN\n"
+            "  RETURN param1 + 1;\n"
+            "END;\n"
+        )
+        elements = _extract(sql)
+        functions = [e for e in elements if isinstance(e, SQLFunction)]
+        assert len(functions) == 1
+        params = functions[0].parameters
+        assert len(params) == 2
+        assert params[0].name == "param1"
+        assert params[0].data_type.upper() == "INT"
+        assert params[1].name == "param2"
+        assert params[1].data_type.upper() == "TEXT"
+
+
+# ---------------------------------------------------------------------------
+# Bug #808 — CREATE TABLE ... AS SELECT drops the table
+# ---------------------------------------------------------------------------
+
+
+class TestCreateTableAsSelect:
+    """#808: CREATE TABLE schema.name AS SELECT must extract the table."""
+
+    def test_create_table_as_select_produces_one_table(self):
+        """#808: 'CREATE TABLE reporting.daily_stats AS SELECT ...' must yield 1 table."""
+        sql = (
+            "CREATE TABLE reporting.daily_stats AS\n"
+            "SELECT user_id, COUNT(*) AS cnt FROM users GROUP BY user_id;\n"
+        )
+        elements = _extract(sql)
+        tables = [e for e in elements if isinstance(e, SQLTable)]
+        assert len(tables) == 1
+
+    def test_create_table_as_select_name_is_table_not_schema(self):
+        """#808: extracted name must be 'daily_stats', not 'reporting'."""
+        sql = (
+            "CREATE TABLE reporting.daily_stats AS\n"
+            "SELECT user_id, COUNT(*) AS cnt FROM users GROUP BY user_id;\n"
+        )
+        elements = _extract(sql)
+        tables = [e for e in elements if isinstance(e, SQLTable)]
+        assert len(tables) == 1
+        assert tables[0].name == "daily_stats"
+
+    def test_create_table_as_select_schema_captured(self):
+        """#808: schema_name field must contain 'reporting'."""
+        sql = (
+            "CREATE TABLE reporting.daily_stats AS\n"
+            "SELECT user_id, COUNT(*) AS cnt FROM users GROUP BY user_id;\n"
+        )
+        elements = _extract(sql)
+        tables = [e for e in elements if isinstance(e, SQLTable)]
+        assert len(tables) == 1
+        assert tables[0].schema_name == "reporting"
+
+    def test_create_table_no_schema_still_works(self):
+        """Plain CREATE TABLE (no schema) is unaffected by the fix."""
+        sql = "CREATE TABLE users (\n  id INT NOT NULL,\n  email TEXT\n);\n"
+        elements = _extract(sql)
+        tables = [e for e in elements if isinstance(e, SQLTable)]
+        assert len(tables) == 1
+        assert tables[0].name == "users"
+
+    def test_create_table_with_schema_no_as_select(self):
+        """Schema-qualified CREATE TABLE with column list (no AS SELECT)."""
+        sql = (
+            "CREATE TABLE myschema.orders (\n"
+            "  id INT NOT NULL,\n"
+            "  total DECIMAL(10,2)\n"
+            ");\n"
+        )
+        elements = _extract(sql)
+        tables = [e for e in elements if isinstance(e, SQLTable)]
+        assert len(tables) == 1
+        assert tables[0].name == "orders"
+        assert tables[0].schema_name == "myschema"
+
+    def test_create_table_as_select_single_schema(self):
+        """Non-schema-qualified CREATE TABLE AS SELECT works too."""
+        sql = "CREATE TABLE archive_users AS SELECT * FROM users WHERE deleted = 1;\n"
+        elements = _extract(sql)
+        tables = [e for e in elements if isinstance(e, SQLTable)]
+        assert len(tables) == 1
+        assert tables[0].name == "archive_users"

--- a/tree_sitter_analyzer/languages/sql_plugin/_class_table_extractor.py
+++ b/tree_sitter_analyzer/languages/sql_plugin/_class_table_extractor.py
@@ -56,11 +56,14 @@ def _table_name_from_children(
     get_node_text: Callable[..., str],
     is_valid_identifier: Callable[[str], bool],
 ) -> str | None:
-    """Extract a table name from object_reference children."""
+    """Extract a table name from object_reference children.
+
+    For ``schema.table`` patterns the LAST identifier is the table name.
+    """
     for child in node.children:
         if child.type != "object_reference":
             continue
-        table_name = _identifier_from_object_reference(
+        table_name = _last_identifier_from_object_reference(
             child,
             get_node_text,
             is_valid_identifier,
@@ -70,16 +73,21 @@ def _table_name_from_children(
     return None
 
 
-def _identifier_from_object_reference(
+def _last_identifier_from_object_reference(
     node: tree_sitter.Node,
     get_node_text: Callable[..., str],
     is_valid_identifier: Callable[[str], bool],
 ) -> str | None:
-    """Extract the first valid identifier from an object_reference node."""
-    for subchild in node.children:
-        if subchild.type != "identifier":
-            continue
-        table_name = get_node_text(subchild).strip()
-        if table_name and is_valid_identifier(table_name):
-            return table_name
-    return None
+    """Extract the LAST valid identifier from an object_reference node.
+
+    For a plain ``tablename`` reference there is one identifier child.
+    For a ``schema.tablename`` reference there are two; we return the last.
+    """
+    valid = [
+        get_node_text(subchild).strip()
+        for subchild in node.children
+        if subchild.type == "identifier"
+        and get_node_text(subchild).strip()
+        and is_valid_identifier(get_node_text(subchild).strip())
+    ]
+    return valid[-1] if valid else None

--- a/tree_sitter_analyzer/languages/sql_plugin/element_validator.py
+++ b/tree_sitter_analyzer/languages/sql_plugin/element_validator.py
@@ -18,7 +18,8 @@ _TRIGGER_NAME_REGEX = re.compile(
     r"CREATE\s+TRIGGER\s+([a-zA-Z_][a-zA-Z0-9_]*)", re.IGNORECASE
 )
 _FUNCTION_NAME_REGEX = re.compile(
-    r"CREATE\s+FUNCTION\s+([a-zA-Z_][a-zA-Z0-9_]*)", re.IGNORECASE
+    r"CREATE\s+FUNCTION\s+(?:[a-zA-Z_][a-zA-Z0-9_]*\.)*([a-zA-Z_][a-zA-Z0-9_]*)",
+    re.IGNORECASE,
 )
 _CREATE_VIEW_LINE_REGEX = re.compile(
     r"^\s*CREATE\s+VIEW\s+(?:IF\s+NOT\s+EXISTS\s+)?(\w+)\s+AS",

--- a/tree_sitter_analyzer/languages/sql_plugin/function_extractor.py
+++ b/tree_sitter_analyzer/languages/sql_plugin/function_extractor.py
@@ -13,7 +13,7 @@ from .identifier_validator import is_valid_identifier
 from .procedure_extractor import extract_procedure_parameters
 
 _FUNCTION_PATTERN = re.compile(
-    r"^\s*CREATE\s+FUNCTION\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\(",
+    r"^\s*CREATE\s+FUNCTION\s+(?:[a-zA-Z_][a-zA-Z0-9_]*\.)*([a-zA-Z_][a-zA-Z0-9_]*)\s*\(",
     re.IGNORECASE,
 )
 
@@ -172,15 +172,19 @@ def _function_name_from_ast(
 def _function_name_from_object_reference(
     node: "tree_sitter.Node", get_node_text: Callable[..., str]
 ) -> str | None:
-    for subchild in node.children:
-        if subchild.type != "identifier":
-            continue
+    """Return the function name from an object_reference node.
 
-        func_name = get_node_text(subchild).strip()
-        if func_name and is_valid_identifier(func_name):
-            return func_name
-
-    return None
+    For ``schema.funcname`` references the LAST identifier is the function
+    name; any preceding identifier is the schema qualifier.
+    """
+    valid = [
+        get_node_text(subchild).strip()
+        for subchild in node.children
+        if subchild.type == "identifier"
+        and get_node_text(subchild).strip()
+        and is_valid_identifier(get_node_text(subchild).strip())
+    ]
+    return valid[-1] if valid else None
 
 
 def _function_already_extracted(sql_elements: list[Any], func_name: str) -> bool:
@@ -335,8 +339,14 @@ def _legacy_function_name_from_text(
     raw_text: str,
     is_valid_identifier_fn: Callable[[str], bool],
 ) -> str | None:
-    """Extract a function name with regex fallback."""
-    match = re.search(r"CREATE\s+FUNCTION\s+(\w+)\s*\(", raw_text, re.IGNORECASE)
+    """Extract a function name with regex fallback.
+
+    Handles both plain ``FUNCTION foo(`` and schema-qualified
+    ``FUNCTION schema.foo(`` patterns; always returns the local name.
+    """
+    match = re.search(
+        r"CREATE\s+FUNCTION\s+(?:\w+\.)*(\w+)\s*\(", raw_text, re.IGNORECASE
+    )
     if not match:
         return None
     potential_name = match.group(1).strip()

--- a/tree_sitter_analyzer/languages/sql_plugin/procedure_extractor.py
+++ b/tree_sitter_analyzer/languages/sql_plugin/procedure_extractor.py
@@ -57,6 +57,10 @@ def extract_procedure_parameters(
         param_name = match.group(2)
         data_type = match.group(3)
 
+        # Filter out SQL DML keywords that can appear as false-positive param
+        # names when the regex matches body text instead of the param list.
+        # Keep only unambiguous reserved words — common column names like
+        # STATUS, NAME, EMAIL, ID are valid parameter identifiers (#775).
         if param_name.upper() in (
             "SELECT",
             "FROM",
@@ -67,12 +71,6 @@ def extract_procedure_parameters(
             "UPDATE",
             "INSERT",
             "DELETE",
-            "CREATED_AT",
-            "UPDATED_AT",
-            "ID",
-            "NAME",
-            "EMAIL",
-            "STATUS",
             "IN",
             "OUT",
             "INOUT",
@@ -88,9 +86,13 @@ def extract_procedure_parameters(
 
 
 def _extract_parameter_section(proc_text: str) -> str:
-    """Return the balanced parameter section for a procedure/function."""
+    """Return the balanced parameter section for a procedure/function.
+
+    Handles both simple names (``FUNCTION foo(``) and schema-qualified names
+    (``FUNCTION schema.foo(``).
+    """
     header_match = re.search(
-        r"(?:PROCEDURE|FUNCTION)\s+[a-zA-Z_][a-zA-Z0-9_]*\s*\(",
+        r"(?:PROCEDURE|FUNCTION)\s+(?:[a-zA-Z_][a-zA-Z0-9_]*\.)*[a-zA-Z_][a-zA-Z0-9_]*\s*\(",
         proc_text,
         re.IGNORECASE,
     )

--- a/tree_sitter_analyzer/languages/sql_plugin/table_extractor.py
+++ b/tree_sitter_analyzer/languages/sql_plugin/table_extractor.py
@@ -26,7 +26,7 @@ def extract_sql_tables(
     for node in traverse_nodes(root_node):
         if node.type != "create_table":
             continue
-        table_name = _find_table_name(node, get_node_text)
+        table_name, schema_name = _find_table_name(node, get_node_text)
         columns: list[SQLColumn] = []
         constraints: list[SQLConstraint] = []
         extract_table_columns(node, columns, constraints, traverse_nodes, get_node_text)
@@ -42,6 +42,7 @@ def extract_sql_tables(
                     language="sql",
                     columns=columns,
                     constraints=constraints,
+                    schema_name=schema_name,
                 )
             )
         except Exception as e:
@@ -51,34 +52,46 @@ def extract_sql_tables(
 def _find_table_name(
     create_table_node: "tree_sitter.Node",
     get_node_text: Callable[..., str],
-) -> str | None:
-    """Walk a ``create_table`` AST node and return its table-identifier text.
+) -> tuple[str | None, str | None]:
+    """Walk a ``create_table`` AST node and return (table_name, schema_name).
+
+    For ``schema.table`` patterns the object_reference node contains two
+    identifiers separated by a dot.  The LAST identifier is the table name;
+    any preceding identifier is the schema name.
 
     r37by: extracted from ``extract_sql_tables`` so the per-object_reference
-    inner loop reads as a focused 8-line helper instead of a depth-8
-    nested block.
+    inner loop reads as a focused helper instead of a depth-8 nested block.
     """
     for child in create_table_node.children:
         if child.type != "object_reference":
             continue
-        name = _first_valid_identifier(child, get_node_text)
+        name, schema = _last_valid_identifier(child, get_node_text)
         if name:
-            return name
-    return None
+            return name, schema
+    return None, None
 
 
-def _first_valid_identifier(
+def _last_valid_identifier(
     object_reference: "tree_sitter.Node",
     get_node_text: Callable[..., str],
-) -> str | None:
-    """Return the first valid identifier under an ``object_reference`` node."""
-    for subchild in object_reference.children:
-        if subchild.type != "identifier":
-            continue
-        text = get_node_text(subchild).strip()
-        if text and is_valid_identifier(text):
-            return text
-    return None
+) -> tuple[str | None, str | None]:
+    """Return (table_name, schema_name) from an ``object_reference`` node.
+
+    When the reference is ``schema.table`` there are two identifier children.
+    We return the LAST valid identifier as the table name and the second-to-last
+    as the schema name.  For a simple ``table`` reference, schema_name is None.
+    """
+    identifiers = [
+        get_node_text(subchild).strip()
+        for subchild in object_reference.children
+        if subchild.type == "identifier"
+    ]
+    valid = [t for t in identifiers if t and is_valid_identifier(t)]
+    if not valid:
+        return None, None
+    table_name = valid[-1]
+    schema_name = valid[-2] if len(valid) >= 2 else None
+    return table_name, schema_name
 
 
 def _process_column_node(


### PR DESCRIPTION
## Summary

- **#775**: Schema-qualified `CREATE FUNCTION schema.foo(params)` was silently broken in four places: the source-line regex (`_FUNCTION_PATTERN`), the parameter-section regex (`_extract_parameter_section`), the validator's name-correction regex (`_FUNCTION_NAME_REGEX`), and the AST identifier extractor (`_function_name_from_object_reference` / `_legacy_function_name_from_text`). All returned or \"corrected to\" the schema prefix (`myschema`) instead of the function name. Also removed `STATUS`, `NAME`, `EMAIL`, `ID`, `CREATED_AT`, `UPDATED_AT` from the parameter blocklist — these are valid parameter names, not SQL keywords.
- **#808**: `CREATE TABLE schema.table AS SELECT ...` extracted `schema` as the table name because `_find_table_name` / `_identifier_from_object_reference` always returned the first identifier. Fixed by always taking the LAST valid identifier as the table name and populating `schema_name` with any prefix.

## Files changed

- `tree_sitter_analyzer/languages/sql_plugin/element_validator.py` — `_FUNCTION_NAME_REGEX` handles `schema.func`
- `tree_sitter_analyzer/languages/sql_plugin/function_extractor.py` — `_FUNCTION_PATTERN`, `_function_name_from_object_reference`, `_legacy_function_name_from_text` handle schema prefix
- `tree_sitter_analyzer/languages/sql_plugin/procedure_extractor.py` — `_extract_parameter_section` header regex handles `schema.func(`; blocklist pruned
- `tree_sitter_analyzer/languages/sql_plugin/table_extractor.py` — `_find_table_name` returns `(name, schema_name)` using last identifier; `extract_sql_tables` populates `schema_name`
- `tree_sitter_analyzer/languages/sql_plugin/_class_table_extractor.py` — `_identifier_from_object_reference` → `_last_identifier_from_object_reference`
- `tests/unit/languages/test_sql_fixes.py` — 13 new exact-assertion tests (RED→GREEN)

## Test plan

- [ ] `uv run pytest tests/unit/languages/test_sql_fixes.py -n 0 -q` → 13 passed
- [ ] `uv run pytest tests/unit/languages/ -n 0 -q --ignore=tests/unit/languages/test_swift_golden_master.py` → 3502 passed, 0 regressions
- [ ] `examples/sample_database.sql` still produces 18 elements (2 functions, 3 tables, 2 views, 2 procedures, 2 triggers, 7 indexes)