### PR TITLE
fix(sql): regex fallback for CREATE TABLE absorbed into ERROR nodes (#808)

### DIFF
--- a/tests/unit/languages/test_sql_fixes.py
+++ b/tests/unit/languages/test_sql_fixes.py
@@ -209,3 +209,73 @@ class TestCreateTableAsSelect:
         tables = [e for e in elements if isinstance(e, SQLTable)]
         assert len(tables) == 1
         assert tables[0].name == "archive_users"
+
+
+# ---------------------------------------------------------------------------
+# Bug #808 — CREATE TABLE silently dropped when FOREIGN KEY + ON DELETE/UPDATE
+#            triggers tree-sitter parse-recovery ERROR node cascade
+# ---------------------------------------------------------------------------
+
+# Minimal Chinook-style DDL that reproduces the cascade:
+# Artist → Album (FK with ON DELETE RESTRICT) → Customer
+# tree-sitter SQL grammar creates an ERROR node that absorbs Customer when
+# it encounters the multi-line ON DELETE/ON UPDATE clause.  The regex
+# fallback in fill_missing_sql_tables_from_regex must recover it.
+_SQL_FOREIGN_KEY_CASCADE = """
+CREATE TABLE Artist (
+    ArtistId INT NOT NULL,
+    Name VARCHAR(120),
+    CONSTRAINT PK_Artist PRIMARY KEY (ArtistId)
+);
+
+CREATE TABLE Album (
+    AlbumId INT NOT NULL,
+    Title VARCHAR(160) NOT NULL,
+    ArtistId INT NOT NULL,
+    CONSTRAINT PK_Album PRIMARY KEY (AlbumId),
+    FOREIGN KEY (ArtistId) REFERENCES Artist (ArtistId)
+        ON DELETE NO ACTION
+        ON UPDATE NO ACTION
+);
+
+CREATE TABLE Customer (
+    CustomerId INT NOT NULL,
+    FirstName VARCHAR(40) NOT NULL,
+    LastName VARCHAR(20) NOT NULL,
+    CONSTRAINT PK_Customer PRIMARY KEY (CustomerId)
+);
+"""
+
+
+class TestCreateTableErrorNodeCascade:
+    """#808: CREATE TABLE absorbed into ERROR node must be recovered via regex fallback."""
+
+    def test_all_three_tables_extracted(self):
+        """Artist + Album + Customer must all appear — Customer is the cascade victim."""
+        elements = _extract(_SQL_FOREIGN_KEY_CASCADE)
+        tables = [e for e in elements if isinstance(e, SQLTable)]
+        names = {t.name for t in tables}
+        assert names == {"Artist", "Album", "Customer"}
+
+    def test_table_count_is_exactly_three(self):
+        """Exact count — ensures no duplicates from regex + AST overlap."""
+        elements = _extract(_SQL_FOREIGN_KEY_CASCADE)
+        tables = [e for e in elements if isinstance(e, SQLTable)]
+        assert len(tables) == 3
+
+    def test_customer_table_name_correct(self):
+        """Customer table must have name='Customer', not 'CustomerId' or similar."""
+        elements = _extract(_SQL_FOREIGN_KEY_CASCADE)
+        tables = [e for e in elements if isinstance(e, SQLTable)]
+        customer = next((t for t in tables if t.name == "Customer"), None)
+        assert customer is not None
+        assert customer.name == "Customer"
+
+    def test_no_schema_name_on_simple_tables(self):
+        """None of the three tables use schema-qualified names — schema_name must be None."""
+        elements = _extract(_SQL_FOREIGN_KEY_CASCADE)
+        tables = [e for e in elements if isinstance(e, SQLTable)]
+        for table in tables:
+            assert table.schema_name is None, (
+                f"{table.name} has unexpected schema_name={table.schema_name!r}"
+            )

--- a/tests/unit/languages/test_sql_fixes.py
+++ b/tests/unit/languages/test_sql_fixes.py
@@ -6,6 +6,8 @@ Tests for SQL extraction bugs:
 RED tests written before the fix; each asserts EXACT values (no >= bounds).
 """
 
+from typing import Any
+
 import pytest
 
 try:
@@ -17,6 +19,10 @@ except ImportError:
     TREE_SITTER_SQL_AVAILABLE = False
 
 from tree_sitter_analyzer.languages.sql_plugin import SQLElementExtractor
+from tree_sitter_analyzer.languages.sql_plugin.table_extractor import (
+    _is_in_sql_comment,
+    fill_missing_sql_tables_from_regex,
+)
 from tree_sitter_analyzer.models import SQLFunction, SQLTable
 
 
@@ -279,3 +285,88 @@ class TestCreateTableErrorNodeCascade:
             assert table.schema_name is None, (
                 f"{table.name} has unexpected schema_name={table.schema_name!r}"
             )
+
+
+# ---------------------------------------------------------------------------
+# Codex P2 fixes — comment detection and schema-aware deduplication
+# ---------------------------------------------------------------------------
+
+
+class TestIsInSqlComment:
+    """Unit tests for _is_in_sql_comment helper."""
+
+    def test_not_in_comment_plain_text(self):
+        src = "CREATE TABLE foo (id INT);"
+        assert _is_in_sql_comment(src, 0) is False
+
+    def test_inside_line_comment(self):
+        src = "-- CREATE TABLE foo (id INT);"
+        assert _is_in_sql_comment(src, 3) is True
+
+    def test_after_line_comment_on_same_line(self):
+        src = "-- removed\nCREATE TABLE foo (id INT);"
+        pos = src.index("CREATE")
+        assert _is_in_sql_comment(src, pos) is False
+
+    def test_inside_block_comment(self):
+        src = "/* CREATE TABLE foo (id INT); */"
+        assert _is_in_sql_comment(src, 3) is True
+
+    def test_after_closed_block_comment(self):
+        src = "/* removed */\nCREATE TABLE foo (id INT);"
+        pos = src.index("CREATE")
+        assert _is_in_sql_comment(src, pos) is False
+
+
+class TestFillMissingTablesCommentSkip:
+    """Regex fallback must not add tables found only inside SQL comments."""
+
+    def test_commented_create_table_is_ignored(self):
+        sql = (
+            "-- CREATE TABLE dropped_users (id INT);\n"
+            "CREATE TABLE real_users (id INT);\n"
+        )
+        elements: list[Any] = []
+        fill_missing_sql_tables_from_regex(sql, elements)
+        tables = [e for e in elements if isinstance(e, SQLTable)]
+        names = {t.name for t in tables}
+        assert "dropped_users" not in names
+        assert "real_users" in names
+
+    def test_block_commented_create_table_is_ignored(self):
+        sql = (
+            "/* CREATE TABLE old_schema (id INT); */\n"
+            "CREATE TABLE new_schema (id INT);\n"
+        )
+        elements: list[Any] = []
+        fill_missing_sql_tables_from_regex(sql, elements)
+        tables = [e for e in elements if isinstance(e, SQLTable)]
+        names = {t.name for t in tables}
+        assert "old_schema" not in names
+        assert "new_schema" in names
+
+
+class TestFillMissingTablesSchemaDeduplciation:
+    """Regex fallback must distinguish same table name in different schemas."""
+
+    def test_same_name_different_schemas_both_recovered(self):
+        sql = (
+            "CREATE TABLE tenant_a.users (id INT);\n"
+            "CREATE TABLE tenant_b.users (id INT);\n"
+        )
+        elements: list[Any] = []
+        fill_missing_sql_tables_from_regex(sql, elements)
+        tables = [e for e in elements if isinstance(e, SQLTable)]
+        assert len(tables) == 2
+        schemas = {t.schema_name for t in tables}
+        assert schemas == {"tenant_a", "tenant_b"}
+
+    def test_duplicate_same_schema_not_added_twice(self):
+        sql = (
+            "CREATE TABLE myschema.orders (id INT);\n"
+            "CREATE TABLE myschema.orders (id INT);\n"
+        )
+        elements: list[Any] = []
+        fill_missing_sql_tables_from_regex(sql, elements)
+        tables = [e for e in elements if isinstance(e, SQLTable)]
+        assert len(tables) == 1

--- a/tree_sitter_analyzer/languages/sql_plugin/extractor.py
+++ b/tree_sitter_analyzer/languages/sql_plugin/extractor.py
@@ -59,6 +59,7 @@ from .table_extractor import (
     _parse_column_definition,
     _split_column_definitions,
     extract_sql_tables,
+    fill_missing_sql_tables_from_regex,
 )
 from .trigger_extractor import (
     extract_legacy_triggers,
@@ -112,6 +113,12 @@ class SQLElementExtractor(ElementExtractor):
 
         try:
             self._extract_sql_tables(tree.root_node, sql_elements)
+            # #808: regex fallback for CREATE TABLE statements absorbed into
+            # ERROR nodes by tree-sitter parse-recovery (FOREIGN KEY + ON
+            # DELETE/UPDATE multi-line clauses trigger the cascade).  Called
+            # immediately after the AST pass so missing tables are added before
+            # the element-validation step.
+            fill_missing_sql_tables_from_regex(self.source_code, sql_elements)
             self._extract_sql_views(tree.root_node, sql_elements)
             self._extract_sql_procedures(tree.root_node, sql_elements)
             self._extract_sql_functions_enhanced(tree.root_node, sql_elements)

--- a/tree_sitter_analyzer/languages/sql_plugin/table_extractor.py
+++ b/tree_sitter_analyzer/languages/sql_plugin/table_extractor.py
@@ -168,6 +168,21 @@ def extract_table_columns(
             _process_column_node(node, columns, get_node_text)
 
 
+def _is_in_sql_comment(source: str, pos: int) -> bool:
+    """Return True if ``pos`` falls inside a SQL line (``--``) or block (``/* */``) comment."""
+    # Line comment: check for -- between the start of the current line and pos.
+    line_start = source.rfind("\n", 0, pos) + 1
+    if "--" in source[line_start:pos]:
+        return True
+    # Block comment: the most recent /* before pos has no matching */ before pos.
+    block_start = source.rfind("/*", 0, pos)
+    if block_start != -1:
+        block_end = source.find("*/", block_start)
+        if block_end == -1 or block_end > pos:
+            return True
+    return False
+
+
 def fill_missing_sql_tables_from_regex(
     source_code: str,
     sql_elements: list[Any],
@@ -182,14 +197,28 @@ def fill_missing_sql_tables_from_regex(
     This function scans the raw source text for ``CREATE TABLE`` patterns and
     appends any tables that the AST pass missed.  It never removes tables already
     found, so it is safe to call unconditionally.
+
+    De-duplicates by ``(schema_name, table_name)`` so that the same table name
+    in two different schemas (e.g. ``tenant_a.users`` and ``tenant_b.users``) is
+    not collapsed into one entry.  Matches inside SQL comments are skipped.
     """
-    found_names = {e.name.lower() for e in sql_elements if isinstance(e, SQLTable)}
+    found_keys: set[tuple[str | None, str]] = {
+        (
+            e.schema_name.lower() if e.schema_name else None,
+            e.name.lower(),
+        )
+        for e in sql_elements
+        if isinstance(e, SQLTable)
+    }
     for match in _CREATE_TABLE_RE.finditer(source_code):
+        if _is_in_sql_comment(source_code, match.start()):
+            continue
         schema_name = match.group(1)  # optional, may be None
         table_name = match.group(2)
         if not table_name or not is_valid_identifier(table_name):
             continue
-        if table_name.lower() in found_names:
+        key = (schema_name.lower() if schema_name else None, table_name.lower())
+        if key in found_keys:
             continue
         start_line = source_code[: match.start()].count("\n") + 1
         end_line = _find_statement_end_line(source_code, match.start())
@@ -207,7 +236,7 @@ def fill_missing_sql_tables_from_regex(
             )
         except Exception as exc:
             log_debug(f"regex fallback: failed to append table {table_name!r}: {exc}")
-        found_names.add(table_name.lower())
+        found_keys.add(key)
 
 
 def _find_statement_end_line(source: str, start: int) -> int:

--- a/tree_sitter_analyzer/languages/sql_plugin/table_extractor.py
+++ b/tree_sitter_analyzer/languages/sql_plugin/table_extractor.py
@@ -11,6 +11,18 @@ from ...models import SQLColumn, SQLConstraint, SQLTable
 from ...utils import log_debug
 from .identifier_validator import is_valid_identifier
 
+# ---------------------------------------------------------------------------
+# Regex fallback for CREATE TABLE inside ERROR nodes (#808)
+# ---------------------------------------------------------------------------
+
+# Matches: CREATE [TEMPORARY] TABLE [IF NOT EXISTS] [schema.]table_name
+# Group 1 = optional schema name, Group 2 = table name
+_CREATE_TABLE_RE = re.compile(
+    r"CREATE\s+(?:TEMPORARY\s+)?TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?"
+    r"(?:([a-zA-Z_][a-zA-Z0-9_]*)\.)?([a-zA-Z_][a-zA-Z0-9_]*)",
+    re.IGNORECASE,
+)
+
 
 def extract_sql_tables(
     root_node: "tree_sitter.Node",
@@ -154,6 +166,76 @@ def extract_table_columns(
     for node in traverse_nodes(table_node):
         if node.type == "column_definition":
             _process_column_node(node, columns, get_node_text)
+
+
+def fill_missing_sql_tables_from_regex(
+    source_code: str,
+    sql_elements: list[Any],
+) -> None:
+    """Regex fallback: add CREATE TABLE statements absorbed by ERROR nodes (#808).
+
+    tree-sitter parse-recovery can absorb an entire CREATE TABLE statement into
+    an ERROR node when a preceding multi-line FOREIGN KEY clause (with ON DELETE /
+    ON UPDATE) triggers grammar ambiguity.  The AST traversal then sees an ERROR
+    node instead of a ``create_table`` node and the table is silently dropped.
+
+    This function scans the raw source text for ``CREATE TABLE`` patterns and
+    appends any tables that the AST pass missed.  It never removes tables already
+    found, so it is safe to call unconditionally.
+    """
+    found_names = {e.name.lower() for e in sql_elements if isinstance(e, SQLTable)}
+    for match in _CREATE_TABLE_RE.finditer(source_code):
+        schema_name = match.group(1)  # optional, may be None
+        table_name = match.group(2)
+        if not table_name or not is_valid_identifier(table_name):
+            continue
+        if table_name.lower() in found_names:
+            continue
+        start_line = source_code[: match.start()].count("\n") + 1
+        end_line = _find_statement_end_line(source_code, match.start())
+        raw_text = _extract_statement_text(source_code, match.start())
+        try:
+            sql_elements.append(
+                SQLTable(
+                    name=table_name,
+                    start_line=start_line,
+                    end_line=end_line,
+                    raw_text=raw_text,
+                    language="sql",
+                    schema_name=schema_name,
+                )
+            )
+        except Exception as exc:
+            log_debug(f"regex fallback: failed to append table {table_name!r}: {exc}")
+        found_names.add(table_name.lower())
+
+
+def _find_statement_end_line(source: str, start: int) -> int:
+    """Return the 1-based line number of the closing ``;`` for the statement at ``start``."""
+    depth = 0
+    for i in range(start, len(source)):
+        ch = source[i]
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        elif ch == ";" and depth <= 0:
+            return source[: i + 1].count("\n") + 1
+    return source.count("\n") + 1
+
+
+def _extract_statement_text(source: str, start: int) -> str:
+    """Return the full CREATE TABLE statement text starting at ``start``."""
+    depth = 0
+    for i in range(start, len(source)):
+        ch = source[i]
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        elif ch == ";" and depth <= 0:
+            return source[start : i + 1]
+    return source[start : start + 2000]
 
 
 def _split_column_definitions(content: str) -> list[str]:


### PR DESCRIPTION
## Problem

tree-sitter SQL parse-recovery creates ERROR nodes when a FOREIGN KEY clause with multi-line `ON DELETE` / `ON UPDATE` options triggers grammar ambiguity. The ERROR node absorbs the immediately following `CREATE TABLE` statement, causing it to be silently dropped during AST traversal.

**Reproduction (Chinook-style DDL):** Artist + Album (FK with ON DELETE) + Customer → only 7 of 11 Chinook tables extracted.

## Fix

Added `fill_missing_sql_tables_from_regex()` in `table_extractor.py`:
- Scans raw source text for `CREATE TABLE` patterns after the AST pass
- Appends any tables not already found by AST traversal
- Never removes existing tables — safe to call unconditionally
- Helpers `_find_statement_end_line` + `_extract_statement_text` use paren-depth tracking to bound statement text and line numbers

Called immediately after `_extract_sql_tables()` in `extract_sql_elements()`.

## Tests

Added `TestCreateTableErrorNodeCascade` in `tests/unit/languages/test_sql_fixes.py`:
- `test_all_three_tables_extracted` — Artist + Album + Customer all recovered
- `test_table_count_is_exactly_three` — no duplicates from regex + AST overlap
- `test_customer_table_name_correct` — recovered name is `Customer`, not a fragment
- `test_no_schema_name_on_simple_tables` — schema_name stays None for unqualified tables

All 17 SQL fix tests pass.

## Test plan
- [ ] `uv run pytest tests/unit/languages/test_sql_fixes.py -v` — 17 passed
- [ ] CI green on all platforms

Closes #808