### PR TITLE
fix(formatters): rust/kotlin format_structure must delegate to base (signatures + csv)

### DIFF
--- a/tests/golden_masters/csv/kotlin_sample_csv.csv
+++ b/tests/golden_masters/csv/kotlin_sample_csv.csv
@@ -1,41 +1,16 @@
-# com.example.kotlin.Sample.kt
-
-## Imports
-```kotlin
-import java.util.Collections
-```
-
-## Classes & Objects
-| Name | Type | Visibility | Lines | Props | Methods |
-|------|------|------------|-------|-------|---------|
-| User | data | public | 8-13 | 0 | 1 |
-| Displayable | interface | public | 15-21 | 0 | 2 |
-| Result | sealed | public | 23-26 | 0 | 2 |
-| Success | data | public | 24-24 | 0 | 1 |
-| Error | data | public | 25-25 | 0 | 1 |
-| UserManager | class | public | 28-45 | 1 | 4 |
-| Config | object | public | 47-50 | 2 | 0 |
-| LegacyUserManager | class | public | 57-60 | 0 | 1 |
-
-## Functions
-| Function | Signature | Vis | Lines | Suspend | Doc |
-|----------|-----------|-----|-------|---------|-----|
-| User | fun(id: Long, username: String, email: String, active: Boolean) | pub | 8-13 | - | - |
-| display | fun(): String | pub | 16-16 | - | - |
-| summary | fun(): String | pub | 18-20 | - | - |
-| Success | fun(data: T) | pub | 24-24 | - | - |
-| Error | fun(message: String) | pub | 25-25 | - | - |
-| UserManager | fun(db: Any?) | pub | 28-28 | - | - |
-| getUser | fun(id: Long): User? | pub | 33-35 | - | - |
-| fetchUserAsync | fun(id: Long): Result<User> | pub | 37-40 | - | - |
-| display | fun(): String | pub | 42-44 | - | - |
-| toTitleCase | fun(): String | pub | 52-54 | - | - |
-| get | fun(): String | pub | 59-59 | - | - |
-| main | fun(args: Array<String>) | pub | 62-65 | - | - |
-
-## Properties
-| Name | Type | Vis | Kind | Line | Doc |
-|------|------|-----|------|------|-----|
-| userCount | Int | pub | - | 30 | - |
-| MAX_USERS | Inferred | pub | - | 48 | - |
-| version | Inferred | pub | - | 49 | - |
+Type,Name,Signature,Visibility,Lines,Complexity,Doc
+Field,userCount,userCount:Int,public,30-31,,-
+Field,MAX_USERS,MAX_USERS:Inferred,public,48-48,,-
+Field,version,version:Inferred,public,49-49,,-
+Constructor,User,"fun(id: Long, username: String, email: String, active: Boolean)",public,8-13,1,-
+Method,display,fun(): String,public,16-16,1,-
+Method,summary,fun(): String,public,18-20,1,-
+Constructor,Success,fun(data: T),public,24-24,1,-
+Constructor,Error,fun(message: String),public,25-25,1,-
+Constructor,UserManager,fun(db: Any?),public,28-28,1,-
+Method,getUser,fun(id: Long): User?,public,33-35,2,-
+Method,fetchUserAsync,fun(id: Long): Result<User>,public,37-40,1,-
+Method,display,fun(): String,public,42-44,1,-
+Method,toTitleCase,fun(): String,public,52-54,2,-
+Method,get,fun(): String,public,59-59,1,-
+Method,main,fun(args: Array<String>),public,62-65,1,-

