### PR TITLE
ci: activate Claude PR review bot on main

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,115 @@
+# Claude PR Review — a Claude-powered reviewer that guards every PR,
+# the same way the Codex connector does, but driven by this repo's own
+# workflow so it never depends on an external connector's rate window.
+#
+# Triggers:
+#   * automatically on every PR open / new pushes (synchronize) / reopen
+#   * on demand when someone comments "@claude review" on a PR
+#
+# Auth: needs the ANTHROPIC_API_KEY repo secret (owner adds it under
+#   Settings → Secrets and variables → Actions). A CLAUDE_CODE_OAUTH_TOKEN
+#   secret works as an alternative — see the `with:` block below.
+#
+# The reviewer posts inline comments + a top-level summary using the
+# GitHub CLI and the action's inline-comment MCP tool. It is instructed
+# to honor the LOCKED design decisions in CLAUDE.md so it does not raise
+# findings the project has already settled (TOON default, exact-assertion
+# tests, etc.).
+
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+
+# Least privilege: read the code, write PR comments/reviews, mint the
+# OIDC token the action uses for the GitHub MCP server.
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+# One review per PR at a time; a new push cancels an in-flight review so
+# we never post stale feedback against an old commit.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    # Auto-review on PR events; for comments, only when it's a PR comment
+    # that explicitly asks for "@claude review".
+    if: >
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request != null &&
+       contains(github.event.comment.body, '@claude review'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Claude review
+        uses: anthropics/claude-code-action@v1
+        with:
+          # Owner must add ANTHROPIC_API_KEY (or swap in
+          # claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}).
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+
+            You are the project's PR reviewer for tree-sitter-analyzer (TSA),
+            a 21-language code-intelligence tool with CLI + MCP surfaces.
+            Review this pull request like an adversarial senior engineer whose
+            job is to find real defects — not to rubber-stamp. The PR branch is
+            already checked out in the current working directory.
+
+            Focus, in priority order:
+            1. Correctness bugs — wrong logic, edge cases, off-by-one, broken
+               cross-surface (CLI vs MCP) parity, regressions in language
+               extractors/formatters.
+            2. Test quality — does a new test actually pin behavior? Flag any
+               self-protecting test that asserts the buggy shape. Flag loose
+               count/measurement assertions (>=, >, <=, <) on deterministic
+               values: this repo REQUIRES exact assertions (== N). See
+               CLAUDE.md "Exact assertions only".
+            3. Security — injection, path traversal, secret leakage, unsafe
+               deserialization, unbounded recursion over external objects.
+            4. Scope/hygiene — kitchen-sink PRs (title must match the diff),
+               half-baked changes, files dropped in the repo root.
+
+            MUST honor these LOCKED design decisions (do NOT raise them as
+            findings — they are settled, see CLAUDE.md):
+            - MCP defaults to TOON output; CLI defaults to JSON. Never suggest
+              flipping the `output_format` default from "toon" to "json" or
+              removing the "toon" default literal.
+            - Exact-value test assertions are intentional. Do NOT suggest
+              relaxing an `== N` assertion to a `>= N` lower bound "for
+              resilience" — that is explicitly rejected.
+            - project_root canonicalisation, BaseMCPTool/PathResolver/
+              SecurityValidator changes are foundational; only comment if the
+              PR actually touches them incorrectly.
+            - Markdown smell-detection is intentionally OFF in project_health.
+
+            For each finding give: file:line, severity (P1 blocking / P2 should-fix
+            / P3 nice-to-have), the concrete problem, and a suggested fix. If the
+            PR is clean, say so plainly — do not invent issues.
+
+            Post feedback on GitHub only (do not return review text as a chat
+            message):
+            - Use `mcp__github_inline_comment__create_inline_comment` (with
+              confirmed: true) for specific line-level issues.
+            - Use `gh pr comment` for the top-level summary with the findings table.
+
+          # Pin the reviewer model. claude_args is a passthrough to the
+          # Claude CLI; --model selects the model and --allowedTools scopes
+          # what the reviewer may run.
+          claude_args: |
+            --model claude-opus-4-8
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## What

Puts `.github/workflows/claude-review.yml` on the default branch (`main`) so the Claude reviewer added in #1071 actually runs.

## Why a hotfix → main

`anthropics/claude-code-action` has an anti-tampering guard: it only runs when the workflow file is **byte-identical to the version on the repo's default branch (main)**. The bot is inert until the file exists on main, and GitFlow forbids `ci/* → main` — so this uses the `hotfix/*` path (mechanically allowed by gitflow-guard). No release is in flight; develop is not frozen.

The file is verified byte-identical to the copy merged to develop in #1071.

## Effect

After merge, every PR targeting develop is reviewed by Claude (opus-4-8), plus on-demand via `@claude review`. Reuses the existing `ANTHROPIC_API_KEY` secret.

## Test plan
- [x] actionlint clean (pre-commit)
- [x] byte-identical to develop's #1071 version (validated with `diff`)
- [ ] first real review fires on the next develop-targeting PR after merge