### PR TITLE
fix: expose bounded index error details

### DIFF
--- a/tests/unit/mcp/test_incremental_sync_bug_806.py
+++ b/tests/unit/mcp/test_incremental_sync_bug_806.py
@@ -78,6 +78,20 @@ def _make_sync_result_with_one_error() -> SyncResult:
     return result
 
 
+def _make_returned_parse_error() -> SyncResult:
+    result = SyncResult(scanned=1, new_files=1, errors=1)
+    result.details = [
+        {
+            "file": "src/bad.swift",
+            "considered": "indexed",
+            "action": "indexed",
+            "status": "error",
+            "reason": "Swift grammar not installed",
+        }
+    ]
+    return result
+
+
 # ---------------------------------------------------------------------------
 # MCP tool layer: response envelope must carry per-file error attribution
 # ---------------------------------------------------------------------------
@@ -184,6 +198,69 @@ class TestMCPResponseEnvelopeOnPerFileError:
         # 3 files scanned total
         assert result["scanned"] == 3
 
+    async def test_partial_error_escalates_verdict_to_warn(self, mcp_tool, project):
+        controlled_result = _make_returned_parse_error()
+
+        with patch.object(IncrementalSync, "sync", return_value=controlled_result):
+            result = await mcp_tool.execute(
+                {"mode": "sync", "max_files": 100, "output_format": "json"}
+            )
+
+        assert result["success"] is True
+        assert result["verdict"] == "WARN"
+
+    async def test_external_path_in_error_message_is_redacted(self, mcp_tool, project):
+        controlled_result = _make_sync_result_with_one_error()
+        controlled_result.details[-1]["error_message"] = "denied /etc/shadow"
+
+        with patch.object(IncrementalSync, "sync", return_value=controlled_result):
+            result = await mcp_tool.execute(
+                {"mode": "sync", "max_files": 100, "output_format": "json"}
+            )
+
+        assert result["details"][-1]["error_message"] == "denied <external-path>"
+
+    async def test_long_error_reason_has_explicit_truncation(self, mcp_tool, project):
+        controlled_result = _make_returned_parse_error()
+        controlled_result.details[0]["reason"] = "x" * 501
+
+        with patch.object(IncrementalSync, "sync", return_value=controlled_result):
+            result = await mcp_tool.execute(
+                {"mode": "sync", "max_files": 100, "output_format": "json"}
+            )
+
+        assert result["details"][0]["reason"] == ("x" * 497) + "..."
+        assert result["details"][0]["reason_truncated"] is True
+
+    async def test_invalid_and_unknown_details_do_not_cross_mcp_boundary(
+        self, mcp_tool, project
+    ):
+        controlled_result = _make_returned_parse_error()
+        controlled_result.details.extend(
+            [
+                "path=/etc/shadow",
+                None,
+                {
+                    "file": "src/other.swift",
+                    "status": "error",
+                    "context": "path=/etc/passwd",
+                    "blob": "x" * 2_000,
+                },
+            ]
+        )
+
+        with patch.object(IncrementalSync, "sync", return_value=controlled_result):
+            result = await mcp_tool.execute(
+                {"mode": "sync", "max_files": 100, "output_format": "json"}
+            )
+
+        assert result["invalid_details_dropped"] == 2
+        assert result["details"][-1] == {
+            "file": "src/other.swift",
+            "status": "error",
+        }
+        assert "/etc/" not in repr(result)
+
 
 # ---------------------------------------------------------------------------
 # Outer catch-all in MCP tool: must not swallow batch for outer exceptions
@@ -223,6 +300,22 @@ class TestMCPOuterExceptionSurface:
         error_msg = result.get("error", "")
         assert "RuntimeError" in error_msg
 
+    async def test_outer_exception_is_bounded_with_explicit_flag(
+        self, mcp_tool, project
+    ):
+        with patch.object(
+            IncrementalSync,
+            "sync",
+            side_effect=RuntimeError("x" * 10_000),
+        ):
+            result = await mcp_tool.execute(
+                {"mode": "sync", "max_files": 100, "output_format": "json"}
+            )
+
+        assert len(result["error"]) == 500
+        assert result["error"].endswith("...")
+        assert result["error_truncated"] is True
+
 
 # ---------------------------------------------------------------------------
 # TOON default path: error attribution must survive TOON formatting (#806)
@@ -257,3 +350,15 @@ class TestMCPResponseEnvelopeOnPerFileErrorToon:
             result = await mcp_tool.execute({"mode": "sync", "max_files": 100})
 
         assert result.get("errors") == 1
+
+    async def test_toon_response_contains_returned_parse_reason(
+        self, mcp_tool, project
+    ):
+        controlled_result = _make_returned_parse_error()
+
+        with patch.object(IncrementalSync, "sync", return_value=controlled_result):
+            result = await mcp_tool.execute({"mode": "sync", "max_files": 100})
+
+        assert result.get("format") == "toon"
+        assert "src/bad.swift" in result.get("toon_content", "")
+        assert "Swift grammar not installed" in result.get("toon_content", "")

--- a/tests/unit/mcp/utils/test_error_sanitizer.py
+++ b/tests/unit/mcp/utils/test_error_sanitizer.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
 
 from tree_sitter_analyzer.mcp.utils.error_sanitizer import (
+    bounded_safe_error_message,
     safe_error_message,
+    sanitize_error_detail,
     sanitize_exception,
     sanitize_message,
 )
@@ -48,6 +51,126 @@ class TestSanitizeMessage:
         once = sanitize_message(msg, str(tmp_path))
         twice = sanitize_message(once, str(tmp_path))
         assert once == twice
