### PR TITLE
fix(rust): render parameters as proper Rust syntax in --table full

### DIFF
--- a/tests/golden_masters/csv/rust_sample_csv.csv
+++ b/tests/golden_masters/csv/rust_sample_csv.csv
@@ -12,12 +12,12 @@
 ## Functions
 | Function | Signature | Vis | Async | Lines | Doc |
 |----------|-----------|-----|-------|-------|-----|
-| display | fn({'name': 'self', 'type': 'Any'}) -> String | public | - | 25-25 | - |
-| summary | fn({'name': 'self', 'type': 'Any'}) -> String | public | - | 27-29 | - |
-| new | fn({'name': 'id', 'type': 'u64'}, {'name': 'username', 'type': 'String'}, {'name': 'email', 'type': 'String'}) -> Self | public | - | 34-41 | - |
-| deactivate | fn({'name': 'self', 'type': 'Any'}) | public | - | 44-46 | - |
-| is_active | fn({'name': 'self', 'type': 'Any'}) -> bool | public | - | 49-51 | - |
-| display | fn({'name': 'self', 'type': 'Any'}) -> String | public | - | 55-57 | - |
-| fetch_user_data | fn({'name': 'user_id', 'type': 'u64'}) -> Result<User, String> | public | Yes | 61-64 | - |
-| new | fn({'name': 'item', 'type': 'T'}) -> Self | public | - | 72-74 | - |
+| display | fn(self) -> String | public | - | 25-25 | - |
+| summary | fn(self) -> String | public | - | 27-29 | - |
+| new | fn(id: u64, username: String, email: String) -> Self | public | - | 34-41 | - |
+| deactivate | fn(self) | public | - | 44-46 | - |
+| is_active | fn(self) -> bool | public | - | 49-51 | - |
+| display | fn(self) -> String | public | - | 55-57 | - |
+| fetch_user_data | fn(user_id: u64) -> Result<User, String> | public | Yes | 61-64 | - |
+| new | fn(item: T) -> Self | public | - | 72-74 | - |
 | main | fn() | public | - | 91-93 | - |

--- a/tests/golden_masters/full/rust_sample_full.md
+++ b/tests/golden_masters/full/rust_sample_full.md
@@ -12,12 +12,12 @@
 ## Functions
 | Function | Signature | Vis | Async | Lines | Doc |
 |----------|-----------|-----|-------|-------|-----|
-| display | fn({'name': 'self', 'type': 'Any'}) -> String | public | - | 25-25 | - |
-| summary | fn({'name': 'self', 'type': 'Any'}) -> String | public | - | 27-29 | - |
-| new | fn({'name': 'id', 'type': 'u64'}, {'name': 'username', 'type': 'String'}, {'name': 'email', 'type': 'String'}) -> Self | public | - | 34-41 | - |
-| deactivate | fn({'name': 'self', 'type': 'Any'}) | public | - | 44-46 | - |
-| is_active | fn({'name': 'self', 'type': 'Any'}) -> bool | public | - | 49-51 | - |
-| display | fn({'name': 'self', 'type': 'Any'}) -> String | public | - | 55-57 | - |
-| fetch_user_data | fn({'name': 'user_id', 'type': 'u64'}) -> Result<User, String> | public | Yes | 61-64 | - |
-| new | fn({'name': 'item', 'type': 'T'}) -> Self | public | - | 72-74 | - |
+| display | fn(self) -> String | public | - | 25-25 | - |
+| summary | fn(self) -> String | public | - | 27-29 | - |
+| new | fn(id: u64, username: String, email: String) -> Self | public | - | 34-41 | - |
+| deactivate | fn(self) | public | - | 44-46 | - |
+| is_active | fn(self) -> bool | public | - | 49-51 | - |
+| display | fn(self) -> String | public | - | 55-57 | - |
+| fetch_user_data | fn(user_id: u64) -> Result<User, String> | public | Yes | 61-64 | - |
+| new | fn(item: T) -> Self | public | - | 72-74 | - |
 | main | fn() | public | - | 91-93 | - |

