### PR TITLE
fix(complexity): Java was silently ignoring switch / ternary / do-while

### DIFF
--- a/tests/golden_masters/compact/java_bigservice_compact.md
+++ b/tests/golden_masters/compact/java_bigservice_compact.md
@@ -29,11 +29,11 @@
 | cleanupCache | ():void | - | 313-326 | 3 | - |
 | updateCacheStatistics | ():void | - | 331-335 | 1 | - |
 | calculateCacheHitRatio | ():d | - | 340-343 | 1 | - |
-| performBackup | (S):void | + | 348-367 | 1 | - |
+| performBackup | (S):void | + | 348-367 | 2 | - |
 | performFullBackup | ():void | - | 372-395 | 6 | - |
 | performIncrementalBackup | ():void | - | 400-414 | 4 | - |
 | performDifferentialBackup | ():void | - | 419-433 | 4 | - |
-| generateReport | (S,M<S, O>):void | + | 438-471 | 2 | - |
+| generateReport | (S,M<S, O>):void | + | 438-471 | 3 | - |
 | prepareReportData | (S,M<S, O>):void | - | 476-490 | 4 | - |
 | generateSalesReport | (M<S, O>):void | - | 495-513 | 6 | - |
 | generatePerformanceReport | (M<S, O>):void | - | 518-534 | 5 | - |
@@ -44,7 +44,7 @@
 | getCustomerInfo | (S):M<S, O> | + | 622-652 | 6 | - |
 | deleteCustomer | (S):b | + | 657-691 | 10 | - |
 | processOrder | (S,L<S>,d):S | + | 696-736 | 12 | - |
-| manageInventory | (S,S,i):void | + | 741-773 | 5 | - |
+| manageInventory | (S,S,i):void | + | 741-773 | 6 | - |
 | addInventory | (S,i):void | - | 778-792 | 4 | - |
 | removeInventory | (S,i):void | - | 797-811 | 4 | - |
 | updateInventory | (S,i):void | - | 816-830 | 4 | - |

--- a/tests/golden_masters/csv/java_bigservice_csv.csv
+++ b/tests/golden_masters/csv/java_bigservice_csv.csv
@@ -27,11 +27,11 @@ Method,manageCache,"(key:String, value:Object):void",public,295-308,2,-
 Method,cleanupCache,():void,private,313-326,3,-
 Method,updateCacheStatistics,():void,private,331-335,1,-
 Method,calculateCacheHitRatio,():double,private,340-343,1,-
-Method,performBackup,(backupType:String):void,public,348-367,1,-
+Method,performBackup,(backupType:String):void,public,348-367,2,-
 Method,performFullBackup,():void,private,372-395,6,-
 Method,performIncrementalBackup,():void,private,400-414,4,-
 Method,performDifferentialBackup,():void,private,419-433,4,-
-Method,generateReport,"(reportType:String, parameters:Map<String, Object>):void",public,438-471,2,-
+Method,generateReport,"(reportType:String, parameters:Map<String, Object>):void",public,438-471,3,-
 Method,prepareReportData,"(reportType:String, parameters:Map<String, Object>):void",private,476-490,4,-
 Method,generateSalesReport,"(parameters:Map<String, Object>):void",private,495-513,6,-
 Method,generatePerformanceReport,"(parameters:Map<String, Object>):void",private,518-534,5,-
@@ -42,7 +42,7 @@ Method,updateCustomerName,"(customerId:String, newName:String):void",public,601-
 Method,getCustomerInfo,"(customerId:String):Map<String, Object>",public,622-652,6,-
 Method,deleteCustomer,(customerId:String):boolean,public,657-691,10,-
 Method,processOrder,"(customerId:String, items:List<String>, totalAmount:double):String",public,696-736,12,-
-Method,manageInventory,"(action:String, itemId:String, quantity:int):void",public,741-773,5,-
+Method,manageInventory,"(action:String, itemId:String, quantity:int):void",public,741-773,6,-
 Method,addInventory,"(itemId:String, quantity:int):void",private,778-792,4,-
 Method,removeInventory,"(itemId:String, quantity:int):void",private,797-811,4,-
 Method,updateInventory,"(itemId:String, quantity:int):void",private,816-830,4,-

--- a/tests/golden_masters/full/java_bigservice_full.md
+++ b/tests/golden_masters/full/java_bigservice_full.md
@@ -52,13 +52,13 @@ import javax.sql.DataSource;
 | validateData | (data:Map<String, Object>):boolean | + | 204-246 | 11 | - |
 | logOperation | (operation:String, details:String):void | + | 280-290 | 2 | - |
 | manageCache | (key:String, value:Object):void | + | 295-308 | 2 | - |
-| performBackup | (backupType:String):void | + | 348-367 | 1 | - |
-| generateReport | (reportType:String, parameters:Map<String, Object>):void | + | 438-471 | 2 | - |
+| performBackup | (backupType:String):void | + | 348-367 | 2 | - |
+| generateReport | (reportType:String, parameters:Map<String, Object>):void | + | 438-471 | 3 | - |
 | updateCustomerName | (customerId:String, newName:String):void | + | 601-617 | 6 | - |
 | getCustomerInfo | (customerId:String):Map<String, Object> | + | 622-652 | 6 | - |
 | deleteCustomer | (customerId:String):boolean | + | 657-691 | 10 | - |
 | processOrder | (customerId:String, items:List<String>, totalAmount:double):String | + | 696-736 | 12 | - |
-| manageInventory | (action:String, itemId:String, quantity:int):void | + | 741-773 | 5 | - |
+| manageInventory | (action:String, itemId:String, quantity:int):void | + | 741-773 | 6 | - |
 | sendNotification | (recipient:String, message:String, type:String):void | + | 855-884 | 9 | - |
 | shutdownSystem | ():void | + | 889-912 | 6 | - |
 | handleError | (error:Exception, context:String):void | + | 958-977 | 4 | - |

