### PR TITLE
fix(nav): track authoritative call-graph build state (#708)

### DIFF
--- a/tests/unit/test_call_graph_built_signal.py
+++ b/tests/unit/test_call_graph_built_signal.py
@@ -1,0 +1,159 @@
+"""Regression coverage for authoritative call-graph-built state (#708)."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tree_sitter_analyzer import _ast_cache_callgraph_state as callgraph_state
+from tree_sitter_analyzer.ast_cache import ASTCache
+from tree_sitter_analyzer.mcp.tools.callees_tool import CodeGraphCalleesTool
+from tree_sitter_analyzer.mcp.tools.callers_tool import CodeGraphCallersTool
+from tree_sitter_analyzer.mcp.tools.codegraph_relation_tool import (
+    CodeGraphRelationToolMixin,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_call_graph_state_marker_round_trip() -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    try:
+        assert callgraph_state.call_graph_built(conn) is False
+
+        callgraph_state.mark_call_graph_built(conn)
+        assert callgraph_state.call_graph_built(conn) is True
+
+        callgraph_state.clear_call_graph_built(conn)
+        assert callgraph_state.call_graph_built(conn) is False
+    finally:
+        conn.close()
+
+
+def _seed_partial_ast_cache_without_call_graph(root: Path) -> None:
+    """Create an AST-cache row that predates the call-graph-built marker."""
+    source = "def solo():\n    return 1\n"
+    source_path = root / "solo.py"
+    source_path.write_text(source, encoding="utf-8")
+
+    cache = ASTCache(str(root))
+    conn = cache.get_conn()
+    conn.execute(
+        "INSERT OR REPLACE INTO ast_index "
+        "(file_path, content_hash, language, mtime_ns, file_size, "
+        "extractor_version, symbols_json, imports_json, structure_json, indexed_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            "solo.py",
+            "partial-cache-without-call-graph",
+            "python",
+            source_path.stat().st_mtime_ns,
+            len(source.encode("utf-8")),
+            0,
+            json.dumps(
+                {
+                    "symbols": [
+                        {
+                            "name": "solo",
+                            "kind": "function",
+                            "line": 1,
+                            "end_line": 2,
+                            "params": "",
+                        }
+                    ]
+                }
+            ),
+            "[]",
+            "{}",
+            "2026-06-15T00:00:00+00:00",
+        ),
+    )
+    conn.commit()
+    cache.close()
+
+
+def test_resolve_only_marks_call_graph_built_for_partial_cache(tmp_path: Path) -> None:
+    _seed_partial_ast_cache_without_call_graph(tmp_path)
+
+    cache = ASTCache(str(tmp_path))
+    try:
+        assert cache.call_graph_built() is False
+
+        result = cache.index_project(resolve_only=True)
+
+        assert result["mode_used"] == "resolve_only"
+        assert cache.call_graph_built() is True
+    finally:
+        cache.close()
+
+
+def test_cache_call_graph_built_degrades_false_on_reader_error() -> None:
+    class BrokenCache:
+        def call_graph_built(self) -> bool:
+            raise RuntimeError("boom")
+
+    assert CodeGraphRelationToolMixin._cache_call_graph_built(BrokenCache()) is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("tool_cls", "count_key"),
+    [
+        (CodeGraphCallersTool, "caller_count"),
+        (CodeGraphCalleesTool, "callee_count"),
+    ],
+)
+async def test_partial_ast_cache_without_call_graph_marker_hints_full_index(
+    tmp_path: Path,
+    tool_cls: type[CodeGraphCallersTool] | type[CodeGraphCalleesTool],
+    count_key: str,
+) -> None:
+    _seed_partial_ast_cache_without_call_graph(tmp_path)
+
+    tool = tool_cls(str(tmp_path))
+    result = await tool.execute({"function_name": "solo", "output_format": "json"})
+
+    assert result["verdict"] == "NOT_FOUND"
+    assert result[count_key] == 0
+    assert "--full-index" in result["next_step"]
+    assert result["agent_summary"]["next_step"] == result["next_step"]
+
+
+@pytest.mark.timeout(60)
+def test_cli_callers_partial_ast_cache_matches_mcp_full_index_hint(
+    tmp_path: Path,
+) -> None:
+    _seed_partial_ast_cache_without_call_graph(tmp_path)
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "tree_sitter_analyzer",
+            "--callers",
+            "solo",
+            "--project-root",
+            str(tmp_path),
+            "--format",
+            "json",
+        ],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    result: dict[str, Any] = json.loads(proc.stdout)
+    assert result["verdict"] == "NOT_FOUND"
+    assert result["caller_count"] == 0
+    assert "--full-index" in result["next_step"]
+    assert result["agent_summary"]["next_step"] == result["next_step"]

--- a/tests/unit/test_call_graph_built_signal.py
+++ b/tests/unit/test_call_graph_built_signal.py
@@ -37,6 +37,44 @@ def test_call_graph_state_marker_round_trip() -> None:
         conn.close()
 
 
+def test_call_graph_state_write_failures_do_not_raise() -> None:
+    class BrokenConn:
+        def execute(self, *args: object, **kwargs: object) -> object:
+            raise sqlite3.OperationalError("locked")
+
+        def commit(self) -> None:
+            raise AssertionError("commit should not run after execute fails")
+
+    broken = BrokenConn()
+
+    callgraph_state.mark_call_graph_built(broken)  # type: ignore[arg-type]
+    callgraph_state.clear_call_graph_built(broken)  # type: ignore[arg-type]
+
+
+def test_call_graph_built_false_when_state_table_has_no_row() -> None:
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.execute(
+            "CREATE TABLE ast_call_graph_state "
+            "(id INTEGER PRIMARY KEY, built INTEGER NOT NULL, built_at REAL NOT NULL)"
+        )
+        conn.commit()
+
+        assert callgraph_state.call_graph_built(conn) is False
+    finally:
+        conn.close()
+
+
+def test_call_graph_built_supports_tuple_rows() -> None:
+    conn = sqlite3.connect(":memory:")
+    try:
+        callgraph_state.mark_call_graph_built(conn)
+
+        assert callgraph_state.call_graph_built(conn) is True
+    finally:
+        conn.close()
+
+
 def _seed_partial_ast_cache_without_call_graph(root: Path) -> None:
     """Create an AST-cache row that predates the call-graph-built marker."""
     source = "def solo():\n    return 1\n"

--- a/tree_sitter_analyzer/_ast_cache_callgraph_state.py
+++ b/tree_sitter_analyzer/_ast_cache_callgraph_state.py
@@ -1,0 +1,65 @@
+"""Persisted call-graph-built marker for AST cache readers (#708)."""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import time
+
+logger = logging.getLogger(__name__)
+
+_CREATE_DDL = (
+    "CREATE TABLE IF NOT EXISTS ast_call_graph_state ("
+    "id INTEGER PRIMARY KEY, "
+    "built INTEGER NOT NULL, "
+    "built_at REAL NOT NULL)"
+)
+
+
+def mark_call_graph_built(conn: sqlite3.Connection) -> None:
+    """Record that the call-graph derivation completed for this cache."""
+    try:
+        conn.execute(_CREATE_DDL)
+        conn.execute(
+            "INSERT INTO ast_call_graph_state (id, built, built_at) "
+            "VALUES (1, 1, ?) "
+            "ON CONFLICT(id) DO UPDATE SET "
+            "built = excluded.built, "
+            "built_at = excluded.built_at",
+            (time.time(),),
+        )
+        conn.commit()
+    except sqlite3.OperationalError:
+        logger.debug("could not mark call-graph-built", exc_info=True)
+
+
+def clear_call_graph_built(conn: sqlite3.Connection) -> None:
+    """Clear the marker before replacing the derived call graph."""
+    try:
+        conn.execute(_CREATE_DDL)
+        conn.execute(
+            "INSERT INTO ast_call_graph_state (id, built, built_at) "
+            "VALUES (1, 0, ?) "
+            "ON CONFLICT(id) DO UPDATE SET "
+            "built = excluded.built, "
+            "built_at = excluded.built_at",
+            (time.time(),),
+        )
+        conn.commit()
+    except sqlite3.OperationalError:
+        logger.debug("could not clear call-graph-built", exc_info=True)
+
+
+def call_graph_built(conn: sqlite3.Connection) -> bool:
+    """Return True iff this cache explicitly records a built call graph."""
+    try:
+        row = conn.execute(
+            "SELECT built FROM ast_call_graph_state WHERE id = 1"
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return False
+    if row is None:
+        return False
+    if isinstance(row, sqlite3.Row):
+        return bool(row["built"])
+    return bool(row[0])

--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -33,6 +33,11 @@ from ._ast_cache_build_state import (
     clear_build_in_progress as _clear_build_in_progress,
     mark_build_in_progress as _mark_build_in_progress,
 )
+from ._ast_cache_callgraph_state import (
+    call_graph_built as _call_graph_built,
+    clear_call_graph_built as _clear_call_graph_built,
+    mark_call_graph_built as _mark_call_graph_built,
+)
 from ._ast_cache_helpers import (
     _build_function_entry,
     _commit_index_results,
@@ -311,6 +316,7 @@ class ASTCache:
             synapse = self._run_synapse_backfill()
             edge_store_refresh = self._refresh_graph_edges_from_cache()
             unresolved = self._run_unresolved_refs_backfill()
+            _mark_call_graph_built(self._get_conn())
             return {
                 "mode_used": "resolve_only",
                 "resolve_only": True,
@@ -336,6 +342,7 @@ class ASTCache:
                 # failed rebuild would leave a stuck marker until TTL expiry.
                 conn = self._get_conn()
                 _mark_build_in_progress(conn)
+                _clear_call_graph_built(conn)
                 conn.execute("DELETE FROM ast_index")
                 conn.commit()
             stats, candidates, count = self._walk_and_partition(
@@ -363,6 +370,7 @@ class ASTCache:
             stats["workers"] = workers
             if stats["indexed"] > 0:
                 self._post_index_backfill(stats)
+                _mark_call_graph_built(self._get_conn())
             if force:
                 stats["db_maintenance"] = _reclaim_storage_after_full_rebuild(
                     conn, self.db_path
@@ -829,6 +837,10 @@ class ASTCache:
             )
         except sqlite3.OperationalError:
             return False
+
+    def call_graph_built(self) -> bool:
+        """True iff the cache explicitly records a completed call-graph build."""
+        return _call_graph_built(self._get_conn())
 
     def get_cross_file_resolver(self) -> Any:
         """Get (or build) the CrossFileResolver for import-aware resolution."""

--- a/tree_sitter_analyzer/mcp/tools/callees_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/callees_tool.py
@@ -131,6 +131,9 @@ class CodeGraphCalleesTool(CodeGraphRelationToolMixin, BaseMCPTool):
             return apply_toon_format_to_response(result, output_format)
 
         cache = self._try_get_cache()
+        call_graph_built = (
+            self._cache_call_graph_built(cache) if cache is not None else False
+        )
         call_graph_indexed = cache is not None and cache.has_call_edges()
         if call_graph_indexed:
             callees = self._sql_native_callees(
@@ -152,9 +155,7 @@ class CodeGraphCalleesTool(CodeGraphRelationToolMixin, BaseMCPTool):
             #       has calls, so the symbol just isn't there.
             # Only fire the hint when the index is absent AND the parse found
             # no edges at all (truly empty/unbuilt state).
-            has_any_call_edges = (
-                self._data_source == "cache" or len(graph.call_edges()) > 0
-            )
+            has_any_call_edges = call_graph_built or len(graph.call_edges()) > 0
 
         warnings_list: list[str] = []
         if _is_stale_resolution(callees):

--- a/tree_sitter_analyzer/mcp/tools/callers_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/callers_tool.py
@@ -144,6 +144,9 @@ class CodeGraphCallersTool(CodeGraphRelationToolMixin, BaseMCPTool):
 
         unattributed_call_sites = 0
         cache = self._try_get_cache()
+        call_graph_built = (
+            self._cache_call_graph_built(cache) if cache is not None else False
+        )
         call_graph_indexed = cache is not None and cache.has_call_edges()
         if call_graph_indexed and not is_qualified:
             callers, unattributed_call_sites = self._sql_native_callers(
@@ -163,9 +166,7 @@ class CodeGraphCallersTool(CodeGraphRelationToolMixin, BaseMCPTool):
             #       has calls, so the symbol just isn't there.
             # Only fire the hint when the index is absent AND the parse found
             # no edges at all (truly empty/unbuilt state).
-            has_any_call_edges = (
-                self._data_source == "cache" or len(graph.call_edges()) > 0
-            )
+            has_any_call_edges = call_graph_built or len(graph.call_edges()) > 0
 
         warnings_list: list[str] = []
         if _is_stale_resolution(callers):

--- a/tree_sitter_analyzer/mcp/tools/codegraph_relation_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_relation_tool.py
@@ -163,6 +163,13 @@ class CodeGraphRelationToolMixin:
             pass
         return None
 
+    @staticmethod
+    def _cache_call_graph_built(cache: Any) -> bool:
+        try:
+            return bool(cache.call_graph_built())
+        except Exception:
+            return False
+
     def _get_call_graph(self) -> CallGraph:
         if self._call_graph is None:
             if not self.project_root:


### PR DESCRIPTION
## Summary

- Adds an authoritative `call-graph-built` signal to callers/callees tools so agents get a deterministic hint about index state rather than heuristic guesses
- Adds edge-case coverage tests for call graph state transitions

Closes #708

## Test plan

- [ ] `uv run pytest tests/unit/test_call_graph_built_signal.py -v` — all tests green
- [ ] CI green across all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)