### PR TITLE
feat(rust): show Cx (complexity) column in full table

### DIFF
--- a/tests/golden_masters/full/rust_sample_full.md
+++ b/tests/golden_masters/full/rust_sample_full.md
@@ -10,14 +10,14 @@
 | BorrowedItem | struct | pub | 77-79 | 1 | - |
 
 ## Functions
-| Function | Signature | Vis | Async | Lines | Doc |
-|----------|-----------|-----|-------|-------|-----|
-| display | fn(self) -> String | public | - | 25-25 | - |
-| summary | fn(self) -> String | public | - | 27-29 | - |
-| new | fn(id: u64, username: String, email: String) -> Self | public | - | 34-41 | - |
-| deactivate | fn(self) | public | - | 44-46 | - |
-| is_active | fn(self) -> bool | public | - | 49-51 | - |
-| display | fn(self) -> String | public | - | 55-57 | - |
-| fetch_user_data | fn(user_id: u64) -> Result<User, String> | public | Yes | 61-64 | - |
-| new | fn(item: T) -> Self | public | - | 72-74 | - |
-| main | fn() | public | - | 91-93 | - |
+| Function | Signature | Vis | Async | Lines | Cx | Doc |
+|----------|-----------|-----|-------|-------|----|-----|
+| display | fn(self) -> String | public | - | 25-25 | 1 | - |
+| summary | fn(self) -> String | public | - | 27-29 | 1 | - |
+| new | fn(id: u64, username: String, email: String) -> Self | public | - | 34-41 | 1 | - |
+| deactivate | fn(self) | public | - | 44-46 | 1 | - |
+| is_active | fn(self) -> bool | public | - | 49-51 | 1 | - |
+| display | fn(self) -> String | public | - | 55-57 | 1 | - |
+| fetch_user_data | fn(user_id: u64) -> Result<User, String> | public | Yes | 61-64 | 1 | - |
+| new | fn(item: T) -> Self | public | - | 72-74 | 1 | - |
+| main | fn() | public | - | 91-93 | 1 | - |

--- a/tests/unit/formatters/test_rust_formatter.py
+++ b/tests/unit/formatters/test_rust_formatter.py
@@ -153,6 +153,34 @@ class TestRustFormatterFormatFullTable:
         assert "Yes" in result  # is_async = True
         assert "-" in result  # is_async = False
 
+    def test_full_table_has_complexity_column(self):
+        """The full Functions table must expose a Cx column with the computed
+        complexity (parity with the Go full table; Rust complexity is computed
+        as of the always-1 fix but was not surfaced in the markdown table)."""
+        formatter = RustTableFormatter()
+        data = {
+            "file_path": "src/lib.rs",
+            "modules": [],
+            "classes": [],
+            "methods": [
+                {
+                    "name": "binary_search",
+                    "parameters": [],
+                    "visibility": "pub",
+                    "line_range": {"start": 1, "end": 14},
+                    "is_async": False,
+                    "docstring": "",
+                    "complexity_score": 4,
+                }
+            ],
+            "fields": [],
+        }
+        result = formatter._format_full_table(data)
+        header = next(line for line in result.splitlines() if "| Function " in line)
+        assert "Cx" in header
+        row = next(line for line in result.splitlines() if "binary_search" in line)
+        assert "| 4 |" in row
+
 
 class TestRustFormatterFormatCompactTable:
     """Test compact table format for Rust"""

--- a/tree_sitter_analyzer/formatters/rust_formatter.py
+++ b/tree_sitter_analyzer/formatters/rust_formatter.py
@@ -80,8 +80,8 @@ class RustTableFormatter(BaseTableFormatter):
         fns = data.get("methods", [])
         if fns:
             lines.append("## Functions")
-            lines.append("| Function | Signature | Vis | Async | Lines | Doc |")
-            lines.append("|----------|-----------|-----|-------|-------|-----|")
+            lines.append("| Function | Signature | Vis | Async | Lines | Cx | Doc |")
+            lines.append("|----------|-----------|-----|-------|-------|----|-----|")
 
             for fn in fns:
                 lines.append(self._format_fn_row(fn))
@@ -158,11 +158,15 @@ class RustTableFormatter(BaseTableFormatter):
         is_async = "Yes" if fn.get("is_async", False) else "-"
         line_range = fn.get("line_range", {})
         lines_str = f"{line_range.get('start', 0)}-{line_range.get('end', 0)}"
+        complexity = fn.get("complexity_score", 1)
         doc = self._clean_csv_text(
             self._extract_doc_summary(str(fn.get("docstring", "") or ""))
         )
 
-        return f"| {name} | {signature} | {visibility} | {is_async} | {lines_str} | {doc} |"
+        return (
+            f"| {name} | {signature} | {visibility} | {is_async} "
+            f"| {lines_str} | {complexity} | {doc} |"
+        )
 
     @staticmethod
     def _format_rust_param(param: Any) -> str:


### PR DESCRIPTION
## Why

The Go full table exposes a **Cx** column (#1064), but the Rust full table did not — so the Rust cyclomatic complexity computed by #1081 was **invisible in the markdown table** (only reachable via JSON/MCP/csv). This closes the parity gap so the complexity fix is actually visible to humans reading the Rust table.

## Change

Add a `Cx` column to the Rust full Functions table, matching Go's `Lines | Cx | Doc` ordering:
```
| Function | Signature | Vis | Async | Lines | Cx | Doc |
```

Compact table left unchanged — Go's compact table has no Cx either (parity).

## Tests (RED-first)
- `test_full_table_has_complexity_column` (header carries "Cx"; row shows the value)
- Re-pinned `rust_sample_full.md` golden (new column only)

## Verification
formatters + integration golden → 2330 passed