### PR TITLE
fix(benchmarks): preserve smoke evidence integrity

### DIFF
--- a/benchmarks/codegraph_compare/smoke_evidence.py
+++ b/benchmarks/codegraph_compare/smoke_evidence.py
@@ -19,6 +19,53 @@ from benchmarks.codegraph_compare.integrity import _sha256
 from benchmarks.codegraph_compare.schemas import IndexStatsV1
 
 READINESS_ORACLE = "gin.Engine.ServeHTTP@gin.go"
+INDEX_LAYOUT = {
+    "tsa-warm": (".ast-cache", "index.db"),
+    "codegraph-warm": (".codegraph", "codegraph.db"),
+}
+
+
+def canonical_semantic_digest(database: Path) -> str:
+    """Hash every user table's schema and rows without creating sidecars."""
+
+    payload = []
+    uri = f"file:{database}?mode=ro&immutable=1"
+    with sqlite3.connect(uri, uri=True) as connection:
+        tables = connection.execute(
+            "SELECT name, sql FROM sqlite_master WHERE type='table' "
+            "AND name NOT LIKE 'sqlite_%' ORDER BY name"
+        ).fetchall()
+        for table, sql in tables:
+            columns = tuple(
+                row[1]
+                for row in connection.execute(
+                    f'PRAGMA table_info("{str(table).replace(chr(34), chr(34) * 2)}")'
+                ).fetchall()
+            )
+            quoted = str(table).replace('"', '""')
+            rows = connection.execute(f'SELECT * FROM "{quoted}"').fetchall()
+            canonical_rows = sorted(
+                json.dumps(
+                    [_semantic_value(value) for value in row],
+                    ensure_ascii=True,
+                    separators=(",", ":"),
+                )
+                for row in rows
+            )
+            payload.append((table, sql, columns, canonical_rows))
+    return hashlib.sha256(
+        json.dumps(payload, ensure_ascii=True, separators=(",", ":")).encode()
+    ).hexdigest()
+
+
+def _semantic_value(value: Any) -> tuple[str, Any]:
+    if value is None:
+        return ("null", None)
+    if isinstance(value, bytes):
+        return ("blob", value.hex())
+    return (type(value).__name__, value)
+
+
 _GENERATED_MARKER = "Code generated"
 _GENERATED_SUFFIX = "DO NOT EDIT."
 
@@ -50,11 +97,7 @@ def tracked_paths(repo_path: Path) -> tuple[str, ...]:
         check=True,
     )
     return tuple(
-        sorted(
-            path.decode("utf-8")
-            for path in result.stdout.split(b"\0")
-            if path
-        )
+        sorted(path.decode("utf-8") for path in result.stdout.split(b"\0") if path)
     )
 
 
@@ -68,11 +111,7 @@ def tracked_go_paths(repo_path: Path) -> tuple[str, ...]:
         check=True,
     )
     return tuple(
-        sorted(
-            path.decode("utf-8")
-            for path in result.stdout.split(b"\0")
-            if path
-        )
+        sorted(path.decode("utf-8") for path in result.stdout.split(b"\0") if path)
     )
 
 
@@ -86,7 +125,11 @@ def classify_go_paths(
     for relative in paths:
         path = repo_path / relative
         prefix = path.read_text(encoding="utf-8", errors="replace")[:2048]
-        target = generated if _GENERATED_MARKER in prefix and _GENERATED_SUFFIX in prefix else eligible
+        target = (
+            generated
+            if _GENERATED_MARKER in prefix and _GENERATED_SUFFIX in prefix
+            else eligible
+        )
         target.append(relative)
     return tuple(eligible), tuple(generated)
 
@@ -182,6 +225,67 @@ def _codegraph_readiness(repo_path: Path) -> bool:
             ("gin.go", "%ServeHTTP%"),
         ).fetchone()
     return row is not None
+
+
+def inspect_frozen_index(arm: str, index_root: Path) -> tuple[str, ...]:
+    """Validate one fixed arm snapshot without creating SQLite sidecars."""
+
+    if arm not in INDEX_LAYOUT:
+        raise ValueError(f"Unsupported indexed Smoke arm: {arm}")
+    _, database_name = INDEX_LAYOUT[arm]
+    database = index_root / database_name
+    regular_files = tuple(
+        sorted(
+            path.relative_to(index_root)
+            for path in index_root.rglob("*")
+            if path.is_file()
+        )
+    )
+    candidates = tuple(
+        path.as_posix()
+        for path in regular_files
+        if path.suffix in {".db", ".sqlite", ".sqlite3"}
+    )
+    if candidates != (database_name,):
+        raise ValueError(f"{arm} must contain exactly one primary database")
+    sidecars = tuple(
+        path.as_posix()
+        for path in regular_files
+        if path.name.endswith(("-wal", "-shm", "-journal"))
+    )
+    if sidecars:
+        raise ValueError(f"Frozen index contains SQLite sidecars: {sidecars}")
+    uri = f"file:{database}?mode=ro&immutable=1"
+    with sqlite3.connect(uri, uri=True) as connection:
+        if connection.execute("PRAGMA integrity_check").fetchone() != ("ok",):
+            raise ValueError(f"{arm} frozen database failed integrity_check")
+        if arm == "tsa-warm":
+            rows = connection.execute(
+                "SELECT file_path FROM ast_index ORDER BY file_path"
+            ).fetchall()
+            ready = connection.execute(
+                "SELECT symbols_json FROM ast_index WHERE file_path = 'gin.go'"
+            ).fetchone()
+            if not ready or "ServeHTTP" not in str(ready[0]):
+                raise ValueError(f"{arm} failed readiness oracle {READINESS_ORACLE}")
+        else:
+            columns = {
+                str(row[1])
+                for row in connection.execute("PRAGMA table_info(nodes)").fetchall()
+            }
+            if not {"name", "file_path"} <= columns:
+                raise ValueError("CodeGraph nodes schema lacks readiness columns")
+            rows = connection.execute(
+                "SELECT DISTINCT file_path FROM nodes "
+                "WHERE file_path IS NOT NULL AND file_path <> '' ORDER BY file_path"
+            ).fetchall()
+            ready = connection.execute(
+                "SELECT 1 FROM nodes WHERE file_path = ? AND name LIKE ? LIMIT 1",
+                ("gin.go", "%ServeHTTP%"),
+            ).fetchone()
+            if ready is None:
+                raise ValueError(f"{arm} failed readiness oracle {READINESS_ORACLE}")
+    return tuple(str(row[0]).replace("\\", "/") for row in rows)
 
 
 def _dir_size(path: Path) -> int:

--- a/benchmarks/codegraph_compare/smoke_evidence.py
+++ b/benchmarks/codegraph_compare/smoke_evidence.py
@@ -8,7 +8,7 @@ import sqlite3
 import subprocess
 import tempfile
 from collections.abc import Iterator
-from contextlib import contextmanager
+from contextlib import closing, contextmanager
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any
@@ -30,7 +30,7 @@ def canonical_semantic_digest(database: Path) -> str:
 
     payload = []
     uri = f"file:{database}?mode=ro&immutable=1"
