### PR TITLE
fix(js): preserve destructuring params in parameter extraction (#745)

### DIFF
--- a/tests/unit/languages/test_js_destructured_params_745.py
+++ b/tests/unit/languages/test_js_destructured_params_745.py
@@ -1,0 +1,105 @@
+"""
+Regression tests for Issue #745 — JS destructured object parameters mangled.
+
+When a JavaScript function uses object destructuring as a parameter:
+    function foo({ title, onUpdate, ...otherProps }) { ... }
+
+the parameter was split on the last space, producing:
+    name="}", type="{ title, onUpdate, ...otherProps"
+
+This file pins the fixed behaviour: the entire destructuring pattern is
+preserved as the parameter name, not torn apart by whitespace splitting.
+
+Two code paths are affected:
+* ``_parse_string_parameter``  (analyze_code_structure_helpers.py — MCP path)
+* ``_process_type_prefix_parameter`` (table_command_helpers.py — CLI path)
+"""
+
+from tree_sitter_analyzer.cli.commands.table_command_helpers import (
+    process_parameters,
+)
+from tree_sitter_analyzer.mcp.tools.analyze_code_structure_helpers import (
+    _parse_string_parameter,
+)
+
+
+class TestParseStringParameterDestructuring:
+    """_parse_string_parameter must preserve destructuring patterns intact."""
+
+    def test_object_destructuring_name_preserved(self):
+        pattern = "{ title, onUpdate, ...otherProps }"
+        result = _parse_string_parameter(pattern)
+        assert result is not None
+        assert result["name"] == pattern, (
+            f"Destructuring pattern was mangled: got name={result['name']!r}"
+        )
+
+    def test_object_destructuring_no_closing_brace_as_name(self):
+        result = _parse_string_parameter("{ title, onUpdate, ...otherProps }")
+        assert result is not None
+        assert result["name"] != "}", (
+            "name must not be '}' — destructuring was split on last space"
+        )
+
+    def test_simple_object_destructuring(self):
+        result = _parse_string_parameter("{ x, y }")
+        assert result is not None
+        assert result["name"] == "{ x, y }"
+
+    def test_array_destructuring_name_preserved(self):
+        pattern = "[first, second]"
+        result = _parse_string_parameter(pattern)
+        assert result is not None
+        assert result["name"] == pattern
+
+    def test_array_destructuring_no_bracket_as_name(self):
+        result = _parse_string_parameter("[first, second]")
+        assert result is not None
+        assert result["name"] != "]"
+
+    def test_normal_typed_param_unchanged(self):
+        result = _parse_string_parameter("name: string")
+        assert result is not None
+        assert result["name"] == "name"
+        assert result["type"] == "string"
+
+    def test_default_valued_param_unchanged(self):
+        result = _parse_string_parameter("limit = 10")
+        assert result is not None
+        assert result["name"] == "limit"
+        assert result["default"] == "10"
+
+
+class TestProcessParametersDestructuring:
+    """process_parameters must preserve JS object-destructuring param names."""
+
+    def test_js_destructured_param_not_mangled(self):
+        params = ["{ title, onUpdate, ...otherProps }"]
+        result = process_parameters(params, "javascript")
+        assert len(result) == 1
+        assert result[0]["name"] == "{ title, onUpdate, ...otherProps }"
+
+    def test_js_destructured_name_not_closing_brace(self):
+        params = ["{ title, onUpdate, ...otherProps }"]
+        result = process_parameters(params, "javascript")
+        assert result[0]["name"] != "}"
+
+    def test_js_array_destructuring_preserved(self):
+        params = ["[head, ...tail]"]
+        result = process_parameters(params, "javascript")
+        assert len(result) == 1
+        assert result[0]["name"] == "[head, ...tail]"
+
+    def test_js_normal_param_unchanged(self):
+        params = ["event"]
+        result = process_parameters(params, "javascript")
+        assert len(result) == 1
+        assert result[0]["name"] == "event"
+
+    def test_mixed_params_all_correct(self):
+        params = ["{ title, onUpdate }", "callback", "options"]
+        result = process_parameters(params, "javascript")
+        assert len(result) == 3
+        assert result[0]["name"] == "{ title, onUpdate }"
+        assert result[1]["name"] == "callback"
+        assert result[2]["name"] == "options"

--- a/tests/unit/languages/test_js_destructured_params_745.py
+++ b/tests/unit/languages/test_js_destructured_params_745.py
@@ -16,6 +16,7 @@ Two code paths are affected:
 """
 
 from tree_sitter_analyzer.cli.commands.table_command_helpers import (
+    _process_type_prefix_parameter,
     process_parameters,
 )
 from tree_sitter_analyzer.mcp.tools.analyze_code_structure_helpers import (
@@ -69,6 +70,28 @@ class TestParseStringParameterDestructuring:
         assert result["name"] == "limit"
         assert result["default"] == "10"
 
+    def test_destructuring_with_default_preserves_pattern_and_default(self):
+        # {title} = {} must NOT return name="{title} = {}" — Codex P2 on #745
+        result = _parse_string_parameter("{title} = {}")
+        assert result is not None
+        assert result["name"] == "{title}"
+        assert result.get("default") == "{}"
+
+    def test_ts_typed_destructuring_preserves_type(self):
+        # { id }: Props must return name="{ id }", type="Props" — Codex P2 on #745
+        result = _parse_string_parameter("{ id }: Props")
+        assert result is not None
+        assert result["name"] == "{ id }"
+        assert result["type"] == "Props"
+
+    def test_ts_typed_destructuring_with_default(self):
+        # { id }: Props = {} must return all three fields
+        result = _parse_string_parameter("{ id }: Props = {}")
+        assert result is not None
+        assert result["name"] == "{ id }"
+        assert result["type"] == "Props"
+        assert result.get("default") == "{}"
+
 
 class TestProcessParametersDestructuring:
     """process_parameters must preserve JS object-destructuring param names."""
@@ -103,3 +126,19 @@ class TestProcessParametersDestructuring:
         assert result[0]["name"] == "{ title, onUpdate }"
         assert result[1]["name"] == "callback"
         assert result[2]["name"] == "options"
+
+
+class TestTypePrefixParameterCSharpAttributes:
+    """C# attribute parameters must NOT be treated as destructuring (#745 Codex P2)."""
+
+    def test_csharp_frombody_attribute_preserved(self):
+        # [FromBody] UserDto dto -> name="dto", type="[FromBody] UserDto"
+        result = _process_type_prefix_parameter("[FromBody] UserDto dto")
+        assert result["name"] == "dto"
+        assert result["type"] == "[FromBody] UserDto"
+
+    def test_cpp_maybe_unused_attribute_preserved(self):
+        # [[maybe_unused]] int value -> name="value", type="[[maybe_unused]] int"
+        result = _process_type_prefix_parameter("[[maybe_unused]] int value")
+        assert result["name"] == "value"
+        assert result["type"] == "[[maybe_unused]] int"

--- a/tree_sitter_analyzer/cli/commands/table_command_helpers.py
+++ b/tree_sitter_analyzer/cli/commands/table_command_helpers.py
@@ -324,6 +324,9 @@ def _process_type_suffix_parameter(param: str) -> dict[str, str]:
 
 def _process_type_prefix_parameter(param: str) -> dict[str, str]:
     """Process type-first parameter syntax, such as Java."""
+    # Destructuring patterns must not be split; preserve whole as name (#745).
+    if param.startswith("{") or param.startswith("["):
+        return {"name": param, "type": ""}
     last_space_idx = param.rfind(" ")
     if last_space_idx == -1:
         return {"name": param, "type": "Any"}

--- a/tree_sitter_analyzer/cli/commands/table_command_helpers.py
+++ b/tree_sitter_analyzer/cli/commands/table_command_helpers.py
@@ -29,6 +29,10 @@ TYPE_SUFFIX_LANGUAGES = {
     "typescript",
     "ts",
     "scala",
+    # JS has no type annotations; routing through the suffix path preserves
+    # destructuring patterns (e.g. { x, y }) without mangling (#745).
+    "javascript",
+    "js",
 }
 
 PACKAGED_LANGUAGES = {"java", "kotlin", "scala", "csharp", "cpp", "c++"}
@@ -324,8 +328,12 @@ def _process_type_suffix_parameter(param: str) -> dict[str, str]:
 
 def _process_type_prefix_parameter(param: str) -> dict[str, str]:
     """Process type-first parameter syntax, such as Java."""
-    # Destructuring patterns must not be split; preserve whole as name (#745).
-    if param.startswith("{") or param.startswith("["):
+    # JS-style object destructuring arrives here for non-JS languages that share
+    # parameter-string processing; no type-prefix language uses { at the start
+    # of a parameter string, so this guard is universally safe (#745).
+    # NOTE: [ is intentionally NOT guarded — C# attributes ([FromBody], etc.)
+    # and C++ attributes ([[maybe_unused]]) must be parsed as type-prefix strings.
+    if param.startswith("{"):
         return {"name": param, "type": ""}
     last_space_idx = param.rfind(" ")
     if last_space_idx == -1:

--- a/tree_sitter_analyzer/mcp/tools/analyze_code_structure_helpers.py
+++ b/tree_sitter_analyzer/mcp/tools/analyze_code_structure_helpers.py
@@ -96,8 +96,38 @@ def _parse_string_parameter(param_str: str) -> dict[str, str] | None:
     text = param_str.strip()
     if not text:
         return None
-    # Destructuring patterns must not be whitespace-split.
+    # Destructuring patterns must not be whitespace-split (#745).
+    # Parse optional `: Type` or `= default` that may follow the closing bracket.
     if text.startswith("{") or text.startswith("["):
+        open_char = text[0]
+        close_char = "}" if open_char == "{" else "]"
+        depth = 0
+        close_idx = -1
+        for i, ch in enumerate(text):
+            if ch == open_char:
+                depth += 1
+            elif ch == close_char:
+                depth -= 1
+                if depth == 0:
+                    close_idx = i
+                    break
+        if close_idx >= 0:
+            pattern = text[: close_idx + 1].strip()
+            rest = text[close_idx + 1 :].strip()
+            entry_d: dict[str, str] = {"name": pattern, "type": ""}
+            if rest.startswith("="):
+                entry_d["default"] = rest[1:].strip()
+            elif rest.startswith(":"):
+                type_and_default = rest[1:].strip()
+                if "=" in type_and_default:
+                    type_part, default_part = (
+                        s.strip() for s in type_and_default.split("=", 1)
+                    )
+                    entry_d["type"] = type_part
+                    entry_d["default"] = default_part
+                else:
+                    entry_d["type"] = type_and_default
+            return entry_d
         return {"name": text, "type": ""}
     default: str | None = None
     if "=" in text:

--- a/tree_sitter_analyzer/mcp/tools/analyze_code_structure_helpers.py
+++ b/tree_sitter_analyzer/mcp/tools/analyze_code_structure_helpers.py
@@ -88,10 +88,17 @@ def _parse_string_parameter(param_str: str) -> dict[str, str] | None:
     Handles the default-valued forms #533 introduced (Codex P2 on #581):
     ``limit = 10`` and ``breed: str = "Mixed"`` must not be whitespace-split
     into ``{"name": "10", "type": "limit ="}``.
+
+    Destructuring patterns (``{ x, y }`` / ``[a, b]``) are preserved whole
+    as the parameter name so they are not torn apart by whitespace splitting
+    (issue #745).
     """
     text = param_str.strip()
     if not text:
         return None
+    # Destructuring patterns must not be whitespace-split.
+    if text.startswith("{") or text.startswith("["):
+        return {"name": text, "type": ""}
     default: str | None = None
     if "=" in text:
         head, default = (s.strip() for s in text.split("=", 1))


### PR DESCRIPTION
## Summary

- `{ title, onUpdate, ...otherProps }` as a JS function parameter was whitespace-split, producing `name="}"` and `type="{ title, onUpdate..."` — the closing brace became the name
- Root cause: two independent code paths both used whitespace-split-last-token logic without guarding for destructuring patterns
- Fixed by detecting `{`/`[` prefix and returning the whole pattern as the name

## Files changed

- `tree_sitter_analyzer/mcp/tools/analyze_code_structure_helpers.py` — guard in `_parse_string_parameter` (MCP path)
- `tree_sitter_analyzer/cli/commands/table_command_helpers.py` — guard in `_process_type_prefix_parameter` (CLI path)
- `tests/unit/languages/test_js_destructured_params_745.py` — 12 regression tests (RED → GREEN)

## Test plan

- [x] 12 new regression tests all pass
- [x] 6081 existing tests pass, 0 regressions

Closes #745