### PR TITLE
fix(index): keep full-index scope consistent

### DIFF
--- a/tests/unit/test_codegraph_full_index_tool.py
+++ b/tests/unit/test_codegraph_full_index_tool.py
@@ -2,9 +2,16 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 
-from tree_sitter_analyzer.mcp.tools.full_index_tool import CodeGraphFullIndexTool
+from tree_sitter_analyzer.ast_cache import ASTCache
+from tree_sitter_analyzer.incremental_sync import SyncResult
+from tree_sitter_analyzer.mcp.tools.full_index_tool import (
+    CodeGraphFullIndexTool,
+    _resolve_exclude_patterns,
+)
 
 
 @pytest.fixture
@@ -16,6 +23,23 @@ def tool():
 def tool_with_root(tmp_path):
     (tmp_path / "app.py").write_text("def hello():\n    pass\n")
     return CodeGraphFullIndexTool(str(tmp_path))
+
+
+def _cache_total_files(project_root) -> int:
+    cache = ASTCache(str(project_root))
+    try:
+        return int(cache.get_stats()["total_files"])
+    finally:
+        cache.close()
+
+
+def _cache_file_paths(project_root) -> set[str]:
+    cache = ASTCache(str(project_root))
+    try:
+        rows = cache.get_conn().execute("SELECT file_path FROM ast_index").fetchall()
+        return {str(row["file_path"]) for row in rows}
+    finally:
+        cache.close()
 
 
 class TestToolDefinition:
@@ -52,6 +76,16 @@ class TestValidation:
     def test_invalid_mode_rejected(self, tool):
         with pytest.raises(ValueError, match="Invalid mode"):
             tool.validate_arguments({"mode": "partial"})
+
+
+class TestExcludeResolution:
+    def test_no_default_excludes_can_resolve_to_empty_scope(self):
+        assert _resolve_exclude_patterns([], True) == frozenset()
+
+    def test_windows_separators_are_normalized_for_both_phases(self):
+        assert _resolve_exclude_patterns([r"src\generated\*"], True) == frozenset(
+            {"src/generated/*"}
+        )
 
 
 @pytest.mark.asyncio
@@ -97,3 +131,177 @@ class TestExecute:
         assert result["verdict"] == "WARN"
         assert result["phases"]["incremental_sync"]["status"] == "error"
         assert result["phases"]["incremental_sync"]["errors"] == 1
