### PR TITLE
fix(cli): --symbol-lineage empty string emits validation error not usage dump (#863)

### DIFF
--- a/tests/unit/cli/test_class_hierarchy_and_dep_matrix_cli.py
+++ b/tests/unit/cli/test_class_hierarchy_and_dep_matrix_cli.py
@@ -260,6 +260,33 @@ def test_dependency_matrix_unstable_cli(monkeypatch) -> None:
     assert seen["arguments"]["threshold"] == 0.8
 
 
+def test_symbol_lineage_empty_string_returns_error_not_usage_dump() -> None:
+    """#863: --symbol-lineage "" must emit a clean validation error, not a usage dump."""
+    errors: list[str] = []
+    result = mcp_commands.handle_mcp_commands(
+        _args(symbol_lineage=""),
+        lambda payload: None,
+        errors.append,
+        lambda: "json",
+    )
+    assert result == 1
+    assert len(errors) == 1
+    assert "symbol" in errors[0].lower() or "empty" in errors[0].lower()
+
+
+def test_symbol_lineage_whitespace_only_returns_error() -> None:
+    """#863: --symbol-lineage '   ' is treated the same as empty."""
+    errors: list[str] = []
+    result = mcp_commands.handle_mcp_commands(
+        _args(symbol_lineage="   "),
+        lambda payload: None,
+        errors.append,
+        lambda: "json",
+    )
+    assert result == 1
+    assert len(errors) == 1
+
+
 def test_dependency_matrix_file_cli(monkeypatch) -> None:
     seen: dict[str, Any] = {}
 

--- a/tree_sitter_analyzer/cli/commands/mcp_commands/_specs_core.py
+++ b/tree_sitter_analyzer/cli/commands/mcp_commands/_specs_core.py
@@ -125,6 +125,8 @@ _CORE_SPECS: tuple[McpCommandSpec, ...] = (
         flag_name="symbol_lineage",
         tool_attr="SymbolLineageTool",
         label="Symbol lineage and impact preview",
+        value_arg_name="symbol_lineage",
+        required_value_error="--symbol-lineage: symbol must not be empty",
         build_tool_args=lambda args, output_format: {
             "symbol": getattr(args, "symbol_lineage", "") or "",
             "max_depth": getattr(args, "max_depth", 3),


### PR DESCRIPTION
## Summary

Added `value_arg_name="symbol_lineage"` and `required_value_error` to the `McpCommandSpec` for `--symbol-lineage`:

- **Before**: `--symbol-lineage ""` — empty string is falsy, spec not selected, falls through to argparse help/usage dump (exits with a huge block of text)
- **After**: `--symbol-lineage ""` — empty `str` matches `isinstance(value, str)` check, spec IS selected, then `validate_mcp_command_args` fires and emits `"--symbol-lineage: symbol must not be empty"` to stderr with RC=1

## Test plan

- [x] `test_symbol_lineage_empty_string_returns_error_not_usage_dump` — RC=1, one error line containing "symbol" or "empty"
- [x] `test_symbol_lineage_whitespace_only_returns_error` — same for `"   "`
- [x] All existing CLI tests pass (symbol_lineage=False in test Namespace skips the spec because `isinstance(False, str)` is False)

Fixes #863.

🤖 Generated with [Claude Code](https://claude.com/claude-code)