### PR TITLE
Prevent pytest temp artifacts from exhausting local disks

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,11 @@ if str(PROJECT_ROOT) not in sys.path:
 import pytest  # noqa: E402
 from hypothesis import settings as hypothesis_settings  # noqa: E402
 
+from tests.pytest_temp_hygiene import (  # noqa: E402
+    cleanup_pytest_temp_root,
+    configure_pytest_temp_root,
+)
+
 QUARANTINED_TESTS: list[str] = []
 
 # TEST-P3 root-cause fix: under pytest-xdist's load balancer, multiple
@@ -48,8 +53,10 @@ def pytest_xdist_auto_num_workers(config) -> int:
     return os.cpu_count() or 4
 
 
+@pytest.hookimpl(tryfirst=True)
 def pytest_configure(config):
     """Configure pytest with custom markers and safety checks."""
+    configure_pytest_temp_root(config)
     if not hasattr(config, "workerinput"):
         _cleanup_pytest_git_repos()
 
@@ -226,6 +233,12 @@ def pytest_sessionfinish(session, exitstatus):
 
     if not hasattr(session.config, "workerinput"):
         _cleanup_pytest_git_repos()
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_unconfigure(config):
+    """Reclaim this process's managed pytest temp directory."""
+    cleanup_pytest_temp_root(config)
 
 
 def pytest_terminal_summary(terminalreporter, exitstatus, config):

--- a/tests/contracts/test_pytest_runtime_contract.py
+++ b/tests/contracts/test_pytest_runtime_contract.py
@@ -302,6 +302,28 @@ def test_posix_temp_parent_preserves_system_path_spelling(monkeypatch) -> None:
     assert parent.as_posix() == "/var/folders/system-temp/tsa-temp-cache/user-501"
 
 
+def test_temp_directory_identity_normalizes_both_paths(monkeypatch) -> None:
+    """macOS filesystem aliases must compare as the same writable directory."""
+    from tests import pytest_temp_hygiene
+
+    observed_paths = []
+    monkeypatch.setattr(
+        Path,
+        "resolve",
+        lambda self: observed_paths.append(self) or Path("/canonical-temp"),
+    )
+
+    result = pytest_temp_hygiene._same_directory(
+        Path("/var/folders/temp"),
+        Path("/private/var/folders/temp"),
+    )
+
+    assert (result, observed_paths) == (
+        True,
+        [Path("/var/folders/temp"), Path("/private/var/folders/temp")],
+    )
+
+
 def test_local_app_data_temp_parent_has_temp_marker(monkeypatch, tmp_path) -> None:
     """Windows security fixtures must recognize the managed root as temporary."""
     from tests import pytest_temp_hygiene

--- a/tests/contracts/test_pytest_runtime_contract.py
+++ b/tests/contracts/test_pytest_runtime_contract.py
@@ -8,7 +8,9 @@ import configparser
 import os
 import re
 import shlex
+import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -180,6 +182,65 @@ def test_local_runtime_artifacts_are_gitignored_without_global_results_trap() ->
     assert "results/" not in lines
     assert "benchmarks/codegraph_compare/results/*" in lines
     assert "!benchmarks/codegraph_compare/results/.gitkeep" in lines
