### PR TITLE
fix(ci): bind installed MCP config evidence

### DIFF
--- a/.github/workflows/reusable-native-qualification-attestation.yml
+++ b/.github/workflows/reusable-native-qualification-attestation.yml
@@ -303,9 +303,16 @@ jobs:
             required=("awk","cat","grep","mktemp","python3","realpath","rm","sleep","uname")
             first=installer["first_path"].split(":"); second=installer["second_path"].split(":")
             assert len(first)==len(second)==2 and first[0]==str(pathlib.PurePosixPath(old["path"]).parent) and second[0]==str(pathlib.PurePosixPath(supported["path"]).parent) and first[1]==second[1] and pathlib.PurePosixPath(first[1]).name=="tools" and tuple(installer["curated_tools"])==required
-          def expected_config_hash(expected_entry):
-            value={"mcpServers":{"tree-sitter-analyzer":expected_entry}}
-            return hashlib.sha256((json.dumps(value,indent=2)+"\n").encode()).hexdigest()
+          def verify_config_sidecar(path,config,after):
+            data=(path/"installed-mcp-config.json").read_bytes()
+            def unique(pairs):
+              value={}
+              for key,item in pairs: assert key not in value; value[key]=item
+              return value
+            value=json.loads(data.decode("utf-8"),object_pairs_hook=unique)
+            exact(value,("mcpServers",)); servers=value["mcpServers"]; exact(servers,("tree-sitter-analyzer",))
+            entry=servers["tree-sitter-analyzer"]; exact(entry,("command","args","env")); exact(entry["env"],("TREE_SITTER_PROJECT_ROOT",))
+            assert entry==config["expected_entry"] and after[".claude/.mcp.json"]=={"path":".claude/.mcp.json","type":"file","sha256":hashlib.sha256(data).hexdigest()}
           def verify_causal_binding(axis,path,causal,bound,supported_exec,wheel,wheel_path,parent_runner,causal_digest):
             verify_runner(causal["runner"],axis); assert causal["runner"]==parent_runner
             install=causal["install"]; tool=install["tool"]; runtime=causal["runtime"]; meta=causal["metadata"]; mcp=causal["mcp"]; record=meta["installed_record"]
@@ -394,7 +401,8 @@ jobs:
             assert "TSA_DISABLE_UNVERIFIED_UV_BOOTSTRAP=1" in first and re.search(r"uv 0\.10\.9(?: [^\n]+)? does not satisfy required uv >= 0\.11\.0",first) and "installation complete" not in first and "uv 0.11.0" in second
             config=report["config"]; assert config["before"]==config["after_first"] and config["backup_sha256"]==hashlib.sha256(b"{}\n").hexdigest()
             before={item["path"]:item for item in config["before"]}; after={item["path"]:item for item in config["after_second"]}; added=set(after)-set(before)
-            assert set(before)-set(after)==set() and set(added)=={next(name for name in added if name.startswith(".claude/.mcp.json.bak."))} and after[next(iter(added))]["sha256"]==config["backup_sha256"] and after[".claude/.mcp.json"]=={"path":".claude/.mcp.json","type":"file","sha256":expected_config_hash(config["expected_entry"])} and before[".claude/.mcp.json"]!=after[".claude/.mcp.json"] and {k:v for k,v in before.items() if k!=".claude/.mcp.json"}=={k:v for k,v in after.items() if k not in added|{".claude/.mcp.json"}}
+            assert set(before)-set(after)==set() and set(added)=={next(name for name in added if name.startswith(".claude/.mcp.json.bak."))} and after[next(iter(added))]["sha256"]==config["backup_sha256"] and before[".claude/.mcp.json"]!=after[".claude/.mcp.json"] and {k:v for k,v in before.items() if k!=".claude/.mcp.json"}=={k:v for k,v in after.items() if k not in added|{".claude/.mcp.json"}}
+            verify_config_sidecar(path,config,after)
             causal_path=path/"mcp/report.json"; causal=json.loads(causal_path.read_text()); bound=report["mcp_causal_report"]
             exact(causal,("schema_version","kind","qualification_id","evidence_scope","axis","qualification_performed","passed","source","workflow","runner","wheel","stages","failure","build_manifest_sha256","install","metadata","runtime","mcp","dependency_manifest_sha256","installed_files_zip_sha256")); identity(causal,"outdated-axis")
             assert causal["axis"]==axis and causal["stages"]==[{"id":stage,"passed":True} for stage in ("verify_wheel","install","metadata_provenance","mcp_protocol")] and causal["failure"] is None

--- a/.github/workflows/reusable-native-qualification-attestation.yml
+++ b/.github/workflows/reusable-native-qualification-attestation.yml
@@ -245,7 +245,8 @@ jobs:
         run: |
           python - <<'PY'
           import base64, csv, hashlib, json, os, pathlib, re, shutil, tarfile, tempfile, zipfile
-          root=pathlib.Path("trusted"); run=os.environ["GITHUB_RUN_ID"]; attempt=os.environ["GITHUB_RUN_ATTEMPT"]; commit=os.environ["GITHUB_SHA"]
+          root=pathlib.Path("trusted")
+          run=os.environ["GITHUB_RUN_ID"]; attempt=os.environ["GITHUB_RUN_ATTEMPT"]; commit=os.environ["GITHUB_SHA"]
           suffix=f"-{run}-{attempt}-{commit}"
           sha=lambda p:hashlib.sha256(p.read_bytes()).hexdigest()
           exact=lambda value,keys: (_ for _ in ()).throw(AssertionError(f"keys: {set(value) if isinstance(value,dict) else type(value)}")) if not isinstance(value,dict) or set(value)!=set(keys) else None
@@ -299,21 +300,17 @@ jobs:
             exact(value,("version","path","sha256","size","version_stdout")); assert value["version"]==version and re.fullmatch(rf"uv {re.escape(version)}(?: [^\n]+)?\n?",value["version_stdout"])
             executable=pure(value["path"],axis); suffix=pathlib.PurePosixPath(member["member"]).parts
             assert absolute(value["path"],axis) and tuple(part.lower() for part in executable.parts[-len(suffix):])==tuple(part.lower() for part in suffix) and (value["sha256"],value["size"])==(member["sha256"],member["size"])
-          def executable_sandbox_root(value,member,label,axis):
+          def trusted_sandbox_root(axis):
+            assert axis in ("linux","macos") and re.fullmatch(r"(?:0|[1-9]\d*)",run) and re.fullmatch(r"(?:0|[1-9]\d*)",attempt)
+            base={"linux":pathlib.PurePosixPath("/tmp"),"macos":pathlib.PurePosixPath("/private/tmp")}[axis]
+            return base/f"tsa-outdated-native-{run}-{attempt}-{axis}"
+          def verify_executable_sandbox(value,member,label,axis,sandbox):
+            assert axis in ("linux","macos")
             executable=lexical(value["path"],axis); suffix=pathlib.PurePosixPath(member["member"]).parts
             assert len(executable.parts)>len(suffix) and tuple(part.lower() for part in executable.parts[-len(suffix):])==tuple(part.lower() for part in suffix)
             extracted=executable
             for _ in suffix: extracted=extracted.parent
-            assert extracted.name.lower()==label
-            return extracted.parent
-          def trusted_sandbox_root(old,old_member,axis,supported=None,supported_member=None):
-            sandbox=executable_sandbox_root(old,old_member,"old",axis)
-            assert re.fullmatch(r"tsa-outdated-native-[^/\\]+",sandbox.name)
-            if axis=="windows": assert supported is supported_member is None
-            else:
-              assert axis in ("linux","macos") and supported is not None and supported_member is not None
-              assert executable_sandbox_root(supported,supported_member,"supported",axis)==sandbox
-            return sandbox
+            assert extracted==sandbox/label
           def verify_installer_paths(installer,old,supported,sandbox_root):
             required=("awk","cat","grep","mktemp","python3","realpath","rm","sleep","uname")
             first=installer["first_path"].split(":"); second=installer["second_path"].split(":"); tools=str(sandbox_root/"tools")
@@ -444,7 +441,6 @@ jobs:
             identity(report,"outdated-uv-axis")
             old_side=path/"old.archive"; assert (old_side.stat().st_size,sha(old_side))==(size,digest); old_member=safe_uv_member(old_side,filename); verify_executable(old["executable"],old_member,"0.10.9",axis)
             if axis=="windows":
-              sandbox_root=trusted_sandbox_root(old["executable"],old_member,axis)
               assert report["status"]=="NOT_APPLICABLE_NO_NATIVE_INSTALLER" and report["passed"] is False and report["qualification_performed"] is False
               assert report["failure"]=={"type":"NotApplicable","message":"Windows has no native install.ps1; real old uv.exe execution retained only as a platform fixture"}
               assert report["supported_uv"] is None and report["installer"] is None and report["config"] is None and report["mcp_causal_report"] is None
@@ -452,7 +448,8 @@ jobs:
             filename,size,digest,url=official[(fixture_axis,"0.11.0")]; supported=report["supported_uv"]
             assert supported["archive"]=={"filename":filename,"size":size,"sha256":digest,"url":url,"version":"0.11.0"}
             supported_side=path/"supported.archive"; assert (supported_side.stat().st_size,sha(supported_side))==(size,digest); supported_member=safe_uv_member(supported_side,filename); verify_executable(supported["executable"],supported_member,"0.11.0",axis)
-            sandbox_root=trusted_sandbox_root(old["executable"],old_member,axis,supported["executable"],supported_member)
+            sandbox_root=trusted_sandbox_root(axis)
+            verify_executable_sandbox(old["executable"],old_member,"old",axis,sandbox_root); verify_executable_sandbox(supported["executable"],supported_member,"supported",axis,sandbox_root)
             assert report["status"]=="PASSED" and report["passed"] is True and report["qualification_performed"] is True
             installer=report["installer"]; exact(installer,("path","sha256","first_exit","second_exit","curl_invocations","first_path","second_path","curated_tools")); assert installer["sha256"]==sha(path/"installer.source")=="754799ff21807228b604b001b6a93bfd62b9748b3cfea45a33e59fefcbb717d5" and (installer["first_exit"],installer["second_exit"],installer["curl_invocations"])==(1,0,0)
             verify_installer_paths(installer,old["executable"],supported["executable"],sandbox_root)

--- a/.github/workflows/reusable-native-qualification-attestation.yml
+++ b/.github/workflows/reusable-native-qualification-attestation.yml
@@ -303,7 +303,28 @@ jobs:
             required=("awk","cat","grep","mktemp","python3","realpath","rm","sleep","uname")
             first=installer["first_path"].split(":"); second=installer["second_path"].split(":")
             assert len(first)==len(second)==2 and first[0]==str(pathlib.PurePosixPath(old["path"]).parent) and second[0]==str(pathlib.PurePosixPath(supported["path"]).parent) and first[1]==second[1] and pathlib.PurePosixPath(first[1]).name=="tools" and tuple(installer["curated_tools"])==required
