### PR TITLE
fix(complexity): count Java switch / ternary / do-while (stale node names)

### DIFF
--- a/tests/golden_masters/compact/java_bigservice_compact.md
+++ b/tests/golden_masters/compact/java_bigservice_compact.md
@@ -29,11 +29,11 @@
 | cleanupCache | ():void | - | 313-326 | 3 | - |
 | updateCacheStatistics | ():void | - | 331-335 | 1 | - |
 | calculateCacheHitRatio | ():d | - | 340-343 | 1 | - |
-| performBackup | (S):void | + | 348-367 | 1 | - |
+| performBackup | (S):void | + | 348-367 | 2 | - |
 | performFullBackup | ():void | - | 372-395 | 6 | - |
 | performIncrementalBackup | ():void | - | 400-414 | 4 | - |
 | performDifferentialBackup | ():void | - | 419-433 | 4 | - |
-| generateReport | (S,M<S, O>):void | + | 438-471 | 2 | - |
+| generateReport | (S,M<S, O>):void | + | 438-471 | 3 | - |
 | prepareReportData | (S,M<S, O>):void | - | 476-490 | 4 | - |
 | generateSalesReport | (M<S, O>):void | - | 495-513 | 6 | - |
 | generatePerformanceReport | (M<S, O>):void | - | 518-534 | 5 | - |
@@ -44,7 +44,7 @@
 | getCustomerInfo | (S):M<S, O> | + | 622-652 | 6 | - |
 | deleteCustomer | (S):b | + | 657-691 | 10 | - |
 | processOrder | (S,L<S>,d):S | + | 696-736 | 12 | - |
-| manageInventory | (S,S,i):void | + | 741-773 | 5 | - |
+| manageInventory | (S,S,i):void | + | 741-773 | 6 | - |
 | addInventory | (S,i):void | - | 778-792 | 4 | - |
 | removeInventory | (S,i):void | - | 797-811 | 4 | - |
 | updateInventory | (S,i):void | - | 816-830 | 4 | - |

--- a/tests/golden_masters/csv/java_bigservice_csv.csv
+++ b/tests/golden_masters/csv/java_bigservice_csv.csv
@@ -27,11 +27,11 @@ Method,manageCache,"(key:String, value:Object):void",public,295-308,2,-
 Method,cleanupCache,():void,private,313-326,3,-
 Method,updateCacheStatistics,():void,private,331-335,1,-
 Method,calculateCacheHitRatio,():double,private,340-343,1,-
-Method,performBackup,(backupType:String):void,public,348-367,1,-
+Method,performBackup,(backupType:String):void,public,348-367,2,-
 Method,performFullBackup,():void,private,372-395,6,-
 Method,performIncrementalBackup,():void,private,400-414,4,-
 Method,performDifferentialBackup,():void,private,419-433,4,-
-Method,generateReport,"(reportType:String, parameters:Map<String, Object>):void",public,438-471,2,-
+Method,generateReport,"(reportType:String, parameters:Map<String, Object>):void",public,438-471,3,-
 Method,prepareReportData,"(reportType:String, parameters:Map<String, Object>):void",private,476-490,4,-
 Method,generateSalesReport,"(parameters:Map<String, Object>):void",private,495-513,6,-
 Method,generatePerformanceReport,"(parameters:Map<String, Object>):void",private,518-534,5,-
@@ -42,7 +42,7 @@ Method,updateCustomerName,"(customerId:String, newName:String):void",public,601-
 Method,getCustomerInfo,"(customerId:String):Map<String, Object>",public,622-652,6,-
 Method,deleteCustomer,(customerId:String):boolean,public,657-691,10,-
 Method,processOrder,"(customerId:String, items:List<String>, totalAmount:double):String",public,696-736,12,-
-Method,manageInventory,"(action:String, itemId:String, quantity:int):void",public,741-773,5,-
+Method,manageInventory,"(action:String, itemId:String, quantity:int):void",public,741-773,6,-
 Method,addInventory,"(itemId:String, quantity:int):void",private,778-792,4,-
 Method,removeInventory,"(itemId:String, quantity:int):void",private,797-811,4,-
 Method,updateInventory,"(itemId:String, quantity:int):void",private,816-830,4,-

--- a/tests/golden_masters/full/java_bigservice_full.md
+++ b/tests/golden_masters/full/java_bigservice_full.md
@@ -52,13 +52,13 @@ import javax.sql.DataSource;
 | validateData | (data:Map<String, Object>):boolean | + | 204-246 | 11 | - |
 | logOperation | (operation:String, details:String):void | + | 280-290 | 2 | - |
 | manageCache | (key:String, value:Object):void | + | 295-308 | 2 | - |
-| performBackup | (backupType:String):void | + | 348-367 | 1 | - |
-| generateReport | (reportType:String, parameters:Map<String, Object>):void | + | 438-471 | 2 | - |
+| performBackup | (backupType:String):void | + | 348-367 | 2 | - |
+| generateReport | (reportType:String, parameters:Map<String, Object>):void | + | 438-471 | 3 | - |
 | updateCustomerName | (customerId:String, newName:String):void | + | 601-617 | 6 | - |
 | getCustomerInfo | (customerId:String):Map<String, Object> | + | 622-652 | 6 | - |
 | deleteCustomer | (customerId:String):boolean | + | 657-691 | 10 | - |
 | processOrder | (customerId:String, items:List<String>, totalAmount:double):String | + | 696-736 | 12 | - |
