### PR TITLE
fix(heatmap): coerce string max_files in project mode (MCP int/str crash)

### DIFF
--- a/tests/unit/test_complexity_heatmap.py
+++ b/tests/unit/test_complexity_heatmap.py
@@ -226,6 +226,24 @@ class TestComplexityHeatmapTool:
         assert result["verdict"] in ("INFO", "REVIEW")
 
     @pytest.mark.asyncio
+    async def test_project_mode_string_max_files(self, complex_project):
+        """Project mode must coerce a string ``max_files`` to int.
+
+        The MCP boundary can deliver numeric params as strings (e.g.
+        ``"200"``). Before the coercion fix, ``_collect_source_files`` did
+        ``len(results) >= max_files`` and raised
+        ``TypeError: '>=' not supported between instances of 'int' and 'str'``.
+        The string path must behave identically to the int path.
+        """
+        tool = self._make_tool(complex_project)
+        result = await tool.execute(
+            {"mode": "project", "output_format": "json", "max_files": "200"}
+        )
+        assert result["success"] is True
+        assert result["mode"] == "project"
+        assert result["total_functions"] == 6
+
+    @pytest.mark.asyncio
     async def test_file_mode(self, complex_project):
         tool = self._make_tool(complex_project)
         result = await tool.execute(

--- a/tree_sitter_analyzer/mcp/tools/complexity_heatmap_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/complexity_heatmap_tool.py
@@ -156,7 +156,10 @@ class CodeGraphComplexityHeatmapTool(BaseMCPTool):
         assert self.project_root is not None, "project_root required"
         language = arguments.get("language")
         directory = arguments.get("directory")
-        max_files = arguments.get("max_files", 200)
+        # The MCP boundary can deliver numeric params as strings (e.g. "200").
+        # Coerce so ``len(results) >= max_files`` in _collect_source_files never
+        # hits ``int >= str`` (matches the int() pattern in _call_tree_tool).
+        max_files = int(arguments.get("max_files", 200))
         cache = self._get_cache()
 
         heatmap = analyze_project_heatmap(


### PR DESCRIPTION
## Summary

`health action=heatmap mode=project` (the project-wide per-function cyclomatic-complexity ranking) crashed with:

```
TypeError: '>=' not supported between instances of 'int' and 'str'
```

when `max_files` arrived as a **string** (e.g. `"200"`) through the MCP boundary. `_collect_source_files` does `len(results) >= max_files`; the tool read `arguments.get("max_files", 200)` without coercion, unlike sibling tools (`_call_tree_tool` uses `int(...)`). This made the documented purpose of `heatmap mode=project` — ranking functions by complexity across a project — **unusable from real MCP clients**.

## How it was found

Dogfooding TSA's Java support on an external project (TheAlgorithms/Java): tried to get a project-wide method-complexity ranking via `health action=heatmap mode=project` and hit the crash. `facade.execute(... max_files=200)` (int) passed; the real MCP path (string) failed — a classic int/str boundary bug.

## Fix

`int()` the value at the read site in `_execute_project` (matches the established `int(arguments.get(...))` pattern in `_call_tree_tool`).

## Test (RED-first)

`test_project_mode_string_max_files` passes `max_files="200"` and pins the string path to the same result as the int path (`total_functions == 6`, exact). RED before the fix (reproduced the TypeError), GREEN after.

## Verification

- 27/27 heatmap tests pass; 654 heatmap+facade+health+contract tests pass, 0 fail.
- End-to-end on TheAlgorithms/Java: `mode=project max_files="200"` now returns 1025 functions across 200 files with a ranked `top_hotspots` list.

## Scope note

A quick scan found ~10 sibling tools reading `max_files`/`max_depth` via `arguments.get(...)` without `int()` — the same latent crash class. Left out of this focused fix; flagged for a separate audit-and-fix pass (each needs its own RED test to confirm reachability).