### PR TITLE
fix(formatters): render module-level functions in TS/JS full table

### DIFF
--- a/docs/CODEMAPS/formatters.md
+++ b/docs/CODEMAPS/formatters.md
@@ -92,6 +92,13 @@ TypeScript formatter signatures module:
   containers; overloads each appear as separate lines; used by
   `TypeScriptTableFormatter._format_signatures_table` via `structure action=signatures`)
 
+TS/JS full-table module-level functions:
+- `formatters/_typescript_formatter_full.py` and
+  `formatters/_javascript_formatter_full_mixin.py` render top-level (non-class)
+  functions in a `## Global Functions` section (same `Cx` column as class
+  methods). JS reads both `methods` (class methods) and `functions` (top-level)
+  since the JS plugin stores them in disjoint lists.
+
 ## CSV Control-Char Safety
 
 `formatters/_csv_safety.py` (`csv_safe_row` / `csv_safe_cell`) strips

--- a/tests/unit/formatters/test_javascript_formatter_coverage.py
+++ b/tests/unit/formatters/test_javascript_formatter_coverage.py
@@ -100,3 +100,89 @@ class TestFormatAdvanced:
     def test_format_advanced_non_json_non_csv(self, fmt, sample_data):
         result = fmt.format_advanced(sample_data, "markdown")
         assert isinstance(result, str)
+
+
+class TestJavaScriptModuleLevelFunctions:
+    """Module-level (non-class) functions must render in the full table.
+
+    Regression: the full table previously rendered only classes and their
+    methods, silently dropping every top-level function.
+    """
+
+    def test_flat_module_functions_render(self, fmt):
+        data = {
+            "file_path": "/x/util.js",
+            "classes": [],
+            "methods": [
+                {
+                    "name": "alpha",
+                    "line_range": {"start": 1, "end": 1},
+                    "parameters": ["a"],
+                    "return_type": "number",
+                    "complexity_score": 1,
+                },
+                {
+                    "name": "beta",
+                    "line_range": {"start": 2, "end": 4},
+                    "parameters": ["b"],
+                    "return_type": "number",
+                    "complexity_score": 2,
+                },
+            ],
+        }
+        result = fmt._format_full_table(data)
+        assert "## Global Functions" in result
+        assert "| alpha |" in result
+        assert "| beta |" in result
+
+    def test_top_level_function_alongside_class(self, fmt):
+        data = {
+            "file_path": "/x/mixed.js",
+            "classes": [
+                {"name": "C", "line_range": {"start": 5, "end": 7}},
+            ],
+            "methods": [
+                {
+                    "name": "topLevel",
+                    "line_range": {"start": 1, "end": 3},
+                    "parameters": ["x"],
+                    "return_type": "number",
+                    "complexity_score": 2,
+                },
+                {
+                    "name": "method",
+                    "line_range": {"start": 6, "end": 6},
+                    "parameters": ["y"],
+                    "return_type": "number",
+                    "complexity_score": 1,
+                },
+            ],
+        }
+        result = fmt._format_full_table(data)
+        # The class method stays under its class; the top-level function does not.
+        assert "## Global Functions" in result
+        assert "| topLevel |" in result
+        global_section = result.split("## Global Functions", 1)[1]
+        assert "topLevel" in global_section
+        assert "| method |" not in global_section
+
+    def test_plugin_shaped_functions_key_render(self, fmt):
+        """Top-level functions arrive under 'functions' (JS plugin shape),
+        not 'methods'; they must still render. (Codex P2 on #1092)"""
+        data = {
+            "file_path": "/x/util.js",
+            "classes": [],
+            "methods": [],
+            "functions": [
+                {
+                    "name": "gamma",
+                    "line_range": {"start": 1, "end": 2},
+                    "parameters": ["g"],
+                    "return_type": "number",
+                    "complexity_score": 1,
+                }
+            ],
+        }
+        result = fmt._format_full_table(data)
+        assert "## Global Functions" in result
+        assert "| gamma |" in result

--- a/tests/unit/formatters/test_typescript_formatter_core.py
+++ b/tests/unit/formatters/test_typescript_formatter_core.py
@@ -168,10 +168,13 @@ class TestTypeScriptTableFormatter:
         result = formatter.format(sample_data)
 
         assert isinstance(result, str)
-        assert len(result.replace("\r\n", "\n")) == 879  # normalize CRLF for Windows
+        assert len(result.replace("\r\n", "\n")) == 1159  # normalize CRLF for Windows
 
         assert "UserService" in result
         assert "class" in result or "interface" in result
+        # Module-level functions render in their own section (previously dropped).
+        assert "## Global Functions" in result
+        assert "mapArray" in result
 
     def test_format_full_table_tsx_file(self, formatter):
         """Test full table formatting for TSX files"""

