### PR TITLE
fix(uml): preserve truncation signals

### DIFF
--- a/tests/unit/test_uml_bugs_787_788_789.py
+++ b/tests/unit/test_uml_bugs_787_788_789.py
@@ -105,6 +105,33 @@ def test_sequence_truncated_false_when_no_paths(monkeypatch) -> None:
     assert diagram.truncated is False
 
 
+def test_sequence_truncated_true_when_path_search_clipped(monkeypatch) -> None:
+    """Bug #959: path-count truncation must survive when hops are not clipped."""
+
+    class FakeFinder:
+        def __init__(self, project_root, cache=None):
+            pass
+
+        def find_path(self, source_function, target_function, max_depth, max_paths):
+            assert max_paths == 1
+            return _make_call_path_result(
+                truncated=True,
+                hops=[{"caller": "entry", "callee": "service"}],
+            )
+
+    monkeypatch.setattr(uml_export, "CallPathFinder", FakeFinder)
+
+    exporter = UMLExporter("/repo", cache=object())
+    diagram = exporter.sequence_diagram(
+        source="entry",
+        target="service",
+        max_hops=12,
+        max_paths=1,
+    )
+
+    assert diagram.truncated is True
+
+
 # ── Bug #788 — activity empty Mermaid on None/empty body ──────────────────────
 
 
@@ -140,8 +167,8 @@ def test_activity_empty_body_returns_nonempty_mermaid(tmp_path) -> None:
         "empty_body must not produce a bare 'flowchart TD\\n' — "
         f"got: {diagram.mermaid!r}"
     )
-    # There should be a visible node or note in the mermaid
-    assert len(diagram.mermaid) > len("flowchart TD\n"), (
+    # Pin the exact length so deterministic Mermaid drift fails loudly.
+    assert len(diagram.mermaid) == 50, (
         f"mermaid is too short to be useful: {diagram.mermaid!r}"
     )
 
@@ -283,6 +310,26 @@ def test_include_tests_production_first_when_all_fit(monkeypatch) -> None:
     assert ("A", "B") in pairs, "Production edge A→B must be present"
     assert ("A", "TestX") in pairs, "Test edge A→TestX must also be present"
     assert diagram.truncated is False
+
+
+def test_include_tests_deduplicates_identical_production_and_test_edges(
+    monkeypatch,
+) -> None:
+    """Bug #959: prod/test allocation must not emit duplicate class edges."""
+    classes = [
+        {"name": "Base", "parents": [], "file": "src/base.py"},
+        {"name": "Worker", "parents": ["Base"], "file": "src/worker.py"},
+        {"name": "Worker", "parents": ["Base"], "file": "tests/unit/test_worker.py"},
+    ]
+    monkeypatch.setattr(uml_export, "ClassHierarchy", _make_hierarchy_factory(classes))
+
+    exporter = UMLExporter("/repo", cache=object())
+    diagram = exporter.class_diagram(max_edges=10, include_tests=True)
+
+    edge_signatures = [
+        (edge.source, edge.target, edge.label, edge.weight) for edge in diagram.edges
+    ]
+    assert edge_signatures == [("Base", "Worker", "inherits", 2)]
 
 
 def test_include_tests_false_excludes_test_classes_unchanged(monkeypatch) -> None:

--- a/tree_sitter_analyzer/uml_export.py
+++ b/tree_sitter_analyzer/uml_export.py
@@ -152,6 +152,26 @@ def _clamp_edges(
     return sorted_edges[:max_edges], len(sorted_edges) > max_edges
 
 
+def _dedupe_edges_by_signature(edges: Iterable[UMLEdge]) -> list[UMLEdge]:
+    """Deduplicate edges that share (source, target, label), preserving order."""
+    merged: dict[tuple[str, str, str], UMLEdge] = {}
+    order: list[tuple[str, str, str]] = []
+    for edge in edges:
+        key = (edge.source, edge.target, edge.label)
+        existing = merged.get(key)
+        if existing is None:
+            merged[key] = edge
+            order.append(key)
+        else:
+            merged[key] = UMLEdge(
+                source=edge.source,
+                target=edge.target,
+                label=edge.label,
+                weight=existing.weight + edge.weight,
+            )
+    return [merged[key] for key in order]
+
+
 def render_class_mermaid(
     nodes: Iterable[str],
     edges: Iterable[UMLEdge],
@@ -478,13 +498,14 @@ class UMLExporter:
             remaining = max_edges - len(prod_edges)
             if remaining > 0:
                 test_edges, test_truncated = _clamp_edges(raw_test_edges, remaining)
-                edges = prod_edges + test_edges
+                edges = _dedupe_edges_by_signature(prod_edges + test_edges)
                 truncated = prod_truncated or test_truncated
             else:
-                edges = prod_edges
+                edges = _dedupe_edges_by_signature(prod_edges)
                 truncated = prod_truncated or bool(raw_test_edges)
         else:
             edges, truncated = _clamp_edges(raw_edges, max_edges)
+            edges = _dedupe_edges_by_signature(edges)
         rendered_nodes = sorted(
             {n for edge in edges for n in (edge.source, edge.target)}
         )
@@ -602,6 +623,9 @@ class UMLExporter:
             hop.get("callee_file") for path in paths for hop in path.get("hops", [])
         )
         source_label = "call_path+synapse_resolved" if has_resolved else "call_path"
+        path_search_truncated = bool(
+            getattr(result, "truncated", False) and len(paths) >= max_paths
+        )
         return UMLDiagram(
             diagram_type="sequence",
             mermaid_type="sequenceDiagram",
@@ -612,7 +636,7 @@ class UMLExporter:
             # the rendered diagram (len > max_hops). result.truncated refers to
             # BFS path-count truncation, not hop truncation — inheriting it
             # causes truncated=True on a 2-node/1-edge complete path.
-            truncated=len(first_hops) > max_hops,
+            truncated=path_search_truncated or len(first_hops) > max_hops,
             metadata={
                 "source": source_label,
                 "analysis_kind": "static_approximation",


### PR DESCRIPTION
## Summary
- preserve real path-search truncation in sequence diagrams when `CallPathFinder` hit `max_paths`
- deduplicate class diagram edges after production/test allocation while preserving production-first ordering
- replace the loose Mermaid length assertion with an exact deterministic pin

## Root Cause
Sequence diagrams only considered rendered-hop clipping for `truncated`, so omitted paths were hidden when the first path fit within `max_hops`. Class diagrams deduped edges inside each clamp call, but identical production/test edges could still be concatenated afterward.

## Validation
- `uv run pytest tests/unit/test_uml_bugs_787_788_789.py -q`
- `uv run pytest tests/unit/cli/test_uml_export_cli_contract.py tests/unit/test_uml_export.py tests/unit/test_uml_export_p1.py tests/unit/test_uml_export_renderers.py -q`
- `uv run pytest tests/unit/test_uml_bugs_787_788_789.py tests/unit/cli/test_uml_export_cli_contract.py tests/unit/test_uml_export.py tests/unit/test_uml_export_p1.py tests/unit/test_uml_export_renderers.py --cov=tree_sitter_analyzer --cov-report=json -q`
- `uv run python scripts/check_patch_coverage.py --base origin/develop --coverage-json coverage.json`
- `uv run pytest -q`

Closes #959