### PR TITLE
fix(codegraph-metrics): warm-cache hang on 157K edges — full-table-SCAN DELETE in replace_edges_for_file (#990)

### DIFF
--- a/tests/unit/test_edge_store.py
+++ b/tests/unit/test_edge_store.py
@@ -229,6 +229,152 @@ def test_edge_store_inheritance_tree_and_node_helpers(tmp_path: Path) -> None:
         store.close()
 
 
+def _insert_raw_edge(
+    conn: sqlite3.Connection,
+    source_node_id: str,
+    target_node_id: str,
+    kind: str,
+    file_path: str,
+) -> None:
+    """Insert one edge row with explicit source/file_path columns.
+
+    Bypasses ``upsert_edges`` so a test can craft the belt-and-braces case
+    where ``file_path`` is empty (pre-B1.1 rows) and only the ``source_node_id``
+    predicate matches — the path that justified keeping all three deletion
+    predicates in ``replace_edges_for_file``.
+    """
+    conn.execute(
+        "INSERT INTO edges (source_node_id, target_node_id, kind, file_path) "
+        "VALUES (?, ?, ?, ?)",
+        (source_node_id, target_node_id, kind, file_path),
+    )
+
+
+def test_replace_edges_for_file_deletes_all_predicate_kinds(tmp_path: Path) -> None:
+    """``replace_edges_for_file`` removes file_path / file-node / symbol-prefix
+    rows for the target file and leaves every other file's rows intact (#990).
+
+    The deletion was split from one ``OR`` predicate into three index-driven
+    statements; this pins the exact surviving row set so a future refactor that
+    drops a predicate (or mis-bounds the prefix range) goes red.
+    """
+    store = EdgeStore(str(tmp_path / "edges.db"))
+    conn = store.conn
+    try:
+        # Rows that MUST be deleted for "pkg/a.py":
+        _insert_raw_edge(conn, "file:pkg/a.py", "module:dep", "imports", "pkg/a.py")
+        _insert_raw_edge(
+            conn, "pkg/a.py:foo:10", "pkg/a.py:bar:11", "calls", "pkg/a.py"
+        )
+        # Symbol-prefixed row with EMPTY file_path — only the source-prefix
+        # range predicate catches it (the belt-and-braces fallback).
+        _insert_raw_edge(conn, "pkg/a.py:Baz:20", "class:Thing", "extends", "")
+        # Row whose file_path is pkg/a.py but source is another file's node —
+        # caught by the file_path equality predicate.
+        _insert_raw_edge(conn, "pkg/z.py:q:2", "pkg/a.py:r:3", "calls", "pkg/a.py")
+
+        # Rows that MUST survive (different file):
+        _insert_raw_edge(conn, "pkg/ab.py:x:1", "pkg/ab.py:y:2", "calls", "pkg/ab.py")
+        _insert_raw_edge(conn, "file:pkg/ab.py", "module:dep", "imports", "pkg/ab.py")
+        conn.commit()
+
+        store.replace_edges_for_file("pkg/a.py", [])
+
+        survivors = sorted(
+            row[0] for row in conn.execute("SELECT source_node_id FROM edges")
+        )
+        assert survivors == ["file:pkg/ab.py", "pkg/ab.py:x:1"]
+    finally:
+        store.close()
+
+
+def test_replace_edges_for_file_preserve_calls_keeps_calls_rows(
+    tmp_path: Path,
+) -> None:
+    """``preserve_calls=True`` deletes structural edges for the file but keeps
+    its CALLS rows (#990 — same three-predicate split must honor the clause)."""
+    store = EdgeStore(str(tmp_path / "edges.db"))
+    conn = store.conn
+    try:
+        _insert_raw_edge(conn, "file:pkg/a.py", "module:dep", "imports", "pkg/a.py")
+        _insert_raw_edge(
+            conn, "pkg/a.py:foo:10", "pkg/a.py:bar:11", "calls", "pkg/a.py"
+        )
+        _insert_raw_edge(conn, "pkg/a.py:Baz:20", "class:Thing", "extends", "")
+        conn.commit()
+
+        store.replace_edges_for_file("pkg/a.py", [], preserve_calls=True)
+
+        rows = sorted(
+            (row[0], row[1])
+            for row in conn.execute("SELECT source_node_id, kind FROM edges")
+        )
+        # Only the CALLS row survives; imports + extends are removed.
+        assert rows == [("pkg/a.py:foo:10", "calls")]
+    finally:
+        store.close()
+
+
+class _SQLCapturingConnection:
+    """Wraps a sqlite3 connection, recording every ``execute`` SQL/params.
+
+    Used to assert the EXACT statements ``replace_edges_for_file`` issues are
+    index-driven — so reintroducing the old single ``OR`` predicate (which the
+    planner turns into a full table SCAN) goes red here, not just in prod.
+    """
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+        self.calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    def execute(self, sql: str, params: tuple[Any, ...] = ()) -> Any:
+        self.calls.append((sql, params))
+        return self._conn.execute(sql, params)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._conn, name)
+
+
+def test_replace_edges_for_file_deletes_use_indexes_not_full_scan(
+    tmp_path: Path,
+) -> None:
+    """Every DELETE ``replace_edges_for_file`` issues must be index-driven (#990).
+
+    A single ``file_path = ? OR source_node_id = ? OR source_node_id LIKE ?``
+    forced a full ``edges`` SCAN — ~1.8 s per file on a 160k-edge warm cache,
+    so the per-file resolve refresh read as a hang. We capture the real SQL the
+    method runs and EXPLAIN each DELETE: any plan step that SCANs without an
+    index fails the test, so a regression reintroducing the OR goes red.
+    """
+    real_conn = sqlite3.connect(str(tmp_path / "edges.db"))
+    real_conn.row_factory = sqlite3.Row
+    store = EdgeStore(real_conn)
+    try:
+        capture = _SQLCapturingConnection(real_conn)
+        store._conn = capture  # type: ignore[assignment]
+
+        store.replace_edges_for_file("pkg/a.py", [])
+
+        delete_calls = [
+            (sql, params)
+            for sql, params in capture.calls
+            if sql.strip().upper().startswith("DELETE")
+        ]
+        # Exactly three index-driven deletes replace the one OR-scan.
+        assert len(delete_calls) == 3
+
+        scan_steps = []
+        for sql, params in delete_calls:
+            plan = real_conn.execute("EXPLAIN QUERY PLAN " + sql, params).fetchall()
+            for step in plan:
+                detail = step["detail"]
+                if "SCAN" in detail and "USING INDEX" not in detail:
+                    scan_steps.append(detail)
+        assert scan_steps == []
+    finally:
+        store.close()
+
+
 def test_edge_store_call_queries_and_node_parser(tmp_path: Path) -> None:
     db_path = tmp_path / "edges.db"
     store = EdgeStore(str(db_path))

