### PR TITLE
fix(enrich): use neutral lang hint for .h files; apply per-function hint fix (#865 codex-p2)

### DIFF
--- a/tests/unit/mcp/tools/test_call_path_enrich.py
+++ b/tests/unit/mcp/tools/test_call_path_enrich.py
@@ -265,7 +265,69 @@ def test_inline_path_bodies_cpp_header_callee_lang_hint(tmp_path):
     bodies, _ = enrich.inline_path_bodies(str(tmp_path), cache, paths)
     names = {b["name"] for b in bodies}
     # Without fix: lang_hint="c" from .h gates out the cpp definition → names={}
-    # With fix: "cpp" used as path_lang_hint → caller_func body is inlined
+    # With fix: "" (neutral) used as path_lang_hint → no lang filter → caller_func inlined
+    assert "caller_func" in names
+
+
+def test_inline_path_bodies_cpp_with_explicit_h_callee_file(tmp_path):
+    """.h as explicit callee_file must not gate out C++ caller definitions (#865 P2).
+
+    Codex P2: when callee_file is an explicit ".h" path (not just the fallback
+    path_lang_hint), the per-function lang_hint was still derived from
+    language_from_path("foo.h") = "c", blocking C++ callers via
+    languages_compatible("c","cpp") == False.
+    Fix: _lang_hint_for_path returns "" for .h so _resolve_def skips language filter.
+    """
+    (tmp_path / "caller.cpp").write_text("void caller_func() { foo(); }\n")
+
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+    db.execute(
+        "CREATE TABLE ast_index"
+        " (file_path TEXT PRIMARY KEY, symbols_json TEXT, language TEXT)"
+    )
+    db.execute(
+        "INSERT INTO ast_index (file_path, symbols_json, language) VALUES (?,?,?)",
+        (
+            "caller.cpp",
+            json.dumps(
+                {
+                    "symbols": [
+                        {
+                            "name": "caller_func",
+                            "kind": "function",
+                            "line": 1,
+                            "end_line": 1,
+                        }
+                    ]
+                }
+            ),
+            "cpp",
+        ),
+    )
+    db.commit()
+
+    cache = MagicMock()
+    cache.has_call_edges.return_value = True
+    cache.get_conn.return_value = db
+
+    paths = [
+        {
+            "hops": [
+                {
+                    "caller": "caller_func",
+                    "caller_file": "src/main.cpp",  # explicit .cpp caller_file
+                    "callee": "foo",
+                    "callee_file": "include/foo.h",  # explicit .h callee_file
+                    "line": 1,
+                }
+            ]
+        }
+    ]
+
+    bodies, _ = enrich.inline_path_bodies(str(tmp_path), cache, paths)
+    names = {b["name"] for b in bodies}
+    # caller_func body must be inlined even when callee_file is an explicit .h path
     assert "caller_func" in names
 
 

--- a/tree_sitter_analyzer/mcp/tools/call_path_enrich.py
+++ b/tree_sitter_analyzer/mcp/tools/call_path_enrich.py
@@ -264,18 +264,18 @@ def _collect_path_functions(
 
 
 def _lang_hint_for_path(path: str) -> str:
-    """Language hint for ``path``, treating ``.h`` headers as ``cpp``.
+    """Language hint for ``path``, returning empty string for ``.h`` headers.
 
     Plain C headers (``.h``) map to ``"c"`` via ``language_from_path``, but
-    headers are included by both C and C++ callers.  Using ``"c"`` as a
-    path-level fallback hint blocks C++ definitions via the directional rule
-    ``languages_compatible("c", "cpp") == False``.  Mapping ``.h`` → ``"cpp"``
-    keeps the hint permissive: ``languages_compatible("cpp", "c")`` is True, so
-    pure-C definitions are still accepted. (#865)
+    headers are included by both C and C++ callers.  Using ``"c"`` blocks C++
+    definitions via ``languages_compatible("c","cpp") == False``; using ``"cpp"``
+    risks selecting C++ definitions in pure-C projects when names collide.
+    Returning ``""`` (falsy) lets ``_resolve_def`` skip the language filter
+    entirely for header file hints, accepting any same-named candidate. (#865)
     """
     lang = language_from_path(path)
     if lang == "c" and path.lower().endswith(".h"):
-        return "cpp"
+        return ""
     return lang
 
 
@@ -315,7 +315,12 @@ def inline_path_bodies(
     path_lang_hint = next((lg for lg in path_langs if lg), None)
 
     for name, file_hint in functions:
-        lang_hint = language_from_path(file_hint) if file_hint else path_lang_hint
+        # Use _lang_hint_for_path so explicit .h callee_file hints are also
+        # treated as language-neutral (falsy ""), matching the path-level hint
+        # logic above.  Without this, a callee with callee_file="include/foo.h"
+        # gets lang_hint="c" from language_from_path and C++ bodies are still
+        # filtered out even when path_lang_hint correctly signals "cpp". (#865)
+        lang_hint = _lang_hint_for_path(file_hint) if file_hint else path_lang_hint
         defn = _resolve_def(index, name, file_hint, lang_hint=lang_hint)
         if defn is None:
             continue


### PR DESCRIPTION
## Summary

Follow-up to #874, addressing two Codex P2 findings from that PR's review.

**P2-1 (line 314 — per-function hint incomplete):** The `inline_path_bodies` loop used `language_from_path(file_hint)` for per-function hints, which still returned `"c"` for an explicit `callee_file="include/foo.h"` edge. This gated out C++ caller definitions even after the path-level fallback (`path_lang_hint`) was fixed. Now uses `_lang_hint_for_path(file_hint)` so explicit `.h` file hints are also treated as language-neutral.

**P2-2 (line 278 — C-project false positive):** Returning `"cpp"` for `.h` files risked selecting a C++ definition over a C definition in pure-C projects when a same-named symbol exists in both languages. Changed `_lang_hint_for_path` to return `""` (falsy) for `.h` files. `_resolve_def` already skips the language filter entirely when `lang_hint` is falsy, giving the same permissive result (accepts any language) without the cross-language false-positive risk.

## Test plan
- [ ] `test_inline_path_bodies_cpp_with_explicit_h_callee_file` — new test covering P2-1: explicit `caller_file=".cpp"` + `callee_file=".h"` still inlines the caller body
- [ ] Existing `test_inline_path_bodies_cpp_header_callee_lang_hint` still passes (P2-2 is backward-compatible: `""` is falsy, same filtering skip as before)
- [ ] All 9 tests in `test_call_path_enrich.py` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)