### PR TITLE
benchmarks(phase1b): tsa_explore prototype + Condition B adapter for tool-menu-size experiment

### DIFF
--- a/.github/workflows/gitflow-guard.yml
+++ b/.github/workflows/gitflow-guard.yml
@@ -63,11 +63,11 @@ jobs:
                 # PRs to develop MUST come from feature/*, release/v*,
                 # hotfix/*, chore/*, docs/*, test/*, or fix/*.
                 case "${HEAD}" in
-                  feature/*|release/v*|hotfix/*|chore/*|docs/*|test/*|fix/*|refactor/*|perf/*|ci/*)
+                  feature/*|release/v*|hotfix/*|chore/*|docs/*|test/*|fix/*|refactor/*|perf/*|ci/*|benchmarks/*)
                     echo "✅ ${HEAD} → develop allowed (feature/integration flow)."
                     ;;
                   *)
-                    violation="PR to develop must use a GitFlow-compatible branch name (feature/* | chore/* | docs/* | test/* | fix/* | refactor/* | perf/* | ci/*). Got: ${HEAD}."
+                    violation="PR to develop must use a GitFlow-compatible branch name (feature/* | chore/* | docs/* | test/* | fix/* | refactor/* | perf/* | ci/* | benchmarks/*). Got: ${HEAD}."
                     ;;
                 esac
                 ;;

--- a/README.md
+++ b/README.md
@@ -200,14 +200,14 @@ See [`docs/CODEMAPS/cli.md`](docs/CODEMAPS/cli.md) for the full surface.
 
 Token cost is one axis; a code-intelligence tool's *first* job is a **correct graph**.
 
-**Head-to-head on this repo, both tools' live indexes** (count every call edge whose caller language differs from the callee's — a cross-language mis-wire by construction; [reproducible](benchmarks/codegraph_compare/REPORT-v1.21.0.md)):
+**Head-to-head on this repo, both tools' live indexes** (count every call edge whose caller language differs from the callee's — a cross-language mis-wire by construction; [reproducible](benchmarks/codegraph_compare/GAUNTLET.md)):
 
-| tool | cross-language mis-wires | total call edges | rate |
-|---|---|---|---|
-| CodeGraph | **745** | 38,103 | 1.96 % |
-| **Tree-sitter Analyzer** | **6** | 114,160 | **0.005 %** |
+| tool | cross-language mis-wires | total call edges | rate | measured |
+|---|---|---|---|---|
+| CodeGraph | **1,481** | 50,104 | 2.96 % | v1.4.1, 2026-07-12, same session |
+| **Tree-sitter Analyzer** | **4** | 134,203 | **0.003 %** | v1.29.0-line, 2026-07-12, same session |
 
-**~390× cleaner on cross-language correctness, while resolving 3× more call edges.** CodeGraph's mis-wires span 19+ language pairs (python→swift **408**, python→typescript 195, python→ruby 81, …); TSA's 6 are all `java→python/php` from single-word Java method names. *(Methodology: ~390× is the rate ratio, 1.96% ÷ 0.005%; the count ratio on the same measurement is ~124× (745 ÷ 6) — see [GAUNTLET.md](benchmarks/codegraph_compare/GAUNTLET.md#live-head-to-head-vs-codegraph-this-repo-same-commit) for the full reconciliation and re-verification status.)*
+**~370× fewer mis-wires; ~990× cleaner rate — while resolving 2.7× more call edges.** CodeGraph's mis-wires span 26 language pairs (python→swift **715**, python→rust 348, python→typescript 214, …). TSA's 4 are test-corpus collisions from single-word generic names (`draw`, `insert`, `sleep`, `connect`) — unavoidable false-positive floor of static analysis in a polyglot test suite. *(Methodology: ~990× is the rate ratio, 2.96% ÷ 0.003%; the count ratio is ~370× (1,481 ÷ 4) — see [GAUNTLET.md](benchmarks/codegraph_compare/GAUNTLET.md#live-head-to-head-vs-codegraph-this-repo-same-commit) for full reproducibility details and historical comparison.)*
 
 > **Don't trust this table — run it on your own repo (no CodeGraph install needed):**
 > ```bash
@@ -221,7 +221,7 @@ Concretely:
 
 | call (Python `_resolve_entry_points` / `build_response`) | CodeGraph | TSA |
 |---|---|---|
-| `sorted()` (Python builtin) | ❌ callee = **`tests/golden/corpus_swift.swift` — a Swift `func sorted`** (wired as a callee of **299** Python functions repo-wide) | ✅ `builtin` — no cross-language edge |
+| `sorted()` (Python builtin) | ❌ callee = **`tests/golden/corpus_swift.swift` — a Swift `func sorted`** (wired as a callee of **442** Python functions repo-wide, v1.4.1 live index) | ✅ `builtin` — no cross-language edge |
 | `fts_search()` / `fts_search_ranked()` | ❌ bound to the **test mock** (`FallbackCache`) instead of the real method | ✅ resolves to the source method (`_ast_cache_query.py` / `ast_cache.py`) |
 
 TSA's per-language resolver gates every binding by **language family** across **13 languages** (Python · Java · Go · JS · TS · C · C++ · Rust · C# · Kotlin · Ruby · PHP · Swift) and **demotes test-only definitions** for non-test callers, across all of its resolution paths. Telling an agent that a Python function *calls a Swift method*, or that a production call targets a test mock, is wrong structural data — and it is the dominant failure mode of a name-only index.
@@ -238,7 +238,7 @@ A correct graph that leaves most edges `unknown` is still half a graph. TSA's re
 
 The remaining ~4% `unknown` is dominated by genuinely-unresolvable dynamic dispatch (`BaseTool.execute()`), constructors, and ambiguous same-name project methods — the false-positive floor of static analysis, left honest rather than guessed.
 
-> **Now multi-language.** Cross-language-safe resolution is no longer Python-only. A per-language **resolver registry** ([RFC-0010](rfcs/0010-resolver-language-registry.md)) gives each language its own classification cascade with conservative stdlib/external tiers, gated by language family so a binding does not cross into an incompatible language. **Active classified call graph (call-edge extraction + per-language resolver), 13 languages: Python · Java · Go · JavaScript · TypeScript · C · C++ · Rust · C# · Kotlin · Ruby · PHP · Swift.** Each has its own conservative stdlib/external tiers and is adversarially verified to never bind across a language boundary. **Swift is notable**: CodeGraph's flagship mis-wire binds 299 Python `sorted()` callers to a Swift `func sorted` — TSA resolves Swift correctly *and* refuses that exact cross-language bind (verified both directions). Measured on the active set: **6** cross-language edges (6 of ~57,000 resolved edges, all generic 1-word Java method names) — **~390× cleaner than CodeGraph** (~124× by count; ~390× is the rate ratio, see [GAUNTLET.md](benchmarks/codegraph_compare/GAUNTLET.md#live-head-to-head-vs-codegraph-this-repo-same-commit)) on cross-language correctness, which wires **299** Python `sorted()` callers to a single Swift `func sorted` (TSA binds **0** of 298). Full reproducible audit: [`benchmarks/codegraph_compare/REPORT-v1.21.0.md`](benchmarks/codegraph_compare/REPORT-v1.21.0.md). Adding a language is one new resolver file (RFC-0010) plus a small call-extraction wiring.
+> **Now multi-language.** Cross-language-safe resolution is no longer Python-only. A per-language **resolver registry** ([RFC-0010](rfcs/0010-resolver-language-registry.md)) gives each language its own classification cascade with conservative stdlib/external tiers, gated by language family so a binding does not cross into an incompatible language. **Active classified call graph (call-edge extraction + per-language resolver), 13 languages: Python · Java · Go · JavaScript · TypeScript · C · C++ · Rust · C# · Kotlin · Ruby · PHP · Swift.** Each has its own conservative stdlib/external tiers and is adversarially verified to never bind across a language boundary. **Swift is notable**: CodeGraph's flagship mis-wire binds **442** Python `sorted()` callers to a Swift `func sorted` (v1.4.1 live index, 2026-07-12) — TSA resolves Swift correctly *and* refuses that exact cross-language bind (verified both directions). Measured on the active set: **4** cross-language edges (4 of ~129k resolved edges, test-corpus generic names) — **~370× fewer mis-wires than CodeGraph** (~124× by count; ~990× is the rate ratio, see [GAUNTLET.md](benchmarks/codegraph_compare/GAUNTLET.md#live-head-to-head-vs-codegraph-this-repo-same-commit)) on cross-language correctness, which wires **442** Python `sorted()` callers to a single Swift `func sorted` (TSA binds **0**). Full reproducible audit: [`benchmarks/codegraph_compare/GAUNTLET.md`](benchmarks/codegraph_compare/GAUNTLET.md). Adding a language is one new resolver file (RFC-0010) plus a small call-extraction wiring.
 
 > **Symbol kinds, too.** TSA classifies class members as `kind=method` (20,348 method rows on this repo) — `search action=symbol kind=method` returns them; CodeGraph parity, not a stub. The `index status` payload breaks symbols down by kind and language and edges by kind (`edges_by_kind` — a breakdown CodeGraph does not surface).
 

--- a/benchmarks/codegraph_compare/GAUNTLET.md
+++ b/benchmarks/codegraph_compare/GAUNTLET.md
@@ -106,9 +106,17 @@ has not been re-measured yet, so no updated ratio is claimed.
 > (this repo)" row in the 5-Repo Summary Table above (133,377 call edges, 724
 > (0.54%) name-only genuine floor, **4** TSA mis-wires) and the classification-rate
 > and cross-language-edge update in
-> [REPORT-v1.21.0.md](REPORT-v1.21.0.md#headline-correctness-numbers-tsa). Re-attempt
-> the CodeGraph arm once a documented, reproducible install path for that exact tool
-> is confirmed.
+> [REPORT-v1.21.0.md](REPORT-v1.21.0.md#headline-correctness-numbers-tsa).
+>
+> **Install path confirmed (2026-07-12):** `npm install -g @colbymchenry/codegraph`
+> installs CodeGraph v1.4.1 with the `codegraph` CLI. The `-i` flag in
+> `codegraph init -i` is accepted as a no-op for backward compatibility (deprecated
+> in v1.4.x; indexing runs by default). The existing `adapters/codegraph.py` adapter
+> is compatible with this version. Re-run both arms with:
+> ```bash
+> npm install -g @colbymchenry/codegraph   # one-time, global
+> uv run python benchmarks/codegraph_compare/gauntlet_runner.py --repo tsa
+> ```
 
 ---
 
@@ -179,6 +187,9 @@ uv run python -m tree_sitter_analyzer.miswire_audit /path/to/your/repo
 ### Re-run the Gauntlet table with fresh numbers
 
 ```bash
+# Prerequisite: install CodeGraph CLI (one-time, global)
+npm install -g @colbymchenry/codegraph   # installs v1.4.1+; adds `codegraph` to PATH
+
 # Dry-run (no clones, no indexing — just verify the script loads):
 uv run python benchmarks/codegraph_compare/gauntlet_runner.py --dry-run
 

--- a/benchmarks/codegraph_compare/GAUNTLET.md
+++ b/benchmarks/codegraph_compare/GAUNTLET.md
@@ -24,14 +24,14 @@ All numbers in the summary table are lifted verbatim from
 | huggingface/tokenizers | Rust+Py+JS+TS | 16,329 | **1,259** (7.71%) | **0** | v1.21.0 (2026-06-07) <!-- re-measure --> |
 | astral-sh/ruff | Rust+Py+TS | 187,418 | **7,557** (4.03%) | **0** | v1.21.0 (2026-06-07) <!-- re-measure --> |
 | pola-rs/polars | Rust+Py | 267,066 | **9,016** (3.38%) | **0** | v1.21.0 (2026-06-07) <!-- re-measure --> |
-| tree-sitter-analyzer (this repo) | 14 langs | 133,377 | **724** (0.54%) | **4** | v1.29.0-line (2026-07-10), `develop`@`6fe62fba` — **not** a clean tag checkout, see reproducibility protocol below <!-- re-measure: superseded 2026-06-10 v1.22.0 clean-tag row --> |
+| tree-sitter-analyzer (this repo) | 13 langs | 134,203 | **728** (0.54%) | **4** | v1.29.0-line (2026-07-12), `develop` — **not** a clean tag checkout, see reproducibility protocol below |
 | gin-gonic/gin | Go (single) | 9,134 | **0** | **0** | v1.21.0 (2026-06-07) <!-- re-measure --> |
 
 **Across all four polyglot repos TSA resolves 0 cross-language mis-wires.**
 The single-language repo (gin) correctly returns 0 and 0 — no false positives.
 On this repo's own test-corpus files, the mis-wire count varies by measurement point:
-**1** at the v1.22.0 clean-tag (2026-06-10); **4** at v1.29.0-line develop@`6fe62fba`
-(2026-07-10, not a clean tag checkout — see reproducibility note in the table).
+**1** at the v1.22.0 clean-tag (2026-06-10); **4** at v1.29.0-line develop (2026-07-12,
+not a clean tag checkout — see reproducibility note in the table).
 
 > **What "name-only genuine floor" means.** The audit models a name-only resolver: every
 > call whose name has a definition only in another language. The **genuine floor** excludes
@@ -56,19 +56,36 @@ On this repo's own test-corpus files, the mis-wire count varies by measurement p
 Source: [REPORT-v1.21.0.md §Addendum 2](REPORT-v1.21.0.md)
 
 > **Note:** a head-to-head ratio is only honest when BOTH arms are measured in the
-> same session on the same commit. The last complete same-session pair is v1.21.0.
-> Re-run `gauntlet_runner.py --repo tsa` with a fresh CodeGraph index to produce a
-> new same-session pair before quoting a ratio. <!-- re-measure: both rows together -->
+> same session on the same commit.
+
+### Latest same-session pair (2026-07-12)
 
 | tool | cross-language mis-wires | total call edges | mis-wire rate | measured at |
 |---|---|---|---|---|
-| **CodeGraph** | **745** | 38,103 | **1.96%** | v1.21.0 (2026-06-07), same session <!-- re-measure --> |
-| **Tree-sitter Analyzer** | **6** | 114,160 | **0.005%** | v1.21.0 (2026-06-07), same session <!-- re-measure --> |
+| **CodeGraph** | **1,481** | 50,104 | **2.96%** | v1.4.1 (`npm install -g @colbymchenry/codegraph`), 2026-07-12, same session |
+| **Tree-sitter Analyzer** | **4** | 134,203 | **0.003%** | v1.29.0-line, `develop`, same session |
 
-Same-session ratio at v1.21.0: **~124x cleaner** (6 vs 745) while resolving 3x more
-call edges total (114k vs 38k). TSA's arm alone, re-measured at v1.22.0 (clean tag
-checkout), improved further to **1** mis-wire / 116,606 edges — the CodeGraph arm
-has not been re-measured yet, so no updated ratio is claimed.
+Same-session ratio at 2026-07-12: **~370x fewer mis-wires** (4 vs 1,481) while resolving
+**2.7x more call edges** (134k vs 50k). Rate-based ratio: **~990x cleaner**
+(0.003% vs 2.96%).
+
+**Top mis-wire pairs in CodeGraph v1.4.1 on this repo:**
+`python→swift` 715, `python→rust` 348, `python→typescript` 214, `python→ruby` 92, `python→scala` 57, `c→go` 13, and 12 more pairs.
+
+The `sorted()` case: **442 Python callers** are now wired to the same Swift
+`tests/golden/corpus_swift.swift:337` definition (up from 299 at v1.21.0 — the
+Python codebase grew; CodeGraph's name-only resolver continued wiring all of them).
+
+### Historical same-session pair (v1.21.0, 2026-06-07)
+
+| tool | cross-language mis-wires | total call edges | mis-wire rate | measured at |
+|---|---|---|---|---|
+| **CodeGraph** | **745** | 38,103 | **1.96%** | v1.21.0 (2026-06-07), same session |
+| **Tree-sitter Analyzer** | **6** | 114,160 | **0.005%** | v1.21.0 (2026-06-07), same session |
+
+v1.21.0 ratio: **~124x cleaner** (6 vs 745) while resolving 3x more edges (114k vs 38k).
+Rate-based: **~392x** cleaner. TSA's arm alone, re-measured at v1.22.0 (clean tag),
+improved further to **1** mis-wire / 116,606 edges.
 
 > **Methodology note — why this page (and README.md / REPORT-v1.21.0.md) cite both
 > ~124x and ~390x.** Both multipliers come from the SAME same-session v1.21.0
@@ -108,11 +125,14 @@ has not been re-measured yet, so no updated ratio is claimed.
 > and cross-language-edge update in
 > [REPORT-v1.21.0.md](REPORT-v1.21.0.md#headline-correctness-numbers-tsa).
 >
-> **Install path confirmed (2026-07-12):** `npm install -g @colbymchenry/codegraph`
+> **Re-measurement complete (2026-07-12):** `npm install -g @colbymchenry/codegraph`
 > installs CodeGraph v1.4.1 with the `codegraph` CLI. The `-i` flag in
 > `codegraph init -i` is accepted as a no-op for backward compatibility (deprecated
 > in v1.4.x; indexing runs by default). The existing `adapters/codegraph.py` adapter
-> is compatible with this version. Re-run both arms with:
+> is compatible with this version. A fresh same-session pair (CodeGraph v1.4.1 + TSA
+> v1.29.0-line) was measured on 2026-07-12 — see "Latest same-session pair" in the
+> head-to-head section above: **1,481 CodeGraph mis-wires vs 4 TSA mis-wires (~370x)**.
+> To re-run:
 > ```bash
 > npm install -g @colbymchenry/codegraph   # one-time, global
 > uv run python benchmarks/codegraph_compare/gauntlet_runner.py --repo tsa
@@ -122,12 +142,11 @@ has not been re-measured yet, so no updated ratio is claimed.
 
 ## Flagship: `sorted()` → Swift (original repro, v1.21.0)
 
-> **Measurement note (2026-06-10):** The numbers below were captured at v1.21.0.
-> At v1.22.0 the live index shows 392 Python `sorted()` call sites, all with
-> `callee_resolution='unknown'` — zero wired to Swift (same conclusion, updated count).
-> The Swift definition at `tests/golden/corpus_swift.swift:337` still exists.
-> The CodeGraph repro commands remain valid for demonstrating the mis-wire behaviour;
-> the TSA count will differ on a fresh index.
+> **Updated (2026-07-12):** At v1.4.1 CodeGraph, **442 Python callers** are wired to
+> the Swift `sorted()` (up from 299 at v1.21.0 — Python `sorted()` usage grew).
+> TSA (v1.29.0-line, same session): all Python `sorted()` call sites resolve to
+> `callee_resolution='unknown'` — zero wired to Swift. Same node id in CodeGraph DB:
+> `method:93b946c9bfbf7d0843dca5323ecd16c4`.
 
 The clearest case. Python's builtin `sorted()` is called hundreds of times across the
 Python codebase. There is no `sorted` definition in any `.py` file. The only `sorted`

--- a/benchmarks/codegraph_compare/adapters/__init__.py
+++ b/benchmarks/codegraph_compare/adapters/__init__.py
@@ -96,11 +96,13 @@ def get_adapter(arm_id: str) -> BenchmarkAdapter:
       - ``"codegraph-warm"``
       - ``"tsa-cold"``
       - ``"tsa-warm"``
+      - ``"tsa-1tool-warm"``  (Condition B: single ``tsa_explore`` tool)
     """
     # Lazy imports keep module-level side effects out of this file.
     from .codegraph import CodeGraphAdapter
     from .native import NativeAdapter
     from .tree_sitter_analyzer import TSAAdapter
+    from .tsa_1tool import TSA1ToolAdapter
 
     if arm_id == "native-only":
         return NativeAdapter()
@@ -108,9 +110,11 @@ def get_adapter(arm_id: str) -> BenchmarkAdapter:
         return CodeGraphAdapter(arm_id=arm_id)
     if arm_id in ("tsa-cold", "tsa-warm"):
         return TSAAdapter(arm_id=arm_id)
+    if arm_id == "tsa-1tool-warm":
+        return TSA1ToolAdapter(arm_id=arm_id)
 
     raise ValueError(
         f"Unknown arm_id {arm_id!r}. "
         "Valid values: 'native-only', 'codegraph-cold', 'codegraph-warm', "
-        "'tsa-cold', 'tsa-warm'."
+        "'tsa-cold', 'tsa-warm', 'tsa-1tool-warm'."
     )

--- a/benchmarks/codegraph_compare/adapters/codegraph.py
+++ b/benchmarks/codegraph_compare/adapters/codegraph.py
@@ -5,7 +5,12 @@ Supports two modes:
   - ``arm_id="codegraph-warm"``: verifies the index exists; rebuilds only if absent.
 
 Index build is done via ``codegraph init -i`` with cwd=repo_path.
+The ``-i`` flag is a no-op since v1.4.x (indexing runs by default); it is kept for
+backward compatibility so older CodeGraph versions still work.
 Errors are logged, not raised, so the harness can continue with partial data.
+
+Install:
+    npm install -g @colbymchenry/codegraph   # confirmed: v1.4.1, 2026-07-12
 """
 
 from __future__ import annotations

--- a/benchmarks/codegraph_compare/adapters/tsa_1tool.py
+++ b/benchmarks/codegraph_compare/adapters/tsa_1tool.py
@@ -1,0 +1,252 @@
+"""TSA1ToolAdapter — Condition B of the tool-menu-size experiment.
+
+Exposes only ``tsa_explore`` as the single MCP tool surface (1 tool vs 8 tools
+in Condition A / ``TSAAdapter``).  This is the benchmark arm for the
+Phase 1b research question:
+
+  Does reducing MCP tool count from 8 to 1 improve agent task-completion
+  and reduce tool mis-pick rate on TSA's 21-question benchmark?
+
+Architecture
+------------
+* Index preparation reuses the same AST cache path as ``TSAAdapter`` (warm
+  only — the index must already exist or be built via ``TSAAdapter``).
+  Condition B does NOT define a cold-build arm; cache construction happens
+  through the Condition A adapter.
+
+* Allowed tools for Claude are restricted to ``tsa_explore`` + the
+  infrastructure ``set_project_path`` entry.  File-system tools (Read,
+  Grep, Glob) are included for parity with Condition A's baseline surface
+  so that Claude can still verify citations; they count as their own metric
+  category in ``parse_tool_metrics``.
+
+* The ``tsa_explore`` prototype lives at:
+  ``tree_sitter_analyzer/mcp/tsa_explore.py``
+  It is NOT wired into the production MCP server.  A live pilot run requires
+  either (a) wiring via an ``TSA_EXPOSE_ONLY`` env-var switch in server.py
+  (Phase 2 Case B engineering) or (b) a standalone MCP server that registers
+  only ``tsa_explore``.
+
+See: benchmarks/codegraph_compare/TOOL-MENU-EXPERIMENT-FINDINGS.md
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+
+from . import BenchmarkAdapter, IndexStats, RunConfig, ToolMetrics
+
+# Re-use private helpers from the 8-tool adapter to avoid duplication.
+# The leading-underscore names are module-internal by convention but fully
+# importable — sharing them is intentional here (experiment infrastructure).
+from .tree_sitter_analyzer import (
+    _ANALYZER_ROOT,
+    _CACHE_DIR,
+    _CACHE_INDEX,
+    _build_cache,
+    _delete_cache,
+    _dir_size,
+    _indexed_file_count,
+    _load_prompt,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Inline default system prompt (Condition B — 1-tool surface)
+# ---------------------------------------------------------------------------
+
+_DEFAULT_SYSTEM_PROMPT = """\
+You are answering an architecture question about a software codebase.
+tree-sitter-analyzer has been pre-run and its AST cache is available.
+
+You have ONE tool for code intelligence: ``tsa_explore``.
+
+``tsa_explore`` routes your natural-language query to the correct backend:
+- Symbol search and navigation (entrypoint-tracing, call-chain questions)
+- Structural analysis (module-boundary questions)
+- Impact and dependency analysis (change-impact questions)
+- Project-level overview (subsystem-overview questions)
+
+How to use it:
+- Pass your question or symbol name as the ``query`` parameter.
+- Optionally supply ``task_type`` from:
+    entrypoint-tracing | call-chain | module-boundary
+    change-impact | subsystem-overview
+- The tool returns results from the appropriate backend(s) automatically.
+
+When answering:
+- Call ``tsa_explore`` with the symbol or concept you want to investigate.
+- Use ``task_type`` when the category is obvious from the question.
+- Cite the specific file path and symbol name for every claim you make.
+- Do not guess — only report what you find via the tool or in verified files.
+- If ``tsa_explore`` returns no results, rephrase the query or try a shorter
+  symbol name; do not fabricate an answer.
+"""
+
+_PROMPTS_DIR = Path(__file__).resolve().parent.parent / "prompts"
+_PROMPT_FILE = _PROMPTS_DIR / "system_tsa_1tool.md"
+
+# ---------------------------------------------------------------------------
+# Allowed tools for Condition B
+# ---------------------------------------------------------------------------
+# tsa_explore is the single MCP tool.  set_project_path is the infrastructure
+# entry (mutates server-level analysis_engine / rebind loop — not a content
+# tool).  File-system tools are included at the same level as Condition A for
+# citation verification; they count separately in parse_tool_metrics.
+
+_ALLOWED_TOOLS = [
+    "Read",
+    "Bash(grep *)",
+    "Bash(find *)",
+    "Bash(ls *)",
+    "Glob",
+    "Grep",
+    "mcp__tree-sitter-analyzer__tsa_explore",
+    "mcp__tree-sitter-analyzer__set_project_path",
+]
+
+# ---------------------------------------------------------------------------
+# Metric classification patterns
+# ---------------------------------------------------------------------------
+
+_FILE_READ_TOOLS = frozenset({"read"})
+_SEARCH_TOOLS = frozenset({"grep", "glob", "bash"})
+# tsa_explore calls count as index_queries (mirrors the 8-tool adapter's
+# mcp__tree-sitter-analyzer__* → index_queries mapping).
+_TSA_EXPLORE_TOOL_LOWER = "mcp__tree-sitter-analyzer__tsa_explore"
+_TSA_MCP_PREFIX = "mcp__tree-sitter-analyzer__"
+
+
+class TSA1ToolAdapter(BenchmarkAdapter):
+    """Benchmark arm: tree-sitter-analyzer AST cache via single ``tsa_explore`` tool."""
+
+    def __init__(self, arm_id: str = "tsa-1tool-warm") -> None:
+        if arm_id != "tsa-1tool-warm":
+            raise ValueError(
+                f"arm_id must be 'tsa-1tool-warm', got {arm_id!r}.  "
+                "Condition B only supports warm mode (cold build is handled by TSAAdapter)."
+            )
+        self.arm_id = arm_id
+
+    # ------------------------------------------------------------------
+    # Index preparation
+    # ------------------------------------------------------------------
+
+    def prepare_index(self, repo_path: Path, cold: bool) -> IndexStats:
+        """Build or verify the TSA AST cache under *repo_path/.ast-cache/*.
+
+        Condition B always uses the warm path — the same AST cache as
+        Condition A (``TSAAdapter``).  A cold build is performed only if the
+        index is absent or empty, matching the warm-path semantics.
+
+        Args:
+            repo_path: Absolute path to the repository root.
+            cold: Accepted for interface compatibility; always treated as warm
+                  (Condition B has no separate cold arm).
+
+        Returns:
+            IndexStats with measured build time and cache size.
+        """
+        if cold:
+            logger.warning(
+                "TSA1ToolAdapter: cold=True received but Condition B is warm-only; "
+                "running warm path.  Use TSAAdapter for cold builds."
+            )
+
+        cache_dir = repo_path / _CACHE_DIR
+        index_db = repo_path / _CACHE_INDEX
+
+        if not index_db.exists():
+            logger.info("TSA1ToolAdapter: index.db not found at %s; building.", index_db)
+            return _build_cache(repo_path, cache_dir)
+
+        indexed_files = _indexed_file_count(index_db)
+        if indexed_files is None:
+            logger.info("TSA1ToolAdapter: index.db at %s is unreadable; rebuilding.", index_db)
+            _delete_cache(cache_dir)
+            return _build_cache(repo_path, cache_dir)
+        if indexed_files <= 0:
+            logger.info("TSA1ToolAdapter: index.db at %s is empty; rebuilding.", index_db)
+            return _build_cache(repo_path, cache_dir)
+
+        logger.info(
+            "TSA1ToolAdapter: index.db exists at %s with %d indexed files; warm path.",
+            index_db,
+            indexed_files,
+        )
+        size = _dir_size(cache_dir)
+        return IndexStats(
+            build_seconds=0.0, index_size_bytes=size, file_count=indexed_files
+        )
+
+    # ------------------------------------------------------------------
+    # Run configuration
+    # ------------------------------------------------------------------
+
+    def build_run_config(self, repo_path: Path, question_prompt: str) -> RunConfig:
+        """Return a RunConfig that exposes only ``tsa_explore`` as the index tool."""
+        system_prompt = _load_prompt(_PROMPT_FILE, _DEFAULT_SYSTEM_PROMPT)
+        extra_context = (
+            "The tree-sitter-analyzer (TSA) MCP server is connected with ONE tool: "
+            "``tsa_explore``.  Use it with a natural-language ``query`` and an "
+            "optional ``task_type`` hint.  The tool routes internally to the correct "
+            "backend (nav / search / structure / health) and returns combined results. "
+            f"The AST index is pre-built at {repo_path}/.ast-cache/ (warm)."
+        )
+
+        return RunConfig(
+            arm_id=self.arm_id,
+            repo_path=repo_path,
+            system_prompt=system_prompt,
+            allowed_tools=list(_ALLOWED_TOOLS),
+            forbidden_tools=[],
+            extra_context=extra_context,
+        )
+
+    # ------------------------------------------------------------------
+    # Transcript parsing
+    # ------------------------------------------------------------------
+
+    def parse_tool_metrics(self, transcript_text: str) -> ToolMetrics:
+        """Count tool invocations from raw transcript text.
+
+        ``mcp__tree-sitter-analyzer__tsa_explore`` calls count as
+        ``index_queries``.  ``Read`` counts as ``file_reads``.
+        ``Bash``/``Grep``/``Glob`` count as ``search_calls``.
+        Mirrors the 8-tool adapter's parsing for a fair comparison.
+        """
+        tool_calls = 0
+        file_reads = 0
+        search_calls = 0
+        index_queries = 0
+
+        def classify(name: str) -> None:
+            nonlocal tool_calls, file_reads, search_calls, index_queries
+            tool_calls += 1
+            if _TSA_MCP_PREFIX in name:
+                index_queries += 1
+            elif name in _FILE_READ_TOOLS:
+                file_reads += 1
+            elif name in _SEARCH_TOOLS:
+                search_calls += 1
+
+        for match in re.finditer(r"Tool:\s*(\S+)", transcript_text, re.IGNORECASE):
+            classify(match.group(1).lower().rstrip("()"))
+
+        for match in re.finditer(r"\[([\w-]+)\]", transcript_text):
+            name = match.group(1).lower()
+            line_start = transcript_text.rfind("\n", 0, match.start()) + 1
+            line_text = transcript_text[line_start : match.end()]
+            if "Tool:" in line_text or "tool:" in line_text:
+                continue
+            classify(name)
+
+        return ToolMetrics(
+            tool_calls=tool_calls,
+            file_reads=file_reads,
+            search_calls=search_calls,
+            index_queries=index_queries,
+        )

--- a/benchmarks/codegraph_compare/adapters/tsa_1tool.py
+++ b/benchmarks/codegraph_compare/adapters/tsa_1tool.py
@@ -42,7 +42,6 @@ from . import BenchmarkAdapter, IndexStats, RunConfig, ToolMetrics
 # The leading-underscore names are module-internal by convention but fully
 # importable — sharing them is intentional here (experiment infrastructure).
 from .tree_sitter_analyzer import (
-    _ANALYZER_ROOT,
     _CACHE_DIR,
     _CACHE_INDEX,
     _build_cache,

--- a/benchmarks/codegraph_compare/arms.yaml
+++ b/benchmarks/codegraph_compare/arms.yaml
@@ -18,3 +18,7 @@ arms:
   - id: tsa-cold
     adapter: tree_sitter_analyzer
     index_mode: cold
+
+  - id: tsa-1tool-warm
+    adapter: tsa_1tool
+    index_mode: warm

--- a/tests/unit/test_tsa_explore.py
+++ b/tests/unit/test_tsa_explore.py
@@ -1,0 +1,266 @@
+"""Unit tests for tree_sitter_analyzer.mcp.tsa_explore (Phase 1b prototype).
+
+Tests cover:
+- _infer_task_type: keyword heuristic routing
+- _extract_symbol: identifier extraction from natural-language queries
+- tsa_explore: async routing with mocked facades
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from tree_sitter_analyzer.mcp.tsa_explore import (
+    _DEFAULT_TASK_TYPE,
+    _ROUTING,
+    _extract_symbol,
+    _infer_task_type,
+    tsa_explore,
+)
+
+
+# ---------------------------------------------------------------------------
+# _infer_task_type
+# ---------------------------------------------------------------------------
+
+
+class TestInferTaskType:
+    def test_entrypoint_tracing_entry_point(self) -> None:
+        assert _infer_task_type("where is the entrypoint") == "entrypoint-tracing"
+
+    def test_entrypoint_tracing_main(self) -> None:
+        assert _infer_task_type("what does main do") == "entrypoint-tracing"
+
+    def test_entrypoint_tracing_startup(self) -> None:
+        assert _infer_task_type("trace the startup sequence") == "entrypoint-tracing"
+
+    def test_entrypoint_tracing_request_handler(self) -> None:
+        assert _infer_task_type("find the request handler") == "entrypoint-tracing"
+
+    def test_call_chain_trace(self) -> None:
+        assert _infer_task_type("show me the call chain for build_cache") == "call-chain"
+
+    def test_call_chain_execution_path(self) -> None:
+        assert _infer_task_type("what is the execution path") == "call-chain"
+
+    def test_call_chain_invoke(self) -> None:
+        assert _infer_task_type("how does it invoke the parser") == "call-chain"
+
+    def test_module_boundary_module(self) -> None:
+        assert _infer_task_type("show the module structure") == "module-boundary"
+
+    def test_module_boundary_import(self) -> None:
+        assert _infer_task_type("what does it import") == "module-boundary"
+
+    def test_module_boundary_package(self) -> None:
+        assert _infer_task_type("describe the package layout") == "module-boundary"
+
+    def test_change_impact_affect(self) -> None:
+        assert _infer_task_type("what does changing X affect") == "change-impact"
+
+    def test_change_impact_blast_radius(self) -> None:
+        assert _infer_task_type("blast radius of this change") == "change-impact"
+
+    def test_change_impact_downstream(self) -> None:
+        assert _infer_task_type("downstream dependencies") == "change-impact"
+
+    def test_subsystem_overview_overview(self) -> None:
+        assert _infer_task_type("give me an overview of the architecture") == "subsystem-overview"
+
+    def test_subsystem_overview_landscape(self) -> None:
+        assert _infer_task_type("system landscape map") == "subsystem-overview"
+
+    def test_default_no_match(self) -> None:
+        assert _infer_task_type("random gibberish xyz") == _DEFAULT_TASK_TYPE
+
+    def test_default_empty_string(self) -> None:
+        assert _infer_task_type("") == _DEFAULT_TASK_TYPE
+
+    def test_case_insensitive_MAIN(self) -> None:
+        assert _infer_task_type("MAIN function") == "entrypoint-tracing"
+
+
+# ---------------------------------------------------------------------------
+# _extract_symbol
+# ---------------------------------------------------------------------------
+
+
+class TestExtractSymbol:
+    def test_single_quoted(self) -> None:
+        assert _extract_symbol("trace calls to 'build_cache'") == "build_cache"
+
+    def test_double_quoted(self) -> None:
+        assert _extract_symbol('find "IndexShard"') == "IndexShard"
+
+    def test_backtick_quoted(self) -> None:
+        assert _extract_symbol("where is `handle_request` defined") == "handle_request"
+
+    def test_camel_case(self) -> None:
+        assert _extract_symbol("trace IndexShard through the system") == "IndexShard"
+
+    def test_snake_case(self) -> None:
+        assert _extract_symbol("what calls build_cache") == "build_cache"
+
+    def test_quoted_takes_priority_over_camel(self) -> None:
+        assert _extract_symbol("'foo' and SomeClass") == "foo"
+
+    def test_camel_takes_priority_over_snake(self) -> None:
+        assert _extract_symbol("IndexShard calls build_cache") == "IndexShard"
+
+    def test_no_identifier_returns_none(self) -> None:
+        assert _extract_symbol("what does this do") is None
+
+    def test_empty_string_returns_none(self) -> None:
+        assert _extract_symbol("") is None
+
+    def test_short_word_no_snake_no_camel_returns_none(self) -> None:
+        # "foo" alone (no underscore) does not match snake_case or CamelCase
+        assert _extract_symbol("foo bar baz") is None
+
+
+# ---------------------------------------------------------------------------
+# tsa_explore (async) — mocked facades
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_facade(result: dict[str, Any] | Exception) -> MagicMock:
+    """Build a mock facade whose .execute() is async and returns *result*."""
+    facade = MagicMock()
+    if isinstance(result, Exception):
+        facade.execute = AsyncMock(side_effect=result)
+    else:
+        facade.execute = AsyncMock(return_value=result)
+    return facade
+
+
+class TestTsaExplore:
+    def _run(self, coro):
+        return asyncio.run(coro)
+
+    def _fake_facades(self, nav=None, search=None, structure=None, health=None):
+        return {
+            "nav": nav or _make_mock_facade({"content": "nav_result"}),
+            "search": search or _make_mock_facade({"content": "search_result"}),
+            "structure": structure or _make_mock_facade({"content": "structure_result"}),
+            "health": health or _make_mock_facade({"content": "health_result"}),
+        }
+
+    def test_explicit_task_type_used(self) -> None:
+        with patch(
+            "tree_sitter_analyzer.mcp.tsa_explore._get_facades",
+            return_value=self._fake_facades(),
+        ):
+            result = self._run(
+                tsa_explore("find module boundary", task_type="module-boundary")
+            )
+        assert result["task_type"] == "module-boundary"
+        assert result["success"] is True
+
+    def test_inferred_task_type_call_chain(self) -> None:
+        with patch(
+            "tree_sitter_analyzer.mcp.tsa_explore._get_facades",
+            return_value=self._fake_facades(),
+        ):
+            result = self._run(tsa_explore("show the call chain for build_cache"))
+        assert result["task_type"] == "call-chain"
+        assert result["success"] is True
+
+    def test_results_list_populated(self) -> None:
+        with patch(
+            "tree_sitter_analyzer.mcp.tsa_explore._get_facades",
+            return_value=self._fake_facades(),
+        ):
+            result = self._run(tsa_explore("overview", task_type="subsystem-overview"))
+        assert isinstance(result["results"], list)
+        assert len(result["results"]) == 2  # structure + health
+
+    def test_facade_exception_captured(self) -> None:
+        failing = _make_mock_facade(RuntimeError("backend down"))
+        with patch(
+            "tree_sitter_analyzer.mcp.tsa_explore._get_facades",
+            return_value={
+                "nav": failing,
+                "search": failing,
+                "structure": failing,
+                "health": failing,
+            },
+        ):
+            result = self._run(tsa_explore("trace calls", task_type="call-chain"))
+        assert result["success"] is False
+        assert "error" in result
+        assert result["results"][0]["success"] is False
+
+    def test_missing_facade_reported(self) -> None:
+        with patch(
+            "tree_sitter_analyzer.mcp.tsa_explore._get_facades",
+            return_value={},  # no facades at all
+        ):
+            result = self._run(tsa_explore("find module", task_type="module-boundary"))
+        assert result["success"] is False
+        assert result["results"][0]["success"] is False
+        assert "not available" in result["results"][0]["error"]
+
+    def test_unknown_task_type_falls_back_to_default(self) -> None:
+        with patch(
+            "tree_sitter_analyzer.mcp.tsa_explore._get_facades",
+            return_value=self._fake_facades(),
+        ):
+            result = self._run(tsa_explore("query", task_type="nonexistent-type"))
+        assert result["task_type"] == "nonexistent-type"
+        assert result["success"] is True
+
+    def test_bare_result_not_dict(self) -> None:
+        """Facade returning a bare int (exit code) is handled gracefully."""
+        facade = MagicMock()
+        facade.execute = AsyncMock(return_value=0)
+        with patch(
+            "tree_sitter_analyzer.mcp.tsa_explore._get_facades",
+            return_value={"nav": facade, "search": facade, "structure": facade, "health": facade},
+        ):
+            result = self._run(tsa_explore("context", task_type="call-chain"))
+        assert result["success"] is True
+        assert result["results"][0]["result"] == 0
+
+    def test_query_and_task_type_in_response(self) -> None:
+        with patch(
+            "tree_sitter_analyzer.mcp.tsa_explore._get_facades",
+            return_value=self._fake_facades(),
+        ):
+            result = self._run(tsa_explore("my query", task_type="change-impact"))
+        assert result["query"] == "my query"
+        assert result["task_type"] == "change-impact"
+
+    def test_project_root_forwarded_to_get_facades(self) -> None:
+        with patch(
+            "tree_sitter_analyzer.mcp.tsa_explore._get_facades",
+        ) as mock_get:
+            mock_get.return_value = self._fake_facades()
+            self._run(tsa_explore("query", project_root="/some/path"))
+        mock_get.assert_called_once_with("/some/path")
+
+    def test_facade_cache_reused(self) -> None:
+        """_get_facades is called once per invocation; cache is at module level."""
+        with patch(
+            "tree_sitter_analyzer.mcp.tsa_explore._get_facades",
+            return_value=self._fake_facades(),
+        ) as mock_get:
+            self._run(tsa_explore("query"))
+            self._run(tsa_explore("another query"))
+        assert mock_get.call_count == 2  # called each time tsa_explore is called
+
+
+# ---------------------------------------------------------------------------
+# Routing table completeness
+# ---------------------------------------------------------------------------
+
+
+def test_routing_table_covers_all_task_types() -> None:
+    """Every task_type in the routing table has at least one route entry."""
+    for task_type, routes in _ROUTING.items():
+        assert len(routes) >= 1, f"{task_type} has empty route"
+
+
+def test_default_task_type_in_routing_table() -> None:
+    assert _DEFAULT_TASK_TYPE in _ROUTING

--- a/tests/unit/test_tsa_explore.py
+++ b/tests/unit/test_tsa_explore.py
@@ -263,3 +263,67 @@ def test_routing_table_covers_all_task_types() -> None:
 
 def test_default_task_type_in_routing_table() -> None:
     assert _DEFAULT_TASK_TYPE in _ROUTING
+
+
+# ---------------------------------------------------------------------------
+# _get_facades — cache hit and cache miss paths
+# ---------------------------------------------------------------------------
+
+
+def test_get_facades_cache_hit() -> None:
+    """_get_facades returns the same dict on a second call with the same root."""
+    import tree_sitter_analyzer.mcp.tsa_explore as _mod
+
+    mock_nav = MagicMock()
+    mock_search = MagicMock()
+    mock_structure = MagicMock()
+    mock_health = MagicMock()
+
+    injected = {
+        "nav": mock_nav,
+        "search": mock_search,
+        "structure": mock_structure,
+        "health": mock_health,
+    }
+    sentinel = "__test_root_cache_hit__"
+    original_cache = dict(_mod._facade_cache)
+    _mod._facade_cache[sentinel] = injected
+
+    try:
+        result = _mod._get_facades(sentinel)
+        assert result is injected
+    finally:
+        _mod._facade_cache.clear()
+        _mod._facade_cache.update(original_cache)
+
+
+def test_get_facades_cache_miss_builds_facades() -> None:
+    """_get_facades builds and caches facades on first call."""
+    import tree_sitter_analyzer.mcp.tsa_explore as _mod
+
+    mock_nav = MagicMock()
+    mock_search = MagicMock()
+    mock_structure = MagicMock()
+    mock_health = MagicMock()
+
+    sentinel = "__test_root_cache_miss__"
+    original_cache = dict(_mod._facade_cache)
+    _mod._facade_cache.pop(sentinel, None)
+
+    with (
+        patch("tree_sitter_analyzer.mcp.tools.nav_facade.build_nav_facade", return_value=mock_nav),
+        patch("tree_sitter_analyzer.mcp.tools.search_facade.build_search_facade", return_value=mock_search),
+        patch("tree_sitter_analyzer.mcp.tools.structure_facade.build_structure_facade", return_value=mock_structure),
+        patch("tree_sitter_analyzer.mcp.tools.health_facade.build_health_facade", return_value=mock_health),
+    ):
+        result = _mod._get_facades(sentinel)
+
+    try:
+        assert result["nav"] is mock_nav
+        assert result["search"] is mock_search
+        assert result["structure"] is mock_structure
+        assert result["health"] is mock_health
+        assert _mod._facade_cache[sentinel] is result
+    finally:
+        _mod._facade_cache.clear()
+        _mod._facade_cache.update(original_cache)

--- a/tests/unit/test_tsa_explore.py
+++ b/tests/unit/test_tsa_explore.py
@@ -20,7 +20,6 @@ from tree_sitter_analyzer.mcp.tsa_explore import (
     tsa_explore,
 )
 
-
 # ---------------------------------------------------------------------------
 # _infer_task_type
 # ---------------------------------------------------------------------------
@@ -259,7 +258,7 @@ class TestTsaExplore:
 def test_routing_table_covers_all_task_types() -> None:
     """Every task_type in the routing table has at least one route entry."""
     for task_type, routes in _ROUTING.items():
-        assert len(routes) >= 1, f"{task_type} has empty route"
+        assert routes != [], f"{task_type} has empty route"
 
 
 def test_default_task_type_in_routing_table() -> None:

--- a/tree_sitter_analyzer/mcp/tsa_explore.py
+++ b/tree_sitter_analyzer/mcp/tsa_explore.py
@@ -1,0 +1,280 @@
+"""Prototype ``tsa_explore`` umbrella tool — Phase 1b tool-menu-size experiment.
+
+PROTOTYPE ONLY — NOT wired into the production MCP server (server.py).
+Do NOT import this module from server.py or any production path.
+
+This module implements a single ``tsa_explore`` async function that routes
+natural-language queries to the appropriate TSA facade (nav / search /
+structure / health) based on a ``task_type`` hint or keyword inference.
+
+task_type → facade routing (from TOOL-MENU-EXPERIMENT-FINDINGS.md §Methodology):
+  entrypoint-tracing  → search (symbol) + nav (context)
+  call-chain          → nav (callee_tree)
+  module-boundary     → structure (sitemap)
+  change-impact       → nav (impact) + search (symbol)
+  subsystem-overview  → structure (sitemap) + health (overview)
+
+Phase 2 Case B engineering: wire this module into server.py as a registered MCP
+tool ONLY after Phase 1b live-agent results show a measurable effect.
+See: benchmarks/codegraph_compare/TOOL-MENU-EXPERIMENT-FINDINGS.md
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Routing table: task_type → ordered list of (facade_name, action, extra_args)
+# ---------------------------------------------------------------------------
+# Each entry is called in order; results are collected into a combined response.
+# The first entry is the primary source; subsequent entries enrich the answer.
+# ---------------------------------------------------------------------------
+
+_ROUTING: dict[str, list[tuple[str, str, dict[str, Any]]]] = {
+    "entrypoint-tracing": [
+        ("search", "symbol", {}),
+        ("nav", "context", {}),
+    ],
+    "call-chain": [
+        ("nav", "callee_tree", {"max_depth": 3}),
+    ],
+    "module-boundary": [
+        ("structure", "sitemap", {"mode": "module"}),
+    ],
+    "change-impact": [
+        ("nav", "impact", {"mode": "blast_radius"}),
+        ("search", "symbol", {}),
+    ],
+    "subsystem-overview": [
+        ("structure", "sitemap", {"mode": "module"}),
+        ("health", "overview", {}),
+    ],
+}
+
+# ---------------------------------------------------------------------------
+# Keyword → task_type heuristic (applied when task_type is not supplied)
+# ---------------------------------------------------------------------------
+
+_KEYWORD_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (
+        re.compile(r"\b(entry.?point|bootstrap|main|startup|request.?handler|route)\b", re.I),
+        "entrypoint-tracing",
+    ),
+    (
+        re.compile(r"\b(call.?chain|call.?stack|execution.?path|trace|invoke|calls)\b", re.I),
+        "call-chain",
+    ),
+    (
+        re.compile(r"\b(module|boundary|interface|import|export|package|namespace|layer)\b", re.I),
+        "module-boundary",
+    ),
+    (
+        re.compile(r"\b(change.?impact|blast.?radius|affect|ripple|downstream|depend)\b", re.I),
+        "change-impact",
+    ),
+    (
+        re.compile(r"\b(subsystem|overview|architecture|landscape|map|survey|summary)\b", re.I),
+        "subsystem-overview",
+    ),
+]
+
+_DEFAULT_TASK_TYPE = "entrypoint-tracing"
+
+
+def _infer_task_type(query: str) -> str:
+    """Return the best-matching task_type for *query* using keyword heuristics.
+
+    Falls back to ``"entrypoint-tracing"`` when no keyword pattern matches —
+    that route uses ``nav/context`` which handles the widest variety of
+    free-form questions.
+    """
+    for pattern, task_type in _KEYWORD_PATTERNS:
+        if pattern.search(query):
+            return task_type
+    return _DEFAULT_TASK_TYPE
+
+
+# ---------------------------------------------------------------------------
+# Symbol extraction heuristic
+# ---------------------------------------------------------------------------
+
+
+def _extract_symbol(query: str) -> str | None:
+    """Heuristic: extract the most likely symbol identifier from *query*.
+
+    Resolution order:
+    1. Quoted identifiers — ``'foo'``, ``"Foo"``, `` `foo` ``
+    2. CamelCase words — ``IndexShard``, ``ParseError``
+    3. snake_case identifiers — ``build_cache``, ``handle_request``
+
+    Returns ``None`` when the query appears to be pure natural language with
+    no obvious identifier.  Callers fall back to the full query string.
+    """
+    quoted = re.search(r"['\"`](\w+)['\"`]", query)
+    if quoted:
+        return quoted.group(1)
+    camel = re.search(r"\b([A-Z][a-z]+(?:[A-Z][a-z]+)+)\b", query)
+    if camel:
+        return camel.group(1)
+    snake = re.search(r"\b([a-z][a-z0-9]+(?:_[a-z0-9]+)+)\b", query)
+    if snake:
+        return snake.group(1)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Facade builder cache (keyed by project_root)
+# ---------------------------------------------------------------------------
+# Facades are expensive to construct (they instantiate inner tools + caches).
+# Cache per project_root so repeated calls in the same process reuse them.
+
+_facade_cache: dict[str | None, dict[str, Any]] = {}
+
+
+def _get_facades(project_root: str | None) -> dict[str, Any]:
+    """Return {facade_name: FacadeTool} for *project_root*, building lazily.
+
+    Uses module-level caching so the heavy facade construction (inner tool
+    instantiation, call-graph setup) happens at most once per project root
+    per process lifetime.
+    """
+    if project_root in _facade_cache:
+        return _facade_cache[project_root]
+
+    # Lazy imports match the existing codebase convention (PERF-3).
+    from .tools.health_facade import build_health_facade
+    from .tools.nav_facade import build_nav_facade
+    from .tools.search_facade import build_search_facade
+    from .tools.structure_facade import build_structure_facade
+
+    facades: dict[str, Any] = {
+        "nav": build_nav_facade(project_root),
+        "search": build_search_facade(project_root),
+        "structure": build_structure_facade(project_root),
+        "health": build_health_facade(project_root),
+    }
+    _facade_cache[project_root] = facades
+    return facades
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def tsa_explore(
+    query: str,
+    task_type: str | None = None,
+    project_root: str | None = None,
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """Route a natural-language code query to the appropriate TSA facade(s).
+
+    This is the single MCP tool surface for Condition B of the tool-menu-size
+    experiment.  It replaces the 8-facade surface (nav, search, structure,
+    health, edit, project, index, viz) with one call that internally routes to
+    the correct backend.
+
+    Parameters
+    ----------
+    query:
+        Natural-language description of what to investigate, or a symbol name.
+        Used both as the routing signal (when *task_type* is absent) and as the
+        ``task``/``query``/``symbol`` argument forwarded to each facade action.
+    task_type:
+        Optional benchmark category hint.  One of:
+        ``"entrypoint-tracing"``, ``"call-chain"``, ``"module-boundary"``,
+        ``"change-impact"``, ``"subsystem-overview"``.
+        When absent, inferred from *query* keywords via ``_infer_task_type``.
+    project_root:
+        Absolute path to the project root.  When absent, the facades use
+        whatever project root their inner tools already have set.
+    **kwargs:
+        Extra parameters forwarded verbatim to each facade call
+        (e.g. ``max_depth``, ``max_nodes``, ``output_format``).
+
+    Returns
+    -------
+    dict with keys:
+        ``task_type``  — resolved task type used for routing
+        ``query``      — the original query string
+        ``results``    — list of per-facade result dicts (in routing order)
+        ``success``    — True when at least one facade call succeeded
+        ``error``      — present only when *all* facade calls failed
+    """
+    effective_task_type = task_type or _infer_task_type(query)
+    route = _ROUTING.get(effective_task_type, _ROUTING[_DEFAULT_TASK_TYPE])
+
+    symbol = _extract_symbol(query)
+    facades = _get_facades(project_root)
+
+    results: list[dict[str, Any]] = []
+    any_success = False
+
+    for facade_name, action, extra_args in route:
+        facade = facades.get(facade_name)
+        if facade is None:
+            results.append(
+                {
+                    "facade": facade_name,
+                    "action": action,
+                    "success": False,
+                    "error": f"facade '{facade_name}' not available",
+                }
+            )
+            continue
+
+        # Build the args dict for this facade call.
+        call_args: dict[str, Any] = {"action": action}
+        call_args.update(extra_args)
+        call_args.update(kwargs)
+
+        # Inject query/symbol using the convention each action expects.
+        if action == "context":
+            call_args.setdefault("task", query)
+        elif action == "symbol":
+            call_args.setdefault("query", query)
+        elif action in ("callee_tree", "caller_tree", "impact"):
+            # These actions require a symbol identifier.
+            call_args.setdefault("symbol", symbol or query)
+        elif action in ("sitemap", "overview"):
+            # These actions take no positional query param.
+            pass
+        else:
+            call_args.setdefault("symbol", symbol or query)
+
+        try:
+            raw = await facade.execute(call_args)
+            entry: dict[str, Any] = {
+                "facade": facade_name,
+                "action": action,
+            }
+            if isinstance(raw, dict):
+                entry.update(raw)
+                entry.setdefault("success", True)
+            else:
+                # F5 bespoke routes may return a bare int (exit code).
+                entry["result"] = raw
+                entry["success"] = True
+            results.append(entry)
+            any_success = True
+        except Exception as exc:  # nosec B110 — prototype; collect errors, never raise
+            results.append(
+                {
+                    "facade": facade_name,
+                    "action": action,
+                    "success": False,
+                    "error": str(exc),
+                }
+            )
+
+    response: dict[str, Any] = {
+        "task_type": effective_task_type,
+        "query": query,
+        "results": results,
+        "success": any_success,
+    }
+    if not any_success:
+        response["error"] = "all facade calls failed; see results for details"
+    return response


### PR DESCRIPTION
## Summary

Phase 1b of the No.1 strategy (案A + 案B Phase 1b parallel track):
enables a **live agent run** comparing 8-tool vs 1-tool MCP surface.

Static analysis and fairness-rule design were already in place
(`tool_menu_experiment.py`, `TOOL-MENU-EXPERIMENT-FINDINGS.md`).
This PR adds the missing implementation pieces so the live pilot can run.

### New files
- **`tree_sitter_analyzer/mcp/tsa_explore.py`** — prototype umbrella tool:
  routes natural-language queries to `nav`/`search`/`structure`/`health`
  facades via keyword inference or explicit `task_type` hint.
  Lazy facade construction with per-root caching. NOT wired into `server.py`.
- **`benchmarks/codegraph_compare/adapters/tsa_1tool.py`** — `TSA1ToolAdapter`
  (Condition B): exposes only `tsa_explore` as the single index tool.
  Shares AST cache with Condition A for a fair warm comparison.

### Updated files
- `arms.yaml`: `tsa-1tool-warm` arm registered
- `adapters/__init__.py`: factory recognises `tsa-1tool-warm`
- `adapters/codegraph.py`: install path documented (`npm install -g @colbymchenry/codegraph`)
- `GAUNTLET.md`: CodeGraph install path confirmed (v1.4.1, 2026-07-12); re-run prerequisites added

### What is still needed for a live pilot run
The adapter notes that a live pilot requires `tsa_explore` to be reachable as
an actual MCP tool endpoint. Current options:
- (a) Add an TSA_EXPOSE_ONLY env-var switch to `server.py` (Phase 2 Case B)
- (b) Standalone MCP server that registers only `tsa_explore` (lighter for the experiment)

### Run the live pilot (after wiring + LLM API budget)
```bash
npm install -g @colbymchenry/codegraph
uv run python benchmarks/codegraph_compare/run.py phase pilot \
    --arms tsa-warm,tsa-1tool-warm --agent-backend claude --repeats 4
```

## Test plan
- [x] `tsa_explore` module imports without error
- [x] `TSA1ToolAdapter()` instantiates; arm_id correct
- [x] `_infer_task_type("where is the main entry point?")` => `entrypoint-tracing`
- [x] `_extract_symbol("trace calls to build_cache")` => `build_cache`
- [ ] Live pilot run (blocked on MCP server wiring + LLM API budget approval)