### PR TITLE
refactor(formatters): remove dead IStructureFormatter abstraction (zero implementers)

### DIFF
--- a/docs/CODEMAPS/languages.md
+++ b/docs/CODEMAPS/languages.md
@@ -39,6 +39,12 @@ Not every registered plugin is wired into the indexer to the same depth:
 | JSON | `languages/json_plugin.py` | inline | basic structure |
 | Bash | `languages/bash_plugin.py` | inline | functions, commands |
 
+## Shared helpers
+
+Cross-cutting logic shared by several plugins (not a language plugin itself):
+
+- `languages/_complexity_logical.py` — `is_executable_logical_operator()`: counts a `&&`/`||` token toward cyclomatic complexity only when it drives executable control flow. Used by the C/C++/C#/Java walkers to exclude booleans in non-executable contexts (`noexcept`/`requires` specifiers, `#if A && B` preprocessor conditions, default arguments, attributes/annotations, `static_assert`). The cross-language convention is "1 + decision points; each `&&`/`||` is one decision; switch/match counts once" (matching Go/Rust/Swift).
+
 ## Plugin Contract
 
 Every language plugin implements:

--- a/tests/golden_masters/compact/cpp_sample_compact.md
+++ b/tests/golden_masters/compact/cpp_sample_compact.md
@@ -30,7 +30,7 @@
 | name | ():str | + | 106-106 | 1 | - |
 | width | ():d | + | 109-109 | 1 | - |
 | height | ():d | + | 110-110 | 1 | - |
-| operator== | (const Rectangle&):b | + | 113-115 | 1 | - |
+| operator== | (const Rectangle&):b | + | 113-115 | 2 | - |
 | square | (d):Rectangle | + | 118-120 | 1 | - |
 | print | ():void | + | 136-136 | 1 | - |
 | ~Printable | ():void | + | 137-137 | 1 | - |

--- a/tests/golden_masters/compact/csharp_sample_compact.md
+++ b/tests/golden_masters/compact/csharp_sample_compact.md
@@ -18,7 +18,7 @@
 | DisplayName | ():string | + | 32-32 | 1 | - |
 | User | (string,string,string):void | + | 35-41 | 1 | - |
 | UpdateEmail | (string):void | + | 44-52 | 2 | - |
-| IsValid | ():bool | + | 54-59 | 1 | - |
+| IsValid | ():bool | + | 54-59 | 3 | - |
 | ToString | ():string | + | 61-64 | 1 | - |
 | GetById | (i):User | + | 72-72 | 1 | - |
 | GetAll | ():IEnumerable<User> | + | 73-73 | 1 | - |

--- a/tests/golden_masters/compact/java_bigservice_compact.md
+++ b/tests/golden_masters/compact/java_bigservice_compact.md
@@ -18,15 +18,15 @@
 | checkMemoryUsage | ():void | - | 93-106 | 2 | - |
 | checkDiskSpace | ():void | - | 111-117 | 2 | - |
 | checkNetworkConnectivity | ():void | - | 122-136 | 3 | - |
-| authenticateUser | (S,S):b | + | 141-172 | 6 | - |
+| authenticateUser | (S,S):b | + | 141-172 | 9 | - |
 | createSession | (S):S | + | 177-199 | 5 | - |
-| validateData | (M<S, O>):b | + | 204-246 | 10 | - |
-| validateEmail | (S):b | - | 251-254 | 1 | - |
-| validatePhoneNumber | (S):b | - | 259-262 | 1 | - |
+| validateData | (M<S, O>):b | + | 204-246 | 11 | - |
+| validateEmail | (S):b | - | 251-254 | 3 | - |
+| validatePhoneNumber | (S):b | - | 259-262 | 2 | - |
 | validateDate | (S):b | - | 267-275 | 2 | - |
 | logOperation | (S,S):void | + | 280-290 | 2 | - |
 | manageCache | (S,O):void | + | 295-308 | 2 | - |
-| cleanupCache | ():void | - | 313-326 | 2 | - |
+| cleanupCache | ():void | - | 313-326 | 3 | - |
 | updateCacheStatistics | ():void | - | 331-335 | 1 | - |
 | calculateCacheHitRatio | ():d | - | 340-343 | 1 | - |
 | performBackup | (S):void | + | 348-367 | 1 | - |
@@ -40,16 +40,16 @@
 | generateUserActivityReport | (M<S, O>):void | - | 539-553 | 4 | - |
 | generateSystemHealthReport | (M<S, O>):void | - | 558-574 | 5 | - |
 | finalizeReport | (S):void | - | 579-593 | 4 | - |
-| updateCustomerName | (S,S):void | + | 601-617 | 4 | - |
-| getCustomerInfo | (S):M<S, O> | + | 622-652 | 5 | - |
-| deleteCustomer | (S):b | + | 657-691 | 9 | - |
-| processOrder | (S,L<S>,d):S | + | 696-736 | 10 | - |
-| manageInventory | (S,S,i):void | + | 741-773 | 3 | - |
+| updateCustomerName | (S,S):void | + | 601-617 | 6 | - |
+| getCustomerInfo | (S):M<S, O> | + | 622-652 | 6 | - |
+| deleteCustomer | (S):b | + | 657-691 | 10 | - |
+| processOrder | (S,L<S>,d):S | + | 696-736 | 12 | - |
+| manageInventory | (S,S,i):void | + | 741-773 | 5 | - |
 | addInventory | (S,i):void | - | 778-792 | 4 | - |
 | removeInventory | (S,i):void | - | 797-811 | 4 | - |
 | updateInventory | (S,i):void | - | 816-830 | 4 | - |
 | checkInventory | (S):void | - | 835-850 | 4 | - |
-| sendNotification | (S,S,S):void | + | 855-884 | 7 | - |
+| sendNotification | (S,S,S):void | + | 855-884 | 9 | - |
 | shutdownSystem | ():void | + | 889-912 | 6 | - |
 | savePendingOperations | ():void | - | 917-926 | 2 | - |
 | closeDatabaseConnections | ():void | - | 931-940 | 2 | - |
@@ -69,7 +69,7 @@
 | validateSecuritySettings | ():void | - | 1197-1211 | 4 | - |
 | performVulnerabilityScan | ():void | - | 1216-1230 | 4 | - |
 | reviewSecurityLogs | ():void | - | 1235-1249 | 4 | - |
-| synchronizeData | (S,S):void | + | 1254-1283 | 3 | - |
+| synchronizeData | (S,S):void | + | 1254-1283 | 5 | - |
 | prepareSynchronization | (S,S):void | - | 1288-1302 | 4 | - |
 | extractData | (S):void | - | 1307-1323 | 5 | - |
 | transformData | ():void | - | 1328-1342 | 4 | - |

