### PR TITLE
fix(csharp): per-class enclosing-namespace FQN for multi/nested namespaces (#977)

### DIFF
--- a/tests/unit/languages/test_csharp_plugin_extraction.py
+++ b/tests/unit/languages/test_csharp_plugin_extraction.py
@@ -560,3 +560,76 @@ class TestCSharpNamespacePackageExtraction:
 
         assert len(packages) == 1
         assert packages[0].name == "MyApp.Interfaces"
+
+
+class TestCSharpPerClassNamespaceFqn:
+    """Bug #977 — each class's FQN must reflect its OWN enclosing namespace."""
+
+    def test_multiple_block_namespaces(self):
+        """Classes in the 2nd+ namespace get that namespace, not the first."""
+        src = "namespace A { class X {} } namespace B { class Y {} }\n"
+        plugin = CSharpPlugin()
+        tree = get_tree_for_code(src, plugin)
+        classes = plugin.extractor.extract_classes(tree, src)
+
+        by_name = {c.name: c for c in classes}
+        assert by_name["X"].full_qualified_name == "A.X"
+        assert by_name["Y"].full_qualified_name == "B.Y"
+
+    def test_nested_block_namespaces(self):
+        """Nested block namespaces concatenate with '.'."""
+        src = "namespace Outer { namespace Inner { class C {} } }\n"
+        plugin = CSharpPlugin()
+        tree = get_tree_for_code(src, plugin)
+        classes = plugin.extractor.extract_classes(tree, src)
+
+        by_name = {c.name: c for c in classes}
+        assert by_name["C"].full_qualified_name == "Outer.Inner.C"
+
+    def test_single_block_namespace_regression(self):
+        """A single block namespace still produces the correct FQN."""
+        src = "namespace App.Models { public class Person {} }\n"
+        plugin = CSharpPlugin()
+        tree = get_tree_for_code(src, plugin)
+        classes = plugin.extractor.extract_classes(tree, src)
+
+        by_name = {c.name: c for c in classes}
+        assert by_name["Person"].full_qualified_name == "App.Models.Person"
+
+    def test_file_scoped_namespace_regression(self):
+        """A file-scoped namespace still produces the correct FQN."""
+        src = "namespace App.Models;\npublic class Person {}\n"
+        plugin = CSharpPlugin()
+        tree = get_tree_for_code(src, plugin)
+        classes = plugin.extractor.extract_classes(tree, src)
+
+        by_name = {c.name: c for c in classes}
+        assert by_name["Person"].full_qualified_name == "App.Models.Person"
+
+    def test_no_namespace_regression(self):
+        """A class with no enclosing namespace keeps its bare name."""
+        src = "public class Bare {}\n"
+        plugin = CSharpPlugin()
+        tree = get_tree_for_code(src, plugin)
+        classes = plugin.extractor.extract_classes(tree, src)
+
+        by_name = {c.name: c for c in classes}
+        assert by_name["Bare"].full_qualified_name == "Bare"
+
+    def test_nested_class_under_file_scoped_namespace(self):
+        """A class nested inside another class under a file-scoped namespace.
+
+        The inner class node is two levels below the compilation unit, so the
+        walk-to-compilation-unit loop iterates before resolving the file-scoped
+        namespace. Outer/Inner are both attributed to the file-scoped namespace
+        (nested-class containment is not part of the FQN here, matching prior
+        behaviour).
+        """
+        src = "namespace App.Models;\npublic class Outer { class Inner {} }\n"
+        plugin = CSharpPlugin()
+        tree = get_tree_for_code(src, plugin)
+        classes = plugin.extractor.extract_classes(tree, src)
+
+        by_name = {c.name: c for c in classes}
+        assert by_name["Outer"].full_qualified_name == "App.Models.Outer"
+        assert by_name["Inner"].full_qualified_name == "App.Models.Inner"

--- a/tree_sitter_analyzer/languages/csharp_plugin.py
+++ b/tree_sitter_analyzer/languages/csharp_plugin.py
@@ -243,11 +243,65 @@ class CSharpElementExtractor(ElementExtractor):
 
         return classes
 
+    def _enclosing_namespace(self, node: tree_sitter.Node) -> str:
+        """Compute a node's fully-qualified enclosing namespace.
+
+        Walks up ``node.parent`` collecting every ancestor
+        ``namespace_declaration`` name, then joins them outermost-first with
+        ``.``. This attributes each class to its OWN namespace (bug #977) rather
+        than the first namespace found in the file, and handles nested block
+        namespaces. A ``file_scoped_namespace_declaration`` is a *sibling* that
+        precedes the class (not an ancestor), so it is resolved separately.
+        Returns "" at module scope.
+        """
+        names: list[str] = []
+        parent = getattr(node, "parent", None)
+        while parent is not None:
+            if parent.type == "namespace_declaration":
+                name_node = parent.child_by_field_name("name")
+                if name_node:
+                    names.append(self._get_node_text_optimized(name_node))
+            parent = getattr(parent, "parent", None)
+
+        # File-scoped namespace: applies to the rest of the compilation unit and
+        # appears as a preceding sibling, never an ancestor. Only relevant when
+        # no enclosing block namespace was found.
+        if not names:
+            file_scoped = self._file_scoped_namespace(node)
+            if file_scoped:
+                names.append(file_scoped)
+
+        return ".".join(reversed(names))
+
+    def _file_scoped_namespace(self, node: tree_sitter.Node) -> str:
+        """Return the file-scoped namespace name in effect for ``node``, if any.
+
+        Walks to the ``compilation_unit`` and returns the name of the first
+        ``file_scoped_namespace_declaration`` whose declaration starts before
+        ``node``. Returns "" when there is none.
+        """
+        top = node
+        parent = getattr(top, "parent", None)
+        while parent is not None and parent.type != "compilation_unit":
+            top = parent
+            parent = getattr(parent, "parent", None)
+        if parent is None:
+            return ""
+        for child in parent.children:
+            if (
+                child.type == "file_scoped_namespace_declaration"
+                and child.start_byte <= node.start_byte
+            ):
+                name_node = child.child_by_field_name("name")
+                if name_node:
+                    return self._get_node_text_optimized(name_node)
+        return ""
+
     def _extract_class_declaration(self, node: tree_sitter.Node) -> Class | None:
         """Extract a single class declaration."""
         return _extract_class_standalone(
             node,
-            self.current_namespace,
+            self._enclosing_namespace(node),
             self._get_node_text_optimized,
             self._extract_modifiers,
             self._extract_attributes,


### PR DESCRIPTION
## Summary
- Walk to each class's nearest ancestor namespace (concatenating nested names) instead of a single instance-level current_namespace
- Fixes wrong FQN for classes in the 2nd+ namespace of a multi-namespace file and nested block namespaces

Closes #977.

🤖 Generated with Claude Code