### PR TITLE
fix(cli): quote --agent-workflow command paths

### DIFF
--- a/tests/unit/mcp/test_agent_workflow_tool.py
+++ b/tests/unit/mcp/test_agent_workflow_tool.py
@@ -18,6 +18,7 @@ path interpolation, and envelope mirroring.
 from __future__ import annotations
 
 import asyncio
+import shlex
 
 import pytest
 
@@ -284,6 +285,49 @@ async def test_agent_workflow_tool_unsupported_extension_still_plans(tmp_path):
     # Agent_summary surface populated (next_step references the path so
     # callers can branch even on unsupported languages).
     assert "src/service.unknownext" in result["agent_summary"]["next_step"]
+
+
+@pytest.mark.asyncio
+async def test_agent_workflow_tool_quotes_target_with_spaces_in_cli_commands(tmp_path):
+    """Path tokens in generated workflow commands are shell-safe for spaces."""
+    target = tmp_path / "src" / "space file.py"
+    target.parent.mkdir()
+    target.write_text("def run():\\n    return 1\\n", encoding="utf-8")
+    target_path = "src/space file.py"
+    safe_target = shlex.quote(target_path)
+
+    result = await AgentWorkflowTool(str(tmp_path)).execute(
+        {"target_path": target_path, "output_format": "json"}
+    )
+
+    analyze_step = next(step for step in result["steps"] if step["step"] == "analyze")
+    retrieve_step = next(step for step in result["steps"] if step["step"] == "retrieve")
+    trace_step = next(step for step in result["steps"] if step["step"] == "trace")
+
+    assert analyze_step["cli_commands"][0] == (
+        f"uv run tree-sitter-analyzer smart-context {safe_target} --format json"
+    )
+    assert analyze_step["cli_commands"][1] == (
+        f"uv run tree-sitter-analyzer file-health {safe_target} --format json"
+    )
+    assert retrieve_step["cli_commands"][0] == (
+        f"uv run tree-sitter-analyzer {safe_target} --structure --output-format json"
+    )
+    assert trace_step["cli_commands"][0] == (
+        f"uv run tree-sitter-analyzer {safe_target} --dependencies file_deps --format json"
+    )
+    assert result["agent_summary"]["next_step"] == (
+        "uv run tree-sitter-analyzer safe-to-edit "
+        f"{safe_target} --edit-type refactor --format json"
+    )
+    assert result["agent_summary"]["queue_ledger_command"] == (
+        "uv run tree-sitter-analyzer change-impact "
+        f"--change-impact-scope {safe_target} --agent-summary-only --format json"
+    )
+    assert (
+        trace_step["cli_commands"][-1]
+        == result["agent_summary"]["queue_ledger_command"]
+    )
 
 
 @pytest.mark.asyncio

--- a/tree_sitter_analyzer/cli/agent_workflow.py
+++ b/tree_sitter_analyzer/cli/agent_workflow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shlex
 from typing import Any
 
 PHASE_ORDER = ("set", "map", "analyze", "retrieve", "trace")
@@ -98,12 +99,13 @@ def build_agent_workflow_pack(
 
 def _build_steps(target: str) -> list[dict[str, Any]]:
     """Build all SMART workflow steps."""
+    safe_target = _shell_safe_path(target)
     steps = [
         _set_step(),
         _map_step(),
-        _analyze_step(target),
-        _retrieve_step(target),
-        _trace_step(target),
+        _analyze_step(safe_target),
+        _retrieve_step(safe_target),
+        _trace_step(safe_target),
     ]
     return _build_step_handoffs(steps)
 
@@ -217,7 +219,10 @@ def _analyze_step(target: str) -> dict[str, Any]:
         "cli_commands": [
             f"uv run tree-sitter-analyzer smart-context {target} --format json",
             f"uv run tree-sitter-analyzer file-health {target} --format json",
-            f"uv run tree-sitter-analyzer safe-to-edit {target} --edit-type refactor --format json",
+            (
+                "uv run tree-sitter-analyzer safe-to-edit "
+                f"{target} --edit-type refactor --format json"
+            ),
             f"uv run tree-sitter-analyzer refactor {target} --format json",
         ],
         "stop_condition": "Queue head, edit boundary, and verification hints are clear.",
@@ -270,13 +275,17 @@ def _build_agent_summary(
     recommended_commands: list[str],
 ) -> dict[str, Any]:
     """Build the compact decision surface for the workflow pack."""
+    safe_target_path = (
+        _shell_safe_path(target_path) if target_path else "path/to/file.py"
+    )
     first_command = (
-        f"uv run tree-sitter-analyzer safe-to-edit {target_path} --edit-type refactor --format json"
+        "uv run tree-sitter-analyzer safe-to-edit "
+        f"{safe_target_path} --edit-type refactor --format json"
         if target_path
         else "uv run tree-sitter-analyzer overview --format json"
     )
     queue_ledger_command = (
-        _scoped_change_impact_command(target_path) if target_path else ""
+        _scoped_change_impact_command(safe_target_path) if target_path else ""
     )
     next_phase = _build_next_phase(current_phase)
     # G8: build summary_line + verdict so this planning tool obeys the
@@ -351,7 +360,9 @@ def _build_evaluator_checks(
         checks.append(
             {
                 "name": "queue_ledger",
-                "command": _scoped_change_impact_command(target_path),
+                "command": _scoped_change_impact_command(
+                    _shell_safe_path(target_path)
+                ),
                 "required": False,
                 "purpose": (
                     "Emit scoped change-impact so evaluator can approve the handoff "
@@ -368,6 +379,13 @@ def _scoped_change_impact_command(target: str) -> str:
         "uv run tree-sitter-analyzer change-impact "
         f"--change-impact-scope {target} --agent-summary-only --format json"
     )
+
+
+def _shell_safe_path(path: str | None) -> str:
+    """Return a shell-safe token for user-provided file paths."""
+    if path is None:
+        return ""
+    return shlex.quote(path)
 
 
 def _build_toon_content(result: dict[str, Any]) -> str:


### PR DESCRIPTION
## Summary
- Quote user-provided target paths in CLI workflow command suggestions to prevent broken command copy/paste for filenames with spaces.
- Apply shell-safe quoting in analyze/retrieve/trace commands and queue ledger/summary command generation.
- Add MCP test coverage for spaced path tokenization in workflow CLI commands.

Closes #864.