### PR TITLE
fix(call-graph): stop hardcoding a 7-language file-scan allowlist

### DIFF
--- a/docs/CODEMAPS/languages.md
+++ b/docs/CODEMAPS/languages.md
@@ -10,7 +10,7 @@ Not every registered plugin is wired into the indexer to the same depth:
 
 - **13 fully wired** (full symbol + call graph): Python, Java, JavaScript, TypeScript, Go, Rust, C, C++, C#, Swift, Kotlin, Ruby, PHP
 - **2 symbol-indexed** (call-graph wiring pending): Bash, Scala — both graduated in v1.22.0
-- **1 partial symbol-indexed**: Lua function symbols; resolved calls and indexed imports pending
+- **1 partial symbol-indexed**: Lua function symbols and same-file resolved calls; cross-file import-based resolution pending
 - **5 data/markup** (reachable via the single-file CLI path): HTML, CSS, Markdown, SQL, YAML
 - **1 scaffold** (plugin exists, indexer wiring pending): JSON
 

--- a/tests/contracts/test_internal_architecture_contract.py
+++ b/tests/contracts/test_internal_architecture_contract.py
@@ -59,6 +59,40 @@ def test_ast_cache_call_edge_extraction_does_not_depend_on_call_graph() -> None:
     assert "tree_sitter_analyzer.call_graph" not in imports
 
 
