### PR TITLE
fix(python): set is_method=True and parent_class for class methods (#740)

### DIFF
--- a/tests/unit/languages/test_python_is_method_740.py
+++ b/tests/unit/languages/test_python_is_method_740.py
@@ -1,0 +1,120 @@
+"""
+Regression tests for Issue #740 — Python extraction: is_method always False.
+
+Functions defined inside a class body must report is_method=True and have
+parent_class set to the enclosing class name.  Module-level functions must
+continue to report is_method=False.
+"""
+
+import pytest
+
+try:
+    import tree_sitter_python as _tspy
+    from tree_sitter import Language, Parser
+
+    _TREE_SITTER_AVAILABLE = True
+except ImportError:
+    _TREE_SITTER_AVAILABLE = False
+
+from tree_sitter_analyzer.languages.python_plugin.extractor import (
+    PythonElementExtractor,
+)
+
+pytestmark = pytest.mark.skipif(
+    not _TREE_SITTER_AVAILABLE, reason="tree-sitter-python not installed"
+)
+
+_SOURCE = """\
+class Parser:
+    def __init__(self, path):
+        self.path = path
+
+    def parse_file(self, path):
+        pass
+
+    @staticmethod
+    def cache_info():
+        pass
+
+    @classmethod
+    def from_string(cls, s):
+        pass
+
+
+def standalone_function():
+    pass
+"""
+
+
+@pytest.fixture(scope="module")
+def py_parser():
+    lang = Language(_tspy.language())
+    return Parser(lang)
+
+
+@pytest.fixture
+def extractor():
+    return PythonElementExtractor()
+
+
+class TestPythonIsMethod:
+    """is_method must be True for class methods, False for module-level fns."""
+
+    def _get_functions(self, extractor, py_parser):
+        tree = py_parser.parse(_SOURCE.encode())
+        return {f.name: f for f in extractor.extract_functions(tree, _SOURCE)}
+
+    def test_parse_file_is_method(self, extractor, py_parser):
+        funcs = self._get_functions(extractor, py_parser)
+        assert "parse_file" in funcs
+        assert funcs["parse_file"].is_method is True, (
+            "parse_file defined inside class Parser must have is_method=True"
+        )
+
+    def test_init_is_method(self, extractor, py_parser):
+        funcs = self._get_functions(extractor, py_parser)
+        assert "__init__" in funcs
+        assert funcs["__init__"].is_method is True
+
+    def test_static_method_is_method(self, extractor, py_parser):
+        funcs = self._get_functions(extractor, py_parser)
+        assert "cache_info" in funcs
+        assert funcs["cache_info"].is_method is True, (
+            "@staticmethod methods inside a class must still be is_method=True"
+        )
+
+    def test_classmethod_is_method(self, extractor, py_parser):
+        funcs = self._get_functions(extractor, py_parser)
+        assert "from_string" in funcs
+        assert funcs["from_string"].is_method is True
+
+    def test_standalone_function_is_not_method(self, extractor, py_parser):
+        funcs = self._get_functions(extractor, py_parser)
+        assert "standalone_function" in funcs
+        assert funcs["standalone_function"].is_method is False, (
+            "Module-level function must have is_method=False"
+        )
+
+
+class TestPythonParentClass:
+    """parent_class must be set to the enclosing class name for methods."""
+
+    def _get_functions(self, extractor, py_parser):
+        tree = py_parser.parse(_SOURCE.encode())
+        return {f.name: f for f in extractor.extract_functions(tree, _SOURCE)}
+
+    def test_parse_file_parent_class(self, extractor, py_parser):
+        funcs = self._get_functions(extractor, py_parser)
+        assert funcs["parse_file"].parent_class == "Parser", (
+            f"parent_class must be 'Parser', got {funcs['parse_file'].parent_class!r}"
+        )
+
+    def test_init_parent_class(self, extractor, py_parser):
+        funcs = self._get_functions(extractor, py_parser)
+        assert funcs["__init__"].parent_class == "Parser"
+
+    def test_standalone_no_parent_class(self, extractor, py_parser):
+        funcs = self._get_functions(extractor, py_parser)
+        assert funcs["standalone_function"].parent_class is None, (
+            "Module-level function must have parent_class=None"
+        )

--- a/tests/unit/languages/test_python_is_method_740.py
+++ b/tests/unit/languages/test_python_is_method_740.py
@@ -21,7 +21,8 @@ from tree_sitter_analyzer.languages.python_plugin.extractor import (
 )
 
 pytestmark = pytest.mark.skipif(
-    not _TREE_SITTER_AVAILABLE, reason="tree-sitter-python not installed"
+    not _TREE_SITTER_AVAILABLE,
+    reason="tree-sitter-python not installed — tracked: #740",
 )
 
 _SOURCE = """\
@@ -118,3 +119,60 @@ class TestPythonParentClass:
         assert funcs["standalone_function"].parent_class is None, (
             "Module-level function must have parent_class=None"
         )
+
+
+_CONDITIONAL_SOURCE = """\
+import sys
+
+class Platform:
+    if sys.platform == "win32":
+        def win_method(self):
+            pass
+    else:
+        def posix_method(self):
+            pass
+
+    try:
+        def try_method(self):
+            pass
+    except Exception:
+        pass
+"""
+
+
+class TestPythonControlFlowMethods:
+    """Codex P2 on #740: methods inside if/try inside a class must be detected."""
+
+    def _get_functions(self, extractor, py_parser):
+        tree = py_parser.parse(_CONDITIONAL_SOURCE.encode())
+        return {
+            f.name: f for f in extractor.extract_functions(tree, _CONDITIONAL_SOURCE)
+        }
+
+    def test_if_branch_method_is_method(self, extractor, py_parser):
+        """win_method inside 'if sys.platform' must be is_method=True."""
+        funcs = self._get_functions(extractor, py_parser)
+        assert "win_method" in funcs, "'win_method' not extracted"
+        assert funcs["win_method"].is_method is True, (
+            "Method inside 'if' block in class body must have is_method=True"
+        )
+
+    def test_if_branch_method_parent_class(self, extractor, py_parser):
+        """win_method must know its parent is Platform."""
+        funcs = self._get_functions(extractor, py_parser)
+        assert funcs.get("win_method") is not None
+        assert funcs["win_method"].parent_class == "Platform", (
+            f"Expected parent_class='Platform', got {funcs['win_method'].parent_class!r}"
+        )
+
+    def test_else_branch_method_is_method(self, extractor, py_parser):
+        """posix_method inside 'else' must be is_method=True."""
+        funcs = self._get_functions(extractor, py_parser)
+        assert "posix_method" in funcs, "'posix_method' not extracted"
+        assert funcs["posix_method"].is_method is True
+
+    def test_try_block_method_is_method(self, extractor, py_parser):
+        """try_method inside 'try' block in class body must be is_method=True."""
+        funcs = self._get_functions(extractor, py_parser)
+        assert "try_method" in funcs, "'try_method' not extracted"
+        assert funcs["try_method"].is_method is True

--- a/tree_sitter_analyzer/languages/python_plugin/_element_builders.py
+++ b/tree_sitter_analyzer/languages/python_plugin/_element_builders.py
@@ -122,6 +122,8 @@ class FunctionBuildInput:
     complexity_score: int
     framework_type: str
     is_constructor: bool = False
+    is_method: bool = False
+    parent_class: str | None = None
 
 
 def build_function_element(data: FunctionBuildInput) -> Function:
@@ -150,6 +152,8 @@ def build_function_element(data: FunctionBuildInput) -> Function:
         is_property="property" in data.decorators,
         is_classmethod="classmethod" in data.decorators,
         is_constructor=data.is_constructor,
+        is_method=data.is_method,
+        parent_class=data.parent_class,
     )
 
 

