### PR TITLE
fix(nav): ambiguity guard fires before NOT_FOUND; surface file_path mismatch hint (#866 #867)

### DIFF
--- a/tests/unit/mcp/test_nav_impact_boundary.py
+++ b/tests/unit/mcp/test_nav_impact_boundary.py
@@ -257,4 +257,61 @@ class TestNavImpactBoundary:
         assert body.get("ambiguous") is True
         assert body.get("candidate_count") == 2
         assert body.get("level") == "unknown"
-        assert "proceed with edit" not in body.get("next_step", "")
+        # #866: ambiguity message must fire BEFORE the NOT_FOUND branch
+        next_step = body.get("next_step", "")
+        assert "proceed with edit" not in next_step
+        assert "Ambiguous" in next_step, f"Expected ambiguity hint, got: {next_step!r}"
+        assert "not found" not in next_step.lower(), (
+            f"Got NOT_FOUND message instead of ambiguity hint: {next_step!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_file_path_mismatch_gives_candidate_hint(self, tmp_path) -> None:
+        """#867: when file_path is set but doesn't match, warn with candidate files."""
+        func_ref_a = _make_ref("execute", "src/tool_a.py")
+        graph = MagicMock()
+
+        # With file_path set: returns nothing (mismatch)
+        # Without file_path: returns the real candidate
+        def resolve_side_effect(name, fp=None):
+            if fp is not None:
+                return []
+            return [func_ref_a]
+
+        graph.resolve_targets.side_effect = resolve_side_effect
+        graph.caller_refs_of.return_value = []
+        graph.callee_refs_of.return_value = []
+        graph.call_chain.return_value = []
+
+        server = TreeSitterAnalyzerMCPServer(str(tmp_path))
+        handler = _capture_call_tool_handler(server)
+
+        with (
+            patch(
+                "tree_sitter_analyzer.mcp.tools.codegraph_impact_tool"
+                ".CodeGraphImpactTool._get_call_graph",
+                return_value=graph,
+            ),
+            patch.object(graph, "build", return_value=None),
+        ):
+            raw = await handler(
+                "nav",
+                {
+                    "action": "impact",
+                    "mode": "risk_score",
+                    "function_name": "execute",
+                    "file_path": "src/wrong_file.py",
+                    "output_format": "json",
+                },
+            )
+
+        body = json.loads(raw[0].text)
+        assert body["success"] is True
+        assert body.get("verdict") == "NOT_FOUND"
+        next_step = body.get("next_step", "")
+        assert "mismatch" in next_step.lower(), (
+            f"Expected file_path mismatch hint, got: {next_step!r}"
+        )
+        assert "src/tool_a.py" in next_step, (
+            f"Expected candidate file in hint, got: {next_step!r}"
+        )

--- a/tree_sitter_analyzer/mcp/tools/codegraph_impact_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_impact_tool.py
@@ -120,12 +120,20 @@ def _compute_risk_score(
 ) -> dict[str, Any]:
     targets = graph.resolve_targets(func_name, file_path)
     if not targets:
-        return {
+        base: dict[str, Any] = {
             "score": 0,
             "level": "unknown",
             "factors": {},
             "tests": {"test_callers_count": 0, "test_callees_count": 0},
         }
+        # #867: when file_path was given but no match, check without it so we
+        # can warn the caller about the mismatch rather than silently NOT_FOUND.
+        if file_path is not None:
+            unconstrained = graph.resolve_targets(func_name, None)
+            if unconstrained:
+                base["file_path_mismatch"] = True
+                base["candidate_files"] = [t.file_path for t in unconstrained[:5]]
+        return base
 
     # Ambiguity guard (#799): multiple definitions of the same name exist.
     # Picking targets[0] silently would produce misleading low-risk verdicts for
@@ -495,20 +503,43 @@ class CodeGraphImpactTool(BaseMCPTool):
             level = result.get("level", "unknown")
             summary_line = f"impact: risk_score={score} level={level}"
 
-        if verdict == "NOT_FOUND":
-            next_step = (
-                "Symbol not found in the call graph. "
-                "Check the function name or run index action=auto."
-            )
-        elif result.get("ambiguous"):
-            # #799: multiple definitions; the picked candidate may not be the
-            # intended one — do NOT say "proceed with edit".
-            candidate_count = result.get("candidate_count", 2)
+        # #866: ambiguous flag lives at top level for risk_score, nested under
+        # "risk" for function_impact. Check BEFORE NOT_FOUND because level="unknown"
+        # (set when ambiguous) makes _impact_verdict return NOT_FOUND, which would
+        # shadow the ambiguity message if we checked NOT_FOUND first.
+        is_ambiguous = result.get("ambiguous") or result.get("risk", {}).get(
+            "ambiguous"
+        )
+        if is_ambiguous:
+            candidate_count = result.get("candidate_count") or result.get(
+                "risk", {}
+            ).get("candidate_count", 2)
+            verdict = "CAUTION"
             next_step = (
                 f"Ambiguous symbol — {candidate_count} definitions found. "
                 "Re-run with file_path to disambiguate "
                 "(e.g. nav action=impact mode=risk_score "
                 "function_name=execute file_path=path/to/file.py)."
+            )
+        elif result.get("file_path_mismatch") or result.get("risk", {}).get(
+            "file_path_mismatch"
+        ):
+            # #867: file_path was given but doesn't match any definition.
+            risk_or_result = (
+                result if result.get("file_path_mismatch") else result.get("risk", {})
+            )
+            candidate_files = risk_or_result.get("candidate_files", [])
+            files_hint = ", ".join(candidate_files) if candidate_files else "unknown"
+            verdict = "NOT_FOUND"
+            next_step = (
+                f"file_path mismatch — symbol not found at '{file_path}'. "
+                f"Known definitions: {files_hint}. "
+                "Re-run with the correct file_path or omit it to use ambiguity resolution."
+            )
+        elif verdict == "NOT_FOUND":
+            next_step = (
+                "Symbol not found in the call graph. "
+                "Check the function name or run index action=auto."
             )
         elif verdict in ("CAUTION", "REVIEW"):
             next_step = (
@@ -523,6 +554,7 @@ class CodeGraphImpactTool(BaseMCPTool):
             "success": True,
             "mode": mode,
             "verdict": verdict,
+            "next_step": next_step,
             **result,
             "agent_summary": {
                 "summary_line": summary_line,


### PR DESCRIPTION
## Summary

- **#866**: `execute()` next_step branching now checks `is_ambiguous` (top-level AND nested under `risk.ambiguous` for `function_impact` mode) **before** `verdict == "NOT_FOUND"`. Previously `level="unknown"` set by the ambiguity guard caused `_impact_verdict` to return `NOT_FOUND`, shadowing the ambiguity branch and emitting a silent/wrong message.
- **#867**: `_compute_risk_score` now makes a second unconstrained `resolve_targets` call when `file_path` is given but no targets match, surfacing `file_path_mismatch=True` and `candidate_files` so the caller gets a useful hint instead of a silent `NOT_FOUND`.
- `next_step` is now exposed at the top-level response dict (alongside `agent_summary.next_step`) so agents reading `body["next_step"]` directly see the correct value.

## Test plan

- [ ] `test_ambiguous_symbol_sets_flag_and_unknown_level` — `"Ambiguous" in next_step`, `"not found" not in next_step`
- [ ] `test_file_path_mismatch_gives_candidate_hint` (new) — `"mismatch" in next_step`, `"src/tool_a.py" in next_step`
- [ ] All 5 `TestNavImpactBoundary` tests pass through the live `handle_call_tool` boundary
- [ ] 6234 tests green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)