### PR TITLE
fix(formatters): add Cx column to Go and Bash full table output

### DIFF
--- a/docs/CODEMAPS/formatters.md
+++ b/docs/CODEMAPS/formatters.md
@@ -66,6 +66,14 @@ Per-language formatter mixins live alongside (`_java_formatter_*_mixin.py`,
 `_cpp_formatter_*_mixin.py`, etc.) and are composed into the concrete formatter
 classes via Python's MRO.
 
+Standalone per-language formatters (self-contained, no mixin composition):
+- `formatters/go_formatter.py` — `GoTableFormatter`; full/compact/csv/json; renders
+  `| Func | Signature | Vis | Lines | Cx | Doc |` (functions) and
+  `| Receiver | Func | Signature | Vis | Lines | Cx | Doc |` (methods)
+- `formatters/bash_formatter.py` — `BashTableFormatter`; registered for "bash" / "sh";
+  renders `| Name | Signature | Vis | Lines | Cx | Doc |` (full) and
+  `| Name | Sig | V | L | Cx | Doc |` (compact)
+
 Key mixins for the Java formatter:
 - `formatters/_java_formatter_full_mixin.py` — `_format_full_table`
 - `formatters/_java_formatter_compact_mixin.py` — `_format_compact_table`

--- a/tests/golden_masters/full/go_sample_full.md
+++ b/tests/golden_masters/full/go_sample_full.md
@@ -40,28 +40,28 @@ import ""time""
 | Middleware | exported | 254-254 |
 
 ## Functions
-| Func | Signature | Vis | Lines | Doc |
-|------|-----------|-----|-------|-----|
-| Read | (p []byte) (n int, err error) | exported | 55-55 | - |
-| Write | (p []byte) (n int, err error) | exported | 61-61 | - |
-| NewService | (name string, config *Config) *Service | exported | 80-86 | - |
-| Name | () string | exported | 89-91 | - |
-| IsRunning | () bool | exported | 94-98 | - |
-| Start | (ctx context.Context) error | exported | 101-114 | - |
-| run | (ctx context.Context) | unexported | 117-132 | - |
-| tick | (t time.Time) | unexported | 135-139 | - |
-| Stop | () error | exported | 142-153 | - |
-| stop | () | unexported | 156-160 | - |
-| ProcessData | (ctx context.Context, input <-chan []byte) (<-chan []byte, <-chan error) | exported | 163-193 | - |
-| process | (data []byte) []byte | unexported | 196-203 | - |
-| NewWorkerPool | (workers int) *WorkerPool | exported | 213-218 | - |
-| Start | () | exported | 221-226 | - |
-| worker | () | unexported | 229-234 | - |
-| Submit | (job func()) | exported | 237-239 | - |
-| Shutdown | () | exported | 242-245 | - |
-| Chain | (middlewares ...Middleware) Middleware | exported | 257-264 | - |
-| WithTimeout | (timeout time.Duration) Middleware | exported | 267-275 | - |
-| WithRetry | (maxRetries int) Middleware | exported | 278-293 | - |
+| Func | Signature | Vis | Lines | Cx | Doc |
+|------|-----------|-----|-------|----|-----|
+| Read | (p []byte) (n int, err error) | exported | 55-55 | 1 | - |
+| Write | (p []byte) (n int, err error) | exported | 61-61 | 1 | - |
+| NewService | (name string, config *Config) *Service | exported | 80-86 | 1 | - |
+| Name | () string | exported | 89-91 | 1 | - |
+| IsRunning | () bool | exported | 94-98 | 1 | - |
+| Start | (ctx context.Context) error | exported | 101-114 | 1 | - |
+| run | (ctx context.Context) | unexported | 117-132 | 1 | - |
+| tick | (t time.Time) | unexported | 135-139 | 1 | - |
+| Stop | () error | exported | 142-153 | 1 | - |
+| stop | () | unexported | 156-160 | 1 | - |
+| ProcessData | (ctx context.Context, input <-chan []byte) (<-chan []byte, <-chan error) | exported | 163-193 | 1 | - |
+| process | (data []byte) []byte | unexported | 196-203 | 1 | - |
+| NewWorkerPool | (workers int) *WorkerPool | exported | 213-218 | 1 | - |
+| Start | () | exported | 221-226 | 1 | - |
+| worker | () | unexported | 229-234 | 1 | - |
+| Submit | (job func()) | exported | 237-239 | 1 | - |
+| Shutdown | () | exported | 242-245 | 1 | - |
+| Chain | (middlewares ...Middleware) Middleware | exported | 257-264 | 1 | - |
+| WithTimeout | (timeout time.Duration) Middleware | exported | 267-275 | 1 | - |
+| WithRetry | (maxRetries int) Middleware | exported | 278-293 | 1 | - |
 
 ## Variables
 | Name | Type | Vis | Line |

