### PR TITLE
fix(complexity): Python cyclomatic complexity is an AST walk, not a keyword-regex count

### DIFF
--- a/docs/CODEMAPS/languages.md
+++ b/docs/CODEMAPS/languages.md
@@ -45,6 +45,7 @@ Cross-cutting logic shared by several plugins (not a language plugin itself):
 
 - `languages/_complexity_logical.py` — `is_executable_logical_operator()`: counts a `&&`/`||` token toward cyclomatic complexity only when it drives executable control flow. Used by the C/C++/C#/Java walkers to exclude booleans in non-executable contexts (`noexcept`/`requires` specifiers, `#if A && B` preprocessor conditions, default arguments, attributes/annotations, `static_assert`). The cross-language convention is "1 + decision points; each `&&`/`||` is one decision; switch/match counts once" (matching Go/Rust/Swift).
 - `languages/_complexity_decisions.py` — `count_decision_complexity()`: AST-node walk for JS/TS cyclomatic complexity (replaces the old keyword-substring text count that inflated complexity for keywords appearing inside identifiers/strings/comments and counted each switch `case`). Counts if / for / for-in/of / while / do-while / switch (once) / catch / ternary plus `&&`/`||`/`??` short-circuit operators (via `_complexity_logical`). Used by the JavaScript and TypeScript extractors.
+- `languages/python_plugin/_python_complexity.py` — `python_cyclomatic_complexity()`: AST-node walk for Python cyclomatic complexity (replaces a `re.findall(r"\bkeyword\b", text)` counter that counted keywords in comments/docstrings/strings, counted `match` per-arm, and counted `with`). Counts if / elif / for / while / except / ternary / match (once) / `and`/`or` / comprehension for-and-if clauses. Used by the Python extractor.
 
 ## Plugin Contract
 

--- a/tests/golden_masters/compact/python_sample_compact.md
+++ b/tests/golden_masters/compact/python_sample_compact.md
@@ -19,7 +19,7 @@
 | Method | Sig | V | L | Cx | Doc |
 |--------|-----|---|---|----|----|
 | __post_init__ | (Any):Any | + | 21-24 | 2 | - |
-| greet | (Any):str | + | 26-28 | 2 | - |
+| greet | (Any):str | + | 26-28 | 1 | - |
 | __init__ | (Any,str,str):Any | + | 34-36 | 1 | - |
 | make_sound | (Any):str | + | 39-41 | 1 | - |
 | describe | (Any):str | + | 43-45 | 1 | - |
@@ -29,14 +29,14 @@
 | __init__ | (Any,str,bool = True):Any | + | 67-69 | 1 | - |
 | make_sound | (Any):str | + | 71-73 | 1 | - |
 | purr | ():str | + | 76-78 | 1 | - |
-| fetch_data | (str):dict[str, any] | + | 81-87 | 3 | - |
-| process_animals | (list[Animal]):dict[str, list[str]] | + | 90-103 | 4 | - |
-| calculate_statistics | (list[int | float]):dict[str, float] | + | 106-117 | 3 | - |
+| fetch_data | (str):dict[str, any] | + | 81-87 | 1 | - |
+| process_animals | (list[Animal]):dict[str, list[str]] | + | 90-103 | 3 | - |
+| calculate_statistics | (list[int | float]):dict[str, float] | + | 106-117 | 2 | - |
 | fibonacci_generator | (int):Any | + | 120-125 | 2 | - |
-| list_comprehension_examples | ():Any | + | 128-142 | 7 | - |
+| list_comprehension_examples | ():Any | + | 128-142 | 6 | - |
 | exception_handling_example | ():Any | + | 145-160 | 3 | - |
