### PR TITLE
fix(indexing): record import statement lines in ast_imports

### DIFF
--- a/tests/unit/test_symbols_json_enrichment.py
+++ b/tests/unit/test_symbols_json_enrichment.py
@@ -143,8 +143,9 @@ class TestExtractorVersionBump:
         from tree_sitter_analyzer import ast_cache
         from tree_sitter_analyzer.cache import indexer as _ast_cache_indexer
 
-        assert ast_cache._AST_CACHE_EXTRACTOR_VERSION == 14
-        assert _ast_cache_indexer._AST_CACHE_EXTRACTOR_VERSION == 14
+        # v15: #1275 (dogfood F5) — imports_json entries carry a line field.
+        assert ast_cache._AST_CACHE_EXTRACTOR_VERSION == 15
+        assert _ast_cache_indexer._AST_CACHE_EXTRACTOR_VERSION == 15
 
 
 class TestBashVariableAssignmentScope:

--- a/tests/unit/test_synapse_resolution.py
+++ b/tests/unit/test_synapse_resolution.py
@@ -600,6 +600,37 @@ class TestStarImportBookkeeping:
         finally:
             cache.close()
 
+    def test_import_rows_carry_statement_line(self, tmp_path: Path) -> None:
+        # #1275 (dogfood F5): ast_imports.line was always 0 because the write
+        # path stored bare statement strings; entries now carry their line.
+        proj = tmp_path / "synapse_pkg"
+        proj.mkdir(parents=True, exist_ok=True)
+        (proj / "__init__.py").write_text("# pkg\n")
+        (proj / "imports.py").write_text(
+            "import os\n"
+            "from typing import Any\n"
+            "\n"
+            "def f() -> Any:\n"
+            "    return os.getcwd()\n"
+        )
+        cache = ASTCache(str(tmp_path))
+        try:
+            cache.index_project()
+            with _open_db(cache) as conn:
+                rows = conn.execute(
+                    "SELECT module_path, line FROM ast_imports "
+                    "WHERE file_path LIKE 'synapse_pkg/imports.py' "
+                    "ORDER BY line"
+                ).fetchall()
+                assert [(r["module_path"], r["line"]) for r in rows] == [
+                    ("os", 1),
+                    ("typing", 2),
+                ], (
+                    f"expected exact lines, got {[(r['module_path'], r['line']) for r in rows]}"
+                )
+        finally:
+            cache.close()
+
 
 # ---------------------------------------------------------------------------
 # RFC-0002 — builtin classifier + shadowing contract

--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -47,7 +47,9 @@ from ._ast_cache_query_mixin import ASTCacheQueryMixin
 # v12: #779 — walker depth cap raised from 20 to 100.
 # v13: #949 — bash command-prefix environment variables are not declarations.
 # v14: #1094 / RFC-0019 — symbols carry canonical extractor complexity.
-_AST_CACHE_EXTRACTOR_VERSION = 14
+# v15: #1275 (dogfood F5) — ast_index.imports_json entries carry a line
+# field (dict entries instead of bare statement strings).
+_AST_CACHE_EXTRACTOR_VERSION = 15
 
 # Preserve the historical public exception identity after implementation split.
 SchemaIntegrityError.__module__ = __name__

--- a/tree_sitter_analyzer/cache/_symbol_walker.py
+++ b/tree_sitter_analyzer/cache/_symbol_walker.py
@@ -251,9 +251,18 @@ def _extract_symbols(tree: Any, source_code: str, language: str) -> dict[str, An
     }
 
 
-def _extract_imports(symbols: dict[str, Any]) -> list[str]:
+def _extract_imports(symbols: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return per-statement import entries carrying the source line.
+
+    Entries are dicts with text and line keys so the ast_imports table can
+    record the statement line instead of a constant zero; string consumers
+    are still served by the text key (dogfood F5, #1275).
+    """
     return [
-        symbol["text"]
+        {
+            "text": symbol["text"],
+            "line": symbol.get("line", 0),
+        }
         for symbol in symbols.get("symbols", [])
         if symbol.get("kind") == "import"
     ]

--- a/tree_sitter_analyzer/cache/extraction.py
+++ b/tree_sitter_analyzer/cache/extraction.py
@@ -224,7 +224,7 @@ def _worker_payload(
     fingerprint: IndexFileFingerprint,
     source_code: str,
     symbols: dict[str, Any],
-    imports: list[str],
+    imports: list[dict[str, Any]] | list[str],
     structure: dict[str, Any],
     call_edges: list[dict[str, Any]],
 ) -> dict[str, Any]:

--- a/tree_sitter_analyzer/cache/indexer.py
+++ b/tree_sitter_analyzer/cache/indexer.py
@@ -124,7 +124,7 @@ _PLUGIN_EXTS: frozenset[str] = frozenset(
 _warned_extensions: set[str] = set()
 
 # Extractor version constant — kept in sync with ast_cache.py.
-_AST_CACHE_EXTRACTOR_VERSION = 14
+_AST_CACHE_EXTRACTOR_VERSION = 15
 
 
 def _walk_source_files(project_root: str) -> Iterator[str]:

--- a/tree_sitter_analyzer/cache/write.py
+++ b/tree_sitter_analyzer/cache/write.py
@@ -260,8 +260,8 @@ def _insert_import_entry(
         conn.execute(
             """INSERT INTO ast_imports
                (file_path, language, module_path, local_name,
-                is_relative, is_star, alias_of)
-               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                is_relative, is_star, alias_of, line)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 rel_path,
                 language,
@@ -270,6 +270,7 @@ def _insert_import_entry(
                 1 if entry.is_relative else 0,
                 1 if entry.is_star else 0,
                 entry.alias_of,
+                entry.line,
             ),
         )
         return True

