### PR TITLE
fix(mcp): add agent_summary envelope to ast_diff and codegraph_overview (#743 #744)

### DIFF
--- a/tests/unit/test_ast_diff_tool.py
+++ b/tests/unit/test_ast_diff_tool.py
@@ -442,11 +442,11 @@ class TestASTDiffNodeBudget:
         default_bytes = _stable_bytes(default_result)
         bodies_bytes = _stable_bytes(bodies_result)
 
-        # Cost invariant (CLAUDE.md rule 11) pinned exactly: 587 < 1718 — the
+        # Cost invariant (CLAUDE.md rule 11) pinned exactly: 746 < 1877 — the
         # default is dramatically smaller than the full-body opt-in.
-        # Re-pinned after #743/#744 added agent_summary+summary_line fields.
-        assert default_bytes == 587
-        assert bodies_bytes == 1718
+        # Re-pinned after Codex P2 made agent_summary a dict (next_step+verdict).
+        assert default_bytes == 746
+        assert bodies_bytes == 1877
 
     @pytest.mark.asyncio
     async def test_include_node_bodies_true_has_children(self, tool):
@@ -506,7 +506,7 @@ class TestAstDiffAgentSummaryEnvelope:
 
     @pytest.mark.asyncio
     async def test_response_has_agent_summary_with_hunks(self, tool):
-        """When diff produces hunks, agent_summary mentions the count."""
+        """When diff produces hunks, agent_summary is a dict with count in summary_line."""
         result = await tool.execute(
             {
                 "mode": "diff_strings",
@@ -518,14 +518,16 @@ class TestAstDiffAgentSummaryEnvelope:
         )
         assert "agent_summary" in result, "agent_summary missing from envelope"
         assert "summary_line" in result, "summary_line missing from envelope"
-        assert isinstance(result["agent_summary"], str)
-        assert result["agent_summary"] == result["summary_line"]
+        # Codex P2: agent_summary must be a dict, not a string
+        assert isinstance(result["agent_summary"], dict), "agent_summary must be a dict"
+        assert result["agent_summary"]["summary_line"] == result["summary_line"]
+        assert "verdict" in result["agent_summary"]
         # There are hunks — summary must mention count, not "No AST changes"
-        assert "No AST changes" not in result["agent_summary"]
+        assert "No AST changes" not in result["agent_summary"]["summary_line"]
 
     @pytest.mark.asyncio
     async def test_response_has_agent_summary_no_hunks(self, tool):
-        """When old == new (no hunks), agent_summary says 'No AST changes'."""
+        """When old == new (no hunks), agent_summary dict says 'No AST changes'."""
         result = await tool.execute(
             {
                 "mode": "diff_strings",
@@ -536,4 +538,26 @@ class TestAstDiffAgentSummaryEnvelope:
             }
         )
         assert "agent_summary" in result, "agent_summary missing from envelope"
-        assert "No AST changes" in result["agent_summary"]
+        assert isinstance(result["agent_summary"], dict), "agent_summary must be a dict"
+        assert "No AST changes" in result["agent_summary"]["summary_line"]
+
+    @pytest.mark.asyncio
+    async def test_response_has_agent_summary_parse_failure(self, tool):
+        """When both sources fail to parse (unsupported language), verdict is ERROR."""
+        result = await tool.execute(
+            {
+                "mode": "diff_strings",
+                "old_source": "a = 1",
+                "new_source": "b = 2",
+                # 'cobol' is unsupported → both parse calls return success=False
+                # → ASTDiffer emits a single error sentinel hunk with no old/new
+                "language": "cobol",
+                "output_format": "json",
+            }
+        )
+        assert "agent_summary" in result
+        assert isinstance(result["agent_summary"], dict)
+        # Parse failure → error hunk → verdict ERROR, not the generic "INFO"
+        assert result["verdict"] == "ERROR"
+        assert result["agent_summary"]["verdict"] == "ERROR"
+        assert result["agent_summary"]["summary_line"] == "Both sources failed to parse"

--- a/tests/unit/test_ast_diff_tool.py
+++ b/tests/unit/test_ast_diff_tool.py
@@ -442,10 +442,11 @@ class TestASTDiffNodeBudget:
         default_bytes = _stable_bytes(default_result)
         bodies_bytes = _stable_bytes(bodies_result)
 
-        # Cost invariant (CLAUDE.md rule 11) pinned exactly: 496 < 1627 — the
+        # Cost invariant (CLAUDE.md rule 11) pinned exactly: 587 < 1718 — the
         # default is dramatically smaller than the full-body opt-in.
-        assert default_bytes == 496
-        assert bodies_bytes == 1627
+        # Re-pinned after #743/#744 added agent_summary+summary_line fields.
+        assert default_bytes == 587
+        assert bodies_bytes == 1718
 
     @pytest.mark.asyncio
     async def test_include_node_bodies_true_has_children(self, tool):
@@ -494,3 +495,45 @@ class TestASTDiffNodeBudget:
         # Exact pin (deterministic for this fixture at budget=1): the omitted
         # bytes equal full-body minus compact = 1627 - 496 = 1131.
         assert result["bytes_omitted"] == 1131
+
+
+class TestAstDiffAgentSummaryEnvelope:
+    """#744: ast_diff must include agent_summary and summary_line in response."""
+
+    @pytest.fixture
+    def tool(self):
+        return ASTDiffTool()
+
+    @pytest.mark.asyncio
+    async def test_response_has_agent_summary_with_hunks(self, tool):
+        """When diff produces hunks, agent_summary mentions the count."""
+        result = await tool.execute(
+            {
+                "mode": "diff_strings",
+                "old_source": _OLD_SRC,
+                "new_source": _NEW_SRC,
+                "language": _LANG,
+                "output_format": "json",
+            }
+        )
+        assert "agent_summary" in result, "agent_summary missing from envelope"
+        assert "summary_line" in result, "summary_line missing from envelope"
+        assert isinstance(result["agent_summary"], str)
+        assert result["agent_summary"] == result["summary_line"]
+        # There are hunks — summary must mention count, not "No AST changes"
+        assert "No AST changes" not in result["agent_summary"]
+
+    @pytest.mark.asyncio
+    async def test_response_has_agent_summary_no_hunks(self, tool):
+        """When old == new (no hunks), agent_summary says 'No AST changes'."""
+        result = await tool.execute(
+            {
+                "mode": "diff_strings",
+                "old_source": _OLD_SRC,
+                "new_source": _OLD_SRC,  # identical → no hunks
+                "language": _LANG,
+                "output_format": "json",
+            }
+        )
+        assert "agent_summary" in result, "agent_summary missing from envelope"
+        assert "No AST changes" in result["agent_summary"]

--- a/tests/unit/test_codegraph_overview_tool.py
+++ b/tests/unit/test_codegraph_overview_tool.py
@@ -160,13 +160,16 @@ class TestCodeGraphOverviewToolExecute:
 
     @pytest.mark.asyncio
     async def test_execute_has_agent_summary_envelope(self, tool):
-        """#743: codegraph_overview must include agent_summary and summary_line."""
+        """#743: codegraph_overview must include agent_summary dict and summary_line."""
         result = await _execute(tool, {"output_format": "json"})
         assert "agent_summary" in result, "agent_summary missing from envelope"
         assert "summary_line" in result, "summary_line missing from envelope"
-        assert isinstance(result["agent_summary"], str)
+        # Codex P2: agent_summary must be a dict so direct callers can read
+        # agent_summary["verdict"] without the MCP server normalizer.
+        assert isinstance(result["agent_summary"], dict), "agent_summary must be a dict"
         assert isinstance(result["summary_line"], str)
-        assert result["agent_summary"] == result["summary_line"]
+        assert result["agent_summary"]["summary_line"] == result["summary_line"]
+        assert "verdict" in result["agent_summary"]
 
     @pytest.mark.asyncio
     async def test_execute_empty_project(self, tmp_path):

--- a/tests/unit/test_codegraph_overview_tool.py
+++ b/tests/unit/test_codegraph_overview_tool.py
@@ -159,6 +159,16 @@ class TestCodeGraphOverviewToolExecute:
         assert "success" in result
 
     @pytest.mark.asyncio
+    async def test_execute_has_agent_summary_envelope(self, tool):
+        """#743: codegraph_overview must include agent_summary and summary_line."""
+        result = await _execute(tool, {"output_format": "json"})
+        assert "agent_summary" in result, "agent_summary missing from envelope"
+        assert "summary_line" in result, "summary_line missing from envelope"
+        assert isinstance(result["agent_summary"], str)
+        assert isinstance(result["summary_line"], str)
+        assert result["agent_summary"] == result["summary_line"]
+
+    @pytest.mark.asyncio
     async def test_execute_empty_project(self, tmp_path):
         empty_dir = str(tmp_path / "empty")
         import os

--- a/tree_sitter_analyzer/mcp/tools/ast_diff_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/ast_diff_tool.py
@@ -242,19 +242,44 @@ class ASTDiffTool(BaseMCPTool):
         # sides are identical (zero hunks), INFO when there are real changes.
         # We deliberately don't escalate to REVIEW/CAUTION here — diff
         # severity is the semantic_classify tool's job.
-        verdict = "NOT_FOUND" if not result_dict.get("hunks") else "INFO"
-        hunk_count = len(result_dict.get("hunks", []))
+        hunks_raw = result_dict.get("hunks", [])
+        hunk_count = len(hunks_raw)
         lang_str = result_dict.get("language", "unknown")
-        agent_summary_line = (
-            f"{hunk_count} AST change(s) in {lang_str}"
-            if hunk_count
-            else f"No AST changes in {lang_str}"
+
+        # Codex P2: surface parse failures — a hunk with neither "old" nor "new"
+        # key is an error sentinel (e.g. "Both sources failed to parse"), not a
+        # real edit. Real hunks always carry at least one of "old" / "new".
+        is_error_hunk = (
+            hunk_count == 1
+            and "old" not in hunks_raw[0]
+            and "new" not in hunks_raw[0]
+            and hunks_raw[0].get("summary")
         )
+        if is_error_hunk:
+            agent_summary_line = hunks_raw[0]["summary"]
+            verdict = "ERROR"
+        elif hunk_count:
+            agent_summary_line = f"{hunk_count} AST change(s) in {lang_str}"
+            verdict = "INFO"
+        else:
+            agent_summary_line = f"No AST changes in {lang_str}"
+            verdict = "NOT_FOUND"
+
         response: dict[str, Any] = {
             "success": True,
             "verdict": verdict,
             "summary_line": agent_summary_line,
-            "agent_summary": agent_summary_line,
+            # Codex P2: agent_summary must be a dict so direct execute() callers
+            # (CLI, tests) can read agent_summary["verdict"] without the MCP
+            # server normalizer running first.
+            "agent_summary": {
+                "summary_line": agent_summary_line,
+                "next_step": (
+                    "Inspect specific hunks to understand the changes. "
+                    "Use semantic_classify for severity rating of each hunk."
+                ),
+                "verdict": verdict,
+            },
             **result_dict,
         }
 

--- a/tree_sitter_analyzer/mcp/tools/ast_diff_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/ast_diff_tool.py
@@ -243,9 +243,18 @@ class ASTDiffTool(BaseMCPTool):
         # We deliberately don't escalate to REVIEW/CAUTION here — diff
         # severity is the semantic_classify tool's job.
         verdict = "NOT_FOUND" if not result_dict.get("hunks") else "INFO"
+        hunk_count = len(result_dict.get("hunks", []))
+        lang_str = result_dict.get("language", "unknown")
+        agent_summary_line = (
+            f"{hunk_count} AST change(s) in {lang_str}"
+            if hunk_count
+            else f"No AST changes in {lang_str}"
+        )
         response: dict[str, Any] = {
             "success": True,
             "verdict": verdict,
+            "summary_line": agent_summary_line,
+            "agent_summary": agent_summary_line,
             **result_dict,
         }
 

--- a/tree_sitter_analyzer/mcp/tools/codegraph_overview_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_overview_tool.py
@@ -155,16 +155,30 @@ class CodeGraphOverviewTool(BaseMCPTool):
         else:
             verdict = "INFO"
 
+        # Codex P2: label capped counts with "+" so agents can tell a cap was hit.
+        ep_count = len(entry_points)
+        dead_suffix = "+" if dead_count >= max_dead else ""
+        ep_suffix = "+" if ep_count >= max_entry_points else ""
         agent_summary_line = (
-            f"{fn_count} functions, {dead_count} dead code entries — "
-            f"{len(entry_points)} entry points, "
+            f"{fn_count} functions, {dead_count}{dead_suffix} dead code entries — "
+            f"{ep_count}{ep_suffix} entry points, "
             f"max call depth {depth_dist.get('max_depth', 0)}"
         )
         result: dict[str, Any] = {
             "success": True,
             "verdict": verdict,
             "summary_line": agent_summary_line,
-            "agent_summary": agent_summary_line,
+            # Codex P2: agent_summary must be a dict so direct execute() callers
+            # (CLI, tests) can read agent_summary["verdict"] without the MCP
+            # server normalizer running first.
+            "agent_summary": {
+                "summary_line": agent_summary_line,
+                "next_step": (
+                    "Check dead_code list for cleanup opportunities. "
+                    "Use --callers to verify callers of flagged dead code."
+                ),
+                "verdict": verdict,
+            },
             "project_root": self.project_root,
             "summary": {
                 "function_count": summary.get("function_count", 0),

--- a/tree_sitter_analyzer/mcp/tools/codegraph_overview_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_overview_tool.py
@@ -155,9 +155,16 @@ class CodeGraphOverviewTool(BaseMCPTool):
         else:
             verdict = "INFO"
 
+        agent_summary_line = (
+            f"{fn_count} functions, {dead_count} dead code entries — "
+            f"{len(entry_points)} entry points, "
+            f"max call depth {depth_dist.get('max_depth', 0)}"
+        )
         result: dict[str, Any] = {
             "success": True,
             "verdict": verdict,
+            "summary_line": agent_summary_line,
+            "agent_summary": agent_summary_line,
             "project_root": self.project_root,
             "summary": {
                 "function_count": summary.get("function_count", 0),


### PR DESCRIPTION
## Summary

- **#743** `--codegraph-overview` JSON response was missing `agent_summary` and `summary_line`; added a string derived from `fn_count / dead_count / entry_point_count / max_depth`
- **#744** `--ast-diff` JSON response was missing `agent_summary` and `summary_line`; added hunk count + language summary (`"N AST change(s) in python"` / `"No AST changes in python"`)
- Re-pinned cost-invariant byte test in `TestASTDiffNodeBudget` (496→587 default, 1627→1718 with bodies) — both fields add ~91 bytes; the `default < full-body` relationship invariant holds

## Test plan

- [ ] `test_execute_has_agent_summary_envelope` — new test for `codegraph_overview`
- [ ] `test_response_has_agent_summary_with_hunks` + `test_response_has_agent_summary_no_hunks` — new tests for `ast_diff`
- [ ] `test_default_bytes_smaller_than_include_bodies_bytes` — re-pinned, still passes
- [ ] Full test files: 66 passed, 0 failed