### PR TITLE
refactor(uml): extract sequence and state builders

### DIFF
--- a/tree_sitter_analyzer/_uml_export_builders.py
+++ b/tree_sitter_analyzer/_uml_export_builders.py
@@ -1,0 +1,255 @@
+"""Focused sequence- and state-diagram builders for :mod:`uml_export`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from .uml_state import StateResult, build_state_result
+
+if TYPE_CHECKING:
+    from .uml_export import UMLDiagram, UMLEdge
+
+
+def build_sequence_diagram(
+    exporter: Any,
+    source: str,
+    target: str,
+    max_depth: int,
+    max_paths: int,
+    max_hops: int,
+) -> UMLDiagram:
+    """Build a sequence diagram while preserving the public patch seams."""
+    from . import uml_export as api
+
+    finder = api.CallPathFinder(exporter.project_root, exporter._cache)
+    result = finder.find_path(
+        source_function=source,
+        target_function=target,
+        max_depth=max_depth,
+        max_paths=max_paths,
+    )
+    paths = result.to_dict().get("paths", [])
+    first_hops = paths[0].get("hops", []) if paths else []
+    path_search_truncated = bool(
+        getattr(result, "truncated", False) and len(paths) >= max_paths
+    )
+    return api.UMLDiagram(
+        diagram_type="sequence",
+        mermaid_type="sequenceDiagram",
+        mermaid=api.render_sequence_mermaid(paths, max_hops),
+        nodes=_sequence_nodes(first_hops, max_hops),
+        edges=_sequence_edges(first_hops, max_hops),
+        truncated=path_search_truncated or len(first_hops) > max_hops,
+        metadata={
+            "source": (
+                "call_path+synapse_resolved"
+                if _has_resolved_hop(paths)
+                else "call_path"
+            ),
+            "analysis_kind": "static_approximation",
+            "path_count": len(paths),
+        },
+    )
+
+
+def _sequence_nodes(hops: list[dict[str, Any]], max_hops: int) -> list[str]:
+    return sorted(
+        {
+            hop.get(key, "")
+            for hop in hops[:max_hops]
+            for key in ("caller", "callee")
+            if hop.get(key)
+        }
+    )
+
+
+def _sequence_edges(hops: list[dict[str, Any]], max_hops: int) -> list[UMLEdge]:
+    from .uml_export import UMLEdge
+
+    return [
+        UMLEdge(hop.get("caller", ""), hop.get("callee", ""), "call")
+        for hop in hops[:max_hops]
+        if hop.get("caller") and hop.get("callee")
+    ]
+
+
+def _has_resolved_hop(paths: list[dict[str, Any]]) -> bool:
+    return any(hop.get("callee_file") for path in paths for hop in path.get("hops", []))
+
+
+def build_state_diagram(
+    exporter: Any,
+    *,
+    class_name: str | None,
+    file_path: str | None,
+    max_nodes: int,
+) -> UMLDiagram:
+    """Build an enum/match-driven state diagram from one current source file."""
+    resolved_path = _state_source_path(exporter, class_name, file_path)
+    if not resolved_path:
+        return _missing_state_source_diagram()
+
+    result = build_state_result(
+        file_path=resolved_path,
+        class_name=class_name,
+        max_nodes=max_nodes,
+    )
+    metadata = _state_metadata(class_name, resolved_path)
+    if result.error:
+        return _state_error_diagram(result, resolved_path, metadata)
+    if not result.transitions:
+        return _state_info_diagram(result, metadata)
+    return _complete_state_diagram(result, metadata)
+
+
+def _state_source_path(
+    exporter: Any,
+    class_name: str | None,
+    file_path: str | None,
+) -> str:
+    if file_path:
+        return _project_path(exporter.project_root, file_path)
+    if class_name is None:
+        return ""
+    return _indexed_class_path(exporter, class_name)
+
+
+def _indexed_class_path(exporter: Any, class_name: str) -> str:
+    from .class_hierarchy import ClassHierarchy
+
+    cache, should_close = exporter._open_cache()
+    try:
+        hierarchy = ClassHierarchy(cache)
+        hierarchy.build()
+        match = next(
+            (
+                item
+                for item in hierarchy.all_classes()
+                if item.get("name") == class_name and item.get("file")
+            ),
+            None,
+        )
+        return _project_path(exporter.project_root, match["file"]) if match else ""
+    finally:
+        if should_close:
+            cache.close()
+
+
+def _project_path(project_root: str, file_path: Any) -> str:
+    path = Path(str(file_path))
+    return str(path) if path.is_absolute() else str(Path(project_root) / path)
+
+
+def _state_metadata(class_name: str | None, resolved_path: str) -> dict[str, Any]:
+    metadata: dict[str, Any] = {
+        "analysis_kind": "static_approximation",
+        "note": "parsed from current file content; may differ from indexed symbols",
+        "file_path": resolved_path,
+    }
+    if class_name:
+        metadata["class_name"] = class_name
+    return metadata
+
+
+def _missing_state_source_diagram() -> UMLDiagram:
+    from .uml_export import UMLDiagram
+
+    return UMLDiagram(
+        diagram_type="state",
+        mermaid_type="stateDiagram-v2",
+        mermaid="stateDiagram-v2\n",
+        nodes=[],
+        edges=[],
+        metadata={
+            "analysis_kind": "static_approximation",
+            "verdict": "NOT_FOUND",
+            "next_step": (
+                "state diagram: supply file_path or class_name with an indexed "
+                "Enum class so the scanner can locate the source file"
+            ),
+        },
+    )
+
+
+def _state_error_diagram(
+    result: StateResult,
+    resolved_path: str,
+    metadata: dict[str, Any],
+) -> UMLDiagram:
+    from .uml_export import UMLDiagram
+
+    if Path(resolved_path).suffix.lower() not in {".py", ".pyw"}:
+        next_step = (
+            "state diagram: state extraction supports Python only; "
+            f"'{Path(resolved_path).name}' is not a Python file. "
+            "Pass a .py file that contains an Enum subclass."
+        )
+    else:
+        next_step = (
+            f"state diagram: {result.error}; "
+            "check that the file exists and contains an Enum subclass"
+        )
+    return UMLDiagram(
+        diagram_type="state",
+        mermaid_type="stateDiagram-v2",
+        mermaid="stateDiagram-v2\n",
+        nodes=[],
+        edges=[],
+        metadata={**metadata, "verdict": "NOT_FOUND", "next_step": next_step},
+    )
+
+
+def _state_info_diagram(
+    result: StateResult,
+    metadata: dict[str, Any],
+) -> UMLDiagram:
+    from .uml_export import UMLDiagram
+
+    mermaid = (
+        "stateDiagram-v2\n"
+        "%% NOTE: state diagram is a static approximation.\n"
+        "%% Guard conditions, timers, and exception-driven transitions are not captured.\n"
+        "%% NOTE: no transitions detected — FSM pattern not recognised by this heuristic."
+    )
+    return UMLDiagram(
+        diagram_type="state",
+        mermaid_type="stateDiagram-v2",
+        mermaid=mermaid,
+        nodes=result.states,
+        edges=[],
+        metadata={
+            **metadata,
+            "verdict": "INFO",
+            "next_step": (
+                f"state diagram: {len(result.states)} enum member(s) extracted "
+                "as states but no match-pattern transitions were found; "
+                "the class may not encode a finite-state machine in a pattern "
+                "this heuristic recognises"
+            ),
+        },
+    )
+
+
+def _complete_state_diagram(
+    result: StateResult,
+    metadata: dict[str, Any],
+) -> UMLDiagram:
+    from .uml_export import UMLDiagram, UMLEdge, render_state_mermaid
+
+    edges = [
+        UMLEdge(item.source, item.target, item.label) for item in result.transitions
+    ]
+    return UMLDiagram(
+        diagram_type="state",
+        mermaid_type="stateDiagram-v2",
+        mermaid=render_state_mermaid(
+            result.states,
+            result.transitions,
+            truncated=result.truncated,
+        ),
+        nodes=result.states,
+        edges=edges,
+        truncated=result.truncated,
+        metadata=metadata,
+    )

--- a/tree_sitter_analyzer/uml_export.py
+++ b/tree_sitter_analyzer/uml_export.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from .call_path import CallPathFinder
+from .call_path import CallPathFinder  # noqa: F401 - public monkeypatch seam
 from .class_hierarchy import ClassHierarchy
 from .import_graph import ImportGraph
 from .utils.test_detection import is_test_file
@@ -593,55 +593,15 @@ class UMLExporter:
         max_paths: int = 3,
         max_hops: int = 12,
     ) -> UMLDiagram:
-        finder = CallPathFinder(self.project_root, self._cache)
-        result = finder.find_path(
-            source_function=source,
-            target_function=target,
-            max_depth=max_depth,
-            max_paths=max_paths,
-        )
-        result_dict = result.to_dict()
-        paths = result_dict.get("paths", [])
-        first_hops = paths[0].get("hops", []) if paths else []
-        nodes = sorted(
-            {
-                hop.get(key, "")
-                for hop in first_hops[:max_hops]
-                for key in ("caller", "callee")
-                if hop.get(key)
-            }
-        )
-        edges = [
-            UMLEdge(hop.get("caller", ""), hop.get("callee", ""), "call")
-            for hop in first_hops[:max_hops]
-            if hop.get("caller") and hop.get("callee")
-        ]
-        # P1-E (RFC-0015): observability label — "call_path+synapse_resolved"
-        # when at least one hop has callee_file populated (synapse resolution
-        # contributed to BFS traversal); "call_path" otherwise.
-        has_resolved = any(
-            hop.get("callee_file") for path in paths for hop in path.get("hops", [])
-        )
-        source_label = "call_path+synapse_resolved" if has_resolved else "call_path"
-        path_search_truncated = bool(
-            getattr(result, "truncated", False) and len(paths) >= max_paths
-        )
-        return UMLDiagram(
-            diagram_type="sequence",
-            mermaid_type="sequenceDiagram",
-            mermaid=render_sequence_mermaid(paths, max_hops),
-            nodes=nodes,
-            edges=edges,
-            # Bug #787: truncated reflects only whether hop list was clipped in
-            # the rendered diagram (len > max_hops). result.truncated refers to
-            # BFS path-count truncation, not hop truncation — inheriting it
-            # causes truncated=True on a 2-node/1-edge complete path.
-            truncated=path_search_truncated or len(first_hops) > max_hops,
-            metadata={
-                "source": source_label,
-                "analysis_kind": "static_approximation",
-                "path_count": len(paths),
-            },
+        from ._uml_export_builders import build_sequence_diagram
+
+        return build_sequence_diagram(
+            self,
+            source,
+            target,
+            max_depth,
+            max_paths,
+            max_hops,
         )
 
     def activity_diagram(
@@ -809,164 +769,12 @@ class UMLExporter:
         file_path: str | None = None,
         max_nodes: int = 50,
     ) -> UMLDiagram:
-        """Build a stateDiagram-v2 from an enum/match-driven FSM (P2-B, RFC-0015).
+        """Build an enum/match-driven state diagram from current source."""
+        from ._uml_export_builders import build_state_diagram
 
