### PR TITLE
fix(heatmap): extend complexity heatmap to all plugin languages

### DIFF
--- a/tests/unit/test_complexity_heatmap.py
+++ b/tests/unit/test_complexity_heatmap.py
@@ -424,3 +424,106 @@ class TestComplexityCLI:
         assert data["mode"] == "function"
         assert data["name"] == "deeply_nested"
         assert data["complexity"] == 8
+
+
+# ---------------------------------------------------------------------------
+# Tests for languages NOT in the hardcoded _METHOD_NODES map (C#, Ruby, …).
+# These exercise the plugin-fallback path added to fix the silent-empty bug.
+# Exact integer counts are pinned per the "exact assertions only" rule.
+# ---------------------------------------------------------------------------
+
+_CSHARP_FIXTURE = """\
+public class Calculator {
+    public int Add(int a, int b) {
+        if (a < 0) return 0;
+        return a + b;
+    }
+    public int Sub(int a, int b) {
+        return a - b;
+    }
+}
+"""
+
+_RUBY_FIXTURE = """\
+def greet(name)
+  if name.nil?
+    "Hello stranger"
+  else
+    "Hello #{name}"
+  end
+end
+
+def add(a, b)
+  a + b
+end
+"""
+
+
+@pytest.fixture()
+def csharp_project(tmp_path):
+    project = tmp_path / "csproject"
+    project.mkdir()
+    (project / "Calculator.cs").write_text(_CSHARP_FIXTURE)
+    return project
+
+
+@pytest.fixture()
+def ruby_project(tmp_path):
+    project = tmp_path / "rbproject"
+    project.mkdir()
+    (project / "helpers.rb").write_text(_RUBY_FIXTURE)
+    return project
+
+
+class TestPluginFallbackLanguages:
+    """Verify that languages absent from _METHOD_NODES get correct results
+    via the plugin-sync fallback rather than a silent empty list."""
+
+    def test_csharp_file_complexity(self, csharp_project):
+        from tree_sitter_analyzer.complexity_heatmap import analyze_file_complexity
+
+        funcs = analyze_file_complexity(str(csharp_project / "Calculator.cs"), "csharp")
+        # C# fixture has exactly 2 methods: Add (complexity 2) and Sub (complexity 1)
+        assert len(funcs) == 2
+        names = {f.name for f in funcs}
+        assert names == {"Add", "Sub"}
+        add_func = next(f for f in funcs if f.name == "Add")
+        assert add_func.complexity == 2
+
+    def test_ruby_file_complexity(self, ruby_project):
+        from tree_sitter_analyzer.complexity_heatmap import analyze_file_complexity
+
+        funcs = analyze_file_complexity(str(ruby_project / "helpers.rb"), "ruby")
+        # Ruby fixture has exactly 2 methods
+        assert len(funcs) == 2
+        names = {f.name for f in funcs}
+        assert names == {"greet", "add"}
+
+    def test_csharp_project_heatmap(self, csharp_project):
+        from tree_sitter_analyzer.complexity_heatmap import analyze_project_heatmap
+
+        heatmap = analyze_project_heatmap(str(csharp_project))
+        # 1 .cs file containing 2 methods
+        assert heatmap["total_files_analyzed"] == 1
+        assert heatmap["total_functions"] == 2
+
+    def test_ruby_project_heatmap(self, ruby_project):
+        from tree_sitter_analyzer.complexity_heatmap import analyze_project_heatmap
+
+        heatmap = analyze_project_heatmap(str(ruby_project))
+        # 1 .rb file containing 2 methods
+        assert heatmap["total_files_analyzed"] == 1
+        assert heatmap["total_functions"] == 2
+
+    def test_empty_project_warns(self, tmp_path):
+        """When a project yields 0 functions, result must carry a note/warning."""
+        from tree_sitter_analyzer.complexity_heatmap import analyze_project_heatmap
+
+        empty_project = tmp_path / "emptyproj"
+        empty_project.mkdir()
+        # A .cs file with no methods (just a using statement)
+        (empty_project / "Empty.cs").write_text("using System;\n")
+        heatmap = analyze_project_heatmap(str(empty_project))
+        assert heatmap["total_functions"] == 0
+        # Must NOT be silently clean — must carry a warning/note field
+        assert "note" in heatmap or "warning" in heatmap

