### PR TITLE
ci: diagnose and retry Windows runner budget stalls

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -123,9 +123,26 @@ jobs:
     - name: Run Tests (no coverage)
       if: ${{ !matrix.coverage }}
       run: |
+        set +e
         uv run pytest tests/ -n auto -v --tb=short --maxfail=200 \
           --ignore=tests/e2e \
-          -m "not slow and not e2e and not network and not benchmark and not full_language"
+          -m "not slow and not e2e and not network and not benchmark and not full_language" \
+          2>&1 | tee pytest-output.txt
+        test_status=${PIPESTATUS[0]}
+        set -e
+        if [ "$test_status" -eq 0 ]; then
+          exit 0
+        fi
+        if [ "$RUNNER_OS" != "Windows" ]; then
+          exit "$test_status"
+        fi
+        if ! uv run python scripts/classify_windows_pytest_failure.py \
+          pytest-output.txt --nodeids-output windows-budget-retry.txt; then
+          exit "$test_status"
+        fi
+        mapfile -t retry_nodeids < windows-budget-retry.txt
+        echo "Windows runner degradation suspected; retrying budget-only failures once."
+        uv run pytest "${retry_nodeids[@]}" -n auto -v --tb=short --maxfail=200
       shell: bash
 
     - name: Run slow tests
@@ -230,9 +247,26 @@ jobs:
     - name: Run Tests (no coverage)
       if: matrix.os != 'ubuntu-latest' || matrix.python-version != inputs.python-version
       run: |
+        set +e
         uv run pytest tests/ -n auto -v --tb=short --maxfail=200 \
           --ignore=tests/e2e \
-          -m "not slow and not e2e and not network and not benchmark and not full_language"
+          -m "not slow and not e2e and not network and not benchmark and not full_language" \
+          2>&1 | tee pytest-output.txt
+        test_status=${PIPESTATUS[0]}
+        set -e
+        if [ "$test_status" -eq 0 ]; then
+          exit 0
+        fi
+        if [ "$RUNNER_OS" != "Windows" ]; then
+          exit "$test_status"
+        fi
+        if ! uv run python scripts/classify_windows_pytest_failure.py \
+          pytest-output.txt --nodeids-output windows-budget-retry.txt; then
+          exit "$test_status"
+        fi
+        mapfile -t retry_nodeids < windows-budget-retry.txt
+        echo "Windows runner degradation suspected; retrying budget-only failures once."
+        uv run pytest "${retry_nodeids[@]}" -n auto -v --tb=short --maxfail=200
       shell: bash
 
     - name: Run slow tests

