### PR TITLE
feat(benchmark): pin seven-repo inventory fingerprints (NO1-008A)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -537,6 +537,57 @@
         "is_verified": false,
         "line_number": 61
       }
+    ],
+    "benchmarks/codegraph_compare/seven_repo_inventory.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "benchmarks/codegraph_compare/seven_repo_inventory.json",
+        "hashed_secret": "ffa29791e2424a85026d09b612962169529b3f7c",
+        "is_verified": false,
+        "line_number": 9
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "benchmarks/codegraph_compare/seven_repo_inventory.json",
+        "hashed_secret": "959f232ef916d9783d9478dc77eac17f314b9bf4",
+        "is_verified": false,
+        "line_number": 18
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "benchmarks/codegraph_compare/seven_repo_inventory.json",
+        "hashed_secret": "afae804ec731595c34261a5d435481dfa784eb4a",
+        "is_verified": false,
+        "line_number": 27
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "benchmarks/codegraph_compare/seven_repo_inventory.json",
+        "hashed_secret": "0da22b84c2e4924c4158ac19bd1737fbb5723601",
+        "is_verified": false,
+        "line_number": 36
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "benchmarks/codegraph_compare/seven_repo_inventory.json",
+        "hashed_secret": "15d7f497db6b004e725a961ae361074aa29421c8",
+        "is_verified": false,
+        "line_number": 45
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "benchmarks/codegraph_compare/seven_repo_inventory.json",
+        "hashed_secret": "cfddb4abb6fbda14ec194ddf41f0f15bc46f230e",
+        "is_verified": false,
+        "line_number": 54
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "benchmarks/codegraph_compare/seven_repo_inventory.json",
+        "hashed_secret": "4f80c46f2abb86c7488e297ec9c8e8ce64bdc4ae",
+        "is_verified": false,
+        "line_number": 63
+      }
     ]
   },
   "generated_at": "2026-08-10T01:38:32Z"

--- a/benchmarks/codegraph_compare/setup_qualification_inventory.py
+++ b/benchmarks/codegraph_compare/setup_qualification_inventory.py
@@ -407,3 +407,92 @@ def inventory_sources(repo_id: str, repo: Path, rules: SourceRulesV1) -> Eligibi
         repo_fingerprint,
         root_tree_id=root_tree_id,
     )
