### PR TITLE
fix(call-path): use callee definition file in hops, not call-site file (#735)

### DIFF
--- a/tests/unit/test_call_path.py
+++ b/tests/unit/test_call_path.py
@@ -408,3 +408,78 @@ class TestCallPathFinderCLI:
             assert False, "Should have raised"
         except ValueError as e:
             assert "target_function" in str(e)
+
+
+class TestCallPathHopCalleFile:
+    """#735: hop callee_file must be the DEFINITION file, not the call-site file."""
+
+    def test_hop_callee_file_is_definition_file_not_caller_file(self, tmp_path):
+        """When callee_resolved_file is set, callee_file in the hop must use it."""
+        edges = [
+            {
+                "caller_name": "index_project",
+                "caller_file": "ast_cache.py",
+                "callee_name": "_commit_index_results",
+                "callee_resolved_file": "_ast_cache_helpers.py",
+            }
+        ]
+        cache = _make_cache_with_edges(tmp_path, edges)
+        finder = CallPathFinder(str(tmp_path), cache=cache)
+        result = finder.find_path(
+            "index_project",
+            "_commit_index_results",
+            source_file="ast_cache.py",
+            direction="forward",
+        )
+        assert len(result.paths) == 1
+        hop = result.paths[0].hops[0]
+        # callee_file must be the definition file, not the call-site file
+        assert hop["callee_file"] == "_ast_cache_helpers.py"
+        assert hop["caller_file"] == "ast_cache.py"
+
+    def test_hop_callee_file_empty_when_resolution_unknown(self, tmp_path):
+        """When callee_resolved_file is empty, callee_file must be '' not the caller's file."""
+        edges = [
+            {
+                "caller_name": "caller_fn",
+                "caller_file": "caller.py",
+                "callee_name": "unknown_callee",
+                "callee_resolved_file": "",  # resolution failed
+            }
+        ]
+        cache = _make_cache_with_edges(tmp_path, edges)
+        finder = CallPathFinder(str(tmp_path), cache=cache)
+        result = finder.find_path(
+            "caller_fn",
+            "unknown_callee",
+            source_file="caller.py",
+            direction="forward",
+        )
+        assert len(result.paths) == 1
+        hop = result.paths[0].hops[0]
+        # When resolution is unknown, callee_file must be '' not 'caller.py'
+        assert hop["callee_file"] == ""
+        assert hop["caller_file"] == "caller.py"
+
+    def test_bidirectional_hop_callee_file_is_definition_file(self, tmp_path):
+        """Same fix must apply in the bidirectional BFS path."""
+        edges = [
+            {
+                "caller_name": "entry",
+                "caller_file": "main.py",
+                "callee_name": "helper",
+                "callee_resolved_file": "lib.py",
+            }
+        ]
+        cache = _make_cache_with_edges(tmp_path, edges)
+        finder = CallPathFinder(str(tmp_path), cache=cache)
+        result = finder.find_path(
+            "entry",
+            "helper",
+            source_file="main.py",
+            direction="bidirectional",
+        )
+        assert len(result.paths) == 1
+        hop = result.paths[0].hops[0]
+        assert hop["callee_file"] == "lib.py"
+        assert hop["caller_file"] == "main.py"

--- a/tree_sitter_analyzer/call_path.py
+++ b/tree_sitter_analyzer/call_path.py
@@ -59,15 +59,23 @@ _BACKWARD_EDGE_SELECT = (
 
 def _fwd_state(row: dict[str, Any]) -> tuple[str, str | None]:
     """Extract the next (name, file) state from a forward-edge row."""
-    callee_file = row.get("callee_resolved_file") or row.get("file_path", "")
-    return (row["callee_name"], callee_file or None)
+    # #735: callee_resolved_file is the definition file; file_path is the
+    # CALLER's file (call-site).  When resolution is unknown, use None so
+    # _query_forward_edges falls back to a name-only query (PR #912) rather
+    # than searching for outgoing edges under the wrong (caller) file.
+    callee_file = row.get("callee_resolved_file") or None
+    return (row["callee_name"], callee_file)
 
 
 def _fwd_hop(
     current_name: str, current_file: str | None, row: dict[str, Any]
 ) -> dict[str, Any]:
     """Build a hop dict for a forward (callee direction) step."""
-    callee_file = row.get("callee_resolved_file") or row.get("file_path", "")
+    # #735: callee_file must be the DEFINITION file, not the call-site file.
+    # file_path in the row is the caller's file; callee_resolved_file is what
+    # we want.  Fall back to empty string (unknown) rather than the caller's
+    # file, which would be misleading.
+    callee_file = row.get("callee_resolved_file") or ""
     return {
         "caller": current_name,
         "caller_file": current_file or "",
@@ -91,11 +99,15 @@ def _bwd_hop(
     current_name: str, current_file: str | None, row: dict[str, Any]
 ) -> dict[str, Any]:
     """Build a hop dict for a backward (caller direction) step."""
+    # #735: callee_resolved_file in a backward edge row IS the definition file
+    # of current_name (the callee we're looking up callers for). Use it when
+    # target_file was not provided (current_file is None/empty).
+    callee_def_file = row.get("callee_resolved_file") or current_file or ""
     return {
         "caller": row["caller_name"],
         "caller_file": row.get("caller_file", ""),
         "callee": current_name,
-        "callee_file": current_file or "",
+        "callee_file": callee_def_file,
         "line": row.get("caller_line", 0),
     }
 
@@ -516,9 +528,8 @@ class CallPathFinder:
                 rows = self._query_forward_edges(conn, current_name, current_file)
                 for row in rows:
                     callee_name = row["callee_name"]
-                    callee_file = row.get("callee_resolved_file") or row.get(
-                        "file_path", ""
-                    )
+                    # #735: definition file, not call-site file.
+                    callee_file = row.get("callee_resolved_file") or ""
                     state = (callee_name, callee_file or None)
                     hop = {
                         "caller": current_name,
@@ -546,11 +557,16 @@ class CallPathFinder:
                     caller_name = row["caller_name"]
                     caller_file = row["caller_file"]
                     state = (caller_name, caller_file or None)
+                    # #735: callee_resolved_file is the definition file of
+                    # current_name; use it when target_file was not provided.
+                    callee_def_file = (
+                        row.get("callee_resolved_file") or current_file or ""
+                    )
                     hop = {
                         "caller": caller_name,
                         "caller_file": caller_file,
                         "callee": current_name,
-                        "callee_file": current_file or "",
+                        "callee_file": callee_def_file,
                         "line": row.get("caller_line", 0),
                     }
                     parent_path = backward_visited.get((current_name, current_file), [])


### PR DESCRIPTION
## Summary
- `_fwd_hop`, `_fwd_state`, `_bwd_hop`, and the inline bidirectional BFS hop builder all fell back to `file_path` (the *caller's* file, i.e. the call-site) when `callee_resolved_file` was absent
- `callee_resolved_file` is the callee's *definition* file — using the caller's file as a fallback produced hops where `callee_file` pointed to the wrong file
- Fix: forward direction falls back to `""` / `None` (unknown); backward direction recovers definition file from `callee_resolved_file` in the row (available in `_BACKWARD_EDGE_SELECT`)

## Root cause
```
# BEFORE (wrong):
callee_file = row.get("callee_resolved_file") or row.get("file_path", "")
# file_path is the CALLER's file in the edges table
```
```
# AFTER (correct):
callee_file = row.get("callee_resolved_file") or ""  # unknown → empty
```

## Test plan
- [ ] `TestCallPathHopCalleFile::test_hop_callee_file_is_definition_file_not_caller_file`
- [ ] `TestCallPathHopCalleFile::test_hop_callee_file_empty_when_resolution_unknown`
- [ ] `TestCallPathHopCalleFile::test_bidirectional_hop_callee_file_is_definition_file`
- [ ] Full `tests/unit/test_call_path.py` suite (28 tests) green

Closes #735