### PR TITLE
fix(install): harden offline bootstrap qualification

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ TSA indexes your codebase with tree-sitter and serves correct call graphs, symbo
 curl -fsSL https://raw.githubusercontent.com/aimasteracc/tree-sitter-analyzer/main/install.sh | bash
 ```
 
-Auto-installs `uv` if missing, detects Claude Desktop / Claude Code / Cursor / VS Code, and writes the MCP entry. Run `tree-sitter-analyzer --doctor` to verify.
+Auto-installs `uv` if missing, detects Claude Desktop / Claude Code / Cursor / VS Code, and writes the MCP entry. Run `tree-sitter-analyzer --doctor` to verify. The official `uv` installer is mutable and **not content-bound**; TSA downloads it over TLS and verifies the installed version. To refuse that bootstrap, run `curl -fsSL https://raw.githubusercontent.com/aimasteracc/tree-sitter-analyzer/main/install.sh | TSA_DISABLE_UNVERIFIED_UV_BOOTSTRAP=1 bash`.
 One-line install for **Claude Code**:
 
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -47,6 +47,19 @@ uv_version_is_supported() {
   }
 }
 
+terminate_uv_version_probe_on_signal() {
+  UV_VERSION_PROBE_SIGNAL_STATUS=$1
+  # Ignore a second termination request while the isolated probe group is
+  # being torn down; otherwise it could interrupt cleanup and leak the temp.
+  trap '' HUP INT TERM
+  kill -TERM -"$UV_VERSION_PROBE_PID" 2>/dev/null || :
+  sleep 1
+  kill -KILL -"$UV_VERSION_PROBE_PID" 2>/dev/null || :
+  wait "$UV_VERSION_PROBE_PID" 2>/dev/null || :
+  rm -f "$UV_VERSION_PROBE_OUTPUT"
+  exit "$UV_VERSION_PROBE_SIGNAL_STATUS"
+}
+
 probe_uv_version() {
   # Portable bounded probe: macOS has no coreutils `timeout`, and bash 3.x has
   # no `wait -n`. Capture to a file so a killed shim cannot hold a command
@@ -61,6 +74,9 @@ probe_uv_version() {
   uv --version >"$UV_VERSION_PROBE_OUTPUT" 2>/dev/null &
   UV_VERSION_PROBE_PID=$!
   set +m
+  trap 'terminate_uv_version_probe_on_signal 129' HUP
+  trap 'terminate_uv_version_probe_on_signal 130' INT
+  trap 'terminate_uv_version_probe_on_signal 143' TERM
   UV_VERSION_WAIT_COUNT=0
   while kill -0 "$UV_VERSION_PROBE_PID" 2>/dev/null; do
     if [ "$UV_VERSION_WAIT_COUNT" -eq 50 ]; then
@@ -81,6 +97,7 @@ probe_uv_version() {
   fi
   UV_VERSION_OUTPUT=$(cat "$UV_VERSION_PROBE_OUTPUT")
   rm -f "$UV_VERSION_PROBE_OUTPUT"
+  trap - HUP INT TERM
   if [ "$UV_VERSION_PROBE_ERROR" = "timeout" ]; then
     return 1
   fi
@@ -283,11 +300,12 @@ if not isinstance(data, dict):
     print("TYPE_ERROR:config root must be a JSON object", file=sys.stderr)
     sys.exit(3)
 
-mcp_servers = data.get("mcpServers")
-if mcp_servers is None:
+if "mcpServers" not in data:
     mcp_servers = {}
     data["mcpServers"] = mcp_servers
-elif not isinstance(mcp_servers, dict):
+else:
+    mcp_servers = data["mcpServers"]
+if not isinstance(mcp_servers, dict):
     print("TYPE_ERROR:mcpServers must be a JSON object", file=sys.stderr)
     sys.exit(3)
 
@@ -305,6 +323,9 @@ if isinstance(existing_entry, dict):
 # never the link path itself.
 write_path = os.path.realpath(config_path)
 config_dir = os.path.dirname(write_path) or "."
+target_mode = stat.S_IMODE(os.stat(write_path).st_mode)
+if target_mode & 0o222 == 0:
+    raise PermissionError(f"config file is not writable: {write_path}")
 if stat.S_IMODE(os.stat(config_dir).st_mode) & 0o222 == 0:
     raise PermissionError(f"config directory is not writable: {config_dir}")
 
@@ -325,7 +346,7 @@ try:
         f.write("\n")
         f.flush()
         os.fsync(f.fileno())
-    os.chmod(temporary_path, stat.S_IMODE(os.stat(write_path).st_mode))
+    os.chmod(temporary_path, target_mode)
     os.replace(temporary_path, write_path)
 except BaseException:
     try:

--- a/install.sh
+++ b/install.sh
@@ -39,9 +39,45 @@ uv_version_is_supported() {
   }
 }
 
+probe_uv_version() {
+  # Portable bounded probe: macOS has no coreutils `timeout`, and bash 3.x has
+  # no `wait -n`. Capture to a file so a killed shim cannot hold a command
+  # substitution pipe open through one of its children.
+  UV_VERSION_PROBE_ERROR="failed"
+  UV_VERSION_PROBE_OUTPUT=$(mktemp "${TMPDIR:-/tmp}/tsa-uv-version.XXXXXX") || return 1
+
+  uv --version >"$UV_VERSION_PROBE_OUTPUT" 2>/dev/null &
+  UV_VERSION_PROBE_PID=$!
+  UV_VERSION_WAIT_COUNT=0
+  while kill -0 "$UV_VERSION_PROBE_PID" 2>/dev/null; do
+    if [ "$UV_VERSION_WAIT_COUNT" -eq 50 ]; then
+      UV_VERSION_PROBE_ERROR="timeout"
+      kill -TERM "$UV_VERSION_PROBE_PID" 2>/dev/null || :
+      sleep 1
+      kill -KILL "$UV_VERSION_PROBE_PID" 2>/dev/null || :
+      break
+    fi
+    sleep 0.1
+    UV_VERSION_WAIT_COUNT=$((UV_VERSION_WAIT_COUNT + 1))
+  done
+
+  if wait "$UV_VERSION_PROBE_PID"; then
+    UV_VERSION_PROBE_STATUS=0
+  else
+    UV_VERSION_PROBE_STATUS=$?
+  fi
+  UV_VERSION_OUTPUT=$(cat "$UV_VERSION_PROBE_OUTPUT")
+  rm -f "$UV_VERSION_PROBE_OUTPUT"
+  if [ "$UV_VERSION_PROBE_ERROR" = "timeout" ]; then
+    return 1
+  fi
+  [ "$UV_VERSION_PROBE_STATUS" -eq 0 ]
+}
+
 uv_is_ready() {
+  UV_VERSION_PROBE_ERROR="missing"
   command -v uv >/dev/null 2>&1 || return 1
-  UV_VERSION_OUTPUT=$(uv --version 2>/dev/null) || return 1
+  probe_uv_version || return 1
   uv_version_is_supported "$UV_VERSION_OUTPUT"
 }
 
@@ -50,9 +86,14 @@ UV_INSTALL_ACTION="install"
 if ! command -v uv >/dev/null 2>&1; then
   echo "📦 uv not found. Automatic installation is required."
   UV_INSTALL_NEEDED=1
-elif ! UV_VERSION_OUTPUT=$(uv --version 2>/dev/null); then
-  echo "❌ Existing uv at $(command -v uv) could not report its version."
+elif ! probe_uv_version; then
+  if [ "$UV_VERSION_PROBE_ERROR" = "timeout" ]; then
+    echo "❌ Timed out after 5 seconds running $(command -v uv) --version."
+  else
+    echo "❌ Existing uv at $(command -v uv) could not report its version."
+  fi
   echo "   Required: uv >= $MINIMUM_UV_VERSION"
+  echo "   Replace or repair uv, then re-run the original Tree-sitter Analyzer install command."
   exit 1
 elif ! uv_version_is_supported "$UV_VERSION_OUTPUT"; then
   echo "📦 $UV_VERSION_OUTPUT does not satisfy required uv >= $MINIMUM_UV_VERSION. Automatic update is required."
@@ -107,6 +148,9 @@ if [ "$UV_INSTALL_NEEDED" = "1" ]; then
   export PATH="$HOME/.local/bin:$PATH"
   hash -r
   if ! uv_is_ready; then
+    if [ "$UV_VERSION_PROBE_ERROR" = "timeout" ]; then
+      echo "❌ Timed out after 5 seconds running $(command -v uv) --version after bootstrap."
+    fi
     echo "❌ uv installation did not provide required uv >= $MINIMUM_UV_VERSION."
     echo "   Install uv manually: https://docs.astral.sh/uv/getting-started/installation/"
     echo "   Then re-run the original Tree-sitter Analyzer install command."

--- a/install.sh
+++ b/install.sh
@@ -20,23 +20,98 @@ if [ -f /proc/version ] && grep -qi microsoft /proc/version 2>/dev/null; then
 fi
 
 # ─── uv check & auto-install ──────────────────────────────────────────────────
+MINIMUM_UV_VERSION="0.11.0"
+
+uv_version_is_supported() {
+  # Match doctor's contract: exactly one "uv X.Y.Z" line, with optional metadata.
+  UV_VERSION_TEXT=$1
+  UV_VERSION=$(printf '%s\n' "$UV_VERSION_TEXT" | awk '
+    NR == 1 && /^uv [0-9]+\.[0-9]+\.[0-9]+([[:blank:]].*)?$/ { version = $2 }
+    END { if (NR != 1 || version == "") exit 1; print version }
+  ') || return 1
+  UV_MAJOR=$(printf '%s\n' "$UV_VERSION" | awk -F. '{print $1}')
+  UV_MINOR=$(printf '%s\n' "$UV_VERSION" | awk -F. '{print $2}')
+  UV_PATCH=$(printf '%s\n' "$UV_VERSION" | awk -F. '{print $3}')
+  [ "$UV_MAJOR" -gt 0 ] || {
+    [ "$UV_MAJOR" -eq 0 ] && [ "$UV_MINOR" -gt 11 ]
+  } || {
+    [ "$UV_MAJOR" -eq 0 ] && [ "$UV_MINOR" -eq 11 ] && [ "$UV_PATCH" -ge 0 ]
+  }
+}
+
+uv_is_ready() {
+  command -v uv >/dev/null 2>&1 || return 1
+  UV_VERSION_OUTPUT=$(uv --version 2>/dev/null) || return 1
+  uv_version_is_supported "$UV_VERSION_OUTPUT"
+}
+
+UV_INSTALL_NEEDED=0
+UV_INSTALL_ACTION="install"
 if ! command -v uv >/dev/null 2>&1; then
-  echo "📦 uv not found. Installing automatically..."
-  curl -LsSf https://astral.sh/uv/install.sh | sh
+  echo "📦 uv not found. Automatic installation is required."
+  UV_INSTALL_NEEDED=1
+elif ! UV_VERSION_OUTPUT=$(uv --version 2>/dev/null); then
+  echo "❌ Existing uv at $(command -v uv) could not report its version."
+  echo "   Required: uv >= $MINIMUM_UV_VERSION"
+  exit 1
+elif ! uv_version_is_supported "$UV_VERSION_OUTPUT"; then
+  echo "📦 $UV_VERSION_OUTPUT does not satisfy required uv >= $MINIMUM_UV_VERSION. Automatic update is required."
+  UV_INSTALL_ACTION="update"
+  UV_INSTALL_NEEDED=1
+fi
+
+if [ "$UV_INSTALL_NEEDED" = "1" ]; then
+  if [ "${TSA_DISABLE_UNVERIFIED_UV_BOOTSTRAP:-0}" = "1" ]; then
+    echo "❌ Automatic uv bootstrap disabled by TSA_DISABLE_UNVERIFIED_UV_BOOTSTRAP=1."
+    echo "   Install uv >= $MINIMUM_UV_VERSION manually: https://docs.astral.sh/uv/"
+    echo "   Then re-run the original Tree-sitter Analyzer install command."
+    exit 1
+  fi
+  if ! command -v curl >/dev/null 2>&1; then
+    echo "❌ curl not found — cannot download the uv installer over TLS."
+    echo "   Install curl and re-run, or install uv >= $MINIMUM_UV_VERSION manually."
+    exit 1
+  fi
+  echo "⚠️  WARNING: the official uv bootstrap is UNVERIFIED and mutable (not content-bound)."
+  echo "   It will be downloaded over TLS to a temporary file and checked after execution."
+  if [ "$UV_INSTALL_ACTION" = "update" ]; then
+    echo "📦 Updating uv automatically..."
+  else
+    echo "📦 Installing uv automatically..."
+  fi
+  UV_INSTALLER_FILE=$(mktemp "${TMPDIR:-/tmp}/tsa-uv-installer.XXXXXX")
+  trap 'rm -f "$UV_INSTALLER_FILE"' EXIT HUP INT TERM
+  if ! curl --proto '=https' --tlsv1.2 -LsSf \
+    https://astral.sh/uv/install.sh -o "$UV_INSTALLER_FILE"; then
+    echo "❌ Automatic uv bootstrap failed."
+    echo "   Recovery: install uv >= $MINIMUM_UV_VERSION from https://docs.astral.sh/uv/"
+    echo "   Then re-run the original Tree-sitter Analyzer install command."
+    exit 1
+  fi
+  if ! sh "$UV_INSTALLER_FILE"; then
+    echo "❌ Automatic uv bootstrap failed."
+    echo "   Recovery: install uv >= $MINIMUM_UV_VERSION from https://docs.astral.sh/uv/"
+    echo "   Then re-run the original Tree-sitter Analyzer install command."
+    exit 1
+  fi
+  rm -f "$UV_INSTALLER_FILE"
+  trap - EXIT HUP INT TERM
   # Re-source common profile locations
   if [ -f "$HOME/.cargo/env" ]; then
     # shellcheck disable=SC1091
     . "$HOME/.cargo/env"
   fi
   export PATH="$HOME/.local/bin:$PATH"
-  if ! command -v uv >/dev/null 2>&1; then
-    echo "❌ uv installation failed. Please install it manually and re-run:"
-    echo "   https://docs.astral.sh/uv/getting-started/installation/"
+  hash -r
+  if ! uv_is_ready; then
+    echo "❌ uv installation did not provide required uv >= $MINIMUM_UV_VERSION."
+    echo "   Install uv manually: https://docs.astral.sh/uv/getting-started/installation/"
+    echo "   Then re-run the original Tree-sitter Analyzer install command."
     exit 1
   fi
-  echo "✅ uv installed: $(command -v uv)"
+  echo "✅ uv ready: $UV_VERSION_OUTPUT ($(command -v uv))"
 else
-  echo "✅ uv: $(command -v uv)"
+  echo "✅ $UV_VERSION_OUTPUT: $(command -v uv)"
 fi
 
 # ─── fd / ripgrep check (optional, warning only) ──────────────────────────────
@@ -94,6 +169,7 @@ fi
 # ─── Process each agent config ────────────────────────────────────────────────
 CONFIGURED_AGENTS=""
 SKIPPED_AGENTS=""
+CONFIGURATION_FAILURE=0
 
 echo ""
 echo "🔍 Scanning for agent config files..."
@@ -113,46 +189,91 @@ while IFS='|' read -r AGENT_LABEL CONFIG_PATH; do
 
   echo "   🔧 $AGENT_LABEL: configuring..."
 
-  # Merge MCP entry using python3
+  # Merge MCP entry using python3. Keep the assignment in an explicit
+  # failure list: under set -e a bare failing command substitution exits before
+  # its status can be classified below.
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "   ❌ $AGENT_LABEL: python3 not found — skipping ($CONFIG_PATH)"
+    SKIPPED_AGENTS="${SKIPPED_AGENTS}${AGENT_LABEL} (python3 not found)\n"
+    CONFIGURATION_FAILURE=1
+    continue
+  fi
+
+  MERGE_EXIT=0
   MERGE_RESULT=$(python3 - "$CONFIG_PATH" "$PROJECT_ROOT" <<'PYEOF'
-import sys, json, shutil, os
+import datetime
+import json
+import os
+import shutil
+import stat
+import sys
+import tempfile
 
 config_path = sys.argv[1]
 project_root = sys.argv[2]
 
-# Create backup with timestamp
-import datetime
-timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
-backup_path = config_path + ".bak." + timestamp
-shutil.copy2(config_path, backup_path)
-
-# Parse existing JSON
 try:
     with open(config_path, encoding="utf-8") as f:
         data = json.load(f)
-except json.JSONDecodeError as e:
-    print(f"PARSE_ERROR:{e}", file=sys.stderr)
+except json.JSONDecodeError as exc:
+    print(f"PARSE_ERROR:{exc}", file=sys.stderr)
     sys.exit(2)
 
-# Ensure mcpServers key exists
-if "mcpServers" not in data:
-    data["mcpServers"] = {}
+if not isinstance(data, dict):
+    print("TYPE_ERROR:config root must be a JSON object", file=sys.stderr)
+    sys.exit(3)
 
-# Merge TSA entry (preserves existing entries)
-data["mcpServers"]["tree-sitter-analyzer"] = {
+mcp_servers = data.get("mcpServers")
+if mcp_servers is None:
+    mcp_servers = {}
+    data["mcpServers"] = mcp_servers
+elif not isinstance(mcp_servers, dict):
+    print("TYPE_ERROR:mcpServers must be a JSON object", file=sys.stderr)
+    sys.exit(3)
+
+existing_entry = mcp_servers.get("tree-sitter-analyzer")
+if existing_entry is not None and not isinstance(existing_entry, dict):
+    print("TYPE_ERROR:tree-sitter-analyzer entry must be a JSON object", file=sys.stderr)
+    sys.exit(3)
+if isinstance(existing_entry, dict):
+    existing_env = existing_entry.get("env")
+    if existing_env is not None and not isinstance(existing_env, dict):
+        print("TYPE_ERROR:tree-sitter-analyzer env must be a JSON object", file=sys.stderr)
+        sys.exit(3)
+
+config_dir = os.path.dirname(config_path) or "."
+if stat.S_IMODE(os.stat(config_dir).st_mode) & 0o222 == 0:
+    raise PermissionError(f"config directory is not writable: {config_dir}")
+
+mcp_servers["tree-sitter-analyzer"] = {
     "command": "uvx",
     "args": ["--from", "tree-sitter-analyzer[mcp]", "tree-sitter-analyzer-mcp"],
     "env": {"TREE_SITTER_PROJECT_ROOT": project_root},
 }
 
-with open(config_path, "w", encoding="utf-8") as f:
-    json.dump(data, f, indent=2, ensure_ascii=False)
-    f.write("\n")
+timestamp = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+backup_path = config_path + ".bak." + timestamp
+shutil.copy2(config_path, backup_path)
+
+fd, temporary_path = tempfile.mkstemp(prefix=".tsa-mcp-", dir=config_dir, text=True)
+try:
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+        f.flush()
+        os.fsync(f.fileno())
+    os.chmod(temporary_path, stat.S_IMODE(os.stat(config_path).st_mode))
+    os.replace(temporary_path, config_path)
+except BaseException:
+    try:
+        os.unlink(temporary_path)
+    except FileNotFoundError:
+        pass
+    raise
 
 print(f"OK:{backup_path}")
 PYEOF
-  )
-  MERGE_EXIT=$?
+  ) || MERGE_EXIT=$?
 
   if [ "$MERGE_EXIT" = "2" ]; then
     echo "   ❌ $AGENT_LABEL: JSON parse error — skipping ($CONFIG_PATH)"
@@ -164,6 +285,7 @@ PYEOF
   else
     echo "   ❌ $AGENT_LABEL: unexpected error (exit $MERGE_EXIT) — skipping"
     SKIPPED_AGENTS="${SKIPPED_AGENTS}${AGENT_LABEL} (error)\n"
+    CONFIGURATION_FAILURE=1
   fi
 
 done <<EOF
@@ -204,4 +326,9 @@ echo ""
 if [ "$WSL_ENV" = "1" ]; then
   echo "⚠️  WSL environment: if agent config is not picked up, check the"
   echo "   Windows-side config file manually."
+fi
+
+if [ "$CONFIGURATION_FAILURE" = "1" ]; then
+  echo "❌ One or more existing agent configs could not be updated."
+  exit 1
 fi

--- a/install.sh
+++ b/install.sh
@@ -80,7 +80,10 @@ if [ "$UV_INSTALL_NEEDED" = "1" ]; then
     echo "📦 Installing uv automatically..."
   fi
   UV_INSTALLER_FILE=$(mktemp "${TMPDIR:-/tmp}/tsa-uv-installer.XXXXXX")
-  trap 'rm -f "$UV_INSTALLER_FILE"' EXIT HUP INT TERM
+  trap 'rm -f "$UV_INSTALLER_FILE"' EXIT
+  trap 'exit 129' HUP
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
   if ! curl --proto '=https' --tlsv1.2 -LsSf \
     https://astral.sh/uv/install.sh -o "$UV_INSTALLER_FILE"; then
     echo "❌ Automatic uv bootstrap failed."
@@ -241,7 +244,10 @@ if isinstance(existing_entry, dict):
         print("TYPE_ERROR:tree-sitter-analyzer env must be a JSON object", file=sys.stderr)
         sys.exit(3)
 
-config_dir = os.path.dirname(config_path) or "."
+# Preserve dotfile-managed symlinks: atomically replace the resolved target,
+# never the link path itself.
+write_path = os.path.realpath(config_path)
+config_dir = os.path.dirname(write_path) or "."
 if stat.S_IMODE(os.stat(config_dir).st_mode) & 0o222 == 0:
     raise PermissionError(f"config directory is not writable: {config_dir}")
 
@@ -262,8 +268,8 @@ try:
         f.write("\n")
         f.flush()
         os.fsync(f.fileno())
-    os.chmod(temporary_path, stat.S_IMODE(os.stat(config_path).st_mode))
-    os.replace(temporary_path, config_path)
+    os.chmod(temporary_path, stat.S_IMODE(os.stat(write_path).st_mode))
+    os.replace(temporary_path, write_path)
 except BaseException:
     try:
         os.unlink(temporary_path)

--- a/install.sh
+++ b/install.sh
@@ -31,11 +31,19 @@ uv_version_is_supported() {
   ') || return 1
   UV_MAJOR=$(printf '%s\n' "$UV_VERSION" | awk -F. '{print $1}')
   UV_MINOR=$(printf '%s\n' "$UV_VERSION" | awk -F. '{print $2}')
-  UV_PATCH=$(printf '%s\n' "$UV_VERSION" | awk -F. '{print $3}')
-  [ "$UV_MAJOR" -gt 0 ] || {
-    [ "$UV_MAJOR" -eq 0 ] && [ "$UV_MINOR" -gt 11 ]
-  } || {
-    [ "$UV_MAJOR" -eq 0 ] && [ "$UV_MINOR" -eq 11 ] && [ "$UV_PATCH" -ge 0 ]
+
+  # Compare digit strings rather than shell integers.  Version output is an
+  # external boundary and components may exceed the native integer range.
+  while [ "${UV_MAJOR#0}" != "$UV_MAJOR" ]; do UV_MAJOR=${UV_MAJOR#0}; done
+  while [ "${UV_MINOR#0}" != "$UV_MINOR" ]; do UV_MINOR=${UV_MINOR#0}; done
+  [ -n "$UV_MAJOR" ] || UV_MAJOR=0
+  [ -n "$UV_MINOR" ] || UV_MINOR=0
+  if [ "${#UV_MAJOR}" -gt 1 ] || { [ "${#UV_MAJOR}" -eq 1 ] && [ "$UV_MAJOR" \> 0 ]; }; then
+    return 0
+  fi
+  [ "$UV_MAJOR" = 0 ] || return 1
+  [ "${#UV_MINOR}" -gt 2 ] || {
+    [ "${#UV_MINOR}" -eq 2 ] && { [ "$UV_MINOR" = 11 ] || [ "$UV_MINOR" \> 11 ]; }
   }
 }
 
@@ -46,15 +54,20 @@ probe_uv_version() {
   UV_VERSION_PROBE_ERROR="failed"
   UV_VERSION_PROBE_OUTPUT=$(mktemp "${TMPDIR:-/tmp}/tsa-uv-version.XXXXXX") || return 1
 
+  # Monitor mode gives the background probe its own process group on both
+  # bash 3 (macOS) and current bash (Linux), so timeout cleanup reaches shims'
+  # descendants instead of killing only the immediate uv process.
+  set -m
   uv --version >"$UV_VERSION_PROBE_OUTPUT" 2>/dev/null &
   UV_VERSION_PROBE_PID=$!
+  set +m
   UV_VERSION_WAIT_COUNT=0
   while kill -0 "$UV_VERSION_PROBE_PID" 2>/dev/null; do
     if [ "$UV_VERSION_WAIT_COUNT" -eq 50 ]; then
       UV_VERSION_PROBE_ERROR="timeout"
-      kill -TERM "$UV_VERSION_PROBE_PID" 2>/dev/null || :
+      kill -TERM -"$UV_VERSION_PROBE_PID" 2>/dev/null || :
       sleep 1
-      kill -KILL "$UV_VERSION_PROBE_PID" 2>/dev/null || :
+      kill -KILL -"$UV_VERSION_PROBE_PID" 2>/dev/null || :
       break
     fi
     sleep 0.1

--- a/scripts/qualify_fresh_install.py
+++ b/scripts/qualify_fresh_install.py
@@ -75,6 +75,7 @@ def _restricted_tools(root: Path) -> Path:
         "realpath",
         "rm",
         "sh",
+        "sleep",
         "uname",
     )
     for command in commands:
@@ -182,24 +183,40 @@ def _fixture_fingerprint(root: Path, fixture: dict[str, str]) -> str:
     return _fingerprint(manifest)
 
 
+def _remove_fixture(root: Path) -> None:
+    if not root.exists():
+        return
+    claude = root / ".claude"
+    if claude.exists():
+        claude.chmod(0o755)
+    shutil.rmtree(root)
+
+
 def _run(
     repo: Path, initial_uv: str | None, bootstrap_mode: str, **options: Any
 ) -> tuple[subprocess.CompletedProcess[str], Path, str]:
     root = Path(tempfile.mkdtemp(prefix="tsa-installer-contract-"))
-    disable = options.pop("disable_bootstrap", False)
-    fixture = _prepare_fixture(root, initial_uv, bootstrap_mode, **options)
-    if disable:
-        fixture["TSA_DISABLE_UNVERIFIED_UV_BOOTSTRAP"] = "1"
-    execution_fingerprint = _fixture_fingerprint(root, fixture)
-    completed = subprocess.run(
-        ["/bin/bash", str(repo / "install.sh")],
-        cwd=root,
-        env=os.environ | fixture,
-        capture_output=True,
-        text=True,
-        check=False,
-        timeout=30,
-    )
+    try:
+        disable = options.pop("disable_bootstrap", False)
+        fixture = _prepare_fixture(root, initial_uv, bootstrap_mode, **options)
+        if disable:
+            fixture["TSA_DISABLE_UNVERIFIED_UV_BOOTSTRAP"] = "1"
+        execution_fingerprint = _fixture_fingerprint(root, fixture)
+        execution_env = os.environ.copy()
+        execution_env.pop("TSA_DISABLE_UNVERIFIED_UV_BOOTSTRAP", None)
+        execution_env.update(fixture)
+        completed = subprocess.run(
+            ["/bin/bash", str(repo / "install.sh")],
+            cwd=root,
+            env=execution_env,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+    except BaseException:
+        _remove_fixture(root)
+        raise
     return completed, root, execution_fingerprint
 
 
@@ -328,10 +345,7 @@ def _scenario(repo: Path, scenario_id: str) -> dict[str, Any]:
         return {"id": scenario_id, "status": "failed", "error_type": type(exc).__name__}
     finally:
         if root is not None:
-            claude = root / ".claude"
-            if claude.exists():
-                claude.chmod(0o755)
-            shutil.rmtree(root)
+            _remove_fixture(root)
 
 
 def _git_provenance(repo: Path) -> dict[str, Any]:

--- a/scripts/qualify_fresh_install.py
+++ b/scripts/qualify_fresh_install.py
@@ -1,0 +1,466 @@
+#!/usr/bin/env python3
+"""Exercise offline installer boundaries without granting qualification."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+AXES = ("macos", "linux", "windows")
+SCENARIOS = (
+    "disable_unverified_bootstrap",
+    "missing_uv_bootstraps",
+    "outdated_uv_bootstraps",
+    "installer_body_failure",
+    "curl_missing",
+    "download_tls_failure",
+    "post_bootstrap_uv_missing",
+    "post_bootstrap_uv_non_executable",
+    "post_bootstrap_uv_too_old",
+    "post_bootstrap_uv_malformed",
+    "post_bootstrap_path_prefers_new_uv",
+    "json_parse_error_skips_and_continues",
+    "python3_missing_fails_closed",
+    "config_root_non_object_fails_closed",
+    "mcp_servers_non_object_fails_closed",
+    "tsa_entry_non_object_fails_closed",
+    "no_agent_config_skips_cleanly",
+    "merge_write_permission_failure_fails_closed",
+)
+CONFIG_TEXT = {
+    "valid": "{}\n",
+    "parse_error": "{ invalid json }\n",
+    "root_list": "[]\n",
+    "mcp_list": '{"mcpServers": []}\n',
+    "entry_list": '{"mcpServers": {"tree-sitter-analyzer": []}}\n',
+    "permission": "{}\n",
+}
+
+
+def _fingerprint(value: object) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _host_axis() -> str:
+    return {"Darwin": "macos", "Linux": "linux", "Windows": "windows"}.get(
+        platform.system(), "unsupported"
+    )
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _restricted_tools(root: Path) -> Path:
+    tool_bin = root / "tool-bin"
+    tool_bin.mkdir()
+    commands = (
+        "awk",
+        "cat",
+        "chmod",
+        "grep",
+        "mkdir",
+        "mktemp",
+        "realpath",
+        "rm",
+        "sh",
+        "uname",
+    )
+    for command in commands:
+        resolved = shutil.which(command)
+        if resolved:
+            (tool_bin / command).symlink_to(resolved)
+    return tool_bin
+
+
+def _prepare_fixture(
+    root: Path,
+    initial_uv: str | None,
+    bootstrap_mode: str,
+    *,
+    config_mode: str = "valid",
+    curl_mode: str = "success",
+    restricted_path: bool = False,
+    initial_uv_location: str = "mock-bin",
+) -> dict[str, str]:
+    mock_bin, home, claude = root / "mock-bin", root / "home", root / ".claude"
+    mock_bin.mkdir()
+    home.mkdir()
+    claude.mkdir()
+    if config_mode != "none":
+        (claude / ".mcp.json").write_text(CONFIG_TEXT[config_mode], encoding="utf-8")
+    if config_mode == "permission":
+        claude.chmod(0o555)
+    initial_bin = mock_bin
+    if initial_uv_location == "legacy-bin":
+        initial_bin = root / "legacy-bin"
+        initial_bin.mkdir()
+    if initial_uv is not None:
+        _write_executable(initial_bin / "uv", f'#!/bin/sh\nprintf "{initial_uv}\\n"\n')
+    if curl_mode != "missing":
+        if curl_mode == "failure":
+            curl = '#!/bin/sh\nprintf "%s\\n" "$*" > "$CURL_LOG"\nexit 60\n'
+        else:
+            curl = r"""#!/bin/sh
+printf '%s\n' "$*" > "$CURL_LOG"
+out=''
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = '-o' ]; then out=$2; shift 2; else shift; fi
+done
+[ -n "$out" ] || exit 64
+cat > "$out" <<'INSTALLER'
+#!/bin/sh
+case "$BOOTSTRAP_MODE" in
+  body_failure) exit 9 ;;
+  missing) exit 0 ;;
+  nonexec)
+    mkdir -p "$HOME/.local/bin"
+    printf '#!/bin/sh\nprintf "uv 0.11.0\\n"\n' > "$HOME/.local/bin/uv"
+    chmod 644 "$HOME/.local/bin/uv" ;;
+  old) version='uv 0.10.9' ;;
+  malformed) version='not-uv 0.11.0' ;;
+  valid) version='uv 0.11.0' ;;
+  *) exit 65 ;;
+esac
+if [ -n "${version:-}" ]; then
+  mkdir -p "$HOME/.local/bin"
+  printf '#!/bin/sh\nprintf "%%s\\n" "%s"\n' "$version" > "$HOME/.local/bin/uv"
+  chmod 755 "$HOME/.local/bin/uv"
+fi
+INSTALLER
+"""
+        _write_executable(mock_bin / "curl", curl)
+    path = [str(mock_bin)]
+    if initial_uv_location == "legacy-bin":
+        path.append(str(initial_bin))
+    path += [str(_restricted_tools(root))] if restricted_path else ["/usr/bin", "/bin"]
+    return {
+        "HOME": str(home),
+        "PATH": os.pathsep.join(path),
+        "BOOTSTRAP_MODE": bootstrap_mode,
+        "CURL_LOG": str(root / "curl.log"),
+    }
+
+
+def _fixture_fingerprint(root: Path, fixture: dict[str, str]) -> str:
+    def file_record(path: Path) -> dict[str, object]:
+        if not path.exists():
+            return {"present": False}
+        return {
+            "present": True,
+            "mode": path.stat().st_mode & 0o777,
+            "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+        }
+
+    normalized_path = [
+        str(Path(item).relative_to(root))
+        if item.startswith(f"{root}{os.sep}")
+        else item
+        for item in fixture["PATH"].split(os.pathsep)
+    ]
+    manifest = {
+        "path": normalized_path,
+        "bootstrap_mode": fixture["BOOTSTRAP_MODE"],
+        "bootstrap_disabled": fixture.get("TSA_DISABLE_UNVERIFIED_UV_BOOTSTRAP"),
+        "bootstrap_install_location": "home/.local/bin/uv",
+        "mock_uv": file_record(root / "mock-bin" / "uv"),
+        "legacy_uv": file_record(root / "legacy-bin" / "uv"),
+        "curl": file_record(root / "mock-bin" / "curl"),
+        "config": file_record(root / ".claude" / ".mcp.json"),
+    }
+    return _fingerprint(manifest)
+
+
+def _run(
+    repo: Path, initial_uv: str | None, bootstrap_mode: str, **options: Any
+) -> tuple[subprocess.CompletedProcess[str], Path, str]:
+    root = Path(tempfile.mkdtemp(prefix="tsa-installer-contract-"))
+    disable = options.pop("disable_bootstrap", False)
+    fixture = _prepare_fixture(root, initial_uv, bootstrap_mode, **options)
+    if disable:
+        fixture["TSA_DISABLE_UNVERIFIED_UV_BOOTSTRAP"] = "1"
+    execution_fingerprint = _fixture_fingerprint(root, fixture)
+    completed = subprocess.run(
+        ["/bin/bash", str(repo / "install.sh")],
+        cwd=root,
+        env=os.environ | fixture,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    return completed, root, execution_fingerprint
+
+
+def _settings(scenario_id: str) -> tuple[str | None, str, dict[str, Any]]:
+    initial: str | None = None
+    bootstrap = "valid"
+    options: dict[str, Any] = {}
+    if scenario_id == "disable_unverified_bootstrap":
+        options["disable_bootstrap"] = True
+    elif scenario_id == "outdated_uv_bootstraps":
+        initial = "uv 0.10.9"
+    elif scenario_id == "post_bootstrap_path_prefers_new_uv":
+        initial = "uv 0.10.9"
+        options["initial_uv_location"] = "legacy-bin"
+    elif scenario_id == "installer_body_failure":
+        bootstrap = "body_failure"
+    elif scenario_id == "curl_missing":
+        options.update(curl_mode="missing", restricted_path=True)
+    elif scenario_id == "download_tls_failure":
+        options["curl_mode"] = "failure"
+    elif scenario_id.startswith("post_bootstrap_uv_"):
+        bootstrap = {
+            "post_bootstrap_uv_missing": "missing",
+            "post_bootstrap_uv_non_executable": "nonexec",
+            "post_bootstrap_uv_too_old": "old",
+            "post_bootstrap_uv_malformed": "malformed",
+        }[scenario_id]
+    elif scenario_id == "json_parse_error_skips_and_continues":
+        initial, options["config_mode"] = "uv 0.11.0", "parse_error"
+    elif scenario_id == "python3_missing_fails_closed":
+        initial, options["restricted_path"] = "uv 0.11.0", True
+    elif scenario_id == "config_root_non_object_fails_closed":
+        initial, options["config_mode"] = "uv 0.11.0", "root_list"
+    elif scenario_id == "mcp_servers_non_object_fails_closed":
+        initial, options["config_mode"] = "uv 0.11.0", "mcp_list"
+    elif scenario_id == "tsa_entry_non_object_fails_closed":
+        initial, options["config_mode"] = "uv 0.11.0", "entry_list"
+    elif scenario_id == "no_agent_config_skips_cleanly":
+        initial, options["config_mode"] = "uv 0.11.0", "none"
+    elif scenario_id == "merge_write_permission_failure_fails_closed":
+        initial, options["config_mode"] = "uv 0.11.0", "permission"
+    return initial, bootstrap, options
+
+
+def _scenario(repo: Path, scenario_id: str) -> dict[str, Any]:
+    root: Path | None = None
+    try:
+        initial, bootstrap, options = _settings(scenario_id)
+        settings_fingerprint = _fingerprint(
+            {
+                "initial_uv": initial,
+                "bootstrap_mode": bootstrap,
+                "options": options,
+            }
+        )
+        completed, root, execution_fingerprint = _run(
+            repo, initial, bootstrap, **options
+        )
+        output, config_path = (
+            completed.stdout + completed.stderr,
+            root / ".claude" / ".mcp.json",
+        )
+        if scenario_id == "disable_unverified_bootstrap":
+            passed = completed.returncode == 1 and not (root / "curl.log").exists()
+        elif scenario_id in {"missing_uv_bootstraps", "outdated_uv_bootstraps"}:
+            config = json.loads(config_path.read_text(encoding="utf-8"))
+            passed = (
+                completed.returncode == 0
+                and config["mcpServers"]["tree-sitter-analyzer"]["command"] == "uvx"
+                and "UNVERIFIED and mutable" in output
+            )
+        elif scenario_id == "post_bootstrap_path_prefers_new_uv":
+            passed = (
+                completed.returncode == 0 and str(root / "home/.local/bin/uv") in output
+            )
+        elif scenario_id == "installer_body_failure":
+            passed = (
+                completed.returncode == 1 and "Recovery: install uv >= 0.11.0" in output
+            )
+        elif scenario_id == "curl_missing":
+            passed = completed.returncode == 1 and "curl not found" in output
+        elif scenario_id == "download_tls_failure":
+            passed = (
+                completed.returncode == 1 and "Automatic uv bootstrap failed" in output
+            )
+        elif scenario_id.startswith("post_bootstrap_uv_"):
+            passed = (
+                completed.returncode == 1 and "did not provide required uv" in output
+            )
+        elif scenario_id == "json_parse_error_skips_and_continues":
+            passed = (
+                completed.returncode == 0
+                and config_path.read_text(encoding="utf-8")
+                == CONFIG_TEXT["parse_error"]
+                and "JSON parse error — skipping" in output
+            )
+        elif scenario_id == "python3_missing_fails_closed":
+            passed = (
+                completed.returncode == 1
+                and config_path.read_text(encoding="utf-8") == CONFIG_TEXT["valid"]
+                and "python3 not found — skipping" in output
+            )
+        elif scenario_id == "no_agent_config_skips_cleanly":
+            passed = completed.returncode == 0 and not config_path.exists()
+        elif scenario_id == "merge_write_permission_failure_fails_closed":
+            passed = (
+                completed.returncode == 1
+                and config_path.read_text(encoding="utf-8") == CONFIG_TEXT["permission"]
+                and "unexpected error (exit 1) — skipping" in output
+            )
+        else:
+            mode = options["config_mode"]
+            passed = (
+                completed.returncode == 1
+                and config_path.read_text(encoding="utf-8") == CONFIG_TEXT[mode]
+                and "unexpected error (exit 3) — skipping" in output
+            )
+        return {
+            "id": scenario_id,
+            "status": "passed" if passed else "failed",
+            "installer_exit": completed.returncode,
+            "settings_fingerprint": settings_fingerprint,
+            "execution_fingerprint": execution_fingerprint,
+        }
+    except Exception as exc:  # noqa: BLE001
+        return {"id": scenario_id, "status": "failed", "error_type": type(exc).__name__}
+    finally:
+        if root is not None:
+            claude = root / ".claude"
+            if claude.exists():
+                claude.chmod(0o755)
+            shutil.rmtree(root)
+
+
+def _git_provenance(repo: Path) -> dict[str, Any]:
+    commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    dirty = bool(
+        subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    )
+    return {"commit": commit, "dirty": dirty}
+
+
+def qualify(repo: Path, requested_axes: tuple[str, ...]) -> dict[str, Any]:
+    host, axes = _host_axis(), []
+    for axis in requested_axes:
+        base = {
+            "axis": axis,
+            "qualification": "not_performed",
+            "qualified": False,
+            "native_evidence": False,
+        }
+        if axis != host:
+            axes.append(
+                base
+                | {
+                    "status": "not_run",
+                    "reason": f"requires {axis} host; current host is {host}",
+                    "scenarios": [],
+                }
+            )
+        elif axis == "windows":
+            axes.append(
+                base
+                | {
+                    "status": "failed",
+                    "reason": "install.sh is POSIX-only",
+                    "scenarios": [],
+                }
+            )
+        else:
+            scenarios = [_scenario(repo, item) for item in SCENARIOS]
+            passed = all(item["status"] == "passed" for item in scenarios)
+            axes.append(
+                base
+                | {
+                    "status": "passed" if passed else "failed",
+                    "scenario_type": "offline_installer_contract",
+                    "scenarios": scenarios,
+                }
+            )
+    return {
+        "schema_version": 2,
+        "qualification_id": "NO1-006A",
+        "evidence_scope": "offline_installer_contract",
+        "evidence_trust": "UNTRUSTED_SELF_REPORTED",
+        "qualification_performed": False,
+        "native_axes_qualified": False,
+        "host": {
+            "axis": host,
+            "os": platform.system(),
+            "os_version": platform.version(),
+            "architecture": platform.machine(),
+            "python": platform.python_version(),
+            "python_runtime": sys.implementation.name,
+        },
+        "source": {
+            "git": _git_provenance(repo),
+            "install_sh_sha256": hashlib.sha256(
+                (repo / "install.sh").read_bytes()
+            ).hexdigest(),
+            "harness_sha256": hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+        },
+        "bootstrap": {
+            "url": "https://astral.sh/uv/install.sh",
+            "integrity": "none",
+            "attestation": "none",
+            "trust": "UNVERIFIED",
+            "execution": "default_unverified_with_secure_opt_out",
+        },
+        "package_evidence": "none",
+        "mcp_protocol_evidence": "none",
+        "axes": axes,
+        "pending_axes": [item["axis"] for item in axes if item["status"] == "not_run"],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--axis", choices=(*AXES, "all"))
+    parser.add_argument(
+        "--local-contract-only",
+        action="store_true",
+        help="run current-host offline contract; never grants qualification",
+    )
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    if args.local_contract_only and args.axis is not None:
+        parser.error(
+            "--local-contract-only cannot be combined with --axis; it always runs only the current host"
+        )
+    repo = Path(__file__).resolve().parents[1]
+    requested = (
+        (_host_axis(),)
+        if args.local_contract_only
+        else AXES
+        if args.axis in {None, "all"}
+        else (args.axis,)
+    )
+    report = qualify(repo, requested)
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    print(rendered, end="")
+    if not args.local_contract_only:
+        return 1
+    executed = [item for item in report["axes"] if item["status"] != "not_run"]
+    return 0 if executed and all(item["status"] == "passed" for item in executed) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/qualify_fresh_install.py
+++ b/scripts/qualify_fresh_install.py
@@ -62,7 +62,8 @@ def _write_executable(path: Path, content: str) -> None:
     path.chmod(0o755)
 
 
-def _restricted_tools(root: Path) -> Path:
+def _restricted_tools(root: Path, *, include_python3: bool = True) -> Path:
+    """Build a hermetic PATH containing tools the installer contract requires."""
     tool_bin = root / "tool-bin"
     tool_bin.mkdir()
     commands = (
@@ -82,6 +83,8 @@ def _restricted_tools(root: Path) -> Path:
         resolved = shutil.which(command)
         if resolved:
             (tool_bin / command).symlink_to(resolved)
+    if include_python3:
+        (tool_bin / "python3").symlink_to(Path(sys.executable).resolve())
     return tool_bin
 
 
@@ -145,7 +148,9 @@ INSTALLER
     path = [str(mock_bin)]
     if initial_uv_location == "legacy-bin":
         path.append(str(initial_bin))
-    path += [str(_restricted_tools(root))] if restricted_path else ["/usr/bin", "/bin"]
+    # Never expose the host PATH: initial_uv=None must mean uv is genuinely
+    # absent even on machines that install it in /usr/bin or /bin.
+    path.append(str(_restricted_tools(root, include_python3=not restricted_path)))
     return {
         "HOME": str(home),
         "PATH": os.pathsep.join(path),
@@ -178,6 +183,7 @@ def _fixture_fingerprint(root: Path, fixture: dict[str, str]) -> str:
         "mock_uv": file_record(root / "mock-bin" / "uv"),
         "legacy_uv": file_record(root / "legacy-bin" / "uv"),
         "curl": file_record(root / "mock-bin" / "curl"),
+        "python3_present": (root / "tool-bin" / "python3").exists(),
         "config": file_record(root / ".claude" / ".mcp.json"),
     }
     return _fingerprint(manifest)

--- a/tests/contracts/test_fresh_install_qualification.py
+++ b/tests/contracts/test_fresh_install_qualification.py
@@ -293,7 +293,11 @@ def test_run_removes_fixture_when_installer_times_out(tmp_path: Path) -> None:
 
 @pytest.mark.parametrize(
     ("probe_signal", "expected_status"),
-    ((signal.SIGHUP, 129), (signal.SIGINT, 130), (signal.SIGTERM, 143)),
+    (
+        (getattr(signal, "SIGHUP", signal.SIGTERM), 129),
+        (signal.SIGINT, 130),
+        (signal.SIGTERM, 143),
+    ),
 )
 @pytest.mark.skipif(
     os.name == "nt",

--- a/tests/contracts/test_fresh_install_qualification.py
+++ b/tests/contracts/test_fresh_install_qualification.py
@@ -7,6 +7,7 @@ import json
 import os
 import platform
 import shutil
+import signal
 import subprocess
 import sys
 import time
@@ -288,6 +289,65 @@ def test_run_removes_fixture_when_installer_times_out(tmp_path: Path) -> None:
         else:
             raise AssertionError("expected installer timeout")
     assert fixture_root.exists() is False
+
+
+@pytest.mark.parametrize(
+    ("probe_signal", "expected_status"),
+    ((signal.SIGHUP, 129), (signal.SIGINT, 130), (signal.SIGTERM, 143)),
+)
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="tracked: install.sh signal contract is for macOS/Linux shell installs",
+)
+def test_installer_signal_terminates_probe_group_and_removes_temp(
+    tmp_path: Path, probe_signal: signal.Signals, expected_status: int
+) -> None:
+    # PR #1233: installer-only signals must clean the isolated uv probe group.
+    root = tmp_path / f"probe-signal-{probe_signal.name.lower()}"
+    root.mkdir()
+    fixture = qualification._prepare_fixture(root, "uv 0.11.0", "valid")
+    child_pid_file = root / "uv-child.pid"
+    probe_tmp = root / "probe-tmp"
+    probe_tmp.mkdir()
+    fixture |= {
+        "UV_CHILD_PID_FILE": str(child_pid_file),
+        "TMPDIR": str(probe_tmp),
+    }
+    qualification._write_executable(
+        root / "mock-bin" / "uv",
+        "#!/bin/sh\ntrap '' HUP INT TERM\nsleep 60 &\n"
+        'echo "$!" > "$UV_CHILD_PID_FILE"\nwait\n',
+    )
+    process = subprocess.Popen(
+        ["/bin/bash", str(REPO / "install.sh")],
+        cwd=root,
+        env=os.environ | fixture,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            if child_pid_file.exists() and list(probe_tmp.glob("tsa-uv-version.*")):
+                break
+            time.sleep(0.05)
+        assert (
+            child_pid_file.exists(),
+            len(list(probe_tmp.glob("tsa-uv-version.*"))),
+        ) == (True, 1)
+        child_pid = int(child_pid_file.read_text(encoding="utf-8"))
+        os.kill(process.pid, probe_signal)
+        process.communicate(timeout=10)
+        assert (
+            process.returncode,
+            _wait_for_process_exit(child_pid),
+            list(probe_tmp.glob("tsa-uv-version.*")),
+        ) == (expected_status, True, [])
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.communicate()
 
 
 @pytest.mark.skipif(

--- a/tests/contracts/test_fresh_install_qualification.py
+++ b/tests/contracts/test_fresh_install_qualification.py
@@ -6,8 +6,10 @@ import hashlib
 import json
 import os
 import platform
+import shutil
 import subprocess
 import sys
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -16,6 +18,17 @@ import pytest
 from scripts import qualify_fresh_install as qualification
 
 REPO = Path(__file__).parents[2]
+
+
+def _wait_for_process_exit(pid: int) -> bool:
+    deadline = time.monotonic() + 3
+    while time.monotonic() < deadline:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return True
+        time.sleep(0.05)
+    return False
 
 
 def _run(*arguments: str) -> tuple[subprocess.CompletedProcess[str], dict[str, object]]:
@@ -286,13 +299,21 @@ def test_installer_times_out_hanging_existing_uv(tmp_path: Path) -> None:
     root = tmp_path / "existing-uv-timeout"
     root.mkdir()
     fixture = qualification._prepare_fixture(root, "uv 0.11.0", "valid")
+    child_pid_file = root / "uv-child.pid"
+    fixture["UV_CHILD_PID_FILE"] = str(child_pid_file)
     qualification._write_executable(
-        root / "mock-bin" / "uv", "#!/bin/sh\nwhile :; do :; done\n"
+        root / "mock-bin" / "uv",
+        '#!/bin/sh\nsleep 60 &\necho "$!" > "$UV_CHILD_PID_FILE"\nwait\n',
     )
+    execution_env = {
+        key: value
+        for key, value in os.environ.items()
+        if key != "TSA_DISABLE_UNVERIFIED_UV_BOOTSTRAP"
+    } | fixture
     completed = subprocess.run(
         ["/bin/bash", str(REPO / "install.sh")],
         cwd=root,
-        env=os.environ | fixture,
+        env=execution_env,
         capture_output=True,
         text=True,
         check=False,
@@ -303,6 +324,8 @@ def test_installer_times_out_hanging_existing_uv(tmp_path: Path) -> None:
         True,
     )
     assert "Replace or repair uv" in completed.stdout
+    child_pid = int(child_pid_file.read_text(encoding="utf-8"))
+    assert _wait_for_process_exit(child_pid) is True
 
 
 @pytest.mark.skipif(
@@ -314,6 +337,8 @@ def test_installer_times_out_hanging_post_bootstrap_uv(tmp_path: Path) -> None:
     root = tmp_path / "bootstrap-uv-timeout"
     root.mkdir()
     fixture = qualification._prepare_fixture(root, None, "valid")
+    child_pid_file = root / "uv-child.pid"
+    fixture["UV_CHILD_PID_FILE"] = str(child_pid_file)
     qualification._write_executable(
         root / "mock-bin" / "curl",
         r"""#!/bin/sh
