### PR TITLE
fix(test): avoid uv during mutation baseline pyproject swap (#716)

### DIFF
--- a/scripts/run_mutation_baseline.py
+++ b/scripts/run_mutation_baseline.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 # Module -> (source file, targeted test paths)
@@ -68,6 +69,17 @@ timeout_constant = 10.0
 """
 
 
+def _resolve_mutmut_command() -> list[str]:
+    """Return a direct mutmut command from the already-resolved environment."""
+    current_env_script = Path(sys.executable).with_name("mutmut")
+    if current_env_script.exists():
+        return [str(current_env_script)]
+    path_script = shutil.which("mutmut")
+    if path_script:
+        return [path_script]
+    return [sys.executable, "-m", "mutmut"]
+
+
 def run_module(module_key: str, repo_root: Path) -> None:
     if module_key not in MODULES:
         print(f"Unknown module: {module_key}. Choose from: {list(MODULES)}")
@@ -76,45 +88,45 @@ def run_module(module_key: str, repo_root: Path) -> None:
     source_path, test_paths = MODULES[module_key]
     test_paths_toml = "[" + ", ".join(f'"{p}"' for p in test_paths) + "]"
 
-    # Write a temporary pyproject.toml stub in a temp directory, then run
-    # mutmut from there with the real source accessible via the PYTHONPATH.
-    # Simpler: mutmut reads pyproject.toml from CWD. We swap it temporarily.
+    # Resolve mutmut before swapping pyproject.toml. The runner is usually
+    # invoked via ``uv run python ...``; calling ``uv run`` again inside the
+    # swap window would make uv resolve from the temporary minimal pyproject.
+    mutmut_command = _resolve_mutmut_command()
+
+    # mutmut 3.6 only reads config from CWD pyproject.toml / setup.cfg and has
+    # no config-file CLI flag. Swap only for mutmut's direct process.
     real_pyproject = repo_root / "pyproject.toml"
-    backup = repo_root / "pyproject.toml.mutation-bak"
 
     content = PYPROJECT_TEMPLATE.format(
         source_path=source_path,
         test_paths_toml=test_paths_toml,
     )
 
-    # Create a minimal pyproject.toml that only has [tool.mutmut] — mutmut
-    # only reads that section, so it doesn't need the full build config.
-    minimal_pyproject = repo_root / "pyproject_mutmut_tmp.toml"
-    minimal_pyproject.write_text(content, encoding="utf-8")
+    with tempfile.TemporaryDirectory(prefix="mutation-baseline-") as temp_dir:
+        temp_root = Path(temp_dir)
+        backup = temp_root / "pyproject.toml"
+        minimal_pyproject = temp_root / "pyproject.mutmut.toml"
+        minimal_pyproject.write_text(content, encoding="utf-8")
+        shutil.copy2(real_pyproject, backup)
+        try:
+            shutil.copy2(minimal_pyproject, real_pyproject)
+            print(f"\n=== Running mutmut on {source_path} ===")
+            print(f"    Tests: {test_paths}")
+            result = subprocess.run(
+                [*mutmut_command, "run"],
+                cwd=repo_root,
+                capture_output=False,
+            )
+            print(f"\n=== mutmut run exit code: {result.returncode} ===")
 
-    # Back up real pyproject.toml, swap in minimal, run, restore.
-    shutil.copy2(real_pyproject, backup)
-    try:
-        shutil.copy2(minimal_pyproject, real_pyproject)
-        print(f"\n=== Running mutmut on {source_path} ===")
-        print(f"    Tests: {test_paths}")
-        result = subprocess.run(
-            ["uv", "run", "mutmut", "run"],
-            cwd=repo_root,
-            capture_output=False,
-        )
-        print(f"\n=== mutmut run exit code: {result.returncode} ===")
-
-        # Collect results
-        print(f"\n=== Results for {module_key} ===")
-        subprocess.run(
-            ["uv", "run", "mutmut", "results"],
-            cwd=repo_root,
-        )
-    finally:
-        shutil.copy2(backup, real_pyproject)
-        backup.unlink(missing_ok=True)
-        minimal_pyproject.unlink(missing_ok=True)
+            # Collect results
+            print(f"\n=== Results for {module_key} ===")
+            subprocess.run(
+                [*mutmut_command, "results"],
+                cwd=repo_root,
+            )
+        finally:
+            shutil.copy2(backup, real_pyproject)
 
 
 def main() -> None:

--- a/tests/unit/test_run_mutation_baseline.py
+++ b/tests/unit/test_run_mutation_baseline.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts import run_mutation_baseline
+
+
+def test_run_module_does_not_invoke_uv_while_pyproject_is_swapped(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path
+    real_pyproject = repo_root / "pyproject.toml"
+    real_pyproject.write_text("[project]\nname = 'sample'\n", encoding="utf-8")
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, *, cwd=None, capture_output=False):
+        assert cwd == repo_root
+        assert "Temporary pyproject.toml" in real_pyproject.read_text(encoding="utf-8")
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(
+        run_mutation_baseline,
+        "_resolve_mutmut_command",
+        lambda: ["/venv/bin/mutmut"],
+        raising=False,
+    )
+    monkeypatch.setattr(run_mutation_baseline.subprocess, "run", fake_run)
+
+    run_mutation_baseline.run_module("ast_diff", repo_root)
+
+    assert calls == [
+        ["/venv/bin/mutmut", "run"],
+        ["/venv/bin/mutmut", "results"],
+    ]
+    assert real_pyproject.read_text(encoding="utf-8") == "[project]\nname = 'sample'\n"
+
+
+def test_resolve_mutmut_command_prefers_current_environment_script(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    bin_dir = tmp_path / "venv" / "bin"
+    bin_dir.mkdir(parents=True)
+    python = bin_dir / "python"
+    mutmut = bin_dir / "mutmut"
+    python.write_text("", encoding="utf-8")
+    mutmut.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(run_mutation_baseline.sys, "executable", str(python))
+    monkeypatch.setattr(run_mutation_baseline.shutil, "which", lambda name: None)
+
+    assert run_mutation_baseline._resolve_mutmut_command() == [str(mutmut)]
+
+
+def test_resolve_mutmut_command_falls_back_to_path(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    python = tmp_path / "python"
+    path_mutmut = tmp_path / "mutmut"
+    monkeypatch.setattr(run_mutation_baseline.sys, "executable", str(python))
+    monkeypatch.setattr(
+        run_mutation_baseline.shutil,
+        "which",
+        lambda name: str(path_mutmut) if name == "mutmut" else None,
+    )
+
+    assert run_mutation_baseline._resolve_mutmut_command() == [str(path_mutmut)]
+
+
+def test_resolve_mutmut_command_falls_back_to_python_module(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    python = tmp_path / "python"
+    monkeypatch.setattr(run_mutation_baseline.sys, "executable", str(python))
+    monkeypatch.setattr(run_mutation_baseline.shutil, "which", lambda name: None)
+
+    assert run_mutation_baseline._resolve_mutmut_command() == [
+        str(python),
+        "-m",
+        "mutmut",
+    ]
+
+
+def test_run_module_rejects_unknown_module(capsys, tmp_path: Path) -> None:
+    with pytest.raises(SystemExit) as exc:
+        run_mutation_baseline.run_module("missing", tmp_path)
+
+    assert exc.value.code == 1
+    assert "Unknown module: missing." in capsys.readouterr().out
+
+
+def test_main_defaults_to_ast_diff(monkeypatch, tmp_path: Path) -> None:
+    calls: list[tuple[str, Path]] = []
+    monkeypatch.setattr(run_mutation_baseline.sys, "argv", ["runner"])
+    monkeypatch.setattr(
+        run_mutation_baseline,
+        "run_module",
+        lambda module_key, repo_root: calls.append((module_key, repo_root)),
+    )
+
+    run_mutation_baseline.main()
+
+    assert calls == [
+        (
+            "ast_diff",
+            Path(run_mutation_baseline.__file__).parent.parent.resolve(),
+        )
+    ]


### PR DESCRIPTION
## Summary

- Fixes the mutation baseline runner to avoid relying on `uv` during `pyproject.toml` swap operations, preventing failures in environments where `uv` is not available or behaves unexpectedly
- Adds tests for the mutation baseline runner

Closes #716

## Test plan

- [ ] `uv run pytest tests/unit/test_run_mutation_baseline.py -v` — all tests green
- [ ] CI green across all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)