-| context_manager_example | ():Any | + | 163-168 | 2 | - |
-| lambda_and_higher_order_functions | ():Any | + | 171-186 | 6 | - |
+| context_manager_example | ():Any | + | 163-168 | 1 | - |
+| lambda_and_higher_order_functions | ():Any | + | 171-186 | 2 | - |
 | decorator_example | (Any):Any | + | 189-198 | 1 | - |
 | wrapper | (Any,Any):Any | + | 192-196 | 1 | - |
 | decorated_function | (str):str | + | 202-204 | 1 | - |

--- a/tests/golden_masters/csv/python_sample_csv.csv
+++ b/tests/golden_masters/csv/python_sample_csv.csv
@@ -1,7 +1,7 @@
 Type,Name,Signature,Visibility,Lines,Complexity,Doc
 Field,email,email:str | None,private,19-19,,None
 Method,__post_init__,(self:Any):Any,public,21-24,2,-
-Method,greet,(self:Any):str,public,26-28,2,-
+Method,greet,(self:Any):str,public,26-28,1,-
 Constructor,__init__,"(self:Any, name:str, species:str):Any",public,34-36,1,-
 Method,make_sound,(self:Any):str,public,39-41,1,-
 Method,describe,(self:Any):str,public,43-45,1,-
@@ -11,14 +11,14 @@ Method,fetch,"(self:Any, item:str):str",public,59-61,1,-
 Constructor,__init__,"(self:Any, name:str, indoor:bool = True):Any",public,67-69,1,-
 Method,make_sound,(self:Any):str,public,71-73,1,-
 Method,purr,():str [static],public,76-78,1,-
-Method,fetch_data,"(url:str):dict[str, any]",public,81-87,3,-
-Method,process_animals,"(animals:list[Animal]):dict[str, list[str]]",public,90-103,4,-
-Method,calculate_statistics,"(numbers:list[int | float]):dict[str, float]",public,106-117,3,-
+Method,fetch_data,"(url:str):dict[str, any]",public,81-87,1,-
+Method,process_animals,"(animals:list[Animal]):dict[str, list[str]]",public,90-103,3,-
+Method,calculate_statistics,"(numbers:list[int | float]):dict[str, float]",public,106-117,2,-
 Method,fibonacci_generator,(n:int):Any,public,120-125,2,-
-Method,list_comprehension_examples,():Any,public,128-142,7,-
+Method,list_comprehension_examples,():Any,public,128-142,6,-
 Method,exception_handling_example,():Any,public,145-160,3,-
-Method,context_manager_example,():Any,public,163-168,2,-
-Method,lambda_and_higher_order_functions,():Any,public,171-186,6,-
+Method,context_manager_example,():Any,public,163-168,1,-
+Method,lambda_and_higher_order_functions,():Any,public,171-186,2,-
 Method,decorator_example,(func:Any):Any,public,189-198,1,-
 Method,wrapper,"(*args:Any, **kwargs:Any):Any",public,192-196,1,-
 Method,decorated_function,(message:str):str,public,202-204,1,-

--- a/tests/golden_masters/full/python_sample_full.md
+++ b/tests/golden_masters/full/python_sample_full.md
@@ -21,7 +21,7 @@ from functools import reduce
 | Method | Signature | Vis | Lines | Cx | Doc |
 |--------|-----------|-----|-------|----|----| 
 | __post_init__ | (self:Any):Any | + | 21-24 | 2 | Validate the person data after initialization. |
-| greet | (self:Any):str | + | 26-28 | 2 | Return a greeting message. |
+| greet | (self:Any):str | + | 26-28 | 1 | Return a greeting message. |
 
 ## Animal (31-45)
 ### Public Methods
@@ -50,14 +50,14 @@ from functools import reduce
 ## Module Functions
 | Method | Signature | Vis | Lines | Cx | Doc |
 |--------|-----------|-----|-------|----|----| 
