### PR TITLE
refactor(uml): split state scanning stages

### DIFF
--- a/tests/unit/test_uml_state.py
+++ b/tests/unit/test_uml_state.py
@@ -1107,6 +1107,35 @@ def test_extract_enum_members_includes_lowercase(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_named_duplicate_enum_scans_only_the_first_match() -> None:
+    """A named lookup must not traverse the full AST once per duplicate Enum."""
+    # PR #1185 Codex review (2026-07-27): selecting after extraction made
+    # duplicate nested class names multiply the full-tree transition scan.
+    from tree_sitter_analyzer._uml_state_results import collect_state_data
+
+    scanned: list[str] = []
+    enum_classes = [
+        {"name": "State", "node": ["FIRST"]},
+        {"name": "State", "node": ["SECOND"]},
+    ]
+
+    def extract_transitions(_root, name, _members):
+        scanned.append(name)
+        return []
+
+    members, transitions = collect_state_data(
+        object(),
+        enum_classes,
+        "State",
+        lambda node: node,
+        extract_transitions,
+    )
+
+    assert scanned == ["State"]
+    assert members == ["FIRST"]
+    assert transitions == []
+
+
 def test_second_enum_transitions_found_when_first_enum_has_none(
     tmp_path: Path,
 ) -> None:

--- a/tree_sitter_analyzer/_uml_state_helpers.py
+++ b/tree_sitter_analyzer/_uml_state_helpers.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
-"""State diagram (stateDiagram-v2) scanner implementation for RFC-0015.
+"""State-diagram scanner facade and stable public data types.
 
-This module now holds the implementation details; ``uml_state.py`` is a thin
-re-export wrapper so the public import path stays stable while the scanner
-logic can evolve independently.
+``uml_state.py`` remains the public import wrapper. Node discovery, transition
+scanning, and result shaping live in focused private stages behind this module.
 """
 
 from __future__ import annotations
@@ -12,6 +11,18 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+
+from ._uml_state_nodes import (
+    extract_enum_members as _extract_members,
+)
+from ._uml_state_nodes import (
+    find_enum_classes as _find_classes,
+)
+from ._uml_state_nodes import (
+    node_text as _decode_node_text,
+)
+from ._uml_state_results import collect_state_data, finalize_states
+from ._uml_state_transitions import extract_transitions
 
 ParseFileForState = Callable[[str, str], tuple[Any, bytes] | None]
 
@@ -38,16 +49,10 @@ class StateResult:
 def _parse_file_for_state(
     file_path: str, language: str = "python"
 ) -> tuple[Any, bytes] | None:
-    """Parse *file_path* with tree-sitter and return (tree_root, source_bytes).
-
-    Returns None when the file does not exist, the language is unsupported,
-    or the parser fails. ONE parse per call — callers MUST NOT call this in
-    a loop for the same file (rule-11 invariant).
-    """
+    """Parse a file once and return its tree root plus source bytes."""
     from .core.parser import Parser
 
-    parser = Parser()
-    result = parser.parse_file(file_path, language)
+    result = Parser().parse_file(file_path, language)
     if not result.success or result.tree is None:
         return None
     raw_source = result.source_code
@@ -60,218 +65,35 @@ def _parse_file_for_state(
 
 
 def _node_text(node: Any, max_len: int = 60) -> str:
-    """Decode a tree-sitter node's text, capped at max_len chars."""
-    try:
-        raw = node.text
-        if raw is None:
-            return ""
-        text: str = raw.decode("utf-8", errors="replace").strip()
-        return text[:max_len] if len(text) > max_len else text
-    except Exception:
-        return ""
+    """Preserve the historical node-text helper surface."""
+    return _decode_node_text(node, max_len)
 
 
 def _find_enum_classes(
     root: Any, class_name_filter: str | None
 ) -> list[dict[str, Any]]:
-    """Walk the root node to find class definitions that inherit from Enum.
-
-    Returns a list of dicts: {"name": str, "node": ts_node}.
-    Looks for class_definition nodes whose argument_list or base_class
-    contains "Enum".
-    """
-    results: list[dict[str, Any]] = []
-
-    def _walk(node: Any) -> None:
-        if node.type == "class_definition":
-            name = ""
-            has_enum_base = False
-            for child in node.children:
-                if child.type == "identifier":
-                    name = _node_text(child)
-                elif child.type == "argument_list":
-                    # Python class bases are in argument_list.
-                    # Accept both bare names ("Enum") and qualified names
-                    # ("enum.Enum", "enum.IntEnum") — take the last segment.
-                    _ENUM_BASES = {"Enum", "IntEnum", "StrEnum", "Flag", "IntFlag"}
-                    for base in child.children:
-                        base_text = _node_text(base)
-                        # last segment handles "enum.Enum" → "Enum"
-                        if base_text.split(".")[-1] in _ENUM_BASES:
-                            has_enum_base = True
-            if name and has_enum_base:
-                if class_name_filter is None or name == class_name_filter:
-                    results.append({"name": name, "node": node})
-        for child in node.children:
-            _walk(child)
-
-    _walk(root)
-    return results
+    """Preserve the historical Enum discovery helper surface."""
+    return _find_classes(root, class_name_filter)
 
 
 def _extract_enum_members(class_node: Any) -> list[str]:
-    """Extract Enum member names from a class_definition body.
-
-    Returns member names in the order they appear (for stable ordering).
-    All assignment targets that are not underscore-prefixed are treated as
-    members (avoiding __doc__, __module__, _ignore_, etc.). This includes
-    UPPERCASE_NAMES, MixedCase, and lowercase names alike.
-    """
-    members: list[str] = []
-    for child in class_node.children:
-        if child.type == "block":
-            for stmt in child.children:
-                if stmt.type == "expression_statement":
-                    for sub in stmt.children:
-                        if sub.type == "assignment":
-                            lhs_children = list(sub.children)
-                            if lhs_children:
-                                lhs = lhs_children[0]
-                                if lhs.type == "identifier":
-                                    name = _node_text(lhs)
-                                    if name and not name.startswith("_"):
-                                        members.append(name)
-    return members
+    """Preserve the historical Enum-member helper surface."""
+    return _extract_members(class_node)
 
 
 def _extract_transitions(
     root: Any, class_name: str, known_members: set[str]
 ) -> list[StateTransition]:
-    """Walk root for match_statement nodes and extract FSM transitions.
+    """Preserve the historical transition helper surface."""
+    return extract_transitions(root, class_name, known_members, StateTransition)
 
-    Heuristic: a match_statement with a subject, where each case_clause
-    whose pattern references <class_name>.<MemberA> and whose body
-    contains a transition target becomes a transition A → B.
 
-    Two transition-target patterns are detected:
-    1. ``return <class_name>.<MemberB>``  — pure functional FSM style.
-    2. ``<target> = <class_name>.<MemberB>``  — OOP style (e.g.
-       ``self.state = Door.OPEN``), detected by scanning assignment
-       statements whose right-hand side is an enum member reference.
-    """
-    transitions: list[StateTransition] = []
-    seen: set[tuple[str, str]] = set()
-
-    def _find_match_statements(node: Any) -> list[Any]:
-        results: list[Any] = []
-        if node.type == "match_statement":
-            results.append(node)
-        for child in node.children:
-            results.extend(_find_match_statements(child))
-        return results
-
-    def _parse_enum_ref(node: Any) -> str | None:
-        """Return the member name if node is <class_name>.<member>."""
-        text = _node_text(node, 80)
-        prefix = class_name + "."
-        if text.startswith(prefix):
-            member = text[len(prefix) :]
-            if member in known_members:
-                return member
-        return None
-
-    def _find_return_enum_ref(node: Any) -> str | None:
-        """Recursively search for a return_statement or assignment whose RHS is
-        <class_name>.<member>.
-
-        Patterns detected:
-        - ``return <class_name>.<member>``  (return_statement)
-        - ``<anything> = <class_name>.<member>``  (assignment, e.g. self.state = Door.OPEN)
-        """
-        if node.type == "return_statement":
-            for child in node.children:
-                ref = _parse_enum_ref(child)
-                if ref is not None:
-                    return ref
-        elif node.type == "assignment":
-            # assignment children: [lhs, "=", rhs]
-            # We look for the RHS (last child that is not "=")
-            children = list(node.children)
-            for child in reversed(children):
-                if child.type != "=" and _node_text(child, 2) != "=":
-                    ref = _parse_enum_ref(child)
-                    if ref is not None:
-                        return ref
-                    break
-        for child in node.children:
-            result = _find_return_enum_ref(child)
-            if result is not None:
-                return result
-        return None
-
-    def _find_case_pattern_member(node: Any) -> str | None:
-        """Extract the enum member from a case pattern like TrafficLight.RED."""
-        # case_clause children include "case", the pattern, and ":"
-        for child in node.children:
-            if child.type in (
-                "dotted_name",
-                "attribute",
-                "identifier",
-                "case_pattern",
-            ):
-                ref = _parse_enum_ref(child)
-                if ref is not None:
-                    return ref
-                # attribute node: value.attribute
-                val = getattr(child, "children", [])
-                for sub in val:
-                    ref2 = _parse_enum_ref(sub)
-                    if ref2 is not None:
-                        return ref2
-        return None
-
-    def _iter_case_clauses(match_stmt: Any) -> list[Any]:
-        """Return all case_clause nodes from a match_statement.
-
-        Tree-sitter places case_clauses inside a 'block' child of
-        match_statement (not as direct children).
-        """
-        clauses: list[Any] = []
-        for child in match_stmt.children:
-            if child.type == "block":
-                for sub in child.children:
-                    if sub.type == "case_clause":
-                        clauses.append(sub)
-            elif child.type == "case_clause":
-                # Direct child fallback (some grammar versions)
-                clauses.append(child)
-        return clauses
-
-    match_stmts = _find_match_statements(root)
-    for match_stmt in match_stmts:
-        for case_clause in _iter_case_clauses(match_stmt):
-            source_member = None
-            target_member = None
-
-            for cc in case_clause.children:
-                if cc.type == "case_pattern":
-                    # case_pattern > dotted_name: "ClassName.MEMBER"
-                    for sub in cc.children:
-                        m = _parse_enum_ref(sub)
-                        if m is not None:
-                            source_member = m
-                            break
-                    if source_member is None:
-                        # fallback: try the case_pattern node text itself
-                        m = _parse_enum_ref(cc)
-                        if m is not None:
-                            source_member = m
-                elif cc.type in ("dotted_name", "attribute"):
-                    m = _parse_enum_ref(cc)
-                    if m is not None:
-                        source_member = m
-                elif cc.type == "block":
-                    target_member = _find_return_enum_ref(cc)
-
-            if source_member and target_member and source_member != target_member:
-                key = (source_member, target_member)
-                if key not in seen:
-                    seen.add(key)
-                    transitions.append(
-                        StateTransition(source=source_member, target=target_member)
-                    )
-
-    return transitions
+def _missing_enum_error(class_name: str | None) -> str:
+    return (
+        "NOT_FOUND:class_missing"
+        if class_name is not None
+        else "NOT_FOUND:no_enum_class"
+    )
 
 
 def build_state_result(
@@ -282,99 +104,29 @@ def build_state_result(
     *,
     parse_file_for_state: ParseFileForState = _parse_file_for_state,
 ) -> StateResult:
-    """Parse *file_path* and extract FSM states and transitions.
-
-    Cost: ONE disk read + ONE tree-sitter parse (rule-11 invariant).
-
-    Returns StateResult with error="" on success (even if transitions is empty —
-    the NOT_FOUND verdict for empty transitions is applied at the UMLExporter
-    level, not here).
-
-    Errors:
-      error="NOT_FOUND:file_missing"  — file does not exist
-      error="NOT_FOUND:no_enum_class" — no Enum subclass found in file
-      error="NOT_FOUND:class_missing" — class_name given but not found
-      error="PARSE_FAILED"            — tree-sitter parse failure
-    """
+    """Parse one file and extract deterministic FSM states and transitions."""
     if not Path(file_path).exists():
         return StateResult(error="NOT_FOUND:file_missing")
 
     parse_result = parse_file_for_state(file_path, language)
     if parse_result is None:
         return StateResult(error="PARSE_FAILED")
-
     root, _source = parse_result
 
     enum_classes = _find_enum_classes(root, class_name)
-
     if not enum_classes:
-        if class_name is not None:
-            # class_name was provided but not found as an Enum subclass
-            return StateResult(error="NOT_FOUND:class_missing")
-        return StateResult(error="NOT_FOUND:no_enum_class")
+        return StateResult(error=_missing_enum_error(class_name))
 
-    # Collect members per enum class and scan each for transitions.
-    # Semantics (P2-2): when class_name is omitted and multiple Enums are
-    # present, we scan every Enum for transitions; if any have transitions we
-    # prefer those (states from transition-bearing enums only).  When none
-    # have transitions we fall back to all members (caller will set NOT_FOUND).
-    per_enum_members: list[tuple[str, list[str]]] = []
-    for ec in enum_classes:
-        members = _extract_enum_members(ec["node"])
-        per_enum_members.append((ec["name"], members))
-
-    if class_name is not None:
-        # Filtered to a single enum — original behaviour, one scan.
-        all_members = per_enum_members[0][1] if per_enum_members else []
-        primary_class = class_name
-        known_members_set: set[str] = set(all_members)
-        all_transitions = _extract_transitions(root, primary_class, known_members_set)
-    else:
-        # Scan each discovered enum independently; aggregate results.
-        enum_transitions: list[tuple[str, list[str], list[StateTransition]]] = []
-        for ec_name, ec_members in per_enum_members:
-            km = set(ec_members)
-            txns = _extract_transitions(root, ec_name, km)
-            enum_transitions.append((ec_name, ec_members, txns))
-
-        # Prefer enums that have transitions (P2-2 semantics).
-        transition_bearing = [
-            (name, members, txns) for name, members, txns in enum_transitions if txns
-        ]
-        if transition_bearing:
-            chosen = transition_bearing
-        else:
-            chosen = enum_transitions  # fall back to all (will result in NOT_FOUND)
-
-        all_members = [m for _, members, _ in chosen for m in members]
-        # Aggregate transitions (deduplicated across enums)
-        seen_txn: set[tuple[str, str]] = set()
-        all_transitions = []
-        for _, _, txns in chosen:
-            for t in txns:
-                key = (t.source, t.target)
-                if key not in seen_txn:
-                    seen_txn.add(key)
-                    all_transitions.append(t)
-
-    # Deduplicate members while preserving order
-    seen_members: set[str] = set()
-    unique_members: list[str] = []
-    for m in all_members:
-        if m not in seen_members:
-            seen_members.add(m)
-            unique_members.append(m)
-
-    truncated = False
-    if len(unique_members) > max_nodes:
-        unique_members = unique_members[:max_nodes]
-        truncated = True
-
-    # Sort for deterministic output
-    states = sorted(unique_members)
-
+    members, transitions = collect_state_data(
+        root,
+        enum_classes,
+        class_name,
+        _extract_enum_members,
+        _extract_transitions,
+    )
+    states, truncated = finalize_states(members, max_nodes)
     return StateResult(
         states=states,
-        transitions=all_transitions,
+        transitions=transitions,
         truncated=truncated,
     )

--- a/tree_sitter_analyzer/_uml_state_nodes.py
+++ b/tree_sitter_analyzer/_uml_state_nodes.py
@@ -1,0 +1,95 @@
+"""Tree-sitter node discovery for the state-diagram scanner."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+_ENUM_BASES = {"Enum", "IntEnum", "StrEnum", "Flag", "IntFlag"}
+
+
+def node_text(node: Any, max_len: int = 60) -> str:
+    """Decode a tree-sitter node's text, capped at ``max_len`` characters."""
+    try:
+        raw = node.text
+        if raw is None:
+            return ""
+        text: str = raw.decode("utf-8", errors="replace").strip()
+        return text[:max_len] if len(text) > max_len else text
+    except Exception:
+        return ""
+
+
+def walk_nodes(root: Any) -> Iterator[Any]:
+    """Yield a tree in stable pre-order without recursive call depth."""
+    pending = [root]
+    while pending:
+        node = pending.pop()
+        yield node
+        pending.extend(reversed(list(node.children)))
+
+
+def _enum_class_identity(node: Any) -> tuple[str, bool]:
+    """Return the direct class name and whether it has a supported Enum base."""
+    name = ""
+    has_enum_base = False
+    for child in node.children:
+        if child.type == "identifier":
+            name = node_text(child)
+            continue
+        if child.type != "argument_list":
+            continue
+        has_enum_base = any(
+            node_text(base).split(".")[-1] in _ENUM_BASES for base in child.children
+        )
+    return name, has_enum_base
+
+
+def find_enum_classes(root: Any, class_name_filter: str | None) -> list[dict[str, Any]]:
+    """Find Enum class definitions, optionally restricted by exact class name."""
+    results: list[dict[str, Any]] = []
+    for node in walk_nodes(root):
+        if node.type != "class_definition":
+            continue
+        name, has_enum_base = _enum_class_identity(node)
+        if not name or not has_enum_base:
+            continue
+        if class_name_filter is None or name == class_name_filter:
+            results.append({"name": name, "node": node})
+    return results
+
+
+def _assignment_member(assignment: Any) -> str | None:
+    """Return a public identifier assignment target, if present."""
+    children = list(assignment.children)
+    if not children:
+        return None
+    lhs = children[0]
+    if lhs.type != "identifier":
+        return None
+    name = node_text(lhs)
+    return name if name and not name.startswith("_") else None
+
+
+def _expression_statements(class_node: Any) -> Iterator[Any]:
+    for block in (child for child in class_node.children if child.type == "block"):
+        yield from (
+            statement
+            for statement in block.children
+            if statement.type == "expression_statement"
+        )
+
+
+def _enum_assignments(class_node: Any) -> Iterator[Any]:
+    for statement in _expression_statements(class_node):
+        yield from (child for child in statement.children if child.type == "assignment")
+
+
+def extract_enum_members(class_node: Any) -> list[str]:
+    """Extract public Enum assignment names in source order."""
+    members: list[str] = []
+    for assignment in _enum_assignments(class_node):
+        member = _assignment_member(assignment)
+        if member is not None:
+            members.append(member)
+    return members

--- a/tree_sitter_analyzer/_uml_state_results.py
+++ b/tree_sitter_analyzer/_uml_state_results.py
@@ -1,0 +1,87 @@
+"""State selection and deterministic result shaping."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, Protocol, TypeVar
+
+
+class TransitionLike(Protocol):
+    """Structural transition surface used for cross-Enum deduplication."""
+
+    source: str
+    target: str
+
+
+TransitionT = TypeVar("TransitionT", bound=TransitionLike)
+TransitionExtractor = Callable[[Any, str, set[str]], list[TransitionT]]
+MemberExtractor = Callable[[Any], list[str]]
+EnumScan = tuple[str, list[str], list[TransitionT]]
+
+
+def _scan_enums(
+    root: Any,
+    enum_classes: list[dict[str, Any]],
+    member_extractor: MemberExtractor,
+    transition_extractor: TransitionExtractor[TransitionT],
+) -> list[EnumScan[TransitionT]]:
+    """Extract members and transitions independently for every Enum."""
+    scans: list[EnumScan[TransitionT]] = []
+    for enum_class in enum_classes:
+        name = str(enum_class["name"])
+        members = member_extractor(enum_class["node"])
+        transitions = transition_extractor(root, name, set(members))
+        scans.append((name, members, transitions))
+    return scans
+
+
+def _selected_scans(
+    scans: list[EnumScan[TransitionT]], class_name: str | None
+) -> list[EnumScan[TransitionT]]:
+    """Choose the requested Enum or every transition-bearing Enum."""
+    if class_name is not None:
+        return scans[:1]
+    transition_bearing = [scan for scan in scans if scan[2]]
+    return transition_bearing or scans
+
+
+def _dedupe_transitions(scans: list[EnumScan[TransitionT]]) -> list[TransitionT]:
+    """Deduplicate transitions across selected Enums in discovery order."""
+    transitions: list[TransitionT] = []
+    seen: set[tuple[str, str]] = set()
+    for _, _, scan_transitions in scans:
+        for transition in scan_transitions:
+            key = (transition.source, transition.target)
+            if key in seen:
+                continue
+            seen.add(key)
+            transitions.append(transition)
+    return transitions
+
+
+def collect_state_data(
+    root: Any,
+    enum_classes: list[dict[str, Any]],
+    class_name: str | None,
+    member_extractor: MemberExtractor,
+    transition_extractor: TransitionExtractor[TransitionT],
+) -> tuple[list[str], list[TransitionT]]:
+    """Return selected member names and deduplicated transitions."""
+    scans = _scan_enums(
+        root,
+        enum_classes,
+        member_extractor,
+        transition_extractor,
+    )
+    selected = _selected_scans(scans, class_name)
+    members = [member for _, names, _ in selected for member in names]
+    return members, _dedupe_transitions(selected)
+
+
+def finalize_states(members: list[str], max_nodes: int) -> tuple[list[str], bool]:
+    """Deduplicate, cap, and sort states with the historical ordering rules."""
+    unique_members = list(dict.fromkeys(members))
+    truncated = len(unique_members) > max_nodes
+    if truncated:
+        unique_members = unique_members[:max_nodes]
+    return sorted(unique_members), truncated

--- a/tree_sitter_analyzer/_uml_state_results.py
+++ b/tree_sitter_analyzer/_uml_state_results.py
@@ -67,9 +67,10 @@ def collect_state_data(
     transition_extractor: TransitionExtractor[TransitionT],
 ) -> tuple[list[str], list[TransitionT]]:
     """Return selected member names and deduplicated transitions."""
+    classes_to_scan = enum_classes[:1] if class_name is not None else enum_classes
     scans = _scan_enums(
         root,
-        enum_classes,
+        classes_to_scan,
         member_extractor,
         transition_extractor,
     )

--- a/tree_sitter_analyzer/_uml_state_transitions.py
+++ b/tree_sitter_analyzer/_uml_state_transitions.py
@@ -1,0 +1,151 @@
+"""Transition extraction for Enum-backed Python state machines."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from typing import Any, Generic, Protocol, TypeVar
+
+from ._uml_state_nodes import node_text, walk_nodes
+
+
+class TransitionLike(Protocol):
+    """Structural surface required from a state transition."""
+
+    source: str
+    target: str
+
+
+TransitionT = TypeVar("TransitionT", bound=TransitionLike)
+TransitionFactory = Callable[..., TransitionT]
+
+
+@dataclass
+class _TransitionScanner(Generic[TransitionT]):
+    """Scan one Enum class for match/case state transitions."""
+
+    class_name: str
+    known_members: set[str]
+    transition_factory: TransitionFactory[TransitionT]
+
+    def scan(self, root: Any) -> list[TransitionT]:
+        """Return unique, source-ordered transitions below ``root``."""
+        transitions: list[TransitionT] = []
+        seen: set[tuple[str, str]] = set()
+        for transition in self._candidate_transitions(root):
+            if transition in seen:
+                continue
+            seen.add(transition)
+            source, target = transition
+            transitions.append(self.transition_factory(source=source, target=target))
+        return transitions
+
+    def _candidate_transitions(self, root: Any) -> Iterator[tuple[str, str]]:
+        matches = (node for node in walk_nodes(root) if node.type == "match_statement")
+        for match_statement in matches:
+            candidates = (
+                self._transition_from_case(case_clause)
+                for case_clause in self._case_clauses(match_statement)
+            )
+            yield from (candidate for candidate in candidates if candidate is not None)
+
+    def _enum_ref(self, node: Any) -> str | None:
+        """Return a known member referenced as ``ClassName.member``."""
+        text = node_text(node, 80)
+        prefix = self.class_name + "."
+        if not text.startswith(prefix):
+            return None
+        member = text[len(prefix) :]
+        return member if member in self.known_members else None
+
+    def _first_enum_ref(self, nodes: list[Any]) -> str | None:
+        for node in nodes:
+            member = self._enum_ref(node)
+            if member is not None:
+                return member
+        return None
+
+    def _direct_target(self, node: Any) -> str | None:
+        """Return a transition target directly owned by one syntax node."""
+        children = list(node.children)
+        if node.type == "return_statement":
+            return self._first_enum_ref(children)
+        if node.type != "assignment":
+            return None
+        for child in reversed(children):
+            if child.type == "=" or node_text(child, 2) == "=":
+                continue
+            return self._enum_ref(child)
+        return None
+
+    def _target_below(self, node: Any) -> str | None:
+        """Find the first return or assignment target in source order."""
+        direct = self._direct_target(node)
+        if direct is not None:
+            return direct
+        for child in node.children:
+            target = self._target_below(child)
+            if target is not None:
+                return target
+        return None
+
+    def _case_source(self, case_clause: Any) -> str | None:
+        """Extract the Enum member named by a case pattern."""
+        for child in case_clause.children:
+            source = self._source_from_child(child)
+            if source is not None:
+                return source
+        return None
+
+    def _source_from_child(self, child: Any) -> str | None:
+        if child.type == "case_pattern":
+            source = self._first_enum_ref(list(child.children))
+            return source if source is not None else self._enum_ref(child)
+        if child.type in ("dotted_name", "attribute"):
+            return self._enum_ref(child)
+        return None
+
+    def _transition_from_case(self, case_clause: Any) -> tuple[str, str] | None:
+        source = self._case_source(case_clause)
+        blocks = (child for child in case_clause.children if child.type == "block")
+        target = next(
+            (
+                candidate
+                for candidate in (self._target_below(block) for block in blocks)
+                if candidate is not None
+            ),
+            None,
+        )
+        if source is None or target is None or source == target:
+            return None
+        return source, target
+
+    @staticmethod
+    def _case_clauses(match_statement: Any) -> list[Any]:
+        """Return direct or block-owned case clauses in grammar order."""
+        clauses: list[Any] = []
+        for child in match_statement.children:
+            clauses.extend(_TransitionScanner._clauses_from_child(child))
+        return clauses
+
+    @staticmethod
+    def _clauses_from_child(child: Any) -> list[Any]:
+        if child.type == "case_clause":
+            return [child]
+        if child.type == "block":
+            return [node for node in child.children if node.type == "case_clause"]
+        return []
+
+
+def extract_transitions(
+    root: Any,
+    class_name: str,
+    known_members: set[str],
+    transition_factory: TransitionFactory[TransitionT],
+) -> list[TransitionT]:
+    """Extract transitions for one Enum class from every match statement."""
+    return _TransitionScanner(
+        class_name=class_name,
+        known_members=known_members,
+        transition_factory=transition_factory,
+    ).scan(root)


### PR DESCRIPTION
## Value

Closes #1122 by removing the final state-scanner hotspot from the auto-sprint backlog without changing the public `tree_sitter_analyzer.uml_state` surface. The former implementation mixed AST discovery, recursive transition extraction, multi-Enum selection, and result shaping in one D-grade module.

## What changed

- Kept `StateResult`, `StateTransition`, parsing, and every historical helper name in the stable facade.
- Moved iterative AST/Enum discovery into `_uml_state_nodes.py`.
- Replaced the 138-line nested transition function with a typed `_TransitionScanner` stage.
- Moved multi-Enum selection, transition deduplication, state capping, and deterministic sorting into `_uml_state_results.py`.
- Bounded named-class extraction before transition scanning, preserving the historical first-match behavior without N full-tree traversals for duplicate names.
- Preserved the one-parse invariant and the `uml_state.py` monkeypatch seam.
- Added no duplicate test file; the existing exhaustive UML state suite covers the moved behavior.

## Review findings addressed

The Codex performance finding on `8acbe743` is fixed in `c5660134` with an exact call-count regression: a named duplicate Enum scans the root once.

## Health result

- Facade: A / 99.1 / 0 smells / 132 lines.
- Node discovery: A / 96.2 / 0 smells / 95 lines.
- Transition scanner: A / 96.2 / 0 smells / 151 lines.
- Result shaping: A / 98.5 / 0 smells / 87 lines.
- Previous hotspot: D / 65.4 / 4 smells / 380 lines.
- Every changed source module is below 500 lines.

## Verification

- Focused UML suites: 184 passed.
- Strict patch coverage: no added executable or branch misses.
- Full quick suite: 1,306 passed, 7 skipped.
- Ruff and format check: passed.
- Focused MyPy: passed.
- Bandit repository gate: 0 findings on the original implementation commit.
- Strict test-quality audit: no blocking findings.
- Weak-assertion ratchet and codemap sync: passed.
- `uv build`: sdist and wheel succeeded on the original implementation commit.
- `git diff --check`: passed.