### PR TITLE
feat(check-scale): max_nesting_depth in file_metrics (#580)

### DIFF
--- a/tests/unit/mcp/test_utils/test_file_metrics.py
+++ b/tests/unit/mcp/test_utils/test_file_metrics.py
@@ -13,6 +13,7 @@ import pytest
 from tree_sitter_analyzer.mcp.utils.file_metrics import (
     FileMetrics,
     _compute_line_metrics,
+    _compute_max_nesting_depth,
     _estimate_tokens,
     compute_file_metrics,
 )
@@ -278,8 +279,72 @@ class TestComputeLineMetrics:
         assert blank == 1
 
 
+class TestComputeMaxNestingDepth:
+    """Tests for _compute_max_nesting_depth (feature #580).
+
+    Block-nesting depth is derived from 4-space indentation levels of
+    executable lines — the same signal the file-health ``deep_nesting``
+    smell uses. Depths are pinned EXACTLY (CLAUDE.md exact-assertion lock):
+    a hand-counted fixture must produce the hand-counted number.
+    """
+
+    def test_flat_module_has_zero_depth(self):
+        """Top-level-only code has nesting depth 0."""
+        content = "import os\nx = 1\ny = 2\n"
+        assert _compute_max_nesting_depth(content) == 0
+
+    def test_five_level_nest_pins_exactly(self):
+        """A hand-built 5-level nest (def→if→if→while→for body) == 5.
+
+        Counting from column 0:
+          def f()            -> col 0
+            if a:            -> body at col 4  (depth 1)
+              if b:          -> body at col 8  (depth 2)
+                while c:     -> body at col 12 (depth 3)
+                  for d ...: -> body at col 16 (depth 4)
+                    return 1 -> col 20         (depth 5)
+        The deepest executable line ``return 1`` sits at 20 spaces -> 5.
+        """
+        content = (
+            "def f():\n"
+            "    if a:\n"
+            "        if b:\n"
+            "            while c:\n"
+            "                for d in e:\n"
+            "                    return 1\n"
+        )
+        assert _compute_max_nesting_depth(content) == 5
+
+    def test_empty_content_has_zero_depth(self):
+        """Empty content has nesting depth 0."""
+        assert _compute_max_nesting_depth("") == 0
+
+
 class TestComputeFileMetrics:
     """Tests for compute_file_metrics function."""
+
+    @patch("tree_sitter_analyzer.mcp.utils.file_metrics.read_file_safe")
+    @patch("tree_sitter_analyzer.mcp.utils.file_metrics.get_shared_cache")
+    def test_compute_file_metrics_max_nesting_depth(
+        self, mock_get_cache, mock_read_file
+    ):
+        """file_metrics carries max_nesting_depth pinned to the hand count (#580)."""
+        content = (
+            "def f():\n"
+            "    if a:\n"
+            "        if b:\n"
+            "            while c:\n"
+            "                for d in e:\n"
+            "                    return 1\n"
+        )
+        mock_read_file.return_value = (content, "utf-8")
+        mock_cache = MagicMock()
+        mock_cache.get_metrics.return_value = None
+        mock_get_cache.return_value = mock_cache
+
+        result = compute_file_metrics("/test/nested.py", language="python")
+
+        assert result["max_nesting_depth"] == 5
 
     @patch("tree_sitter_analyzer.mcp.utils.file_metrics.read_file_safe")
     @patch("tree_sitter_analyzer.mcp.utils.file_metrics.get_shared_cache")

--- a/tree_sitter_analyzer/mcp/utils/file_metrics.py
+++ b/tree_sitter_analyzer/mcp/utils/file_metrics.py
@@ -20,6 +20,7 @@ class FileMetrics:
     estimated_tokens: int
     file_size_bytes: int
     content_hash: str
+    max_nesting_depth: int = 0
 
     def as_dict(self) -> dict[str, int | str]:
         return {
@@ -30,6 +31,10 @@ class FileMetrics:
             "estimated_tokens": self.estimated_tokens,
             "file_size_bytes": self.file_size_bytes,
             "content_hash": self.content_hash,
+            # Feature #580: deepest block-nesting chain so scale callers get a
+            # deep-nesting pathology signal (a 500-level nested file parses
+            # fine but was invisible in scale's lines/tokens/size view).
+            "max_nesting_depth": self.max_nesting_depth,
         }
 
 
@@ -40,6 +45,22 @@ def _estimate_tokens(content: str) -> int:
     # Rough approximation used historically in AnalyzeScaleTool
     tokens = _TOKEN_RE.findall(content)
     return len([t for t in tokens if t.strip()])
+
+
+def _compute_max_nesting_depth(content: str) -> int:
+    """Return the deepest block-nesting depth (feature #580).
+
+    Reuses ``deepest_nesting_location`` — the same indentation-derived
+    block-depth signal the file-health ``deep_nesting`` smell uses — so the
+    scale view reports the deepest chain of nested blocks/scopes an agent
+    needs to flag a pathological file. The helper is O(n) over lines and
+    grammar-independent (so a tree-sitter version bump can't silently shift
+    the value). Returns the depth only; the line number is discarded here.
+    """
+    from ..tools.utils.file_health_locations import deepest_nesting_location
+
+    depth, _line = deepest_nesting_location(content.split("\n"))
+    return depth
 
 
 def _compute_line_metrics(
@@ -163,6 +184,7 @@ def compute_file_metrics(
     total_lines, code_lines, comment_lines, blank_lines = _compute_line_metrics(
         content, language
     )
+    max_nesting_depth = _compute_max_nesting_depth(content)
 
     metrics = FileMetrics(
         total_lines=total_lines,
@@ -172,6 +194,7 @@ def compute_file_metrics(
         estimated_tokens=estimated_tokens,
         file_size_bytes=file_size_bytes,
         content_hash=content_hash,
+        max_nesting_depth=max_nesting_depth,
     ).as_dict()
 
     shared_cache.set_metrics(cache_key, metrics, project_root=project_root)


### PR DESCRIPTION
## Summary
- `--check-scale` / `health action=scale` `file_metrics` now includes `max_nesting_depth` (deepest block-nesting chain, O(n) over lines) so agents can gate on the deep-nesting pathology the scale view previously couldn't see — a 500-level nested file parses fine but was invisible in lines/tokens/size.
- Computed by reusing the existing `deepest_nesting_location` helper (the same indentation-derived block-depth signal the file-health `deep_nesting` smell uses). Grammar-independent, so a tree-sitter version bump cannot silently shift the value.
- Both surfaces share `compute_file_metrics`, so CLI and MCP report the identical value (verified: both `== 5` on a hand-built 5-level nest).

## Test
- RED-first unit test in `tests/unit/mcp/test_utils/test_file_metrics.py` pins a hand-counted 5-level nest to `max_nesting_depth == 5` (exact assertion, per the lock), plus flat=0 and empty=0 cases.
- Existing scale / file_metrics / facade-doc-drift / CLI↔MCP parity suites stay green.

Closes #580.

🤖 Generated with Claude Code