-| fetch_data | (url:str):dict[str, any] | + | 81-87 | 3 | Asynchronously fetch data from a URL. |
-| process_animals | (animals:list[Animal]):dict[str, list[str]] | + | 90-103 | 4 | Process a list of animals and categorize their ... |
-| calculate_statistics | (numbers:list[int | float]):dict[str, float] | + | 106-117 | 3 | Calculate basic statistics for a list of numbers. |
+| fetch_data | (url:str):dict[str, any] | + | 81-87 | 1 | Asynchronously fetch data from a URL. |
+| process_animals | (animals:list[Animal]):dict[str, list[str]] | + | 90-103 | 3 | Process a list of animals and categorize their ... |
+| calculate_statistics | (numbers:list[int | float]):dict[str, float] | + | 106-117 | 2 | Calculate basic statistics for a list of numbers. |
 | fibonacci_generator | (n:int):Any | + | 120-125 | 2 | Generate Fibonacci numbers up to n. |
-| list_comprehension_examples | ():Any | + | 128-142 | 7 | Demonstrate various list comprehensions. |
+| list_comprehension_examples | ():Any | + | 128-142 | 6 | Demonstrate various list comprehensions. |
 | exception_handling_example | ():Any | + | 145-160 | 3 | Demonstrate exception handling. |
-| context_manager_example | ():Any | + | 163-168 | 2 | Demonstrate context managers. |
-| lambda_and_higher_order_functions | ():Any | + | 171-186 | 6 | Demonstrate lambda functions and higher-order f... |
+| context_manager_example | ():Any | + | 163-168 | 1 | Demonstrate context managers. |
+| lambda_and_higher_order_functions | ():Any | + | 171-186 | 2 | Demonstrate lambda functions and higher-order f... |
 | decorator_example | (func:Any):Any | + | 189-198 | 1 | A simple decorator example. |
 | wrapper | (*args:Any, **kwargs:Any):Any | + | 192-196 | 1 | - |
 | decorated_function | (message:str):str | + | 202-204 | 1 | A function that uses the decorator. |

--- a/tests/unit/languages/test_cyclomatic_complexity.py
+++ b/tests/unit/languages/test_cyclomatic_complexity.py
@@ -1536,3 +1536,71 @@ class TestTypeScriptCyclomaticComplexity:
             "case 3:break;default:break;} }"
         )
         assert funcs[0].complexity_score == 2
+
+
+# ---------------------------------------------------------------------------
+# Python
+# ---------------------------------------------------------------------------
+# Python complexity was a `re.findall(r"\bkeyword\b", text)` counter that
+# over-counted keywords appearing as whole words in comments/docstrings/strings
+# and counted `match` per-arm and `with` (not a branch). It is now an AST walk.
+
+
+def _python_functions(source: str):
+    import tree_sitter_python
+
+    lang = tree_sitter.Language(tree_sitter_python.language())
+    tree = tree_sitter.Parser(lang).parse(source.encode())
+    from tree_sitter_analyzer.languages.python_plugin.extractor import (
+        PythonElementExtractor,
+    )
+
+    return PythonElementExtractor().extract_functions(tree, source)
+
+
+class TestPythonCyclomaticComplexity:
+    def test_simple_no_branches(self):
+        funcs = _python_functions("def greet(name):\n    return name\n")
+        assert funcs[0].name == "greet"
+        assert funcs[0].complexity_score == 1
+
+    def test_keywords_in_comment_docstring_string_not_counted(self):
+        for src in [
+            "def f():\n    # if elif while for and or\n    return 1\n",
+            'def f():\n    """if elif while for"""\n    return 1\n',
+            "def f():\n    return 'if you for or while'\n",
+            "def modify(formatter):\n    return formatter\n",
+        ]:
+            assert _python_functions(src)[0].complexity_score == 1
+
+    def test_with_statement_is_not_a_decision(self):
+        funcs = _python_functions(
+            "def f():\n    with open('x') as fh:\n        return fh.read()\n"
+        )
+        assert funcs[0].complexity_score == 1
+
+    def test_match_counts_once_not_per_case(self):
+        funcs = _python_functions(
+            "def f(x):\n    match x:\n        case 1: pass\n"
+            "        case 2: pass\n        case _: pass\n"
+        )
+        assert funcs[0].complexity_score == 2
+
+    def test_comprehension_loop_and_filter_count(self):
+        """`[y for y in z if w]` = comprehension for + if → complexity 3."""
+        funcs = _python_functions("def f(z):\n    return [y for y in z if w]\n")
+        assert funcs[0].complexity_score == 3
+
+    def test_rich_branching(self):
+        """if + elif + for + while + except + ternary + and + or = 8 → 9."""
+        funcs = _python_functions(
+            "def f(x, items):\n"
+            "    if x > 0 and x < 9:\n        pass\n"
+            "    elif x < 0 or x > 20:\n        pass\n"
+            "    for i in items:\n        pass\n"
+            "    while x:\n        pass\n"
+            "    try:\n        pass\n    except ValueError:\n        pass\n"
+            "    r = 1 if x else -1\n    return r\n"
+        )
+        assert funcs[0].name == "f"
+        assert funcs[0].complexity_score == 9

