### PR TITLE
feat(mcp): echo wire-owner action_version on every route (RFC-0022 P0.5)

### DIFF
--- a/docs/agent-envelope-contract.md
+++ b/docs/agent-envelope-contract.md
@@ -117,6 +117,7 @@ the MCP boundary
 | `access_mode` | RFC-0022 capability-access mode selected by the caller. |
 | `access_state` | Primary RFC-0022 capability branch (`available`, `missing`, `unknown`, or `not_applicable`). |
 | `access_reason` | Stable primitive-owned reason whenever capability access is not available. |
+| `action_version` | RFC-0022 P0.5 wire-owner version echo — which adapter contract produced the fragment. |
 | `hint` | Recovery hint on error envelopes — the sharpest edge an agent must not have to dig out of the blob. |
 | `file_path` | Echo of the call's subject file. |
 | `pr_url` | Echo of the PR a review-tool call targeted. |

--- a/tests/unit/mcp/test_safe_to_edit_tool.py
+++ b/tests/unit/mcp/test_safe_to_edit_tool.py
@@ -414,7 +414,9 @@ async def test_edit_safe_explicit_read_existing_honors_compact_only(
             "access_state: unknown\n"
             "access_reason: READ_EXISTING_AUTHORITY_UNCERTIFIED\n"
             "source_snapshots: []\n"
-            "output_format: toon"
+            "output_format: toon\n"
+            # RFC-0022 P0.5: wire owner echo in the TOON control surface.
+            "action_version: edit.safe/v1"
         ),
         "success": True,
         "verdict": "WARN",
@@ -422,6 +424,8 @@ async def test_edit_safe_explicit_read_existing_honors_compact_only(
         "access_state": "unknown",
         "access_reason": "READ_EXISTING_AUTHORITY_UNCERTIFIED",
         "output_format": "toon",
+        # RFC-0022 P0.5: wire owner echo on the envelope.
+        "action_version": "edit.safe/v1",
     }
 
 

--- a/tests/unit/mcp/tools/test_constraint_check_read_only.py
+++ b/tests/unit/mcp/tools/test_constraint_check_read_only.py
@@ -44,6 +44,7 @@ def test_read_only_zero_rules_needs_no_index(tmp_path: Path) -> None:
     assert result == {
         "success": True,
         "verdict": "SAFE",
+        "action_version": "edit.constraints/v1",
         "violations": [],
         "rule_count": 0,
         "evaluated_edge_count": 0,
@@ -59,6 +60,7 @@ def test_persist_missing_index_returns_legacy_safe_response(tmp_path: Path) -> N
     assert result == {
         "success": True,
         "verdict": "SAFE",
+        "action_version": "edit.constraints/v1",
         "violations": [],
         "rule_count": 1,
         "evaluated_edge_count": 0,

--- a/tests/unit/mcp/tools/test_constraint_check_tool.py
+++ b/tests/unit/mcp/tools/test_constraint_check_tool.py
@@ -337,6 +337,8 @@ def test_explicit_access_defaults_unavailable_output_to_json(tmp_path: Path) -> 
         "access_state": "unknown",
         "access_reason": "READ_EXISTING_AUTHORITY_UNCERTIFIED",
         "source_snapshots": [],
+        # RFC-0022 P0.5: wire owner echo on the unavailable envelope.
+        "action_version": "edit.constraints/v1",
         "output_format": "json",
     }
 
@@ -351,6 +353,8 @@ def test_execute_without_project_root_returns_setup_instruction() -> None:
     assert result == {
         "success": False,
         "error": "Project root not set. Call set_project_path first.",
+        # RFC-0022 P0.5: wire owner echo on the missing-root envelope.
+        "action_version": "edit.constraints/v1",
     }
 
 

--- a/tests/unit/mcp/tools/test_nav_facade.py
+++ b/tests/unit/mcp/tools/test_nav_facade.py
@@ -854,7 +854,9 @@ _ACCESS_EVIDENCE_TOON = (
     "access_state: unknown\n"
     "access_reason: READ_EXISTING_AUTHORITY_UNCERTIFIED\n"
     "source_snapshots: []\n"
-    "output_format: toon"
+    "output_format: toon\n"
+    # RFC-0022 P0.5: wire owner echo in the TOON control surface.
+    "action_version: nav.context/v1"
 )
 
 
@@ -910,6 +912,8 @@ def test_context_read_existing_returns_exact_access_evidence_without_backend(
     assert result == {
         **format_fields,
         **_ACCESS_EVIDENCE,
+        # RFC-0022 P0.5: wire-owner echo on the unavailable envelope.
+        "action_version": "nav.context/v1",
         "output_format": output_format,
     }
 

--- a/tests/unit/test_ast_diff_node_budget.py
+++ b/tests/unit/test_ast_diff_node_budget.py
@@ -110,8 +110,10 @@ class TestASTDiffNodeBudget:
         # Cost invariant (CLAUDE.md rule 11) pinned exactly: 746 < 1877 — the
         # default is dramatically smaller than the full-body opt-in.
         # Re-pinned after Codex P2 made agent_summary a dict (next_step+verdict).
-        assert default_bytes == 746
-        assert bodies_bytes == 1877
+        # RFC-0022 P0.5: +38 bytes for the action_version echo.
+        assert default_bytes == 784
+        # RFC-0022 P0.5: +38 bytes for the action_version echo.
+        assert bodies_bytes == 1915
 
     @pytest.mark.asyncio
     async def test_include_node_bodies_true_has_children(self, tool):

--- a/tests/unit/test_semantic_classify_tool.py
+++ b/tests/unit/test_semantic_classify_tool.py
@@ -592,7 +592,8 @@ class TestClassifyByteBudget:
             },
         )
         assert result["success"] is True
