### PR TITLE
fix(lineage): Codex P2 findings (#961 lineage+core)

### DIFF
--- a/docs/CODEMAPS/languages.md
+++ b/docs/CODEMAPS/languages.md
@@ -9,16 +9,16 @@ Each implements the `LanguagePlugin` interface (`tree_sitter_analyzer/plugins/ba
 | Language | Plugin module | Extractor split | Notes |
 |---|---|---|---|
 | Java | `languages/java_plugin.py` | `_java_*_helpers.py` ×4 | Spring/JPA awareness; **fixture file — DO NOT refactor** (see CLAUDE.md memory rule) |
-| Python | `python_plugin/` | submodules | Type annotations, decorators, async |
-| TypeScript | `typescript_plugin/` | submodules | Interfaces, types, TSX/JSX |
+| Python | `python_plugin/` | submodules | Type annotations, decorators, async; module constants include chained and same-line assignments |
+| TypeScript | `typescript_plugin/` | submodules | Interfaces, types, TSX/JSX; enum kind/export parity and class-field decorators |
 | JavaScript | `javascript_plugin/` | submodules | ES6+, JSX; `_function_helpers.py` handles class-field arrow methods (is_method, is_static, computed/string/number key names — #890/#892); `queries/javascript.py` VARIABLES + "variable" query include `field_definition` (#891) |
-| C | `languages/c_plugin.py` | `_c_*_helpers.py` ×8 | functions, structs, unions, enums, preprocessor |
-| C++ | `languages/cpp_plugin.py` | `_cpp_*_helpers.py` ×11 | classes, templates, namespaces |
-| C# | `languages/csharp_plugin.py` | `languages/csharp_helpers.py` | records, async/await, attributes |
+| C | `languages/c_plugin.py` | `_c_*_helpers.py` ×8 | functions, structs, unions, enums, preprocessor; unnamed bitfields are skipped as non-addressable fields |
+| C++ | `languages/cpp_plugin.py` | `_cpp_*_helpers.py` ×11 | classes, templates, namespaces; nested template/union type parent metadata and field-reference guards |
+| C# | `languages/csharp_plugin.py` | `languages/csharp_helpers.py` | records, async/await, attributes; block and file-scoped namespaces surface as packages |
 | Go | `languages/go_plugin.py` | `_go_*_helpers.py` ×6 | structs, interfaces, goroutines |
 | Rust | `languages/rust_plugin.py` | inline | traits, impl, macros, derive |
 | Kotlin | `languages/kotlin_plugin.py` | `languages/kotlin_helpers.py` | data classes, coroutines |
-| Scala | `languages/scala_plugin.py` | inline | objects/traits, scaladoc |
+| Scala | `languages/scala_plugin.py` | inline | objects/traits, scaladoc; Scala 3 enum cases, givens, type members, extensions, and AST-cache symbol rows |
 | Swift | `languages/swift_plugin.py` | `_swift_plugin_*.py` ×3 | classes, structs, protocols; `.swift` + `.swiftinterface` (issue #131) |
 | Ruby | `languages/ruby_plugin.py` | `languages/ruby_helpers.py` | Rails patterns, metaprogramming |
 | PHP | `languages/php_plugin.py` | `languages/php_helpers.py` | PHP 8+ attributes, traits |

--- a/tests/unit/cli/test_constraint_check_command.py
+++ b/tests/unit/cli/test_constraint_check_command.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from tree_sitter_analyzer.cli.commands.constraint_check_command import (
     _compute_verdict,
     _evaluate_with_explicit_file,
@@ -440,6 +442,7 @@ class TestRunAndPersist:
         assert violations == []
         assert edge_count == 0
 
+    @pytest.mark.slow_ok  # Windows xdist-load budget exemption; test logic is trivial, no perf claim (#976)
     def test_empty_call_edges_table_returns_empty(self, tmp_path):
         db = tmp_path / "index.db"
         conn = sqlite3.connect(str(db))

--- a/tests/unit/languages/test_python_module_constants.py
+++ b/tests/unit/languages/test_python_module_constants.py
@@ -130,6 +130,15 @@ class TestPluginModuleConstants:
         )
         assert names == ["A_ONE", "B_TWO"]
 
+    def test_single_line_semicolon_assignments_capture_every_constant(self):
+        source = "A_ONE = 1; B_TWO = 2\n"
+        result = Parser().parse_code(source, "python")
+        names = sorted(
+            v.name
+            for v in PythonElementExtractor().extract_variables(result.tree, source)
+        )
+        assert names == ["A_ONE", "B_TWO"]
+
     def test_none_tree_yields_no_constants(self):
         assert extract_module_constants(None, "") == []
 

--- a/tests/unit/mcp/test_symbol_lineage_fixes.py
+++ b/tests/unit/mcp/test_symbol_lineage_fixes.py
@@ -7,7 +7,11 @@
 import asyncio
 from pathlib import Path
 
-from tree_sitter_analyzer.mcp.tools.symbol_lineage_tool import SymbolLineageTool
+from tree_sitter_analyzer.mcp.tools.symbol_lineage_tool import (
+    SymbolLineageTool,
+    _filter_references_to_scope,
+    _normalize_scope_file_paths,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -381,3 +385,50 @@ class TestRefCountIncludesCallers:
         result = asyncio.run(tool.execute({"symbol": "gone", "output_format": "json"}))
 
         assert not any(r["type"] == "call_site" for r in result["references"])
+
+
+# ---------------------------------------------------------------------------
+# scope-path normalization edge branches (#961 split helpers)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeScopeFilePaths:
+    """Edge branches of the new scope-path helpers."""
+
+    def test_falsy_entries_are_skipped(self, tmp_path):
+        """Empty/None entries are dropped (the ``continue`` branch)."""
+        result = _normalize_scope_file_paths(str(tmp_path), ["", None, "src/a.py"])
+        assert result == {"src/a.py"}
+
+    def test_absolute_path_outside_root_is_kept_verbatim(self, tmp_path):
+        """An absolute path not under root keeps its text (ValueError branch)."""
+        outside = "/some/other/root/b.py"
+        result = _normalize_scope_file_paths(str(tmp_path), [outside])
+        assert result == {"/some/other/root/b.py"}
+
+    def test_absolute_path_inside_root_is_relativized(self, tmp_path):
+        """An absolute path under root is made relative."""
+        inside = tmp_path / "pkg" / "c.py"
+        result = _normalize_scope_file_paths(str(tmp_path), [str(inside)])
+        assert result == {"pkg/c.py"}
+
+    def test_dot_slash_prefix_is_stripped(self, tmp_path):
+        """A leading ``./`` is stripped from relative paths."""
+        result = _normalize_scope_file_paths(str(tmp_path), ["./d.py"])
+        assert result == {"d.py"}
+
+
+class TestFilterReferencesToScope:
+    """Edge branches of _filter_references_to_scope."""
+
+    def test_empty_scope_returns_references_unchanged(self):
+        """Empty scope set short-circuits and returns the input list."""
+        refs = [{"file": "a.py"}, {"file": "b.py"}]
+        result = _filter_references_to_scope(refs, set())
+        assert result is refs
+
+    def test_only_in_scope_references_are_kept(self):
+        """Backslash paths normalize before matching the scope set."""
+        refs = [{"file": "src\\a.py"}, {"file": "src/b.py"}]
+        result = _filter_references_to_scope(refs, {"src/a.py"})
+        assert result == [{"file": "src\\a.py"}]

--- a/tests/unit/mcp/test_symbol_lineage_fixes.py
+++ b/tests/unit/mcp/test_symbol_lineage_fixes.py
@@ -1,7 +1,5 @@
-"""Regression tests for issues #756 and #757 in symbol_lineage_tool.
+"""Regression tests for symbol_lineage_tool scope and caller enrichment.
 
-#756: file_paths scope parameter is silently ignored — response must carry a
-      scope_note when file_paths is provided, and the CLI spec must pass it.
 #757: ref_count counts only import references, not actual call-site callers —
       the call graph must be queried for real callers.
 """
@@ -29,15 +27,12 @@ def _make_tool(tmp_path: Path) -> SymbolLineageTool:
 
 
 # ---------------------------------------------------------------------------
-# #756: scope_note emitted when file_paths provided
+# file_paths scope filtering
 # ---------------------------------------------------------------------------
 
 
-class TestFilepathsScopeNote:
-    """#756: when file_paths is passed, lineage must emit a scope_note
-    telling the caller that results are project-wide and file_paths is
-    not a scope filter for this tool.
-    """
+class TestFilepathsScopeFilter:
+    """file_paths filters reference/call-site rows while keeping definitions."""
 
     def test_scope_note_absent_when_no_file_paths(self, tmp_path):
         """No file_paths → no scope_note (clean envelope)."""
@@ -46,10 +41,26 @@ class TestFilepathsScopeNote:
         result = asyncio.run(tool.execute({"symbol": "foo", "output_format": "json"}))
         assert result["success"] is True
         assert "scope_note" not in result
+        assert result["scope_filtered"] is False
 
-    def test_scope_note_present_when_file_paths_provided(self, tmp_path):
-        """file_paths is given → scope_note must be present in the response."""
-        _write_py(tmp_path, "a.py", "def foo():\n    pass\n")
+    def test_file_paths_filter_references(self, tmp_path):
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        _write_py(tmp_path, "lib.py", "def foo():\n    return 1\n")
+        _write_py(
+            tmp_path,
+            "a.py",
+            "from lib import foo\n\ndef use_a():\n    return foo()\n",
+        )
+        _write_py(
+            tmp_path,
+            "b.py",
+            "from lib import foo\n\ndef use_b():\n    return foo()\n",
+        )
+        cache = ASTCache(str(tmp_path))
+        cache.index_project(max_files=50)
+        cache.close()
+
         tool = _make_tool(tmp_path)
         result = asyncio.run(
             tool.execute(
@@ -61,24 +72,56 @@ class TestFilepathsScopeNote:
             )
         )
         assert result["success"] is True
-        assert "scope_note" in result
+        assert result["scope_filtered"] is True
+        assert result["scope_filter"] == ["a.py"]
+        assert {r["file"] for r in result["references"]} == {"a.py"}
+        assert result["definition_count"] == 1
 
-    def test_scope_note_mentions_project_wide(self, tmp_path):
-        """scope_note must state that lineage is project-wide."""
+    def test_scope_note_mentions_filtered_references(self, tmp_path):
         _write_py(tmp_path, "a.py", "def foo():\n    pass\n")
         tool = _make_tool(tmp_path)
         result = asyncio.run(
             tool.execute(
                 {
                     "symbol": "foo",
-                    "file_paths": ["x/empty.py", "y/other.py"],
+                    "file_paths": ["a.py"],
                     "output_format": "json",
                 }
             )
         )
         assert "scope_note" in result
         note = result["scope_note"].lower()
-        assert "project" in note
+        assert "filters references" in note
+
+    def test_scope_cache_key_does_not_cross_pollute(self, tmp_path):
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        _write_py(tmp_path, "lib.py", "def foo():\n    return 1\n")
+        _write_py(
+            tmp_path,
+            "a.py",
+            "from lib import foo\n\ndef use_a():\n    return foo()\n",
+        )
+        _write_py(
+            tmp_path,
+            "b.py",
+            "from lib import foo\n\ndef use_b():\n    return foo()\n",
+        )
+        cache = ASTCache(str(tmp_path))
+        cache.index_project(max_files=50)
+        cache.close()
+
+        tool = _make_tool(tmp_path)
+        scoped = asyncio.run(
+            tool.execute(
+                {"symbol": "foo", "file_paths": ["a.py"], "output_format": "json"}
+            )
+        )
+        unscoped = asyncio.run(tool.execute({"symbol": "foo", "output_format": "json"}))
+
+        assert {r["file"] for r in scoped["references"]} == {"a.py"}
+        assert {"a.py", "b.py"} <= {r["file"] for r in unscoped["references"]}
+        assert "scope_note" not in unscoped
 
     def test_file_paths_in_tool_schema(self, tmp_path):
         """file_paths must be declared in the tool schema so MCP callers can pass it."""
@@ -120,7 +163,7 @@ class TestFilepathsScopeNote:
 
     def test_cli_spec_file_paths_none_not_included(self, tmp_path):
         """When CLI --file-paths is not set (None), file_paths must not appear
-        in the tool args (clean envelope, no spurious scope_note)."""
+        in the tool args (clean envelope, no spurious scope)."""
         from tree_sitter_analyzer.cli.commands.mcp_commands._specs_core import (
             _CORE_SPECS,
         )
@@ -135,8 +178,8 @@ class TestFilepathsScopeNote:
 
         args = _FakeArgs()
         tool_args = spec.build_tool_args(args, "json")
-        # file_paths absent OR None — either is fine, but scope_note must not
-        # fire (tested in test_scope_note_absent_when_no_file_paths above).
+        # file_paths absent OR None — either is fine, but scoped filtering must
+        # not fire (tested in test_scope_note_absent_when_no_file_paths above).
         assert tool_args.get("file_paths") is None or "file_paths" not in tool_args
 
 
@@ -256,3 +299,85 @@ class TestRefCountIncludesCallers:
         assert len(ref_keys) == len(set(ref_keys)), (
             f"Duplicate references found: {ref_keys}"
         )
+
+    def test_multiple_calls_use_call_site_lines(self, tmp_path):
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        _write_py(tmp_path, "lib.py", "def target():\n    return 1\n")
+        _write_py(
+            tmp_path,
+            "caller.py",
+            (
+                "from lib import target\n\n"
+                "def f():\n"
+                "    x = target()\n"
+                "    y = target()\n"
+                "    return x + y\n"
+            ),
+        )
+        cache = ASTCache(str(tmp_path))
+        cache.index_project(max_files=50)
+        cache.close()
+
+        tool = _make_tool(tmp_path)
+        result = asyncio.run(
+            tool.execute({"symbol": "target", "output_format": "json"})
+        )
+        call_lines = sorted(
+            r["start_line"] for r in result["references"] if r["type"] == "call_site"
+        )
+
+        assert call_lines == [4, 5]
+
+    def test_qualified_symbol_name_is_preserved_for_callers(self, tmp_path):
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        _write_py(tmp_path, "lib.py", "def target():\n    return 1\n")
+        _write_py(tmp_path, "other.py", "def target():\n    return 2\n")
+        _write_py(
+            tmp_path,
+            "main.py",
+            (
+                "import lib\n"
+                "import other\n\n"
+                "def use_lib():\n"
+                "    return lib.target()\n\n"
+                "def use_other():\n"
+                "    return other.target()\n"
+            ),
+        )
+        cache = ASTCache(str(tmp_path))
+        cache.index_project(max_files=50)
+        cache.close()
+
+        tool = _make_tool(tmp_path)
+        result = asyncio.run(
+            tool.execute({"symbol": "lib.target", "output_format": "json"})
+        )
+        call_refs = [r for r in result["references"] if r["type"] == "call_site"]
+
+        assert [r["name"] for r in call_refs] == ["use_lib"]
+        assert [r["start_line"] for r in call_refs] == [5]
+
+    def test_stale_call_graph_does_not_enrich_refs(self, tmp_path):
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        _write_py(tmp_path, "lib.py", "def gone():\n    return 1\n")
+        _write_py(
+            tmp_path,
+            "caller.py",
+            "from lib import gone\n\ndef f():\n    return gone()\n",
+        )
+        cache = ASTCache(str(tmp_path))
+        cache.index_project(max_files=50)
+        cache.close()
+        _write_py(
+            tmp_path,
+            "caller.py",
+            "from lib import gone\n\ndef f():\n    return 0\n",
+        )
+
+        tool = _make_tool(tmp_path)
+        result = asyncio.run(tool.execute({"symbol": "gone", "output_format": "json"}))
+
+        assert not any(r["type"] == "call_site" for r in result["references"])

--- a/tests/unit/test_codegraph_query_backend.py
+++ b/tests/unit/test_codegraph_query_backend.py
@@ -246,3 +246,37 @@ def test_backend_normalizes_callers_and_callees_from_cache_rows() -> None:
     )
     cache.query_callers.assert_called_once_with("run", "main.py", max_depth=2)
     cache.query_callees.assert_called_once_with("run", "main.py", max_depth=1)
+
+
+def test_backend_resolves_enum_as_definition() -> None:
+    """#961 split: ``enum`` rows are definition sites (added to kind filter)."""
+    conn = _connect()
+    conn.execute(
+        """CREATE TABLE ast_symbol_rows (
+            name TEXT,
+            kind TEXT,
+            file_path TEXT,
+            language TEXT,
+            line INTEGER,
+            end_line INTEGER
+        )"""
+    )
+    conn.execute(
+        "INSERT INTO ast_symbol_rows VALUES (?, ?, ?, ?, ?, ?)",
+        ("Color", "enum", "colors.rs", "rust", 4, 9),
+    )
+    backend = CodeGraphQueryBackend(RowCache(conn))
+
+    results = backend.resolve_definitions("Color")
+
+    assert results == [
+        {
+            "file": "colors.rs",
+            "name": "Color",
+            "kind": "enum",
+            "line": 4,
+            "end_line": 9,
+            "language": "rust",
+            "confidence": 1.0,
+        }
+    ]

--- a/tests/unit/test_symbol_resolver.py
+++ b/tests/unit/test_symbol_resolver.py
@@ -118,6 +118,43 @@ class TestSymbolResolverEngine:
         assert result.definitions[0].name == "APP_NAME"
         assert result.definitions[0].kind == "variable"
 
+    def test_find_defs_in_file_returns_enum(self):
+        """#961 split: ``enum`` is a definition kind in _find_defs_in_file."""
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.execute(
+            """CREATE TABLE ast_symbol_rows (
+                name TEXT,
+                kind TEXT,
+                file_path TEXT,
+                language TEXT,
+                line INTEGER,
+                end_line INTEGER
+            )"""
+        )
+        conn.execute(
+            "INSERT INTO ast_symbol_rows VALUES (?, ?, ?, ?, ?, ?)",
+            ("Color", "enum", "colors.rs", "rust", 4, 9),
+        )
+
+        class Cache:
+            _fts5_available = False
+            fts5_available = False
+
+            @staticmethod
+            def get_conn():
+                return conn
+
+            @staticmethod
+            def _get_conn():  # backward-compat alias
+                return Cache.get_conn()
+
+        resolver = SymbolResolver(Cache())
+        defs = resolver._find_defs_in_file("colors.rs", "Color")
+        assert len(defs) == 1
+        assert defs[0].name == "Color"
+        assert defs[0].kind == "enum"
+
     def test_resolve_nonexistent(self, indexed_project):
         cache = ASTCache(str(indexed_project))
         resolver = SymbolResolver(cache)

--- a/tree_sitter_analyzer/cli/commands/mcp_commands/_specs_core.py
+++ b/tree_sitter_analyzer/cli/commands/mcp_commands/_specs_core.py
@@ -131,9 +131,8 @@ _CORE_SPECS: tuple[McpCommandSpec, ...] = (
             "symbol": getattr(args, "symbol_lineage", "") or "",
             "max_depth": getattr(args, "max_depth", 3),
             "output_format": output_format,
-            # #756: pass file_paths when present so the tool can emit a
-            # scope_note warning that lineage is project-wide.  Omit when
-            # None to avoid triggering the note unnecessarily.
+            # Pass file_paths only when present so symbol-lineage scopes
+            # references/call sites without adding a scope note unnecessarily.
             **(
                 {"file_paths": getattr(args, "file_paths", None)}
                 if getattr(args, "file_paths", None)

--- a/tree_sitter_analyzer/codegraph_query_backend.py
+++ b/tree_sitter_analyzer/codegraph_query_backend.py
@@ -9,7 +9,9 @@ from typing import Any
 from .semantic_search import SemanticSymbolSearch
 
 # #610: "constant" — Python module-level constants are definition sites.
-_DEFINITION_KINDS = frozenset({"function", "class", "method", "variable", "constant"})
+_DEFINITION_KINDS = frozenset(
+    {"function", "class", "enum", "method", "variable", "constant"}
+)
 
 
 class CodeGraphQueryBackend:
@@ -92,7 +94,7 @@ class CodeGraphQueryBackend:
             rows = conn.execute(
                 """SELECT name, kind, file_path, language, line, end_line
                    FROM ast_symbol_rows
-                   WHERE name = ? AND kind IN ('function', 'class', 'method', 'variable', 'constant')
+                   WHERE name = ? AND kind IN ('function', 'class', 'enum', 'method', 'variable', 'constant')
                    ORDER BY file_path, line""",
                 (symbol,),
             ).fetchall()

--- a/tree_sitter_analyzer/mcp/tools/symbol_lineage_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/symbol_lineage_tool.py
@@ -51,9 +51,9 @@ TOOL_SCHEMA: dict[str, Any] = {
             "type": "array",
             "items": {"type": "string"},
             "description": (
-                "Informational only — symbol-lineage always searches the whole "
-                "project. Passing file_paths adds a scope_note to the response "
-                "to signal that this parameter is not a scope filter here."
+                "Optional scope filter for references/call sites. Definitions "
+                "are still resolved project-wide so the symbol location remains "
+                "available."
             ),
         },
     },
@@ -156,6 +156,35 @@ def _verdict_and_next_step(risk_level: str) -> tuple[str, str]:
     return verdict, next_step
 
 
+def _normalize_scope_file_paths(project_root: str, file_paths: list[Any]) -> set[str]:
+    root = Path(project_root).resolve()
+    normalized: set[str] = set()
+    for raw_path in file_paths:
+        if not raw_path:
+            continue
+        path = Path(str(raw_path))
+        try:
+            rel = path.resolve().relative_to(root) if path.is_absolute() else path
+        except ValueError:
+            rel = path
+        rel_text = str(rel).replace("\\", "/")
+        normalized.add(rel_text[2:] if rel_text.startswith("./") else rel_text)
+    return normalized
+
+
+def _filter_references_to_scope(
+    references: list[dict[str, Any]],
+    scope_files: set[str],
+) -> list[dict[str, Any]]:
+    if not scope_files:
+        return references
+    return [
+        ref
+        for ref in references
+        if str(ref.get("file", "")).replace("\\", "/") in scope_files
+    ]
+
+
 def _build_agent_summary_block(
     summary_line: str,
     next_step: str,
@@ -180,7 +209,7 @@ class SymbolLineageTool(BaseMCPTool):
         # Lazy graph + per-symbol response cache. Built on the first call,
         # reset on project_root rebind via _on_project_root_changed.
         self._dep_graph: DependencyGraph | None = None
-        self._symbol_cache: dict[tuple[str, int], dict[str, Any]] = {}
+        self._symbol_cache: dict[tuple[str, int, tuple[str, ...]], dict[str, Any]] = {}
         # H4 fix: fingerprint snapshot for the cached graph + symbol cache.
         # When the source tree changes, both the graph and the per-symbol
         # response cache are invalidated together — the symbol responses
@@ -302,12 +331,9 @@ class SymbolLineageTool(BaseMCPTool):
         symbol = arguments["symbol"].strip()
         max_depth = int(arguments.get("max_depth", 3))
         output_format = arguments.get("output_format", "toon")
-        # #756: file_paths is accepted in the schema (so MCP callers don't
-        # get schema-validation errors) but symbol-lineage is always
-        # project-wide — it does not scope results to listed paths.
-        file_paths = arguments.get("file_paths") or []
-
         self._validate_project_root()
+        file_paths = arguments.get("file_paths") or []
+        scope_files = _normalize_scope_file_paths(str(self.project_root), file_paths)
         # H4 fix: refresh dep graph (clears _symbol_cache on rebuild) before
         # the cache lookup below.
         graph = self._get_dep_graph()
@@ -315,11 +341,14 @@ class SymbolLineageTool(BaseMCPTool):
         # (hierarchy is index-derived; the source fingerprint above can't see it).
         self._invalidate_symbol_cache_on_index_change()
 
-        cached_response = self._try_cached_lineage(symbol, max_depth, started)
+        cache_key = (symbol, max_depth, tuple(sorted(scope_files)))
+        cached_response = self._try_cached_lineage(cache_key, started)
         if cached_response is not None:
             return apply_toon_format_to_response(cached_response, output_format)
 
         definitions, references = await self._collect_definitions_and_refs(symbol)
+        if scope_files:
+            references = _filter_references_to_scope(references, scope_files)
         all_symbol_files = self._collect_symbol_files(definitions, references)
         downstream_files, upstream_files = self._compute_blast_radius(
             graph, all_symbol_files
@@ -353,18 +382,18 @@ class SymbolLineageTool(BaseMCPTool):
             hierarchy=self._hierarchy_for(symbol),
         )
 
-        # #756: when the caller provided file_paths, emit a scope_note so they
-        # know results are project-wide and file_paths is not a scope filter
-        # for symbol-lineage.
-        if file_paths:
+        if scope_files:
+            response["scope_filter"] = sorted(scope_files)
+            response["scope_filtered"] = True
             response["scope_note"] = (
-                "symbol-lineage always searches the whole project. "
-                "file_paths is not a scope filter here — all project files "
-                "are included in the result regardless of this parameter."
+                "file_paths filters references and call sites; definitions "
+                "remain project-wide so the symbol location is preserved."
             )
+        else:
+            response["scope_filtered"] = False
 
         return self._finalize_and_cache_response(
-            response, (symbol, max_depth), started, output_format
+            response, cache_key, started, output_format
         )
 
     def _validate_project_root(self) -> None:
@@ -377,17 +406,16 @@ class SymbolLineageTool(BaseMCPTool):
 
     def _try_cached_lineage(
         self,
-        symbol: str,
-        max_depth: int,
+        cache_key: tuple[str, int, tuple[str, ...]],
         started: float,
     ) -> dict[str, Any] | None:
         """Return a deep-copied cached response if one exists, else ``None``.
 
         Per-symbol response cache — the tool does an expensive cross-file
         walk + dep-graph traversal that orchestrators repeat. Cache key
-        is ``(symbol, max_depth)``; reset on project_root rebind.
+        includes ``(symbol, max_depth, scope_files)``; reset on project_root
+        rebind.
         """
-        cache_key = (symbol, max_depth)
         cached = self._symbol_cache.get(cache_key)
         if cached is None:
             return None
@@ -631,7 +659,7 @@ class SymbolLineageTool(BaseMCPTool):
     def _finalize_and_cache_response(
         self,
         response: dict[str, Any],
-        cache_key: tuple[str, int],
+        cache_key: tuple[str, int, tuple[str, ...]],
         started: float,
         output_format: str,
     ) -> dict[str, Any]:
@@ -916,15 +944,16 @@ def _enrich_references_with_callers(
 
     Returns a new list (immutable input) with call-site rows appended.
     """
-    bare_name = symbol.rsplit(".", 1)[-1]
     try:
         from ...ast_cache import ASTCache
 
+        if is_ast_index_stale(project_root):
+            return references
         cache = ASTCache(project_root)
         if not cache.has_call_edges():
             cache.close()
             return references
-        raw_callers = cache.query_callers(bare_name)
+        raw_callers = cache.query_callers(symbol)
         cache.close()
     except Exception:  # nosec BLE001 — degrade gracefully; no callers added
         return references
@@ -941,12 +970,12 @@ def _enrich_references_with_callers(
     for edge in raw_callers:
         caller_name = edge.get("caller_name", "")
         caller_file = edge.get("caller_file", "")
-        caller_line = int(edge.get("caller_line", 0))
+        call_site_line = int(edge.get("callee_line") or edge.get("caller_line") or 0)
         # Skip unattributed call sites (module-level callers with no
         # enclosing function — same rule as callers_tool #638 fix).
         if not caller_name or not caller_file:
             continue
-        key = (caller_file, caller_line)
+        key = (caller_file, call_site_line)
         if key in seen:
             continue
         seen.add(key)
@@ -955,8 +984,8 @@ def _enrich_references_with_callers(
                 "name": caller_name,
                 "type": "call_site",
                 "file": caller_file,
-                "start_line": caller_line,
-                "end_line": caller_line,
+                "start_line": call_site_line,
+                "end_line": call_site_line,
                 "role": "caller",
             }
         )

--- a/tree_sitter_analyzer/symbol_resolver.py
+++ b/tree_sitter_analyzer/symbol_resolver.py
@@ -27,7 +27,9 @@ from .codegraph_query_backend import CodeGraphQueryBackend
 logger = logging.getLogger(__name__)
 
 # #610: "constant" — Python module-level constants are definition sites.
-_DEFINITION_KINDS = frozenset({"function", "class", "method", "variable", "constant"})
+_DEFINITION_KINDS = frozenset(
+    {"function", "class", "enum", "method", "variable", "constant"}
+)
 
 _REFERENCE_KINDS = frozenset({"function", "class", "method", "variable"})
 
@@ -345,7 +347,7 @@ class SymbolResolver:
         rows = conn.execute(
             """SELECT name, kind, file_path, language, line, end_line
                FROM ast_symbol_rows
-               WHERE file_path = ? AND name = ? AND kind IN ('function', 'class', 'method', 'constant')
+               WHERE file_path = ? AND name = ? AND kind IN ('function', 'class', 'enum', 'method', 'constant')
                ORDER BY line""",
             (file_path, name),
         ).fetchall()


### PR DESCRIPTION
Focused split of #971 — lineage+core subset only. Part of issue #961.

Files:
- tree_sitter_analyzer/mcp/tools/symbol_lineage_tool.py (#757 ref_count includes call-site callers)
- tree_sitter_analyzer/codegraph_query_backend.py (enum in _DEFINITION_KINDS — resolution path)
- tree_sitter_analyzer/symbol_resolver.py (enum in _DEFINITION_KINDS — resolution path)
- tree_sitter_analyzer/cli/commands/mcp_commands/_specs_core.py (file_paths scoping)
- tests/unit/mcp/test_symbol_lineage_fixes.py
- tests/unit/languages/test_python_module_constants.py
- docs/CODEMAPS/languages.md (consolidated cross-area codemap)

Cross-area moves from the original assignment (documented in commit):
- _ast_extraction.py moved to the scala PR (its diff is 100% Scala extraction, consumed by the Scala tests via _extract_symbols).
- symbol_search_tool.py, element_extractor.py, models/base.py, test_facade_tool.py moved to the typescript PR (the TS test file is the primary exerciser of the enum search-surface + decorators; a single test file cannot span two PRs).

🤖 Generated with Claude Code