### PR TITLE
test: drop assertion-free should-not-raise tests across banned files

### DIFF
--- a/tests/integration/formatters/test_comprehensive_format_validation.py
+++ b/tests/integration/formatters/test_comprehensive_format_validation.py
@@ -354,37 +354,6 @@ class TestComprehensiveFormatValidation:
         assert retrieved_data is not None
         assert retrieved_data.metadata.id == test_id
 
-    @pytest.mark.asyncio
-    async def test_integration_with_real_components(self, temp_results_dir):
-        """Test integration with real tree-sitter-analyzer components if available"""
-        try:
-            # Try to import real analyzer components
-            from tree_sitter_analyzer.core.analysis_engine import (  # noqa: F401
-                AnalysisEngine,
-            )
-            from tree_sitter_analyzer.formatters.formatter_registry import (  # noqa: F401
-                FormatterRegistry,
-            )
-
-            # If available, test with real components
-            config = FormatTestSuiteConfig(
-                results_directory=temp_results_dir,
-                generate_test_data=False,
-                enable_performance_tests=False,
-                enable_integration_tests=False,
-                enable_end_to_end_tests=False,
-                enable_cross_component_tests=False,
-            )
-
-            ComprehensiveFormatTestSuite(config)
-
-            # Simple test with real components would go here
-            # This is a placeholder for when real integration is needed
-
-        except ImportError:
-            # If real components not available, skip this test
-            pytest.skip("Real tree-sitter-analyzer components not available")
-
     def test_results_serialization(self, temp_results_dir):
         """Test that results can be properly serialized and saved"""
         from .comprehensive_test_suite import TestSuiteResults

--- a/tests/unit/core/test_analysis_engine_branch_coverage.py
+++ b/tests/unit/core/test_analysis_engine_branch_coverage.py
@@ -23,12 +23,6 @@ def reset_engine_instances():
 class TestCleanupCoverage:
     """Hit cleanup paths that require _ensure_initialized first (lines 402-404)"""
 
-    def test_cleanup_with_initialized_components(self):
-        """cleanup should clear cache and performance monitor when initialized"""
-        engine = get_analysis_engine()
-        engine._ensure_initialized()
-        engine.cleanup()  # lines 402, 404
-
 
 class TestCacheKeyCoverage:
     """Hit exception paths in _generate_cache_key (lines 372-373)"""

--- a/tests/unit/core/test_tree_sitter_compat_coverage.py
+++ b/tests/unit/core/test_tree_sitter_compat_coverage.py
@@ -8,7 +8,6 @@ from tree_sitter_analyzer.utils.tree_sitter_compat import (
     TreeSitterQueryCompat,
     create_query_safely,
     get_node_text_safe,
-    log_api_info,
 )
 
 
@@ -297,81 +296,6 @@ class TestTreeSitterCompatCoverage:
 
         text = get_node_text_safe(mock_node, "source")
         assert text == ""
-
-    def test_log_api_info(self):
-        """Test log_api_info"""
-        # Test modern API present
-        with patch.dict(sys.modules, {"tree_sitter": MagicMock()}):
-            sys.modules["tree_sitter"].Query.matches = lambda: None
-            log_api_info()
-
-        # Test legacy API present
-        with patch.dict(sys.modules, {"tree_sitter": MagicMock()}):
-            del sys.modules["tree_sitter"].Query.matches
-            sys.modules["tree_sitter"].Query.captures = lambda: None
-            log_api_info()
-
-        # Test no compatible API
-        with patch.dict(sys.modules, {"tree_sitter": MagicMock()}):
-            del sys.modules["tree_sitter"].Query.matches
-            del sys.modules["tree_sitter"].Query.captures
-            log_api_info()
-
-    def test_log_api_info_import_error(self):
-        """Test log_api_info when tree-sitter import fails (covers lines 288-289)"""
-        import builtins
-
-        original_import = builtins.__import__
-
-        def mock_import(name, *args, **kwargs):
-            if name == "tree_sitter":
-                raise ImportError("No module named 'tree_sitter'")
-            return original_import(name, *args, **kwargs)
-
-        # Temporarily remove tree_sitter from sys.modules and mock import
-        saved_module = sys.modules.get("tree_sitter")
-        try:
-            if "tree_sitter" in sys.modules:
-                del sys.modules["tree_sitter"]
-
-            with patch.object(builtins, "__import__", side_effect=mock_import):
-                # This should handle ImportError gracefully
-                log_api_info()
-        finally:
-            # Restore tree_sitter module if it was present
-            if saved_module is not None:
-                sys.modules["tree_sitter"] = saved_module
-
-    def test_log_api_info_api_detection_exception(self):
-        """Test log_api_info when API detection raises an exception (covers lines 285-286)"""
-        mock_tree_sitter = MagicMock()
-
-        # Make accessing Query raise an exception
-        # This simulates an error during API detection
-        type(mock_tree_sitter).Query = property(
-            lambda self: (_ for _ in ()).throw(Exception("API detection error"))
-        )
-
-        with patch.dict(sys.modules, {"tree_sitter": mock_tree_sitter}):
-            # This should handle the exception gracefully
-            log_api_info()
-
-    def test_log_api_info_api_detection_exception_via_dir(self):
-        """Test log_api_info when dir() on Query raises an exception (covers lines 285-286)"""
-        # Create a mock that raises exception when accessing Query attribute
-        mock_tree_sitter = MagicMock()
-
-        # Create a class that raises exception when dir() is called
-        class QueryThatFailsOnDir:
-            @staticmethod
-            def __dir__():
-                raise RuntimeError("dir() failed")
-
-        mock_tree_sitter.Query = QueryThatFailsOnDir
-
-        with patch.dict(sys.modules, {"tree_sitter": mock_tree_sitter}):
-            # This should handle the exception gracefully
-            log_api_info()
 
     def test_execute_modern_api_exception_raises(self):
         """Test _execute_modern_api exception handling (covers lines 102-104)"""