@@ -326,16 +351,23 @@ cat > "$out" <<'INSTALLER'
 mkdir -p "$HOME/.local/bin"
 cat > "$HOME/.local/bin/uv" <<'UV'
 #!/bin/sh
-while :; do :; done
+sleep 60 &
+echo "$!" > "$UV_CHILD_PID_FILE"
+wait
 UV
 chmod 755 "$HOME/.local/bin/uv"
 INSTALLER
 """,
     )
+    execution_env = {
+        key: value
+        for key, value in os.environ.items()
+        if key != "TSA_DISABLE_UNVERIFIED_UV_BOOTSTRAP"
+    } | fixture
     completed = subprocess.run(
         ["/bin/bash", str(REPO / "install.sh")],
         cwd=root,
-        env=os.environ | fixture,
+        env=execution_env,
         capture_output=True,
         text=True,
         check=False,
@@ -347,3 +379,44 @@ INSTALLER
         "after bootstrap" in completed.stdout,
     ) == (1, True, True)
     assert "Install uv manually" in completed.stdout
+    child_pid = int(child_pid_file.read_text(encoding="utf-8"))
+    assert _wait_for_process_exit(child_pid) is True
+
+
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="tracked: install.sh version contract is for macOS/Linux shell installs",
+)
+def test_installer_accepts_huge_supported_uv_without_bootstrap(tmp_path: Path) -> None:
+    # PR #1233: semver comparison must not overflow native shell integers.
+    root = tmp_path / "huge-uv-version"
+    root.mkdir()
+    huge_version = f"uv {'9' * 200}.0.0"
+    fixture = qualification._prepare_fixture(root, huge_version, "valid")
+    fixture["TSA_DISABLE_UNVERIFIED_UV_BOOTSTRAP"] = "1"
+    completed = subprocess.run(
+        ["/bin/bash", str(REPO / "install.sh")],
+        cwd=root,
+        env=os.environ | fixture,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=20,
+    )
+    assert completed.returncode == 0
+    assert f"✅ {huge_version}:" in completed.stdout
+    assert (root / "curl.log").exists() is False
+
+
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="tracked: install.sh fixture PATH is for macOS/Linux shell installs",
+)
+def test_missing_uv_fixture_path_is_hermetic(tmp_path: Path) -> None:
+    # PR #1233: a host /usr/bin/uv must not rewrite the missing-uv scenario.
+    root = tmp_path / "hermetic-path"
+    root.mkdir()
+    fixture = qualification._prepare_fixture(root, None, "valid")
+    path_entries = fixture["PATH"].split(os.pathsep)
+    assert path_entries == [str(root / "mock-bin"), str(root / "tool-bin")]
+    assert shutil.which("uv", path=fixture["PATH"]) is None

--- a/tests/contracts/test_fresh_install_qualification.py
+++ b/tests/contracts/test_fresh_install_qualification.py
@@ -296,7 +296,7 @@ def test_installer_times_out_hanging_existing_uv(tmp_path: Path) -> None:
         capture_output=True,
         text=True,
         check=False,
-        timeout=10,
+        timeout=20,
     )
     assert (completed.returncode, "Timed out after 5 seconds" in completed.stdout) == (
         1,
@@ -339,7 +339,7 @@ INSTALLER
         capture_output=True,
         text=True,
         check=False,
-        timeout=10,
+        timeout=20,
     )
     assert (
         completed.returncode,

--- a/tests/contracts/test_fresh_install_qualification.py
+++ b/tests/contracts/test_fresh_install_qualification.py
@@ -1,0 +1,226 @@
+"""Contracts for NO1-006A offline installer evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import platform
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).parents[2]
+
+
+def _run(*arguments: str) -> tuple[subprocess.CompletedProcess[str], dict[str, object]]:
+    completed = subprocess.run(
+        [sys.executable, str(REPO / "scripts/qualify_fresh_install.py"), *arguments],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    return completed, json.loads(completed.stdout)
+
+
+def test_axis_all_fails_closed_when_axes_are_pending() -> None:
+    completed, report = _run("--axis", "all")
+    assert completed.returncode == 1
+    assert report["qualification_performed"] is False
+    assert report["native_axes_qualified"] is False
+    assert "qualified_axes" not in report
+    assert [axis["qualified"] for axis in report["axes"]] == [False, False, False]
+    assert [axis["native_evidence"] for axis in report["axes"]] == [False, False, False]
+
+
+def test_local_contract_only_is_explicitly_not_qualification() -> None:
+    completed, report = _run("--local-contract-only")
+    expected = 1 if platform.system() == "Windows" else 0
+    assert completed.returncode == expected
+    assert report["evidence_scope"] == "offline_installer_contract"
+    assert report["package_evidence"] == "none"
+    assert report["mcp_protocol_evidence"] == "none"
+    host_axis = {"Darwin": "macos", "Linux": "linux", "Windows": "windows"}.get(
+        platform.system(), "unsupported"
+    )
+    assert [axis["axis"] for axis in report["axes"]] == [host_axis]
+    assert report["pending_axes"] == []
+    current = report["axes"][0]
+    assert current["qualification"] == "not_performed"
+    assert current["qualified"] is False
+
+
+def test_offline_contract_covers_independent_failure_boundaries() -> None:
+    completed, report = _run("--local-contract-only")
+    if platform.system() == "Windows":
+        assert completed.returncode == 1
+        return
+    assert completed.returncode == 0
+    host = next(axis for axis in report["axes"] if axis["status"] == "passed")
+    assert host["scenario_type"] == "offline_installer_contract"
+    assert [scenario["id"] for scenario in host["scenarios"]] == [
+        "disable_unverified_bootstrap",
+        "missing_uv_bootstraps",
+        "outdated_uv_bootstraps",
+        "installer_body_failure",
+        "curl_missing",
+        "download_tls_failure",
+        "post_bootstrap_uv_missing",
+        "post_bootstrap_uv_non_executable",
+        "post_bootstrap_uv_too_old",
+        "post_bootstrap_uv_malformed",
+        "post_bootstrap_path_prefers_new_uv",
+        "json_parse_error_skips_and_continues",
+        "python3_missing_fails_closed",
+        "config_root_non_object_fails_closed",
+        "mcp_servers_non_object_fails_closed",
+        "tsa_entry_non_object_fails_closed",
+        "no_agent_config_skips_cleanly",
+        "merge_write_permission_failure_fails_closed",
+    ]
+    assert [scenario["status"] for scenario in host["scenarios"]] == ["passed"] * 18
+    assert [scenario["installer_exit"] for scenario in host["scenarios"]] == [
+        1,
+        0,
+        0,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        0,
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+    ]
+
+
+def test_scenario_settings_and_execution_fingerprints_are_unique() -> None:
+    completed, report = _run("--local-contract-only")
+    if platform.system() == "Windows":
+        assert completed.returncode == 1
+        return
+    assert completed.returncode == 0
+    scenarios = report["axes"][0]["scenarios"]
+    settings_fingerprints = [item["settings_fingerprint"] for item in scenarios]
+    execution_fingerprints = [item["execution_fingerprint"] for item in scenarios]
+    assert len(settings_fingerprints) == 18
+    assert len(set(settings_fingerprints)) == 18
+    assert len(execution_fingerprints) == 18
+    assert len(set(execution_fingerprints)) == 18
+
+
+def test_local_contract_only_rejects_axis_combination() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(REPO / "scripts/qualify_fresh_install.py"),
+            "--local-contract-only",
+            "--axis",
+            "all",
+        ],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    assert completed.returncode == 2
+    assert "--local-contract-only cannot be combined with --axis" in completed.stderr
+    assert completed.stdout == ""
+
+
+def test_ambiguous_contract_only_flag_is_rejected() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(REPO / "scripts/qualify_fresh_install.py"),
+            "--contract-only",
+        ],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    assert completed.returncode == 2
+    assert "unrecognized arguments: --contract-only" in completed.stderr
+    assert completed.stdout == ""
+
+
+def test_artifact_records_untrusted_provenance_and_unverified_bootstrap() -> None:
+    completed, report = _run("--local-contract-only")
+    if platform.system() == "Windows":
+        assert completed.returncode == 1
+    else:
+        assert completed.returncode == 0
+    expected_commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    expected_dirty = bool(
+        subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=REPO,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    )
+    assert report["source"] == {
+        "git": {"commit": expected_commit, "dirty": expected_dirty},
+        "install_sh_sha256": hashlib.sha256(
+            (REPO / "install.sh").read_bytes()
+        ).hexdigest(),
+        "harness_sha256": hashlib.sha256(
+            (REPO / "scripts/qualify_fresh_install.py").read_bytes()
+        ).hexdigest(),
+    }
+    assert report["evidence_trust"] == "UNTRUSTED_SELF_REPORTED"
+    assert report["host"]["os"] == platform.system()
+    assert report["host"]["os_version"] == platform.version()
+    assert report["host"]["architecture"] == platform.machine()
+    assert report["host"]["python"] == platform.python_version()
+    assert report["bootstrap"] == {
+        "attestation": "none",
+        "execution": "default_unverified_with_secure_opt_out",
+        "integrity": "none",
+        "trust": "UNVERIFIED",
+        "url": "https://astral.sh/uv/install.sh",
+    }
+
+
+def test_readme_discloses_default_unverified_bootstrap() -> None:
+    readme = (REPO / "README.md").read_text(encoding="utf-8")
+    assert "mutable and **not content-bound**" in readme
+
+
+def test_readme_documents_secure_bootstrap_opt_out() -> None:
+    readme = (REPO / "README.md").read_text(encoding="utf-8")
+    assert "TSA_DISABLE_UNVERIFIED_UV_BOOTSTRAP=1 bash" in readme
+
+
+def test_installer_uses_disable_bootstrap_contract() -> None:
+    installer = (REPO / "install.sh").read_text(encoding="utf-8")
+    assert "TSA_DISABLE_UNVERIFIED_UV_BOOTSTRAP" in installer
+
+
+def test_installer_retires_allow_bootstrap_contract() -> None:
+    installer = (REPO / "install.sh").read_text(encoding="utf-8")
+    assert "TSA_ALLOW_UNVERIFIED_UV_BOOTSTRAP" not in installer
+
+
+def test_harness_contains_no_mock_uvx_first_answer() -> None:
+    source = (REPO / "scripts/qualify_fresh_install.py").read_text(encoding="utf-8")
+    assert "uvx-template" not in source
+    assert "FIRST_ANSWER" not in source

