### PR TITLE
fix(cli): unify --edit-type / --modification-guard-type enums (#985)

### DIFF
--- a/tests/unit/cli/test_argument_parser_builder_integration.py
+++ b/tests/unit/cli/test_argument_parser_builder_integration.py
@@ -486,3 +486,42 @@ class TestCodeGraphImpactCliParity:
         )
         tool_args = spec.build_tool_args(ns, "json")
         assert tool_args["include_tests"] is True
+
+
+def _choices_for_flag(flag: str) -> set[str]:
+    """Return the argparse ``choices`` set for a long flag on the full parser."""
+    parser = create_argument_parser()
+    for action in parser._actions:
+        if flag in action.option_strings:
+            assert action.choices is not None, f"{flag} has no choices"
+            return set(action.choices)
+    raise AssertionError(f"flag {flag} not found on the parser")
+
+
+class TestEditKindEnumParity:
+    """Issue #985 — --edit-type and --modification-guard-type must share one
+    canonical edit-kind vocabulary so they can never diverge again."""
+
+    def test_edit_type_and_modification_guard_type_enums_agree(self):
+        """The two flags' argparse choices sets must be exactly equal."""
+        edit_types = _choices_for_flag("--edit-type")
+        mg_types = _choices_for_flag("--modification-guard-type")
+        assert edit_types == mg_types
+
+    def test_canonical_edit_kinds_set_is_pinned(self):
+        """Lock the canonical set membership exactly so future drift goes red."""
+        from tree_sitter_analyzer.constants import EDIT_KINDS
+
+        assert set(EDIT_KINDS) == {
+            "add_feature",
+            "behavior_change",
+            "delete",
+            "fix_bug",
+            "refactor",
+            "rename",
+            "signature_change",
+        }
+        # No duplicates, and both flags expose exactly this set.
+        assert len(EDIT_KINDS) == 7
+        assert _choices_for_flag("--edit-type") == set(EDIT_KINDS)
+        assert _choices_for_flag("--modification-guard-type") == set(EDIT_KINDS)

--- a/tree_sitter_analyzer/cli/argument_groups/_advanced.py
+++ b/tree_sitter_analyzer/cli/argument_groups/_advanced.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 import argparse
 
+from ...constants import EDIT_KINDS
+
 
 def _add_trace_impact_options(parser: argparse.ArgumentParser) -> None:
     """``--trace-impact`` family (symbol caller / usage trace)."""