+
+
+def test_managed_pytest_temp_root_is_external_and_removed(monkeypatch, tmp_path) -> None:
+    """Default pytest temp data must live outside the repo and be reclaimed."""
+    from tests import pytest_temp_hygiene
+
+    managed_parent = tmp_path / "managed-pytest-temp"
+    monkeypatch.setenv("TSA_PYTEST_TEMP_ROOT", str(managed_parent))
+    config = SimpleNamespace(
+        invocation_params=SimpleNamespace(args=()),
+        option=SimpleNamespace(basetemp=None),
+    )
+
+    try:
+        pytest_temp_hygiene.configure_pytest_temp_root(config)
+        session_root = Path(config.option.basetemp)
+
+        assert session_root.parent == managed_parent
+        assert session_root.is_dir()
+        assert os.environ["TEMP"] == str(session_root)
+        assert os.environ["TMP"] == str(session_root)
+        assert os.environ["TMPDIR"] == str(session_root)
+        assert Path(tempfile.gettempdir()) == session_root
+
+        pytest_temp_hygiene.cleanup_pytest_temp_root(config)
+        assert session_root.exists() is False
+    finally:
+        tempfile.tempdir = None
+
+
+def test_dead_pytest_process_temp_root_is_removed(tmp_path) -> None:
+    """A later pytest run must reclaim debris left by a killed process."""
+    from tests import pytest_temp_hygiene
+
+    stale_root = tmp_path / "run-99999999-deadbeef"
+    stale_root.mkdir()
+    (stale_root / "orphan.txt").write_text("orphan", encoding="utf-8")
+
+    pytest_temp_hygiene.remove_stale_pytest_temp_roots(tmp_path)
+
+    assert stale_root.exists() is False
+
+
+def test_xdist_worker_keeps_controller_temp_root(monkeypatch, tmp_path) -> None:
+    """Workers must inherit the controller root instead of replacing it."""
+    from tests import pytest_temp_hygiene
+    managed_parent = tmp_path / "managed-pytest-temp"
+    controller_root = managed_parent / "run-12345678-deadbeef"
+    monkeypatch.setenv("TSA_PYTEST_TEMP_ROOT", str(managed_parent))
+    config = SimpleNamespace(
+        invocation_params=SimpleNamespace(args=()),
+        option=SimpleNamespace(basetemp=str(controller_root)),
+        workerinput={},
+    )
+
+    pytest_temp_hygiene.configure_pytest_temp_root(config)
+
+    assert config.option.basetemp == str(controller_root)
+    assert managed_parent.exists() is False
 
 
 def test_cli_fixtures_do_not_create_collectable_python_inside_tests_tree() -> None:

--- a/tests/contracts/test_pytest_runtime_contract.py
+++ b/tests/contracts/test_pytest_runtime_contract.py
@@ -197,10 +197,13 @@ def test_managed_pytest_temp_root_is_external_and_removed(monkeypatch, tmp_path)
 
     try:
         pytest_temp_hygiene.configure_pytest_temp_root(config)
-        session_root = Path(config.option.basetemp)
+        basetemp = Path(config.option.basetemp)
+        session_root = basetemp.parent
 
         assert session_root.parent == managed_parent
         assert session_root.is_dir()
+        assert basetemp.name == "work"
+        assert basetemp.exists() is False
         assert os.environ["TEMP"] == str(session_root)
         assert os.environ["TMP"] == str(session_root)
         assert os.environ["TMPDIR"] == str(session_root)
@@ -210,6 +213,19 @@ def test_managed_pytest_temp_root_is_external_and_removed(monkeypatch, tmp_path)
         assert session_root.exists() is False
     finally:
         tempfile.tempdir = None
+
+
+def test_posix_temp_parent_uses_neutral_directory_name(monkeypatch) -> None:
+    """Fixture paths must not be misclassified as tests from their parent name."""
+    from tests import pytest_temp_hygiene
+
+    monkeypatch.delenv("TSA_PYTEST_TEMP_ROOT", raising=False)
+    monkeypatch.delenv("LOCALAPPDATA", raising=False)
+    monkeypatch.setattr(pytest_temp_hygiene.tempfile, "gettempdir", lambda: "/tmp")
+
+    parent = pytest_temp_hygiene._pytest_temp_parent()
+
+    assert parent.name == "tsa-run-cache"
 
 
 def test_dead_pytest_process_temp_root_is_removed(tmp_path) -> None:

--- a/tests/contracts/test_pytest_runtime_contract.py
+++ b/tests/contracts/test_pytest_runtime_contract.py
@@ -281,7 +281,37 @@ def test_posix_temp_parent_is_neutral_and_user_scoped(monkeypatch) -> None:
 
     parent = pytest_temp_hygiene._pytest_temp_parent()
 