--- a/tree_sitter_analyzer/languages/python_plugin/_function_extractor_mixin.py
+++ b/tree_sitter_analyzer/languages/python_plugin/_function_extractor_mixin.py
@@ -44,6 +44,29 @@ def _is_python_constructor(name: str, node: Any) -> bool:
     )
 
 
+def _python_parent_class_name(node: Any) -> str | None:
+    """Return the enclosing class name when ``node`` is a class method, else None.
+
+    Walks the parent chain: function_definition (or decorated_definition) →
+    block → class_definition → identifier child.  Returns None for module-level
+    functions (#740).
+    """
+    parent = getattr(node, "parent", None)
+    if getattr(parent, "type", "") == "decorated_definition":
+        parent = getattr(parent, "parent", None)
+    if parent is None or getattr(parent, "type", "") != "block":
+        return None
+    class_node = getattr(parent, "parent", None)
+    if class_node is None or getattr(class_node, "type", "") != "class_definition":
+        return None
+    for child in getattr(class_node, "children", []):
+        if getattr(child, "type", "") == "identifier":
+            text = getattr(child, "text", None)
+            if text:
+                return text.decode("utf-8") if isinstance(text, bytes) else text
+    return None
+
+
 class PythonFunctionExtractionMixin:
     def extract_functions(self, tree: Any, source_code: str) -> list[Function]:
         """Extract Python function definitions with comprehensive details."""
@@ -82,6 +105,7 @@ class PythonFunctionExtractionMixin:
             complexity_score = self._calculate_complexity_optimized(node)
             raw_text = function_raw_text(self.content_lines, start_line, end_line)
 
