### PR TITLE
docs: fix factual drift (class name, entry points, flag/plugin counts, recovery flag)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@
 
 - The default full-suite command is `uv run pytest -q`.
 - Do not run the full suite serially. Project pytest config enables xdist with `--numprocesses=auto --dist=loadfile`.
-- The full suite must finish in under 5 minutes. The config enforces `--session-timeout=600` and `--timeout=180`. (Bumped from 300 in v1.13.1 — see `docs/POSTMORTEM_v1.13.md` § 9.)
+- The full suite must finish in under 5 minutes. The config enforces `--session-timeout=900` and `--timeout=30`. (Bumped from 300 in v1.13.1 — see `docs/POSTMORTEM_v1.13.md` § 9.)
 - After edits, run `uv run python -m tree_sitter_analyzer --change-impact --format json` and follow its `verification_command`.
 - If `test_required` is `false`, do not run tests just to look busy; run the reported non-test verification such as `git diff --check`.
 - For targeted code feedback, prefer `verification_command`/`test_command`; `pytest_required` and `pytest_command` are retained for pytest-specific compatibility.
@@ -126,7 +126,7 @@ These are failure modes the project has *already paid for* during the v1.13.0 / 
 
 7. **Release-prep PRs >30 commits: prefer rebase-merge over squash.** Squashing a large consolidation PR makes `git bisect` useless on main for every bug it introduced. Use squash only for short feature PRs. (Postmortem § 10.)
 
-8. **Never lower `--maxfail` or `--session-timeout` in pytest config.** v1.13 release CI repeatedly capped failures at 10 while the actual count was ~85, forcing multi-hour debug cycles. `--maxfail=200` + `--session-timeout=600` are the locked floors; `test_default_pytest_runtime_contract_is_locked` enforces them. (Postmortem § 9.)
+8. **Never lower `--session-timeout` in pytest config.** v1.13 release CI repeatedly capped failures at 10 while the actual count was ~85, forcing multi-hour debug cycles. `--session-timeout=900` is the locked floor; `test_default_pytest_runtime_contract_is_locked` enforces it. (Postmortem § 9.)
 
 These rules are guarded by tests in `tests/governance/test_postmortem_guards.py`
 and `tests/contracts/test_pytest_runtime_contract.py`:

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ CodeGraph has zero skills. We ship 13 under `.claude/skills/tsa-*/`:
 
 Each skill ships an `allowed-tools` subset + procedure recipe + decision-surface schema, so the agent doesn't have to triage 8 tools on every question.
 
-### 318 CLI flags
+### 319 CLI flags
 
 Superset of CodeGraph's CLI surface. Highlights:
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ CodeGraph has zero skills. We ship 13 under `.claude/skills/tsa-*/`:
 
 Each skill ships an `allowed-tools` subset + procedure recipe + decision-surface schema, so the agent doesn't have to triage 8 tools on every question.
 
-### 319 CLI flags
+### 318 CLI flags
 
 Superset of CodeGraph's CLI surface. Highlights:
 