-| manageInventory | (action:String, itemId:String, quantity:int):void | + | 741-773 | 5 | - |
+| manageInventory | (action:String, itemId:String, quantity:int):void | + | 741-773 | 6 | - |
 | sendNotification | (recipient:String, message:String, type:String):void | + | 855-884 | 9 | - |
 | shutdownSystem | ():void | + | 889-912 | 6 | - |
 | handleError | (error:Exception, context:String):void | + | 958-977 | 4 | - |

--- a/tests/unit/languages/test_cyclomatic_complexity.py
+++ b/tests/unit/languages/test_cyclomatic_complexity.py
@@ -950,6 +950,76 @@ class TestJavaCyclomaticComplexity:
         assert funcs[0].name == "process"
         assert funcs[0].complexity_score == 8
 
+    def test_switch_counted_once(self):
+        """switch (one switch_expression node) = 1 decision → complexity 2.
+
+        tree-sitter-java emits "switch_expression" (not "switch_statement"),
+        so before the node-name fix this measured 1. The construct counts once,
+        not per case (matching the Go/Rust/Swift convention).
+        """
+        funcs = _java_functions(JAVA_SWITCH)
+        assert len(funcs) == 1
+        assert funcs[0].name == "classify"
+        assert funcs[0].complexity_score == 2
+
+    def test_ternary_counted(self):
+        """ternary ?: (one ternary_expression node) = 1 decision → complexity 2.
+
+        tree-sitter-java emits "ternary_expression" (not "conditional_expression"),
+        so before the node-name fix this measured 1.
+        """
+        funcs = _java_functions(JAVA_TERNARY)
+        assert len(funcs) == 1
+        assert funcs[0].name == "sign"
+        assert funcs[0].complexity_score == 2
+
+    def test_do_while_counted(self):
+        """do-while (one do_statement node) = 1 decision → complexity 2.
+
+        do_statement was entirely absent from the Java decision set, so before
+        the fix this measured 1.
+        """
+        funcs = _java_functions(JAVA_DO_WHILE)
+        assert len(funcs) == 1
+        assert funcs[0].name == "countdown"
+        assert funcs[0].complexity_score == 2
+
+
+JAVA_SWITCH = """\
+class Sample {
+    int classify(int x) {
+        switch (x) {
+            case 1: return 1;
+            case 2: return 2;
+            default: return 0;
+        }
+    }
+}
+"""
+# One switch (switch_expression) counted once → complexity = 1 + 1 = 2.
+
+JAVA_TERNARY = """\
+class Sample {
+    int sign(int x) {
+        int r = x > 0 ? 1 : -1;
+        return r;
+    }
+}
+"""
+# One ternary (ternary_expression) → complexity = 1 + 1 = 2.
+
+JAVA_DO_WHILE = """\
+class Sample {
+    int countdown(int x) {
+        do {
+            x--;
+        } while (x > 0);
+        return x;
+    }
+}
+"""
+# One do-while (do_statement) → complexity = 1 + 1 = 2.
+
 
 # ---------------------------------------------------------------------------
 # C

--- a/tree_sitter_analyzer/languages/_java_ast_helpers.py
+++ b/tree_sitter_analyzer/languages/_java_ast_helpers.py
@@ -50,9 +50,14 @@ _JAVA_DECISION_NODES = frozenset(
         "if_statement",
         "while_statement",
         "for_statement",
-        "switch_statement",
+        "do_statement",
+        # tree-sitter-java emits "switch_expression" for both switch statements
+        # and switch expressions, and "ternary_expression" for the ?: operator —
+        # NOT "switch_statement" / "conditional_expression". The stale names
+        # never matched, so switch / ternary / do-while were silently uncounted.
+        "switch_expression",
+        "ternary_expression",
         "catch_clause",
-        "conditional_expression",
         "enhanced_for_statement",
     }
 )


### PR DESCRIPTION
Follow-up to #1085, found by the **cross-language complexity decision-node audit**.

## Bug
`tree-sitter-java` emits `switch_expression` (for both switch statements *and* switch expressions) and `ternary_expression` for `?:`, but `_JAVA_DECISION_NODES` listed `switch_statement` / `conditional_expression` — names the grammar **never produces**. So every `switch` and ternary was silently uncounted in cyclomatic complexity. `do_statement` (do-while) was also entirely absent from the set. Java therefore under-counted complexity, corrupting the heatmap / `project_health` grading / hotspot ranking for switch/ternary/do-while-heavy code.

The audit confirmed **Java was the only plugin with stale decision-node names** — C/C++/C#/Go/Kotlin/TS all match their grammars.

## Fix
`switch_statement` → `switch_expression`, `conditional_expression` → `ternary_expression`, and add `do_statement`. Each construct counts **once** (matching the Go/Rust/Swift convention — a 3-case switch is +1, not +3; verified by test).

| construct | pre-fix Cx | post-fix Cx |
|---|---|---|
| one `switch` | 1 | 2 |
| one `?:` ternary | 1 | 2 |
| one `do`-while | 1 | 2 |

`if` / `while` / `for` / `enhanced-for` / `catch` / `&&` / `||` (the #1085 work) are unchanged; `binary_search` control stays 4.

## Tests
RED-first `test_switch_counted_once` / `test_ternary_counted` / `test_do_while_counted` (each measured 1 pre-fix, exact-pinned to 2). Re-pinned the `java_bigservice` goldens (full+compact+csv): `performBackup` 1→2, `generateReport` 2→3, `manageInventory` 5→6 — each +1 from its switch. `Sample.java` / `java_userservice` have no switch/ternary/do-while and are unchanged. Full suite green (the only locally-flaky tests were 3 e2e latency/stderr budgets under CPU contention; they pass clean in isolation and on dedicated CI runners).