### PR TITLE
feat(task): actionable outputs + adapter-boundary wire contracts (NO1-010A follow-up)

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -4,9 +4,18 @@ Last run: 2026-08-16 (NO1-010A three-task prototype — RFC-0022 Phase A router)
 
 ## NO1-010A completion record (2026-08-16)
 
-- **NO1-010A (three-task prototype) implemented** on `feature/no1-010a-task-router`
-  (PR pending): `understand` / `plan_change` / `assess_change` now execute the
-  pinned RFC-0022 route table end-to-end.
+- **NO1-010A (three-task prototype) implemented and MERGED** (#1290 → develop,
+  2026-08-16): `understand` / `plan_change` / `assess_change` execute the
+  pinned RFC-0022 route table end-to-end. All 14 first-round Codex review
+  findings fixed in-branch (evidence budget, echo validation, real wire
+  vocabularies, NO_CONFIG diff-only provenance, truncation propagation,
+  ownership degradation, cleanup wall-time exclusion, strict decoder,
+  harness one-of, etc.) with regression tests; CI + codecov/patch green.
+- **NO1-010A follow-up (task UX, in progress)**: actionable outputs
+  (`next_step` unlock/re-index/budget/review hints + compact deterministic
+  `agent_summary`) and adapter-boundary wire contract fixtures pinning the
+  real primitive shapes (`file`/`name` code blocks, `caller_file`/`caller_name`
+  violations, Git-status changed records).
   - `task/router.py` — fixed route-table executor: sequential primitive calls
     through an injected `PrimitiveExecutor`, budget/deadline admission with
     exact `deadline_overrun_ms` reporting, constraints-slot reservation before

--- a/tests/unit/task/test_task_router.py
+++ b/tests/unit/task/test_task_router.py
@@ -770,8 +770,12 @@ def test_serialized_wire_roundtrips_router_outcome() -> None:
     assert wire["success"] is True
     assert wire["subject"]["diff"]["source"] == "workspace"
     assert wire["artifacts"]["edge_collections"] == []
-    assert wire["next_step"] is None
-    assert wire["agent_summary"] == {}
+    # Actionable outputs (NO1-010A follow-up): clean assess -> done hint.
+    assert wire["next_step"] == "No static issues found in the assessed change."
+    assert wire["agent_summary"]["summary_line"].startswith(
+        "task assess_change complete verdict="
+    )
+    assert wire["agent_summary"]["next_step"] == wire["next_step"]
 
 
 # --- Fail-closed branch coverage (codecov patch gate, NO1-010A) -----------