--- a/tests/golden_masters/csv/rust_sample_csv.csv
+++ b/tests/golden_masters/csv/rust_sample_csv.csv
@@ -1,23 +1,20 @@
-# sample.rs
-
-## Structs
-| Name | Type | Visibility | Lines | Fields | Traits |
-|------|------|------------|-------|--------|--------|
-| User | struct | pub | 7-12 | 4 | - |
-| UserRole | enum | pub | 16-21 | 4 | - |
-| Displayable | trait | pub | 24-30 | 0 | - |
-| Container | struct | pub | 67-69 | 1 | - |
-| BorrowedItem | struct | pub | 77-79 | 1 | - |
-
-## Functions
-| Function | Signature | Vis | Async | Lines | Doc |
-|----------|-----------|-----|-------|-------|-----|
-| display | fn(self) -> String | public | - | 25-25 | - |
-| summary | fn(self) -> String | public | - | 27-29 | - |
-| new | fn(id: u64, username: String, email: String) -> Self | public | - | 34-41 | - |
-| deactivate | fn(self) | public | - | 44-46 | - |
-| is_active | fn(self) -> bool | public | - | 49-51 | - |
-| display | fn(self) -> String | public | - | 55-57 | - |
-| fetch_user_data | fn(user_id: u64) -> Result<User, String> | public | Yes | 61-64 | - |
-| new | fn(item: T) -> Self | public | - | 72-74 | - |
-| main | fn() | public | - | 91-93 | - |
+Type,Name,Signature,Visibility,Lines,Complexity,Doc
+Field,id,id:u64,pub,8-8,,-
+Field,username,username:String,pub,9-9,,-
+Field,email,email:String,private,10-10,,-
+Field,active,active:bool,private,11-11,,-
+Field,item,item:T,pub,68-68,,-
+Field,name,name:&'a str,pub,78-78,,-
+Field,Admin,Admin:enum_variant,pub,17-17,,-
+Field,Moderator,Moderator:enum_variant,pub,18-18,,-
+Field,User,User:enum_variant,pub,19-19,,-
+Field,Guest,Guest:enum_variant,pub,20-20,,-
+Method,display,fn(self) -> String,public,25-25,1,-
+Method,summary,fn(self) -> String,public,27-29,1,-
+Method,new,"fn(id: u64, username: String, email: String) -> Self",public,34-41,1,-
+Method,deactivate,fn(self),public,44-46,1,-
+Method,is_active,fn(self) -> bool,public,49-51,1,-
+Method,display,fn(self) -> String,public,55-57,1,-
+Method,fetch_user_data,"fn(user_id: u64) -> Result<User, String>",public,61-64,1,-
+Method,new,fn(item: T) -> Self,public,72-74,1,-
+Method,main,fn(),public,91-93,1,-

--- a/tests/unit/formatters/test_kotlin_formatter.py
+++ b/tests/unit/formatters/test_kotlin_formatter.py
@@ -3,7 +3,25 @@
 Tests for Kotlin-specific table formatter.
 """
 
+import pytest
+
 from tree_sitter_analyzer.formatters.kotlin_formatter import KotlinTableFormatter
+
+
+class TestKotlinFormatterSignaturesUnsupported:
+    """Kotlin does not support the signatures directory mode; it must raise the
+    same enumerable error as the base/Go formatter, not silently render the
+    full table (regression: it fell through to _format_full_table)."""
+
+    def test_format_structure_signatures_raises_enumerable(self):
+        formatter = KotlinTableFormatter(format_type="signatures")
+        data = {
+            "file_path": "Example.kt",
+            "methods": [],
+            "statistics": {"method_count": 0, "field_count": 0},
+        }
+        with pytest.raises(ValueError, match="signatures format not supported"):
+            formatter.format_structure(data)
 
 
 class TestKotlinFormatterInit:

--- a/tests/unit/formatters/test_rust_formatter.py
+++ b/tests/unit/formatters/test_rust_formatter.py
@@ -3,7 +3,25 @@
 Tests for Rust-specific table formatter.
 """
 
+import pytest
+
 from tree_sitter_analyzer.formatters.rust_formatter import RustTableFormatter
