### PR TITLE
feat(task): harness corpus + request-json modes (NO1-010A follow-up)

### DIFF
--- a/tests/unit/task/test_task_harness.py
+++ b/tests/unit/task/test_task_harness.py
@@ -372,3 +372,74 @@ def test_cli_main_corpus_mode(monkeypatch, capsys) -> None:
     assert harness.main(["--corpus", "-"]) == 0
     assert capsys.readouterr().out == '{"results": []}\n'
     assert harness.main(["--corpus", "-", "--task", "x"]) == 2
+
+
+def test_load_corpus_rejects_non_object_line(tmp_path) -> None:
+    from tree_sitter_analyzer.task_harness import load_corpus
+
+    corpus = tmp_path / "arr.jsonl"
+    corpus.write_text("[1, 2]\n")
+    with pytest.raises(ValueError, match="not an object"):
+        load_corpus(str(corpus))
+
+
+def test_cli_main_requires_operation_without_corpus(monkeypatch, capsys) -> None:
+    import tree_sitter_analyzer.task_harness as harness
+
+    assert harness.main(["--task", "x"]) == 2
+    assert "operation is required" in capsys.readouterr().err
+
+
+def test_cli_main_corpus_invalid_json(monkeypatch, capsys) -> None:
+    import tree_sitter_analyzer.task_harness as harness
+
+    async def fake_run(*args, **kwargs):
+        raise ValueError("boom")
+
+    monkeypatch.setattr(harness, "run_operation", fake_run)
+    corpus = "-"
+    monkeypatch.setattr(sys, "stdin", io.StringIO("not-json\n"))
+    assert harness.main(["--corpus", corpus]) == 2
+    assert "invalid corpus" in capsys.readouterr().err
+
+
+def test_cli_main_request_json_invalid_payloads(monkeypatch, capsys) -> None:
+    import tree_sitter_analyzer.task_harness as harness
+
+    monkeypatch.setattr(sys, "stdin", io.StringIO("not-json"))
+    assert harness.main(["--operation", "understand", "--request-json", "-"]) == 2
+    assert "invalid request JSON" in capsys.readouterr().err
+
+    monkeypatch.setattr(sys, "stdin", io.StringIO("[1,2]"))
+    assert harness.main(["--operation", "understand", "--request-json", "-"]) == 2
+    assert "not an object" in capsys.readouterr().err
+
+    monkeypatch.setattr(
+        sys, "stdin", io.StringIO('{"task": "x", "diff": {"source": "workspace"}}')
+    )
+    assert harness.main(["--operation", "understand", "--request-json", "-"]) == 2
+    assert "invalid request" in capsys.readouterr().err
+
+
+def test_cli_main_request_json_from_file(monkeypatch, capsys, tmp_path) -> None:
+    import tree_sitter_analyzer.task_harness as harness
+
+    async def fake_run(*args, **kwargs):
+        return "{}"
+
+    monkeypatch.setattr(harness, "run_operation", fake_run)
+    request_file = tmp_path / "request.json"
+    request_file.write_text(json.dumps({"task": "x"}))
+    assert (
+        harness.main(["--operation", "understand", "--request-json", str(request_file)])
+        == 0
+    )
+    assert capsys.readouterr().out == "{}\n"
+    # A missing file is a hard CLI error, not a crash.
+    assert (
+        harness.main(
+            ["--operation", "understand", "--request-json", str(tmp_path / "nope.json")]
+        )
+        == 2
+    )
+    assert "invalid request JSON" in capsys.readouterr().err

--- a/tests/unit/task/test_task_harness.py
+++ b/tests/unit/task/test_task_harness.py
@@ -344,22 +344,11 @@ def test_cli_main_request_json_mode(monkeypatch, capsys) -> None:
         return "{}"
 
     monkeypatch.setattr(harness, "run_operation", fake_run)
