### PR TITLE
docs(skills): batch_search ≥2 constraint + portable sqlite3 examples (#1029)

### DIFF
--- a/.claude/skills/tsa-find/SKILL.md
+++ b/.claude/skills/tsa-find/SKILL.md
@@ -36,6 +36,7 @@ allowed-tools:
 | Filename pattern only                     | `project action=files`      |
 | Content pattern only (regex / literal)    | `search action=content`     |
 | Filename pattern AND content              | `search action=grep`        |
+| Several patterns in one call (≥2)        | `search action=batch`       |
 | Read specific lines of one file           | `structure action=read`     |
 | "Is this file too big to read fully?"     | `health action=scale`       |
 
@@ -89,4 +90,5 @@ uv run tree-sitter-analyzer <file> --partial-read        # sized read with --sta
 
 - DON'T `Read` a large file before checking scale — burns tokens
 - DON'T `Bash grep -rn` for things `search action=content` handles — slower + noisier
+- DON'T call `search action=batch` with a single query — it enforces a ≥2-query minimum (raises "must be at least 2 queries"); use `search action=content` for one pattern
 - DON'T re-search the same query twice in one session — cache the result mentally

--- a/.claude/skills/tsa-refactor-queue/SKILL.md
+++ b/.claude/skills/tsa-refactor-queue/SKILL.md
@@ -127,11 +127,16 @@ Run on `/Users/aisheng.yu/git-private/tree-sitter-analyzer`:
 # Parallel CLI batch (humans):
 uv run tree-sitter-analyzer --project-health --max-files 20 --output-format json > /tmp/health.json
 uv run tree-sitter-analyzer --dead-code --output-format json > /tmp/dead.json
-sqlite3 .ast-cache/index.db "
-  SELECT s.file_path, SUM(a.mod_count_30d) AS churn
-  FROM ast_symbol_activation a
-  JOIN ast_symbol_rows s ON s.id = a.symbol_id
-  GROUP BY s.file_path ORDER BY churn DESC LIMIT 50" > /tmp/churn.tsv
+uv run python -c "
+import sqlite3
+sql = '''
+SELECT s.file_path, SUM(a.mod_count_30d) AS churn
+FROM ast_symbol_activation a
+JOIN ast_symbol_rows s ON s.id = a.symbol_id
+GROUP BY s.file_path ORDER BY churn DESC LIMIT 50'''
+for r in sqlite3.connect('.ast-cache/index.db').execute(sql):
+    print(*r, sep='\t')
+" > /tmp/churn.tsv
 ```
 
 Expected shape after joining (truncated, illustrative — actual numbers vary
@@ -224,13 +229,18 @@ uv run tree-sitter-analyzer --dead-code --output-format json
 uv run tree-sitter-analyzer --overview --output-format json
 
 # 4. Per-file churn (no dedicated --temporal flag yet — query DB directly)
-sqlite3 .ast-cache/index.db "
-  SELECT s.file_path, SUM(a.mod_count_30d) AS churn_30d
-  FROM ast_symbol_activation a
-  JOIN ast_symbol_rows s ON s.id = a.symbol_id
-  WHERE a.git_state = 'tracked'
-  GROUP BY s.file_path
-  ORDER BY churn_30d DESC LIMIT 50"
+uv run python -c "
+import sqlite3
+sql = '''
+SELECT s.file_path, SUM(a.mod_count_30d) AS churn_30d
+FROM ast_symbol_activation a
+JOIN ast_symbol_rows s ON s.id = a.symbol_id
+WHERE a.git_state = 'tracked'
+GROUP BY s.file_path
+ORDER BY churn_30d DESC LIMIT 50'''
+for r in sqlite3.connect('.ast-cache/index.db').execute(sql):
+    print(*r, sep='\t')
+"
 
 # 5. Per-row enrichment (loop top 5)
 uv run tree-sitter-analyzer <file> --table --output-format json

--- a/.claude/skills/tsa-temporal/SKILL.md
+++ b/.claude/skills/tsa-temporal/SKILL.md
@@ -131,12 +131,19 @@ uv run tree-sitter-analyzer --callees <FUNC> --output-format json | jq '.callees
 
 Or query the SQLite DB directly for batch reports:
 ```bash
-sqlite3 .ast-cache/index.db "
+# Portable: stdlib sqlite3 via `uv run python` (the `sqlite3` CLI is
+# frequently absent from PATH on Windows).
+uv run python -c "
+import sqlite3
+sql = '''
 SELECT s.name, s.file_path, a.mod_count_30d
 FROM ast_symbol_activation a
 JOIN ast_symbol_rows s ON s.id = a.symbol_id
 WHERE a.mod_count_30d >= 5
-ORDER BY a.mod_count_30d DESC LIMIT 20"
+ORDER BY a.mod_count_30d DESC LIMIT 20'''
+for r in sqlite3.connect('.ast-cache/index.db').execute(sql):
+    print(*r, sep='\t')
+"
 ```
 
 ## Anti-patterns

--- a/tree_sitter_analyzer/skills/tsa-find/SKILL.md
+++ b/tree_sitter_analyzer/skills/tsa-find/SKILL.md
@@ -36,6 +36,7 @@ allowed-tools:
 | Filename pattern only                     | `project action=files`      |
 | Content pattern only (regex / literal)    | `search action=content`     |
 | Filename pattern AND content              | `search action=grep`        |
+| Several patterns in one call (≥2)        | `search action=batch`       |
 | Read specific lines of one file           | `structure action=read`     |
 | "Is this file too big to read fully?"     | `health action=scale`       |
 
@@ -89,4 +90,5 @@ uv run tree-sitter-analyzer <file> --partial-read        # sized read with --sta
 
 - DON'T `Read` a large file before checking scale — burns tokens
 - DON'T `Bash grep -rn` for things `search action=content` handles — slower + noisier
+- DON'T call `search action=batch` with a single query — it enforces a ≥2-query minimum (raises "must be at least 2 queries"); use `search action=content` for one pattern
 - DON'T re-search the same query twice in one session — cache the result mentally

--- a/tree_sitter_analyzer/skills/tsa-refactor-queue/SKILL.md
+++ b/tree_sitter_analyzer/skills/tsa-refactor-queue/SKILL.md
@@ -127,11 +127,16 @@ Run on `/Users/aisheng.yu/git-private/tree-sitter-analyzer`:
 # Parallel CLI batch (humans):
 uv run tree-sitter-analyzer --project-health --max-files 20 --output-format json > /tmp/health.json
 uv run tree-sitter-analyzer --dead-code --output-format json > /tmp/dead.json
-sqlite3 .ast-cache/index.db "
-  SELECT s.file_path, SUM(a.mod_count_30d) AS churn
-  FROM ast_symbol_activation a
-  JOIN ast_symbol_rows s ON s.id = a.symbol_id
-  GROUP BY s.file_path ORDER BY churn DESC LIMIT 50" > /tmp/churn.tsv
+uv run python -c "
+import sqlite3
+sql = '''
+SELECT s.file_path, SUM(a.mod_count_30d) AS churn
+FROM ast_symbol_activation a
+JOIN ast_symbol_rows s ON s.id = a.symbol_id
+GROUP BY s.file_path ORDER BY churn DESC LIMIT 50'''
+for r in sqlite3.connect('.ast-cache/index.db').execute(sql):
+    print(*r, sep='\t')
+" > /tmp/churn.tsv
 ```
 
 Expected shape after joining (truncated, illustrative — actual numbers vary
@@ -224,13 +229,18 @@ uv run tree-sitter-analyzer --dead-code --output-format json
 uv run tree-sitter-analyzer --overview --output-format json
 
 # 4. Per-file churn (no dedicated --temporal flag yet — query DB directly)
-sqlite3 .ast-cache/index.db "
-  SELECT s.file_path, SUM(a.mod_count_30d) AS churn_30d
-  FROM ast_symbol_activation a
-  JOIN ast_symbol_rows s ON s.id = a.symbol_id
-  WHERE a.git_state = 'tracked'
-  GROUP BY s.file_path
-  ORDER BY churn_30d DESC LIMIT 50"
+uv run python -c "
+import sqlite3
+sql = '''
+SELECT s.file_path, SUM(a.mod_count_30d) AS churn_30d
+FROM ast_symbol_activation a
+JOIN ast_symbol_rows s ON s.id = a.symbol_id
+WHERE a.git_state = 'tracked'
+GROUP BY s.file_path
+ORDER BY churn_30d DESC LIMIT 50'''
+for r in sqlite3.connect('.ast-cache/index.db').execute(sql):
+    print(*r, sep='\t')
+"
 
 # 5. Per-row enrichment (loop top 5)
 uv run tree-sitter-analyzer <file> --table --output-format json

--- a/tree_sitter_analyzer/skills/tsa-temporal/SKILL.md
+++ b/tree_sitter_analyzer/skills/tsa-temporal/SKILL.md
@@ -131,12 +131,19 @@ uv run tree-sitter-analyzer --callees <FUNC> --output-format json | jq '.callees
 
 Or query the SQLite DB directly for batch reports:
 ```bash
-sqlite3 .ast-cache/index.db "
+# Portable: stdlib sqlite3 via `uv run python` (the `sqlite3` CLI is
+# frequently absent from PATH on Windows).
+uv run python -c "
+import sqlite3
+sql = '''
 SELECT s.name, s.file_path, a.mod_count_30d
 FROM ast_symbol_activation a
 JOIN ast_symbol_rows s ON s.id = a.symbol_id
 WHERE a.mod_count_30d >= 5
-ORDER BY a.mod_count_30d DESC LIMIT 20"
+ORDER BY a.mod_count_30d DESC LIMIT 20'''
+for r in sqlite3.connect('.ast-cache/index.db').execute(sql):
+    print(*r, sep='\t')
+"
 ```
 
 ## Anti-patterns


### PR DESCRIPTION
Closes #1029.

Two skill-doc accuracy gaps found in the v1.24.0 skills dogfood.

## B5 — batch_search minimum-2-queries constraint undocumented
`batch_search_tool.validate_arguments` enforces `len(queries) >= 2` (raises `"queries must be at least 2 queries"`). The constraint is intentional (it's a *batch* tool; a single query should use `search action=content`), but `tsa-find` didn't mention the batch tool or its minimum at all.

- Added a routing-table row: `Several patterns in one call (≥2)` → `search action=batch`.
- Added an anti-pattern line: don't call `search action=batch` with one query; use `search action=content`.

## B8 — sqlite3 CLI examples unsafe on Windows PATH
`tsa-temporal` (1 block) and `tsa-refactor-queue` (2 blocks) invoked the `sqlite3` CLI, frequently absent from PATH on Windows. Converted all three to the portable `uv run python -c "import sqlite3 ..."` form (stdlib `sqlite3` ships with the interpreter), preserving the SQL verbatim. Verified the converted temporal query runs against the real `.ast-cache/index.db` and returns rows.

Both the `.claude/skills/` and packaged `tree_sitter_analyzer/skills/` trees updated identically. Pure documentation change (no code, no tests affected).