--- a/tests/contracts/test_fresh_install_qualification.py
+++ b/tests/contracts/test_fresh_install_qualification.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import platform
 import subprocess
 import sys
 from pathlib import Path
+from unittest.mock import patch
+
+from scripts import qualify_fresh_install as qualification
 
 REPO = Path(__file__).parents[2]
 
@@ -224,3 +228,112 @@ def test_harness_contains_no_mock_uvx_first_answer() -> None:
     source = (REPO / "scripts/qualify_fresh_install.py").read_text(encoding="utf-8")
     assert "uvx-template" not in source
     assert "FIRST_ANSWER" not in source
+
+
+def test_harness_clears_inherited_bootstrap_opt_out() -> None:
+    # PR #1233: hardened parent environments must not rewrite ordinary fixtures.
+    completed = subprocess.CompletedProcess([], 0, "", "")
+    with (
+        patch.dict(os.environ, {"TSA_DISABLE_UNVERIFIED_UV_BOOTSTRAP": "1"}),
+        patch.object(qualification.subprocess, "run", return_value=completed) as run,
+    ):
+        _, root, _ = qualification._run(REPO, None, "valid")
+    try:
+        assert "TSA_DISABLE_UNVERIFIED_UV_BOOTSTRAP" not in run.call_args.kwargs["env"]
+    finally:
+        qualification._remove_fixture(root)
+
+
+def test_harness_preserves_explicit_bootstrap_opt_out() -> None:
+    completed = subprocess.CompletedProcess([], 0, "", "")
+    with patch.object(qualification.subprocess, "run", return_value=completed) as run:
+        _, root, _ = qualification._run(REPO, None, "valid", disable_bootstrap=True)
+    try:
+        assert run.call_args.kwargs["env"]["TSA_DISABLE_UNVERIFIED_UV_BOOTSTRAP"] == "1"
+    finally:
+        qualification._remove_fixture(root)
+
+
+def test_run_removes_fixture_when_installer_times_out(tmp_path: Path) -> None:
+    # PR #1233: subprocess timeouts must not leak tsa-installer-contract fixtures.
+    fixture_root = tmp_path / "tsa-installer-contract-timeout"
+    fixture_root.mkdir()
+    with (
+        patch.object(qualification.tempfile, "mkdtemp", return_value=str(fixture_root)),
+        patch.object(
+            qualification.subprocess,
+            "run",
+            side_effect=subprocess.TimeoutExpired(["/bin/bash", "install.sh"], 30),
+        ),
+    ):
+        try:
+            qualification._run(REPO, None, "valid")
+        except subprocess.TimeoutExpired:
+            pass
+        else:
+            raise AssertionError("expected installer timeout")
+    assert fixture_root.exists() is False
+
+
+def test_installer_times_out_hanging_existing_uv(tmp_path: Path) -> None:
+    # PR #1233: an existing uv shim must not block installation indefinitely.
+    root = tmp_path / "existing-uv-timeout"
+    root.mkdir()
+    fixture = qualification._prepare_fixture(root, "uv 0.11.0", "valid")
+    qualification._write_executable(
+        root / "mock-bin" / "uv", "#!/bin/sh\nwhile :; do :; done\n"
+    )
+    completed = subprocess.run(
+        ["/bin/bash", str(REPO / "install.sh")],
+        cwd=root,
+        env=os.environ | fixture,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+    assert (completed.returncode, "Timed out after 5 seconds" in completed.stdout) == (
+        1,
+        True,
+    )
+    assert "Replace or repair uv" in completed.stdout
+
+
+def test_installer_times_out_hanging_post_bootstrap_uv(tmp_path: Path) -> None:
+    # PR #1233: bootstrap validation must fail closed when the installed uv hangs.
+    root = tmp_path / "bootstrap-uv-timeout"
+    root.mkdir()
+    fixture = qualification._prepare_fixture(root, None, "valid")
+    qualification._write_executable(
+        root / "mock-bin" / "curl",
+        r"""#!/bin/sh
+out=''
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = '-o' ]; then out=$2; shift 2; else shift; fi
+done
+cat > "$out" <<'INSTALLER'
+#!/bin/sh
+mkdir -p "$HOME/.local/bin"
+cat > "$HOME/.local/bin/uv" <<'UV'
+#!/bin/sh
+while :; do :; done
+UV
+chmod 755 "$HOME/.local/bin/uv"
+INSTALLER
+""",
+    )
+    completed = subprocess.run(
+        ["/bin/bash", str(REPO / "install.sh")],
+        cwd=root,
+        env=os.environ | fixture,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+    assert (
+        completed.returncode,
+        "Timed out after 5 seconds" in completed.stdout,
+        "after bootstrap" in completed.stdout,
+    ) == (1, True, True)
+    assert "Install uv manually" in completed.stdout

--- a/tests/contracts/test_fresh_install_qualification.py
+++ b/tests/contracts/test_fresh_install_qualification.py
@@ -11,6 +11,8 @@ import sys
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from scripts import qualify_fresh_install as qualification
 
 REPO = Path(__file__).parents[2]
@@ -275,6 +277,10 @@ def test_run_removes_fixture_when_installer_times_out(tmp_path: Path) -> None:
     assert fixture_root.exists() is False
 
 
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="tracked: install.sh timeout contract is for macOS/Linux shell installs",
+)
 def test_installer_times_out_hanging_existing_uv(tmp_path: Path) -> None:
     # PR #1233: an existing uv shim must not block installation indefinitely.
     root = tmp_path / "existing-uv-timeout"
@@ -299,6 +305,10 @@ def test_installer_times_out_hanging_existing_uv(tmp_path: Path) -> None:
     assert "Replace or repair uv" in completed.stdout
 
 
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="tracked: install.sh timeout contract is for macOS/Linux shell installs",
+)
 def test_installer_times_out_hanging_post_bootstrap_uv(tmp_path: Path) -> None:
     # PR #1233: bootstrap validation must fail closed when the installed uv hangs.
     root = tmp_path / "bootstrap-uv-timeout"

