### PR TITLE
fix(cli): use double quotes in _shell_safe_path for Windows CMD compat (#875)

### DIFF
--- a/tests/unit/cli/test_shell_safe_path_875.py
+++ b/tests/unit/cli/test_shell_safe_path_875.py
@@ -28,15 +28,27 @@ class TestShellSafePathWindowsCompat:
             "must not use single quotes (fails Windows CMD)"
         )
 
-    def test_windows_backslash_path_no_quoting_needed(self) -> None:
-        # Pure backslash+alphanum — safe, no quoting needed
+    def test_windows_backslash_path_is_double_quoted(self) -> None:
+        # Backslash is not in SHELL_SAFE_CHARS to protect POSIX users who
+        # accidentally pass a Windows-style path (the shell would eat the \
+        # if the token were unquoted on POSIX).
         result = _shell_safe_path("src\\main.py")
-        assert result == "src\\main.py"
+        assert result == '"src\\main.py"'
 
     def test_windows_path_with_spaces_double_quoted(self) -> None:
         result = _shell_safe_path("C:\\My Projects\\main.py")
         assert result == '"C:\\My Projects\\main.py"'
         assert not result.startswith("'")
+
+    def test_dollar_sign_escaped_in_double_quotes(self) -> None:
+        # POSIX shells expand $VAR inside double quotes; escape to prevent it.
+        result = _shell_safe_path("src/$HOME file.py")
+        assert result == '"src/\\$HOME file.py"'
+
+    def test_backtick_escaped_in_double_quotes(self) -> None:
+        # POSIX shells execute `cmd` inside double quotes; escape to prevent it.
+        result = _shell_safe_path("src/`date` file.py")
+        assert result == '"src/\\`date\\` file.py"'
 
     def test_empty_path_returns_empty(self) -> None:
         assert _shell_safe_path("") == ""

--- a/tests/unit/cli/test_shell_safe_path_875.py
+++ b/tests/unit/cli/test_shell_safe_path_875.py
@@ -1,0 +1,42 @@
+"""Regression tests for _shell_safe_path — issue #875.
+
+shlex.quote() wraps paths in single quotes which fail in Windows CMD.
+Double quotes work on Windows CMD, PowerShell, and Unix shells.
+"""
+
+from tree_sitter_analyzer.cli.agent_workflow import _shell_safe_path
+
+
+class TestShellSafePathWindowsCompat:
+    def test_none_returns_empty_string(self) -> None:
+        assert _shell_safe_path(None) == ""
+
+    def test_simple_path_no_quoting_needed(self) -> None:
+        # Safe chars only — returned as-is (no quoting overhead)
+        result = _shell_safe_path("src/main.py")
+        assert result == "src/main.py"
+
+    def test_path_with_spaces_uses_double_quotes(self) -> None:
+        result = _shell_safe_path("src/my file.py")
+        # Double-quoted — works on Windows CMD and Unix
+        assert result == '"src/my file.py"'
+
+    def test_path_with_spaces_not_single_quoted(self) -> None:
+        # Single quotes fail in Windows CMD — must never appear
+        result = _shell_safe_path("src/my file.py")
+        assert not result.startswith("'"), (
+            "must not use single quotes (fails Windows CMD)"
+        )
+
+    def test_windows_backslash_path_no_quoting_needed(self) -> None:
+        # Pure backslash+alphanum — safe, no quoting needed
+        result = _shell_safe_path("src\\main.py")
+        assert result == "src\\main.py"
+
+    def test_windows_path_with_spaces_double_quoted(self) -> None:
+        result = _shell_safe_path("C:\\My Projects\\main.py")
+        assert result == '"C:\\My Projects\\main.py"'
+        assert not result.startswith("'")
+
+    def test_empty_path_returns_empty(self) -> None:
+        assert _shell_safe_path("") == ""

--- a/tests/unit/mcp/test_agent_workflow_tool.py
+++ b/tests/unit/mcp/test_agent_workflow_tool.py
@@ -18,7 +18,6 @@ path interpolation, and envelope mirroring.
 from __future__ import annotations
 
 import asyncio
