### PR TITLE
test(cache): close extraction stage coverage gaps

### DIFF
--- a/tests/unit/test_ast_extraction.py
+++ b/tests/unit/test_ast_extraction.py
@@ -169,6 +169,12 @@ class TestNodeText:
         node = SimpleNamespace(text=None, start_byte=999, end_byte=1000)
         assert _node_text(node, "short") == ""
 
+    def test_returns_empty_when_byte_offsets_are_invalid(self):
+        """PR #1193: invalid legacy offsets take the guarded fallback."""
+        node = SimpleNamespace(text=None, start_byte="invalid", end_byte=1)
+
+        assert _node_text(node, "source") == ""
+
 
 # ---------------------------------------------------------------------------
 # _count_decision_points()
@@ -206,6 +212,39 @@ class TestCountDecisionPoints:
         root.children = [child]
         result = _count_decision_points(root, "python")
         assert result.get("if_statement", 0) == 1
+
+
+class TestAnnotateCanonicalComplexity:
+    def test_missing_plugin_leaves_symbols_unchanged(self, monkeypatch):
+        """PR #1193: languages without a plugin exit without annotations."""
+        from tree_sitter_analyzer.cache.extraction import (
+            _annotate_canonical_complexity,
+        )
+        from tree_sitter_analyzer.plugins.manager import PluginManager
+
+        monkeypatch.setattr(PluginManager, "get_plugin", lambda _self, _lang: None)
+        symbols = [{"kind": "function", "name": "run", "line": 1}]
+
+        _annotate_canonical_complexity(symbols, None, "", "unknown")
+
+        assert symbols == [{"kind": "function", "name": "run", "line": 1}]
+
+    def test_plugin_lookup_failure_leaves_symbols_unchanged(self, monkeypatch):
+        """PR #1193: plugin lookup failures remain non-fatal."""
+        from tree_sitter_analyzer.cache.extraction import (
+            _annotate_canonical_complexity,
+        )
+        from tree_sitter_analyzer.plugins.manager import PluginManager
+
+        def fail_lookup(_self, _language):
+            raise RuntimeError("plugin registry unavailable")
+
+        monkeypatch.setattr(PluginManager, "get_plugin", fail_lookup)
+        symbols = [{"kind": "function", "name": "run", "line": 1}]
+
+        _annotate_canonical_complexity(symbols, None, "", "python")
+
+        assert symbols == [{"kind": "function", "name": "run", "line": 1}]
 
 
 # ---------------------------------------------------------------------------
@@ -273,11 +312,34 @@ class TestExtractParentClasses:
 
     def test_extract_parent_classes_exception_swallowed(self):
         """If node iteration raises, the except clause returns empty list."""
-        node = MagicMock()
-        node.children = MagicMock(side_effect=RuntimeError("boom"))
-        # Should not raise
+        node = SimpleNamespace(children=1)
+
         result = _extract_parent_classes(node, "", "python")
-        assert isinstance(result, list)
+
+        assert result == []
+
+    def test_cpp_base_class_clause_is_extracted(self):
+        """PR #1193: the C/C++ parent extractor remains directly covered."""
+        parent = SimpleNamespace(type="type_identifier", text=b"Base")
+        clause = SimpleNamespace(type="base_class_clause", children=[parent])
+        node = SimpleNamespace(children=[clause])
+
+        result = _extract_parent_classes(node, "", "cpp")
+
+        assert result == ["Base"]
+
+    def test_impl_without_type_field_continues_parent_search(self):
+        """PR #1193: a malformed Rust impl does not invent a parent class."""
+        from tree_sitter_analyzer.cache.extraction import _find_parent_class
+
+        impl = SimpleNamespace(
+            type="impl_item",
+            child_by_field_name=lambda _field: None,
+            parent=None,
+        )
+        node = SimpleNamespace(parent=impl)
+
+        assert _find_parent_class(node, "") is None
 
 
 # ---------------------------------------------------------------------------
@@ -310,6 +372,49 @@ class TestWalkForSymbols:
         # symbols is empty because node.type='module' is not in _FUNCTION_LIKE/_CLASS_LIKE
         # but the key guarantee is: no early return at depth=21
         assert symbols == []  # no crash = depth guard didn't fire
