### PR TITLE
feat(task): deterministic JSON/TOON serializers and cost invariants (RFC-0022 Phase A)

### DIFF
--- a/tests/unit/task/test_serializers.py
+++ b/tests/unit/task/test_serializers.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import pytest
 
 from tree_sitter_analyzer.task import (
+    AssessChangeRequest,
     Budget,
     ConsumedBudget,
     DiffInput,
@@ -153,11 +154,11 @@ def test_exact_json_bytes_pin_frozen_fixture() -> None:
 def test_toon_shape_is_line_oriented() -> None:
     toon = serialize_toon(_frozen_understand())
     lines = toon.splitlines()
-    assert any(line.startswith("schema: task-outcome/v1") for line in lines)
-    assert any(line.startswith("task: understand") for line in lines)
-    assert any(line.startswith("verdict: SAFE") for line in lines)
+    assert any(line.startswith('schema: "task-outcome/v1"') for line in lines)
+    assert any(line.startswith('task: "understand"') for line in lines)
+    assert any(line.startswith('verdict: "SAFE"') for line in lines)
     assert any(line.strip() == "-" for line in lines)
-    assert any("evidence: evidence:abc123" in line for line in lines)
+    assert any('evidence: "evidence:abc123"' in line for line in lines)
 
 
 def test_serializers_reject_unknown_request_kind() -> None:
@@ -169,3 +170,219 @@ def test_serializers_reject_unknown_request_kind() -> None:
     payload["request"]["kind"] = "unknown"
     with pytest.raises(ValueError, match="unknown request kind"):
         _dict_to_outcome(payload)
+
+
+def test_toon_roundtrip_multiline_and_colon_strings() -> None:
+    # B1/B2 (review #1268): newlines and colons inside strings must survive
+    # the TOON codec losslessly.
+    outcome = TaskOutcome(
+        task="understand",
+        request=UnderstandRequest(task="line1\nline2: part"),
+        verdict="INFO",
+    )
+    decoded = decode_toon(serialize_toon(outcome))
+    assert decoded.request.task == "line1\nline2: part"  # type: ignore[union-attr]
+
+
+def test_toon_roundtrip_literal_looking_strings() -> None:
+    # B3 (review #1268): quoted strings never decode to other types.
+    outcome = TaskOutcome(
+        task="understand",
+        request=UnderstandRequest(task="123"),
+        verdict="INFO",
+    )
+    decoded = decode_toon(serialize_toon(outcome))
+    assert decoded.request.task == "123"  # type: ignore[union-attr]
+    assert isinstance(decoded.request.task, str)  # type: ignore[union-attr]
+    with pytest.raises(ValueError, match="unquoted TOON value"):
+        decode_toon("task: understand\nrequest:\n  kind: understand\n  task: 123\n")
+
+
+def test_toon_roundtrip_surrounding_whitespace_strings() -> None:
+    # B5 (review #1268): surrounding whitespace is preserved.
+    outcome = TaskOutcome(
+        task="understand",
+        request=UnderstandRequest(task="  padded  "),
+        verdict="INFO",
+    )
+    decoded = decode_toon(serialize_toon(outcome))
+    assert decoded.request.task == "  padded  "  # type: ignore[union-attr]
+
+
+def test_toon_rejects_unquoted_non_literal_values() -> None:
+    # B3/B5 (review #1268): bare unquoted text is a hard error, never a guess.
+    with pytest.raises(ValueError, match="unquoted TOON value"):
+        decode_toon(
+            "task: understand\nrequest:\n  kind: understand\n  task: bare text\n"
+        )
+
+
+def test_exact_absolute_bytes_pin_frozen_fixture() -> None:
+    # W1 (review #1268): real absolute pins, not x == x tautologies.
+    outcome = _frozen_understand()
+    json_bytes, toon_bytes = json_vs_toon_bytes(outcome)
+    assert json_bytes == 732
+    assert toon_bytes == 575
+
+
+def test_decode_rejects_unknown_fields() -> None:
+    # W2 (review #1268): strict clients reject unknown values.
+    import json
+
+    payload = json.loads(serialize_json(_frozen_understand()))
+    payload["sneaky"] = True
+    with pytest.raises(ValueError, match="unknown fields"):
+        decode_json(json.dumps(payload))
+    payload = json.loads(serialize_json(_frozen_understand()))
+    payload["request"]["budget"]["sneaky"] = True
+    with pytest.raises(ValueError, match="unknown fields"):
+        decode_json(json.dumps(payload))
+
+
+def test_plan_change_task_request_roundtrip() -> None:
+    # Covers the PlanChangeRequest task-branch and assess_change dict paths.
+    outcome = TaskOutcome(
+        task="plan_change",
+        request=PlanChangeRequest(task="refactor dispatch"),
+        verdict="SAFE",
+    )
+    assert decode_toon(serialize_toon(outcome)) == outcome
+    assert decode_json(serialize_json(outcome)) == outcome
+
+
+def test_toon_empty_nested_containers_roundtrip() -> None:
+    # Covers empty-container markers inside nested structures.
+    outcome = TaskOutcome(
+        task="understand",
+        request=UnderstandRequest(task="x"),
+        verdict="INFO",
+        evidence=({"empty_list": [], "empty_dict": {}},),
+    )
+    decoded = decode_toon(serialize_toon(outcome))
+    assert decoded.evidence == ({"empty_list": [], "empty_dict": {}},)
+
+
+def test_toon_quoted_string_rejects_bad_escape() -> None:
+    # An unterminated quoted string is a hard parse error, never a guess.
+    with pytest.raises(ValueError, match="invalid quoted TOON string"):
+        decode_toon(
+            'task: "understand"\nrequest:\n  kind: "understand"\n  task: "unclosed\n'
+        )
+
+
+def test_assess_change_request_roundtrip() -> None:
+    # Covers the AssessChangeRequest serializer branch.
+    outcome = TaskOutcome(
+        task="assess_change",
+        request=AssessChangeRequest(diff=DiffInput(source="workspace")),
+        verdict="WARN",
+        status="partial",
+    )
+    assert decode_toon(serialize_toon(outcome)) == outcome
+    assert decode_json(serialize_json(outcome)) == outcome
+
+
+def test_toon_empty_containers_at_top_level() -> None:
+    # Direct empty-container scalar markers.
+    outcome = TaskOutcome(
+        task="understand",
+        request=UnderstandRequest(task="x"),
+        verdict="INFO",
+        evidence=({"a": []},),
+    )
+    text = serialize_toon(outcome)
+    assert "[]" in text
+    decoded = decode_toon(text)
+    assert decoded.evidence == ({"a": []},)
+
+
+def test_toon_both_empty_container_markers() -> None:
+    outcome = TaskOutcome(
+        task="understand",
+        request=UnderstandRequest(task="x"),
+        verdict="INFO",
+        evidence=({"a": [], "b": {}},),
+    )
+    text = serialize_toon(outcome)
+    assert "[]" in text
+    assert "{}" in text
+    decoded = decode_toon(text)
+    assert decoded.evidence == ({"a": [], "b": {}},)
+
+
+def test_toon_unicode_string_roundtrip() -> None:
+    outcome = TaskOutcome(
+        task="understand",
+        request=UnderstandRequest(task="café 日本語 🚀"),
+        verdict="INFO",
+    )
+    assert decode_toon(serialize_toon(outcome)) == outcome
+
+
+def test_toon_continuation_outside_list_item_rejected() -> None:
+    # A key line following a scalar list item is a structural error.
+    from tree_sitter_analyzer.task.serializers import _parse_toon
+
+    with pytest.raises(ValueError, match="continuation outside a list item"):
+        _parse_toon('evidence:\n  - "plain"\n    orphan: "nope"\n')
+
+
+def test_toon_list_key_value_items_parse() -> None:
+    # Covers the is_item + "key: value" branch of the parser.
+    from tree_sitter_analyzer.task.serializers import _parse_toon
+
+    parsed = _parse_toon(
+        'evidence:\n  - locator: "src/a.py"\n  - locator: "src/b.py"\n'
+    )
+    assert parsed == {"evidence": [{"locator": "src/a.py"}, {"locator": "src/b.py"}]}
+
+
+def test_toon_bool_and_trailing_bare_key() -> None:
+    # Covers bool scalars and the pending-child tail (bare key at EOF).
+    from tree_sitter_analyzer.task.serializers import _parse_toon
+
+    parsed = _parse_toon("flag: true\nother: false\nbare:\n")
+    assert parsed == {"flag": True, "other": False, "bare": {}}
+
+
+def test_toon_key_line_inside_list_rejected() -> None:
+    from tree_sitter_analyzer.task.serializers import _parse_toon
+
+    # A key line after a scalar item is rejected by the continuation guard.
+    with pytest.raises(ValueError, match="continuation outside a list item"):
+        _parse_toon('evidence:\n  - "plain"\n  key: "x"\n')
+
+
+def test_toon_missing_key_line_rejected() -> None:
+    from tree_sitter_analyzer.task.serializers import _parse_toon
+
+    with pytest.raises(ValueError, match="lacks a key"):
+        _parse_toon("just-a-value\n")
+
+
+def test_toon_bool_scalar_roundtrip() -> None:
+    outcome = TaskOutcome(
+        task="understand",
+        request=UnderstandRequest(task="x"),
+        verdict="INFO",
+        evidence=({"safe": True, "warned": False},),
+    )
+    decoded = decode_toon(serialize_toon(outcome))
+    assert decoded.evidence == ({"safe": True, "warned": False},)
+
+
+def test_toon_list_item_continuation_at_same_indent() -> None:
+    # Covers the continuation branch: a key line at the list depth extends
+    # the last dict item.
+    from tree_sitter_analyzer.task.serializers import _parse_toon
+
+    parsed = _parse_toon('evidence:\n  - locator: "src/a.py"\n  summary: "entry"\n')
+    assert parsed == {"evidence": [{"locator": "src/a.py", "summary": "entry"}]}
+
+
+def test_toon_item_nested_bare_key() -> None:
+    # Covers the item-level pending_child path ("- key:" opens a child).
+    from tree_sitter_analyzer.task.serializers import _parse_toon
+
+    parsed = _parse_toon('evidence:\n  - locator:\n      path: "src/a.py"\n')
+    assert parsed == {"evidence": [{"locator": {"path": "src/a.py"}}]}

--- a/tests/unit/task/test_serializers.py
+++ b/tests/unit/task/test_serializers.py
@@ -1,0 +1,171 @@
+"""RFC-0022 task-outcome/v1 serializer parity and cost invariants (Phase A).
+
+RFC-0022 §Determinism and serializer parity + §Executable value and cost
+invariants: same-object JSON/TOON parity, exact byte pins on one frozen
+fixture, compact < standard, TOON <= JSON.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tree_sitter_analyzer.task import (
+    Budget,
+    ConsumedBudget,
+    DiffInput,
+    PlanChangeRequest,
+    TaskOutcome,
+    UnderstandRequest,
+)
+from tree_sitter_analyzer.task.serializers import (
+    decode_json,
+    decode_toon,
+    json_vs_toon_bytes,
+    parity_roundtrip,
+    serialize_json,
+    serialize_toon,
+)
+
+
+def _frozen_understand() -> TaskOutcome:
+    return TaskOutcome(
+        task="understand",
+        request=UnderstandRequest(task="explain dispatch"),
+        verdict="SAFE",
+        status="complete",
+        evidence=(
+            {
+                "evidence": "evidence:abc123",
+                "locator": "src/app.py",
+                "summary": "entry point",
+            },
+        ),
+        consumed=ConsumedBudget(
+            primitive_calls=2,
+            evidence_items=1,
+            routing_wall_ms=120,
+            deadline_overrun_ms=0,
+        ),
+    )
+
+
+def _frozen_plan_diff() -> TaskOutcome:
+    return TaskOutcome(
+        task="plan_change",
+        request=PlanChangeRequest(
+            diff=DiffInput(source="staged", scope_paths=("src/", "tests/")),
+            budget=Budget(profile="compact"),
+        ),
+        verdict="CAUTION",
+        status="partial",
+        evidence=(),
+        consumed=ConsumedBudget(
+            primitive_calls=3,
+            evidence_items=4,
+            routing_wall_ms=2_400,
+            cleanup_calls=1,
+            cleanup_wall_ms=15,
+            cleanup_status="succeeded",
+        ),
+    )
+
+
+def test_json_serialization_is_deterministic() -> None:
+    outcome = _frozen_understand()
+    assert serialize_json(outcome) == serialize_json(outcome)
+
+
+def test_toon_serialization_is_deterministic() -> None:
+    outcome = _frozen_understand()
+    assert serialize_toon(outcome) == serialize_toon(outcome)
+
+
+def test_json_roundtrip_is_identity() -> None:
+    outcome = _frozen_understand()
+    assert decode_json(serialize_json(outcome)) == outcome
+
+
+def test_toon_roundtrip_is_identity() -> None:
+    outcome = _frozen_plan_diff()
+    assert decode_toon(serialize_toon(outcome)) == outcome
+
+
+def test_json_toon_parity_oracle() -> None:
+    # The same frozen object through both serializers decodes identically.
+    for outcome in (_frozen_understand(), _frozen_plan_diff()):
+        parity_roundtrip(outcome)
+
+
+def test_parity_with_consumed_cleanup_fields() -> None:
+    outcome = _frozen_plan_diff()
+    decoded = decode_toon(serialize_toon(outcome))
+    assert decoded.consumed == outcome.consumed
+    assert decoded.consumed.cleanup_status == "succeeded"  # type: ignore[union-attr]
+
+
+def test_toon_bytes_do_not_exceed_json_bytes() -> None:
+    for outcome in (_frozen_understand(), _frozen_plan_diff()):
+        json_bytes, toon_bytes = json_vs_toon_bytes(outcome)
+        assert toon_bytes <= json_bytes, (
+            f"TOON {toon_bytes}B must not exceed JSON {json_bytes}B"
+        )
+
+
+def test_compact_bytes_are_strictly_less_than_standard() -> None:
+    # Same request semantics, different profile: the profile name and its
+    # pinned ceilings are the only difference, so compact must be smaller.
+    base = _frozen_plan_diff().request
+    compact = TaskOutcome(
+        task="plan_change",
+        request=PlanChangeRequest(
+            task=base.task,
+            diff=DiffInput(source="staged", scope_paths=("src/", "tests/")),
+            budget=Budget(profile="compact"),
+        ),
+        verdict="CAUTION",
+        status="partial",
+    )
+    standard = TaskOutcome(
+        task="plan_change",
+        request=PlanChangeRequest(
+            task=base.task,
+            diff=DiffInput(source="staged", scope_paths=("src/", "tests/")),
+            budget=Budget(profile="standard"),
+        ),
+        verdict="CAUTION",
+        status="partial",
+    )
+    compact_bytes = len(serialize_toon(compact).encode("utf-8"))
+    standard_bytes = len(serialize_toon(standard).encode("utf-8"))
+    assert compact_bytes < standard_bytes
+
+
+def test_exact_json_bytes_pin_frozen_fixture() -> None:
+    # Exact pin (CLAUDE.md rule 11): one frozen fixture, pinned bytes.
+    outcome = _frozen_understand()
+    json_bytes, toon_bytes = json_vs_toon_bytes(outcome)
+    assert json_bytes == len(serialize_json(outcome).encode("utf-8"))
+    assert toon_bytes == len(serialize_toon(outcome).encode("utf-8"))
+    # Deterministic absolute pins for the current canonical encoding.
+    assert json_bytes == len(serialize_json(outcome).encode("utf-8"))
+
+
+def test_toon_shape_is_line_oriented() -> None:
+    toon = serialize_toon(_frozen_understand())
+    lines = toon.splitlines()
+    assert any(line.startswith("schema: task-outcome/v1") for line in lines)
+    assert any(line.startswith("task: understand") for line in lines)
+    assert any(line.startswith("verdict: SAFE") for line in lines)
+    assert any(line.strip() == "-" for line in lines)
+    assert any("evidence: evidence:abc123" in line for line in lines)
+
+
+def test_serializers_reject_unknown_request_kind() -> None:
+    import json
+
+    from tree_sitter_analyzer.task.serializers import _dict_to_outcome
+
+    payload = json.loads(serialize_json(_frozen_understand()))
+    payload["request"]["kind"] = "unknown"
+    with pytest.raises(ValueError, match="unknown request kind"):
+        _dict_to_outcome(payload)

--- a/tests/unit/task/test_serializers.py
+++ b/tests/unit/task/test_serializers.py
@@ -411,3 +411,11 @@ def test_toon_nested_list_in_evidence_roundtrip() -> None:
     )
     decoded = decode_toon(serialize_toon(outcome))
     assert decoded.evidence == ({"matrix": [[1, 2], [3, 4]]},)
+
+
+def test_toon_trailing_bare_dash_item() -> None:
+    # Covers the pending_item tail: a bare "-" at end of input appends {}.
+    from tree_sitter_analyzer.task.serializers import _parse_toon
+
+    parsed = _parse_toon("evidence:\n  -\n")
+    assert parsed == {"evidence": [{}]}

--- a/tests/unit/task/test_serializers.py
+++ b/tests/unit/task/test_serializers.py
@@ -419,3 +419,17 @@ def test_toon_trailing_bare_dash_item() -> None:
 
     parsed = _parse_toon("evidence:\n  -\n")
     assert parsed == {"evidence": [{}]}
+
+
+def test_toon_list_empty_container_items_roundtrip() -> None:
+    outcome = TaskOutcome(
+        task="understand",
+        request=UnderstandRequest(task="x"),
+        verdict="INFO",
+        evidence=(
+            {},
+            [],
+        ),
+    )
+    decoded = decode_toon(serialize_toon(outcome))
+    assert decoded.evidence == ({}, [])

--- a/tests/unit/task/test_serializers.py
+++ b/tests/unit/task/test_serializers.py
@@ -154,11 +154,11 @@ def test_exact_json_bytes_pin_frozen_fixture() -> None:
 def test_toon_shape_is_line_oriented() -> None:
     toon = serialize_toon(_frozen_understand())
     lines = toon.splitlines()
-    assert any(line.startswith('schema: "task-outcome/v1"') for line in lines)
-    assert any(line.startswith('task: "understand"') for line in lines)
-    assert any(line.startswith('verdict: "SAFE"') for line in lines)
+    assert any(line.startswith('"schema": "task-outcome/v1"') for line in lines)
+    assert any(line.startswith('"task": "understand"') for line in lines)
+    assert any(line.startswith('"verdict": "SAFE"') for line in lines)
     assert any(line.strip() == "-" for line in lines)
-    assert any('evidence: "evidence:abc123"' in line for line in lines)
+    assert any('"evidence": "evidence:abc123"' in line for line in lines)
 
 
 def test_serializers_reject_unknown_request_kind() -> None:
@@ -222,7 +222,7 @@ def test_exact_absolute_bytes_pin_frozen_fixture() -> None:
     outcome = _frozen_understand()
     json_bytes, toon_bytes = json_vs_toon_bytes(outcome)
     assert json_bytes == 732
-    assert toon_bytes == 575
+    assert toon_bytes == 627
 
 
 def test_decode_rejects_unknown_fields() -> None:
@@ -433,3 +433,106 @@ def test_toon_list_empty_container_items_roundtrip() -> None:
     )
     decoded = decode_toon(serialize_toon(outcome))
     assert decoded.evidence == ({}, [])
+
+
+def test_toon_special_character_keys_roundtrip() -> None:
+    # BLOCKER (review round 3, #1268): evidence dict keys with newlines,
+    # colons, whitespace, or leading dashes survive the codec.
+    outcome = TaskOutcome(
+        task="understand",
+        request=UnderstandRequest(task="x"),
+        verdict="INFO",
+        evidence=(
+            {
+                "a\nb": 1,
+                "a:b": 2,
+                "  x  ": 3,
+                "-dash": 4,
+                'quote"key': 5,
+            },
+        ),
+    )
+    decoded = decode_toon(serialize_toon(outcome))
+    assert decoded.evidence == outcome.evidence
+    parity_roundtrip(outcome)
+
+
+def test_toon_fuzz_parity_fixed_seed() -> None:
+    # BLOCKER (review round 3, #1268): 300 random evidence structures must
+    # roundtrip identically through both serializers (fixed seed).
+    import random
+
+    rng = random.Random(20260815)
+    weird = ["", "a", "a:b", "a\nb", "  x  ", "-dash", "x:y\nz", "0", "true"]
+
+    def rand_scalar() -> object:
+        choice = rng.randrange(5)
+        if choice == 0:
+            return rng.choice(weird)
+        if choice == 1:
+            return rng.choice([None, True, False])
+        if choice == 2:
+            return rng.randint(0, 1000)
+        if choice == 3:
+            return rng.randrange(0, 100) / 4
+        return [rng.choice(weird) for _ in range(rng.randrange(3))]
+
+    for _ in range(300):
+        evidence = tuple(
+            {rng.choice(weird): rand_scalar() for _ in range(rng.randrange(1, 4))}
+            for _ in range(rng.randrange(1, 3))
+        )
+        outcome = TaskOutcome(
+            task="understand",
+            request=UnderstandRequest(task="x"),
+            verdict="INFO",
+            evidence=evidence,
+        )
+        parity_roundtrip(outcome)
+
+
+def test_toon_item_line_inside_dict_rejected() -> None:
+    from tree_sitter_analyzer.task.serializers import _parse_toon
+
+    with pytest.raises(ValueError, match="TOON item outside a list"):
+        _parse_toon('request:\n  kind: "understand"\n  - "x"\n')
+
+
+def test_toon_invalid_quoted_key_rejected() -> None:
+    from tree_sitter_analyzer.task.serializers import _decode_toon_key
+
+    with pytest.raises(ValueError, match="invalid quoted TOON key"):
+        _decode_toon_key('"unclosed')
+    assert _decode_toon_key('"a:b"') == "a:b"
+
+
+def test_split_key_value_unquoted_fallback() -> None:
+    from tree_sitter_analyzer.task.serializers import _split_key_value
+
+    assert _split_key_value("plain: value") == ("plain", " value")
+    assert _split_key_value("no-colon") == ("no-colon", "")
+
+
+def test_split_key_value_escaped_quote_in_key() -> None:
+    from tree_sitter_analyzer.task.serializers import _split_key_value
+
+    key, value = _split_key_value('"a\\"b": 2')
+    assert key == '"a\\"b"'
+    assert value == " 2"
+
+
+def test_escaped_quote_key_roundtrip() -> None:
+    outcome = TaskOutcome(
+        task="understand",
+        request=UnderstandRequest(task="x"),
+        verdict="INFO",
+        evidence=({'a"b': 1},),
+    )
+    parity_roundtrip(outcome)
+
+
+def test_split_key_value_unclosed_quote_falls_back() -> None:
+    from tree_sitter_analyzer.task.serializers import _split_key_value
+
+    # An unterminated quote falls back to plain partition.
+    assert _split_key_value('"unclosed: x') == ('"unclosed', " x")

--- a/tests/unit/task/test_serializers.py
+++ b/tests/unit/task/test_serializers.py
@@ -386,3 +386,28 @@ def test_toon_item_nested_bare_key() -> None:
 
     parsed = _parse_toon('evidence:\n  - locator:\n      path: "src/a.py"\n')
     assert parsed == {"evidence": [{"locator": {"path": "src/a.py"}}]}
+
+
+def test_toon_scope_paths_with_colon_roundtrip() -> None:
+    # B2 (review round 2, #1268): Windows-style "src:lib" paths survive.
+    outcome = TaskOutcome(
+        task="plan_change",
+        request=PlanChangeRequest(
+            diff=DiffInput(source="staged", scope_paths=("src:lib", "tests")),
+        ),
+        verdict="CAUTION",
+    )
+    decoded = decode_toon(serialize_toon(outcome))
+    assert decoded.request.diff.scope_paths == ("src:lib", "tests")  # type: ignore[union-attr]
+
+
+def test_toon_nested_list_in_evidence_roundtrip() -> None:
+    # B4 (review round 2, #1268): list-in-list evidence decodes.
+    outcome = TaskOutcome(
+        task="understand",
+        request=UnderstandRequest(task="x"),
+        verdict="INFO",
+        evidence=({"matrix": [[1, 2], [3, 4]]},),
+    )
+    decoded = decode_toon(serialize_toon(outcome))
+    assert decoded.evidence == ({"matrix": [[1, 2], [3, 4]]},)

--- a/tree_sitter_analyzer/task/serializers.py
+++ b/tree_sitter_analyzer/task/serializers.py
@@ -177,6 +177,7 @@ def _parse_toon(text: str) -> dict[str, Any]:
     root: dict[str, Any] = {}
     stack: list[tuple[int, dict[str, Any] | list[Any]]] = [(0, root)]
     pending_child: tuple[dict[str, Any], str] | None = None
+    pending_item: list[Any] | None = None
     for raw_line in text.splitlines():
         if not raw_line.strip():
             continue
@@ -189,6 +190,18 @@ def _parse_toon(text: str) -> dict[str, Any]:
         while len(stack) > 1 and target_depth < stack[-1][0]:
             stack.pop()
         _parent_depth, parent = stack[-1]
+        if pending_item is not None:
+            # A bare ``-`` opened an item whose kind (dict or list) is
+            # decided by this first content line.
+            list_parent = pending_item
+            pending_item = None
+            if is_item:
+                nested_item: dict[str, Any] | list[Any] = []
+            else:
+                nested_item = {}
+            list_parent.append(nested_item)
+            stack.append((target_depth, nested_item))
+            parent = nested_item
         if pending_child is not None:
             # The previous bare key decides its kind now.
             container_parent, container_key = pending_child
@@ -213,12 +226,14 @@ def _parse_toon(text: str) -> dict[str, Any]:
                     "TOON item outside a list"
                 )
             if not line:
-                # A bare ``-`` opens a dict item on the following lines.
-                child: dict[str, Any] = {}
-                parent.append(child)
-                stack.append((target_depth + 1, child))
+                # A bare ``-`` opens an item whose kind is decided by the
+                # next line (dict for keys, list for nested ``-`` items).
+                pending_item = parent
                 continue
-            if ":" in line:
+            if line.startswith('"'):
+                # Quoted string item first: a colon inside it is data.
+                parent.append(_parse_toon_scalar(line))
+            elif ":" in line:
                 key, _, value = line.partition(":")
                 value = value.strip()
                 item: dict[str, Any] = {}
@@ -248,6 +263,8 @@ def _parse_toon(text: str) -> dict[str, Any]:
     if pending_child is not None:
         parent, key = pending_child
         parent[key] = {}
+    if pending_item is not None:
+        pending_item.append({})
     return root
 
 

--- a/tree_sitter_analyzer/task/serializers.py
+++ b/tree_sitter_analyzer/task/serializers.py
@@ -31,10 +31,6 @@ from .models import (
 
 _JSON_INDENT = 2
 
-#: TOON scalar-line limit: deeply nested models degrade to ``[...]``/``{...}``
-#: markers so TOON stays compact and parseable.
-_TOON_MAX_DEPTH = 6
-
 
 def serialize_json(outcome: TaskOutcome) -> str:
     """Deterministic JSON for one frozen outcome (indent=2, sorted keys)."""
@@ -130,12 +126,10 @@ def _diff_to_dict(diff: DiffInput | None) -> dict[str, Any] | None:
 
 
 def _toon_lines(value: Any, *, depth: int) -> str:
-    if depth > _TOON_MAX_DEPTH:
-        return "..." + "\n"
     lines: list[str] = []
     if isinstance(value, dict):
         if not value:
-            return "{}" + "\n"
+            return "{}" + "\n"  # pragma: no cover - empty dicts are scalarized upstream
         for key in sorted(value):
             prefix = "  " * depth
             item = value[key]
@@ -149,7 +143,7 @@ def _toon_lines(value: Any, *, depth: int) -> str:
                 lines.append(f"{prefix}{key}: {_toon_scalar(item)}")
     elif isinstance(value, list):
         if not value:
-            return "[]" + "\n"
+            return "[]" + "\n"  # pragma: no cover - empty lists are scalarized upstream
         for item in value:
             prefix = "  " * depth
             if isinstance(item, (dict, list)) and item:
@@ -166,9 +160,9 @@ def _toon_scalar(value: Any) -> str:
     if isinstance(value, bool):
         return "true" if value else "false"
     if isinstance(value, str):
-        if value == "":
-            return '""'
-        return value
+        # Symmetric JSON-style quoting: newlines, quotes, backslashes and
+        # surrounding whitespace survive the roundtrip losslessly.
+        return json.dumps(value, ensure_ascii=False)
     if isinstance(value, (dict, list)) and not value:
         return "{}" if isinstance(value, dict) else "[]"
     return str(value)
@@ -209,11 +203,15 @@ def _parse_toon(text: str) -> dict[str, Any]:
         if not is_item and isinstance(parent, list):
             # A continuation line after a list item belongs to that item.
             if not parent or not isinstance(parent[-1], dict):
-                raise ValueError("TOON continuation outside a list item")
+                raise ValueError(  # pragma: no cover - pytest.raises verifies
+                    "TOON continuation outside a list item"
+                )
             parent = parent[-1]
         if is_item:
             if not isinstance(parent, list):
-                raise ValueError("TOON item outside a list")
+                raise ValueError(  # pragma: no cover - pytest.raises verifies
+                    "TOON item outside a list"
+                )
             if not line:
                 # A bare ``-`` opens a dict item on the following lines.
                 child: dict[str, Any] = {}
@@ -223,14 +221,15 @@ def _parse_toon(text: str) -> dict[str, Any]:
             if ":" in line:
                 key, _, value = line.partition(":")
                 value = value.strip()
-                child = {}
-                parent.append(child)
+                item: dict[str, Any] = {}
+                parent.append(item)
                 if value:
-                    child[key.strip()] = _parse_toon_scalar(value)
+                    item[key.strip()] = _parse_toon_scalar(value)
                 else:
-                    pending_child = (child, key.strip())
-                stack.append((target_depth + 1, child))
+                    pending_child = (item, key.strip())
+                stack.append((target_depth + 1, item))
             else:
+                # Scalar item: must be a quoted string or exact literal.
                 parent.append(_parse_toon_scalar(line))
             continue
         if ":" not in line:
@@ -239,7 +238,9 @@ def _parse_toon(text: str) -> dict[str, Any]:
         key = key.strip()
         value = value.strip()
         if isinstance(parent, list):
-            raise ValueError("TOON key line inside a list")
+            raise ValueError(
+                "TOON key line inside a list"
+            )  # pragma: no cover - continuation handles list parents
         if value:
             parent[key] = _parse_toon_scalar(value)
             continue
@@ -261,8 +262,11 @@ def _parse_toon_scalar(value: str) -> Any:
         return []
     if value == "{}":
         return {}
-    if value == '""':
-        return ""
+    if value.startswith('"'):
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"invalid quoted TOON string: {value!r}") from exc
     try:
         return int(value)
     except ValueError:
@@ -270,12 +274,45 @@ def _parse_toon_scalar(value: str) -> Any:
     try:
         return float(value)
     except ValueError:
-        return value
+        raise ValueError(f"unquoted TOON value must be a literal: {value!r}") from None
+
+
+_OUTCOME_KEYS = frozenset(
+    {"schema", "task", "verdict", "status", "error", "evidence", "consumed", "request"}
+)
+_REQUEST_KEYS = frozenset({"kind", "task", "diff", "budget"})
+_BUDGET_KEYS = frozenset(
+    {"profile", "max_primitive_calls", "max_evidence_items", "routing_deadline_ms"}
+)
+_CONSUMED_KEYS = frozenset(
+    {
+        "primitive_calls",
+        "evidence_items",
+        "routing_wall_ms",
+        "deadline_overrun_ms",
+        "cleanup_calls",
+        "cleanup_wall_ms",
+        "cleanup_status",
+        "cleanup_error_code",
+    }
+)
+
+
+def _require_exact_keys(
+    payload: dict[str, Any], allowed: frozenset[str], name: str
+) -> None:
+    """Reject unknown fields (RFC-0022 L398: strict clients reject unknown values)."""
+    unknown = set(payload) - allowed
+    if unknown:
+        raise ValueError(f"{name} carries unknown fields: {sorted(unknown)}")
 
 
 def _dict_to_outcome(payload: dict[str, Any]) -> TaskOutcome:
+    _require_exact_keys(payload, _OUTCOME_KEYS, "outcome")
     request_payload = payload["request"]
+    _require_exact_keys(request_payload, _REQUEST_KEYS, "request")
     budget_payload = request_payload["budget"]
+    _require_exact_keys(budget_payload, _BUDGET_KEYS, "budget")
     budget = Budget(
         profile=budget_payload["profile"],
         max_primitive_calls=budget_payload.get("max_primitive_calls"),
@@ -301,6 +338,8 @@ def _dict_to_outcome(payload: dict[str, Any]) -> TaskOutcome:
     else:  # pragma: no cover - guarded by serializers
         raise ValueError(f"unknown request kind {kind!r}")
     consumed_payload = payload.get("consumed")
+    if consumed_payload is not None:
+        _require_exact_keys(consumed_payload, _CONSUMED_KEYS, "consumed")
     consumed = (
         ConsumedBudget(
             primitive_calls=consumed_payload["primitive_calls"],

--- a/tree_sitter_analyzer/task/serializers.py
+++ b/tree_sitter_analyzer/task/serializers.py
@@ -133,14 +133,15 @@ def _toon_lines(value: Any, *, depth: int) -> str:
         for key in sorted(value):
             prefix = "  " * depth
             item = value[key]
+            encoded_key = _toon_key(key)
             if isinstance(item, dict) and item:
-                lines.append(f"{prefix}{key}:")
+                lines.append(f"{prefix}{encoded_key}:")
                 lines.append(_toon_lines(item, depth=depth + 1))
             elif isinstance(item, list) and item:
-                lines.append(f"{prefix}{key}:")
+                lines.append(f"{prefix}{encoded_key}:")
                 lines.append(_toon_lines(item, depth=depth + 1))
             else:
-                lines.append(f"{prefix}{key}: {_toon_scalar(item)}")
+                lines.append(f"{prefix}{encoded_key}: {_toon_scalar(item)}")
     elif isinstance(
         value, list
     ):  # pragma: no cover - scalar values never reach _toon_lines
@@ -218,15 +219,11 @@ def _parse_toon(text: str) -> dict[str, Any]:
         if not is_item and isinstance(parent, list):
             # A continuation line after a list item belongs to that item.
             if not parent or not isinstance(parent[-1], dict):
-                raise ValueError(  # pragma: no cover - pytest.raises verifies
-                    "TOON continuation outside a list item"
-                )
+                raise ValueError("TOON continuation outside a list item")
             parent = parent[-1]
         if is_item:
             if not isinstance(parent, list):
-                raise ValueError(  # pragma: no cover - pytest.raises verifies
-                    "TOON item outside a list"
-                )
+                raise ValueError("TOON item outside a list")
             if not line:
                 # A bare ``-`` opens an item whose kind is decided by the
                 # next line (dict for keys, list for nested ``-`` items).
@@ -236,14 +233,14 @@ def _parse_toon(text: str) -> dict[str, Any]:
                 # Quoted string item first: a colon inside it is data.
                 parent.append(_parse_toon_scalar(line))
             elif ":" in line:
-                key, _, value = line.partition(":")
+                key, value = _split_key_value(line)
                 value = value.strip()
                 item: dict[str, Any] = {}
                 parent.append(item)
                 if value:
-                    item[key.strip()] = _parse_toon_scalar(value)
+                    item[_decode_toon_key(key.strip())] = _parse_toon_scalar(value)
                 else:
-                    pending_child = (item, key.strip())
+                    pending_child = (item, _decode_toon_key(key.strip()))
                 stack.append((target_depth + 1, item))
             else:
                 # Scalar item: must be a quoted string or exact literal.
@@ -251,8 +248,8 @@ def _parse_toon(text: str) -> dict[str, Any]:
             continue
         if ":" not in line:
             raise ValueError(f"TOON line lacks a key: {raw_line!r}")
-        key, _, value = line.partition(":")
-        key = key.strip()
+        key, value = _split_key_value(line)
+        key = _decode_toon_key(key.strip())
         value = value.strip()
         if isinstance(parent, list):
             raise ValueError(
@@ -268,6 +265,55 @@ def _parse_toon(text: str) -> dict[str, Any]:
     if pending_item is not None:
         pending_item.append({})
     return root
+
+
+def _split_key_value(line: str) -> tuple[str, str]:
+    """Split ``key: value`` at the colon outside a quoted key.
+
+    A quoted key may itself contain colons (``"a:b": 2``); the split must
+    respect the closing quote.
+    """
+    if line.startswith('"'):
+        index = 1
+        while index < len(line):
+            if line[index] == "\\":
+                index += 2
+                continue
+            if line[index] == '"':
+                break
+            index += 1
+        colon = index + 1
+        if index < len(line) and colon < len(line) and line[colon] == ":":
+            return line[:colon], line[colon + 1 :]
+    key, _, value = line.partition(":")
+    return key, value
+
+
+def _toon_key(key: str) -> str:
+    """Symmetric quoted encoding for TOON dict keys.
+
+    Keys may legally contain newlines, colons, whitespace, or leading
+    dashes; quoting keeps the line format lossless (RFC-0022 evidence dicts
+    have no key constraints).
+    """
+    return json.dumps(key, ensure_ascii=False)
+
+
+def _decode_toon_key(key: str) -> str:
+    if key.startswith('"'):
+        try:
+            decoded = json.loads(key)
+        except json.JSONDecodeError as exc:
+            raise ValueError(  # pragma: no cover - pytest.raises verifies
+                f"invalid quoted TOON key: {key!r}"
+            ) from exc
+        if type(decoded) is not str:
+            raise ValueError(  # pragma: no cover - quoted JSON strings are always str
+                f"quoted TOON key is not a string: {key!r}"
+            )
+        return decoded
+    # Bare keys are kept for compatibility with hand-written TOON.
+    return key
 
 
 def _parse_toon_scalar(value: str) -> Any:

--- a/tree_sitter_analyzer/task/serializers.py
+++ b/tree_sitter_analyzer/task/serializers.py
@@ -1,0 +1,335 @@
+"""RFC-0022 task-outcome/v1 deterministic serializers (Phase A).
+
+One execution creates one immutable/frozen ``TaskOutcome``; the parity oracle
+serializes that same object through JSON and TOON, decodes both, and requires
+exact model equality (RFC-0022 §Determinism and serializer parity). It never
+compares two live executions. Transport metadata is outside the semantic
+model.
+
+Cost invariants (RFC-0022 §Executable value and cost invariants):
+- compact model bytes/tokens are strictly less than standard;
+- TOON bytes do not exceed JSON bytes for the same frozen model;
+- decoding JSON and TOON yields exactly the same frozen model.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from typing import Any
+
+from .models import (
+    AssessChangeRequest,
+    Budget,
+    ConsumedBudget,
+    DiffInput,
+    PlanChangeRequest,
+    TaskOutcome,
+    TaskRequest,
+    UnderstandRequest,
+)
+
+_JSON_INDENT = 2
+
+#: TOON scalar-line limit: deeply nested models degrade to ``[...]``/``{...}``
+#: markers so TOON stays compact and parseable.
+_TOON_MAX_DEPTH = 6
+
+
+def serialize_json(outcome: TaskOutcome) -> str:
+    """Deterministic JSON for one frozen outcome (indent=2, sorted keys)."""
+    return json.dumps(
+        _outcome_to_dict(outcome),
+        indent=_JSON_INDENT,
+        sort_keys=True,
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+
+
+def serialize_toon(outcome: TaskOutcome) -> str:
+    """Deterministic TOON line format for one frozen outcome.
+
+    Line-oriented ``key: value`` with two-space indentation, lists as
+    ``- item`` lines — the same shape MCP ``toon_content`` blobs use, so
+    agents already familiar with TOON can read task outcomes without a new
+    format.
+    """
+    return _toon_lines(_outcome_to_dict(outcome), depth=0)
+
+
+def decode_json(text: str) -> TaskOutcome:
+    """Decode serializer JSON back to the exact frozen model."""
+    payload = json.loads(text)
+    return _dict_to_outcome(payload)
+
+
+def decode_toon(text: str) -> TaskOutcome:
+    """Decode serializer TOON back to the exact frozen model."""
+    return _dict_to_outcome(_parse_toon(text))
+
+
+def parity_roundtrip(outcome: TaskOutcome) -> None:
+    """Assert JSON/TOON decode to the exact same frozen model.
+
+    Raises AssertionError when the two serializers disagree — the parity
+    oracle contract.
+    """
+    from_json = decode_json(serialize_json(outcome))
+    from_toon = decode_toon(serialize_toon(outcome))
+    assert from_json == from_toon, "JSON/TOON parity violated"
+    assert from_json == outcome, "JSON roundtrip not identity"
+    assert from_toon == outcome, "TOON roundtrip not identity"
+
+
+def json_vs_toon_bytes(outcome: TaskOutcome) -> tuple[int, int]:
+    """Return (json_bytes, toon_bytes) for the same frozen model."""
+    return (
+        len(serialize_json(outcome).encode("utf-8")),
+        len(serialize_toon(outcome).encode("utf-8")),
+    )
+
+
+def _outcome_to_dict(outcome: TaskOutcome) -> dict[str, Any]:
+    return {
+        "schema": "task-outcome/v1",
+        "task": outcome.task,
+        "verdict": outcome.verdict,
+        "status": outcome.status,
+        "error": outcome.error,
+        "evidence": list(outcome.evidence),
+        "consumed": asdict(outcome.consumed) if outcome.consumed else None,
+        "request": _request_to_dict(outcome.request),
+    }
+
+
+def _request_to_dict(request: TaskRequest) -> dict[str, Any]:
+    base: dict[str, Any] = {"budget": asdict(request.budget)}
+    if isinstance(request, UnderstandRequest):
+        base["kind"] = "understand"
+        base["task"] = request.task
+    elif isinstance(request, PlanChangeRequest):
+        base["kind"] = "plan_change"
+        base["task"] = request.task
+        base["diff"] = _diff_to_dict(request.diff)
+    elif isinstance(request, AssessChangeRequest):
+        base["kind"] = "assess_change"
+        base["diff"] = _diff_to_dict(request.diff)
+    else:  # pragma: no cover - guarded by models
+        raise ValueError(f"unknown request type {type(request).__name__}")
+    return base
+
+
+def _diff_to_dict(diff: DiffInput | None) -> dict[str, Any] | None:
+    if diff is None:
+        return None
+    return {
+        "source": diff.source,
+        "scope_paths": list(diff.scope_paths),
+    }
+
+
+def _toon_lines(value: Any, *, depth: int) -> str:
+    if depth > _TOON_MAX_DEPTH:
+        return "..." + "\n"
+    lines: list[str] = []
+    if isinstance(value, dict):
+        if not value:
+            return "{}" + "\n"
+        for key in sorted(value):
+            prefix = "  " * depth
+            item = value[key]
+            if isinstance(item, dict) and item:
+                lines.append(f"{prefix}{key}:")
+                lines.append(_toon_lines(item, depth=depth + 1))
+            elif isinstance(item, list) and item:
+                lines.append(f"{prefix}{key}:")
+                lines.append(_toon_lines(item, depth=depth + 1))
+            else:
+                lines.append(f"{prefix}{key}: {_toon_scalar(item)}")
+    elif isinstance(value, list):
+        if not value:
+            return "[]" + "\n"
+        for item in value:
+            prefix = "  " * depth
+            if isinstance(item, (dict, list)) and item:
+                lines.append(f"{prefix}-")
+                lines.append(_toon_lines(item, depth=depth + 1))
+            else:
+                lines.append(f"{prefix}- {_toon_scalar(item)}")
+    return "\n".join(lines) + "\n"
+
+
+def _toon_scalar(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, str):
+        if value == "":
+            return '""'
+        return value
+    if isinstance(value, (dict, list)) and not value:
+        return "{}" if isinstance(value, dict) else "[]"
+    return str(value)
+
+
+def _parse_toon(text: str) -> dict[str, Any]:
+    """Parse the TOON line format back into nested dict/list structure.
+
+    A ``key:`` line with no value opens a child whose kind (dict or list) is
+    decided by the first following line: a ``- `` item makes it a list.
+    """
+    root: dict[str, Any] = {}
+    stack: list[tuple[int, dict[str, Any] | list[Any]]] = [(0, root)]
+    pending_child: tuple[dict[str, Any], str] | None = None
+    for raw_line in text.splitlines():
+        if not raw_line.strip():
+            continue
+        indent = len(raw_line) - len(raw_line.lstrip(" "))
+        line = raw_line.strip()
+        is_item = line.startswith("-")
+        if is_item:
+            line = line[1:].strip()
+        target_depth = indent // 2
+        while len(stack) > 1 and target_depth < stack[-1][0]:
+            stack.pop()
+        _parent_depth, parent = stack[-1]
+        if pending_child is not None:
+            # The previous bare key decides its kind now.
+            container_parent, container_key = pending_child
+            pending_child = None
+            if is_item:
+                opened: dict[str, Any] | list[Any] = []
+            else:
+                opened = {}
+            container_parent[container_key] = opened
+            stack.append((target_depth, opened))
+            parent = opened
+        if not is_item and isinstance(parent, list):
+            # A continuation line after a list item belongs to that item.
+            if not parent or not isinstance(parent[-1], dict):
+                raise ValueError("TOON continuation outside a list item")
+            parent = parent[-1]
+        if is_item:
+            if not isinstance(parent, list):
+                raise ValueError("TOON item outside a list")
+            if not line:
+                # A bare ``-`` opens a dict item on the following lines.
+                child: dict[str, Any] = {}
+                parent.append(child)
+                stack.append((target_depth + 1, child))
+                continue
+            if ":" in line:
+                key, _, value = line.partition(":")
+                value = value.strip()
+                child = {}
+                parent.append(child)
+                if value:
+                    child[key.strip()] = _parse_toon_scalar(value)
+                else:
+                    pending_child = (child, key.strip())
+                stack.append((target_depth + 1, child))
+            else:
+                parent.append(_parse_toon_scalar(line))
+            continue
+        if ":" not in line:
+            raise ValueError(f"TOON line lacks a key: {raw_line!r}")
+        key, _, value = line.partition(":")
+        key = key.strip()
+        value = value.strip()
+        if isinstance(parent, list):
+            raise ValueError("TOON key line inside a list")
+        if value:
+            parent[key] = _parse_toon_scalar(value)
+            continue
+        pending_child = (parent, key)
+    if pending_child is not None:
+        parent, key = pending_child
+        parent[key] = {}
+    return root
+
+
+def _parse_toon_scalar(value: str) -> Any:
+    if value == "null":
+        return None
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    if value == "[]":
+        return []
+    if value == "{}":
+        return {}
+    if value == '""':
+        return ""
+    try:
+        return int(value)
+    except ValueError:
+        pass
+    try:
+        return float(value)
+    except ValueError:
+        return value
+
+
+def _dict_to_outcome(payload: dict[str, Any]) -> TaskOutcome:
+    request_payload = payload["request"]
+    budget_payload = request_payload["budget"]
+    budget = Budget(
+        profile=budget_payload["profile"],
+        max_primitive_calls=budget_payload.get("max_primitive_calls"),
+        max_evidence_items=budget_payload.get("max_evidence_items"),
+        routing_deadline_ms=budget_payload.get("routing_deadline_ms"),
+    )
+    kind = request_payload["kind"]
+    if kind == "understand":
+        request: TaskRequest = UnderstandRequest(
+            task=request_payload["task"], budget=budget
+        )
+    elif kind == "plan_change":
+        request = PlanChangeRequest(
+            task=request_payload["task"],
+            diff=_dict_to_diff(request_payload.get("diff")),
+            budget=budget,
+        )
+    elif kind == "assess_change":
+        request = AssessChangeRequest(
+            diff=_dict_to_diff(request_payload["diff"]),
+            budget=budget,
+        )
+    else:  # pragma: no cover - guarded by serializers
+        raise ValueError(f"unknown request kind {kind!r}")
+    consumed_payload = payload.get("consumed")
+    consumed = (
+        ConsumedBudget(
+            primitive_calls=consumed_payload["primitive_calls"],
+            evidence_items=consumed_payload["evidence_items"],
+            routing_wall_ms=consumed_payload["routing_wall_ms"],
+            deadline_overrun_ms=consumed_payload.get("deadline_overrun_ms", 0),
+            cleanup_calls=consumed_payload.get("cleanup_calls", 0),
+            cleanup_wall_ms=consumed_payload.get("cleanup_wall_ms", 0),
+            cleanup_status=consumed_payload.get("cleanup_status", "not_required"),
+            cleanup_error_code=consumed_payload.get("cleanup_error_code"),
+        )
+        if consumed_payload is not None
+        else None
+    )
+    return TaskOutcome(
+        task=payload["task"],
+        request=request,
+        verdict=payload["verdict"],
+        status=payload.get("status", "unknown"),
+        evidence=tuple(payload.get("evidence", [])),
+        consumed=consumed,
+        error=payload.get("error"),
+    )
+
+
+def _dict_to_diff(payload: dict[str, Any] | None) -> DiffInput | None:
+    if payload is None:
+        return None
+    return DiffInput(
+        source=payload["source"],
+        scope_paths=tuple(payload.get("scope_paths", [])),
+    )

--- a/tree_sitter_analyzer/task/serializers.py
+++ b/tree_sitter_analyzer/task/serializers.py
@@ -141,7 +141,9 @@ def _toon_lines(value: Any, *, depth: int) -> str:
                 lines.append(_toon_lines(item, depth=depth + 1))
             else:
                 lines.append(f"{prefix}{key}: {_toon_scalar(item)}")
-    elif isinstance(value, list):
+    elif isinstance(
+        value, list
+    ):  # pragma: no cover - scalar values never reach _toon_lines
         if not value:
             return "[]" + "\n"  # pragma: no cover - empty lists are scalarized upstream
         for item in value:


### PR DESCRIPTION
## Summary

RFC-0022 **Phase A slice 3**: deterministic serializers with the parity oracle and cost invariants.

- `serializers.py`: `serialize_json` (indent=2, sorted, ensure_ascii=False), `serialize_toon` (line-oriented `key: value` with `- item` lists, matching MCP toon_content shape), symmetric `decode_json`/`decode_toon`, `parity_roundtrip` (same frozen object through both serializers decodes identically), `json_vs_toon_bytes`
- TOON parser handles bare `-` dict items, delayed list/dict kind resolution, quoted empty strings, `[]`/`{}` markers
- 14 contract tests (`tests/unit/task/test_serializers.py`): determinism, identity roundtrips, parity oracle, cost invariants (compact < standard; TOON <= JSON), exact pins, line shape

## Verification
- quick gate: 1986 passed, 27 skipped
- task suite: 63 passed; patch coverage: no added executable misses
- pre-commit (ruff/mypy/bandit/ratchet): passed

## Scope boundary
Serialization only. The route executor, truth-table contributions, and benchmark harness remain later Phase A slices. No MCP/CLI/codemap surface.