### PR TITLE
feat(viz): Phase 5 — Claude Code hooks installer

### DIFF
--- a/.claude/hooks/on-file-edit.sh
+++ b/.claude/hooks/on-file-edit.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# PostToolUse hook: Edit|Write 後に TSA knowledge graph を incremental update する
+# exit 0 でノンブロッキング実行
+set -euo pipefail
+
+# stdin をドレイン (使用しない)
+cat > /dev/null
+
+# uv が利用可能か確認
+if ! command -v uv &>/dev/null; then exit 0; fi
+
+# TSA が利用可能か確認
+if ! uv run python -m tree_sitter_analyzer --version &>/dev/null 2>&1; then exit 0; fi
+
+# バックグラウンドで incremental update を実行
+PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+nohup uv run python -m tree_sitter_analyzer \
+  --knowledge-graph-index \
+  --knowledge-graph-index-mode update \
+  --project-root "$PROJECT_ROOT" \
+  > /tmp/tsa-kg-update.log 2>&1 &
+
+exit 0

--- a/.claude/hooks/pre-edit-impact.sh
+++ b/.claude/hooks/pre-edit-impact.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# PreToolUse hook: Edit|Write 前に change-impact を Claude context に注入する
+# stdout に {"systemMessage": "..."} を出力する
+set -euo pipefail
+
+INPUT=$(cat)
+
+# tool_input.file_path を JSON から取得
+FILE_PATH=$(printf '%s' "$INPUT" | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    inp = d.get('tool_input', {})
+    print(inp.get('file_path', '') or inp.get('path', ''))
+except Exception:
+    print('')
+" 2>/dev/null || echo "")
+
+if [ -z "$FILE_PATH" ]; then
+  printf '{"systemMessage": ""}\n'
+  exit 0
+fi
+
+# uv が利用可能か確認
+if ! command -v uv &>/dev/null; then
+  printf '{"systemMessage": ""}\n'
+  exit 0
+fi
+
+# change-impact を 30 秒 timeout で実行
+IMPACT=$(timeout 30 uv run python -m tree_sitter_analyzer \
+  --change-impact \
+  --format json \
+  "$FILE_PATH" 2>/dev/null || echo "")
+
+if [ -z "$IMPACT" ]; then
+  printf '{"systemMessage": ""}\n'
+  exit 0
+fi
+
+# systemMessage として JSON 出力
+python3 -c "
+import json, sys
+msg = '[TSA Impact Preview]\nFile: ' + sys.argv[1] + '\n' + sys.argv[2]
+print(json.dumps({'systemMessage': msg}))
+" "$FILE_PATH" "$IMPACT"
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/on-file-edit.sh"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/pre-edit-impact.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/install_hooks.sh
+++ b/scripts/install_hooks.sh
@@ -1,31 +1,102 @@
 #!/usr/bin/env bash
 # Install TSA Claude Code hooks into the project's .claude/settings.json.
 # Run once after cloning: bash scripts/install_hooks.sh
+#
+# The hook scripts and base settings.json are committed to the repo under
+# .claude/hooks/ and .claude/settings.json. This script ensures they are
+# executable and that settings.json contains the hooks stanza.
 set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 SETTINGS="$REPO_ROOT/.claude/settings.json"
 HOOKS_DIR="$REPO_ROOT/.claude/hooks"
 
-echo "[tsa-hooks] Checking hooks directory: $HOOKS_DIR"
+echo "[tsa-hooks] Installing hooks from: $HOOKS_DIR"
 
 if [ ! -d "$HOOKS_DIR" ]; then
-    echo "[tsa-hooks] ERROR: .claude/hooks/ directory not found. Run from repo root."
+    echo "[tsa-hooks] ERROR: .claude/hooks/ directory not found in repo."
+    echo "[tsa-hooks] This directory should be committed to git."
+    exit 1
+fi
+
+if [ ! -f "$HOOKS_DIR/on-file-edit.sh" ] || [ ! -f "$HOOKS_DIR/pre-edit-impact.sh" ]; then
+    echo "[tsa-hooks] ERROR: hook scripts missing from $HOOKS_DIR"
     exit 1
 fi
 
 chmod +x "$HOOKS_DIR/on-file-edit.sh" "$HOOKS_DIR/pre-edit-impact.sh"
 echo "[tsa-hooks] Hook scripts are executable."
 
+# Create or validate settings.json
 if [ ! -f "$SETTINGS" ]; then
-    echo "[tsa-hooks] ERROR: .claude/settings.json not found."
-    exit 1
+    echo "[tsa-hooks] Creating .claude/settings.json with hooks stanza..."
+    mkdir -p "$(dirname "$SETTINGS")"
+    cat > "$SETTINGS" << 'EOF'
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/on-file-edit.sh"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/pre-edit-impact.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+EOF
+    echo "[tsa-hooks] Created settings.json with hooks stanza."
+else
+    # Validate that hooks stanza exists; add it if missing
+    python3 - "$SETTINGS" << 'PY'
+import json
+import sys
+
+settings_path = sys.argv[1]
+with open(settings_path) as f:
+    cfg = json.load(f)
+
+if "hooks" not in cfg:
+    print("[tsa-hooks] hooks stanza missing — adding it...")
+    cfg["hooks"] = {
+        "PostToolUse": [
+            {
+                "matcher": "Edit|Write|MultiEdit",
+                "hooks": [{"type": "command", "command": "bash .claude/hooks/on-file-edit.sh"}],
+            }
+        ],
+        "PreToolUse": [
+            {
+                "matcher": "Edit|Write|MultiEdit",
+                "hooks": [{"type": "command", "command": "bash .claude/hooks/pre-edit-impact.sh"}],
+            }
+        ],
+    }
+    with open(settings_path, "w") as f:
+        json.dump(cfg, f, indent=2)
+    print("[tsa-hooks] Added hooks stanza to existing settings.json")
+else:
+    print("[tsa-hooks] settings.json already has hooks stanza - OK.")
+PY
 fi
 
-echo "[tsa-hooks] Settings already configured at: $SETTINGS"
 echo "[tsa-hooks] Hooks registered:"
-echo "  PostToolUse (Edit|Write|MultiEdit) → on-file-edit.sh (incremental KG update)"
-echo "  PreToolUse  (Edit|Write|MultiEdit) → pre-edit-impact.sh (change-impact injection)"
+echo "  PostToolUse (Edit|Write|MultiEdit) -> on-file-edit.sh (incremental KG update)"
+echo "  PreToolUse  (Edit|Write|MultiEdit) -> pre-edit-impact.sh (change-impact injection)"
 echo ""
 echo "[tsa-hooks] To verify hooks are active, open Claude Code in this repo and edit a file."
 echo "[tsa-hooks] Knowledge graph update log: /tmp/tsa-kg-update.log"

--- a/scripts/install_hooks.sh
+++ b/scripts/install_hooks.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Install TSA Claude Code hooks into the project's .claude/settings.json.
+# Run once after cloning: bash scripts/install_hooks.sh
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SETTINGS="$REPO_ROOT/.claude/settings.json"
+HOOKS_DIR="$REPO_ROOT/.claude/hooks"
+
+echo "[tsa-hooks] Checking hooks directory: $HOOKS_DIR"
+
+if [ ! -d "$HOOKS_DIR" ]; then
+    echo "[tsa-hooks] ERROR: .claude/hooks/ directory not found. Run from repo root."
+    exit 1
+fi
+
+chmod +x "$HOOKS_DIR/on-file-edit.sh" "$HOOKS_DIR/pre-edit-impact.sh"
+echo "[tsa-hooks] Hook scripts are executable."
+
+if [ ! -f "$SETTINGS" ]; then
+    echo "[tsa-hooks] ERROR: .claude/settings.json not found."
+    exit 1
+fi
+
+echo "[tsa-hooks] Settings already configured at: $SETTINGS"
+echo "[tsa-hooks] Hooks registered:"
+echo "  PostToolUse (Edit|Write|MultiEdit) → on-file-edit.sh (incremental KG update)"
+echo "  PreToolUse  (Edit|Write|MultiEdit) → pre-edit-impact.sh (change-impact injection)"
+echo ""
+echo "[tsa-hooks] To verify hooks are active, open Claude Code in this repo and edit a file."
+echo "[tsa-hooks] Knowledge graph update log: /tmp/tsa-kg-update.log"
+echo "[tsa-hooks] Done."


### PR DESCRIPTION
## Summary
- Add `scripts/install_hooks.sh`: one-shot script to verify and activate TSA Claude Code hooks for new contributors
- **PostToolUse** (Edit|Write|MultiEdit) → `on-file-edit.sh`: incremental knowledge graph update via `--knowledge-graph-index --mode update`
- **PreToolUse** (Edit|Write|MultiEdit) → `pre-edit-impact.sh`: `--change-impact` injection into Claude context before edits
- Confirmed all Phase 5 visualization features already present in develop: LadybugDB `patch()`/`delete_by_file()`, `build_delta()`, `FileWatcherDaemon`, Graph Studio UML/Blast-Radius UI, vscode:// jump, real-time polling

## Test plan
- [ ] `bash scripts/install_hooks.sh` → exits 0, prints confirmation
- [ ] Open Claude Code in repo, edit a file → `/tmp/tsa-kg-update.log` shows incremental update

🤖 Generated with [Claude Code](https://claude.com/claude-code)