### PR TITLE
fix(indexing): record future imports and commented paren imports

### DIFF
--- a/tests/unit/test_synapse_resolution.py
+++ b/tests/unit/test_synapse_resolution.py
@@ -546,6 +546,60 @@ class TestStarImportBookkeeping:
         finally:
             cache.close()
 
+    def test_commented_parenthesized_import_records_all_aliases(
+        self, tmp_path: Path
+    ) -> None:
+        # #1275 (dogfood F2): an inline comment after the opening paren of a
+        # parenthesized from-import truncated the names clause, dropping every
+        # alias of that statement from ast_imports.
+        proj = tmp_path / "synapse_pkg"
+        proj.mkdir(parents=True, exist_ok=True)
+        (proj / "__init__.py").write_text("# pkg\n")
+        (proj / "b.py").write_text("X = 1\nY = 2\n")
+        (proj / "commented.py").write_text(
+            "from .b import (  # noqa: F401\n    X,\n    Y,\n)\n"
+        )
+        cache = ASTCache(str(tmp_path))
+        try:
+            cache.index_project()
+            with _open_db(cache) as conn:
+                rows = conn.execute(
+                    "SELECT local_name FROM ast_imports "
+                    "WHERE file_path LIKE 'synapse_pkg/commented.py' "
+                    "ORDER BY local_name"
+                ).fetchall()
+                assert [r["local_name"] for r in rows] == ["X", "Y"], (
+                    "expected both aliases X and Y to be recorded, got "
+                    f"{[r['local_name'] for r in rows]}"
+                )
+        finally:
+            cache.close()
+
+    def test_future_import_recorded_as_import_row(self, tmp_path: Path) -> None:
+        # #1275 (dogfood F1): a future import parses as future_import_statement
+        # and was dropped from the index entirely.
+        proj = tmp_path / "synapse_pkg"
+        proj.mkdir(parents=True, exist_ok=True)
+        (proj / "__init__.py").write_text("# pkg\n")
+        (proj / "future_import.py").write_text(
+            "from __future__ import annotations\nX = 1\n"
+        )
+        cache = ASTCache(str(tmp_path))
+        try:
+            cache.index_project()
+            with _open_db(cache) as conn:
+                row = conn.execute(
+                    "SELECT module_path, local_name FROM ast_imports "
+                    "WHERE file_path LIKE 'synapse_pkg/future_import.py'"
+                ).fetchone()
+                assert row is not None, (
+                    "expected the future import recorded in ast_imports"
+                )
+                assert row["module_path"] == "__future__"
+                assert row["local_name"] == "annotations"
+        finally:
+            cache.close()
+
 
 # ---------------------------------------------------------------------------
 # RFC-0002 — builtin classifier + shadowing contract

--- a/tree_sitter_analyzer/cache/_symbol_rules.py
+++ b/tree_sitter_analyzer/cache/_symbol_rules.py
@@ -65,6 +65,7 @@ _IMPORT_LIKE = frozenset(
     {
         "import_statement",
         "import_from_statement",
+        "future_import_statement",
         "import_declaration",
         "require_statement",
         "use_declaration",

--- a/tree_sitter_analyzer/synapse_resolver/_imports.py
+++ b/tree_sitter_analyzer/synapse_resolver/_imports.py
@@ -14,6 +14,15 @@ _PY_FROM_IMPORT_RE = re.compile(
     r"^from\s+(\.*)([\w.]*)\s+import\s+(.+)$", re.MULTILINE | re.DOTALL
 )
 _PY_IMPORT_RE = re.compile(r"^import\s+([\w.,\s]+)$", re.MULTILINE | re.DOTALL)
+# Inline comments inside parenthesized multi-line imports must be removed
+# per line; a plain split on the hash sign truncates the whole clause at a
+# comment that appears before the first alias (e.g. after the opening paren).
+_STRIP_LINE_COMMENTS_RE = re.compile(r"#[^\n]*")
+
+
+def _strip_line_comments(clause: str) -> str:
+    """Remove hash-comment tails from an import names clause."""
+    return _STRIP_LINE_COMMENTS_RE.sub("", clause)
 
 
 @dataclass(frozen=True)
@@ -88,7 +97,7 @@ def _parse_python_imports(
     if m_from:
         dots = m_from.group(1) or ""
         module_tail = m_from.group(2) or ""
-        names_clause = (m_from.group(3) or "").split("#", 1)[0]
+        names_clause = _strip_line_comments(m_from.group(3) or "")
         module_path = dots + module_tail
         is_relative = bool(dots)
         entries: list[ImportEntry] = []
@@ -123,7 +132,7 @@ def _parse_python_imports(
 
     m_imp = _PY_IMPORT_RE.match(text)
     if m_imp:
-        body = m_imp.group(1).split("#", 1)[0]
+        body = _strip_line_comments(m_imp.group(1))
         entries = []
         for item, alias_of in _split_names_clause(body):
             if alias_of:


### PR DESCRIPTION
## 修复 dogfood 差分验证发现的两个 import 索引缺口（#1275 F1/F2）

**背景**：docs(dogfood) #1275 用 stdlib-ast 差分验证发现：项目 865 个 Python 文件索引后，7836 条预期导入绑定只有 7327 条进入 `ast_imports`（509 条缺失）。

**F1 — future 导入 100% 丢失**（488 文件）
tree-sitter-python 将 `from __future__ import annotations` 解析为 `future_import_statement` 节点，该节点不在 `cache/_symbol_rules.py::_IMPORT_LIKE` 中 → 整个语句从索引完全消失（无 symbol 行、无 ast_imports 行）。修复：加入 `_IMPORT_LIKE`。

**F2 — 括号多行导入带行内注释时整条丢失**（5 文件 22 条绑定）
`from x import (  # noqa: F401\n    a,\n    b,\n)` 这类写法在 `synapse_resolver/_imports.py` 中先按 `#` 切分再处理括号 → names 子句被截断为空白 → 该语句所有别名丢失。修复：新增 `_strip_line_comments` 按行去除行内注释后再切分别名。

**验证**：
- 差分验证重跑：imports_expected 7836 == imports_actual 7836（缺失 509 → 0），符号层仍 100%（0 缺失、0 行号偏差），calls/contains/三表一致性无回归
- 快速门：1992 passed（与基线一致）
- 新增 2 个回归测试（tests/unit/test_synapse_resolution.py，引用 #1275）