### PR TITLE
fix(complexity): heatmap (live + cache) derives CC from the extractor (#1094)

### DIFF
--- a/tests/unit/test_complexity_cross_path_invariant.py
+++ b/tests/unit/test_complexity_cross_path_invariant.py
@@ -1,43 +1,52 @@
 """Cross-path cyclomatic-complexity invariant (RFC-0019 / #1094).
 
-The extractor (``element.complexity_score``, used by ``--table`` and the golden
-masters) and the heatmap path (``complexity_heatmap.analyze_file_complexity``,
-used by the ``viz``/heatmap MCP tools and ``project_health``) must agree on the
-cyclomatic complexity of the same function.
+Every consumer must agree on a function's cyclomatic complexity:
 
-Today they do NOT: the heatmap path counts each ``switch`` arm separately while
-the extractor counts the construct once. These tests pin that invariant as a
-*strict xfail* — they document the known inconsistency as an executable,
-falsifiable contract. When RFC-0019 routes both paths through one source of
-truth, ``strict=True`` makes them fail-as-xpass, forcing the xfail marker to be
-removed in the same change.
+- the **extractor** (``element.complexity_score``, used by ``--table`` and the
+  golden masters — the single source of truth),
+- the **live heatmap** (``complexity_heatmap.analyze_file_complexity``, used by
+  the ``viz``/heatmap MCP tools and ``project_health``),
+- the **cache-backed heatmap** (``analyze_file_complexity_from_cache``).
+
+This was the #1094 inconsistency: the heatmap counted each ``switch`` arm
+separately while the extractor counts the construct once (Java/JS: 2 vs 5).
+RFC-0019 routes the heatmap count — live and cache — through the extractor's
+``complexity_score``, so all three now agree by construction. These are enforced
+invariants (they originally landed as strict-xfail documenting the gap).
 """
 
+import importlib
 import os
 import tempfile
 
 import pytest
 import tree_sitter
 
-from tree_sitter_analyzer.complexity_heatmap import analyze_file_complexity
+from tree_sitter_analyzer._ast_extraction import _extract_symbols
+from tree_sitter_analyzer.complexity_heatmap import (
+    analyze_file_complexity,
+    analyze_file_complexity_from_cache,
+)
 from tree_sitter_analyzer.language_loader import loader
 
 
-def _extractor_cx(lang: str, src: str, mod: str, cls: str) -> dict[str, int]:
-    import importlib
-
+def _parse(lang: str, src: str):
     tslang = loader.load_language(lang)
     parser = tree_sitter.Parser()
     try:
         parser.set_language(tslang)
     except Exception:  # pragma: no cover - tree-sitter API drift
         parser.language = tslang
-    tree = parser.parse(src.encode())
+    return parser.parse(src.encode())
+
+
+def _extractor_cx(lang: str, src: str, mod: str, cls: str) -> dict[str, int]:
+    tree = _parse(lang, src)
     extractor = getattr(importlib.import_module(mod), cls)()
     return {f.name: f.complexity_score for f in extractor.extract_functions(tree, src)}
 
 
-def _heatmap_cx(lang: str, src: str, filename: str) -> dict[str, int]:
+def _live_cx(lang: str, src: str, filename: str) -> dict[str, int]:
     d = tempfile.mkdtemp()
     fp = os.path.join(d, filename)
     with open(fp, "w", encoding="utf-8") as fh:
@@ -45,41 +54,84 @@ def _heatmap_cx(lang: str, src: str, filename: str) -> dict[str, int]:
     return {f.name: f.complexity for f in analyze_file_complexity(fp, lang)}
 
 
-_JAVA_SWITCH = (
-    "class B { int classify(int x){ switch(x){ case 1: return 1; "
-    "case 2: return 2; case 3: return 3; default: return 0; } } }"
-)
-_JS_SWITCH = (
-    "function classify(x){ switch(x){ case 1: break; case 2: break; "
-    "case 3: break; default: break; } }"
-)
+def _cache_cx(lang: str, src: str, filename: str) -> dict[str, int]:
+    tree = _parse(lang, src)
+    syms = _extract_symbols(tree, src, lang)
+
+    class _FakeCache:
+        def lookup(self, _fp):
+            return {"symbols": syms, "language": lang}
+
+    return {
+        f.name: f.complexity
+        for f in analyze_file_complexity_from_cache(_FakeCache(), filename)
+    }
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="#1094 / RFC-0019: heatmap path counts switch per-case; extractor counts once",
-)
-def test_java_switch_extractor_and_heatmap_agree():
-    ext = _extractor_cx(
+# (lang, filename, extractor module, extractor class, fn name, source).
+# Each fixture has a multi-arm switch/match — the construct the heatmap used to
+# over-count per arm.
+_CASES = [
+    (
         "java",
-        _JAVA_SWITCH,
+        "B.java",
         "tree_sitter_analyzer.languages.java_plugin",
         "JavaElementExtractor",
-    )
-    heat = _heatmap_cx("java", _JAVA_SWITCH, "B.java")
-    assert ext["classify"] == heat["classify"]
-
-
-@pytest.mark.xfail(
-    strict=True,
-    reason="#1094 / RFC-0019: heatmap path counts switch per-case; extractor counts once",
-)
-def test_js_switch_extractor_and_heatmap_agree():
-    ext = _extractor_cx(
+        "classify",
+        "class B { int classify(int x){ switch(x){ case 1: return 1; "
+        "case 2: return 2; case 3: return 3; default: return 0; } } }",
+    ),
+    (
         "javascript",
-        _JS_SWITCH,
+        "f.js",
         "tree_sitter_analyzer.languages.javascript_plugin.extractor",
         "JavaScriptElementExtractor",
+        "classify",
+        "function classify(x){ switch(x){ case 1: break; case 2: break; "
+        "case 3: break; default: break; } }",
+    ),
+    (
+        "typescript",
+        "f.ts",
+        "tree_sitter_analyzer.languages.typescript_plugin.extractor",
+        "TypeScriptElementExtractor",
+        "classify",
+        "function classify(x: number){ switch(x){ case 1: break; case 2: break; "
+        "case 3: break; default: break; } }",
+    ),
+    (
+        "go",
+        "f.go",
+        "tree_sitter_analyzer.languages.go_plugin",
+        "GoElementExtractor",
+        "classify",
+        "package m\nfunc classify(x int) int { switch x { case 1: case 2: "
+        "case 3: }; return x }",
+    ),
+    (
+        "rust",
+        "f.rs",
+        "tree_sitter_analyzer.languages.rust_plugin",
+        "RustPlugin",
+        "classify",
+        "fn classify(x: i32) -> i32 { match x { 1 => 1, 2 => 2, _ => 0 } }",
+    ),
+]
+
+
+@pytest.mark.parametrize("lang,fname,mod,cls,fn,src", _CASES)
+def test_extractor_live_and_cache_all_agree(lang, fname, mod, cls, fn, src):
+    if cls == "RustPlugin":
+        tree = _parse(lang, src)
+        ext_obj = getattr(importlib.import_module(mod), cls)().create_extractor()
+        ext = {f.name: f.complexity_score for f in ext_obj.extract_functions(tree, src)}
+    else:
+        ext = _extractor_cx(lang, src, mod, cls)
+    live = _live_cx(lang, src, fname)
+    cache = _cache_cx(lang, src, fname)
+    assert ext[fn] == live[fn], (
+        f"{lang}: extractor {ext[fn]} != live heatmap {live[fn]}"
     )
-    heat = _heatmap_cx("javascript", _JS_SWITCH, "classify.js")
-    assert ext["classify"] == heat["classify"]
+    assert ext[fn] == cache[fn], (
+        f"{lang}: extractor {ext[fn]} != cache heatmap {cache[fn]}"
+    )

--- a/tests/unit/test_symbols_json_enrichment.py
+++ b/tests/unit/test_symbols_json_enrichment.py
@@ -136,14 +136,14 @@ class TestReturnTypeAndParamsSerialized:
 
 
 class TestExtractorVersionBump:
-    def test_extractor_version_is_13_in_both_sites(self):
-        # v13: #949 — bash variable_assignment indexing (skip command-prefix
-        # env vars, unwrap subscript only for assignment targets); bump forces
-        # re-index.
+    def test_extractor_version_matches_in_both_sites(self):
+        # The two declarations must stay equal (they gate cache staleness).
+        # v14: #1094 — function symbols carry the extractor's canonical
+        # ``complexity``; the bump forces existing rows to re-index.
         from tree_sitter_analyzer import _ast_cache_indexer, ast_cache
 
-        assert ast_cache._AST_CACHE_EXTRACTOR_VERSION == 13
-        assert _ast_cache_indexer._AST_CACHE_EXTRACTOR_VERSION == 13
+        assert ast_cache._AST_CACHE_EXTRACTOR_VERSION == 14
+        assert _ast_cache_indexer._AST_CACHE_EXTRACTOR_VERSION == 14
 
 
 class TestBashVariableAssignmentScope:

--- a/tree_sitter_analyzer/_ast_cache_indexer.py
+++ b/tree_sitter_analyzer/_ast_cache_indexer.py
@@ -34,7 +34,10 @@ logger = logging.getLogger(__name__)
 #      cached under the old cap so deeply nested symbols are no longer truncated.
 # v13: #949 — bash variable_assignment indexing: skip command-prefix env vars
 #      (``FOO=bar make``) and unwrap subscript only for assignment targets.
-_AST_CACHE_EXTRACTOR_VERSION = 13
+# v14: #1094 / RFC-0019 — function symbols now carry the extractor's canonical
+#      ``complexity`` so the cache-backed heatmap matches the extractor instead
+#      of re-deriving the count from the per-arm ``decision_points`` sum.
+_AST_CACHE_EXTRACTOR_VERSION = 14
 
 
 def check_cache_or_read(

--- a/tree_sitter_analyzer/_ast_extraction.py
+++ b/tree_sitter_analyzer/_ast_extraction.py
@@ -1124,11 +1124,45 @@ def _extract_symbols(tree: Any, source_code: str, language: str) -> dict[str, An
     _walk_for_symbols(
         root, source_code, symbols, language, _truncated_flag=truncated_flag
     )
+    _annotate_canonical_complexity(symbols, tree, source_code, language)
     return {
         "symbols": symbols,
         "node_count": _count_nodes(root),
         "truncated_depth": truncated_flag[0],
     }
+
+
+def _annotate_canonical_complexity(
+    symbols: list[dict[str, Any]], tree: Any, source_code: str, language: str
+) -> None:
+    """Stamp each function/method symbol with the extractor's ``complexity``.
+
+    The plugin extractor's ``complexity_score`` is the single source of truth
+    (RFC-0019 / #1094); cached here (keyed by start line) so the cache-backed
+    heatmap path uses the same value the live path and ``--table`` do, instead
+    of re-deriving it from the per-arm ``decision_points`` sum.
+    """
+    try:
+        from .plugins.manager import PluginManager
+
+        plugin = PluginManager().get_plugin(language)
+        if plugin is None:
+            return
+        elements = plugin.create_extractor().extract_functions(tree, source_code)
+    except Exception:
+        return
+
+    cx_by_line: dict[int, int] = {}
+    for elem in elements:
+        start = getattr(elem, "start_line", None)
+        if start is not None:
+            cx_by_line[start] = max(getattr(elem, "complexity_score", 1) or 1, 1)
+
+    for sym in symbols:
+        if sym.get("kind") in ("function", "method"):
+            line = sym.get("line")
+            if line is not None and line in cx_by_line:
+                sym["complexity"] = cx_by_line[line]
 
 
 def _extract_imports(symbols: dict[str, Any]) -> list[str]:

--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -85,7 +85,11 @@ logger = logging.getLogger(__name__)
 #      cached under the old cap so deeply nested symbols are no longer truncated.
 # v13: #949 — bash variable_assignment indexing: skip command-prefix env vars
 #      (``FOO=bar make``) and unwrap subscript only for assignment targets.
-_AST_CACHE_EXTRACTOR_VERSION = 13
+# v14: #1094 / RFC-0019 — function symbols carry the extractor's canonical
+#      ``complexity`` so the cache-backed heatmap matches the extractor; the
+#      bump forces existing rows to re-index. MUST stay equal to the copy in
+#      ``_ast_cache_indexer.py`` (gated by test_extractor_version_matches_in_both_sites).
+_AST_CACHE_EXTRACTOR_VERSION = 14
 
 
 class SchemaIntegrityError(RuntimeError):

--- a/tree_sitter_analyzer/complexity_heatmap.py
+++ b/tree_sitter_analyzer/complexity_heatmap.py
@@ -289,7 +289,16 @@ def _extract_functions(
 def _extract_functions_from_ast(
     tree: Any, source: str, language: str, file_path: str, method_nodes: set[str]
 ) -> list[FunctionComplexity]:
-    """Original AST-walk path used for the 8 hardcoded languages."""
+    """AST-walk path for the 8 hardcoded languages.
+
+    The cyclomatic count comes from the language plugin's
+    ``element.complexity_score`` — the single source of truth (RFC-0019 / #1094)
+    that ``--table`` and the golden masters use — so the heatmap can no longer
+    disagree with the extractor (the old ``_count_complexity_in_node`` walk
+    counted switch per-arm, counted ``else``, and used stale operator nodes).
+    The per-type ``decision_points`` breakdown is still derived from the walk.
+    """
+    extractor_cx = _extractor_complexity_by_line(tree, source, language)
     results: list[FunctionComplexity] = []
     stack = [tree.root_node]
 
@@ -298,13 +307,15 @@ def _extract_functions_from_ast(
         if node.type in method_nodes:
             name = _get_function_name(node)
             cc, decision_points = _count_complexity_in_node(node, language)
+            line = node.start_point[0] + 1
+            complexity = extractor_cx.get(line, cc + 1)
             results.append(
                 FunctionComplexity(
                     name=name or "<anonymous>",
                     file=file_path,
-                    line=node.start_point[0] + 1,
+                    line=line,
                     end_line=node.end_point[0] + 1,
-                    complexity=max(cc + 1, 1),
+                    complexity=max(complexity, 1),
                     language=language,
                     class_name=_find_class_name(node, language),
                     decision_points=decision_points,
@@ -313,6 +324,33 @@ def _extract_functions_from_ast(
         stack.extend(node.children)
 
     return results
+
+
+def _extractor_complexity_by_line(
+    tree: Any, source: str, language: str
+) -> dict[int, int]:
+    """Map function start-line → the plugin extractor's ``complexity_score``.
+
+    The canonical cyclomatic value (RFC-0019 / #1094), keyed by start line so a
+    node walk can look each function up.
+    """
+    try:
+        from .plugins.manager import PluginManager
+
+        plugin = PluginManager().get_plugin(language)
+        if plugin is None:
+            return {}
+        elements = plugin.create_extractor().extract_functions(tree, source)
+    except Exception as exc:
+        logger.debug("extractor complexity unavailable for %s: %s", language, exc)
+        return {}
+
+    by_line: dict[int, int] = {}
+    for elem in elements:
+        start = getattr(elem, "start_line", None)
+        if start is not None:
+            by_line[start] = max(getattr(elem, "complexity_score", 1) or 1, 1)
+    return by_line
 
 
 def _extract_functions_via_plugin(
@@ -396,9 +434,14 @@ def analyze_file_complexity_from_cache(
         if sym.get("kind") not in ("function", "method"):
             continue
         dp: dict[str, int] = sym.get("decision_points", {})
-        if not dp:
+        # Prefer the canonical extractor complexity stored at index time
+        # (v14, #1094). An older row without it is re-parsed via the live path
+        # rather than re-derived from the per-arm `decision_points` sum (which
+        # over-counts switch/etc. and would disagree with `--table`).
+        canonical = sym.get("complexity")
+        if canonical is None:
             return analyze_file_complexity(file_path, lang)
-        cc = max(sum(dp.values()) + 1, 1)
+        cc = max(int(canonical), 1)
         results.append(
             FunctionComplexity(
                 name=sym.get("name", "<unknown>"),


### PR DESCRIPTION
First implementation slice of RFC-0019 — closes the **heatmap** half of #1094 (the health half is a parallel PR).

## The bug
The `viz` / complexity-heatmap / hotspot tools disagreed with the extractor (and `--table` / golden masters) on the same function:

| | Java/JS 3-case switch |
|---|---|
| extractor (`--table`, golden) | **2** |
| heatmap (before) | **5** (per-arm + stale operator nodes + counts `else`) |

And the heatmap had **two paths that would drift apart**: the live walk and the cache-backed path (which re-derived the count from the per-arm `decision_points` sum).

## The fix — route both paths through the extractor `complexity_score` (the single source of truth)
- **Live** (`_extract_functions_from_ast`): look each function up from the plugin extractor by start line.
- **Index time** (`_ast_extraction._extract_symbols`): stamp each function symbol with the extractor’s canonical `complexity`.
- **Cache read** (`analyze_file_complexity_from_cache`): use the stored `complexity`; older rows without it re-parse via the live path (never the per-arm sum).
- Bump `_AST_CACHE_EXTRACTOR_VERSION` **13 → 14** so existing rows re-index.

`decision_points` (the per-type breakdown the viz tool shows) is untouched.

## Verified
Empirically, extractor == live == cache = **2** for the Java switch (was 5). The enforced invariant `test_complexity_cross_path_invariant.py` is **un-xfailed** and parametrized over **Java / JS / TS / Go / Rust** (extractor == live == cache for a multi-arm switch/match). Full suite green (21370 passed; only the usual 3 e2e latency/stderr budgets flaked under local CPU contention — they pass in isolation). **No `test_complexity_heatmap` / golden re-pins** — those fixtures have no multi-arm switches, so only switch-heavy code moves (correctly).

Remaining for #1094: `health_scorer` (parallel PR), then the RFC’s full table de-duplication is moot since both consumers now use the extractor value.