### PR TITLE
fix(plugins): compute cyclomatic complexity for Scala and Bash

### DIFF
--- a/tests/unit/languages/test_cyclomatic_complexity.py
+++ b/tests/unit/languages/test_cyclomatic_complexity.py
@@ -330,3 +330,219 @@ class TestPHPCyclomaticComplexity:
         assert len(funcs) == 1
         assert funcs[0].name == "process"
         assert funcs[0].complexity_score == 13
+
+
+# ---------------------------------------------------------------------------
+# Scala
+# ---------------------------------------------------------------------------
+
+SCALA_SIMPLE = """\
+def greet(name: String): String = {
+  s"Hello, $name!"
+}
+"""
+# No branches → complexity = 1
+
+SCALA_BRANCHY = """\
+def binarySearch(arr: Array[Int], target: Int): Int = {
+  var low = 0
+  var high = arr.length - 1
+  while (low <= high) {
+    val mid = (low + high) / 2
+    if (arr(mid) == target) {
+      mid
+    } else if (arr(mid) < target) {
+      low = mid + 1
+      -1
+    } else {
+      high = mid - 1
+      -1
+    }
+  }
+  -1
+}
+"""
+# Decisions: while_expression(1) + if_expression(1) + else-if (another if_expression)(1) = 3
+# → complexity = 1 + 3 = 4
+
+SCALA_RICH = """\
+def process(x: Int): String = {
+  val r = if (x > 0) "pos" else "neg"
+  x match {
+    case 1 => "one"
+    case 2 => "two"
+    case _ => "other"
+  }
+  for (i <- 1 to 10) {
+    println(i)
+  }
+  while (x > 0) { println(x) }
+  val ok = x > 0 && x < 10
+  val ok2 = x < 0 || x > 100
+  try {
+    val d = 1 / x
+  } catch {
+    case e: Exception => println(e)
+  }
+  r
+}
+"""
+# Decisions:
+#   if_expression (inline if)   : 1
+#   match_expression            : 1
+#   case_clause x3 (in match)   : 3
+#   for_expression              : 1
+#   while_expression            : 1
+#   catch_clause                : 1
+#   case_clause (in catch)      : 1
+#   &&  (operator_identifier)   : 1
+#   ||  (operator_identifier)   : 1
+# Total = 11 → complexity = 1 + 11 = 12
+
+
+def _scala_lang():
+    import tree_sitter_scala
+
+    return tree_sitter.Language(tree_sitter_scala.language())
+
+
+def _scala_functions(source: str):
+    lang = _scala_lang()
+    parser = tree_sitter.Parser(lang)
+    tree = parser.parse(source.encode())
+    from tree_sitter_analyzer.languages.scala_plugin import ScalaElementExtractor
+
+    extractor = ScalaElementExtractor()
+    return extractor.extract_functions(tree, source)
+
+
+class TestScalaCyclomaticComplexity:
+    def test_simple_no_branches(self):
+        funcs = _scala_functions(SCALA_SIMPLE)
+        assert len(funcs) == 1
+        assert funcs[0].name == "greet"
+        assert funcs[0].complexity_score == 1
+
+    def test_binary_search(self):
+        """while_expression + if_expression x2 = 3 decisions → complexity 4."""
+        funcs = _scala_functions(SCALA_BRANCHY)
+        assert len(funcs) == 1
+        assert funcs[0].name == "binarySearch"
+        assert funcs[0].complexity_score == 4
+
+    def test_rich_branching(self):
+        """11 decision points → complexity 12."""
+        funcs = _scala_functions(SCALA_RICH)
+        assert len(funcs) == 1
+        assert funcs[0].name == "process"
+        assert funcs[0].complexity_score == 12
+
+
+# ---------------------------------------------------------------------------
+# Bash
+# ---------------------------------------------------------------------------
+
+BASH_SIMPLE = """\
+greet() {
+    echo "Hello, world!"
+}
+"""
+# No branches → complexity = 1
+
+BASH_BRANCHY = """\
+binary_search() {
+    local low=0
+    local high=10
+    while [ $low -le $high ]; do
+        local mid=$(( (low + high) / 2 ))
+        if [ "$mid" -eq 5 ]; then
+            echo $mid
+            return
+        elif [ "$mid" -lt 5 ]; then
+            low=$((mid + 1))
+        else
+            high=$((mid - 1))
+        fi
+    done
+    echo -1
+}
+"""
+# Decisions: while_statement(1) + if_statement(1) + elif_clause(1) = 3 → complexity 4
+
+BASH_RICH = """\
+process() {
+    local x="$1"
+    if [ "$x" -gt 0 ]; then
+        echo "positive"
+    elif [ "$x" -eq 0 ]; then
+        echo "zero"
+    fi
+    while [ "$x" -gt 0 ]; do
+        x=$((x - 1))
+    done
+    until [ "$x" -ge 10 ]; do
+        x=$((x + 1))
+    done
+    for i in 1 2 3; do
+        echo "$i"
+    done
+    for ((j=0; j<3; j++)); do
+        echo "$j"
+    done
+    case "$x" in
+        1) echo "one";;
+        2) echo "two";;
+        *) echo "other";;
+    esac
+    [ "$x" -gt 0 ] && echo "and" || echo "or"
+}
+"""
+# Decisions:
+#   if_statement          : 1
+#   elif_clause           : 1
+#   while_statement (while): 1
+#   while_statement (until): 1
+#   for_statement         : 1
+#   c_style_for_statement : 1
+#   case_item x3          : 3
+#   &&                    : 1
+#   ||                    : 1
+# Total = 11 → complexity = 1 + 11 = 12
+
+
+def _bash_lang():
+    import tree_sitter_bash
+
+    return tree_sitter.Language(tree_sitter_bash.language())
+
+
+def _bash_functions(source: str):
+    lang = _bash_lang()
+    parser = tree_sitter.Parser(lang)
+    tree = parser.parse(source.encode())
+    from tree_sitter_analyzer.languages.bash_plugin import BashElementExtractor
+
+    extractor = BashElementExtractor()
+    return extractor.extract_functions(tree, source)
+
+
+class TestBashCyclomaticComplexity:
+    def test_simple_no_branches(self):
+        funcs = _bash_functions(BASH_SIMPLE)
+        assert len(funcs) == 1
+        assert funcs[0].name == "greet"
+        assert funcs[0].complexity_score == 1
+
+    def test_binary_search(self):
+        """while_statement + if_statement + elif_clause = 3 decisions → complexity 4."""
+        funcs = _bash_functions(BASH_BRANCHY)
+        assert len(funcs) == 1
+        assert funcs[0].name == "binary_search"
+        assert funcs[0].complexity_score == 4
+
+    def test_rich_branching(self):
+        """11 decision points → complexity 12."""
+        funcs = _bash_functions(BASH_RICH)
+        assert len(funcs) == 1
+        assert funcs[0].name == "process"
+        assert funcs[0].complexity_score == 12

