### PR TITLE
refactor(cache): split symbol extraction into staged modules

### DIFF
--- a/tests/unit/test_ast_extraction.py
+++ b/tests/unit/test_ast_extraction.py
@@ -84,6 +84,39 @@ class TestWorkerIndexFile:
         assert "content_hash" in result
         assert "mtime_ns" in result
 
+    def test_uses_facade_symbol_extractor_hook(self, tmp_path, monkeypatch):
+        """Worker dispatch keeps the extraction module's live compatibility hook."""
+        import json
+
+        import tree_sitter_analyzer.cache.extraction as extraction
+
+        f = tmp_path / "module.py"
+        f.write_text("value = 1\n")
+        expected_symbols = {
+            "symbols": [
+                {
+                    "kind": "variable",
+                    "name": "facade_hook",
+                    "line": 1,
+                    "language": "python",
+                }
+            ],
+            "node_count": 1,
+            "truncated_depth": False,
+        }
+        monkeypatch.setattr(extraction, "_worker_parser", None)
+        monkeypatch.setattr(
+            extraction,
+            "_extract_symbols",
+            lambda _tree, _source, _language: expected_symbols,
+        )
+
+        result = extraction._worker_index_file((str(f), str(tmp_path), "python"))
+
+        assert result["status"] == "ok"
+        assert result["symbols_count"] == 1
+        assert json.loads(result["symbols_json"]) == expected_symbols
+
     def test_returns_ok_for_class_with_inheritance(self, tmp_path):
         """Python class with base class → extracted symbols include parent."""
         src = "class Dog(Animal):\n    def bark(self):\n        pass\n"

--- a/tree_sitter_analyzer/cache/_symbol_declarations.py
+++ b/tree_sitter_analyzer/cache/_symbol_declarations.py
@@ -1,0 +1,128 @@
+"""Language-specific constant and documentation extraction."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ._symbol_rules import (
+    _CONST_STYLE_NAME,
+    _PY_CONST_STYLE_NAME,
+    _PY_DUNDER_NAME,
+)
+from ._symbol_syntax import _node_text
+
+_DOCSTRING_MAX_CHARS = 500
+
+
+def _go_package_constants(node: Any, source: str) -> list[dict[str, Any]]:
+    """Return package-scope Go constants and conventionally constant vars."""
+    require_const_style = node.type == "var_declaration"
+    specs: list[Any] = []
+    for child in node.children:
+        if child.type in ("const_spec", "var_spec"):
+            specs.append(child)
+        elif child.type == "var_spec_list":
+            specs.extend(c for c in child.children if c.type == "var_spec")
+    symbols: list[dict[str, Any]] = []
+    for spec in specs:
+        symbols.extend(_go_spec_constants(spec, source, require_const_style))
+    return symbols
+
+
+def _go_spec_constants(
+    spec: Any, source: str, require_const_style: bool
+) -> list[dict[str, Any]]:
+    symbols: list[dict[str, Any]] = []
+    for ident in spec.children_by_field_name("name"):
+        symbol = _go_constant_symbol(ident, spec, source, require_const_style)
+        if symbol is not None:
+            symbols.append(symbol)
+    return symbols
+
+
+def _go_constant_symbol(
+    ident: Any, spec: Any, source: str, require_const_style: bool
+) -> dict[str, Any] | None:
+    if ident.type != "identifier":
+        return None
+    name = _node_text(ident, source)
+    if name == "_" or (require_const_style and not _CONST_STYLE_NAME.match(name)):
+        return None
+    return {
+        "kind": "constant",
+        "name": name,
+        "line": spec.start_point[0] + 1,
+        "end_line": spec.end_point[0] + 1,
+        "language": "go",
+    }
+
+
+def _php_constants(node: Any, source: str) -> list[dict[str, Any]]:
+    """Return one symbol per PHP ``const_element``."""
+    symbols: list[dict[str, Any]] = []
+    for child in node.children:
+        if child.type != "const_element":
+            continue
+        name_node = next((c for c in child.children if c.type == "name"), None)
+        if name_node is None:
+            continue
+        symbols.append(
+            {
+                "kind": "constant",
+                "name": _node_text(name_node, source),
+                "line": child.start_point[0] + 1,
+                "end_line": child.end_point[0] + 1,
+                "language": "php",
+            }
+        )
+    return symbols
+
+
+def _python_module_constant(node: Any, source: str) -> dict[str, Any] | None:
+    """Return a symbol for a qualifying module-scope Python assignment."""
+    left = node.child_by_field_name("left")
+    if left is None or left.type != "identifier":
+        return None
+    if node.child_by_field_name("right") is None:
+        return None
+    name = _node_text(left, source)
+    annotated = node.child_by_field_name("type") is not None
+    if not (
+        annotated or _PY_CONST_STYLE_NAME.match(name) or _PY_DUNDER_NAME.match(name)
+    ):
+        return None
+    return {
+        "kind": "constant",
+        "name": name,
+        "line": node.start_point[0] + 1,
+        "end_line": node.end_point[0] + 1,
+        "language": "python",
+    }
+
+
+def _python_docstring(node: Any, source: str) -> str | None:
+    """Return the PEP 257 docstring of a Python function or class."""
+    body = node.child_by_field_name("body")
+    if body is None or not body.named_children:
+        return None
+    first = body.named_children[0]
+    if first.type != "expression_statement" or not first.named_children:
+        return None
+    string_parts = _docstring_parts(first.named_children[0])
+    if string_parts is None:
+        return None
+    content = "".join(
+        _node_text(child, source)
+        for part in string_parts
+        for child in part.children
+        if child.type == "string_content"
+    ).strip()
+    return content[:_DOCSTRING_MAX_CHARS] if content else None
+
+
+def _docstring_parts(string_node: Any) -> list[Any] | None:
+    if string_node.type == "string":
+        return [string_node]
+    if string_node.type == "concatenated_string":
+        return [c for c in string_node.named_children if c.type == "string"]
+    return None

--- a/tree_sitter_analyzer/cache/_symbol_metrics.py
+++ b/tree_sitter_analyzer/cache/_symbol_metrics.py
@@ -1,0 +1,58 @@
+"""Structural metrics attached to cached symbols."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ._symbol_rules import _COMPLEXITY_NODE_TYPES
+
+
+def _count_nodes(node: Any) -> int:
+    """Count AST nodes iteratively to avoid recursion limits."""
+    count = 0
+    stack = [node]
+    while stack:
+        current = stack.pop()
+        count += 1
+        stack.extend(current.children)
+    return count
+
+
+def _count_decision_points(node: Any, language: str) -> dict[str, int]:
+    lang = "typescript" if language.lower() in ("tsx", "jsx") else language.lower()
+    types = _COMPLEXITY_NODE_TYPES.get(lang)
+    if not types:
+        return {}
+    counts: dict[str, int] = {}
+    stack = [node]
+    while stack:
+        current = stack.pop()
+        if current.type in types:
+            counts[current.type] = counts.get(current.type, 0) + 1
+        stack.extend(current.children)
+    return counts
+
+
+def _annotate_canonical_complexity(
+    symbols: list[dict[str, Any]], tree: Any, source_code: str, language: str
+) -> None:
+    """Add the plugin extractor's canonical complexity to cached symbols."""
+    try:
+        from ..plugins.manager import PluginManager
+
+        plugin = PluginManager().get_plugin(language)
+        if plugin is None:
+            return
+        elements = plugin.create_extractor().extract_functions(tree, source_code)
+    except Exception:
+        return
+
+    complexity_by_line = {
+        start: max(getattr(element, "complexity_score", 1) or 1, 1)
+        for element in elements
+        if (start := getattr(element, "start_line", None)) is not None
+    }
+    for symbol in symbols:
+        line = symbol.get("line")
+        if symbol.get("kind") in ("function", "method") and line in complexity_by_line:
+            symbol["complexity"] = complexity_by_line[line]

