### PR TITLE
fix(js): extract class field declarations and arrow-method names (#746)

### DIFF
--- a/tests/golden_masters/plugins/javascript.json
+++ b/tests/golden_masters/plugins/javascript.json
@@ -1,11 +1,11 @@
 {
   "counts_by_type": {
     "Class": 1,
-    "Function": 32,
+    "Function": 34,
     "Import": 2,
-    "Variable": 10
+    "Variable": 13
   },
-  "element_total": 45,
+  "element_total": 50,
   "names_by_type": {
     "Class": [
       "ModernComponent"
@@ -30,7 +30,9 @@
       "getHeaders",
       "getToken",
       "handleAction",
+      "handleClick",
       "handleResponse",
+      "handleSubmit",
       "html",
       "loadModule",
       "multiParamArrow",
@@ -48,6 +50,8 @@
       "useCallback"
     ],
     "Variable": [
+      "#privateCounter",
+      "#secretKey",
       "API_BASE_URL",
       "AppModule",
       "apiClient",
@@ -56,6 +60,7 @@
       "legacyVariable",
       "response",
       "result",
+      "state",
       "url",
       "user"
     ]

--- a/tests/unit/languages/test_js_class_field_extraction_746.py
+++ b/tests/unit/languages/test_js_class_field_extraction_746.py
@@ -1,0 +1,146 @@
+"""
+Regression tests for Issue #746 — JS class field declarations dropped.
+
+Class fields using the `field_definition` node type (public data fields,
+private `#fields`, and arrow-function class methods) were silently dropped
+because only `property_definition` (object literal) was mapped in the
+extractor.  This file pins the fixed behaviour:
+
+* Public data fields (`state = {}`, `count = 0`) → extracted as Variable
+* Private data fields (`#privateCounter = 0`) → extracted as Variable
+* Arrow-function class methods (`handleClick = () => {}`) → extracted as
+  Function with the field name, NOT as "anonymous"
+* Arrow-function class methods do NOT appear as Variables (no double-entry)
+"""
+
+import pytest
+
+try:
+    import tree_sitter_javascript as _tsjava
+    from tree_sitter import Language, Parser
+
+    _TREE_SITTER_AVAILABLE = True
+except ImportError:
+    _TREE_SITTER_AVAILABLE = False
+
+from tree_sitter_analyzer.languages.javascript_plugin.extractor import (
+    JavaScriptElementExtractor,
+)
+
+pytestmark = pytest.mark.skipif(
+    not _TREE_SITTER_AVAILABLE, reason="tree-sitter-javascript not installed"
+)
+
+_CLASS_WITH_FIELDS = """\
+class Counter {
+    count = 0;
+    #privateCounter = 0;
+    state = { running: false };
+    handleClick = (event) => {
+        this.#privateCounter++;
+    };
+    static defaultStep = 1;
+}
+"""
+
+
+@pytest.fixture(scope="module")
+def js_parser():
+    lang = Language(_tsjava.language())
+    return Parser(lang)
+
+
+@pytest.fixture
+def extractor():
+    return JavaScriptElementExtractor()
+
+
+class TestClassFieldVariableExtraction:
+    """Issue #746 — public / private data fields must be extracted as Variable."""
+
+    def test_public_data_field_extracted(self, extractor, js_parser):
+        """count = 0 must appear as a Variable named 'count'."""
+        tree = js_parser.parse(_CLASS_WITH_FIELDS.encode())
+        variables = extractor.extract_variables(tree, _CLASS_WITH_FIELDS)
+        names = [v.name for v in variables]
+        assert "count" in names, f"'count' field missing from variables; got {names}"
+
+    def test_private_data_field_extracted(self, extractor, js_parser):
+        """#privateCounter = 0 must appear as a Variable named '#privateCounter'."""
+        tree = js_parser.parse(_CLASS_WITH_FIELDS.encode())
+        variables = extractor.extract_variables(tree, _CLASS_WITH_FIELDS)
+        names = [v.name for v in variables]
+        assert "#privateCounter" in names, (
+            f"'#privateCounter' field missing from variables; got {names}"
+        )
+
+    def test_object_initialised_field_extracted(self, extractor, js_parser):
+        """state = { running: false } must appear as a Variable named 'state'."""
+        tree = js_parser.parse(_CLASS_WITH_FIELDS.encode())
+        variables = extractor.extract_variables(tree, _CLASS_WITH_FIELDS)
+        names = [v.name for v in variables]
+        assert "state" in names, f"'state' field missing from variables; got {names}"
+
+    def test_static_field_extracted(self, extractor, js_parser):
+        """static defaultStep = 1 must appear as a Variable named 'defaultStep'."""
+        tree = js_parser.parse(_CLASS_WITH_FIELDS.encode())
+        variables = extractor.extract_variables(tree, _CLASS_WITH_FIELDS)
+        names = [v.name for v in variables]
+        assert "defaultStep" in names, (
+            f"'defaultStep' static field missing from variables; got {names}"
+        )
+
+    def test_static_field_is_static(self, extractor, js_parser):
+        """static defaultStep must have is_static=True."""
+        tree = js_parser.parse(_CLASS_WITH_FIELDS.encode())
+        variables = extractor.extract_variables(tree, _CLASS_WITH_FIELDS)
+        by_name = {v.name: v for v in variables}
+        assert by_name.get("defaultStep") is not None, "'defaultStep' not found"
+        assert by_name["defaultStep"].is_static is True, (
+            "static field must have is_static=True"
+        )
+
+    def test_arrow_method_not_extracted_as_variable(self, extractor, js_parser):
+        """handleClick (arrow fn) must NOT appear as a Variable — it is a Function."""
+        tree = js_parser.parse(_CLASS_WITH_FIELDS.encode())
+        variables = extractor.extract_variables(tree, _CLASS_WITH_FIELDS)
+        names = [v.name for v in variables]
+        assert "handleClick" not in names, (
+            f"arrow-function field 'handleClick' must not appear as Variable; got {names}"
+        )
+
+    def test_exact_data_field_count(self, extractor, js_parser):
+        """Exactly 4 data fields (count, #privateCounter, state, defaultStep)."""
+        tree = js_parser.parse(_CLASS_WITH_FIELDS.encode())
+        variables = extractor.extract_variables(tree, _CLASS_WITH_FIELDS)
+        # Keep only variables coming from field_definition (no top-level let/const)
+        field_vars = [
+            v
+            for v in variables
+            if v.name in {"count", "#privateCounter", "state", "defaultStep"}
+        ]
+        assert len(field_vars) == 4, (
+            f"Expected exactly 4 class field variables; got {[v.name for v in field_vars]}"
+        )
+
+
+class TestClassFieldArrowMethodExtraction:
+    """Issue #746 — arrow-function class fields must be Functions with correct name."""
+
+    def test_arrow_method_extracted_as_function(self, extractor, js_parser):
+        """handleClick = () => {} must appear as a Function."""
+        tree = js_parser.parse(_CLASS_WITH_FIELDS.encode())
+        functions = extractor.extract_functions(tree, _CLASS_WITH_FIELDS)
+        names = [f.name for f in functions]
+        assert "handleClick" in names, (
+            f"arrow-function field 'handleClick' missing from functions; got {names}"
+        )
+
+    def test_arrow_method_not_anonymous(self, extractor, js_parser):
+        """handleClick must NOT have name 'anonymous'."""
+        tree = js_parser.parse(_CLASS_WITH_FIELDS.encode())
+        functions = extractor.extract_functions(tree, _CLASS_WITH_FIELDS)
+        anon = [f for f in functions if f.name == "anonymous"]
+        assert len(anon) == 0, (
+            f"No anonymous functions expected for named class fields; got {[f.name for f in anon]}"
+        )

--- a/tests/unit/languages/test_js_class_field_extraction_746.py
+++ b/tests/unit/languages/test_js_class_field_extraction_746.py
@@ -28,7 +28,8 @@ from tree_sitter_analyzer.languages.javascript_plugin.extractor import (
 )
 
 pytestmark = pytest.mark.skipif(
-    not _TREE_SITTER_AVAILABLE, reason="tree-sitter-javascript not installed"
+    not _TREE_SITTER_AVAILABLE,
+    reason="tree-sitter-javascript not installed — tracked: #746",
 )
 
 _CLASS_WITH_FIELDS = """\
@@ -143,4 +144,49 @@ class TestClassFieldArrowMethodExtraction:
         anon = [f for f in functions if f.name == "anonymous"]
         assert len(anon) == 0, (
             f"No anonymous functions expected for named class fields; got {[f.name for f in anon]}"
+        )
+
+
+class TestClassFieldVisibility:
+    """Codex P2 on #746 — visibility must reflect JS privacy rules."""
+
+    def test_public_field_has_public_visibility(self, extractor, js_parser):
+        """count = 0 is public; visibility must be 'public' not 'private'."""
+        tree = js_parser.parse(_CLASS_WITH_FIELDS.encode())
+        variables = extractor.extract_variables(tree, _CLASS_WITH_FIELDS)
+        by_name = {v.name: v for v in variables}
+        field = by_name.get("count")
+        assert field is not None, "'count' not found"
+        assert field.visibility == "public", (
+            f"public field 'count' must have visibility='public'; got {field.visibility!r}"
+        )
+
+    def test_private_field_has_private_visibility(self, extractor, js_parser):
+        """#privateCounter = 0 is private; visibility must be 'private'."""
+        tree = js_parser.parse(_CLASS_WITH_FIELDS.encode())
+        variables = extractor.extract_variables(tree, _CLASS_WITH_FIELDS)
+        by_name = {v.name: v for v in variables}
+        field = by_name.get("#privateCounter")
+        assert field is not None, "'#privateCounter' not found"
+        assert field.visibility == "private", (
+            f"private field '#privateCounter' must have visibility='private'; "
+            f"got {field.visibility!r}"
+        )
+
+
+class TestClassFieldInitializer:
+    """Codex P2 on #746 — non-primitive initializers must not be silently dropped."""
+
+    def test_object_initializer_preserved(self, extractor, js_parser):
+        """state = { running: false } must have a non-None initializer."""
+        tree = js_parser.parse(_CLASS_WITH_FIELDS.encode())
+        variables = extractor.extract_variables(tree, _CLASS_WITH_FIELDS)
+        by_name = {v.name: v for v in variables}
+        field = by_name.get("state")
+        assert field is not None, "'state' not found"
+        assert field.initializer is not None, (
+            "Object-initialised class field 'state' must have initializer != None"
+        )
+        assert "running" in (field.initializer or ""), (
+            f"Initializer should contain 'running'; got {field.initializer!r}"
         )

--- a/tree_sitter_analyzer/languages/javascript_plugin/_function_helpers.py
+++ b/tree_sitter_analyzer/languages/javascript_plugin/_function_helpers.py
@@ -304,12 +304,16 @@ def _raw_text_for_lines(
 
 def _arrow_function_name(node: tree_sitter.Node, get_node_text: TextExtractor) -> str:
     parent = node.parent
-    if not parent or parent.type != "variable_declarator":
+    if not parent:
         return "anonymous"
-
-    for child in parent.children:
-        if child.type == "identifier":
-            return get_node_text(child)
+    if parent.type == "variable_declarator":
+        for child in parent.children:
+            if child.type == "identifier":
+                return get_node_text(child)
+    elif parent.type == "field_definition":
+        for child in parent.children:
+            if child.type in ("property_identifier", "private_property_identifier"):
+                return get_node_text(child)
     return "anonymous"
 
 

--- a/tree_sitter_analyzer/languages/javascript_plugin/_public_extraction_mixin.py
+++ b/tree_sitter_analyzer/languages/javascript_plugin/_public_extraction_mixin.py
@@ -182,6 +182,7 @@ class JavaScriptPublicExtractionMixin:
             "variable_declaration": self._extract_variable_optimized,
             "lexical_declaration": self._extract_lexical_variable_optimized,
             "property_definition": self._extract_property_optimized,
+            "field_definition": self._extract_field_definition_optimized,
         }
 
         self._traverse_and_extract_iterative(

--- a/tree_sitter_analyzer/languages/javascript_plugin/_traversal_helpers.py
+++ b/tree_sitter_analyzer/languages/javascript_plugin/_traversal_helpers.py
@@ -77,6 +77,7 @@ def _container_node_types() -> set[str]:
         "lexical_declaration",
         "variable_declarator",
         "assignment_expression",
+        "field_definition",
     }
 
 

--- a/tree_sitter_analyzer/languages/javascript_plugin/extractor.py
+++ b/tree_sitter_analyzer/languages/javascript_plugin/extractor.py
@@ -200,15 +200,17 @@ class JavaScriptElementExtractor(
             has_arrow_value = False
             is_static = False
 
+            is_private_field = False
             for child in node.children:
-                if child.type in ("property_identifier", "private_property_identifier"):
+                if child.type == "private_property_identifier":
+                    field_name = self._get_node_text_optimized(child)
+                    is_private_field = True
+                elif child.type == "property_identifier":
                     field_name = self._get_node_text_optimized(child)
                 elif child.type == "static":
                     is_static = True
                 elif child.type == "arrow_function":
                     has_arrow_value = True
-                elif child.type in ("string", "number", "true", "false", "null"):
-                    field_value = self._get_node_text_optimized(child)
 
             # Arrow function class fields are captured in the function extraction pass
             # (via field_definition in container_node_types + _arrow_function_name fix).
@@ -218,7 +220,16 @@ class JavaScriptElementExtractor(
             if not field_name:
                 return None
 
+            # Use the named "value" field for the initializer so non-primitive RHS
+            # expressions (objects, arrays, calls, identifiers) are preserved
+            # intact instead of being silently dropped (Codex P2 on #746).
+            value_node = node.child_by_field_name("value")
+            if value_node is not None:
+                field_value = self._get_node_text_optimized(value_node)
+
             raw_text = self._get_node_text_optimized(node)
+            # Private fields (#name) are private; all others are public (Codex P2 #746).
+            visibility = "private" if is_private_field else "public"
 
             return Variable(
                 name=field_name,
@@ -230,6 +241,7 @@ class JavaScriptElementExtractor(
                 is_static=is_static,
                 is_constant=False,
                 initializer=field_value,
+                visibility=visibility,
             )
         except Exception as e:
             log_debug(f"Failed to extract field definition: {e}")

--- a/tree_sitter_analyzer/languages/javascript_plugin/extractor.py
+++ b/tree_sitter_analyzer/languages/javascript_plugin/extractor.py
@@ -187,6 +187,54 @@ class JavaScriptElementExtractor(
             log_debug(f"Failed to extract property info: {e}")
             return None
 
+    def _extract_field_definition_optimized(
+        self, node: "tree_sitter.Node"
+    ) -> Variable | None:
+        """Extract class field declaration (public and private, not arrow methods)."""
+        try:
+            start_line = node.start_point[0] + 1
+            end_line = node.end_point[0] + 1
+
+            field_name = None
+            field_value = None
+            has_arrow_value = False
+            is_static = False
+
+            for child in node.children:
+                if child.type in ("property_identifier", "private_property_identifier"):
+                    field_name = self._get_node_text_optimized(child)
+                elif child.type == "static":
+                    is_static = True
+                elif child.type == "arrow_function":
+                    has_arrow_value = True
+                elif child.type in ("string", "number", "true", "false", "null"):
+                    field_value = self._get_node_text_optimized(child)
+
+            # Arrow function class fields are captured in the function extraction pass
+            # (via field_definition in container_node_types + _arrow_function_name fix).
+            if has_arrow_value:
+                return None
+
+            if not field_name:
+                return None
+
+            raw_text = self._get_node_text_optimized(node)
+
+            return Variable(
+                name=field_name,
+                start_line=start_line,
+                end_line=end_line,
+                raw_text=raw_text,
+                language="javascript",
+                variable_type=self._infer_type_from_value(field_value),
+                is_static=is_static,
+                is_constant=False,
+                initializer=field_value,
+            )
+        except Exception as e:
+            log_debug(f"Failed to extract field definition: {e}")
+            return None
+
     def _extract_variables_from_declaration(
         self, node: "tree_sitter.Node", kind: str
     ) -> list[Variable]:


### PR DESCRIPTION
## Summary

Fixes #746 — JS `field_definition` nodes (class field declarations) were silently dropped by the extractor because only `property_definition` (object literal properties) was mapped.

- **`_public_extraction_mixin.py`**: adds `"field_definition"` to the variable extractors dict
- **`extractor.py`**: adds `_extract_field_definition_optimized` — extracts public (`state = {}`) and private (`#privateCounter = 0`) data fields as `Variable`; returns `None` for arrow-function values so they are NOT double-emitted
- **`_traversal_helpers.py`**: adds `field_definition` to `_container_node_types()` so the function traversal enters class fields and reaches `arrow_function` children
- **`_function_helpers.py`**: fixes `_arrow_function_name` to return the field name when parent is `field_definition` (was always `"anonymous"` before)

## Before / After

| Element | Before | After |
|---------|--------|-------|
| `count = 0` | dropped | `Variable(name="count")` |
| `#privateCounter = 0` | dropped | `Variable(name="#privateCounter")` |
| `state = { running: false }` | dropped | `Variable(name="state")` |
| `static defaultStep = 1` | dropped | `Variable(name="defaultStep", is_static=True)` |
| `handleClick = (event) => {}` | `Function(name="anonymous")` | `Function(name="handleClick")` |

## Test plan
- [x] `TestClassFieldVariableExtraction` — 7 tests covering each field type + exact count
- [x] `TestClassFieldArrowMethodExtraction` — 2 tests: arrow method named correctly, no anonymous duplicates
- [x] All 66 existing JS extraction tests still pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)