### PR TITLE
fix(onboarding): install-skills destination echo + README CLI verification twin (#549)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ claude mcp add tree-sitter-analyzer \
 ```
 
 Restart your agent, then say: *"Run the `index` tool with action=status."*
+CLI equivalent (no agent needed): `tree-sitter-analyzer --codegraph-status`
 
 > **PyPI / uvx users — install skills:** the 13 `tsa-*` skills are bundled in the wheel. Copy them once with:
 > ```bash
@@ -81,6 +82,7 @@ See **[Supported Agents](#supported-agents)**. Most clients want this MCP server
 ```
 
 After restart: *"Run the `index` tool with action=status."*
+CLI equivalent (no agent needed): `tree-sitter-analyzer --codegraph-status`
 
 **See the correctness edge on your own repo** — no install, no CodeGraph (it re-indexes first; seconds on a small repo, a minute or two on a large one):
 

--- a/tests/unit/cli/test_install_skills.py
+++ b/tests/unit/cli/test_install_skills.py
@@ -310,6 +310,8 @@ class TestInstallSkillsHandlerDispatch:
         assert captured["json"]["success"] is True
         assert captured["json"]["installed_count"] == 13
         assert captured["json"]["skipped_count"] == 0
+        # #549: JSON output echoes the resolved destination dir.
+        assert captured["json"]["destination"] == str(target / ".claude" / "skills")
         assert (target / ".claude" / "skills").is_dir()
 
     def test_handle_install_skills_with_dot_target(self, tmp_path, monkeypatch):
@@ -461,6 +463,21 @@ class TestInstallSkillsErrorHandling:
         assert "Installed:" in captured.err
         # path-separator agnostic (Windows prints backslashes)
         assert str(target / ".claude" / "skills" / "tsa-constraints") in captured.err
+
+    def test_destination_echoed_to_stderr_before_install(self, tmp_path, capsys):
+        """#549: the resolved destination dir is echoed to stderr first, so the
+        user always knows WHERE skills are going (no silent install/skip)."""
+        from tree_sitter_analyzer.cli.install_skills import install_skills
+
+        target = tmp_path / "proj"
+        target.mkdir()
+
+        report = install_skills(target_dir=target)
+
+        captured = capsys.readouterr()
+        dest = str(target / ".claude" / "skills")
+        assert f"Installing skills into: {dest}" in captured.err
+        assert report["destination"] == dest
 
 
 # ---------------------------------------------------------------------------

--- a/tree_sitter_analyzer/cli/install_skills.py
+++ b/tree_sitter_analyzer/cli/install_skills.py
@@ -17,6 +17,7 @@ class InstallReport(TypedDict):
     skipped_count: int
     installed: list[str]
     skipped: list[str]
+    destination: str
 
 
 def _bundled_skills_dir() -> Path:
@@ -80,6 +81,10 @@ def install_skills(
             "directory — refusing to self-copy."
         )
 
+    # #549: echo the resolved destination FIRST, so the user always knows
+    # where skills are going before anything is installed or skipped.
+    print(f"Installing skills into: {dest_root}", file=sys.stderr)
+
     try:
         dest_root.mkdir(parents=True, exist_ok=True)
     except PermissionError as exc:
@@ -107,4 +112,5 @@ def install_skills(
         skipped_count=len(skipped),
         installed=installed,
         skipped=skipped,
+        destination=str(dest_root),
     )

--- a/tree_sitter_analyzer/cli/special_commands.py
+++ b/tree_sitter_analyzer/cli/special_commands.py
@@ -90,9 +90,10 @@ def _handle_install_skills(
         "skipped_count": report["skipped_count"],
         "installed": report["installed"],
         "skipped": report["skipped"],
+        "destination": report["destination"],
         "summary_line": (
             f"install_skills: {report['installed_count']} installed, "
-            f"{report['skipped_count']} skipped"
+            f"{report['skipped_count']} skipped into {report['destination']}"
         ),
     }
     context.output_json(summary)


### PR DESCRIPTION
## Summary
- `--install-skills` now prints the resolved destination dir to stderr FIRST (and adds `destination` to the JSON), so no more silent skip/install into an unexpected cwd.
- README Get Started gains the CLI verification twin (`tree-sitter-analyzer --codegraph-status`) next to both MCP-only instructions.

Closes #549.

🤖 Generated with Claude Code