--- a/tests/golden_masters/compact/java_userservice_compact_format.md
+++ b/tests/golden_masters/compact/java_userservice_compact_format.md
@@ -13,4 +13,4 @@
 | UserService | (UserRepository):void | + | 10-12 | 1 | - |
 | findUserById | (Long):User | + | 14-19 | 2 | - |
 | createUser | (S,S):User | + | 21-25 | 1 | - |
-| validateUser | (User):b | - | 27-35 | 3 | - |
+| validateUser | (User):b | - | 27-35 | 5 | - |

--- a/tests/golden_masters/csv/cpp_sample_csv.csv
+++ b/tests/golden_masters/csv/cpp_sample_csv.csv
@@ -29,7 +29,7 @@ Method,perimeter,():double,public,105-105,1,-
 Method,name,():string,public,106-106,1,-
 Method,width,():double,public,109-109,1,-
 Method,height,():double,public,110-110,1,-
-Method,operator==,(other:const Rectangle&):bool,public,113-115,1,-
+Method,operator==,(other:const Rectangle&):bool,public,113-115,2,-
 Method,square,(side:double):Rectangle [static],public,118-120,1,-
 Method,print,():void,public,136-136,1,-
 Method,~Printable,():void,public,137-137,1,-

--- a/tests/golden_masters/csv/csharp_sample_csv.csv
+++ b/tests/golden_masters/csv/csharp_sample_csv.csv
@@ -10,7 +10,7 @@ Method,PhoneNumber,():string?,public,29-29,1,-
 Method,DisplayName,():string,public,32-32,1,-
 Constructor,User,"(name:string, email:string, createdBy:string):void",public,35-41,1,-
 Method,UpdateEmail,(newEmail:string):void,public,44-52,2,-
-Method,IsValid,():bool,public,54-59,1,-
+Method,IsValid,():bool,public,54-59,3,-
 Method,ToString,():string,public,61-64,1,-
 Method,GetById,(id:int):User,public,72-72,1,-
 Method,GetAll,():IEnumerable<User>,public,73-73,1,-

--- a/tests/golden_masters/csv/java_bigservice_csv.csv
+++ b/tests/golden_masters/csv/java_bigservice_csv.csv
@@ -16,15 +16,15 @@ Method,validateSystemRequirements,():void,private,82-88,1,-
 Method,checkMemoryUsage,():void,private,93-106,2,-
 Method,checkDiskSpace,():void,private,111-117,2,-
 Method,checkNetworkConnectivity,():void,private,122-136,3,-
-Method,authenticateUser,"(username:String, password:String):boolean",public,141-172,6,-
+Method,authenticateUser,"(username:String, password:String):boolean",public,141-172,9,-
 Method,createSession,(username:String):String,public,177-199,5,-
-Method,validateData,"(data:Map<String, Object>):boolean",public,204-246,10,-
-Method,validateEmail,(email:String):boolean,private,251-254,1,-
-Method,validatePhoneNumber,(phone:String):boolean,private,259-262,1,-
+Method,validateData,"(data:Map<String, Object>):boolean",public,204-246,11,-
+Method,validateEmail,(email:String):boolean,private,251-254,3,-
+Method,validatePhoneNumber,(phone:String):boolean,private,259-262,2,-
 Method,validateDate,(date:String):boolean,private,267-275,2,-
 Method,logOperation,"(operation:String, details:String):void",public,280-290,2,-
 Method,manageCache,"(key:String, value:Object):void",public,295-308,2,-
-Method,cleanupCache,():void,private,313-326,2,-
+Method,cleanupCache,():void,private,313-326,3,-
 Method,updateCacheStatistics,():void,private,331-335,1,-
 Method,calculateCacheHitRatio,():double,private,340-343,1,-
 Method,performBackup,(backupType:String):void,public,348-367,1,-
@@ -38,16 +38,16 @@ Method,generatePerformanceReport,"(parameters:Map<String, Object>):void",private
 Method,generateUserActivityReport,"(parameters:Map<String, Object>):void",private,539-553,4,-
 Method,generateSystemHealthReport,"(parameters:Map<String, Object>):void",private,558-574,5,-
 Method,finalizeReport,(reportType:String):void,private,579-593,4,-
-Method,updateCustomerName,"(customerId:String, newName:String):void",public,601-617,4,-
-Method,getCustomerInfo,"(customerId:String):Map<String, Object>",public,622-652,5,-
-Method,deleteCustomer,(customerId:String):boolean,public,657-691,9,-
-Method,processOrder,"(customerId:String, items:List<String>, totalAmount:double):String",public,696-736,10,-
-Method,manageInventory,"(action:String, itemId:String, quantity:int):void",public,741-773,3,-
+Method,updateCustomerName,"(customerId:String, newName:String):void",public,601-617,6,-
+Method,getCustomerInfo,"(customerId:String):Map<String, Object>",public,622-652,6,-
+Method,deleteCustomer,(customerId:String):boolean,public,657-691,10,-
+Method,processOrder,"(customerId:String, items:List<String>, totalAmount:double):String",public,696-736,12,-
+Method,manageInventory,"(action:String, itemId:String, quantity:int):void",public,741-773,5,-
 Method,addInventory,"(itemId:String, quantity:int):void",private,778-792,4,-
 Method,removeInventory,"(itemId:String, quantity:int):void",private,797-811,4,-
 Method,updateInventory,"(itemId:String, quantity:int):void",private,816-830,4,-
 Method,checkInventory,(itemId:String):void,private,835-850,4,-
-Method,sendNotification,"(recipient:String, message:String, type:String):void",public,855-884,7,-
+Method,sendNotification,"(recipient:String, message:String, type:String):void",public,855-884,9,-
 Method,shutdownSystem,():void,public,889-912,6,-
 Method,savePendingOperations,():void,private,917-926,2,-
 Method,closeDatabaseConnections,():void,private,931-940,2,-
@@ -67,7 +67,7 @@ Method,checkAccessPermissions,():void,private,1176-1192,5,-
 Method,validateSecuritySettings,():void,private,1197-1211,4,-
 Method,performVulnerabilityScan,():void,private,1216-1230,4,-
 Method,reviewSecurityLogs,():void,private,1235-1249,4,-
