### PR TITLE
feat(synapse): arch-fix synapse coverage groups 1-8 + complexity filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌳 Tree-sitter Analyzer
+﻿# 🌳 Tree-sitter Analyzer
 
 **English** | **[日本語](README_ja.md)** | **[简体中文](README_zh.md)**
 
@@ -497,4 +497,3 @@ See **[`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md)** for the development guide
 * Lead sponsor: **[@o93](https://github.com/o93)**.
 * MIT licensed — see [LICENSE](LICENSE).
 * Release history: [CHANGELOG.md](CHANGELOG.md).
-

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ CodeGraph has zero skills. We ship 13 under `.claude/skills/tsa-*/`:
 
 Each skill ships an `allowed-tools` subset + procedure recipe + decision-surface schema, so the agent doesn't have to triage 8 tools on every question.
 
-### 321 CLI flags
+### 323 CLI flags
 
 Superset of CodeGraph's CLI surface. Highlights:
 
@@ -497,3 +497,4 @@ See **[`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md)** for the development guide
 * Lead sponsor: **[@o93](https://github.com/o93)**.
 * MIT licensed — see [LICENSE](LICENSE).
 * Release history: [CHANGELOG.md](CHANGELOG.md).
+

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,4 +1,4 @@
-# 🌳 Tree-sitter Analyzer
+﻿# 🌳 Tree-sitter Analyzer
 
 **[English](README.md)** | **日本語** | **[简体中文](README_zh.md)**
 
@@ -461,4 +461,3 @@ uv run pytest -q
 * 💖 [スポンサー](https://github.com/sponsors/aimasteracc) — 継続的な MCP / Skills 開発を支援。
 * リード スポンサー: **[@o93](https://github.com/o93)**。
 * MIT ライセンス — [LICENSE](LICENSE) を参照。
-

--- a/README_ja.md
+++ b/README_ja.md
@@ -160,7 +160,7 @@ CodeGraph には skill システムが存在しない。本ツールは `.claude
 
 各 skill は `allowed-tools` ツール サブセット + 手順レシピ + 決定面スキーマを同梱し、エージェントは 8 個のツールから毎回選別する必要が無い。
 
-### 321 の CLI フラグ
+### 323 の CLI フラグ
 
 CodeGraph の CLI の厳密な上位互換。主なもの:
 
@@ -461,3 +461,4 @@ uv run pytest -q
 * 💖 [スポンサー](https://github.com/sponsors/aimasteracc) — 継続的な MCP / Skills 開発を支援。
 * リード スポンサー: **[@o93](https://github.com/o93)**。
 * MIT ライセンス — [LICENSE](LICENSE) を参照。
+

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,4 +1,4 @@
-# 🌳 Tree-sitter Analyzer
+﻿# 🌳 Tree-sitter Analyzer
 
 **[English](README.md)** | **[日本語](README_ja.md)** | **简体中文**
 
@@ -464,4 +464,3 @@ uv run pytest -q
 * 首席赞助人：**[@o93](https://github.com/o93)**。
 * MIT 许可证 — 详见 [LICENSE](LICENSE)。
 * 发布历史：[CHANGELOG.md](CHANGELOG.md)。
-

--- a/README_zh.md
+++ b/README_zh.md
@@ -160,7 +160,7 @@ CodeGraph 没有 skill 系统。我们在 `.claude/skills/tsa-*/` 下提供 13 �
 
 每个 skill 都带 `allowed-tools` 工具子集 + 操作流程 + 决策面 schema，agent 不必在 8 个工具间反复挑选。
 
-### 321 个 CLI flag
+### 323 个 CLI flag
 
 CodeGraph CLI 的严格超集。亮点：
 
@@ -464,3 +464,4 @@ uv run pytest -q
 * 首席赞助人：**[@o93](https://github.com/o93)**。
 * MIT 许可证 — 详见 [LICENSE](LICENSE)。
 * 发布历史：[CHANGELOG.md](CHANGELOG.md)。
+

--- a/docs/CODEMAPS/languages.md
+++ b/docs/CODEMAPS/languages.md
@@ -38,7 +38,7 @@ Not every registered plugin is wired into the indexer to the same depth:
 | Markdown | `markdown_plugin/` | submodules | headings, code blocks, tables |
 | JSON | `languages/json_plugin.py` | inline | basic structure |
 | Bash | `languages/bash_plugin.py` | inline | functions, commands |
-| Lua | `languages/lua_plugin/` | `plugin.py` | extensibility demo; shows new language = 1 package, no central edits (Phase 2 capability system) |
+| Lua | `languages/lua_plugin/` | `plugin.py` + `extractor.py` | `LuaElementExtractor` with tree-sitter queries for `function_declaration` and `require()` calls; extensibility demo (Phase 2 capability system) |
 
 ## Shared helpers
 

--- a/docs/api/facade-actions.md
+++ b/docs/api/facade-actions.md
@@ -111,7 +111,7 @@ Reading the tables:
 | `auto` | `max_files`, `mode`, `output_format` | `success`*, `verdict`*, `agent_summary`, `error` + action payload | `--autoindex` |
 | `build` | `add_notes`, `roots` | `success`*, `verdict`*, `agent_summary`, `error` + action payload | `--build-project-index` |
 | `cache` | `backend`, `file_path`, `force`, `include_activation`, `language`, `limit`, `max_files`, `mode`, `poll_interval`, `query`, `symbol` | `success`*, `verdict`*, `agent_summary`, `error` + action payload | `--ast-cache` |
-| `full` | `include_activation`, `max_files`, `mode`, `output_format`, `resolve_synapse` | `success`*, `verdict`*, `agent_summary`, `error` + action payload | `--full-index` |
+| `full` | `exclude_patterns`, `include_activation`, `max_files`, `mode`, `no_default_excludes`, `output_format`, `resolve_synapse` | `success`*, `verdict`*, `agent_summary`, `error` + action payload | `--full-index` |
 | `knowledge` | `backend`, `include_docs`, `max_edges`, `max_files`, `max_nodes`, `mode`, `output_format` | `success`*, `verdict`*, `agent_summary`, `error` + action payload | `--knowledge-graph-index` |
 | `status` | `include_lag`, `output_format` | `success`*, `verdict`*, `agent_summary`, `error` + action payload | `--codegraph-status` |
 | `sync` | `max_files`, `mode`, `output_format` | `success`*, `verdict`*, `agent_summary`, `error` + action payload | `--incremental-sync` |

--- a/scripts/benchmark_real_projects.py
+++ b/scripts/benchmark_real_projects.py
@@ -283,32 +283,44 @@ def main():
         )
 
         cg = CODEGRAPH_BASELINES.get(config["comparable_cg"], {})
-        recall = len(
-            set(analysis["found_symbols"]) & set(config["expected_symbols"])
-        ) / max(len(config["expected_symbols"]), 1)
+
+        # REQ-U-027: index_symbols would be populated by a real index step.
+        # Currently no index step is implemented, so this is always 0.
+        index_symbols = 0
+
+        # REQ-U-027: skip recall computation when index_symbols == 0 to avoid
+        # producing invalid measurements against an empty symbol table.
+        if index_symbols == 0:
+            _bmark_logger.warning(
+                "[%s] index_symbols=0 after index step — recall computation skipped "
+                "(empty symbol table). See HISTORICAL DATA NOTE in this file.",
+                name,
+            )
+            recall = -1.0  # sentinel: row is invalid, not a real measurement
+        else:
+            recall = round(
+                len(set(analysis["found_symbols"]) & set(config["expected_symbols"]))
+                / max(len(config["expected_symbols"]), 1),
+                2,
+            )
 
         run = BenchmarkRun(
             project=name,
             query=config["query"],
             language=config["language"],
             index_files=file_count,
+            index_symbols=index_symbols,
             tool_calls_needed=analysis["tool_calls"],
             analysis_time_s=analysis["time_s"],
             file_reads_needed=analysis["file_reads"],
             found_symbols=analysis["found_symbols"],
             expected_symbols=config["expected_symbols"],
-            recall=round(recall, 2),
+            recall=recall,
             comparable_cg=config["comparable_cg"],
             cg_tool_calls=cg.get("tool_calls", 0),
             cg_time_s=cg.get("time_s", 0),
             cg_file_reads=cg.get("file_reads", 0),
         )
-        if run.index_symbols == 0:
-            _bmark_logger.warning(
-                "[%s] index_symbols=0 after index step — recall computation skipped "
-                "(empty symbol table). See HISTORICAL DATA NOTE in this file.",
-                run.project,
-            )
         results.append(run)
 
     print("\n" + "=" * 90)
@@ -336,13 +348,19 @@ def main():
     avg_our_calls = sum(r.tool_calls_needed for r in results) / len(results)
     avg_cg_calls = sum(r.cg_tool_calls for r in results) / len(results)
     avg_our_reads = sum(r.file_reads_needed for r in results) / len(results)
-    avg_recall = sum(r.recall for r in results) / len(results)
+    # REQ-U-027: exclude sentinel rows (recall == -1.0) from the average
+    valid_recalls = [r.recall for r in results if r.recall >= 0]
+    avg_recall_str = (
+        f"{sum(valid_recalls) / len(valid_recalls):.0%}"
+        if valid_recalls
+        else "N/A (all rows have index_symbols=0)"
+    )
 
     print(
         f"\n  Average tool calls — Us: {avg_our_calls:.1f}, CodeGraph: {avg_cg_calls:.1f}"
     )
     print(f"  Average file reads — Us: {avg_our_reads:.1f}, CodeGraph: 0")
-    print(f"  Average recall — Us: {avg_recall:.0%}")
+    print(f"  Average recall — Us: {avg_recall_str}")
     print("\n  Key gaps:")
     print(
         f"    - File reads: CodeGraph=0, Us={avg_our_reads:.1f} (we make agents read files)"

--- a/scripts/benchmark_real_projects.py
+++ b/scripts/benchmark_real_projects.py
@@ -23,13 +23,26 @@ Our test targets (matching languages we support):
   - Express (TypeScript) — web framework
 """
 
+# HISTORICAL DATA NOTE (REQ-U-028):
+# benchmark_results.json was generated with an empty index for all rows
+# (index_symbols=0 for every BenchmarkRun). The recall numbers in that file
+# (approximately 0.14, 0.29, 0.43) are INVALID — they were computed against
+# an empty symbol table, not a real indexed project. Any reader of
+# benchmark_results.json must treat those recall figures as benchmark
+# infrastructure artifacts, not real measurements.
+# Re-running with a properly built index requires network access (cloning
+# real projects) and is tracked separately.
+
 import json
+import logging as _logging
 import subprocess
 import sys
 import tempfile
 import time
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
+
+_bmark_logger = _logging.getLogger(__name__)
 
 # tempdir-style path; "cwqcdr3n…" looks like base64 entropy to
 # detect-secrets but is just a macOS-generated tempdir component.
@@ -290,6 +303,12 @@ def main():
             cg_time_s=cg.get("time_s", 0),
             cg_file_reads=cg.get("file_reads", 0),
         )
+        if run.index_symbols == 0:
+            _bmark_logger.warning(
+                "[%s] index_symbols=0 after index step — recall computation skipped "
+                "(empty symbol table). See HISTORICAL DATA NOTE in this file.",
+                run.project,
+            )
         results.append(run)
 
     print("\n" + "=" * 90)

--- a/tests/benchmarks/claims/test_unknown_rate_ratchet.py
+++ b/tests/benchmarks/claims/test_unknown_rate_ratchet.py
@@ -17,8 +17,6 @@ Measurement SQL (run against tree-sitter-analyzer self-repo index):
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 
 pytestmark = [

--- a/tests/benchmarks/claims/test_unknown_rate_ratchet.py
+++ b/tests/benchmarks/claims/test_unknown_rate_ratchet.py
@@ -1,0 +1,67 @@
+"""Claim invariant: unknown callee resolution rate must not exceed 6.0%.
+
+Baseline history:
+  v1.21.0 (benchmark date TBD): 3.7% unknown  <- published rate
+  v1.29.0-line (2026-07-10):    6.0% unknown  <- current threshold (develop@6fe62fba)
+
+This test is a NON-REGRESSION GATE only. The threshold must NEVER increase
+without an explicit, reviewed decision. After fixes in Groups 1, 3, 4 land,
+re-run the SQL below against the self-repo index, measure the new unknown rate,
+and lower this threshold accordingly.
+
+Measurement SQL (run against tree-sitter-analyzer self-repo index):
+  SELECT ROUND(100.0 * SUM(callee_resolution = 'unknown') / COUNT(*), 1)
+  FROM edges
+  WHERE kind = 'calls';
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.benchmark,
+    pytest.mark.claims_benchmark,
+    pytest.mark.full_language,
+]
+
+# Baseline history:
+#   v1.21.0 (2026-xx-xx): 3.7% unknown
+#   v1.29.0-line (2026-07-10): 6.0% unknown  <- current threshold
+# After Scala resolver (Group 1) and other fixes land:
+#   re-run benchmark, measure new unknown rate, lower this threshold.
+# This threshold must NEVER increase without an explicit decision.
+UNKNOWN_RATE_THRESHOLD_PCT = 6.0
+
+
+def test_unknown_rate_threshold_is_documented_in_this_file():
+    """The threshold value and baseline history must be readable in this file."""
+    import inspect
+
+    src = inspect.getfile(test_unknown_rate_threshold_is_documented_in_this_file)
+    with open(src, encoding="utf-8") as f:
+        content = f.read()
+    assert "UNKNOWN_RATE_THRESHOLD_PCT" in content
+    assert "6.0" in content
+    assert "3.7" in content
+    assert "callee_resolution" in content, (
+        "The measurement SQL must be present in this test file."
+    )
+
+
+def test_unknown_rate_threshold_value():
+    """Threshold value is pinned at 6.0% (current measured floor, 2026-07-10).
+
+    This test does NOT run a live SQL query — it pins the threshold constant
+    so that any future increase to UNKNOWN_RATE_THRESHOLD_PCT triggers a
+    review. A live SQL measurement test requires the self-repo index to be
+    built first; that is tracked separately as a full_language benchmark test.
+    """
+    assert UNKNOWN_RATE_THRESHOLD_PCT == 6.0, (
+        f"Threshold must be 6.0% (current measured floor). "
+        f"Got: {UNKNOWN_RATE_THRESHOLD_PCT}%. "
+        "Lower this only after measuring a genuine improvement; "
+        "never raise it without an explicit decision."
+    )

--- a/tests/integration/cli/test_cli_query_filter_integration.py
+++ b/tests/integration/cli/test_cli_query_filter_integration.py
@@ -464,8 +464,8 @@ public class TestClass {
             stderr_output = captured_stderr.getvalue()
 
             assert results is not None
-            # All results returned because the invalid filter is skipped
-            assert len(results) >= 2
+            # All results returned because the invalid filter is skipped (2 methods in fixture)
+            assert len(results) == 2
             # Warning should have been written to stderr
             assert "abc" in stderr_output or "complexity" in stderr_output, (
                 f"Expected warning in stderr, got: {stderr_output!r}"

--- a/tests/integration/cli/test_cli_query_filter_integration.py
+++ b/tests/integration/cli/test_cli_query_filter_integration.py
@@ -332,5 +332,147 @@ public class EdgeCaseClass {
         assert "genericMethod" in results[0]["content"]
 
 
+class TestCLIQueryComplexityLineSpanFilter:
+    """Integration tests for complexity and line_span comparison filters."""
+
+    def _make_java_file(self, code: str) -> "tempfile.NamedTemporaryFile":
+        tmp = tempfile.NamedTemporaryFile(mode="w", suffix=".java", delete=False)
+        tmp.write(code)
+        tmp.close()
+        return tmp
+
+    def _make_args(self, file_path: str, query_key: str = "methods", filter_expr: str | None = None):
+        return type(
+            "Args",
+            (),
+            {
+                "file_path": file_path,
+                "query_key": query_key,
+                "query_string": None,
+                "filter": filter_expr,
+                "output_format": "json",
+            },
+        )()
+
+    @pytest.mark.asyncio
+    async def test_cli_filter_line_span_gt(self):
+        """filter='line_span>10' → only the long method (60 lines) is returned."""
+        # Build Java file with short_method (3 lines) and long_method (60 lines)
+        body_lines = "\n".join(f"        int x{i} = {i};" for i in range(58))
+        java_code = f"""
+public class SpanTest {{
+    public void shortMethod() {{
+        int x = 1;
+    }}
+
+    public void longMethod() {{
+{body_lines}
+    }}
+}}
+"""
+        tmp = self._make_java_file(java_code)
+        try:
+            args = self._make_args(tmp.name, filter_expr="line_span>10")
+            command = QueryCommand(args)
+            results = await command.execute_query("java", "methods", "methods")
+            assert results is not None
+            # longMethod spans > 10 lines; shortMethod spans <= 10 lines
+            names = [r.get("name") or r.get("content", "") for r in results]
+            assert any("longMethod" in n for n in names), f"longMethod not found in {names}"
+            assert not any("shortMethod" in n for n in names), f"shortMethod should be excluded, names={names}"
+        finally:
+            Path(tmp.name).unlink(missing_ok=True)
+
+    @pytest.mark.asyncio
+    async def test_cli_filter_line_span_lt(self):
+        """filter='line_span<10' → only the short method (3 lines) is returned."""
+        body_lines = "\n".join(f"        int x{i} = {i};" for i in range(58))
+        java_code = f"""
+public class SpanTest {{
+    public void shortMethod() {{
+        int x = 1;
+    }}
+
+    public void longMethod() {{
+{body_lines}
+    }}
+}}
+"""
+        tmp = self._make_java_file(java_code)
+        try:
+            args = self._make_args(tmp.name, filter_expr="line_span<10")
+            command = QueryCommand(args)
+            results = await command.execute_query("java", "methods", "methods")
+            assert results is not None
+            names = [r.get("name") or r.get("content", "") for r in results]
+            assert any("shortMethod" in n for n in names), f"shortMethod not found in {names}"
+            assert not any("longMethod" in n for n in names), f"longMethod should be excluded, names={names}"
+        finally:
+            Path(tmp.name).unlink(missing_ok=True)
+
+    @pytest.mark.asyncio
+    async def test_cli_filter_complexity_gt_no_complexity_score(self):
+        """filter='complexity>5' on a file without complexity_score → all items excluded (empty list)."""
+        java_code = """
+public class SimpleClass {
+    public void simpleMethod() {
+        int x = 1;
+    }
+    public void anotherMethod() {
+        int y = 2;
+    }
+}
+"""
+        tmp = self._make_java_file(java_code)
+        try:
+            args = self._make_args(tmp.name, filter_expr="complexity>5")
+            command = QueryCommand(args)
+            results = await command.execute_query("java", "methods", "methods")
+            assert results is not None
+            # Since these are fallback query nodes without complexity_score,
+            # the filter excludes all of them
+            for r in results:
+                assert "complexity_score" not in r, f"Unexpected complexity_score in {r}"
+            # Results should be empty since all items lack complexity_score
+            assert len(results) == 0
+
+        finally:
+            Path(tmp.name).unlink(missing_ok=True)
+
+    @pytest.mark.asyncio
+    async def test_cli_filter_invalid_rhs_silent_fallback(self, capsys):
+        """filter='complexity>abc' → all results returned (filter ignored), stderr has warning."""
+        java_code = """
+public class TestClass {
+    public void methodA() { int x = 1; }
+    public void methodB() { int y = 2; }
+}
+"""
+        tmp = self._make_java_file(java_code)
+        try:
+            args = self._make_args(tmp.name, filter_expr="complexity>abc")
+            command = QueryCommand(args)
+
+            import io
+            import sys as _sys
+            old_stderr = _sys.stderr
+            _sys.stderr = captured_stderr = io.StringIO()
+            try:
+                results = await command.execute_query("java", "methods", "methods")
+            finally:
+                _sys.stderr = old_stderr
+            stderr_output = captured_stderr.getvalue()
+
+            assert results is not None
+            # All results returned because the invalid filter is skipped
+            assert len(results) >= 2
+            # Warning should have been written to stderr
+            assert "abc" in stderr_output or "complexity" in stderr_output, (
+                f"Expected warning in stderr, got: {stderr_output!r}"
+            )
+        finally:
+            Path(tmp.name).unlink(missing_ok=True)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/unit/core/test_query_filter.py
+++ b/tests/unit/core/test_query_filter.py
@@ -409,6 +409,207 @@ class TestQueryFilterEdgeCases:
         assert "static" in help_text
 
 
+class TestQueryFilterParseExpressionComparison:
+    """Tests for comparison operator parsing in _parse_filter_expression."""
+
+    def test_parse_gt_operator(self, query_filter: QueryFilter) -> None:
+        """Test parsing '>' operator: complexity>10 → {"complexity": {"type": "gt", "value": 10.0}}"""
+        filters = query_filter._parse_filter_expression("complexity>10")
+        assert "complexity" in filters
+        assert filters["complexity"]["type"] == "gt"
+        assert filters["complexity"]["value"] == 10.0
+
+    def test_parse_lt_operator(self, query_filter: QueryFilter) -> None:
+        """Test parsing '<' operator: complexity<5 → {"complexity": {"type": "lt", "value": 5.0}}"""
+        filters = query_filter._parse_filter_expression("complexity<5")
+        assert "complexity" in filters
+        assert filters["complexity"]["type"] == "lt"
+        assert filters["complexity"]["value"] == 5.0
+
+    def test_parse_gte_operator(self, query_filter: QueryFilter) -> None:
+        """Test parsing '>=' operator: line_span>=20 → {"line_span": {"type": "gte", "value": 20.0}}"""
+        filters = query_filter._parse_filter_expression("line_span>=20")
+        assert "line_span" in filters
+        assert filters["line_span"]["type"] == "gte"
+        assert filters["line_span"]["value"] == 20.0
+
+    def test_parse_lte_operator(self, query_filter: QueryFilter) -> None:
+        """Test parsing '<=' operator: line_span<=50 → {"line_span": {"type": "lte", "value": 50.0}}"""
+        filters = query_filter._parse_filter_expression("line_span<=50")
+        assert "line_span" in filters
+        assert filters["line_span"]["type"] == "lte"
+        assert filters["line_span"]["value"] == 50.0
+
+    def test_parse_mixed_eq_and_gt(self, query_filter: QueryFilter) -> None:
+        """Test parsing combined eq and gt conditions: both registered."""
+        filters = query_filter._parse_filter_expression("public=true,complexity>5")
+        assert "public" in filters
+        assert filters["public"]["type"] == "exact"
+        assert filters["public"]["value"] == "true"
+        assert "complexity" in filters
+        assert filters["complexity"]["type"] == "gt"
+        assert filters["complexity"]["value"] == 5.0
+
+    def test_parse_invalid_rhs_non_numeric(self, query_filter: QueryFilter) -> None:
+        """Test parsing non-numeric rhs: complexity>abc → complexity key absent (silent fallback)."""
+        filters = query_filter._parse_filter_expression("complexity>abc")
+        assert "complexity" not in filters
+
+
+class TestQueryFilterComplexityFilter:
+    """Tests for complexity filtering via _matches_single_filter."""
+
+    def test_complexity_gt_match(self, query_filter: QueryFilter) -> None:
+        """complexity_score=15, filter gt 10 → True"""
+        result = {"complexity_score": 15, "content": "void foo() {}"}
+        assert query_filter._matches_single_filter(result, "complexity", {"type": "gt", "value": 10.0}) is True
+
+    def test_complexity_gt_no_match(self, query_filter: QueryFilter) -> None:
+        """complexity_score=5, filter gt 10 → False"""
+        result = {"complexity_score": 5, "content": "void foo() {}"}
+        assert query_filter._matches_single_filter(result, "complexity", {"type": "gt", "value": 10.0}) is False
+
+    def test_complexity_lt_match(self, query_filter: QueryFilter) -> None:
+        """complexity_score=3, filter lt 5 → True"""
+        result = {"complexity_score": 3, "content": "void foo() {}"}
+        assert query_filter._matches_single_filter(result, "complexity", {"type": "lt", "value": 5.0}) is True
+
+    def test_complexity_lt_no_match(self, query_filter: QueryFilter) -> None:
+        """complexity_score=8, filter lt 5 → False"""
+        result = {"complexity_score": 8, "content": "void foo() {}"}
+        assert query_filter._matches_single_filter(result, "complexity", {"type": "lt", "value": 5.0}) is False
+
+    def test_complexity_gte_boundary(self, query_filter: QueryFilter) -> None:
+        """complexity_score=10, filter gte 10 → True (boundary inclusive)"""
+        result = {"complexity_score": 10, "content": "void foo() {}"}
+        assert query_filter._matches_single_filter(result, "complexity", {"type": "gte", "value": 10.0}) is True
+
+    def test_complexity_lte_boundary(self, query_filter: QueryFilter) -> None:
+        """complexity_score=10, filter lte 10 → True (boundary inclusive)"""
+        result = {"complexity_score": 10, "content": "void foo() {}"}
+        assert query_filter._matches_single_filter(result, "complexity", {"type": "lte", "value": 10.0}) is True
+
+    def test_complexity_missing_field(self, query_filter: QueryFilter) -> None:
+        """result without complexity_score, filter gt 5 → False (exclude)"""
+        result = {"content": "void foo() {}"}
+        assert query_filter._matches_single_filter(result, "complexity", {"type": "gt", "value": 5.0}) is False
+
+
+class TestQueryFilterLineSpanFilter:
+    """Tests for line_span filtering via _matches_single_filter."""
+
+    def test_line_span_gt_match(self, query_filter: QueryFilter) -> None:
+        """line_span=60, filter gt 50 → True"""
+        result = {"line_span": 60, "content": "void foo() {}"}
+        assert query_filter._matches_single_filter(result, "line_span", {"type": "gt", "value": 50.0}) is True
+
+    def test_line_span_gt_no_match(self, query_filter: QueryFilter) -> None:
+        """line_span=30, filter gt 50 → False"""
+        result = {"line_span": 30, "content": "void foo() {}"}
+        assert query_filter._matches_single_filter(result, "line_span", {"type": "gt", "value": 50.0}) is False
+
+    def test_line_span_lt_match(self, query_filter: QueryFilter) -> None:
+        """line_span=10, filter lt 20 → True"""
+        result = {"line_span": 10, "content": "void foo() {}"}
+        assert query_filter._matches_single_filter(result, "line_span", {"type": "lt", "value": 20.0}) is True
+
+    def test_line_span_lt_no_match(self, query_filter: QueryFilter) -> None:
+        """line_span=25, filter lt 20 → False"""
+        result = {"line_span": 25, "content": "void foo() {}"}
+        assert query_filter._matches_single_filter(result, "line_span", {"type": "lt", "value": 20.0}) is False
+
+    def test_line_span_gte_boundary(self, query_filter: QueryFilter) -> None:
+        """line_span=20, filter gte 20 → True (boundary inclusive)"""
+        result = {"line_span": 20, "content": "void foo() {}"}
+        assert query_filter._matches_single_filter(result, "line_span", {"type": "gte", "value": 20.0}) is True
+
+    def test_line_span_lte_boundary(self, query_filter: QueryFilter) -> None:
+        """line_span=20, filter lte 20 → True (boundary inclusive)"""
+        result = {"line_span": 20, "content": "void foo() {}"}
+        assert query_filter._matches_single_filter(result, "line_span", {"type": "lte", "value": 20.0}) is True
+
+    def test_line_span_missing_field(self, query_filter: QueryFilter) -> None:
+        """result without line_span, filter gt 10 → False (exclude)"""
+        result = {"content": "void foo() {}"}
+        assert query_filter._matches_single_filter(result, "line_span", {"type": "gt", "value": 10.0}) is False
+
+
+class TestQueryFilterComparisonIntegration:
+    """Integration tests for comparison filters through filter_results."""
+
+    def test_filter_complexity_gt_full(self, query_filter: QueryFilter) -> None:
+        """3 results with scores 3, 12, 7; filter complexity>10 → 1 result (score=12)"""
+        results = [
+            {"content": "void a() {}", "complexity_score": 3},
+            {"content": "void b() {}", "complexity_score": 12},
+            {"content": "void c() {}", "complexity_score": 7},
+        ]
+        filtered = query_filter.filter_results(results, "complexity>10")
+        assert len(filtered) == 1
+        assert filtered[0]["complexity_score"] == 12
+
+    def test_filter_line_span_lt_full(self, query_filter: QueryFilter) -> None:
+        """3 results with spans 100, 20, 50; filter line_span<50 → 1 result (span=20)"""
+        results = [
+            {"content": "void a() {}", "line_span": 100},
+            {"content": "void b() {}", "line_span": 20},
+            {"content": "void c() {}", "line_span": 50},
+        ]
+        filtered = query_filter.filter_results(results, "line_span<50")
+        assert len(filtered) == 1
+        assert filtered[0]["line_span"] == 20
+
+    def test_filter_mixed_eq_and_gt(self, query_filter: QueryFilter) -> None:
+        """Mixed eq and gt filter applied as AND logic."""
+        results = [
+            {"content": "public void a() {}", "complexity_score": 10},
+            {"content": "public void b() {}", "complexity_score": 3},
+            {"content": "private void c() {}", "complexity_score": 10},
+        ]
+        filtered = query_filter.filter_results(results, "public=true,complexity>5")
+        # Should match: public=true AND complexity>5
+        # a: public=true, complexity=10>5 → match
+        # b: public=true, complexity=3 not >5 → no match
+        # c: public=false → no match
+        assert len(filtered) == 1
+        assert filtered[0]["complexity_score"] == 10
+        assert "public" in filtered[0]["content"]
+        assert "void a()" in filtered[0]["content"]
+
+    def test_filter_silent_fallback(
+        self, query_filter: QueryFilter, capsys: pytest.CaptureFixture
+    ) -> None:
+        """complexity>abc → all results returned, stderr warning emitted."""
+        results = [
+            {"content": "void a() {}", "complexity_score": 5},
+            {"content": "void b() {}", "complexity_score": 15},
+        ]
+        filtered = query_filter.filter_results(results, "complexity>abc")
+        # All results returned since the condition is skipped
+        assert len(filtered) == 2
+        captured = capsys.readouterr()
+        assert "abc" in captured.err or "complexity" in captured.err
+
+
+class TestGetFilterHelpContainsComplexity:
+    """Tests that get_filter_help includes complexity and line_span entries."""
+
+    def test_get_filter_help_contains_complexity(self, query_filter: QueryFilter) -> None:
+        """get_filter_help should mention complexity filter."""
+        help_text = query_filter.get_filter_help()
+        assert "complexity" in help_text
+
+    def test_get_filter_help_contains_line_span(self, query_filter: QueryFilter) -> None:
+        """get_filter_help should mention line_span filter."""
+        help_text = query_filter.get_filter_help()
+        assert "line_span" in help_text
+
+    def test_get_filter_help_contains_comparison_operators(self, query_filter: QueryFilter) -> None:
+        """get_filter_help should show comparison operator examples."""
+        help_text = query_filter.get_filter_help()
+        assert ">" in help_text
+
+
 # Pytest fixtures
 @pytest.fixture
 def query_filter() -> QueryFilter:

--- a/tests/unit/core/test_query_service.py
+++ b/tests/unit/core/test_query_service.py
@@ -637,6 +637,40 @@ class TestQueryServiceFallbackAdditionalPaths:
         assert len(captures) == 0
 
 
+class TestCreateResultDictComplexityScore:
+    """Tests for complexity_score inclusion in _create_result_dict (STEP 8)."""
+
+    def test_create_result_dict_with_complexity(self, query_service: QueryService) -> None:
+        """PluginQueryNode with complexity_score=10 → result dict has 'complexity_score': 10"""
+        from tree_sitter_analyzer.core._query_service_helpers import PluginQueryNode
+        from types import SimpleNamespace
+
+        elem = SimpleNamespace(
+            element_type="method",
+            start_line=1,
+            end_line=5,
+            raw_text="void foo() {}",
+            complexity_score=10,
+        )
+        node = PluginQueryNode(elem, "method")
+        assert node.complexity_score == 10
+
+        result = query_service._create_result_dict(node, "method", "void foo() {}")
+        assert "complexity_score" in result
+        assert result["complexity_score"] == 10
+
+    def test_create_result_dict_without_complexity(self, query_service: QueryService) -> None:
+        """Regular MagicMock node (no PluginQueryNode) → result dict has no 'complexity_score' key"""
+        mock_node = MagicMock()
+        mock_node.type = "function_definition"
+        mock_node.start_point = (0, 0)
+        mock_node.end_point = (5, 0)
+        mock_node.text = b"def test(): pass"
+
+        result = query_service._create_result_dict(mock_node, "test", "def test(): pass")
+        assert "complexity_score" not in result
+
+
 # Pytest fixtures
 @pytest.fixture
 def query_service() -> QueryService:

--- a/tests/unit/core/test_query_service.py
+++ b/tests/unit/core/test_query_service.py
@@ -642,8 +642,9 @@ class TestCreateResultDictComplexityScore:
 
     def test_create_result_dict_with_complexity(self, query_service: QueryService) -> None:
         """PluginQueryNode with complexity_score=10 → result dict has 'complexity_score': 10"""
-        from tree_sitter_analyzer.core._query_service_helpers import PluginQueryNode
         from types import SimpleNamespace
+
+        from tree_sitter_analyzer.core._query_service_helpers import PluginQueryNode
 
         elem = SimpleNamespace(
             element_type="method",

--- a/tests/unit/core/test_query_service_helpers.py
+++ b/tests/unit/core/test_query_service_helpers.py
@@ -330,3 +330,31 @@ class TestFallbackQueryCaptures:
         assert (
             fallback_query_captures(SimpleNamespace(type="x", children=[]), None) == []
         )
+
+
+class TestPluginQueryNodeComplexityScore:
+    """Tests for PluginQueryNode.complexity_score attribute (STEP 6)."""
+
+    def test_plugin_query_node_has_complexity_score(self):
+        """element with complexity_score=8 → PluginQueryNode.complexity_score == 8"""
+        elem = FakeElement()
+        elem.complexity_score = 8
+        node = PluginQueryNode(elem, "function")
+        assert node.complexity_score == 8
+
+    def test_plugin_query_node_no_complexity_score(self):
+        """element without complexity_score attribute → PluginQueryNode.complexity_score is None"""
+        elem = FakeElement()
+        # FakeElement has no complexity_score attribute by default
+        node = PluginQueryNode(elem, "function")
+        assert node.complexity_score is None
+
+    def test_element_to_capture_preserves_complexity(self):
+        """element with complexity_score=12 → _element_to_capture returns PluginQueryNode with complexity_score=12"""
+        elem = FakeElement()
+        elem.complexity_score = 12
+        result = _element_to_capture(elem, "function")
+        assert result is not None
+        node, _ = result
+        assert isinstance(node, PluginQueryNode)
+        assert node.complexity_score == 12

--- a/tests/unit/test_bash_resolver.py
+++ b/tests/unit/test_bash_resolver.py
@@ -1,0 +1,131 @@
+"""Unit tests for synapse_resolver/languages/bash.py.
+
+Verifies that the Bash resolver:
+- always returns ``unknown`` for every callee (the moat contract)
+- builds a context only when Bash files are present in the index
+- registers under the ``"bash"`` language key so the cascade never reaches the
+  Python builtin/stdlib tier for shell callers
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from tree_sitter_analyzer.synapse_resolver.languages.bash import (
+    BashResolverContext,
+    build_bash_resolver_context,
+    resolve_bash_callee,
+)
+from tree_sitter_analyzer.synapse_resolver._registry import registered_languages
+
+
+# ---------------------------------------------------------------------------
+# resolve_bash_callee — always returns unknown
+# ---------------------------------------------------------------------------
+
+
+class TestResolveBashCallee:
+    """resolve_bash_callee must always return (None, "unknown", "")."""
+
+    def _ctx(self) -> BashResolverContext:
+        return BashResolverContext()
+
+    def test_bash_resolver_returns_unknown_for_print(self) -> None:
+        """``print`` (a Python builtin) must stay unknown for Bash callers."""
+        _sym_id, resolution, _resolved_file = resolve_bash_callee(
+            "print", "", "script.sh", self._ctx()
+        )
+        assert resolution == "unknown"
+
+    def test_bash_resolver_returns_unknown_for_list(self) -> None:
+        """``list`` (a Python builtin) must stay unknown for Bash callers."""
+        _sym_id, resolution, _resolved_file = resolve_bash_callee(
+            "list", "", "script.sh", self._ctx()
+        )
+        assert resolution == "unknown"
+
+    def test_bash_resolver_returns_none_symbol_id(self) -> None:
+        """symbol_id component of the tuple must be None (no binding)."""
+        sym_id, _resolution, _resolved_file = resolve_bash_callee(
+            "map", "", "deploy.sh", self._ctx()
+        )
+        assert sym_id is None
+
+    def test_bash_resolver_returns_empty_resolved_file(self) -> None:
+        """resolved_file must be an empty string (no cross-file binding)."""
+        _sym_id, _resolution, resolved_file = resolve_bash_callee(
+            "type", "", "run.sh", self._ctx()
+        )
+        assert resolved_file == ""
+
+    def test_bash_resolver_returns_unknown_for_arbitrary_command(self) -> None:
+        """Any shell command name (e.g. ``echo``) returns unknown."""
+        _sym_id, resolution, _resolved_file = resolve_bash_callee(
+            "echo", "echo", "bootstrap.sh", self._ctx()
+        )
+        assert resolution == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# build_bash_resolver_context — context construction gating
+# ---------------------------------------------------------------------------
+
+
+class TestBuildBashResolverContext:
+    """build_bash_resolver_context must return None when no Bash files exist."""
+
+    _common_kwargs = dict(
+        imports_by_file={},
+        file_symbols={},
+        global_name_table={},
+        file_class_methods=None,
+    )
+
+    def test_bash_context_none_when_no_bash_files(self) -> None:
+        """Returns None for a Python-only project (zero cost)."""
+        ctx = build_bash_resolver_context(
+            file_languages={"main.py": "python"},
+            **self._common_kwargs,
+        )
+        assert ctx is None
+
+    def test_bash_context_built_when_bash_present(self) -> None:
+        """Returns a BashResolverContext when at least one Bash file is indexed."""
+        ctx = build_bash_resolver_context(
+            file_languages={"deploy.sh": "bash"},
+            **self._common_kwargs,
+        )
+        assert isinstance(ctx, BashResolverContext)
+
+    def test_bash_context_built_when_bash_mixed_with_other_languages(self) -> None:
+        """Returns context when Bash is mixed with Python/JS (common CI project)."""
+        ctx = build_bash_resolver_context(
+            file_languages={"main.py": "python", "build.sh": "bash"},
+            **self._common_kwargs,
+        )
+        assert isinstance(ctx, BashResolverContext)
+
+    def test_bash_context_none_when_empty_file_languages(self) -> None:
+        """Returns None for an empty file_languages map."""
+        ctx = build_bash_resolver_context(
+            file_languages={},
+            **self._common_kwargs,
+        )
+        assert ctx is None
+
+
+# ---------------------------------------------------------------------------
+# Registry — bash is registered after module import
+# ---------------------------------------------------------------------------
+
+
+class TestBashRegistered:
+    """``bash`` must appear in registered_languages() after the module is imported."""
+
+    def test_bash_registered_after_import(self) -> None:
+        """Importing bash.py registers 'bash' in the global language registry."""
+        # The module is already imported (top-level import above) and calls
+        # register_language at module level — so 'bash' must be in the registry.
+        assert "bash" in registered_languages()

--- a/tests/unit/test_bash_resolver.py
+++ b/tests/unit/test_bash_resolver.py
@@ -9,17 +9,12 @@ Verifies that the Bash resolver:
 
 from __future__ import annotations
 
-import importlib
-
-import pytest
-
+from tree_sitter_analyzer.synapse_resolver._registry import registered_languages
 from tree_sitter_analyzer.synapse_resolver.languages.bash import (
     BashResolverContext,
     build_bash_resolver_context,
     resolve_bash_callee,
 )
-from tree_sitter_analyzer.synapse_resolver._registry import registered_languages
-
 
 # ---------------------------------------------------------------------------
 # resolve_bash_callee — always returns unknown
@@ -76,12 +71,12 @@ class TestResolveBashCallee:
 class TestBuildBashResolverContext:
     """build_bash_resolver_context must return None when no Bash files exist."""
 
-    _common_kwargs = dict(
-        imports_by_file={},
-        file_symbols={},
-        global_name_table={},
-        file_class_methods=None,
-    )
+    _common_kwargs = {
+        "imports_by_file": {},
+        "file_symbols": {},
+        "global_name_table": {},
+        "file_class_methods": None,
+    }
 
     def test_bash_context_none_when_no_bash_files(self) -> None:
         """Returns None for a Python-only project (zero cost)."""

--- a/tests/unit/test_corpus_exclusion.py
+++ b/tests/unit/test_corpus_exclusion.py
@@ -5,15 +5,12 @@ from __future__ import annotations
 import os
 import sqlite3
 
-import pytest
-
 from tree_sitter_analyzer.cache.indexer import (
     _DEFAULT_EXCLUDE_PATTERNS,
     _walk_source_files,
     walk_and_partition,
 )
 from tree_sitter_analyzer.project_graph import _language_from_ext
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -132,8 +129,8 @@ class TestCorpusExclusion:
             exclude_patterns=_DEFAULT_EXCLUDE_PATTERNS,
         )
 
-        assert stats["skipped"] >= 1, (
-            "At least one file must be counted as skipped due to corpus exclusion"
+        assert stats["skipped"] == 1, (
+            "Exactly one corpus file must be counted as skipped"
         )
 
     def test_no_exclusion_when_patterns_is_none(self, tmp_path):

--- a/tests/unit/test_corpus_exclusion.py
+++ b/tests/unit/test_corpus_exclusion.py
@@ -1,0 +1,164 @@
+"""Tests for REQ-E-016: corpus-directory exclusion in walk_and_partition."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+
+import pytest
+
+from tree_sitter_analyzer.cache.indexer import (
+    _DEFAULT_EXCLUDE_PATTERNS,
+    _walk_source_files,
+    walk_and_partition,
+)
+from tree_sitter_analyzer.project_graph import _language_from_ext
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class _MockCache:
+    """Minimal stand-in for ASTCache — walk_and_partition only needs project_root."""
+
+    def __init__(self, root: str) -> None:
+        self.project_root = root
+
+
+def _make_conn() -> sqlite3.Connection:
+    """Return an in-memory SQLite connection with the minimal ast_index schema."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        "CREATE TABLE ast_index ("
+        "  file_path TEXT PRIMARY KEY,"
+        "  content_hash TEXT,"
+        "  mtime_ns INTEGER,"
+        "  file_size INTEGER,"
+        "  extractor_version INTEGER"
+        ")"
+    )
+    conn.commit()
+    return conn
+
+
+def _make_error_entry(rel_path: str, reason: str) -> dict:
+    return {"file": rel_path, "status": "error", "reason": reason}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestCorpusExclusion:
+    def test_corpus_file_excluded_from_candidates(self, tmp_path):
+        """Files under tests/golden/corpus_* must NOT appear in candidates."""
+        corpus_dir = tmp_path / "tests" / "golden"
+        corpus_dir.mkdir(parents=True)
+        (corpus_dir / "corpus_swift.swift").write_text("// swift source\n")
+
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        (src_dir / "main.py").write_text("x = 1\n")
+
+        cache = _MockCache(str(tmp_path))
+        conn = _make_conn()
+
+        _, candidates, _ = walk_and_partition(
+            cache,
+            conn,
+            max_files=10_000,
+            force=True,
+            activation_enabled=False,
+            walk_fn=_walk_source_files,
+            language_fn=_language_from_ext,
+            extractor_version=1,
+            make_error_entry=_make_error_entry,
+            exclude_patterns=_DEFAULT_EXCLUDE_PATTERNS,
+        )
+
+        candidate_names = {os.path.basename(p) for p, _ in candidates}
+        assert "corpus_swift.swift" not in candidate_names, (
+            "corpus_swift.swift should be excluded by _DEFAULT_EXCLUDE_PATTERNS"
+        )
+
+    def test_non_corpus_source_file_included(self, tmp_path):
+        """Normal source files must NOT be excluded."""
+        src_dir = tmp_path / "src"
+        src_dir.mkdir()
+        (src_dir / "main.py").write_text("x = 1\n")
+
+        cache = _MockCache(str(tmp_path))
+        conn = _make_conn()
+
+        _, candidates, _ = walk_and_partition(
+            cache,
+            conn,
+            max_files=10_000,
+            force=True,
+            activation_enabled=False,
+            walk_fn=_walk_source_files,
+            language_fn=_language_from_ext,
+            extractor_version=1,
+            make_error_entry=_make_error_entry,
+            exclude_patterns=_DEFAULT_EXCLUDE_PATTERNS,
+        )
+
+        candidate_names = {os.path.basename(p) for p, _ in candidates}
+        assert "main.py" in candidate_names, (
+            "main.py must be included; it does not match corpus exclusion patterns"
+        )
+
+    def test_exclusion_skipped_stat_incremented(self, tmp_path):
+        """Excluded files must increment stats['skipped']."""
+        corpus_dir = tmp_path / "tests" / "golden"
+        corpus_dir.mkdir(parents=True)
+        (corpus_dir / "corpus_go.go").write_text("package main\n")
+
+        cache = _MockCache(str(tmp_path))
+        conn = _make_conn()
+
+        stats, _, _ = walk_and_partition(
+            cache,
+            conn,
+            max_files=10_000,
+            force=True,
+            activation_enabled=False,
+            walk_fn=_walk_source_files,
+            language_fn=_language_from_ext,
+            extractor_version=1,
+            make_error_entry=_make_error_entry,
+            exclude_patterns=_DEFAULT_EXCLUDE_PATTERNS,
+        )
+
+        assert stats["skipped"] >= 1, (
+            "At least one file must be counted as skipped due to corpus exclusion"
+        )
+
+    def test_no_exclusion_when_patterns_is_none(self, tmp_path):
+        """When exclude_patterns=None the corpus file is NOT excluded."""
+        corpus_dir = tmp_path / "tests" / "golden"
+        corpus_dir.mkdir(parents=True)
+        (corpus_dir / "corpus_swift.swift").write_text("// swift source\n")
+
+        cache = _MockCache(str(tmp_path))
+        conn = _make_conn()
+
+        _, candidates, _ = walk_and_partition(
+            cache,
+            conn,
+            max_files=10_000,
+            force=True,
+            activation_enabled=False,
+            walk_fn=_walk_source_files,
+            language_fn=_language_from_ext,
+            extractor_version=1,
+            make_error_entry=_make_error_entry,
+            exclude_patterns=None,
+        )
+
+        candidate_names = {os.path.basename(p) for p, _ in candidates}
+        assert "corpus_swift.swift" in candidate_names, (
+            "Without exclude_patterns the corpus file must reach the candidate list"
+        )

--- a/tests/unit/test_lua_extractor.py
+++ b/tests/unit/test_lua_extractor.py
@@ -1,0 +1,109 @@
+"""Unit tests for LuaElementExtractor.
+
+Covers:
+  1. Graceful degradation when tree_sitter_lua is absent (always runs).
+  2. Actual function/import extraction with a real Lua parse tree
+     (skipped automatically when tree_sitter_lua is not installed).
+"""
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Availability guard — defined BEFORE any skipif that references it
+# ---------------------------------------------------------------------------
+
+def _tslua_available() -> bool:
+    """Return True when tree_sitter_lua is importable in the current env."""
+    try:
+        import importlib
+
+        importlib.import_module("tree_sitter_lua")
+        return True
+    except ImportError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Test 1: graceful degradation (always runs, no real Lua grammar needed)
+# ---------------------------------------------------------------------------
+
+
+def test_lua_extractor_graceful_when_no_tslua(monkeypatch: pytest.MonkeyPatch) -> None:
+    """extract_functions and extract_imports return [] without crashing when
+    tree_sitter_lua is not available in sys.modules.
+    """
+    # Block the Lua grammar package.  Python treats a None entry in sys.modules
+    # as a failed import and raises ImportError when the name is requested.
+    monkeypatch.setitem(sys.modules, "tree_sitter_lua", None)
+
+    # Import here (after the patch) so that any cached module object is still
+    # safe — the lazy import inside _get_lua_language() re-checks sys.modules
+    # at call time, which is what we rely on.
+    from tree_sitter_analyzer.languages.lua_plugin.extractor import LuaElementExtractor
+
+    extractor = LuaElementExtractor()
+    mock_tree = MagicMock()
+
+    result_functions = extractor.extract_functions(mock_tree, "")
+    result_imports = extractor.extract_imports(mock_tree, "")
+
+    assert result_functions == [], (
+        "extract_functions() must return [] when tree_sitter_lua is unavailable"
+    )
+    assert result_imports == [], (
+        "extract_imports() must return [] when tree_sitter_lua is unavailable"
+    )
+
+    # extract_classes and extract_variables always return []; verify here too.
+    assert extractor.extract_classes(mock_tree, "") == []
+    assert extractor.extract_variables(mock_tree, "") == []
+
+
+# ---------------------------------------------------------------------------
+# Test 2: real extraction (skipped unless tree_sitter_lua is installed)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _tslua_available(), reason="tree_sitter_lua not installed")
+def test_lua_extractor_extracts_functions_and_imports() -> None:
+    """With tree_sitter_lua installed, named and local functions are extracted
+    and require() calls appear as import elements.
+    """
+    import tree_sitter
+    import tree_sitter_lua as tslua
+
+    from tree_sitter_analyzer.languages.lua_plugin.extractor import LuaElementExtractor
+
+    source = """\
+local json = require("json")
+local socket = require("socket.http")
+
+function greet(name)
+    print("Hello, " .. name)
+end
+
+local function add(a, b)
+    return a + b
+end
+"""
+    language = tree_sitter.Language(tslua.language())
+    parser = tree_sitter.Parser()
+    parser.language = language
+    tree = parser.parse(bytes(source, "utf-8"))
+
+    extractor = LuaElementExtractor()
+
+    functions = extractor.extract_functions(tree, source)
+    func_names = [f.name for f in functions]
+    assert "greet" in func_names, f"Expected 'greet' in {func_names}"
+    assert "add" in func_names, f"Expected 'add' in {func_names}"
+
+    imports = extractor.extract_imports(tree, source)
+    import_paths = [i.module_path for i in imports]
+    assert "json" in import_paths, f"Expected 'json' in {import_paths}"
+    assert "socket.http" in import_paths, f"Expected 'socket.http' in {import_paths}"

--- a/tests/unit/test_lua_extractor.py
+++ b/tests/unit/test_lua_extractor.py
@@ -2,7 +2,8 @@
 
 Covers:
   1. Graceful degradation when tree_sitter_lua is absent (always runs).
-  2. Actual function/import extraction with a real Lua parse tree
+  2. Mock-grammar extraction tests (always runs — no real Lua grammar needed).
+  3. Actual function/import extraction with a real Lua parse tree
      (skipped automatically when tree_sitter_lua is not installed).
 """
 from __future__ import annotations
@@ -64,7 +65,151 @@ def test_lua_extractor_graceful_when_no_tslua(monkeypatch: pytest.MonkeyPatch) -
 
 
 # ---------------------------------------------------------------------------
-# Test 2: real extraction (skipped unless tree_sitter_lua is installed)
+# Test 2: mock-grammar extraction (always runs — covers function body lines)
+# ---------------------------------------------------------------------------
+
+
+def _make_name_node(name: bytes, start: tuple[int, int] = (0, 0), end: tuple[int, int] = (5, 0)) -> MagicMock:
+    """Build a mock name node whose parent is a valid function declaration node."""
+    fn_node = MagicMock()
+    fn_node.type = "function_declaration"
+    fn_node.start_point = start
+    fn_node.end_point = end
+    fn_node.text = b"function " + name + b"() end"
+
+    name_node = MagicMock()
+    name_node.text = name
+    name_node.parent = fn_node
+    return name_node
+
+
+def _make_path_node(path: bytes) -> MagicMock:
+    """Build a mock path node (string_content) whose ancestor chain ends at a function_call."""
+    call_node = MagicMock()
+    call_node.type = "function_call"
+    call_node.start_point = (0, 0)
+    call_node.end_point = (0, len(path) + 10)
+    call_node.text = b'require("' + path + b'")'
+
+    string_node = MagicMock()
+    string_node.parent = call_node
+
+    path_node = MagicMock()
+    path_node.text = path
+    path_node.parent = string_node
+    return path_node
+
+
+def test_lua_extract_functions_with_mock_grammar(monkeypatch: pytest.MonkeyPatch) -> None:
+    """extract_functions returns ModelFunction entries when the grammar mock yields name nodes."""
+    from tree_sitter_analyzer.languages.lua_plugin.extractor import LuaElementExtractor
+
+    mock_lang = MagicMock()
+    mock_query = MagicMock()
+    mock_query.captures.return_value = {
+        "name": [_make_name_node(b"greet"), _make_name_node(b"add")],
+    }
+
+    MockQuery = MagicMock(return_value=mock_query)
+    mock_ts = MagicMock()
+    mock_ts.Query = MockQuery
+
+    extractor = LuaElementExtractor()
+    monkeypatch.setattr(extractor, "_get_lua_language", lambda: mock_lang)
+    monkeypatch.setitem(sys.modules, "tree_sitter", mock_ts)
+
+    mock_tree = MagicMock()
+    result = extractor.extract_functions(mock_tree, "")
+
+    assert len(result) == 2
+    names = [f.name for f in result]
+    assert "greet" in names
+    assert "add" in names
+    assert all(f.language == "lua" for f in result)
+
+
+def test_lua_extract_functions_skips_none_parent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Name node with no parent (parent=None) must be skipped without crashing."""
+    from tree_sitter_analyzer.languages.lua_plugin.extractor import LuaElementExtractor
+
+    orphan = MagicMock()
+    orphan.text = b"orphan"
+    orphan.parent = None
+
+    mock_lang = MagicMock()
+    mock_query = MagicMock()
+    mock_query.captures.return_value = {"name": [orphan]}
+
+    mock_ts = MagicMock()
+    mock_ts.Query = MagicMock(return_value=mock_query)
+
+    extractor = LuaElementExtractor()
+    monkeypatch.setattr(extractor, "_get_lua_language", lambda: mock_lang)
+    monkeypatch.setitem(sys.modules, "tree_sitter", mock_ts)
+
+    result = extractor.extract_functions(MagicMock(), "")
+    assert result == [], "orphan name node must be silently skipped"
+
+
+def test_lua_extract_functions_outer_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    """extract_functions catches outer exception and returns empty list."""
+    from tree_sitter_analyzer.languages.lua_plugin.extractor import LuaElementExtractor
+
+    mock_lang = MagicMock()
+    mock_ts = MagicMock()
+    mock_ts.Query.side_effect = RuntimeError("grammar broken")
+
+    extractor = LuaElementExtractor()
+    monkeypatch.setattr(extractor, "_get_lua_language", lambda: mock_lang)
+    monkeypatch.setitem(sys.modules, "tree_sitter", mock_ts)
+
+    result = extractor.extract_functions(MagicMock(), "")
+    assert result == []
+
+
+def test_lua_extract_imports_with_mock_grammar(monkeypatch: pytest.MonkeyPatch) -> None:
+    """extract_imports returns ModelImport entries when the grammar mock yields path nodes."""
+    from tree_sitter_analyzer.languages.lua_plugin.extractor import LuaElementExtractor
+
+    mock_lang = MagicMock()
+    mock_query = MagicMock()
+    mock_query.captures.return_value = {
+        "path": [_make_path_node(b"json"), _make_path_node(b"socket.http")],
+    }
+
+    mock_ts = MagicMock()
+    mock_ts.Query = MagicMock(return_value=mock_query)
+
+    extractor = LuaElementExtractor()
+    monkeypatch.setattr(extractor, "_get_lua_language", lambda: mock_lang)
+    monkeypatch.setitem(sys.modules, "tree_sitter", mock_ts)
+
+    result = extractor.extract_imports(MagicMock(), "")
+
+    assert len(result) == 2
+    paths = [i.module_path for i in result]
+    assert "json" in paths
+    assert "socket.http" in paths
+
+
+def test_lua_extract_imports_outer_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    """extract_imports catches outer exception and returns empty list."""
+    from tree_sitter_analyzer.languages.lua_plugin.extractor import LuaElementExtractor
+
+    mock_lang = MagicMock()
+    mock_ts = MagicMock()
+    mock_ts.Query.side_effect = RuntimeError("query compile error")
+
+    extractor = LuaElementExtractor()
+    monkeypatch.setattr(extractor, "_get_lua_language", lambda: mock_lang)
+    monkeypatch.setitem(sys.modules, "tree_sitter", mock_ts)
+
+    result = extractor.extract_imports(MagicMock(), "")
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Test 3: real extraction (skipped unless tree_sitter_lua is installed)
 # ---------------------------------------------------------------------------
 
 

--- a/tests/unit/test_lua_extractor.py
+++ b/tests/unit/test_lua_extractor.py
@@ -12,7 +12,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # Availability guard — defined BEFORE any skipif that references it
 # ---------------------------------------------------------------------------
@@ -69,7 +68,7 @@ def test_lua_extractor_graceful_when_no_tslua(monkeypatch: pytest.MonkeyPatch) -
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.skipif(not _tslua_available(), reason="tree_sitter_lua not installed")
+@pytest.mark.skipif(not _tslua_available(), reason="tree_sitter_lua not installed; tracked: optional-dep skip")
 def test_lua_extractor_extracts_functions_and_imports() -> None:
     """With tree_sitter_lua installed, named and local functions are extracted
     and require() calls appear as import elements.

--- a/tests/unit/test_plugin_skip_warning.py
+++ b/tests/unit/test_plugin_skip_warning.py
@@ -1,0 +1,188 @@
+"""Tests for REQ-E-020: plugin-extension skip WARNING in walk_and_partition."""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+
+import pytest
+
+import tree_sitter_analyzer.cache.indexer as _indexer_mod
+from tree_sitter_analyzer.cache.indexer import walk_and_partition
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class _MockCache:
+    """Minimal stand-in for ASTCache."""
+
+    def __init__(self, root: str) -> None:
+        self.project_root = root
+
+
+def _make_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        "CREATE TABLE ast_index ("
+        "  file_path TEXT PRIMARY KEY,"
+        "  content_hash TEXT,"
+        "  mtime_ns INTEGER,"
+        "  file_size INTEGER,"
+        "  extractor_version INTEGER"
+        ")"
+    )
+    conn.commit()
+    return conn
+
+
+def _make_error_entry(rel_path: str, reason: str) -> dict:
+    return {"file": rel_path, "status": "error", "reason": reason}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestPluginSkipWarning:
+    def setup_method(self):
+        """Clear the de-duplication set before each test for isolation."""
+        _indexer_mod._warned_extensions.clear()
+
+    def test_css_skip_emits_warning(self, tmp_path, caplog):
+        """A .css file skipped because language_fn returns None must produce a WARNING."""
+        css_file = tmp_path / "style.css"
+        css_file.write_text("body { color: red; }\n")
+
+        cache = _MockCache(str(tmp_path))
+        conn = _make_conn()
+
+        def _walk_css(root: str):
+            yield str(css_file)
+
+        def _lang_none(path: str):
+            return None  # simulate: .css not in EXT_TO_LANG
+
+        with caplog.at_level(logging.WARNING, logger="tree_sitter_analyzer.cache.indexer"):
+            walk_and_partition(
+                cache,
+                conn,
+                max_files=10_000,
+                force=True,
+                activation_enabled=False,
+                walk_fn=_walk_css,
+                language_fn=_lang_none,
+                extractor_version=1,
+                make_error_entry=_make_error_entry,
+            )
+
+        warning_messages = [
+            r.getMessage() for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert any(".css" in msg for msg in warning_messages), (
+            f"Expected a WARNING mentioning .css; got: {warning_messages}"
+        )
+
+    def test_warning_emitted_only_once_per_extension(self, tmp_path, caplog):
+        """The warning for a given extension must be emitted at most once."""
+        css1 = tmp_path / "a.css"
+        css2 = tmp_path / "b.css"
+        css1.write_text("a {}\n")
+        css2.write_text("b {}\n")
+
+        cache = _MockCache(str(tmp_path))
+        conn = _make_conn()
+
+        def _walk_both(root: str):
+            yield str(css1)
+            yield str(css2)
+
+        def _lang_none(path: str):
+            return None
+
+        with caplog.at_level(logging.WARNING, logger="tree_sitter_analyzer.cache.indexer"):
+            walk_and_partition(
+                cache,
+                conn,
+                max_files=10_000,
+                force=True,
+                activation_enabled=False,
+                walk_fn=_walk_both,
+                language_fn=_lang_none,
+                extractor_version=1,
+                make_error_entry=_make_error_entry,
+            )
+
+        css_warnings = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING and ".css" in r.getMessage()
+        ]
+        assert len(css_warnings) == 1, (
+            f"Expected exactly 1 .css WARNING; got {len(css_warnings)}: {css_warnings}"
+        )
+
+    def test_unknown_extension_does_not_warn(self, tmp_path, caplog):
+        """Extensions not in _PLUGIN_EXTS must NOT produce a WARNING."""
+        foo_file = tmp_path / "data.foo"
+        foo_file.write_text("data\n")
+
+        cache = _MockCache(str(tmp_path))
+        conn = _make_conn()
+
+        def _walk_foo(root: str):
+            yield str(foo_file)
+
+        def _lang_none(path: str):
+            return None
+
+        with caplog.at_level(logging.WARNING, logger="tree_sitter_analyzer.cache.indexer"):
+            walk_and_partition(
+                cache,
+                conn,
+                max_files=10_000,
+                force=True,
+                activation_enabled=False,
+                walk_fn=_walk_foo,
+                language_fn=_lang_none,
+                extractor_version=1,
+                make_error_entry=_make_error_entry,
+            )
+
+        warning_messages = [
+            r.getMessage() for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert not any(".foo" in msg for msg in warning_messages), (
+            f"Unexpected .foo WARNING emitted: {warning_messages}"
+        )
+
+    def test_file_still_skipped_after_warning(self, tmp_path, caplog):
+        """The .css file must remain excluded from candidates even after the warning."""
+        css_file = tmp_path / "style.css"
+        css_file.write_text("body {}\n")
+
+        cache = _MockCache(str(tmp_path))
+        conn = _make_conn()
+
+        def _walk_css(root: str):
+            yield str(css_file)
+
+        def _lang_none(path: str):
+            return None
+
+        with caplog.at_level(logging.WARNING, logger="tree_sitter_analyzer.cache.indexer"):
+            stats, candidates, _ = walk_and_partition(
+                cache,
+                conn,
+                max_files=10_000,
+                force=True,
+                activation_enabled=False,
+                walk_fn=_walk_css,
+                language_fn=_lang_none,
+                extractor_version=1,
+                make_error_entry=_make_error_entry,
+            )
+
+        assert candidates == [], f"Expected no candidates; got {candidates}"
+        assert stats["skipped"] == 1

--- a/tests/unit/test_plugin_skip_warning.py
+++ b/tests/unit/test_plugin_skip_warning.py
@@ -5,11 +5,8 @@ from __future__ import annotations
 import logging
 import sqlite3
 
-import pytest
-
 import tree_sitter_analyzer.cache.indexer as _indexer_mod
 from tree_sitter_analyzer.cache.indexer import walk_and_partition
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/unit/test_route_detector_cache.py
+++ b/tests/unit/test_route_detector_cache.py
@@ -81,6 +81,7 @@ class TestRouteCachePersistence:
 
     @pytest.mark.performance
     @pytest.mark.quarantine
+    @pytest.mark.slow
     def test_warm_pass_is_meaningfully_faster_than_cold(self, tmp_path: Path):
         """PERF-1 regression guard: the cache must produce a >=3x speedup on
         second invocation. (Real-world numbers on the analyzer's own repo

--- a/tests/unit/test_scala_resolver.py
+++ b/tests/unit/test_scala_resolver.py
@@ -116,6 +116,83 @@ class TestResolveScalaCallee:
         assert sym_id is None
         assert resolved_file == ""
 
+    def test_receiver_guard_skips_local_for_dotted_callee(self) -> None:
+        """Tier (a) receiver guard: dotted callee_full must NOT match a local symbol.
+
+        When the call site is `items.map`, callee_full='items.map' contains a dot.
+        Even if 'map' exists locally, the resolver must skip local lookup and fall
+        through to tier (c) / unknown — preventing false edges for stdlib/receiver calls.
+        """
+        ctx = ScalaResolverContext(
+            file_symbols={
+                "src/Main.scala": [("map", "function", 5)],
+            },
+            global_name_table={},
+            name_to_source={},
+        )
+        sym_id, resolution, resolved_file = resolve_scala_callee(
+            "map", "items.map", "src/Main.scala", ctx
+        )
+        assert resolution == "unknown", (
+            "Receiver call items.map must not bind to local 'map' symbol (M-3 guard)"
+        )
+        assert sym_id is None
+        assert resolved_file == ""
+
+    def test_tier_b_named_import_returns_unknown(self) -> None:
+        """Tier (b): callee matching an explicit named import returns 'unknown'.
+
+        Scala import resolution to the actual source file is a follow-on task (P0).
+        Until that work lands, tier (b) must acknowledge the import with 'unknown'
+        rather than misrouting to a project-wide match.
+        """
+        ctx = ScalaResolverContext(
+            file_symbols={
+                "src/App.scala": [],
+                "src/Lib.scala": [("Helper", "class", 77)],
+            },
+            global_name_table={
+                "Helper": [("src/Lib.scala", 77)],
+            },
+            name_to_source={
+                "src/App.scala": {"Helper": "com.example.Lib.Helper"},
+            },
+        )
+        sym_id, resolution, resolved_file = resolve_scala_callee(
+            "Helper", "", "src/App.scala", ctx
+        )
+        assert resolution == "unknown"
+        assert sym_id is None
+
+    def test_build_context_populates_name_to_source(self) -> None:
+        """build_scala_resolver_context stores named imports in name_to_source."""
+
+        class _FakeImport:
+            def __init__(self, local_name: str, module_path: str, is_star: bool = False) -> None:
+                self.local_name = local_name
+                self.module_path = module_path
+                self.is_star = is_star
+
+        ctx = build_scala_resolver_context(
+            file_languages={"src/App.scala": "scala"},
+            imports_by_file={
+                "src/App.scala": [
+                    _FakeImport("JsonParser", "com.example.json.JsonParser"),
+                    _FakeImport("", "com.example.util"),           # no local_name — skip
+                    _FakeImport("*", "com.example.star", is_star=True),  # star — skip
+                ],
+            },
+            file_symbols={},
+            global_name_table={},
+            file_class_methods=None,
+        )
+        assert ctx is not None
+        assert "src/App.scala" in ctx.name_to_source
+        name_map = ctx.name_to_source["src/App.scala"]
+        assert "JsonParser" in name_map
+        assert name_map["JsonParser"] == "com.example.json.JsonParser"
+        assert "*" not in name_map, "star imports must be excluded from name_to_source"
+
     def test_scala_resolver_no_cross_language_binding(self) -> None:
         """Tier (c): a symbol that exists only in a Python file must NOT resolve to 'project'.
 

--- a/tests/unit/test_scala_resolver.py
+++ b/tests/unit/test_scala_resolver.py
@@ -1,0 +1,171 @@
+"""Unit tests for synapse_resolver/languages/scala.py.
+
+Verifies that the Scala resolver:
+- returns None context when no Scala files exist in the index
+- builds a context when at least one Scala file is present
+- resolves local symbols (tier a) to "local"
+- resolves a uniquely project-wide symbol (tier c) to "project"
+- falls back to "unknown" for unresolvable names
+- does NOT bind a Scala call to a Python/Go symbol that shares the same bare
+  name (M-1 fix: Scala-only filtering of file_symbols)
+- registers under the "scala" language key so the cascade never accidentally
+  reaches the Python builtin/stdlib tier for Scala callers
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from tree_sitter_analyzer.synapse_resolver.languages.scala import (
+    ScalaResolverContext,
+    build_scala_resolver_context,
+    resolve_scala_callee,
+)
+from tree_sitter_analyzer.synapse_resolver._registry import registered_languages
+
+
+# ---------------------------------------------------------------------------
+# build_scala_resolver_context — context construction gating
+# ---------------------------------------------------------------------------
+
+
+class TestBuildScalaResolverContext:
+    """build_scala_resolver_context must return None when no Scala files exist."""
+
+    _common_kwargs: dict = dict(
+        imports_by_file={},
+        file_symbols={},
+        global_name_table={},
+        file_class_methods=None,
+    )
+
+    def test_build_context_returns_none_for_non_scala_project(self) -> None:
+        """Returns None for a Python-only project (zero cost for absent language)."""
+        ctx = build_scala_resolver_context(
+            file_languages={"main.py": "python", "util.go": "go"},
+            **self._common_kwargs,
+        )
+        assert ctx is None
+
+    def test_build_context_returns_context_for_scala_project(self) -> None:
+        """Returns a ScalaResolverContext when at least one .scala file is indexed."""
+        ctx = build_scala_resolver_context(
+            file_languages={"App.scala": "scala", "util.py": "python"},
+            **self._common_kwargs,
+        )
+        assert isinstance(ctx, ScalaResolverContext)
+
+
+# ---------------------------------------------------------------------------
+# resolve_scala_callee — resolution cascade
+# ---------------------------------------------------------------------------
+
+
+class TestResolveScalaCallee:
+    """Verify each tier of the Scala resolution cascade."""
+
+    def test_scala_resolver_local_cascade(self) -> None:
+        """Tier (a): a name defined in the same file resolves to 'local'."""
+        ctx = ScalaResolverContext(
+            file_symbols={
+                "src/Main.scala": [("parseArgs", "function", 7)],
+            },
+            global_name_table={},
+            name_to_source={},
+        )
+        sym_id, resolution, resolved_file = resolve_scala_callee(
+            "parseArgs", "", "src/Main.scala", ctx
+        )
+        assert resolution == "local"
+        assert sym_id == 7
+        assert resolved_file == "src/Main.scala"
+
+    def test_scala_resolver_project_cascade(self) -> None:
+        """Tier (c): a name with exactly one project-wide entry resolves to 'project'."""
+        # "Helper" is defined only in utils.scala and that file is in file_symbols.
+        ctx = ScalaResolverContext(
+            file_symbols={
+                "src/App.scala": [("run", "function", 1)],
+                "src/utils.scala": [("Helper", "class", 99)],
+            },
+            global_name_table={
+                "Helper": [("src/utils.scala", 99)],
+            },
+            name_to_source={},
+        )
+        sym_id, resolution, resolved_file = resolve_scala_callee(
+            "Helper", "", "src/App.scala", ctx
+        )
+        assert resolution == "project"
+        assert sym_id == 99
+        assert resolved_file == "src/utils.scala"
+
+    def test_scala_resolver_unknown_fallback(self) -> None:
+        """Unresolvable name (not local, not in imports, not uniquely global) -> 'unknown'."""
+        ctx = ScalaResolverContext(
+            file_symbols={
+                "src/App.scala": [("run", "function", 1)],
+            },
+            # "phantom" appears twice — ambiguous, no unique resolution.
+            global_name_table={
+                "phantom": [("src/A.scala", 10), ("src/B.scala", 20)],
+            },
+            name_to_source={},
+        )
+        sym_id, resolution, resolved_file = resolve_scala_callee(
+            "phantom", "", "src/App.scala", ctx
+        )
+        assert resolution == "unknown"
+        assert sym_id is None
+        assert resolved_file == ""
+
+    def test_scala_resolver_no_cross_language_binding(self) -> None:
+        """Tier (c): a symbol that exists only in a Python file must NOT resolve to 'project'.
+
+        This tests the M-1 fix: build_scala_resolver_context filters file_symbols
+        to Scala-only, so a Python-defined 'MyClass' that happens to share a name
+        with a Scala call target is never surfaced as a project-level match.
+        """
+        # Build context the same way the real pipeline does — via the builder.
+        ctx = build_scala_resolver_context(
+            # Only App.scala is Scala; main.py is Python.
+            file_languages={"src/App.scala": "scala", "main.py": "python"},
+            imports_by_file={},
+            # MyClass lives in a Python file, not a Scala file.
+            file_symbols={
+                "main.py": [("MyClass", "class", 42)],
+            },
+            # global_name_table points the name to the Python file.
+            global_name_table={
+                "MyClass": [("main.py", 42)],
+            },
+            file_class_methods=None,
+        )
+        assert ctx is not None, "Context must be built (App.scala is present)"
+
+        # Resolving "MyClass" from the Scala caller must NOT bind to main.py.
+        sym_id, resolution, resolved_file = resolve_scala_callee(
+            "MyClass", "", "src/App.scala", ctx
+        )
+        assert resolution != "project", (
+            "Scala resolver must not bind to a Python-only symbol (M-1 fix)"
+        )
+        assert resolution == "unknown"
+        assert sym_id is None
+
+
+# ---------------------------------------------------------------------------
+# Registry — scala is registered after module import
+# ---------------------------------------------------------------------------
+
+
+class TestScalaRegistered:
+    """'scala' must appear in registered_languages() after the module is imported."""
+
+    def test_scala_registered_after_import(self) -> None:
+        """Importing scala.py registers 'scala' in the global language registry."""
+        # The module is already imported (top-level import above) and calls
+        # register_language at module level — so 'scala' must be in the registry.
+        assert "scala" in registered_languages()

--- a/tests/unit/test_scala_resolver.py
+++ b/tests/unit/test_scala_resolver.py
@@ -14,17 +14,12 @@ Verifies that the Scala resolver:
 
 from __future__ import annotations
 
-import importlib
-
-import pytest
-
+from tree_sitter_analyzer.synapse_resolver._registry import registered_languages
 from tree_sitter_analyzer.synapse_resolver.languages.scala import (
     ScalaResolverContext,
     build_scala_resolver_context,
     resolve_scala_callee,
 )
-from tree_sitter_analyzer.synapse_resolver._registry import registered_languages
-
 
 # ---------------------------------------------------------------------------
 # build_scala_resolver_context — context construction gating
@@ -34,12 +29,12 @@ from tree_sitter_analyzer.synapse_resolver._registry import registered_languages
 class TestBuildScalaResolverContext:
     """build_scala_resolver_context must return None when no Scala files exist."""
 
-    _common_kwargs: dict = dict(
-        imports_by_file={},
-        file_symbols={},
-        global_name_table={},
-        file_class_methods=None,
-    )
+    _common_kwargs: dict = {
+        "imports_by_file": {},
+        "file_symbols": {},
+        "global_name_table": {},
+        "file_class_methods": None,
+    }
 
     def test_build_context_returns_none_for_non_scala_project(self) -> None:
         """Returns None for a Python-only project (zero cost for absent language)."""

--- a/tests/unit/test_star_import_resolution.py
+++ b/tests/unit/test_star_import_resolution.py
@@ -1,0 +1,210 @@
+"""Regression tests for star-import expansion in _build_import_maps.
+
+Verifies that ``from M import *`` entries are expanded into per-name
+name_to_source entries when file_symbols is supplied, and that external
+modules are silently skipped (REQ-N-013).
+"""
+
+from __future__ import annotations
+
+from tree_sitter_analyzer.synapse_resolver._context import _build_import_maps
+from tree_sitter_analyzer.synapse_resolver._imports import ImportEntry
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_star_entry(
+    caller: str,
+    module_path: str,
+    *,
+    is_relative: bool = False,
+) -> ImportEntry:
+    return ImportEntry(
+        file_path=caller,
+        language="python",
+        module_path=module_path,
+        local_name="",
+        is_relative=is_relative,
+        is_star=True,
+        alias_of="",
+        line=1,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 1: star import from a project-local sibling resolves exported names
+# ---------------------------------------------------------------------------
+
+
+class TestStarImportResolvesExportedNameToProject:
+    """``from .sibling import *`` maps each exported name to sibling.py."""
+
+    def test_exported_function_in_name_to_source(self) -> None:
+        # pkg/sibling.py exports helper()
+        file_symbols = {
+            "pkg/sibling.py": [("helper", "function", 10)],
+        }
+        imports_by_file = {
+            "pkg/caller.py": [
+                _make_star_entry("pkg/caller.py", ".sibling", is_relative=True),
+            ],
+        }
+        # module_to_file maps the file path to itself (path-keyed)
+        module_to_file: dict[str, str] = {"pkg/sibling.py": "pkg/sibling.py"}
+
+        name_to_source, _alias = _build_import_maps(
+            imports_by_file, module_to_file, file_symbols
+        )
+
+        assert "pkg/caller.py" in name_to_source
+        assert name_to_source["pkg/caller.py"]["helper"] == "pkg/sibling.py"
+
+    def test_multiple_exported_names_all_mapped(self) -> None:
+        file_symbols = {
+            "pkg/sibling.py": [
+                ("func_a", "function", 5),
+                ("MyClass", "class", 20),
+            ],
+        }
+        imports_by_file = {
+            "pkg/caller.py": [
+                _make_star_entry("pkg/caller.py", ".sibling", is_relative=True),
+            ],
+        }
+        module_to_file = {"pkg/sibling.py": "pkg/sibling.py"}
+
+        name_to_source, _ = _build_import_maps(
+            imports_by_file, module_to_file, file_symbols
+        )
+
+        assert name_to_source["pkg/caller.py"]["func_a"] == "pkg/sibling.py"
+        assert name_to_source["pkg/caller.py"]["MyClass"] == "pkg/sibling.py"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: name not exported by starred module is not in name_to_source
+# ---------------------------------------------------------------------------
+
+
+class TestStarImportNonExportedNameStaysUnknown:
+    """Names absent from the starred module's file_symbols are not injected."""
+
+    def test_unknown_name_not_in_name_to_source(self) -> None:
+        # sibling.py only exports "helper"; "secret" is not exported
+        file_symbols = {
+            "pkg/sibling.py": [("helper", "function", 10)],
+        }
+        imports_by_file = {
+            "pkg/caller.py": [
+                _make_star_entry("pkg/caller.py", ".sibling", is_relative=True),
+            ],
+        }
+        module_to_file = {"pkg/sibling.py": "pkg/sibling.py"}
+
+        name_to_source, _ = _build_import_maps(
+            imports_by_file, module_to_file, file_symbols
+        )
+
+        caller_map = name_to_source.get("pkg/caller.py", {})
+        assert "secret" not in caller_map
+
+    def test_no_symbols_in_starred_module_produces_no_entry(self) -> None:
+        # sibling.py is in file_symbols but has no symbols (empty list)
+        file_symbols: dict[str, list[tuple[str, str, int]]] = {
+            "pkg/sibling.py": [],
+        }
+        imports_by_file = {
+            "pkg/caller.py": [
+                _make_star_entry("pkg/caller.py", ".sibling", is_relative=True),
+            ],
+        }
+        module_to_file = {"pkg/sibling.py": "pkg/sibling.py"}
+
+        name_to_source, _ = _build_import_maps(
+            imports_by_file, module_to_file, file_symbols
+        )
+
+        # No symbols to inject — caller should have no entry
+        assert "pkg/caller.py" not in name_to_source
+
+
+# ---------------------------------------------------------------------------
+# Test 3: star import from an external module produces no name_to_source entry
+# ---------------------------------------------------------------------------
+
+
+class TestStarImportExternalModuleSkipped:
+    """``from os import *`` produces no name_to_source entries (REQ-N-013)."""
+
+    def test_external_module_not_in_module_to_file(self) -> None:
+        file_symbols: dict[str, list[tuple[str, str, int]]] = {}
+        imports_by_file = {
+            "myapp/main.py": [
+                _make_star_entry("myapp/main.py", "os", is_relative=False),
+            ],
+        }
+        # "os" is not in module_to_file (it is a stdlib/external module)
+        module_to_file: dict[str, str] = {}
+
+        name_to_source, alias_target = _build_import_maps(
+            imports_by_file, module_to_file, file_symbols
+        )
+
+        assert "myapp/main.py" not in name_to_source
+        assert "myapp/main.py" not in alias_target
+
+    def test_external_star_does_not_pollute_other_caller_entries(self) -> None:
+        # caller.py has a normal import AND an external star import
+        file_symbols = {
+            "pkg/util.py": [("helper", "function", 3)],
+        }
+        imports_by_file = {
+            "pkg/caller.py": [
+                ImportEntry(
+                    file_path="pkg/caller.py",
+                    language="python",
+                    module_path=".util",
+                    local_name="helper",
+                    is_relative=True,
+                    is_star=False,
+                    alias_of="",
+                    line=1,
+                ),
+                _make_star_entry("pkg/caller.py", "os", is_relative=False),
+            ],
+        }
+        module_to_file = {"pkg/util.py": "pkg/util.py"}
+
+        name_to_source, _ = _build_import_maps(
+            imports_by_file, module_to_file, file_symbols
+        )
+
+        # The normal import is still resolved correctly
+        assert name_to_source["pkg/caller.py"]["helper"] == "pkg/util.py"
+        # External star import added no extra keys
+        assert len(name_to_source["pkg/caller.py"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Test 4: backward-compat — when file_symbols is None, star imports are skipped
+# ---------------------------------------------------------------------------
+
+
+class TestStarImportBackwardCompatNoneFileSymbols:
+    """Passing file_symbols=None (default) preserves old behaviour: skip stars."""
+
+    def test_star_import_skipped_when_file_symbols_none(self) -> None:
+        imports_by_file = {
+            "pkg/caller.py": [
+                _make_star_entry("pkg/caller.py", ".sibling", is_relative=True),
+            ],
+        }
+        module_to_file = {"pkg/sibling.py": "pkg/sibling.py"}
+
+        # No file_symbols supplied — default None
+        name_to_source, _ = _build_import_maps(imports_by_file, module_to_file)
+
+        assert "pkg/caller.py" not in name_to_source

--- a/tests/unit/test_star_import_resolution.py
+++ b/tests/unit/test_star_import_resolution.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 from tree_sitter_analyzer.synapse_resolver._context import _build_import_maps
 from tree_sitter_analyzer.synapse_resolver._imports import ImportEntry
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -327,6 +327,7 @@ class ASTCache:
         resolve_only: bool = False,
         include_activation: bool | None = None,
         language_filter: str | None = None,
+        exclude_patterns: frozenset[str] | None = None,
     ) -> dict[str, Any]:
         """Index every source file under ``self.project_root``."""
         return _indexer.run_index_project(
@@ -337,6 +338,7 @@ class ASTCache:
             resolve_only=resolve_only,
             include_activation=include_activation,
             language_filter=language_filter,
+            exclude_patterns=exclude_patterns,
         )
 
     def _post_index_backfill(self, stats: dict[str, Any]) -> None:

--- a/tree_sitter_analyzer/cache/indexer.py
+++ b/tree_sitter_analyzer/cache/indexer.py
@@ -377,6 +377,7 @@ def run_index_project(
     resolve_only: bool = False,
     include_activation: bool | None = None,
     language_filter: str | None = None,
+    exclude_patterns: frozenset[str] | None = None,
 ) -> dict[str, Any]:
     """Orchestrate a full ASTCache project index run.
 
@@ -417,6 +418,11 @@ def run_index_project(
             conn.execute("DELETE FROM ast_index")
             conn.commit()
         conn = cache._get_conn()
+        effective_exclude = (
+            exclude_patterns
+            if exclude_patterns is not None
+            else _DEFAULT_EXCLUDE_PATTERNS
+        )
         stats, candidates, count = walk_and_partition(
             cache,
             conn,
@@ -428,7 +434,7 @@ def run_index_project(
             _AST_CACHE_EXTRACTOR_VERSION,
             _make_error_entry,
             language_filter,
-            _DEFAULT_EXCLUDE_PATTERNS,
+            effective_exclude,
         )
         workers = cache._resolve_worker_count(workers, candidates)
         if workers and workers >= 2 and len(candidates) >= 2:

--- a/tree_sitter_analyzer/cache/indexer.py
+++ b/tree_sitter_analyzer/cache/indexer.py
@@ -7,6 +7,7 @@ that delegate here.
 
 from __future__ import annotations
 
+import fnmatch
 import json
 import logging
 import os
@@ -43,6 +44,23 @@ from .schema import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Corpus-directory patterns excluded from full-index (REQ-E-016).
+# Uses fnmatch syntax relative to the project root (forward-slash normalised).
+_DEFAULT_EXCLUDE_PATTERNS: frozenset[str] = frozenset({
+    "tests/golden/corpus_*",
+})
+
+# Extensions that have a plugin but are NOT wired for full-index
+# (REQ-E-020).  When a file with one of these extensions is encountered and
+# language_fn returns None, a one-time WARNING is emitted so callers know why
+# the file was silently skipped.
+_PLUGIN_EXTS: frozenset[str] = frozenset({
+    ".css", ".html", ".md", ".sql", ".yaml", ".yml",
+})
+
+# De-duplication set: only warn once per extension per process lifetime.
+_warned_extensions: set[str] = set()
 
 # Extractor version constant — kept in sync with ast_cache.py.
 # v3: #610 — Python module-level constants extracted as kind="constant".
@@ -201,6 +219,7 @@ def walk_and_partition(
     extractor_version: int,
     make_error_entry: Any,
     language_filter: str | None = None,
+    exclude_patterns: frozenset[str] | None = None,
 ) -> tuple[dict[str, Any], list[tuple[str, str]], int]:
     """Walk source files and partition into (stats, candidates, count).
 
@@ -237,14 +256,30 @@ def walk_and_partition(
             stats["truncated_by_max_files"] = True
             break
         count += 1
+        rel_path = os.path.relpath(abs_path, cache.project_root).replace("\\", "/")
+        # REQ-E-016: skip files matching corpus-exclusion patterns.
+        if exclude_patterns:
+            if any(fnmatch.fnmatch(rel_path, pat) for pat in exclude_patterns):
+                stats["skipped"] += 1
+                continue
         lang = language_fn(abs_path)
         if lang is None:
+            # REQ-E-020: emit a one-time WARNING for plugin-registered extensions
+            # that are not wired into the full-index path.
+            ext = os.path.splitext(abs_path)[1].lower()
+            if ext and ext not in _warned_extensions and ext in _PLUGIN_EXTS:
+                logger.warning(
+                    "Extension %s is registered in a plugin but not wired for "
+                    "full-index; use single-file mode for this language. File: %s",
+                    ext,
+                    abs_path,
+                )
+                _warned_extensions.add(ext)
             stats["skipped"] += 1
             continue
         if language_filter is not None and lang != language_filter:
             stats["skipped"] += 1
             continue
-        rel_path = os.path.relpath(abs_path, cache.project_root).replace("\\", "/")
         try:
             stat = os.stat(abs_path)
         except OSError as e:
@@ -393,6 +428,7 @@ def run_index_project(
             _AST_CACHE_EXTRACTOR_VERSION,
             _make_error_entry,
             language_filter,
+            _DEFAULT_EXCLUDE_PATTERNS,
         )
         workers = cache._resolve_worker_count(workers, candidates)
         if workers and workers >= 2 and len(candidates) >= 2:

--- a/tree_sitter_analyzer/cli/argument_groups/_mcp.py
+++ b/tree_sitter_analyzer/cli/argument_groups/_mcp.py
@@ -63,6 +63,27 @@ def _add_mcp_index_management_options(parser: argparse.ArgumentParser) -> None:
         ),
     )
     parser.add_argument(
+        "--full-index-exclude-pattern",
+        action="append",
+        dest="full_index_exclude_patterns",
+        metavar="PAT",
+        default=[],
+        help=(
+            "Glob pattern (fnmatch, relative to project root) to exclude from "
+            "--full-index. Repeatable: --full-index-exclude-pattern 'tests/golden/*' "
+            "--full-index-exclude-pattern 'vendor/**'. Patterns accumulate."
+        ),
+    )
+    parser.add_argument(
+        "--full-index-no-default-excludes",
+        action="store_true",
+        help=(
+            "Disable the built-in default exclude patterns for --full-index "
+            "(e.g. tests/golden/corpus_*). Use with --full-index-exclude-pattern "
+            "to supply a fully custom exclude set."
+        ),
+    )
+    parser.add_argument(
         "--codegraph-metrics",
         action="store_true",
         help=(

--- a/tree_sitter_analyzer/cli/commands/codegraph_index_commands.py
+++ b/tree_sitter_analyzer/cli/commands/codegraph_index_commands.py
@@ -60,7 +60,7 @@ def _autoindex_payload(args: Any, output_format: str) -> dict[str, Any]:
 
 
 def _full_index_payload(args: Any, output_format: str) -> dict[str, Any]:
-    return {
+    payload: dict[str, Any] = {
         "mode": getattr(args, "full_index_mode", "incremental") or "incremental",
         "max_files": int(getattr(args, "full_index_max_files", 20_000)),
         "include_activation": bool(
@@ -68,6 +68,14 @@ def _full_index_payload(args: Any, output_format: str) -> dict[str, Any]:
         ),
         "output_format": output_format,
     }
+    extra_patterns: list[str] = list(
+        getattr(args, "full_index_exclude_patterns", None) or []
+    )
+    if extra_patterns:
+        payload["exclude_patterns"] = extra_patterns
+    if bool(getattr(args, "full_index_no_default_excludes", False)):
+        payload["no_default_excludes"] = True
+    return payload
 
 
 def _incremental_sync_payload(args: Any, output_format: str) -> dict[str, Any]:

--- a/tree_sitter_analyzer/core/_query_service_helpers.py
+++ b/tree_sitter_analyzer/core/_query_service_helpers.py
@@ -14,6 +14,7 @@ class PluginQueryNode:
         self.start_point = (getattr(element, "start_line", 1) - 1, 0)
         self.end_point = (getattr(element, "end_line", 1) - 1, 0)
         self.text = getattr(element, "raw_text", "").encode("utf-8")
+        self.complexity_score = getattr(element, "complexity_score", None)
 
 
 def _element_to_capture(element: Any, query_key: str | None) -> tuple[Any, str] | None:

--- a/tree_sitter_analyzer/core/query_filter.py
+++ b/tree_sitter_analyzer/core/query_filter.py
@@ -176,13 +176,13 @@ class QueryFilter:
         comparison_type = filter_config["type"]
 
         if comparison_type == "gt":
-            return float(field_value) > threshold
+            return bool(float(field_value) > threshold)
         elif comparison_type == "lt":
-            return float(field_value) < threshold
+            return bool(float(field_value) < threshold)
         elif comparison_type == "gte":
-            return float(field_value) >= threshold
+            return bool(float(field_value) >= threshold)
         elif comparison_type == "lte":
-            return float(field_value) <= threshold
+            return bool(float(field_value) <= threshold)
 
         return False
 

--- a/tree_sitter_analyzer/core/query_filter.py
+++ b/tree_sitter_analyzer/core/query_filter.py
@@ -6,6 +6,7 @@ Provides post-processing filtering for query results, supporting filtering by na
 """
 
 import re
+import sys
 from typing import Any
 
 
@@ -43,6 +44,20 @@ class QueryFilter:
             if self._matches_filters(result, filters):
                 filtered_results.append(result)
 
+        # Warn once when complexity filter is present but none of the input items have
+        # complexity_score — this typically means the query key (e.g. classes, imports)
+        # does not produce complexity data.
+        if (
+            "complexity" in filters
+            and results
+            and all("complexity_score" not in r for r in results)
+        ):
+            sys.stderr.write(
+                "Warning: '--filter complexity' was applied but none of the results "
+                "have 'complexity_score'. "
+                "Try --query-key methods or functions instead.\n"
+            )
+
         return filtered_results
 
     def _parse_filter_expression(self, expression: str) -> dict[str, Any]:
@@ -55,7 +70,28 @@ class QueryFilter:
         for condition in conditions:
             condition = condition.strip()
 
-            if "=" in condition:
+            # Check comparison operators first (>=/<= before >/<, to avoid mis-parsing)
+            if ">=" in condition:
+                key, raw_value = condition.split(">=", 1)
+                parsed = self._parse_numeric_value(key.strip(), raw_value.strip(), ">=")
+                if parsed is not None:
+                    filters[key.strip()] = {"type": "gte", "value": parsed}
+            elif "<=" in condition:
+                key, raw_value = condition.split("<=", 1)
+                parsed = self._parse_numeric_value(key.strip(), raw_value.strip(), "<=")
+                if parsed is not None:
+                    filters[key.strip()] = {"type": "lte", "value": parsed}
+            elif ">" in condition:
+                key, raw_value = condition.split(">", 1)
+                parsed = self._parse_numeric_value(key.strip(), raw_value.strip(), ">")
+                if parsed is not None:
+                    filters[key.strip()] = {"type": "gt", "value": parsed}
+            elif "<" in condition:
+                key, raw_value = condition.split("<", 1)
+                parsed = self._parse_numeric_value(key.strip(), raw_value.strip(), "<")
+                if parsed is not None:
+                    filters[key.strip()] = {"type": "lt", "value": parsed}
+            elif "=" in condition:
                 key, value = condition.split("=", 1)
                 key = key.strip()
                 value = value.strip()
@@ -67,6 +103,22 @@ class QueryFilter:
                     filters[key] = {"type": "exact", "value": value}
 
         return filters
+
+    def _parse_numeric_value(
+        self, key: str, raw_value: str, operator: str
+    ) -> float | None:
+        """Parse a numeric RHS value for comparison operators.
+
+        Returns the float value on success, or None on failure (with a warning to stderr).
+        """
+        try:
+            return float(raw_value)
+        except ValueError:
+            sys.stderr.write(
+                f"Warning: filter '{key}{operator}{raw_value}' — "
+                f"'{raw_value}' is not a valid number; condition ignored.\n"
+            )
+            return None
 
     def _matches_filters(self, result: dict[str, Any], filters: dict[str, Any]) -> bool:
         """Check if result matches all filter conditions"""
@@ -102,8 +154,37 @@ class QueryFilter:
             return self._match_modifier(result, "final", filter_value)
         elif filter_key == "abstract":
             return self._match_modifier(result, "abstract", filter_value)
+        elif filter_key == "complexity":
+            return self._match_numeric_comparison(result, "complexity_score", filter_config)
+        elif filter_key == "line_span":
+            return self._match_numeric_comparison(result, "line_span", filter_config)
 
         return True
+
+    def _match_numeric_comparison(
+        self, result: dict[str, Any], field_name: str, filter_config: dict[str, Any]
+    ) -> bool:
+        """Compare a numeric field in result against a filter config with type/value.
+
+        Returns False if the field is absent (excludes the result).
+        """
+        field_value = result.get(field_name)
+        if field_value is None:
+            return False
+
+        threshold = filter_config["value"]
+        comparison_type = filter_config["type"]
+
+        if comparison_type == "gt":
+            return float(field_value) > threshold
+        elif comparison_type == "lt":
+            return float(field_value) < threshold
+        elif comparison_type == "gte":
+            return float(field_value) >= threshold
+        elif comparison_type == "lte":
+            return float(field_value) <= threshold
+
+        return False
 
     def _match_name(self, result: dict[str, Any], match_type: str, value: str) -> bool:
         """Match method name"""
@@ -207,6 +288,12 @@ Basic Syntax:
   --filter "key=~pattern"            # Pattern match (supports wildcard *)
   --filter "key1=value1,key2=value2" # Multiple conditions (AND logic)
 
+Comparison Operators:
+  --filter "key>N"                   # Greater than
+  --filter "key<N"                   # Less than
+  --filter "key>=N"                  # Greater than or equal
+  --filter "key<=N"                  # Less than or equal
+
 Supported filter keys:
   name       - Method/function name
              e.g.: name=main, name=~auth*, name=~get*
@@ -235,8 +322,18 @@ Supported filter keys:
   abstract   - Whether it is abstract
              e.g.: abstract=true, abstract=false
 
+  complexity - Complexity score (比較演算子 >, <, >=, <= が有効)
+             e.g.: complexity>10, complexity<5, complexity>=3
+             Note: complexity_score を持たないアイテムは除外される
+
+  line_span  - 行数 (end_line - start_line + 1) (比較演算子 >, <, >=, <= が有効)
+             e.g.: line_span>50, line_span<20, line_span>=10
+
 Examples:
   --query-key methods --filter "name=main"
   --query-key methods --filter "name=~get*,public=true"
   --query-key methods --filter "params=0,static=true"
+  --query-key methods --filter "complexity>10"
+  --query-key methods --filter "line_span>50"
+  --query-key methods --filter "complexity>5,public=true"
 """

--- a/tree_sitter_analyzer/core/query_service.py
+++ b/tree_sitter_analyzer/core/query_service.py
@@ -15,6 +15,7 @@ from ..plugins.manager import PluginManager
 from ..query_loader import query_loader
 from ..utils.tree_sitter_compat import get_node_text_safe
 from ._query_service_helpers import (
+    PluginQueryNode,
     fallback_query_captures,
     plugin_category_captures,
     plugin_strategy_captures,
@@ -75,6 +76,17 @@ class QueryService:
 
             results = process_captures(captures, content, self._create_result_dict)
 
+            # Only enrich complexity_score when a complexity filter is actually requested.
+            # analyze_code() re-parses the whole file, so calling it unconditionally
+            # doubles parse cost for every query.  line_span is already in result dicts
+            # and needs no enrichment.
+            if (
+                filter_expression
+                and "complexity" in filter_expression
+                and any("complexity_score" not in r for r in results)
+            ):
+                results = self._enrich_complexity_scores(results, language, content)
+
             if filter_expression and results:
                 results = self.filter.filter_results(results, filter_expression)
 
@@ -125,6 +137,10 @@ class QueryService:
         parent_name = self._extract_parent_context(node)
         if parent_name:
             result["parent"] = parent_name
+
+        # PluginQueryNode からのみ complexity_score を引き継ぐ
+        if isinstance(node, PluginQueryNode) and node.complexity_score is not None:
+            result["complexity_score"] = node.complexity_score
 
         return result
 
@@ -289,6 +305,39 @@ class QueryService:
             return query_loader.get_query_description(language, query_key)
         except Exception:
             return None
+
+    def _enrich_complexity_scores(
+        self, results: list[dict[str, Any]], language: str, source_code: str
+    ) -> list[dict[str, Any]]:
+        """Enrich results with complexity_score via analyze_code().
+
+        Native tree-sitter captures are raw Node objects without complexity_score.
+        analyze_code() runs the full plugin pipeline and returns elements with
+        complexity_score populated.  We build a start_line→score lookup and
+        backfill any result that is missing the field.
+        """
+        try:
+            from ..api import analyze_code
+
+            analysis = analyze_code(source_code, language)
+            elements: list[dict[str, Any]] = analysis.get("elements", [])
+        except Exception:
+            return results
+
+        score_by_line: dict[int, int | None] = {
+            int(el.get("start_line", -1)): el.get("complexity_score")
+            for el in elements
+            if isinstance(el, dict) and el.get("complexity_score") is not None
+        }
+
+        enriched = []
+        for r in results:
+            if "complexity_score" not in r:
+                score = score_by_line.get(r.get("start_line", -1))
+                if score is not None:
+                    r = {**r, "complexity_score": score}
+            enriched.append(r)
+        return enriched
 
     def _execute_plugin_query(
         self, root_node: Any, query_key: str | None, language: str, source_code: str

--- a/tree_sitter_analyzer/languages/lua_plugin/__init__.py
+++ b/tree_sitter_analyzer/languages/lua_plugin/__init__.py
@@ -1,5 +1,6 @@
 """Lua language plugin package."""
 
+from .extractor import LuaElementExtractor
 from .plugin import LuaPlugin
 
-__all__ = ["LuaPlugin"]
+__all__ = ["LuaElementExtractor", "LuaPlugin"]

--- a/tree_sitter_analyzer/languages/lua_plugin/extractor.py
+++ b/tree_sitter_analyzer/languages/lua_plugin/extractor.py
@@ -18,16 +18,21 @@ from ..shared.traversal import node_range
 
 __all__ = ["LuaElementExtractor"]
 
-# Tree-sitter query: named and anonymous function definitions.
+# Tree-sitter query: named and local function declarations.
+# `function_declaration` covers both `function name()` and `local function name()`.
 _FUNCTION_QUERY = """
-(function_definition name: (identifier) @name)
-(local_function name: (identifier) @name)
+(function_declaration name: (identifier) @name)
 """
 
 # Tree-sitter query: require() calls (Lua's import mechanism).
+# Matches both `require("m")` (name is a bare identifier) and versions where
+# the grammar wraps the identifier in a `variable` node.
 _IMPORT_QUERY = """
 (function_call
   name: (identifier) @callee (#eq? @callee "require")
+  arguments: (arguments (string content: (string_content) @path)))
+(function_call
+  name: (variable (identifier) @callee (#eq? @callee "require"))
   arguments: (arguments (string content: (string_content) @path)))
 """
 
@@ -67,7 +72,7 @@ class LuaElementExtractor(ElementExtractor):
             return None
 
     def extract_functions(
-        self, tree: "tree_sitter.Tree", source_code: str
+        self, tree: tree_sitter.Tree, source_code: str
     ) -> list[ModelFunction]:
         """Extract Lua function and local-function definitions.
 
@@ -80,7 +85,7 @@ class LuaElementExtractor(ElementExtractor):
         try:
             import tree_sitter as _ts
             query = _ts.Query(language, _FUNCTION_QUERY)
-            captures: dict[str, list[Any]] = query.captures(tree.root_node)
+            captures: dict[str, list[Any]] = query.captures(tree.root_node)  # type: ignore[attr-defined]
             name_nodes: list[Any] = captures.get("name", [])
 
             functions: list[ModelFunction] = []
@@ -116,7 +121,7 @@ class LuaElementExtractor(ElementExtractor):
             return []
 
     def extract_imports(
-        self, tree: "tree_sitter.Tree", source_code: str
+        self, tree: tree_sitter.Tree, source_code: str
     ) -> list[ModelImport]:
         """Extract Lua require() calls as import elements.
 
@@ -129,7 +134,7 @@ class LuaElementExtractor(ElementExtractor):
         try:
             import tree_sitter as _ts
             query = _ts.Query(language, _IMPORT_QUERY)
-            captures: dict[str, list[Any]] = query.captures(tree.root_node)
+            captures: dict[str, list[Any]] = query.captures(tree.root_node)  # type: ignore[attr-defined]
             path_nodes: list[Any] = captures.get("path", [])
 
             imports: list[ModelImport] = []
@@ -166,13 +171,13 @@ class LuaElementExtractor(ElementExtractor):
             return []
 
     def extract_classes(
-        self, tree: "tree_sitter.Tree", source_code: str
+        self, tree: tree_sitter.Tree, source_code: str
     ) -> list[ModelClass]:
         """Lua has no class keyword; always returns an empty list."""
         return []
 
     def extract_variables(
-        self, tree: "tree_sitter.Tree", source_code: str
+        self, tree: tree_sitter.Tree, source_code: str
     ) -> list[ModelVariable]:
         """Variable extraction not implemented for Lua; returns an empty list."""
         return []

--- a/tree_sitter_analyzer/languages/lua_plugin/extractor.py
+++ b/tree_sitter_analyzer/languages/lua_plugin/extractor.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Lua Element Extractor — tree-sitter query-based extraction."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import tree_sitter
+
+from ...models import Class as ModelClass
+from ...models import Function as ModelFunction
+from ...models import Import as ModelImport
+from ...models import Variable as ModelVariable
+from ...plugins.base import ElementExtractor
+from ...utils import log_error
+from ..shared.traversal import node_range
+
+__all__ = ["LuaElementExtractor"]
+
+# Tree-sitter query: named and anonymous function definitions.
+_FUNCTION_QUERY = """
+(function_definition name: (identifier) @name)
+(local_function name: (identifier) @name)
+"""
+
+# Tree-sitter query: require() calls (Lua's import mechanism).
+_IMPORT_QUERY = """
+(function_call
+  name: (identifier) @callee (#eq? @callee "require")
+  arguments: (arguments (string content: (string_content) @path)))
+"""
+
+
+def _node_text(node: Any) -> str:
+    """Return decoded text for a tree-sitter node, empty string on error."""
+    text = getattr(node, "text", None)
+    if isinstance(text, bytes):
+        return text.decode("utf-8", errors="replace")
+    if isinstance(text, str):
+        return text
+    return ""
+
+
+class LuaElementExtractor(ElementExtractor):
+    """Lua-specific element extractor using tree-sitter queries."""
+
+    def __init__(self) -> None:
+        """Initialize the Lua element extractor."""
+        super().__init__()
+
+    def _get_lua_language(self) -> Any | None:
+        """Return a tree_sitter.Language for Lua, or None if not installed.
+
+        Imports tree_sitter and tree_sitter_lua lazily so the extractor
+        degrades gracefully when the Lua grammar package is absent.
+        """
+        try:
+            import tree_sitter
+            import tree_sitter_lua as tslua  # noqa: PLC0415
+
+            return tree_sitter.Language(tslua.language())
+        except ImportError:
+            return None
+        except Exception as exc:
+            log_error(f"Failed to load Lua tree-sitter language: {exc}")
+            return None
+
+    def extract_functions(
+        self, tree: "tree_sitter.Tree", source_code: str
+    ) -> list[ModelFunction]:
+        """Extract Lua function and local-function definitions.
+
+        Returns an empty list when tree_sitter_lua is not installed.
+        """
+        language = self._get_lua_language()
+        if language is None:
+            return []
+
+        try:
+            import tree_sitter as _ts
+            query = _ts.Query(language, _FUNCTION_QUERY)
+            captures: dict[str, list[Any]] = query.captures(tree.root_node)
+            name_nodes: list[Any] = captures.get("name", [])
+
+            functions: list[ModelFunction] = []
+            for name_node in name_nodes:
+                try:
+                    fn_node = name_node.parent
+                    if fn_node is None:
+                        continue
+
+                    name = _node_text(name_node)
+                    if not name:
+                        continue
+
+                    start_line, end_line = node_range(fn_node)
+                    raw_text = _node_text(fn_node)
+
+                    functions.append(
+                        ModelFunction(
+                            name=name,
+                            start_line=start_line,
+                            end_line=end_line,
+                            raw_text=raw_text,
+                            language="lua",
+                        )
+                    )
+                except Exception as exc:
+                    log_error(f"Error extracting Lua function node: {exc}")
+
+            return functions
+
+        except Exception as exc:
+            log_error(f"Error in Lua function extraction: {exc}")
+            return []
+
+    def extract_imports(
+        self, tree: "tree_sitter.Tree", source_code: str
+    ) -> list[ModelImport]:
+        """Extract Lua require() calls as import elements.
+
+        Returns an empty list when tree_sitter_lua is not installed.
+        """
+        language = self._get_lua_language()
+        if language is None:
+            return []
+
+        try:
+            import tree_sitter as _ts
+            query = _ts.Query(language, _IMPORT_QUERY)
+            captures: dict[str, list[Any]] = query.captures(tree.root_node)
+            path_nodes: list[Any] = captures.get("path", [])
+
+            imports: list[ModelImport] = []
+            for path_node in path_nodes:
+                try:
+                    # Walk up from string_content → string → arguments → function_call
+                    call_node = path_node.parent
+                    while call_node is not None and call_node.type != "function_call":
+                        call_node = call_node.parent
+
+                    anchor = call_node if call_node is not None else path_node
+                    module_path = _node_text(path_node)
+                    start_line, end_line = node_range(anchor)
+                    raw_text = _node_text(anchor)
+
+                    imports.append(
+                        ModelImport(
+                            name=module_path,
+                            start_line=start_line,
+                            end_line=end_line,
+                            raw_text=raw_text,
+                            language="lua",
+                            module_name=module_path,
+                            module_path=module_path,
+                        )
+                    )
+                except Exception as exc:
+                    log_error(f"Error extracting Lua import node: {exc}")
+
+            return imports
+
+        except Exception as exc:
+            log_error(f"Error in Lua import extraction: {exc}")
+            return []
+
+    def extract_classes(
+        self, tree: "tree_sitter.Tree", source_code: str
+    ) -> list[ModelClass]:
+        """Lua has no class keyword; always returns an empty list."""
+        return []
+
+    def extract_variables(
+        self, tree: "tree_sitter.Tree", source_code: str
+    ) -> list[ModelVariable]:
+        """Variable extraction not implemented for Lua; returns an empty list."""
+        return []

--- a/tree_sitter_analyzer/languages/lua_plugin/plugin.py
+++ b/tree_sitter_analyzer/languages/lua_plugin/plugin.py
@@ -18,8 +18,9 @@ if TYPE_CHECKING:
     from ...core.analysis_engine import AnalysisRequest
     from ...models import AnalysisResult
 
-from ...plugins.base import DefaultExtractor, ElementExtractor, LanguagePlugin
+from ...plugins.base import ElementExtractor, LanguagePlugin
 from ...utils import log_error
+from .extractor import LuaElementExtractor
 
 
 class LuaPlugin(LanguagePlugin):
@@ -32,7 +33,7 @@ class LuaPlugin(LanguagePlugin):
         return [".lua"]
 
     def create_extractor(self) -> ElementExtractor:
-        return DefaultExtractor()
+        return LuaElementExtractor()
 
     def get_tree_sitter_language(self) -> Any:
         try:

--- a/tree_sitter_analyzer/mcp/tools/full_index_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/full_index_tool.py
@@ -91,6 +91,25 @@ class CodeGraphFullIndexTool(BaseMCPTool):
                     "description": "Output format (default: toon)",
                     "default": "toon",
                 },
+                "exclude_patterns": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Additional fnmatch glob patterns (relative to project root) "
+                        "to exclude from indexing. Example: [\"tests/golden/corpus_*\"]. "
+                        "Combined with built-in defaults unless no_default_excludes=true."
+                    ),
+                    "default": [],
+                },
+                "no_default_excludes": {
+                    "type": "boolean",
+                    "description": (
+                        "When true, disable the built-in default exclude patterns "
+                        "(e.g. tests/golden/corpus_*) and use only the patterns "
+                        "supplied in exclude_patterns. Default: false."
+                    ),
+                    "default": False,
+                },
             },
             "additionalProperties": False,
         }
@@ -119,6 +138,8 @@ class CodeGraphFullIndexTool(BaseMCPTool):
         resolve_synapse = arguments.get("resolve_synapse", True)
         include_activation = bool(arguments.get("include_activation", False))
         output_format = arguments.get("output_format", "toon")
+        extra_patterns: list[str] = list(arguments.get("exclude_patterns", None) or [])
+        no_default_excludes: bool = bool(arguments.get("no_default_excludes", False))
 
         phases: dict[str, Any] = {}
         t_start = time.monotonic()
@@ -130,6 +151,8 @@ class CodeGraphFullIndexTool(BaseMCPTool):
             mode == "full",
             max_files,
             include_activation=include_activation,
+            extra_exclude_patterns=extra_patterns,
+            no_default_excludes=no_default_excludes,
         )
         phases["ast_cache"] = ast_phase
         phases["incremental_sync"] = self._phase_incremental_sync()
@@ -174,16 +197,26 @@ class CodeGraphFullIndexTool(BaseMCPTool):
         max_files: int,
         *,
         include_activation: bool = False,
+        extra_exclude_patterns: list[str] | None = None,
+        no_default_excludes: bool = False,
     ) -> dict[str, Any]:
         t0 = time.monotonic()
         try:
             from ...ast_cache import ASTCache
+            from ...cache.indexer import _DEFAULT_EXCLUDE_PATTERNS
+
+            extra: frozenset[str] = frozenset(extra_exclude_patterns or [])
+            if no_default_excludes:
+                exclude_patterns: frozenset[str] = extra
+            else:
+                exclude_patterns = _DEFAULT_EXCLUDE_PATTERNS | extra
 
             cache = ASTCache(self.project_root or ".")
             result = cache.index_project(
                 max_files=max_files,
                 force=force,
                 include_activation=include_activation,
+                exclude_patterns=exclude_patterns,
             )
             elapsed = round(time.monotonic() - t0, 3)
             indexed = result.get("indexed", 0)

--- a/tree_sitter_analyzer/synapse_resolver/_context.py
+++ b/tree_sitter_analyzer/synapse_resolver/_context.py
@@ -384,15 +384,25 @@ def _build_file_class_methods_from_cache(
 def _build_import_maps(
     imports_by_file: dict[str, list[ImportEntry]],
     module_to_file: dict[str, str],
+    file_symbols: dict[str, list[tuple[str, str, int]]] | None = None,
 ) -> tuple[dict[str, dict[str, str]], dict[str, dict[str, str]]]:
-    """Derive (name_to_source, alias_target) from per-file import entries."""
+    """Derive (name_to_source, alias_target) from per-file import entries.
+
+    When ``file_symbols`` is supplied, ``from M import *`` entries are
+    expanded: each name exported by the starred project module is mapped to
+    that module's file in the caller's ``name_to_source`` entry.  External
+    modules (not found in ``module_to_file``) are silently skipped
+    (REQ-N-013).
+    """
     name_to_source: dict[str, dict[str, str]] = {}
     alias_target: dict[str, dict[str, str]] = {}
+    star_imports: list[tuple[str, ImportEntry]] = []
     for caller_file, entries in imports_by_file.items():
         name_map: dict[str, str] = {}
         alias_map: dict[str, str] = {}
         for entry in entries:
             if entry.is_star:
+                star_imports.append((caller_file, entry))
                 continue
             target = _resolve_module_to_file(
                 entry.module_path, entry.is_relative, caller_file, module_to_file
@@ -421,6 +431,24 @@ def _build_import_maps(
             name_to_source[caller_file] = name_map
         if alias_map:
             alias_target[caller_file] = alias_map
+
+    # Second pass: expand star imports using the project's symbol table.
+    # Only expand when file_symbols is provided; if None, skip (unchanged
+    # behaviour for callers that do not supply the table).
+    if file_symbols is not None:
+        for caller_file, entry in star_imports:
+            target_file = _resolve_module_to_file(
+                entry.module_path, entry.is_relative, caller_file, module_to_file
+            )
+            if not target_file:
+                # External or unresolvable module — skip (REQ-N-013).
+                continue
+            symbols = file_symbols.get(target_file, [])
+            if symbols:
+                name_map = name_to_source.setdefault(caller_file, {})
+                for sym_name, _kind, _sym_id in symbols:
+                    name_map.setdefault(sym_name, target_file)
+
     return name_to_source, alias_target
 
 
@@ -503,7 +531,9 @@ def _build_resolver_context_uncached(cache: ASTCache) -> ResolverContext:
         file_paths.append(r["file_path"])
         file_languages[r["file_path"]] = r["language"]
     module_to_file = _build_module_to_file(file_paths)
-    name_to_source, alias_target = _build_import_maps(imports_by_file, module_to_file)
+    name_to_source, alias_target = _build_import_maps(
+        imports_by_file, module_to_file, file_symbols
+    )
     callee_resolver = _build_callee_resolver(
         file_symbols=file_symbols,
         global_name_table=global_name_table,

--- a/tree_sitter_analyzer/synapse_resolver/languages/bash.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/bash.py
@@ -1,0 +1,86 @@
+"""Bash resolver registration (RFC-0010).
+
+A SAFE, deliberately minimal callee resolver for Bash/shell scripts. Its ONLY
+job is to claim the ``bash`` language slot in the registry so that the Python
+cascade CANNOT mis-classify Bash command names (``print``, ``list``, ``map``,
+``type``, etc.) as Python builtins or stdlib symbols.
+
+Design decisions:
+- ``resolve_bash_callee`` always returns ``(None, "unknown", "")`` — Bash call
+  targets cannot be statically resolved without full shell expansion semantics,
+  and guessing would introduce cross-language false-positives (the moat).
+- ``build_bash_resolver_context`` returns ``None`` when no Bash file is present
+  (zero cost for non-shell projects) and a ``BashResolverContext`` otherwise.
+- No stdlib tier, no local-symbol lookup, no import tracking.
+
+THE MOAT: by registering ``bash``, the language-dispatch in the outer resolve
+loop will call ``resolve_bash_callee`` instead of falling through to the Python
+cascade for ``.sh`` caller files. This prevents a Bash ``print`` or ``list``
+call from ever being classified as a Python builtin.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .._registry import register_language
+
+
+@dataclass
+class BashResolverContext:
+    """Per-index Bash resolution context (built once per pass).
+
+    Currently empty: Bash resolution is always ``unknown``. The class exists
+    so that ``build_bash_resolver_context`` can return a typed non-``None``
+    sentinel and the registry contract (``Any | None``) is satisfied.
+    """
+
+
+def build_bash_resolver_context(
+    *,
+    imports_by_file: dict[str, Any],
+    file_languages: dict[str, str],
+    file_symbols: dict[str, Any],
+    global_name_table: dict[str, Any],
+    file_class_methods: Any,  # zero-arg thunk -> class->method map (lazy; unused)
+    **_ignored: Any,
+) -> BashResolverContext | None:
+    """Build the Bash context, or ``None`` when no Bash file is indexed.
+
+    Zero cost for non-shell projects (gated on ``file_languages``). When at
+    least one ``.sh``/Bash file is present the returned context acts as a
+    sentinel: the registry dispatches to ``resolve_bash_callee`` instead of the
+    Python cascade, preventing false-positive builtin/stdlib classifications.
+    """
+    if not any(lang == "bash" for lang in file_languages.values()):
+        return None
+    return BashResolverContext()
+
+
+def resolve_bash_callee(
+    callee_name: str,
+    callee_full: str,
+    caller_file: str,
+    ctx: BashResolverContext,
+) -> tuple[int | None, str, str]:
+    """Resolve a Bash call edge — always returns ``unknown``.
+
+    Bash command targets (builtins, aliases, functions, external programs)
+    cannot be statically resolved without full shell-expansion semantics. This
+    resolver claims the language slot to prevent cross-language mis-binding and
+    conservatively returns ``unknown`` for every call.
+
+    Returns ``(symbol_id, resolution, resolved_file)``.
+    """
+    return (None, "unknown", "")
+
+
+register_language("bash", build_bash_resolver_context, resolve_bash_callee)
+
+
+__all__ = [
+    "BashResolverContext",
+    "build_bash_resolver_context",
+    "resolve_bash_callee",
+]

--- a/tree_sitter_analyzer/synapse_resolver/languages/scala.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/scala.py
@@ -52,8 +52,16 @@ def build_scala_resolver_context(
         if name_map:
             name_to_source[caller_file] = name_map
 
+    # Filter file_symbols to Scala-only to prevent tier (c) from binding
+    # a Scala call to a Python/Go symbol that happens to share the same name.
+    scala_file_symbols = {
+        fp: syms
+        for fp, syms in file_symbols.items()
+        if file_languages.get(fp) == "scala"
+    }
+
     return ScalaResolverContext(
-        file_symbols=file_symbols,
+        file_symbols=scala_file_symbols,
         global_name_table={
             name: list(entries)
             for name, entries in global_name_table.items()

--- a/tree_sitter_analyzer/synapse_resolver/languages/scala.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/scala.py
@@ -89,10 +89,12 @@ def resolve_scala_callee(
     """Resolve one Scala call edge. Returns (symbol_id, resolution, resolved_file)."""
     name = callee_full or callee_name
 
-    # (a) local
-    sym_id = _lookup_in_file(ctx, caller_file, callee_name)
-    if sym_id is not None:
-        return sym_id, "local", caller_file
+    # (a) local — skip when the call has a receiver prefix (e.g., items.map)
+    # so a local symbol named `map` does not shadow a receiver method call.
+    if "." not in (callee_full or ""):
+        sym_id = _lookup_in_file(ctx, caller_file, callee_name)
+        if sym_id is not None:
+            return sym_id, "local", caller_file
 
     # (b) explicit named import — P0: returns unknown (file resolution is follow-on)
     if caller_file in ctx.name_to_source:

--- a/tree_sitter_analyzer/synapse_resolver/languages/scala.py
+++ b/tree_sitter_analyzer/synapse_resolver/languages/scala.py
@@ -1,0 +1,113 @@
+"""Scala callee resolver (RFC-0010).
+
+Replaces the Python cascade for Scala callers. Resolution cascade:
+  (a) local symbol in the same file
+  (b) explicit named import (import a.b.C → resolves C or a.b.C)
+  (c) single project-wide symbol with that bare name
+  (d) unknown
+
+Never applies Python stdlib allowlist, builtin names, or self/cls semantics.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .._registry import register_language
+
+
+@dataclass
+class ScalaResolverContext:
+    """Per-index Scala resolution maps (built once per pass)."""
+
+    file_symbols: dict[str, list[tuple[str, str, int]]] = field(default_factory=dict)
+    global_name_table: dict[str, list[tuple[str, int]]] = field(default_factory=dict)
+    name_to_source: dict[str, dict[str, str]] = field(default_factory=dict)
+
+
+def build_scala_resolver_context(
+    *,
+    imports_by_file: dict[str, Any],
+    file_languages: dict[str, str],
+    file_symbols: dict[str, Any],
+    global_name_table: dict[str, Any],
+    **_ignored: Any,
+) -> ScalaResolverContext | None:
+    """Build the Scala context, or None when no Scala file is indexed."""
+    if not any(lang == "scala" for lang in file_languages.values()):
+        return None
+
+    name_to_source: dict[str, dict[str, str]] = {}
+    for caller_file, entries in imports_by_file.items():
+        if file_languages.get(caller_file) != "scala":
+            continue
+        name_map: dict[str, str] = {}
+        for entry in entries:
+            if entry.is_star or not entry.local_name:
+                continue
+            name_map[entry.local_name] = entry.module_path
+            if entry.module_path:
+                name_map[entry.module_path] = entry.module_path
+        if name_map:
+            name_to_source[caller_file] = name_map
+
+    return ScalaResolverContext(
+        file_symbols=file_symbols,
+        global_name_table={
+            name: list(entries)
+            for name, entries in global_name_table.items()
+        },
+        name_to_source=name_to_source,
+    )
+
+
+def _lookup_in_file(
+    ctx: ScalaResolverContext, file_path: str, name: str
+) -> int | None:
+    """Return symbol_id if name is defined in file_path, else None."""
+    for sym_name, kind, sym_id in ctx.file_symbols.get(file_path, []):
+        if sym_name == name and kind in ("function", "method", "class"):
+            return sym_id
+    return None
+
+
+def resolve_scala_callee(
+    callee_name: str,
+    callee_full: str,
+    caller_file: str,
+    ctx: ScalaResolverContext,
+) -> tuple[int | None, str, str]:
+    """Resolve one Scala call edge. Returns (symbol_id, resolution, resolved_file)."""
+    name = callee_full or callee_name
+
+    # (a) local
+    sym_id = _lookup_in_file(ctx, caller_file, callee_name)
+    if sym_id is not None:
+        return sym_id, "local", caller_file
+
+    # (b) explicit named import — P0: returns unknown (file resolution is follow-on)
+    if caller_file in ctx.name_to_source:
+        if callee_name in ctx.name_to_source[caller_file]:
+            return None, "unknown", ""
+
+    # (c) single project-wide symbol
+    entries = ctx.global_name_table.get(callee_name, [])
+    if len(entries) == 1:
+        target_file, sym_id = entries[0]
+        if target_file in ctx.file_symbols:
+            return sym_id, "project", target_file
+
+    # (d) unknown
+    _ = name
+    return None, "unknown", ""
+
+
+register_language("scala", build_scala_resolver_context, resolve_scala_callee)
+
+
+__all__ = [
+    "ScalaResolverContext",
+    "build_scala_resolver_context",
+    "resolve_scala_callee",
+]


### PR DESCRIPTION
## Summary

### Arch-Fix: Synapse Resolver Coverage (Groups 1-8, P0->P2)

**P0 - Silent quality regression fixes**
- Add Scala synapse resolver (synapse_resolver/languages/scala.py): Scala call edges no longer fall through to the Python cascade. Resolves local/project symbols via register_language() auto-discovery.
- Add unknown rate ratchet test pinned at 6.0% (v1.21.0=3.7% -> current=6.0%). Non-regression gate; threshold must only decrease.

**P1 - Correctness gaps**
- Add LuaElementExtractor (lua_plugin/extractor.py): real tree-sitter queries for function_definition/local_function and require() call detection. Replaces DefaultExtractor stub.
- Star import expansion in _context.py._build_import_maps: from .sibling import * now resolves exported symbol names to project files.
- Corpus isolation: walk_and_partition() gains exclude_patterns; default frozenset({"tests/golden/corpus_*"}) eliminates 4 genuine self-repo mis-wires.

**P2 - Observability / maintenance**
- Add Bash synapse resolver: always returns unknown, preventing Python stdlib/builtin mis-classification of shell commands.
- Plugin skip warning: walk_and_partition() emits de-duplicated WARNING for extensions in plugins but absent from EXT_TO_LANG.
- Benchmark repair: benchmark_real_projects.py gains pre-flight guard and historical data note for invalid prior recall figures.

### Bonus: Complexity Filter (discovered during arch-fix)
- Enrich complexity_score lazily (only when --filter complexity is present).
- Propagate complexity_score through PluginQueryNode -> result dicts.
- Fix comparison operator parsing (>=/<=  before >/<).

## Test plan

- [x] Scala resolver registered in registered_languages(); cascade a/b/c/d verified
- [x] Ratchet test: 2 tests pass with full_language + benchmark markers
- [x] Lua: graceful degradation test passes; plugin contract tests pass
- [x] Star imports: 7 tests pass (resolve/non-exported/external/backward-compat)
- [x] Corpus + skip warning: 8 tests pass
- [x] Bash resolver: 10 unit + 32 contract tests pass
- [x] Benchmark repair: syntax OK; historical data comment present
- [ ] Full suite: run on CI