### PR TITLE
perf(mcp): omit empty agent_next_action guidance fields (RFC-0018 Part 3)

### DIFF
--- a/tests/unit/mcp/test_file_health_tool.py
+++ b/tests/unit/mcp/test_file_health_tool.py
@@ -96,12 +96,12 @@ def test_file_health_result_marks_healthy_files_as_no_action() -> None:
         "src/healthy.py", health, [], "/tmp/healthy.py", None
     )
 
+    # RFC-0018 Part 3: a no-op action omits the empty command fields
+    # (``mcp_command``/``cli_command``/``post_edit_commands``) — they carry
+    # zero agent signal and cost tokens on every healthy-file response.
     assert result["agent_next_action"] == {
         "priority": "none",
         "reason": "file is healthy enough; no immediate refactor needed",
-        "mcp_command": "",
-        "cli_command": "",
-        "post_edit_commands": [],
     }
     # M10 (round-26): file_health's top-level ``verdict`` mirrors into
     # ``agent_summary`` via ``mirror_summary_line``. Grade A → SAFE.
@@ -576,5 +576,10 @@ def test_file_health_empty_file(tmp_path) -> None:
     assert "empty" in result["recommendation"].lower()
     # The follow-up actions must be no-ops — agents must not chain refactor
     # commands on a 0-byte file.
-    assert result["agent_next_action"]["mcp_command"] == ""
-    assert result["agent_next_action"]["post_edit_commands"] == []
+    # RFC-0018 Part 3: the no-op action omits empty command fields rather
+    # than ship ``mcp_command:""`` / ``post_edit_commands:[]`` (zero signal).
+    # The no-op intent is now pinned by their ABSENCE + priority "none".
+    assert result["agent_next_action"]["priority"] == "none"
+    assert "mcp_command" not in result["agent_next_action"]
+    assert "cli_command" not in result["agent_next_action"]
+    assert "post_edit_commands" not in result["agent_next_action"]