+
+    def test_scala_class_like_without_name_is_skipped(self):
+        """PR #1193: the staged Scala handler keeps its empty-symbol branch."""
+        node = MagicMock()
+        node.type = "object_definition"
+        node.child_by_field_name.return_value = None
+        node.children = []
+        symbols: list[dict] = []
+
+        _walk_for_symbols(node, "", symbols, "scala")
+
+        assert symbols == []
+
+    def test_class_with_empty_name_is_skipped(self):
+        """PR #1193: empty class-name nodes do not produce cache rows."""
+        name_node = SimpleNamespace(type="identifier", text=b"")
+        node = MagicMock()
+        node.type = "class_definition"
+        node.child_by_field_name.side_effect = (
+            lambda field: name_node if field == "name" else None
+        )
+        node.children = []
+        symbols: list[dict] = []
+
+        _walk_for_symbols(node, "", symbols, "python")
+
+        assert symbols == []
+
+    def test_variable_with_empty_name_is_skipped(self):
+        """PR #1193: empty variable-name nodes do not produce cache rows."""
+        name_node = SimpleNamespace(type="identifier", text=b"")
+        node = MagicMock()
+        node.type = "variable_declarator"
+        node.parent = None
+        node.child_by_field_name.side_effect = (
+            lambda field: name_node if field == "name" else None
+        )
+        node.children = []
+        symbols: list[dict] = []
+
+        _walk_for_symbols(node, "", symbols, "python")
+
+        assert symbols == []
 
     def test_extract_symbols_truncated_depth_flag_when_deeply_nested(self):
         """_extract_symbols returns truncated_depth=True when AST depth exceeds limit.
@@ -467,6 +572,21 @@ class TestCDeclaratorName:
             type="parenthesized_declarator",
             children=[SimpleNamespace(type="(", children=[])],
         )
+        assert _c_declarator_name(paren, "", 0) is None
+
+    def test_parenthesized_wrapper_without_identifier_returns_none(self):
+        """PR #1193: a recognized wrapper may still contain no identifier."""
+        from tree_sitter_analyzer.cache.extraction import _c_declarator_name
+
+        wrapper = SimpleNamespace(
+            type="function_declarator",
+            child_by_field_name=lambda _field: None,
+        )
+        paren = SimpleNamespace(
+            type="parenthesized_declarator",
+            children=[wrapper],
+        )
+
         assert _c_declarator_name(paren, "", 0) is None
 
 
@@ -1755,6 +1875,17 @@ class TestScalaHelpers:
 
         result = _scala_symbol_name(node, "")
         assert result == "MyTrait"
+
+    def test_scala_symbol_name_non_given_without_name_returns_none(self):
+        """PR #1193: an unnamed non-given Scala node has no synthetic name."""
+        from tree_sitter_analyzer.cache.extraction import _scala_symbol_name
+
+        node = MagicMock()
+        node.type = "object_definition"
+        node.child_by_field_name.return_value = None
+        node.children = []
+
+        assert _scala_symbol_name(node, "") is None
 
     def test_scala_symbol_name_given_definition_with_generic_type(self):
         """given_definition with a generic_type child (not identifier) → 'given <type>'.

--- a/tests/unit/test_ast_extraction.py
+++ b/tests/unit/test_ast_extraction.py
@@ -332,14 +332,20 @@ class TestExtractParentClasses:
         """PR #1193: a malformed Rust impl does not invent a parent class."""
         from tree_sitter_analyzer.cache.extraction import _find_parent_class
 
+        outer_name = SimpleNamespace(text=b"Outer")
+        outer = SimpleNamespace(
+            type="class_definition",
+            child_by_field_name=lambda field: (outer_name if field == "name" else None),
+            parent=None,
+        )
         impl = SimpleNamespace(
             type="impl_item",
             child_by_field_name=lambda _field: None,
-            parent=None,
+            parent=outer,
         )
         node = SimpleNamespace(parent=impl)
 
-        assert _find_parent_class(node, "") is None
+        assert _find_parent_class(node, "") == "Outer"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to #1193 after Codecov applied new-file semantics and reported 15 uncovered line/branch outcomes despite the repository's move-aware local patch gate passing.

- cover invalid legacy byte offsets and parent-extractor failures
- cover C/C++ parent extraction and malformed Rust/C declarator paths
- cover unnamed Scala, class, and variable nodes in the staged walker
- cover missing/failing plugin lookups in canonical complexity annotation
- replace the previous ineffective exception mock with an input that actually raises during iteration

## Coverage result

The same focused suite used for #1193 now reports no missing lines and no missing branches for:

- `_symbol_syntax.py`: 100% lines / branches
- `_symbol_metrics.py`: 100% lines / branches
- `_symbol_walker.py`: 100% lines / branches

## Verification

- focused cache/extraction suite — 460 passed
- `uv run pytest -q` — 1315 passed, 1 skipped
- `uv run mypy tree_sitter_analyzer/` — 780 source files clean
- `uv run ruff check .`
- weak assertion ratchet — no new violations
- patch coverage gate — no added executable misses
