### PR TITLE
test(security): budget whole-repository fixture canary

### DIFF
--- a/tests/unit/security/test_fixture_detector.py
+++ b/tests/unit/security/test_fixture_detector.py
@@ -183,6 +183,9 @@ class TestTier2Scan:
 
 
 class TestRealRepoRegression:
+    # Issue #1206: this deliberate whole-repository scan can exceed the
+    # five-second unit budget on macOS runners.
+    @pytest.mark.slow_ok
     def test_real_repo_finds_java_plugin(self) -> None:
         # Regression test for feedback_test-fixture-files (memory):
         # java_plugin.py IS a negative fixture in the real repo and the


### PR DESCRIPTION
## Summary

- mark the deliberate whole-repository fixture detector canary `slow_ok`
- document #1206 and the macOS runner reason directly beside the marker
- keep the global five-second unit budget unchanged

Fixes #1206.

## Evidence

After #1207 fixed the incidental evidence-count assertion, merged `develop` CI proved macOS 3.11 green. macOS 3.12 then completed the correct scan in 10.28s and failed only the global 5s budget; CI's diagnostic explicitly prescribes `slow_ok` for a real, documented cost.

## Verification

- `uv run pytest tests/unit/security/test_fixture_detector.py -q` — 32 passed
- `uv run pytest -q` — 1309 passed, 7 skipped
- TSA file health: B 89.7 unchanged
- change-impact exact focused command passed
- `git diff --check`