+
+
+SEVEN_REPO_INVENTORY_PATH = Path(__file__).with_name("seven_repo_inventory.json")
+SEVEN_REPO_INVENTORY_SCHEMA_PATH = Path(__file__).with_name(
+    "seven_repo_inventory.schema.json"
+)
+_COMMIT_HEX = frozenset("0123456789abcdef")
+
+
+def _validate_inventory_entry(entry: object, index: int) -> dict[str, object]:
+    """Enforce exact pinned-inventory entry semantics beyond JSON shape."""
+    if type(entry) is not dict:
+        raise ValueError(f"seven-repo inventory entry {index} is not an object")
+    repo_id = entry.get("repo_id")
+    commit = entry.get("commit")
+    extensions = entry.get("source_extensions")
+    approx_files = entry.get("approx_files")
+    if type(repo_id) is not str or not repo_id:
+        raise ValueError(f"seven-repo inventory entry {index} has no repo_id")
+    if (
+        type(commit) is not str
+        or len(commit) != 40
+        or any(char not in _COMMIT_HEX for char in commit)
+    ):
+        raise ValueError(f"seven-repo inventory entry {index} has a bad commit pin")
+    if (
+        type(extensions) is not list
+        or not extensions
+        or any(type(item) is not str or not item.startswith(".") for item in extensions)
+    ):
+        raise ValueError(
+            f"seven-repo inventory entry {index} has bad source_extensions"
+        )
+    if tuple(extensions) != tuple(sorted(set(extensions))):
+        raise ValueError(
+            f"seven-repo inventory entry {index} extensions are not sorted unique"
+        )
+    if type(approx_files) is not int or approx_files < 1:
+        raise ValueError(
+            f"seven-repo inventory entry {index} has a bad approx_files count"
+        )
+    return entry
+
+
+def load_seven_repo_inventory() -> dict[str, object]:
+    """Load and validate the pinned NO1-008A repository inventory.
+
+    The pinned inventory is the offline source of truth for the seven
+    repository fingerprints; live clones and oracles must agree with it
+    before any cell may be qualified (NO1-008A exact-partition gate).
+    """
+    import json
+
+    from jsonschema import ValidationError, validate
+
+    raw = SEVEN_REPO_INVENTORY_PATH.read_bytes()
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError("seven-repo inventory is not valid JSON") from exc
+    schema = json.loads(SEVEN_REPO_INVENTORY_SCHEMA_PATH.read_text("utf-8"))
+    try:
+        validate(instance=payload, schema=schema)
+    except ValidationError as exc:
+        raise ValueError(
+            f"seven-repo inventory violates its schema: {exc.message}"
+        ) from None
+    if type(payload) is not dict or payload.get("schema_version") != 1:
+        raise ValueError("seven-repo inventory must carry schema_version=1")
+    repositories = payload.get("repositories")
+    if type(repositories) is not list or len(repositories) != 7:
+        raise ValueError("seven-repo inventory must list exactly seven repositories")
+    from benchmarks.codegraph_compare.setup_qualification_plan import REPOSITORIES
+
+    seen: list[str] = []
+    for index, entry in enumerate(repositories):
+        validated = _validate_inventory_entry(entry, index)
+        repo_id = validated["repo_id"]
+        if type(repo_id) is not str:
+            raise ValueError(f"seven-repo inventory entry {index} has no repo_id")
+        if repo_id in seen:
+            raise ValueError(f"seven-repo inventory duplicates repo_id {repo_id}")
+        seen.append(repo_id)
+    if tuple(seen) != REPOSITORIES:
+        raise ValueError(
+            "seven-repo inventory repo order must match the canonical "
+            f"seven repositories: {REPOSITORIES}"
+        )
+    return payload

--- a/benchmarks/codegraph_compare/seven_repo_inventory.json
+++ b/benchmarks/codegraph_compare/seven_repo_inventory.json
@@ -1,0 +1,68 @@
+{
+  "schema_version": 1,
+  "repositories": [
+    {
+      "repo_id": "vscode",
+      "name": "VS Code",
+      "language": "TypeScript",
+      "url": "https://github.com/microsoft/vscode",
+      "commit": "0e3051a9669d4b829aec4f16e8d4d17adec8fb28",
+      "approx_files": 10000,
+      "source_extensions": [".ts", ".tsx"]
+    },
+    {
+      "repo_id": "excalidraw",
+      "name": "Excalidraw",
+      "language": "TypeScript",
+      "url": "https://github.com/excalidraw/excalidraw",
+      "commit": "c08be69618dcac9386817bced03d2d79883e50b6",
+      "approx_files": 800,
+      "source_extensions": [".ts", ".tsx"]
+    },
+    {
+      "repo_id": "django",
+      "name": "Django",
+      "language": "Python",
+      "url": "https://github.com/django/django",
+      "commit": "0a2bc6d88ffd7918ca9bbe039ec2f4ed7dd639c9",
+      "approx_files": 5000,
+      "source_extensions": [".py"]
+    },
+    {
+      "repo_id": "tokio",
+      "name": "Tokio",
+      "language": "Rust",
+      "url": "https://github.com/tokio-rs/tokio",
+      "commit": "32312ae0d6f0b1c6457f1323e3e7f568f448d0db",
+      "approx_files": 800,
+      "source_extensions": [".rs"]
+    },
+    {
+      "repo_id": "okhttp",
+      "name": "OkHttp",
+      "language": "Java",
+      "url": "https://github.com/square/okhttp",
+      "commit": "cfc45a3f146d2389797a3d51d405e9118bed56c9",
+      "approx_files": 600,
+      "source_extensions": [".java", ".kt"]
+    },
+    {
+      "repo_id": "gin",
+      "name": "Gin",
+      "language": "Go",
+      "url": "https://github.com/gin-gonic/gin",
+      "commit": "5f4f9643258dc2a65e684b63f12c8d543c936c67",
+      "approx_files": 200,
+      "source_extensions": [".go"]
+    },
+    {
+      "repo_id": "alamofire",
+      "name": "Alamofire",
+      "language": "Swift",
+      "url": "https://github.com/Alamofire/Alamofire",
+      "commit": "7595cbcf59809f9977c5f6378500de2ad73b7ddb",
+      "approx_files": 150,
+      "source_extensions": [".swift"]
+    }
+  ]
+}

