### PR TITLE
fix(go): compute cyclomatic complexity (was always 1)

### DIFF
--- a/tests/golden_masters/csv/go_sample_csv.csv
+++ b/tests/golden_masters/csv/go_sample_csv.csv
@@ -26,18 +26,18 @@ Method,Write,"(p:[]byte):(n int, err error)",public,61-61,1,-
 Method,NewService,"(name:string, config:*Config):*Service",public,80-86,1,-
 Method,Name,():string,public,89-91,1,-
 Method,IsRunning,():bool,public,94-98,1,-
-Method,Start,(ctx:context.Context):error,public,101-114,1,-
-Method,run,(ctx:context.Context):,private,117-132,1,-
-Method,tick,(t:time.Time):,private,135-139,1,-
-Method,Stop,():error,public,142-153,1,-
+Method,Start,(ctx:context.Context):error,public,101-114,2,-
+Method,run,(ctx:context.Context):,private,117-132,3,-
+Method,tick,(t:time.Time):,private,135-139,2,-
+Method,Stop,():error,public,142-153,2,-
 Method,stop,():,private,156-160,1,-
-Method,ProcessData,"(ctx:context.Context, input:<-chan []byte):(<-chan []byte, <-chan error)",public,163-193,1,-
-Method,process,(data:[]byte):[]byte,private,196-203,1,-
+Method,ProcessData,"(ctx:context.Context, input:<-chan []byte):(<-chan []byte, <-chan error)",public,163-193,5,-
+Method,process,(data:[]byte):[]byte,private,196-203,2,-
 Method,NewWorkerPool,(workers:int):*WorkerPool,public,213-218,1,-
-Method,Start,():,public,221-226,1,-
-Method,worker,():,private,229-234,1,-
+Method,Start,():,public,221-226,2,-
+Method,worker,():,private,229-234,2,-
 Method,Submit,(job:func()):,public,237-239,1,-
 Method,Shutdown,():,public,242-245,1,-
-Method,Chain,(middlewares:...Middleware):Middleware,public,257-264,1,-
+Method,Chain,(middlewares:...Middleware):Middleware,public,257-264,2,-
 Method,WithTimeout,(timeout:time.Duration):Middleware,public,267-275,1,-
-Method,WithRetry,(maxRetries:int):Middleware,public,278-293,1,-
+Method,WithRetry,(maxRetries:int):Middleware,public,278-293,3,-

--- a/tests/golden_masters/full/go_sample_full.md
+++ b/tests/golden_masters/full/go_sample_full.md
@@ -47,21 +47,21 @@ import ""time""
 | NewService | (name string, config *Config) *Service | exported | 80-86 | 1 | - |
 | Name | () string | exported | 89-91 | 1 | - |
 | IsRunning | () bool | exported | 94-98 | 1 | - |
-| Start | (ctx context.Context) error | exported | 101-114 | 1 | - |
-| run | (ctx context.Context) | unexported | 117-132 | 1 | - |
-| tick | (t time.Time) | unexported | 135-139 | 1 | - |
-| Stop | () error | exported | 142-153 | 1 | - |
+| Start | (ctx context.Context) error | exported | 101-114 | 2 | - |
+| run | (ctx context.Context) | unexported | 117-132 | 3 | - |
+| tick | (t time.Time) | unexported | 135-139 | 2 | - |
+| Stop | () error | exported | 142-153 | 2 | - |
 | stop | () | unexported | 156-160 | 1 | - |
-| ProcessData | (ctx context.Context, input <-chan []byte) (<-chan []byte, <-chan error) | exported | 163-193 | 1 | - |
-| process | (data []byte) []byte | unexported | 196-203 | 1 | - |
+| ProcessData | (ctx context.Context, input <-chan []byte) (<-chan []byte, <-chan error) | exported | 163-193 | 5 | - |
+| process | (data []byte) []byte | unexported | 196-203 | 2 | - |
 | NewWorkerPool | (workers int) *WorkerPool | exported | 213-218 | 1 | - |
-| Start | () | exported | 221-226 | 1 | - |
-| worker | () | unexported | 229-234 | 1 | - |
+| Start | () | exported | 221-226 | 2 | - |
+| worker | () | unexported | 229-234 | 2 | - |
 | Submit | (job func()) | exported | 237-239 | 1 | - |
 | Shutdown | () | exported | 242-245 | 1 | - |
-| Chain | (middlewares ...Middleware) Middleware | exported | 257-264 | 1 | - |
+| Chain | (middlewares ...Middleware) Middleware | exported | 257-264 | 2 | - |
 | WithTimeout | (timeout time.Duration) Middleware | exported | 267-275 | 1 | - |
-| WithRetry | (maxRetries int) Middleware | exported | 278-293 | 1 | - |
+| WithRetry | (maxRetries int) Middleware | exported | 278-293 | 3 | - |
 
 ## Variables
 | Name | Type | Vis | Line |

--- a/tests/unit/languages/test_cyclomatic_complexity.py
+++ b/tests/unit/languages/test_cyclomatic_complexity.py
@@ -661,3 +661,99 @@ class TestBashCyclomaticComplexity:
         assert len(funcs) == 1
         assert funcs[0].name == "process"
         assert funcs[0].complexity_score == 12
