### PR TITLE
fix(swift): preserve parameter & return type info in extraction

### DIFF
--- a/tests/golden_masters/full/swift_sample_full.md
+++ b/tests/golden_masters/full/swift_sample_full.md
@@ -24,14 +24,14 @@ import Foundation
 ### Methods
 | Name | Return Type | Parameters | Access | Line |
 |------|-------------|------------|--------|------|
-| greet | String | Any name | internal | 4 |
+| greet | String | String name | internal | 4 |
 
 ## Greeting (7-19)
 ### Methods
 | Name | Return Type | Parameters | Access | Line |
 |------|-------------|------------|--------|------|
-| init | - | Any prefix | public | 11 |
-| greet | String | Any name | public | 15 |
+| init | - | String prefix | public | 11 |
+| greet | String | String name | public | 15 |
 
 ### Fields
 | Name | Type | Access | Static | Final | Line |
@@ -43,7 +43,7 @@ import Foundation
 ### Methods
 | Name | Return Type | Parameters | Access | Line |
 |------|-------------|------------|--------|------|
-| welcome | String | Any user | internal | 24 |
+| welcome | String | String user | internal | 24 |
 
 ### Fields
 | Name | Type | Access | Static | Final | Line |

--- a/tests/unit/languages/test_swift_plugin.py
+++ b/tests/unit/languages/test_swift_plugin.py
@@ -127,8 +127,29 @@ class TestSwiftExtraction:
         assert load.return_type == "User"
 
         greet = next(item for item in functions if item.name == "greet")
-        assert greet.parameters == ["message"]
+        assert greet.parameters == ["message: String"]
         assert greet.return_type == "String"
+
+    def test_function_parameters_keep_types(self, plugin: SwiftPlugin) -> None:
+        # Swift params must render as "name: Type" (mirrors Rust), not bare
+        # names — the internal name + the type, with the external argument
+        # label and the `_` no-label marker dropped, and default values
+        # stripped. Regression for the type-dropping defect.
+        sample = """
+        func config(name: String, times count: Int = 3, _ flag: Bool) -> Void {}
+        func lookup(map: [String: Int]) -> Int { return 0 }
+        """
+        tree = _swift_parser().parse(sample.encode("utf-8"))
+        functions = plugin.create_extractor().extract_functions(tree, sample)
+        by_name = {item.name: item for item in functions}
+        assert by_name["config"].parameters == [
+            "name: String",
+            "count: Int",
+            "flag: Bool",
+        ]
+        # A dictionary type contains its own colon; only the first colon
+        # separates name from type.
+        assert by_name["lookup"].parameters == ["map: [String: Int]"]
 
     def test_extract_variables(self, plugin: SwiftPlugin, tree) -> None:
         variables = plugin.create_extractor().extract_variables(tree, SWIFT_SAMPLE)

--- a/tests/unit/languages/test_swift_plugin.py
+++ b/tests/unit/languages/test_swift_plugin.py
@@ -151,6 +151,26 @@ class TestSwiftExtraction:
         # separates name from type.
         assert by_name["lookup"].parameters == ["map: [String: Int]"]
 
+    def test_return_types_with_brackets_and_closures(self, plugin: SwiftPlugin) -> None:
+        # Swift return types using collection shorthand ([T], [K: V]) or
+        # tuples start with a bracket/paren, and a completion-handler param
+        # carries its own `->`. The return type is the text after the final
+        # signature arrow, before the body. Regression for return types
+        # being dropped (returned None) on bracket-led types.
+        sample = """
+        func all() -> [String: [Int]] { return [:] }
+        func ids() -> [Int] { return [] }
+        func pair() -> (Int, String) { return (0, "") }
+        func register(handler: () -> Void) -> Bool { return true }
+        """
+        tree = _swift_parser().parse(sample.encode("utf-8"))
+        functions = plugin.create_extractor().extract_functions(tree, sample)
+        ret = {item.name: item.return_type for item in functions}
+        assert ret["all"] == "[String: [Int]]"
+        assert ret["ids"] == "[Int]"
+        assert ret["pair"] == "(Int, String)"
+        assert ret["register"] == "Bool"
+
     def test_extract_variables(self, plugin: SwiftPlugin, tree) -> None:
         variables = plugin.create_extractor().extract_variables(tree, SWIFT_SAMPLE)
         by_name = {item.name: item for item in variables}

