### PR TITLE
fix(csharp): Codex P2 findings (#961 csharp)

### DIFF
--- a/tests/unit/languages/test_csharp_plugin_extraction.py
+++ b/tests/unit/languages/test_csharp_plugin_extraction.py
@@ -509,6 +509,35 @@ class TestCSharpNamespacePackageExtraction:
         assert len(packages) == 1
         assert packages[0].name == "MyApp"
 
+    def test_file_scoped_namespace_produces_package_element(self):
+        """C# 10 file-scoped namespace declarations use a distinct node type."""
+        src = "namespace MyApp.Services;\npublic class Foo {}\n"
+        plugin = CSharpPlugin()
+        tree = get_tree_for_code(src, plugin)
+        packages = plugin.extractor.extract_packages(tree, src)
+
+        assert len(packages) == 1
+        assert packages[0].name == "MyApp.Services"
+
+    def test_multiple_block_namespaces_are_all_extracted(self):
+        src = (
+            "namespace First { public class A {} }\n"
+            "namespace Second { public class B {} }\n"
+        )
+        plugin = CSharpPlugin()
+        tree = get_tree_for_code(src, plugin)
+        packages = plugin.extractor.extract_packages(tree, src)
+
+        assert [pkg.name for pkg in packages] == ["First", "Second"]
+
+    def test_grouped_extract_elements_includes_packages(self):
+        plugin = CSharpPlugin()
+        tree = get_tree_for_code(SIMPLE_CLASS_CODE, plugin)
+        grouped = plugin.extract_elements(tree, SIMPLE_CLASS_CODE)
+
+        assert "packages" in grouped
+        assert grouped["packages"][0].name == "MyApp.Models"
+
     def test_no_namespace_returns_empty(self):
         """A C# file without a namespace declaration returns no Package."""
         src = "public class Bare {}\n"

--- a/tree_sitter_analyzer/languages/csharp_plugin.py
+++ b/tree_sitter_analyzer/languages/csharp_plugin.py
@@ -154,7 +154,7 @@ class CSharpElementExtractor(ElementExtractor):
         Args:
             node: Root node of the AST
         """
-        if node.type == "namespace_declaration":
+        if node.type in ("namespace_declaration", "file_scoped_namespace_declaration"):
             name_node = node.child_by_field_name("name")
             if name_node:
                 self.current_namespace = self._get_node_text_optimized(name_node)
@@ -162,7 +162,10 @@ class CSharpElementExtractor(ElementExtractor):
 
         # Recursively search for namespace
         for child in node.children:
-            if child.type == "namespace_declaration":
+            if child.type in (
+                "namespace_declaration",
+                "file_scoped_namespace_declaration",
+            ):
                 name_node = child.child_by_field_name("name")
                 if name_node:
                     self.current_namespace = self._get_node_text_optimized(name_node)
@@ -459,7 +462,10 @@ class CSharpElementExtractor(ElementExtractor):
             return packages
 
         for node in self._traverse_iterative(tree.root_node):
-            if node.type != "namespace_declaration":
+            if node.type not in (
+                "namespace_declaration",
+                "file_scoped_namespace_declaration",
+            ):
                 continue
             name_node = node.child_by_field_name("name")
             if name_node is None:
@@ -476,10 +482,19 @@ class CSharpElementExtractor(ElementExtractor):
                     language="csharp",
                 )
             )
-            # Only capture the outermost (first) namespace per file
-            break
-
         return packages
+
+    def extract_elements(
+        self, tree: tree_sitter.Tree, source_code: str
+    ) -> dict[str, list[Any]]:
+        """Extract grouped C# elements, including namespace packages."""
+        return {
+            "functions": self.extract_functions(tree, source_code),
+            "classes": self.extract_classes(tree, source_code),
+            "variables": self.extract_variables(tree, source_code),
+            "imports": self.extract_imports(tree, source_code),
+            "packages": self.extract_packages(tree, source_code),
+        }
 
 
 class CSharpPlugin(LanguagePlugin):


### PR DESCRIPTION
Focused split of #971 — csharp subset only. Part of issue #961.

Files:
- tree_sitter_analyzer/languages/csharp_plugin.py
- tests/unit/languages/test_csharp_plugin_extraction.py

🤖 Generated with Claude Code