-        Static approximation: enum members become states; match/case patterns
-        with return <Enum>.<Member> become transitions.
-
-        Honesty rules (#480 update):
-        - metadata["analysis_kind"] == "static_approximation" always.
-        - metadata["note"] records that parsing is done from current file content.
-        - states found, zero transitions → verdict="INFO" with next_step note
-          (partial result — enum members extracted but FSM pattern not recognised).
-        - zero states (class missing / no enum found / file absent) → verdict="NOT_FOUND".
-        - Language coverage: Python-only; non-Python files emit a language note.
-
-        Cost: ONE disk read + ONE tree-sitter parse (rule-11 invariant).
-        """
-        from .uml_state import build_state_result
-
-        # Resolve file_path: use as-is if absolute, otherwise interpret as
-        # relative to project_root (mirrors activity_diagram path logic).
-        resolved_path = ""
-        if file_path:
-            p = Path(file_path)
-            if p.is_absolute():
-                resolved_path = str(p)
-            else:
-                resolved_path = str(Path(self.project_root) / p)
-
-        if not resolved_path:
-            # No file given — try to find via class_hierarchy if class_name provided
-            # (best-effort: use ClassHierarchy to find the file for the named class)
-            if class_name is not None:
-                cache, should_close = self._open_cache()
-                try:
-                    from .class_hierarchy import ClassHierarchy
-
-                    hierarchy = ClassHierarchy(cache)
-                    hierarchy.build()
-                    all_cls = hierarchy.all_classes()
-                    for cls_info in all_cls:
-                        if cls_info.get("name") == class_name:
-                            cf = cls_info.get("file", "") or ""
-                            if cf:
-                                cp = Path(cf)
-                                resolved_path = (
-                                    str(cp)
-                                    if cp.is_absolute()
-                                    else str(Path(self.project_root) / cp)
-                                )
-                            if resolved_path:
-                                break
-                finally:
-                    if should_close:
-                        cache.close()
-
-        if not resolved_path:
-            return UMLDiagram(
-                diagram_type="state",
-                mermaid_type="stateDiagram-v2",
-                mermaid="stateDiagram-v2\n",
-                nodes=[],
-                edges=[],
-                metadata={
-                    "analysis_kind": "static_approximation",
-                    "verdict": "NOT_FOUND",
-                    "next_step": (
-                        "state diagram: supply file_path or class_name with an indexed "
-                        "Enum class so the scanner can locate the source file"
-                    ),
-                },
-            )
-
-        # Language coverage: state extraction is Python-only (#480).
-        # Non-Python files (e.g. .ts, .java) will fail the no-enum check below,
-        # but the message should explain the scope limit, not just say "check
-        # for an Enum subclass" (which is meaningless for TypeScript).
-        _py_extensions = {".py", ".pyw"}
-        _file_is_python = Path(resolved_path).suffix.lower() in _py_extensions
-
-        result = build_state_result(
-            file_path=resolved_path,
+        return build_state_diagram(
+            self,
             class_name=class_name,
+            file_path=file_path,
             max_nodes=max_nodes,
-        )
-
-        base_metadata: dict[str, Any] = {
-            "analysis_kind": "static_approximation",
-            "note": "parsed from current file content; may differ from indexed symbols",
-        }
-        if class_name:
-            base_metadata["class_name"] = class_name
-        base_metadata["file_path"] = resolved_path
-
-        if result.error:
-            if not _file_is_python:
-                next_step_msg = (
-                    f"state diagram: state extraction supports Python only; "
-                    f"'{Path(resolved_path).name}' is not a Python file. "
-                    "Pass a .py file that contains an Enum subclass."
-                )
-            else:
-                next_step_msg = (
-                    f"state diagram: {result.error}; "
-                    "check that the file exists and contains an Enum subclass"
-                )
-            return UMLDiagram(
-                diagram_type="state",
-                mermaid_type="stateDiagram-v2",
-                mermaid="stateDiagram-v2\n",
-                nodes=[],
-                edges=[],
-                metadata={
-                    **base_metadata,
-                    "verdict": "NOT_FOUND",
-                    "next_step": next_step_msg,
-                },
-            )
-
-        # Zero transitions but states found → INFO (#480 fix).
-        # A partial result (states extracted, FSM pattern not recognised) is not
-        # "not found". Use INFO so agents can consume the extracted enum members.
-        # The mermaid [*]--> lines are still suppressed (mermaid honesty rule):
-        # an agent reading only `mermaid` would see a structurally-valid diagram;
-        # emitting only the header + NOTE guard keeps the mermaid honest.
-        if not result.transitions:
-            info_mermaid = (
-                "stateDiagram-v2\n"
-                "%% NOTE: state diagram is a static approximation.\n"
-                "%% Guard conditions, timers, and exception-driven transitions are not captured.\n"
-                "%% NOTE: no transitions detected — FSM pattern not recognised by this heuristic."
-            )
-            return UMLDiagram(
-                diagram_type="state",
-                mermaid_type="stateDiagram-v2",
-                mermaid=info_mermaid,
-                nodes=result.states,
-                edges=[],
-                metadata={
-                    **base_metadata,
-                    "verdict": "INFO",
-                    "next_step": (
-                        f"state diagram: {len(result.states)} enum member(s) extracted "
-                        "as states but no match-pattern transitions were found; "
-                        "the class may not encode a finite-state machine in a pattern "
-                        "this heuristic recognises"
-                    ),
-                },
-            )
-
-        uml_edges = [UMLEdge(t.source, t.target, t.label) for t in result.transitions]
-        mermaid = render_state_mermaid(
-            result.states, result.transitions, truncated=result.truncated
-        )
-        return UMLDiagram(
-            diagram_type="state",
-            mermaid_type="stateDiagram-v2",
-            mermaid=mermaid,
-            nodes=result.states,
-            edges=uml_edges,
-            truncated=result.truncated,
-            metadata=base_metadata,
         )


### PR DESCRIPTION
## Value

Closes #1175 and advances the live health backlog in #1122 by removing two focused diagram-building responsibilities from `uml_export.py` without changing its public API or serialized output.

## What changed

- Added `_uml_export_builders.py` with focused sequence/state orchestration and small helpers.
- Kept `UMLExporter.sequence_diagram(...)` and `state_diagram(...)` as signature-compatible delegates.
- Preserved the module-level `CallPathFinder` monkeypatch seam used by integrations and tests.
- Preserved sequence ordering, node/edge shape, truncation semantics, Synapse source labeling, and metadata.
- Preserved state path/index resolution, owned-cache closing, Python-only guidance, INFO/NOT_FOUND honesty, Mermaid output, transition shape, truncation, and metadata.

## Measured health

- `uml_export.py`: D/69.2, 972 lines, 6 smells → **B/81.6, 780 lines, 4 smells**.
- New `_uml_export_builders.py`: **A/94.5, 255 lines, 0 smells**.

## Verification

- Change-impact: high risk, focused-then-default.
- Focused UML behavior suite: 245 passed with coverage.
- Strict worktree patch coverage: no added executable or branch misses.
- Full quick suite: 1273 passed, 7 skipped.
- `uv build`: sdist and wheel succeeded.
- Global Ruff and changed-file format: passed.
- Full-package MyPy: no issues in 758 source files.
- Strict test-quality audit: completed without blocking findings.
- Weak-assertion ratchet and `git diff --check`: passed.