### PR TITLE
feat(benchmarks): qualify isolated Gin Smoke bundles

### DIFF
--- a/benchmarks/codegraph_compare/README.md
+++ b/benchmarks/codegraph_compare/README.md
@@ -1,5 +1,29 @@
 # CodeGraph Comparison Benchmark
 
+## NO1-001A Gin Smoke qualification
+
+The model-free qualification adapter proves that the fixed native,
+tree-sitter-analyzer, and CodeGraph cells can be isolated and replayed. It
+does not run an index, backend, or model and can only emit E0 evidence:
+
+```bash
+RECEIPT=$(python -m benchmarks.codegraph_compare.gin_smoke create /tmp/gin-smoke \
+  --benchmark-git-sha "$(git rev-parse HEAD)" \
+  --repository-path /fixture/gin \
+  --question "Where is the Gin router assembled?" \
+  --model fixture-model --timeout-seconds 60)
+DIGEST=$(printf '%s' "$RECEIPT" | jq -r .bundle_digest)
+python -m benchmarks.codegraph_compare.gin_smoke validate /tmp/gin-smoke \
+  --expected-git-sha "$(git rev-parse HEAD)" --expected-bundle-digest "$DIGEST"
+python -m benchmarks.codegraph_compare.gin_smoke replay \
+  /tmp/gin-smoke /tmp/gin-smoke-replay \
+  --expected-git-sha "$(git rev-parse HEAD)" --expected-bundle-digest "$DIGEST"
+```
+
+Validation requires a trusted Git SHA supplied outside the bundle. Any
+checksum change, missing or mixed cell, namespace collision, tool leakage,
+oracle material, selective retry, or claim above E0 invalidates the bundle.
+
 Measures answer quality, token cost, and latency across three code-intelligence approaches on real open-source repositories:
 
 | Arm | Tool(s) | Index |

--- a/benchmarks/codegraph_compare/README.md
+++ b/benchmarks/codegraph_compare/README.md
@@ -10,6 +10,8 @@ does not run an index, backend, or model and can only emit E0 evidence:
 RECEIPT=$(python -m benchmarks.codegraph_compare.gin_smoke create /tmp/gin-smoke \
   --benchmark-git-sha "$(git rev-parse HEAD)" \
   --repository-path /fixture/gin \
+  --repository-commit 0123456789abcdef0123456789abcdef01234567 \
+  --repository-fingerprint 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
   --question "Where is the Gin router assembled?" \
   --model fixture-model --timeout-seconds 60)
 DIGEST=$(printf '%s' "$RECEIPT" | jq -r .bundle_digest)

--- a/benchmarks/codegraph_compare/gin_smoke.py
+++ b/benchmarks/codegraph_compare/gin_smoke.py
@@ -11,11 +11,10 @@ import argparse
 import hashlib
 import json
 import os
-import stat
 import sys
 import tempfile
-from dataclasses import asdict, dataclass, fields
-from pathlib import Path, PurePosixPath
+from dataclasses import asdict, dataclass
+from pathlib import Path
 from typing import Any, cast
 
 from benchmarks.codegraph_compare.integrity import _sha256
