### PR TITLE
fix(table): propagate is_async and is_abstract in --table json output (#774)

### DIFF
--- a/tests/golden_masters/compact/rust_sample_compact.md
+++ b/tests/golden_masters/compact/rust_sample_compact.md
@@ -16,6 +16,6 @@
 | deactivate | (1) | public | - | 44-46 | - |
 | is_active | (1)->bool | public | - | 49-51 | - |
 | display | (1)->String | public | - | 55-57 | - |
-| fetch_user_data | (1)->Result<User, String> | public | - | 61-64 | - |
+| fetch_user_data | (1)->Result<User, String> | public | Y | 61-64 | - |
 | new | (1)->Self | public | - | 72-74 | - |
 | main | (0) | public | - | 91-93 | - |

--- a/tests/golden_masters/csv/rust_sample_csv.csv
+++ b/tests/golden_masters/csv/rust_sample_csv.csv
@@ -18,6 +18,6 @@
 | deactivate | fn({'name': 'self', 'type': 'Any'}) | public | - | 44-46 | - |
 | is_active | fn({'name': 'self', 'type': 'Any'}) -> bool | public | - | 49-51 | - |
 | display | fn({'name': 'self', 'type': 'Any'}) -> String | public | - | 55-57 | - |
-| fetch_user_data | fn({'name': 'user_id', 'type': 'u64'}) -> Result<User, String> | public | - | 61-64 | - |
+| fetch_user_data | fn({'name': 'user_id', 'type': 'u64'}) -> Result<User, String> | public | Yes | 61-64 | - |
 | new | fn({'name': 'item', 'type': 'T'}) -> Self | public | - | 72-74 | - |
 | main | fn() | public | - | 91-93 | - |

--- a/tests/golden_masters/full/rust_sample_full.md
+++ b/tests/golden_masters/full/rust_sample_full.md
@@ -18,6 +18,6 @@
 | deactivate | fn({'name': 'self', 'type': 'Any'}) | public | - | 44-46 | - |
 | is_active | fn({'name': 'self', 'type': 'Any'}) -> bool | public | - | 49-51 | - |
 | display | fn({'name': 'self', 'type': 'Any'}) -> String | public | - | 55-57 | - |
-| fetch_user_data | fn({'name': 'user_id', 'type': 'u64'}) -> Result<User, String> | public | - | 61-64 | - |
+| fetch_user_data | fn({'name': 'user_id', 'type': 'u64'}) -> Result<User, String> | public | Yes | 61-64 | - |
 | new | fn({'name': 'item', 'type': 'T'}) -> Self | public | - | 72-74 | - |
 | main | fn() | public | - | 91-93 | - |

--- a/tests/unit/cli/test_table_command_conversion.py
+++ b/tests/unit/cli/test_table_command_conversion.py
@@ -329,6 +329,71 @@ class TestTableCommandConvertFunctionElement:
         result = command._convert_function_element(mock_function, "python")
         assert result["javadoc"] == "Test function"
 
+    def test_convert_function_element_is_async_propagated(self, command):
+        """#774: is_async must appear in the table-command method dict."""
+        from tree_sitter_analyzer.constants import ELEMENT_TYPE_FUNCTION
+
+        mock_function = MagicMock()
+        mock_function.name = "fetchData"
+        mock_function.visibility = "public"
+        mock_function.return_type = "Promise<void>"
+        mock_function.parameters = []
+        mock_function.start_line = 10
+        mock_function.end_line = 15
+        mock_function.is_constructor = False
+        mock_function.is_static = False
+        mock_function.is_async = True
+        mock_function.is_abstract = False
+        mock_function.complexity_score = 1
+        mock_function.element_type = ELEMENT_TYPE_FUNCTION
+
+        result = command._convert_function_element(mock_function, "typescript")
+        assert result["is_async"] is True
+        assert result["is_abstract"] is False
+
+    def test_convert_function_element_is_abstract_propagated(self, command):
+        """#774: is_abstract must appear in the table-command method dict."""
+        from tree_sitter_analyzer.constants import ELEMENT_TYPE_FUNCTION
+
+        mock_function = MagicMock()
+        mock_function.name = "validate"
+        mock_function.visibility = "public"
+        mock_function.return_type = "boolean"
+        mock_function.parameters = []
+        mock_function.start_line = 5
+        mock_function.end_line = 5
+        mock_function.is_constructor = False
+        mock_function.is_static = False
+        mock_function.is_async = False
+        mock_function.is_abstract = True
+        mock_function.complexity_score = 1
+        mock_function.element_type = ELEMENT_TYPE_FUNCTION
+
+        result = command._convert_function_element(mock_function, "typescript")
+        assert result["is_abstract"] is True
+        assert result["is_async"] is False
+
+    def test_convert_function_element_default_false_when_absent(self, command):
+        """#774: is_async/is_abstract default to False when not set on element."""
+        from tree_sitter_analyzer.constants import ELEMENT_TYPE_FUNCTION
+
+        class MinimalElement:
+            name = "foo"
+            visibility = "public"
+            return_type = "void"
+            parameters = []
+            start_line = 1
+            end_line = 3
+            is_constructor = False
+            is_static = False
+            complexity_score = 1
+            element_type = ELEMENT_TYPE_FUNCTION
+            is_private = False
+
+        result = command._convert_function_element(MinimalElement(), "python")
+        assert result["is_async"] is False
+        assert result["is_abstract"] is False
+
 
 class TestTableCommandConvertVariableElement:
     """Tests for TableCommand._convert_variable_element method."""

--- a/tree_sitter_analyzer/cli/commands/table_command.py
+++ b/tree_sitter_analyzer/cli/commands/table_command.py
@@ -359,6 +359,8 @@ class TableCommand(BaseCommand):
             "parameters": processed_params,
             "is_constructor": getattr(element, "is_constructor", False),
             "is_static": getattr(element, "is_static", False),
+            "is_async": getattr(element, "is_async", False),
+            "is_abstract": getattr(element, "is_abstract", False),
             "complexity_score": getattr(element, "complexity_score", 1),
             "line_range": {
                 "start": getattr(element, "start_line", 0),


### PR DESCRIPTION
## Summary
- `_convert_function_element` hardcoded the method dict without `is_async` and `is_abstract` fields, causing both to be silently dropped in `--table json` output
- Added both fields using `getattr(element, "is_async", False)` / `getattr(element, "is_abstract", False)` for safe fallback
- Added 3 targeted tests pinning the exact propagation behaviour

## Test plan
- [ ] `test_convert_function_element_is_async_propagated` — `is_async=True` appears in result
- [ ] `test_convert_function_element_is_abstract_propagated` — `is_abstract=True` appears in result
- [ ] `test_convert_function_element_default_false_when_absent` — defaults to `False` when fields absent (uses plain class, not MagicMock)

Fixes #774