### PR TITLE
refactor(uml): extract _make_activity_not_found_diagram to reduce deep_nesting

### DIFF
--- a/tests/unit/test_uml_export.py
+++ b/tests/unit/test_uml_export.py
@@ -9,8 +9,10 @@ import pytest
 from tree_sitter_analyzer import uml_export
 from tree_sitter_analyzer._uml_export_builders import _prioritized_class_edges
 from tree_sitter_analyzer.uml_export import (
+    UMLDiagram,
     UMLEdge,
     UMLExporter,
+    _ACTIVITY_NOT_FOUND_MERMAID,
     _clamp_edges,
     _component_name,
     _package_name,
@@ -330,3 +332,94 @@ def test_sequence_diagram_uses_call_path_and_marks_static_approximation(
     assert diagram.truncated is True
     assert diagram.nodes == ["entry", "service"]
     assert diagram.edges == [UMLEdge("entry", "service", "call")]
+
+
+# ── _activity_error_diagram helper (TDD RED -> GREEN) ─────────────────────────
+# These tests drive extraction of the nested error-dispatch inside
+# activity_diagram() into a dedicated _activity_error_diagram() helper,
+# reducing the deep_nesting severity from depth 7 to depth <= 3.
+
+
+def test_activity_error_diagram_file_missing_returns_not_found() -> None:
+    """_activity_error_diagram returns NOT_FOUND with file-path message for file_missing."""
+    exporter = UMLExporter("/repo", cache=object())
+    result = exporter._activity_error_diagram(
+        "file_missing: /repo/src/a.py", "my_func", "/repo/src/a.py"
+    )
+    assert isinstance(result, UMLDiagram)
+    assert result.diagram_type == "activity"
+    assert result.mermaid == _ACTIVITY_NOT_FOUND_MERMAID
+    assert result.metadata["verdict"] == "NOT_FOUND"
+    assert "/repo/src/a.py" in result.metadata["next_step"]
+    assert "next_step" in result.metadata
+    assert "error" not in result.metadata
+
+
+def test_activity_error_diagram_function_missing_returns_not_found() -> None:
+    """_activity_error_diagram returns NOT_FOUND with function-name message for function_missing."""
+    exporter = UMLExporter("/repo", cache=object())
+    result = exporter._activity_error_diagram(
+        "function_missing: my_func", "my_func", "/repo/src/a.py"
+    )
+    assert result.metadata["verdict"] == "NOT_FOUND"
+    assert "my_func" in result.metadata["next_step"]
+    assert "error" not in result.metadata
+
+
+def test_activity_error_diagram_empty_body_returns_not_found() -> None:
+    """_activity_error_diagram returns NOT_FOUND with stub message for empty_body."""
+    exporter = UMLExporter("/repo", cache=object())
+    result = exporter._activity_error_diagram(
+        "empty_body", "stub_func", "/repo/src/a.py"
+    )
+    assert result.metadata["verdict"] == "NOT_FOUND"
+    assert "stub_func" in result.metadata["next_step"]
+    assert "error" not in result.metadata
+
+
+def test_activity_error_diagram_unknown_error_includes_error_field() -> None:
+    """_activity_error_diagram falls through to PARSE_FAILED path for unknown errors."""
+    exporter = UMLExporter("/repo", cache=object())
+    result = exporter._activity_error_diagram(
+        "PARSE_FAILED: syntax error at line 42", "my_func", "/repo/src/a.py"
+    )
+    assert result.metadata["verdict"] == "NOT_FOUND"
+    assert "error" in result.metadata
+    assert result.metadata["error"] == "PARSE_FAILED: syntax error at line 42"
+
+
+def test_activity_error_diagram_returns_activity_type() -> None:
+    """_activity_error_diagram always returns diagram_type='activity'."""
+    exporter = UMLExporter("/repo", cache=object())
+    for error_str in [
+        "file_missing",
+        "function_missing",
+        "empty_body",
+        "PARSE_FAILED",
+    ]:
+        result = exporter._activity_error_diagram(error_str, "f", "/p/f.py")
+        assert result.diagram_type == "activity"
+        assert result.mermaid_type == "flowchart"
+        assert result.nodes == []
+        assert result.edges == []
+
+
+# ── _make_activity_not_found_diagram (TDD RED -> GREEN) ───────────────────────
+# Drives extraction of UMLDiagram construction from _activity_error_diagram into
+# a module-level helper, reducing deep_nesting at L655 from depth 5 to depth 2.
+
+
+def test_make_activity_not_found_diagram_returns_correct_structure() -> None:
+    """_make_activity_not_found_diagram builds a NOT_FOUND activity UMLDiagram."""
+    from tree_sitter_analyzer.uml_export import _make_activity_not_found_diagram
+
+    diagram = _make_activity_not_found_diagram("some next_step message")
+    assert isinstance(diagram, UMLDiagram)
+    assert diagram.diagram_type == "activity"
+    assert diagram.mermaid_type == "flowchart"
+    assert diagram.mermaid == _ACTIVITY_NOT_FOUND_MERMAID
+    assert diagram.nodes == []
+    assert diagram.edges == []
+    assert diagram.metadata["verdict"] == "NOT_FOUND"
+    assert diagram.metadata["next_step"] == "some next_step message"
+    assert "error" not in diagram.metadata

--- a/tests/unit/test_uml_export.py
+++ b/tests/unit/test_uml_export.py
@@ -9,10 +9,10 @@ import pytest
 from tree_sitter_analyzer import uml_export
 from tree_sitter_analyzer._uml_export_builders import _prioritized_class_edges
 from tree_sitter_analyzer.uml_export import (
+    _ACTIVITY_NOT_FOUND_MERMAID,
     UMLDiagram,
     UMLEdge,
     UMLExporter,
-    _ACTIVITY_NOT_FOUND_MERMAID,
     _clamp_edges,
     _component_name,
     _package_name,

--- a/tree_sitter_analyzer/uml_export.py
+++ b/tree_sitter_analyzer/uml_export.py
@@ -42,7 +42,7 @@ _TRUNCATION_NOTE = (
 _ACTIVITY_NOT_FOUND_MERMAID = 'flowchart TD\n  not_found["No activity flow found"]'
 
 
-def _make_activity_not_found_diagram(next_step: str) -> "UMLDiagram":
+def _make_activity_not_found_diagram(next_step: str) -> UMLDiagram:
     """Build a NOT_FOUND activity UMLDiagram with the given next_step message.
 
     Extracted from _activity_error_diagram to eliminate the deep_nesting code

--- a/tree_sitter_analyzer/uml_export.py
+++ b/tree_sitter_analyzer/uml_export.py
@@ -42,6 +42,26 @@ _TRUNCATION_NOTE = (
 _ACTIVITY_NOT_FOUND_MERMAID = 'flowchart TD\n  not_found["No activity flow found"]'
 
 
+def _make_activity_not_found_diagram(next_step: str) -> "UMLDiagram":
+    """Build a NOT_FOUND activity UMLDiagram with the given next_step message.
+
+    Extracted from _activity_error_diagram to eliminate the deep_nesting code
+    smell (L655: depth 5 inside for→if→UMLDiagram→metadata→key).
+    """
+    return UMLDiagram(
+        diagram_type="activity",
+        mermaid_type="flowchart",
+        mermaid=_ACTIVITY_NOT_FOUND_MERMAID,
+        nodes=[],
+        edges=[],
+        metadata={
+            "diagram_type": "activity",
+            "verdict": "NOT_FOUND",
+            "next_step": next_step,
+        },
+    )
+
+
 @dataclass(frozen=True)
 class UMLEdge:
     source: str
@@ -570,72 +590,10 @@ class UMLExporter:
         cfg = build_activity_cfg(function_name, resolved_path, max_nodes)
 
         if cfg.error:
-            if "file_missing" in cfg.error:
-                return UMLDiagram(
-                    diagram_type="activity",
-                    mermaid_type="flowchart",
-                    # Bug #788: use non-degenerate mermaid so consumers see a
-                    # self-describing diagram, not a bare "flowchart TD\n".
-                    mermaid=_ACTIVITY_NOT_FOUND_MERMAID,
-                    nodes=[],
-                    edges=[],
-                    metadata={
-                        "diagram_type": "activity",
-                        "verdict": "NOT_FOUND",
-                        "next_step": (
-                            f"activity diagram: source file '{resolved_path}' does "
-                            "not exist; the indexed symbol's source file may have "
-                            "been deleted or moved"
-                        ),
-                    },
-                )
-            if "function_missing" in cfg.error:
-                return UMLDiagram(
-                    diagram_type="activity",
-                    mermaid_type="flowchart",
-                    mermaid=_ACTIVITY_NOT_FOUND_MERMAID,
-                    nodes=[],
-                    edges=[],
-                    metadata={
-                        "diagram_type": "activity",
-                        "verdict": "NOT_FOUND",
-                        "next_step": (
-                            f"activity diagram: function '{function_name}' not found "
-                            f"in '{resolved_path}'"
-                        ),
-                    },
-                )
-            if "empty_body" in cfg.error:
-                return UMLDiagram(
-                    diagram_type="activity",
-                    mermaid_type="flowchart",
-                    mermaid=_ACTIVITY_NOT_FOUND_MERMAID,
-                    nodes=[],
-                    edges=[],
-                    metadata={
-                        "diagram_type": "activity",
-                        "verdict": "NOT_FOUND",
-                        "next_step": (
-                            f"activity diagram found no control-flow nodes in "
-                            f"'{function_name}'; the function may be a stub or use "
-                            "a pattern not yet supported"
-                        ),
-                    },
-                )
-            # PARSE_FAILED or unknown error
-            return UMLDiagram(
-                diagram_type="activity",
-                mermaid_type="flowchart",
-                mermaid=_ACTIVITY_NOT_FOUND_MERMAID,
-                nodes=[],
-                edges=[],
-                metadata={
-                    "diagram_type": "activity",
-                    "verdict": "NOT_FOUND",
-                    "error": cfg.error,
-                    "next_step": "activity diagram: parse failed; check the file is valid Python",
-                },
-            )
+            # Bug #788: use non-degenerate mermaid so consumers see a
+            # self-describing diagram, not a bare "flowchart TD\n".
+            # Dispatch delegated to helper to reduce deep_nesting (depth 7 → 2).
+            return self._activity_error_diagram(cfg.error, function_name, resolved_path)
 
         # Build Mermaid from CFG
         uml_nodes = [n.node_id for n in cfg.nodes]
@@ -680,6 +638,52 @@ class UMLExporter:
                 # the current file from disk (AST bodies are not cache-resident),
                 # so the diagram reflects the current file content, not the index.
                 "note": "parsed from current file content; may differ from indexed symbols",
+            },
+        )
+
+    def _activity_error_diagram(
+        self,
+        error: str,
+        function_name: str,
+        resolved_path: str | None,
+    ) -> UMLDiagram:
+        """Return a NOT_FOUND activity UMLDiagram for a known build-cfg error.
+
+        Extracted from activity_diagram() to reduce deep_nesting (depth 7 -> 2).
+        Uses a dispatch-dict to avoid repeated nested if-in-str chains.
+        Public API of activity_diagram() is unchanged.
+        """
+        _ERROR_NEXT_STEPS: dict[str, str] = {
+            "file_missing": (
+                f"activity diagram: source file '{resolved_path}' does "
+                "not exist; the indexed symbol's source file may have "
+                "been deleted or moved"
+            ),
+            "function_missing": (
+                f"activity diagram: function '{function_name}' not found "
+                f"in '{resolved_path}'"
+            ),
+            "empty_body": (
+                f"activity diagram found no control-flow nodes in "
+                f"'{function_name}'; the function may be a stub or use "
+                "a pattern not yet supported"
+            ),
+        }
+        for key, next_step in _ERROR_NEXT_STEPS.items():
+            if key in error:
+                return _make_activity_not_found_diagram(next_step)
+        # PARSE_FAILED or unknown error
+        return UMLDiagram(
+            diagram_type="activity",
+            mermaid_type="flowchart",
+            mermaid=_ACTIVITY_NOT_FOUND_MERMAID,
+            nodes=[],
+            edges=[],
+            metadata={
+                "diagram_type": "activity",
+                "verdict": "NOT_FOUND",
+                "error": error,
+                "next_step": "activity diagram: parse failed; check the file is valid Python",
             },
         )
 


### PR DESCRIPTION
## Summary

- Adds module-level `_make_activity_not_found_diagram(next_step)` helper in `uml_export.py` that builds a NOT_FOUND activity `UMLDiagram`, eliminating the `deep_nesting` code smell at L655 (depth 5: `for→if→UMLDiagram→metadata→key`).
- Refactors `_activity_error_diagram()` to call the helper, reducing the for-loop body from depth 5 to depth 2.
- `--code-patterns` now reports 2 warnings (was 4); `deep_nesting` eliminated.
- `--file-health` grade: **D (score 69.7) → B (score 87.1)**.
- Public API of `activity_diagram()` and `_activity_error_diagram()` is unchanged.
- `kotlin_helpers._PRIVATE_COMPAT_EXPORTS` is NOT modified (private-import contract respected).
- Ruff UP037 and I001 fixed.

## Issues addressed

- Closes part of #1227 (auto-sprint backlog: `uml_export.py` `deep_nesting`)
- Comments posted on #1221, #1223, #1195 (`NOT_EVALUATED` maintained, no `WON''T-FIX` label)

## Test plan

- [x] `uv run pytest tests/unit/test_uml_export.py` — 30 passed (29 existing + 1 new TDD test)
- [x] `--code-patterns tree_sitter_analyzer/uml_export.py` — `deep_nesting` eliminated (4 warnings → 2)
- [x] `--file-health tree_sitter_analyzer/uml_export.py` — grade D → B (score 87.1)
- [x] quick-gate: 1310 passed, 1 pre-existing failure (Windows symlink WinError 1314, unrelated to this change)
- [x] Ruff check: 0 errors after `--fix`

Supersedes #1228 (wrong base: develop→main instead of feature→develop)