### PR TITLE
fix: address codex review follow-ups for PR 1106

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -51,9 +51,24 @@ jobs:
        contains(github.event.comment.body, '@claude review'))
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve PR head
+        id: pr-head
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" = "issue_comment" ]; then
+            echo "repository=$(gh api '${{ github.event.issue.pull_request.url }}' --jq '.head.repo.full_name')" >> "$GITHUB_OUTPUT"
+            echo "ref=$(gh api '${{ github.event.issue.pull_request.url }}' --jq '.head.sha')" >> "$GITHUB_OUTPUT"
+          else
+            echo "repository=${{ github.event.pull_request.head.repo.full_name }}" >> "$GITHUB_OUTPUT"
+            echo "ref=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Check out PR head
         uses: actions/checkout@v4
         with:
+          repository: ${{ steps.pr-head.outputs.repository }}
+          ref: ${{ steps.pr-head.outputs.ref }}
           fetch-depth: 1
 
       - name: Claude review

--- a/docs/CODEMAPS/formatters.md
+++ b/docs/CODEMAPS/formatters.md
@@ -96,8 +96,8 @@ TS/JS full-table module-level functions:
 - `formatters/_typescript_formatter_full.py` and
   `formatters/_javascript_formatter_full_mixin.py` render top-level (non-class)
   functions in a `## Global Functions` section (same `Cx` column as class
-  methods). JS reads both `methods` (class methods) and `functions` (top-level)
-  since the JS plugin stores them in disjoint lists.
+  methods). JS and TS read both `methods` (class methods) and `functions`
+  (top-level) since the plugins can store them in disjoint lists.
 
 ## CSV Control-Char Safety
 

--- a/tests/governance/test_ci_routing_contract.py
+++ b/tests/governance/test_ci_routing_contract.py
@@ -31,6 +31,7 @@ SKIPPED_SCAN_DIRS = {
     ".venv",
 }
 
+
 def test_reusable_test_workflow_has_job_timeout() -> None:
     """The CI matrix must fail fast instead of hanging forever on runner stalls."""
     workflow = PROJECT_ROOT / ".github" / "workflows" / "reusable-test.yml"
@@ -179,6 +180,18 @@ def test_benchmarks_are_path_filtered_for_pr_and_push() -> None:
     assert "paths:" in text
     assert "tests/benchmarks/**" in text
     assert "tree_sitter_analyzer/ast_cache.py" in text