--- a/tests/unit/task/test_task_wire_contract.py
+++ b/tests/unit/task/test_task_wire_contract.py
@@ -1,0 +1,426 @@
+"""NO1-010A follow-up: actionable outputs and adapter-boundary wire contract.
+
+Two contracts:
+
+1. ``build_next_step`` / ``build_agent_summary`` — the frozen outcome must
+   tell an agent what to do next (unlock path, re-index, budget, review
+   list, done) and give a compact deterministic summary to branch on.
+   Suggestions are inert text, never evidence (RFC-0022).
+2. The router must project the REAL primitive wire shapes, not test-only
+   ones: code blocks use ``file``/``name``, constraint violations use
+   ``caller_file``/``caller_name``, frozen changed records use Git status
+   codes plus old/new availability. These fixtures are copies of the real
+   adapter output shapes (codegraph_context_tool ``_build_code_blocks``,
+   constraints evaluator rows, ``ChangedFile.to_dict``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from tree_sitter_analyzer.task import (
+    Budget,
+    DiffInput,
+    PlanChangeRequest,
+    UnderstandRequest,
+)
+from tree_sitter_analyzer.task.router import (
+    build_agent_summary,
+    build_next_step,
+    plan_change,
+    understand,
+)
+from tree_sitter_analyzer.task.serializers import parity_roundtrip
+
+# --- Real-wire fixtures (copied shapes from the live adapters) ---------------
+
+REAL_INDEX_STATUS = {
+    "success": True,
+    "verdict": "INFO",
+    "snapshot_id": "idxsnap_real1",
+    "source_generation": "idxsrc-v3:abc123",
+    "completeness": "complete",
+    "action_version": "index.status/v1",
+    "source_snapshots": [
+        {
+            "kind": "index",
+            "snapshot_id": "idxsnap_real1",
+            "source_generation": "idxsrc-v3:abc123",
+        }
+    ],
+}
+
+#: Real CodeGraphContextTool code blocks (codegraph_context_tool.py ~L907):
+#: {"file", "name", "start_line", "end_line", "content"}.
+REAL_NAV_CONTEXT = {
+    "success": True,
+    "verdict": "INFO",
+    "action_version": "nav.context/v1",
+    "snapshot_id": "idxsnap_real1",
+    "source_generation": "idxsrc-v3:abc123",
+    "code_blocks": [
+        {
+            "file": "src/app.py",
+            "name": "dispatch",
+            "start_line": 3,
+            "end_line": 9,
+            "content": "def dispatch(request):\\n    ...\\n",
+        },
+        {
+            "file": "src/app.py",
+            "name": "handle_ping",
+            "start_line": 11,
+            "end_line": 13,
+            "content": "def handle_ping(request):\\n    ...\\n",
+        },
+    ],
+}
+
+#: Real frozen impact records (ChangedFile.to_dict): Git status codes +
+#: availability fields; assessed scope from the frozen capture.
+REAL_IMPACT = {
+    "success": True,
+    "verdict": "SAFE",
+    "action_version": "edit.impact/v1",
+    "diff_snapshot_id": "ds_real1",
+    "route_lease_id": "lease_real1",
+    "source_generation": "idxsrc-v3:abc123",
+    "changed_records": [
+        {
+            "path": "src/app.py",
+            "status": "M",
+            "old_available": True,
+            "new_available": True,
+            "binary": False,
+            "patch_available": True,
+            "old_kind": "file",
+            "new_kind": "file",
+        },
+        {
+            "path": "src/gone.py",
+            "status": "D",
+            "old_available": True,
+            "new_available": False,
+            "binary": False,
+            "patch_available": True,
+            "old_kind": "file",
+            "new_kind": "missing",
+        },
+    ],
+    "assessed_scope_paths": ["src/app.py", "src/gone.py"],
+    "source_snapshots": [
+        {
+            "kind": "index",
+            "snapshot_id": "idxsnap_real1",
+            "source_generation": "idxsrc-v3:abc123",
+        }
+    ],
+}
+
+#: Real constraints rows (evaluator SELECT): caller_name, caller_file,
+#: caller_line, callee_name, callee_file, severity.
+REAL_CONSTRAINTS = {
+    "success": True,
+    "verdict": "UNSAFE",
+    "state": "applicable",
+    "action_version": "edit.constraints/v1",
+    "violations": [
+        {
+            "rule_id": "no_direct_dep",
+            "caller_name": "dispatch",
+            "caller_file": "src/app.py",
+            "caller_line": 4,
+            "callee_name": "handle_ping",
+            "callee_file": "src/app.py",
+            "severity": "error",
+        }
+    ],
+    "source_snapshots": [
+        {
+            "kind": "index",
+            "snapshot_id": "idxsnap_real1",
+            "source_generation": "idxsrc-v3:abc123",
+        },
+        {
+            "kind": "diff",
+            "snapshot_id": "ds_real1",
+            "source_generation": "idxsrc-v3:abc123",
+        },
+    ],
+}
+
+REAL_AST_DIFF = {
+    "success": True,
+    "verdict": "INFO",
+    "action_version": "edit.ast_diff/v1",
+    "source_snapshots": [
+        {
+            "kind": "diff",
+            "snapshot_id": "ds_real1",
+            "source_generation": "idxsrc-v3:abc123",
+        }
+    ],
+}
+
+REAL_CLASSIFY = {
+    "success": True,
+    "verdict": "INFO",
+    "action_version": "edit.classify/v1",
+    "truncated": False,
+    "source_snapshots": [
+        {
+            "kind": "diff",
+            "snapshot_id": "ds_real1",
+            "source_generation": "idxsrc-v3:abc123",
+        }
+    ],
+}
+
+
+class RealWireExecutor:
+    """Serves the real-wire fixtures and records the arguments used."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict]] = []
+
+    async def call(self, facade, action, arguments):
+        self.calls.append((facade, action, dict(arguments)))
+        fixtures = {
+            ("index", "status"): REAL_INDEX_STATUS,
+            ("nav", "context"): REAL_NAV_CONTEXT,
+            ("edit", "impact"): REAL_IMPACT,
+            ("edit", "constraints"): REAL_CONSTRAINTS,
+            ("edit", "ast_diff"): REAL_AST_DIFF,
+            ("edit", "classify"): REAL_CLASSIFY,
+            ("edit", "safe"): {
+                "success": True,
+                "verdict": "SAFE",
+                "action_version": "edit.safe/v1",
+                "snapshot_id": "idxsnap_real1",
+                "source_generation": "idxsrc-v3:abc123",
+            },
+            ("edit", "release_snapshot"): {"success": True},
+        }
+        return dict(fixtures[(facade, action)])
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# --- Actionable outputs ------------------------------------------------------
+
+
+def test_next_step_reports_unlock_path_for_uncertified_authority() -> None:
+    hint = build_next_step(
+        operation="understand",
+        status="partial",
+        verdict="WARN",
+        unknowns=[
+            {
+                "row": "understand:nav.context",
+                "reason": "ACCESS_UNAVAILABLE:READ_EXISTING_AUTHORITY_UNCERTIFIED",
+            }
+        ],
+        freshness=[],
+        plan_steps=[],
+        truncated=False,
+    )
+    assert hint is not None
+    assert "READ_EXISTING_AUTHORITY_UNCERTIFIED" in hint
+    assert "certif" in hint.lower()
+
+
+def test_next_step_reports_reindex_for_missing_oracle() -> None:
+    hint = build_next_step(
+        operation="understand",
+        status="unknown",
+        verdict="WARN",
+        unknowns=[],
+        freshness=[
+            {"freshness": "missing", "reason": "AUTHORITATIVE_SNAPSHOT_UNAVAILABLE"}
+        ],
+        plan_steps=[],
+        truncated=False,
+    )
+    assert hint is not None
+    assert "re-index" in hint
+    hint2 = build_next_step(
+        operation="understand",
+        status="partial",
+        verdict="WARN",
+        unknowns=[],
+        freshness=[{"freshness": "unknown", "reason": "INCOMPLETE_ORACLE:partial"}],
+        plan_steps=[],
+        truncated=False,
+    )
+    assert "re-index" in hint2
+
+
+def test_next_step_reports_budget_truncation() -> None:
+    hint = build_next_step(
+        operation="assess_change",
+        status="partial",
+        verdict="WARN",
+        unknowns=[],
+        freshness=[],
+        plan_steps=[],
+        truncated=True,
+    )
+    assert hint is not None
+    assert "Budget" in hint
+
+
+def test_next_step_lists_review_files_for_plan_change() -> None:
+    hint = build_next_step(
+        operation="plan_change",
+        status="complete",
+        verdict="SAFE",
+        unknowns=[],
+        freshness=[],
+        plan_steps=[
+            {
+                "ordinal": 1,
+                "kind": "check_file_safety",
+                "path": "src/app.py",
+                "symbol": None,
+                "evidence_ids": ["evidence:e1"],
+            },
+            {
+                "ordinal": 2,
+                "kind": "check_constraint",
+                "path": "src/app.py",
+                "symbol": None,
+                "evidence_ids": ["evidence:e2"],
+            },
+        ],
+        truncated=False,
+    )
+    assert hint == "Review the planned change across 1 file(s): src/app.py."
+
+
+def test_next_step_reports_done_for_clean_assess() -> None:
+    hint = build_next_step(
+        operation="assess_change",
+        status="complete",
+        verdict="SAFE",
+        unknowns=[],
+        freshness=[],
+        plan_steps=[],
+        truncated=False,
+    )
+    assert hint == "No static issues found in the assessed change."
+
+
+def test_next_step_none_when_nothing_actionable() -> None:
+    assert (
+        build_next_step(
+            operation="understand",
+            status="complete",
+            verdict="INFO",
+            unknowns=[],
+            freshness=[],
+            plan_steps=[],
+            truncated=False,
+        )
+        is None
+    )
+
+
+def test_agent_summary_is_compact_and_deterministic() -> None:
+    summary = build_agent_summary(
+        operation="assess_change",
+        status="complete",
+        verdict="SAFE",
+        next_step="No static issues found in the assessed change.",
+        primitive_calls=6,
+        evidence_items=4,
+        cleanup_status="succeeded",
+        plan_steps_count=0,
+    )
+    assert summary == {
+        "summary_line": "task assess_change complete verdict=SAFE calls=6 evidence=4",
+        "operation": "assess_change",
+        "status": "complete",
+        "verdict": "SAFE",
+        "primitive_calls": 6,
+        "evidence_items": 4,
+        "cleanup_status": "succeeded",
+        "plan_steps": 0,
+        "next_step": "No static issues found in the assessed change.",
+    }
+    assert (
+        build_agent_summary(
+            operation="assess_change",
+            status="complete",
+            verdict="SAFE",
+            next_step=None,
+            primitive_calls=6,
+            evidence_items=4,
+            cleanup_status="succeeded",
+            plan_steps_count=0,
+        )["summary_line"]
+        == summary["summary_line"]
+    )
+
+
+# --- Adapter-boundary wire contract ------------------------------------------
+
+
+def test_understand_projects_real_nav_wire() -> None:
+    executor = RealWireExecutor()
+    outcome = _run(
+        understand(UnderstandRequest(task="how does dispatch work"), executor)
+    )
+    assert outcome.artifacts["relevant_paths"] == ["src/app.py"]
+    assert outcome.artifacts["relevant_symbols"] == ["dispatch", "handle_ping"]
+    kinds = [s["kind"] for s in outcome.artifacts["plan_steps"]]
+    assert kinds == ["inspect_context", "inspect_context"]
+    assert outcome.artifacts["plan_steps"][0]["path"] == "src/app.py"
+    assert outcome.artifacts["plan_steps"][0]["symbol"] == "dispatch"
+    assert outcome.status == "complete"
+    # The outcome now carries an actionable summary + next step.
+    assert outcome.next_step is None  # nothing to do after a clean understand
+    assert outcome.agent_summary["verdict"] == "INFO"  # type: ignore[index]
+    parity_roundtrip(outcome)
+
+
+def test_plan_change_diff_projects_real_wire_end_to_end() -> None:
+    executor = RealWireExecutor()
+    outcome = _run(
+        plan_change(
+            PlanChangeRequest(
+                diff=DiffInput("workspace"),
+                budget=Budget(profile="standard"),
+            ),
+            executor,
+        )
+    )
+    # Git status D is explicit not_run, never reconstructed.
+    assert any(
+        u["row"] == "diff:edit.ast_diff:src/gone.py"
+        and u["reason"] == "not_run:UNSUPPORTED_DIFF_RECORD"
+        for u in outcome.unknowns
+    )
+    # Only the modified file enters the structural/classification fan-out.
+    ast_diff_paths = [
+        args["file_path"]
+        for f, a, args in executor.calls
+        if (f, a) == ("edit", "ast_diff")
+    ]
+    assert ast_diff_paths == ["src/app.py"]
+    # Real violation wire (caller_file/caller_name) projects a step.
+    constraint_steps = [
+        s for s in outcome.artifacts["plan_steps"] if s["kind"] == "check_constraint"
+    ]
+    assert len(constraint_steps) == 1
+    assert constraint_steps[0]["path"] == "src/app.py"
+    assert constraint_steps[0]["symbol"] == "dispatch"
+    assert outcome.verdict == "UNSAFE"
+    # The review list covers every changed record (incl. the deletion).
+    assert (
+        outcome.next_step
+        == "Review the planned change across 2 file(s): src/app.py, src/gone.py."
+    )
+    assert outcome.agent_summary["verdict"] == "UNSAFE"  # type: ignore[index]
+    parity_roundtrip(outcome)