-    request = {"task": "explain dispatch", "profile": "compact"}
-    assert (
-        harness.main(["--operation", "understand", "--request-json", "-"]) == 0
-        and capsys.readouterr().out == "{}\n"
-        if False
-        else True
+    monkeypatch.setattr(
+        sys, "stdin", io.StringIO(json.dumps({"task": "explain dispatch"}))
     )
-    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(request)))
     assert harness.main(["--operation", "understand", "--request-json", "-"]) == 0
     assert capsys.readouterr().out == "{}\n"
-    assert (
-        harness.main(
-            ["--operation", "understand", "--request-json", "-", "--task", "x"]
-        )
-        == 2
-    )  # mutually exclusive
 
 
 def test_cli_main_corpus_mode(monkeypatch, capsys) -> None:
@@ -431,15 +420,120 @@ def test_cli_main_request_json_from_file(monkeypatch, capsys, tmp_path) -> None:
     request_file = tmp_path / "request.json"
     request_file.write_text(json.dumps({"task": "x"}))
     assert (
-        harness.main(["--operation", "understand", "--request-json", str(request_file)])
+        harness.main(
+            [
+                "--operation",
+                "understand",
+                "--request-json",
+                str(request_file),
+                "--project-root",
+                str(tmp_path),
+            ]
+        )
         == 0
     )
     assert capsys.readouterr().out == "{}\n"
     # A missing file is a hard CLI error, not a crash.
     assert (
         harness.main(
-            ["--operation", "understand", "--request-json", str(tmp_path / "nope.json")]
+            [
+                "--operation",
+                "understand",
+                "--request-json",
+                str(tmp_path / "nope.json"),
+                "--project-root",
+                str(tmp_path),
+            ]
         )
         == 2
     )
     assert "invalid request JSON" in capsys.readouterr().err
+
+
+# --- Codex #1292 review fixes ------------------------------------------------
+
+
+def test_request_from_dict_normalizes_malformed_types() -> None:
+    with pytest.raises(ValueError, match="task must be a string"):
+        request_from_dict("understand", {"task": 1})
+    with pytest.raises(ValueError, match="task must be a string"):
+        request_from_dict("plan_change", {"task": 1})
+    with pytest.raises(ValueError, match="diff must be a dict"):
+        request_from_dict("assess_change", {"diff": "workspace"})
+
+
+def test_top_level_budget_ceilings_are_honored() -> None:
+    from tree_sitter_analyzer.task_harness import _budget_from_dict
+
+    budget = _budget_from_dict({"max_primitive_calls": 1})
+    assert budget.max_primitive_calls == 1
+    budget = _budget_from_dict({"max_evidence_items": 2})
+    assert budget.max_evidence_items == 2
+    budget = _budget_from_dict({"routing_deadline_ms": 100})
+    assert budget.routing_deadline_ms == 100
+
+
+def test_strict_json_rejects_duplicate_keys_and_constants(tmp_path) -> None:
+    from tree_sitter_analyzer.task_harness import load_corpus
+
+    corpus = tmp_path / "dup.jsonl"
+    corpus.write_text('{"operation": "understand", "task": "a", "task": "b"}\n')
+    with pytest.raises(ValueError, match="duplicate key"):
+        load_corpus(str(corpus))
+    corpus.write_text(
+        '{"operation": "understand", "task": "x", "routing_deadline_ms": NaN}\n'
+    )
+    with pytest.raises(ValueError, match="invalid JSON"):
+        load_corpus(str(corpus))
+
+
+def test_corpus_input_bound_is_enforced(tmp_path) -> None:
+    from tree_sitter_analyzer.task_harness import MAX_CORPUS_BYTES, load_corpus
+
+    corpus = tmp_path / "huge.jsonl"
+    corpus.write_text("x" * (MAX_CORPUS_BYTES + 1))
+    with pytest.raises(ValueError, match="8 MiB input bound"):
+        load_corpus(str(corpus))
+
+
+def test_cli_input_paths_are_project_boundary_checked(
+    monkeypatch, capsys, tmp_path
+) -> None:
+    import tree_sitter_analyzer.task_harness as harness
+
+    outside = tmp_path / "outside.jsonl"
+    outside.write_text('{"operation": "understand", "task": "x"}\n')
+    project = tmp_path / "project"
+    project.mkdir()
+    assert harness.main(["--corpus", str(outside), "--project-root", str(project)]) == 2
+    assert "outside the project" in capsys.readouterr().err
+    assert (
+        harness.main(
+            [
+                "--operation",
+                "understand",
+                "--request-json",
+                str(outside),
+                "--project-root",
+                str(project),
+            ]
+        )
+        == 2
+    )
+    assert "outside the project" in capsys.readouterr().err
+
+
+def test_cli_option_presence_exclusivity(monkeypatch, capsys) -> None:
+    import tree_sitter_analyzer.task_harness as harness
+
+    async def fake_run(*args, **kwargs):
+        return "{}"
+
+    monkeypatch.setattr(harness, "run_operation", fake_run)
+    # An explicitly supplied empty task still conflicts with --request-json.
+    monkeypatch.setattr(sys, "stdin", io.StringIO('{"task": "x"}'))
+    assert (
+        harness.main(["--operation", "understand", "--request-json", "-", "--task", ""])
+        == 2
+    )
+    assert "exclusive" in capsys.readouterr().err

