### PR TITLE
fix(ast-cache): cap linear-fallback results at limit so truncated flag is reliable

### DIFF
--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -585,7 +585,9 @@ class ASTCache:
         limit: int = 100,
     ) -> list[dict[str, Any]]:
         if not self._fts5_available:
-            return self._search_symbols_linear(query, language)
+            # Linear fallback has no SQL LIMIT — cap here so truncation
+            # detection in callers (len >= limit) is reliable.
+            return self._search_symbols_linear(query, language)[:limit]
         return _fts_search(self._get_conn(), query, language, limit)
 
     def fts_search_ranked(
@@ -600,7 +602,7 @@ class ASTCache:
         Results include a ``relevance_score`` field in [0.0, 1.0].
         """
         if not self._fts5_available or len(query) < 2:
-            return self._search_symbols_linear(query, language)
+            return self._search_symbols_linear(query, language)[:limit]
         return _fts_search_ranked(self._get_conn(), query, language, limit)
 
     def _search_symbols_linear(


### PR DESCRIPTION
## Summary

- Cap `_search_symbols_linear` results at `limit` in both `fts_search` and `fts_search_ranked` fallback paths
- Without this, callers computing `truncated = len(raw_results) >= limit` could get a false `True` when the linear scan returns more than `limit` items but nothing was actually capped

## Motivation

Codex P2 finding on PR #914: the `truncated` field added in #914 uses `len(raw_results) >= limit` to detect truncation. The FTS5 path always caps at `limit` via `SQL LIMIT ?`, so the check is correct there. But the linear fallback (`_search_symbols_linear`) returns all matches without any SQL limit. Any search that happens to match ≥ `limit` symbols would report `truncated: true` misleadingly.

The fix is minimal: apply `[:limit]` in both fallback branches so both paths consistently honour the limit.

## Test plan

- [ ] `uv run pytest tests/unit/test_ast_cache_tool.py` — all 35 tests pass
- [ ] Existing `TestAstCacheSearchTruncated` (added in #914) already covers truncated=True/False semantics; the linear-fallback case now correctly caps before the flag is evaluated

🤖 Generated with [Claude Code](https://claude.com/claude-code)