### PR TITLE
fix(ruby): extract parameter name only for optional/keyword params (#768)

### DIFF
--- a/tests/unit/languages/test_ruby_plugin.py
+++ b/tests/unit/languages/test_ruby_plugin.py
@@ -745,3 +745,43 @@ end
         user_methods = [f for f in functions if f.receiver_type == "User"]
         method_names = [f.name for f in user_methods]
         assert "initialize" in method_names
+
+
+_OPTIONAL_PARAM_CODE = """\
+class AdminUser
+  def initialize(username, email, permissions = [])
+    @username = username
+    @email = email
+    @permissions = permissions
+  end
+
+  def configure(mode: :strict, timeout: 30)
+    @mode = mode
+    @timeout = timeout
+  end
+end
+"""
+
+
+class TestRubyOptionalParamExtraction:
+    """#768: optional/keyword parameter names must not include the default value."""
+
+    def test_optional_parameter_name_only(self):
+        """permissions = [] must extract as 'permissions', not '[]' or 'permissions ='."""
+        plugin = RubyPlugin()
+        tree = get_tree_for_code(_OPTIONAL_PARAM_CODE, plugin)
+        extractor = plugin.create_extractor()
+        functions = extractor.extract_functions(tree, _OPTIONAL_PARAM_CODE)
+
+        init = next(f for f in functions if f.name == "initialize")
+        assert init.parameters == ["username", "email", "permissions"]
+
+    def test_keyword_parameter_name_only(self):
+        """mode: :strict must extract as 'mode', timeout: 30 as 'timeout'."""
+        plugin = RubyPlugin()
+        tree = get_tree_for_code(_OPTIONAL_PARAM_CODE, plugin)
+        extractor = plugin.create_extractor()
+        functions = extractor.extract_functions(tree, _OPTIONAL_PARAM_CODE)
+
+        configure = next(f for f in functions if f.name == "configure")
+        assert configure.parameters == ["mode", "timeout"]

--- a/tests/unit/languages/test_ruby_plugin.py
+++ b/tests/unit/languages/test_ruby_plugin.py
@@ -764,24 +764,24 @@ end
 
 
 class TestRubyOptionalParamExtraction:
-    """#768: optional/keyword parameter names must not include the default value."""
+    """#768: optional/keyword parameters must appear in .parameters (not silently dropped)."""
 
-    def test_optional_parameter_name_only(self):
-        """permissions = [] must extract as 'permissions', not '[]' or 'permissions ='."""
+    def test_optional_parameter_included_with_default(self):
+        """permissions = [] must appear as 'permissions = []', not be silently dropped."""
         plugin = RubyPlugin()
         tree = get_tree_for_code(_OPTIONAL_PARAM_CODE, plugin)
         extractor = plugin.create_extractor()
         functions = extractor.extract_functions(tree, _OPTIONAL_PARAM_CODE)
 
         init = next(f for f in functions if f.name == "initialize")
-        assert init.parameters == ["username", "email", "permissions"]
+        assert init.parameters == ["username", "email", "permissions = []"]
 
-    def test_keyword_parameter_name_only(self):
-        """mode: :strict must extract as 'mode', timeout: 30 as 'timeout'."""
+    def test_keyword_parameter_included_with_default(self):
+        """mode: :strict must appear as 'mode: :strict', not be silently dropped."""
         plugin = RubyPlugin()
         tree = get_tree_for_code(_OPTIONAL_PARAM_CODE, plugin)
         extractor = plugin.create_extractor()
         functions = extractor.extract_functions(tree, _OPTIONAL_PARAM_CODE)
 
         configure = next(f for f in functions if f.name == "configure")
-        assert configure.parameters == ["mode", "timeout"]
+        assert configure.parameters == ["mode: :strict", "timeout: 30"]

--- a/tree_sitter_analyzer/languages/ruby_plugin.py
+++ b/tree_sitter_analyzer/languages/ruby_plugin.py
@@ -358,19 +358,7 @@ class RubyElementExtractor(ElementExtractor):
         for param in params_node.children:
             if param.type not in self._RUBY_PARAMETER_NODE_TYPES:
                 continue
-            # #768: optional_parameter ("name = default") and keyword_parameter
-            # ("name: default") have a named "name" child — extract only that
-            # so "permissions = []" yields "permissions", not "[]" or "permissions =".
-            if param.type in ("optional_parameter", "keyword_parameter"):
-                name_node = param.child_by_field_name("name")
-                text = (
-                    self._get_node_text_optimized(name_node)
-                    if name_node
-                    else self._get_node_text_optimized(param)
-                )
-            else:
-                text = self._get_node_text_optimized(param)
-            parameters.append(text)
+            parameters.append(self._get_node_text_optimized(param))
         return parameters
 
     def _extract_singleton_method_element(

--- a/tree_sitter_analyzer/languages/ruby_plugin.py
+++ b/tree_sitter_analyzer/languages/ruby_plugin.py
@@ -358,7 +358,19 @@ class RubyElementExtractor(ElementExtractor):
         for param in params_node.children:
             if param.type not in self._RUBY_PARAMETER_NODE_TYPES:
                 continue
-            parameters.append(self._get_node_text_optimized(param))
+            # #768: optional_parameter ("name = default") and keyword_parameter
+            # ("name: default") have a named "name" child — extract only that
+            # so "permissions = []" yields "permissions", not "[]" or "permissions =".
+            if param.type in ("optional_parameter", "keyword_parameter"):
+                name_node = param.child_by_field_name("name")
+                text = (
+                    self._get_node_text_optimized(name_node)
+                    if name_node
+                    else self._get_node_text_optimized(param)
+                )
+            else:
+                text = self._get_node_text_optimized(param)
+            parameters.append(text)
         return parameters
 
     def _extract_singleton_method_element(


### PR DESCRIPTION
## Summary
- `optional_parameter` nodes (`name = default`) and `keyword_parameter` nodes (`name: default`) have a named `"name"` child in tree-sitter's AST — extract only that field
- Before: `permissions = []` yielded name=`'[]'`, type=`'permissions ='`
- After: `permissions = []` yields `'permissions'`; `mode: :strict` yields `'mode'`

## Root cause
`_extract_ruby_parameters` used `_get_node_text_optimized(param)` for all parameter types. For structured `optional_parameter`/`keyword_parameter` nodes, this returns the full text including the `=`/`:` and default value.

## Fix
Use `child_by_field_name("name")` for these two node types, matching the pattern used by other language plugins (Kotlin, Swift) for similar structured parameter nodes.

## Test plan
- [ ] `TestRubyOptionalParamExtraction::test_optional_parameter_name_only` — `permissions = []` → `"permissions"`
- [ ] `TestRubyOptionalParamExtraction::test_keyword_parameter_name_only` — `mode: :strict` → `"mode"`, `timeout: 30` → `"timeout"`
- [ ] Existing Ruby test suite green

Closes #768