### PR TITLE
fix(complexity): JS/TS complexity is an AST walk, not keyword-substring text counting

### DIFF
--- a/docs/CODEMAPS/languages.md
+++ b/docs/CODEMAPS/languages.md
@@ -44,6 +44,7 @@ Not every registered plugin is wired into the indexer to the same depth:
 Cross-cutting logic shared by several plugins (not a language plugin itself):
 
 - `languages/_complexity_logical.py` — `is_executable_logical_operator()`: counts a `&&`/`||` token toward cyclomatic complexity only when it drives executable control flow. Used by the C/C++/C#/Java walkers to exclude booleans in non-executable contexts (`noexcept`/`requires` specifiers, `#if A && B` preprocessor conditions, default arguments, attributes/annotations, `static_assert`). The cross-language convention is "1 + decision points; each `&&`/`||` is one decision; switch/match counts once" (matching Go/Rust/Swift).
+- `languages/_complexity_decisions.py` — `count_decision_complexity()`: AST-node walk for JS/TS cyclomatic complexity (replaces the old keyword-substring text count that inflated complexity for keywords appearing inside identifiers/strings/comments and counted each switch `case`). Counts if / for / for-in/of / while / do-while / switch (once) / catch / ternary plus `&&`/`||`/`??` short-circuit operators (via `_complexity_logical`). Used by the JavaScript and TypeScript extractors.
 
 ## Plugin Contract
 

--- a/tests/unit/languages/test_cyclomatic_complexity.py
+++ b/tests/unit/languages/test_cyclomatic_complexity.py
@@ -1375,3 +1375,112 @@ class TestJavaDecisionNodeCoverage:
         assert len(funcs) == 1
         assert funcs[0].name == "run"
         assert funcs[0].complexity_score == 4
+
+
+# ---------------------------------------------------------------------------
+# JavaScript / TypeScript
+# ---------------------------------------------------------------------------
+# These plugins previously computed complexity by counting keyword *substrings*
+# in the function text, which (a) counted keywords inside identifiers, strings,
+# and comments (the "for" in "formatter", the "if" in "notify", every keyword
+# in a comment), and (b) counted each switch `case` separately. They now walk
+# the AST and count decision nodes once each. These tests pin the AST behavior.
+
+
+def _js_functions(source: str):
+    import tree_sitter_javascript
+
+    lang = tree_sitter.Language(tree_sitter_javascript.language())
+    tree = tree_sitter.Parser(lang).parse(source.encode())
+    from tree_sitter_analyzer.languages.javascript_plugin.extractor import (
+        JavaScriptElementExtractor,
+    )
+
+    return JavaScriptElementExtractor().extract_functions(tree, source)
+
+
+def _ts_functions(source: str):
+    import tree_sitter_typescript
+
+    lang = tree_sitter.Language(tree_sitter_typescript.language_typescript())
+    tree = tree_sitter.Parser(lang).parse(source.encode())
+    from tree_sitter_analyzer.languages.typescript_plugin.extractor import (
+        TypeScriptElementExtractor,
+    )
+
+    return TypeScriptElementExtractor().extract_functions(tree, source)
+
+
+class TestJavaScriptCyclomaticComplexity:
+    def test_simple_no_branches(self):
+        funcs = _js_functions("function greet(name){ return name; }")
+        assert funcs[0].name == "greet"
+        assert funcs[0].complexity_score == 1
+
+    def test_keyword_substrings_in_identifiers_not_counted(self):
+        """Identifiers containing keyword substrings must NOT add complexity."""
+        # "for" in formatData/formatter, "if" in notify, "case" in processCases
+        for src, name in [
+            ("function notify(){ return 1; }", "notify"),
+            ("function formatData(formatter){ return formatter; }", "formatData"),
+            ("function processCases(database){ return database; }", "processCases"),
+        ]:
+            funcs = _js_functions(src)
+            assert funcs[0].name == name
+            assert funcs[0].complexity_score == 1
+
+    def test_keywords_in_comment_and_string_not_counted(self):
+        funcs = _js_functions(
+            "function plain(){ /* if while for case switch && || ? */ "
+            "return 'if you switch the case'; }"
+        )
+        assert funcs[0].complexity_score == 1
+
+    def test_switch_counts_once_not_per_case(self):
+        funcs = _js_functions(
+            "function f(x){ switch(x){case 1:break;case 2:break;"
+            "case 3:break;default:break;} }"
+        )
+        assert funcs[0].complexity_score == 2
+
+    def test_nullish_coalescing_counts_but_optional_chain_does_not(self):
+        """`??` short-circuits (a decision); `?.` is not a branch."""
+        assert (
+            _js_functions("function f(a,b){ return a ?? b; }")[0].complexity_score == 2
+        )
+        assert _js_functions("function f(a){ return a?.b; }")[0].complexity_score == 1
+
+    def test_rich_branching(self):
+        """if + else-if + for + for-of + while + do + switch + catch + ternary
+        + && + || = 11 decisions → complexity 12."""
+        funcs = _js_functions(
+            "function f(x, a){"
+            " if (x>0 && x<9) {} else if (x<0 || x>20) {}"
+            " for (let i=0;i<3;i++) {} for (const v of a) {}"
+            " while (x>0) {} do {} while (x<5);"
+            " switch (x) { case 1: break; default: break; }"
+            " try {} catch (e) {}"
+            " let r = x>0 ? 1 : -1; return r; }"
+        )
+        assert funcs[0].complexity_score == 12
+
+
+class TestTypeScriptCyclomaticComplexity:
+    def test_simple_no_branches(self):
+        funcs = _ts_functions("function greet(name: string): string { return name; }")
+        assert funcs[0].name == "greet"
+        assert funcs[0].complexity_score == 1
+
+    def test_keyword_substrings_not_counted(self):
+        funcs = _ts_functions(
+            "function render(forEachItem: number): number { return forEachItem; }"
+        )
+        assert funcs[0].name == "render"
+        assert funcs[0].complexity_score == 1
+
+    def test_switch_counts_once_not_per_case(self):
+        funcs = _ts_functions(
+            "function f(x: number){ switch(x){case 1:break;case 2:break;"
+            "case 3:break;default:break;} }"
+        )
+        assert funcs[0].complexity_score == 2

