### PR TITLE
fix(sync): delete partial ast_index row on per-file failure so next sync re-indexes (#886)

### DIFF
--- a/tests/unit/test_incremental_sync.py
+++ b/tests/unit/test_incremental_sync.py
@@ -371,7 +371,7 @@ class TestSavepointRollbackOnPartialWrite:
         with patch.object(cache, "_write_imports_for_file", side_effect=_fail_once):
             first_result = sync.sync()
 
-        assert first_result.errors >= 1
+        assert first_result.errors == 1
 
         # Second sync must index fragile.py as NEW (not see it as unchanged).
         second_result = sync.sync()

--- a/tests/unit/test_incremental_sync.py
+++ b/tests/unit/test_incremental_sync.py
@@ -312,3 +312,72 @@ class TestAnyExceptionDoesNotAbortSync:
         assert len(error_details) == 1
         assert "unreadable" in error_details[0]["file"]
         assert error_details[0].get("error_type") == "OSError"
+
+
+class TestSavepointRollbackOnPartialWrite:
+    """Issue #886: savepoint must roll back partial ast_index writes on mid-write failure.
+
+    Scenario: index_file inserts into ast_index then raises before conn.commit().
+    Without a savepoint, the outer sync's final commit picks up the partial row —
+    the file then appears as "unchanged" on the next sync, hiding missing symbols.
+    """
+
+    def test_partial_write_rolled_back_so_next_sync_treats_file_as_new(
+        self, project, cache
+    ):
+        src = project / "src"
+        (src / "flaky.py").write_text("def boom(): pass\n")
+
+        original_write_imports = cache._write_imports_for_file
+
+        def _fail_after_ast_index(conn, rel_path, language, imports):
+            if "flaky.py" in rel_path:
+                # Simulate failure AFTER ast_index INSERT but BEFORE conn.commit().
+                raise RuntimeError("simulated mid-write failure")
+            return original_write_imports(conn, rel_path, language, imports)
+
+        sync = IncrementalSync(cache)
+        with patch.object(
+            cache, "_write_imports_for_file", side_effect=_fail_after_ast_index
+        ):
+            result = sync.sync()
+
+        assert result.errors == 1
+
+        # #886: savepoint must have rolled back the partial ast_index row so
+        # the file does NOT silently appear unchanged on the next sync.
+        conn = cache.get_conn()
+        row = conn.execute(
+            "SELECT file_path FROM ast_index WHERE file_path LIKE '%flaky.py'",
+        ).fetchone()
+        assert row is None, (
+            "ast_index must have no row for flaky.py after a mid-write rollback"
+        )
+
+    def test_second_sync_reindexes_file_after_savepoint_rollback(self, project, cache):
+        src = project / "src"
+        (src / "fragile.py").write_text("def ok(): pass\n")
+
+        original_write_imports = cache._write_imports_for_file
+        call_count = {"n": 0}
+
+        def _fail_once(conn, rel_path, language, imports):
+            if "fragile.py" in rel_path and call_count["n"] == 0:
+                call_count["n"] += 1
+                raise RuntimeError("first attempt fails")
+            return original_write_imports(conn, rel_path, language, imports)
+
+        sync = IncrementalSync(cache)
+        with patch.object(cache, "_write_imports_for_file", side_effect=_fail_once):
+            first_result = sync.sync()
+
+        assert first_result.errors >= 1
+
+        # Second sync must index fragile.py as NEW (not see it as unchanged).
+        second_result = sync.sync()
+        new_file_names = [
+            d["file"] for d in second_result.details if d.get("considered") == "indexed"
+        ]
+        assert any("fragile.py" in f for f in new_file_names), (
+            f"fragile.py must be re-indexed as new on second sync; got {new_file_names}"
+        )

--- a/tree_sitter_analyzer/incremental_sync.py
+++ b/tree_sitter_analyzer/incremental_sync.py
@@ -240,11 +240,21 @@ class IncrementalSync:
         try:
             index_result = self._cache.index_file(abs_path)
         except Exception as exc:
-            # #886: if index_file wrote a partial ast_index row before raising
-            # (INSERT committed or uncommitted), DELETE it so the next sync
-            # treats the file as new rather than silently skipping it as
-            # "unchanged" with missing symbols/edges.
-            conn.execute("DELETE FROM ast_index WHERE file_path = ?", (rel_path,))
+            # #886: if index_file wrote partial rows before raising, clean them
+            # all up (ast_index + ast_symbol_rows + ast_symbols_fts) so the next
+            # sync treats the file as new rather than silently "unchanged" with
+            # missing symbols. Codex P2: wrap best-effort cleanup so a locked/
+            # full DB doesn't abort the whole sync — we already have the error.
+            try:
+                conn.execute("DELETE FROM ast_index WHERE file_path = ?", (rel_path,))
+                conn.execute(
+                    "DELETE FROM ast_symbol_rows WHERE file_path = ?", (rel_path,)
+                )
+                conn.execute(
+                    "DELETE FROM ast_symbols_fts WHERE file_path = ?", (rel_path,)
+                )
+            except Exception:
+                logger.debug("Cleanup DELETE failed for %s — continuing", rel_path)
             # Issue #806/#805: catch all per-file errors so one pathological
             # file cannot abort the whole sync and discard accumulated results.
             logger.error(
@@ -279,8 +289,17 @@ class IncrementalSync:
         try:
             index_result = self._cache.index_file(abs_path)
         except Exception as exc:
-            # #886: same DELETE-on-failure guard as _index_new_file.
-            conn.execute("DELETE FROM ast_index WHERE file_path = ?", (rel_path,))
+            # #886: same three-table cleanup as _index_new_file (Codex P2 parity).
+            try:
+                conn.execute("DELETE FROM ast_index WHERE file_path = ?", (rel_path,))
+                conn.execute(
+                    "DELETE FROM ast_symbol_rows WHERE file_path = ?", (rel_path,)
+                )
+                conn.execute(
+                    "DELETE FROM ast_symbols_fts WHERE file_path = ?", (rel_path,)
+                )
+            except Exception:
+                logger.debug("Cleanup DELETE failed for %s — continuing", rel_path)
             # Issue #806/#805: same broad guard for re-index path.
             logger.error(
                 "Error re-indexing %s (%s): %s",

--- a/tree_sitter_analyzer/incremental_sync.py
+++ b/tree_sitter_analyzer/incremental_sync.py
@@ -240,6 +240,11 @@ class IncrementalSync:
         try:
             index_result = self._cache.index_file(abs_path)
         except Exception as exc:
+            # #886: if index_file wrote a partial ast_index row before raising
+            # (INSERT committed or uncommitted), DELETE it so the next sync
+            # treats the file as new rather than silently skipping it as
+            # "unchanged" with missing symbols/edges.
+            conn.execute("DELETE FROM ast_index WHERE file_path = ?", (rel_path,))
             # Issue #806/#805: catch all per-file errors so one pathological
             # file cannot abort the whole sync and discard accumulated results.
             logger.error(
@@ -274,6 +279,8 @@ class IncrementalSync:
         try:
             index_result = self._cache.index_file(abs_path)
         except Exception as exc:
+            # #886: same DELETE-on-failure guard as _index_new_file.
+            conn.execute("DELETE FROM ast_index WHERE file_path = ?", (rel_path,))
             # Issue #806/#805: same broad guard for re-index path.
             logger.error(
                 "Error re-indexing %s (%s): %s",


### PR DESCRIPTION
## Summary

- When `index_file` raised after writing to `ast_index` but before `conn.commit()`, the outer sync's final commit persisted the partial row. On the next sync the file appeared unchanged, hiding missing symbols/edges indefinitely.
- Fix: `DELETE FROM ast_index WHERE file_path = ?` in both `_index_new_file` and `_reindex_modified` exception handlers. Works regardless of whether the row was already committed or still pending.

Note: a savepoint approach was attempted but fails because `index_file` calls `conn.commit()` internally, which destroys any caller-set savepoint.

## Changes

- `incremental_sync.py`: DELETE partial row in both per-file exception handlers
- `test_incremental_sync.py`: `TestSavepointRollbackOnPartialWrite` — 2 tests verifying rollback behavior and re-indexing on the next sync

## Test plan

- [x] `test_partial_write_rolled_back_so_next_sync_treats_file_as_new` — no `ast_index` row after failure
- [x] `test_second_sync_reindexes_file_after_savepoint_rollback` — file appears as new on retry
- [x] All 25 `test_incremental_sync.py` tests pass
- [ ] CI green across all platforms