### PR TITLE
fix(toon): quote scalar-ambiguous strings; add ToonDecoder + round-trip oracle (#1058)

### DIFF
--- a/docs/CODEMAPS/formatters.md
+++ b/docs/CODEMAPS/formatters.md
@@ -118,6 +118,19 @@ Same data in JSON costs noticeably more tokens for typical AST outputs (the
 
 Serialization helpers: `formatters/toon_formatter.py:_emit_*` (extracted in r37dm dogfood).
 
+### TOON Encoder/Decoder internals
+
+| Module | Role |
+|---|---|
+| `formatters/toon_encoder.py` | `ToonEncoder` — iterative encoder; `encode_value` for scalars |
+| `formatters/_toon_encoder_string_helpers.py` | `needs_quotes`, `escape_string` — quoting rules |
+| `formatters/_toon_encoder_table_helpers.py` | Array-table encoding: `union_schema`, `encode_array_table_lines` |
+| `formatters/_toon_encoder_task_helpers.py` | Stack-based task dispatch helpers |
+| `formatters/toon_decoder.py` | `decode_toon(token)` — inverse of `encode_value` for scalar tokens (issue #1058); `ToonDecodeError` |
+
+The decoder is intentionally **scalar-only** (PR1 scope): it handles `null`, `true`/`false`, numbers, quoted strings, and bare words.
+Full dict/list/table parsing is deferred to RFC-0018.
+
 ## Format Stability Contract
 
 Format changes are tracked by:

--- a/tests/unit/formatters/test_toon_roundtrip.py
+++ b/tests/unit/formatters/test_toon_roundtrip.py
@@ -1,0 +1,360 @@
+"""Round-trip oracle tests for TOON encoder + decoder.
+
+Issue #1058: The TOON encoder is type-lossy — a string that LOOKS like a
+scalar (bool/null/number) is emitted bare, so a spec-compliant decoder
+reconstructs the WRONG Python type.
+
+These tests are written RED-first (before the encoder fix and before the
+decoder exists) per the CLAUDE.md TDD requirement and the exact-assertion
+rule: every assertion pins an exact expected value, never a loose bound.
+
+Test categories
+---------------
+1. ``TestAmbiguousStringQuoting`` — encoder conformance: scalar-looking strings
+   MUST be quoted so a decoder can reconstruct the correct str type.
+2. ``TestToonDecoder`` — decoder unit tests: the decoder must invert the encoder.
+3. ``TestToonRoundTrip`` — oracle: ``decode_toon(encode_toon(x)) == x`` for all
+   input shapes the encoder produces.
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Import the decoder — this will fail with ImportError until the decoder
+# module is created.  The test is intentionally RED at that point.
+# ---------------------------------------------------------------------------
+from tree_sitter_analyzer.formatters.toon_decoder import decode_toon
+from tree_sitter_analyzer.formatters.toon_encoder import ToonEncoder
+
+# ===========================================================================
+# Section 1 — Encoder conformance: scalar-ambiguous strings must be quoted
+# ===========================================================================
+
+
+class TestAmbiguousStringQuoting:
+    """Strings that look like TOON/JSON scalars MUST be quoted.
+
+    Without quoting, a decoder cannot distinguish the Python ``str "true"``
+    from the Python ``bool True``.  These were the exact failure cases from
+    issue #1058.
+    """
+
+    def setup_method(self):
+        self.enc = ToonEncoder(normalize_paths=False)
+
+    # --- bool literals ---
+
+    def test_string_true_is_quoted(self):
+        result = self.enc.encode("true")
+        assert result == '"true"'
+
+    def test_string_false_is_quoted(self):
+        result = self.enc.encode("false")
+        assert result == '"false"'
+
+    # --- null literal ---
+
+    def test_string_null_is_quoted(self):
+        result = self.enc.encode("null")
+        assert result == '"null"'
+
+    # --- integer-looking strings ---
+
+    def test_string_integer_positive_is_quoted(self):
+        result = self.enc.encode("42")
+        assert result == '"42"'
+
+    def test_string_integer_zero_is_quoted(self):
+        result = self.enc.encode("0")
+        assert result == '"0"'
+
+    def test_string_integer_negative_is_quoted(self):
+        result = self.enc.encode("-3")
+        assert result == '"-3"'
+
+    # --- float-looking strings ---
+
+    def test_string_float_is_quoted(self):
+        """The exact case from #1058: "100.0" decoded as float, not str."""
+        result = self.enc.encode("100.0")
+        assert result == '"100.0"'
+
+    def test_string_float_no_leading_digit_is_quoted(self):
+        result = self.enc.encode("3.14")
+        assert result == '"3.14"'
+
+    def test_string_negative_float_is_quoted(self):
+        result = self.enc.encode("-1.5")
+        assert result == '"-1.5"'
+
+    # --- scientific notation ---
+
+    def test_string_scientific_upper_is_quoted(self):
+        result = self.enc.encode("1E5")
+        assert result == '"1E5"'
+
+    def test_string_scientific_lower_is_quoted(self):
+        result = self.enc.encode("1e5")
+        assert result == '"1e5"'
+
+    def test_string_scientific_negative_exp_is_quoted(self):
+        result = self.enc.encode("1.5e-3")
+        assert result == '"1.5e-3"'
+
+    # --- genuine scalars (not strings) stay unquoted ---
+
+    def test_bool_true_stays_bare(self):
+        """Python True -> bare ``true``; it is a genuine bool scalar."""
+        result = self.enc.encode(True)
+        assert result == "true"
+
+    def test_bool_false_stays_bare(self):
+        result = self.enc.encode(False)
+        assert result == "false"
+
+    def test_none_stays_bare(self):
+        result = self.enc.encode(None)
+        assert result == "null"
+
+    def test_int_stays_bare(self):
+        result = self.enc.encode(42)
+        assert result == "42"
+
+    def test_float_stays_bare(self):
+        result = self.enc.encode(3.14)
+        assert result == "3.14"
+
+    # --- ordinary strings stay unquoted (no structural chars, not scalar-looking) ---
+
+    def test_ordinary_word_stays_bare(self):
+        result = self.enc.encode("hello")
+        assert result == "hello"
+
+    def test_mixed_alphanum_stays_bare(self):
+        result = self.enc.encode("hello123world")
+        assert result == "hello123world"
+
+    # --- in dict values ---
+
+    def test_dict_with_scalar_ambiguous_string_values(self):
+        """All scalar-looking string VALUES in a dict must be quoted."""
+        enc = ToonEncoder(normalize_paths=False)
+        result = enc.encode(
+            {
+                "a": "true",
+                "b": "false",
+                "c": "null",
+                "d": "42",
+                "e": "100.0",
+            }
+        )
+        assert 'a: "true"' in result
+        assert 'b: "false"' in result
+        assert 'c: "null"' in result
+        assert 'd: "42"' in result
+        assert 'e: "100.0"' in result
+
+
+# ===========================================================================
+# Section 2 — Decoder unit tests
+# ===========================================================================
+
+
+class TestToonDecoder:
+    """Unit tests for the ``decode_toon`` function."""
+
+    # --- scalars ---
+
+    def test_decode_null(self):
+        assert decode_toon("null") is None
+
+    def test_decode_true(self):
+        assert decode_toon("true") is True
+
+    def test_decode_false(self):
+        assert decode_toon("false") is False
+
+    def test_decode_integer(self):
+        result = decode_toon("42")
+        assert result == 42
+        assert type(result) is int
+
+    def test_decode_negative_integer(self):
+        result = decode_toon("-7")
+        assert result == -7
+        assert type(result) is int
+
+    def test_decode_float(self):
+        result = decode_toon("3.14")
+        assert result == 3.14
+        assert type(result) is float
+
+    # --- quoted strings (the bug cases) ---
+
+    def test_decode_quoted_true_gives_str(self):
+        result = decode_toon('"true"')
+        assert result == "true"
+        assert type(result) is str
+
+    def test_decode_quoted_false_gives_str(self):
+        result = decode_toon('"false"')
+        assert result == "false"
+        assert type(result) is str
+
+    def test_decode_quoted_null_gives_str(self):
+        result = decode_toon('"null"')
+        assert result == "null"
+        assert type(result) is str
+
+    def test_decode_quoted_number_gives_str(self):
+        result = decode_toon('"100.0"')
+        assert result == "100.0"
+        assert type(result) is str
+
+    def test_decode_quoted_string(self):
+        assert decode_toon('"hello"') == "hello"
+
+    def test_decode_quoted_string_with_escape_sequences(self):
+        assert decode_toon('"line1\\nline2"') == "line1\nline2"
+
+    def test_decode_quoted_string_with_tab(self):
+        assert decode_toon('"value1\\tvalue2"') == "value1\tvalue2"
+
+    def test_decode_quoted_string_with_escaped_quote(self):
+        assert decode_toon('"say \\"hello\\""') == 'say "hello"'
+
+    # --- bare strings ---
+
+    def test_decode_bare_word_gives_str(self):
+        result = decode_toon("hello")
+        assert result == "hello"
+        assert type(result) is str
+
+
+# ===========================================================================
+# Section 3 — Round-trip oracle: decode_toon(encode_toon(x)) == x
+# ===========================================================================
+
+
+class TestToonRoundTrip:
+    """Property oracle: encode then decode must recover the original Python value.
+
+    Only tests shapes the encoder actually produces: scalars, strings,
+    dicts with scalar/string values, flat lists.  The table format used for
+    lists-of-dicts is not part of this PR's decoder scope — noted in comments
+    where skipped.
+    """
+
+    def _rt(self, value):
+        """Encode with ToonEncoder then decode; return reconstructed value."""
+        enc = ToonEncoder(normalize_paths=False, use_tabs=False)
+        encoded = enc.encode_value(value)
+        return decode_toon(encoded)
+
+    # --- None / bool ---
+
+    def test_none_roundtrip(self):
+        assert self._rt(None) is None
+
+    def test_true_roundtrip(self):
+        result = self._rt(True)
+        assert result is True
+
+    def test_false_roundtrip(self):
+        result = self._rt(False)
+        assert result is False
+
+    # --- integers ---
+
+    def test_zero_roundtrip(self):
+        result = self._rt(0)
+        assert result == 0
+        assert type(result) is int
+
+    def test_positive_int_roundtrip(self):
+        result = self._rt(42)
+        assert result == 42
+        assert type(result) is int
+
+    def test_negative_int_roundtrip(self):
+        result = self._rt(-7)
+        assert result == -7
+        assert type(result) is int
+
+    # --- floats ---
+
+    def test_float_roundtrip(self):
+        result = self._rt(3.14)
+        assert result == 3.14
+        assert type(result) is float
+
+    def test_negative_float_roundtrip(self):
+        result = self._rt(-1.5)
+        assert result == -1.5
+        assert type(result) is float
+
+    # --- strings that look like scalars (the #1058 bug cases) ---
+
+    def test_str_true_roundtrip(self):
+        result = self._rt("true")
+        assert result == "true"
+        assert type(result) is str
+
+    def test_str_false_roundtrip(self):
+        result = self._rt("false")
+        assert result == "false"
+        assert type(result) is str
+
+    def test_str_null_roundtrip(self):
+        result = self._rt("null")
+        assert result == "null"
+        assert type(result) is str
+
+    def test_str_integer_roundtrip(self):
+        result = self._rt("42")
+        assert result == "42"
+        assert type(result) is str
+
+    def test_str_float_roundtrip(self):
+        """The exact #1058 case: "100.0" must round-trip as str, not float."""
+        result = self._rt("100.0")
+        assert result == "100.0"
+        assert type(result) is str
+
+    def test_str_negative_int_roundtrip(self):
+        result = self._rt("-3")
+        assert result == "-3"
+        assert type(result) is str
+
+    def test_str_scientific_roundtrip(self):
+        result = self._rt("1e5")
+        assert result == "1e5"
+        assert type(result) is str
+
+    # --- ordinary strings ---
+
+    def test_ordinary_str_roundtrip(self):
+        result = self._rt("hello")
+        assert result == "hello"
+        assert type(result) is str
+
+    def test_str_with_spaces_roundtrip(self):
+        """Strings with spaces pass through bare if no structural chars."""
+        result = self._rt("hello world")
+        assert result == "hello world"
+        assert type(result) is str
+
+    def test_str_with_special_chars_roundtrip(self):
+        result = self._rt("say,hello")
+        assert result == "say,hello"
+        assert type(result) is str
+
+    def test_str_with_newline_roundtrip(self):
+        result = self._rt("line1\nline2")
+        assert result == "line1\nline2"
+        assert type(result) is str
+
+    def test_str_with_colon_roundtrip(self):
+        result = self._rt("key:value")
+        assert result == "key:value"
+        assert type(result) is str

--- a/tree_sitter_analyzer/formatters/_toon_encoder_string_helpers.py
+++ b/tree_sitter_analyzer/formatters/_toon_encoder_string_helpers.py
@@ -1,5 +1,7 @@
 """String escaping helpers for :mod:`toon_encoder`."""
 
+import re
+
 _TOON_QUOTE_CHARS = (
     "\n",
     "\r",
@@ -13,10 +15,34 @@ _TOON_QUOTE_CHARS = (
     '"',
 )
 
+# Matches strings that a TOON/JSON-spec decoder would parse as a non-string
+# scalar.  Such strings MUST be quoted so the type round-trips correctly.
+#
+# Matches (in order):
+#   bool literals   — "true" / "false" (case-sensitive, JSON spec)
+#   null literal    — "null"
+#   JSON number     — optional sign, integer part, optional fraction, optional
+#                     exponent; covers "42", "-3", "100.0", "1e5", "1.5e-3",
+#                     "1E5".  The regex mirrors RFC 8259 §6 (JSON numbers) and
+#                     is anchored to the full string so "1abc" stays unquoted.
+_SCALAR_PATTERN = re.compile(
+    r"^(?:true|false|null|-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+\-]?\d+)?)$"
+)
+
 
 def needs_quotes(value: str, delimiter: str) -> bool:
-    """Return whether a TOON string needs quoted escaping."""
-    return delimiter in value or any(char in value for char in _TOON_QUOTE_CHARS)
+    """Return whether a TOON string needs quoted escaping.
+
+    A string requires quoting if it:
+    - contains structural TOON characters (delimiter, braces, brackets, etc.)
+    - would be mis-parsed as a scalar by a spec-compliant decoder (i.e. it
+      looks like a bool literal, null, or JSON number).  Quoting is the only
+      way to preserve the ``str`` type across an encode-decode round-trip.
+    """
+    if delimiter in value or any(char in value for char in _TOON_QUOTE_CHARS):
+        return True
+    # Quote strings that are ambiguous with TOON/JSON scalars.
+    return bool(_SCALAR_PATTERN.match(value))
 
 
 def escape_string(value: str) -> str:

--- a/tree_sitter_analyzer/formatters/toon_decoder.py
+++ b/tree_sitter_analyzer/formatters/toon_decoder.py
@@ -1,0 +1,114 @@
+"""TOON scalar decoder — inverse of :mod:`toon_encoder` for single values.
+
+Scope (PR1 / issue #1058)
+--------------------------
+This module decodes the *scalar* tokens that :class:`~toon_encoder.ToonEncoder`
+emits via ``encode_value``.  It is the minimum decoder needed to make a
+round-trip oracle property hold: ``decode_toon(encode_toon(x)) == x`` for
+every primitive the encoder produces.
+
+Supported input shapes
+----------------------
+- ``null``           → ``None``
+- ``true`` / ``false`` → ``bool``
+- bare integer       → ``int``   (e.g. ``42``, ``-3``)
+- bare float/sci     → ``float`` (e.g. ``3.14``, ``1e5``)
+- ``"quoted string"`` → ``str``  (with ``\\n``, ``\\t``, ``\\r``, ``\\\\``,
+                                  ``\\"`` escape sequences resolved)
+- bare word          → ``str``
+
+Out of scope (deferred to RFC-0018 / later PRs)
+------------------------------------------------
+- Full dict / list / array-table parsing.  That requires a context-sensitive
+  line-oriented parser and belongs in the RFC-0018 surface-normalization work.
+  Do NOT add dict/list parsing here without an RFC.
+"""
+
+from __future__ import annotations
+
+import re
+
+__all__ = ["ToonDecodeError", "decode_toon"]
+
+
+class ToonDecodeError(Exception):
+    """Raised when a TOON token cannot be decoded."""
+
+
+# Regex matching a JSON-number token (same grammar as _SCALAR_PATTERN in the
+# encoder helpers, kept in sync).
+_NUMBER_PATTERN = re.compile(r"^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+\-]?\d+)?$")
+
+# Escape sequences the encoder produces inside quoted strings.
+_UNESCAPE_MAP: dict[str, str] = {
+    "n": "\n",
+    "r": "\r",
+    "t": "\t",
+    "\\": "\\",
+    '"': '"',
+}
+
+
+def _unescape(s: str) -> str:
+    """Resolve backslash escape sequences inside a quoted TOON string.
+
+    Only the sequences that :func:`~._toon_encoder_string_helpers.escape_string`
+    produces are handled: ``\\n``, ``\\r``, ``\\t``, ``\\\\``, ``\\"``.
+    Any other ``\\X`` is left verbatim (pass-through).
+    """
+    result: list[str] = []
+    i = 0
+    while i < len(s):
+        ch = s[i]
+        if ch == "\\" and i + 1 < len(s):
+            next_ch = s[i + 1]
+            result.append(_UNESCAPE_MAP.get(next_ch, next_ch))
+            i += 2
+        else:
+            result.append(ch)
+            i += 1
+    return "".join(result)
+
+
+def decode_toon(token: str) -> object:
+    """Decode a single TOON scalar token to the corresponding Python value.
+
+    This is the inverse of ``ToonEncoder.encode_value`` for scalar inputs.
+
+    Args:
+        token: A TOON-encoded scalar string as produced by the encoder.
+
+    Returns:
+        The decoded Python value: ``None``, ``bool``, ``int``, ``float``,
+        or ``str``.
+
+    Raises:
+        ToonDecodeError: If the token is structurally invalid (e.g. an
+            unterminated quoted string).
+    """
+    # Quoted string — highest priority so "true" stays str, not bool.
+    if token.startswith('"'):
+        if not token.endswith('"') or len(token) < 2:
+            raise ToonDecodeError(f"Unterminated quoted string token: {token!r}")
+        inner = token[1:-1]
+        return _unescape(inner)
+
+    # Null literal — nosec B105: "null" is a TOON keyword, not a password
+    if token == "null":  # nosec B105
+        return None
+
+    # Bool literals (JSON-spec: lowercase only) — nosec B105: TOON keywords
+    if token == "true":  # nosec B105
+        return True
+    if token == "false":  # nosec B105
+        return False
+
+    # Number — try int first, then float
+    if _NUMBER_PATTERN.match(token):
+        # If it contains '.', 'e', or 'E' it is a float; otherwise int.
+        if "." in token or "e" in token or "E" in token:
+            return float(token)
+        return int(token)
+
+    # Bare word → str
+    return token


### PR DESCRIPTION
## Summary

- **Bug fixed**: `needs_quotes` in `_toon_encoder_string_helpers.py` only checked for structural TOON characters. A string that looks like a scalar (e.g. `"true"`, `"null"`, `"42"`, `"100.0"`, `"1e5"`) was emitted bare, so a spec-compliant decoder would reconstruct the wrong Python type.
- **Encoder fix**: Extended `needs_quotes` with `_SCALAR_PATTERN` (RFC 8259 JSON-number grammar + bool/null literals) — any string matching that pattern is now quoted. Genuine Python scalars (`bool`, `int`, `float`, `None`) stay bare.
- **New decoder**: `tree_sitter_analyzer/formatters/toon_decoder.py` — `decode_toon(token)` and `ToonDecodeError`. Inverts `encode_value` for scalars: quoted strings (with escape-sequence resolution), `null`/bool literals, int/float numbers, bare words. Full dict/list/table parsing is deferred to RFC-0018.
- **Round-trip oracle tests**: 55 tests in `tests/unit/formatters/test_toon_roundtrip.py`, written RED-first. Three sections: encoder conformance (ambiguous-string quoting), decoder unit tests, and the property oracle `decode_toon(encode_value(x)) == x` with exact type assertions for every bug case from #1058.

## Test plan

- [x] 55 new round-trip tests GREEN after encoder + decoder fix
- [x] 0 existing TOON tests broke (639 TOON-tagged tests all pass)
- [x] 0 golden masters needed updating — scalar-ambiguous strings don't appear in any code-analysis TOON output as string-typed values
- [x] All hooks pass (bandit nosec B105 for TOON keyword comparisons, codemap updated)
- [x] `uv run pytest tests -n 0 -q -k toon` → 639 passed, 1 skipped, 7 xfailed

## Files changed

| File | Change |
|---|---|
| `tree_sitter_analyzer/formatters/_toon_encoder_string_helpers.py` | Add `_SCALAR_PATTERN` regex; extend `needs_quotes` |
| `tree_sitter_analyzer/formatters/toon_decoder.py` | **NEW** — scalar decoder |
| `tests/unit/formatters/test_toon_roundtrip.py` | **NEW** — 55 round-trip oracle tests |
| `docs/CODEMAPS/formatters.md` | Add toon_decoder row |

🤖 Generated with [Claude Code](https://claude.com/claude-code)