--- a/tree_sitter_analyzer/languages/bash_plugin.py
+++ b/tree_sitter_analyzer/languages/bash_plugin.py
@@ -79,6 +79,58 @@ _BASH_CONTAINER_NODE_TYPES: frozenset[str] = frozenset(
 )
 
 
+# ---------------------------------------------------------------------------
+# Cyclomatic complexity for Bash
+# ---------------------------------------------------------------------------
+
+_BASH_DECISION_TYPES: frozenset[str] = frozenset(
+    {
+        "if_statement",
+        "elif_clause",
+        "while_statement",  # covers both 'while' and 'until' loops
+        "for_statement",
+        "c_style_for_statement",
+        "case_item",
+    }
+)
+
+_BASH_LOGIC_OP_TOKENS: frozenset[str] = frozenset({"&&", "||"})
+
+
+def _safe_children_bash(node: Any) -> list[Any]:
+    """Return children list from a tree-sitter node, empty list on any error."""
+    try:
+        children = getattr(node, "children", None)
+        if children is None:
+            return []
+        return list(children)
+    except (TypeError, AttributeError):
+        return []
+
+
+def calculate_bash_complexity(node: Any) -> int:
+    """Return cyclomatic complexity for a Bash function node.
+
+    complexity = 1 + decision_points.
+    Decision points: if_statement, elif_clause, while_statement (covers
+    both while and until), for_statement, c_style_for_statement, case_item
+    (non-leaf nodes), and ``&&`` / ``||`` leaf operator tokens.
+    """
+    decisions = 0
+    stack = [node]
+    while stack:
+        cur = stack.pop()
+        children = _safe_children_bash(cur)
+        is_leaf = len(children) == 0
+        node_type = getattr(cur, "type", None)
+        if not is_leaf and node_type in _BASH_DECISION_TYPES:
+            decisions += 1
+        elif is_leaf and node_type in _BASH_LOGIC_OP_TOKENS:
+            decisions += 1
+        stack.extend(children)
+    return 1 + decisions
+
+
 def _push_bash_children(
     node_stack: list[tuple[tree_sitter.Node, int]],
     current_node: tree_sitter.Node,
@@ -462,6 +514,7 @@ class BashElementExtractor(ElementExtractor):
                 language="bash",
                 parameters=[],  # Bash functions don't have formal parameters in signature
                 return_type="",  # Bash functions don't have type annotations
+                complexity_score=calculate_bash_complexity(node),
             )
         except Exception as e:
             log_error(f"Failed to extract Bash function info: {e}")