+
+
+class TestRustFormatterSignaturesUnsupported:
+    """Rust does not support the signatures directory mode; it must raise the
+    same enumerable error as the base/Go formatter, not silently render the
+    full table (regression: it fell through to _format_full_table)."""
+
+    def test_format_structure_signatures_raises_enumerable(self):
+        formatter = RustTableFormatter(format_type="signatures")
+        data = {
+            "file_path": "lib.rs",
+            "methods": [],
+            "statistics": {"method_count": 0, "field_count": 0},
+        }
+        with pytest.raises(ValueError, match="signatures format not supported"):
+            formatter.format_structure(data)
 
 
 class TestRustFormatterInit:

--- a/tree_sitter_analyzer/formatters/kotlin_formatter.py
+++ b/tree_sitter_analyzer/formatters/kotlin_formatter.py
@@ -247,10 +247,15 @@ class KotlinTableFormatter(BaseTableFormatter):
         return self._format_compact_table(analysis_result)
 
     def format_structure(self, analysis_result: dict[str, Any]) -> str:
-        """Format structure analysis output for Kotlin"""
-        if self.format_type == "compact":
-            return self._format_compact_table(analysis_result)
-        return self._format_full_table(analysis_result)
+        """Format structure analysis output for Kotlin.
+
+        Delegates to the base dispatcher (like Go) so every format type is
+        handled consistently: full/compact/csv render, and an unsupported
+        type such as ``signatures`` raises the enumerable "supported
+        languages" error instead of silently falling through to the full
+        table.
+        """
+        return super().format_structure(analysis_result)
 
     def format_advanced(
         self, analysis_result: dict[str, Any], output_format: str = "json"

--- a/tree_sitter_analyzer/formatters/rust_formatter.py
+++ b/tree_sitter_analyzer/formatters/rust_formatter.py
@@ -237,10 +237,15 @@ class RustTableFormatter(BaseTableFormatter):
         return self._format_compact_table(analysis_result)
 
     def format_structure(self, analysis_result: dict[str, Any]) -> str:
-        """Format structure analysis output for Rust"""
-        if self.format_type == "compact":
-            return self._format_compact_table(analysis_result)
-        return self._format_full_table(analysis_result)
+        """Format structure analysis output for Rust.
+
+        Delegates to the base dispatcher (like Go) so every format type is
+        handled consistently: full/compact/csv render, and an unsupported
+        type such as ``signatures`` raises the enumerable "supported
+        languages" error instead of silently falling through to the full
+        table.
+        """
+        return super().format_structure(analysis_result)
 
     def format_advanced(
         self, analysis_result: dict[str, Any], output_format: str = "json"


### PR DESCRIPTION
## Bug

`RustTableFormatter`/`KotlinTableFormatter` overrode `format_structure` as `if compact: compact else: full`, so **every non-compact format type fell through to the full markdown table**, bypassing the base dispatcher. One root cause, two visible symptoms:

| `--table` | Rust/Kotlin (before) | Correct (Go/base, after) |
|---|---|---|
| `signatures` | silently renders **full table** | raises enumerable "not supported; supported: java, python, typescript" (#449) |
| `csv` | renders **full markdown** | emits real **CSV** |

Found by dogfooding `structure action=signatures` / `--table csv` across all languages (MCP + CLI).

## Fix

Delegate to `super().format_structure()` like Go does — every type dispatches consistently. Verified PHP/C#/Ruby already delegate (unaffected); Rust & Kotlin were the only two outliers.

## Tests (RED-first)
- `test_format_structure_signatures_raises_enumerable` for Rust + Kotlin
- Re-pinned `rust_sample_csv.csv` / `kotlin_sample_csv.csv` golden masters — old goldens had captured the buggy **full-markdown-as-csv**; new output is validated parseable CSV (`Type,Name,Signature,Visibility,Lines,Complexity,Doc`)

## Verification
- formatters + golden-regression + targeted cli/mcp/integration (rust|kotlin|csv|signature|table|structure) → all green
- the originally-failing `test_golden_master_comparison[...rust_sample-csv]` / `[...kotlin_sample-csv]` now pass