### PR TITLE
fix(ast-cache): honor --ast-cache-language in the index file-walk (#1018)

### DIFF
--- a/tests/unit/test_ast_cache.py
+++ b/tests/unit/test_ast_cache.py
@@ -230,6 +230,19 @@ class TestIndexProject:
         assert result["total_files"] == 2
         assert result["indexed"] == 2
 
+    def test_index_project_language_filter_indexes_only_matching(self, cache):
+        """#1018: language_filter restricts the walk to that language's files.
+
+        The fixture project has main.py + util.js (readme.md is an unsupported
+        extension and never counted). With language_filter="python", only the
+        single .py file is indexed; the .js file is skipped BEFORE any parse,
+        and no parse-error is produced for the filtered-out language.
+        """
+        result = cache.index_project(language_filter="python")
+        assert result["indexed"] == 1
+        assert result["skipped"] == 1
+        assert result["errors"] == 0
+
     def test_index_project_cached(self, cache):
         cache.index_project()
         result = cache.index_project()

--- a/tests/unit/test_ast_cache_tool.py
+++ b/tests/unit/test_ast_cache_tool.py
@@ -294,9 +294,27 @@ class TestExecute:
             max_files=100,
             force=True,
             include_activation=False,
+            language_filter=None,
         )
         # DF-9: verify summary includes the symbol count
         assert "symbols=100" in result["summary_line"]
+
+    @pytest.mark.asyncio
+    async def test_index_project_threads_language_filter(self, tool_with_mock_cache):
+        """#1018: --ast-cache-language / language arg reaches index_project."""
+        tool, mock_cache = tool_with_mock_cache
+        mock_cache.index_project.return_value = {"indexed": 1}
+        mock_cache.get_stats.return_value = {"total_symbols": 1, "total_files": 1}
+        result = await tool.execute(
+            {"mode": "index", "max_files": 100, "language": "python"}
+        )
+        assert result["success"] is True
+        mock_cache.index_project.assert_called_once_with(
+            max_files=100,
+            force=False,
+            include_activation=False,
+            language_filter="python",
+        )
 
     @pytest.mark.asyncio
     async def test_index_project_can_include_activation(self, tool_with_mock_cache):
@@ -314,6 +332,7 @@ class TestExecute:
             max_files=100,
             force=False,
             include_activation=True,
+            language_filter=None,
         )
 
     @pytest.mark.asyncio

--- a/tree_sitter_analyzer/_ast_cache_indexer.py
+++ b/tree_sitter_analyzer/_ast_cache_indexer.py
@@ -161,8 +161,15 @@ def walk_and_partition(
     language_fn: Any,
     extractor_version: int,
     make_error_entry: Any,
+    language_filter: str | None = None,
 ) -> tuple[dict[str, Any], list[tuple[str, str]], int]:
-    """Walk source files and partition into (stats, candidates, count)."""
+    """Walk source files and partition into (stats, candidates, count).
+
+    ``language_filter`` (#1018): when set, only files whose detected language
+    equals it are considered; non-matching files are skipped BEFORE any parse
+    attempt, so a Python-scoped run never tries to load an optional grammar
+    (e.g. Swift) and never surfaces a "grammar not installed" error.
+    """
     candidates: list[tuple[str, str]] = []
     already_cached: list[dict[str, Any]] = []
     stats: dict[str, Any] = {
@@ -193,6 +200,9 @@ def walk_and_partition(
         count += 1
         lang = language_fn(abs_path)
         if lang is None:
+            stats["skipped"] += 1
+            continue
+        if language_filter is not None and lang != language_filter:
             stats["skipped"] += 1
             continue
         rel_path = os.path.relpath(abs_path, cache.project_root).replace("\\", "/")

--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -328,8 +328,16 @@ class ASTCache:
         workers: int | None = None,
         resolve_only: bool = False,
         include_activation: bool | None = None,
+        language_filter: str | None = None,
     ) -> dict[str, Any]:
-        """Index every source file under ``self.project_root``."""
+        """Index every source file under ``self.project_root``.
+
+        ``language_filter`` (#1018): when provided, restrict the walk to files
+        whose detected language equals it. Non-matching files (e.g. ``.swift``
+        when ``language_filter="python"``) are skipped before any parse, so a
+        language-scoped run never emits "grammar not installed" errors for
+        other languages.
+        """
         activation_enabled = _project_index_activation_enabled(include_activation)
         if resolve_only:
             synapse = self._run_synapse_backfill()
@@ -364,7 +372,7 @@ class ASTCache:
                 conn.execute("DELETE FROM ast_index")
                 conn.commit()
             stats, candidates, count = self._walk_and_partition(
-                max_files, force, activation_enabled
+                max_files, force, activation_enabled, language_filter
             )
             workers = self._resolve_worker_count(workers, candidates)
             if workers and workers >= 2 and len(candidates) >= 2:
@@ -410,7 +418,11 @@ class ASTCache:
                 _clear_build_in_progress(self._get_conn())
 
     def _walk_and_partition(
-        self, max_files: int, force: bool, activation_enabled: bool
+        self,
+        max_files: int,
+        force: bool,
+        activation_enabled: bool,
+        language_filter: str | None = None,
     ) -> tuple[dict[str, Any], list[tuple[str, str]], int]:
         """Walk source files and partition into (stats, candidates, count)."""
         from . import _ast_cache_indexer as _indexer
@@ -425,6 +437,7 @@ class ASTCache:
             _language_from_ext,
             _AST_CACHE_EXTRACTOR_VERSION,
             _make_error_entry,
+            language_filter,
         )
 
     @staticmethod

--- a/tree_sitter_analyzer/mcp/tools/ast_cache_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/ast_cache_tool.py
@@ -435,10 +435,15 @@ class ASTCacheTool(BaseMCPTool):
             max_files = arguments.get("max_files", 20_000)
             force = arguments.get("force", False)
             include_activation = bool(arguments.get("include_activation", False))
+            # #1018: honor the language scope on the index path. Without this the
+            # filter was accepted but dropped, so e.g. --ast-cache-language python
+            # still parsed .swift files and emitted "grammar not installed" errors.
+            language_filter = arguments.get("language") or None
             result = cache.index_project(
                 max_files=max_files,
                 force=force,
                 include_activation=include_activation,
+                language_filter=language_filter,
             )
             files_indexed_fallback = result.get("files_indexed", 0)
             indexed_files = int(result.get("indexed", files_indexed_fallback) or 0)


### PR DESCRIPTION
## Summary
- `--ast-cache-language X` now restricts indexing to language-X files; non-matching files (e.g. .swift when X=python) are skipped before parse, eliminating spurious 'missing grammar' errors.

## Root cause
`ASTCacheTool._handle_index` read the `language` argument only on the search path; the index path called `cache.index_project(...)` without it, so the filter was accepted at the CLI/MCP boundary but dropped. `index_project` / `_walk_and_partition` / `walk_and_partition` had no language-filter parameter, so the walk yielded every supported file regardless of the requested language and each non-matching file was parse-attempted (Swift → 'grammar not installed' error).

## Fix (surgical)
- Added `language_filter` param threaded `_handle_index → index_project → _walk_and_partition → walk_and_partition`.
- In the walk, files whose detected language != filter are counted as `skipped` and excluded from candidates **before** any parse, so no optional grammar is loaded for filtered-out languages.
- No-filter behavior unchanged.

## Verification
CLI repro (mixed .py + .swift tree), before: `indexed=2 errors=2 skipped=0` (2 swift grammar errors); after: `indexed=2 errors=0 skipped=2` (no swift entries).

RED-first tests (exact `==` assertions):
- `test_index_project_language_filter_indexes_only_matching`: `indexed==1, skipped==1, errors==0` on a .py+.js fixture.
- `test_index_project_threads_language_filter`: asserts `language_filter="python"` reaches `index_project`.

Closes #1018.

🤖 Generated with Claude Code