### PR TITLE
fix(benchmark): reject duplicate pins, widen yaml parity (#1260 Codex follow-up)

### DIFF
--- a/benchmarks/codegraph_compare/setup_qualification_inventory.py
+++ b/benchmarks/codegraph_compare/setup_qualification_inventory.py
@@ -462,11 +462,19 @@ def load_seven_repo_inventory() -> dict[str, object]:
 
     from jsonschema import ValidationError, validate
 
+    from benchmarks.codegraph_compare.setup_qualification_schema import (
+        strict_json_loads,
+    )
+
     raw = SEVEN_REPO_INVENTORY_PATH.read_bytes()
+    # Codex P2 (#1260): json.loads silently keeps the last of duplicate
+    # object members; a duplicated commit pin would pass schema validation
+    # on the collapsed object while another parser reads the other value.
+    # strict_json_loads rejects duplicate members up front.
     try:
-        payload = json.loads(raw)
-    except json.JSONDecodeError as exc:
-        raise ValueError("seven-repo inventory is not valid JSON") from exc
+        payload = strict_json_loads(raw)
+    except ValueError as exc:
+        raise ValueError("seven-repo inventory is not strict JSON") from exc
     schema = json.loads(SEVEN_REPO_INVENTORY_SCHEMA_PATH.read_text("utf-8"))
     try:
         validate(instance=payload, schema=schema)

--- a/benchmarks/codegraph_compare/seven_repo_inventory.schema.json
+++ b/benchmarks/codegraph_compare/seven_repo_inventory.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "seven-repo-inventory-v1",
   "title": "NO1-008A pinned seven-repository inventory",
-  "description": "Pinned repository fingerprints for NO1-008A setup qualification. Every commit is a trusted SHA-256 pin; source_extensions must stay in lockstep with DEFAULT_SOURCE_RULES and repos.yaml.",
+  "description": "Pinned repository fingerprints for NO1-008A setup qualification. Every commit is a trusted 40-hex Git SHA-1 object ID pin; source_extensions must stay in lockstep with DEFAULT_SOURCE_RULES and repos.yaml.",
   "type": "object",
   "additionalProperties": false,
   "required": ["schema_version", "repositories"],

--- a/tests/unit/test_benchmark_harness.py
+++ b/tests/unit/test_benchmark_harness.py
@@ -16410,9 +16410,31 @@ def test_seven_repo_inventory_commit_pins_match_repos_yaml() -> None:
 
     payload = load_seven_repo_inventory()
     registry = yaml.safe_load(REPOS_YAML.read_text(encoding="utf-8"))
-    pinned = {entry["repo_id"]: entry["commit"] for entry in payload["repositories"]}
-    for repo in registry["repos"]:
-        assert pinned[repo["id"]] == repo["commit"], repo["id"]
+    # Codex P2 (#1260): compare every shared field across the exact
+    # seven-entry mapping, so name/language/url/approx_files drift (or a
+    # removed repository) turns the parity test red, not just commit pins.
+    pinned = {
+        entry["repo_id"]: {
+            "commit": entry["commit"],
+            "name": entry["name"],
+            "language": entry["language"],
+            "url": entry["url"],
+            "approx_files": entry["approx_files"],
+        }
+        for entry in payload["repositories"]
+    }
+    assert len(pinned) == 7
+    yaml_repos = registry["repos"]
+    assert len(yaml_repos) == 7
+    for repo in yaml_repos:
+        expected = {
+            "commit": repo["commit"],
+            "name": repo["name"],
+            "language": repo["language"],
+            "url": repo["url"],
+            "approx_files": repo["approx_files"],
+        }
+        assert pinned[repo["id"]] == expected, repo["id"]
 
 
 def test_seven_repo_inventory_extensions_match_default_source_rules() -> None:
@@ -16497,6 +16519,48 @@ def test_seven_repo_inventory_schema_rejects_wrong_repository_count(
         broken,
     ):
         with pytest.raises(ValueError, match="violates its schema"):
+            load_seven_repo_inventory()
+
+
+def test_seven_repo_inventory_rejects_duplicate_json_members(
+    tmp_path: Path,
+) -> None:
+    # Codex P2 (#1260): a duplicated member (e.g. two "commit" keys) must
+    # be rejected up front — json.loads would silently keep the last value
+    # and the schema would validate only the collapsed object.
+    from unittest.mock import patch
+
+    from benchmarks.codegraph_compare.setup_qualification_inventory import (
+        SEVEN_REPO_INVENTORY_PATH,
+        load_seven_repo_inventory,
+    )
+
+    payload = json.loads(SEVEN_REPO_INVENTORY_PATH.read_text("utf-8"))
+    first = payload["repositories"][0]
+    duplicated = (
+        "{"
+        + '"repo_id": "gin", "commit": "'
+        + first["commit"]
+        + '", "commit": "'
+        + first["commit"]
+        + '", "name": "Gin", "language": "Go", "url": "https://github.com/gin-gonic/gin", "approx_files": 200, "source_extensions": [".go"]'
+        + "}"
+    )
+    broken = tmp_path / "broken-duplicate.json"
+    broken.write_text(
+        '{"schema_version": 1, "repositories": ['
+        + duplicated
+        + ","
+        + json.dumps(payload["repositories"][1:])[1:]
+        + "}",
+        encoding="utf-8",
+    )
+    with patch(
+        "benchmarks.codegraph_compare.setup_qualification_inventory"
+        ".SEVEN_REPO_INVENTORY_PATH",
+        broken,
+    ):
+        with pytest.raises(ValueError, match="not strict JSON"):
             load_seven_repo_inventory()
 
 


### PR DESCRIPTION
## Summary

Codex P2/P3 triage from merged PR #1260:

1. **P2 duplicate members**: `load_seven_repo_inventory` now parses with `strict_json_loads` (rejects duplicate JSON members up front); a duplicated commit pin can no longer pass the collapsed-object schema. Contract test proves `Duplicate JSON member: commit` is rejected.
2. **P2 parity coverage**: the repos.yaml parity test now compares every shared field (commit/name/language/url/approx_files) across the exact seven-entry mapping — drift or removal turns red.
3. **P3 label**: schema description now calls the pins 40-hex Git SHA-1 object IDs instead of SHA-256.

## Verification
- quick gate: 1982 passed, 27 skipped
- focused inventory tests: 8 passed
- pre-commit: passed