### PR TITLE
fix(ast-cache): add truncated flag to mode=search response (#737)

### DIFF
--- a/tests/unit/test_ast_cache_tool.py
+++ b/tests/unit/test_ast_cache_tool.py
@@ -325,3 +325,53 @@ class TestExecute:
         ):
             result = await tool.execute({"mode": "invalidate", "file_path": "test.py"})
         assert result["invalidated"] is True
+
+
+class TestAstCacheSearchTruncated:
+    """#737: ast_cache mode=search must report truncated=True when results hit the limit."""
+
+    @pytest.mark.asyncio
+    async def test_search_not_truncated_when_below_limit(self, tmp_path):
+        tool = ASTCacheTool(str(tmp_path))
+        mock_cache = MagicMock()
+        mock_cache.fts_search_ranked.return_value = [{"name": "foo"}]
+        mock_cache.fts5_available = True
+        mock_cache.project_root = str(tmp_path)
+        with patch.object(tool, "_get_cache", return_value=mock_cache):
+            result = await tool.execute({"mode": "search", "query": "foo", "limit": 10})
+        assert result["count"] == 1
+        assert result["truncated"] is False
+
+    @pytest.mark.asyncio
+    async def test_search_truncated_when_results_equal_limit(self, tmp_path):
+        tool = ASTCacheTool(str(tmp_path))
+        mock_cache = MagicMock()
+        mock_cache.fts_search_ranked.return_value = [
+            {"name": f"sym{i}"} for i in range(5)
+        ]
+        mock_cache.fts5_available = True
+        mock_cache.project_root = str(tmp_path)
+        with patch.object(tool, "_get_cache", return_value=mock_cache):
+            result = await tool.execute({"mode": "search", "query": "sym", "limit": 5})
+        assert result["count"] == 5
+        assert result["truncated"] is True
+
+    @pytest.mark.asyncio
+    async def test_search_truncated_measured_before_split_expansion(self, tmp_path):
+        """#737: truncated is measured on raw_results BEFORE _apply_legacy_import_split.
+
+        A single raw row whose name is 'a,b' expands to 2 after split.
+        If truncated were measured after split, count==2 with limit==2 would
+        falsely report truncated=True — but the DB only returned 1 row.
+        """
+        tool = ASTCacheTool(str(tmp_path))
+        mock_cache = MagicMock()
+        # 1 raw row that will be split into 2 by _apply_legacy_import_split
+        mock_cache.fts_search.return_value = [{"name": "a, b", "type": "import"}]
+        mock_cache.fts_search_ranked.return_value = [{"name": "a, b", "type": "import"}]
+        mock_cache.fts5_available = True
+        mock_cache.project_root = str(tmp_path)
+        with patch.object(tool, "_get_cache", return_value=mock_cache):
+            # limit=2 — raw_results has 1 row < 2, so truncated must be False
+            result = await tool.execute({"mode": "search", "query": "a", "limit": 2})
+        assert result["truncated"] is False

--- a/tree_sitter_analyzer/mcp/tools/ast_cache_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/ast_cache_tool.py
@@ -494,6 +494,10 @@ class ASTCacheTool(BaseMCPTool):
             raw_results = cache.fts_search_ranked(query, language=language, limit=limit)
         else:
             raw_results = cache.fts_search(query, language=language, limit=limit)
+        # #737: measure truncation BEFORE _apply_legacy_import_split — that helper
+        # can expand rows (multi-symbol imports), so post-split len may exceed limit
+        # even without the DB capping results, producing a false positive.
+        truncated = len(raw_results) >= limit
         # K7: defensively split legacy multi-symbol import rows.
         results = _apply_legacy_import_split(raw_results)
         summary_line = (
@@ -521,6 +525,7 @@ class ASTCacheTool(BaseMCPTool):
             "query": query,
             "results": results,
             "count": len(results),
+            "truncated": truncated,
             "fts5_available": fts5_available,
         }
         if use_ranked and results:


### PR DESCRIPTION
## Summary
- `ast_cache mode=search` now includes `truncated: true` in the response when results hit the limit
- Truncation measured on `raw_results` BEFORE `_apply_legacy_import_split` (same pattern as PR #911's fix to `symbol_search_tool`) — split can expand rows, measuring after would be a false positive
- 3 new exact-pinned tests covering: not truncated, truncated at limit boundary, and pre-split measurement

## Root cause
`_handle_search` built the payload from `results` (post-split) without a `truncated` field. Agents got `count: 117` with no signal that results were capped at the default limit=100.

## Test plan
- [ ] `TestAstCacheSearchTruncated::test_search_not_truncated_when_below_limit`
- [ ] `TestAstCacheSearchTruncated::test_search_truncated_when_results_equal_limit`
- [ ] `TestAstCacheSearchTruncated::test_search_truncated_measured_before_split_expansion`
- [ ] Full `tests/unit/test_ast_cache_tool.py` suite green (35 tests)

Closes #737 (partially — `--symbol-search` CLI path was fixed by PR #911)