### PR TITLE
Fail closed benchmark setup before model runs

### DIFF
--- a/benchmarks/codegraph_compare/adapters/__init__.py
+++ b/benchmarks/codegraph_compare/adapters/__init__.py
@@ -65,9 +65,9 @@ class BenchmarkAdapter(ABC):
     def prepare_index(self, repo_path: Path, cold: bool) -> IndexStats:
         """Build (cold=True) or verify (cold=False, warm) the index.
 
-        Must always return an IndexStats even if preparation is a no-op.
-        Implementations should log errors rather than raise so the harness
-        can continue.
+        Must always return an IndexStats when preparation succeeds or is a
+        no-op. Implementations may raise on failure; the matrix setup gate
+        records the failure and blocks all model-backed work.
         """
         ...
 

--- a/benchmarks/codegraph_compare/adapters/claude_runner.py
+++ b/benchmarks/codegraph_compare/adapters/claude_runner.py
@@ -343,6 +343,7 @@ def _build_agent_cmd(
     agent_backend: str,
 ) -> list[str]:
     """Build the CLI command list for the given agent backend."""
+    validate_backend_arm_support(agent_backend, arm_id)
     if agent_backend == "claude":
         cmd = [
             "claude",
@@ -374,14 +375,6 @@ def _build_agent_cmd(
     # TSA-vs-CodeGraph comparison. Fail loudly rather than emit wrong numbers
     # (Codex P2 on #290). Use --agent-backend claude for MCP arms until codex
     # MCP wiring (codex -c mcp_servers.*) is implemented and verified.
-    if arm_id.startswith(("tsa", "codegraph")):
-        raise NotImplementedError(
-            f"Per-arm MCP isolation is not wired for the codex backend, but arm "
-            f"{arm_id!r} requires its own MCP server. Running `codex exec` here "
-            f"would miss the server or inherit the global ~/.codex MCP config, "
-            f"invalidating the comparison. Use --agent-backend claude for MCP "
-            f"arms, or wire `codex -c mcp_servers.*` before enabling this path."
-        )
     sandbox = _codex_sandbox_for_arm(arm_id)
     return [
         "codex",
@@ -398,6 +391,21 @@ def _build_agent_cmd(
         str(repo_path),
         "-",
     ]
+
+
+def validate_backend_arm_support(agent_backend: str, arm_id: str) -> None:
+    """Reject backend/arm combinations that cannot run a valid trial."""
+
+    if agent_backend not in {"claude", "codex"}:
+        raise ValueError("agent_backend must be one of: claude, codex")
+    if agent_backend == "codex" and arm_id.startswith(("tsa", "codegraph")):
+        raise NotImplementedError(
+            f"Per-arm MCP isolation is not wired for the codex backend, but arm "
+            f"{arm_id!r} requires its own MCP server. Running `codex exec` here "
+            f"would miss the server or inherit the global ~/.codex MCP config, "
+            f"invalidating the comparison. Use --agent-backend claude for MCP "
+            f"arms, or wire `codex -c mcp_servers.*` before enabling this path."
+        )
 
 
 def _usage_int(usage: dict[str, Any], key: str) -> int:

--- a/benchmarks/codegraph_compare/adapters/codegraph.py
+++ b/benchmarks/codegraph_compare/adapters/codegraph.py
@@ -7,7 +7,7 @@ Supports two modes:
 Index build is done via ``codegraph init -i`` with cwd=repo_path.
 The ``-i`` flag is a no-op since v1.4.x (indexing runs by default); it is kept for
 backward compatibility so older CodeGraph versions still work.
-Errors are logged, not raised, so the harness can continue with partial data.
+Preparation errors raise so the matrix setup gate can block model-backed work.
 
 Install:
     npm install -g @colbymchenry/codegraph   # confirmed: v1.4.1, 2026-07-12
@@ -18,6 +18,7 @@ from __future__ import annotations
 import logging
 import re
 import shutil
+import sqlite3
 import subprocess
 import time
 from pathlib import Path
@@ -54,6 +55,7 @@ _PROMPT_FILE = _PROMPTS_DIR / "system_codegraph.md"
 # ---------------------------------------------------------------------------
 
 _INDEX_DIR = ".codegraph"
+_INDEX_DB = "codegraph.db"
 
 # Tools Claude is allowed to call in this arm
 _ALLOWED_TOOLS = [
@@ -108,20 +110,25 @@ class CodeGraphAdapter(BenchmarkAdapter):
             _delete_index(index_dir)
             return _build_index(repo_path, index_dir)
 
-        # Warm path — rebuild only if absent
-        if not index_dir.exists():
+        # Warm path — only a queryable DB with indexed source paths is ready.
+        index_db = index_dir / _INDEX_DB
+        indexed_files = _indexed_source_file_count(index_db)
+        if indexed_files is None or indexed_files <= 0:
             logger.info(
-                "CodeGraph index not found at %s; running cold build.", index_dir
+                "CodeGraph index missing, unreadable, or empty at %s; rebuilding.",
+                index_db,
             )
+            _delete_index(index_dir)
             return _build_index(repo_path, index_dir)
 
         logger.info(
-            "CodeGraph index exists at %s; warm path — skipping build.", index_dir
+            "CodeGraph index at %s has %d source files; warm path — skipping build.",
+            index_db,
+            indexed_files,
         )
         size = _dir_size(index_dir)
-        file_count = _count_files(index_dir)
         return IndexStats(
-            build_seconds=0.0, index_size_bytes=size, file_count=file_count
+            build_seconds=0.0, index_size_bytes=size, file_count=indexed_files
         )
 
     # ------------------------------------------------------------------
@@ -207,6 +214,7 @@ def _delete_index(index_dir: Path) -> None:
             shutil.rmtree(index_dir)
         except OSError as exc:
             logger.error("Failed to delete %s: %s", index_dir, exc)
+            raise RuntimeError(f"failed to delete CodeGraph index: {exc}") from exc
 
 
 def _build_index(repo_path: Path, index_dir: Path) -> IndexStats:
@@ -231,9 +239,14 @@ def _build_index(repo_path: Path, index_dir: Path) -> IndexStats:
             result.returncode,
             result.stderr[:2000],
         )
+        raise RuntimeError(
+            f"codegraph init -i exited with code {result.returncode}: "
+            f"{result.stderr[:500]}"
+        )
 
     size = _dir_size(index_dir) if index_dir.exists() else 0
-    file_count = _count_files(index_dir) if index_dir.exists() else 0
+    indexed_files = _indexed_source_file_count(index_dir / _INDEX_DB)
+    file_count = indexed_files if indexed_files is not None else 0
 
     logger.info(
         "CodeGraph index built in %.2fs, size=%d bytes, files=%d",
@@ -255,11 +268,21 @@ def _dir_size(path: Path) -> int:
     return sum(f.stat().st_size for f in path.rglob("*") if f.is_file())
 
 
-def _count_files(path: Path) -> int:
-    """Return the number of files under *path*."""
-    if not path.exists():
-        return 0
-    return sum(1 for f in path.rglob("*") if f.is_file())
+def _indexed_source_file_count(index_db: Path) -> int | None:
+    """Return distinct indexed source paths, or None for an invalid database."""
+
+    try:
+        conn = sqlite3.connect(f"file:{index_db}?mode=ro", uri=True)
+        try:
+            row = conn.execute(
+                "SELECT COUNT(DISTINCT file_path) FROM nodes "
+                "WHERE file_path IS NOT NULL AND file_path <> ''"
+            ).fetchone()
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return None
+    return int(row[0]) if row else None
 
 
 def _load_prompt(prompt_file: Path, default: str) -> str:

--- a/benchmarks/codegraph_compare/adapters/tree_sitter_analyzer.py
+++ b/benchmarks/codegraph_compare/adapters/tree_sitter_analyzer.py
@@ -221,6 +221,7 @@ def _delete_cache(cache_dir: Path) -> None:
             shutil.rmtree(cache_dir)
         except OSError as exc:
             logger.error("Failed to delete %s: %s", cache_dir, exc)
+            raise RuntimeError(f"failed to delete TSA cache: {exc}") from exc
 
 
 def _build_cache(repo_path: Path, cache_dir: Path) -> IndexStats:
@@ -261,12 +262,15 @@ def _build_cache(repo_path: Path, cache_dir: Path) -> IndexStats:
             result.returncode,
             result.stderr[:2000],
         )
+        raise RuntimeError(
+            f"tree_sitter_analyzer exited with code {result.returncode}: "
+            f"{result.stderr[:500]}"
+        )
 
     size = _dir_size(cache_dir) if cache_dir.exists() else 0
     index_db = cache_dir / "index.db"
-    file_count = _indexed_file_count(index_db) or (
-        _count_files(cache_dir) if cache_dir.exists() else 0
-    )
+    indexed_file_count = _indexed_file_count(index_db)
+    file_count = indexed_file_count if indexed_file_count is not None else 0
 
     logger.info(
         "TSA cache built in %.2fs, size=%d bytes, files=%d",
@@ -286,13 +290,6 @@ def _dir_size(path: Path) -> int:
     if not path.exists():
         return 0
     return sum(f.stat().st_size for f in path.rglob("*") if f.is_file())
-
-
-def _count_files(path: Path) -> int:
-    """Return the number of files under *path*."""
-    if not path.exists():
-        return 0
-    return sum(1 for f in path.rglob("*") if f.is_file())
 
 
 def _indexed_file_count(index_db: Path) -> int | None:

--- a/benchmarks/codegraph_compare/run.py
+++ b/benchmarks/codegraph_compare/run.py
@@ -34,7 +34,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import NoReturn
+from typing import Any, NoReturn
 
 # ---------------------------------------------------------------------------
 # Path constants  (all relative to this file so the harness is portable)
@@ -438,6 +438,52 @@ def cmd_run_matrix(args: argparse.Namespace) -> int:
         )
         for repo_entry in repo_entries
     }
+
+    prepared_adapters: dict[tuple[str, str], Any] = {}
+    prepared_run_configs: dict[tuple[str, str, str], Any] = {}
+    if not args.dry_run:
+        try:
+            from benchmarks.codegraph_compare.setup_validation import (  # noqa: PLC0415
+                validate_matrix_setup,
+                write_setup_failure_evidence,
+            )
+        except ImportError:
+            import importlib  # noqa: PLC0415
+
+            setup_validation = importlib.import_module("setup_validation")
+            validate_matrix_setup = setup_validation.validate_matrix_setup
+            write_setup_failure_evidence = (
+                setup_validation.write_setup_failure_evidence
+            )
+
+        setup_result = validate_matrix_setup(
+            repo_entries,
+            arm_entries,
+            questions_by_repo=question_entries_by_repo,
+            repo_path_resolver=_repo_local_path,
+            adapter_factory=get_adapter,
+        )
+        if not setup_result.ok:
+            evidence_path = write_setup_failure_evidence(
+                RESULTS_DIR,
+                session_id=session_id,
+                result=setup_result,
+            )
+            print(
+                f"[setup] FAILED: {len(setup_result.failures)} indexed cell(s); "
+                "no model calls started.",
+                file=sys.stderr,
+            )
+            for failure in setup_result.failures:
+                print(
+                    f"  repo={failure.repo_id}  arm={failure.arm_id}  "
+                    f"{failure.code}: {failure.message}",
+                    file=sys.stderr,
+                )
+            print(f"Setup evidence: {evidence_path}", file=sys.stderr)
+            return 1
+        prepared_adapters = setup_result.prepared_adapters
+        prepared_run_configs = setup_result.prepared_run_configs
     total = (
         sum(len(items) for items in question_entries_by_repo.values())
         * len(arm_entries)
@@ -457,17 +503,13 @@ def cmd_run_matrix(args: argparse.Namespace) -> int:
 
         for arm_entry in arm_entries:
             arm_id: str = arm_entry["id"]
-            index_mode: str = arm_entry.get("index_mode", "warm")
-            cold = index_mode == "cold"
 
-            adapter = get_adapter(arm_id)
+            adapter = prepared_adapters.get((repo_id, arm_id)) or get_adapter(arm_id)
             if args.dry_run:
                 print(
                     f"[prepare] skipped dry-run  arm={arm_id}  repo={repo_id}",
                     file=sys.stderr,
                 )
-            else:
-                adapter.prepare_index(repo_path, cold=cold)
             run_config_cache: dict = {}
 
             for question_entry in question_entries:
@@ -475,8 +517,10 @@ def cmd_run_matrix(args: argparse.Namespace) -> int:
                 question_prompt: str = question_entry["prompt"]
 
                 if question_id not in run_config_cache:
-                    run_config_cache[question_id] = adapter.build_run_config(
-                        repo_path, question_prompt
+                    run_config_cache[question_id] = (
+                        adapter.build_run_config(repo_path, question_prompt)
+                        if args.dry_run
+                        else prepared_run_configs[(repo_id, arm_id, question_id)]
                     )
                 run_config = run_config_cache[question_id]
 

--- a/benchmarks/codegraph_compare/run.py
+++ b/benchmarks/codegraph_compare/run.py
@@ -332,6 +332,17 @@ def cmd_run(args: argparse.Namespace) -> int:
 
     adapter = get_adapter(arm_id)
 
+    try:
+        from adapters.claude_runner import (  # noqa: PLC0415
+            validate_backend_arm_support,
+        )
+    except ImportError:
+        _die("Could not import adapters.claude_runner.")
+    try:
+        validate_backend_arm_support(args.agent_backend, arm_id)
+    except (ValueError, NotImplementedError) as exc:
+        _die(str(exc))
+
     # Prepare index (warm by default unless index_mode says cold)
     index_mode: str = arm_entry.get("index_mode", "warm")
     cold = index_mode == "cold"
@@ -422,7 +433,10 @@ def cmd_run_matrix(args: argparse.Namespace) -> int:
     # Lazy imports
     try:
         from adapters import get_adapter  # noqa: PLC0415
-        from adapters.claude_runner import run_one  # noqa: PLC0415
+        from adapters.claude_runner import (  # noqa: PLC0415
+            run_one,
+            validate_backend_arm_support,
+        )
     except ImportError:
         _die("Could not import adapters or adapters.claude_runner.")
 
@@ -462,6 +476,9 @@ def cmd_run_matrix(args: argparse.Namespace) -> int:
             questions_by_repo=question_entries_by_repo,
             repo_path_resolver=_repo_local_path,
             adapter_factory=get_adapter,
+            backend_validator=lambda arm_id: validate_backend_arm_support(
+                args.agent_backend, arm_id
+            ),
         )
         if not setup_result.ok:
             evidence_path = write_setup_failure_evidence(

--- a/benchmarks/codegraph_compare/setup_validation.py
+++ b/benchmarks/codegraph_compare/setup_validation.py
@@ -1,0 +1,228 @@
+"""Fail-closed, model-free setup validation for benchmark matrices.
+
+This module intentionally validates only the runner's basic index-readiness
+boundary. Manifest provenance, exact source partitions, and known-answer query
+checks are separate RFC-0021 slices and can extend this boundary without
+changing the rule that every selected indexed cell is checked first.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, cast
+
+
+@dataclass(frozen=True)
+class SetupFailure:
+    """One repository/arm setup failure that blocks model-backed work."""
+
+    repo_id: str
+    arm_id: str
+    index_mode: str
+    code: str
+    message: str
+    question_id: str | None = None
+
+
+@dataclass(frozen=True)
+class SetupValidationResult:
+    """Collected setup outcome plus prepared adapters for later execution."""
+
+    failures: tuple[SetupFailure, ...]
+    prepared_adapters: dict[tuple[str, str], Any]
+    prepared_run_configs: dict[tuple[str, str, str], Any]
+
+    @property
+    def ok(self) -> bool:
+        return not self.failures
+
+
+@dataclass(frozen=True)
+class _PreparedCell:
+    repo_id: str
+    arm_id: str
+    index_mode: str
+    repo_path: Path
+    adapter: Any
+
+
+def validate_matrix_setup(
+    repo_entries: Sequence[dict],
+    arm_entries: Sequence[dict],
+    *,
+    questions_by_repo: Mapping[str, Sequence[dict]],
+    repo_path_resolver: Callable[[dict], Path],
+    adapter_factory: Callable[[str], Any],
+) -> SetupValidationResult:
+    """Prepare every indexed repo/arm cell and collect all basic failures.
+
+    Native/no-index arms skip index preparation but still validate their run
+    configuration. Indexed arms must return a positive source-file count.
+    """
+
+    failures: list[SetupFailure] = []
+    prepared_adapters: dict[tuple[str, str], Any] = {}
+    prepared_run_configs: dict[tuple[str, str, str], Any] = {}
+
+    for repo_entry in repo_entries:
+        for arm_entry in arm_entries:
+            cell, failure = _prepare_cell(
+                repo_entry,
+                arm_entry,
+                repo_path_resolver=repo_path_resolver,
+                adapter_factory=adapter_factory,
+            )
+            if failure is not None:
+                failures.append(failure)
+                continue
+            cell = cast(_PreparedCell, cell)
+
+            configs, config_failures = _build_run_configs(
+                cell, questions_by_repo.get(cell.repo_id, ())
+            )
+            prepared_run_configs.update(configs)
+            failures.extend(config_failures)
+            if not config_failures:
+                prepared_adapters[(cell.repo_id, cell.arm_id)] = cell.adapter
+
+    return SetupValidationResult(
+        tuple(failures), prepared_adapters, prepared_run_configs
+    )
+
+
+def _prepare_cell(
+    repo_entry: dict,
+    arm_entry: dict,
+    *,
+    repo_path_resolver: Callable[[dict], Path],
+    adapter_factory: Callable[[str], Any],
+) -> tuple[_PreparedCell | None, SetupFailure | None]:
+    repo_id = str(repo_entry["id"])
+    arm_id = str(arm_entry["id"])
+    index_mode = str(arm_entry.get("index_mode", "warm"))
+    if index_mode not in {"none", "warm", "cold"}:
+        return None, _failure(
+            repo_id, arm_id, index_mode, "INVALID_INDEX_MODE",
+            f"unsupported index_mode: {index_mode}",
+        )
+
+    try:
+        repo_path = repo_path_resolver(repo_entry)
+        adapter = adapter_factory(arm_id)
+        stats = (
+            adapter.prepare_index(repo_path, cold=index_mode == "cold")
+            if index_mode != "none"
+            else None
+        )
+    except Exception as exc:  # noqa: BLE001 - evidence must capture every arm
+        return None, _failure(
+            repo_id, arm_id, index_mode, "PREPARE_EXCEPTION", str(exc)
+        )
+
+    stats_failure = _validate_index_stats(repo_id, arm_id, index_mode, stats)
+    if stats_failure is not None:
+        return None, stats_failure
+    return _PreparedCell(repo_id, arm_id, index_mode, repo_path, adapter), None
+
+
+def _validate_index_stats(
+    repo_id: str, arm_id: str, index_mode: str, stats: Any
+) -> SetupFailure | None:
+    if index_mode == "none":
+        return None
+    file_count = getattr(stats, "file_count", None)
+    if isinstance(file_count, bool) or not isinstance(file_count, int):
+        return _failure(
+            repo_id,
+            arm_id,
+            index_mode,
+            "INVALID_INDEX_STATS",
+            "index preparation returned invalid file_count",
+        )
+    if file_count <= 0:
+        return _failure(
+            repo_id,
+            arm_id,
+            index_mode,
+            "EMPTY_INDEX",
+            "index preparation returned zero indexed files",
+        )
+    return None
+
+
+def _build_run_configs(
+    cell: _PreparedCell, question_entries: Sequence[dict]
+) -> tuple[dict[tuple[str, str, str], Any], tuple[SetupFailure, ...]]:
+    configs: dict[tuple[str, str, str], Any] = {}
+    failures: list[SetupFailure] = []
+    for question_entry in question_entries:
+        question_id = str(question_entry["id"])
+        try:
+            config = cell.adapter.build_run_config(
+                cell.repo_path, str(question_entry["prompt"])
+            )
+        except Exception as exc:  # noqa: BLE001 - collect later cells too
+            failures.append(
+                _failure(
+                    cell.repo_id,
+                    cell.arm_id,
+                    cell.index_mode,
+                    "RUN_CONFIG_EXCEPTION",
+                    str(exc),
+                    question_id=question_id,
+                )
+            )
+            continue
+        configs[(cell.repo_id, cell.arm_id, question_id)] = config
+    return configs, tuple(failures)
+
+
+def _failure(
+    repo_id: str,
+    arm_id: str,
+    index_mode: str,
+    code: str,
+    message: str,
+    *,
+    question_id: str | None = None,
+) -> SetupFailure:
+    return SetupFailure(
+        repo_id=repo_id,
+        arm_id=arm_id,
+        index_mode=index_mode,
+        code=code,
+        message=message,
+        question_id=question_id,
+    )
+
+
+def write_setup_failure_evidence(
+    results_dir: Path,
+    *,
+    session_id: str,
+    result: SetupValidationResult,
+) -> Path:
+    """Persist session-scoped failure evidence without overwriting history."""
+
+    if result.ok:
+        raise ValueError("setup failure evidence requires at least one failure")
+
+    results_dir.mkdir(parents=True, exist_ok=True)
+    path = results_dir / f"setup_failures_{session_id}.json"
+    payload = {
+        "schema_version": 1,
+        "session_id": session_id,
+        "status": "setup_failed",
+        "model_calls_started": 0,
+        "failures": [
+            {key: value for key, value in asdict(failure).items() if value is not None}
+            for failure in result.failures
+        ],
+    }
+    with path.open("x", encoding="utf-8") as stream:
+        json.dump(payload, stream, indent=2, sort_keys=True)
+        stream.write("\n")
+    return path

--- a/benchmarks/codegraph_compare/setup_validation.py
+++ b/benchmarks/codegraph_compare/setup_validation.py
@@ -56,6 +56,7 @@ def validate_matrix_setup(
     questions_by_repo: Mapping[str, Sequence[dict]],
     repo_path_resolver: Callable[[dict], Path],
     adapter_factory: Callable[[str], Any],
+    backend_validator: Callable[[str], None] | None = None,
 ) -> SetupValidationResult:
     """Prepare every indexed repo/arm cell and collect all basic failures.
 
@@ -74,6 +75,7 @@ def validate_matrix_setup(
                 arm_entry,
                 repo_path_resolver=repo_path_resolver,
                 adapter_factory=adapter_factory,
+                backend_validator=backend_validator,
             )
             if failure is not None:
                 failures.append(failure)
@@ -99,6 +101,7 @@ def _prepare_cell(
     *,
     repo_path_resolver: Callable[[dict], Path],
     adapter_factory: Callable[[str], Any],
+    backend_validator: Callable[[str], None] | None,
 ) -> tuple[_PreparedCell | None, SetupFailure | None]:
     repo_id = str(repo_entry["id"])
     arm_id = str(arm_entry["id"])
@@ -108,6 +111,18 @@ def _prepare_cell(
             repo_id, arm_id, index_mode, "INVALID_INDEX_MODE",
             f"unsupported index_mode: {index_mode}",
         )
+
+    if backend_validator is not None:
+        try:
+            backend_validator(arm_id)
+        except Exception as exc:  # noqa: BLE001 - persist unsupported combinations
+            return None, _failure(
+                repo_id,
+                arm_id,
+                index_mode,
+                "BACKEND_UNSUPPORTED",
+                str(exc),
+            )
 
     try:
         repo_path = repo_path_resolver(repo_entry)

--- a/tests/unit/test_benchmark_harness.py
+++ b/tests/unit/test_benchmark_harness.py
@@ -519,13 +519,18 @@ class TestCodeGraphCompareSetupGate:
         return repos, arms, questions
 
     @staticmethod
-    def _install_runner_modules(monkeypatch, get_adapter, run_one) -> None:
+    def _install_runner_modules(
+        monkeypatch, get_adapter, run_one, validate_backend=None
+    ) -> None:
         from types import ModuleType
 
         adapters_module = ModuleType("adapters")
         adapters_module.get_adapter = get_adapter
         runner_module = ModuleType("adapters.claude_runner")
         runner_module.run_one = run_one
+        runner_module.validate_backend_arm_support = validate_backend or (
+            lambda agent_backend, arm_id: None
+        )
         monkeypatch.setitem(sys.modules, "adapters", adapters_module)
         monkeypatch.setitem(sys.modules, "adapters.claude_runner", runner_module)
 
@@ -744,6 +749,70 @@ class TestCodeGraphCompareSetupGate:
             "INVALID_INDEX_MODE",
             "INVALID_INDEX_STATS",
         ]
+
+    def test_unsupported_backend_arms_block_native_model_before_index_setup(
+        self, monkeypatch, tmp_path: Path
+    ):
+        from benchmarks.codegraph_compare.adapters import RunConfig
+
+        events: list[str] = []
+
+        class Adapter:
+            def __init__(self, arm_id: str) -> None:
+                self.arm_id = arm_id
+
+            def prepare_index(self, repo_path: Path, cold: bool) -> IndexStats:
+                events.append(f"prepare:{self.arm_id}")
+                return IndexStats(0.1, 100, 2)
+
+            def build_run_config(self, repo_path: Path, prompt: str) -> RunConfig:
+                return RunConfig(self.arm_id, repo_path, "system")
+
+        def validate_backend(agent_backend: str, arm_id: str) -> None:
+            events.append(f"validate:{agent_backend}:{arm_id}")
+            if agent_backend == "codex" and arm_id != "native-only":
+                raise NotImplementedError(f"codex does not support {arm_id}")
+
+        def run_one(**kwargs):
+            events.append(f"model:{kwargs['arm_id']}")
+            raise AssertionError("model call must remain unreachable")
+
+        self._patch_matrix_inputs(monkeypatch, tmp_path)
+        self._install_runner_modules(
+            monkeypatch, Adapter, run_one, validate_backend=validate_backend
+        )
+
+        assert compare_run.cmd_run_matrix(self._matrix_args()) == 1
+        assert events == [
+            "validate:codex:native-only",
+            "validate:codex:codegraph-warm",
+            "validate:codex:tsa-warm",
+        ]
+        evidence_path = next(
+            (tmp_path / "results").glob("setup_failures_*.json")
+        )
+        evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
+        assert [item["code"] for item in evidence["failures"]] == [
+            "BACKEND_UNSUPPORTED",
+            "BACKEND_UNSUPPORTED",
+        ]
+
+    @pytest.mark.parametrize("arm_id", ("codegraph-warm", "tsa-warm"))
+    def test_codex_backend_validator_rejects_indexed_mcp_arms(self, arm_id: str):
+        from benchmarks.codegraph_compare.adapters.claude_runner import (
+            validate_backend_arm_support,
+        )
+
+        with pytest.raises(NotImplementedError, match="Per-arm MCP isolation"):
+            validate_backend_arm_support("codex", arm_id)
+
+    def test_backend_validator_allows_supported_combinations(self):
+        from benchmarks.codegraph_compare.adapters.claude_runner import (
+            validate_backend_arm_support,
+        )
+
+        validate_backend_arm_support("codex", "native-only")
+        validate_backend_arm_support("claude", "tsa-warm")
 
 
 class TestCodeGraphCompareAnalysisGate:

--- a/tests/unit/test_benchmark_harness.py
+++ b/tests/unit/test_benchmark_harness.py
@@ -242,6 +242,106 @@ class TestCodeGraphCompareTSAAdapter:
         assert result.file_count == 1
         build_cache.assert_not_called()
 
+    def test_failed_tsa_index_command_raises_instead_of_counting_cache_files(
+        self, tmp_path: Path
+    ):
+        from benchmarks.codegraph_compare.adapters.tree_sitter_analyzer import (
+            _build_cache,
+        )
+
+        cache_dir = tmp_path / ".ast-cache"
+        cache_dir.mkdir()
+        (cache_dir / "stale-metadata.json").write_text("{}", encoding="utf-8")
+        with patch(
+            "benchmarks.codegraph_compare.adapters.tree_sitter_analyzer.subprocess.run",
+            return_value=SimpleNamespace(returncode=2, stderr="index failed"),
+        ):
+            with pytest.raises(RuntimeError, match="exited with code 2"):
+                _build_cache(tmp_path, cache_dir)
+
+    def test_successful_tsa_command_does_not_count_metadata_as_indexed_source(
+        self, tmp_path: Path
+    ):
+        from benchmarks.codegraph_compare.adapters.tree_sitter_analyzer import (
+            _build_cache,
+        )
+
+        cache_dir = tmp_path / ".ast-cache"
+        cache_dir.mkdir()
+        index_db = cache_dir / "index.db"
+        conn = sqlite3.connect(index_db)
+        conn.execute("CREATE TABLE ast_index (file_path TEXT)")
+        conn.commit()
+        conn.close()
+        (cache_dir / "metadata.json").write_text("{}", encoding="utf-8")
+
+        with patch(
+            "benchmarks.codegraph_compare.adapters.tree_sitter_analyzer.subprocess.run",
+            return_value=SimpleNamespace(returncode=0, stderr=""),
+        ):
+            stats = _build_cache(tmp_path, cache_dir)
+
+        assert stats.file_count == 0
+
+    def test_failed_codegraph_index_command_raises_before_stale_files_count(
+        self, tmp_path: Path
+    ):
+        from benchmarks.codegraph_compare.adapters.codegraph import _build_index
+
+        index_dir = tmp_path / ".codegraph"
+        index_dir.mkdir()
+        (index_dir / "stale.json").write_text("{}", encoding="utf-8")
+        with patch(
+            "benchmarks.codegraph_compare.adapters.codegraph.subprocess.run",
+            return_value=SimpleNamespace(returncode=3, stderr="codegraph failed"),
+        ):
+            with pytest.raises(RuntimeError, match="exited with code 3"):
+                _build_index(tmp_path, index_dir)
+
+    def test_codegraph_warm_rebuilds_stale_directory_without_valid_db(
+        self, tmp_path: Path
+    ):
+        from benchmarks.codegraph_compare.adapters.codegraph import CodeGraphAdapter
+
+        index_dir = tmp_path / ".codegraph"
+        index_dir.mkdir()
+        (index_dir / "stale.json").write_text("{}", encoding="utf-8")
+        expected = IndexStats(1.0, 200, 3)
+
+        with patch(
+            "benchmarks.codegraph_compare.adapters.codegraph._build_index",
+            return_value=expected,
+        ) as build_index:
+            result = CodeGraphAdapter().prepare_index(tmp_path, cold=False)
+
+        assert result == expected
+        assert not (index_dir / "stale.json").exists()
+        build_index.assert_called_once_with(tmp_path, index_dir)
+
+    def test_codegraph_warm_counts_distinct_source_paths_from_database(
+        self, tmp_path: Path
+    ):
+        from benchmarks.codegraph_compare.adapters.codegraph import CodeGraphAdapter
+
+        index_dir = tmp_path / ".codegraph"
+        index_dir.mkdir()
+        conn = sqlite3.connect(index_dir / "codegraph.db")
+        conn.execute("CREATE TABLE nodes (file_path TEXT)")
+        conn.executemany(
+            "INSERT INTO nodes VALUES (?)",
+            [("src/a.py",), ("src/a.py",), ("src/b.py",)],
+        )
+        conn.commit()
+        conn.close()
+
+        with patch(
+            "benchmarks.codegraph_compare.adapters.codegraph._build_index"
+        ) as build_index:
+            result = CodeGraphAdapter().prepare_index(tmp_path, cold=False)
+
+        assert result.file_count == 2
+        build_index.assert_not_called()
+
     def test_parse_tool_metrics_counts_mcp_calls_as_index_queries(self):
         # The TSA arm now runs through its MCP facade tools (not the CLI), so
         # mcp__tree-sitter-analyzer__* calls count as index queries, Bash as
@@ -383,6 +483,267 @@ class TestCodeGraphComparePhases:
 
         with pytest.raises(SystemExit):
             compare_run._phase_to_matrix_args(args)
+
+
+class TestCodeGraphCompareSetupGate:
+    """Model-backed matrix work must be fail-closed behind setup validation."""
+
+    @staticmethod
+    def _matrix_args() -> SimpleNamespace:
+        return SimpleNamespace(
+            repos="all",
+            arms="all",
+            repeats=1,
+            question_limit=None,
+            dry_run=False,
+            agent_backend="codex",
+            model="gpt-5",
+            timeout_seconds=1200,
+        )
+
+    @staticmethod
+    def _matrix_configs(repo_path: Path) -> tuple[list[dict], list[dict], list[dict]]:
+        repos = [{"id": "demo", "local_path": str(repo_path)}]
+        arms = [
+            {"id": "native-only", "index_mode": "none"},
+            {"id": "codegraph-warm", "index_mode": "warm"},
+            {"id": "tsa-warm", "index_mode": "warm"},
+        ]
+        questions = [
+            {
+                "id": "demo-q1",
+                "repo": "demo",
+                "prompt": "Where is the entry point?",
+            }
+        ]
+        return repos, arms, questions
+
+    @staticmethod
+    def _install_runner_modules(monkeypatch, get_adapter, run_one) -> None:
+        from types import ModuleType
+
+        adapters_module = ModuleType("adapters")
+        adapters_module.get_adapter = get_adapter
+        runner_module = ModuleType("adapters.claude_runner")
+        runner_module.run_one = run_one
+        monkeypatch.setitem(sys.modules, "adapters", adapters_module)
+        monkeypatch.setitem(sys.modules, "adapters.claude_runner", runner_module)
+
+    @staticmethod
+    def _patch_matrix_inputs(monkeypatch, tmp_path: Path) -> None:
+        repos, arms, questions = TestCodeGraphCompareSetupGate._matrix_configs(
+            tmp_path
+        )
+        configs = {
+            compare_run.REPOS_YAML: repos,
+            compare_run.ARMS_YAML: arms,
+            compare_run.QUESTIONS_YAML: questions,
+        }
+        monkeypatch.setattr(compare_run, "_load_yaml", configs.__getitem__)
+        monkeypatch.setattr(
+            compare_run, "_repo_local_path", lambda repo: Path(repo["local_path"])
+        )
+        monkeypatch.setattr(compare_run, "RESULTS_DIR", tmp_path / "results")
+
+    def test_setup_failure_checks_all_indexed_arms_and_blocks_model_calls(
+        self, monkeypatch, tmp_path: Path
+    ):
+        from benchmarks.codegraph_compare.adapters import RunConfig
+
+        events: list[str] = []
+
+        class Adapter:
+            def __init__(self, arm_id: str) -> None:
+                self.arm_id = arm_id
+
+            def prepare_index(self, repo_path: Path, cold: bool) -> IndexStats:
+                events.append(f"prepare:{self.arm_id}")
+                if self.arm_id == "codegraph-warm":
+                    raise RuntimeError("codegraph executable missing")
+                if self.arm_id == "tsa-warm":
+                    return IndexStats(0.1, 0, 0)
+                return IndexStats(0.1, 100, 2)
+
+            def build_run_config(self, repo_path: Path, prompt: str) -> RunConfig:
+                return RunConfig(self.arm_id, repo_path, "system")
+
+        def run_one(**kwargs):
+            events.append(f"model:{kwargs['arm_id']}")
+            raise AssertionError("model call must remain unreachable")
+
+        self._patch_matrix_inputs(monkeypatch, tmp_path)
+        self._install_runner_modules(monkeypatch, Adapter, run_one)
+
+        exit_code = compare_run.cmd_run_matrix(self._matrix_args())
+
+        assert exit_code == 1
+        assert events == ["prepare:codegraph-warm", "prepare:tsa-warm"]
+        evidence_files = list((tmp_path / "results").glob("setup_failures_*.json"))
+        assert len(evidence_files) == 1
+        evidence = json.loads(evidence_files[0].read_text(encoding="utf-8"))
+        assert evidence["status"] == "setup_failed"
+        assert evidence["model_calls_started"] == 0
+        assert evidence["failures"] == [
+            {
+                "arm_id": "codegraph-warm",
+                "code": "PREPARE_EXCEPTION",
+                "index_mode": "warm",
+                "message": "codegraph executable missing",
+                "repo_id": "demo",
+            },
+            {
+                "arm_id": "tsa-warm",
+                "code": "EMPTY_INDEX",
+                "index_mode": "warm",
+                "message": "index preparation returned zero indexed files",
+                "repo_id": "demo",
+            },
+        ]
+
+    def test_all_indexed_setup_finishes_before_first_model_call(
+        self, monkeypatch, tmp_path: Path
+    ):
+        from benchmarks.codegraph_compare.adapters import RunConfig
+
+        events: list[str] = []
+
+        class Adapter:
+            def __init__(self, arm_id: str) -> None:
+                self.arm_id = arm_id
+
+            def prepare_index(self, repo_path: Path, cold: bool) -> IndexStats:
+                events.append(f"prepare:{self.arm_id}")
+                return IndexStats(0.1, 100, 2)
+
+            def build_run_config(self, repo_path: Path, prompt: str) -> RunConfig:
+                events.append(f"config:{self.arm_id}")
+                return RunConfig(self.arm_id, repo_path, "system")
+
+        def run_one(**kwargs):
+            events.append(f"model:{kwargs['arm_id']}")
+            return {
+                "answer": "ok",
+                "elapsed_seconds": 0.1,
+            }
+
+        self._patch_matrix_inputs(monkeypatch, tmp_path)
+        self._install_runner_modules(monkeypatch, Adapter, run_one)
+
+        exit_code = compare_run.cmd_run_matrix(self._matrix_args())
+
+        assert exit_code == 0
+        first_model = next(i for i, event in enumerate(events) if event.startswith("model:"))
+        assert events[:first_model] == [
+            "config:native-only",
+            "prepare:codegraph-warm",
+            "config:codegraph-warm",
+            "prepare:tsa-warm",
+            "config:tsa-warm",
+        ]
+        assert events.count("prepare:codegraph-warm") == 1
+        assert events.count("prepare:tsa-warm") == 1
+
+    def test_dry_run_preserves_stub_execution_without_index_setup(
+        self, monkeypatch, tmp_path: Path
+    ):
+        from benchmarks.codegraph_compare.adapters import RunConfig
+
+        dry_run_calls: list[bool] = []
+
+        class Adapter:
+            def __init__(self, arm_id: str) -> None:
+                self.arm_id = arm_id
+
+            def prepare_index(self, repo_path: Path, cold: bool) -> IndexStats:
+                raise AssertionError("dry-run must not prepare indexes")
+
+            def build_run_config(self, repo_path: Path, prompt: str) -> RunConfig:
+                return RunConfig(self.arm_id, repo_path, "system")
+
+        def run_one(**kwargs):
+            dry_run_calls.append(kwargs["dry_run"])
+            return {"answer": "DRY_RUN", "elapsed_seconds": 0.0}
+
+        self._patch_matrix_inputs(monkeypatch, tmp_path)
+        self._install_runner_modules(monkeypatch, Adapter, run_one)
+        args = self._matrix_args()
+        args.dry_run = True
+
+        exit_code = compare_run.cmd_run_matrix(args)
+
+        assert exit_code == 0
+        assert dry_run_calls == [True, True, True]
+        assert not list((tmp_path / "results").glob("setup_failures_*.json"))
+
+    def test_run_config_failure_is_collected_before_model_execution(
+        self, monkeypatch, tmp_path: Path
+    ):
+        from benchmarks.codegraph_compare.adapters import RunConfig
+
+        model_calls = 0
+
+        class Adapter:
+            def __init__(self, arm_id: str) -> None:
+                self.arm_id = arm_id
+
+            def prepare_index(self, repo_path: Path, cold: bool) -> IndexStats:
+                return IndexStats(0.1, 100, 2)
+
+            def build_run_config(self, repo_path: Path, prompt: str) -> RunConfig:
+                if self.arm_id == "tsa-warm":
+                    raise RuntimeError("prompt unavailable")
+                return RunConfig(self.arm_id, repo_path, "system")
+
+        def run_one(**kwargs):
+            nonlocal model_calls
+            model_calls += 1
+            raise AssertionError("model call must remain unreachable")
+
+        self._patch_matrix_inputs(monkeypatch, tmp_path)
+        self._install_runner_modules(monkeypatch, Adapter, run_one)
+
+        assert compare_run.cmd_run_matrix(self._matrix_args()) == 1
+        assert model_calls == 0
+        evidence_path = next(
+            (tmp_path / "results").glob("setup_failures_*.json")
+        )
+        evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
+        assert evidence["failures"] == [
+            {
+                "arm_id": "tsa-warm",
+                "code": "RUN_CONFIG_EXCEPTION",
+                "index_mode": "warm",
+                "message": "prompt unavailable",
+                "question_id": "demo-q1",
+                "repo_id": "demo",
+            }
+        ]
+
+    def test_invalid_mode_and_malformed_stats_fail_closed(self, tmp_path: Path):
+        from benchmarks.codegraph_compare.setup_validation import (
+            validate_matrix_setup,
+        )
+
+        class InvalidStatsAdapter:
+            def prepare_index(self, repo_path: Path, cold: bool):
+                return None
+
+        result = validate_matrix_setup(
+            [{"id": "demo", "local_path": str(tmp_path)}],
+            [
+                {"id": "bad-mode", "index_mode": "typo"},
+                {"id": "bad-stats", "index_mode": "warm"},
+            ],
+            questions_by_repo={"demo": []},
+            repo_path_resolver=lambda repo: Path(repo["local_path"]),
+            adapter_factory=lambda arm_id: InvalidStatsAdapter(),
+        )
+
+        assert result.ok is False
+        assert [failure.code for failure in result.failures] == [
+            "INVALID_INDEX_MODE",
+            "INVALID_INDEX_STATS",
+        ]
 
 
 class TestCodeGraphCompareAnalysisGate:


### PR DESCRIPTION
## What changed

- preflight every selected repository and benchmark arm before the first model-backed trial
- reject setup exceptions, invalid index modes, malformed/empty indexes, and run-configuration failures
- persist session-scoped machine-readable setup failure evidence with zero model calls recorded
- make CodeGraph and TSA adapters raise on build/delete failures instead of continuing with partial data
- validate warm CodeGraph readiness from distinct source paths in `codegraph.db`, and TSA readiness from actual AST rows

## Why

The matrix runner previously prepared and executed one arm at a time. A later competitor setup failure could therefore happen after earlier arms had already consumed model calls. In addition, stale index artifacts could be counted as successful index data. That made benchmark cost and comparison claims unsafe.

This change makes basic setup readiness fail closed: every selected cell must be ready before any model cost is incurred, and failures remain visible as structured evidence.

## Scope

This is RFC-0021 Slice A2.1: the runner ordering and basic readiness boundary. Manifest provenance, exact eligible/indexed path partitions, pinned known-answer queries, and final `NOT_EVALUATED` reporting remain separate follow-up slices.

## Verification

- `uv run pytest tests/unit/test_benchmark_harness.py --cov=tree_sitter_analyzer --cov-report=json -q` — 73 passed
- `uv run python scripts/check_patch_coverage.py --base origin/develop --coverage-json coverage.json` — passed, no added executable misses
- `uv run pytest -q` — 1245 passed, 8 skipped in 99.09s
- Ruff and mypy on changed benchmark modules — passed
- TSA file health: new setup module grade A (95.7); runner remains grade B
