### PR TITLE
fix(autoindex): truthful indexed flag + cache_stats on warm cache (#1004)

### DIFF
--- a/tests/unit/test_codegraph_autoindex_tool.py
+++ b/tests/unit/test_codegraph_autoindex_tool.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import pytest
 
+from tree_sitter_analyzer.ast_cache import ASTCache
 from tree_sitter_analyzer.mcp.tools.auto_index_tool import CodeGraphAutoIndexTool
+from tree_sitter_analyzer.mcp.utils import auto_index_guard
 
 
 @pytest.fixture
@@ -15,6 +17,28 @@ def tool():
 @pytest.fixture
 def tool_with_root(tmp_path):
     return CodeGraphAutoIndexTool(str(tmp_path))
+
+
+@pytest.fixture
+def warm_cache_root(tmp_path):
+    """A project whose on-disk cache is fully populated, but whose
+    in-memory auto-index guard is cold — mirroring a fresh process that
+    finds a warm cache on disk (the #1004 repro condition).
+    """
+    (tmp_path / "a.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+    (tmp_path / "b.py").write_text(
+        "from a import f\n\ndef g():\n    return f()\n", encoding="utf-8"
+    )
+    cache = ASTCache(str(tmp_path))
+    try:
+        cache.index_project(max_files=10, workers=0)
+    finally:
+        cache.close()
+    # Cold guard: this process never "warmed" the cache via ensure_indexed,
+    # so is_indexed() returns False even though the cache has rows on disk.
+    auto_index_guard.reset()
+    yield tmp_path
+    auto_index_guard.reset()
 
 
 class TestToolDefinition:
@@ -86,3 +110,45 @@ class TestExecute:
         assert result["indexed"] is True
         assert result["cache_stats"] is not None
         assert isinstance(result["cache_stats"], dict)
+
+    async def test_status_warm_cache_reports_indexed_true(self, warm_cache_root):
+        # #1004: a fresh process must report a populated on-disk cache as
+        # indexed=True, not lie with indexed=False because the in-memory
+        # guard is cold.
+        tool = CodeGraphAutoIndexTool(str(warm_cache_root))
+        result = await tool.execute({"mode": "status", "output_format": "json"})
+        assert result["indexed"] is True
+        assert result["cache_stats"] is not None
+        assert result["cache_stats"]["total_files"] == 2
+
+    async def test_status_indexed_matches_actual_row_count(self, warm_cache_root):
+        # #1004 contract: indexed reflects whether ast_index has rows.
+        tool = CodeGraphAutoIndexTool(str(warm_cache_root))
+        result = await tool.execute({"mode": "status", "output_format": "json"})
+        cache = ASTCache(str(warm_cache_root))
+        try:
+            actual_rows = cache.get_stats()["total_files"]
+        finally:
+            cache.close()
+        assert actual_rows == 2
+        assert result["indexed"] == (actual_rows > 0)
+
+    async def test_status_built_marker_distinct_from_indexed(self, warm_cache_root):
+        # #1004: built_marker reflects the in-memory guard ("did THIS
+        # process warm it"); indexed reflects on-disk rows. On a warm cache
+        # in a fresh process they diverge — that divergence is the truth
+        # the field separation exposes.
+        tool = CodeGraphAutoIndexTool(str(warm_cache_root))
+        result = await tool.execute({"mode": "status", "output_format": "json"})
+        assert result["indexed"] is True
+        assert result["built_marker"] is False
+
+    async def test_status_empty_cache_reports_indexed_false(self, tool_with_root):
+        # An empty tmp project has no rows → indexed must be False and
+        # cache_stats reflects the (empty) real cache, never a bare None lie.
+        result = await tool_with_root.execute(
+            {"mode": "status", "output_format": "json"}
+        )
+        assert result["indexed"] is False
+        assert result["cache_stats"] is not None
+        assert result["cache_stats"]["total_files"] == 0

--- a/tree_sitter_analyzer/mcp/tools/auto_index_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/auto_index_tool.py
@@ -111,21 +111,32 @@ class CodeGraphAutoIndexTool(BaseMCPTool):
             )
             return apply_toon_format_to_response(result, output_format)
 
-        indexed = is_indexed(self.project_root)
+        # #1004: ``indexed`` must reflect whether the ON-DISK cache actually
+        # holds rows, not whether THIS process happened to warm it. The old
+        # code keyed ``indexed`` off ``is_indexed()`` — the in-memory guard
+        # marker — so a fresh process facing a fully-built cache reported
+        # ``indexed: false`` + ``cache_stats: null``, lying to agents that
+        # use ``--autoindex`` as the AGENTS.md entry point. We read the real
+        # cache stats and derive ``indexed`` from the row count, and expose
+        # the in-memory guard separately as ``built_marker`` so the two
+        # signals are never conflated.
         cache_stats = None
-        if indexed:
-            try:
-                from ...ast_cache import ASTCache
+        try:
+            from ...ast_cache import ASTCache
 
-                cache = ASTCache(self.project_root)
-                cache_stats = cache.get_stats()
-            except Exception:
-                pass
+            cache = ASTCache(self.project_root)
+            cache_stats = cache.get_stats()
+        except Exception:
+            cache_stats = None
+
+        indexed = bool(cache_stats and cache_stats.get("total_files", 0) > 0)
+        built_marker = is_indexed(self.project_root)
 
         result = build_response(
             verdict="INFO",
             project_root=self.project_root,
             indexed=indexed,
+            built_marker=built_marker,
             cache_stats=cache_stats,
         )
         return apply_toon_format_to_response(result, output_format)


### PR DESCRIPTION
## Summary
- `--autoindex` on a populated cache no longer lies (`indexed:false`/`cache_stats:null`) to agents using it as an entry-point; it now reports the project as indexed and fills `cache_stats` from the real cache.

## Root cause
`_status` keyed `indexed` off `is_indexed()` — the **in-memory** auto-index guard marker, which is empty in a fresh process. So a fresh `--autoindex` against a fully-built on-disk cache reported `indexed: false` + `cache_stats: null`, even though `ast_index` held 1955 rows. The marker reflects "did THIS process warm it", not "is the project indexed".

## Fix / chosen semantics
- `indexed: true` ⇔ the on-disk cache has rows (`total_files > 0`), read via `ASTCache.get_stats()` — independent of whether this call did the warming.
- `cache_stats` is **always** populated from the real cache (same dict as `--ast-cache --ast-cache-mode stats`), even when empty (`total_files: 0`), never a bare `null`.
- Added a separate `built_marker` field carrying the in-memory guard state, so "rows exist" and "this process warmed it" are never conflated (per the issue's field-separation guidance).

## Verification
- Standalone repro (warm on-disk cache, cold guard): before → `indexed:false, cache_stats:null`; after → `indexed:true, built_marker:false, cache_stats={total_files:…}`.
- CLI repro on the real 1975-file cache now returns `indexed:true` with full `cache_stats`.
- RED-first tests added to `tests/unit/test_codegraph_autoindex_tool.py` (warm-cache indexed=true, indexed==row-count contract, built_marker divergence, empty-cache indexed=false). 17/17 pass locally (`-n 0`); related guard/CLI/status suites (56) green. Full suite via CI (parallel pytest lock held locally).

Closes #1004.

🤖 Generated with Claude Code