--- a/tree_sitter_analyzer/languages/_swift_plugin_elements.py
+++ b/tree_sitter_analyzer/languages/_swift_plugin_elements.py
@@ -294,11 +294,28 @@ def _parameter_names(raw_text: str) -> list[str]:
     match = re.search(r"\(([^)]*)\)", raw_text, flags=re.DOTALL)
     if not match:
         return []
-    return [_parameter_name(part) for part in match.group(1).split(",") if part.strip()]
+    return [_parameter(part) for part in match.group(1).split(",") if part.strip()]
 
 
-def _parameter_name(parameter_text: str) -> str:
-    before_type = parameter_text.split(":", 1)[0].strip()
+def _parameter(parameter_text: str) -> str:
+    """Render a Swift parameter as ``name: Type`` (mirrors Rust).
+
+    Drops the external argument label and the ``_`` no-label marker (keeping
+    the internal name), strips any default value, and splits on the *first*
+    colon only so dictionary types like ``[String: Int]`` stay intact.
+    """
+    before_type, sep, after_type = parameter_text.partition(":")
+    name = _parameter_name(before_type)
+    if not sep:
+        return name
+    type_text = " ".join(after_type.split("=", 1)[0].split())
+    if not type_text:
+        return name
+    return f"{name}: {type_text}" if name else type_text
+
+
+def _parameter_name(before_type: str) -> str:
+    before_type = before_type.strip()
     if not before_type:
         return ""
     tokens = before_type.split()

--- a/tree_sitter_analyzer/languages/_swift_plugin_elements.py
+++ b/tree_sitter_analyzer/languages/_swift_plugin_elements.py
@@ -323,10 +323,19 @@ def _parameter_name(before_type: str) -> str:
 
 
 def _return_type(raw_text: str) -> str | None:
-    match = re.search(r"->\s*([A-Za-z_][A-Za-z0-9_?.<>,\s]*)", raw_text)
-    if not match:
+    """Extract a Swift return type, including bracket/tuple-led types.
+
+    The return type is the text after the *final* signature arrow (so a
+    completion-handler parameter's own ``->`` is ignored) and before the
+    function body. This covers collection shorthand (``[T]``, ``[K: V]``)
+    and tuples (``(A, B)``), which the previous letter-anchored regex
+    dropped entirely.
+    """
+    signature = raw_text.split("{", 1)[0]
+    arrow = signature.rfind("->")
+    if arrow == -1:
         return None
-    return match.group(1).split("{", 1)[0].strip()
+    return signature[arrow + 2 :].strip() or None
 
 
 def _import_module_path(raw_text: str) -> str:


### PR DESCRIPTION
## Bug

Swift extraction dropped type information via two overly-narrow regexes — found by **dogfooding TSA's own `structure` output on Swift** (self-evolution loop):

**1. Parameter types dropped.** `_parameter_name` split on `:` and kept only the name. Output was `parameters=["name"]` instead of `["name: String"]`; the full-table formatter then rendered the missing type as **`Any`** (`Any name`).

**2. Bracket/tuple return types dropped.** `_return_type`'s regex was anchored to `[A-Za-z_]`, so collection-shorthand (`[T]`, `[K: V]`) and tuple (`(A, B)`) return types — which start with `[`/`(` — returned **`None`**. `func all() -> [String: [Int]]` lost its return type entirely.

Same root cause: narrow regex losing Swift type info.

### Before → After
```
func greet(name: String, count: Int) -> String
  params: ['name','count']         → ['name: String','count: Int']
  table:  | greet | String | Any name | …  → | … | String name | …

func all() -> [String: [Int]]
  return_type: None                → '[String: [Int]]'
```

## Fix
- **Params:** render `name: Type` (mirrors Rust) — internal name kept, external label and `_` dropped, defaults stripped, split on first colon only so `[String: Int]` stays intact.
- **Return:** take the text after the *final* signature arrow (ignores a completion-handler param's own `->`) up to the body.

Completes the typed-info family alongside Go (#1053) and Rust (#1066). Verified C#/Kotlin/PHP/Java/C/C++/TS already preserve types — Swift was the sole outlier.

## Tests (RED-first, exact assertions)
- `test_extract_functions` updated: `greet.parameters == ["message: String"]`
- `test_function_parameters_keep_types`: labels, `_`, defaults, dict type
- `test_return_types_with_brackets_and_closures`: dict, array, tuple, completion-handler param
- Re-pinned `swift_sample_full.md` golden (`Any name` → `String name`)

## Verification
`tests/unit/languages/ tests/unit/formatters/ tests/golden/` → **6317 passed, 30 skipped**