### PR TITLE
chore: remove two verified-dead internal helpers (-25 LOC)

### DIFF
--- a/tree_sitter_analyzer/_health_score_cache.py
+++ b/tree_sitter_analyzer/_health_score_cache.py
@@ -28,7 +28,7 @@ import json
 import logging
 import os
 import sqlite3
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -225,17 +225,4 @@ class HealthScoreCache:
             "entries": int(row[0] or 0),
             "last_cached_at": row[1],
             "db_path": self._db_path,
-        }
-
-
-def score_to_dict(score: Any) -> dict[str, Any]:
-    """Best-effort serialize a HealthScore into the cache row schema."""
-    try:
-        return asdict(score)
-    except TypeError:
-        return {
-            "file_path": getattr(score, "file_path", ""),
-            "total": getattr(score, "total", 0.0),
-            "grade": getattr(score, "grade", "F"),
-            "dimensions": getattr(score, "dimensions", {}),
         }

--- a/tree_sitter_analyzer/cli/commands/mcp_command_helpers.py
+++ b/tree_sitter_analyzer/cli/commands/mcp_command_helpers.py
@@ -39,18 +39,6 @@ class McpCommandSpec:
     required_value_error: str | None = None
 
 
-def _spec_value(args: Any, spec: McpCommandSpec) -> Any:
-    """Return the user-facing value associated with the spec's flag.
-
-    For value-bearing flags (``value_arg_name`` set) we look up the
-    actual argparse attribute; for boolean flags we keep the legacy
-    ``flag_name`` lookup so the rest of the dispatcher is unchanged.
-    """
-    if spec.value_arg_name is not None:
-        return getattr(args, spec.value_arg_name, None)
-    return getattr(args, spec.flag_name, False)
-
-
 def find_selected_mcp_command(
     args: Any,
     command_specs: tuple[McpCommandSpec, ...],


### PR DESCRIPTION
## What
Removes two **internal-only** dead functions (−25 LOC). Scoped per owner decision: garbage-removal targets internal dead code with no public-API contract (unlike the closed #1088/#1091, which Codex correctly flagged as public-surface breaks).

## Removed
- `cli/commands/mcp_command_helpers.py::_spec_value` — underscore-private orphan helper. Its docstring says the dispatcher uses it ("so the rest of the dispatcher is unchanged"), but nothing calls it. Zero references repo-wide.
- `_health_score_cache.py::score_to_dict` — orphan serializer in a private (`_`-prefixed) module. The lone grep hit was the *substring* inside the test name `test_health_score_to_dict`, which actually exercises `HealthScore.to_dict()` (a method), not this module function. Also drops the now-unused `asdict` import.

## Verification
- [x] word-boundary grep `\b_spec_value\b` / `\bscore_to_dict\b` across `tree_sitter_analyzer/` + `tests/` → zero references after removal
- [x] neither is in any `__all__`, neither is a `@property`/dunder/decorator/registry-dispatched symbol
- [x] `ruff check` clean (confirms no orphaned imports; `asdict` removed, `dataclass` kept)
- [x] import smoke OK
- [x] `test_health_scorer.py`, `test_health_score_cache.py`, `tests/unit/cli/`, `test_mcp_commands.py` → all green (1457 passed)

Net: −25 LOC, behavior-preserving, no public surface touched.
