### PR TITLE
docs(codemaps): re-sync all 6 CODEMAPS with current code (doc-code alignment)

### DIFF
--- a/docs/CODEMAPS/architecture.md
+++ b/docs/CODEMAPS/architecture.md
@@ -1,4 +1,4 @@
-<!-- Generated: 2026-05-22 -->
+<!-- Generated: 2026-05-22; doc-code re-sync: 2026-06-17 -->
 # Architecture Codemap
 
 High-level topology of the `tree-sitter-analyzer` Python package.
@@ -17,8 +17,15 @@ tree_sitter_analyzer/
 ├── languages/        ← 21 tree-sitter plugins                (languages.md)
 ├── formatters/       ← TOON / JSON / table / CSV / YAML      (formatters.md)
 ├── core/             ← Parser, engine, AnalysisSession, AnalysisRequest
+├── models/           ← AnalysisResult + Class/Function/Variable/Import models
 ├── plugins/          ← LanguagePlugin / ElementExtractor base + registry
 ├── queries/          ← Per-language tree-sitter query files
+├── import_extractors/← Per-language import extraction (_python/_java/…)
+├── synapse_resolver/ ← Cross-file callee binder (primary call-edge resolution)
+├── graph/            ← edge_store.py — single-edge-table call-graph store (B1)
+├── constraints/      ← architectural-constraints.yml evaluator/parser/schema
+├── hyphae/           ← Hyphae selector DSL (lexer/parser/ast/evaluator) — RFC-0001 reactive push
+├── skills/           ← 13 bundled tsa-* agent skills
 ├── security/         ← Boundary manager, path validator      (security.md)
 ├── grammar_coverage/ ← Coverage validator + auto-discovery
 ├── platform_compat/  ← Cross-platform recorder + compare
@@ -50,10 +57,10 @@ stdout / stderr / file_output_factory
 
 ### Security boundary
 Every path is validated against `TREE_SITTER_PROJECT_ROOT` by `security/validator.py`.
-**No tool ever reads outside the project root.** `BoundaryManager` is the single source of truth.
+**No tool ever reads outside the project root.** `ProjectBoundaryManager` is the single source of truth.
 
 ### Token optimization
-- **TOON** is the default MCP output format — ~73% smaller than JSON.
+- **TOON** is the default MCP output format — 50-70% fewer tokens than JSON (see `CLAUDE.md` §1).
 - AST results are stored in **SQLite** via `ast_cache.py` (content-hash keyed).
 - `incremental_sync.py` reindexes only changed files (mtime + SHA-256).
 
@@ -74,14 +81,15 @@ contract violation.**
 |---|---|---|
 | `tree-sitter-analyzer` CLI | `cli_main.py` → `cli/` | Human-facing, JSON default |
 | `tree-sitter-analyzer-mcp` MCP stdio server | `mcp/server.py` | AI-agent-facing, TOON default |
-| `find-and-grep` | `cli/commands/find_and_grep_cli.py` | fd + ripgrep wrapper |
-| `tree-sitter-analyzer-cli` (Python API) | `api.py` | Embeddable |
+| `miswire-audit` | `miswire_audit.py` | Run-on-your-repo cross-language correctness demo |
+| `list-files` / `search-content` / `find-and-grep` | `cli/commands/*_cli.py` | fd / ripgrep / fd+rg standalone utilities |
+| Python API (no console script) | `api.py` | Embeddable library entry |
 
 ## Critical Invariants (do NOT change without reading [`CLAUDE.md`](../../CLAUDE.md))
 
 1. **MCP default `output_format` = `"toon"`** — locked. Flipping to JSON loses 50-70% token savings.
 2. **CLI default `output_format` = `"json"`** — locked. Humans pipe into `jq`.
-3. **`project_root` is resolved via `os.path.abspath`** — NOT `os.path.realpath` (macOS symlink trap).
+3. **`project_root` resolution must NOT be naively re-canonicalised in `BaseMCPTool.__init__`** — `SecurityValidator`, `PathResolver`, and the test fixtures already agree on a `Path.resolve()` (realpath) resolution; the macOS `/var → /private/var` symlink means a mismatched re-canonicalisation diverges. r36's attempt broke 164 tests on macOS (rolled back).
 4. **CLI diagnostic output → stderr; payload → stdout** — never mix.
 5. **markdown files** are NOT scored by `project_health` — use `markdown_health` for that.
 

