### PR TITLE
refactor(formatters): remove dead IStructureFormatter abstraction (zero implementers)

### DIFF
--- a/docs/CODEMAPS/formatters.md
+++ b/docs/CODEMAPS/formatters.md
@@ -37,9 +37,8 @@ Interfaces live in `formatters/_formatter_interface.py` (no upward imports — b
 | Interface | Implementors | Purpose |
 |---|---|---|
 | `IFormatter` | `HtmlFormatter`, `JsonFormatter`, `CsvFormatter`, … | `format(elements)` → str |
-| `IStructureFormatter` | legacy adapters | `format_structure(dict)` → str |
 
-`formatters/formatter_registry.py` re-exports both for backward compat.
+`formatters/formatter_registry.py` re-exports `IFormatter` for backward compat.
 `formatters/html_formatter.py` imports directly from `formatters/_formatter_interface.py` to avoid the
 `formatter_registry ↔ html_formatter` import cycle (fixed 2026-05-30).
 

--- a/tree_sitter_analyzer/formatters/__init__.py
+++ b/tree_sitter_analyzer/formatters/__init__.py
@@ -32,7 +32,6 @@ from .formatter_registry import (
     FormatterRegistry,
     FullFormatter,
     IFormatter,
-    IStructureFormatter,
     JsonFormatter,
 )
 from .table_formatter import TableFormatter
@@ -41,7 +40,6 @@ __all__ = [
     # Primary API
     "FormatterRegistry",
     "IFormatter",
-    "IStructureFormatter",
     # Built-in formatters
     "JsonFormatter",
     "CsvFormatter",

--- a/tree_sitter_analyzer/formatters/_formatter_interface.py
+++ b/tree_sitter_analyzer/formatters/_formatter_interface.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any
 
 from ..models import CodeElement
 
@@ -19,11 +18,3 @@ class IFormatter(ABC):
     @abstractmethod
     def format(self, elements: list[CodeElement]) -> str:
         """Format a list of CodeElements into a string representation."""
-
-
-class IStructureFormatter(ABC):
-    """Interface for structure-based formatters (legacy compatibility)."""
-
-    @abstractmethod
-    def format_structure(self, structure_data: dict[str, Any]) -> str:
-        """Format structure data dictionary into a string representation."""

--- a/tree_sitter_analyzer/formatters/formatter_registry.py
+++ b/tree_sitter_analyzer/formatters/formatter_registry.py
@@ -12,7 +12,7 @@ import logging
 from typing import Any
 
 from ..models import CodeElement
-from ._formatter_interface import IFormatter, IStructureFormatter  # noqa: F401
+from ._formatter_interface import IFormatter
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## What
Removes the dead `IStructureFormatter` ABC — **zero implementers repo-wide**.

(Re-opens the change from closed #1086, which had its branch cross-contaminated by a concurrent branch-name collision in a shared worktree. This PR is built cleanly in an isolated worktree off current `develop`.)

## Why
Ponytail audit #1083 finding #1 (dead abstraction). `IStructureFormatter` had one abstract method `format_structure` and **no subclasses** (verified: `grep -rn '(IStructureFormatter)' --include='*.py' .` → 0). It was imported `# noqa: F401` (explicitly known-unused) in `formatter_registry.py`, re-exported in `formatters/__init__.py`, and documented as 'legacy adapters' in the codemap. The live `format_structure` lives on `BaseFormatter`; nothing routes through this interface.

## Changes (pure dead-weight removal, no behavior change)
- delete the `IStructureFormatter` class + its now-unused `from typing import Any` import
- drop the registry re-export (and its now-unneeded `noqa`; `IFormatter` stays — it's used)
- drop the `__init__` import + `__all__` entry
- drop the codemap row; fix 're-exports both' → 'IFormatter'

## Test plan
- [x] `grep IStructureFormatter tree_sitter_analyzer/ docs/` → zero remaining
- [x] `ruff check` on touched files → clean
- [x] import smoke: `from tree_sitter_analyzer.formatters import IFormatter, FormatterRegistry, JsonFormatter` OK
- [x] formatters unit suite → 2252 passed, 7 skipped (verified pre-isolation)
- [x] no test references `IStructureFormatter` (only an auto-regenerated hypothesis constants cache)

Net: ~-10 LOC. First of the #1083 junk cuts (paired with #1088 for finding #2).