@@ -413,14 +413,14 @@ MCP client config (the project root inside the container is the mount point `/wo
 
 ## Supported Languages
 
-21 language plugins; 13 fully wired into the indexer (full symbol + call graph) + 2 symbol-indexed (call-graph wiring pending) + 5 (data/markup) reachable via the single-file CLI path + 1 scaffold (plugin exists, indexer wiring pending). bash and scala graduated in v1.22.0; the 2026-05-24 patch unblocked Swift / Kotlin / Ruby / PHP / C# that had been silently skipped for months.
+22 language plugins; 13 fully wired into the indexer (full symbol + call graph) + 2 symbol-indexed (call-graph wiring pending) + 5 (data/markup) reachable via the single-file CLI path + 2 scaffold (plugin exists, indexer wiring pending). bash and scala graduated in v1.22.0; the 2026-05-24 patch unblocked Swift / Kotlin / Ruby / PHP / C# that had been silently skipped for months.
 
 | Tier | Languages |
 |---|---|
 | **Full index + symbol + call graph** | Python · Java · JavaScript · TypeScript · Go · Rust · C · C++ · C# · Swift · Kotlin · Ruby · PHP |
 | **Full index + symbols (call-graph wiring pending)** | Bash · Scala |
 | **Single-file analysis (CLI)** | HTML · CSS · Markdown · SQL · YAML |
-| **Scaffold (plugin exists, indexer wiring pending)** | json |
+| **Scaffold (plugin exists, indexer wiring pending)** | JSON · Lua |
 
 CodeGraph supports a similar set. **Dart, Vue, Svelte, Lua** are not yet shipped — aspirational backlog, no committed date.
 
@@ -464,7 +464,7 @@ uv run python check_quality.py --new-code-only  # quality gate
 |---|---|
 | `unsupported language` on `.swift / .kt / .rb / .php / .cs` | Update to ≥ 1.12.x — the 5-language gap was patched in commit `50e99a8f`. Grammar modules for extras-gated languages are not bundled in the base install; run `pip install "tree-sitter-analyzer[swift]"` (or `kotlin`, `ruby`, `php`, `csharp`) to add them. |
 | MCP server doesn't appear in client | `TREE_SITTER_PROJECT_ROOT` must be **absolute**; restart the client after config edit. |
-| `database is locked` | Stop any other process holding `.ast-cache/index.db`; if persistent, `rm -rf .ast-cache && tree-sitter-analyzer --autoindex`. |
+| `database is locked` | Stop any other process holding `.ast-cache/index.db`; if persistent, `rm -rf .ast-cache && tree-sitter-analyzer --full-index`. |
 | Slow first call | First call builds the index. Subsequent calls are sub-second. Run `--full-index` upfront to amortise. |
 | Agent picks the wrong tool | Use a `tsa-*` skill (`/tsa-graph`, `/tsa-find`, ...) — each skill restricts the visible tool set to one workflow. |
 

--- a/docs/CODEMAPS/cli.md
+++ b/docs/CODEMAPS/cli.md
@@ -1,7 +1,7 @@
 <!-- Generated: 2026-05-22; doc-code re-sync: 2026-06-17 -->
 # CLI Codemap
 
-Three console-script entry points + flag-based dispatch through `cli_main.py`.
+Five console-script entry points + flag-based dispatch through `cli_main.py`.
 
 ## Entry Points
 
@@ -10,6 +10,8 @@ Three console-script entry points + flag-based dispatch through `cli_main.py`.
 | `tree-sitter-analyzer` | `cli_main.py` | `json` |
 | `tree-sitter-analyzer-mcp` | `mcp/server.py` (stdio) | `toon` |
 | `find-and-grep` | `cli/commands/find_and_grep_cli.py` | `json` |
+| `list-files` | `cli/commands/list_files_cli.py` | `json` |
+| `search-content` | `cli/commands/search_content_cli.py` | `json` |
 
 Default format divergence is **intentional** (see `CLAUDE.md`): CLI users pipe into `jq`,
 MCP callers are LLM agents and benefit from TOON's token savings.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,7 +52,7 @@ The analyzer engine is the central component that orchestrates code analysis.
 - Coordinate with language plugins
 
 **Key Classes**:
-- `CodeAnalyzer`: Main analysis orchestrator
+- `UnifiedAnalysisEngine`: Main analysis orchestrator
 - `AnalysisResult`: Container for analysis results
 - `ElementExtractor`: Base class for element extraction
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -101,7 +101,7 @@ For users integrating with AI assistants (Claude Desktop, Cursor, etc.):
 }
 ```
 
-> **Note**: `TREE_SITTER_PROJECT_ROOT` is optional - you can set it dynamically via the AI assistant.
+> **Note**: `TREE_SITTER_PROJECT_ROOT` must be an **absolute** path. The server enforces a security boundary (`SecurityValidator`) that rejects relative paths. You can also set it dynamically per-call via the AI assistant, but the value must still be absolute.
 
 3. Restart your AI client
 4. Verify by asking the AI to use the tree-sitter-analyzer tools


### PR DESCRIPTION
## Summary

Fix 7 factual drift items detected by doc-code audit. All claims were verified against actual source files before editing; one sub-item (item 7 `--timeout` value) was corrected from the audited value as well.

| # | Claim | Actual (file:line) | Action |
|---|---|---|---|
| 1 | `docs/architecture.md` L55: `CodeAnalyzer` listed as main orchestrator | `UnifiedAnalysisEngine` is the only class in `core/analysis_engine.py:55`; `CodeAnalyzer` does not exist | Fixed: renamed to `UnifiedAnalysisEngine` |
| 2 | `docs/CODEMAPS/cli.md`: table says "Three console-script entry points"; `list-files` and `search-content` absent | `pyproject.toml` L314-316 declares 5 entry points including `list-files` and `search-content` | Fixed: added two rows; updated prose count to "Five" |
| 3 | `README.md` Troubleshooting ~L467: `--autoindex` as recovery command after cache deletion | `--autoindex` default mode is `status` (display only, see `_mcp.py:28`); rebuild requires `--full-index` | Fixed: changed to `--full-index` |
| 4 | `docs/installation.md` ~L104: `TREE_SITTER_PROJECT_ROOT` described as "optional" | `README.md` states "must be absolute"; `SecurityValidator` enforces the boundary | Fixed: replaced "optional" note with absolute-path requirement and security boundary note |
| 5 | `README.md` ~L416: "21 language plugins" + "1 scaffold" | `docs/CODEMAPS/languages.md` says 22 (13+2+5+**2** scaffold: JSON + Lua); scaffold table row confirmed in languages.md | Fixed: 21→22, "1 scaffold"→"2 scaffold", table row `json`→`JSON · Lua` |
| 6 | `README.md` ~L158: "319 CLI flags" | `grep add_argument tree_sitter_analyzer/cli/argument_groups/` = **318** total across 8 files | Fixed: 319→318 |
| 7 | `AGENTS.md` L20: `--session-timeout=600 --timeout=180`; L129: `--maxfail=200 + --session-timeout=600` | `pytest.ini` addopts: `--session-timeout=900 --timeout=30`; no `--maxfail` present | Fixed: both occurrences updated; `--maxfail=200` reference removed from lesson #8 |

## Test plan

- [ ] No source code changed — doc-only diff
- [ ] Verify `docs/architecture.md` no longer references `CodeAnalyzer`
- [ ] Verify `docs/CODEMAPS/cli.md` entry points table matches `pyproject.toml [project.scripts]`
- [ ] Verify `README.md` troubleshooting `database is locked` row uses `--full-index`
- [ ] Verify `docs/installation.md` does not call `TREE_SITTER_PROJECT_ROOT` optional
- [ ] Verify `README.md` Supported Languages says 22 with 2 scaffold (JSON · Lua)
- [ ] Verify `README.md` says 318 CLI flags
- [ ] Verify `AGENTS.md` session-timeout matches `pytest.ini` (900) and no `--maxfail=200` claim
