### PR TITLE
fix(js): JS destructuring phantom fields and computed-property empty name #747 #748

### DIFF
--- a/tests/golden_masters/plugins/javascript.json
+++ b/tests/golden_masters/plugins/javascript.json
@@ -3,9 +3,9 @@
     "Class": 1,
     "Function": 32,
     "Import": 2,
-    "Variable": 13
+    "Variable": 10
   },
-  "element_total": 48,
+  "element_total": 45,
   "names_by_type": {
     "Class": [
       "ModernComponent"
@@ -13,8 +13,8 @@
     "Function": [
       "#logActivity",
       "#validateData",
-      "<anonymous>",
       "FunctionalComponent",
+      "[`post`]",
       "blockArrow",
       "constructor",
       "createCounter",
@@ -51,16 +51,13 @@
       "API_BASE_URL",
       "AppModule",
       "apiClient",
-      "arrayData",
       "contentType",
       "globalCounter",
       "legacyVariable",
-      "options",
       "response",
       "result",
       "url",
-      "user",
-      "userProfile"
+      "user"
     ]
   },
   "types": [

--- a/tests/unit/languages/test_javascript_bugs_747_748.py
+++ b/tests/unit/languages/test_javascript_bugs_747_748.py
@@ -1,0 +1,153 @@
+"""
+Regression tests for JS extraction bugs #747 and #748.
+
+#747: Destructuring RHS identifiers were extracted as phantom variable names.
+      `const { a, b } = obj` → only the bound names `a`, `b` should be skipped
+      (they are patterns, not declarations); the RHS `obj` must NOT appear as a
+      declared variable.
+
+#748: Computed-property method names were extracted as '' (empty string).
+      `[post](){}` → name should be `'[post]'`.
+      `[Symbol.iterator](){}` → name should be `'[Symbol.iterator]'`.
+"""
+
+import pytest
+
+try:
+    import tree_sitter_javascript as _tsjava
+    from tree_sitter import Language, Parser
+
+    _TREE_SITTER_AVAILABLE = True
+except ImportError:
+    _TREE_SITTER_AVAILABLE = False
+
+from tree_sitter_analyzer.languages.javascript_plugin.extractor import (
+    JavaScriptElementExtractor,
+)
+
+pytestmark = pytest.mark.skipif(
+    not _TREE_SITTER_AVAILABLE, reason="tree-sitter-javascript not installed"
+)
+
+
+@pytest.fixture(scope="module")
+def js_parser():
+    lang = Language(_tsjava.language())
+    return Parser(lang)
+
+
+@pytest.fixture
+def extractor():
+    return JavaScriptElementExtractor()
+
+
+# ---------------------------------------------------------------------------
+# Bug #747 — destructuring RHS identifiers must NOT appear as variable names
+# ---------------------------------------------------------------------------
+
+
+class TestDestructuringPhantomFields:
+    """Bug #747: RHS identifier of destructuring must not be extracted as a variable."""
+
+    def test_object_destructuring_rhs_not_extracted(self, extractor, js_parser):
+        """const { a, b } = obj  →  no variable named 'obj' extracted."""
+        code = "const { a, b } = obj;\n"
+        tree = js_parser.parse(code.encode())
+        variables = extractor.extract_variables(tree, code)
+        names = [v.name for v in variables]
+        assert "obj" not in names, (
+            f"RHS 'obj' must not appear as a variable; got {names}"
+        )
+
+    def test_array_destructuring_rhs_not_extracted(self, extractor, js_parser):
+        """const [x, y] = arr  →  no variable named 'arr' extracted."""
+        code = "const [x, y] = arr;\n"
+        tree = js_parser.parse(code.encode())
+        variables = extractor.extract_variables(tree, code)
+        names = [v.name for v in variables]
+        assert "arr" not in names, (
+            f"RHS 'arr' must not appear as a variable; got {names}"
+        )
+
+    def test_plain_variable_still_extracted(self, extractor, js_parser):
+        """const name = 'hello'  →  variable 'name' IS extracted (regression guard)."""
+        code = "const name = 'hello';\n"
+        tree = js_parser.parse(code.encode())
+        variables = extractor.extract_variables(tree, code)
+        names = [v.name for v in variables]
+        assert "name" in names, f"Plain variable 'name' must be extracted; got {names}"
+
+    def test_mixed_declarations(self, extractor, js_parser):
+        """Mix of destructuring and plain declarations: only plain ones are extracted."""
+        code = "const { a, b } = obj;\nconst [x, y] = arr;\nconst greeting = 'hi';\n"
+        tree = js_parser.parse(code.encode())
+        variables = extractor.extract_variables(tree, code)
+        names = [v.name for v in variables]
+        assert "obj" not in names
+        assert "arr" not in names
+        assert "greeting" in names
+
+    def test_object_destructuring_empty_result(self, extractor, js_parser):
+        """A lone destructuring produces zero extracted variables (no phantom names)."""
+        code = "const { foo, bar } = source;\n"
+        tree = js_parser.parse(code.encode())
+        variables = extractor.extract_variables(tree, code)
+        assert variables == [], (
+            f"Expected no variables from destructuring; got {[v.name for v in variables]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Bug #748 — computed-property method names must not be ''
+# ---------------------------------------------------------------------------
+
+
+class TestComputedPropertyMethodName:
+    """Bug #748: method_definition with computed_property_name must yield non-empty name."""
+
+    def test_simple_computed_identifier(self, extractor, js_parser):
+        """class Foo { [post]() {} }  →  method name is '[post]', not ''."""
+        code = "class Foo {\n  [post]() { return 1; }\n}\n"
+        tree = js_parser.parse(code.encode())
+        functions = extractor.extract_functions(tree, code)
+        methods = [f for f in functions if f.is_method]
+        assert len(methods) == 1
+        assert methods[0].name == "[post]"
+
+    def test_member_expression_computed_name(self, extractor, js_parser):
+        """class Foo { [Symbol.iterator]() {} }  →  method name is '[Symbol.iterator]'."""
+        code = "class Foo {\n  [Symbol.iterator]() { return this; }\n}\n"
+        tree = js_parser.parse(code.encode())
+        functions = extractor.extract_functions(tree, code)
+        methods = [f for f in functions if f.is_method]
+        assert len(methods) == 1
+        assert methods[0].name == "[Symbol.iterator]"
+
+    def test_regular_method_name_unchanged(self, extractor, js_parser):
+        """Regular method name is still extracted correctly (regression guard)."""
+        code = "class Foo {\n  regularMethod() {}\n}\n"
+        tree = js_parser.parse(code.encode())
+        functions = extractor.extract_functions(tree, code)
+        methods = [f for f in functions if f.is_method]
+        assert len(methods) == 1
+        assert methods[0].name == "regularMethod"
+
+    def test_mixed_class_methods(self, extractor, js_parser):
+        """Class with computed and regular methods: all names are non-empty."""
+        code = (
+            "class Foo {\n"
+            "  [post]() { return 1; }\n"
+            "  [Symbol.iterator]() { return this; }\n"
+            "  regularMethod() {}\n"
+            "}\n"
+        )
+        tree = js_parser.parse(code.encode())
+        functions = extractor.extract_functions(tree, code)
+        methods = [f for f in functions if f.is_method]
+        assert len(methods) == 3
+        names = [m.name for m in methods]
+        assert "[post]" in names
+        assert "[Symbol.iterator]" in names
+        assert "regularMethod" in names
+        # No empty names
+        assert "" not in names

--- a/tree_sitter_analyzer/languages/javascript_plugin/_function_mixin.py
+++ b/tree_sitter_analyzer/languages/javascript_plugin/_function_mixin.py
@@ -109,6 +109,13 @@ class JavaScriptFunctionExtractionMixin:
                     # so private methods like #logActivity yielded name="".
                     name = self._get_node_text_optimized(child)
                     is_constructor = name == "constructor"
+                elif child.type == "computed_property_name":
+                    # Issue #748: computed-property methods like `[post](){}` or
+                    # `[Symbol.iterator](){}` have a `computed_property_name` node
+                    # instead of a `property_identifier`.  Use the full bracket
+                    # text (e.g. "[post]", "[Symbol.iterator]") as the name so
+                    # it is non-empty and self-documenting.
+                    name = self._get_node_text_optimized(child)
                 elif child.type == "formal_parameters":
                     parameters = self._extract_parameters(child)
 

--- a/tree_sitter_analyzer/languages/javascript_plugin/_variable_helpers.py
+++ b/tree_sitter_analyzer/languages/javascript_plugin/_variable_helpers.py
@@ -33,10 +33,14 @@ _VALUE_NODE_TYPES = {
 }
 
 
+_DESTRUCTURING_PATTERN_TYPES = {"object_pattern", "array_pattern"}
+
+
 @dataclass
 class _VariableParts:
     name: str | None = None
     value: str | None = None
+    is_destructuring: bool = False
 
 
 def parse_variable_declarator(
@@ -48,9 +52,17 @@ def parse_variable_declarator(
     infer_type: TypeInferer,
     extract_jsdoc: JsdocExtractor,
 ) -> Variable | None:
-    """Parse an individual JavaScript variable declarator."""
+    """Parse an individual JavaScript variable declarator.
+
+    Destructuring declarations (``const { a } = obj``, ``const [x] = arr``)
+    are skipped entirely — they bind names via patterns rather than declaring a
+    single named variable, and the RHS identifier (``obj``, ``arr``) must not
+    be reported as a phantom variable name.
+    """
     try:
         parts = _parse_variable_parts(node, get_node_text)
+        if parts.is_destructuring:
+            return None
         if not parts.name or _has_arrow_function_child(node):
             return None
 
@@ -115,7 +127,13 @@ def _apply_variable_child(
     child: tree_sitter.Node,
     get_node_text: TextExtractor,
 ) -> None:
-    if child.type == "identifier":
+    if child.type in _DESTRUCTURING_PATTERN_TYPES:
+        # Mark as destructuring so the RHS identifier is not used as the name.
+        parts.is_destructuring = True
+    elif child.type == "identifier" and not parts.is_destructuring:
+        # Only treat a bare identifier as the declared name when no destructuring
+        # pattern has been seen yet.  After a pattern like `{ a, b }` or `[x]`,
+        # any subsequent identifier is the RHS source, not the declared name.
         parts.name = get_node_text(child)
     elif child.type == "=" and child.next_sibling:
         parts.value = get_node_text(child.next_sibling)


### PR DESCRIPTION
## Summary

- **#747**: `const { a, b } = obj` was emitting `obj` (the RHS identifier) as a phantom variable. `_apply_variable_child` set `parts.name` from every `identifier` child of `variable_declarator`, including the source identifier after `=`. Fix: detect `object_pattern`/`array_pattern` as a destructuring sentinel and suppress any subsequent identifier-as-name. Entire destructuring declarators return `None` early (no single declared name to report).

- **#748**: Methods with computed property names (`[post](){}`, `[Symbol.iterator](){}`) were extracted with `name = ''` because `_parse_method_signature_optimized` only matched `property_identifier` / `private_property_identifier`. Fix: also handle `computed_property_name` by reading the full bracket text as the method name.

- Golden master updated: 3 phantom variables removed (`arrayData`, `options`, `userProfile`), computed-property method now named `[\`post\`]` instead of empty string.

## Test plan

- [x] 9 new regression tests in `tests/unit/languages/test_javascript_bugs_747_748.py` — all pass
- [x] All 539 JS-related tests pass (`uv run pytest tests/ -k javascript`)
- [x] Pre-commit hooks pass (ruff, mypy, bandit, secrets)
- [x] Golden master updated via `TSA_UPDATE_GOLDEN=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)