--- a/tests/unit/formatters/test_cpp_formatter_coverage.py
+++ b/tests/unit/formatters/test_cpp_formatter_coverage.py
@@ -269,28 +269,6 @@ def test_format_table_json(formatter):
 # --- format_advanced: csv and full_table paths ---
 
 
-def test_format_advanced_csv(formatter):
-    """Cover format_advanced csv path."""
-    data = {
-        "file_path": "t.cpp",
-        "language": "cpp",
-        "methods": [{"name": "f", "return_type": "void", "parameters": []}],
-    }
-    output = formatter.format_advanced(data, "csv")
-    assert output  # csv output produced
-
-
-def test_format_advanced_full(formatter):
-    """Cover format_advanced non-json, non-csv → _format_full_table path."""
-    data = {
-        "file_path": "t.cpp",
-        "language": "cpp",
-        "methods": [{"name": "f", "return_type": "void", "parameters": []}],
-    }
-    output = formatter.format_advanced(data, "full")
-    assert output
-
-
 # --- _convert_function_element: parameter formats ---
 
 

--- a/tests/unit/languages/test_markdown_plugin_coverage_supplement.py
+++ b/tests/unit/languages/test_markdown_plugin_coverage_supplement.py
@@ -695,28 +695,6 @@ class TestMarkdownLinkRefDefinitions:
         self.extractor._processed_nodes = set()
         self.extractor._element_cache = {}
 
-    def test_extract_link_reference_defs_success(self):
-        """Test link reference definition extraction success (lines 955-980)"""
-        from unittest.mock import Mock
-
-        mock_root = Mock()
-        mock_root.children = []
-
-        ref_node = Mock()
-        ref_node.children = []
-        ref_node.type = "link_reference_definition"
-        ref_node.start_point = (0, 0)
-        ref_node.end_point = (0, 35)
-        ref_node.start_byte = 0
-        ref_node.end_byte = 35
-
-        mock_root.children = [ref_node]
-
-        refs = []
-        self.extractor._extract_link_reference_definitions(mock_root, refs)
-
-        assert refs
-
 
 class TestMarkdownAllElementsExtract:
     """Tests for extract_all_elements method"""

--- a/tests/unit/languages/test_plugins_coverage.py
+++ b/tests/unit/languages/test_plugins_coverage.py
@@ -256,14 +256,6 @@ class TestDefaultExtractor:
 class TestPluginManagerAdvanced:
     """Test advanced PluginManager functionality"""
 
-    def test_register_plugin_with_exception(self, mocker, plugin_manager_instance):
-        """Test plugin registration with exception"""
-        mock_plugin = mocker.MagicMock()
-        mock_plugin.get_language_name.side_effect = Exception("Test error")
-
-        # Should not raise exception
-        plugin_manager_instance.register_plugin(mock_plugin)
-
     def test_get_plugin_for_file_with_applicable_plugin(
         self, mocker, plugin_manager_instance
     ):

--- a/tests/unit/mcp/test_server_comprehensive_init.py
+++ b/tests/unit/mcp/test_server_comprehensive_init.py
@@ -75,13 +75,6 @@ class TestTreeSitterAnalyzerMCPServerInitialization:
 
             assert server.universal_analyze_tool is None
 