--- a/tree_sitter_analyzer/cache/_symbol_rules.py
+++ b/tree_sitter_analyzer/cache/_symbol_rules.py
@@ -1,0 +1,261 @@
+"""Declarative node-type rules for cache symbol extraction."""
+
+from __future__ import annotations
+
+import re
+
+_FUNCTION_LIKE = frozenset(
+    {
+        "function_definition",
+        "function_declaration",
+        "method_definition",
+        "arrow_function",
+        "generator_function_declaration",
+        "function_item",
+        "method_declaration",
+        "constructor_declaration",
+        "lambda_expression",
+        "anonymous_function",
+        "class_method",
+        "member_function",
+        "function_declarator",
+        "declaration",
+        "init_declarator",
+        "method",
+        "singleton_method",
+    }
+)
+
+_ENUM_LIKE = frozenset({"enum_declaration", "enum", "enum_specifier"})
+
+_CLASS_LIKE = frozenset(
+    {
+        "class_definition",
+        "class_declaration",
+        "class",
+        "interface_declaration",
+        "struct_item",
+        "trait_declaration",
+        "impl_item",
+        "struct_declaration",
+        "type_declaration",
+        "struct_specifier",
+        "class_specifier",
+        "type_spec",
+        "annotation_type_declaration",
+        "companion_object",
+        "module",
+        "trait_item",
+        "abstract_class_declaration",
+    }
+    | _ENUM_LIKE
+)
+
+_SCALA_CLASS_LIKE = frozenset(
+    {
+        "object_definition",
+        "trait_definition",
+        "enum_definition",
+        "given_definition",
+        "type_definition",
+    }
+)
+
+_IMPORT_LIKE = frozenset(
+    {
+        "import_statement",
+        "import_from_statement",
+        "import_declaration",
+        "require_statement",
+        "use_declaration",
+        "extern_crate_item",
+        "package_declaration",
+        "include_directive",
+    }
+)
+
+_VAR_DECL_LIKE = frozenset(
+    {
+        "variable_declarator",
+        "assignment_expression",
+        "lexical_declaration",
+        "variable_declaration",
+        "const_declaration",
+        "let_declaration",
+        "variable_assignment",
+    }
+)
+
+_CONST_STYLE_NAME = re.compile(r"^_?[A-Z][A-Z0-9_]+$")
+_PY_CONST_STYLE_NAME = re.compile(r"^_?[A-Z][A-Z0-9_]*$")
+_PY_DUNDER_NAME = re.compile(r"^__\w+__$")
+
+_PY_SCOPE_BODY_NODES = frozenset({"function_definition", "class_definition"})
+_GO_CONST_LIKE = frozenset({"const_declaration", "var_declaration"})
+_GO_SCOPE_BODY_NODES = frozenset(
+    {"function_declaration", "method_declaration", "func_literal"}
+)
+_RUST_CONST_LIKE = frozenset({"const_item", "static_item"})
+_RUST_SCOPE_BODY_NODES = frozenset({"function_item", "closure_expression", "block"})
+_PHP_SCOPE_BODY_NODES = frozenset(
+    {
+        "function_definition",
+        "method_declaration",
+        "anonymous_function",
+        "arrow_function",
+    }
+)
+_JSTS_SCOPE_BODY_NODES = frozenset(
+    {
+        "function_declaration",
+        "function_expression",
+        "function",
+        "arrow_function",
+        "method_definition",
+        "generator_function",
+        "generator_function_declaration",
+        "class_static_block",
+        "ERROR",
+    }
+)
+_JAVA_SCOPE_BODY_NODES = frozenset(
+    {
+        "method_declaration",
+        "constructor_declaration",
+        "compact_constructor_declaration",
+        "lambda_expression",
+        "static_initializer",
+        "block",
+        "ERROR",
+    }
+)
+_CSHARP_SCOPE_BODY_NODES = frozenset(
+    {
+        "method_declaration",
+        "constructor_declaration",
+        "destructor_declaration",
+        "operator_declaration",
+        "conversion_operator_declaration",
+        "local_function_statement",
+        "accessor_declaration",
+        "lambda_expression",
+        "anonymous_method_expression",
+        "ERROR",
+    }
+)
+_SCALA_SCOPE_BODY_NODES = frozenset({"function_definition", "function_declaration"})
+
+_SCOPE_BODY_NODES: dict[str, frozenset[str]] = {
+    "python": _PY_SCOPE_BODY_NODES,
+    "go": _GO_SCOPE_BODY_NODES,
+    "rust": _RUST_SCOPE_BODY_NODES,
+    "php": _PHP_SCOPE_BODY_NODES,
+    "javascript": _JSTS_SCOPE_BODY_NODES,
+    "typescript": _JSTS_SCOPE_BODY_NODES,
+    "java": _JAVA_SCOPE_BODY_NODES,
+    "csharp": _CSHARP_SCOPE_BODY_NODES,
+    "scala": _SCALA_SCOPE_BODY_NODES,
+}
+
+_COMPLEXITY_NODE_TYPES: dict[str, set[str]] = {
+    "python": {
+        "if_statement",
+        "elif_clause",
+        "for_statement",
+        "while_statement",
+        "except_clause",
+        "boolean_operator",
+        "conditional_expression",
+        "list_comprehension",
+        "set_comprehension",
+        "dict_comprehension",
+        "generator_expression",
+        "match_statement",
+        "case_clause",
+    },
+    "javascript": {
+        "if_statement",
+        "else_clause",
+        "for_statement",
+        "for_in_statement",
+        "for_of_statement",
+        "while_statement",
+        "do_statement",
+        "catch_clause",
+        "ternary_expression",
+        "switch_case",
+        "switch_default",
+        "logical_expression",
+        "conditional_expression",
+    },
+    "typescript": {
+        "if_statement",
+        "else_clause",
+        "for_statement",
+        "for_in_statement",
+        "for_of_statement",
+        "while_statement",
+        "do_statement",
+        "catch_clause",
+        "ternary_expression",
+        "switch_case",
+        "switch_default",
+        "logical_expression",
+        "conditional_expression",
+    },
+    "java": {
+        "if_statement",
+        "else_clause",
+        "for_statement",
+        "enhanced_for_statement",
+        "while_statement",
+        "do_statement",
+        "catch_clause",
+        "ternary_expression",
+        "switch_block_statement_group",
+        "logical_expression",
+        "conditional_expression",
+    },
+    "go": {
+        "if_statement",
+        "else_clause",
+        "for_statement",
+        "expression_switch_case",
+        "type_switch_case",
+        "select_case",
+        "binary_expression",
+    },
+    "rust": {
+        "if_expression",
+        "else_clause",
+        "for_expression",
+        "while_expression",
+        "loop_expression",
+        "match_arm",
+        "binary_expression",
+    },
+    "c": {
+        "if_statement",
+        "else_clause",
+        "for_statement",
+        "while_statement",
+        "do_statement",
+        "switch_case",
+        "binary_expression",
+        "conditional_expression",
+    },
+    "cpp": {
+        "if_statement",
+        "else_clause",
+        "for_statement",
+        "while_statement",
+        "do_statement",
+        "switch_case",
+        "binary_expression",
+        "conditional_expression",
+        "range_based_for_statement",
+        "catch_clause",
+    },
+}
+
+_WALK_MAX_DEPTH = 100

--- a/tree_sitter_analyzer/cache/_symbol_syntax.py
+++ b/tree_sitter_analyzer/cache/_symbol_syntax.py
@@ -1,0 +1,208 @@
+"""Tree-sitter syntax navigation helpers for symbol extraction."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ._symbol_rules import _CLASS_LIKE, _SCALA_CLASS_LIKE
+
+_C_DECLARATOR_WRAPPERS = (
+    "function_declarator",
+    "pointer_declarator",
+    "array_declarator",
+)
+
+
+def _node_text(node: Any, source: str) -> str:
+    """Extract node text while respecting tree-sitter's UTF-8 byte offsets."""
+    if node is None:
+        return ""
+    text_attr = getattr(node, "text", None)
+    if isinstance(text_attr, bytes):
+        return text_attr.decode("utf-8", errors="replace")
+    if isinstance(text_attr, str):
+        return text_attr
+    try:
+        return source.encode("utf-8")[node.start_byte : node.end_byte].decode(
+            "utf-8", errors="replace"
+        )
+    except (IndexError, TypeError, UnicodeDecodeError):
+        return ""
+
+
+def _find_parent_class(node: Any, source: str) -> str | None:
+    """Return the innermost enclosing class-like container name."""
+    parent = node.parent
+    while parent:
+        if parent.type == "impl_item":
+            type_node = parent.child_by_field_name("type")
+            if type_node is not None:
+                raw = _node_text(type_node, source)
+                return raw.split("<")[0].strip() or None
+        elif parent.type in _CLASS_LIKE:
+            name_node = parent.child_by_field_name("name")
+            if name_node:
+                return _node_text(name_node, source)
+        parent = parent.parent
+    return None
+
+
+def _extract_parent_classes(node: Any, source: str, language: str) -> list[str]:
+    """Extract direct base-class names from a class definition."""
+    try:
+        extractor = _PARENT_EXTRACTORS.get(language)
+        return extractor(node, source) if extractor is not None else []
+    except Exception:  # nosec B110 - tolerate incomplete parser nodes
+        return []
+
+
+def _python_parents(node: Any, source: str) -> list[str]:
+    return [
+        _node_text(arg, source)
+        for child in node.children
+        if child.type == "argument_list"
+        for arg in child.children
+        if arg.type in ("identifier", "attribute", "type")
+    ]
+
+
+def _javascript_parents(node: Any, source: str) -> list[str]:
+    return [
+        _node_text(parent, source)
+        for child in node.children
+        if child.type == "class_heritage"
+        for parent in child.children
+        if parent.type in ("identifier", "member_expression")
+    ]
+
+
+def _java_parents(node: Any, source: str) -> list[str]:
+    superclass = [
+        _node_text(parent, source)
+        for child in node.children
+        if child.type == "superclass"
+        for parent in child.children
+        if parent.type == "type_identifier"
+    ]
+    interfaces = [
+        _node_text(parent, source)
+        for child in node.children
+        if child.type == "super_interfaces"
+        for type_list in child.children
+        if type_list.type == "type_list"
+        for parent in type_list.children
+        if parent.type == "type_identifier"
+    ]
+    return superclass + interfaces
+
+
+def _cpp_parents(node: Any, source: str) -> list[str]:
+    return [
+        _node_text(parent, source)
+        for child in node.children
+        if child.type == "base_class_clause"
+        for parent in child.children
+        if parent.type in ("type_identifier", "qualified_identifier")
+    ]
+
+
+_PARENT_EXTRACTORS = {
+    "python": _python_parents,
+    "javascript": _javascript_parents,
+    "typescript": _javascript_parents,
+    "java": _java_parents,
+    "c": _cpp_parents,
+    "cpp": _cpp_parents,
+}
+
+
+def _c_function_def_name(node: Any, source: str) -> str | None:
+    """Recover a C function name from its declarator chain."""
+    return _c_declarator_name(node.child_by_field_name("declarator"), source, 0)
+
+
+def _c_declarator_name(declarator: Any, source: str, depth: int) -> str | None:
+    """Descend a bounded C declarator chain to its innermost identifier."""
+    if declarator is None or depth > 16:
+        return None
+    if declarator.type in ("identifier", "field_identifier", "type_identifier"):
+        return _node_text(declarator, source) or None
+    if declarator.type == "parenthesized_declarator":
+        return _parenthesized_c_declarator_name(declarator, source, depth)
+    if declarator.type in _C_DECLARATOR_WRAPPERS:
+        return _c_declarator_name(
+            declarator.child_by_field_name("declarator"), source, depth + 1
+        )
+    return None
+
+
+def _parenthesized_c_declarator_name(
+    declarator: Any, source: str, depth: int
+) -> str | None:
+    for child in declarator.children:
+        if child.type in _C_DECLARATOR_WRAPPERS or child.type.endswith("identifier"):
+            name = _c_declarator_name(child, source, depth + 1)
+            if name is not None:
+                return name
+    return None
+
+
+def _bash_subscript_base(subscript: Any) -> Any:
+    """Return the base variable node of a Bash subscript assignment."""
+    base = subscript.child_by_field_name("name")
+    if base is not None:
+        return base
+    return next(
+        (
+            child
+            for child in subscript.children
+            if child.type in ("variable_name", "word")
+        ),
+        None,
+    )
+
+
+def _scala_symbol_from_node(node: Any, source: str) -> dict[str, Any] | None:
+    if node.type not in _SCALA_CLASS_LIKE:
+        return None
+    name = _scala_symbol_name(node, source)
+    if not name:
+        return None
+    return {
+        "kind": "enum" if node.type == "enum_definition" else "class",
+        "name": name,
+        "line": node.start_point[0] + 1,
+        "end_line": node.end_point[0] + 1,
+        "language": "scala",
+    }
+
+
+def _scala_symbol_name(node: Any, source: str) -> str | None:
+    name_node = node.child_by_field_name("name")
+    if name_node is not None:
+        return _node_text(name_node, source)
+    for child in node.children:
+        if child.type in ("identifier", "type_identifier"):
+            return _node_text(child, source)
+    if node.type != "given_definition":
+        return None
+    type_name = _scala_given_type_text(node, source)
+    return (
+        f"given {type_name}"
+        if type_name
+        else f"anonymous_given_{node.start_point[0] + 1}"
+    )
+
+
+def _scala_given_type_text(node: Any, source: str) -> str | None:
+    type_nodes = {
+        "generic_type",
+        "type_identifier",
+        "stable_type_identifier",
+        "tuple_type",
+        "function_type",
+    }
+    for child in node.children:
+        if child.type in type_nodes:
+            return _node_text(child, source)
+    return None

