### PR TITLE
feat(task): evidence identity, freshness, route table (RFC-0022 Phase A)

### DIFF
--- a/tests/unit/task/test_evidence_router.py
+++ b/tests/unit/task/test_evidence_router.py
@@ -1,0 +1,255 @@
+"""RFC-0022 task-outcome/v1 evidence, freshness, and route-table contracts.
+
+Exact pins for evidence identity (RFC-0022 §Evidence and provenance
+identity), freshness states (§Freshness and snapshot truth), and the
+complete route decision table (§Complete V1 route decision table).
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from tree_sitter_analyzer.task import (
+    FRESHNESS_STATES,
+    ROUTE_TABLE,
+    SAFE_FANOUT_CAPS,
+    EvidenceInput,
+    SnapshotTruth,
+    evidence_identity,
+    normalized_result_hash,
+)
+
+
+def _base_evidence() -> EvidenceInput:
+    return EvidenceInput(
+        primitive_facade="edit",
+        action="safe",
+        action_version="edit.safe/v1",
+        normalized_result_sha256=hashlib.sha256(b"{}").hexdigest(),
+        source_snapshot_id="idxsnap_01",
+        locator="src/app.py",
+    )
+
+
+def test_evidence_identity_is_exact_digest_prefix() -> None:
+    identity = evidence_identity(_base_evidence())
+    assert identity.startswith("evidence:")
+    assert len(identity) == len("evidence:") + 64
+    hex_part = identity[len("evidence:") :]
+    assert all(char in "0123456789abcdef" for char in hex_part)
+
+
+def test_evidence_identity_is_deterministic() -> None:
+    assert evidence_identity(_base_evidence()) == evidence_identity(_base_evidence())
+
+
+def test_evidence_identity_changes_with_each_owner_field() -> None:
+    base = _base_evidence()
+    baseline = evidence_identity(base)
+    variants = {
+        "facade": EvidenceInput(
+            primitive_facade="nav",
+            action=base.action,
+            action_version=base.action_version,
+            normalized_result_sha256=base.normalized_result_sha256,
+            source_snapshot_id=base.source_snapshot_id,
+            locator=base.locator,
+        ),
+        "action": EvidenceInput(
+            primitive_facade=base.primitive_facade,
+            action="classify",
+            action_version=base.action_version,
+            normalized_result_sha256=base.normalized_result_sha256,
+            source_snapshot_id=base.source_snapshot_id,
+            locator=base.locator,
+        ),
+        "version": EvidenceInput(
+            primitive_facade=base.primitive_facade,
+            action=base.action,
+            action_version="edit.safe/v2",
+            normalized_result_sha256=base.normalized_result_sha256,
+            source_snapshot_id=base.source_snapshot_id,
+            locator=base.locator,
+        ),
+        "result": EvidenceInput(
+            primitive_facade=base.primitive_facade,
+            action=base.action,
+            action_version=base.action_version,
+            normalized_result_sha256=hashlib.sha256(b"other").hexdigest(),
+            source_snapshot_id=base.source_snapshot_id,
+            locator=base.locator,
+        ),
+        "snapshot": EvidenceInput(
+            primitive_facade=base.primitive_facade,
+            action=base.action,
+            action_version=base.action_version,
+            normalized_result_sha256=base.normalized_result_sha256,
+            source_snapshot_id="other-snap",
+            locator=base.locator,
+        ),
+        "locator": EvidenceInput(
+            primitive_facade=base.primitive_facade,
+            action=base.action,
+            action_version=base.action_version,
+            normalized_result_sha256=base.normalized_result_sha256,
+            source_snapshot_id=base.source_snapshot_id,
+            locator="src/other.py",
+        ),
+    }
+    for name, variant in variants.items():
+        assert evidence_identity(variant) != baseline, name
+
+
+def test_evidence_identity_same_locator_different_results_are_distinct() -> None:
+    # Locator alone never identifies or deduplicates evidence.
+    first = evidence_identity(_base_evidence())
+    different_result = EvidenceInput(
+        primitive_facade="edit",
+        action="safe",
+        action_version="edit.safe/v1",
+        normalized_result_sha256=hashlib.sha256(b'{"x":1}').hexdigest(),
+        source_snapshot_id="idxsnap_01",
+        locator="src/app.py",
+    )
+    assert evidence_identity(different_result) != first
+
+
+def test_evidence_input_rejects_bad_digest() -> None:
+    with pytest.raises(ValueError, match="64-hex digest"):
+        EvidenceInput(
+            primitive_facade="edit",
+            action="safe",
+            action_version="edit.safe/v1",
+            normalized_result_sha256="short",
+            source_snapshot_id=None,
+            locator="x",
+        )
+
+
+def test_normalized_result_hash_is_canonical() -> None:
+    assert normalized_result_hash({"b": 1, "a": 2}) == normalized_result_hash(
+        {"a": 2, "b": 1}
+    )
+    assert normalized_result_hash({"a": 2, "b": 1}) != normalized_result_hash(
+        {"a": 2, "b": 1, "c": 3}
+    )
+
+
+def test_freshness_states_are_pinned() -> None:
+    assert FRESHNESS_STATES == {
+        "fresh",
+        "stale",
+        "missing",
+        "not_applicable",
+        "unknown",
+    }
+
+
+def test_freshness_not_applicable_without_graph_evidence() -> None:
+    truth = SnapshotTruth(oracle_complete=True, snapshot_id="s1", graph_tokens=())
+    assert truth.freshness == ("not_applicable", None)
+    assert truth.graph_status_cap == "partial"
+
+
+def test_freshness_fresh_requires_complete_oracle_and_matching_tokens() -> None:
+    truth = SnapshotTruth(
+        oracle_complete=True,
+        snapshot_id="s1",
+        graph_tokens=("s1",),
+    )
+    assert truth.freshness == ("fresh", None)
+    assert truth.graph_status_cap == "complete"
+
+
+def test_freshness_incomplete_oracle_is_unknown() -> None:
+    truth = SnapshotTruth(
+        oracle_complete=False,
+        snapshot_id="s1",
+        graph_tokens=("s1",),
+    )
+    assert truth.freshness == (
+        "unknown",
+        "AUTHORITATIVE_SNAPSHOT_UNAVAILABLE",
+    )
+    assert truth.graph_status_cap == "partial"
+
+
+def test_freshness_missing_snapshot_is_missing() -> None:
+    truth = SnapshotTruth(oracle_complete=True, snapshot_id=None, graph_tokens=("s1",))
+    assert truth.freshness == ("missing", "AUTHORITATIVE_SNAPSHOT_UNAVAILABLE")
+
+
+def test_freshness_token_mismatch_is_stale() -> None:
+    truth = SnapshotTruth(
+        oracle_complete=True,
+        snapshot_id="s1",
+        graph_tokens=("s2",),
+    )
+    assert truth.freshness == ("stale", "SNAPSHOT_TOKEN_MISMATCH")
+    assert truth.graph_status_cap == "partial"
+
+
+def test_route_table_rows_are_pinned_exactly() -> None:
+    assert [(row.operation, row.facade, row.action) for row in ROUTE_TABLE] == [
+        ("all", "index", "status"),
+        ("understand(task)", "nav", "context"),
+        ("plan_change(task)", "nav", "context"),
+        ("plan_change(task)", "edit", "safe"),
+        ("diff operation", "edit", "impact"),
+        ("diff operation", "edit", "constraints"),
+        ("diff operation", "edit", "ast_diff"),
+        ("diff operation", "edit", "classify"),
+    ]
+
+
+def test_route_table_orders_constraints_before_fanout() -> None:
+    # Common routing rule 2: constraints is reserved before file fan-out and
+    # follows a successful impact immediately.
+    order = {id(row): index for index, row in enumerate(ROUTE_TABLE)}
+    impact = next(row for row in ROUTE_TABLE if row.action == "impact")
+    constraints = next(row for row in ROUTE_TABLE if row.action == "constraints")
+    ast_diff = next(row for row in ROUTE_TABLE if row.action == "ast_diff")
+    assert order[id(impact)] < order[id(constraints)] < order[id(ast_diff)]
+
+
+def test_route_table_primitive_parameters_are_exact() -> None:
+    params = {
+        (row.operation, row.facade, row.action): row.parameters for row in ROUTE_TABLE
+    }
+    assert params[("all", "index", "status")] == (
+        ("access_mode", "read_existing"),
+        ("output_format", "json"),
+    )
+    assert params[("understand(task)", "nav", "context")] == (
+        ("max_nodes", "12/30"),
+        ("max_code_blocks", "3/5"),
+        ("include_graph", "false"),
+        ("access_mode", "read_existing"),
+        ("output_format", "json"),
+    )
+    assert params[("diff operation", "edit", "constraints")] == (
+        ("persist", "false"),
+        ("access_mode", "read_existing"),
+        ("output_format", "json"),
+    )
+
+
+def test_safe_fanout_caps_are_pinned() -> None:
+    assert SAFE_FANOUT_CAPS == {"compact": 2, "standard": 5}
+
+
+def test_route_table_has_no_llm_or_keyword_router() -> None:
+    # RFC-0022: no task-layer keyword, regex, intent, or LLM router.
+    for row in ROUTE_TABLE:
+        assert row.facade in {"index", "nav", "edit"}
+        assert row.action in {
+            "status",
+            "context",
+            "safe",
+            "impact",
+            "constraints",
+            "ast_diff",
+            "classify",
+        }

--- a/tests/unit/task/test_evidence_router.py
+++ b/tests/unit/task/test_evidence_router.py
@@ -356,6 +356,16 @@ def test_route_table_dynamic_parameters_are_pinned() -> None:
         for row in ROUTE_TABLE
     }
     assert dynamic[("all", "index", "status")] == ()
+    assert dynamic[("understand(task)", "nav", "context")] == (
+        "task",
+        "snapshot_id",
+        "source_generation",
+    )
+    assert dynamic[("plan_change(task)", "nav", "context")] == (
+        "task",
+        "snapshot_id",
+        "source_generation",
+    )
     assert dynamic[("plan_change(task)", "edit", "safe")] == (
         "file_path",
         "snapshot_id",

--- a/tests/unit/task/test_evidence_router.py
+++ b/tests/unit/task/test_evidence_router.py
@@ -17,9 +17,25 @@ from tree_sitter_analyzer.task import (
     SAFE_FANOUT_CAPS,
     EvidenceInput,
     SnapshotTruth,
+    SourceSnapshotRecord,
     evidence_identity,
     normalized_result_hash,
 )
+
+
+def _base_snapshots() -> tuple[SourceSnapshotRecord, ...]:
+    return (
+        SourceSnapshotRecord(
+            kind="diff",
+            snapshot_id="diffsnap_01",
+            source_generation="gen_01",
+        ),
+        SourceSnapshotRecord(
+            kind="index",
+            snapshot_id="idxsnap_01",
+            source_generation="gen_01",
+        ),
+    )
 
 
 def _base_evidence() -> EvidenceInput:
@@ -28,7 +44,7 @@ def _base_evidence() -> EvidenceInput:
         action="safe",
         action_version="edit.safe/v1",
         normalized_result_sha256=hashlib.sha256(b"{}").hexdigest(),
-        source_snapshot_id="idxsnap_01",
+        source_snapshots=_base_snapshots(),
         locator="src/app.py",
     )
 
@@ -54,7 +70,7 @@ def test_evidence_identity_changes_with_each_owner_field() -> None:
             action=base.action,
             action_version=base.action_version,
             normalized_result_sha256=base.normalized_result_sha256,
-            source_snapshot_id=base.source_snapshot_id,
+            source_snapshots=base.source_snapshots,
             locator=base.locator,
         ),
         "action": EvidenceInput(
@@ -62,7 +78,7 @@ def test_evidence_identity_changes_with_each_owner_field() -> None:
             action="classify",
             action_version=base.action_version,
             normalized_result_sha256=base.normalized_result_sha256,
-            source_snapshot_id=base.source_snapshot_id,
+            source_snapshots=base.source_snapshots,
             locator=base.locator,
         ),
         "version": EvidenceInput(
@@ -70,7 +86,7 @@ def test_evidence_identity_changes_with_each_owner_field() -> None:
             action=base.action,
             action_version="edit.safe/v2",
             normalized_result_sha256=base.normalized_result_sha256,
-            source_snapshot_id=base.source_snapshot_id,
+            source_snapshots=base.source_snapshots,
             locator=base.locator,
         ),
         "result": EvidenceInput(
@@ -78,7 +94,7 @@ def test_evidence_identity_changes_with_each_owner_field() -> None:
             action=base.action,
             action_version=base.action_version,
             normalized_result_sha256=hashlib.sha256(b"other").hexdigest(),
-            source_snapshot_id=base.source_snapshot_id,
+            source_snapshots=base.source_snapshots,
             locator=base.locator,
         ),
         "snapshot": EvidenceInput(
@@ -86,7 +102,18 @@ def test_evidence_identity_changes_with_each_owner_field() -> None:
             action=base.action,
             action_version=base.action_version,
             normalized_result_sha256=base.normalized_result_sha256,
-            source_snapshot_id="other-snap",
+            source_snapshots=(
+                SourceSnapshotRecord(
+                    kind="diff",
+                    snapshot_id="other-snap",
+                    source_generation="gen_01",
+                ),
+                SourceSnapshotRecord(
+                    kind="index",
+                    snapshot_id="idxsnap_01",
+                    source_generation="gen_01",
+                ),
+            ),
             locator=base.locator,
         ),
         "locator": EvidenceInput(
@@ -94,7 +121,7 @@ def test_evidence_identity_changes_with_each_owner_field() -> None:
             action=base.action,
             action_version=base.action_version,
             normalized_result_sha256=base.normalized_result_sha256,
-            source_snapshot_id=base.source_snapshot_id,
+            source_snapshots=base.source_snapshots,
             locator="src/other.py",
         ),
     }
@@ -110,7 +137,7 @@ def test_evidence_identity_same_locator_different_results_are_distinct() -> None
         action="safe",
         action_version="edit.safe/v1",
         normalized_result_sha256=hashlib.sha256(b'{"x":1}').hexdigest(),
-        source_snapshot_id="idxsnap_01",
+        source_snapshots=_base_snapshots(),
         locator="src/app.py",
     )
     assert evidence_identity(different_result) != first
@@ -123,7 +150,7 @@ def test_evidence_input_rejects_bad_digest() -> None:
             action="safe",
             action_version="edit.safe/v1",
             normalized_result_sha256="short",
-            source_snapshot_id=None,
+            source_snapshots=(),
             locator="x",
         )
 
@@ -253,3 +280,145 @@ def test_route_table_has_no_llm_or_keyword_router() -> None:
             "ast_diff",
             "classify",
         }
+
+
+def test_evidence_identity_binds_both_snapshot_kinds() -> None:
+    # RFC-0022: a constraint contribution binds both the diff and graph-index
+    # identities — dropping one record changes the evidence ID.
+    both = _base_evidence()
+    diff_only = EvidenceInput(
+        primitive_facade=both.primitive_facade,
+        action=both.action,
+        action_version=both.action_version,
+        normalized_result_sha256=both.normalized_result_sha256,
+        source_snapshots=_base_snapshots()[:1],
+        locator=both.locator,
+    )
+    assert evidence_identity(both) != evidence_identity(diff_only)
+
+
+def test_snapshot_record_rejects_unknown_kind() -> None:
+    with pytest.raises(ValueError, match="unknown snapshot kind"):
+        SourceSnapshotRecord(kind="worktree", snapshot_id="s", source_generation="g")  # type: ignore[arg-type]
+
+
+def test_route_table_all_rows_parameters_are_pinned() -> None:
+    params = {
+        (row.operation, row.facade, row.action): row.parameters for row in ROUTE_TABLE
+    }
+    assert params[("all", "index", "status")] == (
+        ("access_mode", "read_existing"),
+        ("output_format", "json"),
+    )
+    assert params[("understand(task)", "nav", "context")] == (
+        ("max_nodes", "12/30"),
+        ("max_code_blocks", "3/5"),
+        ("include_graph", "false"),
+        ("access_mode", "read_existing"),
+        ("output_format", "json"),
+    )
+    assert params[("plan_change(task)", "nav", "context")] == (
+        ("max_nodes", "12/30"),
+        ("max_code_blocks", "3/5"),
+        ("include_graph", "false"),
+        ("access_mode", "read_existing"),
+        ("output_format", "json"),
+    )
+    assert params[("plan_change(task)", "edit", "safe")] == (
+        ("edit_type", "refactor"),
+        ("access_mode", "read_existing"),
+        ("output_format", "json"),
+    )
+    assert params[("diff operation", "edit", "impact")] == (
+        ("include_tests", "true"),
+        ("resource_profile", "local_low_impact"),
+        ("access_mode", "read_existing"),
+        ("output_format", "json"),
+    )
+    assert params[("diff operation", "edit", "constraints")] == (
+        ("persist", "false"),
+        ("access_mode", "read_existing"),
+        ("output_format", "json"),
+    )
+    assert params[("diff operation", "edit", "ast_diff")] == (
+        ("access_mode", "read_existing"),
+        ("output_format", "json"),
+    )
+    assert params[("diff operation", "edit", "classify")] == (
+        ("access_mode", "read_existing"),
+        ("output_format", "json"),
+    )
+
+
+def test_route_table_dynamic_parameters_are_pinned() -> None:
+    dynamic = {
+        (row.operation, row.facade, row.action): row.dynamic_parameters
+        for row in ROUTE_TABLE
+    }
+    assert dynamic[("all", "index", "status")] == ()
+    assert dynamic[("plan_change(task)", "edit", "safe")] == (
+        "file_path",
+        "snapshot_id",
+        "source_generation",
+    )
+    assert dynamic[("diff operation", "edit", "impact")] == (
+        "mode",
+        "scope_paths",
+    )
+    assert dynamic[("diff operation", "edit", "constraints")] == (
+        "diff_snapshot_id",
+        "snapshot_id",
+        "source_generation",
+        "scope_paths",
+    )
+    assert dynamic[("diff operation", "edit", "ast_diff")] == (
+        "diff_snapshot_id",
+        "file_path",
+    )
+    assert dynamic[("diff operation", "edit", "classify")] == (
+        "diff_snapshot_id",
+        "file_path",
+    )
+
+
+def test_snapshot_record_boundaries() -> None:
+    with pytest.raises(ValueError, match="snapshot_id must be a non-empty"):
+        SourceSnapshotRecord(kind="diff", snapshot_id="", source_generation="g")
+    with pytest.raises(ValueError, match="source_generation must be a non-empty"):
+        SourceSnapshotRecord(kind="diff", snapshot_id="s", source_generation="")
+    with pytest.raises(ValueError, match="tuple of SourceSnapshotRecord"):
+        EvidenceInput(
+            primitive_facade="edit",
+            action="safe",
+            action_version="edit.safe/v1",
+            normalized_result_sha256=hashlib.sha256(b"{}").hexdigest(),
+            source_snapshots=(("diff", "s", "g"),),  # type: ignore[arg-type]
+            locator="x",
+        )
+    with pytest.raises(ValueError, match="non-empty string"):
+        EvidenceInput(
+            primitive_facade="",
+            action="safe",
+            action_version="edit.safe/v1",
+            normalized_result_sha256=hashlib.sha256(b"{}").hexdigest(),
+            source_snapshots=(),
+            locator="x",
+        )
+    with pytest.raises(ValueError, match="locator must be a string"):
+        EvidenceInput(
+            primitive_facade="edit",
+            action="safe",
+            action_version="edit.safe/v1",
+            normalized_result_sha256=hashlib.sha256(b"{}").hexdigest(),
+            source_snapshots=(),
+            locator=123,  # type: ignore[arg-type]
+        )
+
+
+def test_snapshot_truth_boundaries() -> None:
+    with pytest.raises(ValueError, match="oracle_complete must be a bool"):
+        SnapshotTruth(oracle_complete=1)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="snapshot_id must be a non-empty"):
+        SnapshotTruth(oracle_complete=True, snapshot_id="", graph_tokens=("s",))
+    with pytest.raises(ValueError, match="graph_tokens must be strings"):
+        SnapshotTruth(oracle_complete=True, snapshot_id="s", graph_tokens=(1,))  # type: ignore[arg-type]

--- a/tree_sitter_analyzer/task/__init__.py
+++ b/tree_sitter_analyzer/task/__init__.py
@@ -6,6 +6,12 @@ Not registered as an MCP facade, CLI command, or codemap surface
 
 from __future__ import annotations
 
+from .evidence import (
+    EvidenceInput,
+    evidence_identity,
+    normalized_result_hash,
+)
+from .freshness import FRESHNESS_STATES, SnapshotTruth
 from .models import (
     BUDGET_PROFILES,
     AssessChangeRequest,
@@ -17,9 +23,18 @@ from .models import (
     TaskRequest,
     UnderstandRequest,
 )
+from .route_table import ROUTE_TABLE, SAFE_FANOUT_CAPS, RouteRow
 
 __all__ = [
     "AssessChangeRequest",
+    "EvidenceInput",
+    "FRESHNESS_STATES",
+    "ROUTE_TABLE",
+    "RouteRow",
+    "SAFE_FANOUT_CAPS",
+    "SnapshotTruth",
+    "evidence_identity",
+    "normalized_result_hash",
     "Budget",
     "BUDGET_PROFILES",
     "ConsumedBudget",

--- a/tree_sitter_analyzer/task/__init__.py
+++ b/tree_sitter_analyzer/task/__init__.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from .evidence import (
     EvidenceInput,
+    SourceSnapshotRecord,
     evidence_identity,
     normalized_result_hash,
 )
@@ -33,6 +34,7 @@ __all__ = [
     "RouteRow",
     "SAFE_FANOUT_CAPS",
     "SnapshotTruth",
+    "SourceSnapshotRecord",
     "evidence_identity",
     "normalized_result_hash",
     "Budget",

--- a/tree_sitter_analyzer/task/evidence.py
+++ b/tree_sitter_analyzer/task/evidence.py
@@ -1,0 +1,102 @@
+"""RFC-0022 task-outcome/v1 evidence identity (Phase A).
+
+Every supported/contradicted claim cites evidence; unknown claims cite an
+unknown. Evidence IDs are deterministic digests over the canonical wire
+fragment supporting the claim:
+
+    evidence:sha256(canonical_json({
+      primitive_facade, action, action_version,
+      normalized_result_sha256, source_snapshot_id, locator
+    }))
+
+The task adapter only validates, canonicalizes, and hashes the exact
+primitive wire bytes; it never inserts owner fields, and the primitive never
+supplies the digest. Missing or disagreement makes the contribution
+``unknown`` and mints no evidence ID. Locator alone never identifies or
+deduplicates evidence (RFC-0022 §Evidence and provenance identity).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+
+_EVIDENCE_PREFIX = "evidence:"
+
+
+#: Canonical JSON for digest inputs: sorted keys, compact separators, no
+#: NaN, ASCII-escaped — byte-stable across interpreters.
+def canonical_json_bytes(value: object) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+@dataclass(frozen=True)
+class EvidenceInput:
+    """The six owner/result fields that define one evidence identity.
+
+    ``normalized_result_sha256`` is the digest of the canonical bytes of the
+    exact primitive wire fragment supporting the claim; the primitive wire
+    already carries its facade, action, action version and (when rule-derived)
+    producer rule id/version — the task adapter never inserts them.
+    """
+
+    primitive_facade: str
+    action: str
+    action_version: str
+    normalized_result_sha256: str
+    source_snapshot_id: str | None
+    locator: str
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("primitive_facade", self.primitive_facade),
+            ("action", self.action),
+            ("action_version", self.action_version),
+        ):
+            if type(value) is not str or not value:
+                raise ValueError(f"{name} must be a non-empty string")
+        if (
+            type(self.normalized_result_sha256) is not str
+            or len(self.normalized_result_sha256) != 64
+            or any(
+                char not in "0123456789abcdef" for char in self.normalized_result_sha256
+            )
+        ):
+            raise ValueError("normalized_result_sha256 must be a 64-hex digest")
+        if self.source_snapshot_id is not None and (
+            type(self.source_snapshot_id) is not str or not self.source_snapshot_id
+        ):
+            raise ValueError("source_snapshot_id must be a non-empty string or null")
+        if type(self.locator) is not str:
+            raise ValueError("locator must be a string")
+
+
+def evidence_identity(inputs: EvidenceInput) -> str:
+    """Mint the deterministic evidence ID for one contribution.
+
+    Returns ``evidence:sha256(...)`` over the canonical owner/result fields.
+    Missing or disagreeing ownership is handled by the caller as ``unknown``
+    (no ID minted) before this function is invoked.
+    """
+    payload = {
+        "primitive_facade": inputs.primitive_facade,
+        "action": inputs.action,
+        "action_version": inputs.action_version,
+        "normalized_result_sha256": inputs.normalized_result_sha256,
+        "source_snapshot_id": inputs.source_snapshot_id,
+        "locator": inputs.locator,
+    }
+    digest = hashlib.sha256(canonical_json_bytes(payload)).hexdigest()
+    return f"{_EVIDENCE_PREFIX}{digest}"
+
+
+def normalized_result_hash(result: object) -> str:
+    """Canonical digest of one exact primitive wire fragment (result only)."""
+    return hashlib.sha256(canonical_json_bytes(result)).hexdigest()

