### PR TITLE
fix(php): use bare name for top-level functions (#765)

### DIFF
--- a/tests/golden_masters/compact/php_sample_compact.md
+++ b/tests/golden_masters/compact/php_sample_compact.md
@@ -29,5 +29,5 @@
 | Loggable::log | (string):void | + | 165-171 | 1 | - |
 | Loggable::getLogs | ():array | + | 173-176 | 1 | - |
 | UserStatus::label | ():string | + | 189-197 | 1 | - |
-| App\Models\createUser | (string, string):User | + | 203-206 | 1 | - |
-| App\Models\hashPassword | (string):string | + | 211-214 | 1 | - |
+| createUser | (string, string):User | + | 203-206 | 1 | - |
+| hashPassword | (string):string | + | 211-214 | 1 | - |

--- a/tests/golden_masters/csv/php_sample_csv.csv
+++ b/tests/golden_masters/csv/php_sample_csv.csv
@@ -30,5 +30,5 @@ Method,UserRepositoryInterface::delete,($user:User):void,public,155-155,1,-
 Method,Loggable::log,($message:string):void,public,165-171,1,-
 Method,Loggable::getLogs,():array,public,173-176,1,-
 Method,UserStatus::label,():string,public,189-197,1,-
-Method,App\Models\createUser,($username:string, $email:string):User,public,203-206,1,-
-Method,App\Models\hashPassword,($password:string):string,public,211-214,1,-
+Method,createUser,($username:string, $email:string):User,public,203-206,1,-
+Method,hashPassword,($password:string):string,public,211-214,1,-

--- a/tests/golden_masters/full/php_sample_full.md
+++ b/tests/golden_masters/full/php_sample_full.md
@@ -94,5 +94,5 @@ import App\Traits\Timestampable
 ## Functions
 | Method | Signature | Vis | Lines | Cx | Doc |
 |--------|-----------|-----|-------|----|----|
-| App\Models\createUser | ($username:string, $email:string):User | + | 203-206 | 1 | - |
-| App\Models\hashPassword | ($password:string):string | + | 211-214 | 1 | - |
+| createUser | ($username:string, $email:string):User | + | 203-206 | 1 | - |
+| hashPassword | ($password:string):string | + | 211-214 | 1 | - |

--- a/tests/golden_masters/plugins/php.json
+++ b/tests/golden_masters/plugins/php.json
@@ -15,12 +15,11 @@
       "App\\Models\\UserStatus"
     ],
     "Function": [
-      "App\\Models\\createUser",
-      "App\\Models\\hashPassword",
       "__construct",
       "__get",
       "__set",
       "authenticate",
+      "createUser",
       "delete",
       "find",
       "findByEmail",
@@ -30,6 +29,7 @@
       "getUsername",
       "grantPermission",
       "hasPermission",
+      "hashPassword",
       "label",
       "log",
       "save",

--- a/tests/golden_masters/toon/php_sample_toon.toon
+++ b/tests/golden_masters/toon/php_sample_toon.toon
@@ -29,8 +29,8 @@ methods:
     log,public,(165,171)
     getLogs,public,(173,176)
     label,public,(189,197)
-    "App\\Models\\createUser",public,(203,206)
-    "App\\Models\\hashPassword",public,(211,214)
+    createUser,public,(203,206)
+    hashPassword,public,(211,214)
 fields:
   [12]{name,type,line_range(a,b)}:
     STATUS_ACTIVE,,(20,20)

--- a/tests/unit/languages/test_php_plugin.py
+++ b/tests/unit/languages/test_php_plugin.py
@@ -937,3 +937,52 @@ enum Suit
         consts = [v for v in variables if v.name == "ENUM_C"]
         assert len(consts) == 1
         assert consts[0].receiver_type == "Suit"
+
+
+class TestPHPTopLevelFunctionNamespace:
+    """#765: Top-level PHP functions in namespaced files must use bare names."""
+
+    CODE_WITH_NS = """<?php
+namespace App\\Models;
+
+function createUser(string $name): int
+{
+    return 1;
+}
+
+function hashPassword(string $pwd): string
+{
+    return md5($pwd);
+}
+"""
+
+    CODE_WITHOUT_NS = """<?php
+function topLevelOne(): void {}
+function topLevelTwo(int $x): int { return $x; }
+"""
+
+    def _parse(self, code: str):
+        import tree_sitter
+        import tree_sitter_php
+
+        from tree_sitter_analyzer.languages.php_plugin import PHPElementExtractor
+
+        lang = tree_sitter.Language(tree_sitter_php.language_php())
+        tree = tree_sitter.Parser(lang).parse(code.encode())
+        extractor = PHPElementExtractor()
+        return extractor.extract_functions(tree, code)
+
+    def test_namespaced_file_uses_bare_names(self):
+        funcs = self._parse(self.CODE_WITH_NS)
+        names = [f.name for f in funcs]
+        assert "createUser" in names
+        assert "hashPassword" in names
+        # Namespace must NOT be embedded in Function.name (#765)
+        assert not any("\\" in n for n in names), (
+            f"Namespace leaked into names: {names}"
+        )
+
+    def test_no_namespace_file_uses_bare_names(self):
+        funcs = self._parse(self.CODE_WITHOUT_NS)
+        names = [f.name for f in funcs]
+        assert names == ["topLevelOne", "topLevelTwo"]

--- a/tests/unit/languages/test_ruby_php_extraction_fixes.py
+++ b/tests/unit/languages/test_ruby_php_extraction_fixes.py
@@ -283,8 +283,8 @@ function helper(): void {}
 
 
 def test_php_top_level_function_name_consistent_when_called_standalone() -> None:
-    """extract_functions called standalone must include the file namespace in
-    top-level function names (App\\Services\\helper), not bare 'helper'."""
+    """#765: top-level functions in namespaced files use bare names (not qualified).
+    Calling extract_functions standalone must return 'helper', not 'App\\Services\\helper'."""
     parser = _php_parser()
     tree = parser.parse(PHP_NS_FUNC_SRC)
     src = PHP_NS_FUNC_SRC.decode()
@@ -294,12 +294,12 @@ def test_php_top_level_function_name_consistent_when_called_standalone() -> None
     funcs = extractor.extract_functions(tree, src)
 
     helper = next(f for f in funcs if "helper" in f.name)
-    assert helper.name == "App\\Services\\helper"
+    assert helper.name == "helper"
 
 
 def test_php_top_level_function_name_consistent_after_extract_classes() -> None:
-    """extract_functions called AFTER extract_classes must yield the same name
-    as when called standalone (order-independence)."""
+    """#765: order-independence — result must be bare name whether or not
+    extract_classes (which sets current_namespace) ran first."""
     parser = _php_parser()
     tree = parser.parse(PHP_NS_FUNC_SRC)
     src = PHP_NS_FUNC_SRC.decode()
@@ -309,7 +309,7 @@ def test_php_top_level_function_name_consistent_after_extract_classes() -> None:
     funcs = extractor.extract_functions(tree, src)
 
     helper = next(f for f in funcs if "helper" in f.name)
-    assert helper.name == "App\\Services\\helper"
+    assert helper.name == "helper"
 
 
 def test_php_no_namespace_function_has_bare_name() -> None:

--- a/tree_sitter_analyzer/languages/php_helpers.py
+++ b/tree_sitter_analyzer/languages/php_helpers.py
@@ -344,10 +344,11 @@ def extract_php_function_element(
         if return_type_node:
             return_type = get_node_text(return_type_node)
 
-        full_name = f"{current_namespace}\\{name}" if current_namespace else name
-
+        # #765: use bare name — consistent with class methods (always bare,
+        # receiver_type carries owner). Namespace-prefixed names broke symbol
+        # search ("createUser" not found when file has a namespace).
         return Function(
-            name=full_name,
+            name=name,
             start_line=node.start_point[0] + 1,
             end_line=node.end_point[0] + 1,
             visibility="public",


### PR DESCRIPTION
## Summary
- PHP functions outside classes were embedding namespace in `Function.name` (e.g. `App\Models\createUser`) while class methods always use bare names
- This broke symbol search: searching `createUser` missed the prefixed entry
- Fix: use bare `name` in `extract_php_function_element` — consistent with class methods

## Test plan
- [ ] `TestPHPTopLevelFunctionNamespace::test_namespaced_file_uses_bare_names` — asserts no `\` in function names from namespaced files
- [ ] `TestPHPTopLevelFunctionNamespace::test_no_namespace_file_uses_bare_names` — baseline still works without namespace
- [ ] Golden masters (full/compact/csv/toon) updated for `php_sample`
- [ ] Full PHP test suite: 59 passed, no regressions

Closes #765

🤖 Generated with [Claude Code](https://claude.com/claude-code)