### PR TITLE
fix(cli): --summary no longer crashes on SQL method parameters (P1 #1015)

### DIFF
--- a/tests/unit/cli/test_summary_command.py
+++ b/tests/unit/cli/test_summary_command.py
@@ -508,3 +508,59 @@ class TestR37zSummaryCanonicalEnvelope:
         ):
             command._output_summary_analysis(analysis_result)
         assert captured.get("success") is True
+
+
+class TestSummarySQLParameterSerialization:
+    """Regression for #1015: --summary --format json crashed on SQL methods.
+
+    SQL methods carry ``SQLParameter`` dataclass instances; the JSON path
+    emitted them raw and ``json.dumps`` raised
+    ``Object of type SQLParameter is not JSON serializable``. The fix
+    normalizes parameters to plain dicts via the API-style converter.
+    """
+
+    def test_sql_method_parameters_are_json_safe_dicts(self, command):
+        """Method params become plain dicts and the payload is JSON-serializable."""
+        import json
+
+        from tree_sitter_analyzer.models.sql_models import (
+            SQLElementType,
+            SQLFunction,
+            SQLParameter,
+        )
+
+        sql_function = SQLFunction(
+            name="get_user_orders",
+            start_line=1,
+            end_line=5,
+            language="sql",
+            sql_element_type=SQLElementType.FUNCTION,
+            parameters=[
+                SQLParameter(name="order_id_param", data_type="INT", direction="IN"),
+                SQLParameter(name="user_id_param", data_type="INT", direction="IN"),
+            ],
+        )
+        analysis_result = MagicMock()
+        analysis_result.file_path = "/test/db.sql"
+        analysis_result.language = "sql"
+        analysis_result.elements = [sql_function]
+
+        command.args.output_format = "json"
+        command.args.summary = "methods"
+
+        captured: dict[str, object] = {}
+        with patch(
+            "tree_sitter_analyzer.cli.commands.summary_command.output_json",
+            side_effect=lambda d: captured.update(d),
+        ):
+            command._output_summary_analysis(analysis_result)
+
+        methods = captured["summary"]["methods"]
+        assert len(methods) == 1
+        params = methods[0]["parameters"]
+        assert params == [
+            {"name": "order_id_param", "data_type": "INT", "direction": "IN"},
+            {"name": "user_id_param", "data_type": "INT", "direction": "IN"},
+        ]
+        # The whole payload must round-trip through json.dumps without raising.
+        assert json.loads(json.dumps(captured)) == captured

--- a/tree_sitter_analyzer/_api_result_helpers.py
+++ b/tree_sitter_analyzer/_api_result_helpers.py
@@ -35,6 +35,21 @@ _OPTIONAL_ELEM_FIELDS = [
 ]
 
 
+def normalize_parameters(value: Any) -> Any:
+    """Convert a parameters value to a JSON-safe representation.
+
+    SQL plugin stores parameters as ``list[SQLParameter]`` (dataclasses).
+    JSON cannot serialize dataclass instances; convert them to plain dicts
+    so all output formats (JSON, TOON, text) stay consistent. Non-list and
+    non-dataclass values are returned unchanged.
+    """
+    if isinstance(value, list):
+        return [
+            dataclasses.asdict(p) if dataclasses.is_dataclass(p) else p for p in value
+        ]
+    return value
+
+
 def element_to_dict(
     elem: Any, all_elements: Sequence[Any] | None = None
 ) -> dict[str, Any]:
@@ -57,14 +72,8 @@ def element_to_dict(
     for field in _OPTIONAL_ELEM_FIELDS:
         if hasattr(elem, field):
             value = getattr(elem, field)
-            # SQL plugin stores parameters as list[SQLParameter] (dataclasses).
-            # JSON cannot serialize dataclass instances; convert them to plain
-            # dicts so all output formats (JSON, TOON, text) stay consistent.
-            if field == "parameters" and isinstance(value, list):
-                value = [
-                    dataclasses.asdict(p) if dataclasses.is_dataclass(p) else p
-                    for p in value
-                ]
+            if field == "parameters":
+                value = normalize_parameters(value)
             result[field] = value
 
     if result["type"] == "function" and all_elements:

--- a/tree_sitter_analyzer/cli/commands/summary_command.py
+++ b/tree_sitter_analyzer/cli/commands/summary_command.py
@@ -7,6 +7,7 @@ Handles summary functionality with specified element types.
 
 from typing import TYPE_CHECKING, Any
 
+from ..._api_result_helpers import normalize_parameters
 from ...constants import (
     ELEMENT_TYPE_CLASS,
     ELEMENT_TYPE_FUNCTION,
@@ -167,7 +168,7 @@ class SummaryCommand(BaseCommand):
                     "end_line": getattr(m, "end_line", None),
                     "visibility": getattr(m, "visibility", None),
                     "modifiers": getattr(m, "modifiers", []),
-                    "parameters": getattr(m, "parameters", []),
+                    "parameters": normalize_parameters(getattr(m, "parameters", [])),
                     "return_type": getattr(m, "return_type", None),
                 }
                 for m in methods


### PR DESCRIPTION
## Summary
- `--summary --format json` on SQL files no longer crashes with 'SQLParameter is not JSON serializable'; method parameters are normalized to plain dicts via the existing API-style conversion (the path `--summary` previously bypassed).

Closes #1015.

🤖 Generated with Claude Code