### PR TITLE
fix(outline): remove top_level_functions alias as methods[] (#741)

### DIFF
--- a/tests/unit/mcp/test_tools/test_get_code_outline_budget.py
+++ b/tests/unit/mcp/test_tools/test_get_code_outline_budget.py
@@ -486,8 +486,8 @@ class TestByteBudgetDifferentialInvariant:
 # uncapped (80/80 classes, 5 methods each): 158804 B  (ratio 1.60x)
 # Re-measure and re-pin if response envelope fields change.
 # ---------------------------------------------------------------------------
-_EXPECTED_CAPPED_BYTES: int = 99217
-_EXPECTED_UNCAPPED_BYTES: int = 158804
+_EXPECTED_CAPPED_BYTES: int = 99202
+_EXPECTED_UNCAPPED_BYTES: int = 158789
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp/test_tools/test_get_code_outline_tool.py
+++ b/tests/unit/mcp/test_tools/test_get_code_outline_tool.py
@@ -851,6 +851,84 @@ class TestGetCodeOutlineToolExecute:
 
 
 # ---------------------------------------------------------------------------
+# Issue #741: top_level_functions must NOT be duplicated as methods[]
+# ---------------------------------------------------------------------------
+
+
+class TestAssembleOutlineResponseNoMethodsDuplication:
+    """_assemble_outline_response must not copy top_level_functions into methods[].
+
+    Issue #741: lines 514-516 of get_code_outline_tool.py added
+    ``result["methods"] = fns_capped`` which made every top-level function
+    appear twice — once under ``top_level_functions`` and once under
+    ``methods``.  The ``methods`` alias must be absent from the response dict.
+    """
+
+    def _make_outline(self, top_fns: list, classes: list | None = None) -> dict:
+        return {
+            "classes": classes or [],
+            "top_level_functions": top_fns,
+            "statistics": {
+                "class_count": len(classes or []),
+                "method_count": len(top_fns),
+                "field_count": 0,
+                "import_count": 0,
+            },
+            "total_lines": 50,
+            "language": "python",
+        }
+
+    def test_no_top_level_methods_key_when_functions_present(self):
+        """result must not have a top-level 'methods' key (Issue #741)."""
+        fns = [{"name": "main", "line_start": 1, "line_end": 10}]
+        outline = self._make_outline(fns)
+        result = GetCodeOutlineTool._assemble_outline_response(
+            file_path="/proj/foo.py", language="python", outline=outline
+        )
+        assert "methods" not in result, (
+            "'methods' key must not appear in the response — "
+            "top-level functions belong only in 'top_level_functions'"
+        )
+
+    def test_no_top_level_methods_key_when_no_functions(self):
+        """result must not have a 'methods' key even when top_level_functions is empty."""
+        outline = self._make_outline([])
+        result = GetCodeOutlineTool._assemble_outline_response(
+            file_path="/proj/empty.py", language="python", outline=outline
+        )
+        assert "methods" not in result
+
+    def test_top_level_functions_not_duplicated(self):
+        """top_level_functions and methods must not carry the same items (#741)."""
+        fns = [
+            {"name": "foo", "line_start": 1, "line_end": 5},
+            {"name": "bar", "line_start": 7, "line_end": 12},
+        ]
+        outline = self._make_outline(fns)
+        result = GetCodeOutlineTool._assemble_outline_response(
+            file_path="/proj/mod.py", language="python", outline=outline
+        )
+        assert result["top_level_functions"] == fns[:2]
+        # If 'methods' were present it would be a duplicated alias — must be absent.
+        assert "methods" not in result
+
+    def test_class_methods_stay_in_classes_not_top_level_methods(self):
+        """Methods belonging to a class must only appear inside classes[i].methods."""
+        cls = {
+            "name": "MyClass",
+            "line_start": 1,
+            "line_end": 30,
+            "methods": [{"name": "my_method", "line_start": 5, "line_end": 10}],
+        }
+        outline = self._make_outline(top_fns=[], classes=[cls])
+        result = GetCodeOutlineTool._assemble_outline_response(
+            file_path="/proj/cls.py", language="python", outline=outline
+        )
+        assert "methods" not in result
+        assert result["classes"][0]["methods"][0]["name"] == "my_method"
+
+
+# ---------------------------------------------------------------------------
 # 工具定义测试
 # ---------------------------------------------------------------------------
 

--- a/tree_sitter_analyzer/mcp/tools/get_code_outline_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/get_code_outline_tool.py
@@ -511,10 +511,7 @@ class GetCodeOutlineTool(BaseMCPTool):
         result["top_level_functions"] = fns_capped
         if outline.get("top_level_fields"):
             result["top_level_fields"] = outline["top_level_fields"]
-        # 3) ``top_level_functions`` also surfaces as ``methods``.
-        if "methods" not in result:
-            result["methods"] = fns_capped
-        # 4) Hoist the count summaries from outline.statistics — PRE-cap totals
+        # 3) Hoist the count summaries from outline.statistics — PRE-cap totals
         #    (aggregate-mode invariant: totals must equal the full element count,
         #    never the capped slice).
         stats = outline.get("statistics")


### PR DESCRIPTION
## Summary

- Removes 3 lines (514-516) from `_assemble_outline_response` that unconditionally set `result["methods"] = fns_capped`
- Top-level functions already surface correctly under `result["top_level_functions"]`; the `methods` alias was a duplicate that inflated response size and confused callers
- Re-pins byte invariants in `test_get_code_outline_budget.py` to reflect the smaller response (~15B savings per outline with top-level functions)

## Test plan

- [x] RED: 4 new tests in `TestAssembleOutlineResponseNoMethodsDuplication` all fail before fix
- [x] GREEN: all 4 pass after removing the 3 lines
- [x] No regressions: 680 outline-related tests pass

Fixes #741

🤖 Generated with [Claude Code](https://claude.com/claude-code)