### PR TITLE
Merge release/v1.26.0 back into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,62 @@
 # Changelog
 
+## [1.26.0] - 2026-06-22
+
+Graph-visualization and correctness release. 54 commits since 1.25.0
+deliver the first browser-visualization data contract, complete a broad
+cyclomatic-complexity correctness sweep, tighten formatter output parity, and
+add CI review automation. No default output formats changed.
+
+### Added
+
+- **Sigma.js / Graphology graph payload export.** `viz action=graph` and
+  `--codegraph-visualize` now accept `visualization_format=sigma` /
+  `--codegraph-visualize-format sigma`, returning a Graphology-compatible
+  directed graph with node/edge attributes and LOD metadata for package,
+  class, and method drilldown. Mermaid remains the default. (#1110)
+- **Dead-code path scoping.** `health action=dead` can now scope analysis by
+  path, reducing noise for focused cleanup passes. (#1104)
+- **Formatter complexity columns.** Rust and Kotlin full-table output now show
+  cyclomatic complexity, matching the broader formatter surface. (#1082,
+  #1093)
+- **Claude PR review automation.** PRs now run a Claude-powered review job as
+  part of the CI feedback surface. (#1071, #1073)
+
+### Fixed
+
+- **Cyclomatic complexity is now extractor-owned and language-correct.**
+  Complexity scoring was corrected across Go, Rust, Python, JavaScript,
+  TypeScript, Java, C, C++, C#, Ruby, Scala, Bash, Swift, Kotlin, and
+  PHP. Heatmap and project-health consumers now read the extractor-derived
+  value instead of recomputing divergent scores. (#1055, #1056, #1057,
+  #1080, #1081, #1085, #1087, #1090, #1094, #1097, #1098, #1100, #1101,
+  #1102)
+- **MCP numeric parameter coercion.** Eleven MCP tools now coerce numeric
+  boundary parameters before validation, preventing int/string crashes from
+  agent callers. (#1054)
+- **Complexity heatmap language coverage.** Project-mode heatmap handles
+  string `max_files` and uses fallback complexity extraction across plugin
+  languages. (#1051, #1052)
+- **Formatter signature/output correctness.** Go parameter names/types,
+  Swift parameter and return types, Rust signatures, PHP and JS/TS module
+  functions, and Go/Bash complexity columns now render correctly in table
+  outputs. (#1053, #1064, #1065, #1066, #1074, #1075, #1077, #1079, #1092)
+- **Trace impact payload slimming.** `trace_impact` no longer duplicates the
+  bulk `results` array, reducing MCP response size while preserving the data
+  in the formatted payload. (#1078)
+- **PR review base resolution.** PR review routing now resolves the intended
+  base branch correctly. (#1109)
+
+### Changed
+
+- **TOON scalar safety.** Ambiguous scalar-looking strings are quoted, and a
+  `ToonDecoder` plus round-trip oracle now guard TOON losslessness. (#1063)
+- **README honesty.** README wording was corrected around TOON efficiency and
+  verdict vocabulary. (#1062)
+- **Test and CI hardening.** E2E project-health timing now warms the index
+  before measuring, formatter helper fixtures were simplified, and release
+  docs/counts were refreshed for 21,232 collected tests. (#1105, #1106)
+
 ## [1.25.0] - 2026-06-17
 
 Correctness & agent-honesty point release. 14 commits since 1.24.0 (6 fixes,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tree-sitter-analyzer"
-version = "1.25.0"
+version = "1.26.0"
 description = "MCP code-intelligence server for AI agents — a more complete and more correct call graph with classified, cross-file edges. 8 facade MCP tools, 13 curated skills, TOON-compressed output, 100% local."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -596,7 +596,7 @@ directory = "htmlcov"
 # MCP server configuration
 [tool.mcp]
 server_name = "tree-sitter-analyzer"
-server_version = "1.25.0"
+server_version = "1.26.0"
 description = "AI-era enterprise-grade code analysis MCP server with comprehensive HTML/CSS support and multi-language capabilities"
 capabilities = [
     "check_code_scale",

--- a/tests/unit/mcp/test_mcp_utils_init.py
+++ b/tests/unit/mcp/test_mcp_utils_init.py
@@ -1,12 +1,29 @@
 """Tests for tree_sitter_analyzer.mcp.utils.__init__ module."""
 
 import importlib
+import sys
 
 from tree_sitter_analyzer.mcp.utils import (
     MCP_UTILS_CAPABILITIES,
     get_cache_manager,
     get_performance_monitor,
 )
+
+
+def _snapshot_modules(prefix: str) -> dict[str, object]:
+    return {m: sys.modules[m] for m in list(sys.modules) if m.startswith(prefix)}
+
+
+def _restore_modules(prefix: str, snapshot: dict[str, object]) -> None:
+    for mod in list(sys.modules):
+        if mod.startswith(prefix):
+            del sys.modules[mod]
+    sys.modules.update(snapshot)
+    for name, module in snapshot.items():
+        parent_name, _, child_name = name.rpartition(".")
+        parent = sys.modules.get(parent_name)
+        if parent is not None:
+            setattr(parent, child_name, module)
 
 
 class TestMcpUtilsCapabilities:
@@ -46,16 +63,10 @@ class TestGetPerformanceMonitor:
 class TestImportErrorFallback:
     def test_fallback_get_cache_manager_returns_none(self):
         """Test that fallback returns None when core services unavailable."""
-        import sys
-
         blocked = "tree_sitter_analyzer.core.cache_service"
         saved = sys.modules.pop(blocked, None)
 
-        mcp_utils_snapshot = {
-            m: sys.modules[m]
-            for m in list(sys.modules)
-            if m.startswith("tree_sitter_analyzer.mcp.utils")
-        }
+        mcp_utils_snapshot = _snapshot_modules("tree_sitter_analyzer.mcp.utils")
 
         block_list = {blocked}
 
@@ -80,23 +91,14 @@ class TestImportErrorFallback:
             sys.meta_path.remove(finder)
             if saved is not None:
                 sys.modules[blocked] = saved
-            for mod in list(sys.modules):
-                if mod.startswith("tree_sitter_analyzer.mcp.utils"):
-                    del sys.modules[mod]
-            sys.modules.update(mcp_utils_snapshot)
+            _restore_modules("tree_sitter_analyzer.mcp.utils", mcp_utils_snapshot)
 
     def test_fallback_get_performance_monitor_returns_none(self):
         """Test that fallback performance monitor returns None."""
-        import sys
-
         blocked = "tree_sitter_analyzer.core.cache_service"
         saved = sys.modules.pop(blocked, None)
 
-        mcp_utils_snapshot = {
-            m: sys.modules[m]
-            for m in list(sys.modules)
-            if m.startswith("tree_sitter_analyzer.mcp.utils")
-        }
+        mcp_utils_snapshot = _snapshot_modules("tree_sitter_analyzer.mcp.utils")
 
         block_list = {blocked}
 
@@ -121,7 +123,4 @@ class TestImportErrorFallback:
             sys.meta_path.remove(finder)
             if saved is not None:
                 sys.modules[blocked] = saved
-            for mod in list(sys.modules):
-                if mod.startswith("tree_sitter_analyzer.mcp.utils"):
-                    del sys.modules[mod]
-            sys.modules.update(mcp_utils_snapshot)
+            _restore_modules("tree_sitter_analyzer.mcp.utils", mcp_utils_snapshot)

--- a/tree_sitter_analyzer/__init__.py
+++ b/tree_sitter_analyzer/__init__.py
@@ -11,7 +11,7 @@ Architecture:
 - Data Models: Generic and language-specific code element representations
 """
 
-__version__ = "1.25.0"
+__version__ = "1.26.0"
 __author__ = "aisheng.yu"
 __email__ = "aimasteracc@gmail.com"
 

--- a/uv.lock
+++ b/uv.lock
@@ -3002,7 +3002,7 @@ wheels = [
 
 [[package]]
 name = "tree-sitter-analyzer"
-version = "1.25.0"
+version = "1.26.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Release merge-back

Brings the v1.26.0 release-prep commits back into develop after the PyPI-first release completed and PR #1111 was merged to main.

## Verification

- Release automation run 27910416205 passed
- PyPI reports tree-sitter-analyzer 1.26.0
- GitHub Release v1.26.0 created