### PR TITLE
fix(cli): use class_type in --advanced elements payload for TS enums/interfaces (#795)

### DIFF
--- a/tests/unit/cli/test_advanced_command.py
+++ b/tests/unit/cli/test_advanced_command.py
@@ -466,3 +466,70 @@ class TestR37yCanonicalEnvelope:
 
         assert "mode=full" in full_captured["summary_line"]
         assert "mode=stats" in stats_captured["summary_line"]
+
+
+# ---------------------------------------------------------------------------
+# Issue #795 — _build_elements_payload must use class_type for TS subtypes
+# ---------------------------------------------------------------------------
+
+
+class TestBuildElementsPayloadClassType:
+    """#795: enum/interface/type-alias mislabeled as type='class' in --advanced.
+
+    _build_elements_payload previously overwrote type with get_element_type()
+    which always returns ELEMENT_TYPE_CLASS ('class') for any Class model
+    object.  The fix uses class_type when available so TypeScript-specific
+    subtypes surface correctly.
+    """
+
+    def _make_class(self, class_type: str = "class") -> object:
+        from tree_sitter_analyzer.models import Class
+
+        return Class(
+            name="Test",
+            start_line=1,
+            end_line=5,
+            raw_text="",
+            language="typescript",
+            class_type=class_type,
+        )
+
+    def _build(self, elements: list) -> list:
+        from tree_sitter_analyzer.cli.commands.advanced_command import (
+            _build_elements_payload,
+        )
+
+        return _build_elements_payload(elements)
+
+    def test_interface_type_preserved(self):
+        payload = self._build([self._make_class("interface")])
+        assert payload[0]["type"] == "interface"
+
+    def test_enum_type_preserved(self):
+        payload = self._build([self._make_class("enum")])
+        assert payload[0]["type"] == "enum"
+
+    def test_type_alias_preserved(self):
+        payload = self._build([self._make_class("type")])
+        assert payload[0]["type"] == "type"
+
+    def test_namespace_type_preserved(self):
+        payload = self._build([self._make_class("namespace")])
+        assert payload[0]["type"] == "namespace"
+
+    def test_actual_class_still_class(self):
+        payload = self._build([self._make_class("class")])
+        assert payload[0]["type"] == "class"
+
+    def test_function_unaffected(self):
+        from tree_sitter_analyzer.models import Function
+
+        fn = Function(
+            name="do_thing",
+            start_line=1,
+            end_line=3,
+            raw_text="",
+            language="typescript",
+        )
+        payload = self._build([fn])
+        assert payload[0]["type"] == "function"

--- a/tree_sitter_analyzer/cli/commands/advanced_command.py
+++ b/tree_sitter_analyzer/cli/commands/advanced_command.py
@@ -122,7 +122,13 @@ def _build_elements_payload(
     elements_list = list(elements)
     for element in elements_list:
         elem_dict = element_to_dict(element, elements_list)
-        elem_dict["type"] = get_element_type(element)
+        # For Class-model objects (enums/interfaces/type-aliases in TS/JS/etc.),
+        # prefer the granular class_type over the generic "class" group key so
+        # that type:"enum", type:"interface", type:"type" reach the caller.
+        elem_type = get_element_type(element)
+        if elem_type == ELEMENT_TYPE_CLASS:
+            elem_type = getattr(element, "class_type", None) or elem_type
+        elem_dict["type"] = elem_type
         elem_dict["complexity"] = elem_dict.get("complexity_score")
         payload.append(elem_dict)
     return payload


### PR DESCRIPTION
## Summary

- `_build_elements_payload` in `advanced_command.py` overwrote `elem_dict["type"]` with `get_element_type(element)` which always returns `"class"` for any `Class` model object
- TypeScript interfaces, enums, type-aliases, and namespaces all appeared as `type:"class"` in `--advanced` JSON output despite the plugin setting `class_type` correctly
- Fix: when the element group key is `"class"`, prefer `getattr(element, "class_type", None)` so `type:"enum"`, `type:"interface"`, `type:"type"`, `type:"namespace"` surface correctly

Closes #795.

## Test plan

- [x] 6 new unit tests in `TestBuildElementsPayloadClassType` (interface, enum, type-alias, namespace, actual-class no-regression, Function no-regression)
- [x] All 6 pass: `uv run pytest tests/unit/cli/test_advanced_command.py::TestBuildElementsPayloadClassType -q`
- [x] Pre-commit hooks clean