--- a/tests/unit/cli/test_doctor_command.py
+++ b/tests/unit/cli/test_doctor_command.py
@@ -42,6 +42,20 @@ class TestCheckUv:
             result = _check_uv()
         assert (result.status, result.message) == (status, message)
 
+    def test_fail_when_uv_version_component_exceeds_integer_limit(self) -> None:
+        # PR #1233: adversarial numeric output must produce a diagnostic, not a traceback.
+        from tree_sitter_analyzer.cli.commands.doctor import _check_uv
+
+        completed = subprocess.CompletedProcess([], 0, f"uv {'1' * 5000}.11.0\n", "")
+        with patch("shutil.which", return_value="/usr/local/bin/uv"), patch(
+            "subprocess.run", return_value=completed
+        ):
+            result = _check_uv()
+        assert (result.status, result.message) == (
+            "FAIL",
+            "cannot determine version at /usr/local/bin/uv — required uv >= 0.11.0",
+        )
+
     def test_fail_when_uv_version_check_times_out(self) -> None:
         # NO1-006A (2026-08-08): doctor must not hang on a broken uv executable.
         from tree_sitter_analyzer.cli.commands.doctor import _check_uv

--- a/tests/unit/cli/test_doctor_command.py
+++ b/tests/unit/cli/test_doctor_command.py
@@ -46,7 +46,7 @@ class TestTerminateProcessTree:
         ):
             _terminate_process_tree(process)
         assert run.call_args.args[0] == [
-            r"C:\Windows/System32/taskkill.exe",
+            os.path.join(r"C:\Windows", "System32", "taskkill.exe"),
             "/PID",
             "123",
             "/T",
@@ -93,7 +93,7 @@ class TestTerminateProcessTree:
         ]
         with (
             patch("tree_sitter_analyzer.cli.commands.doctor.os.name", "posix"),
-            patch("tree_sitter_analyzer.cli.commands.doctor.os.killpg") as killpg,
+            patch("tree_sitter_analyzer.cli.commands.doctor.os.killpg", create=True) as killpg,
         ):
             _terminate_process_tree(process)
         assert killpg.call_args_list == [
@@ -116,6 +116,7 @@ class TestTerminateProcessTree:
             patch(
                 "tree_sitter_analyzer.cli.commands.doctor.os.killpg",
                 side_effect=ProcessLookupError,
+                create=True,
             ),
         ):
             _terminate_process_tree(process)

