### PR TITLE
fix(benchmarks): preserve bound index hashes in validation

### DIFF
--- a/benchmarks/codegraph_compare/_integrity_gate.py
+++ b/benchmarks/codegraph_compare/_integrity_gate.py
@@ -115,6 +115,7 @@ def _validate_manifest(manifest: ExperimentManifestV1) -> list[IntegrityViolatio
             expected_cells=manifest.expected_cells,
             required_arms=manifest.required_arms,
             indexed_arms=manifest.indexed_arms,
+            index_content_hashes=dict(manifest.index_content_hashes),
             tool_fingerprints=dict(manifest.tool_fingerprints),
             repo_commits=dict(manifest.repo_commits),
             repo_fingerprints=dict(manifest.repo_fingerprints),

--- a/tests/unit/test_benchmark_harness.py
+++ b/tests/unit/test_benchmark_harness.py
@@ -5017,6 +5017,34 @@ class TestBenchmarkExperimentIntegrity:
             "INVALID_MANIFEST_STRUCTURE",
         )
 
+    def test_bound_index_hashes_survive_manifest_normalization(self):
+        from benchmarks.codegraph_compare.integrity import (
+            validate_publishable_experiment,
+        )
+
+        manifest = _v1_manifest(
+            index_content_hashes={
+                "codegraph-warm": "codegraph-index-hash",
+                "tsa-warm": "tsa-index-hash",
+            }
+        )
+        runs = tuple(
+            _v1_run(manifest, cell.run_id) for cell in manifest.expected_cells
+        )
+
+        verdict = validate_publishable_experiment(
+            manifest,
+            registry=_registry_for(manifest),
+            runs=runs,
+            evals=tuple(_v1_eval(run) for run in runs),
+            reported_experiment_ids=(manifest.experiment_id,),
+        )
+
+        # Issue #1201: index-bound manifests must normalize with their hashes.
+        assert "INVALID_MANIFEST_STRUCTURE" not in {
+            item.code for item in verdict.violations
+        }
+
     def test_failed_registry_status_is_terminal(self):
         from benchmarks.codegraph_compare.integrity import (
             RegistryEvent,


### PR DESCRIPTION
Found by the independent NO1-001C red-team review for #1201.\n\nThe manifest validator normalized indexed manifests without passing index_content_hashes, falsely reporting INVALID_MANIFEST_STRUCTURE. This change preserves the bound hashes during normalization and adds an issue-linked regression test.\n\nVerification:\n- uv run pytest tests/unit/test_benchmark_harness.py -q (212 passed)\n- uv run pytest -q (1309 passed, 7 skipped)\n- patch coverage gate: no added executable misses\n- ruff and mypy passed\n- original immutable NO1-001C evidence now recomputes to the true terminal violations: REGISTRY_TERMINAL_FAILURE plus three REQUIRED_CELL_FAILED