### PR TITLE
fix(cli): no raw traceback / no silent dir-as-file — structured errors + nonzero exit (#1002 #1003)

### DIFF
--- a/tests/unit/cli/test_cli_input_robustness.py
+++ b/tests/unit/cli/test_cli_input_robustness.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""CLI input-robustness regression tests (#1002, #1003).
+
+These tests pin the *failure presentation* contract for three CLI input
+paths that previously mishandled bad input:
+
+* ``--batch-search`` with a missing / malformed ``--batch-search-queries-json``
+  used to leak a raw Python traceback instead of a structured error envelope
+  (#1003).
+* ``--safe-to-edit <dir>`` used to silently analyze a directory as a file and
+  exit 0 (#1002, finding 1).
+* ``--agent-workflow <dir>`` returned the right error message but exited 0
+  (#1002, finding 3).
+
+All cases must now: emit a structured ``{success: false, ...}`` envelope on
+``--format json``, never leak a traceback, and return a non-zero exit code.
+
+Run end-to-end via subprocess so the assertions cover the real process exit
+code and the real stdout/stderr split (a traceback only surfaces at process
+level, not when calling handlers in-process).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _run_cli(*cli_args: str) -> subprocess.CompletedProcess[str]:
+    """Invoke the TSA CLI in a subprocess from the project root."""
+    return subprocess.run(
+        [sys.executable, "-m", "tree_sitter_analyzer", *cli_args],
+        cwd=str(PROJECT_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+
+
+def _assert_no_traceback(proc: subprocess.CompletedProcess[str]) -> None:
+    assert "Traceback (most recent call last)" not in proc.stdout
+    assert "Traceback (most recent call last)" not in proc.stderr
+
+
+class TestBatchSearchInputRobustness:
+    """#1003 — no raw traceback for bad --batch-search-queries-json."""
+
+    def test_batch_search_missing_queries_json_returns_structured_error(self) -> None:
+        proc = _run_cli(
+            "--batch-search",
+            "--batch-search-queries-json",
+            "/nonexistent/path/does/not/exist.json",
+            "--format",
+            "json",
+        )
+        _assert_no_traceback(proc)
+        assert proc.returncode == 1
+        payload = json.loads(proc.stdout)
+        assert payload["success"] is False
+        assert payload["verdict"] == "ERROR"
+        assert isinstance(payload["error"], str)
+
+    def test_batch_search_malformed_json_returns_structured_error(
+        self, tmp_path: Path
+    ) -> None:
+        bad = tmp_path / "bad.json"
+        bad.write_text("not-json{]", encoding="utf-8")
+        proc = _run_cli(
+            "--batch-search",
+            "--batch-search-queries-json",
+            str(bad),
+            "--format",
+            "json",
+        )
+        _assert_no_traceback(proc)
+        assert proc.returncode == 1
+        payload = json.loads(proc.stdout)
+        assert payload["success"] is False
+        assert payload["verdict"] == "ERROR"
+        assert isinstance(payload["error"], str)
+
+
+class TestSafeToEditDirectoryRejection:
+    """#1002 finding 1 — --safe-to-edit must reject a directory."""
+
+    def test_safe_to_edit_directory_returns_structured_error(self) -> None:
+        proc = _run_cli(
+            "--safe-to-edit",
+            "tree_sitter_analyzer/cli",
+            "--format",
+            "json",
+        )
+        _assert_no_traceback(proc)
+        assert proc.returncode == 1
+        payload = json.loads(proc.stdout)
+        assert payload["success"] is False
+        assert payload["verdict"] == "ERROR"
+        assert "directory" in payload["error"].lower()
+
+
+class TestAgentWorkflowDirectoryRejection:
+    """#1002 finding 3 — --agent-workflow must exit non-zero for a dir."""
+
+    def test_agent_workflow_directory_returns_nonzero_exit(self) -> None:
+        proc = _run_cli(
+            "--agent-workflow",
+            "tree_sitter_analyzer/cli",
+            "--format",
+            "json",
+        )
+        _assert_no_traceback(proc)
+        assert proc.returncode == 1
+        payload = json.loads(proc.stdout)
+        assert payload["success"] is False
+        assert payload["verdict"] == "ERROR"
+        assert "directory" in payload["error"].lower()
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tree_sitter_analyzer/cli/commands/mcp_commands/__init__.py
+++ b/tree_sitter_analyzer/cli/commands/mcp_commands/__init__.py
@@ -288,16 +288,50 @@ def handle_mcp_commands(
 
     output_format = output_format_fn()
     fail_on_verdict = getattr(args, "change_impact_fail_on_risk", None)
+    # #1003: build_tool_args runs BEFORE _run_tool's try/except. Builders
+    # that read files / parse JSON / validate paths (e.g. --batch-search,
+    # --partial-read) raise here, and an unwrapped raise escapes as a raw
+    # Python traceback instead of a structured envelope. Wrap it so input
+    # errors surface the same {success: False, verdict: "ERROR"} shape and a
+    # non-zero exit code as runtime errors from execute().
+    try:
+        tool_args = build_mcp_tool_args(args, spec, output_format)
+    except Exception as exc:  # noqa: BLE001 — any builder error → envelope
+        return _emit_builder_error(
+            spec, exc, output_format, output_json_fn, output_error_fn
+        )
     return _run_tool(
         args,
         _get_tool_class(spec.tool_attr),
-        build_mcp_tool_args(args, spec, output_format),
+        tool_args,
         spec.label,
         output_json_fn,
         output_error_fn,
         output_format_fn,
         fail_on_verdict_worse_than=fail_on_verdict,
     )
+
+
+def _emit_builder_error(
+    spec: McpCommandSpec,
+    exc: Exception,
+    output_format: str,
+    output_json_fn: Callable[[dict[str, Any]], None],
+    output_error_fn: Callable[[str], None],
+) -> int:
+    """Emit a structured error envelope for a build_tool_args failure (#1003).
+
+    Mirrors the ``--format json``/``toon`` vs human split used elsewhere: a
+    JSON/TOON caller gets the canonical ``_build_error_envelope`` shape on
+    stdout; a plain caller gets a clear stderr message. Always exit 1 — never
+    a raw traceback.
+    """
+    if output_format in {"json", "toon"}:
+        envelope = _build_error_envelope(spec.flag_name, spec.label, exc)
+        output_json_fn(envelope)
+    else:
+        output_error_fn(f"{spec.label}: {exc}")
+    return 1
 
 
 __all__ = [

--- a/tree_sitter_analyzer/cli/commands/mcp_commands/_builders.py
+++ b/tree_sitter_analyzer/cli/commands/mcp_commands/_builders.py
@@ -82,6 +82,28 @@ def _build_trace_impact_tool_args(args: Any, output_format: str) -> dict[str, An
     return tool_args
 
 
+def _build_safe_to_edit_tool_args(args: Any, output_format: str) -> dict[str, Any]:
+    """Build tool args for --safe-to-edit, rejecting directory inputs (#1002).
+
+    SafeToEditTool expects a single source file. A directory path used to slip
+    through and get analyzed as if it were a file (bogus downstream_count,
+    language=null, success=true). Guard here so a directory raises a clean
+    ``ValueError`` that the dispatcher renders as a structured ERROR envelope
+    with a non-zero exit code instead of a misleading SAFE/UNSAFE verdict.
+    """
+    file_path = getattr(args, "file_path", None)
+    if file_path and Path(file_path).is_dir():
+        raise ValueError(
+            f"--safe-to-edit expects a file, but '{file_path}' is a directory"
+        )
+    return {
+        "file_path": file_path,
+        "edit_type": getattr(args, "edit_type", "refactor") or "refactor",
+        "output_format": output_format,
+        "compact_only": bool(getattr(args, "compact_toon", False)),
+    }
+
+
 def _build_batch_search_tool_args(args: Any, output_format: str) -> dict[str, Any]:
     """Build tool args for --batch-search (T2 round-37d parity fix).
 

--- a/tree_sitter_analyzer/cli/commands/mcp_commands/_specs_core.py
+++ b/tree_sitter_analyzer/cli/commands/mcp_commands/_specs_core.py
@@ -13,6 +13,7 @@ from ._builders import (
     _build_dependency_tool_args,
     _build_detect_routes_tool_args,
     _build_parser_readiness_tool_args,
+    _build_safe_to_edit_tool_args,
     _dependency_mode_requires_file,
 )
 
@@ -53,12 +54,7 @@ _CORE_SPECS: tuple[McpCommandSpec, ...] = (
         tool_attr="SafeToEditTool",
         label="Safe to edit",
         required_file_error="--safe-to-edit requires a file path",
-        build_tool_args=lambda args, output_format: {
-            "file_path": args.file_path,
-            "edit_type": getattr(args, "edit_type", "refactor") or "refactor",
-            "output_format": output_format,
-            "compact_only": bool(getattr(args, "compact_toon", False)),
-        },
+        build_tool_args=_build_safe_to_edit_tool_args,
     ),
     McpCommandSpec(
         flag_name="change_impact",

--- a/tree_sitter_analyzer/cli/special_commands.py
+++ b/tree_sitter_analyzer/cli/special_commands.py
@@ -132,7 +132,10 @@ def _handle_agent_workflow(
         target_path=getattr(args, "file_path", None),
     )
     _print_result(result, args, context.output_json)
-    return 0
+    # #1002 finding 3: a blocked workflow (e.g. target_path is a directory)
+    # emits verdict=ERROR but used to exit 0, so shells / set -e pipelines
+    # treated the failure as success. Map success=False to a non-zero exit.
+    return 0 if result.get("success", False) else 1
 
 
 def _effective_output_format(args: Any) -> str:


### PR DESCRIPTION
## Summary
- `--batch-search` with missing/invalid `--queries-json` now returns a structured error envelope + non-zero exit instead of leaking a raw Python traceback (#1003)
- `--safe-to-edit` / `--agent-workflow` now reject directory arguments with a clear error + non-zero exit (was: silent file-processing / wrong error + exit 0) (#1002)

## Changes
- `cli/commands/mcp_commands/__init__.py`: wrap `build_mcp_tool_args` in `handle_mcp_commands`; builder errors (file read / JSON parse / path validation) now route through new `_emit_builder_error` -> `{success:false, verdict:"ERROR", error:str}` JSON envelope (or clear stderr for non-json) + exit 1, never a traceback.
- `cli/commands/mcp_commands/_builders.py` + `_specs_core.py`: new `_build_safe_to_edit_tool_args` rejects directory `file_path` with a clean `ValueError` (flows through the envelope path above) instead of analyzing a dir as a file.
- `cli/special_commands.py`: `_handle_agent_workflow` now maps `success=False` -> exit 1 (was hardcoded `return 0`).
- New `tests/unit/cli/test_cli_input_robustness.py`: 4 end-to-end subprocess tests pinning structured-envelope + exit-code + no-traceback for all four input paths.

## Verification
- New tests: 4 passed.
- Existing `tests/unit/cli/test_mcp_commands.py` + `test_cli_main_module.py`: 152 passed, 7 skipped (no regressions).
- Valid file path to `--safe-to-edit` still returns a normal verdict + exit 0.

Closes #1002, closes #1003.

🤖 Generated with Claude Code