### PR TITLE
chore(release): refresh uv.lock to 1.24.0 — unblocks uv --locked (#1017)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3002,7 +3002,7 @@ wheels = [
 
 [[package]]
 name = "tree-sitter-analyzer"
-version = "1.23.0"
+version = "1.24.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- The v1.24.0 version bump didn't regenerate uv.lock; it still pinned the editable package at 1.23.0, so `uv run --locked` failed with exit 2. Regenerated with `uv lock`.

Closes #1017.

🤖 Generated with Claude Code