### PR TITLE
fix(viz): compact similarity default strips functions[], uses sample_files (#801)

### DIFF
--- a/tests/unit/mcp/test_output_cost_invariants.py
+++ b/tests/unit/mcp/test_output_cost_invariants.py
@@ -860,7 +860,7 @@ def _make_synthetic_similarity_group(i: int, include_snippet: bool) -> dict:
 
 
 def _make_synthetic_similarity_response(include_snippets: bool) -> dict:
-    """Deterministic 20-group similarity response — summary or full bodies.
+    """Deterministic full-bodies similarity response.
 
     Fixture design:
     - 20 groups × 3 functions each = 60 clone instances (always REVIEW verdict).
@@ -883,28 +883,56 @@ def _make_synthetic_similarity_response(include_snippets: bool) -> dict:
     }
 
 
+def _make_synthetic_similarity_compact_group(i: int) -> dict:
+    """Compact summary group — no functions list, just sample_files (#801 fix)."""
+    return {
+        "fingerprint": f"abcdef1234567{i:03d}",
+        "method": "structural",
+        "similarity": 1.0,
+        "function_count": 3,
+        "sample_files": [f"src/module_{i}/handler_{j}.py" for j in range(3)],
+    }
+
+
+def _make_synthetic_similarity_compact_response() -> dict:
+    """Deterministic compact response — groups have sample_files, not functions[]."""
+    return {
+        "success": True,
+        "verdict": "REVIEW",
+        "project_root": "/repo",
+        "stats": {
+            "total_groups": 20,
+            "total_clone_instances": 60,
+            "mode": "all",
+            "min_lines": 5,
+            "cache_used": True,
+        },
+        "groups": [_make_synthetic_similarity_compact_group(i) for i in range(20)],
+    }
+
+
 def test_similarity_summary_smaller_than_full_bodies() -> None:
-    """Rule-11 differential invariant: summary response < full-bodies response.
+    """Rule-11 differential invariant: compact response < full-bodies response.
 
     The whole point of include_bodies=False (the default): the response must
-    be strictly smaller than include_bodies=True.  If this fails, summary mode
+    be strictly smaller than include_bodies=True.  If this fails, compact mode
     is a no-op and the 226KB default is back.
     """
-    summary_resp = _make_synthetic_similarity_response(include_snippets=False)
+    compact_resp = _make_synthetic_similarity_compact_response()
     full_resp = _make_synthetic_similarity_response(include_snippets=True)
 
-    summary_bytes = len(json.dumps(summary_resp, ensure_ascii=False))
+    compact_bytes = len(json.dumps(compact_resp, ensure_ascii=False))
     full_bytes = len(json.dumps(full_resp, ensure_ascii=False))
 
-    assert summary_bytes < full_bytes, (
-        f"similarity summary ({summary_bytes}B) >= full-bodies ({full_bytes}B) — "
-        "include_bodies=False is a no-op; snippet stripping is broken."
+    assert compact_bytes < full_bytes, (
+        f"similarity compact ({compact_bytes}B) >= full-bodies ({full_bytes}B) — "
+        "compact mode is a no-op; group summarisation is broken."
     )
     # Exact pins — synthetic fixture is deterministic (no tmp paths, no dates).
     # Re-measure and re-pin if envelope fields change.
-    # Measured 2026-06-11: summary=9416 B, full=13616 B (1.446x reduction).
-    assert summary_bytes == 9416, (
-        f"similarity summary bytes drifted: {summary_bytes} != 9416 — "
+    # Measured 2026-06-15: compact=4336 B, full=13616 B (3.14x reduction).
+    assert compact_bytes == 4336, (
+        f"similarity compact bytes drifted: {compact_bytes} != 4336 — "
         "re-measure and re-pin"
     )
     assert full_bytes == 13616, (
@@ -913,25 +941,44 @@ def test_similarity_summary_smaller_than_full_bodies() -> None:
 
 
 def test_similarity_summary_no_snippet_fields() -> None:
-    """Structural invariant: summary groups must not contain 'snippet' key.
+    """Structural invariant: compact groups must not contain 'snippet' or 'functions' keys.
 
-    Verifies the data shape, not just the byte count.  If snippet is somehow
-    included in the summary response (e.g. include_bodies default flipped or
-    to_dict signature changed), this fails immediately.
+    Compact mode (#801) replaces the full functions[] list with sample_files[].
+    Verifies the data shape — if functions/snippet somehow reappear, this fails.
     """
