### PR TITLE
fix(enrich): .h callee causes wrong cpp lang hint in call_path bodies (#865)

### DIFF
--- a/tests/unit/mcp/tools/test_call_path_enrich.py
+++ b/tests/unit/mcp/tools/test_call_path_enrich.py
@@ -207,6 +207,68 @@ def test_inline_path_bodies_returns_verbatim_bodies(tmp_path):
     assert "def gamma" in gamma["content"]
 
 
+def test_inline_path_bodies_cpp_header_callee_lang_hint(tmp_path):
+    """#865: .h callee must not gate out C++ caller definitions.
+
+    Path: caller_func (no caller_file) → foo (include/foo.h).
+    caller_func is indexed as "cpp".  Before the fix, path_lang_hint="c"
+    from the .h callee caused _resolve_def to reject the cpp candidate via
+    the directional rule languages_compatible("c","cpp") == False.
+    """
+    (tmp_path / "caller.cpp").write_text("void caller_func() { foo(); }\n")
+
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    db.execute(
+        "CREATE TABLE ast_index"
+        " (file_path TEXT PRIMARY KEY, symbols_json TEXT, language TEXT)"
+    )
+    db.execute(
+        "INSERT INTO ast_index (file_path, symbols_json, language) VALUES (?,?,?)",
+        (
+            "caller.cpp",
+            json.dumps(
+                {
+                    "symbols": [
+                        {
+                            "name": "caller_func",
+                            "kind": "function",
+                            "line": 1,
+                            "end_line": 1,
+                        }
+                    ]
+                }
+            ),
+            "cpp",
+        ),
+    )
+    db.commit()
+
+    cache = MagicMock()
+    cache.has_call_edges.return_value = True
+    cache.get_conn.return_value = db
+
+    paths = [
+        {
+            "hops": [
+                {
+                    "caller": "caller_func",
+                    "caller_file": "",  # source_file not provided
+                    "callee": "foo",
+                    "callee_file": "include/foo.h",  # .h → "c" without fix
+                    "line": 1,
+                }
+            ]
+        }
+    ]
+
+    bodies, _ = enrich.inline_path_bodies(str(tmp_path), cache, paths)
+    names = {b["name"] for b in bodies}
+    # Without fix: lang_hint="c" from .h gates out the cpp definition → names={}
+    # With fix: "cpp" used as path_lang_hint → caller_func body is inlined
+    assert "caller_func" in names
+
+
 def test_inline_path_bodies_dedupes(tmp_path):
     cache = _build_cache(tmp_path)
     # Two paths that share the alpha->beta prefix.

--- a/tree_sitter_analyzer/mcp/tools/call_path_enrich.py
+++ b/tree_sitter_analyzer/mcp/tools/call_path_enrich.py
@@ -263,6 +263,22 @@ def _collect_path_functions(
     return ordered
 
 
+def _lang_hint_for_path(path: str) -> str:
+    """Language hint for ``path``, treating ``.h`` headers as ``cpp``.
+
+    Plain C headers (``.h``) map to ``"c"`` via ``language_from_path``, but
+    headers are included by both C and C++ callers.  Using ``"c"`` as a
+    path-level fallback hint blocks C++ definitions via the directional rule
+    ``languages_compatible("c", "cpp") == False``.  Mapping ``.h`` → ``"cpp"``
+    keeps the hint permissive: ``languages_compatible("cpp", "c")`` is True, so
+    pure-C definitions are still accepted. (#865)
+    """
+    lang = language_from_path(path)
+    if lang == "c" and path.lower().endswith(".h"):
+        return "cpp"
+    return lang
+
+
 def inline_path_bodies(
     project_root: str,
     cache: Any,
@@ -292,7 +308,10 @@ def inline_path_bodies(
     # missing-file source symbol (e.g. 'execute' with no caller_file) does not
     # fall back to a same-named symbol in a completely unrelated language (e.g.
     # Go runtime proc.go when the path is Python). (#800)
-    path_langs = [language_from_path(fh) for _, fh in functions if fh]
+    # #865: .h headers are ambiguous — included by both C and C++ callers.
+    # Use "cpp" for .h files so the path hint doesn't gate out C++ definitions
+    # via the directional rule languages_compatible("c","cpp") == False.
+    path_langs = [_lang_hint_for_path(fh) for _, fh in functions if fh]
     path_lang_hint = next((lg for lg in path_langs if lg), None)
 
     for name, file_hint in functions:


### PR DESCRIPTION
## Summary

- `call_path_enrich.py`: adds `_lang_hint_for_path()` helper that maps `.h` → `"cpp"` for path-level language hints
- When `source_file` is omitted (caller_file empty), the only file hint may be the callee's `.h` header. Using `"c"` as `path_lang_hint` gated out C++ caller definitions via the directional rule `languages_compatible("c","cpp") == False`.
- `"cpp"` is the right upgrade: `languages_compatible("cpp","c")` is True so pure-C definitions are still accepted.

## Test plan

- [x] `test_inline_path_bodies_cpp_header_callee_lang_hint` — new RED→GREEN test
- [x] All 8 existing call_path_enrich tests pass
- [x] Full 4643-test suite green