### PR TITLE
fix(c-cpp): Codex P2 findings (#961 c-cpp)

### DIFF
--- a/tests/unit/languages/test_c_cpp_fixes.py
+++ b/tests/unit/languages/test_c_cpp_fixes.py
@@ -127,6 +127,46 @@ class Outer {
         assert outer.class_type == "class"
         assert inner.class_type == "struct"
 
+    def test_field_type_reference_is_not_nested_class(self) -> None:
+        """struct Point field references inside Rect must not emit bogus nested Point."""
+        code = """\
+struct Point { int x; int y; };
+struct Rect { struct Point br; };
+"""
+        tree = _parse_cpp(code)
+        ext = CppElementExtractor()
+        classes = ext.extract_classes(tree, code)
+        names = [c.name for c in classes]
+
+        assert names.count("Point") == 1
+        assert not any(c.name == "Point" and c.parent_class == "Rect" for c in classes)
+
+    def test_template_nested_struct_has_parent_class(self) -> None:
+        code = """\
+class Outer {
+public:
+    template <typename T> struct Inner {};
+};
+"""
+        tree = _parse_cpp(code)
+        ext = CppElementExtractor()
+        inner = next(c for c in ext.extract_classes(tree, code) if c.name == "Inner")
+
+        assert inner.parent_class == "Outer"
+        assert "template" in inner.modifiers
+
+    def test_union_nested_struct_has_parent_class(self) -> None:
+        code = """\
+union Outer {
+    struct Inner { int x; };
+};
+"""
+        tree = _parse_cpp(code)
+        ext = CppElementExtractor()
+        inner = next(c for c in ext.extract_classes(tree, code) if c.name == "Inner")
+
+        assert inner.parent_class == "Outer"
+
 
 # ---------------------------------------------------------------------------
 # Bug #752 — C typedef struct regression guard (no duplicate entries)
@@ -241,3 +281,23 @@ class TestBug753CAnonymousNestedContainerSkipped:
 
         names = sorted(c.name for c in classes)
         assert names == ["Inner", "Outer"]
+
+
+class TestBitfields:
+    """Unnamed C/C++ bitfields are padding, not addressable field symbols."""
+
+    def test_c_unnamed_bitfield_is_skipped(self) -> None:
+        code = "struct Flags { unsigned : 1; unsigned enabled : 1; };\n"
+        tree = _parse_c(code)
+        ext = CElementExtractor()
+        names = [v.name for v in ext.extract_variables(tree, code)]
+
+        assert names == ["enabled"]
+
+    def test_cpp_unnamed_bitfield_is_skipped(self) -> None:
+        code = "struct Flags { unsigned : 1; unsigned enabled : 1; };\n"
+        tree = _parse_cpp(code)
+        ext = CppElementExtractor()
+        names = [v.name for v in ext.extract_variables(tree, code)]
+
+        assert names == ["enabled"]

--- a/tree_sitter_analyzer/languages/_c_declaration_helpers.py
+++ b/tree_sitter_analyzer/languages/_c_declaration_helpers.py
@@ -100,7 +100,7 @@ def _field_parts(
         elif child.type == "type_qualifier":
             _append_modifier(modifiers, child, get_node_text)
         elif child.type == "field_identifier":
-            field_names.append(get_node_text(child))
+            _append_nonempty_name(field_names, child, get_node_text)
         elif child.type == "array_declarator":
             field_type = _append_array_fields(
                 child, field_names, field_type, get_node_text
@@ -154,7 +154,7 @@ def _append_initializer_fields(
 ) -> None:
     for grandchild in node.children:
         if grandchild.type in {"field_identifier", "identifier"}:
-            field_names.append(get_node_text(grandchild))
+            _append_nonempty_name(field_names, grandchild, get_node_text)
 
 
 def _append_pointer_fields(
@@ -188,8 +188,18 @@ def _append_child_names(
     initial_len = len(names)
     for child in node.children:
         if child.type == node_type:
-            names.append(get_node_text(child))
+            _append_nonempty_name(names, child, get_node_text)
     return len(names) > initial_len
+
+
+def _append_nonempty_name(
+    names: list[str],
+    node: Any,
+    get_node_text: Callable[..., str],
+) -> None:
+    name = get_node_text(node)
+    if name:
+        names.append(name)
 
 
 def _append_modifier(

--- a/tree_sitter_analyzer/languages/_cpp_element_helpers.py
+++ b/tree_sitter_analyzer/languages/_cpp_element_helpers.py
@@ -29,7 +29,9 @@ class CppClassExtractionContext:
     extract_comment_for_line: Callable[[int], str | None]
 
 
-_CPP_CLASS_NODE_TYPES = frozenset({"class_specifier", "struct_specifier"})
+_CPP_CLASS_NODE_TYPES = frozenset(
+    {"class_specifier", "struct_specifier", "union_specifier"}
+)
 _CPP_CLASS_PARENT_WALK_LIMIT = 12
 _CPP_NAMESPACE_PARENT_WALK_LIMIT = 16
 _CPP_NAMESPACE_NAME_NODE_TYPES = frozenset(
@@ -194,30 +196,48 @@ def extract_cpp_function(
 
 def _cpp_direct_parent_class_name(node: Any) -> str | None:
     """Return the enclosing class/struct name when ``node`` is a nested type
-    declared directly inside a class body (one level up via field_declaration).
+    declared directly inside a class body.
 
-    Walk: node → field_declaration → field_declaration_list → class/struct/union_specifier
-    with a hard cap to avoid infinite walks on mocked nodes.
+    Handles both ordinary declarations and templated nested types:
+    ``node → field_declaration → field_declaration_list → owner`` and
+    ``node → template_declaration → field_declaration_list → owner``.
+    The hard cap avoids infinite walks on mocked nodes.
     """
-    parent = getattr(node, "parent", None)
-    if parent is None or getattr(parent, "type", "") != "field_declaration":
-        return None
-    grandparent = getattr(parent, "parent", None)
-    if (
-        grandparent is None
-        or getattr(grandparent, "type", "") != "field_declaration_list"
-    ):
-        return None
-    great = getattr(grandparent, "parent", None)
-    if great is None or getattr(great, "type", "") not in _CPP_CLASS_NODE_TYPES:
-        return None
-    for child in getattr(great, "children", ()):
+    current = getattr(node, "parent", None)
+    depth = 0
+    while current is not None and depth < _CPP_CLASS_PARENT_WALK_LIMIT:
+        if getattr(current, "type", "") == "field_declaration_list":
+            owner = getattr(current, "parent", None)
+            if getattr(owner, "type", "") in _CPP_CLASS_NODE_TYPES:
+                return _cpp_type_name(owner)
+            return None
+        current = getattr(current, "parent", None)
+        depth += 1
+    return None
+
+
+def _cpp_type_name(node: Any) -> str | None:
+    for child in getattr(node, "children", ()):
         if getattr(child, "type", "") == "type_identifier":
             text = getattr(child, "text", b"")
             if isinstance(text, bytes):
                 return text.decode("utf-8", errors="replace")
             return str(text)
     return None
+
+
+def _cpp_has_definition_body(node: Any) -> bool:
+    return any(
+        getattr(child, "type", "")
+        in {"field_declaration_list", "declaration_list", "enumerator_list"}
+        for child in getattr(node, "children", ())
+    )
+
+
+def _is_cpp_field_type_reference(node: Any) -> bool:
+    return getattr(
+        getattr(node, "parent", None), "type", ""
+    ) == "field_declaration" and not _cpp_has_definition_body(node)
 
 
 def extract_cpp_class(
@@ -232,6 +252,8 @@ def extract_cpp_class(
             node, ctx.get_node_text, ctx.extract_base_classes
         )
         if not class_name:
+            return None
+        if _is_cpp_field_type_reference(node):
             return None
 
         start_line = node.start_point[0] + 1

--- a/tree_sitter_analyzer/languages/_cpp_variable_helpers.py
+++ b/tree_sitter_analyzer/languages/_cpp_variable_helpers.py
@@ -10,6 +10,7 @@ from ..utils import log_debug
 _TYPE_NODES_CPP = frozenset(
     {
         "primitive_type",
+        "sized_type_specifier",
         "type_identifier",
         "qualified_identifier",
         "template_type",
@@ -118,7 +119,7 @@ def _apply_variable_child(
     elif child.type in ("storage_class_specifier", "type_qualifier"):
         _append_text_modifier(parts.modifiers, child, get_node_text)
     elif child.type in declarator_name_types:
-        parts.names.append(get_node_text(child))
+        _append_nonempty_name(parts.names, child, get_node_text)
     elif child.type == "init_declarator":
         parts.names.extend(
             _init_declarator_names(child, get_node_text, declarator_name_types)
@@ -138,11 +139,21 @@ def _init_declarator_names(
     get_node_text: Callable[..., str],
     declarator_name_types: tuple[str, ...],
 ) -> list[str]:
-    return [
-        get_node_text(child)
-        for child in node.children
-        if child.type in declarator_name_types
-    ]
+    names: list[str] = []
+    for child in node.children:
+        if child.type in declarator_name_types:
+            _append_nonempty_name(names, child, get_node_text)
+    return names
+
+
+def _append_nonempty_name(
+    names: list[str],
+    node: Any,
+    get_node_text: Callable[..., str],
+) -> None:
+    name = get_node_text(node)
+    if name:
+        names.append(name)
 
 
 def _build_variables(


### PR DESCRIPTION
Focused split of #971 — c-cpp subset only. Part of issue #961.

Files:
- tree_sitter_analyzer/languages/_c_declaration_helpers.py
- tree_sitter_analyzer/languages/_cpp_element_helpers.py
- tree_sitter_analyzer/languages/_cpp_variable_helpers.py
- tests/unit/languages/test_c_cpp_fixes.py

🤖 Generated with Claude Code