### PR TITLE
fix(api): surface class_type as type field in element_to_dict (#795)

### DIFF
--- a/tests/unit/test_api_result_helpers.py
+++ b/tests/unit/test_api_result_helpers.py
@@ -104,6 +104,42 @@ class TestElementToDict:
         result = element_to_dict(elem)
         assert result["type"] == "class"
 
+    def test_enum_class_type_surfaces_as_type_enum(self):
+        """#795: Class element with class_type='enum' must output type='enum', not 'class'."""
+        elem = _make_elem(cls_name="Class", class_type="enum")
+        result = element_to_dict(elem)
+        assert result["type"] == "enum"
+
+    def test_interface_class_type_surfaces_as_type_interface(self):
+        """#795: Class element with class_type='interface' must output type='interface'."""
+        elem = _make_elem(cls_name="Class", class_type="interface")
+        result = element_to_dict(elem)
+        assert result["type"] == "interface"
+
+    def test_type_alias_class_type_surfaces_as_type_type(self):
+        """#795: Class element with class_type='type' must output type='type'."""
+        elem = _make_elem(cls_name="Class", class_type="type")
+        result = element_to_dict(elem)
+        assert result["type"] == "type"
+
+    def test_namespace_class_type_surfaces_as_type_namespace(self):
+        """#795: Class element with class_type='namespace' must output type='namespace'."""
+        elem = _make_elem(cls_name="Class", class_type="namespace")
+        result = element_to_dict(elem)
+        assert result["type"] == "namespace"
+
+    def test_abstract_class_type_surfaces_as_type_abstract_class(self):
+        """#795: Class element with class_type='abstract_class' must output type='abstract_class'."""
+        elem = _make_elem(cls_name="Class", class_type="abstract_class")
+        result = element_to_dict(elem)
+        assert result["type"] == "abstract_class"
+
+    def test_plain_class_with_default_class_type_stays_class(self):
+        """#795: Class element with class_type='class' (default) must still output type='class'."""
+        elem = _make_elem(cls_name="Class", class_type="class")
+        result = element_to_dict(elem)
+        assert result["type"] == "class"
+
     def test_sql_parameter_dataclass_is_serialized_to_dict(self):
         """SQLParameter dataclass instances in parameters[] must become plain dicts.
 

--- a/tree_sitter_analyzer/_api_result_helpers.py
+++ b/tree_sitter_analyzer/_api_result_helpers.py
@@ -38,9 +38,16 @@ def element_to_dict(
     elem: Any, all_elements: Sequence[Any] | None = None
 ) -> dict[str, Any]:
     """Convert an analysis element to the stable API dict representation."""
+    python_type = type(elem).__name__.lower()
+    # #795: Class objects carry a class_type that distinguishes enum/interface/type/namespace
+    # from plain "class".  Surface that specificity in the output type field.
+    if python_type == "class":
+        output_type = getattr(elem, "class_type", "class") or "class"
+    else:
+        output_type = python_type
     result: dict[str, Any] = {
         "name": elem.name,
-        "type": type(elem).__name__.lower(),
+        "type": output_type,
         "start_line": elem.start_line,
         "end_line": elem.end_line,
         "raw_text": elem.raw_text,


### PR DESCRIPTION
## Summary
- TypeScript enums, interfaces, type aliases, and namespaces were all serialized as `type:"class"` because `element_to_dict` used `type(elem).__name__.lower()`, which is always `"class"` for `Class` objects regardless of `class_type`
- Fix: when `python_type == "class"`, use `getattr(elem, "class_type", "class")` for the output `type` field
- Correct output: `enum→type:"enum"`, `interface→type:"interface"`, `type→type:"type"`, `namespace→type:"namespace"`, `abstract_class→type:"abstract_class"`. Regular classes remain `type:"class"`.

## Test plan
- [ ] 6 new RED→GREEN tests in `TestElementToDict` cover all class_type variants
- [ ] All 14 `TestElementToDict` tests pass
- [ ] All 86 TypeScript + api_result_helpers tests pass
- [ ] Formatter tests (63) pass

Closes #795.

🤖 Generated with [Claude Code](https://claude.com/claude-code)