-        assert len(json.dumps(result)) == 4544
+        # RFC-0022 P0.5: +38 bytes for the action_version echo.
+        assert len(json.dumps(result)) == 4582
 
     def test_default_response_leq_raw_diff_bytes_git_mode(
         self, tool: SemanticClassifyTool, git_repo_with_two_commits

--- a/tests/unit/test_wire_owner_contract.py
+++ b/tests/unit/test_wire_owner_contract.py
@@ -1,0 +1,182 @@
+"""RFC-0022 P0.5 wire-owner contract: every route echoes its action_version.
+
+The registry in ``tree_sitter_analyzer/wire_owner.py`` is the single source
+of truth; each adapter imports its constant and echoes it on success,
+classified-unavailable, and missing-root responses. These tests pin the
+wire bytes so a version change (or a dropped echo) turns red.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from tree_sitter_analyzer.wire_owner import ACTION_VERSIONS
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_wire_owner_versions_cover_every_route() -> None:
+    # RFC-0022 P0.5: every adapter route must own exactly one version.
+    assert ACTION_VERSIONS == {
+        ("index", "status"): "index.status/v1",
+        ("nav", "context"): "nav.context/v1",
+        ("edit", "safe"): "edit.safe/v1",
+        ("edit", "impact"): "edit.impact/v1",
+        ("edit", "ast_diff"): "edit.ast_diff/v1",
+        ("edit", "classify"): "edit.classify/v1",
+        ("edit", "constraints"): "edit.constraints/v1",
+    }
+
+
+def test_wire_owner_versions_are_unique() -> None:
+    assert len(set(ACTION_VERSIONS.values())) == len(ACTION_VERSIONS)
+
+
+def test_nav_context_success_echoes_action_version(tmp_path: Path) -> None:
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        CodeGraphContextTool,
+    )
+    from tree_sitter_analyzer.wire_owner import NAV_CONTEXT_ACTION_VERSION
+
+    tool = CodeGraphContextTool(str(tmp_path))
+    result = _run(tool.execute({"task": "does_not_exist_zzz", "max_nodes": 5}))
+    assert result["action_version"] == NAV_CONTEXT_ACTION_VERSION
+    assert result["action_version"] == "nav.context/v1"
+
+
+def test_nav_context_unavailable_echoes_action_version() -> None:
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        CodeGraphContextTool,
+    )
+    from tree_sitter_analyzer.wire_owner import NAV_CONTEXT_ACTION_VERSION
+
+    tool = CodeGraphContextTool()
+    result = _run(
+        tool.execute(
+            {
+                "task": "x",
+                "access_mode": "read_existing",
+                "snapshot_id": "s1",
+                "source_generation": "1",
+            }
+        )
+    )
+    assert result["action_version"] == NAV_CONTEXT_ACTION_VERSION
+
+
+def test_safe_to_edit_unavailable_echoes_action_version() -> None:
+    from tree_sitter_analyzer.mcp.tools.safe_to_edit_tool import SafeToEditTool
+    from tree_sitter_analyzer.wire_owner import EDIT_SAFE_ACTION_VERSION
+
+    tool = SafeToEditTool(str(Path.cwd()))
+    result = _run(
+        tool.execute(
+            {
+                "file_path": "src/x.py",
+                "access_mode": "read_existing",
+                "snapshot_id": "s1",
+                "source_generation": "1",
+            }
+        )
+    )
+    assert result["action_version"] == EDIT_SAFE_ACTION_VERSION
+    assert result["action_version"] == "edit.safe/v1"
+
+
+def test_change_impact_unavailable_echoes_action_version() -> None:
+    from tree_sitter_analyzer.mcp.tools.change_impact_tool import ChangeImpactTool
+    from tree_sitter_analyzer.wire_owner import EDIT_IMPACT_ACTION_VERSION
+
+    tool = ChangeImpactTool(str(Path.cwd()))
+    result = _run(
+        tool.execute(
+            {
+                "mode": "diff",
+                "access_mode": "read_existing",
+                "scope_paths": ["src"],
+            }
+        )
+    )
+    assert result["action_version"] == EDIT_IMPACT_ACTION_VERSION
+    assert result["action_version"] == "edit.impact/v1"
+
+
+def test_constraints_unavailable_echoes_action_version(tmp_path: Path) -> None:
+    from tree_sitter_analyzer.mcp.tools.constraint_check_tool import (
+        ConstraintCheckTool,
+    )
+    from tree_sitter_analyzer.wire_owner import EDIT_CONSTRAINTS_ACTION_VERSION
+
+    tool = ConstraintCheckTool(str(tmp_path))
+    result = _run(
+        tool.execute(
+            {
+                "access_mode": "read_existing",
+                "diff_snapshot_id": "s1",
+                "persist": False,
+                "scope_paths": ["src"],
+            }
+        )
+    )
+    assert result["action_version"] == EDIT_CONSTRAINTS_ACTION_VERSION
+    assert result["action_version"] == "edit.constraints/v1"
+
+
+def test_constraints_missing_root_echoes_action_version() -> None:
+    from tree_sitter_analyzer.mcp.tools.constraint_check_tool import (
+        ConstraintCheckTool,
+    )
+    from tree_sitter_analyzer.wire_owner import EDIT_CONSTRAINTS_ACTION_VERSION
+
+    tool = ConstraintCheckTool()
+    result = _run(tool.execute({}))
+    assert result["action_version"] == EDIT_CONSTRAINTS_ACTION_VERSION
+
+
+def test_ast_diff_unavailable_echoes_action_version(tmp_path: Path) -> None:
+    from tree_sitter_analyzer.mcp.tools.ast_diff_tool import ASTDiffTool
+    from tree_sitter_analyzer.wire_owner import EDIT_AST_DIFF_ACTION_VERSION
+
+    tool = ASTDiffTool(str(tmp_path))
+    result = _run(
+        tool.execute(
+            {
+                "access_mode": "read_existing",
+                "diff_snapshot_id": "s1",
+                "file_path": "a.py",
+            }
+        )
+    )
+    assert result["action_version"] == EDIT_AST_DIFF_ACTION_VERSION
+
+
+def test_classify_unavailable_echoes_action_version(tmp_path: Path) -> None:
+    from tree_sitter_analyzer.mcp.tools.semantic_classify_tool import (
+        SemanticClassifyTool,
+    )
+    from tree_sitter_analyzer.wire_owner import EDIT_CLASSIFY_ACTION_VERSION
+
+    tool = SemanticClassifyTool(str(tmp_path))
+    result = _run(
+        tool.execute(
+            {
+                "file_path": "a.py",
+                "access_mode": "read_existing",
+                "diff_snapshot_id": "s1",
+            }
+        )
+    )
+    assert result["action_version"] == EDIT_CLASSIFY_ACTION_VERSION
+    assert result["action_version"] == "edit.classify/v1"
+
+
+def test_read_existing_unavailable_omits_version_without_argument() -> None:
+    # The shared builder only echoes a version when the caller supplies one;
+    # unowned callers must not fabricate a wire owner.
+    from tree_sitter_analyzer.read_existing_access import read_existing_unavailable
+
+    result = read_existing_unavailable({"access_mode": "read_existing"})
+    assert "action_version" not in result

--- a/tests/unit/test_wire_owner_contract.py
+++ b/tests/unit/test_wire_owner_contract.py
@@ -180,3 +180,53 @@ def test_read_existing_unavailable_omits_version_without_argument() -> None:
 
     result = read_existing_unavailable({"access_mode": "read_existing"})
     assert "action_version" not in result
+
+
+def test_change_impact_frozen_agent_summary_keeps_wire_owner(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # REQ-1 (review round 2, #1264): edit.impact frozen success with
+    # agent_summary_only=true rebuilds the envelope through an allowlist
+    # builder — the wire owner echo must be written after that rebuild so
+    # the summary-only variant keeps it.
+    from unittest.mock import MagicMock
+
+    import tree_sitter_analyzer.mcp.tools.change_impact_tool as tool_module
+    from tree_sitter_analyzer import diff_snapshot_registry as registry
+    from tree_sitter_analyzer.wire_owner import EDIT_IMPACT_ACTION_VERSION
+
+    tool = tool_module.ChangeImpactTool(str(tmp_path))
+    consumer = MagicMock()
+    consumer.snapshot.assessed_scope_paths = []
+    monkeypatch.setattr(registry.REGISTRY, "bind_assessed_scope", lambda *a: None)
+    monkeypatch.setattr(registry.REGISTRY, "validate_publish", lambda *a: None)
+    monkeypatch.setattr(
+        tool_module,
+        "build_frozen_scope_result",
+        lambda *a: (
+            {
+                "success": True,
+                "verdict": "SAFE",
+                "mode": "diff",
+                "agent_summary": {"summary_line": "s"},
+            },
+            [],
+            [],
+            [],
+        ),
+    )
+    result = tool._execute_frozen_snapshot(
+        frozen={
+            "diff_snapshot_id": "ds",
+            "source_generation": "g",
+            "success": True,
+        },
+        consumer=consumer,
+        mode="diff",
+        scope_paths=[],
+        scope_mode="report",
+        output_format="json",
+        agent_summary_only=True,
+        compact_only=False,
+    )
+    assert result["action_version"] == EDIT_IMPACT_ACTION_VERSION

--- a/tree_sitter_analyzer/mcp/tools/ast_diff_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/ast_diff_tool.py
@@ -23,6 +23,7 @@ from ...read_existing_access import (
     validate_read_existing_schema_values,
 )
 from ...utils import setup_logger
+from ...wire_owner import EDIT_AST_DIFF_ACTION_VERSION
 from ..utils.format_helper import (
     apply_toon_format_to_response,
     preformat_diff_snapshot_publish_errors,
@@ -260,6 +261,7 @@ class ASTDiffTool(BaseMCPTool):
         unavailable = read_existing_unavailable(
             arguments,
             reason=READ_EXISTING_AUTHORITY_UNCERTIFIED,
+            action_version=EDIT_AST_DIFF_ACTION_VERSION,
         )
         if unavailable is not None:
             return apply_toon_format_to_response(
@@ -381,6 +383,7 @@ class ASTDiffTool(BaseMCPTool):
             response: dict[str, Any] = {
                 "success": True,
                 "verdict": verdict,
+                "action_version": EDIT_AST_DIFF_ACTION_VERSION,
                 "summary_line": agent_summary_line,
                 # Codex P2: agent_summary must be a dict so direct execute() callers
                 # (CLI, tests) can read agent_summary["verdict"] without the MCP

--- a/tree_sitter_analyzer/mcp/tools/change_impact_support.py
+++ b/tree_sitter_analyzer/mcp/tools/change_impact_support.py
@@ -342,6 +342,8 @@ def _finalize_pr_result(
     if agent_summary_only:
         result = build_agent_summary_only_response(result)
     result["output_format"] = output_format
+    # RFC-0022 P0.5: PR route success fragment echoes the wire owner.
+    result["action_version"] = "edit.impact/v1"
     _canonicalize_change_impact_verdict(result)
     result = mirror_summary_line(result)
     return apply_toon_format_to_response(

--- a/tree_sitter_analyzer/mcp/tools/change_impact_support.py
+++ b/tree_sitter_analyzer/mcp/tools/change_impact_support.py
@@ -343,7 +343,9 @@ def _finalize_pr_result(
         result = build_agent_summary_only_response(result)
     result["output_format"] = output_format
     # RFC-0022 P0.5: PR route success fragment echoes the wire owner.
-    result["action_version"] = "edit.impact/v1"
+    from ...wire_owner import EDIT_IMPACT_ACTION_VERSION
+
+    result["action_version"] = EDIT_IMPACT_ACTION_VERSION
     _canonicalize_change_impact_verdict(result)
     result = mirror_summary_line(result)
     return apply_toon_format_to_response(

--- a/tree_sitter_analyzer/mcp/tools/change_impact_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/change_impact_tool.py
@@ -384,9 +384,6 @@ class ChangeImpactTool(BaseMCPTool):
         response_frozen = dict(frozen)
         response_frozen["changed_records"] = records
         result = self._attach_diff_snapshot(result, mode, True, frozen=response_frozen)
-        # RFC-0022 P0.5: the frozen route is a success fragment — echo the
-        # wire owner version.
-        result["action_version"] = EDIT_IMPACT_ACTION_VERSION
         if agent_summary_only:
             snapshot_surface: dict[str, Any] = {
                 key: result[key]
@@ -401,6 +398,10 @@ class ChangeImpactTool(BaseMCPTool):
             }
             result = build_agent_summary_only_response(result)
             result.update(snapshot_surface)
+        # RFC-0022 P0.5: the frozen route is a success fragment — echo the
+        # wire owner version after any agent-summary rebuild so the
+        # agent_summary_only variant keeps it too.
+        result["action_version"] = EDIT_IMPACT_ACTION_VERSION
         result["output_format"] = output_format
         _canonicalize_change_impact_verdict(result)
         result = mirror_summary_line(result)

--- a/tree_sitter_analyzer/mcp/tools/change_impact_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/change_impact_tool.py
@@ -384,6 +384,9 @@ class ChangeImpactTool(BaseMCPTool):
         response_frozen = dict(frozen)
         response_frozen["changed_records"] = records
         result = self._attach_diff_snapshot(result, mode, True, frozen=response_frozen)
+        # RFC-0022 P0.5: the frozen route is a success fragment — echo the
+        # wire owner version.
+        result["action_version"] = EDIT_IMPACT_ACTION_VERSION
         if agent_summary_only:
             snapshot_surface: dict[str, Any] = {
                 key: result[key]

--- a/tree_sitter_analyzer/mcp/tools/change_impact_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/change_impact_tool.py
@@ -11,6 +11,7 @@ from ...pr_url import (
     fetch_pr_diff_stat,
     parse_pr_url,
 )
+from ...wire_owner import EDIT_IMPACT_ACTION_VERSION
 from ..utils.format_helper import apply_toon_format_to_response
 from .base_tool import BaseMCPTool, mirror_summary_line
 from .change_impact_frozen import build_frozen_scope_result, scope_matches_raw
@@ -159,6 +160,7 @@ class ChangeImpactTool(BaseMCPTool):
             arguments,
             reason=read_access.DIFF_SNAPSHOT_READ_EXISTING_UNSUPPORTED,
             compact_only=bool(arguments.get("compact_only", False)),
+            action_version=EDIT_IMPACT_ACTION_VERSION,
         )
         if unavailable is not None:
             return unavailable
@@ -277,6 +279,8 @@ class ChangeImpactTool(BaseMCPTool):
             if agent_summary_only:
                 result = build_agent_summary_only_response(result)
             result["output_format"] = output_format
+            # RFC-0022 P0.5: echo the adapter-owned wire owner version.
+            result["action_version"] = EDIT_IMPACT_ACTION_VERSION
             # F1 (round-37f7): defensive verdict canonicalization in
             # the no-changes path. ``apply_scope_validation`` already
             # stamps ``CHANGE_IMPACT_VERDICT_CLEAN`` (now ``"SAFE"``)
@@ -324,6 +328,8 @@ class ChangeImpactTool(BaseMCPTool):
         if agent_summary_only:
             result = build_agent_summary_only_response(result)
         result["output_format"] = output_format
+        # RFC-0022 P0.5: echo the adapter-owned wire owner version.
+        result["action_version"] = EDIT_IMPACT_ACTION_VERSION
         # F1 (round-37f7): same defensive canonicalization as the
         # no-changes path — guarantees the cross-tool envelope sees
         # only canonical verdict tokens regardless of which builder

--- a/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
@@ -17,6 +17,7 @@ from ... import read_existing_access as read_access
 from ...test_gap_analyzer import _NON_PROD_DIRS as _SHARED_NON_PROD_DIRS
 from ...utils.test_detection import is_test_file as _shared_is_test_file
 from ...utils.test_detection import query_wants_tests as _task_wants_tests
+from ...wire_owner import NAV_CONTEXT_ACTION_VERSION
 from ._codegraph_explore_helpers import extract_snippet_from_lines, read_file_lines
 from .base_tool import BaseMCPTool
 
@@ -238,7 +239,10 @@ class CodeGraphContextTool(BaseMCPTool):
 
     async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
         self.validate_arguments(arguments)
-        if unavailable := read_access.format_read_existing_unavailable(arguments):
+        if unavailable := read_access.format_read_existing_unavailable(
+            arguments,
+            action_version=NAV_CONTEXT_ACTION_VERSION,
+        ):
             return unavailable
         started = time.perf_counter()
 
@@ -305,6 +309,7 @@ class CodeGraphContextTool(BaseMCPTool):
             result: dict[str, Any] = {
                 "success": True,
                 "verdict": verdict,
+                "action_version": NAV_CONTEXT_ACTION_VERSION,
                 "task": task,
                 "candidates": candidates,
                 "entry_points": entry_points,
@@ -341,6 +346,7 @@ class CodeGraphContextTool(BaseMCPTool):
             result = {
                 "success": True,
                 "verdict": verdict,
+                "action_version": NAV_CONTEXT_ACTION_VERSION,
                 "task": task,
                 "candidates": candidates,
                 "entry_points": entry_points,

--- a/tree_sitter_analyzer/mcp/tools/constraint_check_frozen.py
+++ b/tree_sitter_analyzer/mcp/tools/constraint_check_frozen.py
@@ -16,6 +16,7 @@ from ...git_path_codec import path_to_wire
 from ...index_source_scope import SourceScopeDescriptor
 from ...languages.lang_extension_map import EXT_TO_LANG
 from ...source_oracle import SourceOracleError
+from ...wire_owner import EDIT_CONSTRAINTS_ACTION_VERSION
 from ..utils.format_helper import apply_toon_format_to_response
 
 _CONFIG_CANDIDATES = (
@@ -158,6 +159,7 @@ def execute_frozen(tool: Any, arguments: dict[str, Any]) -> dict[str, Any]:
                 "state": "not_applicable",
                 "reason": "NO_CONFIG",
                 "verdict": "INFO",
+                "action_version": EDIT_CONSTRAINTS_ACTION_VERSION,
                 "violations": [],
                 "rule_count": 0,
                 "evaluated_edge_count": 0,
@@ -176,6 +178,7 @@ def execute_frozen(tool: Any, arguments: dict[str, Any]) -> dict[str, Any]:
                     "success": True,
                     "state": "applicable",
                     "verdict": "SAFE",
+                    "action_version": EDIT_CONSTRAINTS_ACTION_VERSION,
                     "violations": [],
                     "rule_count": 0,
                     "evaluated_edge_count": 0,
@@ -246,6 +249,7 @@ def execute_frozen(tool: Any, arguments: dict[str, Any]) -> dict[str, Any]:
                             "success": True,
                             "state": "applicable",
                             "verdict": tool._compute_verdict(rows),
+                            "action_version": EDIT_CONSTRAINTS_ACTION_VERSION,
                             "violations": rows,
                             "rule_count": len(constraints),
                             "evaluated_edge_count": edge_count,

--- a/tree_sitter_analyzer/mcp/tools/constraint_check_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/constraint_check_tool.py
@@ -170,6 +170,7 @@ class ConstraintCheckTool(BaseMCPTool):
                 {
                     "success": True,
                     "verdict": "SAFE",
+                    "action_version": EDIT_CONSTRAINTS_ACTION_VERSION,
                     "violations": [],
                     "rule_count": 0,
                     "evaluated_edge_count": 0,
@@ -183,6 +184,7 @@ class ConstraintCheckTool(BaseMCPTool):
                 {
                     "success": True,
                     "verdict": "SAFE",
+                    "action_version": EDIT_CONSTRAINTS_ACTION_VERSION,
                     "violations": [],
                     "rule_count": len(constraints),
                     "evaluated_edge_count": 0,

--- a/tree_sitter_analyzer/mcp/tools/constraint_check_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/constraint_check_tool.py
@@ -27,6 +27,7 @@ from ...read_existing_access import (
     validate_read_existing_schema_values,
 )
 from ...source_oracle import SourceOracleError
+from ...wire_owner import EDIT_CONSTRAINTS_ACTION_VERSION
 from ..utils.format_helper import apply_toon_format_to_response
 from .base_tool import BaseMCPTool
 from .constraint_check_live import (
@@ -103,6 +104,7 @@ class ConstraintCheckTool(BaseMCPTool):
             return {
                 "success": False,
                 "error": "Project root not set. Call set_project_path first.",
+                "action_version": EDIT_CONSTRAINTS_ACTION_VERSION,
             }
 
         access_arguments = arguments
@@ -111,6 +113,7 @@ class ConstraintCheckTool(BaseMCPTool):
         unavailable = read_existing_unavailable(
             access_arguments,
             reason=READ_EXISTING_AUTHORITY_UNCERTIFIED,
+            action_version=EDIT_CONSTRAINTS_ACTION_VERSION,
         )
         if unavailable is not None:
             return apply_toon_format_to_response(
@@ -244,6 +247,7 @@ class ConstraintCheckTool(BaseMCPTool):
             {
                 "success": True,
                 "verdict": verdict,
+                "action_version": EDIT_CONSTRAINTS_ACTION_VERSION,
                 "violations": filtered_rows,
                 "rule_count": len(constraints),
                 "evaluated_edge_count": evaluated_edges,

--- a/tree_sitter_analyzer/mcp/tools/safe_to_edit_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/safe_to_edit_tool.py
@@ -280,6 +280,7 @@ def _syntax_error_response(
     summary_line = f"{file_path} signal=syntax_error verdict=ERROR"
     return {
         "success": True,
+        "action_version": EDIT_SAFE_ACTION_VERSION,
         "file_path": file_path,
         "edit_type": edit_type,
         "language": language,

--- a/tree_sitter_analyzer/mcp/tools/safe_to_edit_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/safe_to_edit_tool.py
@@ -20,6 +20,7 @@ from ...read_existing_access import (
     validate_required_index_access,
 )
 from ...utils import setup_logger
+from ...wire_owner import EDIT_SAFE_ACTION_VERSION
 from .base_tool import BaseMCPTool, mirror_summary_line
 from .utils.parse_validity import is_file_parse_broken
 from .utils.safe_to_edit_helpers import (
@@ -170,6 +171,7 @@ class SafeToEditTool(BaseMCPTool):
         unavailable = format_read_existing_unavailable(
             arguments,
             compact_only=bool(arguments.get("compact_only", False)),
+            action_version=EDIT_SAFE_ACTION_VERSION,
         )
         if unavailable is not None:
             return unavailable
@@ -215,6 +217,9 @@ class SafeToEditTool(BaseMCPTool):
         # Echo the requested output_format so agents can audit envelope
         # parity without re-reading their own call site.
         result["output_format"] = output_format
+        # RFC-0022 P0.5: echo the adapter-owned wire owner version on the
+        # success path.
+        result["action_version"] = EDIT_SAFE_ACTION_VERSION
 
         # M14 (round-26): also echo ``language`` on the success path.
         # The syntax-error short-circuit above already echoes it; the

--- a/tree_sitter_analyzer/mcp/tools/semantic_classify_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/semantic_classify_tool.py
@@ -18,6 +18,7 @@ from ...git_path_codec import path_to_wire
 from ...project_graph import _language_from_ext
 from ...semantic_change_classifier import SemanticChangeClassifier
 from ...utils import setup_logger
+from ...wire_owner import EDIT_CLASSIFY_ACTION_VERSION
 from ..utils.format_helper import (
     apply_toon_format_to_response,
     preformat_diff_snapshot_publish_errors,
@@ -248,7 +249,9 @@ class SemanticClassifyTool(BaseMCPTool):
         self.validate_arguments(arguments)
 
         unavailable = read_access.format_read_existing_unavailable(
-            arguments, reason=read_access.READ_EXISTING_AUTHORITY_UNCERTIFIED
+            arguments,
+            reason=read_access.READ_EXISTING_AUTHORITY_UNCERTIFIED,
+            action_version=EDIT_CLASSIFY_ACTION_VERSION,
         )
         if unavailable is not None:
             return unavailable
@@ -401,6 +404,7 @@ class SemanticClassifyTool(BaseMCPTool):
             # list. Tests pin this name (pain pass 2).
             response: dict[str, Any] = {
                 "success": True,
+                "action_version": EDIT_CLASSIFY_ACTION_VERSION,
                 "file_path": (
                     path_to_wire(file_path)
                     if consumer is not None and file_path is not None

--- a/tree_sitter_analyzer/mcp/utils/format_helper.py
+++ b/tree_sitter_analyzer/mcp/utils/format_helper.py
@@ -39,6 +39,9 @@ TOON_CONTROL_SURFACE: frozenset[str] = frozenset(
         "access_mode",
         "access_state",
         "access_reason",
+        # RFC-0022 P0.5 wire owner: compact callers must still see which
+        # adapter contract produced the fragment.
+        "action_version",
         # Cheap branchable identifiers/affordances an agent should not have to
         # parse the TOON blob for (review nit): the recovery ``hint`` on error
         # envelopes is the sharpest edge; ``file_path`` / ``pr_url`` /

--- a/tree_sitter_analyzer/read_existing_access.py
+++ b/tree_sitter_analyzer/read_existing_access.py
@@ -213,11 +213,12 @@ def read_existing_unavailable(
     *,
     reason: str = READ_EXISTING_AUTHORITY_UNCERTIFIED,
     default_output_format: str = "toon",
+    action_version: str | None = None,
 ) -> dict[str, Any] | None:
     """Return the raw classified-unavailable envelope for an explicit request."""
     if "access_mode" not in arguments:
         return None
-    return {
+    envelope: dict[str, Any] = {
         "success": True,
         "verdict": "WARN",
         "access_mode": "read_existing",
@@ -226,6 +227,11 @@ def read_existing_unavailable(
         "source_snapshots": [],
         "output_format": arguments.get("output_format", default_output_format),
     }
+    # RFC-0022 P0.5: every route fragment echoes its adapter-owned wire
+    # owner version, including classified-unavailable results.
+    if action_version is not None:
+        envelope["action_version"] = action_version
+    return envelope
 
 
 def format_read_existing_unavailable(
@@ -234,12 +240,14 @@ def format_read_existing_unavailable(
     reason: str = READ_EXISTING_AUTHORITY_UNCERTIFIED,
     default_output_format: str = "toon",
     compact_only: bool = False,
+    action_version: str | None = None,
 ) -> dict[str, Any] | None:
     """Format one unavailable classification through the normal tool boundary."""
     result = read_existing_unavailable(
         arguments,
         reason=reason,
         default_output_format=default_output_format,
+        action_version=action_version,
     )
     if result is None:
         return None
@@ -258,6 +266,7 @@ def read_existing_gate(
     *,
     reason: str,
     compact_only: bool = False,
+    action_version: str | None = None,
 ) -> dict[str, Any] | None:
     """Validate and classify an explicit route before any adapter backend work."""
     if "access_mode" not in arguments:
@@ -267,4 +276,5 @@ def read_existing_gate(
         arguments,
         reason=reason,
         compact_only=compact_only,
+        action_version=action_version,
     )

--- a/tree_sitter_analyzer/wire_owner.py
+++ b/tree_sitter_analyzer/wire_owner.py
@@ -1,0 +1,38 @@
+"""RFC-0022 P0.5 wire ownership: one authoritative version per route.
+
+Every RFC-0022 route result must echo its adapter-owned ``action_version``
+so consumers can tell which adapter contract produced a wire fragment. The
+registry is the single source of truth; each adapter imports its own
+constant from here (or stays bound to a pre-existing constant, as
+``index.status`` does via ``index_snapshot.ACTION_VERSION``).
+"""
+
+from __future__ import annotations
+
+from .index_snapshot import ACTION_VERSION as INDEX_STATUS_ACTION_VERSION
+
+#: Canonical wire owner versions, keyed by ``(facade, action)``.
+#: ``index.status`` reuses the pre-existing constant so the two definitions
+#: cannot drift; every other route owns exactly one entry here.
+ACTION_VERSIONS: dict[tuple[str, str], str] = {
+    ("index", "status"): INDEX_STATUS_ACTION_VERSION,
+    ("nav", "context"): "nav.context/v1",
+    ("edit", "safe"): "edit.safe/v1",
+    ("edit", "impact"): "edit.impact/v1",
+    ("edit", "ast_diff"): "edit.ast_diff/v1",
+    ("edit", "classify"): "edit.classify/v1",
+    ("edit", "constraints"): "edit.constraints/v1",
+}
+
+NAV_CONTEXT_ACTION_VERSION = ACTION_VERSIONS[("nav", "context")]
+EDIT_SAFE_ACTION_VERSION = ACTION_VERSIONS[("edit", "safe")]
+EDIT_IMPACT_ACTION_VERSION = ACTION_VERSIONS[("edit", "impact")]
+EDIT_AST_DIFF_ACTION_VERSION = ACTION_VERSIONS[("edit", "ast_diff")]
+EDIT_CLASSIFY_ACTION_VERSION = ACTION_VERSIONS[("edit", "classify")]
+EDIT_CONSTRAINTS_ACTION_VERSION = ACTION_VERSIONS[("edit", "constraints")]
+
+#: All route versions must be unique — a shared version would let two
+#: adapters silently masquerade as one contract.
+assert len(set(ACTION_VERSIONS.values())) == len(ACTION_VERSIONS), (
+    "wire owner versions must be unique per route"
+)


### PR DESCRIPTION
## Summary

RFC-0022 **P0.5 slice 1**: every route result now echoes its adapter-owned `action_version` wire field.

- **`tree_sitter_analyzer/wire_owner.py`** (new): canonical `ACTION_VERSIONS` registry keyed by (facade, action) — 7 routes; `index.status` reuses the pre-existing constant so the two definitions cannot drift; uniqueness asserted at import.
- **6 adapters** (`nav.context`, `edit.safe`, `edit.impact`, `edit.ast_diff`, `edit.classify`, `edit.constraints`) echo their version on success, classified-unavailable, and missing-root envelopes.
- **Shared builders**: `read_existing_unavailable` / `format_read_existing_unavailable` / `read_existing_gate` accept `action_version`; unowned callers still emit no version (no fabrication).
- **11 contract tests** (`tests/unit/test_wire_owner_contract.py`, new subsystem): exact registry pin, uniqueness, per-adapter success + unavailable echo, no-version-when-unowned.

## Verification
- quick gate: 1985 passed, 27 skipped
- wire-owner contract: 11 passed
- pre-commit (ruff/mypy/bandit/ratchet/codemap): passed

## Scope boundary
Wire-owner echo only. `producer_rule_id/version` echoes for rule-derived fragments, unknown-on-mismatch evidence semantics, and task-layer composition remain later P0.5 slices (depend on Phase A rule engine).