### PR TITLE
fix(test): allow deliberate unbound-root trap in read_existing test

### DIFF
--- a/tests/unit/mcp/test_change_impact_tool_execute_and_mapping.py
+++ b/tests/unit/mcp/test_change_impact_tool_execute_and_mapping.py
@@ -1453,7 +1453,9 @@ def test_execute_read_existing_fails_closed_without_project_root():
     # receives base_path=None and skips its project-boundary layer, so an
     # arbitrary relative scope path validates. The route must fail closed
     # with the stable MISSING_PROJECT_ROOT error instead of classifying.
-    tool = tool_module.ChangeImpactTool(project_root=None)
+    tool = tool_module.ChangeImpactTool(
+        project_root=None  # allowed: chdir(tmp_path)
+    )
 
     with pytest.raises(ValueError) as exc_info:
         asyncio.run(


### PR DESCRIPTION
## Summary

#1257's read_existing fail-closed test deliberately constructs `ChangeImpactTool(project_root=None)` (the route must raise MISSING_PROJECT_ROOT before any graph build), but the static trap `test_no_project_root_traps` requires the `# allowed: chdir(tmp_path)` marker on the same line. The merge landed without the marker, breaking the develop quick gate.

- add the same-line allowance marker; the None fallback never walks the repository because the guard raises first

## Verification
- `test_no_project_root_traps` + focused change-impact test: 3 passed
- pre-commit hooks: passed