### PR TITLE
fix(go): correct parameter name/type swap and raw-dict signature leak

### DIFF
--- a/tests/golden_masters/csv/go_sample_csv.csv
+++ b/tests/golden_masters/csv/go_sample_csv.csv
@@ -21,23 +21,23 @@ Field,workers,workers:int,private,207-207,,-
 Field,jobs,jobs:chan func(),private,208-208,,-
 Field,wg,wg:sync.WaitGroup,private,209-209,,-
 Field,lastErr,lastErr:error,private,281-281,,-
-Method,Read,"([]byte:p):(n int, err error)",public,55-55,1,-
-Method,Write,"([]byte:p):(n int, err error)",public,61-61,1,-
-Method,NewService,"(string:name, *Config:config):*Service",public,80-86,1,-
+Method,Read,"(p:[]byte):(n int, err error)",public,55-55,1,-
+Method,Write,"(p:[]byte):(n int, err error)",public,61-61,1,-
+Method,NewService,"(name:string, config:*Config):*Service",public,80-86,1,-
 Method,Name,():string,public,89-91,1,-
 Method,IsRunning,():bool,public,94-98,1,-
-Method,Start,(context.Context:ctx):error,public,101-114,1,-
-Method,run,(context.Context:ctx):,private,117-132,1,-
-Method,tick,(time.Time:t):,private,135-139,1,-
+Method,Start,(ctx:context.Context):error,public,101-114,1,-
+Method,run,(ctx:context.Context):,private,117-132,1,-
+Method,tick,(t:time.Time):,private,135-139,1,-
 Method,Stop,():error,public,142-153,1,-
 Method,stop,():,private,156-160,1,-
-Method,ProcessData,"(context.Context:ctx, []byte:input <-chan):(<-chan []byte, <-chan error)",public,163-193,1,-
-Method,process,([]byte:data):[]byte,private,196-203,1,-
-Method,NewWorkerPool,(int:workers):*WorkerPool,public,213-218,1,-
+Method,ProcessData,"(ctx:context.Context, input:<-chan []byte):(<-chan []byte, <-chan error)",public,163-193,1,-
+Method,process,(data:[]byte):[]byte,private,196-203,1,-
+Method,NewWorkerPool,(workers:int):*WorkerPool,public,213-218,1,-
 Method,Start,():,public,221-226,1,-
 Method,worker,():,private,229-234,1,-
-Method,Submit,(func():job):,public,237-239,1,-
+Method,Submit,(job:func()):,public,237-239,1,-
 Method,Shutdown,():,public,242-245,1,-
-Method,Chain,(...Middleware:middlewares):Middleware,public,257-264,1,-
-Method,WithTimeout,(time.Duration:timeout):Middleware,public,267-275,1,-
-Method,WithRetry,(int:maxRetries):Middleware,public,278-293,1,-
+Method,Chain,(middlewares:...Middleware):Middleware,public,257-264,1,-
+Method,WithTimeout,(timeout:time.Duration):Middleware,public,267-275,1,-
+Method,WithRetry,(maxRetries:int):Middleware,public,278-293,1,-

--- a/tests/golden_masters/full/go_sample_full.md
+++ b/tests/golden_masters/full/go_sample_full.md
@@ -42,26 +42,26 @@ import ""time""
 ## Functions
 | Func | Signature | Vis | Lines | Doc |
 |------|-----------|-----|-------|-----|
-| Read | ({'name': '[]byte', 'type': 'p'}) (n int, err error) | exported | 55-55 | - |
-| Write | ({'name': '[]byte', 'type': 'p'}) (n int, err error) | exported | 61-61 | - |
-| NewService | ({'name': 'string', 'type': 'name'}, {'name': '*Config', 'type': 'config'}) *Service | exported | 80-86 | - |
+| Read | (p []byte) (n int, err error) | exported | 55-55 | - |
+| Write | (p []byte) (n int, err error) | exported | 61-61 | - |
+| NewService | (name string, config *Config) *Service | exported | 80-86 | - |
 | Name | () string | exported | 89-91 | - |
 | IsRunning | () bool | exported | 94-98 | - |