--- a/tree_sitter_analyzer/formatters/_javascript_formatter_full_mixin.py
+++ b/tree_sitter_analyzer/formatters/_javascript_formatter_full_mixin.py
@@ -18,6 +18,10 @@ class JavaScriptTableFormatterFullMixin:
         lines: list[str] = []
         classes = _list_or_empty(data.get("classes", []))
         methods = _list_or_empty(data.get("methods", []))
+        # The JS plugin stores class methods under "methods" and top-level
+        # functions under "functions" (disjoint lists), so both must be
+        # considered when collecting module-level functions.
+        callables = methods + _list_or_empty(data.get("functions", []))
 
         lines.append(f"# {_title(data, classes)}")
         lines.append("")
@@ -26,6 +30,15 @@ class JavaScriptTableFormatterFullMixin:
             _append_classes_overview(lines, classes, methods)
             for class_info in classes:
                 lines.extend(self._format_class_section(class_info, data))
+
+        _append_method_section(
+            lines,
+            "## Global Functions",
+            "| Function | Signature | Vis | Lines | Cx | Doc |",
+            "|----------|-----------|-----|-------|----|----|",
+            _module_level_functions(callables, classes),
+            self._format_method_table_row,
+        )
 
         _trim_trailing_blank_lines(lines)
         return "\n".join(lines)
@@ -138,6 +151,23 @@ def _items_in_range(
         item
         for item in items
         if start <= item.get("line_range", {}).get("start", 0) <= end
+    ]
+
+
+def _module_level_functions(
+    methods: list[dict[str, Any]], classes: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Return methods that don't fall inside any class range."""
+    class_ranges = [c.get("line_range") or {} for c in classes if c is not None]
+    return [
+        method
+        for method in methods
+        if not any(
+            rng.get("start", 0)
+            <= (method.get("line_range") or {}).get("start", 0)
+            <= rng.get("end", 0)
+            for rng in class_ranges
+        )
     ]
 
 

--- a/tree_sitter_analyzer/formatters/_typescript_formatter_full.py
+++ b/tree_sitter_analyzer/formatters/_typescript_formatter_full.py
@@ -14,6 +14,7 @@ from ._typescript_formatter_helpers import (
     trim_trailing_blank_lines,
     typescript_title,
 )
+from ._typescript_formatter_signatures_table import _module_level_functions
 
 
 def format_typescript_full_table(formatter: Any, data: dict[str, Any]) -> str:
@@ -30,9 +31,27 @@ def format_typescript_full_table(formatter: Any, data: dict[str, Any]) -> str:
     _append_classes_overview(lines, classes, methods, fields)
     for class_info in classes:
         _append_class_section(formatter, lines, class_info, methods, fields)
+    _append_global_functions(
+        formatter, lines, _module_level_functions(methods, classes)
+    )
 
     trim_trailing_blank_lines(lines)
     return "\n".join(lines)
+
+
+def _append_global_functions(
+    formatter: Any, lines: list[str], functions: list[dict[str, Any]]
+) -> None:
+    """Render module-level (non-class) functions in their own section."""
+    if not functions:
+        return
+
+    lines.append("## Global Functions")
+    lines.append("| Function | Signature | Vis | Lines | Cx | Doc |")
+    lines.append("|----------|-----------|-----|-------|----|----|")
+    for function in functions:
+        lines.append(format_method_row(formatter, function))
+    lines.append("")
 
 
 def _append_classes_overview(


### PR DESCRIPTION
## Problem

The TypeScript and JavaScript **full-table** formatters rendered only classes and their methods. Every **top-level / module-level function** (one not inside any class) was silently dropped:

- A flat module of functions → the full table showed nothing but the `# filename` header.
- A mixed file → the classes rendered, the module functions vanished.

For a code-intelligence tool whose job is to show structure to agents, this hides a core part of every TS/JS module. Found by dogfooding `--table full` on a module-level TS function (extracted, `method_count=1`, but absent from the table).

## Fix

Add a `## Global Functions` section (same `Cx` column as class methods) listing functions outside every class range — mirroring the C/Go full table and the existing TS **signatures**-table behaviour (which already had `_module_level_functions`).

## Tests

- TS `test_format_full_table` now asserts the `## Global Functions` section and a previously-dropped function (`mapArray`); exact length re-pinned 879 → 1159.
- New JS tests cover the flat-module and class+top-level cases.
- **No golden masters change** — the regression fixtures (`test_enum.ts` / `test_class.js`) have no top-level functions, so this was invisible to the golden suite (exactly why it went unnoticed).

@codex review