-    summary_resp = _make_synthetic_similarity_response(include_snippets=False)
-    for group in summary_resp["groups"]:
-        for func in group["functions"]:
-            assert "snippet" not in func, (
-                f"snippet key present in summary response function entry: {func}. "
-                "Summary mode must omit code bodies."
-            )
+    compact_resp = _make_synthetic_similarity_compact_response()
+    for group in compact_resp["groups"]:
+        assert "functions" not in group, (
+            f"functions key present in compact group: {group}. "
+            "Compact mode must replace functions[] with sample_files[]."
+        )
+        assert "snippet" not in group, (
+            f"snippet key present in compact group: {group}. "
+            "Compact mode must omit code bodies."
+        )
+
+
+def test_similarity_compact_has_sample_files() -> None:
+    """Structural invariant: compact groups must contain 'sample_files' key (#801).
+
+    Compact mode replaces functions[] with sample_files[] for bounded output.
+    If sample_files disappears (e.g. the compact path is bypassed), this fails.
+    """
+    compact_resp = _make_synthetic_similarity_compact_response()
+    for group in compact_resp["groups"]:
+        assert "sample_files" in group, (
+            f"sample_files key missing in compact group: {group}. "
+            "Compact mode must include sample_files[] for agent discoverability."
+        )
+        assert isinstance(group["sample_files"], list), (
+            f"sample_files must be a list, got: {type(group['sample_files'])}"
+        )
 
 
 def test_similarity_full_has_snippet_fields() -> None:
     """Structural invariant: full-bodies groups must contain 'snippet' key.
 
-    Mirrors the previous test — verifies that include_bodies=True actually
+    Mirrors the compact test — verifies that include_bodies=True actually
     adds the snippet, so the feature is not silently a no-op in either direction.
     """
     full_resp = _make_synthetic_similarity_response(include_snippets=True)

--- a/tests/unit/test_codegraph_similarity_tool.py
+++ b/tests/unit/test_codegraph_similarity_tool.py
@@ -277,8 +277,10 @@ class TestBoundingParams801:
         )
         assert result["success"] is True
 
-    async def test_compact_large_group_capped_at_10(self, tool_with_large_group):
-        """Compact mode (include_bodies=False) must cap functions[] to 10 entries."""
+    async def test_compact_large_group_has_no_functions_key(
+        self, tool_with_large_group
+    ):
+        """Compact mode (include_bodies=False) strips functions[]; exposes sample_files + function_count."""
         result = await tool_with_large_group.execute({"output_format": "json"})
         assert result["success"] is True
         groups = result["groups"]
@@ -286,13 +288,13 @@ class TestBoundingParams801:
             len(groups) == 2
         )  # 15 identical funcs → 1 structural + 1 textual clone group
         for group in groups:
-            funcs = group["functions"]
-            assert len(funcs) == 10, (
-                f"Expected exactly 10 functions (capped); got {len(funcs)}"
+            assert "functions" not in group, (
+                "compact mode must not include functions[] key"
             )
-            assert group.get("truncated") is True, (
-                "truncated flag must be True when functions[] was capped"
-            )
+            assert "sample_files" in group, "compact mode must include sample_files key"
+            assert isinstance(group["sample_files"], list)
+            assert len(group["sample_files"]) <= 3
+            assert group["function_count"] == 15
 
     async def test_include_bodies_true_not_capped(self, tool_with_large_group):
         """include_bodies=True must NOT cap functions[] — all 15 returned."""
@@ -309,13 +311,13 @@ class TestBoundingParams801:
             f"include_bodies=True should return all 15 functions; got max={max_funcs}"
         )
 