+
+
+# ---------------------------------------------------------------------------
+# Go
+# ---------------------------------------------------------------------------
+
+GO_SIMPLE = """\
+package main
+
+func greet(name string) string {
+	return "Hello, " + name
+}
+"""
+# No branches → complexity = 1
+
+GO_BRANCHY = """\
+package main
+
+func binarySearch(arr []int, target int) int {
+	low := 0
+	high := len(arr) - 1
+	for low <= high {
+		mid := (low + high) / 2
+		if arr[mid] == target {
+			return mid
+		} else if arr[mid] < target {
+			low = mid + 1
+		} else {
+			high = mid - 1
+		}
+	}
+	return -1
+}
+"""
+# Decisions: for(1) + if(1) + else-if (nested if_statement)(1) = 3 → complexity = 4
+
+GO_RICH = """\
+package main
+
+func process(x int) int {
+	if x > 0 && x < 100 {
+		return 1
+	} else if x < 0 || x > 200 {
+		return 2
+	}
+	for i := 0; i < 10; i++ {
+	}
+	switch x {
+	case 1:
+		return 3
+	}
+	return 0
+}
+"""
+# Decisions:
+#   if_statement                 : 1
+#   &&                           : 1
+#   else if (nested if_statement): 1
+#   ||                           : 1
+#   for_statement                : 1
+#   expression_switch_statement  : 1
+# Total = 6 → complexity = 1 + 6 = 7
+
+
+def _go_functions(source: str):
+    import tree_sitter_go
+
+    lang = tree_sitter.Language(tree_sitter_go.language())
+    parser = tree_sitter.Parser(lang)
+    tree = parser.parse(source.encode())
+    from tree_sitter_analyzer.languages.go_plugin import GoElementExtractor
+
+    extractor = GoElementExtractor()
+    return extractor.extract_functions(tree, source)
+
+
+class TestGoCyclomaticComplexity:
+    def test_simple_no_branches(self):
+        funcs = _go_functions(GO_SIMPLE)
+        assert len(funcs) == 1
+        assert funcs[0].name == "greet"
+        assert funcs[0].complexity_score == 1
+
+    def test_binary_search(self):
+        """for + if + else-if (nested if_statement) = 3 decisions → complexity 4."""
+        funcs = _go_functions(GO_BRANCHY)
+        assert len(funcs) == 1
+        assert funcs[0].name == "binarySearch"
+        assert funcs[0].complexity_score == 4
+
+    def test_rich_branching(self):
+        """6 decision points → complexity 7."""
+        funcs = _go_functions(GO_RICH)
+        assert len(funcs) == 1
+        assert funcs[0].name == "process"
+        assert funcs[0].complexity_score == 7

--- a/tree_sitter_analyzer/languages/_go_function_helpers.py
+++ b/tree_sitter_analyzer/languages/_go_function_helpers.py
@@ -13,6 +13,38 @@ from ._go_common_helpers import (
     go_visibility,
 )
 
+# AST node types that each add one decision point to cyclomatic complexity.
+# Switch/select constructs count once (matching the Swift plugin's
+# count-the-construct-once convention), and the "&&"/"||" leaf tokens count
+# the short-circuit boolean operators.
+_GO_DECISION_NODE_TYPES: frozenset[str] = frozenset(
+    {
+        "if_statement",
+        "for_statement",
+        "expression_switch_statement",
+        "type_switch_statement",
+        "select_statement",
+        "&&",
+        "||",
+    }
+)
+
+
+def _go_calculate_complexity(node: Any) -> int:
+    """Return cyclomatic complexity (1 + decision points) for a Go function node."""
+    decisions = 0
+    stack = [node]
+    while stack:
+        cur = stack.pop()
+        try:
+            children = list(getattr(cur, "children", None) or [])
+        except (TypeError, AttributeError):
+            children = []
+        if getattr(cur, "type", None) in _GO_DECISION_NODE_TYPES:
+            decisions += 1
+        stack.extend(children)
+    return 1 + decisions
+
 
 def extract_go_function(
     node: Any,
@@ -123,4 +155,5 @@ def _build_go_function(
         visibility=visibility,
         docstring=extract_docstring(node, content_lines),
         is_public=visibility == "public",
+        complexity_score=_go_calculate_complexity(node),
     )


### PR DESCRIPTION
## Bug

Go functions/methods **never had cyclomatic complexity computed**. `_build_go_function` left `complexity_score` at the model default of **1**, so every Go function reported complexity 1 regardless of its branches.

### Repro (before)
```go
func f(a, b int) int {
    if a > 0 && b > 0 { return 1 } else if a < 0 || b < 0 { return 2 }
    for i := 0; i < 10; i++ {}
    return 0
}
// complexity_score: 1   ← should be 6
```

This silently corrupted the **complexity heatmap, project_health grading, and hotspot ranking** for any Go code. Found by a cross-language complexity dogfood (Python/Swift compute correctly; **Go and Rust both returned 1**).

## Fix

Add `_go_calculate_complexity` (1 + decision points), mirroring the Swift plugin's AST-walk convention: count `if`/`for`/`switch` (expr+type)/`select` once each, plus the `&&` / `||` short-circuit operators. All three Go builders (function, method, interface method) route through `_build_go_function`, so one wiring covers them all.

## Tests (RED-first, exact assertions)
- `TestGoCyclomaticComplexity`: simple=1, binary_search=4, rich=7
- Re-pinned `go_sample` full + csv golden masters (Cx column 1 → real values; diff is **only** the Cx column)

## Verification
- languages + formatters + integration golden → 6382 passed
- heatmap/health/complexity/project (509 tests) → all green

## Follow-up
Rust has the identical always-1 bug (multiple Function() construction sites) — fixed in a separate PR.