### PR TITLE
feat(change-impact): surface doc-drift verification steps for CLI/MCP surface changes (#732)

### DIFF
--- a/tests/unit/mcp/test_change_impact_tool_execute_and_mapping.py
+++ b/tests/unit/mcp/test_change_impact_tool_execute_and_mapping.py
@@ -751,3 +751,70 @@ def test_validate_arguments_rejects_bad_scope_mode():
     tool = tool_module.ChangeImpactTool(project_root="/repo")
     with pytest.raises(ValueError, match=r"scope_mode must be report\|strict"):
         tool.validate_arguments({"scope_mode": "nonsense"})
+
+
+# ── Issue #732 — doc-drift hints ──────────────────────────────────────────────
+
+
+def test_doc_drift_hints_absent_for_unrelated_files():
+    """No doc_drift_checks when changed files don't touch CLI or MCP tools."""
+    from tree_sitter_analyzer.mcp.tools.utils.change_impact_analysis import (
+        _attach_doc_drift_hints,
+    )
+
+    result = _attach_doc_drift_hints({}, ["tree_sitter_analyzer/plugins/python.py"])
+    assert "doc_drift_checks" not in result
+
+
+def test_doc_drift_hints_cli_main_triggers_readme_count_check():
+    """Changing cli_main.py must append the README-count test to doc_drift_checks."""
+    from tree_sitter_analyzer.mcp.tools.utils.change_impact_analysis import (
+        _attach_doc_drift_hints,
+    )
+
+    result = _attach_doc_drift_hints({}, ["tree_sitter_analyzer/cli_main.py"])
+    assert "doc_drift_checks" in result
+    assert any(
+        "test_readme_counts_match_registry" in step
+        for step in result["doc_drift_checks"]
+    )
+
+
+def test_doc_drift_hints_tool_registry_triggers_readme_count_check():
+    """Changing _tool_registry.py must also append the README-count test."""
+    from tree_sitter_analyzer.mcp.tools.utils.change_impact_analysis import (
+        _attach_doc_drift_hints,
+    )
+
+    result = _attach_doc_drift_hints({}, ["tree_sitter_analyzer/mcp/_tool_registry.py"])
+    assert any(
+        "test_readme_counts_match_registry" in step
+        for step in result["doc_drift_checks"]
+    )
+
+
+def test_doc_drift_hints_facade_tool_triggers_doc_regen():
+    """Changing a facade tool must append the facade-actions.md regen step."""
+    from tree_sitter_analyzer.mcp.tools.utils.change_impact_analysis import (
+        _attach_doc_drift_hints,
+    )
+
+    result = _attach_doc_drift_hints(
+        {}, ["tree_sitter_analyzer/mcp/tools/symbol_search_tool.py"]
+    )
+    assert "doc_drift_checks" in result
+    assert any(
+        "generate_facade_actions_doc" in step for step in result["doc_drift_checks"]
+    )
+
+
+def test_doc_drift_hints_util_file_not_treated_as_facade_tool():
+    """Files under mcp/tools/utils/ must NOT trigger facade-actions regen."""
+    from tree_sitter_analyzer.mcp.tools.utils.change_impact_analysis import (
+        _attach_doc_drift_hints,
+    )
+
+    result = _attach_doc_drift_hints(
+        {}, ["tree_sitter_analyzer/mcp/tools/utils/change_impact_analysis.py"]
+    )
+    assert "doc_drift_checks" not in result

--- a/tests/unit/mcp/test_change_impact_tool_execute_and_mapping.py
+++ b/tests/unit/mcp/test_change_impact_tool_execute_and_mapping.py
@@ -818,3 +818,65 @@ def test_doc_drift_hints_util_file_not_treated_as_facade_tool():
         {}, ["tree_sitter_analyzer/mcp/tools/utils/change_impact_analysis.py"]
     )
     assert "doc_drift_checks" not in result
