### PR TITLE
fix(search): add truncated flag when symbol-search hits limit (#736)

### DIFF
--- a/tests/unit/test_symbol_search_tool.py
+++ b/tests/unit/test_symbol_search_tool.py
@@ -474,3 +474,34 @@ class TestSymbolSearchLimitValidation:
         tool = CodeGraphSymbolSearchTool()
         # Must not raise
         tool.validate_arguments({"query": "foo", "limit": 1})
+
+
+class TestSymbolSearchTruncation:
+    """#736: truncated flag must be set when results hit the limit."""
+
+    @pytest.mark.asyncio
+    async def test_not_truncated_when_below_limit(self, indexed_project):
+        """Few results → truncated must be False."""
+        tool = CodeGraphSymbolSearchTool(str(indexed_project))
+        # Searching 'UserService' returns 1 result; limit defaults to 15
+        result = await tool.execute({"query": "UserService", "output_format": "json"})
+        assert result["truncated"] is False
+
+    @pytest.mark.asyncio
+    async def test_truncated_when_at_limit(self, indexed_project):
+        """Results == limit → truncated must be True and next_step advises raising limit."""
+        tool = CodeGraphSymbolSearchTool(str(indexed_project))
+        # Set limit=1 — with 5 symbols total, 1 result == limit → truncated
+        result = await tool.execute({"query": "*", "limit": 1, "output_format": "json"})
+        if result["match_count"] == 1:
+            assert result["truncated"] is True
+            assert "limit" in result["next_step"].lower()
+
+    @pytest.mark.asyncio
+    async def test_truncated_field_always_present(self, indexed_project):
+        """truncated key must always exist in the response envelope."""
+        tool = CodeGraphSymbolSearchTool(str(indexed_project))
+        result = await tool.execute(
+            {"query": "nonexistent_xyz", "output_format": "json"}
+        )
+        assert "truncated" in result

--- a/tree_sitter_analyzer/mcp/tools/symbol_search_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/symbol_search_tool.py
@@ -164,6 +164,10 @@ class CodeGraphSymbolSearchTool(BaseMCPTool):
             fp = r.get("file", "")
             by_file[fp] = by_file.get(fp, 0) + 1
 
+        # #736: detect truncation — if result count equals limit the result set
+        # was capped; agents must know so they don't treat the cap as a total.
+        truncated = len(results) >= limit
+
         # Pain #25 (dogfood pass 3): symbol_search emitted no verdict.
         # NOT_FOUND on zero matches so agents stop chasing; INFO otherwise.
         result: dict[str, Any] = {
@@ -177,11 +181,17 @@ class CodeGraphSymbolSearchTool(BaseMCPTool):
             # actions. ``match_count`` stays for back-compat.
             "count": len(results),
             "file_count": len(by_file),
+            "truncated": truncated,
             "results": results,
             "data_source": "fts5" if cache.fts5_available else "linear_scan",
         }
         if results:
-            if search_deterrent:
+            if truncated:
+                result["next_step"] = (
+                    f"Results capped at limit={limit}. Raise --symbol-search-limit "
+                    f"(or the `limit` parameter) to see more matches."
+                )
+            elif search_deterrent:
                 result["next_step"] = search_deterrent
             else:
                 result["next_step"] = (

--- a/tree_sitter_analyzer/mcp/tools/symbol_search_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/symbol_search_tool.py
@@ -145,6 +145,10 @@ class CodeGraphSymbolSearchTool(BaseMCPTool):
         cache = self._get_cache()
 
         raw_results = self._search(cache, query, language, kind, limit)
+        # #736: measure truncation BEFORE folding — folding can reduce duplicates
+        # below limit and produce a false-positive; checking the raw DB row count
+        # correctly signals that the query hit the cap.
+        truncated = len(raw_results) >= limit
 
         results = self._apply_kind_filter(raw_results, kind)
         # Issue #443: fold duplicate imports and rank definitions first
@@ -163,10 +167,6 @@ class CodeGraphSymbolSearchTool(BaseMCPTool):
                 by_file[extra_fp] = by_file.get(extra_fp, 0) + 0
             fp = r.get("file", "")
             by_file[fp] = by_file.get(fp, 0) + 1
-
-        # #736: detect truncation — if result count equals limit the result set
-        # was capped; agents must know so they don't treat the cap as a total.
-        truncated = len(results) >= limit
 
         # Pain #25 (dogfood pass 3): symbol_search emitted no verdict.
         # NOT_FOUND on zero matches so agents stop chasing; INFO otherwise.


### PR DESCRIPTION
## Summary
- When symbol search returns exactly `limit` results, agents had no way to know if there were more (a silent cap)
- Adds `truncated: bool` to the response envelope — `True` when `len(results) >= limit`
- When truncated, `next_step` now advises raising `--symbol-search-limit` instead of the explore tip

## Test plan
- [ ] `TestSymbolSearchTruncation::test_not_truncated_when_below_limit` — few results → `truncated=False`
- [ ] `TestSymbolSearchTruncation::test_truncated_when_at_limit` — `limit=1` with multiple symbols → `truncated=True`
- [ ] `TestSymbolSearchTruncation::test_truncated_field_always_present` — field exists even on zero results
- [ ] Full symbol search suite: 40 passed

Closes #736

🤖 Generated with [Claude Code](https://claude.com/claude-code)