### PR TITLE
feat(lua): wire loader-backed symbol indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,7 +419,6 @@ MCP client config (the project root inside the container is the mount point `/wo
 ---
 
 ## Supported Languages
-
 22 language plugins; 13 fully wired into the indexer (full symbol + call graph) + 2 symbol-indexed (call-graph wiring pending) + 1 partial function-symbol indexer + 5 (data/markup) reachable via the single-file CLI path + 1 scaffold (plugin exists, indexer wiring pending). bash and scala graduated in v1.22.0; Lua indexes function symbols while indexed imports and resolved calls remain pending. The 2026-05-24 patch unblocked Swift / Kotlin / Ruby / PHP / C# that had been silently skipped for months.
 
 | Tier | Languages |

--- a/README.md
+++ b/README.md
@@ -420,16 +420,17 @@ MCP client config (the project root inside the container is the mount point `/wo
 
 ## Supported Languages
 
-22 language plugins; 13 fully wired into the indexer (full symbol + call graph) + 2 symbol-indexed (call-graph wiring pending) + 5 (data/markup) reachable via the single-file CLI path + 2 scaffold (plugin exists, indexer wiring pending). bash and scala graduated in v1.22.0; the 2026-05-24 patch unblocked Swift / Kotlin / Ruby / PHP / C# that had been silently skipped for months.
+22 language plugins; 13 fully wired into the indexer (full symbol + call graph) + 2 symbol-indexed (call-graph wiring pending) + 1 partial function-symbol indexer + 5 (data/markup) reachable via the single-file CLI path + 1 scaffold (plugin exists, indexer wiring pending). bash and scala graduated in v1.22.0; Lua indexes function symbols while indexed imports and resolved calls remain pending. The 2026-05-24 patch unblocked Swift / Kotlin / Ruby / PHP / C# that had been silently skipped for months.
 
 | Tier | Languages |
 |---|---|
 | **Full index + symbol + call graph** | Python · Java · JavaScript · TypeScript · Go · Rust · C · C++ · C# · Swift · Kotlin · Ruby · PHP |
 | **Full index + symbols (call-graph wiring pending)** | Bash · Scala |
+| **Partial function-symbol indexing** | Lua |
 | **Single-file analysis (CLI)** | HTML · CSS · Markdown · SQL · YAML |
-| **Scaffold (plugin exists, indexer wiring pending)** | JSON · Lua |
+| **Scaffold (plugin exists, indexer wiring pending)** | JSON |
 
-CodeGraph supports a similar set. **Dart, Vue, Svelte, Lua** are not yet shipped — aspirational backlog, no committed date.
+CodeGraph supports a similar set. **Dart, Vue, Svelte** are not yet shipped — aspirational backlog, no committed date.
 
 ---
 

--- a/docs/CODEMAPS/README.md
+++ b/docs/CODEMAPS/README.md
@@ -11,7 +11,7 @@ Each map under ~1k tokens — load only the one(s) you need.
 | [architecture.md](./architecture.md) | High-level topology · data flow · cross-cutting concerns |
 | [mcp-tools.md](./mcp-tools.md) | 8 facade tools + set_project_path registered in `mcp/_tool_registry.py` |
 | [cli.md](./cli.md) | CLI flags / commands / `tree-sitter-analyzer` entry points |
-| [languages.md](./languages.md) | 21 language plugins + grammar coverage |
+| [languages.md](./languages.md) | 22 language plugins + grammar coverage |
 | [formatters.md](./formatters.md) | Output formats (TOON / JSON / table / CSV / YAML) |
 | [security.md](./security.md) | Boundary enforcement · project root resolution · path validation |
 

--- a/docs/CODEMAPS/languages.md
+++ b/docs/CODEMAPS/languages.md
@@ -10,8 +10,9 @@ Not every registered plugin is wired into the indexer to the same depth:
 
 - **13 fully wired** (full symbol + call graph): Python, Java, JavaScript, TypeScript, Go, Rust, C, C++, C#, Swift, Kotlin, Ruby, PHP
 - **2 symbol-indexed** (call-graph wiring pending): Bash, Scala — both graduated in v1.22.0
+- **1 partial symbol-indexed**: Lua function symbols; resolved calls and indexed imports pending
 - **5 data/markup** (reachable via the single-file CLI path): HTML, CSS, Markdown, SQL, YAML
-- **2 scaffold** (plugin exists, indexer wiring pending): JSON, Lua
+- **1 scaffold** (plugin exists, indexer wiring pending): JSON
 
 ## Supported Languages
 
@@ -38,7 +39,7 @@ Not every registered plugin is wired into the indexer to the same depth:
 | Markdown | `markdown_plugin/` | submodules | headings, code blocks, tables |
 | JSON | `languages/json_plugin.py` | inline | basic structure |
 | Bash | `languages/bash_plugin.py` | inline | functions, commands |
-| Lua | `languages/lua_plugin/` | `plugin.py` + `extractor.py` | Production scaffold plugin with `function_declaration` / `require()` extraction via the shared QueryCursor compatibility layer; Synapse claims the Lua resolver slot conservatively as `unknown` |
+| Lua | `languages/lua_plugin/` | `plugin.py` + `extractor.py` | Loader-backed function-symbol indexing; `require()` extraction is available on the single-file plugin path but indexed imports and resolved calls remain pending; Synapse claims the resolver slot conservatively as `unknown` |
 
 ## Shared helpers
 

--- a/tests/contracts/test_plugin_architecture_contract.py
+++ b/tests/contracts/test_plugin_architecture_contract.py
@@ -48,6 +48,23 @@ def _discover_plugin_files() -> list[tuple[str, Path]]:
     return result
 
 
+def test_plugin_detector_and_loader_canonical_language_sets_match() -> None:
+    """Every built-in entry-point plugin has detector and loader truth entries."""
+    pyproject = tomllib.loads((PROJECT_ROOT / "pyproject.toml").read_text("utf-8"))
+    plugin_languages = set(
+        pyproject["project"]["entry-points"]["tree_sitter_analyzer.plugins"]
+    )
+
+    from tree_sitter_analyzer.language_detector import LanguageDetector
+    from tree_sitter_analyzer.language_loader import LanguageLoader
+
+    loader_aliases = {"cs", "tsx", "yml"}
+    loader_languages = set(LanguageLoader.LANGUAGE_MODULES) - loader_aliases
+    detector_languages = set(LanguageDetector.SUPPORTED_LANGUAGES)
+
+    assert plugin_languages == detector_languages == loader_languages
+
+
 def test_every_plugin_class_inherits_language_plugin() -> None:
     """All XxxPlugin classes must inherit from LanguagePlugin (not ElementExtractor)."""
 

--- a/tests/unit/cli/test_info_commands.py
+++ b/tests/unit/cli/test_info_commands.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Tests for cli/info_commands.py"""
 
+import importlib.util
 from argparse import Namespace
 from unittest.mock import patch
 
@@ -13,6 +14,7 @@ from tree_sitter_analyzer.cli.info_commands import (
     ShowExtensionsCommand,
     ShowLanguagesCommand,
 )
+from tree_sitter_analyzer.language_loader import grammar_install_hint
 
 
 @pytest.fixture
@@ -505,9 +507,6 @@ class TestR37aeRemainingInfoCommandsJsonEnvelope:
         lua_entries = [
             entry for entry in captured["languages"] if entry["language"] == "lua"
         ]
-        import importlib.util
-        from tree_sitter_analyzer.language_loader import grammar_install_hint
-
         lua_installed = importlib.util.find_spec("tree_sitter_lua") is not None
         expected_lua = {
             "language": "lua",
@@ -538,8 +537,6 @@ class TestR37aeRemainingInfoCommandsJsonEnvelope:
         assert captured.get("extension_count") == len(captured["extensions"])
 
     def test_show_supported_languages_uses_canonical_lua_install_hint(self):
-        from tree_sitter_analyzer.language_loader import grammar_install_hint
-
         args = Namespace(output_format="json", format="json")
         captured: dict = {}
         with (

--- a/tests/unit/cli/test_info_commands.py
+++ b/tests/unit/cli/test_info_commands.py
@@ -506,6 +506,7 @@ class TestR37aeRemainingInfoCommandsJsonEnvelope:
             entry for entry in captured["languages"] if entry["language"] == "lua"
         ]
         import importlib.util
+        from tree_sitter_analyzer.language_loader import grammar_install_hint
 
         lua_installed = importlib.util.find_spec("tree_sitter_lua") is not None
         expected_lua = {
@@ -514,9 +515,7 @@ class TestR37aeRemainingInfoCommandsJsonEnvelope:
             "installed": lua_installed,
         }
         if not lua_installed:
-            expected_lua["install_hint"] = (
-                'Lua grammar not installed — pip install "tree-sitter-analyzer[lua]"'
-            )
+            expected_lua["install_hint"] = grammar_install_hint("lua")
         assert lua_entries == [expected_lua]
 
     def test_show_supported_extensions_json_envelope(self):
@@ -537,6 +536,36 @@ class TestR37aeRemainingInfoCommandsJsonEnvelope:
         assert captured.get("verdict") == "INFO"
         assert isinstance(captured.get("extensions"), list)
         assert captured.get("extension_count") == len(captured["extensions"])
+
+    def test_show_supported_languages_uses_canonical_lua_install_hint(self):
+        from tree_sitter_analyzer.language_loader import grammar_install_hint
+
+        args = Namespace(output_format="json", format="json")
+        captured: dict = {}
+        with (
+            patch(
+                "tree_sitter_analyzer.cli.info_commands.importlib.util.find_spec",
+                return_value=None,
+            ),
+            patch(
+                "tree_sitter_analyzer.cli.info_commands.output_json",
+                side_effect=lambda data: captured.update(data),
+            ),
+        ):
+            rc = ShowLanguagesCommand(args).execute()
+
+        lua_entries = [
+            entry for entry in captured["languages"] if entry["language"] == "lua"
+        ]
+        assert rc == 0
+        assert lua_entries == [
+            {
+                "language": "lua",
+                "extensions": [".lua"],
+                "installed": False,
+                "install_hint": grammar_install_hint("lua"),
+            }
+        ]
 
     def test_show_languages_text_path_preserved(self):
         """Text default must still go through output_list (backward compat)."""

--- a/tests/unit/cli/test_info_commands.py
+++ b/tests/unit/cli/test_info_commands.py
@@ -211,7 +211,6 @@ class TestQ3SupportedExtensionsParity:
             # extensions are wired end-to-end (see
             # test_bash_language_wiring.py / test_scala_language_wiring.py
             # + test_core_extensions_still_advertised).
-            ".lua",
             ".hs",
             ".dart",
             ".elm",
@@ -260,6 +259,7 @@ class TestQ3SupportedExtensionsParity:
             ".bash",
             ".zsh",
             ".scala",
+            ".lua",
             ".html",
             ".css",
             ".json",
@@ -495,12 +495,29 @@ class TestR37aeRemainingInfoCommandsJsonEnvelope:
         assert captured.get("success") is True
         assert captured.get("verdict") == "INFO"
         assert isinstance(captured.get("languages"), list)
-        assert captured.get("language_count") == 21
+        assert captured.get("language_count") == 22
         # Each language entry must have the documented shape.
         sample = captured["languages"][0]
         assert "language" in sample
         assert "extensions" in sample
         assert isinstance(sample["extensions"], list)
+
+        lua_entries = [
+            entry for entry in captured["languages"] if entry["language"] == "lua"
+        ]
+        import importlib.util
+
+        lua_installed = importlib.util.find_spec("tree_sitter_lua") is not None
+        expected_lua = {
+            "language": "lua",
+            "extensions": [".lua"],
+            "installed": lua_installed,
+        }
+        if not lua_installed:
+            expected_lua["install_hint"] = (
+                'Lua grammar not installed — pip install "tree-sitter-analyzer[lua]"'
+            )
+        assert lua_entries == [expected_lua]
 
     def test_show_supported_extensions_json_envelope(self):
         from argparse import Namespace
@@ -536,5 +553,5 @@ class TestR37aeRemainingInfoCommandsJsonEnvelope:
             rc = cmd.execute()
         assert rc == 0
         assert mock_json.call_count == 0
-        # One header line + one line per supported language (21)
-        assert mock_list.call_count == 22
+        # One header line + one line per supported language (22)
+        assert mock_list.call_count == 23

--- a/tests/unit/core/test_grammar_install_hints.py
+++ b/tests/unit/core/test_grammar_install_hints.py
@@ -61,6 +61,11 @@ class TestGrammarInstallHint:
         assert hint is not None
         assert "pip install" in hint
 
+    def test_lua_hint_uses_canonical_acronym_and_extra(self):
+        assert grammar_install_hint("lua") == (
+            'LUA grammar not installed — pip install "tree-sitter-analyzer[lua]"'
+        )
+
     def test_all_loader_languages_have_a_hint(self):
         """Every language in LANGUAGE_MODULES must have a hint (extras or package)."""
         loader = LanguageLoader()

--- a/tests/unit/core/test_language_loader_comprehensive.py
+++ b/tests/unit/core/test_language_loader_comprehensive.py
@@ -17,7 +17,7 @@ from tree_sitter_analyzer.language_loader import (
     loader,
 )
 
-EXPECTED_LANGUAGE_MODULE_COUNT = 24
+EXPECTED_LANGUAGE_MODULE_COUNT = 25
 
 
 class TestLanguageLoaderInitialization:

--- a/tests/unit/core/test_parser.py
+++ b/tests/unit/core/test_parser.py
@@ -201,13 +201,14 @@ class TestParserLanguageSupport:
         """Test getting list of supported languages."""
         languages = parser.get_supported_languages()
         assert isinstance(languages, list)
-        # 24 in CI (full grammar set). 23 locally when optional wheels such as
-        # tree-sitter-swift are absent. Acceptable range: [23, 24].
-        # A grammar add/remove outside this range should trip this test.
+        # 25 with both optional Swift and Lua grammars installed; otherwise the
+        # expectation subtracts each missing wheel exactly so a legitimate
+        # minimal install stays green and registry drift still trips the test.
         import importlib.util
 
         swift_available = importlib.util.find_spec("tree_sitter_swift") is not None
-        expected = 24 if swift_available else 23
+        lua_available = importlib.util.find_spec("tree_sitter_lua") is not None
+        expected = 23 + int(swift_available) + int(lua_available)
         assert len(languages) == expected, (
             f"expected {expected}, got {len(languages)}: {languages}"
         )

--- a/tests/unit/languages/test_lua_plugin.py
+++ b/tests/unit/languages/test_lua_plugin.py
@@ -30,6 +30,86 @@ def _tslua_available() -> bool:
         return False
 
 
+def test_lua_loader_mapping_targets_installed_grammar() -> None:
+    """The public loader must wire Lua to its declared parser package."""
+    from tree_sitter_analyzer.language_loader import LanguageLoader
+
+    assert LanguageLoader.LANGUAGE_MODULES["lua"] == "tree_sitter_lua"
+
+
+@pytest.mark.skipif(
+    not _tslua_available(),
+    reason="tree_sitter_lua not installed; tracked: optional-dep skip",
+)
+def test_lua_loader_parses_minimal_chunk_without_errors() -> None:
+    """Loader-backed parsing must work before Lua is advertised as supported."""
+    from tree_sitter_analyzer.language_loader import LanguageLoader
+
+    parser = LanguageLoader().create_parser_safely("lua")
+    assert parser is not None
+    tree = parser.parse(b'local module = require("sample")')
+    assert tree.root_node.type == "chunk"
+    assert tree.root_node.has_error is False
+
+
+@pytest.mark.skipif(
+    not _tslua_available(),
+    reason="tree_sitter_lua not installed; tracked: optional-dep skip",
+)
+def test_lua_project_index_persists_exact_function_snapshot(tmp_path) -> None:
+    """A real project index must persist Lua's currently supported surface."""
+    from tree_sitter_analyzer.ast_cache import ASTCache
+
+    source = tmp_path / "main.lua"
+    source.write_text(
+        'local json = require("json")\n'
+        'function greet(name) return name end\n'
+        'greet("world")\n',
+        encoding="utf-8",
+    )
+    cache = ASTCache(str(tmp_path))
+    try:
+        cache.index_project()
+        conn = cache.get_conn()
+        indexed_files = [
+            tuple(row)
+            for row in conn.execute(
+                "SELECT file_path, language FROM ast_index ORDER BY file_path"
+            )
+        ]
+        symbols = [
+            tuple(row)
+            for row in conn.execute(
+                "SELECT name, kind, file_path, language, line, end_line "
+                "FROM ast_symbol_rows ORDER BY name"
+            )
+        ]
+        imports = [
+            tuple(row)
+            for row in conn.execute(
+                "SELECT module_path, file_path, language FROM ast_imports "
+                "ORDER BY module_path"
+            )
+        ]
+        calls = [
+            tuple(row)
+            for row in conn.execute(
+                "SELECT callee_name, callee_resolution, callee_resolved_file "
+                "FROM edges WHERE kind = 'calls' AND language = 'lua' "
+                "ORDER BY callee_name"
+            )
+        ]
+        assert indexed_files == [("main.lua", "lua")]
+        assert symbols == [("greet", "function", "main.lua", "lua", 2, 2)]
+        assert imports == []
+        assert calls == [
+            ("greet", "unknown", ""),
+            ("require", "unknown", ""),
+        ]
+    finally:
+        cache.close()
+
+
 # ---------------------------------------------------------------------------
 # Test 1: graceful degradation (always runs, no real Lua grammar needed)
 # ---------------------------------------------------------------------------

--- a/tree_sitter_analyzer/language_detector.py
+++ b/tree_sitter_analyzer/language_detector.py
@@ -141,6 +141,7 @@ class LanguageDetector:
         "swift",
         "bash",
         "scala",
+        "lua",
         "markdown",
         "html",
         "css",

--- a/tree_sitter_analyzer/language_loader.py
+++ b/tree_sitter_analyzer/language_loader.py
@@ -70,6 +70,7 @@ class LanguageLoader:
         "swift": "tree_sitter_swift",
         "bash": "tree_sitter_bash",
         "scala": "tree_sitter_scala",
+        "lua": "tree_sitter_lua",
     }
 
     # TypeScript特別処理（TypeScriptとTSX）
