### PR TITLE
fix(graph): resolved EXTENDS edges replace generic placeholders

### DIFF
--- a/tests/unit/test_incremental_sync.py
+++ b/tests/unit/test_incremental_sync.py
@@ -2032,7 +2032,9 @@ def test_modified_base_rebuilds_resolved_hierarchy_edge(tmp_path):
     finally:
         cache.close()
 
-    assert targets == ["base.py:Base:1", "class:Base"]
+    # #1275 (dogfood F4): the resolved edge replaces the generic placeholder,
+    # so exactly one EXTENDS edge survives the re-resolution.
+    assert targets == ["base.py:Base:1"]
 
 
 @requires_posix_fd

--- a/tests/unit/test_unresolved_refs_cache_parity.py
+++ b/tests/unit/test_unresolved_refs_cache_parity.py
@@ -175,6 +175,44 @@ def test_candidate_cache_collapses_duplicate_selects(tmp_path: Path) -> None:
         cache.close()
 
 
+def test_resolved_extends_replaces_generic_placeholder(tmp_path: Path) -> None:
+    """Dogfood F4 (#1275): resolved EXTENDS edges replace the index-time
+    generic class-placeholder edge instead of duplicating it.
+
+    The indexer writes one generic edge per base before resolution; the
+    second pass must delete it when a real symbol node resolves, otherwise
+    class_hierarchy sees every cross-file base twice (536 vs 328 edges on
+    this repo's own index).
+    """
+    _write_repeated_name_project(tmp_path)
+    cache = ASTCache(str(tmp_path))
+    try:
+        cache.index_project(workers=0)
+        conn = cache.get_conn()
+        _reset_resolution(conn)
+        stats = unresolved.resolve_unresolved_refs(conn)
+        assert stats is not None
+        assert stats["errors"] == 0, stats
+        assert stats["resolved"] == 24, stats
+
+        placeholder = conn.execute(
+            "SELECT COUNT(*) FROM edges WHERE kind = 'extends' "
+            "AND target_node_id LIKE 'class:%'"
+        ).fetchone()[0]
+        assert placeholder == 0, (
+            f"expected no generic class placeholder after resolution, got {placeholder}"
+        )
+        resolved = conn.execute(
+            "SELECT COUNT(*) FROM edges WHERE kind = 'extends' "
+            "AND target_node_id LIKE '%/base.py:%'"
+        ).fetchone()[0]
+        assert resolved == 12, (
+            f"expected all 12 widgets resolved to base.py symbols, got {resolved}"
+        )
+    finally:
+        cache.close()
+
+
 def test_candidate_cache_returns_empty_on_broken_connection() -> None:
     """A failing candidate SELECT still yields [] and is cached as the abort."""
     no_schema = sqlite3.connect(":memory:")

--- a/tests/unit/test_unresolved_refs_cache_parity.py
+++ b/tests/unit/test_unresolved_refs_cache_parity.py
@@ -213,6 +213,30 @@ def test_resolved_extends_replaces_generic_placeholder(tmp_path: Path) -> None:
         cache.close()
 
 
+def test_drop_placeholder_extends_ignores_non_hierarchy_kinds() -> None:
+    """CALLS refs must never touch EXTENDS placeholder rows (#1275 F4)."""
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.execute(
+            "CREATE TABLE edges (source_node_id TEXT, target_node_id TEXT, kind TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO edges VALUES ('caller.py:run:1', 'class:Base', 'extends')"
+        )
+        unresolved._drop_placeholder_extends(
+            conn,
+            {
+                "from_node_id": "caller.py:run:1",
+                "reference_kind": "calls",
+                "reference_name": "Base",
+            },
+        )
+        remaining = conn.execute("SELECT COUNT(*) FROM edges").fetchone()[0]
+        assert remaining == 1, "non-hierarchy refs must not delete extends edges"
+    finally:
+        conn.close()
+
+
 def test_candidate_cache_returns_empty_on_broken_connection() -> None:
     """A failing candidate SELECT still yields [] and is cached as the abort."""
     no_schema = sqlite3.connect(":memory:")

--- a/tree_sitter_analyzer/cache/unresolved.py
+++ b/tree_sitter_analyzer/cache/unresolved.py
@@ -138,6 +138,7 @@ def resolve_unresolved_refs(conn: sqlite3.Connection) -> dict[str, int] | None:
                     # EXTENDS/IMPLEMENTS: upsert a real edge pointing at the
                     # resolved base class so class_hierarchy can traverse it.
                     edge = _resolved_edge(conn, ref, chosen, len(candidates))
+                    _drop_placeholder_extends(conn, ref)
                     store.upsert_edges([edge])
                 resolved += 1
             except (sqlite3.OperationalError, TypeError, ValueError) as exc:
@@ -232,6 +233,30 @@ def mark_resolution_converged(conn: sqlite3.Connection) -> None:
         conn.commit()
     except sqlite3.OperationalError:
         logger.debug("could not persist resolution fingerprint", exc_info=True)
+
+
+def _drop_placeholder_extends(conn: sqlite3.Connection, ref: dict[str, Any]) -> None:
+    """Remove the index-time generic class-placeholder EXTENDS edge.
+
+    The indexer writes one generic edge per base before resolution (dogfood
+    F4, #1275: extends counts were doubled for every cross-file base). Once
+    the second pass resolves the base to a real symbol node, the placeholder
+    is no longer reachable and would otherwise duplicate the edge.
+    """
+    if ref["reference_kind"] not in {
+        EdgeKind.EXTENDS.value,
+        EdgeKind.IMPLEMENTS.value,
+    }:
+        return
+    conn.execute(
+        "DELETE FROM edges WHERE source_node_id = ? AND kind = ? "
+        "AND target_node_id = ?",
+        (
+            ref["from_node_id"],
+            ref["reference_kind"],
+            "class:" + str(ref["reference_name"]),
+        ),
+    )
 
 
 def _ref(


### PR DESCRIPTION
## 修复 EXTENDS 边重复（dogfood F4, #1275）

**问题**：差分验证发现 146 个文件的每条跨文件基类边生成 2 条 EXTENDS 边（预期 328、实际 536）——索引时写入通用占位边 + 第二遍解析后插入的符号边并存。

**改动**：`cache/unresolved.py` 第二遍解析成功时，先删除该 (source, kind, parent) 的通用 `class:` 占位边，再 upsert 解析边。未解析的基类（外部/歧义）保留占位边（58 条，符合预期）。

**验证**：自身索引 extends 536 → 328（58 个占位保留）；新增回归测试 `test_resolved_extends_replaces_generic_placeholder`（12 个跨文件继承全部解析且无占位残留）。