### PR TITLE
fix(cli): --symbol-search "" now emits validation error instead of file-path fallback (#738)

### DIFF
--- a/tests/unit/cli/test_class_hierarchy_and_dep_matrix_cli.py
+++ b/tests/unit/cli/test_class_hierarchy_and_dep_matrix_cli.py
@@ -316,3 +316,31 @@ def test_dependency_matrix_file_cli(monkeypatch) -> None:
     assert result == 0
     assert seen["arguments"]["mode"] == "file"
     assert seen["arguments"]["file_path"] == "src/parser.py"
+
+
+def test_symbol_search_empty_string_returns_error_not_file_path_fallback() -> None:
+    """#738: --symbol-search "" must emit a clean validation error, not 'File path not specified'."""
+    errors: list[str] = []
+    result = mcp_commands.handle_mcp_commands(
+        _args(symbol_search=""),
+        lambda payload: None,
+        errors.append,
+        lambda: "json",
+    )
+    assert result == 1
+    assert len(errors) == 1
+    assert "symbol" in errors[0].lower() or "query" in errors[0].lower()
+    assert "file" not in errors[0].lower()
+
+
+def test_symbol_search_whitespace_only_returns_error() -> None:
+    """#738: --symbol-search '   ' is treated the same as empty."""
+    errors: list[str] = []
+    result = mcp_commands.handle_mcp_commands(
+        _args(symbol_search="   "),
+        lambda payload: None,
+        errors.append,
+        lambda: "json",
+    )
+    assert result == 1
+    assert len(errors) == 1

--- a/tree_sitter_analyzer/cli/commands/mcp_commands/_specs_core.py
+++ b/tree_sitter_analyzer/cli/commands/mcp_commands/_specs_core.py
@@ -257,6 +257,12 @@ _CORE_SPECS: tuple[McpCommandSpec, ...] = (
         flag_name="symbol_search",
         tool_attr="CodeGraphSymbolSearchTool",
         label="FTS5-powered instant symbol search (CodeGraph parity)",
+        # #738: value_arg_name is required so find_selected_mcp_command() uses
+        # the non-empty string check instead of truthiness — empty string ""
+        # is falsy and would cause the spec to be skipped entirely, routing
+        # the call to the file-path fallback with a misleading error.
+        value_arg_name="symbol_search",
+        required_value_error="--symbol-search requires a non-empty query string",
         build_tool_args=lambda args, output_format: {
             # Pain #21 (dogfood pass 3): same dest-name bug as #17. --symbol-search QUERY
             # stores into args.symbol_search; reading symbol_search_query was always None


### PR DESCRIPTION
## Summary

- Add `value_arg_name="symbol_search"` and `required_value_error` to the `symbol_search` McpCommandSpec in `_specs_core.py`
- Without this, `--symbol-search ""` fell through to the file-path fallback, emitting "File path not specified" — an unrelated and confusing error

## Root cause

`find_selected_mcp_command()` checks `if value:` for boolean specs. An empty string `""` is falsy, so the `symbol_search` spec was never selected when the user passed an empty query. The dispatcher then hit the file-path validation check.

The M12 mechanism (`value_arg_name`) already existed for exactly this pattern (see `symbol_lineage` spec). Adding it to `symbol_search` routes the empty-string case into `validate_mcp_command_args`, which emits the canonical `required_value_error`.

## Test plan

- [ ] `uv run pytest tests/unit/cli/test_class_hierarchy_and_dep_matrix_cli.py` — 11 tests pass (includes 2 new regression tests)
- [ ] `test_symbol_search_empty_string_returns_error_not_file_path_fallback` — verifies the error message is about the query, not a file path
- [ ] `test_symbol_search_whitespace_only_returns_error` — verifies whitespace-only is treated the same as empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)