### PR TITLE
fix(safe-to-edit): recommendation must agree with escalated verdict (#1027)

### DIFF
--- a/tests/unit/mcp/tools/test_safe_to_edit_unsafe_verdict.py
+++ b/tests/unit/mcp/tools/test_safe_to_edit_unsafe_verdict.py
@@ -251,6 +251,42 @@ class TestSafeToEditConstraintIntegration:
         assert "summary_line" in result, sorted(result)
         assert f"verdict={verdict}" in result["summary_line"], result["summary_line"]
 
+    def test_recommendation_matches_escalated_verdict(self, tmp_path: Path) -> None:
+        """#1027: ``recommendation`` must agree with the escalated ``verdict``.
+
+        Before the fix, ``recommendation`` was rebuilt from the original,
+        un-escalated ``risk`` (``_risk_to_verdict(risk)``), while ``verdict``
+        was promoted to UNSAFE by a constraint violation. The result was a
+        self-contradicting envelope: ``verdict=UNSAFE`` next to a
+        ``recommendation`` that opened with "SAFE to edit". An agent reading
+        the two fields gets opposite instructions → false-positive work stop.
+        """
+        project = _scaffold_min_project(tmp_path)
+        _stage_dogfood_constraints(project)
+
+        db_path = project / ".ast-cache" / "index.db"
+        _init_violations_db(db_path)
+        _seed_violation(
+            db_path,
+            rule_id="mcp-no-cli",
+            caller_file=TARGET_FILE_REL,
+            severity="error",
+            caller_line=2,
+        )
+
+        tool = _make_safe_to_edit_tool(project)
+        result = _run(
+            tool.execute({"file_path": TARGET_FILE_REL, "output_format": "json"})
+        )
+
+        verdict = result["verdict"]
+        assert verdict == "UNSAFE", verdict
+        recommendation = result["recommendation"]
+        # The recommendation is escalated alongside the verdict: it must open
+        # with the UNSAFE phrasing and must NOT contain the SAFE-branch text.
+        assert recommendation.startswith("UNSAFE to edit"), recommendation
+        assert "SAFE to edit (health" not in recommendation, recommendation
+
     def test_safe_to_edit_emits_CAUTION_on_warn_violation(self, tmp_path: Path) -> None:
         """Only warn-severity → CAUTION (not the legacy ``REVIEW``).
 

--- a/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
@@ -181,7 +181,12 @@ def _format_safe_to_edit_result(
         risk_factors.extend(constraint_risk_factor(row) for row in violations)
     if fixture_fact.is_fixture:
         risk_factors.append(_fixture_risk_factor(fixture_fact, context.file_path))
-    recommendation = _format_recommendation(risk, facts, workflow)
+    # #1027: build the recommendation from the FINAL (possibly escalated)
+    # verdict, never the un-escalated ``risk``. A constraint/fixture
+    # promotion that lifts SAFE→UNSAFE must lift the recommendation too,
+    # otherwise the envelope self-contradicts (verdict=UNSAFE next to a
+    # "SAFE to edit" recommendation) and an agent reads opposite instructions.
+    recommendation = _format_recommendation(verdict, facts, workflow)
     # #781: pass the (possibly escalated) verdict so summary_line AND
     # summary["verdict"] are both built from it — never a CAUTION/UNSAFE split.
     summary = build_agent_summary(workflow_context, workflow, verdict_override=verdict)
@@ -288,20 +293,26 @@ def _fixture_risk_factor(fact: Any, file_path: str) -> dict[str, Any]:
 
 
 def _format_recommendation(
-    risk: str,
+    verdict: str,
     facts: SafeToEditFacts,
     workflow: dict[str, Any],
 ) -> str:
-    """One-line agent-readable summary of what to do next."""
+    """One-line agent-readable summary of what to do next.
+
+    #1027: built from the FINAL (possibly escalated) verdict so it can never
+    contradict the structured ``verdict`` field. ``ERROR`` collapses into the
+    UNSAFE bucket and ``REVIEW`` into the CAUTION bucket (mirroring
+    ``_VERDICT_SEVERITY``); everything else is the SAFE bucket.
+    """
     grade = facts.health.grade
     downstream = len(facts.dependents)
-    verdict = _risk_to_verdict(risk).lower()
-    if verdict == "unsafe":
+    verdict = (verdict or "").lower()
+    if verdict in ("unsafe", "error"):
         return (
             f"UNSAFE to edit: health grade {grade}, {downstream} downstream "
             f"file(s) depend on this. Refactor in stages with tests after each."
         )
-    if verdict == "caution":
+    if verdict in ("caution", "review"):
         return (
             f"CAUTION: health grade {grade}, {downstream} downstream file(s). "
             "Run tests in the affected scope before and after the edit."


### PR DESCRIPTION
Closes #1027.

## Problem
`edit action=safe` / `--safe-to-edit` could return a self-contradicting envelope:

```json
{ "verdict": "UNSAFE", "risk_level": "safe",
  "recommendation": "SAFE to edit (health A, 0 downstream)..." }
```

An agent reading `verdict=UNSAFE` aborts the edit while `recommendation` says it's safe → false-positive work stoppage.

## Root cause
In `safe_to_edit_helpers._format_safe_to_edit_result`:
- `verdict` is **escalated** beyond the base risk via constraint/fixture checks: `_max_verdict(_max_verdict(base_verdict, constraint_verdict), fixture_verdict)`.
- `recommendation` was built by `_format_recommendation(risk, ...)`, which recomputed a *local* verdict from the **original, un-escalated** `risk` (`_risk_to_verdict(risk)`).

So a constraint/fixture promotion that lifts SAFE→UNSAFE never reached the recommendation text.

## Fix
Feed the **final escalated `verdict`** into `_format_recommendation` instead of the raw `risk`. The function now buckets directly off the verdict vocabulary (`ERROR`→UNSAFE bucket, `REVIEW`→CAUTION bucket, mirroring `_VERDICT_SEVERITY`). All three surfaces — `verdict`, `summary_line`, `recommendation` — now derive from the same escalated value.

## Test
RED-first: `test_recommendation_matches_escalated_verdict` seeds an error-severity constraint violation on the target file (base risk SAFE, health A, 0 downstream → verdict escalates to UNSAFE) and pins that `recommendation` opens with "UNSAFE to edit" and never contains the SAFE-branch text. Fails before the fix, passes after.

## Verification
- `tests/unit/mcp/test_safe_to_edit_tool.py tests/unit/mcp/tools/test_safe_to_edit_dependency_view.py tests/unit/mcp/tools/test_safe_to_edit_unsafe_verdict.py` → 48 passed (the `--change-impact` verification set).
- ruff + ruff format + mypy clean (pre-commit green).

Surgical: one call-site arg + one function's bucketing logic. No behavior change when verdict is not escalated.