-    async def test_no_truncated_flag_when_under_10(self, tool_with_clones):
-        """When group has <= 10 functions, truncated flag must be absent or False."""
+    async def test_no_truncated_flag_in_compact_mode(self, tool_with_clones):
+        """Compact mode never sets 'truncated' — it strips functions[] entirely instead."""
         result = await tool_with_clones.execute({"output_format": "json"})
         assert result["success"] is True
         for group in result["groups"]:
-            assert not group.get("truncated"), (
-                "truncated must not be set when functions count <= 10"
+            assert "truncated" not in group, (
+                "compact mode must not set truncated flag (functions[] is stripped entirely)"
             )
 
 

--- a/tree_sitter_analyzer/mcp/tools/code_similarity_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/code_similarity_tool.py
@@ -149,19 +149,31 @@ class CodeGraphSimilarityTool(BaseMCPTool):
         else:
             verdict = "CAUTION"
 
-        # Cap functions[] per group in compact mode to prevent token overflow (#801).
-        # include_bodies=True is opt-in for large output; compact default must stay bounded.
-        _COMPACT_FUNCTIONS_CAP = 10
+        # Compact mode: strip per-function metadata, show only summary + sample files (#801).
+        # Full functions[] with bodies is opt-in via include_bodies=True.
+        _COMPACT_SAMPLE_FILES = 3
 
         def _group_to_dict(group: Any) -> dict[str, Any]:
             d: dict[str, Any] = group.to_dict(include_bodies=include_bodies)
-            if (
-                not include_bodies
-                and len(d.get("functions", [])) > _COMPACT_FUNCTIONS_CAP
-            ):
-                d["functions"] = d["functions"][:_COMPACT_FUNCTIONS_CAP]
-                d["truncated"] = True
-            return d
+            if include_bodies:
+                return d
+            # Compact: replace full functions list with up to 3 representative file paths.
+            seen: set[str] = set()
+            sample_files: list[str] = []
+            for f in d.get("functions", []):
+                path = f.get("file", "")
+                if path and path not in seen:
+                    seen.add(path)
+                    sample_files.append(path)
+                    if len(sample_files) >= _COMPACT_SAMPLE_FILES:
+                        break
+            return {
+                "fingerprint": d["fingerprint"],
+                "method": d["method"],
+                "similarity": d["similarity"],
+                "function_count": d["function_count"],
+                "sample_files": sample_files,
+            }
 
         response: dict[str, Any] = {
             "success": True,


### PR DESCRIPTION
## Problem

`viz action=similarity` with default params returned 59,304 chars (58,978 in toon_content), always rejected with "result exceeds maximum allowed tokens". The `limit` param had no effect (wrong param), and `max_groups=3` crashed with "slice indices must be integers" because MCP may deliver params as strings.

## Fix

**Compact mode** (default, `include_bodies=False`): replace the full `functions[]` list per group with `sample_files[]` — up to 3 representative file paths. Agents see _which_ files have clones without the per-function metadata overhead.

**Full mode** (`include_bodies=True`): unchanged — returns full function list with code snippets.

**Int coercion** (already in place): `max_groups`, `min_lines`, `min_group_size` are coerced to `int` before use.

## Bytes (synthetic 20-group fixture)

| Mode | Before | After |
|---|---|---|
| Compact (default) | 9,416 B (still overflowed) | **4,336 B** |
| Full bodies | 13,616 B | 13,616 B (unchanged) |
| Reduction | 1.45× | **3.14×** |

## Tests

- `test_similarity_summary_smaller_than_full_bodies` — re-pins compact=4336 B vs full=13616 B
- `test_similarity_summary_no_snippet_fields` — verifies no `functions` or `snippet` key in compact groups
- `test_similarity_compact_has_sample_files` — new: verifies `sample_files` key present in compact groups

Closes #801