+
+    @pytest.mark.parametrize(
+        ("message", "expected"),
+        [
+            ("failure path=/etc/shadow", "failure path=<external-path>"),
+            ("failure [/etc/shadow]", "failure [<external-path>]"),
+            ("failure {/etc/shadow}", "failure {<external-path>}"),
+        ],
+    )
+    def test_external_path_is_redacted_at_punctuation_boundaries(
+        self,
+        message: str,
+        expected: str,
+        tmp_path: Path,
+    ):
+        assert sanitize_message(message, str(tmp_path)) == expected
+
+    def test_project_path_is_relative_at_equals_boundary(self, tmp_path: Path):
+        target = tmp_path / "src" / "bad.py"
+        assert sanitize_message(f"path={target}", str(tmp_path)) == "path=./src/bad.py"
+
+    @pytest.mark.parametrize("prefix", ["failure-", "failure_", "failure."])
+    def test_external_path_is_redacted_after_word_punctuation(
+        self,
+        prefix: str,
+        tmp_path: Path,
+    ):
+        assert (
+            sanitize_message(f"{prefix}/etc/shadow", str(tmp_path))
+            == f"{prefix}<external-path>"
+        )
+
+    def test_unquoted_external_path_with_spaces_is_fully_redacted(self, tmp_path: Path):
+        assert (
+            sanitize_message(
+                "failed /Users/alice/My Secrets/key.txt",
+                str(tmp_path),
+            )
+            == "failed <external-path>"
+        )
+
+    def test_unquoted_project_path_with_spaces_stays_actionable(self, tmp_path: Path):
+        target = tmp_path / "My Secrets" / "key.txt"
+        assert (
+            sanitize_message(f"failed {target}", str(tmp_path))
+            == "failed ./My Secrets/key.txt"
+        )
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX host path interpretation")
+    @pytest.mark.parametrize(
+        "external_path",
+        [r"C:\Users\alice\secret.txt", r"\\server\share\secret.txt"],
+    )
+    def test_windows_paths_are_not_treated_as_project_relative_on_posix(
+        self,
+        external_path: str,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.chdir(tmp_path)
+        cleaned = sanitize_message(f"denied {external_path}", str(tmp_path))
+        assert cleaned == "denied <external-path>"
+
+
+class TestSanitizeErrorDetail:
+    def test_sanitizes_copy_without_mutating_core_detail(self, tmp_path: Path):
+        detail = {
+            "file": str(tmp_path / "src" / "bad.py"),
+            "status": "error",
+            "error_message": "denied /etc/shadow",
+        }
+
+        cleaned = sanitize_error_detail(detail, str(tmp_path))
+
+        assert cleaned == {
+            "file": "./src/bad.py",
+            "status": "error",
+            "error_message": "denied <external-path>",
+        }
+        assert detail["file"] == str(tmp_path / "src" / "bad.py")
+        assert detail["error_message"] == "denied /etc/shadow"
+
+    def test_truncation_is_exact_and_explicit(self):
+        cleaned = sanitize_error_detail(
+            {"file": "src/bad.swift", "status": "error", "reason": "x" * 501}
+        )
+
+        assert cleaned["reason"] == ("x" * 497) + "..."
+        assert cleaned["reason_truncated"] is True
+
+    def test_structured_file_path_handles_spaces(self, tmp_path: Path):
+        project_root = tmp_path / "my project"
+        file_path = project_root / "src folder" / "bad.py"
+
+        cleaned = sanitize_error_detail(
+            {"file": str(file_path), "status": "error"},
+            str(project_root),
+        )
+
+        assert cleaned["file"] == "./src folder/bad.py"
+
+    def test_structured_file_path_redacts_relative_traversal(self, tmp_path: Path):
+        cleaned = sanitize_error_detail(
+            {"file": "../outside/secret.py", "status": "error"},
+            str(tmp_path),
+        )
+
+        assert cleaned["file"] == "<external-path>"
+
+    def test_unknown_fields_are_dropped(self):
+        cleaned = sanitize_error_detail(
+            {
+                "file": "src/bad.py",
+                "status": "error",
+                "context": "path=/etc/passwd",
+                "blob": "x" * 2_000,
+            }
+        )
+
+        assert cleaned == {"file": "src/bad.py", "status": "error"}
 
 
 class TestSanitizeException:
@@ -94,6 +217,17 @@ class TestSafeErrorMessage:
             out = safe_error_message(e, str(tmp_path), include_class=False)
             assert "ValueError" not in out
             assert "boom" in out
+
+    def test_bounded_message_reports_exact_truncation(self, tmp_path: Path):
+        message, truncated = bounded_safe_error_message(
+            RuntimeError("x" * 1_000),
+            str(tmp_path),
+            prefix="Sync failed: ",
+        )
+
+        assert len(message) == 500
+        assert message.endswith("...")
+        assert truncated is True
 
 
 class TestIntegrationWithErrorRecovery:

--- a/tests/unit/test_codegraph_full_index_tool.py
+++ b/tests/unit/test_codegraph_full_index_tool.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 
+from tree_sitter_analyzer.incremental_sync import SyncResult
 from tree_sitter_analyzer.mcp.tools.full_index_tool import CodeGraphFullIndexTool
 
 
@@ -97,3 +100,249 @@ class TestExecute:
         assert result["verdict"] == "WARN"
         assert result["phases"]["incremental_sync"]["status"] == "error"
         assert result["phases"]["incremental_sync"]["errors"] == 1
+
+    async def test_verdict_is_warn_when_ast_cache_has_errors(self, tool_with_root):
+        with (
+            patch.object(
+                tool_with_root,
+                "_phase_ast_cache",
+                return_value={"status": "error", "errors": 1},
+            ),
+            patch.object(
+                tool_with_root,
+                "_phase_incremental_sync",
+                return_value={"status": "ok", "errors": 0},
+            ),
+            patch.object(
+                tool_with_root,
+                "_phase_fts5_stats",
+                return_value={"status": "ok"},
+            ),
+            patch.object(
+                tool_with_root,
+                "_phase_call_edge_stats",
+                return_value={"status": "ok"},
+            ),
+            patch.object(tool_with_root, "_collect_final_stats", return_value={}),
+        ):
+            result = await tool_with_root.execute(
+                {
+                    "mode": "incremental",
+                    "resolve_synapse": False,
+                    "output_format": "json",
+                }
+            )
+
+        assert result["success"] is True
+        assert result["verdict"] == "WARN"
+
+    async def test_default_toon_surfaces_truncation_metadata(self, tool_with_root):
+        incremental_phase = {
+            "status": "error",
+            "errors": 21,
+            "error_details": [{"file": "src/00.swift", "status": "error"}],
+            "error_details_total": 21,
+            "error_details_listed": 20,
+            "error_details_cap": 20,
+            "error_details_truncated": True,
+        }
+        with (
+            patch.object(
+                tool_with_root,
+                "_phase_ast_cache",
+                return_value={"status": "ok", "errors": 0},
+            ),
+            patch.object(
+                tool_with_root,
+                "_phase_incremental_sync",
+                return_value=incremental_phase,
+            ),
+            patch.object(
+                tool_with_root,
+                "_phase_fts5_stats",
+                return_value={"status": "ok"},
+            ),
+            patch.object(
+                tool_with_root,
+                "_phase_call_edge_stats",
+                return_value={"status": "ok"},
+            ),
+            patch.object(tool_with_root, "_collect_final_stats", return_value={}),
+        ):
+            result = await tool_with_root.execute(
+                {"mode": "incremental", "resolve_synapse": False}
+            )
+
+        assert result["format"] == "toon"
+        assert "error_details_truncated: true" in result["toon_content"]
+
+
+class TestErrorTransparency:
+    """Incident 2026-07-26: indexing failures must stay actionable and bounded."""
+
+    @staticmethod
+    def _ast_result_with_errors():
+        return {
+            "indexed": 1,
+            "cached": 0,
+            "errors": 2,
+            "files": [
+                {
+                    "file": "src/z_bad.swift",
+                    "status": "error",
+                    "reason": "Swift grammar not installed",
+                },
+                {"file": "src/good.py", "status": "indexed"},
+                {
+                    "file": "src/a_bad.lua",
+                    "status": "error",
+                    "reason": "LUA grammar not installed",
+                },
+            ],
+        }
+
+    def _run_ast_phase(self, tool_with_root):
+        ast_result = self._ast_result_with_errors()
+        with patch("tree_sitter_analyzer.ast_cache.ASTCache") as cache_cls:
+            cache_cls.return_value.index_project.return_value = ast_result
+            return tool_with_root._phase_ast_cache(False, 10)
+
+    @staticmethod
+    def _run_incremental_phase(tool_with_root, sync_result):
+        with (
+            patch("tree_sitter_analyzer.ast_cache.ASTCache"),
+            patch("tree_sitter_analyzer.incremental_sync.IncrementalSync") as sync_cls,
+        ):
+            sync_cls.return_value.sync.return_value = sync_result
+            return tool_with_root._phase_incremental_sync()
+
+    def test_ast_phase_marks_returned_errors(self, tool_with_root):
+        phase = self._run_ast_phase(tool_with_root)
+
+        assert phase["status"] == "error"
+        assert phase["errors"] == 2
+
+    def test_ast_phase_reports_sorted_error_details(self, tool_with_root):
+        phase = self._run_ast_phase(tool_with_root)
+
+        assert phase["error_details"] == [
+            {
+                "file": "src/a_bad.lua",
+                "status": "error",
+                "reason": "LUA grammar not installed",
+            },
+            {
+                "file": "src/z_bad.swift",
+                "status": "error",
+                "reason": "Swift grammar not installed",
+            },
+        ]
+
+    def test_ast_phase_reports_detail_metadata(self, tool_with_root):
+        phase = self._run_ast_phase(tool_with_root)
+
+        assert {
+            key: phase[key]
+            for key in (
+                "error_details_total",
+                "error_details_listed",
+                "error_details_cap",
+                "error_details_truncated",
+                "unattributed_errors",
+            )
+        } == {
+            "error_details_total": 2,
+            "error_details_listed": 2,
+            "error_details_cap": 20,
+            "error_details_truncated": False,
+            "unattributed_errors": 0,
+        }
+
+    def test_incremental_phase_sorts_before_returning_details(self, tool_with_root):
+        sync_result = SyncResult(errors=3)
+        sync_result.details = [
+            {"file": f"src/{index}.swift", "status": "error"}
+            for index in reversed(range(3))
+        ]
+
+        phase = self._run_incremental_phase(tool_with_root, sync_result)
+
+        assert [detail["file"] for detail in phase["error_details"]] == [
+            "src/0.swift",
+            "src/1.swift",
+            "src/2.swift",
+        ]
+
+    def test_incremental_phase_caps_error_details(self, tool_with_root):
+        sync_result = SyncResult(errors=21)
+        sync_result.details = [
+            {
+                "file": f"src/{index:02}.swift",
+                "status": "error",
+                "reason": "Swift grammar not installed",
+            }
+            for index in reversed(range(21))
+        ]
+
+        phase = self._run_incremental_phase(tool_with_root, sync_result)
+
+        assert phase["error_details_total"] == 21
+        assert phase["error_details_listed"] == 20
+        assert phase["error_details_cap"] == 20
+        assert phase["error_details_truncated"] is True
+        assert len(phase["error_details"]) == 20
+        assert (
+            phase["error_details_next_step"]
+            == "Run --incremental-sync --format json for uncapped per-file details."
+        )
+
+    def test_incremental_phase_reports_unattributed_errors(self, tool_with_root):
+        sync_result = SyncResult(errors=2)
+        sync_result.details = [{"file": "src/bad.swift", "status": "error"}]
+
+        phase = self._run_incremental_phase(tool_with_root, sync_result)
+
+        assert phase["unattributed_errors"] == 1
+
+    def test_error_detail_keeps_phase_status_honest_when_count_is_inconsistent(
+        self, tool_with_root
+    ):
+        sync_result = SyncResult(errors=0)
+        sync_result.details = [{"file": "src/bad.swift", "status": "error"}]
+
+        phase = self._run_incremental_phase(tool_with_root, sync_result)
+
+        assert phase["errors"] == 0
+        assert phase["status"] == "error"
+
+    def test_ast_cache_closes_after_index_exception(self, tool_with_root):
+        with patch("tree_sitter_analyzer.ast_cache.ASTCache") as cache_cls:
+            cache_cls.return_value.index_project.side_effect = RuntimeError("boom")
+            tool_with_root._phase_ast_cache(False, 10)
+
+        cache_cls.return_value.close.assert_called_once_with()
+
+    def test_ast_cache_close_failure_does_not_mask_result(self, tool_with_root):
+        ast_result = {
+            "indexed": 0,
+            "cached": 0,
+            "errors": 0,
+            "files": [],
+        }
+        with patch("tree_sitter_analyzer.ast_cache.ASTCache") as cache_cls:
+            cache_cls.return_value.index_project.return_value = ast_result
+            cache_cls.return_value.close.side_effect = RuntimeError("close failed")
+            phase = tool_with_root._phase_ast_cache(False, 10)
+
+        assert phase["status"] == "ok"
+
+    def test_ast_outer_exception_is_bounded(self, tool_with_root):
+        with patch("tree_sitter_analyzer.ast_cache.ASTCache") as cache_cls:
+            cache_cls.return_value.index_project.side_effect = RuntimeError(
+                "x" * 10_000
+            )
+            phase = tool_with_root._phase_ast_cache(False, 10)
+
+        assert len(phase["error"]) == 500
+        assert phase["error"].endswith("...")
+        assert phase["error_truncated"] is True

--- a/tests/unit/test_codegraph_incremental_sync_tool.py
+++ b/tests/unit/test_codegraph_incremental_sync_tool.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 
+from tree_sitter_analyzer.incremental_sync import IncrementalSync, SyncResult
 from tree_sitter_analyzer.mcp.tools.incremental_sync_tool import (
     CodeGraphIncrementalSyncTool,
 )
@@ -80,3 +83,66 @@ class TestExecute:
         result = await tool_with_root.execute({"mode": "status"})
         assert result["format"] == "toon"
         assert "toon_content" in result
+
+
+class TestCacheLifecycle:
+    def test_sync_closes_cache_after_success(self, tool_with_root):
+        cache = MagicMock()
+        with (
+            patch.object(tool_with_root, "_ensure_cache", return_value=cache),
+            patch.object(IncrementalSync, "sync", return_value=SyncResult()),
+        ):
+            tool_with_root._sync(100, "json")
+
+        cache.close.assert_called_once_with()
+
+    def test_sync_closes_cache_after_exception(self, tool_with_root):
+        cache = MagicMock()
+        with (
+            patch.object(tool_with_root, "_ensure_cache", return_value=cache),
+            patch.object(
+                IncrementalSync,
+                "sync",
+                side_effect=RuntimeError("sync failed"),
+            ),
+        ):
+            tool_with_root._sync(100, "json")
+
+        cache.close.assert_called_once_with()
+
+    def test_sync_closes_cache_after_sync_constructor_exception(self, tool_with_root):
+        cache = MagicMock()
+        with (
+            patch.object(tool_with_root, "_ensure_cache", return_value=cache),
+            patch(
+                "tree_sitter_analyzer.mcp.tools.incremental_sync_tool.IncrementalSync",
+                side_effect=RuntimeError("constructor failed"),
+            ),
+        ):
+            tool_with_root._sync(100, "json")
+
+        cache.close.assert_called_once_with()
+
+    def test_changes_closes_cache(self, tool_with_root):
+        cache = MagicMock()
+        with (
+            patch.object(tool_with_root, "_ensure_cache", return_value=cache),
+            patch.object(IncrementalSync, "get_changes", return_value={}),
+        ):
+            tool_with_root._changes("json")
+
+        cache.close.assert_called_once_with()
+
+    def test_status_closes_cache(self, tool_with_root):
+        cache = MagicMock()
+        cache.get_stats.return_value = {}
+        with (
+            patch(
+                "tree_sitter_analyzer.ast_cache.ASTCache",
+                return_value=cache,
+            ),
+            patch.object(IncrementalSync, "get_changes", return_value={}),
+        ):
+            tool_with_root._status("json")
+
+        cache.close.assert_called_once_with()

--- a/tests/unit/test_incremental_sync.py
+++ b/tests/unit/test_incremental_sync.py
@@ -206,6 +206,89 @@ class TestContentHashComparison:
         assert result.updated_files == 0
 
 
+class TestReturnedErrorDetails:
+    """Incident 2026-07-26: returned parse failures must keep their reason."""
+
+    def test_new_file_error_result_preserves_reason(self, sync, cache):
+        with patch.object(
+            cache,
+            "index_file",
+            return_value={
+                "status": "error",
+                "reason": "Swift grammar not installed",
+            },
+        ):
+            detail = sync._index_new_file(
+                "src/bad.swift",
+                "/project/src/bad.swift",
+                cache.get_conn(),
+            )
+
+        assert detail == {
+            "file": "src/bad.swift",
+            "considered": "indexed",
+            "action": "indexed",
+            "status": "error",
+            "reason": "Swift grammar not installed",
+        }
+
+    def test_modified_file_error_result_preserves_reason(self, sync, cache):
+        with (
+            patch.object(cache, "invalidate"),
+            patch.object(
+                cache,
+                "index_file",
+                return_value={
+                    "status": "error",
+                    "reason": "LUA grammar not installed",
+                },
+            ),
+        ):
+            detail = sync._reindex_modified(
+                "src/bad.lua",
+                "/project/src/bad.lua",
+                cache.get_conn(),
+            )
+
+        assert detail == {
+            "file": "src/bad.lua",
+            "considered": "updated",
+            "action": "updated",
+            "status": "error",
+            "reason": "LUA grammar not installed",
+        }
+
+    def test_public_sync_attributes_returned_error_and_continues(
+        self, sync, cache, project
+    ):
+        bad_file = project / "src" / "bad.swift"
+        bad_file.write_text("func broken() {}\n")
+        original_index_file = cache.index_file
+
+        def index_file(path):
+            if path == str(bad_file):
+                return {
+                    "status": "error",
+                    "reason": "Swift grammar not installed",
+                }
+            return original_index_file(path)
+
+        with patch.object(cache, "index_file", side_effect=index_file):
+            result = sync.sync()
+
+        assert result.errors == 1
+        assert result.new_files == 4
+        assert [d for d in result.details if d.get("status") == "error"] == [
+            {
+                "file": "src/bad.swift",
+                "considered": "indexed",
+                "action": "indexed",
+                "status": "error",
+                "reason": "Swift grammar not installed",
+            }
+        ]
+
+
 class TestRecursionErrorHandling:
     """Issue #805: RecursionError from deeply-nested AST must not abort sync."""
 

--- a/tree_sitter_analyzer/incremental_sync.py
+++ b/tree_sitter_analyzer/incremental_sync.py
@@ -272,12 +272,15 @@ class IncrementalSync:
                 "error_message": str(exc),
             }
         status = index_result.get("status", "unknown")