--- a/tests/unit/languages/test_python_element_extractor_core.py
+++ b/tests/unit/languages/test_python_element_extractor_core.py
@@ -426,41 +426,39 @@ def __magic_method__(self, other):
         assert result2 == "Test docstring"
 
     def test_calculate_complexity_optimized(self, extractor):
-        """Test complexity calculation"""
-        mock_node = Mock()
-        node_id = id(mock_node)
+        """Complexity is an AST-node walk over a real parse, not a text count."""
+        import tree_sitter
+        import tree_sitter_python
 
-        # Test simple function
-        with patch.object(extractor, "_get_node_text_optimized") as mock_get_text:
-            mock_get_text.return_value = "def simple_function(): return True"
+        def _func_node(src: str):
+            lang = tree_sitter.Language(tree_sitter_python.language())
+            tree = tree_sitter.Parser(lang).parse(src.encode())
+            stack = [tree.root_node]
+            while stack:
+                n = stack.pop()
+                if n.type == "function_definition":
+                    return n
+                stack.extend(n.children)
+            raise AssertionError("no function")
 
-            result = extractor._calculate_complexity_optimized(mock_node)
-            assert result == 1  # Base complexity
-            assert node_id in extractor._complexity_cache
+        simple = _func_node("def simple_function():\n    return True\n")
+        assert extractor._calculate_complexity_optimized(simple) == 1
+        assert id(simple) in extractor._complexity_cache
 
-        # Test complex function with different mock node
-        complex_mock_node = Mock()
-        complex_code = """
-        def complex_function(x):
-            if x > 0:
-                for i in range(x):
-                    if i % 2 == 0:
-                        while i > 0:
-                            try:
-                                result = i / 2
-                            except ZeroDivisionError:
-                                pass
-                            i -= 1
-            elif x < 0:
-                pass
-            return x
-        """
-
-        with patch.object(extractor, "_get_node_text_optimized") as mock_get_text:
-            mock_get_text.return_value = complex_code
-
-            result = extractor._calculate_complexity_optimized(complex_mock_node)
-            assert (
-                result >= 5
-            )  # Should have higher complexity (if, for, if, while, try, elif)
-
+        # if + for + if + while + except + elif = 6 decisions → 7
+        complex_src = (
+            "def complex_function(x):\n"
+            "    if x > 0:\n"
+            "        for i in range(x):\n"
+            "            if i % 2 == 0:\n"
+            "                while i > 0:\n"
+            "                    try:\n"
+            "                        result = i / 2\n"
+            "                    except ZeroDivisionError:\n"
+            "                        pass\n"
+            "                    i -= 1\n"
+            "    elif x < 0:\n"
+            "        pass\n"
+            "    return x\n"
+        )
+        assert extractor._calculate_complexity_optimized(_func_node(complex_src)) == 7

