### PR TITLE
fix(scala): Codex P2 findings (#961 scala)

### DIFF
--- a/tests/unit/languages/test_scala_fixes.py
+++ b/tests/unit/languages/test_scala_fixes.py
@@ -133,6 +133,29 @@ class TestEnumCaseExtraction:
         classes = _classes(_ENUM_WITH_PARAMS)
         assert classes["Mercury"].parent_class == "Planet"
 
+    def test_full_enum_cases_with_constructor_params_are_extracted(self) -> None:
+        code = """\
+enum Command:
+  case Quit
+  case Move(dx: Int, dy: Int)
+  case Error(code: Int) extends Command
+"""
+        classes = _classes(code)
+        assert classes["Move"].class_type == "enum_member"
+        assert classes["Move"].parent_class == "Command"
+        assert "dx: Int" in classes["Move"].raw_text
+        assert classes["Error"].superclass == "Command"
+
+    def test_enum_modifiers_are_preserved(self) -> None:
+        classes = _classes(
+            """\
+private enum Secret:
+  case Token
+"""
+        )
+        assert classes["Secret"].visibility == "private"
+        assert "private" in classes["Secret"].modifiers
+
 
 # ---------------------------------------------------------------------------
 # Bug #764: given/type/extension inside object/trait must carry parent_class
@@ -239,3 +262,84 @@ class TestGivenTypeParentClass:
     def test_nested_type_alias_parent_class(self) -> None:
         classes = _classes(_NESTED_MIX)
         assert classes["AliasT"].parent_class == "Outer"
+
+    def test_local_given_and_type_inside_method_are_not_members(self) -> None:
+        classes = _classes(
+            """\
+object Ops:
+  def configure(): Unit =
+    given localOrdering: Ordering[Int] = Ordering.Int
+    type LocalAlias = String
+"""
+        )
+        assert "localOrdering" not in classes
+        assert "LocalAlias" not in classes
+
+    def test_given_and_type_modifiers_are_preserved(self) -> None:
+        classes = _classes(
+            """\
+object Api:
+  private given secret: String = "s"
+  protected type Hidden = Int
+"""
+        )
+        assert classes["secret"].visibility == "private"
+        assert "private" in classes["secret"].modifiers
+        assert classes["Hidden"].visibility == "protected"
+        assert "protected" in classes["Hidden"].modifiers
+
+    def test_anonymous_givens_use_distinct_type_based_names(self) -> None:
+        classes = _classes(
+            """\
+object Instances:
+  given Ordering[Int] = Ordering.Int
+  given Ordering[String] = Ordering.String
+"""
+        )
+        assert "given Ordering[Int]" in classes
+        assert "given Ordering[String]" in classes
+
+    def test_abstract_type_members_are_not_reported_as_aliases(self) -> None:
+        classes = _classes(
+            """\
+trait Api:
+  type Out
+  type In <: String
+  type Alias = Int
+"""
+        )
+        assert classes["Out"].class_type == "type_member"
+        assert classes["In"].class_type == "type_member"
+        assert classes["Alias"].class_type == "type_alias"
+
+    def test_extension_symbol_and_method_keep_owner_context(self) -> None:
+        code = """\
+object Ops:
+  extension (s: String)
+    def shout: String = s.toUpperCase
+"""
+        classes = _classes(code)
+        functions = _functions(code)
+        assert classes["extension[String]"].class_type == "extension"
+        assert classes["extension[String]"].parent_class == "Ops"
+        assert functions["shout"].parent_class == "Ops"
+        assert functions["shout"].receiver_type == "String"
+
+
+def test_scala_ast_cache_symbol_path_indexes_new_constructs() -> None:
+    from tree_sitter_analyzer._ast_extraction import _extract_symbols
+
+    code = """\
+object Instances:
+  given Ordering[Int] = Ordering.Int
+  type Alias = Int
+
+enum Color:
+  case Red
+"""
+    symbols = _extract_symbols(_parse(code), code, "scala")["symbols"]
+    by_name = {s["name"]: s for s in symbols}
+    assert by_name["Instances"]["kind"] == "class"
+    assert by_name["given Ordering[Int]"]["kind"] == "class"
+    assert by_name["Alias"]["kind"] == "class"
+    assert by_name["Color"]["kind"] == "enum"

--- a/tests/unit/languages/test_scala_fixes.py
+++ b/tests/unit/languages/test_scala_fixes.py
@@ -288,6 +288,22 @@ object Api:
         assert classes["Hidden"].visibility == "protected"
         assert "protected" in classes["Hidden"].modifiers
 
+    def test_qualified_access_class_visibility_is_private(self) -> None:
+        # #961 regression: ``_scala_modifiers`` yields the literal token
+        # ``private[pkg]`` (not bare ``private``), so the exact-membership
+        # check reported ``public``. Match the keyword as a prefix instead.
+        classes = _classes("private[pkg] class Secret(x: Int)\n")
+        assert classes["Secret"].visibility == "private"
+
+    def test_qualified_access_protected_def_visibility(self) -> None:
+        functions = _functions(
+            """\
+object O:
+  protected[this] def f(): Int = 1
+"""
+        )
+        assert functions["f"].visibility == "protected"
+
     def test_anonymous_givens_use_distinct_type_based_names(self) -> None:
         classes = _classes(
             """\

--- a/tests/unit/languages/test_scala_fixes.py
+++ b/tests/unit/languages/test_scala_fixes.py
@@ -342,6 +342,179 @@ object Ops:
         assert functions["shout"].receiver_type == "String"
 
 
+class TestScalaVisibilityBranches:
+    """#972: cover every prefix branch of ``_scala_visibility`` / ``_scala_modifiers``."""
+
+    def test_private_qualified_class_is_private(self) -> None:
+        classes = _classes("private[pkg] class Secret(x: Int)\n")
+        assert classes["Secret"].visibility == "private"
+        assert classes["Secret"].modifiers == ["private[pkg]"]
+
+    def test_protected_qualified_def_is_protected(self) -> None:
+        functions = _functions(
+            """\
+object O:
+  protected[this] def f(): Int = 1
+"""
+        )
+        assert functions["f"].visibility == "protected"
+        assert functions["f"].modifiers == ["protected[this]"]
+
+    def test_bare_private_class_is_private(self) -> None:
+        classes = _classes("private class Hidden(x: Int)\n")
+        assert classes["Hidden"].visibility == "private"
+
+    def test_bare_protected_class_is_protected(self) -> None:
+        classes = _classes("protected class Guarded(x: Int)\n")
+        assert classes["Guarded"].visibility == "protected"
+
+    def test_no_modifier_class_defaults_public(self) -> None:
+        classes = _classes("class Plain(x: Int)\n")
+        assert classes["Plain"].visibility == "public"
+        assert classes["Plain"].modifiers == []
+
+    def test_non_visibility_modifier_stays_public(self) -> None:
+        # ``final`` is a modifier but not a visibility keyword: visibility stays
+        # public while the modifier is still captured.
+        classes = _classes("final class Sealed(x: Int)\n")
+        assert classes["Sealed"].visibility == "public"
+        assert classes["Sealed"].modifiers == ["final"]
+
+
+class TestScalaGivenNameBranches:
+    """#972: cover the named / typed / anonymous arms of ``_scala_given_name``."""
+
+    def test_named_given_uses_identifier(self) -> None:
+        classes = _classes("object O:\n  given namedGiven: Int = 1\n")
+        assert "namedGiven" in classes
+
+    def test_anonymous_given_uses_generic_type(self) -> None:
+        classes = _classes("object O:\n  given Ordering[Int] = ???\n")
+        assert classes["given Ordering[Int]"].class_type == "given"
+
+    def test_anonymous_given_uses_tuple_type(self) -> None:
+        classes = _classes("object O:\n  given (Int, String) = ???\n")
+        assert "given (Int, String)" in classes
+
+    def test_anonymous_given_uses_function_type(self) -> None:
+        classes = _classes("object O:\n  given (Int => String) = ???\n")
+        assert "given (Int => String)" in classes
+
+    def test_anonymous_given_uses_stable_type_identifier(self) -> None:
+        classes = _classes("object O:\n  given Foo.Bar = ???\n")
+        assert "given Foo.Bar" in classes
+
+    def test_degenerate_given_falls_back_to_line_based_name(self) -> None:
+        # ``given = 1`` has neither a name identifier nor a recognizable type
+        # child, so ``_scala_given_name`` falls back to ``anonymous_given_<line>``
+        # (and ``_scala_given_type_name`` returns None).
+        classes = _classes("object O:\n  given = 1\n")
+        assert "anonymous_given_2" in classes
+
+
+class TestScalaExtensionReceiver:
+    """#972: cover ``_scala_extension_receiver_type`` typed / no-param arms."""
+
+    def test_typed_receiver_is_split_after_colon(self) -> None:
+        classes = _classes(
+            """\
+object Ops:
+  extension (xs: List[Int])
+    def f: Int = 1
+"""
+        )
+        assert classes["extension[List[Int]]"].class_type == "extension"
+        assert classes["extension[List[Int]]"].parent_class == "Ops"
+
+    def test_no_valid_params_falls_back_to_line_suffix(self) -> None:
+        # ``extension (s)`` (no type) parses with an ERROR node, so
+        # ``_extract_parameters`` yields nothing and the receiver type is None,
+        # forcing the line-number suffix.
+        classes = _classes("extension (s)\n  def f: Int = 1\n")
+        assert "extension[1]" in classes
+        assert classes["extension[1]"].class_type == "extension"
+
+    def test_no_parameters_child_falls_back_to_line_suffix(self) -> None:
+        # ``extension EmptyExt`` has no ``parameters`` child at all, so
+        # ``_scala_extension_receiver_type`` returns None via its final
+        # ``return None`` and the line-number suffix is used.
+        classes = _classes(
+            """\
+object O:
+  extension EmptyExt
+    def f: Int = 1
+"""
+        )
+        assert "extension[2]" in classes
+        assert classes["extension[2]"].class_type == "extension"
+
+
+class TestScalaTypeMemberVsAlias:
+    """#972: ``_scala_type_has_alias_target`` decides type_alias vs type_member."""
+
+    def test_assigned_type_is_alias(self) -> None:
+        classes = _classes("trait Api:\n  type Alias = Int\n")
+        assert classes["Alias"].class_type == "type_alias"
+
+    def test_abstract_type_is_member(self) -> None:
+        classes = _classes("trait Api:\n  type Out\n")
+        assert classes["Out"].class_type == "type_member"
+
+    def test_bounded_abstract_type_is_member(self) -> None:
+        classes = _classes("trait Api:\n  type In <: String\n")
+        assert classes["In"].class_type == "type_member"
+
+
+class TestScalaFunctionContext:
+    """#972: ``_traverse_functions_with_context`` propagates parent_class /
+    receiver_type through class-like, given, and extension scopes."""
+
+    def test_method_in_object_has_parent_class(self) -> None:
+        functions = _functions(
+            """\
+object Calc:
+  def add(a: Int, b: Int): Int = a + b
+"""
+        )
+        assert functions["add"].parent_class == "Calc"
+        assert functions["add"].receiver_type is None
+
+    def test_method_in_trait_has_parent_class(self) -> None:
+        functions = _functions(
+            """\
+trait Shape:
+  def area(): Double = 0.0
+"""
+        )
+        assert functions["area"].parent_class == "Shape"
+
+    def test_abstract_method_declaration_has_parent_class(self) -> None:
+        # ``function_declaration`` (no body) goes through the declaration arm.
+        functions = _functions(
+            """\
+trait Shape:
+  def perimeter(): Double
+"""
+        )
+        assert functions["perimeter"].parent_class == "Shape"
+
+    def test_method_inside_given_with_block_has_given_parent(self) -> None:
+        functions = _functions(
+            """\
+object O:
+  given listOrd: Ordering[List[Int]] with
+    def compare(a: List[Int], b: List[Int]): Int = 0
+"""
+        )
+        assert functions["compare"].parent_class == "listOrd"
+        assert functions["compare"].receiver_type is None
+
+    def test_top_level_function_has_no_parent(self) -> None:
+        functions = _functions("def free(x: Int): Int = x\n")
+        assert functions["free"].parent_class is None
+        assert functions["free"].receiver_type is None
+
+
 def test_scala_ast_cache_symbol_path_indexes_new_constructs() -> None:
     from tree_sitter_analyzer._ast_extraction import _extract_symbols
 

--- a/tests/unit/test_scala_language_wiring.py
+++ b/tests/unit/test_scala_language_wiring.py
@@ -131,3 +131,116 @@ def test_ast_cache_path_excludes_method_local_given_and_type() -> None:
     assert "Ops" in names
     assert "topGiven" in names
     assert "TopAlias" in names
+
+
+# ---------------------------------------------------------------------------
+# #972: ast_cache symbol-extraction helpers (_scala_symbol_from_node /
+# _scala_symbol_name / _scala_given_type_text). These mirror the plugin
+# helpers but live on the shared ast_cache walk; the branches differ, so
+# they are covered independently here.
+# ---------------------------------------------------------------------------
+
+
+def _scala_node(code: str, node_type: str):
+    """Return the first ``node_type`` node in a parsed Scala snippet."""
+    import tree_sitter
+
+    from tree_sitter_analyzer.languages.scala_plugin import ScalaPlugin
+
+    lang = ScalaPlugin().get_tree_sitter_language()
+    parser = tree_sitter.Parser(lang)
+    tree = parser.parse(code.encode("utf-8"))
+
+    def find(node):
+        if node.type == node_type:
+            return node
+        for child in node.children:
+            hit = find(child)
+            if hit is not None:
+                return hit
+        return None
+
+    return find(tree.root_node)
+
+
+def test_ast_cache_symbol_from_node_object_is_class() -> None:
+    from tree_sitter_analyzer._ast_extraction import _scala_symbol_from_node
+
+    code = "object Box:\n  val x = 1\n"
+    node = _scala_node(code, "object_definition")
+    sym = _scala_symbol_from_node(node, code)
+    assert sym is not None
+    assert sym["kind"] == "class"
+    assert sym["name"] == "Box"
+
+
+def test_ast_cache_symbol_from_node_enum_is_enum() -> None:
+    from tree_sitter_analyzer._ast_extraction import _scala_symbol_from_node
+
+    code = "enum Color:\n  case Red\n"
+    node = _scala_node(code, "enum_definition")
+    sym = _scala_symbol_from_node(node, code)
+    assert sym is not None
+    assert sym["kind"] == "enum"
+    assert sym["name"] == "Color"
+
+
+def test_ast_cache_symbol_from_node_rejects_non_class_like() -> None:
+    """A node outside ``_SCALA_CLASS_LIKE`` (e.g. the bare ``enum`` keyword)
+    returns None (line 877-878 guard)."""
+    from tree_sitter_analyzer._ast_extraction import _scala_symbol_from_node
+
+    code = "enum Color:\n  case Red\n"
+    keyword = _scala_node(code, "enum")
+    assert _scala_symbol_from_node(keyword, code) is None
+
+
+def test_ast_cache_symbol_name_uses_identifier_child_for_object() -> None:
+    """``object_definition`` exposes no ``name`` field, so the identifier-child
+    fallback path (line 895-897) resolves the name."""
+    from tree_sitter_analyzer._ast_extraction import _scala_symbol_name
+
+    code = "object Box:\n  val x = 1\n"
+    node = _scala_node(code, "object_definition")
+    assert _scala_symbol_name(node, code) == "Box"
+
+
+def test_ast_cache_symbol_name_named_given_via_type() -> None:
+    from tree_sitter_analyzer._ast_extraction import _scala_symbol_name
+
+    code = "object O:\n  given Ordering[Int] = ???\n"
+    node = _scala_node(code, "given_definition")
+    assert _scala_symbol_name(node, code) == "given Ordering[Int]"
+
+
+def test_ast_cache_symbol_name_degenerate_given_is_empty() -> None:
+    """``given = 1`` parses with an empty ``type_identifier`` child, so the
+    identifier-child branch (line 895-897) returns ``""`` — distinct from the
+    plugin path which line-numbers it. The empty name then trips the
+    ``if not name`` guard in ``_scala_symbol_from_node`` (line 880-881)."""
+    from tree_sitter_analyzer._ast_extraction import (
+        _scala_symbol_from_node,
+        _scala_symbol_name,
+    )
+
+    code = "object O:\n  given = 1\n"
+    node = _scala_node(code, "given_definition")
+    assert _scala_symbol_name(node, code) == ""
+    # Empty name => the class-like guard rejects the node.
+    assert _scala_symbol_from_node(node, code) is None
+
+
+def test_ast_cache_given_type_text_resolves_tuple_type() -> None:
+    from tree_sitter_analyzer._ast_extraction import _scala_given_type_text
+
+    code = "object O:\n  given (Int, String) = ???\n"
+    node = _scala_node(code, "given_definition")
+    assert _scala_given_type_text(node, code) == "(Int, String)"
+
+
+def test_ast_cache_given_type_text_resolves_generic_type() -> None:
+    from tree_sitter_analyzer._ast_extraction import _scala_given_type_text
+
+    code = "object O:\n  given Ordering[Int] = ???\n"
+    node = _scala_node(code, "given_definition")
+    assert _scala_given_type_text(node, code) == "Ordering[Int]"

--- a/tests/unit/test_scala_language_wiring.py
+++ b/tests/unit/test_scala_language_wiring.py
@@ -98,3 +98,36 @@ def test_ast_cache_indexes_scala_file() -> None:
         cache.close()
     finally:
         shutil.rmtree(d, ignore_errors=True)
+
+
+def test_ast_cache_path_excludes_method_local_given_and_type() -> None:
+    """#961: the shared ast_cache walk (``_extract_symbols``) must NOT emit a
+    ``given``/``type`` declared inside a method body as a top-level symbol —
+    matching the plugin path (``test_local_given_and_type_inside_method_are_
+    not_members``). Top-level constructs in the same file still ARE emitted.
+    """
+    import tree_sitter
+
+    from tree_sitter_analyzer._ast_extraction import _extract_symbols
+    from tree_sitter_analyzer.languages.scala_plugin import ScalaPlugin
+
+    code = """object Ops:
+  def configure(): Unit =
+    given localOrdering: Ordering[Int] = Ordering.Int
+    type LocalAlias = String
+
+  given topGiven: Int = 1
+  type TopAlias = String
+"""
+    lang = ScalaPlugin().get_tree_sitter_language()
+    parser = tree_sitter.Parser(lang)
+    tree = parser.parse(code.encode("utf-8"))
+    names = [s["name"] for s in _extract_symbols(tree, code, "scala")["symbols"]]
+
+    # Method-local declarations must NOT leak as top-level symbols.
+    assert "localOrdering" not in names
+    assert "LocalAlias" not in names
+    # Top-level constructs in the same file are still emitted.
+    assert "Ops" in names
+    assert "topGiven" in names
+    assert "TopAlias" in names

--- a/tests/unit/test_scala_language_wiring.py
+++ b/tests/unit/test_scala_language_wiring.py
@@ -92,7 +92,9 @@ def test_ast_cache_indexes_scala_file() -> None:
         cache.index_project()
         conn = cache.get_conn()
         count = conn.execute("SELECT COUNT(*) FROM ast_symbol_rows").fetchone()[0]
-        assert count == 86, f"expected exactly 86 scala symbols indexed, got {count}"
+        # Repinned 2026-06-15: Scala object/trait/enum/given/type symbols are
+        # now indexed in the AST cache instead of only the plugin extractor.
+        assert count == 107, f"expected exactly 107 scala symbols indexed, got {count}"
         cache.close()
     finally:
         shutil.rmtree(d, ignore_errors=True)

--- a/tree_sitter_analyzer/_ast_extraction.py
+++ b/tree_sitter_analyzer/_ast_extraction.py
@@ -214,6 +214,7 @@ _VAR_DECL_LIKE = frozenset(
         "variable_declaration",
         "const_declaration",
         "let_declaration",
+        "variable_assignment",
     }
 )
 
@@ -442,6 +443,19 @@ _CSHARP_SCOPE_BODY_NODES = frozenset(
         "lambda_expression",
         "anonymous_method_expression",
         "ERROR",
+    }
+)
+
+# #961: Scala method bodies must mark their descendants as enclosed so a
+# method-local ``given``/``type`` is NOT emitted as a top-level class-like
+# symbol (mirrors the scala_plugin path, which ``continue``s instead of
+# descending into ``function_definition``/``function_declaration``). The
+# scope node itself is enough — gating on it makes the body container
+# (``block`` / ``indented_block``) and everything below it enclosed.
+_SCALA_SCOPE_BODY_NODES = frozenset(
+    {
+        "function_definition",
+        "function_declaration",
     }
 )
 
