### PR TITLE
fix(class-hierarchy): add agent_summary to all mode responses (#733)

### DIFF
--- a/tests/unit/test_codegraph_class_hierarchy_tool.py
+++ b/tests/unit/test_codegraph_class_hierarchy_tool.py
@@ -504,3 +504,126 @@ class TestSameNameDifferentBaseCollision:
         assert [(s["file"]) for s in base_subs] == ["a.py"]
         other_subs = h.subclasses_of("Other")
         assert [(s["file"]) for s in other_subs] == ["b.py"]
+
+
+@pytest.mark.asyncio
+class TestAgentSummaryPresence:
+    """#733: class_hierarchy must include agent_summary in every mode's response."""
+
+    @pytest.fixture
+    def tool_with_monkeypatched_hierarchy(self, tool, monkeypatch):
+        from tree_sitter_analyzer.class_hierarchy import ClassHierarchy
+
+        h = ClassHierarchy.__new__(ClassHierarchy)
+        h._class_map = {
+            "Animal": type(
+                "CI",
+                (),
+                {
+                    "name": "Animal",
+                    "file": "a.py",
+                    "line": 1,
+                    "end_line": 5,
+                    "parents": [],
+                    "language": "python",
+                },
+            )(),
+            "Dog": type(
+                "CI",
+                (),
+                {
+                    "name": "Dog",
+                    "file": "b.py",
+                    "line": 1,
+                    "end_line": 5,
+                    "parents": ["Animal"],
+                    "language": "python",
+                },
+            )(),
+        }
+        h._built = True
+        h.build = lambda: None
+
+        def _has_class(name):
+            return name in h._class_map
+
+        def _subclasses_of(name, max_depth=10):
+            return (
+                [
+                    {"name": "Dog", "file": "b.py", "line": 1}
+                    for n in h._class_map
+                    if name == "Animal"
+                ]
+                if name == "Animal"
+                else []
+            )
+
+        def _superclasses_of(name):
+            return (
+                [{"name": "Animal", "file": "a.py", "line": 1}] if name == "Dog" else []
+            )
+
+        def _hierarchy_tree(name):
+            return {"name": name, "children": []}
+
+        def _all_classes(self=None):
+            return ["Animal", "Dog"]
+
+        def _summary(self=None):
+            return {"total_classes": 2, "total_relationships": 1}
+
+        h.has_class = _has_class
+        h.subclasses_of = _subclasses_of
+        h.superclasses_of = _superclasses_of
+        h.hierarchy_tree = _hierarchy_tree
+        h.all_classes = _all_classes
+        h.summary = _summary
+        monkeypatch.setattr(tool, "_hierarchy", h)
+        monkeypatch.setattr(tool, "_get_hierarchy", lambda: h)
+        return tool
+
+    async def test_subclasses_has_agent_summary(
+        self, tool_with_monkeypatched_hierarchy
+    ):
+        result = await tool_with_monkeypatched_hierarchy.execute(
+            {"mode": "subclasses", "class_name": "Animal", "output_format": "json"}
+        )
+        assert "agent_summary" in result
+        assert "summary_line" in result["agent_summary"]
+        assert "next_step" in result["agent_summary"]
+        assert "verdict" in result["agent_summary"]
+
+    async def test_superclasses_has_agent_summary(
+        self, tool_with_monkeypatched_hierarchy
+    ):
+        result = await tool_with_monkeypatched_hierarchy.execute(
+            {"mode": "superclasses", "class_name": "Dog", "output_format": "json"}
+        )
+        assert "agent_summary" in result
+
+    async def test_tree_has_agent_summary(self, tool_with_monkeypatched_hierarchy):
+        result = await tool_with_monkeypatched_hierarchy.execute(
+            {"mode": "tree", "class_name": "Animal", "output_format": "json"}
+        )
+        assert "agent_summary" in result
+
+    async def test_all_has_agent_summary(self, tool_with_monkeypatched_hierarchy):
+        result = await tool_with_monkeypatched_hierarchy.execute(
+            {"mode": "all", "output_format": "json"}
+        )
+        assert "agent_summary" in result
+
+    async def test_summary_has_agent_summary(self, tool_with_monkeypatched_hierarchy):
+        result = await tool_with_monkeypatched_hierarchy.execute(
+            {"mode": "summary", "output_format": "json"}
+        )
+        assert "agent_summary" in result
+
+    async def test_unknown_mode_has_agent_summary(
+        self, tool_with_monkeypatched_hierarchy
+    ):
+        result = await tool_with_monkeypatched_hierarchy.execute(
+            {"mode": "nonexistent_mode", "output_format": "json"}
+        )
+        assert "agent_summary" in result
+        assert result["agent_summary"]["verdict"] == "ERROR"

--- a/tree_sitter_analyzer/mcp/tools/class_hierarchy_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/class_hierarchy_tool.py
@@ -18,7 +18,7 @@ from typing import Any
 from ...ast_cache import ASTCache
 from ...class_hierarchy import ClassHierarchy
 from ...utils import setup_logger
-from .base_tool import BaseMCPTool
+from .base_tool import BaseMCPTool, mirror_summary_line
 from .index_rebuild_signal import (
     is_index_rebuilding,
     rebuild_in_progress_next_step,
@@ -202,6 +202,19 @@ class ClassHierarchyTool(BaseMCPTool):
         result: Any
         if mode == "subclasses":
             result = hierarchy.subclasses_of(class_name, max_depth=max_depth)
+            verdict = (
+                "INFO" if result or hierarchy.has_class(class_name) else "NOT_FOUND"
+            )
+            summary_line = (
+                f"class_hierarchy subclasses={len(result)} class={class_name}"
+            )
+            next_step = (
+                f"Found {len(result)} subclass(es) of {class_name}"
+                if result
+                else f"{class_name} has no subclasses"
+                if hierarchy.has_class(class_name)
+                else f"{class_name} not found — check class name with class_hierarchy mode=all"
+            )
             response: dict[str, Any] = {
                 "success": True,
                 "mode": "subclasses",
@@ -211,12 +224,29 @@ class ClassHierarchyTool(BaseMCPTool):
                 # Wave 1b (audit structure-01): NOT_FOUND means the class is
                 # unknown — an existing class with zero subclasses is a valid
                 # INFO result, not a missing one.
-                "verdict": (
-                    "INFO" if result or hierarchy.has_class(class_name) else "NOT_FOUND"
-                ),
+                "verdict": verdict,
+                "summary_line": summary_line,
+                "agent_summary": {
+                    "summary_line": summary_line,
+                    "next_step": next_step,
+                    "verdict": verdict,
+                },
             }
         elif mode == "superclasses":
             result = hierarchy.superclasses_of(class_name)
+            verdict = (
+                "INFO" if result or hierarchy.has_class(class_name) else "NOT_FOUND"
+            )
+            summary_line = (
+                f"class_hierarchy superclasses={len(result)} class={class_name}"
+            )
+            next_step = (
+                f"Found {len(result)} superclass(es) of {class_name}"
+                if result
+                else f"{class_name} is a root class (no parents)"
+                if hierarchy.has_class(class_name)
+                else f"{class_name} not found — check class name with class_hierarchy mode=all"
+            )
             response = {
                 "success": True,
                 "mode": "superclasses",
@@ -225,13 +255,26 @@ class ClassHierarchyTool(BaseMCPTool):
                 "superclasses": result,
                 # Wave 1b: same existence-vs-emptiness distinction — a root
                 # class with no parents exists and is INFO, not NOT_FOUND.
-                "verdict": (
-                    "INFO" if result or hierarchy.has_class(class_name) else "NOT_FOUND"
-                ),
+                "verdict": verdict,
+                "summary_line": summary_line,
+                "agent_summary": {
+                    "summary_line": summary_line,
+                    "next_step": next_step,
+                    "verdict": verdict,
+                },
             }
         elif mode == "tree":
             result = hierarchy.hierarchy_tree(class_name)
             all_subs = hierarchy.subclasses_of(class_name, max_depth=max_depth)
+            verdict = "INFO" if hierarchy.has_class(class_name) else "NOT_FOUND"
+            summary_line = (
+                f"class_hierarchy tree subclasses={len(all_subs)} class={class_name}"
+            )
+            next_step = (
+                f"Hierarchy tree for {class_name} with {len(all_subs)} subclass(es)"
+                if hierarchy.has_class(class_name)
+                else f"{class_name} not found — check class name with class_hierarchy mode=all"
+            )
             response = {
                 "success": True,
                 "mode": "tree",
@@ -243,47 +286,91 @@ class ClassHierarchyTool(BaseMCPTool):
                 # class (e.g. a concrete final class) must not read as
                 # NOT_FOUND just because nothing inherits from it. ``tree`` is
                 # the default mode for a named class, so this is the common path.
-                "verdict": "INFO" if hierarchy.has_class(class_name) else "NOT_FOUND",
+                "verdict": verdict,
+                "summary_line": summary_line,
+                "agent_summary": {
+                    "summary_line": summary_line,
+                    "next_step": next_step,
+                    "verdict": verdict,
+                },
             }
         elif mode == "impact":
             impact = hierarchy.hierarchy_impact(class_name)
+            verdict = (
+                "CAUTION"
+                if impact.risk_level in ("high", "critical")
+                else "REVIEW"
+                if impact.risk_level == "medium"
+                else "INFO"
+            )
+            summary_line = (
+                f"class_hierarchy impact risk={impact.risk_level} class={class_name}"
+            )
+            next_step = f"Impact analysis for {class_name}: risk={impact.risk_level}"
             response = {
                 "success": True,
                 "mode": "impact",
-                "verdict": (
-                    "CAUTION"
-                    if impact.risk_level in ("high", "critical")
-                    else "REVIEW"
-                    if impact.risk_level == "medium"
-                    else "INFO"
-                ),
+                "verdict": verdict,
+                "summary_line": summary_line,
+                "agent_summary": {
+                    "summary_line": summary_line,
+                    "next_step": next_step,
+                    "verdict": verdict,
+                },
                 **impact.to_dict(),
             }
         elif mode == "all":
             classes = hierarchy.all_classes()
+            summary_line = f"class_hierarchy all classes={len(classes)}"
+            next_step = f"Found {len(classes)} class(es) in the hierarchy"
             response = {
                 "success": True,
                 "mode": "all",
                 "class_count": len(classes),
                 "classes": classes,
                 "verdict": "INFO",
+                "summary_line": summary_line,
+                "agent_summary": {
+                    "summary_line": summary_line,
+                    "next_step": next_step,
+                    "verdict": "INFO",
+                },
             }
         elif mode == "summary":
+            hier_summary = hierarchy.summary()
+            total = hier_summary.get("total_classes", 0)
+            summary_line = f"class_hierarchy summary total_classes={total}"
+            next_step = f"Hierarchy has {total} class(es)"
             response = {
                 "success": True,
                 "mode": "summary",
                 "verdict": "INFO",
-                **hierarchy.summary(),
+                "summary_line": summary_line,
+                "agent_summary": {
+                    "summary_line": summary_line,
+                    "next_step": next_step,
+                    "verdict": "INFO",
+                },
+                **hier_summary,
             }
         else:
             valid = ", ".join(self._VALID_MODES)
+            summary_line = f"class_hierarchy unknown mode={mode!r}"
             response = {
                 "success": False,
                 "error": f"Unknown mode: '{mode}'. Valid modes: {valid}",
                 "error_type": "validation",
                 "verdict": "ERROR",
+                "summary_line": summary_line,
+                "agent_summary": {
+                    "summary_line": summary_line,
+                    "next_step": f"Use one of: {valid}",
+                    "verdict": "ERROR",
+                },
             }
 
         from ..utils.format_helper import apply_toon_format_to_response
 
-        return apply_toon_format_to_response(response, output_format)
+        return mirror_summary_line(
+            apply_toon_format_to_response(response, output_format)
+        )


### PR DESCRIPTION
## Summary
- `class_hierarchy` tool was missing `agent_summary` (and `summary_line`) in all 6 normal-operation mode responses
- The `rebuild_in_progress` path already had it — this fixes the remaining gap after PR #577
- All modes now return `{summary_line, agent_summary:{summary_line,next_step,verdict}}` consistent with sibling tools
- `mirror_summary_line()` added so TOON output also gets the top-level `summary_line` field

## Modes covered
`subclasses`, `superclasses`, `tree`, `impact`, `all`, `summary`, unknown-mode error path

## Test plan
- [ ] `TestAgentSummaryPresence` (6 tests) — one per mode including error path
- [ ] Full `tests/unit/test_codegraph_class_hierarchy_tool.py` (34 tests) green

Closes #733