+
+
+def test_doc_drift_hints_argument_groups_file_triggers_readme_count_check():
+    """Adding a flag in cli/argument_groups/*.py must trigger README-count check (P2 #924)."""
+    from tree_sitter_analyzer.mcp.tools.utils.change_impact_analysis import (
+        _attach_doc_drift_hints,
+    )
+
+    result = _attach_doc_drift_hints(
+        {}, ["tree_sitter_analyzer/cli/argument_groups/_analysis.py"]
+    )
+    assert "doc_drift_checks" in result
+    assert any(
+        "test_readme_counts_match_registry" in step
+        for step in result["doc_drift_checks"]
+    )
+
+
+def test_doc_drift_hints_facade_map_triggers_facade_doc_regen():
+    """Changing facade_map.py must trigger facade-actions.md regen (P2 #924)."""
+    from tree_sitter_analyzer.mcp.tools.utils.change_impact_analysis import (
+        _attach_doc_drift_hints,
+    )
+
+    result = _attach_doc_drift_hints({}, ["tree_sitter_analyzer/mcp/facade_map.py"])
+    assert "doc_drift_checks" in result
+    assert any(
+        "generate_facade_actions_doc" in step for step in result["doc_drift_checks"]
+    )
+
+
+def test_doc_drift_hints_tool_registry_triggers_both_checks():
+    """_tool_registry.py drives both README counts and facade-actions.md (P2 #924)."""
+    from tree_sitter_analyzer.mcp.tools.utils.change_impact_analysis import (
+        _attach_doc_drift_hints,
+    )
+
+    result = _attach_doc_drift_hints({}, ["tree_sitter_analyzer/mcp/_tool_registry.py"])
+    assert any(
+        "test_readme_counts_match_registry" in step
+        for step in result["doc_drift_checks"]
+    )
+    assert any(
+        "generate_facade_actions_doc" in step for step in result["doc_drift_checks"]
+    )
+
+
+def test_doc_drift_hints_appends_to_verification_steps():
+    """doc-drift checks must appear in verification_steps, not just doc_drift_checks (P2 #924)."""
+    from tree_sitter_analyzer.mcp.tools.utils.change_impact_analysis import (
+        _attach_doc_drift_hints,
+    )
+
+    result = _attach_doc_drift_hints(
+        {"verification_steps": ["uv run pytest tests/unit/ -x"]},
+        ["tree_sitter_analyzer/cli_main.py"],
+    )
+    assert len(result["verification_steps"]) == 2
+    assert any(
+        "test_readme_counts_match_registry" in step
+        for step in result["verification_steps"]
+    )

