### PR TITLE
fix(ci): pin uv to 0.12.3 in ci.yml jobs (#1258 follow-up)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          version: "latest"
+          version: "0.12.3"
           enable-cache: true
           cache-dependency-glob: "uv.lock"
       - name: Set up Python 3.11
@@ -121,7 +121,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          version: "latest"
+          version: "0.12.3"
           enable-cache: true
           cache-dependency-glob: "uv.lock"
 
@@ -185,7 +185,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          version: "latest"
+          version: "0.12.3"
           enable-cache: true
           cache-dependency-glob: "uv.lock"
       - name: Set up Python 3.11


### PR DESCRIPTION
## #1258 follow-up：ci.yml 的 setup-uv 也 pin 到 0.12.3

**问题**：#1258 只 pin 了 `reusable-test.yml`，但 `ci.yml` 的 3 处 `setup-uv`（docs-check / E2E / test-quality-audit）仍是 `latest`（当前解析到 0.12.5），导致每个 PR 的 Docs Check 都在 `test_collect_no1_006b_baseline::test_receipt_binds_exact_collector_tool_lock_and_export` 失败：`assert ['uv', '0.12.5'] == ['uv', '0.12.3']`。

**修复**：ci.yml 3 处 `version: "latest"` → `"0.12.3"`，与 #1258 的 pin 一致（NO1-006B 工具锁绑定 0.12.3）。

**验证**：actionlint 已过；docs-only PR（如 #1275）的 Docs Check 将恢复绿色。