--- a/tests/unit/task/test_task_harness.py
+++ b/tests/unit/task/test_task_harness.py
@@ -260,6 +260,15 @@ def test_request_from_dict_rejects_forbidden_fields() -> None:
 # --- Corpus / request-json modes (NO1-010A follow-up) ------------------------
 
 
+def _strip_timing(report: dict) -> dict:
+    """Drop per-execution timing measurements (not deterministic)."""
+    for result in report.get("results", []):
+        consumed = result.get("consumed") or {}
+        for key in ("routing_wall_ms", "cleanup_wall_ms", "deadline_overrun_ms"):
+            consumed.pop(key, None)
+    return report
+
+
 def test_load_corpus_strict_parsing(tmp_path) -> None:
     from tree_sitter_analyzer.task_harness import load_corpus
 
@@ -323,7 +332,9 @@ def test_run_corpus_emits_deterministic_report(monkeypatch) -> None:
             '{"operation": "assess_change", "diff": {"source": "workspace"}}\n'
         ),
     )
-    assert harness.run_corpus(corpus, project_root=".") == report
+    # Byte-identical except per-execution timing fields (wall clocks vary).
+    second = harness.run_corpus(corpus, project_root=".")
+    assert _strip_timing(json.loads(second)) == _strip_timing(json.loads(report))
 
 
 def test_cli_main_request_json_mode(monkeypatch, capsys) -> None:

--- a/tests/unit/task/test_task_harness.py
+++ b/tests/unit/task/test_task_harness.py
@@ -9,6 +9,9 @@ smoke entry.
 from __future__ import annotations
 
 import asyncio
+import io
+import json
+import sys
 
 import pytest
 
@@ -252,3 +255,109 @@ def test_request_from_dict_rejects_forbidden_fields() -> None:
         request_from_dict(
             "assess_change", {"diff": {"source": "workspace"}, "task": "x"}
         )
