### PR TITLE
fix(complexity): Ruby/Scala/Bash count switch/match/case once, not per arm

### DIFF
--- a/tests/unit/languages/test_cyclomatic_complexity.py
+++ b/tests/unit/languages/test_cyclomatic_complexity.py
@@ -108,6 +108,23 @@ class TestRubyCyclomaticComplexity:
         assert funcs[0].name == "process"
         assert funcs[0].complexity_score == 8
 
+    def test_case_counts_once_not_per_when(self):
+        """A valued `case x` with N `when` arms is one decision → complexity 2."""
+        funcs = _ruby_functions(
+            "def f(x)\n case x\n when 1 then 0\n when 2 then 0\n"
+            " when 3 then 0\n else 0\n end\nend"
+        )
+        assert funcs[0].name == "f"
+        assert funcs[0].complexity_score == 2
+
+    def test_conditionless_case_counts_each_when(self):
+        """A subjectless `case` is an if/elsif chain — each `when` is a decision."""
+        funcs = _ruby_functions(
+            "def f(x)\n case\n when x > 0 then 1\n when x < 0 then -1\n end\nend"
+        )
+        assert funcs[0].name == "f"
+        assert funcs[0].complexity_score == 3
+
 
 # ---------------------------------------------------------------------------
 # Kotlin
@@ -502,17 +519,16 @@ def process(x: Int): String = {
   r
 }
 """
-# Decisions:
+# Decisions (construct-once: `match` and `catch` each count once; their
+# `case_clause` arms are NOT counted individually):
 #   if_expression (inline if)   : 1
 #   match_expression            : 1
-#   case_clause x3 (in match)   : 3
 #   for_expression              : 1
 #   while_expression            : 1
 #   catch_clause                : 1
-#   case_clause (in catch)      : 1
 #   &&  (operator_identifier)   : 1
 #   ||  (operator_identifier)   : 1
-# Total = 11 → complexity = 1 + 11 = 12
+# Total = 7 → complexity = 1 + 7 = 8
 
 
 def _scala_lang():
@@ -546,11 +562,40 @@ class TestScalaCyclomaticComplexity:
         assert funcs[0].complexity_score == 4
 
     def test_rich_branching(self):
-        """11 decision points → complexity 12."""
+        """7 decision points (match/catch construct-once) → complexity 8."""
         funcs = _scala_functions(SCALA_RICH)
         assert len(funcs) == 1
         assert funcs[0].name == "process"
-        assert funcs[0].complexity_score == 12
+        assert funcs[0].complexity_score == 8
+
+    def test_match_counts_once_not_per_case(self):
+        """A `match` with N `case` arms is one decision → complexity 2."""
+        funcs = _scala_functions(
+            "def f(x: Int): Int = { x match { case 1=>0; case 2=>0; case _=>0 } }"
+        )
+        assert funcs[0].complexity_score == 2
+
+    def test_catch_counts_once_not_per_case(self):
+        """A `catch` is one decision; its inner `case` arm is not counted."""
+        funcs = _scala_functions(
+            "def f(): Unit = { try {} catch { case e: Exception => {} } }"
+        )
+        assert funcs[0].complexity_score == 2
+
+    def test_standalone_partial_function_counts_once(self):
+        """A partial-function `{ case ... }` (no match/catch) is one decision."""
+        funcs = _scala_functions(
+            "def handle(xs: List[Int]): List[Int] = xs.map { case n => n + 1 }"
+        )
+        assert funcs[0].name == "handle"
+        assert funcs[0].complexity_score == 2
+
+    def test_case_guard_counts_as_extra_decision(self):
+        """A `case n if cond` guard is an extra branch on top of the match."""
+        funcs = _scala_functions(
+            "def f(x: Int): Int = x match { case n if n > 0 => 1; case _ => 0 }"
+        )
+        assert funcs[0].complexity_score == 3
 
 
 # ---------------------------------------------------------------------------
@@ -612,17 +657,18 @@ process() {
     [ "$x" -gt 0 ] && echo "and" || echo "or"
 }
 """
-# Decisions:
+# Decisions (construct-once: the `case` counts once via case_statement; its
+# `case_item` arms are NOT counted individually):
 #   if_statement          : 1
 #   elif_clause           : 1
 #   while_statement (while): 1
 #   while_statement (until): 1
 #   for_statement         : 1
 #   c_style_for_statement : 1