-Method,synchronizeData,"(sourceSystem:String, targetSystem:String):void",public,1254-1283,3,-
+Method,synchronizeData,"(sourceSystem:String, targetSystem:String):void",public,1254-1283,5,-
 Method,prepareSynchronization,"(sourceSystem:String, targetSystem:String):void",private,1288-1302,4,-
 Method,extractData,(sourceSystem:String):void,private,1307-1323,5,-
 Method,transformData,():void,private,1328-1342,4,-

--- a/tests/golden_masters/csv/java_userservice_csv_format.csv
+++ b/tests/golden_masters/csv/java_userservice_csv_format.csv
@@ -4,4 +4,4 @@ Field,logger,logger:Logger,private,8-8,,-
 Constructor,UserService,(userRepository:UserRepository):void,public,10-12,1,-
 Method,findUserById,(id:Long):User,public,14-19,2,-
 Method,createUser,"(name:String, email:String):User",public,21-25,1,-
-Method,validateUser,(user:User):boolean,private,27-35,3,-
+Method,validateUser,(user:User):boolean,private,27-35,5,-

--- a/tests/golden_masters/full/cpp_sample_full.md
+++ b/tests/golden_masters/full/cpp_sample_full.md
@@ -80,7 +80,7 @@ using StringList = vector<string>;
 | name | ():string | + | 106-106 | 5-6 | 1 | - |
 | width | ():double | + | 109-109 | 5-6 | 1 | - |
 | height | ():double | + | 110-110 | 5-6 | 1 | - |
-| operator== | (other:const Rectangle&):bool | + | 113-115 | 5-6 | 1 | - |
+| operator== | (other:const Rectangle&):bool | + | 113-115 | 5-6 | 2 | - |
 | square | (side:double):Rectangle [static] | + | 118-120 | 5-6 | 1 | - |
 
 ## Printable (134-138)

--- a/tests/golden_masters/full/csharp_sample_full.md
+++ b/tests/golden_masters/full/csharp_sample_full.md
@@ -38,7 +38,7 @@ using System.Linq;
 | PhoneNumber | ():string? | + | 29-29 | 1 | - |
 | DisplayName | ():string | + | 32-32 | 1 | - |
 | UpdateEmail | (newEmail:string):void | + | 44-52 | 2 | - |
-| IsValid | ():bool | + | 54-59 | 1 | - |
+| IsValid | ():bool | + | 54-59 | 3 | - |
 | ToString | ():string | + | 61-64 | 1 | - |
 
 ## IUserRepository (70-77)

--- a/tests/golden_masters/full/java_bigservice_full.md
+++ b/tests/golden_masters/full/java_bigservice_full.md
@@ -47,24 +47,24 @@ import javax.sql.DataSource;
 ### Public Methods
 | Method | Signature | Vis | Lines | Cx | Doc |
 |--------|-----------|-----|-------|----|----|
-| authenticateUser | (username:String, password:String):boolean | + | 141-172 | 6 | - |
+| authenticateUser | (username:String, password:String):boolean | + | 141-172 | 9 | - |
 | createSession | (username:String):String | + | 177-199 | 5 | - |
-| validateData | (data:Map<String, Object>):boolean | + | 204-246 | 10 | - |
+| validateData | (data:Map<String, Object>):boolean | + | 204-246 | 11 | - |
 | logOperation | (operation:String, details:String):void | + | 280-290 | 2 | - |
 | manageCache | (key:String, value:Object):void | + | 295-308 | 2 | - |
 | performBackup | (backupType:String):void | + | 348-367 | 1 | - |
 | generateReport | (reportType:String, parameters:Map<String, Object>):void | + | 438-471 | 2 | - |
-| updateCustomerName | (customerId:String, newName:String):void | + | 601-617 | 4 | - |
-| getCustomerInfo | (customerId:String):Map<String, Object> | + | 622-652 | 5 | - |
-| deleteCustomer | (customerId:String):boolean | + | 657-691 | 9 | - |
-| processOrder | (customerId:String, items:List<String>, totalAmount:double):String | + | 696-736 | 10 | - |
-| manageInventory | (action:String, itemId:String, quantity:int):void | + | 741-773 | 3 | - |
-| sendNotification | (recipient:String, message:String, type:String):void | + | 855-884 | 7 | - |
+| updateCustomerName | (customerId:String, newName:String):void | + | 601-617 | 6 | - |
+| getCustomerInfo | (customerId:String):Map<String, Object> | + | 622-652 | 6 | - |
+| deleteCustomer | (customerId:String):boolean | + | 657-691 | 10 | - |
+| processOrder | (customerId:String, items:List<String>, totalAmount:double):String | + | 696-736 | 12 | - |
+| manageInventory | (action:String, itemId:String, quantity:int):void | + | 741-773 | 5 | - |
+| sendNotification | (recipient:String, message:String, type:String):void | + | 855-884 | 9 | - |
 | shutdownSystem | ():void | + | 889-912 | 6 | - |
 | handleError | (error:Exception, context:String):void | + | 958-977 | 4 | - |
 | monitorPerformance | ():void | + | 1046-1067 | 1 | - |
 | performSecurityCheck | ():void | + | 1155-1171 | 1 | - |
-| synchronizeData | (sourceSystem:String, targetSystem:String):void | + | 1254-1283 | 3 | - |
+| synchronizeData | (sourceSystem:String, targetSystem:String):void | + | 1254-1283 | 5 | - |
 | main | (args:String[]):void [static] | + | 1385-1418 | 1 | - |
 
 ### Private Methods
@@ -77,10 +77,10 @@ import javax.sql.DataSource;
 | checkMemoryUsage | ():void | - | 93-106 | 2 | - |
 | checkDiskSpace | ():void | - | 111-117 | 2 | - |
 | checkNetworkConnectivity | ():void | - | 122-136 | 3 | - |
-| validateEmail | (email:String):boolean | - | 251-254 | 1 | - |
-| validatePhoneNumber | (phone:String):boolean | - | 259-262 | 1 | - |
+| validateEmail | (email:String):boolean | - | 251-254 | 3 | - |
+| validatePhoneNumber | (phone:String):boolean | - | 259-262 | 2 | - |
 | validateDate | (date:String):boolean | - | 267-275 | 2 | - |
-| cleanupCache | ():void | - | 313-326 | 2 | - |
+| cleanupCache | ():void | - | 313-326 | 3 | - |
 | updateCacheStatistics | ():void | - | 331-335 | 1 | - |
 | calculateCacheHitRatio | ():double | - | 340-343 | 1 | - |
 | performFullBackup | ():void | - | 372-395 | 6 | - |