--- a/tree_sitter_analyzer/complexity_heatmap.py
+++ b/tree_sitter_analyzer/complexity_heatmap.py
@@ -279,9 +279,17 @@ def _extract_functions(
     tree: Any, source: str, language: str, file_path: str
 ) -> list[FunctionComplexity]:
     method_nodes = _METHOD_NODES.get(language, set())
-    if not method_nodes:
-        return []
+    if method_nodes:
+        return _extract_functions_from_ast(
+            tree, source, language, file_path, method_nodes
+        )
+    return _extract_functions_via_plugin(tree, source, language, file_path)
 
+
+def _extract_functions_from_ast(
+    tree: Any, source: str, language: str, file_path: str, method_nodes: set[str]
+) -> list[FunctionComplexity]:
+    """Original AST-walk path used for the 8 hardcoded languages."""
     results: list[FunctionComplexity] = []
     stack = [tree.root_node]
 
@@ -304,6 +312,51 @@ def _extract_functions(
             )
         stack.extend(node.children)
 
+    return results
+
+
+def _extract_functions_via_plugin(
+    tree: Any, source: str, language: str, file_path: str
+) -> list[FunctionComplexity]:
+    """Fallback path for languages not in _METHOD_NODES.
+
+    Uses the language plugin's synchronous extract_functions() which already
+    computes complexity_score for all 13 supported languages.
+    """
+    try:
+        from .plugins.manager import PluginManager
+
+        pm = PluginManager()
+        plugin = pm.get_plugin(language)
+        if plugin is None:
+            logger.debug(
+                "No plugin available for language %r — skipping %s", language, file_path
+            )
+            return []
+
+        extractor = plugin.create_extractor()
+        elements = extractor.extract_functions(tree, source)
+    except Exception as exc:
+        logger.debug(
+            "Plugin extraction failed for %s (%s): %s", file_path, language, exc
+        )
+        return []
+
+    results: list[FunctionComplexity] = []
+    for elem in elements:
+        results.append(
+            FunctionComplexity(
+                name=elem.name or "<anonymous>",
+                file=file_path,
+                line=elem.start_line,
+                end_line=elem.end_line,
+                complexity=max(getattr(elem, "complexity_score", 1), 1),
+                language=language,
+                class_name=getattr(elem, "receiver_type", None)
+                or getattr(elem, "parent_class", None),
+                decision_points={},
+            )
+        )
     return results
 
 
@@ -416,7 +469,7 @@ def analyze_project_heatmap(
     total_funcs = len(all_functions)
     project_avg = round(total_cc / total_funcs, 2) if total_funcs else 0.0
 
-    return {
+    result: dict[str, Any] = {
         "project_root": project_root,
         "total_files_analyzed": len(file_heatmaps),
         "total_functions": total_funcs,
@@ -459,6 +512,12 @@ def analyze_project_heatmap(
             for fh in file_heatmaps
         ],
     }
+    if total_funcs == 0:
+        result["note"] = (
+            "No functions extracted. The project may contain only languages "
+            "without parser support, or all files may be empty."
+        )
+    return result
 
 
 def _collect_source_files(


### PR DESCRIPTION
## Summary

- **Root cause**: `_extract_functions` in `complexity_heatmap.py` fell back to `[]` when `language` was absent from the hardcoded `_METHOD_NODES` map (only 8 languages). C#, Kotlin, Ruby, PHP, and Swift all hit this path, causing `analyze_project_heatmap` to report `total_files_analyzed: 0` with `success: true` — a silent false-success on real projects.
- **Fix**: Added a plugin-sync fallback path `_extract_functions_via_plugin` that calls `PluginManager().get_plugin(language).create_extractor().extract_functions(tree, source)` and maps `Function.complexity_score` → `FunctionComplexity`. The original AST-walk path is unchanged for the 8 hardcoded languages.
- **Honesty fix**: `analyze_project_heatmap` now appends a `"note"` field when `total_functions == 0` so callers receive an explicit signal instead of a clean-but-empty result.

## Test plan

- [ ] All 5 new tests in `TestPluginFallbackLanguages` are RED before the fix and GREEN after (verified locally)
- [ ] All 26 pre-existing tests in `test_complexity_heatmap.py` still pass (31 total, 0 failures)
- [ ] Exact integer assertions: C# fixture → `total_files_analyzed == 1`, `total_functions == 2`, `Add.complexity == 2`; Ruby fixture → `total_files_analyzed == 1`, `total_functions == 2`
- [ ] `test_empty_project_warns` verifies `"note"` key present when 0 functions found
- [ ] Pre-commit hooks passed: ruff, mypy, bandit, codemap-sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)