-    assert parent.parts[-2:] == ("tsa-run-cache", "user-123")
+    assert parent.parts[-2:] == ("tsa-temp-cache", "user-123")
+
+
+def test_posix_temp_parent_preserves_system_path_spelling(monkeypatch) -> None:
+    """macOS /var spelling must remain compatible with project path normalization."""
+    from tests import pytest_temp_hygiene
+
+    monkeypatch.delenv("TSA_PYTEST_TEMP_ROOT", raising=False)
+    monkeypatch.delenv("LOCALAPPDATA", raising=False)
+    monkeypatch.setattr(
+        pytest_temp_hygiene.tempfile,
+        "gettempdir",
+        lambda: "/var/folders/system-temp",
+    )
+    monkeypatch.setattr(pytest_temp_hygiene, "_current_user_key", lambda: "user-501")
+
+    parent = pytest_temp_hygiene._pytest_temp_parent()
+
+    assert parent.as_posix() == "/var/folders/system-temp/tsa-temp-cache/user-501"
+
+
+def test_local_app_data_temp_parent_has_temp_marker(monkeypatch, tmp_path) -> None:
+    """Windows security fixtures must recognize the managed root as temporary."""
+    from tests import pytest_temp_hygiene
+
+    monkeypatch.delenv("TSA_PYTEST_TEMP_ROOT", raising=False)
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
+
+    parent = pytest_temp_hygiene._pytest_temp_parent()
+
+    assert parent.name == "temp-runtime"
 
 
 def test_managed_temp_directories_are_private(monkeypatch, tmp_path) -> None:

--- a/tests/contracts/test_pytest_runtime_contract.py
+++ b/tests/contracts/test_pytest_runtime_contract.py
@@ -184,8 +184,7 @@ def test_local_runtime_artifacts_are_gitignored_without_global_results_trap() ->
     assert "!benchmarks/codegraph_compare/results/.gitkeep" in lines
 
 
-def test_managed_pytest_temp_root_is_external_and_removed(monkeypatch, tmp_path) -> None:
-    """Default pytest temp data must live outside the repo and be reclaimed."""
+def _managed_temp_config(monkeypatch, tmp_path):
     from tests import pytest_temp_hygiene
 
     managed_parent = tmp_path / "managed-pytest-temp"
@@ -194,38 +193,144 @@ def test_managed_pytest_temp_root_is_external_and_removed(monkeypatch, tmp_path)
         invocation_params=SimpleNamespace(args=()),
         option=SimpleNamespace(basetemp=None),
     )
+    pytest_temp_hygiene.configure_pytest_temp_root(config)
+    return pytest_temp_hygiene, config, managed_parent
+
+
+def test_managed_pytest_temp_root_routes_basetemp_to_work_child(
+    monkeypatch, tmp_path
+) -> None:
+    """The pytest work directory must be separate from the system temp root."""
+    pytest_temp_hygiene, config, managed_parent = _managed_temp_config(
+        monkeypatch, tmp_path
+    )
 
     try:
-        pytest_temp_hygiene.configure_pytest_temp_root(config)
         basetemp = Path(config.option.basetemp)
-        session_root = basetemp.parent
+        assert (basetemp.parent.parent, basetemp.name) == (managed_parent, "work")
+    finally:
+        pytest_temp_hygiene.cleanup_pytest_temp_root(config)
 
-        assert session_root.parent == managed_parent
-        assert session_root.is_dir()
-        assert basetemp.name == "work"
-        assert basetemp.exists() is False
-        assert os.environ["TEMP"] == str(session_root)
-        assert os.environ["TMP"] == str(session_root)
-        assert os.environ["TMPDIR"] == str(session_root)
-        assert Path(tempfile.gettempdir()) == session_root
 