-| Start | ({'name': 'context.Context', 'type': 'ctx'}) error | exported | 101-114 | - |
-| run | ({'name': 'context.Context', 'type': 'ctx'}) | unexported | 117-132 | - |
-| tick | ({'name': 'time.Time', 'type': 't'}) | unexported | 135-139 | - |
+| Start | (ctx context.Context) error | exported | 101-114 | - |
+| run | (ctx context.Context) | unexported | 117-132 | - |
+| tick | (t time.Time) | unexported | 135-139 | - |
 | Stop | () error | exported | 142-153 | - |
 | stop | () | unexported | 156-160 | - |
-| ProcessData | ({'name': 'context.Context', 'type': 'ctx'}, {'name': '[]byte', 'type': 'input <-chan'}) (<-chan []byte, <-chan error) | exported | 163-193 | - |
-| process | ({'name': '[]byte', 'type': 'data'}) []byte | unexported | 196-203 | - |
-| NewWorkerPool | ({'name': 'int', 'type': 'workers'}) *WorkerPool | exported | 213-218 | - |
+| ProcessData | (ctx context.Context, input <-chan []byte) (<-chan []byte, <-chan error) | exported | 163-193 | - |
+| process | (data []byte) []byte | unexported | 196-203 | - |
+| NewWorkerPool | (workers int) *WorkerPool | exported | 213-218 | - |
 | Start | () | exported | 221-226 | - |
 | worker | () | unexported | 229-234 | - |
-| Submit | ({'name': 'func()', 'type': 'job'}) | exported | 237-239 | - |
+| Submit | (job func()) | exported | 237-239 | - |
 | Shutdown | () | exported | 242-245 | - |
-| Chain | ({'name': '...Middleware', 'type': 'middlewares'}) Middleware | exported | 257-264 | - |
-| WithTimeout | ({'name': 'time.Duration', 'type': 'timeout'}) Middleware | exported | 267-275 | - |
-| WithRetry | ({'name': 'int', 'type': 'maxRetries'}) Middleware | exported | 278-293 | - |
+| Chain | (middlewares ...Middleware) Middleware | exported | 257-264 | - |
+| WithTimeout | (timeout time.Duration) Middleware | exported | 267-275 | - |
+| WithRetry | (maxRetries int) Middleware | exported | 278-293 | - |
 
 ## Variables
 | Name | Type | Vis | Line |