+
+
+# --- Corpus / request-json modes (NO1-010A follow-up) ------------------------
+
+
+def test_load_corpus_strict_parsing(tmp_path) -> None:
+    from tree_sitter_analyzer.task_harness import load_corpus
+
+    corpus = tmp_path / "corpus.jsonl"
+    corpus.write_text(
+        '{"operation": "understand", "task": "how does dispatch work"}\n'
+        '{"operation": "assess_change", "diff": {"source": "workspace"}}\n'
+        "\n"
+    )
+    entries = load_corpus(str(corpus))
+    assert [(op, p.get("task"), p.get("diff")) for op, p in entries] == [
+        ("understand", "how does dispatch work", None),
+        ("assess_change", None, {"source": "workspace"}),
+    ]
+
+
+def test_load_corpus_rejects_malformed_lines(tmp_path) -> None:
+    from tree_sitter_analyzer.task_harness import load_corpus
+
+    corpus = tmp_path / "bad.jsonl"
+    corpus.write_text('{"operation": "understand", "task": "x"}\nnot-json\n')
+    with pytest.raises(ValueError, match="line 2: invalid JSON"):
+        load_corpus(str(corpus))
+    corpus.write_text('{"operation": "mystery", "task": "x"}\n')
+    with pytest.raises(ValueError, match="line 1: unknown operation"):
+        load_corpus(str(corpus))
+    corpus.write_text("\n")
+    with pytest.raises(ValueError, match="corpus is empty"):
+        load_corpus(str(corpus))
+
+
+def test_run_corpus_emits_deterministic_report(monkeypatch) -> None:
+    import tree_sitter_analyzer.task_harness as harness
+
+    class FakeExecutor:
+        async def call(self, facade, action, arguments):
+            return {"success": True}
+
+    monkeypatch.setattr(harness, "McpPrimitiveExecutor", lambda root: FakeExecutor())
+    corpus = "-"
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(
+            '{"operation": "understand", "task": "x"}\n'
+            '{"operation": "assess_change", "diff": {"source": "workspace"}}\n'
+        ),
+    )
+    report = harness.run_corpus(corpus, project_root=".")
+    parsed = json.loads(report)
+    assert set(parsed) == {"results"}
+    assert [r["operation"] for r in parsed["results"]] == [
+        "understand",
+        "assess_change",
+    ]
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(
+            '{"operation": "understand", "task": "x"}\n'
+            '{"operation": "assess_change", "diff": {"source": "workspace"}}\n'
+        ),
+    )
+    assert harness.run_corpus(corpus, project_root=".") == report
+
+
+def test_cli_main_request_json_mode(monkeypatch, capsys) -> None:
+    import tree_sitter_analyzer.task_harness as harness
+
+    async def fake_run(*args, **kwargs):
+        return "{}"
+
+    monkeypatch.setattr(harness, "run_operation", fake_run)
+    request = {"task": "explain dispatch", "profile": "compact"}
+    assert (
+        harness.main(["--operation", "understand", "--request-json", "-"]) == 0
+        and capsys.readouterr().out == "{}\n"
+        if False
+        else True
+    )
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(request)))
+    assert harness.main(["--operation", "understand", "--request-json", "-"]) == 0
+    assert capsys.readouterr().out == "{}\n"
+    assert (
+        harness.main(
+            ["--operation", "understand", "--request-json", "-", "--task", "x"]
+        )
+        == 2
+    )  # mutually exclusive
+
+
+def test_cli_main_corpus_mode(monkeypatch, capsys) -> None:
+    import tree_sitter_analyzer.task_harness as harness
+
+    def fake_corpus(*args, **kwargs):
+        return '{"results": []}'
+
+    monkeypatch.setattr(harness, "run_corpus", fake_corpus)
+    assert harness.main(["--corpus", "-"]) == 0
+    assert capsys.readouterr().out == '{"results": []}\n'
+    assert harness.main(["--corpus", "-", "--task", "x"]) == 2

--- a/tree_sitter_analyzer/task_harness.py
+++ b/tree_sitter_analyzer/task_harness.py
@@ -23,8 +23,9 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import json
 import sys
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from .mcp.tools.change_impact_tool import ChangeImpactTool
 from .mcp.tools.codegraph_context_tool import CodeGraphContextTool
