### PR TITLE
fix(trust): fail closed on RENAME_EXCHANGE and NUL literals

### DIFF
--- a/scripts/rfc0022_strace_parser.py
+++ b/scripts/rfc0022_strace_parser.py
@@ -57,6 +57,10 @@ def _bytes_from_code_points(decoded: str) -> str:
         raw_bytes = decoded.encode("latin-1")
     except UnicodeEncodeError:
         raise AuthorityError(f"strace literal is not byte-exact: {decoded!r}") from None
+    if b"\x00" in raw_bytes:
+        # Follow-up (#1259): a NUL byte can never be part of a pathname or
+        # argv entry; the descriptor decoder rejects it and so must we.
+        raise AuthorityError(f"strace literal contains a NUL byte: {decoded!r}")
     return os.fsdecode(raw_bytes)
 
 
@@ -342,6 +346,17 @@ def classify_calls(
                 # whole shared fs context. Update the modeled cwd before
                 # reporting the mutation targets so subsequent calls resolve
                 # against the new pathname.
+                if call.syscall == "renameat2":
+                    flags = args[4] if len(args) > 4 else ""
+                    if "RENAME_EXCHANGE" in flags:
+                        # Follow-up (#1259): RENAME_EXCHANGE atomically
+                        # swaps both pathnames; a live cwd on either side is
+                        # moved to the opposite side, which the one-way
+                        # rebase cannot model. Fail closed rather than
+                        # report stale targets.
+                        raise AuthorityError(
+                            "renameat2 RENAME_EXCHANGE with live cwd is unsupported"
+                        )
                 old_index, new_index = (0, 1) if call.syscall == "rename" else (1, 3)
                 state.rename_cwd(
                     call.pid,

--- a/tests/contracts/test_rfc0022_strace_process_state.py
+++ b/tests/contracts/test_rfc0022_strace_process_state.py
@@ -634,3 +634,43 @@ def test_live_clone_files_peer_keeps_shared_table_ambiguous(
     )
     with pytest.raises(AuthorityError, match="ambiguous"):
         _parse(trace)
+
+
+def test_renameat2_exchange_with_live_cwd_fails_closed(
+    tmp_path: Path,
+) -> None:
+    # Follow-up (#1259): RENAME_EXCHANGE atomically swaps both pathnames;
+    # the one-way cwd rebase cannot model a cwd moved to the opposite side,
+    # so the authority must fail closed instead of reporting stale targets.
+    trace = tmp_path / "trace"
+    _write_trace(
+        trace,
+        100,
+        [
+            'chdir("/project/a") = 0',
+            'renameat2(AT_FDCWD</project>, "/project/a", AT_FDCWD</project>, '
+            '"/project/b", RENAME_EXCHANGE) = 0',
+            "+++ exited with 0 +++",
+        ],
+    )
+    with pytest.raises(AuthorityError, match="RENAME_EXCHANGE"):
+        _parse(trace)
+
+
+def test_renameat2_without_exchange_still_rebases(tmp_path: Path) -> None:
+    # Follow-up (#1259) negative control: plain renameat2 keeps the
+    # one-way rebase working.
+    trace = tmp_path / "trace"
+    _write_trace(
+        trace,
+        100,
+        [
+            'chdir("/project/a") = 0',
+            'renameat2(AT_FDCWD</project>, "/project/a", AT_FDCWD</project>, '
+            '"/project/b", RENAME_NOREPLACE) = 0',
+            'unlink("x") = 0',
+            "+++ exited with 0 +++",
+        ],
+    )
+    targets = [event["target"] for event in _parse(trace)]
+    assert "/project/b/x" in targets

--- a/tests/contracts/test_rfc0022_strace_syntax.py
+++ b/tests/contracts/test_rfc0022_strace_syntax.py
@@ -425,3 +425,10 @@ def test_octal_escaped_argv_entries_decode_as_filesystem_bytes(
         traces, POLICY, Path("/project"), expected_argv=["target", "café"]
     )
     assert violations == []
+
+
+def test_nul_byte_in_path_fails_closed(tmp_path: Path) -> None:
+    # Follow-up (#1259): a NUL byte can never be part of a pathname; the
+    # decoded literal must be rejected rather than carried into evidence.
+    with pytest.raises(AuthorityError, match="contains a NUL byte"):
+        _parse_line(tmp_path, r'unlink("bad\000name") = 0')


### PR DESCRIPTION
## Summary

Follow-up hardening from the stopped #1259 implementer's read-only review (and the adversarial reviewer's INFO note):

1. **RENAME_EXCHANGE fail-closed**: renameat2 with RENAME_EXCHANGE atomically swaps both pathnames; the one-way cwd rebase cannot model a live cwd moved to the opposite side. The authority now raises a stable AuthorityError instead of reporting stale targets. Plain renameat2 (e.g. RENAME_NOREPLACE) keeps the rebase.
2. **NUL literal rejection**: a NUL byte can never be part of a pathname or argv entry; decoded literals containing NUL are now rejected (matching the descriptor decoder's existing behavior).

## Verification
- strace suite: 215 passed, 19 skipped (live-only)
- quick gate: 1985 passed, 27 skipped
- pre-commit: passed