@@ -359,6 +360,7 @@ _GRAMMAR_EXTRAS: dict[str, str] = {
     "swift": "swift",
     "bash": "bash",
     "scala": "scala",
+    "lua": "lua",
 }
 
 

--- a/tree_sitter_analyzer/languages/lua_plugin/plugin.py
+++ b/tree_sitter_analyzer/languages/lua_plugin/plugin.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python3
-"""Lua Language Plugin (RFC-0010 production plugin).
+"""Lua plugin with an RFC-0010 resolver slot.
 
-Demonstrates the new-language contract: adding Lua required only:
+Lua's plugin and resolver remain self-contained, while advertising it through
+the legacy CLI/parser discovery surfaces also requires central registry entries:
   1. This plugin package (``languages/lua_plugin/``)
   2. A resolver in ``synapse_resolver/languages/lua.py`` (moat slot)
   3. An entry-point in ``pyproject.toml``
   4. An optional dep ``tree-sitter-lua``
+  5. Loader/detector mappings until those legacy registries become dynamic
 
-No changes to any central file were needed. Capability methods default
-to ``frozenset()`` / ``None`` so the plugin uses the Phase 2
+Capability methods default to ``frozenset()`` / ``None`` so the plugin uses the Phase 2
 plugin-dispatch paths in the central files without any central
 ``if-language==`` branch for "lua".
 
@@ -30,7 +31,7 @@ from .extractor import LuaElementExtractor
 
 
 class LuaPlugin(LanguagePlugin):
-    """Lua language plugin — extensibility demo, no central file changes needed."""
+    """Lua plugin with partial function/import extraction."""
 
     def get_language_name(self) -> str:
         return "lua"


### PR DESCRIPTION
## Summary
- wire Lua into the canonical detector and grammar loader registries
- advertise Lua as partial function-symbol indexing instead of a scaffold
- consolidate Lua tests under the language test suite and pin the current index boundary

## Capability boundary
- function symbols are persisted by project indexing
- raw `require` and function calls are retained with `callee_resolution=unknown`
- indexed imports and resolved Lua calls remain intentionally pending

## Verification
- generated change-impact command: 2552 passed, 58 skipped
- default suite: 1245 passed, 8 skipped in 74.75s
- focused coverage: 146 passed
- patch coverage: no added executable misses
- supported-language and supported-extension CLI smoke checks include Lua
- codemap sync check passed