### PR TITLE
docs(rfc): land RFC-0018 on develop; index RFC-0018/0019

### DIFF
--- a/rfcs/0018-response-envelope-normalization-and-adaptive-toon.md
+++ b/rfcs/0018-response-envelope-normalization-and-adaptive-toon.md
@@ -100,11 +100,18 @@ too — it is payload hygiene, not a format problem. **Correction (review):** th
 2. **Add a `ToonDecoder`.** New module `formatters/toon_decoder.py` implementing
    `decode_toon(text) -> dict|list`, spec-conformant, including array-table
    header+rows. Sparse/union rows (`[{a,b},{a}]`) must round-trip unambiguously —
-   define the missing-cell encoding explicitly (emit explicit `null`, not an
-   empty trailing cell) so absent ≠ `""` ≠ `0`.
+   define the missing-cell encoding explicitly with a representation that is
+   **distinct from `null`** (e.g. a truly-empty cell reserved for "absent",
+   with `null`, `""` and `0` each encoded distinguishably) so absent ≠ `null`
+   ≠ `""` ≠ `0` — otherwise the round-trip oracle cannot hold for inputs like
+   `[{"a": null}, {}]` (Codex review, #1136).
 3. **Round-trip oracle (correctness, not cost).**
    `assert decode_toon(format_as_toon(x)) == x` over a corpus covering scalars,
-   nested objects, uniform arrays, sparse arrays, comma/quote-bearing strings.
+   nested objects, uniform arrays, sparse arrays, comma/quote-bearing strings,
+   **and Windows-style paths** (`C:\\repo\\file.py`): the encoder's
+   `normalize_paths` backslash→slash rewrite is lossy, so raw-wire mode must
+   disable it (or make it opt-in) for the oracle to hold on Windows clients
+   (Codex review, #1136).
 
 ```python
 # formatters/toon_decoder.py  (NEW)
@@ -126,6 +133,14 @@ def _emit(result: dict) -> list[TextContent]:
         return [TextContent(type="text", text=result["toon_content"])]
     return [TextContent(type="text", text=_json_dumps(result))]
 ```
+
+**Boundary-normalization ordering (Codex review, #1136):** `handle_call_tool`
+applies `ensure_canonical_success_envelope` AFTER the tool built
+`toon_content`, so boundary-added contract fields (top-level `summary_line`,
+`agent_summary`) live only in the JSON envelope today. PR 2 MUST regenerate
+`toon_content` after boundary normalization (or move TOON formatting to the
+boundary itself) — emitting the tool's cached pre-normalization blob raw would
+silently drop those contract fields.
 
 **Consumer migration (mandatory, same PR):** ~35 test files + any external client
 call `json.loads(wire)` to read `verdict`/`success`. They must switch to
@@ -229,7 +244,10 @@ rules combined. State current-vs-post-PR2 explicitly anywhere a ratio is quoted.
 ### Wire decision (PM 拍板)
 Ship **raw TOON on the wire as the default** for `output_format="toon"` responses.
 `output_format="json"` is the documented **escape hatch** for any client that cannot
-read TOON. Set `mimeType: "application/toon"` so a non-TOON client gets a *detectable*
+read TOON. Set `mimeType: "text/toon"` — the media type the TOON spec itself
+uses and the one §Motivation already cites; a single consistent value repo-wide
+(Codex review, #1136 flagged the earlier `application/toon` inconsistency) — so
+a non-TOON client gets a *detectable*
 content-type mismatch rather than a silent `json.loads` failure. We do **not** build
 opt-in capability negotiation — the format is already per-call selectable. Residual
 gap (accepted): `output_format=json` is per-call, so a TOON-unaware client's *first*
@@ -284,7 +302,11 @@ dictionary (project_root + command templates re-sent every call).
    corpus incl. sparse arrays (RED today: no decoder exists).
 3. `test_wire_toon_is_raw_document` — emitted `TextContent.text` parses via
    `decode_toon` and is **not** `json.dumps`-wrapped (Part 2).
-4. `test_decision_envelope_single_score` — exactly one score key (RED: 4).
+4. `test_decision_envelope_single_score` — exactly one **canonical** score key.
+   During the mandatory one-release alias-deprecation window the test asserts
+   "one canonical + N explicitly-`_deprecated`-marked aliases"; only after the
+   window closes does it tighten to exactly-one-key (Codex review, #1136 —
+   otherwise the gate contradicts Part 3's own deprecation requirement).
 5. `test_no_empty_guidance_fields` — no `""`/`[]` command fields shipped.
 6. `test_agent_summary_keeps_contract_echoes` — `agent_summary.verdict` and
    `.summary_line` **still present and equal to top level** (guards against

--- a/rfcs/0018-response-envelope-normalization-and-adaptive-toon.md
+++ b/rfcs/0018-response-envelope-normalization-and-adaptive-toon.md
@@ -1,0 +1,323 @@
+# RFC-0018: Correct TOON Wire + Envelope Normalization (the real token win)
+
+- **Status**: accepted (PR 1 partially implemented — scalar quoting + scalar
+  `ToonDecoder` + round-trip oracle landed via #1063; document-level decoder,
+  raw wire (PR 2) and envelope normalization (PR 3) outstanding. Landed on
+  develop 2026-07-02; the README has referenced this file since v1.26.)
+- **Author(s)**: @aisheng.yu (PM) + dogfood investigation 2026-06-18
+- **Created**: 2026-06-18
+- **Last updated**: 2026-06-18 (rev 3 — 10-expert panel rulings folded in: new
+  rules R9 total_count-on-truncation, R10 no-duplicate-arrays/columns, R11 CI
+  token-ratchet; R3 reframed as schema-normalization; R4 methodology bug fixed
+  (semantic denylist) + deprecation window; R7 narrowed; wire decision = raw
+  TOON default + `output_format=json` escape hatch + `mimeType`. rev 2 — review
+  findings; Part B "adaptive selection" DROPPED, encoder-conformance promoted to
+  prerequisite, Part A re-scoped to keep contract echoes)
+- **Tracking issue**: #1058 (PR 1); PR 2/3 tracking TBD
+- **Supersedes**: extends RFC-0012 (toon-json-dedup, implemented). RFC-0012's
+  Phase 1/2 reduced *duplication between* `toon_content` and the top level; this
+  RFC fixes the actual cost sink — TOON is **wrapped wrong** (re-serialized
+  inside `json.dumps(indent=2)`), and our **TOON encoder is not round-trippable**
+  so we cannot safely send it raw yet.
+- **Affected source paths**:
+  - `tree_sitter_analyzer/formatters/_toon_encoder_string_helpers.py` (quoting gap)
+  - `tree_sitter_analyzer/formatters/` (NEW: a TOON decoder + round-trip test)
+  - `tree_sitter_analyzer/mcp/server_utils/tool_registration.py` (the wire: `_json_dumps`)
+  - `tree_sitter_analyzer/mcp/utils/format_helper.py` (TOON wrap)
+  - `tree_sitter_analyzer/mcp/tools/utils/file_health_response.py` + sibling decision tools (payload shape)
+  - `tests/unit/mcp/test_output_cost_invariants.py` (token + round-trip oracles)
+
+## Summary
+
+The MCP server sends a TOON response as `json.dumps({…, toon_content:
+"<TOON text>"}, indent=2)` — pretty-printed JSON containing an *escaped TOON
+string*, paying the JSON envelope **plus** the TOON text. Measured: toon-mode is
+**1.66–1.88× JSON** today; sending the **raw TOON document** would be **~0.76×**
+(a 2.5× swing) — the entire win is in the wire, not the format. But we cannot
+flip the wire yet: our encoder emits scalar-ambiguous strings unquoted
+(`"100.0"`→`100.0`) and there is **no decoder**, so raw TOON is **not
+round-trippable** — promoting it to the authoritative payload would silently
+corrupt string fields. This RFC therefore sequences: **(1) make the encoder
+spec-conformant + add a decoder + round-trip oracle** (prerequisite), **(2) wire
+the raw TOON document** (the win), **(3) normalize the envelope payload**
+(format-independent hygiene, ~90% of a response is redundant) **(4) re-base the
+cost oracle on tokens, not bytes, alongside the round-trip oracle.** The
+`output_format="toon"` default is untouched and TOON stays the wire for every
+tool — **CLAUDE.md §1 LOCK is fully honored, no toon→json output flip.**
+
+> **Dropped in rev 2:** the original "adaptive format selection" (route
+> scalar-heavy payloads to JSON) is **removed** — review measured raw TOON
+> beating JSON on *every* shape (0.56–0.70× even for pure scalar objects), so a
+> JSON fallback only forfeits 30–44% and would re-litigate §1. TOON-always-raw is
+> simpler and strictly better.
+
+## Motivation
+
+Measured on `develop` @ `304db4b4` (2026-06-18), `file_health`, tokens via
+`tiktoken cl100k_base` (the metric that matters — TOON is *Token*-Oriented):
+
+| Wire the server emits | tokens | vs JSON |
+|---|---:|---:|
+| json mode | ~161 | 1.00× |
+| **toon mode (today: `json.dumps(envelope+toon_content)`)** | ~302 | **1.88×** |
+| **raw TOON document (this RFC)** | ~122 | **0.76×** |
+
+Root causes, ranked by blast radius:
+
+**RC-2b (dominant) — TOON is wrapped wrong.** `tool_registration.py:~98` emits
+`TextContent(text=json.dumps(result, indent=2))` where `result.toon_content` is a
+TOON string. The model receives JSON envelope + escaped TOON + indentation —
+both formats paid at once. Fixing only this delivers the full 1.88×→0.76× swing.
+TOON is designed to *be* the wire payload (`text/toon`), not a JSON string field.
+
+**RC-0 (blocking RC-2b) — our TOON is not round-trippable.**
+`_toon_encoder_string_helpers.py:needs_quotes` only quotes on structural chars,
+so a string `"100.0"`/`"true"`/`"null"`/`"42"` is emitted bare and a
+spec-compliant decoder reconstructs a float/bool/None/int — **lossy**. There is
+**no TOON decoder in the repo at all** (0 hits for `decode_toon`/`from_toon`), so
+the "lossless" property RFC-0012 and the spec assume is **unimplemented and
+untested**. Until this is fixed, raw TOON on the wire silently corrupts any
+string field that looks numeric/boolean (versions, grades like `"100.0"`, ids).
+
+**RC-1 (independent, format-agnostic) — the payload is ~90% redundant.**
+`file_health` (1406 B JSON, 21 fields) carries the file path 4× (20% of the
+response), `line_count == lines`, an `agent_next_action` block shipping
+`mcp_command:""`/`cli_command:""`/`post_edit_commands:[]`, and four identical
+score keys. The genuinely-unique signal is ~80–120 B. This is true in JSON mode
+too — it is payload hygiene, not a format problem. **Correction (review):** the
+*test-pinned* costly field is `summary_line` (48 test files), `health_score`
+(13), `agent_next_action` shape (25) — **not** the score aliases
+`total_score`/`overall_score` (0 test pins). RC-1's fix must target the former.
+
+## Detailed design
+
+### Part 1 (PREREQUISITE) — make TOON round-trippable
+
+1. **Quote scalar-ambiguous strings.** Extend `needs_quotes` to also quote any
+   string that would otherwise parse as a TOON number / `true` / `false` /
+   `null` (per spec v3.2 §scalars). Add fixtures: `"100.0"`, `"true"`, `"null"`,
+   `"42"`, `"1e5"`, `"-3"` must survive round-trip as strings.
+2. **Add a `ToonDecoder`.** New module `formatters/toon_decoder.py` implementing
+   `decode_toon(text) -> dict|list`, spec-conformant, including array-table
+   header+rows. Sparse/union rows (`[{a,b},{a}]`) must round-trip unambiguously —
+   define the missing-cell encoding explicitly (emit explicit `null`, not an
+   empty trailing cell) so absent ≠ `""` ≠ `0`.
+3. **Round-trip oracle (correctness, not cost).**
+   `assert decode_toon(format_as_toon(x)) == x` over a corpus covering scalars,
+   nested objects, uniform arrays, sparse arrays, comma/quote-bearing strings.
+
+```python
+# formatters/toon_decoder.py  (NEW)
+def decode_toon(text: str) -> dict | list:
+    """Parse a TOON document back to the JSON data model. Inverse of
+    format_as_toon. MUST satisfy decode_toon(format_as_toon(x)) == x."""
+```
+
+### Part 2 (THE WIN) — wire the raw TOON document
+
+Gated behind Part 1. When the response is TOON, `TextContent.text` **is** the
+TOON document; verdict/success live as TOON keys at the top, so no JSON envelope
+is needed.
+
+```python
+# tool_registration.py
+def _emit(result: dict) -> list[TextContent]:
+    if result.get("format") == "toon" and "toon_content" in result:
+        return [TextContent(type="text", text=result["toon_content"])]
+    return [TextContent(type="text", text=_json_dumps(result))]
+```
+
+**Consumer migration (mandatory, same PR):** ~35 test files + any external client
+call `json.loads(wire)` to read `verdict`/`success`. They must switch to
+`decode_toon` (now available from Part 1) or the server must offer a
+`output_format="json"` opt-out path that those callers use. The
+`docs/agent-envelope-contract.md` canonical example updates to show the TOON
+document. Error envelopes (`success=False`) stay JSON — small, scalar, must be
+maximally parseable.
+
+### Part 3 (INDEPENDENT) — envelope payload normalization (format-agnostic)
+
+Applies on **both** CLI(JSON) and MCP surfaces; shrinks both. **Re-scoped after
+review** — only the genuinely-redundant fields, NOT the contract echoes:
+
+- **DO collapse** the 4 identical score keys → `score` (verified identical by
+  construction: `file_health_response.py:141-144`, `project_health_tool.py:388`).
+  Keep aliases for **one deprecation release** (re-opens the r37f7-U4 "agent read
+  None" incident otherwise).
+- **DO omit** empty `agent_next_action` command fields (no consumer pins the
+  empty shape; aligns with Issue #446 intent).
+- **DO drop** only `agent_summary.grade` / `agent_summary.score` (0 test pins).
+- **DO NOT touch** `agent_summary.verdict` and `agent_summary.summary_line` —
+  **these are enforced contracts**, not redundancy: the r37u cross-tool
+  invariant (`_AGENT_SUMMARY_KEYS = {"summary_line","verdict"}`, 10+ test files)
+  and Issue #446 deliberately make `agent_summary` the canonical dual-read home.
+  Their value being identical to the top level is the *point* — it guarantees an
+  agent can branch from either location. Dropping them = the exact "agent info
+  not transmitted" failure this RFC must avoid.
+- **DO NOT collapse** the `file` ↔ `file_path` dual-key in `project_health`
+  (documented cross-tool compat vocabulary, `project_health_tool.py:378`).
+- **Path-once** applies only to *raw repetition* (e.g. emit the path at top level
+  and let `summary_line`/`verification_command` be the only other carriers).
+
+### Error handling / concurrency
+
+Unchanged from today except the wire branch (Part 2). All new helpers return new
+dicts (no mutation, per coding-style immutability rule).
+
+## Three-Surface impact (CLI <-> MCP parity)
+
+- MCP default stays `toon`; CLI default stays `json` (§1 intentional asymmetry,
+  unchanged). **No toon→json output flip anywhere** — Part B (which would have
+  caused one) is dropped.
+- Part 3 changes both surfaces identically (same fields, one copy each) → parity
+  preserved. The existing parity test `test_n7_file_health_smell_parity.py` must
+  stay green and is named as an acceptance gate.
+- Part 2 (raw wire) is MCP-only.
+
+## Drawbacks
+
+- **Encoder/decoder work is real** (Part 1) and must land before any wire change
+  — but it also fixes a latent correctness bug (type-lossy TOON) that exists
+  today regardless of this RFC.
+- **Consumer contract churn** (Part 2): ~35 `json.loads(wire)` call sites +
+  `agent-envelope-contract.md` migrate in lockstep. High blast radius — gated,
+  announced, version-noted.
+- **Re-baseline surface (corrected):** ~155 envelope-pinning test files + 44 JSON
+  goldens + 18 TOON goldens — larger and differently shaped than RFC-0012's "62".
+  Part 3 hits the JSON goldens + unit pins; Part 2 hits the TOON goldens.
+- **Score-alias removal** reverses the deliberate r37f7-U4 alias decision →
+  one-release deprecation window is mandatory, not optional.
+
+## Alternatives
+
+- **Alt A — Reword the README only** (drop the false "0.52× on decision tools",
+  keep "50-70% on bulk/tabular"). Ships *now* as a stopgap (separate issue),
+  but concedes the loss instead of fixing it. Not the primary fix.
+- **Alt B — Adaptive format selection (route scalar payloads to JSON).**
+  **REJECTED by review:** raw TOON beats JSON on every measured shape
+  (0.56–0.70×), so a JSON branch forfeits 30–44% and re-litigates §1. Removed.
+- **Alt C — Keep a thin JSON header + inline TOON only for bulk bodies.** A
+  middle path if full raw-TOON migration of the 35 call sites is judged too
+  risky for one release. Preserves `json.loads(wire)` for the header. Listed as
+  the fallback if Part 2's migration proves too large to land atomically.
+- **Alt D — Drop TOON entirely.** Violates §1; throws away the genuine
+  array/tabular win. Rejected.
+
+## Prior art
+
+- **TOON spec v3.2** (`toon-format/spec`, `toonformat.dev`): TOON is the wire
+  format (`text/toon`), lossless to JSON, requires quoting scalar-ambiguous
+  strings (the gap Part 1 fixes); 39.9% fewer tokens on mixed data. Reference
+  decoders exist in TS/Python (`xaviviro/python-toon`) — Part 1 can port rather
+  than invent.
+- **RFC-0012**: established decision tools have no bulk arrays to strip; this RFC
+  concludes the fix is the wire + payload hygiene, not more denylist tuning.
+
+## Rev 3 — 10-expert panel rulings (PM 拍板, 2026-06-18)
+
+A 10-expert panel (LLM context-engineering, serialization-format design, API/schema,
+MCP protocol, DX, information theory, columnar/query-result, SRE/contract-stability,
+agent-orchestration, measurement-rigor) stress-tested the design on the real 25-tool
+capture. Convergent findings forced these rulings.
+
+### Measurement correction (read first)
+All `_stats.json` ratios are **post-PR2 hypothetical** — the *current* wire is
+**~1.81× JSON** (json.dumps envelope + escaped toon_content), not 0.79×. The wire
+fix (PR2) alone saves ~847k tokens per full-tool sweep — larger than all payload
+rules combined. State current-vs-post-PR2 explicitly anywhere a ratio is quoted.
+
+### Wire decision (PM 拍板)
+Ship **raw TOON on the wire as the default** for `output_format="toon"` responses.
+`output_format="json"` is the documented **escape hatch** for any client that cannot
+read TOON. Set `mimeType: "application/toon"` so a non-TOON client gets a *detectable*
+content-type mismatch rather than a silent `json.loads` failure. We do **not** build
+opt-in capability negotiation — the format is already per-call selectable. Residual
+gap (accepted): `output_format=json` is per-call, so a TOON-unaware client's *first*
+call still gets TOON; this is acceptable given TSA's TOON-first positioning. §1 default
+literal untouched.
+
+### Rule rulings
+| Rule | Ruling | Key change from panel |
+|---|---|---|
+| R1 cap+paginate | MODIFY | **per-tool** caps (token-budget-derived, not global 50); **keyset cursor** not offset (SQLite OFFSET is O(n²)); mandatory `sort_by` |
+| R2 sitemap reshape | ADOPT | highest-certainty win (47,722 tok, frequency-independent); use **file-index** in flattened records; **keep trees as trees** (don't flatten call-trees) |
+| R3 repeated strings | REFRAME → **schema normalization** | not string-dedup (4 of 8 `edit.safe` copies are prose-wrapped, exact-match misses them). Collapse 8 command fields → 2 structured (`verification_command` + `run_verification:{pre,post,queue}`). ~720 tok (42% of edit.safe), no encoder/decoder dep, **standalone PR** |
+| R4 canonical key | MODIFY | **methodology bug fixed**: dup-detector matched on value, falsely grouped `success==truncated==True`. Semantic **denylist** (never merge success/truncated/verdict). Only merge true synonyms. **Mandatory dual-emit deprecation window** + `_deprecated` field + instrument live alias access before drop (blast radius: 104 test files / 1142 assertion lines) |
+| R5 agent_summary slim | ADOPT | strip non-locked echoes only |
+| R6 keep scalar dicts | ADOPT | unanimous (EAV anti-pattern) |
+| R7 drop empty/derivable | NARROW | drop **empty + zero-info echoes only**. **KEEP** `binary` (agent pre-filter), `non_source_match_count` (source-vs-test caller split), `top_directories` (scoping histogram), `data_source` (edge provenance). Per-field consumer check before any drop |
+| R8 locked contract | ADOPT unchanged | locked echoes stay; panel's "single authoritative location" rejected |
+
+### New rules adopted
+- **R9 — truncation completeness (correctness, not cosmetics):** any response with
+  `truncated=true` MUST carry a top-level `total_count: int` (and `sort_by`). Without
+  it an agent refactoring on "50 of unknown" ships broken work. Tree tools expose
+  `total_node_count` + `truncated_at_depth`.
+- **R10 — no duplicate top-level arrays / columns:** `nav.trace` ships `usages` AND
+  `results` as *identical* arrays (46.7% of the response) and `file==file_path`,
+  `line==line_number` columns inside them. R4 (scalar aliases) misses these.
+- **R11 — CI token ratchet (anti-regression keystone):** for every tool, two assertions
+  in `test_output_cost_invariants.py`: (a) `toon_tokens < json_tokens` (the disjoint
+  invariant — currently RED for sitemap), (b) `ratio <= PINNED_RATIOS[tool]` (a ratchet;
+  re-pin only via a conscious commit with measurement date). This is the §11
+  belief→executable-invariant fix. Also: round-trip oracle asserts **types** decode
+  correctly (`line`→int, `success`→bool), not just bytes.
+
+### Deferred to a future RFC (logged, not in scope)
+caller-driven projection (`fields=`/`verbosity=` param), verdict `status`/`action`
+split (the enum conflates outcome with directive), cross-response/session template
+dictionary (project_root + command templates re-sent every call).
+
+### Revised sequencing
+- **PR3a (standalone, highest ROI, zero wire/encoder dependency):** R3 `edit.safe`
+  command collapse + R2 sitemap reshape + R10 dup-array/column removal + R9 total_count
+  contract. Pure payload — ship first.
+- **PR3b (high risk, needs deprecation window):** R4 alias collapse (dual-emit +
+  instrumentation) + R5/R7 slimming.
+- PR1/PR2 as before; R11 ratchet spans all PRs.
+
+## Test plan (RED-first)
+
+1. `test_toon_roundtrip_scalars` — `"100.0"`/`"true"`/`"null"`/`"42"` survive as
+   strings (RED today: decode to non-string types). **Correctness gate for Part 1.**
+2. `test_toon_roundtrip_corpus` — `decode_toon(format_as_toon(x)) == x` over the
+   corpus incl. sparse arrays (RED today: no decoder exists).
+3. `test_wire_toon_is_raw_document` — emitted `TextContent.text` parses via
+   `decode_toon` and is **not** `json.dumps`-wrapped (Part 2).
+4. `test_decision_envelope_single_score` — exactly one score key (RED: 4).
+5. `test_no_empty_guidance_fields` — no `""`/`[]` command fields shipped.
+6. `test_agent_summary_keeps_contract_echoes` — `agent_summary.verdict` and
+   `.summary_line` **still present and equal to top level** (guards against
+   over-aggressive normalization — protects "agent info transmitted").
+7. **Token cost oracle** (replaces perma-xfail): measure **tokens of the emitted
+   wire** via tiktoken; assert `tokens(toon_wire) < tokens(json_wire)` for
+   decision tools (relationship form, per the §0 documented exception) → flips
+   the strict-xfail to enforced pass. **No `<= 0.6×` ceiling** (hand-waved bound
+   violates the exact-assertion LOCK; use a `<` relationship, or an exact re-pin).
+
+## Acceptance criteria
+
+- [ ] Part 1: `needs_quotes` quotes scalar-ambiguous strings; `ToonDecoder`
+      lands; tests 1-2 (round-trip) green. **Prerequisite — merges first.**
+- [ ] Part 2: raw-TOON wire; ~35 `json.loads(wire)` consumers migrated to
+      `decode_toon` (same PR); `agent-envelope-contract.md` updated; test 3 green.
+- [ ] Part 3: score collapse (+ 1-release alias deprecation), empty-guidance
+      omitted, `agent_summary.grade/score` dropped; tests 4-6 green; contract
+      echoes preserved.
+- [ ] Part 4: token cost oracle re-based; strict-xfail flipped to enforced pass;
+      round-trip oracle in CI.
+- [ ] Goldens re-baselined (44 JSON + 18 TOON) in dedicated commits per PR.
+- [ ] `test_n7_file_health_smell_parity` stays green (CLI↔MCP parity gate).
+- [ ] README "Why TSA" efficiency claim updated to the now-true measured numbers.
+- [ ] Codex review triaged; all P1/P2 resolved.
+
+## Phasing (per review — PRs, not the 4 abstract "Parts")
+
+- **PR 1**: Part 1 (encoder conformance + decoder + round-trip oracle). Self-
+  contained correctness fix; mergeable alone; unblocks everything.
+- **PR 2**: Part 2 + Part 4 (raw wire + token/round-trip oracle + 35-consumer
+  migration + TOON golden rebaseline). Inseparable — the strict-xfail flips to
+  XPASS the moment the wire changes, so the oracle re-base must land together.
+- **PR 3**: Part 3 (envelope normalization + JSON golden rebaseline). Format-
+  independent; can land before or after PR 2; independent of the wire.
+- **PR 0 (stopgap, optional, immediate)**: README reword (Alt A).

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -74,6 +74,8 @@ number; if two RFCs collide on a number in flight, the later-merged one renames.
 | [0015](0015-instant-uml-family.md) | Instant UML family — scoping fixes + activity/state diagrams | implemented (Phase 1 #462; P2-A #472; P2-B #475; v1.23.0) |
 | [0016](0016-semantic-symbol-search.md) | Semantic symbol search via sqlite-vec in `.ast-cache` | rejected (data-driven; pilot NO-GO at deployment scale, #517) |
 | [0017](0017-test-effectiveness-mutation-and-value-invariants.md) | Test effectiveness — mutation scoring, value invariants, outside-the-loop authorship | accepted (owner 2026-06-14; phase 1 = mutation baseline) |
+| [0018](0018-response-envelope-normalization-and-adaptive-toon.md) | Correct TOON wire + envelope normalization — the real token win | accepted (PR 1 scalar quoting + decoder + round-trip oracle #1063; raw wire + envelope normalization outstanding) |
+| [0019](0019-complexity-single-source-of-truth.md) | Cyclomatic complexity — one source of truth | implemented (#1099, #1101, #1102) |
 
 ## Roadmap
 


### PR DESCRIPTION
## Summary

**Fixes a broken README link that has shipped since v1.26.** README.md references `rfcs/0018-response-envelope-normalization-and-adaptive-toon.md` in three places (TOON efficiency note L100, feature table L131, comparison section L243) — but the file only exists on the unmerged `feature/rfc-0018-envelope-normalization-adaptive-toon` branch. Every reader who clicks the link gets a 404.

### Changes
1. **Land the RFC-0018 rev-3 text** (10-expert panel rulings, as reviewed on the feature branch) with an updated Status line that records reality:
   - PR 1 (scalar-ambiguous string quoting + scalar `ToonDecoder` + round-trip oracle) **already shipped** via #1063 / issue #1058 — the code is on develop, the spec wasn't.
   - PR 2 (raw TOON wire) and PR 3 (envelope normalization) remain outstanding; the 12 strict-xfail cost invariants in `test_output_cost_invariants.py` still reference this RFC as their tracking doc.
2. **Index RFC-0018 and RFC-0019** in `rfcs/README.md` — 0019 merged via #1099/#1101/#1102 but was never added to the index table.

Per the CLAUDE.md RFC-process rule this is exactly where the spec should live — the current state (code merged, spec orphaned on a stale branch, README linking to it) is the anti-pattern the rule exists to prevent.

## Testing
- `tests/governance` + `tests/contracts` + `tests/integration/docs`: 84 passed, 5 skipped
- README link-checker sweep: no missing local links after this PR

Docs-only, no code changes.