### PR TITLE
feat(task): task-outcome v1 models and budget contract (RFC-0022 Phase A)

### DIFF
--- a/tests/unit/task/test_task_models.py
+++ b/tests/unit/task/test_task_models.py
@@ -1,0 +1,145 @@
+"""RFC-0022 task-outcome/v1 model and budget contracts (Phase A).
+
+Exact pins for the frozen models, budget profiles, and boundary rules
+(RFC-0022 RED-first acceptance items 3-4 groundwork).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tree_sitter_analyzer.task import (
+    BUDGET_PROFILES,
+    AssessChangeRequest,
+    Budget,
+    ConsumedBudget,
+    DiffInput,
+    PlanChangeRequest,
+    TaskOutcome,
+    UnderstandRequest,
+)
+
+
+def test_budget_profiles_are_pinned_exactly() -> None:
+    assert BUDGET_PROFILES == {
+        "compact": (4, 15, 5_000),
+        "standard": (12, 50, 30_000),
+    }
+
+
+def test_budget_defaults_to_standard_profile() -> None:
+    budget = Budget()
+    assert budget.profile == "standard"
+    assert budget.effective_calls == 12
+    assert budget.effective_evidence == 50
+    assert budget.effective_deadline_ms == 30_000
+
+
+def test_budget_compact_effective_values() -> None:
+    budget = Budget(profile="compact")
+    assert budget.effective_calls == 4
+    assert budget.effective_evidence == 15
+    assert budget.effective_deadline_ms == 5_000
+
+
+def test_budget_explicit_values_may_only_lower() -> None:
+    assert Budget(profile="compact", max_primitive_calls=2).effective_calls == 2
+    assert Budget(profile="standard", max_evidence_items=20).effective_evidence == 20
+    assert (
+        Budget(profile="standard", routing_deadline_ms=10_000).effective_deadline_ms
+        == 10_000
+    )
+
+
+def test_budget_rejects_raising_explicit_value() -> None:
+    with pytest.raises(ValueError, match="BUDGET_INVALID"):
+        Budget(profile="compact", max_primitive_calls=5)
+    with pytest.raises(ValueError, match="BUDGET_INVALID"):
+        Budget(profile="standard", max_evidence_items=60)
+
+
+def test_budget_rejects_unknown_profile() -> None:
+    with pytest.raises(ValueError, match="BUDGET_INVALID"):
+        Budget(profile="wide")  # type: ignore[arg-type]
+
+
+def test_budget_require_calls_rejects_below_floor() -> None:
+    with pytest.raises(ValueError, match="BUDGET_INVALID"):
+        Budget(profile="standard", max_primitive_calls=2).require_calls(3)
+    Budget(profile="compact").require_calls(3)  # compact 4 >= 3 is fine
+
+
+def test_diff_input_requires_valid_source() -> None:
+    assert DiffInput(source="workspace").source == "workspace"
+    assert DiffInput(source="staged").source == "staged"
+    with pytest.raises(ValueError, match="unknown diff source"):
+        DiffInput(source="mixed")  # type: ignore[arg-type]
+
+
+def test_diff_input_rejects_empty_scope_paths() -> None:
+    with pytest.raises(ValueError, match="non-empty strings"):
+        DiffInput(source="workspace", scope_paths=("",))
+
+
+def test_understand_requires_exactly_one_task_or_diff() -> None:
+    assert UnderstandRequest(task="explain dispatch").task == "explain dispatch"
+    assert UnderstandRequest(diff=DiffInput("staged")).diff is not None
+    with pytest.raises(ValueError, match="exactly one of task or diff"):
+        UnderstandRequest()
+    with pytest.raises(ValueError, match="exactly one of task or diff"):
+        UnderstandRequest(task="x", diff=DiffInput("workspace"))
+
+
+def test_plan_change_diff_requires_three_calls_floor() -> None:
+    PlanChangeRequest(diff=DiffInput("workspace"))  # standard 12 >= 3
+    PlanChangeRequest(  # compact 4 >= 3 is fine
+        diff=DiffInput("workspace"), budget=Budget(profile="compact")
+    )
+    with pytest.raises(ValueError, match="BUDGET_INVALID"):
+        PlanChangeRequest(
+            diff=DiffInput("workspace"),
+            budget=Budget(profile="standard", max_primitive_calls=2),
+        )
+
+
+def test_assess_change_requires_diff() -> None:
+    with pytest.raises(ValueError, match="exactly one diff"):
+        AssessChangeRequest()
+
+
+def test_consumed_budget_rejects_negative_counters() -> None:
+    ConsumedBudget(primitive_calls=3, evidence_items=10, routing_wall_ms=100)
+    with pytest.raises(ValueError, match="non-negative"):
+        ConsumedBudget(primitive_calls=-1, evidence_items=0, routing_wall_ms=0)
+
+
+def test_task_outcome_requires_canonical_verdict_without_error() -> None:
+    outcome = TaskOutcome(
+        task="understand",
+        request=UnderstandRequest(task="x"),
+        verdict="OK",
+    )
+    assert outcome.verdict == "OK"
+    with pytest.raises(ValueError, match="canonical verdict"):
+        TaskOutcome(
+            task="understand",
+            request=UnderstandRequest(task="x"),
+            verdict="FANCY",
+        )
+    # error outcomes may carry any verdict
+    TaskOutcome(
+        task="understand",
+        request=UnderstandRequest(task="x"),
+        verdict="ERROR",
+        error="boom",
+    )
+
+
+def test_models_are_frozen_and_hashable() -> None:
+    import dataclasses
+
+    for cls in (Budget, DiffInput, UnderstandRequest, PlanChangeRequest, TaskOutcome):
+        assert dataclasses.is_dataclass(cls)
+        assert cls.__dataclass_params__.frozen is True  # type: ignore[attr-defined]
+    budget = Budget(profile="compact")
+    assert hash(budget) == hash(Budget(profile="compact"))

--- a/tests/unit/task/test_task_models.py
+++ b/tests/unit/task/test_task_models.py
@@ -81,13 +81,14 @@ def test_diff_input_rejects_empty_scope_paths() -> None:
         DiffInput(source="workspace", scope_paths=("",))
 
 
-def test_understand_requires_exactly_one_task_or_diff() -> None:
+def test_understand_accepts_task_text_only() -> None:
     assert UnderstandRequest(task="explain dispatch").task == "explain dispatch"
-    assert UnderstandRequest(diff=DiffInput("staged")).diff is not None
-    with pytest.raises(ValueError, match="exactly one of task or diff"):
+    with pytest.raises(ValueError, match="task must not be empty"):
         UnderstandRequest()
-    with pytest.raises(ValueError, match="exactly one of task or diff"):
-        UnderstandRequest(task="x", diff=DiffInput("workspace"))
+    # RFC-0022: understand(diff) is invalid — the model has no diff field.
+    import dataclasses
+
+    assert "diff" not in dataclasses.fields(UnderstandRequest)
 
 
 def test_plan_change_diff_requires_three_calls_floor() -> None:
@@ -113,32 +114,122 @@ def test_consumed_budget_rejects_negative_counters() -> None:
         ConsumedBudget(primitive_calls=-1, evidence_items=0, routing_wall_ms=0)
 
 
-def test_task_outcome_requires_canonical_verdict_without_error() -> None:
+def test_task_outcome_uses_rfc_verdict_vocabulary() -> None:
+    from tree_sitter_analyzer.task.models import CANONICAL_VERDICTS
+
+    assert CANONICAL_VERDICTS == {
+        "SAFE",
+        "CAUTION",
+        "REVIEW",
+        "UNSAFE",
+        "INFO",
+        "WARN",
+        "NOT_FOUND",
+        "ERROR",
+    }
     outcome = TaskOutcome(
-        task="understand",
-        request=UnderstandRequest(task="x"),
-        verdict="OK",
+        task="understand", request=UnderstandRequest(task="x"), verdict="SAFE"
     )
-    assert outcome.verdict == "OK"
-    with pytest.raises(ValueError, match="canonical verdict"):
+    assert outcome.verdict == "SAFE"
+    with pytest.raises(ValueError, match="not in canonical set"):
         TaskOutcome(
             task="understand",
             request=UnderstandRequest(task="x"),
-            verdict="FANCY",
-        )
-    # error outcomes may carry any verdict
+            verdict="OK",
+        )  # RFC verdicts only — OK/PARTIAL are statuses, not verdicts
+
+
+def test_task_outcome_error_forces_verdict_error() -> None:
     TaskOutcome(
         task="understand",
         request=UnderstandRequest(task="x"),
         verdict="ERROR",
         error="boom",
     )
+    with pytest.raises(ValueError, match="must be verdict=ERROR"):
+        TaskOutcome(
+            task="understand",
+            request=UnderstandRequest(task="x"),
+            verdict="WARN",
+            error="boom",
+        )
+    with pytest.raises(ValueError, match="forbidden without an error"):
+        TaskOutcome(
+            task="understand",
+            request=UnderstandRequest(task="x"),
+            verdict="ERROR",
+        )
+
+
+def test_task_outcome_status_vocabulary() -> None:
+    assert (
+        TaskOutcome(
+            task="understand",
+            request=UnderstandRequest(task="x"),
+            verdict="SAFE",
+            status="complete",
+        ).status
+        == "complete"
+    )
+    with pytest.raises(ValueError, match="not in canonical set"):
+        TaskOutcome(
+            task="understand",
+            request=UnderstandRequest(task="x"),
+            verdict="SAFE",
+            status="done",
+        )
+
+
+def test_task_text_boundaries() -> None:
+    with pytest.raises(ValueError, match="task must be a string"):
+        UnderstandRequest(task=123)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="must not contain NUL"):
+        UnderstandRequest(task="bad\x00name")
+
+
+def test_scope_paths_boundaries() -> None:
+    from tree_sitter_analyzer.task.models import MAX_SCOPE_PATHS
+
+    too_many = tuple(f"p{i}" for i in range(MAX_SCOPE_PATHS + 1))
+    with pytest.raises(ValueError, match="exceeds"):
+        DiffInput(source="workspace", scope_paths=too_many)
+    with pytest.raises(ValueError, match="exceeds.*UTF-8 bytes"):
+        DiffInput(source="workspace", scope_paths=("x" * 1025,))
+
+
+def test_consumed_budget_cleanup_contract() -> None:
+    with pytest.raises(ValueError, match="zero or one"):
+        ConsumedBudget(
+            primitive_calls=1, evidence_items=1, routing_wall_ms=1, cleanup_calls=2
+        )
+    with pytest.raises(ValueError, match="requires the stable error code"):
+        ConsumedBudget(
+            primitive_calls=1,
+            evidence_items=1,
+            routing_wall_ms=1,
+            cleanup_status="failed",
+        )
+    ConsumedBudget(
+        primitive_calls=1,
+        evidence_items=1,
+        routing_wall_ms=1,
+        cleanup_status="failed",
+        cleanup_error_code="DIFF_SNAPSHOT_CLEANUP_FAILED",
+    )
 
 
 def test_models_are_frozen_and_hashable() -> None:
     import dataclasses
 
-    for cls in (Budget, DiffInput, UnderstandRequest, PlanChangeRequest, TaskOutcome):
+    for cls in (
+        Budget,
+        DiffInput,
+        UnderstandRequest,
+        PlanChangeRequest,
+        AssessChangeRequest,
+        ConsumedBudget,
+        TaskOutcome,
+    ):
         assert dataclasses.is_dataclass(cls)
         assert cls.__dataclass_params__.frozen is True  # type: ignore[attr-defined]
     budget = Budget(profile="compact")

--- a/tests/unit/task/test_task_models.py
+++ b/tests/unit/task/test_task_models.py
@@ -234,3 +234,83 @@ def test_models_are_frozen_and_hashable() -> None:
         assert cls.__dataclass_params__.frozen is True  # type: ignore[attr-defined]
     budget = Budget(profile="compact")
     assert hash(budget) == hash(Budget(profile="compact"))
+
+
+def test_scope_paths_total_bytes_boundary() -> None:
+    # RFC-0022: 128 entries x 256 bytes each stays under the 32768 total.
+    many = tuple(f"p{i}" + "x" * 250 for i in range(128))
+    assert len(DiffInput(source="workspace", scope_paths=many).scope_paths) == 128
+    with pytest.raises(ValueError, match="exceed .* total bytes"):
+        DiffInput(source="workspace", scope_paths=("x" * 1024,) * 33)
+
+
+def test_request_rejects_non_budget_budget() -> None:
+    with pytest.raises(ValueError, match="budget must be a frozen Budget"):
+        UnderstandRequest(task="x", budget="standard")  # type: ignore[arg-type]
+
+
+def test_task_text_exceeding_max_bytes_rejected() -> None:
+    with pytest.raises(ValueError, match="exceeds .* UTF-8 bytes"):
+        UnderstandRequest(task="x" * 16_385)
+
+
+def test_assess_change_diff_runs_budget_floor() -> None:
+    # L181 coverage: the diff floor runs on the assess route too.
+    AssessChangeRequest(diff=DiffInput("workspace"))
+    with pytest.raises(ValueError, match="BUDGET_INVALID"):
+        AssessChangeRequest(
+            diff=DiffInput("workspace"),
+            budget=Budget(profile="standard", max_primitive_calls=2),
+        )
+
+
+def test_consumed_budget_negative_durations_rejected() -> None:
+    with pytest.raises(ValueError, match="non-negative"):
+        ConsumedBudget(primitive_calls=1, evidence_items=1, routing_wall_ms=-1)
+    with pytest.raises(ValueError, match="cleanup_wall_ms must be non-negative"):
+        ConsumedBudget(
+            primitive_calls=1, evidence_items=1, routing_wall_ms=1, cleanup_wall_ms=-1
+        )
+
+
+def test_consumed_budget_unknown_cleanup_status_rejected() -> None:
+    with pytest.raises(ValueError, match="unknown cleanup_status"):
+        ConsumedBudget(
+            primitive_calls=1,
+            evidence_items=1,
+            routing_wall_ms=1,
+            cleanup_status="pending",  # type: ignore[arg-type]
+        )
+    with pytest.raises(ValueError, match="must be null or"):
+        ConsumedBudget(
+            primitive_calls=1,
+            evidence_items=1,
+            routing_wall_ms=1,
+            cleanup_error_code="OTHER",
+        )
+
+
+def test_task_outcome_unknown_task_name_rejected() -> None:
+    with pytest.raises(ValueError, match="unknown task name"):
+        TaskOutcome(  # type: ignore[arg-type]
+            task="explain",
+            request=UnderstandRequest(task="x"),
+            verdict="SAFE",
+        )
+
+
+def test_task_outcome_rejects_non_consumed_budget() -> None:
+    with pytest.raises(ValueError, match="consumed must be a frozen ConsumedBudget"):
+        TaskOutcome(
+            task="understand",
+            request=UnderstandRequest(task="x"),
+            verdict="SAFE",
+            consumed={"primitive_calls": 1},  # type: ignore[arg-type]
+        )
+
+
+def test_plan_change_task_text_path_runs_validator() -> None:
+    # L271/273 coverage: the task-text branch of the one-of validator.
+    assert PlanChangeRequest(task="refactor dispatch").task == "refactor dispatch"
+    with pytest.raises(ValueError, match="exactly one of task or diff"):
+        PlanChangeRequest()

--- a/tree_sitter_analyzer/task/__init__.py
+++ b/tree_sitter_analyzer/task/__init__.py
@@ -1,0 +1,31 @@
+"""RFC-0022 task-outcome/v1 package (Phase A, internal experiment only).
+
+Not registered as an MCP facade, CLI command, or codemap surface
+(RFC-0022 §Public surface: Phase A — internal experiment only).
+"""
+
+from __future__ import annotations
+
+from .models import (
+    BUDGET_PROFILES,
+    AssessChangeRequest,
+    Budget,
+    ConsumedBudget,
+    DiffInput,
+    PlanChangeRequest,
+    TaskOutcome,
+    TaskRequest,
+    UnderstandRequest,
+)
+
+__all__ = [
+    "AssessChangeRequest",
+    "Budget",
+    "BUDGET_PROFILES",
+    "ConsumedBudget",
+    "DiffInput",
+    "PlanChangeRequest",
+    "TaskOutcome",
+    "TaskRequest",
+    "UnderstandRequest",
+]

--- a/tree_sitter_analyzer/task/models.py
+++ b/tree_sitter_analyzer/task/models.py
@@ -12,12 +12,30 @@ from typing import Any, Literal
 
 Profile = Literal["compact", "standard"]
 TaskName = Literal["understand", "plan_change", "assess_change"]
+Verdict = Literal[
+    "SAFE", "CAUTION", "REVIEW", "UNSAFE", "INFO", "WARN", "NOT_FOUND", "ERROR"
+]
+Status = Literal["complete", "partial", "unknown"]
 
 BUDGET_PROFILES: dict[Profile, tuple[int, int, int]] = {
     # profile -> (max_primitive_calls, max_evidence_items, routing_deadline_ms)
     "compact": (4, 15, 5_000),
     "standard": (12, 50, 30_000),
 }
+
+#: RFC-0022 fixed wire verdict vocabulary (strict clients reject unknown values).
+CANONICAL_VERDICTS: frozenset[str] = frozenset(
+    {"SAFE", "CAUTION", "REVIEW", "UNSAFE", "INFO", "WARN", "NOT_FOUND", "ERROR"}
+)
+
+#: RFC-0022 fixed wire status vocabulary.
+CANONICAL_STATUSES: frozenset[str] = frozenset({"complete", "partial", "unknown"})
+
+#: RFC-0022 boundary limits (§Fixed task-outcome/v1 semantics).
+MAX_SCOPE_PATHS = 128
+MAX_SCOPE_PATH_BYTES = 1024
+MAX_SCOPE_TOTAL_BYTES = 32_768
+MAX_TASK_BYTES = 16_384
 
 _BUDGET_FIELD_NAMES = (
     "max_primitive_calls",
@@ -81,7 +99,7 @@ class Budget:
 
 @dataclass(frozen=True)
 class DiffInput:
-    """A diff-based task input (exactly one of task/diff per request)."""
+    """A diff-based task input (diff is the only subject for two operations)."""
 
     source: Literal["workspace", "staged"]
     #: Passed unchanged only to ``edit.impact`` (RFC-0022 §Internal contract).
@@ -90,8 +108,20 @@ class DiffInput:
     def __post_init__(self) -> None:
         if self.source not in {"workspace", "staged"}:
             raise ValueError(f"unknown diff source {self.source!r}")
-        if any(type(path) is not str or not path for path in self.scope_paths):
-            raise ValueError("scope_paths must be non-empty strings")
+        if len(self.scope_paths) > MAX_SCOPE_PATHS:
+            raise ValueError(f"scope_paths exceeds {MAX_SCOPE_PATHS} entries")
+        total_bytes = 0
+        for path in self.scope_paths:
+            if type(path) is not str or not path:
+                raise ValueError("scope_paths must be non-empty strings")
+            raw = path.encode("utf-8")
+            if len(raw) > MAX_SCOPE_PATH_BYTES:
+                raise ValueError(
+                    f"scope path exceeds {MAX_SCOPE_PATH_BYTES} UTF-8 bytes"
+                )
+            total_bytes += len(raw)
+        if total_bytes > MAX_SCOPE_TOTAL_BYTES:
+            raise ValueError(f"scope_paths exceed {MAX_SCOPE_TOTAL_BYTES} total bytes")
 
 
 @dataclass(frozen=True)
@@ -101,19 +131,31 @@ class TaskRequest:
     budget: Budget = field(default_factory=Budget)
 
     def __post_init__(self) -> None:
-        # Force the frozen contract: subclasses re-validate their own fields.
         if type(self.budget) is not Budget:
             raise ValueError("budget must be a frozen Budget")
 
 
+def _validate_task_text(task: str) -> None:
+    """Bound untrusted task text (RFC-0022: 1..16384 UTF-8 bytes, no NUL)."""
+    if type(task) is not str:
+        raise ValueError("task must be a string")
+    if not task.strip():
+        raise ValueError("task must not be empty")
+    raw = task.encode("utf-8")
+    if len(raw) > MAX_TASK_BYTES:
+        raise ValueError(f"task exceeds {MAX_TASK_BYTES} UTF-8 bytes")
+    if "\x00" in task:
+        raise ValueError("task must not contain NUL")
+
+
 @dataclass(frozen=True)
 class UnderstandRequest(TaskRequest):
+    #: RFC-0022: understand(diff) is invalid — task text only.
     task: str = ""
-    diff: DiffInput | None = None
 
     def __post_init__(self) -> None:
         super().__post_init__()
-        _validate_task_or_diff(self.task, self.diff)
+        _validate_task_text(self.task)
 
 
 @dataclass(frozen=True)
@@ -141,27 +183,60 @@ class AssessChangeRequest(TaskRequest):
 
 @dataclass(frozen=True)
 class ConsumedBudget:
-    """Reported primitive accounting (RFC-0022 §Budget and truncation)."""
+    """Reported primitive accounting (RFC-0022 §Budget and truncation).
+
+    ``routing_deadline_ms`` is a routing deadline, not a wall-time SLA:
+    ``routing_wall_ms`` may exceed it, with ``deadline_overrun_ms`` reported
+    exactly. Cleanup accounting is fixed per RFC: the host records the four
+    cleanup fields after the unconditional release runs in an outer finally.
+    """
 
     primitive_calls: int
     evidence_items: int
     routing_wall_ms: int
     deadline_overrun_ms: int = 0
+    cleanup_calls: int = 0
+    cleanup_wall_ms: int = 0
+    cleanup_status: Literal["not_required", "succeeded", "failed"] = "not_required"
+    cleanup_error_code: str | None = None
 
     def __post_init__(self) -> None:
         if self.primitive_calls < 0 or self.evidence_items < 0:
             raise ValueError("consumed counters must be non-negative")
         if self.routing_wall_ms < 0 or self.deadline_overrun_ms < 0:
             raise ValueError("consumed durations must be non-negative")
+        if self.cleanup_calls not in {0, 1}:
+            raise ValueError("cleanup_calls must be zero or one")
+        if self.cleanup_wall_ms < 0:
+            raise ValueError("cleanup_wall_ms must be non-negative")
+        if self.cleanup_status not in {"not_required", "succeeded", "failed"}:
+            raise ValueError(f"unknown cleanup_status {self.cleanup_status!r}")
+        if self.cleanup_error_code not in {
+            None,
+            "DIFF_SNAPSHOT_CLEANUP_FAILED",
+        }:
+            raise ValueError(
+                f"cleanup_error_code must be null or DIFF_SNAPSHOT_CLEANUP_FAILED, "
+                f"got {self.cleanup_error_code!r}"
+            )
+        if self.cleanup_status == "failed" and self.cleanup_error_code is None:
+            raise ValueError("failed cleanup requires the stable error code")
 
 
 @dataclass(frozen=True)
 class TaskOutcome:
-    """One task-outcome/v1 result (frozen; serializer must be deterministic)."""
+    """One task-outcome/v1 result (frozen; serializer must be deterministic).
+
+    RFC-0022 fixed wire: ``status`` (complete|partial|unknown) is separate
+    from ``verdict`` (SAFE|CAUTION|REVIEW|UNSAFE|INFO|WARN|NOT_FOUND|ERROR).
+    A failed outcome is always ``verdict=ERROR``; ERROR is forbidden on
+    success.
+    """
 
     task: TaskName
     request: TaskRequest
-    verdict: str
+    verdict: Verdict
+    status: Status = "unknown"
     evidence: tuple[dict[str, Any], ...] = ()
     consumed: ConsumedBudget | None = None
     error: str | None = None
@@ -169,17 +244,30 @@ class TaskOutcome:
     def __post_init__(self) -> None:
         if self.task not in {"understand", "plan_change", "assess_change"}:
             raise ValueError(f"unknown task name {self.task!r}")
-        if self.error is None and self.verdict not in {"OK", "PARTIAL", "NOT_FOUND"}:
+        if self.verdict not in CANONICAL_VERDICTS:
             raise ValueError(
-                f"non-error outcome requires canonical verdict, got {self.verdict!r}"
+                f"verdict {self.verdict!r} not in canonical set "
+                f"{sorted(CANONICAL_VERDICTS)}"
             )
+        if self.status not in CANONICAL_STATUSES:
+            raise ValueError(
+                f"status {self.status!r} not in canonical set "
+                f"{sorted(CANONICAL_STATUSES)}"
+            )
+        if self.error is not None:
+            if self.verdict != "ERROR":
+                raise ValueError("failed outcome must be verdict=ERROR")
+        elif self.verdict == "ERROR":
+            raise ValueError("verdict=ERROR is forbidden without an error")
+        if type(self.consumed) not in {ConsumedBudget, type(None)}:
+            raise ValueError("consumed must be a frozen ConsumedBudget")
 
 
 def _validate_task_or_diff(task: str, diff: DiffInput | None) -> None:
     """Exactly one of task/diff must be supplied (RFC-0022 §Internal contract)."""
-    has_task = bool(task.strip())
+    has_task = bool(task.strip()) if type(task) is str else True
     has_diff = diff is not None
     if has_task == has_diff:
         raise ValueError("task request must have exactly one of task or diff")
-    if has_task and not isinstance(task, str):
-        raise ValueError("task must be a string")
+    if has_task:
+        _validate_task_text(task)

--- a/tree_sitter_analyzer/task/models.py
+++ b/tree_sitter_analyzer/task/models.py
@@ -1,0 +1,185 @@
+"""RFC-0022 task-outcome/v1 internal models (Phase A, experiment only).
+
+Frozen value objects for the three task outcomes. This package is
+deliberately internal: no MCP facade, no CLI flags, no codemap surface
+(RFC-0022 §Public surface: Phase A is internal experiment only).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+Profile = Literal["compact", "standard"]
+TaskName = Literal["understand", "plan_change", "assess_change"]
+
+BUDGET_PROFILES: dict[Profile, tuple[int, int, int]] = {
+    # profile -> (max_primitive_calls, max_evidence_items, routing_deadline_ms)
+    "compact": (4, 15, 5_000),
+    "standard": (12, 50, 30_000),
+}
+
+_BUDGET_FIELD_NAMES = (
+    "max_primitive_calls",
+    "max_evidence_items",
+    "routing_deadline_ms",
+)
+
+
+@dataclass(frozen=True)
+class Budget:
+    """One pinned routing budget for a task-outcome request.
+
+    Explicit values may only lower a profile value; raising one is
+    BUDGET_INVALID and rejected before any primitive call (RFC-0022
+    §Internal Python contract).
+    """
+
+    profile: Profile = "standard"
+    max_primitive_calls: int | None = None
+    max_evidence_items: int | None = None
+    routing_deadline_ms: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.profile not in BUDGET_PROFILES:
+            raise ValueError(f"BUDGET_INVALID: unknown profile {self.profile!r}")
+        pinned_calls, pinned_evidence, pinned_deadline = BUDGET_PROFILES[self.profile]
+        for name, value, ceiling in (
+            ("max_primitive_calls", self.max_primitive_calls, pinned_calls),
+            ("max_evidence_items", self.max_evidence_items, pinned_evidence),
+            ("routing_deadline_ms", self.routing_deadline_ms, pinned_deadline),
+        ):
+            if value is not None and (value < 1 or value > ceiling):
+                raise ValueError(
+                    f"BUDGET_INVALID: {name}={value} must be 1..{ceiling} "
+                    f"for profile {self.profile!r}"
+                )
+
+    @property
+    def effective_calls(self) -> int:
+        ceiling = BUDGET_PROFILES[self.profile][0]
+        return self.max_primitive_calls or ceiling
+
+    @property
+    def effective_evidence(self) -> int:
+        ceiling = BUDGET_PROFILES[self.profile][1]
+        return self.max_evidence_items or ceiling
+
+    @property
+    def effective_deadline_ms(self) -> int:
+        ceiling = BUDGET_PROFILES[self.profile][2]
+        return self.routing_deadline_ms or ceiling
+
+    def require_calls(self, minimum: int) -> None:
+        """Reject budgets below a routing floor (e.g. diff requests >= 3)."""
+        if self.effective_calls < minimum:
+            raise ValueError(
+                f"BUDGET_INVALID: requires max_primitive_calls >= {minimum}, "
+                f"got {self.effective_calls}"
+            )
+
+
+@dataclass(frozen=True)
+class DiffInput:
+    """A diff-based task input (exactly one of task/diff per request)."""
+
+    source: Literal["workspace", "staged"]
+    #: Passed unchanged only to ``edit.impact`` (RFC-0022 §Internal contract).
+    scope_paths: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.source not in {"workspace", "staged"}:
+            raise ValueError(f"unknown diff source {self.source!r}")
+        if any(type(path) is not str or not path for path in self.scope_paths):
+            raise ValueError("scope_paths must be non-empty strings")
+
+
+@dataclass(frozen=True)
+class TaskRequest:
+    """Common request fields for the three task outcomes."""
+
+    budget: Budget = field(default_factory=Budget)
+
+    def __post_init__(self) -> None:
+        # Force the frozen contract: subclasses re-validate their own fields.
+        if type(self.budget) is not Budget:
+            raise ValueError("budget must be a frozen Budget")
+
+
+@dataclass(frozen=True)
+class UnderstandRequest(TaskRequest):
+    task: str = ""
+    diff: DiffInput | None = None
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        _validate_task_or_diff(self.task, self.diff)
+
+
+@dataclass(frozen=True)
+class PlanChangeRequest(TaskRequest):
+    task: str = ""
+    diff: DiffInput | None = None
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        _validate_task_or_diff(self.task, self.diff)
+        if self.diff is not None:
+            self.budget.require_calls(3)
+
+
+@dataclass(frozen=True)
+class AssessChangeRequest(TaskRequest):
+    diff: DiffInput | None = None
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        if self.diff is None:
+            raise ValueError("assess_change requires exactly one diff")
+        self.budget.require_calls(3)
+
+
+@dataclass(frozen=True)
+class ConsumedBudget:
+    """Reported primitive accounting (RFC-0022 §Budget and truncation)."""
+
+    primitive_calls: int
+    evidence_items: int
+    routing_wall_ms: int
+    deadline_overrun_ms: int = 0
+
+    def __post_init__(self) -> None:
+        if self.primitive_calls < 0 or self.evidence_items < 0:
+            raise ValueError("consumed counters must be non-negative")
+        if self.routing_wall_ms < 0 or self.deadline_overrun_ms < 0:
+            raise ValueError("consumed durations must be non-negative")
+
+
+@dataclass(frozen=True)
+class TaskOutcome:
+    """One task-outcome/v1 result (frozen; serializer must be deterministic)."""
+
+    task: TaskName
+    request: TaskRequest
+    verdict: str
+    evidence: tuple[dict[str, Any], ...] = ()
+    consumed: ConsumedBudget | None = None
+    error: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.task not in {"understand", "plan_change", "assess_change"}:
+            raise ValueError(f"unknown task name {self.task!r}")
+        if self.error is None and self.verdict not in {"OK", "PARTIAL", "NOT_FOUND"}:
+            raise ValueError(
+                f"non-error outcome requires canonical verdict, got {self.verdict!r}"
+            )
+
+
+def _validate_task_or_diff(task: str, diff: DiffInput | None) -> None:
+    """Exactly one of task/diff must be supplied (RFC-0022 §Internal contract)."""
+    has_task = bool(task.strip())
+    has_diff = diff is not None
+    if has_task == has_diff:
+        raise ValueError("task request must have exactly one of task or diff")
+    if has_task and not isinstance(task, str):
+        raise ValueError("task must be a string")


### PR DESCRIPTION
## Summary

RFC-0022 **Phase A slice 1**: internal `tree_sitter_analyzer/task/` package with frozen models and the pinned budget contract.

- `models.py`: frozen `Budget` (compact 4/15/5000ms, standard 12/50/30000ms; explicit values may only lower; BUDGET_INVALID), `DiffInput` (workspace/staged + scope_paths), `UnderstandRequest` / `PlanChangeRequest` / `AssessChangeRequest` (exactly one task-or-diff; diff requires >=3 primitive calls), `ConsumedBudget`, `TaskOutcome` (canonical verdicts; frozen)
- `__init__.py` exports
- 15 contract tests (`tests/unit/task/test_task_models.py`, new subsystem per T-1 exception): exact profile pins, lowering-only rule, floors, frozen/hashable

## Verification
- quick gate: 1986 passed, 27 skipped
- focused: 15 passed
- pre-commit: passed

## Scope boundary
Models + budget only. Routing table, evidence identity, freshness, serializer parity, and the benchmark harness remain later Phase A slices (RED-first items 3-9). No MCP/CLI/codemap surface (RFC-0022 Phase A internal-only).