### PR TITLE
Fix project health scan statistics

### DIFF
--- a/tests/unit/test_health_scorer.py
+++ b/tests/unit/test_health_scorer.py
@@ -185,7 +185,16 @@ class TestHealthScorer:
         scores, stats = scorer.score_project_with_stats(str(tmp_path), use_cache=False)
 
         assert scores == []
-        assert stats["skip_reasons"]["scoring_failed"] == 1
+        assert stats == {
+            "total_files_scanned": 1,
+            "total_files_scored": 0,
+            "total_files_skipped": 1,
+            "pruned_directories": 0,
+            "skip_reasons": {
+                "excluded_dir": 0,
+                "scoring_failed": 1,
+            },
+        }
 
     def test_score_project_counts_defensive_excluded_file(self, monkeypatch, tmp_path):
         """A defensive _is_excluded hit is still reported in project stats."""
@@ -205,8 +214,39 @@ class TestHealthScorer:
         scores, stats = scorer.score_project_with_stats(str(tmp_path), use_cache=False)
 
         assert scores == []
-        assert stats["total_files_scanned"] == 1
-        assert stats["skip_reasons"]["excluded_dir"] == 1
+        assert stats == {
+            "total_files_scanned": 1,
+            "total_files_scored": 0,
+            "total_files_skipped": 1,
+            "pruned_directories": 0,
+            "skip_reasons": {
+                "excluded_dir": 1,
+                "scoring_failed": 0,
+            },
+        }
+
+    def test_score_empty_project_has_zeroed_stats(self, tmp_path):
+        """An empty project should report an exact zero-valued partition."""
+        from tree_sitter_analyzer.health_scorer import HealthScorer
+
+        scores, stats = HealthScorer(
+            source_extensions={".py"}
+        ).score_project_with_stats(
+            str(tmp_path),
+            use_cache=False,
+        )
+
+        assert scores == []
+        assert stats == {
+            "total_files_scanned": 0,
+            "total_files_scored": 0,
+            "total_files_skipped": 0,
+            "pruned_directories": 0,
+            "skip_reasons": {
+                "excluded_dir": 0,
+                "scoring_failed": 0,
+            },
+        }
 
     def test_score_project_prunes_hidden_and_generated_dirs(self, tmp_path):
         """Project scoring should not descend into hidden/generated directories."""
@@ -231,7 +271,13 @@ class TestHealthScorer:
 
         assert {Path(score.file_path).name for score in scores} == {"main.py"}
         assert stats["total_files_scanned"] == 1
-        assert stats["skip_reasons"]["excluded_dir"] == 2
+        assert stats["total_files_scored"] == 1
+        assert stats["total_files_skipped"] == 0
+        assert stats["skip_reasons"] == {
+            "excluded_dir": 0,
+            "scoring_failed": 0,
+        }
+        assert stats["pruned_directories"] == 2
 
     def test_large_file_gets_penalized(self, scorer, tmp_path):
         """Files over 500 lines should have lower size score."""

--- a/tests/unit/test_project_health_coverage_fields.py
+++ b/tests/unit/test_project_health_coverage_fields.py
@@ -12,9 +12,10 @@ flagged this as the Q2 ⚠. This test pins the fix so the fields cannot
 quietly disappear.
 
 Required fields:
-  - total_files_scanned   (rglob hits, pre-filter)
+  - total_files_scanned   (source candidates after directory pruning)
   - total_files_analyzed  (alias of total_files for the scored set)
   - total_files_skipped   (scanned but not scored)
