### PR TITLE
fix(call-path): fallback to name-only query when cross-file chain dead-ends (#734)

### DIFF
--- a/tests/unit/test_call_path.py
+++ b/tests/unit/test_call_path.py
@@ -303,6 +303,68 @@ class TestCallPathFinderBidirectional:
         assert len(result.paths) == 1
 
 
+class TestCallPathFinderCrossFile:
+    """#734: 2-hop cross-file chains must not dead-end when the intermediate
+    node has callee_resolved_file=''.
+
+    The bug: _fwd_state() sets the intermediate node's file to
+    ``callee_resolved_file or file_path``.  When callee_resolved_file is empty,
+    file_path (the *caller* side) is used.  The next BFS iteration then queries
+    ``WHERE caller_name=? AND file_path=<caller-side-file>``, but the outgoing
+    edges for that node are stored under its *definition* file — so the query
+    returns 0 rows and the BFS silently dead-ends.
+
+    The fix adds a fallback: retry with name-only when file-filtered returns 0.
+    """
+
+    def test_two_hop_cross_file_with_unresolved_intermediate(self, tmp_path):
+        """main(a.py) → foo(b.py, unresolved) → bar(c.py) must yield 1 path."""
+        edges = [
+            {
+                "caller_name": "main",
+                "caller_file": "a.py",
+                "callee_name": "foo",
+                # callee_resolved_file intentionally empty — triggers the bug
+                "callee_resolved_file": "",
+            },
+            {
+                "caller_name": "foo",
+                "caller_file": "b.py",
+                "callee_name": "bar",
+                "callee_resolved_file": "c.py",
+            },
+        ]
+        cache = _make_cache_with_edges(tmp_path, edges)
+        finder = CallPathFinder(str(tmp_path), cache=cache)
+        result = finder.find_path("main", "bar", direction="forward")
+        assert result.data_source == "sql"
+        assert len(result.paths) == 1
+        assert result.paths[0].total_hops == 2
+
+    def test_two_hop_cross_file_with_resolved_intermediate(self, tmp_path):
+        """Baseline: same chain with callee_resolved_file set must also work."""
+        edges = [
+            {
+                "caller_name": "main",
+                "caller_file": "a.py",
+                "callee_name": "foo",
+                "callee_resolved_file": "b.py",
+            },
+            {
+                "caller_name": "foo",
+                "caller_file": "b.py",
+                "callee_name": "bar",
+                "callee_resolved_file": "c.py",
+            },
+        ]
+        cache = _make_cache_with_edges(tmp_path, edges)
+        finder = CallPathFinder(str(tmp_path), cache=cache)
+        result = finder.find_path("main", "bar", direction="forward")
+        assert result.data_source == "sql"
+        assert len(result.paths) == 1
+        assert result.paths[0].total_hops == 2
+
+
 class TestCallPathFinderFallback:
     def test_no_cache_falls_back(self, tmp_path):
         cache = MagicMock()

--- a/tree_sitter_analyzer/call_path.py
+++ b/tree_sitter_analyzer/call_path.py
@@ -583,6 +583,17 @@ class CallPathFinder:
                     + "WHERE kind = 'calls' AND caller_name = ? AND file_path = ?",
                     (caller_name, caller_file),
                 ).fetchall()
+                # #734: intermediate nodes use callee_resolved_file || file_path
+                # as their "file" — file_path is the *caller-side* file, but the
+                # node's outgoing edges are stored under its *definition* file.
+                # When the file-filtered query returns nothing, retry without the
+                # filter so cross-file chains are not silently dead-ended.
+                if not rows:
+                    rows = conn.execute(
+                        _FORWARD_EDGE_SELECT
+                        + "WHERE kind = 'calls' AND caller_name = ?",
+                        (caller_name,),
+                    ).fetchall()
             else:
                 rows = conn.execute(
                     _FORWARD_EDGE_SELECT + "WHERE kind = 'calls' AND caller_name = ?",


### PR DESCRIPTION
## Summary

- Fixes #734: `--call-path` returns NO_PATH for valid 2-hop cross-file chains
- Root cause: `_fwd_state()` assigns intermediate node's "file" as `callee_resolved_file || file_path`; when `callee_resolved_file` is empty, the caller-side file is used, but outgoing edges are stored under the definition file — causing the file-filtered BFS query to return 0 rows
- Fix: when file-filtered `_query_forward_edges` returns nothing, fall back to name-only (mirrors existing pattern in `_query_backward_edges`)

## Test plan

- [x] `TestCallPathFinderCrossFile::test_two_hop_cross_file_with_unresolved_intermediate` — reproduces the bug, verifies the fix
- [x] `TestCallPathFinderCrossFile::test_two_hop_cross_file_with_resolved_intermediate` — baseline case (was already working)
- [x] All 25 existing `test_call_path.py` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)