--- a/tests/unit/formatters/test_rust_formatter.py
+++ b/tests/unit/formatters/test_rust_formatter.py
@@ -417,6 +417,124 @@ class TestRustFormatterFormatJson:
         assert result is not None
 
 
+class TestRustFormatterParamDictLeak:
+    """Regression tests: parameters must never render as raw Python dicts.
+
+    Before the fix, parameters provided as dicts (e.g. from the Rust extractor)
+    were coerced via ``str(p)`` which produced the ugly
+    ``{'name': 'self', 'type': 'Any'}`` literal in the signature column.
+    """
+
+    def test_format_rust_param_dict_self(self):
+        """self param as dict renders as bare 'self' (Rust convention)."""
+        formatter = RustTableFormatter()
+        result = formatter._format_rust_param({"name": "self", "type": "Any"})
+        assert result == "self"
+        assert "{'name'" not in result
+
+    def test_format_rust_param_dict_ref_self(self):
+        """&self param as dict renders as '&self'."""
+        formatter = RustTableFormatter()
+        result = formatter._format_rust_param({"name": "&self", "type": "Any"})
+        assert result == "&self"
+        assert "{'name'" not in result
+
+    def test_format_rust_param_dict_mut_self(self):
+        """&mut self param as dict renders as '&mut self'."""
+        formatter = RustTableFormatter()
+        result = formatter._format_rust_param({"name": "&mut self", "type": "Any"})
+        assert result == "&mut self"
+        assert "{'name'" not in result
+
+    def test_format_rust_param_dict_typed(self):
+        """Typed param renders as 'name: type'."""
+        formatter = RustTableFormatter()
+        result = formatter._format_rust_param({"name": "value", "type": "&T"})
+        assert result == "value: &T"
+        assert "{'name'" not in result
+
+    def test_format_rust_param_dict_i32(self):
+        """Typed param with primitive type renders correctly."""
+        formatter = RustTableFormatter()
+        result = formatter._format_rust_param({"name": "a", "type": "i32"})
+        assert result == "a: i32"
+        assert "{'name'" not in result
+
+    def test_format_rust_param_string(self):
+        """String params (already formatted) pass through unchanged."""
+        formatter = RustTableFormatter()
+        assert formatter._format_rust_param("x: i32") == "x: i32"
+        assert formatter._format_rust_param("&self") == "&self"
+
+    def test_create_full_signature_dict_params_no_leak(self):
+        """Full signature with dict params must not contain literal braces."""
+        formatter = RustTableFormatter()
+        fn = {
+            "name": "search",
+            "parameters": [
+                {"name": "self", "type": "Any"},
+                {"name": "value", "type": "&T"},
+            ],
+            "return_type": "bool",
+        }
+        result = formatter._create_full_signature(fn)
+        assert result == "fn(self, value: &T) -> bool"
+        assert "{'name'" not in result
+
+    def test_create_full_signature_add_dict_params(self):
+        """fn(a: i32, b: i32) -> i32 from dict params."""
+        formatter = RustTableFormatter()
+        fn = {
+            "name": "add",
+            "parameters": [
+                {"name": "a", "type": "i32"},
+                {"name": "b", "type": "i32"},
+            ],
+            "return_type": "i32",
+        }
+        result = formatter._create_full_signature(fn)
+        assert result == "fn(a: i32, b: i32) -> i32"
+        assert "{'name'" not in result
+
+    def test_format_full_table_dict_params_no_leak(self):
+        """Full table output must not contain raw dict reprs in any row."""
+        formatter = RustTableFormatter()
+        data = {
+            "file_path": "src/lib.rs",
+            "modules": [],
+            "classes": [],
+            "methods": [
+                {
+                    "name": "search",
+                    "parameters": [
+                        {"name": "self", "type": "Any"},
+                        {"name": "value", "type": "&T"},
+                    ],
+                    "visibility": "pub",
+                    "return_type": "bool",
+                    "line_range": {"start": 10, "end": 15},
+                    "is_async": False,
+                    "docstring": "",
+                },
+                {
+                    "name": "new",
+                    "parameters": [],
+                    "visibility": "pub",
+                    "return_type": "Self",
+                    "line_range": {"start": 20, "end": 25},
+                    "is_async": False,
+                    "docstring": "",
+                },
+            ],
+            "fields": [],
+        }
+        result = formatter._format_full_table(data)
+        assert "{'name'" not in result
+        assert "search" in result
+        assert "fn(self, value: &T) -> bool" in result
+        assert "fn() -> Self" in result
+
+
 class TestRustFormatterEdgeCases:
     """Test edge cases"""
 

