### PR TITLE
fix(index): define positive max_files contract

### DIFF
--- a/.claude/skills/tsa-index/SKILL.md
+++ b/.claude/skills/tsa-index/SKILL.md
@@ -90,6 +90,7 @@ uv run tree-sitter-analyzer --full-index           # index action=full
 # Prefer `--ast-cache --ast-cache-mode index` for an incremental refresh.
 # `--full-index` defaults to mode 'incremental'; pass `--full-index-mode full` for a
 # true full rebuild, and `--full-index-max-files N` (default 20000) to cap scope.
+# Indexing max-files options require N >= 1; zero is invalid, never unlimited.
 ```
 
 ## Anti-patterns

--- a/docs/api/mcp_tools_specification.md
+++ b/docs/api/mcp_tools_specification.md
@@ -1517,6 +1517,12 @@ uv run tree-sitter-analyzer --parser-readiness --parser-readiness-include-suppor
 
 The v1.13.0 release adds 40 specialised tools for autonomous-agent workflows: AST cache + FTS5 indexing, function-level CodeGraph parity (callers/callees/blast-radius/visualise), pre-edit safety verdicts, anti-pattern / dead-code / route detection, architectural-constraint enforcement, and a persistent decision journal. All tools default to TOON output for 50-70% token savings versus JSON. Tools are listed alphabetically.
 
+For project-indexing tools, `max_files` is always a positive integer. Omitting
+it selects the tool's documented default. Zero, negative values, booleans, and
+non-integral values are rejected; zero is never an alias for “unlimited” or “no work.”
+Capped incremental results expose `truncated_by_max_files` so callers can
+distinguish a complete scan from a bounded prefix.
+
 ### 16. ast_cache
 
 **Purpose**: Pre-indexed AST cache with FTS5 search and incremental sync (CodeGraph parity). The only tool that persists AST data across sessions — other codegraph tools build on top of this cache.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -99,6 +99,13 @@ Use `project-health --max-files <n>` when working inside a noisy repository.
 It limits detailed file rows, top targets, and the agent backlog so the next
 queue head stays compact and intentional.
 
+Project-index commands use one stricter limit contract:
+`--ast-cache-max-files`, `--autoindex-max-files`, `--full-index-max-files`,
+`--incremental-sync-max-files`, and `--knowledge-graph-max-files` accept only a
+positive integer. Omitting the option selects its documented default; zero,
+negative values, and booleans are invalid. Zero never means “unlimited” or
+“process no files.”
+
 `file-health` JSON and TOON responses include an `agent_summary` with the weakest
 dimension and score plus the first actionable smell, its line, symbol, and detail
 when those can be inferred, so an agent can jump straight to the right function

--- a/loop-run-log.md
+++ b/loop-run-log.md
@@ -23,6 +23,20 @@ Append one entry per run. Prune entries older than 30 days.
 
 ```json
 {
+  "run_id": "2026-07-26T07:52:24Z",
+  "pattern": "index-contract-repair",
+  "duration_s": 900,
+  "items_found": 4,
+  "actions_taken": 4,
+  "escalations": 0,
+  "tokens_estimate": 24000,
+  "outcome": "fix-proposed",
+  "summary": "Issue #1169: unified max_files normalization across CLI, MCP, AST walking, incremental sync, knowledge indexing, and cold-cache warming; zero/negative/bool limits now fail before mutation, and capped syncs report truncated_by_max_files. Focused coverage (228 tests), patch coverage, full pytest (1273 passed, 7 skipped), build, Ruff, changed-file formatting, focused MyPy, and diff checks passed."
+}
+```
+
+```json
+{
   "run_id": "2026-07-26T07:26:49Z",
   "pattern": "pr-readiness",
   "duration_s": 600,

--- a/tests/unit/cli/test_codegraph_index_commands.py
+++ b/tests/unit/cli/test_codegraph_index_commands.py
@@ -9,6 +9,8 @@ import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from tree_sitter_analyzer.cli.commands.codegraph_index_commands import (
     _autoindex_payload,
     _exit_code_for,
@@ -117,6 +119,10 @@ class TestAutoindexPayload:
         payload = _autoindex_payload(args, "json")
         assert payload["mode"] == "status"
 
+    def test_zero_max_files_is_rejected(self):
+        with pytest.raises(ValueError, match="max_files must be a positive integer"):
+            _autoindex_payload(_args(autoindex_max_files=0), "json")
+
 
 class TestFullIndexPayload:
     def test_default_values(self):
@@ -132,6 +138,10 @@ class TestFullIndexPayload:
         payload = _full_index_payload(args, "json")
         assert payload["include_activation"] is True
 
+    def test_zero_max_files_is_rejected(self):
+        with pytest.raises(ValueError, match="max_files must be a positive integer"):
+            _full_index_payload(_args(full_index_max_files=0), "json")
+
 
 class TestIncrementalSyncPayload:
     def test_default_values(self):
@@ -144,6 +154,10 @@ class TestIncrementalSyncPayload:
         args = _args(incremental_sync_mode="check")
         payload = _incremental_sync_payload(args, "toon")
         assert payload["mode"] == "check"
+
+    def test_zero_max_files_is_rejected(self):
+        with pytest.raises(ValueError, match="max_files must be a positive integer"):
+            _incremental_sync_payload(_args(incremental_sync_max_files=0), "json")
 
 
 class TestKnowledgeGraphIndexPayload:
@@ -175,6 +189,13 @@ class TestKnowledgeGraphIndexPayload:
         assert payload["max_edges"] == 789
         assert payload["include_docs"] is False
         assert payload["output_format"] == "toon"
+
+    def test_zero_max_files_is_rejected(self):
+        with pytest.raises(ValueError, match="max_files must be a positive integer"):
+            _knowledge_graph_index_payload(
+                _args(knowledge_graph_max_files=0),
+                "json",
+            )
 
 
 class TestMetricsPayload:

--- a/tests/unit/test_ast_cache_tool.py
+++ b/tests/unit/test_ast_cache_tool.py
@@ -72,6 +72,10 @@ class TestGetToolSchema:
         assert "mode" in schema["properties"]
         assert "mode" not in schema.get("required", [])
 
+    def test_schema_requires_positive_max_files(self):
+        schema = ASTCacheTool().get_tool_schema()
+        assert schema["properties"]["max_files"]["minimum"] == 1
+
     def test_resolve_mode_defaults_to_search_with_query(self):
         # index-10: cache query=X with no mode searches instead of silently
         # returning stats and dropping the query.
@@ -176,6 +180,12 @@ class TestValidateArguments:
     def test_valid_search_with_query(self):
         tool = ASTCacheTool()
         assert tool.validate_arguments({"mode": "search", "query": "MyClass"}) is True
+
+    @pytest.mark.parametrize("value", [True, 0, -1])
+    def test_invalid_max_files_rejected(self, value):
+        tool = ASTCacheTool()
+        with pytest.raises(ValueError, match="max_files must be a positive integer"):
+            tool.validate_arguments({"mode": "index", "max_files": value})
 
 
 class TestExecute:

--- a/tests/unit/test_codegraph_autoindex_tool.py
+++ b/tests/unit/test_codegraph_autoindex_tool.py
@@ -60,6 +60,9 @@ class TestToolDefinition:
         assert hints["readOnlyHint"] is False
         assert hints["destructiveHint"] is True
 
+    def test_schema_requires_positive_max_files(self, tool):
+        assert tool.get_tool_schema()["properties"]["max_files"]["minimum"] == 1
+
 
 class TestValidation:
     def test_valid_status(self, tool):
@@ -74,6 +77,11 @@ class TestValidation:
     def test_invalid_mode_rejected(self, tool):
         with pytest.raises(ValueError, match="Invalid mode"):
             tool.validate_arguments({"mode": "delete"})
+
+    @pytest.mark.parametrize("value", [True, 0, -1])
+    def test_invalid_max_files_rejected(self, tool, value):
+        with pytest.raises(ValueError, match="max_files must be a positive integer"):
+            tool.validate_arguments({"mode": "warm", "max_files": value})
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_codegraph_full_index_tool.py
+++ b/tests/unit/test_codegraph_full_index_tool.py
@@ -65,6 +65,9 @@ class TestToolDefinition:
         assert hints["readOnlyHint"] is False
         assert hints["destructiveHint"] is True
 
+    def test_schema_requires_positive_max_files(self, tool):
+        assert tool.get_tool_schema()["properties"]["max_files"]["minimum"] == 1
+
 
 class TestValidation:
     def test_valid_incremental(self, tool):
@@ -76,6 +79,17 @@ class TestValidation:
     def test_invalid_mode_rejected(self, tool):
         with pytest.raises(ValueError, match="Invalid mode"):
             tool.validate_arguments({"mode": "partial"})
+
+    @pytest.mark.parametrize("value", [True, 0, -1])
+    def test_invalid_max_files_rejected(self, tool, value):
+        with pytest.raises(ValueError, match="max_files must be a positive integer"):
+            tool.validate_arguments({"mode": "incremental", "max_files": value})
+
+    def test_omitted_max_files_is_normalized(self, tool):
+        arguments = {"mode": "incremental"}
+
+        assert tool.validate_arguments(arguments) is True
+        assert arguments["max_files"] == 20_000
 
 
 class TestExcludeResolution:
@@ -293,7 +307,7 @@ class TestExecute:
         (tmp_path / "b.py").write_text("b = 2\n")
         full_tool = CodeGraphFullIndexTool(str(tmp_path))
 
-        await full_tool.execute(
+        result = await full_tool.execute(
             {
                 "mode": "full",
                 "max_files": 1,
@@ -303,6 +317,8 @@ class TestExecute:
         )
 
         assert _cache_total_files(tmp_path) == 1
+        assert result["phases"]["ast_cache"]["truncated_by_max_files"] is True
+        assert result["phases"]["incremental_sync"]["truncated_by_max_files"] is True
 
     async def test_default_exclude_is_not_reintroduced_by_sync(self, tmp_path):
         # Incident 2026-07-26: sync reintroduced a default-excluded corpus file.

--- a/tests/unit/test_codegraph_incremental_sync_tool.py
+++ b/tests/unit/test_codegraph_incremental_sync_tool.py
@@ -45,6 +45,9 @@ class TestToolDefinition:
         assert hints["destructiveHint"] is True
         assert hints["readOnlyHint"] is False
 
+    def test_schema_requires_positive_max_files(self, tool):
+        assert tool.get_tool_schema()["properties"]["max_files"]["minimum"] == 1
+
 
 class TestValidation:
     def test_valid_sync(self, tool):
@@ -59,6 +62,17 @@ class TestValidation:
     def test_invalid_mode_rejected(self, tool):
         with pytest.raises(ValueError, match="Invalid mode"):
             tool.validate_arguments({"mode": "rebuild"})
+
+    @pytest.mark.parametrize("value", [True, 0, -1])
+    def test_invalid_max_files_rejected(self, tool, value):
+        with pytest.raises(ValueError, match="max_files must be a positive integer"):
+            tool.validate_arguments({"mode": "sync", "max_files": value})
+
+    def test_omitted_max_files_is_normalized(self, tool):
+        arguments = {"mode": "sync"}
+
+        assert tool.validate_arguments(arguments) is True
+        assert arguments["max_files"] == 20_000
 
 
 @pytest.mark.asyncio
@@ -86,6 +100,16 @@ class TestExecute:
 
 
 class TestCacheLifecycle:
+    def test_sync_uses_limit_for_cold_cache_warmup(self, tool_with_root):
+        cache = MagicMock()
+        with (
+            patch.object(tool_with_root, "_ensure_cache", return_value=cache) as ensure,
+            patch.object(IncrementalSync, "sync", return_value=SyncResult()),
+        ):
+            tool_with_root._sync(7, "json")
+
+        ensure.assert_called_once_with("json", max_files=7)
+
     def test_sync_closes_cache_after_success(self, tool_with_root):
         cache = MagicMock()
         with (

--- a/tests/unit/test_incremental_sync.py
+++ b/tests/unit/test_incremental_sync.py
@@ -135,6 +135,8 @@ class TestSyncMaxFiles:
         (project / "src" / "extra2.py").write_text("y = 2\n")
         result = sync.sync(max_files=2)
         assert result.scanned == 2
+        assert result.truncated_by_max_files is True
+        assert result.to_dict()["truncated_by_max_files"] is True
 
     def test_truncated_scan_does_not_delete_unseen_indexed_files(self, sync, cache):
         # Incident 2026-07-26: capped scans invalidated live files beyond the cap.
@@ -145,14 +147,13 @@ class TestSyncMaxFiles:
         assert result.deleted_files == 0
         assert cache.get_stats()["total_files"] == 3
 
-    def test_zero_limit_does_not_delete_existing_index(self, sync, cache):
-        # Incident 2026-07-26: an empty capped scan invalidated the entire cache.
+    def test_zero_limit_is_rejected_without_deleting_existing_index(self, sync, cache):
+        # Issue #1169: zero is invalid, and validation must precede mutations.
         sync.sync()
 
-        result = sync.sync(max_files=0)
+        with pytest.raises(ValueError, match="max_files must be a positive integer"):
+            sync.sync(max_files=0)
 
-        assert result.scanned == 0
-        assert result.deleted_files == 0
         assert cache.get_stats()["total_files"] == 3
 
     def test_truncated_scan_defers_real_deletion_until_complete_scan(

--- a/tests/unit/test_indexing_limits.py
+++ b/tests/unit/test_indexing_limits.py
@@ -1,0 +1,79 @@
+"""Contract tests for the shared project-index file limit."""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from tree_sitter_analyzer.ast_cache import ASTCache
+from tree_sitter_analyzer.cli.argument_groups._analysis import _add_analysis_options
+from tree_sitter_analyzer.cli.argument_groups._mcp import (
+    _add_mcp_index_management_options,
+)
+from tree_sitter_analyzer.indexing_limits import (
+    DEFAULT_INDEX_MAX_FILES,
+    normalize_index_max_files,
+    parse_index_max_files,
+)
+
+
+def test_omitted_index_limit_uses_the_documented_default() -> None:
+    assert normalize_index_max_files(None) == DEFAULT_INDEX_MAX_FILES
+
+
+@pytest.mark.parametrize("value", [17, 17.0, "17"])
+def test_positive_index_limit_is_normalized(value: object) -> None:
+    assert normalize_index_max_files(value) == 17
+
+
+@pytest.mark.parametrize("value", [True, False, 0, -1, 0.0, "0", "invalid"])
+def test_non_positive_or_non_integer_index_limit_is_rejected(value: object) -> None:
+    with pytest.raises(ValueError, match="max_files must be a positive integer"):
+        normalize_index_max_files(value)
+
+
+def test_cli_index_limit_parser_uses_the_same_contract() -> None:
+    assert parse_index_max_files("17") == 17
+    with pytest.raises(ValueError, match="max_files must be a positive integer"):
+        parse_index_max_files("0")
+
+
+@pytest.mark.parametrize(
+    "option",
+    [
+        "--autoindex-max-files",
+        "--full-index-max-files",
+        "--incremental-sync-max-files",
+        "--knowledge-graph-max-files",
+    ],
+)
+def test_index_management_cli_rejects_zero(option: str) -> None:
+    parser = argparse.ArgumentParser()
+    _add_mcp_index_management_options(parser)
+
+    with pytest.raises(SystemExit):
+        parser.parse_args([option, "0"])
+
+
+def test_ast_cache_cli_rejects_zero() -> None:
+    parser = argparse.ArgumentParser()
+    _add_analysis_options(parser)
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--ast-cache-max-files", "0"])
+
+
+def test_invalid_force_limit_is_rejected_before_cache_mutation(tmp_path) -> None:
+    source = tmp_path / "app.py"
+    source.write_text("value = 1\n", encoding="utf-8")
+    cache = ASTCache(str(tmp_path))
+    try:
+        cache.index_project(max_files=1, workers=0)
+
+        with pytest.raises(ValueError, match="max_files must be a positive integer"):
+            cache.index_project(max_files=0, force=True, workers=0)
+
+        assert cache.get_stats()["total_files"] == 1
+    finally:
+        cache.close()

--- a/tests/unit/test_knowledge_graph.py
+++ b/tests/unit/test_knowledge_graph.py
@@ -122,7 +122,11 @@ def _seed_sqlite_knowledge_graph(
                 "(file_path, content_hash, language, mtime_ns, file_size, "
                 "extractor_version, symbols_json, imports_json, structure_json, indexed_at) "
                 "VALUES (?, '', ?, 0, 0, 0, ?, '[]', '{}', 'test')",
-                (file_path, file_node.language or "python", json.dumps({"symbols": symbols})),
+                (
+                    file_path,
+                    file_node.language or "python",
+                    json.dumps({"symbols": symbols}),
+                ),
             )
         EdgeStore(conn).upsert_edges(
             [
@@ -1429,7 +1433,7 @@ def test_ensure_knowledge_graph_ready_updates_by_default_even_when_fresh(
             ],
             edges=[],
             stats={"node_count": 1, "edge_count": 0},
-        )
+        ),
     )
     os.utime(ast_cache / "index.db", ns=(1, 1))
     monkeypatch.setattr(LadybugKnowledgeGraphStore, "available", lambda: False)
@@ -1751,6 +1755,10 @@ def test_knowledge_index_tool_validation_rejects_bad_values(tmp_path: Path) -> N
         tool.validate_arguments({"mode": "bad"})
     with pytest.raises(ValueError, match="backend must be one of"):
         tool.validate_arguments({"backend": "bad"})
+    for value in (True, 0, -1):
+        with pytest.raises(ValueError, match="max_files must be a positive integer"):
+            tool.validate_arguments({"max_files": value})
+    assert tool.get_tool_schema()["properties"]["max_files"]["minimum"] == 1
 
 
 @pytest.mark.asyncio
@@ -2025,7 +2033,9 @@ async def test_knowledge_graph_tool_requires_project_root() -> None:
 
 
 @pytest.mark.asyncio
-async def test_knowledge_graph_tool_reads_empty_sqlite_projection(tmp_path: Path) -> None:
+async def test_knowledge_graph_tool_reads_empty_sqlite_projection(
+    tmp_path: Path,
+) -> None:
     tool = CodeGraphKnowledgeGraphTool(str(tmp_path))
 
     result = await tool.execute({"output_format": "json"})

--- a/tree_sitter_analyzer/cache/indexer.py
+++ b/tree_sitter_analyzer/cache/indexer.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     pass
 
 from ..constants import EXCLUDE_DIRS as _EXCLUDE_DIRS
+from ..indexing_limits import normalize_index_max_files
 from ..languages.lang_extension_map import EXT_TO_LANG as _EXT_TO_LANG
 from ..project_graph import _language_from_ext
 from .build_state import (
@@ -237,6 +238,7 @@ def walk_and_partition(
     attempt, so a Python-scoped run never tries to load an optional grammar
     (e.g. Swift) and never surfaces a "grammar not installed" error.
     """
+    max_files = normalize_index_max_files(max_files)
     candidates: list[tuple[str, str]] = []
     already_cached: list[dict[str, Any]] = []
     stats: dict[str, Any] = {
@@ -393,6 +395,7 @@ def run_index_project(
     ASTCache keeps the connection/backfill helpers; this module owns the
     high-level control flow so ``ast_cache.py`` stays thin.
     """
+    max_files = normalize_index_max_files(max_files)
     activation_enabled = _project_index_activation_enabled(include_activation)
     if resolve_only:
         synapse = cache._run_synapse_backfill()
@@ -550,7 +553,9 @@ def post_index_backfill(
 
         # SQLite is the canonical graph index. LadybugDB is a derived projection
         # and must never survive an SQLite update as an implicitly fresh mirror.
-        ladybug_removed = LadybugKnowledgeGraphStore(cache.project_root).remove_if_exists()
+        ladybug_removed = LadybugKnowledgeGraphStore(
+            cache.project_root
+        ).remove_if_exists()
         if ladybug_removed:
             stats["knowledge_graph"] = {"ladybug_stale_removed": True}
     except Exception:

--- a/tree_sitter_analyzer/cli/argument_groups/_analysis.py
+++ b/tree_sitter_analyzer/cli/argument_groups/_analysis.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 
 from ...constants import EDIT_KINDS
+from ...indexing_limits import parse_index_max_files
 from ._analysis_codegraph import _add_mcp_codegraph_map_options
 from ._analysis_graph_nav import _add_mcp_graph_nav_options
 
@@ -303,9 +304,12 @@ def _add_mcp_analysis_options(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--ast-cache-max-files",
-        type=int,
+        type=parse_index_max_files,
         default=20_000,
-        help="Max files to index with --ast-cache (default: 20000)",
+        help=(
+            "Positive max files to index or sync with --ast-cache; "
+            "zero is invalid (default: 20000)"
+        ),
     )
     parser.add_argument(
         "--ast-cache-force",

--- a/tree_sitter_analyzer/cli/argument_groups/_mcp.py
+++ b/tree_sitter_analyzer/cli/argument_groups/_mcp.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import argparse
 
+from ...indexing_limits import parse_index_max_files
+
 
 def _add_mcp_index_management_options(parser: argparse.ArgumentParser) -> None:
     """Add cache/index management flags (codegraph_autoindex / full_index / metrics).
@@ -29,9 +31,12 @@ def _add_mcp_index_management_options(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--autoindex-max-files",
-        type=int,
+        type=parse_index_max_files,
         default=20_000,
-        help="Max files to index when --autoindex-mode=warm (default: 20000)",
+        help=(
+            "Positive max files to index when --autoindex-mode=warm; "
+            "zero is invalid (default: 20000)"
+        ),
     )
     parser.add_argument(
         "--full-index",
@@ -50,9 +55,12 @@ def _add_mcp_index_management_options(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--full-index-max-files",
-        type=int,
+        type=parse_index_max_files,
         default=20_000,
-        help="Max files to index per --full-index run (default: 20000)",
+        help=(
+            "Positive max files to index per --full-index run; "
+            "zero is invalid (default: 20000)"
+        ),
     )
     parser.add_argument(
         "--full-index-include-activation",
@@ -121,9 +129,12 @@ def _add_mcp_index_management_options(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--incremental-sync-max-files",
-        type=int,
+        type=parse_index_max_files,
         default=20_000,
-        help="Max files for --incremental-sync (default: 20000)",
+        help=(
+            "Positive max files for --incremental-sync; "
+            "zero is invalid (default: 20000)"
+        ),
     )
     parser.add_argument(
         "--knowledge-graph-index",
@@ -150,11 +161,12 @@ def _add_mcp_index_management_options(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--knowledge-graph-max-files",
-        type=int,
+        type=parse_index_max_files,
         default=1_000_000,
         help=(
-            "Max files for --knowledge-graph-index-mode build; update mode "
-            "uses a safe full-project scan (default: 1000000)"
+            "Positive max files for --knowledge-graph-index-mode build; zero is "
+            "invalid and update mode uses a safe full-project scan "
+            "(default: 1000000)"
         ),
     )
     parser.add_argument(

--- a/tree_sitter_analyzer/cli/commands/codegraph_index_commands.py
+++ b/tree_sitter_analyzer/cli/commands/codegraph_index_commands.py
@@ -20,6 +20,11 @@ import os
 from collections.abc import Callable
 from typing import Any
 
+from ...indexing_limits import (
+    KNOWLEDGE_INDEX_MAX_FILES,
+    normalize_index_max_files,
+)
+
 OutputJsonFn = Callable[[dict[str, Any]], None]
 OutputErrorFn = Callable[[str], None]
 
@@ -54,7 +59,9 @@ def _exit_code_for(result: dict[str, Any]) -> int:
 def _autoindex_payload(args: Any, output_format: str) -> dict[str, Any]:
     return {
         "mode": getattr(args, "autoindex_mode", "status") or "status",
-        "max_files": int(getattr(args, "autoindex_max_files", 20_000)),
+        "max_files": normalize_index_max_files(
+            getattr(args, "autoindex_max_files", None)
+        ),
         "output_format": output_format,
     }
 
@@ -62,7 +69,9 @@ def _autoindex_payload(args: Any, output_format: str) -> dict[str, Any]:
 def _full_index_payload(args: Any, output_format: str) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "mode": getattr(args, "full_index_mode", "incremental") or "incremental",
-        "max_files": int(getattr(args, "full_index_max_files", 20_000)),
+        "max_files": normalize_index_max_files(
+            getattr(args, "full_index_max_files", None)
+        ),
         "include_activation": bool(
             getattr(args, "full_index_include_activation", False)
         ),
@@ -81,7 +90,9 @@ def _full_index_payload(args: Any, output_format: str) -> dict[str, Any]:
 def _incremental_sync_payload(args: Any, output_format: str) -> dict[str, Any]:
     return {
         "mode": getattr(args, "incremental_sync_mode", "sync") or "sync",
-        "max_files": int(getattr(args, "incremental_sync_max_files", 20_000)),
+        "max_files": normalize_index_max_files(
+            getattr(args, "incremental_sync_max_files", None)
+        ),
         "output_format": output_format,
     }
 
@@ -90,7 +101,10 @@ def _knowledge_graph_index_payload(args: Any, output_format: str) -> dict[str, A
     return {
         "mode": getattr(args, "knowledge_graph_index_mode", "update") or "update",
         "backend": getattr(args, "knowledge_graph_backend", "auto") or "auto",
-        "max_files": int(getattr(args, "knowledge_graph_max_files", 1_000_000)),
+        "max_files": normalize_index_max_files(
+            getattr(args, "knowledge_graph_max_files", None),
+            default=KNOWLEDGE_INDEX_MAX_FILES,
+        ),
         "max_nodes": int(getattr(args, "knowledge_graph_max_nodes", 0)),
         "max_edges": int(getattr(args, "knowledge_graph_max_edges", 0)),
         "include_docs": not bool(getattr(args, "knowledge_graph_no_docs", False)),

--- a/tree_sitter_analyzer/incremental_sync.py
+++ b/tree_sitter_analyzer/incremental_sync.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from .ast_cache import _EXT_TO_LANG, _walk_source_files
+from .indexing_limits import normalize_index_max_files
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +37,7 @@ class SyncResult:
     deleted_files: int = 0
     unchanged_files: int = 0
     errors: int = 0
+    truncated_by_max_files: bool = False
     synapse_resolved: int = 0
     details: list[dict[str, Any]] = field(default_factory=list)
 
@@ -48,6 +50,7 @@ class SyncResult:
             "deleted_files": self.deleted_files,
             "unchanged_files": self.unchanged_files,
             "errors": self.errors,
+            "truncated_by_max_files": self.truncated_by_max_files,
             "synapse_resolved": self.synapse_resolved,
             "details": self.details,
         }
@@ -90,6 +93,7 @@ class IncrementalSync:
         ``_invalidate_deleted_files`` / ``_index_or_reindex_files``) own
         per-phase logic; ``sync`` becomes a thin orchestrator.
         """
+        max_files = normalize_index_max_files(max_files)
         result = SyncResult()
         conn = self._cache.get_conn()
 
@@ -99,6 +103,7 @@ class IncrementalSync:
             exclude_patterns,
         )
         result.scanned = len(disk_files)
+        result.truncated_by_max_files = truncated
 
         # A capped walk is only a prefix of the live source set. Treating every
         # indexed row outside that prefix as deleted corrupts a healthy cache.
@@ -153,6 +158,7 @@ class IncrementalSync:
         exclude_patterns: frozenset[str] | None = None,
     ) -> tuple[dict[str, dict[str, Any]], set[str], bool]:
         """Return eligible files, all present paths, and truncation state."""
+        max_files = normalize_index_max_files(max_files)
         disk_files: dict[str, dict[str, Any]] = {}
         present_paths: set[str] = set()
         count = 0

--- a/tree_sitter_analyzer/indexing_limits.py
+++ b/tree_sitter_analyzer/indexing_limits.py
@@ -1,0 +1,58 @@
+"""Shared limits for project-indexing entry points."""
+
+from __future__ import annotations
+
+DEFAULT_INDEX_MAX_FILES = 20_000
+KNOWLEDGE_INDEX_MAX_FILES = 1_000_000
+
+
+def normalize_index_max_files(
+    value: object | None,
+    *,
+    default: int = DEFAULT_INDEX_MAX_FILES,
+) -> int:
+    """Return a positive project-index file limit.
+
+    ``None`` means that the caller omitted the option and therefore selects the
+    supplied positive default. Zero is deliberately invalid rather than an
+    alias for either "no work" or "unlimited"; callers that need an unlimited
+    operation must choose an explicit, bounded positive limit.
+    """
+    candidate: object = default if value is None else value
+    if isinstance(candidate, bool):
+        raise ValueError(
+            "max_files must be a positive integer; "
+            f"got {candidate!r} ({type(candidate).__name__})"
+        )
+    if isinstance(candidate, int):
+        normalized = candidate
+    elif isinstance(candidate, float) and candidate.is_integer():
+        normalized = int(candidate)
+    elif isinstance(candidate, str):
+        try:
+            normalized = int(candidate, 10)
+        except ValueError as exc:
+            raise ValueError(
+                "max_files must be a positive integer; "
+                f"got {candidate!r} ({type(candidate).__name__})"
+            ) from exc
+    else:
+        raise ValueError(
+            "max_files must be a positive integer; "
+            f"got {candidate!r} ({type(candidate).__name__})"
+        )
+    if normalized <= 0:
+        raise ValueError(
+            "max_files must be a positive integer; "
+            f"got {candidate!r} ({type(candidate).__name__})"
+        )
+    return normalized
+
+
+def parse_index_max_files(value: str) -> int:
+    """Argparse converter for :func:`normalize_index_max_files`."""
+    try:
+        parsed = int(value, 10)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("max_files must be a positive integer") from exc
+    return normalize_index_max_files(parsed)

--- a/tree_sitter_analyzer/mcp/tools/ast_cache_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/ast_cache_tool.py
@@ -16,6 +16,7 @@ from typing import Any
 from ...ast_cache import ASTCache
 from ...file_watcher import FileWatcherDaemon
 from ...incremental_sync import IncrementalSync
+from ...indexing_limits import normalize_index_max_files
 from ...utils import setup_logger
 from ._validators import invalid_enum_error
 from .base_tool import BaseMCPTool, _canonicalize_verdict, mirror_summary_line
@@ -289,7 +290,11 @@ class ASTCacheTool(BaseMCPTool):
                 },
                 "max_files": {
                     "type": "integer",
-                    "description": "Max files to index (default: 20000)",
+                    "minimum": 1,
+                    "description": (
+                        "Positive maximum files to index or sync; zero is invalid "
+                        "(default: 20000)"
+                    ),
                     "default": 20000,
                 },
                 "force": {
@@ -372,6 +377,7 @@ class ASTCacheTool(BaseMCPTool):
             raise ValueError(f"file_path is required for mode '{mode}'")
         if mode in ("search", "fts_search") and not arguments.get("query"):
             raise ValueError(f"query is required for {mode} mode")
+        arguments["max_files"] = normalize_index_max_files(arguments.get("max_files"))
         return True
 
     async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
@@ -432,7 +438,7 @@ class ASTCacheTool(BaseMCPTool):
                 "to retrieve the cached entry"
             )
         else:
-            max_files = int(arguments.get("max_files", 20_000))
+            max_files = arguments["max_files"]
             force = arguments.get("force", False)
             include_activation = bool(arguments.get("include_activation", False))
             # #1018: honor the language scope on the index path. Without this the
@@ -595,7 +601,7 @@ class ASTCacheTool(BaseMCPTool):
     def _handle_sync(self, arguments: dict[str, Any]) -> dict[str, Any]:
         """``mode=sync``: drift-detect + reconcile + M15 considered alias."""
         sync_engine = self._get_sync()
-        max_files = int(arguments.get("max_files", 20_000))
+        max_files = arguments["max_files"]
         sync_result = sync_engine.sync(max_files=max_files)
         sync_dict = sync_result.to_dict()
         # M15: surface J8's ``considered`` vocabulary at the top level too.

--- a/tree_sitter_analyzer/mcp/tools/auto_index_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/auto_index_tool.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from ...indexing_limits import normalize_index_max_files
 from ...utils import setup_logger
 from ..utils.auto_index_guard import (
     ensure_indexed,
@@ -68,7 +69,11 @@ class CodeGraphAutoIndexTool(BaseMCPTool):
                 },
                 "max_files": {
                     "type": "integer",
-                    "description": "Max files to index when warming (default: 20000)",
+                    "minimum": 1,
+                    "description": (
+                        "Positive maximum files to index when warming; "
+                        "zero is invalid (default: 20000)"
+                    ),
                     "default": 20000,
                 },
                 "output_format": {
@@ -86,6 +91,7 @@ class CodeGraphAutoIndexTool(BaseMCPTool):
         valid_modes = ["status", "warm", "reset"]
         if mode not in valid_modes:
             raise invalid_enum_error("mode", mode, valid_modes)
+        arguments["max_files"] = normalize_index_max_files(arguments.get("max_files"))
         return True
 
     async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
@@ -96,7 +102,7 @@ class CodeGraphAutoIndexTool(BaseMCPTool):
         if mode == "status":
             return self._status(output_format)
         elif mode == "warm":
-            return self._warm(arguments.get("max_files", 20_000), output_format)
+            return self._warm(arguments["max_files"], output_format)
         elif mode == "reset":
             return self._reset(output_format)
 

--- a/tree_sitter_analyzer/mcp/tools/full_index_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/full_index_tool.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import time
 from typing import Any
 
+from ...indexing_limits import normalize_index_max_files
 from ...utils import setup_logger
 from ..utils.auto_index_guard import mark_dirty
 from ..utils.error_sanitizer import (
@@ -160,7 +161,11 @@ class CodeGraphFullIndexTool(BaseMCPTool):
                 },
                 "max_files": {
                     "type": "integer",
-                    "description": "Max files to index (default: 20000)",
+                    "minimum": 1,
+                    "description": (
+                        "Positive maximum files to index; zero is invalid "
+                        "(default: 20000)"
+                    ),
                     "default": 20000,
                 },
                 "resolve_synapse": {
@@ -209,6 +214,7 @@ class CodeGraphFullIndexTool(BaseMCPTool):
         mode = arguments.get("mode", "incremental")
         if mode not in ("full", "incremental"):
             raise ValueError(f"Invalid mode: {mode}. Must be 'full' or 'incremental'")
+        arguments["max_files"] = normalize_index_max_files(arguments.get("max_files"))
         return True
 
     async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
@@ -225,7 +231,7 @@ class CodeGraphFullIndexTool(BaseMCPTool):
             )
 
         mode = arguments.get("mode", "incremental")
-        max_files = int(arguments.get("max_files", 20_000))
+        max_files = arguments["max_files"]
         resolve_synapse = arguments.get("resolve_synapse", True)
         include_activation = bool(arguments.get("include_activation", False))
         output_format = arguments.get("output_format", "toon")
@@ -333,6 +339,9 @@ class CodeGraphFullIndexTool(BaseMCPTool):
                 "errors": errors,
                 "mode_used": result.get("mode_used", "unknown"),
                 "activation_enabled": result.get("activation_enabled", False),
+                "truncated_by_max_files": bool(
+                    result.get("truncated_by_max_files", False)
+                ),
                 # Surface the backfill counts produced by _post_index_backfill so
                 # the synapse_resolution phase can report without re-running (A1).
                 "synapse_backfill": result.get("synapse_backfill"),
@@ -390,6 +399,7 @@ class CodeGraphFullIndexTool(BaseMCPTool):
                 "deleted_files": result.deleted_files,
                 "unchanged_files": result.unchanged_files,
                 "errors": result.errors,
+                "truncated_by_max_files": result.truncated_by_max_files,
                 **error_summary,
             }
         except Exception as exc:

--- a/tree_sitter_analyzer/mcp/tools/incremental_sync_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/incremental_sync_tool.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from typing import Any
 
 from ...incremental_sync import IncrementalSync
+from ...indexing_limits import normalize_index_max_files
 from ...utils import setup_logger
 from ..utils.auto_index_guard import ensure_indexed, is_indexed
 from ..utils.error_sanitizer import (
@@ -75,7 +76,11 @@ class CodeGraphIncrementalSyncTool(BaseMCPTool):
                 },
                 "max_files": {
                     "type": "integer",
-                    "description": "Max files to scan (default: 20000)",
+                    "minimum": 1,
+                    "description": (
+                        "Positive maximum files to scan; zero is invalid "
+                        "(default: 20000)"
+                    ),
                     "default": 20000,
                 },
                 "output_format": {
@@ -93,6 +98,7 @@ class CodeGraphIncrementalSyncTool(BaseMCPTool):
         valid_modes = ["sync", "changes", "status"]
         if mode not in valid_modes:
             raise invalid_enum_error("mode", mode, valid_modes)
+        arguments["max_files"] = normalize_index_max_files(arguments.get("max_files"))
         return True
 
     async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
@@ -105,7 +111,7 @@ class CodeGraphIncrementalSyncTool(BaseMCPTool):
             return apply_toon_format_to_response(result, output_format)
 
         if mode == "sync":
-            return self._sync(arguments.get("max_files", 20_000), output_format)
+            return self._sync(arguments["max_files"], output_format)
         elif mode == "changes":
             return self._changes(output_format)
         elif mode == "status":
@@ -113,9 +119,14 @@ class CodeGraphIncrementalSyncTool(BaseMCPTool):
 
         return build_error(error=f"Unknown mode: {mode}")
 
-    def _ensure_cache(self, output_format: str) -> Any | None:
+    def _ensure_cache(
+        self,
+        output_format: str,
+        *,
+        max_files: int = 20_000,
+    ) -> Any | None:
         if not is_indexed(str(self.project_root)):
-            cache = ensure_indexed(str(self.project_root))
+            cache = ensure_indexed(str(self.project_root), max_files=max_files)
             if cache is None:
                 return None
             return cache
@@ -124,7 +135,7 @@ class CodeGraphIncrementalSyncTool(BaseMCPTool):
         return ASTCache(str(self.project_root))
 
     def _sync(self, max_files: int, output_format: str) -> dict[str, Any]:
-        cache = self._ensure_cache(output_format)
+        cache = self._ensure_cache(output_format, max_files=max_files)
         if cache is None:
             result = build_error(error="Failed to initialize AST cache")
             return apply_toon_format_to_response(result, output_format)

--- a/tree_sitter_analyzer/mcp/tools/knowledge_graph_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/knowledge_graph_tool.py
@@ -6,6 +6,10 @@ from __future__ import annotations
 from typing import Any
 
 from ...incremental_sync import IncrementalSync
+from ...indexing_limits import (
+    KNOWLEDGE_INDEX_MAX_FILES,
+    normalize_index_max_files,
+)
 from ...knowledge_graph import (
     KnowledgeGraphBuilder,
     LadybugKnowledgeGraphStore,
@@ -69,8 +73,12 @@ class CodeGraphKnowledgeIndexTool(BaseMCPTool):
                 },
                 "max_files": {
                     "type": "integer",
+                    "minimum": 1,
                     "default": 1000000,
-                    "description": "Max source files for full build; update mode uses a safe full-project scan",
+                    "description": (
+                        "Positive maximum source files for full build; zero is "
+                        "invalid. Update mode uses a safe full-project scan."
+                    ),
                 },
                 "max_nodes": {
                     "type": "integer",
@@ -103,6 +111,10 @@ class CodeGraphKnowledgeIndexTool(BaseMCPTool):
         backend = arguments.get("backend", "auto")
         if backend not in _BACKENDS:
             raise ValueError("backend must be one of: auto, ladybug, sqlite")
+        arguments["max_files"] = normalize_index_max_files(
+            arguments.get("max_files"),
+            default=KNOWLEDGE_INDEX_MAX_FILES,
+        )
         return True
 
     async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
@@ -132,7 +144,7 @@ class CodeGraphKnowledgeIndexTool(BaseMCPTool):
 
         sync_report = self._prepare_index(
             mode=mode,
-            max_files=int(arguments.get("max_files", 20_000)),
+            max_files=arguments["max_files"],
         )
         ladybug_invalidated = False
         if effective_backend == "sqlite" and _sync_has_changes(sync_report):

--- a/tree_sitter_analyzer/mcp/utils/auto_index_guard.py
+++ b/tree_sitter_analyzer/mcp/utils/auto_index_guard.py
@@ -32,6 +32,8 @@ import logging
 import threading
 from typing import Any
 
+from ...indexing_limits import normalize_index_max_files
+
 logger = logging.getLogger(__name__)
 
 _lock = threading.Lock()
@@ -60,9 +62,10 @@ def ensure_indexed(
     * **False** — fail fast. If the cache is empty, return ``None``
       immediately so the calling tool can surface "run
       codegraph_autoindex first" rather than blocking. Read-only
-      tools that don't *need* to build the cache (``codegraph_metrics``,
-      ``codegraph_status``) should pass this.
+    tools that don't *need* to build the cache (``codegraph_metrics``,
+    ``codegraph_status``) should pass this.
     """
+    max_files = normalize_index_max_files(max_files)
     if project_root is None:
         return None
 

--- a/tree_sitter_analyzer/skills/tsa-index/SKILL.md
+++ b/tree_sitter_analyzer/skills/tsa-index/SKILL.md
@@ -90,6 +90,7 @@ uv run tree-sitter-analyzer --full-index           # index action=full
 # Prefer `--ast-cache --ast-cache-mode index` for an incremental refresh.
 # `--full-index` defaults to mode 'incremental'; pass `--full-index-mode full` for a
 # true full rebuild, and `--full-index-max-files N` (default 20000) to cap scope.
+# Indexing max-files options require N >= 1; zero is invalid, never unlimited.
 ```
 
 ## Anti-patterns


### PR DESCRIPTION
## Value

Closes #1169 by giving every project-indexing surface one explicit `max_files` contract: omitted selects the documented bounded default; positive integral values are normalized; zero, negative values, and booleans are rejected before any index mutation.

## What changed

- Added one shared normalizer for CLI, MCP, AST-cache walking, incremental sync, knowledge indexing, and cold-cache auto-warming.
- Added `minimum: 1` plus zero-invalid guidance to the relevant MCP schemas and CLI flags.
- Removed per-surface coercion differences, including cold incremental warm-up ignoring the requested cap.
- Added `truncated_by_max_files` to incremental results and both full-index phase reports.
- Preserved the established MCP compatibility for integral numeric strings/floats while rejecting booleans.
- Documented the contract in the CLI reference, MCP specification, and TSA indexing skill.

## Safety and regression coverage

- Invalid forced rebuilds are proven to fail before deleting an existing cache.
- Truncated scans are proven not to invalidate unseen indexed files.
- CLI payloads/parser flags, five MCP index tools, full-index phases, incremental sync, and the low-level AST path have exact tests.

## Verification

- Focused coverage: 228 passed.
- Patch coverage: no added executable misses.
- Full suite: 1273 passed, 7 skipped.
- `uv build`: sdist and wheel succeeded.
- Ruff check: passed.
- Changed-file Ruff format: passed.
- Focused MyPy: passed.
- `git diff --check`: passed.

Full-repository `ruff format --check .` still reports 24 pre-existing files from `develop`; this PR does not modify or reformat them.