### PR TITLE
feat: add benchmark integrity foundation

### DIFF
--- a/benchmarks/codegraph_compare/_integrity_gate.py
+++ b/benchmarks/codegraph_compare/_integrity_gate.py
@@ -23,6 +23,8 @@ from benchmarks.codegraph_compare.schemas import (
     RunRecordV1,
 )
 
+_PUBLISHABLE_REGISTRY_STATUSES = frozenset({"PLANNED"})
+
 
 def _identity(record: RunRecordV1 | EvalRecordV1) -> tuple[str, str, str, int]:
     value = record.identity
@@ -217,7 +219,9 @@ def _registry_binding_violation(
         return IntegrityViolation(
             code="REGISTRY_MANIFEST_MISMATCH", experiment_id=manifest.experiment_id
         )
-    if any(item.status in {"BLOCKED", "INVALID"} for item in current_events):
+    if any(
+        item.status not in _PUBLISHABLE_REGISTRY_STATUSES for item in current_events
+    ):
         return IntegrityViolation(
             code="REGISTRY_TERMINAL_FAILURE", experiment_id=manifest.experiment_id
         )
@@ -487,6 +491,16 @@ def validate_experiment(
     eval_items = tuple(evals)
     cells = {cell.run_id: cell for cell in manifest.expected_cells}
     violations = _validate_manifest(manifest)
+    if violations:
+        registered_ids = tuple(sorted({item.experiment_id for item in registry_items}))
+        return _build_verdict(
+            manifest,
+            violations=violations,
+            canonical=[],
+            run_items=run_items,
+            cells=cells,
+            registered_ids=registered_ids,
+        )
     registry_violations, registered_ids = _validate_registry(
         manifest, registry_items, reported_experiment_ids
     )

--- a/benchmarks/codegraph_compare/_integrity_gate.py
+++ b/benchmarks/codegraph_compare/_integrity_gate.py
@@ -1,0 +1,509 @@
+"""Focused validation engine for RFC-0021 benchmark integrity."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Iterable
+from typing import cast
+
+from benchmarks.codegraph_compare.integrity import (
+    ExpectedCellV1,
+    ExperimentManifestV1,
+    IntegrityVerdict,
+    IntegrityViolation,
+    RegistryEvent,
+    _manifest_payload,
+    _sha256,
+    create_manifest,
+)
+from benchmarks.codegraph_compare.schemas import (
+    BenchmarkStatus,
+    EvalRecordV1,
+    IndexStatsV1,
+    RunRecordV1,
+)
+
+
+def _identity(record: RunRecordV1 | EvalRecordV1) -> tuple[str, str, str, int]:
+    value = record.identity
+    return value.experiment_id, value.session_id, value.run_id, value.attempt_no
+
+
+def _cell_matches(record: RunRecordV1, cell: ExpectedCellV1) -> bool:
+    return (
+        record.repo == cell.repo
+        and record.question_id == cell.question_id
+        and record.arm == cell.arm
+        and record.repeat == cell.repeat
+        and record.agent_backend == cell.agent_backend
+        and record.run_id == cell.run_id
+    )
+
+
+def _base_provenance_matches(
+    record: RunRecordV1, manifest: ExperimentManifestV1
+) -> bool:
+    return (
+        record.config_hash == manifest.config_hash
+        and record.question_hash == manifest.question_hash
+        and record.oracle_hash == manifest.oracle_hash
+        and record.model == manifest.model
+        and record.agent_backend == manifest.agent_backend
+        and record.benchmark_git_sha == manifest.benchmark_git_sha
+        and record.agent_cli_fingerprint == manifest.agent_cli_fingerprint
+        and record.platform == manifest.platform
+        and record.environment_fingerprint == manifest.environment_fingerprint
+        and record.repo_commit == dict(manifest.repo_commits).get(record.repo)
+        and record.tool_fingerprint == dict(manifest.tool_fingerprints).get(record.arm)
+    )
+
+
+def _index_partition_is_exact(
+    stats: IndexStatsV1,
+    manifest: ExperimentManifestV1,
+    repo: str,
+) -> bool:
+    eligible_paths = set(dict(manifest.eligible_paths)[repo])
+    indexed_paths = set(stats.indexed_paths)
+    excluded_paths = set(stats.excluded_paths)
+    parse_error_paths = set(stats.parse_error_paths)
+    path_sets = (indexed_paths, excluded_paths, parse_error_paths)
+    partition_is_exact = (
+        not (indexed_paths & excluded_paths)
+        and not (indexed_paths & parse_error_paths)
+        and not (excluded_paths & parse_error_paths)
+        and set().union(*path_sets) == eligible_paths
+    )
+    hashes_match = (
+        stats.indexed_paths_hash == _sha256(list(stats.indexed_paths))
+        and stats.excluded_paths_hash == _sha256(list(stats.excluded_paths))
+        and stats.parse_error_paths_hash == _sha256(list(stats.parse_error_paths))
+    )
+    counts_match = (
+        stats.eligible_source_files == len(eligible_paths)
+        and stats.indexed_source_files == len(indexed_paths)
+        and stats.excluded_source_files == len(excluded_paths)
+        and stats.parse_error_files == len(parse_error_paths)
+    )
+    allowed_errors = set(dict(manifest.parse_error_allowlists)[repo])
+    return (
+        partition_is_exact
+        and hashes_match
+        and counts_match
+        and parse_error_paths == allowed_errors
+    )
+
+
+def _index_stats_violation(
+    record: RunRecordV1, manifest: ExperimentManifestV1
+) -> str | None:
+    indexed = record.arm in manifest.indexed_arms
+    if not indexed:
+        return "UNEXPECTED_INDEX_STATS" if record.index_stats is not None else None
+    if record.status is BenchmarkStatus.NOT_EVALUATED:
+        return None
+    stats = record.index_stats
+    if stats is None:
+        return "INDEX_NOT_READY"
+    if (
+        stats.repo_fingerprint != dict(manifest.repo_fingerprints).get(record.repo)
+        or stats.tool_fingerprint != record.tool_fingerprint
+        or stats.eligible_paths_hash
+        != dict(manifest.eligible_paths_hashes).get(record.repo)
+    ):
+        return "MIXED_INDEX_PROVENANCE"
+    required_oracles = set(dict(manifest.required_readiness_oracles)[record.arm])
+    if (
+        stats.eligible_source_files <= 0
+        or stats.indexed_source_files <= 0
+        or not _index_partition_is_exact(stats, manifest, record.repo)
+        or not required_oracles <= set(stats.readiness_oracles)
+    ):
+        return "INDEX_NOT_READY"
+    return None
+
+
+def _provenance_violation(
+    record: RunRecordV1, manifest: ExperimentManifestV1
+) -> str | None:
+    if not _base_provenance_matches(record, manifest):
+        return "MIXED_PROVENANCE"
+    return _index_stats_violation(record, manifest)
+
+
+def _validate_manifest(manifest: ExperimentManifestV1) -> list[IntegrityViolation]:
+    violations: list[IntegrityViolation] = []
+    recomputed_hash = _sha256(_manifest_payload(manifest))
+    if (
+        type(manifest.benchmark_version) is not int
+        or manifest.benchmark_version != 1
+        or manifest.manifest_hash != recomputed_hash
+        or manifest.experiment_id != f"sha256:{recomputed_hash}"
+    ):
+        violations.append(IntegrityViolation(code="INVALID_MANIFEST_HASH"))
+    try:
+        normalized = create_manifest(
+            benchmark_git_sha=manifest.benchmark_git_sha,
+            config_hash=manifest.config_hash,
+            question_hash=manifest.question_hash,
+            oracle_hash=manifest.oracle_hash,
+            seed=manifest.seed,
+            timeout_seconds=manifest.timeout_seconds,
+            schedule_hash=manifest.schedule_hash,
+            agent_backend=manifest.agent_backend,
+            model=manifest.model,
+            agent_cli_fingerprint=manifest.agent_cli_fingerprint,
+            platform=manifest.platform,
+            environment_fingerprint=manifest.environment_fingerprint,
+            primary_session_id=manifest.primary_session_id,
+            retry_session_ids=manifest.retry_session_ids,
+            expected_cells=manifest.expected_cells,
+            required_arms=manifest.required_arms,
+            indexed_arms=manifest.indexed_arms,
+            tool_fingerprints=dict(manifest.tool_fingerprints),
+            repo_commits=dict(manifest.repo_commits),
+            repo_fingerprints=dict(manifest.repo_fingerprints),
+            eligible_paths=dict(manifest.eligible_paths),
+            eligible_paths_hashes=dict(manifest.eligible_paths_hashes),
+            parse_error_allowlists=dict(manifest.parse_error_allowlists),
+            required_readiness_oracles=dict(manifest.required_readiness_oracles),
+        )
+        if normalized != manifest:
+            violations.append(IntegrityViolation(code="INVALID_MANIFEST_STRUCTURE"))
+    except ValueError:
+        violations.append(IntegrityViolation(code="INVALID_MANIFEST_STRUCTURE"))
+    return violations
+
+
+def _validate_registry(
+    manifest: ExperimentManifestV1,
+    registry_items: tuple[RegistryEvent, ...],
+    reported_experiment_ids: tuple[str, ...],
+) -> tuple[list[IntegrityViolation], tuple[str, ...]]:
+    violations: list[IntegrityViolation] = []
+    registered_ids = tuple(sorted({item.experiment_id for item in registry_items}))
+    current_events = tuple(
+        item for item in registry_items if item.experiment_id == manifest.experiment_id
+    )
+    binding_violation = _registry_binding_violation(manifest, current_events)
+    if binding_violation is not None:
+        violations.append(binding_violation)
+    hidden_ids = (
+        experiment_id
+        for experiment_id in registered_ids
+        if experiment_id not in reported_experiment_ids
+    )
+    violations.extend(
+        IntegrityViolation(code="HIDDEN_EXPERIMENT", experiment_id=experiment_id)
+        for experiment_id in hidden_ids
+    )
+    unregistered_reported = (
+        set(reported_experiment_ids) - set(registered_ids) - {manifest.experiment_id}
+    )
+    if unregistered_reported:
+        violations.append(IntegrityViolation(code="UNREGISTERED_REPORTED_EXPERIMENT"))
+    return violations, registered_ids
+
+
+def _registry_binding_violation(
+    manifest: ExperimentManifestV1,
+    current_events: tuple[RegistryEvent, ...],
+) -> IntegrityViolation | None:
+    if not current_events:
+        return IntegrityViolation(
+            code="UNREGISTERED_EXPERIMENT", experiment_id=manifest.experiment_id
+        )
+    if any(item.manifest_hash != manifest.manifest_hash for item in current_events):
+        return IntegrityViolation(
+            code="REGISTRY_MANIFEST_MISMATCH", experiment_id=manifest.experiment_id
+        )
+    if any(item.status in {"BLOCKED", "INVALID"} for item in current_events):
+        return IntegrityViolation(
+            code="REGISTRY_TERMINAL_FAILURE", experiment_id=manifest.experiment_id
+        )
+    return None
+
+
+def _collect_attempts(
+    manifest: ExperimentManifestV1,
+    run_items: tuple[RunRecordV1, ...],
+    cells: dict[str, ExpectedCellV1],
+) -> tuple[list[IntegrityViolation], dict[str, list[RunRecordV1]]]:
+    violations: list[IntegrityViolation] = []
+    allowed_sessions = {manifest.primary_session_id, *manifest.retry_session_ids}
+    attempts_by_run: dict[str, list[RunRecordV1]] = {}
+    seen: set[tuple[str, str, str, int]] = set()
+    for record in run_items:
+        identity = _identity(record)
+        if identity in seen:
+            violations.append(
+                IntegrityViolation(code="DUPLICATE_ATTEMPT", identity=identity)
+            )
+            continue
+        seen.add(identity)
+        if record.experiment_id != manifest.experiment_id:
+            violations.append(
+                IntegrityViolation(code="MIXED_EXPERIMENT", identity=identity)
+            )
+            continue
+        cell = cells.get(record.run_id)
+        if cell is None:
+            violations.append(
+                IntegrityViolation(code="UNEXPECTED_RUN_CELL", identity=identity)
+            )
+            continue
+        if record.session_id not in allowed_sessions:
+            violations.append(
+                IntegrityViolation(code="UNLINKED_SESSION", identity=identity)
+            )
+            continue
+        if not _cell_matches(record, cell):
+            violations.append(
+                IntegrityViolation(code="CELL_PROVENANCE_MISMATCH", identity=identity)
+            )
+            attempts_by_run.setdefault(record.run_id, []).append(record)
+            continue
+        provenance_code = _provenance_violation(record, manifest)
+        if provenance_code is not None:
+            violations.append(
+                IntegrityViolation(code=provenance_code, identity=identity)
+            )
+        attempts_by_run.setdefault(record.run_id, []).append(record)
+    return violations, attempts_by_run
+
+
+RetryBlock = tuple[tuple[str, str, int, str], str, str]
+
+
+def _find_primary_attempt(
+    manifest: ExperimentManifestV1,
+    cell: ExpectedCellV1,
+    candidates: list[RunRecordV1],
+) -> tuple[RunRecordV1 | None, IntegrityViolation | None]:
+    primaries = [
+        item
+        for item in candidates
+        if item.session_id == manifest.primary_session_id
+        and item.attempt_no == 0
+        and item.retry_of is None
+    ]
+    if len(primaries) == 1:
+        return primaries[0], None
+    code = "MISSING_RUN_CELL" if not primaries else "DUPLICATE_PRIMARY"
+    identity = (
+        manifest.experiment_id,
+        manifest.primary_session_id,
+        cell.run_id,
+        0,
+    )
+    return None, IntegrityViolation(code=code, identity=identity)
+
+
+def _select_cell_attempt(
+    manifest: ExperimentManifestV1,
+    cell: ExpectedCellV1,
+    candidates: list[RunRecordV1],
+) -> tuple[RunRecordV1 | None, list[IntegrityViolation], RetryBlock | None]:
+    violations: list[IntegrityViolation] = []
+    primary, primary_violation = _find_primary_attempt(manifest, cell, candidates)
+    if primary is None:
+        return None, [cast(IntegrityViolation, primary_violation)], None
+    retry_candidates = [item for item in candidates if item is not primary]
+    if not retry_candidates:
+        return primary, violations, None
+    if primary.status is not BenchmarkStatus.INFRA_FAILURE:
+        return (
+            primary,
+            [
+                IntegrityViolation(
+                    code="ILLEGAL_RETRY_STATUS", identity=_identity(primary)
+                )
+            ],
+            None,
+        )
+    if len(retry_candidates) != 1:
+        return (
+            primary,
+            [IntegrityViolation(code="MULTIPLE_RETRIES", identity=_identity(primary))],
+            None,
+        )
+    retry = retry_candidates[0]
+    valid_lineage = (
+        retry.session_id in manifest.retry_session_ids
+        and retry.attempt_no == 1
+        and retry.retry_of == primary.identity
+    )
+    if not valid_lineage:
+        return (
+            primary,
+            [
+                IntegrityViolation(
+                    code="INVALID_RETRY_LINEAGE", identity=_identity(retry)
+                )
+            ],
+            None,
+        )
+    block = (cell.repo, cell.question_id, cell.repeat, cell.agent_backend)
+    return retry, violations, (block, retry.session_id, cell.arm)
+
+
+def _select_canonical_attempts(
+    manifest: ExperimentManifestV1,
+    attempts_by_run: dict[str, list[RunRecordV1]],
+) -> tuple[
+    list[IntegrityViolation],
+    list[RunRecordV1],
+    dict[tuple[str, str, int, str], dict[str, set[str]]],
+]:
+    violations: list[IntegrityViolation] = []
+    canonical: list[RunRecordV1] = []
+    retried_blocks: dict[tuple[str, str, int, str], dict[str, set[str]]] = {}
+    for cell in manifest.expected_cells:
+        selected, cell_violations, retry_block = _select_cell_attempt(
+            manifest, cell, attempts_by_run.get(cell.run_id, [])
+        )
+        violations.extend(cell_violations)
+        if selected is not None:
+            canonical.append(selected)
+        if retry_block is not None:
+            block, session_id, arm = retry_block
+            retried_blocks.setdefault(block, {}).setdefault(session_id, set()).add(arm)
+    return violations, canonical, retried_blocks
+
+
+def _validate_retry_blocks(
+    manifest: ExperimentManifestV1,
+    retried_blocks: dict[tuple[str, str, int, str], dict[str, set[str]]],
+) -> list[IntegrityViolation]:
+    violations: list[IntegrityViolation] = []
+    for block, sessions in retried_blocks.items():
+        expected_arms = {
+            cell.arm
+            for cell in manifest.expected_cells
+            if (cell.repo, cell.question_id, cell.repeat, cell.agent_backend) == block
+        }
+        if len(sessions) != 1:
+            violations.append(IntegrityViolation(code="MIXED_RETRY_SESSION"))
+        elif next(iter(sessions.values())) != expected_arms:
+            violations.append(IntegrityViolation(code="UNPAIRED_RETRY"))
+    return violations
+
+
+def _validate_evaluations(
+    manifest: ExperimentManifestV1,
+    eval_items: tuple[EvalRecordV1, ...],
+    canonical: list[RunRecordV1],
+) -> list[IntegrityViolation]:
+    violations: list[IntegrityViolation] = []
+    canonical_ids = {_identity(item) for item in canonical}
+    eval_counts = Counter(_identity(item) for item in eval_items)
+    for identity, count in eval_counts.items():
+        if count > 1:
+            violations.append(
+                IntegrityViolation(code="DUPLICATE_EVAL", identity=identity)
+            )
+        if identity[0] != manifest.experiment_id:
+            violations.append(
+                IntegrityViolation(code="MIXED_EVAL_EXPERIMENT", identity=identity)
+            )
+        elif identity not in canonical_ids:
+            violations.append(IntegrityViolation(code="EXTRA_EVAL", identity=identity))
+    for selected in canonical:
+        identity = _identity(selected)
+        if selected.status is BenchmarkStatus.SUCCESS and eval_counts[identity] == 0:
+            violations.append(
+                IntegrityViolation(code="MISSING_EVAL_CELL", identity=identity)
+            )
+        if selected.status is BenchmarkStatus.NOT_EVALUATED:
+            violations.append(
+                IntegrityViolation(
+                    code="REQUIRED_ARM_NOT_EVALUATED",
+                    identity=identity,
+                    arm=selected.arm,
+                    reason=selected.blocker_reason,
+                )
+            )
+        elif selected.status is not BenchmarkStatus.SUCCESS:
+            violations.append(
+                IntegrityViolation(
+                    code="REQUIRED_CELL_FAILED",
+                    identity=identity,
+                    arm=selected.arm,
+                    reason=selected.status.value,
+                )
+            )
+        if selected.status is not BenchmarkStatus.SUCCESS and eval_counts[identity]:
+            violations.append(
+                IntegrityViolation(code="UNEXPECTED_EVAL_FOR_STATUS", identity=identity)
+            )
+    return violations
+
+
+def _build_verdict(
+    manifest: ExperimentManifestV1,
+    *,
+    violations: list[IntegrityViolation],
+    canonical: list[RunRecordV1],
+    run_items: tuple[RunRecordV1, ...],
+    cells: dict[str, ExpectedCellV1],
+    registered_ids: tuple[str, ...],
+) -> IntegrityVerdict:
+    only_not_evaluated = bool(violations) and all(
+        item.code == "REQUIRED_ARM_NOT_EVALUATED" for item in violations
+    )
+    claim_level = (
+        "NOT_EVALUATED" if only_not_evaluated else ("INVALID" if violations else "E1")
+    )
+    return IntegrityVerdict(
+        publishable=not violations,
+        claim_level=claim_level,
+        violations=tuple(violations),
+        canonical_attempts=tuple(canonical),
+        reliability_attempts=tuple(
+            item
+            for item in run_items
+            if item.experiment_id == manifest.experiment_id and item.run_id in cells
+        ),
+        disclosed_attempts=run_items,
+        expected_cell_count=len(manifest.expected_cells),
+        observed_cell_count=len(canonical),
+        dominance_allowed=False,
+        winner=None,
+        disclosed_experiment_ids=registered_ids,
+    )
+
+
+def validate_experiment(
+    manifest: ExperimentManifestV1,
+    *,
+    registry: Iterable[RegistryEvent],
+    runs: Iterable[RunRecordV1],
+    evals: Iterable[EvalRecordV1],
+    reported_experiment_ids: tuple[str, ...],
+) -> IntegrityVerdict:
+    """Validate registry, exact cells, provenance, lineage, and evaluations."""
+    registry_items = tuple(registry)
+    run_items = tuple(runs)
+    eval_items = tuple(evals)
+    cells = {cell.run_id: cell for cell in manifest.expected_cells}
+    violations = _validate_manifest(manifest)
+    registry_violations, registered_ids = _validate_registry(
+        manifest, registry_items, reported_experiment_ids
+    )
+    violations.extend(registry_violations)
+    attempt_violations, attempts_by_run = _collect_attempts(manifest, run_items, cells)
+    violations.extend(attempt_violations)
+    selection_violations, canonical, retried_blocks = _select_canonical_attempts(
+        manifest, attempts_by_run
+    )
+    violations.extend(selection_violations)
+    violations.extend(_validate_retry_blocks(manifest, retried_blocks))
+    violations.extend(_validate_evaluations(manifest, eval_items, canonical))
+    return _build_verdict(
+        manifest,
+        violations=violations,
+        canonical=canonical,
+        run_items=run_items,
+        cells=cells,
+        registered_ids=registered_ids,
+    )

--- a/benchmarks/codegraph_compare/integrity.py
+++ b/benchmarks/codegraph_compare/integrity.py
@@ -1,0 +1,409 @@
+"""Fail-closed experiment integrity primitives for RFC-0021 Slice A1."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable
+from dataclasses import asdict, dataclass, fields
+from pathlib import Path
+from typing import Any
+
+from benchmarks.codegraph_compare.schemas import (
+    EvalRecordV1,
+    RunRecordV1,
+)
+
+
+@dataclass(frozen=True)
+class ExpectedCellV1:
+    """Exact logical cell declared before an experiment starts."""
+
+    repo: str
+    question_id: str
+    arm: str
+    repeat: int
+    agent_backend: str
+    run_id: str
+
+    def __post_init__(self) -> None:
+        expected = (
+            f"{self.question_id}__{self.arm}__{self.agent_backend}__{self.repeat:02d}"
+        )
+        if self.run_id != expected:
+            raise ValueError(f"run_id must equal {expected}")
+        if not all((self.repo, self.question_id, self.arm, self.agent_backend)):
+            raise ValueError("Expected cell fields must be non-empty")
+        if self.repeat < 0:
+            raise ValueError("Expected cell repeat must be non-negative")
+
+
+@dataclass(frozen=True)
+class ExperimentManifestV1:
+    """Immutable inputs that define one logical experiment."""
+
+    benchmark_version: int
+    experiment_id: str
+    manifest_hash: str
+    benchmark_git_sha: str
+    config_hash: str
+    question_hash: str
+    oracle_hash: str
+    seed: int
+    timeout_seconds: int
+    schedule_hash: str
+    agent_backend: str
+    model: str
+    agent_cli_fingerprint: str
+    platform: str
+    environment_fingerprint: str
+    primary_session_id: str
+    retry_session_ids: tuple[str, ...]
+    expected_cells: tuple[ExpectedCellV1, ...]
+    required_arms: tuple[str, ...]
+    indexed_arms: tuple[str, ...]
+    tool_fingerprints: tuple[tuple[str, str], ...]
+    repo_commits: tuple[tuple[str, str], ...]
+    repo_fingerprints: tuple[tuple[str, str], ...]
+    eligible_paths: tuple[tuple[str, tuple[str, ...]], ...]
+    eligible_paths_hashes: tuple[tuple[str, str], ...]
+    parse_error_allowlists: tuple[tuple[str, tuple[str, ...]], ...]
+    required_readiness_oracles: tuple[tuple[str, tuple[str, ...]], ...]
+
+
+@dataclass(frozen=True)
+class RegistryEvent:
+    """One append-only experiment lifecycle event."""
+
+    experiment_id: str
+    manifest_hash: str
+    status: str
+    outcome: str
+
+
+@dataclass(frozen=True)
+class IntegrityViolation:
+    """Machine-readable reason an experiment cannot be published."""
+
+    code: str
+    identity: tuple[str, str, str, int] | None = None
+    experiment_id: str | None = None
+    arm: str | None = None
+    reason: str | None = None
+
+
+@dataclass(frozen=True)
+class IntegrityVerdict:
+    """Complete decision surface for the experiment integrity gate."""
+
+    publishable: bool
+    claim_level: str
+    violations: tuple[IntegrityViolation, ...]
+    canonical_attempts: tuple[RunRecordV1, ...]
+    reliability_attempts: tuple[RunRecordV1, ...]
+    disclosed_attempts: tuple[RunRecordV1, ...]
+    expected_cell_count: int
+    observed_cell_count: int
+    dominance_allowed: bool
+    winner: str | None
+    disclosed_experiment_ids: tuple[str, ...]
+
+
+def _canonical_json_bytes(payload: Any) -> bytes:
+    return json.dumps(
+        payload, ensure_ascii=True, separators=(",", ":"), sort_keys=True
+    ).encode("utf-8")
+
+
+def _sha256(payload: Any) -> str:
+    return hashlib.sha256(_canonical_json_bytes(payload)).hexdigest()
+
+
+def _manifest_payload(manifest: ExperimentManifestV1) -> dict[str, Any]:
+    return {
+        "benchmark_version": 1,
+        "benchmark_git_sha": manifest.benchmark_git_sha,
+        "config_hash": manifest.config_hash,
+        "question_hash": manifest.question_hash,
+        "oracle_hash": manifest.oracle_hash,
+        "seed": manifest.seed,
+        "timeout_seconds": manifest.timeout_seconds,
+        "schedule_hash": manifest.schedule_hash,
+        "agent_backend": manifest.agent_backend,
+        "model": manifest.model,
+        "agent_cli_fingerprint": manifest.agent_cli_fingerprint,
+        "platform": manifest.platform,
+        "environment_fingerprint": manifest.environment_fingerprint,
+        "primary_session_id": manifest.primary_session_id,
+        "retry_session_ids": list(manifest.retry_session_ids),
+        "expected_cells": [asdict(cell) for cell in manifest.expected_cells],
+        "required_arms": list(manifest.required_arms),
+        "indexed_arms": list(manifest.indexed_arms),
+        "tool_fingerprints": dict(manifest.tool_fingerprints),
+        "repo_commits": dict(manifest.repo_commits),
+        "repo_fingerprints": dict(manifest.repo_fingerprints),
+        "eligible_paths": dict(manifest.eligible_paths),
+        "eligible_paths_hashes": dict(manifest.eligible_paths_hashes),
+        "parse_error_allowlists": dict(manifest.parse_error_allowlists),
+        "required_readiness_oracles": dict(manifest.required_readiness_oracles),
+    }
+
+
+def create_manifest(
+    *,
+    benchmark_git_sha: str,
+    config_hash: str,
+    question_hash: str,
+    oracle_hash: str,
+    seed: int,
+    timeout_seconds: int,
+    schedule_hash: str,
+    agent_backend: str,
+    model: str,
+    agent_cli_fingerprint: str,
+    platform: str,
+    environment_fingerprint: str,
+    primary_session_id: str,
+    retry_session_ids: tuple[str, ...],
+    expected_cells: tuple[ExpectedCellV1, ...],
+    required_arms: tuple[str, ...],
+    indexed_arms: tuple[str, ...],
+    tool_fingerprints: dict[str, str],
+    repo_commits: dict[str, str],
+    repo_fingerprints: dict[str, str],
+    eligible_paths: dict[str, tuple[str, ...]],
+    eligible_paths_hashes: dict[str, str],
+    parse_error_allowlists: dict[str, tuple[str, ...]],
+    required_readiness_oracles: dict[str, tuple[str, ...]],
+) -> ExperimentManifestV1:
+    """Create and validate a canonical experiment manifest."""
+    strings = (
+        benchmark_git_sha,
+        config_hash,
+        question_hash,
+        oracle_hash,
+        schedule_hash,
+        agent_backend,
+        model,
+        agent_cli_fingerprint,
+        platform,
+        environment_fingerprint,
+        primary_session_id,
+    )
+    if not all(strings):
+        raise ValueError("Manifest identity and provenance fields must be non-empty")
+    if timeout_seconds <= 0:
+        raise ValueError("timeout_seconds must be positive")
+    if len(set(retry_session_ids)) != len(retry_session_ids):
+        raise ValueError("retry_session_ids must be unique")
+    if primary_session_id in retry_session_ids or any(
+        not item for item in retry_session_ids
+    ):
+        raise ValueError("Primary and retry sessions must be unique and non-empty")
+    run_ids = tuple(cell.run_id for cell in expected_cells)
+    if not run_ids or len(set(run_ids)) != len(run_ids):
+        raise ValueError("Expected cells must be non-empty and unique")
+    arm_set = {cell.arm for cell in expected_cells}
+    required_set = set(required_arms)
+    if arm_set != required_set or len(required_set) != len(required_arms):
+        raise ValueError("Required arms must exactly match expected cell arms")
+    indexed_set = set(indexed_arms)
+    if not indexed_set <= required_set or len(indexed_set) != len(indexed_arms):
+        raise ValueError("Indexed arms must be a unique subset of required arms")
+    if set(tool_fingerprints) != required_set or any(
+        not value for value in tool_fingerprints.values()
+    ):
+        raise ValueError("Tool fingerprints must exactly cover required arms")
+    repo_set = {cell.repo for cell in expected_cells}
+    if set(repo_commits) != repo_set or any(
+        not value for value in repo_commits.values()
+    ):
+        raise ValueError("Repo commits must exactly cover expected cell repos")
+    for mapping in (repo_fingerprints, eligible_paths_hashes):
+        if set(mapping) != repo_set or any(not value for value in mapping.values()):
+            raise ValueError("Repo fingerprints must exactly cover expected cell repos")
+    if set(eligible_paths) != repo_set or set(parse_error_allowlists) != repo_set:
+        raise ValueError("Path policies must exactly cover expected cell repos")
+    for repo, paths in eligible_paths.items():
+        if (
+            tuple(sorted(set(paths))) != paths
+            or not paths
+            or any(not path for path in paths)
+        ):
+            raise ValueError("Eligible paths must be sorted, unique, and non-empty")
+        if eligible_paths_hashes[repo] != _sha256(list(paths)):
+            raise ValueError("Eligible paths hash must match the exact path set")
+        allowed_errors = parse_error_allowlists[repo]
+        if tuple(sorted(set(allowed_errors))) != allowed_errors:
+            raise ValueError("Parse-error allowlists must be sorted and unique")
+        if not set(allowed_errors) <= set(paths):
+            raise ValueError("Parse-error allowlists must be eligible paths")
+    if set(required_readiness_oracles) != indexed_set or any(
+        not value for value in required_readiness_oracles.values()
+    ):
+        raise ValueError("Readiness oracles must exactly cover indexed arms")
+    if any(cell.agent_backend != agent_backend for cell in expected_cells):
+        raise ValueError("Expected cell backend must match manifest backend")
+    blocks: dict[tuple[str, str, int, str], set[str]] = {}
+    for cell in expected_cells:
+        block = (cell.repo, cell.question_id, cell.repeat, cell.agent_backend)
+        blocks.setdefault(block, set()).add(cell.arm)
+    if any(arms != required_set for arms in blocks.values()):
+        raise ValueError("Every paired block must contain every required arm")
+
+    provisional = ExperimentManifestV1(
+        benchmark_version=1,
+        experiment_id="",
+        manifest_hash="",
+        benchmark_git_sha=benchmark_git_sha,
+        config_hash=config_hash,
+        question_hash=question_hash,
+        oracle_hash=oracle_hash,
+        seed=seed,
+        timeout_seconds=timeout_seconds,
+        schedule_hash=schedule_hash,
+        agent_backend=agent_backend,
+        model=model,
+        agent_cli_fingerprint=agent_cli_fingerprint,
+        platform=platform,
+        environment_fingerprint=environment_fingerprint,
+        primary_session_id=primary_session_id,
+        retry_session_ids=retry_session_ids,
+        expected_cells=expected_cells,
+        required_arms=required_arms,
+        indexed_arms=indexed_arms,
+        tool_fingerprints=tuple(sorted(tool_fingerprints.items())),
+        repo_commits=tuple(sorted(repo_commits.items())),
+        repo_fingerprints=tuple(sorted(repo_fingerprints.items())),
+        eligible_paths=tuple(sorted(eligible_paths.items())),
+        eligible_paths_hashes=tuple(sorted(eligible_paths_hashes.items())),
+        parse_error_allowlists=tuple(sorted(parse_error_allowlists.items())),
+        required_readiness_oracles=tuple(sorted(required_readiness_oracles.items())),
+    )
+    manifest_hash = _sha256(_manifest_payload(provisional))
+    return ExperimentManifestV1(
+        **{
+            **asdict(provisional),
+            "experiment_id": f"sha256:{manifest_hash}",
+            "manifest_hash": manifest_hash,
+            "expected_cells": expected_cells,
+            "tool_fingerprints": provisional.tool_fingerprints,
+            "repo_commits": provisional.repo_commits,
+        }
+    )
+
+
+def parse_manifest_v1(raw: dict[str, Any]) -> ExperimentManifestV1:
+    """Decode a persisted JSON manifest and revalidate its nested structures."""
+    version = raw.get("benchmark_version")
+    if type(version) is not int or version != 1:
+        raise ValueError(f"Unsupported benchmark_version: {version}")
+    expected_keys = {field.name for field in fields(ExperimentManifestV1)}
+    if set(raw) != expected_keys:
+        raise ValueError("Manifest fields do not match the V1 schema")
+    manifest = ExperimentManifestV1(
+        benchmark_version=1,
+        experiment_id=raw["experiment_id"],
+        manifest_hash=raw["manifest_hash"],
+        benchmark_git_sha=raw["benchmark_git_sha"],
+        config_hash=raw["config_hash"],
+        question_hash=raw["question_hash"],
+        oracle_hash=raw["oracle_hash"],
+        seed=raw["seed"],
+        timeout_seconds=raw["timeout_seconds"],
+        schedule_hash=raw["schedule_hash"],
+        agent_backend=raw["agent_backend"],
+        model=raw["model"],
+        agent_cli_fingerprint=raw["agent_cli_fingerprint"],
+        platform=raw["platform"],
+        environment_fingerprint=raw["environment_fingerprint"],
+        primary_session_id=raw["primary_session_id"],
+        retry_session_ids=tuple(raw["retry_session_ids"]),
+        expected_cells=tuple(ExpectedCellV1(**cell) for cell in raw["expected_cells"]),
+        required_arms=tuple(raw["required_arms"]),
+        indexed_arms=tuple(raw["indexed_arms"]),
+        tool_fingerprints=tuple(tuple(item) for item in raw["tool_fingerprints"]),
+        repo_commits=tuple(tuple(item) for item in raw["repo_commits"]),
+        repo_fingerprints=tuple(tuple(item) for item in raw["repo_fingerprints"]),
+        eligible_paths=tuple(
+            (item[0], tuple(item[1])) for item in raw["eligible_paths"]
+        ),
+        eligible_paths_hashes=tuple(
+            tuple(item) for item in raw["eligible_paths_hashes"]
+        ),
+        parse_error_allowlists=tuple(
+            (item[0], tuple(item[1])) for item in raw["parse_error_allowlists"]
+        ),
+        required_readiness_oracles=tuple(
+            (item[0], tuple(item[1])) for item in raw["required_readiness_oracles"]
+        ),
+    )
+    normalized = create_manifest(
+        benchmark_git_sha=manifest.benchmark_git_sha,
+        config_hash=manifest.config_hash,
+        question_hash=manifest.question_hash,
+        oracle_hash=manifest.oracle_hash,
+        seed=manifest.seed,
+        timeout_seconds=manifest.timeout_seconds,
+        schedule_hash=manifest.schedule_hash,
+        agent_backend=manifest.agent_backend,
+        model=manifest.model,
+        agent_cli_fingerprint=manifest.agent_cli_fingerprint,
+        platform=manifest.platform,
+        environment_fingerprint=manifest.environment_fingerprint,
+        primary_session_id=manifest.primary_session_id,
+        retry_session_ids=manifest.retry_session_ids,
+        expected_cells=manifest.expected_cells,
+        required_arms=manifest.required_arms,
+        indexed_arms=manifest.indexed_arms,
+        tool_fingerprints=dict(manifest.tool_fingerprints),
+        repo_commits=dict(manifest.repo_commits),
+        repo_fingerprints=dict(manifest.repo_fingerprints),
+        eligible_paths=dict(manifest.eligible_paths),
+        eligible_paths_hashes=dict(manifest.eligible_paths_hashes),
+        parse_error_allowlists=dict(manifest.parse_error_allowlists),
+        required_readiness_oracles=dict(manifest.required_readiness_oracles),
+    )
+    if normalized != manifest:
+        raise ValueError("Manifest hash or structure is invalid")
+    return manifest
+
+
+def append_registry_event(path: Path, event: RegistryEvent) -> None:
+    """Atomically bind an experiment ID to one hash, then append its event."""
+    if event.status not in {"PLANNED", "RUNNING", "BLOCKED", "COMPLETE", "INVALID"}:
+        raise ValueError(f"Unsupported registry status: {event.status}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    owner = path.parent / f"{event.experiment_id.replace(':', '_')}.manifest-hash"
+    try:
+        with owner.open("x", encoding="utf-8", newline="\n") as handle:
+            handle.write(event.manifest_hash + "\n")
+    except FileExistsError:
+        bound_hash = owner.read_text(encoding="utf-8").strip()
+        if bound_hash != event.manifest_hash:
+            raise ValueError(
+                f"Experiment {event.experiment_id} already has manifest hash {bound_hash}"
+            ) from None
+    encoded = _canonical_json_bytes(asdict(event)).decode("utf-8")
+    with path.open("a", encoding="utf-8", newline="\n") as handle:
+        handle.write(encoded + "\n")
+
+
+def validate_publishable_experiment(
+    manifest: ExperimentManifestV1,
+    *,
+    registry: Iterable[RegistryEvent],
+    runs: Iterable[RunRecordV1],
+    evals: Iterable[EvalRecordV1],
+    reported_experiment_ids: tuple[str, ...],
+) -> IntegrityVerdict:
+    """Validate one experiment through the focused fail-closed gate."""
+    from benchmarks.codegraph_compare._integrity_gate import validate_experiment
+
+    return validate_experiment(
+        manifest,
+        registry=registry,
+        runs=runs,
+        evals=evals,
+        reported_experiment_ids=reported_experiment_ids,
+    )

--- a/benchmarks/codegraph_compare/schemas.py
+++ b/benchmarks/codegraph_compare/schemas.py
@@ -7,6 +7,9 @@ Repo, question, and arm specs define the benchmark configuration.
 
 from __future__ import annotations
 
+from enum import Enum
+from typing import Any, Literal
+
 from pydantic import ConfigDict
 from pydantic.dataclasses import dataclass
 
@@ -79,6 +82,277 @@ class EvalRecord:
     bad_citations: list[str]
     evaluator_model: str
     evaluated_at: str  # ISO 8601
+
+
+class BenchmarkStatus(str, Enum):
+    """Fail-closed outcome for one versioned benchmark attempt."""
+
+    SUCCESS = "SUCCESS"
+    PRODUCT_FAILURE = "PRODUCT_FAILURE"
+    INFRA_FAILURE = "INFRA_FAILURE"
+    INVALID = "INVALID"
+    NOT_EVALUATED = "NOT_EVALUATED"
+
+
+@dataclass(frozen=True, config=ConfigDict(extra="forbid"))
+class AttemptIdentityV1:
+    """Immutable identity for one physical attempt of a logical run."""
+
+    experiment_id: str
+    session_id: str
+    run_id: str
+    attempt_no: int
+
+    def __post_init__(self) -> None:
+        if not self.experiment_id or not self.session_id or not self.run_id:
+            raise ValueError("Attempt identity fields must be non-empty")
+        if self.attempt_no < 0:
+            raise ValueError("attempt_no must be non-negative")
+
+
+@dataclass(frozen=True, config=ConfigDict(extra="forbid"))
+class IndexStatsV1:
+    """Comparable index readiness and provenance for one attempt."""
+
+    eligible_source_files: int
+    indexed_source_files: int
+    excluded_source_files: int
+    parse_error_files: int
+    eligible_paths_hash: str
+    indexed_paths_hash: str
+    excluded_paths_hash: str
+    parse_error_paths_hash: str
+    indexed_paths: tuple[str, ...]
+    excluded_paths: tuple[str, ...]
+    parse_error_paths: tuple[str, ...]
+    build_seconds: float
+    index_size_bytes: int
+    repo_fingerprint: str
+    tool_fingerprint: str
+    readiness_oracles: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        counts = (
+            self.eligible_source_files,
+            self.indexed_source_files,
+            self.excluded_source_files,
+            self.parse_error_files,
+            self.index_size_bytes,
+        )
+        if any(value < 0 for value in counts) or self.build_seconds < 0:
+            raise ValueError("Index statistics must be non-negative")
+        provenance = (
+            self.eligible_paths_hash,
+            self.indexed_paths_hash,
+            self.excluded_paths_hash,
+            self.parse_error_paths_hash,
+            self.repo_fingerprint,
+            self.tool_fingerprint,
+        )
+        if not all(provenance):
+            raise ValueError("Index provenance fields must be non-empty")
+        for paths in (self.indexed_paths, self.excluded_paths, self.parse_error_paths):
+            if tuple(sorted(set(paths))) != paths or any(not path for path in paths):
+                raise ValueError(
+                    "Index path sets must be sorted, unique, and non-empty"
+                )
+
+
+@dataclass(frozen=True, config=ConfigDict(extra="forbid"))
+class RunRecordV1:
+    """Strict provenance record for one RFC-0021 benchmark attempt."""
+
+    benchmark_version: Literal[1]
+    experiment_id: str
+    session_id: str
+    run_id: str
+    attempt_no: int
+    retry_of: AttemptIdentityV1 | None
+    status: BenchmarkStatus
+    repo: str
+    question_id: str
+    arm: str
+    repeat: int
+    agent_backend: str
+    model: str
+    config_hash: str
+    question_hash: str
+    oracle_hash: str
+    tool_fingerprint: str
+    repo_commit: str
+    benchmark_git_sha: str
+    agent_cli_fingerprint: str
+    platform: str
+    environment_fingerprint: str
+    blocker_reason: str | None
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+    total_cost_usd: float
+    tool_calls: int
+    answer: str
+    started_at: str = ""
+    ended_at: str = ""
+    elapsed_seconds: float = 0.0
+    estimated_cost_usd: float = 0.0
+    cost_source: Literal["provider", "estimated", "none"] = "none"
+    cached_input_tokens: int = 0
+    reasoning_output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_creation_tokens: int = 0
+    num_turns: int = 0
+    file_reads: int = 0
+    search_calls: int = 0
+    index_queries: int = 0
+    citations: tuple[str, ...] = ()
+    transcript_path: str = ""
+    index_stats: IndexStatsV1 | None = None
+
+    @property
+    def identity(self) -> AttemptIdentityV1:
+        """Return the full physical-attempt identity."""
+        return AttemptIdentityV1(
+            self.experiment_id,
+            self.session_id,
+            self.run_id,
+            self.attempt_no,
+        )
+
+    def __post_init__(self) -> None:
+        _ = self.identity
+        required = {
+            "repo": self.repo,
+            "question_id": self.question_id,
+            "arm": self.arm,
+            "agent_backend": self.agent_backend,
+            "model": self.model,
+            "config_hash": self.config_hash,
+            "question_hash": self.question_hash,
+            "oracle_hash": self.oracle_hash,
+            "tool_fingerprint": self.tool_fingerprint,
+            "repo_commit": self.repo_commit,
+            "benchmark_git_sha": self.benchmark_git_sha,
+            "agent_cli_fingerprint": self.agent_cli_fingerprint,
+            "platform": self.platform,
+            "environment_fingerprint": self.environment_fingerprint,
+        }
+        missing = tuple(name for name, value in required.items() if not value)
+        if missing:
+            raise ValueError(f"V1 provenance fields must be non-empty: {missing}")
+        non_negative = {
+            "repeat": self.repeat,
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "total_tokens": self.total_tokens,
+            "total_cost_usd": self.total_cost_usd,
+            "tool_calls": self.tool_calls,
+            "elapsed_seconds": self.elapsed_seconds,
+            "estimated_cost_usd": self.estimated_cost_usd,
+            "cached_input_tokens": self.cached_input_tokens,
+            "reasoning_output_tokens": self.reasoning_output_tokens,
+            "cache_read_tokens": self.cache_read_tokens,
+            "cache_creation_tokens": self.cache_creation_tokens,
+            "num_turns": self.num_turns,
+            "file_reads": self.file_reads,
+            "search_calls": self.search_calls,
+            "index_queries": self.index_queries,
+        }
+        invalid = tuple(name for name, value in non_negative.items() if value < 0)
+        if invalid:
+            raise ValueError(f"V1 numeric fields must be non-negative: {invalid}")
+        if self.status is BenchmarkStatus.NOT_EVALUATED:
+            if not self.blocker_reason:
+                raise ValueError("NOT_EVALUATED requires blocker_reason")
+            zero_fields = (
+                self.input_tokens,
+                self.output_tokens,
+                self.total_tokens,
+                self.total_cost_usd,
+                self.tool_calls,
+                self.estimated_cost_usd,
+                self.cached_input_tokens,
+                self.reasoning_output_tokens,
+                self.cache_read_tokens,
+                self.cache_creation_tokens,
+                self.num_turns,
+                self.file_reads,
+                self.search_calls,
+                self.index_queries,
+            )
+            if any(zero_fields) or self.answer or self.transcript_path:
+                raise ValueError(
+                    "NOT_EVALUATED attempts must have zero usage and answer"
+                )
+        elif self.status is BenchmarkStatus.SUCCESS and self.blocker_reason is not None:
+            raise ValueError("SUCCESS must not include blocker_reason")
+
+
+@dataclass(frozen=True, config=ConfigDict(extra="forbid"))
+class EvalRecordV1:
+    """Arm-blind evaluation tied to a full V1 attempt identity."""
+
+    benchmark_version: Literal[1]
+    experiment_id: str
+    session_id: str
+    run_id: str
+    attempt_no: int
+    correctness: int
+    completeness: int
+    citation_location_validity: float
+    claim_support: int
+    overall: float
+    evaluator_model: str
+    hallucination_risk: int = 1
+    missing_key_points: tuple[str, ...] = ()
+    bad_citations: tuple[str, ...] = ()
+    evaluated_at: str = ""
+
+    @property
+    def identity(self) -> AttemptIdentityV1:
+        """Return the evaluated physical-attempt identity."""
+        return AttemptIdentityV1(
+            self.experiment_id,
+            self.session_id,
+            self.run_id,
+            self.attempt_no,
+        )
+
+    def __post_init__(self) -> None:
+        _ = self.identity
+        if not 0.0 <= self.citation_location_validity <= 1.0:
+            raise ValueError("citation_location_validity must be between 0 and 1")
+        scores = (
+            self.correctness,
+            self.completeness,
+            self.claim_support,
+            self.hallucination_risk,
+        )
+        if any(score < 1 or score > 5 for score in scores):
+            raise ValueError("V1 evaluation scores must be between 1 and 5")
+        if not 1.0 <= self.overall <= 5.0:
+            raise ValueError("overall must be between 1 and 5")
+        if not self.evaluator_model:
+            raise ValueError("evaluator_model must be non-empty")
+
+
+def parse_run_record(raw: dict[str, Any]) -> RunRecord | RunRecordV1:
+    """Dispatch legacy and V1 run records without weakening either schema."""
+    version = raw.get("benchmark_version")
+    if version is None:
+        return RunRecord(**raw)
+    if type(version) is int and version == 1:
+        return RunRecordV1(**raw)
+    raise ValueError(f"Unsupported benchmark_version: {version}")
+
+
+def parse_eval_record(raw: dict[str, Any]) -> EvalRecord | EvalRecordV1:
+    """Dispatch legacy and V1 evaluation records by explicit version."""
+    version = raw.get("benchmark_version")
+    if version is None:
+        return EvalRecord(**raw)
+    if type(version) is int and version == 1:
+        return EvalRecordV1(**raw)
+    raise ValueError(f"Unsupported benchmark_version: {version}")
 
 
 @dataclass(config=ConfigDict(extra="forbid"))

--- a/tests/unit/test_benchmark_harness.py
+++ b/tests/unit/test_benchmark_harness.py
@@ -9,6 +9,7 @@ Created: 2026-05-22 r37fE
 
 from __future__ import annotations
 
+import hashlib
 import json
 import sqlite3
 import sys
@@ -742,3 +743,790 @@ class TestRunRecordCostCacheColumns:
         ):
             assert key in record, key
         RunRecord(**record)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# RFC-0021 Slice A1 — experiment integrity core
+# ---------------------------------------------------------------------------
+
+
+def _v1_paths_hash(paths: tuple[str, ...]) -> str:
+    payload = json.dumps(
+        list(paths), ensure_ascii=True, separators=(",", ":"), sort_keys=True
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _v1_manifest(**overrides):
+    from benchmarks.codegraph_compare.integrity import ExpectedCellV1, create_manifest
+
+    values = {
+        "benchmark_git_sha": "abc123",
+        "config_hash": "cfg123",
+        "question_hash": "questions123",
+        "oracle_hash": "oracles123",
+        "seed": 210021,
+        "timeout_seconds": 300,
+        "schedule_hash": "schedule123",
+        "agent_backend": "codex",
+        "model": "gpt-5",
+        "agent_cli_fingerprint": "codex-cli-1",
+        "platform": "windows-x64",
+        "environment_fingerprint": "env123",
+        "primary_session_id": "PRIMARY",
+        "retry_session_ids": (),
+        "expected_run_ids": (
+            "q1__codegraph-warm__codex__00",
+            "q1__tsa-warm__codex__00",
+        ),
+        "required_arms": ("codegraph-warm", "tsa-warm"),
+        "indexed_arms": ("codegraph-warm", "tsa-warm"),
+        "tool_fingerprints": {"codegraph-warm": "cg141", "tsa-warm": "tsa130"},
+        "repo_commits": {"gin": "repo123"},
+        "repo_fingerprints": {"gin": "repo-fingerprint"},
+        "eligible_paths": {"gin": tuple(f"src/file_{index}.py" for index in range(10))},
+        "parse_error_allowlists": {"gin": ()},
+        "required_readiness_oracles": {
+            "codegraph-warm": ("known-symbol",),
+            "tsa-warm": ("known-symbol",),
+        },
+    }
+    values.update(overrides)
+    if "eligible_paths_hashes" not in overrides:
+        values["eligible_paths_hashes"] = {
+            repo: _v1_paths_hash(paths)
+            for repo, paths in values["eligible_paths"].items()
+        }
+    if "indexed_arms" not in overrides:
+        values["indexed_arms"] = tuple(
+            arm for arm in values["required_arms"] if arm != "native-only"
+        )
+    if "required_readiness_oracles" not in overrides:
+        values["required_readiness_oracles"] = dict.fromkeys(
+            values["indexed_arms"], ("known-symbol",)
+        )
+    run_ids = values.pop("expected_run_ids")
+    values["expected_cells"] = tuple(
+        ExpectedCellV1(
+            repo="gin",
+            question_id=run_id.rsplit("__", 3)[0],
+            arm=run_id.rsplit("__", 3)[1],
+            agent_backend=run_id.rsplit("__", 3)[2],
+            repeat=int(run_id.rsplit("__", 3)[3]),
+            run_id=run_id,
+        )
+        for run_id in run_ids
+    )
+    return create_manifest(**values)
+
+
+def _registry_for(manifest):
+    from benchmarks.codegraph_compare.integrity import RegistryEvent
+
+    return (
+        RegistryEvent(
+            manifest.experiment_id,
+            manifest.manifest_hash,
+            "PLANNED",
+            "registered",
+        ),
+    )
+
+
+def _v1_run(manifest, run_id: str, **overrides):
+    from benchmarks.codegraph_compare.schemas import (
+        BenchmarkStatus,
+        IndexStatsV1,
+        RunRecordV1,
+    )
+
+    arm = run_id.rsplit("__", 3)[1]
+    eligible_paths = dict(manifest.eligible_paths)["gin"]
+    empty_paths: tuple[str, ...] = ()
+    tool_fingerprint = {
+        "codegraph-warm": "cg141",
+        "tsa-warm": "tsa130",
+        "native-only": "native1",
+    }[arm]
+    values = {
+        "benchmark_version": 1,
+        "experiment_id": manifest.experiment_id,
+        "session_id": "PRIMARY",
+        "run_id": run_id,
+        "attempt_no": 0,
+        "retry_of": None,
+        "status": BenchmarkStatus.SUCCESS,
+        "repo": "gin",
+        "question_id": "q1",
+        "arm": arm,
+        "repeat": 0,
+        "agent_backend": "codex",
+        "model": "gpt-5",
+        "config_hash": "cfg123",
+        "question_hash": "questions123",
+        "oracle_hash": "oracles123",
+        "tool_fingerprint": tool_fingerprint,
+        "repo_commit": "repo123",
+        "benchmark_git_sha": "abc123",
+        "agent_cli_fingerprint": "codex-cli-1",
+        "platform": "windows-x64",
+        "environment_fingerprint": "env123",
+        "blocker_reason": None,
+        "input_tokens": 10,
+        "output_tokens": 5,
+        "total_tokens": 15,
+        "total_cost_usd": 0.01,
+        "tool_calls": 1,
+        "answer": "answer",
+        "index_stats": IndexStatsV1(
+            eligible_source_files=len(eligible_paths),
+            indexed_source_files=len(eligible_paths),
+            excluded_source_files=0,
+            parse_error_files=0,
+            eligible_paths_hash=_v1_paths_hash(eligible_paths),
+            indexed_paths_hash=_v1_paths_hash(eligible_paths),
+            excluded_paths_hash=_v1_paths_hash(empty_paths),
+            parse_error_paths_hash=_v1_paths_hash(empty_paths),
+            indexed_paths=eligible_paths,
+            excluded_paths=empty_paths,
+            parse_error_paths=empty_paths,
+            build_seconds=1.0,
+            index_size_bytes=100,
+            repo_fingerprint="repo-fingerprint",
+            tool_fingerprint=tool_fingerprint,
+            readiness_oracles=("known-symbol",),
+        ),
+    }
+    values.update(overrides)
+    return RunRecordV1(**values)
+
+
+def _v1_eval(run):
+    from benchmarks.codegraph_compare.schemas import EvalRecordV1
+
+    return EvalRecordV1(
+        benchmark_version=1,
+        experiment_id=run.experiment_id,
+        session_id=run.session_id,
+        run_id=run.run_id,
+        attempt_no=run.attempt_no,
+        correctness=5,
+        completeness=5,
+        citation_location_validity=1.0,
+        claim_support=5,
+        overall=5.0,
+        evaluator_model="judge-v1",
+    )
+
+
+class TestBenchmarkV1SchemaDispatch:
+    def test_record_without_version_uses_legacy_schema(self):
+        from benchmarks.codegraph_compare.schemas import RunRecord, parse_run_record
+
+        legacy = {
+            "run_id": "q1__native-only__codex__00",
+            "repo": "gin",
+            "question_id": "q1",
+            "arm": "native-only",
+            "repeat": 0,
+            "started_at": "2026-07-17T00:00:00Z",
+            "ended_at": "2026-07-17T00:00:01Z",
+            "elapsed_seconds": 1.0,
+            "input_tokens": 1,
+            "output_tokens": 1,
+            "total_tokens": 2,
+            "estimated_cost_usd": 0.0,
+            "tool_calls": 0,
+            "file_reads": 0,
+            "search_calls": 0,
+            "index_queries": 0,
+            "answer": "ok",
+            "citations": [],
+            "transcript_path": "legacy.jsonl",
+        }
+
+        parsed = parse_run_record(legacy)
+
+        assert type(parsed) is RunRecord
+
+    def test_unknown_benchmark_version_is_rejected(self):
+        from benchmarks.codegraph_compare.schemas import parse_run_record
+
+        with pytest.raises(ValueError, match="Unsupported benchmark_version: 2"):
+            parse_run_record({"benchmark_version": 2})
+
+    def test_boolean_benchmark_version_is_rejected(self):
+        from benchmarks.codegraph_compare.schemas import parse_run_record
+
+        with pytest.raises(ValueError, match="Unsupported benchmark_version: True"):
+            parse_run_record({"benchmark_version": True})
+
+    def test_v1_run_survives_real_json_round_trip(self):
+        from dataclasses import asdict
+
+        from benchmarks.codegraph_compare.schemas import parse_run_record
+
+        manifest = _v1_manifest(
+            retry_session_ids=("RETRY",),
+            expected_run_ids=("q1__tsa-warm__codex__00",),
+            required_arms=("tsa-warm",),
+            tool_fingerprints={"tsa-warm": "tsa130"},
+        )
+        primary = _v1_run(manifest, "q1__tsa-warm__codex__00")
+        retry = _v1_run(
+            manifest,
+            "q1__tsa-warm__codex__00",
+            session_id="RETRY",
+            attempt_no=1,
+            retry_of=primary.identity,
+            citations=("file.py:10",),
+        )
+        payload = json.loads(json.dumps(asdict(retry)))
+
+        parsed = parse_run_record(payload)
+
+        assert parsed == retry
+
+    def test_v1_eval_survives_real_json_round_trip(self):
+        from dataclasses import asdict
+
+        from benchmarks.codegraph_compare.schemas import parse_eval_record
+
+        manifest = _v1_manifest(
+            expected_run_ids=("q1__tsa-warm__codex__00",),
+            required_arms=("tsa-warm",),
+            tool_fingerprints={"tsa-warm": "tsa130"},
+        )
+        evaluation = _v1_eval(_v1_run(manifest, "q1__tsa-warm__codex__00"))
+        payload = json.loads(json.dumps(asdict(evaluation)))
+
+        parsed = parse_eval_record(payload)
+
+        assert parsed == evaluation
+
+
+class TestBenchmarkExperimentIntegrity:
+    def test_manifest_id_is_stable_across_mapping_order(self):
+        first = _v1_manifest(
+            tool_fingerprints={"codegraph-warm": "cg141", "tsa-warm": "tsa130"}
+        )
+        second = _v1_manifest(
+            tool_fingerprints={"tsa-warm": "tsa130", "codegraph-warm": "cg141"}
+        )
+
+        assert first.experiment_id == second.experiment_id
+
+    def test_manifest_survives_real_json_round_trip(self):
+        from dataclasses import asdict
+
+        from benchmarks.codegraph_compare.integrity import parse_manifest_v1
+
+        manifest = _v1_manifest()
+        payload = json.loads(json.dumps(asdict(manifest)))
+
+        parsed = parse_manifest_v1(payload)
+
+        assert parsed == manifest
+
+    def test_manifest_rejects_required_arm_without_expected_cell(self):
+        with pytest.raises(
+            ValueError, match="Required arms must exactly match expected cell arms"
+        ):
+            _v1_manifest(
+                expected_run_ids=("q1__tsa-warm__codex__00",),
+                required_arms=("codegraph-warm", "tsa-warm"),
+            )
+
+    def test_registry_rejects_conflicting_manifest_for_same_experiment(
+        self, tmp_path: Path
+    ):
+        from benchmarks.codegraph_compare.integrity import (
+            RegistryEvent,
+            append_registry_event,
+        )
+
+        registry = tmp_path / "registry.jsonl"
+        append_registry_event(
+            registry,
+            RegistryEvent("EXP", "hash-a", "PLANNED", "created"),
+        )
+
+        with pytest.raises(
+            ValueError, match="Experiment EXP already has manifest hash hash-a"
+        ):
+            append_registry_event(
+                registry,
+                RegistryEvent("EXP", "hash-b", "PLANNED", "replaced"),
+            )
+
+        assert registry.read_text(encoding="utf-8").count("\n") == 1
+
+    def test_publish_gate_rejects_exact_missing_manifest_cell(self):
+        from benchmarks.codegraph_compare.integrity import (
+            validate_publishable_experiment,
+        )
+
+        manifest = _v1_manifest()
+        tsa = _v1_run(manifest, "q1__tsa-warm__codex__00")
+
+        verdict = validate_publishable_experiment(
+            manifest,
+            registry=_registry_for(manifest),
+            runs=(tsa,),
+            evals=(_v1_eval(tsa),),
+            reported_experiment_ids=(manifest.experiment_id,),
+        )
+
+        assert verdict.publishable is False
+        assert verdict.claim_level == "INVALID"
+        assert verdict.expected_cell_count == 2
+        assert verdict.observed_cell_count == 1
+        assert tuple(item.code for item in verdict.violations) == ("MISSING_RUN_CELL",)
+        assert verdict.violations[0].identity == (
+            manifest.experiment_id,
+            "PRIMARY",
+            "q1__codegraph-warm__codex__00",
+            0,
+        )
+
+    def test_publish_gate_rejects_unregistered_current_experiment(self):
+        from benchmarks.codegraph_compare.integrity import (
+            validate_publishable_experiment,
+        )
+
+        manifest = _v1_manifest(
+            expected_run_ids=("q1__tsa-warm__codex__00",),
+            required_arms=("tsa-warm",),
+            tool_fingerprints={"tsa-warm": "tsa130"},
+        )
+        tsa = _v1_run(manifest, "q1__tsa-warm__codex__00")
+
+        verdict = validate_publishable_experiment(
+            manifest,
+            registry=(),
+            runs=(tsa,),
+            evals=(_v1_eval(tsa),),
+            reported_experiment_ids=(manifest.experiment_id,),
+        )
+
+        assert tuple(item.code for item in verdict.violations) == (
+            "UNREGISTERED_EXPERIMENT",
+        )
+        assert verdict.publishable is False
+
+    def test_unlinked_session_cannot_replace_failed_primary(self):
+        from benchmarks.codegraph_compare.integrity import (
+            validate_publishable_experiment,
+        )
+        from benchmarks.codegraph_compare.schemas import BenchmarkStatus
+
+        manifest = _v1_manifest(
+            expected_run_ids=("q1__tsa-warm__codex__00",),
+            required_arms=("tsa-warm",),
+            tool_fingerprints={"tsa-warm": "tsa130"},
+        )
+        failed = _v1_run(
+            manifest,
+            "q1__tsa-warm__codex__00",
+            status=BenchmarkStatus.PRODUCT_FAILURE,
+            answer="",
+        )
+        rogue = _v1_run(
+            manifest,
+            "q1__tsa-warm__codex__00",
+            session_id="ROGUE",
+        )
+
+        verdict = validate_publishable_experiment(
+            manifest,
+            registry=_registry_for(manifest),
+            runs=(failed, rogue),
+            evals=(),
+            reported_experiment_ids=(manifest.experiment_id,),
+        )
+
+        assert tuple(item.code for item in verdict.violations) == (
+            "UNLINKED_SESSION",
+            "REQUIRED_CELL_FAILED",
+        )
+        assert verdict.canonical_attempts == (failed,)
+        assert verdict.reliability_attempts == (failed, rogue)
+        assert verdict.disclosed_attempts == (failed, rogue)
+
+    def test_not_evaluated_competitor_disables_dominance(self):
+        from benchmarks.codegraph_compare.integrity import (
+            validate_publishable_experiment,
+        )
+        from benchmarks.codegraph_compare.schemas import BenchmarkStatus
+
+        manifest = _v1_manifest()
+        codegraph = _v1_run(
+            manifest,
+            "q1__codegraph-warm__codex__00",
+            status=BenchmarkStatus.NOT_EVALUATED,
+            blocker_reason="INSTALL_FAILED",
+            input_tokens=0,
+            output_tokens=0,
+            total_tokens=0,
+            total_cost_usd=0.0,
+            tool_calls=0,
+            answer="",
+        )
+        tsa = _v1_run(manifest, "q1__tsa-warm__codex__00")
+
+        verdict = validate_publishable_experiment(
+            manifest,
+            registry=_registry_for(manifest),
+            runs=(codegraph, tsa),
+            evals=(_v1_eval(tsa),),
+            reported_experiment_ids=(manifest.experiment_id,),
+        )
+
+        assert verdict.publishable is False
+        assert verdict.claim_level == "NOT_EVALUATED"
+        assert verdict.dominance_allowed is False
+        assert verdict.winner is None
+        assert tuple(item.code for item in verdict.violations) == (
+            "REQUIRED_ARM_NOT_EVALUATED",
+        )
+        assert verdict.violations[0].arm == "codegraph-warm"
+        assert verdict.violations[0].reason == "INSTALL_FAILED"
+
+    def test_expected_codegraph_cell_cannot_be_faked_by_tsa_record(self):
+        from benchmarks.codegraph_compare.integrity import (
+            validate_publishable_experiment,
+        )
+
+        manifest = _v1_manifest(
+            expected_run_ids=("q1__codegraph-warm__codex__00",),
+            required_arms=("codegraph-warm",),
+            tool_fingerprints={"codegraph-warm": "cg141"},
+        )
+        disguised = _v1_run(
+            manifest,
+            "q1__codegraph-warm__codex__00",
+            arm="tsa-warm",
+            tool_fingerprint="tsa130",
+        )
+
+        verdict = validate_publishable_experiment(
+            manifest,
+            registry=_registry_for(manifest),
+            runs=(disguised,),
+            evals=(_v1_eval(disguised),),
+            reported_experiment_ids=(manifest.experiment_id,),
+        )
+
+        assert tuple(item.code for item in verdict.violations) == (
+            "CELL_PROVENANCE_MISMATCH",
+        )
+        assert verdict.publishable is False
+
+    def test_retry_after_success_is_rejected(self):
+        from benchmarks.codegraph_compare.integrity import (
+            validate_publishable_experiment,
+        )
+
+        manifest = _v1_manifest(
+            retry_session_ids=("RETRY",),
+            expected_run_ids=("q1__tsa-warm__codex__00",),
+            required_arms=("tsa-warm",),
+            tool_fingerprints={"tsa-warm": "tsa130"},
+        )
+        primary = _v1_run(manifest, "q1__tsa-warm__codex__00")
+        retry = _v1_run(
+            manifest,
+            "q1__tsa-warm__codex__00",
+            session_id="RETRY",
+            attempt_no=1,
+            retry_of=primary.identity,
+        )
+
+        verdict = validate_publishable_experiment(
+            manifest,
+            registry=_registry_for(manifest),
+            runs=(primary, retry),
+            evals=(_v1_eval(primary),),
+            reported_experiment_ids=(manifest.experiment_id,),
+        )
+
+        assert tuple(item.code for item in verdict.violations) == (
+            "ILLEGAL_RETRY_STATUS",
+        )
+        assert verdict.canonical_attempts == (primary,)
+
+    def test_unretried_infrastructure_failure_is_not_publishable(self):
+        from benchmarks.codegraph_compare.integrity import (
+            validate_publishable_experiment,
+        )
+        from benchmarks.codegraph_compare.schemas import BenchmarkStatus
+
+        manifest = _v1_manifest(
+            expected_run_ids=("q1__tsa-warm__codex__00",),
+            required_arms=("tsa-warm",),
+            tool_fingerprints={"tsa-warm": "tsa130"},
+        )
+        failed = _v1_run(
+            manifest,
+            "q1__tsa-warm__codex__00",
+            status=BenchmarkStatus.INFRA_FAILURE,
+            answer="",
+        )
+
+        verdict = validate_publishable_experiment(
+            manifest,
+            registry=_registry_for(manifest),
+            runs=(failed,),
+            evals=(),
+            reported_experiment_ids=(manifest.experiment_id,),
+        )
+
+        assert tuple(item.code for item in verdict.violations) == (
+            "REQUIRED_CELL_FAILED",
+        )
+        assert verdict.publishable is False
+
+    def test_duplicate_evaluation_is_rejected(self):
+        from benchmarks.codegraph_compare.integrity import (
+            validate_publishable_experiment,
+        )
+
+        manifest = _v1_manifest(
+            expected_run_ids=("q1__tsa-warm__codex__00",),
+            required_arms=("tsa-warm",),
+            tool_fingerprints={"tsa-warm": "tsa130"},
+        )
+        tsa = _v1_run(manifest, "q1__tsa-warm__codex__00")
+        evaluation = _v1_eval(tsa)
+
+        verdict = validate_publishable_experiment(
+            manifest,
+            registry=_registry_for(manifest),
+            runs=(tsa,),
+            evals=(evaluation, evaluation),
+            reported_experiment_ids=(manifest.experiment_id,),
+        )
+
+        assert tuple(item.code for item in verdict.violations) == ("DUPLICATE_EVAL",)
+        assert verdict.publishable is False
+
+    def test_native_control_requires_no_index_stats(self):
+        from benchmarks.codegraph_compare.integrity import (
+            validate_publishable_experiment,
+        )
+
+        manifest = _v1_manifest(
+            expected_run_ids=("q1__native-only__codex__00",),
+            required_arms=("native-only",),
+            indexed_arms=(),
+            tool_fingerprints={"native-only": "native1"},
+            required_readiness_oracles={},
+        )
+        native = _v1_run(
+            manifest,
+            "q1__native-only__codex__00",
+            index_stats=None,
+        )
+
+        verdict = validate_publishable_experiment(
+            manifest,
+            registry=_registry_for(manifest),
+            runs=(native,),
+            evals=(_v1_eval(native),),
+            reported_experiment_ids=(manifest.experiment_id,),
+        )
+
+        assert verdict.violations == ()
+        assert verdict.publishable is True
+
+    def test_stale_index_repo_fingerprint_is_rejected(self):
+        from dataclasses import replace
+
+        from benchmarks.codegraph_compare.integrity import (
+            validate_publishable_experiment,
+        )
+
+        manifest = _v1_manifest(
+            expected_run_ids=("q1__tsa-warm__codex__00",),
+            required_arms=("tsa-warm",),
+            tool_fingerprints={"tsa-warm": "tsa130"},
+        )
+        valid = _v1_run(manifest, "q1__tsa-warm__codex__00")
+        stale = replace(
+            valid,
+            index_stats=replace(valid.index_stats, repo_fingerprint="stale-repo"),
+        )
+
+        verdict = validate_publishable_experiment(
+            manifest,
+            registry=_registry_for(manifest),
+            runs=(stale,),
+            evals=(_v1_eval(stale),),
+            reported_experiment_ids=(manifest.experiment_id,),
+        )
+
+        assert tuple(item.code for item in verdict.violations) == (
+            "MIXED_INDEX_PROVENANCE",
+        )
+        assert verdict.publishable is False
+
+    def test_report_gate_rejects_hidden_registered_experiment(self):
+        from benchmarks.codegraph_compare.integrity import (
+            RegistryEvent,
+            validate_publishable_experiment,
+        )
+
+        manifest = _v1_manifest()
+        codegraph = _v1_run(manifest, "q1__codegraph-warm__codex__00")
+        tsa = _v1_run(manifest, "q1__tsa-warm__codex__00")
+        hidden = RegistryEvent("EXP_FAILED", "failed-hash", "FAILED", "unfavorable")
+
+        verdict = validate_publishable_experiment(
+            manifest,
+            registry=(*_registry_for(manifest), hidden),
+            runs=(codegraph, tsa),
+            evals=(_v1_eval(codegraph), _v1_eval(tsa)),
+            reported_experiment_ids=(manifest.experiment_id,),
+        )
+
+        assert tuple(item.code for item in verdict.violations) == ("HIDDEN_EXPERIMENT",)
+        assert verdict.violations[0].experiment_id == "EXP_FAILED"
+        assert verdict.disclosed_experiment_ids == tuple(
+            sorted(("EXP_FAILED", manifest.experiment_id))
+        )
+        assert verdict.publishable is False
+
+    def test_linked_retry_keeps_failure_in_reliability_denominator(self):
+        from benchmarks.codegraph_compare.integrity import (
+            validate_publishable_experiment,
+        )
+        from benchmarks.codegraph_compare.schemas import BenchmarkStatus
+
+        manifest = _v1_manifest(
+            primary_session_id="PRIMARY",
+            retry_session_ids=("RETRY",),
+            expected_run_ids=("q1__tsa-warm__codex__00",),
+            required_arms=("tsa-warm",),
+            tool_fingerprints={"tsa-warm": "tsa130"},
+        )
+        failed = _v1_run(
+            manifest,
+            "q1__tsa-warm__codex__00",
+            status=BenchmarkStatus.INFRA_FAILURE,
+            answer="",
+        )
+        retry = _v1_run(
+            manifest,
+            "q1__tsa-warm__codex__00",
+            session_id="RETRY",
+            attempt_no=1,
+            retry_of=failed.identity,
+        )
+
+        verdict = validate_publishable_experiment(
+            manifest,
+            registry=_registry_for(manifest),
+            runs=(failed, retry),
+            evals=(_v1_eval(retry),),
+            reported_experiment_ids=(manifest.experiment_id,),
+        )
+
+        assert verdict.publishable is True
+        assert verdict.claim_level == "E1"
+        assert verdict.canonical_attempts == (retry,)
+        assert verdict.reliability_attempts == (failed, retry)
+        assert verdict.violations == ()
+
+    def test_paired_retry_must_use_one_retry_session(self):
+        from benchmarks.codegraph_compare.integrity import (
+            validate_publishable_experiment,
+        )
+        from benchmarks.codegraph_compare.schemas import BenchmarkStatus
+
+        manifest = _v1_manifest(retry_session_ids=("R1", "R2"))
+        codegraph = _v1_run(
+            manifest,
+            "q1__codegraph-warm__codex__00",
+            status=BenchmarkStatus.INFRA_FAILURE,
+            answer="",
+        )
+        tsa = _v1_run(
+            manifest,
+            "q1__tsa-warm__codex__00",
+            status=BenchmarkStatus.INFRA_FAILURE,
+            answer="",
+        )
+        codegraph_retry = _v1_run(
+            manifest,
+            codegraph.run_id,
+            session_id="R1",
+            attempt_no=1,
+            retry_of=codegraph.identity,
+        )
+        tsa_retry = _v1_run(
+            manifest,
+            tsa.run_id,
+            session_id="R2",
+            attempt_no=1,
+            retry_of=tsa.identity,
+        )
+
+        verdict = validate_publishable_experiment(
+            manifest,
+            registry=_registry_for(manifest),
+            runs=(codegraph, tsa, codegraph_retry, tsa_retry),
+            evals=(_v1_eval(codegraph_retry), _v1_eval(tsa_retry)),
+            reported_experiment_ids=(manifest.experiment_id,),
+        )
+
+        assert tuple(item.code for item in verdict.violations) == (
+            "MIXED_RETRY_SESSION",
+        )
+        assert verdict.publishable is False
+
+    @pytest.mark.parametrize("mode", ("incomplete", "unapproved_parse_errors"))
+    def test_index_partition_must_exactly_cover_eligible_paths(self, mode):
+        from dataclasses import replace
+
+        from benchmarks.codegraph_compare.integrity import (
+            validate_publishable_experiment,
+        )
+
+        manifest = _v1_manifest(
+            expected_run_ids=("q1__tsa-warm__codex__00",),
+            required_arms=("tsa-warm",),
+            tool_fingerprints={"tsa-warm": "tsa130"},
+        )
+        valid = _v1_run(manifest, "q1__tsa-warm__codex__00")
+        assert valid.index_stats is not None
+        eligible = valid.index_stats.indexed_paths
+        if mode == "incomplete":
+            stats = replace(
+                valid.index_stats,
+                indexed_source_files=1,
+                indexed_paths=(eligible[0],),
+                indexed_paths_hash=_v1_paths_hash((eligible[0],)),
+            )
+        else:
+            errors = eligible[1:]
+            stats = replace(
+                valid.index_stats,
+                indexed_source_files=1,
+                parse_error_files=len(errors),
+                indexed_paths=(eligible[0],),
+                parse_error_paths=errors,
+                indexed_paths_hash=_v1_paths_hash((eligible[0],)),
+                parse_error_paths_hash=_v1_paths_hash(errors),
+            )
+        run = replace(valid, index_stats=stats)
+
+        verdict = validate_publishable_experiment(
+            manifest,
+            registry=_registry_for(manifest),
+            runs=(run,),
+            evals=(_v1_eval(run),),
+            reported_experiment_ids=(manifest.experiment_id,),
+        )
+
+        assert "INDEX_NOT_READY" in {violation.code for violation in verdict.violations}
+        assert verdict.publishable is False

--- a/tests/unit/test_benchmark_harness.py
+++ b/tests/unit/test_benchmark_harness.py
@@ -1530,3 +1530,66 @@ class TestBenchmarkExperimentIntegrity:
 
         assert "INDEX_NOT_READY" in {violation.code for violation in verdict.violations}
         assert verdict.publishable is False
+
+    def test_invalid_manifest_returns_verdict_instead_of_crashing(self):
+        from dataclasses import replace
+
+        from benchmarks.codegraph_compare.integrity import (
+            validate_publishable_experiment,
+        )
+
+        valid_manifest = _v1_manifest(
+            expected_run_ids=("q1__tsa-warm__codex__00",),
+            required_arms=("tsa-warm",),
+            tool_fingerprints={"tsa-warm": "tsa130"},
+        )
+        tampered_manifest = replace(valid_manifest, eligible_paths=())
+        run = _v1_run(valid_manifest, "q1__tsa-warm__codex__00")
+
+        verdict = validate_publishable_experiment(
+            tampered_manifest,
+            registry=_registry_for(tampered_manifest),
+            runs=(run,),
+            evals=(_v1_eval(run),),
+            reported_experiment_ids=(tampered_manifest.experiment_id,),
+        )
+
+        assert verdict.publishable is False
+        assert tuple(item.code for item in verdict.violations) == (
+            "INVALID_MANIFEST_HASH",
+            "INVALID_MANIFEST_STRUCTURE",
+        )
+
+    def test_failed_registry_status_is_terminal(self):
+        from benchmarks.codegraph_compare.integrity import (
+            RegistryEvent,
+            validate_publishable_experiment,
+        )
+
+        manifest = _v1_manifest(
+            expected_run_ids=("q1__tsa-warm__codex__00",),
+            required_arms=("tsa-warm",),
+            tool_fingerprints={"tsa-warm": "tsa130"},
+        )
+        run = _v1_run(manifest, "q1__tsa-warm__codex__00")
+        registry = (
+            RegistryEvent(
+                manifest.experiment_id,
+                manifest.manifest_hash,
+                "FAILED",
+                "runner failed",
+            ),
+        )
+
+        verdict = validate_publishable_experiment(
+            manifest,
+            registry=registry,
+            runs=(run,),
+            evals=(_v1_eval(run),),
+            reported_experiment_ids=(manifest.experiment_id,),
+        )
+
+        assert verdict.publishable is False
+        assert tuple(item.code for item in verdict.violations) == (
+            "REGISTRY_TERMINAL_FAILURE",
+        )


### PR DESCRIPTION
## Summary
- add versioned benchmark run, evaluation, and index-readiness schemas while preserving legacy record parsing
- add canonical experiment manifests, append-only registry binding, and fail-closed publication validation
- enforce exact benchmark cells, provenance, paired retry lineage, evaluation joins, native/indexed boundaries, and complete index path partitions
- add adversarial regression coverage for hidden experiments, stale indexes, incomplete partitions, unapproved parse errors, and mixed retry sessions

## Verification
- `uv run pytest -q` — 1245 passed, 8 skipped
- `uv run pytest tests/unit/test_benchmark_harness.py --cov=tree_sitter_analyzer --cov-report=json -q` — 61 passed, 2 rerun
- `uv run python scripts/check_patch_coverage.py --base origin/develop --coverage-json coverage.json` — passed, no added executable misses
- Ruff and mypy — passed
- TSA file health: schemas A/SAFE, integrity B/SAFE, validation gate B/SAFE