--- a/docs/CODEMAPS/cli.md
+++ b/docs/CODEMAPS/cli.md
@@ -1,4 +1,4 @@
-<!-- Generated: 2026-05-22 -->
+<!-- Generated: 2026-05-22; doc-code re-sync: 2026-06-17 -->
 # CLI Codemap
 
 Three console-script entry points + flag-based dispatch through `cli_main.py`.
@@ -29,8 +29,8 @@ cli/commands/
 ├── find_and_grep_cli.py        ← fd + ripgrep subcommands
 ├── list_files_cli.py           ← `list-files` subcommand
 ├── search_content_cli.py       ← `search-content` subcommand
-├── mcp_commands.py             ← MCP-equivalent CLI flags (parity contract)
-└── codegraph_index_commands.py ← cache trio: autoindex / full-index / incremental-sync / metrics
+├── mcp_commands/               ← MCP-equivalent CLI flags (parity contract; package)
+└── codegraph_index_commands.py ← cache commands: autoindex / full-index / incremental-sync / metrics
 ```
 
 ## Flag → Tool Mapping
@@ -51,7 +51,7 @@ Categories of CLI surface:
 - `--query "(method_declaration) @m"` — raw tree-sitter query
 
 ### Project-Level
-- `--project-overview` — snapshot
+- `--overview` — snapshot
 - `--project-health` — health-score distribution
 - `--smart-context` / `smart-context FILE` — SMART workflow context
 - `--change-impact` — blast radius (`--change-impact-resource-profile local_low_impact` emits nice/xdist-capped local pytest commands plus the original CI command)
@@ -88,7 +88,7 @@ Categories of CLI surface:
 - `--call-path FROM TO` — BFS path between two functions
 - `--symbol-resolve` — go-to-definition / find-all-references
 - `--ast-path FILE:LINE` — "what is at file:line?"
-- `--codegraph-symbol-search QUERY` — FTS5 symbol search
+- `--symbol-search QUERY` — FTS5 symbol search
 - `--codegraph-explore QUERY` — bulk-fetch N related symbols + relmap (CodeGraph parity)
 - `--codegraph-query CHAIN` — jQuery-style chained graph query (`semantic('auth handler').has(callees=True, name='auth').uml(direction='TD').answer(compact=True)`)
 - `--codegraph-query-compact` — trim duplicate source payloads and empty relationship fields in chained query answers

--- a/docs/CODEMAPS/formatters.md
+++ b/docs/CODEMAPS/formatters.md
@@ -1,4 +1,4 @@
-<!-- Generated: 2026-05-30 -->
+<!-- Generated: 2026-05-30; doc-code re-sync: 2026-06-17 -->
 # Formatters Codemap
 
 Output formats supported by both CLI and MCP. Located in `tree_sitter_analyzer/formatters/`.
@@ -7,7 +7,7 @@ Output formats supported by both CLI and MCP. Located in `tree_sitter_analyzer/f
 
 | Format | Module | Default for | Use case |
 |---|---|---|---|
-| `toon` | `formatters/toon_formatter.py` | **MCP** | LLM agents — 73% smaller than JSON |
+| `toon` | `formatters/toon_formatter.py` (+ `formatters/toon_encoder.py` engine) | **MCP** | LLM agents — 50-70% fewer tokens than JSON (see `CLAUDE.md` §1; enforced by `tests/unit/mcp/test_output_cost_invariants.py`) |
 | `json` | `formatters/json_formatter.py` | **CLI** | `jq` piping, programmatic ingestion |
 | `table` | `formatters/table_formatter.py` (canonical, re-exports `LegacyTableFormatter`) + `tree_sitter_analyzer/default_table_formatter.py` + `legacy_table_formatter.py` | `--table` flag | Terminal viewing with box-drawing chars |
 | `csv` | via `tree_sitter_analyzer/_legacy_table_formatter_csv.py` | `--table csv` | Spreadsheet ingestion |
