### PR TITLE
fix(clean-state): preserve foreign DBs (ruvector/agentdb), honor --format json (#988)

### DIFF
--- a/tests/unit/cli/test_clean_state_command.py
+++ b/tests/unit/cli/test_clean_state_command.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from pathlib import Path
 
@@ -29,8 +30,8 @@ def _capture_errors() -> list[str]:
 
 
 def test_removes_present_file(tmp_path: Path, capsys) -> None:
-    """A present file should be unlinked and reported as ``removed``."""
-    target = tmp_path / "ruvector.db"
+    """A present TSA-owned file should be unlinked and reported as ``removed``."""
+    target = tmp_path / ".tree-sitter-cache"
     target.write_text("placeholder")
 
     errors = _capture_errors()
@@ -39,7 +40,7 @@ def test_removes_present_file(tmp_path: Path, capsys) -> None:
     assert exit_code == 0
     assert errors == []
     out = capsys.readouterr().out
-    assert "removed: ruvector.db" in out
+    assert "removed: .tree-sitter-cache" in out
     assert not target.exists()
 
 
@@ -130,3 +131,65 @@ def test_returns_failure_when_project_root_invalid(monkeypatch) -> None:
 
     assert exit_code == 1
     assert errors == ["--clean-state cannot resolve project_root: synthetic"]
+
+
+# --- #988: scope to TSA-owned artifacts only -------------------------------
+
+
+def test_allowlist_excludes_foreign_ruflo_artifacts() -> None:
+    """The ephemeral allowlist must never contain Ruflo-owned databases (#988)."""
+    forbidden = {"ruvector.db", "agentdb.rvf", "agentdb.rvf.lock"}
+    assert set(EPHEMERAL_STATE_PATHS) & forbidden == set()
+
+
+def test_clean_state_preserves_foreign_dbs_deletes_tsa_artifact(
+    tmp_path: Path,
+) -> None:
+    """Critical regression guard (#988).
+
+    With BOTH a TSA artifact and Ruflo's foreign DBs co-located, clean-state
+    must delete the TSA artifact and leave every foreign file untouched.
+    """
+    tsa_artifact = tmp_path / ".ast-cache"
+    tsa_artifact.mkdir()
+    (tsa_artifact / "index.db").write_text("tsa state")
+
+    foreign = [
+        tmp_path / "ruvector.db",
+        tmp_path / "agentdb.rvf",
+        tmp_path / "agentdb.rvf.wal",
+        tmp_path / "agentdb.rvf.lock",
+    ]
+    for path in foreign:
+        path.write_text("ruflo state")
+
+    errors = _capture_errors()
+    exit_code = run_clean_state(_args(tmp_path), errors.append)
+
+    assert exit_code == 0
+    assert errors == []
+    # TSA artifact gone.
+    assert tsa_artifact.exists() is False
+    # Every foreign file STILL present.
+    for path in foreign:
+        assert path.exists() is True
+
+
+def test_format_json_emits_structured_envelope(tmp_path: Path, capsys) -> None:
+    """``--format json`` must emit a parseable JSON envelope (#988)."""
+    target = tmp_path / ".ast-cache"
+    target.mkdir()
+    (target / "data.bin").write_text("x")
+
+    errors = _capture_errors()
+    exit_code = run_clean_state(
+        _args(tmp_path, format="json"),
+        errors.append,
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["success"] is True
+    assert payload["dry_run"] is False
+    assert payload["removed"] == [".ast-cache"]
+    assert payload["failed"] == []

--- a/tree_sitter_analyzer/cli/commands/clean_state_command.py
+++ b/tree_sitter_analyzer/cli/commands/clean_state_command.py
@@ -2,34 +2,48 @@
 """CLI dispatcher for ``--clean-state`` / ``--clean-state-dry-run``.
 
 Removes ephemeral workspace state that accumulates from running the CLI
-(AST cache, tree-sitter cache, RuVector DB, AgentDB files, the literal
-``:memory:`` directory some legacy code creates, and the large test
-fixture directory).
+(AST cache, tree-sitter cache, the literal ``:memory:`` directory some
+legacy code creates, and the large test fixture directory).
+
+Scope (#988): clean-state removes ONLY tree-sitter-analyzer's own
+artifacts. It must never touch sibling tools' databases that happen to
+live in the same directory — e.g. Ruflo's ``ruvector.db`` and
+``agentdb.rvf*`` files. Those are owned by another tool and may hold
+irreplaceable state; a user consenting to reset TSA's cache did not
+consent to wiping Ruflo's memory.
 
 Each path is handled independently so a missing one doesn't stop the
 sweep. Output is one line per path: ``removed: <path>``, ``skipped (not
 present): <path>``, or ``failed: <path>: <error>`` — easy to grep and
-easy for tests to assert on.
+easy for tests to assert on. With ``--format json`` the sweep emits a
+structured envelope instead (``success`` / ``dry_run`` / ``removed`` /
+``skipped`` / ``failed``).
 """
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
 from collections.abc import Callable, Iterable
 from pathlib import Path
 from typing import Any
 
-# Exact list of ephemeral paths from the PL-C brief. Relative to the
-# current project root (or CWD if --project-root is unset). Keep this
-# tuple frozen so callers and tests can introspect what the sweep
+from ..output_format import wants_json_output
+
+# Exact list of ephemeral paths owned by tree-sitter-analyzer. Relative
+# to the current project root (or CWD if --project-root is unset). Keep
+# this tuple frozen so callers and tests can introspect what the sweep
 # considers "ephemeral state".
+#
+# IMPORTANT (#988): this list MUST contain only TSA-owned artifacts.
+# Sibling-tool databases (Ruflo's ``ruvector.db`` / ``agentdb.rvf*``)
+# were historically bundled here from a co-located install and were
+# silently deleted on clean-state — a cross-tool data-loss bug. They
+# are deliberately NOT listed here.
 EPHEMERAL_STATE_PATHS: tuple[str, ...] = (
     ".ast-cache",
     ".tree-sitter-cache",
-    "ruvector.db",
-    "agentdb.rvf",
-    "agentdb.rvf.lock",
     # ``:memory:`` is created as a literal directory by some legacy code
     # paths that mis-pass the SQLite in-memory sentinel as a filesystem
     # path. Removing it as part of clean-state keeps re-runs clean.
@@ -65,9 +79,42 @@ def run_clean_state(args: Any, output_error: OutputErrorFn) -> int:
         return 1
 
     summary = _sweep(root_path, EPHEMERAL_STATE_PATHS, dry_run=dry_run)
-    for line in summary:
-        print(line)
+
+    if wants_json_output(args):
+        print(json.dumps(_build_json_payload(summary, dry_run=dry_run), indent=2))
+    else:
+        for line in summary:
+            print(line)
     return 0
+
+
+def _build_json_payload(summary: list[str], *, dry_run: bool) -> dict[str, Any]:
+    """Bucket the per-path status lines into a structured JSON envelope.
+
+    Each line is ``"<status>: <rel>"`` (failures are ``"failed: <rel>: <err>"``).
+    We split on the first ``": "`` to recover the relative path so the
+    envelope mirrors exactly what the text output reported. ``success`` is
+    ``True`` when no path failed.
+    """
+    removed: list[str] = []
+    skipped: list[str] = []
+    failed: list[str] = []
+    for line in summary:
+        status, _, rest = line.partition(": ")
+        if status in ("removed", "would_remove"):
+            removed.append(rest)
+        elif status == "failed":
+            # rest is "<rel>: <error>"; keep the whole detail.
+            failed.append(rest)
+        else:  # "skipped (not present)" / "would_skip (not present)"
+            skipped.append(rest)
+    return {
+        "success": not failed,
+        "dry_run": dry_run,
+        "removed": removed,
+        "skipped": skipped,
+        "failed": failed,
+    }
 
 
 def _sweep(


### PR DESCRIPTION
## Summary
- clean-state now deletes ONLY TSA-owned artifacts and never touches sibling DBs (`ruvector.db`, `agentdb.rvf*`) — was silently wiping Ruflo's databases.
- clean-state now honors `--format json` with a structured result.

Closes #988.

🤖 Generated with Claude Code