-        return {
+        detail = {
             "file": rel_path,
             "considered": "indexed",
             "action": "indexed",
             "status": status,
         }
+        if status == "error" and "reason" in index_result:
+            detail["reason"] = index_result["reason"]
+        return detail
 
     def _reindex_modified(
         self,
@@ -316,12 +319,15 @@ class IncrementalSync:
                 "error_message": str(exc),
             }
         status = index_result.get("status", "unknown")
-        return {
+        detail = {
             "file": rel_path,
             "considered": "updated",
             "action": "updated",
             "status": status,
         }
+        if status == "error" and "reason" in index_result:
+            detail["reason"] = index_result["reason"]
+        return detail
 
     def get_changes(self) -> dict[str, list[str]]:
         """

--- a/tree_sitter_analyzer/mcp/tools/full_index_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/full_index_tool.py
@@ -23,10 +23,88 @@ from typing import Any
 
 from ...utils import setup_logger
 from ..utils.auto_index_guard import mark_dirty
+from ..utils.error_sanitizer import (
+    bounded_safe_error_message,
+    sanitize_error_detail,
+)
 from ..utils.format_helper import apply_toon_format_to_response
 from .base_tool import BaseMCPTool
 
 logger = setup_logger(__name__)
+
+_ERROR_DETAILS_CAP = 20
+_INCREMENTAL_DETAILS_NEXT_STEP = (
+    "Run --incremental-sync --format json for uncapped per-file details."
+)
+
+
+def _safe_close_cache(cache: Any | None) -> None:
+    """Close an owned cache without masking the primary phase result."""
+    if cache is None:
+        return
+    try:
+        cache.close()
+    except Exception as exc:
+        logger.debug("AST cache close failed (%s)", type(exc).__name__)
+
+
+def _phase_error(
+    exc: BaseException,
+    project_root: str | None,
+    *,
+    elapsed_seconds: float | None = None,
+) -> dict[str, Any]:
+    error, truncated = bounded_safe_error_message(exc, project_root)
+    result: dict[str, Any] = {
+        "status": "error",
+        "error": error,
+        "error_truncated": truncated,
+    }
+    if elapsed_seconds is not None:
+        result["elapsed_seconds"] = elapsed_seconds
+    return result
+
+
+def _bounded_error_details(
+    details: Any,
+    errors: int,
+    project_root: str | None,
+    *,
+    next_step: str,
+) -> dict[str, Any]:
+    """Build a deterministic, response-safe summary of per-file errors."""
+    detail_items = details if isinstance(details, list) else []
+    candidates = [
+        sanitize_error_detail(detail, project_root)
+        for detail in detail_items
+        if isinstance(detail, dict) and detail.get("status") == "error"
+    ]
+    candidates.sort(
+        key=lambda detail: (
+            str(detail.get("file", "")),
+            str(detail.get("error_type", "")),
+            str(
+                detail.get(
+                    "reason",
+                    detail.get("error_message", detail.get("error", "")),
+                )
+            ),
+        )
+    )
+    total = len(candidates)
+    listed = min(total, _ERROR_DETAILS_CAP)
+    truncated = total > listed
+    summary: dict[str, Any] = {
+        "error_details": candidates[:listed],
+        "error_details_total": total,
+        "error_details_listed": listed,
+        "error_details_cap": _ERROR_DETAILS_CAP,
+        "error_details_truncated": truncated,
+        "unattributed_errors": max(0, errors - total),
+    }
+    if truncated:
+        summary["error_details_next_step"] = next_step
+    return summary
 
 
 class CodeGraphFullIndexTool(BaseMCPTool):
@@ -96,7 +174,7 @@ class CodeGraphFullIndexTool(BaseMCPTool):
                     "items": {"type": "string"},
                     "description": (
                         "Additional fnmatch glob patterns (relative to project root) "
-                        "to exclude from indexing. Example: [\"tests/golden/corpus_*\"]. "
+                        'to exclude from indexing. Example: ["tests/golden/corpus_*"]. '
                         "Combined with built-in defaults unless no_default_excludes=true."
                     ),
                     "default": [],
@@ -201,6 +279,7 @@ class CodeGraphFullIndexTool(BaseMCPTool):
         no_default_excludes: bool = False,
     ) -> dict[str, Any]:
         t0 = time.monotonic()
+        cache: Any | None = None
         try:
             from ...ast_cache import ASTCache
             from ...cache.indexer import _DEFAULT_EXCLUDE_PATTERNS
@@ -222,9 +301,18 @@ class CodeGraphFullIndexTool(BaseMCPTool):
             indexed = result.get("indexed", 0)
             cached = result.get("cached", 0)
             errors = result.get("errors", 0)
-            cache.close()
+            error_summary = _bounded_error_details(
+                result.get("files", []),
+                errors,
+                str(self.project_root) if self.project_root else None,
+                next_step=_INCREMENTAL_DETAILS_NEXT_STEP,
+            )
             return {
-                "status": "ok",
+                "status": (
+                    "error"
+                    if errors > 0 or error_summary["error_details_total"] > 0
+                    else "ok"
+                ),
                 "elapsed_seconds": elapsed,
                 "files_indexed": indexed,
                 "files_cached": cached,
@@ -235,16 +323,20 @@ class CodeGraphFullIndexTool(BaseMCPTool):
                 # the synapse_resolution phase can report without re-running (A1).
                 "synapse_backfill": result.get("synapse_backfill"),
                 "unresolved_refs_backfill": result.get("unresolved_refs_backfill"),
+                **error_summary,
             }
         except Exception as exc:
-            return {
-                "status": "error",
-                "error": str(exc),
-                "elapsed_seconds": round(time.monotonic() - t0, 3),
-            }
+            return _phase_error(
+                exc,
+                str(self.project_root) if self.project_root else None,
+                elapsed_seconds=round(time.monotonic() - t0, 3),
+            )
+        finally:
+            _safe_close_cache(cache)
 
     def _phase_incremental_sync(self) -> dict[str, Any]:
         t0 = time.monotonic()
+        cache: Any | None = None
         try:
             from ...ast_cache import ASTCache
             from ...incremental_sync import IncrementalSync
@@ -252,11 +344,20 @@ class CodeGraphFullIndexTool(BaseMCPTool):
             cache = ASTCache(self.project_root or ".")
             sync = IncrementalSync(cache)
             result = sync.sync(max_files=20_000)
-            cache.close()
             elapsed = round(time.monotonic() - t0, 3)
+            error_summary = _bounded_error_details(
+                result.details,
+                result.errors,
+                str(self.project_root) if self.project_root else None,
+                next_step=_INCREMENTAL_DETAILS_NEXT_STEP,
+            )
             # #860: surface DB flush failures — sync catches them into result.errors
             # so they never raise but also must NOT be silently reported as "ok".
-            status = "error" if result.errors > 0 else "ok"
+            status = (
+                "error"
+                if result.errors > 0 or error_summary["error_details_total"] > 0
+                else "ok"
+            )
             return {
                 "status": status,
                 "elapsed_seconds": elapsed,
@@ -266,28 +367,35 @@ class CodeGraphFullIndexTool(BaseMCPTool):
                 "deleted_files": result.deleted_files,
                 "unchanged_files": result.unchanged_files,
                 "errors": result.errors,
+                **error_summary,
             }
         except Exception as exc:
-            return {
-                "status": "error",
-                "error": str(exc),
-                "elapsed_seconds": round(time.monotonic() - t0, 3),
-            }
+            return _phase_error(
+                exc,
+                str(self.project_root) if self.project_root else None,
+                elapsed_seconds=round(time.monotonic() - t0, 3),
+            )
+        finally:
+            _safe_close_cache(cache)
 
     def _phase_fts5_stats(self) -> dict[str, Any]:
+        cache: Any | None = None
         try:
             from ...ast_cache import ASTCache
 
             cache = ASTCache(self.project_root or ".")
             stats = cache.get_stats()
-            cache.close()
             return {
                 "status": "ok",
                 "fts5_available": stats.get("fts5_available", False),
                 "fts_indexed_symbols": stats.get("fts_indexed_symbols", 0),
             }
         except Exception as exc:
-            return {"status": "error", "error": str(exc)}
+            return _phase_error(
+                exc, str(self.project_root) if self.project_root else None
+            )
+        finally:
+            _safe_close_cache(cache)
 
     def _phase_synapse(self, ast_phase: dict[str, Any]) -> dict[str, Any]:
         """Report cross-file resolution results.
@@ -313,13 +421,13 @@ class CodeGraphFullIndexTool(BaseMCPTool):
         }
 
     def _phase_call_edge_stats(self) -> dict[str, Any]:
+        cache: Any | None = None
         try:
             from ...ast_cache import ASTCache
 
             cache = ASTCache(self.project_root or ".")
             has_edges = cache.has_call_edges()
             stats = cache.get_stats()
-            cache.close()
             return {
                 "status": "ok",
                 "has_call_edges": has_edges,
@@ -327,15 +435,19 @@ class CodeGraphFullIndexTool(BaseMCPTool):
                 "total_symbols": stats.get("total_symbols", 0),
             }
         except Exception as exc:
-            return {"status": "error", "error": str(exc)}
+            return _phase_error(
+                exc, str(self.project_root) if self.project_root else None
+            )
+        finally:
+            _safe_close_cache(cache)
 
     def _collect_final_stats(self) -> dict[str, Any]:
+        cache: Any | None = None
         try:
             from ...ast_cache import ASTCache
 
             cache = ASTCache(self.project_root or ".")
             stats = cache.get_stats()
-            cache.close()
             return {
                 "total_files": stats.get("total_files", 0),
                 "total_symbols": stats.get("total_symbols", 0),
@@ -345,3 +457,5 @@ class CodeGraphFullIndexTool(BaseMCPTool):
             }
         except Exception:
             return {}
+        finally:
+            _safe_close_cache(cache)

--- a/tree_sitter_analyzer/mcp/tools/incremental_sync_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/incremental_sync_tool.py
@@ -18,12 +18,24 @@ from typing import Any
 from ...incremental_sync import IncrementalSync
 from ...utils import setup_logger
 from ..utils.auto_index_guard import ensure_indexed, is_indexed
+from ..utils.error_sanitizer import (
+    bounded_safe_error_message,
+    sanitize_error_detail,
+)
 from ..utils.format_helper import apply_toon_format_to_response
 from ._response_builder import build_error, build_response
 from ._validators import invalid_enum_error
 from .base_tool import BaseMCPTool
 
 logger = setup_logger(__name__)
+
+
+def _safe_close_cache(cache: Any) -> None:
+    """Close an owned cache without masking the primary tool result."""
+    try:
+        cache.close()
+    except Exception as exc:
+        logger.debug("AST cache close failed (%s)", type(exc).__name__)
 
 
 class CodeGraphIncrementalSyncTool(BaseMCPTool):
@@ -117,21 +129,42 @@ class CodeGraphIncrementalSyncTool(BaseMCPTool):
             result = build_error(error="Failed to initialize AST cache")
             return apply_toon_format_to_response(result, output_format)
 
-        sync = IncrementalSync(cache)
         try:
+            sync = IncrementalSync(cache)
             sync_result = sync.sync(max_files=max_files)
         except Exception as exc:
-            logger.exception("Incremental sync raised %s", type(exc).__name__)
+            logger.error("Incremental sync raised %s", type(exc).__name__)
+            error, truncated = bounded_safe_error_message(
+                exc,
+                str(self.project_root),
+                prefix="Sync failed: ",
+            )
             result = build_error(
-                error=f"Sync failed ({type(exc).__name__}): {exc}",
+                error=error,
+                error_truncated=truncated,
             )
             return apply_toon_format_to_response(result, output_format)
+        finally:
+            _safe_close_cache(cache)
 
+        payload = sync_result.to_dict()
+        raw_details = payload.get("details", [])
+        details = raw_details if isinstance(raw_details, list) else []
+        payload["details"] = [
+            sanitize_error_detail(detail, str(self.project_root))
+            for detail in details
+            if isinstance(detail, dict)
+        ]
+        invalid_details_dropped = len(details) - len(payload["details"])
+        if not isinstance(raw_details, list):
+            invalid_details_dropped += 1
+        if invalid_details_dropped:
+            payload["invalid_details_dropped"] = invalid_details_dropped
         result = build_response(
-            verdict="INFO",
+            verdict="WARN" if sync_result.errors > 0 else "INFO",
             project_root=self.project_root,
             mode="sync",
-            **sync_result.to_dict(),
+            **payload,
         )
         return apply_toon_format_to_response(result, output_format)
 
@@ -141,12 +174,22 @@ class CodeGraphIncrementalSyncTool(BaseMCPTool):
             result = build_error(error="Failed to initialize AST cache")
             return apply_toon_format_to_response(result, output_format)
 
-        sync = IncrementalSync(cache)
         try:
+            sync = IncrementalSync(cache)
             changes = sync.get_changes()
         except Exception as exc:
-            result = build_error(error=f"Change detection failed: {exc}")
+            error, truncated = bounded_safe_error_message(
+                exc,
+                str(self.project_root),
+                prefix="Change detection failed: ",
+            )
+            result = build_error(
+                error=error,
+                error_truncated=truncated,
+            )
             return apply_toon_format_to_response(result, output_format)
+        finally:
+            _safe_close_cache(cache)
 
         new_count = len(changes.get("new", []))
         modified_count = len(changes.get("modified", []))
@@ -169,30 +212,32 @@ class CodeGraphIncrementalSyncTool(BaseMCPTool):
         from ...ast_cache import ASTCache
 
         cache = ASTCache(str(self.project_root))
-        stats = cache.get_stats()
-
         try:
-            sync = IncrementalSync(cache)
-            changes = sync.get_changes()
-            pending_changes = (
-                len(changes.get("new", []))
-                + len(changes.get("modified", []))
-                + len(changes.get("deleted", []))
+            stats = cache.get_stats()
+
+            try:
+                sync = IncrementalSync(cache)
+                changes = sync.get_changes()
+                pending_changes = (
+                    len(changes.get("new", []))
+                    + len(changes.get("modified", []))
+                    + len(changes.get("deleted", []))
+                )
+            except Exception:
+                pending_changes = -1
+
+            up_to_date = pending_changes == 0 if pending_changes >= 0 else None
+
+            result = build_response(
+                verdict="INFO",
+                project_root=self.project_root,
+                mode="status",
+                indexed_files=stats.get("total_files", 0),
+                total_symbols=stats.get("total_symbols", 0),
+                fts5_available=stats.get("fts5_available", False),
+                pending_changes=pending_changes,
+                up_to_date=up_to_date,
             )
-        except Exception:
-            pending_changes = -1
-            changes = {}
-
-        up_to_date = pending_changes == 0 if pending_changes >= 0 else None
-
-        result = build_response(
-            verdict="INFO",
-            project_root=self.project_root,
-            mode="status",
-            indexed_files=stats.get("total_files", 0),
-            total_symbols=stats.get("total_symbols", 0),
-            fts5_available=stats.get("fts5_available", False),
-            pending_changes=pending_changes,
-            up_to_date=up_to_date,
-        )
-        return apply_toon_format_to_response(result, output_format)
+            return apply_toon_format_to_response(result, output_format)
+        finally:
+            _safe_close_cache(cache)

--- a/tree_sitter_analyzer/mcp/utils/error_sanitizer.py
+++ b/tree_sitter_analyzer/mcp/utils/error_sanitizer.py
@@ -28,32 +28,51 @@ from __future__ import annotations
 import os
 import re
 from pathlib import Path
+from typing import Any
 
 # A path-looking token: starts with ``/`` (POSIX) or a drive letter +
-# ``\`` (Windows), followed by at least one non-whitespace, non-quote
-# character. Matches absolute paths inside log lines such as
+# ``\`` (Windows), followed by characters up to a clear delimiter or line
+# boundary. Spaces are intentionally allowed: unquoted paths such as
+# ``/Users/alice/My Secrets/key.txt`` must be redacted as one unit. Matches
+# absolute paths inside log lines such as
 # ``[Errno 2] No such file or directory: '/x/y.py'``.
 _ABSOLUTE_PATH_RE = re.compile(
     r"""
-    (?:                    # opening boundary that we keep
-        (?<=[\s'\"\(:])    # whitespace, quote, paren, colon
-        |
-        ^                  # or start of string
-    )
+    (?<![A-Za-z0-9])       # start or punctuation boundary such as -, _, =, [
     (
         (?:[A-Za-z]:)?     # optional Windows drive letter
         [/\\]              # leading slash
-        (?:[^\s'\"\(\)]+)  # one or more non-whitespace, non-quote chars
+        (?:[^'\"\(\)\[\]\{\}=,;\r\n]+)
     )
     """,
     re.VERBOSE,
 )
+
+_ERROR_DETAIL_TEXT_LIMIT = 500
+_ERROR_DETAIL_FIELDS = (
+    "considered",
+    "action",
+    "status",
+    "language",
+    "error_type",
+    "reason",
+    "error_message",
+    "error",
+)
+_WINDOWS_DRIVE_PATH_RE = re.compile(r"^[A-Za-z]:[/\\]")
 
 
 def _sanitize_path_token(token: str, project_root: str | None) -> str:
     """Convert one absolute-path token to a relative or redacted form."""
     if not token:
         return token
+    # ``pathlib.Path`` follows the host OS. On POSIX it treats Windows drive
+    # and UNC paths as relative, which could make ``C:\Users\...`` appear to
+    # live under the current project and leak it as ``./C:\Users\...``.
+    if os.name != "nt" and (
+        _WINDOWS_DRIVE_PATH_RE.match(token) or token.startswith("\\\\")
+    ):
+        return "<external-path>"
     try:
         resolved = Path(token).resolve(strict=False)
     except (OSError, RuntimeError):
@@ -79,9 +98,82 @@ def sanitize_message(text: str, project_root: str | None = None) -> str:
         return text
 
     def _replace(match: re.Match[str]) -> str:
+        start = match.start(1)
+        if (
+            start > 0
+            and text[start - 1] == "."
+            and (start == 1 or not text[start - 2].isalnum())
+        ):
+            # Keep an already-sanitized project-relative ``./...`` path
+            # idempotent, while still catching ``failure./etc/shadow``.
+            return match.group(1)
         return _sanitize_path_token(match.group(1), project_root)
 
     return _ABSOLUTE_PATH_RE.sub(_replace, text)
+
+
+def _sanitize_detail_file_path(value: Any, project_root: str | None) -> str:
+    """Normalize a structured file field without tokenizing on whitespace."""
+    text = str(value)
+    if not text:
+        return text
+
+    if os.name != "nt" and (
+        _WINDOWS_DRIVE_PATH_RE.match(text) or text.startswith("\\\\")
+    ):
+        return "<external-path>"
+
+    path = Path(text)
+    if path.is_absolute():
+        return _sanitize_path_token(text, project_root)
+
+    if not project_root:
+        return "<external-path>" if ".." in path.parts else text
+
+    try:
+        root_resolved = Path(project_root).resolve()
+        candidate = (root_resolved / path).resolve(strict=False)
+        candidate.relative_to(root_resolved)
+    except (OSError, RuntimeError, ValueError):
+        return "<external-path>"
+    return text
+
+
+def _bounded_sanitized_text(
+    value: Any,
+    project_root: str | None,
+) -> tuple[str, bool]:
+    safe_value = sanitize_message(str(value), project_root)
+    if len(safe_value) <= _ERROR_DETAIL_TEXT_LIMIT:
+        return safe_value, False
+    return safe_value[: _ERROR_DETAIL_TEXT_LIMIT - 3] + "...", True
+
+
+def sanitize_error_detail(
+    detail: dict[str, Any],
+    project_root: str | None = None,
+) -> dict[str, Any]:
+    """Return a safe, bounded copy of one per-file error detail.
+
+    Core indexing keeps raw diagnostics because it has no dependency on the
+    MCP layer. Responses cross the trust boundary here: paths are made
+    project-relative (or redacted), and unbounded parser/library messages are
+    capped so one pathological failure cannot inflate an MCP response.
+    """
+    cleaned: dict[str, Any] = {}
+    file_path = detail.get("file")
+    if file_path is not None:
+        cleaned["file"] = _sanitize_detail_file_path(file_path, project_root)
+
+    for field in _ERROR_DETAIL_FIELDS:
+        if field not in detail or detail[field] is None:
+            continue
+        safe_value, truncated = _bounded_sanitized_text(detail[field], project_root)
+        if truncated:
+            cleaned[f"{field}_truncated"] = True
+        cleaned[field] = safe_value
+
+    return cleaned
 
 
 def sanitize_exception(exc: BaseException, project_root: str | None = None) -> str:
@@ -118,6 +210,22 @@ def safe_error_message(
     if include_class:
         return sanitize_exception(exc, project_root)
     return sanitize_message(str(exc), project_root)
+
+
+def bounded_safe_error_message(
+    exc: BaseException,
+    project_root: str | None = None,
+    *,
+    prefix: str = "",
+    max_length: int = _ERROR_DETAIL_TEXT_LIMIT,
+) -> tuple[str, bool]:
+    """Return one bounded MCP error string and whether truncation occurred."""
+    message = f"{prefix}{safe_error_message(exc, project_root)}"
+    if len(message) <= max_length:
+        return message, False
+    if max_length <= 3:
+        return "." * max_length, True
+    return message[: max_length - 3] + "...", True
 
 
 def project_root_from_env() -> str | None:


### PR DESCRIPTION
## Summary

- preserve `reason` when incremental indexing returns `status=error` without raising
- surface deterministic, capped per-file errors from full-index AST and sync phases
- report partial indexing failures as `WARN` while preserving `success=true`
- sanitize structured and free-form paths, bound error text, and drop invalid/unknown detail fields at the MCP boundary
- close owned AST caches on success, failure, result shaping, and constructor failures

## Compatibility

- keeps the existing integer `errors` field and partial-success semantics
- keeps TOON as the MCP default
- adds error-detail metadata without introducing a public limit parameter
- limits full-index details to 20 entries after sorting; `unattributed_errors` preserves DB-level failures without file attribution

## Verification

- RED baseline: 8 focused cases, 7 failures before implementation
- related tests: 119 passed
- quick gate bodies: 1262 passed, 7 skipped, 0 failed
- patch coverage: no added executable misses
- Ruff lint and format: passed
- Mypy: passed
- generated facade docs and drift tests: passed
- change-impact: REVIEW/high, 9 changed files, 227 affected surfaces
- independent diagnosis review: PASS
- independent security/red-team review: PASS

The container's standard terminal-summary hook still raises the known post-100% `psutil.NoSuchProcess`; the same quick-gate bodies complete successfully with that reporting hook disabled and an isolated pytest temp root.