### PR TITLE
fix(benchmarks): qualify indexed Smoke tooling before freeze

### DIFF
--- a/benchmarks/codegraph_compare/adapters/claude_runner.py
+++ b/benchmarks/codegraph_compare/adapters/claude_runner.py
@@ -437,6 +437,40 @@ def _codex_mcp_config_args(arm_id: str, repo_path: Path) -> list[str]:
     return config
 
 
+def preflight_codex_arm_tools(repo_path: Path) -> dict[str, dict[str, Any]]:
+    """Validate indexed-arm MCP configuration without invoking a model."""
+
+    evidence: dict[str, dict[str, Any]] = {}
+    for arm_id, server_name in (
+        ("tsa-warm", "tree-sitter-analyzer"),
+        ("codegraph-warm", "codegraph"),
+    ):
+        config = _codex_mcp_config_args(arm_id, repo_path)
+        result = subprocess.run(
+            ["codex", "mcp", *config, "list", "--json"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        servers = json.loads(result.stdout)
+        matches = [item for item in servers if item.get("name") == server_name]
+        if len(matches) != 1 or not matches[0].get("enabled"):
+            raise ValueError(f"Codex MCP preflight failed for {arm_id}")
+        transport = matches[0].get("transport")
+        if not isinstance(transport, dict):
+            raise ValueError(f"Codex MCP transport is missing for {arm_id}")
+        command = Path(str(transport.get("command") or ""))
+        if not command.is_absolute() or not command.is_file():
+            raise ValueError(f"Codex MCP executable is unavailable for {arm_id}")
+        evidence[arm_id] = {
+            "server": server_name,
+            "enabled": True,
+            "command": str(command.resolve()),
+            "args": list(transport.get("args") or []),
+        }
+    return evidence
+
+
 def _toml_cli_value(value: Any) -> str:
     """Encode a value for Codex's ``-c key=value`` TOML parser."""
 
@@ -589,6 +623,9 @@ def run_one(
             "files or project configuration. For indexed arms, the only allowed "
             "writes are tool-maintained cache/database side effects such as "
             ".codegraph SQLite WAL files or .ast-cache metadata. "
+            "For an indexed arm, successfully call at least one configured MCP "
+            "tool before direct source discovery; never substitute its CLI through "
+            "the shell. "
             "Answer the architecture question with concrete file citations."
         )
         user_message = f"{tool_policy}\n\n{user_message}"

--- a/benchmarks/codegraph_compare/adapters/claude_runner.py
+++ b/benchmarks/codegraph_compare/adapters/claude_runner.py
@@ -420,6 +420,7 @@ def _codex_mcp_config_args(arm_id: str, repo_path: Path) -> list[str]:
     values = {
         "command": command,
         "args": args,
+        "enabled": True,
         "enabled_tools": enabled_tools,
         "required": True,
         "startup_timeout_sec": 30,
@@ -437,7 +438,9 @@ def _codex_mcp_config_args(arm_id: str, repo_path: Path) -> list[str]:
     return config
 
 
-def preflight_codex_arm_tools(repo_path: Path) -> dict[str, dict[str, Any]]:
+def preflight_codex_arm_tools(
+    repo_paths: dict[str, Path],
+) -> dict[str, dict[str, Any]]:
     """Validate indexed-arm MCP configuration without invoking a model."""
 
     evidence: dict[str, dict[str, Any]] = {}
@@ -445,6 +448,7 @@ def preflight_codex_arm_tools(repo_path: Path) -> dict[str, dict[str, Any]]:
         ("tsa-warm", "tree-sitter-analyzer"),
         ("codegraph-warm", "codegraph"),
     ):
+        repo_path = repo_paths[arm_id]
         config = _codex_mcp_config_args(arm_id, repo_path)
         result = subprocess.run(
             ["codex", "mcp", *config, "list", "--json"],

--- a/benchmarks/codegraph_compare/smoke_bundle.py
+++ b/benchmarks/codegraph_compare/smoke_bundle.py
@@ -25,10 +25,13 @@ _PLAN_FILES = (
     "model-preflight.json",
     "workspace-evidence.json",
 )
-_OPTIONAL_PLAN_FILES = ("arm-tool-preflight.json",)
 _TERMINAL_EXCEPTION = re.compile(
     r"^(?:EXECUTION|EVIDENCE)_EXCEPTION:[A-Za-z_][A-Za-z0-9_]*$"
 )
+_ARM_TOOL_SERVERS = {
+    "tsa-warm": "tree-sitter-analyzer",
+    "codegraph-warm": "codegraph",
+}
 
 
 def _sha256_bytes(payload: bytes) -> str:
@@ -37,6 +40,24 @@ def _sha256_bytes(payload: bytes) -> str:
 
 def _json(path: Path) -> Any:
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _validate_arm_tool_preflight(path: Path, *, require_executables: bool) -> None:
+    raw = _json(path)
+    if not isinstance(raw, dict) or set(raw) != set(_ARM_TOOL_SERVERS):
+        raise ValueError("arm-tool preflight must contain both indexed arms")
+    expected_fields = {"server", "enabled", "command", "args"}
+    for arm, server in _ARM_TOOL_SERVERS.items():
+        record = raw[arm]
+        if not isinstance(record, dict) or set(record) != expected_fields:
+            raise ValueError(f"arm-tool preflight fields are invalid for {arm}")
+        if record["server"] != server or record["enabled"] is not True:
+            raise ValueError(f"arm-tool preflight server is invalid for {arm}")
+        command = Path(str(record["command"]))
+        if not command.is_absolute() or not isinstance(record["args"], list):
+            raise ValueError(f"arm-tool preflight transport is invalid for {arm}")
+        if require_executables and not command.is_file():
+            raise ValueError(f"arm-tool preflight executable is unavailable for {arm}")
 
 
 def _runs(path: Path) -> tuple[RunRecordV1, ...]:
@@ -134,10 +155,11 @@ def create_smoke_bundle(
     plan_target.mkdir()
     for name in _PLAN_FILES:
         (plan_target / name).write_bytes((plan_dir / name).read_bytes())
-    for name in _OPTIONAL_PLAN_FILES:
-        source = plan_dir / name
-        if source.is_file():
-            (plan_target / name).write_bytes(source.read_bytes())
+    arm_tool_preflight = plan_dir / "arm-tool-preflight.json"
+    _validate_arm_tool_preflight(arm_tool_preflight, require_executables=True)
+    (plan_target / "arm-tool-preflight.json").write_bytes(
+        arm_tool_preflight.read_bytes()
+    )
     manifest = parse_manifest_v1(_json(plan_target / "experiment-manifest.json"))
     validate_model_preflight(
         plan_target / "model-preflight.json",
@@ -234,6 +256,9 @@ def validate_smoke_bundle(bundle: Path, *, external_digest: str) -> dict[str, An
         expected_model=manifest.model,
         expected_cli_fingerprint=manifest.agent_cli_fingerprint,
     )
+    arm_tool_preflight = bundle / "plan/arm-tool-preflight.json"
+    if arm_tool_preflight.is_file():
+        _validate_arm_tool_preflight(arm_tool_preflight, require_executables=False)
     events = _registry(bundle / "registry.jsonl", manifest.experiment_id)
     runs = _runs(bundle / "evidence/runs.jsonl")
     _validate_policy_evidence(bundle, runs)

--- a/benchmarks/codegraph_compare/smoke_bundle.py
+++ b/benchmarks/codegraph_compare/smoke_bundle.py
@@ -25,6 +25,7 @@ _PLAN_FILES = (
     "model-preflight.json",
     "workspace-evidence.json",
 )
+_OPTIONAL_PLAN_FILES = ("arm-tool-preflight.json",)
 _TERMINAL_EXCEPTION = re.compile(
     r"^(?:EXECUTION|EVIDENCE)_EXCEPTION:[A-Za-z_][A-Za-z0-9_]*$"
 )
@@ -52,8 +53,7 @@ def _registry(path: Path, experiment_id: str) -> tuple[RegistryEvent, ...]:
     return tuple(
         RegistryEvent(**raw)
         for raw in (
-            json.loads(line)
-            for line in path.read_text(encoding="utf-8").splitlines()
+            json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()
         )
         if raw["experiment_id"] == experiment_id
     )
@@ -96,12 +96,8 @@ def _validate_policy_evidence(
     runs: tuple[RunRecordV1, ...],
 ) -> None:
     evidence = bundle_root / "evidence"
-    expected_policy_files = {
-        f"policy_{run.run_id}.json" for run in runs
-    }
-    actual_policy_files = {
-        path.name for path in evidence.glob("policy_*.json")
-    }
+    expected_policy_files = {f"policy_{run.run_id}.json" for run in runs}
+    actual_policy_files = {path.name for path in evidence.glob("policy_*.json")}
     if actual_policy_files != expected_policy_files:
         raise ValueError("policy evidence inventory mismatch")
     for run in runs:
@@ -109,17 +105,11 @@ def _validate_policy_evidence(
         if stored.get("transcript_path") != run.transcript_path:
             raise ValueError(f"policy transcript binding mismatch: {run.run_id}")
         transcript = (
-            bundle_root
-            / "artifacts"
-            / run.arm
-            / "raw"
-            / Path(run.transcript_path).name
+            bundle_root / "artifacts" / run.arm / "raw" / Path(run.transcript_path).name
         )
         recomputed = cast(
             dict[str, Any],
-            json.loads(
-                json.dumps(asdict(audit_codex_transcript(transcript, run.arm)))
-            ),
+            json.loads(json.dumps(asdict(audit_codex_transcript(transcript, run.arm)))),
         )
         recomputed["transcript_path"] = run.transcript_path
         stored_violations = stored.get("violations")
@@ -144,6 +134,10 @@ def create_smoke_bundle(
     plan_target.mkdir()
     for name in _PLAN_FILES:
         (plan_target / name).write_bytes((plan_dir / name).read_bytes())
+    for name in _OPTIONAL_PLAN_FILES:
+        source = plan_dir / name
+        if source.is_file():
+            (plan_target / name).write_bytes(source.read_bytes())
     manifest = parse_manifest_v1(_json(plan_target / "experiment-manifest.json"))
     validate_model_preflight(
         plan_target / "model-preflight.json",

--- a/benchmarks/codegraph_compare/smoke_plan.py
+++ b/benchmarks/codegraph_compare/smoke_plan.py
@@ -224,8 +224,9 @@ def freeze_smoke_plan(
     benchmark_repo = benchmark_repo.resolve()
     if _git_output(benchmark_repo, "status", "--porcelain", "--untracked-files=no"):
         raise ValueError("Benchmark implementation has tracked modifications")
+    checkouts = {arm: (checkout_root / arm / "gin").resolve() for arm in ARMS}
     tools, agent_fingerprint = tool_fingerprints(benchmark_repo)
-    arm_tool_preflight = preflight_codex_arm_tools(benchmark_repo)
+    arm_tool_preflight = preflight_codex_arm_tools(checkouts)
     preflight = validate_model_preflight(
         model_preflight,
         expected_model=model,
@@ -237,7 +238,6 @@ def freeze_smoke_plan(
     _write_exclusive(destination / "arm-tool-preflight.json", arm_tool_preflight)
     config_dir = benchmark_repo / "benchmarks" / "codegraph_compare"
     repo, arms, question = _load_selected_config(config_dir)
-    checkouts = {arm: (checkout_root / arm / "gin").resolve() for arm in ARMS}
     index_path = destination / "index-evidence.json"
     eligibility_path = destination / "eligibility.json"
     eligibility = produce_gin_index_evidence(

--- a/benchmarks/codegraph_compare/smoke_plan.py
+++ b/benchmarks/codegraph_compare/smoke_plan.py
@@ -17,6 +17,9 @@ from typing import Any
 import yaml
 
 from benchmarks.codegraph_compare.adapters import codegraph_executable_identity
+from benchmarks.codegraph_compare.adapters.claude_runner import (
+    preflight_codex_arm_tools,
+)
 from benchmarks.codegraph_compare.integrity import (
     ExpectedCellV1,
     _sha256,
@@ -222,6 +225,7 @@ def freeze_smoke_plan(
     if _git_output(benchmark_repo, "status", "--porcelain", "--untracked-files=no"):
         raise ValueError("Benchmark implementation has tracked modifications")
     tools, agent_fingerprint = tool_fingerprints(benchmark_repo)
+    arm_tool_preflight = preflight_codex_arm_tools(benchmark_repo)
     preflight = validate_model_preflight(
         model_preflight,
         expected_model=model,
@@ -230,6 +234,7 @@ def freeze_smoke_plan(
     )
     destination.mkdir(parents=True, exist_ok=False)
     _write_exclusive(destination / "model-preflight.json", preflight)
+    _write_exclusive(destination / "arm-tool-preflight.json", arm_tool_preflight)
     config_dir = benchmark_repo / "benchmarks" / "codegraph_compare"
     repo, arms, question = _load_selected_config(config_dir)
     checkouts = {arm: (checkout_root / arm / "gin").resolve() for arm in ARMS}
@@ -334,6 +339,7 @@ def freeze_smoke_plan(
     return {
         "manifest": manifest_path,
         "model_preflight": destination / "model-preflight.json",
+        "arm_tool_preflight": destination / "arm-tool-preflight.json",
         "index_evidence": index_path,
         "eligibility": eligibility_path,
         "workspace": workspace_path,

--- a/benchmarks/codegraph_compare/smoke_policy.py
+++ b/benchmarks/codegraph_compare/smoke_policy.py
@@ -101,6 +101,7 @@ def audit_codex_transcript(transcript_path: Path, arm: str) -> PolicyAudit:
     servers: list[str] = []
     successful_servers: list[str] = []
     tools: list[str] = []
+    successful_index_seen = False
     if not transcript_path.is_file():
         violations.append("TRANSCRIPT_MISSING")
         return PolicyAudit(arm, str(transcript_path), (), (), tuple(violations))
@@ -130,7 +131,14 @@ def audit_codex_transcript(transcript_path: Path, arm: str) -> PolicyAudit:
         elif item_type == "web_search":
             violations.append(f"NETWORK_TOOL:{line_number}")
         elif item_type == "command_execution":
-            _audit_command(str(item.get("command") or ""), line_number, violations)
+            command = str(item.get("command") or "")
+            if (
+                expected_server is not None
+                and not successful_index_seen
+                and _is_source_discovery_command(command)
+            ):
+                violations.append(f"SOURCE_DISCOVERY_BEFORE_INDEX:{line_number}")
+            _audit_command(command, line_number, violations)
         elif item_type == "mcp_tool_call":
             if event.get("type") != "item.completed":
                 continue
@@ -146,6 +154,7 @@ def audit_codex_transcript(transcript_path: Path, arm: str) -> PolicyAudit:
                 violations.append(f"MCP_CALL_FAILED:{line_number}")
             else:
                 successful_servers.append(server)
+                successful_index_seen = True
 
     if expected_server is not None and expected_server not in successful_servers:
         violations.append("MISSING_INDEX_QUERY")
@@ -213,18 +222,9 @@ def _unwrap_shell_launcher(command: str) -> str:
 def _command_is_allowlisted(command: str) -> bool:
     if "$(" in command or "`" in command:
         return False
-    try:
-        lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|")
-        lexer.whitespace_split = True
-        tokens = list(lexer)
-    except ValueError:
+    segments = _shell_segments(command)
+    if segments is None:
         return False
-    segments: list[list[str]] = [[]]
-    for token in tokens:
-        if token and set(token) <= {";", "&", "|"}:
-            segments.append([])
-        else:
-            segments[-1].append(token)
     for segment in segments:
         if not segment:
             continue
@@ -253,18 +253,9 @@ def _command_is_allowlisted(command: str) -> bool:
 def _contains_network_execution(command: str) -> bool:
     """Inspect executable positions, not inert grep patterns or file contents."""
 
-    try:
-        lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|")
-        lexer.whitespace_split = True
-        tokens = list(lexer)
-    except ValueError:
+    segments = _shell_segments(command)
+    if segments is None:
         return False
-    segments: list[list[str]] = [[]]
-    for token in tokens:
-        if token and set(token) <= {";", "&", "|"}:
-            segments.append([])
-        else:
-            segments[-1].append(token)
     for segment in segments:
         if not segment:
             continue
@@ -281,3 +272,36 @@ def _contains_network_execution(command: str) -> bool:
                     if Path(segment[index + 1]).name.lower() in _NETWORK_EXECUTABLES:
                         return True
     return False
+
+
+def _shell_segments(command: str) -> list[list[str]] | None:
+    """Tokenize shell segments, including literal newline separators."""
+
+    try:
+        lexer = shlex.shlex(
+            command.replace("\r\n", "\n").replace("\r", "\n").replace("\n", " ; "),
+            posix=True,
+            punctuation_chars=";&|",
+        )
+        lexer.whitespace_split = True
+        tokens = list(lexer)
+    except ValueError:
+        return None
+    segments: list[list[str]] = [[]]
+    for token in tokens:
+        if token and set(token) <= {";", "&", "|"}:
+            segments.append([])
+        else:
+            segments[-1].append(token)
+    return segments
+
+
+def _is_source_discovery_command(command: str) -> bool:
+    command = _unwrap_shell_launcher(command)
+    segments = _shell_segments(command)
+    if segments is None:
+        return True
+    return any(
+        segment and Path(segment[0]).name in _READ_COMMANDS - {"cd", "pwd"}
+        for segment in segments
+    )

--- a/benchmarks/codegraph_compare/smoke_policy.py
+++ b/benchmarks/codegraph_compare/smoke_policy.py
@@ -29,9 +29,7 @@ _INDEX_COMMAND = re.compile(
     r"\b(?:codegraph|tree[-_]sitter[-_]analyzer)\b",
     re.IGNORECASE,
 )
-_INDEX_NAMESPACE = re.compile(
-    r"(?:^|[\s/\\])(?:\.ast-cache|\.codegraph)(?:[/\\]|$)"
-)
+_INDEX_NAMESPACE = re.compile(r"(?:^|[\s/\\])(?:\.ast-cache|\.codegraph)(?:[/\\]|$)")
 _BOUNDARY_ESCAPE = re.compile(
     r"(?:^|[\s'\"=])(?:/|~|\.\.(?:[/\\]|\s|$)|\$HOME\b|\$\{HOME\}|[A-Za-z]:[/\\])"
 )
@@ -39,12 +37,25 @@ _PROCESS_INSPECTION = re.compile(
     r"(?:^|[;&|]\s*|\s)(?:ps|pgrep|lsof|env|printenv|mount)\b",
     re.IGNORECASE,
 )
-_NETWORK_COMMAND = re.compile(
-    r"(?:^|[;&|]\s*|\s)"
-    r"(?:curl|wget|ssh|scp|sftp|nc|netcat|telnet|python|python3|node|ruby|perl|php)"
-    r"\b|\bgit\s+(?:clone|fetch|pull|push|ls-remote)\b",
-    re.IGNORECASE,
+_NETWORK_EXECUTABLES = frozenset(
+    {
+        "curl",
+        "wget",
+        "ssh",
+        "scp",
+        "sftp",
+        "nc",
+        "netcat",
+        "telnet",
+        "python",
+        "python3",
+        "node",
+        "ruby",
+        "perl",
+        "php",
+    }
 )
+_NETWORK_GIT_SUBCOMMANDS = frozenset({"clone", "fetch", "pull", "push", "ls-remote"})
 _READ_COMMANDS = frozenset(
     {
         "cat",
@@ -164,9 +175,7 @@ def _mcp_call_failed(item: dict[str, object]) -> bool:
     )
 
 
-def _audit_command(
-    command: str, line_number: int, violations: list[str]
-) -> None:
+def _audit_command(command: str, line_number: int, violations: list[str]) -> None:
     command = _unwrap_shell_launcher(command)
     violation_count = len(violations)
     checks = (
@@ -179,7 +188,7 @@ def _audit_command(
             violations.append(f"{code}:{line_number}")
     if _BOUNDARY_ESCAPE.search(command) or _PROCESS_INSPECTION.search(command):
         violations.append(f"FILESYSTEM_BOUNDARY_ESCAPE:{line_number}")
-    if _NETWORK_COMMAND.search(command):
+    if _contains_network_execution(command):
         violations.append(f"NETWORK_COMMAND:{line_number}")
     if len(violations) == violation_count and not _command_is_allowlisted(command):
         violations.append(f"UNDECLARED_SHELL_COMMAND:{line_number}")
@@ -231,7 +240,44 @@ def _command_is_allowlisted(command: str) -> bool:
         if executable == "sed" and (
             "-n" not in segment[1:]
             or any(token == "-i" or token.startswith("-i") for token in segment[1:])
-            or any("e" in token.lstrip("-") for token in segment[1:] if token.startswith("-"))
+            or any(
+                "e" in token.lstrip("-")
+                for token in segment[1:]
+                if token.startswith("-")
+            )
         ):
             return False
     return True
+
+
+def _contains_network_execution(command: str) -> bool:
+    """Inspect executable positions, not inert grep patterns or file contents."""
+
+    try:
+        lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|")
+        lexer.whitespace_split = True
+        tokens = list(lexer)
+    except ValueError:
+        return False
+    segments: list[list[str]] = [[]]
+    for token in tokens:
+        if token and set(token) <= {";", "&", "|"}:
+            segments.append([])
+        else:
+            segments[-1].append(token)
+    for segment in segments:
+        if not segment:
+            continue
+        executable = Path(segment[0]).name.lower()
+        if executable in _NETWORK_EXECUTABLES:
+            return True
+        if executable == "git" and any(
+            token in _NETWORK_GIT_SUBCOMMANDS for token in segment[1:]
+        ):
+            return True
+        if executable == "find":
+            for index, token in enumerate(segment[:-1]):
+                if token in {"-exec", "-execdir", "-ok", "-okdir"}:
+                    if Path(segment[index + 1]).name.lower() in _NETWORK_EXECUTABLES:
+                        return True
+    return False

--- a/tests/unit/test_benchmark_harness.py
+++ b/tests/unit/test_benchmark_harness.py
@@ -2379,7 +2379,9 @@ class TestCodeGraphCompareSetupGate:
 
         monkeypatch.setattr(claude_runner.subprocess, "run", fake_run)
 
-        evidence = claude_runner.preflight_codex_arm_tools(tmp_path)
+        evidence = claude_runner.preflight_codex_arm_tools(
+            {"tsa-warm": tmp_path, "codegraph-warm": tmp_path}
+        )
 
         assert set(evidence) == {"tsa-warm", "codegraph-warm"}
         assert all(item["enabled"] for item in evidence.values())
@@ -2419,7 +2421,9 @@ class TestCodeGraphCompareSetupGate:
         )
 
         with pytest.raises(ValueError, match="executable is unavailable"):
-            claude_runner.preflight_codex_arm_tools(tmp_path)
+            claude_runner.preflight_codex_arm_tools(
+                {"tsa-warm": tmp_path, "codegraph-warm": tmp_path}
+            )
 
     def test_codex_native_command_ignores_user_config_without_mcp_servers(
         self, tmp_path: Path
@@ -2512,8 +2516,9 @@ class TestGinSmokeManifestExecution:
                         {
                             "type": "item.completed",
                             "item": {
-                                "type": "command_execution",
-                                "command": "grep -n ServeHTTP gin.go",
+                                "type": "mcp_tool_call",
+                                "server": "tree-sitter-analyzer",
+                                "tool": "nav",
                             },
                         }
                     ),
@@ -2521,9 +2526,8 @@ class TestGinSmokeManifestExecution:
                         {
                             "type": "item.completed",
                             "item": {
-                                "type": "mcp_tool_call",
-                                "server": "tree-sitter-analyzer",
-                                "tool": "nav",
+                                "type": "command_execution",
+                                "command": "grep -n ServeHTTP gin.go",
                             },
                         }
                     ),
@@ -2817,6 +2821,66 @@ class TestGinSmokeManifestExecution:
         audit = audit_codex_transcript(transcript, "native-only")
 
         assert audit.violations == ("NETWORK_COMMAND:1",)
+
+    def test_codex_transcript_audits_literal_newline_commands(self, tmp_path: Path):
+        from benchmarks.codegraph_compare.smoke_execution import (
+            audit_codex_transcript,
+        )
+
+        transcript = tmp_path / "multiline-network.jsonl"
+        transcript.write_text(
+            json.dumps(
+                {
+                    "type": "item.completed",
+                    "item": {
+                        "type": "command_execution",
+                        "command": "rg -n foo .\ncurl https://example.com",
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        audit = audit_codex_transcript(transcript, "native-only")
+
+        assert audit.violations == ("NETWORK_COMMAND:1",)
+
+    def test_indexed_arm_rejects_source_discovery_before_mcp(self, tmp_path: Path):
+        from benchmarks.codegraph_compare.smoke_execution import (
+            audit_codex_transcript,
+        )
+
+        transcript = tmp_path / "mcp-second.jsonl"
+        transcript.write_text(
+            "\n".join(
+                (
+                    json.dumps(
+                        {
+                            "type": "item.completed",
+                            "item": {
+                                "type": "command_execution",
+                                "command": "rg -n ServeHTTP .",
+                            },
+                        }
+                    ),
+                    json.dumps(
+                        {
+                            "type": "item.completed",
+                            "item": {
+                                "type": "mcp_tool_call",
+                                "server": "tree-sitter-analyzer",
+                                "tool": "search",
+                            },
+                        }
+                    ),
+                )
+            ),
+            encoding="utf-8",
+        )
+
+        audit = audit_codex_transcript(transcript, "tsa-warm")
+
+        assert audit.violations == ("SOURCE_DISCOVERY_BEFORE_INDEX:1",)
 
     def test_v1_attempt_is_manifest_bound_and_append_only(self, tmp_path: Path):
         from benchmarks.codegraph_compare.smoke_execution import (
@@ -3997,8 +4061,24 @@ class TestGinSmokeBundle:
             ),
             encoding="utf-8",
         )
+        (plan / "arm-tool-preflight.json").write_text(
+            json.dumps(
+                {
+                    arm: {
+                        "server": server,
+                        "enabled": True,
+                        "command": sys.executable,
+                        "args": ["serve", "--mcp"],
+                    }
+                    for arm, server in {
+                        "tsa-warm": "tree-sitter-analyzer",
+                        "codegraph-warm": "codegraph",
+                    }.items()
+                }
+            ),
+            encoding="utf-8",
+        )
         for name in (
-            "arm-tool-preflight.json",
             "eligibility.json",
             "index-evidence.json",
             "workspace-evidence.json",

--- a/tests/unit/test_benchmark_harness.py
+++ b/tests/unit/test_benchmark_harness.py
@@ -2342,6 +2342,85 @@ class TestCodeGraphCompareSetupGate:
                 'CODEGRAPH_NO_DAEMON = "1" }'
             ) in command
 
+    def test_codex_arm_tool_preflight_qualifies_both_indexed_servers(
+        self, monkeypatch, tmp_path: Path
+    ):
+        import subprocess
+
+        from benchmarks.codegraph_compare.adapters import claude_runner
+
+        executable = tmp_path / "server"
+        executable.write_text("fixture", encoding="utf-8")
+        monkeypatch.setattr(
+            claude_runner,
+            "_codex_mcp_config_args",
+            lambda arm, repo: ["-c", f"fixture={arm}:{repo.name}"],
+        )
+
+        def fake_run(command, **kwargs):
+            server = "tree-sitter-analyzer" if "tsa-warm" in command[3] else "codegraph"
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=json.dumps(
+                    [
+                        {
+                            "name": server,
+                            "enabled": True,
+                            "transport": {
+                                "command": str(executable),
+                                "args": ["serve", "--mcp"],
+                            },
+                        }
+                    ]
+                ),
+                stderr="",
+            )
+
+        monkeypatch.setattr(claude_runner.subprocess, "run", fake_run)
+
+        evidence = claude_runner.preflight_codex_arm_tools(tmp_path)
+
+        assert set(evidence) == {"tsa-warm", "codegraph-warm"}
+        assert all(item["enabled"] for item in evidence.values())
+
+    def test_codex_arm_tool_preflight_rejects_missing_executable(
+        self, monkeypatch, tmp_path: Path
+    ):
+        import subprocess
+
+        from benchmarks.codegraph_compare.adapters import claude_runner
+
+        monkeypatch.setattr(
+            claude_runner,
+            "_codex_mcp_config_args",
+            lambda arm, repo: ["-c", f"fixture={arm}:{repo.name}"],
+        )
+        monkeypatch.setattr(
+            claude_runner.subprocess,
+            "run",
+            lambda command, **kwargs: subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=json.dumps(
+                    [
+                        {
+                            "name": "tree-sitter-analyzer",
+                            "enabled": True,
+                            "transport": {
+                                "command": str(tmp_path / "missing"),
+                                "args": [],
+                            },
+                        }
+                    ]
+                ),
+                stderr="",
+            ),
+        )
+
+        with pytest.raises(ValueError, match="executable is unavailable"):
+            claude_runner.preflight_codex_arm_tools(tmp_path)
+
     def test_codex_native_command_ignores_user_config_without_mcp_servers(
         self, tmp_path: Path
     ):
@@ -2618,7 +2697,7 @@ class TestGinSmokeManifestExecution:
                     "type": "command_execution",
                     "command": "git -c credential.helper=x fetch origin",
                 },
-                "UNDECLARED_SHELL_COMMAND:1",
+                "NETWORK_COMMAND:1",
             ),
             (
                 {
@@ -2671,6 +2750,37 @@ class TestGinSmokeManifestExecution:
         )
 
         transcript = tmp_path / "readonly.jsonl"
+        transcript.write_text(
+            json.dumps(
+                {
+                    "type": "item.completed",
+                    "item": {"type": "command_execution", "command": command},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        audit = audit_codex_transcript(transcript, "native-only")
+
+        assert audit.violations == ()
+
+    @pytest.mark.parametrize(
+        "command",
+        (
+            "grep -RIn 'http.MethodGet|http.ListenAndServe' .",
+            "rg -n 'python|node|curl' README.md",
+            "/bin/bash -lc \"grep -n 'func ServeHTTP' gin.go\"",
+        ),
+    )
+    def test_codex_transcript_does_not_treat_search_terms_as_network_commands(
+        self, tmp_path: Path, command: str
+    ):
+        """Regression for the retained NO1-001C false policy failures (#1216)."""
+        from benchmarks.codegraph_compare.smoke_execution import (
+            audit_codex_transcript,
+        )
+
+        transcript = tmp_path / "source-search.jsonl"
         transcript.write_text(
             json.dumps(
                 {
@@ -3888,6 +3998,7 @@ class TestGinSmokeBundle:
             encoding="utf-8",
         )
         for name in (
+            "arm-tool-preflight.json",
             "eligibility.json",
             "index-evidence.json",
             "workspace-evidence.json",


### PR DESCRIPTION
Closes #1216

Parent objective: #1195

## Summary
- classify network activity from executable positions instead of inert grep/rg search terms
- preserve fail-closed handling for real network executables, wrapped shell commands, and `git fetch` variants
- run a no-model Codex MCP configuration/executable preflight for TSA and CodeGraph before manifest destination creation
- retain the preflight record in new bundles while preserving validation compatibility for immutable legacy bundles
- require indexed Codex arms to use their configured MCP before direct source discovery and prohibit CLI substitution

This does not rerun or alter NO1-001C and makes no quality, efficiency, winner, or dominance claim.

## Validation
- actual local no-model preflight resolved enabled TSA and CodeGraph MCP servers to absolute existing executables
- `uv run pytest tests/unit/test_benchmark_harness.py -q` (241 passed)
- patch coverage gate: no added executable misses
- `uv run mypy ...` (success)
- `uv run ruff check ...` (success)
- `uv run pytest -q` (1316 passed, 1 skipped)