-          def verify_config_sidecar(path,config,after):
+          def canonical_relative(value):
+            assert isinstance(value,str) and value and "\\" not in value and "\0" not in value and "\n" not in value and "\r" not in value
+            result=pathlib.PurePosixPath(value)
+            assert not result.is_absolute() and result.as_posix()==value and all(part not in ("",".","..") for part in result.parts)
+            return result
+          def snapshots(items):
+            assert isinstance(items,list); result={}
+            for item in items:
+              exact(item,("path","type","sha256")); name=item["path"]; canonical_relative(name); assert name not in result
+              kind=item["type"]; digest=item["sha256"]
+              assert kind in ("file","dir","symlink") and ((kind=="file" and isinstance(digest,str) and re.fullmatch(r"[0-9a-f]{64}",digest)) or (kind in ("dir","symlink") and digest is None))
+              result[name]=item
+            return result
+          def project_root_from_stdout(second,axis):
+            assert axis in ("linux","macos")
+            matches=re.findall(r"(?m)^📁 Project root: ([^\r\n]+)$",second)
+            assert len(matches)==1; value=matches[0]
+            assert "\0" not in value and str(lexical(value,axis))==value
+            root_path=pure(value,axis); assert root_path.name=="fixture" and re.fullmatch(r"tsa-outdated-native-[^/]+",root_path.parent.name)
+            return value
+          def verify_config_sidecar(path,config,after,axis,second):
+            exact(config,("before","after_first","after_second","expected_entry","backup_sha256"))
             data=(path/"installed-mcp-config.json").read_bytes()
             def unique(pairs):
               value={}
@@ -312,7 +333,8 @@ jobs:
             value=json.loads(data.decode("utf-8"),object_pairs_hook=unique)
             exact(value,("mcpServers",)); servers=value["mcpServers"]; exact(servers,("tree-sitter-analyzer",))
             entry=servers["tree-sitter-analyzer"]; exact(entry,("command","args","env")); exact(entry["env"],("TREE_SITTER_PROJECT_ROOT",))
-            assert entry==config["expected_entry"] and after[".claude/.mcp.json"]=={"path":".claude/.mcp.json","type":"file","sha256":hashlib.sha256(data).hexdigest()}
+            expected={"command":"uvx","args":["--from","tree-sitter-analyzer[mcp]","tree-sitter-analyzer-mcp"],"env":{"TREE_SITTER_PROJECT_ROOT":project_root_from_stdout(second,axis)}}
+            assert entry==config["expected_entry"]==expected and after[".claude/.mcp.json"]=={"path":".claude/.mcp.json","type":"file","sha256":hashlib.sha256(data).hexdigest()}
           def verify_causal_binding(axis,path,causal,bound,supported_exec,wheel,wheel_path,parent_runner,causal_digest):
             verify_runner(causal["runner"],axis); assert causal["runner"]==parent_runner
             install=causal["install"]; tool=install["tool"]; runtime=causal["runtime"]; meta=causal["metadata"]; mcp=causal["mcp"]; record=meta["installed_record"]
@@ -368,14 +390,24 @@ jobs:
           outdated_dirs={axis:root/f"outdated/outdated-uv-{axis}{suffix}" for axis in ("linux","macos","windows")}
           outdated_aggregate_path=root/f"outdated/outdated-uv-aggregate{suffix}/aggregate.json"; outdated_aggregate=json.loads(outdated_aggregate_path.read_text())
           reports={}; package_common=None; package_axis_sha256={}
+          posix_artifacts={"old.archive","supported.archive","installer.source","installed-mcp-config.json","first.stdout","first.stderr","second.stdout","second.stderr","mcp-driver.stdout","mcp-driver.stderr","mcp/report.json","mcp/install.stdout","mcp/install.stderr","mcp/dependency-manifest.txt","mcp/mcp-transcript.ndjson","mcp/mcp.stderr","mcp/installed-files.zip"}
           for axis,path in outdated_dirs.items():
             report_path=path/"report.json"; report=reports[axis]=json.loads(report_path.read_text()); artifacts=report["artifacts"]
             exact(report,("schema_version","kind","qualification_id","evidence_scope","axis","qualification_performed","passed","status","source","workflow","runner","remediation_mode","automatic_mutable_bootstrap_qualified","old_uv","supported_uv","installer","config","package_qualification","mcp_causal_report","artifacts","failure"))
-            actual={str(p.relative_to(path)) for p in path.rglob("*") if p.is_file()}
-            assert actual=={"report.json","job-result.json",*artifacts}
-            for name,meta in artifacts.items():
-              target=path/name; assert target.is_file() and not target.is_symlink() and meta=={"sha256":sha(target),"size":target.stat().st_size}
-            assert report["schema_version"]=="no1-006a-outdated-uv-attestation-v2" and report["evidence_scope"]=="native_outdated_uv_actionable_recovery"
+            expected_artifacts={"old.archive"} if axis=="windows" else posix_artifacts
+            assert set(artifacts)==expected_artifacts
+            expected_files={"report.json","job-result.json",*expected_artifacts}; expected_entries=expected_files|({"mcp"} if axis!="windows" else set())
+            actual_entries={p.relative_to(path).as_posix() for p in path.rglob("*")}
+            assert actual_entries==expected_entries and len(expected_files)==(3 if axis=="windows" else 19)
+            base=path.resolve(strict=True)
+            for name in expected_files:
+              relative=canonical_relative(name); target=path/pathlib.Path(*relative.parts); current=path
+              for part in relative.parts:
+                current=current/part; assert not current.is_symlink()
+              assert target.is_file() and target.resolve(strict=True).relative_to(base)
+              if name in artifacts:
+                meta=artifacts[name]; exact(meta,("sha256","size")); assert meta=={"sha256":sha(target),"size":target.stat().st_size}
+            assert report["schema_version"]=="no1-006a-outdated-uv-attestation-v3" and report["evidence_scope"]=="native_outdated_uv_actionable_recovery"
             assert report["axis"]==axis and report["remediation_mode"]=="manual_content_bound_remediation" and report["automatic_mutable_bootstrap_qualified"] is False
             verify_runner(report["runner"],axis)
             fixture_axis=(f"macos-{'arm64' if report['runner']['machine'].lower() in ('arm64','aarch64') else 'x86_64'}" if axis=="macos" else axis)
@@ -399,10 +431,11 @@ jobs:
             verify_installer_paths(installer,old["executable"],supported["executable"])
             first=(path/"first.stdout").read_text(); second=(path/"second.stdout").read_text()
             assert "TSA_DISABLE_UNVERIFIED_UV_BOOTSTRAP=1" in first and re.search(r"uv 0\.10\.9(?: [^\n]+)? does not satisfy required uv >= 0\.11\.0",first) and "installation complete" not in first and "uv 0.11.0" in second
-            config=report["config"]; assert config["before"]==config["after_first"] and config["backup_sha256"]==hashlib.sha256(b"{}\n").hexdigest()
-            before={item["path"]:item for item in config["before"]}; after={item["path"]:item for item in config["after_second"]}; added=set(after)-set(before)
-            assert set(before)-set(after)==set() and set(added)=={next(name for name in added if name.startswith(".claude/.mcp.json.bak."))} and after[next(iter(added))]["sha256"]==config["backup_sha256"] and before[".claude/.mcp.json"]!=after[".claude/.mcp.json"] and {k:v for k,v in before.items() if k!=".claude/.mcp.json"}=={k:v for k,v in after.items() if k not in added|{".claude/.mcp.json"}}
-            verify_config_sidecar(path,config,after)
+            config=report["config"]; exact(config,("before","after_first","after_second","expected_entry","backup_sha256")); assert config["before"]==config["after_first"] and re.fullmatch(r"[0-9a-f]{64}",config["backup_sha256"]) and config["backup_sha256"]==hashlib.sha256(b"{}\n").hexdigest()
+            before=snapshots(config["before"]); snapshots(config["after_first"]); after=snapshots(config["after_second"]); added=set(after)-set(before)
+            backups={name for name in added if re.fullmatch(r"\.claude/\.mcp\.json\.bak\.\d{8}-\d{6}",name)}
+            assert set(before)-set(after)==set() and added==backups and len(backups)==1 and after[next(iter(backups))]["sha256"]==config["backup_sha256"] and before[".claude/.mcp.json"]!=after[".claude/.mcp.json"] and {k:v for k,v in before.items() if k!=".claude/.mcp.json"}=={k:v for k,v in after.items() if k not in added|{".claude/.mcp.json"}}
+            verify_config_sidecar(path,config,after,axis,second)
             causal_path=path/"mcp/report.json"; causal=json.loads(causal_path.read_text()); bound=report["mcp_causal_report"]
             exact(causal,("schema_version","kind","qualification_id","evidence_scope","axis","qualification_performed","passed","source","workflow","runner","wheel","stages","failure","build_manifest_sha256","install","metadata","runtime","mcp","dependency_manifest_sha256","installed_files_zip_sha256")); identity(causal,"outdated-axis")
             assert causal["axis"]==axis and causal["stages"]==[{"id":stage,"passed":True} for stage in ("verify_wheel","install","metadata_provenance","mcp_protocol")] and causal["failure"] is None
@@ -435,6 +468,7 @@ jobs:
                 if pathlib.PurePosixPath(row[0].replace("\\","/")).name=="direct_url.json": observed_direct.append(json.loads(data))
               assert observed_direct==[direct]
           exact(outdated_aggregate,("schema_version","kind","qualification_id","evidence_scope","qualification_performed","qualified","evidence_trust","source_commit","package_qualification","required_axes","automatic_mutable_bootstrap_qualified","axes","failures","workflow"))
