### PR TITLE
docs: correct CLI codemap surface (smart-context and --format)

### DIFF
--- a/docs/CODEMAPS/cli.md
+++ b/docs/CODEMAPS/cli.md
@@ -53,7 +53,7 @@ Categories of CLI surface:
 ### Project-Level
 - `--project-overview` — snapshot
 - `--project-health` — health-score distribution
-- `--smart-context [--query "X"]` — SMART workflow context
+- `--smart-context` / `smart-context FILE` — SMART workflow context
 - `--change-impact` — blast radius (`--change-impact-resource-profile local_low_impact` emits nice/xdist-capped local pytest commands plus the original CI command)
 - `--call-graph` — caller/callee graph
 
@@ -112,15 +112,20 @@ Categories of CLI surface:
 
 ## Output Format Selection
 
-`--format toon|json|table|csv|yaml`:
+`--format toon|json` (global machine-readable envelope alias):
 
 | Format | Default for | Token cost | Notes |
 |---|---|---|---|
 | `toon` | MCP | -73% vs JSON | LLM-optimized, lossless |
 | `json` | CLI | baseline | jq-pipe friendly |
+| `text` | `--output-format text` | n/a | human-readable output for legacy text paths |
 | `table` | `--table` flag | n/a | Box-drawing chars, terminal only |
 | `csv` | `--table csv` | n/a | spreadsheet ingestion |
-| `yaml` | optional | larger than JSON | human-readable structured |
+
+`--format` is intentionally narrower than `--output-format` and `--table`:
+use `--format json|toon` for agent envelopes, `--output-format text` for the
+remaining human-readable text paths, and `--table csv|full|compact|json|toon`
+for table rendering. There is no global `--format yaml` mode.
 
 ## File Output
 


### PR DESCRIPTION
### Motivation
- The CLI codemap advertised a non-existent `--smart-context --query "X"` form and overly-broad global `--format` options, causing agents and users to follow stale examples that fail at runtime.
- Documentation/CLI parity drift is a recurring pain point for MCP/CLI users and was the specific friction surfaced during a dogfood pass. 

### Description
- Update `docs/CODEMAPS/cli.md` to replace the invalid `--smart-context [--query "X"]` example with the actual `--smart-context` / `smart-context FILE` usage.
- Narrow the documented global `--format` to `json|toon`, add guidance that `--output-format text` serves legacy text paths, and clarify `--table`/`--table csv` are used for table/csv outputs. 

### Testing
- Ran the project change-impact check (`python -m tree_sitter_analyzer --change-impact --format json`) which classified this as a docs-only change and recommended `git diff --check` as verification, and `git diff --check` passed. 
- Executed CLI smoke checks which showed `smart-context FILE --format json` returns a valid envelope and that `--smart-context --query X` exits with argparse code `2` as expected, confirming the previous docs form was stale. 
- Verified `--help` shows `--format {json,toon}` and the updated codemap language matches the actual argparse surface.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f6a872b00832ea611b7662d0c5fdb)