--- a/scripts/classify_windows_pytest_failure.py
+++ b/scripts/classify_windows_pytest_failure.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Classify whether a Windows pytest failure is safe for one bounded retry."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+_OUTCOME = re.compile(
+    r"^(?P<outcome>FAILED|ERROR) (?P<nodeid>\S+) - (?P<reason>.+)$",
+    re.MULTILINE,
+)
+_BUDGET = "Unit test exceeded per-test budget:"
+
+
+def classify(output: str) -> dict[str, object]:
+    """Allow retry only when every reported failure is a runtime-budget failure."""
+
+    failures = tuple(_OUTCOME.finditer(output))
+    nodeids = tuple(match.group("nodeid") for match in failures)
+    budget_only = bool(failures) and all(
+        match.group("outcome") == "FAILED" and _BUDGET in match.group("reason")
+        for match in failures
+    )
+    return {
+        "retry_eligible": budget_only,
+        "nodeids": list(nodeids) if budget_only else [],
+        "failure_count": len(failures),
+        "reason": "budget_only" if budget_only else "non_budget_or_unclassified",
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("log", type=Path)
+    parser.add_argument("--nodeids-output", type=Path, required=True)
+    args = parser.parse_args()
+    result = classify(args.log.read_text(encoding="utf-8", errors="replace"))
+    args.nodeids_output.write_text(
+        "".join(f"{nodeid}\n" for nodeid in result["nodeids"]), encoding="utf-8"
+    )
+    print(json.dumps(result, sort_keys=True))
+    return 0 if result["retry_eligible"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/governance/test_ci_routing_contract.py
+++ b/tests/governance/test_ci_routing_contract.py
@@ -114,6 +114,17 @@ def test_slow_suite_runs_once_per_reusable_test_matrix() -> None:
     assert text.count(slow_marker) == 2
 
 
+def test_windows_budget_retry_is_bounded_and_budget_only() -> None:
+    """Windows may retry measured runner stalls, never functional failures."""
+    workflow = PROJECT_ROOT / ".github" / "workflows" / "reusable-test.yml"
+    text = workflow.read_text(encoding="utf-8")
+
+    assert text.count('if [ "$RUNNER_OS" != "Windows" ]; then') == 2
+    assert text.count("scripts/classify_windows_pytest_failure.py") == 2
+    assert text.count('uv run pytest "${retry_nodeids[@]}" -n auto') == 2
+    assert text.count("retrying budget-only failures once") == 2
+
+
 def test_default_gate_has_a_real_five_minute_ci_deadline() -> None:
     """The documented local quick-gate budget must be enforced in CI."""
     workflow = PROJECT_ROOT / ".github" / "workflows" / "reusable-test.yml"

--- a/tests/unit/test_classify_windows_pytest_failure.py
+++ b/tests/unit/test_classify_windows_pytest_failure.py
@@ -1,0 +1,50 @@
+"""Behavioral tests for the Windows degraded-runner classifier."""
+
+from scripts.classify_windows_pytest_failure import classify
+
+
+def test_budget_only_failures_are_retry_eligible() -> None:
+    output = (
+        "FAILED tests/unit/test_a.py::test_a - Failed: Unit test exceeded "
+        "per-test budget: 8.92s > 8.0s.\n"
+        "FAILED tests/unit/test_b.py::test_b - Failed: Unit test exceeded "
+        "per-test budget: 9.10s > 8.0s.\n"
+    )
+
+    assert classify(output) == {
+        "retry_eligible": True,
+        "nodeids": ["tests/unit/test_a.py::test_a", "tests/unit/test_b.py::test_b"],
+        "failure_count": 2,
+        "reason": "budget_only",
+    }
+
+
+def test_assertion_failure_blocks_retry() -> None:
+    output = "FAILED tests/unit/test_a.py::test_a - AssertionError: wrong value\n"
+
+    assert classify(output) == {
+        "retry_eligible": False,
+        "nodeids": [],
+        "failure_count": 1,
+        "reason": "non_budget_or_unclassified",
+    }
+
+
+def test_mixed_failures_block_retry() -> None:
+    output = (
+        "FAILED tests/unit/test_a.py::test_a - Failed: Unit test exceeded "
+        "per-test budget: 8.92s > 8.0s.\n"
+        "FAILED tests/unit/test_b.py::test_b - RuntimeError: boom\n"
+    )
+
+    assert classify(output)["retry_eligible"] is False
+
+
+def test_collection_error_blocks_retry() -> None:
+    output = (
+        "FAILED tests/unit/test_a.py::test_a - Failed: Unit test exceeded "
+        "per-test budget: 8.92s > 8.0s.\n"
+        "ERROR tests/unit/test_b.py - ImportError: missing dependency\n"
+    )
+
+    assert classify(output)["retry_eligible"] is False


### PR DESCRIPTION
Closes #1209

## Summary
- classify pytest summaries and permit retry only when every failure is a per-test runtime-budget failure
- retry only the affected Windows node IDs, once, while preserving all locked budgets
- add unit and governance contracts preventing broader retries

## Validation
- `uv run pre-commit run actionlint --files .github/workflows/reusable-test.yml`
- `uv run pytest tests/governance/test_ci_routing_contract.py tests/unit/test_classify_windows_pytest_failure.py -q --cov=tree_sitter_analyzer --cov-report=json` (17 passed)
- `uv run python scripts/check_patch_coverage.py --base origin/develop --coverage-json coverage.json`
- `uv run pytest -q` (1316 passed, 1 skipped)