### PR TITLE
fix(formatters): restore registry isolation

### DIFF
--- a/docs/CODEMAPS/formatters.md
+++ b/docs/CODEMAPS/formatters.md
@@ -40,6 +40,13 @@ Interfaces live in `formatters/_formatter_interface.py` (no upward imports — b
 | `IStructureFormatter` | legacy adapters | `format_structure(dict)` → str |
 
 `formatters/formatter_registry.py` re-exports both for backward compat.
+Generic `CodeElement` implementations (`JsonFormatter`, `CsvFormatter`,
+`FullFormatter`, and `CompactFormatter`) live in
+`formatters/_builtin_formatters.py`; the registry remains their stable import
+facade. `formatters/_language_formatter_registration.py` owns bundled-language
+registration and defers only the legacy default formatter during circular
+imports, so importing `default_table_formatter` first cannot silently disable
+the language-specific registry.
 `formatters/html_formatter.py` imports directly from `formatters/_formatter_interface.py` to avoid the
 `formatter_registry ↔ html_formatter` import cycle (fixed 2026-05-30).
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -365,7 +365,12 @@ def _reset_all_singletons():
         (
             "tree_sitter_analyzer.formatters.formatter_registry",
             "FormatterRegistry",
-            lambda cls: (cls.clear(), cls.register_builtin_formatters()),
+            lambda cls: (
+                cls.clear_registry(),
+                importlib.import_module(
+                    "tree_sitter_analyzer.formatters.formatter_registry"
+                ).register_builtin_formatters(),
+            ),
         ),
         (
             "tree_sitter_analyzer.core.engine_manager",

--- a/tests/unit/formatters/test_formatter_registry.py
+++ b/tests/unit/formatters/test_formatter_registry.py
@@ -7,6 +7,10 @@ including IFormatter interface, FormatterRegistry, and built-in formatters.
 """
 
 import json
+import logging
+import pickle
+import subprocess
+import sys
 
 import pytest
 
@@ -551,6 +555,87 @@ class TestFormatterRegistryIntegration:
 
         assert formatter1 is not formatter2
         assert isinstance(formatter1, type(formatter2))
+
+    def test_default_formatter_first_import_registers_java(self):
+        """Import order must not degrade language lookup to a generic formatter."""
+        # Issue #1181 (2026-07-27): a partial default-formatter import skipped
+        # every language registration on a fresh interpreter.
+        script = """
+from tree_sitter_analyzer.default_table_formatter import DefaultTableFormatter
+from tree_sitter_analyzer.formatters.formatter_registry import FormatterRegistry
+formatter = FormatterRegistry.get_formatter_for_language("java", "full")
+print(type(formatter).__name__)
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.stdout == "JavaTableFormatter\n"
+        assert result.stderr == ""
+
+    def test_global_reset_restores_java_language_formatter(self):
+        """The autouse reset helper must restore language-specific state."""
+        # Issue #1181 (2026-07-27): the fixture called nonexistent registry
+        # methods and swallowed the resulting AttributeError.
+        from tests.conftest import _reset_all_singletons
+
+        FormatterRegistry.clear_registry()
+        _reset_all_singletons()
+
+        formatter = FormatterRegistry.get_formatter_for_language("java", "full")
+        assert isinstance(formatter, JavaTableFormatter)
+
+    def test_failed_language_loading_preserves_generic_json_fallback(self, monkeypatch):
+        """A partial installation must keep generic formatters usable."""
+        # PR #1182 Codex review (2026-07-27): installing the table default
+        # before a failed language load stole the generic JSON fallback.
+        from tree_sitter_analyzer.formatters import (
+            _language_formatter_registration as registration,
+        )
+
+        def fail_language_import():
+            raise ImportError("optional formatter missing")
+
+        monkeypatch.setattr(
+            registration, "_code_language_formatters", fail_language_import
+        )
+        FormatterRegistry.clear_registry()
+        for formatter_class in (
+            JsonFormatter,
+            CsvFormatter,
+            FullFormatter,
+            CompactFormatter,
+        ):
+            FormatterRegistry.register_formatter(formatter_class)
+
+        registration.register_language_formatters(
+            FormatterRegistry, logging.getLogger(__name__)
+        )
+        formatter = FormatterRegistry.get_formatter_for_language("unknown", "json")
+
+        assert FormatterRegistry._default_language_formatter is None
+        assert isinstance(formatter, JsonFormatter)
+        assert formatter.format([]) == "[]"
+
+    def test_builtin_formatter_pickle_identity_remains_public(self):
+        """Moved public formatter classes must retain their stable pickle path."""
+        # PR #1182 Codex review (2026-07-27): the private module path would
+        # make new pickles unreadable by the preceding release.
+        expected_module = "tree_sitter_analyzer.formatters.formatter_registry"
+
+        assert {
+            formatter_class.__module__
+            for formatter_class in (
+                JsonFormatter,
+                CsvFormatter,
+                FullFormatter,
+                CompactFormatter,
+            )
+        } == {expected_module}
+        assert type(pickle.loads(pickle.dumps(JsonFormatter()))) is JsonFormatter
 
 
 class TestFormatterRegistryLanguageSupport:

--- a/tree_sitter_analyzer/formatters/_builtin_formatters.py
+++ b/tree_sitter_analyzer/formatters/_builtin_formatters.py
@@ -1,0 +1,168 @@
+"""Generic element formatters registered by :mod:`formatter_registry`."""
+
+import csv
+import io
+import json
+from typing import Any
+
+from ..models import CodeElement
+from ._csv_safety import csv_safe_row
+from ._formatter_interface import IFormatter
+
+
+class JsonFormatter(IFormatter):
+    """JSON formatter for CodeElement lists."""
+
+    @staticmethod
+    def get_format_name() -> str:
+        """Return the registry key."""
+        return "json"
+
+    @staticmethod
+    def _element_to_dict(element: Any) -> dict[str, Any]:
+        """Convert one element to a JSON-serialisable dict."""
+        elem_type = getattr(element, "element_type", "unknown")
+        data: dict[str, Any] = {
+            "name": element.name,
+            "type": elem_type,
+            "start_line": element.start_line,
+            "end_line": element.end_line,
+            "language": element.language,
+        }
+        for attribute in (
+            "parameters",
+            "return_type",
+            "visibility",
+            "modifiers",
+            "tag_name",
+            "selector",
+            "element_class",
+        ):
+            if hasattr(element, attribute):
+                data[attribute] = getattr(element, attribute)
+        return data
+
+    def format(self, elements: list[CodeElement]) -> str:
+        """Format elements as JSON."""
+        result = [self._element_to_dict(element) for element in elements]
+        return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+class CsvFormatter(IFormatter):
+    """CSV formatter for CodeElement lists."""
+
+    @staticmethod
+    def get_format_name() -> str:
+        """Return the registry key."""
+        return "csv"
+
+    def format(self, elements: list[CodeElement]) -> str:
+        """Format elements as CSV."""
+        output = io.StringIO()
+        writer = csv.writer(output, lineterminator="\n")
+        writer.writerow(
+            [
+                "Type",
+                "Name",
+                "Start Line",
+                "End Line",
+                "Language",
+                "Visibility",
+                "Parameters",
+                "Return Type",
+                "Modifiers",
+            ]
+        )
+        for element in elements:
+            writer.writerow(_csv_element_row(element))
+        csv_content = output.getvalue()
+        output.close()
+        return csv_content.rstrip("\n")
+
+
+def _csv_element_row(element: CodeElement) -> list[Any]:
+    """Return one control-character-safe generic CSV row."""
+    return csv_safe_row(
+        [
+            getattr(element, "element_type", "unknown"),
+            element.name,
+            element.start_line,
+            element.end_line,
+            element.language,
+            getattr(element, "visibility", ""),
+            str(getattr(element, "parameters", [])),
+            getattr(element, "return_type", ""),
+            str(getattr(element, "modifiers", [])),
+        ]
+    )
+
+
+def _append_full_element_lines(lines: list[str], element: CodeElement) -> None:
+    """Append one detailed element block."""
+    lines.append(f"  {element.name}")
+    lines.append(f"    Lines: {element.start_line}-{element.end_line}")
+    lines.append(f"    Language: {element.language}")
+    if hasattr(element, "visibility"):
+        lines.append(f"    Visibility: {element.visibility}")
+    if hasattr(element, "parameters") and (params := element.parameters):
+        lines.append(f"    Parameters: {', '.join(map(str, params))}")
+    if ret_type := getattr(element, "return_type", None):
+        lines.append(f"    Return Type: {ret_type}")
+    lines.append("")
+
+
+class FullFormatter(IFormatter):
+    """Full table formatter for CodeElement lists."""
+
+    @staticmethod
+    def get_format_name() -> str:
+        """Return the registry key."""
+        return "full"
+
+    def format(self, elements: list[CodeElement]) -> str:
+        """Format elements as a full text table."""
+        if not elements:
+            return "No elements found."
+
+        lines = ["=" * 80, "CODE STRUCTURE ANALYSIS", "=" * 80, ""]
+        element_groups: dict[str, list[CodeElement]] = {}
+        for element in elements:
+            element_type = getattr(element, "element_type", "unknown")
+            element_groups.setdefault(element_type, []).append(element)
+
+        for element_type, group_elements in element_groups.items():
+            lines.extend([f"{element_type.upper()}S ({len(group_elements)})", "-" * 40])
+            for element in group_elements:
+                _append_full_element_lines(lines, element)
+            lines.append("")
+        return "\n".join(lines)
+
+
+class CompactFormatter(IFormatter):
+    """Compact formatter for CodeElement lists."""
+
+    @staticmethod
+    def get_format_name() -> str:
+        """Return the registry key."""
+        return "compact"
+
+    def format(self, elements: list[CodeElement]) -> str:
+        """Format elements in compact form."""
+        if not elements:
+            return "No elements found."
+
+        lines = ["CODE ELEMENTS", "-" * 20]
+        for element in elements:
+            visibility = getattr(element, "visibility", "")
+            lines.append(
+                f"{self._get_visibility_symbol(visibility)} {element.name} "
+                f"({getattr(element, 'element_type', 'unknown')}) "
+                f"[{element.start_line}-{element.end_line}]"
+            )
+        return "\n".join(lines)
+
+    @staticmethod
+    def _get_visibility_symbol(visibility: str) -> str:
+        """Return the compact visibility marker."""
+        mapping = {"public": "+", "private": "-", "protected": "#", "package": "~"}
+        return mapping.get(visibility, "?")

--- a/tree_sitter_analyzer/formatters/_language_formatter_registration.py
+++ b/tree_sitter_analyzer/formatters/_language_formatter_registration.py
@@ -1,0 +1,110 @@
+"""Language-specific formatter registration without registry import cycles."""
+
+import logging
+from typing import Any
+
+
+def ensure_default_language_formatter(
+    registry: type[Any], logger: logging.Logger
+) -> None:
+    """Install the default table formatter once its module is importable."""
+    if registry._default_language_formatter is not None:
+        return
+    try:
+        from ..default_table_formatter import DefaultTableFormatter
+    except ImportError as error:
+        logger.debug("Deferred default formatter registration: %s", error)
+        return
+    registry.set_default_language_formatter(DefaultTableFormatter)
+
+
+def _code_language_formatters() -> dict[str, type[Any]]:
+    """Load formatter classes for programming languages."""
+    from .bash_formatter import BashTableFormatter
+    from .cpp_formatter import CppTableFormatter
+    from .csharp_formatter import CSharpTableFormatter
+    from .go_formatter import GoTableFormatter
+    from .java_formatter import JavaTableFormatter
+    from .javascript_formatter import JavaScriptTableFormatter
+    from .kotlin_formatter import KotlinTableFormatter
+    from .php_formatter import PHPTableFormatter
+    from .python_formatter import PythonTableFormatter
+    from .ruby_formatter import RubyTableFormatter
+    from .rust_formatter import RustTableFormatter
+    from .typescript_formatter import TypeScriptTableFormatter
+
+    return {
+        "java": JavaTableFormatter,
+        "python": PythonTableFormatter,
+        "py": PythonTableFormatter,
+        "javascript": JavaScriptTableFormatter,
+        "js": JavaScriptTableFormatter,
+        "typescript": TypeScriptTableFormatter,
+        "ts": TypeScriptTableFormatter,
+        "csharp": CSharpTableFormatter,
+        "cs": CSharpTableFormatter,
+        "php": PHPTableFormatter,
+        "ruby": RubyTableFormatter,
+        "rb": RubyTableFormatter,
+        "kotlin": KotlinTableFormatter,
+        "kt": KotlinTableFormatter,
+        "kts": KotlinTableFormatter,
+        "bash": BashTableFormatter,
+        "sh": BashTableFormatter,
+        "go": GoTableFormatter,
+        "rust": RustTableFormatter,
+        "rs": RustTableFormatter,
+        "c": CppTableFormatter,
+        "cpp": CppTableFormatter,
+        "h": CppTableFormatter,
+        "hpp": CppTableFormatter,
+    }
+
+
+def _data_language_formatters() -> dict[str, type[Any]]:
+    """Load formatter classes for data and markup languages."""
+    from .css_formatter import CSSFormatter
+    from .html_formatter import HtmlFormatter
+    from .json_formatter import JSONFormatter
+    from .markdown_formatter import MarkdownFormatter
+    from .sql_formatter_wrapper import SQLFormatterWrapper
+    from .yaml_formatter import YAMLFormatter
+
+    return {
+        "yaml": YAMLFormatter,
+        "yml": YAMLFormatter,
+        "json": JSONFormatter,
+        "jsonc": JSONFormatter,
+        "json5": JSONFormatter,
+        "css": CSSFormatter,
+        "html": HtmlFormatter,
+        "htm": HtmlFormatter,
+        "markdown": MarkdownFormatter,
+        "md": MarkdownFormatter,
+        "sql": SQLFormatterWrapper,
+    }
+
+
+def _load_language_formatters(
+    logger: logging.Logger,
+) -> dict[str, type[Any]] | None:
+    """Load all bundled formatter classes or report a broken installation."""
+    try:
+        return {**_code_language_formatters(), **_data_language_formatters()}
+    except ImportError as error:
+        logger.warning("Failed to register language formatters: %s", error)
+        return None
+
+
+def register_language_formatters(registry: type[Any], logger: logging.Logger) -> None:
+    """Register every bundled language formatter while tolerating a default cycle."""
+    language_formatters = _load_language_formatters(logger)
+    if language_formatters is None:
+        registry._language_registration_complete = False
+        return
+    for language, formatter_class in language_formatters.items():
+        for format_type in ("full", "compact", "csv", "signatures"):
+            registry.register_language_formatter(language, format_type, formatter_class)
+    registry._language_registration_complete = True
+    ensure_default_language_formatter(registry, logger)
+    logger.info("Registered language-specific formatters")

--- a/tree_sitter_analyzer/formatters/formatter_registry.py
+++ b/tree_sitter_analyzer/formatters/formatter_registry.py
@@ -11,10 +11,23 @@ This is the unified entry point for all formatter operations in the project.
 import logging
 from typing import Any
 
-from ..models import CodeElement
+from ._builtin_formatters import (
+    CompactFormatter,
+    CsvFormatter,
+    FullFormatter,
+    JsonFormatter,
+)
 from ._formatter_interface import IFormatter, IStructureFormatter  # noqa: F401
+from ._language_formatter_registration import (
+    ensure_default_language_formatter,
+    register_language_formatters,
+)
 
 logger = logging.getLogger(__name__)
+
+# Keep the historical public identity after moving implementations behind the facade.
+for _formatter_class in (JsonFormatter, CsvFormatter, FullFormatter, CompactFormatter):
+    _formatter_class.__module__ = __name__
 
 
 class FormatterRegistry:
@@ -32,6 +45,7 @@ class FormatterRegistry:
     _formatters: dict[str, type[IFormatter]] = {}
     _language_formatters: dict[str, Any] = {}
     _default_language_formatter: type[Any] | None = None
+    _language_registration_complete = False
 
     @classmethod
     # Format data for output: register_formatter
@@ -137,6 +151,7 @@ class FormatterRegistry:
         cls._formatters.clear()
         cls._language_formatters.clear()
         cls._default_language_formatter = None
+        cls._language_registration_complete = False
         logger.debug("Cleared all registered formatters")
 
     @classmethod
@@ -191,24 +206,9 @@ class FormatterRegistry:
         format_type: str = "full",
         **kwargs: Any,
     ) -> Any:
-        """
-        Get a formatter instance for the specified language and format type.
+        """Return the best language-specific, default, or generic formatter.
 
-        This is the primary method for obtaining formatters in the unified architecture.
-        It handles language-specific formatter lookup with fallback to defaults.
-
-        Args:
-            language: Programming language name
-            format_type: Format type (full, compact, csv, json, etc.)
-            **kwargs: Additional arguments passed to formatter constructor
-                - include_javadoc: bool - Include JavaDoc in output
-
-        Returns:
-            Formatter instance appropriate for the language and format
-
-        Example:
-            >>> formatter = FormatterRegistry.get_formatter_for_language("java", "full")
-            >>> output = formatter.format_structure(analysis_data)
+        Extra keyword arguments are forwarded to table-style constructors.
         """
         lang_key = language.lower()
         format_key = format_type.lower()
@@ -220,6 +220,9 @@ class FormatterRegistry:
             return cls._create_formatter_instance(
                 formatter_class, format_key, language, **kwargs
             )
+
+        if cls._language_registration_complete:
+            ensure_default_language_formatter(cls, logger)
 
         # Fall back to default language formatter if set
         if cls._default_language_formatter is not None:
@@ -298,315 +301,16 @@ class FormatterRegistry:
         return language.lower() in cls._language_formatters
 
 
-# Built-in formatter implementations
-
-
-class JsonFormatter(IFormatter):
-    """JSON formatter for CodeElement lists"""
-
-    @staticmethod
-    # Format data for output: get_format_name
-    def get_format_name() -> str:
-        return "json"
-
-    @staticmethod
-    def _element_to_dict(element: Any) -> dict[str, Any]:
-        """Convert one element to a JSON-serialisable dict."""
-        elem_type = getattr(element, "element_type", "unknown")
-        d: dict[str, Any] = {
-            "name": element.name,
-            "type": elem_type,
-            "start_line": element.start_line,
-            "end_line": element.end_line,
-            "language": element.language,
-        }
-        if hasattr(element, "parameters"):
-            d["parameters"] = element.parameters
-        if hasattr(element, "return_type"):
-            d["return_type"] = element.return_type
-        if hasattr(element, "visibility"):
-            d["visibility"] = element.visibility
-        if hasattr(element, "modifiers"):
-            d["modifiers"] = element.modifiers
-        if hasattr(element, "tag_name"):
-            d["tag_name"] = element.tag_name
-        if hasattr(element, "selector"):
-            d["selector"] = element.selector
-        if hasattr(element, "element_class"):
-            d["element_class"] = element.element_class
-        return d
-
-    # Format data for output: format
-    def format(self, elements: list[CodeElement]) -> str:
-        """Format elements as JSON"""
-        import json
-
-        result = [JsonFormatter._element_to_dict(el) for el in elements]
-        return json.dumps(result, indent=2, ensure_ascii=False)
-
-
-class CsvFormatter(IFormatter):
-    """CSV formatter for CodeElement lists"""
-
-    @staticmethod
-    # Format data for output: get_format_name
-    def get_format_name() -> str:
-        return "csv"
-
-    # Format data for output: format
-    def format(self, elements: list[CodeElement]) -> str:
-        """Format elements as CSV"""
-        import csv
-        import io
-
-        from ._csv_safety import csv_safe_row
-
-        output = io.StringIO()
-        writer = csv.writer(output, lineterminator="\n")
-
-        # Write header
-        writer.writerow(
-            [
-                "Type",
-                "Name",
-                "Start Line",
-                "End Line",
-                "Language",
-                "Visibility",
-                "Parameters",
-                "Return Type",
-                "Modifiers",
-            ]
-        )
-
-        # Write data rows
-        for element in elements:
-            elem_type = getattr(element, "element_type", "unknown")
-            visibility = getattr(element, "visibility", "")
-            return_type = getattr(element, "return_type", "")
-            params_raw = getattr(element, "parameters", [])
-            mods_raw = getattr(element, "modifiers", [])
-            params_str = str(params_raw)
-            mods_str = str(mods_raw)
-            writer.writerow(
-                csv_safe_row(
-                    [
-                        elem_type,
-                        element.name,
-                        element.start_line,
-                        element.end_line,
-                        element.language,
-                        visibility,
-                        params_str,
-                        return_type,
-                        mods_str,
-                    ]
-                )
-            )
-
-        csv_content = output.getvalue()
-        output.close()
-        return csv_content.rstrip("\n")
-
-
-def _append_full_element_lines(lines: list[str], element: CodeElement) -> None:
-    """Append the per-element block lines used by ``FullFormatter.format``.
-
-    r37cl (dogfood): tool flagged ``FullFormatter.format`` at nesting
-    depth 7 (L498). The per-element ``hasattr`` chain (visibility →
-    parameters → return_type) moves here so the outer formatter body
-    stays flat.
-    """
-    lines.append(f"  {element.name}")
-    lines.append(f"    Lines: {element.start_line}-{element.end_line}")
-    lines.append(f"    Language: {element.language}")
-
-    if hasattr(element, "visibility"):
-        lines.append(f"    Visibility: {element.visibility}")
-    if hasattr(element, "parameters") and (params := element.parameters):
-        params_str = ", ".join(map(str, params))
-        lines.append(f"    Parameters: {params_str}")
-    if hasattr(element, "return_type"):
-        ret_type = getattr(element, "return_type", None)
-        if ret_type:
-            lines.append(f"    Return Type: {ret_type}")
-    lines.append("")
-
-
-class FullFormatter(IFormatter):
-    """Full table formatter for CodeElement lists"""
-
-    @staticmethod
-    # Format data for output: get_format_name
-    def get_format_name() -> str:
-        return "full"
-
-    # Format data for output: format
-    def format(self, elements: list[CodeElement]) -> str:
-        """Format elements as full table"""
-        if not elements:
-            return "No elements found."
-
-        lines = []
-        lines.append("=" * 80)
-        lines.append("CODE STRUCTURE ANALYSIS")
-        lines.append("=" * 80)
-        lines.append("")
-
-        # Group elements by type
-        element_groups: dict[str, Any] = {}
-        for element in elements:
-            element_type = getattr(element, "element_type", "unknown")
-            if element_type not in element_groups:
-                element_groups[element_type] = []
-            element_groups[element_type].append(element)
-
-        # Format each group
-        for element_type, group_elements in element_groups.items():
-            type_label = element_type.upper()
-            group_count = len(group_elements)
-            lines.append(f"{type_label}S ({group_count})")
-            lines.append("-" * 40)
-            for element in group_elements:
-                # r37cl (dogfood): extracted to flatten nesting 7 → 3.
-                _append_full_element_lines(lines, element)
-            lines.append("")
-
-        return "\n".join(lines)
-
-
-class CompactFormatter(IFormatter):
-    """Compact formatter for CodeElement lists"""
-
-    @staticmethod
-    # Format data for output: get_format_name
-    def get_format_name() -> str:
-        return "compact"
-
-    # Format data for output: format
-    def format(self, elements: list[CodeElement]) -> str:
-        """Format elements in compact format"""
-        if not elements:
-            return "No elements found."
-
-        lines = []
-        lines.append("CODE ELEMENTS")
-        lines.append("-" * 20)
-
-        for element in elements:
-            element_type = getattr(element, "element_type", "unknown")
-            visibility = getattr(element, "visibility", "")
-            vis_symbol = self._get_visibility_symbol(visibility)
-
-            line = f"{vis_symbol} {element.name} ({element_type}) [{element.start_line}-{element.end_line}]"
-            lines.append(line)
-
-        return "\n".join(lines)
-
-    def _get_visibility_symbol(self, visibility: str) -> str:
-        """Get symbol for visibility"""
-        mapping = {"public": "+", "private": "-", "protected": "#", "package": "~"}
-        return mapping.get(visibility, "?")
-
-
-# Register built-in formatters
 def register_builtin_formatters() -> None:
-    """Register all built-in formatters"""
-    FormatterRegistry.register_formatter(JsonFormatter)
-
-    # Fallback to simple formatters first to avoid circular import issues
-    FormatterRegistry.register_formatter(CsvFormatter)
-    FormatterRegistry.register_formatter(FullFormatter)
-    FormatterRegistry.register_formatter(CompactFormatter)
-
-    # Register language-specific formatters
-    _register_language_formatters_safe()
-
-
-# Format data for output: _register_language_formatters_safe
-def _register_language_formatters_safe() -> None:
-    """Register language-specific formatters safely to avoid circular imports"""
-    try:
-        # Import language-specific formatters
-        from ..default_table_formatter import DefaultTableFormatter
-        from .bash_formatter import BashTableFormatter
-        from .cpp_formatter import CppTableFormatter
-        from .csharp_formatter import CSharpTableFormatter
-        from .css_formatter import CSSFormatter
-        from .go_formatter import GoTableFormatter
-        from .html_formatter import HtmlFormatter
-        from .java_formatter import JavaTableFormatter
-        from .javascript_formatter import JavaScriptTableFormatter
-        from .json_formatter import JSONFormatter
-        from .kotlin_formatter import KotlinTableFormatter
-        from .markdown_formatter import MarkdownFormatter
-        from .php_formatter import PHPTableFormatter
-        from .python_formatter import PythonTableFormatter
-        from .ruby_formatter import RubyTableFormatter
-        from .rust_formatter import RustTableFormatter
-        from .sql_formatter_wrapper import SQLFormatterWrapper
-        from .typescript_formatter import TypeScriptTableFormatter
-        from .yaml_formatter import YAMLFormatter
-
-        # Set DefaultTableFormatter as default for unsupported languages
-        FormatterRegistry.set_default_language_formatter(DefaultTableFormatter)
-
-        # Language to formatter mapping
-        language_formatters = {
-            "java": JavaTableFormatter,
-            "python": PythonTableFormatter,
-            "py": PythonTableFormatter,
-            "javascript": JavaScriptTableFormatter,
-            "js": JavaScriptTableFormatter,
-            "typescript": TypeScriptTableFormatter,
-            "ts": TypeScriptTableFormatter,
-            "csharp": CSharpTableFormatter,
-            "cs": CSharpTableFormatter,
-            "php": PHPTableFormatter,
-            "ruby": RubyTableFormatter,
-            "rb": RubyTableFormatter,
-            "kotlin": KotlinTableFormatter,
-            "kt": KotlinTableFormatter,
-            "kts": KotlinTableFormatter,
-            "bash": BashTableFormatter,
-            "sh": BashTableFormatter,
-            "go": GoTableFormatter,
-            "rust": RustTableFormatter,
-            "rs": RustTableFormatter,
-            "c": CppTableFormatter,
-            "cpp": CppTableFormatter,
-            "h": CppTableFormatter,
-            "hpp": CppTableFormatter,
-            "yaml": YAMLFormatter,
-            "yml": YAMLFormatter,
-            "json": JSONFormatter,
-            "jsonc": JSONFormatter,
-            "json5": JSONFormatter,
-            "css": CSSFormatter,
-            "html": HtmlFormatter,
-            "htm": HtmlFormatter,
-            "markdown": MarkdownFormatter,
-            "md": MarkdownFormatter,
-            "sql": SQLFormatterWrapper,
-        }
-
-        # Register each language with all format types
-        # "signatures" is the lightweight method-directory mode (~25 % of full tokens).
-        format_types = ["full", "compact", "csv", "signatures"]
-        for lang, formatter_class in language_formatters.items():
-            for fmt in format_types:
-                FormatterRegistry.register_language_formatter(
-                    lang, fmt, formatter_class
-                )
-
-        logger.info("Registered language-specific formatters")
-    except ImportError as e:
-        logger.warning(f"Failed to register language formatters: {e}")
-
-
-# NOTE: HTML formatters are intentionally excluded from analyze_code_structure
-# as they are not part of the v1.6.1.4 specification and cause format regression.
-# HTML formatters can still be registered separately for other tools if needed.
+    """Register generic and language-specific built-in formatters."""
+    for formatter_class in (
+        JsonFormatter,
+        CsvFormatter,
+        FullFormatter,
+        CompactFormatter,
+    ):
+        FormatterRegistry.register_formatter(formatter_class)
+    register_language_formatters(FormatterRegistry, logger)
 
 
 # Auto-register built-in formatters when module is imported


### PR DESCRIPTION
## Value

Closes #1181 and advances #1122 by making formatter registration deterministic across import orders and pytest-xdist workers. The fix removes a real production failure where importing the legacy default formatter first could permanently disable every language-specific formatter.

## What changed

- Fixed the autouse singleton-reset fixture to call the real `clear_registry()` API and the module-level `register_builtin_formatters()` function.
- Made bundled language registration independent from the legacy default formatter's circular-import window.
- Lazily installs the default formatter once its module is importable.
- Split the 613-line registry hotspot into a 310-line facade, 168-line generic formatter module, and 108-line language-registration module.
- Preserved all historical formatter imports through `formatter_registry.py`.
- Added exact regressions for fresh-interpreter import order and singleton reset behavior.
- Updated the formatter codemap.

## Health result

- Registry facade: grade A, score 94.3, 0 smells, 310 lines.
- Generic built-ins: grade A, score 95.5, 0 smells, 168 lines.
- Language registration: grade A, score 96.4, 0 smells, 108 lines.
- Every changed source module is below 500 lines.

## Verification

- Original default-xdist Java reproduction: 236 passed, 11 skipped.
- Focused registry/reset suite: 50 passed.
- Strict patch coverage: no added executable or branch misses.
- Full quick suite: 1306 passed, 7 skipped.
- Ruff: passed.
- MyPy: 762 source files passed.
- Bandit with repository policy: passed.
- Strict test-quality audit: no blocking findings.
- Weak-assertion ratchet, test-name contract, and codemap sync: passed.
- Change-impact contract: high risk; focused and default verification completed.
- `uv build`: sdist and wheel succeeded.
- `git diff --check`: passed.