### PR TITLE
test(health): slow_ok remaining heavy boundary tests (kill Windows budget whack-a-mole)

### DIFF
--- a/tests/unit/mcp/test_nav_impact_boundary.py
+++ b/tests/unit/mcp/test_nav_impact_boundary.py
@@ -62,6 +62,10 @@ def _make_mock_graph(func_ref: FunctionRef, callers=None, callees=None):
     return graph
 
 
+# Each test builds nav action=impact on a real tmp_path project (dependency
+# graph + test partition); ~5s+ each, tips the 5s unit budget under Windows
+# full-matrix xdist load. Real work, not a perf regression — budget-exempt.
+@pytest.mark.slow_ok
 class TestNavImpactBoundary:
     """RFC-0014 Phase A: boundary integration for nav action=impact.
 

--- a/tests/unit/mcp/test_toon_compact_only.py
+++ b/tests/unit/mcp/test_toon_compact_only.py
@@ -178,6 +178,8 @@ async def test_boundary_default_unaffected(tmp_path) -> None:
     assert "agent_summary" in body
 
 
+# Full-surface boundary walk (all facades/actions); ~16s on Windows under load.
+@pytest.mark.slow_ok
 @pytest.mark.asyncio
 async def test_boundary_compact_only_second_tool(tmp_path) -> None:
     """The boundary reduction is generic — exercise a second decision tool
@@ -196,6 +198,8 @@ async def test_boundary_compact_only_second_tool(tmp_path) -> None:
     assert "agent_summary" not in body
 
 
+# Full-surface boundary walk; budget-exempt under Windows full-matrix load.
+@pytest.mark.slow_ok
 @pytest.mark.asyncio
 async def test_boundary_compact_only_error_envelope_keeps_hint(tmp_path) -> None:
     """An ERROR response under compact_only must still carry the recovery
@@ -244,6 +248,8 @@ async def test_boundary_compact_only_legacy_keeps_deprecation(tmp_path) -> None:
     )
 
 
+# Full-surface boundary walk; budget-exempt under Windows full-matrix load.
+@pytest.mark.slow_ok
 @pytest.mark.asyncio
 async def test_boundary_reduction_is_idempotent(tmp_path) -> None:
     """Reducing an already-compact response at the boundary is a no-op — guards


### PR DESCRIPTION
## Summary
The full-surface MCP boundary tests (toon compact-only + nav impact) legitimately take 5-16s (they walk all 8 facades × actions / build a real dependency graph). Under Windows full-matrix xdist+build load they intermittently tip the 5s per-test budget, flaking unrelated PRs (#1021/#1022 hit this). Marked the remaining unmarked ones `@pytest.mark.slow_ok` (the sanctioned escape hatch in tests/conftest.py) — same treatment the heavier siblings already carry.

- test_toon_compact_only.py: second_tool, error_envelope_keeps_hint, reduction_is_idempotent
- test_nav_impact_boundary.py: TestNavImpactBoundary class (all 6 impact tests)

No logic/assertion change — markers only.

🤖 Generated with Claude Code