### PR TITLE
fix(rust): compute cyclomatic complexity (was always 1)

### DIFF
--- a/tests/unit/languages/test_cyclomatic_complexity.py
+++ b/tests/unit/languages/test_cyclomatic_complexity.py
@@ -757,3 +757,92 @@ class TestGoCyclomaticComplexity:
         assert len(funcs) == 1
         assert funcs[0].name == "process"
         assert funcs[0].complexity_score == 7
+
+
+# ---------------------------------------------------------------------------
+# Rust
+# ---------------------------------------------------------------------------
+
+RUST_SIMPLE = """\
+fn greet(name: &str) -> String {
+    format!("Hello, {}!", name)
+}
+"""
+# No branches → complexity = 1
+
+RUST_BRANCHY = """\
+fn binary_search(arr: &[i32], target: i32) -> i32 {
+    let mut low = 0i32;
+    let mut high = arr.len() as i32 - 1;
+    while low <= high {
+        let mid = (low + high) / 2;
+        if arr[mid as usize] == target {
+            return mid;
+        } else if arr[mid as usize] < target {
+            low = mid + 1;
+        } else {
+            high = mid - 1;
+        }
+    }
+    -1
+}
+"""
+# Decisions: while(1) + if(1) + else-if (nested if_expression)(1) = 3 → complexity = 4
+
+RUST_RICH = """\
+fn process(x: i32) -> i32 {
+    if x > 0 && x < 100 {
+        return 1;
+    } else if x < 0 || x > 200 {
+        return 2;
+    }
+    for _i in 0..10 {}
+    match x {
+        1 => return 3,
+        _ => {}
+    }
+    0
+}
+"""
+# Decisions:
+#   if_expression                  : 1
+#   &&                            : 1
+#   else if (nested if_expression) : 1
+#   ||                            : 1
+#   for_expression                 : 1
+#   match_expression               : 1
+# Total = 6 → complexity = 1 + 6 = 7
+
+
+def _rust_functions(source: str):
+    import tree_sitter_rust
+
+    lang = tree_sitter.Language(tree_sitter_rust.language())
+    parser = tree_sitter.Parser(lang)
+    tree = parser.parse(source.encode())
+    from tree_sitter_analyzer.languages.rust_plugin import RustPlugin
+
+    extractor = RustPlugin().create_extractor()
+    return extractor.extract_functions(tree, source)
+
+
+class TestRustCyclomaticComplexity:
+    def test_simple_no_branches(self):
+        funcs = _rust_functions(RUST_SIMPLE)
+        assert len(funcs) == 1
+        assert funcs[0].name == "greet"
+        assert funcs[0].complexity_score == 1
+
+    def test_binary_search(self):
+        """while + if + else-if (nested if_expression) = 3 decisions → complexity 4."""
+        funcs = _rust_functions(RUST_BRANCHY)
+        assert len(funcs) == 1
+        assert funcs[0].name == "binary_search"
+        assert funcs[0].complexity_score == 4
+
+    def test_rich_branching(self):
+        """6 decision points → complexity 7."""
+        funcs = _rust_functions(RUST_RICH)
+        assert len(funcs) == 1
+        assert funcs[0].name == "process"
+        assert funcs[0].complexity_score == 7

--- a/tree_sitter_analyzer/languages/rust_plugin.py
+++ b/tree_sitter_analyzer/languages/rust_plugin.py
@@ -21,6 +21,37 @@ from ..models import Class, Function, Import, Package, Variable
 from ..plugins.base import ElementExtractor, LanguagePlugin
 from ..utils import log_debug, log_error
 
+# AST node types that each add one decision point to cyclomatic complexity.
+# Loop/branch constructs count once (matching the Swift/Go plugin convention),
+# and the "&&"/"||" leaf tokens count the short-circuit boolean operators.
+_RUST_DECISION_NODE_TYPES: frozenset[str] = frozenset(
+    {
+        "if_expression",
+        "for_expression",
+        "while_expression",
+        "loop_expression",
+        "match_expression",
+        "&&",
+        "||",
+    }
+)
+
+
+def _rust_calculate_complexity(node: Any) -> int:
+    """Return cyclomatic complexity (1 + decision points) for a Rust fn node."""
+    decisions = 0
+    stack = [node]
+    while stack:
+        cur = stack.pop()
+        try:
+            children = list(getattr(cur, "children", None) or [])
+        except (TypeError, AttributeError):
+            children = []
+        if getattr(cur, "type", None) in _RUST_DECISION_NODE_TYPES:
+            decisions += 1
+        stack.extend(children)
+    return 1 + decisions
+
 
 def _rust_function_is_async(node: tree_sitter.Node) -> bool:
     """Return ``True`` when ``node`` carries an ``async`` modifier.
@@ -390,6 +421,7 @@ class RustElementExtractor(ElementExtractor):
                 return_type=return_type,
                 visibility=visibility,
                 docstring=docstring,
+                complexity_score=_rust_calculate_complexity(node),
             )
             # Attach Rust-specific attributes
             func.is_async = is_async


### PR DESCRIPTION
## Bug

Like Go (#1080), **Rust functions/methods never had cyclomatic complexity computed**. `_extract_function` left `complexity_score` at the model default of **1**, so every Rust function reported complexity 1 regardless of its branches — corrupting the complexity heatmap, `project_health` grading, and hotspot ranking for Rust code.

### Repro (before)
```rust
fn f(a: i32, b: i32) -> i32 {
    if a > 0 && b > 0 { return 1; } else if a < 0 || b < 0 { return 2; }
    for _i in 0..10 {}
    0
}
// complexity_score: 1   ← should be 6
```

## Fix

Add `_rust_calculate_complexity` (1 + decision points), mirroring the Swift/Go convention: count `if`/`for`/`while`/`loop`/`match` once each plus the `&&` / `||` operators. Wired into `_extract_function` (the sole builder for bodied fns/methods); trait abstract methods (`_extract_function_signature`) correctly stay at 1 (no body).

## Tests (RED-first, exact assertions)
- `TestRustCyclomaticComplexity`: simple=1, binary_search=4, rich=7
- **No golden change** — `examples/sample.rs` has no branchy Rust functions (all genuinely complexity 1, verified)

## Verification
- languages + integration golden → 4134 passed
- dogfood: branchy fn now reports cx=6 (was 1)

Completes the always-1 complexity bug across **Go (#1080) + Rust**, found by cross-language complexity dogfood.