### PR TITLE
fix(indexing): resolve call edges only from the complete index

### DIFF
--- a/tests/unit/test_synapse_resolution.py
+++ b/tests/unit/test_synapse_resolution.py
@@ -272,6 +272,37 @@ class TestResolveCrossFile:
         finally:
             cache.close()
 
+    def test_import_pins_same_named_callee_file(self, tmp_path: Path) -> None:
+        # #1275 (dogfood F3): a same-named helper in several files must resolve
+        # to the file the caller actually imports, not the first by sort order.
+        # The imported module is indexed AFTER the caller (zz > caller > aa),
+        # which used to break import resolution and fall back to the global
+        # name table (aa_helpers.py winning by file-path order).
+        proj = tmp_path / "synapse_pkg"
+        proj.mkdir(parents=True, exist_ok=True)
+        (proj / "__init__.py").write_text("# pkg\n")
+        (proj / "aa_helpers.py").write_text("def helper():\n    return 'aa'\n")
+        (proj / "caller.py").write_text(
+            "from .zz_helpers import helper\n\ndef run():\n    return helper()\n"
+        )
+        (proj / "zz_helpers.py").write_text("def helper():\n    return 'zz'\n")
+        cache = ASTCache(str(tmp_path))
+        try:
+            cache.index_project()
+            with _open_db(cache) as conn:
+                row = conn.execute(
+                    "SELECT callee_resolved_file FROM edges "
+                    "WHERE kind='calls' AND file_path LIKE 'synapse_pkg/caller.py' "
+                    "AND callee_name='helper'"
+                ).fetchone()
+                assert row is not None, "expected caller -> helper edge"
+                assert row["callee_resolved_file"].endswith("zz_helpers.py"), (
+                    "imported zz_helpers.helper must win over aa_helpers.helper, "
+                    f"got {row['callee_resolved_file']}"
+                )
+        finally:
+            cache.close()
+
     def test_qualified_call_module_alias(self, tmp_path: Path) -> None:
         """`bb.baz()` after `from . import b as bb` resolves to b.py."""
         proj = _make_pkg(tmp_path, ["module_alias.py", "b.py"])

--- a/tree_sitter_analyzer/cache/indexer_io.py
+++ b/tree_sitter_analyzer/cache/indexer_io.py
@@ -146,7 +146,11 @@ def parse_and_write(
             "reason": "graph edge write failed",
             "certification_errors": 1,
         }
-    cache._resolve_call_edges_for_file(conn, rel_path)  # noqa: SLF001
+    # Cross-file resolution is deferred to the call-graph pipeline: the
+    # per-file index pass sees only the files indexed so far, so import
+    # targets for later files are unresolvable and same-named symbols in
+    # other files win by sort order (dogfood F3, #1275). The pipeline runs
+    # with the complete index and resolves every edge correctly.
     conn.commit()
     return {
         "file": rel_path,


### PR DESCRIPTION
## 修复跨文件调用错指（dogfood F3, #1275）

**问题**：差分验证发现 19 条跨文件调用解析到错误的同名定义（如 `cache/_symbol_declarations.py` 调用 `_node_text`——import 自 `cache/_symbol_syntax.py`——被指到 `_uml_state_helpers.py`；`add_output_options` 被指到 `find_and_grep_cli_helpers.py` 而非 import 的 `search_content_cli_helpers.py`）。

**根因**：单文件索引阶段立即解析调用边，但 `module_to_file`（由 `ast_index` 构建）缺少**尚未索引**的文件 → 相对 import 目标解析失败 → 退化为全局同名表按文件路径排序选择 → 错指。而 call-graph pipeline（数据完整）只重扫 `unknown` 边，无法纠正已标 `project` 的错误。

**修复**：`cache/indexer_io.py` 删除每文件解析步骤——跨文件解析统一由 pipeline 在完整索引上执行一次。语义：索引只负责提取与写库，解析收敛于单一完整数据源。

**验证**：
- 自身索引差分：calls_missing 28 → 9（剩余 9 条均为"本地定义遮蔽 import"的正确场景，如 `incremental_sync.get_changes` 内调用同名 import——本地优先）
- 三个铁证案例全部修复（`_node_text`→`_symbol_syntax.py`、`add_output_options`→`search_content_cli_helpers.py`、`is_language_supported`→`language_detector.py`）
- 新增回归测试：目标文件晚于 caller 索引时，import 必须赢过按文件序排前的同名干扰文件
- 快速门 1992 不变；相关测试 90+ passed