### PR TITLE
fix(nav): detect file_path_mismatch when CallGraph falls back to unscoped candidates (#873)

### DIFF
--- a/tests/unit/mcp/test_nav_impact_boundary.py
+++ b/tests/unit/mcp/test_nav_impact_boundary.py
@@ -267,15 +267,20 @@ class TestNavImpactBoundary:
 
     @pytest.mark.asyncio
     async def test_file_path_mismatch_gives_candidate_hint(self, tmp_path) -> None:
-        """#867: when file_path is set but doesn't match, warn with candidate files."""
+        """#867/#873: when file_path is set but doesn't match, warn with candidate files.
+
+        CallGraph._resolve_targets falls back to unscoped candidates rather than
+        returning [] — so targets is non-empty even for a wrong file_path.  The
+        mismatch must be detected by checking whether any target lives in the
+        requested file, not by testing for an empty list.
+        """
         func_ref_a = _make_ref("execute", "src/tool_a.py")
         graph = MagicMock()
 
-        # With file_path set: returns nothing (mismatch)
-        # Without file_path: returns the real candidate
+        # Real CallGraph fallback: always returns the candidate even when a
+        # non-matching file_path is supplied — the scoped lookup fails and
+        # _resolve_targets falls back to the unscoped list.
         def resolve_side_effect(name, fp=None):
-            if fp is not None:
-                return []
             return [func_ref_a]
 
         graph.resolve_targets.side_effect = resolve_side_effect

--- a/tests/unit/mcp/test_nav_impact_boundary.py
+++ b/tests/unit/mcp/test_nav_impact_boundary.py
@@ -320,3 +320,46 @@ class TestNavImpactBoundary:
         assert "src/tool_a.py" in next_step, (
             f"Expected candidate file in hint, got: {next_step!r}"
         )
+
+    @pytest.mark.asyncio
+    async def test_file_path_dot_prefix_does_not_false_positive(self, tmp_path) -> None:
+        """Codex P2 (#873): ./src/tool_a.py and src/tool_a.py are the same file.
+
+        After path normalization, calling with file_path='./src/tool_a.py' when
+        CallGraph stores 'src/tool_a.py' must NOT return file_path_mismatch.
+        """
+        func_ref_a = _make_ref("execute", "src/tool_a.py")
+        graph = MagicMock()
+        graph.resolve_targets.return_value = [func_ref_a]
+        graph.caller_refs_of.return_value = []
+        graph.callee_refs_of.return_value = []
+        graph.call_chain.return_value = []
+
+        server = TreeSitterAnalyzerMCPServer(str(tmp_path))
+        handler = _capture_call_tool_handler(server)
+
+        with (
+            patch(
+                "tree_sitter_analyzer.mcp.tools.codegraph_impact_tool"
+                ".CodeGraphImpactTool._get_call_graph",
+                return_value=graph,
+            ),
+            patch.object(graph, "build", return_value=None),
+        ):
+            raw = await handler(
+                "nav",
+                {
+                    "action": "impact",
+                    "mode": "risk_score",
+                    "function_name": "execute",
+                    # Caller passes ./src/tool_a.py; CallGraph stores src/tool_a.py
+                    "file_path": "./src/tool_a.py",
+                    "output_format": "json",
+                },
+            )
+
+        body = json.loads(raw[0].text)
+        assert body["success"] is True
+        assert "file_path_mismatch" not in body, (
+            "./src/tool_a.py and src/tool_a.py are the same path — no mismatch"
+        )

--- a/tree_sitter_analyzer/mcp/tools/codegraph_impact_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_impact_tool.py
@@ -135,6 +135,23 @@ def _compute_risk_score(
                 base["candidate_files"] = [t.file_path for t in unconstrained[:5]]
         return base
 
+    # #873: CallGraph._resolve_targets falls back to unscoped candidates when
+    # the requested file_path doesn't match any definition.  Targets is
+    # therefore non-empty even for a wrong file_path, so the empty-targets
+    # branch above never fires.  Detect the fallback by checking whether any
+    # returned target actually lives in the requested file.
+    if file_path is not None and not any(
+        getattr(t, "file_path", None) == file_path for t in targets
+    ):
+        return {
+            "score": 0,
+            "level": "unknown",
+            "factors": {},
+            "tests": {"test_callers_count": 0, "test_callees_count": 0},
+            "file_path_mismatch": True,
+            "candidate_files": [t.file_path for t in targets[:5]],
+        }
+
     # Ambiguity guard (#799): multiple definitions of the same name exist.
     # Picking targets[0] silently would produce misleading low-risk verdicts for
     # highly-overloaded names (e.g. 'execute' across 30+ MCP tool classes).

--- a/tree_sitter_analyzer/mcp/tools/codegraph_impact_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_impact_tool.py
@@ -140,8 +140,17 @@ def _compute_risk_score(
     # therefore non-empty even for a wrong file_path, so the empty-targets
     # branch above never fires.  Detect the fallback by checking whether any
     # returned target actually lives in the requested file.
+    # Codex P2: normalise paths (strip leading ./, os.sep variants, empty)
+    # before comparing so ./src/a.py, src/a.py, and src\a.py all match.
+    import os as _os
+
+    def _norm(p: str | None) -> str:
+        if not p:
+            return ""
+        return _os.path.normpath(p).replace("\\", "/")
+
     if file_path is not None and not any(
-        getattr(t, "file_path", None) == file_path for t in targets
+        _norm(getattr(t, "file_path", None)) == _norm(file_path) for t in targets
     ):
         return {
             "score": 0,


### PR DESCRIPTION
## Summary
- `_compute_risk_score` only detected `file_path_mismatch` when `resolve_targets` returned `[]`
- The real `CallGraph._resolve_targets` falls back to returning unscoped candidates when `file_path` doesn't match, so `targets` is never empty for an existing function name with a wrong file path
- Added a post-resolve check: if `file_path` was requested but no target lives in that file, surface `file_path_mismatch=True` and populate `candidate_files`
- Updated the test to reflect real fallback behavior (returns the candidate, not `[]`)

## Test plan
- [ ] `test_file_path_mismatch_gives_candidate_hint` passes with real fallback mock

Fixes #873