@@ -20,7 +20,7 @@ Output formats supported by both CLI and MCP. Located in `tree_sitter_analyzer/f
 
 | | TOON | JSON |
 |---|---|---|
-| Token cost | -73% | baseline |
+| Token cost | -50-70% | baseline |
 | Loss | none | none |
 | `jq` friendliness | no | yes |
 | Human readability | medium | high |
@@ -39,8 +39,8 @@ Interfaces live in `formatters/_formatter_interface.py` (no upward imports — b
 | `IFormatter` | `HtmlFormatter`, `JsonFormatter`, `CsvFormatter`, … | `format(elements)` → str |
 | `IStructureFormatter` | legacy adapters | `format_structure(dict)` → str |
 
-`formatter_registry.py` re-exports both for backward compat.
-`html_formatter.py` imports directly from `_formatter_interface.py` to avoid the
+`formatters/formatter_registry.py` re-exports both for backward compat.
+`formatters/html_formatter.py` imports directly from `formatters/_formatter_interface.py` to avoid the
 `formatter_registry ↔ html_formatter` import cycle (fixed 2026-05-30).
 
 ## Formatter Architecture
@@ -49,9 +49,16 @@ Each formatter inherits from `formatters/base_formatter.py`:
 
 ```python
 class BaseFormatter(ABC):
-    def format(self, result: AnalysisResult) -> str: ...
-    def _format_full(self, ...) -> str: ...
-    def _format_compact(self, ...) -> str: ...
+    def format(self, data: Any) -> str: ...
+    def format_summary(self, analysis_result: dict) -> str: ...
+    def format_structure(self, analysis_result: dict) -> str: ...
+    def format_advanced(self, ...) -> str: ...
+    def format_table(self, ...) -> str: ...
+
+class BaseTableFormatter(BaseFormatter):
+    # table-flavour helpers live here, not on BaseFormatter
+    def _format_full_table(self, ...) -> str: ...
+    def _format_compact_table(self, ...) -> str: ...
     def _format_csv(self, ...) -> str: ...
 ```
 
@@ -60,19 +67,19 @@ Per-language formatter mixins live alongside (`_java_formatter_*_mixin.py`,
 classes via Python's MRO.
 
 Key mixins for the Java formatter:
-- `_java_formatter_full_mixin.py` — `_format_full_table`
-- `_java_formatter_compact_mixin.py` — `_format_compact_table`
-- `_java_formatter_signatures_mixin.py` — `_format_signatures_table` (lightweight
+- `formatters/_java_formatter_full_mixin.py` — `_format_full_table`
+- `formatters/_java_formatter_compact_mixin.py` — `_format_compact_table`
+- `formatters/_java_formatter_signatures_mixin.py` — `_format_signatures_table` (lightweight
   method-directory; lists methods as `name →returnType(Np) L-L`, no bodies)
 
 Python formatter signatures module:
-- `_python_formatter_signatures_table.py` — `format_python_signatures_table`
+- `formatters/_python_formatter_signatures_table.py` — `format_python_signatures_table`
   (same lightweight directory shape as Java; groups methods by class + emits
   `<module functions>` block for top-level functions; used by
   `PythonTableFormatter._format_signatures_table` via `structure action=signatures`)
 
 TypeScript formatter signatures module:
-- `_typescript_formatter_signatures_table.py` — `format_typescript_signatures_table`
+- `formatters/_typescript_formatter_signatures_table.py` — `format_typescript_signatures_table`
   (lightweight directory for .ts/.tsx/.d.ts files; interfaces count as grouping
   containers; overloads each appear as separate lines; used by
   `TypeScriptTableFormatter._format_signatures_table` via `structure action=signatures`)
@@ -106,7 +113,8 @@ classes:
         line: 14
 ```
 
-Same data in JSON: ~30% more chars, ~73% more tokens for typical AST outputs.
+Same data in JSON costs noticeably more tokens for typical AST outputs (the
+50-70% TOON saving cited above; the exact ratio is pinned by `tests/unit/mcp/test_output_cost_invariants.py`).
 
 Serialization helpers: `formatters/toon_formatter.py:_emit_*` (extracted in r37dm dogfood).
 

--- a/docs/CODEMAPS/languages.md
+++ b/docs/CODEMAPS/languages.md
@@ -1,8 +1,17 @@
-<!-- Generated: 2026-05-24 -->
+<!-- Generated: 2026-05-24; doc-code re-sync: 2026-06-17 -->
 # Languages Codemap
 
 21 language plugins under `tree_sitter_analyzer/languages/` (16 single-file + 5 subdir packages).
 Each implements the `LanguagePlugin` interface (`tree_sitter_analyzer/plugins/base.py`).
