### PR TITLE
fix(swift): compute cyclomatic complexity for Swift functions

### DIFF
--- a/tests/unit/languages/test_cyclomatic_complexity.py
+++ b/tests/unit/languages/test_cyclomatic_complexity.py
@@ -330,3 +330,118 @@ class TestPHPCyclomaticComplexity:
         assert len(funcs) == 1
         assert funcs[0].name == "process"
         assert funcs[0].complexity_score == 13
+
+
+# ---------------------------------------------------------------------------
+# Swift
+# ---------------------------------------------------------------------------
+
+SWIFT_SIMPLE = """\
+func greet(name: String) -> String {
+    return name
+}
+"""
+# No branches → complexity = 1
+
+SWIFT_BRANCHY = """\
+func binarySearch(_ arr: [Int], _ target: Int) -> Int {
+    var low = 0
+    var high = arr.count - 1
+    while low <= high {
+        let mid = (low + high) / 2
+        if arr[mid] == target {
+            return mid
+        } else if arr[mid] < target {
+            low = mid + 1
+        } else {
+            high = mid - 1
+        }
+    }
+    return -1
+}
+"""
+# Decisions: while_statement(1) + if_statement(1) + else-if=nested if_statement(1) = 3
+# → complexity = 1 + 3 = 4
+
+SWIFT_RICH = """\
+func process(x: Int) -> Int {
+    if x > 0 {
+        print(x)
+    }
+    guard x < 100 else { return -1 }
+    switch x {
+    case 1: print("one")
+    default: print("other")
+    }
+    for i in 1...10 {
+        print(i)
+    }
+    while x > 0 {
+        print(x)
+    }
+    repeat {
+        print(x)
+    } while x < 10
+    do {
+        try riskyOp()
+    } catch {
+        print("error")
+    }
+    let r = x > 0 ? 1 : -1
+    let t = x > 0 && x < 10
+    let u = x < 0 || x > 100
+    return r
+}
+"""
+# Decisions:
+#   if_statement           : 1
+#   guard_statement        : 1
+#   switch_statement       : 1
+#   for_statement          : 1
+#   while_statement        : 1
+#   repeat_while_statement : 1
+#   catch_block            : 1
+#   ternary_expression     : 1
+#   conjunction_expression : 1   (x > 0 && x < 10)
+#   disjunction_expression : 1   (x < 0 || x > 100)
+# Total = 10 → complexity = 1 + 10 = 11
+
+
+def _swift_lang():
+    import tree_sitter_swift
+
+    return tree_sitter.Language(tree_sitter_swift.language())
+
+
+def _swift_functions(source: str):
+    lang = _swift_lang()
+    parser = tree_sitter.Parser(lang)
+    tree = parser.parse(source.encode())
+    from tree_sitter_analyzer.languages._swift_plugin_extractor import (
+        SwiftElementExtractor,
+    )
+
+    extractor = SwiftElementExtractor()
+    return extractor.extract_functions(tree, source)
+
+
+class TestSwiftCyclomaticComplexity:
+    def test_simple_no_branches(self):
+        funcs = _swift_functions(SWIFT_SIMPLE)
+        assert len(funcs) == 1
+        assert funcs[0].name == "greet"
+        assert funcs[0].complexity_score == 1
+
+    def test_binary_search(self):
+        """while + if + else-if (nested if_statement) = 3 decisions → complexity 4."""
+        funcs = _swift_functions(SWIFT_BRANCHY)
+        assert len(funcs) == 1
+        assert funcs[0].name == "binarySearch"
+        assert funcs[0].complexity_score == 4
+
+    def test_rich_branching(self):
+        """10 decision points → complexity 11."""
+        funcs = _swift_functions(SWIFT_RICH)
+        assert len(funcs) == 1
+        assert funcs[0].name == "process"
+        assert funcs[0].complexity_score == 11

--- a/tree_sitter_analyzer/languages/_swift_plugin_elements.py
+++ b/tree_sitter_analyzer/languages/_swift_plugin_elements.py
@@ -26,6 +26,60 @@ if TYPE_CHECKING:
     import tree_sitter
 
 
