### PR TITLE
fix(sync): catch all per-file exceptions to prevent aborting whole sync (#806)

### DIFF
--- a/tests/unit/test_incremental_sync.py
+++ b/tests/unit/test_incremental_sync.py
@@ -262,3 +262,53 @@ class TestRecursionErrorHandling:
         detail = error_details[0]
         assert "deep_nest" in detail["file"]
         assert detail.get("error_type") == "RecursionError"
+
+
+class TestAnyExceptionDoesNotAbortSync:
+    """Issue #806: non-RecursionError per-file exceptions must not abort the whole sync."""
+
+    def test_value_error_in_one_file_does_not_abort_sync(self, project, cache):
+        """A ValueError in index_file must be caught; sibling files must still be indexed."""
+        src = project / "src"
+        (src / "bad.py").write_text("x = 1\n")
+        (src / "good.py").write_text("def ok(): pass\n")
+
+        original_index_file = cache.index_file
+
+        def _boom_on_bad(path, language=None):
+            if "bad.py" in path:
+                raise ValueError("unexpected content")
+            return original_index_file(path, language)
+
+        sync = IncrementalSync(cache)
+        with patch.object(cache, "index_file", side_effect=_boom_on_bad):
+            result = sync.sync()
+
+        assert result.errors == 1
+        error_details = [d for d in result.details if d.get("status") == "error"]
+        assert len(error_details) == 1
+        assert "bad.py" in error_details[0]["file"]
+        assert error_details[0].get("error_type") == "ValueError"
+        assert error_details[0].get("error_message") == "unexpected content"
+
+    def test_os_error_in_one_file_does_not_abort_sync(self, project, cache):
+        """An OSError in index_file must be caught; remaining files still indexed."""
+        src = project / "src"
+        (src / "unreadable.py").write_text("y = 2\n")
+
+        original_index_file = cache.index_file
+
+        def _boom_os(path, language=None):
+            if "unreadable" in path:
+                raise OSError("permission denied")
+            return original_index_file(path, language)
+
+        sync = IncrementalSync(cache)
+        with patch.object(cache, "index_file", side_effect=_boom_os):
+            result = sync.sync()
+
+        assert result.errors == 1
+        error_details = [d for d in result.details if d.get("status") == "error"]
+        assert len(error_details) == 1
+        assert "unreadable" in error_details[0]["file"]
+        assert error_details[0].get("error_type") == "OSError"

--- a/tree_sitter_analyzer/incremental_sync.py
+++ b/tree_sitter_analyzer/incremental_sync.py
@@ -239,12 +239,13 @@ class IncrementalSync:
         # the cache refused. ``action`` is preserved as a back-compat alias.
         try:
             index_result = self._cache.index_file(abs_path)
-        except RecursionError as exc:
-            # Issue #805: deeply-nested AST triggers unbounded recursion.
-            # Catch per-file so the rest of the sync continues.
+        except Exception as exc:
+            # Issue #806/#805: catch all per-file errors so one pathological
+            # file cannot abort the whole sync and discard accumulated results.
             logger.error(
-                "RecursionError indexing %s (AST too deeply nested): %s",
+                "Error indexing %s (%s): %s",
                 rel_path,
+                type(exc).__name__,
                 exc,
             )
             return {
@@ -272,11 +273,12 @@ class IncrementalSync:
         self._cache.invalidate(abs_path)
         try:
             index_result = self._cache.index_file(abs_path)
-        except RecursionError as exc:
-            # Issue #805: same guard for re-index path.
+        except Exception as exc:
+            # Issue #806/#805: same broad guard for re-index path.
             logger.error(
-                "RecursionError re-indexing %s (AST too deeply nested): %s",
+                "Error re-indexing %s (%s): %s",
                 rel_path,
+                type(exc).__name__,
                 exc,
             )
             return {


### PR DESCRIPTION
## Problem

`_index_new_file` and `_reindex_modified` only caught `RecursionError`. Any other exception (OSError, ValueError, IOError, etc.) escaped through the loop into `sync()`, then was caught by the tool-level handler which discarded the accumulated `SyncResult` — losing file attribution, error count, and all successfully indexed files.

## Fix

Widen both per-file guards from `except RecursionError` to `except Exception`. One pathological file can no longer abort the whole sync. The error detail dict already carries `file`, `error_type`, and `error_message`.

## Tests

Added `TestAnyExceptionDoesNotAbortSync`:
- `test_value_error_in_one_file_does_not_abort_sync` — ValueError is caught per-file
- `test_os_error_in_one_file_does_not_abort_sync` — OSError is caught per-file

Closes #806