### PR TITLE
fix(sql): serialize SQLParameter dataclasses to dicts in element_to_dict (#775)

### DIFF
--- a/tests/unit/test_api_result_helpers.py
+++ b/tests/unit/test_api_result_helpers.py
@@ -104,6 +104,42 @@ class TestElementToDict:
         result = element_to_dict(elem)
         assert result["type"] == "class"
 
+    def test_sql_parameter_dataclass_is_serialized_to_dict(self):
+        """SQLParameter dataclass instances in parameters[] must become plain dicts.
+
+        Issue #775: json.dumps crashed with 'SQLParameter not JSON serializable'
+        because element_to_dict passed the raw dataclass list through unchanged.
+        """
+        import dataclasses
+        import json
+
+        @dataclasses.dataclass
+        class FakeSQLParameter:
+            name: str
+            data_type: str
+            direction: str = "IN"
+
+        params = [
+            FakeSQLParameter("uid", "INT"),
+            FakeSQLParameter("v", "VARCHAR", "OUT"),
+        ]
+        elem = _make_elem(parameters=params)
+        result = element_to_dict(elem)
+        # Must be JSON-serializable (no crash).
+        serialized = json.dumps(result)
+        assert "uid" in serialized
+        # Each parameter must be a plain dict, not a dataclass instance.
+        assert result["parameters"] == [
+            {"name": "uid", "data_type": "INT", "direction": "IN"},
+            {"name": "v", "data_type": "VARCHAR", "direction": "OUT"},
+        ]
+
+    def test_string_parameters_pass_through_unchanged(self):
+        """String parameters (non-dataclass) are not modified."""
+        elem = _make_elem(parameters=["x: int", "y: str"])
+        result = element_to_dict(elem)
+        assert result["parameters"] == ["x: int", "y: str"]
+
 
 class TestFindClassName:
     """Tests for find_class_name."""

--- a/tree_sitter_analyzer/_api_result_helpers.py
+++ b/tree_sitter_analyzer/_api_result_helpers.py
@@ -1,5 +1,6 @@
 """Result-shaping helpers for the public API facade."""
 
+import dataclasses
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
@@ -47,7 +48,16 @@ def element_to_dict(
     }
     for field in _OPTIONAL_ELEM_FIELDS:
         if hasattr(elem, field):
-            result[field] = getattr(elem, field)
+            value = getattr(elem, field)
+            # SQL plugin stores parameters as list[SQLParameter] (dataclasses).
+            # JSON cannot serialize dataclass instances; convert them to plain
+            # dicts so all output formats (JSON, TOON, text) stay consistent.
+            if field == "parameters" and isinstance(value, list):
+                value = [
+                    dataclasses.asdict(p) if dataclasses.is_dataclass(p) else p
+                    for p in value
+                ]
+            result[field] = value
 
     if result["type"] == "function" and all_elements:
         # A LOCAL function (innermost container is another function, e.g.


### PR DESCRIPTION
## Summary

- `element_to_dict` now converts any dataclass instance in `parameters[]` to a plain dict via `dataclasses.asdict()`, fixing the `JSONDecodeError: SQLParameter not JSON serializable` crash on `--advanced` for SQL files with CREATE FUNCTION.
- The fix applies at the serialization boundary so JSON, TOON, and text output all get consistent, plain-dict parameters.

Closes #775.

## Test plan
- [ ] `test_sql_parameter_dataclass_is_serialized_to_dict` — new test verifying dataclass→dict conversion and json.dumps succeeds
- [ ] `test_string_parameters_pass_through_unchanged` — existing string parameters still pass through unmodified
- [ ] Verify repro: `printf 'CREATE FUNCTION get_user(uid INT) RETURNS VARCHAR AS ...' | uv run python -m tree_sitter_analyzer ... --advanced --output-format json` returns valid JSON with `parameters: [{"name": "uid", ...}]`