### PR TITLE
docs: record dogfood session completion and Windows CI re-analysis

### DIFF
--- a/HANDOFF-2026-08-15.md
+++ b/HANDOFF-2026-08-15.md
@@ -72,6 +72,20 @@
 3. 或直接开 NO1-010A(§5)
 4. 新对话结束时,把本文件标记完成/删除,并更新 STATE.md
 
+## 8. 后续会话更新（2026-08-15 晚，dogfood 会话）
+
+**§1 Windows constraint_check —— 已重新定位（未修复）**：
+- 当前失败集中在 `test_constraint_index_snapshot_budget/faults.py`（CONCURRENT_WRITER 误报、sidecar 计数 1 vs 3）与 `test_constraint_check_execution.py`；Windows 3.11 绿、3.12/3.13 红（Python 版本相关）。
+- 新线索：`path_matches_pinned_database`（index_snapshot_capability.py:142）用 `os.stat("index.db", dir_fd=cache_fd)` 比较 (st_dev, st_ino)——Windows 上 dir_fd 支持有限 + 3.12+ 行为差异，疑似 CONCURRENT_WRITER 误报根因；`build_in_progress`（cache/build_state.py:111）为另一嫌疑。需 Windows 环境或 CI 迭代验证。
+
+**§2 T-1 禁名测试 —— 已清理 7 删 1 改名（#1280）**，剩余 UNIQUE 内容文件 70+ 待逐文件 triage（非时间瓶颈）。
+
+**§5 路线图**：NO1-010A 仍未开始。
+
+**dogfood 差分验证（#1275）遗留 F1–F5 全部修复并合并**：F1/F2 import 索引（#1279）、F4 extends 去重（#1282）、F5 import 行号（#1281）、F3 synapse 完整索引解析（#1283）。自索引差分最终状态：symbols 100%、imports 7836/7836、calls 错指 28→9（剩余 9 条为本地遮蔽 import 的正确场景）、extends 328=328。
+
+**遗留**：Windows §1（见上）、NO1-010A、STATE.md 更新、剩余 T-1 文件。
+
 ## 7. 关键命令速查
 
 ```bash


### PR DESCRIPTION
Updates HANDOFF-2026-08-15.md with the dogfood session outcome (F1-F5 all fixed and merged: #1279-#1283) and a re-analysis of the Windows 3.12/3.13 constraint_check failures (CONCURRENT_WRITER misreport likely tied to dir_fd usage in path_matches_pinned_database; 3.11 green suggests a Python-version-specific difference). Remaining: Windows fix, NO1-010A, remaining T-1 files.