### PR TITLE
fix(go): normalize generic receivers

### DIFF
--- a/tests/unit/languages/test_go_bugs_749_750.py
+++ b/tests/unit/languages/test_go_bugs_749_750.py
@@ -214,6 +214,40 @@ func (p Pair[A, B]) First() interface{} {
         assert by_name["First"].receiver_type == "Pair"
 
 
+class TestGenericReceiverMultilineAndUnnamed:
+    """Generic receivers may be multiline or omit the receiver variable (#958)."""
+
+    SRC = """\
+package main
+
+type Stack[T any] struct {
+    items []T
+}
+
+func (s *Stack[
+    T,
+]) Clear() {
+    s.items = nil
+}
+
+func (*Stack[T]) Len() int {
+    return 0
+}
+"""
+
+    def test_multiline_generic_receiver_type_strips_type_params(self) -> None:
+        functions = _parse_and_extract(self.SRC)
+        by_name = {f.name: f for f in functions}
+        assert by_name["Clear"].receiver == "s"
+        assert by_name["Clear"].receiver_type == "*Stack"
+
+    def test_unnamed_generic_receiver_keeps_type(self) -> None:
+        functions = _parse_and_extract(self.SRC)
+        by_name = {f.name: f for f in functions}
+        assert by_name["Len"].receiver is None
+        assert by_name["Len"].receiver_type == "*Stack"
+
+
 class TestNonGenericReceiverUnchanged:
     """Existing non-generic receivers must not be affected by the fix."""
 
@@ -277,6 +311,21 @@ class TestExtractMethodReceiverRegex:
         recv, rtype = self._extract("(p Pair[A, B])")
         assert recv == "p"
         assert rtype == "Pair"
+
+    def test_value_generic_multiline(self) -> None:
+        recv, rtype = self._extract("(p Pair[\n    A, B,\n])")
+        assert recv == "p"
+        assert rtype == "Pair"
+
+    def test_unnamed_pointer_generic(self) -> None:
+        recv, rtype = self._extract("(*Stack[T])")
+        assert recv is None
+        assert rtype == "*Stack"
+
+    def test_unnamed_pointer_generic_multiline(self) -> None:
+        recv, rtype = self._extract("(*Stack[\n    T,\n])")
+        assert recv is None
+        assert rtype == "*Stack"
 
     def test_non_generic_pointer_unchanged(self) -> None:
         recv, rtype = self._extract("(c *Counter)")

--- a/tests/unit/languages/test_go_receiver_helpers_branches.py
+++ b/tests/unit/languages/test_go_receiver_helpers_branches.py
@@ -1,0 +1,318 @@
+"""Branch-level unit tests for the Go receiver-parsing helpers (#964).
+
+The full-parser tests in ``test_go_bugs_749_750.py`` exercise the common
+(AST) path, but several helper branches are only reachable from synthetic
+inputs:
+
+* ``_strip_generic_suffix`` — unbalanced brackets, the ``start is None``
+  fall-through, the empty-base case, and trailing whitespace.
+* ``_extract_receiver_from_text`` — the lightweight fake-node text fallback
+  (unnamed receiver, malformed/empty input, no-space type).
+* ``_extract_receiver_parts`` — the ``qualified_type`` branch and the
+  no-type-found ``return None, None``.
+* ``find_receiver_type_go`` / ``_normalize_go_receiver_type_for_graph`` —
+  the bracket-depth stripping branches, the pointer strip, and the
+  unbalanced/empty fall-throughs.
+
+All assertions pin exact return values (== / is), never loose bounds.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tree_sitter_analyzer.function_extraction import (
+    _normalize_go_receiver_type_for_graph,
+    find_receiver_type_go,
+)
+from tree_sitter_analyzer.languages._go_common_helpers import (
+    _extract_receiver_from_text,
+    _extract_receiver_parts,
+    _strip_generic_suffix,
+    extract_method_receiver,
+)
+
+
+# ---------------------------------------------------------------------------
+# Lightweight fake tree-sitter nodes (text-only) for the fallback paths.
+# ---------------------------------------------------------------------------
+class _FakeNode:
+    def __init__(
+        self, text: str, ntype: str = "x", children: list[_FakeNode] | None = None
+    ) -> None:
+        self._text = text
+        self.type = ntype
+        self.children = children or []
+
+    @property
+    def text(self) -> bytes:
+        return self._text.encode()
+
+
+class _FakeMethod:
+    """Minimal stand-in for a method_declaration node."""
+
+    def __init__(self, receiver_node: Any) -> None:
+        self._receiver = receiver_node
+        self.type = "method_declaration"
+
+    def child_by_field_name(self, name: str) -> Any:
+        return self._receiver if name == "receiver" else None
+
+
+def _gnt(node: Any) -> str:
+    text = node.text
+    return text.decode("utf-8") if isinstance(text, bytes) else str(text)
+
+
+# ---------------------------------------------------------------------------
+# _strip_generic_suffix
+# ---------------------------------------------------------------------------
+class TestStripGenericSuffix:
+    def test_plain_type_unchanged(self) -> None:
+        assert _strip_generic_suffix("T") == "T"
+
+    def test_pointer_generic_strips_param(self) -> None:
+        assert _strip_generic_suffix("*Stack[T]") == "*Stack"
+
+    def test_two_type_params_stripped(self) -> None:
+        assert _strip_generic_suffix("Pair[A, B]") == "Pair"
+        assert _strip_generic_suffix("Map[K,V]") == "Map"
+
+    def test_trailing_space_stripped(self) -> None:
+        # "T[K] " — trailing whitespace is skipped before the closing ']'.
+        assert _strip_generic_suffix("T[K] ") == "T"
+
+    def test_unbalanced_open_bracket_returned_verbatim(self) -> None:
+        # "T[" does not end in ']' -> early return of the raw text.
+        assert _strip_generic_suffix("T[") == "T["
+
+    def test_only_brackets_yields_none(self) -> None:
+        # "[T]" — matching '[' is at index 0, base becomes "" -> None.
+        assert _strip_generic_suffix("[T]") is None
+
+    def test_empty_input_yields_none(self) -> None:
+        assert _strip_generic_suffix("") is None
+
+    def test_no_bracket_close_only_returns_verbatim(self) -> None:
+        # "T]" / "Stack]]" have no '[' at all -> early "[" not in text return.
+        assert _strip_generic_suffix("T]") == "T]"
+        assert _strip_generic_suffix("Stack]]") == "Stack]]"
+
+    def test_unbalanced_start_none_fallthrough(self) -> None:
+        # "T[]]" has '[' and ends in ']' but the reverse scan never returns to
+        # depth 0 at the '[' -> ``start is None`` fall-through.
+        assert _strip_generic_suffix("T[]]") == "T[]]"
+
+
+# ---------------------------------------------------------------------------
+# _extract_receiver_from_text (the fake-node text fallback)
+# ---------------------------------------------------------------------------
+class TestExtractReceiverFromText:
+    def test_named_pointer_generic(self) -> None:
+        assert _extract_receiver_from_text("(p *Stack[T])") == ("p", "*Stack")
+
+    def test_unnamed_pointer_generic(self) -> None:
+        # "(*Stack[T])" — no receiver name, type only.
+        assert _extract_receiver_from_text("(*Stack[T])") == (None, "*Stack")
+
+    def test_empty_string(self) -> None:
+        assert _extract_receiver_from_text("") == (None, None)
+
+    def test_only_parens_whitespace(self) -> None:
+        assert _extract_receiver_from_text("(   )") == (None, None)
+
+    def test_without_surrounding_parens(self) -> None:
+        assert _extract_receiver_from_text("p *Stack[T]") == ("p", "*Stack")
+
+    def test_single_token_no_space(self) -> None:
+        # No space at depth 0 -> falls through to (None, stripped-type).
+        assert _extract_receiver_from_text("(noSpaceType)") == (None, "noSpaceType")
+
+    def test_two_param_generic_named(self) -> None:
+        assert _extract_receiver_from_text("( s Pair[A, B] )") == ("s", "Pair")
+
+
+# ---------------------------------------------------------------------------
+# extract_method_receiver — drives the fallback + None-receiver branches
+# ---------------------------------------------------------------------------
+class TestExtractMethodReceiver:
+    def test_none_receiver_node(self) -> None:
+        assert extract_method_receiver(_FakeMethod(None), _gnt) == (None, None)
+
+    def test_text_fallback_when_no_parameter_declaration_child(self) -> None:
+        # receiver node has only non-parameter_declaration children -> fallback.
+        rn = _FakeNode("(p *Stack[T])", ntype="parameter_list", children=[])
+        assert extract_method_receiver(_FakeMethod(rn), _gnt) == ("p", "*Stack")
+
+    def test_parameter_declaration_qualified_type(self) -> None:
+        # child_by_field_name -> a receiver node whose parameter_declaration
+        # child carries a qualified_type -> _extract_receiver_parts path.
+        qualified = _FakeNode("pkg.T", ntype="qualified_type")
+        ident = _FakeNode("s", ntype="identifier")
+        param = _FakeNode(
+            "s pkg.T", ntype="parameter_declaration", children=[ident, qualified]
+        )
+        rn = _FakeNode("(s pkg.T)", ntype="parameter_list", children=[param])
+        assert extract_method_receiver(_FakeMethod(rn), _gnt) == ("s", "pkg.T")
+
+
+# ---------------------------------------------------------------------------
+# _extract_receiver_parts — direct (qualified_type + no-type-found)
+# ---------------------------------------------------------------------------
+class TestExtractReceiverParts:
+    def test_qualified_type_with_generic_suffix_stripped(self) -> None:
+        ident = _FakeNode("s", ntype="identifier")
+        gen = _FakeNode("pkg.T[K]", ntype="generic_type")
+        param = _FakeNode(
+            "s pkg.T[K]", ntype="parameter_declaration", children=[ident, gen]
+        )
+        assert _extract_receiver_parts(param, _gnt) == ("s", "pkg.T")
+
+    def test_no_recognized_type_returns_none_none(self) -> None:
+        # Only an identifier, no type node -> receiver_type stays None.
+        ident = _FakeNode("s", ntype="identifier")
+        param = _FakeNode("s", ntype="parameter_declaration", children=[ident])
+        assert _extract_receiver_parts(param, _gnt) == (None, None)
+
+    def test_unrelated_child_is_skipped(self) -> None:
+        # A non-identifier, non-type child (e.g. a comment) is skipped, then the
+        # real type is picked up -> exercises the type-check ``in`` False branch.
+        comment = _FakeNode("/*x*/", ntype="comment")
+        ident = _FakeNode("s", ntype="identifier")
+        ti = _FakeNode("Counter", ntype="type_identifier")
+        param = _FakeNode(
+            "s Counter",
+            ntype="parameter_declaration",
+            children=[comment, ident, ti],
+        )
+        assert _extract_receiver_parts(param, _gnt) == ("s", "Counter")
+
+
+# ---------------------------------------------------------------------------
+# _normalize_go_receiver_type_for_graph
+# ---------------------------------------------------------------------------
+class TestNormalizeReceiverTypeForGraph:
+    def test_none_input(self) -> None:
+        assert _normalize_go_receiver_type_for_graph(None) is None
+
+    def test_empty_string(self) -> None:
+        assert _normalize_go_receiver_type_for_graph("") is None
+
+    def test_pointer_generic_strips_pointer_and_param(self) -> None:
+        # graph normalization also strips the leading '*'.
+        assert _normalize_go_receiver_type_for_graph("*Stack[T]") == "Stack"
+
+    def test_two_type_params(self) -> None:
+        assert _normalize_go_receiver_type_for_graph("Map[K,V]") == "Map"
+
+    def test_plain_type(self) -> None:
+        assert _normalize_go_receiver_type_for_graph("T") == "T"
+
+    def test_pointer_only(self) -> None:
+        assert _normalize_go_receiver_type_for_graph("*T") == "T"
+
+    def test_only_brackets_yields_none(self) -> None:
+        # "[T]" -> after stripping, base is empty -> None.
+        assert _normalize_go_receiver_type_for_graph("[T]") is None
+
+    def test_trailing_space(self) -> None:
+        assert _normalize_go_receiver_type_for_graph("Stack[T] ") == "Stack"
+
+    def test_unbalanced_open_bracket_returns_base(self) -> None:
+        # "Unbal[T" does not end in ']' -> base returned verbatim.
+        assert _normalize_go_receiver_type_for_graph("Unbal[T") == "Unbal[T"
+
+    def test_no_bracket_close_only_returns_base(self) -> None:
+        # "Stack]" has no '[' -> early "[" not in base return.
+        assert _normalize_go_receiver_type_for_graph("Stack]") == "Stack]"
+
+    def test_pointer_only_yields_none(self) -> None:
+        # "*" -> base empty after lstrip('*') -> None.
+        assert _normalize_go_receiver_type_for_graph("*") is None
+
+    def test_unbalanced_start_none_fallthrough(self) -> None:
+        # "T[]]" has '[' and ends in ']' but the reverse scan never balances
+        # to depth 0 -> final ``return base``.
+        assert _normalize_go_receiver_type_for_graph("T[]]") == "T[]]"
+
+
+# ---------------------------------------------------------------------------
+# find_receiver_type_go — non-method node + None guards
+# ---------------------------------------------------------------------------
+class TestFindReceiverTypeGo:
+    def test_none_node(self) -> None:
+        assert find_receiver_type_go(None) is None
+
+    def test_non_method_node(self) -> None:
+        assert (
+            find_receiver_type_go(_FakeNode("x", ntype="function_declaration")) is None
+        )
+
+    def test_no_receiver_field(self) -> None:
+        assert find_receiver_type_go(_FakeMethod(None)) is None
+
+    def test_qualified_type_receiver(self) -> None:
+        # parameter_declaration with a direct qualified_type sub -> normalized.
+        qualified = _FakeNode("pkg.T", ntype="qualified_type")
+        param = _FakeNode(
+            "s pkg.T", ntype="parameter_declaration", children=[qualified]
+        )
+        rn = _FakeNode("(s pkg.T)", ntype="parameter_list", children=[param])
+        assert find_receiver_type_go(_FakeMethod(rn)) == "pkg.T"
+
+    def test_generic_pointer_receiver_strips_pointer_and_param(self) -> None:
+        ptr = _FakeNode("*Stack[T]", ntype="pointer_type")
+        param = _FakeNode("s *Stack[T]", ntype="parameter_declaration", children=[ptr])
+        rn = _FakeNode("(s *Stack[T])", ntype="parameter_list", children=[param])
+        assert find_receiver_type_go(_FakeMethod(rn)) == "Stack"
+
+    def test_nested_leaf_type_identifier(self) -> None:
+        # sub node is not itself a type, but has a type_identifier leaf.
+        leaf = _FakeNode("Counter", ntype="type_identifier")
+        wrapper = _FakeNode("Counter", ntype="some_wrapper", children=[leaf])
+        param = _FakeNode(
+            "c Counter", ntype="parameter_declaration", children=[wrapper]
+        )
+        rn = _FakeNode("(c Counter)", ntype="parameter_list", children=[param])
+        assert find_receiver_type_go(_FakeMethod(rn)) == "Counter"
+
+    def test_no_parameter_declaration_returns_none(self) -> None:
+        rn = _FakeNode("()", ntype="parameter_list", children=[])
+        assert find_receiver_type_go(_FakeMethod(rn)) is None
+
+    def test_parameter_declaration_without_type_returns_none(self) -> None:
+        # parameter_declaration whose subs are neither types nor carry type
+        # leaves -> type_text stays None -> normalize(None) -> None -> next loop.
+        only_ident = _FakeNode("s", ntype="identifier")
+        param = _FakeNode("s", ntype="parameter_declaration", children=[only_ident])
+        rn = _FakeNode("(s)", ntype="parameter_list", children=[param])
+        assert find_receiver_type_go(_FakeMethod(rn)) is None
+
+    def test_non_matching_leaf_is_skipped(self) -> None:
+        # First sub has only a non-type leaf (skipped), second sub is the type.
+        bad_leaf = _FakeNode("x", ntype="comment")
+        wrapper = _FakeNode("x", ntype="some_wrapper", children=[bad_leaf])
+        ti = _FakeNode("Counter", ntype="type_identifier")
+        param = _FakeNode(
+            "c Counter",
+            ntype="parameter_declaration",
+            children=[wrapper, ti],
+        )
+        rn = _FakeNode("(c Counter)", ntype="parameter_list", children=[param])
+        assert find_receiver_type_go(_FakeMethod(rn)) == "Counter"
+
+    def test_first_param_decl_none_then_second_resolves(self) -> None:
+        # First parameter_declaration yields no type (normalized None) -> the
+        # outer loop continues to the second, which resolves.
+        empty_param = _FakeNode("", ntype="parameter_declaration", children=[])
+        ti = _FakeNode("Counter", ntype="type_identifier")
+        good_param = _FakeNode(
+            "c Counter", ntype="parameter_declaration", children=[ti]
+        )
+        rn = _FakeNode(
+            "(c Counter)",
+            ntype="parameter_list",
+            children=[empty_param, good_param],
+        )
+        assert find_receiver_type_go(_FakeMethod(rn)) == "Counter"

--- a/tests/unit/languages/test_go_receiver_serialization.py
+++ b/tests/unit/languages/test_go_receiver_serialization.py
@@ -51,6 +51,7 @@ def test_receiver_survives_api_serialization() -> None:
     inc = element_to_dict(funcs["Inc"])
     assert inc.get("receiver") == "c"
     assert inc.get("receiver_type") == "*Counter"
+    assert inc["is_abstract"] is False
     standalone = element_to_dict(funcs["Standalone"])
     # Function dataclass defaults receiver=None, so the field is always
     # present (as None) for non-methods — pin that exact behavior.

--- a/tests/unit/test_call_graph_ast_a.py
+++ b/tests/unit/test_call_graph_ast_a.py
@@ -284,11 +284,35 @@ class TestWalkTree:
         assert method_node is not None
         assert _find_receiver_type_go(method_node) == "Engine"
 
+    def test_find_receiver_type_go_generic_pointer(self):
+        source = "package main\n\ntype Stack[T any] struct{}\n\nfunc (s *Stack[T]) Push() {}\n"
+        root, src = _parse_source(source, "go")
+        method_node = next(c for c in root.children if c.type == "method_declaration")
+        assert _find_receiver_type_go(method_node) == "Stack"
+
+    def test_find_receiver_type_go_generic_multiline_pointer(self):
+        source = (
+            "package main\n\n"
+            "type Stack[T any] struct{}\n\n"
+            "func (s *Stack[\n"
+            "    T,\n"
+            "]) Clear() {}\n"
+        )
+        root, src = _parse_source(source, "go")
+        method_node = next(c for c in root.children if c.type == "method_declaration")
+        assert _find_receiver_type_go(method_node) == "Stack"
+
     def test_find_receiver_type_go_value_receiver(self):
         source = "package main\n\nfunc (e Engine) Run() {}\n"
         root, src = _parse_source(source, "go")
         method_node = next(c for c in root.children if c.type == "method_declaration")
         assert _find_receiver_type_go(method_node) == "Engine"
+
+    def test_find_receiver_type_go_unnamed_pointer_receiver(self):
+        source = "package main\n\ntype Counter struct{}\n\nfunc (*Counter) Run() {}\n"
+        root, src = _parse_source(source, "go")
+        method_node = next(c for c in root.children if c.type == "method_declaration")
+        assert _find_receiver_type_go(method_node) == "Counter"
 
     def test_find_receiver_type_go_none_for_non_method(self):
         assert _find_receiver_type_go(None) is None

--- a/tree_sitter_analyzer/_api_result_helpers.py
+++ b/tree_sitter_analyzer/_api_result_helpers.py
@@ -18,6 +18,7 @@ _OPTIONAL_ELEM_FIELDS = [
     "is_static",
     "is_constructor",
     "is_method",
+    "is_abstract",
     "complexity_score",
     "superclass",
     # Theme-C (2026-06-10): implements/mixins were collected by plugins but

--- a/tree_sitter_analyzer/function_extraction.py
+++ b/tree_sitter_analyzer/function_extraction.py
@@ -646,16 +646,69 @@ def find_receiver_type_go(node: Any) -> str | None:
     """Extract the receiver type from a Go method_declaration node."""
     if node is None or node.type != "method_declaration":
         return None
-    for child in node.children:
-        if child.type == "parameter_list":
-            for param in child.children:
-                for sub in param.children if hasattr(param, "children") else []:
-                    if sub.type in ("type_identifier", "generic_type", "pointer_type"):
-                        return _node_text_value(sub).lstrip("*")
-                    for leaf in sub.children if hasattr(sub, "children") else []:
-                        if leaf.type in ("type_identifier", "generic_type"):
-                            return _node_text_value(leaf).lstrip("*")
+
+    receiver_node = node.child_by_field_name("receiver")
+    if receiver_node is None:
+        return None
+
+    for child in receiver_node.children:
+        if child.type != "parameter_declaration":
+            continue
+
+        type_text = None
+        for sub in child.children if hasattr(child, "children") else []:
+            if sub.type in (
+                "type_identifier",
+                "generic_type",
+                "pointer_type",
+                "qualified_type",
+            ):
+                type_text = _node_text_value(sub)
+                break
+            for leaf in sub.children if hasattr(sub, "children") else []:
+                if leaf.type in (
+                    "type_identifier",
+                    "generic_type",
+                    "qualified_type",
+                ):
+                    type_text = _node_text_value(leaf)
+                    break
+            if type_text is not None:
+                break
+
+        normalized = _normalize_go_receiver_type_for_graph(type_text)
+        if normalized is not None:
+            return normalized
     return None
+
+
+def _normalize_go_receiver_type_for_graph(receiver_type: str | None) -> str | None:
+    """Normalize Go receiver type for class matching in call graphs."""
+    if not receiver_type:
+        return None
+
+    base = receiver_type.strip().lstrip("*").strip()
+    if not base:
+        return None
+    if "[" not in base:
+        return base
+
+    idx = len(base) - 1
+    while idx >= 0 and base[idx].isspace():
+        idx -= 1
+    if idx < 0 or base[idx] != "]":
+        return base
+
+    depth = 0
+    for i in range(idx, -1, -1):
+        if base[i] == "]":
+            depth += 1
+        elif base[i] == "[":
+            depth -= 1
+            if depth == 0:
+                stripped = base[:i].rstrip()
+                return stripped or None
+    return base
 
 
 def _node_text_value(node: Any) -> str:

--- a/tree_sitter_analyzer/languages/_go_common_helpers.py
+++ b/tree_sitter_analyzer/languages/_go_common_helpers.py
@@ -1,6 +1,5 @@
 """Shared helpers for Go AST extraction."""
 
-import re
 from collections.abc import Callable
 from typing import Any
 
@@ -65,20 +64,105 @@ def extract_method_receiver(
 ) -> tuple[str | None, str | None]:
     """Extract method receiver name and type.
 
-    Handles generic receivers such as ``(s *Stack[T])`` or ``(p Pair[A, B])``.
-    The type-parameter suffix ``[...]`` is stripped so that ``receiver_type``
-    returns the bare type name (e.g. ``"*Stack"`` instead of ``"*Stack[T]"``).
+    Handles AST-level receiver extraction and strips trailing generic type
+    parameters so type arguments are omitted. Pointer markers (``*``) are
+    preserved so ``receiver_type`` remains a Go receiver type (for example,
+    ``*Stack`` instead of ``Stack``).
     Bug #750.
     """
     receiver_node = node.child_by_field_name("receiver")
-    if receiver_node:
-        receiver_text = get_node_text(receiver_node)
-        # Match: open-paren, receiver-var, receiver-type (optional pointer),
-        # optional generic type-param list ``[...]``, close-paren.
-        match = re.search(r"\(\s*(\w+)\s+(\*?\w+)(?:\[.*?\])?\s*\)", receiver_text)
-        if match:
-            return match.group(1), match.group(2)
-    return None, None
+    if receiver_node is None:
+        return None, None
+
+    for child in receiver_node.children:
+        if child.type != "parameter_declaration":
+            continue
+        return _extract_receiver_parts(child, get_node_text)
+
+    # Unit tests use lightweight fake nodes that provide only `text`. Fall back to
+    # tolerant text parsing in that shape so helper behavior remains testable
+    # without constructing a full tree-sitter parameter node.
+    return _extract_receiver_from_text(get_node_text(receiver_node))
+
+
+def _extract_receiver_parts(
+    parameter_node: Any, get_node_text: Callable[..., str]
+) -> tuple[str | None, str | None]:
+    """Extract ``(name, normalized_type)`` from a Go ``parameter_declaration``."""
+    receiver_name = None
+    receiver_type = None
+
+    for child in parameter_node.children:
+        if child.type == "identifier" and receiver_name is None:
+            receiver_name = get_node_text(child)
+            continue
+        if child.type in (
+            "type_identifier",
+            "generic_type",
+            "pointer_type",
+            "qualified_type",
+        ):
+            receiver_type = _strip_generic_suffix(get_node_text(child))
+            break
+
+    if receiver_type is None:
+        return None, None
+    return receiver_name, receiver_type
+
+
+def _extract_receiver_from_text(receiver_text: str) -> tuple[str | None, str | None]:
+    """Parse a raw receiver tuple text like ``(p *Stack[T])``."""
+    text = (receiver_text or "").strip()
+    if not text:
+        return None, None
+    if text.startswith("(") and text.endswith(")"):
+        text = text[1:-1].strip()
+    if not text:
+        return None, None
+
+    depth = 0
+    for idx, ch in enumerate(text):
+        if ch == "[":
+            depth += 1
+        elif ch == "]":
+            depth = max(depth - 1, 0)
+        elif depth == 0 and ch.isspace():
+            name = text[:idx].strip()
+            tail = text[idx:].strip()
+            if not name:
+                break
+            return name, _strip_generic_suffix(tail)
+
+    return None, _strip_generic_suffix(text)
+
+
+def _strip_generic_suffix(receiver_type: str) -> str | None:
+    """Strip trailing Go type arguments like ``[T]`` or ``[A, B]``."""
+    text = (receiver_type or "").strip()
+    if not text or "[" not in text:
+        return text or None
+
+    idx = len(text) - 1
+    while idx >= 0 and text[idx].isspace():
+        idx -= 1
+    if idx < 0 or text[idx] != "]":
+        return text or None
+
+    depth = 0
+    start = None
+    for i in range(idx, -1, -1):
+        if text[i] == "]":
+            depth += 1
+        elif text[i] == "[":
+            depth -= 1
+            if depth == 0:
+                start = i
+                break
+    if start is None:
+        return text or None
+
+    base = text[:start].rstrip()
+    return base or None
 
 
 def go_visibility(name: str) -> str:


### PR DESCRIPTION
## Summary
- replace brittle Go receiver regex parsing with AST-first extraction plus a text fallback for helper tests
- support multiline generic receivers and unnamed receiver declarations
- normalize Go receiver types for call-graph class matching and expose `is_abstract` through API serialization

## Root Cause
Go receiver extraction depended on a single-line regex that required a receiver variable. The call-graph path separately stripped only `*`, leaving generic type arguments in class names, and the public API allowlist omitted `is_abstract`.

## Validation
- `uv run pytest tests/unit/languages/test_go_bugs_749_750.py tests/unit/test_call_graph_ast_a.py tests/unit/languages/test_go_receiver_serialization.py -q`
- `uv run pytest tests/unit/languages/test_go_receiver_serialization.py tests/unit/test_api_result_helpers.py tests/unit/test_call_graph_ast_a.py -q`
- `uv run pytest tests/unit/languages/test_go_bugs_749_750.py tests/unit/languages/test_go_receiver_serialization.py tests/unit/test_api_result_helpers.py tests/unit/test_call_graph_ast_a.py --cov=tree_sitter_analyzer --cov-report=json -q`
- `uv run python scripts/check_patch_coverage.py --base origin/develop --coverage-json coverage.json`
- `uv run pytest -q`

Closes #958