### PR TITLE
fix(skills/runtime): replace invalid --ast-cache-mode force/status with valid commands (#1028)

### DIFF
--- a/.claude/skills/tsa-graph/SKILL.md
+++ b/.claude/skills/tsa-graph/SKILL.md
@@ -103,7 +103,7 @@ callee_symbol_id: null | <int FK to ast_symbol_rows>
 Filter rules of thumb:
 - `resolution=stdlib` → ignore for change-impact (won't be in this repo)
 - `resolution=local|project` with non-null `callee_symbol_id` → trustworthy edge
-- `resolution=unknown` → may need re-index: `uv run tree-sitter-analyzer --ast-cache --ast-cache-mode force`
+- `resolution=unknown` → may need re-index: `uv run tree-sitter-analyzer --ast-cache --ast-cache-mode index --ast-cache-force`
 
 ## CLI equivalents
 

--- a/.claude/skills/tsa-index/SKILL.md
+++ b/.claude/skills/tsa-index/SKILL.md
@@ -32,7 +32,7 @@ allowed-tools:
 | Goal                                           | Tool                              |
 |------------------------------------------------|-----------------------------------|
 | Status / stats of the AST cache                | `index action=cache` (mode=status) |
-| Force rebuild                                  | `index action=cache` (mode=force)  |
+| Force rebuild                                  | `index action=full`                |
 | Incremental refresh                            | `index action=cache` (mode=index)  |
 | Watch a directory and auto-refresh             | `index action=cache` (mode=watch_start) |
 | AST-level diff of one file across commits      | `edit action=ast_diff`            |
@@ -51,7 +51,7 @@ The auto-cache is usually correct. Force rebuild only when:
 - Files were renamed/moved en masse (mtime-based invalidation may miss this)
 
 ```bash
-uv run tree-sitter-analyzer --ast-cache --ast-cache-mode force
+uv run tree-sitter-analyzer --ast-cache --ast-cache-mode index --ast-cache-force
 # OR safer (preserves what works):
 uv run tree-sitter-analyzer --ast-cache --ast-cache-mode index
 ```
@@ -80,8 +80,8 @@ Avoid asking "why doesn't swift work" — query this first.
 ## CLI equivalents
 
 ```bash
-uv run tree-sitter-analyzer --ast-cache --ast-cache-mode status
-uv run tree-sitter-analyzer --ast-cache --ast-cache-mode force
+uv run tree-sitter-analyzer --ast-cache --ast-cache-mode stats
+uv run tree-sitter-analyzer --ast-cache --ast-cache-mode index --ast-cache-force
 uv run tree-sitter-analyzer --ast-diff --ast-diff-file <file> --ast-diff-old-ref HEAD~5 --ast-diff-new-ref HEAD
 uv run tree-sitter-analyzer --parser-readiness swift
 uv run tree-sitter-analyzer --autoindex            # index action=auto

--- a/docs/agent-envelope-contract.md
+++ b/docs/agent-envelope-contract.md
@@ -161,7 +161,7 @@ EOF
   "listed_cap": 3,
   "truncated": true,
   "warnings": [
-    "stale_cache: most edges have callee_resolution='unknown'. Run `uv run tree-sitter-analyzer --ast-cache --ast-cache-mode force` or rebuild with `--mode resolve` to populate Synapse resolution columns."
+    "stale_cache: most edges have callee_resolution='unknown'. Run `uv run tree-sitter-analyzer --ast-cache --ast-cache-mode index --ast-cache-force` or rebuild with `--mode resolve` to populate Synapse resolution columns."
   ],
   "next_step": "showing 3 of 39 callers — raise limit, or qualify with ClassName.method to narrow (dynamic-dispatch names like 'execute' have huge fan-in). Each caller/callee's source body is inlined under 'body' — answer directly, no Read needed. Coordinate-only entries beyond the top-N can be Read on demand."
 }

--- a/tests/unit/test_callers_callees_tools.py
+++ b/tests/unit/test_callers_callees_tools.py
@@ -418,14 +418,21 @@ class TestStaleCacheWarning:
         ]
         assert _is_stale_resolution(entries) is True
 
-    def test_warning_message_recommends_resolve_mode(self) -> None:
+    def test_warning_message_recommends_valid_rebuild_command(self) -> None:
         from tree_sitter_analyzer.mcp.tools.callees_tool import _STALE_CACHE_WARNING
 
-        # The user-visible string must point at the right fix. Pinning
-        # the substring stops a future "minor wording cleanup" from
-        # dropping the actionable command.
-        assert "--mode resolve" in _STALE_CACHE_WARNING
+        # #1028: the user-visible string must point at a command that
+        # actually runs. The old text recommended `--ast-cache-mode force`
+        # and `--mode resolve`, neither of which is a valid flag/choice
+        # (argparse errors with "invalid choice"). Pin the VALID rebuild
+        # command and assert the invalid forms never come back.
         assert "stale_cache" in _STALE_CACHE_WARNING
+        assert (
+            "--ast-cache --ast-cache-mode index --ast-cache-force"
+            in _STALE_CACHE_WARNING
+        )
+        assert "--ast-cache-mode force" not in _STALE_CACHE_WARNING
+        assert "--mode resolve" not in _STALE_CACHE_WARNING
 
     @pytest.mark.asyncio
     async def test_callees_warning_omitted_when_callees_empty(

--- a/tree_sitter_analyzer/mcp/tools/codegraph_relation_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_relation_tool.py
@@ -85,8 +85,9 @@ _STALE_CACHE_UNKNOWN_RATIO = 0.8
 
 _STALE_CACHE_WARNING = (
     "stale_cache: most edges have callee_resolution='unknown'. "
-    "Run `uv run tree-sitter-analyzer --ast-cache --ast-cache-mode force` "
-    "or rebuild with `--mode resolve` to populate Synapse resolution columns."
+    "Run `uv run tree-sitter-analyzer --ast-cache --ast-cache-mode index "
+    "--ast-cache-force` to rebuild the index and populate Synapse "
+    "resolution columns."
 )
 
 

--- a/tree_sitter_analyzer/skills/tsa-graph/SKILL.md
+++ b/tree_sitter_analyzer/skills/tsa-graph/SKILL.md
@@ -103,7 +103,7 @@ callee_symbol_id: null | <int FK to ast_symbol_rows>
 Filter rules of thumb:
 - `resolution=stdlib` → ignore for change-impact (won't be in this repo)
 - `resolution=local|project` with non-null `callee_symbol_id` → trustworthy edge
-- `resolution=unknown` → may need re-index: `uv run tree-sitter-analyzer --ast-cache --ast-cache-mode force`
+- `resolution=unknown` → may need re-index: `uv run tree-sitter-analyzer --ast-cache --ast-cache-mode index --ast-cache-force`
 
 ## CLI equivalents
 

--- a/tree_sitter_analyzer/skills/tsa-index/SKILL.md
+++ b/tree_sitter_analyzer/skills/tsa-index/SKILL.md
@@ -32,7 +32,7 @@ allowed-tools:
 | Goal                                           | Tool                              |
 |------------------------------------------------|-----------------------------------|
 | Status / stats of the AST cache                | `index action=cache` (mode=status) |
-| Force rebuild                                  | `index action=cache` (mode=force)  |
+| Force rebuild                                  | `index action=full`                |
 | Incremental refresh                            | `index action=cache` (mode=index)  |
 | Watch a directory and auto-refresh             | `index action=cache` (mode=watch_start) |
 | AST-level diff of one file across commits      | `edit action=ast_diff`            |
@@ -51,7 +51,7 @@ The auto-cache is usually correct. Force rebuild only when:
 - Files were renamed/moved en masse (mtime-based invalidation may miss this)
 
 ```bash
-uv run tree-sitter-analyzer --ast-cache --ast-cache-mode force
+uv run tree-sitter-analyzer --ast-cache --ast-cache-mode index --ast-cache-force
 # OR safer (preserves what works):
 uv run tree-sitter-analyzer --ast-cache --ast-cache-mode index
 ```
@@ -80,8 +80,8 @@ Avoid asking "why doesn't swift work" — query this first.
 ## CLI equivalents
 
 ```bash
-uv run tree-sitter-analyzer --ast-cache --ast-cache-mode status
-uv run tree-sitter-analyzer --ast-cache --ast-cache-mode force
+uv run tree-sitter-analyzer --ast-cache --ast-cache-mode stats
+uv run tree-sitter-analyzer --ast-cache --ast-cache-mode index --ast-cache-force
 uv run tree-sitter-analyzer --ast-diff --ast-diff-file <file> --ast-diff-old-ref HEAD~5 --ast-diff-new-ref HEAD
 uv run tree-sitter-analyzer --parser-readiness swift
 uv run tree-sitter-analyzer --autoindex            # index action=auto


### PR DESCRIPTION
Closes #1028.

## Problem
`--ast-cache-mode` has exactly 10 valid choices (`cli/argument_groups/_analysis.py`): `index, lookup, search, sync, changes, watch_start, watch_stop, watch_status, stats, invalidate`. **Neither `force` nor `status` is among them** — both error with argparse `invalid choice` (verified by running them). A force rebuild uses the boolean `--ast-cache-force` flag; a status read uses `--ast-cache-mode stats`.

The worst offender is agent-facing: `_STALE_CACHE_WARNING` (emitted at runtime by `nav callers/callees` / `codegraph_relation_tool` when the cache is stale) literally tells the agent to run a command that errors — and its alternative `--mode resolve` is *also* not a valid flag.

## Fix
- **Runtime (priority):** `codegraph_relation_tool._STALE_CACHE_WARNING` (shared by `callers_tool` + `callees_tool`) now recommends `uv run tree-sitter-analyzer --ast-cache --ast-cache-mode index --ast-cache-force` and drops the invalid `--mode resolve` alternative.
- **Skills** (both `.claude/skills/` and the packaged `tree_sitter_analyzer/skills/` trees, kept identical): `tsa-index` + `tsa-graph` — `force` → valid rebuild; the CLI `status` invocation → `stats`; the MCP "Force rebuild" table row `index action=cache (mode=force)` → `index action=full`.
- **Doc:** `docs/agent-envelope-contract.md` — same `force` → valid rebuild.

While fixing the enumerated `force` occurrences I found `--ast-cache-mode status` (tsa-index CLI block) is invalid by the same mechanism, so it's corrected in the same sweep. A repo-wide grep now finds **zero** invalid `--ast-cache-mode force|status` in skills/runtime/docs.

## Test
`test_warning_message_recommends_*` previously pinned the **invalid** `--mode resolve` (a test protecting a bug). Rewritten to pin the **valid** command and assert the invalid forms (`--ast-cache-mode force`, `--mode resolve`) never return → `tests/unit/test_callers_callees_tools.py` 52 passed.

## Scope note
`docs/internal/benchmark-scripts/benchmark.py:288` has the same invalid string but carries pre-existing unrelated ruff debt; left out to keep this PR focused and lint-clean. Can follow up separately.