+def test_managed_pytest_temp_root_updates_process_temp_settings(
+    monkeypatch, tmp_path
+) -> None:
+    """All process temp APIs must use the managed session root."""
+    pytest_temp_hygiene, config, _ = _managed_temp_config(monkeypatch, tmp_path)
+
+    try:
+        session_root = Path(config.option.basetemp).parent
+        assert (
+            os.environ["TEMP"],
+            os.environ["TMP"],
+            os.environ["TMPDIR"],
+            Path(tempfile.gettempdir()),
+        ) == (str(session_root), str(session_root), str(session_root), session_root)
+    finally:
+        pytest_temp_hygiene.cleanup_pytest_temp_root(config)
+
+
+def test_cleanup_removes_managed_pytest_temp_root(monkeypatch, tmp_path) -> None:
+    """Normal pytest shutdown must reclaim the managed session directory."""
+    pytest_temp_hygiene, config, _ = _managed_temp_config(monkeypatch, tmp_path)
+    session_root = Path(config.option.basetemp).parent
+
+    try:
         pytest_temp_hygiene.cleanup_pytest_temp_root(config)
         assert session_root.exists() is False
     finally:
-        tempfile.tempdir = None
+        pytest_temp_hygiene.cleanup_pytest_temp_root(config)
 
 
-def test_posix_temp_parent_uses_neutral_directory_name(monkeypatch) -> None:
-    """Fixture paths must not be misclassified as tests from their parent name."""
+def test_cleanup_restores_process_temp_settings(monkeypatch, tmp_path) -> None:
+    """Embedded pytest runs must leave the caller's temp settings unchanged."""
+    original_temp = tmp_path / "caller-temp"
+    original_temp.mkdir()
+    for variable in ("TEMP", "TMP", "TMPDIR"):
+        monkeypatch.setenv(variable, str(original_temp))
+    previous_cache = tempfile.tempdir
+    tempfile.tempdir = str(original_temp)
+    pytest_temp_hygiene, config, _ = _managed_temp_config(monkeypatch, tmp_path)
+
+    try:
+        pytest_temp_hygiene.cleanup_pytest_temp_root(config)
+        assert (
+            os.environ["TEMP"],
+            os.environ["TMP"],
+            os.environ["TMPDIR"],
+            tempfile.tempdir,
+        ) == (
+            str(original_temp),
+            str(original_temp),
+            str(original_temp),
+            str(original_temp),
+        )
+    finally:
+        pytest_temp_hygiene.cleanup_pytest_temp_root(config)
+        tempfile.tempdir = previous_cache
+
+
+def test_posix_temp_parent_is_neutral_and_user_scoped(monkeypatch) -> None:
+    """Fallback temp data must use a neutral, per-user directory."""
     from tests import pytest_temp_hygiene
 
     monkeypatch.delenv("TSA_PYTEST_TEMP_ROOT", raising=False)
     monkeypatch.delenv("LOCALAPPDATA", raising=False)
     monkeypatch.setattr(pytest_temp_hygiene.tempfile, "gettempdir", lambda: "/tmp")
+    monkeypatch.setattr(pytest_temp_hygiene, "_current_user_key", lambda: "user-123")
 
     parent = pytest_temp_hygiene._pytest_temp_parent()
 
-    assert parent.name == "tsa-run-cache"
+    assert parent.parts[-2:] == ("tsa-run-cache", "user-123")
+
+
+def test_managed_temp_directories_are_private(monkeypatch, tmp_path) -> None:
+    """Managed directory creation must request owner-only permissions."""
+    from tests import pytest_temp_hygiene
+
+    chmod_calls = []
+    monkeypatch.setattr(Path, "chmod", lambda self, mode: chmod_calls.append((self, mode)))
+    private_root = tmp_path / "private"
+
+    pytest_temp_hygiene._ensure_private_directory(private_root)
+
+    assert chmod_calls == [(private_root, 0o700)]
+
+
+def test_configured_basetemp_is_preserved(monkeypatch, tmp_path) -> None:
+    """PYTEST_ADDOPTS and ini basetemp values must override managed defaults."""
+    from tests import pytest_temp_hygiene
+
+    managed_parent = tmp_path / "managed-pytest-temp"
+    configured_basetemp = tmp_path / "configured-basetemp"
+    monkeypatch.setenv("TSA_PYTEST_TEMP_ROOT", str(managed_parent))
+    config = SimpleNamespace(
+        invocation_params=SimpleNamespace(args=()),
+        option=SimpleNamespace(basetemp=str(configured_basetemp)),
+    )
+
+    pytest_temp_hygiene.configure_pytest_temp_root(config)
+
+    assert (config.option.basetemp, managed_parent.exists()) == (
+        str(configured_basetemp),
+        False,
+    )
+
+
+def test_process_probe_uses_non_destructive_pid_lookup(monkeypatch) -> None:
+    """Liveness checks must never send a signal to a Windows process."""
+    from tests import pytest_temp_hygiene
+
+    observed_pids = []
+    monkeypatch.setattr(
+        pytest_temp_hygiene.psutil,
+        "pid_exists",
+        lambda pid: observed_pids.append(pid) or True,
+    )
+
+    result = pytest_temp_hygiene._process_is_running(43210)
+
+    assert (result, observed_pids) == (True, [43210])
 
 
 def test_dead_pytest_process_temp_root_is_removed(tmp_path) -> None:

--- a/tests/pytest_temp_hygiene.py
+++ b/tests/pytest_temp_hygiene.py
@@ -1,0 +1,95 @@
+"""Managed pytest temporary-directory lifecycle."""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import tempfile
+import uuid
+from pathlib import Path
+from typing import Any
+
+_MANAGED_TEMP_PATTERN = re.compile(r"run-(?P<pid>\d+)-[0-9a-f]{8}")
+
+
+def _pytest_temp_parent() -> Path:
+    """Return a writable, repository-external parent for pytest artifacts."""
+    configured = os.environ.get("TSA_PYTEST_TEMP_ROOT")
+    if configured:
+        return Path(configured).expanduser().resolve()
+
+    local_app_data = os.environ.get("LOCALAPPDATA")
+    if local_app_data:
+        return Path(local_app_data).resolve() / "tree-sitter-analyzer" / "pytest"
+
+    return Path(tempfile.gettempdir()).resolve() / "tree-sitter-analyzer-pytest"
+
+
+def _process_is_running(pid: int) -> bool:
+    """Return whether a process id still belongs to a live process."""
+    if pid == os.getpid():
+        return True
+    try:
+        os.kill(pid, 0)
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def remove_stale_pytest_temp_roots(parent: Path) -> None:
+    """Remove managed temp roots whose owning pytest process has exited."""
+    if not parent.is_dir():
+        return
+
+    for candidate in parent.iterdir():
+        match = _MANAGED_TEMP_PATTERN.fullmatch(candidate.name)
+        if match is None or not candidate.is_dir():
+            continue
+        if _process_is_running(int(match.group("pid"))):
+            continue
+        shutil.rmtree(candidate, ignore_errors=True)
+
+
+def _has_explicit_basetemp(config: Any) -> bool:
+    args = tuple(str(arg) for arg in config.invocation_params.args)
+    return any(arg == "--basetemp" or arg.startswith("--basetemp=") for arg in args)
+
+
+def configure_pytest_temp_root(config: Any) -> None:
+    """Route default pytest artifacts to a managed controller directory."""
+    if hasattr(config, "workerinput"):
+        return
+    if _has_explicit_basetemp(config):
+        return
+
+    parent = _pytest_temp_parent()
+    parent.mkdir(parents=True, exist_ok=True)
+    remove_stale_pytest_temp_roots(parent)
+    session_root = parent / f"run-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+    session_root.mkdir()
+
+    for variable in ("TEMP", "TMP", "TMPDIR"):
+        os.environ[variable] = str(session_root)
+    tempfile.tempdir = None
+    if Path(tempfile.gettempdir()).resolve() != session_root:
+        raise RuntimeError(f"pytest temp root is not writable: {session_root}")
+
+    config.option.basetemp = str(session_root)
+    config._tsa_pytest_temp_root = session_root
+
+
+def cleanup_pytest_temp_root(config: Any) -> None:
+    """Remove the managed temp root created for this pytest controller."""
+    session_root = getattr(config, "_tsa_pytest_temp_root", None)
+    if session_root is None:
+        return
+
+    parent = session_root.parent
+    shutil.rmtree(session_root, ignore_errors=True)
+    try:
+        parent.rmdir()
+    except OSError:
+        pass

