### PR TITLE
fix(rust,nav): enum variant extraction, cap impact fan-out (#755 #796)

### DIFF
--- a/tests/golden_masters/plugins/rust.json
+++ b/tests/golden_masters/plugins/rust.json
@@ -4,9 +4,9 @@
     "Function": 9,
     "Import": 1,
     "Package": 1,
-    "Variable": 6
+    "Variable": 10
   },
-  "element_total": 22,
+  "element_total": 26,
   "names_by_type": {
     "Class": [
       "BorrowedItem",
@@ -31,6 +31,10 @@
       "sample_module"
     ],
     "Variable": [
+      "Admin",
+      "Guest",
+      "Moderator",
+      "User",
       "active",
       "email",
       "id",

--- a/tests/unit/languages/test_rust_enum_variants_796.py
+++ b/tests/unit/languages/test_rust_enum_variants_796.py
@@ -1,0 +1,182 @@
+"""Bug #796 — Rust enum variants must be extracted as Variable entries.
+
+RED-first: these tests fail until extract_variables() walks enum_variant_list
+and yields one Variable per enum_variant child.
+
+Contract:
+- Each enum variant becomes a Variable with variable_type == "enum_variant"
+- The variant's name is the identifier text
+- parent_class (or receiver_type) carries the enum name
+- Unit-style variants (no fields) are extracted; tuple/struct variants too
+"""
+
+from __future__ import annotations
+
+import pytest
+
+_TS_RUST_AVAILABLE = False
+try:
+    import tree_sitter_rust  # noqa: F401
+
+    _TS_RUST_AVAILABLE = True
+except ImportError:
+    pass
+
+
+def _parse_rust(code: str):
+    """Parse Rust code with tree-sitter-rust. Returns (tree, language) or None."""
+    if not _TS_RUST_AVAILABLE:
+        return None, None
+    import tree_sitter
+    import tree_sitter_rust
+
+    caps = tree_sitter_rust.language()
+    lang = tree_sitter.Language(caps)
+    parser = tree_sitter.Parser(lang)
+    tree = parser.parse(code.encode("utf-8"))
+    return tree, lang
+
+
+@pytest.mark.skipif(not _TS_RUST_AVAILABLE, reason="tree-sitter-rust not installed")
+class TestRustEnumVariantExtraction:
+    """extract_variables() must yield one Variable per enum variant."""
+
+    def test_simple_enum_variants_are_extracted(self):
+        """Direction enum: four unit variants must each become a Variable."""
+        from tree_sitter_analyzer.languages.rust_plugin import RustElementExtractor
+
+        code = "enum Direction { North, South, East, West }"
+        tree, _ = _parse_rust(code)
+        extractor = RustElementExtractor()
+        variables = extractor.extract_variables(tree, code)
+
+        variant_names = {
+            v.name
+            for v in variables
+            if getattr(v, "variable_type", None) == "enum_variant"
+        }
+        assert variant_names == {"North", "South", "East", "West"}, (
+            f"Expected all four Direction variants, got: {variant_names}"
+        )
+
+    def test_option_like_enum_variants(self):
+        """Option<T>-style enum: None and Some variants extracted."""
+        from tree_sitter_analyzer.languages.rust_plugin import RustElementExtractor
+
+        code = "enum Option<T> { None, Some(T) }"
+        tree, _ = _parse_rust(code)
+        extractor = RustElementExtractor()
+        variables = extractor.extract_variables(tree, code)
+
+        variant_names = {
+            v.name
+            for v in variables
+            if getattr(v, "variable_type", None) == "enum_variant"
+        }
+        assert variant_names == {"None", "Some"}, (
+            f"Expected None and Some, got: {variant_names}"
+        )
+
+    def test_enum_variant_has_correct_variable_type(self):
+        """Each variant must carry variable_type == 'enum_variant'."""
+        from tree_sitter_analyzer.languages.rust_plugin import RustElementExtractor
+
+        code = "enum Color { Red, Green, Blue }"
+        tree, _ = _parse_rust(code)
+        extractor = RustElementExtractor()
+        variables = extractor.extract_variables(tree, code)
+
+        enum_variants = [
+            v for v in variables if getattr(v, "variable_type", None) == "enum_variant"
+        ]
+        assert len(enum_variants) == 3, (
+            f"Expected 3 enum_variant variables, got {len(enum_variants)}"
+        )
+        for v in enum_variants:
+            assert v.variable_type == "enum_variant", (
+                f"Variant {v.name} has wrong variable_type: {v.variable_type!r}"
+            )
+
+    def test_enum_variant_receiver_type_is_enum_name(self):
+        """Each variant's receiver_type must be the containing enum name."""
+        from tree_sitter_analyzer.languages.rust_plugin import RustElementExtractor
+
+        code = "enum Status { Active, Inactive }"
+        tree, _ = _parse_rust(code)
+        extractor = RustElementExtractor()
+        variables = extractor.extract_variables(tree, code)
+
+        variants = [
+            v for v in variables if getattr(v, "variable_type", None) == "enum_variant"
+        ]
+        assert len(variants) == 2
+        for v in variants:
+            assert v.receiver_type == "Status", (
+                f"Variant {v.name} receiver_type expected 'Status', "
+                f"got {v.receiver_type!r}"
+            )
+
+    def test_struct_fields_and_enum_variants_coexist(self):
+        """Struct fields (field_declaration) must not be crowded out by enum variant extraction."""
+        from tree_sitter_analyzer.languages.rust_plugin import RustElementExtractor
+
+        code = "struct Point { x: f64, y: f64 }\nenum Dir { North, South }\n"
+        tree, _ = _parse_rust(code)
+        extractor = RustElementExtractor()
+        variables = extractor.extract_variables(tree, code)
+
+        field_names = {
+            v.name
+            for v in variables
+            if getattr(v, "variable_type", None) != "enum_variant"
+        }
+        variant_names = {
+            v.name
+            for v in variables
+            if getattr(v, "variable_type", None) == "enum_variant"
+        }
+
+        assert "x" in field_names and "y" in field_names, (
+            f"Struct fields x/y missing from: {field_names}"
+        )
+        assert variant_names == {"North", "South"}, (
+            f"Enum variants wrong: {variant_names}"
+        )
+
+    def test_enum_variant_line_range_within_enum_span(self):
+        """Variant start_line must be within the enclosing enum's line span."""
+        from tree_sitter_analyzer.languages.rust_plugin import RustElementExtractor
+
+        code = "enum Suit {\n    Clubs,\n    Diamonds,\n    Hearts,\n    Spades,\n}\n"
+        tree, _ = _parse_rust(code)
+        extractor = RustElementExtractor()
+        variables = extractor.extract_variables(tree, code)
+
+        variants = [
+            v for v in variables if getattr(v, "variable_type", None) == "enum_variant"
+        ]
+        assert len(variants) == 4, f"Expected 4 variants, got {len(variants)}"
+        # All variants must be inside lines 1-6 (1-based)
+        for v in variants:
+            assert 1 <= v.start_line <= 6, (
+                f"Variant {v.name} start_line={v.start_line} out of enum span"
+            )
+
+    def test_multiple_enums_variants_separate(self):
+        """Two enums in one file: each set of variants has the correct receiver_type."""
+        from tree_sitter_analyzer.languages.rust_plugin import RustElementExtractor
+
+        code = "enum A { Foo, Bar }\nenum B { Baz, Qux }\n"
+        tree, _ = _parse_rust(code)
+        extractor = RustElementExtractor()
+        variables = extractor.extract_variables(tree, code)
+
+        variants = [
+            v for v in variables if getattr(v, "variable_type", None) == "enum_variant"
+        ]
+        assert len(variants) == 4
+
+        a_variants = {v.name for v in variants if v.receiver_type == "A"}
+        b_variants = {v.name for v in variants if v.receiver_type == "B"}
+        assert a_variants == {"Foo", "Bar"}, f"A variants wrong: {a_variants}"
+        assert b_variants == {"Baz", "Qux"}, f"B variants wrong: {b_variants}"

--- a/tests/unit/mcp/test_tools/test_check_scale_output_cap_755.py
+++ b/tests/unit/mcp/test_tools/test_check_scale_output_cap_755.py
@@ -1,0 +1,255 @@
+"""Bug #755 — check-scale / extract_structural_overview_universal must cap method list.
+
+Without a cap, a 20 000-method file produces multi-MB JSON that can crash
+agents. The fix adds a default cap of 50 entries to the methods list in
+extract_structural_overview_universal (and the Java-path equivalent in
+_extract_method_infos), with metadata fields:
+  - structural_overview.methods_truncated: True  (only when list was cut)
+  - structural_overview.total_methods: <full count>
+
+The cap must be configurable via a ``method_cap`` keyword argument.
+``total_methods`` is always present; ``methods_truncated`` is only present
+when truncation actually occurred.
+
+RED-first: these tests fail until the cap is added.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from tree_sitter_analyzer.mcp.tools.analyze_scale_helpers import (
+    METHODS_OUTPUT_CAP,
+    extract_structural_overview,
+    extract_structural_overview_universal,
+)
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_fn_element(
+    name: str, start_line: int = 1, end_line: int = 5, complexity: int = 0
+):
+    """Minimal mock function element for universal overview."""
+    e = MagicMock()
+    e.element_type = "function"
+    e.name = name
+    e.start_line = start_line
+    e.end_line = end_line
+    e.complexity_score = complexity
+    return e
+
+
+def _make_java_fn_element(
+    name: str,
+    start_line: int = 1,
+    end_line: int = 5,
+    complexity_score: int = 0,
+    visibility: str = "public",
+    return_type: str = "void",
+    parameters: list | None = None,
+    is_constructor: bool = False,
+    is_static: bool = False,
+    annotations: list | None = None,
+):
+    """Minimal mock for the Java/Python extract_structural_overview path."""
+    from tree_sitter_analyzer.constants import ELEMENT_TYPE_FUNCTION
+
+    e = MagicMock()
+    e.element_type = ELEMENT_TYPE_FUNCTION
+    # is_element_of_type checks element_type attribute OR kind constant:
+    e.name = name
+    e.start_line = start_line
+    e.end_line = end_line
+    e.complexity_score = complexity_score
+    e.visibility = visibility
+    e.return_type = return_type
+    e.parameters = parameters or []
+    e.is_constructor = is_constructor
+    e.is_static = is_static
+    ann_mocks = []
+    for a in annotations or []:
+        m = MagicMock()
+        m.name = a
+        ann_mocks.append(m)
+    e.annotations = ann_mocks
+    return e
+
+
+def _make_analysis_result_universal(elements):
+    r = MagicMock()
+    r.elements = elements
+    return r
+
+
+def _make_analysis_result_java(elements):
+    r = MagicMock()
+    r.elements = elements
+    return r
+
+
+# ---------------------------------------------------------------------------
+# METHODS_OUTPUT_CAP constant
+# ---------------------------------------------------------------------------
+
+
+class TestMethodsOutputCap:
+    def test_cap_constant_is_fifty(self):
+        """Default cap must be exactly 50."""
+        assert METHODS_OUTPUT_CAP == 50
+
+    def test_cap_constant_is_int(self):
+        assert isinstance(METHODS_OUTPUT_CAP, int)
+
+
+# ---------------------------------------------------------------------------
+# extract_structural_overview_universal — cap behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestUniversalOverviewMethodCap:
+    def _make_n_methods(self, n: int):
+        return [
+            _make_fn_element(f"fn_{i}", start_line=i * 10, end_line=i * 10 + 5)
+            for i in range(n)
+        ]
+
+    def test_under_cap_no_truncation_metadata(self):
+        """Fewer than CAP methods: no truncation flag, total_methods == len(methods)."""
+        elements = self._make_n_methods(10)
+        result = _make_analysis_result_universal(elements)
+        overview = extract_structural_overview_universal(result)
+
+        assert len(overview["methods"]) == 10
+        assert (
+            overview.get("methods_truncated") is None
+            or overview.get("methods_truncated") is False
+        ), "methods_truncated must not be True when no truncation occurred"
+        assert overview["total_methods"] == 10
+
+    def test_exactly_cap_no_truncation(self):
+        """Exactly 50 methods: no truncation."""
+        elements = self._make_n_methods(50)
+        result = _make_analysis_result_universal(elements)
+        overview = extract_structural_overview_universal(result)
+
+        assert len(overview["methods"]) == 50
+        assert (
+            overview.get("methods_truncated") is None
+            or overview.get("methods_truncated") is False
+        )
+        assert overview["total_methods"] == 50
+
+    def test_over_cap_truncates_to_cap(self):
+        """51 methods: list is capped at 50, truncation flag set."""
+        elements = self._make_n_methods(51)
+        result = _make_analysis_result_universal(elements)
+        overview = extract_structural_overview_universal(result)
+
+        assert len(overview["methods"]) == 50, (
+            f"Expected 50 methods after cap, got {len(overview['methods'])}"
+        )
+        assert overview["methods_truncated"] is True, (
+            "methods_truncated must be True when list was cut"
+        )
+        assert overview["total_methods"] == 51, (
+            f"total_methods must reflect the full count, got {overview['total_methods']}"
+        )
+
+    def test_large_method_count_capped_exactly(self):
+        """20 000 methods: list stays at 50, total_methods = 20 000."""
+        elements = self._make_n_methods(20_000)
+        result = _make_analysis_result_universal(elements)
+        overview = extract_structural_overview_universal(result)
+
+        assert len(overview["methods"]) == 50
+        assert overview["methods_truncated"] is True
+        assert overview["total_methods"] == 20_000
+
+    def test_cap_preserves_first_n_entries_by_line(self):
+        """The kept entries should be the first N by line order (insertion order)."""
+        elements = self._make_n_methods(100)
+        result = _make_analysis_result_universal(elements)
+        overview = extract_structural_overview_universal(result)
+
+        kept_names = [m["name"] for m in overview["methods"]]
+        expected_names = [f"fn_{i}" for i in range(50)]
+        assert kept_names == expected_names, (
+            "Cap should keep the first 50 entries by insertion order"
+        )
+
+    def test_custom_cap_via_kwarg(self):
+        """method_cap keyword argument overrides the default cap."""
+        elements = self._make_n_methods(20)
+        result = _make_analysis_result_universal(elements)
+        overview = extract_structural_overview_universal(result, method_cap=5)
+
+        assert len(overview["methods"]) == 5
+        assert overview["methods_truncated"] is True
+        assert overview["total_methods"] == 20
+
+    def test_zero_methods_no_truncation_metadata(self):
+        """Empty method list: total_methods == 0, no truncation flag."""
+        result = _make_analysis_result_universal([])
+        overview = extract_structural_overview_universal(result)
+
+        assert overview["total_methods"] == 0
+        assert (
+            overview.get("methods_truncated") is None
+            or overview.get("methods_truncated") is False
+        )
+
+
+# ---------------------------------------------------------------------------
+# extract_structural_overview (Java/Python path) — cap behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestJavaOverviewMethodCap:
+    """The Java/Python extract_structural_overview path must enforce the same cap."""
+
+    def _make_n_java_methods(self, n: int):
+        return [
+            _make_java_fn_element(f"method_{i}", start_line=i * 10) for i in range(n)
+        ]
+
+    def _make_result(self, elements):
+        r = MagicMock()
+        r.elements = elements
+        # is_element_of_type uses ELEMENT_TYPE_FUNCTION constant check too
+        return r
+
+    def test_under_cap_no_truncation(self):
+        elements = self._make_n_java_methods(10)
+        result = self._make_result(elements)
+        overview = extract_structural_overview(result)
+
+        assert len(overview["methods"]) == 10
+        assert overview["total_methods"] == 10
+        assert (
+            overview.get("methods_truncated") is None
+            or overview.get("methods_truncated") is False
+        )
+
+    def test_over_cap_truncates(self):
+        elements = self._make_n_java_methods(200)
+        result = self._make_result(elements)
+        overview = extract_structural_overview(result)
+
+        assert len(overview["methods"]) == 50
+        assert overview["methods_truncated"] is True
+        assert overview["total_methods"] == 200
+
+    def test_exactly_cap_no_truncation(self):
+        elements = self._make_n_java_methods(50)
+        result = self._make_result(elements)
+        overview = extract_structural_overview(result)
+
+        assert len(overview["methods"]) == 50
+        assert (
+            overview.get("methods_truncated") is None
+            or overview.get("methods_truncated") is False
+        )
+        assert overview["total_methods"] == 50

--- a/tree_sitter_analyzer/languages/rust_plugin.py
+++ b/tree_sitter_analyzer/languages/rust_plugin.py
@@ -115,26 +115,60 @@ class RustElementExtractor(ElementExtractor):
     def extract_variables(
         self, tree: tree_sitter.Tree, source_code: str
     ) -> list[Variable]:
-        """Extract Rust struct fields"""
+        """Extract Rust struct fields and enum variants.
+
+        Bug #796: enum variants (e.g. ``None``, ``Some``, ``North``) are now
+        extracted as Variable entries with ``variable_type="enum_variant"``
+        and ``parent_class`` set to the enclosing enum name.
+
+        Implementation note: struct-field extraction and enum-variant
+        extraction are run as two separate passes. Running them together in
+        a single ``_traverse_and_extract`` call would cause struct-like enum
+        variant bodies (``enum Foo { Bar { x: i32 } }``) to emit their
+        ``field_declaration`` children as if they were ordinary struct
+        fields. Separate passes avoid this:
+        - Pass 1 collects ``field_declaration`` nodes only (struct fields).
+        - Pass 2 collects ``enum_item`` nodes and extracts their variants
+          directly, without recursing into the variant bodies.
+        """
         self.source_code = source_code
         self.content_lines = source_code.split("\n")
         self._reset_caches()
 
         variables: list[Variable] = []
 
-        # We extract fields from struct definitions
-        extractors = {
-            "field_declaration": self._extract_field,
-        }
-
+        # Pass 1: struct fields via generic traversal
         self._traverse_and_extract(
             tree.root_node,
-            extractors,
+            {"field_declaration": self._extract_field},
             variables,
         )
 
-        log_debug(f"Extracted {len(variables)} Rust fields")
+        # Pass 2: enum variants — collect directly, skip field_declaration recursion
+        self._collect_enum_variants(tree.root_node, variables)
+
+        log_debug(f"Extracted {len(variables)} Rust fields/variants")
         return variables
+
+    def _collect_enum_variants(
+        self, node: tree_sitter.Node, results: list[Variable]
+    ) -> None:
+        """Walk the AST and extract enum variants from every ``enum_item``.
+
+        Unlike ``_traverse_and_extract``, this walk recurses into
+        non-enum-item children (to find enums nested inside mod blocks), but
+        does NOT recurse into ``enum_item`` children — so
+        ``field_declaration`` nodes inside struct-like variant bodies are
+        never picked up here.
+        """
+        if node.type == "enum_item":
+            variants = self._extract_enum_variants(node)
+            if variants:
+                results.extend(variants)
+            # Do not recurse further: the enum body is fully handled above.
+            return
+        for child in node.children:
+            self._collect_enum_variants(child, results)
 
     def extract_imports(self, tree: tree_sitter.Tree, source_code: str) -> list[Import]:
         """Extract Rust use declarations"""
@@ -242,11 +276,25 @@ class RustElementExtractor(ElementExtractor):
         extractors: dict[str, Any],
         results: list[Any],
     ) -> None:
-        """Recursive traversal to find and extract elements"""
+        """Recursive traversal to find and extract elements.
+
+        When an extractor returns a list, all items in the list are added
+        to ``results`` (extends rather than appends). Single-item returns
+        are appended as before. Recursion always continues so that nested
+        structures (e.g. nested ``mod_item`` inside a mod body) are
+        discovered. Extractors that need to suppress child traversal (e.g.
+        enum variants preventing struct-like variant fields from leaking as
+        struct fields) do so by specifying their own ``no_recurse_types``
+        set — an internal contract between the extractor dict and the
+        caller, not the traversal itself.
+        """
         if node.type in extractors:
             element = extractors[node.type](node)
-            if element:
-                results.append(element)
+            if element is not None:
+                if isinstance(element, list):
+                    results.extend(element)
+                else:
+                    results.append(element)
 
         for child in node.children:
             self._traverse_and_extract(child, extractors, results)
@@ -581,6 +629,63 @@ class RustElementExtractor(ElementExtractor):
             )
         except Exception as e:
             log_error(f"Error extracting Rust field: {e}")
+            return None
+
+    def _extract_enum_variants(self, node: tree_sitter.Node) -> list[Variable] | None:
+        """Extract each enum variant from an ``enum_item`` node as a Variable.
+
+        For an enum like ``enum Direction { North, South }`` this yields two
+        Variable entries with ``variable_type="enum_variant"`` and
+        ``parent_class`` set to the enum name (e.g. ``"Direction"``).
+
+        The method returns a *list* (possibly empty), not a single Variable.
+        ``_traverse_and_extract`` checks for list returns and extends the
+        accumulator rather than appending.
+
+        Bug #796: enum variants were previously invisible — the ``enum_item``
+        node was only visited by ``extract_classes`` (which emits the enum as
+        a Class), while ``extract_variables`` skipped it entirely.
+        """
+        try:
+            name_node = node.child_by_field_name("name")
+            if name_node is None:
+                return None
+            enum_name = self._get_node_text(name_node)
+
+            # Walk children looking for the enum_variant_list node.
+            variant_list = None
+            for child in node.children:
+                if child.type == "enum_variant_list":
+                    variant_list = child
+                    break
+            if variant_list is None:
+                return None
+
+            variants: list[Variable] = []
+            for child in variant_list.children:
+                if child.type != "enum_variant":
+                    continue
+                variant_name_node = child.child_by_field_name("name")
+                if variant_name_node is None:
+                    continue
+                variant_name = self._get_node_text(variant_name_node)
+                start_line = child.start_point[0] + 1
+                end_line = child.end_point[0] + 1
+                raw_text = self._get_node_text(child)
+
+                var = Variable(
+                    name=variant_name,
+                    start_line=start_line,
+                    end_line=end_line,
+                    raw_text=raw_text,
+                    language="rust",
+                    variable_type="enum_variant",
+                    receiver_type=enum_name,
+                )
+                variants.append(var)
+            return variants if variants else None
+        except Exception as e:
+            log_error(f"Error extracting Rust enum variants: {e}")
             return None
 
     def _extract_rust_parameters(

--- a/tree_sitter_analyzer/mcp/tools/analyze_scale_helpers.py
+++ b/tree_sitter_analyzer/mcp/tools/analyze_scale_helpers.py
@@ -18,10 +18,20 @@ from .base_tool import format_summary_line
 
 logger = setup_logger(__name__)
 
+# ---------------------------------------------------------------------------
+# Output size cap for the methods list (Bug #755).
+# A large file can have tens of thousands of methods — emitting all of them
+# inline produces multi-MB JSON that can crash agents. Cap the list and emit
+# metadata so callers know the full count without the payload cost.
+# ---------------------------------------------------------------------------
+METHODS_OUTPUT_CAP = 50
+
 
 # Tree-sitter element extraction for structure view
 # Converts unified analysis engine results into LLM-consumable dicts
-def extract_structural_overview(analysis_result: Any) -> dict[str, Any]:
+def extract_structural_overview(
+    analysis_result: Any, *, method_cap: int = METHODS_OUTPUT_CAP
+) -> dict[str, Any]:
     """Extract structural overview with position information for LLM guidance.
 
     r37bd (dogfood): tool flagged this at 112 lines. Split into 4
@@ -37,9 +47,14 @@ def extract_structural_overview(analysis_result: Any) -> dict[str, Any]:
         "imports": _extract_import_infos(elements),
         "complexity_hotspots": [],
     }
-    overview["methods"], overview["complexity_hotspots"] = _extract_method_infos(
-        elements
-    )
+    all_methods, overview["complexity_hotspots"] = _extract_method_infos(elements)
+    total_methods = len(all_methods)
+    overview["total_methods"] = total_methods
+    if total_methods > method_cap:
+        overview["methods"] = all_methods[:method_cap]
+        overview["methods_truncated"] = True
+    else:
+        overview["methods"] = all_methods
     return overview
 
 
@@ -151,8 +166,17 @@ def _make_hotspot_entry(
 # Universal extraction for non-Java/Python languages using tree-sitter
 def extract_structural_overview_universal(
     analysis_result: Any,
+    *,
+    method_cap: int = METHODS_OUTPUT_CAP,
 ) -> dict[str, Any]:
-    """Extract structural overview from universal analysis result (non-Java languages)."""
+    """Extract structural overview from universal analysis result (non-Java languages).
+
+    Bug #755: the methods list is capped at ``method_cap`` entries (default
+    ``METHODS_OUTPUT_CAP`` = 50) to prevent multi-MB output for large files.
+    When the cap fires, two extra fields appear:
+      - ``total_methods``: the full method count (always present)
+      - ``methods_truncated``: True (only when the list was cut)
+    """
     # Initialize empty overview containers
     overview: dict[str, Any] = {
         "classes": [],
@@ -165,11 +189,12 @@ def extract_structural_overview_universal(
 
     # Guard against empty or invalid analysis results
     if not analysis_result or not hasattr(analysis_result, "elements"):
+        overview["total_methods"] = 0
         return overview
 
     # Pre-bind lists to avoid deep subscript chains inside the loop
     _classes = overview["classes"]
-    _methods = overview["methods"]
+    _all_methods: list[dict[str, Any]] = []
     _fields = overview["fields"]
     _imports = overview["imports"]
     _hotspots = overview["complexity_hotspots"]
@@ -201,7 +226,7 @@ def extract_structural_overview_universal(
                 "line_span": _line_span,
                 "complexity": _complexity_score,
             }
-            _methods.append(method_info)
+            _all_methods.append(method_info)
             _entry = _make_hotspot_entry(name, _complexity_score, start_line, end_line)
             if _complexity_score and _complexity_score >= _COMPLEXITY_HOTSPOT_THRESHOLD:
                 _hotspots.append(_entry)
@@ -211,6 +236,15 @@ def extract_structural_overview_universal(
             )
         elif etype == "import":
             _imports.append({"name": name, "line": start_line})
+
+    # Apply output cap (Bug #755)
+    total_methods = len(_all_methods)
+    overview["total_methods"] = total_methods
+    if total_methods > method_cap:
+        overview["methods"] = _all_methods[:method_cap]
+        overview["methods_truncated"] = True
+    else:
+        overview["methods"] = _all_methods
 
     return overview
 


### PR DESCRIPTION
## Summary

- **#796**: Rust enum variants (e.g. `enum Color { Red, Green, Blue }`) were invisible to the extractor — only the enum *class* was captured. Now each `enum_variant` is extracted as a `Variable` with `variable_type="enum_variant"` and `receiver_type` set to the enum name. A two-pass strategy prevents struct-like variant bodies from leaking `field_declaration` nodes as ordinary struct fields.
- **#755**: `extract_structural_overview` / `extract_structural_overview_universal` had no cap on the methods list. A file with thousands of methods would produce multi-MB JSON responses that crash agents. Added `METHODS_OUTPUT_CAP = 50` (configurable via `method_cap` kwarg). When truncated, `methods_truncated: True` and `total_methods: <full count>` are emitted.

## Files changed

- `tree_sitter_analyzer/languages/rust_plugin.py` — `_extract_enum_variants()` + `_collect_enum_variants()` + two-pass `extract_variables()`
- `tree_sitter_analyzer/mcp/tools/analyze_scale_helpers.py` — `METHODS_OUTPUT_CAP` constant, cap applied in both `extract_structural_overview` and `extract_structural_overview_universal`
- `tests/unit/languages/test_rust_enum_variants_796.py` — 7 new tests (unit variants, tuple variants, struct coexistence, receiver_type, line ranges, multi-enum)
- `tests/unit/mcp/test_tools/test_check_scale_output_cap_755.py` — 11 new tests covering universal path, Java/Python path, custom cap kwarg
- `tests/golden_masters/plugins/rust.json` — updated to include 4 UserRole enum variants (Variable count 6→10, total 22→26)

## Test plan

- [x] Unit tests for rust enum variants: 7 passed
- [x] Unit tests for check-scale output cap: 12 passed
- [x] Golden master regression test (rust): 1 passed
- [x] Full language + mcp tool unit suite: 4094 passed, 1 pre-existing Swift failure unrelated to these changes