+          assert (outdated_aggregate["schema_version"],outdated_aggregate["kind"],outdated_aggregate["qualification_id"],outdated_aggregate["evidence_scope"])==("no1-006a-outdated-uv-attestation-v3","outdated_uv_aggregate","NO1-006A","native_outdated_uv_actionable_recovery")
           assert outdated_aggregate["workflow"] == {
               "event": "push", "run_id": run, "run_attempt": attempt,
               "job": "outdated-uv-aggregate", "workflow_ref": os.environ["GITHUB_WORKFLOW_REF"],

--- a/.github/workflows/reusable-native-qualification-attestation.yml
+++ b/.github/workflows/reusable-native-qualification-attestation.yml
@@ -299,10 +299,25 @@ jobs:
             exact(value,("version","path","sha256","size","version_stdout")); assert value["version"]==version and re.fullmatch(rf"uv {re.escape(version)}(?: [^\n]+)?\n?",value["version_stdout"])
             executable=pure(value["path"],axis); suffix=pathlib.PurePosixPath(member["member"]).parts
             assert absolute(value["path"],axis) and tuple(part.lower() for part in executable.parts[-len(suffix):])==tuple(part.lower() for part in suffix) and (value["sha256"],value["size"])==(member["sha256"],member["size"])
-          def verify_installer_paths(installer,old,supported):
+          def executable_sandbox_root(value,member,label,axis):
+            executable=lexical(value["path"],axis); suffix=pathlib.PurePosixPath(member["member"]).parts
+            assert len(executable.parts)>len(suffix) and tuple(part.lower() for part in executable.parts[-len(suffix):])==tuple(part.lower() for part in suffix)
+            extracted=executable
+            for _ in suffix: extracted=extracted.parent
+            assert extracted.name.lower()==label
+            return extracted.parent
+          def trusted_sandbox_root(old,old_member,axis,supported=None,supported_member=None):
+            sandbox=executable_sandbox_root(old,old_member,"old",axis)
+            assert re.fullmatch(r"tsa-outdated-native-[^/\\]+",sandbox.name)
+            if axis=="windows": assert supported is supported_member is None
+            else:
+              assert axis in ("linux","macos") and supported is not None and supported_member is not None
+              assert executable_sandbox_root(supported,supported_member,"supported",axis)==sandbox
+            return sandbox
+          def verify_installer_paths(installer,old,supported,sandbox_root):
             required=("awk","cat","grep","mktemp","python3","realpath","rm","sleep","uname")
-            first=installer["first_path"].split(":"); second=installer["second_path"].split(":")
-            assert len(first)==len(second)==2 and first[0]==str(pathlib.PurePosixPath(old["path"]).parent) and second[0]==str(pathlib.PurePosixPath(supported["path"]).parent) and first[1]==second[1] and pathlib.PurePosixPath(first[1]).name=="tools" and tuple(installer["curated_tools"])==required
+            first=installer["first_path"].split(":"); second=installer["second_path"].split(":"); tools=str(sandbox_root/"tools")
+            assert len(first)==len(second)==2 and first[0]==str(pathlib.PurePosixPath(old["path"]).parent) and second[0]==str(pathlib.PurePosixPath(supported["path"]).parent) and first[1]==second[1]==tools and tuple(installer["curated_tools"])==required
           def canonical_relative(value):
             assert isinstance(value,str) and value and "\\" not in value and "\0" not in value and "\n" not in value and "\r" not in value
             result=pathlib.PurePosixPath(value)
@@ -316,24 +331,33 @@ jobs:
               assert kind in ("file","dir","symlink") and ((kind=="file" and isinstance(digest,str) and re.fullmatch(r"[0-9a-f]{64}",digest)) or (kind in ("dir","symlink") and digest is None))
               result[name]=item
             return result
-          def project_root_from_stdout(second,axis):
-            assert axis in ("linux","macos")
-            matches=re.findall(r"(?m)^📁 Project root: ([^\r\n]+)$",second)
-            assert len(matches)==1; value=matches[0]
-            assert "\0" not in value and str(lexical(value,axis))==value
-            root_path=pure(value,axis); assert root_path.name=="fixture" and re.fullmatch(r"tsa-outdated-native-[^/]+",root_path.parent.name)
-            return value
-          def verify_config_sidecar(path,config,after,axis,second):
-            exact(config,("before","after_first","after_second","expected_entry","backup_sha256"))
-            data=(path/"installed-mcp-config.json").read_bytes()
+          def verify_initial_config(config):
+            exact(config,("before","after_first","after_second","expected_entry","backup_sha256")); initial_digest=hashlib.sha256(b"{}\n").hexdigest()
+            initial=[{"path":".claude","type":"dir","sha256":None},{"path":".claude/.mcp.json","type":"file","sha256":initial_digest}]
+            assert config["before"]==config["after_first"]==initial and config["backup_sha256"]==initial_digest
+            return snapshots(config["before"])
+          def strict_json_bytes(data):
             def unique(pairs):
               value={}
               for key,item in pairs: assert key not in value; value[key]=item
               return value
-            value=json.loads(data.decode("utf-8"),object_pairs_hook=unique)
+            return json.loads(data.decode("utf-8","strict"),object_pairs_hook=unique)
+          def verify_job_result(path,axis):
+            value=strict_json_bytes(path.read_bytes()); exact(value,("job","axis","status"))
+            assert value=={"job":"outdated-axis","axis":axis,"status":"success"}
+            return hashlib.sha256(path.read_bytes()).hexdigest()
+          def project_root_from_stdout(second,axis,sandbox_root):
+            assert axis in ("linux","macos")
+            matches=re.findall(r"(?m)^📁 Project root: ([^\r\n]+)$",second)
+            assert len(matches)==1; value=matches[0]; expected=str(sandbox_root/"fixture")
+            assert "\0" not in value and str(lexical(value,axis))==value==expected
+            return value
+          def verify_config_sidecar(path,config,after,axis,second,sandbox_root):
+            exact(config,("before","after_first","after_second","expected_entry","backup_sha256"))
+            data=(path/"installed-mcp-config.json").read_bytes(); value=strict_json_bytes(data)
             exact(value,("mcpServers",)); servers=value["mcpServers"]; exact(servers,("tree-sitter-analyzer",))
             entry=servers["tree-sitter-analyzer"]; exact(entry,("command","args","env")); exact(entry["env"],("TREE_SITTER_PROJECT_ROOT",))
-            expected={"command":"uvx","args":["--from","tree-sitter-analyzer[mcp]","tree-sitter-analyzer-mcp"],"env":{"TREE_SITTER_PROJECT_ROOT":project_root_from_stdout(second,axis)}}
+            expected={"command":"uvx","args":["--from","tree-sitter-analyzer[mcp]","tree-sitter-analyzer-mcp"],"env":{"TREE_SITTER_PROJECT_ROOT":project_root_from_stdout(second,axis,sandbox_root)}}
             assert entry==config["expected_entry"]==expected and after[".claude/.mcp.json"]=={"path":".claude/.mcp.json","type":"file","sha256":hashlib.sha256(data).hexdigest()}
           def verify_causal_binding(axis,path,causal,bound,supported_exec,wheel,wheel_path,parent_runner,causal_digest):
             verify_runner(causal["runner"],axis); assert causal["runner"]==parent_runner
@@ -389,7 +413,7 @@ jobs:
           assert package_aggregate["axes"]==[{"axis":a,"report_sha256":sha(package_dirs[a]/"report.json"),"passed":True} for a in ("linux","macos","windows")]
           outdated_dirs={axis:root/f"outdated/outdated-uv-{axis}{suffix}" for axis in ("linux","macos","windows")}
           outdated_aggregate_path=root/f"outdated/outdated-uv-aggregate{suffix}/aggregate.json"; outdated_aggregate=json.loads(outdated_aggregate_path.read_text())
-          reports={}; package_common=None; package_axis_sha256={}
+          reports={}; package_common=None; package_axis_sha256={}; job_result_sha256={}
           posix_artifacts={"old.archive","supported.archive","installer.source","installed-mcp-config.json","first.stdout","first.stderr","second.stdout","second.stderr","mcp-driver.stdout","mcp-driver.stderr","mcp/report.json","mcp/install.stdout","mcp/install.stderr","mcp/dependency-manifest.txt","mcp/mcp-transcript.ndjson","mcp/mcp.stderr","mcp/installed-files.zip"}
           for axis,path in outdated_dirs.items():
             report_path=path/"report.json"; report=reports[axis]=json.loads(report_path.read_text()); artifacts=report["artifacts"]
@@ -407,6 +431,7 @@ jobs:
               assert target.is_file() and target.resolve(strict=True).relative_to(base)
               if name in artifacts:
                 meta=artifacts[name]; exact(meta,("sha256","size")); assert meta=={"sha256":sha(target),"size":target.stat().st_size}
+            job_result_sha256[axis]=verify_job_result(path/"job-result.json",axis)
             assert report["schema_version"]=="no1-006a-outdated-uv-attestation-v3" and report["evidence_scope"]=="native_outdated_uv_actionable_recovery"
             assert report["axis"]==axis and report["remediation_mode"]=="manual_content_bound_remediation" and report["automatic_mutable_bootstrap_qualified"] is False
             verify_runner(report["runner"],axis)
@@ -417,25 +442,26 @@ jobs:
             assert common==package_common=={"aggregate_sha256":sha(package_aggregate_path),"build_manifest_sha256":sha(manifest_path),"wheel":wheel} and binding["axis_report_sha256"]==sha(package_dirs[axis]/"report.json")
             package_axis_sha256[axis]=binding["axis_report_sha256"]
             identity(report,"outdated-uv-axis")
-            old_side=path/"old.archive"; assert (old_side.stat().st_size,sha(old_side))==(size,digest); verify_executable(old["executable"],safe_uv_member(old_side,filename),"0.10.9",axis)
+            old_side=path/"old.archive"; assert (old_side.stat().st_size,sha(old_side))==(size,digest); old_member=safe_uv_member(old_side,filename); verify_executable(old["executable"],old_member,"0.10.9",axis)
             if axis=="windows":
+              sandbox_root=trusted_sandbox_root(old["executable"],old_member,axis)
               assert report["status"]=="NOT_APPLICABLE_NO_NATIVE_INSTALLER" and report["passed"] is False and report["qualification_performed"] is False
               assert report["failure"]=={"type":"NotApplicable","message":"Windows has no native install.ps1; real old uv.exe execution retained only as a platform fixture"}
               assert report["supported_uv"] is None and report["installer"] is None and report["config"] is None and report["mcp_causal_report"] is None
               continue
             filename,size,digest,url=official[(fixture_axis,"0.11.0")]; supported=report["supported_uv"]
             assert supported["archive"]=={"filename":filename,"size":size,"sha256":digest,"url":url,"version":"0.11.0"}
-            supported_side=path/"supported.archive"; assert (supported_side.stat().st_size,sha(supported_side))==(size,digest); verify_executable(supported["executable"],safe_uv_member(supported_side,filename),"0.11.0",axis)
+            supported_side=path/"supported.archive"; assert (supported_side.stat().st_size,sha(supported_side))==(size,digest); supported_member=safe_uv_member(supported_side,filename); verify_executable(supported["executable"],supported_member,"0.11.0",axis)
+            sandbox_root=trusted_sandbox_root(old["executable"],old_member,axis,supported["executable"],supported_member)
             assert report["status"]=="PASSED" and report["passed"] is True and report["qualification_performed"] is True
             installer=report["installer"]; exact(installer,("path","sha256","first_exit","second_exit","curl_invocations","first_path","second_path","curated_tools")); assert installer["sha256"]==sha(path/"installer.source")=="754799ff21807228b604b001b6a93bfd62b9748b3cfea45a33e59fefcbb717d5" and (installer["first_exit"],installer["second_exit"],installer["curl_invocations"])==(1,0,0)
-            verify_installer_paths(installer,old["executable"],supported["executable"])
+            verify_installer_paths(installer,old["executable"],supported["executable"],sandbox_root)
             first=(path/"first.stdout").read_text(); second=(path/"second.stdout").read_text()
             assert "TSA_DISABLE_UNVERIFIED_UV_BOOTSTRAP=1" in first and re.search(r"uv 0\.10\.9(?: [^\n]+)? does not satisfy required uv >= 0\.11\.0",first) and "installation complete" not in first and "uv 0.11.0" in second
-            config=report["config"]; exact(config,("before","after_first","after_second","expected_entry","backup_sha256")); assert config["before"]==config["after_first"] and re.fullmatch(r"[0-9a-f]{64}",config["backup_sha256"]) and config["backup_sha256"]==hashlib.sha256(b"{}\n").hexdigest()
-            before=snapshots(config["before"]); snapshots(config["after_first"]); after=snapshots(config["after_second"]); added=set(after)-set(before)
+            config=report["config"]; before=verify_initial_config(config); snapshots(config["after_first"]); after=snapshots(config["after_second"]); added=set(after)-set(before)
             backups={name for name in added if re.fullmatch(r"\.claude/\.mcp\.json\.bak\.\d{8}-\d{6}",name)}
             assert set(before)-set(after)==set() and added==backups and len(backups)==1 and after[next(iter(backups))]["sha256"]==config["backup_sha256"] and before[".claude/.mcp.json"]!=after[".claude/.mcp.json"] and {k:v for k,v in before.items() if k!=".claude/.mcp.json"}=={k:v for k,v in after.items() if k not in added|{".claude/.mcp.json"}}
-            verify_config_sidecar(path,config,after,axis,second)
+            verify_config_sidecar(path,config,after,axis,second,sandbox_root)
             causal_path=path/"mcp/report.json"; causal=json.loads(causal_path.read_text()); bound=report["mcp_causal_report"]
             exact(causal,("schema_version","kind","qualification_id","evidence_scope","axis","qualification_performed","passed","source","workflow","runner","wheel","stages","failure","build_manifest_sha256","install","metadata","runtime","mcp","dependency_manifest_sha256","installed_files_zip_sha256")); identity(causal,"outdated-axis")
             assert causal["axis"]==axis and causal["stages"]==[{"id":stage,"passed":True} for stage in ("verify_wheel","install","metadata_provenance","mcp_protocol")] and causal["failure"] is None
@@ -478,9 +504,9 @@ jobs:
           assert outdated_aggregate["qualified"] is False and outdated_aggregate["evidence_trust"]=="EXTERNAL_ATTESTATION_REQUIRED" and outdated_aggregate["automatic_mutable_bootstrap_qualified"] is False and outdated_aggregate["failures"]==[]
           assert outdated_aggregate["required_axes"]=={"package":["linux","macos","windows"],"outdated":["linux","macos"],"not_applicable":{"windows":"NOT_APPLICABLE_NO_NATIVE_INSTALLER"}}
           assert outdated_aggregate["axes"]==[{"axis":a,"report_sha256":sha(outdated_dirs[a]/"report.json"),"status":reports[a]["status"],"passed":reports[a]["passed"]} for a in ("linux","macos","windows")]
-          leaves=[sha(wheel_path),sha(package_aggregate_path),sha(outdated_aggregate_path),*[sha(p/"report.json") for p in package_dirs.values()],*[sha(p/"report.json") for p in outdated_dirs.values()]]
+          leaves=[sha(wheel_path),sha(package_aggregate_path),sha(outdated_aggregate_path),*[sha(p/"report.json") for p in package_dirs.values()],*[sha(p/"report.json") for p in outdated_dirs.values()],*[job_result_sha256[a] for a in ("linux","macos","windows")]]
           closure=hashlib.sha256("\n".join(leaves).encode()).hexdigest()
-          receipt={"schema_version":"no1-006a-independent-verification-v1","source_commit":commit,"run_id":run,"run_attempt":attempt,"wheel":{"path":str(wheel_path),"sha256":leaves[0]},"package_aggregate_sha256":leaves[1],"outdated_aggregate_sha256":leaves[2],"closure_sha256":closure,"automatic_mutable_bootstrap_qualified":False}
+          receipt={"schema_version":"no1-006a-independent-verification-v1","source_commit":commit,"run_id":run,"run_attempt":attempt,"wheel":{"path":str(wheel_path),"sha256":leaves[0]},"package_aggregate_sha256":leaves[1],"outdated_aggregate_sha256":leaves[2],"outdated_job_result_sha256":job_result_sha256,"closure_sha256":closure,"automatic_mutable_bootstrap_qualified":False}
           pathlib.Path("verified").mkdir(); pathlib.Path("verified/receipt.json").write_text(json.dumps(receipt,sort_keys=True)+"\n")
           PY
       - name: Publish read-only verification receipt

--- a/rfcs/schemas/no1-006a-outdated-uv-attestation-v2.schema.json
+++ b/rfcs/schemas/no1-006a-outdated-uv-attestation-v2.schema.json
@@ -752,6 +752,7 @@
                     "old.archive",
                     "supported.archive",
                     "installer.source",
+                    "installed-mcp-config.json",
                     "first.stdout",
                     "first.stderr",
                     "second.stdout",

--- a/rfcs/schemas/no1-006a-outdated-uv-attestation-v3.schema.json
+++ b/rfcs/schemas/no1-006a-outdated-uv-attestation-v3.schema.json
@@ -116,8 +116,53 @@
         "after_first": {
           "items": {
             "additionalProperties": false,
+            "allOf": [
+              {
+                "if": {
+                  "properties": {
+                    "type": {
+                      "const": "file"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                "then": {
+                  "properties": {
+                    "sha256": {
+                      "pattern": "^[0-9a-f]{64}$",
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              {
+                "if": {
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "dir",
+                        "symlink"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                "then": {
+                  "properties": {
+                    "sha256": {
+                      "type": "null"
+                    }
+                  }
+                }
+              }
+            ],
             "properties": {
               "path": {
+                "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.?(?:/|$))(?!.*\\\\)[^\\x00\\r\\n]+$",
                 "type": "string"
               },
               "sha256": {
@@ -147,8 +192,53 @@
         "after_second": {
           "items": {
             "additionalProperties": false,
+            "allOf": [
+              {
+                "if": {
+                  "properties": {
+                    "type": {
+                      "const": "file"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                "then": {
+                  "properties": {
+                    "sha256": {
+                      "pattern": "^[0-9a-f]{64}$",
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              {
+                "if": {
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "dir",
+                        "symlink"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                "then": {
+                  "properties": {
+                    "sha256": {
+                      "type": "null"
+                    }
+                  }
+                }
+              }
+            ],
             "properties": {
               "path": {
+                "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.?(?:/|$))(?!.*\\\\)[^\\x00\\r\\n]+$",
                 "type": "string"
               },
               "sha256": {
@@ -182,8 +272,53 @@
         "before": {
           "items": {
             "additionalProperties": false,
+            "allOf": [
+              {
+                "if": {
+                  "properties": {
+                    "type": {
+                      "const": "file"
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                "then": {
+                  "properties": {
+                    "sha256": {
+                      "pattern": "^[0-9a-f]{64}$",
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              {
+                "if": {
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "dir",
+                        "symlink"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "type"
+                  ]
+                },
+                "then": {
+                  "properties": {
+                    "sha256": {
+                      "type": "null"
+                    }
+                  }
+                }
+              }
+            ],
             "properties": {
               "path": {
+                "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.?(?:/|$))(?!.*\\\\)[^\\x00\\r\\n]+$",
                 "type": "string"
               },
               "sha256": {
@@ -748,6 +883,29 @@
             {
               "properties": {
                 "artifacts": {
+                  "maxProperties": 17,
+                  "minProperties": 17,
+                  "propertyNames": {
+                    "enum": [
+                      "old.archive",
+                      "supported.archive",
+                      "installer.source",
+                      "installed-mcp-config.json",
+                      "first.stdout",
+                      "first.stderr",
+                      "second.stdout",
+                      "second.stderr",
+                      "mcp-driver.stdout",
+                      "mcp-driver.stderr",
+                      "mcp/report.json",
+                      "mcp/install.stdout",
+                      "mcp/install.stderr",
+                      "mcp/dependency-manifest.txt",
+                      "mcp/mcp-transcript.ndjson",
+                      "mcp/mcp.stderr",
+                      "mcp/installed-files.zip"
+                    ]
+                  },
                   "required": [
                     "old.archive",
                     "supported.archive",
@@ -878,6 +1036,13 @@
             {
               "properties": {
                 "artifacts": {
+                  "maxProperties": 1,
+                  "minProperties": 1,
+                  "propertyNames": {
+                    "enum": [
+                      "old.archive"
+                    ]
+                  },
                   "required": [
                     "old.archive"
                   ]
@@ -1144,7 +1309,7 @@
           "$ref": "#/$defs/runner"
         },
         "schema_version": {
-          "const": "no1-006a-outdated-uv-attestation-v2"
+          "const": "no1-006a-outdated-uv-attestation-v3"
         },
         "source": {
           "additionalProperties": false,
@@ -1447,7 +1612,7 @@
           }
         },
         "schema_version": {
-          "const": "no1-006a-outdated-uv-attestation-v2"
+          "const": "no1-006a-outdated-uv-attestation-v3"
         },
         "source_commit": {
           "pattern": "^[0-9a-f]{40}$",

--- a/scripts/qualify_outdated_uv.py
+++ b/scripts/qualify_outdated_uv.py
@@ -186,7 +186,8 @@ def sandbox_root(axis:str)->Path:
     if not base.is_absolute() or root.parent!=base: raise ValueError("unsafe qualification sandbox base")
     root.mkdir(mode=0o700,exist_ok=False)
     observed=root.lstat()
-    if not stat.S_ISDIR(observed.st_mode) or root.is_symlink() or root.stat().st_uid!=os.getuid():
+    owner_matches = not hasattr(os, "getuid") or observed.st_uid == os.getuid()
+    if not stat.S_ISDIR(observed.st_mode) or root.is_symlink() or not owner_matches:
         shutil.rmtree(root,ignore_errors=True); raise ValueError("unsafe qualification sandbox root")
     root.chmod(0o700)
     return root

--- a/scripts/qualify_outdated_uv.py
+++ b/scripts/qualify_outdated_uv.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 # ruff: noqa: B904, E401, E701, E702, I001
 # fmt: off
-import argparse, hashlib, json, os, platform, re, shutil, signal, subprocess, sys, tarfile, tempfile, time, urllib.request, zipfile
+import argparse, hashlib, json, os, platform, re, shutil, signal, stat, subprocess, sys, tarfile, tempfile, time, urllib.request, zipfile
 from pathlib import Path
 
 import psutil
@@ -17,6 +17,7 @@ AXES = ("linux", "macos", "windows")
 PROJECT = Path(__file__).resolve().parents[1]
 ALLOWLIST_PATH = PROJECT / "config/no1_uv_fixtures.json"
 REQUIRED_COMMANDS = ("awk", "cat", "grep", "mktemp", "python3", "realpath", "rm", "sleep", "uname")
+POSIX_SANDBOX_BASES = {"linux": Path("/tmp"), "macos": Path("/private/tmp")}
 
 def sha256(path: Path) -> str:
     h=hashlib.sha256()
@@ -177,6 +178,19 @@ def package_binding(args: argparse.Namespace)->dict[str,Any]:
     if r.get("wheel")!=meta or expected not in a.get("axes",[]) or a.get("wheel")!=meta: raise ValueError("package axis/wheel binding mismatch")
     return {"aggregate_sha256":sha256(aggregate),"axis_report_sha256":sha256(report),"build_manifest_sha256":sha256(manifest),"wheel":meta}
 
+def sandbox_root(axis:str)->Path:
+    if axis not in POSIX_SANDBOX_BASES: raise ValueError("deterministic sandbox is POSIX-only")
+    run=os.environ.get("GITHUB_RUN_ID","0"); attempt=os.environ.get("GITHUB_RUN_ATTEMPT","0")
+    if re.fullmatch(r"(?:0|[1-9]\d*)",run) is None or re.fullmatch(r"(?:0|[1-9]\d*)",attempt) is None: raise ValueError("invalid GitHub run identity for sandbox")
+    base=POSIX_SANDBOX_BASES[axis]; root=base/f"tsa-outdated-native-{run}-{attempt}-{axis}"
+    if not base.is_absolute() or root.parent!=base: raise ValueError("unsafe qualification sandbox base")
+    root.mkdir(mode=0o700,exist_ok=False)
+    observed=root.lstat()
+    if not stat.S_ISDIR(observed.st_mode) or root.is_symlink() or root.stat().st_uid!=os.getuid():
+        shutil.rmtree(root,ignore_errors=True); raise ValueError("unsafe qualification sandbox root")
+    root.chmod(0o700)
+    return root
+
 def base_report(axis:str)->dict[str,Any]:
     source,workflow=identity("outdated-uv-axis")
     return {"schema_version":SCHEMA_VERSION,"kind":"outdated_uv_axis","qualification_id":"NO1-006A","evidence_scope":"native_outdated_uv_actionable_recovery","axis":axis,"qualification_performed":axis!="windows","passed":False,"status":"NOT_APPLICABLE_NO_NATIVE_INSTALLER" if axis=="windows" else "PENDING","source":source,"workflow":workflow,"runner":{"declared_axis":axis,"observed_system":platform.system(),"release":platform.release(),"machine":platform.machine(),"image_os":os.environ.get("ImageOS","unknown"),"image_version":os.environ.get("ImageVersion","unknown")},"remediation_mode":"manual_content_bound_remediation","automatic_mutable_bootstrap_qualified":False,"old_uv":None,"supported_uv":None,"installer":None,"config":None,"package_qualification":None,"mcp_causal_report":None,"artifacts":{},"failure":None}
@@ -190,7 +204,7 @@ def axis(args:argparse.Namespace)->int:
         expected_system={"linux":"Linux","macos":"Darwin","windows":"Windows"}[args.axis]
         if platform.system()!=expected_system: raise ValueError("declared axis and native runner differ")
         old_archive=Path(args.old_archive); old_meta=validate_archive(old_archive,fixture(args.axis,OLD_VERSION)); shutil.copyfile(old_archive,side/"old.archive"); report["artifacts"]["old.archive"]={"sha256":old_meta["sha256"],"size":old_meta["size"]}
-        root=Path(tempfile.mkdtemp(prefix="tsa-outdated-native-"))
+        root=sandbox_root(args.axis) if args.axis!="windows" else Path(tempfile.mkdtemp(prefix="tsa-outdated-native-windows-"))
         try:
             old=uv_details(safe_extract(old_archive,root/"old",old_meta["filename"]),OLD_VERSION); report["old_uv"]={"archive":old_meta,"executable":old}
             report["package_qualification"]=package_binding(args)

--- a/scripts/qualify_outdated_uv.py
+++ b/scripts/qualify_outdated_uv.py
@@ -215,11 +215,12 @@ def axis(args:argparse.Namespace)->int:
             second=run_tree(["/bin/bash",str(installer)],project,clean_env(home,temp,supported_path,False),args.timeout)
             write_side(side,"second.stdout",second.stdout,report); write_side(side,"second.stderr",second.stderr,report); after_second=tree_snapshot(home)
             expected_entry={"command":"uvx","args":["--from","tree-sitter-analyzer[mcp]","tree-sitter-analyzer-mcp"],"env":{"TREE_SITTER_PROJECT_ROOT":str(project.resolve())}}
-            value=json.loads(config.read_text()); backups=list(config.parent.glob(".mcp.json.bak.*"))
+            config_bytes=config.read_bytes(); write_side(side,"installed-mcp-config.json",config_bytes,report)
+            value=json.loads(config_bytes); backups=list(config.parent.glob(".mcp.json.bak.*"))
             expected_value={"mcpServers":{"tree-sitter-analyzer":expected_entry}}
             if second.returncode!=0 or f"uv {SUPPORTED_VERSION}" not in second.stdout.decode("utf-8","replace") or value!=expected_value or len(backups)!=1 or backups[0].read_bytes()!=b'{}\n': raise ValueError("manual recovery config diff/backup oracle failed")
             expected_after=[item for item in before if item["path"] not in (".claude/.mcp.json",)]
-            expected_after.extend([{"path":".claude/.mcp.json","type":"file","sha256":hashlib.sha256((json.dumps(expected_value,indent=2)+"\n").encode()).hexdigest()},{"path":str(backups[0].relative_to(home)),"type":"file","sha256":hashlib.sha256(b'{}\n').hexdigest()}])
+            expected_after.extend([{"path":".claude/.mcp.json","type":"file","sha256":sha256(config)},{"path":str(backups[0].relative_to(home)),"type":"file","sha256":hashlib.sha256(b'{}\n').hexdigest()}])
             if sorted(after_second,key=lambda item:item["path"])!=sorted(expected_after,key=lambda item:item["path"]): raise ValueError("second install changed HOME beyond exact config replacement and one backup")
             report["installer"]={"path":str(installer),"sha256":sha256(installer),"first_exit":first.returncode,"second_exit":second.returncode,"curl_invocations":0,"first_path":old_path,"second_path":supported_path,"curated_tools":list(REQUIRED_COMMANDS)}
             report["config"]={"before":before,"after_first":after_first,"after_second":after_second,"expected_entry":expected_entry,"backup_sha256":sha256(backups[0])}

--- a/scripts/qualify_outdated_uv.py
+++ b/scripts/qualify_outdated_uv.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import psutil
 from typing import Any
 
-SCHEMA_VERSION = "no1-006a-outdated-uv-attestation-v2"
+SCHEMA_VERSION = "no1-006a-outdated-uv-attestation-v3"
 OLD_VERSION, SUPPORTED_VERSION = "0.10.9", "0.11.0"
 AXES = ("linux", "macos", "windows")
 PROJECT = Path(__file__).resolve().parents[1]
@@ -284,6 +284,6 @@ def main()->int:
     a=sub.add_parser("axis"); a.add_argument("--axis",choices=AXES,required=True)
     for name in ("old-archive","installer","wheel","wheel-manifest","package-aggregate","package-report","output"): a.add_argument("--"+name,required=True)
     a.add_argument("--supported-archive"); a.add_argument("--timeout",type=float,default=180); a.set_defaults(func=axis)
-    g=sub.add_parser("aggregate"); g.add_argument("--reports",nargs=3,required=True); g.add_argument("--schema",default=str(PROJECT/"rfcs/schemas/no1-006a-outdated-uv-attestation-v2.schema.json")); g.add_argument("--output",required=True); g.add_argument("--trusted",action="store_true"); g.set_defaults(func=aggregate)
+    g=sub.add_parser("aggregate"); g.add_argument("--reports",nargs=3,required=True); g.add_argument("--schema",default=str(PROJECT/"rfcs/schemas/no1-006a-outdated-uv-attestation-v3.schema.json")); g.add_argument("--output",required=True); g.add_argument("--trusted",action="store_true"); g.set_defaults(func=aggregate)
     args=parser.parse_args(); return int(args.func(args))
 if __name__=="__main__": raise SystemExit(main())

--- a/tests/contracts/test_outdated_uv_qualification.py
+++ b/tests/contracts/test_outdated_uv_qualification.py
@@ -10,7 +10,7 @@ import sys
 import tarfile
 import time
 import zipfile
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 import jsonschema
 import psutil
@@ -682,7 +682,7 @@ def test_trusted_config_sidecar_accepts_noncanonical_format(tmp_path: Path) -> N
             after,
             "linux",
             "📁 Project root: /tmp/tsa-outdated-native-test/fixture\n",
-            Path("/tmp/tsa-outdated-native-test"),
+            PurePosixPath("/tmp/tsa-outdated-native-test"),
         )
         is None
     )
@@ -723,7 +723,7 @@ def test_trusted_config_sidecar_rejects_forgery(tmp_path: Path, mutation: str) -
             after,
             "linux",
             "📁 Project root: /tmp/tsa-outdated-native-test/fixture\n",
-            Path("/tmp/tsa-outdated-native-test"),
+            PurePosixPath("/tmp/tsa-outdated-native-test"),
         )
 
 
@@ -748,7 +748,7 @@ def test_trusted_config_rejects_coordinated_command_forgery(tmp_path: Path) -> N
             after,
             "linux",
             "📁 Project root: /tmp/tsa-outdated-native-test/fixture\n",
-            Path("/tmp/tsa-outdated-native-test"),
+            PurePosixPath("/tmp/tsa-outdated-native-test"),
         )
 
 
@@ -800,7 +800,7 @@ def test_trusted_installer_paths_reject_unverified_first_executable() -> None:
             report["installer"],
             report["old_uv"]["executable"],
             report["supported_uv"]["executable"],
-            Path("/tmp/tsa-outdated-native-test"),
+            PurePosixPath("/tmp/tsa-outdated-native-test"),
         )
 
 
@@ -813,7 +813,7 @@ def test_trusted_installer_paths_reject_non_curated_path_tail() -> None:
             report["installer"],
             report["old_uv"]["executable"],
             report["supported_uv"]["executable"],
-            Path("/tmp/tsa-outdated-native-test"),
+            PurePosixPath("/tmp/tsa-outdated-native-test"),
         )
 
 
@@ -938,7 +938,7 @@ def test_trusted_project_root_rejects_coordinated_candidate_value() -> None:
         trusted_helpers()["project_root_from_stdout"](
             "📁 Project root: /tmp/tsa-outdated-native-forged/fixture\n",
             "linux",
-            Path("/tmp/tsa-outdated-native-test"),
+            PurePosixPath("/tmp/tsa-outdated-native-test"),
         )
 
 

--- a/tests/contracts/test_outdated_uv_qualification.py
+++ b/tests/contracts/test_outdated_uv_qualification.py
@@ -60,6 +60,37 @@ def test_clean_environment_drops_host_uv_python_xdg_and_shell_injection(
     )
 
 
+def test_local_identity_uses_deterministic_absolute_posix_sandbox(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # PR #1245: local identity 0 remains directly testable without random prefixes.
+    monkeypatch.setenv("GITHUB_RUN_ID", "0")
+    monkeypatch.setenv("GITHUB_RUN_ATTEMPT", "0")
+    monkeypatch.setitem(qualification.POSIX_SANDBOX_BASES, "linux", tmp_path)
+    root = qualification.sandbox_root("linux")
+    try:
+        assert root == tmp_path / "tsa-outdated-native-0-0-linux"
+        assert root.is_absolute()
+        assert root.stat().st_mode & 0o777 == 0o700
+    finally:
+        qualification.shutil.rmtree(root)
+
+
+def test_deterministic_sandbox_refuses_identity_collision(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # PR #1245: a concurrent/replayed identity cannot reuse an existing root.
+    monkeypatch.setenv("GITHUB_RUN_ID", "0")
+    monkeypatch.setenv("GITHUB_RUN_ATTEMPT", "0")
+    monkeypatch.setitem(qualification.POSIX_SANDBOX_BASES, "linux", tmp_path)
+    root = qualification.sandbox_root("linux")
+    try:
+        with pytest.raises(FileExistsError):
+            qualification.sandbox_root("linux")
+    finally:
+        qualification.shutil.rmtree(root)
+
+
 @pytest.mark.skipif(
     os.name == "nt", reason="tracked: POSIX installer process-group cleanup"
 )
@@ -310,7 +341,7 @@ def valid_passed_report() -> dict[str, object]:
                 "sha256": digest,
             },
             "executable": executable(
-                "0.10.9", "/tmp/tsa-outdated-native-test/old/bundle/uv"
+                "0.10.9", "/tmp/tsa-outdated-native-0-0-linux/old/bundle/uv"
             ),
         },
         supported_uv={
@@ -322,7 +353,7 @@ def valid_passed_report() -> dict[str, object]:
                 "sha256": digest,
             },
             "executable": executable(
-                "0.11.0", "/tmp/tsa-outdated-native-test/supported/bundle/uv"
+                "0.11.0", "/tmp/tsa-outdated-native-0-0-linux/supported/bundle/uv"
             ),
         },
         installer={
@@ -331,8 +362,8 @@ def valid_passed_report() -> dict[str, object]:
             "first_exit": 1,
             "second_exit": 0,
             "curl_invocations": 0,
-            "first_path": "/tmp/tsa-outdated-native-test/old/bundle:/tmp/tsa-outdated-native-test/tools",
-            "second_path": "/tmp/tsa-outdated-native-test/supported/bundle:/tmp/tsa-outdated-native-test/tools",
+            "first_path": "/tmp/tsa-outdated-native-0-0-linux/old/bundle:/tmp/tsa-outdated-native-0-0-linux/tools",
+            "second_path": "/tmp/tsa-outdated-native-0-0-linux/supported/bundle:/tmp/tsa-outdated-native-0-0-linux/tools",
             "curated_tools": list(qualification.REQUIRED_COMMANDS),
         },
         config={
@@ -347,7 +378,7 @@ def valid_passed_report() -> dict[str, object]:
                     "tree-sitter-analyzer-mcp",
                 ],
                 "env": {
-                    "TREE_SITTER_PROJECT_ROOT": "/tmp/tsa-outdated-native-test/fixture"
+                    "TREE_SITTER_PROJECT_ROOT": "/tmp/tsa-outdated-native-0-0-linux/fixture"
                 },
             },
             "backup_sha256": digest,
@@ -374,7 +405,7 @@ def valid_passed_report() -> dict[str, object]:
                 "summary": "codegraph_status: index missing or empty",
             },
             "install_tool": executable(
-                "0.11.0", "/tmp/tsa-outdated-native-test/supported/bundle/uv"
+                "0.11.0", "/tmp/tsa-outdated-native-0-0-linux/supported/bundle/uv"
             ),
             "install_argv": [
                 "/tmp/supported/bundle/uv",
@@ -615,9 +646,9 @@ def trusted_helpers() -> dict[str, object]:
     code = "\n".join(
         line
         for line in code.splitlines()
-        if not line.lstrip().startswith(("root=", "suffix="))
+        if not line.lstrip().startswith(("root=", "run=", "suffix="))
     )
-    namespace: dict[str, object] = {}
+    namespace: dict[str, object] = {"run": "0", "attempt": "0"}
     exec(textwrap.dedent(code), namespace)
     return namespace
 
@@ -681,8 +712,8 @@ def test_trusted_config_sidecar_accepts_noncanonical_format(tmp_path: Path) -> N
             config,
             after,
             "linux",
-            "📁 Project root: /tmp/tsa-outdated-native-test/fixture\n",
-            PurePosixPath("/tmp/tsa-outdated-native-test"),
+            "📁 Project root: /tmp/tsa-outdated-native-0-0-linux/fixture\n",
+            PurePosixPath("/tmp/tsa-outdated-native-0-0-linux"),
         )
         is None
     )
@@ -722,8 +753,8 @@ def test_trusted_config_sidecar_rejects_forgery(tmp_path: Path, mutation: str) -
             config,
             after,
             "linux",
-            "📁 Project root: /tmp/tsa-outdated-native-test/fixture\n",
-            PurePosixPath("/tmp/tsa-outdated-native-test"),
+            "📁 Project root: /tmp/tsa-outdated-native-0-0-linux/fixture\n",
+            PurePosixPath("/tmp/tsa-outdated-native-0-0-linux"),
         )
 
 
@@ -747,8 +778,8 @@ def test_trusted_config_rejects_coordinated_command_forgery(tmp_path: Path) -> N
             config,
             after,
             "linux",
-            "📁 Project root: /tmp/tsa-outdated-native-test/fixture\n",
-            PurePosixPath("/tmp/tsa-outdated-native-test"),
+            "📁 Project root: /tmp/tsa-outdated-native-0-0-linux/fixture\n",
+            PurePosixPath("/tmp/tsa-outdated-native-0-0-linux"),
         )
 
 
@@ -800,7 +831,7 @@ def test_trusted_installer_paths_reject_unverified_first_executable() -> None:
             report["installer"],
             report["old_uv"]["executable"],
             report["supported_uv"]["executable"],
-            PurePosixPath("/tmp/tsa-outdated-native-test"),
+            PurePosixPath("/tmp/tsa-outdated-native-0-0-linux"),
         )
 
 
@@ -813,7 +844,7 @@ def test_trusted_installer_paths_reject_non_curated_path_tail() -> None:
             report["installer"],
             report["old_uv"]["executable"],
             report["supported_uv"]["executable"],
-            PurePosixPath("/tmp/tsa-outdated-native-test"),
+            PurePosixPath("/tmp/tsa-outdated-native-0-0-linux"),
         )
 
 
@@ -886,49 +917,58 @@ def test_trusted_causal_binding_rejects_install_mutation(
         )
 
 
-@pytest.mark.parametrize("mutation", ["old-label", "different-root", "tools"])
-def test_trusted_sandbox_root_rejects_candidate_coordination(mutation: str) -> None:
-    # PR #1245: executable archive layouts, not cooperating sidecars, anchor the root.
+@pytest.mark.parametrize(
+    ("axis", "expected"),
+    [
+        ("linux", PurePosixPath("/tmp/tsa-outdated-native-0-0-linux")),
+        ("macos", PurePosixPath("/private/tmp/tsa-outdated-native-0-0-macos")),
+    ],
+)
+def test_trusted_sandbox_root_is_independent_platform_oracle(
+    axis: str, expected: PurePosixPath
+) -> None:
+    # PR #1245: trusted roots come only from run/attempt/axis and platform base.
+    assert trusted_helpers()["trusted_sandbox_root"](axis) == expected
+
+
+def test_trusted_sandbox_root_is_not_applied_to_windows_na() -> None:
+    # PR #1245: Windows retains its N/A fixture without a POSIX root assumption.
+    with pytest.raises(AssertionError):
+        trusted_helpers()["trusted_sandbox_root"]("windows")
+
+
+def test_trusted_executable_rejects_coordinated_forged_prefixes() -> None:
+    # Codex 3742146107: matching old/supported producer prefixes are not an oracle.
     helpers = trusted_helpers()
     report = valid_passed_report()
     member = {"member": "bundle/uv", "sha256": "a" * 64, "size": 1}
-    if mutation == "old-label":
-        report["old_uv"]["executable"]["path"] = (
-            "/tmp/tsa-outdated-native-test/evil/bundle/uv"
+    sandbox = helpers["trusted_sandbox_root"]("linux")
+    for label in ("old", "supported"):
+        report[f"{label}_uv"]["executable"]["path"] = (
+            f"/tmp/tsa-outdated-native-forged/{label}/bundle/uv"
         )
         with pytest.raises(AssertionError):
-            helpers["executable_sandbox_root"](
-                report["old_uv"]["executable"], member, "old", "linux"
+            helpers["verify_executable_sandbox"](
+                report[f"{label}_uv"]["executable"], member, label, "linux", sandbox
             )
-        return
-    old_root = helpers["executable_sandbox_root"](
-        report["old_uv"]["executable"], member, "old", "linux"
-    )
-    if mutation == "different-root":
-        report["supported_uv"]["executable"]["path"] = (
-            "/tmp/tsa-outdated-native-forged/supported/bundle/uv"
-        )
-        with pytest.raises(AssertionError):
-            helpers["trusted_sandbox_root"](
-                report["old_uv"]["executable"],
-                member,
-                "linux",
-                report["supported_uv"]["executable"],
-                member,
-            )
-        return
+
+
+def test_trusted_installer_paths_reject_forged_tools_root() -> None:
+    # PR #1245: curated tools must be under the independently expected sandbox.
+    helpers = trusted_helpers()
+    report = valid_passed_report()
     report["installer"]["first_path"] = (
-        "/tmp/tsa-outdated-native-test/old/bundle:/tmp/attacker/tools"
+        "/tmp/tsa-outdated-native-0-0-linux/old/bundle:/tmp/attacker/tools"
     )
     report["installer"]["second_path"] = (
-        "/tmp/tsa-outdated-native-test/supported/bundle:/tmp/attacker/tools"
+        "/tmp/tsa-outdated-native-0-0-linux/supported/bundle:/tmp/attacker/tools"
     )
     with pytest.raises(AssertionError):
         helpers["verify_installer_paths"](
             report["installer"],
             report["old_uv"]["executable"],
             report["supported_uv"]["executable"],
-            old_root,
+            helpers["trusted_sandbox_root"]("linux"),
         )
 
 
@@ -938,7 +978,7 @@ def test_trusted_project_root_rejects_coordinated_candidate_value() -> None:
         trusted_helpers()["project_root_from_stdout"](
             "📁 Project root: /tmp/tsa-outdated-native-forged/fixture\n",
             "linux",
-            PurePosixPath("/tmp/tsa-outdated-native-test"),
+            PurePosixPath("/tmp/tsa-outdated-native-0-0-linux"),
         )
 
 

--- a/tests/contracts/test_outdated_uv_qualification.py
+++ b/tests/contracts/test_outdated_uv_qualification.py
@@ -131,7 +131,7 @@ def test_windows_na_requires_evidence_and_allows_empty_sidecar() -> None:
 def test_passed_schema_requires_every_platform_artifact() -> None:
     # PR #1242: PASSED POSIX evidence must retain every causal sidecar.
     report = valid_passed_report()
-    del report["artifacts"]["mcp/report.json"]
+    del report["artifacts"]["installed-mcp-config.json"]
     with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(report, SCHEMA)
 
@@ -377,6 +377,7 @@ def valid_passed_report() -> dict[str, object]:
         "old.archive",
         "supported.archive",
         "installer.source",
+        "installed-mcp-config.json",
         "first.stdout",
         "first.stderr",
         "second.stdout",
@@ -644,17 +645,52 @@ def test_trusted_archive_member_digest_binds_reported_executable(
         helpers["verify_executable"](executable, observed, "0.11.0", "linux")
 
 
-def test_trusted_config_hash_is_recomputed_from_expected_entry() -> None:
-    # PR #1242: trusted config evidence is bound to canonical installer JSON bytes.
-    expected_entry = valid_passed_report()["config"]["expected_entry"]
-    observed = trusted_helpers()["expected_config_hash"](expected_entry)
-    expected = {"mcpServers": {"tree-sitter-analyzer": expected_entry}}
-    assert (
-        observed
-        == qualification.hashlib.sha256(
-            (json.dumps(expected, indent=2) + "\n").encode()
-        ).hexdigest()
+def test_trusted_config_sidecar_accepts_noncanonical_format(tmp_path: Path) -> None:
+    # Run 31284682751: formatting must not substitute for observed config bytes.
+    config = valid_passed_report()["config"]
+    value = {"mcpServers": {"tree-sitter-analyzer": config["expected_entry"]}}
+    data = json.dumps(value, separators=(",", ":")).encode()
+    (tmp_path / "installed-mcp-config.json").write_bytes(data)
+    after = {
+        ".claude/.mcp.json": {
+            "path": ".claude/.mcp.json",
+            "type": "file",
+            "sha256": qualification.hashlib.sha256(data).hexdigest(),
+        }
+    }
+    assert trusted_helpers()["verify_config_sidecar"](tmp_path, config, after) is None
+
+
+@pytest.mark.parametrize("mutation", ["duplicate", "extra", "entry", "snapshot"])
+def test_trusted_config_sidecar_rejects_forgery(tmp_path: Path, mutation: str) -> None:
+    # Run 31284682751: trusted verification parses and binds the actual sidecar.
+    config = valid_passed_report()["config"]
+    expected = {"mcpServers": {"tree-sitter-analyzer": config["expected_entry"]}}
+    if mutation == "duplicate":
+        body = json.dumps(expected["mcpServers"])
+        data = f'{{"mcpServers":{body},"mcpServers":{body}}}'.encode()
+    else:
+        forged = json.loads(json.dumps(expected))
+        if mutation == "extra":
+            forged["extra"] = True
+        elif mutation == "entry":
+            forged["mcpServers"]["tree-sitter-analyzer"]["command"] = "forged"
+        data = json.dumps(forged).encode()
+    digest = (
+        "0" * 64
+        if mutation == "snapshot"
+        else qualification.hashlib.sha256(data).hexdigest()
     )
+    (tmp_path / "installed-mcp-config.json").write_bytes(data)
+    after = {
+        ".claude/.mcp.json": {
+            "path": ".claude/.mcp.json",
+            "type": "file",
+            "sha256": digest,
+        }
+    }
+    with pytest.raises(AssertionError):
+        trusted_helpers()["verify_config_sidecar"](tmp_path, config, after)
 
 
 def test_trusted_installer_paths_reject_unverified_first_executable() -> None:

--- a/tests/contracts/test_outdated_uv_qualification.py
+++ b/tests/contracts/test_outdated_uv_qualification.py
@@ -23,7 +23,7 @@ from _native_trusted_verifier_helpers import outdated_causal_fixture  # noqa: E4
 
 ROOT = Path(__file__).parents[2]
 SCHEMA = json.loads(
-    (ROOT / "rfcs/schemas/no1-006a-outdated-uv-attestation-v2.schema.json").read_text()
+    (ROOT / "rfcs/schemas/no1-006a-outdated-uv-attestation-v3.schema.json").read_text()
 )
 
 
@@ -117,10 +117,11 @@ def test_schema_rejects_windows_pass_and_mutable_bootstrap_claim() -> None:
         jsonschema.validate(report, SCHEMA)
 
 
-def test_windows_na_requires_evidence_and_allows_empty_sidecar() -> None:
+def test_windows_na_requires_exact_old_archive_artifact() -> None:
     report = valid_windows_report()
     report["artifacts"]["empty.stderr"] = {"sha256": "0" * 64, "size": 0}
-    jsonschema.validate(report, SCHEMA)
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(report, SCHEMA)
     for field in ("old_uv", "package_qualification"):
         invalid = valid_windows_report()
         invalid[field] = {}
@@ -132,6 +133,14 @@ def test_passed_schema_requires_every_platform_artifact() -> None:
     # PR #1242: PASSED POSIX evidence must retain every causal sidecar.
     report = valid_passed_report()
     del report["artifacts"]["installed-mcp-config.json"]
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(report, SCHEMA)
+
+
+def test_passed_schema_rejects_artifacts_outside_exact_allowlist() -> None:
+    # Final gate 2026-07-17: POSIX evidence is exactly the 17 protocol files.
+    report = valid_passed_report()
+    report["artifacts"]["extra.bin"] = {"sha256": "a" * 64, "size": 0}
     with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(report, SCHEMA)
 
@@ -333,7 +342,9 @@ def valid_passed_report() -> dict[str, object]:
                     "tree-sitter-analyzer[mcp]",
                     "tree-sitter-analyzer-mcp",
                 ],
-                "env": {"TREE_SITTER_PROJECT_ROOT": "/tmp/project"},
+                "env": {
+                    "TREE_SITTER_PROJECT_ROOT": "/tmp/tsa-outdated-native-test/fixture"
+                },
             },
             "backup_sha256": digest,
         },
@@ -482,7 +493,7 @@ def run_aggregate(tmp_path: Path, paths: list[Path]) -> tuple[int, dict[str, obj
             output=str(output),
             reports=[str(path) for path in paths],
             schema=str(
-                ROOT / "rfcs/schemas/no1-006a-outdated-uv-attestation-v2.schema.json"
+                ROOT / "rfcs/schemas/no1-006a-outdated-uv-attestation-v3.schema.json"
             ),
             trusted=False,
         )
@@ -658,7 +669,16 @@ def test_trusted_config_sidecar_accepts_noncanonical_format(tmp_path: Path) -> N
             "sha256": qualification.hashlib.sha256(data).hexdigest(),
         }
     }
-    assert trusted_helpers()["verify_config_sidecar"](tmp_path, config, after) is None
+    assert (
+        trusted_helpers()["verify_config_sidecar"](
+            tmp_path,
+            config,
+            after,
+            "linux",
+            "📁 Project root: /tmp/tsa-outdated-native-test/fixture\n",
+        )
+        is None
+    )
 
 
 @pytest.mark.parametrize("mutation", ["duplicate", "extra", "entry", "snapshot"])
@@ -690,7 +710,74 @@ def test_trusted_config_sidecar_rejects_forgery(tmp_path: Path, mutation: str) -
         }
     }
     with pytest.raises(AssertionError):
-        trusted_helpers()["verify_config_sidecar"](tmp_path, config, after)
+        trusted_helpers()["verify_config_sidecar"](
+            tmp_path,
+            config,
+            after,
+            "linux",
+            "📁 Project root: /tmp/tsa-outdated-native-test/fixture\n",
+        )
+
+
+def test_trusted_config_rejects_coordinated_command_forgery(tmp_path: Path) -> None:
+    # Final gate 2026-07-17: candidate config and sidecar cannot define the oracle.
+    config = json.loads(json.dumps(valid_passed_report()["config"]))
+    config["expected_entry"]["command"] = "evil"
+    value = {"mcpServers": {"tree-sitter-analyzer": config["expected_entry"]}}
+    data = json.dumps(value).encode()
+    (tmp_path / "installed-mcp-config.json").write_bytes(data)
+    after = {
+        ".claude/.mcp.json": {
+            "path": ".claude/.mcp.json",
+            "type": "file",
+            "sha256": qualification.hashlib.sha256(data).hexdigest(),
+        }
+    }
+    with pytest.raises(AssertionError):
+        trusted_helpers()["verify_config_sidecar"](
+            tmp_path,
+            config,
+            after,
+            "linux",
+            "📁 Project root: /tmp/tsa-outdated-native-test/fixture\n",
+        )
+
+
+@pytest.mark.parametrize(
+    "stdout",
+    [
+        "📁 Project root: /tmp/tsa-outdated-native-a/fixture\n"
+        "📁 Project root: /tmp/tsa-outdated-native-b/fixture\n",
+        "📁 Project root: /tmp/other/fixture\n",
+        "📁 Project root: /tmp/tsa-outdated-native-a/fixture/../fixture\n",
+        "📁 Project root: relative/tsa-outdated-native-a/fixture\n",
+    ],
+)
+def test_trusted_stdout_rejects_ambiguous_or_unstructured_root(stdout: str) -> None:
+    # Final gate 2026-07-17: the hash-bound stdout uniquely defines the root.
+    with pytest.raises(AssertionError):
+        trusted_helpers()["project_root_from_stdout"](stdout, "linux")
+
+
+@pytest.mark.parametrize(
+    "items",
+    [
+        [
+            {"path": "a", "type": "file", "sha256": "a" * 64},
+            {"path": "a", "type": "file", "sha256": "b" * 64},
+        ],
+        [{"path": "a", "type": "dir", "sha256": "a" * 64}],
+        [{"path": "a", "type": "file", "sha256": None}],
+        [{"path": "../a", "type": "file", "sha256": "a" * 64}],
+        [{"path": "a", "type": "file", "sha256": "a" * 64, "extra": True}],
+    ],
+)
+def test_trusted_snapshots_reject_ambiguous_entries(
+    items: list[dict[str, object]],
+) -> None:
+    # Final gate 2026-07-17: snapshot dictionaries must not erase ambiguity.
+    with pytest.raises(AssertionError):
+        trusted_helpers()["snapshots"](items)
 
 
 def test_trusted_installer_paths_reject_unverified_first_executable() -> None:

--- a/tests/contracts/test_outdated_uv_qualification.py
+++ b/tests/contracts/test_outdated_uv_qualification.py
@@ -71,7 +71,8 @@ def test_local_identity_uses_deterministic_absolute_posix_sandbox(
     try:
         assert root == tmp_path / "tsa-outdated-native-0-0-linux"
         assert root.is_absolute()
-        assert root.stat().st_mode & 0o777 == 0o700
+        if os.name != "nt":
+            assert root.stat().st_mode & 0o777 == 0o700
     finally:
         qualification.shutil.rmtree(root)
 

--- a/tests/contracts/test_outdated_uv_qualification.py
+++ b/tests/contracts/test_outdated_uv_qualification.py
@@ -309,7 +309,9 @@ def valid_passed_report() -> dict[str, object]:
                 "size": 1,
                 "sha256": digest,
             },
-            "executable": executable("0.10.9", "/tmp/old/bundle/uv"),
+            "executable": executable(
+                "0.10.9", "/tmp/tsa-outdated-native-test/old/bundle/uv"
+            ),
         },
         supported_uv={
             "archive": {
@@ -319,7 +321,9 @@ def valid_passed_report() -> dict[str, object]:
                 "size": 1,
                 "sha256": digest,
             },
-            "executable": executable("0.11.0", "/tmp/supported/bundle/uv"),
+            "executable": executable(
+                "0.11.0", "/tmp/tsa-outdated-native-test/supported/bundle/uv"
+            ),
         },
         installer={
             "path": "/checkout/install.sh",
@@ -327,8 +331,8 @@ def valid_passed_report() -> dict[str, object]:
             "first_exit": 1,
             "second_exit": 0,
             "curl_invocations": 0,
-            "first_path": "/tmp/old:/tmp/tools",
-            "second_path": "/tmp/supported:/tmp/tools",
+            "first_path": "/tmp/tsa-outdated-native-test/old/bundle:/tmp/tsa-outdated-native-test/tools",
+            "second_path": "/tmp/tsa-outdated-native-test/supported/bundle:/tmp/tsa-outdated-native-test/tools",
             "curated_tools": list(qualification.REQUIRED_COMMANDS),
         },
         config={
@@ -369,7 +373,9 @@ def valid_passed_report() -> dict[str, object]:
                 "total_files": 0,
                 "summary": "codegraph_status: index missing or empty",
             },
-            "install_tool": executable("0.11.0", "/tmp/supported/bundle/uv"),
+            "install_tool": executable(
+                "0.11.0", "/tmp/tsa-outdated-native-test/supported/bundle/uv"
+            ),
             "install_argv": [
                 "/tmp/supported/bundle/uv",
                 "pip",
@@ -676,6 +682,7 @@ def test_trusted_config_sidecar_accepts_noncanonical_format(tmp_path: Path) -> N
             after,
             "linux",
             "📁 Project root: /tmp/tsa-outdated-native-test/fixture\n",
+            Path("/tmp/tsa-outdated-native-test"),
         )
         is None
     )
@@ -716,6 +723,7 @@ def test_trusted_config_sidecar_rejects_forgery(tmp_path: Path, mutation: str) -
             after,
             "linux",
             "📁 Project root: /tmp/tsa-outdated-native-test/fixture\n",
+            Path("/tmp/tsa-outdated-native-test"),
         )
 
 
@@ -740,6 +748,7 @@ def test_trusted_config_rejects_coordinated_command_forgery(tmp_path: Path) -> N
             after,
             "linux",
             "📁 Project root: /tmp/tsa-outdated-native-test/fixture\n",
+            Path("/tmp/tsa-outdated-native-test"),
         )
 
 
@@ -756,7 +765,9 @@ def test_trusted_config_rejects_coordinated_command_forgery(tmp_path: Path) -> N
 def test_trusted_stdout_rejects_ambiguous_or_unstructured_root(stdout: str) -> None:
     # Final gate 2026-07-17: the hash-bound stdout uniquely defines the root.
     with pytest.raises(AssertionError):
-        trusted_helpers()["project_root_from_stdout"](stdout, "linux")
+        trusted_helpers()["project_root_from_stdout"](
+            stdout, "linux", Path("/tmp/tsa-outdated-native-a")
+        )
 
 
 @pytest.mark.parametrize(
@@ -789,6 +800,7 @@ def test_trusted_installer_paths_reject_unverified_first_executable() -> None:
             report["installer"],
             report["old_uv"]["executable"],
             report["supported_uv"]["executable"],
+            Path("/tmp/tsa-outdated-native-test"),
         )
 
 
@@ -801,6 +813,7 @@ def test_trusted_installer_paths_reject_non_curated_path_tail() -> None:
             report["installer"],
             report["old_uv"]["executable"],
             report["supported_uv"]["executable"],
+            Path("/tmp/tsa-outdated-native-test"),
         )
 
 
@@ -871,3 +884,112 @@ def test_trusted_causal_binding_rejects_install_mutation(
         helpers["verify_causal_binding"](
             "linux", tmp_path, causal, bound, tool, wheel, wheel_path, runner, "b" * 64
         )
+
+
+@pytest.mark.parametrize("mutation", ["old-label", "different-root", "tools"])
+def test_trusted_sandbox_root_rejects_candidate_coordination(mutation: str) -> None:
+    # PR #1245: executable archive layouts, not cooperating sidecars, anchor the root.
+    helpers = trusted_helpers()
+    report = valid_passed_report()
+    member = {"member": "bundle/uv", "sha256": "a" * 64, "size": 1}
+    if mutation == "old-label":
+        report["old_uv"]["executable"]["path"] = (
+            "/tmp/tsa-outdated-native-test/evil/bundle/uv"
+        )
+        with pytest.raises(AssertionError):
+            helpers["executable_sandbox_root"](
+                report["old_uv"]["executable"], member, "old", "linux"
+            )
+        return
+    old_root = helpers["executable_sandbox_root"](
+        report["old_uv"]["executable"], member, "old", "linux"
+    )
+    if mutation == "different-root":
+        report["supported_uv"]["executable"]["path"] = (
+            "/tmp/tsa-outdated-native-forged/supported/bundle/uv"
+        )
+        with pytest.raises(AssertionError):
+            helpers["trusted_sandbox_root"](
+                report["old_uv"]["executable"],
+                member,
+                "linux",
+                report["supported_uv"]["executable"],
+                member,
+            )
+        return
+    report["installer"]["first_path"] = (
+        "/tmp/tsa-outdated-native-test/old/bundle:/tmp/attacker/tools"
+    )
+    report["installer"]["second_path"] = (
+        "/tmp/tsa-outdated-native-test/supported/bundle:/tmp/attacker/tools"
+    )
+    with pytest.raises(AssertionError):
+        helpers["verify_installer_paths"](
+            report["installer"],
+            report["old_uv"]["executable"],
+            report["supported_uv"]["executable"],
+            old_root,
+        )
+
+
+def test_trusted_project_root_rejects_coordinated_candidate_value() -> None:
+    # PR #1245: a matching stdout/config claim cannot override the executable root.
+    with pytest.raises(AssertionError):
+        trusted_helpers()["project_root_from_stdout"](
+            "📁 Project root: /tmp/tsa-outdated-native-forged/fixture\n",
+            "linux",
+            Path("/tmp/tsa-outdated-native-test"),
+        )
+
+
+@pytest.mark.parametrize("mutation", ["backup", "before-digest", "extra-entry"])
+def test_trusted_initial_snapshot_rejects_mutation(mutation: str) -> None:
+    # PR #1245: backup identity is the exact complete pre-install HOME snapshot.
+    digest = qualification.hashlib.sha256(b"{}\n").hexdigest()
+    config = valid_passed_report()["config"]
+    initial = [
+        {"path": ".claude", "type": "dir", "sha256": None},
+        {"path": ".claude/.mcp.json", "type": "file", "sha256": digest},
+    ]
+    config["before"] = json.loads(json.dumps(initial))
+    config["after_first"] = json.loads(json.dumps(initial))
+    config["backup_sha256"] = digest
+    if mutation == "backup":
+        config["backup_sha256"] = "0" * 64
+    elif mutation == "before-digest":
+        config["before"][1]["sha256"] = "0" * 64
+    else:
+        config["before"].append({"path": "extra", "type": "dir", "sha256": None})
+        config["after_first"].append({"path": "extra", "type": "dir", "sha256": None})
+    with pytest.raises(AssertionError):
+        trusted_helpers()["verify_initial_config"](config)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        b'{"job":"outdated-axis","axis":"linux","status":"failed"}',
+        b'{"job":"outdated-axis","axis":"linux","status":"success","extra":1}',
+        b'{"job":"outdated-axis","axis":"linux","axis":"linux","status":"success"}',
+        b'{"job":"outdated-axis","axis":"linux","status":"success"}\xff',
+    ],
+)
+def test_trusted_job_result_rejects_semantic_or_encoding_mutation(
+    tmp_path: Path, data: bytes
+) -> None:
+    # PR #1245: retained job status is strict UTF-8 JSON with one exact identity.
+    result = tmp_path / "job-result.json"
+    result.write_bytes(data)
+    with pytest.raises((AssertionError, UnicodeDecodeError, json.JSONDecodeError)):
+        trusted_helpers()["verify_job_result"](result, "linux")
+
+
+def test_trusted_job_result_digest_is_content_bound(tmp_path: Path) -> None:
+    # PR #1245: the receipt closure consumes the verified job-result digest.
+    result = tmp_path / "job-result.json"
+    data = b'{"job":"outdated-axis","axis":"windows","status":"success"}\n'
+    result.write_bytes(data)
+    assert (
+        trusted_helpers()["verify_job_result"](result, "windows")
+        == qualification.hashlib.sha256(data).hexdigest()
+    )


### PR DESCRIPTION
## Summary
- preserve the exact installed MCP config bytes as a hash-bound sidecar instead of predicting JSON serialization
- upgrade outdated-uv evidence to v3 and enforce exact POSIX/Windows artifact closure
- independently verify exact uvx entry, hash-bound installer project root, canonical snapshots, and backup shape

## Failure evidence
Protected develop run 31284682751 passed every producer/aggregate but failed the read-only verifier because report key sorting changed JSON object order before hash reconstruction. This change binds actual bytes and semantic content separately.

## Verification
- independent final gate: Blocker/P1/P2 = 0/0/0
- focused 71 passed; quick 1547 passed, 7 skipped
- patch coverage, actionlint, pre-commit: pass