-import shlex
 
 import pytest
 
@@ -294,7 +293,9 @@ async def test_agent_workflow_tool_quotes_target_with_spaces_in_cli_commands(tmp
     target.parent.mkdir()
     target.write_text("def run():\\n    return 1\\n", encoding="utf-8")
     target_path = "src/space file.py"
-    safe_target = shlex.quote(target_path)
+    # double-quoted: the new helper wraps paths with spaces in double quotes
+    # so commands work on Windows CMD, PowerShell, and POSIX shells (#875).
+    safe_target = '"src/space file.py"'
 
     result = await AgentWorkflowTool(str(tmp_path)).execute(
         {"target_path": target_path, "output_format": "json"}

--- a/tree_sitter_analyzer/cli/agent_workflow.py
+++ b/tree_sitter_analyzer/cli/agent_workflow.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import shlex
 from pathlib import Path
 from typing import Any
 
@@ -427,11 +426,22 @@ def _scoped_change_impact_command(target: str) -> str:
     )
 
 
+_SHELL_SAFE_CHARS: frozenset[str] = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-/\\:"
+)
+
+
 def _shell_safe_path(path: str | None) -> str:
-    """Return a shell-safe token for user-provided file paths."""
-    if path is None:
+    """Return a shell-safe token for user-provided file paths.
+
+    Double quotes work on Windows CMD, PowerShell, and Unix shells (#875).
+    shlex.quote() uses single quotes which fail in Windows CMD.
+    """
+    if not path:
         return ""
-    return shlex.quote(path)
+    if all(c in _SHELL_SAFE_CHARS for c in path):
+        return path
+    return '"' + path.replace('"', '\\"') + '"'
 
 
 def _build_toon_content(result: dict[str, Any]) -> str:

--- a/tree_sitter_analyzer/cli/agent_workflow.py
+++ b/tree_sitter_analyzer/cli/agent_workflow.py
@@ -427,7 +427,7 @@ def _scoped_change_impact_command(target: str) -> str:
 
 
 _SHELL_SAFE_CHARS: frozenset[str] = frozenset(
-    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-/\\:"
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-/:"
 )
 
 
@@ -436,12 +436,19 @@ def _shell_safe_path(path: str | None) -> str:
 
     Double quotes work on Windows CMD, PowerShell, and Unix shells (#875).
     shlex.quote() uses single quotes which fail in Windows CMD.
+
+    Inside double quotes: `"` and POSIX-expanding characters ($, `) are
+    escaped with a backslash.  Backslash itself is NOT escaped because both
+    POSIX shells (where `\\X` → `\\X` for non-special X) and Windows CMD
+    (which does not interpret `\\` as an escape) handle a bare `\\` correctly
+    inside double quotes.
     """
     if not path:
         return ""
     if all(c in _SHELL_SAFE_CHARS for c in path):
         return path
-    return '"' + path.replace('"', '\\"') + '"'
+    escaped = path.replace('"', '\\"').replace("$", "\\$").replace("`", "\\`")
+    return '"' + escaped + '"'
 
 
 def _build_toon_content(result: dict[str, Any]) -> str:


### PR DESCRIPTION
## Summary

- `shlex.quote()` wraps paths in single quotes which fail in Windows CMD (`cmd.exe`)
- Replace `shlex.quote(path)` in `_shell_safe_path()` with double-quote approach that works on Windows CMD, PowerShell, and Unix shells
- Safe-char paths (alphanumeric + `._-/\:`) are returned unquoted; all others get `"path"` with embedded `"` escaped

## Test plan
- [ ] 7 new tests in `tests/unit/cli/test_shell_safe_path_875.py` — none/simple/spaces/backslash/Windows paths
- [ ] Verify `test_path_with_spaces_not_single_quoted` catches the regression
- [ ] CI green on all platforms

Closes #875

🤖 Generated with [Claude Code](https://claude.com/claude-code)