### PR TITLE
test(cli): de-duplicate triplicated CLI info-command tests (#1037)

### DIFF
--- a/tests/integration/cli/test_cli_execution.py
+++ b/tests/integration/cli/test_cli_execution.py
@@ -209,68 +209,6 @@ pytestmark = [pytest.mark.unit]
 class TestCLIAdditionalCoverage:
     """Additional test cases to improve CLI coverage"""
 
-    def test_show_supported_languages(self, monkeypatch):
-        """Test --show-supported-languages option"""
-        monkeypatch.setattr(sys, "argv", ["cli", "--show-supported-languages"])
-        mock_stdout = StringIO()
-        monkeypatch.setattr("sys.stdout", mock_stdout)
-
-        with contextlib.suppress(SystemExit):
-            main()
-
-        output = mock_stdout.getvalue()
-        assert "Supported languages" in output or '"languages"' in output
-
-    def test_show_supported_extensions(self, monkeypatch):
-        """Test --show-supported-extensions option"""
-        monkeypatch.setattr(sys, "argv", ["cli", "--show-supported-extensions"])
-        mock_stdout = StringIO()
-        monkeypatch.setattr("sys.stdout", mock_stdout)
-
-        with contextlib.suppress(SystemExit):
-            main()
-
-        output = mock_stdout.getvalue()
-        assert "Supported file extensions" in output or '"extensions"' in output
-
-    def test_show_common_queries(self, monkeypatch):
-        """Test --show-common-queries option"""
-        monkeypatch.setattr(sys, "argv", ["cli", "--show-common-queries"])
-        mock_stdout = StringIO()
-        monkeypatch.setattr("sys.stdout", mock_stdout)
-
-        with contextlib.suppress(SystemExit):
-            main()
-
-        output = mock_stdout.getvalue()
-        assert len(output) > 0
-
-    def test_show_query_languages(self, monkeypatch):
-        """Test --show-query-languages option"""
-        monkeypatch.setattr(sys, "argv", ["cli", "--show-query-languages"])
-        mock_stdout = StringIO()
-        monkeypatch.setattr("sys.stdout", mock_stdout)
-
-        with contextlib.suppress(SystemExit):
-            main()
-
-        output = mock_stdout.getvalue()
-        assert "Languages with query support" in output or '"languages"' in output
-
-    def test_list_queries_with_language(self, monkeypatch):
-        """Test --list-queries with --language option"""
-        monkeypatch.setattr(
-            sys, "argv", ["cli", "--list-queries", "--language", "java"]
-        )
-        mock_stdout = StringIO()
-        monkeypatch.setattr("sys.stdout", mock_stdout)
-
-        with contextlib.suppress(SystemExit):
-            main()
-
-        output = mock_stdout.getvalue()
-        assert "Available query keys" in output or '"queries"' in output
-
     def test_list_queries_with_file(self, monkeypatch, sample_java_file):
         """Test --list-queries with file path"""
         monkeypatch.setattr(sys, "argv", ["cli", "--list-queries", sample_java_file])
@@ -294,20 +232,6 @@ class TestCLIAdditionalCoverage:
 
         output = mock_stdout.getvalue()
         assert "Supported languages" in output or '"languages"' in output
-
-    def test_describe_query_with_language(self, monkeypatch):
-        """Test --describe-query with --language option"""
-        monkeypatch.setattr(
-            sys, "argv", ["cli", "--describe-query", "class", "--language", "java"]
-        )
-        mock_stdout = StringIO()
-        monkeypatch.setattr("sys.stdout", mock_stdout)
-
-        with contextlib.suppress(SystemExit):
-            main()
-
-        output = mock_stdout.getvalue()
-        assert "Query key 'class'" in output or '"class"' in output
 
     def test_describe_query_with_file(self, monkeypatch, sample_java_file):
         """Test --describe-query with file path"""

--- a/tests/integration/cli/test_cli_query_exec_coverage.py
+++ b/tests/integration/cli/test_cli_query_exec_coverage.py
@@ -198,66 +198,6 @@ pytestmark = [pytest.mark.unit]
 class TestCLIAdditionalCoverage:
     """Additional test cases to improve CLI coverage"""
 
-    def test_show_supported_languages(self, monkeypatch):
-        monkeypatch.setattr(sys, "argv", ["cli", "--show-supported-languages"])
-        mock_stdout = StringIO()
-        monkeypatch.setattr("sys.stdout", mock_stdout)
-
-        with contextlib.suppress(SystemExit):
-            main()
-
-        # Accept either legacy plain-text ("Supported languages") or the
-        # JSON-envelope shape that became the default in v1.13.0.
-        output = mock_stdout.getvalue()
-        assert "Supported languages" in output or '"languages"' in output
-
-    def test_show_supported_extensions(self, monkeypatch):
-        monkeypatch.setattr(sys, "argv", ["cli", "--show-supported-extensions"])
-        mock_stdout = StringIO()
-        monkeypatch.setattr("sys.stdout", mock_stdout)
-
-        with contextlib.suppress(SystemExit):
-            main()
-
-        output = mock_stdout.getvalue()
-        assert "Supported file extensions" in output or '"extensions"' in output
-
-    def test_show_common_queries(self, monkeypatch):
-        monkeypatch.setattr(sys, "argv", ["cli", "--show-common-queries"])
-        mock_stdout = StringIO()
-        monkeypatch.setattr("sys.stdout", mock_stdout)
-
-        with contextlib.suppress(SystemExit):
-            main()
-
-        output = mock_stdout.getvalue()
-        assert len(output) > 0
-
-    def test_show_query_languages(self, monkeypatch):
-        monkeypatch.setattr(sys, "argv", ["cli", "--show-query-languages"])
-        mock_stdout = StringIO()
-        monkeypatch.setattr("sys.stdout", mock_stdout)
-
-        with contextlib.suppress(SystemExit):
-            main()
-
-        output = mock_stdout.getvalue()
-        # v1.13.0: JSON envelope replaces plain-text — accept either.
-        assert "Languages with query support" in output or '"languages"' in output
-
-    def test_list_queries_with_language(self, monkeypatch):
-        monkeypatch.setattr(
-            sys, "argv", ["cli", "--list-queries", "--language", "java"]
-        )
-        mock_stdout = StringIO()
-        monkeypatch.setattr("sys.stdout", mock_stdout)
-
-        with contextlib.suppress(SystemExit):
-            main()
-
-        output = mock_stdout.getvalue()
-        assert "Available query keys" in output or '"queries"' in output
-
     def test_list_queries_with_file(self, monkeypatch, sample_java_file):
         monkeypatch.setattr(sys, "argv", ["cli", "--list-queries", sample_java_file])
         mock_stdout = StringIO()
@@ -279,20 +219,6 @@ class TestCLIAdditionalCoverage:
 
         output = mock_stdout.getvalue()
         assert "Supported languages" in output or '"languages"' in output
-
-    def test_describe_query_with_language(self, monkeypatch):
-        monkeypatch.setattr(
-            sys, "argv", ["cli", "--describe-query", "class", "--language", "java"]
-        )
-        mock_stdout = StringIO()
-        monkeypatch.setattr("sys.stdout", mock_stdout)
-
-        with contextlib.suppress(SystemExit):
-            main()
-
-        output = mock_stdout.getvalue()
-        # v1.13.0: JSON envelope replaces plain-text "Query key 'X'".
-        assert "Query key 'class'" in output or '"class"' in output
 
     def test_describe_query_with_file(self, monkeypatch, sample_java_file):
         sample_dir = str(Path(sample_java_file).parent)


### PR DESCRIPTION
Closes #1037.

## Problem
Six CLI info-command tests were byte-for-byte triplicated across three integration files (verified against develop HEAD): `test_show_supported_languages`, `test_show_supported_extensions`, `test_show_query_languages`, `test_show_common_queries`, `test_list_queries_with_language`, `test_describe_query_with_language` — same `argv`, same exact assertions — in:
- `tests/integration/cli/test_cli_commands.py` (canonical, docstring'd, in `TestCLIInfoCommands` / `TestCLIQueryCommands`)
- `tests/integration/cli/test_cli_execution.py` (`TestCLIAdditionalCoverage`)
- `tests/integration/cli/test_cli_query_exec_coverage.py` (`TestCLIAdditionalCoverage`)

## Fix
Keep the canonical copies in `test_cli_commands.py`; remove the two duplicate copies from the `*_execution` / `*_query_exec_coverage` files. 150 lines deleted, **no production code touched**.

## Coverage preserved (CLAUDE.md §7)
These tests are the only coverage of `cli/info_commands.py`. The canonical copies in `test_cli_commands.py` are byte-identical (same `main()` invocation + same assertions), so coverage is fully preserved. Exact assertions kept verbatim — no loosening (locked exact-assertion rule).

## Scope
Held to the 6 verbatim info-command duplicates only. The broader near-total duplication between `test_cli_execution.py` and `test_cli_query_exec_coverage.py` (query-execution + logging tests) is MEDIUM-risk/high-churn and tracked separately under #1039 — deliberately out of scope here.

## Verification
- CLI integration suite: **455 passed, 5 skipped**.
- The 6 canonical tests still present + passing in `test_cli_commands.py`; 0 remain in the other two files.
- ruff + format + mypy clean (pre-commit green).