### PR TITLE
feat(benchmarks): preflight frozen Smoke models

### DIFF
--- a/benchmarks/codegraph_compare/README.md
+++ b/benchmarks/codegraph_compare/README.md
@@ -170,6 +170,33 @@ uv run python benchmarks/codegraph_compare/run.py phase full-warm --agent-backen
 uv run python benchmarks/codegraph_compare/run.py phase cold --agent-backend codex
 ```
 
+### Manifest-bound Gin Smoke
+
+Before freezing a real three-arm Gin Smoke, prove that the exact Codex model is
+available without exposing the repository, benchmark question, or oracle:
+
+```bash
+uv run python -m benchmarks.codegraph_compare.smoke_preflight \
+  --model gpt-5.4 \
+  --output .benchmark-runs/no1-001c/model-preflight.json
+```
+
+Then pass that immutable evidence to the plan freezer:
+
+```bash
+uv run python -m benchmarks.codegraph_compare.smoke_plan \
+  --checkout-root .benchmark-runs/no1-001c/checkouts \
+  --destination .benchmark-runs/no1-001c/frozen \
+  --model-preflight .benchmark-runs/no1-001c/model-preflight.json \
+  --model gpt-5.4 \
+  --session-id NO1-001C-PRIMARY
+```
+
+The freezer rejects failed, stale, future-dated, differently authenticated,
+different-model, or different-CLI preflight evidence before it creates the
+destination or reads benchmark questions. The evidence is copied into the
+immutable plan and included in bundle checksums and byte-identical replay.
+
 ---
 
 ## Reading the Summary Table

--- a/benchmarks/codegraph_compare/smoke_bundle.py
+++ b/benchmarks/codegraph_compare/smoke_bundle.py
@@ -15,11 +15,13 @@ from benchmarks.codegraph_compare.integrity import (
 )
 from benchmarks.codegraph_compare.schemas import RunRecordV1, parse_run_record
 from benchmarks.codegraph_compare.smoke_policy import audit_codex_transcript
+from benchmarks.codegraph_compare.smoke_preflight import validate_model_preflight
 
 _PLAN_FILES = (
     "eligibility.json",
     "experiment-manifest.json",
     "index-evidence.json",
+    "model-preflight.json",
     "workspace-evidence.json",
 )
 
@@ -112,6 +114,11 @@ def create_smoke_bundle(
     for name in _PLAN_FILES:
         (plan_target / name).write_bytes((plan_dir / name).read_bytes())
     manifest = parse_manifest_v1(_json(plan_target / "experiment-manifest.json"))
+    validate_model_preflight(
+        plan_target / "model-preflight.json",
+        expected_model=manifest.model,
+        expected_cli_fingerprint=manifest.agent_cli_fingerprint,
+    )
     evidence_target = destination / "evidence"
     _copy_tree_files(experiment_dir, evidence_target)
     artifact_target = destination / "artifacts"
@@ -197,6 +204,11 @@ def validate_smoke_bundle(bundle: Path, *, external_digest: str) -> dict[str, An
             raise ValueError(f"bundle checksum mismatch: {relative}")
 
     manifest = parse_manifest_v1(_json(bundle / "plan/experiment-manifest.json"))
+    validate_model_preflight(
+        bundle / "plan/model-preflight.json",
+        expected_model=manifest.model,
+        expected_cli_fingerprint=manifest.agent_cli_fingerprint,
+    )
     events = _registry(bundle / "registry.jsonl", manifest.experiment_id)
     runs = _runs(bundle / "evidence/runs.jsonl")
     _validate_policy_evidence(bundle, runs)

--- a/benchmarks/codegraph_compare/smoke_plan.py
+++ b/benchmarks/codegraph_compare/smoke_plan.py
@@ -32,6 +32,7 @@ from benchmarks.codegraph_compare.smoke_evidence import (
     index_content_hash,
     produce_gin_index_evidence,
 )
+from benchmarks.codegraph_compare.smoke_preflight import validate_model_preflight
 
 ARMS = ("native-only", "tsa-warm", "codegraph-warm")
 INDEXED_ARMS = ("tsa-warm", "codegraph-warm")
@@ -149,6 +150,7 @@ def freeze_smoke_plan(
     benchmark_repo: Path,
     checkout_root: Path,
     destination: Path,
+    model_preflight: Path,
     model: str,
     session_id: str,
     timeout_seconds: int,
@@ -161,13 +163,20 @@ def freeze_smoke_plan(
         benchmark_repo, "status", "--porcelain", "--untracked-files=no"
     ):
         raise ValueError("Benchmark implementation has tracked modifications")
+    tools, agent_fingerprint = tool_fingerprints(benchmark_repo)
+    preflight = validate_model_preflight(
+        model_preflight,
+        expected_model=model,
+        expected_cli_fingerprint=agent_fingerprint,
+        max_age_seconds=900,
+    )
     destination.mkdir(parents=True, exist_ok=False)
+    _write_exclusive(destination / "model-preflight.json", preflight)
     config_dir = benchmark_repo / "benchmarks" / "codegraph_compare"
     repo, arms, question = _load_selected_config(config_dir)
     checkouts = {
         arm: (checkout_root / arm / "gin").resolve() for arm in ARMS
     }
-    tools, agent_fingerprint = tool_fingerprints(benchmark_repo)
     index_path = destination / "index-evidence.json"
     eligibility_path = destination / "eligibility.json"
     eligibility = produce_gin_index_evidence(
@@ -267,6 +276,7 @@ def freeze_smoke_plan(
     )
     return {
         "manifest": manifest_path,
+        "model_preflight": destination / "model-preflight.json",
         "index_evidence": index_path,
         "eligibility": eligibility_path,
         "workspace": workspace_path,
@@ -277,6 +287,7 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--checkout-root", required=True, type=Path)
     parser.add_argument("--destination", required=True, type=Path)
+    parser.add_argument("--model-preflight", required=True, type=Path)
     parser.add_argument("--model", required=True)
     parser.add_argument("--session-id", required=True)
     parser.add_argument("--timeout-seconds", type=int, default=1200)
@@ -287,6 +298,7 @@ def main(argv: list[str] | None = None) -> int:
             benchmark_repo=Path.cwd(),
             checkout_root=args.checkout_root,
             destination=args.destination,
+            model_preflight=args.model_preflight,
             model=args.model,
             session_id=args.session_id,
             timeout_seconds=args.timeout_seconds,

--- a/benchmarks/codegraph_compare/smoke_preflight.py
+++ b/benchmarks/codegraph_compare/smoke_preflight.py
@@ -1,0 +1,174 @@
+"""Prove exact Codex model availability before freezing a Smoke manifest."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, cast
+
+from benchmarks.codegraph_compare.integrity import _sha256
+
+SCHEMA_VERSION = 1
+SENTINEL = "NO1_MODEL_PREFLIGHT_OK"
+
+
+def _codex_identity() -> dict[str, str]:
+    executable = shutil.which("codex")
+    if executable is None:
+        raise ValueError("Required executable is unavailable: codex")
+    binary = Path(executable).resolve()
+    version = subprocess.run(
+        ["codex", "--version"], capture_output=True, text=True, check=True
+    )
+    return {
+        "command": "codex --version",
+        "version": (version.stdout or version.stderr).strip(),
+        "executable": str(binary),
+        "executable_sha256": hashlib.sha256(binary.read_bytes()).hexdigest(),
+    }
+
+
+def _account_surface() -> str:
+    status = subprocess.run(
+        ["codex", "login", "status"], capture_output=True, text=True, check=True
+    )
+    output = (status.stdout or status.stderr).strip()
+    if output != "Logged in using ChatGPT":
+        raise ValueError(f"Unsupported or ambiguous Codex account surface: {output}")
+    return "ChatGPT"
+
+
+def _agent_message(stdout: str) -> str:
+    messages: list[str] = []
+    for line in stdout.splitlines():
+        event = json.loads(line)
+        item = event.get("item", {})
+        if event.get("type") == "item.completed" and item.get("type") == "agent_message":
+            text = item.get("text")
+            if not isinstance(text, str):
+                raise ValueError("Model preflight agent message is not text")
+            messages.append(text)
+    if messages != [SENTINEL]:
+        raise ValueError("Model preflight did not return the exact terminal sentinel")
+    return messages[0]
+
+
+def run_model_preflight(
+    *, model: str, output_path: Path, timeout_seconds: int = 120
+) -> dict[str, Any]:
+    """Call an exact model outside the benchmark tree and write immutable evidence."""
+
+    identity = _codex_identity()
+    account_surface = _account_surface()
+    with tempfile.TemporaryDirectory(prefix="no1-model-preflight-") as directory:
+        result = subprocess.run(
+            [
+                "codex",
+                "exec",
+                "--model",
+                model,
+                "--sandbox",
+                "read-only",
+                "--ephemeral",
+                "--ignore-user-config",
+                "--skip-git-repo-check",
+                "--json",
+                SENTINEL,
+            ],
+            cwd=directory,
+            env={**os.environ, "CODEX_NETWORK_DISABLED": "1"},
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            check=True,
+        )
+    _agent_message(result.stdout)
+    evidence = {
+        "schema_version": SCHEMA_VERSION,
+        "status": "PASSED",
+        "provider": "OpenAI",
+        "account_surface": account_surface,
+        "model": model,
+        "checked_at": datetime.now(timezone.utc).isoformat(),
+        "agent_cli": identity,
+        "agent_cli_fingerprint": _sha256(identity),
+        "sentinel_sha256": hashlib.sha256(SENTINEL.encode()).hexdigest(),
+    }
+    with output_path.open("x", encoding="utf-8") as stream:
+        json.dump(evidence, stream, indent=2, sort_keys=True)
+        stream.write("\n")
+    return evidence
+
+
+def validate_model_preflight(
+    path: Path,
+    *,
+    expected_model: str,
+    expected_cli_fingerprint: str,
+    max_age_seconds: int | None = None,
+) -> dict[str, Any]:
+    """Reject stale, failed, ambiguous, or differently bound preflight evidence."""
+
+    evidence = cast(dict[str, Any], json.loads(path.read_text(encoding="utf-8")))
+    required = {
+        "schema_version",
+        "status",
+        "provider",
+        "account_surface",
+        "model",
+        "checked_at",
+        "agent_cli",
+        "agent_cli_fingerprint",
+        "sentinel_sha256",
+    }
+    if set(evidence) != required:
+        raise ValueError("Model preflight evidence has an invalid field set")
+    if evidence["schema_version"] != SCHEMA_VERSION or evidence["status"] != "PASSED":
+        raise ValueError("Model preflight evidence is not a successful V1 record")
+    if evidence["provider"] != "OpenAI" or evidence["account_surface"] != "ChatGPT":
+        raise ValueError("Model preflight provider/account surface is not approved")
+    if evidence["model"] != expected_model:
+        raise ValueError("Model preflight does not match the requested model")
+    if evidence["agent_cli_fingerprint"] != expected_cli_fingerprint:
+        raise ValueError("Model preflight Codex CLI fingerprint is stale or mismatched")
+    if evidence["sentinel_sha256"] != hashlib.sha256(SENTINEL.encode()).hexdigest():
+        raise ValueError("Model preflight sentinel is invalid")
+    checked_at = datetime.fromisoformat(evidence["checked_at"])
+    if checked_at.tzinfo is None:
+        raise ValueError("Model preflight timestamp must include a timezone")
+    if max_age_seconds is not None:
+        age = (datetime.now(timezone.utc) - checked_at).total_seconds()
+        if age < 0 or age > max_age_seconds:
+            raise ValueError("Model preflight is stale or has a future timestamp")
+    return evidence
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--timeout-seconds", type=int, default=120)
+    args = parser.parse_args(argv)
+    try:
+        evidence = run_model_preflight(
+            model=args.model,
+            output_path=args.output,
+            timeout_seconds=args.timeout_seconds,
+        )
+    except (OSError, subprocess.SubprocessError, ValueError, json.JSONDecodeError) as exc:
+        print(f"Model preflight failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(evidence, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_benchmark_harness.py
+++ b/tests/unit/test_benchmark_harness.py
@@ -3241,6 +3241,24 @@ class TestGinSmokeBundle:
         (plan / "experiment-manifest.json").write_text(
             json.dumps(asdict(manifest)), encoding="utf-8"
         )
+        from benchmarks.codegraph_compare.smoke_preflight import SENTINEL
+
+        (plan / "model-preflight.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "status": "PASSED",
+                    "provider": "OpenAI",
+                    "account_surface": "ChatGPT",
+                    "model": manifest.model,
+                    "checked_at": "2026-07-31T00:00:00+00:00",
+                    "agent_cli": {},
+                    "agent_cli_fingerprint": manifest.agent_cli_fingerprint,
+                    "sentinel_sha256": hashlib.sha256(SENTINEL.encode()).hexdigest(),
+                }
+            ),
+            encoding="utf-8",
+        )
         for name in (
             "eligibility.json",
             "index-evidence.json",
@@ -4887,3 +4905,112 @@ class TestBenchmarkExperimentIntegrity:
         assert tuple(item.code for item in verdict.violations) == (
             "REGISTRY_TERMINAL_FAILURE",
         )
+
+
+class TestSmokeModelPreflight:
+    def test_preflight_runs_exact_model_outside_benchmark_tree(self, tmp_path: Path):
+        from benchmarks.codegraph_compare import smoke_preflight
+
+        identity = {
+            "command": "codex --version",
+            "version": "codex-cli 1.2.3",
+            "executable": "/tools/codex",
+            "executable_sha256": "a" * 64,
+        }
+        event = json.dumps(
+            {
+                "type": "item.completed",
+                "item": {
+                    "type": "agent_message",
+                    "text": smoke_preflight.SENTINEL,
+                },
+            }
+        )
+        output = tmp_path / "preflight.json"
+        completed = subprocess.CompletedProcess([], 0, stdout=event, stderr="")
+
+        with (
+            patch.object(smoke_preflight, "_codex_identity", return_value=identity),
+            patch.object(smoke_preflight, "_account_surface", return_value="ChatGPT"),
+            patch.object(smoke_preflight.subprocess, "run", return_value=completed) as run,
+        ):
+            evidence = smoke_preflight.run_model_preflight(
+                model="gpt-fixture", output_path=output
+            )
+
+        command = run.call_args.args[0]
+        assert command[command.index("--model") + 1] == "gpt-fixture"
+        assert "--ephemeral" in command
+        assert "--ignore-user-config" in command
+        assert "--skip-git-repo-check" in command
+        assert Path(run.call_args.kwargs["cwd"]) != Path.cwd()
+        assert evidence["status"] == "PASSED"
+        assert json.loads(output.read_text()) == evidence
+
+    @pytest.mark.parametrize(
+        ("field", "value", "message"),
+        [
+            ("status", "FAILED", "not a successful V1 record"),
+            ("model", "wrong-model", "does not match"),
+            ("account_surface", "API", "not approved"),
+            ("agent_cli_fingerprint", "stale", "stale or mismatched"),
+        ],
+    )
+    def test_preflight_rejects_unbound_evidence(
+        self, tmp_path: Path, field: str, value: str, message: str
+    ):
+        from benchmarks.codegraph_compare import smoke_preflight
+
+        evidence = {
+            "schema_version": 1,
+            "status": "PASSED",
+            "provider": "OpenAI",
+            "account_surface": "ChatGPT",
+            "model": "gpt-fixture",
+            "checked_at": "2026-07-31T00:00:00+00:00",
+            "agent_cli": {},
+            "agent_cli_fingerprint": "bound",
+            "sentinel_sha256": hashlib.sha256(
+                smoke_preflight.SENTINEL.encode()
+            ).hexdigest(),
+        }
+        evidence[field] = value
+        path = tmp_path / "preflight.json"
+        path.write_text(json.dumps(evidence))
+
+        with pytest.raises(ValueError, match=message):
+            smoke_preflight.validate_model_preflight(
+                path,
+                expected_model="gpt-fixture",
+                expected_cli_fingerprint="bound",
+            )
+
+    def test_preflight_rejects_stale_evidence_before_freeze(self, tmp_path: Path):
+        from benchmarks.codegraph_compare import smoke_preflight
+
+        path = tmp_path / "preflight.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "status": "PASSED",
+                    "provider": "OpenAI",
+                    "account_surface": "ChatGPT",
+                    "model": "gpt-fixture",
+                    "checked_at": "2020-01-01T00:00:00+00:00",
+                    "agent_cli": {},
+                    "agent_cli_fingerprint": "bound",
+                    "sentinel_sha256": hashlib.sha256(
+                        smoke_preflight.SENTINEL.encode()
+                    ).hexdigest(),
+                }
+            )
+        )
+
+        with pytest.raises(ValueError, match="stale or has a future timestamp"):
+            smoke_preflight.validate_model_preflight(
+                path,
+                expected_model="gpt-fixture",
+                expected_cli_fingerprint="bound",
+                max_age_seconds=900,
+            )


### PR DESCRIPTION
## Objective

Implements the model-availability qualification stage of #1201 (`NO1-001C`). No benchmark result or winner claim is included in this PR.

## What changed

- adds an isolated Codex model preflight that sends only a fixed sentinel outside the benchmark tree
- records provider, ChatGPT account surface, exact model, timestamp, CLI identity, binary hash, and fingerprint
- rejects failed, stale, future-dated, wrong-model, wrong-account, and wrong-CLI evidence before creating a frozen plan
- copies preflight evidence into the immutable plan and binds it into bundle checksums and byte-identical replay
- documents the preflight-before-freeze sequence

## Real qualification

`gpt-5.4` passed on ChatGPT with `codex-cli 0.146.0` at `2026-07-31T10:55:37Z`. This local preflight is qualification evidence only; the new manifest and Gin Smoke will be frozen from the clean merged implementation SHA.

## Validation

- `uv run pytest tests/unit/test_benchmark_harness.py -q` — 208 passed
- focused coverage + patch coverage gate — no added executable misses
- `uv run pytest -q` — 1309 passed, 7 skipped
- MyPy, Ruff, and `git diff --check` — passed

## Claim boundary

E0 implementation/qualification only. `dominance_allowed=false`; no winner, quality, efficiency, or comparative claim.

## Rollback

Revert this PR. Existing NO1-001B evidence and digest are not modified.