### PR TITLE
fix(ruby,php): populate line_count in AnalysisResult (#769)

### DIFF
--- a/tests/golden_masters/toon/php_sample_toon.toon
+++ b/tests/golden_masters/toon/php_sample_toon.toon
@@ -54,6 +54,6 @@ statistics:
   method_count: 21
   field_count: 12
   import_count: 2
-  total_lines: 0
+  total_lines: 214
 effective_table: toon
 requested_table: toon

--- a/tests/golden_masters/toon/ruby_sample_toon.toon
+++ b/tests/golden_masters/toon/ruby_sample_toon.toon
@@ -67,6 +67,6 @@ statistics:
   method_count: 33
   field_count: 12
   import_count: 3
-  total_lines: 0
+  total_lines: 220
 effective_table: toon
 requested_table: toon

--- a/tests/unit/languages/test_php_plugin.py
+++ b/tests/unit/languages/test_php_plugin.py
@@ -747,6 +747,8 @@ class TestPHPPluginAnalyzeFile:
         # 3 functions (__construct/getName/getAge), 2 variables (name/age),
         # 2 imports (UserInterface/HasTimestamps — extracted since #617).
         assert len(result.elements) == 8
+        # #769: line_count must be non-zero (was always 0 before this fix)
+        assert result.line_count == len(SIMPLE_CLASS_CODE.splitlines())
 
 
 class TestPHPIntegration:

--- a/tests/unit/languages/test_ruby_plugin.py
+++ b/tests/unit/languages/test_ruby_plugin.py
@@ -596,6 +596,17 @@ class TestRubyPluginAnalyzeFile:
 
         assert result.node_count == 77
 
+    @pytest.mark.asyncio
+    async def test_analyze_file_line_count_nonzero(self, tmp_path):
+        """#769: line_count must reflect actual file line count, not default 0."""
+        rb_file = tmp_path / "test.rb"
+        rb_file.write_text(SIMPLE_CLASS_CODE, encoding="utf-8")
+
+        plugin = RubyPlugin()
+        result = await plugin.analyze_file(str(rb_file), None)
+
+        assert result.line_count == len(SIMPLE_CLASS_CODE.splitlines())
+
 
 class TestRubyIntegration:
     """Integration tests for Ruby plugin."""

--- a/tree_sitter_analyzer/languages/php_plugin.py
+++ b/tree_sitter_analyzer/languages/php_plugin.py
@@ -507,6 +507,7 @@ class PHPPlugin(LanguagePlugin):
                 file_path=file_path,
                 success=True,
                 elements=all_elements,
+                line_count=len(content.splitlines()),
                 node_count=self._count_nodes(tree.root_node),
             )
         except Exception as e:

--- a/tree_sitter_analyzer/languages/ruby_plugin.py
+++ b/tree_sitter_analyzer/languages/ruby_plugin.py
@@ -675,6 +675,7 @@ class RubyPlugin(LanguagePlugin):
                 file_path=file_path,
                 success=True,
                 elements=all_elements,
+                line_count=len(content.splitlines()),
                 node_count=self._count_nodes(tree.root_node),
             )
         except Exception as e:


### PR DESCRIPTION
## Summary

- **#769** Both Ruby and PHP plugins constructed `AnalysisResult()` without `line_count`, causing it to default to `0`
- Added `line_count=len(content.splitlines())` to both, matching the Python/Go/Kotlin pattern
- Updated two TOON golden masters that were pinned to `total_lines: 0` (the buggy value): ruby_sample 0→220, php_sample 0→214

## Test plan

- [ ] `test_analyze_file_line_count_nonzero` — new Ruby test, pins exact value via `len(SIMPLE_CLASS_CODE.splitlines())`
- [ ] `test_analyze_file_with_temp_file` — PHP test extended with `line_count` assertion
- [ ] Ruby and PHP golden master regression tests: 8 passed