### PR TITLE
fix(api): class filter includes interface/enum/namespace subtypes (#795 P2)

### DIFF
--- a/tests/unit/test_api_query_helpers.py
+++ b/tests/unit/test_api_query_helpers.py
@@ -261,3 +261,42 @@ class TestFilterElementsByType:
         elements = [{"type": "function"}]
         result = filter_elements_by_type(elements, ["class"])
         assert result == []
+
+    # --- #795 backward-compat: element_types=["class"] must include subtypes ---
+
+    def test_class_filter_includes_interface(self):
+        """#795 P2: filtering by 'class' must still return interface elements."""
+        elements = [{"type": "interface"}, {"type": "function"}]
+        result = filter_elements_by_type(elements, ["class"])
+        assert len(result) == 1
+        assert result[0]["type"] == "interface"
+
+    def test_class_filter_includes_enum(self):
+        elements = [{"type": "enum"}, {"type": "function"}]
+        result = filter_elements_by_type(elements, ["class"])
+        assert len(result) == 1
+        assert result[0]["type"] == "enum"
+
+    def test_class_filter_includes_namespace(self):
+        elements = [{"type": "namespace"}, {"type": "function"}]
+        result = filter_elements_by_type(elements, ["class"])
+        assert len(result) == 1
+        assert result[0]["type"] == "namespace"
+
+    def test_class_filter_includes_type_alias(self):
+        elements = [{"type": "type"}, {"type": "function"}]
+        result = filter_elements_by_type(elements, ["class"])
+        assert len(result) == 1
+        assert result[0]["type"] == "type"
+
+    def test_class_filter_includes_abstract_class(self):
+        elements = [{"type": "abstract_class"}, {"type": "class"}]
+        result = filter_elements_by_type(elements, ["class"])
+        assert len(result) == 2
+
+    def test_interface_filter_does_not_widen_to_all_class_family(self):
+        """Filtering by 'interface' should NOT return plain 'class' elements."""
+        elements = [{"type": "class"}, {"type": "interface"}, {"type": "enum"}]
+        result = filter_elements_by_type(elements, ["interface"])
+        assert len(result) == 1
+        assert result[0]["type"] == "interface"

--- a/tree_sitter_analyzer/_api_query_helpers.py
+++ b/tree_sitter_analyzer/_api_query_helpers.py
@@ -116,13 +116,29 @@ def query_execution_result(
     }
 
 
+# All type strings that are conceptually "a class" — PR #795 expanded the
+# type field beyond the literal "class" string.  Callers that filter with
+# element_types=["class"] must still receive these subtypes for backward
+# compatibility (Codex P2 on PR #901).
+_CLASS_FAMILY_TYPES = frozenset(
+    {"class", "abstract_class", "interface", "enum", "namespace", "type"}
+)
+
+
 def filter_elements_by_type(
     elements: list[dict[str, Any]],
     element_types: list[str] | None,
 ) -> list[dict[str, Any]]:
-    """Filter extracted elements by fuzzy type match."""
+    """Filter extracted elements by fuzzy type match.
+
+    ``element_types=["class"]`` matches all class-family types
+    (interface, enum, namespace, abstract_class, type) in addition to
+    plain "class" for backward compatibility after PR #795.
+    """
     if not element_types:
         return elements
+
+    wants_class_family = any(t.lower() == "class" for t in element_types)
 
     return [
         element
@@ -131,4 +147,5 @@ def filter_elements_by_type(
             element_type.lower() in element.get("type", "").lower()
             for element_type in element_types
         )
+        or (wants_class_family and element.get("type", "") in _CLASS_FAMILY_TYPES)
     ]


### PR DESCRIPTION
## Summary

- Addresses Codex P2 finding on PR #901: after that PR changed `type:"class"` to `type:"interface"/"enum"/"namespace"/"type"/"abstract_class"`, filtering by `element_types=["class"]` silently dropped those subtypes
- Adds `_CLASS_FAMILY_TYPES` constant and expands `filter_elements_by_type` so `"class"` continues to match all class-family elements
- Adds 7 new tests for the backward-compat behavior and validates specificity (filtering by "interface" does NOT widen to all class-family types)

## Test plan
- [x] `uv run pytest tests/unit/test_api_query_helpers.py::TestFilterElementsByType` → 12 passed