--- a/tests/golden_masters/full/java_userservice_full_format.md
+++ b/tests/golden_masters/full/java_userservice_full_format.md
@@ -40,4 +40,4 @@ import java.sql.SQLException;
 ### Private Methods
 | Method | Signature | Vis | Lines | Cx | Doc |
 |--------|-----------|-----|-------|----|----|
-| validateUser | (user:User):boolean | - | 27-35 | 3 | - |
+| validateUser | (user:User):boolean | - | 27-35 | 5 | - |

--- a/tests/integration/formatters/test_formatter_integration.py
+++ b/tests/integration/formatters/test_formatter_integration.py
@@ -166,7 +166,7 @@ public class UserService {
         assert "| Methods | 4 |" in table_output
         assert "| Fields | 2 |" in table_output
         assert "| findUserById | (Long):User | + | 14-19 | 2 | - |" in table_output
-        assert "| validateUser | (User):b | - | 27-35 | 3 | - |" in table_output
+        assert "| validateUser | (User):b | - | 27-35 | 5 | - |" in table_output
 
     @pytest.mark.asyncio
     async def test_csv_format_end_to_end(
@@ -266,7 +266,7 @@ public class UserService {
         )
         assert (
             results["full"].count(
-                "| validateUser | (user:User):boolean | - | 27-35 | 3 | - |"
+                "| validateUser | (user:User):boolean | - | 27-35 | 5 | - |"
             )
             == 1
         )
@@ -282,7 +282,7 @@ public class UserService {
             == 1
         )
         assert (
-            results["compact"].count("| validateUser | (User):b | - | 27-35 | 3 | - |")
+            results["compact"].count("| validateUser | (User):b | - | 27-35 | 5 | - |")
             == 1
         )
         assert results["csv"].count("\nMethod,") == 3

--- a/tests/unit/languages/test_cyclomatic_complexity.py
+++ b/tests/unit/languages/test_cyclomatic_complexity.py
@@ -846,3 +846,345 @@ class TestRustCyclomaticComplexity:
         assert len(funcs) == 1
         assert funcs[0].name == "process"
         assert funcs[0].complexity_score == 7
+
+
+# ---------------------------------------------------------------------------
+# Java
+# ---------------------------------------------------------------------------
+# The C-family plugins (Java/C/C++/C#) historically counted control-flow
+# statements but NOT the "&&"/"||" short-circuit operators, while every other
+# plugin (Python/JS/TS/Go/Rust/Ruby/Kotlin/PHP/Scala/Swift/Bash) does. These
+# RED-first tests pin the post-fix value where each "&&"/"||" adds one decision
+# point, restoring cross-language parity. The binary_search fixture has no
+# boolean operators, so it is a control that stays at 4 (unchanged by the fix).
+
+JAVA_SIMPLE = """\
+class Sample {
+    String greet(String name) {
+        return "Hello, " + name;
+    }
+}
+"""
+# No branches → complexity = 1
+
+JAVA_BRANCHY = """\
+class Sample {
+    int binarySearch(int[] arr, int target) {
+        int low = 0;
+        int high = arr.length - 1;
+        while (low <= high) {
+            int mid = (low + high) / 2;
+            if (arr[mid] == target) {
+                return mid;
+            } else if (arr[mid] < target) {
+                low = mid + 1;
+            } else {
+                high = mid - 1;
+            }
+        }
+        return -1;
+    }
+}
+"""
+# Decisions: while(1) + if(1) + else-if (nested if_statement)(1) = 3
+# No boolean operators → complexity = 1 + 3 = 4 (unchanged by the fix).
+
+JAVA_RICH = """\
+class Sample {
+    int process(int x) {
+        if (x > 0 && x < 100) {
+            return 1;
+        } else if (x < 0 || x > 200) {
+            return 2;
+        }
+        for (int i = 0; i < 10; i++) {}
+        while (x > 0) {
+            x--;
+        }
+        try {
+            int d = 1 / x;
+        } catch (Exception e) {}
+        return 0;
+    }
+}
+"""
+# Decisions counted by the Java walker:
+#   if_statement          : 2   (if + else-if)
+#   for_statement         : 1
+#   while_statement       : 1
+#   catch_clause          : 1
+#   &&                    : 1   (NEW: short-circuit operator)
+#   ||                    : 1   (NEW: short-circuit operator)
+# Total = 7 → complexity = 1 + 7 = 8 (pre-fix this measured 6).
+
+
+def _java_functions(source: str):
+    import tree_sitter_java
+
+    lang = tree_sitter.Language(tree_sitter_java.language())
+    parser = tree_sitter.Parser(lang)
+    tree = parser.parse(source.encode())
+    from tree_sitter_analyzer.languages.java_plugin import JavaElementExtractor
+
+    return JavaElementExtractor().extract_functions(tree, source)
+
+
+class TestJavaCyclomaticComplexity:
+    def test_simple_no_branches(self):
+        funcs = _java_functions(JAVA_SIMPLE)
+        assert len(funcs) == 1
+        assert funcs[0].name == "greet"
+        assert funcs[0].complexity_score == 1
+
+    def test_binary_search(self):
+        """while + if + else-if = 3 decisions, no booleans → complexity 4."""
+        funcs = _java_functions(JAVA_BRANCHY)
+        assert len(funcs) == 1
+        assert funcs[0].name == "binarySearch"
+        assert funcs[0].complexity_score == 4
+
+    def test_rich_branching(self):
+        """7 decision points (incl. && and ||) → complexity 8."""
+        funcs = _java_functions(JAVA_RICH)
+        assert len(funcs) == 1
+        assert funcs[0].name == "process"
+        assert funcs[0].complexity_score == 8
+
+
+# ---------------------------------------------------------------------------
+# C
+# ---------------------------------------------------------------------------
+
+C_SIMPLE = """\
+int greet(int n) {
+    return n;
+}
+"""
+# No branches → complexity = 1
+
+C_BRANCHY = """\
+int binary_search(int* arr, int n, int target) {
+    int low = 0;
+    int high = n - 1;
+    while (low <= high) {
+        int mid = (low + high) / 2;
+        if (arr[mid] == target) {
+            return mid;
+        } else if (arr[mid] < target) {
+            low = mid + 1;
+        } else {
+            high = mid - 1;
+        }
+    }
+    return -1;
+}
+"""
+# Decisions: while(1) + if(1) + else-if (nested if_statement)(1) = 3
+# No boolean operators → complexity = 1 + 3 = 4 (unchanged by the fix).
+
+C_RICH = """\
+int process(int x) {
+    if (x > 0 && x < 100) {
+        return 1;
+    } else if (x < 0 || x > 200) {
+        return 2;
+    }
+    for (int i = 0; i < 10; i++) {}
+    while (x > 0) {
+        x--;
+    }
+    switch (x) {
+        case 1: return 3;
+    }
+    int r = x > 0 ? 1 : -1;
+    return r;
+}
+"""
+# Decisions counted by the C walker:
+#   if_statement          : 2   (if + else-if)
+#   for_statement         : 1
+#   while_statement       : 1
+#   switch_statement      : 1
+#   case_statement        : 1
+#   conditional_expression: 1   (ternary)
+#   &&                    : 1   (NEW: short-circuit operator)
+#   ||                    : 1   (NEW: short-circuit operator)
+# Total = 9 → complexity = 1 + 9 = 10 (pre-fix this measured 8).
+
+
+def _c_functions(source: str):
+    import tree_sitter_c
+
+    lang = tree_sitter.Language(tree_sitter_c.language())
+    parser = tree_sitter.Parser(lang)
+    tree = parser.parse(source.encode())
+    from tree_sitter_analyzer.languages.c_plugin import CElementExtractor
+
+    return CElementExtractor().extract_functions(tree, source)
+
+
+class TestCCyclomaticComplexity:
+    def test_simple_no_branches(self):
+        funcs = _c_functions(C_SIMPLE)
+        assert len(funcs) == 1
+        assert funcs[0].name == "greet"
+        assert funcs[0].complexity_score == 1
+
+    def test_binary_search(self):
+        """while + if + else-if = 3 decisions, no booleans → complexity 4."""
+        funcs = _c_functions(C_BRANCHY)
+        assert len(funcs) == 1
+        assert funcs[0].name == "binary_search"
+        assert funcs[0].complexity_score == 4
+
+    def test_rich_branching(self):
+        """9 decision points (incl. && and ||) → complexity 10."""
+        funcs = _c_functions(C_RICH)
+        assert len(funcs) == 1
+        assert funcs[0].name == "process"
+        assert funcs[0].complexity_score == 10
+
+
+# ---------------------------------------------------------------------------
+# C++
+# ---------------------------------------------------------------------------
+
+
+def _cpp_functions(source: str):
+    import tree_sitter_cpp
+
+    lang = tree_sitter.Language(tree_sitter_cpp.language())
+    parser = tree_sitter.Parser(lang)
+    tree = parser.parse(source.encode())
+    from tree_sitter_analyzer.languages.cpp_plugin import CppElementExtractor
+
+    return CppElementExtractor().extract_functions(tree, source)
+
+
+class TestCppCyclomaticComplexity:
+    # Reuses the C fixtures: the grammars share the same decision-node types
+    # for these constructs, and the C++ walker now counts && / || as well.
+    def test_simple_no_branches(self):
+        funcs = _cpp_functions(C_SIMPLE)
+        assert len(funcs) == 1
+        assert funcs[0].name == "greet"
+        assert funcs[0].complexity_score == 1
+
+    def test_binary_search(self):
+        """while + if + else-if = 3 decisions, no booleans → complexity 4."""
+        funcs = _cpp_functions(C_BRANCHY)
+        assert len(funcs) == 1
+        assert funcs[0].name == "binary_search"
+        assert funcs[0].complexity_score == 4
+
+    def test_rich_branching(self):
+        """9 decision points (incl. && and ||) → complexity 10."""
+        funcs = _cpp_functions(C_RICH)
+        assert len(funcs) == 1
+        assert funcs[0].name == "process"
+        assert funcs[0].complexity_score == 10
+
+
+# ---------------------------------------------------------------------------
+# C#
+# ---------------------------------------------------------------------------
+
+CSHARP_SIMPLE = """\
+class Sample {
+    int Greet(int n) {
+        return n;
+    }
+}
+"""
+# No branches → complexity = 1
+
+CSHARP_BRANCHY = """\
+class Sample {
+    int BinarySearch(int[] arr, int target) {
+        int low = 0;
+        int high = arr.Length - 1;
+        while (low <= high) {
+            int mid = (low + high) / 2;
+            if (arr[mid] == target) {
+                return mid;
+            } else if (arr[mid] < target) {
+                low = mid + 1;
+            } else {
+                high = mid - 1;
+            }
+        }
+        return -1;
+    }
+}
+"""
+# Decisions: while(1) + if(1) + else-if (nested if_statement)(1) = 3
+# No boolean operators → complexity = 1 + 3 = 4 (unchanged by the fix).
+
+CSHARP_RICH = """\
+class Sample {
+    int Process(int x) {
+        if (x > 0 && x < 100) {
+            return 1;
+        } else if (x < 0 || x > 200) {
+            return 2;
+        }
+        for (int i = 0; i < 10; i++) {}
+        foreach (var y in new[] {1, 2}) {}
+        while (x > 0) {
+            x--;
+        }
+        switch (x) {
+            case 1: return 3;
+        }
+        try {
+            int d = 1 / x;
+        } catch (Exception e) {}
+        int r = x > 0 ? 1 : -1;
+        return r;
+    }
+}
+"""
+# Decisions counted by the C# walker:
+#   if_statement          : 2   (if + else-if)
+#   for_statement         : 1
+#   foreach_statement     : 1
+#   while_statement       : 1
+#   switch_statement      : 1
+#   catch_clause          : 1
+#   conditional_expression: 1   (ternary)
+#   &&                    : 1   (NEW: short-circuit operator)
+#   ||                    : 1   (NEW: short-circuit operator)
+# Total = 10 → complexity = 1 + 10 = 11 (pre-fix this measured 9).
+
+
+def _csharp_functions(source: str):
+    import tree_sitter_c_sharp
+
+    lang = tree_sitter.Language(tree_sitter_c_sharp.language())
+    parser = tree_sitter.Parser(lang)
+    tree = parser.parse(source.encode())
+    from tree_sitter_analyzer.languages.csharp_plugin import CSharpElementExtractor
+
+    return CSharpElementExtractor().extract_functions(tree, source)
+
+
+class TestCSharpCyclomaticComplexity:
+    def test_simple_no_branches(self):
+        funcs = _csharp_functions(CSHARP_SIMPLE)
+        assert len(funcs) == 1
+        assert funcs[0].name == "Greet"
+        assert funcs[0].complexity_score == 1
+
+    def test_binary_search(self):
+        """while + if + else-if = 3 decisions, no booleans → complexity 4."""
+        funcs = _csharp_functions(CSHARP_BRANCHY)
+        assert len(funcs) == 1
+        assert funcs[0].name == "BinarySearch"
+        assert funcs[0].complexity_score == 4
+
+    def test_rich_branching(self):
+        """10 decision points (incl. && and ||) → complexity 11."""
+        funcs = _csharp_functions(CSHARP_RICH)
+        assert len(funcs) == 1
+        assert funcs[0].name == "Process"
+        assert funcs[0].complexity_score == 11

--- a/tests/unit/languages/test_cyclomatic_complexity.py
+++ b/tests/unit/languages/test_cyclomatic_complexity.py
@@ -1188,3 +1188,74 @@ class TestCSharpCyclomaticComplexity:
         assert len(funcs) == 1
         assert funcs[0].name == "Process"
         assert funcs[0].complexity_score == 11
+
+
+# ---------------------------------------------------------------------------
+# Non-executable boolean contexts (Codex P2/P3 on PR #1085)
+# ---------------------------------------------------------------------------
+# A "&&"/"||" only adds a decision point when it drives executable control
+# flow. Boolean tokens in a C++ noexcept/requires specifier, a preprocessor
+# "#if A && B" condition, a default argument, or an attribute/annotation are
+# compile-time / signature metadata, NOT runtime branches, and must leave an
+# otherwise branch-free function at complexity 1.
+
+
+class TestLogicalOperatorNonExecutableContexts:
+    def test_cpp_noexcept_boolean_not_counted(self):
+        funcs = _cpp_functions("int f() noexcept(true && false) { return 1; }")
+        assert funcs[0].name == "f"
+        assert funcs[0].complexity_score == 1
+
+    def test_cpp_requires_boolean_not_counted(self):
+        src = (
+            "template<class T> int g() "
+            "requires (sizeof(T) > 0 && sizeof(T) < 99) { return 2; }"
+        )
+        funcs = _cpp_functions(src)
+        assert funcs[0].name == "g"
+        assert funcs[0].complexity_score == 1
+
+    def test_cpp_default_argument_boolean_not_counted(self):
+        funcs = _cpp_functions("int h(bool flag = true && false) { return 1; }")
+        assert funcs[0].name == "h"
+        assert funcs[0].complexity_score == 1
+
+    def test_cpp_preproc_if_boolean_not_counted(self):
+        src = (
+            "int f(int x) {\n#if defined(A) && defined(B)\n x++;\n#endif\n return x;\n}"
+        )
+        funcs = _cpp_functions(src)
+        assert funcs[0].name == "f"
+        assert funcs[0].complexity_score == 1
+
+    def test_c_preproc_if_boolean_not_counted(self):
+        src = (
+            "int f(int x) {\n#if defined(A) && defined(B)\n x++;\n#endif\n return x;\n}"
+        )
+        funcs = _c_functions(src)
+        assert funcs[0].name == "f"
+        assert funcs[0].complexity_score == 1
+
+    def test_csharp_default_argument_boolean_not_counted(self):
+        funcs = _csharp_functions("class P { void M(bool flag = true && false) {} }")
+        assert funcs[0].name == "M"
+        assert funcs[0].complexity_score == 1
+
+    def test_csharp_attribute_boolean_not_counted(self):
+        funcs = _csharp_functions("class P { [Attr(true && false)] void M() {} }")
+        assert funcs[0].name == "M"
+        assert funcs[0].complexity_score == 1
+
+    def test_csharp_preproc_if_boolean_not_counted(self):
+        src = "class P {\n void M(int x) {\n#if DEBUG && TRACE\n x++;\n#endif\n }\n}"
+        funcs = _csharp_functions(src)
+        assert funcs[0].name == "M"
+        assert funcs[0].complexity_score == 1
+
+    def test_body_boolean_still_counts_as_control(self):
+        """A genuine body "&&" must still add a decision point (regression guard)."""
+        funcs = _cpp_functions(
+            "int f(int x) { if (x > 0 && x < 9) { return 1; } return 0; }"
+        )
+        assert funcs[0].name == "f"
+        assert funcs[0].complexity_score == 3

--- a/tree_sitter_analyzer/languages/_complexity_logical.py
+++ b/tree_sitter_analyzer/languages/_complexity_logical.py
@@ -1,0 +1,45 @@
+"""Shared helper for counting short-circuit boolean operators in cyclomatic
+complexity across the C-family plugins (C / C++ / C# / Java).
+
+Each ``&&`` / ``||`` adds one decision point — but ONLY when it drives
+executable control flow. A boolean token can also appear in non-executable
+contexts (C++ ``noexcept`` / ``requires`` specifiers, preprocessor ``#if``
+conditions, default parameter values, attributes / annotations). Counting
+those would inflate the complexity of an otherwise branch-free function, so
+the anchor of the logical expression is checked against a per-language set of
+non-executable anchor node types.
+"""
+
+from typing import Any
+
+# Ancestors that are skipped when locating a logical expression's "anchor"
+# (the first ancestor that is not part of the same boolean expression).
+_TRANSPARENT_ANCESTORS = frozenset({"binary_expression", "parenthesized_expression"})
+
+
+def is_executable_logical_operator(
+    node: Any, non_executable_anchors: frozenset[str]
+) -> bool:
+    """Return True when a ``&&`` / ``||`` token is an executable branch.
+
+    ``node`` must be the ``&&`` / ``||`` leaf. It counts as a decision point
+    only when it is an operand of a ``binary_expression`` (filtering out the
+    C++ rvalue-reference ``&&`` declarator) AND the expression's anchor — the
+    first ancestor above the chained ``binary_expression`` / parenthesis nodes
+    — is not one of ``non_executable_anchors`` (e.g. ``noexcept``,
+    ``requires_clause``, ``preproc_if``, a parameter default, an attribute).
+    """
+    parent = getattr(node, "parent", None)
+    if parent is None or getattr(parent, "type", None) != "binary_expression":
+        return False
+
+    anchor: Any = parent
+    while (
+        anchor is not None and getattr(anchor, "type", None) in _TRANSPARENT_ANCESTORS
+    ):
+        anchor = getattr(anchor, "parent", None)
+
+    return (
+        anchor is not None
+        and getattr(anchor, "type", None) not in non_executable_anchors
+    )

--- a/tree_sitter_analyzer/languages/_cpp_complexity_helpers.py
+++ b/tree_sitter_analyzer/languages/_cpp_complexity_helpers.py
@@ -2,6 +2,8 @@
 
 from typing import Any
 
+from ._complexity_logical import is_executable_logical_operator
+
 _DECISION_NODES = frozenset(
     {
         "if_statement",
@@ -17,22 +19,30 @@ _DECISION_NODES = frozenset(
 )
 
 # Short-circuit boolean operators each add a decision point, matching the
-# Go/Rust/Swift convention. They must be counted ONLY as logical operators
-# (operands of a binary_expression); in C++ the "&&" token is also the
-# rvalue-reference declarator (e.g. ``T&& x``), which is NOT a branch.
+# Go/Rust/Swift convention. They are counted ONLY as logical operators
+# (operands of a binary_expression) driving executable control flow; "&&" in a
+# non-body context — the rvalue-reference declarator ``T&& x`` (parent is not a
+# binary_expression), a ``noexcept`` / ``requires`` specifier, a preprocessor
+# ``#if`` condition, a default argument, or a ``static_assert`` — is not a
+# branch and must not inflate complexity.
 _LOGICAL_OPERATORS = frozenset({"&&", "||"})
+_NON_EXECUTABLE_ANCHORS = frozenset(
+    {
+        "noexcept",
+        "requires_clause",
+        "preproc_if",
+        "preproc_elif",
+        "optional_parameter_declaration",
+        "static_assert_declaration",
+    }
+)
 
 
 def _is_logical_operator(node: Any) -> bool:
-    """True when ``node`` is a "&&"/"||" used as a boolean operator.
-
-    Filters out the C++ rvalue-reference ``&&`` (parent ``reference_declarator``)
-    so move constructors / rvalue-ref parameters do not inflate complexity.
-    """
+    """True when ``node`` is a "&&"/"||" used as an executable boolean branch."""
     if getattr(node, "type", None) not in _LOGICAL_OPERATORS:
         return False
-    parent = getattr(node, "parent", None)
-    return parent is not None and getattr(parent, "type", None) == "binary_expression"
+    return is_executable_logical_operator(node, _NON_EXECUTABLE_ANCHORS)
 
 
 def calculate_complexity(node: Any) -> int:

--- a/tree_sitter_analyzer/languages/_cpp_complexity_helpers.py
+++ b/tree_sitter_analyzer/languages/_cpp_complexity_helpers.py
@@ -16,6 +16,24 @@ _DECISION_NODES = frozenset(
     }
 )
 
+# Short-circuit boolean operators each add a decision point, matching the
+# Go/Rust/Swift convention. They must be counted ONLY as logical operators
+# (operands of a binary_expression); in C++ the "&&" token is also the
+# rvalue-reference declarator (e.g. ``T&& x``), which is NOT a branch.
+_LOGICAL_OPERATORS = frozenset({"&&", "||"})
+
+
+def _is_logical_operator(node: Any) -> bool:
+    """True when ``node`` is a "&&"/"||" used as a boolean operator.
+
+    Filters out the C++ rvalue-reference ``&&`` (parent ``reference_declarator``)
+    so move constructors / rvalue-ref parameters do not inflate complexity.
+    """
+    if getattr(node, "type", None) not in _LOGICAL_OPERATORS:
+        return False
+    parent = getattr(node, "parent", None)
+    return parent is not None and getattr(parent, "type", None) == "binary_expression"
+
 
 def calculate_complexity(node: Any) -> int:
     """Calculate cyclomatic complexity for a C++ syntax node."""
@@ -25,6 +43,8 @@ def calculate_complexity(node: Any) -> int:
     while stack:
         current = stack.pop()
         if getattr(current, "type", None) in _DECISION_NODES:
+            count += 1
+        elif _is_logical_operator(current):
             count += 1
 
         children = getattr(current, "children", None)

--- a/tree_sitter_analyzer/languages/_java_ast_helpers.py
+++ b/tree_sitter_analyzer/languages/_java_ast_helpers.py
@@ -4,6 +4,8 @@ import re
 from collections.abc import Callable
 from typing import Any
 
+from ._complexity_logical import is_executable_logical_operator
+
 _MODIFIER_KEYWORDS = frozenset(
     {
         "public",
@@ -57,8 +59,13 @@ _JAVA_DECISION_NODES = frozenset(
 
 # Short-circuit boolean operators each add a decision point, matching the
 # Go/Rust/Swift convention. Counted only as logical operators (operands of a
-# binary_expression) for consistency with the C/C++ walkers.
+# binary_expression) that drive executable control flow, for consistency with
+# the C/C++ walkers. A "&&"/"||" in an annotation argument (a compile-time
+# constant) is not a runtime branch and must not inflate complexity.
 _JAVA_LOGICAL_OPERATORS = frozenset({"&&", "||"})
+_JAVA_NON_EXECUTABLE_ANCHORS = frozenset(
+    {"element_value_pair", "annotation_argument_list"}
+)
 
 
 def extract_modifiers(node: Any, get_node_text: Callable[..., str]) -> list[str]:
@@ -208,11 +215,7 @@ def _count_decision_nodes(node: Any) -> int:
         if current_type in _JAVA_DECISION_NODES:
             count += 1
         elif current_type in _JAVA_LOGICAL_OPERATORS:
-            parent = getattr(current, "parent", None)
-            if (
-                parent is not None
-                and getattr(parent, "type", None) == "binary_expression"
-            ):
+            if is_executable_logical_operator(current, _JAVA_NON_EXECUTABLE_ANCHORS):
                 count += 1
         stack.extend(_safe_children(current))
     return count

--- a/tree_sitter_analyzer/languages/_java_ast_helpers.py
+++ b/tree_sitter_analyzer/languages/_java_ast_helpers.py
@@ -55,6 +55,11 @@ _JAVA_DECISION_NODES = frozenset(
     }
 )
 
+# Short-circuit boolean operators each add a decision point, matching the
+# Go/Rust/Swift convention. Counted only as logical operators (operands of a
+# binary_expression) for consistency with the C/C++ walkers.
+_JAVA_LOGICAL_OPERATORS = frozenset({"&&", "||"})
+
 
 def extract_modifiers(node: Any, get_node_text: Callable[..., str]) -> list[str]:
     """Extract modifiers from a declaration node."""
@@ -199,8 +204,16 @@ def _count_decision_nodes(node: Any) -> int:
     stack = [node]
     while stack:
         current = stack.pop()
-        if getattr(current, "type", None) in _JAVA_DECISION_NODES:
+        current_type = getattr(current, "type", None)
+        if current_type in _JAVA_DECISION_NODES:
             count += 1
+        elif current_type in _JAVA_LOGICAL_OPERATORS:
+            parent = getattr(current, "parent", None)
+            if (
+                parent is not None
+                and getattr(parent, "type", None) == "binary_expression"
+            ):
+                count += 1
         stack.extend(_safe_children(current))
     return count
 

--- a/tree_sitter_analyzer/languages/c_helpers.py
+++ b/tree_sitter_analyzer/languages/c_helpers.py
@@ -28,6 +28,7 @@ from ._c_type_definition_helpers import (
 from ._c_type_definition_helpers import (
     extract_struct_definition as _extract_struct_definition_impl,
 )
+from ._complexity_logical import is_executable_logical_operator
 
 
 # Extract elements from AST: extract_c_imports
@@ -136,6 +137,11 @@ def calculate_complexity(node: Any) -> int:
         "conditional_expression",
         "do_statement",
     }
+    # "&&"/"||" in a preprocessor "#if A && B" condition or a "_Static_assert"
+    # is compile-time, not executable control flow, and must not be counted.
+    non_executable_anchors = frozenset(
+        {"preproc_if", "preproc_elif", "static_assert_declaration"}
+    )
 
     def count_decisions(n: Any) -> int:
         count = 0
@@ -143,14 +149,10 @@ def calculate_complexity(node: Any) -> int:
         if n_type in decision_nodes:
             count += 1
         elif n_type in ("&&", "||"):
-            # Short-circuit boolean operators each add a decision point, but
-            # only as logical operators (operands of a binary_expression),
-            # matching the Go/Rust/Swift convention.
-            parent = getattr(n, "parent", None)
-            if (
-                parent is not None
-                and getattr(parent, "type", None) == "binary_expression"
-            ):
+            # Short-circuit boolean operators each add a decision point when
+            # they drive executable control flow, matching the Go/Rust/Swift
+            # convention.
+            if is_executable_logical_operator(n, non_executable_anchors):
                 count += 1
         if hasattr(n, "children"):
             try:

--- a/tree_sitter_analyzer/languages/c_helpers.py
+++ b/tree_sitter_analyzer/languages/c_helpers.py
@@ -139,8 +139,19 @@ def calculate_complexity(node: Any) -> int:
 
     def count_decisions(n: Any) -> int:
         count = 0
-        if hasattr(n, "type") and n.type in decision_nodes:
+        n_type = getattr(n, "type", None)
+        if n_type in decision_nodes:
             count += 1
+        elif n_type in ("&&", "||"):
+            # Short-circuit boolean operators each add a decision point, but
+            # only as logical operators (operands of a binary_expression),
+            # matching the Go/Rust/Swift convention.
+            parent = getattr(n, "parent", None)
+            if (
+                parent is not None
+                and getattr(parent, "type", None) == "binary_expression"
+            ):
+                count += 1
         if hasattr(n, "children"):
             try:
                 for child in n.children:

--- a/tree_sitter_analyzer/languages/csharp_helpers.py
+++ b/tree_sitter_analyzer/languages/csharp_helpers.py
@@ -5,6 +5,13 @@ from typing import Any
 
 from ..models import Class, Function, Import, Variable
 from ..utils import log_error
+from ._complexity_logical import is_executable_logical_operator
+
+# "&&"/"||" in a default argument, an attribute, or a "#if A && B" condition is
+# not executable control flow and must not inflate a method's complexity.
+_CSHARP_NON_EXECUTABLE_ANCHORS = frozenset(
+    {"parameter", "attribute_argument", "preproc_if", "preproc_elif"}
+)
 
 _OWNING_TYPE_NODES = frozenset(
     {
@@ -105,14 +112,10 @@ def calculate_complexity(node: Any, traverse_fn: Callable[..., Iterator]) -> int
         if child_type in decision_keywords:
             complexity += 1
         elif child_type in ("&&", "||"):
-            # Short-circuit boolean operators each add a decision point, but
-            # only as logical operators (operands of a binary_expression),
-            # matching the Go/Rust/Swift convention.
-            parent = getattr(child, "parent", None)
-            if (
-                parent is not None
-                and getattr(parent, "type", None) == "binary_expression"
-            ):
+            # Short-circuit boolean operators each add a decision point when
+            # they drive executable control flow, matching the Go/Rust/Swift
+            # convention.
+            if is_executable_logical_operator(child, _CSHARP_NON_EXECUTABLE_ANCHORS):
                 complexity += 1
     return complexity
 

--- a/tree_sitter_analyzer/languages/csharp_helpers.py
+++ b/tree_sitter_analyzer/languages/csharp_helpers.py
@@ -101,8 +101,19 @@ def calculate_complexity(node: Any, traverse_fn: Callable[..., Iterator]) -> int
         "conditional_expression",
     }
     for child in traverse_fn(node):
-        if child.type in decision_keywords:
+        child_type = child.type
+        if child_type in decision_keywords:
             complexity += 1
+        elif child_type in ("&&", "||"):
+            # Short-circuit boolean operators each add a decision point, but
+            # only as logical operators (operands of a binary_expression),
+            # matching the Go/Rust/Swift convention.
+            parent = getattr(child, "parent", None)
+            if (
+                parent is not None
+                and getattr(parent, "type", None) == "binary_expression"
+            ):
+                complexity += 1
     return complexity
 
 


### PR DESCRIPTION
## What
Removes the dead `IStructureFormatter` ABC — **zero implementers repo-wide**.

## Why
Ponytail audit #1083 finding #1 (dead abstraction). `IStructureFormatter` had one abstract method `format_structure` and **no subclasses** (verified: `grep -rn '(IStructureFormatter)' --include='*.py' .` → 0). It was:
- imported `# noqa: F401` (explicitly known-unused) in `formatter_registry.py`
- re-exported in `formatters/__init__.py` (import + `__all__`)
- documented as 'legacy adapters' in `docs/CODEMAPS/formatters.md`

The live `format_structure` lives on `BaseFormatter`; nothing routes through this interface.

## Changes (pure dead-weight removal, no behavior change)
- delete the `IStructureFormatter` class + its now-unused `from typing import Any` import
- drop the registry re-export (and its now-unneeded `noqa`; `IFormatter` stays — it's used)
- drop the `__init__` import + `__all__` entry
- drop the codemap row; fix 're-exports both' → 'IFormatter'

## Test plan
- [x] `grep IStructureFormatter tree_sitter_analyzer/ docs/` → zero remaining
- [x] `ruff check` on touched files → clean
- [x] import smoke: `from tree_sitter_analyzer.formatters import IFormatter, FormatterRegistry, JsonFormatter` OK
- [x] `pytest tests/unit/formatters/` → 2252 passed, 7 skipped
- [x] no tests reference `IStructureFormatter` (only an auto-regenerated hypothesis constants cache)

Net: ~-10 LOC. First of the #1083 junk-removal cuts.