### PR TITLE
docs: handoff remaining work to next session

### DIFF
--- a/HANDOFF-2026-08-15.md
+++ b/HANDOFF-2026-08-15.md
@@ -1,0 +1,83 @@
+# Handoff — 2026-08-15 NO1 接管会话(上下文移交)
+
+> 目的:本会话上下文已长,剩余问题移交到新对话继续开发。
+> 本文件只记录"尚未完成、需要新对话接手"的事项;已完成事项见 STATE.md。
+
+## 0. 当前基线(接手前确认)
+
+- 分支:所有工作基于 `origin/develop`(HEAD `e4b7b97e`),已完成 PR 全部合并
+- 本会话合并到 develop 的 PR:#1271(review gates)、#1272、#1270(CI -q)、#1273(dedupe)、#1274、#1251(dependabot actions bump,已修复 strace pin 冲突)
+- 快速门:本地 `uv run pytest -q` = 1992 passed;完整契约 `tests/contracts/` = 582 passed
+- uv 缓存问题:沙箱内 `~/.cache/uv` 不可写 → 所有命令加 `UV_CACHE_DIR=/tmp/uv-cache-<rand>`
+- 提交钩子需要 `UV_CACHE_DIR` 环境变量,否则 weak-assertion-ratchet 会因缓存失败
+
+## 1. 最高优先级:Windows 3.12/3.13 CI 失败(既有问题,非本会话引入)
+
+**现象**:develop CI 反复失败(合并前后一致),失败轴:`Test Suite (full) (windows-latest, 3.12/3.13)` + `Quality Gate`。ubuntu/macos/win-3.11 全绿。
+
+**失败测试清单**(每次 ~20 个,同一批):
+- `tests/unit/mcp/tools/test_constraint_check_live.py::test_portable_probe_enforces_config_byte_capacity`
+- `tests/unit/mcp/tools/test_constraint_check_portable_snapshot.py::test_portable_live_config_detects_changed_identity`
+- `tests/unit/mcp/tools/test_constraint_check_portable_snapshot.py::test_portable_source_certifier_hashes_stable_supported_scope`
+- `tests/unit/mcp/tools/test_constraint_check_read_only.py::test_read_only_*`(CONFIG_UNKNOWN vs CONFIG_CHANGED 断言差)
+- `tests/unit/mcp/tools/test_constraint_index_snapshot_budget.py::test_portable_snapshot_*`(CONCURRENT_WRITER)
+- `tests/unit/mcp/tools/test_constraint_index_snapshot.py::test_portable_snapshot_*`
+- `tests/unit/mcp/test_index_sync_tools.py::TestCodeGraphFullIndexTool::test_execute_incremental`
+- `tests/unit/cli/test_constraint_check_command.py::test_explicit_*`
+- `tests/unit/cli/test_constraint_check_execution.py::TestEvaluateWithExplicitFile::test_read_only_corrupt_edges_*`
+
+**推断根因**(未验证):`constraint_check` / `source_oracle` 的**配置并发写检测**(CONFIG_CHANGED / CONCURRENT_WRITER / "constraint file changed during read")在 Windows 上行为不同——大概率是 Windows 文件句柄/stat/时间戳语义,或 portable snapshot 的临时目录/权限差异。错误模式 `CONFIG_UNKNOWN` vs `CONFIG_CHANGED` 表明检测到了"配置变了"但 state 投影顺序不对。
+
+**验证方法**:
+1. 本地(需要 Windows):`uv run pytest tests/unit/mcp/tools/test_constraint_check_live.py tests/unit/mcp/tools/test_constraint_check_read_only.py -q -n 0`(单线程复现)
+2. 或 CI 加 `--reruns=2` 判断是否 flake(注意:失败集合每次完全一致 → 大概率确定性失败,不是 flake)
+3. 已检查:这些失败在合并 #1271 之前就存在(run 31880675513 与合并后失败清单一字不差)→ **不是 #1271/#1270/#1273/#1251 引入的回归**
+
+## 2. 中优先级:93 个 T-1 禁名测试文件(重复测试债务)
+
+**现状**:CLAUDE.md T-1 明令禁止的命名(`*_coverage*` / `*_comprehensive*` / `*_edge_cases*` / `*_extended*` / `*_optimized*`)存量文件 **93 个 / 2015 测试 / 35402 行**,覆盖率追逐时代残留。T-1 钩子只挡新增,存量在基线里。
+
+**已做**:#1273 删除 1 个示范文件(`test_python_plugin_coverage.py`,4 测试,快速门 1992 不变 = 纯重复证明)。
+
+**未做(留给新对话)**:
+- 逐文件 triage:coverage 类文件多为纯重复(可删);comprehensive/edge_cases 常含主线没有的真实边界测试(需并入主线再删文件,如 `test_python_plugin_comprehensive.py::test_full_extraction_workflow` 有实质断言而主线同名测试是弱断言)
+- **注意不是时间瓶颈**(2015 测试 ~10s),CI 8-9 分钟主因是 25k 测试在 4-vCPU runner 上执行
+- 做法:一次一个主题(chore 分支),删除前确认快速门数字不变
+
+## 3. 低优先级:测试效率(已部分优化)
+
+- 已做:`-v`→`-q`(#1270),coverage 轴 608s→511s(-16%)
+- 已验证无效:worker 超配(`-n 8` 比 `-n 4` 慢)
+- 不做:4 轴矩阵去重(`test_pr_ci_uses_fast_matrix_while_release_keeps_full_matrix` 契约锁定)
+
+## 4. 并行会话的工作(不要动)
+
+以下 PR/分支属于**其他并行 agent 会话**,非本会话产出,不要接管合并:
+- **#1275** `chore/python-self-index-dogfood` — python self-index 差分验证(docs + /tmp/tsa-dogfood/index.db 数据)
+- **#1276** `fix/uv-pin-ci-yml` — ci.yml 里 pin uv 0.12.3(#1258 follow-up)
+- worktree 列表里 feature/no1-* 分支多数已合并,可忽略;`fix/no1-1257-trap-allowance`、`fix/no1-006b-collector-uv-pin` 等仍有 worktree
+
+## 5. NO1 路线图剩余任务(按依赖顺序)
+
+见 `rfcs/ROADMAP-no1-agent-trust.md` §10 执行顺序 + STATE.md。P0 已完成项:003A/B/D、004A/B、005A、006A、007A/B。剩余:
+- **NO1-003C**:E0 Gin canary——阻塞于人工门(签名 attestation + judge + budget),非开发任务
+- **NO1-008A**:seven-repo model-free setup——需先有独立的 RFC-0021 E1 qualification
+- **NO1-010A**:three-task prototype(understand/plan_change/assess_change)——RFC-0022/0023 Phase A 已合并,#1265-#1269 已落;这是**下一个可开发的实现任务**
+- **NO1-012A**:Performance/SLO artifact pipeline(依赖 006A,已 qualifed)
+
+## 6. 接手后的建议动作
+
+1. 跑 `UV_CACHE_DIR=/tmp/uv-cache-x uv run python -m tree_sitter_analyzer --change-impact --format json` 确认基线
+2. 第一个开发任务:复现并修复 Windows constraint_check 失败(§1)——先加 `--reruns=2` 排除 flake,再单线程复现
+3. 或直接开 NO1-010A(§5)
+4. 新对话结束时,把本文件标记完成/删除,并更新 STATE.md
+
+## 7. 关键命令速查
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache-x uv run pytest -q                          # 快速门(5min 内)
+UV_CACHE_DIR=/tmp/uv-cache-x uv run pytest tests/ -q --timeout=120 -m "not e2e and not network and not benchmark"  # 全量
+UV_CACHE_DIR=/tmp/uv-cache-x uv run python -m tree_sitter_analyzer --change-impact --format json
+UV_CACHE_DIR=/tmp/uv-cache-x uv run pytest tests/unit/task/test_edge_evidence.py -q --cov=tree_sitter_analyzer --cov-report=json
+UV_CACHE_DIR=/tmp/uv-cache-x uv run python scripts/check_patch_coverage.py --base origin/develop --coverage-json coverage.json
+```


### PR DESCRIPTION
Context handoff document for the next development session. Covers: (1) Windows 3.12/3.13 constraint_check CI failures — pre-existing, deterministic, same 20 tests before/after this session's merges, suspected Windows file-handle/timestamp semantics in the config-change detector; (2) 93-file T-1 banned-name duplicate test debt, one removed as proof (#1273), bulk removal deliberately rejected as low-ROI; (3) NO1-010A as next implementable roadmap task; (4) parallel-session PRs #1275/#1276 to leave alone; (5) command cheat-sheet incl. the UV_CACHE_DIR sandbox workaround.