### PR TITLE
fix(ruby): filter phantom fields in _extract_assignment_variable (#770)

### DIFF
--- a/tests/golden_masters/compact/ruby_sample_compact.md
+++ b/tests/golden_masters/compact/ruby_sample_compact.md
@@ -5,7 +5,7 @@
 |----------|-------|
 | Package |  |
 | Methods | 33 |
-| Fields | 16 |
+| Fields | 12 |
 
 ## Methods
 | Method | Sig | V | L | Cx | Doc |

--- a/tests/golden_masters/csv/ruby_sample_csv.csv
+++ b/tests/golden_masters/csv/ruby_sample_csv.csv
@@ -11,10 +11,6 @@ Field,last_login_at,last_login_at:None,private,31-31,,-
 Field,permissions,permissions:None,private,96-96,,-
 Field,database,database:None,private,144-144,,-
 Field,cache,cache:None,private,145-145,,-
-Field,validate_email,validate_email:None,private,196-196,,-
-Field,format_username,format_username:None,private,197-197,,-
-Field,log_action,log_action:None,private,200-202,,-
-Field,user,user:None,private,218-218,,-
 Method,User#username,():,public,18-18,1,-
 Method,User#email,():,public,18-18,1,-
 Method,User#id,():,public,19-19,1,-

--- a/tests/golden_masters/plugins/ruby.json
+++ b/tests/golden_masters/plugins/ruby.json
@@ -3,9 +3,9 @@
     "Class": 5,
     "Function": 33,
     "Import": 3,
-    "Variable": 16
+    "Variable": 12
   },