--- a/tests/unit/mcp/test_omit_empty_guidance_fields.py
+++ b/tests/unit/mcp/test_omit_empty_guidance_fields.py
@@ -1,0 +1,112 @@
+"""RFC-0018 Part 3 (safe subset) — decision-tool envelopes must not ship
+*empty* agent_next_action guidance command fields.
+
+An empty ``mcp_command:""`` / ``cli_command:""`` / ``post_edit_commands:[]``
+carries zero information for an agent but costs tokens in EVERY response on
+BOTH surfaces (the field is encoded into ``toon_content`` as well as the
+top-level dict). The healthy-file path is the common case, so the waste is
+paid on the majority of file_health calls.
+
+These tests drive the REAL ``handle_call_tool`` boundary (NOT
+``tool.execute`` — the boundary-order trap from RFC-0012) and assert the
+empty command fields are absent from BOTH the JSON envelope and the TOON
+``toon_content`` blob. Written RED-first: the fields are present until the
+build sites stop emitting them when empty.
+
+Scope guard (verified, do NOT broaden): only the empty placeholders are
+dropped. The populated refactor action (``_build_refactor_agent_action``,
+priority != "none") keeps its real commands — covered by the unchanged
+``test_file_health_result_includes_direct_agent_commands_for_smells`` in
+``test_file_health_tool.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import Mock, patch
+
+import pytest
+
+from tree_sitter_analyzer.mcp.server import TreeSitterAnalyzerMCPServer
+
+_EMPTY_GUIDANCE_KEYS = ("mcp_command", "cli_command", "post_edit_commands")
+
+
+def _capture_call_tool_handler(server: TreeSitterAnalyzerMCPServer):
+    """Capture the ``handle_call_tool`` closure (mirrors test_toon_losslessness_637)."""
+    with patch("tree_sitter_analyzer.mcp.server.MCP_AVAILABLE", True):
+        with patch("tree_sitter_analyzer.mcp.server.Server") as mock_server_class:
+            mock_server = Mock()
+            captured: dict = {}
+
+            def capture_decorator(name):
+                def decorator(func):
+                    captured[name] = func
+                    return func
+
+                return decorator
+
+            mock_server.call_tool.return_value = capture_decorator("call_tool")
+            mock_server_class.return_value = mock_server
+            server.create_server()
+            return captured["call_tool"]
+
+
+async def _call(handler, file_path: str, output_format: str) -> tuple[dict, str]:
+    """Return (parsed_envelope, raw_wire_text) for a file_health call."""
+    raw = await handler(
+        "check_file_health",
+        {"file_path": file_path, "output_format": output_format},
+    )
+    text = raw[0].text
+    return json.loads(text), text
+
+
+@pytest.fixture()
+def handler(tmp_path):
+    server = TreeSitterAnalyzerMCPServer(project_root=str(tmp_path))
+    return _capture_call_tool_handler(server)
+
+
+def _healthy_file(tmp_path) -> str:
+    src = tmp_path / "clean.py"
+    src.write_text("def f(x):\n    return x + 1\n")
+    return str(src)
+
+
+@pytest.mark.asyncio
+async def test_no_empty_guidance_fields_json(handler, tmp_path):
+    """JSON envelope: agent_next_action carries no empty command fields."""
+    body, _ = await _call(handler, _healthy_file(tmp_path), "json")
+    action = body.get("agent_next_action")
+    assert isinstance(action, dict), "healthy file_health must carry agent_next_action"
+    present = [k for k in _EMPTY_GUIDANCE_KEYS if k in action]
+    assert present == [], (
+        f"empty guidance fields shipped in JSON envelope: {present} (action={action})"
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_empty_guidance_fields_toon(handler, tmp_path):
+    """TOON wire: the empty command fields are absent from toon_content too.
+
+    The fields are encoded into ``toon_content`` during execute(), so a
+    top-level-only strip would leave them in the TOON blob. This asserts
+    the strip happens BEFORE encoding (at the build site).
+    """
+    body, _ = await _call(handler, _healthy_file(tmp_path), "toon")
+    toon = body.get("toon_content")
+    assert isinstance(toon, str) and toon, "toon mode must carry toon_content"
+    leaked = [k for k in _EMPTY_GUIDANCE_KEYS if f"{k}:" in toon]
+    assert leaked == [], f"empty guidance fields leaked into toon_content: {leaked}"
+
+
+@pytest.mark.asyncio
+async def test_no_empty_guidance_fields_empty_file(handler, tmp_path):
+    """The empty-file terminal response also drops the empty command fields."""
+    src = tmp_path / "empty.py"
+    src.write_text("")
+    body, _ = await _call(handler, str(src), "json")
+    action = body.get("agent_next_action", {})
+    present = [k for k in _EMPTY_GUIDANCE_KEYS if k in action]
+    assert present == [], f"empty-file response shipped empty guidance: {present}"

--- a/tree_sitter_analyzer/mcp/tools/file_health_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/file_health_tool.py
@@ -396,9 +396,6 @@ def _empty_file_response(resolved: str, file_path: str) -> dict[str, Any] | None
         "agent_next_action": {
             "priority": "none",
             "reason": "file is empty",
-            "mcp_command": "",
-            "cli_command": "",
-            "post_edit_commands": [],
         },
     }
 
@@ -445,9 +442,6 @@ def _non_code_file_response(resolved: str, file_path: str) -> dict[str, Any] | N
         "agent_next_action": {
             "priority": "none",
             "reason": "non-code file",
-            "mcp_command": "",
-            "cli_command": "",
-            "post_edit_commands": [],
         },
     }
 
@@ -593,8 +587,5 @@ def _syntax_error_response(
         "agent_next_action": {
             "priority": "high",
             "reason": "syntax error blocks analysis",
-            "mcp_command": "",
-            "cli_command": "",
-            "post_edit_commands": [],
         },
     }

--- a/tree_sitter_analyzer/mcp/tools/utils/file_health_response.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/file_health_response.py
@@ -349,12 +349,13 @@ def _build_agent_next_action(
 
 def _build_noop_agent_action() -> dict[str, Any]:
     """Build the action payload for files that need no immediate work."""
+    # RFC-0018 Part 3: a no-op action carries no commands. Emitting empty
+    # ``mcp_command:""`` / ``cli_command:""`` / ``post_edit_commands:[]``
+    # costs tokens on every healthy-file response (both surfaces) for zero
+    # agent signal — omit them rather than ship empties.
     return {
         "priority": "none",
         "reason": "file is healthy enough; no immediate refactor needed",
-        "mcp_command": "",
-        "cli_command": "",
-        "post_edit_commands": [],
     }
 
 
@@ -485,7 +486,7 @@ def _health_next_step(action: dict[str, Any], smells: list[dict[str, Any]]) -> s
         return "No immediate refactor needed."
     if not _has_refactor_target_smell(smells):
         return "Inspect the weakest health dimension and make a focused cleanup."
-    return f"Run refactoring suggestions: {action['cli_command']}"
+    return f"Run refactoring suggestions: {action.get('cli_command', '')}"
 
 
 def _health_verification_command(action: dict[str, Any], file_path: str) -> str:


### PR DESCRIPTION
## What

Decision-tool `agent_next_action` blocks shipped **empty** placeholder command
fields on every no-op / healthy-file / terminal response:

```
"mcp_command": "", "cli_command": "", "post_edit_commands": []
```

These carry **zero agent signal** but cost tokens on **both surfaces** — the
fields are encoded into `toon_content` as well as the top-level dict — and the
healthy-file path is the *common* case, so the waste is paid on the majority of
`file_health` calls.

This PR omits the command fields **when empty**, at the response **build sites**
(so the TOON wire shrinks too, not just JSON), keeping populated refactor
actions fully intact.

## Why this is the RFC-0018 *Part 3 safe subset* (and not the headline wire flip)

During implementation I verified the headline "raw TOON as the wire default"
(RFC-0018 Part 2) is **not safely shippable yet**: `decode_toon` (#1058) is a
**scalar-only** decoder — it returns the input string unchanged for any TOON
*document* — and the encoder is non-round-trippable in three independent ways
(path normalization, flat-`list[str]`↔list-of-1-key-dict collision, sparse
array-table empty-vs-null ambiguity). Flipping the wire now would leave agents
unable to parse responses. That is a separate encoder/decoder program.

This PR is the **format-agnostic, decoder-independent** slice: pure payload
hygiene that reduces what every decision tool returns, on both surfaces, with
no contract risk.

## Changes
- `file_health_response.py::_build_noop_agent_action` and 3 terminal responses
  in `file_health_tool.py` (empty-file / non-code / syntax-error) omit the
  empty command keys.
- `_health_next_step` made `.get`-safe for the now-optional `cli_command`.
- New RED-first boundary test (`test_omit_empty_guidance_fields.py`) asserts
  absence in **both** the JSON envelope and the `toon_content` blob.
- Two prior tests that pinned the *empty* shape migrated to pin the *lean* shape.

## Scope guard
Only **empty** placeholders are dropped. `_build_refactor_agent_action`
(priority ≠ "none") keeps its real commands — covered by the unchanged
`test_file_health_result_includes_direct_agent_commands_for_smells`.

## Verification
- `tests/unit/mcp` full (5151 passed) + `test_agent_contracts` (78 passed) green
- `ruff` + `ruff format` + `mypy` clean on touched files
- Independent adversarial review: **APPROVE**, 0 P1/P2 (1 P3 test-quality nit fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)