### PR TITLE
fix(ast-cache): harden index freshness signals

### DIFF
--- a/tests/unit/mcp/test_symbol_lineage_tool.py
+++ b/tests/unit/mcp/test_symbol_lineage_tool.py
@@ -477,6 +477,63 @@ class TestAstIndexStaleness:
         assert is_ast_index_stale(str(tmp_path)) is True
 
 
+class TestGraphCacheFingerprintHelpers:
+    """Direct coverage for the freshness-walk helper branches (#970)."""
+
+    def test_indexed_abs_and_rel_path_absolute_outside_root_falls_back(self, tmp_path):
+        """An absolute indexed path outside root → relative_to raises ValueError,
+        so the helper falls back to the path's own posix form."""
+        from pathlib import Path
+
+        from tree_sitter_analyzer._graph_cache_fingerprint import (
+            _indexed_abs_and_rel_path,
+        )
+
+        outside = tmp_path.parent / "elsewhere" / "foreign.py"
+        abs_path, rel_path = _indexed_abs_and_rel_path(tmp_path, str(outside))
+
+        assert abs_path == Path(str(outside))
+        assert rel_path == outside.as_posix()
+
+    def test_indexed_abs_and_rel_path_relative_inside_root(self, tmp_path):
+        """A relative indexed path is resolved against root and stays relative."""
+        from pathlib import Path
+
+        from tree_sitter_analyzer._graph_cache_fingerprint import (
+            _indexed_abs_and_rel_path,
+        )
+
+        abs_path, rel_path = _indexed_abs_and_rel_path(tmp_path, "pkg/a.py")
+
+        assert abs_path == Path(tmp_path) / "pkg" / "a.py"
+        assert rel_path == "pkg/a.py"
+
+    def test_walk_supported_source_paths_skips_dotfiles_excluded_and_unsupported(
+        self, tmp_path
+    ):
+        """The walker yields only supported, non-dot files outside EXCLUDE_DIRS."""
+        from tree_sitter_analyzer._graph_cache_fingerprint import (
+            _walk_supported_source_paths,
+        )
+
+        # Supported, should be yielded.
+        _write_py(tmp_path, "pkg/a.py", "class A:\n    pass\n")
+        # Dotfile — skipped by the fname.startswith(".") branch.
+        (tmp_path / ".hidden.py").write_text("x = 1\n")
+        # Unsupported extension — skipped by the ext-not-in-EXT_TO_LANG branch.
+        (tmp_path / "notes.txt").write_text("hello\n")
+        # Excluded directory — pruned from dirnames.
+        (tmp_path / "node_modules").mkdir()
+        (tmp_path / "node_modules" / "dep.py").write_text("y = 2\n")
+        # Dot-directory — pruned from dirnames.
+        (tmp_path / ".cache_dir").mkdir()
+        (tmp_path / ".cache_dir" / "c.py").write_text("z = 3\n")
+
+        found = set(_walk_supported_source_paths(tmp_path))
+
+        assert found == {"pkg/a.py"}
+
+
 class TestR37uTopLevelVerdictMirror:
     """r37u dogfood: ``--symbol-lineage`` envelope used to omit top-level
     ``verdict`` even though ``agent_summary.verdict`` was populated.

--- a/tests/unit/mcp/test_symbol_lineage_tool.py
+++ b/tests/unit/mcp/test_symbol_lineage_tool.py
@@ -4,6 +4,7 @@ import asyncio
 
 import pytest
 
+from tree_sitter_analyzer.mcp.tools._graph_cache_fingerprint import is_ast_index_stale
 from tree_sitter_analyzer.mcp.tools.symbol_lineage_tool import (
     SymbolLineageTool,
     _assess_risk,
@@ -401,6 +402,79 @@ class TestInheritanceLineage:
             "authoritative ast_index mtime check"
         )
         assert "index_hint" in hier
+
+    def test_execute_invalidates_symbol_cache_when_ast_index_is_stale(
+        self, tool, tmp_path
+    ):
+        """#932: a warm lineage response must not hide stale AST-index data."""
+        import os
+        import time
+
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        kt_path = tmp_path / "Main.kt"
+        kt_path.write_text("class Main {\n    fun run() {}\n}\n")
+        _write_py(tmp_path, "main_wrapper.py", "class MainWrapper:\n    pass\n")
+
+        past_s = time.time() - 60
+        os.utime(str(kt_path), (past_s, past_s))
+        os.utime(str(tmp_path / "main_wrapper.py"), (past_s, past_s))
+        ASTCache(str(tmp_path)).index_project(max_files=50)
+
+        first = asyncio.run(
+            tool.execute({"symbol": "MainWrapper", "output_format": "json"})
+        )
+        assert first["from_cache"] is False
+        assert first["hierarchy"]["index_stale"] is False
+
+        future_ns = int(time.time() * 1e9) + 10_000_000_000
+        future_s = future_ns / 1e9
+        os.utime(str(kt_path), (future_s, future_s))
+
+        second = asyncio.run(
+            tool.execute({"symbol": "MainWrapper", "output_format": "json"})
+        )
+        assert second["from_cache"] is False
+        assert second["hierarchy"]["index_stale"] is True
+        assert "index_hint" in second["hierarchy"]
+
+
+class TestAstIndexStaleness:
+    def test_empty_ast_index_is_unknown_not_stale(self, tool, tmp_path):
+        """An empty DB created by a read path is not a completed stale index."""
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        _write_py(tmp_path, "pkg/a.py", "class A:\n    pass\n")
+        ASTCache(str(tmp_path)).close()
+
+        assert is_ast_index_stale(str(tmp_path)) is False
+
+    def test_stale_when_supported_source_file_is_added_after_index(
+        self, tool, tmp_path
+    ):
+        """#931: newly added supported files must invalidate the AST index."""
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        _write_py(tmp_path, "pkg/a.py", "class A:\n    pass\n")
+        ASTCache(str(tmp_path)).index_project(max_files=50)
+        assert is_ast_index_stale(str(tmp_path)) is False
+
+        _write_py(tmp_path, "pkg/b.py", "class B:\n    pass\n")
+
+        assert is_ast_index_stale(str(tmp_path)) is True
+
+    def test_stale_when_indexed_source_file_is_deleted(self, tool, tmp_path):
+        """#933: deleted indexed files must make the AST index stale."""
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        source_path = tmp_path / "pkg" / "a.py"
+        _write_py(tmp_path, "pkg/a.py", "class A:\n    pass\n")
+        ASTCache(str(tmp_path)).index_project(max_files=50)
+        assert is_ast_index_stale(str(tmp_path)) is False
+
+        source_path.unlink()
+
+        assert is_ast_index_stale(str(tmp_path)) is True
 
 
 class TestR37uTopLevelVerdictMirror:

--- a/tests/unit/mcp/tools/test_co_change.py
+++ b/tests/unit/mcp/tools/test_co_change.py
@@ -808,6 +808,9 @@ def test_lru_cache_evicts_at_maxsize() -> None:
         "platform-independent and runs everywhere"
     ),
 )
+# Real git fixture setup can exceed 5s under xdist load; the compute path
+# keeps its own <2s assertion below.
+@pytest.mark.slow_ok
 def test_real_repo_co_change_under_2s(tmp_path: Path) -> None:  # noqa: F821
     """Rule-11: _compute_co_change on a ~10-commit real git repo completes < 2.0 s.
 

--- a/tests/unit/test_call_graph_built_signal.py
+++ b/tests/unit/test_call_graph_built_signal.py
@@ -6,6 +6,7 @@ import json
 import sqlite3
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
@@ -117,7 +118,37 @@ def _seed_partial_ast_cache_without_call_graph(root: Path) -> None:
     cache.close()
 
 
-def test_resolve_only_marks_call_graph_built_for_partial_cache(tmp_path: Path) -> None:
+def _seed_call_edges_without_built_marker(root: Path) -> None:
+    """Create real CALLS edges while leaving the authoritative marker false."""
+    source_path = root / "calls.py"
+    source_path.write_text(
+        "def caller():\n    target()\n\ndef target():\n    return 1\n",
+        encoding="utf-8",
+    )
+    cache = ASTCache(str(root))
+    try:
+        result = cache.index_file(str(source_path))
+        assert result["status"] == "indexed"
+        assert cache.has_call_edges() is True
+        callgraph_state.clear_call_graph_built(cache.get_conn())
+        assert cache.call_graph_built() is False
+    finally:
+        cache.close()
+
+
+def _call_graph_built_at(cache: ASTCache) -> float:
+    row = (
+        cache.get_conn()
+        .execute("SELECT built_at FROM ast_call_graph_state WHERE id = 1")
+        .fetchone()
+    )
+    assert row is not None
+    return float(row["built_at"])
+
+
+def test_resolve_only_does_not_mark_call_graph_built_for_partial_cache(
+    tmp_path: Path,
+) -> None:
     _seed_partial_ast_cache_without_call_graph(tmp_path)
 
     cache = ASTCache(str(tmp_path))
@@ -127,7 +158,48 @@ def test_resolve_only_marks_call_graph_built_for_partial_cache(tmp_path: Path) -
         result = cache.index_project(resolve_only=True)
 
         assert result["mode_used"] == "resolve_only"
+        assert cache.call_graph_built() is False
+    finally:
+        cache.close()
+
+
+def test_partial_incremental_index_does_not_stamp_call_graph_built_marker(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "a.py").write_text("def a():\n    return 1\n", encoding="utf-8")
+    (tmp_path / "b.py").write_text("def b():\n    return 2\n", encoding="utf-8")
+
+    cache = ASTCache(str(tmp_path))
+    try:
+        result = cache.index_project(max_files=1, workers=0)
+
+        assert result["indexed"] == 1
+        assert result["truncated_by_max_files"] is True
+        assert cache.call_graph_built() is False
+    finally:
+        cache.close()
+
+
+def test_single_file_reindex_refreshes_existing_call_graph_built_marker(
+    tmp_path: Path,
+) -> None:
+    source_path = tmp_path / "sample.py"
+    source_path.write_text("def sample():\n    return 1\n", encoding="utf-8")
+
+    cache = ASTCache(str(tmp_path))
+    try:
+        result = cache.index_project(force=True, workers=0)
+        assert result["indexed"] == 1
         assert cache.call_graph_built() is True
+        before = _call_graph_built_at(cache)
+
+        time.sleep(0.01)
+        source_path.write_text("def sample():\n    return 2\n", encoding="utf-8")
+        single = cache.index_file(str(source_path))
+
+        assert single["status"] == "indexed"
+        assert cache.call_graph_built() is True
+        assert _call_graph_built_at(cache) > before
     finally:
         cache.close()
 
@@ -157,6 +229,30 @@ async def test_partial_ast_cache_without_call_graph_marker_hints_full_index(
 
     tool = tool_cls(str(tmp_path))
     result = await tool.execute({"function_name": "solo", "output_format": "json"})
+
+    assert result["verdict"] == "NOT_FOUND"
+    assert result[count_key] == 0
+    assert "--full-index" in result["next_step"]
+    assert result["agent_summary"]["next_step"] == result["next_step"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("tool_cls", "count_key"),
+    [
+        (CodeGraphCallersTool, "caller_count"),
+        (CodeGraphCalleesTool, "callee_count"),
+    ],
+)
+async def test_existing_edges_without_call_graph_marker_still_hint_full_index(
+    tmp_path: Path,
+    tool_cls: type[CodeGraphCallersTool] | type[CodeGraphCalleesTool],
+    count_key: str,
+) -> None:
+    _seed_call_edges_without_built_marker(tmp_path)
+
+    tool = tool_cls(str(tmp_path))
+    result = await tool.execute({"function_name": "missing", "output_format": "json"})
 
     assert result["verdict"] == "NOT_FOUND"
     assert result[count_key] == 0

--- a/tests/unit/test_call_graph_built_signal.py
+++ b/tests/unit/test_call_graph_built_signal.py
@@ -291,3 +291,123 @@ def test_cli_callers_partial_ast_cache_matches_mcp_full_index_hint(
     assert result["caller_count"] == 0
     assert "--full-index" in result["next_step"]
     assert result["agent_summary"]["next_step"] == result["next_step"]
+
+
+# --- _completed_full_index_sweep (staticmethod) -----------------------------
+
+
+def test_completed_full_index_sweep_true_when_clean() -> None:
+    stats = {"truncated_by_max_files": False, "errors": 0, "skipped": 0}
+    assert ASTCache._completed_full_index_sweep(stats) is True
+
+
+def test_completed_full_index_sweep_false_when_truncated() -> None:
+    stats = {"truncated_by_max_files": True, "errors": 0, "skipped": 0}
+    assert ASTCache._completed_full_index_sweep(stats) is False
+
+
+def test_completed_full_index_sweep_false_when_errors() -> None:
+    stats = {"truncated_by_max_files": False, "errors": 1, "skipped": 0}
+    assert ASTCache._completed_full_index_sweep(stats) is False
+
+
+def test_completed_full_index_sweep_false_when_skipped() -> None:
+    stats = {"truncated_by_max_files": False, "errors": 0, "skipped": 1}
+    assert ASTCache._completed_full_index_sweep(stats) is False
+
+
+def test_completed_full_index_sweep_true_on_empty_stats_defaults() -> None:
+    # Missing keys default to not-truncated / 0 errors / 0 skipped.
+    assert ASTCache._completed_full_index_sweep({}) is True
+
+
+# --- _indexed_source_files_are_complete -------------------------------------
+
+
+def test_indexed_source_files_complete_false_on_empty_source_set(
+    tmp_path: Path,
+) -> None:
+    # No source files on disk → degenerate empty set → never "complete".
+    cache = ASTCache(str(tmp_path))
+    try:
+        assert cache._indexed_source_files_are_complete() is False
+    finally:
+        cache.close()
+
+
+def test_indexed_source_files_complete_true_when_index_matches_source(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "a.py").write_text("def a():\n    return 1\n", encoding="utf-8")
+    cache = ASTCache(str(tmp_path))
+    try:
+        result = cache.index_project(force=True, workers=0)
+        assert result["indexed"] == 1
+        assert cache._indexed_source_files_are_complete() is True
+    finally:
+        cache.close()
+
+
+def test_indexed_source_files_complete_false_when_source_added_after_index(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "a.py").write_text("def a():\n    return 1\n", encoding="utf-8")
+    cache = ASTCache(str(tmp_path))
+    try:
+        result = cache.index_project(force=True, workers=0)
+        assert result["indexed"] == 1
+        # A new source file the index has never seen breaks the equality.
+        (tmp_path / "b.py").write_text("def b():\n    return 2\n", encoding="utf-8")
+        assert cache._indexed_source_files_are_complete() is False
+    finally:
+        cache.close()
+
+
+# --- _mark_single_file_index_complete_if_needed -----------------------------
+
+
+def test_mark_single_file_complete_skips_non_indexed_status(
+    tmp_path: Path,
+) -> None:
+    cache = ASTCache(str(tmp_path))
+    try:
+        assert cache.call_graph_built() is False
+        # status not in {indexed, cached} → early return, no marker written.
+        cache._mark_single_file_index_complete_if_needed(
+            had_built_marker=True, result={"status": "error", "reason": "boom"}
+        )
+        assert cache.call_graph_built() is False
+    finally:
+        cache.close()
+
+
+def test_mark_single_file_complete_skips_skipped_status(
+    tmp_path: Path,
+) -> None:
+    cache = ASTCache(str(tmp_path))
+    try:
+        assert cache.call_graph_built() is False
+        cache._mark_single_file_index_complete_if_needed(
+            had_built_marker=True, result={"status": "skipped"}
+        )
+        assert cache.call_graph_built() is False
+    finally:
+        cache.close()
+
+
+def test_mark_single_file_complete_no_marker_when_index_incomplete(
+    tmp_path: Path,
+) -> None:
+    # status is indexable, but there was no prior marker and the source set is
+    # not fully indexed → neither branch fires, falls through without marking.
+    (tmp_path / "unindexed.py").write_text("def u():\n    return 0\n", encoding="utf-8")
+    cache = ASTCache(str(tmp_path))
+    try:
+        assert cache.call_graph_built() is False
+        assert cache._indexed_source_files_are_complete() is False
+        cache._mark_single_file_index_complete_if_needed(
+            had_built_marker=False, result={"status": "indexed"}
+        )
+        assert cache.call_graph_built() is False
+    finally:
+        cache.close()

--- a/tests/unit/test_callers_callees_tools.py
+++ b/tests/unit/test_callers_callees_tools.py
@@ -559,8 +559,15 @@ class TestEmptyIndexHint:
     async def test_callers_non_empty_index_no_spurious_hint(
         self, tiny_project_root
     ) -> None:
-        """When the index has call edges, NOT_FOUND for unknown symbol does NOT
-        mention --full-index (it's the symbol that's missing, not the index)."""
+        """When a built index has call edges, an unknown symbol gets no hint."""
+        cache = ASTCache(tiny_project_root)
+        try:
+            cache.index_project(workers=0)
+            assert cache.call_graph_built() is True
+            assert cache.has_call_edges() is True
+        finally:
+            cache.close()
+
         tool = CodeGraphCallersTool(tiny_project_root)
         result = await tool.execute(
             {
@@ -568,11 +575,10 @@ class TestEmptyIndexHint:
                 "output_format": "json",
             }
         )
-        # tiny_project_root has foo→bar edges, so the call graph is populated
         assert result["verdict"] == "NOT_FOUND"
         next_step = result.get("next_step", "")
         assert "--full-index" not in next_step, (
-            f"--full-index hint must NOT appear when index has edges; "
+            f"--full-index hint must NOT appear when built index has edges; "
             f"got: {next_step!r}"
         )
 

--- a/tree_sitter_analyzer/_ast_cache_indexer.py
+++ b/tree_sitter_analyzer/_ast_cache_indexer.py
@@ -169,6 +169,7 @@ def walk_and_partition(
         "skipped": 0,
         "files": [],
         "activation_enabled": activation_enabled,
+        "truncated_by_max_files": False,
     }
     if force:
         indexed_map: dict[str, tuple[int, int, int]] = {}
@@ -183,6 +184,7 @@ def walk_and_partition(
     count = 0
     for abs_path in walk_fn(cache.project_root):
         if count >= max_files:
+            stats["truncated_by_max_files"] = True
             break
         count += 1
         lang = language_fn(abs_path)

--- a/tree_sitter_analyzer/_graph_cache_fingerprint.py
+++ b/tree_sitter_analyzer/_graph_cache_fingerprint.py
@@ -27,6 +27,7 @@ from collections.abc import Iterable
 from pathlib import Path
 from typing import NamedTuple
 
+from ._lang_extension_map import EXT_TO_LANG
 from .constants import EXCLUDE_DIRS
 
 # Use the shared exclude set so the fingerprint scope matches the graph walkers
@@ -183,6 +184,7 @@ def is_ast_index_stale(project_root: str) -> bool:
     db_path = Path(project_root) / ".ast-cache" / "index.db"
     if not db_path.is_file():
         return False
+    root = Path(project_root)
     try:
         conn = sqlite3.connect(str(db_path), check_same_thread=False)
         try:
@@ -192,16 +194,44 @@ def is_ast_index_stale(project_root: str) -> bool:
     except sqlite3.Error:
         return False
 
+    if not rows:
+        return False
+
+    indexed_paths: set[str] = set()
     for file_path, recorded_mtime_ns in rows:
-        abs_path = (
-            Path(project_root) / file_path
-            if not Path(file_path).is_absolute()
-            else Path(file_path)
-        )
+        abs_path, rel_path = _indexed_abs_and_rel_path(root, str(file_path))
+        indexed_paths.add(rel_path)
         try:
             current_mtime_ns = abs_path.stat().st_mtime_ns
         except OSError:
-            continue
+            return True
         if current_mtime_ns > recorded_mtime_ns:
             return True
+    for rel_path in _walk_supported_source_paths(root):
+        if rel_path not in indexed_paths:
+            return True
     return False
+
+
+def _indexed_abs_and_rel_path(root: Path, file_path: str) -> tuple[Path, str]:
+    path = Path(file_path)
+    abs_path = path if path.is_absolute() else root / path
+    try:
+        rel_path = abs_path.relative_to(root).as_posix()
+    except ValueError:
+        rel_path = path.as_posix()
+    return abs_path, rel_path
+
+
+def _walk_supported_source_paths(root: Path) -> Iterable[str]:
+    """Yield project-relative paths accepted by the AST indexer."""
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [
+            d for d in dirnames if d not in _EXCLUDE_DIRS and not d.startswith(".")
+        ]
+        for fname in filenames:
+            if fname.startswith("."):
+                continue
+            ext = Path(fname).suffix.lower()
+            if ext in EXT_TO_LANG:
+                yield (Path(dirpath) / fname).relative_to(root).as_posix()

--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -215,13 +215,28 @@ class ASTCache:
         except OSError as e:
             return {"file": rel_path, "status": "error", "reason": str(e)}
         conn = self._get_conn()
+        had_built_marker = self.call_graph_built()
         cached_or_source = self._check_cache_or_read(conn, rel_path, abs_path, stat)
         if isinstance(cached_or_source, dict):
+            self._mark_single_file_index_complete_if_needed(
+                had_built_marker, cached_or_source
+            )
             return cached_or_source
         source_code, content_hash = cached_or_source
-        return self._parse_and_write(
+        result = self._parse_and_write(
             conn, abs_path, rel_path, language, stat, source_code, content_hash
         )
+        self._mark_single_file_index_complete_if_needed(had_built_marker, result)
+        return result
+
+    def _mark_single_file_index_complete_if_needed(
+        self, had_built_marker: bool, result: dict[str, Any]
+    ) -> None:
+        """Refresh the built marker after a successful single-file reindex."""
+        if result.get("status") not in {"indexed", "cached"}:
+            return
+        if had_built_marker or self._indexed_source_files_are_complete():
+            _mark_call_graph_built(self._get_conn())
 
     def _check_cache_or_read(
         self,
@@ -316,7 +331,6 @@ class ASTCache:
             synapse = self._run_synapse_backfill()
             edge_store_refresh = self._refresh_graph_edges_from_cache()
             unresolved = self._run_unresolved_refs_backfill()
-            _mark_call_graph_built(self._get_conn())
             return {
                 "mode_used": "resolve_only",
                 "resolve_only": True,
@@ -370,7 +384,8 @@ class ASTCache:
             stats["workers"] = workers
             if stats["indexed"] > 0:
                 self._post_index_backfill(stats)
-                _mark_call_graph_built(self._get_conn())
+                if self._completed_full_index_sweep(stats):
+                    _mark_call_graph_built(self._get_conn())
             if force:
                 stats["db_maintenance"] = _reclaim_storage_after_full_rebuild(
                     conn, self.db_path
@@ -397,6 +412,27 @@ class ASTCache:
             _AST_CACHE_EXTRACTOR_VERSION,
             _make_error_entry,
         )
+
+    @staticmethod
+    def _completed_full_index_sweep(stats: dict[str, Any]) -> bool:
+        """True when this run processed the whole source set without gaps."""
+        return (
+            not stats.get("truncated_by_max_files", False)
+            and stats.get("errors", 0) == 0
+            and stats.get("skipped", 0) == 0
+        )
+
+    def _indexed_source_files_are_complete(self) -> bool:
+        """Return True when ast_index covers exactly the current source set."""
+        source_files = {
+            os.path.relpath(path, self.project_root).replace("\\", "/")
+            for path in _walk_source_files(self.project_root)
+        }
+        if not source_files:
+            return False
+        rows = self._get_conn().execute("SELECT file_path FROM ast_index").fetchall()
+        indexed_files = {str(row["file_path"]).replace("\\", "/") for row in rows}
+        return indexed_files == source_files
 
     @staticmethod
     def _resolve_worker_count(workers: int | None, candidates: list[Any]) -> int:

--- a/tree_sitter_analyzer/mcp/tools/callees_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/callees_tool.py
@@ -134,7 +134,9 @@ class CodeGraphCalleesTool(CodeGraphRelationToolMixin, BaseMCPTool):
         call_graph_built = (
             self._cache_call_graph_built(cache) if cache is not None else False
         )
-        call_graph_indexed = cache is not None and cache.has_call_edges()
+        call_graph_indexed = (
+            cache is not None and call_graph_built and cache.has_call_edges()
+        )
         if call_graph_indexed:
             callees = self._sql_native_callees(
                 cache, func_name, file_path, include_activation
@@ -148,14 +150,9 @@ class CodeGraphCalleesTool(CodeGraphRelationToolMixin, BaseMCPTool):
             if include_activation:
                 self._enrich_graph_callees_with_activation(callees)
             self._enrich_callees_with_resolution(callees)
-            # Suppress the --full-index hint when either:
-            #   (a) the index was built (data_source=="cache") — even if it
-            #       has zero call edges, the user already ran --full-index; or
-            #   (b) the parse fallback itself found call edges — the project
-            #       has calls, so the symbol just isn't there.
-            # Only fire the hint when the index is absent AND the parse found
-            # no edges at all (truly empty/unbuilt state).
-            has_any_call_edges = call_graph_built or len(graph.call_edges()) > 0
+            # Only the persisted built marker proves that --full-index
+            # completed. Partial/stale edge rows must still surface the hint.
+            has_any_call_edges = call_graph_built
 
         warnings_list: list[str] = []
         if _is_stale_resolution(callees):

--- a/tree_sitter_analyzer/mcp/tools/callers_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/callers_tool.py
@@ -147,7 +147,9 @@ class CodeGraphCallersTool(CodeGraphRelationToolMixin, BaseMCPTool):
         call_graph_built = (
             self._cache_call_graph_built(cache) if cache is not None else False
         )
-        call_graph_indexed = cache is not None and cache.has_call_edges()
+        call_graph_indexed = (
+            cache is not None and call_graph_built and cache.has_call_edges()
+        )
         if call_graph_indexed and not is_qualified:
             callers, unattributed_call_sites = self._sql_native_callers(
                 cache, func_name, file_path, include_activation
@@ -159,14 +161,9 @@ class CodeGraphCallersTool(CodeGraphRelationToolMixin, BaseMCPTool):
             callers = graph.callers_of(func_name, file_path)
             data_source = self._data_source
             self._enrich_callers_with_resolution(callers)
-            # Suppress the --full-index hint when either:
-            #   (a) the index was built (data_source=="cache") — even if it
-            #       has zero call edges, the user already ran --full-index; or
-            #   (b) the parse fallback itself found call edges — the project
-            #       has calls, so the symbol just isn't there.
-            # Only fire the hint when the index is absent AND the parse found
-            # no edges at all (truly empty/unbuilt state).
-            has_any_call_edges = call_graph_built or len(graph.call_edges()) > 0
+            # Only the persisted built marker proves that --full-index
+            # completed. Partial/stale edge rows must still surface the hint.
+            has_any_call_edges = call_graph_built
 
         warnings_list: list[str] = []
         if _is_stale_resolution(callers):

--- a/tree_sitter_analyzer/mcp/tools/symbol_lineage_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/symbol_lineage_tool.py
@@ -314,6 +314,10 @@ class SymbolLineageTool(BaseMCPTool):
         # #568: also clear the per-symbol cache when the AST index changed
         # (hierarchy is index-derived; the source fingerprint above can't see it).
         self._invalidate_symbol_cache_on_index_change()
+        # #932: an unchanged index DB can still be stale relative to source
+        # edits/adds/deletes. Check before serving the per-symbol cache so a
+        # warm lineage response never hides stale hierarchy/index_hint data.
+        self._invalidate_symbol_cache_on_stale_ast_index()
 
         cached_response = self._try_cached_lineage(symbol, max_depth, started)
         if cached_response is not None:
@@ -502,6 +506,14 @@ class SymbolLineageTool(BaseMCPTool):
         """
         if self._index_signature() != self._ast_index_mtime_ns:
             self._symbol_cache = {}