--- a/tree_sitter_analyzer/task/evidence.py
+++ b/tree_sitter_analyzer/task/evidence.py
@@ -6,7 +6,7 @@ fragment supporting the claim:
 
     evidence:sha256(canonical_json({
       primitive_facade, action, action_version,
-      normalized_result_sha256, source_snapshot_id, locator
+      normalized_result_sha256, source_snapshots, locator
     }))
 
 The task adapter only validates, canonicalizes, and hashes the exact
@@ -21,8 +21,11 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import dataclass
+from typing import Literal
 
 _EVIDENCE_PREFIX = "evidence:"
+
+SnapshotKind = Literal["index", "diff"]
 
 
 #: Canonical JSON for digest inputs: sorted keys, compact separators, no
@@ -38,6 +41,28 @@ def canonical_json_bytes(value: object) -> bytes:
 
 
 @dataclass(frozen=True)
+class SourceSnapshotRecord:
+    """One stable P0.4 snapshot record bound to a contribution.
+
+    RFC-0022: ``source_snapshots`` is the exact stable P0.4 list received
+    for that fragment — a constraint contribution binds both the diff/config
+    and graph-index identities (``kind`` is ``index`` or ``diff``).
+    """
+
+    kind: SnapshotKind
+    snapshot_id: str
+    source_generation: str
+
+    def __post_init__(self) -> None:
+        if self.kind not in {"index", "diff"}:
+            raise ValueError(f"unknown snapshot kind {self.kind!r}")
+        if type(self.snapshot_id) is not str or not self.snapshot_id:
+            raise ValueError("snapshot_id must be a non-empty string")
+        if type(self.source_generation) is not str or not self.source_generation:
+            raise ValueError("source_generation must be a non-empty string")
+
+
+@dataclass(frozen=True)
 class EvidenceInput:
     """The six owner/result fields that define one evidence identity.
 
@@ -45,13 +70,15 @@ class EvidenceInput:
     exact primitive wire fragment supporting the claim; the primitive wire
     already carries its facade, action, action version and (when rule-derived)
     producer rule id/version — the task adapter never inserts them.
+    ``source_snapshots`` is the exact stable P0.4 record list received for
+    that fragment (RFC-0022 §Evidence and provenance identity).
     """
 
     primitive_facade: str
     action: str
     action_version: str
     normalized_result_sha256: str
