### PR TITLE
fix(project-health): reconcile signal with verdict on D/F grades (#783)

### DIFF
--- a/tests/unit/mcp/test_project_health_tool.py
+++ b/tests/unit/mcp/test_project_health_tool.py
@@ -602,6 +602,70 @@ class TestBug783VerdictCoherence:
             )
 
 
+class TestBug783SignalCoherence:
+    """Bug #783 (signal leg): top-level signal must not say 'healthy' when
+    agent_summary.verdict says 'REVIEW' (D/F grades present).
+
+    The dimension-average signal can say 'healthy' on a large project where
+    most files are A/B even though one D-grade file exists. _project_signal()
+    overrides the dimension signal to 'grade_risk_high'/'grade_risk_critical'
+    when the grade-distribution risk is 'high'/'critical'.
+    """
+
+    @staticmethod
+    def _mostly_a_with_d() -> dict:
+        """999 A-grade files + 1 D-grade file; dimension averages stay >= 70."""
+        healthy_dims = {"complexity": 90.0, "size": 90.0}
+        a_scores = [
+            _score(f"src/a_{i}.py", "A", 90.0, healthy_dims) for i in range(999)
+        ]
+        d_score = _score("src/bad.py", "D", 50.0, {"complexity": 50.0, "size": 90.0})
+        return _build_project_health_result("/repo", [*a_scores, d_score], "D", 20)
+
+    @staticmethod
+    def _mostly_a_with_f() -> dict:
+        """999 A-grade files + 1 F-grade file."""
+        healthy_dims = {"complexity": 90.0, "size": 90.0}
+        a_scores = [
+            _score(f"src/a_{i}.py", "A", 90.0, healthy_dims) for i in range(999)
+        ]
+        f_score = _score("src/awful.py", "F", 10.0, {"complexity": 10.0, "size": 90.0})
+        return _build_project_health_result("/repo", [*a_scores, f_score], "D", 20)
+
+    def test_d_grade_signal_not_healthy(self) -> None:
+        """signal must not be 'healthy' when a D-grade file forces verdict=REVIEW."""
+        result = self._mostly_a_with_d()
+        assert result["verdict"] == "REVIEW"
+        assert result["signal"] != "healthy", (
+            f"signal={result['signal']!r} says 'healthy' but verdict='REVIEW' — "
+            "contradictory signals in one envelope"
+        )
+
+    def test_f_grade_signal_not_healthy(self) -> None:
+        """signal must not be 'healthy' when an F-grade file forces verdict=REVIEW."""
+        result = self._mostly_a_with_f()
+        assert result["verdict"] == "REVIEW"
+        assert result["signal"] != "healthy"
+
+    def test_d_grade_signal_value(self) -> None:
+        """signal should be 'grade_risk_high' when risk='high' (D-grade files)."""
+        result = self._mostly_a_with_d()
+        assert result["signal"] == "grade_risk_high"
+
+    def test_f_grade_signal_value(self) -> None:
+        """signal should be 'grade_risk_critical' when risk='critical' (F-grade files)."""
+        result = self._mostly_a_with_f()
+        assert result["signal"] == "grade_risk_critical"
+
+    def test_all_a_signal_stays_healthy(self) -> None:
+        """When only A grades exist, signal must remain 'healthy'."""
+        healthy_dims = {"complexity": 90.0, "size": 90.0}
+        a_scores = [_score(f"src/a_{i}.py", "A", 90.0, healthy_dims) for i in range(5)]
+        result = _build_project_health_result("/repo", a_scores, "D", 20)
+        assert result["signal"] == "healthy"
+        assert result["verdict"] == "SAFE"
+
+
 class TestBug785MatchingFileCount:
     """Bug #785: PROJECT_HEALTH_SOURCE_EXTS must include all extensions
     supported by the analyzer, not just a stale hand-maintained subset.

--- a/tree_sitter_analyzer/mcp/tools/project_health_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/project_health_tool.py
@@ -279,7 +279,7 @@ def _build_project_health_result(
         "detail_count": len(agg.files),
         "hidden_detail_count": max(0, len(agg.worst) - len(agg.files)),
         "grade_distribution": agg.grade_distribution,
-        "signal": _build_signal(agg.signal_dims),
+        "signal": _project_signal(_build_signal(agg.signal_dims), risk),
         "average_dimensions": agg.dim_avgs,
         "coverage_status": _coverage_status(agg.dim_avgs),
         "weakest_dimension": agg.weakest_dim,
@@ -643,6 +643,20 @@ def _project_queue_head(queue_head: dict[str, Any]) -> dict[str, Any]:
         "signal": queue_head["signal"],
         "weakest_dimension": queue_head["weakest_dimension"],
     }
+
+
+def _project_signal(dim_signal: str, risk: str) -> str:
+    """Return a project-level signal consistent with the grade-distribution risk.
+
+    Bug #783: dimension-average signal can say "healthy" while grade-distribution
+    risk says "high" (D-grade files exist), causing agent_summary.verdict="REVIEW"
+    to contradict signal="healthy" in the same envelope.  When risk is "high" or
+    "critical" and the dimension signal is "healthy", override it so the two
+    models can never point opposite directions.
+    """
+    if dim_signal == "healthy" and risk in ("high", "critical"):
+        return f"grade_risk_{risk}"
+    return dim_signal
 
 
 def _project_risk(grade_distribution: dict[str, int]) -> str:


### PR DESCRIPTION
## Summary

- Adds `_project_signal()` to `project_health_tool.py` that overrides the dimension-average signal when grade-distribution risk is `high`/`critical` and the dimension signal would say `"healthy"`
- Signal `"grade_risk_high"` when D-grade files present; `"grade_risk_critical"` when F-grade files present
- An agent reading the compact path (agent_summary) and the full envelope will now see consistent signals

## Root cause

Two independent models operated over the same data:
1. `signal` = `_build_signal(dim_avgs)` — dimension average, could say `"healthy"` if most files are A/B
2. `agent_summary.verdict` = `_project_risk_to_verdict(_project_risk(grade_dist))` — count-based, `"REVIEW"` if any D/F files exist

On a 1830-file project (A=1531 B=288 C=10 D=1), signal="healthy" while verdict="REVIEW".

## Test plan
- [x] `test_d_grade_signal_not_healthy` — 999 A + 1 D → signal ≠ "healthy"
- [x] `test_f_grade_signal_not_healthy` — 999 A + 1 F → signal ≠ "healthy"
- [x] `test_d_grade_signal_value` — signal = "grade_risk_high"
- [x] `test_f_grade_signal_value` — signal = "grade_risk_critical"
- [x] `test_all_a_signal_stays_healthy` — all A → signal = "healthy" (no regression)
- [x] All 43 project health tests pass

Closes #783