+
+    async def test_scope_options_are_forwarded_to_incremental_phase(
+        self, tool_with_root
+    ):
+        # Incident 2026-07-26: sync discarded max_files and exclude_patterns.
+        with (
+            patch.object(
+                tool_with_root,
+                "_phase_ast_cache",
+                return_value={"status": "ok"},
+            ),
+            patch.object(
+                tool_with_root,
+                "_phase_incremental_sync",
+                return_value={"status": "ok"},
+            ) as incremental_phase,
+            patch.object(
+                tool_with_root,
+                "_phase_fts5_stats",
+                return_value={"status": "ok"},
+            ),
+            patch.object(
+                tool_with_root,
+                "_phase_call_edge_stats",
+                return_value={"status": "ok"},
+            ),
+            patch.object(tool_with_root, "_collect_final_stats", return_value={}),
+        ):
+            await tool_with_root.execute(
+                {
+                    "mode": "incremental",
+                    "max_files": 7,
+                    "exclude_patterns": ["vendor/*"],
+                    "resolve_synapse": False,
+                    "output_format": "json",
+                }
+            )
+
+        incremental_phase.assert_called_once_with(
+            7,
+            frozenset({"tests/golden/corpus_*", "vendor/*"}),
+        )
+
+    async def test_no_default_excludes_are_forwarded_exactly(self, tool_with_root):
+        # Incident 2026-07-26: sync silently restored disabled default excludes.
+        with (
+            patch.object(
+                tool_with_root,
+                "_phase_ast_cache",
+                return_value={"status": "ok"},
+            ),
+            patch.object(
+                tool_with_root,
+                "_phase_incremental_sync",
+                return_value={"status": "ok"},
+            ) as incremental_phase,
+            patch.object(
+                tool_with_root,
+                "_phase_fts5_stats",
+                return_value={"status": "ok"},
+            ),
+            patch.object(
+                tool_with_root,
+                "_phase_call_edge_stats",
+                return_value={"status": "ok"},
+            ),
+            patch.object(tool_with_root, "_collect_final_stats", return_value={}),
+        ):
+            await tool_with_root.execute(
+                {
+                    "mode": "incremental",
+                    "max_files": 3,
+                    "exclude_patterns": ["vendor/*"],
+                    "no_default_excludes": True,
+                    "resolve_synapse": False,
+                    "output_format": "json",
+                }
+            )
+
+        incremental_phase.assert_called_once_with(3, frozenset({"vendor/*"}))
+
+    async def test_full_mode_max_files_bounds_both_phases(self, tmp_path):
+        # Incident 2026-07-26: sync re-indexed files beyond the requested cap.
+        (tmp_path / "a.py").write_text("a = 1\n")
+        (tmp_path / "b.py").write_text("b = 2\n")
+        full_tool = CodeGraphFullIndexTool(str(tmp_path))
+
+        await full_tool.execute(
+            {
+                "mode": "full",
+                "max_files": 1,
+                "resolve_synapse": False,
+                "output_format": "json",
+            }
+        )
+
+        assert _cache_total_files(tmp_path) == 1
+
+    async def test_default_exclude_is_not_reintroduced_by_sync(self, tmp_path):
+        # Incident 2026-07-26: sync reintroduced a default-excluded corpus file.
+        (tmp_path / "app.py").write_text("app = 1\n")
+        golden = tmp_path / "tests" / "golden"
+        golden.mkdir(parents=True)
+        (golden / "corpus_bad.py").write_text("bad = 1\n")
+        full_tool = CodeGraphFullIndexTool(str(tmp_path))
+
+        await full_tool.execute(
+            {
+                "mode": "full",
+                "resolve_synapse": False,
+                "output_format": "json",
+            }
+        )
+
+        assert _cache_file_paths(tmp_path) == {"app.py"}
+
+    async def test_custom_exclude_is_not_reintroduced_by_sync(self, tmp_path):
+        # Incident 2026-07-26: sync reintroduced a custom-excluded source file.
+        (tmp_path / "app.py").write_text("app = 1\n")
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "skip.py").write_text("skip = 1\n")
+        full_tool = CodeGraphFullIndexTool(str(tmp_path))
+
+        await full_tool.execute(
+            {
+                "mode": "full",
+                "exclude_patterns": ["src/*"],
+                "resolve_synapse": False,
+                "output_format": "json",
+            }
+        )
+
+        assert _cache_file_paths(tmp_path) == {"app.py"}
+
+    async def test_no_default_excludes_indexes_golden_file(self, tmp_path):
+        # Incident 2026-07-26: both phases must share the custom-only scope.
+        (tmp_path / "app.py").write_text("app = 1\n")
+        golden = tmp_path / "tests" / "golden"
+        golden.mkdir(parents=True)
+        (golden / "corpus_allowed.py").write_text("allowed = 1\n")
+        full_tool = CodeGraphFullIndexTool(str(tmp_path))
+
+        await full_tool.execute(
+            {
+                "mode": "full",
+                "no_default_excludes": True,
+                "resolve_synapse": False,
+                "output_format": "json",
+            }
+        )
+
+        assert _cache_file_paths(tmp_path) == {
+            "app.py",
+            "tests/golden/corpus_allowed.py",
+        }
+
+
+class TestIncrementalPhaseScope:
+    def test_forwards_limit_above_old_hardcoded_cap_to_engine(self, tool_with_root):
+        # Incident 2026-07-26: the phase hard-coded a 20,000-file ceiling.
+        exclude_patterns = frozenset({"tests/golden/corpus_*"})
+        sync_result = SyncResult()
+        with (
+            patch("tree_sitter_analyzer.ast_cache.ASTCache"),
+            patch("tree_sitter_analyzer.incremental_sync.IncrementalSync") as sync_cls,
+        ):
+            sync_cls.return_value.sync.return_value = sync_result
+            tool_with_root._phase_incremental_sync(25_001, exclude_patterns)
+
+        sync_cls.return_value.sync.assert_called_once_with(
+            max_files=25_001,
+            exclude_patterns=exclude_patterns,
+        )

--- a/tests/unit/test_incremental_sync.py
+++ b/tests/unit/test_incremental_sync.py
@@ -136,6 +136,91 @@ class TestSyncMaxFiles:
         result = sync.sync(max_files=2)
         assert result.scanned == 2
 
