### PR TITLE
fix(ci): verify Windows native attestation scripts

### DIFF
--- a/.github/workflows/native-install-qualification.yml
+++ b/.github/workflows/native-install-qualification.yml
@@ -400,7 +400,7 @@ jobs:
                       elif name != wheel_record:
                           generated_dist = normalized in {str(pathlib.PurePosixPath(wheel_record).parent / generated) for generated in ("INSTALLER", "direct_url.json", "REQUESTED")}
                           expected_script = (f"../../Scripts/{leaf}" if axis == "windows" else f"../../../bin/{leaf}")
-                generated_script = normalized.lower() == expected_script.lower() and leaf.removesuffix(".exe") in console_scripts
+                          generated_script = normalized.lower() == expected_script.lower() and leaf.removesuffix(".exe") in console_scripts
                           assert generated_dist or generated_script or (leaf.endswith(".pyc") and normalized.startswith("tree_sitter_analyzer/"))
                   assert set(wheel_rows).issubset(installed_names) and observed_direct == direct
               runtime = report["runtime"]; exact(runtime, ("python", "executable", "prefix")); assert all(isinstance(value, str) and value for value in runtime.values())

--- a/.github/workflows/native-install-qualification.yml
+++ b/.github/workflows/native-install-qualification.yml
@@ -399,8 +399,12 @@ jobs:
                           assert data == wheel_bytes[name] and [declared, declared_size] == wheel_rows[name]
                       elif name != wheel_record:
                           generated_dist = normalized in {str(pathlib.PurePosixPath(wheel_record).parent / generated) for generated in ("INSTALLER", "direct_url.json", "REQUESTED")}
-                          expected_script = (f"../../Scripts/{leaf}" if axis == "windows" else f"../../../bin/{leaf}")
-                          generated_script = normalized.lower() == expected_script.lower() and leaf.removesuffix(".exe") in console_scripts
+                          generated_script = any(
+                              normalized.lower() == f"../../scripts/{entry}.exe".lower()
+                              if axis == "windows"
+                              else normalized == f"../../../bin/{entry}"
+                              for entry in console_scripts
+                          )
                           assert generated_dist or generated_script or (leaf.endswith(".pyc") and normalized.startswith("tree_sitter_analyzer/"))
                   assert set(wheel_rows).issubset(installed_names) and observed_direct == direct
               runtime = report["runtime"]; exact(runtime, ("python", "executable", "prefix")); assert all(isinstance(value, str) and value for value in runtime.values())

--- a/.github/workflows/native-install-qualification.yml
+++ b/.github/workflows/native-install-qualification.yml
@@ -399,7 +399,8 @@ jobs:
                           assert data == wheel_bytes[name] and [declared, declared_size] == wheel_rows[name]
                       elif name != wheel_record:
                           generated_dist = normalized in {str(pathlib.PurePosixPath(wheel_record).parent / generated) for generated in ("INSTALLER", "direct_url.json", "REQUESTED")}
-                          generated_script = (normalized.startswith("../../../bin/") or normalized.lower().startswith("../../scripts/")) and leaf.removesuffix(".exe") in console_scripts
+                          expected_script = (f"../../Scripts/{leaf}" if axis == "windows" else f"../../../bin/{leaf}")
+                generated_script = normalized.lower() == expected_script.lower() and leaf.removesuffix(".exe") in console_scripts
                           assert generated_dist or generated_script or (leaf.endswith(".pyc") and normalized.startswith("tree_sitter_analyzer/"))
                   assert set(wheel_rows).issubset(installed_names) and observed_direct == direct
               runtime = report["runtime"]; exact(runtime, ("python", "executable", "prefix")); assert all(isinstance(value, str) and value for value in runtime.values())

--- a/.github/workflows/native-install-qualification.yml
+++ b/.github/workflows/native-install-qualification.yml
@@ -399,7 +399,7 @@ jobs:
                           assert data == wheel_bytes[name] and [declared, declared_size] == wheel_rows[name]
                       elif name != wheel_record:
                           generated_dist = normalized in {str(pathlib.PurePosixPath(wheel_record).parent / generated) for generated in ("INSTALLER", "direct_url.json", "REQUESTED")}
-                          generated_script = normalized.startswith("../../../") and leaf.removesuffix(".exe") in console_scripts
+                          generated_script = (normalized.startswith("../../../bin/") or normalized.lower().startswith("../../scripts/")) and leaf.removesuffix(".exe") in console_scripts
                           assert generated_dist or generated_script or (leaf.endswith(".pyc") and normalized.startswith("tree_sitter_analyzer/"))
                   assert set(wheel_rows).issubset(installed_names) and observed_direct == direct
               runtime = report["runtime"]; exact(runtime, ("python", "executable", "prefix")); assert all(isinstance(value, str) and value for value in runtime.values())


### PR DESCRIPTION
## Summary
- accept the platform-canonical Windows venv console-script RECORD path (`../../Scripts/*.exe`) in the no-checkout trusted verifier
- retain exact entry-point-name matching and the stricter POSIX `../../../bin/` path

## Failure evidence
The first protected develop qualification run 31270564637 passed build, Linux, macOS, Windows, and aggregate. Its trusted attestation job rejected the Windows axis at the generated-script path check. Replaying the patched inline verifier against those exact downloaded wheel/aggregate/three-axis artifacts succeeds and writes the gated verification marker.

## Verification
- real trusted artifact replay: exit 0, marker created
- actionlint / PowerShell ASCII / commit hooks: pass