--- a/tree_sitter_analyzer/call_graph.py
+++ b/tree_sitter_analyzer/call_graph.py
@@ -768,7 +768,8 @@ class CachedCallGraph(CallGraph):
         file_import_map: dict[str, dict[str, str]] = {}
         for file_path, import_texts in imports_raw.items():
             name_map: dict[str, str] = {}
-            for imp_text in import_texts:
+            for imp in import_texts:
+                imp_text = imp["text"] if isinstance(imp, dict) else imp
                 parts = imp_text.split()
                 if len(parts) >= 4 and parts[0] == "from":
                     mod_name = parts[1]

--- a/tree_sitter_analyzer/cross_file_resolver.py
+++ b/tree_sitter_analyzer/cross_file_resolver.py
@@ -296,9 +296,10 @@ class CrossFileResolver:
         for row in rows:
             fp = row["file_path"]
             lang = row["language"]
-            imports_raw: list[str] = json.loads(row["imports_json"])
+            imports_raw: list[Any] = json.loads(row["imports_json"])
             entries: list[ImportEntry] = []
-            for imp_text in imports_raw:
+            for imp in imports_raw:
+                imp_text = imp["text"] if isinstance(imp, dict) else imp
                 parsed = self._parse_import(imp_text, fp, lang)
                 if parsed:
                     entries.append(parsed)

--- a/tree_sitter_analyzer/dependency_matrix.py
+++ b/tree_sitter_analyzer/dependency_matrix.py
@@ -151,7 +151,8 @@ class DependencyMatrix:
         for source_file, imports in imports_by_file.items():
             if not isinstance(imports, list):
                 continue
-            for imp_text in imports:
+            for imp in imports:
+                imp_text = imp["text"] if isinstance(imp, dict) else imp
                 if not isinstance(imp_text, str):
                     continue
                 resolved = self._resolve_import(imp_text, source_file, project_files)

--- a/tree_sitter_analyzer/import_graph.py
+++ b/tree_sitter_analyzer/import_graph.py
@@ -308,7 +308,8 @@ class ImportGraph:
         for source_file, imports in imports_by_file.items():
             if not isinstance(imports, list):
                 continue
-            for imp_text in imports:
+            for imp in imports:
+                imp_text = imp["text"] if isinstance(imp, dict) else imp
                 if not isinstance(imp_text, str):
                     continue
                 resolved = self._resolve_import(imp_text, source_file)

--- a/tree_sitter_analyzer/xref.py
+++ b/tree_sitter_analyzer/xref.py
@@ -300,9 +300,10 @@ class XRefEngine:
                 continue
             imports = json.loads(row["imports_json"])
             for imp in imports:
+                imp_text = imp["text"] if isinstance(imp, dict) else imp
                 if (
-                    module_name in imp
-                    or file_path.rstrip(".py").replace("/", ".") in imp
+                    module_name in imp_text
+                    or file_path.rstrip(".py").replace("/", ".") in imp_text
                 ):
                     results.append(
                         {


### PR DESCRIPTION
## 修复 ast_imports 行号恒为 0（dogfood F5, #1275）

**问题**：差分验证发现 7327/7327 条 `ast_imports` 行 `line=0`——索引写入的是裸 import 语句字符串，`_parse_import_raw` 对字符串固定返回 0。

**改动**：
- `_extract_imports` 返回 `{text, line}` dict（extractor v15，旧缓存自动失效重建）
- `_insert_import_entry` 持久化 `entry.line`
- 字符串消费点适配 dict 条目：xref / import_graph / dependency_matrix / call_graph / cross_file_resolver（这些模块对非字符串元素静默 continue，是隐性丢边陷阱）

**验证**：7836/7836 行带真实行号（如 `importlib` → line 18）；快速门 1992 不变；新增回归测试（精确行号断言）。