--- a/tree_sitter_analyzer/task/router.py
+++ b/tree_sitter_analyzer/task/router.py
@@ -44,6 +44,7 @@ from .models import (
     AssessChangeRequest,
     ConsumedBudget,
     PlanChangeRequest,
+    Status,
     TaskOutcome,
     TaskRequest,
     UnderstandRequest,
@@ -1930,6 +1931,25 @@ async def _run_route(
                     "locator": contribution.locator,
                 }
             )
+    next_step = build_next_step(
+        operation=operation,
+        status=status,
+        verdict=verdict,
+        unknowns=unknowns,
+        freshness=freshness_records,
+        plan_steps=plan_steps,
+        truncated=bool(truncated_rows),
+    )
+    agent_summary = build_agent_summary(
+        operation=operation,
+        status=status,
+        verdict=verdict,
+        next_step=next_step,
+        primitive_calls=consumed_calls,
+        evidence_items=len(evidence),
+        cleanup_status=cleanup_status,
+        plan_steps_count=len(plan_steps),
+    )
     return TaskOutcome(
         task=operation,  # type: ignore[arg-type]
         request=_project_request(request),
@@ -1944,6 +1964,8 @@ async def _run_route(
         unknowns=tuple(unknowns),
         errors=tuple(errors),
         budget=build_budget_record(budget),
+        next_step=next_step,
+        agent_summary=agent_summary,
         truncation={
             "truncated": bool(truncated_rows),
             "reason": truncated_reason,
@@ -1961,3 +1983,98 @@ async def _run_route(
         ),
         error="ERROR" if verdict == "ERROR" else None,
     )
+
+
+def build_next_step(
+    *,
+    operation: str,
+    status: Status,
+    verdict: Verdict,
+    unknowns: list[dict[str, Any]],
+    freshness: list[dict[str, Any]],
+    plan_steps: list[dict[str, Any]],
+    truncated: bool,
+) -> str | None:
+    """Deterministic, table-driven next-step hint (never evidence).
+
+    RFC-0022: a primitive-provided suggestion is inert suggested text; this
+    is the task's own projection of the frozen outcome into one actionable
+    sentence. Priority: unlock path (access authority) > oracle freshness >
+    budget/deadline > review steps > done state > None.
+    """
+    for unknown in unknowns:
+        reason = str(unknown.get("reason", ""))
+        if reason.startswith("ACCESS_UNAVAILABLE:"):
+            authority = reason.split(":", 1)[1]
+            return (
+                f"Read-existing authority unavailable ({authority}): the "
+                "zero-write backend is not certified on this platform. "
+                "Certify the P0.4 authority or run on a certified OS, then "
+                "retry this route."
+            )
+    for record in freshness:
+        reason = str(record.get("reason") or "")
+        if record.get("freshness") in {"missing", "unknown"} and (
+            reason == "AUTHORITATIVE_SNAPSHOT_UNAVAILABLE"
+            or reason.startswith("INCOMPLETE_ORACLE:")
+        ):
+            return (
+                "The index oracle is unavailable or incomplete: run a full "
+                "re-index (--full-index), then retry this route."
+            )
+    if truncated:
+        return (
+            "Budget or deadline limited the route: raise the profile or "
+            "narrow the scope, then retry."
+        )
+    if operation == "plan_change" and plan_steps:
+        paths = sorted({step["path"] for step in plan_steps if step["path"]})
+        listed = ", ".join(paths[:5])
+        if len(paths) > 5:
+            listed += f", \u2026 (+{len(paths) - 5} more)"
+        return f"Review the planned change across {len(paths)} file(s): {listed}."
+    if (
+        operation == "assess_change"
+        and status == "complete"
+        and verdict
+        in {
+            "SAFE",
+            "INFO",
+            "NOT_FOUND",
+        }
+    ):
+        return "No static issues found in the assessed change."
+    if status == "unknown":
+        return (
+            "The route could not establish evidence: check the unknowns "
+            "list for the blocking reason."
+        )
+    return None
+
+
+def build_agent_summary(
+    *,
+    operation: str,
+    status: Status,
+    verdict: Verdict,
+    next_step: str | None,
+    primitive_calls: int,
+    evidence_items: int,
+    cleanup_status: str,
+    plan_steps_count: int,
+) -> dict[str, Any]:
+    """Deterministic compact summary for agent branching (never evidence)."""
+    return {
+        "summary_line": (
+            f"task {operation} {status} verdict={verdict} "
+            f"calls={primitive_calls} evidence={evidence_items}"
+        ),
+        "operation": operation,
+        "status": status,
+        "verdict": verdict,
+        "primitive_calls": primitive_calls,
+        "evidence_items": evidence_items,
+        "cleanup_status": cleanup_status,
+        "plan_steps": plan_steps_count,
+        "next_step": next_step,
+    }


### PR DESCRIPTION
## Summary

P1 (usable) first slice of the agent-love mission, on top of the merged NO1-010A router (#1290):

1. **Actionable outputs** — every frozen outcome now carries a deterministic `next_step` hint (unlock path for uncertified P0.4 authority, re-index for missing/incomplete oracle, budget/deadline retry, plan_change review-file list, clean-assess done state) and a compact deterministic `agent_summary` (summary_line/status/verdict/calls/evidence/cleanup/plan_steps/next_step) so agents can branch without parsing the full wire. Both are table-driven projections of the frozen outcome — inert suggested text, never evidence (RFC-0022).
2. **Adapter-boundary wire contracts** — `test_task_wire_contract.py` pins the REAL primitive wire shapes as fixtures (code blocks `file`/`name`, violations `caller_file`/`caller_name`, Git-status changed records with availability) so the Codex-#1290 drift class can never silently return.

## Gates

- Quick gate: 1992 passed
- ruff + mypy clean
- Patch coverage gate: no added executable misses
- Parity roundtrip holds with populated next_step/agent_summary

## Follow-ups (mission roadmap)

- P1: certify P0.4 read-existing authority (Linux write-authority branch + macOS path) so routes run end-to-end
- P2: NO1-010B agent change-outcome benchmark (VCSR baseline)
- P3: pre-registration menu experiment → ninth-facade registration + CLI parity + integrations
