### PR TITLE
fix(swift): keep nested-comma parameter types intact (no dropped params)

### DIFF
--- a/tests/unit/languages/test_swift_plugin.py
+++ b/tests/unit/languages/test_swift_plugin.py
@@ -151,6 +151,30 @@ class TestSwiftExtraction:
         # separates name from type.
         assert by_name["lookup"].parameters == ["map: [String: Int]"]
 
+    def test_parameters_with_nested_commas(self, plugin: SwiftPlugin) -> None:
+        # Tuple, generic, and multi-arg-closure parameter types contain their
+        # own commas/parens. The parameter clause must be matched with
+        # balanced parens (not the first ")") and split on top-level commas
+        # only — otherwise the nested comma both corrupts the type AND drops
+        # every following parameter.
+        sample = """
+        func handle(pair: (Int, String), name: String) -> Bool { return true }
+        func run(onDone: (Int, Error?) -> Void, tag: String) {}
+        func wrap(box: Result<Int, Error>, count: Int) {}
+        """
+        tree = _swift_parser().parse(sample.encode("utf-8"))
+        functions = plugin.create_extractor().extract_functions(tree, sample)
+        by_name = {item.name: item for item in functions}
+        assert by_name["handle"].parameters == ["pair: (Int, String)", "name: String"]
+        assert by_name["run"].parameters == [
+            "onDone: (Int, Error?) -> Void",
+            "tag: String",
+        ]
+        assert by_name["wrap"].parameters == [
+            "box: Result<Int, Error>",
+            "count: Int",
+        ]
+
     def test_return_types_with_brackets_and_closures(self, plugin: SwiftPlugin) -> None:
         # Swift return types using collection shorthand ([T], [K: V]) or
         # tuples start with a bracket/paren, and a completion-handler param

--- a/tree_sitter_analyzer/languages/_swift_plugin_elements.py
+++ b/tree_sitter_analyzer/languages/_swift_plugin_elements.py
@@ -291,10 +291,53 @@ def _swift_import_fields(
 
 
 def _parameter_names(raw_text: str) -> list[str]:
-    match = re.search(r"\(([^)]*)\)", raw_text, flags=re.DOTALL)
-    if not match:
+    clause = _parameter_clause(raw_text)
+    if clause is None:
         return []
-    return [_parameter(part) for part in match.group(1).split(",") if part.strip()]
+    return [_parameter(part) for part in _split_top_level(clause) if part.strip()]
+
+
+def _parameter_clause(raw_text: str) -> str | None:
+    """Return the text inside the parameter parentheses, matched with
+    balanced parens so tuple/closure types keep their own ``)``."""
+    start = raw_text.find("(")
+    if start == -1:
+        return None
+    depth = 0
+    for index in range(start, len(raw_text)):
+        char = raw_text[index]
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if depth == 0:
+                return raw_text[start + 1 : index]
+    return raw_text[start + 1 :]
+
+
+def _split_top_level(text: str) -> list[str]:
+    """Split on commas that sit outside any (), [], or <> nesting, so a
+    tuple ``(Int, String)``, dictionary, or generic ``Result<Int, Error>``
+    stays in one parameter. The ``>`` of a ``->`` arrow is not a closer."""
+    parts: list[str] = []
+    depth = 0
+    current: list[str] = []
+    prev = ""
+    for char in text:
+        if char in "([<":
+            depth += 1
+        elif char in ")]":
+            depth = max(0, depth - 1)
+        elif char == ">" and prev != "-":
+            depth = max(0, depth - 1)
+        if char == "," and depth == 0:
+            parts.append("".join(current))
+            current = []
+        else:
+            current.append(char)
+        prev = char
+    parts.append("".join(current))
+    return parts
 
 
 def _parameter(parameter_text: str) -> str:


### PR DESCRIPTION
## Bug (silent parameter loss)

Follow-up to #1074, found by continued dogfooding. `_parameter_names` had two nesting-blind steps:
1. The clause regex `\(([^)]*)\)` stops at the **first** `)` — a tuple/closure param's own paren — truncating the parameter list.
2. `.split(",")` then breaks on a tuple's internal comma.

Result: a following parameter is **dropped entirely**, not just mis-rendered.

### Before → After
```
func handle(pair: (Int, String), name: String) -> Bool
  before: ['pair: (Int', 'String']          # tuple corrupted, name: String LOST
  after:  ['pair: (Int, String)', 'name: String']

func run(onDone: (Int, Error?) -> Void, tag: String)
  before: ['onDone: (Int', 'Error?']         # tag LOST
  after:  ['onDone: (Int, Error?) -> Void', 'tag: String']
```

## Fix
- Match the parameter clause with **balanced parens** (scan to the matching `)`).
- Split on **top-level commas only**, tracking `()`/`[]`/`<>` depth (the `>` of a `->` arrow is not a closer).

Tuples, dictionaries, generics (`Result<Int, Error>`), and multi-arg closure types now stay in one parameter.

## Tests (RED-first, exact assertions)
- `test_parameters_with_nested_commas`: tuple, multi-arg closure, generic — each with a trailing param to prove no loss
- Golden master unchanged; existing Swift param/return tests still pass

## Verification
`tests/unit/languages/ tests/unit/formatters/ tests/golden/` → **6318 passed, 30 skipped**