### PR TITLE
docs(README): document additional CLI entry points + --install-skills-global (#1032, #1033)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ CLI equivalent (no agent needed): `tree-sitter-analyzer --codegraph-status`
 
 > **PyPI / uvx users — install skills:** the 13 `tsa-*` skills are bundled in the wheel. Copy them once with:
 > ```bash
-> tree-sitter-analyzer --install-skills
+> tree-sitter-analyzer --install-skills              # into ./.claude/skills/ (this project)
+> tree-sitter-analyzer --install-skills-global       # into ~/.claude/skills/ (all projects)
 > ```
 > Git-clone users already have them under `.claude/skills/` — no action needed.
 
@@ -171,6 +172,15 @@ tree-sitter-analyzer --dead-code                  # transitive unreachable
 tree-sitter-analyzer --check-constraints          # architectural rules
 tree-sitter-analyzer --safe-to-edit <file>        # refuse if risky
 tree-sitter-analyzer --uml class                  # Mermaid UML class diagram
+```
+
+Installing the package also registers three standalone search utilities (thin
+entry points over the same engine, handy in shell pipelines):
+
+```bash
+list-files <dir>          # fd-style file discovery
+search-content <pattern>  # ripgrep-style content search
+find-and-grep <pattern>   # two-stage fd + ripgrep
 ```
 
 See [`docs/CODEMAPS/cli.md`](docs/CODEMAPS/cli.md) for the full surface.
@@ -311,7 +321,8 @@ Verify: `claude mcp list`. The 13 `tsa-*` skills auto-discover from `.claude/ski
 
 **PyPI / uvx users** — install the bundled skills once with:
 ```bash
-tree-sitter-analyzer --install-skills
+tree-sitter-analyzer --install-skills              # into ./.claude/skills/ (this project)
+tree-sitter-analyzer --install-skills-global       # into ~/.claude/skills/ (all projects)
 ```
 Git-clone users already have them — no action needed.
 </details>


### PR DESCRIPTION
Closes #1032. Closes #1033.

Two README fact-check omissions (both verified against `pyproject.toml` / the argument parser; documentation-only, no behaviour change).

## #1033 — `--install-skills-global`
The CLI exposes both `--install-skills` and `--install-skills-global`, but the README documented only the former. Added `--install-skills-global` (installs the bundled `tsa-*` skills into `~/.claude/skills/` for all projects) next to `--install-skills` in both install snippets, each with a one-line scope comment.

## #1032 — standalone search utilities
`[project.scripts]` registers three entry points the README never mentioned (only `docs/CODEMAPS/cli.md` did): `list-files`, `search-content`, `find-and-grep`. Added a short block under the CLI-flags section listing them as install-scoped pipeline helpers.

## Verification
- `pyproject.toml` `[project.scripts]` confirms all three commands; parser confirms both `--install-skills*` flags.
- README count/structure tests green: `test_readme_counts_match_registry`, `test_all_readmes_under_500_lines` (now 492), `test_no_stale_facade_tool_names`, multilang consistency — 29 passed / 5 skipped.

Both issues are the same theme (README documents the full installed CLI surface), same single file, kept in one focused PR.