### PR TITLE
fix(index): propagate incremental_sync DB errors to top-level verdict (#860)

### DIFF
--- a/tests/unit/test_codegraph_full_index_tool.py
+++ b/tests/unit/test_codegraph_full_index_tool.py
@@ -70,3 +70,30 @@ class TestExecute:
         result = await tool_with_root.execute({"mode": "incremental"})
         assert result["format"] == "toon"
         assert "toon_content" in result
+
+    async def test_verdict_is_warn_when_incremental_sync_has_errors(
+        self, tool_with_root
+    ):
+        """#860: DB flush errors in incremental_sync must escalate verdict to WARN."""
+        from unittest.mock import patch
+
+        from tree_sitter_analyzer.incremental_sync import SyncResult
+
+        bad_result = SyncResult(
+            scanned=5,
+            new_files=0,
+            updated_files=0,
+            deleted_files=0,
+            unchanged_files=5,
+            errors=1,
+        )
+        with patch("tree_sitter_analyzer.incremental_sync.IncrementalSync") as MockSync:
+            MockSync.return_value.sync.return_value = bad_result
+            result = await tool_with_root.execute(
+                {"mode": "incremental", "output_format": "json"}
+            )
+
+        assert result["success"] is True
+        assert result["verdict"] == "WARN"
+        assert result["phases"]["incremental_sync"]["status"] == "error"
+        assert result["phases"]["incremental_sync"]["errors"] == 1

--- a/tree_sitter_analyzer/mcp/tools/full_index_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/full_index_tool.py
@@ -150,9 +150,16 @@ class CodeGraphFullIndexTool(BaseMCPTool):
 
         stats = self._collect_final_stats()
 
+        # #860: propagate phase-level errors to top-level verdict so callers
+        # don't receive "success: True / verdict: INFO" when a DB flush failed.
+        any_phase_error = any(
+            p.get("status") == "error" for p in phases.values() if isinstance(p, dict)
+        )
+        top_verdict = "WARN" if any_phase_error else "INFO"
+
         result: dict[str, Any] = {
             "success": True,
-            "verdict": "INFO",
+            "verdict": top_verdict,
             "mode": mode,
             "elapsed_seconds": elapsed,
             "phases": phases,
@@ -214,14 +221,18 @@ class CodeGraphFullIndexTool(BaseMCPTool):
             result = sync.sync(max_files=20_000)
             cache.close()
             elapsed = round(time.monotonic() - t0, 3)
+            # #860: surface DB flush failures — sync catches them into result.errors
+            # so they never raise but also must NOT be silently reported as "ok".
+            status = "error" if result.errors > 0 else "ok"
             return {
-                "status": "ok",
+                "status": status,
                 "elapsed_seconds": elapsed,
                 "scanned": result.scanned,
                 "new_files": result.new_files,
                 "updated_files": result.updated_files,
                 "deleted_files": result.deleted_files,
                 "unchanged_files": result.unchanged_files,
+                "errors": result.errors,
             }
         except Exception as exc:
             return {


### PR DESCRIPTION
## Summary

- `_phase_incremental_sync` now returns `status: "error"` (and includes `errors` count) when `sync_stats.errors > 0` — DB commit failures are caught by `IncrementalSync.sync()` into `result.errors`, not as exceptions, so they were silently reported as `"ok"` before this fix
- `execute()` now checks all phases for any `status == "error"` and sets top-level `verdict: "WARN"` instead of the previous `"INFO"`, so callers get a non-ok signal

## Test plan

- [x] `test_verdict_is_warn_when_incremental_sync_has_errors` — mocks `IncrementalSync.sync()` to return `errors=1`, asserts `verdict=="WARN"`, `phases.incremental_sync.status=="error"`, `errors==1`
- [x] All existing 12 tests pass

Fixes #860.

🤖 Generated with [Claude Code](https://claude.com/claude-code)