### PR TITLE
chore: merge v1.28.0 release back to develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [1.28.0] - 2026-06-22
+
+Knowledge-graph viewer release. This release completes the human-facing graph
+path for the Ladybug/Graphology knowledge graph added in 1.27.0.
+
+### Added
+
+- **Standalone knowledge graph HTML viewer.** `viz action=knowledge` and
+  `--knowledge-graph-export` now accept `export_format=html` /
+  `--knowledge-graph-export-format html`, returning a self-contained browser
+  page over the existing capped Graphology/LOD payload.
+- **Obsidian-style interactive graph controls.** The viewer supports pan/zoom,
+  search, node-kind filtering, edge-kind filtering, node detail inspection, and
+  rendering for Markdown doc links, files, symbols, calls, imports, inheritance,
+  and containment edges.
+
+### Changed
+
+- **Human and program visualization split.** Graphology JSON remains the
+  programmatic Sigma-compatible export, while the HTML format gives people a
+  no-server browser view of the same package/file/symbol/docs LOD graph.
+
 ## [1.27.0] - 2026-06-22
 
 Ladybug knowledge-graph release. This release adds an optional whole-project

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tree-sitter-analyzer"
-version = "1.27.0"
+version = "1.28.0"
 description = "MCP code-intelligence server for AI agents — a more complete and more correct call graph with classified, cross-file edges. 8 facade MCP tools, 13 curated skills, TOON-compressed output, 100% local."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -597,7 +597,7 @@ directory = "htmlcov"
 # MCP server configuration
 [tool.mcp]
 server_name = "tree-sitter-analyzer"
-server_version = "1.27.0"
+server_version = "1.28.0"
 description = "AI-era enterprise-grade code analysis MCP server with comprehensive HTML/CSS support and multi-language capabilities"
 capabilities = [
     "check_code_scale",

--- a/tree_sitter_analyzer/__init__.py
+++ b/tree_sitter_analyzer/__init__.py
@@ -11,7 +11,7 @@ Architecture:
 - Data Models: Generic and language-specific code element representations
 """
 
-__version__ = "1.27.0"
+__version__ = "1.28.0"
 __author__ = "aisheng.yu"
 __email__ = "aimasteracc@gmail.com"
 

--- a/uv.lock
+++ b/uv.lock
@@ -3050,7 +3050,7 @@ wheels = [
 
 [[package]]
 name = "tree-sitter-analyzer"
-version = "1.27.0"
+version = "1.28.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Merge release/v1.28.0 back into develop after v1.28.0 was published and merged to main. This brings back the version bump and CHANGELOG release notes per GITFLOW.md.