### PR TITLE
fix(css,nav): SCSS var/comment filtering, test_map cross-language + helpers (#952)

### DIFF
--- a/tests/unit/formatters/test_css_formatter_coverage.py
+++ b/tests/unit/formatters/test_css_formatter_coverage.py
@@ -446,6 +446,29 @@ class TestHelperMethods:
         }
         assert formatter._is_rule(element) is True
 
+    def test_is_rule_with_style_element_object(self, formatter):
+        """Object (non-dict) path: a ``css_rule`` StyleElement with a selector IS a rule."""
+        element = StyleElement(
+            name=".box",
+            start_line=1,
+            end_line=3,
+            element_type="css_rule",
+            selector=".box",
+            element_class="class_selector",
+        )
+        assert formatter._is_rule(element) is True
+
+    def test_is_rule_with_style_element_object_variable(self, formatter):
+        """Object path: a Variable StyleElement (``$var``) is NOT a rule."""
+        element = StyleElement(
+            name="$primary",
+            start_line=1,
+            end_line=1,
+            element_type="variable",
+            selector="",
+        )
+        assert formatter._is_rule(element) is False
+
     def test_is_at_rule_with_dict(self, formatter):
         """Test _is_at_rule with dictionary element."""
         element = {"element_class": "at_rule"}

--- a/tests/unit/formatters/test_css_formatter_coverage.py
+++ b/tests/unit/formatters/test_css_formatter_coverage.py
@@ -427,6 +427,25 @@ class TestHelperMethods:
         element = {"element_type": "at_rule", "element_class": "at_rule"}
         assert formatter._is_rule(element) is False
 
+    def test_is_rule_excludes_scss_variable(self, formatter):
+        """Bug #790: SCSS Variable elements must NOT be counted as CSS rules."""
+        element = {"element_type": "variable", "name": "$primary", "selector": ""}
+        assert formatter._is_rule(element) is False
+
+    def test_is_rule_requires_selector_for_non_rule_type(self, formatter):
+        """A non-``rule`` element with no selector is not a rule (blank-row guard)."""
+        element = {"element_type": "css_rule", "element_class": "other", "selector": ""}
+        assert formatter._is_rule(element) is False
+
+    def test_is_rule_css_rule_with_selector(self, formatter):
+        """A ``css_rule`` StyleElement with a selector IS a rule."""
+        element = {
+            "element_type": "css_rule",
+            "element_class": "layout",
+            "selector": ".box",
+        }
+        assert formatter._is_rule(element) is True
+
     def test_is_at_rule_with_dict(self, formatter):
         """Test _is_at_rule with dictionary element."""
         element = {"element_class": "at_rule"}

--- a/tests/unit/languages/test_css_plugin.py
+++ b/tests/unit/languages/test_css_plugin.py
@@ -838,6 +838,29 @@ class TestScssVariableExtraction:
         names = [v.name for v in results]
         assert names == ["$live"]
 
+    def test_extract_scss_variables_literal_slash_star_in_string(self):
+        """Bug #967: a literal ``/*`` inside a quoted value must NOT open a comment.
+
+        ``$glob: "src/*";`` contains ``/*`` with no same-line ``*/``. The naive
+        raw-line scan set ``in_block_comment`` and silently dropped every
+        following declaration. The string-aware scan must keep BOTH variables.
+        """
+        from tree_sitter_analyzer.languages.css_plugin import _extract_scss_variables
+
+        content = '$glob: "src/*";\n$color: red;\n'
+        results = _extract_scss_variables("dummy.scss", content)
+        names = [v.name for v in results]
+        assert names == ["$glob", "$color"]
+
+    def test_extract_scss_variables_single_quoted_slash_star(self):
+        """A single-quoted ``'a/*b'`` literal also must not open a block comment."""
+        from tree_sitter_analyzer.languages.css_plugin import _extract_scss_variables
+
+        content = "$path: 'a/*b';\n$size: 1rem;\n"
+        results = _extract_scss_variables("dummy.scss", content)
+        names = [v.name for v in results]
+        assert names == ["$path", "$size"]
+
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/unit/languages/test_css_plugin.py
+++ b/tests/unit/languages/test_css_plugin.py
@@ -816,6 +816,28 @@ class TestScssVariableExtraction:
         assert results[0].name == "$color"
         assert results[0].start_line == 1
 
+    def test_extract_scss_variables_skips_block_comments(self):
+        """Bug #790: ``$var`` inside a ``/* ... */`` block comment is skipped.
+
+        A commented-out declaration must NOT yield a phantom Variable, whether
+        the comment spans multiple lines or sits inline on a single line.
+        """
+        from tree_sitter_analyzer.languages.css_plugin import _extract_scss_variables
+
+        content = "$live: #fff;\n/*\n$old: red;\n$older: blue;\n*/\n$also_live: 1rem;\n"
+        results = _extract_scss_variables("dummy.scss", content)
+        names = [v.name for v in results]
+        assert names == ["$live", "$also_live"]
+
+    def test_extract_scss_variables_skips_inline_block_comment(self):
+        """A single-line ``/* $old: red; */`` block comment yields no Variable."""
+        from tree_sitter_analyzer.languages.css_plugin import _extract_scss_variables
+
+        content = "/* $old: red; */\n$live: #fff;\n"
+        results = _extract_scss_variables("dummy.scss", content)
+        names = [v.name for v in results]
+        assert names == ["$live"]
+
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/unit/mcp/tools/test_nav_facade_test_map.py
+++ b/tests/unit/mcp/tools/test_nav_facade_test_map.py
@@ -634,3 +634,163 @@ async def test_test_map_excludes_non_test_prefixed_public_helpers() -> None:
     assert result["edge_count"] == 1
     assert result["unique_function_count"] == 1
     assert result["test_functions"] == ["tests/test_c.py::test_scenario"]