+
+
+def test_claude_review_comment_trigger_checks_out_pr_head() -> None:
+    """Comment-triggered reviews must inspect the PR head, not default branch."""
+    text = (PROJECT_ROOT / ".github" / "workflows" / "claude-review.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "github.event.issue.pull_request.url" in text
+    assert "gh api '${{ github.event.issue.pull_request.url }}'" in text
+    assert "repository: ${{ steps.pr-head.outputs.repository }}" in text
+    assert "ref: ${{ steps.pr-head.outputs.ref }}" in text
 
 
 def test_bandit_security_scan_is_blocking_and_configured() -> None:

--- a/tests/unit/formatters/test_typescript_formatter_core.py
+++ b/tests/unit/formatters/test_typescript_formatter_core.py
@@ -191,6 +191,47 @@ class TestTypeScriptTableFormatter:
         result = formatter.format(tsx_data)
         assert "Component" in result
 
+    def test_format_full_table_keeps_functions_when_methods_list_exists(
+        self, formatter
+    ):
+        """Class methods and separate module-level functions both render."""
+        data = {
+            "file_path": "/workspace/src/mixed.ts",
+            "classes": [
+                {
+                    "name": "Runner",
+                    "class_type": "class",
+                    "line_range": {"start": 1, "end": 5},
+                }
+            ],
+            "methods": [
+                {
+                    "name": "run",
+                    "return_type": "void",
+                    "parameters": [],
+                    "line_range": {"start": 2, "end": 4},
+                    "complexity_score": 1,
+                }
+            ],
+            "functions": [
+                {
+                    "name": "bootstrap",
+                    "return_type": "void",
+                    "parameters": [],
+                    "line_range": {"start": 7, "end": 9},
+                    "complexity_score": 1,
+                }
+            ],
+            "variables": [],
+            "statistics": {"function_count": 2, "variable_count": 0},
+        }
+
+        result = formatter.format(data)
+
+        assert "run" in result
+        assert "## Global Functions" in result
+        assert "bootstrap" in result
+
     def test_format_full_table_declaration_file(self, formatter):
         """Test full table formatting for declaration files"""
         dts_data = {

--- a/tests/unit/test_complexity_heatmap.py
+++ b/tests/unit/test_complexity_heatmap.py
@@ -114,6 +114,22 @@ class TestComplexityEngine:
         assert len(fetch) == 1
         assert fetch[0].complexity == 5
 
+    def test_same_line_javascript_functions_keep_distinct_complexity(self, tmp_path):
+        from tree_sitter_analyzer.complexity_heatmap import analyze_file_complexity
+
+        script = tmp_path / "same_line.js"
+        script.write_text(
+            "const a = (x) => x ? 1 : 2; "
+            "const b = (x, y) => { if (x) return 1; if (y) return 2; return 3; };\n",
+            encoding="utf-8",
+        )
+
+        funcs = {
+            f.name: f.complexity
+            for f in analyze_file_complexity(str(script), "javascript")
+        }
+        assert funcs == {"a": 2, "b": 3}
+
     def test_risk_bands(self):
         from tree_sitter_analyzer.complexity_heatmap import _risk_band
 

--- a/tests/unit/test_complexity_heatmap.py
+++ b/tests/unit/test_complexity_heatmap.py
@@ -130,6 +130,95 @@ class TestComplexityEngine:
         }
         assert funcs == {"a": 2, "b": 3}
 
+    def test_complexity_span_keys_reject_missing_lines(self):
+        from tree_sitter_analyzer.complexity_heatmap import (
+            _complexity_key,
+            _span_name_key,
+        )
+
+        assert _complexity_key(None, 4, "fn", "body") is None
+        assert _complexity_key(1, None, "fn", "body") is None
+        assert _span_name_key(None, 4, "fn") is None
+        assert _span_name_key(1, None, "fn") is None
+
+    def test_extractor_complexity_by_span_handles_missing_plugin(self, monkeypatch):
+        from tree_sitter_analyzer.complexity_heatmap import (
+            _extractor_complexity_by_span,
+        )
+
+        class MissingPluginManager:
+            def get_plugin(self, _language):
+                return None
+
+        monkeypatch.setattr(
+            "tree_sitter_analyzer.plugins.manager.PluginManager",
+            MissingPluginManager,
+        )
+
+        assert _extractor_complexity_by_span(None, "", "unknown") == ({}, {})
+
+    def test_extractor_complexity_by_span_handles_extractor_failure(
+        self, monkeypatch
+    ):
+        from tree_sitter_analyzer.complexity_heatmap import (
+            _extractor_complexity_by_span,
+        )
+
+        class BrokenExtractor:
+            def extract_functions(self, _tree, _source):
+                raise RuntimeError("boom")
+
+        class BrokenPlugin:
+            def create_extractor(self):
+                return BrokenExtractor()
+
+        class BrokenPluginManager:
+            def get_plugin(self, _language):
+                return BrokenPlugin()
+
+        monkeypatch.setattr(
+            "tree_sitter_analyzer.plugins.manager.PluginManager",
+            BrokenPluginManager,
+        )
+
+        assert _extractor_complexity_by_span(None, "", "python") == ({}, {})
+
+    def test_extractor_complexity_by_span_skips_incomplete_metadata(
+        self, monkeypatch
+    ):
+        from types import SimpleNamespace
+
+        from tree_sitter_analyzer.complexity_heatmap import (
+            _extractor_complexity_by_span,
+        )
+
+        incomplete = SimpleNamespace(
+            start_line=None,
+            end_line=3,
+            name="missing_start",
+            raw_text="def missing_start(): pass",
+            complexity_score=7,
+        )
+
+        class IncompleteExtractor:
+            def extract_functions(self, _tree, _source):
+                return [incomplete]
+
+        class IncompletePlugin:
+            def create_extractor(self):
+                return IncompleteExtractor()
+
+        class IncompletePluginManager:
+            def get_plugin(self, _language):
+                return IncompletePlugin()
+
+        monkeypatch.setattr(
+            "tree_sitter_analyzer.plugins.manager.PluginManager",
+            IncompletePluginManager,
+        )
+
+        assert _extractor_complexity_by_span(None, "", "python") == ({}, {})
+
     def test_risk_bands(self):
         from tree_sitter_analyzer.complexity_heatmap import _risk_band
 

--- a/tests/unit/test_health_scorer.py
+++ b/tests/unit/test_health_scorer.py
@@ -763,6 +763,15 @@ class TestScoreComplexityExtractorPath:
         f = self._write(tmp_path, "x.txt", "hello world\n")
         assert score_complexity(f, "hello world\n", None) == 50.0
 
+    def test_top_level_script_control_flow_is_scored(self, tmp_path):
+        """Script-style files with no functions still count top-level branches."""
+        from tree_sitter_analyzer.health_scorer import score_complexity
+
+        py_src = "\n".join(f"if flag_{idx}:\n    value = {idx}" for idx in range(20))
+        f = self._write(tmp_path, "script.py", py_src)
+
+        assert score_complexity(f, py_src, "python") == 83.2
+
     def test_extractor_aggregate_matches_scorer_for_multi_function_file(self, tmp_path):
         """For a Python file with >= 3 functions, score_complexity must use
         the average extractor CC (not a raw AST walk with stale node types).

--- a/tests/unit/test_health_scorer.py
+++ b/tests/unit/test_health_scorer.py
@@ -70,9 +70,21 @@ class TestHealthScorer:
         for r in results:
             assert 0 <= r.total <= 100
 
-    def test_score_project_includes_reported_source_extensions(self, scorer, tmp_path):
+    def test_score_project_includes_reported_source_extensions(
+        self, scorer, monkeypatch, tmp_path
+    ):
         """Project scoring should include all configured reportable extensions."""
-        from tree_sitter_analyzer.health_scorer import PROJECT_HEALTH_SOURCE_EXTS
+        from tree_sitter_analyzer.health_scorer import (
+            PROJECT_HEALTH_SOURCE_EXTS,
+            HealthScore,
+        )
+
+        def fake_score_file_with_cache(file_path, _cache):
+            return HealthScore(file_path=file_path, total=100.0, dimensions={})
+
+        monkeypatch.setattr(
+            scorer, "_score_file_with_cache", fake_score_file_with_cache
+        )
 
         for idx, ext in enumerate(sorted(PROJECT_HEALTH_SOURCE_EXTS)):
             path = tmp_path / f"sample{idx}{ext}"
@@ -81,14 +93,14 @@ class TestHealthScorer:
         unknown = tmp_path / "ignored.log"
         unknown.write_text("x = 1\n")
 
-        results = scorer.score_project(str(tmp_path))
+        results = scorer.score_project(str(tmp_path), use_cache=False)
         names = {Path(result.file_path).name for result in results}
         included = {
             f"sample{idx}{ext}"
             for idx, ext in enumerate(sorted(PROJECT_HEALTH_SOURCE_EXTS))
         }
 
-        assert names >= included
+        assert names == included
         assert "ignored.log" not in names
 
     def test_score_project_respects_custom_source_extensions(self, tmp_path):
@@ -771,6 +783,34 @@ class TestScoreComplexityExtractorPath:
         f = self._write(tmp_path, "script.py", py_src)
 
         assert score_complexity(f, py_src, "python") == 83.2
+
+    def test_top_level_script_parse_failure_returns_neutral(
+        self, monkeypatch, tmp_path
+    ):
+        """If script-level complexity cannot parse, score stays neutral."""
+        from tree_sitter_analyzer import complexity_heatmap, health_scorer
+        from tree_sitter_analyzer.health_scorer import score_complexity
+
+        monkeypatch.setattr(complexity_heatmap, "analyze_file_complexity", lambda *_: [])
+        monkeypatch.setattr(health_scorer, "_file_level_complexity", lambda *_: None)
+
+        f = self._write(tmp_path, "script.py", "if flag:\n    value = 1\n")
+
+        assert score_complexity(f, "if flag:\n    value = 1\n", "python") == 50.0
+
+    def test_file_level_complexity_returns_none_on_parse_failure(self, monkeypatch):
+        """Parser failures are reported as missing file-level complexity."""
+        from types import SimpleNamespace
+
+        from tree_sitter_analyzer.health_scorer import _file_level_complexity
+
+        class FailingParser:
+            def parse_file(self, _file_path, _language):
+                return SimpleNamespace(success=False, tree=None)
+
+        monkeypatch.setattr("tree_sitter_analyzer.core.parser.Parser", FailingParser)
+
+        assert _file_level_complexity("broken.py", "python") is None
 
     def test_extractor_aggregate_matches_scorer_for_multi_function_file(self, tmp_path):
         """For a Python file with >= 3 functions, score_complexity must use

--- a/tree_sitter_analyzer/complexity_heatmap.py
+++ b/tree_sitter_analyzer/complexity_heatmap.py
@@ -298,7 +298,9 @@ def _extract_functions_from_ast(
     counted switch per-arm, counted ``else``, and used stale operator nodes).
     The per-type ``decision_points`` breakdown is still derived from the walk.
     """
-    extractor_cx = _extractor_complexity_by_line(tree, source, language)
+    extractor_cx, extractor_cx_by_span_name = _extractor_complexity_by_span(
+        tree, source, language
+    )
     results: list[FunctionComplexity] = []
     stack = [tree.root_node]
 
@@ -308,13 +310,25 @@ def _extract_functions_from_ast(
             name = _get_function_name(node)
             cc, decision_points = _count_complexity_in_node(node, language)
             line = node.start_point[0] + 1
-            complexity = extractor_cx.get(line, cc + 1)
+            end_line = node.end_point[0] + 1
+            key = (
+                line,
+                end_line,
+                name or "",
+                _node_text(node).strip(),
+            )
+            complexity = extractor_cx.get(key)
+            if complexity is None:
+                complexity = extractor_cx_by_span_name.get(
+                    (line, end_line, name or ""),
+                    cc + 1,
+                )
             results.append(
                 FunctionComplexity(
                     name=name or "<anonymous>",
                     file=file_path,
                     line=line,
-                    end_line=node.end_point[0] + 1,
+                    end_line=end_line,
                     complexity=max(complexity, 1),
                     language=language,
                     class_name=_find_class_name(node, language),
@@ -326,31 +340,76 @@ def _extract_functions_from_ast(
     return results
 
 
-def _extractor_complexity_by_line(
-    tree: Any, source: str, language: str
-) -> dict[int, int]:
-    """Map function start-line → the plugin extractor's ``complexity_score``.
+_ComplexityKey = tuple[int, int, str, str]
+_SpanNameKey = tuple[int, int, str]
 
-    The canonical cyclomatic value (RFC-0019 / #1094), keyed by start line so a
-    node walk can look each function up.
+
+def _complexity_key(
+    start_line: int | None,
+    end_line: int | None,
+    name: str | None,
+    raw_text: str | None,
+) -> _ComplexityKey | None:
+    if start_line is None or end_line is None:
+        return None
+    return (start_line, end_line, name or "", (raw_text or "").strip())
+
+
+def _span_name_key(
+    start_line: int | None,
+    end_line: int | None,
+    name: str | None,
+) -> _SpanNameKey | None:
+    if start_line is None or end_line is None:
+        return None
+    return (start_line, end_line, name or "")
+
+
+def _extractor_complexity_by_span(
+    tree: Any, source: str, language: str
+) -> tuple[dict[_ComplexityKey, int], dict[_SpanNameKey, int]]:
+    """Map function span/name/text → the plugin extractor's ``complexity_score``.
+
+    The canonical cyclomatic value (RFC-0019 / #1094), keyed by more than line
+    number so compact one-line JS/TS callables cannot overwrite each other.
     """
     try:
         from .plugins.manager import PluginManager
 
         plugin = PluginManager().get_plugin(language)
         if plugin is None:
-            return {}
+            return {}, {}
         elements = plugin.create_extractor().extract_functions(tree, source)
     except Exception as exc:
         logger.debug("extractor complexity unavailable for %s: %s", language, exc)
-        return {}
+        return {}, {}
 
-    by_line: dict[int, int] = {}
+    by_span: dict[_ComplexityKey, int] = {}
+    candidates_by_span_name: dict[_SpanNameKey, list[int]] = defaultdict(list)
     for elem in elements:
-        start = getattr(elem, "start_line", None)
-        if start is not None:
-            by_line[start] = max(getattr(elem, "complexity_score", 1) or 1, 1)
-    return by_line
+        key = _complexity_key(
+            getattr(elem, "start_line", None),
+            getattr(elem, "end_line", None),
+            getattr(elem, "name", None),
+            getattr(elem, "raw_text", None),
+        )
+        complexity = max(getattr(elem, "complexity_score", 1) or 1, 1)
+        if key is not None:
+            by_span[key] = complexity
+        span_name_key = _span_name_key(
+            getattr(elem, "start_line", None),
+            getattr(elem, "end_line", None),
+            getattr(elem, "name", None),
+        )
+        if span_name_key is not None:
+            candidates_by_span_name[span_name_key].append(complexity)
+
+    unique_by_span_name = {
+        span_name_key: candidates[0]
+        for span_name_key, candidates in candidates_by_span_name.items()
+        if len(candidates) == 1
+    }
+    return by_span, unique_by_span_name
 
 
 def _extract_functions_via_plugin(

--- a/tree_sitter_analyzer/formatters/_typescript_formatter_full.py
+++ b/tree_sitter_analyzer/formatters/_typescript_formatter_full.py
@@ -25,7 +25,7 @@ def format_typescript_full_table(formatter: Any, data: dict[str, Any]) -> str:
     ]
 
     classes = data.get("classes", [])
-    methods = data.get("methods", []) or data.get("functions", [])
+    methods = [*(data.get("methods", []) or []), *(data.get("functions", []) or [])]
     fields = data.get("fields", []) or data.get("variables", [])
 
     _append_classes_overview(lines, classes, methods, fields)

--- a/tree_sitter_analyzer/health_scorer.py
+++ b/tree_sitter_analyzer/health_scorer.py
@@ -533,11 +533,9 @@ def score_complexity(file_path: str, source: str, language: str | None) -> float
         n_funcs = len(funcs)
 
         if n_funcs == 0:
-            # No functions found (empty file, language with no plugin, or
-            # parse failure inside analyze_file_complexity). Fall back to
-            # base CC = 1 — same as the old path for files with no decision
-            # nodes and no function defs.
-            cc = 1
+            cc = _file_level_complexity(file_path, language)
+            if cc is None:
+                return 50.0
         else:
             cc = sum(f.complexity for f in funcs)
 
@@ -568,6 +566,18 @@ def score_complexity(file_path: str, source: str, language: str | None) -> float
 
     except Exception:
         return 50.0
+
+
+def _file_level_complexity(file_path: str, language: str) -> int | None:
+    """Return file-level CC for scripts with top-level control flow."""
+    from .complexity_heatmap import _count_complexity_in_node
+    from .core.parser import Parser
+
+    result = Parser().parse_file(file_path, language)
+    if not result.success or result.tree is None:
+        return None
+    cc, _ = _count_complexity_in_node(result.tree.root_node, language)
+    return max(cc + 1, 1)
 
 
 def find_project_root(path: Path) -> Path:


### PR DESCRIPTION
## Summary
- Fix comment-triggered Claude review checkout so it reviews the PR head instead of the default/base branch.
- Preserve script-level complexity scoring for files without extracted functions.
- Keep same-line JS/TS function complexity distinct and include TypeScript module functions when methods exist.

## Why
Follow-up for actionable Codex review feedback from PR #1106. The first pytest runtime-contract item was already fixed on develop; this PR handles the remaining issues.

## Verification
- `uv run pytest -q` => `21128 passed, 89 skipped, 8 xfailed`
- `uv run pytest tests/unit/formatters/test_typescript_formatter_core.py tests/unit/test_complexity_heatmap.py tests/unit/test_health_scorer.py tests/unit/test_complexity_cross_path_invariant.py -q --cov=tree_sitter_analyzer --cov-report=json`
- `uv run python scripts/check_patch_coverage.py --base origin/develop --coverage-json coverage.json`
- `uv run mypy tree_sitter_analyzer/complexity_heatmap.py`
- `uv run pre-commit run actionlint --files .github/workflows/claude-review.yml`
- pre-commit on commit passed
