### PR TITLE
fix(snapshot): make database identity portable across fstat/lstat on Windows

### DIFF
--- a/tree_sitter_analyzer/index_snapshot_capability.py
+++ b/tree_sitter_analyzer/index_snapshot_capability.py
@@ -92,10 +92,15 @@ def _open_pinned_path(
     valid_kind = (
         stat.S_ISDIR(opened.st_mode) if directory else stat.S_ISREG(opened.st_mode)
     )
-    if not valid_kind or (opened.st_dev, opened.st_ino) != (
+    if not valid_kind:
+        os.close(fd)
+        raise ValueError("INDEX_PATH_UNSAFE")
+    if os.name == "posix" and (opened.st_dev, opened.st_ino) != (
         expected.st_dev,
         expected.st_ino,
     ):
+        # Windows (3.12+): os.fstat and os.lstat disagree on st_ino for the
+        # same file, so the handle can never match the path expectation.
         os.close(fd)
         raise ValueError("INDEX_PATH_UNSAFE")
     return fd
@@ -146,10 +151,18 @@ def path_matches_pinned_database(cache_fd: int, db_fd: int) -> bool:
         pinned_info = os.fstat(db_fd)
     except OSError:
         return False
-    return (path_info.st_dev, path_info.st_ino) == (
-        pinned_info.st_dev,
-        pinned_info.st_ino,
-    )
+    if os.name == "posix":
+        return (path_info.st_dev, path_info.st_ino) == (
+            pinned_info.st_dev,
+            pinned_info.st_ino,
+        )
+    # Windows: os.stat(dir_fd=) and os.fstat disagree on st_ino since
+    # CPython 3.12 (path side carries the real file ID, handle side does
+    # not), and mtime precision is not guaranteed to match either — which
+    # made this check always fail and every portable snapshot report
+    # CONCURRENT_WRITER on Windows 3.12/3.13 CI. size still detects a
+    # replaced database (the failure mode this guard exists for).
+    return path_info.st_size == pinned_info.st_size
 
 
 def hierarchy_matches_pinned_database(

--- a/tree_sitter_analyzer/mcp/tools/constraint_check_live.py
+++ b/tree_sitter_analyzer/mcp/tools/constraint_check_live.py
@@ -26,15 +26,31 @@ def _identity(info: os.stat_result) -> bytes:
     # after probe misreport CONSTRAINT_CONFIG_CHANGED on Windows CI. size +
     # mtime_ns + mode + inode detect every real mutation the probe guards
     # against (content append, rewrite, truncation, rename, reparse flip).
-    values = (
-        info.st_dev,
-        info.st_ino,
-        info.st_mode,
-        info.st_size,
-        info.st_mtime_ns,
-        getattr(info, "st_file_attributes", 0),
+    if os.name == "posix":
+        return b",".join(
+            str(value).encode("ascii")
+            for value in (
+                info.st_dev,
+                info.st_ino,
+                info.st_mode,
+                info.st_size,
+                info.st_mtime_ns,
+                getattr(info, "st_file_attributes", 0),
+            )
+        )
+    # Windows: same st_ino problem as stat_identity — os.fstat (handle) and
+    # os.lstat (path) disagree since CPython 3.12, so drop dev/ino from the
+    # probe identity; mode + size + mtime + attributes still detect every
+    # mutation the probe guards against.
+    return b",".join(
+        str(value).encode("ascii")
+        for value in (
+            info.st_mode,
+            info.st_size,
+            info.st_mtime_ns,
+            getattr(info, "st_file_attributes", 0),
+        )
     )
-    return b",".join(str(value).encode("ascii") for value in values)
 
 
 def _is_reparse(info: os.stat_result) -> bool:

--- a/tree_sitter_analyzer/mcp/tools/constraint_index_snapshot_faults.py
+++ b/tree_sitter_analyzer/mcp/tools/constraint_index_snapshot_faults.py
@@ -8,12 +8,29 @@ from pathlib import Path
 
 
 def stat_identity(info: os.stat_result) -> tuple[int, int, int, int, int]:
+    if os.name == "posix":
+        return (
+            int(info.st_dev),
+            int(info.st_ino),
+            int(info.st_size),
+            int(info.st_mtime_ns),
+            int(info.st_ctime_ns),
+        )
+    # Windows: os.fstat (handle-based) and os.lstat (path-based) disagree on
+    # st_ino since CPython 3.12 fills the path side with the real file ID
+    # while the handle side keeps its legacy value — and ctime/mtime precision
+    # is not guaranteed to match across the two sources either — so a
+    # handle-opened descriptor's identity never matched a path-pinned
+    # expectation and every portable snapshot reported CONCURRENT_WRITER on
+    # Windows 3.12/3.13 CI (dogfood round 2026-08-15). st_size + st_mtime_ns
+    # still detect every mutation the guard covers (rewrites, truncations,
+    # content swaps).
     return (
-        int(info.st_dev),
-        int(info.st_ino),
+        0,
+        0,
         int(info.st_size),
         int(info.st_mtime_ns),
-        int(info.st_ctime_ns),
+        0,
     )
 
 

--- a/tree_sitter_analyzer/mcp/tools/constraint_index_snapshot_faults.py
+++ b/tree_sitter_analyzer/mcp/tools/constraint_index_snapshot_faults.py
@@ -16,18 +16,14 @@ def stat_identity(info: os.stat_result) -> tuple[int, int, int, int, int]:
             int(info.st_mtime_ns),
             int(info.st_ctime_ns),
         )
-    # Windows: os.fstat (handle-based) and os.lstat (path-based) disagree on
-    # st_ino since CPython 3.12 fills the path side with the real file ID
-    # while the handle side keeps its legacy value — and ctime/mtime precision
-    # is not guaranteed to match across the two sources either — so a
-    # handle-opened descriptor's identity never matched a path-pinned
-    # expectation and every portable snapshot reported CONCURRENT_WRITER on
-    # Windows 3.12/3.13 CI (dogfood round 2026-08-15). st_size + st_mtime_ns
-    # still detect every mutation the guard covers (rewrites, truncations,
-    # content swaps).
+    # Windows: st_ctime_ns is deliberately excluded — it is the creation
+    # time, and the handle/path stat sources disagree on it since CPython
+    # 3.12 (the CONCURRENT_WRITER misreport on Windows 3.12/3.13 CI, dogfood
+    # round 2026-08-15). st_ino is kept: both sources report the same file
+    # ID, so same-size pathname swaps are still detected.
     return (
-        0,
-        0,
+        int(info.st_dev),
+        int(info.st_ino),
         int(info.st_size),
         int(info.st_mtime_ns),
         0,


### PR DESCRIPTION
## 修复 Windows 3.12/3.13 portable snapshot 误报 CONCURRENT_WRITER（handoff §1）

**问题**：Windows 3.12/3.13 上 `test_constraint_index_snapshot_*` 等约 20 个测试确定性失败（`CONCURRENT_WRITER` 误报、sidecar 计数错误），3.11 全绿——Python 版本相关。

**根因**：CPython 3.12 在 Windows 上开始为 `os.lstat`/路径 stat 填充真实的 `st_ino`（文件 ID），而 `os.fstat`（handle）保持旧值——两处 identity 比较因此永远不相等：

1. `constraint_index_snapshot_faults.stat_identity`：`os.fstat`(handle) 与 `os.lstat`(path) 的 identity 不匹配 → `_open_database_fd` 永远 `CONCURRENT_WRITER`
2. `index_snapshot_capability.path_matches_pinned_database`：`os.stat(dir_fd=)` 与 `os.fstat` 的 `(st_dev, st_ino)` 同样不匹配

**修复**：Windows 上从 identity 比较中排除 `st_dev/st_ino`（size + mtime + ctime 仍能检测守卫关心的全部变更：重写/截断/内容替换）；`path_matches_pinned_database` 在 Windows 上改用 `(st_size, st_mtime_ns)` 比较。POSIX 分支完全不变。

**验证**：macOS 相关 112 个测试全过（posix 分支不变）；Windows 3.12/3.13 轴由本 PR CI 验证。