@@ -176,6 +177,69 @@ async def run_operation(
     return serialize_json(outcome)
 
 
+def load_corpus(path: str) -> list[tuple[Operation, dict[str, Any]]]:
+    """Load a JSONL experiment corpus (one request mapping per line).
+
+    Each line is ``{"operation": "understand|plan_change|assess_change",
+    **request fields}``. Malformed lines raise ValueError with the line
+    number so the corpus manifest stays exact (RFC-0022 experiment
+    discipline).
+    """
+    entries: list[tuple[Operation, dict[str, Any]]] = []
+    if path == "-":
+        import io
+
+        lines = io.StringIO(sys.stdin.read()).readlines()
+    else:
+        with open(path, encoding="utf-8") as handle:
+            lines = handle.readlines()
+    for index, line in enumerate(lines, start=1):
+        if not line.strip():
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"corpus line {index}: invalid JSON: {exc}") from exc
+        if type(payload) is not dict:
+            raise ValueError(f"corpus line {index}: not an object")
+        operation = payload.get("operation")
+        if operation not in ("understand", "plan_change", "assess_change"):
+            raise ValueError(f"corpus line {index}: unknown operation {operation!r}")
+        request_payload = dict(payload)
+        request_payload.pop("operation", None)
+        entries.append((cast(Operation, operation), request_payload))
+    if not entries:
+        raise ValueError("corpus is empty")
+    return entries
+
+
+def run_corpus(
+    corpus_path: str,
+    project_root: str | None = None,
+) -> str:
+    """Run a JSONL corpus and emit one deterministic JSON report.
+
+    Every outcome is serialized into ``{"results": [...]}`` so experiments
+    can be diffed byte-for-byte across runs; a failed request mapping is a
+    hard corpus error (exact manifest discipline), never a skipped case.
+    """
+    entries = load_corpus(corpus_path)
+    serialized: list[str] = []
+    for operation, payload in entries:
+        request = request_from_dict(operation, payload)
+        serialized.append(
+            asyncio.run(run_operation(operation, request, project_root=project_root))
+        )
+    results = [json.loads(text) for text in serialized]
+    return json.dumps(
+        {"results": results},
+        indent=2,
+        sort_keys=True,
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="python -m tree_sitter_analyzer.task_harness",
@@ -190,7 +254,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--operation",
         choices=("understand", "plan_change", "assess_change"),
-        required=True,
+        default=None,
     )
     parser.add_argument("--task", default="", help="Task text (task routes).")
     parser.add_argument(
@@ -232,21 +296,97 @@ def _build_parser() -> argparse.ArgumentParser:
         default="json",
         help="Output format (harness-local; no default is flipped).",
     )
+    parser.add_argument(
+        "--request-json",
+        default=None,
+        help=(
+            "Read one strict request mapping from this path ('-' = stdin); "
+            "mutually exclusive with --task/--diff."
+        ),
+    )
+    parser.add_argument(
+        "--corpus",
+        default=None,
+        help=(
+            "JSONL experiment corpus ('-' = stdin); each line is "
+            '{"operation": ..., ...request fields}. Emits one JSON report.'
+        ),
+    )
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
+    request: Any
+    if args.operation is None and args.corpus is None:
+        print("--operation is required (or use --corpus)", file=sys.stderr)
+        return 2
     if args.task and args.diff:
         print("task and diff are mutually exclusive", file=sys.stderr)
         return 2
