### PR TITLE
fix(codex): address P2 batch 961 findings

### DIFF
--- a/docs/CODEMAPS/languages.md
+++ b/docs/CODEMAPS/languages.md
@@ -9,16 +9,16 @@ Each implements the `LanguagePlugin` interface (`tree_sitter_analyzer/plugins/ba
 | Language | Plugin module | Extractor split | Notes |
 |---|---|---|---|
 | Java | `languages/java_plugin.py` | `_java_*_helpers.py` ×4 | Spring/JPA awareness; **fixture file — DO NOT refactor** (see CLAUDE.md memory rule) |
-| Python | `python_plugin/` | submodules | Type annotations, decorators, async |
-| TypeScript | `typescript_plugin/` | submodules | Interfaces, types, TSX/JSX |
+| Python | `python_plugin/` | submodules | Type annotations, decorators, async; module constants include chained and same-line assignments |
+| TypeScript | `typescript_plugin/` | submodules | Interfaces, types, TSX/JSX; enum kind/export parity and class-field decorators |
 | JavaScript | `javascript_plugin/` | submodules | ES6+, JSX; `_function_helpers.py` handles class-field arrow methods (is_method, is_static, computed/string/number key names — #890/#892); `queries/javascript.py` VARIABLES + "variable" query include `field_definition` (#891) |
-| C | `languages/c_plugin.py` | `_c_*_helpers.py` ×8 | functions, structs, unions, enums, preprocessor |
-| C++ | `languages/cpp_plugin.py` | `_cpp_*_helpers.py` ×11 | classes, templates, namespaces |
-| C# | `languages/csharp_plugin.py` | `languages/csharp_helpers.py` | records, async/await, attributes |
+| C | `languages/c_plugin.py` | `_c_*_helpers.py` ×8 | functions, structs, unions, enums, preprocessor; unnamed bitfields are skipped as non-addressable fields |
+| C++ | `languages/cpp_plugin.py` | `_cpp_*_helpers.py` ×11 | classes, templates, namespaces; nested template/union type parent metadata and field-reference guards |
+| C# | `languages/csharp_plugin.py` | `languages/csharp_helpers.py` | records, async/await, attributes; block and file-scoped namespaces surface as packages |
 | Go | `languages/go_plugin.py` | `_go_*_helpers.py` ×6 | structs, interfaces, goroutines |
 | Rust | `languages/rust_plugin.py` | inline | traits, impl, macros, derive |
 | Kotlin | `languages/kotlin_plugin.py` | `languages/kotlin_helpers.py` | data classes, coroutines |
-| Scala | `languages/scala_plugin.py` | inline | objects/traits, scaladoc |
+| Scala | `languages/scala_plugin.py` | inline | objects/traits, scaladoc; Scala 3 enum cases, givens, type members, extensions, and AST-cache symbol rows |
 | Swift | `languages/swift_plugin.py` | `_swift_plugin_*.py` ×3 | classes, structs, protocols; `.swift` + `.swiftinterface` (issue #131) |
 | Ruby | `languages/ruby_plugin.py` | `languages/ruby_helpers.py` | Rails patterns, metaprogramming |
 | PHP | `languages/php_plugin.py` | `languages/php_helpers.py` | PHP 8+ attributes, traits |

--- a/tests/unit/languages/test_c_cpp_fixes.py
+++ b/tests/unit/languages/test_c_cpp_fixes.py
@@ -127,6 +127,46 @@ class Outer {
         assert outer.class_type == "class"
         assert inner.class_type == "struct"
 
+    def test_field_type_reference_is_not_nested_class(self) -> None:
+        """struct Point field references inside Rect must not emit bogus nested Point."""
+        code = """\
+struct Point { int x; int y; };
+struct Rect { struct Point br; };
+"""
+        tree = _parse_cpp(code)
+        ext = CppElementExtractor()
+        classes = ext.extract_classes(tree, code)
+        names = [c.name for c in classes]
+
+        assert names.count("Point") == 1
+        assert not any(c.name == "Point" and c.parent_class == "Rect" for c in classes)
+
+    def test_template_nested_struct_has_parent_class(self) -> None:
+        code = """\
+class Outer {
+public:
+    template <typename T> struct Inner {};
+};
+"""
+        tree = _parse_cpp(code)
+        ext = CppElementExtractor()
+        inner = next(c for c in ext.extract_classes(tree, code) if c.name == "Inner")
+
+        assert inner.parent_class == "Outer"
+        assert "template" in inner.modifiers
+
+    def test_union_nested_struct_has_parent_class(self) -> None:
+        code = """\
+union Outer {
+    struct Inner { int x; };
+};
+"""
+        tree = _parse_cpp(code)
+        ext = CppElementExtractor()
+        inner = next(c for c in ext.extract_classes(tree, code) if c.name == "Inner")
+
+        assert inner.parent_class == "Outer"
+
 
 # ---------------------------------------------------------------------------
 # Bug #752 — C typedef struct regression guard (no duplicate entries)
@@ -241,3 +281,23 @@ class TestBug753CAnonymousNestedContainerSkipped:
 
         names = sorted(c.name for c in classes)
         assert names == ["Inner", "Outer"]
+
+
+class TestBitfields:
+    """Unnamed C/C++ bitfields are padding, not addressable field symbols."""
+
+    def test_c_unnamed_bitfield_is_skipped(self) -> None:
+        code = "struct Flags { unsigned : 1; unsigned enabled : 1; };\n"
+        tree = _parse_c(code)
+        ext = CElementExtractor()
+        names = [v.name for v in ext.extract_variables(tree, code)]
+
+        assert names == ["enabled"]
+
+    def test_cpp_unnamed_bitfield_is_skipped(self) -> None:
+        code = "struct Flags { unsigned : 1; unsigned enabled : 1; };\n"
+        tree = _parse_cpp(code)
+        ext = CppElementExtractor()
+        names = [v.name for v in ext.extract_variables(tree, code)]
+
+        assert names == ["enabled"]

--- a/tests/unit/languages/test_csharp_plugin_extraction.py
+++ b/tests/unit/languages/test_csharp_plugin_extraction.py
@@ -509,6 +509,35 @@ class TestCSharpNamespacePackageExtraction:
         assert len(packages) == 1
         assert packages[0].name == "MyApp"
 
+    def test_file_scoped_namespace_produces_package_element(self):
+        """C# 10 file-scoped namespace declarations use a distinct node type."""
+        src = "namespace MyApp.Services;\npublic class Foo {}\n"
+        plugin = CSharpPlugin()
+        tree = get_tree_for_code(src, plugin)
+        packages = plugin.extractor.extract_packages(tree, src)
+
+        assert len(packages) == 1
+        assert packages[0].name == "MyApp.Services"
+
+    def test_multiple_block_namespaces_are_all_extracted(self):
+        src = (
+            "namespace First { public class A {} }\n"
+            "namespace Second { public class B {} }\n"
+        )
+        plugin = CSharpPlugin()
+        tree = get_tree_for_code(src, plugin)
+        packages = plugin.extractor.extract_packages(tree, src)
+
+        assert [pkg.name for pkg in packages] == ["First", "Second"]
+
+    def test_grouped_extract_elements_includes_packages(self):
+        plugin = CSharpPlugin()
+        tree = get_tree_for_code(SIMPLE_CLASS_CODE, plugin)
+        grouped = plugin.extract_elements(tree, SIMPLE_CLASS_CODE)
+
+        assert "packages" in grouped
+        assert grouped["packages"][0].name == "MyApp.Models"
+
     def test_no_namespace_returns_empty(self):
         """A C# file without a namespace declaration returns no Package."""
         src = "public class Bare {}\n"

--- a/tests/unit/languages/test_python_module_constants.py
+++ b/tests/unit/languages/test_python_module_constants.py
@@ -130,6 +130,15 @@ class TestPluginModuleConstants:
         )
         assert names == ["A_ONE", "B_TWO"]
 
+    def test_single_line_semicolon_assignments_capture_every_constant(self):
+        source = "A_ONE = 1; B_TWO = 2\n"
+        result = Parser().parse_code(source, "python")
+        names = sorted(
+            v.name
+            for v in PythonElementExtractor().extract_variables(result.tree, source)
+        )
+        assert names == ["A_ONE", "B_TWO"]
+
     def test_none_tree_yields_no_constants(self):
         assert extract_module_constants(None, "") == []
 

--- a/tests/unit/languages/test_scala_fixes.py
+++ b/tests/unit/languages/test_scala_fixes.py
@@ -133,6 +133,29 @@ class TestEnumCaseExtraction:
         classes = _classes(_ENUM_WITH_PARAMS)
         assert classes["Mercury"].parent_class == "Planet"
 
+    def test_full_enum_cases_with_constructor_params_are_extracted(self) -> None:
+        code = """\
+enum Command:
+  case Quit
+  case Move(dx: Int, dy: Int)
+  case Error(code: Int) extends Command
+"""
+        classes = _classes(code)
+        assert classes["Move"].class_type == "enum_member"
+        assert classes["Move"].parent_class == "Command"
+        assert "dx: Int" in classes["Move"].raw_text
+        assert classes["Error"].superclass == "Command"
+
+    def test_enum_modifiers_are_preserved(self) -> None:
+        classes = _classes(
+            """\
+private enum Secret:
+  case Token
+"""
+        )
+        assert classes["Secret"].visibility == "private"
+        assert "private" in classes["Secret"].modifiers
+
 
 # ---------------------------------------------------------------------------
 # Bug #764: given/type/extension inside object/trait must carry parent_class
@@ -239,3 +262,84 @@ class TestGivenTypeParentClass:
     def test_nested_type_alias_parent_class(self) -> None:
         classes = _classes(_NESTED_MIX)
         assert classes["AliasT"].parent_class == "Outer"
+
+    def test_local_given_and_type_inside_method_are_not_members(self) -> None:
+        classes = _classes(
+            """\
+object Ops:
+  def configure(): Unit =
+    given localOrdering: Ordering[Int] = Ordering.Int
+    type LocalAlias = String
+"""
+        )
+        assert "localOrdering" not in classes
+        assert "LocalAlias" not in classes
+
+    def test_given_and_type_modifiers_are_preserved(self) -> None:
+        classes = _classes(
+            """\
+object Api:
+  private given secret: String = "s"
+  protected type Hidden = Int
+"""
+        )
+        assert classes["secret"].visibility == "private"
+        assert "private" in classes["secret"].modifiers
+        assert classes["Hidden"].visibility == "protected"
+        assert "protected" in classes["Hidden"].modifiers
+
+    def test_anonymous_givens_use_distinct_type_based_names(self) -> None:
+        classes = _classes(
+            """\
+object Instances:
+  given Ordering[Int] = Ordering.Int
+  given Ordering[String] = Ordering.String
+"""
+        )
+        assert "given Ordering[Int]" in classes
+        assert "given Ordering[String]" in classes
+
+    def test_abstract_type_members_are_not_reported_as_aliases(self) -> None:
+        classes = _classes(
+            """\
+trait Api:
+  type Out
+  type In <: String
+  type Alias = Int
+"""
+        )
+        assert classes["Out"].class_type == "type_member"
+        assert classes["In"].class_type == "type_member"
+        assert classes["Alias"].class_type == "type_alias"
+
+    def test_extension_symbol_and_method_keep_owner_context(self) -> None:
+        code = """\
+object Ops:
+  extension (s: String)
+    def shout: String = s.toUpperCase
+"""
+        classes = _classes(code)
+        functions = _functions(code)
+        assert classes["extension[String]"].class_type == "extension"
+        assert classes["extension[String]"].parent_class == "Ops"
+        assert functions["shout"].parent_class == "Ops"
+        assert functions["shout"].receiver_type == "String"
+
+
+def test_scala_ast_cache_symbol_path_indexes_new_constructs() -> None:
+    from tree_sitter_analyzer._ast_extraction import _extract_symbols
+
+    code = """\
+object Instances:
+  given Ordering[Int] = Ordering.Int
+  type Alias = Int
+
+enum Color:
+  case Red
+"""
+    symbols = _extract_symbols(_parse(code), code, "scala")["symbols"]
+    by_name = {s["name"]: s for s in symbols}
+    assert by_name["Instances"]["kind"] == "class"
+    assert by_name["given Ordering[Int]"]["kind"] == "class"
+    assert by_name["Alias"]["kind"] == "class"
+    assert by_name["Color"]["kind"] == "enum"

--- a/tests/unit/languages/test_typescript_extraction_fixes.py
+++ b/tests/unit/languages/test_typescript_extraction_fixes.py
@@ -233,6 +233,16 @@ class Foo {
     assert fn.decorators == []
 
 
+def test_property_decorator_column() -> None:
+    """@Column() on a class field must be captured in Variable.decorators."""
+    tree = _parse(_DECORATOR_CLASS_CODE)
+    extractor = TypeScriptElementExtractor()
+    variables = extractor.extract_variables(tree, _DECORATOR_CLASS_CODE)
+    name_field = next(v for v in variables if v.name == "name")
+
+    assert "Column" in name_field.decorators
+
+
 def test_class_without_decorator_has_empty_list() -> None:
     code = """\
 class Foo {}
@@ -287,3 +297,43 @@ def test_enum_kind_in_ast_extraction() -> None:
         assert sym["kind"] == "enum", (
             f"Expected kind='enum' for {sym['name']!r}, got {sym['kind']!r}"
         )
+
+
+def test_exported_enum_interface_and_type_are_detected() -> None:
+    code = """\
+export enum Status { Active, Inactive }
+export interface Shape {}
+export type Id = string
+class Local {}
+export { Local }
+"""
+    classes = {c.name: c for c in _classes(code)}
+
+    assert classes["Status"].is_exported is True
+    assert classes["Shape"].is_exported is True
+    assert classes["Id"].is_exported is True
+    assert classes["Local"].is_exported is True
+
+
+def test_enum_export_surface_includes_members() -> None:
+    from tree_sitter_analyzer.mcp.tools.utils.element_extractor import get_all_exports
+    from tree_sitter_analyzer.models import AnalysisResult
+
+    code = "export enum Status { Active = 'active', Inactive = 'inactive' }"
+    result = AnalysisResult(
+        file_path="status.ts",
+        language="typescript",
+        elements=_classes(code),
+        source_code=code,
+    )
+    exports = get_all_exports(result)
+    enum_export = next(e for e in exports if e["name"] == "Status")
+
+    assert enum_export["kind"] == "enum"
+    assert enum_export["members"] == ["Active", "Inactive"]
+
+
+def test_enum_kind_is_available_in_symbol_search_filters() -> None:
+    from tree_sitter_analyzer.mcp.tools.symbol_search_tool import SYMBOL_SEARCH_KINDS
+
+    assert "enum" in SYMBOL_SEARCH_KINDS

--- a/tests/unit/mcp/test_symbol_lineage_fixes.py
+++ b/tests/unit/mcp/test_symbol_lineage_fixes.py
@@ -1,7 +1,5 @@
-"""Regression tests for issues #756 and #757 in symbol_lineage_tool.
+"""Regression tests for symbol_lineage_tool scope and caller enrichment.
 
-#756: file_paths scope parameter is silently ignored — response must carry a
-      scope_note when file_paths is provided, and the CLI spec must pass it.
 #757: ref_count counts only import references, not actual call-site callers —
       the call graph must be queried for real callers.
 """
@@ -29,15 +27,12 @@ def _make_tool(tmp_path: Path) -> SymbolLineageTool:
 
 
 # ---------------------------------------------------------------------------
-# #756: scope_note emitted when file_paths provided
+# file_paths scope filtering
 # ---------------------------------------------------------------------------
 
 
-class TestFilepathsScopeNote:
-    """#756: when file_paths is passed, lineage must emit a scope_note
-    telling the caller that results are project-wide and file_paths is
-    not a scope filter for this tool.
-    """
+class TestFilepathsScopeFilter:
+    """file_paths filters reference/call-site rows while keeping definitions."""
 
     def test_scope_note_absent_when_no_file_paths(self, tmp_path):
         """No file_paths → no scope_note (clean envelope)."""
@@ -46,10 +41,26 @@ class TestFilepathsScopeNote:
         result = asyncio.run(tool.execute({"symbol": "foo", "output_format": "json"}))
         assert result["success"] is True
         assert "scope_note" not in result
+        assert result["scope_filtered"] is False
 
-    def test_scope_note_present_when_file_paths_provided(self, tmp_path):
-        """file_paths is given → scope_note must be present in the response."""
-        _write_py(tmp_path, "a.py", "def foo():\n    pass\n")
+    def test_file_paths_filter_references(self, tmp_path):
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        _write_py(tmp_path, "lib.py", "def foo():\n    return 1\n")
+        _write_py(
+            tmp_path,
+            "a.py",
+            "from lib import foo\n\ndef use_a():\n    return foo()\n",
+        )
+        _write_py(
+            tmp_path,
+            "b.py",
+            "from lib import foo\n\ndef use_b():\n    return foo()\n",
+        )
+        cache = ASTCache(str(tmp_path))
+        cache.index_project(max_files=50)
+        cache.close()
+
         tool = _make_tool(tmp_path)
         result = asyncio.run(
             tool.execute(
@@ -61,24 +72,56 @@ class TestFilepathsScopeNote:
             )
         )
         assert result["success"] is True
-        assert "scope_note" in result
+        assert result["scope_filtered"] is True
+        assert result["scope_filter"] == ["a.py"]
+        assert {r["file"] for r in result["references"]} == {"a.py"}
+        assert result["definition_count"] == 1
 
-    def test_scope_note_mentions_project_wide(self, tmp_path):
-        """scope_note must state that lineage is project-wide."""
+    def test_scope_note_mentions_filtered_references(self, tmp_path):
         _write_py(tmp_path, "a.py", "def foo():\n    pass\n")
         tool = _make_tool(tmp_path)
         result = asyncio.run(
             tool.execute(
                 {
                     "symbol": "foo",
-                    "file_paths": ["x/empty.py", "y/other.py"],
+                    "file_paths": ["a.py"],
                     "output_format": "json",
                 }
             )
         )
         assert "scope_note" in result
         note = result["scope_note"].lower()
-        assert "project" in note
+        assert "filters references" in note
+
+    def test_scope_cache_key_does_not_cross_pollute(self, tmp_path):
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        _write_py(tmp_path, "lib.py", "def foo():\n    return 1\n")
+        _write_py(
+            tmp_path,
+            "a.py",
+            "from lib import foo\n\ndef use_a():\n    return foo()\n",
+        )
+        _write_py(
+            tmp_path,
+            "b.py",
+            "from lib import foo\n\ndef use_b():\n    return foo()\n",
+        )
+        cache = ASTCache(str(tmp_path))
+        cache.index_project(max_files=50)
+        cache.close()
+
+        tool = _make_tool(tmp_path)
+        scoped = asyncio.run(
+            tool.execute(
+                {"symbol": "foo", "file_paths": ["a.py"], "output_format": "json"}
+            )
+        )
+        unscoped = asyncio.run(tool.execute({"symbol": "foo", "output_format": "json"}))
+
+        assert {r["file"] for r in scoped["references"]} == {"a.py"}
+        assert {"a.py", "b.py"} <= {r["file"] for r in unscoped["references"]}
+        assert "scope_note" not in unscoped
 
     def test_file_paths_in_tool_schema(self, tmp_path):
         """file_paths must be declared in the tool schema so MCP callers can pass it."""
@@ -120,7 +163,7 @@ class TestFilepathsScopeNote:
 
     def test_cli_spec_file_paths_none_not_included(self, tmp_path):
         """When CLI --file-paths is not set (None), file_paths must not appear
-        in the tool args (clean envelope, no spurious scope_note)."""
+        in the tool args (clean envelope, no spurious scope)."""
         from tree_sitter_analyzer.cli.commands.mcp_commands._specs_core import (
             _CORE_SPECS,
         )
@@ -135,8 +178,8 @@ class TestFilepathsScopeNote:
 
         args = _FakeArgs()
         tool_args = spec.build_tool_args(args, "json")
-        # file_paths absent OR None — either is fine, but scope_note must not
-        # fire (tested in test_scope_note_absent_when_no_file_paths above).
+        # file_paths absent OR None — either is fine, but scoped filtering must
+        # not fire (tested in test_scope_note_absent_when_no_file_paths above).
         assert tool_args.get("file_paths") is None or "file_paths" not in tool_args
 
 
@@ -256,3 +299,85 @@ class TestRefCountIncludesCallers:
         assert len(ref_keys) == len(set(ref_keys)), (
             f"Duplicate references found: {ref_keys}"
         )
+
+    def test_multiple_calls_use_call_site_lines(self, tmp_path):
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        _write_py(tmp_path, "lib.py", "def target():\n    return 1\n")
+        _write_py(
+            tmp_path,
+            "caller.py",
+            (
+                "from lib import target\n\n"
+                "def f():\n"
+                "    x = target()\n"
+                "    y = target()\n"
+                "    return x + y\n"
+            ),
+        )
+        cache = ASTCache(str(tmp_path))
+        cache.index_project(max_files=50)
+        cache.close()
+
+        tool = _make_tool(tmp_path)
+        result = asyncio.run(
+            tool.execute({"symbol": "target", "output_format": "json"})
+        )
+        call_lines = sorted(
+            r["start_line"] for r in result["references"] if r["type"] == "call_site"
+        )
+
+        assert call_lines == [4, 5]
+
+    def test_qualified_symbol_name_is_preserved_for_callers(self, tmp_path):
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        _write_py(tmp_path, "lib.py", "def target():\n    return 1\n")
+        _write_py(tmp_path, "other.py", "def target():\n    return 2\n")
+        _write_py(
+            tmp_path,
+            "main.py",
+            (
+                "import lib\n"
+                "import other\n\n"
+                "def use_lib():\n"
+                "    return lib.target()\n\n"
+                "def use_other():\n"
+                "    return other.target()\n"
+            ),
+        )
+        cache = ASTCache(str(tmp_path))
+        cache.index_project(max_files=50)
+        cache.close()
+
+        tool = _make_tool(tmp_path)
+        result = asyncio.run(
+            tool.execute({"symbol": "lib.target", "output_format": "json"})
+        )
+        call_refs = [r for r in result["references"] if r["type"] == "call_site"]
+
+        assert [r["name"] for r in call_refs] == ["use_lib"]
+        assert [r["start_line"] for r in call_refs] == [5]
+
+    def test_stale_call_graph_does_not_enrich_refs(self, tmp_path):
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        _write_py(tmp_path, "lib.py", "def gone():\n    return 1\n")
+        _write_py(
+            tmp_path,
+            "caller.py",
+            "from lib import gone\n\ndef f():\n    return gone()\n",
+        )
+        cache = ASTCache(str(tmp_path))
+        cache.index_project(max_files=50)
+        cache.close()
+        _write_py(
+            tmp_path,
+            "caller.py",
+            "from lib import gone\n\ndef f():\n    return 0\n",
+        )
+
+        tool = _make_tool(tmp_path)
+        result = asyncio.run(tool.execute({"symbol": "gone", "output_format": "json"}))
+
+        assert not any(r["type"] == "call_site" for r in result["references"])

--- a/tests/unit/mcp/tools/test_facade_tool.py
+++ b/tests/unit/mcp/tools/test_facade_tool.py
@@ -547,12 +547,13 @@ def test_search_facade_schema_declares_kind_with_enum() -> None:
     from tree_sitter_analyzer.mcp.tools.symbol_search_tool import SYMBOL_SEARCH_KINDS
 
     # The authoritative enum: exactly the kinds _extract_symbols emits into
-    # ast_symbol_rows (function/method/class/variable/import/constant) plus
+    # ast_symbol_rows (function/method/class/enum/variable/import/constant) plus
     # the "any" no-filter default. Exact pin — extraction changes must re-pin.
     assert SYMBOL_SEARCH_KINDS == (
         "function",
         "method",
         "class",
+        "enum",
         "variable",
         "import",
         "constant",

--- a/tests/unit/test_scala_language_wiring.py
+++ b/tests/unit/test_scala_language_wiring.py
@@ -92,7 +92,9 @@ def test_ast_cache_indexes_scala_file() -> None:
         cache.index_project()
         conn = cache.get_conn()
         count = conn.execute("SELECT COUNT(*) FROM ast_symbol_rows").fetchone()[0]
-        assert count == 86, f"expected exactly 86 scala symbols indexed, got {count}"
+        # Repinned 2026-06-15: Scala object/trait/enum/given/type symbols are
+        # now indexed in the AST cache instead of only the plugin extractor.
+        assert count == 107, f"expected exactly 107 scala symbols indexed, got {count}"
         cache.close()
     finally:
         shutil.rmtree(d, ignore_errors=True)

--- a/tree_sitter_analyzer/_ast_extraction.py
+++ b/tree_sitter_analyzer/_ast_extraction.py
@@ -183,6 +183,16 @@ _CLASS_LIKE = frozenset(
     | _ENUM_LIKE
 )
 
+_SCALA_CLASS_LIKE = frozenset(
+    {
+        "object_definition",
+        "trait_definition",
+        "enum_definition",
+        "given_definition",
+        "type_definition",
+    }
+)
+
 _IMPORT_LIKE = frozenset(
     {
         "import_statement",
@@ -832,6 +842,50 @@ def _c_declarator_name(declarator: Any, source: str, depth: int) -> str | None:
     return None
 
 
+def _scala_symbol_from_node(node: Any, source: str) -> dict[str, Any] | None:
+    node_type = node.type
+    if node_type not in _SCALA_CLASS_LIKE:
+        return None
+    name = _scala_symbol_name(node, source)
+    if not name:
+        return None
+    return {
+        "kind": "enum" if node_type == "enum_definition" else "class",
+        "name": name,
+        "line": node.start_point[0] + 1,
+        "end_line": node.end_point[0] + 1,
+        "language": "scala",
+    }
+
+
+def _scala_symbol_name(node: Any, source: str) -> str | None:
+    name_node = node.child_by_field_name("name")
+    if name_node is not None:
+        return _node_text(name_node, source)
+    for child in node.children:
+        if child.type in ("identifier", "type_identifier"):
+            return _node_text(child, source)
+    if node.type == "given_definition":
+        type_name = _scala_given_type_text(node, source)
+        if type_name:
+            return f"given {type_name}"
+        return f"anonymous_given_{node.start_point[0] + 1}"
+    return None
+
+
+def _scala_given_type_text(node: Any, source: str) -> str | None:
+    for child in node.children:
+        if child.type in (
+            "generic_type",
+            "type_identifier",
+            "stable_type_identifier",
+            "tuple_type",
+            "function_type",
+        ):
+            return _node_text(child, source)
+    return None
+
+
 _WALK_MAX_DEPTH = (
     100  # #779: DoS protection — functions nested beyond this are dropped.
 )
@@ -911,6 +965,10 @@ def _walk_for_symbols(
             sym["kind"] = "method"
             sym["class"] = parent_cls
         symbols.append(sym)
+    elif language == "scala" and node_type in _SCALA_CLASS_LIKE:
+        scala_sym = _scala_symbol_from_node(node, source)
+        if scala_sym is not None:
+            symbols.append(scala_sym)
     elif node_type in _CLASS_LIKE and name_node is not None:
         name = _node_text(name_node, source)
         parents = _extract_parent_classes(node, source, language)

--- a/tree_sitter_analyzer/cli/commands/mcp_commands/_specs_core.py
+++ b/tree_sitter_analyzer/cli/commands/mcp_commands/_specs_core.py
@@ -131,9 +131,8 @@ _CORE_SPECS: tuple[McpCommandSpec, ...] = (
             "symbol": getattr(args, "symbol_lineage", "") or "",
             "max_depth": getattr(args, "max_depth", 3),
             "output_format": output_format,
-            # #756: pass file_paths when present so the tool can emit a
-            # scope_note warning that lineage is project-wide.  Omit when
-            # None to avoid triggering the note unnecessarily.
+            # Pass file_paths only when present so symbol-lineage scopes
+            # references/call sites without adding a scope note unnecessarily.
             **(
                 {"file_paths": getattr(args, "file_paths", None)}
                 if getattr(args, "file_paths", None)

--- a/tree_sitter_analyzer/codegraph_query_backend.py
+++ b/tree_sitter_analyzer/codegraph_query_backend.py
@@ -9,7 +9,9 @@ from typing import Any
 from .semantic_search import SemanticSymbolSearch
 
 # #610: "constant" — Python module-level constants are definition sites.
-_DEFINITION_KINDS = frozenset({"function", "class", "method", "variable", "constant"})
+_DEFINITION_KINDS = frozenset(
+    {"function", "class", "enum", "method", "variable", "constant"}
+)
 
 
 class CodeGraphQueryBackend:
@@ -92,7 +94,7 @@ class CodeGraphQueryBackend:
             rows = conn.execute(
                 """SELECT name, kind, file_path, language, line, end_line
                    FROM ast_symbol_rows
-                   WHERE name = ? AND kind IN ('function', 'class', 'method', 'variable', 'constant')
+                   WHERE name = ? AND kind IN ('function', 'class', 'enum', 'method', 'variable', 'constant')
                    ORDER BY file_path, line""",
                 (symbol,),
             ).fetchall()

--- a/tree_sitter_analyzer/languages/_c_declaration_helpers.py
+++ b/tree_sitter_analyzer/languages/_c_declaration_helpers.py
@@ -100,7 +100,7 @@ def _field_parts(
         elif child.type == "type_qualifier":
             _append_modifier(modifiers, child, get_node_text)
         elif child.type == "field_identifier":
-            field_names.append(get_node_text(child))
+            _append_nonempty_name(field_names, child, get_node_text)
         elif child.type == "array_declarator":
             field_type = _append_array_fields(
                 child, field_names, field_type, get_node_text
@@ -154,7 +154,7 @@ def _append_initializer_fields(
 ) -> None:
     for grandchild in node.children:
         if grandchild.type in {"field_identifier", "identifier"}:
-            field_names.append(get_node_text(grandchild))
+            _append_nonempty_name(field_names, grandchild, get_node_text)
 
 
 def _append_pointer_fields(
@@ -188,8 +188,18 @@ def _append_child_names(
     initial_len = len(names)
     for child in node.children:
         if child.type == node_type:
-            names.append(get_node_text(child))
+            _append_nonempty_name(names, child, get_node_text)
     return len(names) > initial_len
+
+
+def _append_nonempty_name(
+    names: list[str],
+    node: Any,
+    get_node_text: Callable[..., str],
+) -> None:
+    name = get_node_text(node)
+    if name:
+        names.append(name)
 
 
 def _append_modifier(

--- a/tree_sitter_analyzer/languages/_cpp_element_helpers.py
+++ b/tree_sitter_analyzer/languages/_cpp_element_helpers.py
@@ -29,7 +29,9 @@ class CppClassExtractionContext:
     extract_comment_for_line: Callable[[int], str | None]
 
 
-_CPP_CLASS_NODE_TYPES = frozenset({"class_specifier", "struct_specifier"})
+_CPP_CLASS_NODE_TYPES = frozenset(
+    {"class_specifier", "struct_specifier", "union_specifier"}
+)
 _CPP_CLASS_PARENT_WALK_LIMIT = 12
 _CPP_NAMESPACE_PARENT_WALK_LIMIT = 16
 _CPP_NAMESPACE_NAME_NODE_TYPES = frozenset(
@@ -194,30 +196,48 @@ def extract_cpp_function(
 
 def _cpp_direct_parent_class_name(node: Any) -> str | None:
     """Return the enclosing class/struct name when ``node`` is a nested type
-    declared directly inside a class body (one level up via field_declaration).
+    declared directly inside a class body.
 
-    Walk: node → field_declaration → field_declaration_list → class/struct/union_specifier
-    with a hard cap to avoid infinite walks on mocked nodes.
+    Handles both ordinary declarations and templated nested types:
+    ``node → field_declaration → field_declaration_list → owner`` and
+    ``node → template_declaration → field_declaration_list → owner``.
+    The hard cap avoids infinite walks on mocked nodes.
     """
-    parent = getattr(node, "parent", None)
-    if parent is None or getattr(parent, "type", "") != "field_declaration":
-        return None
-    grandparent = getattr(parent, "parent", None)
-    if (
-        grandparent is None
-        or getattr(grandparent, "type", "") != "field_declaration_list"
-    ):
-        return None
-    great = getattr(grandparent, "parent", None)
-    if great is None or getattr(great, "type", "") not in _CPP_CLASS_NODE_TYPES:
-        return None
-    for child in getattr(great, "children", ()):
+    current = getattr(node, "parent", None)
+    depth = 0
+    while current is not None and depth < _CPP_CLASS_PARENT_WALK_LIMIT:
+        if getattr(current, "type", "") == "field_declaration_list":
+            owner = getattr(current, "parent", None)
+            if getattr(owner, "type", "") in _CPP_CLASS_NODE_TYPES:
+                return _cpp_type_name(owner)
+            return None
+        current = getattr(current, "parent", None)
+        depth += 1
+    return None
+
+
+def _cpp_type_name(node: Any) -> str | None:
+    for child in getattr(node, "children", ()):
         if getattr(child, "type", "") == "type_identifier":
             text = getattr(child, "text", b"")
             if isinstance(text, bytes):
                 return text.decode("utf-8", errors="replace")
             return str(text)
     return None
+
+
+def _cpp_has_definition_body(node: Any) -> bool:
+    return any(
+        getattr(child, "type", "")
+        in {"field_declaration_list", "declaration_list", "enumerator_list"}
+        for child in getattr(node, "children", ())
+    )
+
+
+def _is_cpp_field_type_reference(node: Any) -> bool:
+    return getattr(
+        getattr(node, "parent", None), "type", ""
+    ) == "field_declaration" and not _cpp_has_definition_body(node)
 
 
 def extract_cpp_class(
@@ -232,6 +252,8 @@ def extract_cpp_class(
             node, ctx.get_node_text, ctx.extract_base_classes
         )
         if not class_name:
+            return None
+        if _is_cpp_field_type_reference(node):
             return None
 
         start_line = node.start_point[0] + 1

--- a/tree_sitter_analyzer/languages/_cpp_variable_helpers.py
+++ b/tree_sitter_analyzer/languages/_cpp_variable_helpers.py
@@ -10,6 +10,7 @@ from ..utils import log_debug
 _TYPE_NODES_CPP = frozenset(
     {
         "primitive_type",
+        "sized_type_specifier",
         "type_identifier",
         "qualified_identifier",
         "template_type",
@@ -118,7 +119,7 @@ def _apply_variable_child(
     elif child.type in ("storage_class_specifier", "type_qualifier"):
         _append_text_modifier(parts.modifiers, child, get_node_text)
     elif child.type in declarator_name_types:
-        parts.names.append(get_node_text(child))
+        _append_nonempty_name(parts.names, child, get_node_text)
     elif child.type == "init_declarator":
         parts.names.extend(
             _init_declarator_names(child, get_node_text, declarator_name_types)
@@ -138,11 +139,21 @@ def _init_declarator_names(
     get_node_text: Callable[..., str],
     declarator_name_types: tuple[str, ...],
 ) -> list[str]:
-    return [
-        get_node_text(child)
-        for child in node.children
-        if child.type in declarator_name_types
-    ]
+    names: list[str] = []
+    for child in node.children:
+        if child.type in declarator_name_types:
+            _append_nonempty_name(names, child, get_node_text)
+    return names
+
+
+def _append_nonempty_name(
+    names: list[str],
+    node: Any,
+    get_node_text: Callable[..., str],
+) -> None:
+    name = get_node_text(node)
+    if name:
+        names.append(name)
 
 
 def _build_variables(

--- a/tree_sitter_analyzer/languages/csharp_plugin.py
+++ b/tree_sitter_analyzer/languages/csharp_plugin.py
@@ -154,7 +154,7 @@ class CSharpElementExtractor(ElementExtractor):
         Args:
             node: Root node of the AST
         """
-        if node.type == "namespace_declaration":
+        if node.type in ("namespace_declaration", "file_scoped_namespace_declaration"):
             name_node = node.child_by_field_name("name")
             if name_node:
                 self.current_namespace = self._get_node_text_optimized(name_node)
@@ -162,7 +162,10 @@ class CSharpElementExtractor(ElementExtractor):
 
         # Recursively search for namespace
         for child in node.children:
-            if child.type == "namespace_declaration":
+            if child.type in (
+                "namespace_declaration",
+                "file_scoped_namespace_declaration",
+            ):
                 name_node = child.child_by_field_name("name")
                 if name_node:
                     self.current_namespace = self._get_node_text_optimized(name_node)
@@ -459,7 +462,10 @@ class CSharpElementExtractor(ElementExtractor):
             return packages
 
         for node in self._traverse_iterative(tree.root_node):
-            if node.type != "namespace_declaration":
+            if node.type not in (
+                "namespace_declaration",
+                "file_scoped_namespace_declaration",
+            ):
                 continue
             name_node = node.child_by_field_name("name")
             if name_node is None:
@@ -476,10 +482,19 @@ class CSharpElementExtractor(ElementExtractor):
                     language="csharp",
                 )
             )
-            # Only capture the outermost (first) namespace per file
-            break
-
         return packages
+
+    def extract_elements(
+        self, tree: tree_sitter.Tree, source_code: str
+    ) -> dict[str, list[Any]]:
+        """Extract grouped C# elements, including namespace packages."""
+        return {
+            "functions": self.extract_functions(tree, source_code),
+            "classes": self.extract_classes(tree, source_code),
+            "variables": self.extract_variables(tree, source_code),
+            "imports": self.extract_imports(tree, source_code),
+            "packages": self.extract_packages(tree, source_code),
+        }
 
 
 class CSharpPlugin(LanguagePlugin):

--- a/tree_sitter_analyzer/languages/scala_plugin.py
+++ b/tree_sitter_analyzer/languages/scala_plugin.py
@@ -138,16 +138,7 @@ class ScalaElementExtractor(ElementExtractor):
 
         functions: list[Function] = []
 
-        extractors = {
-            "function_definition": self._extract_function,
-            "function_declaration": self._extract_function_declaration,
-        }
-
-        self._traverse_and_extract(
-            tree.root_node,
-            extractors,
-            functions,
-        )
+        self._traverse_functions_with_context(tree.root_node, functions, None, None)
 
         log_debug(f"Extracted {len(functions)} Scala functions")
         return functions
@@ -408,9 +399,6 @@ class ScalaElementExtractor(ElementExtractor):
                 cls = self._extract_given(current, current_parent)
                 if cls:
                     results.append(cls)
-                # given bodies can theoretically contain nested defs.
-                for child in reversed(current.children):
-                    stack.append((child, current_parent))
 
             elif node_type == "type_definition":
                 # #764: type alias inside an object/trait — carry parent_class.
@@ -418,10 +406,78 @@ class ScalaElementExtractor(ElementExtractor):
                 if cls:
                     results.append(cls)
 
+            elif node_type == "extension_definition":
+                cls = self._extract_extension(current, current_parent)
+                if cls:
+                    results.append(cls)
+
+            elif node_type in ("function_definition", "function_declaration"):
+                continue
+
             else:
                 # Generic node: descend preserving context.
                 for child in reversed(current.children):
                     stack.append((child, current_parent))
+
+    def _traverse_functions_with_context(
+        self,
+        node: tree_sitter.Node,
+        results: list[Function],
+        parent_class: str | None,
+        receiver_type: str | None,
+    ) -> None:
+        stack: list[tuple[tree_sitter.Node, str | None, str | None]] = [
+            (node, parent_class, receiver_type)
+        ]
+        while stack:
+            current, current_parent, current_receiver = stack.pop()
+            node_type = current.type
+
+            if node_type in (
+                "class_definition",
+                "object_definition",
+                "trait_definition",
+                "enum_definition",
+            ):
+                new_parent = self._scala_class_like_name(current)
+                for child in reversed(current.children):
+                    stack.append((child, new_parent, None))
+                continue
+
+            if node_type == "given_definition":
+                new_parent = self._scala_given_name(current)
+                for child in reversed(current.children):
+                    stack.append((child, new_parent, None))
+                continue
+
+            if node_type == "extension_definition":
+                new_receiver = self._scala_extension_receiver_type(current)
+                for child in reversed(current.children):
+                    stack.append((child, current_parent, new_receiver))
+                continue
+
+            if node_type == "function_definition":
+                fn = self._extract_function(current)
+                if fn:
+                    fn.parent_class = current_parent
+                    fn.receiver_type = current_receiver
+                    results.append(fn)
+                for child in reversed(current.children):
+                    stack.append((child, current_parent, current_receiver))
+                continue
+
+            if node_type == "function_declaration":
+                fn = self._extract_function_declaration(current)
+                if fn:
+                    fn.parent_class = current_parent
+                    fn.receiver_type = current_receiver
+                    results.append(fn)
+                for child in reversed(current.children):
+                    stack.append((child, current_parent, current_receiver))
+                continue
+
+            for child in reversed(current.children):
+                stack.append((child, current_parent, current_receiver))
 
     def _extract_class_like_with_parent(
         self,
@@ -441,7 +497,7 @@ class ScalaElementExtractor(ElementExtractor):
         parent_class: str | None,
         results: list[Class],
     ) -> None:
-        """Emit the enum itself and each ``simple_enum_case`` as enum_member.
+        """Emit the enum itself and each enum case as enum_member.
 
         AST shape (tree-sitter-scala):
             enum_definition
@@ -452,7 +508,7 @@ class ScalaElementExtractor(ElementExtractor):
                 ':'
                 enum_case_definitions*
                   'case'
-                  simple_enum_case+  ← one or more cases
+                  simple_enum_case+ / full_enum_case+  ← one or more cases
                     identifier       ← case name
                     extends_clause?
 
@@ -479,6 +535,7 @@ class ScalaElementExtractor(ElementExtractor):
             superclass=superclass,
             interfaces=interfaces,
             parent_class=parent_class,
+            modifiers=self._scala_modifiers(node),
         )
         results.append(enum_cls)
 
@@ -490,9 +547,12 @@ class ScalaElementExtractor(ElementExtractor):
                 if case_defs.type != "enum_case_definitions":
                     continue
                 for case_node in case_defs.children:
-                    if case_node.type != "simple_enum_case":
+                    if case_node.type not in ("simple_enum_case", "full_enum_case"):
                         continue
                     case_name = self._scala_class_like_name(case_node)
+                    case_superclass, case_interfaces = (
+                        self._extract_scala_extends_clause(case_node)
+                    )
                     results.append(
                         Class(
                             name=case_name,
@@ -501,9 +561,12 @@ class ScalaElementExtractor(ElementExtractor):
                             raw_text=self._get_node_text(case_node),
                             language="scala",
                             class_type="enum_member",
-                            visibility="public",
+                            visibility=self._scala_visibility(case_node),
                             package_name=self.current_package,
                             parent_class=enum_name,
+                            superclass=case_superclass,
+                            interfaces=case_interfaces,
+                            modifiers=self._scala_modifiers(case_node),
                         )
                     )
 
@@ -524,19 +587,7 @@ class ScalaElementExtractor(ElementExtractor):
               <expr>
         """
         try:
-            name_node = node.child_by_field_name("name")
-            if name_node:
-                name = self._get_node_text(name_node)
-            else:
-                # Fall back to first identifier child.
-                name = next(
-                    (
-                        self._get_node_text(c)
-                        for c in node.children
-                        if c.type == "identifier"
-                    ),
-                    "anonymous_given",
-                )
+            name = self._scala_given_name(node)
             return Class(
                 name=name,
                 start_line=node.start_point[0] + 1,
@@ -544,7 +595,8 @@ class ScalaElementExtractor(ElementExtractor):
                 raw_text=self._get_node_text(node),
                 language="scala",
                 class_type="given",
-                visibility="public",
+                visibility=self._scala_visibility(node),
+                modifiers=self._scala_modifiers(node),
                 package_name=self.current_package,
                 parent_class=parent_class,
             )
@@ -575,19 +627,49 @@ class ScalaElementExtractor(ElementExtractor):
                 ),
                 "unknown_type",
             )
+            class_type = (
+                "type_alias"
+                if self._scala_type_has_alias_target(node)
+                else "type_member"
+            )
             return Class(
                 name=name,
                 start_line=node.start_point[0] + 1,
                 end_line=node.end_point[0] + 1,
                 raw_text=self._get_node_text(node),
                 language="scala",
-                class_type="type_alias",
-                visibility="public",
+                class_type=class_type,
+                visibility=self._scala_visibility(node),
+                modifiers=self._scala_modifiers(node),
                 package_name=self.current_package,
                 parent_class=parent_class,
             )
         except Exception as e:
             log_error(f"Error extracting Scala type alias: {e}")
+            return None
+
+    def _extract_extension(
+        self,
+        node: tree_sitter.Node,
+        parent_class: str | None,
+    ) -> Class | None:
+        try:
+            receiver_type = self._scala_extension_receiver_type(node)
+            suffix = receiver_type or str(node.start_point[0] + 1)
+            return Class(
+                name=f"extension[{suffix}]",
+                start_line=node.start_point[0] + 1,
+                end_line=node.end_point[0] + 1,
+                raw_text=self._get_node_text(node),
+                language="scala",
+                class_type="extension",
+                visibility=self._scala_visibility(node),
+                modifiers=self._scala_modifiers(node),
+                package_name=self.current_package,
+                parent_class=parent_class,
+            )
+        except Exception as e:
+            log_error(f"Error extracting Scala extension: {e}")
             return None
 
     def _extract_function(self, node: tree_sitter.Node) -> Function | None:
@@ -628,6 +710,7 @@ class ScalaElementExtractor(ElementExtractor):
                 parameters=parameters,
                 return_type=return_type,
                 visibility=visibility,
+                modifiers=self._scala_modifiers(node),
                 docstring=docstring,
                 is_constructor=name == "this",
             )
@@ -745,16 +828,69 @@ class ScalaElementExtractor(ElementExtractor):
         the explicit keywords. Defaults to ``public`` when no modifiers
         node is present or contains neither keyword.
         """
+        modifiers = self._scala_modifiers(node)
+        if "private" in modifiers:
+            return "private"
+        if "protected" in modifiers:
+            return "protected"
+        return "public"
+
+    def _scala_modifiers(self, node: tree_sitter.Node) -> list[str]:
+        modifiers: list[str] = []
         for child in node.children:
             if child.type != "modifiers":
                 continue
-            modifiers_text = self._get_node_text(child)
-            if "private" in modifiers_text:
-                return "private"
-            if "protected" in modifiers_text:
-                return "protected"
-            return "public"
-        return "public"
+            for modifier in child.children:
+                text = self._get_node_text(modifier)
+                if text:
+                    modifiers.append(text)
+            if not modifiers:
+                text = self._get_node_text(child)
+                if text:
+                    modifiers.extend(text.split())
+            break
+        return modifiers
+
+    def _scala_given_name(self, node: tree_sitter.Node) -> str:
+        name_node = node.child_by_field_name("name")
+        if name_node:
+            return self._get_node_text(name_node)
+        for child in node.children:
+            if child.type == "identifier":
+                return self._get_node_text(child)
+        type_name = self._scala_given_type_name(node)
+        if type_name:
+            return f"given {type_name}"
+        return f"anonymous_given_{node.start_point[0] + 1}"
+
+    def _scala_given_type_name(self, node: tree_sitter.Node) -> str | None:
+        for child in node.children:
+            if child.type in (
+                "generic_type",
+                "type_identifier",
+                "stable_type_identifier",
+                "tuple_type",
+                "function_type",
+            ):
+                return self._get_node_text(child)
+        return None
+
+    @staticmethod
+    def _scala_type_has_alias_target(node: tree_sitter.Node) -> bool:
+        return any(child.type == "=" for child in node.children)
+
+    def _scala_extension_receiver_type(self, node: tree_sitter.Node) -> str | None:
+        for child in node.children:
+            if child.type != "parameters":
+                continue
+            params = self._extract_parameters(child)
+            if not params:
+                return None
+            first = params[0]
+            if ":" in first:
+                return first.split(":", 1)[1].strip()
+            return first
+        return None
 
     def _extract_parameters(self, param_node: tree_sitter.Node) -> list[str]:
         """Extract parameters from a parameter clause.
@@ -886,6 +1022,7 @@ class ScalaElementExtractor(ElementExtractor):
                 language="scala",
                 class_type=kind,
                 visibility=visibility,
+                modifiers=self._scala_modifiers(node),
                 package_name=self.current_package,
                 docstring=docstring,
                 superclass=superclass,

--- a/tree_sitter_analyzer/languages/typescript_plugin/_variable_helpers.py
+++ b/tree_sitter_analyzer/languages/typescript_plugin/_variable_helpers.py
@@ -58,6 +58,7 @@ def extract_property(
             is_static=parts.is_static,
             is_constant=False,
             visibility=parts.visibility,
+            decorators=_extract_direct_decorator_names(node),
         )
     except Exception as e:
         log_debug(f"Failed to extract property info: {e}")
@@ -142,10 +143,21 @@ def is_framework_component(
 
 
 def is_exported_class(class_name: str, source_code: str) -> bool:
-    """Check if class is exported."""
+    """Check if a TypeScript type-like symbol is exported."""
+    export_prefixes = (
+        "class",
+        "abstract class",
+        "interface",
+        "type",
+        "enum",
+        "const enum",
+    )
     return (
-        f"export class {class_name}" in source_code
+        any(
+            f"export {prefix} {class_name}" in source_code for prefix in export_prefixes
+        )
         or f"export default {class_name}" in source_code
+        or f"export {{ {class_name} }}" in source_code
     )
 
 
@@ -236,6 +248,35 @@ def _apply_property_child(
         parts.type_name = get_node_text(child).lstrip(": ")
     elif child.type in ["string", "number", "true", "false", "null"]:
         parts.value = get_node_text(child)
+
+
+def _extract_direct_decorator_names(node: tree_sitter.Node) -> list[str]:
+    names: list[str] = []
+    for child in node.children:
+        if child.type != "decorator":
+            continue
+        name = _decorator_name(child)
+        if name:
+            names.append(name)
+    return names
+
+
+def _decorator_name(node: tree_sitter.Node) -> str | None:
+    for child in node.children:
+        if child.type == "identifier":
+            return _node_text(child)
+        if child.type == "call_expression":
+            for grandchild in child.children:
+                if grandchild.type == "identifier":
+                    return _node_text(grandchild)
+    return None
+
+
+def _node_text(node: tree_sitter.Node) -> str:
+    text = node.text
+    if isinstance(text, bytes):
+        return text.decode("utf-8", errors="replace")
+    return str(text or "")
 
 
 def _parse_variable_parts(

--- a/tree_sitter_analyzer/mcp/tools/symbol_lineage_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/symbol_lineage_tool.py
@@ -51,9 +51,9 @@ TOOL_SCHEMA: dict[str, Any] = {
             "type": "array",
             "items": {"type": "string"},
             "description": (
-                "Informational only — symbol-lineage always searches the whole "
-                "project. Passing file_paths adds a scope_note to the response "
-                "to signal that this parameter is not a scope filter here."
+                "Optional scope filter for references/call sites. Definitions "
+                "are still resolved project-wide so the symbol location remains "
+                "available."
             ),
         },
     },
@@ -156,6 +156,35 @@ def _verdict_and_next_step(risk_level: str) -> tuple[str, str]:
     return verdict, next_step
 
 
+def _normalize_scope_file_paths(project_root: str, file_paths: list[Any]) -> set[str]:
+    root = Path(project_root).resolve()
+    normalized: set[str] = set()
+    for raw_path in file_paths:
+        if not raw_path:
+            continue
+        path = Path(str(raw_path))
+        try:
+            rel = path.resolve().relative_to(root) if path.is_absolute() else path
+        except ValueError:
+            rel = path
+        rel_text = str(rel).replace("\\", "/")
+        normalized.add(rel_text[2:] if rel_text.startswith("./") else rel_text)
+    return normalized
+
+
+def _filter_references_to_scope(
+    references: list[dict[str, Any]],
+    scope_files: set[str],
+) -> list[dict[str, Any]]:
+    if not scope_files:
+        return references
+    return [
+        ref
+        for ref in references
+        if str(ref.get("file", "")).replace("\\", "/") in scope_files
+    ]
+
+
 def _build_agent_summary_block(
     summary_line: str,
     next_step: str,
@@ -180,7 +209,7 @@ class SymbolLineageTool(BaseMCPTool):
         # Lazy graph + per-symbol response cache. Built on the first call,
         # reset on project_root rebind via _on_project_root_changed.
         self._dep_graph: DependencyGraph | None = None
-        self._symbol_cache: dict[tuple[str, int], dict[str, Any]] = {}
+        self._symbol_cache: dict[tuple[str, int, tuple[str, ...]], dict[str, Any]] = {}
         # H4 fix: fingerprint snapshot for the cached graph + symbol cache.
         # When the source tree changes, both the graph and the per-symbol
         # response cache are invalidated together — the symbol responses
@@ -302,12 +331,9 @@ class SymbolLineageTool(BaseMCPTool):
         symbol = arguments["symbol"].strip()
         max_depth = int(arguments.get("max_depth", 3))
         output_format = arguments.get("output_format", "toon")
-        # #756: file_paths is accepted in the schema (so MCP callers don't
-        # get schema-validation errors) but symbol-lineage is always
-        # project-wide — it does not scope results to listed paths.
-        file_paths = arguments.get("file_paths") or []
-
         self._validate_project_root()
+        file_paths = arguments.get("file_paths") or []
+        scope_files = _normalize_scope_file_paths(str(self.project_root), file_paths)
         # H4 fix: refresh dep graph (clears _symbol_cache on rebuild) before
         # the cache lookup below.
         graph = self._get_dep_graph()
@@ -315,11 +341,14 @@ class SymbolLineageTool(BaseMCPTool):
         # (hierarchy is index-derived; the source fingerprint above can't see it).
         self._invalidate_symbol_cache_on_index_change()
 
-        cached_response = self._try_cached_lineage(symbol, max_depth, started)
+        cache_key = (symbol, max_depth, tuple(sorted(scope_files)))
+        cached_response = self._try_cached_lineage(cache_key, started)
         if cached_response is not None:
             return apply_toon_format_to_response(cached_response, output_format)
 
         definitions, references = await self._collect_definitions_and_refs(symbol)
+        if scope_files:
+            references = _filter_references_to_scope(references, scope_files)
         all_symbol_files = self._collect_symbol_files(definitions, references)
         downstream_files, upstream_files = self._compute_blast_radius(
             graph, all_symbol_files
@@ -353,18 +382,18 @@ class SymbolLineageTool(BaseMCPTool):
             hierarchy=self._hierarchy_for(symbol),
         )
 
-        # #756: when the caller provided file_paths, emit a scope_note so they
-        # know results are project-wide and file_paths is not a scope filter
-        # for symbol-lineage.
-        if file_paths:
+        if scope_files:
+            response["scope_filter"] = sorted(scope_files)
+            response["scope_filtered"] = True
             response["scope_note"] = (
-                "symbol-lineage always searches the whole project. "
-                "file_paths is not a scope filter here — all project files "
-                "are included in the result regardless of this parameter."
+                "file_paths filters references and call sites; definitions "
+                "remain project-wide so the symbol location is preserved."
             )
+        else:
+            response["scope_filtered"] = False
 
         return self._finalize_and_cache_response(
-            response, (symbol, max_depth), started, output_format
+            response, cache_key, started, output_format
         )
 
     def _validate_project_root(self) -> None:
@@ -377,17 +406,16 @@ class SymbolLineageTool(BaseMCPTool):
 
     def _try_cached_lineage(
         self,
-        symbol: str,
-        max_depth: int,
+        cache_key: tuple[str, int, tuple[str, ...]],
         started: float,
     ) -> dict[str, Any] | None:
         """Return a deep-copied cached response if one exists, else ``None``.
 
         Per-symbol response cache — the tool does an expensive cross-file
         walk + dep-graph traversal that orchestrators repeat. Cache key
-        is ``(symbol, max_depth)``; reset on project_root rebind.
+        includes ``(symbol, max_depth, scope_files)``; reset on project_root
+        rebind.
         """
-        cache_key = (symbol, max_depth)
         cached = self._symbol_cache.get(cache_key)
         if cached is None:
             return None
@@ -631,7 +659,7 @@ class SymbolLineageTool(BaseMCPTool):
     def _finalize_and_cache_response(
         self,
         response: dict[str, Any],
-        cache_key: tuple[str, int],
+        cache_key: tuple[str, int, tuple[str, ...]],
         started: float,
         output_format: str,
     ) -> dict[str, Any]:
@@ -916,15 +944,16 @@ def _enrich_references_with_callers(
 
     Returns a new list (immutable input) with call-site rows appended.
     """
-    bare_name = symbol.rsplit(".", 1)[-1]
     try:
         from ...ast_cache import ASTCache
 
+        if is_ast_index_stale(project_root):
+            return references
         cache = ASTCache(project_root)
         if not cache.has_call_edges():
             cache.close()
             return references
-        raw_callers = cache.query_callers(bare_name)
+        raw_callers = cache.query_callers(symbol)
         cache.close()
     except Exception:  # nosec BLE001 — degrade gracefully; no callers added
         return references
@@ -941,12 +970,12 @@ def _enrich_references_with_callers(
     for edge in raw_callers:
         caller_name = edge.get("caller_name", "")
         caller_file = edge.get("caller_file", "")
-        caller_line = int(edge.get("caller_line", 0))
+        call_site_line = int(edge.get("callee_line") or edge.get("caller_line") or 0)
         # Skip unattributed call sites (module-level callers with no
         # enclosing function — same rule as callers_tool #638 fix).
         if not caller_name or not caller_file:
             continue
-        key = (caller_file, caller_line)
+        key = (caller_file, call_site_line)
         if key in seen:
             continue
         seen.add(key)
@@ -955,8 +984,8 @@ def _enrich_references_with_callers(
                 "name": caller_name,
                 "type": "call_site",
                 "file": caller_file,
-                "start_line": caller_line,
-                "end_line": caller_line,
+                "start_line": call_site_line,
+                "end_line": call_site_line,
                 "role": "caller",
             }
         )

--- a/tree_sitter_analyzer/mcp/tools/symbol_search_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/symbol_search_tool.py
@@ -29,7 +29,7 @@ DEFAULT_SYMBOL_SEARCH_LIMIT = 15
 
 # Authoritative ``kind`` filter values. Must mirror exactly what
 # ``_extract_symbols`` (tree_sitter_analyzer/_ast_extraction.py) writes into
-# ``ast_symbol_rows`` — function/method/class/variable/import/constant — plus
+# ``ast_symbol_rows`` — function/method/class/enum/variable/import/constant — plus
 # the "any" no-filter default. Exported so the CLI (`--symbol-search-kind`
 # choices) and the ``search`` facade public schema stay in lock-step with this
 # tool's schema (#640: ``kind`` worked at runtime but was undiscoverable).
@@ -37,6 +37,7 @@ SYMBOL_SEARCH_KINDS: tuple[str, ...] = (
     "function",
     "method",
     "class",
+    "enum",
     "variable",
     "import",
     "constant",

--- a/tree_sitter_analyzer/mcp/tools/utils/element_extractor.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/element_extractor.py
@@ -9,6 +9,7 @@ plugin system so that all 15 supported languages get full MCP tool value.
 from __future__ import annotations
 
 import ast
+import re
 from pathlib import Path
 from typing import Any
 
@@ -137,14 +138,18 @@ def get_all_exports(result: AnalysisResult) -> list[dict[str, Any]]:
     for e in result.elements:
         if is_element_of_type(e, ELEMENT_TYPE_CLASS):
             methods = getattr(e, "methods", [])
-            exports.append(
-                {
-                    "name": e.name,
-                    "kind": "class",
-                    "line": e.start_line,
-                    "methods": len(methods),
-                }
-            )
+            class_type = getattr(e, "class_type", "class")
+            export: dict[str, Any] = {
+                "name": e.name,
+                "kind": "enum" if class_type == "enum" else "class",
+                "line": e.start_line,
+                "methods": len(methods),
+            }
+            if class_type == "enum":
+                export["members"] = _enum_members_from_raw_text(
+                    getattr(e, "raw_text", "")
+                )
+            exports.append(export)
             seen_names.add(e.name)
         elif is_element_of_type(e, ELEMENT_TYPE_FUNCTION):
             if not e.name.startswith("_"):
@@ -180,6 +185,21 @@ def get_all_exports(result: AnalysisResult) -> list[dict[str, Any]]:
             seen_names.add(reexport["name"])
 
     return exports
+
+
+def _enum_members_from_raw_text(raw_text: str) -> list[str]:
+    body_match = re.search(r"\{(?P<body>.*)\}", raw_text, flags=re.DOTALL)
+    if not body_match:
+        return []
+    members: list[str] = []
+    for part in body_match.group("body").split(","):
+        candidate = part.split("=", 1)[0].strip()
+        if not candidate:
+            continue
+        name = re.match(r"[A-Za-z_$][\w$]*", candidate)
+        if name:
+            members.append(name.group(0))
+    return members
 
 
 def _extract_all_reexports(file_path: str) -> list[dict[str, Any]]:

--- a/tree_sitter_analyzer/models/base.py
+++ b/tree_sitter_analyzer/models/base.py
@@ -167,6 +167,8 @@ class Variable(CodeElement):
     # Owning struct/class for class-level fields (#794) — mirrors
     # Function.receiver_type; names stay bare, the owner travels here.
     receiver_type: str | None = None  # Go struct field owner
+    # TypeScript/JavaScript property decorators (without '@'), e.g. ['Column']
+    decorators: list[str] = field(default_factory=list)
 
 
 @dataclass(frozen=False)

--- a/tree_sitter_analyzer/symbol_resolver.py
+++ b/tree_sitter_analyzer/symbol_resolver.py
@@ -27,7 +27,9 @@ from .codegraph_query_backend import CodeGraphQueryBackend
 logger = logging.getLogger(__name__)
 
 # #610: "constant" — Python module-level constants are definition sites.
-_DEFINITION_KINDS = frozenset({"function", "class", "method", "variable", "constant"})
+_DEFINITION_KINDS = frozenset(
+    {"function", "class", "enum", "method", "variable", "constant"}
+)
 
 _REFERENCE_KINDS = frozenset({"function", "class", "method", "variable"})
 
@@ -345,7 +347,7 @@ class SymbolResolver:
         rows = conn.execute(
             """SELECT name, kind, file_path, language, line, end_line
                FROM ast_symbol_rows
-               WHERE file_path = ? AND name = ? AND kind IN ('function', 'class', 'method', 'constant')
+               WHERE file_path = ? AND name = ? AND kind IN ('function', 'class', 'enum', 'method', 'constant')
                ORDER BY line""",
             (file_path, name),
         ).fetchall()


### PR DESCRIPTION
## Summary
- Addresses Codex P2 findings tracked in #961 across Scala, C/C++, C#, Python, and TypeScript extraction.
- Adds scoped symbol-lineage reference filtering, call-site line reporting, qualified caller lookup, and stale call-graph protection.
- Adds TypeScript enum/export parity, Scala AST cache indexing for object/trait/enum/given/type symbols, and focused regressions plus language codemap updates.

Closes #961

## Verification
- `uv run pytest tests/unit/test_scala_language_wiring.py tests/unit/languages/test_scala_fixes.py tests/unit/languages/test_c_cpp_fixes.py tests/unit/languages/test_csharp_plugin_extraction.py tests/unit/languages/test_typescript_extraction_fixes.py tests/unit/languages/test_python_module_constants.py tests/unit/mcp/test_symbol_lineage_fixes.py tests/unit/mcp/tools/test_facade_tool.py tests/unit/cli/test_mcp_commands.py --cov=tree_sitter_analyzer --cov-report=json -q` (214 passed)
- `uv run python scripts/check_patch_coverage.py --base origin/develop --coverage-json coverage.json`
- `uv run python scripts/generate_facade_actions_doc.py`
- `uv run pytest tests/unit/docs/test_facade_actions_doc_drift.py -x` (3 passed)
- `uv run pytest -q` (20860 passed, 89 skipped, 8 xfailed, 1 rerun)
- commit hooks: ruff, ruff format, mypy, pyupgrade, codemap sync, secrets/bandit checks passed