### PR TITLE
fix(cli): validate target_path in agent workflow before building analyze plan (#862)

### DIFF
--- a/tests/unit/cli/test_cli_main_module.py
+++ b/tests/unit/cli/test_cli_main_module.py
@@ -96,12 +96,14 @@ class TestHandleSpecialCommandsBranchCoverage:
         assert payload["skills"][0]["acceptance_criteria_present"] is True
 
     @patch("tree_sitter_analyzer.output_manager.output_json")
-    def test_handle_agent_workflow_outputs_pack(self, mock_output_json):
+    def test_handle_agent_workflow_outputs_pack(self, mock_output_json, tmp_path):
         """Agent workflow returns a structured SMART command pack."""
+        target = tmp_path / "target.py"
+        target.write_text("def run(): pass\n")
         args = argparse.Namespace(
             agent_workflow=True,
             file_path="target.py",
-            project_root="/repo",
+            project_root=str(tmp_path),
             format="json",
         )
 

--- a/tests/unit/mcp/test_agent_workflow_tool.py
+++ b/tests/unit/mcp/test_agent_workflow_tool.py
@@ -495,3 +495,54 @@ async def test_agent_workflow_tool_envelope_holds_for_both_formats(tmp_path):
                 args["target_path"] = target_path
             result = await tool.execute(args)
             _assert_envelope_holds(result, target_path, output_format)
+
+
+# ---------------------------------------------------------------------------
+# CLI builder path validation (#862)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_builder_blocks_missing_file(tmp_path):
+    """build_agent_workflow_pack returns risk=blocked for non-existent target.
+
+    The CLI planner must validate the target path before building an analyze
+    plan — a missing file produces blocked result, not an analyze plan that
+    will fail downstream.
+    """
+    result = agent_workflow.build_agent_workflow_pack(
+        project_root=str(tmp_path),
+        target_path="no_such_file.py",
+    )
+    assert result["success"] is False
+    assert result.get("risk") == "blocked"
+    assert "no_such_file.py" in result.get("error", "")
+    assert result.get("current_phase") != "analyze"
+    assert result.get("recommended_commands", []) == []
+
+
+def test_cli_builder_blocks_path_outside_project(tmp_path):
+    """build_agent_workflow_pack returns risk=blocked for an external absolute path.
+
+    A path that resolves outside project_root is rejected so the planner
+    cannot generate commands referencing system-level files.
+    """
+    result = agent_workflow.build_agent_workflow_pack(
+        project_root=str(tmp_path),
+        target_path="/tmp/outside.py",
+    )
+    assert result["success"] is False
+    assert result.get("risk") == "blocked"
+    assert result.get("recommended_commands", []) == []
+
+
+def test_cli_builder_succeeds_for_existing_file(tmp_path):
+    """build_agent_workflow_pack proceeds normally when target file exists."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "service.py").write_text("def run(): pass\n")
+
+    result = agent_workflow.build_agent_workflow_pack(
+        project_root=str(tmp_path),
+        target_path="src/service.py",
+    )
+    assert result["success"] is True
+    assert result["current_phase"] == "analyze"

--- a/tree_sitter_analyzer/cli/agent_workflow.py
+++ b/tree_sitter_analyzer/cli/agent_workflow.py
@@ -48,16 +48,24 @@ def _check_target_path(project_root: str, target_path: str) -> str | None:
 
     Checks:
     1. The resolved path must sit inside ``project_root`` (boundary guard).
-    2. The file must exist.
+    2. The path must be an existing file (not a directory).
+
+    Windows-style separators are normalised to ``/`` so POSIX hosts do not
+    report ``src\\file.py`` as missing when ``src/file.py`` exists.
     """
     root = Path(project_root).resolve()
-    candidate = Path(target_path).expanduser()
+    # Normalise Windows separators before constructing the Path so that
+    # ``src\service.py`` resolves correctly on POSIX hosts.
+    normalised = target_path.replace("\\", "/")
+    candidate = Path(normalised).expanduser()
     resolved = candidate if candidate.is_absolute() else root / candidate
     try:
         resolved.resolve().relative_to(root)
     except ValueError:
         return f"target_path '{target_path}' is outside the project root"
-    if not resolved.exists():
+    if not resolved.is_file():
+        if resolved.is_dir():
+            return f"target_path '{target_path}' is a directory, not a file"
         return f"target_path '{target_path}' does not exist"
     return None
 
@@ -78,9 +86,9 @@ def build_agent_workflow_pack(
                 "project_root": project_root,
                 "current_phase": "set",
                 "recommended_commands": [],
-                "verdict": "BLOCKED",
+                "verdict": "ERROR",
                 "agent_summary": {
-                    "verdict": "BLOCKED",
+                    "verdict": "ERROR",
                     "risk": "blocked",
                     "summary_line": f"agent_workflow blocked: {err}",
                     "next_step": "Provide a valid target_path within the project root.",

--- a/tree_sitter_analyzer/cli/agent_workflow.py
+++ b/tree_sitter_analyzer/cli/agent_workflow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import shlex
+from pathlib import Path
 from typing import Any
 
 PHASE_ORDER = ("set", "map", "analyze", "retrieve", "trace")
@@ -42,11 +43,50 @@ PHASE_ROUTING: tuple[dict[str, str], ...] = (
 )
 
 
+def _check_target_path(project_root: str, target_path: str) -> str | None:
+    """Return an error message if ``target_path`` is invalid, else ``None``.
+
+    Checks:
+    1. The resolved path must sit inside ``project_root`` (boundary guard).
+    2. The file must exist.
+    """
+    root = Path(project_root).resolve()
+    candidate = Path(target_path).expanduser()
+    resolved = candidate if candidate.is_absolute() else root / candidate
+    try:
+        resolved.resolve().relative_to(root)
+    except ValueError:
+        return f"target_path '{target_path}' is outside the project root"
+    if not resolved.exists():
+        return f"target_path '{target_path}' does not exist"
+    return None
+
+
 def build_agent_workflow_pack(
     project_root: str,
     target_path: str | None = None,
 ) -> dict[str, Any]:
     """Build a SMART workflow command pack for agents and humans."""
+    if target_path:
+        err = _check_target_path(project_root, target_path)
+        if err:
+            return {
+                "success": False,
+                "risk": "blocked",
+                "error": err,
+                "target_path": target_path,
+                "project_root": project_root,
+                "current_phase": "set",
+                "recommended_commands": [],
+                "verdict": "BLOCKED",
+                "agent_summary": {
+                    "verdict": "BLOCKED",
+                    "risk": "blocked",
+                    "summary_line": f"agent_workflow blocked: {err}",
+                    "next_step": "Provide a valid target_path within the project root.",
+                    "current_phase": "set",
+                },
+            }
     target = target_path or "path/to/file.py"
     steps = _build_steps(target)
     queue_boundary = _build_queue_boundary_commands()
@@ -360,9 +400,7 @@ def _build_evaluator_checks(
         checks.append(
             {
                 "name": "queue_ledger",
-                "command": _scoped_change_impact_command(
-                    _shell_safe_path(target_path)
-                ),
+                "command": _scoped_change_impact_command(_shell_safe_path(target_path)),
                 "required": False,
                 "purpose": (
                     "Emit scoped change-impact so evaluator can approve the handoff "

--- a/tree_sitter_analyzer/mcp/tools/agent_workflow_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/agent_workflow_tool.py
@@ -88,6 +88,17 @@ class AgentWorkflowTool(BaseMCPTool):
         # planning output stable while only the MCP envelope is
         # normalised.
         _canonicalize_workflow_verdict(result)
+        # Blocked results (success=False) lack the full workflow envelope
+        # that _build_toon_response expects.  Return them directly so TOON
+        # callers don't get a KeyError; include format and toon_content for
+        # parity with the normal TOON shape.
+        if not result.get("success", True):
+            if arguments.get("output_format", "toon") == "toon":
+                result["format"] = "toon"
+                result["toon_content"] = (
+                    f"blocked: {result.get('error', 'invalid target_path')}"
+                )
+            return result
         if arguments.get("output_format", "toon") == "toon":
             return _build_toon_response(result)
         # Strip ``toon_content`` from the JSON path — wastes ~2 KB per


### PR DESCRIPTION
## Summary

- `build_agent_workflow_pack` now calls `_check_target_path()` before building the plan
- Missing file → `success=False, risk=blocked, recommended_commands=[]`
- Path outside `project_root` → same blocked response
- Existing relative paths within project root proceed normally

## Test plan

- [x] `test_cli_builder_blocks_missing_file` — new: non-existent file returns blocked
- [x] `test_cli_builder_blocks_path_outside_project` — new: `/tmp/outside.py` returns blocked
- [x] `test_cli_builder_succeeds_for_existing_file` — new: valid file succeeds
- [x] `test_handle_agent_workflow_outputs_pack` — updated to use `tmp_path` with real file
- [x] Full 19114-test suite green