+
+
+# ---------------------------------------------------------------------------
+# 10. #807 cross-language: non-Python test callers must NOT be dropped by the
+#     pytest ``test_`` name filter (Go TestFoo, Java shouldHandleFoo, JS .test.ts)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_test_map_preserves_go_test_callers() -> None:
+    """Go ``TestFoo`` in a ``*_test.go`` file is a valid test caller (#807).
+
+    pytest's ``test_`` rule is Python-specific. Go's convention is ``TestXxx``
+    in ``*_test.go`` — applying the pytest filter wrongly dropped it.
+    """
+    facade = build_nav_facade(project_root=None)
+    impact_inner = _get_impact_inner(facade)
+
+    target_fn = _make_func("Handle", "pkg/server.go", language="go")
+    go_test = _make_func("TestHandle", "pkg/server_test.go", 10, language="go")
+
+    mock_graph = MagicMock()
+    mock_graph.resolve_targets.return_value = [target_fn]
+    mock_graph.caller_refs_of.return_value = [go_test]
+    mock_graph.build = MagicMock()
+    impact_inner._call_graph = mock_graph
+
+    result = await facade.execute(
+        {"action": "test_map", "symbol": "Handle", "output_format": "json"}
+    )
+
+    assert result["success"] is True
+    assert result["edge_count"] == 1
+    assert result["unique_function_count"] == 1
+    assert result["test_functions"] == ["pkg/server_test.go::TestHandle"]
+
+
+@pytest.mark.asyncio
+async def test_test_map_preserves_js_and_java_test_callers() -> None:
+    """JS ``*.test.ts`` and Java test-tree callers are preserved (#807).
+
+    Java ``shouldHandleFoo`` lives under ``src/test/`` and JS specs are
+    ``*.test.ts`` — neither matches the pytest ``test_`` rule, but both are
+    valid test entry points for their language.
+    """
+    facade = build_nav_facade(project_root=None)
+    impact_inner = _get_impact_inner(facade)
+
+    target_fn = _make_func("render", "src/render.ts", language="typescript")
+    js_test = _make_func(
+        "renders correctly", "src/render.test.ts", 4, language="typescript"
+    )
+    java_test = _make_func(
+        "shouldHandleFoo", "src/test/java/FooTest.java", 12, language="java"
+    )
+
+    mock_graph = MagicMock()
+    mock_graph.resolve_targets.return_value = [target_fn]
+    mock_graph.caller_refs_of.return_value = [js_test, java_test]
+    mock_graph.build = MagicMock()
+    impact_inner._call_graph = mock_graph
+
+    result = await facade.execute(
+        {"action": "test_map", "symbol": "render", "output_format": "json"}
+    )
+
+    assert result["success"] is True
+    assert result["edge_count"] == 2
+    assert result["unique_function_count"] == 2
+    assert result["test_functions"] == [
+        "src/render.test.ts::renders correctly",
+        "src/test/java/FooTest.java::shouldHandleFoo",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 11. #807 helper resolution: walk up ONE hop from a non-collectible Python
+#     helper (``_run``) to the ``test_*`` function that drives it.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_test_map_walks_up_one_hop_from_helper_to_test() -> None:
+    """``test_foo`` → ``_run`` → prod fn: the test_* caller is recovered (#807).
+
+    The production function is only reached via the ``_run`` helper, so the
+    direct caller is the non-collectible ``_run``. The route walks up one hop
+    to ``test_foo`` so the function is not reported as uncovered.
+    """
+    facade = build_nav_facade(project_root=None)
+    impact_inner = _get_impact_inner(facade)
+
+    target_fn = _make_func("prod_fn", "src/prod.py")
+    helper = _make_func("_run", "tests/test_helpers.py", 5)
+    real_test = _make_func("test_foo", "tests/test_helpers.py", 20)
+
+    def _callers(func: FunctionRef):
+        # prod_fn is called ONLY by _run; _run is called by test_foo.
+        if func.name == "prod_fn":
+            return [helper]
+        if func.name == "_run":
+            return [real_test]
+        return []
+
+    mock_graph = MagicMock()
+    mock_graph.resolve_targets.return_value = [target_fn]
+    mock_graph.caller_refs_of.side_effect = _callers
+    mock_graph.build = MagicMock()
+    impact_inner._call_graph = mock_graph
+
+    result = await facade.execute(
+        {"action": "test_map", "symbol": "prod_fn", "output_format": "json"}
+    )
+
+    assert result["success"] is True
+    assert result["edge_count"] == 1
+    assert result["unique_function_count"] == 1
+    assert result["test_functions"] == ["tests/test_helpers.py::test_foo"]
+
+
+@pytest.mark.asyncio
+async def test_test_map_walk_up_capped_at_one_hop() -> None:
+    """The helper walk-up is capped at ONE hop — a 2-hop chain is NOT followed.
+
+    ``prod_fn`` → ``_inner`` → ``_outer`` → ``test_foo``: only one hop up from
+    ``_inner`` is taken, reaching ``_outer`` (non-collectible) and stopping.
+    ``test_foo`` two hops away is NOT recovered.
+    """
+    facade = build_nav_facade(project_root=None)
+    impact_inner = _get_impact_inner(facade)
+
+    target_fn = _make_func("prod_fn", "src/prod.py")
+    inner = _make_func("_inner", "tests/test_chain.py", 3)
+    outer = _make_func("_outer", "tests/test_chain.py", 8)
+    real_test = _make_func("test_foo", "tests/test_chain.py", 30)
+
+    def _callers(func: FunctionRef):
+        if func.name == "prod_fn":
+            return [inner]
+        if func.name == "_inner":
+            return [outer]
+        if func.name == "_outer":
+            return [real_test]
+        return []
+
+    mock_graph = MagicMock()
+    mock_graph.resolve_targets.return_value = [target_fn]
+    mock_graph.caller_refs_of.side_effect = _callers
+    mock_graph.build = MagicMock()
+    impact_inner._call_graph = mock_graph
+
+    result = await facade.execute(
+        {"action": "test_map", "symbol": "prod_fn", "output_format": "json"}
+    )
+
+    assert result["success"] is True
+    # No collectible test reachable within one hop → nothing recorded.
+    assert result["edge_count"] == 0
+    assert result["unique_function_count"] == 0
+    assert result["test_functions"] == []

--- a/tests/unit/mcp/tools/test_nav_facade_test_map.py
+++ b/tests/unit/mcp/tools/test_nav_facade_test_map.py
@@ -440,6 +440,52 @@ async def test_test_map_edge_count_vs_unique_function_count_divergence() -> None
     assert result["test_functions"] == ["tests/test_shared.py::test_shared_behaviour"]
 
 
+@pytest.mark.asyncio
+async def test_test_map_shared_helper_edge_count_counts_both_targets() -> None:
+    """Two targets share ONE helper called by ONE test → edge_count==2 (#967).
+
+    ``fn_a`` and ``fn_b`` are each reached only via the non-collectible helper
+    ``_setup``; ``_setup`` is called by a single ``test_shared``. Each
+    (target, helper→test) pair is a genuine coverage edge, so edge_count must be
+    2 even though ``test_shared`` appears once in test_functions. Previously the
+    global dedupe branch fired before the second target's edge was counted,
+    undercounting edge_count to 1.
+    """
+    facade = build_nav_facade(project_root=None)
+    impact_inner = _get_impact_inner(facade)
+
+    target_a = _make_func("fn_a", "src/mod_a.py")
+    target_b = _make_func("fn_b", "src/mod_b.py")
+    helper = _make_func("_setup", "tests/test_shared.py", 5)
+    real_test = _make_func("test_shared", "tests/test_shared.py", 20)
+
+    def _callers(func: FunctionRef):
+        # Both fn_a and fn_b are called ONLY by the shared _setup helper;
+        # _setup is called by the single test_shared function.
+        if func.name in ("fn_a", "fn_b"):
+            return [helper]
+        if func.name == "_setup":
+            return [real_test]
+        return []
+
+    mock_graph = MagicMock()
+    mock_graph.resolve_targets.return_value = [target_a, target_b]
+    mock_graph.caller_refs_of.side_effect = _callers
+    mock_graph.build = MagicMock()
+    impact_inner._call_graph = mock_graph
+
+    result = await facade.execute(
+        {"action": "test_map", "symbol": "fn_a", "output_format": "json"}
+    )
+
+    assert result["success"] is True
+    # Two genuine coverage edges: (fn_a → test_shared), (fn_b → test_shared).
+    assert result["edge_count"] == 2
+    # The test function is deduped in the SET — appears exactly once.
+    assert result["unique_function_count"] == 1
+    assert result["test_functions"] == ["tests/test_shared.py::test_shared"]
+
+
 # ---------------------------------------------------------------------------
 # 8. P3 output_format threading — TOON / JSON
 # ---------------------------------------------------------------------------
@@ -669,6 +715,49 @@ async def test_test_map_preserves_go_test_callers() -> None:
     assert result["edge_count"] == 1
     assert result["unique_function_count"] == 1
     assert result["test_functions"] == ["pkg/server_test.go::TestHandle"]
+
+
+@pytest.mark.asyncio
+async def test_test_map_go_helper_walks_up_to_test_func() -> None:
+    """Go helper ``setupServer`` is NOT a test func → walk up to ``TestServer`` (#967).
+
+    A direct caller in ``*_test.go`` whose name does not match Go's
+    ``Test``/``Benchmark``/``Example``/``Fuzz`` convention (e.g. ``setupServer``)
+    is a helper that ``go test`` never runs directly. It must be treated like a
+    Python ``_run`` helper: the route walks up ONE hop to the convention-matching
+    ``TestServer`` that calls it. The helper itself must NOT be recorded.
+    """
+    facade = build_nav_facade(project_root=None)
+    impact_inner = _get_impact_inner(facade)
+
+    target_fn = _make_func("Handle", "pkg/server.go", language="go")
+    helper = _make_func("setupServer", "pkg/server_test.go", 5, language="go")
+    real_test = _make_func("TestServer", "pkg/server_test.go", 20, language="go")
+
+    def _callers(func: FunctionRef):
+        # Handle is called ONLY by setupServer; setupServer by TestServer.
+        if func.name == "Handle":
+            return [helper]
+        if func.name == "setupServer":
+            return [real_test]
+        return []
+
+    mock_graph = MagicMock()
+    mock_graph.resolve_targets.return_value = [target_fn]
+    mock_graph.caller_refs_of.side_effect = _callers
+    mock_graph.build = MagicMock()
+    impact_inner._call_graph = mock_graph
+
+    result = await facade.execute(
+        {"action": "test_map", "symbol": "Handle", "output_format": "json"}
+    )
+
+    assert result["success"] is True
+    assert result["edge_count"] == 1
+    assert result["unique_function_count"] == 1
+    # The helper is excluded; only the TestXxx entry point is reported.
+    assert result["test_functions"] == ["pkg/server_test.go::TestServer"]
+    assert all("setupServer" not in fn for fn in result["test_functions"])
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcp/tools/test_nav_facade_test_map.py
+++ b/tests/unit/mcp/tools/test_nav_facade_test_map.py
@@ -16,7 +16,14 @@ import pytest
 
 from tree_sitter_analyzer.call_graph import FunctionRef
 from tree_sitter_analyzer.mcp.tools.codegraph_impact_tool import CodeGraphImpactTool
-from tree_sitter_analyzer.mcp.tools.nav_facade import _MAX_TEST_MAP, build_nav_facade
+from tree_sitter_analyzer.mcp.tools.nav_facade import (
+    _MAX_TEST_MAP,
+    _is_collectible_caller,
+    _is_go_test_func,
+    _is_java_test_method,
+    _is_js_test_func,
+    build_nav_facade,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -883,3 +890,102 @@ async def test_test_map_walk_up_capped_at_one_hop() -> None:
     assert result["edge_count"] == 0
     assert result["unique_function_count"] == 0
     assert result["test_functions"] == []
+
+
+# ---------------------------------------------------------------------------
+# 12. Per-language test-name helpers — direct unit coverage of every branch
+#     (#967). Each helper is a pure predicate; assert the exact boolean.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_test_map_walk_up_skips_helper_parent_in_non_test_file() -> None:
+    """Walk-up ignores a helper's parent that lives in a NON-test file (#967).
+
+    ``prod_fn`` is reached only via the test-file helper ``_run``; ``_run`` is
+    itself called from a PRODUCTION file (``src/driver.py``), not a test. The
+    one-hop walk-up must skip that non-test parent, so no coverage edge is
+    recorded.
+    """
+    facade = build_nav_facade(project_root=None)
+    impact_inner = _get_impact_inner(facade)
+
+    target_fn = _make_func("prod_fn", "src/prod.py")
+    helper = _make_func("_run", "tests/test_helpers.py", 5)
+    prod_caller = _make_func("driver", "src/driver.py", 20)
+
+    def _callers(func: FunctionRef):
+        # prod_fn called only by the test-file helper _run; _run called only
+        # from a production (non-test) file.
+        if func.name == "prod_fn":
+            return [helper]
+        if func.name == "_run":
+            return [prod_caller]
+        return []
+
+    mock_graph = MagicMock()
+    mock_graph.resolve_targets.return_value = [target_fn]
+    mock_graph.caller_refs_of.side_effect = _callers
+    mock_graph.build = MagicMock()
+    impact_inner._call_graph = mock_graph
+
+    result = await facade.execute(
+        {"action": "test_map", "symbol": "prod_fn", "output_format": "json"}
+    )
+
+    assert result["success"] is True
+    # The only helper parent is in a non-test file → skipped, nothing recorded.
+    assert result["edge_count"] == 0
+    assert result["unique_function_count"] == 0
+    assert result["test_functions"] == []
+
+
+def test_is_go_test_func_accepts_test_and_benchmark_example_fuzz() -> None:
+    """Go test entry-point prefixes followed by uppercase / empty → True."""
+    assert _is_go_test_func("TestHandle") is True
+    assert _is_go_test_func("BenchmarkParse") is True
+    assert _is_go_test_func("ExampleServer") is True
+    assert _is_go_test_func("FuzzDecode") is True
+    # Bare prefix with no suffix is a valid Go example/test name.
+    assert _is_go_test_func("Example") is True
+
+
+def test_is_go_test_func_rejects_lowercase_suffix_and_non_prefix() -> None:
+    """``Testing``-style lowercase suffix and plain helpers → False."""
+    # Starts with ``Test`` but suffix is lowercase alpha → not a test func.
+    assert _is_go_test_func("Testing") is False
+    # Lowercase helper with no recognised prefix → False.
+    assert _is_go_test_func("setupServer") is False
+
+
+def test_is_js_test_func_whitespace_description_is_test() -> None:
+    """A spec description containing whitespace → True (no prefix check)."""
+    assert _is_js_test_func("renders correctly") is True
+
+
+def test_is_js_test_func_known_prefixes_are_tests() -> None:
+    """``test``/``it``/``should``/``when``/``describe`` prefixes → True."""
+    assert _is_js_test_func("testRender") is True
+    assert _is_js_test_func("itWorks") is True
+    assert _is_js_test_func("shouldRender") is True
+    assert _is_js_test_func("whenClicked") is True
+    assert _is_js_test_func("describeFlow") is True
+
+
+def test_is_js_test_func_bare_camelcase_helper_is_not_test() -> None:
+    """A bare camelCase / underscore helper identifier → False (walk up)."""
+    assert _is_js_test_func("mountComponent") is False
+    assert _is_js_test_func("_helper") is False
+
+
+def test_is_java_test_method_public_vs_private() -> None:
+    """Any public (non-underscore) Java method → True; ``_``-leading → False."""
+    assert _is_java_test_method("shouldHandleFoo") is True
+    assert _is_java_test_method("_privateHelper") is False
+
+
+def test_is_collectible_caller_unknown_language_accepts() -> None:
+    """A non-Python file with no recognised convention → accept the caller."""
+    assert _is_collectible_caller("src/mod.rb", "anything", "ruby") is True
+    # No language hint and an unrecognised extension also accepts.
+    assert _is_collectible_caller("src/mod.xyz", "whatever", "") is True

--- a/tree_sitter_analyzer/formatters/css_formatter.py
+++ b/tree_sitter_analyzer/formatters/css_formatter.py
@@ -382,15 +382,32 @@ class CSSFormatter(BaseFormatter):
 
     # Helper methods for extracting data from elements (handles both dict and object)
     def _is_rule(self, element: Any) -> bool:
-        """Check if element is a CSS rule."""
+        """Check if element is a CSS rule.
+
+        SCSS ``$variable`` declarations are emitted as ``Variable`` elements
+        (``element_type == "variable"``) with no selector. They must NOT be
+        counted as CSS rules — doing so inflates rule counts and produces
+        blank-selector rows. Variables and selector-less non-rule elements
+        are excluded.
+        """
         if isinstance(element, dict):
             element_type = element.get("element_type", "")
             element_class = element.get("element_class", "")
+            selector = element.get("selector", "")
         else:
             element_type = getattr(element, "element_type", "")
             element_class = getattr(element, "element_class", "")
+            selector = getattr(element, "selector", "")
 
-        return bool(element_type == "rule" or element_class != "at_rule")
+        # SCSS ``$var`` declarations surface as Variable elements — never rules.
+        if element_type == "variable":
+            return False
+        # An element explicitly typed as a rule is always a rule.
+        if element_type == "rule":
+            return True
+        # Otherwise it's a rule only if it is a non-at-rule WITH a selector,
+        # so blank-selector / non-style elements are not miscounted.
+        return bool(element_class != "at_rule" and selector)
 
     def _is_at_rule(self, element: Any) -> bool:
         """Check if element is an at-rule."""

--- a/tree_sitter_analyzer/languages/css_plugin.py
+++ b/tree_sitter_analyzer/languages/css_plugin.py
@@ -51,7 +51,20 @@ def _extract_scss_variables(file_path: str, content: str) -> list[Variable]:
     lines = content.splitlines()
     seen: set[str] = set()
     variables: list[Variable] = []
+    in_block_comment = False
     for lineno_0, line in enumerate(lines):
+        # Track ``/* ... */`` block comments so commented-out declarations
+        # like ``/* $old: red; */`` are not picked up as phantom variables.
+        if in_block_comment:
+            close_idx = line.find("*/")
+            if close_idx == -1:
+                continue
+            in_block_comment = False
+            line = line[close_idx + 2 :]
+        open_idx = line.find("/*")
+        if open_idx != -1 and "*/" not in line[open_idx:]:
+            in_block_comment = True
+            line = line[:open_idx]
         m = _SCSS_VAR_RE.match(line)
         if not m:
             continue

--- a/tree_sitter_analyzer/languages/css_plugin.py
+++ b/tree_sitter_analyzer/languages/css_plugin.py
@@ -36,6 +36,34 @@ logger = logging.getLogger(__name__)
 _SCSS_VAR_RE = re.compile(r"^\s*(\$[\w-]+)\s*:", re.MULTILINE)
 
 
+def _blank_quoted_ranges(line: str) -> str:
+    """Replace the contents of quoted strings with spaces (markers excluded).
+
+    A literal ``/*`` inside an SCSS value like ``$glob: "src/*";`` must NOT be
+    treated as the start of a block comment (Bug #967). We blank out single- and
+    double-quoted ranges before scanning for ``/*``/``*/`` markers, preserving
+    overall length so column offsets stay valid for the comment scan. Quote
+    characters themselves are kept; only their interior is blanked.
+    """
+    out: list[str] = []
+    quote: str | None = None
+    for ch in line:
+        if quote is None:
+            if ch in ('"', "'"):
+                quote = ch
+                out.append(ch)
+            else:
+                out.append(ch)
+        else:
+            if ch == quote:
+                quote = None
+                out.append(ch)
+            else:
+                # Blank the interior so embedded /* or */ is not seen as a marker.
+                out.append(" ")
+    return "".join(out)
+
+
 def _extract_scss_variables(file_path: str, content: str) -> list[Variable]:
     """Return a ``Variable`` element for every SCSS ``$variable`` declaration.
 
@@ -55,14 +83,20 @@ def _extract_scss_variables(file_path: str, content: str) -> list[Variable]:
     for lineno_0, line in enumerate(lines):
         # Track ``/* ... */`` block comments so commented-out declarations
         # like ``/* $old: red; */`` are not picked up as phantom variables.
+        # Comment markers are detected on a copy with quoted-string interiors
+        # blanked, so a literal ``/*`` inside a value like ``$glob: "src/*";``
+        # does not falsely open a block comment (Bug #967). Offsets are
+        # length-preserving, so indices map back onto the real ``line``.
+        scan = _blank_quoted_ranges(line)
         if in_block_comment:
-            close_idx = line.find("*/")
+            close_idx = scan.find("*/")
             if close_idx == -1:
                 continue
             in_block_comment = False
             line = line[close_idx + 2 :]
-        open_idx = line.find("/*")
-        if open_idx != -1 and "*/" not in line[open_idx:]:
+            scan = scan[close_idx + 2 :]
+        open_idx = scan.find("/*")
+        if open_idx != -1 and "*/" not in scan[open_idx:]:
             in_block_comment = True
             line = line[:open_idx]
         m = _SCSS_VAR_RE.match(line)

--- a/tree_sitter_analyzer/mcp/tools/nav_facade.py
+++ b/tree_sitter_analyzer/mcp/tools/nav_facade.py
@@ -70,18 +70,98 @@ def _is_python_file(file_path: str) -> bool:
     return file_path.endswith(".py")
 
 
-def _is_collectible_caller(file_path: str, name: str) -> bool:
+def _is_go_test_func(name: str) -> bool:
+    """True for Go test entry points: ``TestXxx``/``BenchmarkXxx``/``ExampleXxx``/``FuzzXxx``.
+
+    ``go test`` runs only top-level functions whose name starts with one of
+    these four prefixes followed by an uppercase letter (or nothing, e.g.
+    ``Example``). A bare ``Test`` with no suffix is also valid. Helpers like
+    ``setupServer`` are NOT run directly by ``go test`` and must walk up.
+    """
+    for prefix in ("Test", "Benchmark", "Example", "Fuzz"):
+        if name.startswith(prefix):
+            rest = name[len(prefix) :]
+            # ``TestFoo`` (uppercase suffix) or bare ``Test``/``Example`` are
+            # collected; ``Testing``-style lowercase suffixes are not test funcs
+            # per the gotest convention (suffix must start uppercase or be empty).
+            if rest == "" or rest[0].isupper() or not rest[0].isalpha():
+                return True
+    return False
+
+
+def _is_js_test_func(name: str) -> bool:
+    """Heuristic for JS/TS test functions inside a test file.
+
+    JS/TS test runners (jest/vitest/mocha) register cases via ``test(...)`` /
+    ``it(...)`` callbacks whose recorded name is the spec description (e.g.
+    ``renders correctly``) rather than a function identifier. The call graph
+    surfaces those descriptions as the caller ``name``. We treat any name that
+    is NOT a plain private-helper identifier as a test entry point: i.e. accept
+    unless it looks like a bare ``_helper``/``camelCaseHelper`` identifier.
+    A name containing whitespace is a spec description → always a test.
+    """
+    if " " in name:
+        return True
+    # ``test``/``it``/``should``/``when`` prefixed identifiers are test-like.
+    lowered = name.lower()
+    if lowered.startswith(("test", "it", "should", "when", "describe")):
+        return True
+    # A bare identifier (e.g. ``setup``, ``_helper``, ``mountComponent``) is a
+    # helper, not a test entry point → defer to the walk-up.
+    return False
+
+
+def _is_java_test_method(name: str) -> bool:
+    """Heuristic for JUnit test methods (annotation-based, no name rule).
+
+    JUnit identifies tests by the ``@Test`` annotation, not by name, so there
+    is no reliable name convention. We accept the common BDD-style prefixes
+    (``test*``/``should*``/``when*``) AND any other public (non-underscore)
+    method as a reasonable heuristic — JUnit test methods are public and the
+    call graph only surfaces methods physically inside the test file. A private
+    helper (leading underscore — rare in Java but possible in generated code)
+    defers to the walk-up.
+
+    NOTE (lead, correct if wrong): chose "accept any public method" over a
+    strict prefix list because @Test names are arbitrary (``shouldHandleFoo``,
+    ``rendersOnInit``); a strict list would drop valid tests. Underscore-leading
+    names are the only ones treated as helpers.
+    """
+    return not name.startswith("_")
+
+
+def _is_collectible_caller(file_path: str, name: str, language: str = "") -> bool:
     """Decide whether a test-file caller is an accepted test entry point.
 
-    The pytest ``test_`` name rule is Python-specific. Go (``TestFoo``),
-    Java (``shouldHandleFoo``), and JS/TS (``*.test.ts``) use different
-    naming conventions, so applying the pytest filter to them drops valid
-    cross-language test callers (Bug #807). For non-Python files we trust
-    ``is_test_file`` (already checked by the caller) and accept the caller
-    without a Python-style name filter.
+    The pytest ``test_`` name rule is Python-specific. Other languages use
+    different conventions, so applying the pytest filter to them drops valid
+    cross-language test callers — but accepting EVERY function in a non-Python
+    test file over-accepts helpers (e.g. a Go ``setupServer`` that ``go test``
+    never runs directly), bypassing the 1-hop walk-up (Bug #807 follow-up).
+
+    Per-language convention:
+      - Python: pytest ``test_`` prefix (module funcs and methods).
+      - Go: ``TestXxx``/``BenchmarkXxx``/``ExampleXxx``/``FuzzXxx``.
+      - JS/TS: spec descriptions / ``test``/``it``/``should``/``when`` names.
+      - Java/JUnit: any public (non-underscore) method (annotation-based).
+      - Unknown language: accept (no convention to apply).
+
+    A caller that does NOT match its language convention is treated as a
+    non-collectible helper, so the caller code applies the SAME 1-hop walk-up
+    used for Python helpers to find the convention-matching test above it.
     """
     if _is_python_file(file_path):
         return _is_pytest_collectible(name)
+    lang = (language or "").lower()
+    if lang == "go" or file_path.endswith(".go"):
+        return _is_go_test_func(name)
+    if lang in ("javascript", "typescript", "js", "ts", "jsx", "tsx") or (
+        file_path.endswith((".js", ".ts", ".jsx", ".tsx", ".mjs", ".cjs"))
+    ):
+        return _is_js_test_func(name)
+    if lang == "java" or file_path.endswith(".java"):
+        return _is_java_test_method(name)
+    # Unknown language with no recognised convention → accept the caller.
     return True
 
 
@@ -357,43 +437,65 @@ def build_nav_facade(project_root: str | None = None) -> FacadeTool:
         test_funcs: list[str] = []  # "file::name" strings, pre-dedup
         test_file_set: set[str] = set()
         total_edge_count = 0
-        # Non-collectible Python helpers (e.g. ``_run``) in test files, kept for
-        # a deferred one-hop walk-up after all direct callers are known (#807).
-        helper_refs: list[Any] = []
+        # Per-(target, test) coverage edges already counted, so a test that is
+        # both a direct caller AND (via a helper) a walk-up parent of the SAME
+        # target is not double-counted — while a DIFFERENT target sharing the
+        # same test still counts its own genuine coverage edge (P2 undercount).
+        counted_edges: set[tuple[str, str]] = set()
+        # Non-collectible helpers (Python ``_run``, Go ``setupServer``, …) in
+        # test files, paired with the target they were reached from, for a
+        # deferred one-hop walk-up after all direct callers are known (#807).
+        helper_refs: list[tuple[Any, Any]] = []
 
-        def _record(file_path: str, name: str) -> None:
-            nonlocal total_edge_count
-            total_edge_count += 1
+        def _add_to_set(file_path: str, name: str) -> None:
             key = f"{file_path}::{name}"
             if key not in seen_qualified:
                 seen_qualified.add(key)
                 test_funcs.append(key)
                 test_file_set.add(file_path)
 
+        def _record_edge(target: Any, file_path: str, name: str) -> None:
+            """Count one (target → test) coverage edge, deduped per target."""
+            nonlocal total_edge_count
+            edge_key = (target.qualified_name(), f"{file_path}::{name}")
+            if edge_key in counted_edges:
+                return
+            counted_edges.add(edge_key)
+            total_edge_count += 1
+            _add_to_set(file_path, name)
+
         for target in targets:
             for ref in graph.caller_refs_of(target):
                 if not is_test_file(ref.file_path):
                     continue
-                if _is_collectible_caller(ref.file_path, ref.name):
-                    _record(ref.file_path, ref.name)
+                if _is_collectible_caller(
+                    ref.file_path, ref.name, getattr(ref, "language", "")
+                ):
+                    _record_edge(target, ref.file_path, ref.name)
                 else:
-                    helper_refs.append(ref)
+                    helper_refs.append((target, ref))
 
-        # Bug #807: a direct caller in a Python test file whose name is not
-        # pytest-collectible (e.g. a ``_run`` helper) hides the real test_*
-        # entry point. Walk up ONE hop to the test_* function that calls the
-        # helper. Only record parents not already captured as direct callers —
-        # so a helper whose test_* is also a direct caller adds no extra edge.
-        # The walk is capped at a single hop to avoid cost blowups.
-        for helper in helper_refs:
+        # Bug #807: a direct caller in a test file whose name does not match the
+        # language test convention (e.g. a Python ``_run`` helper or a Go
+        # ``setupServer``) hides the real test entry point. Walk up ONE hop to
+        # the convention-matching test that calls the helper. The walk is capped
+        # at a single hop to avoid cost blowups.
+        #
+        # P2 undercount fix: edge_count counts genuine (target, helper→test)
+        # coverage edges. When ONE test function reaches TWO targets via a shared
+        # helper, both edges are counted (each keyed by its own target) even
+        # though the test appears once in test_functions. _record_edge dedupes
+        # only per (target, test) — mirroring the direct-caller path which counts
+        # a raw edge per (target, caller) pair before deduping the function set.
+        for target, helper in helper_refs:
             for parent in graph.caller_refs_of(helper):
                 if not is_test_file(parent.file_path):
                     continue
-                if not _is_collectible_caller(parent.file_path, parent.name):
+                if not _is_collectible_caller(
+                    parent.file_path, parent.name, getattr(parent, "language", "")
+                ):
                     continue
-                if f"{parent.file_path}::{parent.name}" in seen_qualified:
-                    continue
-                _record(parent.file_path, parent.name)
+                _record_edge(target, parent.file_path, parent.name)
 
         test_funcs_sorted = sorted(test_funcs)
         test_files_sorted = sorted(test_file_set)

--- a/tree_sitter_analyzer/mcp/tools/nav_facade.py
+++ b/tree_sitter_analyzer/mcp/tools/nav_facade.py
@@ -65,6 +65,26 @@ def _is_pytest_collectible(name: str) -> bool:
     return name.startswith("test_")
 
 
+def _is_python_file(file_path: str) -> bool:
+    """True for Python source files (where the pytest ``test_`` rule applies)."""
+    return file_path.endswith(".py")
+
+
+def _is_collectible_caller(file_path: str, name: str) -> bool:
+    """Decide whether a test-file caller is an accepted test entry point.
+
+    The pytest ``test_`` name rule is Python-specific. Go (``TestFoo``),
+    Java (``shouldHandleFoo``), and JS/TS (``*.test.ts``) use different
+    naming conventions, so applying the pytest filter to them drops valid
+    cross-language test callers (Bug #807). For non-Python files we trust
+    ``is_test_file`` (already checked by the caller) and accept the caller
+    without a Python-style name filter.
+    """
+    if _is_python_file(file_path):
+        return _is_pytest_collectible(name)
+    return True
+
+
 def _test_map_next_step(
     test_files: list[str],
     *,
@@ -337,19 +357,43 @@ def build_nav_facade(project_root: str | None = None) -> FacadeTool:
         test_funcs: list[str] = []  # "file::name" strings, pre-dedup
         test_file_set: set[str] = set()
         total_edge_count = 0
+        # Non-collectible Python helpers (e.g. ``_run``) in test files, kept for
+        # a deferred one-hop walk-up after all direct callers are known (#807).
+        helper_refs: list[Any] = []
+
+        def _record(file_path: str, name: str) -> None:
+            nonlocal total_edge_count
+            total_edge_count += 1
+            key = f"{file_path}::{name}"
+            if key not in seen_qualified:
+                seen_qualified.add(key)
+                test_funcs.append(key)
+                test_file_set.add(file_path)
 
         for target in targets:
             for ref in graph.caller_refs_of(target):
                 if not is_test_file(ref.file_path):
                     continue
-                if not _is_pytest_collectible(ref.name):
+                if _is_collectible_caller(ref.file_path, ref.name):
+                    _record(ref.file_path, ref.name)
+                else:
+                    helper_refs.append(ref)
+
+        # Bug #807: a direct caller in a Python test file whose name is not
+        # pytest-collectible (e.g. a ``_run`` helper) hides the real test_*
+        # entry point. Walk up ONE hop to the test_* function that calls the
+        # helper. Only record parents not already captured as direct callers —
+        # so a helper whose test_* is also a direct caller adds no extra edge.
+        # The walk is capped at a single hop to avoid cost blowups.
+        for helper in helper_refs:
+            for parent in graph.caller_refs_of(helper):
+                if not is_test_file(parent.file_path):
                     continue
-                total_edge_count += 1
-                key = f"{ref.file_path}::{ref.name}"
-                if key not in seen_qualified:
-                    seen_qualified.add(key)
-                    test_funcs.append(key)
-                    test_file_set.add(ref.file_path)
+                if not _is_collectible_caller(parent.file_path, parent.name):
+                    continue
+                if f"{parent.file_path}::{parent.name}" in seen_qualified:
+                    continue
+                _record(parent.file_path, parent.name)
 
         test_funcs_sorted = sorted(test_funcs)
         test_files_sorted = sorted(test_file_set)


### PR DESCRIPTION
## Summary
- Exclude Variable elements from CSS rule count/display (fixes SCSS variable inflation)
- Skip SCSS variable matches inside block comments
- test_map: preserve cross-language test callers (Go TestFoo, Java shouldHandleFoo, JS .test.ts)
- test_map: walk up 1 hop from non-collectible helpers in test files to the test_ caller

Addresses Codex P2s from PR #952.

🤖 Generated with Claude Code