### PR TITLE
fix(symbol-search): use FTS5 prefix matching in fuzzy search so ~Prefix finds CamelCase (#739)

### DIFF
--- a/tests/unit/test_symbol_search_tool.py
+++ b/tests/unit/test_symbol_search_tool.py
@@ -92,7 +92,10 @@ class TestCodeGraphSymbolSearchExecution:
         tool = CodeGraphSymbolSearchTool(str(indexed_project))
         result = await tool.execute({"query": "~user", "output_format": "json"})
         assert result["success"] is True
-        assert result["match_count"] == 3
+        # Fixture has UserService, get_user, _find_user, format_user = 4 symbols
+        # containing "user". After #739 fix (prefix matching), UserService is
+        # now found via user* prefix on the token "userservice".
+        assert result["match_count"] == 4
 
     async def test_wildcard_match(self, indexed_project):
         tool = CodeGraphSymbolSearchTool(str(indexed_project))
@@ -210,6 +213,16 @@ class TestCodeGraphSymbolSearchExecution:
             )
             score = hit["relevance_score"]
             assert 0.0 <= score <= 1.0, f"score out of range: {score}"
+
+    async def test_fuzzy_prefix_finds_camelcase_class(self, indexed_project):
+        """#739: ~User must match UserService via FTS5 prefix (user*), not exact-token."""
+        tool = CodeGraphSymbolSearchTool(str(indexed_project))
+        result = await tool.execute({"query": "~User", "output_format": "json"})
+        assert result["success"] is True
+        names = [r["name"] for r in result["results"]]
+        assert "UserService" in names, (
+            f"~User must find UserService via prefix match; got {names}"
+        )
 
     async def test_plain_query_cascade_fuzzy_finds_typo(self, indexed_project):
         tool = CodeGraphSymbolSearchTool(str(indexed_project))

--- a/tests/unit/test_symbol_search_tool.py
+++ b/tests/unit/test_symbol_search_tool.py
@@ -224,6 +224,19 @@ class TestCodeGraphSymbolSearchExecution:
             f"~User must find UserService via prefix match; got {names}"
         )
 
+    async def test_fuzzy_special_chars_do_not_crash(self, indexed_project):
+        """Codex P2 / #739: ~foo-bar must not raise sqlite3.OperationalError.
+
+        Plain term* drops quoting, so FTS5 special chars (-, ., :) in the query
+        cause a syntax error.  Quoted-prefix ("term"*) is always safe.
+        """
+        tool = CodeGraphSymbolSearchTool(str(indexed_project))
+        for bad_query in ["~foo-bar", "~foo.bar", "~foo:bar"]:
+            result = await tool.execute({"query": bad_query, "output_format": "json"})
+            assert result["success"] is True, (
+                f"Query {bad_query!r} must not crash; got {result}"
+            )
+
     async def test_plain_query_cascade_fuzzy_finds_typo(self, indexed_project):
         tool = CodeGraphSymbolSearchTool(str(indexed_project))
         result = await tool.execute(

--- a/tree_sitter_analyzer/mcp/tools/symbol_search_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/symbol_search_tool.py
@@ -264,10 +264,10 @@ class CodeGraphSymbolSearchTool(BaseMCPTool):
         if cache.fts5_available:
             terms = substring.split()
             if terms:
-                # Use prefix matching (term*) so "SecurityVal" matches
-                # "SecurityValidator" — FTS5 exact-token "term" only matches
-                # the whole stored token and misses partial prefixes (#739).
-                fts_query = " OR ".join(f"{t}*" for t in terms)
+                # Use quoted-prefix matching ("term"*) so "SecurityVal" matches
+                # "SecurityValidator" — plain term* drops quoting and crashes on
+                # inputs with FTS5 special chars (-, ., :); "term"* is safe (#739).
+                fts_query = " OR ".join(f'"{t.lower()}"*' for t in terms)
 
                 conn = cache.get_conn()
                 # Weighted BM25 (name col 10x) — hardcoded constant, no injection risk.

--- a/tree_sitter_analyzer/mcp/tools/symbol_search_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/symbol_search_tool.py
@@ -264,7 +264,10 @@ class CodeGraphSymbolSearchTool(BaseMCPTool):
         if cache.fts5_available:
             terms = substring.split()
             if terms:
-                fts_query = " OR ".join(f'"{t}"' for t in terms)
+                # Use prefix matching (term*) so "SecurityVal" matches
+                # "SecurityValidator" — FTS5 exact-token "term" only matches
+                # the whole stored token and misses partial prefixes (#739).
+                fts_query = " OR ".join(f"{t}*" for t in terms)
 
                 conn = cache.get_conn()
                 # Weighted BM25 (name col 10x) — hardcoded constant, no injection risk.


### PR DESCRIPTION
## Summary

- `_fuzzy_search` was building FTS5 queries with exact-token syntax (`"term"`) which can only match a stored token verbatim. `UserService` is tokenized as the single FTS5 token `userservice`, so querying `"User"` never matched it.
- Changed to prefix syntax (`term*`): `user*` matches `userservice` since it starts with `user`. The existing post-filter `sub_lower in row["name"].lower()` continues to guard false-positives from the wider prefix scan.

## Changes

- `symbol_search_tool.py`: line 267 — `f'"{t}"'` → `f'{t}*'` 
- `test_symbol_search_tool.py`: add `test_fuzzy_prefix_finds_camelcase_class`; re-pin `test_fuzzy_match` count 3→4 (UserService now correctly returned)

## What's not fixed (filed as #919)

`~Service` finding `UserService` (suffix, not prefix) — `_linear_search` falls through to `cache.search_symbols()` which also uses FTS5 and hits the same limitation for non-prefix substrings.

## Test plan

- [x] `test_fuzzy_prefix_finds_camelcase_class` — `~User` finds `UserService`
- [x] All 41 `test_symbol_search_tool.py` tests pass
- [ ] CI green across all platforms