--- a/tests/unit/cli/test_doctor_command.py
+++ b/tests/unit/cli/test_doctor_command.py
@@ -83,6 +83,10 @@ class TestTerminateProcessTree:
             _terminate_process_tree(process)
         process.kill.assert_called_once_with()
 
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="tracked: POSIX process-group cleanup is covered on macOS/Linux",
+    )
     def test_posix_escalates_process_group_to_sigkill(self) -> None:
         from tree_sitter_analyzer.cli.commands.doctor import _terminate_process_tree
 
@@ -102,6 +106,10 @@ class TestTerminateProcessTree:
             ((123, 9),),
         ]
 
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="tracked: POSIX process-group cleanup is covered on macOS/Linux",
+    )
     def test_posix_tolerates_group_exiting_before_sigkill(self) -> None:
         from tree_sitter_analyzer.cli.commands.doctor import _terminate_process_tree
 
@@ -121,6 +129,10 @@ class TestTerminateProcessTree:
             ((123, 9),),
         ]
 
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="tracked: POSIX process-group cleanup is covered on macOS/Linux",
+    )
     def test_posix_reaps_after_group_is_already_gone(self) -> None:
         from tree_sitter_analyzer.cli.commands.doctor import _terminate_process_tree
 

--- a/tests/unit/cli/test_doctor_command.py
+++ b/tests/unit/cli/test_doctor_command.py
@@ -98,6 +98,7 @@ class TestTerminateProcessTree:
             _terminate_process_tree(process)
         assert killpg.call_args_list == [
             ((123, 15),),
+            ((123, 0),),
             ((123, 9),),
         ]
 
@@ -217,7 +218,7 @@ class TestCheckUv:
         child_pid_file = tmp_path / "child.pid"
         uv = tmp_path / "uv"
         uv.write_text(
-            "#!/bin/sh\nsleep 60 &\necho $! > "
+            "#!/bin/sh\nsh -c 'trap \'\' TERM; sleep 60' &\necho $! > "
             f"{child_pid_file!s}\nwait\n",
             encoding="utf-8",
         )

--- a/tests/unit/cli/test_doctor_command.py
+++ b/tests/unit/cli/test_doctor_command.py
@@ -102,6 +102,25 @@ class TestTerminateProcessTree:
             ((123, 9),),
         ]
 
+    def test_posix_tolerates_group_exiting_before_sigkill(self) -> None:
+        from tree_sitter_analyzer.cli.commands.doctor import _terminate_process_tree
+
+        process = MagicMock(pid=123)
+        with (
+            patch("tree_sitter_analyzer.cli.commands.doctor.os.name", "posix"),
+            patch(
+                "tree_sitter_analyzer.cli.commands.doctor.os.killpg",
+                side_effect=(None, None, ProcessLookupError),
+                create=True,
+            ) as killpg,
+        ):
+            _terminate_process_tree(process)
+        assert killpg.call_args_list == [
+            ((123, 15),),
+            ((123, 0),),
+            ((123, 9),),
+        ]
+
     def test_posix_reaps_after_group_is_already_gone(self) -> None:
         from tree_sitter_analyzer.cli.commands.doctor import _terminate_process_tree
 
@@ -133,6 +152,7 @@ class TestCheckUv:
             (subprocess.CompletedProcess([], 0, " uv 0.11.0\n", ""), "FAIL", "cannot determine version at /usr/local/bin/uv — required uv >= 0.11.0"),
             (subprocess.CompletedProcess([], 0, "\nuv 0.11.0\n", ""), "FAIL", "cannot determine version at /usr/local/bin/uv — required uv >= 0.11.0"),
             (subprocess.CompletedProcess([], 0, "uv 0.11.0.1\n", ""), "FAIL", "cannot determine version at /usr/local/bin/uv — required uv >= 0.11.0"),
+            (subprocess.CompletedProcess([], 0, "uv ٠.١١.٠\n", ""), "FAIL", "cannot determine version at /usr/local/bin/uv — required uv >= 0.11.0"),
             (subprocess.CompletedProcess([], 0, b"uv 0.11.0\xff\n", b""), "FAIL", "undecodable version output from /usr/local/bin/uv --version"),
         ),
     )
@@ -197,6 +217,29 @@ class TestCheckUv:
         assert (result.status, result.message) == (
             "FAIL", "timed out running /usr/local/bin/uv --version"
         )
