### PR TITLE
fix(java): set is_method=True for all Java class methods/constructors (#740)

### DIFF
--- a/tests/unit/languages/test_java_element_extractor_optimized.py
+++ b/tests/unit/languages/test_java_element_extractor_optimized.py
@@ -79,6 +79,8 @@ def _assert_method_extracted(result) -> None:
     assert result.complexity_score == 2
     assert result.is_abstract is False
     assert result.is_final is False
+    # #740: Java methods inside a class must have is_method=True
+    assert result.is_method is True
 
 
 def _assert_field_extracted(result) -> None:
@@ -576,6 +578,7 @@ class UserConfig {
             assert result.name == "UserService"
             assert result.is_constructor is True
             assert result.return_type == "void"
+            assert result.is_method is True
 
     def test_extract_field_optimized_complete(self, extractor):
         """Test complete field extraction"""

--- a/tree_sitter_analyzer/languages/_java_element_helpers.py
+++ b/tree_sitter_analyzer/languages/_java_element_helpers.py
@@ -126,6 +126,7 @@ def extract_java_method(
             complexity_score=calculate_complexity(node),
             is_abstract="abstract" in modifiers,
             is_final="final" in modifiers,
+            is_method=True,
         )
     except (AttributeError, ValueError, TypeError) as e:
         log_debug_func(f"Failed to extract method info: {e}")


### PR DESCRIPTION
## Summary

- Fixes #740: `--advanced/--structure` output reports `is_method=False` for every Java class method
- Root cause: `extract_java_method` in `_java_element_helpers.py` creates a `Function` object without setting `is_method`; the default is `False`
- Fix: add `is_method=True` — all `method_declaration` and `constructor_declaration` nodes in Java are always inside a class body

## Test plan

- [x] Verified: `examples/MultiClass.java --advanced --output-format json` now reports `is_method=True` for all 8 methods (getName, helper, setValue, getValue, staticMethod, and constructors)
- [x] Updated `test_extract_method_optimized_complete` to assert `is_method is True`
- [x] Updated `test_extract_method_optimized_constructor` to assert `is_method is True`
- [x] All 5 Java extractor tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)