-    def test_ensure_initialized_success(self, temp_project_dir):
-        """Test _ensure_initialized when server is initialized."""
-        server = TreeSitterAnalyzerMCPServer(temp_project_dir)
-
-        # Should not raise any exception
-        server._ensure_initialized()
-
     def test_ensure_initialized_failure(self, temp_project_dir):
         """Test _ensure_initialized when server is not initialized."""
         server = TreeSitterAnalyzerMCPServer(temp_project_dir)

--- a/tests/unit/mcp/test_server_comprehensive_tools.py
+++ b/tests/unit/mcp/test_server_comprehensive_tools.py
@@ -419,17 +419,6 @@ class TestTreeSitterAnalyzerMCPServerProjectPath:
                 new_project_dir
             )
 
-    def test_set_project_path_without_universal_tool(self, temp_project_dir):
-        """Test project path setting without universal tool."""
-        server = TreeSitterAnalyzerMCPServer(temp_project_dir)
-        server.universal_analyze_tool = None
-
-        import tempfile
-
-        with tempfile.TemporaryDirectory() as new_project_dir:
-            # Should not raise any exception
-            server.set_project_path(new_project_dir)
-
 
 class TestTreeSitterAnalyzerMCPServerRuntime:
     """Test MCP server runtime functionality."""

--- a/tests/unit/mcp/test_server_edge_cases.py
+++ b/tests/unit/mcp/test_server_edge_cases.py
@@ -577,37 +577,6 @@ class TestMCPServerUtilityEdgeCases:
                     with pytest.raises(SystemExit):
                         await main()
 
-    @pytest.mark.asyncio
-    async def test_main_with_environment_variable_issues(self):
-        """Test main function with problematic environment variables."""
-        with patch.dict(os.environ, {"TREE_SITTER_PROJECT_ROOT": "${invalid}"}):
-            with patch("tree_sitter_analyzer.mcp.server.parse_mcp_args") as mock_parse:
-                mock_args = Mock()
-                mock_args.project_root = None
-                mock_parse.return_value = mock_args
-
-                with patch(
-                    "tree_sitter_analyzer.mcp.server.detect_project_root"
-                ) as mock_detect:
-                    mock_detect.return_value = "/fallback/path"
-
-                    with patch(
-                        "tree_sitter_analyzer.mcp.server.TreeSitterAnalyzerMCPServer"
-                    ) as mock_server_class:
-                        mock_server = AsyncMock()
-                        mock_server_class.return_value = mock_server
-                        mock_server.run.side_effect = KeyboardInterrupt()
-
-                        with (
-                            patch("sys.stdin"),
-                            patch("sys.stdout"),
-                            patch("sys.stderr"),
-                        ):
-                            try:
-                                await main()
-                            except SystemExit:
-                                pass  # Expected for KeyboardInterrupt handling
-
     def test_main_sync_with_exception(self):
         """Test synchronous main function with exception."""
         with patch("tree_sitter_analyzer.mcp.server.asyncio.run") as mock_run:
@@ -643,25 +612,3 @@ class TestMCPServerLoggingEdgeCases:
                 # Should not raise exception even if logging fails
                 server = TreeSitterAnalyzerMCPServer(temp_project_dir)
                 assert server.is_initialized()
-
-    @pytest.mark.asyncio
-    async def test_tool_call_with_logging_failure(self, temp_project_dir):
-        """Test tool calls when logging fails."""
-        server = TreeSitterAnalyzerMCPServer(temp_project_dir)
-
-        with patch("tree_sitter_analyzer.mcp.server.logger") as mock_logger:
-            mock_logger.info.side_effect = ValueError("Logging failed")
-            mock_logger.error.side_effect = ValueError("Logging failed")
-
-            with patch("sys.stdin"), patch("sys.stdout"), patch("sys.stderr"):
-                # Should handle logging failures gracefully
-                arguments = {"file_path": "non_existent.py"}
-
-                try:
-                    await server._analyze_code_scale(arguments)
-                except FileNotFoundError:
-                    # Expected for non-existent file
-                    pass
-                except ValueError as e:
-                    if "Logging failed" in str(e):
-                        pytest.fail("Should handle logging failures gracefully")

--- a/tests/unit/security/test_boundary_manager_coverage.py
+++ b/tests/unit/security/test_boundary_manager_coverage.py
@@ -228,21 +228,6 @@ class TestIsSymlinkSafe:
 class TestAuditAccess:
     """Tests for audit_access method"""
 