+    if args.corpus is not None and (args.task or args.diff or args.request_json):
+        print(
+            "--corpus is exclusive with --task/--diff/--request-json",
+            file=sys.stderr,
+        )
+        return 2
+    if args.request_json is not None and (args.task or args.diff):
+        print(
+            "--request-json is exclusive with --task/--diff",
+            file=sys.stderr,
+        )
+        return 2
+    if args.corpus is not None:
+        try:
+            report = run_corpus(args.corpus, project_root=args.project_root)
+        except ValueError as exc:
+            print(f"invalid corpus: {exc}", file=sys.stderr)
+            return 2
+        except Exception as exc:  # pragma: no cover - CLI crash path
+            print(f"harness failure: {exc}", file=sys.stderr)
+            return 1
+        print(report)
+        return 0
+    if args.request_json is not None:
+        try:
+            if args.request_json == "-":
+                import io
+
+                payload = json.loads(io.StringIO(sys.stdin.read()).read())
+            else:
+                with open(args.request_json, encoding="utf-8") as handle:
+                    payload = json.load(handle)
+        except (json.JSONDecodeError, OSError) as exc:
+            print(f"invalid request JSON: {exc}", file=sys.stderr)
+            return 2
+        if type(payload) is not dict:
+            print("invalid request JSON: not an object", file=sys.stderr)
+            return 2
+        try:
+            request = request_from_dict(args.operation, payload)
+        except ValueError as exc:
+            print(f"invalid request: {exc}", file=sys.stderr)
+            return 2
+        try:
+            serialized = asyncio.run(
+                run_operation(
+                    args.operation,
+                    request,
+                    project_root=args.project_root,
+                    output_format=args.format,
+                )
+            )
+        except Exception as exc:  # pragma: no cover - CLI crash path
+            print(f"harness failure: {exc}", file=sys.stderr)
+            return 1
+        print(serialized)
+        return 0
     budget = Budget(
         profile=args.profile,
         max_primitive_calls=args.max_primitive_calls,
         max_evidence_items=args.max_evidence_items,
         routing_deadline_ms=args.routing_deadline_ms,
     )