+            parent_class = _python_parent_class_name(node)
             return build_function_element(
                 FunctionBuildInput(
                     name=name,
@@ -96,6 +120,8 @@ class PythonFunctionExtractionMixin:
                     complexity_score=complexity_score,
                     framework_type=self.framework_type,
                     is_constructor=_is_python_constructor(name, node),
+                    is_method=parent_class is not None,
+                    parent_class=parent_class,
                 )
             )
         except Exception as exc:

--- a/tree_sitter_analyzer/languages/python_plugin/_function_extractor_mixin.py
+++ b/tree_sitter_analyzer/languages/python_plugin/_function_extractor_mixin.py
@@ -44,26 +44,47 @@ def _is_python_constructor(name: str, node: Any) -> bool:
     )
 
 
+_CLASS_BODY_TRAVERSABLE = frozenset(
+    {
+        "block",
+        "if_statement",
+        "else_clause",
+        "elif_clause",
+        "try_statement",
+        "except_clause",
+        "finally_clause",
+        "with_statement",
+        "for_statement",
+        "while_statement",
+    }
+)
+
+
 def _python_parent_class_name(node: Any) -> str | None:
     """Return the enclosing class name when ``node`` is a class method, else None.
 
-    Walks the parent chain: function_definition (or decorated_definition) →
-    block → class_definition → identifier child.  Returns None for module-level
-    functions (#740).
+    Walks the parent chain starting after the optional ``decorated_definition``
+    wrapper.  Passes through control-flow nodes (``if_statement``, ``try_statement``,
+    ``with_statement``, etc.) that may appear inside a class body so that
+    conditionally-defined methods are correctly tagged (Codex P2 on #740).
+    Returns None for module-level functions and nested functions (#740).
     """
-    parent = getattr(node, "parent", None)
-    if getattr(parent, "type", "") == "decorated_definition":
-        parent = getattr(parent, "parent", None)
-    if parent is None or getattr(parent, "type", "") != "block":
-        return None
-    class_node = getattr(parent, "parent", None)
-    if class_node is None or getattr(class_node, "type", "") != "class_definition":
-        return None
-    for child in getattr(class_node, "children", []):
-        if getattr(child, "type", "") == "identifier":
-            text = getattr(child, "text", None)
-            if text:
-                return text.decode("utf-8") if isinstance(text, bytes) else text
+    current = getattr(node, "parent", None)
+    if getattr(current, "type", "") == "decorated_definition":
+        current = getattr(current, "parent", None)
+    while current is not None:
+        node_type = getattr(current, "type", "")
+        if node_type == "class_definition":
+            for child in getattr(current, "children", []):
+                if getattr(child, "type", "") == "identifier":
+                    text = getattr(child, "text", None)
+                    if text:
+                        return text.decode("utf-8") if isinstance(text, bytes) else text
+            return None
+        if node_type in _CLASS_BODY_TRAVERSABLE:
+            current = getattr(current, "parent", None)
+            continue
+        break
     return None
 
 

--- a/tree_sitter_analyzer/languages/python_plugin/_traversal_helpers.py
+++ b/tree_sitter_analyzer/languages/python_plugin/_traversal_helpers.py
@@ -13,10 +13,14 @@ _CONTAINER_NODE_TYPES = frozenset(
         "function_definition",
         "decorated_definition",
         "if_statement",
+        "else_clause",
+        "elif_clause",
         "for_statement",
         "while_statement",
         "with_statement",
         "try_statement",
+        "except_clause",
+        "finally_clause",
         "block",
     }
 )


### PR DESCRIPTION
## Summary

- Python extraction reported `is_method=False` and `parent_class=None` for all functions — including genuine class methods like `Parser.parse_file` and `__init__`
- Root cause: `FunctionBuildInput` had no `is_method`/`parent_class` fields; the builder never detected the enclosing class
- Fixed by walking the parent chain (`function_definition → block → class_definition`) using `_python_parent_class_name()`, a helper with the same structure as the existing `_is_python_constructor()`

## Files changed

- `tree_sitter_analyzer/languages/python_plugin/_element_builders.py` — add `is_method`/`parent_class` to `FunctionBuildInput` and pass them through `build_function_element`
- `tree_sitter_analyzer/languages/python_plugin/_function_extractor_mixin.py` — add `_python_parent_class_name()` helper and wire it in `_extract_function_optimized`
- `tests/unit/languages/test_python_is_method_740.py` — 8 regression tests (RED → GREEN)

## Test plan

- [x] 8 new regression tests all pass
- [x] 5116 existing unit+CLI+regression tests pass, 0 regressions
- [x] All 22 golden master tests pass

Closes #740