### PR TITLE
fix(typescript): Codex P2 findings (#961 typescript)

### DIFF
--- a/tests/unit/languages/test_typescript_extraction_fixes.py
+++ b/tests/unit/languages/test_typescript_extraction_fixes.py
@@ -233,6 +233,16 @@ class Foo {
     assert fn.decorators == []
 
 
+def test_property_decorator_column() -> None:
+    """@Column() on a class field must be captured in Variable.decorators."""
+    tree = _parse(_DECORATOR_CLASS_CODE)
+    extractor = TypeScriptElementExtractor()
+    variables = extractor.extract_variables(tree, _DECORATOR_CLASS_CODE)
+    name_field = next(v for v in variables if v.name == "name")
+
+    assert "Column" in name_field.decorators
+
+
 def test_class_without_decorator_has_empty_list() -> None:
     code = """\
 class Foo {}
@@ -287,3 +297,43 @@ def test_enum_kind_in_ast_extraction() -> None:
         assert sym["kind"] == "enum", (
             f"Expected kind='enum' for {sym['name']!r}, got {sym['kind']!r}"
         )
+
+
+def test_exported_enum_interface_and_type_are_detected() -> None:
+    code = """\
+export enum Status { Active, Inactive }
+export interface Shape {}
+export type Id = string
+class Local {}
+export { Local }
+"""
+    classes = {c.name: c for c in _classes(code)}
+
+    assert classes["Status"].is_exported is True
+    assert classes["Shape"].is_exported is True
+    assert classes["Id"].is_exported is True
+    assert classes["Local"].is_exported is True
+
+
+def test_enum_export_surface_includes_members() -> None:
+    from tree_sitter_analyzer.mcp.tools.utils.element_extractor import get_all_exports
+    from tree_sitter_analyzer.models import AnalysisResult
+
+    code = "export enum Status { Active = 'active', Inactive = 'inactive' }"
+    result = AnalysisResult(
+        file_path="status.ts",
+        language="typescript",
+        elements=_classes(code),
+        source_code=code,
+    )
+    exports = get_all_exports(result)
+    enum_export = next(e for e in exports if e["name"] == "Status")
+
+    assert enum_export["kind"] == "enum"
+    assert enum_export["members"] == ["Active", "Inactive"]
+
+
+def test_enum_kind_is_available_in_symbol_search_filters() -> None:
+    from tree_sitter_analyzer.mcp.tools.symbol_search_tool import SYMBOL_SEARCH_KINDS
+
+    assert "enum" in SYMBOL_SEARCH_KINDS

--- a/tests/unit/languages/test_typescript_extraction_fixes.py
+++ b/tests/unit/languages/test_typescript_extraction_fixes.py
@@ -412,3 +412,202 @@ def test_reexport_multi_name() -> None:
 def test_reexport_aliased() -> None:
     code = "class Local {}\nexport { Local as Foo }\n"
     assert {c.name: c for c in _classes(code)}["Local"].is_exported is True
+
+
+# ---------------------------------------------------------------------------
+# #975 — _is_named_reexport / is_exported_class negative branches
+#   The whole-word match must NOT fire on a longer name that merely *contains*
+#   the target (Local vs LocalThing), and a file with no export at all must
+#   return False (both the plain pattern and the alias pattern miss).
+# ---------------------------------------------------------------------------
+
+
+def test_reexport_name_is_substring_does_not_match() -> None:
+    """`export { LocalThing }` must NOT report `Local` as re-exported."""
+    from tree_sitter_analyzer.languages.typescript_plugin._variable_helpers import (
+        _is_named_reexport,
+    )
+
+    assert _is_named_reexport("Local", "export { LocalThing }") is False
+
+
+def test_reexport_alias_lhs_substring_does_not_match() -> None:
+    """`{ LocalThing as Foo }` must NOT report `Local` (alias-pattern miss)."""
+    from tree_sitter_analyzer.languages.typescript_plugin._variable_helpers import (
+        _is_named_reexport,
+    )
+
+    assert _is_named_reexport("Local", "export { LocalThing as Foo }") is False
+
+
+def test_reexport_no_export_block_returns_false() -> None:
+    """A source with no `export { ... }` block at all returns False."""
+    from tree_sitter_analyzer.languages.typescript_plugin._variable_helpers import (
+        _is_named_reexport,
+    )
+
+    assert _is_named_reexport("Local", "class Local {}\nconst x = 1\n") is False
+
+
+def test_reexport_alias_form_direct() -> None:
+    """`{ Local as Foo }` reports the LHS `Local` via the alias pattern."""
+    from tree_sitter_analyzer.languages.typescript_plugin._variable_helpers import (
+        _is_named_reexport,
+    )
+
+    assert _is_named_reexport("Local", "export { Local as Foo }") is True
+
+
+def test_is_exported_class_unexported_returns_false() -> None:
+    """A locally-declared, never-exported class is not reported as exported."""
+    from tree_sitter_analyzer.languages.typescript_plugin._variable_helpers import (
+        is_exported_class,
+    )
+
+    assert is_exported_class("Local", "class Local {}\n") is False
+
+
+def test_is_exported_class_interface_prefix() -> None:
+    """`export interface X` is recognised via the interface prefix."""
+    from tree_sitter_analyzer.languages.typescript_plugin._variable_helpers import (
+        is_exported_class,
+    )
+
+    assert is_exported_class("Shape", "export interface Shape {}\n") is True
+
+
+def test_is_exported_class_default_export() -> None:
+    """`export default X` is recognised."""
+    from tree_sitter_analyzer.languages.typescript_plugin._variable_helpers import (
+        is_exported_class,
+    )
+
+    assert (
+        is_exported_class("Widget", "class Widget {}\nexport default Widget\n") is True
+    )
+
+
+# ---------------------------------------------------------------------------
+# #975 — _split_top_level_commas: quote / bracket / escape scanner branches
+#   The scanner must ignore commas inside '..', ".." and `..` strings (with
+#   backslash escapes) and inside (), [], {} nesting, and must never let depth
+#   go negative on an unbalanced closing bracket.
+# ---------------------------------------------------------------------------
+
+
+def test_split_single_quote_string_with_comma() -> None:
+    from tree_sitter_analyzer.mcp.tools.utils.element_extractor import (
+        _split_top_level_commas,
+    )
+
+    assert _split_top_level_commas("A = 'x,y', B") == ["A = 'x,y'", " B"]
+
+
+def test_split_double_quote_string_with_comma() -> None:
+    from tree_sitter_analyzer.mcp.tools.utils.element_extractor import (
+        _split_top_level_commas,
+    )
+
+    assert _split_top_level_commas('A = "x,y", B') == ['A = "x,y"', " B"]
+
+
+def test_split_backtick_template_with_comma() -> None:
+    from tree_sitter_analyzer.mcp.tools.utils.element_extractor import (
+        _split_top_level_commas,
+    )
+
+    assert _split_top_level_commas("A = `x,y`, B") == ["A = `x,y`", " B"]
+
+
+def test_split_escaped_quote_inside_string() -> None:
+    """A backslash-escaped quote does not close the string early."""
+    from tree_sitter_analyzer.mcp.tools.utils.element_extractor import (
+        _split_top_level_commas,
+    )
+
+    # The escaped `\"` stays inside the string, so the inner comma is protected
+    # and the string only closes at the final unescaped `"`.
+    assert _split_top_level_commas('A = "a\\",b", B') == ['A = "a\\",b"', " B"]
+
+
+def test_split_nested_paren_brackets() -> None:
+    from tree_sitter_analyzer.mcp.tools.utils.element_extractor import (
+        _split_top_level_commas,
+    )
+
+    assert _split_top_level_commas("A = f(1, 2), B") == ["A = f(1, 2)", " B"]
+
+
+def test_split_nested_square_brackets() -> None:
+    from tree_sitter_analyzer.mcp.tools.utils.element_extractor import (
+        _split_top_level_commas,
+    )
+
+    assert _split_top_level_commas("A = [1, 2], B") == ["A = [1, 2]", " B"]
+
+
+def test_split_nested_curly_brackets() -> None:
+    from tree_sitter_analyzer.mcp.tools.utils.element_extractor import (
+        _split_top_level_commas,
+    )
+
+    assert _split_top_level_commas("A = {x: 1, y: 2}, B") == ["A = {x: 1, y: 2}", " B"]
+
+
+def test_split_empty_body() -> None:
+    from tree_sitter_analyzer.mcp.tools.utils.element_extractor import (
+        _split_top_level_commas,
+    )
+
+    assert _split_top_level_commas("") == [""]
+
+
+def test_split_trailing_comma_yields_empty_segment() -> None:
+    from tree_sitter_analyzer.mcp.tools.utils.element_extractor import (
+        _split_top_level_commas,
+    )
+
+    assert _split_top_level_commas("A, B,") == ["A", " B", ""]
+
+
+def test_split_unbalanced_close_bracket_depth_never_negative() -> None:
+    """A stray closing bracket must not drive depth below zero, so a following
+    top-level comma still splits (the depth-never-negative guard)."""
+    from tree_sitter_analyzer.mcp.tools.utils.element_extractor import (
+        _split_top_level_commas,
+    )
+
+    assert _split_top_level_commas("A), B") == ["A)", " B"]
+
+
+# ---------------------------------------------------------------------------
+# #975 — _enum_members_from_raw_text: empty-candidate + no-identifier branches
+# ---------------------------------------------------------------------------
+
+
+def test_enum_members_trailing_comma_skips_empty_candidate() -> None:
+    """A trailing comma produces an empty segment that is skipped (continue)."""
+    from tree_sitter_analyzer.mcp.tools.utils.element_extractor import (
+        _enum_members_from_raw_text,
+    )
+
+    assert _enum_members_from_raw_text("{ A, B, }") == ["A", "B"]
+
+
+def test_enum_members_segment_without_identifier_skipped() -> None:
+    """A segment whose candidate has no leading identifier is skipped."""
+    from tree_sitter_analyzer.mcp.tools.utils.element_extractor import (
+        _enum_members_from_raw_text,
+    )
+
+    # The `123` segment has no valid identifier head -> regex miss -> skipped.
+    assert _enum_members_from_raw_text("{ A, 123, B }") == ["A", "B"]
+
+
+def test_enum_members_no_braces_uses_raw_text() -> None:
+    """With no `{...}` wrapper the whole raw text is split directly."""
+    from tree_sitter_analyzer.mcp.tools.utils.element_extractor import (
+        _enum_members_from_raw_text,
+    )
+
+    assert _enum_members_from_raw_text("A, B") == ["A", "B"]

--- a/tests/unit/languages/test_typescript_extraction_fixes.py
+++ b/tests/unit/languages/test_typescript_extraction_fixes.py
@@ -337,3 +337,78 @@ def test_enum_kind_is_available_in_symbol_search_filters() -> None:
     from tree_sitter_analyzer.mcp.tools.symbol_search_tool import SYMBOL_SEARCH_KINDS
 
     assert "enum" in SYMBOL_SEARCH_KINDS
+
+
+# ---------------------------------------------------------------------------
+# #975 — enum member split must respect quoted / parenthesised commas
+#   _enum_members_from_raw_text split the raw body on every ',', so a comma
+#   inside a quoted string value (or a call-expr value) fabricated a phantom
+#   member from the value text. e.g. { A = "x,y", B } returned ['A','y','B'].
+# ---------------------------------------------------------------------------
+
+
+def test_enum_members_phantom_from_quoted_comma() -> None:
+    """A comma inside a quoted value must NOT fabricate a phantom member."""
+    from tree_sitter_analyzer.mcp.tools.utils.element_extractor import (
+        _enum_members_from_raw_text,
+    )
+
+    assert _enum_members_from_raw_text('A = "x,y", B = "z"') == ["A", "B"]
+
+
+def test_enum_members_phantom_from_call_expr_comma() -> None:
+    """A comma inside a call-expression value must NOT fabricate a member."""
+    from tree_sitter_analyzer.mcp.tools.utils.element_extractor import (
+        _enum_members_from_raw_text,
+    )
+
+    assert _enum_members_from_raw_text("A = f(1, 2), B") == ["A", "B"]
+
+
+def test_enum_members_plain_string_values_regression() -> None:
+    """Common string-valued enum still splits correctly."""
+    from tree_sitter_analyzer.mcp.tools.utils.element_extractor import (
+        _enum_members_from_raw_text,
+    )
+
+    assert _enum_members_from_raw_text(
+        '{ Active = "active", Inactive = "inactive" }'
+    ) == ["Active", "Inactive"]
+
+
+def test_enum_export_surface_no_phantom_member() -> None:
+    """End-to-end through get_all_exports: quoted comma must not add a member."""
+    from tree_sitter_analyzer.mcp.tools.utils.element_extractor import get_all_exports
+    from tree_sitter_analyzer.models import AnalysisResult
+
+    code = 'export enum E { A = "x,y", B = "z" }'
+    result = AnalysisResult(
+        file_path="e.ts",
+        language="typescript",
+        elements=_classes(code),
+        source_code=code,
+    )
+    enum_export = next(e for e in get_all_exports(result) if e["name"] == "E")
+    assert enum_export["members"] == ["A", "B"]
+
+
+# ---------------------------------------------------------------------------
+# #975 (P3) — is_exported_class re-export form must tolerate spacing/multi-name
+# ---------------------------------------------------------------------------
+
+
+def test_reexport_no_inner_spaces() -> None:
+    code = "class Local {}\nexport {Local}\n"
+    assert {c.name: c for c in _classes(code)}["Local"].is_exported is True
+
+
+def test_reexport_multi_name() -> None:
+    code = "class Local {}\nclass Other {}\nexport { Local, Other }\n"
+    by_name = {c.name: c for c in _classes(code)}
+    assert by_name["Local"].is_exported is True
+    assert by_name["Other"].is_exported is True
+
+
+def test_reexport_aliased() -> None:
+    code = "class Local {}\nexport { Local as Foo }\n"
+    assert {c.name: c for c in _classes(code)}["Local"].is_exported is True

--- a/tests/unit/mcp/tools/test_facade_tool.py
+++ b/tests/unit/mcp/tools/test_facade_tool.py
@@ -547,12 +547,13 @@ def test_search_facade_schema_declares_kind_with_enum() -> None:
     from tree_sitter_analyzer.mcp.tools.symbol_search_tool import SYMBOL_SEARCH_KINDS
 
     # The authoritative enum: exactly the kinds _extract_symbols emits into
-    # ast_symbol_rows (function/method/class/variable/import/constant) plus
+    # ast_symbol_rows (function/method/class/enum/variable/import/constant) plus
     # the "any" no-filter default. Exact pin — extraction changes must re-pin.
     assert SYMBOL_SEARCH_KINDS == (
         "function",
         "method",
         "class",
+        "enum",
         "variable",
         "import",
         "constant",

--- a/tree_sitter_analyzer/languages/typescript_plugin/_variable_helpers.py
+++ b/tree_sitter_analyzer/languages/typescript_plugin/_variable_helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, TypeAlias
@@ -157,8 +158,28 @@ def is_exported_class(class_name: str, source_code: str) -> bool:
             f"export {prefix} {class_name}" in source_code for prefix in export_prefixes
         )
         or f"export default {class_name}" in source_code
-        or f"export {{ {class_name} }}" in source_code
+        or _is_named_reexport(class_name, source_code)
     )
+
+
+def _is_named_reexport(class_name: str, source_code: str) -> bool:
+    """Detect ``export { ... }`` re-export of ``class_name``.
+
+    Matches the name as a whole word inside any ``export { ... }`` block,
+    tolerating inner spacing (``export {Local}``), multiple names
+    (``export { Local, Other }``), and aliases (``export { Local as Foo }``).
+    The name is matched on its own (word-boundary) so ``Local`` does not match
+    ``LocalThing``; an aliased name matches the LHS only (``{ Local as Foo }``
+    exports ``Local``, not ``Foo``).
+    """
+    pattern = r"export\s*\{[^}]*\b" + re.escape(class_name) + r"\b(?!\s+as\s)[^}]*\}"
+    if re.search(pattern, source_code):
+        return True
+    # Aliased form: `{ Local as Foo }` — class_name is the LHS of `as`.
+    alias_pattern = (
+        r"export\s*\{[^}]*\b" + re.escape(class_name) + r"\s+as\s+\w+[^}]*\}"
+    )
+    return bool(re.search(alias_pattern, source_code))
 
 
 def infer_type_from_value(value: str | None) -> str:

--- a/tree_sitter_analyzer/languages/typescript_plugin/_variable_helpers.py
+++ b/tree_sitter_analyzer/languages/typescript_plugin/_variable_helpers.py
@@ -58,6 +58,7 @@ def extract_property(
             is_static=parts.is_static,
             is_constant=False,
             visibility=parts.visibility,
+            decorators=_extract_direct_decorator_names(node),
         )
     except Exception as e:
         log_debug(f"Failed to extract property info: {e}")
@@ -142,10 +143,21 @@ def is_framework_component(
 
 
 def is_exported_class(class_name: str, source_code: str) -> bool:
-    """Check if class is exported."""
+    """Check if a TypeScript type-like symbol is exported."""
+    export_prefixes = (
+        "class",
+        "abstract class",
+        "interface",
+        "type",
+        "enum",
+        "const enum",
+    )
     return (
-        f"export class {class_name}" in source_code
+        any(
+            f"export {prefix} {class_name}" in source_code for prefix in export_prefixes
+        )
         or f"export default {class_name}" in source_code
+        or f"export {{ {class_name} }}" in source_code
     )
 
 
@@ -236,6 +248,35 @@ def _apply_property_child(
         parts.type_name = get_node_text(child).lstrip(": ")
     elif child.type in ["string", "number", "true", "false", "null"]:
         parts.value = get_node_text(child)
+
+
+def _extract_direct_decorator_names(node: tree_sitter.Node) -> list[str]:
+    names: list[str] = []
+    for child in node.children:
+        if child.type != "decorator":
+            continue
+        name = _decorator_name(child)
+        if name:
+            names.append(name)
+    return names
+
+
+def _decorator_name(node: tree_sitter.Node) -> str | None:
+    for child in node.children:
+        if child.type == "identifier":
+            return _node_text(child)
+        if child.type == "call_expression":
+            for grandchild in child.children:
+                if grandchild.type == "identifier":
+                    return _node_text(grandchild)
+    return None
+
+
+def _node_text(node: tree_sitter.Node) -> str:
+    text = node.text
+    if isinstance(text, bytes):
+        return text.decode("utf-8", errors="replace")
+    return str(text or "")
 
 
 def _parse_variable_parts(

--- a/tree_sitter_analyzer/mcp/tools/symbol_search_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/symbol_search_tool.py
@@ -29,7 +29,7 @@ DEFAULT_SYMBOL_SEARCH_LIMIT = 15
 
 # Authoritative ``kind`` filter values. Must mirror exactly what
 # ``_extract_symbols`` (tree_sitter_analyzer/_ast_extraction.py) writes into
-# ``ast_symbol_rows`` — function/method/class/variable/import/constant — plus
+# ``ast_symbol_rows`` — function/method/class/enum/variable/import/constant — plus
 # the "any" no-filter default. Exported so the CLI (`--symbol-search-kind`
 # choices) and the ``search`` facade public schema stay in lock-step with this
 # tool's schema (#640: ``kind`` worked at runtime but was undiscoverable).
@@ -37,6 +37,7 @@ SYMBOL_SEARCH_KINDS: tuple[str, ...] = (
     "function",
     "method",
     "class",
+    "enum",
     "variable",
     "import",
     "constant",

--- a/tree_sitter_analyzer/mcp/tools/utils/element_extractor.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/element_extractor.py
@@ -187,12 +187,53 @@ def get_all_exports(result: AnalysisResult) -> list[dict[str, Any]]:
     return exports
 
 
+def _split_top_level_commas(body: str) -> list[str]:
+    """Split ``body`` on commas that are NOT inside quotes or brackets.
+
+    Respects single/double/backtick string literals (with backslash escapes)
+    and ``()``/``[]``/``{}`` nesting, so a comma inside a quoted value
+    (``A = "x,y"``) or a call-expression value (``A = f(1, 2)``) does not
+    fabricate a phantom member. Returns the raw top-level segments.
+    """
+    segments: list[str] = []
+    current: list[str] = []
+    depth = 0
+    quote: str | None = None
+    escaped = False
+    for ch in body:
+        if quote is not None:
+            current.append(ch)
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == quote:
+                quote = None
+            continue
+        if ch in ("'", '"', "`"):
+            quote = ch
+            current.append(ch)
+        elif ch in ("(", "[", "{"):
+            depth += 1
+            current.append(ch)
+        elif ch in (")", "]", "}"):
+            if depth > 0:
+                depth -= 1
+            current.append(ch)
+        elif ch == "," and depth == 0:
+            segments.append("".join(current))
+            current = []
+        else:
+            current.append(ch)
+    segments.append("".join(current))
+    return segments
+
+
 def _enum_members_from_raw_text(raw_text: str) -> list[str]:
     body_match = re.search(r"\{(?P<body>.*)\}", raw_text, flags=re.DOTALL)
-    if not body_match:
-        return []
+    body = body_match.group("body") if body_match else raw_text
     members: list[str] = []
-    for part in body_match.group("body").split(","):
+    for part in _split_top_level_commas(body):
         candidate = part.split("=", 1)[0].strip()
         if not candidate:
             continue

--- a/tree_sitter_analyzer/mcp/tools/utils/element_extractor.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/element_extractor.py
@@ -9,6 +9,7 @@ plugin system so that all 15 supported languages get full MCP tool value.
 from __future__ import annotations
 
 import ast
+import re
 from pathlib import Path
 from typing import Any
 
@@ -137,14 +138,18 @@ def get_all_exports(result: AnalysisResult) -> list[dict[str, Any]]:
     for e in result.elements:
         if is_element_of_type(e, ELEMENT_TYPE_CLASS):
             methods = getattr(e, "methods", [])
-            exports.append(
-                {
-                    "name": e.name,
-                    "kind": "class",
-                    "line": e.start_line,
-                    "methods": len(methods),
-                }
-            )
+            class_type = getattr(e, "class_type", "class")
+            export: dict[str, Any] = {
+                "name": e.name,
+                "kind": "enum" if class_type == "enum" else "class",
+                "line": e.start_line,
+                "methods": len(methods),
+            }
+            if class_type == "enum":
+                export["members"] = _enum_members_from_raw_text(
+                    getattr(e, "raw_text", "")
+                )
+            exports.append(export)
             seen_names.add(e.name)
         elif is_element_of_type(e, ELEMENT_TYPE_FUNCTION):
             if not e.name.startswith("_"):
@@ -180,6 +185,21 @@ def get_all_exports(result: AnalysisResult) -> list[dict[str, Any]]:
             seen_names.add(reexport["name"])
 
     return exports
+
+
+def _enum_members_from_raw_text(raw_text: str) -> list[str]:
+    body_match = re.search(r"\{(?P<body>.*)\}", raw_text, flags=re.DOTALL)
+    if not body_match:
+        return []
+    members: list[str] = []
+    for part in body_match.group("body").split(","):
+        candidate = part.split("=", 1)[0].strip()
+        if not candidate:
+            continue
+        name = re.match(r"[A-Za-z_$][\w$]*", candidate)
+        if name:
+            members.append(name.group(0))
+    return members
 
 
 def _extract_all_reexports(file_path: str) -> list[dict[str, Any]]:

--- a/tree_sitter_analyzer/models/base.py
+++ b/tree_sitter_analyzer/models/base.py
@@ -167,6 +167,8 @@ class Variable(CodeElement):
     # Owning struct/class for class-level fields (#794) — mirrors
     # Function.receiver_type; names stay bare, the owner travels here.
     receiver_type: str | None = None  # Go struct field owner
+    # TypeScript/JavaScript property decorators (without '@'), e.g. ['Column']
+    decorators: list[str] = field(default_factory=list)
 
 
 @dataclass(frozen=False)


### PR DESCRIPTION
Focused split of #971 — typescript subset only. Part of issue #961.

Files:
- tree_sitter_analyzer/languages/typescript_plugin/_variable_helpers.py
- tree_sitter_analyzer/models/base.py (Variable.decorators — TS/JS property decorators; comment in diff says so)
- tree_sitter_analyzer/mcp/tools/utils/element_extractor.py (enum members in get_all_exports)
- tree_sitter_analyzer/mcp/tools/symbol_search_tool.py (SYMBOL_SEARCH_KINDS += enum)
- tests/unit/languages/test_typescript_extraction_fixes.py
- tests/unit/mcp/tools/test_facade_tool.py (pins SYMBOL_SEARCH_KINDS enum surface)

Note: the enum search-surface plumbing (symbol_search_tool, element_extractor, models/base, test_facade_tool) is grouped here rather than in the lineage/core PR because the TypeScript test file is the primary exerciser of `get_all_exports` enum members and `SYMBOL_SEARCH_KINDS`, and a single test file cannot be split across two PRs.

🤖 Generated with Claude Code