### PR TITLE
fix(benchmarks): add fail-closed canary qualification

### DIFF
--- a/benchmarks/codegraph_compare/_canary_evidence_replay.py
+++ b/benchmarks/codegraph_compare/_canary_evidence_replay.py
@@ -1,0 +1,209 @@
+"""Semantic replay helpers for NO1-002C evidence artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from benchmarks.codegraph_compare.canary_policy import audit_canary_transcript
+
+_TOOLS = {"tsa-warm": "nav", "codegraph-warm": "codegraph_search"}
+_ORACLE = {
+    "expected_path": "gin.go",
+    "expected_symbol": "Engine.ServeHTTP",
+    "expected_kind": "method",
+}
+_WORKSPACE_KEYS = {
+    "schema_version",
+    "manifest_hash",
+    "session_id",
+    "run_id",
+    "cell_id",
+    "arm",
+    "audit_sha256",
+    "audit",
+}
+_AUDIT_KEYS = {
+    "checkout_root",
+    "head_commit",
+    "tracked_paths",
+    "repository_fingerprint",
+    "source_before",
+    "source_after",
+    "runtime_namespace",
+    "runtime_before",
+    "runtime_after",
+}
+
+
+def read_if_file(path: Path | None) -> bytes | None:
+    try:
+        return path.read_bytes() if path is not None and path.is_file() else None
+    except OSError:
+        return None
+
+
+def workspace_envelope(
+    manifest_hash: str,
+    session_id: str,
+    run_id: str,
+    cell: Any,
+    audit_hash: str,
+    audit: Any,
+) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "manifest_hash": manifest_hash,
+        "session_id": session_id,
+        "run_id": run_id,
+        "cell_id": cell.cell_id,
+        "arm": cell.arm,
+        "audit_sha256": audit_hash,
+        "audit": audit,
+    }
+
+
+def _json_object(payload: bytes) -> dict[str, Any] | None:
+    try:
+        value = json.loads(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    return value if type(value) is dict else None
+
+
+def _sha256_json(value: Any) -> str:
+    encoded = json.dumps(
+        value, ensure_ascii=True, allow_nan=False, separators=(",", ":"), sort_keys=True
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _valid_inventory(value: Any) -> bool:
+    return type(value) is list and all(
+        type(item) is list
+        and len(item) == 2
+        and type(item[0]) is str
+        and bool(item[0])
+        and type(item[1]) is str
+        and len(item[1]) == 64
+        for item in value
+    )
+
+
+def _workspace_audit_valid(audit: Any, arm: str) -> bool:
+    if type(audit) is not dict or set(audit) != _AUDIT_KEYS:
+        return False
+    namespace = ".ast-cache" if arm == "tsa-warm" else ".codegraph"
+    return (
+        type(audit["checkout_root"]) is str
+        and Path(audit["checkout_root"]).is_absolute()
+        and type(audit["head_commit"]) is str
+        and bool(audit["head_commit"])
+        and type(audit["tracked_paths"]) is list
+        and all(type(path) is str and path for path in audit["tracked_paths"])
+        and type(audit["repository_fingerprint"]) is str
+        and len(audit["repository_fingerprint"]) == 64
+        and _valid_inventory(audit["source_before"])
+        and audit["source_after"] == audit["source_before"]
+        and audit["runtime_namespace"] == namespace
+        and _valid_inventory(audit["runtime_before"])
+        and _valid_inventory(audit["runtime_after"])
+    )
+
+
+def replay_artifact_semantics(
+    attempt: Any, payloads: dict[str, tuple[Path, bytes]]
+) -> bool:
+    """Replay receipt/source-order semantics and exact workspace bindings."""
+
+    receipt = _json_object(payloads["receipt"][1])
+    if receipt != {"call_id": attempt.receipt_call_id}:
+        return False
+    transcript_path = payloads["transcript"][0]
+    try:
+        audit = audit_canary_transcript(
+            transcript_path,
+            attempt.arm,
+            expected_tool=_TOOLS[attempt.arm],
+            **_ORACLE,
+        )
+    except (KeyError, OSError, TypeError, ValueError):
+        return False
+    if (
+        audit.violations
+        or audit.receipt is None
+        or audit.receipt.call_id != attempt.receipt_call_id
+    ):
+        return False
+    workspace = _json_object(payloads["workspace_audit"][1])
+    expected_workspace = {
+        "schema_version": 1,
+        "manifest_hash": attempt.manifest_hash,
+        "session_id": attempt.session_id,
+        "run_id": attempt.run_id,
+        "cell_id": attempt.cell_id,
+        "arm": attempt.arm,
+        "audit_sha256": attempt.workspace_audit_sha256,
+        "audit": workspace.get("audit") if workspace is not None else None,
+    }
+    if workspace is None or set(workspace) != _WORKSPACE_KEYS:
+        return False
+    if workspace != expected_workspace:
+        return False
+    if not _workspace_audit_valid(workspace["audit"], attempt.arm):
+        return False
+    if _sha256_json(workspace["audit"]) != attempt.workspace_audit_sha256:
+        return False
+    return payloads["runtime"][1] == attempt.runtime_hash.encode("ascii")
+
+
+def artifacts_are_bound(
+    attempt: Any, artifacts: tuple[Any, ...], expected_hashes: dict[str, str]
+) -> bool:
+    """Read every artifact and verify its digest, binding, and semantics."""
+
+    payloads: dict[str, tuple[Path, bytes]] = {}
+    for item in artifacts:
+        try:
+            path = Path(item.evidence_path)
+            payload = path.read_bytes()
+        except (OSError, TypeError, ValueError):
+            return False
+        expected = (
+            hashlib.sha256(
+                json.dumps(
+                    {"call_id": attempt.receipt_call_id},
+                    ensure_ascii=True,
+                    separators=(",", ":"),
+                    sort_keys=True,
+                ).encode()
+            ).hexdigest()
+            if item.kind == "receipt"
+            else expected_hashes[item.kind]
+        )
+        if item.kind == "runtime":
+            content_bound = payload == attempt.runtime_hash.encode("ascii")
+        elif item.kind == "workspace_audit":
+            content_bound = True
+        else:
+            content_bound = item.sha256 == expected
+        receipt_bound = (
+            item.receipt_call_id == attempt.receipt_call_id
+            if item.kind == "receipt"
+            else item.receipt_call_id is None
+        )
+        if not (
+            path.is_absolute()
+            and hashlib.sha256(payload).hexdigest() == item.sha256
+            and type(item.schema_version) is int
+            and item.schema_version == 1
+            and item.manifest_hash == attempt.manifest_hash
+            and item.session_id == attempt.session_id
+            and content_bound
+            and receipt_bound
+        ):
+            return False
+        payloads[item.kind] = (path, payload)
+    return replay_artifact_semantics(attempt, payloads)

--- a/benchmarks/codegraph_compare/canary_evidence.py
+++ b/benchmarks/codegraph_compare/canary_evidence.py
@@ -1,0 +1,478 @@
+"""Frozen, model-free evidence contract for the NO1-002C E0 canary."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Iterable
+from dataclasses import asdict, dataclass, replace
+from typing import Any
+
+from benchmarks.codegraph_compare._canary_evidence_replay import artifacts_are_bound
+
+SCHEMA_VERSION = 1
+PROTOCOL = "NO1-002C"
+EXPECTED_CELLS = (
+    ("tsa-warm-canary", "tsa-warm", 0),
+    ("codegraph-warm-canary", "codegraph-warm", 1),
+)
+EXPECTED_ORACLE = ("gin.go", "Engine.ServeHTTP", "method")
+ARTIFACT_KINDS = ("receipt", "transcript", "workspace_audit", "runtime")
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    """Serialize evidence deterministically, rejecting non-JSON values."""
+
+    try:
+        encoded = json.dumps(
+            value,
+            ensure_ascii=True,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    except (TypeError, ValueError) as error:
+        raise ValueError("value is not canonical JSON") from error
+    return encoded.encode("utf-8")
+
+
+def canonical_sha256(value: Any) -> str:
+    return hashlib.sha256(canonical_json_bytes(value)).hexdigest()
+
+
+def _nonempty(value: object, label: str) -> str:
+    if type(value) is not str or not value:
+        raise ValueError(f"{label} must be a non-empty string")
+    return value
+
+
+def _digest(value: object, label: str) -> str:
+    if type(value) is not str or _SHA256.fullmatch(value) is None:
+        raise ValueError(f"{label} must be a lowercase SHA-256 digest")
+    return value
+
+
+@dataclass(frozen=True)
+class CanaryCellV1:
+    cell_id: str
+    arm: str
+    attempt_count: int
+    schedule_order: int
+    phase: str
+    native_allowed: bool
+
+
+@dataclass(frozen=True)
+class CanaryManifestV1:
+    schema_version: int
+    protocol: str
+    manifest_hash: str
+    experiment_id: str
+    benchmark_git_sha: str
+    benchmark_version: str
+    model: str
+    agent_cli_fingerprint: str
+    gin_commit: str
+    gin_source_fingerprint: str
+    canary_prompt_sha256: str
+    oracle: tuple[str, str, str]
+    oracle_hash: str
+    launch_config_hashes: tuple[tuple[str, str], ...]
+    timeout_seconds: int
+    seed: int
+    budget_ceiling_usd: float
+    cells: tuple[CanaryCellV1, ...]
+    winner: None
+    dominance_allowed: bool
+    publishable: bool
+
+
+@dataclass(frozen=True)
+class CanaryAttemptV1:
+    schema_version: int
+    manifest_hash: str
+    session_id: str
+    run_id: str
+    cell_id: str
+    arm: str
+    attempt_no: int
+    receipt_call_id: str
+    transcript_sha256: str
+    workspace_audit_sha256: str
+    runtime_hash: str
+    status: str
+
+
+@dataclass(frozen=True)
+class CanaryArtifactV1:
+    schema_version: int
+    manifest_hash: str
+    session_id: str
+    run_id: str
+    cell_id: str
+    arm: str
+    kind: str
+    sha256: str
+    evidence_path: str
+    receipt_call_id: str | None = None
+
+
+@dataclass(frozen=True)
+class CanaryRegistryEventV1:
+    schema_version: int
+    manifest_hash: str
+    session_id: str
+    status: str
+    outcome: str
+    completed_run_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class CanaryEvidenceVerdict:
+    status: str
+    violations: tuple[str, ...]
+    accepted_cells: int
+    required_cells: int
+    winner: None
+    dominance_allowed: bool
+    publishable: bool
+
+
+def _manifest_payload(manifest: CanaryManifestV1) -> dict[str, Any]:
+    payload = asdict(manifest)
+    payload.pop("manifest_hash")
+    payload.pop("experiment_id")
+    return payload
+
+
+def _canary_cells() -> tuple[CanaryCellV1, ...]:
+    return tuple(
+        CanaryCellV1(cell_id, arm, 1, order, "E0", False)
+        for cell_id, arm, order in EXPECTED_CELLS
+    )
+
+
+def _validate_manifest_scalars(
+    values: tuple[tuple[str, object], ...],
+    gin_source_fingerprint: object,
+    canary_prompt_sha256: object,
+    timeout_seconds: object,
+    seed: object,
+) -> None:
+    for label, value in values:
+        _nonempty(value, label)
+    _digest(gin_source_fingerprint, "gin_source_fingerprint")
+    _digest(canary_prompt_sha256, "canary_prompt_sha256")
+    if type(timeout_seconds) is not int or timeout_seconds <= 0:
+        raise ValueError("timeout_seconds must be a positive integer")
+    if type(seed) is not int or seed < 0:
+        raise ValueError("seed must be a non-negative integer")
+
+
+def _launches(launch_config_hashes: dict[str, str]) -> tuple[tuple[str, str], ...]:
+    if type(launch_config_hashes) is not dict:
+        raise ValueError("launch_config_hashes must be an object")
+    if set(launch_config_hashes) != {arm for _, arm, _ in EXPECTED_CELLS}:
+        raise ValueError("launch_config_hashes must bind exactly both indexed arms")
+    return tuple(
+        (arm, _digest(launch_config_hashes[arm], f"launch_config_hashes.{arm}"))
+        for _, arm, _ in EXPECTED_CELLS
+    )
+
+
+def create_canary_manifest(
+    *,
+    benchmark_git_sha: str,
+    benchmark_version: str,
+    model: str,
+    agent_cli_fingerprint: str,
+    gin_commit: str,
+    gin_source_fingerprint: str,
+    canary_prompt_sha256: str,
+    launch_config_hashes: dict[str, str],
+    timeout_seconds: int,
+    seed: int,
+    budget_ceiling_usd: float = 3.0,
+) -> CanaryManifestV1:
+    """Freeze the only admissible two-cell E0 schedule and claim posture."""
+
+    _validate_manifest_scalars(
+        (
+            ("benchmark_git_sha", benchmark_git_sha),
+            ("benchmark_version", benchmark_version),
+            ("model", model),
+            ("agent_cli_fingerprint", agent_cli_fingerprint),
+            ("gin_commit", gin_commit),
+        ),
+        gin_source_fingerprint,
+        canary_prompt_sha256,
+        timeout_seconds,
+        seed,
+    )
+    if type(budget_ceiling_usd) not in (int, float) or budget_ceiling_usd != 3.0:
+        raise ValueError("budget_ceiling_usd must be exactly 3 USD")
+    oracle_hash = canonical_sha256(list(EXPECTED_ORACLE))
+    provisional = CanaryManifestV1(
+        SCHEMA_VERSION,
+        PROTOCOL,
+        "",
+        "",
+        benchmark_git_sha,
+        benchmark_version,
+        model,
+        agent_cli_fingerprint,
+        gin_commit,
+        gin_source_fingerprint,
+        canary_prompt_sha256,
+        EXPECTED_ORACLE,
+        oracle_hash,
+        _launches(launch_config_hashes),
+        timeout_seconds,
+        seed,
+        3.0,
+        _canary_cells(),
+        None,
+        False,
+        False,
+    )
+    digest = canonical_sha256(_manifest_payload(provisional))
+    return replace(provisional, manifest_hash=digest, experiment_id=f"sha256:{digest}")
+
+
+def validate_canary_manifest(manifest: CanaryManifestV1) -> None:
+    """Reject any mutation of the frozen protocol, schedule, or claim flags."""
+
+    if type(manifest) is not CanaryManifestV1:
+        raise ValueError("manifest must be CanaryManifestV1")
+    if (
+        type(manifest.schema_version) is not int
+        or manifest.schema_version != SCHEMA_VERSION
+    ):
+        raise ValueError("unsupported canary manifest schema")
+    if type(manifest.protocol) is not str or manifest.protocol != PROTOCOL:
+        raise ValueError("unsupported canary manifest schema")
+    _validate_manifest_scalars(
+        (
+            ("benchmark_git_sha", manifest.benchmark_git_sha),
+            ("benchmark_version", manifest.benchmark_version),
+            ("model", manifest.model),
+            ("agent_cli_fingerprint", manifest.agent_cli_fingerprint),
+            ("gin_commit", manifest.gin_commit),
+        ),
+        manifest.gin_source_fingerprint,
+        manifest.canary_prompt_sha256,
+        manifest.timeout_seconds,
+        manifest.seed,
+    )
+    if manifest.oracle != EXPECTED_ORACLE:
+        raise ValueError("oracle tuple is not the frozen canary oracle")
+    if manifest.oracle_hash != canonical_sha256(list(manifest.oracle)):
+        raise ValueError("oracle hash mismatch")
+    if manifest.cells != _canary_cells():
+        raise ValueError(
+            "canary schedule must be exact, seeded, E0-only, and non-native"
+        )
+    if any(
+        type(cell.attempt_count) is not int
+        or type(cell.schedule_order) is not int
+        or type(cell.native_allowed) is not bool
+        for cell in manifest.cells
+    ):
+        raise ValueError("canary cell field types are invalid")
+    if type(manifest.launch_config_hashes) is not tuple:
+        raise ValueError("launch_config_hashes must be a tuple")
+    if tuple(arm for arm, _ in manifest.launch_config_hashes) != tuple(
+        arm for _, arm, _ in EXPECTED_CELLS
+    ):
+        raise ValueError("launch config arm order mismatch")
+    for arm, digest in manifest.launch_config_hashes:
+        _digest(digest, f"launch_config_hashes.{arm}")
+    if (
+        type(manifest.budget_ceiling_usd) is not float
+        or manifest.budget_ceiling_usd != 3.0
+    ):
+        raise ValueError("budget ceiling mismatch")
+    if (
+        manifest.winner is not None
+        or type(manifest.dominance_allowed) is not bool
+        or manifest.dominance_allowed
+        or type(manifest.publishable) is not bool
+        or manifest.publishable
+    ):
+        raise ValueError("protected claim flags must remain false/null")
+    expected_hash = canonical_sha256(_manifest_payload(manifest))
+    if manifest.manifest_hash != expected_hash:
+        raise ValueError("manifest hash mismatch")
+    if manifest.experiment_id != f"sha256:{expected_hash}":
+        raise ValueError("experiment id mismatch")
+
+
+def _identity(record: CanaryAttemptV1 | CanaryArtifactV1) -> tuple[str, str, str]:
+    return record.run_id, record.cell_id, record.arm
+
+
+def _group_attempts(
+    attempts: tuple[object, ...], violations: list[str]
+) -> dict[tuple[str, str], list[CanaryAttemptV1]]:
+    grouped = {(cell_id, arm): [] for cell_id, arm, _ in EXPECTED_CELLS}
+    for attempt in attempts:
+        if type(attempt) is not CanaryAttemptV1:
+            violations.append("ATTEMPT_SCHEMA_INVALID")
+        elif (attempt.cell_id, attempt.arm) not in grouped:
+            violations.append("ATTEMPT_EXTRA_OR_CROSS_ARM")
+        else:
+            grouped[(attempt.cell_id, attempt.arm)].append(attempt)
+    return grouped
+
+
+def _attempt_hashes(
+    attempt: CanaryAttemptV1, cell_id: str, violations: list[str]
+) -> dict[str, str]:
+    hashes = {
+        "transcript": attempt.transcript_sha256,
+        "workspace_audit": attempt.workspace_audit_sha256,
+        "runtime": attempt.runtime_hash,
+    }
+    for label, digest in hashes.items():
+        try:
+            _digest(digest, f"{cell_id}.{label}")
+        except ValueError:
+            violations.append(f"ATTEMPT_HASH:{cell_id}:{label}")
+    return hashes
+
+
+def _attempt_is_bound(attempt: CanaryAttemptV1, manifest_hash: str) -> bool:
+    return (
+        type(attempt.schema_version) is int
+        and attempt.schema_version == SCHEMA_VERSION
+        and attempt.manifest_hash == manifest_hash
+        and type(attempt.run_id) is str
+        and bool(attempt.run_id)
+        and type(attempt.attempt_no) is int
+        and attempt.attempt_no == 1
+        and attempt.status == "SUCCESS"
+        and type(attempt.session_id) is str
+        and bool(attempt.session_id)
+        and type(attempt.receipt_call_id) is str
+        and bool(attempt.receipt_call_id)
+    )
+
+
+def _validate_cell(
+    cell_id: str,
+    arm: str,
+    manifest_hash: str,
+    grouped: dict[tuple[str, str], list[CanaryAttemptV1]],
+    artifacts: tuple[CanaryArtifactV1, ...],
+    violations: list[str],
+) -> bool:
+    matches = grouped[(cell_id, arm)]
+    if len(matches) != 1:
+        violations.append(f"ATTEMPT_BIJECTION:{cell_id}")
+        return False
+    attempt = matches[0]
+    if not _attempt_is_bound(attempt, manifest_hash):
+        violations.append(f"ATTEMPT_BINDING:{cell_id}")
+        return False
+    expected_hashes = _attempt_hashes(attempt, cell_id, violations)
+    related = tuple(item for item in artifacts if _identity(item) == _identity(attempt))
+    if len(related) != 4 or {item.kind for item in related} != set(ARTIFACT_KINDS):
+        violations.append(f"ARTIFACT_BIJECTION:{cell_id}")
+        return False
+    if not artifacts_are_bound(attempt, related, expected_hashes):
+        violations.append(f"ARTIFACT_BINDING:{cell_id}")
+        return False
+    return True
+
+
+def _registry_is_terminal(
+    registry: tuple[object, ...],
+    manifest_hash: str,
+    attempts: tuple[object, ...],
+    grouped: dict[tuple[str, str], list[CanaryAttemptV1]],
+) -> bool:
+    if len(registry) != 1 or type(registry[0]) is not CanaryRegistryEventV1:
+        return False
+    sessions = {item.session_id for item in attempts if type(item) is CanaryAttemptV1}
+    if any(len(grouped[(cell_id, arm)]) != 1 for cell_id, arm, _ in EXPECTED_CELLS):
+        return False
+    run_ids = tuple(
+        grouped[(cell_id, arm)][0].run_id for cell_id, arm, _ in EXPECTED_CELLS
+    )
+    event = registry[0]
+    return (
+        type(event.schema_version) is int
+        and event.schema_version == SCHEMA_VERSION
+        and event.manifest_hash == manifest_hash
+        and event.session_id in sessions
+        and event.status == "COMPLETE"
+        and event.outcome == "canary_accepted"
+        and event.completed_run_ids == run_ids
+        and len(run_ids) == len(set(run_ids))
+        and len(sessions) == 1
+    )
+
+
+def validate_canary_evidence(
+    manifest: CanaryManifestV1,
+    attempts: Iterable[CanaryAttemptV1],
+    artifacts: Iterable[CanaryArtifactV1],
+    registry: Iterable[CanaryRegistryEventV1],
+) -> CanaryEvidenceVerdict:
+    """Require a 2/2 bijection across terminal attempts and all four artifacts."""
+
+    violations: list[str] = []
+    try:
+        validate_canary_manifest(manifest)
+    except (AttributeError, TypeError, ValueError) as error:
+        violations.append(f"MANIFEST_INVALID:{error}")
+    if type(manifest) is not CanaryManifestV1:
+        return CanaryEvidenceVerdict(
+            "INVALID", tuple(violations), 0, 2, None, False, False
+        )
+    attempt_items = tuple(attempts)
+    artifact_items = tuple(artifacts)
+    registry_items = tuple(registry)
+    if not attempt_items and not artifact_items and not registry_items:
+        return CanaryEvidenceVerdict(
+            "INVALID" if violations else "NOT_EVALUATED",
+            tuple(violations),
+            0,
+            2,
+            None,
+            False,
+            False,
+        )
+    valid_artifacts = tuple(
+        item for item in artifact_items if type(item) is CanaryArtifactV1
+    )
+    if len(valid_artifacts) != len(artifact_items):
+        violations.append("ARTIFACT_SCHEMA_INVALID")
+    grouped = _group_attempts(attempt_items, violations)
+    accepted = sum(
+        _validate_cell(
+            cell_id,
+            arm,
+            manifest.manifest_hash,
+            grouped,
+            valid_artifacts,
+            violations,
+        )
+        for cell_id, arm, _ in EXPECTED_CELLS
+    )
+    expected = {(cell_id, arm) for cell_id, arm, _ in EXPECTED_CELLS}
+    if any((item.cell_id, item.arm) not in expected for item in valid_artifacts):
+        violations.append("ARTIFACT_EXTRA_OR_CROSS_ARM")
+    if not _registry_is_terminal(
+        registry_items, manifest.manifest_hash, attempt_items, grouped
+    ):
+        violations.append("REGISTRY_TERMINAL_INVALID")
+    status = "INVALID"
+    if not violations and accepted == 2:
+        status = "NOT_EVALUATED"
+        violations.append("PRODUCTION_TRUST_ANCHOR_UNAVAILABLE")
+    return CanaryEvidenceVerdict(
+        status, tuple(violations), accepted, 2, None, False, False
+    )

--- a/benchmarks/codegraph_compare/canary_policy.py
+++ b/benchmarks/codegraph_compare/canary_policy.py
@@ -1,0 +1,243 @@
+"""Fail-closed transcript qualification for indexed MCP canary cells."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from benchmarks.codegraph_compare.smoke_policy import (
+    _ARM_SERVER,
+    PolicyAudit,
+    _is_source_discovery_command,
+    _mcp_call_failed,
+    audit_codex_transcript,
+)
+
+
+@dataclass(frozen=True)
+class CanaryReceipt:
+    call_id: str
+    server: str
+    tool: str
+    repository_relative_path: str
+    symbol_identity: str
+    symbol_kind: str
+    transcript_line: int
+
+
+@dataclass(frozen=True)
+class CanaryAudit:
+    policy: PolicyAudit
+    receipt: CanaryReceipt | None
+    violations: tuple[str, ...]
+
+
+def audit_canary_transcript(
+    transcript_path: Path,
+    arm: str,
+    *,
+    expected_tool: str,
+    expected_path: str,
+    expected_symbol: str,
+    expected_kind: str,
+    expected_arguments: dict[str, object] | None = None,
+) -> CanaryAudit:
+    """Bind one qualification to exact MCP order, identity, and evidence."""
+
+    policy = audit_codex_transcript(transcript_path, arm)
+    violations = list(policy.violations)
+    expected_server = _ARM_SERVER.get(arm)
+    if expected_arguments is None:
+        expected_arguments = (
+            {
+                "action": "navigate",
+                "symbol": expected_symbol,
+                "file_path": expected_path,
+                "output_format": "json",
+            }
+            if expected_server == "tree-sitter-analyzer"
+            else {
+                "query": expected_symbol,
+                "kind": expected_kind,
+                "limit": 10,
+            }
+        )
+    receipts: list[CanaryReceipt] = []
+    receipt_seen = False
+    if expected_server is None:
+        violations.append("CANARY_INDEXED_ARM_REQUIRED")
+    elif transcript_path.is_file():
+        for line_number, line in enumerate(
+            transcript_path.read_text(encoding="utf-8").splitlines(), start=1
+        ):
+            receipt, violation = _canary_receipt(
+                line,
+                line_number,
+                expected_server=expected_server,
+                expected_tool=expected_tool,
+                expected_path=expected_path,
+                expected_symbol=expected_symbol,
+                expected_kind=expected_kind,
+                expected_arguments=expected_arguments,
+            )
+            if violation:
+                violations.append(violation)
+            if receipt is not None:
+                receipts.append(receipt)
+                receipt_seen = True
+            elif not receipt_seen and _canary_source_discovery(line):
+                violations.append(
+                    f"CANARY_SOURCE_DISCOVERY_BEFORE_RECEIPT:{line_number}"
+                )
+    if len(receipts) != 1:
+        code = "CANARY_RECEIPT_MISSING" if not receipts else "CANARY_RECEIPT_AMBIGUOUS"
+        violations.append(code)
+    return CanaryAudit(
+        policy,
+        receipts[0] if len(receipts) == 1 else None,
+        tuple(dict.fromkeys(violations)),
+    )
+
+
+def _canary_source_discovery(line: str) -> bool:
+    try:
+        event = json.loads(line)
+    except json.JSONDecodeError:
+        return False
+    if not isinstance(event, dict) or event.get("type") != "item.completed":
+        return False
+    item = event.get("item")
+    return (
+        isinstance(item, dict)
+        and item.get("type") == "command_execution"
+        and _is_source_discovery_command(str(item.get("command") or ""))
+    )
+
+
+def _canary_receipt(
+    line: str,
+    line_number: int,
+    *,
+    expected_server: str,
+    expected_tool: str,
+    expected_path: str,
+    expected_symbol: str,
+    expected_kind: str,
+    expected_arguments: dict[str, object] | None,
+) -> tuple[CanaryReceipt | None, str | None]:
+    try:
+        event = json.loads(line)
+    except json.JSONDecodeError:
+        return None, None
+    if not isinstance(event, dict) or event.get("type") != "item.completed":
+        return None, None
+    item = event.get("item")
+    if (
+        not isinstance(item, dict)
+        or item.get("type") != "mcp_tool_call"
+        or item.get("server") != expected_server
+        or _mcp_call_failed(item)
+    ):
+        return None, None
+    if item.get("tool") != expected_tool:
+        return None, f"CANARY_TOOL_MISMATCH:{line_number}"
+    call_id = item.get("id")
+    result = item.get("result")
+    if (
+        not isinstance(call_id, str)
+        or not call_id
+        or item.get("status") != "completed"
+        or not isinstance(result, dict)
+    ):
+        return None, f"CANARY_RECEIPT_INVALID:{line_number}"
+    if expected_arguments is None or item.get("arguments") != expected_arguments:
+        return None, f"CANARY_ARGUMENTS_MISMATCH:{line_number}"
+    evidence = (
+        _codegraph_evidence(item, result, expected_path, expected_symbol, expected_kind)
+        if expected_server == "codegraph"
+        else _tsa_evidence(result)
+    )
+    if evidence is None:
+        return None, f"CANARY_RECEIPT_INVALID:{line_number}"
+    if evidence != (expected_path, expected_symbol, expected_kind):
+        return None, f"CANARY_EVIDENCE_MISMATCH:{line_number}"
+    return (
+        CanaryReceipt(
+            call_id,
+            expected_server,
+            expected_tool,
+            expected_path,
+            expected_symbol,
+            expected_kind,
+            line_number,
+        ),
+        None,
+    )
+
+
+def _codegraph_evidence(
+    item: dict[str, object],
+    result: dict[str, object],
+    expected_path: str,
+    expected_symbol: str,
+    expected_kind: str,
+) -> tuple[str, str, str] | None:
+    text = _single_text_content(result)
+    if text is None:
+        return None
+    short_name = expected_symbol.rsplit(".", 1)[-1]
+    receiver = expected_symbol.rsplit(".", 1)[0]
+    header = re.compile(
+        rf"(?m)^\*\*{re.escape(short_name)}\*\* \({re.escape(expected_kind)}\)$"
+    )
+    if len(tuple(header.finditer(text))) != 1:
+        return None
+    pattern = re.compile(
+        rf"(?m)^\*\*{re.escape(short_name)}\*\* \({re.escape(expected_kind)}\)\n"
+        rf"func \(\s*[A-Za-z_]\w*\s+\*?{re.escape(receiver)}\s*\) "
+        rf"{re.escape(short_name)}\([^\n]*\)\n"
+        rf"{re.escape(expected_path)}:(?P<line>[1-9]\d*)$"
+    )
+    if len(tuple(pattern.finditer(text))) != 1:
+        return None
+    return expected_path, expected_symbol, expected_kind
+
+
+def _tsa_evidence(result: dict[str, object]) -> tuple[str, str, str] | None:
+    text = _single_text_content(result)
+    if text is None:
+        return None
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict) or not isinstance(payload.get("symbol"), str):
+        return None
+    definition = payload.get("definition")
+    definitions = (
+        definition.get("definitions") if isinstance(definition, dict) else None
+    )
+    if not isinstance(definitions, list) or len(definitions) != 1:
+        return None
+    entry = definitions[0]
+    if not isinstance(entry, dict):
+        return None
+    evidence = entry.get("file"), entry.get("name"), entry.get("kind")
+    if not all(isinstance(value, str) and value for value in evidence):
+        return None
+    if payload["symbol"] != evidence[1]:
+        return None
+    return evidence
+
+
+def _single_text_content(result: dict[str, object]) -> str | None:
+    content = result.get("content")
+    if not isinstance(content, list) or len(content) != 1:
+        return None
+    block = content[0]
+    if not isinstance(block, dict) or block.get("type") != "text":
+        return None
+    text = block.get("text")
+    return text if isinstance(text, str) else None

--- a/benchmarks/codegraph_compare/canary_preflight.py
+++ b/benchmarks/codegraph_compare/canary_preflight.py
@@ -30,7 +30,16 @@ def _executable(path: Path) -> tuple[str, str]:
     resolved = path.resolve(strict=True)
     if not resolved.is_file():
         raise ValueError(f"Canary executable is not a file: {resolved}")
-    if not os.access(resolved, os.X_OK):
+    windows_suffixes = {
+        suffix.lower()
+        for suffix in os.environ.get("PATHEXT", ".COM;.EXE;.BAT;.CMD").split(";")
+    }
+    executable = (
+        resolved.suffix.lower() in windows_suffixes
+        if os.name == "nt"
+        else os.access(resolved, os.X_OK)
+    )
+    if not executable:
         raise ValueError(f"Canary executable is not executable: {resolved}")
     return str(resolved), hashlib.sha256(resolved.read_bytes()).hexdigest()
 

--- a/benchmarks/codegraph_compare/canary_preflight.py
+++ b/benchmarks/codegraph_compare/canary_preflight.py
@@ -1,0 +1,212 @@
+"""Model-free MCP launch-contract preflight for NO1-002C canary arms."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from benchmarks.codegraph_compare.adapters import CODEGRAPH_NPM_PACKAGE
+
+SCHEMA_VERSION = 1
+TSA_ARM = "tsa-warm"
+CODEGRAPH_ARM = "codegraph-warm"
+_ANALYZER_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _sha256(payload: dict[str, Any]) -> str:
+    encoded = json.dumps(
+        payload, ensure_ascii=True, separators=(",", ":"), sort_keys=True
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _executable(path: Path) -> tuple[str, str]:
+    resolved = path.resolve(strict=True)
+    if not resolved.is_file():
+        raise ValueError(f"Canary executable is not a file: {resolved}")
+    if not os.access(resolved, os.X_OK):
+        raise ValueError(f"Canary executable is not executable: {resolved}")
+    return str(resolved), hashlib.sha256(resolved.read_bytes()).hexdigest()
+
+
+def _tree_digest(root: Path) -> str:
+    records = [
+        (
+            path.relative_to(root).as_posix(),
+            hashlib.sha256(path.read_bytes()).hexdigest(),
+        )
+        for path in sorted(root.rglob("*.py"))
+        if path.is_file()
+    ]
+    return _sha256({"files": records})
+
+
+def _tsa_identity(executable: Path) -> dict[str, str]:
+    source = _ANALYZER_ROOT / "tree_sitter_analyzer"
+    lock = _ANALYZER_ROOT / "uv.lock"
+    if not source.is_dir() or not lock.is_file():
+        raise ValueError("TSA source or dependency lock is unavailable")
+    trusted_python = Path(sys.executable).resolve(strict=True)
+    if executable.resolve(strict=True) != trusted_python:
+        raise ValueError("TSA executable is not the trusted repository interpreter")
+    entrypoint = source / "mcp" / "server.py"
+    if not entrypoint.is_file():
+        raise ValueError("TSA trusted MCP entrypoint is unavailable")
+    return {
+        "trusted_repo": str(_ANALYZER_ROOT),
+        "entrypoint": str(entrypoint.resolve()),
+        "entrypoint_sha256": hashlib.sha256(entrypoint.read_bytes()).hexdigest(),
+        "source_root": str(source.resolve()),
+        "source_sha256": _tree_digest(source),
+        "dependency_lock": str(lock.resolve()),
+        "dependency_lock_sha256": hashlib.sha256(lock.read_bytes()).hexdigest(),
+    }
+
+
+def _codegraph_identity(executable: Path) -> dict[str, str]:
+    result = subprocess.run(
+        [str(executable), "--version"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=True,
+        env={
+            "CODEGRAPH_NO_DAEMON": "1",
+            "CODEGRAPH_NO_UPDATE_CHECK": "1",
+            "CODEGRAPH_TELEMETRY": "0",
+            "PATH": os.defpath,
+        },
+    )
+    version = (result.stdout or result.stderr).strip()
+    if version != "1.5.0":
+        raise ValueError(f"CodeGraph version identity mismatch: {version!r}")
+    return {"package": CODEGRAPH_NPM_PACKAGE, "version": version}
+
+
+IdentityProbe = Callable[[str, Path], dict[str, str]]
+
+
+def _production_identity_probe(arm: str, executable: Path) -> dict[str, str]:
+    if arm == TSA_ARM:
+        return _tsa_identity(executable)
+    if arm == CODEGRAPH_ARM:
+        return _codegraph_identity(executable)
+    raise ValueError(f"unsupported identity arm: {arm}")
+
+
+def _seal(payload: dict[str, Any]) -> dict[str, Any]:
+    return {**payload, "launch_config_hash": _sha256(payload)}
+
+
+def build_canary_launch_contracts(
+    checkout: Path,
+    *,
+    tsa_executable: Path,
+    codegraph_executable: Path,
+    identity_probe: IdentityProbe | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Build exact, hash-bound MCP launch contracts for both indexed arms."""
+
+    resolved_checkout = checkout.resolve(strict=True)
+    if not resolved_checkout.is_dir():
+        raise ValueError(f"Canary checkout is not a directory: {resolved_checkout}")
+    root = str(resolved_checkout)
+    tsa_command, tsa_digest = _executable(tsa_executable)
+    codegraph_command, codegraph_digest = _executable(codegraph_executable)
+    common = {
+        "schema_version": SCHEMA_VERSION,
+        "required": True,
+        "network": False,
+        "inherit_environment": False,
+    }
+    probe = identity_probe or _production_identity_probe
+    tsa_identity = probe(TSA_ARM, Path(tsa_command))
+    codegraph_identity = probe(CODEGRAPH_ARM, Path(codegraph_command))
+    if not tsa_identity or not codegraph_identity:
+        raise ValueError("canary identity probe returned incomplete evidence")
+    tsa = _seal(
+        {
+            **common,
+            "arm": TSA_ARM,
+            "server": "tree-sitter-analyzer",
+            "command": tsa_command,
+            "args": [
+                "-m",
+                "tree_sitter_analyzer.mcp.server",
+                "--project-root",
+                root,
+            ],
+            "env": {
+                "PYTHONHASHSEED": "0",
+                "PYTHONNOUSERSITE": "1",
+                "TREE_SITTER_PROJECT_ROOT": root,
+            },
+            "enabled_tools": ["nav"],
+            "executable_sha256": tsa_digest,
+            "tsa_identity": tsa_identity,
+            "production_ready": False,
+        }
+    )
+    codegraph = _seal(
+        {
+            **common,
+            "arm": CODEGRAPH_ARM,
+            "server": "codegraph",
+            "package": CODEGRAPH_NPM_PACKAGE,
+            "command": codegraph_command,
+            "args": ["serve", "--mcp", "--no-watch", "-p", root],
+            "env": {
+                "CODEGRAPH_MCP_TOOLS": "search",
+                "CODEGRAPH_NO_DAEMON": "1",
+                "CODEGRAPH_NO_UPDATE_CHECK": "1",
+                "CODEGRAPH_TELEMETRY": "0",
+                "PATH": os.defpath,
+            },
+            "enabled_tools": ["codegraph_search"],
+            "executable_sha256": codegraph_digest,
+            "codegraph_identity": codegraph_identity,
+            "production_ready": False,
+        }
+    )
+    return {TSA_ARM: tsa, CODEGRAPH_ARM: codegraph}
+
+
+def validate_canary_launch_contracts(
+    contracts: dict[str, Any],
+    checkout: Path,
+    *,
+    tsa_executable: Path,
+    codegraph_executable: Path,
+    identity_probe: IdentityProbe | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Reject any launch surface not identical to the model-free contract."""
+
+    expected = build_canary_launch_contracts(
+        checkout,
+        tsa_executable=tsa_executable,
+        codegraph_executable=codegraph_executable,
+        identity_probe=identity_probe,
+    )
+    if set(contracts) != set(expected):
+        raise ValueError("Canary launch contracts have an invalid arm set")
+    for arm, expected_contract in expected.items():
+        observed = contracts.get(arm)
+        if not isinstance(observed, dict):
+            raise ValueError(f"Canary launch contract is not an object: {arm}")
+        if set(observed) != set(expected_contract):
+            raise ValueError(f"Canary launch contract has an invalid field set: {arm}")
+        unsigned = {
+            key: value for key, value in observed.items() if key != "launch_config_hash"
+        }
+        if observed["launch_config_hash"] != _sha256(unsigned):
+            raise ValueError(f"Canary launch config hash is invalid: {arm}")
+        for key, value in expected_contract.items():
+            if observed[key] != value:
+                raise ValueError(f"Canary launch contract mismatch: {arm}.{key}")
+    return expected

--- a/benchmarks/codegraph_compare/canary_protocol.py
+++ b/benchmarks/codegraph_compare/canary_protocol.py
@@ -1,0 +1,499 @@
+"""One-shot, model-free orchestration for the NO1-002C canary."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+from collections.abc import Callable, Mapping
+from dataclasses import asdict, dataclass, is_dataclass
+from pathlib import Path
+from typing import Any
+
+from benchmarks.codegraph_compare._canary_evidence_replay import (
+    read_if_file,
+    workspace_envelope,
+)
+from benchmarks.codegraph_compare.canary_evidence import (
+    ARTIFACT_KINDS,
+    SCHEMA_VERSION,
+    CanaryArtifactV1,
+    CanaryAttemptV1,
+    CanaryManifestV1,
+    CanaryRegistryEventV1,
+    canonical_json_bytes,
+    canonical_sha256,
+    validate_canary_evidence,
+    validate_canary_manifest,
+)
+from benchmarks.codegraph_compare.canary_policy import CanaryAudit
+from benchmarks.codegraph_compare.canary_workspace import (
+    audit_canary_checkout,
+    cleanup_and_verify_canary_checkout,
+    snapshot_canary_checkout,
+)
+
+_ORACLE_PATH = "gin.go"
+_ORACLE_SYMBOL = "Engine.ServeHTTP"
+_ORACLE_KIND = "method"
+_TOOLS = {"tsa-warm": "nav", "codegraph-warm": "codegraph_search"}
+_ZERO_HASH = "0" * 64
+
+
+@dataclass(frozen=True)
+class CanaryRunResult:
+    transcript_path: Path
+    cost_usd: float
+    reported_index_queries: int
+
+
+class CanaryRunFailure(Exception):
+    """A failed model call carrying evidence already produced by that call."""
+
+    def __init__(self, message: str, result: CanaryRunResult) -> None:
+        super().__init__(message)
+        self.result = result
+
+
+@dataclass(frozen=True)
+class CanaryProtocolCallbacks:
+    validate_launch: Callable[
+        [Mapping[str, Mapping[str, Any]], Mapping[str, Path]], None
+    ]
+    snapshot: Callable[[Path, str], Any] | None
+    setup_index: Callable[[str, Path], None]
+    run_cell: Callable[
+        [Any, Path, str, str, Mapping[str, Any], float, float], CanaryRunResult
+    ]
+    audit_policy: Callable[..., CanaryAudit]
+    audit_workspace: Callable[[Any], Any] | None
+    cleanup_workspace: Callable[[Any, Any], None] | None
+    runtime_hash: Callable[[str, Path, Any], str]
+    new_id: Callable[[str], str]
+
+
+@dataclass(frozen=True)
+class CanaryProtocolResult:
+    attempts: tuple[CanaryAttemptV1, ...]
+    artifacts: tuple[CanaryArtifactV1, ...]
+    registry: tuple[CanaryRegistryEventV1, ...]
+    status: str
+    violations: tuple[str, ...]
+    cumulative_cost_usd: float
+
+
+def _transcript_hash(path: Path) -> str:
+    if not path.is_file():
+        raise ValueError("transcript is missing")
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _record_cost(result: CanaryRunResult, cumulative_cost: float) -> float:
+    cost = result.cost_usd
+    if type(cost) not in (int, float) or not math.isfinite(cost) or cost < 0:
+        raise ValueError("reported cost must be a finite non-negative number")
+    return cumulative_cost + float(cost)
+
+
+def _canonical_object_hash(value: Any) -> str:
+    if is_dataclass(value) and not isinstance(value, type):
+        value = asdict(value)
+    return canonical_sha256(_json_value(value))
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, Mapping):
+        return {str(key): _json_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item) for item in value]
+    return value
+
+
+class CanaryProtocol:
+    def __init__(
+        self,
+        manifest: CanaryManifestV1,
+        launch_contracts: Mapping[str, Mapping[str, Any]],
+        checkouts: Mapping[str, Path],
+        callbacks: CanaryProtocolCallbacks,
+        journal_path: Path,
+        fixture_cost_plan_usd: Mapping[str, float],
+        execution_mode: str = "production",
+    ) -> None:
+        self._manifest = manifest
+        self._launch_contracts = launch_contracts
+        self._checkouts = checkouts
+        self._callbacks = callbacks
+        self._journal_path = journal_path
+        self._fixture_cost_plan_usd = fixture_cost_plan_usd
+        self._execution_mode = execution_mode
+        self._started = False
+
+    def _snapshot_workspace(self, checkout: Path, arm: str) -> Any:
+        callback = self._callbacks.snapshot or snapshot_canary_checkout
+        return callback(checkout, arm)
+
+    def _audit_workspace(self, snapshot: Any) -> Any:
+        callback = self._callbacks.audit_workspace or audit_canary_checkout
+        return callback(snapshot)
+
+    def _cleanup_workspace(self, snapshot: Any, audit: Any) -> None:
+        callback = (
+            self._callbacks.cleanup_workspace or cleanup_and_verify_canary_checkout
+        )
+        callback(snapshot, audit)
+
+    def _reserve(self, session_id: str) -> None:
+        """Persist a one-shot fixture reservation before simulation starts."""
+
+        self._journal_path.parent.mkdir(parents=True, exist_ok=True)
+        journal = self._journal_path.resolve(strict=False)
+        for checkout in self._checkouts.values():
+            checkout_root = checkout.resolve(strict=False)
+            if journal == checkout_root or checkout_root in journal.parents:
+                raise ValueError("canary journal must be outside every checkout")
+        payload = canonical_sha256(
+            {
+                "manifest_hash": self._manifest.manifest_hash,
+                "session_id": session_id,
+                "fixture_cost_plan_usd": dict(
+                    sorted(self._fixture_cost_plan_usd.items())
+                ),
+            }
+        )
+        record = {
+            "schema_version": 1,
+            "state": "RESERVED",
+            "manifest_hash": self._manifest.manifest_hash,
+            "session_id": session_id,
+            "fixture_cost_plan_usd": dict(sorted(self._fixture_cost_plan_usd.items())),
+            "reservation_hash": payload,
+        }
+        try:
+            descriptor = os.open(
+                self._journal_path,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o600,
+            )
+        except FileExistsError as error:
+            raise RuntimeError(
+                "canary fixture reservation already exists; retry is forbidden"
+            ) from error
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            json.dump(record, stream, sort_keys=True, separators=(",", ":"))
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        directory = os.open(self._journal_path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+
+    def _terminalize(self, result: CanaryProtocolResult) -> CanaryProtocolResult:
+        """Atomically replace the reservation with durable terminal evidence."""
+
+        record = {
+            "schema_version": 1,
+            "state": "TERMINAL",
+            "manifest_hash": self._manifest.manifest_hash,
+            "status": result.status,
+            "result": _json_value(asdict(result)),
+        }
+        temporary = self._journal_path.with_name(self._journal_path.name + ".terminal")
+        with temporary.open("x", encoding="utf-8") as stream:
+            json.dump(record, stream, sort_keys=True, separators=(",", ":"))
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, self._journal_path)
+        directory = os.open(self._journal_path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+        return result
+
+    def _persist_artifact(
+        self, run_id: str, kind: str, payload: bytes
+    ) -> tuple[str, str]:
+        root = self._journal_path.with_name(self._journal_path.name + ".artifacts")
+        root.mkdir(mode=0o700, exist_ok=True)
+        target = (root / f"{run_id}.{kind}").resolve(strict=False)
+        with target.open("xb") as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        return hashlib.sha256(payload).hexdigest(), str(target)
+
+    def execute(self) -> CanaryProtocolResult:
+        if self._started:
+            raise RuntimeError("canary protocol is one-shot; retry is forbidden")
+        self._started = True
+        if self._execution_mode != "fixture":
+            return CanaryProtocolResult(
+                (),
+                (),
+                (),
+                "NOT_EVALUATED",
+                ("QUALIFICATION_SCAFFOLD_NOT_PRODUCTION_READY",),
+                0.0,
+            )
+        attempts: list[CanaryAttemptV1] = []
+        artifacts: list[CanaryArtifactV1] = []
+        violations: list[str] = []
+        completed: list[str] = []
+        cumulative_cost = 0.0
+        session_id = self._callbacks.new_id("session")
+        seen_ids = {session_id}
+
+        try:
+            validate_canary_manifest(self._manifest)
+            if not session_id:
+                raise ValueError("session id must be fresh and non-empty")
+            expected_arms = {cell.arm for cell in self._manifest.cells}
+            if set(self._checkouts) != expected_arms:
+                raise ValueError("checkout arm set does not match frozen schedule")
+            if set(self._launch_contracts) != expected_arms:
+                raise ValueError("launch arm set does not match frozen schedule")
+            self._callbacks.validate_launch(self._launch_contracts, self._checkouts)
+            expected_cells = {cell.cell_id for cell in self._manifest.cells}
+            if set(self._fixture_cost_plan_usd) != expected_cells:
+                raise ValueError("fixture cost plan must bind every canary cell")
+            reservations = tuple(
+                self._fixture_cost_plan_usd[cell.cell_id]
+                for cell in self._manifest.cells
+            )
+            if any(
+                type(value) not in (int, float)
+                or not math.isfinite(value)
+                or value <= 0
+                for value in reservations
+            ):
+                raise ValueError("fixture cost plans must be finite and positive")
+            if sum(reservations) > self._manifest.budget_ceiling_usd:
+                raise ValueError("fixture cost plan exceeds declared simulation budget")
+        except Exception as error:
+            violations.append(f"PREFLIGHT_INVALID:{error}")
+            return self._finish(
+                session_id, attempts, artifacts, completed, violations, cumulative_cost
+            )
+
+        self._reserve(session_id)
+
+        for cell in self._manifest.cells:
+            run_id = self._callbacks.new_id(f"run:{cell.cell_id}")
+            if not run_id or run_id in seen_ids:
+                violations.append(f"RUN_ID_NOT_FRESH:{cell.cell_id}")
+                break
+            seen_ids.add(run_id)
+            snapshot = None
+            audit = None
+            run_result = None
+            policy = None
+            transcript_hash = _ZERO_HASH
+            workspace_hash = _ZERO_HASH
+            runtime_hash = _ZERO_HASH
+            receipt_id = ""
+            failures: list[str] = []
+            setup_started = False
+            checkout = self._checkouts[cell.arm]
+            remaining_usd = self._manifest.budget_ceiling_usd - cumulative_cost
+            fixture_cost_limit_usd = float(self._fixture_cost_plan_usd[cell.cell_id])
+            if fixture_cost_limit_usd > remaining_usd:
+                violations.append(
+                    f"CELL_BUDGET_UNAVAILABLE:{cell.cell_id}:"
+                    f"remaining={remaining_usd}:fixture_limit={fixture_cost_limit_usd}"
+                )
+                break
+            try:
+                snapshot = self._snapshot_workspace(checkout, cell.arm)
+                setup_started = True
+                self._callbacks.setup_index(cell.arm, checkout)
+                run_result = self._callbacks.run_cell(
+                    cell,
+                    checkout,
+                    session_id,
+                    run_id,
+                    self._launch_contracts[cell.arm],
+                    remaining_usd,
+                    fixture_cost_limit_usd,
+                )
+                cumulative_cost = _record_cost(run_result, cumulative_cost)
+                if run_result.cost_usd > fixture_cost_limit_usd:
+                    raise ValueError("fixture reported cost above its declared plan")
+                transcript_hash = _transcript_hash(run_result.transcript_path)
+                if cumulative_cost > self._manifest.budget_ceiling_usd:
+                    raise ValueError(
+                        "fixture reported cumulative cost above simulation budget"
+                    )
+                policy = self._callbacks.audit_policy(
+                    run_result.transcript_path,
+                    cell.arm,
+                    expected_tool=_TOOLS[cell.arm],
+                    expected_path=_ORACLE_PATH,
+                    expected_symbol=_ORACLE_SYMBOL,
+                    expected_kind=_ORACLE_KIND,
+                )
+                qualifying_receipts = int(policy.receipt is not None)
+                receipt_id = policy.receipt.call_id if policy.receipt else ""
+                if policy.violations:
+                    raise ValueError("policy audit rejected transcript")
+                if run_result.reported_index_queries != qualifying_receipts:
+                    raise ValueError("qualifying receipt/query count mismatch")
+            except CanaryRunFailure as error:
+                failures.append(f"primary={error}")
+                run_result = error.result
+                try:
+                    cumulative_cost = _record_cost(error.result, cumulative_cost)
+                    if error.result.cost_usd > fixture_cost_limit_usd:
+                        raise ValueError(
+                            "fixture reported cost above its declared plan"
+                        )
+                    transcript_hash = _transcript_hash(error.result.transcript_path)
+                    if cumulative_cost > self._manifest.budget_ceiling_usd:
+                        raise ValueError(
+                            "fixture reported cumulative cost above simulation budget"
+                        )
+                except Exception as evidence_error:
+                    failures.append(f"failure_evidence={evidence_error}")
+            except Exception as error:
+                failures.append(f"primary={error}")
+            finally:
+                if setup_started:
+                    try:
+                        audit = self._audit_workspace(snapshot)
+                        workspace_hash = _canonical_object_hash(audit)
+                        runtime_hash = self._callbacks.runtime_hash(
+                            cell.arm, checkout, audit
+                        )
+                        if len(runtime_hash) != 64 or any(
+                            character not in "0123456789abcdef"
+                            for character in runtime_hash
+                        ):
+                            raise ValueError(
+                                "runtime callback returned invalid SHA-256"
+                            )
+                    except Exception as error:
+                        failures.append(f"workspace={error}")
+                    try:
+                        self._cleanup_workspace(snapshot, audit)
+                    except Exception as error:
+                        failures.append(f"cleanup={error}")
+
+            status = "SUCCESS" if not failures else "INVALID"
+            attempt = CanaryAttemptV1(
+                SCHEMA_VERSION,
+                self._manifest.manifest_hash,
+                session_id,
+                run_id,
+                cell.cell_id,
+                cell.arm,
+                1,
+                receipt_id,
+                transcript_hash,
+                workspace_hash,
+                runtime_hash,
+                status,
+            )
+            attempts.append(attempt)
+            digest_by_kind = {
+                "receipt": canonical_json_bytes({"call_id": receipt_id})
+                if receipt_id
+                else None,
+                "transcript": read_if_file(
+                    run_result.transcript_path if run_result is not None else None
+                ),
+                "workspace_audit": canonical_json_bytes(
+                    workspace_envelope(
+                        self._manifest.manifest_hash,
+                        session_id,
+                        run_id,
+                        cell,
+                        workspace_hash,
+                        _json_value(audit),
+                    )
+                )
+                if workspace_hash != _ZERO_HASH
+                else None,
+                "runtime": runtime_hash.encode("ascii")
+                if runtime_hash != _ZERO_HASH
+                else None,
+            }
+            for kind in ARTIFACT_KINDS:
+                payload = digest_by_kind[kind]
+                if payload is not None:
+                    digest, evidence_path = self._persist_artifact(
+                        run_id, kind, payload
+                    )
+                    artifacts.append(
+                        CanaryArtifactV1(
+                            SCHEMA_VERSION,
+                            self._manifest.manifest_hash,
+                            session_id,
+                            run_id,
+                            cell.cell_id,
+                            cell.arm,
+                            kind,
+                            digest,
+                            evidence_path,
+                            receipt_id if kind == "receipt" else None,
+                        )
+                    )
+            if not failures:
+                completed.append(run_id)
+            else:
+                violations.append(f"CELL_INVALID:{cell.cell_id}:{'|'.join(failures)}")
+                break
+
+        return self._terminalize(
+            self._finish(
+                session_id,
+                attempts,
+                artifacts,
+                completed,
+                violations,
+                cumulative_cost,
+            )
+        )
+
+    def _finish(
+        self,
+        session_id: str,
+        attempts: list[CanaryAttemptV1],
+        artifacts: list[CanaryArtifactV1],
+        completed: list[str],
+        violations: list[str],
+        cumulative_cost: float,
+    ) -> CanaryProtocolResult:
+        simulated_complete = not violations and len(attempts) == len(
+            self._manifest.cells
+        )
+        if simulated_complete:
+            violations.append("FIXTURE_SIMULATION_NOT_QUALIFICATION")
+        registry = (
+            CanaryRegistryEventV1(
+                SCHEMA_VERSION,
+                self._manifest.manifest_hash,
+                session_id,
+                "INVALID",
+                "fixture_not_evaluated" if simulated_complete else "canary_invalid",
+                tuple(completed),
+            ),
+        )
+        verdict = validate_canary_evidence(
+            self._manifest, tuple(attempts), tuple(artifacts), registry
+        )
+        status = "NOT_EVALUATED" if simulated_complete else "INVALID"
+        combined = tuple(dict.fromkeys((*violations, *verdict.violations)))
+        return CanaryProtocolResult(
+            tuple(attempts),
+            tuple(artifacts),
+            registry,
+            status,
+            combined,
+            cumulative_cost,
+        )

--- a/benchmarks/codegraph_compare/canary_protocol.py
+++ b/benchmarks/codegraph_compare/canary_protocol.py
@@ -41,6 +41,18 @@ _TOOLS = {"tsa-warm": "nav", "codegraph-warm": "codegraph_search"}
 _ZERO_HASH = "0" * 64
 
 
+def _fsync_directory(path: Path) -> None:
+    """Flush a directory entry where the platform exposes directory handles."""
+
+    if os.name == "nt":
+        return
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
 @dataclass(frozen=True)
 class CanaryRunResult:
     transcript_path: Path
@@ -187,11 +199,7 @@ class CanaryProtocol:
             stream.write("\n")
             stream.flush()
             os.fsync(stream.fileno())
-        directory = os.open(self._journal_path.parent, os.O_RDONLY)
-        try:
-            os.fsync(directory)
-        finally:
-            os.close(directory)
+        _fsync_directory(self._journal_path.parent)
 
     def _terminalize(self, result: CanaryProtocolResult) -> CanaryProtocolResult:
         """Atomically replace the reservation with durable terminal evidence."""
@@ -210,11 +218,7 @@ class CanaryProtocol:
             stream.flush()
             os.fsync(stream.fileno())
         os.replace(temporary, self._journal_path)
-        directory = os.open(self._journal_path.parent, os.O_RDONLY)
-        try:
-            os.fsync(directory)
-        finally:
-            os.close(directory)
+        _fsync_directory(self._journal_path.parent)
         return result
 
     def _persist_artifact(

--- a/benchmarks/codegraph_compare/canary_workspace.py
+++ b/benchmarks/codegraph_compare/canary_workspace.py
@@ -1,0 +1,216 @@
+"""Model-free checkout immutability evidence for the NO1-002C canary."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import stat
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from benchmarks.codegraph_compare.smoke_evidence import (
+    repository_fingerprint,
+    tracked_paths,
+)
+from benchmarks.codegraph_compare.smoke_workspace import cleanup_runtime_index
+
+RUNTIME_NAMESPACES = {"tsa-warm": ".ast-cache", "codegraph-warm": ".codegraph"}
+
+
+@dataclass(frozen=True)
+class CanaryCheckoutSnapshot:
+    """Byte-level identity of a canary checkout outside its runtime namespace."""
+
+    arm: str
+    checkout_root: Path
+    head_commit: str
+    tracked_paths: tuple[str, ...]
+    repository_fingerprint: str
+    source_inventory: tuple[tuple[str, str], ...]
+    runtime_namespace: str
+    runtime_before: tuple[tuple[str, str], ...]
+
+
+@dataclass(frozen=True)
+class CanaryWorkspaceAudit:
+    """Before/after evidence kept separately for the derived runtime namespace."""
+
+    checkout_root: Path
+    head_commit: str
+    tracked_paths: tuple[str, ...]
+    repository_fingerprint: str
+    source_before: tuple[tuple[str, str], ...]
+    source_after: tuple[tuple[str, str], ...]
+    runtime_namespace: str
+    runtime_before: tuple[tuple[str, str], ...]
+    runtime_after: tuple[tuple[str, str], ...]
+
+
+def _git(checkout: Path, *arguments: str) -> str:
+    return subprocess.run(
+        ["git", *arguments],
+        cwd=checkout,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+def _require_physical_directory(path: Path, label: str) -> None:
+    if path.is_symlink() or not path.is_dir():
+        raise ValueError(f"{label} must be a real directory")
+
+
+def _hash_inventory(
+    root: Path, excluded_root: str | None
+) -> tuple[tuple[str, str], ...]:
+    inventory: list[tuple[str, str]] = []
+    for current, directories, files in os.walk(root, followlinks=False):
+        relative_dir = Path(current).relative_to(root)
+        directories[:] = sorted(
+            name
+            for name in directories
+            if not (
+                relative_dir == Path(".")
+                and (
+                    name == excluded_root
+                    or (excluded_root is not None and name == ".git")
+                )
+            )
+        )
+        for name in (*directories, *sorted(files)):
+            path = Path(current) / name
+            mode = path.lstat().st_mode
+            if stat.S_ISLNK(mode):
+                raise ValueError(f"checkout inventory contains symlink: {path}")
+            if stat.S_ISREG(mode):
+                if path.stat().st_nlink != 1:
+                    raise ValueError(f"checkout inventory contains hardlink: {path}")
+                relative = path.relative_to(root).as_posix()
+                inventory.append(
+                    (relative, hashlib.sha256(path.read_bytes()).hexdigest())
+                )
+            elif not stat.S_ISDIR(mode):
+                raise ValueError(f"checkout inventory contains special node: {path}")
+    return tuple(sorted(inventory))
+
+
+def _runtime_path(root: Path, namespace: str) -> Path:
+    runtime = root / namespace
+    if runtime.parent.resolve(strict=True) != root:
+        raise ValueError("runtime namespace escapes exact checkout")
+    return runtime
+
+
+def snapshot_canary_checkout(checkout: Path, arm: str) -> CanaryCheckoutSnapshot:
+    """Capture a clean checkout before the arm creates its runtime index."""
+
+    if arm not in RUNTIME_NAMESPACES:
+        raise ValueError(f"unsupported canary arm: {arm}")
+    supplied = checkout.absolute()
+    _require_physical_directory(supplied, "checkout")
+    root = supplied.resolve(strict=True)
+    if supplied != root:
+        raise ValueError("checkout path must be its resolved physical root")
+    namespace = RUNTIME_NAMESPACES[arm]
+    foreign = ".codegraph" if namespace == ".ast-cache" else ".ast-cache"
+    if os.path.lexists(root / foreign):
+        raise ValueError("checkout contains cross-arm runtime namespace")
+    runtime = _runtime_path(root, namespace)
+    if os.path.lexists(runtime):
+        raise ValueError("declared runtime namespace must be absent before execution")
+    tracked = tracked_paths(root)
+    return CanaryCheckoutSnapshot(
+        arm=arm,
+        checkout_root=root,
+        head_commit=_git(root, "rev-parse", "HEAD"),
+        tracked_paths=tracked,
+        repository_fingerprint=repository_fingerprint(root, tracked),
+        source_inventory=_hash_inventory(root, namespace),
+        runtime_namespace=namespace,
+        runtime_before=(),
+    )
+
+
+def audit_canary_checkout(snapshot: CanaryCheckoutSnapshot) -> CanaryWorkspaceAudit:
+    """Reject any checkout mutation outside the arm's exact runtime directory."""
+
+    root = snapshot.checkout_root
+    _require_physical_directory(root, "checkout")
+    if root.resolve(strict=True) != root:
+        raise ValueError("checkout root identity changed")
+    if _git(root, "rev-parse", "HEAD") != snapshot.head_commit:
+        raise ValueError("checkout HEAD changed")
+    tracked = tracked_paths(root)
+    if tracked != snapshot.tracked_paths:
+        raise ValueError("tracked path inventory changed")
+    try:
+        fingerprint = repository_fingerprint(root, tracked)
+    except ValueError as error:
+        raise ValueError("tracked repository content changed") from error
+    if fingerprint != snapshot.repository_fingerprint:
+        raise ValueError("tracked repository content changed")
+    source_after = _hash_inventory(root, snapshot.runtime_namespace)
+    if source_after != snapshot.source_inventory:
+        raise ValueError("non-runtime checkout inventory changed")
+    foreign = (
+        ".codegraph" if snapshot.runtime_namespace == ".ast-cache" else ".ast-cache"
+    )
+    if os.path.lexists(root / foreign):
+        raise ValueError("checkout contains cross-arm runtime namespace")
+    runtime = _runtime_path(root, snapshot.runtime_namespace)
+    _require_physical_directory(runtime, "runtime namespace")
+    runtime_after = _hash_inventory(runtime, None)
+    return CanaryWorkspaceAudit(
+        checkout_root=root,
+        head_commit=snapshot.head_commit,
+        tracked_paths=tracked,
+        repository_fingerprint=fingerprint,
+        source_before=snapshot.source_inventory,
+        source_after=source_after,
+        runtime_namespace=snapshot.runtime_namespace,
+        runtime_before=snapshot.runtime_before,
+        runtime_after=runtime_after,
+    )
+
+
+def cleanup_and_verify_canary_checkout(
+    snapshot: CanaryCheckoutSnapshot, audit: CanaryWorkspaceAudit | None
+) -> None:
+    """Remove only the declared runtime directory and prove checkout restoration."""
+
+    runtime = _runtime_path(snapshot.checkout_root, snapshot.runtime_namespace)
+    if audit is not None:
+        if audit.checkout_root != snapshot.checkout_root:
+            raise ValueError("audit checkout does not match snapshot")
+        if (
+            audit.runtime_namespace != snapshot.runtime_namespace
+            or audit.source_before != snapshot.source_inventory
+            or audit.runtime_before != snapshot.runtime_before
+        ):
+            raise ValueError("audit evidence does not match snapshot")
+        if _hash_inventory(runtime, None) != audit.runtime_after:
+            raise ValueError("runtime namespace changed after audit")
+    if os.path.lexists(runtime):
+        cleanup_runtime_index(
+            snapshot.checkout_root, snapshot.runtime_namespace, runtime
+        )
+    if os.path.lexists(runtime):
+        raise ValueError("runtime namespace cleanup failed")
+    if (
+        _hash_inventory(snapshot.checkout_root, snapshot.runtime_namespace)
+        != snapshot.source_inventory
+    ):
+        raise ValueError("checkout changed during runtime cleanup")
+    if _git(snapshot.checkout_root, "rev-parse", "HEAD") != snapshot.head_commit:
+        raise ValueError("checkout HEAD changed during runtime cleanup")
+    tracked = tracked_paths(snapshot.checkout_root)
+    if tracked != snapshot.tracked_paths:
+        raise ValueError("tracked paths changed during runtime cleanup")
+    try:
+        fingerprint = repository_fingerprint(snapshot.checkout_root, tracked)
+    except ValueError as error:
+        raise ValueError("tracked content changed during runtime cleanup") from error
+    if fingerprint != snapshot.repository_fingerprint:
+        raise ValueError("tracked content changed during runtime cleanup")

--- a/benchmarks/codegraph_compare/smoke_bundle.py
+++ b/benchmarks/codegraph_compare/smoke_bundle.py
@@ -303,6 +303,10 @@ def _validate_policy_evidence(
     actual_policy_files = {path.name for path in evidence.glob("policy_*.json")}
     if actual_policy_files != expected_policy_files:
         raise ValueError("policy evidence inventory mismatch")
+    expected_runtime_files = {f"runtime_index_{run.run_id}.json" for run in runs}
+    actual_runtime_files = {path.name for path in evidence.glob("runtime_index_*.json")}
+    if not actual_runtime_files <= expected_runtime_files:
+        raise ValueError("runtime evidence inventory mismatch")
     for run in runs:
         stored = _json(evidence / f"policy_{run.run_id}.json")
         if stored.get("transcript_path") != run.transcript_path:

--- a/tests/unit/test_benchmark_harness.py
+++ b/tests/unit/test_benchmark_harness.py
@@ -6775,17 +6775,35 @@ class TestSmokeModelPreflight:
 
 class TestCanaryLaunchPreflight:
     @staticmethod
+    def _identity_probe(arm: str, executable: Path) -> dict[str, str]:
+        if arm == "tsa-warm":
+            return {
+                "trusted_repo": "fixture",
+                "entrypoint": "fixture",
+                "entrypoint_sha256": "1" * 64,
+                "source_root": "fixture",
+                "source_sha256": "2" * 64,
+                "dependency_lock": "fixture",
+                "dependency_lock_sha256": "3" * 64,
+            }
+        return {
+            "package": "@colbymchenry/codegraph@1.5.0",
+            "version": "1.5.0",
+        }
+
+    @staticmethod
     def _fixture(tmp_path: Path):
         from benchmarks.codegraph_compare import canary_preflight
 
         checkout = tmp_path / "checkout"
         checkout.mkdir()
         tsa = Path(sys.executable)
-        codegraph = tmp_path / "codegraph"
-        codegraph.write_text("#!/bin/sh\necho 1.5.0\n", encoding="utf-8")
-        codegraph.chmod(0o755)
+        codegraph = Path(sys.executable)
         contracts = canary_preflight.build_canary_launch_contracts(
-            checkout, tsa_executable=tsa, codegraph_executable=codegraph
+            checkout,
+            tsa_executable=tsa,
+            codegraph_executable=codegraph,
+            identity_probe=TestCanaryLaunchPreflight._identity_probe,
         )
         return canary_preflight, checkout, tsa, codegraph, contracts
 
@@ -6861,16 +6879,20 @@ class TestCanaryLaunchPreflight:
         assert contracts[module.CODEGRAPH_ARM]["command"] == str(codegraph.resolve())
         assert (
             contracts[module.CODEGRAPH_ARM]["executable_sha256"]
-            == hashlib.sha256(b"#!/bin/sh\necho 1.5.0\n").hexdigest()
+            == hashlib.sha256(codegraph.read_bytes()).hexdigest()
         )
 
     def test_builder_rejects_non_executable_server(self, tmp_path: Path):
-        module, checkout, tsa, codegraph, _contracts = self._fixture(tmp_path)
-        codegraph.chmod(0o644)
+        module, checkout, tsa, _codegraph, _contracts = self._fixture(tmp_path)
+        codegraph = tmp_path / "codegraph"
+        codegraph.write_bytes(b"not executable")
 
         with pytest.raises(ValueError, match="is not executable"):
             module.build_canary_launch_contracts(
-                checkout, tsa_executable=tsa, codegraph_executable=codegraph
+                checkout,
+                tsa_executable=tsa,
+                codegraph_executable=codegraph,
+                identity_probe=self._identity_probe,
             )
 
     def test_builder_rejects_untrusted_tsa_interpreter(self, tmp_path: Path):
@@ -6885,11 +6907,18 @@ class TestCanaryLaunchPreflight:
 
     def test_builder_rejects_wrong_codegraph_version(self, tmp_path: Path):
         module, checkout, tsa, codegraph, _contracts = self._fixture(tmp_path)
-        codegraph.write_text("#!/bin/sh\necho 1.4.9\n", encoding="utf-8")
+
+        def wrong_version(arm: str, executable: Path) -> dict[str, str]:
+            if arm == module.CODEGRAPH_ARM:
+                raise ValueError("CodeGraph version identity mismatch: '1.4.9'")
+            return self._identity_probe(arm, executable)
 
         with pytest.raises(ValueError, match="version identity mismatch"):
             module.build_canary_launch_contracts(
-                checkout, tsa_executable=tsa, codegraph_executable=codegraph
+                checkout,
+                tsa_executable=tsa,
+                codegraph_executable=codegraph,
+                identity_probe=wrong_version,
             )
 
     def test_injected_identity_probe_marks_contract_as_scaffold(self, tmp_path: Path):
@@ -6944,6 +6973,7 @@ class TestCanaryLaunchPreflight:
                 checkout,
                 tsa_executable=tsa,
                 codegraph_executable=codegraph,
+                identity_probe=self._identity_probe,
             )
 
     def test_validator_rejects_rehashed_foreign_tool(self, tmp_path: Path):
@@ -6961,6 +6991,7 @@ class TestCanaryLaunchPreflight:
                 checkout,
                 tsa_executable=tsa,
                 codegraph_executable=codegraph,
+                identity_probe=self._identity_probe,
             )
 
     def test_validator_rejects_rehashed_ambient_environment_inheritance(
@@ -6980,6 +7011,7 @@ class TestCanaryLaunchPreflight:
                 checkout,
                 tsa_executable=tsa,
                 codegraph_executable=codegraph,
+                identity_probe=self._identity_probe,
             )
 
     def test_validator_accepts_exact_contracts(self, tmp_path: Path):
@@ -6990,6 +7022,7 @@ class TestCanaryLaunchPreflight:
             checkout,
             tsa_executable=tsa,
             codegraph_executable=codegraph,
+            identity_probe=self._identity_probe,
         )
 
         assert validated == contracts

--- a/tests/unit/test_benchmark_harness.py
+++ b/tests/unit/test_benchmark_harness.py
@@ -6897,7 +6897,7 @@ class TestCanaryLaunchPreflight:
 
     def test_builder_rejects_untrusted_tsa_interpreter(self, tmp_path: Path):
         module, checkout, tsa, codegraph, _contracts = self._fixture(tmp_path)
-        foreign = tmp_path / "foreign-python"
+        foreign = tmp_path / f"foreign-python{tsa.suffix}"
         shutil.copy2(tsa, foreign)
 
         with pytest.raises(ValueError, match="trusted repository interpreter"):
@@ -6926,12 +6926,8 @@ class TestCanaryLaunchPreflight:
 
         checkout = tmp_path / "checkout"
         checkout.mkdir()
-        tsa = tmp_path / "tsa"
-        tsa.write_text("#!/bin/sh\n", encoding="utf-8")
-        tsa.chmod(0o755)
-        codegraph = tmp_path / "codegraph"
-        codegraph.write_text("#!/bin/sh\n", encoding="utf-8")
-        codegraph.chmod(0o755)
+        tsa = Path(sys.executable)
+        codegraph = Path(sys.executable)
 
         contracts = canary_preflight.build_canary_launch_contracts(
             checkout,

--- a/tests/unit/test_benchmark_harness.py
+++ b/tests/unit/test_benchmark_harness.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import shutil
 import sqlite3
 import subprocess
@@ -2472,6 +2473,38 @@ class TestCodeGraphCompareSetupGate:
 
 class TestGinSmokeManifestExecution:
     @staticmethod
+    def _tsa_canary_item(call_id: str = "call-001") -> dict:
+        payload = {
+            "symbol": "Engine.ServeHTTP",
+            "definition": {
+                "definitions": [
+                    {
+                        "file": "gin.go",
+                        "name": "Engine.ServeHTTP",
+                        "kind": "method",
+                    }
+                ]
+            },
+        }
+        return {
+            "id": call_id,
+            "type": "mcp_tool_call",
+            "status": "completed",
+            "server": "tree-sitter-analyzer",
+            "tool": "nav",
+            "arguments": {
+                "action": "navigate",
+                "symbol": "Engine.ServeHTTP",
+                "file_path": "gin.go",
+                "output_format": "json",
+            },
+            "result": {
+                "content": [{"type": "text", "text": json.dumps(payload)}],
+                "structured_content": {"untrusted": "not receipt evidence"},
+            },
+        }
+
+    @staticmethod
     def _legacy_record(manifest, run_id: str, transcript_path: Path) -> dict:
         cell = next(cell for cell in manifest.expected_cells if cell.run_id == run_id)
         return {
@@ -2654,6 +2687,528 @@ class TestGinSmokeManifestExecution:
         audit = audit_codex_transcript(transcript, "tsa-warm")
 
         assert audit.violations == ("CROSS_ARM_MCP:1", "MISSING_INDEX_QUERY")
+
+    def test_canary_transcript_binds_exact_mcp_receipt(self, tmp_path: Path):
+        from benchmarks.codegraph_compare.canary_policy import audit_canary_transcript
+
+        transcript = tmp_path / "canary.jsonl"
+        transcript.write_text(
+            json.dumps(
+                {
+                    "type": "item.completed",
+                    "item": self._tsa_canary_item(),
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        audit = audit_canary_transcript(
+            transcript,
+            "tsa-warm",
+            expected_tool="nav",
+            expected_path="gin.go",
+            expected_symbol="Engine.ServeHTTP",
+            expected_kind="method",
+        )
+
+        assert audit.violations == ()
+        assert audit.receipt is not None
+        assert audit.receipt.call_id == "call-001"
+        assert audit.receipt.repository_relative_path == "gin.go"
+        assert audit.receipt.symbol_identity == "Engine.ServeHTTP"
+        assert audit.receipt.symbol_kind == "method"
+
+    @pytest.mark.parametrize(
+        "arguments",
+        (
+            {
+                "action": "navigate",
+                "symbol": "Engine.ServeHTTP",
+                "file_path": "gin.go",
+            },
+            {
+                "action": "navigate",
+                "symbol": "Engine.ServeHTTP",
+                "file_path": "gin.go",
+                "output_format": "toon",
+            },
+            {
+                "action": "resolve",
+                "symbol": "Engine.ServeHTTP",
+                "file_path": "gin.go",
+                "output_format": "json",
+            },
+        ),
+    )
+    def test_canary_transcript_rejects_nonexact_tsa_arguments(
+        self, tmp_path: Path, arguments: dict
+    ):
+        from benchmarks.codegraph_compare.canary_policy import audit_canary_transcript
+
+        item = {**self._tsa_canary_item(), "arguments": arguments}
+        transcript = tmp_path / "wrong-tsa-arguments.jsonl"
+        transcript.write_text(
+            json.dumps({"type": "item.completed", "item": item}) + "\n",
+            encoding="utf-8",
+        )
+
+        audit = audit_canary_transcript(
+            transcript,
+            "tsa-warm",
+            expected_tool="nav",
+            expected_path="gin.go",
+            expected_symbol="Engine.ServeHTTP",
+            expected_kind="method",
+        )
+
+        assert audit.violations == (
+            "CANARY_ARGUMENTS_MISMATCH:1",
+            "CANARY_RECEIPT_MISSING",
+        )
+        assert audit.receipt is None
+
+    @pytest.mark.parametrize(
+        ("mutation", "violation"),
+        (
+            ({"tool": "unknown"}, "CANARY_TOOL_MISMATCH:1"),
+            ({"id": ""}, "CANARY_RECEIPT_INVALID:1"),
+            ({"result": {}}, "CANARY_RECEIPT_INVALID:1"),
+            ({"status": "started"}, "CANARY_RECEIPT_INVALID:1"),
+            ({"status": None}, "CANARY_RECEIPT_INVALID:1"),
+        ),
+    )
+    def test_canary_transcript_rejects_ambiguous_mcp_success(
+        self, tmp_path: Path, mutation: dict, violation: str
+    ):
+        from benchmarks.codegraph_compare.canary_policy import audit_canary_transcript
+
+        item = {**self._tsa_canary_item(), **mutation}
+        transcript = tmp_path / "ambiguous-canary.jsonl"
+        transcript.write_text(
+            json.dumps({"type": "item.completed", "item": item}) + "\n",
+            encoding="utf-8",
+        )
+
+        audit = audit_canary_transcript(
+            transcript,
+            "tsa-warm",
+            expected_tool="nav",
+            expected_path="gin.go",
+            expected_symbol="Engine.ServeHTTP",
+            expected_kind="method",
+        )
+
+        assert audit.violations == (violation, "CANARY_RECEIPT_MISSING")
+        assert audit.receipt is None
+
+    def test_canary_transcript_binds_codegraph_markdown_receipt(self, tmp_path: Path):
+        from benchmarks.codegraph_compare.canary_policy import audit_canary_transcript
+
+        markdown = (
+            "**ServeHTTP** (method)\n"
+            "func (engine *Engine) ServeHTTP(w http.ResponseWriter, req *http.Request)\n"
+            "gin.go:688"
+        )
+        transcript = tmp_path / "wrong-symbol.jsonl"
+        transcript.write_text(
+            json.dumps(
+                {
+                    "type": "item.completed",
+                    "item": {
+                        "id": "call-001",
+                        "type": "mcp_tool_call",
+                        "status": "completed",
+                        "server": "codegraph",
+                        "tool": "codegraph_search",
+                        "arguments": {
+                            "query": "Engine.ServeHTTP",
+                            "kind": "method",
+                            "limit": 10,
+                        },
+                        "result": {"content": [{"type": "text", "text": markdown}]},
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        audit = audit_canary_transcript(
+            transcript,
+            "codegraph-warm",
+            expected_tool="codegraph_search",
+            expected_path="gin.go",
+            expected_symbol="Engine.ServeHTTP",
+            expected_kind="method",
+        )
+
+        assert audit.violations == ()
+        assert audit.receipt is not None
+        assert audit.receipt.server == "codegraph"
+        assert audit.receipt.repository_relative_path == "gin.go"
+
+    @pytest.mark.parametrize(
+        "markdown",
+        (
+            "**ServeHTTP** (method)\ngin.go:688",
+            "**ServeHTTP** (method)\nfunc ServeHTTP(w http.ResponseWriter)\ngin.go:688",
+            "**ServeHTTP** (method)\nfunc (server *Server) ServeHTTP(w http.ResponseWriter)\ngin.go:688",
+            "**ServeHTTP** (method)\nfunc (engine *Engine) ServeHTTP(w http.ResponseWriter)\ngin.go:688\n"
+            "**ServeHTTP** (method)\nfunc (server *Server) ServeHTTP(w http.ResponseWriter)\nother.go:42",
+        ),
+    )
+    def test_canary_transcript_rejects_codegraph_receiver_counterexamples(
+        self, tmp_path: Path, markdown: str
+    ):
+        from benchmarks.codegraph_compare.canary_policy import audit_canary_transcript
+
+        item = {
+            "id": "call-001",
+            "type": "mcp_tool_call",
+            "status": "completed",
+            "server": "codegraph",
+            "tool": "codegraph_search",
+            "arguments": {
+                "query": "Engine.ServeHTTP",
+                "kind": "method",
+                "limit": 10,
+            },
+            "result": {"content": [{"type": "text", "text": markdown}]},
+        }
+        transcript = tmp_path / "receiver-counterexample.jsonl"
+        transcript.write_text(
+            json.dumps({"type": "item.completed", "item": item}) + "\n",
+            encoding="utf-8",
+        )
+
+        audit = audit_canary_transcript(
+            transcript,
+            "codegraph-warm",
+            expected_tool="codegraph_search",
+            expected_path="gin.go",
+            expected_symbol="Engine.ServeHTTP",
+            expected_kind="method",
+        )
+
+        assert audit.violations == (
+            "CANARY_RECEIPT_INVALID:1",
+            "CANARY_RECEIPT_MISSING",
+        )
+        assert audit.receipt is None
+
+    @pytest.mark.parametrize(
+        ("arguments", "markdown", "violation"),
+        (
+            (
+                {"query": "ServeHTTP", "kind": "method", "limit": 10},
+                "**ServeHTTP** (method)\ngin.go:42",
+                "CANARY_ARGUMENTS_MISMATCH:1",
+            ),
+            (
+                {"query": "Engine.ServeHTTP", "kind": "method", "limit": 10},
+                "**ServeHTTP** (method)\ngin.go:42\n**ServeHTTP** (method)\ngin.go:688",
+                "CANARY_RECEIPT_INVALID:1",
+            ),
+            (
+                {"query": "Engine.ServeHTTP", "kind": "method", "limit": 10},
+                "**ServeHTTP** (method)\ngin.go:0",
+                "CANARY_RECEIPT_INVALID:1",
+            ),
+        ),
+    )
+    def test_canary_transcript_rejects_codegraph_receipt_ambiguity(
+        self, tmp_path: Path, arguments: dict, markdown: str, violation: str
+    ):
+        from benchmarks.codegraph_compare.canary_policy import audit_canary_transcript
+
+        item = {
+            "id": "call-001",
+            "type": "mcp_tool_call",
+            "status": "completed",
+            "server": "codegraph",
+            "tool": "codegraph_search",
+            "arguments": arguments,
+            "result": {"content": [{"type": "text", "text": markdown}]},
+        }
+        transcript = tmp_path / "bad-codegraph-receipt.jsonl"
+        transcript.write_text(
+            json.dumps({"type": "item.completed", "item": item}) + "\n",
+            encoding="utf-8",
+        )
+
+        audit = audit_canary_transcript(
+            transcript,
+            "codegraph-warm",
+            expected_tool="codegraph_search",
+            expected_path="gin.go",
+            expected_symbol="Engine.ServeHTTP",
+            expected_kind="method",
+        )
+
+        assert audit.violations == (
+            violation,
+            "CANARY_RECEIPT_MISSING",
+        )
+        assert audit.receipt is None
+
+    def test_canary_transcript_rejects_started_item_shape(self, tmp_path: Path):
+        from benchmarks.codegraph_compare.canary_policy import audit_canary_transcript
+
+        item = {**self._tsa_canary_item(), "status": "in_progress"}
+        transcript = tmp_path / "started-canary.jsonl"
+        transcript.write_text(
+            json.dumps({"type": "item.started", "item": item}) + "\n",
+            encoding="utf-8",
+        )
+
+        audit = audit_canary_transcript(
+            transcript,
+            "tsa-warm",
+            expected_tool="nav",
+            expected_path="gin.go",
+            expected_symbol="Engine.ServeHTTP",
+            expected_kind="method",
+        )
+
+        assert audit.violations == ("MISSING_INDEX_QUERY", "CANARY_RECEIPT_MISSING")
+        assert audit.receipt is None
+
+    def test_canary_transcript_rejects_failed_item_status(self, tmp_path: Path):
+        from benchmarks.codegraph_compare.canary_policy import audit_canary_transcript
+
+        item = {**self._tsa_canary_item(), "status": "failed"}
+        transcript = tmp_path / "failed-canary.jsonl"
+        transcript.write_text(
+            json.dumps({"type": "item.completed", "item": item}) + "\n",
+            encoding="utf-8",
+        )
+
+        audit = audit_canary_transcript(
+            transcript,
+            "tsa-warm",
+            expected_tool="nav",
+            expected_path="gin.go",
+            expected_symbol="Engine.ServeHTTP",
+            expected_kind="method",
+        )
+
+        assert audit.violations == (
+            "MCP_CALL_FAILED:1",
+            "MISSING_INDEX_QUERY",
+            "CANARY_RECEIPT_MISSING",
+        )
+        assert audit.receipt is None
+
+    def test_canary_transcript_rejects_wrong_tsa_definition(self, tmp_path: Path):
+        from benchmarks.codegraph_compare.canary_policy import audit_canary_transcript
+
+        item = self._tsa_canary_item()
+        payload = json.loads(item["result"]["content"][0]["text"])
+        payload["definition"]["definitions"][0]["file"] = "tree.go"
+        item["result"]["content"][0]["text"] = json.dumps(payload)
+        transcript = tmp_path / "wrong-tsa-definition.jsonl"
+        transcript.write_text(
+            json.dumps({"type": "item.completed", "item": item}) + "\n",
+            encoding="utf-8",
+        )
+
+        audit = audit_canary_transcript(
+            transcript,
+            "tsa-warm",
+            expected_tool="nav",
+            expected_path="gin.go",
+            expected_symbol="Engine.ServeHTTP",
+            expected_kind="method",
+        )
+
+        assert audit.violations == (
+            "CANARY_EVIDENCE_MISMATCH:1",
+            "CANARY_RECEIPT_MISSING",
+        )
+        assert audit.receipt is None
+
+    def test_canary_transcript_rejects_multiple_exact_receipts(self, tmp_path: Path):
+        from benchmarks.codegraph_compare.canary_policy import audit_canary_transcript
+
+        def event(call_id: str) -> str:
+            return json.dumps(
+                {
+                    "type": "item.completed",
+                    "item": self._tsa_canary_item(call_id),
+                }
+            )
+
+        transcript = tmp_path / "duplicate-receipts.jsonl"
+        transcript.write_text(
+            event("call-001") + "\n" + event("call-002") + "\n",
+            encoding="utf-8",
+        )
+
+        audit = audit_canary_transcript(
+            transcript,
+            "tsa-warm",
+            expected_tool="nav",
+            expected_path="gin.go",
+            expected_symbol="Engine.ServeHTTP",
+            expected_kind="method",
+        )
+
+        assert audit.violations == ("CANARY_RECEIPT_AMBIGUOUS",)
+        assert audit.receipt is None
+
+    @pytest.mark.parametrize("command", ("rg -n ServeHTTP .", "cat gin.go"))
+    def test_canary_transcript_keeps_source_locked_after_unknown_mcp(
+        self, tmp_path: Path, command: str
+    ):
+        from benchmarks.codegraph_compare.canary_policy import audit_canary_transcript
+
+        transcript = tmp_path / "unknown-before-source.jsonl"
+        transcript.write_text(
+            "\n".join(
+                (
+                    json.dumps(
+                        {
+                            "type": "item.completed",
+                            "item": {
+                                "id": "call-unknown",
+                                "type": "mcp_tool_call",
+                                "status": "completed",
+                                "server": "tree-sitter-analyzer",
+                                "tool": "unknown",
+                                "result": {},
+                            },
+                        }
+                    ),
+                    json.dumps(
+                        {
+                            "type": "item.completed",
+                            "item": {
+                                "type": "command_execution",
+                                "command": command,
+                            },
+                        }
+                    ),
+                )
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        audit = audit_canary_transcript(
+            transcript,
+            "tsa-warm",
+            expected_tool="nav",
+            expected_path="gin.go",
+            expected_symbol="Engine.ServeHTTP",
+            expected_kind="method",
+        )
+
+        assert audit.violations == (
+            "CANARY_TOOL_MISMATCH:1",
+            "CANARY_SOURCE_DISCOVERY_BEFORE_RECEIPT:2",
+            "CANARY_RECEIPT_MISSING",
+        )
+
+    @pytest.mark.parametrize(
+        "result_error",
+        ({"isError": True}, {"error": {"message": "query failed"}}),
+    )
+    def test_canary_transcript_rejects_nested_error_result_before_source(
+        self, tmp_path: Path, result_error: dict
+    ):
+        from benchmarks.codegraph_compare.canary_policy import audit_canary_transcript
+
+        result = {**self._tsa_canary_item()["result"], **result_error}
+        transcript = tmp_path / "failed-before-source.jsonl"
+        transcript.write_text(
+            "\n".join(
+                (
+                    json.dumps(
+                        {
+                            "type": "item.completed",
+                            "item": {
+                                "id": "call-failed",
+                                "type": "mcp_tool_call",
+                                "status": "completed",
+                                "server": "tree-sitter-analyzer",
+                                "tool": "nav",
+                                "result": result,
+                            },
+                        }
+                    ),
+                    json.dumps(
+                        {
+                            "type": "item.completed",
+                            "item": {
+                                "type": "command_execution",
+                                "command": "rg -n ServeHTTP .",
+                            },
+                        }
+                    ),
+                )
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        audit = audit_canary_transcript(
+            transcript,
+            "tsa-warm",
+            expected_tool="nav",
+            expected_path="gin.go",
+            expected_symbol="Engine.ServeHTTP",
+            expected_kind="method",
+        )
+
+        assert audit.violations == (
+            "MCP_CALL_FAILED:1",
+            "SOURCE_DISCOVERY_BEFORE_INDEX:2",
+            "MISSING_INDEX_QUERY",
+            "CANARY_SOURCE_DISCOVERY_BEFORE_RECEIPT:2",
+            "CANARY_RECEIPT_MISSING",
+        )
+
+    def test_canary_transcript_unlocks_source_after_exact_receipt(self, tmp_path: Path):
+        from benchmarks.codegraph_compare.canary_policy import audit_canary_transcript
+
+        transcript = tmp_path / "receipt-before-source.jsonl"
+        transcript.write_text(
+            "\n".join(
+                (
+                    json.dumps(
+                        {
+                            "type": "item.completed",
+                            "item": self._tsa_canary_item(),
+                        }
+                    ),
+                    json.dumps(
+                        {
+                            "type": "item.completed",
+                            "item": {
+                                "type": "command_execution",
+                                "command": "cat gin.go",
+                            },
+                        }
+                    ),
+                )
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        audit = audit_canary_transcript(
+            transcript,
+            "tsa-warm",
+            expected_tool="nav",
+            expected_path="gin.go",
+            expected_symbol="Engine.ServeHTTP",
+            expected_kind="method",
+        )
+
+        assert audit.violations == ()
+        assert audit.receipt is not None
+        assert audit.receipt.call_id == "call-001"
 
     @pytest.mark.parametrize(
         ("item", "violation"),
@@ -4178,6 +4733,23 @@ class TestGinSmokeBundle:
         assert verdict["claim_level"] == "INVALID"
         assert verdict["dominance_allowed"] is False
         assert verdict["winner"] is None
+
+    def test_bundle_rejects_orphan_runtime_evidence(self, tmp_path: Path):
+        from benchmarks.codegraph_compare.smoke_bundle import create_smoke_bundle
+
+        plan, experiment, registry = self._bundle_inputs(tmp_path)
+        (experiment / "runtime_index_unknown-run.json").write_text(
+            "{}\n", encoding="utf-8"
+        )
+
+        # Issue #1219: every retained runtime audit must bind to an exact run.
+        with pytest.raises(ValueError, match="runtime evidence inventory mismatch"):
+            create_smoke_bundle(
+                tmp_path / "bundle",
+                plan_dir=plan,
+                experiment_dir=experiment,
+                registry_path=registry,
+            )
 
     def test_bundle_accepts_bound_legacy_terminal_exception(self, tmp_path: Path):
         from benchmarks.codegraph_compare.smoke_bundle import create_smoke_bundle
@@ -6199,3 +6771,1305 @@ class TestSmokeModelPreflight:
                 expected_cli_fingerprint="bound",
                 max_age_seconds=900,
             )
+
+
+class TestCanaryLaunchPreflight:
+    @staticmethod
+    def _fixture(tmp_path: Path):
+        from benchmarks.codegraph_compare import canary_preflight
+
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+        tsa = Path(sys.executable)
+        codegraph = tmp_path / "codegraph"
+        codegraph.write_text("#!/bin/sh\necho 1.5.0\n", encoding="utf-8")
+        codegraph.chmod(0o755)
+        contracts = canary_preflight.build_canary_launch_contracts(
+            checkout, tsa_executable=tsa, codegraph_executable=codegraph
+        )
+        return canary_preflight, checkout, tsa, codegraph, contracts
+
+    def test_builder_pins_exact_tsa_nav_launch(self, tmp_path: Path):
+        module, checkout, _tsa, _codegraph, contracts = self._fixture(tmp_path)
+
+        contract = contracts[module.TSA_ARM]
+
+        assert contract["args"] == [
+            "-m",
+            "tree_sitter_analyzer.mcp.server",
+            "--project-root",
+            str(checkout.resolve()),
+        ]
+        assert contract["enabled_tools"] == ["nav"]
+        assert contract["required"] is True
+        assert contract["network"] is False
+        assert contract["env"] == {
+            "PYTHONHASHSEED": "0",
+            "PYTHONNOUSERSITE": "1",
+            "TREE_SITTER_PROJECT_ROOT": str(checkout.resolve()),
+        }
+        assert contract["inherit_environment"] is False
+        assert set(contract["tsa_identity"]) == {
+            "trusted_repo",
+            "entrypoint",
+            "entrypoint_sha256",
+            "source_root",
+            "source_sha256",
+            "dependency_lock",
+            "dependency_lock_sha256",
+        }
+        assert contract["production_ready"] is False
+
+    def test_builder_pins_exact_codegraph_search_launch(self, tmp_path: Path):
+        module, checkout, _tsa, _codegraph, contracts = self._fixture(tmp_path)
+
+        contract = contracts[module.CODEGRAPH_ARM]
+
+        assert contract["package"] == "@colbymchenry/codegraph@1.5.0"
+        assert contract["args"] == [
+            "serve",
+            "--mcp",
+            "--no-watch",
+            "-p",
+            str(checkout.resolve()),
+        ]
+        assert contract["env"] == {
+            "CODEGRAPH_MCP_TOOLS": "search",
+            "CODEGRAPH_NO_DAEMON": "1",
+            "CODEGRAPH_NO_UPDATE_CHECK": "1",
+            "CODEGRAPH_TELEMETRY": "0",
+            "PATH": os.defpath,
+        }
+        assert contract["enabled_tools"] == ["codegraph_search"]
+        assert contract["required"] is True
+        assert contract["network"] is False
+        assert contract["inherit_environment"] is False
+        assert contract["codegraph_identity"] == {
+            "package": "@colbymchenry/codegraph@1.5.0",
+            "version": "1.5.0",
+        }
+        assert contract["production_ready"] is False
+
+    def test_builder_binds_absolute_executables_and_digests(self, tmp_path: Path):
+        module, _checkout, tsa, codegraph, contracts = self._fixture(tmp_path)
+
+        assert contracts[module.TSA_ARM]["command"] == str(tsa.resolve())
+        assert (
+            contracts[module.TSA_ARM]["executable_sha256"]
+            == hashlib.sha256(tsa.read_bytes()).hexdigest()
+        )
+        assert contracts[module.CODEGRAPH_ARM]["command"] == str(codegraph.resolve())
+        assert (
+            contracts[module.CODEGRAPH_ARM]["executable_sha256"]
+            == hashlib.sha256(b"#!/bin/sh\necho 1.5.0\n").hexdigest()
+        )
+
+    def test_builder_rejects_non_executable_server(self, tmp_path: Path):
+        module, checkout, tsa, codegraph, _contracts = self._fixture(tmp_path)
+        codegraph.chmod(0o644)
+
+        with pytest.raises(ValueError, match="is not executable"):
+            module.build_canary_launch_contracts(
+                checkout, tsa_executable=tsa, codegraph_executable=codegraph
+            )
+
+    def test_builder_rejects_untrusted_tsa_interpreter(self, tmp_path: Path):
+        module, checkout, tsa, codegraph, _contracts = self._fixture(tmp_path)
+        foreign = tmp_path / "foreign-python"
+        shutil.copy2(tsa, foreign)
+
+        with pytest.raises(ValueError, match="trusted repository interpreter"):
+            module.build_canary_launch_contracts(
+                checkout, tsa_executable=foreign, codegraph_executable=codegraph
+            )
+
+    def test_builder_rejects_wrong_codegraph_version(self, tmp_path: Path):
+        module, checkout, tsa, codegraph, _contracts = self._fixture(tmp_path)
+        codegraph.write_text("#!/bin/sh\necho 1.4.9\n", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="version identity mismatch"):
+            module.build_canary_launch_contracts(
+                checkout, tsa_executable=tsa, codegraph_executable=codegraph
+            )
+
+    def test_injected_identity_probe_marks_contract_as_scaffold(self, tmp_path: Path):
+        from benchmarks.codegraph_compare import canary_preflight
+
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+        tsa = tmp_path / "tsa"
+        tsa.write_text("#!/bin/sh\n", encoding="utf-8")
+        tsa.chmod(0o755)
+        codegraph = tmp_path / "codegraph"
+        codegraph.write_text("#!/bin/sh\n", encoding="utf-8")
+        codegraph.chmod(0o755)
+
+        contracts = canary_preflight.build_canary_launch_contracts(
+            checkout,
+            tsa_executable=tsa,
+            codegraph_executable=codegraph,
+            identity_probe=lambda arm, executable: {
+                "fixture_arm": arm,
+                "fixture_executable": str(executable),
+            },
+        )
+
+        assert contracts["tsa-warm"]["production_ready"] is False
+        assert contracts["codegraph-warm"]["production_ready"] is False
+
+    @pytest.mark.parametrize(
+        ("arm", "field", "value"),
+        [
+            ("tsa-warm", "args", ["--project-root", "/wrong"]),
+            ("tsa-warm", "enabled_tools", ["search"]),
+            ("tsa-warm", "required", False),
+            ("tsa-warm", "network", True),
+            ("tsa-warm", "executable_sha256", "0" * 64),
+            ("codegraph-warm", "args", ["serve", "--mcp"]),
+            ("codegraph-warm", "enabled_tools", ["search", "read"]),
+            ("codegraph-warm", "env", {"CODEGRAPH_MCP_TOOLS": "search"}),
+            ("codegraph-warm", "required", False),
+            ("codegraph-warm", "executable_sha256", "f" * 64),
+        ],
+    )
+    def test_validator_rejects_mutated_launch_surface(
+        self, tmp_path: Path, arm: str, field: str, value: object
+    ):
+        module, checkout, tsa, codegraph, contracts = self._fixture(tmp_path)
+        contracts[arm][field] = value
+
+        with pytest.raises(ValueError, match="launch config hash is invalid"):
+            module.validate_canary_launch_contracts(
+                contracts,
+                checkout,
+                tsa_executable=tsa,
+                codegraph_executable=codegraph,
+            )
+
+    def test_validator_rejects_rehashed_foreign_tool(self, tmp_path: Path):
+        module, checkout, tsa, codegraph, contracts = self._fixture(tmp_path)
+        contract = contracts[module.CODEGRAPH_ARM]
+        contract["enabled_tools"] = ["read"]
+        unsigned = {
+            key: value for key, value in contract.items() if key != "launch_config_hash"
+        }
+        contract["launch_config_hash"] = module._sha256(unsigned)
+
+        with pytest.raises(ValueError, match="codegraph-warm.enabled_tools"):
+            module.validate_canary_launch_contracts(
+                contracts,
+                checkout,
+                tsa_executable=tsa,
+                codegraph_executable=codegraph,
+            )
+
+    def test_validator_rejects_rehashed_ambient_environment_inheritance(
+        self, tmp_path: Path
+    ):
+        module, checkout, tsa, codegraph, contracts = self._fixture(tmp_path)
+        contract = contracts[module.TSA_ARM]
+        contract["inherit_environment"] = True
+        unsigned = {
+            key: value for key, value in contract.items() if key != "launch_config_hash"
+        }
+        contract["launch_config_hash"] = module._sha256(unsigned)
+
+        with pytest.raises(ValueError, match="tsa-warm.inherit_environment"):
+            module.validate_canary_launch_contracts(
+                contracts,
+                checkout,
+                tsa_executable=tsa,
+                codegraph_executable=codegraph,
+            )
+
+    def test_validator_accepts_exact_contracts(self, tmp_path: Path):
+        module, checkout, tsa, codegraph, contracts = self._fixture(tmp_path)
+
+        validated = module.validate_canary_launch_contracts(
+            contracts,
+            checkout,
+            tsa_executable=tsa,
+            codegraph_executable=codegraph,
+        )
+
+        assert validated == contracts
+
+
+class TestCanaryWorkspaceImmutability:
+    def _checkout(self, tmp_path: Path) -> Path:
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=checkout, check=True)
+        subprocess.run(
+            ["git", "config", "user.email", "canary@example.invalid"],
+            cwd=checkout,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Canary"], cwd=checkout, check=True
+        )
+        (checkout / "gin.go").write_text("package gin\n", encoding="utf-8")
+        (checkout / "README.md").write_text("fixture\n", encoding="utf-8")
+        subprocess.run(["git", "add", "."], cwd=checkout, check=True)
+        subprocess.run(
+            ["git", "commit", "-q", "-m", "fixture"], cwd=checkout, check=True
+        )
+        return checkout.resolve()
+
+    def test_audit_records_exact_source_and_runtime_inventories(self, tmp_path: Path):
+        from benchmarks.codegraph_compare.canary_workspace import (
+            audit_canary_checkout,
+            cleanup_and_verify_canary_checkout,
+            snapshot_canary_checkout,
+        )
+
+        checkout = self._checkout(tmp_path)
+        snapshot = snapshot_canary_checkout(checkout, "tsa-warm")
+        runtime = checkout / ".ast-cache"
+        runtime.mkdir()
+        (runtime / "index.db").write_bytes(b"index")
+
+        audit = audit_canary_checkout(snapshot)
+
+        assert audit.checkout_root == checkout
+        assert audit.head_commit == snapshot.head_commit
+        assert audit.tracked_paths == ("README.md", "gin.go")
+        assert audit.repository_fingerprint == snapshot.repository_fingerprint
+        assert audit.source_after == audit.source_before
+        assert audit.runtime_before == ()
+        assert audit.runtime_after == (
+            ("index.db", hashlib.sha256(b"index").hexdigest()),
+        )
+        cleanup_and_verify_canary_checkout(snapshot, audit)
+        assert os.path.lexists(runtime) is False
+
+    def test_runtime_inventory_includes_nested_git_metadata(self, tmp_path: Path):
+        from benchmarks.codegraph_compare.canary_workspace import (
+            audit_canary_checkout,
+            snapshot_canary_checkout,
+        )
+
+        checkout = self._checkout(tmp_path)
+        snapshot = snapshot_canary_checkout(checkout, "tsa-warm")
+        runtime_git = checkout / ".ast-cache" / ".git"
+        runtime_git.mkdir(parents=True)
+        (runtime_git / "config").write_bytes(b"runtime-metadata")
+
+        audit = audit_canary_checkout(snapshot)
+
+        assert audit.runtime_after == (
+            (
+                ".git/config",
+                hashlib.sha256(b"runtime-metadata").hexdigest(),
+            ),
+        )
+
+    @pytest.mark.parametrize(
+        ("mutation", "message"),
+        [
+            ("tracked", "tracked repository content changed"),
+            ("new", "non-runtime checkout inventory changed"),
+            ("delete", "tracked repository content changed"),
+            ("rename", "tracked repository content changed"),
+        ],
+    )
+    def test_audit_rejects_checkout_namespace_mutation(
+        self, tmp_path: Path, mutation: str, message: str
+    ):
+        from benchmarks.codegraph_compare.canary_workspace import (
+            audit_canary_checkout,
+            snapshot_canary_checkout,
+        )
+
+        checkout = self._checkout(tmp_path)
+        snapshot = snapshot_canary_checkout(checkout, "codegraph-warm")
+        (checkout / ".codegraph").mkdir()
+        if mutation == "tracked":
+            (checkout / "gin.go").write_text("mutated\n", encoding="utf-8")
+        elif mutation == "new":
+            (checkout / "unprovenanced.txt").write_text("new\n", encoding="utf-8")
+        elif mutation == "delete":
+            (checkout / "gin.go").unlink()
+        else:
+            (checkout / "gin.go").rename(checkout / "renamed.go")
+
+        with pytest.raises(ValueError, match=message):
+            audit_canary_checkout(snapshot)
+
+    def test_audit_rejects_symlinked_runtime_namespace(self, tmp_path: Path):
+        from benchmarks.codegraph_compare.canary_workspace import (
+            audit_canary_checkout,
+            snapshot_canary_checkout,
+        )
+
+        checkout = self._checkout(tmp_path)
+        snapshot = snapshot_canary_checkout(checkout, "tsa-warm")
+        target = tmp_path / "escaped"
+        target.mkdir()
+        (checkout / ".ast-cache").symlink_to(target, target_is_directory=True)
+
+        with pytest.raises(
+            ValueError, match="runtime namespace must be a real directory"
+        ):
+            audit_canary_checkout(snapshot)
+
+    def test_snapshot_rejects_cross_arm_namespace(self, tmp_path: Path):
+        from benchmarks.codegraph_compare.canary_workspace import (
+            snapshot_canary_checkout,
+        )
+
+        checkout = self._checkout(tmp_path)
+        (checkout / ".codegraph").mkdir()
+
+        with pytest.raises(ValueError, match="cross-arm runtime namespace"):
+            snapshot_canary_checkout(checkout, "tsa-warm")
+
+    def test_audit_rejects_hardlinked_runtime_file(self, tmp_path: Path):
+        from benchmarks.codegraph_compare.canary_workspace import (
+            audit_canary_checkout,
+            snapshot_canary_checkout,
+        )
+
+        checkout = self._checkout(tmp_path)
+        snapshot = snapshot_canary_checkout(checkout, "codegraph-warm")
+        runtime = checkout / ".codegraph"
+        runtime.mkdir()
+        source = tmp_path / "shared.db"
+        source.write_bytes(b"shared")
+        os.link(source, runtime / "codegraph.db")
+
+        with pytest.raises(ValueError, match="checkout inventory contains hardlink"):
+            audit_canary_checkout(snapshot)
+
+    def test_cleanup_restores_checkout_when_audit_failed(self, tmp_path: Path):
+        from benchmarks.codegraph_compare.canary_workspace import (
+            cleanup_and_verify_canary_checkout,
+            snapshot_canary_checkout,
+        )
+
+        checkout = self._checkout(tmp_path)
+        snapshot = snapshot_canary_checkout(checkout, "tsa-warm")
+        runtime = checkout / ".ast-cache"
+        runtime.mkdir()
+        (runtime / "partial.db").write_bytes(b"partial")
+
+        cleanup_and_verify_canary_checkout(snapshot, None)
+
+        assert os.path.lexists(runtime) is False
+
+
+class TestCanaryEvidence:
+    @staticmethod
+    def _manifest():
+        from benchmarks.codegraph_compare.canary_evidence import create_canary_manifest
+
+        return create_canary_manifest(
+            benchmark_git_sha="benchmark-sha",
+            benchmark_version="NO1-002C-E0-v1",
+            model="gpt-fixture",
+            agent_cli_fingerprint="codex-cli-fixture",
+            gin_commit="gin-commit",
+            gin_source_fingerprint="a" * 64,
+            canary_prompt_sha256="b" * 64,
+            launch_config_hashes={"tsa-warm": "c" * 64, "codegraph-warm": "d" * 64},
+            timeout_seconds=300,
+            seed=1195,
+        )
+
+    @staticmethod
+    def _evidence(manifest, tmp_path):
+        from benchmarks.codegraph_compare.canary_evidence import (
+            CanaryArtifactV1,
+            CanaryAttemptV1,
+            CanaryRegistryEventV1,
+        )
+
+        attempts = []
+        artifacts = []
+        for index, cell in enumerate(manifest.cells):
+            call_id = f"call-{index}"
+            if cell.arm == "tsa-warm":
+                item = TestGinSmokeManifestExecution._tsa_canary_item(call_id)
+            else:
+                item = {
+                    "id": call_id,
+                    "type": "mcp_tool_call",
+                    "status": "completed",
+                    "server": "codegraph",
+                    "tool": "codegraph_search",
+                    "arguments": {
+                        "query": "Engine.ServeHTTP",
+                        "kind": "method",
+                        "limit": 10,
+                    },
+                    "result": {
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "**ServeHTTP** (method)\n"
+                                "func (engine *Engine) ServeHTTP(w http.ResponseWriter, req *http.Request)\n"
+                                "gin.go:42",
+                            }
+                        ]
+                    },
+                }
+            transcript_payload = (
+                json.dumps({"type": "item.completed", "item": item}) + "\n"
+            ).encode()
+            source_inventory = [["gin.go", "a" * 64]]
+            audit = {
+                "checkout_root": str((tmp_path / f"checkout-{index}").resolve()),
+                "head_commit": "e" * 40,
+                "tracked_paths": ["gin.go"],
+                "repository_fingerprint": "f" * 64,
+                "source_before": source_inventory,
+                "source_after": source_inventory,
+                "runtime_namespace": ".ast-cache"
+                if cell.arm == "tsa-warm"
+                else ".codegraph",
+                "runtime_before": [],
+                "runtime_after": [["index.db", "b" * 64]],
+            }
+            workspace = hashlib.sha256(
+                json.dumps(audit, separators=(",", ":"), sort_keys=True).encode()
+            ).hexdigest()
+            payloads = {
+                "receipt": json.dumps(
+                    {"call_id": call_id}, separators=(",", ":"), sort_keys=True
+                ).encode(),
+                "transcript": transcript_payload,
+                "workspace_audit": json.dumps(
+                    {
+                        "schema_version": 1,
+                        "manifest_hash": manifest.manifest_hash,
+                        "session_id": "session-001",
+                        "run_id": cell.cell_id,
+                        "cell_id": cell.cell_id,
+                        "arm": cell.arm,
+                        "audit_sha256": workspace,
+                        "audit": audit,
+                    },
+                    separators=(",", ":"),
+                    sort_keys=True,
+                ).encode(),
+            }
+            runtime = hashlib.sha256(f"runtime-{index}".encode()).hexdigest()
+            payloads["runtime"] = runtime.encode()
+            transcript = hashlib.sha256(payloads["transcript"]).hexdigest()
+            attempt = CanaryAttemptV1(
+                1,
+                manifest.manifest_hash,
+                "session-001",
+                cell.cell_id,
+                cell.cell_id,
+                cell.arm,
+                1,
+                call_id,
+                transcript,
+                workspace,
+                runtime,
+                "SUCCESS",
+            )
+            attempts.append(attempt)
+            for kind, payload in payloads.items():
+                path = (tmp_path / f"{cell.cell_id}.{kind}").resolve()
+                path.write_bytes(payload)
+                artifacts.append(
+                    CanaryArtifactV1(
+                        1,
+                        manifest.manifest_hash,
+                        "session-001",
+                        cell.cell_id,
+                        cell.cell_id,
+                        cell.arm,
+                        kind,
+                        hashlib.sha256(payload).hexdigest(),
+                        str(path),
+                        call_id if kind == "receipt" else None,
+                    )
+                )
+        registry = (
+            CanaryRegistryEventV1(
+                1,
+                manifest.manifest_hash,
+                "session-001",
+                "COMPLETE",
+                "canary_accepted",
+                ("tsa-warm-canary", "codegraph-warm-canary"),
+            ),
+        )
+        return tuple(attempts), tuple(artifacts), registry
+
+    def test_manifest_freezes_exact_two_cell_e0_protocol(self):
+        from benchmarks.codegraph_compare.canary_evidence import (
+            canonical_sha256,
+            validate_canary_manifest,
+        )
+
+        manifest = self._manifest()
+        validate_canary_manifest(manifest)
+
+        assert tuple(
+            (
+                cell.cell_id,
+                cell.arm,
+                cell.attempt_count,
+                cell.schedule_order,
+                cell.phase,
+                cell.native_allowed,
+            )
+            for cell in manifest.cells
+        ) == (
+            ("tsa-warm-canary", "tsa-warm", 1, 0, "E0", False),
+            ("codegraph-warm-canary", "codegraph-warm", 1, 1, "E0", False),
+        )
+        assert manifest.oracle == ("gin.go", "Engine.ServeHTTP", "method")
+        assert manifest.oracle_hash == canonical_sha256(list(manifest.oracle))
+        assert manifest.budget_ceiling_usd == 3.0
+        assert (manifest.winner, manifest.dominance_allowed, manifest.publishable) == (
+            None,
+            False,
+            False,
+        )
+
+    def test_canonical_sha256_is_key_order_independent_and_exact(self):
+        from benchmarks.codegraph_compare.canary_evidence import canonical_sha256
+
+        left = canonical_sha256({"b": 2, "a": [1, "x"]})
+        right = canonical_sha256({"a": [1, "x"], "b": 2})
+
+        assert (
+            left == "8cbd548a32262b76a6536efe4e7ba86a0e811fcd0475d83a43e10acd0615aa37"
+        )
+        assert right == left
+
+    def test_complete_two_cell_evidence_requires_production_trust_anchor(
+        self, tmp_path
+    ):
+        from benchmarks.codegraph_compare.canary_evidence import (
+            validate_canary_evidence,
+        )
+
+        manifest = self._manifest()
+        verdict = validate_canary_evidence(
+            manifest, *self._evidence(manifest, tmp_path)
+        )
+
+        assert verdict.status == "NOT_EVALUATED"
+        assert verdict.violations == ("PRODUCTION_TRUST_ANCHOR_UNAVAILABLE",)
+        assert (verdict.accepted_cells, verdict.required_cells) == (2, 2)
+        assert (verdict.winner, verdict.dominance_allowed, verdict.publishable) == (
+            None,
+            False,
+            False,
+        )
+
+    def test_absent_evidence_is_not_evaluated(self):
+        from benchmarks.codegraph_compare.canary_evidence import (
+            validate_canary_evidence,
+        )
+
+        verdict = validate_canary_evidence(self._manifest(), (), (), ())
+
+        assert verdict.status == "NOT_EVALUATED"
+        assert verdict.violations == ()
+        assert (verdict.accepted_cells, verdict.required_cells) == (0, 2)
+        assert verdict.publishable is False
+
+    def test_tampered_protected_claim_flag_is_invalid_without_evidence(self):
+        from dataclasses import replace
+
+        from benchmarks.codegraph_compare.canary_evidence import (
+            validate_canary_evidence,
+        )
+
+        manifest = replace(self._manifest(), dominance_allowed=True)
+
+        verdict = validate_canary_evidence(manifest, (), (), ())
+
+        assert verdict.status == "INVALID"
+        assert verdict.violations == (
+            "MANIFEST_INVALID:protected claim flags must remain false/null",
+        )
+        assert (verdict.winner, verdict.dominance_allowed, verdict.publishable) == (
+            None,
+            False,
+            False,
+        )
+
+    def test_malformed_manifest_type_returns_invalid_instead_of_raising(self):
+        from benchmarks.codegraph_compare.canary_evidence import (
+            validate_canary_evidence,
+        )
+
+        verdict = validate_canary_evidence({}, (), (), ())
+
+        assert verdict.status == "INVALID"
+        assert verdict.violations == (
+            "MANIFEST_INVALID:manifest must be CanaryManifestV1",
+        )
+        assert (verdict.accepted_cells, verdict.required_cells) == (0, 2)
+
+    @pytest.mark.parametrize("mutation", ("duplicate", "cross-arm"))
+    def test_artifact_nonbijection_fails_closed(self, tmp_path, mutation: str):
+        from dataclasses import replace
+
+        from benchmarks.codegraph_compare.canary_evidence import (
+            validate_canary_evidence,
+        )
+
+        manifest = self._manifest()
+        attempts, artifacts, registry = self._evidence(manifest, tmp_path)
+        mutated = list(artifacts)
+        if mutation == "duplicate":
+            mutated.append(artifacts[0])
+        else:
+            mutated[4] = replace(
+                mutated[4],
+                cell_id="tsa-warm-canary",
+                arm="tsa-warm",
+                run_id="tsa-warm-canary",
+            )
+
+        verdict = validate_canary_evidence(manifest, attempts, mutated, registry)
+
+        assert verdict.status == "INVALID"
+        assert "ARTIFACT_BIJECTION:tsa-warm-canary" in verdict.violations
+        assert verdict.publishable is False
+
+    def test_attempt_receipt_binding_mismatch_is_invalid(self, tmp_path):
+        from dataclasses import replace
+
+        from benchmarks.codegraph_compare.canary_evidence import (
+            validate_canary_evidence,
+        )
+
+        manifest = self._manifest()
+        attempts, artifacts, registry = self._evidence(manifest, tmp_path)
+        attempts = (replace(attempts[0], receipt_call_id="call-tampered"), attempts[1])
+
+        verdict = validate_canary_evidence(manifest, attempts, artifacts, registry)
+
+        assert verdict.status == "INVALID"
+        assert verdict.violations == ("ARTIFACT_BINDING:tsa-warm-canary",)
+        assert verdict.publishable is False
+
+    def test_artifact_digest_cannot_self_attest_tampered_bytes(self, tmp_path):
+        from benchmarks.codegraph_compare.canary_evidence import (
+            validate_canary_evidence,
+        )
+
+        manifest = self._manifest()
+        attempts, artifacts, registry = self._evidence(manifest, tmp_path)
+        Path(artifacts[0].evidence_path).write_bytes(b"tampered")
+
+        verdict = validate_canary_evidence(manifest, attempts, artifacts, registry)
+
+        assert verdict.status == "INVALID"
+        assert verdict.violations == ("ARTIFACT_BINDING:tsa-warm-canary",)
+
+    @pytest.mark.parametrize("mutation", ("no-receipt", "wrong-receiver"))
+    def test_transcript_hash_cannot_replace_semantic_replay(
+        self, tmp_path, mutation: str
+    ):
+        from dataclasses import replace
+
+        from benchmarks.codegraph_compare.canary_evidence import (
+            validate_canary_evidence,
+        )
+
+        manifest = self._manifest()
+        attempts, artifacts, registry = self._evidence(manifest, tmp_path)
+        transcript = artifacts[1]
+        if mutation == "no-receipt":
+            payload = b'{"type":"turn.completed"}\n'
+        else:
+            item = TestGinSmokeManifestExecution._tsa_canary_item("call-0")
+            body = json.loads(item["result"]["content"][0]["text"])
+            body["symbol"] = "Other.ServeHTTP"
+            item["result"]["content"][0]["text"] = json.dumps(body)
+            payload = (
+                json.dumps({"type": "item.completed", "item": item}) + "\n"
+            ).encode()
+        Path(transcript.evidence_path).write_bytes(payload)
+        digest = hashlib.sha256(payload).hexdigest()
+        attempts = (replace(attempts[0], transcript_sha256=digest), attempts[1])
+        artifacts = tuple(
+            replace(artifact, sha256=digest) if artifact is transcript else artifact
+            for artifact in artifacts
+        )
+
+        verdict = validate_canary_evidence(manifest, attempts, artifacts, registry)
+
+        assert verdict.status == "INVALID"
+        assert verdict.violations == ("ARTIFACT_BINDING:tsa-warm-canary",)
+
+    def test_workspace_hash_cannot_replace_schema_binding(self, tmp_path):
+        from dataclasses import replace
+
+        from benchmarks.codegraph_compare.canary_evidence import (
+            validate_canary_evidence,
+        )
+
+        manifest = self._manifest()
+        attempts, artifacts, registry = self._evidence(manifest, tmp_path)
+        workspace = artifacts[2]
+        payload = b'{"audit_sha256":"arbitrary"}'
+        Path(workspace.evidence_path).write_bytes(payload)
+        digest = hashlib.sha256(payload).hexdigest()
+        artifacts = tuple(
+            replace(artifact, sha256=digest) if artifact is workspace else artifact
+            for artifact in artifacts
+        )
+
+        verdict = validate_canary_evidence(manifest, attempts, artifacts, registry)
+
+        assert verdict.status == "INVALID"
+        assert verdict.violations == ("ARTIFACT_BINDING:tsa-warm-canary",)
+
+    def test_workspace_arbitrary_self_hash_cannot_replace_raw_audit(self, tmp_path):
+        from dataclasses import replace
+
+        from benchmarks.codegraph_compare.canary_evidence import (
+            validate_canary_evidence,
+        )
+
+        manifest = self._manifest()
+        attempts, artifacts, registry = self._evidence(manifest, tmp_path)
+        workspace = artifacts[2]
+        envelope = json.loads(Path(workspace.evidence_path).read_text())
+        envelope["audit_sha256"] = "f" * 64
+        payload = json.dumps(envelope, separators=(",", ":"), sort_keys=True).encode()
+        Path(workspace.evidence_path).write_bytes(payload)
+        digest = hashlib.sha256(payload).hexdigest()
+        attempts = (replace(attempts[0], workspace_audit_sha256="f" * 64), attempts[1])
+        artifacts = tuple(
+            replace(artifact, sha256=digest) if artifact is workspace else artifact
+            for artifact in artifacts
+        )
+
+        verdict = validate_canary_evidence(manifest, attempts, artifacts, registry)
+
+        assert verdict.status == "INVALID"
+        assert verdict.violations == ("ARTIFACT_BINDING:tsa-warm-canary",)
+
+    def test_synchronized_raw_audit_rehash_never_unlocks_accept(self, tmp_path):
+        from dataclasses import replace
+
+        from benchmarks.codegraph_compare.canary_evidence import (
+            validate_canary_evidence,
+        )
+
+        manifest = self._manifest()
+        attempts, artifacts, registry = self._evidence(manifest, tmp_path)
+        workspace = artifacts[2]
+        envelope = json.loads(Path(workspace.evidence_path).read_text())
+        envelope["audit"]["head_commit"] = "d" * 40
+        audit_hash = hashlib.sha256(
+            json.dumps(
+                envelope["audit"], separators=(",", ":"), sort_keys=True
+            ).encode()
+        ).hexdigest()
+        envelope["audit_sha256"] = audit_hash
+        payload = json.dumps(envelope, separators=(",", ":"), sort_keys=True).encode()
+        Path(workspace.evidence_path).write_bytes(payload)
+        artifact_hash = hashlib.sha256(payload).hexdigest()
+        attempts = (
+            replace(attempts[0], workspace_audit_sha256=audit_hash),
+            attempts[1],
+        )
+        artifacts = tuple(
+            replace(artifact, sha256=artifact_hash)
+            if artifact is workspace
+            else artifact
+            for artifact in artifacts
+        )
+
+        verdict = validate_canary_evidence(manifest, attempts, artifacts, registry)
+
+        assert verdict.status == "NOT_EVALUATED"
+        assert verdict.violations == ("PRODUCTION_TRUST_ANCHOR_UNAVAILABLE",)
+        assert verdict.publishable is False
+
+    @pytest.mark.parametrize("launches", (None, [], "not-a-tuple"))
+    def test_malformed_manifest_launch_config_type_is_invalid(self, launches):
+        from dataclasses import replace
+
+        from benchmarks.codegraph_compare.canary_evidence import (
+            validate_canary_evidence,
+        )
+
+        verdict = validate_canary_evidence(
+            replace(self._manifest(), launch_config_hashes=launches), (), (), ()
+        )
+
+        assert verdict.status == "INVALID"
+        assert verdict.violations == (
+            "MANIFEST_INVALID:launch_config_hashes must be a tuple",
+        )
+
+    @pytest.mark.parametrize(
+        ("field", "value", "message"),
+        (
+            ("schema_version", True, "unsupported canary manifest schema"),
+            ("timeout_seconds", True, "timeout_seconds must be a positive integer"),
+            ("seed", False, "seed must be a non-negative integer"),
+            ("budget_ceiling_usd", 3, "budget ceiling mismatch"),
+            ("dominance_allowed", 0, "protected claim flags must remain false/null"),
+            ("publishable", 0, "protected claim flags must remain false/null"),
+        ),
+    )
+    def test_manifest_rejects_bool_integer_type_confusion(self, field, value, message):
+        from dataclasses import replace
+
+        from benchmarks.codegraph_compare.canary_evidence import (
+            validate_canary_evidence,
+        )
+
+        verdict = validate_canary_evidence(
+            replace(self._manifest(), **{field: value}), (), (), ()
+        )
+
+        assert verdict.status == "INVALID"
+        assert verdict.violations == (f"MANIFEST_INVALID:{message}",)
+
+    @pytest.mark.parametrize("invalid_artifact", (object(), {"kind": "receipt"}))
+    def test_invalid_artifact_schema_fails_closed(
+        self, tmp_path, invalid_artifact: object
+    ):
+        from benchmarks.codegraph_compare.canary_evidence import (
+            validate_canary_evidence,
+        )
+
+        manifest = self._manifest()
+        attempts, artifacts, registry = self._evidence(manifest, tmp_path)
+
+        verdict = validate_canary_evidence(
+            manifest, attempts, (*artifacts, invalid_artifact), registry
+        )
+
+        assert verdict.status == "INVALID"
+        assert verdict.violations == ("ARTIFACT_SCHEMA_INVALID",)
+        assert verdict.publishable is False
+
+    def test_extra_registry_event_is_invalid(self, tmp_path):
+        from dataclasses import replace
+
+        from benchmarks.codegraph_compare.canary_evidence import (
+            validate_canary_evidence,
+        )
+
+        manifest = self._manifest()
+        attempts, artifacts, registry = self._evidence(manifest, tmp_path)
+        registry = (*registry, replace(registry[0], outcome="late_event"))
+
+        verdict = validate_canary_evidence(manifest, attempts, artifacts, registry)
+
+        assert verdict.status == "INVALID"
+        assert verdict.violations == ("REGISTRY_TERMINAL_INVALID",)
+        assert verdict.publishable is False
+
+
+class TestCanaryProtocol:
+    @staticmethod
+    def _manifest():
+        from benchmarks.codegraph_compare.canary_evidence import create_canary_manifest
+
+        return create_canary_manifest(
+            benchmark_git_sha="benchmark-sha",
+            benchmark_version="NO1-002C-E0-v1",
+            model="gpt-fixture",
+            agent_cli_fingerprint="codex-cli-fixture",
+            gin_commit="gin-commit",
+            gin_source_fingerprint="a" * 64,
+            canary_prompt_sha256="b" * 64,
+            launch_config_hashes={"tsa-warm": "c" * 64, "codegraph-warm": "d" * 64},
+            timeout_seconds=300,
+            seed=1195,
+        )
+
+    @staticmethod
+    def _runner(
+        tmp_path,
+        *,
+        costs=(1.0, 1.0),
+        policy_invalid=False,
+        drift=False,
+        run_raises=False,
+        transcript_missing=False,
+        cleanup_fails=False,
+        fixture_cost_plan=(1.5, 1.5),
+        execution_mode="fixture",
+        omit_execution_mode=False,
+    ):
+        from benchmarks.codegraph_compare.canary_policy import (
+            CanaryAudit,
+            CanaryReceipt,
+        )
+        from benchmarks.codegraph_compare.canary_protocol import (
+            CanaryProtocol,
+            CanaryProtocolCallbacks,
+            CanaryRunFailure,
+            CanaryRunResult,
+        )
+        from benchmarks.codegraph_compare.smoke_policy import PolicyAudit
+
+        state = {"runs": [], "setups": [], "cleanups": [], "ids": 0}
+
+        def new_id(label):
+            state["ids"] += 1
+            return f"{label}-{state['ids']}"
+
+        def setup(arm, checkout):
+            state["setups"].append((arm, checkout))
+
+        def run(
+            cell,
+            checkout,
+            session_id,
+            run_id,
+            contract,
+            remaining_usd,
+            fixture_cost_limit_usd,
+        ):
+            index = len(state["runs"])
+            transcript = tmp_path / f"{cell.cell_id}.jsonl"
+            call_id = f"call-{cell.arm}"
+            if cell.arm == "tsa-warm":
+                item = TestGinSmokeManifestExecution._tsa_canary_item(call_id)
+            else:
+                item = {
+                    "id": call_id,
+                    "type": "mcp_tool_call",
+                    "status": "completed",
+                    "server": "codegraph",
+                    "tool": "codegraph_search",
+                    "arguments": {
+                        "query": "Engine.ServeHTTP",
+                        "kind": "method",
+                        "limit": 10,
+                    },
+                    "result": {
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "**ServeHTTP** (method)\n"
+                                "func (engine *Engine) ServeHTTP(w http.ResponseWriter, req *http.Request)\n"
+                                "gin.go:42",
+                            }
+                        ]
+                    },
+                }
+            transcript.write_text(
+                json.dumps({"type": "item.completed", "item": item}) + "\n",
+                encoding="utf-8",
+            )
+            state["runs"].append(
+                (
+                    cell.cell_id,
+                    session_id,
+                    run_id,
+                    contract["arm"],
+                    remaining_usd,
+                    fixture_cost_limit_usd,
+                )
+            )
+            if run_raises:
+                raise CanaryRunFailure(
+                    "run failed after transcript creation",
+                    CanaryRunResult(transcript, costs[index], 0),
+                )
+            if transcript_missing:
+                transcript.unlink()
+            return CanaryRunResult(transcript, costs[index], 1)
+
+        def policy(path, arm, **expected):
+            violations = ("FIXTURE_POLICY_INVALID",) if policy_invalid else ()
+            base = PolicyAudit(arm, str(path), (arm,), (expected["expected_tool"],), ())
+            receipt = CanaryReceipt(
+                f"call-{arm}",
+                arm,
+                expected["expected_tool"],
+                expected["expected_path"],
+                expected["expected_symbol"],
+                expected["expected_kind"],
+                1,
+            )
+            return CanaryAudit(base, receipt, violations)
+
+        def workspace(snapshot):
+            if drift:
+                raise ValueError("workspace drift")
+            source_inventory = [["gin.go", "a" * 64]]
+            return {
+                "checkout_root": str(Path(snapshot["checkout"]).resolve()),
+                "head_commit": "e" * 40,
+                "tracked_paths": ["gin.go"],
+                "repository_fingerprint": "f" * 64,
+                "source_before": source_inventory,
+                "source_after": source_inventory,
+                "runtime_namespace": ".ast-cache"
+                if snapshot["arm"] == "tsa-warm"
+                else ".codegraph",
+                "runtime_before": [],
+                "runtime_after": [["index.db", "b" * 64]],
+            }
+
+        def cleanup(snapshot, audit):
+            state["cleanups"].append((snapshot["arm"], audit))
+            if cleanup_fails:
+                raise ValueError("cleanup failed")
+
+        callbacks = CanaryProtocolCallbacks(
+            validate_launch=lambda contracts, checkouts: None,
+            snapshot=lambda checkout, arm: {"checkout": str(checkout), "arm": arm},
+            setup_index=setup,
+            run_cell=run,
+            audit_policy=policy,
+            audit_workspace=workspace,
+            cleanup_workspace=cleanup,
+            runtime_hash=lambda arm, checkout, audit: (
+                "1" * 64 if arm == "tsa-warm" else "2" * 64
+            ),
+            new_id=new_id,
+        )
+        contracts = {
+            "tsa-warm": {"arm": "tsa-warm"},
+            "codegraph-warm": {"arm": "codegraph-warm"},
+        }
+        checkouts = {
+            "tsa-warm": tmp_path / "tsa",
+            "codegraph-warm": tmp_path / "codegraph",
+        }
+        mode_arguments = (
+            {} if omit_execution_mode else {"execution_mode": execution_mode}
+        )
+        return (
+            CanaryProtocol(
+                TestCanaryProtocol._manifest(),
+                contracts,
+                checkouts,
+                callbacks,
+                tmp_path / "canary-journal.json",
+                {
+                    "tsa-warm-canary": fixture_cost_plan[0],
+                    "codegraph-warm-canary": fixture_cost_plan[1],
+                },
+                **mode_arguments,
+            ),
+            state,
+        )
+
+    def test_fixture_simulates_exact_seeded_two_cell_order(self, tmp_path):
+        runner, state = self._runner(tmp_path)
+
+        result = runner.execute()
+
+        assert result.status == "NOT_EVALUATED"
+        assert result.violations[0] == "FIXTURE_SIMULATION_NOT_QUALIFICATION"
+        assert result.cumulative_cost_usd == 2.0
+        assert tuple(item[0] for item in state["runs"]) == (
+            "tsa-warm-canary",
+            "codegraph-warm-canary",
+        )
+        assert tuple((item[4], item[5]) for item in state["runs"]) == (
+            (3.0, 1.5),
+            (2.0, 1.5),
+        )
+        assert len(result.attempts) == 2
+        assert len(result.artifacts) == 8
+        assert len(result.registry) == 1
+        assert result.registry[0].status == "INVALID"
+
+    def test_first_cell_failure_prevents_second_cell(self, tmp_path):
+        runner, state = self._runner(tmp_path, policy_invalid=True)
+
+        result = runner.execute()
+
+        assert result.status == "INVALID"
+        assert len(state["runs"]) == 1
+        assert len(result.attempts) == 1
+        assert result.attempts[0].status == "INVALID"
+        assert result.registry[0].status == "INVALID"
+
+    def test_policy_invalid_is_terminal(self, tmp_path):
+        runner, _ = self._runner(tmp_path, policy_invalid=True)
+
+        result = runner.execute()
+
+        assert result.violations[0] == (
+            "CELL_INVALID:tsa-warm-canary:primary=policy audit rejected transcript"
+        )
+
+    def test_workspace_drift_is_terminal(self, tmp_path):
+        runner, state = self._runner(tmp_path, drift=True)
+
+        result = runner.execute()
+
+        assert result.status == "INVALID"
+        assert len(state["runs"]) == 1
+        assert result.violations[0] == (
+            "CELL_INVALID:tsa-warm-canary:workspace=workspace drift"
+        )
+
+    def test_fixture_cost_plan_rejects_overage_before_simulation_callback(
+        self, tmp_path
+    ):
+        runner, state = self._runner(tmp_path, fixture_cost_plan=(3.01, 0.01))
+
+        result = runner.execute()
+
+        assert result.status == "INVALID"
+        assert state["runs"] == []
+        assert result.violations[0] == (
+            "PREFLIGHT_INVALID:fixture cost plan exceeds declared simulation budget"
+        )
+
+    @pytest.mark.parametrize("cost", (float("nan"), float("inf"), float("-inf")))
+    def test_nonfinite_cost_is_rejected_before_second_cell(self, tmp_path, cost):
+        runner, state = self._runner(tmp_path, costs=(cost, 0.0))
+
+        result = runner.execute()
+
+        assert result.status == "INVALID"
+        assert len(state["runs"]) == 1
+        assert result.violations[0] == (
+            "CELL_INVALID:tsa-warm-canary:primary="
+            "reported cost must be a finite non-negative number"
+        )
+
+    def test_protocol_object_cannot_attempt_callbacks_twice(self, tmp_path):
+        runner, state = self._runner(tmp_path)
+        first = runner.execute()
+
+        with pytest.raises(RuntimeError, match="one-shot; retry is forbidden"):
+            runner.execute()
+
+        assert first.status == "NOT_EVALUATED"
+        assert len(state["runs"]) == 2
+
+    @pytest.mark.parametrize("mode", (None, "production"))
+    def test_nonfixture_mode_rejects_before_every_callback(self, tmp_path, mode):
+        runner, state = self._runner(
+            tmp_path,
+            execution_mode=mode,
+            omit_execution_mode=mode is None,
+        )
+
+        result = runner.execute()
+
+        assert result.status == "NOT_EVALUATED"
+        assert result.violations == ("QUALIFICATION_SCAFFOLD_NOT_PRODUCTION_READY",)
+        assert state == {"runs": [], "setups": [], "cleanups": [], "ids": 0}
+        assert result.registry == ()
+
+    def test_terminal_journal_blocks_new_protocol_instance(self, tmp_path):
+        runner, state = self._runner(tmp_path)
+        first = runner.execute()
+        journal = tmp_path / "canary-journal.json"
+        terminal = json.loads(journal.read_text(encoding="utf-8"))
+        replacement, _ = self._runner(tmp_path)
+
+        with pytest.raises(RuntimeError, match="fixture.*retry is forbidden"):
+            replacement.execute()
+
+        assert first.status == "NOT_EVALUATED"
+        assert terminal["state"] == "TERMINAL"
+        assert terminal["status"] == "NOT_EVALUATED"
+        assert len(state["runs"]) == 2
+
+    def test_existing_reservation_blocks_first_simulation_callback(self, tmp_path):
+        runner, state = self._runner(tmp_path)
+        (tmp_path / "canary-journal.json").write_text(
+            '{"state":"RESERVED"}\n', encoding="utf-8"
+        )
+
+        with pytest.raises(RuntimeError, match="fixture.*retry is forbidden"):
+            runner.execute()
+
+        assert state["runs"] == []
+
+    def test_journal_inside_checkout_is_rejected_before_simulation_callback(
+        self, tmp_path
+    ):
+        runner, state = self._runner(tmp_path)
+        checkout = tmp_path / "tsa"
+        checkout.mkdir()
+        runner._journal_path = checkout / "journal.json"
+
+        with pytest.raises(ValueError, match="outside every checkout"):
+            runner.execute()
+
+        assert state["runs"] == []
+
+    def test_run_failure_after_setup_still_attempts_cleanup(self, tmp_path):
+        runner, state = self._runner(tmp_path, run_raises=True)
+
+        result = runner.execute()
+
+        assert result.status == "INVALID"
+        assert len(state["runs"]) == 1
+        assert len(state["cleanups"]) == 1
+        assert state["cleanups"][0][0] == "tsa-warm"
+        assert result.cumulative_cost_usd == 1.0
+        assert tuple(artifact.kind for artifact in result.artifacts) == (
+            "transcript",
+            "workspace_audit",
+            "runtime",
+        )
+        expected_transcript = (tmp_path / "tsa-warm-canary.jsonl").read_bytes()
+        assert (
+            result.attempts[0].transcript_sha256
+            == hashlib.sha256(expected_transcript).hexdigest()
+        )
+        transcript_artifact = next(
+            artifact for artifact in result.artifacts if artifact.kind == "transcript"
+        )
+        assert (
+            Path(transcript_artifact.evidence_path).read_bytes() == expected_transcript
+        )
+        assert tmp_path / "tsa" not in Path(transcript_artifact.evidence_path).parents
+        journal = json.loads((tmp_path / "canary-journal.json").read_text())
+        journal_transcript = next(
+            artifact
+            for artifact in journal["result"]["artifacts"]
+            if artifact["kind"] == "transcript"
+        )
+        assert journal_transcript["evidence_path"] == transcript_artifact.evidence_path
+
+    def test_cost_survives_transcript_hash_failure_in_terminal_journal(self, tmp_path):
+        runner, state = self._runner(tmp_path, transcript_missing=True)
+
+        result = runner.execute()
+        journal = json.loads((tmp_path / "canary-journal.json").read_text())
+
+        assert result.status == "INVALID"
+        assert result.cumulative_cost_usd == 1.0
+        assert len(state["runs"]) == 1
+        assert journal["state"] == "TERMINAL"
+        assert journal["result"]["cumulative_cost_usd"] == 1.0
+        assert journal["result"]["attempts"][0]["transcript_sha256"] == "0" * 64
+
+    def test_policy_failure_and_workspace_mutation_are_both_recorded(self, tmp_path):
+        runner, state = self._runner(tmp_path, policy_invalid=True, drift=True)
+
+        result = runner.execute()
+
+        assert result.violations[0] == (
+            "CELL_INVALID:tsa-warm-canary:primary=policy audit rejected transcript"
+            "|workspace=workspace drift"
+        )
+        assert len(state["cleanups"]) == 1
+        assert state["cleanups"][0][1] is None
+
+    def test_cleanup_failure_is_terminal_and_prevents_second_cell(self, tmp_path):
+        runner, state = self._runner(tmp_path, cleanup_fails=True)
+
+        result = runner.execute()
+
+        assert result.status == "INVALID"
+        assert len(state["runs"]) == 1
+        assert len(state["cleanups"]) == 1
+        assert result.violations[0] == (
+            "CELL_INVALID:tsa-warm-canary:cleanup=cleanup failed"
+        )


### PR DESCRIPTION
## What changed

- adds fail-closed NO1-002C canary policy, preflight, workspace, protocol, and evidence-replay primitives
- binds exact TSA and CodeGraph MCP receipts for `Engine.ServeHTTP`
- adds durable exactly-once reservation, checkout/runtime isolation, cleanup, and replayable artifact checks
- rejects orphan runtime evidence in retained smoke bundles

## Trust boundary

This PR is qualification infrastructure only. It deliberately has no production execution path:

- production/default protocol modes invoke zero callbacks and return `NOT_EVALUATED`
- fixture simulation can never become `ACCEPT` or publishable
- even a complete 2/2 bundle returns `PRODUCTION_TRUST_ANCHOR_UNAVAILABLE`
- no model-backed call was made and no budget was spent

A separately reviewed production runner and external trust anchor are required before the protected two-cell canary can be scheduled. This PR does not complete #1195 or establish E2/E3/E4.

## Why

Issue #1221 needs a model-free, adversarially reviewed qualification layer before any exact-model canary is authorized. Multiple independent Judge passes found and drove fixes for receipt ambiguity, self-hashed evidence, runtime namespace gaps, retry safety, and false production-readiness claims.

## Validation

- `UV_FROZEN=1 uv run pytest tests/unit/test_benchmark_harness.py -q` — 349 passed
- `UV_FROZEN=1 uv run pytest -q` — 1316 passed, 1 skipped
- patch coverage gate — no added executable misses
- Ruff check and format check — passed
- `git diff --check` — passed
- independent Judge v5 — ACCEPT, limited to fail-closed qualification scaffold

Closes the infrastructure slice of #1221; production trust-anchor/runner work remains explicitly blocked.