--- a/tests/unit/languages/test_go_param_name_type_swap.py
+++ b/tests/unit/languages/test_go_param_name_type_swap.py
@@ -1,0 +1,236 @@
+"""Regression tests for Go parameter name/type swap bug.
+
+Two defects (confirmed by reproduce command):
+1. process_parameters("go") routes through _process_type_prefix_parameter
+   which assumes type-before-name (Java style). Go is name-before-type,
+   so "n int64" produces name="int64", type="n" (SWAPPED).
+2. GoTableFormatter._create_go_signature does str(p) on each param dict,
+   leaking {'name': 'int64', 'type': 'n'} into the rendered signature.
+
+Reproduce:
+  uv run python -m tree_sitter_analyzer /tmp/oss-go/Go/math/eulertotient.go
+      --advanced --table full
+  Source: func Phi(n int64) int64
+  Bad:    | Phi | ({'name': 'int64', 'type': 'n'}) int64 | ...
+  Good:   | Phi | (n int64) int64 | ...
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tree_sitter_analyzer.cli.commands.table_command_helpers import process_parameters
+from tree_sitter_analyzer.formatters.go_formatter import GoTableFormatter
+
+# ---------------------------------------------------------------------------
+# Defect 1: process_parameters for Go language
+# ---------------------------------------------------------------------------
+
+
+class TestProcessParametersGo:
+    """Go params are name-before-type: 'n int64' → name='n', type='int64'."""
+
+    def test_single_param_name_before_type(self):
+        """'n int64' must parse as name='n', type='int64', not swapped."""
+        result = process_parameters(["n int64"], "go")
+        assert len(result) == 1
+        assert result[0]["name"] == "n"
+        assert result[0]["type"] == "int64"
+
+    def test_single_param_plain_int(self):
+        """'n int' must parse as name='n', type='int'."""
+        result = process_parameters(["n int"], "go")
+        assert len(result) == 1
+        assert result[0]["name"] == "n"
+        assert result[0]["type"] == "int"
+
+    def test_two_params_same_type(self):
+        """'n int, k int' — each individually parsed."""
+        result = process_parameters(["n int", "k int"], "go")
+        assert len(result) == 2
+        assert result[0]["name"] == "n"
+        assert result[0]["type"] == "int"
+        assert result[1]["name"] == "k"
+        assert result[1]["type"] == "int"
+
+    def test_multi_word_type(self):
+        """Pointer receiver type: 'p []byte' → name='p', type='[]byte'."""
+        result = process_parameters(["p []byte"], "go")
+        assert len(result) == 1
+        assert result[0]["name"] == "p"
+        assert result[0]["type"] == "[]byte"
+
+    def test_pointer_param(self):
+        """'config *Config' → name='config', type='*Config'."""
+        result = process_parameters(["config *Config"], "go")
+        assert len(result) == 1
+        assert result[0]["name"] == "config"
+        assert result[0]["type"] == "*Config"
+
+    def test_variadic_param(self):
+        """'numbers ...int' → name='numbers', type='...int'."""
+        result = process_parameters(["numbers ...int"], "go")
+        assert len(result) == 1
+        assert result[0]["name"] == "numbers"
+        assert result[0]["type"] == "...int"
+
+    def test_empty_list(self):
+        """Empty param list returns empty list."""
+        result = process_parameters([], "go")
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Defect 2: GoTableFormatter._create_go_signature renders correctly
+# ---------------------------------------------------------------------------
+
+
+class TestGoSignatureRendering:
+    """Signature must show 'n int64', never the raw dict repr."""
+
+    def _func_dict(self, params: list[dict], return_type: str = "") -> dict:
+        return {
+            "name": "Phi",
+            "parameters": params,
+            "return_type": return_type,
+            "line_range": {"start": 1, "end": 3},
+            "docstring": "",
+            "is_method": False,
+        }
+
+    def test_single_param_renders_correctly(self):
+        """(n int64) int64 — no raw dict repr in output."""
+        formatter = GoTableFormatter("full")
+        params = [{"name": "n", "type": "int64"}]
+        func = self._func_dict(params, "int64")
+        sig = formatter._create_go_signature(func)
+        # Correct: shows "n int64"
+        assert "n int64" in sig
+        # Never leaks raw dict
+        assert "{'name'" not in sig
+        assert '{"name"' not in sig
+
+    def test_two_params_render_correctly(self):
+        """(n int, k int) — two params rendered without dict repr."""
+        formatter = GoTableFormatter("full")
+        params = [{"name": "n", "type": "int"}, {"name": "k", "type": "int"}]
+        func = self._func_dict(params, "")
+        sig = formatter._create_go_signature(func)
+        assert "n int" in sig
+        assert "k int" in sig
+        assert "{'name'" not in sig
+
+    def test_return_type_appended(self):
+        """Return type is appended after the param list."""
+        formatter = GoTableFormatter("full")
+        params = [{"name": "n", "type": "int64"}]
+        func = self._func_dict(params, "int64")
+        sig = formatter._create_go_signature(func)
+        # Should end with ) int64
+        assert sig.endswith(") int64")
+
+    def test_multi_return_type(self):
+        """(int, error) return type is preserved."""
+        formatter = GoTableFormatter("full")
+        params = [{"name": "n", "type": "int"}, {"name": "k", "type": "int"}]
+        func = self._func_dict(params, "(int, error)")
+        sig = formatter._create_go_signature(func)
+        assert "(int, error)" in sig
+        assert "{'name'" not in sig
+
+    def test_no_params(self):
+        """() — zero-param function renders clean parens."""
+        formatter = GoTableFormatter("full")
+        func = self._func_dict([], "string")
+        sig = formatter._create_go_signature(func)
+        assert sig == "() string"
+
+
+# ---------------------------------------------------------------------------
+# Defect 1+2 combined: end-to-end via real Go plugin
+# ---------------------------------------------------------------------------
+
+
+class TestGoParamExtractionEndToEnd:
+    """Parse a real Go snippet; verify the params and signature are correct."""
+
+    @pytest.fixture
+    def phi_fixture(self, tmp_path):
+        """Write a minimal Go fixture with func Phi(n int64) int64."""
+        go_src = tmp_path / "phi.go"
+        go_src.write_text("package math\n\nfunc Phi(n int64) int64 {\n\treturn n\n}\n")
+        return str(go_src)
+
+    @pytest.fixture
+    def combinations_fixture(self, tmp_path):
+        """Write a minimal Go fixture with func Combinations(n int, k int) (int, error)."""
+        go_src = tmp_path / "combo.go"
+        go_src.write_text(
+            "package math\n\n"
+            "func Combinations(n int, k int) (int, error) {\n\treturn 0, nil\n}\n"
+        )
+        return str(go_src)
+
+    def _extract_functions(self, file_path: str) -> list:
+        """Run the Go plugin against a file and return Function elements."""
+        import tree_sitter
+        import tree_sitter_go
+
+        from tree_sitter_analyzer.languages.go_plugin import GoElementExtractor
+
+        source = open(file_path, "rb").read()
+        lang = tree_sitter.Language(tree_sitter_go.language())
+        parser = tree_sitter.Parser(lang)
+        tree = parser.parse(source)
+        extractor = GoElementExtractor()
+        extractor._get_node_text = lambda node: source[
+            node.start_byte : node.end_byte
+        ].decode("utf-8")
+        extractor._content_lines = source.decode("utf-8").splitlines()
+        return extractor.extract_functions(tree, source.decode("utf-8"))
+
+    def test_phi_param_extraction(self, phi_fixture):
+        """func Phi(n int64) int64 — extracted params must have name='n', type='int64'."""
+        functions = self._extract_functions(phi_fixture)
+        phi = next((f for f in functions if f.name == "Phi"), None)
+        assert phi is not None, "Phi function not extracted"
+        # parameters is list[str] at extraction time: ["n int64"]
+        assert phi.parameters == ["n int64"]
+
+    def test_combinations_param_extraction(self, combinations_fixture):
+        """func Combinations(n int, k int) — params extracted as strings."""
+        functions = self._extract_functions(combinations_fixture)
+        combo = next((f for f in functions if f.name == "Combinations"), None)
+        assert combo is not None, "Combinations function not extracted"
+        assert combo.parameters == ["n int", "k int"]
+
+    def test_phi_signature_in_table(self, phi_fixture):
+        """GoTableFormatter must render (n int64) int64, not raw dicts."""
+        functions = self._extract_functions(phi_fixture)
+        phi = next((f for f in functions if f.name == "Phi"), None)
+        assert phi is not None
+
+        # Simulate what TableCommand._convert_function_element does:
+        from tree_sitter_analyzer.cli.commands.table_command_helpers import (
+            process_parameters,
+        )
+
+        params = phi.parameters  # list[str] = ["n int64"]
+        processed = process_parameters(params, "go")
+        assert processed[0]["name"] == "n"
+        assert processed[0]["type"] == "int64"
+
+        # Now render via the formatter
+        formatter = GoTableFormatter("full")
+        func_dict = {
+            "name": phi.name,
+            "parameters": processed,
+            "return_type": phi.return_type,
+            "line_range": {"start": phi.start_line, "end": phi.end_line},
+            "docstring": phi.docstring or "",
+            "is_method": phi.is_method,
+        }
+        sig = formatter._create_go_signature(func_dict)
+        assert "n int64" in sig
+        assert "{'name'" not in sig
+        assert '{"name"' not in sig

--- a/tree_sitter_analyzer/cli/commands/table_command_helpers.py
+++ b/tree_sitter_analyzer/cli/commands/table_command_helpers.py
@@ -39,6 +39,10 @@ TYPE_SUFFIX_LANGUAGES = {
     "rb",
 }
 
+# Go params are name-before-type with a space separator and no colon:
+# "n int64", "config *Config", "numbers ...int".
+GO_LANGUAGES = {"go"}
+
 PACKAGED_LANGUAGES = {"java", "kotlin", "scala", "csharp", "cpp", "c++"}
 STRUCTURE_SQL_ELEMENT_TYPES = {
     ELEMENT_TYPE_SQL_TABLE,
@@ -317,9 +321,30 @@ def _process_single_parameter(param: Any, language: str) -> dict[str, str]:
         return {"name": str(param), "type": "Any"}
 
     stripped = param.strip()
-    if language.lower() in TYPE_SUFFIX_LANGUAGES:
+    lang = language.lower()
+    if lang in GO_LANGUAGES:
+        return _process_go_parameter(stripped)
+    if lang in TYPE_SUFFIX_LANGUAGES:
         return _process_type_suffix_parameter(stripped)
     return _process_type_prefix_parameter(stripped)
+
+
+def _process_go_parameter(param: str) -> dict[str, str]:
+    """Process a Go parameter string: name-before-type, space-separated.
+
+    Go syntax: ``n int64``, ``config *Config``, ``numbers ...int``.
+    The name is the first whitespace-delimited token; everything after
+    the first space is the type (handles multi-word types like ``[]byte``).
+    """
+    first_space = param.find(" ")
+    if first_space == -1:
+        # No space — bare name with no type (unnamed parameter or type-only)
+        return {"name": param, "type": "Any"}
+    name = param[:first_space].strip()
+    param_type = param[first_space + 1 :].strip()
+    if not name or not param_type:
+        return {"name": param, "type": "Any"}
+    return {"name": name, "type": param_type}
 
 
 def _process_type_suffix_parameter(param: str) -> dict[str, str]:

--- a/tree_sitter_analyzer/formatters/go_formatter.py
+++ b/tree_sitter_analyzer/formatters/go_formatter.py
@@ -108,7 +108,7 @@ class GoTableFormatter(BaseTableFormatter):
         """Create Go function signature"""
         params = func.get("parameters", [])
         if isinstance(params, list):
-            params_str = ", ".join(str(p) for p in params)
+            params_str = ", ".join(self._format_go_param(p) for p in params)
         else:
             params_str = str(params)
 
@@ -116,6 +116,17 @@ class GoTableFormatter(BaseTableFormatter):
         if return_type:
             return f"({params_str}) {return_type}"
         return f"({params_str})"
+
+    @staticmethod
+    def _format_go_param(param: Any) -> str:
+        """Render one Go parameter as 'name type' (never a raw dict repr)."""
+        if isinstance(param, dict):
+            name = param.get("name", "")
+            ptype = param.get("type", "")
+            if name and ptype:
+                return f"{name} {ptype}"
+            return name or ptype or str(param)
+        return str(param)
 
     def _create_go_compact_signature(self, func: dict[str, Any]) -> str:
         """Create compact Go function signature"""


### PR DESCRIPTION
## Summary

- **Bug 1 — name/type swap**: `process_parameters()` routed Go through `_process_type_prefix_parameter` (Java-style: type-before-name). Go syntax is name-before-type (`n int64`), so the old code produced `name='int64', type='n'` (swapped). Fixed by adding `_process_go_parameter()` that splits on the first space: first token is name, rest is type.

- **Bug 2 — raw dict in signature**: `GoTableFormatter._create_go_signature()` used `str(p)` on each param dict, leaking `{'name': 'int64', 'type': 'n'}` into the rendered signature. Fixed by adding `_format_go_param()` that renders `{"name": n, "type": t}` as `"n t"` (Go order).

- Golden masters for `go_sample` full and csv updated to reflect the corrected output.

**Reproduce (before fix):**
```
func Phi(n int64) int64
→ | Phi | ({'name': 'int64', 'type': 'n'}) int64 | ...   ← WRONG (swapped + raw dict)
```
**After fix:**
```
→ | Phi | (n int64) int64 | ...   ← CORRECT
```

## Test plan

- [x] 15 new regression tests in `tests/unit/languages/test_go_param_name_type_swap.py` — RED before fix, GREEN after
- [x] All existing Go unit tests pass (`tests/unit/languages -k go`: 299 pass)
- [x] All Go formatter tests pass (`tests/unit/formatters/test_go_formatter_*.py`: 71 pass)
- [x] Integration golden master tests pass (`test_golden_master_regression.py -k go`: 78 pass)
- [x] All ruff/mypy/bandit hooks pass