+
+    def _invalidate_symbol_cache_on_stale_ast_index(self) -> None:
+        """Clear cached lineage responses when source has outpaced ast_index."""
+        if not self.project_root:
+            return
+        if is_ast_index_stale(str(self.project_root)):
+            self._symbol_cache = {}
+            self._cache_invalidated_reason = "ast_index_stale"
 
     def _hierarchy_for(self, symbol: str) -> dict[str, Any] | None:
         """#568: the advertised inheritance/override lineage.


### PR DESCRIPTION
## Summary
- Treat new, deleted, and modified supported source files as stale for AST-index freshness while preserving empty-index warm-cache behavior.
- Stop resolve-only and partial incremental runs from stamping the call-graph-built marker; refresh the marker from complete sweeps and valid single-file reindexes.
- Make callers/callees full-index hints depend on the authoritative built marker, and invalidate symbol-lineage cache before stale AST-index hits.
- Mark the real-git co_change performance fixture slow_ok; its own compute-path <2s assertion remains intact.

Fixes #931
Fixes #932
Fixes #933
Fixes #934
Fixes #935
Fixes #936
Fixes #937

## Verification
- uv run pytest tests/integration/test_ast_cache_lifecycle.py tests/unit/mcp/test_ast_cache_watch_modes.py tests/unit/mcp/test_symbol_lineage_tool.py tests/unit/mcp/tools/test_co_change.py tests/unit/test_ast_cache.py tests/unit/test_ast_cache_bfs.py tests/unit/test_ast_cache_build_state.py tests/unit/test_ast_cache_cascade_search.py tests/unit/test_ast_cache_maintenance.py tests/unit/test_ast_cache_mode_used.py tests/unit/test_ast_cache_tool.py tests/unit/test_ast_cache_utf8_bug.py tests/unit/test_callers_callees_tools.py tests/unit/test_codegraph_callees_tool.py -q
- uv run pytest tests/unit/mcp/test_symbol_lineage_tool.py tests/unit/test_call_graph_built_signal.py tests/unit/test_callers_callees_tools.py tests/unit/test_ast_cache.py --cov=tree_sitter_analyzer --cov-report=json -q
- uv run python scripts/check_patch_coverage.py --base origin/develop --coverage-json coverage.json
- uv run python scripts/generate_facade_actions_doc.py && uv run pytest tests/unit/docs/test_facade_actions_doc_drift.py -x
- uv run pytest -q