-    def test_audit_allowed_access(self, tmp_path):
-        """Test auditing allowed file access"""
-        file_path = tmp_path / "test.py"
-        file_path.write_text("test")
-
-        manager = ProjectBoundaryManager(str(tmp_path))
-        # Should not raise
-        manager.audit_access(str(file_path), "read")
-
-    def test_audit_denied_access(self, tmp_path):
-        """Test auditing denied file access"""
-        manager = ProjectBoundaryManager(str(tmp_path))
-        # Should not raise
-        manager.audit_access("/etc/passwd", "read")
-
 
 class TestStringRepresentations:
     """Tests for __str__ and __repr__ methods"""

--- a/tests/unit/utils/test_encoding_utils_edge_cases.py
+++ b/tests/unit/utils/test_encoding_utils_edge_cases.py
@@ -112,14 +112,6 @@ class TestEncodingManagerEdge:
         clear_encoding_cache()
         assert get_encoding_cache_size() == 0
 
-    def test_get_encoding_cache_size(self):
-        from tree_sitter_analyzer.encoding_utils import _encoding_cache
-
-        _encoding_cache.set("test.txt", "utf-8")
-        size = get_encoding_cache_size()
-        assert size
-        clear_encoding_cache()
-
     def test_cleanup_expired_on_eviction(self):
         cache = EncodingCache(max_size=2, ttl_seconds=-1)
         cache.set("a.py", "utf-8")

--- a/tests/unit/utils/test_logging_coverage.py
+++ b/tests/unit/utils/test_logging_coverage.py
@@ -16,10 +16,8 @@ from tree_sitter_analyzer.utils.logging import (
     QuietMode,
     SafeStreamHandler,
     create_performance_logger,
-    log_debug,
     logger,
     perf_logger,
-    safe_print,
     setup_logger,
     setup_performance_logger,
     suppress_output,
@@ -124,17 +122,6 @@ class TestSafeStreamHandler:
 class TestLogFunctions:
     """Tests for logging functions"""
 
-    def test_log_debug(self):
-        """Test log_debug function"""
-        # Should not raise — if it does, the test fails
-        log_debug("Test debug message")
-
-    def test_log_debug_with_closed_handler(self):
-        """Test log_debug handles closed handlers gracefully"""
-        with patch.object(logger, "debug", side_effect=OSError("Test error")):
-            # Should not raise, just suppress — if it does, the test fails
-            log_debug("Test message")
-
 
 class TestQuietMode:
     """Tests for QuietMode context manager"""
@@ -162,11 +149,6 @@ class TestQuietMode:
 
 class TestSafePrint:
     """Tests for safe_print function"""
-
-    def test_safe_print_debug(self):
-        """Test safe_print with debug level"""
-        # Should not raise — if it does, the test fails
-        safe_print("Test debug", level="debug")
 
 
 class TestPerformanceLogging:

--- a/tests/unit/utils/test_path_resolver_extended.py
+++ b/tests/unit/utils/test_path_resolver_extended.py
@@ -202,16 +202,6 @@ class TestPathResolverExtended:
         result = self.resolver.is_relative(str(self.test_file))
         assert not result
 
-    def test_is_relative_with_relative_path(self):
-        """Test is_relative method with relative path."""
-        result = self.resolver.is_relative("test.txt")
-        assert result
-
-    def test_is_relative_with_empty_path(self):
-        """Test is_relative method with empty path."""
-        result = self.resolver.is_relative("")
-        assert result
-
     def test_is_relative_with_none_path(self):
         """Test is_relative method with None path."""
         with pytest.raises(TypeError):


### PR DESCRIPTION
## 删除禁名测试文件中的断言空洞测试（T-3 违规）

扫描全部 84 个 T-1 禁名测试文件，用 AST 定位**零行为验证**的测试函数（无 assert / 无 `assert_called*` / 无 `pytest.raises`，或仅 `assert x` 裸名弱断言），删除 13 个文件中的 22 个函数（-261 行）：

- 纯 `should not raise` 型（注释自证）：`test_log_debug`、`test_audit_allowed_access`、`test_ensure_initialized_success` 等
- 裸名弱断言（`assert output` / `assert result` / `assert size`）：`test_format_advanced_csv`、`test_is_relative_with_relative_path`、`test_get_encoding_cache_size` 等

**验证**：受影响 13 文件 186 passed；快速门 1992 passed 不变；全量收集 24956/25056（0 collect 错误）。

说明：其余 62 个禁名文件经三轮扫描（含 helper 断言、`is None` 有效断言、`assert_called` 行为断言）确认**有真实行为验证**，非"无意义测试"——保留（其命名合规化建议列入后续）。