### PR TITLE
feat(kotlin): show Cx (complexity) column in full table

### DIFF
--- a/tests/golden_masters/full/kotlin_sample_full.md
+++ b/tests/golden_masters/full/kotlin_sample_full.md
@@ -18,20 +18,20 @@ import java.util.Collections
 | LegacyUserManager | class | public | 57-60 | 0 | 1 |
 
 ## Functions
-| Function | Signature | Vis | Lines | Suspend | Doc |
-|----------|-----------|-----|-------|---------|-----|
-| User | fun(id: Long, username: String, email: String, active: Boolean) | pub | 8-13 | - | - |
-| display | fun(): String | pub | 16-16 | - | - |
-| summary | fun(): String | pub | 18-20 | - | - |
-| Success | fun(data: T) | pub | 24-24 | - | - |
-| Error | fun(message: String) | pub | 25-25 | - | - |
-| UserManager | fun(db: Any?) | pub | 28-28 | - | - |
-| getUser | fun(id: Long): User? | pub | 33-35 | - | - |
-| fetchUserAsync | fun(id: Long): Result<User> | pub | 37-40 | - | - |
-| display | fun(): String | pub | 42-44 | - | - |
-| toTitleCase | fun(): String | pub | 52-54 | - | - |
-| get | fun(): String | pub | 59-59 | - | - |
-| main | fun(args: Array<String>) | pub | 62-65 | - | - |
+| Function | Signature | Vis | Lines | Cx | Suspend | Doc |
+|----------|-----------|-----|-------|----|---------|-----|
+| User | fun(id: Long, username: String, email: String, active: Boolean) | pub | 8-13 | 1 | - | - |
+| display | fun(): String | pub | 16-16 | 1 | - | - |
+| summary | fun(): String | pub | 18-20 | 1 | - | - |
+| Success | fun(data: T) | pub | 24-24 | 1 | - | - |
+| Error | fun(message: String) | pub | 25-25 | 1 | - | - |
+| UserManager | fun(db: Any?) | pub | 28-28 | 1 | - | - |
+| getUser | fun(id: Long): User? | pub | 33-35 | 2 | - | - |
+| fetchUserAsync | fun(id: Long): Result<User> | pub | 37-40 | 1 | - | - |
+| display | fun(): String | pub | 42-44 | 1 | - | - |
+| toTitleCase | fun(): String | pub | 52-54 | 2 | - | - |
+| get | fun(): String | pub | 59-59 | 1 | - | - |
+| main | fun(args: Array<String>) | pub | 62-65 | 1 | - | - |
 
 ## Properties
 | Name | Type | Vis | Kind | Line | Doc |

--- a/tests/unit/formatters/test_kotlin_formatter.py
+++ b/tests/unit/formatters/test_kotlin_formatter.py
@@ -574,3 +574,33 @@ class TestKotlinFormatterEdgeCases:
         assert "longFunction" in result
         assert "param0" in result
         assert "param9" in result
+
+
+class TestKotlinFullTableComplexityColumn:
+    """The full table shows a Cx (cyclomatic complexity) column, matching the
+    other language formatters (Go/Java/JS/TS/Rust/C#/C++)."""
+
+    def test_full_table_has_cx_column_with_value(self):
+        formatter = KotlinTableFormatter()
+        data = {
+            "package": {"name": "demo"},
+            "file_path": "/x/Demo.kt",
+            "imports": [],
+            "classes": [],
+            "methods": [
+                {
+                    "name": "f",
+                    "visibility": "public",
+                    "line_range": {"start": 1, "end": 8},
+                    "parameters": [],
+                    "return_type": "Int",
+                    "complexity_score": 10,
+                }
+            ],
+            "fields": [],
+        }
+        result = formatter._format_full_table(data)
+        assert "| Function | Signature | Vis | Lines | Cx | Suspend | Doc |" in result
+        # The function row carries its complexity score in the Cx column.
+        f_row = next(line for line in result.splitlines() if line.startswith("| f |"))
+        assert "| 10 |" in f_row

--- a/tree_sitter_analyzer/formatters/kotlin_formatter.py
+++ b/tree_sitter_analyzer/formatters/kotlin_formatter.py
@@ -84,8 +84,8 @@ class KotlinTableFormatter(BaseTableFormatter):
         fns = data.get("methods", [])
         if fns:
             lines.append("## Functions")
-            lines.append("| Function | Signature | Vis | Lines | Suspend | Doc |")
-            lines.append("|----------|-----------|-----|-------|---------|-----|")
+            lines.append("| Function | Signature | Vis | Lines | Cx | Suspend | Doc |")
+            lines.append("|----------|-----------|-----|-------|----|---------|-----|")
 
             for fn in fns:
                 lines.append(self._format_fn_row(fn))
@@ -161,11 +161,15 @@ class KotlinTableFormatter(BaseTableFormatter):
         is_suspend = "Yes" if fn.get("is_suspend", False) else "-"
         line_range = fn.get("line_range", {})
         lines_str = f"{line_range.get('start', 0)}-{line_range.get('end', 0)}"
+        complexity = fn.get("complexity_score", 1)
         doc = self._clean_csv_text(
             self._extract_doc_summary(str(fn.get("docstring", "") or ""))
         )
 
-        return f"| {name} | {signature} | {visibility} | {lines_str} | {is_suspend} | {doc} |"
+        return (
+            f"| {name} | {signature} | {visibility} | {lines_str} | "
+            f"{complexity} | {is_suspend} | {doc} |"
+        )
 
     def _format_prop_row(self, prop: dict[str, Any]) -> str:
         """Format a property table row for Kotlin"""


### PR DESCRIPTION
## Problem

Kotlin already computes `complexity_score` (`calculate_kotlin_complexity`), but the full-table formatter never displayed it — the function table showed a `Suspend` column and no `Cx`. Kotlin was the **only** language whose full table omits the complexity metric (Go/Java/JS/TS/Rust/C#/C++/Python all show `Cx`).

Found by a cross-language complexity-display audit (the value was computed, e.g. `cx=10`, but invisible in `--table full`).

## Fix

Add a `Cx` column after `Lines` (keeping the Kotlin-specific `Suspend` column), mirroring the Rust full-table fix (#1082). Full table only — compact unchanged, matching #1082's scope.

## Tests

Re-pinned `kotlin_sample` full golden (Cx column added to existing rows; compact/csv/toon unchanged). New unit test asserts the header and a populated Cx value.

@codex review