### PR TITLE
fix(rust): harden enum variants and scale caps

### DIFF
--- a/docs/CODEMAPS/languages.md
+++ b/docs/CODEMAPS/languages.md
@@ -16,7 +16,7 @@ Each implements the `LanguagePlugin` interface (`tree_sitter_analyzer/plugins/ba
 | C++ | `languages/cpp_plugin.py` | `_cpp_*_helpers.py` ×11 | classes, templates, namespaces |
 | C# | `languages/csharp_plugin.py` | `languages/csharp_helpers.py` | records, async/await, attributes |
 | Go | `languages/go_plugin.py` | `_go_*_helpers.py` ×6 | structs, interfaces, goroutines |
-| Rust | `languages/rust_plugin.py` | inline | traits, impl, macros, derive |
+| Rust | `languages/rust_plugin.py` | inline | traits, impl, macros, derive, enum variants as variables |
 | Kotlin | `languages/kotlin_plugin.py` | `languages/kotlin_helpers.py` | data classes, coroutines |
 | Scala | `languages/scala_plugin.py` | inline | objects/traits, scaladoc |
 | Swift | `languages/swift_plugin.py` | `_swift_plugin_*.py` ×3 | classes, structs, protocols; `.swift` + `.swiftinterface` (issue #131) |

--- a/tests/unit/languages/test_rust_enum_variants_796.py
+++ b/tests/unit/languages/test_rust_enum_variants_796.py
@@ -37,7 +37,10 @@ def _parse_rust(code: str):
     return tree, lang
 
 
-@pytest.mark.skipif(not _TS_RUST_AVAILABLE, reason="tree-sitter-rust not installed")
+@pytest.mark.skipif(
+    not _TS_RUST_AVAILABLE,
+    reason="#960: tree-sitter-rust not installed",
+)
 class TestRustEnumVariantExtraction:
     """extract_variables() must yield one Variable per enum variant."""
 
@@ -142,6 +145,50 @@ class TestRustEnumVariantExtraction:
         assert variant_names == {"North", "South"}, (
             f"Enum variants wrong: {variant_names}"
         )
+
+    def test_struct_like_enum_variant_fields_do_not_leak(self):
+        """Struct-like enum body fields are not ordinary struct fields (#960)."""
+        from tree_sitter_analyzer.languages.rust_plugin import RustElementExtractor
+
+        code = (
+            "struct Point { px: f64, py: f64 }\n"
+            "enum Event { Move { x: i32, y: i32 }, Quit }\n"
+        )
+        tree, _ = _parse_rust(code)
+        extractor = RustElementExtractor()
+        variables = extractor.extract_variables(tree, code)
+
+        field_names = [
+            v.name
+            for v in variables
+            if getattr(v, "variable_type", None) != "enum_variant"
+        ]
+        variant_names = [
+            v.name
+            for v in variables
+            if getattr(v, "variable_type", None) == "enum_variant"
+        ]
+
+        assert field_names == ["px", "py"]
+        assert variant_names == ["Move", "Quit"]
+
+    def test_enum_variant_visibility_inherits_enum_visibility(self):
+        """Variants inherit the enclosing enum visibility for API consumers (#960)."""
+        from tree_sitter_analyzer.languages.rust_plugin import RustElementExtractor
+
+        code = "pub enum Direction { North, South }"
+        tree, _ = _parse_rust(code)
+        extractor = RustElementExtractor()
+        variables = extractor.extract_variables(tree, code)
+
+        variants = [
+            v for v in variables if getattr(v, "variable_type", None) == "enum_variant"
+        ]
+
+        assert [(v.name, v.visibility) for v in variants] == [
+            ("North", "pub"),
+            ("South", "pub"),
+        ]
 
     def test_enum_variant_line_range_within_enum_span(self):
         """Variant start_line must be within the enclosing enum's line span."""

--- a/tests/unit/mcp/test_tools/test_check_scale_output_cap_755.py
+++ b/tests/unit/mcp/test_tools/test_check_scale_output_cap_755.py
@@ -204,6 +204,27 @@ class TestUniversalOverviewMethodCap:
             or overview.get("methods_truncated") is False
         )
 
+    def test_complexity_hotspots_are_capped_with_metadata(self):
+        """#960: hotspots must be capped separately from the methods list."""
+        elements = [
+            _make_fn_element(
+                f"hotspot_{i}",
+                start_line=i * 10,
+                end_line=i * 10 + 5,
+                complexity=12,
+            )
+            for i in range(60)
+        ]
+        result = _make_analysis_result_universal(elements)
+        overview = extract_structural_overview_universal(result)
+
+        assert len(overview["complexity_hotspots"]) == 50
+        assert overview["total_complexity_hotspots"] == 60
+        assert overview["complexity_hotspots_truncated"] is True
+        assert [h["name"] for h in overview["complexity_hotspots"]] == [
+            f"hotspot_{i}" for i in range(50)
+        ]
+
 
 # ---------------------------------------------------------------------------
 # extract_structural_overview (Java/Python path) — cap behaviour
@@ -256,3 +277,22 @@ class TestJavaOverviewMethodCap:
             or overview.get("methods_truncated") is False
         )
         assert overview["total_methods"] == 50
+
+    def test_complexity_hotspots_are_capped_with_metadata(self):
+        elements = [
+            _make_java_fn_element(
+                f"hotspot_{i}",
+                start_line=i * 10,
+                complexity_score=12,
+            )
+            for i in range(60)
+        ]
+        result = self._make_result(elements)
+        overview = extract_structural_overview(result)
+
+        assert len(overview["complexity_hotspots"]) == 50
+        assert overview["total_complexity_hotspots"] == 60
+        assert overview["complexity_hotspots_truncated"] is True
+        assert [h["name"] for h in overview["complexity_hotspots"]] == [
+            f"hotspot_{i}" for i in range(50)
+        ]

--- a/tree_sitter_analyzer/languages/rust_plugin.py
+++ b/tree_sitter_analyzer/languages/rust_plugin.py
@@ -137,12 +137,9 @@ class RustElementExtractor(ElementExtractor):
 
         variables: list[Variable] = []
 
-        # Pass 1: struct fields via generic traversal
-        self._traverse_and_extract(
-            tree.root_node,
-            {"field_declaration": self._extract_field},
-            variables,
-        )
+        # Pass 1: struct fields only. Do not recurse into enum_item because
+        # struct-like enum variants also contain field_declaration nodes (#960).
+        self._collect_struct_fields(tree.root_node, variables)
 
         # Pass 2: enum variants — collect directly, skip field_declaration recursion
         self._collect_enum_variants(tree.root_node, variables)
@@ -169,6 +166,20 @@ class RustElementExtractor(ElementExtractor):
             return
         for child in node.children:
             self._collect_enum_variants(child, results)
+
+    def _collect_struct_fields(
+        self, node: tree_sitter.Node, results: list[Variable]
+    ) -> None:
+        """Walk the AST for real struct fields, skipping enum variant bodies."""
+        if node.type == "enum_item":
+            return
+        if node.type == "field_declaration":
+            field = self._extract_field(node)
+            if field is not None:
+                results.append(field)
+            return
+        for child in node.children:
+            self._collect_struct_fields(child, results)
 
     def extract_imports(self, tree: tree_sitter.Tree, source_code: str) -> list[Import]:
         """Extract Rust use declarations"""
@@ -651,6 +662,7 @@ class RustElementExtractor(ElementExtractor):
             if name_node is None:
                 return None
             enum_name = self._get_node_text(name_node)
+            enum_visibility = self._extract_visibility(node)
 
             # Walk children looking for the enum_variant_list node.
             variant_list = None
@@ -680,6 +692,7 @@ class RustElementExtractor(ElementExtractor):
                     raw_text=raw_text,
                     language="rust",
                     variable_type="enum_variant",
+                    visibility=enum_visibility,
                     receiver_type=enum_name,
                 )
                 variants.append(var)

--- a/tree_sitter_analyzer/mcp/tools/analyze_scale_helpers.py
+++ b/tree_sitter_analyzer/mcp/tools/analyze_scale_helpers.py
@@ -25,12 +25,16 @@ logger = setup_logger(__name__)
 # metadata so callers know the full count without the payload cost.
 # ---------------------------------------------------------------------------
 METHODS_OUTPUT_CAP = 50
+HOTSPOTS_OUTPUT_CAP = 50
 
 
 # Tree-sitter element extraction for structure view
 # Converts unified analysis engine results into LLM-consumable dicts
 def extract_structural_overview(
-    analysis_result: Any, *, method_cap: int = METHODS_OUTPUT_CAP
+    analysis_result: Any,
+    *,
+    method_cap: int = METHODS_OUTPUT_CAP,
+    hotspot_cap: int = HOTSPOTS_OUTPUT_CAP,
 ) -> dict[str, Any]:
     """Extract structural overview with position information for LLM guidance.
 
@@ -47,7 +51,8 @@ def extract_structural_overview(
         "imports": _extract_import_infos(elements),
         "complexity_hotspots": [],
     }
-    all_methods, overview["complexity_hotspots"] = _extract_method_infos(elements)
+    all_methods, hotspots = _extract_method_infos(elements)
+    _apply_hotspot_cap(overview, hotspots, hotspot_cap)
     total_methods = len(all_methods)
     overview["total_methods"] = total_methods
     if total_methods > method_cap:
@@ -112,6 +117,19 @@ def _extract_method_infos(
     return method_infos, hotspots
 
 
+def _apply_hotspot_cap(
+    overview: dict[str, Any], hotspots: list[dict[str, Any]], hotspot_cap: int
+) -> None:
+    """Cap hotspot payloads and expose metadata only when truncation occurs."""
+    total_hotspots = len(hotspots)
+    if total_hotspots > hotspot_cap:
+        overview["complexity_hotspots"] = hotspots[:hotspot_cap]
+        overview["total_complexity_hotspots"] = total_hotspots
+        overview["complexity_hotspots_truncated"] = True
+    else:
+        overview["complexity_hotspots"] = hotspots
+
+
 def _extract_field_infos(elements: list[Any]) -> list[dict[str, Any]]:
     """Field element → dict with type + modifiers + position."""
     fields = [e for e in elements if is_element_of_type(e, ELEMENT_TYPE_VARIABLE)]
@@ -168,6 +186,7 @@ def extract_structural_overview_universal(
     analysis_result: Any,
     *,
     method_cap: int = METHODS_OUTPUT_CAP,
+    hotspot_cap: int = HOTSPOTS_OUTPUT_CAP,
 ) -> dict[str, Any]:
     """Extract structural overview from universal analysis result (non-Java languages).
 
@@ -197,7 +216,7 @@ def extract_structural_overview_universal(
     _all_methods: list[dict[str, Any]] = []
     _fields = overview["fields"]
     _imports = overview["imports"]
-    _hotspots = overview["complexity_hotspots"]
+    _hotspots: list[dict[str, Any]] = []
 
     # Classify each element by its type and extract metadata
     for e in analysis_result.elements:
@@ -245,6 +264,7 @@ def extract_structural_overview_universal(
         overview["methods_truncated"] = True
     else:
         overview["methods"] = _all_methods
+    _apply_hotspot_cap(overview, _hotspots, hotspot_cap)
 
     return overview
 


### PR DESCRIPTION
## Summary
- stop Rust struct-like enum variant fields from leaking into ordinary field extraction
- make Rust enum variant variables inherit the enclosing enum visibility
- cap `complexity_hotspots` output for both universal and Java/Python scale overview paths
- add #960 tracking to the Rust enum variant skip marker and update the languages codemap

## Root Cause
Rust field extraction still walked into `enum_item`, so struct-like variants exposed their internal fields as top-level variables. Enum variant entries did not copy the enum visibility, and scale overview capped `methods` but left `complexity_hotspots` unbounded.

## Validation
- `uv run pytest tests/unit/languages/test_rust_enum_variants_796.py tests/unit/mcp/test_tools/test_check_scale_output_cap_755.py -q`
- `uv run pytest tests/integration/core/test_analyze_scale_tool_batch_metrics.py tests/integration/core/test_analyze_scale_tool_cli_compatible.py tests/integration/core/test_analyze_scale_tool_file_output.py tests/integration/mcp/test_tools/test_analyze_scale_tool.py tests/unit/languages/test_rust_plugin_basic.py tests/unit/languages/test_rust_plugin_extractor.py tests/unit/languages/test_rust_plugin_integration.py tests/unit/mcp/test_tools/test_analyze_scale_advanced.py tests/unit/mcp/test_tools/test_analyze_scale_basic.py tests/unit/mcp/test_tools/test_analyze_scale_core.py tests/unit/mcp/test_tools/test_analyze_scale_helpers.py tests/unit/mcp/test_tools/test_analyze_scale_helpers_build.py tests/unit/mcp/test_tools/test_analyze_scale_helpers_guidance.py tests/unit/mcp/test_tools/test_analyze_scale_helpers_overview.py tests/unit/mcp/test_tools/test_analyze_scale_tool_cli_compat_unit.py -q`
- `uv run pytest tests/unit/languages/test_rust_enum_variants_796.py tests/unit/mcp/test_tools/test_check_scale_output_cap_755.py tests/unit/mcp/test_tools/test_analyze_scale_core.py tests/unit/mcp/test_tools/test_analyze_scale_helpers_overview.py tests/regression/test_plugin_golden_masters.py --cov=tree_sitter_analyzer --cov-report=json -q`
- `uv run python scripts/check_patch_coverage.py --base origin/develop --coverage-json coverage.json`
- `uv run python scripts/generate_facade_actions_doc.py && uv run pytest tests/unit/docs/test_facade_actions_doc_drift.py -x`
- `uv run pytest -q`

Closes #960