### PR TITLE
fix(ci): verify outdated aggregate identity shape

### DIFF
--- a/.github/workflows/reusable-native-qualification-attestation.yml
+++ b/.github/workflows/reusable-native-qualification-attestation.yml
@@ -429,7 +429,7 @@ jobs:
           assert outdated_aggregate["workflow"] == {
               "event": "push", "run_id": run, "run_attempt": attempt,
               "job": "outdated-uv-aggregate", "workflow_ref": os.environ["GITHUB_WORKFLOW_REF"],
-              "run_url": f"{os.environ['GITHUB_SERVER_URL']}/{repo}/actions/runs/{run}",
+              "run_url": f"{os.environ['GITHUB_SERVER_URL']}/{os.environ['GITHUB_REPOSITORY']}/actions/runs/{run}",
           }
           assert outdated_aggregate["source_commit"]==commit and outdated_aggregate["package_qualification"]=={**package_common,"axis_report_sha256":package_axis_sha256}
           assert outdated_aggregate["qualified"] is False and outdated_aggregate["evidence_trust"]=="EXTERNAL_ATTESTATION_REQUIRED" and outdated_aggregate["automatic_mutable_bootstrap_qualified"] is False and outdated_aggregate["failures"]==[]

--- a/.github/workflows/reusable-native-qualification-attestation.yml
+++ b/.github/workflows/reusable-native-qualification-attestation.yml
@@ -426,7 +426,11 @@ jobs:
                 if pathlib.PurePosixPath(row[0].replace("\\","/")).name=="direct_url.json": observed_direct.append(json.loads(data))
               assert observed_direct==[direct]
           exact(outdated_aggregate,("schema_version","kind","qualification_id","evidence_scope","qualification_performed","qualified","evidence_trust","source_commit","package_qualification","required_axes","automatic_mutable_bootstrap_qualified","axes","failures","workflow"))
-          identity(outdated_aggregate,"outdated-uv-aggregate")
+          assert outdated_aggregate["workflow"] == {
+              "event": "push", "run_id": run, "run_attempt": attempt,
+              "job": "outdated-uv-aggregate", "workflow_ref": os.environ["GITHUB_WORKFLOW_REF"],
+              "run_url": f"{os.environ['GITHUB_SERVER_URL']}/{repo}/actions/runs/{run}",
+          }
           assert outdated_aggregate["source_commit"]==commit and outdated_aggregate["package_qualification"]=={**package_common,"axis_report_sha256":package_axis_sha256}
           assert outdated_aggregate["qualified"] is False and outdated_aggregate["evidence_trust"]=="EXTERNAL_ATTESTATION_REQUIRED" and outdated_aggregate["automatic_mutable_bootstrap_qualified"] is False and outdated_aggregate["failures"]==[]
           assert outdated_aggregate["required_axes"]=={"package":["linux","macos","windows"],"outdated":["linux","macos"],"not_applicable":{"windows":"NOT_APPLICABLE_NO_NATIVE_INSTALLER"}}


### PR DESCRIPTION
## Summary
- fix the no-checkout trusted verifier to validate the aggregate's actual identity shape (`source_commit` + `workflow`) rather than calling the axis-report helper that requires a `source` object
- preserve exact event/ref/SHA/run/attempt/workflow binding

## Failure evidence
Protected develop run 31282924864 passed build, three package axes, package aggregate, three outdated axes, and outdated aggregate. The read-only verifier failed with `KeyError: source` at `identity(outdated_aggregate, ...)`.

## Verification
- actionlint/pre-commit: pass