--- a/tree_sitter_analyzer/graph/edge_store.py
+++ b/tree_sitter_analyzer/graph/edge_store.py
@@ -241,14 +241,45 @@ class EdgeStore:
         resolution columns) intact — used by the structural-edge refresh path,
         which has no extracted call-edge source to rebuild them from after the
         ``ast_call_edges`` table was dropped.
+
+        Performance (#990): the deletion is issued as three separate
+        index-driven statements rather than a single ``OR`` predicate. A single
+        ``file_path = ? OR source_node_id = ? OR source_node_id LIKE ?`` forces
+        SQLite into a full ``edges`` table SCAN — the trailing ``LIKE`` cannot
+        use any index and the ``OR`` poisons index selection for the whole
+        clause. On a warm 1900-file / 160k-edge cache that is ~1.8 s *per file*
+        (a full scan each), so the resolve-only refresh — which calls this once
+        per indexed file — took ~55 minutes and read as a hang. Split apart,
+        each statement uses an index: ``file_path`` → ``idx_edges_file_path``,
+        the ``file:`` node id → ``idx_edges_source_kind`` (equality), and the
+        symbol-prefixed sources via a half-open range scan (``>=`` / ``<``) over
+        the same index instead of a ``LIKE`` SCAN. Same row set, milliseconds
+        instead of seconds.
         """
         file_node_id = file_node(file_path)
-        symbol_prefix = _escape_like(f"{file_path}:")
         calls_clause = "" if not preserve_calls else "kind != 'calls' AND "
+        # Equality predicates — each uses an index (idx_edges_file_path /
+        # idx_edges_source_kind). Covers edges tagged with the file's real
+        # ``file_path`` column and edges whose source is the synthetic
+        # ``file:<path>`` node.
+        self._conn.execute(
+            f"DELETE FROM edges WHERE {calls_clause}file_path = ?",  # nosec B608
+            (file_path,),
+        )
+        self._conn.execute(
+            f"DELETE FROM edges WHERE {calls_clause}source_node_id = ?",  # nosec B608
+            (file_node_id,),
+        )
+        # Symbol-prefixed sources (``<path>:Class:method:line``): a half-open
+        # range scan over idx_edges_source_kind replaces ``LIKE '<path>:%'``.
+        # BINARY (default) collation makes ``source_node_id >= '<path>:' AND
+        # source_node_id < '<path>:' || char(0x10FFFF)`` an index range that
+        # matches exactly the rows the prefix ``LIKE`` matched.
+        prefix = f"{file_path}:"
         self._conn.execute(
             f"DELETE FROM edges WHERE {calls_clause}"  # nosec B608 — constant clause
-            "(file_path = ? OR source_node_id = ? OR source_node_id LIKE ? ESCAPE '\\')",
-            (file_path, file_node_id, f"{symbol_prefix}%"),
+            "source_node_id >= ? AND source_node_id < ?",
+            (prefix, prefix + "\U0010ffff"),
         )
         self.upsert_edges(edges)
 
@@ -541,10 +572,6 @@ def _edge_query_without_kind(
         "ORDER BY kind, source_node_id, target_node_id, line",
         (node_id, node_id),
     )
-
-
-def _escape_like(value: str) -> str:
-    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
 def _edge_from_row(row: sqlite3.Row) -> Edge:


### PR DESCRIPTION
## Summary

- **Root cause** (faulthandler stuck frame): `EdgeStore.replace_edges_for_file` (`tree_sitter_analyzer/graph/edge_store.py:248`), reached via
  `ensure_indexed` → `_resolve_pending_unresolved_refs` → `index_project(resolve_only=True)` → `_refresh_graph_edges_from_cache` → `write_graph_edges_for_file`.
  The deletion used **one OR predicate** — `file_path = ? OR source_node_id = ? OR source_node_id LIKE ?`. SQLite plans that as a **full `edges`-table SCAN** (the trailing `LIKE` can't use an index, and the `OR` poisons index selection for the whole clause). The resolve-only refresh runs this **once per indexed file**, so on the maintainer's warm cache (1975 files / 159,149 edges) it was **~1.8 s per file × ~1898 files ≈ 55 minutes** — i.e. the reported >90 s zero-output hang.
  - Why warm-cache specifically: the resolve pass only runs when `resolution_converged()` is false. On the warm cache the stored fingerprint (`1944:…`) ≠ current (`1975:…`), so it fired; the 370 terminal `extends → class:` edges keep `pending_unresolved_count > 0`, triggering the full re-refresh. The prior regression test only exercised a cold (empty) cache, so this path was untested — exactly the gap #990 called out.

- **Fix** (algorithmic, not a timeout bump): split the single OR-DELETE into **three index-driven DELETEs** covering the identical row set:
  1. `file_path = ?` → `idx_edges_file_path`
  2. `source_node_id = ?` (the `file:<path>` node) → `idx_edges_source_kind`
  3. half-open range scan `source_node_id >= '<path>:' AND source_node_id < '<path>:' || char(0x10FFFF)` → `idx_edges_source_kind` (replaces the `LIKE '<path>:%'` SCAN; BINARY collation makes the range match exactly the prefix `LIKE` rows). `preserve_calls` clause applied to all three. Removed the now-orphaned `_escape_like` helper.

- **Before / after** (maintainer warm cache, 159k edges):
  - per-file DELETE: **1757 ms → index lookups (µs)**; full `_refresh_graph_edges_from_cache` over all 1975 files: **~3335 s (projected) → 1.3 s** (~2500×).
  - `--codegraph-metrics` `tool.execute()`: **>90 s hang → ~6 s** (warm imports; 2nd call after convergence stamp ~1.9 s). Well under the 10 s target.

- **Also resolves #1001**: `--incremental-sync-mode changes` reaches the same `ensure_indexed` → resolve-only → `replace_edges_for_file` path. Verified on a pristine warm-cache copy: **~6.2 s** (previously the same ~55-min hang). One root cause, one fix.

- **Added warm-cache regression tests** (`tests/unit/test_edge_store.py`) — the gap #990 flagged (prior coverage was cold-cache only):
  - `test_replace_edges_for_file_deletes_all_predicate_kinds` — exact surviving-row set across all three predicate kinds (incl. the empty-`file_path` belt-and-braces row).
  - `test_replace_edges_for_file_preserve_calls_keeps_calls_rows` — `preserve_calls=True` keeps CALLS, drops structural edges.
  - `test_replace_edges_for_file_deletes_use_indexes_not_full_scan` — captures the actual SQL the method issues and `EXPLAIN QUERY PLAN`s each; fails if any DELETE SCANs without an index. **Verified RED** against the old OR-DELETE, GREEN with the fix (CLAUDE.md rule 11: the cost claim is now an executable invariant).

## Test plan
- [x] `uv run pytest tests/unit/test_edge_store.py tests/unit/test_edge_store_name_columns.py` (change-impact recommended) — 33 passed
- [x] `tests/unit/test_codegraph_metrics_tool.py`, `test_call_graph_cached.py`, `cli/test_codegraph_index_commands.py` — 105 passed total
- [x] `ruff check` + `mypy` clean on changed files
- [x] RED-first verified (perf-invariant test fails on old code, passes on fix)
- [x] End-to-end: warm cache `--codegraph-metrics` and `--incremental-sync-mode changes` both complete in ~6 s

Closes #990.

🤖 Generated with Claude Code