### PR TITLE
feat(install): add install.sh, --doctor command, and README Quick Start improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ TSA indexes your codebase with tree-sitter and serves correct call graphs, symbo
 
 > **Requires Python 3.10+** (check: `python3 --version`). Install from [python.org](https://www.python.org/downloads/) if needed.
 
+### Automated install (recommended)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/aimasteracc/tree-sitter-analyzer/main/install.sh | bash
+```
+
+`install.sh` checks for `uv`, installs it if missing, detects Claude Desktop / Claude Code / Cursor / VS Code config files, and writes the MCP entry automatically. Run `tree-sitter-analyzer --doctor` to verify your setup afterwards.
+
 One-line install for **Claude Code**:
 
 ```bash
@@ -45,6 +53,9 @@ CLI equivalent (no agent needed): `tree-sitter-analyzer --codegraph-status`
 
 ### Quick install
 
+<details>
+<summary>Prerequisites (manual setup)</summary>
+
 #### 1. Install dependencies
 
 ```bash
@@ -56,6 +67,8 @@ powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | ie
 brew install fd ripgrep                                # macOS
 winget install sharkdp.fd BurntSushi.ripgrep.MSVC      # Windows
 ```
+
+</details>
 
 #### 2. Install Tree-sitter Analyzer
 
@@ -155,7 +168,7 @@ CodeGraph has zero skills. We ship 13 under `.claude/skills/tsa-*/`:
 
 Each skill ships an `allowed-tools` subset + procedure recipe + decision-surface schema, so the agent doesn't have to triage 8 tools on every question.
 
-### 319 CLI flags
+### 321 CLI flags
 
 Superset of CodeGraph's CLI surface. Highlights:
 
@@ -463,10 +476,32 @@ uv run python check_quality.py --new-code-only  # quality gate
 | Symptom | Fix |
 |---|---|
 | `unsupported language` on `.swift / .kt / .rb / .php / .cs` | Update to ≥ 1.12.x — the 5-language gap was patched in commit `50e99a8f`. Grammar modules for extras-gated languages are not bundled in the base install; run `pip install "tree-sitter-analyzer[swift]"` (or `kotlin`, `ruby`, `php`, `csharp`) to add them. |
-| MCP server doesn't appear in client | `TREE_SITTER_PROJECT_ROOT` must be **absolute**; restart the client after config edit. |
+| MCP server doesn't appear in client | `TREE_SITTER_PROJECT_ROOT` must be **absolute**; restart the client after config edit. See [Relative path in TREE_SITTER_PROJECT_ROOT](#relative-path-in-tree_sitter_project_root) below. |
 | `database is locked` | Stop any other process holding `.ast-cache/index.db`; if persistent, `rm -rf .ast-cache && tree-sitter-analyzer --full-index`. |
 | Slow first call | First call builds the index. Subsequent calls are sub-second. Run `--full-index` upfront to amortise. |
 | Agent picks the wrong tool | Use a `tsa-*` skill (`/tsa-graph`, `/tsa-find`, ...) — each skill restricts the visible tool set to one workflow. |
+
+### Relative path in TREE\_SITTER\_PROJECT\_ROOT
+
+**Symptom:** The MCP server starts without errors, but TSA returns wrong analysis results or an error like `project root not found`.
+
+**Root cause:** `TREE_SITTER_PROJECT_ROOT` is set to a relative path (e.g. `./myproject`). When `uvx` launches the server, the process working directory may differ from where you ran the install command, so the relative path resolves to a wrong location.
+
+**Fix:** Always set an absolute path:
+
+```bash
+# Correct
+"TREE_SITTER_PROJECT_ROOT": "/home/user/myproject"
+
+# Also correct (resolved at install time by install.sh)
+"TREE_SITTER_PROJECT_ROOT": "$(pwd)"        # or $(realpath .)
+
+# Wrong
+"TREE_SITTER_PROJECT_ROOT": "./myproject"
+"TREE_SITTER_PROJECT_ROOT": "myproject"
+```
+
+Run `tree-sitter-analyzer --doctor` to verify your configuration.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ TSA indexes your codebase with tree-sitter and serves correct call graphs, symbo
 curl -fsSL https://raw.githubusercontent.com/aimasteracc/tree-sitter-analyzer/main/install.sh | bash
 ```
 
-`install.sh` checks for `uv`, installs it if missing, detects Claude Desktop / Claude Code / Cursor / VS Code config files, and writes the MCP entry automatically. Run `tree-sitter-analyzer --doctor` to verify your setup afterwards.
-
+Auto-installs `uv` if missing, detects Claude Desktop / Claude Code / Cursor / VS Code, and writes the MCP entry. Run `tree-sitter-analyzer --doctor` to verify.
 One-line install for **Claude Code**:
 
 ```bash
@@ -53,9 +52,6 @@ CLI equivalent (no agent needed): `tree-sitter-analyzer --codegraph-status`
 
 ### Quick install
 
-<details>
-<summary>Prerequisites (manual setup)</summary>
-
 #### 1. Install dependencies
 
 ```bash
@@ -67,8 +63,6 @@ powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | ie
 brew install fd ripgrep                                # macOS
 winget install sharkdp.fd BurntSushi.ripgrep.MSVC      # Windows
 ```
-
-</details>
 
 #### 2. Install Tree-sitter Analyzer
 
@@ -476,32 +470,10 @@ uv run python check_quality.py --new-code-only  # quality gate
 | Symptom | Fix |
 |---|---|
 | `unsupported language` on `.swift / .kt / .rb / .php / .cs` | Update to ≥ 1.12.x — the 5-language gap was patched in commit `50e99a8f`. Grammar modules for extras-gated languages are not bundled in the base install; run `pip install "tree-sitter-analyzer[swift]"` (or `kotlin`, `ruby`, `php`, `csharp`) to add them. |
-| MCP server doesn't appear in client | `TREE_SITTER_PROJECT_ROOT` must be **absolute**; restart the client after config edit. See [Relative path in TREE_SITTER_PROJECT_ROOT](#relative-path-in-tree_sitter_project_root) below. |
+| MCP server doesn't appear in client | `TREE_SITTER_PROJECT_ROOT` must be an **absolute path** (e.g. `$(pwd)` or `/home/user/project`); a relative path causes the server to resolve against the wrong directory. Restart the client after editing. Run `tree-sitter-analyzer --doctor` to verify. |
 | `database is locked` | Stop any other process holding `.ast-cache/index.db`; if persistent, `rm -rf .ast-cache && tree-sitter-analyzer --full-index`. |
 | Slow first call | First call builds the index. Subsequent calls are sub-second. Run `--full-index` upfront to amortise. |
 | Agent picks the wrong tool | Use a `tsa-*` skill (`/tsa-graph`, `/tsa-find`, ...) — each skill restricts the visible tool set to one workflow. |
-
-### Relative path in TREE\_SITTER\_PROJECT\_ROOT
-
-**Symptom:** The MCP server starts without errors, but TSA returns wrong analysis results or an error like `project root not found`.
-
-**Root cause:** `TREE_SITTER_PROJECT_ROOT` is set to a relative path (e.g. `./myproject`). When `uvx` launches the server, the process working directory may differ from where you ran the install command, so the relative path resolves to a wrong location.
-
-**Fix:** Always set an absolute path:
-
-```bash
-# Correct
-"TREE_SITTER_PROJECT_ROOT": "/home/user/myproject"
-
-# Also correct (resolved at install time by install.sh)
-"TREE_SITTER_PROJECT_ROOT": "$(pwd)"        # or $(realpath .)
-
-# Wrong
-"TREE_SITTER_PROJECT_ROOT": "./myproject"
-"TREE_SITTER_PROJECT_ROOT": "myproject"
-```
-
-Run `tree-sitter-analyzer --doctor` to verify your configuration.
 
 ---
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -23,6 +23,14 @@ TSA は tree-sitter でコードベースをインデックスし、正確なコ
 
 > **Python 3.10 以上が必要です**（確認: `python3 --version`）。必要に応じて [python.org](https://www.python.org/downloads/) からインストールしてください。
 
+### 自動インストール（推奨）
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/aimasteracc/tree-sitter-analyzer/main/install.sh | bash
+```
+
+`install.sh` は `uv` の有無を確認して未インストールなら自動導入し、Claude Desktop / Claude Code / Cursor / VS Code の設定ファイルを検出して MCP エントリを自動書き込みします。セットアップ後は `tree-sitter-analyzer --doctor` で設定を確認できます。
+
 **Claude Code** へワンライナーでインストール:
 
 ```bash
@@ -43,6 +51,9 @@ claude mcp add tree-sitter-analyzer \
 
 ### クイック インストール
 
+<details>
+<summary>Prerequisites（手動セットアップ）</summary>
+
 #### 1. 依存関係をインストール
 
 ```bash
@@ -54,6 +65,8 @@ powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | ie
 brew install fd ripgrep                                # macOS
 winget install sharkdp.fd BurntSushi.ripgrep.MSVC      # Windows
 ```
+
+</details>
 
 #### 2. Tree-sitter Analyzer をインストール
 
@@ -152,7 +165,7 @@ CodeGraph には skill システムが存在しない。本ツールは `.claude
 
 各 skill は `allowed-tools` ツール サブセット + 手順レシピ + 決定面スキーマを同梱し、エージェントは 8 個のツールから毎回選別する必要が無い。
 
-### 319 の CLI フラグ
+### 321 の CLI フラグ
 
 CodeGraph の CLI の厳密な上位互換。主なもの:
 
@@ -405,10 +418,32 @@ uv run python check_quality.py --new-code-only  # 品質ゲート
 | 症状 | 修正 |
 |---|---|
 | `.swift / .kt / .rb / .php / .cs` で `unsupported language` | ≥ 1.12.x へ更新 — 5 言語 gap は commit `50e99a8f` で修正済み。extras 区分の文法モジュールはベースインストールに同梱されません。`pip install "tree-sitter-analyzer[swift]"`(または `kotlin`、`ruby`、`php`、`csharp`)で追加してください |
-| MCP サーバーがクライアントに表示されない | `TREE_SITTER_PROJECT_ROOT` は**絶対パス**必須; 設定編集後にクライアント再起動 |
+| MCP サーバーがクライアントに表示されない | `TREE_SITTER_PROJECT_ROOT` は**絶対パス**必須; 設定編集後にクライアント再起動。[TREE\_SITTER\_PROJECT\_ROOT に相対パスを指定した場合](#tree_sitter_project_root-に相対パスを指定した場合)も参照 |
 | `database is locked` | `.ast-cache/index.db` を保持する他プロセスを停止; 継続する場合は `rm -rf .ast-cache && tree-sitter-analyzer --autoindex` |
 | 初回呼び出しが遅い | 初回はインデックスを構築。後続はサブ秒。事前に `--full-index` を実行すれば償却可能 |
 | エージェントが誤ったツールを選ぶ | `tsa-*` skill (`/tsa-graph`、`/tsa-find` 等) を使用 — 各 skill は可視ツールを 1 ワークフローに制限 |
+
+### TREE\_SITTER\_PROJECT\_ROOT に相対パスを指定した場合
+
+**症状:** MCP サーバーはエラーなく起動するが、TSA が誤った解析結果を返すか `project root not found` のようなエラーが発生する。
+
+**原因:** `TREE_SITTER_PROJECT_ROOT` に相対パス（例: `./myproject`）が設定されている。`uvx` がサーバーを起動するとき、プロセスの作業ディレクトリがインストール実行時と異なる場合があり、相対パスが誤った場所に解決される。
+
+**修正:** 常に絶対パスを使用する:
+
+```bash
+# 正しい
+"TREE_SITTER_PROJECT_ROOT": "/home/user/myproject"
+
+# これも正しい（install.sh が実行時に解決する）
+"TREE_SITTER_PROJECT_ROOT": "$(pwd)"        # または $(realpath .)
+
+# 誤り
+"TREE_SITTER_PROJECT_ROOT": "./myproject"
+"TREE_SITTER_PROJECT_ROOT": "myproject"
+```
+
+`tree-sitter-analyzer --doctor` で設定を確認できます。
 
 ---
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -51,9 +51,6 @@ claude mcp add tree-sitter-analyzer \
 
 ### クイック インストール
 
-<details>
-<summary>Prerequisites（手動セットアップ）</summary>
-
 #### 1. 依存関係をインストール
 
 ```bash
@@ -65,8 +62,6 @@ powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | ie
 brew install fd ripgrep                                # macOS
 winget install sharkdp.fd BurntSushi.ripgrep.MSVC      # Windows
 ```
-
-</details>
 
 #### 2. Tree-sitter Analyzer をインストール
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -51,9 +51,6 @@ claude mcp add tree-sitter-analyzer \
 
 ### 快速安装
 
-<details>
-<summary>Prerequisites（手动安装依赖）</summary>
-
 #### 1. 安装依赖
 
 ```bash
@@ -65,8 +62,6 @@ powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | ie
 brew install fd ripgrep                                # macOS
 winget install sharkdp.fd BurntSushi.ripgrep.MSVC      # Windows
 ```
-
-</details>
 
 #### 2. 安装 Tree-sitter Analyzer
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -23,6 +23,14 @@ TSA 使用 tree-sitter 索引你的代码库，向 AI 编程 agent 提供正确�
 
 > **需要 Python 3.10+**（检查：`python3 --version`）。如需安装请访问 [python.org](https://www.python.org/downloads/)。
 
+### 自动安装（推荐）
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/aimasteracc/tree-sitter-analyzer/main/install.sh | bash
+```
+
+`install.sh` 会检测 `uv` 是否已安装（未安装则自动安装），并自动检测 Claude Desktop / Claude Code / Cursor / VS Code 的配置文件，写入 MCP 配置项。安装完成后可运行 `tree-sitter-analyzer --doctor` 验证配置。
+
 为 **Claude Code** 一行安装：
 
 ```bash
@@ -43,6 +51,9 @@ claude mcp add tree-sitter-analyzer \
 
 ### 快速安装
 
+<details>
+<summary>Prerequisites（手动安装依赖）</summary>
+
 #### 1. 安装依赖
 
 ```bash
@@ -54,6 +65,8 @@ powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | ie
 brew install fd ripgrep                                # macOS
 winget install sharkdp.fd BurntSushi.ripgrep.MSVC      # Windows
 ```
+
+</details>
 
 #### 2. 安装 Tree-sitter Analyzer
 
@@ -152,7 +165,7 @@ CodeGraph 没有 skill 系统。我们在 `.claude/skills/tsa-*/` 下提供 13 �
 
 每个 skill 都带 `allowed-tools` 工具子集 + 操作流程 + 决策面 schema，agent 不必在 8 个工具间反复挑选。
 
-### 319 个 CLI flag
+### 321 个 CLI flag
 
 CodeGraph CLI 的严格超集。亮点：
 
@@ -407,10 +420,32 @@ uv run python check_quality.py --new-code-only  # 质量闸门
 | 症状 | 修复 |
 |---|---|
 | `.swift / .kt / .rb / .php / .cs` 显示 `unsupported language` | 升级到 ≥ 1.12.x — 5 语言 gap 已在 commit `50e99a8f` 中修复。extras 门控语言的语法模块不随基础安装捆绑;运行 `pip install "tree-sitter-analyzer[swift]"`(或 `kotlin`、`ruby`、`php`、`csharp`)补装 |
-| MCP 服务在客户端中不出现 | `TREE_SITTER_PROJECT_ROOT` 必须是**绝对路径**；编辑配置后重启客户端 |
+| MCP 服务在客户端中不出现 | `TREE_SITTER_PROJECT_ROOT` 必须是**绝对路径**；编辑配置后重启客户端。另见 [TREE\_SITTER\_PROJECT\_ROOT 使用了相对路径](#tree_sitter_project_root-使用了相对路径) |
 | `database is locked` | 关闭其他占用 `.ast-cache/index.db` 的进程；持续存在则 `rm -rf .ast-cache && tree-sitter-analyzer --autoindex` |
 | 首次调用慢 | 首次调用会建索引。后续亚秒。预先跑 `--full-index` 即可分摊 |
 | Agent 选错工具 | 使用 `tsa-*` skill（`/tsa-graph`、`/tsa-find` 等）— 每个 skill 把可见工具限定到一个工作流 |
+
+### TREE\_SITTER\_PROJECT\_ROOT 使用了相对路径
+
+**症状：** MCP 服务启动时无报错，但 TSA 返回错误的分析结果，或出现类似 `project root not found` 的错误。
+
+**根本原因：** `TREE_SITTER_PROJECT_ROOT` 设置了相对路径（如 `./myproject`）。`uvx` 启动服务时，进程工作目录可能与安装时不同，导致相对路径解析到错误位置。
+
+**修复方法：** 始终使用绝对路径：
+
+```bash
+# 正确
+"TREE_SITTER_PROJECT_ROOT": "/home/user/myproject"
+
+# 也正确（install.sh 在安装时自动解析）
+"TREE_SITTER_PROJECT_ROOT": "$(pwd)"        # 或 $(realpath .)
+
+# 错误
+"TREE_SITTER_PROJECT_ROOT": "./myproject"
+"TREE_SITTER_PROJECT_ROOT": "myproject"
+```
+
+运行 `tree-sitter-analyzer --doctor` 可验证你的配置。
 
 ---
 

--- a/install.sh
+++ b/install.sh
@@ -16,12 +16,12 @@ esac
 WSL_ENV=0
 if [ -f /proc/version ] && grep -qi microsoft /proc/version 2>/dev/null; then
   WSL_ENV=1
-  echo "ℹ️  WSL 環境が検出されました。エージェント自動検出は動作しない場合があります。"
+  echo "ℹ️  WSL detected. Agent auto-detection may not work in all cases."
 fi
 
 # ─── uv check & auto-install ──────────────────────────────────────────────────
 if ! command -v uv >/dev/null 2>&1; then
-  echo "📦 uv が見つかりません。自動インストールします..."
+  echo "📦 uv not found. Installing automatically..."
   curl -LsSf https://astral.sh/uv/install.sh | sh
   # Re-source common profile locations
   if [ -f "$HOME/.cargo/env" ]; then
@@ -30,27 +30,27 @@ if ! command -v uv >/dev/null 2>&1; then
   fi
   export PATH="$HOME/.local/bin:$PATH"
   if ! command -v uv >/dev/null 2>&1; then
-    echo "❌ uv のインストールに失敗しました。手動でインストールしてから再実行してください:"
+    echo "❌ uv installation failed. Please install it manually and re-run:"
     echo "   https://docs.astral.sh/uv/getting-started/installation/"
     exit 1
   fi
-  echo "✅ uv がインストールされました: $(command -v uv)"
+  echo "✅ uv installed: $(command -v uv)"
 else
   echo "✅ uv: $(command -v uv)"
 fi
 
 # ─── fd / ripgrep check (optional, warning only) ──────────────────────────────
 if ! command -v fd >/dev/null 2>&1; then
-  echo "⚠️  fd が見つかりません (text search に必要)。後でインストールしてください:"
+  echo "⚠️  fd not found (required for text search). Install it later:"
   if [ "$(uname -s)" = "Darwin" ]; then
     echo "   brew install fd"
   else
-    echo "   apt install fd-find  # または sudo snap install fd"
+    echo "   apt install fd-find  # or: sudo snap install fd"
   fi
 fi
 
 if ! command -v rg >/dev/null 2>&1; then
-  echo "⚠️  ripgrep (rg) が見つかりません (text search に必要)。後でインストールしてください:"
+  echo "⚠️  ripgrep (rg) not found (required for text search). Install it later:"
   if [ "$(uname -s)" = "Darwin" ]; then
     echo "   brew install ripgrep"
   else
@@ -65,7 +65,7 @@ else
   PROJECT_ROOT=$(pwd)
 fi
 echo ""
-echo "📁 プロジェクトルート: $PROJECT_ROOT"
+echo "📁 Project root: $PROJECT_ROOT"
 
 # ─── Agent config paths ───────────────────────────────────────────────────────
 OS_TYPE="$(uname -s)"
@@ -96,7 +96,7 @@ CONFIGURED_AGENTS=""
 SKIPPED_AGENTS=""
 
 echo ""
-echo "🔍 エージェント設定ファイルを検索中..."
+echo "🔍 Scanning for agent config files..."
 
 # Use printf to interpret \n, then process line by line
 while IFS='|' read -r AGENT_LABEL CONFIG_PATH; do
@@ -106,12 +106,12 @@ while IFS='|' read -r AGENT_LABEL CONFIG_PATH; do
   fi
 
   if [ ! -f "$CONFIG_PATH" ]; then
-    echo "   ⏭️  $AGENT_LABEL: 設定ファイルが見つかりません ($CONFIG_PATH)"
+    echo "   ⏭️  $AGENT_LABEL: config file not found ($CONFIG_PATH)"
     SKIPPED_AGENTS="${SKIPPED_AGENTS}${AGENT_LABEL}\n"
     continue
   fi
 
-  echo "   🔧 $AGENT_LABEL: 設定中..."
+  echo "   🔧 $AGENT_LABEL: configuring..."
 
   # Merge MCP entry using python3
   MERGE_RESULT=$(python3 - "$CONFIG_PATH" "$PROJECT_ROOT" <<'PYEOF'
@@ -155,14 +155,14 @@ PYEOF
   MERGE_EXIT=$?
 
   if [ "$MERGE_EXIT" = "2" ]; then
-    echo "   ❌ $AGENT_LABEL: JSON 解析エラー — スキップします ($CONFIG_PATH)"
+    echo "   ❌ $AGENT_LABEL: JSON parse error — skipping ($CONFIG_PATH)"
     SKIPPED_AGENTS="${SKIPPED_AGENTS}${AGENT_LABEL} (JSON parse error)\n"
   elif [ "$MERGE_EXIT" = "0" ]; then
     BACKUP_PATH="${MERGE_RESULT#OK:}"
-    echo "   ✅ $AGENT_LABEL: 設定完了 (バックアップ: $BACKUP_PATH)"
+    echo "   ✅ $AGENT_LABEL: configured (backup: $BACKUP_PATH)"
     CONFIGURED_AGENTS="${CONFIGURED_AGENTS}${AGENT_LABEL}\n"
   else
-    echo "   ❌ $AGENT_LABEL: 予期しないエラー (exit $MERGE_EXIT) — スキップします"
+    echo "   ❌ $AGENT_LABEL: unexpected error (exit $MERGE_EXIT) — skipping"
     SKIPPED_AGENTS="${SKIPPED_AGENTS}${AGENT_LABEL} (error)\n"
   fi
 
@@ -173,14 +173,14 @@ EOF
 # ─── Summary ──────────────────────────────────────────────────────────────────
 echo ""
 echo "═══════════════════════════════════════════════════════"
-echo "🎉 Tree-sitter Analyzer インストール完了"
+echo "🎉 Tree-sitter Analyzer installation complete"
 echo "═══════════════════════════════════════════════════════"
 echo ""
-echo "📌 プロジェクトルート: $PROJECT_ROOT"
+echo "📌 Project root: $PROJECT_ROOT"
 echo ""
 
 if [ -n "$CONFIGURED_AGENTS" ]; then
-  echo "✅ 設定済みエージェント:"
+  echo "✅ Configured agents:"
   printf "$CONFIGURED_AGENTS" | while IFS= read -r agent; do
     [ -n "$agent" ] && echo "   • $agent"
   done
@@ -188,20 +188,20 @@ if [ -n "$CONFIGURED_AGENTS" ]; then
 fi
 
 if [ -n "$SKIPPED_AGENTS" ]; then
-  echo "⏭️  スキップされたエージェント (設定ファイルなし):"
+  echo "⏭️  Skipped agents (config file not found):"
   printf "$SKIPPED_AGENTS" | while IFS= read -r agent; do
     [ -n "$agent" ] && echo "   • $agent"
   done
   echo ""
 fi
 
-echo "📋 次のステップ:"
-echo "   1. エージェント (Claude Code / Claude Desktop / Cursor / VS Code) を再起動してください"
-echo "   2. エージェントに「Run the index tool with action=status」と入力してください"
-echo "   3. 問題が発生した場合: tree-sitter-analyzer --doctor"
+echo "📋 Next steps:"
+echo "   1. Restart your agent (Claude Code / Claude Desktop / Cursor / VS Code)"
+echo "   2. Ask your agent: \"Run the index tool with action=status\""
+echo "   3. If something looks wrong: tree-sitter-analyzer --doctor"
 echo ""
 
 if [ "$WSL_ENV" = "1" ]; then
-  echo "⚠️  WSL 環境: エージェント設定が正しく反映されない場合は、"
-  echo "   Windows 側の設定ファイルを手動で確認してください。"
+  echo "⚠️  WSL environment: if agent config is not picked up, check the"
+  echo "   Windows-side config file manually."
 fi

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# install.sh — Tree-sitter Analyzer one-command installer
+# Supports: macOS / Linux. Windows PowerShell: use install.ps1 (coming soon).
+# bash 3.x compatible (no declare -A, no ${var,,}, no mapfile)
+set -euo pipefail
+
+# ─── Windows MSYS2/MINGW guard ────────────────────────────────────────────────
+case "$(uname -s)" in
+  MINGW* | MSYS*)
+    echo "Windows PowerShell: use install.ps1 (coming soon)"
+    exit 0
+    ;;
+esac
+
+# ─── WSL detection ────────────────────────────────────────────────────────────
+WSL_ENV=0
+if [ -f /proc/version ] && grep -qi microsoft /proc/version 2>/dev/null; then
+  WSL_ENV=1
+  echo "ℹ️  WSL 環境が検出されました。エージェント自動検出は動作しない場合があります。"
+fi
+
+# ─── uv check & auto-install ──────────────────────────────────────────────────
+if ! command -v uv >/dev/null 2>&1; then
+  echo "📦 uv が見つかりません。自動インストールします..."
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  # Re-source common profile locations
+  if [ -f "$HOME/.cargo/env" ]; then
+    # shellcheck disable=SC1091
+    . "$HOME/.cargo/env"
+  fi
+  export PATH="$HOME/.local/bin:$PATH"
+  if ! command -v uv >/dev/null 2>&1; then
+    echo "❌ uv のインストールに失敗しました。手動でインストールしてから再実行してください:"
+    echo "   https://docs.astral.sh/uv/getting-started/installation/"
+    exit 1
+  fi
+  echo "✅ uv がインストールされました: $(command -v uv)"
+else
+  echo "✅ uv: $(command -v uv)"
+fi
+
+# ─── fd / ripgrep check (optional, warning only) ──────────────────────────────
+if ! command -v fd >/dev/null 2>&1; then
+  echo "⚠️  fd が見つかりません (text search に必要)。後でインストールしてください:"
+  if [ "$(uname -s)" = "Darwin" ]; then
+    echo "   brew install fd"
+  else
+    echo "   apt install fd-find  # または sudo snap install fd"
+  fi
+fi
+
+if ! command -v rg >/dev/null 2>&1; then
+  echo "⚠️  ripgrep (rg) が見つかりません (text search に必要)。後でインストールしてください:"
+  if [ "$(uname -s)" = "Darwin" ]; then
+    echo "   brew install ripgrep"
+  else
+    echo "   apt install ripgrep"
+  fi
+fi
+
+# ─── Resolve absolute project root ────────────────────────────────────────────
+if command -v realpath >/dev/null 2>&1; then
+  PROJECT_ROOT=$(realpath .)
+else
+  PROJECT_ROOT=$(pwd)
+fi
+echo ""
+echo "📁 プロジェクトルート: $PROJECT_ROOT"
+
+# ─── Agent config paths ───────────────────────────────────────────────────────
+OS_TYPE="$(uname -s)"
+
+# Build list of (label, path) pairs using positional variables (bash 3.x compatible)
+# Format: "label|path" — process with IFS='|'
+
+AGENT_CONFIG_ENTRIES=""
+
+if [ "$OS_TYPE" = "Darwin" ]; then
+  AGENT_CONFIG_ENTRIES="${AGENT_CONFIG_ENTRIES}Claude Desktop (macOS)|$HOME/Library/Application Support/Claude/claude_desktop_config.json\n"
+else
+  AGENT_CONFIG_ENTRIES="${AGENT_CONFIG_ENTRIES}Claude Desktop (Linux)|$HOME/.config/claude/claude_desktop_config.json\n"
+fi
+
+AGENT_CONFIG_ENTRIES="${AGENT_CONFIG_ENTRIES}Claude Code (global)|$HOME/.claude/.mcp.json\n"
+AGENT_CONFIG_ENTRIES="${AGENT_CONFIG_ENTRIES}Claude Code (project-local)|$(pwd)/.claude/.mcp.json\n"
+AGENT_CONFIG_ENTRIES="${AGENT_CONFIG_ENTRIES}Cursor|$HOME/.cursor/mcp.json\n"
+
+if [ "$OS_TYPE" = "Darwin" ]; then
+  AGENT_CONFIG_ENTRIES="${AGENT_CONFIG_ENTRIES}VS Code (macOS)|$HOME/Library/Application Support/Code/User/mcp.json\n"
+else
+  AGENT_CONFIG_ENTRIES="${AGENT_CONFIG_ENTRIES}VS Code (Linux)|$HOME/.config/Code/User/mcp.json\n"
+fi
+
+# ─── Process each agent config ────────────────────────────────────────────────
+CONFIGURED_AGENTS=""
+SKIPPED_AGENTS=""
+
+echo ""
+echo "🔍 エージェント設定ファイルを検索中..."
+
+# Use printf to interpret \n, then process line by line
+while IFS='|' read -r AGENT_LABEL CONFIG_PATH; do
+  # Skip empty lines
+  if [ -z "$AGENT_LABEL" ]; then
+    continue
+  fi
+
+  if [ ! -f "$CONFIG_PATH" ]; then
+    echo "   ⏭️  $AGENT_LABEL: 設定ファイルが見つかりません ($CONFIG_PATH)"
+    SKIPPED_AGENTS="${SKIPPED_AGENTS}${AGENT_LABEL}\n"
+    continue
+  fi
+
+  echo "   🔧 $AGENT_LABEL: 設定中..."
+
+  # Merge MCP entry using python3
+  MERGE_RESULT=$(python3 - "$CONFIG_PATH" "$PROJECT_ROOT" <<'PYEOF'
+import sys, json, shutil, os
+
+config_path = sys.argv[1]
+project_root = sys.argv[2]
+
+# Create backup with timestamp
+import datetime
+timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+backup_path = config_path + ".bak." + timestamp
+shutil.copy2(config_path, backup_path)
+
+# Parse existing JSON
+try:
+    with open(config_path, encoding="utf-8") as f:
+        data = json.load(f)
+except json.JSONDecodeError as e:
+    print(f"PARSE_ERROR:{e}", file=sys.stderr)
+    sys.exit(2)
+
+# Ensure mcpServers key exists
+if "mcpServers" not in data:
+    data["mcpServers"] = {}
+
+# Merge TSA entry (preserves existing entries)
+data["mcpServers"]["tree-sitter-analyzer"] = {
+    "command": "uvx",
+    "args": ["--from", "tree-sitter-analyzer[mcp]", "tree-sitter-analyzer-mcp"],
+    "env": {"TREE_SITTER_PROJECT_ROOT": project_root},
+}
+
+with open(config_path, "w", encoding="utf-8") as f:
+    json.dump(data, f, indent=2, ensure_ascii=False)
+    f.write("\n")
+
+print(f"OK:{backup_path}")
+PYEOF
+  )
+  MERGE_EXIT=$?
+
+  if [ "$MERGE_EXIT" = "2" ]; then
+    echo "   ❌ $AGENT_LABEL: JSON 解析エラー — スキップします ($CONFIG_PATH)"
+    SKIPPED_AGENTS="${SKIPPED_AGENTS}${AGENT_LABEL} (JSON parse error)\n"
+  elif [ "$MERGE_EXIT" = "0" ]; then
+    BACKUP_PATH="${MERGE_RESULT#OK:}"
+    echo "   ✅ $AGENT_LABEL: 設定完了 (バックアップ: $BACKUP_PATH)"
+    CONFIGURED_AGENTS="${CONFIGURED_AGENTS}${AGENT_LABEL}\n"
+  else
+    echo "   ❌ $AGENT_LABEL: 予期しないエラー (exit $MERGE_EXIT) — スキップします"
+    SKIPPED_AGENTS="${SKIPPED_AGENTS}${AGENT_LABEL} (error)\n"
+  fi
+
+done <<EOF
+$(printf "$AGENT_CONFIG_ENTRIES")
+EOF
+
+# ─── Summary ──────────────────────────────────────────────────────────────────
+echo ""
+echo "═══════════════════════════════════════════════════════"
+echo "🎉 Tree-sitter Analyzer インストール完了"
+echo "═══════════════════════════════════════════════════════"
+echo ""
+echo "📌 プロジェクトルート: $PROJECT_ROOT"
+echo ""
+
+if [ -n "$CONFIGURED_AGENTS" ]; then
+  echo "✅ 設定済みエージェント:"
+  printf "$CONFIGURED_AGENTS" | while IFS= read -r agent; do
+    [ -n "$agent" ] && echo "   • $agent"
+  done
+  echo ""
+fi
+
+if [ -n "$SKIPPED_AGENTS" ]; then
+  echo "⏭️  スキップされたエージェント (設定ファイルなし):"
+  printf "$SKIPPED_AGENTS" | while IFS= read -r agent; do
+    [ -n "$agent" ] && echo "   • $agent"
+  done
+  echo ""
+fi
+
+echo "📋 次のステップ:"
+echo "   1. エージェント (Claude Code / Claude Desktop / Cursor / VS Code) を再起動してください"
+echo "   2. エージェントに「Run the index tool with action=status」と入力してください"
+echo "   3. 問題が発生した場合: tree-sitter-analyzer --doctor"
+echo ""
+
+if [ "$WSL_ENV" = "1" ]; then
+  echo "⚠️  WSL 環境: エージェント設定が正しく反映されない場合は、"
+  echo "   Windows 側の設定ファイルを手動で確認してください。"
+fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -306,6 +306,8 @@ all = [
 tree-sitter-analyzer = "tree_sitter_analyzer.cli_main:main"
 # MCP server entry point
 tree-sitter-analyzer-mcp = "tree_sitter_analyzer.mcp.server:main_sync"
+# Doctor / diagnostics entry point
+tree-sitter-analyzer-doctor = "tree_sitter_analyzer.cli_main:main_doctor"
 # Mis-Wire Audit — run-on-your-repo cross-language correctness demo
 miswire-audit = "tree_sitter_analyzer.miswire_audit:main"
 # Legacy aliases for backward compatibility

--- a/tests/unit/cli/test_doctor_command.py
+++ b/tests/unit/cli/test_doctor_command.py
@@ -1,0 +1,430 @@
+"""Tests for --doctor CLI command (installation diagnostics)."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+
+class TestCheckUv:
+    def test_pass_when_uv_found(self) -> None:
+        from tree_sitter_analyzer.cli.commands.doctor import _check_uv
+
+        with patch("shutil.which", return_value="/usr/local/bin/uv"):
+            result = _check_uv()
+        assert result.status == "PASS"
+        assert result.message == "/usr/local/bin/uv"
+
+    def test_fail_when_uv_missing(self) -> None:
+        from tree_sitter_analyzer.cli.commands.doctor import _check_uv
+
+        with patch("shutil.which", return_value=None):
+            result = _check_uv()
+        assert result.status == "FAIL"
+        assert "not found" in result.message
+
+
+class TestCheckUvx:
+    def test_pass_when_uvx_found(self) -> None:
+        from tree_sitter_analyzer.cli.commands.doctor import _check_uvx
+
+        with patch("shutil.which", return_value="/usr/local/bin/uvx"):
+            result = _check_uvx()
+        assert result.status == "PASS"
+
+    def test_warn_when_uvx_missing(self) -> None:
+        from tree_sitter_analyzer.cli.commands.doctor import _check_uvx
+
+        with patch("shutil.which", return_value=None):
+            result = _check_uvx()
+        assert result.status == "WARN"
+        assert "reinstall uv" in result.message
+
+
+class TestCheckFd:
+    def test_pass_when_fd_found(self) -> None:
+        from tree_sitter_analyzer.cli.commands.doctor import _check_fd
+
+        with patch("shutil.which", return_value="/usr/bin/fd"):
+            result = _check_fd()
+        assert result.status == "PASS"
+
+    def test_warn_when_fd_missing(self) -> None:
+        from tree_sitter_analyzer.cli.commands.doctor import _check_fd
+
+        with patch("shutil.which", return_value=None):
+            result = _check_fd()
+        assert result.status == "WARN"
+
+
+class TestCheckRg:
+    def test_pass_when_rg_found(self) -> None:
+        from tree_sitter_analyzer.cli.commands.doctor import _check_rg
+
+        with patch("shutil.which", return_value="/usr/bin/rg"):
+            result = _check_rg()
+        assert result.status == "PASS"
+
+    def test_warn_when_rg_missing(self) -> None:
+        from tree_sitter_analyzer.cli.commands.doctor import _check_rg
+
+        with patch("shutil.which", return_value=None):
+            result = _check_rg()
+        assert result.status == "WARN"
+
+
+class TestCheckProjectRoot:
+    def test_fail_when_env_var_not_set(self) -> None:
+        from tree_sitter_analyzer.cli.commands.doctor import _check_project_root
+
+        with patch.dict(os.environ, {}, clear=True):
+            env = {
+                k: v for k, v in os.environ.items() if k != "TREE_SITTER_PROJECT_ROOT"
+            }
+            with patch.dict(os.environ, env, clear=True):
+                result = _check_project_root()
+        assert result.status == "FAIL"
+        assert "not set" in result.message
+
+    def test_fail_when_relative_path(self) -> None:
+        from tree_sitter_analyzer.cli.commands.doctor import _check_project_root
+
+        with patch.dict(os.environ, {"TREE_SITTER_PROJECT_ROOT": "./relative"}):
+            result = _check_project_root()
+        assert result.status == "FAIL"
+        assert "relative path" in result.message
+
+    def test_fail_when_directory_missing(self, tmp_path: Path) -> None:
+        from tree_sitter_analyzer.cli.commands.doctor import _check_project_root
+
+        nonexistent = str(tmp_path / "does_not_exist")
+        with patch.dict(os.environ, {"TREE_SITTER_PROJECT_ROOT": nonexistent}):
+            result = _check_project_root()
+        assert result.status == "FAIL"
+        assert "does not exist" in result.message
+
+    def test_pass_when_absolute_and_exists(self, tmp_path: Path) -> None:
+        from tree_sitter_analyzer.cli.commands.doctor import _check_project_root
+
+        with patch.dict(os.environ, {"TREE_SITTER_PROJECT_ROOT": str(tmp_path)}):
+            result = _check_project_root()
+        assert result.status == "PASS"
+        assert result.message == str(tmp_path)
+
+
+class TestCheckAgentConfigs:
+    def test_warn_when_no_config_files_exist(self, tmp_path: Path) -> None:
+        from tree_sitter_analyzer.cli.commands.doctor import _check_agent_configs
+
+        fake_paths = [
+            ("Test Agent", str(tmp_path / "nonexistent.json")),
+        ]
+        with patch(
+            "tree_sitter_analyzer.cli.commands.doctor._agent_config_paths",
+            return_value=fake_paths,
+        ):
+            results = _check_agent_configs()
+        assert len(results) == 1
+        assert results[0].status == "WARN"
+        assert "not found" in results[0].message
+
+    def test_pass_when_tsa_entry_present_and_absolute(self, tmp_path: Path) -> None:
+        from tree_sitter_analyzer.cli.commands.doctor import _check_agent_configs
+
+        config = tmp_path / "mcp.json"
+        config.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "tree-sitter-analyzer": {
+                            "command": "uvx",
+                            "args": [],
+                            "env": {"TREE_SITTER_PROJECT_ROOT": str(tmp_path)},
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        with patch(
+            "tree_sitter_analyzer.cli.commands.doctor._agent_config_paths",
+            return_value=[("Test Agent", str(config))],
+        ):
+            results = _check_agent_configs()
+        assert len(results) == 1
+        assert results[0].status == "PASS"
+
+    def test_warn_when_tsa_entry_missing(self, tmp_path: Path) -> None:
+        from tree_sitter_analyzer.cli.commands.doctor import _check_agent_configs
+
+        config = tmp_path / "mcp.json"
+        config.write_text(json.dumps({"mcpServers": {}}), encoding="utf-8")
+        with patch(
+            "tree_sitter_analyzer.cli.commands.doctor._agent_config_paths",
+            return_value=[("Test Agent", str(config))],
+        ):
+            results = _check_agent_configs()
+        assert len(results) == 1
+        assert results[0].status == "WARN"
+        assert "not found" in results[0].message
+
+    def test_warn_when_tsa_entry_has_relative_root(self, tmp_path: Path) -> None:
+        from tree_sitter_analyzer.cli.commands.doctor import _check_agent_configs
+
+        config = tmp_path / "mcp.json"
+        config.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "tree-sitter-analyzer": {
+                            "command": "uvx",
+                            "args": [],
+                            "env": {"TREE_SITTER_PROJECT_ROOT": "./relative"},
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        with patch(
+            "tree_sitter_analyzer.cli.commands.doctor._agent_config_paths",
+            return_value=[("Test Agent", str(config))],
+        ):
+            results = _check_agent_configs()
+        assert len(results) == 1
+        assert results[0].status == "WARN"
+        assert "relative path" in results[0].message
+
+    def test_warn_when_json_parse_error(self, tmp_path: Path) -> None:
+        from tree_sitter_analyzer.cli.commands.doctor import _check_agent_configs
+
+        config = tmp_path / "mcp.json"
+        config.write_text("{ invalid json }", encoding="utf-8")
+        with patch(
+            "tree_sitter_analyzer.cli.commands.doctor._agent_config_paths",
+            return_value=[("Test Agent", str(config))],
+        ):
+            results = _check_agent_configs()
+        assert len(results) == 1
+        assert results[0].status == "WARN"
+        assert "cannot read" in results[0].message
+
+
+class TestRunDoctor:
+    def test_returns_zero_when_no_failures(self, tmp_path: Path, capsys) -> None:
+        from tree_sitter_analyzer.cli.commands.doctor import run_doctor
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/tool"),
+            patch.dict(os.environ, {"TREE_SITTER_PROJECT_ROOT": str(tmp_path)}),
+            patch(
+                "tree_sitter_analyzer.cli.commands.doctor._check_agent_configs",
+                return_value=[],
+            ),
+        ):
+            exit_code = run_doctor()
+        assert exit_code == 0
+
+    def test_returns_one_when_failure_present(self, capsys) -> None:
+        from tree_sitter_analyzer.cli.commands.doctor import run_doctor
+
+        with (
+            patch("shutil.which", return_value=None),
+            patch.dict(os.environ, {}, clear=True),
+            patch(
+                "tree_sitter_analyzer.cli.commands.doctor._check_agent_configs",
+                return_value=[],
+            ),
+        ):
+            env = {
+                k: v for k, v in os.environ.items() if k != "TREE_SITTER_PROJECT_ROOT"
+            }
+            with patch.dict(os.environ, env, clear=True):
+                exit_code = run_doctor()
+        assert exit_code == 1
+
+    def test_text_output_contains_pass_warn_fail(self, tmp_path: Path, capsys) -> None:
+        from tree_sitter_analyzer.cli.commands.doctor import run_doctor
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/tool"),
+            patch.dict(os.environ, {"TREE_SITTER_PROJECT_ROOT": "./bad"}),
+            patch(
+                "tree_sitter_analyzer.cli.commands.doctor._check_agent_configs",
+                return_value=[],
+            ),
+        ):
+            run_doctor(json_output=False)
+        captured = capsys.readouterr()
+        assert "PASS" in captured.out
+        assert "FAIL" in captured.out
+
+    def test_json_output_is_valid_json(self, tmp_path: Path, capsys) -> None:
+        from tree_sitter_analyzer.cli.commands.doctor import run_doctor
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/tool"),
+            patch.dict(os.environ, {"TREE_SITTER_PROJECT_ROOT": str(tmp_path)}),
+            patch(
+                "tree_sitter_analyzer.cli.commands.doctor._check_agent_configs",
+                return_value=[],
+            ),
+        ):
+            run_doctor(json_output=True)
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert "checks" in data
+        assert "summary" in data
+        assert set(data["summary"].keys()) == {"pass", "warn", "fail"}
+
+    def test_json_each_check_has_required_fields(self, tmp_path: Path, capsys) -> None:
+        from tree_sitter_analyzer.cli.commands.doctor import run_doctor
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/tool"),
+            patch.dict(os.environ, {"TREE_SITTER_PROJECT_ROOT": str(tmp_path)}),
+            patch(
+                "tree_sitter_analyzer.cli.commands.doctor._check_agent_configs",
+                return_value=[],
+            ),
+        ):
+            run_doctor(json_output=True)
+        data = json.loads(capsys.readouterr().out)
+        for check in data["checks"]:
+            assert "name" in check
+            assert "status" in check
+            assert check["status"] in ("PASS", "WARN", "FAIL")
+            assert "message" in check
+
+
+class TestAgentConfigPaths:
+    def test_linux_paths_include_correct_labels(self) -> None:
+        from tree_sitter_analyzer.cli.commands.doctor import _agent_config_paths
+
+        with patch.object(sys, "platform", "linux"):
+            paths = _agent_config_paths()
+        labels = [label for label, _ in paths]
+        assert "Claude Desktop (Linux)" in labels
+        assert "Claude Code (global)" in labels
+        assert "Claude Code (project-local)" in labels
+        assert "Cursor" in labels
+        assert "VS Code (Linux)" in labels
+
+    def test_macos_paths_include_correct_labels(self) -> None:
+        from tree_sitter_analyzer.cli.commands.doctor import _agent_config_paths
+
+        with patch.object(sys, "platform", "darwin"):
+            paths = _agent_config_paths()
+        labels = [label for label, _ in paths]
+        assert "Claude Desktop (macOS)" in labels
+        assert "VS Code (macOS)" in labels
+        assert "Claude Code (global)" in labels
+        assert "Cursor" in labels
+
+    def test_macos_desktop_path_contains_library(self) -> None:
+        from tree_sitter_analyzer.cli.commands.doctor import _agent_config_paths
+
+        with patch.object(sys, "platform", "darwin"):
+            paths = _agent_config_paths()
+        desktop_path = next(p for label, p in paths if "Desktop" in label)
+        assert "Library" in desktop_path
+        assert "claude_desktop_config.json" in desktop_path
+
+    def test_linux_desktop_path_contains_config(self) -> None:
+        from tree_sitter_analyzer.cli.commands.doctor import _agent_config_paths
+
+        with patch.object(sys, "platform", "linux"):
+            paths = _agent_config_paths()
+        desktop_path = next(p for label, p in paths if "Desktop" in label)
+        assert ".config" in desktop_path
+        assert "claude_desktop_config.json" in desktop_path
+
+    def test_returns_five_entries_on_linux(self) -> None:
+        from tree_sitter_analyzer.cli.commands.doctor import _agent_config_paths
+
+        with patch.object(sys, "platform", "linux"):
+            paths = _agent_config_paths()
+        assert len(paths) == 5
+
+    def test_returns_five_entries_on_macos(self) -> None:
+        from tree_sitter_analyzer.cli.commands.doctor import _agent_config_paths
+
+        with patch.object(sys, "platform", "darwin"):
+            paths = _agent_config_paths()
+        assert len(paths) == 5
+
+
+class TestDoctorFlagsRegistered:
+    def test_doctor_flag_registered_in_parser(self) -> None:
+        from tree_sitter_analyzer.cli_main import create_argument_parser
+
+        parser = create_argument_parser()
+        flags = {s for a in parser._actions for s in a.option_strings}
+        assert "--doctor" in flags
+
+    def test_doctor_json_flag_registered_in_parser(self) -> None:
+        from tree_sitter_analyzer.cli_main import create_argument_parser
+
+        parser = create_argument_parser()
+        flags = {s for a in parser._actions for s in a.option_strings}
+        assert "--doctor-json" in flags
+
+
+class TestHandleDoctor:
+    def test_returns_none_when_doctor_flag_absent(self) -> None:
+        from unittest.mock import MagicMock
+
+        from tree_sitter_analyzer.cli.special_commands import (
+            SpecialCommandContext,
+            _handle_doctor,
+        )
+
+        args = MagicMock(spec=[])
+        context = MagicMock(spec=SpecialCommandContext)
+        result = _handle_doctor(args, context)
+        assert result is None
+
+    def test_calls_run_doctor_when_flag_set(self, tmp_path: Path) -> None:
+        from unittest.mock import MagicMock
+
+        from tree_sitter_analyzer.cli.special_commands import (
+            SpecialCommandContext,
+            _handle_doctor,
+        )
+
+        args = MagicMock()
+        args.doctor = True
+        args.doctor_json = False
+        context = MagicMock(spec=SpecialCommandContext)
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/uv"),
+            patch.dict(os.environ, {"TREE_SITTER_PROJECT_ROOT": str(tmp_path)}),
+            patch(
+                "tree_sitter_analyzer.cli.commands.doctor._check_agent_configs",
+                return_value=[],
+            ),
+        ):
+            result = _handle_doctor(args, context)
+        assert result == 0
+
+
+class TestMainDoctor:
+    def test_main_doctor_prepends_doctor_flag(self) -> None:
+        from tree_sitter_analyzer.cli_main import main_doctor
+
+        called_with: list[str] = []
+
+        def fake_main() -> None:
+            called_with.extend(sys.argv)
+
+        with (
+            patch("tree_sitter_analyzer.cli_main.main", side_effect=fake_main),
+            patch.object(sys, "argv", ["tree-sitter-analyzer-doctor"]),
+        ):
+            main_doctor()
+
+        assert called_with[1] == "--doctor"

--- a/tree_sitter_analyzer/cli/argument_groups/_core.py
+++ b/tree_sitter_analyzer/cli/argument_groups/_core.py
@@ -140,6 +140,17 @@ def _add_batch_options(parser: argparse.ArgumentParser) -> None:
         help="Project health: score all source files and report grade distribution, worst files, and refactoring targets",
     )
     parser.add_argument(
+        "--doctor",
+        action="store_true",
+        help="Run installation diagnostics: check uv/uvx/fd/rg, TREE_SITTER_PROJECT_ROOT, and agent config files.",
+    )
+    parser.add_argument(
+        "--doctor-json",
+        action="store_true",
+        dest="doctor_json",
+        help="With --doctor: emit results as machine-readable JSON instead of human-readable text.",
+    )
+    parser.add_argument(
         "--metrics-only",
         action="store_true",
         help="Batch metrics: compute file metrics only (no structural analysis). Requires --file-paths or --files-from.",

--- a/tree_sitter_analyzer/cli/commands/doctor.py
+++ b/tree_sitter_analyzer/cli/commands/doctor.py
@@ -1,0 +1,216 @@
+"""Diagnostic checks for TSA installation health (--doctor)."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+from dataclasses import dataclass
+from typing import Literal
+
+
+@dataclass
+class CheckResult:
+    name: str
+    status: Literal["PASS", "WARN", "FAIL"]
+    message: str
+
+
+def _check_uv() -> CheckResult:
+    path = shutil.which("uv")
+    if path:
+        return CheckResult("uv", "PASS", path)
+    return CheckResult(
+        "uv", "FAIL", "not found — install from https://docs.astral.sh/uv/"
+    )
+
+
+def _check_uvx() -> CheckResult:
+    path = shutil.which("uvx")
+    if path:
+        return CheckResult("uvx", "PASS", path)
+    return CheckResult(
+        "uvx",
+        "WARN",
+        "uvx is installed with uv; if uvx is missing, reinstall uv",
+    )
+
+
+def _check_fd() -> CheckResult:
+    path = shutil.which("fd")
+    if path:
+        return CheckResult("fd", "PASS", path)
+    return CheckResult(
+        "fd",
+        "WARN",
+        "not found — required for text search (brew install fd / apt install fd-find)",
+    )
+
+
+def _check_rg() -> CheckResult:
+    path = shutil.which("rg")
+    if path:
+        return CheckResult("rg (ripgrep)", "PASS", path)
+    return CheckResult(
+        "rg (ripgrep)",
+        "WARN",
+        "not found — required for text search (brew install ripgrep / apt install ripgrep)",
+    )
+
+
+def _check_project_root() -> CheckResult:
+    value = os.environ.get("TREE_SITTER_PROJECT_ROOT")
+    if not value:
+        return CheckResult(
+            "TREE_SITTER_PROJECT_ROOT",
+            "FAIL",
+            "env var is not set — set it to the absolute path of your project",
+        )
+    if not os.path.isabs(value):
+        return CheckResult(
+            "TREE_SITTER_PROJECT_ROOT",
+            "FAIL",
+            f"value is a relative path: {value!r} — use an absolute path (e.g. $(pwd))",
+        )
+    if not os.path.isdir(value):
+        return CheckResult(
+            "TREE_SITTER_PROJECT_ROOT",
+            "FAIL",
+            f"directory does not exist: {value}",
+        )
+    return CheckResult("TREE_SITTER_PROJECT_ROOT", "PASS", value)
+
+
+def _agent_config_paths() -> list[tuple[str, str]]:
+    """Return (agent_label, expanded_path) pairs to check."""
+    home = os.path.expanduser("~")
+    cwd = os.getcwd()
+    is_macos = sys.platform == "darwin"
+
+    paths = []
+    if is_macos:
+        paths.append(
+            (
+                "Claude Desktop (macOS)",
+                os.path.join(
+                    home,
+                    "Library",
+                    "Application Support",
+                    "Claude",
+                    "claude_desktop_config.json",
+                ),
+            )
+        )
+    else:
+        paths.append(
+            (
+                "Claude Desktop (Linux)",
+                os.path.join(home, ".config", "claude", "claude_desktop_config.json"),
+            )
+        )
+
+    paths.append(("Claude Code (global)", os.path.join(home, ".claude", ".mcp.json")))
+    paths.append(
+        ("Claude Code (project-local)", os.path.join(cwd, ".claude", ".mcp.json"))
+    )
+    paths.append(("Cursor", os.path.join(home, ".cursor", "mcp.json")))
+
+    if is_macos:
+        paths.append(
+            (
+                "VS Code (macOS)",
+                os.path.join(
+                    home, "Library", "Application Support", "Code", "User", "mcp.json"
+                ),
+            )
+        )
+    else:
+        paths.append(
+            (
+                "VS Code (Linux)",
+                os.path.join(home, ".config", "Code", "User", "mcp.json"),
+            )
+        )
+
+    return paths
+
+
+def _check_agent_configs() -> list[CheckResult]:
+    results = []
+    for label, path in _agent_config_paths():
+        name = f"agent config: {label}"
+        if not os.path.isfile(path):
+            results.append(CheckResult(name, "WARN", f"not found: {path}"))
+            continue
+
+        try:
+            with open(path, encoding="utf-8") as f:
+                data = json.load(f)
+        except (json.JSONDecodeError, OSError) as exc:
+            results.append(CheckResult(name, "WARN", f"cannot read {path}: {exc}"))
+            continue
+
+        mcp_servers = data.get("mcpServers", {})
+        tsa_entry = mcp_servers.get("tree-sitter-analyzer")
+        if tsa_entry is None:
+            results.append(
+                CheckResult(
+                    name,
+                    "WARN",
+                    f"MCP entry 'tree-sitter-analyzer' not found in {path}",
+                )
+            )
+            continue
+
+        env = tsa_entry.get("env", {})
+        root = env.get("TREE_SITTER_PROJECT_ROOT", "")
+        if root and not os.path.isabs(root):
+            results.append(
+                CheckResult(
+                    name,
+                    "WARN",
+                    f"TREE_SITTER_PROJECT_ROOT is a relative path {root!r} in {path}",
+                )
+            )
+        else:
+            results.append(CheckResult(name, "PASS", path))
+
+    return results
+
+
+def run_doctor(json_output: bool = False) -> int:
+    """Run all diagnostic checks and print results.
+
+    Returns 0 if no FAIL checks, 1 otherwise.
+    """
+    results: list[CheckResult] = [
+        _check_uv(),
+        _check_uvx(),
+        _check_fd(),
+        _check_rg(),
+        _check_project_root(),
+        *_check_agent_configs(),
+    ]
+
+    fail_count = sum(1 for r in results if r.status == "FAIL")
+    warn_count = sum(1 for r in results if r.status == "WARN")
+    pass_count = sum(1 for r in results if r.status == "PASS")
+
+    if json_output:
+        output = {
+            "checks": [
+                {"name": r.name, "status": r.status, "message": r.message}
+                for r in results
+            ],
+            "summary": {"pass": pass_count, "warn": warn_count, "fail": fail_count},
+        }
+        print(json.dumps(output, ensure_ascii=False, indent=2))
+    else:
+        icons = {"PASS": "✓", "WARN": "⚠", "FAIL": "✗"}  # nosec B105
+        for r in results:
+            print(f"{r.status} {icons[r.status]} {r.name}: {r.message}")
+        print()
+        print(f"Summary: {pass_count} PASS, {warn_count} WARN, {fail_count} FAIL")
+
+    return 0 if fail_count == 0 else 1

--- a/tree_sitter_analyzer/cli/special_commands.py
+++ b/tree_sitter_analyzer/cli/special_commands.py
@@ -35,6 +35,7 @@ def handle_special_commands(
         lambda: _handle_agent_workflow(args, context),
         lambda: _handle_batch_partial_read(args, context),
         lambda: _handle_health_check(args, context),
+        lambda: _handle_doctor(args, context),
         lambda: _handle_check_scale(args, context),
         lambda: _handle_outline(args, context),
         lambda: _handle_batch_metrics(args, context),
@@ -309,6 +310,19 @@ def _handle_health_check(
             error_type="runtime",
         )
         return 1
+
+
+def _handle_doctor(
+    args: Any,
+    context: SpecialCommandContext,
+) -> int | None:
+    """Run installation diagnostics for --doctor."""
+    if not getattr(args, "doctor", False):
+        return None
+    from .commands.doctor import run_doctor
+
+    json_output = getattr(args, "doctor_json", False)
+    return run_doctor(json_output=json_output)
 
 
 def _emit_cli_error(

--- a/tree_sitter_analyzer/cli_main.py
+++ b/tree_sitter_analyzer/cli_main.py
@@ -202,6 +202,12 @@ def main() -> None:
     _execute_selected_command(args, parser)
 
 
+def main_doctor() -> None:
+    """Entry point for tree-sitter-analyzer-doctor CLI script."""
+    sys.argv = [sys.argv[0], "--doctor"] + sys.argv[1:]
+    main()
+
+
 def _set_cli_log_environment() -> None:
     """Force CLI logging to stderr-only error noise regardless of quiet mode."""
     os.environ["LOG_LEVEL"] = "ERROR"


### PR DESCRIPTION
## Summary

- **install.sh**: one-command setup — auto-installs uv, detects Claude Desktop / Claude Code / Cursor / VS Code config files, writes MCP entry with absolute \`TREE_SITTER_PROJECT_ROOT\`; bash 3.x compatible, JSON merge via python3, timestamped backups
- **\`--doctor\` command**: new \`tree_sitter_analyzer/cli/commands/doctor.py\` that checks uv/uvx/fd/rg availability, validates \`TREE_SITTER_PROJECT_ROOT\` is absolute and exists, lists agent config file status; stdlib-only, supports \`--doctor-json\`
- **\`pyproject.toml\`**: add \`tree-sitter-analyzer-doctor\` entry point
- **README (EN/JA/ZH)**: add automated install section at top of Get Started, collapse Prerequisites into \`<details>\`, add Troubleshooting entry for relative-path \`TREE_SITTER_PROJECT_ROOT\`, update CLI flag count 319 → 321

## Test plan

- [ ] \`bash install.sh\` on macOS with existing \`~/.claude/.mcp.json\` — TSA entry merged, backup created, absolute path set
- [ ] \`tree-sitter-analyzer --doctor\` with \`TREE_SITTER_PROJECT_ROOT=$(pwd)\` — all checks PASS, exit 0
- [ ] \`tree-sitter-analyzer --doctor\` with \`TREE_SITTER_PROJECT_ROOT=./relative\` — FAIL check, exit 1
- [ ] \`tree-sitter-analyzer --doctor --doctor-json\` — valid JSON output
- [ ] \`tree-sitter-analyzer-doctor\` entry point works
- [ ] Existing test suite passes (\`uv run pytest -x -q\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)