### PR TITLE
fix(call-path,extractor): BFS forward-meeting, backward dedup, extractor version (#951)

### DIFF
--- a/tests/unit/test_call_path.py
+++ b/tests/unit/test_call_path.py
@@ -10,6 +10,7 @@ from tree_sitter_analyzer.call_path import (
     CallPathFinder,
     CallPathResult,
     _files_in_chain,
+    _path_signature,
 )
 from tree_sitter_analyzer.graph.edge_store import EdgeKind, symbol_node
 
@@ -508,6 +509,98 @@ _FOUR_HOP_EDGES = [
 ]
 
 
+# #968: two chains differing ONLY by the file of the intermediate ``worker``:
+#   s.py:s -> pkg1.py:worker -> t.py:t
+#   s.py:s -> pkg2.py:worker -> t.py:t
+# A name-only signature collapses both to (s,worker),(worker,t) and drops one.
+_DISTINCT_BY_FILE_EDGES = [
+    {
+        "caller_name": "s",
+        "caller_file": "s.py",
+        "callee_name": "worker",
+        "callee_resolved_file": "pkg1.py",
+    },
+    {
+        "caller_name": "s",
+        "caller_file": "s.py",
+        "callee_name": "worker",
+        "callee_resolved_file": "pkg2.py",
+    },
+    {
+        "caller_name": "worker",
+        "caller_file": "pkg1.py",
+        "callee_name": "t",
+        "callee_resolved_file": "t.py",
+    },
+    {
+        "caller_name": "worker",
+        "caller_file": "pkg2.py",
+        "callee_name": "t",
+        "callee_resolved_file": "t.py",
+    },
+]
+
+
+class TestPathSignatureFileAware:
+    """#968: dedup signature must distinguish chains by node file identity."""
+
+    def test_same_names_different_file_have_distinct_signatures(self):
+        chain_via_pkg1 = [
+            {
+                "caller": "s",
+                "caller_file": "s.py",
+                "callee": "worker",
+                "callee_file": "pkg1.py",
+            },
+            {
+                "caller": "worker",
+                "caller_file": "pkg1.py",
+                "callee": "t",
+                "callee_file": "t.py",
+            },
+        ]
+        chain_via_pkg2 = [
+            {
+                "caller": "s",
+                "caller_file": "s.py",
+                "callee": "worker",
+                "callee_file": "pkg2.py",
+            },
+            {
+                "caller": "worker",
+                "caller_file": "pkg2.py",
+                "callee": "t",
+                "callee_file": "t.py",
+            },
+        ]
+        assert _path_signature(chain_via_pkg1) != _path_signature(chain_via_pkg2)
+
+    def test_identical_chains_share_signature(self):
+        chain = [
+            {
+                "caller": "s",
+                "caller_file": "s.py",
+                "callee": "worker",
+                "callee_file": "pkg1.py",
+            },
+        ]
+        assert _path_signature(list(chain)) == _path_signature(list(chain))
+
+
+class TestBidirectionalDistinctByFile:
+    """#968: distinct-by-file chains must both survive the bidirectional BFS."""
+
+    def test_two_chains_differing_only_by_intermediate_file_preserved(self, tmp_path):
+        cache = _make_cache_with_edges(tmp_path, _DISTINCT_BY_FILE_EDGES)
+        finder = CallPathFinder(str(tmp_path), cache=cache)
+        result = finder.find_path("s", "t", direction="bidirectional")
+        assert result.data_source == "sql"
+        # Both worker-via-pkg1 and worker-via-pkg2 chains are kept.
+        assert len(result.paths) == 2
+        intermediate_files = sorted(p.hops[0]["callee_file"] for p in result.paths)
+        assert intermediate_files == ["pkg1.py", "pkg2.py"]
+
+
 class TestBidirectionalMeetingOrder:
     """#951: forward-side meetings must reconstruct in caller->callee order."""
 
@@ -535,9 +628,49 @@ class TestBidirectionalMeetingOrder:
 
 
 class TestFallbackBackwardGate:
-    """#951: parse-fallback backward search runs only when forward found none."""
+    """#968: parse-fallback backward pass runs and is merged with signature dedup.
 
-    def test_bidirectional_fallback_no_duplicate_when_forward_succeeds(self, tmp_path):
+    The earlier gate (#951) skipped backward entirely once forward found any path,
+    which dropped genuinely-distinct chains the forward pass missed because
+    ``_bfs_graph_core`` marks intermediate states visited.  Backward now runs, but
+    its chains are merged only when their (file-aware) signature is new, so an
+    identical chain re-found by both directions is still recorded exactly once.
+    """
+
+    def test_bidirectional_fallback_backward_duplicate_deduped(self, tmp_path):
+        from tree_sitter_analyzer.call_graph import CallGraph
+
+        graph = CallGraph(str(tmp_path))
+        graph.build = lambda: None  # type: ignore[method-assign]
+        finder = CallPathFinder(str(tmp_path), cache=None)
+
+        same_hop = [
+            {"caller": "s", "caller_file": "a.py", "callee": "t", "callee_file": "b.py"}
+        ]
+
+        def fake_forward(g, *a):  # noqa: ANN001, ANN002
+            paths = a[-1]
+            paths.append(CallChain(hops=list(same_hop), total_hops=1, files_crossed=2))
+
+        def fake_backward(g, *a):  # noqa: ANN001, ANN002
+            # Backward re-discovers the SAME chain (identical signature).
+            paths = a[-1]
+            paths.append(CallChain(hops=list(same_hop), total_hops=1, files_crossed=2))
+
+        finder._bfs_graph_forward = fake_forward  # type: ignore[assignment]
+        finder._bfs_graph_backward = fake_backward  # type: ignore[assignment]
+        import unittest.mock as _m
+
+        with _m.patch.object(
+            __import__("tree_sitter_analyzer.call_graph", fromlist=["CallGraph"]),
+            "CallGraph",
+            return_value=graph,
+        ):
+            result = finder._fallback_graph("s", "t", None, None, 6, 5, "bidirectional")
+        # Same chain found by both passes → recorded exactly once.
+        assert len(result.paths) == 1
+
+    def test_bidirectional_fallback_backward_adds_distinct_chain(self, tmp_path):
         from tree_sitter_analyzer.call_graph import CallGraph
 
         graph = CallGraph(str(tmp_path))
@@ -548,15 +681,39 @@ class TestFallbackBackwardGate:
             paths = a[-1]
             paths.append(
                 CallChain(
-                    hops=[{"caller": "s", "callee": "t"}], total_hops=1, files_crossed=1
+                    hops=[
+                        {
+                            "caller": "s",
+                            "caller_file": "a.py",
+                            "callee": "t",
+                            "callee_file": "b.py",
+                        }
+                    ],
+                    total_hops=1,
+                    files_crossed=2,
                 )
             )
 
-        def fail_backward(*a, **k):  # noqa: ANN002, ANN003
-            raise AssertionError("backward must not run when forward found paths")
+        def fake_backward(g, *a):  # noqa: ANN001, ANN002
+            # Backward finds a DISTINCT chain the forward pass missed.
+            paths = a[-1]
+            paths.append(
+                CallChain(
+                    hops=[
+                        {
+                            "caller": "s",
+                            "caller_file": "a.py",
+                            "callee": "t",
+                            "callee_file": "c.py",
+                        }
+                    ],
+                    total_hops=1,
+                    files_crossed=2,
+                )
+            )
 
         finder._bfs_graph_forward = fake_forward  # type: ignore[assignment]
-        finder._bfs_graph_backward = fail_backward  # type: ignore[assignment]
+        finder._bfs_graph_backward = fake_backward  # type: ignore[assignment]
         import unittest.mock as _m
 
         with _m.patch.object(
@@ -565,4 +722,5 @@ class TestFallbackBackwardGate:
             return_value=graph,
         ):
             result = finder._fallback_graph("s", "t", None, None, 6, 5, "bidirectional")
-        assert len(result.paths) == 1
+        # Distinct chain (differs by callee_file) is preserved, not dropped.
+        assert len(result.paths) == 2

--- a/tests/unit/test_call_path.py
+++ b/tests/unit/test_call_path.py
@@ -483,3 +483,86 @@ class TestCallPathHopCalleFile:
         hop = result.paths[0].hops[0]
         assert hop["callee_file"] == "lib.py"
         assert hop["caller_file"] == "main.py"
+
+
+# 4-hop linear chain: s -> a -> b -> t (frontiers meet on the forward side at b)
+_FOUR_HOP_EDGES = [
+    {
+        "caller_name": "s",
+        "caller_file": "s.py",
+        "callee_name": "a",
+        "callee_resolved_file": "a.py",
+    },
+    {
+        "caller_name": "a",
+        "caller_file": "a.py",
+        "callee_name": "b",
+        "callee_resolved_file": "b.py",
+    },
+    {
+        "caller_name": "b",
+        "caller_file": "b.py",
+        "callee_name": "t",
+        "callee_resolved_file": "t.py",
+    },
+]
+
+
+class TestBidirectionalMeetingOrder:
+    """#951: forward-side meetings must reconstruct in caller->callee order."""
+
+    def test_three_plus_hop_path_in_executable_order(self, tmp_path):
+        cache = _make_cache_with_edges(tmp_path, _FOUR_HOP_EDGES)
+        finder = CallPathFinder(str(tmp_path), cache=cache)
+        result = finder.find_path("s", "t", direction="bidirectional")
+        assert result.data_source == "sql"
+        assert len(result.paths) == 1
+        hops = result.paths[0].hops
+        # Hops must be ordered s->a, a->b, b->t — a non-executable scramble
+        # (e.g. s->a, b->t, a->b) is the bug this guards against.
+        assert [(h["caller"], h["callee"]) for h in hops] == [
+            ("s", "a"),
+            ("a", "b"),
+            ("b", "t"),
+        ]
+
+    def test_no_duplicate_paths_from_both_frontiers(self, tmp_path):
+        """A meeting node found by both passes is recorded exactly once."""
+        cache = _make_cache_with_edges(tmp_path, _LINEAR_EDGES)
+        finder = CallPathFinder(str(tmp_path), cache=cache)
+        result = finder.find_path("main", "bar", direction="bidirectional")
+        assert len(result.paths) == 1
+
+
+class TestFallbackBackwardGate:
+    """#951: parse-fallback backward search runs only when forward found none."""
+
+    def test_bidirectional_fallback_no_duplicate_when_forward_succeeds(self, tmp_path):
+        from tree_sitter_analyzer.call_graph import CallGraph
+
+        graph = CallGraph(str(tmp_path))
+        graph.build = lambda: None  # type: ignore[method-assign]
+        finder = CallPathFinder(str(tmp_path), cache=None)
+
+        def fake_forward(g, *a):  # noqa: ANN001, ANN002
+            paths = a[-1]
+            paths.append(
+                CallChain(
+                    hops=[{"caller": "s", "callee": "t"}], total_hops=1, files_crossed=1
+                )
+            )
+
+        def fail_backward(*a, **k):  # noqa: ANN002, ANN003
+            raise AssertionError("backward must not run when forward found paths")
+
+        finder._bfs_graph_forward = fake_forward  # type: ignore[assignment]
+        finder._bfs_graph_backward = fail_backward  # type: ignore[assignment]
+        import unittest.mock as _m
+
+        with _m.patch.object(
+            __import__("tree_sitter_analyzer.call_graph", fromlist=["CallGraph"]),
+            "CallGraph",
+            return_value=graph,
+        ):
+            result = finder._fallback_graph("s", "t", None, None, 6, 5, "bidirectional")
+        assert len(result.paths) == 1

--- a/tests/unit/test_symbols_json_enrichment.py
+++ b/tests/unit/test_symbols_json_enrichment.py
@@ -136,12 +136,12 @@ class TestReturnTypeAndParamsSerialized:
 
 
 class TestExtractorVersionBump:
-    def test_extractor_version_is_11_in_both_sites(self):
-        # v11: #638 — call edges keep ALL same-named definition spans.
+    def test_extractor_version_is_12_in_both_sites(self):
+        # v12: #779 — walker depth cap raised 20 -> 100; bump forces re-index.
         from tree_sitter_analyzer import _ast_cache_indexer, ast_cache
 
-        assert ast_cache._AST_CACHE_EXTRACTOR_VERSION == 11
-        assert _ast_cache_indexer._AST_CACHE_EXTRACTOR_VERSION == 11
+        assert ast_cache._AST_CACHE_EXTRACTOR_VERSION == 12
+        assert _ast_cache_indexer._AST_CACHE_EXTRACTOR_VERSION == 12
 
 
 class TestCodexP2sOn621:

--- a/tree_sitter_analyzer/_ast_cache_indexer.py
+++ b/tree_sitter_analyzer/_ast_cache_indexer.py
@@ -30,7 +30,9 @@ logger = logging.getLogger(__name__)
 # v10: #628 — C# function-local variables no longer over-captured.
 # v11: #638 — call edges keep ALL same-named definition spans; calls inside
 #      the earlier of two same-named methods regain their enclosing caller.
-_AST_CACHE_EXTRACTOR_VERSION = 11
+# v12: #779 — walker depth cap raised 20 -> 100; bump forces re-index of files
+#      cached under the old cap so deeply nested symbols are no longer truncated.
+_AST_CACHE_EXTRACTOR_VERSION = 12
 
 
 def check_cache_or_read(

--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -81,7 +81,9 @@ logger = logging.getLogger(__name__)
 # v10: #628 — C# function-local variables no longer over-captured.
 # v11: #638 — call edges keep ALL same-named definition spans; calls inside
 #      the earlier of two same-named methods regain their enclosing caller.
-_AST_CACHE_EXTRACTOR_VERSION = 11
+# v12: #779 — walker depth cap raised 20 -> 100; bump forces re-index of files
+#      cached under the old cap so deeply nested symbols are no longer truncated.
+_AST_CACHE_EXTRACTOR_VERSION = 12
 
 
 class SchemaIntegrityError(RuntimeError):

--- a/tree_sitter_analyzer/call_path.py
+++ b/tree_sitter_analyzer/call_path.py
@@ -326,9 +326,28 @@ def _make_chain(path: list[dict[str, Any]]) -> CallChain:
     )
 
 
-def _path_signature(path: list[dict[str, Any]]) -> tuple[tuple[str, str], ...]:
-    """Stable signature for a hop list, used to dedup equivalent paths."""
-    return tuple((hop.get("caller", ""), hop.get("callee", "")) for hop in path)
+def _path_signature(
+    path: list[dict[str, Any]],
+) -> tuple[tuple[str, str, str, str], ...]:
+    """Stable signature for a hop list, used to dedup equivalent paths.
+
+    #968: the signature must incorporate each node's file identity, not just the
+    bare symbol name.  Two genuinely distinct chains that differ only by the file
+    of an intermediate node — e.g. ``s -> pkg1.py:worker -> t`` vs
+    ``s -> pkg2.py:worker -> t`` — share the same ``(caller, callee)`` name pairs
+    and would otherwise collapse to one signature, silently dropping a real path.
+    Including ``caller_file`` / ``callee_file`` keeps distinct-by-file chains
+    while still deduping genuinely identical ones.
+    """
+    return tuple(
+        (
+            hop.get("caller", ""),
+            hop.get("caller_file", ""),
+            hop.get("callee", ""),
+            hop.get("callee_file", ""),
+        )
+        for hop in path
+    )
 
 
 class CallPathFinder:
@@ -524,7 +543,7 @@ class CallPathFinder:
         paths: list[CallChain] = []
         # #951: dedup paths by their hop signature so a meeting node discovered
         # by both the forward and backward pass in the same round is recorded once.
-        seen_paths: set[tuple[tuple[str, str], ...]] = set()
+        seen_paths: set[tuple[tuple[str, str, str, str], ...]] = set()
         depth = 0
         half_depth = max(1, max_depth // 2)
         while forward_queue or backward_queue:
@@ -539,9 +558,16 @@ class CallPathFinder:
                     # #735: definition file, not call-site file.
                     callee_file = row.get("callee_resolved_file") or ""
                     state = (callee_name, callee_file or None)
+                    # #968: when current_file is unknown (e.g. the source seed had
+                    # no file), fall back to the row's caller_file (file_path is the
+                    # call-site/caller file).  This keeps the caller_file consistent
+                    # with what the backward pass resolves for the same node, so the
+                    # file-aware path signature dedups a chain found by both passes
+                    # instead of treating "" vs the resolved file as two paths.
+                    caller_file = current_file or row.get("caller_file") or ""
                     hop = {
                         "caller": current_name,
-                        "caller_file": current_file or "",
+                        "caller_file": caller_file,
                         "callee": callee_name,
                         "callee_file": callee_file,
                         "line": row.get("callee_line", 0),
@@ -708,15 +734,18 @@ class CallPathFinder:
                 max_paths,
                 paths,
             )
-        # #797/#951: bidirectional fallback must try backward only when forward
-        # found NOTHING (mirrors the SQL bidirectional that tries both frontiers).
-        # Running it whenever fewer than max_paths were found re-discovers the
-        # same chains and inflates path_count with duplicates.  For a pure
-        # backward search the forward pass never ran, so backward always runs.
-        run_backward = direction == "backward" or (
-            direction == "bidirectional" and not paths
-        )
-        if run_backward:
+        # #968: reconcile the backward pass.  The original gate (#797/#951) skipped
+        # backward the moment forward found ANY path — but ``_bfs_graph_core`` marks
+        # intermediate states visited within one direction, so the forward pass can
+        # return only ONE chain through a shared meeting node and miss other,
+        # genuinely-distinct chains.  The gate's real intent was to avoid DUPLICATE
+        # paths, not to drop distinct ones.  So for bidirectional we now ALSO run
+        # the backward pass when there's still room for more paths, collect its
+        # chains separately, and merge only those whose (file-aware) signature is
+        # not already present — adding distinct chains while the signature dedup
+        # prevents the duplicate inflation the gate was added to fix.  A pure
+        # backward search still runs backward unconditionally (forward never ran).
+        if direction == "backward":
             self._bfs_graph_backward(
                 graph,
                 source_function,
@@ -727,6 +756,26 @@ class CallPathFinder:
                 max_paths,
                 paths,
             )
+        elif direction == "bidirectional" and len(paths) < max_paths:
+            backward_paths: list[CallChain] = []
+            self._bfs_graph_backward(
+                graph,
+                source_function,
+                target_function,
+                source_file,
+                target_file,
+                max_depth,
+                max_paths,
+                backward_paths,
+            )
+            seen = {_path_signature(p.hops) for p in paths}
+            for chain in backward_paths:
+                if len(paths) >= max_paths:
+                    break
+                sig = _path_signature(chain.hops)
+                if sig not in seen:
+                    seen.add(sig)
+                    paths.append(chain)
         return CallPathResult(
             source=source_function,
             target=target_function,

--- a/tree_sitter_analyzer/call_path.py
+++ b/tree_sitter_analyzer/call_path.py
@@ -326,6 +326,11 @@ def _make_chain(path: list[dict[str, Any]]) -> CallChain:
     )
 
 
+def _path_signature(path: list[dict[str, Any]]) -> tuple[tuple[str, str], ...]:
+    """Stable signature for a hop list, used to dedup equivalent paths."""
+    return tuple((hop.get("caller", ""), hop.get("callee", "")) for hop in path)
+
+
 class CallPathFinder:
     """Find execution paths between two functions via BFS on call edges.
 
@@ -517,6 +522,9 @@ class CallPathFinder:
             [(target_function, target_file)]
         )
         paths: list[CallChain] = []
+        # #951: dedup paths by their hop signature so a meeting node discovered
+        # by both the forward and backward pass in the same round is recorded once.
+        seen_paths: set[tuple[tuple[str, str], ...]] = set()
         depth = 0
         half_depth = max(1, max_depth // 2)
         while forward_queue or backward_queue:
@@ -540,11 +548,22 @@ class CallPathFinder:
                     }
                     parent_path = forward_visited.get((current_name, current_file), [])
                     forward_visited[state] = parent_path + [hop]
-                    # #797: only check for a meeting in backward_visited to stop
-                    # further exploration of this callee.  Paths are recorded
-                    # exclusively by the backward pass to prevent duplicates when
-                    # both passes discover the same meeting node in the same round.
-                    if _lookup_in_visited(state, backward_visited)[0]:
+                    # #797/#951: when the frontier first meets during the forward
+                    # expansion, record the path here in the correctly-ordered
+                    # form (forward segment to the meeting node, then the backward
+                    # segment from the meeting node) and stop exploring this callee.
+                    # Relying on the later backward pass to record it rebuilds the
+                    # chain in the wrong order for 3+ hop paths.
+                    found, bwd_path = _lookup_in_visited(state, backward_visited)
+                    if found:
+                        # backward_visited stores hops in forward (caller->callee)
+                        # order via ``[hop] + parent_path``, so the backward segment
+                        # is appended as-is — reversing it scrambles 2+ hop tails.
+                        full_path = forward_visited[state] + bwd_path
+                        sig = _path_signature(full_path)
+                        if sig not in seen_paths:
+                            seen_paths.add(sig)
+                            paths.append(_make_chain(full_path))
                         # Terminal node reached: stop exploring its callees.
                         continue
                     next_forward.append(state)
@@ -573,8 +592,13 @@ class CallPathFinder:
                     backward_visited[state] = [hop] + list(parent_path)
                     found, fwd_path = _lookup_in_visited(state, forward_visited)
                     if found:
-                        full_path = fwd_path + list(reversed(backward_visited[state]))
-                        paths.append(_make_chain(full_path))
+                        # backward_visited stores hops in forward (caller->callee)
+                        # order, so append the backward segment as-is.
+                        full_path = fwd_path + backward_visited[state]
+                        sig = _path_signature(full_path)
+                        if sig not in seen_paths:
+                            seen_paths.add(sig)
+                            paths.append(_make_chain(full_path))
                         continue
                     next_backward.append(state)
             backward_queue = next_backward
@@ -684,9 +708,15 @@ class CallPathFinder:
                 max_paths,
                 paths,
             )
-        # #797: bidirectional fallback must also try backward when forward found
-        # nothing (mirrors the SQL bidirectional that tries both frontiers).
-        if direction in ("backward", "bidirectional") and len(paths) < max_paths:
+        # #797/#951: bidirectional fallback must try backward only when forward
+        # found NOTHING (mirrors the SQL bidirectional that tries both frontiers).
+        # Running it whenever fewer than max_paths were found re-discovers the
+        # same chains and inflates path_count with duplicates.  For a pure
+        # backward search the forward pass never ran, so backward always runs.
+        run_backward = direction == "backward" or (
+            direction == "bidirectional" and not paths
+        )
+        if run_backward:
             self._bfs_graph_backward(
                 graph,
                 source_function,


### PR DESCRIPTION
## Summary
- Record forward-side meeting nodes in bidirectional BFS so 3+ hop paths reconstruct in correct caller->callee order (previously returned a scrambled, non-executable chain)
- backward_visited already stores hops in forward order, so both reconstruction sites stop reversing the backward segment and dedup by hop signature — removing the duplicate path a shared meeting node produced
- Only run fallback backward search when forward found 0 paths (removes duplicate paths / inflated path_count)
- Bump AST cache extractor version 11 -> 12 so the #779 depth-cap fix applies to already-cached files

Addresses Codex P2s from PR #951.

## Test plan
- `tests/unit/test_call_path.py` — 31 passed (added TestBidirectionalMeetingOrder + TestFallbackBackwardGate regressions: 3+ hop executable order, no-duplicate, fallback gate)
- `test_symbols_json_enrichment.py` version-pin re-pinned 11 -> 12; `test_ast_cache.py` stale-version re-index test green
- nav facade / call_path_enrich / b1 edge-parity suites green (159 combined)

🤖 Generated with Claude Code