-    with sqlite3.connect(uri, uri=True) as connection:
+    with closing(sqlite3.connect(uri, uri=True)) as connection:
         tables = connection.execute(
             "SELECT name, sql FROM sqlite_master WHERE type='table' "
             "AND name NOT LIKE 'sqlite_%' ORDER BY name"
@@ -185,7 +185,9 @@ def masked_paths(repo_path: Path, paths: tuple[str, ...]) -> Iterator[None]:
 
 def _tsa_indexed_paths(repo_path: Path) -> tuple[str, ...]:
     database = repo_path / ".ast-cache" / "index.db"
-    with sqlite3.connect(f"file:{database}?mode=ro", uri=True) as connection:
+    with closing(
+        sqlite3.connect(f"file:{database}?mode=ro", uri=True)
+    ) as connection:
         rows = connection.execute(
             "SELECT file_path FROM ast_index ORDER BY file_path"
         ).fetchall()
@@ -194,7 +196,9 @@ def _tsa_indexed_paths(repo_path: Path) -> tuple[str, ...]:
 
 def _codegraph_indexed_paths(repo_path: Path) -> tuple[str, ...]:
     database = repo_path / ".codegraph" / "codegraph.db"
-    with sqlite3.connect(f"file:{database}?mode=ro", uri=True) as connection:
+    with closing(
+        sqlite3.connect(f"file:{database}?mode=ro", uri=True)
+    ) as connection:
         rows = connection.execute(
             "SELECT DISTINCT file_path FROM nodes "
             "WHERE file_path IS NOT NULL AND file_path <> '' ORDER BY file_path"
@@ -204,7 +208,9 @@ def _codegraph_indexed_paths(repo_path: Path) -> tuple[str, ...]:
 
 def _tsa_readiness(repo_path: Path) -> bool:
     database = repo_path / ".ast-cache" / "index.db"
-    with sqlite3.connect(f"file:{database}?mode=ro", uri=True) as connection:
+    with closing(
+        sqlite3.connect(f"file:{database}?mode=ro", uri=True)
+    ) as connection:
         row = connection.execute(
             "SELECT symbols_json FROM ast_index WHERE file_path = 'gin.go'"
         ).fetchone()
@@ -213,7 +219,9 @@ def _tsa_readiness(repo_path: Path) -> bool:
 
 def _codegraph_readiness(repo_path: Path) -> bool:
     database = repo_path / ".codegraph" / "codegraph.db"
-    with sqlite3.connect(f"file:{database}?mode=ro", uri=True) as connection:
+    with closing(
+        sqlite3.connect(f"file:{database}?mode=ro", uri=True)
+    ) as connection:
         columns = {
             str(row[1])
             for row in connection.execute("PRAGMA table_info(nodes)").fetchall()
@@ -256,7 +264,7 @@ def inspect_frozen_index(arm: str, index_root: Path) -> tuple[str, ...]:
     if sidecars:
         raise ValueError(f"Frozen index contains SQLite sidecars: {sidecars}")
     uri = f"file:{database}?mode=ro&immutable=1"
-    with sqlite3.connect(uri, uri=True) as connection:
+    with closing(sqlite3.connect(uri, uri=True)) as connection:
         if connection.execute("PRAGMA integrity_check").fetchone() != ("ok",):
             raise ValueError(f"{arm} frozen database failed integrity_check")
         if arm == "tsa-warm":

--- a/benchmarks/codegraph_compare/smoke_execution.py
+++ b/benchmarks/codegraph_compare/smoke_execution.py
@@ -19,12 +19,21 @@ from benchmarks.codegraph_compare.schemas import (
     IndexStatsV1,
     RunRecordV1,
 )
+from benchmarks.codegraph_compare.smoke_evidence import (
+    INDEX_LAYOUT,
+    canonical_semantic_digest,
+    index_content_hash,
+)
 from benchmarks.codegraph_compare.smoke_policy import (
     PolicyAudit,
     audit_codex_transcript,
 )
 from benchmarks.codegraph_compare.smoke_workspace import (
+    IndexContentDriftError,
     SmokeWorkspaceV1,
+    audit_runtime_index,
+    cleanup_runtime_index,
+    materialize_runtime_index,
     validate_index_content_v1,
     validate_workspace_v1,
 )
@@ -64,6 +73,8 @@ def build_v1_attempt(
     if not policy_audit.ok:
         status = BenchmarkStatus.INVALID
         blocker = "POLICY_AUDIT:" + ",".join(policy_audit.violations)
+        if error:
+            blocker += f";PRODUCT_FAILURE:{error}"
     elif error:
         status = BenchmarkStatus.PRODUCT_FAILURE
         blocker = str(error)
@@ -116,9 +127,7 @@ def build_v1_attempt(
         estimated_cost_usd=estimated_cost,
         cost_source=cost_source,
         cached_input_tokens=int(legacy_record.get("cached_input_tokens", 0)),
-        reasoning_output_tokens=int(
-            legacy_record.get("reasoning_output_tokens", 0)
-        ),
+        reasoning_output_tokens=int(legacy_record.get("reasoning_output_tokens", 0)),
         cache_read_tokens=int(legacy_record.get("cache_read_tokens", 0)),
         cache_creation_tokens=int(legacy_record.get("cache_creation_tokens", 0)),
         num_turns=int(legacy_record.get("num_turns", 0)),
@@ -218,17 +227,59 @@ def run_manifest_smoke(
     failed = 0
     for cell in manifest.expected_cells:
         legacy: dict[str, Any] | None = None
+        runtime_state: dict[str, Any] | None = None
+        runtime_path: Path | None = None
         try:
             _ = arms[cell.arm]
             question = questions[(cell.repo, cell.question_id)]
-            workspace_cell = (
-                workspace.cell(cell.arm) if workspace is not None else None
-            )
+            workspace_cell = workspace.cell(cell.arm) if workspace is not None else None
             repo_path = (
                 workspace_cell.checkout_path
                 if workspace_cell is not None
                 else repo_path_resolver(repos[cell.repo])
             )
+            if workspace_cell is not None and cell.arm in manifest.indexed_arms:
+                stats = supplied_index_stats[(cell.repo, cell.arm)]
+                expected_hash = dict(manifest.index_content_hashes)[cell.arm]
+                expected_paths = stats.indexed_paths
+                _, database_name = INDEX_LAYOUT[cell.arm]
+                frozen_before = index_content_hash(workspace_cell.index_path)
+                runtime_state = {
+                    "schema_version": 1,
+                    "experiment_id": manifest.experiment_id,
+                    "manifest_hash": manifest.manifest_hash,
+                    "session_id": manifest.primary_session_id,
+                    "run_id": cell.run_id,
+                    "repo": cell.repo,
+                    "arm": cell.arm,
+                    "repeat": cell.repeat,
+                    "expected_hash": expected_hash,
+                    "expected_paths": list(expected_paths),
+                    "frozen_hash_before": frozen_before,
+                    "runtime_hash_before": None,
+                    "runtime_hash_after": None,
+                    "frozen_hash_after": None,
+                    "semantic_digest_before": canonical_semantic_digest(
+                        workspace_cell.index_path / database_name
+                    ),
+                    "semantic_digest_after": None,
+                    "post_paths": None,
+                    "materialized": False,
+                    "runtime_mutated": None,
+                    "cleanup_status": "NOT_STARTED",
+                    "failure_codes": [],
+                }
+                if frozen_before != expected_hash:
+                    raise IndexContentDriftError("frozen index content hash mismatch")
+                runtime_path = materialize_runtime_index(
+                    workspace_cell.index_path,
+                    repo_path,
+                    cell.arm,
+                    expected_hash,
+                    expected_paths,
+                )
+                runtime_state["materialized"] = True
+                runtime_state["runtime_hash_before"] = index_content_hash(runtime_path)
             adapter_key = (cell.repo, cell.arm)
             if adapter_key not in adapters:
                 adapters[adapter_key] = adapter_factory(cell.arm)
@@ -261,7 +312,11 @@ def run_manifest_smoke(
             transcript = Path(str(legacy.get("transcript_path", "")))
             audit = audit_codex_transcript(transcript, cell.arm)
         except Exception as exc:  # noqa: BLE001 - every cell needs a terminal record
-            marker = f"EXECUTION_EXCEPTION:{type(exc).__name__}"
+            marker = (
+                "INDEX_CONTENT_DRIFT"
+                if isinstance(exc, IndexContentDriftError)
+                else f"EXECUTION_EXCEPTION:{type(exc).__name__}"
+            )
             if legacy is None:
                 legacy = _exception_record(manifest, cell, exc)
                 audit = PolicyAudit(
@@ -273,7 +328,6 @@ def run_manifest_smoke(
                 )
             else:
                 legacy = dict(legacy)
-                legacy["error"] = f"{type(exc).__name__}: {exc}"
                 transcript_path = str(legacy.get("transcript_path", ""))
                 transcript_audit = audit_codex_transcript(
                     Path(transcript_path), cell.arm
@@ -285,6 +339,64 @@ def run_manifest_smoke(
                     transcript_audit.observed_mcp_tools,
                     (marker, *transcript_audit.violations),
                 )
+        if runtime_state is not None:
+            runtime_failures: list[str] = []
+            if runtime_path is not None and runtime_path.exists():
+                try:
+                    runtime_state["runtime_hash_after"] = index_content_hash(
+                        runtime_path
+                    )
+                    digest, paths = audit_runtime_index(
+                        runtime_path,
+                        workspace_cell.artifact_path / f".{cell.run_id}.runtime-audit",
+                        cell.arm,
+                        tuple(runtime_state["expected_paths"]),
+                    )
+                    runtime_state["semantic_digest_after"] = digest
+                    runtime_state["post_paths"] = list(paths)
+                    if digest != runtime_state["semantic_digest_before"]:
+                        runtime_failures.append("RUNTIME_SEMANTIC_DRIFT")
+                except Exception as exc:  # noqa: BLE001 - preserve all stages
+                    runtime_failures.append(
+                        f"RUNTIME_POST_AUDIT_FAILED:{type(exc).__name__}"
+                    )
+            try:
+                runtime_state["frozen_hash_after"] = index_content_hash(
+                    workspace_cell.index_path
+                )
+                if runtime_state["frozen_hash_after"] != runtime_state["expected_hash"]:
+                    runtime_failures.append("INDEX_CONTENT_DRIFT")
+            except Exception as exc:  # noqa: BLE001
+                runtime_failures.append(f"FROZEN_POSTCHECK_FAILED:{type(exc).__name__}")
+            if runtime_path is not None:
+                try:
+                    cleanup_runtime_index(
+                        workspace_cell.checkout_path,
+                        INDEX_LAYOUT[cell.arm][0],
+                        runtime_path,
+                    )
+                    runtime_state["cleanup_status"] = "SUCCESS"
+                except Exception as exc:  # noqa: BLE001
+                    runtime_state["cleanup_status"] = "FAILED"
+                    runtime_failures.append(
+                        f"RUNTIME_CLEANUP_FAILED:{type(exc).__name__}"
+                    )
+            runtime_state["runtime_mutated"] = (
+                runtime_state["runtime_hash_after"]
+                != runtime_state["runtime_hash_before"]
+                if runtime_state["runtime_hash_after"] is not None
+                else None
+            )
+            runtime_state["failure_codes"] = runtime_failures
+            if runtime_failures:
+                audit = PolicyAudit(
+                    audit.arm,
+                    audit.transcript_path,
+                    audit.observed_mcp_servers,
+                    audit.observed_mcp_tools,
+                    (*runtime_failures, *audit.violations),
+                )
+            _write_runtime_audit(results_dir, manifest, cell, runtime_state)
         try:
             attempt = build_v1_attempt(
                 manifest,
@@ -316,6 +428,23 @@ def run_manifest_smoke(
         if attempt.status is not BenchmarkStatus.SUCCESS:
             failed += 1
     return 0 if failed == 0 else 1
+
+
+def _write_runtime_audit(
+    results_dir: Path,
+    manifest: ExperimentManifestV1,
+    cell: ExpectedCellV1,
+    payload: dict[str, Any],
+) -> Path:
+    experiment = results_dir / "experiments" / manifest.manifest_hash
+    experiment.mkdir(parents=True, exist_ok=True)
+    path = experiment / f"runtime_index_{cell.run_id}.json"
+    with path.open("x", encoding="utf-8") as stream:
+        json.dump(
+            payload, stream, ensure_ascii=True, separators=(",", ":"), sort_keys=True
+        )
+        stream.write("\n")
+    return path
 
 
 def _exception_record(
@@ -371,9 +500,7 @@ def run_manifest_setup_gate(
 
     if workspace is not None:
         try:
-            if set(dict(manifest.index_content_hashes)) != set(
-                manifest.indexed_arms
-            ):
+            if set(dict(manifest.index_content_hashes)) != set(manifest.indexed_arms):
                 raise ValueError(
                     "manifest-backed execution requires bound index content hashes"
                 )

--- a/benchmarks/codegraph_compare/smoke_plan.py
+++ b/benchmarks/codegraph_compare/smoke_plan.py
@@ -33,6 +33,7 @@ from benchmarks.codegraph_compare.smoke_evidence import (
     produce_gin_index_evidence,
 )
 from benchmarks.codegraph_compare.smoke_preflight import validate_model_preflight
+from benchmarks.codegraph_compare.smoke_workspace import create_frozen_index_snapshot
 
 ARMS = ("native-only", "tsa-warm", "codegraph-warm")
 INDEXED_ARMS = ("tsa-warm", "codegraph-warm")
@@ -121,9 +122,7 @@ def _load_selected_config(config_dir: Path) -> tuple[dict, list[dict], dict]:
         next(item for item in arms["arms"] if item["id"] == arm) for arm in ARMS
     ]
     question = next(
-        item
-        for item in questions["questions"]
-        if item["id"] == "gin-route-matching"
+        item for item in questions["questions"] if item["id"] == "gin-route-matching"
     )
     return repo, selected_arms, question
 
@@ -145,6 +144,67 @@ def _write_exclusive(path: Path, payload: Any) -> None:
         stream.write("\n")
 
 
+def freeze_index_baselines(
+    checkouts: dict[str, Path],
+    checkout_root: Path,
+    indexed_paths: dict[str, tuple[str, ...]],
+) -> dict[str, Path]:
+    """Checkpoint and move warm indexes into isolated frozen namespaces."""
+
+    layout = (
+        ("tsa-warm", ".ast-cache"),
+        ("codegraph-warm", ".codegraph"),
+    )
+    paths = {
+        arm: (
+            checkouts[arm] / index_name,
+            (checkout_root / "frozen-indexes" / arm / index_name).resolve(),
+        )
+        for arm, index_name in layout
+    }
+    for _source, target in paths.values():
+        if target.exists() or target.parent.exists():
+            raise ValueError(f"Frozen index destination already exists: {target}")
+    created: list[Path] = []
+    try:
+        for arm, (source, target) in paths.items():
+            create_frozen_index_snapshot(source, target, arm, indexed_paths[arm])
+            created.append(target)
+    except Exception:
+        for target in reversed(created):
+            shutil.rmtree(target.parent)
+        raise
+    quarantines = {
+        arm: source.with_name(source.name + ".freeze-quarantine")
+        for arm, (source, _) in paths.items()
+    }
+    if any(os.path.lexists(path) for path in quarantines.values()):
+        for target in reversed(created):
+            shutil.rmtree(target.parent)
+        raise ValueError("Frozen index quarantine already exists")
+    renamed: list[tuple[Path, Path]] = []
+    try:
+        for arm, (source, _) in paths.items():
+            quarantine = quarantines[arm]
+            source.rename(quarantine)
+            renamed.append((source, quarantine))
+    except OSError:
+        for source, quarantine in reversed(renamed):
+            quarantine.rename(source)
+        for target in reversed(created):
+            shutil.rmtree(target.parent)
+        raise
+    try:
+        for quarantine in quarantines.values():
+            shutil.rmtree(quarantine)
+    except OSError as exc:
+        raise RuntimeError(
+            "Frozen index committed but quarantine cleanup failed; "
+            "frozen authority and recoverable quarantine were preserved"
+        ) from exc
+    return {arm: target for arm, (_, target) in paths.items()}
+
+
 def freeze_smoke_plan(
     *,
     benchmark_repo: Path,
@@ -159,9 +219,7 @@ def freeze_smoke_plan(
     """Build indexes and freeze manifest/workspace evidence before model use."""
 
     benchmark_repo = benchmark_repo.resolve()
-    if _git_output(
-        benchmark_repo, "status", "--porcelain", "--untracked-files=no"
-    ):
+    if _git_output(benchmark_repo, "status", "--porcelain", "--untracked-files=no"):
         raise ValueError("Benchmark implementation has tracked modifications")
     tools, agent_fingerprint = tool_fingerprints(benchmark_repo)
     preflight = validate_model_preflight(
@@ -174,9 +232,7 @@ def freeze_smoke_plan(
     _write_exclusive(destination / "model-preflight.json", preflight)
     config_dir = benchmark_repo / "benchmarks" / "codegraph_compare"
     repo, arms, question = _load_selected_config(config_dir)
-    checkouts = {
-        arm: (checkout_root / arm / "gin").resolve() for arm in ARMS
-    }
+    checkouts = {arm: (checkout_root / arm / "gin").resolve() for arm in ARMS}
     index_path = destination / "index-evidence.json"
     eligibility_path = destination / "eligibility.json"
     eligibility = produce_gin_index_evidence(
@@ -186,11 +242,14 @@ def freeze_smoke_plan(
         eligibility_path=eligibility_path,
         tool_fingerprints=tools,
     )
+    evidence_cells = json.loads(index_path.read_text(encoding="utf-8"))["cells"]
+    evidence_paths = {
+        str(cell["arm_id"]): tuple(cell["index_stats"]["indexed_paths"])
+        for cell in evidence_cells
+    }
+    frozen_indexes = freeze_index_baselines(checkouts, checkout_root, evidence_paths)
     index_content_hashes = {
-        "tsa-warm": index_content_hash(checkouts["tsa-warm"] / ".ast-cache"),
-        "codegraph-warm": index_content_hash(
-            checkouts["codegraph-warm"] / ".codegraph"
-        ),
+        arm: index_content_hash(path) for arm, path in frozen_indexes.items()
     }
     expected_cells = tuple(
         ExpectedCellV1(
@@ -239,9 +298,7 @@ def freeze_smoke_plan(
         eligible_paths={"gin": tuple(eligibility["eligible_paths"])},
         eligible_paths_hashes={"gin": eligibility["eligible_paths_hash"]},
         parse_error_allowlists={"gin": ()},
-        required_readiness_oracles=dict.fromkeys(
-            INDEXED_ARMS, (READINESS_ORACLE,)
-        ),
+        required_readiness_oracles=dict.fromkeys(INDEXED_ARMS, (READINESS_ORACLE,)),
         index_content_hashes=index_content_hashes,
     )
     artifacts = destination / "artifacts"
@@ -251,8 +308,8 @@ def freeze_smoke_plan(
         artifact.mkdir(parents=True)
         index_dir = {
             "native-only": None,
-            "tsa-warm": checkouts[arm] / ".ast-cache",
-            "codegraph-warm": checkouts[arm] / ".codegraph",
+            "tsa-warm": frozen_indexes.get(arm),
+            "codegraph-warm": frozen_indexes.get(arm),
         }[arm]
         workspace_cells.append(
             {

--- a/benchmarks/codegraph_compare/smoke_workspace.py
+++ b/benchmarks/codegraph_compare/smoke_workspace.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import hashlib
 import os
+import shutil
+import sqlite3
 import stat
 import subprocess
 from dataclasses import dataclass
@@ -11,7 +14,10 @@ from typing import Any
 
 from benchmarks.codegraph_compare.integrity import ExperimentManifestV1
 from benchmarks.codegraph_compare.smoke_evidence import (
+    INDEX_LAYOUT,
+    canonical_semantic_digest,
     index_content_hash,
+    inspect_frozen_index,
     repository_fingerprint,
     tracked_paths,
 )
@@ -25,9 +31,11 @@ _INDEX_DIRS = {
 _WORKSPACE_KEYS = frozenset(
     {"schema_version", "experiment_id", "manifest_hash", "cells"}
 )
-_CELL_KEYS = frozenset(
-    {"arm_id", "checkout_path", "index_path", "artifact_path"}
-)
+_CELL_KEYS = frozenset({"arm_id", "checkout_path", "index_path", "artifact_path"})
+
+
+class IndexContentDriftError(ValueError):
+    """The live index no longer matches its manifest-bound content."""
 
 
 @dataclass(frozen=True)
@@ -108,7 +116,9 @@ def parse_workspace_v1(raw: Any) -> SmokeWorkspaceV1:
         )
     experiment_id = raw["experiment_id"]
     manifest_hash = raw["manifest_hash"]
-    if any(type(value) is not str or not value for value in (experiment_id, manifest_hash)):
+    if any(
+        type(value) is not str or not value for value in (experiment_id, manifest_hash)
+    ):
         raise ValueError("workspace identity fields must be non-empty strings")
     return SmokeWorkspaceV1(experiment_id, manifest_hash, tuple(cells))
 
@@ -146,6 +156,190 @@ def _reject_special_tree(root: Path, label: str) -> None:
             mode = path.lstat().st_mode
             if not (stat.S_ISDIR(mode) or stat.S_ISREG(mode)):
                 raise ValueError(f"{label} namespace contains a special node: {path}")
+            if stat.S_ISREG(mode) and path.stat().st_nlink != 1:
+                raise ValueError(
+                    f"{label} namespace contains a hardlinked file: {path}"
+                )
+
+
+def _regular_inventory(root: Path, database_name: str) -> dict[str, str]:
+    """Classify every regular file; reject undeclared DBs and sidecars."""
+
+    inventory = {}
+    primary = Path(database_name)
+    allowed_sidecars = {
+        Path(database_name + suffix) for suffix in ("-wal", "-shm", "-journal")
+    }
+    primary_count = 0
+    for path in sorted(item for item in root.rglob("*") if item.is_file()):
+        relative = path.relative_to(root)
+        if relative == primary:
+            primary_count += 1
+            continue
+        if relative in allowed_sidecars:
+            continue
+        if path.name.endswith(("-wal", "-shm", "-journal")):
+            raise ValueError(f"undeclared SQLite sidecar: {relative.as_posix()}")
+        if path.suffix in {".db", ".sqlite", ".sqlite3"}:
+            raise ValueError(f"undeclared SQLite database: {relative.as_posix()}")
+        inventory[relative.as_posix()] = hashlib.sha256(path.read_bytes()).hexdigest()
+    if primary_count != 1:
+        raise ValueError("index must contain exactly one top-level primary database")
+    return inventory
+
+
+def create_frozen_index_snapshot(
+    source: Path,
+    target: Path,
+    arm: str,
+    expected_paths: tuple[str, ...],
+) -> Path:
+    """Create one consistent arm-specific frozen index via SQLite backup."""
+
+    if arm not in INDEX_LAYOUT:
+        raise ValueError(f"Unsupported indexed Smoke arm: {arm}")
+    _, database_name = INDEX_LAYOUT[arm]
+    source_root = _canonical_root(source, "live index")
+    target_root = target.absolute()
+    temporary = target_root.with_name(target_root.name + ".materializing")
+    if _paths_overlap(source_root, target_root) or _paths_overlap(
+        source_root, temporary
+    ):
+        raise ValueError("frozen snapshot overlaps live index")
+    if os.path.lexists(target_root) or os.path.lexists(temporary):
+        raise ValueError("frozen snapshot destination already exists")
+    _reject_special_tree(source_root, "live index")
+    before = _regular_inventory(source_root, database_name)
+    try:
+        temporary.mkdir(parents=True)
+        for relative in before:
+            destination = temporary / relative
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source_root / relative, destination)
+        source_db = sqlite3.connect(
+            f"file:{source_root / database_name}?mode=ro", uri=True, timeout=0
+        )
+        destination_db = sqlite3.connect(temporary / database_name)
+        try:
+            source_db.backup(destination_db)
+        finally:
+            destination_db.close()
+            source_db.close()
+        if _regular_inventory(source_root, database_name) != before:
+            raise ValueError("live non-database index files changed during snapshot")
+        observed_paths = inspect_frozen_index(arm, temporary)
+        if observed_paths != expected_paths:
+            raise ValueError("frozen index paths do not match index evidence")
+        temporary.rename(target_root)
+    except Exception:
+        if os.path.lexists(temporary) and not temporary.is_symlink():
+            shutil.rmtree(temporary)
+        raise
+    return target_root
+
+
+def runtime_index_path(checkout: Path, index_name: str) -> Path:
+    """Resolve the one permitted runtime index path under a checkout."""
+
+    if index_name not in {".ast-cache", ".codegraph"}:
+        raise ValueError(f"unsupported runtime index name: {index_name}")
+    checkout_root = _canonical_root(checkout, "checkout")
+    return checkout_root / index_name
+
+
+def materialize_runtime_index(
+    baseline: Path,
+    checkout: Path,
+    arm: str,
+    expected_hash: str,
+    expected_paths: tuple[str, ...],
+) -> Path:
+    """Publish a verified private index copy at the tool's fixed namespace."""
+
+    if arm not in INDEX_LAYOUT:
+        raise ValueError(f"Unsupported indexed Smoke arm: {arm}")
+    index_name, _ = INDEX_LAYOUT[arm]
+    baseline_root = _canonical_root(baseline, "frozen index")
+    runtime = runtime_index_path(checkout, index_name)
+    temporary = runtime.with_name(runtime.name + ".materializing")
+    if _paths_overlap(baseline_root, _canonical_root(checkout, "checkout")):
+        raise ValueError("frozen index overlaps checkout")
+    if _paths_overlap(baseline_root, runtime) or _paths_overlap(
+        baseline_root, temporary
+    ):
+        raise ValueError("frozen index overlaps runtime namespace")
+    if os.path.lexists(runtime):
+        raise ValueError("runtime index already exists")
+    if os.path.lexists(temporary):
+        raise ValueError("materialization residue exists")
+    _reject_special_tree(baseline_root, "frozen index")
+    baseline_before = index_content_hash(baseline_root)
+    if baseline_before != expected_hash:
+        raise IndexContentDriftError("frozen index content hash mismatch")
+    try:
+        shutil.copytree(baseline_root, temporary, copy_function=shutil.copy2)
+        _reject_special_tree(temporary, "runtime index")
+        if index_content_hash(temporary) != expected_hash:
+            raise IndexContentDriftError("runtime index copy hash mismatch")
+        if inspect_frozen_index(arm, temporary) != expected_paths:
+            raise ValueError("runtime index paths do not match index evidence")
+        if index_content_hash(temporary) != expected_hash:
+            raise ValueError("fixed oracle mutated runtime index")
+        if index_content_hash(baseline_root) != expected_hash:
+            raise IndexContentDriftError("frozen index changed during materialization")
+        _require_distinct_file_inodes(baseline_root, temporary)
+        temporary.rename(runtime)
+    except Exception:
+        if os.path.lexists(temporary) and not temporary.is_symlink():
+            shutil.rmtree(temporary)
+        raise
+    return runtime
+
+
+def audit_runtime_index(
+    runtime: Path,
+    audit_target: Path,
+    arm: str,
+    expected_paths: tuple[str, ...],
+) -> tuple[str, tuple[str, ...]]:
+    """Snapshot a quiesced runtime index and return canonical semantics."""
+
+    snapshot = create_frozen_index_snapshot(runtime, audit_target, arm, expected_paths)
+    _, database_name = INDEX_LAYOUT[arm]
+    try:
+        paths = inspect_frozen_index(arm, snapshot)
+        digest = canonical_semantic_digest(snapshot / database_name)
+    finally:
+        shutil.rmtree(snapshot)
+    return digest, paths
+
+
+def _require_distinct_file_inodes(baseline: Path, runtime: Path) -> None:
+    """Prove corresponding regular files are physical copies."""
+
+    for source in sorted(path for path in baseline.rglob("*") if path.is_file()):
+        target = runtime / source.relative_to(baseline)
+        if not target.is_file():
+            raise ValueError(f"runtime index file missing: {target}")
+        if (source.stat().st_dev, source.stat().st_ino) == (
+            target.stat().st_dev,
+            target.stat().st_ino,
+        ):
+            raise ValueError(f"runtime index shares inode: {target}")
+
+
+def cleanup_runtime_index(checkout: Path, index_name: str, target: Path) -> None:
+    """Remove only the exact derived runtime namespace, never an arbitrary path."""
+
+    expected = runtime_index_path(checkout, index_name)
+    target_normalized = Path(os.path.normpath(os.fspath(target.absolute())))
+    if target_normalized != expected.absolute():
+        raise ValueError("runtime cleanup target mismatch")
+    if os.path.lexists(target) and target.is_symlink():
+        raise ValueError("runtime cleanup target is a symlink")
+    if target.exists():
+        _reject_special_tree(target, "runtime index")
+        shutil.rmtree(target)
 
 
 def validate_index_content_v1(
@@ -158,10 +352,10 @@ def validate_index_content_v1(
     cell = workspace.cell(arm_id)
     expected = dict(manifest.index_content_hashes).get(arm_id)
     if cell.index_path is None or expected is None:
-        raise ValueError(f"{arm_id} lacks manifest-bound index content")
+        raise IndexContentDriftError(f"{arm_id} lacks manifest-bound index content")
     _reject_special_tree(cell.index_path, "index")
     if index_content_hash(cell.index_path) != expected:
-        raise ValueError(f"{arm_id} index content hash mismatch")
+        raise IndexContentDriftError(f"{arm_id} index content hash mismatch")
 
 
 def _git_output(checkout: Path, *args: str) -> str:
@@ -186,9 +380,7 @@ def _unprovenanced_paths(checkout: Path, allowed_root: str | None) -> tuple[str,
             capture_output=True,
             check=True,
         ).stdout
-        paths.update(
-            item.decode("utf-8") for item in output.split(b"\0") if item
-        )
+        paths.update(item.decode("utf-8") for item in output.split(b"\0") if item)
     if allowed_root is not None:
         prefix = allowed_root + "/"
         paths = {
@@ -221,11 +413,26 @@ def validate_workspace_v1(
     checkouts = tuple(_canonical_root(path, "checkout") for path in checkouts)
     artifacts = tuple(_canonical_root(path, "artifact") for path in artifacts)
     indexes = tuple(_canonical_root(path, "index") for path in indexes)
-    for index in indexes:
-        _reject_special_tree(index, "index")
     _require_disjoint(checkouts, "checkout")
     _require_disjoint(artifacts, "artifact")
     _require_disjoint(indexes, "index")
+    runtime_indexes = tuple(
+        cell.checkout_path / _INDEX_DIRS[cell.arm_id]
+        for cell in workspace.cells
+        if _INDEX_DIRS[cell.arm_id] is not None
+    )
+    for index in indexes:
+        if any(_paths_overlap(index, checkout) for checkout in checkouts):
+            raise ValueError("frozen index overlaps checkout")
+        if any(_paths_overlap(index, artifact) for artifact in artifacts):
+            raise ValueError("frozen index overlaps artifact")
+        if any(_paths_overlap(index, runtime) for runtime in runtime_indexes):
+            raise ValueError("frozen index overlaps runtime")
+        _reject_special_tree(index, "index")
+    for cell in workspace.cells:
+        expected_index_hash = dict(manifest.index_content_hashes).get(cell.arm_id)
+        if cell.index_path is not None and expected_index_hash is not None:
+            validate_index_content_v1(workspace, manifest, cell.arm_id)
     if any(
         _paths_overlap(artifact, checkout)
         for artifact in artifacts
@@ -253,11 +460,10 @@ def validate_workspace_v1(
             raise ValueError(f"{cell.arm_id} repository fingerprint mismatch")
 
         index_name = _INDEX_DIRS[cell.arm_id]
-        expected_index = (
-            None if index_name is None else cell.checkout_path / index_name
-        )
-        if cell.index_path != expected_index:
-            raise ValueError(f"{cell.arm_id} index namespace mismatch")
+        if index_name is None and cell.index_path is not None:
+            raise ValueError(f"{cell.arm_id} cannot have frozen index content")
+        if index_name is not None and cell.index_path is None:
+            raise ValueError(f"{cell.arm_id} lacks frozen index content")
         forbidden = (
             (".ast-cache", ".codegraph")
             if cell.arm_id == "native-only"
@@ -267,21 +473,23 @@ def validate_workspace_v1(
         )
         if any((cell.checkout_path / name).exists() for name in forbidden):
             raise ValueError(f"{cell.arm_id} contains a foreign index namespace")
-        if cell.index_path is not None:
-            if cell.index_path.is_symlink():
-                raise ValueError(f"{cell.arm_id} index namespace is a symlink")
-            if cell.index_path.resolve().parent != cell.checkout_path.resolve():
-                raise ValueError(f"{cell.arm_id} index namespace escapes checkout")
-        unprovenanced = _unprovenanced_paths(cell.checkout_path, index_name)
+        runtime_index = None if index_name is None else cell.checkout_path / index_name
+        if runtime_index is not None and runtime_index.exists():
+            raise ValueError(f"{cell.arm_id} runtime index already exists")
+        residue = (
+            None
+            if runtime_index is None
+            else runtime_index.with_name(runtime_index.name + ".materializing")
+        )
+        if residue is not None and residue.exists():
+            raise ValueError(f"{cell.arm_id} materialization residue exists")
+        unprovenanced = _unprovenanced_paths(cell.checkout_path, None)
         if unprovenanced:
             raise ValueError(
                 f"{cell.arm_id} contains unprovenanced paths: {unprovenanced}"
             )
         if cell.index_path is not None and not cell.index_path.is_dir():
             raise ValueError(f"{cell.arm_id} index namespace does not exist")
-        expected_index_hash = dict(manifest.index_content_hashes).get(cell.arm_id)
-        if cell.index_path is not None and expected_index_hash is not None:
-            validate_index_content_v1(workspace, manifest, cell.arm_id)
         if not cell.artifact_path.is_dir():
             raise ValueError(f"{cell.arm_id} artifact namespace does not exist")
         if any(cell.artifact_path.iterdir()):

--- a/tests/unit/test_benchmark_harness.py
+++ b/tests/unit/test_benchmark_harness.py
@@ -3376,8 +3376,9 @@ class TestGinSmokeWorkspace:
 
         manifest, _, workspace = self._fixture(tmp_path)
         index = workspace.cell("tsa-warm").index_path
-        assert index is not None
-        (tmp_path / "alias.db").hardlink_to(index / "index.db")
+        expected_index = tmp_path / "frozen-indexes" / "tsa-warm" / ".ast-cache"
+        assert index == expected_index
+        (tmp_path / "alias.db").hardlink_to(expected_index / "index.db")
 
         with pytest.raises(ValueError, match="hardlinked file"):
             validate_workspace_v1(workspace, manifest)

--- a/tests/unit/test_benchmark_harness.py
+++ b/tests/unit/test_benchmark_harness.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import shutil
 import sqlite3
 import subprocess
 import sys
@@ -248,9 +249,7 @@ class TestGinSmokeQualification:
         ):
             self._validate(bundle)
 
-    def test_external_bundle_digest_rejects_recomputed_checksums(
-        self, tmp_path: Path
-    ):
+    def test_external_bundle_digest_rejects_recomputed_checksums(self, tmp_path: Path):
         bundle = self._bundle(tmp_path)
         original_digest = hashlib.sha256(
             (bundle / "checksums.json").read_bytes()
@@ -367,9 +366,7 @@ class TestGinSmokeQualification:
             ("question_sha256", ""),
         ],
     )
-    def test_manifest_schema_is_exact(
-        self, tmp_path: Path, field: str, value: object
-    ):
+    def test_manifest_schema_is_exact(self, tmp_path: Path, field: str, value: object):
         bundle = self._bundle(tmp_path)
         path = "manifest.json"
         target = bundle / path
@@ -625,12 +622,15 @@ class TestCodeGraphCompareTSAAdapter:
         index_dir = tmp_path / ".codegraph"
         index_dir.mkdir()
         (index_dir / "stale.json").write_text("{}", encoding="utf-8")
-        with patch(
-            "benchmarks.codegraph_compare.adapters.codegraph.subprocess.run",
-            return_value=SimpleNamespace(returncode=3, stderr="codegraph failed"),
-        ), patch(
-            "benchmarks.codegraph_compare.adapters.codegraph.resolve_codegraph_executable",
-            return_value=Path("/cached/codegraph"),
+        with (
+            patch(
+                "benchmarks.codegraph_compare.adapters.codegraph.subprocess.run",
+                return_value=SimpleNamespace(returncode=3, stderr="codegraph failed"),
+            ),
+            patch(
+                "benchmarks.codegraph_compare.adapters.codegraph.resolve_codegraph_executable",
+                return_value=Path("/cached/codegraph"),
+            ),
         ):
             with pytest.raises(RuntimeError, match="exited with code 3"):
                 _build_index(tmp_path, index_dir)
@@ -641,12 +641,15 @@ class TestCodeGraphCompareTSAAdapter:
         from benchmarks.codegraph_compare.adapters.codegraph import _build_index
 
         index_dir = tmp_path / ".codegraph"
-        with patch(
-            "benchmarks.codegraph_compare.adapters.codegraph.subprocess.run",
-            return_value=SimpleNamespace(returncode=0, stderr=""),
-        ) as run, patch(
-            "benchmarks.codegraph_compare.adapters.codegraph.resolve_codegraph_executable",
-            return_value=Path("/cached/codegraph"),
+        with (
+            patch(
+                "benchmarks.codegraph_compare.adapters.codegraph.subprocess.run",
+                return_value=SimpleNamespace(returncode=0, stderr=""),
+            ) as run,
+            patch(
+                "benchmarks.codegraph_compare.adapters.codegraph.resolve_codegraph_executable",
+                return_value=Path("/cached/codegraph"),
+            ),
         ):
             _build_index(tmp_path, index_dir)
 
@@ -1291,11 +1294,7 @@ class TestCodeGraphCompareSetupGate:
         assert compare_run.cmd_run_matrix(args) == 0
         assert observed == [cell.run_id for cell in manifest.expected_cells]
         attempts_path = (
-            tmp_path
-            / "results"
-            / "experiments"
-            / manifest.manifest_hash
-            / "runs.jsonl"
+            tmp_path / "results" / "experiments" / manifest.manifest_hash / "runs.jsonl"
         )
         attempts = [
             json.loads(line)
@@ -2274,9 +2273,7 @@ class TestCodeGraphCompareSetupGate:
             "BACKEND_UNSUPPORTED",
         ]
 
-    @pytest.mark.parametrize(
-        "arm_id", ("native-only", "codegraph-warm", "tsa-warm")
-    )
+    @pytest.mark.parametrize("arm_id", ("native-only", "codegraph-warm", "tsa-warm"))
     def test_codex_backend_validator_allows_isolated_smoke_arms(self, arm_id: str):
         from benchmarks.codegraph_compare.adapters.claude_runner import (
             validate_backend_arm_support,
@@ -2333,7 +2330,9 @@ class TestCodeGraphCompareSetupGate:
         assert configured_servers == [f"mcp_servers.{server_name}.required=true"]
         if arm_id == "tsa-warm":
             assert not any(
-                value.endswith('enabled_tools=["nav","search","structure","health","index","project"]')
+                value.endswith(
+                    'enabled_tools=["nav","search","structure","health","index","project"]'
+                )
                 for value in command
             )
             assert not any('"index"' in value for value in command)
@@ -2497,9 +2496,7 @@ class TestGinSmokeManifestExecution:
 
         assert audit.violations == ("MCP_CALL_FAILED:1", "MISSING_INDEX_QUERY")
 
-    def test_codex_transcript_does_not_accept_started_index_query(
-        self, tmp_path: Path
-    ):
+    def test_codex_transcript_does_not_accept_started_index_query(self, tmp_path: Path):
         from benchmarks.codegraph_compare.smoke_execution import (
             audit_codex_transcript,
         )
@@ -2524,9 +2521,7 @@ class TestGinSmokeManifestExecution:
         assert audit.violations == ("MISSING_INDEX_QUERY",)
         assert audit.observed_mcp_servers == ()
 
-    def test_codex_transcript_rejects_mutating_tsa_index_tool(
-        self, tmp_path: Path
-    ):
+    def test_codex_transcript_rejects_mutating_tsa_index_tool(self, tmp_path: Path):
         from benchmarks.codegraph_compare.smoke_execution import (
             audit_codex_transcript,
         )
@@ -2748,7 +2743,9 @@ class TestGinSmokeManifestExecution:
         assert persisted["status"] == "SUCCESS"
         path.unlink()
         recovered = append_v1_attempt(tmp_path, manifest, attempt, audit)
-        assert json.loads(recovered.read_text(encoding="utf-8"))["run_id"] == cell.run_id
+        assert (
+            json.loads(recovered.read_text(encoding="utf-8"))["run_id"] == cell.run_id
+        )
         with pytest.raises(ValueError, match="Duplicate physical attempt"):
             append_v1_attempt(tmp_path, manifest, attempt, audit)
 
@@ -2782,9 +2779,7 @@ class TestGinSmokeManifestExecution:
             session_id=manifest.primary_session_id,
             results_dir=tmp_path,
             repo_path_resolver=lambda repo: tmp_path,
-            append_event=lambda _, status, outcome: events.append(
-                (status, outcome)
-            ),
+            append_event=lambda _, status, outcome: events.append((status, outcome)),
             adapter_factory=lambda arm: None,
             run_one=lambda **kwargs: None,
         )
@@ -2828,7 +2823,7 @@ class TestGinSmokeManifestExecution:
                             "type": "mcp_tool_call",
                             "server": "tree-sitter-analyzer",
                             "tool": "nav",
-                        }
+                        },
                     }
                 ),
                 encoding="utf-8",
@@ -2846,9 +2841,7 @@ class TestGinSmokeManifestExecution:
                 {"id": "codegraph-warm"},
                 {"id": "tsa-warm"},
             ],
-            questions_by_repo={
-                "gin": [{"id": "q1", "prompt": "Where is it?"}]
-            },
+            questions_by_repo={"gin": [{"id": "q1", "prompt": "Where is it?"}]},
             supplied_index_stats=stats,
             results_dir=tmp_path / "results",
             workspace=None,
@@ -2891,12 +2884,23 @@ class TestGinSmokeManifestExecution:
     def test_manifest_smoke_preserves_completed_evidence_after_index_failure(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
+        from dataclasses import replace
+
         from benchmarks.codegraph_compare.adapters import RunConfig
         from benchmarks.codegraph_compare.smoke_execution import (
             run_manifest_smoke,
         )
+        from benchmarks.codegraph_compare.smoke_workspace import (
+            IndexContentDriftError,
+        )
 
-        manifest = _v1_manifest()
+        manifest = replace(
+            _v1_manifest(),
+            index_content_hashes=(
+                ("codegraph-warm", "codegraph-index-hash"),
+                ("tsa-warm", "tsa-index-hash"),
+            ),
+        )
         cells = iter(manifest.expected_cells)
 
         class Adapter:
@@ -2929,6 +2933,25 @@ class TestGinSmokeManifestExecution:
             )
             record = self._legacy_record(manifest, cell.run_id, transcript)
             record["answer"] = f"completed answer for {cell.arm}"
+            record["input_tokens"] = 101
+            record["output_tokens"] = 23
+            record["total_tokens"] = 124
+            record["tool_calls"] = 7
+            record["file_reads"] = 3
+            record["search_calls"] = 2
+            record["index_queries"] = 1
+            record["cached_input_tokens"] = 41
+            record["reasoning_output_tokens"] = 11
+            record["cache_read_tokens"] = 37
+            record["cache_creation_tokens"] = 4
+            record["total_cost_usd"] = 0.125
+            record["estimated_cost_usd"] = 0.25
+            record["citations"] = ["gin.go", "tree.go"]
+            record["started_at"] = "2026-07-31T01:02:03Z"
+            record["ended_at"] = "2026-07-31T01:02:08Z"
+            record["elapsed_seconds"] = 5.0
+            if cell.arm == "codegraph-warm":
+                record["error"] = "provider returned a partial failure"
             return record
 
         validation_calls = 0
@@ -2937,13 +2960,54 @@ class TestGinSmokeManifestExecution:
             nonlocal validation_calls
             validation_calls += 1
             if validation_calls == 1:
-                raise ValueError("index changed after completed model call")
+                raise IndexContentDriftError("index changed after completed model call")
+            raise OSError("index digest could not be read")
 
-        workspace_cell = SimpleNamespace(
-            checkout_path=tmp_path,
-            artifact_path=tmp_path / "artifacts",
+        workspace_cells = {}
+        for arm, index_name in (
+            ("codegraph-warm", ".codegraph"),
+            ("tsa-warm", ".ast-cache"),
+        ):
+            checkout_path = tmp_path / "checkouts" / arm
+            artifact_path = tmp_path / "artifacts" / arm
+            index_path = tmp_path / "frozen-indexes" / arm / index_name
+            checkout_path.mkdir(parents=True)
+            artifact_path.mkdir(parents=True)
+            index_path.mkdir(parents=True)
+            workspace_cells[arm] = SimpleNamespace(
+                checkout_path=checkout_path,
+                artifact_path=artifact_path,
+                index_path=index_path,
+            )
+        workspace = SimpleNamespace(cell=workspace_cells.__getitem__)
+        expected_hashes = dict(manifest.index_content_hashes)
+        monkeypatch.setattr(
+            "benchmarks.codegraph_compare.smoke_execution.index_content_hash",
+            lambda path: expected_hashes[
+                next(arm for arm in manifest.indexed_arms if arm in path.parts)
+            ],
         )
-        workspace = SimpleNamespace(cell=lambda arm: workspace_cell)
+        monkeypatch.setattr(
+            "benchmarks.codegraph_compare.smoke_execution.canonical_semantic_digest",
+            lambda path: "semantic-digest",
+        )
+
+        def materialize(index_path, checkout_path, arm, expected_hash, expected_paths):
+            runtime_path = checkout_path / index_path.name
+            runtime_path.mkdir()
+            return runtime_path
+
+        monkeypatch.setattr(
+            "benchmarks.codegraph_compare.smoke_execution.materialize_runtime_index",
+            materialize,
+        )
+        monkeypatch.setattr(
+            "benchmarks.codegraph_compare.smoke_execution.audit_runtime_index",
+            lambda runtime_path, audit_path, arm, expected_paths: (
+                "semantic-digest",
+                expected_paths,
+            ),
+        )
         monkeypatch.setattr(
             "benchmarks.codegraph_compare.smoke_execution.validate_index_content_v1",
             validate,
@@ -2960,9 +3024,7 @@ class TestGinSmokeManifestExecution:
                 {"id": "codegraph-warm"},
                 {"id": "tsa-warm"},
             ],
-            questions_by_repo={
-                "gin": [{"id": "q1", "prompt": "Where is it?"}]
-            },
+            questions_by_repo={"gin": [{"id": "q1", "prompt": "Where is it?"}]},
             supplied_index_stats=stats,
             results_dir=tmp_path / "results",
             workspace=workspace,
@@ -2971,17 +3033,17 @@ class TestGinSmokeManifestExecution:
             run_one=run_one,
         )
 
-        experiment = (
-            tmp_path / "results" / "experiments" / manifest.manifest_hash
-        )
+        experiment = tmp_path / "results" / "experiments" / manifest.manifest_hash
         first = json.loads(
             (experiment / "runs.jsonl").read_text(encoding="utf-8").splitlines()[0]
         )
+        second = json.loads(
+            (experiment / "runs.jsonl").read_text(encoding="utf-8").splitlines()[1]
+        )
         policy = json.loads(
-            (
-                experiment
-                / f"policy_{manifest.expected_cells[0].run_id}.json"
-            ).read_text(encoding="utf-8")
+            (experiment / f"policy_{manifest.expected_cells[0].run_id}.json").read_text(
+                encoding="utf-8"
+            )
         )
         # Issue #1201: post-run index validation must not erase model evidence.
         assert result == 1
@@ -2989,7 +3051,31 @@ class TestGinSmokeManifestExecution:
         assert first["transcript_path"].endswith(
             f"{manifest.expected_cells[0].run_id}.jsonl"
         )
-        assert policy["violations"] == ["EXECUTION_EXCEPTION:ValueError"]
+        assert first["input_tokens"] == 101
+        assert first["output_tokens"] == 23
+        assert first["total_tokens"] == 124
+        assert first["tool_calls"] == 7
+        assert first["file_reads"] == 3
+        assert first["search_calls"] == 2
+        assert first["index_queries"] == 1
+        assert first["cached_input_tokens"] == 41
+        assert first["reasoning_output_tokens"] == 11
+        assert first["cache_read_tokens"] == 37
+        assert first["cache_creation_tokens"] == 4
+        assert first["total_cost_usd"] == 0.125
+        assert first["estimated_cost_usd"] == 0.25
+        assert first["citations"] == ["gin.go", "tree.go"]
+        assert first["started_at"] == "2026-07-31T01:02:03Z"
+        assert first["ended_at"] == "2026-07-31T01:02:08Z"
+        assert first["elapsed_seconds"] == 5.0
+        assert first["status"] == "INVALID"
+        assert first["blocker_reason"] == (
+            "POLICY_AUDIT:INDEX_CONTENT_DRIFT;"
+            "PRODUCT_FAILURE:provider returned a partial failure"
+        )
+        assert policy["violations"] == ["INDEX_CONTENT_DRIFT"]
+        assert second["status"] == "INVALID"
+        assert second["blocker_reason"] == "POLICY_AUDIT:EXECUTION_EXCEPTION:OSError"
 
 
 class TestGinSmokeIndexEvidence:
@@ -3003,9 +3089,7 @@ class TestGinSmokeIndexEvidence:
             encoding="utf-8",
         )
 
-        eligible, excluded = classify_go_paths(
-            tmp_path, ("gin.go", "test.pb.go")
-        )
+        eligible, excluded = classify_go_paths(tmp_path, ("gin.go", "test.pb.go"))
 
         assert eligible == ("gin.go",)
         assert excluded == ("test.pb.go",)
@@ -3033,9 +3117,7 @@ class TestGinSmokeIndexEvidence:
         cache = tmp_path / ".ast-cache"
         cache.mkdir()
         connection = sqlite3.connect(cache / "index.db")
-        connection.execute(
-            "CREATE TABLE ast_index (file_path TEXT, symbols_json TEXT)"
-        )
+        connection.execute("CREATE TABLE ast_index (file_path TEXT, symbols_json TEXT)")
         connection.executemany(
             "INSERT INTO ast_index VALUES (?, ?)",
             (("gin.go", "ServeHTTP"), ("unexpected.go", "{}")),
@@ -3062,13 +3144,66 @@ class TestGinSmokeIndexEvidence:
 
 
 class TestGinSmokeWorkspace:
+    def test_freeze_index_baselines_moves_indexes_out_of_checkouts(
+        self, tmp_path: Path
+    ):
+        from benchmarks.codegraph_compare.smoke_plan import freeze_index_baselines
+
+        checkouts = {}
+        for arm, name in (
+            ("tsa-warm", ".ast-cache"),
+            ("codegraph-warm", ".codegraph"),
+        ):
+            checkout = tmp_path / "checkouts" / arm / "gin"
+            index = checkout / name
+            index.mkdir(parents=True)
+            database_name = "index.db" if arm == "tsa-warm" else "codegraph.db"
+            connection = sqlite3.connect(index / database_name)
+            if arm == "tsa-warm":
+                connection.execute(
+                    "CREATE TABLE ast_index(file_path TEXT, symbols_json TEXT)"
+                )
+                connection.execute(
+                    "INSERT INTO ast_index VALUES ('gin.go', 'ServeHTTP')"
+                )
+            else:
+                connection.execute("CREATE TABLE nodes(file_path TEXT, name TEXT)")
+                connection.execute("INSERT INTO nodes VALUES ('gin.go', 'ServeHTTP')")
+            connection.commit()
+            connection.close()
+            checkouts[arm] = checkout
+
+        frozen = freeze_index_baselines(
+            checkouts,
+            tmp_path / "checkouts",
+            {"tsa-warm": ("gin.go",), "codegraph-warm": ("gin.go",)},
+        )
+
+        assert tuple(sorted(frozen)) == ("codegraph-warm", "tsa-warm")
+        assert tuple(
+            (checkouts[arm] / name).exists()
+            for arm, name in (
+                ("tsa-warm", ".ast-cache"),
+                ("codegraph-warm", ".codegraph"),
+            )
+        ) == (False, False)
+        assert tuple(path.parent.parent.name for path in frozen.values()) == (
+            "frozen-indexes",
+            "frozen-indexes",
+        )
+
     @staticmethod
     def _fixture(tmp_path: Path):
+        from dataclasses import replace
+
         from benchmarks.codegraph_compare.integrity import (
             ExpectedCellV1,
+            _manifest_payload,
+            _sha256,
             create_manifest,
         )
         from benchmarks.codegraph_compare.smoke_evidence import (
+            index_content_hash,
             repository_fingerprint,
             tracked_paths,
         )
@@ -3097,9 +3232,7 @@ class TestGinSmokeWorkspace:
             check=True,
         )
         subprocess.run(["git", "add", "."], cwd=source, check=True)
-        subprocess.run(
-            ["git", "commit", "-qm", "fixture"], cwd=source, check=True
-        )
+        subprocess.run(["git", "commit", "-qm", "fixture"], cwd=source, check=True)
         commit = subprocess.run(
             ["git", "rev-parse", "HEAD"],
             cwd=source,
@@ -3158,11 +3291,15 @@ class TestGinSmokeWorkspace:
             )
             index_path = None
             if arm == "tsa-warm":
-                index_path = checkout / ".ast-cache"
+                index_path = tmp_path / "frozen-indexes" / arm / ".ast-cache"
+                index_path.parent.mkdir(parents=True)
                 index_path.mkdir()
+                (index_path / "index.db").write_bytes(b"tsa")
             elif arm == "codegraph-warm":
-                index_path = checkout / ".codegraph"
+                index_path = tmp_path / "frozen-indexes" / arm / ".codegraph"
+                index_path.parent.mkdir(parents=True)
                 index_path.mkdir()
+                (index_path / "codegraph.db").write_bytes(b"codegraph")
             artifact = tmp_path / "artifacts" / arm
             artifact.mkdir(parents=True)
             raw_cells.append(
@@ -3179,11 +3316,24 @@ class TestGinSmokeWorkspace:
             "manifest_hash": manifest.manifest_hash,
             "cells": raw_cells,
         }
+        manifest = replace(
+            manifest,
+            index_content_hashes=tuple(
+                (cell["arm_id"], index_content_hash(Path(cell["index_path"])))
+                for cell in raw_cells
+                if cell["index_path"] is not None
+            ),
+        )
+        manifest = replace(
+            manifest,
+            manifest_hash=_sha256(_manifest_payload(manifest)),
+        )
+        manifest = replace(manifest, experiment_id=f"sha256:{manifest.manifest_hash}")
+        raw["experiment_id"] = manifest.experiment_id
+        raw["manifest_hash"] = manifest.manifest_hash
         return manifest, raw, parse_workspace_v1(raw)
 
-    def test_workspace_accepts_three_independent_clean_checkouts(
-        self, tmp_path: Path
-    ):
+    def test_workspace_accepts_three_independent_clean_checkouts(self, tmp_path: Path):
         from benchmarks.codegraph_compare.smoke_workspace import (
             validate_workspace_v1,
         )
@@ -3191,6 +3341,337 @@ class TestGinSmokeWorkspace:
         manifest, _, workspace = self._fixture(tmp_path)
 
         validate_workspace_v1(workspace, manifest)
+
+    def test_workspace_rejects_frozen_index_inside_checkout(self, tmp_path: Path):
+        from benchmarks.codegraph_compare.smoke_workspace import validate_workspace_v1
+
+        manifest, _, workspace = self._fixture(tmp_path)
+        cell = workspace.cell("tsa-warm")
+        object.__setattr__(cell, "index_path", cell.checkout_path)
+
+        with pytest.raises(ValueError, match="frozen index overlaps checkout"):
+            validate_workspace_v1(workspace, manifest)
+
+    def test_workspace_rejects_existing_runtime_index(self, tmp_path: Path):
+        from benchmarks.codegraph_compare.smoke_workspace import validate_workspace_v1
+
+        manifest, _, workspace = self._fixture(tmp_path)
+        (workspace.cell("tsa-warm").checkout_path / ".ast-cache").mkdir()
+
+        with pytest.raises(ValueError, match="runtime index already exists"):
+            validate_workspace_v1(workspace, manifest)
+
+    def test_workspace_rejects_frozen_index_inside_artifact(self, tmp_path: Path):
+        from benchmarks.codegraph_compare.smoke_workspace import validate_workspace_v1
+
+        manifest, _, workspace = self._fixture(tmp_path)
+        cell = workspace.cell("tsa-warm")
+        object.__setattr__(cell, "index_path", cell.artifact_path)
+
+        with pytest.raises(ValueError, match="frozen index overlaps artifact"):
+            validate_workspace_v1(workspace, manifest)
+
+    def test_workspace_rejects_hardlinked_frozen_index_file(self, tmp_path: Path):
+        from benchmarks.codegraph_compare.smoke_workspace import validate_workspace_v1
+
+        manifest, _, workspace = self._fixture(tmp_path)
+        index = workspace.cell("tsa-warm").index_path
+        assert index is not None
+        (tmp_path / "alias.db").hardlink_to(index / "index.db")
+
+        with pytest.raises(ValueError, match="hardlinked file"):
+            validate_workspace_v1(workspace, manifest)
+
+    def test_snapshot_includes_committed_wal_with_open_writer(self, tmp_path: Path):
+        from benchmarks.codegraph_compare.smoke_workspace import (
+            create_frozen_index_snapshot,
+        )
+
+        baseline = tmp_path / "baseline" / ".codegraph"
+        baseline.mkdir(parents=True)
+        connection = sqlite3.connect(baseline / "codegraph.db")
+        connection.execute("PRAGMA journal_mode=WAL")
+        connection.execute("CREATE TABLE nodes (file_path TEXT, name TEXT)")
+        connection.execute("INSERT INTO nodes VALUES ('gin.go', 'ServeHTTP')")
+        connection.commit()
+        assert ((baseline / "codegraph.db-wal").stat().st_size == 0) is False
+        frozen = create_frozen_index_snapshot(
+            baseline,
+            tmp_path / "frozen" / ".codegraph",
+            "codegraph-warm",
+            ("gin.go",),
+        )
+        connection.close()
+        assert sqlite3.connect(frozen / "codegraph.db").execute(
+            "SELECT file_path, name FROM nodes"
+        ).fetchone() == ("gin.go", "ServeHTTP")
+
+    def test_snapshot_excludes_uncommitted_rows(self, tmp_path: Path):
+        from benchmarks.codegraph_compare.smoke_workspace import (
+            create_frozen_index_snapshot,
+        )
+
+        source = tmp_path / "live" / ".codegraph"
+        source.mkdir(parents=True)
+        writer = sqlite3.connect(source / "codegraph.db")
+        writer.execute("PRAGMA journal_mode=WAL")
+        writer.execute("CREATE TABLE nodes(file_path TEXT, name TEXT)")
+        writer.execute("INSERT INTO nodes VALUES ('gin.go', 'ServeHTTP')")
+        writer.commit()
+        writer.execute("BEGIN IMMEDIATE")
+        writer.execute("INSERT INTO nodes VALUES ('secret.go', 'Uncommitted')")
+        try:
+            frozen = create_frozen_index_snapshot(
+                source,
+                tmp_path / "frozen" / ".codegraph",
+                "codegraph-warm",
+                ("gin.go",),
+            )
+        finally:
+            writer.rollback()
+            writer.close()
+        assert sqlite3.connect(frozen / "codegraph.db").execute(
+            "SELECT file_path FROM nodes ORDER BY file_path"
+        ).fetchall() == [("gin.go",)]
+
+    def test_snapshot_rejects_multiple_primary_databases(self, tmp_path: Path):
+        from benchmarks.codegraph_compare.smoke_workspace import (
+            create_frozen_index_snapshot,
+        )
+
+        source = tmp_path / "live" / ".codegraph"
+        source.mkdir(parents=True)
+        sqlite3.connect(source / "codegraph.db").close()
+        sqlite3.connect(source / "extra.db").close()
+        with pytest.raises(ValueError, match="undeclared SQLite database: extra.db"):
+            create_frozen_index_snapshot(
+                source, tmp_path / "frozen", "codegraph-warm", ()
+            )
+
+    @pytest.mark.parametrize(
+        ("relative", "message"),
+        (
+            ("nested/extra.db", "undeclared SQLite database"),
+            ("nested/codegraph.db", "undeclared SQLite database"),
+            ("nested/codegraph.db-wal", "undeclared SQLite sidecar"),
+        ),
+    )
+    def test_snapshot_rejects_nested_sqlite_artifact(
+        self, tmp_path: Path, relative: str, message: str
+    ):
+        from benchmarks.codegraph_compare.smoke_workspace import (
+            create_frozen_index_snapshot,
+        )
+
+        source = tmp_path / "live" / ".codegraph"
+        source.mkdir(parents=True)
+        connection = sqlite3.connect(source / "codegraph.db")
+        connection.execute("CREATE TABLE nodes(file_path TEXT, name TEXT)")
+        connection.execute("INSERT INTO nodes VALUES ('gin.go', 'ServeHTTP')")
+        connection.commit()
+        connection.close()
+        artifact = source / relative
+        artifact.parent.mkdir()
+        artifact.write_bytes(b"foreign")
+        with pytest.raises(ValueError, match=message):
+            create_frozen_index_snapshot(
+                source, tmp_path / "frozen", "codegraph-warm", ("gin.go",)
+            )
+
+    def test_snapshot_rejects_evidence_path_mismatch(self, tmp_path: Path):
+        from benchmarks.codegraph_compare.smoke_workspace import (
+            create_frozen_index_snapshot,
+        )
+
+        source = tmp_path / "live" / ".codegraph"
+        source.mkdir(parents=True)
+        connection = sqlite3.connect(source / "codegraph.db")
+        connection.execute("CREATE TABLE nodes(file_path TEXT, name TEXT)")
+        connection.execute("INSERT INTO nodes VALUES ('gin.go', 'ServeHTTP')")
+        connection.commit()
+        connection.close()
+        with pytest.raises(ValueError, match="paths do not match index evidence"):
+            create_frozen_index_snapshot(
+                source, tmp_path / "frozen", "codegraph-warm", ("other.go",)
+            )
+
+    def test_snapshot_oracle_creates_no_sqlite_sidecars(self, tmp_path: Path):
+        from benchmarks.codegraph_compare.smoke_workspace import (
+            create_frozen_index_snapshot,
+        )
+
+        source = tmp_path / "live" / ".codegraph"
+        source.mkdir(parents=True)
+        connection = sqlite3.connect(source / "codegraph.db")
+        connection.execute("CREATE TABLE nodes(file_path TEXT, name TEXT)")
+        connection.execute("INSERT INTO nodes VALUES ('gin.go', 'ServeHTTP')")
+        connection.commit()
+        connection.close()
+        frozen = create_frozen_index_snapshot(
+            source, tmp_path / "frozen" / ".codegraph", "codegraph-warm", ("gin.go",)
+        )
+        assert tuple(sorted(path.name for path in frozen.iterdir())) == (
+            "codegraph.db",
+        )
+
+    def test_materialize_uses_fixed_arm_oracle_and_distinct_copy(self, tmp_path: Path):
+        from benchmarks.codegraph_compare.smoke_evidence import index_content_hash
+        from benchmarks.codegraph_compare.smoke_workspace import (
+            create_frozen_index_snapshot,
+            materialize_runtime_index,
+        )
+
+        source = tmp_path / "live" / ".codegraph"
+        source.mkdir(parents=True)
+        connection = sqlite3.connect(source / "codegraph.db")
+        connection.execute("CREATE TABLE nodes(file_path TEXT, name TEXT)")
+        connection.execute("INSERT INTO nodes VALUES ('gin.go', 'ServeHTTP')")
+        connection.commit()
+        connection.close()
+        frozen = create_frozen_index_snapshot(
+            source, tmp_path / "frozen" / ".codegraph", "codegraph-warm", ("gin.go",)
+        )
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+        runtime = materialize_runtime_index(
+            frozen, checkout, "codegraph-warm", index_content_hash(frozen), ("gin.go",)
+        )
+        assert (
+            (frozen / "codegraph.db").stat().st_ino
+            == (runtime / "codegraph.db").stat().st_ino
+        ) is False
+
+    def test_freeze_rolls_back_both_live_indexes_when_second_rename_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        from benchmarks.codegraph_compare.smoke_plan import freeze_index_baselines
+
+        checkouts = self._indexed_checkout_pair(tmp_path)
+        original = Path.rename
+
+        def fail_second(path: Path, target: Path):
+            if path.name == ".codegraph" and target.name.endswith("freeze-quarantine"):
+                raise OSError("rename failed")
+            return original(path, target)
+
+        monkeypatch.setattr(Path, "rename", fail_second)
+        with pytest.raises(OSError, match="rename failed"):
+            freeze_index_baselines(
+                checkouts,
+                tmp_path / "checkouts",
+                {"tsa-warm": ("gin.go",), "codegraph-warm": ("gin.go",)},
+            )
+        assert tuple(
+            (checkouts[arm] / name).is_dir()
+            for arm, name in (
+                ("tsa-warm", ".ast-cache"),
+                ("codegraph-warm", ".codegraph"),
+            )
+        ) == (True, True)
+        assert tuple((tmp_path / "checkouts").rglob("*.freeze-quarantine")) == ()
+        assert tuple((tmp_path / "checkouts" / "frozen-indexes").rglob("*.db")) == ()
+
+    def test_freeze_cleanup_failure_preserves_frozen_authority(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        from benchmarks.codegraph_compare.smoke_plan import freeze_index_baselines
+
+        checkouts = self._indexed_checkout_pair(tmp_path)
+        original = shutil.rmtree
+
+        def fail_quarantine(path: Path, *args, **kwargs):
+            if Path(path).name == ".codegraph.freeze-quarantine":
+                raise OSError("cleanup failed")
+            return original(path, *args, **kwargs)
+
+        monkeypatch.setattr(shutil, "rmtree", fail_quarantine)
+        with pytest.raises(RuntimeError, match="frozen authority"):
+            freeze_index_baselines(
+                checkouts,
+                tmp_path / "checkouts",
+                {"tsa-warm": ("gin.go",), "codegraph-warm": ("gin.go",)},
+            )
+        assert tuple(
+            sorted(
+                path.name
+                for path in (tmp_path / "checkouts" / "frozen-indexes").rglob("*.db")
+            )
+        ) == ("codegraph.db", "index.db")
+        assert (
+            checkouts["codegraph-warm"] / ".codegraph.freeze-quarantine"
+        ).is_dir() is True
+
+    @staticmethod
+    def _indexed_checkout_pair(tmp_path: Path) -> dict[str, Path]:
+        checkouts = {}
+        for arm, index_name, database_name in (
+            ("tsa-warm", ".ast-cache", "index.db"),
+            ("codegraph-warm", ".codegraph", "codegraph.db"),
+        ):
+            checkout = tmp_path / "checkouts" / arm / "gin"
+            index = checkout / index_name
+            index.mkdir(parents=True)
+            connection = sqlite3.connect(index / database_name)
+            if arm == "tsa-warm":
+                connection.execute(
+                    "CREATE TABLE ast_index(file_path TEXT, symbols_json TEXT)"
+                )
+                connection.execute(
+                    "INSERT INTO ast_index VALUES ('gin.go', 'ServeHTTP')"
+                )
+            else:
+                connection.execute("CREATE TABLE nodes(file_path TEXT, name TEXT)")
+                connection.execute("INSERT INTO nodes VALUES ('gin.go', 'ServeHTTP')")
+            connection.commit()
+            connection.close()
+            checkouts[arm] = checkout
+        return checkouts
+
+    def test_cleanup_runtime_index_rejects_path_escape(self, tmp_path: Path):
+        from benchmarks.codegraph_compare.smoke_workspace import cleanup_runtime_index
+
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+        outside = tmp_path / ".ast-cache"
+        outside.mkdir()
+
+        with pytest.raises(ValueError, match="runtime cleanup target mismatch"):
+            cleanup_runtime_index(checkout, ".ast-cache", outside)
+
+    def test_cleanup_runtime_index_removes_exact_runtime_tree(self, tmp_path: Path):
+        from benchmarks.codegraph_compare.smoke_workspace import cleanup_runtime_index
+
+        checkout = tmp_path / "checkout"
+        runtime = checkout / ".ast-cache"
+        runtime.mkdir(parents=True)
+        (runtime / "index.db").write_bytes(b"index")
+
+        cleanup_runtime_index(checkout, ".ast-cache", runtime)
+
+        assert runtime.exists() is False
+
+    @pytest.mark.parametrize(
+        "target_kind", ("dotdot", "broken_symlink", "checkout", "baseline", "root")
+    )
+    def test_cleanup_rejects_unsafe_target(self, tmp_path: Path, target_kind: str):
+        from benchmarks.codegraph_compare.smoke_workspace import cleanup_runtime_index
+
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+        baseline = tmp_path / "baseline"
+        baseline.mkdir()
+        targets = {
+            "dotdot": checkout / ".." / ".ast-cache",
+            "broken_symlink": checkout / ".ast-cache",
+            "checkout": checkout,
+            "baseline": baseline,
+            "root": Path("/"),
+        }
+        target = targets[target_kind]
+        if target_kind == "broken_symlink":
+            target.symlink_to(tmp_path / "missing")
+        with pytest.raises(ValueError, match="runtime cleanup"):
+            cleanup_runtime_index(checkout, ".ast-cache", target)
 
     def test_workspace_rejects_cross_arm_artifact_collision(self, tmp_path: Path):
         from benchmarks.codegraph_compare.smoke_workspace import (
@@ -3204,9 +3685,7 @@ class TestGinSmokeWorkspace:
         with pytest.raises(ValueError, match="artifact namespace collision"):
             validate_workspace_v1(parse_workspace_v1(raw), manifest)
 
-    def test_workspace_rejects_foreign_index_in_native_checkout(
-        self, tmp_path: Path
-    ):
+    def test_workspace_rejects_foreign_index_in_native_checkout(self, tmp_path: Path):
         from benchmarks.codegraph_compare.smoke_workspace import (
             validate_workspace_v1,
         )
@@ -3238,9 +3717,8 @@ class TestGinSmokeWorkspace:
 
         manifest, raw, workspace = self._fixture(tmp_path)
         tsa_index = workspace.cell("tsa-warm").index_path
-        assert tsa_index == (
-            workspace.cell("tsa-warm").checkout_path / ".ast-cache"
-        )
+        assert tsa_index.name == ".ast-cache"
+        (tsa_index / "index.db").unlink()
         tsa_index.rmdir()
         external = tmp_path / "shared-index"
         external.mkdir()
@@ -3272,7 +3750,7 @@ class TestGinSmokeWorkspace:
 
         manifest, _, workspace = self._fixture(tmp_path)
         index = workspace.cell("tsa-warm").index_path
-        assert index == workspace.cell("tsa-warm").checkout_path / ".ast-cache"
+        assert index.name == ".ast-cache"
         (index / "external.db").symlink_to(tmp_path / "outside.db")
 
         with pytest.raises(ValueError, match="contains a special node"):
@@ -3294,10 +3772,8 @@ class TestGinSmokeWorkspace:
         manifest, _, workspace = self._fixture(tmp_path)
         tsa_index = workspace.cell("tsa-warm").index_path
         codegraph_index = workspace.cell("codegraph-warm").index_path
-        assert tsa_index == workspace.cell("tsa-warm").checkout_path / ".ast-cache"
-        assert codegraph_index == (
-            workspace.cell("codegraph-warm").checkout_path / ".codegraph"
-        )
+        assert tsa_index.name == ".ast-cache"
+        assert codegraph_index.name == ".codegraph"
         hashes = tuple(
             (
                 arm,
@@ -3378,11 +3854,7 @@ class TestGinSmokeBundle:
         for cell in manifest.expected_cells:
             transcript_path = f"/original/{cell.run_id}.jsonl"
             transcript = (
-                plan
-                / "artifacts"
-                / cell.arm
-                / "raw"
-                / Path(transcript_path).name
+                plan / "artifacts" / cell.arm / "raw" / Path(transcript_path).name
             )
             transcript.parent.mkdir(parents=True)
             transcript.write_text(
@@ -3393,15 +3865,13 @@ class TestGinSmokeBundle:
                             "type": "mcp_tool_call",
                             "server": servers[cell.arm],
                             "tool": "query",
-                        }
+                        },
                     }
                 )
                 + "\n",
                 encoding="utf-8",
             )
-            run = _v1_run(
-                manifest, cell.run_id, transcript_path=transcript_path
-            )
+            run = _v1_run(manifest, cell.run_id, transcript_path=transcript_path)
             runs.append(run)
             (experiment / f"policy_{cell.run_id}.json").write_text(
                 json.dumps(
@@ -3464,9 +3934,7 @@ class TestGinSmokeBundle:
         assert verdict["dominance_allowed"] is False
         assert verdict["winner"] is None
 
-    def test_bundle_accepts_bound_legacy_terminal_exception(
-        self, tmp_path: Path
-    ):
+    def test_bundle_accepts_bound_legacy_terminal_exception(self, tmp_path: Path):
         from benchmarks.codegraph_compare.smoke_bundle import create_smoke_bundle
 
         plan, experiment, registry = self._bundle_inputs(tmp_path)
@@ -3521,9 +3989,7 @@ class TestGinSmokeBundle:
             registry_path=registry,
         )
 
-        replay_smoke_bundle(
-            bundle, tmp_path / "replay", external_digest=digest
-        )
+        replay_smoke_bundle(bundle, tmp_path / "replay", external_digest=digest)
 
         assert {
             path.relative_to(bundle): path.read_bytes()
@@ -3535,9 +4001,7 @@ class TestGinSmokeBundle:
             if path.is_file()
         }
 
-    def test_bundle_rejects_tampering_against_external_digest(
-        self, tmp_path: Path
-    ):
+    def test_bundle_rejects_tampering_against_external_digest(self, tmp_path: Path):
         from benchmarks.codegraph_compare.smoke_bundle import (
             create_smoke_bundle,
             validate_smoke_bundle,
@@ -3551,9 +4015,7 @@ class TestGinSmokeBundle:
             experiment_dir=experiment,
             registry_path=registry,
         )
-        (bundle / "evidence" / "runs.jsonl").write_text(
-            "tampered\n", encoding="utf-8"
-        )
+        (bundle / "evidence" / "runs.jsonl").write_text("tampered\n", encoding="utf-8")
 
         with pytest.raises(ValueError, match="bundle checksum mismatch"):
             validate_smoke_bundle(bundle, external_digest=digest)
@@ -5028,9 +5490,7 @@ class TestBenchmarkExperimentIntegrity:
                 "tsa-warm": "tsa-index-hash",
             }
         )
-        runs = tuple(
-            _v1_run(manifest, cell.run_id) for cell in manifest.expected_cells
-        )
+        runs = tuple(_v1_run(manifest, cell.run_id) for cell in manifest.expected_cells)
 
         verdict = validate_publishable_experiment(
             manifest,
@@ -5096,9 +5556,7 @@ class TestSmokeModelPreflight:
                 "type": "item.completed",
                 "item": {
                     "type": "agent_message",
-                    "text": json.dumps(
-                        {"status": smoke_preflight.SENTINEL}
-                    ),
+                    "text": json.dumps({"status": smoke_preflight.SENTINEL}),
                 },
             }
         )
@@ -5108,7 +5566,9 @@ class TestSmokeModelPreflight:
         with (
             patch.object(smoke_preflight, "_codex_identity", return_value=identity),
             patch.object(smoke_preflight, "_account_surface", return_value="ChatGPT"),
-            patch.object(smoke_preflight.subprocess, "run", return_value=completed) as run,
+            patch.object(
+                smoke_preflight.subprocess, "run", return_value=completed
+            ) as run,
         ):
             evidence = smoke_preflight.run_model_preflight(
                 model="gpt-fixture", output_path=output

--- a/tests/unit/test_benchmark_harness.py
+++ b/tests/unit/test_benchmark_harness.py
@@ -3515,6 +3515,54 @@ class TestGinSmokeWorkspace:
             "codegraph.db",
         )
 
+    def test_snapshot_closes_oracle_connection_before_publish(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # PR #1213: Windows refuses to rename a directory containing an open DB.
+        from benchmarks.codegraph_compare import smoke_evidence
+
+        source = tmp_path / "live" / ".codegraph"
+        source.mkdir(parents=True)
+        connection = sqlite3.connect(source / "codegraph.db")
+        connection.execute("CREATE TABLE nodes(file_path TEXT, name TEXT)")
+        connection.execute("INSERT INTO nodes VALUES ('gin.go', 'ServeHTTP')")
+        connection.commit()
+        connection.close()
+
+        original_connect = smoke_evidence.sqlite3.connect
+        oracle_connections = []
+
+        class TrackingConnection:
+            def __init__(self, wrapped):
+                self.wrapped = wrapped
+                self.closed = False
+
+            def __getattr__(self, name):
+                return getattr(self.wrapped, name)
+
+            def __enter__(self):
+                self.wrapped.__enter__()
+                return self
+
+            def __exit__(self, *args):
+                return self.wrapped.__exit__(*args)
+
+            def close(self):
+                self.closed = True
+                self.wrapped.close()
+
+        def track_connect(database, *args, **kwargs):
+            tracked = TrackingConnection(original_connect(database, *args, **kwargs))
+            oracle_connections.append(tracked)
+            return tracked
+
+        monkeypatch.setattr(smoke_evidence.sqlite3, "connect", track_connect)
+
+        observed = smoke_evidence.inspect_frozen_index("codegraph-warm", source)
+
+        assert observed == ("gin.go",)
+        assert tuple(item.closed for item in oracle_connections) == (True,)
+
     def test_materialize_uses_fixed_arm_oracle_and_distinct_copy(self, tmp_path: Path):
         from benchmarks.codegraph_compare.smoke_evidence import index_content_hash
         from benchmarks.codegraph_compare.smoke_workspace import (


### PR DESCRIPTION
## Summary

- freeze warm-index snapshots and materialize isolated runtime copies for each smoke attempt
- bind runtime index state to the manifest/session and detect semantic or filesystem drift
- preserve product-failure evidence alongside policy-audit failures and strengthen workspace validation
- expand the benchmark harness tests for index isolation, cleanup, tampering, and failure evidence

## Root cause

The smoke harness could let runtime index mutations affect the evidence source, and some validation or policy-failure paths could discard useful product-failure context. That weakened reproducibility and made terminal evidence less trustworthy.

## Impact

Warm benchmark arms now execute against isolated runtime indexes while the frozen evidence remains immutable and auditable. Failures retain both policy and product context, and cleanup/validation failures are surfaced deterministically.

## Validation

- `uv run pytest tests/unit/test_benchmark_harness.py -q` — 235 passed
- `uv run pytest -q` — 1309 passed, 7 skipped
- `uv run pytest tests/unit/test_benchmark_harness.py -q --cov=tree_sitter_analyzer --cov-report=json` — 235 passed
- `uv run python scripts/check_patch_coverage.py --base origin/develop --coverage-json coverage.json` — no added executable misses
- `git diff --check`