+
+    @pytest.mark.parametrize("interruption", (KeyboardInterrupt(), BaseException("stop")))
+    def test_interruption_terminates_probe_tree_and_is_reraised(
+        self, interruption: BaseException
+    ) -> None:
+        # PR #1233: an interrupted doctor probe must not orphan its process group.
+        from tree_sitter_analyzer.cli.commands.doctor import _check_uv
+
+        process = MagicMock()
+        process.communicate.side_effect = interruption
+        with (
+            patch("shutil.which", return_value="/usr/local/bin/uv"),
+            patch(
+                "tree_sitter_analyzer.cli.commands.doctor.subprocess.Popen",
+                return_value=process,
+            ),
+            patch(
+                "tree_sitter_analyzer.cli.commands.doctor._terminate_process_tree"
+            ) as terminate,
+            pytest.raises(type(interruption), match="stop" if str(interruption) else None),
+        ):
+            _check_uv()
+        terminate.assert_called_once_with(process)
 
     def test_fail_when_uv_missing(self) -> None:
         from tree_sitter_analyzer.cli.commands.doctor import _check_uv

--- a/tests/unit/cli/test_doctor_command.py
+++ b/tests/unit/cli/test_doctor_command.py
@@ -1,30 +1,67 @@
+# fmt: off
 """Tests for --doctor CLI command (installation diagnostics)."""
 
 from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
+SUPPORTED_UV_RESULT = subprocess.CompletedProcess([], 0, "uv 0.11.0\n", "")
+
+
+def _check_configs(paths: list[tuple[str, str]]):
+    from tree_sitter_analyzer.cli.commands.doctor import _check_agent_configs
+
+    with patch("tree_sitter_analyzer.cli.commands.doctor._agent_config_paths", return_value=paths):
+        return _check_agent_configs()
+
 
 class TestCheckUv:
-    def test_pass_when_uv_found(self) -> None:
+    @pytest.mark.parametrize(
+        ("completed", "status", "message"),
+        (
+            (SUPPORTED_UV_RESULT, "PASS", "/usr/local/bin/uv (0.11.0)"),
+            (subprocess.CompletedProcess([], 0, "uv 0.10.9\n", ""), "FAIL", "0.10.9 at /usr/local/bin/uv is too old — required uv >= 0.11.0; rerun install.sh or update uv manually"),
+            (subprocess.CompletedProcess([], 0, "not-uv 0.11.0\n", ""), "FAIL", "cannot determine version at /usr/local/bin/uv — required uv >= 0.11.0"),
+            (subprocess.CompletedProcess([], 0, " uv 0.11.0\n", ""), "FAIL", "cannot determine version at /usr/local/bin/uv — required uv >= 0.11.0"),
+            (subprocess.CompletedProcess([], 0, "\nuv 0.11.0\n", ""), "FAIL", "cannot determine version at /usr/local/bin/uv — required uv >= 0.11.0"),
+            (subprocess.CompletedProcess([], 0, "uv 0.11.0.1\n", ""), "FAIL", "cannot determine version at /usr/local/bin/uv — required uv >= 0.11.0"),
+            (subprocess.CompletedProcess([], 0, b"uv 0.11.0\xff\n", b""), "FAIL", "undecodable version output from /usr/local/bin/uv --version"),
+        ),
+    )
+    def test_uv_version_boundary(self, completed, status, message) -> None:
         from tree_sitter_analyzer.cli.commands.doctor import _check_uv
 
-        with patch("shutil.which", return_value="/usr/local/bin/uv"):
+        with patch("shutil.which", return_value="/usr/local/bin/uv"), patch("subprocess.run", return_value=completed):
             result = _check_uv()
-        assert result.status == "PASS"
-        assert result.message == "/usr/local/bin/uv"
+        assert (result.status, result.message) == (status, message)
+
+    def test_fail_when_uv_version_check_times_out(self) -> None:
+        # NO1-006A (2026-08-08): doctor must not hang on a broken uv executable.
+        from tree_sitter_analyzer.cli.commands.doctor import _check_uv
+
+        with patch("shutil.which", return_value="/usr/local/bin/uv"), patch(
+            "subprocess.run", side_effect=subprocess.TimeoutExpired(["uv", "--version"], 5)
+        ):
+            result = _check_uv()
+        assert (result.status, result.message) == (
+            "FAIL", "timed out running /usr/local/bin/uv --version"
+        )
 
     def test_fail_when_uv_missing(self) -> None:
         from tree_sitter_analyzer.cli.commands.doctor import _check_uv
 
         with patch("shutil.which", return_value=None):
             result = _check_uv()
-        assert result.status == "FAIL"
-        assert "not found" in result.message
+        assert (result.status, result.message) == (
+            "FAIL", "not found — install from https://docs.astral.sh/uv/"
+        )
 
 
 class TestCheckUvx:
@@ -117,22 +154,16 @@ class TestCheckProjectRoot:
 
 class TestCheckAgentConfigs:
     def test_warn_when_no_config_files_exist(self, tmp_path: Path) -> None:
-        from tree_sitter_analyzer.cli.commands.doctor import _check_agent_configs
 
         fake_paths = [
             ("Test Agent", str(tmp_path / "nonexistent.json")),
         ]
-        with patch(
-            "tree_sitter_analyzer.cli.commands.doctor._agent_config_paths",
-            return_value=fake_paths,
-        ):
-            results = _check_agent_configs()
+        results = _check_configs(fake_paths)
         assert len(results) == 1
         assert results[0].status == "WARN"
         assert "not found" in results[0].message
 
     def test_pass_when_tsa_entry_present_and_absolute(self, tmp_path: Path) -> None:
-        from tree_sitter_analyzer.cli.commands.doctor import _check_agent_configs
 
         config = tmp_path / "mcp.json"
         config.write_text(
@@ -149,30 +180,20 @@ class TestCheckAgentConfigs:
             ),
             encoding="utf-8",
         )
-        with patch(
-            "tree_sitter_analyzer.cli.commands.doctor._agent_config_paths",
-            return_value=[("Test Agent", str(config))],
-        ):
-            results = _check_agent_configs()
+        results = _check_configs([("Test Agent", str(config))])
         assert len(results) == 1
         assert results[0].status == "PASS"
 
     def test_warn_when_tsa_entry_missing(self, tmp_path: Path) -> None:
-        from tree_sitter_analyzer.cli.commands.doctor import _check_agent_configs
 
         config = tmp_path / "mcp.json"
         config.write_text(json.dumps({"mcpServers": {}}), encoding="utf-8")
-        with patch(
-            "tree_sitter_analyzer.cli.commands.doctor._agent_config_paths",
-            return_value=[("Test Agent", str(config))],
-        ):
-            results = _check_agent_configs()
+        results = _check_configs([("Test Agent", str(config))])
         assert len(results) == 1
         assert results[0].status == "WARN"
         assert "not found" in results[0].message
 
     def test_warn_when_tsa_entry_has_relative_root(self, tmp_path: Path) -> None:
-        from tree_sitter_analyzer.cli.commands.doctor import _check_agent_configs
 
         config = tmp_path / "mcp.json"
         config.write_text(
@@ -189,28 +210,59 @@ class TestCheckAgentConfigs:
             ),
             encoding="utf-8",
         )
-        with patch(
-            "tree_sitter_analyzer.cli.commands.doctor._agent_config_paths",
-            return_value=[("Test Agent", str(config))],
-        ):
-            results = _check_agent_configs()
+        results = _check_configs([("Test Agent", str(config))])
         assert len(results) == 1
         assert results[0].status == "WARN"
         assert "relative path" in results[0].message
 
-    def test_warn_when_json_parse_error(self, tmp_path: Path) -> None:
-        from tree_sitter_analyzer.cli.commands.doctor import _check_agent_configs
+    @pytest.mark.parametrize(
+        "content",
+        ("{ invalid json }", '{"mcpServers": ' + "1" * 5000 + "}", "[" * 100_000 + "]" * 100_000),
+        ids=("syntax", "integer-limit", "nesting-limit"),
+    )
+    def test_warn_when_json_decoder_rejects_content(
+        self, tmp_path: Path, content: str
+    ) -> None:
 
         config = tmp_path / "mcp.json"
-        config.write_text("{ invalid json }", encoding="utf-8")
-        with patch(
-            "tree_sitter_analyzer.cli.commands.doctor._agent_config_paths",
-            return_value=[("Test Agent", str(config))],
-        ):
-            results = _check_agent_configs()
+        config.write_text(content, encoding="utf-8")
+        results = _check_configs([("Test Agent", str(config))])
         assert len(results) == 1
         assert results[0].status == "WARN"
-        assert "cannot read" in results[0].message
+        assert results[0].message == f"cannot read {config}: invalid JSON content"
+
+    def test_warn_when_config_open_fails(self, tmp_path: Path) -> None:
+        config = tmp_path / "mcp.json"
+        config.touch()
+        with patch("builtins.open", side_effect=OSError("denied")):
+            results = _check_configs([("Test Agent", str(config))])
+        assert results[0].status == "WARN"
+        assert results[0].message == f"cannot read {config}: denied"
+
+    @pytest.mark.parametrize(
+        ("content", "message"),
+        (
+            ("[]", "config root must be a JSON object: {config}"),
+            ('{"mcpServers": []}', "mcpServers must be a JSON object: {config}"),
+            ('{"mcpServers": {"tree-sitter-analyzer": []}}', "MCP entry 'tree-sitter-analyzer' must be a JSON object: {config}"),
+            ('{"mcpServers": {"tree-sitter-analyzer": {"env": []}}}', "MCP entry 'tree-sitter-analyzer'.env must be a JSON object: {config}"),
+            ('{"mcpServers": {"tree-sitter-analyzer": {"env": {"TREE_SITTER_PROJECT_ROOT": []}}}}', "TREE_SITTER_PROJECT_ROOT must be a string in MCP entry 'tree-sitter-analyzer': {config}"),
+        ),
+    )
+    def test_warn_when_config_boundary_is_not_object_or_string(
+        self, tmp_path: Path, content: str, message: str
+    ) -> None:
+        from tree_sitter_analyzer.cli.commands.doctor import (
+            CheckResult,
+        )
+
+        config = tmp_path / "mcp.json"
+        config.write_text(content, encoding="utf-8")
+        results = _check_configs([("Test Agent", str(config))])
+        assert results == [
+            CheckResult("agent config: Test Agent", "WARN", message.format(config=config))
+        ]
+
 
 
 class TestRunDoctor:
@@ -219,6 +271,7 @@ class TestRunDoctor:
 
         with (
             patch("shutil.which", return_value="/usr/bin/tool"),
+            patch("subprocess.run", return_value=SUPPORTED_UV_RESULT),
             patch.dict(os.environ, {"TREE_SITTER_PROJECT_ROOT": str(tmp_path)}),
             patch(
                 "tree_sitter_analyzer.cli.commands.doctor._check_agent_configs",
@@ -402,6 +455,7 @@ class TestHandleDoctor:
 
         with (
             patch("shutil.which", return_value="/usr/bin/uv"),
+            patch("subprocess.run", return_value=SUPPORTED_UV_RESULT),
             patch.dict(os.environ, {"TREE_SITTER_PROJECT_ROOT": str(tmp_path)}),
             patch(
                 "tree_sitter_analyzer.cli.commands.doctor._check_agent_configs",

--- a/tests/unit/cli/test_doctor_command.py
+++ b/tests/unit/cli/test_doctor_command.py
@@ -7,12 +7,21 @@ import json
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 SUPPORTED_UV_RESULT = subprocess.CompletedProcess([], 0, "uv 0.11.0\n", "")
+
+
+def _probe_process(completed: subprocess.CompletedProcess):
+    process = MagicMock()
+    process.args = completed.args
+    process.returncode = completed.returncode
+    process.communicate.return_value = (completed.stdout, completed.stderr)
+    return process
 
 
 def _check_configs(paths: list[tuple[str, str]]):
@@ -20,6 +29,96 @@ def _check_configs(paths: list[tuple[str, str]]):
 
     with patch("tree_sitter_analyzer.cli.commands.doctor._agent_config_paths", return_value=paths):
         return _check_agent_configs()
+
+
+class TestTerminateProcessTree:
+    def test_windows_uses_taskkill_for_descendants(self) -> None:
+        from tree_sitter_analyzer.cli.commands.doctor import _terminate_process_tree
+
+        process = MagicMock(pid=123)
+        terminated = subprocess.CompletedProcess([], 0)
+        with (
+            patch("tree_sitter_analyzer.cli.commands.doctor.os.name", "nt"),
+            patch(
+                "tree_sitter_analyzer.cli.commands.doctor.subprocess.run",
+                return_value=terminated,
+            ) as run,
+        ):
+            _terminate_process_tree(process)
+        assert run.call_args.args[0] == [
+            r"C:\Windows/System32/taskkill.exe",
+            "/PID",
+            "123",
+            "/T",
+            "/F",
+        ]
+        process.kill.assert_not_called()
+
+    def test_windows_falls_back_when_taskkill_returns_failure(self) -> None:
+        from tree_sitter_analyzer.cli.commands.doctor import _terminate_process_tree
+
+        process = MagicMock(pid=123)
+        terminated = subprocess.CompletedProcess([], 1)
+        with (
+            patch("tree_sitter_analyzer.cli.commands.doctor.os.name", "nt"),
+            patch(
+                "tree_sitter_analyzer.cli.commands.doctor.subprocess.run",
+                return_value=terminated,
+            ),
+        ):
+            _terminate_process_tree(process)
+        process.kill.assert_called_once_with()
+
+    def test_windows_falls_back_when_taskkill_fails(self) -> None:
+        from tree_sitter_analyzer.cli.commands.doctor import _terminate_process_tree
+
+        process = MagicMock(pid=123)
+        with (
+            patch("tree_sitter_analyzer.cli.commands.doctor.os.name", "nt"),
+            patch(
+                "tree_sitter_analyzer.cli.commands.doctor.subprocess.run",
+                side_effect=OSError("taskkill unavailable"),
+            ),
+        ):
+            _terminate_process_tree(process)
+        process.kill.assert_called_once_with()
+
+    def test_posix_escalates_process_group_to_sigkill(self) -> None:
+        from tree_sitter_analyzer.cli.commands.doctor import _terminate_process_tree
+
+        process = MagicMock(pid=123)
+        process.communicate.side_effect = [
+            subprocess.TimeoutExpired([], 1),
+            (b"", b""),
+        ]
+        with (
+            patch("tree_sitter_analyzer.cli.commands.doctor.os.name", "posix"),
+            patch("tree_sitter_analyzer.cli.commands.doctor.os.killpg") as killpg,
+        ):
+            _terminate_process_tree(process)
+        assert killpg.call_args_list == [
+            ((123, 15),),
+            ((123, 9),),
+        ]
+
+    def test_posix_reaps_after_group_is_already_gone(self) -> None:
+        from tree_sitter_analyzer.cli.commands.doctor import _terminate_process_tree
+
+        process = MagicMock(pid=123)
+        process.communicate.side_effect = [
+            subprocess.TimeoutExpired([], 1),
+            subprocess.TimeoutExpired([], 1),
+            (b"", b""),
+        ]
+        with (
+            patch("tree_sitter_analyzer.cli.commands.doctor.os.name", "posix"),
+            patch(
+                "tree_sitter_analyzer.cli.commands.doctor.os.killpg",
+                side_effect=ProcessLookupError,
+            ),
+        ):
+            _terminate_process_tree(process)
+        process.kill.assert_called_once_with()
 
 
 class TestCheckUv:
@@ -38,7 +137,7 @@ class TestCheckUv:
     def test_uv_version_boundary(self, completed, status, message) -> None:
         from tree_sitter_analyzer.cli.commands.doctor import _check_uv
 
-        with patch("shutil.which", return_value="/usr/local/bin/uv"), patch("subprocess.run", return_value=completed):
+        with patch("shutil.which", return_value="/usr/local/bin/uv"), patch("tree_sitter_analyzer.cli.commands.doctor.subprocess.Popen", return_value=_probe_process(completed)):
             result = _check_uv()
         assert (result.status, result.message) == (status, message)
 
@@ -48,7 +147,8 @@ class TestCheckUv:
 
         completed = subprocess.CompletedProcess([], 0, f"uv {'1' * 5000}.11.0\n", "")
         with patch("shutil.which", return_value="/usr/local/bin/uv"), patch(
-            "subprocess.run", return_value=completed
+            "tree_sitter_analyzer.cli.commands.doctor.subprocess.Popen",
+            return_value=_probe_process(completed),
         ):
             result = _check_uv()
         assert (result.status, result.message) == (
@@ -56,14 +156,42 @@ class TestCheckUv:
             "cannot determine version at /usr/local/bin/uv — required uv >= 0.11.0",
         )
 
+    def test_windows_probe_starts_in_new_process_group(self) -> None:
+        from tree_sitter_analyzer.cli.commands.doctor import _check_uv
+
+        process = _probe_process(SUPPORTED_UV_RESULT)
+        with (
+            patch("shutil.which", return_value=r"C:\tools\uv.exe"),
+            patch("tree_sitter_analyzer.cli.commands.doctor.os.name", "nt"),
+            patch(
+                "tree_sitter_analyzer.cli.commands.doctor.subprocess.Popen",
+                return_value=process,
+            ) as popen,
+        ):
+            result = _check_uv()
+        assert (result.status, popen.call_args.kwargs["creationflags"]) == (
+            "PASS",
+            0x00000200,
+        )
+
     def test_fail_when_uv_version_check_times_out(self) -> None:
         # NO1-006A (2026-08-08): doctor must not hang on a broken uv executable.
         from tree_sitter_analyzer.cli.commands.doctor import _check_uv
 
-        with patch("shutil.which", return_value="/usr/local/bin/uv"), patch(
-            "subprocess.run", side_effect=subprocess.TimeoutExpired(["uv", "--version"], 5)
+        process = MagicMock()
+        process.communicate.side_effect = subprocess.TimeoutExpired(
+            ["uv", "--version"], 5
+        )
+        with (
+            patch("shutil.which", return_value="/usr/local/bin/uv"),
+            patch(
+                "tree_sitter_analyzer.cli.commands.doctor.subprocess.Popen",
+                return_value=process,
+            ),
+            patch("tree_sitter_analyzer.cli.commands.doctor._terminate_process_tree") as terminate,
         ):
             result = _check_uv()
+        terminate.assert_called_once_with(process)
         assert (result.status, result.message) == (
             "FAIL", "timed out running /usr/local/bin/uv --version"
         )
@@ -76,6 +204,38 @@ class TestCheckUv:
         assert (result.status, result.message) == (
             "FAIL", "not found — install from https://docs.astral.sh/uv/"
         )
+
+    @pytest.mark.slow_ok
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="tracked: POSIX process-group cleanup has a separate Windows implementation",
+    )
+    def test_timeout_terminates_uv_descendant(self, tmp_path: Path) -> None:
+        # PR #1233: doctor timeout cleanup must not orphan a uv shim's child.
+        from tree_sitter_analyzer.cli.commands.doctor import _check_uv
+
+        child_pid_file = tmp_path / "child.pid"
+        uv = tmp_path / "uv"
+        uv.write_text(
+            "#!/bin/sh\nsleep 60 &\necho $! > "
+            f"{child_pid_file!s}\nwait\n",
+            encoding="utf-8",
+        )
+        uv.chmod(0o755)
+        with patch("shutil.which", return_value=str(uv)):
+            result = _check_uv()
+
+        child_pid = int(child_pid_file.read_text(encoding="utf-8"))
+        deadline = time.monotonic() + 3
+        child_exited = False
+        while time.monotonic() < deadline:
+            try:
+                os.kill(child_pid, 0)
+            except ProcessLookupError:
+                child_exited = True
+                break
+            time.sleep(0.05)
+        assert (result.status, child_exited) == ("FAIL", True)
 
 
 class TestCheckUvx:
@@ -285,7 +445,7 @@ class TestRunDoctor:
 
         with (
             patch("shutil.which", return_value="/usr/bin/tool"),
-            patch("subprocess.run", return_value=SUPPORTED_UV_RESULT),
+            patch("tree_sitter_analyzer.cli.commands.doctor.subprocess.Popen", return_value=_probe_process(SUPPORTED_UV_RESULT)),
             patch.dict(os.environ, {"TREE_SITTER_PROJECT_ROOT": str(tmp_path)}),
             patch(
                 "tree_sitter_analyzer.cli.commands.doctor._check_agent_configs",
@@ -469,7 +629,7 @@ class TestHandleDoctor:
 
         with (
             patch("shutil.which", return_value="/usr/bin/uv"),
-            patch("subprocess.run", return_value=SUPPORTED_UV_RESULT),
+            patch("tree_sitter_analyzer.cli.commands.doctor.subprocess.Popen", return_value=_probe_process(SUPPORTED_UV_RESULT)),
             patch.dict(os.environ, {"TREE_SITTER_PROJECT_ROOT": str(tmp_path)}),
             patch(
                 "tree_sitter_analyzer.cli.commands.doctor._check_agent_configs",

--- a/tests/unit/cli/test_install_skills.py
+++ b/tests/unit/cli/test_install_skills.py
@@ -5,6 +5,7 @@ RED-first tests written before the implementation.
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import subprocess
@@ -646,7 +647,7 @@ class TestInstallScriptUvVersion:
         }
         if disable_bootstrap:
             env["TSA_DISABLE_UNVERIFIED_UV_BOOTSTRAP"] = "1"
-        (tmp_path / "home").mkdir()
+        (tmp_path / "home").mkdir(exist_ok=True)
         return subprocess.run(
             ["/bin/bash", str(repo / "install.sh")],
             cwd=tmp_path,
@@ -702,6 +703,32 @@ class TestInstallScriptUvVersion:
         )
         assert "📦 Updating uv automatically..." in result.stdout
         assert (tmp_path / "curl-log").exists() is True
+
+    def test_agent_config_symlink_target_is_updated_without_replacing_link(
+        self, tmp_path: Path
+    ) -> None:
+        home = tmp_path / "home"
+        (home / ".claude").mkdir(parents=True)
+        managed = tmp_path / "managed-mcp.json"
+        managed.write_text('{"mcpServers": {}}', encoding="utf-8")
+        link = home / ".claude" / ".mcp.json"
+        link.symlink_to(managed)
+        result = self._run(tmp_path, "uv 0.11.0")
+        assert result.returncode == 0
+        assert link.is_symlink()
+        data = json.loads(managed.read_text(encoding="utf-8"))
+        assert data["mcpServers"]["tree-sitter-analyzer"]["command"] == "uvx"
+
+    def test_bootstrap_signal_traps_terminate_after_exit_cleanup(self) -> None:
+        installer = (Path(__file__).parents[3] / "install.sh").read_text(
+            encoding="utf-8"
+        )
+        assert """trap 'rm -f "$UV_INSTALLER_FILE"' EXIT""" in installer
+        assert tuple(re.findall(r"trap 'exit (\d+)' (HUP|INT|TERM)", installer)) == (
+            ("129", "HUP"),
+            ("130", "INT"),
+            ("143", "TERM"),
+        )
 
     def test_secure_opt_out_blocks_bootstrap_with_actionable_recovery(
         self, tmp_path: Path

--- a/tests/unit/cli/test_install_skills.py
+++ b/tests/unit/cli/test_install_skills.py
@@ -596,6 +596,10 @@ class TestSkillContentSync:
         )
 
 
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="tracked: install.sh supports macOS/Linux; Windows uses PowerShell",
+)
 class TestInstallScriptUvVersion:
     def test_uv_minimum_matches_project_contract(self) -> None:
         # NO1-006A (2026-08-08): installer and doctor must track tool.uv exactly.

--- a/tests/unit/cli/test_install_skills.py
+++ b/tests/unit/cli/test_install_skills.py
@@ -704,6 +704,10 @@ class TestInstallScriptUvVersion:
         assert "📦 Updating uv automatically..." in result.stdout
         assert (tmp_path / "curl-log").exists() is True
 
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="tracked: install.sh is macOS/Linux-only; Windows uses PowerShell",
+    )
     def test_agent_config_symlink_target_is_updated_without_replacing_link(
         self, tmp_path: Path
     ) -> None:

--- a/tests/unit/cli/test_install_skills.py
+++ b/tests/unit/cli/test_install_skills.py
@@ -708,6 +708,65 @@ class TestInstallScriptUvVersion:
         assert "📦 Updating uv automatically..." in result.stdout
         assert (tmp_path / "curl-log").exists() is True
 
+    def test_agent_config_missing_mcp_servers_is_created(self, tmp_path: Path) -> None:
+        # PR #1233: a missing key remains distinct from an explicit null value.
+        config = tmp_path / "home" / ".claude" / ".mcp.json"
+        config.parent.mkdir(parents=True)
+        config.write_text("{}", encoding="utf-8")
+        result = self._run(tmp_path, "uv 0.11.0")
+        data = json.loads(config.read_text(encoding="utf-8"))
+        assert (
+            result.returncode,
+            data["mcpServers"]["tree-sitter-analyzer"]["command"],
+        ) == (0, "uvx")
+
+    def test_agent_config_explicit_null_mcp_servers_fails_closed(
+        self, tmp_path: Path
+    ) -> None:
+        # PR #1233: explicit null is malformed input, not an absent key.
+        config = tmp_path / "home" / ".claude" / ".mcp.json"
+        config.parent.mkdir(parents=True)
+        original = '{"mcpServers": null}\n'
+        config.write_text(original, encoding="utf-8")
+        result = self._run(tmp_path, "uv 0.11.0")
+        assert (
+            result.returncode,
+            config.read_text(encoding="utf-8"),
+            list(config.parent.glob(".mcp.json.bak.*")),
+        ) == (1, original, [])
+
+    def test_read_only_agent_config_fails_closed(self, tmp_path: Path) -> None:
+        # PR #1233: atomic replacement must respect a target marked read-only.
+        config = tmp_path / "home" / ".claude" / ".mcp.json"
+        config.parent.mkdir(parents=True)
+        original = '{"mcpServers": {}}\n'
+        config.write_text(original, encoding="utf-8")
+        config.chmod(0o444)
+        result = self._run(tmp_path, "uv 0.11.0")
+        assert (
+            result.returncode,
+            config.read_text(encoding="utf-8"),
+            config.stat().st_mode & 0o777,
+        ) == (1, original, 0o444)
+
+    def test_read_only_symlink_target_fails_closed(self, tmp_path: Path) -> None:
+        # PR #1233: permission checks must inspect the resolved managed target.
+        config_dir = tmp_path / "home" / ".claude"
+        config_dir.mkdir(parents=True)
+        target = tmp_path / "managed-mcp.json"
+        original = '{"mcpServers": {}}\n'
+        target.write_text(original, encoding="utf-8")
+        target.chmod(0o444)
+        link = config_dir / ".mcp.json"
+        link.symlink_to(target)
+        result = self._run(tmp_path, "uv 0.11.0")
+        assert (
+            result.returncode,
+            link.is_symlink(),
+            target.read_text(encoding="utf-8"),
+            target.stat().st_mode & 0o777,
+        ) == (1, True, original, 0o444)
+
     @pytest.mark.skipif(
         os.name == "nt",
         reason="tracked: install.sh is macOS/Linux-only; Windows uses PowerShell",

--- a/tests/unit/cli/test_install_skills.py
+++ b/tests/unit/cli/test_install_skills.py
@@ -5,7 +5,12 @@ RED-first tests written before the implementation.
 
 from __future__ import annotations
 
+import os
+import re
+import subprocess
 from pathlib import Path
+
+import pytest
 
 # ---------------------------------------------------------------------------
 # D1a — bundled skills exist inside the package at install time
@@ -588,3 +593,125 @@ class TestSkillContentSync:
             "Replace with facade+action form (e.g. 'safe_to_edit(' → "
             "'edit action=safe'). Violations: " + str(violations)
         )
+
+
+class TestInstallScriptUvVersion:
+    def test_uv_minimum_matches_project_contract(self) -> None:
+        # NO1-006A (2026-08-08): installer and doctor must track tool.uv exactly.
+        repo = Path(__file__).parents[3]
+        pyproject_versions = re.findall(
+            r'^required-version = ">=([0-9]+\.[0-9]+\.[0-9]+)"$',
+            (repo / "pyproject.toml").read_text(encoding="utf-8"),
+            flags=re.MULTILINE,
+        )
+        installer_versions = re.findall(
+            r'^MINIMUM_UV_VERSION="([0-9]+\.[0-9]+\.[0-9]+)"$',
+            (repo / "install.sh").read_text(encoding="utf-8"),
+            flags=re.MULTILINE,
+        )
+        from tree_sitter_analyzer.cli.commands.doctor import MINIMUM_UV_VERSION
+
+        assert pyproject_versions == ["0.11.0"]
+        assert installer_versions == pyproject_versions
+        assert ".".join(str(part) for part in MINIMUM_UV_VERSION) == "0.11.0"
+
+    @staticmethod
+    def _run(
+        tmp_path: Path, output: str, *, disable_bootstrap: bool = False
+    ) -> subprocess.CompletedProcess[str]:
+        repo = Path(__file__).parents[3]
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        version_file = tmp_path / "uv-version"
+        version_file.write_text(output, encoding="utf-8")
+        (bin_dir / "uv").write_text(
+            '#!/bin/sh\nprintf "%s\\n" "$(cat "$UV_VERSION_FILE")"\n',
+            encoding="utf-8",
+        )
+        (bin_dir / "curl").write_text(
+            '#!/bin/sh\nprintf "%s\\n" "$*" > "$CURL_LOG"\n'
+            'while [ "$#" -gt 0 ]; do '
+            'if [ "$1" = "-o" ]; then out=$2; shift 2; else shift; fi; done\n'
+            "printf '%s\\n' '#!/bin/sh' "
+            '\'printf "uv 0.11.0" > "$UV_VERSION_FILE"\' > "$out"\n',
+            encoding="utf-8",
+        )
+        (bin_dir / "uv").chmod(0o755)
+        (bin_dir / "curl").chmod(0o755)
+        env = os.environ | {
+            "HOME": str(tmp_path / "home"),
+            "PATH": f"{bin_dir}:/usr/bin:/bin",
+            "UV_VERSION_FILE": str(version_file),
+            "CURL_LOG": str(tmp_path / "curl-log"),
+        }
+        if disable_bootstrap:
+            env["TSA_DISABLE_UNVERIFIED_UV_BOOTSTRAP"] = "1"
+        (tmp_path / "home").mkdir()
+        return subprocess.run(
+            ["/bin/bash", str(repo / "install.sh")],
+            cwd=tmp_path,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_supported_uv_is_not_upgraded(self, tmp_path: Path) -> None:
+        result = self._run(tmp_path, "uv 0.11.0")
+        assert result.returncode == 0
+        assert (
+            result.stdout.splitlines()[0] == f"✅ uv 0.11.0: {tmp_path / 'bin' / 'uv'}"
+        )
+        assert (tmp_path / "curl-log").exists() is False
+
+    def test_old_uv_is_conditionally_updated(self, tmp_path: Path) -> None:
+        # NO1-006A (2026-08-08): only versions below the project floor are updated.
+        result = self._run(tmp_path, "uv 0.10.9")
+        assert result.returncode == 0
+        assert (
+            result.stdout.splitlines()[0]
+            == "📦 uv 0.10.9 does not satisfy required uv >= 0.11.0. Automatic update is required."
+        )
+        assert (tmp_path / "uv-version").read_text(encoding="utf-8") == "uv 0.11.0"
+        curl_log = (tmp_path / "curl-log").read_text(encoding="utf-8")
+        assert (
+            re.fullmatch(
+                r"--proto =https --tlsv1\.2 -LsSf https://astral\.sh/uv/install\.sh -o /[^\n ]+/tsa-uv-installer\.[A-Za-z0-9]+\n",
+                curl_log,
+            )
+            is not None
+        )
+
+    @pytest.mark.parametrize("output", ("not-uv 0.11.0", "uv 0.11.0.1"))
+    def test_malformed_uv_version_is_updated(self, tmp_path: Path, output: str) -> None:
+        result = self._run(tmp_path, output)
+        assert (result.returncode, result.stdout.splitlines()[0]) == (
+            0,
+            f"📦 {output} does not satisfy required uv >= 0.11.0. Automatic update is required.",
+        )
+        assert (tmp_path / "uv-version").read_text(encoding="utf-8") == "uv 0.11.0"
+
+    def test_default_bootstrap_warns_that_mutable_code_is_unverified(
+        self, tmp_path: Path
+    ) -> None:
+        result = self._run(tmp_path, "uv 0.10.9")
+        assert result.returncode == 0
+        assert (
+            "⚠️  WARNING: the official uv bootstrap is UNVERIFIED and mutable "
+            "(not content-bound)." in result.stdout
+        )
+        assert "📦 Updating uv automatically..." in result.stdout
+        assert (tmp_path / "curl-log").exists() is True
+
+    def test_secure_opt_out_blocks_bootstrap_with_actionable_recovery(
+        self, tmp_path: Path
+    ) -> None:
+        result = self._run(tmp_path, "uv 0.10.9", disable_bootstrap=True)
+        assert result.returncode == 1
+        assert (
+            "Automatic uv bootstrap disabled by "
+            "TSA_DISABLE_UNVERIFIED_UV_BOOTSTRAP=1." in result.stdout
+        )
+        assert "Install uv >= 0.11.0 manually" in result.stdout
+        assert "Updating uv automatically" not in result.stdout
+        assert (tmp_path / "curl-log").exists() is False

--- a/tree_sitter_analyzer/cli/commands/doctor.py
+++ b/tree_sitter_analyzer/cli/commands/doctor.py
@@ -60,7 +60,14 @@ def _check_uv() -> CheckResult:
             f"cannot determine version at {path} — required uv >= 0.11.0",
         )
 
-    version = tuple(int(part) for part in match.groups())
+    try:
+        version = tuple(int(part) for part in match.groups())
+    except ValueError:
+        return CheckResult(
+            "uv",
+            "FAIL",
+            f"cannot determine version at {path} — required uv >= 0.11.0",
+        )
     if version < MINIMUM_UV_VERSION:
         version_text = ".".join(str(part) for part in version)
         return CheckResult(

--- a/tree_sitter_analyzer/cli/commands/doctor.py
+++ b/tree_sitter_analyzer/cli/commands/doctor.py
@@ -47,8 +47,15 @@ def _terminate_process_tree(process: subprocess.Popen[bytes]) -> None:
             pass
         try:
             process.communicate(timeout=1)
-            return
         except subprocess.TimeoutExpired:
+            pass
+        # Reaping the direct shim does not prove that its descendants exited.
+        # Probe the isolated group, then escalate any surviving member.
+        try:
+            os.killpg(process.pid, 0)
+        except ProcessLookupError:
+            pass
+        else:
             try:
                 os.killpg(process.pid, signal.SIGKILL)
             except ProcessLookupError:

--- a/tree_sitter_analyzer/cli/commands/doctor.py
+++ b/tree_sitter_analyzer/cli/commands/doctor.py
@@ -6,6 +6,7 @@ import json
 import os
 import re
 import shutil
+import signal
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -22,6 +23,43 @@ class CheckResult:
 MINIMUM_UV_VERSION = (0, 11, 0)
 
 
+def _terminate_process_tree(process: subprocess.Popen[bytes]) -> None:
+    """Terminate a timed-out probe and every descendant in its isolated group."""
+    if os.name == "nt":
+        system_root = os.environ.get("SystemRoot", r"C:\Windows")
+        taskkill = os.path.join(system_root, "System32", "taskkill.exe")
+        try:
+            terminated = subprocess.run(  # noqa: S603 - fixed executable/arguments
+                [taskkill, "/PID", str(process.pid), "/T", "/F"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+                timeout=5,
+            )
+            if terminated.returncode != 0:
+                process.kill()
+        except (OSError, subprocess.TimeoutExpired):
+            process.kill()
+    else:
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        try:
+            process.communicate(timeout=1)
+            return
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+    try:
+        process.communicate(timeout=1)
+    except (OSError, subprocess.TimeoutExpired):
+        process.kill()
+        process.communicate()
+
+
 def _check_uv() -> CheckResult:
     path = shutil.which("uv")
     if not path:
@@ -30,29 +68,46 @@ def _check_uv() -> CheckResult:
         )
 
     try:
-        completed = subprocess.run(  # noqa: S603 - resolved executable, fixed argument
-            [path, "--version"],
-            capture_output=True,
-            check=False,
-            timeout=5,
+        if os.name == "nt":
+            process = subprocess.Popen(  # noqa: S603 - resolved executable
+                [path, "--version"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                creationflags=0x00000200,  # CREATE_NEW_PROCESS_GROUP
+            )
+        else:
+            process = subprocess.Popen(  # noqa: S603 - resolved executable
+                [path, "--version"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                start_new_session=True,
+            )
+        try:
+            probe_stdout, probe_stderr = process.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            _terminate_process_tree(process)
+            return CheckResult("uv", "FAIL", f"timed out running {path} --version")
+        completed = subprocess.CompletedProcess(
+            process.args, process.returncode, probe_stdout, probe_stderr
         )
-    except subprocess.TimeoutExpired:
-        return CheckResult("uv", "FAIL", f"timed out running {path} --version")
     except OSError as exc:
         return CheckResult("uv", "FAIL", f"cannot run {path}: {exc}")
 
     try:
-        stdout = (
-            completed.stdout.decode("utf-8", errors="strict")
-            if isinstance(completed.stdout, bytes)
-            else completed.stdout
+        raw_stdout = completed.stdout
+        decoded_stdout: str = (
+            raw_stdout.decode("utf-8", errors="strict")
+            if isinstance(raw_stdout, bytes)
+            else raw_stdout
         )
     except UnicodeDecodeError:
         return CheckResult(
             "uv", "FAIL", f"undecodable version output from {path} --version"
         )
 
-    match = re.fullmatch(r"uv (\d+)\.(\d+)\.(\d+)(?:[ \t]+.*)?", stdout.rstrip("\n"))
+    match = re.fullmatch(
+        r"uv (\d+)\.(\d+)\.(\d+)(?:[ \t]+.*)?", decoded_stdout.rstrip("\n")
+    )
     if completed.returncode != 0 or match is None:
         return CheckResult(
             "uv",

--- a/tree_sitter_analyzer/cli/commands/doctor.py
+++ b/tree_sitter_analyzer/cli/commands/doctor.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
+import subprocess
 import sys
 from dataclasses import dataclass
 from typing import Literal
@@ -17,13 +19,57 @@ class CheckResult:
     message: str
 
 
+MINIMUM_UV_VERSION = (0, 11, 0)
+
+
 def _check_uv() -> CheckResult:
     path = shutil.which("uv")
-    if path:
-        return CheckResult("uv", "PASS", path)
-    return CheckResult(
-        "uv", "FAIL", "not found — install from https://docs.astral.sh/uv/"
-    )
+    if not path:
+        return CheckResult(
+            "uv", "FAIL", "not found — install from https://docs.astral.sh/uv/"
+        )
+
+    try:
+        completed = subprocess.run(  # noqa: S603 - resolved executable, fixed argument
+            [path, "--version"],
+            capture_output=True,
+            check=False,
+            timeout=5,
+        )
+    except subprocess.TimeoutExpired:
+        return CheckResult("uv", "FAIL", f"timed out running {path} --version")
+    except OSError as exc:
+        return CheckResult("uv", "FAIL", f"cannot run {path}: {exc}")
+
+    try:
+        stdout = (
+            completed.stdout.decode("utf-8", errors="strict")
+            if isinstance(completed.stdout, bytes)
+            else completed.stdout
+        )
+    except UnicodeDecodeError:
+        return CheckResult(
+            "uv", "FAIL", f"undecodable version output from {path} --version"
+        )
+
+    match = re.fullmatch(r"uv (\d+)\.(\d+)\.(\d+)(?:[ \t]+.*)?", stdout.rstrip("\n"))
+    if completed.returncode != 0 or match is None:
+        return CheckResult(
+            "uv",
+            "FAIL",
+            f"cannot determine version at {path} — required uv >= 0.11.0",
+        )
+
+    version = tuple(int(part) for part in match.groups())
+    if version < MINIMUM_UV_VERSION:
+        version_text = ".".join(str(part) for part in version)
+        return CheckResult(
+            "uv",
+            "FAIL",
+            f"{version_text} at {path} is too old — required uv >= 0.11.0; "
+            "rerun install.sh or update uv manually",
+        )
+    return CheckResult("uv", "PASS", f"{path} ({'.'.join(match.groups())})")
 
 
 def _check_uvx() -> CheckResult:
@@ -147,11 +193,28 @@ def _check_agent_configs() -> list[CheckResult]:
         try:
             with open(path, encoding="utf-8") as f:
                 data = json.load(f)
-        except (json.JSONDecodeError, OSError) as exc:
+        except (ValueError, RecursionError):
+            results.append(
+                CheckResult(name, "WARN", f"cannot read {path}: invalid JSON content")
+            )
+            continue
+        except OSError as exc:
             results.append(CheckResult(name, "WARN", f"cannot read {path}: {exc}"))
             continue
 
+        if not isinstance(data, dict):
+            results.append(
+                CheckResult(name, "WARN", f"config root must be a JSON object: {path}")
+            )
+            continue
+
         mcp_servers = data.get("mcpServers", {})
+        if not isinstance(mcp_servers, dict):
+            results.append(
+                CheckResult(name, "WARN", f"mcpServers must be a JSON object: {path}")
+            )
+            continue
+
         tsa_entry = mcp_servers.get("tree-sitter-analyzer")
         if tsa_entry is None:
             results.append(
@@ -162,9 +225,37 @@ def _check_agent_configs() -> list[CheckResult]:
                 )
             )
             continue
+        if not isinstance(tsa_entry, dict):
+            results.append(
+                CheckResult(
+                    name,
+                    "WARN",
+                    f"MCP entry 'tree-sitter-analyzer' must be a JSON object: {path}",
+                )
+            )
+            continue
 
         env = tsa_entry.get("env", {})
+        if not isinstance(env, dict):
+            results.append(
+                CheckResult(
+                    name,
+                    "WARN",
+                    f"MCP entry 'tree-sitter-analyzer'.env must be a JSON object: {path}",
+                )
+            )
+            continue
         root = env.get("TREE_SITTER_PROJECT_ROOT", "")
+        if not isinstance(root, str):
+            results.append(
+                CheckResult(
+                    name,
+                    "WARN",
+                    "TREE_SITTER_PROJECT_ROOT must be a string "
+                    f"in MCP entry 'tree-sitter-analyzer': {path}",
+                )
+            )
+            continue
         if root and not os.path.isabs(root):
             results.append(
                 CheckResult(

--- a/tree_sitter_analyzer/cli/commands/doctor.py
+++ b/tree_sitter_analyzer/cli/commands/doctor.py
@@ -94,6 +94,9 @@ def _check_uv() -> CheckResult:
         except subprocess.TimeoutExpired:
             _terminate_process_tree(process)
             return CheckResult("uv", "FAIL", f"timed out running {path} --version")
+        except BaseException:
+            _terminate_process_tree(process)
+            raise
         completed = subprocess.CompletedProcess(
             process.args, process.returncode, probe_stdout, probe_stderr
         )
@@ -113,7 +116,8 @@ def _check_uv() -> CheckResult:
         )
 
     match = re.fullmatch(
-        r"uv (\d+)\.(\d+)\.(\d+)(?:[ \t]+.*)?", decoded_stdout.rstrip("\n")
+        r"uv ([0-9]+)\.([0-9]+)\.([0-9]+)(?:[ \t]+.*)?",
+        decoded_stdout.rstrip("\n"),
     )
     if completed.returncode != 0 or match is None:
         return CheckResult(


### PR DESCRIPTION
## Summary
- harden the `uv >= 0.11.0` bootstrap and preserve an explicit secure opt-out
- make doctor fail closed on undecodable output and adversarial-but-valid JSON shapes
- add an offline, untrusted 18-boundary installer contract with distinct execution fingerprints
- keep every native OS qualification axis false; this does **not** qualify a released package or MCP first answer

## Evidence boundary
This PR proves only the local offline installer contract. Mutable upstream bootstrap content remains unverified, and macOS/Linux/Windows package-to-MCP qualification remains pending.

## Verification
- `uv run pytest tests/unit/cli/test_doctor_command.py tests/unit/cli/test_install_skills.py tests/contracts/test_fresh_install_qualification.py -q` → 92 passed
- `uv run pytest -q` → 1339 passed, 7 skipped, 1 rerun
- patch coverage → no added executable misses (validated on orchestration diff)
- `bash -n install.sh`, ruff, mypy, pre-commit → pass
