### PR TITLE
fix(ruby): add Ruby to suffix-param path; strip defaults (#768)

### DIFF
--- a/tests/unit/languages/test_ruby_default_param_768.py
+++ b/tests/unit/languages/test_ruby_default_param_768.py
@@ -1,0 +1,82 @@
+"""Regression tests for Issue #768 — Ruby default-valued parameters mangled.
+
+`permissions = []` was extracting as name='[]', type='permissions =' because
+`_process_type_prefix_parameter` used rfind(" ") and treated the last
+word as the name. Fix: add Ruby to TYPE_SUFFIX_LANGUAGES and strip `= default`
+in `_process_type_suffix_parameter`.
+"""
+
+import pytest
+
+from tree_sitter_analyzer.cli.commands.table_command_helpers import (
+    TYPE_SUFFIX_LANGUAGES,
+    _process_single_parameter,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestRubyInTypeSuffixLanguages:
+    """Ruby must route through the suffix (name-first) path — tracked: #768."""
+
+    def test_ruby_in_type_suffix_languages(self):
+        assert "ruby" in TYPE_SUFFIX_LANGUAGES, (
+            "'ruby' must be in TYPE_SUFFIX_LANGUAGES so default-valued "
+            "params are not garbled by the type-prefix rfind path"
+        )
+
+
+class TestRubyDefaultValuedParameters:
+    """Default-valued Ruby params must extract the name, not the default literal."""
+
+    def test_array_default(self):
+        """permissions = [] → name='permissions', not '[]'."""
+        result = _process_single_parameter("permissions = []", "ruby")
+        assert result["name"] == "permissions", (
+            f"Expected name='permissions' but got name='{result['name']}' — "
+            "the default literal [] must not be the name"
+        )
+
+    def test_hash_default(self):
+        """opts = {} → name='opts'."""
+        result = _process_single_parameter("opts = {}", "ruby")
+        assert result["name"] == "opts"
+
+    def test_string_default(self):
+        """role = 'admin' → name='role'."""
+        result = _process_single_parameter("role = 'admin'", "ruby")
+        assert result["name"] == "role"
+
+    def test_integer_default(self):
+        """limit = 10 → name='limit'."""
+        result = _process_single_parameter("limit = 10", "ruby")
+        assert result["name"] == "limit"
+
+    def test_nil_default(self):
+        """options = nil → name='options'."""
+        result = _process_single_parameter("options = nil", "ruby")
+        assert result["name"] == "options"
+
+    def test_no_default_unchanged(self):
+        """Bare params without defaults must still extract correctly."""
+        result = _process_single_parameter("username", "ruby")
+        assert result["name"] == "username"
+        assert result["type"] == "Any"
+
+    def test_splat_param(self):
+        """*args → name='*args', type='Any' (no mangling)."""
+        result = _process_single_parameter("*args", "ruby")
+        assert result["name"] == "*args"
+
+    def test_double_splat_param(self):
+        """**kwargs → name='**kwargs', type='Any'."""
+        result = _process_single_parameter("**kwargs", "ruby")
+        assert result["name"] == "**kwargs"
+
+    def test_type_not_garbled(self):
+        """Type must be 'Any' (Ruby has no type annotations)."""
+        result = _process_single_parameter("permissions = []", "ruby")
+        assert result["type"] == "Any", (
+            f"Expected type='Any' but got type='{result['type']}' — "
+            "the fragment 'permissions =' must not become the type"
+        )

--- a/tree_sitter_analyzer/cli/commands/table_command_helpers.py
+++ b/tree_sitter_analyzer/cli/commands/table_command_helpers.py
@@ -33,6 +33,10 @@ TYPE_SUFFIX_LANGUAGES = {
     # destructuring patterns (e.g. { x, y }) without mangling (#745).
     "javascript",
     "js",
+    # Ruby has no type annotations; routing through the suffix path prevents
+    # rfind-based mangling of default-valued params (`permissions = []` → #768).
+    "ruby",
+    "rb",
 }
 
 PACKAGED_LANGUAGES = {"java", "kotlin", "scala", "csharp", "cpp", "c++"}
@@ -320,6 +324,13 @@ def _process_single_parameter(param: Any, language: str) -> dict[str, str]:
 
 def _process_type_suffix_parameter(param: str) -> dict[str, str]:
     """Process name-first parameter syntax, such as Python or TypeScript."""
+    # Strip `= default` when the `=` appears before any type annotation (`:`).
+    # This handles Ruby `permissions = []` → name="permissions" (#768) and
+    # Python bare-name defaults like `limit = 10`.
+    colon_idx = param.find(":")
+    eq_idx = param.find("=")
+    if eq_idx != -1 and (colon_idx == -1 or eq_idx < colon_idx):
+        param = param[:eq_idx].strip()
     if ":" not in param:
         return {"name": param, "type": "Any"}
     name, param_type = param.split(":", 1)


### PR DESCRIPTION
## Summary

- Adds `"ruby"` and `"rb"` to `TYPE_SUFFIX_LANGUAGES` so Ruby parameters route through the name-first path instead of the type-prefix `rfind` path
- In `_process_type_suffix_parameter`, strips `= default` when `=` appears before any `:` type annotation — handles `permissions = []`, `limit = 10`, `role = 'admin'`, `opts = nil`, etc.

## Root cause

Ruby has no type annotations. The `_process_type_prefix_parameter` path used `rfind(" ")` to split type from name, making the last word the name. For `permissions = []`, the last word is `[]` — resulting in `name='[]'`, `type='permissions ='`.

## Test plan

- [x] 7 RED tests before fix (TestRubyInTypeSuffixLanguages + TestRubyDefaultValuedParameters)
- [x] 10 GREEN after fix
- [x] 7261 existing tests pass — no regressions

Fixes #768

🤖 Generated with [Claude Code](https://claude.com/claude-code)