### PR TITLE
fix(benchmarks): retain runtime audit failures in bundles

### DIFF
--- a/benchmarks/codegraph_compare/smoke_bundle.py
+++ b/benchmarks/codegraph_compare/smoke_bundle.py
@@ -30,6 +30,10 @@ _TERMINAL_EVIDENCE_MARKER = re.compile(
     r"(?:RUNTIME_POST_AUDIT|FROZEN_POSTCHECK|RUNTIME_CLEANUP)_FAILED):"
     r"[A-Za-z_][A-Za-z0-9_]*$|^(?:INDEX_CONTENT|RUNTIME_SEMANTIC)_DRIFT$"
 )
+_RUNTIME_EVIDENCE_MARKER = re.compile(
+    r"^(?:(?:RUNTIME_POST_AUDIT|FROZEN_POSTCHECK|RUNTIME_CLEANUP)_FAILED:"
+    r"[A-Za-z_][A-Za-z0-9_]*|(?:INDEX_CONTENT|RUNTIME_SEMANTIC)_DRIFT)$"
+)
 _ARM_TOOL_SERVERS = {
     "tsa-warm": "tree-sitter-analyzer",
     "codegraph-warm": "codegraph",
@@ -90,7 +94,7 @@ def _copy_tree_files(source: Path, destination: Path) -> None:
 
 
 def _without_terminal_exception(
-    stored: dict[str, Any], run: RunRecordV1
+    stored: dict[str, Any], run: RunRecordV1, evidence: Path
 ) -> dict[str, Any]:
     """Validate and remove terminal markers before transcript comparison."""
 
@@ -108,12 +112,30 @@ def _without_terminal_exception(
     if marker_count == 0:
         return stored
     expected_blocker = "POLICY_AUDIT:" + ",".join(violations)
+    blocker = run.blocker_reason or ""
+    product_failure = blocker.removeprefix(expected_blocker + ";PRODUCT_FAILURE:")
     if (
         run.status.value != "INVALID"
-        or run.blocker_reason != expected_blocker
+        or (blocker != expected_blocker and not product_failure)
         or (not run.transcript_path and run.answer != "ERROR")
     ):
         raise ValueError(f"terminal exception binding mismatch: {run.run_id}")
+    runtime_markers = [
+        marker
+        for marker in violations[:marker_count]
+        if _RUNTIME_EVIDENCE_MARKER.fullmatch(marker)
+    ]
+    if runtime_markers:
+        runtime = _json(evidence / f"runtime_index_{run.run_id}.json")
+        expected_identity = {
+            "experiment_id": run.experiment_id,
+            "session_id": run.session_id,
+            "run_id": run.run_id,
+            "arm": run.arm,
+            "failure_codes": runtime_markers,
+        }
+        if any(runtime.get(key) != value for key, value in expected_identity.items()):
+            raise ValueError(f"runtime evidence binding mismatch: {run.run_id}")
     comparable = dict(stored)
     comparable["violations"] = violations[marker_count:]
     return comparable
@@ -141,7 +163,7 @@ def _validate_policy_evidence(
         )
         recomputed["transcript_path"] = run.transcript_path
         stored_violations = stored.get("violations")
-        comparable = _without_terminal_exception(stored, run)
+        comparable = _without_terminal_exception(stored, run, evidence)
         if recomputed != comparable:
             raise ValueError(f"policy audit mismatch: {run.run_id}")
         if stored_violations and run.status.value != "INVALID":

--- a/benchmarks/codegraph_compare/smoke_bundle.py
+++ b/benchmarks/codegraph_compare/smoke_bundle.py
@@ -11,6 +11,7 @@ from typing import Any, cast
 
 from benchmarks.codegraph_compare._integrity_gate import validate_experiment
 from benchmarks.codegraph_compare.integrity import (
+    ExperimentManifestV1,
     RegistryEvent,
     parse_manifest_v1,
 )
@@ -34,6 +35,12 @@ _RUNTIME_EVIDENCE_MARKER = re.compile(
     r"^(?:(?:RUNTIME_POST_AUDIT|FROZEN_POSTCHECK|RUNTIME_CLEANUP)_FAILED:"
     r"[A-Za-z_][A-Za-z0-9_]*|(?:INDEX_CONTENT|RUNTIME_SEMANTIC)_DRIFT)$"
 )
+_EXECUTION_EVIDENCE_MARKER = re.compile(
+    r"^(?:EXECUTION_EXCEPTION:[A-Za-z_][A-Za-z0-9_]*|INDEX_CONTENT_DRIFT)$"
+)
+_EVIDENCE_EXCEPTION_MARKER = re.compile(
+    r"^EVIDENCE_EXCEPTION:[A-Za-z_][A-Za-z0-9_]*$"
+)
 _ARM_TOOL_SERVERS = {
     "tsa-warm": "tree-sitter-analyzer",
     "codegraph-warm": "codegraph",
@@ -46,6 +53,25 @@ def _sha256_bytes(payload: bytes) -> str:
 
 def _json(path: Path) -> Any:
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _valid_runtime_marker_sequence(markers: list[str]) -> bool:
+    index = 0
+    if index < len(markers) and (
+        markers[index] == "RUNTIME_SEMANTIC_DRIFT"
+        or markers[index].startswith("RUNTIME_POST_AUDIT_FAILED:")
+    ):
+        index += 1
+    if index < len(markers) and (
+        markers[index] == "INDEX_CONTENT_DRIFT"
+        or markers[index].startswith("FROZEN_POSTCHECK_FAILED:")
+    ):
+        index += 1
+    if index < len(markers) and markers[index].startswith(
+        "RUNTIME_CLEANUP_FAILED:"
+    ):
+        index += 1
+    return index == len(markers)
 
 
 def _validate_arm_tool_preflight(path: Path, *, require_executables: bool) -> None:
@@ -94,48 +120,74 @@ def _copy_tree_files(source: Path, destination: Path) -> None:
 
 
 def _without_terminal_exception(
-    stored: dict[str, Any], run: RunRecordV1, evidence: Path
+    stored: dict[str, Any],
+    run: RunRecordV1,
+    evidence: Path,
+    manifest: ExperimentManifestV1,
 ) -> dict[str, Any]:
     """Validate and remove terminal markers before transcript comparison."""
 
     violations = stored.get("violations")
     if not isinstance(violations, list) or not violations:
         return stored
-    marker_count = 0
-    for violation in violations:
-        if (
-            not isinstance(violation, str)
-            or _TERMINAL_EVIDENCE_MARKER.fullmatch(violation) is None
-        ):
-            break
-        marker_count += 1
+    runtime_path = evidence / f"runtime_index_{run.run_id}.json"
+    runtime_markers: list[str] = []
+    if runtime_path.is_file():
+        runtime = _json(runtime_path)
+        failure_codes = runtime.get("failure_codes")
+        if not isinstance(failure_codes, list) or not all(
+            isinstance(marker, str)
+            and _RUNTIME_EVIDENCE_MARKER.fullmatch(marker)
+            for marker in failure_codes
+        ) or not _valid_runtime_marker_sequence(failure_codes):
+            raise ValueError(f"runtime evidence marker mismatch: {run.run_id}")
+        runtime_markers = failure_codes
+        if runtime_markers:
+            if run.arm not in manifest.indexed_arms:
+                raise ValueError(f"runtime evidence on non-indexed arm: {run.run_id}")
+            expected_identity = {
+                "experiment_id": run.experiment_id,
+                "session_id": run.session_id,
+                "run_id": run.run_id,
+                "arm": run.arm,
+                "failure_codes": runtime_markers,
+            }
+            if any(
+                runtime.get(key) != value for key, value in expected_identity.items()
+            ):
+                raise ValueError(f"runtime evidence binding mismatch: {run.run_id}")
+            if violations[: len(runtime_markers)] != runtime_markers:
+                raise ValueError(f"runtime evidence ordering mismatch: {run.run_id}")
+    marker_count = len(runtime_markers)
+    remaining = violations[marker_count:]
+    if remaining and isinstance(remaining[0], str):
+        marker = remaining[0]
+        if _EXECUTION_EVIDENCE_MARKER.fullmatch(marker):
+            marker_count += 1
+        elif _EVIDENCE_EXCEPTION_MARKER.fullmatch(marker):
+            if runtime_markers:
+                raise ValueError(f"terminal evidence ordering mismatch: {run.run_id}")
+            marker_count += 1
     if marker_count == 0:
         return stored
+    if marker_count < len(violations):
+        next_violation = violations[marker_count]
+        if isinstance(next_violation, str) and _TERMINAL_EVIDENCE_MARKER.fullmatch(
+            next_violation
+        ):
+            raise ValueError(f"terminal evidence ordering mismatch: {run.run_id}")
     expected_blocker = "POLICY_AUDIT:" + ",".join(violations)
     blocker = run.blocker_reason or ""
-    product_failure = blocker.removeprefix(expected_blocker + ";PRODUCT_FAILURE:")
+    product_prefix = expected_blocker + ";PRODUCT_FAILURE:"
+    has_product_failure = blocker.startswith(product_prefix) and bool(
+        blocker[len(product_prefix) :]
+    )
     if (
         run.status.value != "INVALID"
-        or (blocker != expected_blocker and not product_failure)
+        or (blocker != expected_blocker and not has_product_failure)
         or (not run.transcript_path and run.answer != "ERROR")
     ):
         raise ValueError(f"terminal exception binding mismatch: {run.run_id}")
-    runtime_markers = [
-        marker
-        for marker in violations[:marker_count]
-        if _RUNTIME_EVIDENCE_MARKER.fullmatch(marker)
-    ]
-    if runtime_markers:
-        runtime = _json(evidence / f"runtime_index_{run.run_id}.json")
-        expected_identity = {
-            "experiment_id": run.experiment_id,
-            "session_id": run.session_id,
-            "run_id": run.run_id,
-            "arm": run.arm,
-            "failure_codes": runtime_markers,
-        }
-        if any(runtime.get(key) != value for key, value in expected_identity.items()):
-            raise ValueError(f"runtime evidence binding mismatch: {run.run_id}")
     comparable = dict(stored)
     comparable["violations"] = violations[marker_count:]
     return comparable
@@ -144,6 +196,7 @@ def _without_terminal_exception(
 def _validate_policy_evidence(
     bundle_root: Path,
     runs: tuple[RunRecordV1, ...],
+    manifest: ExperimentManifestV1,
 ) -> None:
     evidence = bundle_root / "evidence"
     expected_policy_files = {f"policy_{run.run_id}.json" for run in runs}
@@ -163,7 +216,7 @@ def _validate_policy_evidence(
         )
         recomputed["transcript_path"] = run.transcript_path
         stored_violations = stored.get("violations")
-        comparable = _without_terminal_exception(stored, run, evidence)
+        comparable = _without_terminal_exception(stored, run, evidence, manifest)
         if recomputed != comparable:
             raise ValueError(f"policy audit mismatch: {run.run_id}")
         if stored_violations and run.status.value != "INVALID":
@@ -216,7 +269,7 @@ def create_smoke_bundle(
         encoding="utf-8",
     )
     runs = _runs(evidence_target / "runs.jsonl")
-    _validate_policy_evidence(destination, runs)
+    _validate_policy_evidence(destination, runs, manifest)
     verdict = validate_experiment(
         manifest,
         registry=events,
@@ -290,7 +343,7 @@ def validate_smoke_bundle(bundle: Path, *, external_digest: str) -> dict[str, An
         _validate_arm_tool_preflight(arm_tool_preflight, require_executables=False)
     events = _registry(bundle / "registry.jsonl", manifest.experiment_id)
     runs = _runs(bundle / "evidence/runs.jsonl")
-    _validate_policy_evidence(bundle, runs)
+    _validate_policy_evidence(bundle, runs, manifest)
     verdict = validate_experiment(
         manifest,
         registry=events,

--- a/benchmarks/codegraph_compare/smoke_bundle.py
+++ b/benchmarks/codegraph_compare/smoke_bundle.py
@@ -38,9 +38,7 @@ _RUNTIME_EVIDENCE_MARKER = re.compile(
 _EXECUTION_EVIDENCE_MARKER = re.compile(
     r"^(?:EXECUTION_EXCEPTION:[A-Za-z_][A-Za-z0-9_]*|INDEX_CONTENT_DRIFT)$"
 )
-_EVIDENCE_EXCEPTION_MARKER = re.compile(
-    r"^EVIDENCE_EXCEPTION:[A-Za-z_][A-Za-z0-9_]*$"
-)
+_EVIDENCE_EXCEPTION_MARKER = re.compile(r"^EVIDENCE_EXCEPTION:[A-Za-z_][A-Za-z0-9_]*$")
 _ARM_TOOL_SERVERS = {
     "tsa-warm": "tree-sitter-analyzer",
     "codegraph-warm": "codegraph",
@@ -67,17 +65,32 @@ def _valid_runtime_marker_sequence(markers: list[str]) -> bool:
         or markers[index].startswith("FROZEN_POSTCHECK_FAILED:")
     ):
         index += 1
-    if index < len(markers) and markers[index].startswith(
-        "RUNTIME_CLEANUP_FAILED:"
-    ):
+    if index < len(markers) and markers[index].startswith("RUNTIME_CLEANUP_FAILED:"):
         index += 1
     return index == len(markers)
 
 
+def _runtime_hashes_match(runtime: dict[str, Any]) -> bool:
+    if runtime.get("materialized") is True and runtime.get(
+        "runtime_hash_before"
+    ) != runtime.get("expected_hash"):
+        return False
+    runtime_hash_after = runtime.get("runtime_hash_after")
+    expected_mutated = (
+        runtime_hash_after != runtime.get("runtime_hash_before")
+        if isinstance(runtime_hash_after, str)
+        else None
+    )
+    return runtime.get("runtime_mutated") == expected_mutated
+
+
 def _runtime_measurements_match(runtime: dict[str, Any], markers: list[str]) -> bool:
-    if runtime.get("cleanup_status") in {"SUCCESS", "FAILED"} and runtime.get(
-        "materialized"
-    ) is not True:
+    if (
+        runtime.get("cleanup_status") in {"SUCCESS", "FAILED"}
+        and runtime.get("materialized") is not True
+    ):
+        return False
+    if not _runtime_hashes_match(runtime):
         return False
     for marker in markers:
         if marker.startswith("RUNTIME_POST_AUDIT_FAILED:") and (
@@ -97,13 +110,15 @@ def _runtime_measurements_match(runtime: dict[str, Any], markers: list[str]) -> 
             or runtime["expected_hash"] == runtime["frozen_hash_after"]
         ):
             return False
-        if marker.startswith("FROZEN_POSTCHECK_FAILED:") and runtime.get(
-            "frozen_hash_after"
-        ) is not None:
+        if (
+            marker.startswith("FROZEN_POSTCHECK_FAILED:")
+            and runtime.get("frozen_hash_after") is not None
+        ):
             return False
-        if marker.startswith("RUNTIME_CLEANUP_FAILED:") and runtime.get(
-            "cleanup_status"
-        ) != "FAILED":
+        if (
+            marker.startswith("RUNTIME_CLEANUP_FAILED:")
+            and runtime.get("cleanup_status") != "FAILED"
+        ):
             return False
     required = {
         "semantic_drift": isinstance(runtime.get("semantic_digest_before"), str)
@@ -126,6 +141,36 @@ def _runtime_measurements_match(runtime: dict[str, Any], markers: list[str]) -> 
         ),
     }
     return represented == required
+
+
+def _runtime_paths_match(runtime: dict[str, Any], run: RunRecordV1) -> bool:
+    expected_paths = list(run.index_stats.indexed_paths) if run.index_stats else []
+    return runtime.get("expected_paths") == expected_paths and (
+        not isinstance(runtime.get("semantic_digest_after"), str)
+        or runtime.get("post_paths") == expected_paths
+    )
+
+
+def _terminal_binding_matches(
+    run: RunRecordV1,
+    violations: list[Any],
+    marker_count: int,
+    evidence_fallback: bool,
+) -> bool:
+    expected_blocker = "POLICY_AUDIT:" + ",".join(violations)
+    blocker = run.blocker_reason or ""
+    product_prefix = expected_blocker + ";PRODUCT_FAILURE:"
+    blocker_matches = blocker == expected_blocker or (
+        blocker.startswith(product_prefix) and bool(blocker[len(product_prefix) :])
+    )
+    synthetic_exception = evidence_fallback or any(
+        isinstance(marker, str) and marker.startswith("EXECUTION_EXCEPTION:")
+        for marker in violations[:marker_count]
+    )
+    answer_matches = (
+        bool(run.transcript_path) or run.answer == "ERROR" or not synthetic_exception
+    )
+    return run.status.value == "INVALID" and blocker_matches and answer_matches
 
 
 def _validate_arm_tool_preflight(path: Path, *, require_executables: bool) -> None:
@@ -192,11 +237,14 @@ def _without_terminal_exception(
     if runtime_path.is_file():
         runtime = _json(runtime_path)
         failure_codes = runtime.get("failure_codes")
-        if not isinstance(failure_codes, list) or not all(
-            isinstance(marker, str)
-            and _RUNTIME_EVIDENCE_MARKER.fullmatch(marker)
-            for marker in failure_codes
-        ) or not _valid_runtime_marker_sequence(failure_codes):
+        if (
+            not isinstance(failure_codes, list)
+            or not all(
+                isinstance(marker, str) and _RUNTIME_EVIDENCE_MARKER.fullmatch(marker)
+                for marker in failure_codes
+            )
+            or not _valid_runtime_marker_sequence(failure_codes)
+        ):
             raise ValueError(f"runtime evidence marker mismatch: {run.run_id}")
         runtime_markers = failure_codes
         if run.arm not in manifest.indexed_arms:
@@ -215,6 +263,8 @@ def _without_terminal_exception(
         }
         if any(runtime.get(key) != value for key, value in expected_identity.items()):
             raise ValueError(f"runtime evidence binding mismatch: {run.run_id}")
+        if not _runtime_paths_match(runtime, run):
+            raise ValueError(f"runtime evidence path mismatch: {run.run_id}")
         if not _runtime_measurements_match(runtime, runtime_markers):
             raise ValueError(f"runtime evidence measurement mismatch: {run.run_id}")
         if not evidence_fallback:
@@ -236,17 +286,7 @@ def _without_terminal_exception(
             next_violation
         ):
             raise ValueError(f"terminal evidence ordering mismatch: {run.run_id}")
-    expected_blocker = "POLICY_AUDIT:" + ",".join(violations)
-    blocker = run.blocker_reason or ""
-    product_prefix = expected_blocker + ";PRODUCT_FAILURE:"
-    has_product_failure = blocker.startswith(product_prefix) and bool(
-        blocker[len(product_prefix) :]
-    )
-    if (
-        run.status.value != "INVALID"
-        or (blocker != expected_blocker and not has_product_failure)
-        or (not run.transcript_path and run.answer != "ERROR")
-    ):
+    if not _terminal_binding_matches(run, violations, marker_count, evidence_fallback):
         raise ValueError(f"terminal exception binding mismatch: {run.run_id}")
     comparable = dict(stored)
     comparable["violations"] = violations[marker_count:]

--- a/benchmarks/codegraph_compare/smoke_bundle.py
+++ b/benchmarks/codegraph_compare/smoke_bundle.py
@@ -101,7 +101,32 @@ def _runtime_measurements_match(runtime: dict[str, Any], markers: list[str]) -> 
             "cleanup_status"
         ) != "FAILED":
             return False
-    return True
+    required = {
+        "runtime_post": runtime.get("materialized") is True
+        and runtime.get("semantic_digest_after") is None,
+        "semantic_drift": isinstance(runtime.get("semantic_digest_before"), str)
+        and isinstance(runtime.get("semantic_digest_after"), str)
+        and runtime["semantic_digest_before"] != runtime["semantic_digest_after"],
+        "index_drift": isinstance(runtime.get("expected_hash"), str)
+        and isinstance(runtime.get("frozen_hash_after"), str)
+        and runtime["expected_hash"] != runtime["frozen_hash_after"],
+        "frozen_postcheck": runtime.get("frozen_hash_after") is None,
+        "cleanup": runtime.get("cleanup_status") == "FAILED",
+    }
+    represented = {
+        "runtime_post": any(
+            marker.startswith("RUNTIME_POST_AUDIT_FAILED:") for marker in markers
+        ),
+        "semantic_drift": "RUNTIME_SEMANTIC_DRIFT" in markers,
+        "index_drift": "INDEX_CONTENT_DRIFT" in markers,
+        "frozen_postcheck": any(
+            marker.startswith("FROZEN_POSTCHECK_FAILED:") for marker in markers
+        ),
+        "cleanup": any(
+            marker.startswith("RUNTIME_CLEANUP_FAILED:") for marker in markers
+        ),
+    }
+    return represented == required
 
 
 def _validate_arm_tool_preflight(path: Path, *, require_executables: bool) -> None:
@@ -179,10 +204,15 @@ def _without_terminal_exception(
             if run.arm not in manifest.indexed_arms:
                 raise ValueError(f"runtime evidence on non-indexed arm: {run.run_id}")
             expected_identity = {
+                "schema_version": 1,
                 "experiment_id": run.experiment_id,
+                "manifest_hash": manifest.manifest_hash,
                 "session_id": run.session_id,
                 "run_id": run.run_id,
+                "repo": run.repo,
                 "arm": run.arm,
+                "repeat": run.repeat,
+                "expected_hash": dict(manifest.index_content_hashes)[run.arm],
                 "failure_codes": runtime_markers,
             }
             if any(
@@ -198,6 +228,8 @@ def _without_terminal_exception(
     if not evidence_fallback and remaining and isinstance(remaining[0], str):
         marker = remaining[0]
         if _EXECUTION_EVIDENCE_MARKER.fullmatch(marker):
+            if marker == "INDEX_CONTENT_DRIFT" and marker not in runtime_markers:
+                raise ValueError(f"runtime evidence missing for drift: {run.run_id}")
             marker_count += 1
     if marker_count == 0:
         return stored

--- a/benchmarks/codegraph_compare/smoke_bundle.py
+++ b/benchmarks/codegraph_compare/smoke_bundle.py
@@ -75,6 +75,10 @@ def _valid_runtime_marker_sequence(markers: list[str]) -> bool:
 
 
 def _runtime_measurements_match(runtime: dict[str, Any], markers: list[str]) -> bool:
+    if runtime.get("cleanup_status") in {"SUCCESS", "FAILED"} and runtime.get(
+        "materialized"
+    ) is not True:
+        return False
     for marker in markers:
         if marker.startswith("RUNTIME_POST_AUDIT_FAILED:") and (
             runtime.get("semantic_digest_after") is not None
@@ -102,8 +106,6 @@ def _runtime_measurements_match(runtime: dict[str, Any], markers: list[str]) -> 
         ) != "FAILED":
             return False
     required = {
-        "runtime_post": runtime.get("materialized") is True
-        and runtime.get("semantic_digest_after") is None,
         "semantic_drift": isinstance(runtime.get("semantic_digest_before"), str)
         and isinstance(runtime.get("semantic_digest_after"), str)
         and runtime["semantic_digest_before"] != runtime["semantic_digest_after"],
@@ -114,9 +116,6 @@ def _runtime_measurements_match(runtime: dict[str, Any], markers: list[str]) -> 
         "cleanup": runtime.get("cleanup_status") == "FAILED",
     }
     represented = {
-        "runtime_post": any(
-            marker.startswith("RUNTIME_POST_AUDIT_FAILED:") for marker in markers
-        ),
         "semantic_drift": "RUNTIME_SEMANTIC_DRIFT" in markers,
         "index_drift": "INDEX_CONTENT_DRIFT" in markers,
         "frozen_postcheck": any(
@@ -190,7 +189,7 @@ def _without_terminal_exception(
     )
     runtime_path = evidence / f"runtime_index_{run.run_id}.json"
     runtime_markers: list[str] = []
-    if runtime_path.is_file() and not evidence_fallback:
+    if runtime_path.is_file():
         runtime = _json(runtime_path)
         failure_codes = runtime.get("failure_codes")
         if not isinstance(failure_codes, list) or not all(
@@ -200,27 +199,25 @@ def _without_terminal_exception(
         ) or not _valid_runtime_marker_sequence(failure_codes):
             raise ValueError(f"runtime evidence marker mismatch: {run.run_id}")
         runtime_markers = failure_codes
-        if runtime_markers:
-            if run.arm not in manifest.indexed_arms:
-                raise ValueError(f"runtime evidence on non-indexed arm: {run.run_id}")
-            expected_identity = {
-                "schema_version": 1,
-                "experiment_id": run.experiment_id,
-                "manifest_hash": manifest.manifest_hash,
-                "session_id": run.session_id,
-                "run_id": run.run_id,
-                "repo": run.repo,
-                "arm": run.arm,
-                "repeat": run.repeat,
-                "expected_hash": dict(manifest.index_content_hashes)[run.arm],
-                "failure_codes": runtime_markers,
-            }
-            if any(
-                runtime.get(key) != value for key, value in expected_identity.items()
-            ):
-                raise ValueError(f"runtime evidence binding mismatch: {run.run_id}")
-            if not _runtime_measurements_match(runtime, runtime_markers):
-                raise ValueError(f"runtime evidence measurement mismatch: {run.run_id}")
+        if run.arm not in manifest.indexed_arms:
+            raise ValueError(f"runtime evidence on non-indexed arm: {run.run_id}")
+        expected_identity = {
+            "schema_version": 1,
+            "experiment_id": run.experiment_id,
+            "manifest_hash": manifest.manifest_hash,
+            "session_id": run.session_id,
+            "run_id": run.run_id,
+            "repo": run.repo,
+            "arm": run.arm,
+            "repeat": run.repeat,
+            "expected_hash": dict(manifest.index_content_hashes)[run.arm],
+            "failure_codes": runtime_markers,
+        }
+        if any(runtime.get(key) != value for key, value in expected_identity.items()):
+            raise ValueError(f"runtime evidence binding mismatch: {run.run_id}")
+        if not _runtime_measurements_match(runtime, runtime_markers):
+            raise ValueError(f"runtime evidence measurement mismatch: {run.run_id}")
+        if not evidence_fallback:
             if violations[: len(runtime_markers)] != runtime_markers:
                 raise ValueError(f"runtime evidence ordering mismatch: {run.run_id}")
     marker_count = 1 if evidence_fallback else len(runtime_markers)
@@ -228,7 +225,7 @@ def _without_terminal_exception(
     if not evidence_fallback and remaining and isinstance(remaining[0], str):
         marker = remaining[0]
         if _EXECUTION_EVIDENCE_MARKER.fullmatch(marker):
-            if marker == "INDEX_CONTENT_DRIFT" and marker not in runtime_markers:
+            if marker == "INDEX_CONTENT_DRIFT" and not runtime_path.is_file():
                 raise ValueError(f"runtime evidence missing for drift: {run.run_id}")
             marker_count += 1
     if marker_count == 0:

--- a/benchmarks/codegraph_compare/smoke_bundle.py
+++ b/benchmarks/codegraph_compare/smoke_bundle.py
@@ -25,8 +25,10 @@ _PLAN_FILES = (
     "model-preflight.json",
     "workspace-evidence.json",
 )
-_TERMINAL_EXCEPTION = re.compile(
-    r"^(?:EXECUTION|EVIDENCE)_EXCEPTION:[A-Za-z_][A-Za-z0-9_]*$"
+_TERMINAL_EVIDENCE_MARKER = re.compile(
+    r"^(?:(?:EXECUTION|EVIDENCE)_EXCEPTION|"
+    r"(?:RUNTIME_POST_AUDIT|FROZEN_POSTCHECK|RUNTIME_CLEANUP)_FAILED):"
+    r"[A-Za-z_][A-Za-z0-9_]*$|^(?:INDEX_CONTENT|RUNTIME_SEMANTIC)_DRIFT$"
 )
 _ARM_TOOL_SERVERS = {
     "tsa-warm": "tree-sitter-analyzer",
@@ -90,15 +92,20 @@ def _copy_tree_files(source: Path, destination: Path) -> None:
 def _without_terminal_exception(
     stored: dict[str, Any], run: RunRecordV1
 ) -> dict[str, Any]:
-    """Validate and remove one terminal marker before transcript comparison."""
+    """Validate and remove terminal markers before transcript comparison."""
 
     violations = stored.get("violations")
-    if (
-        not isinstance(violations, list)
-        or not violations
-        or not isinstance(violations[0], str)
-        or _TERMINAL_EXCEPTION.fullmatch(violations[0]) is None
-    ):
+    if not isinstance(violations, list) or not violations:
+        return stored
+    marker_count = 0
+    for violation in violations:
+        if (
+            not isinstance(violation, str)
+            or _TERMINAL_EVIDENCE_MARKER.fullmatch(violation) is None
+        ):
+            break
+        marker_count += 1
+    if marker_count == 0:
         return stored
     expected_blocker = "POLICY_AUDIT:" + ",".join(violations)
     if (
@@ -108,7 +115,7 @@ def _without_terminal_exception(
     ):
         raise ValueError(f"terminal exception binding mismatch: {run.run_id}")
     comparable = dict(stored)
-    comparable["violations"] = violations[1:]
+    comparable["violations"] = violations[marker_count:]
     return comparable
 
 

--- a/benchmarks/codegraph_compare/smoke_bundle.py
+++ b/benchmarks/codegraph_compare/smoke_bundle.py
@@ -130,9 +130,12 @@ def _without_terminal_exception(
     violations = stored.get("violations")
     if not isinstance(violations, list) or not violations:
         return stored
+    evidence_fallback = isinstance(violations[0], str) and bool(
+        _EVIDENCE_EXCEPTION_MARKER.fullmatch(violations[0])
+    )
     runtime_path = evidence / f"runtime_index_{run.run_id}.json"
     runtime_markers: list[str] = []
-    if runtime_path.is_file():
+    if runtime_path.is_file() and not evidence_fallback:
         runtime = _json(runtime_path)
         failure_codes = runtime.get("failure_codes")
         if not isinstance(failure_codes, list) or not all(
@@ -158,15 +161,11 @@ def _without_terminal_exception(
                 raise ValueError(f"runtime evidence binding mismatch: {run.run_id}")
             if violations[: len(runtime_markers)] != runtime_markers:
                 raise ValueError(f"runtime evidence ordering mismatch: {run.run_id}")
-    marker_count = len(runtime_markers)
+    marker_count = 1 if evidence_fallback else len(runtime_markers)
     remaining = violations[marker_count:]
-    if remaining and isinstance(remaining[0], str):
+    if not evidence_fallback and remaining and isinstance(remaining[0], str):
         marker = remaining[0]
         if _EXECUTION_EVIDENCE_MARKER.fullmatch(marker):
-            marker_count += 1
-        elif _EVIDENCE_EXCEPTION_MARKER.fullmatch(marker):
-            if runtime_markers:
-                raise ValueError(f"terminal evidence ordering mismatch: {run.run_id}")
             marker_count += 1
     if marker_count == 0:
         return stored

--- a/benchmarks/codegraph_compare/smoke_bundle.py
+++ b/benchmarks/codegraph_compare/smoke_bundle.py
@@ -74,6 +74,36 @@ def _valid_runtime_marker_sequence(markers: list[str]) -> bool:
     return index == len(markers)
 
 
+def _runtime_measurements_match(runtime: dict[str, Any], markers: list[str]) -> bool:
+    for marker in markers:
+        if marker.startswith("RUNTIME_POST_AUDIT_FAILED:") and (
+            runtime.get("semantic_digest_after") is not None
+            or runtime.get("post_paths") is not None
+        ):
+            return False
+        if marker == "RUNTIME_SEMANTIC_DRIFT" and (
+            not isinstance(runtime.get("semantic_digest_before"), str)
+            or not isinstance(runtime.get("semantic_digest_after"), str)
+            or runtime["semantic_digest_before"] == runtime["semantic_digest_after"]
+        ):
+            return False
+        if marker == "INDEX_CONTENT_DRIFT" and (
+            not isinstance(runtime.get("expected_hash"), str)
+            or not isinstance(runtime.get("frozen_hash_after"), str)
+            or runtime["expected_hash"] == runtime["frozen_hash_after"]
+        ):
+            return False
+        if marker.startswith("FROZEN_POSTCHECK_FAILED:") and runtime.get(
+            "frozen_hash_after"
+        ) is not None:
+            return False
+        if marker.startswith("RUNTIME_CLEANUP_FAILED:") and runtime.get(
+            "cleanup_status"
+        ) != "FAILED":
+            return False
+    return True
+
+
 def _validate_arm_tool_preflight(path: Path, *, require_executables: bool) -> None:
     raw = _json(path)
     if not isinstance(raw, dict) or set(raw) != set(_ARM_TOOL_SERVERS):
@@ -159,6 +189,8 @@ def _without_terminal_exception(
                 runtime.get(key) != value for key, value in expected_identity.items()
             ):
                 raise ValueError(f"runtime evidence binding mismatch: {run.run_id}")
+            if not _runtime_measurements_match(runtime, runtime_markers):
+                raise ValueError(f"runtime evidence measurement mismatch: {run.run_id}")
             if violations[: len(runtime_markers)] != runtime_markers:
                 raise ValueError(f"runtime evidence ordering mismatch: {run.run_id}")
     marker_count = 1 if evidence_fallback else len(runtime_markers)

--- a/tests/unit/test_benchmark_harness.py
+++ b/tests/unit/test_benchmark_harness.py
@@ -4203,7 +4203,6 @@ class TestGinSmokeBundle:
         policy["observed_mcp_tools"] = []
         policy["violations"] = violations
         policy_path.write_text(json.dumps(policy) + "\n", encoding="utf-8")
-
         # Issue #1201: immutable INVALID evidence predates transcript retention.
         digest = create_smoke_bundle(
             tmp_path / "bundle",
@@ -4213,6 +4212,97 @@ class TestGinSmokeBundle:
         )
 
         assert len(digest) == 64
+
+    def test_bundle_accepts_runtime_marker_with_product_failure(self, tmp_path: Path):
+        from benchmarks.codegraph_compare.smoke_bundle import create_smoke_bundle
+
+        plan, experiment, registry = self._bundle_inputs(tmp_path)
+        runs_path = experiment / "runs.jsonl"
+        runs = [
+            json.loads(line)
+            for line in runs_path.read_text(encoding="utf-8").splitlines()
+        ]
+        run = runs[0]
+        policy_path = experiment / f"policy_{run['run_id']}.json"
+        policy = json.loads(policy_path.read_text(encoding="utf-8"))
+        marker = "RUNTIME_CLEANUP_FAILED:OSError"
+        policy["violations"] = [marker, *policy["violations"]]
+        policy_path.write_text(json.dumps(policy) + "\n", encoding="utf-8")
+        run["status"] = "INVALID"
+        run["blocker_reason"] = (
+            "POLICY_AUDIT:"
+            + ",".join(policy["violations"])
+            + ";PRODUCT_FAILURE:backend unavailable"
+        )
+        runs_path.write_text(
+            "".join(json.dumps(item) + "\n" for item in runs), encoding="utf-8"
+        )
+        (experiment / f"runtime_index_{run['run_id']}.json").write_text(
+            json.dumps(
+                {
+                    "experiment_id": run["experiment_id"],
+                    "session_id": run["session_id"],
+                    "run_id": run["run_id"],
+                    "arm": run["arm"],
+                    "failure_codes": [marker],
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        # Issue #1219: product failures remain bound to runtime policy evidence.
+        digest = create_smoke_bundle(
+            tmp_path / "bundle",
+            plan_dir=plan,
+            experiment_dir=experiment,
+            registry_path=registry,
+        )
+
+        assert len(digest) == 64
+
+    def test_bundle_rejects_runtime_marker_missing_from_audit(self, tmp_path: Path):
+        from benchmarks.codegraph_compare.smoke_bundle import create_smoke_bundle
+
+        plan, experiment, registry = self._bundle_inputs(tmp_path)
+        runs_path = experiment / "runs.jsonl"
+        runs = [
+            json.loads(line)
+            for line in runs_path.read_text(encoding="utf-8").splitlines()
+        ]
+        run = runs[0]
+        policy_path = experiment / f"policy_{run['run_id']}.json"
+        policy = json.loads(policy_path.read_text(encoding="utf-8"))
+        marker = "RUNTIME_POST_AUDIT_FAILED:ValueError"
+        policy["violations"] = [marker, *policy["violations"]]
+        policy_path.write_text(json.dumps(policy) + "\n", encoding="utf-8")
+        run["status"] = "INVALID"
+        run["blocker_reason"] = "POLICY_AUDIT:" + ",".join(policy["violations"])
+        runs_path.write_text(
+            "".join(json.dumps(item) + "\n" for item in runs), encoding="utf-8"
+        )
+        (experiment / f"runtime_index_{run['run_id']}.json").write_text(
+            json.dumps(
+                {
+                    "experiment_id": run["experiment_id"],
+                    "session_id": run["session_id"],
+                    "run_id": run["run_id"],
+                    "arm": run["arm"],
+                    "failure_codes": ["RUNTIME_SEMANTIC_DRIFT"],
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        # Issue #1219: a policy marker cannot self-authorize runtime evidence.
+        with pytest.raises(ValueError, match="runtime evidence binding mismatch"):
+            create_smoke_bundle(
+                tmp_path / "bundle",
+                plan_dir=plan,
+                experiment_dir=experiment,
+                registry_path=registry,
+            )
 
     def test_bundle_accepts_bound_runtime_post_audit_failure(self, tmp_path: Path):
         from benchmarks.codegraph_compare.smoke_bundle import create_smoke_bundle
@@ -4235,6 +4325,19 @@ class TestGinSmokeBundle:
         )
         policy["violations"] = violations
         policy_path.write_text(json.dumps(policy) + "\n", encoding="utf-8")
+        (experiment / f"runtime_index_{run['run_id']}.json").write_text(
+            json.dumps(
+                {
+                    "experiment_id": run["experiment_id"],
+                    "session_id": run["session_id"],
+                    "run_id": run["run_id"],
+                    "arm": run["arm"],
+                    "failure_codes": [violations[0]],
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
 
         # Issue #1219: runtime terminal evidence must remain bundleable.
         digest = create_smoke_bundle(

--- a/tests/unit/test_benchmark_harness.py
+++ b/tests/unit/test_benchmark_harness.py
@@ -4214,6 +4214,38 @@ class TestGinSmokeBundle:
 
         assert len(digest) == 64
 
+    def test_bundle_accepts_bound_runtime_post_audit_failure(self, tmp_path: Path):
+        from benchmarks.codegraph_compare.smoke_bundle import create_smoke_bundle
+
+        plan, experiment, registry = self._bundle_inputs(tmp_path)
+        runs_path = experiment / "runs.jsonl"
+        runs = [
+            json.loads(line)
+            for line in runs_path.read_text(encoding="utf-8").splitlines()
+        ]
+        run = runs[0]
+        policy_path = experiment / f"policy_{run['run_id']}.json"
+        policy = json.loads(policy_path.read_text(encoding="utf-8"))
+        violations = ["RUNTIME_POST_AUDIT_FAILED:ValueError", *policy["violations"]]
+        run["status"] = "INVALID"
+        run["blocker_reason"] = "POLICY_AUDIT:" + ",".join(violations)
+        runs_path.write_text(
+            "".join(json.dumps(item) + "\n" for item in runs),
+            encoding="utf-8",
+        )
+        policy["violations"] = violations
+        policy_path.write_text(json.dumps(policy) + "\n", encoding="utf-8")
+
+        # Issue #1219: runtime terminal evidence must remain bundleable.
+        digest = create_smoke_bundle(
+            tmp_path / "bundle",
+            plan_dir=plan,
+            experiment_dir=experiment,
+            registry_path=registry,
+        )
+
+        assert len(digest) == 64
+
     def test_bundle_replay_is_byte_identical(self, tmp_path: Path):
         from benchmarks.codegraph_compare.smoke_bundle import (
             create_smoke_bundle,

--- a/tests/unit/test_benchmark_harness.py
+++ b/tests/unit/test_benchmark_harness.py
@@ -4296,7 +4296,7 @@ class TestGinSmokeBundle:
         )
 
         # Issue #1219: a policy marker cannot self-authorize runtime evidence.
-        with pytest.raises(ValueError, match="runtime evidence binding mismatch"):
+        with pytest.raises(ValueError, match="runtime evidence ordering mismatch"):
             create_smoke_bundle(
                 tmp_path / "bundle",
                 plan_dir=plan,

--- a/tests/unit/test_benchmark_harness.py
+++ b/tests/unit/test_benchmark_harness.py
@@ -4298,6 +4298,7 @@ class TestGinSmokeBundle:
                     "run_id": run["run_id"],
                     "arm": run["arm"],
                     "failure_codes": [marker],
+                    "cleanup_status": "FAILED",
                 }
             )
             + "\n",
@@ -4314,7 +4315,7 @@ class TestGinSmokeBundle:
 
         assert len(digest) == 64
 
-    def test_bundle_rejects_runtime_marker_missing_from_audit(self, tmp_path: Path):
+    def test_bundle_rejects_runtime_marker_contradicting_audit(self, tmp_path: Path):
         from benchmarks.codegraph_compare.smoke_bundle import create_smoke_bundle
 
         plan, experiment, registry = self._bundle_inputs(tmp_path)
@@ -4341,7 +4342,9 @@ class TestGinSmokeBundle:
                     "session_id": run["session_id"],
                     "run_id": run["run_id"],
                     "arm": run["arm"],
-                    "failure_codes": ["RUNTIME_SEMANTIC_DRIFT"],
+                    "failure_codes": [marker],
+                    "semantic_digest_after": "unexpected-digest",
+                    "post_paths": None,
                 }
             )
             + "\n",
@@ -4349,7 +4352,7 @@ class TestGinSmokeBundle:
         )
 
         # Issue #1219: a policy marker cannot self-authorize runtime evidence.
-        with pytest.raises(ValueError, match="runtime evidence ordering mismatch"):
+        with pytest.raises(ValueError, match="runtime evidence measurement mismatch"):
             create_smoke_bundle(
                 tmp_path / "bundle",
                 plan_dir=plan,
@@ -4386,6 +4389,8 @@ class TestGinSmokeBundle:
                     "run_id": run["run_id"],
                     "arm": run["arm"],
                     "failure_codes": [violations[0]],
+                    "semantic_digest_after": None,
+                    "post_paths": None,
                 }
             )
             + "\n",

--- a/tests/unit/test_benchmark_harness.py
+++ b/tests/unit/test_benchmark_harness.py
@@ -4213,6 +4213,59 @@ class TestGinSmokeBundle:
 
         assert len(digest) == 64
 
+    def test_bundle_accepts_evidence_fallback_after_runtime_failure(
+        self, tmp_path: Path
+    ):
+        from benchmarks.codegraph_compare.smoke_bundle import create_smoke_bundle
+
+        plan, experiment, registry = self._bundle_inputs(tmp_path)
+        runs_path = experiment / "runs.jsonl"
+        runs = [
+            json.loads(line)
+            for line in runs_path.read_text(encoding="utf-8").splitlines()
+        ]
+        run = runs[0]
+        violations = ["EVIDENCE_EXCEPTION:ValueError", "TRANSCRIPT_MISSING"]
+        run["status"] = "INVALID"
+        run["answer"] = "ERROR"
+        run["transcript_path"] = ""
+        run["blocker_reason"] = "POLICY_AUDIT:" + ",".join(violations)
+        runs_path.write_text(
+            "".join(json.dumps(item) + "\n" for item in runs), encoding="utf-8"
+        )
+        policy_path = experiment / f"policy_{run['run_id']}.json"
+        policy = json.loads(policy_path.read_text(encoding="utf-8"))
+        policy.update(
+            transcript_path="",
+            observed_mcp_servers=[],
+            observed_mcp_tools=[],
+            violations=violations,
+        )
+        policy_path.write_text(json.dumps(policy) + "\n", encoding="utf-8")
+        (experiment / f"runtime_index_{run['run_id']}.json").write_text(
+            json.dumps(
+                {
+                    "experiment_id": run["experiment_id"],
+                    "session_id": run["session_id"],
+                    "run_id": run["run_id"],
+                    "arm": run["arm"],
+                    "failure_codes": ["RUNTIME_SEMANTIC_DRIFT"],
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        # Issue #1219: evidence fallback replaces the earlier runtime policy audit.
+        digest = create_smoke_bundle(
+            tmp_path / "bundle",
+            plan_dir=plan,
+            experiment_dir=experiment,
+            registry_path=registry,
+        )
+
+        assert len(digest) == 64
+
     def test_bundle_accepts_runtime_marker_with_product_failure(self, tmp_path: Path):
         from benchmarks.codegraph_compare.smoke_bundle import create_smoke_bundle
 

--- a/tests/unit/test_benchmark_harness.py
+++ b/tests/unit/test_benchmark_harness.py
@@ -4247,14 +4247,26 @@ class TestGinSmokeBundle:
             violations=violations,
         )
         policy_path.write_text(json.dumps(policy) + "\n", encoding="utf-8")
+        manifest = json.loads((plan / "experiment-manifest.json").read_text())
+        expected_hash = dict(manifest["index_content_hashes"])[run["arm"]]
         (experiment / f"runtime_index_{run['run_id']}.json").write_text(
             json.dumps(
                 {
+                    "schema_version": 1,
                     "experiment_id": run["experiment_id"],
+                    "manifest_hash": manifest["manifest_hash"],
                     "session_id": run["session_id"],
                     "run_id": run["run_id"],
+                    "repo": run["repo"],
                     "arm": run["arm"],
+                    "repeat": run["repeat"],
+                    "expected_hash": expected_hash,
                     "failure_codes": ["RUNTIME_SEMANTIC_DRIFT"],
+                    "materialized": True,
+                    "semantic_digest_before": "before-digest",
+                    "semantic_digest_after": "after-digest",
+                    "frozen_hash_after": expected_hash,
+                    "cleanup_status": "SUCCESS",
                 }
             )
             + "\n",
@@ -4310,7 +4322,7 @@ class TestGinSmokeBundle:
                     "repeat": run["repeat"],
                     "expected_hash": expected_hash,
                     "failure_codes": [marker],
-                    "materialized": False,
+                    "materialized": True,
                     "semantic_digest_before": "same-digest",
                     "semantic_digest_after": "same-digest",
                     "frozen_hash_after": expected_hash,

--- a/tests/unit/test_benchmark_harness.py
+++ b/tests/unit/test_benchmark_harness.py
@@ -4037,7 +4037,12 @@ class TestGinSmokeBundle:
         from benchmarks.codegraph_compare.integrity import RegistryEvent
         from benchmarks.codegraph_compare.smoke_policy import PolicyAudit
 
-        manifest = _v1_manifest()
+        manifest = _v1_manifest(
+            index_content_hashes={
+                "codegraph-warm": "codegraph-index-hash",
+                "tsa-warm": "tsa-index-hash",
+            },
+        )
         plan = tmp_path / "plan-source"
         plan.mkdir()
         (plan / "experiment-manifest.json").write_text(
@@ -4290,14 +4295,25 @@ class TestGinSmokeBundle:
         runs_path.write_text(
             "".join(json.dumps(item) + "\n" for item in runs), encoding="utf-8"
         )
+        manifest = json.loads((plan / "experiment-manifest.json").read_text())
+        expected_hash = dict(manifest["index_content_hashes"])[run["arm"]]
         (experiment / f"runtime_index_{run['run_id']}.json").write_text(
             json.dumps(
                 {
+                    "schema_version": 1,
                     "experiment_id": run["experiment_id"],
+                    "manifest_hash": manifest["manifest_hash"],
                     "session_id": run["session_id"],
                     "run_id": run["run_id"],
+                    "repo": run["repo"],
                     "arm": run["arm"],
+                    "repeat": run["repeat"],
+                    "expected_hash": expected_hash,
                     "failure_codes": [marker],
+                    "materialized": False,
+                    "semantic_digest_before": "same-digest",
+                    "semantic_digest_after": "same-digest",
+                    "frozen_hash_after": expected_hash,
                     "cleanup_status": "FAILED",
                 }
             )
@@ -4335,16 +4351,27 @@ class TestGinSmokeBundle:
         runs_path.write_text(
             "".join(json.dumps(item) + "\n" for item in runs), encoding="utf-8"
         )
+        manifest = json.loads((plan / "experiment-manifest.json").read_text())
+        expected_hash = dict(manifest["index_content_hashes"])[run["arm"]]
         (experiment / f"runtime_index_{run['run_id']}.json").write_text(
             json.dumps(
                 {
+                    "schema_version": 1,
                     "experiment_id": run["experiment_id"],
+                    "manifest_hash": manifest["manifest_hash"],
                     "session_id": run["session_id"],
                     "run_id": run["run_id"],
+                    "repo": run["repo"],
                     "arm": run["arm"],
+                    "repeat": run["repeat"],
+                    "expected_hash": expected_hash,
                     "failure_codes": [marker],
+                    "materialized": True,
+                    "semantic_digest_before": "original-digest",
                     "semantic_digest_after": "unexpected-digest",
                     "post_paths": None,
+                    "frozen_hash_after": expected_hash,
+                    "cleanup_status": "SUCCESS",
                 }
             )
             + "\n",
@@ -4381,16 +4408,27 @@ class TestGinSmokeBundle:
         )
         policy["violations"] = violations
         policy_path.write_text(json.dumps(policy) + "\n", encoding="utf-8")
+        manifest = json.loads((plan / "experiment-manifest.json").read_text())
+        expected_hash = dict(manifest["index_content_hashes"])[run["arm"]]
         (experiment / f"runtime_index_{run['run_id']}.json").write_text(
             json.dumps(
                 {
+                    "schema_version": 1,
                     "experiment_id": run["experiment_id"],
+                    "manifest_hash": manifest["manifest_hash"],
                     "session_id": run["session_id"],
                     "run_id": run["run_id"],
+                    "repo": run["repo"],
                     "arm": run["arm"],
+                    "repeat": run["repeat"],
+                    "expected_hash": expected_hash,
                     "failure_codes": [violations[0]],
+                    "materialized": True,
+                    "semantic_digest_before": "original-digest",
                     "semantic_digest_after": None,
                     "post_paths": None,
+                    "frozen_hash_after": expected_hash,
+                    "cleanup_status": "SUCCESS",
                 }
             )
             + "\n",

--- a/tests/unit/test_benchmark_harness.py
+++ b/tests/unit/test_benchmark_harness.py
@@ -4249,6 +4249,7 @@ class TestGinSmokeBundle:
         policy_path.write_text(json.dumps(policy) + "\n", encoding="utf-8")
         manifest = json.loads((plan / "experiment-manifest.json").read_text())
         expected_hash = dict(manifest["index_content_hashes"])[run["arm"]]
+        expected_paths = run["index_stats"]["indexed_paths"]
         (experiment / f"runtime_index_{run['run_id']}.json").write_text(
             json.dumps(
                 {
@@ -4261,10 +4262,15 @@ class TestGinSmokeBundle:
                     "arm": run["arm"],
                     "repeat": run["repeat"],
                     "expected_hash": expected_hash,
+                    "expected_paths": expected_paths,
                     "failure_codes": ["RUNTIME_SEMANTIC_DRIFT"],
                     "materialized": True,
+                    "runtime_hash_before": expected_hash,
+                    "runtime_hash_after": expected_hash,
+                    "runtime_mutated": False,
                     "semantic_digest_before": "before-digest",
                     "semantic_digest_after": "after-digest",
+                    "post_paths": expected_paths,
                     "frozen_hash_after": expected_hash,
                     "cleanup_status": "SUCCESS",
                 }
@@ -4282,6 +4288,28 @@ class TestGinSmokeBundle:
         )
 
         assert len(digest) == 64
+
+        runtime_path = experiment / f"runtime_index_{run['run_id']}.json"
+        valid_runtime = json.loads(runtime_path.read_text(encoding="utf-8"))
+        for name, mutation, message in (
+            ("wrong-paths", {"expected_paths": ["unrelated.go"]}, "path mismatch"),
+            (
+                "wrong-baseline",
+                {"runtime_hash_before": "wrong"},
+                "measurement mismatch",
+            ),
+            ("wrong-mutated", {"runtime_mutated": True}, "measurement mismatch"),
+        ):
+            runtime_path.write_text(
+                json.dumps({**valid_runtime, **mutation}) + "\n", encoding="utf-8"
+            )
+            with pytest.raises(ValueError, match=message):
+                create_smoke_bundle(
+                    tmp_path / f"bundle-{name}",
+                    plan_dir=plan,
+                    experiment_dir=experiment,
+                    registry_path=registry,
+                )
 
     def test_bundle_accepts_runtime_marker_with_product_failure(self, tmp_path: Path):
         from benchmarks.codegraph_compare.smoke_bundle import create_smoke_bundle
@@ -4309,6 +4337,7 @@ class TestGinSmokeBundle:
         )
         manifest = json.loads((plan / "experiment-manifest.json").read_text())
         expected_hash = dict(manifest["index_content_hashes"])[run["arm"]]
+        expected_paths = run["index_stats"]["indexed_paths"]
         (experiment / f"runtime_index_{run['run_id']}.json").write_text(
             json.dumps(
                 {
@@ -4321,10 +4350,15 @@ class TestGinSmokeBundle:
                     "arm": run["arm"],
                     "repeat": run["repeat"],
                     "expected_hash": expected_hash,
+                    "expected_paths": expected_paths,
                     "failure_codes": [marker],
                     "materialized": True,
+                    "runtime_hash_before": expected_hash,
+                    "runtime_hash_after": expected_hash,
+                    "runtime_mutated": False,
                     "semantic_digest_before": "same-digest",
                     "semantic_digest_after": "same-digest",
+                    "post_paths": expected_paths,
                     "frozen_hash_after": expected_hash,
                     "cleanup_status": "FAILED",
                 }
@@ -4365,6 +4399,7 @@ class TestGinSmokeBundle:
         )
         manifest = json.loads((plan / "experiment-manifest.json").read_text())
         expected_hash = dict(manifest["index_content_hashes"])[run["arm"]]
+        expected_paths = run["index_stats"]["indexed_paths"]
         (experiment / f"runtime_index_{run['run_id']}.json").write_text(
             json.dumps(
                 {
@@ -4377,11 +4412,15 @@ class TestGinSmokeBundle:
                     "arm": run["arm"],
                     "repeat": run["repeat"],
                     "expected_hash": expected_hash,
+                    "expected_paths": expected_paths,
                     "failure_codes": [marker],
                     "materialized": True,
+                    "runtime_hash_before": expected_hash,
+                    "runtime_hash_after": expected_hash,
+                    "runtime_mutated": False,
                     "semantic_digest_before": "original-digest",
                     "semantic_digest_after": "unexpected-digest",
-                    "post_paths": None,
+                    "post_paths": expected_paths,
                     "frozen_hash_after": expected_hash,
                     "cleanup_status": "SUCCESS",
                 }
@@ -4411,17 +4450,25 @@ class TestGinSmokeBundle:
         run = runs[0]
         policy_path = experiment / f"policy_{run['run_id']}.json"
         policy = json.loads(policy_path.read_text(encoding="utf-8"))
-        violations = ["RUNTIME_POST_AUDIT_FAILED:ValueError", *policy["violations"]]
+        violations = ["RUNTIME_POST_AUDIT_FAILED:ValueError", "TRANSCRIPT_MISSING"]
         run["status"] = "INVALID"
+        run["answer"] = "retained backend answer"
+        run["transcript_path"] = ""
         run["blocker_reason"] = "POLICY_AUDIT:" + ",".join(violations)
         runs_path.write_text(
             "".join(json.dumps(item) + "\n" for item in runs),
             encoding="utf-8",
         )
-        policy["violations"] = violations
+        policy.update(
+            transcript_path="",
+            observed_mcp_servers=[],
+            observed_mcp_tools=[],
+            violations=violations,
+        )
         policy_path.write_text(json.dumps(policy) + "\n", encoding="utf-8")
         manifest = json.loads((plan / "experiment-manifest.json").read_text())
         expected_hash = dict(manifest["index_content_hashes"])[run["arm"]]
+        expected_paths = run["index_stats"]["indexed_paths"]
         (experiment / f"runtime_index_{run['run_id']}.json").write_text(
             json.dumps(
                 {
@@ -4434,8 +4481,12 @@ class TestGinSmokeBundle:
                     "arm": run["arm"],
                     "repeat": run["repeat"],
                     "expected_hash": expected_hash,
+                    "expected_paths": expected_paths,
                     "failure_codes": [violations[0]],
                     "materialized": True,
+                    "runtime_hash_before": expected_hash,
+                    "runtime_hash_after": expected_hash,
+                    "runtime_mutated": False,
                     "semantic_digest_before": "original-digest",
                     "semantic_digest_after": None,
                     "post_paths": None,


### PR DESCRIPTION
Closes #1219
Unblocks terminal evidence retention for #1218 / #1195.

## Summary
- recognize only execution-emitted runtime/frozen-index terminal marker grammars
- require exact INVALID/blocker binding before excluding those markers from transcript re-audit
- support multiple leading runtime markers while arbitrary markers remain fail-closed
- add exact #1219 regression coverage

## Verification
- `uv run --frozen pytest -q tests/unit/test_benchmark_harness.py --cov=tree_sitter_analyzer --cov-report=json` (244 passed, 1 rerun)
- patch coverage: no added executable misses
- `uv run --frozen pytest -q` (1316 passed, 1 skipped)
- ruff + mypy passed
- actual NO1-002B bundle validated and replayed byte-identically; digest `c8e118566e92a1c2b940c8aa033887e6a37379e9e6b187ba5d8dd1eacc0913c3`