--- a/tests/pytest_temp_hygiene.py
+++ b/tests/pytest_temp_hygiene.py
@@ -33,11 +33,15 @@ def _pytest_temp_parent() -> Path:
 
     local_app_data = os.environ.get("LOCALAPPDATA")
     if local_app_data:
-        return Path(local_app_data).resolve() / "tree-sitter-analyzer" / "runtime"
+        return (
+            Path(local_app_data).resolve()
+            / "tree-sitter-analyzer"
+            / "temp-runtime"
+        )
 
     return (
-        Path(tempfile.gettempdir()).resolve()
-        / "tsa-run-cache"
+        Path(tempfile.gettempdir())
+        / "tsa-temp-cache"
         / _current_user_key()
     )
 

--- a/tests/pytest_temp_hygiene.py
+++ b/tests/pytest_temp_hygiene.py
@@ -52,6 +52,11 @@ def _ensure_private_directory(path: Path) -> None:
     path.chmod(0o700)
 
 
+def _same_directory(first: Path, second: Path) -> bool:
+    """Return whether two path spellings identify the same directory."""
+    return first.resolve() == second.resolve()
+
+
 def _process_is_running(pid: int) -> bool:
     """Return whether a process id still belongs to a live process."""
     return psutil.pid_exists(pid)
@@ -115,7 +120,7 @@ def configure_pytest_temp_root(config: Any) -> None:
     for variable in _TEMP_VARIABLES:
         os.environ[variable] = str(session_root)
     tempfile.tempdir = None
-    if Path(tempfile.gettempdir()).resolve() != session_root:
+    if not _same_directory(Path(tempfile.gettempdir()), session_root):
         _restore_process_temp_settings(config)
         shutil.rmtree(session_root, ignore_errors=True)
         raise RuntimeError(f"pytest temp root is not writable: {session_root}")

--- a/tests/pytest_temp_hygiene.py
+++ b/tests/pytest_temp_hygiene.py
@@ -21,9 +21,9 @@ def _pytest_temp_parent() -> Path:
 
     local_app_data = os.environ.get("LOCALAPPDATA")
     if local_app_data:
-        return Path(local_app_data).resolve() / "tree-sitter-analyzer" / "pytest"
+        return Path(local_app_data).resolve() / "tree-sitter-analyzer" / "runtime"
 
-    return Path(tempfile.gettempdir()).resolve() / "tree-sitter-analyzer-pytest"
+    return Path(tempfile.gettempdir()).resolve() / "tsa-run-cache"
 
 
 def _process_is_running(pid: int) -> bool:
@@ -77,7 +77,7 @@ def configure_pytest_temp_root(config: Any) -> None:
     if Path(tempfile.gettempdir()).resolve() != session_root:
         raise RuntimeError(f"pytest temp root is not writable: {session_root}")
 
-    config.option.basetemp = str(session_root)
+    config.option.basetemp = str(session_root / "work")
     config._tsa_pytest_temp_root = session_root
 
 

--- a/tests/pytest_temp_hygiene.py
+++ b/tests/pytest_temp_hygiene.py
@@ -10,7 +10,19 @@ import uuid
 from pathlib import Path
 from typing import Any
 
+import psutil
+
 _MANAGED_TEMP_PATTERN = re.compile(r"run-(?P<pid>\d+)-[0-9a-f]{8}")
+_TEMP_VARIABLES = ("TEMP", "TMP", "TMPDIR")
+
+
+def _current_user_key() -> str:
+    """Return a filesystem-safe identifier for the current user."""
+    if hasattr(os, "getuid"):
+        return f"user-{os.getuid()}"
+    username = os.environ.get("USERNAME", "unknown")
+    safe_username = re.sub(r"[^A-Za-z0-9_.-]", "_", username)
+    return f"user-{safe_username}"
 
 
 def _pytest_temp_parent() -> Path:
@@ -23,20 +35,22 @@ def _pytest_temp_parent() -> Path:
     if local_app_data:
         return Path(local_app_data).resolve() / "tree-sitter-analyzer" / "runtime"
 
