### PR TITLE
fix(cli): --ast-cache-mode requires --ast-cache (clear error + non-zero exit) (#982)

### DIFF
--- a/tests/unit/cli/test_ast_cache_mode_wiring.py
+++ b/tests/unit/cli/test_ast_cache_mode_wiring.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Contract tests for ``--ast-cache-mode`` / ``--ast-cache`` flag wiring (#982).
+
+``--ast-cache-mode`` is a *mode selector*; the actual trigger is the boolean
+``--ast-cache``. Passing only ``--ast-cache-mode <mode>`` used to silently drop
+the mode and fall through to single-file analysis (confusing "File path not
+specified" error, sometimes exit 0). It must instead fail fast with a clear
+message naming the missing ``--ast-cache`` flag and a non-zero exit.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from tree_sitter_analyzer.cli_main import main
+
+
+def _run_main(argv: list[str]) -> pytest.ExceptionInfo[SystemExit]:
+    """Run ``main()`` with the given argv, returning the SystemExit info."""
+    with patch.object(sys, "argv", ["tree_sitter_analyzer", *argv]):
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+    return exc_info
+
+
+def test_ast_cache_mode_alone_errors_naming_ast_cache(capsys):
+    """``--ast-cache-mode stats`` without ``--ast-cache`` → parser.error (exit 2).
+
+    The message must name ``--ast-cache`` and must NOT be the generic
+    "File path not specified" fall-through.
+    """
+    exc_info = _run_main(["--ast-cache-mode", "stats"])
+
+    assert exc_info.value.code == 2
+    err = capsys.readouterr().err
+    assert "--ast-cache-mode requires --ast-cache" in err
+    assert "File path not specified" not in err
+
+
+def test_ast_cache_with_mode_still_dispatches():
+    """``--ast-cache --ast-cache-mode stats`` → reaches the AST cache dispatch.
+
+    The mode-wiring guard must NOT trip when ``--ast-cache`` is present; the
+    command runs to completion and exits (any non-error tool exit is fine).
+    """
+    exc_info = _run_main(["--ast-cache", "--ast-cache-mode", "stats"])
+
+    # The guard did not fire: we got through to the tool, which exits cleanly.
+    # parser.error would have produced code 2 with our specific message.
+    assert exc_info.value.code == 0
+
+
+def test_bare_ast_cache_defaults_to_stats():
+    """Bare ``--ast-cache`` (no mode) → still defaults to stats and dispatches.
+
+    The guard only fires on explicit ``--ast-cache-mode`` without
+    ``--ast-cache``; the bare ``--ast-cache`` path is unchanged.
+    """
+    exc_info = _run_main(["--ast-cache"])
+
+    assert exc_info.value.code == 0

--- a/tree_sitter_analyzer/cli_main.py
+++ b/tree_sitter_analyzer/cli_main.py
@@ -192,6 +192,7 @@ def main() -> None:
     parser = create_argument_parser()
     args = parser.parse_args(_normalize_agent_command_aliases(sys.argv[1:]))
     _apply_format_alias(args)
+    _validate_ast_cache_mode_wiring(args, parser)
     _configure_logging(args)
 
     special_result = handle_special_commands(args)
@@ -230,6 +231,27 @@ def _apply_format_alias(args: argparse.Namespace) -> None:
     """Mirror --format into --output-format after parsing."""
     if hasattr(args, "format") and args.format:
         args.output_format = args.format
+
+
+def _validate_ast_cache_mode_wiring(
+    args: argparse.Namespace,
+    parser: argparse.ArgumentParser,
+) -> None:
+    """Fail fast when ``--ast-cache-mode`` is used without its trigger (#982).
+
+    ``--ast-cache-mode`` is a mode *selector* with a default of ``stats``; the
+    actual trigger is the boolean ``--ast-cache`` (or the ``--watch``
+    shortcut). Because the mode has a default, a user who passes only
+    ``--ast-cache-mode <mode>`` silently dropped the mode and fell through to
+    single-file analysis ("File path not specified"). Detect explicit
+    supply via the raw ``sys.argv`` token — robust against the default — and
+    emit a clear ``parser.error`` (exit code 2) naming the missing flag.
+    """
+    if "--ast-cache-mode" not in sys.argv:
+        return
+    if getattr(args, "ast_cache", False) or getattr(args, "watch", False):
+        return
+    parser.error("--ast-cache-mode requires --ast-cache")
 
 
 def _configure_logging(args: argparse.Namespace) -> None:


### PR DESCRIPTION
## Summary
- Passing `--ast-cache-mode <mode>` without `--ast-cache` now fails fast with a message naming the missing flag (`--ast-cache-mode requires --ast-cache`) and a non-zero exit (parser.error → exit 2), instead of silently dropping the mode and emitting a confusing 'File path not specified' (which exited 1).

## Detection approach
- Checks raw `sys.argv` for the `--ast-cache-mode` token (robust against the `default="stats"`) in a small guard in `main()`, right after `parse_args`. Chose this over flipping the default to `None` because the default is read in multiple places (`_specs_core.py`, `special_commands.py`) and is the less disruptive, surgical change.
- The `--watch` shortcut (documented as `--ast-cache --ast-cache-mode watch_start`) is exempted via `args.watch`, so `--watch` standalone still works.

## Tests (new file `tests/unit/cli/test_ast_cache_mode_wiring.py`)
- `--ast-cache-mode stats` alone → exits 2, message names `--ast-cache`, NOT 'File path not specified'.
- `--ast-cache --ast-cache-mode stats` → unchanged happy path (exit 0).
- bare `--ast-cache` → still defaults to stats (exit 0).

Closes #982.

🤖 Generated with Claude Code