### PR TITLE
fix(complexity): C/C++ switch counts once, not per case

### DIFF
--- a/tests/unit/languages/test_c_plugin_coverage_boost.py
+++ b/tests/unit/languages/test_c_plugin_coverage_boost.py
@@ -473,4 +473,5 @@ def test_extract_function_with_switch(plugin):
     elements = plugin.extract_elements(tree, code)
     funcs = elements["functions"]
     assert len(funcs) == 1
-    assert funcs[0].complexity_score == 5
+    # A switch counts once (construct-once convention); cases are not summed.
+    assert funcs[0].complexity_score == 2

--- a/tests/unit/languages/test_cpp_plugin_coverage_boost_advanced.py
+++ b/tests/unit/languages/test_cpp_plugin_coverage_boost_advanced.py
@@ -164,7 +164,8 @@ def test_switch_complexity(extractor):
     funcs = extractor.extract_functions(tree, code)
     grade_funcs = [f for f in funcs if f.name == "grade"]
     assert len(grade_funcs) == 1
-    assert grade_funcs[0].complexity_score == 5
+    # A switch counts once (construct-once convention); cases are not summed.
+    assert grade_funcs[0].complexity_score == 2
 
 
 # --- Catch clause complexity ---

--- a/tests/unit/languages/test_cyclomatic_complexity.py
+++ b/tests/unit/languages/test_cyclomatic_complexity.py
@@ -1004,12 +1004,11 @@ int process(int x) {
 #   if_statement          : 2   (if + else-if)
 #   for_statement         : 1
 #   while_statement       : 1
-#   switch_statement      : 1
-#   case_statement        : 1
+#   switch_statement      : 1   (switch counts ONCE — case_statement excluded)
 #   conditional_expression: 1   (ternary)
-#   &&                    : 1   (NEW: short-circuit operator)
-#   ||                    : 1   (NEW: short-circuit operator)
-# Total = 9 → complexity = 1 + 9 = 10 (pre-fix this measured 8).
+#   &&                    : 1   (short-circuit operator)
+#   ||                    : 1   (short-circuit operator)
+# Total = 8 → complexity = 1 + 8 = 9.
 
 
 def _c_functions(source: str):
@@ -1038,11 +1037,28 @@ class TestCCyclomaticComplexity:
         assert funcs[0].complexity_score == 4
 
     def test_rich_branching(self):
-        """9 decision points (incl. && and ||) → complexity 10."""
+        """8 decision points (switch counts once, incl. && and ||) → complexity 9."""
         funcs = _c_functions(C_RICH)
         assert len(funcs) == 1
         assert funcs[0].name == "process"
-        assert funcs[0].complexity_score == 10
+        assert funcs[0].complexity_score == 9
+
+    def test_switch_counts_once_not_per_case(self):
+        """A switch with many cases adds exactly one decision point."""
+        src = (
+            "int classify(int x) {\n"
+            "    switch (x) {\n"
+            "        case 1: return 10;\n"
+            "        case 2: return 20;\n"
+            "        case 3: return 30;\n"
+            "        default: return 0;\n"
+            "    }\n"
+            "}\n"
+        )
+        funcs = _c_functions(src)
+        assert len(funcs) == 1
+        assert funcs[0].name == "classify"
+        assert funcs[0].complexity_score == 2
 
 
 # ---------------------------------------------------------------------------
@@ -1078,11 +1094,28 @@ class TestCppCyclomaticComplexity:
         assert funcs[0].complexity_score == 4
 
     def test_rich_branching(self):
-        """9 decision points (incl. && and ||) → complexity 10."""
+        """8 decision points (switch counts once, incl. && and ||) → complexity 9."""
         funcs = _cpp_functions(C_RICH)
         assert len(funcs) == 1
         assert funcs[0].name == "process"
-        assert funcs[0].complexity_score == 10
+        assert funcs[0].complexity_score == 9
+
+    def test_switch_counts_once_not_per_case(self):
+        """A switch with many cases adds exactly one decision point."""
+        src = (
+            "int classify(int x) {\n"
+            "    switch (x) {\n"
+            "        case 1: return 10;\n"
+            "        case 2: return 20;\n"
+            "        case 3: return 30;\n"
+            "        default: return 0;\n"
+            "    }\n"
+            "}\n"
+        )
+        funcs = _cpp_functions(src)
+        assert len(funcs) == 1
+        assert funcs[0].name == "classify"
+        assert funcs[0].complexity_score == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tree_sitter_analyzer/languages/_cpp_complexity_helpers.py
+++ b/tree_sitter_analyzer/languages/_cpp_complexity_helpers.py
@@ -4,6 +4,10 @@ from typing import Any
 
 from ._complexity_logical import is_executable_logical_operator
 
+# A switch counts ONCE (the "switch_statement" node), per the cross-language
+# construct-once convention shared by Go/Rust/Swift/Java/C#. "case_statement"
+# is deliberately excluded — counting each case (and the default) on top of the
+# switch over-counted C/C++ relative to every other language.
 _DECISION_NODES = frozenset(
     {
         "if_statement",
@@ -11,7 +15,6 @@ _DECISION_NODES = frozenset(
         "for_statement",
         "for_range_loop",
         "switch_statement",
-        "case_statement",
         "conditional_expression",
         "catch_clause",
         "do_statement",

--- a/tree_sitter_analyzer/languages/c_helpers.py
+++ b/tree_sitter_analyzer/languages/c_helpers.py
@@ -128,12 +128,15 @@ def extract_macro_function(
 
 def calculate_complexity(node: Any) -> int:
     """Calculate cyclomatic complexity."""
+    # A switch counts ONCE (the "switch_statement" node), per the cross-language
+    # construct-once convention. "case_statement" is excluded — counting each
+    # case (and default) on top of the switch over-counted C relative to every
+    # other language.
     decision_nodes = {
         "if_statement",
         "while_statement",
         "for_statement",
         "switch_statement",
-        "case_statement",
         "conditional_expression",
         "do_statement",
     }


### PR DESCRIPTION
## Problem

The C and C++ cyclomatic-complexity walkers counted both `switch_statement` **and** every `case_statement` (plus `default`), so a switch with N cases added N+1 decision points. Every other language (Go/Rust/Swift/Java/C#) follows the **construct-once** convention where a switch/match adds exactly one.

A cross-language parity audit (same logical function run through every language) measured the divergence:

| Lang | Cx | |
|---|---|---|
| C# | 10 | ✓ reference (counts switch once) |
| **C / C++** | **13** | over-counted by the extra case labels |

A 4-case switch in an otherwise empty C function reported Cx 6 instead of 2 — corrupting the cross-language complexity heatmap / hotspot ranking that this metric exists to power.

## Fix

Drop `case_statement` from the C and C++ decision-node sets. The switch is already counted once via `switch_statement`. Brings C/C++ to 10, matching C#/Java.

This is the third and final fix completing C-family ↔ rest-of-language complexity parity, after #1085 (`&&`/`||`) and #1087 (Java switch/ternary/do-while node names).

## Tests (RED-first)

`test_switch_counts_once_not_per_case` pins a 4-case switch at Cx 2 in both C and C++; the rich-branching fixtures drop 10 → 9 (one fewer case counted). **No golden masters change** — no example file contains a switch.

@codex review