### PR TITLE
Merge release v1.27.0 back to develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Changelog
 
+## [1.27.0] - 2026-06-22
+
+Ladybug knowledge-graph release. This release adds an optional whole-project
+code/document graph projection for browser viewers and agent consumers, while
+keeping the existing SQLite AST/FTS index as the source of truth.
+
+### Added
+
+- **Whole-project knowledge graph indexing.** New `index action=knowledge`
+  MCP facade and `--knowledge-graph-index` CLI command materialize package,
+  file, symbol, and Markdown-link nodes from the existing AST cache, unified
+  edge store, and docs references.
+- **Optional LadybugDB mirror.** Installing `tree-sitter-analyzer[graph]`
+  enables a LadybugDB-backed graph mirror for Cypher-style traversal without
+  replacing SQLite. JSON remains the portable default; `backend=hybrid`
+  writes both.
+- **Graphology/Sigma export.** New `viz action=knowledge` MCP facade and
+  `--knowledge-graph-export` CLI command export Graphology-compatible JSON
+  for Sigma.js/browser visualization, plus raw and compact summary formats for
+  programmatic consumers.
+- **Obsidian-style docs/code links.** Markdown file references are projected
+  into the same graph as code files and symbols, so documentation-to-code and
+  code-to-code relationships can be explored together.
+
+### Changed
+
+- **Differential knowledge graph refresh.** `mode=update` reuses the existing
+  incremental sync path before graph materialization, preserving TSA's current
+  SQLite indexing pipeline while adding a graph-database sidecar for traversal.
+- **Facade and CLI parity.** The new knowledge graph actions are available
+  through both MCP facades and CLI entry points, with codemap and API docs
+  updated in the same release.
+
+### Fixed
+
+- **Cross-platform knowledge graph tests.** Knowledge graph sidecar path
+  assertions now handle Windows path separators, and patch coverage covers the
+  new graph export and optional-backend branches.
+
 ## [1.26.0] - 2026-06-22
 
 Graph-visualization and correctness release. 54 commits since 1.25.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tree-sitter-analyzer"
-version = "1.26.0"
+version = "1.27.0"
 description = "MCP code-intelligence server for AI agents — a more complete and more correct call graph with classified, cross-file edges. 8 facade MCP tools, 13 curated skills, TOON-compressed output, 100% local."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -597,7 +597,7 @@ directory = "htmlcov"
 # MCP server configuration
 [tool.mcp]
 server_name = "tree-sitter-analyzer"
-server_version = "1.26.0"
+server_version = "1.27.0"
 description = "AI-era enterprise-grade code analysis MCP server with comprehensive HTML/CSS support and multi-language capabilities"
 capabilities = [
     "check_code_scale",

--- a/tree_sitter_analyzer/__init__.py
+++ b/tree_sitter_analyzer/__init__.py
@@ -11,7 +11,7 @@ Architecture:
 - Data Models: Generic and language-specific code element representations
 """
 
-__version__ = "1.26.0"
+__version__ = "1.27.0"
 __author__ = "aisheng.yu"
 __email__ = "aimasteracc@gmail.com"
 

--- a/uv.lock
+++ b/uv.lock
@@ -3050,7 +3050,7 @@ wheels = [
 
 [[package]]
 name = "tree-sitter-analyzer"
-version = "1.26.0"
+version = "1.27.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Merge-back required by GITFLOW.md after publishing v1.27.0.\n\nRelease status:\n- Release Branch Automation passed and published to PyPI.\n- PR #1115 merged release/v1.27.0 to main.\n- Tag v1.27.0 and GitHub Release are created.\n\nThis PR brings release prep files back to develop: pyproject version, MCP server_version, __version__, uv.lock, and CHANGELOG.