+# ---------------------------------------------------------------------------
+# Cyclomatic complexity for Swift
+# ---------------------------------------------------------------------------
+
+# Non-leaf AST node types that each add one decision point.
+# conjunction_expression / disjunction_expression are non-leaf container nodes
+# (not bare && / || tokens), so the non-leaf check is redundant but harmless.
+_SWIFT_DECISION_NODE_TYPES: frozenset[str] = frozenset(
+    {
+        "if_statement",
+        "guard_statement",
+        "switch_statement",
+        "for_statement",
+        "while_statement",
+        "repeat_while_statement",
+        "catch_block",
+        "ternary_expression",
+        "conjunction_expression",  # x && y
+        "disjunction_expression",  # x || y
+    }
+)
+
+
+def _safe_children(node: object) -> list[object]:
+    """Return children list from a tree-sitter node, empty list on any error."""
+    try:
+        children = getattr(node, "children", None)
+        if children is None:
+            return []
+        return list(children)
+    except (TypeError, AttributeError):
+        return []
+
+
+def _swift_calculate_complexity(node: object) -> int:
+    """Return cyclomatic complexity for a Swift function node.
+
+    complexity = 1 + (number of decision points).
+
+    Decision points are non-leaf AST nodes whose type is in
+    _SWIFT_DECISION_NODE_TYPES (if/guard/switch/for/while/repeat-while/
+    catch_block/ternary_expression/conjunction_expression/disjunction_expression).
+    """
+    decisions = 0
+    stack = [node]
+    while stack:
+        cur = stack.pop()
+        children = _safe_children(cur)
+        if getattr(cur, "type", None) in _SWIFT_DECISION_NODE_TYPES and children:
+            decisions += 1
+        stack.extend(children)
+    return 1 + decisions
+
+
 def extract_swift_function(extractor: Any, node: tree_sitter.Node) -> Function | None:
     """Extract one Swift function-like declaration."""
     try:
@@ -117,6 +171,7 @@ def _swift_function_fields(
         "modifiers": modifiers,
         "visibility": found_visibility,
         "is_constructor": node.type == "init_declaration",
+        "complexity_score": _swift_calculate_complexity(node),
         **_swift_function_flags(modifiers, raw_text, found_visibility),
     }
 


### PR DESCRIPTION
## Summary

- Adds `_swift_calculate_complexity()` helper to `_swift_plugin_elements.py` (mirrors the Ruby/Kotlin/PHP approach from #1055, deferred in that commit)
- Wires `complexity_score` into `_swift_function_fields()` — previously all Swift functions returned the default `1`
- Decision points counted: `if_statement`, `guard_statement`, `switch_statement`, `for_statement`, `while_statement`, `repeat_while_statement`, `catch_block`, `ternary_expression`, `conjunction_expression`, `disjunction_expression`
- Adds 3 exact-pinned `TestSwiftCyclomaticComplexity` tests to `tests/unit/languages/test_cyclomatic_complexity.py`

## Part B (test-isolation)

The two failing tests (`test_poetic_moat_end_to_end`, `test_swift_full_table_matches_golden_master`) reproduced even when run alone — root cause was `tree-sitter-swift` not installed in the worktree's venv. With the package present, all 7 swift tests pass alone and together with the cyclomatic complexity tests under `-n 0`. No code fix required for isolation; there is no shared-state leak.

## Test plan

- [x] `uv run pytest tests/unit/languages/test_cyclomatic_complexity.py::TestSwiftCyclomaticComplexity -n 0 -v` — 3 passed
- [x] `uv run pytest tests/unit/languages/test_cyclomatic_complexity.py tests/unit/languages/test_swift_golden_master.py tests/unit/test_swift_method_resolution.py -n 0 -q` — 19 passed
- [x] All existing Swift plugin tests still pass (110 tests)
- [x] Exact pins: `greet` → 1, `binarySearch` → 4, `process` (10 decisions) → 11

🤖 Generated with [Claude Code](https://claude.com/claude-code)