### PR TITLE
fix(deps): add scope_note to summary mode (#784)

### DIFF
--- a/tests/unit/mcp/test_dependency_analysis_tool.py
+++ b/tests/unit/mcp/test_dependency_analysis_tool.py
@@ -450,3 +450,22 @@ class TestBug784CyclesScope:
         result = _cycles(graph)
         assert result["scope"] == "file_dependency_graph"
         assert "scope_note" in result
+
+    def test_summary_response_has_scope_field(self, tmp_path):
+        """summary mode must also include scope so a consumer comparing
+        cycle_count from summary vs import-graph-summary sees an explanation."""
+        _write(tmp_path, "a.py", "import b\n")
+        _write(tmp_path, "b.py", "import a\n")
+        t = DependencyAnalysisTool(project_root=str(tmp_path))
+        t.set_project_path(str(tmp_path))
+        result = _run(t.execute({"mode": "summary", "output_format": "json"}))
+        assert result["scope"] == "file_dependency_graph"
+
+    def test_summary_response_has_scope_note(self, tmp_path):
+        """summary mode scope_note must reference the import-graph alternative."""
+        _write(tmp_path, "x.py", "import os\n")
+        t = DependencyAnalysisTool(project_root=str(tmp_path))
+        t.set_project_path(str(tmp_path))
+        result = _run(t.execute({"mode": "summary", "output_format": "json"}))
+        assert "scope_note" in result
+        assert "import" in result["scope_note"].lower()

--- a/tree_sitter_analyzer/mcp/tools/dependency_analysis_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/dependency_analysis_tool.py
@@ -268,6 +268,12 @@ def _summary(graph: DependencyGraph) -> dict[str, Any]:
     return {
         "success": True,
         "mode": "summary",
+        "scope": "file_dependency_graph",
+        "scope_note": (
+            "Counts cycles in the file-level dependency graph. "
+            "Use health action=imports mode=summary for import-resolution statistics "
+            "(different graph, legitimately different cycle_count)."
+        ),
         "node_count": node_count,
         "edge_count": edge_count,
         "top_hub_files": [{"file": f, "dependents": c} for f, c in hubs if c > 0],


### PR DESCRIPTION
## Summary

- Adds `scope` and `scope_note` fields to the `analyze_dependencies mode=summary` response to match what `mode=cycles` already had from a prior partial fix
- The `scope_note` explains that `cycle_count` here uses the file-level `DependencyGraph`, which includes benchmarks/tests/fixtures — making it legitimately different from `health action=imports` which uses the `ImportGraph`
- Adds 2 regression tests (`test_summary_response_has_scope_field`, `test_summary_response_has_scope_note`)

## Root cause

`analyze_dependencies mode=summary` showed a cycle_count (16) while `health action=imports mode=summary` showed a different count (8) with no explanation for either tool. The cycles mode had already gotten a scope_note in a prior fix; summary mode was missed.

## Test plan
- [x] `test_summary_response_has_scope_field` — scope = "file_dependency_graph"
- [x] `test_summary_response_has_scope_note` — scope_note references "import"
- [x] All 54 dependency analysis tests pass

Closes #784