--- a/tree_sitter_analyzer/mcp/tools/utils/change_impact_analysis.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/change_impact_analysis.py
@@ -829,6 +829,16 @@ def _hot_zone_symbols_for_files(
 _CLI_SURFACE_FILES = frozenset(
     {
         "tree_sitter_analyzer/cli_main.py",
+        "tree_sitter_analyzer/cli/argument_parser_builder.py",
+        "tree_sitter_analyzer/mcp/_tool_registry.py",
+    }
+)
+# Directories that, when any .py file changes, indicate CLI surface edits.
+_CLI_SURFACE_PREFIXES = ("tree_sitter_analyzer/cli/argument_groups/",)
+# Files that contribute to facade-actions.md generation but live outside mcp/tools/.
+_FACADE_DOC_FILES = frozenset(
+    {
+        "tree_sitter_analyzer/mcp/facade_map.py",
         "tree_sitter_analyzer/mcp/_tool_registry.py",
     }
 )
@@ -849,15 +859,23 @@ def _attach_doc_drift_hints(
 
     Resolves Issue #732: when CLI argument registration or facade action
     parameters change, change-impact must surface the follow-up obligations:
-    - cli_main.py / _tool_registry.py → README count contracts
-    - mcp/tools/*.py → facade-actions.md regeneration
+    - cli_main.py / argument_groups/*.py / _tool_registry.py → README count contracts
+    - mcp/tools/*.py / facade_map.py / _tool_registry.py → facade-actions.md regen
     """
-    cli_changed = any(f.replace("\\", "/") in _CLI_SURFACE_FILES for f in changed_files)
+    normalized = [f.replace("\\", "/") for f in changed_files]
+    cli_changed = any(
+        f in _CLI_SURFACE_FILES
+        or any(f.startswith(pfx) and f.endswith(".py") for pfx in _CLI_SURFACE_PREFIXES)
+        for f in normalized
+    )
     facade_changed = any(
-        f.replace("\\", "/").startswith(_FACADE_TOOL_PREFIX)
-        and not any(f.replace("\\", "/").startswith(ex) for ex in _FACADE_TOOL_EXCLUDE)
-        and f.endswith(".py")
-        for f in changed_files
+        f in _FACADE_DOC_FILES
+        or (
+            f.startswith(_FACADE_TOOL_PREFIX)
+            and not any(f.startswith(ex) for ex in _FACADE_TOOL_EXCLUDE)
+            and f.endswith(".py")
+        )
+        for f in normalized
     )
 
     extra_steps: list[str] = []
@@ -875,16 +893,10 @@ def _attach_doc_drift_hints(
         return result
 
     result["doc_drift_checks"] = extra_steps
-    strategy = result.get("verification_strategy", {})
-    if isinstance(strategy, dict):
-        steps = strategy.get("verification_steps") or []
-        strategy["verification_steps"] = list(steps) + extra_steps
-    else:
-        hint = result.get("verification_hint", "")
-        if hint:
-            result["verification_hint"] = (
-                hint + " Also check: " + "; ".join(extra_steps)
-            )
+    # Append to the top-level verification_steps list that agents consume.
+    # (verification_strategy is a string label, not a nested dict.)
+    steps = result.get("verification_steps") or []
+    result["verification_steps"] = list(steps) + extra_steps
     return result
 
 

--- a/tree_sitter_analyzer/mcp/tools/utils/change_impact_analysis.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/change_impact_analysis.py
@@ -702,6 +702,8 @@ def _build_change_impact_result(request: ChangeImpactRequest) -> dict[str, Any]:
     # CURRENT activation state, not the freshly-recomputed one.
     result = _attach_hot_zone_risk(result, request)
 
+    result = _attach_doc_drift_hints(result, request.changed_files)
+
     if request.agent_summary_only:
         return _attach_constraint_violations(result, request, affected)
 
@@ -822,6 +824,68 @@ def _hot_zone_symbols_for_files(
                 conn.close()
             except Exception:  # noqa: BLE001
                 pass
+
+
+_CLI_SURFACE_FILES = frozenset(
+    {
+        "tree_sitter_analyzer/cli_main.py",
+        "tree_sitter_analyzer/mcp/_tool_registry.py",
+    }
+)
+_FACADE_TOOL_PREFIX = "tree_sitter_analyzer/mcp/tools/"
+_FACADE_TOOL_EXCLUDE = frozenset(
+    {
+        "tree_sitter_analyzer/mcp/tools/utils",
+        "tree_sitter_analyzer/mcp/tools/__pycache__",
+    }
+)
+
+
+def _attach_doc_drift_hints(
+    result: dict[str, Any],
+    changed_files: list[str],
+) -> dict[str, Any]:
+    """Append deterministic doc-drift verification steps for known CLI/MCP surfaces.
+
+    Resolves Issue #732: when CLI argument registration or facade action
+    parameters change, change-impact must surface the follow-up obligations:
+    - cli_main.py / _tool_registry.py → README count contracts
+    - mcp/tools/*.py → facade-actions.md regeneration
+    """
+    cli_changed = any(f.replace("\\", "/") in _CLI_SURFACE_FILES for f in changed_files)
+    facade_changed = any(
+        f.replace("\\", "/").startswith(_FACADE_TOOL_PREFIX)
+        and not any(f.replace("\\", "/").startswith(ex) for ex in _FACADE_TOOL_EXCLUDE)
+        and f.endswith(".py")
+        for f in changed_files
+    )
+
+    extra_steps: list[str] = []
+    if cli_changed:
+        extra_steps.append(
+            "uv run pytest tests/unit/test_agent_contracts.py::test_readme_counts_match_registry -x"
+        )
+    if facade_changed:
+        extra_steps.append(
+            "uv run python scripts/generate_facade_actions_doc.py && "
+            "uv run pytest tests/unit/docs/test_facade_actions_doc_drift.py -x"
+        )
+
+    if not extra_steps:
+        return result
+
+    result["doc_drift_checks"] = extra_steps
+    strategy = result.get("verification_strategy", {})
+    if isinstance(strategy, dict):
+        steps = strategy.get("verification_steps") or []
+        strategy["verification_steps"] = list(steps) + extra_steps
+    else:
+        hint = result.get("verification_hint", "")
+        if hint:
+            result["verification_hint"] = (
+                hint + " Also check: " + "; ".join(extra_steps)
+            )
+    return result
 
 
 def _attach_constraint_violations(


### PR DESCRIPTION
## Summary

- Adds `doc_drift_checks` field to change-impact responses when CLI surface files (`cli_main.py`, `_tool_registry.py`) or MCP facade tools are modified
- Surfaces exact `pytest` commands agents should run to catch README count drift and facade action doc staleness
- Prevents silent drift where README flag/tool counts become stale after surface changes

## Changes

- `tree_sitter_analyzer/mcp/tools/utils/change_impact_analysis.py`: Added `_attach_doc_drift_hints()` + constants
- `tests/unit/mcp/test_change_impact_tool_execute_and_mapping.py`: 5 new tests covering all hint conditions

## Test plan

- [ ] `uv run pytest tests/unit/mcp/test_change_impact_tool_execute_and_mapping.py -x` — all new tests pass
- [ ] `uv run pytest tests/ -x` — full suite green
- [ ] Verify `doc_drift_checks` absent for unrelated file changes
- [ ] Verify `doc_drift_checks` present for `cli_main.py` / `_tool_registry.py` / facade tool changes

Fixes #732

🤖 Generated with [Claude Code](https://claude.com/claude-code)