### PR TITLE
fix(test): tolerate terminal-summary process exit race

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -246,29 +246,30 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
     try:
         import psutil
     except ImportError:
-        return
+        psutil = None
 
-    try:
-        process = psutil.Process(os.getpid())
-        rss_gb = process.memory_info().rss / (1024**3)
-        system_total_gb = psutil.virtual_memory().total / (1024**3)
-        usage_pct = process.memory_info().rss / psutil.virtual_memory().total * 100
+    if psutil is not None:
+        try:
+            process = psutil.Process(os.getpid())
+            rss_gb = process.memory_info().rss / (1024**3)
+            system_total_gb = psutil.virtual_memory().total / (1024**3)
+            usage_pct = process.memory_info().rss / psutil.virtual_memory().total * 100
 
-        if rss_gb > 2.0:
-            terminalreporter.write_sep(
-                "!",
-                f"MEMORY WARNING: pytest RSS = {rss_gb:.1f} GB "
-                f"({usage_pct:.0f}% of {system_total_gb:.0f} GB system RAM). "
-                f"Consider running fewer tests or using -x.",
-            )
-        if rss_gb > 4.0:
-            terminalreporter.write_sep(
-                "!",
-                f"MEMORY CRITICAL: pytest RSS = {rss_gb:.1f} GB! "
-                f"This can crash the system. Reduce test batch size.",
-            )
-    except psutil.Error:
-        return
+            if rss_gb > 2.0:
+                terminalreporter.write_sep(
+                    "!",
+                    f"MEMORY WARNING: pytest RSS = {rss_gb:.1f} GB "
+                    f"({usage_pct:.0f}% of {system_total_gb:.0f} GB system RAM). "
+                    f"Consider running fewer tests or using -x.",
+                )
+            if rss_gb > 4.0:
+                terminalreporter.write_sep(
+                    "!",
+                    f"MEMORY CRITICAL: pytest RSS = {rss_gb:.1f} GB! "
+                    f"This can crash the system. Reduce test batch size.",
+                )
+        except psutil.Error:
+            pass
 
     if QUARANTINED_TESTS:
         terminalreporter.write_sep(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -244,10 +244,11 @@ def pytest_unconfigure(config):
 def pytest_terminal_summary(terminalreporter, exitstatus, config):
     """Warn if memory usage is dangerously high at end of session."""
     try:
-        import os
-
         import psutil
+    except ImportError:
+        return
 
+    try:
         process = psutil.Process(os.getpid())
         rss_gb = process.memory_info().rss / (1024**3)
         system_total_gb = psutil.virtual_memory().total / (1024**3)
@@ -266,8 +267,8 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
                 f"MEMORY CRITICAL: pytest RSS = {rss_gb:.1f} GB! "
                 f"This can crash the system. Reduce test batch size.",
             )
-    except ImportError:
-        pass
+    except psutil.Error:
+        return
 
     if QUARANTINED_TESTS:
         terminalreporter.write_sep(

--- a/tests/contracts/test_pytest_runtime_contract.py
+++ b/tests/contracts/test_pytest_runtime_contract.py
@@ -386,26 +386,34 @@ def test_process_probe_uses_non_destructive_pid_lookup(monkeypatch) -> None:
 
 
 def test_terminal_summary_ignores_process_exit_race(monkeypatch) -> None:
-    """A vanished controller process must not turn a green suite red."""
+    """A vanished controller must not hide unrelated terminal reporting."""
     import psutil
 
     from tests import conftest
 
     # Incident 2026-07-26: the suite reached 100%, then psutil lost /proc/<pid>.
+    quarantined_test = "tests/unit/test_flaky.py::test_case"
+    monkeypatch.setattr(conftest, "QUARANTINED_TESTS", [quarantined_test])
     monkeypatch.setattr(
         psutil,
         "Process",
         lambda pid: (_ for _ in ()).throw(psutil.NoSuchProcess(pid)),
     )
-    writes = []
+    events = []
 
     conftest.pytest_terminal_summary(
-        SimpleNamespace(write_sep=lambda *args: writes.append(args)),
+        SimpleNamespace(
+            write_sep=lambda *args: events.append(("sep", args)),
+            write_line=lambda line: events.append(("line", line)),
+        ),
         0,
         SimpleNamespace(),
     )
 
-    assert writes == []
+    assert events == [
+        ("sep", ("=", "quarantined tests (1)")),
+        ("line", quarantined_test),
+    ]
 
 
 def test_dead_pytest_process_temp_root_is_removed(tmp_path) -> None:

--- a/tests/contracts/test_pytest_runtime_contract.py
+++ b/tests/contracts/test_pytest_runtime_contract.py
@@ -385,6 +385,29 @@ def test_process_probe_uses_non_destructive_pid_lookup(monkeypatch) -> None:
     assert (result, observed_pids) == (True, [43210])
 
 
+def test_terminal_summary_ignores_process_exit_race(monkeypatch) -> None:
+    """A vanished controller process must not turn a green suite red."""
+    import psutil
+
+    from tests import conftest
+
+    # Incident 2026-07-26: the suite reached 100%, then psutil lost /proc/<pid>.
+    monkeypatch.setattr(
+        psutil,
+        "Process",
+        lambda pid: (_ for _ in ()).throw(psutil.NoSuchProcess(pid)),
+    )
+    writes = []
+
+    conftest.pytest_terminal_summary(
+        SimpleNamespace(write_sep=lambda *args: writes.append(args)),
+        0,
+        SimpleNamespace(),
+    )
+
+    assert writes == []
+
+
 def test_dead_pytest_process_temp_root_is_removed(tmp_path) -> None:
     """A later pytest run must reclaim debris left by a killed process."""
     from tests import pytest_temp_hygiene


### PR DESCRIPTION
## Summary

- keep the pytest terminal summary optional when `psutil` is unavailable
- tolerate `psutil.Error` when the controller process disappears during terminal reporting
- add a regression contract for the observed `NoSuchProcess` shutdown race

## Incident

On 2026-07-26 the quick suite reached 100%, then `psutil.Process(os.getpid())` raised `NoSuchProcess` from `pytest_terminal_summary`, turning a green suite into exit code 1.

## Verification

- `uv run pytest tests/contracts/test_pytest_runtime_contract.py tests/unit/core/test_conftest_query.py -q` (34 passed)
- `uv run pytest -q` (1268 passed, 1 skipped)
- `uv build`
- `uv run ruff check tests/conftest.py tests/contracts/test_pytest_runtime_contract.py`
- `git diff --check`