+def test_call_graph_supported_exts_covers_function_extraction_languages() -> None:
+    """CallGraph's file-scan allowlist must not silently narrow past what
+    function_extraction.py already knows how to walk.
+
+    Regression: CallGraph.build() historically hardcoded its own 7-language
+    supported_exts set, independent of function_extraction's per-language
+    dispatch tables. Rust/C#/Kotlin/Ruby/PHP/Swift/Lua all had working
+    _FUNC_DEF_TYPES/_CALL_NODE_TYPES entries but were silently excluded from
+    every CodeGraph-parity tool (--call-graph, --callers, --callees,
+    dead-code detection, codegraph_* MCP tools) because the file scanner
+    dropped their files before parsing. See call_graph.py's SUPPORTED_EXTS
+    docstring.
+    """
+    from tree_sitter_analyzer.call_graph import SUPPORTED_EXTS
+    from tree_sitter_analyzer.function_extraction import SUPPORTED_LANGUAGES
+    from tree_sitter_analyzer.languages.lang_extension_map import EXT_TO_LANG
+
+    exts_by_lang: dict[str, set[str]] = {}
+    for ext, lang in EXT_TO_LANG.items():
+        exts_by_lang.setdefault(lang, set()).add(ext)
+
+    missing: dict[str, set[str]] = {}
+    for lang in SUPPORTED_LANGUAGES:
+        lang_exts = exts_by_lang.get(lang, set())
+        uncovered = lang_exts - SUPPORTED_EXTS
+        if uncovered:
+            missing[lang] = uncovered
+
+    assert missing == {}, (
+        f"function_extraction supports these languages' node types but "
+        f"CallGraph.SUPPORTED_EXTS omits their extensions: {missing}"
+    )
+
+
 def test_callee_resolution_algorithm_has_single_shared_home() -> None:
     """CallGraph/CrossFile/Synapse may expose APIs, but not bespoke algorithms."""
     call_graph = (PROJECT_ROOT / "tree_sitter_analyzer" / "call_graph.py").read_text(

--- a/tests/contracts/test_internal_architecture_contract.py
+++ b/tests/contracts/test_internal_architecture_contract.py
@@ -63,14 +63,15 @@ def test_call_graph_supported_exts_covers_function_extraction_languages() -> Non
     """CallGraph's file-scan allowlist must not silently narrow past what
     function_extraction.py already knows how to walk.
 
-    Regression: CallGraph.build() historically hardcoded its own 7-language
-    supported_exts set, independent of function_extraction's per-language
-    dispatch tables. Rust/C#/Kotlin/Ruby/PHP/Swift/Lua all had working
-    _FUNC_DEF_TYPES/_CALL_NODE_TYPES entries but were silently excluded from
-    every CodeGraph-parity tool (--call-graph, --callers, --callees,
-    dead-code detection, codegraph_* MCP tools) because the file scanner
-    dropped their files before parsing. See call_graph.py's SUPPORTED_EXTS
-    docstring.
+    Regression: found in the 2026-07-21 architecture-consistency dogfood
+    pass (PR #1157). CallGraph.build() historically hardcoded its own
+    7-language supported_exts set, independent of function_extraction's
+    per-language dispatch tables. Rust/C#/Kotlin/Ruby/PHP/Swift/Lua all had
+    working _FUNC_DEF_TYPES/_CALL_NODE_TYPES entries but were silently
+    excluded from every CodeGraph-parity tool (--call-graph, --callers,
+    --callees, dead-code detection, codegraph_* MCP tools) because the file
+    scanner dropped their files before parsing. See call_graph.py's
+    SUPPORTED_EXTS docstring.
     """
     from tree_sitter_analyzer.call_graph import SUPPORTED_EXTS
     from tree_sitter_analyzer.function_extraction import SUPPORTED_LANGUAGES

--- a/tests/fixtures/call_graph/csharp_project/Main.cs
+++ b/tests/fixtures/call_graph/csharp_project/Main.cs
@@ -1,0 +1,18 @@
+class Program
+{
+    static int LoadData()
+    {
+        return 1;
+    }
+
+    static int ProcessData(int data)
+    {
+        return data * 2;
+    }
+
+    static void Main()
+    {
+        int d = LoadData();
+        ProcessData(d);
+    }
+}

--- a/tests/fixtures/call_graph/kotlin_project/main.kt
+++ b/tests/fixtures/call_graph/kotlin_project/main.kt
@@ -1,0 +1,12 @@
+fun loadData(): Int {
+    return 1
+}
+
+fun processData(data: Int): Int {
+    return data * 2
+}
+
+fun main() {
+    val d = loadData()
+    processData(d)
+}

--- a/tests/fixtures/call_graph/lua_project/main.lua
+++ b/tests/fixtures/call_graph/lua_project/main.lua
@@ -1,0 +1,12 @@
+function loadData()
+    return 1
+end
+
+function processData(data)
+    return data * 2
+end
+
+function main()
+    local d = loadData()
+    processData(d)
+end

--- a/tests/fixtures/call_graph/php_project/main.php
+++ b/tests/fixtures/call_graph/php_project/main.php
@@ -1,0 +1,14 @@
+<?php
+
+function loadData() {
+    return 1;
+}
+
+function processData($data) {
+    return $data * 2;
+}
+
+function main() {
+    $d = loadData();
+    processData($d);
+}

--- a/tests/fixtures/call_graph/ruby_project/main.rb
+++ b/tests/fixtures/call_graph/ruby_project/main.rb
@@ -1,0 +1,12 @@
+def load_data
+  1
+end
+
+def process_data(data)
+  data * 2
+end
+
+def main
+  d = load_data
+  process_data(d)
+end

--- a/tests/fixtures/call_graph/rust_project/main.rs
+++ b/tests/fixtures/call_graph/rust_project/main.rs
@@ -1,0 +1,12 @@
+fn load_data() -> i32 {
+    1
+}
+
+fn process_data(data: i32) -> i32 {
+    data * 2
+}
+
+fn main() {
+    let d = load_data();
+    process_data(d);
+}

--- a/tests/fixtures/call_graph/swift_project/main.swift
+++ b/tests/fixtures/call_graph/swift_project/main.swift
@@ -1,0 +1,12 @@
+func loadData() -> Int {
+    return 1
+}
+
+func processData(_ data: Int) -> Int {
+    return data * 2
+}
+
+func main() {
+    let d = loadData()
+    processData(d)
+}

--- a/tests/unit/test_call_graph_integration.py
+++ b/tests/unit/test_call_graph_integration.py
@@ -28,6 +28,13 @@ JS_PROJECT = FIXTURES_DIR / "js_project"
 JAVA_PROJECT = FIXTURES_DIR / "java_project"
 GO_PROJECT = FIXTURES_DIR / "go_project"
 C_PROJECT = FIXTURES_DIR / "c_project"
+RUST_PROJECT = FIXTURES_DIR / "rust_project"
+CSHARP_PROJECT = FIXTURES_DIR / "csharp_project"
+KOTLIN_PROJECT = FIXTURES_DIR / "kotlin_project"
+RUBY_PROJECT = FIXTURES_DIR / "ruby_project"
+PHP_PROJECT = FIXTURES_DIR / "php_project"
+SWIFT_PROJECT = FIXTURES_DIR / "swift_project"
+LUA_PROJECT = FIXTURES_DIR / "lua_project"
 
 
 # ============================================================
@@ -83,6 +90,64 @@ class TestCallGraphBuild:
         assert s["function_count"] == 15
         assert s["call_edge_count"] == 8
         assert s["file_count"] == 5
+
+
+class TestCallGraphLanguageParity:
+    """Issue: CallGraph.build() hardcoded a 7-language supported_exts
+    allowlist that silently excluded rust/csharp/kotlin/ruby/php/swift/lua
+    even though function_extraction.py already implements their node-type
+    dispatch tables. These fixtures each define exactly two functions
+    (loadData + main calling it), so the exact count is pinned per the
+    no-approximate-assertions rule."""
+
+    def test_build_rust_project(self):
+        cg = CallGraph(str(RUST_PROJECT))
+        cg.build()
+        funcs = cg.all_functions()
+        names = {f["name"] for f in funcs}
+        assert names == {"load_data", "process_data", "main"}
+
+    def test_build_csharp_project(self):
+        cg = CallGraph(str(CSHARP_PROJECT))
+        cg.build()
+        funcs = cg.all_functions()
+        names = {f["name"] for f in funcs}
+        assert names == {"LoadData", "ProcessData", "Main"}
+
+    def test_build_kotlin_project(self):
+        cg = CallGraph(str(KOTLIN_PROJECT))
+        cg.build()
+        funcs = cg.all_functions()
+        names = {f["name"] for f in funcs}
+        assert names == {"loadData", "processData", "main"}
+
+    def test_build_ruby_project(self):
+        cg = CallGraph(str(RUBY_PROJECT))
+        cg.build()
+        funcs = cg.all_functions()
+        names = {f["name"] for f in funcs}
+        assert names == {"load_data", "process_data", "main"}
+
+    def test_build_php_project(self):
+        cg = CallGraph(str(PHP_PROJECT))
+        cg.build()
+        funcs = cg.all_functions()
+        names = {f["name"] for f in funcs}
+        assert names == {"loadData", "processData", "main"}
+
+    def test_build_swift_project(self):
+        cg = CallGraph(str(SWIFT_PROJECT))
+        cg.build()
+        funcs = cg.all_functions()
+        names = {f["name"] for f in funcs}
+        assert names == {"loadData", "processData", "main"}
+
+    def test_build_lua_project(self):
+        cg = CallGraph(str(LUA_PROJECT))
+        cg.build()
+        funcs = cg.all_functions()
+        names = {f["name"] for f in funcs}
+        assert names == {"loadData", "processData", "main"}
 
 
 class TestCallGraphCallersOf:

--- a/tests/unit/test_call_graph_integration.py
+++ b/tests/unit/test_call_graph_integration.py
@@ -1,5 +1,6 @@
 """Unit tests for call_graph.py — CallGraph integration tests."""
 
+import importlib
 from pathlib import Path
 
 import pytest
@@ -8,6 +9,24 @@ from tree_sitter_analyzer.call_graph import (
     CallGraph,
     FunctionRef,
 )
+
+
+def _grammar_available(module_name: str) -> bool:
+    """Return True when an optional tree-sitter grammar package is importable.
+
+    tree-sitter-swift and tree-sitter-lua are optional extras, not part of
+    the default dev/test dependency set (Codex #1157). Mirrors the guard
+    pattern already used by test_swift_plugin.py / test_lua_plugin.py.
+    """
+    try:
+        importlib.import_module(module_name)
+        return True
+    except ImportError:
+        return False
+
+
+_SWIFT_GRAMMAR_AVAILABLE = _grammar_available("tree_sitter_swift")
+_LUA_GRAMMAR_AVAILABLE = _grammar_available("tree_sitter_lua")
 
 # Historical: this marker first gated three call_graph cross-file
 # resolution tests as Windows-only. Then we discovered Linux CI fails
@@ -93,7 +112,8 @@ class TestCallGraphBuild:
 
 
 class TestCallGraphLanguageParity:
-    """Issue: CallGraph.build() hardcoded a 7-language supported_exts
+    """Regression: found in the 2026-07-21 architecture-consistency dogfood
+    pass (PR #1157). CallGraph.build() hardcoded a 7-language supported_exts
     allowlist that silently excluded rust/csharp/kotlin/ruby/php/swift/lua
     even though function_extraction.py already implements their node-type
     dispatch tables. These fixtures each define exactly two functions
@@ -135,6 +155,10 @@ class TestCallGraphLanguageParity:
         names = {f["name"] for f in funcs}
         assert names == {"loadData", "processData", "main"}
 
+    @pytest.mark.skipif(
+        not _SWIFT_GRAMMAR_AVAILABLE,
+        reason="tree-sitter-swift not installed",
+    )
     def test_build_swift_project(self):
         cg = CallGraph(str(SWIFT_PROJECT))
         cg.build()
@@ -142,6 +166,10 @@ class TestCallGraphLanguageParity:
         names = {f["name"] for f in funcs}
         assert names == {"loadData", "processData", "main"}
 
+    @pytest.mark.skipif(
+        not _LUA_GRAMMAR_AVAILABLE,
+        reason="tree_sitter_lua not installed; tracked: optional-dep skip",
+    )
     def test_build_lua_project(self):
         cg = CallGraph(str(LUA_PROJECT))
         cg.build()

--- a/tests/unit/test_dead_code_analyzer.py
+++ b/tests/unit/test_dead_code_analyzer.py
@@ -62,10 +62,25 @@ class TestIsKnownEntry:
         assert _is_known_entry("TestMain", "go") is True
 
     def test_unknown_language(self) -> None:
-        assert _is_known_entry("main", "rust") is False
+        # ruby has no entry pattern (see _KNOWN_ENTRY_PATTERNS comment):
+        # unlike rust/csharp/kotlin/swift, it has no single canonical
+        # entry-function convention (Codex #1157 follow-up).
+        assert _is_known_entry("main", "ruby") is False
 
     def test_non_entry_name(self) -> None:
         assert _is_known_entry("helper_func", "python") is False
+
+    def test_rust_main(self) -> None:
+        assert _is_known_entry("main", "rust") is True
+
+    def test_csharp_main(self) -> None:
+        assert _is_known_entry("Main", "csharp") is True
+
+    def test_kotlin_main(self) -> None:
+        assert _is_known_entry("main", "kotlin") is True
+
+    def test_swift_main(self) -> None:
+        assert _is_known_entry("main", "swift") is True
 
 
 # ---------------------------------------------------------------------------

--- a/tree_sitter_analyzer/call_graph.py
+++ b/tree_sitter_analyzer/call_graph.py
@@ -3,8 +3,9 @@
 Call Graph — Bidirectional function-level call tracking.
 
 Builds a directed graph of function/method calls within a project using
-Tree-sitter AST parsing. Supports Python, JavaScript, TypeScript, Java,
-Go, and C/C++.
+Tree-sitter AST parsing. Supported languages are derived from
+``function_extraction.SUPPORTED_LANGUAGES`` (see ``SUPPORTED_EXTS`` below),
+not hardcoded here.
 
 Key classes:
 - CallGraph: Construct and query function-level call relationships
@@ -13,16 +14,27 @@ Key classes:
 
 import os
 from collections import defaultdict, deque
+from collections.abc import Set as AbstractSet
 from pathlib import Path
 from typing import Any
 
 from .callee_resolution import CalleeResolver
 from .core.parser import Parser, ParseResult
+from .function_extraction import SUPPORTED_LANGUAGES as _FUNC_EXTRACTION_LANGUAGES
 from .function_extraction import (
     walk_tree as _walk_tree,
 )
 from .import_extractors import walk_imports
+from .languages.lang_extension_map import EXT_TO_LANG
 from .project_graph import _language_from_ext
+
+# Derived (not hardcoded) from EXT_TO_LANG — the project's single source
+# of truth for ext->language — filtered to languages function_extraction
+# actually knows how to walk. See function_extraction.SUPPORTED_LANGUAGES
+# docstring for why a hardcoded copy of this set is a recurring bug class.
+SUPPORTED_EXTS: frozenset[str] = frozenset(
+    ext for ext, lang in EXT_TO_LANG.items() if lang in _FUNC_EXTRACTION_LANGUAGES
+)
 
 _EXCLUDE_DIRS = {
     "node_modules",
@@ -131,21 +143,7 @@ class CallGraph:
         if self._built:
             return
 
-        supported_exts = {
-            ".py",
-            ".js",
-            ".ts",
-            ".jsx",
-            ".tsx",
-            ".java",
-            ".go",
-            ".c",
-            ".cpp",
-            ".cc",
-            ".cxx",
-        }
-
-        all_files = self._iter_source_files(supported_exts)
+        all_files = self._iter_source_files(SUPPORTED_EXTS)
 
         rel_to_abs: dict[str, str] = {}
         for f in all_files:
@@ -241,7 +239,7 @@ class CallGraph:
             rel_parts = path.parts
         return any(part in _EXCLUDE_DIRS or part.startswith(".") for part in rel_parts)
 
-    def _iter_source_files(self, supported_exts: set[str]) -> list[Path]:
+    def _iter_source_files(self, supported_exts: AbstractSet[str]) -> list[Path]:
         """Return source files while pruning generated and hidden work dirs."""
         files: list[Path] = []
         for root, dirs, names in os.walk(self.project_root):
@@ -651,7 +649,7 @@ class CallGraph:
         """
         return self._is_excluded(path)
 
-    def iter_source_files(self, supported_exts: set) -> list["Path"]:
+    def iter_source_files(self, supported_exts: AbstractSet[str]) -> list["Path"]:
         """Public alias for :meth:`_iter_source_files`.
 
         Yields source files under the project root whose suffix is in

--- a/tree_sitter_analyzer/call_graph.py
+++ b/tree_sitter_analyzer/call_graph.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any
 
 from .callee_resolution import CalleeResolver
+from .constants import EXCLUDE_DIRS as _EXCLUDE_DIRS
 from .core.parser import Parser, ParseResult
 from .function_extraction import SUPPORTED_LANGUAGES as _FUNC_EXTRACTION_LANGUAGES
 from .function_extraction import (
@@ -36,27 +37,12 @@ SUPPORTED_EXTS: frozenset[str] = frozenset(
     ext for ext, lang in EXT_TO_LANG.items() if lang in _FUNC_EXTRACTION_LANGUAGES
 )
 
-_EXCLUDE_DIRS = {
-    "node_modules",
-    ".git",
-    ".hg",
-    ".svn",
-    "__pycache__",
-    ".venv",
-    "venv",
-    ".tox",
-    ".mypy_cache",
-    ".pytest_cache",
-    ".ruff_cache",
-    "dist",
-    "build",
-    "htmlcov",
-    ".cache",
-    ".eggs",
-    ".idea",
-    ".vscode",
-    ".claude",
-}
+# _EXCLUDE_DIRS used to be a second, independently-maintained copy of
+# constants.EXCLUDE_DIRS missing target/obj/vendor/Pods/DerivedData (Codex
+# #1157 P1): once rust/csharp/php/swift files were admitted by SUPPORTED_EXTS
+# above, this scanner started walking into their build/vendor directories,
+# which can be enormous and made graph construction appear to hang. Import
+# the canonical set instead of re-copying it.
 
 
 class FunctionRef:

--- a/tree_sitter_analyzer/dead_code_analyzer.py
+++ b/tree_sitter_analyzer/dead_code_analyzer.py
@@ -76,6 +76,16 @@ _KNOWN_ENTRY_PATTERNS = {
     "go": re.compile(r"^(main|init|TestMain)$"),
     "c": re.compile(r"^(main|WinMain)$"),
     "cpp": re.compile(r"^(main|WinMain)$"),
+    # Added alongside call_graph.py's language-parity fix (Codex P1 #1157):
+    # rust/csharp/kotlin/swift all have one unambiguous entry-point
+    # convention. ruby/php/lua are intentionally NOT added here — they
+    # execute top-level script code directly rather than via a single named
+    # entry function, so a regex guess would be as likely to be wrong as
+    # right; dead-code detection for those three remains a known follow-up.
+    "rust": re.compile(r"^(main)$"),
+    "csharp": re.compile(r"^(Main)$"),
+    "kotlin": re.compile(r"^(main)$"),
+    "swift": re.compile(r"^(main)$"),
 }
 
 _TEST_FILE_PATTERNS = re.compile(

--- a/tree_sitter_analyzer/function_extraction.py
+++ b/tree_sitter_analyzer/function_extraction.py
@@ -46,6 +46,14 @@ _FUNC_DEF_TYPES = {
     "swift": {"function_declaration"},
 }
 
+# Languages this module can extract function definitions and call sites
+# for. Single source of truth for callers (e.g. CallGraph.build()) that
+# need to know which files are worth walking — do NOT re-derive this list
+# independently; a hardcoded copy is exactly what let call_graph.py's file
+# scanner silently exclude rust/csharp/kotlin/ruby/php/swift/lua for
+# months even after their dispatch entries above were added.
+SUPPORTED_LANGUAGES = frozenset(_FUNC_DEF_TYPES) | frozenset(_CALL_NODE_TYPES)
+
 # ---------------------------------------------------------------------------
 # Per-language function-name extractors
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `CallGraph.build()` hardcoded a `supported_exts` allowlist to 11 extensions covering only python/js/ts/java/go/c/cpp, completely independent of `function_extraction.py`'s per-language dispatch tables (`_FUNC_DEF_TYPES`/`_CALL_NODE_TYPES`), which already implement rust/csharp/kotlin/ruby/php/swift/lua.
- Because `CallGraph` is the shared backbone for `call_graph_tool`, `dead_code_analyzer`, and every `codegraph_*` MCP tool (context/explore/impact/navigate/overview/pr_review/relation/visualize/metrics), these 7 languages silently returned empty results across the entire CodeGraph-parity surface even though their extraction logic already worked.
- `SUPPORTED_EXTS` is now derived from `EXT_TO_LANG` (the project's documented single source of truth for ext→language, see `languages/lang_extension_map.py`) filtered by a new `function_extraction.SUPPORTED_LANGUAGES` constant, so the two lists can't drift apart again.
- Added a contract test (`test_call_graph_supported_exts_covers_function_extraction_languages`) plus per-language integration fixtures for the 7 previously-excluded languages.

## Verification
- New parity tests (rust/csharp/kotlin/ruby/php/swift/lua) pass; full `tests/unit -k "call_graph or dead_code or codegraph"` suite: 1202 passed, 16 pre-existing skips, 0 new failures.
- Empirically verified against `tests/golden/`: `--call-graph all_functions` went from 277 → 506 detected functions, now including rust/kotlin/ruby/php/swift.
- `mypy`/`ruff` clean on touched files.
- One pre-existing, unrelated failure confirmed on base `develop` too: `test_dead_code_analyzer.py::TestDeadCodeErrorHandling::test_symlink_handled` (Windows symlink privilege, environment-only).

## Out of scope (intentional)
- **Scala**: `Parser.parse_file` currently returns no tree for `.scala` in this environment — a separate root-cause investigation, not this allowlist bug.
- **Bash**: has no `_FUNC_DEF_TYPES`/`_CALL_NODE_TYPES` entries at all — a feature gap, not a regression of this bug.
- Lua's cross-file import resolution (`import_extractors`) still has no lua branch — same-file call resolution now works (verified `callers_of`/`callees_of`), cross-file import-based resolution is a follow-up.

## Test plan
- [x] `pytest tests/unit/test_call_graph_integration.py -v`
- [x] `pytest tests/contracts/ -q`
- [x] Full call-graph/codegraph/dead-code regression sweep (1202 passed)
- [x] `mypy` / `ruff check` clean
- [x] Empirical CLI check against golden corpus