+  - pruned_directories    (excluded before file scanning)
   - skip_reasons          {excluded_dir: N, scoring_failed: N}
   - coverage_pct          (analyzed / scanned * 100, rounded to 0.1)
 """
@@ -47,6 +48,7 @@ def test_project_health_emits_coverage_fields(tmp_path: Path) -> None:
         "total_files_scanned",
         "total_files_analyzed",
         "total_files_skipped",
+        "pruned_directories",
         "skip_reasons",
         "coverage_pct",
     ):
@@ -57,20 +59,21 @@ def test_project_health_emits_coverage_fields(tmp_path: Path) -> None:
         )
 
 
-def test_excluded_dirs_show_up_in_skip_reasons(tmp_path: Path) -> None:
-    """``__pycache__/ignored.py`` must be counted as excluded_dir skip."""
+def test_pruned_dirs_are_separate_from_skipped_files(tmp_path: Path) -> None:
+    """Pruned directories must not be mixed into file skip statistics."""
     project = _make_project(tmp_path)
     tool = ProjectHealthTool(str(project))
     result = asyncio.run(tool.execute({"output_format": "json", "max_files": 5}))
 
-    skip_reasons = result["skip_reasons"]
-    # The excluded-dir count must reflect the pycache file we planted.
-    assert skip_reasons["excluded_dir"], (
-        f"expected at least 1 excluded_dir skip (the __pycache__ file), "
-        f"got skip_reasons={skip_reasons}"
-    )
-    # No scoring failures expected on this trivial fixture.
-    assert skip_reasons["scoring_failed"] == 0
+    assert result["total_files_scanned"] == 2
+    assert result["total_files_analyzed"] == 2
+    assert result["total_files_skipped"] == 0
+    assert result["skip_reasons"] == {
+        "excluded_dir": 0,
+        "scoring_failed": 0,
+    }
+    # The fixture plants __pycache__; the default health cache adds .ast-cache.
+    assert result["pruned_directories"] == 2
 
 
 def test_coverage_pct_is_consistent(tmp_path: Path) -> None:

--- a/tree_sitter_analyzer/health_scorer.py
+++ b/tree_sitter_analyzer/health_scorer.py
@@ -310,7 +310,7 @@ class HealthScorer:
 
         Coverage stats let an agent answer "how many files did you
         actually look at?" honestly — the difference between scanned
-        and scored files (excluded directories, parse failures) is the
+        and scored files (defensive exclusions, parse failures) is the
         kind of information that used to be silently dropped before
         ``TRUST_BUT_VERIFY_2026-05-23.md``.
 
@@ -325,11 +325,12 @@ class HealthScorer:
             Tuple of (scores, stats) where stats has shape::
 
                 {
-                    "total_files_scanned":   int,  # rglob hits, pre-filter
+                    "total_files_scanned":   int,  # candidates after dir pruning
                     "total_files_scored":    int,  # actually scored
                     "total_files_skipped":   int,  # scanned but not scored
+                    "pruned_directories":    int,  # excluded before file scanning
                     "skip_reasons": {
-                        "excluded_dir":   int,  # in self._EXCLUDE_DIRS
+                        "excluded_dir":   int,  # defensive file-level exclusions
                         "scoring_failed": int,  # score_file raised
                     },
                 }
@@ -343,14 +344,15 @@ class HealthScorer:
         cache = HealthScoreCache(str(root)) if use_cache else None
         results: list[HealthScore] = []
         scanned = 0
-        excluded_dir = 0
+        excluded_files = 0
+        pruned_directories = 0
         scoring_failed = 0
         try:
-            files, excluded_dir = self._iter_source_files(root)
+            files, pruned_directories = self._iter_source_files(root)
             for f in files:
                 scanned += 1
                 if self._is_excluded(f, root):
-                    excluded_dir += 1
+                    excluded_files += 1
                     continue
                 score = self._score_file_with_cache(str(f), cache)
                 if score is None:
@@ -365,9 +367,10 @@ class HealthScorer:
         stats: dict[str, Any] = {
             "total_files_scanned": scanned,
             "total_files_scored": len(results),
-            "total_files_skipped": excluded_dir + scoring_failed,
+            "total_files_skipped": excluded_files + scoring_failed,
+            "pruned_directories": pruned_directories,
             "skip_reasons": {
-                "excluded_dir": excluded_dir,
+                "excluded_dir": excluded_files,
                 "scoring_failed": scoring_failed,
             },
         }

--- a/tree_sitter_analyzer/mcp/tools/project_health_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/project_health_tool.py
@@ -310,6 +310,7 @@ def _build_project_health_result(
         payload["total_files_scanned"] = scanned
         payload["total_files_analyzed"] = analyzed
         payload["total_files_skipped"] = int(walk_stats.get("total_files_skipped", 0))
+        payload["pruned_directories"] = int(walk_stats.get("pruned_directories", 0))
         payload["skip_reasons"] = walk_stats.get(
             "skip_reasons", {"excluded_dir": 0, "scoring_failed": 0}
         )


### PR DESCRIPTION
## What changed

- separate pruned directory counts from scanned/skipped file counts
- add `pruned_directories` to project-health output
- preserve the invariant `total_files_scanned = total_files_analyzed + total_files_skipped`
- add exact tests for normal, defensive-exclusion, scoring-failure, and empty-project paths

## Root cause

The optimized `os.walk` traversal returned a count of pruned directories, but `score_project_with_stats()` treated that value as skipped files. This produced internally contradictory output such as `scanned=1916`, `analyzed=1916`, `skipped=119`.

## User impact

Project-health consumers now receive unit-consistent scan statistics. Existing fields keep their meanings; `pruned_directories` is additive and backward compatible.

## Validation

- focused change-impact suite: 89 passed, 1 tracked skip
- quick-gate test bodies: 1,262 passed, 7 tracked skips
- patch coverage: no added executable misses
- Ruff check and Ruff format: passed
- Mypy on changed source: passed
- `git diff --check`: passed
- independent diagnosis: PASS
- adversarial red-team review: PASS

The repository's pre-existing `pytest_terminal_summary` hook can raise `psutil.NoSuchProcess` after tests reach 100% in this container; rerunning with only that terminal hook disabled produced clean zero exit codes.