### PR TITLE
fix(formatters): render top-level functions in PHP --table full output

### DIFF
--- a/tests/unit/formatters/test_php_formatter_helpers.py
+++ b/tests/unit/formatters/test_php_formatter_helpers.py
@@ -9,7 +9,6 @@ from tree_sitter_analyzer.formatters._php_formatter_helpers import (
 
 
 class TestGetVisibilitySymbol:
-
     def test_public(self):
         assert get_visibility_symbol("public") == "+"
 
@@ -30,7 +29,6 @@ class TestGetVisibilitySymbol:
 
 
 class TestFormatSignature:
-
     def test_no_params(self):
         method = {"parameters": [], "return_type": "void"}
         assert format_signature(method) == "():void"
@@ -82,7 +80,6 @@ class TestFormatSignature:
 
 
 class TestFormatCompactSignature:
-
     def test_dict_params(self):
         method = {
             "parameters": [{"name": "x", "type": "int"}],
@@ -107,13 +104,8 @@ class TestFormatCompactSignature:
 
 
 class TestExtractNamespace:
-
     def test_from_full_qualified_name(self):
-        data = {
-            "classes": [
-                {"full_qualified_name": "App\\Services\\UserService"}
-            ]
-        }
+        data = {"classes": [{"full_qualified_name": "App\\Services\\UserService"}]}
         assert extract_namespace(data) == "App\\Services"
 
     def test_from_metadata(self):
@@ -147,7 +139,6 @@ class TestExtractNamespace:
 
 
 class TestFormatFullTable:
-
     def test_empty_data(self):
         result = format_full_table({})
         assert isinstance(result, str)
@@ -390,7 +381,9 @@ class TestFormatFullTable:
         result = format_full_table(data)
         assert "User::getName" in result
 
-    def test_no_module_functions_without_classes(self):
+    def test_top_level_functions_rendered_without_classes(self):
+        # Regression: when classes=[], top-level functions MUST still produce a
+        # "## Functions" section (the old code had `if not classes: return`).
         data = {
             "file_path": "test.php",
             "classes": [],
@@ -401,16 +394,60 @@ class TestFormatFullTable:
                     "return_type": "void",
                     "visibility": "public",
                     "line_range": {"start": 1, "end": 5},
+                    "complexity_score": 1,
                 }
             ],
             "fields": [],
+            "imports": [],
         }
         result = format_full_table(data)
-        assert "## Functions" not in result
+        assert "## Functions" in result
+        assert "standalone" in result
+
+    def test_top_level_functions_exact_row_format(self):
+        # Pin exact row content for binary_search_iterative (cx=4) and greet (cx=1)
+        # so any formatter regression turns red immediately.
+        data = {
+            "file_path": "php_fns.php",
+            "classes": [],
+            "methods": [
+                {
+                    "name": "binary_search_iterative",
+                    "parameters": [
+                        {"name": "list", "type": "mixed"},
+                        {"name": "target", "type": "mixed"},
+                    ],
+                    "return_type": "mixed",
+                    "visibility": "public",
+                    "line_range": {"start": 2, "end": 11},
+                    "complexity_score": 4,
+                },
+                {
+                    "name": "greet",
+                    "parameters": [{"name": "name", "type": "mixed"}],
+                    "return_type": "mixed",
+                    "visibility": "public",
+                    "line_range": {"start": 12, "end": 12},
+                    "complexity_score": 1,
+                },
+            ],
+            "fields": [],
+            "imports": [],
+        }
+        result = format_full_table(data)
+        # Header row
+        assert "## Functions" in result
+        assert "| Method | Signature | Vis | Lines | Cx | Doc |" in result
+        # binary_search_iterative: exact complexity pin = 4
+        assert (
+            "| binary_search_iterative | ($list:mixed, $target:mixed):mixed | + | 2-11 | 4 | - |"
+            in result
+        )
+        # greet: exact complexity pin = 1
+        assert "| greet | ($name:mixed):mixed | + | 12-12 | 1 | - |" in result
 
 
 class TestFormatCompactTable:
-
     def test_empty_data(self):
         result = format_compact_table({})
         assert "# " in result

--- a/tree_sitter_analyzer/formatters/_php_formatter_helpers.py
+++ b/tree_sitter_analyzer/formatters/_php_formatter_helpers.py
@@ -268,9 +268,6 @@ def _full_method_row(
 def _append_module_level_functions(
     lines: list[str], classes: list[dict[str, Any]], methods: list[dict[str, Any]]
 ) -> None:
-    if not classes:
-        return
-
     module_methods = _module_level_methods(classes, methods)
     if not module_methods:
         return


### PR DESCRIPTION
## Summary

- **Bug**: `--advanced --table full` on a PHP file with only top-level functions (no class) rendered only the file title — no function table.
- **Root cause**: `_append_module_level_functions()` in `_php_formatter_helpers.py` had an early `if not classes: return` guard that silently skipped the entire section when the file was purely procedural.
- **Fix**: Remove the 3-line early-return guard. `_module_level_methods()` already handles the empty-classes case correctly (returns all methods when no class ranges exist), so no other change was needed.

## Test plan

- [x] RED-first: both new tests were confirmed FAILING before the fix
- [x] GREEN after fix: `test_top_level_functions_rendered_without_classes` + `test_top_level_functions_exact_row_format` pass
- [x] `test_top_level_functions_exact_row_format` pins exact Cx values (`binary_search_iterative=4`, `greet=1`) per locked exact-assertion rule
- [x] Old `test_no_module_functions_without_classes` (asserting the bug) removed and replaced with the above
- [x] Full PHP/formatter/golden suite: `uv run pytest tests -n 0 -q -k "php or formatter or golden"` → 2717 passed, 0 PHP/formatter failures (2 pre-existing Swift failures unrelated to this change)
- [x] Golden master `php_sample_full.md` unchanged (class-based rendering unaffected)
- [x] End-to-end CLI: `uv run python -m tree_sitter_analyzer /tmp/php_fns.php --advanced --table full --project-root /tmp` now shows the Functions table with Cx column

🤖 Generated with [Claude Code](https://claude.com/claude-code)