--- a/tree_sitter_analyzer/formatters/rust_formatter.py
+++ b/tree_sitter_analyzer/formatters/rust_formatter.py
@@ -164,11 +164,31 @@ class RustTableFormatter(BaseTableFormatter):
 
         return f"| {name} | {signature} | {visibility} | {is_async} | {lines_str} | {doc} |"
 
+    @staticmethod
+    def _format_rust_param(param: Any) -> str:
+        """Render one Rust parameter as proper Rust syntax (never a raw dict repr).
+
+        Handles three cases:
+        - Receiver params (``self`` / ``&self`` / ``&mut self``): the extractor
+          sets ``type`` to the placeholder ``'Any'``; render as the bare name only.
+        - Typed dict ``{"name": "value", "type": "&T"}`` → ``"value: &T"``.
+        - String (already formatted by the extractor) → pass through unchanged.
+        """
+        if isinstance(param, dict):
+            name = param.get("name", "")
+            ptype = param.get("type", "")
+            # Receiver params and Any-typed params: return bare name
+            if ptype in ("Any", "", None) or name in ("self", "&self", "&mut self"):
+                return name or ptype or str(param)
+            if name and ptype:
+                return f"{name}: {ptype}"
+            return name or ptype or str(param)
+        return str(param)
+
     def _create_full_signature(self, fn: dict[str, Any]) -> str:
         """Create full function signature for Rust"""
         params = fn.get("parameters", [])
-        # Rust parameters are usually strings like "x: i32", keep them as is or simplify
-        params_str = ", ".join([str(p) for p in params])
+        params_str = ", ".join(self._format_rust_param(p) for p in params)
         return_type = fn.get("return_type", "")
         ret_str = f" -> {return_type}" if return_type and return_type != "()" else ""
 


### PR DESCRIPTION
## Summary

- The Rust table formatter was calling `str(p)` on each parameter dict, leaking raw Python repr like `{'name': 'self', 'type': 'Any'}` into the Signature column of `--table full` / `--advanced --table full` output. Same class of bug as the Go fix in #1053.
- Added `_format_rust_param()` static method (mirrors Go's `_format_go_param`) that renders receiver params (`self`/`&self`/`&mut self`) as bare names and typed params as `name: type`.
- Updated `_create_full_signature()` to use `_format_rust_param()` instead of `str()`.
- Regenerated Rust golden masters (full `.md`, `.csv`, `.toon`) with corrected signatures.

**Before:** `fn({'name': 'self', 'type': 'Any'}, {'name': 'value', 'type': '&T'}) -> bool`
**After:** `fn(self, value: &T) -> bool`

## Test plan

- [x] 9 RED tests added to `tests/unit/formatters/test_rust_formatter.py::TestRustFormatterParamDictLeak` — confirmed RED before fix
- [x] All 41 Rust formatter tests pass GREEN after fix
- [x] `uv run pytest tests -n 0 -q -k "rust or formatter or golden"` — 2746 passed (2 pre-existing Swift failures unrelated to this change, due to missing `tree_sitter_swift`)
- [x] Rust golden masters regenerated and verified correct

## Swift `Any` type note

The Swift formatter does not exist as a separate formatter (`LanguageFormatterFactory` has no Swift entry). The "Swift `Any` type" issue mentioned in the task description would require a separate investigation into how Swift files are processed. Deferred as a follow-up — out of scope for this focused formatter fix.