--- a/tests/unit/languages/test_python_plugin_edge_cases.py
+++ b/tests/unit/languages/test_python_plugin_edge_cases.py
@@ -674,27 +674,33 @@ class TestPythonPluginEdgeCases:
             )  # Should use fallback (10 bytes = "def test()")
 
     def test_complexity_calculation_edge_cases(self, extractor):
-        """Test complexity calculation edge cases"""
-        # Exact measured complexities per input (text-keyword counting ignores context)
-        expected_by_code = {
-            "": 1,
-            "pass": 1,
-            "if if if:": 4,
-            "# if elif while for": 5,
-            "'if elif while'": 4,
-            "if True: pass": 2,
-        }
+        """Keywords in comments / docstrings / strings / identifiers do NOT add
+        complexity (the AST walk respects context, unlike the old keyword count)."""
+        import tree_sitter
+        import tree_sitter_python
 
-        for code, expected_complexity in expected_by_code.items():
-            mock_node = Mock()
+        lang = tree_sitter.Language(tree_sitter_python.language())
+        _trees = []  # keep parses alive so node ids are not recycled across calls
 
-            with patch.object(extractor, "_get_node_text_optimized") as mock_get_text:
-                mock_get_text.return_value = code
+        def _func_cx(src: str) -> int:
+            extractor._complexity_cache.clear()
+            tree = tree_sitter.Parser(lang).parse(src.encode())
+            _trees.append(tree)
+            stack = [tree.root_node]
+            while stack:
+                n = stack.pop()
+                if n.type == "function_definition":
+                    return extractor._calculate_complexity_optimized(n)
+                stack.extend(n.children)
+            raise AssertionError("no function")
 
-                result = extractor._calculate_complexity_optimized(mock_node)
-                assert result == expected_complexity, (
-                    f"code={code!r}: expected {expected_complexity}, got {result}"
-                )
+        # keywords only in a comment / docstring / string / identifier → Cx 1
+        assert _func_cx("def f():\n    # if elif while for and or\n    return 1\n") == 1
+        assert _func_cx('def f():\n    """if elif while"""\n    return 1\n') == 1
+        assert _func_cx("def f():\n    return 'if you for or while'\n") == 1
+        assert _func_cx("def modify(formatter):\n    return formatter\n") == 1
+        # one real `if` → Cx 2
+        assert _func_cx("def f(x):\n    if x:\n        pass\n") == 2
 
     def test_docstring_extraction_edge_cases(self, extractor):
         """Test docstring extraction edge cases"""

--- a/tree_sitter_analyzer/languages/python_plugin/_core_extractor_mixin.py
+++ b/tree_sitter_analyzer/languages/python_plugin/_core_extractor_mixin.py
@@ -15,6 +15,7 @@ from ._extractor_helpers import (
     find_docstring_after_line,
     run_iterative_traversal,
 )
+from ._python_complexity import python_cyclomatic_complexity
 
 
 class PythonExtractorCoreMixin:
@@ -148,34 +149,20 @@ class PythonExtractorCoreMixin:
             return None
 
     def _calculate_complexity_optimized(self, node: Any) -> int:
-        """Calculate cyclomatic complexity efficiently."""
-        import re
+        """Calculate cyclomatic complexity via an AST-node walk.
 
+        Replaces a keyword-regex text count that over-counted Python keywords
+        appearing in comments/docstrings/strings and counted ``match`` per-arm.
+        """
         node_id = id(node)
         if node_id in self._complexity_cache:
             return self._complexity_cache[node_id]
 
-        complexity = 1
         try:
-            node_text = self._get_node_text_optimized(node).lower()
-            keywords = [
-                "if",
-                "elif",
-                "while",
-                "for",
-                "except",
-                "and",
-                "or",
-                "with",
-                "match",
-                "case",
-            ]
-            for keyword in keywords:
-                pattern = rf"\b{keyword}\b"
-                matches = re.findall(pattern, node_text)
-                complexity += len(matches)
+            complexity = python_cyclomatic_complexity(node)
         except Exception as exc:
             log_debug(f"Failed to calculate complexity: {exc}")