+
+## Wiring tiers (canonical breakdown — see README "Supported Languages")
+
+Not every registered plugin is wired into the indexer to the same depth:
+
+- **13 fully wired** (full symbol + call graph): Python, Java, JavaScript, TypeScript, Go, Rust, C, C++, C#, Swift, Kotlin, Ruby, PHP
+- **2 symbol-indexed** (call-graph wiring pending): Bash, Scala — both graduated in v1.22.0
+- **5 data/markup** (reachable via the single-file CLI path): HTML, CSS, Markdown, SQL, YAML
+- **1 scaffold** (plugin exists, indexer wiring pending): JSON
 
 ## Supported Languages
 
@@ -11,7 +20,7 @@ Each implements the `LanguagePlugin` interface (`tree_sitter_analyzer/plugins/ba
 | Java | `languages/java_plugin.py` | `_java_*_helpers.py` ×4 | Spring/JPA awareness; **fixture file — DO NOT refactor** (see CLAUDE.md memory rule) |
 | Python | `python_plugin/` | submodules | Type annotations, decorators, async; module constants include chained and same-line assignments |
 | TypeScript | `typescript_plugin/` | submodules | Interfaces, types, TSX/JSX; enum kind/export parity and class-field decorators |
-| JavaScript | `javascript_plugin/` | submodules | ES6+, JSX; `_function_helpers.py` handles class-field arrow methods (is_method, is_static, computed/string/number key names — #890/#892); `queries/javascript.py` VARIABLES + "variable" query include `field_definition` (#891) |
+| JavaScript | `javascript_plugin/` | submodules | ES6+, JSX; `languages/javascript_plugin/_function_helpers.py` handles class-field arrow methods (is_method, is_static, computed/string/number key names — #890/#892); `queries/javascript.py` VARIABLES + "variable" query include `field_definition` (#891) |
 | C | `languages/c_plugin.py` | `_c_*_helpers.py` ×8 | functions, structs, unions, enums, preprocessor; unnamed bitfields are skipped as non-addressable fields |
 | C++ | `languages/cpp_plugin.py` | `_cpp_*_helpers.py` ×11 | classes, templates, namespaces; nested template/union type parent metadata and field-reference guards |
 | C# | `languages/csharp_plugin.py` | `languages/csharp_helpers.py` | records, async/await, attributes; block and file-scoped namespaces surface as packages |
@@ -24,7 +33,7 @@ Each implements the `LanguagePlugin` interface (`tree_sitter_analyzer/plugins/ba
 | PHP | `languages/php_plugin.py` | `languages/php_helpers.py` | PHP 8+ attributes, traits |
 | HTML | `languages/html_plugin.py` | `languages/html_helpers.py` | DOM elements with role classification |
 | CSS | `languages/css_plugin.py` | `languages/css_helpers.py` | selectors + properties |
-| SQL | `sql_plugin/` | submodules | tables, views, procedures, triggers; `table_extractor.py` regex fallback supports ANSI/MySQL/SQL-Server quoted identifiers and populates columns; CTAS (`AS SELECT`) guarded; case-sensitive dedup for quoted names (#880/#881); schema-qualified `CREATE FUNCTION` now extracted (#775); CTAS table name extracted instead of schema name (#808) |
+| SQL | `sql_plugin/` | submodules | tables, views, procedures, triggers; `languages/sql_plugin/table_extractor.py` regex fallback supports ANSI/MySQL/SQL-Server quoted identifiers and populates columns; CTAS (`AS SELECT`) guarded; case-sensitive dedup for quoted names (#880/#881); schema-qualified `CREATE FUNCTION` now extracted (#775); CTAS table name extracted instead of schema name (#808) |
 | YAML | `languages/yaml_plugin.py` | `languages/yaml_helpers.py` | anchors, aliases, multi-doc |
 | Markdown | `markdown_plugin/` | submodules | headings, code blocks, tables |
 | JSON | `languages/json_plugin.py` | inline | basic structure |
@@ -72,7 +81,7 @@ class LanguagePlugin(ABC):
 | `utils/tree_sitter_compat.py` | all plugins (handle tree-sitter API version differences) |
 | `language_loader.py` | dynamic import of `tree_sitter_<lang>` modules |
 | `language_detector.py` | extension → language mapping for unknown files |
-| `import_extractors.py` | shared import-row builders across languages |
+| `import_extractors/` | shared per-language import-row builders (top-level package: `import_extractors/_python.py`, `import_extractors/_java.py`, …) |
 
 ## See Also
 

--- a/docs/CODEMAPS/mcp-tools.md
+++ b/docs/CODEMAPS/mcp-tools.md
@@ -1,4 +1,4 @@
-<!-- Generated: 2026-05-22; Wave C2 facade cutover: 2026-06-02 -->
+<!-- Generated: 2026-05-22; Wave C2 facade cutover: 2026-06-02; doc-code re-sync: 2026-06-17 -->
 # MCP Tools Codemap
 
 **8 facade tools** registered in [`mcp/_tool_registry.py`](../../tree_sitter_analyzer/mcp/_tool_registry.py)
@@ -15,7 +15,7 @@ Response-envelope semantics (verdict alphabet, truncation fields, `compact_only`
 |---|---|---|
 | `search` | symbol / query / content / grep / batch / chain / select / subscribe / unsubscribe | Code search: BM25 symbol lookup, tree-sitter .scm DSL, ripgrep, fd+rg, batch, graph-chain DSL, Hyphae DSL, reactive push subscriptions (RFC-0001) |
 | `nav` | navigate / call_path / xref / resolve / lineage / impact / trace / context / callers / callees / callee_tree / caller_tree / test_map / co_change | Call-graph navigation + one-call symbol context; test_map = which tests exercise a function (RFC-0014 Phase B); co_change = git-history temporal coupling (RFC-0014 Phase C) |
-| `structure` | outline / analyze / ast_path / sitemap / class_tree / class_detail / explore / read | Structural AST analysis + partial file read |
+| `structure` | outline / analyze / ast_path / sitemap / class_tree / class_detail / explore / read / signatures | Structural AST analysis + partial file read + signature-only listing |
 | `health` | project / file / scale / patterns / heatmap / imports / matrix / dead / routes / overview / deps / test_gap | Code health, complexity, dependency analysis, untested symbol discovery |
 | `edit` | safe / guard / impact / refactor / constraints / pr / classify / ast_diff | Edit-safety, blast-radius, refactor, PR review |
 | `project` | overview / files / smart / parser / tools / metrics / skills / workflow / journal / doc_sync | Project-intelligence hub |
@@ -47,7 +47,7 @@ legacy MCP name is now reached via its facade (`old_name` →
 | `list_agent_skills` | `--list-skills` | Curated skill index for AI agents |
 | `get_agent_workflow` | `--smart-context` | SMART workflow (Set→Map→Analyze→Retrieve→Trace) |
 | `advise_parser_readiness` | `--parser-readiness` | Pre-flight check before parsing |
-| `get_project_overview` | `--project-overview` | One-screen project snapshot |
+| `get_project_overview` | `--overview` | One-screen project snapshot |
 | `build_project_index` | `--build-project-index` / `--build-project-index-roots` | Rebuild the persistent project index from scratch and save to disk |
 | `check_project_health` | `--project-health` | Health-score per file + grade distribution |
 | `check_file_health` | `--file-health` | One-file health score + actionable smells |
@@ -73,7 +73,7 @@ legacy MCP name is now reached via its facade (`old_name` →
 | `codegraph_navigate` | `--codegraph-navigate` | PRIMARY symbol navigation hub (def + refs + hierarchy) |
 | `codegraph_explore` | `--codegraph-explore` | BULK fetch N related symbols' source + relationship map |
 | `codegraph_query` | `--codegraph-query` | jQuery-style chained graph query with lexical `search()`, offline `semantic()`, filter/exclude/has selection, cached relationship expansion, Mermaid `uml()` facets, compact answer packs, and evidence facets |
-| `codegraph_symbol_search` | `--codegraph-symbol-search` | FTS5-powered symbol search over indexed project |
+| `codegraph_symbol_search` | `--symbol-search` | FTS5-powered symbol search over indexed project |
 | `codegraph_resolve` | `--symbol-resolve` | Go-to-definition / find-all-references |
 | `codegraph_ast_path` | `--ast-path` | "What is at file:line?" AST path/scope |
 | **CodeGraph parity — call graph** | | |
@@ -144,7 +144,7 @@ All tools return:
 
 | File | Purpose |
 |---|---|
-| `mcp/utils/project_index.py` | Persistent project structure snapshot |
+| `mcp/utils/project_index/` | Persistent project structure snapshot |
 | `mcp/utils/search_cache.py` | LRU cache for fd/ripgrep results |
 | `mcp/utils/file_output_factory.py` | Atomic file output for large payloads |
 | `mcp/utils/error_handler.py` | Typed error envelopes |

--- a/docs/CODEMAPS/security.md
+++ b/docs/CODEMAPS/security.md
@@ -1,4 +1,4 @@
-<!-- Generated: 2026-05-22 -->
+<!-- Generated: 2026-05-22; doc-code re-sync: 2026-06-17 -->
 # Security Codemap
 
 Security boundary enforcement for both CLI and MCP. Located in `tree_sitter_analyzer/security/`.
@@ -8,22 +8,26 @@ Security boundary enforcement for both CLI and MCP. Located in `tree_sitter_anal
 | File | Responsibility |
 |---|---|
 | `security/validator.py` | `SecurityValidator` — path validation, **god class — high-risk to touch** |
-| `security/boundary_manager.py` | `BoundaryManager` — root resolution & boundary checks |
-| `mcp/utils/path_resolver.py` | Canonicalize paths consistently across macOS/Windows |
-| `security/regex_checker.py` | Block regex DoS (ReDoS) patterns in user-supplied regex |
+| `security/boundary_manager.py` | `ProjectBoundaryManager` — root resolution & boundary checks |
+| `security/regex_checker.py` | `RegexSafetyChecker` — block regex DoS (ReDoS) patterns in user-supplied regex |
+| `security/fixture_detector.py` | `is_fixture` / `fixture_to_verdict` / `list_fixtures` — cached test-fixture detection; powers the fixture-based verdict escalation in `edit action=safe` |
+| `mcp/utils/path_resolver.py` | `PathResolver` — canonicalize paths consistently across macOS/Windows |
 
 ## Boundary Contract
 
 > **Every tool — MCP and CLI — must operate strictly within `TREE_SITTER_PROJECT_ROOT`.**
 
-`BoundaryManager.is_within_project_root(path)`:
-- Resolves `path` to absolute form
-- Compares against `project_root` using `os.path.abspath` (NOT `realpath`)
-- Returns `False` for anything outside; tools then return `status=error` with `reason`
+`ProjectBoundaryManager.is_within_project(path)` / `validate_and_resolve_path(path)`:
+- Resolves `path` via `Path.resolve()` (realpath semantics — symlinks ARE resolved)
+- Compares the resolved path against the resolved `project_root`
+- Returns `False` / `None` for anything outside; tools then return `status=error` with `reason`
 
-**Why `abspath` not `realpath`**: on macOS, `/var/folders/...` symlinks to
-`/private/var/folders/...`. `realpath()` resolves the symlink and breaks 164+ test fixtures.
-This is a **locked design decision** — see `CLAUDE.md` § "project_root canonicalisation".
+**macOS symlink caveat (locked)**: `/var/folders/...` symlinks to `/private/var/folders/...`.
+Because the boundary manager resolves via `realpath`, `project_root` and candidate paths must be
+resolved the **same** way or fixtures diverge. The locked decision is therefore *do not naively
+re-canonicalise `project_root` inside `BaseMCPTool.__init__`* — `SecurityValidator`, `PathResolver`,
+and the test fixtures already agree on a resolution, and r36's attempt to add one broke 164 tests on
+macOS. See `CLAUDE.md` § "project_root canonicalisation".
 
 ## Threat Model
 
@@ -31,8 +35,8 @@ The server is intended to be run by **trusted users on their own machines**, but
 
 | Threat | Mitigation |
 |---|---|
-| Path traversal via crafted file_path | `BoundaryManager.is_within_project_root` |
-| ReDoS via crafted regex | `RegexChecker` rejects exponential-blowup patterns |
+| Path traversal via crafted file_path | `ProjectBoundaryManager.validate_and_resolve_path` |
+| ReDoS via crafted regex | `RegexSafetyChecker` rejects exponential-blowup patterns |
 | Arbitrary command execution | No `shell=True`, all subprocess invocations use list form |
 | Reading sensitive files (`.env`, `.ssh`) | Boundary check + `.gitignore` aware |
 | SQL injection in `_route_cache.py` | Parameterised queries (validated in r37d3) |
@@ -43,12 +47,12 @@ The server is intended to be run by **trusted users on their own machines**, but
 All boundary checks happen at MCP/CLI entry:
 
 1. `mcp/tools/base_tool.py:BaseMCPTool.__init__` — receives `project_root`, builds
-   `BoundaryManager` lazily.
+   `ProjectBoundaryManager` lazily.
 2. `cli/commands/base_command.py` — same project_root resolution.
 3. Per-tool `execute()` validates `file_path` against the boundary before any IO.
 
-Adding a new tool that touches files? **Always call `self._security.is_within_project_root(path)`
-before `open()`.** Tests in `tests/unit/security/test_security_boundary_properties.py` are
+Adding a new tool that touches files? **Always validate via `SecurityValidator.validate_file_path(path)`
+(or `ProjectBoundaryManager.validate_and_resolve_path(path)`) before `open()`.** Tests in `tests/unit/security/test_security_boundary_properties.py` are
 property-based (Hypothesis) — they fuzz paths to catch missed validations.
 
 ## Critical Files — Solo Commits Only


### PR DESCRIPTION
## Goal
Align `docs/CODEMAPS/*` with the current code. Method: spawned read-only audit agents, one per codemap, each comparing the doc against ground truth (tool registry, argument parser, plugin entry-points, source tree); the lead verified every finding (rejecting 1 agent false-positive) and applied the fixes. The project's own `--doc-sync` stale-reference scan on the codemaps now reports **0 stale** (was 15).

## Verified drift corrected

**mcp-tools.md** — `structure` facade was missing the `signatures` action (now 9/9, confirmed via `FacadeTool._available_actions()`); stale flags `--project-overview`→`--overview`, `--codegraph-symbol-search`→`--symbol-search` (neither old flag exists in the parser).

**cli.md** — same two stale flags; `mcp_commands.py`→`mcp_commands/` (package); "cache trio"→"cache commands" (4 items). Flag count 295 confirmed correct.

**security.md** — `BoundaryManager`→`ProjectBoundaryManager`, `RegexChecker`→`RegexSafetyChecker`; added `fixture_detector.py` (largest module, powers the `edit action=safe` fixture escalation); `is_within_project_root()` (doesn't exist)→real methods; **corrected an inverted abspath/realpath claim** — code resolves via `Path.resolve()` (realpath semantics); the locked decision is "don't re-canonicalise `project_root` in `BaseMCPTool`" (r36 broke 164 tests), now matching CLAUDE.md.

**formatters.md** — `BaseFormatter.format(self, result: AnalysisResult)`→`format(self, data: Any)`; `_format_full`/`_format_compact` (don't exist)→`_format_full_table`/`_format_compact_table` on `BaseTableFormatter`; reconciled the unverified TOON "73% smaller" to the locked **50-70%** (CLAUDE.md §1/§11) + cited the enforcing invariant test.

**architecture.md** — added omitted top-level subsystems (`models/`, `import_extractors/`, `synapse_resolver/`, `graph/`, `constraints/`, `hyphae/`, `skills/`); fixed entry points (dropped non-existent `tree-sitter-analyzer-cli` console script — `api.py` is an embeddable library; added `miswire-audit`/`list-files`/`search-content`); same `ProjectBoundaryManager` + TOON + abspath/realpath corrections.

**languages.md** — added the canonical 4-tier wiring breakdown (13 fully-wired + 2 symbol-indexed + 5 data/markup + 1 scaffold) matching README; `import_extractors.py`→the package.

Plus: every bare-filename backtick reference now uses a resolvable path so `--doc-sync` resolves it (15→0 stale).

## Verification
- `--doc-sync --doc-sync-patterns "docs/CODEMAPS/*.md"` → 0 stale references.
- Doc test suite (`test_doc_sync`, `tests/integration/docs/`, `test_agent_contracts`) → 107 passed, 5 skipped.
- pre-commit green incl. `tsa-codemap-sync`. Doc-only change; no code touched.

## Rejected (verified false) audit findings
- `mcp/utils/path_resolver.py` "missing" — it **exists**; kept.