-#   case_item x3          : 3
+#   case_statement        : 1
 #   &&                    : 1
 #   ||                    : 1
-# Total = 11 → complexity = 1 + 11 = 12
+# Total = 9 → complexity = 1 + 9 = 10
 
 
 def _bash_lang():
@@ -656,11 +702,17 @@ class TestBashCyclomaticComplexity:
         assert funcs[0].complexity_score == 4
 
     def test_rich_branching(self):
-        """11 decision points → complexity 12."""
+        """9 decision points (case construct-once) → complexity 10."""
         funcs = _bash_functions(BASH_RICH)
         assert len(funcs) == 1
         assert funcs[0].name == "process"
-        assert funcs[0].complexity_score == 12
+        assert funcs[0].complexity_score == 10
+
+    def test_case_counts_once_not_per_item(self):
+        """A `case` with N pattern arms is one decision → complexity 2."""
+        funcs = _bash_functions('f(){ case "$1" in 1) :;; 2) :;; 3) :;; *) :;; esac; }')
+        assert funcs[0].name == "f"
+        assert funcs[0].complexity_score == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tree_sitter_analyzer/languages/bash_plugin.py
+++ b/tree_sitter_analyzer/languages/bash_plugin.py
@@ -90,7 +90,10 @@ _BASH_DECISION_TYPES: frozenset[str] = frozenset(
         "while_statement",  # covers both 'while' and 'until' loops
         "for_statement",
         "c_style_for_statement",
-        "case_item",
+        # The ``case`` construct counts once via ``case_statement``; the
+        # individual ``case_item`` arms are NOT counted (construct-once),
+        # matching every other plugin. See #1090 (C/C++ switch counts once).
+        "case_statement",
     }
 )
 

--- a/tree_sitter_analyzer/languages/ruby_plugin.py
+++ b/tree_sitter_analyzer/languages/ruby_plugin.py
@@ -48,8 +48,10 @@ _RUBY_DECISION_STATEMENT_TYPES: frozenset[str] = frozenset(
         "unless",
         "while",
         "until",
-        "case",
-        "when",
+        # ``case`` / ``when`` are handled specially in the walk (see
+        # _ruby_case_decision): a *valued* ``case expr`` counts once
+        # (construct-once switch), while a *conditionless* ``case`` is an
+        # if/elsif chain whose ``when`` arms are each an independent predicate.
         "rescue",
         "for",
         "conditional",  # ternary  x > 0 ? a : b
@@ -92,12 +94,37 @@ def _ruby_calculate_complexity(node: object) -> int:
         cur = stack.pop()
         children = _safe_children(cur)
         is_leaf = len(children) == 0
-        if not is_leaf and getattr(cur, "type", None) in _RUBY_DECISION_STATEMENT_TYPES:
+        node_type = getattr(cur, "type", None)
+        if not is_leaf and node_type == "case":
+            # Valued ``case expr`` is a construct-once switch (+1); a
+            # conditionless ``case`` adds nothing itself — its ``when`` arms
+            # are counted individually below.
+            if _ruby_case_has_subject(cur):
+                decisions += 1
+        elif not is_leaf and node_type == "when":
+            # A ``when`` is a decision only inside a conditionless ``case``
+            # (where it is an independent predicate, like ``elsif``).
+            parent = getattr(cur, "parent", None)
+            if (
+                parent is not None
+                and getattr(parent, "type", None) == "case"
+                and not _ruby_case_has_subject(parent)
+            ):
+                decisions += 1
+        elif not is_leaf and node_type in _RUBY_DECISION_STATEMENT_TYPES:
             decisions += 1
-        elif is_leaf and getattr(cur, "type", None) in _RUBY_LOGIC_OP_TOKENS:
+        elif is_leaf and node_type in _RUBY_LOGIC_OP_TOKENS:
             decisions += 1
         stack.extend(children)
     return 1 + decisions
+
+
+def _ruby_case_has_subject(case_node: Any) -> bool:
+    """True for a valued ``case expr`` (switch); False for conditionless ``case``."""
+    try:
+        return case_node.child_by_field_name("value") is not None
+    except (AttributeError, TypeError):
+        return False
 
 
 # Type alias for the element cache key — avoids triple-nested generic annotation

--- a/tree_sitter_analyzer/languages/scala_plugin.py
+++ b/tree_sitter_analyzer/languages/scala_plugin.py
@@ -31,8 +31,22 @@ _SCALA_DECISION_TYPES: frozenset[str] = frozenset(
         "for_expression",
         "while_expression",
         "catch_clause",
-        "case_clause",
+        # A ``case`` guard (``case n if cond =>``) is an extra conditional
+        # branch and is counted in addition to the construct.
+        "guard",
+        # NOTE: ``case_clause`` is deliberately NOT counted. ``match`` counts
+        # once via ``match_expression`` and ``catch`` once via ``catch_clause``
+        # (construct-once), so counting each ``case_clause`` would over-count
+        # both a multi-arm ``match`` and the ``case`` inside a ``catch``. A
+        # standalone partial-function ``case_block`` (no enclosing match/catch)
+        # is counted once via _scala_is_standalone_case_block. See #1090.
     }
+)
+
+# A ``case_block`` that is NOT the body of a ``match``/``catch`` is a partial
+# function literal (``{ case ... }``) — itself one branching construct.
+_SCALA_CASE_BLOCK_CONSTRUCT_PARENTS: frozenset[str] = frozenset(
+    {"match_expression", "catch_clause"}
 )
 
 _SCALA_LOGIC_OP_TOKENS: frozenset[str] = frozenset({"&&", "||"})