--- a/tree_sitter_analyzer/cache/_symbol_walker.py
+++ b/tree_sitter_analyzer/cache/_symbol_walker.py
@@ -1,0 +1,273 @@
+"""Staged tree walker for cache symbol extraction."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ._symbol_declarations import (
+    _go_package_constants,
+    _php_constants,
+    _python_docstring,
+    _python_module_constant,
+)
+from ._symbol_metrics import (
+    _annotate_canonical_complexity,
+    _count_decision_points,
+    _count_nodes,
+)
+from ._symbol_rules import (
+    _CLASS_LIKE,
+    _ENUM_LIKE,
+    _FUNCTION_LIKE,
+    _GO_CONST_LIKE,
+    _IMPORT_LIKE,
+    _RUST_CONST_LIKE,
+    _SCALA_CLASS_LIKE,
+    _SCOPE_BODY_NODES,
+    _VAR_DECL_LIKE,
+    _WALK_MAX_DEPTH,
+)
+from ._symbol_syntax import (
+    _bash_subscript_base,
+    _c_function_def_name,
+    _extract_parent_classes,
+    _find_parent_class,
+    _node_text,
+    _scala_symbol_from_node,
+)
+
+
+@dataclass(slots=True)
+class _SymbolWalker:
+    source: str
+    symbols: list[dict[str, Any]]
+    language: str
+    truncated_flag: list[bool] | None
+
+    def walk(self, node: Any, depth: int = 0, enclosed: bool = False) -> None:
+        if depth > _WALK_MAX_DEPTH:
+            if self.truncated_flag is not None:
+                self.truncated_flag[0] = True
+            return
+        self._collect_node(node, depth, enclosed)
+        child_enclosed = enclosed or node.type in _SCOPE_BODY_NODES.get(
+            self.language, frozenset()
+        )
+        for child in node.children:
+            self.walk(child, depth + 1, child_enclosed)
+
+    def _collect_node(self, node: Any, depth: int, enclosed: bool) -> None:
+        name_node = node.child_by_field_name("name")
+        function_name = self._function_name(node, name_node)
+        if function_name is not None:
+            self._append_function(node, function_name)
+            return
+        if self._append_scala(node, enclosed):
+            return
+        if node.type in _CLASS_LIKE:
+            self._append_class(node, name_node)
+            return
+        if node.type in _IMPORT_LIKE:
+            self._append_import(node)
+            return
+        if self._is_variable(node, name_node, enclosed):
+            self._append_variable(node, name_node, depth)
+            return
+        self._append_constant(node, name_node, enclosed)
+
+    def _function_name(self, node: Any, name_node: Any) -> str | None:
+        if node.type not in _FUNCTION_LIKE:
+            return None
+        if name_node is not None:
+            return _node_text(name_node, self.source)
+        if node.type == "function_definition" and self.language == "c":
+            return _c_function_def_name(node, self.source)
+        return None
+
+    def _append_function(self, node: Any, name: str) -> None:
+        params_node = node.child_by_field_name("parameters")
+        symbol: dict[str, Any] = {
+            "kind": "function",
+            "name": name,
+            "line": node.start_point[0] + 1,
+            "end_line": node.end_point[0] + 1,
+            "params": _node_text(params_node, self.source) if params_node else "",
+            "language": self.language,
+        }
+        decision_points = _count_decision_points(node, self.language)
+        if decision_points:
+            symbol["decision_points"] = decision_points
+        return_type = node.child_by_field_name("return_type")
+        if return_type is not None:
+            symbol["return_type"] = _node_text(return_type, self.source).lstrip(": ")
+        self._add_python_docstring(symbol, node)
+        parent_class = _find_parent_class(node, self.source)
+        if parent_class:
+            symbol["kind"] = "method"
+            symbol["class"] = parent_class
+        self.symbols.append(symbol)
+
+    def _add_python_docstring(self, symbol: dict[str, Any], node: Any) -> None:
+        if self.language != "python":
+            return
+        docstring = _python_docstring(node, self.source)
+        if docstring is not None:
+            symbol["docstring"] = docstring
+
+    def _append_scala(self, node: Any, enclosed: bool) -> bool:
+        if self.language != "scala" or node.type not in _SCALA_CLASS_LIKE or enclosed:
+            return False
+        symbol = _scala_symbol_from_node(node, self.source)
+        if symbol is not None:
+            self.symbols.append(symbol)
+        return True
+
+    def _append_class(self, node: Any, name_node: Any) -> None:
+        effective_name = self._class_name_node(node, name_node)
+        if effective_name is None:
+            return
+        name = _node_text(effective_name, self.source)
+        if not name:
+            return
+        symbol: dict[str, Any] = {
+            "kind": "enum" if node.type in _ENUM_LIKE else "class",
+            "name": name,
+            "line": node.start_point[0] + 1,
+            "end_line": node.end_point[0] + 1,
+            "language": self.language,
+        }
+        parents = _extract_parent_classes(node, self.source, self.language)
+        if parents:
+            symbol["parents"] = parents
+        self._add_python_docstring(symbol, node)
+        self.symbols.append(symbol)
+
+    @staticmethod
+    def _class_name_node(node: Any, name_node: Any) -> Any:
+        if name_node is not None:
+            return name_node
+        for child in node.children:
+            if child.type in ("type_identifier", "constant", "identifier"):
+                return child
+        return None
+
+    def _append_import(self, node: Any) -> None:
+        self.symbols.append(
+            {
+                "kind": "import",
+                "text": _node_text(node, self.source),
+                "line": node.start_point[0] + 1,
+                "language": self.language,
+            }
+        )
+
+    def _is_variable(self, node: Any, name_node: Any, enclosed: bool) -> bool:
+        if node.type not in _VAR_DECL_LIKE or name_node is None:
+            return False
+        if self.language in ("javascript", "typescript", "java", "csharp"):
+            if enclosed:
+                return False
+        return not (
+            node.type == "variable_assignment"
+            and node.parent is not None
+            and node.parent.type == "command"
+        )
+
+    def _append_variable(self, node: Any, name_node: Any, depth: int) -> None:
+        if name_node.type == "subscript":
+            name_node = _bash_subscript_base(name_node)
+        name = _node_text(name_node, self.source) if name_node is not None else ""
+        if name and (not name.startswith("_") or depth < 3):
+            self.symbols.append(
+                {
+                    "kind": "variable",
+                    "name": name,
+                    "line": node.start_point[0] + 1,
+                    "language": self.language,
+                }
+            )
+
+    def _append_constant(self, node: Any, name_node: Any, enclosed: bool) -> None:
+        if node.type == "assignment" and self.language == "python" and not enclosed:
+            symbol = _python_module_constant(node, self.source)
+            if symbol is not None:
+                self.symbols.append(symbol)
+            return
+        if node.type in _GO_CONST_LIKE and self.language == "go" and not enclosed:
+            self.symbols.extend(_go_package_constants(node, self.source))
+            return
+        if self._is_rust_constant(node, name_node, enclosed):
+            self.symbols.append(
+                {
+                    "kind": "constant",
+                    "name": _node_text(name_node, self.source),
+                    "line": node.start_point[0] + 1,
+                    "end_line": node.end_point[0] + 1,
+                    "language": "rust",
+                }
+            )
+            return
+        if node.type == "const_declaration" and self.language == "php" and not enclosed:
+            self.symbols.extend(_php_constants(node, self.source))
+
+    def _is_rust_constant(self, node: Any, name_node: Any, enclosed: bool) -> bool:
+        return (
+            node.type in _RUST_CONST_LIKE
+            and self.language == "rust"
+            and not enclosed
+            and name_node is not None
+            and _node_text(name_node, self.source) != "_"
+        )
+
+
+def _walk_for_symbols(
+    node: Any,
+    source: str,
+    symbols: list[dict[str, Any]],
+    language: str,
+    depth: int = 0,
+    enclosed: bool = False,
+    _truncated_flag: list[bool] | None = None,
+) -> None:
+    """Walk an AST while preserving the historical helper signature."""
+    _SymbolWalker(source, symbols, language, _truncated_flag).walk(
+        node, depth, enclosed
+    )
+
+
+def _extract_symbols(tree: Any, source_code: str, language: str) -> dict[str, Any]:
+    symbols: list[dict[str, Any]] = []
+    if tree is None:
+        return {"symbols": symbols, "node_count": 0, "truncated_depth": False}
+    root = tree.root_node
+    truncated_flag = [False]
+    _SymbolWalker(source_code, symbols, language, truncated_flag).walk(root)
+    _annotate_canonical_complexity(symbols, tree, source_code, language)
+    return {
+        "symbols": symbols,
+        "node_count": _count_nodes(root),
+        "truncated_depth": truncated_flag[0],
+    }
+
+
+def _extract_imports(symbols: dict[str, Any]) -> list[str]:
+    return [
+        symbol["text"]
+        for symbol in symbols.get("symbols", [])
+        if symbol.get("kind") == "import"
+    ]
+
+
+def _extract_structure(symbols: dict[str, Any]) -> dict[str, Any]:
+    functions = [
+        {"name": symbol["name"], "line": symbol["line"]}
+        for symbol in symbols.get("symbols", [])
+        if symbol["kind"] in ("function", "method")
+    ]
+    classes = [
+        {"name": symbol["name"], "line": symbol["line"]}
+        for symbol in symbols.get("symbols", [])
+        if symbol["kind"] in ("class", "enum")
+    ]
+    return {"functions": functions, "classes": classes}

--- a/tree_sitter_analyzer/cache/extraction.py
+++ b/tree_sitter_analyzer/cache/extraction.py
@@ -1,10 +1,11 @@
-"""AST symbol-extraction helpers for ASTCache.
+"""Stable facade for AST cache extraction.
 
-These module-level functions are isolated here so that:
-  1. ast_cache.py stays under the 500-line limit
-  2. _worker_index_file is picklable by multiprocessing.Pool without
-     pulling in the entire ASTCache class and its imports
+Symbol rules, language helpers, and traversal live in focused modules. The
+worker remains here so multiprocessing pickles and runtime monkeypatches keep
+resolving the historical module-level entry points.
 """