@@ -284,212 +283,19 @@ def create_bundle(
     return {**cast(dict[str, Any], qualification), "bundle_digest": bundle_digest}
 
 
-def _read_json(path: Path) -> Any:
-    try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
-        raise QualificationError(f"invalid JSON: {path.name}") from exc
-
-
-def _read_object(path: Path) -> dict[str, Any]:
-    payload = _read_json(path)
-    if not isinstance(payload, dict) or any(
-        not isinstance(key, str) for key in payload
-    ):
-        raise QualificationError(f"JSON object required: {path.name}")
-    return cast(dict[str, Any], payload)
-
-
-def _reject_forbidden_keys(payload: Any) -> None:
-    if isinstance(payload, dict):
-        for key, value in payload.items():
-            if str(key).casefold() in FORBIDDEN_NAMES:
-                raise QualificationError("oracle material is forbidden")
-            _reject_forbidden_keys(value)
-    elif isinstance(payload, (list, tuple)):
-        for value in payload:
-            _reject_forbidden_keys(value)
-
-
-def _regular_files(root: Path) -> tuple[str, ...]:
-    names: list[str] = []
-    for path in root.rglob("*"):
-        mode = path.lstat().st_mode
-        if stat.S_ISLNK(mode) or (not stat.S_ISREG(mode) and not stat.S_ISDIR(mode)):
-            raise QualificationError(f"special filesystem node: {path}")
-        if path.is_file():
-            names.append(path.relative_to(root).as_posix())
-    return tuple(sorted(names))
-
-
-def _validate_names(names: tuple[str, ...]) -> None:
-    expected = tuple(sorted((*FILES, "checksums.json")))
-    if names != expected:
-        raise QualificationError("missing, duplicate, or unexpected bundle files")
-    for name in names:
-        parts = {part.casefold() for part in PurePosixPath(name).parts}
-        if parts & FORBIDDEN_NAMES:
-            raise QualificationError("oracle material is forbidden")
-
-
 def validate_bundle(
     root: Path, *, expected_git_sha: str, expected_bundle_digest: str
 ) -> dict[str, Any]:
     """Validate a bundle against an external, trusted Git SHA anchor."""
-    if (
-        not root.is_dir()
-        or not expected_git_sha
-        or not _is_sha256(expected_bundle_digest)
-    ):
-        raise QualificationError("bundle directory and external anchors are required")
-    names = _regular_files(root)
-    _validate_names(names)
-    manifest = _read_object(root / "manifest.json")
-    qualification = _read_object(root / "qualification.json")
-    checksum_doc = _read_object(root / "checksums.json")
-    if _digest_bytes((root / "checksums.json").read_bytes()) != expected_bundle_digest:
-        raise QualificationError("external bundle digest mismatch")
-    _reject_forbidden_keys((manifest, qualification, checksum_doc))
-    if (
-        manifest.get("benchmark_git_sha") != expected_git_sha
-        or not _is_git_sha(expected_git_sha)
-    ):
-        raise QualificationError("wrong benchmark Git SHA")
-    if (
-        set(manifest) != MANIFEST_KEYS
-        or manifest.get("schema_version") != SCHEMA_VERSION
-        or manifest.get("objective_id") != OBJECTIVE_ID
-        or manifest.get("mode") != "fixture"
-        or manifest.get("expected_arms") != list(EXPECTED_ARMS)
-        or manifest.get("network") != "disabled"
-        or manifest.get("allowed_native_tools") != ["read", "search"]
-        or not _is_sha256(manifest.get("question_sha256"))
-        or not _is_sha256(manifest.get("config_fingerprint"))
-        or type(manifest.get("timeout_seconds")) is not int
-        or manifest["timeout_seconds"] <= 0
-        or not isinstance(manifest.get("model"), str)
-        or not manifest["model"]
-        or not isinstance(manifest.get("repository_path"), str)
-        or not manifest["repository_path"]
-        or not _is_git_sha(manifest.get("repository_commit"))
-        or not _is_sha256(manifest.get("repository_fingerprint"))
-        or manifest.get("oracle_material_in_bundle") is not False
-        or manifest.get("retry_policy")
-        != {"kind": "none", "selective_reruns": False}
-    ):
-        raise QualificationError("invalid manifest contract")
-    shared = {
-        "question_sha256": manifest.get("question_sha256"),
-        "model": manifest.get("model"),
-        "timeout_seconds": manifest.get("timeout_seconds"),
-        "network": manifest.get("network"),
-        "allowed_native_tools": manifest.get("allowed_native_tools"),
-    }
-    if manifest.get("config_fingerprint") != _sha256(shared):
-        raise QualificationError("config fingerprint mismatch")
-    expected_checksums = checksum_doc.get("sha256")
-    if (
-        set(checksum_doc) != {"sha256"}
-        or not isinstance(expected_checksums, dict)
-        or set(expected_checksums) != set(FILES)
-        or any(not _is_sha256(value) for value in expected_checksums.values())
-    ):
-        raise QualificationError("invalid checksum inventory")
-    actual = {name: _digest_bytes((root / name).read_bytes()) for name in FILES}
-    if actual != expected_checksums:
-        raise QualificationError("checksum mismatch")
+    from benchmarks.codegraph_compare.gin_smoke_validation import (
+        validate_bundle as validate,
+    )
 
-    cells = [
-        _read_object(root / "cells" / f"{arm}.json") for arm in EXPECTED_ARMS
-    ]
-    policies = [
-        _read_object(root / "policies" / f"{arm}.json") for arm in EXPECTED_ARMS
-    ]
-    _reject_forbidden_keys((cells, policies))
-    cell_keys = {field.name for field in fields(Cell)}
-    for arm, cell, policy in zip(EXPECTED_ARMS, cells, policies, strict=True):
-        slug = arm.replace("-", "_")
-        if (
-            set(cell) != cell_keys
-            or any(not isinstance(cell[key], str) for key in cell_keys - {
-                "backend_executed",
-                "index_created",
-                "model_executed",
-            })
-            or cell.get("arm") != arm
-            or cell.get("checkout_namespace") != f"checkout/{slug}"
-            or cell.get("mcp_namespace") != f"mcp/{slug}"
-            or cell.get("index_namespace") != f"index/{slug}"
-            or cell.get("artifact_namespace") != f"artifact/{slug}"
-            or not _is_sha256(cell.get("input_fingerprint"))
-            or not _is_sha256(cell.get("config_fingerprint"))
-            or not _is_sha256(cell.get("tool_policy_fingerprint"))
-            or policy != _policy(arm)
-        ):
-            raise QualificationError("mixed or invalid cell")
-        if cell.get("repository_path") != manifest.get("repository_path"):
-            raise QualificationError("wrong repository")
-        if (
-            cell.get("repository_commit") != manifest.get("repository_commit")
-            or cell.get("repository_fingerprint")
-            != manifest.get("repository_fingerprint")
-        ):
-            raise QualificationError("wrong repository provenance")
-        expected_input = _sha256(
-            {
-                "question_sha256": manifest.get("question_sha256"),
-                "repository_commit": manifest.get("repository_commit"),
-                "repository_fingerprint": manifest.get("repository_fingerprint"),
-            }
-        )
-        if cell.get("input_fingerprint") != expected_input:
-            raise QualificationError("input fingerprint mismatch")
-        if cell.get("config_fingerprint") != manifest.get("config_fingerprint"):
-            raise QualificationError("config fingerprint mismatch")
-        if cell.get("tool_policy_fingerprint") != _sha256(policy):
-            raise QualificationError("tool policy fingerprint mismatch")
-        if any(
-            cell.get(flag) is not False
-            for flag in ("backend_executed", "index_created", "model_executed")
-        ):
-            raise QualificationError("qualification executed forbidden work")
-        transcript = _read_object(root / "transcripts" / f"{arm}.jsonl")
-        _reject_forbidden_keys(transcript)
-        if transcript != {
-            "arm": arm,
-            "event": "qualification_only",
-            "backend_executed": False,
-            "index_created": False,
-            "model_executed": False,
-        }:
-            raise QualificationError("invalid qualification transcript")
-    namespaces = [
-        cell[key]
-        for cell in cells
-        for key in (
-            "checkout_namespace",
-            "mcp_namespace",
-            "index_namespace",
-            "artifact_namespace",
-        )
-    ]
-    if len(namespaces) != len(set(namespaces)):
-        raise QualificationError("namespace collision")
-    expected_qualification = {
-        "schema_version": 1,
-        "objective_id": OBJECTIVE_ID,
-        "evidence_level": "E0",
-        "publishable": False,
-        "qualification_only": True,
-        "backend_executed": False,
-        "index_created": False,
-        "model_executed": False,
-        "dominance_allowed": False,
-        "winner": None,
-    }
-    if qualification != expected_qualification:
-        raise QualificationError("qualification claim exceeds E0")
-    return qualification
+    return validate(
+        root,
+        expected_git_sha=expected_git_sha,
+        expected_bundle_digest=expected_bundle_digest,
+    )
 
 
 def replay_bundle(

--- a/benchmarks/codegraph_compare/gin_smoke.py
+++ b/benchmarks/codegraph_compare/gin_smoke.py
@@ -1,0 +1,478 @@
+"""Deterministic, model-free qualification bundle for NO1-001A.
+
+This adapter deliberately produces E0 infrastructure evidence only.  It
+reuses the benchmark's canonical hashing vocabulary while keeping model,
+backend, and index execution outside the qualification boundary.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import stat
+import sys
+import tempfile
+from dataclasses import asdict, dataclass, fields
+from pathlib import Path, PurePosixPath
+from typing import Any, cast
+
+from benchmarks.codegraph_compare.integrity import _sha256
+
+OBJECTIVE_ID = "NO1-001A"
+SCHEMA_VERSION = 1
+EXPECTED_ARMS = ("native", "tree-sitter-analyzer", "codegraph")
+FORBIDDEN_NAMES = frozenset({"oracle", "oracles", "expected_answer", "answers"})
+FILES = (
+    "manifest.json",
+    "qualification.json",
+    "cells/native.json",
+    "cells/tree-sitter-analyzer.json",
+    "cells/codegraph.json",
+    "policies/native.json",
+    "policies/tree-sitter-analyzer.json",
+    "policies/codegraph.json",
+    "transcripts/native.jsonl",
+    "transcripts/tree-sitter-analyzer.jsonl",
+    "transcripts/codegraph.jsonl",
+)
+
+
+class QualificationError(ValueError):
+    """A bundle is not valid qualification evidence."""
+
+
+@dataclass(frozen=True)
+class Cell:
+    arm: str
+    repository_path: str
+    checkout_namespace: str
+    mcp_namespace: str
+    index_namespace: str
+    artifact_namespace: str
+    config_fingerprint: str
+    input_fingerprint: str
+    tool_policy_fingerprint: str
+    backend_executed: bool = False
+    index_created: bool = False
+    model_executed: bool = False
+
+
+def _canonical(payload: Any) -> bytes:
+    return json.dumps(
+        payload, ensure_ascii=True, separators=(",", ":"), sort_keys=True
+    ).encode()
+
+
+def _digest_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _write(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(_canonical(payload) + b"\n")
+
+
+def _policy(arm: str) -> dict[str, Any]:
+    allowed = {
+        "native": ["read", "search"],
+        "tree-sitter-analyzer": ["read", "search", "tree-sitter-analyzer"],
+        "codegraph": ["read", "search", "codegraph"],
+    }[arm]
+    forbidden = sorted({"tree-sitter-analyzer", "codegraph"} - set(allowed))
+    return {
+        "arm": arm,
+        "allowed_native_tools": ["read", "search"],
+        "allowed_tools": allowed,
+        "forbidden_tools": forbidden,
+        "network": "disabled",
+        "oracle_access": False,
+        "retry_policy": "none",
+    }
+
+
+def _cell(
+    arm: str,
+    *,
+    repository_path: str,
+    input_fingerprint: str,
+    config_fingerprint: str,
+) -> Cell:
+    policy_hash = _sha256(_policy(arm))
+    slug = arm.replace("-", "_")
+    return Cell(
+        arm=arm,
+        repository_path=repository_path,
+        checkout_namespace=f"checkout/{slug}",
+        mcp_namespace=f"mcp/{slug}",
+        index_namespace=f"index/{slug}",
+        artifact_namespace=f"artifact/{slug}",
+        config_fingerprint=config_fingerprint,
+        input_fingerprint=input_fingerprint,
+        tool_policy_fingerprint=policy_hash,
+    )
+
+
+def create_bundle(
+    destination: Path,
+    *,
+    benchmark_git_sha: str,
+    repository_path: str,
+    question: str,
+    model: str,
+    timeout_seconds: int,
+) -> dict[str, Any]:
+    """Create an immutable fixture bundle without executing a backend or model."""
+    if destination.exists():
+        raise QualificationError("destination already exists")
+    if not benchmark_git_sha or not repository_path or not question or not model:
+        raise QualificationError("identity fields must be non-empty")
+    if timeout_seconds <= 0:
+        raise QualificationError("timeout_seconds must be positive")
+
+    destination.mkdir(parents=True)
+    input_fingerprint = _digest_bytes(question.encode())
+    shared = {
+        "question_sha256": input_fingerprint,
+        "model": model,
+        "timeout_seconds": timeout_seconds,
+        "network": "disabled",
+        "allowed_native_tools": ["read", "search"],
+    }
+    config_fingerprint = _sha256(shared)
+    cells = tuple(
+        _cell(
+            arm,
+            repository_path=repository_path,
+            input_fingerprint=input_fingerprint,
+            config_fingerprint=config_fingerprint,
+        )
+        for arm in EXPECTED_ARMS
+    )
+    namespaces = [
+        value
+        for cell in cells
+        for value in (
+            cell.checkout_namespace,
+            cell.mcp_namespace,
+            cell.index_namespace,
+            cell.artifact_namespace,
+        )
+    ]
+    if len(namespaces) != len(set(namespaces)):
+        raise QualificationError("namespace collision")
+
+    manifest = {
+        "schema_version": SCHEMA_VERSION,
+        "objective_id": OBJECTIVE_ID,
+        "mode": "fixture",
+        "benchmark_git_sha": benchmark_git_sha,
+        "repository_path": repository_path,
+        "question_sha256": input_fingerprint,
+        "config_fingerprint": config_fingerprint,
+        "expected_arms": list(EXPECTED_ARMS),
+        "retry_policy": {"kind": "none", "selective_reruns": False},
+        "oracle_material_in_bundle": False,
+        **shared,
+    }
+    _write(destination / "manifest.json", manifest)
+    for cell in cells:
+        _write(destination / "cells" / f"{cell.arm}.json", asdict(cell))
+        _write(destination / "policies" / f"{cell.arm}.json", _policy(cell.arm))
+        _write(
+            destination / "transcripts" / f"{cell.arm}.jsonl",
+            {
+                "arm": cell.arm,
+                "event": "qualification_only",
+                "backend_executed": False,
+                "index_created": False,
+                "model_executed": False,
+            },
+        )
+    qualification = {
+        "schema_version": SCHEMA_VERSION,
+        "objective_id": OBJECTIVE_ID,
+        "evidence_level": "E0",
+        "publishable": False,
+        "qualification_only": True,
+        "backend_executed": False,
+        "index_created": False,
+        "model_executed": False,
+        "dominance_allowed": False,
+        "winner": None,
+    }
+    _write(destination / "qualification.json", qualification)
+    checksums = {
+        name: _digest_bytes((destination / name).read_bytes()) for name in FILES
+    }
+    _write(destination / "checksums.json", {"sha256": checksums})
+    bundle_digest = _digest_bytes((destination / "checksums.json").read_bytes())
+    validate_bundle(
+        destination,
+        expected_git_sha=benchmark_git_sha,
+        expected_bundle_digest=bundle_digest,
+    )
+    if not isinstance(qualification, dict):
+        raise QualificationError("qualification must be an object")
+    return {**cast(dict[str, Any], qualification), "bundle_digest": bundle_digest}
+
+
+def _read_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise QualificationError(f"invalid JSON: {path.name}") from exc
+
+
+def _read_object(path: Path) -> dict[str, Any]:
+    payload = _read_json(path)
+    if not isinstance(payload, dict) or any(
+        not isinstance(key, str) for key in payload
+    ):
+        raise QualificationError(f"JSON object required: {path.name}")
+    return cast(dict[str, Any], payload)
+
+
+def _reject_forbidden_keys(payload: Any) -> None:
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            if str(key).casefold() in FORBIDDEN_NAMES:
+                raise QualificationError("oracle material is forbidden")
+            _reject_forbidden_keys(value)
+    elif isinstance(payload, (list, tuple)):
+        for value in payload:
+            _reject_forbidden_keys(value)
+
+
+def _regular_files(root: Path) -> tuple[str, ...]:
+    names: list[str] = []
+    for path in root.rglob("*"):
+        mode = path.lstat().st_mode
+        if stat.S_ISLNK(mode) or (not stat.S_ISREG(mode) and not stat.S_ISDIR(mode)):
+            raise QualificationError(f"special filesystem node: {path}")
+        if path.is_file():
+            names.append(path.relative_to(root).as_posix())
+    return tuple(sorted(names))
+
+
+def _validate_names(names: tuple[str, ...]) -> None:
+    expected = tuple(sorted((*FILES, "checksums.json")))
+    if names != expected:
+        raise QualificationError("missing, duplicate, or unexpected bundle files")
+    for name in names:
+        parts = {part.casefold() for part in PurePosixPath(name).parts}
+        if parts & FORBIDDEN_NAMES:
+            raise QualificationError("oracle material is forbidden")
+
+
+def validate_bundle(
+    root: Path, *, expected_git_sha: str, expected_bundle_digest: str
+) -> dict[str, Any]:
+    """Validate a bundle against an external, trusted Git SHA anchor."""
+    if not root.is_dir() or not expected_git_sha or not expected_bundle_digest:
+        raise QualificationError("bundle directory and external anchors are required")
+    names = _regular_files(root)
+    _validate_names(names)
+    manifest = _read_object(root / "manifest.json")
+    qualification = _read_object(root / "qualification.json")
+    checksum_doc = _read_object(root / "checksums.json")
+    if _digest_bytes((root / "checksums.json").read_bytes()) != expected_bundle_digest:
+        raise QualificationError("external bundle digest mismatch")
+    _reject_forbidden_keys((manifest, qualification, checksum_doc))
+    if manifest.get("benchmark_git_sha") != expected_git_sha:
+        raise QualificationError("wrong benchmark Git SHA")
+    if (
+        manifest.get("schema_version") != SCHEMA_VERSION
+        or manifest.get("objective_id") != OBJECTIVE_ID
+        or manifest.get("mode") != "fixture"
+        or tuple(manifest.get("expected_arms", ())) != EXPECTED_ARMS
+        or manifest.get("network") != "disabled"
+        or manifest.get("allowed_native_tools") != ["read", "search"]
+        or type(manifest.get("timeout_seconds")) is not int
+        or manifest["timeout_seconds"] <= 0
+        or not isinstance(manifest.get("model"), str)
+        or not manifest["model"]
+        or not isinstance(manifest.get("repository_path"), str)
+        or not manifest["repository_path"]
+        or manifest.get("oracle_material_in_bundle") is not False
+        or manifest.get("retry_policy")
+        != {"kind": "none", "selective_reruns": False}
+    ):
+        raise QualificationError("invalid manifest contract")
+    shared = {
+        "question_sha256": manifest.get("question_sha256"),
+        "model": manifest.get("model"),
+        "timeout_seconds": manifest.get("timeout_seconds"),
+        "network": manifest.get("network"),
+        "allowed_native_tools": manifest.get("allowed_native_tools"),
+    }
+    if manifest.get("config_fingerprint") != _sha256(shared):
+        raise QualificationError("config fingerprint mismatch")
+    expected_checksums = checksum_doc.get("sha256")
+    if not isinstance(expected_checksums, dict) or set(expected_checksums) != set(FILES):
+        raise QualificationError("invalid checksum inventory")
+    actual = {name: _digest_bytes((root / name).read_bytes()) for name in FILES}
+    if actual != expected_checksums:
+        raise QualificationError("checksum mismatch")
+
+    cells = [
+        _read_object(root / "cells" / f"{arm}.json") for arm in EXPECTED_ARMS
+    ]
+    policies = [
+        _read_object(root / "policies" / f"{arm}.json") for arm in EXPECTED_ARMS
+    ]
+    _reject_forbidden_keys((cells, policies))
+    cell_keys = {field.name for field in fields(Cell)}
+    for arm, cell, policy in zip(EXPECTED_ARMS, cells, policies, strict=True):
+        if (
+            set(cell) != cell_keys
+            or any(not isinstance(cell[key], str) for key in cell_keys - {
+                "backend_executed",
+                "index_created",
+                "model_executed",
+            })
+            or cell.get("arm") != arm
+            or policy != _policy(arm)
+        ):
+            raise QualificationError("mixed or invalid cell")
+        if cell.get("repository_path") != manifest.get("repository_path"):
+            raise QualificationError("wrong repository")
+        if cell.get("input_fingerprint") != manifest.get("question_sha256"):
+            raise QualificationError("input fingerprint mismatch")
+        if cell.get("config_fingerprint") != manifest.get("config_fingerprint"):
+            raise QualificationError("config fingerprint mismatch")
+        if cell.get("tool_policy_fingerprint") != _sha256(policy):
+            raise QualificationError("tool policy fingerprint mismatch")
+        if any(
+            cell.get(flag) is not False
+            for flag in ("backend_executed", "index_created", "model_executed")
+        ):
+            raise QualificationError("qualification executed forbidden work")
+        transcript = _read_object(root / "transcripts" / f"{arm}.jsonl")
+        _reject_forbidden_keys(transcript)
+        if transcript != {
+            "arm": arm,
+            "event": "qualification_only",
+            "backend_executed": False,
+            "index_created": False,
+            "model_executed": False,
+        }:
+            raise QualificationError("invalid qualification transcript")
+    namespaces = [
+        cell[key]
+        for cell in cells
+        for key in (
+            "checkout_namespace",
+            "mcp_namespace",
+            "index_namespace",
+            "artifact_namespace",
+        )
+    ]
+    if len(namespaces) != len(set(namespaces)):
+        raise QualificationError("namespace collision")
+    expected_qualification = {
+        "schema_version": 1,
+        "objective_id": OBJECTIVE_ID,
+        "evidence_level": "E0",
+        "publishable": False,
+        "qualification_only": True,
+        "backend_executed": False,
+        "index_created": False,
+        "model_executed": False,
+        "dominance_allowed": False,
+        "winner": None,
+    }
+    if qualification != expected_qualification:
+        raise QualificationError("qualification claim exceeds E0")
+    return qualification
+
+
+def replay_bundle(
+    source: Path,
+    destination: Path,
+    *,
+    expected_git_sha: str,
+    expected_bundle_digest: str,
+) -> None:
+    """Replay the deterministic bundle atomically and verify byte identity."""
+    validate_bundle(
+        source,
+        expected_git_sha=expected_git_sha,
+        expected_bundle_digest=expected_bundle_digest,
+    )
+    if destination.exists():
+        raise QualificationError("replay destination already exists")
+    parent = destination.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(dir=parent) as temp_name:
+        temp = Path(temp_name)
+        for name in (*FILES, "checksums.json"):
+            target = temp / name
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes((source / name).read_bytes())
+        validate_bundle(
+            temp,
+            expected_git_sha=expected_git_sha,
+            expected_bundle_digest=expected_bundle_digest,
+        )
+        os.replace(temp, destination)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    create = sub.add_parser("create")
+    create.add_argument("destination", type=Path)
+    create.add_argument("--benchmark-git-sha", required=True)
+    create.add_argument("--repository-path", required=True)
+    create.add_argument("--question", required=True)
+    create.add_argument("--model", required=True)
+    create.add_argument("--timeout-seconds", type=int, required=True)
+    validate = sub.add_parser("validate")
+    validate.add_argument("bundle", type=Path)
+    validate.add_argument("--expected-git-sha", required=True)
+    validate.add_argument("--expected-bundle-digest", required=True)
+    replay = sub.add_parser("replay")
+    replay.add_argument("source", type=Path)
+    replay.add_argument("destination", type=Path)
+    replay.add_argument("--expected-git-sha", required=True)
+    replay.add_argument("--expected-bundle-digest", required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        if args.command == "create":
+            result = create_bundle(
+                args.destination,
+                benchmark_git_sha=args.benchmark_git_sha,
+                repository_path=args.repository_path,
+                question=args.question,
+                model=args.model,
+                timeout_seconds=args.timeout_seconds,
+            )
+        elif args.command == "validate":
+            result = validate_bundle(
+                args.bundle,
+                expected_git_sha=args.expected_git_sha,
+                expected_bundle_digest=args.expected_bundle_digest,
+            )
+        else:
+            replay_bundle(
+                args.source,
+                args.destination,
+                expected_git_sha=args.expected_git_sha,
+                expected_bundle_digest=args.expected_bundle_digest,
+            )
+            result = {"replayed": True, "destination": str(args.destination)}
+    except QualificationError as exc:
+        print(json.dumps({"valid": False, "error": str(exc)}))
+        return 2
+    print(json.dumps({"valid": True, **result}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/codegraph_compare/gin_smoke.py
+++ b/benchmarks/codegraph_compare/gin_smoke.py
@@ -37,6 +37,24 @@ FILES = (
     "transcripts/tree-sitter-analyzer.jsonl",
     "transcripts/codegraph.jsonl",
 )
+MANIFEST_KEYS = frozenset(
+    {
+        "schema_version",
+        "objective_id",
+        "mode",
+        "benchmark_git_sha",
+        "repository_path",
+        "question_sha256",
+        "config_fingerprint",
+        "expected_arms",
+        "retry_policy",
+        "oracle_material_in_bundle",
+        "model",
+        "timeout_seconds",
+        "network",
+        "allowed_native_tools",
+    }
+)
 
 
 class QualificationError(ValueError):
@@ -283,10 +301,11 @@ def validate_bundle(
     if manifest.get("benchmark_git_sha") != expected_git_sha:
         raise QualificationError("wrong benchmark Git SHA")
     if (
-        manifest.get("schema_version") != SCHEMA_VERSION
+        set(manifest) != MANIFEST_KEYS
+        or manifest.get("schema_version") != SCHEMA_VERSION
         or manifest.get("objective_id") != OBJECTIVE_ID
         or manifest.get("mode") != "fixture"
-        or tuple(manifest.get("expected_arms", ())) != EXPECTED_ARMS
+        or manifest.get("expected_arms") != list(EXPECTED_ARMS)
         or manifest.get("network") != "disabled"
         or manifest.get("allowed_native_tools") != ["read", "search"]
         or type(manifest.get("timeout_seconds")) is not int

--- a/benchmarks/codegraph_compare/gin_smoke.py
+++ b/benchmarks/codegraph_compare/gin_smoke.py
@@ -87,6 +87,16 @@ def _digest_bytes(payload: bytes) -> str:
     return hashlib.sha256(payload).hexdigest()
 
 
+def _is_sha256(value: object) -> bool:
+    if not isinstance(value, str) or len(value) != 64:
+        return False
+    try:
+        int(value, 16)
+    except ValueError:
+        return False
+    return True
+
+
 def _write(path: Path, payload: Any) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_bytes(_canonical(payload) + b"\n")
@@ -288,7 +298,11 @@ def validate_bundle(
     root: Path, *, expected_git_sha: str, expected_bundle_digest: str
 ) -> dict[str, Any]:
     """Validate a bundle against an external, trusted Git SHA anchor."""
-    if not root.is_dir() or not expected_git_sha or not expected_bundle_digest:
+    if (
+        not root.is_dir()
+        or not expected_git_sha
+        or not _is_sha256(expected_bundle_digest)
+    ):
         raise QualificationError("bundle directory and external anchors are required")
     names = _regular_files(root)
     _validate_names(names)
@@ -308,6 +322,8 @@ def validate_bundle(
         or manifest.get("expected_arms") != list(EXPECTED_ARMS)
         or manifest.get("network") != "disabled"
         or manifest.get("allowed_native_tools") != ["read", "search"]
+        or not _is_sha256(manifest.get("question_sha256"))
+        or not _is_sha256(manifest.get("config_fingerprint"))
         or type(manifest.get("timeout_seconds")) is not int
         or manifest["timeout_seconds"] <= 0
         or not isinstance(manifest.get("model"), str)
@@ -329,7 +345,11 @@ def validate_bundle(
     if manifest.get("config_fingerprint") != _sha256(shared):
         raise QualificationError("config fingerprint mismatch")
     expected_checksums = checksum_doc.get("sha256")
-    if not isinstance(expected_checksums, dict) or set(expected_checksums) != set(FILES):
+    if (
+        not isinstance(expected_checksums, dict)
+        or set(expected_checksums) != set(FILES)
+        or any(not _is_sha256(value) for value in expected_checksums.values())
+    ):
         raise QualificationError("invalid checksum inventory")
     actual = {name: _digest_bytes((root / name).read_bytes()) for name in FILES}
     if actual != expected_checksums:
@@ -352,6 +372,9 @@ def validate_bundle(
                 "model_executed",
             })
             or cell.get("arm") != arm
+            or not _is_sha256(cell.get("input_fingerprint"))
+            or not _is_sha256(cell.get("config_fingerprint"))
+            or not _is_sha256(cell.get("tool_policy_fingerprint"))
             or policy != _policy(arm)
         ):
             raise QualificationError("mixed or invalid cell")

--- a/benchmarks/codegraph_compare/gin_smoke.py
+++ b/benchmarks/codegraph_compare/gin_smoke.py
@@ -44,6 +44,8 @@ MANIFEST_KEYS = frozenset(
         "mode",
         "benchmark_git_sha",
         "repository_path",
+        "repository_commit",
+        "repository_fingerprint",
         "question_sha256",
         "config_fingerprint",
         "expected_arms",
@@ -65,6 +67,8 @@ class QualificationError(ValueError):
 class Cell:
     arm: str
     repository_path: str
+    repository_commit: str
+    repository_fingerprint: str
     checkout_namespace: str
     mcp_namespace: str
     index_namespace: str
@@ -89,6 +93,16 @@ def _digest_bytes(payload: bytes) -> str:
 
 def _is_sha256(value: object) -> bool:
     if not isinstance(value, str) or len(value) != 64:
+        return False
+    try:
+        int(value, 16)
+    except ValueError:
+        return False
+    return True
+
+
+def _is_git_sha(value: object) -> bool:
+    if not isinstance(value, str) or len(value) != 40:
         return False
     try:
         int(value, 16)
@@ -124,6 +138,8 @@ def _cell(
     arm: str,
     *,
     repository_path: str,
+    repository_commit: str,
+    repository_fingerprint: str,
     input_fingerprint: str,
     config_fingerprint: str,
 ) -> Cell:
@@ -132,6 +148,8 @@ def _cell(
     return Cell(
         arm=arm,
         repository_path=repository_path,
+        repository_commit=repository_commit,
+        repository_fingerprint=repository_fingerprint,
         checkout_namespace=f"checkout/{slug}",
         mcp_namespace=f"mcp/{slug}",
         index_namespace=f"index/{slug}",
@@ -147,6 +165,8 @@ def create_bundle(
     *,
     benchmark_git_sha: str,
     repository_path: str,
+    repository_commit: str,
+    repository_fingerprint: str,
     question: str,
     model: str,
     timeout_seconds: int,
@@ -154,15 +174,29 @@ def create_bundle(
     """Create an immutable fixture bundle without executing a backend or model."""
     if destination.exists():
         raise QualificationError("destination already exists")
-    if not benchmark_git_sha or not repository_path or not question or not model:
+    if (
+        not _is_git_sha(benchmark_git_sha)
+        or not repository_path
+        or not _is_git_sha(repository_commit)
+        or not _is_sha256(repository_fingerprint)
+        or not question
+        or not model
+    ):
         raise QualificationError("identity fields must be non-empty")
     if timeout_seconds <= 0:
         raise QualificationError("timeout_seconds must be positive")
 
     destination.mkdir(parents=True)
-    input_fingerprint = _digest_bytes(question.encode())
+    question_sha256 = _digest_bytes(question.encode())
+    input_fingerprint = _sha256(
+        {
+            "question_sha256": question_sha256,
+            "repository_commit": repository_commit,
+            "repository_fingerprint": repository_fingerprint,
+        }
+    )
     shared = {
-        "question_sha256": input_fingerprint,
+        "question_sha256": question_sha256,
         "model": model,
         "timeout_seconds": timeout_seconds,
         "network": "disabled",
@@ -173,6 +207,8 @@ def create_bundle(
         _cell(
             arm,
             repository_path=repository_path,
+            repository_commit=repository_commit,
+            repository_fingerprint=repository_fingerprint,
             input_fingerprint=input_fingerprint,
             config_fingerprint=config_fingerprint,
         )
@@ -197,7 +233,9 @@ def create_bundle(
         "mode": "fixture",
         "benchmark_git_sha": benchmark_git_sha,
         "repository_path": repository_path,
-        "question_sha256": input_fingerprint,
+        "repository_commit": repository_commit,
+        "repository_fingerprint": repository_fingerprint,
+        "question_sha256": question_sha256,
         "config_fingerprint": config_fingerprint,
         "expected_arms": list(EXPECTED_ARMS),
         "retry_policy": {"kind": "none", "selective_reruns": False},
@@ -312,7 +350,10 @@ def validate_bundle(
     if _digest_bytes((root / "checksums.json").read_bytes()) != expected_bundle_digest:
         raise QualificationError("external bundle digest mismatch")
     _reject_forbidden_keys((manifest, qualification, checksum_doc))
-    if manifest.get("benchmark_git_sha") != expected_git_sha:
+    if (
+        manifest.get("benchmark_git_sha") != expected_git_sha
+        or not _is_git_sha(expected_git_sha)
+    ):
         raise QualificationError("wrong benchmark Git SHA")
     if (
         set(manifest) != MANIFEST_KEYS
@@ -330,6 +371,8 @@ def validate_bundle(
         or not manifest["model"]
         or not isinstance(manifest.get("repository_path"), str)
         or not manifest["repository_path"]
+        or not _is_git_sha(manifest.get("repository_commit"))
+        or not _is_sha256(manifest.get("repository_fingerprint"))
         or manifest.get("oracle_material_in_bundle") is not False
         or manifest.get("retry_policy")
         != {"kind": "none", "selective_reruns": False}
@@ -346,7 +389,8 @@ def validate_bundle(
         raise QualificationError("config fingerprint mismatch")
     expected_checksums = checksum_doc.get("sha256")
     if (
-        not isinstance(expected_checksums, dict)
+        set(checksum_doc) != {"sha256"}
+        or not isinstance(expected_checksums, dict)
         or set(expected_checksums) != set(FILES)
         or any(not _is_sha256(value) for value in expected_checksums.values())
     ):
@@ -364,6 +408,7 @@ def validate_bundle(
     _reject_forbidden_keys((cells, policies))
     cell_keys = {field.name for field in fields(Cell)}
     for arm, cell, policy in zip(EXPECTED_ARMS, cells, policies, strict=True):
+        slug = arm.replace("-", "_")
         if (
             set(cell) != cell_keys
             or any(not isinstance(cell[key], str) for key in cell_keys - {
@@ -372,6 +417,10 @@ def validate_bundle(
                 "model_executed",
             })
             or cell.get("arm") != arm
+            or cell.get("checkout_namespace") != f"checkout/{slug}"
+            or cell.get("mcp_namespace") != f"mcp/{slug}"
+            or cell.get("index_namespace") != f"index/{slug}"
+            or cell.get("artifact_namespace") != f"artifact/{slug}"
             or not _is_sha256(cell.get("input_fingerprint"))
             or not _is_sha256(cell.get("config_fingerprint"))
             or not _is_sha256(cell.get("tool_policy_fingerprint"))
@@ -380,7 +429,20 @@ def validate_bundle(
             raise QualificationError("mixed or invalid cell")
         if cell.get("repository_path") != manifest.get("repository_path"):
             raise QualificationError("wrong repository")
-        if cell.get("input_fingerprint") != manifest.get("question_sha256"):
+        if (
+            cell.get("repository_commit") != manifest.get("repository_commit")
+            or cell.get("repository_fingerprint")
+            != manifest.get("repository_fingerprint")
+        ):
+            raise QualificationError("wrong repository provenance")
+        expected_input = _sha256(
+            {
+                "question_sha256": manifest.get("question_sha256"),
+                "repository_commit": manifest.get("repository_commit"),
+                "repository_fingerprint": manifest.get("repository_fingerprint"),
+            }
+        )
+        if cell.get("input_fingerprint") != expected_input:
             raise QualificationError("input fingerprint mismatch")
         if cell.get("config_fingerprint") != manifest.get("config_fingerprint"):
             raise QualificationError("config fingerprint mismatch")
@@ -468,6 +530,8 @@ def _parser() -> argparse.ArgumentParser:
     create.add_argument("destination", type=Path)
     create.add_argument("--benchmark-git-sha", required=True)
     create.add_argument("--repository-path", required=True)
+    create.add_argument("--repository-commit", required=True)
+    create.add_argument("--repository-fingerprint", required=True)
     create.add_argument("--question", required=True)
     create.add_argument("--model", required=True)
     create.add_argument("--timeout-seconds", type=int, required=True)
@@ -491,6 +555,8 @@ def main(argv: list[str] | None = None) -> int:
                 args.destination,
                 benchmark_git_sha=args.benchmark_git_sha,
                 repository_path=args.repository_path,
+                repository_commit=args.repository_commit,
+                repository_fingerprint=args.repository_fingerprint,
                 question=args.question,
                 model=args.model,
                 timeout_seconds=args.timeout_seconds,

--- a/benchmarks/codegraph_compare/gin_smoke_validation.py
+++ b/benchmarks/codegraph_compare/gin_smoke_validation.py
@@ -1,0 +1,229 @@
+"""Fail-closed validation for the NO1-001A Gin qualification bundle."""
+
+from __future__ import annotations
+
+import json
+import stat
+from dataclasses import fields
+from pathlib import Path, PurePosixPath
+from typing import Any, cast
+
+from benchmarks.codegraph_compare.gin_smoke import (
+    EXPECTED_ARMS,
+    FILES,
+    FORBIDDEN_NAMES,
+    MANIFEST_KEYS,
+    OBJECTIVE_ID,
+    SCHEMA_VERSION,
+    Cell,
+    QualificationError,
+    _digest_bytes,
+    _is_git_sha,
+    _is_sha256,
+    _policy,
+)
+from benchmarks.codegraph_compare.integrity import _sha256
+
+
+def _read_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise QualificationError(f"invalid JSON: {path.name}") from exc
+
+
+def _read_object(path: Path) -> dict[str, Any]:
+    payload = _read_json(path)
+    if not isinstance(payload, dict) or any(
+        not isinstance(key, str) for key in payload
+    ):
+        raise QualificationError(f"JSON object required: {path.name}")
+    return cast(dict[str, Any], payload)
+
+
+def _reject_forbidden_keys(payload: Any) -> None:
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            if str(key).casefold() in FORBIDDEN_NAMES:
+                raise QualificationError("oracle material is forbidden")
+            _reject_forbidden_keys(value)
+    elif isinstance(payload, (list, tuple)):
+        for value in payload:
+            _reject_forbidden_keys(value)
+
+
+def _regular_files(root: Path) -> tuple[str, ...]:
+    names: list[str] = []
+    for path in root.rglob("*"):
+        mode = path.lstat().st_mode
+        if stat.S_ISLNK(mode) or (not stat.S_ISREG(mode) and not stat.S_ISDIR(mode)):
+            raise QualificationError(f"special filesystem node: {path}")
+        if path.is_file():
+            names.append(path.relative_to(root).as_posix())
+    return tuple(sorted(names))
+
+
+def _validate_names(names: tuple[str, ...]) -> None:
+    expected = tuple(sorted((*FILES, "checksums.json")))
+    if names != expected:
+        raise QualificationError("missing, duplicate, or unexpected bundle files")
+    for name in names:
+        parts = {part.casefold() for part in PurePosixPath(name).parts}
+        if parts & FORBIDDEN_NAMES:
+            raise QualificationError("oracle material is forbidden")
+
+
+def validate_bundle(
+    root: Path, *, expected_git_sha: str, expected_bundle_digest: str
+) -> dict[str, Any]:
+    """Validate a bundle against external trusted Git and digest anchors."""
+    if (
+        not root.is_dir()
+        or not expected_git_sha
+        or not _is_sha256(expected_bundle_digest)
+    ):
+        raise QualificationError("bundle directory and external anchors are required")
+    names = _regular_files(root)
+    _validate_names(names)
+    manifest = _read_object(root / "manifest.json")
+    qualification = _read_object(root / "qualification.json")
+    checksum_doc = _read_object(root / "checksums.json")
+    if _digest_bytes((root / "checksums.json").read_bytes()) != expected_bundle_digest:
+        raise QualificationError("external bundle digest mismatch")
+    _reject_forbidden_keys((manifest, qualification, checksum_doc))
+    if (
+        manifest.get("benchmark_git_sha") != expected_git_sha
+        or not _is_git_sha(expected_git_sha)
+    ):
+        raise QualificationError("wrong benchmark Git SHA")
+    if (
+        set(manifest) != MANIFEST_KEYS
+        or manifest.get("schema_version") != SCHEMA_VERSION
+        or manifest.get("objective_id") != OBJECTIVE_ID
+        or manifest.get("mode") != "fixture"
+        or manifest.get("expected_arms") != list(EXPECTED_ARMS)
+        or manifest.get("network") != "disabled"
+        or manifest.get("allowed_native_tools") != ["read", "search"]
+        or not _is_sha256(manifest.get("question_sha256"))
+        or not _is_sha256(manifest.get("config_fingerprint"))
+        or type(manifest.get("timeout_seconds")) is not int
+        or manifest["timeout_seconds"] <= 0
+        or not isinstance(manifest.get("model"), str)
+        or not manifest["model"]
+        or not isinstance(manifest.get("repository_path"), str)
+        or not manifest["repository_path"]
+        or not _is_git_sha(manifest.get("repository_commit"))
+        or not _is_sha256(manifest.get("repository_fingerprint"))
+        or manifest.get("oracle_material_in_bundle") is not False
+        or manifest.get("retry_policy")
+        != {"kind": "none", "selective_reruns": False}
+    ):
+        raise QualificationError("invalid manifest contract")
+    shared = {
+        "question_sha256": manifest.get("question_sha256"),
+        "model": manifest.get("model"),
+        "timeout_seconds": manifest.get("timeout_seconds"),
+        "network": manifest.get("network"),
+        "allowed_native_tools": manifest.get("allowed_native_tools"),
+    }
+    if manifest.get("config_fingerprint") != _sha256(shared):
+        raise QualificationError("config fingerprint mismatch")
+    expected_checksums = checksum_doc.get("sha256")
+    if (
+        set(checksum_doc) != {"sha256"}
+        or not isinstance(expected_checksums, dict)
+        or set(expected_checksums) != set(FILES)
+        or any(not _is_sha256(value) for value in expected_checksums.values())
+    ):
+        raise QualificationError("invalid checksum inventory")
+    actual = {name: _digest_bytes((root / name).read_bytes()) for name in FILES}
+    if actual != expected_checksums:
+        raise QualificationError("checksum mismatch")
+
+    cells = [
+        _read_object(root / "cells" / f"{arm}.json") for arm in EXPECTED_ARMS
+    ]
+    policies = [
+        _read_object(root / "policies" / f"{arm}.json") for arm in EXPECTED_ARMS
+    ]
+    _reject_forbidden_keys((cells, policies))
+    cell_keys = {field.name for field in fields(Cell)}
+    for arm, cell, policy in zip(EXPECTED_ARMS, cells, policies, strict=True):
+        slug = arm.replace("-", "_")
+        boolean_keys = {"backend_executed", "index_created", "model_executed"}
+        if (
+            set(cell) != cell_keys
+            or any(
+                not isinstance(cell[key], str) for key in cell_keys - boolean_keys
+            )
+            or cell.get("arm") != arm
+            or cell.get("checkout_namespace") != f"checkout/{slug}"
+            or cell.get("mcp_namespace") != f"mcp/{slug}"
+            or cell.get("index_namespace") != f"index/{slug}"
+            or cell.get("artifact_namespace") != f"artifact/{slug}"
+            or not _is_sha256(cell.get("input_fingerprint"))
+            or not _is_sha256(cell.get("config_fingerprint"))
+            or not _is_sha256(cell.get("tool_policy_fingerprint"))
+            or policy != _policy(arm)
+        ):
+            raise QualificationError("mixed or invalid cell")
+        if cell.get("repository_path") != manifest.get("repository_path"):
+            raise QualificationError("wrong repository")
+        if (
+            cell.get("repository_commit") != manifest.get("repository_commit")
+            or cell.get("repository_fingerprint")
+            != manifest.get("repository_fingerprint")
+        ):
+            raise QualificationError("wrong repository provenance")
+        expected_input = _sha256(
+            {
+                "question_sha256": manifest.get("question_sha256"),
+                "repository_commit": manifest.get("repository_commit"),
+                "repository_fingerprint": manifest.get("repository_fingerprint"),
+            }
+        )
+        if cell.get("input_fingerprint") != expected_input:
+            raise QualificationError("input fingerprint mismatch")
+        if cell.get("config_fingerprint") != manifest.get("config_fingerprint"):
+            raise QualificationError("config fingerprint mismatch")
+        if cell.get("tool_policy_fingerprint") != _sha256(policy):
+            raise QualificationError("tool policy fingerprint mismatch")
+        if any(cell.get(flag) is not False for flag in boolean_keys):
+            raise QualificationError("qualification executed forbidden work")
+        transcript = _read_object(root / "transcripts" / f"{arm}.jsonl")
+        _reject_forbidden_keys(transcript)
+        if transcript != {
+            "arm": arm,
+            "event": "qualification_only",
+            "backend_executed": False,
+            "index_created": False,
+            "model_executed": False,
+        }:
+            raise QualificationError("invalid qualification transcript")
+    namespaces = [
+        cell[key]
+        for cell in cells
+        for key in (
+            "checkout_namespace",
+            "mcp_namespace",
+            "index_namespace",
+            "artifact_namespace",
+        )
+    ]
+    if len(namespaces) != len(set(namespaces)):
+        raise QualificationError("namespace collision")
+    expected_qualification = {
+        "schema_version": 1,
+        "objective_id": OBJECTIVE_ID,
+        "evidence_level": "E0",
+        "publishable": False,
+        "qualification_only": True,
+        "backend_executed": False,
+        "index_created": False,
+        "model_executed": False,
+        "dominance_allowed": False,
+        "winner": None,
+    }
+    if qualification != expected_qualification:
+        raise QualificationError("qualification claim exceeds E0")
+    return qualification

--- a/tests/unit/test_benchmark_harness.py
+++ b/tests/unit/test_benchmark_harness.py
@@ -91,6 +91,8 @@ class TestGinSmokeQualification:
             bundle,
             benchmark_git_sha="a" * 40,
             repository_path="/fixture/repository",
+            repository_commit="b" * 40,
+            repository_fingerprint="c" * 64,
             question="Where is the Gin router assembled?",
             model="fixture-model",
             timeout_seconds=60,
@@ -159,7 +161,13 @@ class TestGinSmokeQualification:
                 "cells/native.json",
                 "index_namespace",
                 "index/tree_sitter_analyzer",
-                "namespace collision",
+                "mixed or invalid cell",
+            ),
+            (
+                "cells/native.json",
+                "repository_commit",
+                "d" * 40,
+                "wrong repository provenance",
             ),
         ],
     )
@@ -383,6 +391,19 @@ class TestGinSmokeQualification:
             gin_smoke.QualificationError, match="wrong benchmark Git SHA"
         ):
             self._validate(bundle, git_sha="b" * 40)
+
+    def test_mutable_benchmark_ref_is_rejected(self, tmp_path: Path):
+        with pytest.raises(gin_smoke.QualificationError, match="identity fields"):
+            gin_smoke.create_bundle(
+                tmp_path / "bundle",
+                benchmark_git_sha="main",
+                repository_path="/fixture/repository",
+                repository_commit="b" * 40,
+                repository_fingerprint="c" * 64,
+                question="Where is the Gin router assembled?",
+                model="fixture-model",
+                timeout_seconds=60,
+            )
 
     def test_missing_cell_is_rejected(self, tmp_path: Path):
         bundle = self._bundle(tmp_path)

--- a/tests/unit/test_benchmark_harness.py
+++ b/tests/unit/test_benchmark_harness.py
@@ -350,6 +350,28 @@ class TestGinSmokeQualification:
         ):
             self._validate(bundle)
 
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [("ground_truth", "secret"), ("expected_arms", None)],
+    )
+    def test_manifest_schema_is_exact(
+        self, tmp_path: Path, field: str, value: object
+    ):
+        bundle = self._bundle(tmp_path)
+        path = "manifest.json"
+        target = bundle / path
+        manifest = json.loads(target.read_text())
+        manifest[field] = value
+        target.write_text(json.dumps(manifest, sort_keys=True) + "\n")
+        checksums = json.loads((bundle / "checksums.json").read_text())
+        checksums["sha256"][path] = hashlib.sha256(target.read_bytes()).hexdigest()
+        (bundle / "checksums.json").write_text(
+            json.dumps(checksums, sort_keys=True) + "\n"
+        )
+
+        with pytest.raises(gin_smoke.QualificationError, match="invalid manifest"):
+            self._validate(bundle)
+
     def test_external_git_anchor_is_required(self, tmp_path: Path):
         bundle = self._bundle(tmp_path)
 

--- a/tests/unit/test_benchmark_harness.py
+++ b/tests/unit/test_benchmark_harness.py
@@ -30,6 +30,7 @@ import scenarios  # noqa: E402
 
 from benchmarks.codegraph_compare import analyze as compare_analyze  # noqa: E402
 from benchmarks.codegraph_compare import evaluate as compare_evaluate  # noqa: E402
+from benchmarks.codegraph_compare import gin_smoke  # noqa: E402
 from benchmarks.codegraph_compare import run as compare_run  # noqa: E402
 from benchmarks.codegraph_compare.adapters import IndexStats  # noqa: E402
 from benchmarks.codegraph_compare.adapters.tree_sitter_analyzer import (  # noqa: E402
@@ -81,6 +82,291 @@ def tiny_repo(tmp_path: Path) -> Path:
 # ---------------------------------------------------------------------------
 # scenarios.SCENARIOS registry contract
 # ---------------------------------------------------------------------------
+
+
+class TestGinSmokeQualification:
+    def _bundle(self, tmp_path: Path) -> Path:
+        bundle = tmp_path / "bundle"
+        gin_smoke.create_bundle(
+            bundle,
+            benchmark_git_sha="a" * 40,
+            repository_path="/fixture/repository",
+            question="Where is the Gin router assembled?",
+            model="fixture-model",
+            timeout_seconds=60,
+        )
+        return bundle
+
+    def _validate(self, bundle: Path, git_sha: str = "a" * 40):
+        digest = hashlib.sha256((bundle / "checksums.json").read_bytes()).hexdigest()
+        return gin_smoke.validate_bundle(
+            bundle,
+            expected_git_sha=git_sha,
+            expected_bundle_digest=digest,
+        )
+
+    def test_fixture_bundle_is_e0_only(self, tmp_path: Path):
+        bundle = self._bundle(tmp_path)
+
+        result = self._validate(bundle)
+
+        assert result["evidence_level"] == "E0"
+        assert result["publishable"] is False
+        assert result["dominance_allowed"] is False
+        assert result["winner"] is None
+
+    def test_replay_is_byte_identical(self, tmp_path: Path):
+        bundle = self._bundle(tmp_path)
+        replay = tmp_path / "replay"
+
+        gin_smoke.replay_bundle(
+            bundle,
+            replay,
+            expected_git_sha="a" * 40,
+            expected_bundle_digest=hashlib.sha256(
+                (bundle / "checksums.json").read_bytes()
+            ).hexdigest(),
+        )
+
+        source_bytes = {
+            path.relative_to(bundle): path.read_bytes()
+            for path in bundle.rglob("*")
+            if path.is_file()
+        }
+        replay_bytes = {
+            path.relative_to(replay): path.read_bytes()
+            for path in replay.rglob("*")
+            if path.is_file()
+        }
+        assert replay_bytes == source_bytes
+
+    @pytest.mark.parametrize(
+        ("path", "field", "value", "message"),
+        [
+            (
+                "cells/native.json",
+                "repository_path",
+                "/wrong/repository",
+                "wrong repository",
+            ),
+            (
+                "cells/native.json",
+                "input_fingerprint",
+                "wrong",
+                "input fingerprint mismatch",
+            ),
+            (
+                "cells/native.json",
+                "index_namespace",
+                "index/tree_sitter_analyzer",
+                "namespace collision",
+            ),
+        ],
+    )
+    def test_tampered_cell_is_rejected(
+        self,
+        tmp_path: Path,
+        path: str,
+        field: str,
+        value: str,
+        message: str,
+    ):
+        bundle = self._bundle(tmp_path)
+        target = bundle / path
+        payload = json.loads(target.read_text())
+        payload[field] = value
+        target.write_text(json.dumps(payload, sort_keys=True) + "\n")
+        checksums = json.loads((bundle / "checksums.json").read_text())
+        checksums["sha256"][path] = hashlib.sha256(target.read_bytes()).hexdigest()
+        (bundle / "checksums.json").write_text(
+            json.dumps(checksums, sort_keys=True) + "\n"
+        )
+
+        with pytest.raises(gin_smoke.QualificationError, match=message):
+            self._validate(bundle)
+
+    def test_cross_arm_tool_leakage_is_rejected(self, tmp_path: Path):
+        bundle = self._bundle(tmp_path)
+        path = "policies/native.json"
+        target = bundle / path
+        policy = json.loads(target.read_text())
+        policy["allowed_tools"].append("codegraph")
+        target.write_text(json.dumps(policy, sort_keys=True) + "\n")
+        checksums = json.loads((bundle / "checksums.json").read_text())
+        checksums["sha256"][path] = hashlib.sha256(target.read_bytes()).hexdigest()
+        (bundle / "checksums.json").write_text(
+            json.dumps(checksums, sort_keys=True) + "\n"
+        )
+
+        with pytest.raises(gin_smoke.QualificationError, match="invalid cell"):
+            self._validate(bundle)
+
+    @pytest.mark.parametrize("mutation", ["missing_namespace", "extra_result"])
+    def test_cell_schema_is_exact(self, tmp_path: Path, mutation: str):
+        bundle = self._bundle(tmp_path)
+        path = "cells/native.json"
+        target = bundle / path
+        cell = json.loads(target.read_text())
+        if mutation == "missing_namespace":
+            del cell["index_namespace"]
+        else:
+            cell["model_output"] = "undeclared result"
+        target.write_text(json.dumps(cell, sort_keys=True) + "\n")
+        checksums = json.loads((bundle / "checksums.json").read_text())
+        checksums["sha256"][path] = hashlib.sha256(target.read_bytes()).hexdigest()
+        (bundle / "checksums.json").write_text(
+            json.dumps(checksums, sort_keys=True) + "\n"
+        )
+
+        with pytest.raises(gin_smoke.QualificationError, match="invalid cell"):
+            self._validate(bundle)
+
+    def test_recomputed_config_fingerprint_rejects_tampering(self, tmp_path: Path):
+        bundle = self._bundle(tmp_path)
+        path = "manifest.json"
+        target = bundle / path
+        manifest = json.loads(target.read_text())
+        manifest["model"] = "different-model"
+        target.write_text(json.dumps(manifest, sort_keys=True) + "\n")
+        checksums = json.loads((bundle / "checksums.json").read_text())
+        checksums["sha256"][path] = hashlib.sha256(target.read_bytes()).hexdigest()
+        (bundle / "checksums.json").write_text(
+            json.dumps(checksums, sort_keys=True) + "\n"
+        )
+
+        with pytest.raises(
+            gin_smoke.QualificationError, match="config fingerprint mismatch"
+        ):
+            self._validate(bundle)
+
+    def test_external_bundle_digest_rejects_recomputed_checksums(
+        self, tmp_path: Path
+    ):
+        bundle = self._bundle(tmp_path)
+        original_digest = hashlib.sha256(
+            (bundle / "checksums.json").read_bytes()
+        ).hexdigest()
+        manifest_path = bundle / "manifest.json"
+        manifest = json.loads(manifest_path.read_text())
+        manifest["question_sha256"] = "b" * 64
+        manifest_path.write_text(json.dumps(manifest, sort_keys=True) + "\n")
+        checksums = json.loads((bundle / "checksums.json").read_text())
+        checksums["sha256"]["manifest.json"] = hashlib.sha256(
+            manifest_path.read_bytes()
+        ).hexdigest()
+        (bundle / "checksums.json").write_text(
+            json.dumps(checksums, sort_keys=True) + "\n"
+        )
+
+        with pytest.raises(
+            gin_smoke.QualificationError, match="external bundle digest mismatch"
+        ):
+            gin_smoke.validate_bundle(
+                bundle,
+                expected_git_sha="a" * 40,
+                expected_bundle_digest=original_digest,
+            )
+
+    def test_recomputed_enabled_network_is_rejected(self, tmp_path: Path):
+        bundle = self._bundle(tmp_path)
+        manifest_path = bundle / "manifest.json"
+        manifest = json.loads(manifest_path.read_text())
+        manifest["network"] = "enabled"
+        shared = {
+            key: manifest[key]
+            for key in (
+                "question_sha256",
+                "model",
+                "timeout_seconds",
+                "network",
+                "allowed_native_tools",
+            )
+        }
+        manifest["config_fingerprint"] = gin_smoke._sha256(shared)
+        manifest_path.write_text(json.dumps(manifest, sort_keys=True) + "\n")
+        for arm in gin_smoke.EXPECTED_ARMS:
+            cell_path = bundle / "cells" / f"{arm}.json"
+            cell = json.loads(cell_path.read_text())
+            cell["config_fingerprint"] = manifest["config_fingerprint"]
+            cell_path.write_text(json.dumps(cell, sort_keys=True) + "\n")
+        checksums = {
+            name: hashlib.sha256((bundle / name).read_bytes()).hexdigest()
+            for name in gin_smoke.FILES
+        }
+        (bundle / "checksums.json").write_text(
+            json.dumps({"sha256": checksums}, sort_keys=True) + "\n"
+        )
+
+        with pytest.raises(gin_smoke.QualificationError, match="invalid manifest"):
+            self._validate(bundle)
+
+    def test_transcript_semantic_tampering_is_rejected(self, tmp_path: Path):
+        bundle = self._bundle(tmp_path)
+        path = "transcripts/native.jsonl"
+        target = bundle / path
+        transcript = json.loads(target.read_text())
+        transcript["model_executed"] = True
+        target.write_text(json.dumps(transcript, sort_keys=True) + "\n")
+        checksums = json.loads((bundle / "checksums.json").read_text())
+        checksums["sha256"][path] = hashlib.sha256(target.read_bytes()).hexdigest()
+        (bundle / "checksums.json").write_text(
+            json.dumps(checksums, sort_keys=True) + "\n"
+        )
+
+        with pytest.raises(
+            gin_smoke.QualificationError, match="invalid qualification transcript"
+        ):
+            self._validate(bundle)
+
+    def test_non_object_json_is_rejected_cleanly(self, tmp_path: Path):
+        bundle = self._bundle(tmp_path)
+        path = "manifest.json"
+        target = bundle / path
+        target.write_text("[]\n")
+        checksums = json.loads((bundle / "checksums.json").read_text())
+        checksums["sha256"][path] = hashlib.sha256(target.read_bytes()).hexdigest()
+        (bundle / "checksums.json").write_text(
+            json.dumps(checksums, sort_keys=True) + "\n"
+        )
+
+        with pytest.raises(gin_smoke.QualificationError, match="JSON object required"):
+            self._validate(bundle)
+
+    def test_embedded_oracle_field_is_rejected(self, tmp_path: Path):
+        bundle = self._bundle(tmp_path)
+        path = "manifest.json"
+        target = bundle / path
+        manifest = json.loads(target.read_text())
+        manifest["expected_answer"] = "secret"
+        target.write_text(json.dumps(manifest, sort_keys=True) + "\n")
+        checksums = json.loads((bundle / "checksums.json").read_text())
+        checksums["sha256"][path] = hashlib.sha256(target.read_bytes()).hexdigest()
+        (bundle / "checksums.json").write_text(
+            json.dumps(checksums, sort_keys=True) + "\n"
+        )
+
+        with pytest.raises(
+            gin_smoke.QualificationError, match="oracle material is forbidden"
+        ):
+            self._validate(bundle)
+
+    def test_external_git_anchor_is_required(self, tmp_path: Path):
+        bundle = self._bundle(tmp_path)
+
+        with pytest.raises(
+            gin_smoke.QualificationError, match="wrong benchmark Git SHA"
+        ):
+            self._validate(bundle, git_sha="b" * 40)
+
+    def test_missing_cell_is_rejected(self, tmp_path: Path):
+        bundle = self._bundle(tmp_path)
+        (bundle / "cells" / "codegraph.json").unlink()
+
+        with pytest.raises(
+            gin_smoke.QualificationError,
+            match="missing, duplicate, or unexpected",
+        ):
+            self._validate(bundle)
 
 
 class TestScenarioRegistry:

--- a/tests/unit/test_benchmark_harness.py
+++ b/tests/unit/test_benchmark_harness.py
@@ -153,7 +153,7 @@ class TestGinSmokeQualification:
                 "cells/native.json",
                 "input_fingerprint",
                 "wrong",
-                "input fingerprint mismatch",
+                "mixed or invalid cell",
             ),
             (
                 "cells/native.json",
@@ -352,7 +352,11 @@ class TestGinSmokeQualification:
 
     @pytest.mark.parametrize(
         ("field", "value"),
-        [("ground_truth", "secret"), ("expected_arms", None)],
+        [
+            ("ground_truth", "secret"),
+            ("expected_arms", None),
+            ("question_sha256", ""),
+        ],
     )
     def test_manifest_schema_is_exact(
         self, tmp_path: Path, field: str, value: object


### PR DESCRIPTION
## Objective

Implements NO1-001A and advances #1196. This is infrastructure qualification only (E0), not a competitive result.

## What changed

- adds a deterministic three-arm fixture bundle for native, tree-sitter-analyzer, and CodeGraph
- isolates checkout, MCP, index, and artifact namespaces per arm
- validates exact cell/policy/transcript schemas, tool isolation, disabled network, no retries, no oracle material, and E0-only claims
- anchors the bundle with an externally retained digest so internal checksum recomputation cannot certify tampering
- adds public create/validate/replay commands; replay is atomic and byte-identical

## Evidence

- `uv run pytest tests/unit/test_benchmark_harness.py -q` — 145 passed
- `uv run pytest -q` — 1309 passed, 7 skipped
- Ruff and MyPy pass
- patch coverage gate: no added executable misses
- public create/validate/replay smoke produced 12 byte-identical files
- independent Codex red-team rounds found and drove fixes for untracked delivery, config fingerprint recomputation, transcript semantics, non-object JSON, embedded oracle fields, network semantic tampering, external checksum anchoring, and exact Cell schemas

## Claim boundary

`publishable=false`, `evidence_level=E0`, `backend_executed=false`, `index_created=false`, `model_executed=false`, `dominance_allowed=false`, `winner=null`. No model/backend spend or competitive claim.

## Rollback

Revert commit `147cd282`; no product code, persistent index, or external evidence is modified.

Closes #1196 after merge.