-    return Path(tempfile.gettempdir()).resolve() / "tsa-run-cache"
+    return (
+        Path(tempfile.gettempdir()).resolve()
+        / "tsa-run-cache"
+        / _current_user_key()
+    )
+
+
+def _ensure_private_directory(path: Path) -> None:
+    """Create a directory and restrict it to the current user."""
+    path.mkdir(mode=0o700, parents=True, exist_ok=True)
+    path.chmod(0o700)
 
 
 def _process_is_running(pid: int) -> bool:
     """Return whether a process id still belongs to a live process."""
-    if pid == os.getpid():
-        return True
-    try:
-        os.kill(pid, 0)
-    except PermissionError:
-        return True
-    except OSError:
-        return False
-    return True
+    return psutil.pid_exists(pid)
 
 
 def remove_stale_pytest_temp_roots(parent: Path) -> None:
@@ -54,8 +68,25 @@ def remove_stale_pytest_temp_roots(parent: Path) -> None:
 
 
 def _has_explicit_basetemp(config: Any) -> bool:
+    if getattr(config.option, "basetemp", None) is not None:
+        return True
     args = tuple(str(arg) for arg in config.invocation_params.args)
     return any(arg == "--basetemp" or arg.startswith("--basetemp=") for arg in args)
+
+
+def _restore_process_temp_settings(config: Any) -> None:
+    previous_environment = getattr(
+        config, "_tsa_previous_temp_environment", None
+    )
+    if previous_environment is None:
+        return
+
+    for variable, value in previous_environment.items():
+        if value is None:
+            os.environ.pop(variable, None)
+        else:
+            os.environ[variable] = value
+    tempfile.tempdir = config._tsa_previous_tempfile_tempdir
 
 
 def configure_pytest_temp_root(config: Any) -> None:
@@ -66,19 +97,26 @@ def configure_pytest_temp_root(config: Any) -> None:
         return
 
     parent = _pytest_temp_parent()
-    parent.mkdir(parents=True, exist_ok=True)
+    _ensure_private_directory(parent)
     remove_stale_pytest_temp_roots(parent)
     session_root = parent / f"run-{os.getpid()}-{uuid.uuid4().hex[:8]}"
-    session_root.mkdir()
+    _ensure_private_directory(session_root)
 
-    for variable in ("TEMP", "TMP", "TMPDIR"):
+    config._tsa_previous_temp_environment = {
+        variable: os.environ.get(variable) for variable in _TEMP_VARIABLES
+    }
+    config._tsa_previous_tempfile_tempdir = tempfile.tempdir
+    config._tsa_pytest_temp_root = session_root
+
+    for variable in _TEMP_VARIABLES:
         os.environ[variable] = str(session_root)
     tempfile.tempdir = None
     if Path(tempfile.gettempdir()).resolve() != session_root:
+        _restore_process_temp_settings(config)
+        shutil.rmtree(session_root, ignore_errors=True)
         raise RuntimeError(f"pytest temp root is not writable: {session_root}")
 
     config.option.basetemp = str(session_root / "work")
-    config._tsa_pytest_temp_root = session_root
 
 
 def cleanup_pytest_temp_root(config: Any) -> None:
@@ -87,6 +125,8 @@ def cleanup_pytest_temp_root(config: Any) -> None:
     if session_root is None:
         return
 
+    _restore_process_temp_settings(config)
+    config._tsa_pytest_temp_root = None
     parent = session_root.parent
     shutil.rmtree(session_root, ignore_errors=True)
     try:


### PR DESCRIPTION
## Summary
- route default pytest temporary files to a repository-external per-run directory
- share the controller directory safely across xdist workers
- remove normal-run artifacts at shutdown and reclaim dead-process leftovers on the next run
- preserve explicit --basetemp overrides

## Verification
- focused change-impact command: 23 passed
- default gate: 1248 passed, 8 skipped in 61.36s
- Ruff and diff checks passed
- managed temp leftovers after the full suite: 0