@@ -842,6 +856,22 @@ def _c_declarator_name(declarator: Any, source: str, depth: int) -> str | None:
     return None
 
 
+def _bash_subscript_base(subscript: Any) -> Any:
+    """Return the base ``variable_name`` node of a Bash ``subscript`` target.
+
+    For ``arr[0]=x`` tree-sitter-bash nests the base variable under the
+    subscript's ``name`` field (``arr``). Fall back to the first
+    ``variable_name`` / ``word`` child if the field is absent.
+    """
+    base = subscript.child_by_field_name("name")
+    if base is not None:
+        return base
+    for child in subscript.children:
+        if child.type in ("variable_name", "word"):
+            return child
+    return None
+
+
 def _scala_symbol_from_node(node: Any, source: str) -> dict[str, Any] | None:
     node_type = node.type
     if node_type not in _SCALA_CLASS_LIKE:
@@ -965,7 +995,10 @@ def _walk_for_symbols(
             sym["kind"] = "method"
             sym["class"] = parent_cls
         symbols.append(sym)
-    elif language == "scala" and node_type in _SCALA_CLASS_LIKE:
+    elif language == "scala" and node_type in _SCALA_CLASS_LIKE and not enclosed:
+        # #961: ``not enclosed`` keeps a method-local ``given``/``type`` out of
+        # the top-level symbol set (CLI/plugin already excludes it; the
+        # ast_cache path must match — otherwise CLI vs MCP diverge).
         scala_sym = _scala_symbol_from_node(node, source)
         if scala_sym is not None:
             symbols.append(scala_sym)
@@ -1007,9 +1040,24 @@ def _walk_for_symbols(
         and not (
             language in ("javascript", "typescript", "java", "csharp") and enclosed
         )
+        # #949 Codex P2: ``FOO=bar make`` makes tree-sitter-bash emit
+        # ``FOO=bar`` as a variable_assignment *child of a command* node — a
+        # transient per-command env override, not a script-level variable.
+        # Skip those; only standalone assignments (parent is the
+        # program/compound/list) are real symbols.
+        and not (
+            node_type == "variable_assignment"
+            and node.parent is not None
+            and node.parent.type == "command"
+        )
     ):
-        name = _node_text(name_node, source)
-        if not name.startswith("_") or depth < 3:
+        # Bash array/associative assignments (``arr[0]=x``) expose the target
+        # as a ``subscript`` node, not a bare ``variable_name``. Unwrap to the
+        # base variable so the symbol is the variable name, not ``arr[0]``.
+        if name_node.type == "subscript":
+            name_node = _bash_subscript_base(name_node)
+        name = _node_text(name_node, source) if name_node is not None else ""
+        if name and (not name.startswith("_") or depth < 3):
             symbols.append(
                 {
                     "kind": "variable",
@@ -1059,6 +1107,7 @@ def _walk_for_symbols(
         )
         or (language == "java" and node_type in _JAVA_SCOPE_BODY_NODES)
         or (language == "csharp" and node_type in _CSHARP_SCOPE_BODY_NODES)
+        or (language == "scala" and node_type in _SCALA_SCOPE_BODY_NODES)
     )
     for child in node.children:
         _walk_for_symbols(

--- a/tree_sitter_analyzer/_ast_extraction.py
+++ b/tree_sitter_analyzer/_ast_extraction.py
@@ -183,6 +183,16 @@ _CLASS_LIKE = frozenset(
     | _ENUM_LIKE
 )
 
+_SCALA_CLASS_LIKE = frozenset(
+    {
+        "object_definition",
+        "trait_definition",
+        "enum_definition",
+        "given_definition",
+        "type_definition",
+    }
+)
+
 _IMPORT_LIKE = frozenset(
     {
         "import_statement",
@@ -204,7 +214,6 @@ _VAR_DECL_LIKE = frozenset(
         "variable_declaration",
         "const_declaration",
         "let_declaration",
-        "variable_assignment",
     }
 )
 
@@ -833,19 +842,47 @@ def _c_declarator_name(declarator: Any, source: str, depth: int) -> str | None:
     return None
 
 
-def _bash_subscript_base(subscript: Any) -> Any:
-    """Return the base ``variable_name`` node of a Bash ``subscript`` target.
+def _scala_symbol_from_node(node: Any, source: str) -> dict[str, Any] | None:
+    node_type = node.type
+    if node_type not in _SCALA_CLASS_LIKE:
+        return None
+    name = _scala_symbol_name(node, source)
+    if not name:
+        return None
+    return {
+        "kind": "enum" if node_type == "enum_definition" else "class",
+        "name": name,
+        "line": node.start_point[0] + 1,
+        "end_line": node.end_point[0] + 1,
+        "language": "scala",
+    }
 
-    For ``arr[0]=x`` tree-sitter-bash nests the base variable under the
-    subscript's ``name`` field (``arr``). Fall back to the first
-    ``variable_name`` / ``word`` child if the field is absent.
-    """
-    base = subscript.child_by_field_name("name")
-    if base is not None:
-        return base
-    for child in subscript.children:
-        if child.type in ("variable_name", "word"):
-            return child
+
+def _scala_symbol_name(node: Any, source: str) -> str | None:
+    name_node = node.child_by_field_name("name")
+    if name_node is not None:
+        return _node_text(name_node, source)
+    for child in node.children:
+        if child.type in ("identifier", "type_identifier"):
+            return _node_text(child, source)
+    if node.type == "given_definition":
+        type_name = _scala_given_type_text(node, source)
+        if type_name:
+            return f"given {type_name}"
+        return f"anonymous_given_{node.start_point[0] + 1}"
+    return None
+
+
+def _scala_given_type_text(node: Any, source: str) -> str | None:
+    for child in node.children:
+        if child.type in (
+            "generic_type",
+            "type_identifier",
+            "stable_type_identifier",
+            "tuple_type",
+            "function_type",
+        ):
+            return _node_text(child, source)
     return None
 
 
@@ -928,6 +965,10 @@ def _walk_for_symbols(
             sym["kind"] = "method"
             sym["class"] = parent_cls
         symbols.append(sym)
+    elif language == "scala" and node_type in _SCALA_CLASS_LIKE:
+        scala_sym = _scala_symbol_from_node(node, source)
+        if scala_sym is not None:
+            symbols.append(scala_sym)
     elif node_type in _CLASS_LIKE and name_node is not None:
         name = _node_text(name_node, source)
         parents = _extract_parent_classes(node, source, language)
@@ -966,24 +1007,9 @@ def _walk_for_symbols(
         and not (
             language in ("javascript", "typescript", "java", "csharp") and enclosed
         )
-        # #949 Codex P2: ``FOO=bar make`` makes tree-sitter-bash emit
-        # ``FOO=bar`` as a variable_assignment *child of a command* node — a
-        # transient per-command env override, not a script-level variable.
-        # Skip those; only standalone assignments (parent is the
-        # program/compound/list) are real symbols.
-        and not (
-            node_type == "variable_assignment"
-            and node.parent is not None
-            and node.parent.type == "command"
-        )
     ):
-        # Bash array/associative assignments (``arr[0]=x``) expose the target
-        # as a ``subscript`` node, not a bare ``variable_name``. Unwrap to the
-        # base variable so the symbol is the variable name, not ``arr[0]``.
-        if name_node.type == "subscript":
-            name_node = _bash_subscript_base(name_node)
-        name = _node_text(name_node, source) if name_node is not None else ""
-        if name and (not name.startswith("_") or depth < 3):
+        name = _node_text(name_node, source)
+        if not name.startswith("_") or depth < 3:
             symbols.append(
                 {
                     "kind": "variable",

--- a/tree_sitter_analyzer/languages/scala_plugin.py
+++ b/tree_sitter_analyzer/languages/scala_plugin.py
@@ -827,11 +827,17 @@ class ScalaElementExtractor(ElementExtractor):
         Scans for the first ``modifiers`` child and checks its text for
         the explicit keywords. Defaults to ``public`` when no modifiers
         node is present or contains neither keyword.
+
+        Qualified-access modifiers such as ``private[pkg]`` /
+        ``protected[this]`` are emitted by ``_scala_modifiers`` as the
+        single literal token ``private[pkg]`` (not a bare ``private``), so
+        match the keyword as a prefix rather than by exact membership —
+        otherwise ``private[pkg] class Secret`` is misreported as public.
         """
         modifiers = self._scala_modifiers(node)
-        if "private" in modifiers:
+        if any(m == "private" or m.startswith("private[") for m in modifiers):
             return "private"
-        if "protected" in modifiers:
+        if any(m == "protected" or m.startswith("protected[") for m in modifiers):
             return "protected"
         return "public"
 

--- a/tree_sitter_analyzer/languages/scala_plugin.py
+++ b/tree_sitter_analyzer/languages/scala_plugin.py
@@ -138,16 +138,7 @@ class ScalaElementExtractor(ElementExtractor):
 
         functions: list[Function] = []
 
-        extractors = {
-            "function_definition": self._extract_function,
-            "function_declaration": self._extract_function_declaration,
-        }
-
-        self._traverse_and_extract(
-            tree.root_node,
-            extractors,
-            functions,
-        )
+        self._traverse_functions_with_context(tree.root_node, functions, None, None)
 
         log_debug(f"Extracted {len(functions)} Scala functions")
         return functions
@@ -408,9 +399,6 @@ class ScalaElementExtractor(ElementExtractor):
                 cls = self._extract_given(current, current_parent)
                 if cls:
                     results.append(cls)
-                # given bodies can theoretically contain nested defs.
-                for child in reversed(current.children):
-                    stack.append((child, current_parent))
 
             elif node_type == "type_definition":
                 # #764: type alias inside an object/trait — carry parent_class.
@@ -418,10 +406,78 @@ class ScalaElementExtractor(ElementExtractor):
                 if cls:
                     results.append(cls)
 
+            elif node_type == "extension_definition":
+                cls = self._extract_extension(current, current_parent)
+                if cls:
+                    results.append(cls)
+
+            elif node_type in ("function_definition", "function_declaration"):
+                continue
+
             else:
                 # Generic node: descend preserving context.
                 for child in reversed(current.children):
                     stack.append((child, current_parent))
+
+    def _traverse_functions_with_context(
+        self,
+        node: tree_sitter.Node,
+        results: list[Function],
+        parent_class: str | None,
+        receiver_type: str | None,
+    ) -> None:
+        stack: list[tuple[tree_sitter.Node, str | None, str | None]] = [
+            (node, parent_class, receiver_type)
+        ]
+        while stack:
+            current, current_parent, current_receiver = stack.pop()
+            node_type = current.type
+
+            if node_type in (
+                "class_definition",
+                "object_definition",
+                "trait_definition",
+                "enum_definition",
+            ):
+                new_parent = self._scala_class_like_name(current)
+                for child in reversed(current.children):
+                    stack.append((child, new_parent, None))
+                continue
+
+            if node_type == "given_definition":
+                new_parent = self._scala_given_name(current)
+                for child in reversed(current.children):
+                    stack.append((child, new_parent, None))
+                continue
+
+            if node_type == "extension_definition":
+                new_receiver = self._scala_extension_receiver_type(current)
+                for child in reversed(current.children):
+                    stack.append((child, current_parent, new_receiver))
+                continue
+
+            if node_type == "function_definition":
+                fn = self._extract_function(current)
+                if fn:
+                    fn.parent_class = current_parent
+                    fn.receiver_type = current_receiver
+                    results.append(fn)
+                for child in reversed(current.children):
+                    stack.append((child, current_parent, current_receiver))
+                continue
+
+            if node_type == "function_declaration":
+                fn = self._extract_function_declaration(current)
+                if fn:
+                    fn.parent_class = current_parent
+                    fn.receiver_type = current_receiver
+                    results.append(fn)
+                for child in reversed(current.children):
+                    stack.append((child, current_parent, current_receiver))
+                continue
+
+            for child in reversed(current.children):
+                stack.append((child, current_parent, current_receiver))
 
     def _extract_class_like_with_parent(
         self,
@@ -441,7 +497,7 @@ class ScalaElementExtractor(ElementExtractor):
         parent_class: str | None,
         results: list[Class],
     ) -> None:
-        """Emit the enum itself and each ``simple_enum_case`` as enum_member.
+        """Emit the enum itself and each enum case as enum_member.
 
         AST shape (tree-sitter-scala):
             enum_definition
@@ -452,7 +508,7 @@ class ScalaElementExtractor(ElementExtractor):
                 ':'
                 enum_case_definitions*
                   'case'
-                  simple_enum_case+  ← one or more cases
+                  simple_enum_case+ / full_enum_case+  ← one or more cases
                     identifier       ← case name
                     extends_clause?
 
@@ -479,6 +535,7 @@ class ScalaElementExtractor(ElementExtractor):
             superclass=superclass,
             interfaces=interfaces,
             parent_class=parent_class,
+            modifiers=self._scala_modifiers(node),
         )
         results.append(enum_cls)
 
@@ -490,9 +547,12 @@ class ScalaElementExtractor(ElementExtractor):
                 if case_defs.type != "enum_case_definitions":
                     continue
                 for case_node in case_defs.children:
-                    if case_node.type != "simple_enum_case":
+                    if case_node.type not in ("simple_enum_case", "full_enum_case"):
                         continue
                     case_name = self._scala_class_like_name(case_node)
+                    case_superclass, case_interfaces = (
+                        self._extract_scala_extends_clause(case_node)
+                    )
                     results.append(
                         Class(
                             name=case_name,
@@ -501,9 +561,12 @@ class ScalaElementExtractor(ElementExtractor):
                             raw_text=self._get_node_text(case_node),
                             language="scala",
                             class_type="enum_member",
-                            visibility="public",
+                            visibility=self._scala_visibility(case_node),
                             package_name=self.current_package,
                             parent_class=enum_name,
+                            superclass=case_superclass,
+                            interfaces=case_interfaces,
+                            modifiers=self._scala_modifiers(case_node),
                         )
                     )
 
@@ -524,19 +587,7 @@ class ScalaElementExtractor(ElementExtractor):
               <expr>
         """
         try:
-            name_node = node.child_by_field_name("name")
-            if name_node:
-                name = self._get_node_text(name_node)
-            else:
-                # Fall back to first identifier child.
-                name = next(
-                    (
-                        self._get_node_text(c)
-                        for c in node.children
-                        if c.type == "identifier"
-                    ),
-                    "anonymous_given",
-                )
+            name = self._scala_given_name(node)
             return Class(
                 name=name,
                 start_line=node.start_point[0] + 1,
@@ -544,7 +595,8 @@ class ScalaElementExtractor(ElementExtractor):
                 raw_text=self._get_node_text(node),
                 language="scala",
                 class_type="given",
-                visibility="public",
+                visibility=self._scala_visibility(node),
+                modifiers=self._scala_modifiers(node),
                 package_name=self.current_package,
                 parent_class=parent_class,
             )
@@ -575,19 +627,49 @@ class ScalaElementExtractor(ElementExtractor):
                 ),
                 "unknown_type",
             )
+            class_type = (
+                "type_alias"
+                if self._scala_type_has_alias_target(node)
+                else "type_member"
+            )
             return Class(
                 name=name,
                 start_line=node.start_point[0] + 1,
                 end_line=node.end_point[0] + 1,
                 raw_text=self._get_node_text(node),
                 language="scala",
-                class_type="type_alias",
-                visibility="public",
+                class_type=class_type,
+                visibility=self._scala_visibility(node),
+                modifiers=self._scala_modifiers(node),
                 package_name=self.current_package,
                 parent_class=parent_class,
             )
         except Exception as e:
             log_error(f"Error extracting Scala type alias: {e}")
+            return None
+
+    def _extract_extension(
+        self,
+        node: tree_sitter.Node,
+        parent_class: str | None,
+    ) -> Class | None:
+        try:
+            receiver_type = self._scala_extension_receiver_type(node)
+            suffix = receiver_type or str(node.start_point[0] + 1)
+            return Class(
+                name=f"extension[{suffix}]",
+                start_line=node.start_point[0] + 1,
+                end_line=node.end_point[0] + 1,
+                raw_text=self._get_node_text(node),
+                language="scala",
+                class_type="extension",
+                visibility=self._scala_visibility(node),
+                modifiers=self._scala_modifiers(node),
+                package_name=self.current_package,
+                parent_class=parent_class,
+            )
+        except Exception as e:
+            log_error(f"Error extracting Scala extension: {e}")
             return None
 
     def _extract_function(self, node: tree_sitter.Node) -> Function | None:
@@ -628,6 +710,7 @@ class ScalaElementExtractor(ElementExtractor):
                 parameters=parameters,
                 return_type=return_type,
                 visibility=visibility,
+                modifiers=self._scala_modifiers(node),
                 docstring=docstring,
                 is_constructor=name == "this",
             )
@@ -745,16 +828,69 @@ class ScalaElementExtractor(ElementExtractor):
         the explicit keywords. Defaults to ``public`` when no modifiers
         node is present or contains neither keyword.
         """
+        modifiers = self._scala_modifiers(node)
+        if "private" in modifiers:
+            return "private"
+        if "protected" in modifiers:
+            return "protected"
+        return "public"
+
+    def _scala_modifiers(self, node: tree_sitter.Node) -> list[str]:
+        modifiers: list[str] = []
         for child in node.children:
             if child.type != "modifiers":
                 continue
-            modifiers_text = self._get_node_text(child)
-            if "private" in modifiers_text:
-                return "private"
-            if "protected" in modifiers_text:
-                return "protected"
-            return "public"
-        return "public"
+            for modifier in child.children:
+                text = self._get_node_text(modifier)
+                if text:
+                    modifiers.append(text)
+            if not modifiers:
+                text = self._get_node_text(child)
+                if text:
+                    modifiers.extend(text.split())
+            break
+        return modifiers
+
+    def _scala_given_name(self, node: tree_sitter.Node) -> str:
+        name_node = node.child_by_field_name("name")
+        if name_node:
+            return self._get_node_text(name_node)
+        for child in node.children:
+            if child.type == "identifier":
+                return self._get_node_text(child)
+        type_name = self._scala_given_type_name(node)
+        if type_name:
+            return f"given {type_name}"
+        return f"anonymous_given_{node.start_point[0] + 1}"
+
+    def _scala_given_type_name(self, node: tree_sitter.Node) -> str | None:
+        for child in node.children:
+            if child.type in (
+                "generic_type",
+                "type_identifier",
+                "stable_type_identifier",
+                "tuple_type",
+                "function_type",
+            ):
+                return self._get_node_text(child)
+        return None
+
+    @staticmethod
+    def _scala_type_has_alias_target(node: tree_sitter.Node) -> bool:
+        return any(child.type == "=" for child in node.children)
+
+    def _scala_extension_receiver_type(self, node: tree_sitter.Node) -> str | None:
+        for child in node.children:
+            if child.type != "parameters":
+                continue
+            params = self._extract_parameters(child)
+            if not params:
+                return None
+            first = params[0]
+            if ":" in first:
+                return first.split(":", 1)[1].strip()
+            return first
+        return None
 
     def _extract_parameters(self, param_node: tree_sitter.Node) -> list[str]:
         """Extract parameters from a parameter clause.
@@ -886,6 +1022,7 @@ class ScalaElementExtractor(ElementExtractor):
                 language="scala",
                 class_type=kind,
                 visibility=visibility,
+                modifiers=self._scala_modifiers(node),
                 package_name=self.current_package,
                 docstring=docstring,
                 superclass=superclass,


### PR DESCRIPTION
Focused split of #971 — scala subset only. Part of issue #961.

Files:
- tree_sitter_analyzer/languages/scala_plugin.py
- tree_sitter_analyzer/_ast_extraction.py (Scala class-like symbol extraction; consumed directly by the Scala tests via `_extract_symbols`, so grouped here rather than in the lineage/core PR)
- tests/unit/languages/test_scala_fixes.py
- tests/unit/test_scala_language_wiring.py

🤖 Generated with Claude Code