### PR TITLE
perf(mcp): drop duplicate 'results' array from trace_impact (RFC-0018 R10)

### DIFF
--- a/tests/unit/mcp/test_trace_no_duplicate_results_array.py
+++ b/tests/unit/mcp/test_trace_no_duplicate_results_array.py
@@ -1,0 +1,92 @@
+"""RFC-0018 R10 — trace_impact must not ship a duplicate ``results`` array.
+
+``trace_impact`` built ``"usages": usages`` and ``"results": usages`` — the
+SAME list object under two keys. The array is the largest part of the
+response and is re-encoded into ``toon_content`` as well, so the duplicate
+doubled the dominant cost on both surfaces for zero added signal.
+
+``usages`` is the canonical key (``usage_count`` counts it). ``results``
+(the cross-tool *search* key) is dropped from trace; trace does not route
+through ``search_envelope``, so nothing downstream depends on it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+
+from tree_sitter_analyzer.mcp.tools.trace_impact_tool import TraceImpactTool
+
+
+def _project() -> str:
+    d = tempfile.mkdtemp()
+    os.makedirs(os.path.join(d, "pkg"))
+    with open(os.path.join(d, "pkg", "a.py"), "w") as fh:
+        fh.write("def target():\n    return 1\n")
+    with open(os.path.join(d, "pkg", "b.py"), "w") as fh:
+        fh.write(
+            "from pkg.a import target\n"
+            "def caller():\n    return target()\n"
+            "def caller2():\n    return target()\n"
+        )
+    return d
+
+
+def test_trace_has_no_duplicate_results_array() -> None:
+    d = _project()
+    res = asyncio.run(
+        TraceImpactTool(project_root=d).execute(
+            {"symbol": "target", "output_format": "json"}
+        )
+    )
+    # Canonical array present and populated.
+    assert isinstance(res["usages"], list)
+    assert res["usage_count"] == len(res["usages"])
+    # The duplicate is gone — no second copy of the same array.
+    assert "results" not in res, (
+        "trace_impact still ships a duplicate 'results' array (== usages)"
+    )
+
+
+def test_trace_not_found_has_no_results_key() -> None:
+    d = _project()
+    res = asyncio.run(
+        TraceImpactTool(project_root=d).execute(
+            {"symbol": "does_not_exist_anywhere", "output_format": "json"}
+        )
+    )
+    assert res["usages"] == []
+    assert "results" not in res
+
+
+def test_trace_response_does_not_pay_for_the_duplicate_array() -> None:
+    """RFC-0018 R11 cost invariant: dropping the duplicate is a measured win.
+
+    Not just "is the key absent?" (conformance) but "is it actually cheaper?"
+    (value) — per CLAUDE.md §11. The emitted JSON response must be strictly
+    smaller than the same response with the old ``results == usages``
+    duplicate restored, and the saving must be at least the serialized size
+    of the usages array itself (i.e. the whole duplicate array is gone, not a
+    stray byte). Relationship form, never a hand-waved byte ceiling.
+    """
+    import json
+
+    d = _project()
+    res = asyncio.run(
+        TraceImpactTool(project_root=d).execute(
+            {"symbol": "target", "output_format": "json"}
+        )
+    )
+    assert res["usages"], "fixture must produce a non-empty usages array"
+    with_dup = {**res, "results": res["usages"]}
+    now = len(json.dumps(res))
+    before = len(json.dumps(with_dup))
+    array_bytes = len(json.dumps(res["usages"]))
+    assert now < before, (
+        "duplicate-free response is not smaller than the duplicated one"
+    )
+    assert before - now >= array_bytes, (
+        f"saving {before - now}B is smaller than the usages array "
+        f"({array_bytes}B) — the full duplicate array was not eliminated"
+    )

--- a/tree_sitter_analyzer/mcp/tools/trace_impact_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/trace_impact_tool.py
@@ -492,7 +492,6 @@ def _build_not_found_response(symbol: str, language: str | None) -> dict[str, An
         "usages": [],
         "call_count": 0,
         "count": 0,
-        "results": [],
         "impact_level": impact["level"],
         "impact_verdict": impact["level"].upper(),
         "verdict": "NOT_FOUND",
@@ -588,8 +587,15 @@ def _trace_impact_base_envelope(
         "verdict": verdict,
         "impact_badge": impact["badge"],
         "impact_guidance": impact["guidance"],
+        # RFC-0018 R10: ``usages`` is the canonical array for trace_impact
+        # (``usage_count`` counts it). The former ``"results": usages`` was an
+        # exact duplicate of the SAME list object — it doubled the largest
+        # field of the JSON response returned to the agent (trace emits a raw
+        # JSON dict; it does not apply TOON) for zero added signal. Dropped;
+        # consumers read ``usages``. (``results`` remains the cross-tool key
+        # for *search* tools, which is unaffected — trace does not route
+        # through search_envelope.)
         "usages": usages,
-        "results": usages,
         "summary_line": summary_line,
         "agent_summary": {
             "summary_line": summary_line,


### PR DESCRIPTION
## What

`trace_impact` built **two keys pointing at the same list object**:

```python
"usages": usages,
"results": usages,   # ← exact duplicate (results IS usages)
```

`usages` is the largest field of a trace response, so this duplicate **doubled
the dominant cost of every trace response returned to an agent** for **zero
added signal**. This PR drops the `results` duplicate from both the populated
and not-found envelopes. `usages` is canonical (`usage_count` counts it).

> **Surface note (corrected after review):** `trace_impact` emits a **raw JSON
> dict** — it does not apply TOON encoding — so there was no `toon_content`
> duplication. The saving is on the JSON wire that trace already returns. Still
> a real "adjust the values returned to AI" reduction; just JSON, not TOON.

## Why it's safe (verified per §11, not trusted from the RFC)
- `results is usages` → exact same object; no information lost.
- No src consumer reads trace's `results` — `modification_guard_tool` reads
  `usages`; `search_envelope` (the only generic `results` reader) is **never**
  called by trace (confirmed: `displayed_count` is never set on trace).
- The cross-tool `results` search contract (`test_intent_aliases_integration`)
  targets `search_content` / `list_files`, **not** trace.
- `count` / `usage_count` / `source_call_count` preserve all count signal.

## Verification
- RED-first conformance test (populated + not-found): `results` absent, `usages` canonical.
- **R11 cost invariant**: the emitted JSON response is strictly smaller without
  the duplicate, and the saving is ≥ the serialized size of the `usages` array
  (relationship form, no hand-waved ceiling — per CLAUDE.md §11/§0).
- Full `tests/unit/mcp` + `tests/integration/mcp` + `test_agent_contracts` +
  golden masters: **green** (5481 passed).
- `ruff` / `mypy` clean.
- Independent adversarial review: **APPROVE**, 0 P1/P2 (2 P3 docs/coverage notes addressed).

## RFC context
RFC-0018 R10 ("no duplicate top-level arrays"), the ship-first / zero
wire-encoder-dependency slice. Independent of the blocked raw-TOON-wire flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)