-    source_snapshot_id: str | None
+    source_snapshots: tuple[SourceSnapshotRecord, ...]
     locator: str
 
     def __post_init__(self) -> None:
@@ -70,10 +97,10 @@ class EvidenceInput:
             )
         ):
             raise ValueError("normalized_result_sha256 must be a 64-hex digest")
-        if self.source_snapshot_id is not None and (
-            type(self.source_snapshot_id) is not str or not self.source_snapshot_id
+        if type(self.source_snapshots) is not tuple or any(
+            type(record) is not SourceSnapshotRecord for record in self.source_snapshots
         ):
-            raise ValueError("source_snapshot_id must be a non-empty string or null")
+            raise ValueError("source_snapshots must be a tuple of SourceSnapshotRecord")
         if type(self.locator) is not str:
             raise ValueError("locator must be a string")
 
@@ -81,22 +108,36 @@ class EvidenceInput:
 def evidence_identity(inputs: EvidenceInput) -> str:
     """Mint the deterministic evidence ID for one contribution.
 
-    Returns ``evidence:sha256(...)`` over the canonical owner/result fields.
-    Missing or disagreeing ownership is handled by the caller as ``unknown``
-    (no ID minted) before this function is invoked.
+    Returns ``evidence:sha256(...)`` over the canonical owner/result fields,
+    with ``source_snapshots`` serialized as the exact record list. Missing or
+    disagreeing ownership is handled by the caller as ``unknown`` (no ID
+    minted) before this function is invoked.
     """
     payload = {
         "primitive_facade": inputs.primitive_facade,
         "action": inputs.action,
         "action_version": inputs.action_version,
         "normalized_result_sha256": inputs.normalized_result_sha256,
-        "source_snapshot_id": inputs.source_snapshot_id,
+        "source_snapshots": [
+            {
+                "kind": record.kind,
+                "snapshot_id": record.snapshot_id,
+                "source_generation": record.source_generation,
+            }
+            for record in inputs.source_snapshots
+        ],
         "locator": inputs.locator,
     }
     digest = hashlib.sha256(canonical_json_bytes(payload)).hexdigest()
     return f"{_EVIDENCE_PREFIX}{digest}"
 
 
-def normalized_result_hash(result: object) -> str:
-    """Canonical digest of one exact primitive wire fragment (result only)."""
-    return hashlib.sha256(canonical_json_bytes(result)).hexdigest()
+def normalized_result_hash(fragment: object) -> str:
+    """Canonical digest of the exact primitive wire fragment bytes.
+
+    RFC-0022: the hash covers the canonical bytes of the exact primitive wire
+    fragment supporting the claim — that wire already contains its primitive
+    facade, action, action version and (when rule-derived) producer rule
+    id/version, so the adapter never inserts owner fields.
+    """
+    return hashlib.sha256(canonical_json_bytes(fragment)).hexdigest()

--- a/tree_sitter_analyzer/task/freshness.py
+++ b/tree_sitter_analyzer/task/freshness.py
@@ -1,0 +1,68 @@
+"""RFC-0022 task-outcome/v1 freshness and snapshot truth (Phase A).
+
+Freshness states are ``fresh|stale|missing|not_applicable|unknown``.
+``fresh`` is allowed only when the authoritative oracle is complete and
+every graph result echoes its token. Without that oracle, repository/index
+fingerprints are null, reason is ``AUTHORITATIVE_SNAPSHOT_UNAVAILABLE``, and
+graph-dependent status is at most partial. Outcomes never claim a mixed
+snapshot is complete (RFC-0022 §Freshness and snapshot truth).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+Freshness = str  # fresh|stale|missing|not_applicable|unknown
+
+FRESHNESS_STATES: frozenset[str] = frozenset(
+    {"fresh", "stale", "missing", "not_applicable", "unknown"}
+)
+
+
+@dataclass(frozen=True)
+class SnapshotTruth:
+    """One snapshot-truth judgement from the authoritative oracle."""
+
+    oracle_complete: bool
+    snapshot_id: str | None = None
+    source_generation: str | None = None
+    graph_tokens: tuple[str, ...] = ()
+    reason: str | None = None
+
+    def __post_init__(self) -> None:
+        if type(self.oracle_complete) is not bool:
+            raise ValueError("oracle_complete must be a bool")
+        if self.snapshot_id is not None and (
+            type(self.snapshot_id) is not str or not self.snapshot_id
+        ):
+            raise ValueError("snapshot_id must be a non-empty string or null")
+        if any(type(token) is not str for token in self.graph_tokens):
+            raise ValueError("graph_tokens must be strings")
+
+    @property
+    def freshness(self) -> tuple[str, str | None]:
+        """Return (freshness, reason) per RFC-0022.
+
+        - not_applicable: no graph evidence was used (nothing to judge).
+        - fresh: oracle complete AND every graph result echoes its token.
+        - stale: oracle complete but a graph token disagrees.
+        - missing: no snapshot id from the oracle.
+        - unknown: oracle incomplete (AUTHORITATIVE_SNAPSHOT_UNAVAILABLE).
+        """
+        if not self.graph_tokens:
+            return "not_applicable", None
+        if not self.oracle_complete:
+            return "unknown", "AUTHORITATIVE_SNAPSHOT_UNAVAILABLE"
+        if self.snapshot_id is None:
+            return "missing", "AUTHORITATIVE_SNAPSHOT_UNAVAILABLE"
+        if any(token != self.snapshot_id for token in self.graph_tokens):
+            return "stale", "SNAPSHOT_TOKEN_MISMATCH"
+        return "fresh", None
+
+    @property
+    def graph_status_cap(self) -> str:
+        """Graph-dependent status is at most partial without a fresh oracle."""
+        freshness, _ = self.freshness
+        if freshness == "fresh":
+            return "complete"
+        return "partial"

--- a/tree_sitter_analyzer/task/route_table.py
+++ b/tree_sitter_analyzer/task/route_table.py
@@ -59,6 +59,7 @@ ROUTE_TABLE: tuple[RouteRow, ...] = (
             ("access_mode", "read_existing"),
             ("output_format", "json"),
         ),
+        dynamic_parameters=("task", "snapshot_id", "source_generation"),
         stop_rule="failure => unknown; success ends route",
     ),
     RouteRow(
@@ -73,6 +74,7 @@ ROUTE_TABLE: tuple[RouteRow, ...] = (
             ("access_mode", "read_existing"),
             ("output_format", "json"),
         ),
+        dynamic_parameters=("task", "snapshot_id", "source_generation"),
         stop_rule="failure => unknown and stop",
     ),
     RouteRow(

--- a/tree_sitter_analyzer/task/route_table.py
+++ b/tree_sitter_analyzer/task/route_table.py
@@ -1,0 +1,136 @@
+"""RFC-0022 task-outcome/v1 fixed route table (Phase A).
+
+The route decision table is pinned row by row from RFC-0022 §Complete V1
+route decision table. There is no task-layer keyword, regex, identifier,
+intent, or LLM router: free text passes unchanged to ``nav.context``, the
+sole owner of natural-language symbol inference. Parameters not shown are
+not sent; primitive output format is JSON internally. The compact/standard
+values in a cell are selected only by ``Budget.profile``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RouteRow:
+    """One pinned route row: condition -> primitive call + stop/degrade rule."""
+
+    operation: str
+    condition: str
+    facade: str
+    action: str
+    parameters: tuple[tuple[str, str], ...]
+    stop_rule: str
+
+
+#: Row order is significant: calls run in displayed order, fan-out lists are
+#: de-duplicated and sorted by (path, symbol) before their pinned cap.
+ROUTE_TABLE: tuple[RouteRow, ...] = (
+    RouteRow(
+        operation="all",
+        condition="always",
+        facade="index",
+        action="status",
+        parameters=(
+            ("access_mode", "read_existing"),
+            ("output_format", "json"),
+        ),
+        stop_rule="missing oracle => freshness unknown; continue, at most "
+        "partial if graph evidence is used",
+    ),
+    RouteRow(
+        operation="understand(task)",
+        condition="valid task",
+        facade="nav",
+        action="context",
+        parameters=(
+            ("max_nodes", "12/30"),
+            ("max_code_blocks", "3/5"),
+            ("include_graph", "false"),
+            ("access_mode", "read_existing"),
+            ("output_format", "json"),
+        ),
+        stop_rule="failure => unknown; success ends route",
+    ),
+    RouteRow(
+        operation="plan_change(task)",
+        condition="valid task",
+        facade="nav",
+        action="context",
+        parameters=(
+            ("max_nodes", "12/30"),
+            ("max_code_blocks", "3/5"),
+            ("include_graph", "false"),
+            ("access_mode", "read_existing"),
+            ("output_format", "json"),
+        ),
+        stop_rule="failure => unknown and stop",
+    ),
+    RouteRow(
+        operation="plan_change(task)",
+        condition="each distinct existing path explicitly returned in "
+        "code_blocks, max 2/5",
+        facade="edit",
+        action="safe",
+        parameters=(
+            ("edit_type", "refactor"),
+            ("access_mode", "read_existing"),
+            ("output_format", "json"),
+        ),
+        stop_rule="missing path is not inferred; per-call failure is partial",
+    ),
+    RouteRow(
+        operation="diff operation",
+        condition="valid diff",
+        facade="edit",
+        action="impact",
+        parameters=(
+            ("include_tests", "true"),
+            ("resource_profile", "local_low_impact"),
+            ("access_mode", "read_existing"),
+            ("output_format", "json"),
+        ),
+        stop_rule="missing/failing diff_snapshot_id => unknown and stop",
+    ),
+    RouteRow(
+        operation="diff operation",
+        condition="successful impact; reserved before fan-out",
+        facade="edit",
+        action="constraints",
+        parameters=(
+            ("persist", "false"),
+            ("access_mode", "read_existing"),
+            ("output_format", "json"),
+        ),
+        stop_rule="not_applicable:NO_CONFIG satisfies the row; invocation "
+        "failure degrades per the truth table",
+    ),
+    RouteRow(
+        operation="diff operation",
+        condition="each non-binary changed record with old/new material available",
+        facade="edit",
+        action="ast_diff",
+        parameters=(
+            ("access_mode", "read_existing"),
+            ("output_format", "json"),
+        ),
+        stop_rule="unsupported add/delete/rename is explicit not_run, never "
+        "locally reconstructed",
+    ),
+    RouteRow(
+        operation="diff operation",
+        condition="same eligible records",
+        facade="edit",
+        action="classify",
+        parameters=(
+            ("access_mode", "read_existing"),
+            ("output_format", "json"),
+        ),
+        stop_rule="per-file failure => partial",
+    ),
+)
+
+#: edit.safe fan-out caps per profile (RFC-0022 §Complete V1 route table).
+SAFE_FANOUT_CAPS: dict[str, int] = {"compact": 2, "standard": 5}

--- a/tree_sitter_analyzer/task/route_table.py
+++ b/tree_sitter_analyzer/task/route_table.py
@@ -15,7 +15,13 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True)
 class RouteRow:
-    """One pinned route row: condition -> primitive call + stop/degrade rule."""
+    """One pinned route row: condition -> primitive call + stop/degrade rule.
+
+    ``parameters`` pins the static parameter set; ``dynamic_parameters``
+    names the runtime-supplied parameters (file_path, mode, scope_paths,
+    snapshot/generation tokens) that the executor must attach per RFC-0022
+    §Complete V1 route decision table.
+    """
 
     operation: str
     condition: str
@@ -23,6 +29,7 @@ class RouteRow:
     action: str
     parameters: tuple[tuple[str, str], ...]
     stop_rule: str
+    dynamic_parameters: tuple[str, ...] = ()
 
 
 #: Row order is significant: calls run in displayed order, fan-out lists are
@@ -42,7 +49,7 @@ ROUTE_TABLE: tuple[RouteRow, ...] = (
     ),
     RouteRow(
         operation="understand(task)",
-        condition="valid task",
+        condition="valid task and certified index tokens",
         facade="nav",
         action="context",
         parameters=(
@@ -56,7 +63,7 @@ ROUTE_TABLE: tuple[RouteRow, ...] = (
     ),
     RouteRow(
         operation="plan_change(task)",
-        condition="valid task",
+        condition="valid task and certified index tokens",
         facade="nav",
         action="context",
         parameters=(
@@ -70,8 +77,8 @@ ROUTE_TABLE: tuple[RouteRow, ...] = (
     ),
     RouteRow(
         operation="plan_change(task)",
-        condition="each distinct existing path explicitly returned in "
-        "code_blocks, max 2/5",
+        condition="each distinct generation-matched existing path explicitly "
+        "returned in code_blocks, max 2/5",
         facade="edit",
         action="safe",
         parameters=(
@@ -79,7 +86,9 @@ ROUTE_TABLE: tuple[RouteRow, ...] = (
             ("access_mode", "read_existing"),
             ("output_format", "json"),
         ),
-        stop_rule="missing path is not inferred; per-call failure is partial",
+        dynamic_parameters=("file_path", "snapshot_id", "source_generation"),
+        stop_rule="missing path is not inferred; token mismatch stops route; "
+        "other per-call failure is partial",
     ),
     RouteRow(
         operation="diff operation",
@@ -92,17 +101,24 @@ ROUTE_TABLE: tuple[RouteRow, ...] = (
             ("access_mode", "read_existing"),
             ("output_format", "json"),
         ),
+        dynamic_parameters=("mode", "scope_paths"),
         stop_rule="missing/failing diff_snapshot_id => unknown and stop",
     ),
     RouteRow(
         operation="diff operation",
-        condition="successful impact; reserved before fan-out",
+        condition="successful generation-matched impact; reserved before fan-out",
         facade="edit",
         action="constraints",
         parameters=(
             ("persist", "false"),
             ("access_mode", "read_existing"),
             ("output_format", "json"),
+        ),
+        dynamic_parameters=(
+            "diff_snapshot_id",
+            "snapshot_id",
+            "source_generation",
+            "scope_paths",
         ),
         stop_rule="not_applicable:NO_CONFIG satisfies the row; invocation "
         "failure degrades per the truth table",
@@ -116,6 +132,7 @@ ROUTE_TABLE: tuple[RouteRow, ...] = (
             ("access_mode", "read_existing"),
             ("output_format", "json"),
         ),
+        dynamic_parameters=("diff_snapshot_id", "file_path"),
         stop_rule="unsupported add/delete/rename is explicit not_run, never "
         "locally reconstructed",
     ),
@@ -128,6 +145,7 @@ ROUTE_TABLE: tuple[RouteRow, ...] = (
             ("access_mode", "read_existing"),
             ("output_format", "json"),
         ),
+        dynamic_parameters=("diff_snapshot_id", "file_path"),
         stop_rule="per-file failure => partial",
     ),
 )


### PR DESCRIPTION
## Summary

RFC-0022 **Phase A slice 2**: internal task package gains evidence identity, freshness truth, and the pinned route decision table.

- `evidence.py`: `EvidenceInput` (6 owner/result fields) + `evidence_identity` (deterministic `evidence:sha256(canonical_json({...}))` digest; locator alone never dedupes) + `normalized_result_hash` (canonical wire-fragment digest)
- `freshness.py`: `SnapshotTruth` — fresh only with complete oracle + matching graph tokens; unknown/missing on `AUTHORITATIVE_SNAPSHOT_UNAVAILABLE`; stale on token mismatch; not_applicable without graph evidence; graph status at most partial unless fresh
- `route_table.py`: `ROUTE_TABLE` pinned row-by-row from RFC-0022 §Complete V1 route decision table (8 rows, exact primitive parameters; constraints reserved before fan-out; no LLM/keyword router) + `SAFE_FANOUT_CAPS` (compact 2 / standard 5)
- 26 contract tests (`tests/unit/task/test_evidence_router.py`)

## Verification
- quick gate: 1986 passed, 27 skipped
- task suite: 46 passed; patch coverage gate: no added executable misses
- pre-commit: passed

## Scope boundary
Identity/freshness/route logic only. The route executor, truth-table contributions, serializer parity, and the benchmark harness remain later Phase A slices. No MCP/CLI/codemap surface.