--- a/tests/unit/languages/test_cyclomatic_complexity.py
+++ b/tests/unit/languages/test_cyclomatic_complexity.py
@@ -1259,3 +1259,86 @@ class TestLogicalOperatorNonExecutableContexts:
         )
         assert funcs[0].name == "f"
         assert funcs[0].complexity_score == 3
+
+
+# ---------------------------------------------------------------------------
+# Java decision-node coverage (tree-sitter-java node-name parity)
+# ---------------------------------------------------------------------------
+# tree-sitter-java emits "switch_expression" (NOT "switch_statement"),
+# "ternary_expression" (NOT "conditional_expression"), and has a separate
+# "do_statement". The historical _JAVA_DECISION_NODES used the wrong names, so
+# Java silently ignored every switch, every ternary, and every do-while loop.
+# Each construct is pinned in isolation (per CLAUDE.md: a mixed fixture would
+# let one missed construct hide behind another's count).
+
+JAVA_SWITCH_ONLY = """\
+class S {
+    int pick(int x) {
+        switch (x) {
+            case 1: return 10;
+            case 2: return 20;
+            case 3: return 30;
+            default: return 0;
+        }
+    }
+}
+"""
+# switch counts once (construct-once convention) → complexity = 1 + 1 = 2.
+
+JAVA_TERNARY_ONLY = """\
+class S {
+    int sign(int x) {
+        return x > 0 ? 1 : -1;
+    }
+}
+"""
+# one ternary → complexity = 1 + 1 = 2.
+
+JAVA_DO_WHILE_ONLY = """\
+class S {
+    int drain(int x) {
+        do {
+            x--;
+        } while (x > 0);
+        return x;
+    }
+}
+"""
+# one do-while → complexity = 1 + 1 = 2.
+
+JAVA_ALL_THREE = """\
+class S {
+    int run(int x) {
+        do { x--; } while (x > 0);
+        switch (x) { case 1: return 1; case 2: return 2; }
+        return x > 0 ? 1 : -1;
+    }
+}
+"""
+# do-while(1) + switch(1) + ternary(1) = 3 → complexity = 1 + 3 = 4.
+
+
+class TestJavaDecisionNodeCoverage:
+    def test_switch_counts_once(self):
+        funcs = _java_functions(JAVA_SWITCH_ONLY)
+        assert len(funcs) == 1
+        assert funcs[0].name == "pick"
+        assert funcs[0].complexity_score == 2
+
+    def test_ternary_counts(self):
+        funcs = _java_functions(JAVA_TERNARY_ONLY)
+        assert len(funcs) == 1
+        assert funcs[0].name == "sign"
+        assert funcs[0].complexity_score == 2
+
+    def test_do_while_counts(self):
+        funcs = _java_functions(JAVA_DO_WHILE_ONLY)
+        assert len(funcs) == 1
+        assert funcs[0].name == "drain"
+        assert funcs[0].complexity_score == 2
+
+    def test_all_three_combined(self):
+        funcs = _java_functions(JAVA_ALL_THREE)
+        assert len(funcs) == 1
+        assert funcs[0].name == "run"
+        assert funcs[0].complexity_score == 4

--- a/tree_sitter_analyzer/languages/_java_ast_helpers.py
+++ b/tree_sitter_analyzer/languages/_java_ast_helpers.py
@@ -45,15 +45,21 @@ _FIELD_TYPE_NODES = frozenset(
     }
 )
 
+# tree-sitter-java node names (verified against the grammar): the switch is
+# "switch_expression" (covers statement and expression forms), the ternary is
+# "ternary_expression", and the do-while is "do_statement". Earlier this set
+# used "switch_statement"/"conditional_expression" — node types the grammar
+# never emits — so Java silently dropped every switch / ternary / do-while.
 _JAVA_DECISION_NODES = frozenset(
     {
         "if_statement",
         "while_statement",
         "for_statement",
-        "switch_statement",
-        "catch_clause",
-        "conditional_expression",
         "enhanced_for_statement",
+        "do_statement",
+        "switch_expression",
+        "catch_clause",
+        "ternary_expression",
     }
 )
 


### PR DESCRIPTION
## Problem

A cross-language cyclomatic-complexity parity audit (same logical function run through every language) found Java under-counting by 3 vs the C# reference:

| Lang | Cx | |
|---|---|---|
| C# | 10 | ✓ reference |
| **Java** | **7** | missing switch + ternary + do-while |

`_JAVA_DECISION_NODES` listed two node types **tree-sitter-java never emits**:
- `switch_statement` — the grammar produces **`switch_expression`**
- `conditional_expression` — the grammar produces **`ternary_expression`**

…and omitted **`do_statement`** entirely. The dead names silently never matched, so Java cyclomatic complexity dropped **every switch, every ternary, and every do-while loop** — under-counting the flagship language and corrupting the complexity heatmap / `project_health` grade / hotspot ranking.

## Fix

Use the real node names (`switch_expression`, `ternary_expression`, `do_statement`), verified against the grammar. Switch counts **once** per the cross-language construct-once convention (matching Go/Rust/Swift/C#).

## Tests (RED-first)

Each construct pinned **in isolation** (switch-only / ternary-only / do-while-only fixtures with exact Cx) so a future miss can't hide behind another construct's count — plus a combined fixture. Re-pinned `java_bigservice` full/compact/csv goldens: three switch-bearing methods rose by 1 (performBackup 1→2, generateReport 2→3, manageInventory 5→6). TOON golden unaffected (complexity normalized out). Local suite green (4239 passed).

@codex review