+    def test_truncated_scan_does_not_delete_unseen_indexed_files(self, sync, cache):
+        # Incident 2026-07-26: capped scans invalidated live files beyond the cap.
+        sync.sync()
+
+        result = sync.sync(max_files=1)
+
+        assert result.deleted_files == 0
+        assert cache.get_stats()["total_files"] == 3
+
+    def test_zero_limit_does_not_delete_existing_index(self, sync, cache):
+        # Incident 2026-07-26: an empty capped scan invalidated the entire cache.
+        sync.sync()
+
+        result = sync.sync(max_files=0)
+
+        assert result.scanned == 0
+        assert result.deleted_files == 0
+        assert cache.get_stats()["total_files"] == 3
+
+    def test_truncated_scan_defers_real_deletion_until_complete_scan(
+        self, sync, cache, project
+    ):
+        # Incident 2026-07-26: incomplete scans could not distinguish unseen/deleted.
+        sync.sync()
+        (project / "src" / "helper.js").unlink()
+
+        truncated = sync.sync(max_files=1)
+
+        assert truncated.deleted_files == 0
+        assert cache.get_stats()["total_files"] == 3
+
+        complete = sync.sync()
+        assert complete.deleted_files == 1
+        assert cache.get_stats()["total_files"] == 2
+
+
+class TestSyncExcludePatterns:
+    def test_excluded_new_file_is_not_indexed(self, sync, cache):
+        # Incident 2026-07-26: full-index sync ignored the requested scope.
+        result = sync.sync(exclude_patterns=frozenset({"src/helper.js"}))
+
+        assert result.scanned == 2
+        assert result.new_files == 2
+        assert cache.get_stats()["total_files"] == 2
+        assert {detail["file"] for detail in result.details} == {
+            "src/main.py",
+            "src/util.py",
+        }
+
+    def test_excluded_cached_file_is_not_treated_as_deleted(self, sync, cache):
+        # Incident 2026-07-26: exclusion filtering could mimic a disk deletion.
+        sync.sync()
+
+        result = sync.sync(exclude_patterns=frozenset({"src/helper.js"}))
+
+        assert result.deleted_files == 0
+        assert cache.get_stats()["total_files"] == 3
+
+    def test_deleted_excluded_file_is_removed_after_complete_scan(
+        self, sync, cache, project
+    ):
+        # Incident 2026-07-26: exclusions must not hide real deletions forever.
+        sync.sync()
+        (project / "src" / "helper.js").unlink()
+
+        result = sync.sync(exclude_patterns=frozenset({"src/helper.js"}))
+
+        assert result.deleted_files == 1
+        assert cache.get_stats()["total_files"] == 2
+
+    def test_excluded_file_consumes_the_shared_file_limit(self, sync, cache, project):
+        # Incident 2026-07-26: AST and sync phases counted scoped files differently.
+        excluded = project / "src" / "helper.js"
+        included = project / "src" / "main.py"
+        with patch(
+            "tree_sitter_analyzer.incremental_sync._walk_source_files",
+            return_value=iter([str(excluded), str(included)]),
+        ):
+            sync.sync(
+                max_files=1,
+                exclude_patterns=frozenset({"src/helper.js"}),
+            )
+
+        assert cache.get_stats()["total_files"] == 0
+
 
 class TestSyncCallback:
     def test_callback_receives_details(self, sync, cache, project):

--- a/tree_sitter_analyzer/incremental_sync.py
+++ b/tree_sitter_analyzer/incremental_sync.py
@@ -13,6 +13,7 @@ Key features:
 - Integration with ASTCache for automatic re-indexing
 """
 
+import fnmatch
 import hashlib
 import logging
 import os
@@ -79,6 +80,8 @@ class IncrementalSync:
         self,
         max_files: int = 20_000,
         callback: Any | None = None,
+        *,
+        exclude_patterns: frozenset[str] | None = None,
     ) -> SyncResult:
         """Sync the on-disk source tree with the AST cache.
 
@@ -91,11 +94,18 @@ class IncrementalSync:
         conn = self._cache.get_conn()
 
         indexed_rows = self._load_indexed_rows(conn)
-        disk_files = self._scan_disk_files(max_files)
+        disk_files, present_paths, truncated = self._scan_disk_files(
+            max_files,
+            exclude_patterns,
+        )
         result.scanned = len(disk_files)
 
-        deleted_paths = set(indexed_rows.keys()) - set(disk_files.keys())
-        self._invalidate_deleted_files(deleted_paths, result, callback)
+        # A capped walk is only a prefix of the live source set. Treating every
+        # indexed row outside that prefix as deleted corrupts a healthy cache.
+        # Deletion detection is safe only after a complete walk.
+        if not truncated:
+            deleted_paths = set(indexed_rows) - present_paths
+            self._invalidate_deleted_files(deleted_paths, result, callback)
         self._index_or_reindex_files(disk_files, indexed_rows, conn, result, callback)
 
         try:
@@ -137,14 +147,25 @@ class IncrementalSync:
             ).fetchall()
         }
 
-    def _scan_disk_files(self, max_files: int) -> dict[str, dict[str, Any]]:
-        """Walk the project tree; return ``{rel_path: {abs_path, mtime, size}}``."""
+    def _scan_disk_files(
+        self,
+        max_files: int,
+        exclude_patterns: frozenset[str] | None = None,
+    ) -> tuple[dict[str, dict[str, Any]], set[str], bool]:
+        """Return eligible files, all present paths, and truncation state."""
         disk_files: dict[str, dict[str, Any]] = {}
+        present_paths: set[str] = set()
         count = 0
         for abs_path in _walk_source_files(self._cache.project_root):
             if count >= max_files:
-                break
+                return disk_files, present_paths, True
+            count += 1
             rel = os.path.relpath(abs_path, self._cache.project_root).replace("\\", "/")
+            present_paths.add(rel)
+            if exclude_patterns and any(
+                fnmatch.fnmatch(rel, pattern) for pattern in exclude_patterns
+            ):
+                continue
             try:
                 stat = os.stat(abs_path)
                 disk_files[rel] = {
@@ -154,8 +175,7 @@ class IncrementalSync:
                 }
             except OSError:
                 continue
-            count += 1
-        return disk_files
+        return disk_files, present_paths, False
 
     def _invalidate_deleted_files(
         self,

--- a/tree_sitter_analyzer/mcp/tools/full_index_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/full_index_tool.py
@@ -29,6 +29,19 @@ from .base_tool import BaseMCPTool
 logger = setup_logger(__name__)
 
 
+def _resolve_exclude_patterns(
+    extra_patterns: list[str],
+    no_default_excludes: bool,
+) -> frozenset[str]:
+    """Resolve the one effective scope shared by both indexing phases."""
+    from ...cache.indexer import _DEFAULT_EXCLUDE_PATTERNS
+
+    extra = frozenset(pattern.replace("\\", "/") for pattern in extra_patterns)
+    if no_default_excludes:
+        return extra
+    return _DEFAULT_EXCLUDE_PATTERNS | extra
+
+
 class CodeGraphFullIndexTool(BaseMCPTool):
     """MCP Tool for one-shot complete project intelligence indexing."""
 
@@ -96,7 +109,7 @@ class CodeGraphFullIndexTool(BaseMCPTool):
                     "items": {"type": "string"},
                     "description": (
                         "Additional fnmatch glob patterns (relative to project root) "
-                        "to exclude from indexing. Example: [\"tests/golden/corpus_*\"]. "
+                        'to exclude from indexing. Example: ["tests/golden/corpus_*"]. '
                         "Combined with built-in defaults unless no_default_excludes=true."
                     ),
                     "default": [],
@@ -140,6 +153,10 @@ class CodeGraphFullIndexTool(BaseMCPTool):
         output_format = arguments.get("output_format", "toon")
         extra_patterns: list[str] = list(arguments.get("exclude_patterns", None) or [])
         no_default_excludes: bool = bool(arguments.get("no_default_excludes", False))
+        exclude_patterns = _resolve_exclude_patterns(
+            extra_patterns,
+            no_default_excludes,
+        )
 
         phases: dict[str, Any] = {}
         t_start = time.monotonic()
@@ -151,11 +168,13 @@ class CodeGraphFullIndexTool(BaseMCPTool):
             mode == "full",
             max_files,
             include_activation=include_activation,
-            extra_exclude_patterns=extra_patterns,
-            no_default_excludes=no_default_excludes,
+            exclude_patterns=exclude_patterns,
         )
         phases["ast_cache"] = ast_phase
-        phases["incremental_sync"] = self._phase_incremental_sync()
+        phases["incremental_sync"] = self._phase_incremental_sync(
+            max_files,
+            exclude_patterns,
+        )
         phases["fts5"] = self._phase_fts5_stats()
 
         if resolve_synapse:
@@ -197,19 +216,14 @@ class CodeGraphFullIndexTool(BaseMCPTool):
         max_files: int,
         *,
         include_activation: bool = False,
-        extra_exclude_patterns: list[str] | None = None,
-        no_default_excludes: bool = False,
+        exclude_patterns: frozenset[str] | None = None,
     ) -> dict[str, Any]:
         t0 = time.monotonic()
         try:
             from ...ast_cache import ASTCache
