### PR TITLE
fix(ci): pin collector-bound uv in test matrix

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -76,7 +76,7 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@v7
       with:
-        version: "latest"
+        version: "0.12.3"
         enable-cache: true
         cache-dependency-glob: "uv.lock"
 
@@ -103,19 +103,20 @@ jobs:
       if: matrix.coverage
       id: test-coverage
       run: |
-        echo "### 📊 Test Coverage Report" >> $GITHUB_STEP_SUMMARY
+        exec 3>> "$GITHUB_STEP_SUMMARY"
+        echo "### 📊 Test Coverage Report" >&3
         uv run pytest tests/ -n auto -v --tb=short --maxfail=200 \
           --cov=tree_sitter_analyzer --cov-report=xml --cov-report=term-missing \
           --ignore=tests/e2e \
           -m "not slow and not e2e and not network and not benchmark" > pytest-output.txt 2>&1 || touch test_failed
 
         cat pytest-output.txt
-        echo '```text' >> $GITHUB_STEP_SUMMARY
-        tail -n 20 pytest-output.txt >> $GITHUB_STEP_SUMMARY
-        echo '```' >> $GITHUB_STEP_SUMMARY
+        echo '```text' >&3
+        tail -n 20 pytest-output.txt >&3
+        echo '```' >&3
 
         if [ -f test_failed ]; then
-          echo "❌ Tests failed!" >> $GITHUB_STEP_SUMMARY
+          echo "❌ Tests failed!" >&3
           exit 1
         fi
       shell: bash
@@ -200,7 +201,7 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@v7
       with:
-        version: "latest"
+        version: "0.12.3"
         enable-cache: true
         cache-dependency-glob: "uv.lock"
 
@@ -227,19 +228,20 @@ jobs:
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == inputs.python-version
       id: test-coverage
       run: |
-        echo "### 📊 Test Coverage Report" >> $GITHUB_STEP_SUMMARY
+        exec 3>> "$GITHUB_STEP_SUMMARY"
+        echo "### 📊 Test Coverage Report" >&3
         uv run pytest tests/ -n auto -v --tb=short --maxfail=200 \
           --cov=tree_sitter_analyzer --cov-report=xml --cov-report=term-missing \
           --ignore=tests/e2e \
           -m "not slow and not e2e and not network and not benchmark" > pytest-output.txt 2>&1 || touch test_failed
 
         cat pytest-output.txt
-        echo '```text' >> $GITHUB_STEP_SUMMARY
-        tail -n 20 pytest-output.txt >> $GITHUB_STEP_SUMMARY
-        echo '```' >> $GITHUB_STEP_SUMMARY
+        echo '```text' >&3
+        tail -n 20 pytest-output.txt >&3
+        echo '```' >&3
 
         if [ -f test_failed ]; then
-          echo "❌ Tests failed!" >> $GITHUB_STEP_SUMMARY
+          echo "❌ Tests failed!" >&3
           exit 1
         fi
       shell: bash


### PR DESCRIPTION
## Summary

- pin both reusable PR/full test matrices to `uv 0.12.3`, the exact tool version bound by the immutable NO1-006B collector receipt
- keep the checked-in receipt, schema, collector, `uv.lock`, and exported dependency evidence unchanged
- route repeated step-summary writes through a quoted fd so the touched workflow passes the mandatory `actionlint`/ShellCheck gate

## Why

`astral-sh/setup-uv` was configured as `latest`. It moved to 0.12.4, while `test_receipt_binds_exact_collector_tool_lock_and_export` intentionally requires the historical collector closure's uv 0.12.3. Every PR-fast OS axis now fails for the same ambient-version drift. Regenerating evidence would change the historical baseline and is not the correct repair.

This unblocks the unrelated test-matrix failures currently visible on #1257.

## Verification

- `uv run pytest -q` — **1760 passed, 8 skipped**
- collector receipt contract + CI routing contracts — **15 passed**
- changed-workflow pre-commit — passed
- `actionlint` / ShellCheck — passed
- post-edit change impact — `REVIEW`, low risk; verification command `uv run pytest -q`