+            complexity = 1
 
         self._complexity_cache[node_id] = complexity
         return complexity

--- a/tree_sitter_analyzer/languages/python_plugin/_python_complexity.py
+++ b/tree_sitter_analyzer/languages/python_plugin/_python_complexity.py
@@ -1,0 +1,45 @@
+"""AST-node-based cyclomatic complexity for Python.
+
+Replaces a ``re.findall(r"\\bkeyword\\b", text)`` counter that counted Python
+keywords appearing as whole words inside comments, docstrings, and strings (a
+function whose only body was a comment listing keywords scored 6), counted
+``match`` arms per-``case``, and counted ``with`` (not a branch). This walks the
+AST and counts each decision construct once, matching the construct-once
+convention used by the other language plugins.
+"""
+
+from typing import Any
+
+# Decision constructs, counted once each. ``match_statement`` (not each
+# ``case_clause``) keeps a ``match`` construct-once; ``boolean_operator`` counts
+# each ``and`` / ``or`` (Python's short-circuit operators); ``for_in_clause`` /
+# ``if_clause`` count comprehension loops and filters. ``else`` / ``with`` are
+# NOT decisions.
+_PYTHON_DECISION_NODES = frozenset(
+    {
+        "if_statement",
+        "elif_clause",
+        "for_statement",
+        "while_statement",
+        "except_clause",
+        "conditional_expression",  # ternary  a if c else b
+        "match_statement",
+        "boolean_operator",  # `and` / `or`
+        "for_in_clause",  # comprehension loop
+        "if_clause",  # comprehension filter
+    }
+)
+
+
+def python_cyclomatic_complexity(node: Any) -> int:
+    """Return ``1 + decision points`` for a Python function/method subtree."""
+    count = 1
+    stack = [node]
+    while stack:
+        current = stack.pop()
+        if getattr(current, "type", None) in _PYTHON_DECISION_NODES:
+            count += 1
+        children = getattr(current, "children", None)
+        if children:
+            stack.extend(children)
+    return count


### PR DESCRIPTION
Found by the **Codex review of RFC-0019 (#1099)**, which flagged that the Python extractor cannot be the canonical complexity source until it stops text-counting. Standalone bug fix; also unblocks RFC-0019.

## The bug
`PythonElementExtractor._calculate_complexity_optimized` used `re.findall(r"\bkeyword\b", node_text)` over `[if, elif, while, for, except, and, or, with, match, case]`. Three defects:

1. **Keywords in comments / docstrings / strings count.** A function whose body is `# if elif while for and or` scored **Cx 6**; a docstring `"""Return x if positive"""` added a phantom decision.
2. **`match` counted per `case` arm** (per-arm, not construct-once).
3. **`with` counted** — `async with ...: async with ...:` added 2 to a branch-free function (e.g. `fetch_data`).

Unlike the JS/TS bug (#1097) the `\b` word-boundary spared *identifier* substrings, but comments/strings/`with`/`match`-arms were all wrong.

## The fix
AST-node walk (`python_plugin/_python_complexity.py`) counting each construct once: `if / elif / for / while / except / ternary / match (once) / and / or / comprehension for+if clauses`. Matches the construct-once convention of every other plugin (#1085/#1097/#1098).

## Tests
RED-first `TestPythonCyclomaticComplexity` (pollution → 1, `with` → 1, match construct-once → 2, comprehension → 3, rich → 9). Rewrote the two mock-node-text tests (which fed text to the old counter) to parse real ASTs. Re-pinned `python_sample` goldens (full/compact/csv) — values drop where the old counter over-counted keywords-in-text / `with` (e.g. `fetch_data` 3→1: its only "branches" were two `async with`). Full suite green (only the usual 3 e2e latency/stderr budgets flaked under local CPU contention; they pass in isolation).