--- a/tests/unit/languages/test_javascript_plugin_comprehensive.py
+++ b/tests/unit/languages/test_javascript_plugin_comprehensive.py
@@ -19,6 +19,26 @@ from tree_sitter_analyzer.languages.javascript_plugin import (
 )
 
 
+def _js_function_node(source: str):
+    """Parse ``source`` and return its first function-ish AST node.
+
+    Complexity is computed by walking the real AST, so these tests must feed a
+    parsed node (not a mock whose text is keyword-counted).
+    """
+    import tree_sitter
+    import tree_sitter_javascript
+
+    lang = tree_sitter.Language(tree_sitter_javascript.language())
+    tree = tree_sitter.Parser(lang).parse(source.encode())
+    stack = [tree.root_node]
+    while stack:
+        n = stack.pop()
+        if n.type in ("function_declaration", "function_expression", "arrow_function"):
+            return n
+        stack.extend(n.children)
+    raise AssertionError("no function node found")
+
+
 @pytest.fixture
 def extractor():
     """Fixture to provide enhanced JavaScriptElementExtractor instance"""
@@ -198,15 +218,12 @@ class TestEnhancedJavaScriptElementExtractor:
         expected = "This is a function @param {string} name - The name parameter @returns {string} The greeting"
         assert cleaned == expected
 
