### PR TITLE
fix(swift): no bogus return type from a closure param's arrow

### DIFF
--- a/tests/unit/languages/test_swift_plugin.py
+++ b/tests/unit/languages/test_swift_plugin.py
@@ -195,6 +195,23 @@ class TestSwiftExtraction:
         assert ret["pair"] == "(Int, String)"
         assert ret["register"] == "Bool"
 
+    def test_no_return_type_with_closure_param(self, plugin: SwiftPlugin) -> None:
+        # A function with a closure parameter but NO return type must report
+        # return_type None — the closure param's own `->` is inside the
+        # parameter list and must not be mistaken for the return arrow
+        # (regression: it produced the malformed "Void)").
+        sample = """
+        func run(onDone: (Int, Error?) -> Void) { }
+        func sub(cb: () -> Void) { }
+        func plain(x: Int) { }
+        """
+        tree = _swift_parser().parse(sample.encode("utf-8"))
+        functions = plugin.create_extractor().extract_functions(tree, sample)
+        ret = {item.name: item.return_type for item in functions}
+        assert ret["run"] is None
+        assert ret["sub"] is None
+        assert ret["plain"] is None
+
     def test_extract_variables(self, plugin: SwiftPlugin, tree) -> None:
         variables = plugin.create_extractor().extract_variables(tree, SWIFT_SAMPLE)
         by_name = {item.name: item for item in variables}

--- a/tree_sitter_analyzer/languages/_swift_plugin_elements.py
+++ b/tree_sitter_analyzer/languages/_swift_plugin_elements.py
@@ -368,17 +368,37 @@ def _parameter_name(before_type: str) -> str:
 def _return_type(raw_text: str) -> str | None:
     """Extract a Swift return type, including bracket/tuple-led types.
 
-    The return type is the text after the *final* signature arrow (so a
-    completion-handler parameter's own ``->`` is ignored) and before the
-    function body. This covers collection shorthand (``[T]``, ``[K: V]``)
+    The return arrow is sought *after* the parameter list's closing paren,
+    so a closure-typed parameter's own ``->`` is never mistaken for it (a
+    function with a closure param and no return type yields None, not the
+    malformed ``Void)``). Covers collection shorthand (``[T]``, ``[K: V]``)
     and tuples (``(A, B)``), which the previous letter-anchored regex
     dropped entirely.
     """
-    signature = raw_text.split("{", 1)[0]
-    arrow = signature.rfind("->")
+    end = _param_list_end(raw_text)
+    tail = raw_text[end + 1 :] if end != -1 else raw_text
+    tail = tail.split("{", 1)[0]
+    arrow = tail.find("->")
     if arrow == -1:
         return None
-    return signature[arrow + 2 :].strip() or None
+    return tail[arrow + 2 :].strip() or None
+
+
+def _param_list_end(raw_text: str) -> int:
+    """Index of the parameter list's matching closing paren, or -1."""
+    start = raw_text.find("(")
+    if start == -1:
+        return -1
+    depth = 0
+    for index in range(start, len(raw_text)):
+        char = raw_text[index]
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if depth == 0:
+                return index
+    return -1
 
 
 def _import_module_path(raw_text: str) -> str:


### PR DESCRIPTION
## Bug (regression from #1074)

#1074's `_return_type` used `rfind("->")` across the whole signature. A function with a **closure-typed parameter but no return type** then picked up the closure's own arrow:

```
func run(onDone: (Int, Error?) -> Void) { }
  return_type: "Void)"   ← malformed (trailing paren); should be None
```

Found via **MCP dogfooding** (`structure action=signatures` showed `run →Void)`) — also confirms the #1074/#1075 param fixes have correct CLI↔MCP parity.

## Fix

Seek the return arrow only **after** the parameter list's matching closing paren (balanced-paren scan), so a parameter's internal `->` is never mistaken for the return arrow. This also simplifies the earlier `rfind` heuristic — the first `->` after the params is unambiguously the return arrow.

## Tests (RED-first, exact)
- `test_no_return_type_with_closure_param`: closure param / empty closure / plain param → all `None`
- All existing return-type cases (`[String: [Int]]`, `[Int]`, `(Int, String)`, `register → Bool`) still pass
- Golden master unchanged

## Verification
`tests/unit/languages/ tests/unit/formatters/ tests/golden/` → **6319 passed, 30 skipped**