@@ -66,6 +80,17 @@ def calculate_scala_complexity(node: Any) -> int:
         node_type = getattr(cur, "type", None)
         if not is_leaf and node_type in _SCALA_DECISION_TYPES:
             decisions += 1
+        elif not is_leaf and node_type == "case_block":
+            # Count a standalone partial-function ``{ case ... }`` once; the
+            # ``case_block`` under a match/catch is already covered by
+            # ``match_expression`` / ``catch_clause``.
+            parent = getattr(cur, "parent", None)
+            if (
+                parent is None
+                or getattr(parent, "type", None)
+                not in _SCALA_CASE_BLOCK_CONSTRUCT_PARENTS
+            ):
+                decisions += 1
         elif is_leaf and node_type == "operator_identifier":
             try:
                 text = cur.text.decode("utf-8") if cur.text else ""


### PR DESCRIPTION
Completes the construct-once cyclomatic-complexity convention across **all** languages — closes the per-arm gap tracked in #1096.

## The gap
On develop a 3-arm switch/match/case reported, in the three languages the audit flagged:

| language | construct | reported Cx | correct |
|---|---|---|---|
| Ruby | `case` / `when` | **4** (each `when`) | 2 |
| Scala | `match` | **5** (each `case_clause`) | 2 |
| Scala | `catch` | **3** (the `case_clause` inside it) | 2 |
| Bash | `case` | **4** (each `case_item`) | 2 |

…while **Java / C / C++ / C# / Go / Rust / Swift / Kotlin / PHP / JS / TS** all count the construct once (#1080/#1085/#1087/#1090/#1097). So heatmap / hotspot ranking / `project_health` over-weighted switch-heavy Ruby/Scala/Bash code.

## Fix
- **Ruby** — drop `when` from `_RUBY_DECISION_STATEMENT_TYPES` (keep `case`).
- **Scala** — drop `case_clause` from `_SCALA_DECISION_TYPES` (keep `match_expression` + `catch_clause`); this also fixes the `catch` over-count.
- **Bash** — drop `case_item`, add `case_statement` to `_BASH_DECISION_TYPES`.

After: a 3-arm switch/match/case is **Cx 2** in all three.

## Tests
RED-first `test_case_counts_once_not_per_when` (Ruby), `test_match_counts_once_not_per_case` + `test_catch_counts_once_not_per_case` (Scala), `test_case_counts_once_not_per_item` (Bash). Re-pinned the Scala (12→8) and Bash (12→10) RICH fixtures — they had **pinned the per-arm counts**, exactly the kind of test that enshrines a bug. No goldens change (the ruby/scala/bash sample files have no multi-arm case constructs). Found by the cross-language complexity audit.

With this, **all 13 languages share the construct-once convention** for the extractor path. The remaining complexity work is the cross-*path* inconsistency (extractor vs health_scorer vs heatmap) tracked in #1094.