### PR TITLE
ci: authenticate Claude review bot via subscription OAuth token

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -6,15 +6,18 @@
 #   * automatically on every PR open / new pushes (synchronize) / reopen
 #   * on demand when someone comments "@claude review" on a PR
 #
-# Auth: needs the ANTHROPIC_API_KEY repo secret (owner adds it under
-#   Settings → Secrets and variables → Actions). A CLAUDE_CODE_OAUTH_TOKEN
-#   secret works as an alternative — see the `with:` block below.
+# Auth: uses a Claude Pro/Max SUBSCRIPTION via an OAuth token (no API
+#   billing). Generate it once with `claude setup-token` locally, then add
+#   it as the repo secret CLAUDE_CODE_OAUTH_TOKEN under
+#   Settings → Secrets and variables → Actions. (An ANTHROPIC_API_KEY would
+#   work as an alternative, but this project authenticates by subscription.)
 #
-# The reviewer posts inline comments + a top-level summary using the
-# GitHub CLI and the action's inline-comment MCP tool. It is instructed
-# to honor the LOCKED design decisions in CLAUDE.md so it does not raise
-# findings the project has already settled (TOON default, exact-assertion
-# tests, etc.).
+# The reviewer posts a top-level summary via the GitHub CLI, plus inline
+# comments where possible. Note: inline-comment classification works best
+# with an API key; on a subscription token the summary path is the primary
+# channel. It is instructed to honor the LOCKED design decisions in
+# CLAUDE.md so it does not raise findings the project has already settled
+# (TOON default, exact-assertion tests, etc.).
 
 name: Claude PR Review
 
@@ -56,9 +59,9 @@ jobs:
       - name: Claude review
         uses: anthropics/claude-code-action@v1
         with:
-          # Owner must add ANTHROPIC_API_KEY (or swap in
-          # claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}).
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Subscription auth: token from `claude setup-token`, stored as
+          # the CLAUDE_CODE_OAUTH_TOKEN repo secret (no API key / no billing).
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
## What

Switches the Claude review bot (added in #1071) from `anthropic_api_key` to **`claude_code_oauth_token`**, so it runs on a **Claude Pro/Max subscription** instead of pay-as-you-go API billing.

## Why

The repo owner has a Claude Code subscription, not API credits. The official action supports subscription auth via an OAuth token.

## Owner action required (one-time)

1. Locally run: `claude setup-token` (requires an active Pro/Max subscription)
2. Copy the token it prints
3. Add it as a repo secret named **`CLAUDE_CODE_OAUTH_TOKEN`** (Settings → Secrets and variables → Actions)

Until that secret exists, the bot will fail to authenticate — but it is already inert until the workflow reaches `main` anyway (anti-tampering guard, see #1071), so there's no rush.

## Note

Inline-comment classification works best with an API key; on a subscription token the **top-level `gh pr comment` summary** is the primary feedback channel — which is already the prompt's main path. Model stays `claude-opus-4-8` (adjust `--model` in `claude_args` if your plan tier doesn't include Opus).

## Test plan
- [x] actionlint clean (pre-commit)
- [x] YAML parses
- [ ] After secret is added + workflow reaches main: bot posts a review summary on the next develop PR