--- a/tree_sitter_analyzer/languages/scala_plugin.py
+++ b/tree_sitter_analyzer/languages/scala_plugin.py
@@ -20,6 +20,63 @@ from ..models import Class, Expression, Function, Import, Package, Variable
 from ..plugins.base import ElementExtractor, LanguagePlugin
 from ..utils import log_debug, log_error
 
+# ---------------------------------------------------------------------------
+# Cyclomatic complexity for Scala
+# ---------------------------------------------------------------------------
+
+_SCALA_DECISION_TYPES: frozenset[str] = frozenset(
+    {
+        "if_expression",
+        "match_expression",
+        "for_expression",
+        "while_expression",
+        "catch_clause",
+        "case_clause",
+    }
+)
+
+_SCALA_LOGIC_OP_TOKENS: frozenset[str] = frozenset({"&&", "||"})
+
+
+def _safe_children(node: Any) -> list[Any]:
+    """Return children list from a tree-sitter node, empty list on any error."""
+    try:
+        children = getattr(node, "children", None)
+        if children is None:
+            return []
+        return list(children)
+    except (TypeError, AttributeError):
+        return []
+
+
+def calculate_scala_complexity(node: Any) -> int:
+    """Return cyclomatic complexity for a Scala function node.
+
+    complexity = 1 + decision_points.
+    Decision points: if_expression, match_expression, for_expression,
+    while_expression, catch_clause, case_clause (non-leaf nodes),
+    and ``&&`` / ``||`` operator_identifier leaf tokens.
+    """
+    decisions = 0
+    stack = [node]
+    while stack:
+        cur = stack.pop()
+        children = _safe_children(cur)
+        is_leaf = len(children) == 0
+        node_type = getattr(cur, "type", None)
+        if not is_leaf and node_type in _SCALA_DECISION_TYPES:
+            decisions += 1
+        elif is_leaf and node_type == "operator_identifier":
+            try:
+                text = cur.text.decode("utf-8") if cur.text else ""
+            except (AttributeError, UnicodeDecodeError):
+                text = ""
+            if text in _SCALA_LOGIC_OP_TOKENS:
+                decisions += 1
+        stack.extend(children)
+    return 1 + decisions
+
+
 _SCALA_ELEMENT_KEYS: tuple[str, ...] = (
     "functions",
     "classes",
@@ -713,6 +770,7 @@ class ScalaElementExtractor(ElementExtractor):
                 modifiers=self._scala_modifiers(node),
                 docstring=docstring,
                 is_constructor=name == "this",
+                complexity_score=calculate_scala_complexity(node),
             )
 
         except Exception as e:


### PR DESCRIPTION
## Summary

- Scala plugin was returning `complexity_score=1` for every function (no decision-point counting), same gap as Ruby/Kotlin/PHP fixed in #1055
- Bash plugin had the same flat `complexity_score=1` regression
- Adds `calculate_scala_complexity` and `calculate_bash_complexity` with `_safe_children` guards, mirroring the exact pattern from Kotlin/PHP helpers

## Key implementation notes

**Scala** — logical operators appear as `operator_identifier` *named* leaf nodes (not bare `&&`/`||` token types), so the check decodes `.text` rather than comparing `node.type` to `"&&"`. Decision types: `if_expression`, `match_expression`, `for_expression`, `while_expression`, `catch_clause`, `case_clause`.

**Bash** — `while_statement` covers *both* `while` and `until` loops in the grammar (same node type). `&&`/`||` are bare leaf token types directly (type literally equals `"&&"` / `"||"`). Decision types: `if_statement`, `elif_clause`, `while_statement`, `for_statement`, `c_style_for_statement`, `case_item`.

## Test plan

- RED-first: 4 tests failed before implementation (Scala×2, Bash×2)
- All 15 cyclomatic-complexity tests green after fix (Ruby×3 + Kotlin×3 + PHP×3 + Scala×3 + Bash×3)
- Exact integer pins per CLAUDE.md locked rule: `== 1` / `== 4` / `== 12` (no `>=` loose bounds)
- Node types verified by parsing real sample code with `tree_sitter_scala` / `tree_sitter_bash` before writing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)