--- a/benchmarks/codegraph_compare/seven_repo_inventory.schema.json
+++ b/benchmarks/codegraph_compare/seven_repo_inventory.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "seven-repo-inventory-v1",
+  "title": "NO1-008A pinned seven-repository inventory",
+  "description": "Pinned repository fingerprints for NO1-008A setup qualification. Every commit is a trusted SHA-256 pin; source_extensions must stay in lockstep with DEFAULT_SOURCE_RULES and repos.yaml.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "repositories"],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "repositories": {
+      "type": "array",
+      "minItems": 7,
+      "maxItems": 7,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "repo_id",
+          "name",
+          "language",
+          "url",
+          "commit",
+          "approx_files",
+          "source_extensions"
+        ],
+        "properties": {
+          "repo_id": {
+            "type": "string",
+            "pattern": "^[a-z0-9]+$"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "language": {
+            "type": "string",
+            "minLength": 1
+          },
+          "url": {
+            "type": "string",
+            "pattern": "^https://github\\.com/"
+          },
+          "commit": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{40}$"
+          },
+          "approx_files": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "source_extensions": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "pattern": "^\\.[A-Za-z0-9]+$"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/unit/test_benchmark_harness.py
+++ b/tests/unit/test_benchmark_harness.py
@@ -16385,4 +16385,119 @@ def test_authority_cleanup_unknown_state_is_process_fatal(monkeypatch):
         authority._cleanup_producer("producer", Path("/missing/cgroup"))
 
 
+# ---------------------------------------------------------------------------
+# NO1-008A pinned seven-repository inventory (Slice A)
+# ---------------------------------------------------------------------------
+
+
+def test_seven_repo_inventory_lists_exactly_the_canonical_repositories() -> None:
+    from benchmarks.codegraph_compare.setup_qualification_inventory import (
+        load_seven_repo_inventory,
+    )
+    from benchmarks.codegraph_compare.setup_qualification_plan import REPOSITORIES
+
+    payload = load_seven_repo_inventory()
+    assert [entry["repo_id"] for entry in payload["repositories"]] == list(REPOSITORIES)
+
+
+def test_seven_repo_inventory_commit_pins_match_repos_yaml() -> None:
+    import yaml
+
+    from benchmarks.codegraph_compare.run import REPOS_YAML
+    from benchmarks.codegraph_compare.setup_qualification_inventory import (
+        load_seven_repo_inventory,
+    )
+
+    payload = load_seven_repo_inventory()
+    registry = yaml.safe_load(REPOS_YAML.read_text(encoding="utf-8"))
+    pinned = {entry["repo_id"]: entry["commit"] for entry in payload["repositories"]}
+    for repo in registry["repos"]:
+        assert pinned[repo["id"]] == repo["commit"], repo["id"]
+
+
+def test_seven_repo_inventory_extensions_match_default_source_rules() -> None:
+    from benchmarks.codegraph_compare.setup_qualification_inventory import (
+        load_seven_repo_inventory,
+    )
+    from benchmarks.codegraph_compare.setup_qualification_plan import (
+        DEFAULT_SOURCE_RULES,
+    )
+
+    payload = load_seven_repo_inventory()
+    for entry in payload["repositories"]:
+        assert entry["source_extensions"] == list(
+            DEFAULT_SOURCE_RULES.extensions(entry["repo_id"])
+        ), entry["repo_id"]
+
+
+def test_seven_repo_inventory_rejects_bad_commit_pin() -> None:
+    from benchmarks.codegraph_compare.setup_qualification_inventory import (
+        SEVEN_REPO_INVENTORY_PATH,
+        _validate_inventory_entry,
+    )
+
+    payload = json.loads(SEVEN_REPO_INVENTORY_PATH.read_text("utf-8"))
+    entry = dict(payload["repositories"][0])
+    entry["commit"] = entry["commit"][:-1]  # 39 hex: bad pin
+    with pytest.raises(ValueError, match="bad commit pin"):
+        _validate_inventory_entry(entry, 0)
+
+
+def test_seven_repo_inventory_rejects_unsorted_extensions() -> None:
+    from benchmarks.codegraph_compare.setup_qualification_inventory import (
+        SEVEN_REPO_INVENTORY_PATH,
+        _validate_inventory_entry,
+    )
+
+    payload = json.loads(SEVEN_REPO_INVENTORY_PATH.read_text("utf-8"))
+    entry = dict(payload["repositories"][0])
+    entry["source_extensions"] = [".tsx", ".ts"]
+    with pytest.raises(ValueError, match="not sorted unique"):
+        _validate_inventory_entry(entry, 0)
+
+
+def test_seven_repo_inventory_rejects_duplicate_repo_id(tmp_path: Path) -> None:
+    from unittest.mock import patch
+
+    from benchmarks.codegraph_compare.setup_qualification_inventory import (
+        SEVEN_REPO_INVENTORY_PATH,
+        load_seven_repo_inventory,
+    )
+
+    payload = json.loads(SEVEN_REPO_INVENTORY_PATH.read_text("utf-8"))
+    payload["repositories"][6] = dict(payload["repositories"][0])
+    broken = tmp_path / "broken-inventory.json"
+    broken.write_text(json.dumps(payload), encoding="utf-8")
+    with patch(
+        "benchmarks.codegraph_compare.setup_qualification_inventory"
+        ".SEVEN_REPO_INVENTORY_PATH",
+        broken,
+    ):
+        with pytest.raises(ValueError, match="duplicates repo_id"):
+            load_seven_repo_inventory()
+
+
+def test_seven_repo_inventory_schema_rejects_wrong_repository_count(
+    tmp_path: Path,
+) -> None:
+    from unittest.mock import patch
+
+    from benchmarks.codegraph_compare.setup_qualification_inventory import (
+        SEVEN_REPO_INVENTORY_PATH,
+        load_seven_repo_inventory,
+    )
+
+    payload = json.loads(SEVEN_REPO_INVENTORY_PATH.read_text("utf-8"))
+    del payload["repositories"][-1]
+    broken = tmp_path / "broken-inventory.json"
+    broken.write_text(json.dumps(payload), encoding="utf-8")
+    with patch(
+        "benchmarks.codegraph_compare.setup_qualification_inventory"
+        ".SEVEN_REPO_INVENTORY_PATH",
+        broken,
+    ):
+        with pytest.raises(ValueError, match="violates its schema"):
+            load_seven_repo_inventory()
+
+
 _mark_posix_qualification_section_tests()


### PR DESCRIPTION
## Summary

NO1-008A Slice A: pinned seven-repository inventory as the offline source of truth for setup qualification.

- `benchmarks/codegraph_compare/seven_repo_inventory.json` — pinned fingerprints (commit SHA-1 pins, source extensions, approx file counts) for the canonical seven repositories, in lockstep with `repos.yaml` and `DEFAULT_SOURCE_RULES`
- `seven_repo_inventory.schema.json` — strict draft-07 schema (exactly 7 repos, 40-hex commits, sorted unique dotted extensions)
- `load_seven_repo_inventory()` in setup_qualification_inventory.py — JSON schema validation + exact semantic checks (canonical repo order, duplicate detection, byte-exact pins)
- 7 contract tests: canonical set, repos.yaml commit-pin parity, DEFAULT_SOURCE_RULES extension parity, fail-closed on bad pin / unsorted extensions / duplicate id / wrong count

## Verification
- quick gate: 1760 passed, 8 skipped
- harness file: 701 passed
- pre-commit (ruff, mypy, bandit, secrets baseline, weak-assertion ratchet, codemap sync): passed

## Scope boundary
Offline contract slice only. Live clones, oracle sets, `produce_strict_cell`, and the 14-cell Linux run remain later slices (need network / Linux root / Docker).