### PR TITLE
fix(benchmarks): schema-bind model preflight

### DIFF
--- a/benchmarks/codegraph_compare/smoke_preflight.py
+++ b/benchmarks/codegraph_compare/smoke_preflight.py
@@ -56,9 +56,15 @@ def _agent_message(stdout: str) -> str:
             if not isinstance(text, str):
                 raise ValueError("Model preflight agent message is not text")
             messages.append(text)
-    if messages != [SENTINEL]:
+    if len(messages) != 1:
+        raise ValueError("Model preflight did not return exactly one terminal message")
+    try:
+        payload = json.loads(messages[0])
+    except json.JSONDecodeError as exc:
+        raise ValueError("Model preflight terminal message is not JSON") from exc
+    if payload != {"status": SENTINEL}:
         raise ValueError("Model preflight did not return the exact terminal sentinel")
-    return messages[0]
+    return SENTINEL
 
 
 def run_model_preflight(
@@ -69,6 +75,21 @@ def run_model_preflight(
     identity = _codex_identity()
     account_surface = _account_surface()
     with tempfile.TemporaryDirectory(prefix="no1-model-preflight-") as directory:
+        schema_path = Path(directory) / "output-schema.json"
+        schema_path.write_text(
+            json.dumps(
+                {
+                    "type": "object",
+                    "properties": {
+                        "status": {"type": "string", "const": SENTINEL},
+                    },
+                    "required": ["status"],
+                    "additionalProperties": False,
+                },
+                sort_keys=True,
+            ),
+            encoding="utf-8",
+        )
         result = subprocess.run(
             [
                 "codex",
@@ -81,7 +102,9 @@ def run_model_preflight(
                 "--ignore-user-config",
                 "--skip-git-repo-check",
                 "--json",
-                SENTINEL,
+                "--output-schema",
+                str(schema_path),
+                "Return the required JSON object.",
             ],
             cwd=directory,
             env={**os.environ, "CODEX_NETWORK_DISABLED": "1"},

--- a/tests/unit/test_benchmark_harness.py
+++ b/tests/unit/test_benchmark_harness.py
@@ -4909,6 +4909,7 @@ class TestBenchmarkExperimentIntegrity:
 
 class TestSmokeModelPreflight:
     def test_preflight_runs_exact_model_outside_benchmark_tree(self, tmp_path: Path):
+        # Issue #1201: unconstrained prompts produced "Acknowledged." intermittently.
         from benchmarks.codegraph_compare import smoke_preflight
 
         identity = {
@@ -4922,7 +4923,9 @@ class TestSmokeModelPreflight:
                 "type": "item.completed",
                 "item": {
                     "type": "agent_message",
-                    "text": smoke_preflight.SENTINEL,
+                    "text": json.dumps(
+                        {"status": smoke_preflight.SENTINEL}
+                    ),
                 },
             }
         )
@@ -4943,9 +4946,24 @@ class TestSmokeModelPreflight:
         assert "--ephemeral" in command
         assert "--ignore-user-config" in command
         assert "--skip-git-repo-check" in command
+        assert "--output-schema" in command
         assert Path(run.call_args.kwargs["cwd"]) != Path.cwd()
         assert evidence["status"] == "PASSED"
         assert json.loads(output.read_text()) == evidence
+
+    def test_preflight_rejects_unstructured_acknowledgement(self):
+        # Issue #1201: availability must be proven by schema-bound output.
+        from benchmarks.codegraph_compare import smoke_preflight
+
+        event = json.dumps(
+            {
+                "type": "item.completed",
+                "item": {"type": "agent_message", "text": "Acknowledged."},
+            }
+        )
+
+        with pytest.raises(ValueError, match="terminal message is not JSON"):
+            smoke_preflight._agent_message(event)
 
     @pytest.mark.parametrize(
         ("field", "value", "message"),


### PR DESCRIPTION
## Objective

Fixes the real NO1-001C preflight failure discovered while executing #1201 after PR #1202 merged.

## Root cause

The preflight prompt consisted only of the sentinel. `gpt-5.4` was available but legitimately answered `Acknowledged.`, so strict text equality rejected an available model. No manifest was created and no benchmark input was exposed.

## Fix

- pass a JSON Schema through Codex `--output-schema`
- constrain `status` with a schema-level `const`
- require exactly one terminal agent message
- parse it as JSON and require the exact object `{"status":"NO1_MODEL_PREFLIGHT_OK"}`
- retain strict failure for prose, malformed JSON, extra fields, or wrong sentinel

## Real verification

A fresh structured `gpt-5.4` preflight passed on ChatGPT / codex-cli 0.146.0 before any manifest freeze.

## Validation

- benchmark harness: 209 passed
- default gate: 1309 passed, 7 skipped
- MyPy, Ruff, diff check: passed

## Claim boundary

No benchmark result or comparative claim. The failed unstructured preflight produced no manifest.