@@ -90,17 +92,12 @@ def _add_modification_guard_options(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--modification-guard-type",
-        choices=[
-            "rename",
-            "signature_change",
-            "delete",
-            "behavior_change",
-            "refactor",
-        ],
+        choices=list(EDIT_KINDS),
         help=(
             "Type of modification you plan to make for --modification-guard "
-            "(required: rename / signature_change / delete / behavior_change / "
-            "refactor)"
+            "(required; shares the same edit-kind vocabulary as --edit-type: "
+            + " / ".join(EDIT_KINDS)
+            + ")"
         ),
     )
     parser.add_argument(

--- a/tree_sitter_analyzer/cli/argument_groups/_analysis.py
+++ b/tree_sitter_analyzer/cli/argument_groups/_analysis.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 
+from ...constants import EDIT_KINDS
 from ._analysis_codegraph import _add_mcp_codegraph_map_options
 from ._analysis_graph_nav import _add_mcp_graph_nav_options
 
@@ -80,7 +81,7 @@ def _add_mcp_health_options(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--edit-type",
         default="refactor",
-        choices=["refactor", "add_feature", "fix_bug", "rename"],
+        choices=list(EDIT_KINDS),
         help="Planned edit type for --safe-to-edit risk scoring (default: refactor)",
     )
 

--- a/tree_sitter_analyzer/constants.py
+++ b/tree_sitter_analyzer/constants.py
@@ -60,6 +60,35 @@ LEGACY_CLASS_MAPPING = {
 }
 
 
+# ---------------------------------------------------------------------------
+# Canonical "what kind of edit am I about to make?" vocabulary.
+#
+# Single source of truth shared by BOTH edit-classification flags so they can
+# never diverge again (issue #985): the CLI's --edit-type (safe-to-edit, file
+# level) and --modification-guard-type (modification-guard, symbol level), plus
+# the matching MCP schemas (SafeToEditTool.edit_type, ModificationGuardTool /
+# edit facade modification_type).
+#
+# Every value here is handled by downstream logic:
+#   - safe_to_edit_risk._add_edit_type_factor / build_checklist branch on the
+#     file-level risk kinds and treat the rest as neutral.
+#   - modification_guard_tool adds type-specific actions for the symbol-level
+#     kinds (rename/signature_change/delete/behavior_change/refactor) and falls
+#     through to its caller-count verdict for the rest — no value is silently
+#     accepted-but-unhandled.
+# Adding a value here means adding its handling in BOTH tools.
+# ---------------------------------------------------------------------------
+EDIT_KINDS: tuple[str, ...] = (
+    "add_feature",
+    "behavior_change",
+    "delete",
+    "fix_bug",
+    "refactor",
+    "rename",
+    "signature_change",
+)
+
+
 def get_element_type(element: Any) -> str:
     """
     Get the element type from an element object.

--- a/tree_sitter_analyzer/mcp/tools/modification_guard_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/modification_guard_tool.py
@@ -12,6 +12,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+from ...constants import EDIT_KINDS
 from ...utils import setup_logger
 from ..utils.error_handler import handle_mcp_errors
 from .base_tool import BaseMCPTool, format_summary_line, mirror_summary_line
@@ -46,16 +47,12 @@ _VERDICT_TO_RISK: dict[str, str] = {
     "UNSAFE": "high",
 }
 
-# Authoritative enum for the modification_type parameter.
-# Used by get_tool_schema, validate_arguments, and the edit facade's
-# extra_public_params — single source so they can never drift.
-MODIFICATION_TYPES: tuple[str, ...] = (
-    "behavior_change",
-    "delete",
-    "refactor",
-    "rename",
-    "signature_change",
-)
+# Enum for the modification_type parameter. Aliased to the canonical
+# EDIT_KINDS vocabulary (tree_sitter_analyzer.constants) so the MCP schema,
+# validate_arguments, the edit facade's extra_public_params, AND the two CLI
+# flags (--edit-type / --modification-guard-type) all share one source of
+# truth and can never diverge again (issue #985).
+MODIFICATION_TYPES: tuple[str, ...] = EDIT_KINDS
 
 CRITICAL_NODES_FILE = ".tree-sitter-cache/critical_nodes.json"
 

--- a/tree_sitter_analyzer/mcp/tools/safe_to_edit_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/safe_to_edit_tool.py
@@ -11,6 +11,7 @@ a risk assessment with specific warnings and a concrete pre-edit checklist.
 from pathlib import Path
 from typing import Any
 
+from ...constants import EDIT_KINDS
 from ...health_scorer import HealthScorer
 from ...project_graph import DependencyGraph
 from ...utils import setup_logger
@@ -37,7 +38,7 @@ TOOL_SCHEMA: dict[str, Any] = {
         },
         "edit_type": {
             "type": "string",
-            "enum": ["refactor", "add_feature", "fix_bug", "rename"],
+            "enum": list(EDIT_KINDS),
             "description": "Type of edit planned (affects risk assessment)",
             "default": "refactor",
         },

--- a/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_risk.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_risk.py
@@ -167,7 +167,15 @@ def _add_init_factor(factors: list[RiskFactor], is_init_file: bool) -> int:
 def _add_edit_type_factor(
     factors: list[RiskFactor], edit_type: str, forward_count: int
 ) -> int:
-    """Add risk based on the planned edit type."""
+    """Add risk based on the planned edit type.
+
+    Handles every value in the shared EDIT_KINDS vocabulary
+    (tree_sitter_analyzer.constants). The symbol-level kinds shared with
+    --modification-guard-type (delete / signature_change / behavior_change)
+    are scored at the file level too so no enum value is accepted-but-
+    unhandled (issue #985). add_feature / fix_bug stay risk-neutral here —
+    they add code rather than break the existing importer contract.
+    """
     if edit_type == "rename":
         factors.append(
             {
@@ -177,6 +185,33 @@ def _add_edit_type_factor(
             }
         )
         return 2
+    if edit_type == "delete":
+        factors.append(
+            {
+                "factor": "delete_risk",
+                "detail": "Deleting code breaks every importer - confirm all downstream callers first",
+                "severity": "caution",
+            }
+        )
+        return 2
+    if edit_type == "signature_change":
+        factors.append(
+            {
+                "factor": "signature_change_risk",
+                "detail": "Changing a signature requires updating every call site - check importers first",
+                "severity": "caution",
+            }
+        )
+        return 2
+    if edit_type == "behavior_change":
+        factors.append(
+            {
+                "factor": "behavior_change_risk",
+                "detail": "Behavior changes can silently break callers - verify tests cover the changed contract",
+                "severity": "caution",
+            }
+        )
+        return 1
     if edit_type == "refactor" and forward_count > 5:
         factors.append(
             {


### PR DESCRIPTION
## Summary
- The two flags now share one canonical edit-kind enum (`EDIT_KINDS` in `tree_sitter_analyzer/constants.py`), so they can no longer diverge. Both CLI flags, the `SafeToEditTool` schema, `ModificationGuardTool.MODIFICATION_TYPES`, and the edit facade's `modification_type` param all reference it.
- Canonical set (union of both former enums): `add_feature, behavior_change, delete, fix_bug, refactor, rename, signature_change`.
- `delete` / `signature_change` / `behavior_change` are now also scored at the file level in `safe_to_edit_risk` — previously they'd have been accepted-but-unhandled when added to `--edit-type`. `add_feature` / `fix_bug` stay risk-neutral. The symbol-level kinds were already handled by `modification_guard`.
- Added a test pinning the two flags' argparse `choices` sets equal, plus a test locking the canonical set membership exactly (so future drift goes red).

Closes #985.

🤖 Generated with Claude Code