### PR TITLE
fix(constraints): stop Windows CI CONSTRAINT_CONFIG_UNKNOWN/CHANGED flakiness

### DIFF
--- a/tree_sitter_analyzer/mcp/tools/constraint_check_live.py
+++ b/tree_sitter_analyzer/mcp/tools/constraint_check_live.py
@@ -20,13 +20,18 @@ _CONFIG_CANDIDATES = (
 
 
 def _identity(info: os.stat_result) -> bytes:
+    # st_ctime_ns is deliberately excluded: on Windows it is the file creation
+    # time (not a modification signal) and is known to differ between os.fstat
+    # (handle) and os.lstat (path) for the same file, which made the open-before/
+    # after probe misreport CONSTRAINT_CONFIG_CHANGED on Windows CI. size +
+    # mtime_ns + mode + inode detect every real mutation the probe guards
+    # against (content append, rewrite, truncation, rename, reparse flip).
     values = (
         info.st_dev,
         info.st_ino,
         info.st_mode,
         info.st_size,
         info.st_mtime_ns,
-        info.st_ctime_ns,
         getattr(info, "st_file_attributes", 0),
     )
     return b",".join(str(value).encode("ascii") for value in values)

--- a/tree_sitter_analyzer/mcp/tools/constraint_check_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/constraint_check_tool.py
@@ -156,10 +156,15 @@ class ConstraintCheckTool(BaseMCPTool):
 
         if not constraints and not persist:
             assert config_before is not None
+            # The recheck probes the live file again; it must not reuse the
+            # original deadline, which may already be exhausted by graph
+            # execution on slower runners (Windows CI: CONSTRAINT_CONFIG_DEADLINE
+            # surfaced as CONSTRAINT_CONFIG_UNKNOWN).
+            recheck_deadline = time.monotonic() + 10.0
             changed = _config_changed_response(
                 self.project_root,
                 config_before,
-                deadline,
+                recheck_deadline,
                 output_format,
                 self._snapshot_error,
                 _live_config_snapshot,
@@ -233,10 +238,11 @@ class ConstraintCheckTool(BaseMCPTool):
 
         if not persist:
             assert config_before is not None
+            recheck_deadline = time.monotonic() + 10.0
             changed = _config_changed_response(
                 self.project_root,
                 config_before,
-                deadline,
+                recheck_deadline,
                 output_format,
                 self._snapshot_error,
                 _live_config_snapshot,


### PR DESCRIPTION
## Root causes (Windows CI, deterministic — same 20 tests every run)

1. **`_identity()` included `st_ctime_ns`** — on Windows this is the file *creation* time and differs between `os.fstat` (handle) and `os.lstat` (path) for the same file. The portable probe's open-before/after comparison (constraint_check_live.py:84/95/97) then misreported `CONSTRAINT_CONFIG_CHANGED` for unchanged files — e.g. `test_portable_probe_enforces_config_byte_capacity` got CHANGED instead of CAPACITY.
2. **`config_changed_response` reused the original 10s deadline** across graph execution; on slower Windows runners the recheck probe hit `CONSTRAINT_CONFIG_DEADLINE` → mapped to `CONSTRAINT_CONFIG_UNKNOWN` (tests expected CHANGED).

## Fix

- Drop `st_ctime_ns` from `_identity`: size + mtime_ns + mode + inode detect every real mutation the probe guards against (append, rewrite, truncation, rename, reparse flip).
- Recompute `recheck_deadline = time.monotonic() + 10.0` at both `_config_changed_response` call sites.

## Verification

- 303 constraint/CLI/index-sync tests pass locally
- Windows CI (3.12/3.13) is the real gate — this PR exists to prove the fix there

## Scope note

Not yet addressed (separate root causes): `test_portable_source_certifier_hashes_stable_supported_scope` (`unsafe` vs `exact`) and `test_execute_incremental` in `test_index_sync_tools.py` — those need separate investigation if they persist after this fix.