--- a/tests/unit/formatters/test_cx_column_coverage.py
+++ b/tests/unit/formatters/test_cx_column_coverage.py
@@ -1,0 +1,205 @@
+"""Tests: --advanced --table full Cx column present for Go and Bash.
+
+LOCKED rule: exact-assertion pins only (no >= / > bounds).
+Each test picks a minimal fixture with a known complexity_score and asserts
+the EXACT value appears in the rendered table row.
+"""
+
+from tree_sitter_analyzer.formatters.bash_formatter import BashTableFormatter
+from tree_sitter_analyzer.formatters.go_formatter import GoTableFormatter
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Shared fixture builders
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _go_data_with_func(complexity: int) -> dict:
+    """Minimal Go structure dict with a single function at known complexity."""
+    return {
+        "file_path": "pkg/math/sample.go",
+        "packages": [{"name": "math"}],
+        "classes": [],
+        "methods": [
+            {
+                "name": "Compute",
+                "parameters": [{"name": "n", "type": "int"}],
+                "return_type": "int",
+                "line_range": {"start": 5, "end": 12},
+                "complexity_score": complexity,
+                "docstring": "",
+            }
+        ],
+        "fields": [],
+        "imports": [],
+        "statistics": {"function_count": 1, "class_count": 0, "variable_count": 0},
+    }
+
+
+def _bash_data_with_func(complexity: int) -> dict:
+    """Minimal Bash structure dict with a single function at known complexity."""
+    return {
+        "file_path": "scripts/deploy.sh",
+        "classes": [],
+        "methods": [
+            {
+                "name": "deploy",
+                "parameters": [],
+                "return_type": "",
+                "line_range": {"start": 3, "end": 15},
+                "complexity_score": complexity,
+                "javadoc": "",
+            }
+        ],
+        "fields": [],
+        "imports": [],
+        "statistics": {"method_count": 1, "field_count": 0},
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Go formatter tests
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestGoFormatterCxColumn:
+    """Go full-table must include Cx column with exact complexity value."""
+
+    def test_functions_header_has_cx_column(self):
+        formatter = GoTableFormatter("full")
+        output = formatter.format_structure(_go_data_with_func(1))
+        assert "| Func | Signature | Vis | Lines | Cx | Doc |" in output
+
+    def test_function_row_cx_value_1(self):
+        """Trivial function → complexity_score == 1 → renders '| 1 |' in row."""
+        formatter = GoTableFormatter("full")
+        output = formatter.format_structure(_go_data_with_func(1))
+        # Row must contain the exact complexity value 1
+        assert "| Compute | (n int) int | exported | 5-12 | 1 | - |" in output
+
+    def test_function_row_cx_value_5(self):
+        """Function with complexity 5 → renders '| 5 |'."""
+        formatter = GoTableFormatter("full")
+        output = formatter.format_structure(_go_data_with_func(5))
+        assert "| Compute | (n int) int | exported | 5-12 | 5 | - |" in output
+
+    def test_methods_header_has_cx_column(self):
+        """Go method table (receiver present) must also have Cx column."""
+        formatter = GoTableFormatter("full")
+        data = {
+            "file_path": "pkg/service.go",
+            "packages": [{"name": "service"}],
+            "classes": [],
+            "methods": [
+                {
+                    "name": "Run",
+                    "parameters": [],
+                    "return_type": "error",
+                    "line_range": {"start": 10, "end": 20},
+                    "complexity_score": 3,
+                    "docstring": "",
+                    "is_method": True,
+                    "receiver_type": "Service",
+                }
+            ],
+            "fields": [],
+            "imports": [],
+            "statistics": {"function_count": 0, "class_count": 0, "variable_count": 0},
+        }
+        output = formatter.format_structure(data)
+        assert "| Receiver | Func | Signature | Vis | Lines | Cx | Doc |" in output
+
+    def test_method_row_cx_value_3(self):
+        """Go method row includes exact complexity."""
+        formatter = GoTableFormatter("full")
+        data = {
+            "file_path": "pkg/service.go",
+            "packages": [{"name": "service"}],
+            "classes": [],
+            "methods": [
+                {
+                    "name": "Run",
+                    "parameters": [],
+                    "return_type": "error",
+                    "line_range": {"start": 10, "end": 20},
+                    "complexity_score": 3,
+                    "docstring": "",
+                    "is_method": True,
+                    "receiver_type": "Service",
+                }
+            ],
+            "fields": [],
+            "imports": [],
+            "statistics": {"function_count": 0, "class_count": 0, "variable_count": 0},
+        }
+        output = formatter.format_structure(data)
+        assert "| Service | Run | () error | exported | 10-20 | 3 | - |" in output
+
+    def test_no_cx_column_absent_from_old_go_output(self):
+        """Negative: the OLD 5-column header should NOT appear anymore."""
+        formatter = GoTableFormatter("full")
+        output = formatter.format_structure(_go_data_with_func(1))
+        assert "| Func | Signature | Vis | Lines | Doc |" not in output
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Bash formatter tests
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestBashFormatterCxColumn:
+    """Bash full-table must include Cx column with exact complexity value."""
+
+    def test_functions_header_has_cx_column(self):
+        formatter = BashTableFormatter("full")
+        output = formatter.format_structure(_bash_data_with_func(1))
+        assert "| Name | Signature | Vis | Lines | Cx | Doc |" in output
+
+    def test_function_row_cx_value_1(self):
+        """Simple bash function → complexity_score == 1 → renders '| 1 |'."""
+        formatter = BashTableFormatter("full")
+        output = formatter.format_structure(_bash_data_with_func(1))
+        assert "| deploy | () | public | 3-15 | 1 | - |" in output
+
+    def test_function_row_cx_value_4(self):
+        """Bash function with complexity 4 → renders '| 4 |'."""
+        formatter = BashTableFormatter("full")
+        output = formatter.format_structure(_bash_data_with_func(4))
+        assert "| deploy | () | public | 3-15 | 4 | - |" in output
+
+    def test_compact_functions_header_has_cx_column(self):
+        """Compact Bash table also includes Cx column."""
+        formatter = BashTableFormatter("compact")
+        output = formatter.format_structure(_bash_data_with_func(2))
+        assert "| Name | Sig | V | L | Cx | Doc |" in output
+
+    def test_compact_function_row_cx_value_2(self):
+        """Compact Bash row includes exact complexity 2."""
+        formatter = BashTableFormatter("compact")
+        output = formatter.format_structure(_bash_data_with_func(2))
+        assert "| deploy | (0) | + | 3-15 | 2 | - |" in output
+
+    def test_bash_formatter_registered(self):
+        """BashTableFormatter must be reachable via FormatterRegistry."""
+        from tree_sitter_analyzer.formatters.formatter_registry import FormatterRegistry
+
+        formatter = FormatterRegistry.get_formatter_for_language("bash", "full")
+        assert isinstance(formatter, BashTableFormatter)
+
+    def test_sh_alias_registered(self):
+        """'sh' language alias must also resolve to BashTableFormatter."""
+        from tree_sitter_analyzer.formatters.formatter_registry import FormatterRegistry
+
+        formatter = FormatterRegistry.get_formatter_for_language("sh", "full")
+        assert isinstance(formatter, BashTableFormatter)
+
+    def test_bash_section_header_present(self):
+        """Full table must include a '## Functions' section."""
+        formatter = BashTableFormatter("full")
+        output = formatter.format_structure(_bash_data_with_func(1))
+        assert "## Functions" in output
+
+    def test_old_legacy_columns_absent(self):
+        """OLD legacy columns (Name | Return Type | Parameters | Access | Line) must NOT appear."""
+        formatter = BashTableFormatter("full")
+        output = formatter.format_structure(_bash_data_with_func(1))
+        assert "| Name | Return Type | Parameters | Access | Line |" not in output

--- a/tree_sitter_analyzer/formatters/_go_formatter_helpers.py
+++ b/tree_sitter_analyzer/formatters/_go_formatter_helpers.py
@@ -193,8 +193,8 @@ def _append_functions(
         return
 
     lines.append("## Functions")
-    lines.append("| Func | Signature | Vis | Lines | Doc |")
-    lines.append("|------|-----------|-----|-------|-----|")
+    lines.append("| Func | Signature | Vis | Lines | Cx | Doc |")
+    lines.append("|------|-----------|-----|-------|----|-----|")
     for func in funcs:
         lines.append(format_func_row(func))
     lines.append("")
@@ -209,8 +209,8 @@ def _append_methods(
         return
 
     lines.append("## Methods")
-    lines.append("| Receiver | Func | Signature | Vis | Lines | Doc |")
-    lines.append("|----------|------|-----------|-----|-------|-----|")
+    lines.append("| Receiver | Func | Signature | Vis | Lines | Cx | Doc |")
+    lines.append("|----------|------|-----------|-----|-------|----|-----|")
     for method in methods:
         lines.append(format_method_row(method))
     lines.append("")

--- a/tree_sitter_analyzer/formatters/bash_formatter.py
+++ b/tree_sitter_analyzer/formatters/bash_formatter.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""
+Bash-specific table formatter.
+
+Renders shell-script analysis in the standard
+  Method | Signature | Vis | Lines | Cx | Doc
+column set, mirroring the Java/Ruby/Go formatters.
+"""
+
+from typing import Any
+
+from .base_formatter import BaseTableFormatter
+
+
+class BashTableFormatter(BaseTableFormatter):
+    """Table formatter specialised for Bash / shell scripts."""
+
+    # ------------------------------------------------------------------ #
+    # Public entry points                                                   #
+    # ------------------------------------------------------------------ #
+
+    def format_table(
+        self, analysis_result: dict[str, Any], table_type: str = "full"
+    ) -> str:
+        """Format table output for Bash."""
+        original = self.format_type
+        self.format_type = table_type
+        try:
+            if table_type == "json":
+                return self._format_json(analysis_result)
+            return self.format_structure(analysis_result)
+        finally:
+            self.format_type = original
+
+    def format_summary(self, analysis_result: dict[str, Any]) -> str:
+        """Compact table (summary) for Bash."""
+        return self._format_compact_table(analysis_result)
+
+    def format_structure(self, analysis_result: dict[str, Any]) -> str:
+        """Dispatch to the correct sub-formatter."""
+        return super().format_structure(analysis_result)
+
+    def format_advanced(
+        self, analysis_result: dict[str, Any], output_format: str = "json"
+    ) -> str:
+        """Advanced output for Bash."""
+        if output_format == "json":
+            return self._format_json(analysis_result)
+        if output_format == "csv":
+            return self._format_csv(analysis_result)
+        return self._format_full_table(analysis_result)
+
+    # ------------------------------------------------------------------ #
+    # Full table                                                            #
+    # ------------------------------------------------------------------ #
+
+    def _format_full_table(self, data: dict[str, Any]) -> str:
+        lines: list[str] = []
+        file_name = _file_stem(str(data.get("file_path", "Unknown")))
+        lines.append(f"# {file_name}")
+        lines.append("")
+
+        # Script info
+        stats = data.get("statistics") or {}
+        lines.append("## Script Info")
+        lines.append("| Property | Value |")
+        lines.append("|----------|-------|")
+        lines.append(
+            f"| Functions | {stats.get('method_count', len(data.get('methods', [])))} |"
+        )
+        lines.append(
+            f"| Variables | {stats.get('field_count', len(data.get('fields', [])))} |"
+        )
+        lines.append("")
+
+        # Imports (source/. statements)
+        imports = data.get("imports", [])
+        if imports:
+            lines.append("## Sourced Files")
+            lines.append("```bash")
+            for imp in imports:
+                stmt = imp.get("raw_text", "") or imp.get("import_statement", "")
+                if stmt:
+                    lines.append(stmt.strip())
+            lines.append("```")
+            lines.append("")
+
+        # Functions
+        methods = data.get("methods", []) or []
+        if methods:
+            lines.append("## Functions")
+            lines.append("| Name | Signature | Vis | Lines | Cx | Doc |")
+            lines.append("|------|-----------|-----|-------|----|-----|")
+            for method in methods:
+                lines.append(self._format_func_row(method))
+            lines.append("")
+
+        # Variables / globals
+        fields = data.get("fields", []) or []
+        if fields:
+            lines.append("## Variables")
+            lines.append("| Name | Type | Vis | Line |")
+            lines.append("|------|------|-----|------|")
+            for field in fields:
+                lines.append(self._format_field_row(field))
+            lines.append("")
+
+        while lines and lines[-1] == "":
+            lines.pop()
+        return "\n".join(lines)
+
+    # ------------------------------------------------------------------ #
+    # Compact table                                                         #
+    # ------------------------------------------------------------------ #
+
+    def _format_compact_table(self, data: dict[str, Any]) -> str:
+        lines: list[str] = []
+        file_name = _file_stem(str(data.get("file_path", "Unknown")))
+        lines.append(f"# {file_name}")
+        lines.append("")
+
+        stats = data.get("statistics") or {}
+        methods = data.get("methods", []) or []
+        fields = data.get("fields", []) or []
+
+        lines.append("## Info")
+        lines.append("| Property | Value |")
+        lines.append("|----------|-------|")
+        lines.append(f"| Functions | {stats.get('method_count', len(methods))} |")
+        lines.append(f"| Variables | {stats.get('field_count', len(fields))} |")
+        lines.append("")
+
+        if methods:
+            lines.append("## Functions")
+            lines.append("| Name | Sig | V | L | Cx | Doc |")
+            lines.append("|------|-----|---|---|----|-----|")
+            for method in methods:
+                lines.append(self._format_compact_func_row(method))
+            lines.append("")
+
+        while lines and lines[-1] == "":
+            lines.pop()
+        return "\n".join(lines)
+
+    # ------------------------------------------------------------------ #
+    # Row helpers                                                           #
+    # ------------------------------------------------------------------ #
+
+    def _format_func_row(self, func: dict[str, Any]) -> str:
+        name = str(func.get("name", ""))
+        sig = self._create_bash_signature(func)
+        vis = self._bash_visibility(name)
+        line_range = func.get("line_range", {})
+        lines_str = f"{line_range.get('start', 0)}-{line_range.get('end', 0)}"
+        complexity = func.get("complexity_score", 1)
+        doc = self._extract_doc_summary(
+            func.get("javadoc", "") or func.get("docstring", "") or ""
+        )
+        return f"| {name} | {sig} | {vis} | {lines_str} | {complexity} | {doc or '-'} |"
+
+    def _format_compact_func_row(self, func: dict[str, Any]) -> str:
+        name = str(func.get("name", ""))
+        params = func.get("parameters", [])
+        param_count = len(params) if isinstance(params, list) else 0
+        vis = "+" if self._bash_visibility(name) == "public" else "-"
+        line_range = func.get("line_range", {})
+        lines_str = f"{line_range.get('start', 0)}-{line_range.get('end', 0)}"
+        complexity = func.get("complexity_score", 1)
+        doc = self._extract_doc_summary(
+            func.get("javadoc", "") or func.get("docstring", "") or ""
+        )
+        return f"| {name} | ({param_count}) | {vis} | {lines_str} | {complexity} | {doc or '-'} |"
+
+    def _format_field_row(self, field: dict[str, Any]) -> str:
+        name = str(field.get("name", ""))
+        ftype = str(field.get("type", field.get("variable_type", "-")) or "-")
+        vis = self._bash_visibility(name)
+        line = field.get("line_range", {}).get("start", 0)
+        return f"| {name} | {ftype} | {vis} | {line} |"
+
+    # ------------------------------------------------------------------ #
+    # Signature / visibility helpers                                        #
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _create_bash_signature(func: dict[str, Any]) -> str:
+        params = func.get("parameters", [])
+        if not isinstance(params, list) or not params:
+            return "()"
+        parts = []
+        for p in params:
+            if isinstance(p, dict):
+                parts.append(str(p.get("name", "") or p.get("type", "")))
+            else:
+                parts.append(str(p))
+        return f"({', '.join(parts)})"
+
+    @staticmethod
+    def _bash_visibility(name: str) -> str:
+        """Bash functions starting with '_' are conventionally private."""
+        return "private" if name.startswith("_") else "public"
+
+    # ------------------------------------------------------------------ #
+    # Misc helpers                                                          #
+    # ------------------------------------------------------------------ #
+
+    def _format_json(self, data: dict[str, Any]) -> str:
+        import json
+
+        try:
+            return json.dumps(data, indent=2, ensure_ascii=False)
+        except (TypeError, ValueError) as e:
+            return f"# JSON serialization error: {e}\n"
+
+
+def _file_stem(file_path: str) -> str:
+    """Return just the filename (no directory) from a path."""
+    return file_path.replace("\\", "/").split("/")[-1]

--- a/tree_sitter_analyzer/formatters/formatter_registry.py
+++ b/tree_sitter_analyzer/formatters/formatter_registry.py
@@ -529,6 +529,7 @@ def _register_language_formatters_safe() -> None:
     try:
         # Import language-specific formatters
         from ..default_table_formatter import DefaultTableFormatter
+        from .bash_formatter import BashTableFormatter
         from .cpp_formatter import CppTableFormatter
         from .csharp_formatter import CSharpTableFormatter
         from .css_formatter import CSSFormatter
@@ -567,6 +568,8 @@ def _register_language_formatters_safe() -> None:
             "kotlin": KotlinTableFormatter,
             "kt": KotlinTableFormatter,
             "kts": KotlinTableFormatter,
+            "bash": BashTableFormatter,
+            "sh": BashTableFormatter,
             "go": GoTableFormatter,
             "rust": RustTableFormatter,
             "rs": RustTableFormatter,

--- a/tree_sitter_analyzer/formatters/go_formatter.py
+++ b/tree_sitter_analyzer/formatters/go_formatter.py
@@ -84,9 +84,10 @@ class GoTableFormatter(BaseTableFormatter):
         vis = self._go_visibility(name)
         line_range = func.get("line_range", {})
         lines_str = f"{line_range.get('start', 0)}-{line_range.get('end', 0)}"
+        complexity = func.get("complexity_score", 1)
         doc = self._extract_doc_summary(func.get("docstring", "") or "")
 
-        return f"| {name} | {sig} | {vis} | {lines_str} | {doc or '-'} |"
+        return f"| {name} | {sig} | {vis} | {lines_str} | {complexity} | {doc or '-'} |"
 
     def _format_method_row(self, method: dict[str, Any]) -> str:
         """Format a method table row for Go (with receiver)"""
@@ -98,11 +99,10 @@ class GoTableFormatter(BaseTableFormatter):
         vis = self._go_visibility(name)
         line_range = method.get("line_range", {})
         lines_str = f"{line_range.get('start', 0)}-{line_range.get('end', 0)}"
+        complexity = method.get("complexity_score", 1)
         doc = self._extract_doc_summary(method.get("docstring", "") or "")
 
-        return (
-            f"| {receiver_type} | {name} | {sig} | {vis} | {lines_str} | {doc or '-'} |"
-        )
+        return f"| {receiver_type} | {name} | {sig} | {vis} | {lines_str} | {complexity} | {doc or '-'} |"
 
     def _create_go_signature(self, func: dict[str, Any]) -> str:
         """Create Go function signature"""


### PR DESCRIPTION
## Summary

- **Go**: `_format_func_row` and `_format_method_row` now include `complexity_score`; `_go_formatter_helpers` headers updated from 5-column to 6-column layout (`| Func | Signature | Vis | Lines | Cx | Doc |` for functions, `| Receiver | Func | Signature | Vis | Lines | Cx | Doc |` for methods)
- **Bash**: new `BashTableFormatter` (registered for `"bash"` / `"sh"`) renders the standard 6-column method table (`| Name | Signature | Vis | Lines | Cx | Doc |` full, `| Name | Sig | V | L | Cx | Doc |` compact), replacing the legacy fallback that had no Cx column
- **Golden master** `tests/golden_masters/full/go_sample_full.md` regenerated with Cx column (all 20 functions have complexity_score = 1)
- **Codemap** `docs/CODEMAPS/formatters.md` updated to document `GoTableFormatter` and `BashTableFormatter`

**Audit result**: all other languages (Java, Python, JS/TS, PHP, Ruby, C#, C/C++, Kotlin, Rust, Scala, Swift) already rendered the Cx column. Only Go and Bash were missing it.

## Test plan

- [ ] `tests/unit/formatters/test_cx_column_coverage.py` — 15 exact-pin assertions
  - Go function header: `| Func | Signature | Vis | Lines | Cx | Doc |`
  - Go function row Cx=1: `| Compute | (n int) int | exported | 5-12 | 1 | - |`
  - Go function row Cx=5: `| Compute | (n int) int | exported | 5-12 | 5 | - |`
  - Go method header: `| Receiver | Func | Signature | Vis | Lines | Cx | Doc |`
  - Go method row Cx=3: `| Service | Run | () error | exported | 10-20 | 3 | - |`
  - Negative: old 5-column header `| Func | Signature | Vis | Lines | Doc |` absent
  - Bash function header: `| Name | Signature | Vis | Lines | Cx | Doc |`
  - Bash function row Cx=1: `| deploy | () | public | 3-15 | 1 | - |`
  - Bash function row Cx=4: `| deploy | () | public | 3-15 | 4 | - |`
  - Bash compact header: `| Name | Sig | V | L | Cx | Doc |`
  - Bash compact row Cx=2: `| deploy | (0) | + | 3-15 | 2 | - |`
  - Registry resolves `"bash"` → `BashTableFormatter`
  - Registry resolves `"sh"` → `BashTableFormatter`
  - Full table includes `## Functions` section header
  - Old legacy columns absent: `| Name | Return Type | Parameters | Access | Line |`
- [ ] All 3088 related tests pass: `uv run pytest tests -n 0 -q -k "go or bash or formatter or golden"`
- [ ] All hooks pass (ruff, mypy, bandit, tsa-codemap-sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)