-    def test_calculate_complexity_optimized(self, extractor, mocker):
-        """Test complexity calculation"""
-        mock_node = mocker.MagicMock()
-        extractor._get_node_text_optimized = mocker.MagicMock(
-            return_value="if (x) { while (y) { for (z) { } } }"
+    def test_calculate_complexity_optimized(self, extractor):
+        """AST walk: if + while + for = 3 decisions → complexity 4."""
+        node = _js_function_node(
+            "function f(x){ if (x) { while (y) { for (let z=0;;) { } } } }"
         )
-
-        complexity = extractor._calculate_complexity_optimized(mock_node)
-        assert complexity == 4  # Base 1 + if + while + for
+        assert extractor._calculate_complexity_optimized(node) == 4
 
     def test_get_variable_kind_const(self, extractor):
         """Test variable kind detection for const"""
@@ -337,35 +354,29 @@ class TestJavaScriptComplexityAnalysis:
         complexity = extractor._calculate_complexity_optimized(mock_node)
         assert complexity == 1  # Base complexity
 
-    def test_complexity_with_conditionals(self, extractor, mocker):
-        """Test complexity calculation with conditionals"""
-        mock_node = mocker.MagicMock()
-        extractor._get_node_text_optimized = mocker.MagicMock(
-            return_value="function complex(x) { if (x > 0) return x; else if (x < 0) return -x; else return 0; }"
+    def test_complexity_with_conditionals(self, extractor):
+        """if + else-if (nested if_statement) = 2 decisions → complexity 3.
+
+        ``else`` is not a decision; the old keyword-text count reported 4 by
+        counting the ``if`` substring inside ``else if``.
+        """
+        node = _js_function_node(
+            "function complex(x) { if (x > 0) return x; "
+            "else if (x < 0) return -x; else return 0; }"
         )
+        assert extractor._calculate_complexity_optimized(node) == 3
 
-        complexity = extractor._calculate_complexity_optimized(mock_node)
-        assert complexity == 4  # Base 1 + if + else if
-
-    def test_complexity_with_loops(self, extractor, mocker):
-        """Test complexity calculation with loops"""
-        mock_node = mocker.MagicMock()
-        extractor._get_node_text_optimized = mocker.MagicMock(
-            return_value="function loop() { for (let i = 0; i < 10; i++) { while (condition) { } } }"
+    def test_complexity_with_loops(self, extractor):
+        """for + while = 2 decisions → complexity 3."""
+        node = _js_function_node(
+            "function loop() { for (let i = 0; i < 10; i++) { while (condition) { } } }"
         )
+        assert extractor._calculate_complexity_optimized(node) == 3
 
-        complexity = extractor._calculate_complexity_optimized(mock_node)
-        assert complexity == 3  # Base 1 + for + while
-
-    def test_complexity_with_logical_operators(self, extractor, mocker):
-        """Test complexity calculation with logical operators"""
-        mock_node = mocker.MagicMock()
-        extractor._get_node_text_optimized = mocker.MagicMock(
-            return_value="function logical(a, b, c) { return a && b || c; }"
-        )
-
-        complexity = extractor._calculate_complexity_optimized(mock_node)
-        assert complexity == 3  # Base 1 + && + ||
+    def test_complexity_with_logical_operators(self, extractor):
+        """&& + || = 2 decisions → complexity 3."""
+        node = _js_function_node("function logical(a, b, c) { return a && b || c; }")
+        assert extractor._calculate_complexity_optimized(node) == 3
 
 
 class TestJavaScriptFrameworkDetection:

--- a/tests/unit/languages/test_typescript_plugin.py
+++ b/tests/unit/languages/test_typescript_plugin.py
@@ -310,22 +310,33 @@ export default UserComponent;
         assert extractor._is_exported_class("TestClass") is False
 
     def test_calculate_complexity_optimized(self, extractor):
-        """Test complexity calculation"""
-        # Mock node
+        """Cache hit returns the cached value; otherwise an AST-node walk."""
+        # Cache hit short-circuits.
         node = Mock()
-        node_id = id(node)
-
-        # Test caching
-        extractor._complexity_cache[node_id] = 5
+        extractor._complexity_cache[id(node)] = 5
         assert extractor._calculate_complexity_optimized(node) == 5
 
-        # Test calculation
+        # Real calculation: if + while + for = 3 decisions → complexity 4.
         extractor._complexity_cache.clear()
-        extractor._get_node_text_optimized = Mock(
-            return_value="if (condition) { while (true) { for (let i = 0; i < 10; i++) {} } }"
-        )
-        complexity = extractor._calculate_complexity_optimized(node)
-        assert complexity > 1  # Should be greater than base complexity
+        import tree_sitter
+        import tree_sitter_typescript
+
+        lang = tree_sitter.Language(tree_sitter_typescript.language_typescript())
+        src = "function f(x:number){ if (x) { while (x) { for (let i=0;;) {} } } }"
+        tree = tree_sitter.Parser(lang).parse(src.encode())
+        stack = [tree.root_node]
+        fn = None
+        while stack:
+            n = stack.pop()
+            if n.type in (
+                "function_declaration",
+                "function_expression",
+                "arrow_function",
+            ):
+                fn = n
+                break
+            stack.extend(n.children)
+        assert extractor._calculate_complexity_optimized(fn) == 4
 
 
 class TestTypeScriptPlugin:

--- a/tree_sitter_analyzer/languages/_complexity_decisions.py
+++ b/tree_sitter_analyzer/languages/_complexity_decisions.py
@@ -1,0 +1,56 @@
+"""Shared AST-node-based cyclomatic complexity for the JS/TS plugins.
+
+Replaces the previous keyword-substring *text* counting, which counted any
+keyword that merely appeared as a substring of an identifier, string, or
+comment (the ``for`` in ``formatter``, the ``if`` in ``notify``, every keyword
+inside a ``/* ... */`` comment) and counted each ``switch`` ``case`` arm
+separately. This walks the AST and counts each decision construct once,
+matching the construct-once convention used by the other language plugins.
+"""
+
+from typing import Any
+
+from ._complexity_logical import is_executable_logical_operator
+
+# Decision constructs, counted once each. ``switch_case`` is deliberately
+# excluded: the ``switch_statement`` itself is the single decision point
+# (construct-once), consistent with #1090 (C/C++) and the other plugins.
+# ``for_in_statement`` covers both ``for-in`` and ``for-of``.
+_DECISION_NODES = frozenset(
+    {
+        "if_statement",
+        "for_statement",
+        "for_in_statement",
+        "while_statement",
+        "do_statement",
+        "switch_statement",
+        "catch_clause",
+        "ternary_expression",
+    }
+)
+
+# Short-circuit operators, each a decision point: ``&&`` / ``||`` and the
+# nullish-coalescing ``??`` (also short-circuiting; matches the PHP plugin,
+# which counts ``??``). In JS/TS these are always boolean/coalescing operators
+# (no rvalue-reference form), so there are no non-executable anchors to exclude.
+_SHORT_CIRCUIT_OPERATORS = frozenset({"&&", "||", "??"})
+_NO_ANCHORS: frozenset[str] = frozenset()
+
+
+def count_decision_complexity(node: Any) -> int:
+    """Return ``1 + decision points`` for a function/method subtree."""
+    count = 1
+    stack = [node]
+    while stack:
+        current = stack.pop()
+        node_type = getattr(current, "type", None)
+        if node_type in _DECISION_NODES:
+            count += 1
+        elif node_type in _SHORT_CIRCUIT_OPERATORS and is_executable_logical_operator(
+            current, _NO_ANCHORS
+        ):
+            count += 1
+        children = getattr(current, "children", None)
+        if children:
+            stack.extend(children)
+    return count

--- a/tree_sitter_analyzer/languages/javascript_plugin/_utility_mixin.py
+++ b/tree_sitter_analyzer/languages/javascript_plugin/_utility_mixin.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ...utils import log_debug
+from .._complexity_decisions import count_decision_complexity
 from ._jsdoc_helpers import clean_jsdoc, extract_jsdoc_for_line
 from ._variable_helpers import infer_type_from_value
 
@@ -84,25 +85,11 @@ class JavaScriptUtilityMixin:
         if node_id in self._complexity_cache:
             return self._complexity_cache[node_id]
 
-        complexity = 1
         try:
-            node_text = self._get_node_text_optimized(node).lower()
-            keywords = [
-                "if",
-                "else if",
-                "while",
-                "for",
-                "catch",
-                "case",
-                "switch",
-                "&&",
-                "||",
-                "?",
-            ]
-            for keyword in keywords:
-                complexity += node_text.count(keyword)
+            complexity = count_decision_complexity(node)
         except Exception as e:
             log_debug(f"Failed to calculate complexity: {e}")
+            complexity = 1
 
         self._complexity_cache[node_id] = complexity
         return complexity

--- a/tree_sitter_analyzer/languages/typescript_plugin/_text_helpers.py
+++ b/tree_sitter_analyzer/languages/typescript_plugin/_text_helpers.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, TypeAlias
 
 from ...utils import log_debug, log_error
+from .._complexity_decisions import count_decision_complexity
 
 if TYPE_CHECKING:
     import tree_sitter
@@ -103,37 +104,26 @@ def _slice_fallback_line(
     return line
 
 
-_COMPLEXITY_KEYWORDS = (
-    "if",
-    "else if",
-    "while",
-    "for",
-    "catch",
-    "case",
-    "switch",
-    "&&",
-    "||",
-    "?",
-)
-
-
 def calculate_complexity(
     node: tree_sitter.Node,
     get_node_text: Callable[[tree_sitter.Node], str],
     cache: dict[int, int],
 ) -> int:
-    """Calculate cyclomatic complexity for a node."""
+    """Calculate cyclomatic complexity for a node.
+
+    ``get_node_text`` is retained for signature compatibility with existing
+    callers but is no longer used: complexity is now an AST-node walk rather
+    than a keyword-substring text count.
+    """
     node_id = id(node)
     if node_id in cache:
         return cache[node_id]
 
-    complexity = 1
     try:
-        node_text = get_node_text(node).lower()
-        for keyword in _COMPLEXITY_KEYWORDS:
-            complexity += node_text.count(keyword)
+        complexity = count_decision_complexity(node)
     except Exception as e:
         log_debug(f"Failed to calculate complexity: {e}")
+        complexity = 1
 
     cache[node_id] = complexity
     return complexity


### PR DESCRIPTION
Found by the cross-language complexity audit (supersedes #1096 for JS/TS).

## The bug
JS and TS computed cyclomatic complexity by counting **keyword substrings in the function text** — `node_text.count(keyword)` over `["if","else if","while","for","catch","case","switch","&&","||","?"]`. Two severe consequences, measured on develop:

**1. Substring pollution** — any keyword appearing inside an identifier, string, or comment was counted:

| function | reported Cx | correct |
|---|---|---|
| `function notify(){}` | **2** | 1 (the `if` in "not**if**y") |
| `function formatData(formatter){}` | **4** | 1 (`for` ×2) |
| body = one comment containing the keywords | **9** | 1 |
| `function render(forEachItem){}` (TS) | **3** | 1 (`for` in "**for**Each") |

So `heatmap` / `hotspot` ranking / `project_health` grade for **real JS/TS code — the two most common languages** — were systematically inflated by their *identifiers and comments*.

**2. Per-case switch** — `case` counted per arm, so a 3-case switch added ~4 instead of 1 (the gap tracked in #1096).

## The fix
Replace both with a shared AST-node walk (`_complexity_decisions.py`) that counts each decision construct **once**: `if / for / for-in/of / while / do-while / switch (once) / catch / ternary`, plus `&&`/`||` via the existing `is_executable_logical_operator` guard. This matches the construct-once convention every other plugin uses (#1080/#1085/#1087/#1090).

After: all the pollution cases above are **Cx 1**; a clean `if+while+for` is 4; a 3-case switch is 2; `a && b || c` is 3.

## Tests
RED-first `TestJavaScript/TypeScriptCyclomaticComplexity` pin the pollution cases → 1, switch → 2, and a rich fixture → 12. Rewrote the 5 mock-based `_calculate_complexity_optimized` tests (which mocked node *text* to drive the old substring counter) to parse real ASTs. JS/TS goldens unchanged (their sample functions have no polluting identifiers or multi-case switches). Codemap updated. Full suite green (only the usual 3 e2e latency/stderr budgets flaked under local CPU contention; they pass in isolation and on CI runners).