-            from ...cache.indexer import _DEFAULT_EXCLUDE_PATTERNS
 
-            extra: frozenset[str] = frozenset(extra_exclude_patterns or [])
-            if no_default_excludes:
-                exclude_patterns: frozenset[str] = extra
-            else:
-                exclude_patterns = _DEFAULT_EXCLUDE_PATTERNS | extra
+            if exclude_patterns is None:
+                exclude_patterns = _resolve_exclude_patterns([], False)
 
             cache = ASTCache(self.project_root or ".")
             result = cache.index_project(
@@ -243,15 +257,24 @@ class CodeGraphFullIndexTool(BaseMCPTool):
                 "elapsed_seconds": round(time.monotonic() - t0, 3),
             }
 
-    def _phase_incremental_sync(self) -> dict[str, Any]:
+    def _phase_incremental_sync(
+        self,
+        max_files: int = 20_000,
+        exclude_patterns: frozenset[str] | None = None,
+    ) -> dict[str, Any]:
         t0 = time.monotonic()
         try:
             from ...ast_cache import ASTCache
             from ...incremental_sync import IncrementalSync
 
+            if exclude_patterns is None:
+                exclude_patterns = _resolve_exclude_patterns([], False)
             cache = ASTCache(self.project_root or ".")
             sync = IncrementalSync(cache)
-            result = sync.sync(max_files=20_000)
+            result = sync.sync(
+                max_files=max_files,
+                exclude_patterns=exclude_patterns,
+            )
             cache.close()
             elapsed = round(time.monotonic() - t0, 3)
             # #860: surface DB flush failures — sync catches them into result.errors

--- a/tree_sitter_analyzer/mcp/tools/knowledge_graph_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/knowledge_graph_tool.py
@@ -196,9 +196,9 @@ class CodeGraphKnowledgeIndexTool(BaseMCPTool):
                     cache.index_project(max_files=max_files, force=True)
                 )
             sync = IncrementalSync(cache)
-            # IncrementalSync treats indexed files outside max_files as deleted.
-            # Knowledge graph update must be safe on large repos, so use a full
-            # scan floor and reserve max_files as a full-build cap.
+            # Knowledge graph updates intentionally use a full-scan floor so the
+            # materialized graph covers the complete project. ``max_files``
+            # remains the explicit cap for full builds.
             safe_max_files = max(max_files, 1_000_000)
             return _compact_sync_report(sync.sync(max_files=safe_max_files).to_dict())
         finally:


### PR DESCRIPTION
## Summary

- resolve the effective full-index exclude scope once and pass the same `max_files` and patterns to both AST and incremental phases
- distinguish eligible files from all present source paths during incremental sync
- skip deletion detection for truncated walks, then reconcile real deletions on the next complete scan
- preserve standalone IncrementalSync defaults and existing MCP JSON/TOON response contracts
- correct the stale knowledge-graph comment without changing its full-scan policy

## Why

The AST phase honored `max_files`, default/custom excludes, and `no_default_excludes`, but the follow-up incremental phase hard-coded 20,000 files and used no excludes. That could reintroduce excluded files and exceed the requested cap.

Simply forwarding the cap was unsafe: a truncated scan previously treated every indexed row outside the scanned prefix as deleted. The fix tracks three states—eligible files, all present paths, and truncation—and only calculates deletions after a complete walk.

## Validation

- RED reproduction: 9 focused cases, 8 failures before implementation
- scope suites: 53 passed
- change-impact focused suites: 77 passed
- full quick suite: 1,262 passed, 7 skipped, 0 failed (1,269 total)
- patch coverage: no added executable misses
- Ruff check/format, Mypy, `git diff --check`, generated facade docs/drift: passed
- change-impact: `changed=5 risk=high pytest_required=True`
- independent diagnosis review: PASS
- adversarial SQLite/JSON/TOON matrix: PASS

The literal local `pytest -q` run reached 100%, then the repository's terminal-summary hook hit the known container-only `psutil.NoSuchProcess`; the same full test bodies passed with that terminal hook disabled and JUnit recorded zero failures.

## Compatibility

This is an internal bug fix: no new MCP parameters, schema constraints, response fields, or CLI behavior. `exclude_patterns` is keyword-only on the internal sync engine.

## Integration note

This branch is independently based on `develop`. It overlaps a few files with #1165 and may need a mechanical rebase depending on merge order.

## Deferred

Both phases still perform separate filesystem walks. Concurrent tree mutation between phases is not a transactional snapshot; solving that requires a larger orchestration design and is intentionally outside this bug fix.