+
+# ruff: noqa: F401
 
 from __future__ import annotations
 
@@ -17,13 +18,67 @@ from typing import Any
 
 from ..constants import EXCLUDE_DIRS
 from ..core.parser import Parser
+from ._symbol_declarations import (
+    _DOCSTRING_MAX_CHARS,
+    _go_package_constants,
+    _php_constants,
+    _python_docstring,
+    _python_module_constant,
+)
+from ._symbol_metrics import (
+    _annotate_canonical_complexity,
+    _count_decision_points,
+    _count_nodes,
+)
+from ._symbol_rules import (
+    _CLASS_LIKE,
+    _COMPLEXITY_NODE_TYPES,
+    _CONST_STYLE_NAME,
+    _CSHARP_SCOPE_BODY_NODES,
+    _ENUM_LIKE,
+    _FUNCTION_LIKE,
+    _GO_CONST_LIKE,
+    _GO_SCOPE_BODY_NODES,
+    _IMPORT_LIKE,
+    _JAVA_SCOPE_BODY_NODES,
+    _JSTS_SCOPE_BODY_NODES,
+    _PHP_SCOPE_BODY_NODES,
+    _PY_CONST_STYLE_NAME,
+    _PY_DUNDER_NAME,
+    _PY_SCOPE_BODY_NODES,
+    _RUST_CONST_LIKE,
+    _RUST_SCOPE_BODY_NODES,
+    _SCALA_CLASS_LIKE,
+    _SCALA_SCOPE_BODY_NODES,
+    _SCOPE_BODY_NODES,
+    _VAR_DECL_LIKE,
+    _WALK_MAX_DEPTH,
+)
+from ._symbol_syntax import (
+    _C_DECLARATOR_WRAPPERS,
+    _bash_subscript_base,
+    _c_declarator_name,
+    _c_function_def_name,
+    _extract_parent_classes,
+    _find_parent_class,
+    _node_text,
+    _scala_given_type_text,
+    _scala_symbol_from_node,
+    _scala_symbol_name,
+)
+from ._symbol_walker import (
+    _extract_imports,
+    _extract_structure,
+    _extract_symbols,
+    _walk_for_symbols,
+)
 
-# ---------------------------------------------------------------------------
-# FTS5 probe
-# ---------------------------------------------------------------------------
+_EXCLUDE_DIRS = EXCLUDE_DIRS
+_worker_parser: Parser | None = None
 
 
 def _has_fts5(conn: sqlite3.Connection) -> bool:
+    """Return whether the SQLite connection supports FTS5."""
     try:
         conn.execute(
             "SELECT fts5 FROM pragma_compile_options WHERE fts5 = 'ENABLE_FTS5'"
@@ -38,43 +93,21 @@ def _has_fts5(conn: sqlite3.Connection) -> bool:
             return False
 
 
-# ---------------------------------------------------------------------------
-# File-walk constants
-# ---------------------------------------------------------------------------
-
-# Shared exclude set (incl. C#/Java/Rust/Go build-artifact dirs) — see
-# constants.EXCLUDE_DIRS. Indexing must skip bin/obj/packages/target/etc or
-# `index full` hangs on compiled-language projects.
-_EXCLUDE_DIRS = EXCLUDE_DIRS
-
-
-# ---------------------------------------------------------------------------
-# Multiprocessing worker — must stay at module level so it is picklable
-# ---------------------------------------------------------------------------
-
-_worker_parser: Parser | None = None
-
-
 def _init_worker_parser() -> None:
+    """Initialize the process-local parser used by index workers."""
     global _worker_parser
     _worker_parser = Parser()
 
 
 def _worker_index_file(args: tuple[str, str, str]) -> dict[str, Any]:
-    """Worker used by ``ASTCache._index_parallel`` via a process pool.
-
-    Must be module-level so pickle can resolve it across spawn.
-    Returns a dict with status/symbols/imports/structure/call_edges.
-    Tree-sitter ``Tree`` objects are NEVER returned — they are C objects
-    that cannot be pickled; the worker discards them after extraction.
-    """
+    """Parse and serialize one file without returning unpicklable tree objects."""
     global _worker_parser
     abs_path, project_root, language = args
     rel_path = os.path.relpath(abs_path, project_root).replace("\\", "/")
     try:
         stat = os.stat(abs_path)
-        with open(abs_path, encoding="utf-8", errors="replace") as f:
-            source_code = f.read()
+        with open(abs_path, encoding="utf-8", errors="replace") as source_file:
+            source_code = source_file.read()
     except OSError as exc:
         return {
             "status": "io_error",
@@ -96,6 +129,31 @@ def _worker_index_file(args: tuple[str, str, str]) -> dict[str, Any]:
     imports = _extract_imports(symbols)
     structure = _extract_structure(symbols)
     call_edges = _extract_call_edges(result.tree, source_code, language, symbols)
+    return _worker_payload(
+        rel_path,
+        abs_path,
+        language,
+        stat,
+        source_code,
+        symbols,
+        imports,
+        structure,
+        call_edges,
+    )
+
+
+def _worker_payload(
+    rel_path: str,
+    abs_path: str,
+    language: str,
+    stat: os.stat_result,
+    source_code: str,
+    symbols: dict[str, Any],
+    imports: list[str],
+    structure: dict[str, Any],
+    call_edges: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Serialize one successful extraction into a process-safe payload."""
     return {
         "status": "ok",
         "rel_path": rel_path,
@@ -111,1094 +169,21 @@ def _worker_index_file(args: tuple[str, str, str]) -> dict[str, Any]:
         "call_edges_json": json.dumps(call_edges, ensure_ascii=False),
         "symbol_rows": [
             (
-                sym.get("name", sym.get("text", "")),
-                sym.get("kind", "unknown"),
-                sym.get("line", 0),
-                sym.get("end_line", 0),
+                symbol.get("name", symbol.get("text", "")),
+                symbol.get("kind", "unknown"),
+                symbol.get("line", 0),
+                symbol.get("end_line", 0),
             )
-            for sym in symbols.get("symbols", [])
+            for symbol in symbols.get("symbols", [])
         ],
     }
 
 
-# ---------------------------------------------------------------------------
-# Content hashing
-# ---------------------------------------------------------------------------
-
-
 def _content_hash(source: str | bytes) -> str:
+    """Return the stable SHA-256 hash used by cache invalidation."""
     if isinstance(source, str):
         source = source.encode("utf-8", errors="replace")
     return hashlib.sha256(source).hexdigest()
-
-
-# ---------------------------------------------------------------------------
-# Symbol extraction — tree-walker + node-type sets
-# ---------------------------------------------------------------------------
-
-_FUNCTION_LIKE = frozenset(
-    {
-        "function_definition",
-        "function_declaration",
-        "method_definition",
-        "arrow_function",
-        "generator_function_declaration",
-        "function_item",
-        "method_declaration",
-        "constructor_declaration",
-        "lambda_expression",
-        "anonymous_function",
-        "class_method",
-        "member_function",
-        "function_declarator",
-        "declaration",
-        "init_declarator",
-        # Issue #532: Ruby uses ``method`` / ``singleton_method`` node types;
-        # without these, Ruby methods were invisible in symbols_json so the
-        # class_inspect_tool showed 0 methods for every Ruby class.
-        "method",
-        "singleton_method",
-    }
-)
-
-_ENUM_LIKE = frozenset(
-    {
-        "enum_declaration",
-        "enum",
-        "enum_specifier",  # C/C++
-    }
-)
-
-_CLASS_LIKE = frozenset(
-    {
-        "class_definition",
-        "class_declaration",
-        "class",
-        "interface_declaration",
-        "struct_item",
-        "trait_declaration",
-        "impl_item",
-        "struct_declaration",
-        "type_declaration",
-        "struct_specifier",  # C/C++
-        "class_specifier",  # C++
-        "type_spec",  # Go
-        "annotation_type_declaration",  # Java
-        "companion_object",  # Kotlin
-        "module",  # Ruby
-        "trait_item",  # Rust
-        "abstract_class_declaration",  # TypeScript/TSX
-    }
-    | _ENUM_LIKE
-)
-
-_SCALA_CLASS_LIKE = frozenset(
-    {
-        "object_definition",
-        "trait_definition",
-        "enum_definition",
-        "given_definition",
-        "type_definition",
-    }
-)
-
-_IMPORT_LIKE = frozenset(
-    {
-        "import_statement",
-        "import_from_statement",
-        "import_declaration",
-        "require_statement",
-        "use_declaration",
-        "extern_crate_item",
-        "package_declaration",
-        "include_directive",
-    }
-)
-
-_VAR_DECL_LIKE = frozenset(
-    {
-        "variable_declarator",
-        "assignment_expression",
-        "lexical_declaration",
-        "variable_declaration",
-        "const_declaration",
-        "let_declaration",
-        "variable_assignment",
-    }
-)
-
-# Issue #610 — Python module-level constants. tree-sitter-python emits
-# ``assignment`` nodes (with a ``left`` field, not ``name``), so they never
-# matched _VAR_DECL_LIKE and were invisible to ast_symbol_rows. Scope rule
-# (approved on #610): module-scope simple assignments whose target is
-# const-style, annotated (``x: T = ...``), or a dunder (``^__\w+__$``) —
-# emitted as kind="constant".
-# Const-style name pattern used by the Go (#613) rule: requires ≥2 chars
-# (``+``) to avoid capturing single-letter package-level vars like ``var F``.
-_CONST_STYLE_NAME = re.compile(r"^_?[A-Z][A-Z0-9_]+$")
-# Issue #793 — Python-only pattern: single-letter ALL_CAPS names (N, A, X …)
-# are valid Python constants (e.g. ``N = 100``) and must be captured.
-# Uses ``*`` (zero-or-more) so a single uppercase letter matches.
-_PY_CONST_STYLE_NAME = re.compile(r"^_?[A-Z][A-Z0-9_]*$")
-_PY_DUNDER_NAME = re.compile(r"^__\w+__$")
-
-# Node types that open a non-module scope: an ``assignment`` nested under any
-# of these is a class attribute or function local, not a module constant.
-_PY_SCOPE_BODY_NODES = frozenset({"function_definition", "class_definition"})
-
-# Issue #613 — Go package-level constants, same shape as #610. tree-sitter-go
-# puts names on ``const_spec``/``var_spec`` children (repeated ``name`` field);
-# the const_declaration/var_declaration wrappers carry no ``name`` field, so
-# they never produced rows via _VAR_DECL_LIKE.
-_GO_CONST_LIKE = frozenset({"const_declaration", "var_declaration"})
-
-# Nodes that open a function scope in Go: const/var declarations nested under
-# any of these are locals, not package constants (Go analogue of
-# _PY_SCOPE_BODY_NODES, feeding the same top-down ``enclosed`` flag).
-_GO_SCOPE_BODY_NODES = frozenset(
-    {"function_declaration", "method_declaration", "func_literal"}
-)
-
-
-def _go_package_constants(node: Any, source: str) -> list[dict[str, Any]]:
-    """Return kind="constant" symbols for a package-scope Go const/var
-    declaration, or [] when nothing matches the #613 scope rule.
-
-    The caller guarantees package scope (no enclosing function body).
-    Asymmetry (deliberate): every ``const`` spec name is captured — Go consts
-    are constants by definition, the compiler enforces immutability, so no
-    name-pattern gate is needed. A package-level ``var`` is mutable state, so
-    var_spec names count only when const-style (the #612 pattern) — the
-    author signalling a constant by convention (e.g. MAX_RETRIES). The blank
-    identifier ``_`` is skipped — it is not a referenceable name.
-    """
-    require_const_style = node.type == "var_declaration"
-    specs: list[Any] = []
-    for child in node.children:
-        if child.type in ("const_spec", "var_spec"):
-            specs.append(child)
-        elif child.type == "var_spec_list":
-            specs.extend(c for c in child.children if c.type == "var_spec")
-    out: list[dict[str, Any]] = []
-    for spec in specs:
-        for ident in spec.children_by_field_name("name"):
-            if ident.type != "identifier":
-                continue  # separator tokens can appear in the field list
-            name = _node_text(ident, source)
-            if name == "_":
-                continue
-            if require_const_style and not _CONST_STYLE_NAME.match(name):
-                continue
-            out.append(
-                {
-                    "kind": "constant",
-                    "name": name,
-                    "line": spec.start_point[0] + 1,
-                    "end_line": spec.end_point[0] + 1,
-                    "language": "go",
-                }
-            )
-    return out
-
-
-# Issue #613 — Rust const/static items, same shape as #610/#615. tree-sitter-
-# rust emits ``const_item``/``static_item`` (with a ``name`` field), but
-# neither type is in _VAR_DECL_LIKE (which carries Go's ``const_declaration``,
-# not Rust's node names), so they never produced rows. ALL names are captured
-# — Rust const/static are language-level constants/globals (rustc lints
-# non_upper_case_globals), so no const-style name gate is needed; this mirrors
-# the Go const reasoning. ``static mut`` counts too: still a named crate-level
-# global. Associated consts in impl/trait bodies ARE captured (deliberate):
-# they are compiler-enforced constants addressable as ``Type::CONST``, unlike
-# the Python class attributes #612 excludes — and impl/trait bodies are
-# ``declaration_list`` nodes, not function scopes, so the ``enclosed``
-# mechanism keeps them naturally.
-_RUST_CONST_LIKE = frozenset({"const_item", "static_item"})
-
-# Nodes that open a function scope in Rust: const/static items nested under
-# any of these are function-locals, not module constants (Rust analogue of
-# _PY_SCOPE_BODY_NODES / _GO_SCOPE_BODY_NODES, feeding the same top-down
-# ``enclosed`` flag). mod/impl/trait bodies are ``declaration_list`` — module
-# scope — and deliberately absent.
-_RUST_SCOPE_BODY_NODES = frozenset({"function_item", "closure_expression", "block"})
-
-# Issue #624 — PHP const declarations, same shape as #610/#615/#618.
-# tree-sitter-php emits ``const_declaration`` (the node type already sits in
-# _VAR_DECL_LIKE via Go's grammar) but the names live on ``const_element``
-# children which carry NO ``name`` field — the identifier is a bare ``name``
-# child — so the _VAR_DECL_LIKE name gate never matched and no rows were
-# produced. ALL names are captured — PHP ``const`` is compiler-enforced
-# immutable, so no const-style name gate (mirrors the Go/Rust reasoning).
-# Class/interface/trait/enum consts ARE captured (deliberate): addressable as
-# ``Config::MAX_USERS`` like Rust associated consts; their bodies are
-# declaration_list / enum_declaration_list nodes, not function scopes, so the
-# ``enclosed`` mechanism keeps them naturally. ``define()`` calls are
-# function_call_expression nodes — runtime registration whose name is a
-# string argument, not a declaration — and stay out of scope.
-
-# Nodes that open a function scope in PHP (PHP analogue of the other
-# _*_SCOPE_BODY_NODES sets, feeding the same top-down ``enclosed`` flag).
-# PHP has no legal function-scope const, but tree-sitter-php parses one
-# permissively as const_declaration, so the gate is still required. Braced
-# namespace bodies are ``compound_statement`` nodes — the gate keys on the
-# function/closure declaration node types (not compound_statement) precisely
-# so namespace-scope consts stay captured.
-_PHP_SCOPE_BODY_NODES = frozenset(
-    {
-        "function_definition",
-        "method_declaration",
-        "anonymous_function",
-        "arrow_function",
-    }
-)
-
-# Issue #626 — JS/TS function-local variables were OVER-captured: every
-# ``variable_declarator`` with a ``name`` field became a kind="variable" row
-# regardless of scope, so function locals (``const id = req.params.id``)
-# polluted FTS and symbol search (−57% JS / −54% TS variable rows on the
-# in-repo corpus). Inverse of the constants family (#612/#615/#618/#625):
-# the same language-gated top-down ``enclosed`` flag, used here to SKIP rows
-# instead of adding them. Module/top-level declarators stay captured —
-# const+let+var, NO const-style name gate (this is a contraction of the
-# pre-existing kind="variable" contract, not a constants feature).
-#
-# ``statement_block`` is deliberately ABSENT: module-level ``if``/``try``
-# bodies are statement_blocks outside any function node — including it would
-# break the #612 guarantee that if/try-wrapped module declarators stay
-# captured. TS namespace bodies (``internal_module`` / ``module`` /
-# ``ambient_declaration``) are not function scopes either, so namespace-level
-# declarators stay captured naturally (PHP #624 namespace precedent).
-# ``function`` is the anonymous-function-expression node of older grammar
-# versions; in current grammars it only matches the bare ``function`` keyword
-# token, which is harmless (keyword tokens have no children).
-_JSTS_SCOPE_BODY_NODES = frozenset(
-    {
-        "function_declaration",
-        "function_expression",
-        "function",
-        "arrow_function",
-        "method_definition",
-        "generator_function",
-        "generator_function_declaration",
-        "class_static_block",
-        # Declarations inside error-recovered regions have undecidable scope
-        # (.tsx is parsed with the typescript grammar, so JSX can shatter
-        # function bodies into ERROR nodes) — better unindexed than wrong
-        # (Codex P2 on #629; defensive hardening, 4 JSX shapes probed clean).
-        "ERROR",
-    }
-)
-
-# Issue #626 (Java half) — same over-capture disease: every Java
-# ``variable_declarator`` became a kind="variable" row, so method/ctor/
-# lambda/initializer locals polluted FTS and symbol search (−69% Java
-# variable rows on the in-repo corpus). Class fields and interface constants
-# stay captured: they route ``class_body > field_declaration`` /
-# ``interface_body > constant_declaration`` and NEVER through any node in
-# this set — ``block`` is safe for Java because fields never sit inside a
-# block node (live-parse verified), while the instance initializer is a bare
-# ``block`` child of ``class_body``, which is exactly why ``block`` is here.
-# ``constructor_declaration`` gates ctor locals (their body is a
-# ``constructor_body``, not a ``block``); ``compact_constructor_declaration``
-# covers record compact ctors; ``lambda_expression`` covers lambdas hanging
-# off FIELD initializers (lambdas in methods are already inside the method).
-# ``ERROR`` per the #629 hardening precedent: declarations inside
-# error-recovered regions have undecidable scope — better unindexed than a
-# lambda local masquerading as a field.
-_JAVA_SCOPE_BODY_NODES = frozenset(
-    {
-        "method_declaration",
-        "constructor_declaration",
-        "compact_constructor_declaration",
-        "lambda_expression",
-        "static_initializer",
-        "block",
-        "ERROR",
-    }
-)
-
-# Issue #628 (C#) — same over-capture disease as #626: every C#
-# ``variable_declarator`` became a kind="variable" row, so method/ctor/
-# dtor/local-fn/lambda/accessor/operator locals polluted FTS and symbol
-# search. Class/interface/record fields (const, static readonly, plain)
-# stay captured: they route ``declaration_list > field_declaration`` and
-# NEVER through any node in this set (live-parse verified).
-#
-# Unlike Java, ``block`` is deliberately ABSENT: C# top-level statements
-# (C# 9 top-level programs) put blocks at compilation-unit level
-# (``block < if_statement < global_statement``), so a block-keyed set
-# would drop if/try-wrapped top-level declarators and break the #612
-# module-scope guarantee. Function-keying is complete anyway: every
-# local's ancestry passes through one of these declaration nodes.
-# ``accessor_declaration`` gates property/indexer/event get/set/init/
-# add/remove bodies (their bodies are plain ``block``s);
-# ``local_function_statement`` is itself redundant under a method but
-# kept for explicitness (and gates top-level local functions);
-# ``lambda_expression`` / ``anonymous_method_expression`` cover lambdas
-# and ``delegate`` bodies hanging off FIELD initializers (lambdas in
-# methods are already inside the method). ``ERROR`` per the #629
-# hardening precedent: declarations inside error-recovered regions have
-# undecidable scope — better unindexed than a local masquerading as a
-# field.
-_CSHARP_SCOPE_BODY_NODES = frozenset(
-    {
-        "method_declaration",
-        "constructor_declaration",
-        "destructor_declaration",
-        "operator_declaration",
-        "conversion_operator_declaration",
-        "local_function_statement",
-        "accessor_declaration",
-        "lambda_expression",
-        "anonymous_method_expression",
-        "ERROR",
-    }
-)
-
-# #961: Scala method bodies must mark their descendants as enclosed so a
-# method-local ``given``/``type`` is NOT emitted as a top-level class-like
-# symbol (mirrors the scala_plugin path, which ``continue``s instead of
-# descending into ``function_definition``/``function_declaration``). The
-# scope node itself is enough — gating on it makes the body container
-# (``block`` / ``indented_block``) and everything below it enclosed.
-_SCALA_SCOPE_BODY_NODES = frozenset(
-    {
-        "function_definition",
-        "function_declaration",
-    }
-)
-
-
-def _php_constants(node: Any, source: str) -> list[dict[str, Any]]:
-    """Return kind="constant" symbols for a PHP const_declaration, one row
-    per ``const_element`` (``const A = 1, B = 2;`` yields two rows).
-
-    The caller guarantees the declaration is not enclosed in a function
-    body (#624 scope rule).
-    """
-    out: list[dict[str, Any]] = []
-    for child in node.children:
-        if child.type != "const_element":
-            continue
-        name_node = next((c for c in child.children if c.type == "name"), None)
-        if name_node is None:
-            continue
-        out.append(
-            {
-                "kind": "constant",
-                "name": _node_text(name_node, source),
-                "line": child.start_point[0] + 1,
-                "end_line": child.end_point[0] + 1,
-                "language": "php",
-            }
-        )
-    return out
-
-
-def _python_module_constant(node: Any, source: str) -> dict[str, Any] | None:
-    """Return a kind="constant" symbol for a module-scope Python assignment,
-    or None when the node does not match the #610 scope rule.
-
-    The caller guarantees module scope (no enclosing function/class body);
-    this helper checks target shape and naming/annotation rules only.
-    """
-    left = node.child_by_field_name("left")
-    if left is None or left.type != "identifier":
-        return None  # tuple/attribute/subscript targets are out of scope
-    if node.child_by_field_name("right") is None:
-        return None  # bare annotation (``x: int``) — not a definition site
-    name = _node_text(left, source)
-    annotated = node.child_by_field_name("type") is not None
-    if not (
-        annotated or _PY_CONST_STYLE_NAME.match(name) or _PY_DUNDER_NAME.match(name)
-    ):
-        return None
-    return {
-        "kind": "constant",
-        "name": name,
-        "line": node.start_point[0] + 1,
-        "end_line": node.end_point[0] + 1,
-        "language": "python",
-    }
-
-
-# Issue #614 — RFC-0016 prerequisite. symbols_json must carry enough text to
-# build the embedding/BM25 input "{kind} {name}({params}) -> {return_type}\n
-# {docstring}". Docstrings are much larger than names, so serialized values
-# are capped at 500 chars (stated cap; index-size impact measured on #614).
-_DOCSTRING_MAX_CHARS = 500
-
-
-def _python_docstring(node: Any, source: str) -> str | None:
-    """Return the PEP 257 docstring of a Python function/class node, or None.
-
-    The first statement of the ``body`` block must be an expression statement
-    whose sole expression is a string literal. Quote delimiters are excluded
-    by reading the ``string_content`` children. Python-only this PR — other
-    languages keep docs in comments, which need per-language helpers (#614
-    follow-up). Result is stripped and capped at ``_DOCSTRING_MAX_CHARS``;
-    whitespace-only docstrings yield None so absent stays absent.
-    """
-    body = node.child_by_field_name("body")
-    if body is None or not body.named_children:
-        return None
-    first = body.named_children[0]
-    if first.type != "expression_statement" or not first.named_children:
-        return None
-    string_node = first.named_children[0]
-    if string_node.type == "string":
-        string_parts = [string_node]
-    elif string_node.type == "concatenated_string":
-        # Adjacent literals ('a' 'b') fold into __doc__ — a legal PEP 257
-        # docstring; tree-sitter wraps them in concatenated_string
-        # (Codex P2 on #621).
-        string_parts = [c for c in string_node.named_children if c.type == "string"]
-    else:
-        return None
-    content = "".join(
-        _node_text(child, source)
-        for part in string_parts
-        for child in part.children
-        if child.type == "string_content"
-    ).strip()
-    if not content:
-        return None
-    return content[:_DOCSTRING_MAX_CHARS]
-
-
-_COMPLEXITY_NODE_TYPES: dict[str, set[str]] = {
-    "python": {
-        "if_statement",
-        "elif_clause",
-        "for_statement",
-        "while_statement",
-        "except_clause",
-        "boolean_operator",
-        "conditional_expression",
-        "list_comprehension",
-        "set_comprehension",
-        "dict_comprehension",
-        "generator_expression",
-        "match_statement",
-        "case_clause",
-    },
-    "javascript": {
-        "if_statement",
-        "else_clause",
-        "for_statement",
-        "for_in_statement",
-        "for_of_statement",
-        "while_statement",
-        "do_statement",
-        "catch_clause",
-        "ternary_expression",
-        "switch_case",
-        "switch_default",
-        "logical_expression",
-        "conditional_expression",
-    },
-    "typescript": {
-        "if_statement",
-        "else_clause",
-        "for_statement",
-        "for_in_statement",
-        "for_of_statement",
-        "while_statement",
-        "do_statement",
-        "catch_clause",
-        "ternary_expression",
-        "switch_case",
-        "switch_default",
-        "logical_expression",
-        "conditional_expression",
-    },
-    "java": {
-        "if_statement",
-        "else_clause",
-        "for_statement",
-        "enhanced_for_statement",
-        "while_statement",
-        "do_statement",
-        "catch_clause",
-        "ternary_expression",
-        "switch_block_statement_group",
-        "logical_expression",
-        "conditional_expression",
-    },
-    "go": {
-        "if_statement",
-        "else_clause",
-        "for_statement",
-        "expression_switch_case",
-        "type_switch_case",
-        "select_case",
-        "binary_expression",
-    },
-    "rust": {
-        "if_expression",
-        "else_clause",
-        "for_expression",
-        "while_expression",
-        "loop_expression",
-        "match_arm",
-        "binary_expression",
-    },
-    "c": {
-        "if_statement",
-        "else_clause",
-        "for_statement",
-        "while_statement",
-        "do_statement",
-        "switch_case",
-        "binary_expression",
-        "conditional_expression",
-    },
-    "cpp": {
-        "if_statement",
-        "else_clause",
-        "for_statement",
-        "while_statement",
-        "do_statement",
-        "switch_case",
-        "binary_expression",
-        "conditional_expression",
-        "range_based_for_statement",
-        "catch_clause",
-    },
-}
-
-
-def _node_text(node: Any, source: str) -> str:
-    """Extract the source text of a tree-sitter node.
-
-    🚨 BUG history: tree-sitter exposes ``start_byte`` / ``end_byte`` as
-    UTF-8 BYTE offsets. The old implementation sliced ``source`` (a
-    ``str``) using those byte values, which is correct for pure-ASCII
-    files but silently shifts by N chars after each multi-byte glyph.
-
-    Fix: prefer ``node.text`` (returned as ``bytes`` by tree-sitter, the
-    canonical source-of-truth). Fall back to slicing the encoded source
-    so legacy callers still work when ``node.text`` is unavailable.
-    """
-    if node is None:
-        return ""
-    text_attr = getattr(node, "text", None)
-    if isinstance(text_attr, bytes):
-        try:
-            return text_attr.decode("utf-8", errors="replace")
-        except UnicodeDecodeError:
-            return ""
-    if isinstance(text_attr, str):
-        return text_attr
-    try:
-        return source.encode("utf-8")[node.start_byte : node.end_byte].decode(
-            "utf-8", errors="replace"
-        )
-    except (IndexError, TypeError, UnicodeDecodeError):
-        return ""
-
-
-def _count_nodes(node: Any) -> int:
-    """Count AST nodes iteratively to avoid RecursionError on deeply-nested trees."""
-    count = 0
-    stack = [node]
-    while stack:
-        current = stack.pop()
-        count += 1
-        for child in current.children:
-            stack.append(child)
-    return count
-
-
-def _count_decision_points(node: Any, language: str) -> dict[str, int]:
-    lang = language.lower()
-    if lang in ("tsx", "jsx"):
-        lang = "typescript"
-    types = _COMPLEXITY_NODE_TYPES.get(lang)
-    if not types:
-        return {}
-    counts: dict[str, int] = {}
-    stack = [node]
-    while stack:
-        current = stack.pop()
-        if current.type in types:
-            counts[current.type] = counts.get(current.type, 0) + 1
-        for child in current.children:
-            stack.append(child)
-    return counts
-
-
-def _find_parent_class(node: Any, source: str) -> str | None:
-    """Walk up the parent chain to find the innermost enclosing class-like
-    container, returning its name.
-
-    Special cases:
-    - ``impl_item`` (Rust): exposes the implemented type in the ``type``
-      field (e.g. ``Container<T>`` or ``User``), NOT a ``name`` field.
-      Strip any generic parameters so ``Container<T>`` → ``"Container"``.
-    """
-    parent = node.parent
-    while parent:
-        if parent.type in _CLASS_LIKE:
-            if parent.type == "impl_item":
-                # Rust impl block: the implemented type is in the ``type`` field.
-                type_node = parent.child_by_field_name("type")
-                if type_node is not None:
-                    raw = _node_text(type_node, source)
-                    # Strip generic parameters: "Container<T>" → "Container"
-                    return raw.split("<")[0].strip() or None
-            else:
-                name_node = parent.child_by_field_name("name")
-                if name_node:
-                    return _node_text(name_node, source)
-        parent = parent.parent
-    return None
-
-
-def _extract_parent_classes(node: Any, source: str, language: str) -> list[str]:
-    """Extract base class names from a class definition node."""
-    parents: list[str] = []
-    try:
-        if language == "python":
-            parents.extend(
-                _node_text(arg, source)
-                for child in node.children
-                if child.type == "argument_list"
-                for arg in child.children
-                if arg.type in ("identifier", "attribute", "type")
-            )
-        elif language in ("javascript", "typescript"):
-            parents.extend(
-                _node_text(hc, source)
-                for child in node.children
-                if child.type == "class_heritage"
-                for hc in child.children
-                if hc.type in ("identifier", "member_expression")
-            )
-        elif language == "java":
-            parents.extend(
-                _node_text(sc, source)
-                for child in node.children
-                if child.type == "superclass"
-                for sc in child.children
-                if sc.type == "type_identifier"
-            )
-            parents.extend(
-                _node_text(tc, source)
-                for child in node.children
-                if child.type == "super_interfaces"
-                for si in child.children
-                if si.type == "type_list"
-                for tc in si.children
-                if tc.type == "type_identifier"
-            )
-        elif language in ("c", "cpp"):
-            parents.extend(
-                _node_text(bc, source)
-                for child in node.children
-                if child.type == "base_class_clause"
-                for bc in child.children
-                if bc.type in ("type_identifier", "qualified_identifier")
-            )
-    except Exception:  # nosec B110
-        pass
-    return parents
-
-
-def _c_function_def_name(node: Any, source: str) -> str | None:
-    """Recover the name of a C ``function_definition`` node.
-
-    A tree-sitter C ``function_definition`` does NOT expose a ``name`` field —
-    the identifier lives under its ``function_declarator``, which may itself be
-    wrapped in one or more ``pointer_declarator`` / ``parenthesized_declarator``
-    layers. For a plain pointer-returning function (``void *malloc(...)``) one
-    ``pointer_declarator`` wraps the ``function_declarator``. For a function that
-    *returns a function pointer* (``int (*factory(void))(int)``) the name lives
-    in an INNER ``function_declarator`` nested inside a ``parenthesized_declarator``
-    — so we must keep descending past the outermost ``function_declarator`` until
-    we reach the identifier itself. Return the innermost declarator identifier
-    text, or ``None`` when it cannot be recovered.
-
-    This is what lets C free functions reach ``ast_symbol_rows`` so the synapse
-    C resolver's ownership gate (``_project_owns``) sees project-defined libc
-    names (e.g. a custom ``malloc``) and does NOT misclassify them as ``stdlib``.
-    """
-    return _c_declarator_name(node.child_by_field_name("declarator"), source, 0)
-
-
-# Declarator wrappers a C function name can be nested under, ordered so the
-# common cases stay shallow. ``parenthesized_declarator`` does NOT expose a
-# ``declarator`` field, so it is handled by scanning children explicitly.
-_C_DECLARATOR_WRAPPERS = (
-    "function_declarator",
-    "pointer_declarator",
-    "array_declarator",
-)
-
-
-def _c_declarator_name(declarator: Any, source: str, depth: int) -> str | None:
-    """Descend a C declarator chain to its innermost identifier.
-
-    Handles pointer / array / function declarator wrappers (which expose a
-    ``declarator`` field) and ``parenthesized_declarator`` (which does not — its
-    inner declarator is an unnamed child). Bounded to avoid pathological depth.
-    """
-    if declarator is None or depth > 16:
-        return None
-    dtype = declarator.type
-    if dtype in ("identifier", "field_identifier", "type_identifier"):
-        text = _node_text(declarator, source)
-        return text or None
-    if dtype == "parenthesized_declarator":
-        for child in declarator.children:
-            if child.type in _C_DECLARATOR_WRAPPERS or child.type.endswith(
-                "identifier"
-            ):
-                name = _c_declarator_name(child, source, depth + 1)
-                if name is not None:
-                    return name
-        return None
-    if dtype in _C_DECLARATOR_WRAPPERS:
-        return _c_declarator_name(
-            declarator.child_by_field_name("declarator"), source, depth + 1
-        )
-    return None
-
-
-def _bash_subscript_base(subscript: Any) -> Any:
-    """Return the base ``variable_name`` node of a Bash ``subscript`` target.
-
-    For ``arr[0]=x`` tree-sitter-bash nests the base variable under the
-    subscript's ``name`` field (``arr``). Fall back to the first
-    ``variable_name`` / ``word`` child if the field is absent.
-    """
-    base = subscript.child_by_field_name("name")
-    if base is not None:
-        return base
-    for child in subscript.children:
-        if child.type in ("variable_name", "word"):
-            return child
-    return None
-
-
-def _scala_symbol_from_node(node: Any, source: str) -> dict[str, Any] | None:
-    node_type = node.type
-    if node_type not in _SCALA_CLASS_LIKE:
-        return None
-    name = _scala_symbol_name(node, source)
-    if not name:
-        return None
-    return {
-        "kind": "enum" if node_type == "enum_definition" else "class",
-        "name": name,
-        "line": node.start_point[0] + 1,
-        "end_line": node.end_point[0] + 1,
-        "language": "scala",
-    }
-
-
-def _scala_symbol_name(node: Any, source: str) -> str | None:
-    name_node = node.child_by_field_name("name")
-    if name_node is not None:
-        return _node_text(name_node, source)
-    for child in node.children:
-        if child.type in ("identifier", "type_identifier"):
-            return _node_text(child, source)
-    if node.type == "given_definition":
-        type_name = _scala_given_type_text(node, source)
-        if type_name:
-            return f"given {type_name}"
-        return f"anonymous_given_{node.start_point[0] + 1}"
-    return None
-
-
-def _scala_given_type_text(node: Any, source: str) -> str | None:
-    for child in node.children:
-        if child.type in (
-            "generic_type",
-            "type_identifier",
-            "stable_type_identifier",
-            "tuple_type",
-            "function_type",
-        ):
-            return _node_text(child, source)
-    return None
-
-
-_WALK_MAX_DEPTH = (
-    100  # #779: DoS protection — functions nested beyond this are dropped.
-)
-
-
-def _walk_for_symbols(
-    node: Any,
-    source: str,
-    symbols: list[dict[str, Any]],
-    language: str,
-    depth: int = 0,
-    enclosed: bool = False,
-    _truncated_flag: list[bool] | None = None,
-) -> None:
-    """Walk the AST collecting symbol dicts.
-
-    ``enclosed`` tracks (top-down, no parent walking) whether *node* sits
-    inside a Python function/class body (#610), a Go function body (#613),
-    a Rust function/closure body (#613), a PHP function/closure body
-    (#624), a JS/TS function/method/static-block body (#626), a Java
-    method/ctor/lambda/initializer body (#626 Java half), or a C#
-    method/ctor/dtor/local-fn/lambda/accessor/operator body (#628) —
-    module/package-constant capture must fire at top-level scope only,
-    including ``if``/``try``-wrapped module-level assignments, and
-    JS/TS/Java/C# function-local declarators must NOT produce
-    kind="variable" rows.
-
-    ``_truncated_flag`` is an optional single-element list.  When the depth
-    guard fires the list is set to ``[True]`` so the caller can detect that
-    deeply nested functions were silently dropped (#779).
-    """
-    if depth > _WALK_MAX_DEPTH:
-        if _truncated_flag is not None:
-            _truncated_flag[0] = True
-        return
-    node_type = node.type
-    name_node = node.child_by_field_name("name")
-    # C ``function_definition`` nodes carry their identifier under
-    # ``function_declarator`` (no ``name`` field), so recover it explicitly —
-    # otherwise ordinary C free functions never reach ``ast_symbol_rows`` and the
-    # synapse C resolver's project-ownership gate cannot shadow the libc tier.
-    func_name: str | None = None
-    if node_type in _FUNCTION_LIKE:
-        if name_node is not None:
-            func_name = _node_text(name_node, source)
-        elif node_type == "function_definition" and language == "c":
-            func_name = _c_function_def_name(node, source)
-    if func_name is not None:
-        name = func_name
-        params_node = node.child_by_field_name("parameters")
-        params = _node_text(params_node, source) if params_node else ""
-        dp = _count_decision_points(node, language)
-        sym: dict[str, Any] = {
-            "kind": "function",
-            "name": name,
-            "line": node.start_point[0] + 1,
-            "end_line": node.end_point[0] + 1,
-            "params": params,
-            "language": language,
-        }
-        if dp:
-            sym["decision_points"] = dp
-        # #614: return_type where the grammar exposes the field (python/rust/
-        # typescript use "return_type"; absent field → key absent, no noise).
-        return_type_node = node.child_by_field_name("return_type")
-        if return_type_node is not None:
-            # TS/TSX expose a type_annotation node whose text is ": string" —
-            # strip the annotation prefix so consumers compare bare types
-            # (Codex P2 on #621; mirrors the TS signature helpers).
-            sym["return_type"] = _node_text(return_type_node, source).lstrip(": ")
-        if language == "python":
-            doc = _python_docstring(node, source)
-            if doc is not None:
-                sym["docstring"] = doc
-        parent_cls = _find_parent_class(node, source)
-        if parent_cls:
-            sym["kind"] = "method"
-            sym["class"] = parent_cls
-        symbols.append(sym)
-    elif language == "scala" and node_type in _SCALA_CLASS_LIKE and not enclosed:
-        # #961: ``not enclosed`` keeps a method-local ``given``/``type`` out of
-        # the top-level symbol set (CLI/plugin already excludes it; the
-        # ast_cache path must match — otherwise CLI vs MCP diverge).
-        scala_sym = _scala_symbol_from_node(node, source)
-        if scala_sym is not None:
-            symbols.append(scala_sym)
-    elif node_type in _CLASS_LIKE:
-        effective_name_node = name_node
-        if effective_name_node is None:
-            for child in node.children:
-                if child.type in ("type_identifier", "constant", "identifier"):
-                    effective_name_node = child
-                    break
-        if effective_name_node is None:
-            pass
-        else:
-            name = _node_text(effective_name_node, source)
-            if not name:
-                pass
-            else:
-                parents = _extract_parent_classes(node, source, language)
-                cls_sym: dict[str, Any] = {
-                    "kind": "enum" if node_type in _ENUM_LIKE else "class",
-                    "name": name,
-                    "line": node.start_point[0] + 1,
-                    "end_line": node.end_point[0] + 1,
-                    "language": language,
-                }
-                if parents:
-                    cls_sym["parents"] = parents
-                if language == "python":
-                    doc = _python_docstring(node, source)
-                    if doc is not None:
-                        cls_sym["docstring"] = doc
-                symbols.append(cls_sym)
-    elif node_type in _IMPORT_LIKE:
-        symbols.append(
-            {
-                "kind": "import",
-                "text": _node_text(node, source),
-                "line": node.start_point[0] + 1,
-                "language": language,
-            }
-        )
-    elif (
-        node_type in _VAR_DECL_LIKE
-        and name_node is not None
-        # #626/#628: JS/TS/Java/C# function-local declarators are not
-        # cross-file symbols — skip them. The ast_cache path only ever
-        # delivers the language ids "javascript"/"typescript"/"java"/
-        # "csharp" for this family (.jsx → "javascript", .tsx →
-        # "typescript", .java → "java", .cs → "csharp"), so gating on
-        # these ids is complete.
-        and not (
-            language in ("javascript", "typescript", "java", "csharp") and enclosed
-        )
-        # #949 Codex P2: ``FOO=bar make`` makes tree-sitter-bash emit
-        # ``FOO=bar`` as a variable_assignment *child of a command* node — a
-        # transient per-command env override, not a script-level variable.
-        # Skip those; only standalone assignments (parent is the
-        # program/compound/list) are real symbols.
-        and not (
-            node_type == "variable_assignment"
-            and node.parent is not None
-            and node.parent.type == "command"
-        )
-    ):
-        # Bash array/associative assignments (``arr[0]=x``) expose the target
-        # as a ``subscript`` node, not a bare ``variable_name``. Unwrap to the
-        # base variable so the symbol is the variable name, not ``arr[0]``.
-        if name_node.type == "subscript":
-            name_node = _bash_subscript_base(name_node)
-        name = _node_text(name_node, source) if name_node is not None else ""
-        if name and (not name.startswith("_") or depth < 3):
-            symbols.append(
-                {
-                    "kind": "variable",
-                    "name": name,
-                    "line": node.start_point[0] + 1,
-                    "language": language,
-                }
-            )
-    elif node_type == "assignment" and language == "python" and not enclosed:
-        const_sym = _python_module_constant(node, source)
-        if const_sym is not None:
-            symbols.append(const_sym)
-    elif node_type in _GO_CONST_LIKE and language == "go" and not enclosed:
-        symbols.extend(_go_package_constants(node, source))
-    elif (
-        node_type in _RUST_CONST_LIKE
-        and language == "rust"
-        and not enclosed
-        and name_node is not None
-        # `const _: usize = ...;` compile-time assertions: `_` is not a
-        # referenceable symbol (Codex P2 on #618; mirrors the Go blank rule)
-        and _node_text(name_node, source) != "_"
-    ):
-        symbols.append(
-            {
-                "kind": "constant",
-                "name": _node_text(name_node, source),
-                "line": node.start_point[0] + 1,
-                "end_line": node.end_point[0] + 1,
-                "language": "rust",
-            }
-        )
-    elif node_type == "const_declaration" and language == "php" and not enclosed:
-        symbols.extend(_php_constants(node, source))
-    # Language-gated: Rust needs "block" in its scope set (const-initializer
-    # block expressions, Codex P2 on #618), but Python's if/try bodies are
-    # also "block" nodes — a shared set would break the #612 guarantee that
-    # if/try-wrapped module assignments stay captured.
-    child_enclosed = enclosed or (
-        (language == "python" and node_type in _PY_SCOPE_BODY_NODES)
-        or (language == "go" and node_type in _GO_SCOPE_BODY_NODES)
-        or (language == "rust" and node_type in _RUST_SCOPE_BODY_NODES)
-        or (language == "php" and node_type in _PHP_SCOPE_BODY_NODES)
-        or (
-            language in ("javascript", "typescript")
-            and node_type in _JSTS_SCOPE_BODY_NODES
-        )
-        or (language == "java" and node_type in _JAVA_SCOPE_BODY_NODES)
-        or (language == "csharp" and node_type in _CSHARP_SCOPE_BODY_NODES)
-        or (language == "scala" and node_type in _SCALA_SCOPE_BODY_NODES)
-    )
-    for child in node.children:
-        _walk_for_symbols(
-            child, source, symbols, language, depth + 1, child_enclosed, _truncated_flag
-        )
-
-
-def _extract_symbols(tree: Any, source_code: str, language: str) -> dict[str, Any]:
-    symbols: list[dict[str, Any]] = []
-    if tree is None:
-        return {"symbols": symbols, "node_count": 0, "truncated_depth": False}
-    root = tree.root_node
-    truncated_flag: list[bool] = [False]
-    _walk_for_symbols(
-        root, source_code, symbols, language, _truncated_flag=truncated_flag
-    )
-    _annotate_canonical_complexity(symbols, tree, source_code, language)
-    return {
-        "symbols": symbols,
-        "node_count": _count_nodes(root),
-        "truncated_depth": truncated_flag[0],
-    }
-
-
-def _annotate_canonical_complexity(
-    symbols: list[dict[str, Any]], tree: Any, source_code: str, language: str
-) -> None:
-    """Stamp each function/method symbol with the extractor's ``complexity``.
-
-    The plugin extractor's ``complexity_score`` is the single source of truth
-    (RFC-0019 / #1094); cached here (keyed by start line) so the cache-backed
-    heatmap path uses the same value the live path and ``--table`` do, instead
-    of re-deriving it from the per-arm ``decision_points`` sum.
-    """
-    try:
-        from ..plugins.manager import PluginManager
-
-        plugin = PluginManager().get_plugin(language)
-        if plugin is None:
-            return
-        elements = plugin.create_extractor().extract_functions(tree, source_code)
-    except Exception:
-        return
-
-    cx_by_line: dict[int, int] = {}
-    for elem in elements:
-        start = getattr(elem, "start_line", None)
-        if start is not None:
-            cx_by_line[start] = max(getattr(elem, "complexity_score", 1) or 1, 1)
-
-    for sym in symbols:
-        if sym.get("kind") in ("function", "method"):
-            line = sym.get("line")
-            if line is not None and line in cx_by_line:
-                sym["complexity"] = cx_by_line[line]
-
-
-def _extract_imports(symbols: dict[str, Any]) -> list[str]:
-    return [s["text"] for s in symbols.get("symbols", []) if s.get("kind") == "import"]
-
-
-def _extract_structure(symbols: dict[str, Any]) -> dict[str, Any]:
-    functions = []
-    classes = []
-    for s in symbols.get("symbols", []):
-        if s["kind"] in ("function", "method"):
-            functions.append({"name": s["name"], "line": s["line"]})
-        elif s["kind"] in ("class", "enum"):
-            classes.append({"name": s["name"], "line": s["line"]})
-    return {"functions": functions, "classes": classes}
 
 
 def _extract_call_edges(


### PR DESCRIPTION
## Summary

- replace the 1,210-line cache extraction god file with a stable 195-line compatibility facade
- separate declarative node rules, declaration extraction, syntax navigation, structural metrics, and staged traversal into focused modules
- replace the 204-line recursive symbol collector with a small stateful walker whose stages are independently auditable
- preserve historical private imports, the process-local `_worker_parser`, multiprocessing picklability, and the live facade hook used by indexing monkeypatches
- add an exact regression contract proving `_worker_index_file` dispatches through `extraction._extract_symbols`

## Value

The cache indexer supports many language grammars and was concentrated in one high-risk module (grade D, 68.6, 1,210 lines, 9-level nesting). This change keeps behavior stable while reducing blast radius and making language rules, syntax recovery, complexity annotation, and traversal independently maintainable. All six resulting implementation files are under 500 lines, grade A, and report zero code smells in the project's own analyzer.

## Verification

- `uv run pytest -q` — 1315 passed, 1 skipped
- focused cache/extraction suite — 450 passed
- patch coverage gate — no added executable misses
- `uv run mypy tree_sitter_analyzer/` — 780 source files clean
- `uv run ruff check .`
- Bandit — 0 issues
- weak assertion ratchet — no new violations
- package build + Twine validation — passed
