### PR TITLE
fix(scala): enum case values, parent_class for given/type constructs (#762 #764)

### DIFF
--- a/tests/unit/languages/test_scala_fixes.py
+++ b/tests/unit/languages/test_scala_fixes.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Tests for Scala extraction bugs #762 and #764.
+
+#762: Scala enum case values dropped — `enum Color { case Red, Green, Blue }`
+      must extract Red, Green, Blue as enum members.
+
+#764: Scala `given`, `extension`, and `type` aliases inside an object/trait
+      must carry parent_class="<owner>".
+"""
+
+from __future__ import annotations
+
+import tree_sitter
+import tree_sitter_scala
+
+from tree_sitter_analyzer.languages.scala_plugin import ScalaElementExtractor
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse(source: str) -> tree_sitter.Tree:
+    lang = tree_sitter.Language(tree_sitter_scala.language())
+    parser = tree_sitter.Parser(lang)
+    return parser.parse(source.encode("utf-8"))
+
+
+def _classes(source: str) -> dict[str, object]:
+    extractor = ScalaElementExtractor()
+    return {c.name: c for c in extractor.extract_classes(_parse(source), source)}
+
+
+def _functions(source: str) -> dict[str, object]:
+    extractor = ScalaElementExtractor()
+    return {f.name: f for f in extractor.extract_functions(_parse(source), source)}
+
+
+def _variables(source: str) -> dict[str, object]:
+    extractor = ScalaElementExtractor()
+    return {v.name: v for v in extractor.extract_variables(_parse(source), source)}
+
+
+# ---------------------------------------------------------------------------
+# Bug #762: Scala enum case values must be extracted as enum members
+# ---------------------------------------------------------------------------
+
+
+_ENUM_SIMPLE = """\
+enum Color:
+  case Red
+  case Green
+  case Blue
+"""
+
+_ENUM_MULTI = """\
+enum Direction:
+  case North, South, East, West
+"""
+
+_ENUM_WITH_PARAMS = """\
+enum Planet(mass: Double, radius: Double):
+  case Mercury extends Planet(3.303e+23, 2.4397e6)
+  case Venus extends Planet(4.869e+24, 6.0518e6)
+"""
+
+
+class TestEnumCaseExtraction:
+    """#762: enum case values must appear in the extracted elements."""
+
+    def test_enum_itself_extracted(self) -> None:
+        classes = _classes(_ENUM_SIMPLE)
+        assert "Color" in classes
+
+    def test_enum_class_type(self) -> None:
+        classes = _classes(_ENUM_SIMPLE)
+        assert classes["Color"].class_type == "enum"
+
+    def test_simple_enum_cases_count(self) -> None:
+        classes = _classes(_ENUM_SIMPLE)
+        # Color + Red + Green + Blue = 4
+        assert len(classes) == 4
+
+    def test_red_extracted(self) -> None:
+        classes = _classes(_ENUM_SIMPLE)
+        assert "Red" in classes
+
+    def test_green_extracted(self) -> None:
+        classes = _classes(_ENUM_SIMPLE)
+        assert "Green" in classes
+
+    def test_blue_extracted(self) -> None:
+        classes = _classes(_ENUM_SIMPLE)
+        assert "Blue" in classes
+
+    def test_enum_case_class_type(self) -> None:
+        classes = _classes(_ENUM_SIMPLE)
+        assert classes["Red"].class_type == "enum_member"
+
+    def test_enum_case_parent_class(self) -> None:
+        classes = _classes(_ENUM_SIMPLE)
+        assert classes["Red"].parent_class == "Color"
+        assert classes["Green"].parent_class == "Color"
+        assert classes["Blue"].parent_class == "Color"
+
+    def test_multi_case_on_one_line_count(self) -> None:
+        classes = _classes(_ENUM_MULTI)
+        # Direction + North + South + East + West = 5
+        assert len(classes) == 5
+
+    def test_multi_case_names_extracted(self) -> None:
+        classes = _classes(_ENUM_MULTI)
+        assert "North" in classes
+        assert "South" in classes
+        assert "East" in classes
+        assert "West" in classes
+
+    def test_multi_case_parent_class(self) -> None:
+        classes = _classes(_ENUM_MULTI)
+        assert classes["North"].parent_class == "Direction"
+
+    def test_enum_with_params_cases_count(self) -> None:
+        classes = _classes(_ENUM_WITH_PARAMS)
+        # Planet + Mercury + Venus = 3
+        assert len(classes) == 3
+
+    def test_enum_with_params_case_names(self) -> None:
+        classes = _classes(_ENUM_WITH_PARAMS)
+        assert "Mercury" in classes
+        assert "Venus" in classes
+
+    def test_enum_with_params_case_parent(self) -> None:
+        classes = _classes(_ENUM_WITH_PARAMS)
+        assert classes["Mercury"].parent_class == "Planet"
+
+
+# ---------------------------------------------------------------------------
+# Bug #764: given/type/extension inside object/trait must carry parent_class
+# ---------------------------------------------------------------------------
+
+
+_GIVEN_IN_OBJECT = """\
+object Instances {
+  given intOrdering: Ordering[Int] = Ordering.Int
+  given stringOrdering: Ordering[String] = Ordering.String
+}
+"""
+
+_TYPE_IN_OBJECT = """\
+object Types {
+  type MyInt = Int
+  type MyString = String
+}
+"""
+
+_GIVEN_IN_TRAIT = """\
+trait Defaults {
+  given defaultString: String = "hello"
+}
+"""
+
+_NESTED_MIX = """\
+object Outer {
+  given outerGiven: Int = 42
+  type AliasT = Long
+
+  object Inner {
+    given innerGiven: Boolean = true
+  }
+}
+"""
+
+
+class TestGivenTypeParentClass:
+    """#764: given/type constructs must carry parent_class of their enclosing scope."""
+
+    # --- given_definition inside object ---
+
+    def test_given_in_object_classes_extracted(self) -> None:
+        classes = _classes(_GIVEN_IN_OBJECT)
+        # Instances + intOrdering + stringOrdering = 3
+        assert len(classes) == 3
+
+    def test_given_intOrdering_extracted(self) -> None:
+        classes = _classes(_GIVEN_IN_OBJECT)
+        assert "intOrdering" in classes
+
+    def test_given_stringOrdering_extracted(self) -> None:
+        classes = _classes(_GIVEN_IN_OBJECT)
+        assert "stringOrdering" in classes
+
+    def test_given_parent_class_is_object(self) -> None:
+        classes = _classes(_GIVEN_IN_OBJECT)
+        assert classes["intOrdering"].parent_class == "Instances"
+        assert classes["stringOrdering"].parent_class == "Instances"
+
+    def test_given_class_type(self) -> None:
+        classes = _classes(_GIVEN_IN_OBJECT)
+        assert classes["intOrdering"].class_type == "given"
+
+    # --- type_definition inside object ---
+
+    def test_type_alias_in_object_count(self) -> None:
+        classes = _classes(_TYPE_IN_OBJECT)
+        # Types + MyInt + MyString = 3
+        assert len(classes) == 3
+
+    def test_type_alias_extracted(self) -> None:
+        classes = _classes(_TYPE_IN_OBJECT)
+        assert "MyInt" in classes
+        assert "MyString" in classes
+
+    def test_type_alias_parent_class(self) -> None:
+        classes = _classes(_TYPE_IN_OBJECT)
+        assert classes["MyInt"].parent_class == "Types"
+        assert classes["MyString"].parent_class == "Types"
+
+    def test_type_alias_class_type(self) -> None:
+        classes = _classes(_TYPE_IN_OBJECT)
+        assert classes["MyInt"].class_type == "type_alias"
+
+    # --- given inside trait ---
+
+    def test_given_in_trait_parent_class(self) -> None:
+        classes = _classes(_GIVEN_IN_TRAIT)
+        assert "defaultString" in classes
+        assert classes["defaultString"].parent_class == "Defaults"
+
+    # --- nested objects: inner given must reference Inner, not Outer ---
+
+    def test_nested_inner_given_parent_class(self) -> None:
+        classes = _classes(_NESTED_MIX)
+        assert classes["innerGiven"].parent_class == "Inner"
+
+    def test_nested_outer_given_parent_class(self) -> None:
+        classes = _classes(_NESTED_MIX)
+        assert classes["outerGiven"].parent_class == "Outer"
+
+    def test_nested_type_alias_parent_class(self) -> None:
+        classes = _classes(_NESTED_MIX)
+        assert classes["AliasT"].parent_class == "Outer"

--- a/tests/unit/test_scala_language_wiring.py
+++ b/tests/unit/test_scala_language_wiring.py
@@ -75,7 +75,9 @@ def test_scala_corpus_extracts_symbols() -> None:
     # grammar-version bump that changes these counts MUST fail the test
     # and force a conscious re-pin, not pass silently.
     assert len(elements["functions"]) == 66
-    assert len(elements["classes"]) == 33
+    assert (
+        len(elements["classes"]) == 38
+    )  # +5 from enum/given/type extraction (#762 #764)
     assert len(elements["imports"]) == 3
 
 

--- a/tree_sitter_analyzer/languages/scala_plugin.py
+++ b/tree_sitter_analyzer/languages/scala_plugin.py
@@ -153,7 +153,7 @@ class ScalaElementExtractor(ElementExtractor):
         return functions
 
     def extract_classes(self, tree: tree_sitter.Tree, source_code: str) -> list[Class]:
-        """Extract Scala class, object, and trait definitions"""
+        """Extract Scala class, object, trait, enum, given, and type definitions."""
         self.source_code = source_code
         self.content_lines = source_code.split("\n")
         self._reset_caches()
@@ -162,18 +162,7 @@ class ScalaElementExtractor(ElementExtractor):
         self._extract_package(tree.root_node)
 
         classes: list[Class] = []
-
-        extractors = {
-            "class_definition": self._extract_class,
-            "object_definition": self._extract_object,
-            "trait_definition": self._extract_trait,
-        }
-
-        self._traverse_and_extract(
-            tree.root_node,
-            extractors,
-            classes,
-        )
+        self._traverse_classes_with_context(tree.root_node, classes, parent_class=None)
 
         log_debug(f"Extracted {len(classes)} Scala classes/objects/traits")
         return classes
@@ -351,6 +340,255 @@ class ScalaElementExtractor(ElementExtractor):
             if "identifier" in grandchild.type:
                 return self._get_node_text(grandchild)
         return None
+
+    # -----------------------------------------------------------------------
+    # Context-aware class traversal (Bug #762 + #764)
+    # -----------------------------------------------------------------------
+
+    #: Node types that introduce a new named scope (class / object / trait /
+    #: enum).  When the traversal descends into one of these it updates the
+    #: running ``parent_class`` so that nested constructs (given, type alias,
+    #: enum cases) inherit the right owner name.
+    _SCOPE_INTRODUCING_TYPES: frozenset[str] = frozenset(
+        {
+            "class_definition",
+            "object_definition",
+            "trait_definition",
+            "enum_definition",
+        }
+    )
+
+    def _traverse_classes_with_context(
+        self,
+        node: tree_sitter.Node,
+        results: list[Class],
+        parent_class: str | None,
+    ) -> None:
+        """DFS traversal that extracts all class-like constructs with context.
+
+        Unlike the generic ``_traverse_and_extract`` this walk keeps track of
+        the innermost enclosing named scope so that nested ``given`` /
+        ``type`` / enum-case nodes can record their ``parent_class``.
+
+        Stack entries: ``(node, parent_class_name)``.
+        """
+        stack: list[tuple[tree_sitter.Node, str | None]] = [(node, parent_class)]
+        while stack:
+            current, current_parent = stack.pop()
+            node_type = current.type
+
+            if node_type in (
+                "class_definition",
+                "object_definition",
+                "trait_definition",
+            ):
+                cls = self._extract_class_like_with_parent(
+                    current, node_type.split("_")[0], current_parent
+                )
+                if cls:
+                    results.append(cls)
+                # Descend with this class as the new parent scope.
+                new_parent = cls.name if cls else current_parent
+                for child in reversed(current.children):
+                    stack.append((child, new_parent))
+
+            elif node_type == "enum_definition":
+                # Emit the enum itself, then its cases.
+                self._extract_enum_with_cases(current, current_parent, results)
+                # Descend into the enum body for further nested defs (rare
+                # but possible), still under the enum's name as parent.
+                enum_name = self._scala_class_like_name(current)
+                for child in reversed(current.children):
+                    if child.type == "enum_body":
+                        for sub in reversed(child.children):
+                            stack.append((sub, enum_name))
+
+            elif node_type == "given_definition":
+                # #764: given inside an object/trait — carry parent_class.
+                cls = self._extract_given(current, current_parent)
+                if cls:
+                    results.append(cls)
+                # given bodies can theoretically contain nested defs.
+                for child in reversed(current.children):
+                    stack.append((child, current_parent))
+
+            elif node_type == "type_definition":
+                # #764: type alias inside an object/trait — carry parent_class.
+                cls = self._extract_type_alias(current, current_parent)
+                if cls:
+                    results.append(cls)
+
+            else:
+                # Generic node: descend preserving context.
+                for child in reversed(current.children):
+                    stack.append((child, current_parent))
+
+    def _extract_class_like_with_parent(
+        self,
+        node: tree_sitter.Node,
+        kind: str,
+        parent_class: str | None,
+    ) -> Class | None:
+        """Like ``_extract_class_like`` but also populates ``parent_class``."""
+        cls = self._extract_class_like(node, kind)
+        if cls is not None and parent_class is not None:
+            cls.parent_class = parent_class
+        return cls
+
+    def _extract_enum_with_cases(
+        self,
+        node: tree_sitter.Node,
+        parent_class: str | None,
+        results: list[Class],
+    ) -> None:
+        """Emit the enum itself and each ``simple_enum_case`` as enum_member.
+
+        AST shape (tree-sitter-scala):
+            enum_definition
+              'enum'
+              identifier            ← enum name
+              class_parameters?     ← optional constructor params
+              enum_body
+                ':'
+                enum_case_definitions*
+                  'case'
+                  simple_enum_case+  ← one or more cases
+                    identifier       ← case name
+                    extends_clause?
+
+        Each ``enum_case_definitions`` may contain multiple ``simple_enum_case``
+        children separated by commas (``case North, South, East, West``).
+        """
+        enum_name = self._scala_class_like_name(node)
+        start_line = node.start_point[0] + 1
+        end_line = node.end_point[0] + 1
+        raw_text = self._get_node_text(node)
+        docstring = self._extract_docstring(node)
+        superclass, interfaces = self._extract_scala_extends_clause(node)
+
+        enum_cls = Class(
+            name=enum_name,
+            start_line=start_line,
+            end_line=end_line,
+            raw_text=raw_text,
+            language="scala",
+            class_type="enum",
+            visibility=self._scala_visibility(node),
+            package_name=self.current_package,
+            docstring=docstring,
+            superclass=superclass,
+            interfaces=interfaces,
+            parent_class=parent_class,
+        )
+        results.append(enum_cls)
+
+        # Walk enum_body → enum_case_definitions → simple_enum_case
+        for child in node.children:
+            if child.type != "enum_body":
+                continue
+            for case_defs in child.children:
+                if case_defs.type != "enum_case_definitions":
+                    continue
+                for case_node in case_defs.children:
+                    if case_node.type != "simple_enum_case":
+                        continue
+                    case_name = self._scala_class_like_name(case_node)
+                    results.append(
+                        Class(
+                            name=case_name,
+                            start_line=case_node.start_point[0] + 1,
+                            end_line=case_node.end_point[0] + 1,
+                            raw_text=self._get_node_text(case_node),
+                            language="scala",
+                            class_type="enum_member",
+                            visibility="public",
+                            package_name=self.current_package,
+                            parent_class=enum_name,
+                        )
+                    )
+
+    def _extract_given(
+        self,
+        node: tree_sitter.Node,
+        parent_class: str | None,
+    ) -> Class | None:
+        """Extract a ``given_definition`` as a Class with class_type='given'.
+
+        AST shape:
+            given_definition
+              'given'
+              identifier    ← name (may be absent for anonymous givens)
+              ':'
+              <type>
+              '='
+              <expr>
+        """
+        try:
+            name_node = node.child_by_field_name("name")
+            if name_node:
+                name = self._get_node_text(name_node)
+            else:
+                # Fall back to first identifier child.
+                name = next(
+                    (
+                        self._get_node_text(c)
+                        for c in node.children
+                        if c.type == "identifier"
+                    ),
+                    "anonymous_given",
+                )
+            return Class(
+                name=name,
+                start_line=node.start_point[0] + 1,
+                end_line=node.end_point[0] + 1,
+                raw_text=self._get_node_text(node),
+                language="scala",
+                class_type="given",
+                visibility="public",
+                package_name=self.current_package,
+                parent_class=parent_class,
+            )
+        except Exception as e:
+            log_error(f"Error extracting Scala given: {e}")
+            return None
+
+    def _extract_type_alias(
+        self,
+        node: tree_sitter.Node,
+        parent_class: str | None,
+    ) -> Class | None:
+        """Extract a ``type_definition`` as a Class with class_type='type_alias'.
+
+        AST shape:
+            type_definition
+              'type'
+              type_identifier   ← alias name
+              '='
+              <type>
+        """
+        try:
+            name = next(
+                (
+                    self._get_node_text(c)
+                    for c in node.children
+                    if c.type == "type_identifier"
+                ),
+                "unknown_type",
+            )
+            return Class(
+                name=name,
+                start_line=node.start_point[0] + 1,
+                end_line=node.end_point[0] + 1,
+                raw_text=self._get_node_text(node),
+                language="scala",
+                class_type="type_alias",
+                visibility="public",
+                package_name=self.current_package,
+                parent_class=parent_class,
+            )
+        except Exception as e:
+            log_error(f"Error extracting Scala type alias: {e}")
+            return None
 
     def _extract_function(self, node: tree_sitter.Node) -> Function | None:
         """Extract function definition (with body)"""


### PR DESCRIPTION
## Summary
- Scala `enum case` values now extracted as symbols with correct parent_class (#762)
- `given` and type alias constructs carry `parent_class` for accurate hierarchy (#764)
- Corpus count updated to 38 after new extraction coverage

## Test plan
- [ ] `uv run pytest tests/unit/ -q` passes

🤖 Generated with Claude Code