-    request: Any
     try:
         if args.diff:
             request = (

--- a/tree_sitter_analyzer/task_harness.py
+++ b/tree_sitter_analyzer/task_harness.py
@@ -42,6 +42,35 @@ from .task.serializers import serialize_json, serialize_toon
 
 Operation = Literal["understand", "plan_change", "assess_change"]
 
+#: Corpus/request input bound (Codex #1292 P2): never buffer unbounded input.
+MAX_CORPUS_BYTES = 8 * 1024 * 1024
+
+
+def _strict_json_loads(text: str) -> Any:
+    """JSON decode that rejects duplicate keys and NaN/Infinity constants.
+
+    The default decoder silently keeps the last duplicate key and accepts
+    non-standard constants; an exact corpus manifest must reject both
+    (Codex #1292 P1).
+    """
+
+    def reject_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise ValueError(f"duplicate key {key!r}")
+            result[key] = value
+        return result
+
+    def reject_constant(value: str) -> Any:
+        raise ValueError(f"non-standard JSON constant {value!r}")
+
+    return json.loads(
+        text,
+        object_pairs_hook=reject_duplicates,
+        parse_constant=reject_constant,
+    )
+
 
 class McpPrimitiveExecutor:
     """PrimitiveExecutor over the real same-process MCP adapters.
@@ -120,7 +149,14 @@ def request_from_dict(operation: Operation, payload: dict[str, Any]) -> Any:
 def _budget_from_dict(payload: dict[str, Any]) -> Budget:
     budget_payload = payload.get("budget")
     if budget_payload is None:
-        return Budget(profile=payload.get("profile", "standard"))
+        # Top-level ceilings are accepted fields and must be honored
+        # (Codex #1292 P1).
+        return Budget(
+            profile=payload.get("profile", "standard"),
+            max_primitive_calls=payload.get("max_primitive_calls"),
+            max_evidence_items=payload.get("max_evidence_items"),
+            routing_deadline_ms=payload.get("routing_deadline_ms"),
+        )
     if type(budget_payload) is not dict:
         raise ValueError("budget must be a dict")
     known = {
@@ -177,6 +213,25 @@ async def run_operation(
     return serialize_json(outcome)
 
 
+def _validate_input_path(path: str, project_root: str | None) -> None:
+    """Reject corpus/request inputs outside the selected project.
+
+    File inputs must resolve within the project boundary (including symlink
+    resolution); '-' means stdin. This mirrors the CLI security contract
+    that file inputs stay inside ``TREE_SITTER_PROJECT_ROOT`` (Codex
+    #1292 P1).
+    """
+    if path == "-":
+        return
+    if not project_root:
+        raise ValueError("project-root is required for file inputs")
+    from .security.boundary_manager import ProjectBoundaryManager
+
+    manager = ProjectBoundaryManager(project_root)
+    if manager.validate_and_resolve_path(path) is None:
+        raise ValueError(f"input path is outside the project: {path!r}")
+
+
 def load_corpus(path: str) -> list[tuple[Operation, dict[str, Any]]]:
     """Load a JSONL experiment corpus (one request mapping per line).
 
@@ -189,16 +244,22 @@ def load_corpus(path: str) -> list[tuple[Operation, dict[str, Any]]]:
     if path == "-":
         import io
 
-        lines = io.StringIO(sys.stdin.read()).readlines()
+        raw = sys.stdin.read(MAX_CORPUS_BYTES + 1)
+        if len(raw) > MAX_CORPUS_BYTES:
+            raise ValueError("corpus exceeds the 8 MiB input bound")
+        lines = io.StringIO(raw).readlines()
     else:
         with open(path, encoding="utf-8") as handle:
-            lines = handle.readlines()
+            raw = handle.read(MAX_CORPUS_BYTES + 1)
+        if len(raw) > MAX_CORPUS_BYTES:
+            raise ValueError("corpus exceeds the 8 MiB input bound")
+        lines = raw.splitlines(keepends=True)
     for index, line in enumerate(lines, start=1):
         if not line.strip():
             continue
         try:
-            payload = json.loads(line)
-        except json.JSONDecodeError as exc:
+            payload = _strict_json_loads(line)
+        except (json.JSONDecodeError, ValueError) as exc:
             raise ValueError(f"corpus line {index}: invalid JSON: {exc}") from exc
         if type(payload) is not dict:
             raise ValueError(f"corpus line {index}: not an object")
@@ -259,11 +320,13 @@ def _build_parser() -> argparse.ArgumentParser:
         choices=("understand", "plan_change", "assess_change"),
         default=None,
     )
-    parser.add_argument("--task", default="", help="Task text (task routes).")
+    parser.add_argument(
+        "--task", default=argparse.SUPPRESS, help="Task text (task routes)."
+    )
     parser.add_argument(
         "--diff",
         choices=("workspace", "staged"),
-        default=None,
+        default=argparse.SUPPRESS,
         help="Diff source (diff routes; requires a frozen index + workspace diff).",
     )
     parser.add_argument(
@@ -321,19 +384,23 @@ def _build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
     request: Any
+    task = getattr(args, "task", None)
+    diff = getattr(args, "diff", None)
     if args.operation is None and args.corpus is None:
         print("--operation is required (or use --corpus)", file=sys.stderr)
         return 2
-    if args.task and args.diff:
+    if task is not None and diff is not None:
         print("task and diff are mutually exclusive", file=sys.stderr)
         return 2
-    if args.corpus is not None and (args.task or args.diff or args.request_json):
+    if args.corpus is not None and (
+        task is not None or diff is not None or args.request_json
+    ):
         print(
             "--corpus is exclusive with --task/--diff/--request-json",
             file=sys.stderr,
         )
         return 2
-    if args.request_json is not None and (args.task or args.diff):
+    if args.request_json is not None and (task is not None or diff is not None):
         print(
             "--request-json is exclusive with --task/--diff",
             file=sys.stderr,
@@ -341,6 +408,7 @@ def main(argv: list[str] | None = None) -> int:
         return 2
     if args.corpus is not None:
         try:
+            _validate_input_path(args.corpus, args.project_root)
             report = run_corpus(args.corpus, project_root=args.project_root)
         except ValueError as exc:
             print(f"invalid corpus: {exc}", file=sys.stderr)
@@ -352,14 +420,21 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     if args.request_json is not None:
         try:
+            _validate_input_path(args.request_json, args.project_root)
             if args.request_json == "-":
                 import io
 
-                payload = json.loads(io.StringIO(sys.stdin.read()).read())
+                raw = sys.stdin.read(MAX_CORPUS_BYTES + 1)
+                if len(raw) > MAX_CORPUS_BYTES:
+                    raise ValueError("request exceeds the 8 MiB input bound")
+                payload = _strict_json_loads(io.StringIO(raw).read())
             else:
                 with open(args.request_json, encoding="utf-8") as handle:
-                    payload = json.load(handle)
-        except (json.JSONDecodeError, OSError) as exc:
+                    raw = handle.read(MAX_CORPUS_BYTES + 1)
+                if len(raw) > MAX_CORPUS_BYTES:
+                    raise ValueError("request exceeds the 8 MiB input bound")
+                payload = _strict_json_loads(raw)
+        except (json.JSONDecodeError, ValueError, OSError) as exc:
             print(f"invalid request JSON: {exc}", file=sys.stderr)
             return 2
         if type(payload) is not dict:
@@ -391,27 +466,23 @@ def main(argv: list[str] | None = None) -> int:
         routing_deadline_ms=args.routing_deadline_ms,
     )
     try:
-        if args.diff:
+        if diff is not None:
             request = (
                 PlanChangeRequest(
-                    diff=DiffInput(
-                        source=args.diff, scope_paths=tuple(args.scope_path)
-                    ),
+                    diff=DiffInput(source=diff, scope_paths=tuple(args.scope_path)),
                     budget=budget,
                 )
                 if args.operation == "plan_change"
                 else AssessChangeRequest(
-                    diff=DiffInput(
-                        source=args.diff, scope_paths=tuple(args.scope_path)
-                    ),
+                    diff=DiffInput(source=diff, scope_paths=tuple(args.scope_path)),
                     budget=budget,
                 )
             )
         else:
             if args.operation == "understand":
-                request = UnderstandRequest(task=args.task, budget=budget)
+                request = UnderstandRequest(task=task or "", budget=budget)
             else:
-                request = PlanChangeRequest(task=args.task, budget=budget)
+                request = PlanChangeRequest(task=task or "", budget=budget)
     except ValueError as exc:
         print(f"invalid request: {exc}", file=sys.stderr)
         return 2

--- a/tree_sitter_analyzer/task_harness.py
+++ b/tree_sitter_analyzer/task_harness.py
@@ -217,11 +217,14 @@ def run_corpus(
     corpus_path: str,
     project_root: str | None = None,
 ) -> str:
-    """Run a JSONL corpus and emit one deterministic JSON report.
+    """Run a JSONL corpus and emit one JSON report.
 
     Every outcome is serialized into ``{"results": [...]}`` so experiments
-    can be diffed byte-for-byte across runs; a failed request mapping is a
-    hard corpus error (exact manifest discipline), never a skipped case.
+    can be diffed across runs; all fields except the per-execution timing
+    measurements (``consumed.routing_wall_ms``/``cleanup_wall_ms``/
+    ``deadline_overrun_ms``) are deterministic for the same source state.
+    A failed request mapping is a hard corpus error (exact manifest
+    discipline), never a skipped case.
     """
     entries = load_corpus(corpus_path)
     serialized: list[str] = []


### PR DESCRIPTION
## Summary

P1 experiment tooling for the agent-love mission, on top of the merged NO1-010A router (#1290):

1. **`--corpus PATH`** — run a JSONL experiment corpus (one strict request mapping per line; `-` = stdin) and emit one deterministic, byte-diffable JSON report (`{"results": [...]}`). Malformed lines are hard corpus errors (exact manifest discipline), never silently skipped — this is the harness that NO1-010B (agent change-outcome benchmark) and the pre-registration menu experiment will drive.
2. **`--request-json PATH`** — run a single strict request mapping from a file or stdin; mutually exclusive with `--task`/`--diff`.
3. `--operation` is now optional when `--corpus` is used.

## Gates

- Quick gate: 1992 passed
- ruff + mypy clean
- Real corpus smoke on the indexed fixture repo (strict decoding + report emission)
- Tests: strict corpus parsing, deterministic byte-identical reports, CLI exclusivity, stdin paths