-  "element_total": 57,
+  "element_total": 53,
   "names_by_type": {
     "Class": [
       "AdminUser",
@@ -59,15 +59,11 @@
       "created_at",
       "database",
       "email",
-      "format_username",
       "instance_count",
       "last_login_at",
-      "log_action",
       "password_hash",
       "permissions",
-      "user",
-      "username",
-      "validate_email"
+      "username"
     ]
   },
   "types": [

--- a/tests/golden_masters/toon/ruby_sample_toon.toon
+++ b/tests/golden_masters/toon/ruby_sample_toon.toon
@@ -44,7 +44,7 @@ methods:
     hash_password,public,(191,193)
     with_transaction,public,(205,214)
 fields:
-  [16]{name,type,line_range(a,b)}:
+  [12]{name,type,line_range(a,b)}:
     STATUS_ACTIVE,,(13,13)
     STATUS_INACTIVE,,(14,14)
     MAX_LOGIN_ATTEMPTS,,(15,15)
@@ -57,10 +57,6 @@ fields:
     permissions,,(96,96)
     database,,(144,144)
     cache,,(145,145)
-    validate_email,,(196,196)
-    format_username,,(197,197)
-    log_action,,(200,202)
-    user,,(218,218)
 imports:
   [3]{name,module_name,statement,is_static,is_wildcard,line_range(a,b),imported_names,raw_text}:
     date,,import date,false,false,(1,1),[],import date
@@ -69,7 +65,7 @@ imports:
 statistics:
   class_count: 5
   method_count: 33
-  field_count: 16
+  field_count: 12
   import_count: 3
   total_lines: 0
 effective_table: toon

--- a/tests/unit/languages/test_ruby_phantom_fields_770.py
+++ b/tests/unit/languages/test_ruby_phantom_fields_770.py
@@ -1,0 +1,200 @@
+"""Regression tests for Ruby phantom-field bug #770.
+
+_extract_assignment_variable emitted Variable for ANY assignment LHS:
+  - local identifiers (user = new(...))
+  - qualified targets (user.password_hash = ...)
+  - index/element-reference targets (@cache[id] = value)
+  - top-level lambdas/procs (validate_email = lambda { ... })
+
+Only genuine @ivar, @@cvar, and CONSTANT assignments should be emitted.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+try:
+    import tree_sitter
+    import tree_sitter_ruby
+
+    RUBY_AVAILABLE = True
+except ImportError:
+    RUBY_AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(
+    not RUBY_AVAILABLE,
+    reason="tree-sitter-ruby not installed (tracked: #770 environment dependency)",
+)
+
+
+def _parse(code: str):
+    lang = tree_sitter.Language(tree_sitter_ruby.language())
+    parser = tree_sitter.Parser(lang)
+    return parser.parse(code.encode())
+
+
+def _extract_vars(code: str):
+    from tree_sitter_analyzer.languages.ruby_plugin import RubyElementExtractor
+
+    tree = _parse(code)
+    ext = RubyElementExtractor()
+    return ext.extract_variables(tree, code)
+
+
+# ---------------------------------------------------------------------------
+# Phantom cases that must NOT be emitted
+# ---------------------------------------------------------------------------
+
+
+def test_local_variable_in_initialize_is_not_a_field():
+    """Local variable assignment inside initialize must NOT become a field (#770).
+
+    Uses a name (``temp_record``) that has no @ivar counterpart in the same
+    code, so there is no naming collision after the ``@``-strip.
+    """
+    code = """\
+class UserService
+  def initialize(user_id)
+    temp_record = find_by_id(user_id)
+    @user_id = user_id
+  end
+end
+"""
+    vars_ = _extract_vars(code)
+    names = [v.name for v in vars_]
+    assert "temp_record" not in names
+
+
+def test_instance_variable_in_initialize_is_a_field():
+    """@ivar assignment inside initialize MUST be emitted (#770 complement)."""
+    code = """\
+class UserService
+  def initialize(user_id)
+    temp_record = find_by_id(user_id)
+    @user_id = user_id
+  end
+end
+"""
+    vars_ = _extract_vars(code)
+    names = [v.name for v in vars_]
+    assert "user_id" in names
+
+
+def test_qualified_assignment_is_not_a_field():
+    """recv.attr = value (call target) must NOT become a field (#770)."""
+    code = """\
+class UserService
+  def update(user_id)
+    user = find_by_id(user_id)
+    user.password_hash = "hash"  # pragma: allowlist secret
+  end
+end
+"""
+    vars_ = _extract_vars(code)
+    names = [v.name for v in vars_]
+    assert "user.password_hash" not in names
+    assert "password_hash" not in names
+
+
+def test_index_assignment_is_not_a_field():
+    """recv[key] = value (element_reference target) must NOT become a field (#770)."""
+    code = """\
+class UserService
+  def initialize
+    @cache = {}
+  end
+
+  def cache_user(id, user)
+    @cache[id] = user
+  end
+end
+"""
+    vars_ = _extract_vars(code)
+    names = [v.name for v in vars_]
+    # @cache itself is valid; @cache[id] must not appear
+    assert "cache[id]" not in names
+    assert "cache" in names
+
+
+def test_toplevel_lambda_is_not_a_field():
+    """Top-level lambda/proc assignments must NOT appear as fields (#770)."""
+    code = """\
+class Validator
+  RULE = "strict"
+end
+
+validate_email = lambda { |e| e.include?("@") }
+format_username = proc { |u| u.downcase }
+"""
+    vars_ = _extract_vars(code)
+    names = [v.name for v in vars_]
+    assert "validate_email" not in names
+    assert "format_username" not in names
+
+
+# ---------------------------------------------------------------------------
+# Real fields that MUST still be emitted
+# ---------------------------------------------------------------------------
+
+
+def test_real_ivar_still_extracted():
+    """@ivar inside initialize must still be a field after the fix."""
+    code = """\
+class Order
+  def initialize(total)
+    @total = total
+    @status = "pending"
+  end
+end
+"""
+    vars_ = _extract_vars(code)
+    names = [v.name for v in vars_]
+    assert "total" in names
+    assert "status" in names
+
+
+def test_real_classvar_still_extracted():
+    """@@cvar at class body level must still be a field after the fix."""
+    code = """\
+class Counter
+  @@count = 0
+
+  def initialize
+    @@count += 1
+  end
+end
+"""
+    vars_ = _extract_vars(code)
+    names = [v.name for v in vars_]
+    assert "count" in names
+
+
+def test_real_constant_still_extracted():
+    """CONSTANT assignment at class body level must still be a field after the fix."""
+    code = """\
+class Config
+  MAX = 100
+  TIMEOUT = 30
+end
+"""
+    vars_ = _extract_vars(code)
+    names = [v.name for v in vars_]
+    assert "MAX" in names
+    assert "TIMEOUT" in names
+
+
+def test_exact_field_count_in_clean_class():
+    """A class with exactly 2 @ivars and 1 @@cvar yields exactly 3 fields (#770)."""
+    code = """\
+class Account
+  @@count = 0
+
+  def initialize(name, balance)
+    @name = name
+    @balance = balance
+    local_temp = 0
+  end
+end
+"""
+    vars_ = _extract_vars(code)
+    assert len(vars_) == 3

--- a/tests/unit/languages/test_ruby_plugin.py
+++ b/tests/unit/languages/test_ruby_plugin.py
@@ -382,6 +382,31 @@ class TestRubyVariableExtraction:
 
         assert variables == []
 
+    def test_scoped_constant_assignment_not_dropped(self):
+        """#902 Codex P2: Config::TIMEOUT = 30 must not be silently dropped.
+
+        tree-sitter reports the LHS of a scope_resolution assignment as
+        ``scope_resolution``, not ``constant``.  Without the guard the
+        scoped constant was filtered out by the phantom-field fix (#770).
+        """
+        code = """
+class MyApp
+  Config::DEFAULT_TIMEOUT = 30
+  Config::MAX_RETRIES = 5
+end
+"""
+        plugin = RubyPlugin()
+        tree = get_tree_for_code(code, plugin)
+        extractor = plugin.create_extractor()
+        variables = extractor.extract_variables(tree, code)
+
+        names = [v.name for v in variables]
+        assert "Config::DEFAULT_TIMEOUT" in names
+        assert "Config::MAX_RETRIES" in names
+        # Scoped constants are treated as constants (public, is_constant=True)
+        for v in variables:
+            assert v.is_constant is True
+
 
 class TestRubyImportExtraction:
     """Test Ruby require statement extraction."""

--- a/tree_sitter_analyzer/languages/ruby_plugin.py
+++ b/tree_sitter_analyzer/languages/ruby_plugin.py
@@ -489,13 +489,21 @@ class RubyElementExtractor(ElementExtractor):
             if not left_node:
                 return None
 
+            # #770: only emit real Ruby fields — @ivar, @@cvar, CONSTANT.
+            # Silently drop local identifiers, qualified targets (recv.attr=),
+            # and element-reference targets (recv[key]=).
+            if left_node.type not in (
+                "instance_variable",
+                "class_variable",
+                "constant",
+            ):
+                return None
+
             var_text = self._get_node_text_optimized(left_node)
 
             # Determine variable type
             is_constant = left_node.type == "constant"
-            # is_instance_var = var_text.startswith("@") and not var_text.startswith("@@")  # Reserved for future use
-            is_class_var = var_text.startswith("@@")
-            # is_global = var_text.startswith("$")  # Reserved for future use
+            is_class_var = left_node.type == "class_variable"
 
             # Clean variable name
             name = var_text.lstrip("@$")

--- a/tree_sitter_analyzer/languages/ruby_plugin.py
+++ b/tree_sitter_analyzer/languages/ruby_plugin.py
@@ -492,17 +492,20 @@ class RubyElementExtractor(ElementExtractor):
             # #770: only emit real Ruby fields — @ivar, @@cvar, CONSTANT.
             # Silently drop local identifiers, qualified targets (recv.attr=),
             # and element-reference targets (recv[key]=).
+            # #902 Codex P2: also allow scope_resolution for scoped constant
+            # assignments such as ``Config::DEFAULT_TIMEOUT = 30``.
             if left_node.type not in (
                 "instance_variable",
                 "class_variable",
                 "constant",
+                "scope_resolution",
             ):
                 return None
 
             var_text = self._get_node_text_optimized(left_node)
 
             # Determine variable type
-            is_constant = left_node.type == "constant"
+            is_constant = left_node.type in ("constant", "scope_resolution")
             is_class_var = left_node.type == "class_variable"
 
             # Clean variable name


### PR DESCRIPTION
## Summary
- `_extract_assignment_variable` emitted `Variable` for any assignment LHS: local identifiers, qualified targets (`recv.attr = ...`), and element-reference targets (`recv[key] = ...`) all passed through unfiltered
- Fix: add a node-type guard — only `left_node.type in ("instance_variable", "class_variable", "constant")` proceeds; all other LHS forms return `None`
- Also tightens `is_class_var` detection from text-prefix (`@@`) to node type `"class_variable"` for consistency

## Test plan
- [ ] 9 new tests in `test_ruby_phantom_fields_770.py` (phantom-filtered + real-field regression) — all GREEN
- [ ] All 71 existing Ruby tests pass with no regressions

Closes #770.

🤖 Generated with [Claude Code](https://claude.com/claude-code)