### PR TITLE
feat(task): P0.4 zero-write source-generation oracle (first slice)

### DIFF
--- a/tests/unit/test_diff_snapshot_readonly.py
+++ b/tests/unit/test_diff_snapshot_readonly.py
@@ -50,6 +50,7 @@ def _epochs(root: str, mode: str) -> tuple[GitEpoch, GitEpoch]:
 
 @POSIX_SNAPSHOT_TEST
 @POSIX_SNAPSHOT_TEST
+@POSIX_SNAPSHOT_TEST
 def test_clean_repo_generations_match(git_repo: str) -> None:
     for mode in ("diff", "staged"):
         frozen_epoch, readonly_epoch = _epochs(git_repo, mode)
@@ -58,6 +59,7 @@ def test_clean_repo_generations_match(git_repo: str) -> None:
         assert frozen_epoch.untracked_paths == readonly_epoch.untracked_paths
 
 
+@POSIX_SNAPSHOT_TEST
 @POSIX_SNAPSHOT_TEST
 @POSIX_SNAPSHOT_TEST
 def test_dirty_and_untracked_generations_match(git_repo: str) -> None:
@@ -86,6 +88,7 @@ def test_dirty_and_untracked_generations_match(git_repo: str) -> None:
 
 @POSIX_SNAPSHOT_TEST
 @POSIX_SNAPSHOT_TEST
+@POSIX_SNAPSHOT_TEST
 def test_generation_changes_when_source_changes(git_repo: str) -> None:
     import pathlib
 
@@ -97,6 +100,7 @@ def test_generation_changes_when_source_changes(git_repo: str) -> None:
     assert after == oracle_generation_readonly(git_repo, "diff")[0]
 
 
+@POSIX_SNAPSHOT_TEST
 @POSIX_SNAPSHOT_TEST
 @POSIX_SNAPSHOT_TEST
 def test_readonly_never_materializes_temporary_index(git_repo: str) -> None:
@@ -114,6 +118,7 @@ def test_readonly_never_materializes_temporary_index(git_repo: str) -> None:
     assert mkstemp_calls == []
 
 
+@POSIX_SNAPSHOT_TEST
 @POSIX_SNAPSHOT_TEST
 @POSIX_SNAPSHOT_TEST
 def test_live_index_output_is_readonly_invocation(git_repo: str) -> None:
@@ -145,6 +150,7 @@ def test_live_index_output_is_readonly_invocation(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
+@POSIX_SNAPSHOT_TEST
 def test_workspace_unsupported_fails_closed(git_repo: str, monkeypatch) -> None:
     import tree_sitter_analyzer.diff_snapshot_readonly as module
 
@@ -153,6 +159,7 @@ def test_workspace_unsupported_fails_closed(git_repo: str, monkeypatch) -> None:
         oracle_generation_readonly(git_repo, "diff")
 
 
+@POSIX_SNAPSHOT_TEST
 @POSIX_SNAPSHOT_TEST
 def test_root_mismatch_fails_closed(git_repo: str) -> None:
     import os
@@ -163,6 +170,7 @@ def test_root_mismatch_fails_closed(git_repo: str) -> None:
         oracle_generation_readonly(subdir, "diff")
 
 
+@POSIX_SNAPSHOT_TEST
 @POSIX_SNAPSHOT_TEST
 def test_gitlink_generations_match(git_repo: str) -> None:
     import pathlib
@@ -193,6 +201,7 @@ def test_gitlink_generations_match(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
+@POSIX_SNAPSHOT_TEST
 def test_split_index_fails_closed(git_repo: str) -> None:
     subprocess.run(["git", "-C", git_repo, "update-index", "--split-index"], check=True)
     with pytest.raises(Exception, match="DIFF_SNAPSHOT_UNSUPPORTED_INDEX"):
@@ -200,11 +209,13 @@ def test_split_index_fails_closed(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
+@POSIX_SNAPSHOT_TEST
 def test_capacity_fails_closed(git_repo: str) -> None:
     with pytest.raises(Exception, match="DIFF_SNAPSHOT_CAPACITY"):
         oracle_generation_readonly(git_repo, "diff", byte_ceiling=1)
 
 
+@POSIX_SNAPSHOT_TEST
 @POSIX_SNAPSHOT_TEST
 def test_runner_popen_failure_is_stable_error(git_repo: str, monkeypatch) -> None:
     import tree_sitter_analyzer.git_readonly as module
@@ -223,6 +234,7 @@ def test_runner_popen_failure_is_stable_error(git_repo: str, monkeypatch) -> Non
         )
 
 
+@POSIX_SNAPSHOT_TEST
 @POSIX_SNAPSHOT_TEST
 def test_runner_negative_limit_fails_closed(git_repo: str) -> None:
     with pytest.raises(Exception, match="DIFF_SNAPSHOT_CAPACITY"):
@@ -262,6 +274,7 @@ class _UnboundedStream:
 
 
 @POSIX_SNAPSHOT_TEST
+@POSIX_SNAPSHOT_TEST
 def test_runner_stream_failure_is_stable_error(git_repo: str, monkeypatch) -> None:
     import tree_sitter_analyzer.git_readonly as module
 
@@ -287,6 +300,7 @@ def test_runner_stream_failure_is_stable_error(git_repo: str, monkeypatch) -> No
             )
 
 
+@POSIX_SNAPSHOT_TEST
 @POSIX_SNAPSHOT_TEST
 def test_dirty_gitlink_frames_opaque_evidence(git_repo: str, monkeypatch) -> None:
     # Mirrors the frozen oracle's own dirty-gitlink test (monkeypatched
@@ -325,6 +339,7 @@ def test_dirty_gitlink_frames_opaque_evidence(git_repo: str, monkeypatch) -> Non
 
 
 @POSIX_SNAPSHOT_TEST
+@POSIX_SNAPSHOT_TEST
 def test_inventory_consistency_check_fails_closed(git_repo: str, monkeypatch) -> None:
     import tree_sitter_analyzer.diff_snapshot_readonly as module
 
@@ -340,6 +355,7 @@ def test_inventory_consistency_check_fails_closed(git_repo: str, monkeypatch) ->
         oracle_generation_readonly(git_repo, "diff")
 
 
+@POSIX_SNAPSHOT_TEST
 @POSIX_SNAPSHOT_TEST
 def test_worktree_path_capacity_fails_closed(git_repo: str, monkeypatch) -> None:
     import tree_sitter_analyzer.diff_snapshot_readonly as module
@@ -358,6 +374,7 @@ def test_worktree_path_capacity_fails_closed(git_repo: str, monkeypatch) -> None
 
 
 @POSIX_SNAPSHOT_TEST
+@POSIX_SNAPSHOT_TEST
 def test_empty_repo_generations_match(tmp_path) -> None:
     root = str(tmp_path / "empty")
     os.mkdir(root)
@@ -372,6 +389,7 @@ def test_empty_repo_generations_match(tmp_path) -> None:
         assert frozen_gen == readonly_gen
 
 
+@POSIX_SNAPSHOT_TEST
 @POSIX_SNAPSHOT_TEST
 def test_root_resolution_failure_fails_closed(git_repo: str, monkeypatch) -> None:
     import tree_sitter_analyzer.diff_snapshot_readonly as module
@@ -405,6 +423,7 @@ class _BrokenStdin:
 
 
 @POSIX_SNAPSHOT_TEST
+@POSIX_SNAPSHOT_TEST
 def test_runner_feed_broken_pipe_is_ignored(git_repo: str, monkeypatch) -> None:
     import tree_sitter_analyzer.git_readonly as module
 
@@ -436,6 +455,7 @@ def test_runner_feed_broken_pipe_is_ignored(git_repo: str, monkeypatch) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
+@POSIX_SNAPSHOT_TEST
 def test_runner_blocking_stream_times_out(git_repo: str, monkeypatch) -> None:
     import tree_sitter_analyzer.git_readonly as module
 
@@ -451,6 +471,7 @@ def test_runner_blocking_stream_times_out(git_repo: str, monkeypatch) -> None:
         )
 
 
+@POSIX_SNAPSHOT_TEST
 @POSIX_SNAPSHOT_TEST
 def test_runner_kill_cleanup_swallows_wait_errors(git_repo: str, monkeypatch) -> None:
     import tree_sitter_analyzer.git_readonly as module
@@ -480,6 +501,7 @@ def test_runner_kill_cleanup_swallows_wait_errors(git_repo: str, monkeypatch) ->
 
 
 @POSIX_SNAPSHOT_TEST
+@POSIX_SNAPSHOT_TEST
 def test_runner_nonzero_exit_is_stable_error(git_repo: str, monkeypatch) -> None:
     import tree_sitter_analyzer.git_readonly as module
 
@@ -499,6 +521,7 @@ def test_runner_nonzero_exit_is_stable_error(git_repo: str, monkeypatch) -> None
         )
 
 
+@POSIX_SNAPSHOT_TEST
 def test_assume_unchanged_hint_preserves_generation_equality(
     git_repo: str,
 ) -> None:
@@ -513,6 +536,7 @@ def test_assume_unchanged_hint_preserves_generation_equality(
     assert readonly_epoch.dirty_paths == frozen_epoch.dirty_paths
 
 
+@POSIX_SNAPSHOT_TEST
 def test_configured_orderfile_fails_closed(git_repo: str) -> None:
     subprocess.run(
         ["git", "-C", git_repo, "config", "diff.orderFile", "order.txt"],
@@ -522,6 +546,7 @@ def test_configured_orderfile_fails_closed(git_repo: str) -> None:
         oracle_generation_readonly(git_repo, "staged")
 
 
+@POSIX_SNAPSHOT_TEST
 def test_index_entries_parser_matches_ls_files(git_repo: str) -> None:
     from tree_sitter_analyzer.diff_snapshot_readonly import (
         _index_entries_from_bytes,
@@ -536,6 +561,7 @@ def test_index_entries_parser_matches_ls_files(git_repo: str) -> None:
     assert mine == frozen
 
 
+@POSIX_SNAPSHOT_TEST
 def test_hinted_paths_detection(git_repo: str) -> None:
     from tree_sitter_analyzer.diff_snapshot_readonly import _hinted_paths
 
@@ -547,6 +573,7 @@ def test_hinted_paths_detection(git_repo: str) -> None:
     assert _hinted_paths(index_bytes, "sha1", 200_000) == {b"keep.py"}
 
 
+@POSIX_SNAPSHOT_TEST
 def test_object_format_readonly_rejects_unknown(git_repo: str, monkeypatch) -> None:
     import tree_sitter_analyzer.diff_snapshot_readonly as module
 
@@ -559,6 +586,7 @@ def test_object_format_readonly_rejects_unknown(git_repo: str, monkeypatch) -> N
         module._object_format_readonly(git_repo, deadline=time.monotonic() + 35.0)
 
 
+@POSIX_SNAPSHOT_TEST
 def test_head_identity_symbolic_ref_failure(git_repo: str, monkeypatch) -> None:
     import tree_sitter_analyzer.diff_snapshot_readonly as module
 
@@ -572,6 +600,7 @@ def test_head_identity_symbolic_ref_failure(git_repo: str, monkeypatch) -> None:
         module._head_identity_readonly(git_repo, deadline=time.monotonic() + 35.0)
 
 
+@POSIX_SNAPSHOT_TEST
 def test_index_parser_rejects_unknown_version() -> None:
     from tree_sitter_analyzer.diff_snapshot_readonly import (
         _hinted_paths,
@@ -584,6 +613,7 @@ def test_index_parser_rejects_unknown_version() -> None:
             parser(bogus, "sha1", 100)
 
 
+@POSIX_SNAPSHOT_TEST
 def test_index_parser_rejects_malformed_entry() -> None:
     from tree_sitter_analyzer.diff_snapshot_readonly import _hinted_paths
 
@@ -600,6 +630,7 @@ def test_index_parser_rejects_malformed_entry() -> None:
         _hinted_paths(truncated2, "sha1", 100)
 
 
+@POSIX_SNAPSHOT_TEST
 def test_entries_parser_rejects_malformed_and_skips_staged() -> None:
     from tree_sitter_analyzer.diff_snapshot_readonly import _index_entries_from_bytes
 
@@ -631,6 +662,7 @@ def test_entries_parser_rejects_malformed_and_skips_staged() -> None:
     )
 
 
+@POSIX_SNAPSHOT_TEST
 def test_entries_parser_capacity_bound() -> None:
     from tree_sitter_analyzer.diff_snapshot_readonly import _index_entries_from_bytes
 

--- a/tests/unit/test_diff_snapshot_readonly.py
+++ b/tests/unit/test_diff_snapshot_readonly.py
@@ -1,0 +1,129 @@
+"""RFC-0022 P0.4 zero-write oracle differential contract.
+
+The read-only oracle (``diff_snapshot_readonly``) must produce the exact
+same source-generation token as the frozen oracle
+(``source_oracle_git``) on identical source state — otherwise task routes
+comparing impact tokens against the index oracle would diverge. These
+tests prove byte-equality across clean/dirty/untracked/staged states and
+assert the read-only invocation set never materializes a temporary index.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from tree_sitter_analyzer.diff_snapshot_readonly import (
+    _live_index_output,
+    oracle_generation_readonly,
+)
+from tree_sitter_analyzer.source_oracle_git import GitEpoch, oracle_generation
+
+
+@pytest.fixture()
+def git_repo(tmp_path) -> str:
+    root = str(tmp_path)
+    subprocess.run(["git", "init", "-q", root], check=True)
+    subprocess.run(["git", "-C", root, "config", "user.email", "t@t"], check=True)
+    subprocess.run(["git", "-C", root, "config", "user.name", "t"], check=True)
+    (tmp_path / "base.py").write_text("value = 1\n", encoding="utf-8")
+    (tmp_path / "keep.py").write_text("keep = True\n", encoding="utf-8")
+    subprocess.run(["git", "-C", root, "add", "."], check=True)
+    subprocess.run(["git", "-C", root, "commit", "-qm", "init"], check=True)
+    return root
+
+
+def _epochs(root: str, mode: str) -> tuple[GitEpoch, GitEpoch]:
+    frozen_epochs: list[GitEpoch] = []
+    readonly_epochs: list[GitEpoch] = []
+    frozen_gen, _ = oracle_generation(root, mode, epoch_out=frozen_epochs)
+    readonly_gen, _ = oracle_generation_readonly(root, mode, epoch_out=readonly_epochs)
+    assert frozen_gen == readonly_gen
+    return frozen_epochs[0], readonly_epochs[0]
+
+
+def test_clean_repo_generations_match(git_repo: str) -> None:
+    for mode in ("diff", "staged"):
+        frozen_epoch, readonly_epoch = _epochs(git_repo, mode)
+        assert frozen_epoch.tracked_paths == readonly_epoch.tracked_paths
+        assert frozen_epoch.dirty_paths == readonly_epoch.dirty_paths
+        assert frozen_epoch.untracked_paths == readonly_epoch.untracked_paths
+
+
+def test_dirty_and_untracked_generations_match(git_repo: str) -> None:
+    import pathlib
+
+    root = pathlib.Path(git_repo)
+    (root / "base.py").write_text("value = 2\n", encoding="utf-8")
+    (root / "new_file.py").write_text("brand = 'new'\n", encoding="utf-8")
+    (root / "ignored.log").write_text("noise\n", encoding="utf-8")
+    (root / ".gitignore").write_text("*.log\n", encoding="utf-8")
+
+    frozen_epoch, readonly_epoch = _epochs(git_repo, "diff")
+    # The frozen oracle's stat-invalidation framing conservatively reports
+    # every tracked path dirty; the P0.4 oracle replicates it exactly.
+    assert frozen_epoch.dirty_paths == (b"base.py", b"keep.py")
+    assert frozen_epoch.untracked_paths == (b".gitignore", b"new_file.py")
+    assert readonly_epoch.dirty_paths == frozen_epoch.dirty_paths
+    assert readonly_epoch.untracked_paths == frozen_epoch.untracked_paths
+
+    # Staged mode ignores the worktree dirt but includes the staged change.
+    subprocess.run(["git", "-C", git_repo, "add", "base.py"], check=True)
+    frozen_epoch, readonly_epoch = _epochs(git_repo, "staged")
+    assert readonly_epoch.dirty_paths == frozen_epoch.dirty_paths
+    assert readonly_epoch.untracked_paths == frozen_epoch.untracked_paths
+
+
+def test_generation_changes_when_source_changes(git_repo: str) -> None:
+    import pathlib
+
+    before = oracle_generation_readonly(git_repo, "diff")[0]
+    pathlib.Path(git_repo, "base.py").write_text("value = 3\n", encoding="utf-8")
+    after = oracle_generation_readonly(git_repo, "diff")[0]
+    assert before != after
+    # Deterministic for the same state.
+    assert after == oracle_generation_readonly(git_repo, "diff")[0]
+
+
+def test_readonly_never_materializes_temporary_index(git_repo: str) -> None:
+    import tempfile
+
+    mkstemp_calls: list[str] = []
+
+    def spy_mkstemp(*args, **kwargs):
+        mkstemp_calls.append("mkstemp")
+        return tempfile.mkstemp(*args, **kwargs)
+
+    # The read-only oracle must never invoke the temp-index machinery.
+    frozen_epochs: list[GitEpoch] = []
+    oracle_generation_readonly(git_repo, "diff", epoch_out=frozen_epochs)
+    assert mkstemp_calls == []
+
+
+def test_live_index_output_is_readonly_invocation(git_repo: str) -> None:
+    """GIT_OPTIONAL_LOCKS=0 is set and no GIT_INDEX_FILE is injected."""
+    import tree_sitter_analyzer.diff_snapshot_readonly as module
+
+    seen_env: dict[str, str] = {}
+
+    def spy(root, args, *, deadline, limit, env=None, input_=None):
+        seen_env.update(dict(env or {}))
+        return b""
+
+    original = module._run_git_readonly_bounded
+    module._run_git_readonly_bounded = spy
+    try:
+        import time as _time
+
+        _live_index_output(
+            git_repo,
+            b"",
+            ["ls-files", "--others"],
+            deadline=_time.monotonic() + 35.0,
+            limit=1024,
+        )
+    finally:
+        module._run_git_readonly_bounded = original
+    assert seen_env.get("GIT_OPTIONAL_LOCKS") == "0"
+    assert "GIT_INDEX_FILE" not in seen_env

--- a/tests/unit/test_diff_snapshot_readonly.py
+++ b/tests/unit/test_diff_snapshot_readonly.py
@@ -11,6 +11,7 @@ assert the read-only invocation set never materializes a temporary index.
 from __future__ import annotations
 
 import os
+import pathlib
 import subprocess
 import time
 from pathlib import Path
@@ -125,8 +126,8 @@ def test_live_index_output_is_readonly_invocation(git_repo: str) -> None:
         seen_env.update(dict(env or {}))
         return b""
 
-    original = module._run_git_readonly_bounded
-    module._run_git_readonly_bounded = spy
+    original = module.run_git_readonly
+    module.run_git_readonly = spy
     try:
         import time as _time
 
@@ -138,7 +139,7 @@ def test_live_index_output_is_readonly_invocation(git_repo: str) -> None:
             limit=1024,
         )
     finally:
-        module._run_git_readonly_bounded = original
+        module.run_git_readonly = original
     assert seen_env.get("GIT_OPTIONAL_LOCKS") == "0"
     assert "GIT_INDEX_FILE" not in seen_env
 
@@ -206,7 +207,7 @@ def test_capacity_fails_closed(git_repo: str) -> None:
 
 @POSIX_SNAPSHOT_TEST
 def test_runner_popen_failure_is_stable_error(git_repo: str, monkeypatch) -> None:
-    import tree_sitter_analyzer.diff_snapshot_readonly as module
+    import tree_sitter_analyzer.git_readonly as module
 
     def boom(*args, **kwargs):
         raise OSError("no git here")
@@ -262,7 +263,7 @@ class _UnboundedStream:
 
 @POSIX_SNAPSHOT_TEST
 def test_runner_stream_failure_is_stable_error(git_repo: str, monkeypatch) -> None:
-    import tree_sitter_analyzer.diff_snapshot_readonly as module
+    import tree_sitter_analyzer.git_readonly as module
 
     for proc in (
         _FakeProc(stdout=None, stderr=None),  # missing streams
@@ -375,14 +376,14 @@ def test_empty_repo_generations_match(tmp_path) -> None:
 def test_root_resolution_failure_fails_closed(git_repo: str, monkeypatch) -> None:
     import tree_sitter_analyzer.diff_snapshot_readonly as module
 
-    original = module.git_output
+    original = module._git_output_readonly
 
     def fake_git_output(root, args, *, deadline, limit):
         if args and args[0] == "rev-parse" and "--show-toplevel" in args:
             return b"no-such-dir-xyz\n"  # canonical_root stat fails
         return original(root, args, deadline=deadline, limit=limit)
 
-    monkeypatch.setattr(module, "git_output", fake_git_output)
+    monkeypatch.setattr(module, "_git_output_readonly", fake_git_output)
     with pytest.raises(Exception, match="DIFF_SNAPSHOT_ROOT_MISMATCH"):
         oracle_generation_readonly(git_repo, "diff")
 
@@ -405,7 +406,7 @@ class _BrokenStdin:
 
 @POSIX_SNAPSHOT_TEST
 def test_runner_feed_broken_pipe_is_ignored(git_repo: str, monkeypatch) -> None:
-    import tree_sitter_analyzer.diff_snapshot_readonly as module
+    import tree_sitter_analyzer.git_readonly as module
 
     class _EmptyStream:
         def read(self, size):
@@ -436,7 +437,7 @@ def test_runner_feed_broken_pipe_is_ignored(git_repo: str, monkeypatch) -> None:
 
 @POSIX_SNAPSHOT_TEST
 def test_runner_blocking_stream_times_out(git_repo: str, monkeypatch) -> None:
-    import tree_sitter_analyzer.diff_snapshot_readonly as module
+    import tree_sitter_analyzer.git_readonly as module
 
     proc = _FakeProc(stdout=_BlockingStream(), stderr=_BlockingStream())
     monkeypatch.setattr(module.subprocess, "Popen", lambda *a, **k: proc)
@@ -452,7 +453,7 @@ def test_runner_blocking_stream_times_out(git_repo: str, monkeypatch) -> None:
 
 @POSIX_SNAPSHOT_TEST
 def test_runner_kill_cleanup_swallows_wait_errors(git_repo: str, monkeypatch) -> None:
-    import tree_sitter_analyzer.diff_snapshot_readonly as module
+    import tree_sitter_analyzer.git_readonly as module
 
     class _SlowKillProc(_FakeProc):
         def wait(self, timeout=0):
@@ -480,7 +481,7 @@ def test_runner_kill_cleanup_swallows_wait_errors(git_repo: str, monkeypatch) ->
 
 @POSIX_SNAPSHOT_TEST
 def test_runner_nonzero_exit_is_stable_error(git_repo: str, monkeypatch) -> None:
-    import tree_sitter_analyzer.diff_snapshot_readonly as module
+    import tree_sitter_analyzer.git_readonly as module
 
     class _EmptyStream:
         def read(self, size):
@@ -496,3 +497,148 @@ def test_runner_nonzero_exit_is_stable_error(git_repo: str, monkeypatch) -> None
             deadline=time.monotonic() + 35.0,
             limit=1024,
         )
+
+
+def test_assume_unchanged_hint_preserves_generation_equality(
+    git_repo: str,
+) -> None:
+    # Codex #1293 P1: assume-unchanged paths are never dirty and never
+    # content-framed by the frozen oracle; the P0.4 oracle must replicate.
+    subprocess.run(
+        ["git", "-C", git_repo, "update-index", "--assume-unchanged", "keep.py"],
+        check=True,
+    )
+    frozen_epoch, readonly_epoch = _epochs(git_repo, "diff")
+    assert b"keep.py" not in frozen_epoch.dirty_paths
+    assert readonly_epoch.dirty_paths == frozen_epoch.dirty_paths
+
+
+def test_configured_orderfile_fails_closed(git_repo: str) -> None:
+    subprocess.run(
+        ["git", "-C", git_repo, "config", "diff.orderFile", "order.txt"],
+        check=True,
+    )
+    with pytest.raises(Exception, match="DIFF_SNAPSHOT_UNSUPPORTED_ORDERFILE"):
+        oracle_generation_readonly(git_repo, "staged")
+
+
+def test_index_entries_parser_matches_ls_files(git_repo: str) -> None:
+    from tree_sitter_analyzer.diff_snapshot_readonly import (
+        _index_entries_from_bytes,
+    )
+    from tree_sitter_analyzer.source_oracle_git import _index_entries
+
+    index_bytes = pathlib.Path(git_repo, ".git", "index").read_bytes()
+    mine = _index_entries_from_bytes(index_bytes, "sha1", 200_000)
+    frozen = _index_entries(
+        git_repo, deadline=time.monotonic() + 35.0, index_bytes=None
+    )
+    assert mine == frozen
+
+
+def test_hinted_paths_detection(git_repo: str) -> None:
+    from tree_sitter_analyzer.diff_snapshot_readonly import _hinted_paths
+
+    subprocess.run(
+        ["git", "-C", git_repo, "update-index", "--assume-unchanged", "keep.py"],
+        check=True,
+    )
+    index_bytes = pathlib.Path(git_repo, ".git", "index").read_bytes()
+    assert _hinted_paths(index_bytes, "sha1", 200_000) == {b"keep.py"}
+
+
+def test_object_format_readonly_rejects_unknown(git_repo: str, monkeypatch) -> None:
+    import tree_sitter_analyzer.diff_snapshot_readonly as module
+
+    monkeypatch.setattr(
+        module,
+        "_git_output_readonly",
+        lambda root, args, *, deadline, limit: b"md5\n",
+    )
+    with pytest.raises(Exception, match="DIFF_SNAPSHOT_GIT_ERROR"):
+        module._object_format_readonly(git_repo, deadline=time.monotonic() + 35.0)
+
+
+def test_head_identity_symbolic_ref_failure(git_repo: str, monkeypatch) -> None:
+    import tree_sitter_analyzer.diff_snapshot_readonly as module
+
+    def fake(root, args, *, deadline, limit):
+        if "--verify" in args:
+            raise module.SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR")
+        raise module.SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR")
+
+    monkeypatch.setattr(module, "_git_output_readonly", fake)
+    with pytest.raises(Exception, match="DIFF_SNAPSHOT_GIT_ERROR"):
+        module._head_identity_readonly(git_repo, deadline=time.monotonic() + 35.0)
+
+
+def test_index_parser_rejects_unknown_version() -> None:
+    from tree_sitter_analyzer.diff_snapshot_readonly import (
+        _hinted_paths,
+        _index_entries_from_bytes,
+    )
+
+    bogus = b"DIRC" + (4).to_bytes(4, "big") + (0).to_bytes(4, "big")
+    for parser in (_hinted_paths, _index_entries_from_bytes):
+        with pytest.raises(Exception, match="DIFF_SNAPSHOT_UNSUPPORTED_INDEX"):
+            parser(bogus, "sha1", 100)
+
+
+def test_index_parser_rejects_malformed_entry() -> None:
+    from tree_sitter_analyzer.diff_snapshot_readonly import _hinted_paths
+
+    # v2 header claiming one entry but no entry bytes.
+    truncated = b"DIRC" + (2).to_bytes(4, "big") + (1).to_bytes(4, "big")
+    truncated += b"\0" * 20  # far too short for an entry
+    with pytest.raises(Exception, match="DIFF_SNAPSHOT_GIT_ERROR"):
+        _hinted_paths(truncated, "sha1", 100)
+    # Entry with a valid fixed part but an unterminated path.
+    entry = b"\0" * 62 + b"no-nul-path"
+    truncated2 = b"DIRC" + (2).to_bytes(4, "big") + (1).to_bytes(4, "big")
+    truncated2 += entry + b"\0" * 20
+    with pytest.raises(Exception, match="DIFF_SNAPSHOT_GIT_ERROR"):
+        _hinted_paths(truncated2, "sha1", 100)
+
+
+def test_entries_parser_rejects_malformed_and_skips_staged() -> None:
+    from tree_sitter_analyzer.diff_snapshot_readonly import _index_entries_from_bytes
+
+    # Truncated entry (fixed part beyond the content end).
+    short = b"DIRC" + (2).to_bytes(4, "big") + (1).to_bytes(4, "big")
+    short += b"\0" * 30 + b"\0" * 20
+    with pytest.raises(Exception, match="DIFF_SNAPSHOT_GIT_ERROR"):
+        _index_entries_from_bytes(short, "sha1", 100)
+    # Unterminated path.
+    bad = b"DIRC" + (2).to_bytes(4, "big") + (1).to_bytes(4, "big")
+    bad += b"\0" * 62 + b"no-nul-path" + b"\0" * 20
+    with pytest.raises(Exception, match="DIFF_SNAPSHOT_GIT_ERROR"):
+        _index_entries_from_bytes(bad, "sha1", 100)
+    # A stage-1 entry (conflict) is skipped; stage-0 is kept. Each entry is
+    # padded to a multiple of 8 bytes total.
+    flags_stage1 = (1 << 12).to_bytes(2, "big")
+    fixed = b"\0" * 40 + b"\x01" * 20 + flags_stage1
+    entry1 = fixed + b"conflict.py\x00" + b"\x00" * 6  # 62+12 -> 80
+    flags_stage0 = (0).to_bytes(2, "big")
+    fixed0 = b"\0" * 24 + (0o100644).to_bytes(4, "big") + b"\0" * 12
+    fixed0 += b"\x02" * 20 + flags_stage0
+    entry0 = fixed0 + b"ok.py\x00" + b"\x00" * 4  # 62+6 -> 72
+    payload = b"DIRC" + (2).to_bytes(4, "big") + (2).to_bytes(4, "big")
+    payload += entry1 + entry0 + b"\0" * 20
+    parsed = _index_entries_from_bytes(payload, "sha1", 100)
+    assert set(parsed) == {b"ok.py"}
+    assert parsed[b"ok.py"] == (
+        b"100644 " + (b"\x02" * 20).hex().encode("ascii") + b" 0"
+    )
+
+
+def test_entries_parser_capacity_bound() -> None:
+    from tree_sitter_analyzer.diff_snapshot_readonly import _index_entries_from_bytes
+
+    flags_stage0 = (0).to_bytes(2, "big")
+    fixed0 = b"\0" * 24 + (0o100644).to_bytes(4, "big") + b"\0" * 12
+    fixed0 += b"\x02" * 20 + flags_stage0
+    entry0 = fixed0 + b"ok.py\x00" + b"\x00" * 4  # 62+6 -> 72
+    payload = b"DIRC" + (2).to_bytes(4, "big") + (1).to_bytes(4, "big")
+    payload += entry0 + b"\0" * 20
+    with pytest.raises(Exception, match="DIFF_SNAPSHOT_CAPACITY"):
+        _index_entries_from_bytes(payload, "sha1", max_paths=0)

--- a/tests/unit/test_diff_snapshot_readonly.py
+++ b/tests/unit/test_diff_snapshot_readonly.py
@@ -14,6 +14,7 @@ import subprocess
 
 import pytest
 
+from tests.unit._diff_snapshot_support import POSIX_SNAPSHOT_TEST
 from tree_sitter_analyzer.diff_snapshot_readonly import (
     _live_index_output,
     oracle_generation_readonly,
@@ -43,6 +44,7 @@ def _epochs(root: str, mode: str) -> tuple[GitEpoch, GitEpoch]:
     return frozen_epochs[0], readonly_epochs[0]
 
 
+@POSIX_SNAPSHOT_TEST
 def test_clean_repo_generations_match(git_repo: str) -> None:
     for mode in ("diff", "staged"):
         frozen_epoch, readonly_epoch = _epochs(git_repo, mode)
@@ -51,6 +53,7 @@ def test_clean_repo_generations_match(git_repo: str) -> None:
         assert frozen_epoch.untracked_paths == readonly_epoch.untracked_paths
 
 
+@POSIX_SNAPSHOT_TEST
 def test_dirty_and_untracked_generations_match(git_repo: str) -> None:
     import pathlib
 
@@ -75,6 +78,7 @@ def test_dirty_and_untracked_generations_match(git_repo: str) -> None:
     assert readonly_epoch.untracked_paths == frozen_epoch.untracked_paths
 
 
+@POSIX_SNAPSHOT_TEST
 def test_generation_changes_when_source_changes(git_repo: str) -> None:
     import pathlib
 
@@ -86,6 +90,7 @@ def test_generation_changes_when_source_changes(git_repo: str) -> None:
     assert after == oracle_generation_readonly(git_repo, "diff")[0]
 
 
+@POSIX_SNAPSHOT_TEST
 def test_readonly_never_materializes_temporary_index(git_repo: str) -> None:
     import tempfile
 
@@ -101,6 +106,7 @@ def test_readonly_never_materializes_temporary_index(git_repo: str) -> None:
     assert mkstemp_calls == []
 
 
+@POSIX_SNAPSHOT_TEST
 def test_live_index_output_is_readonly_invocation(git_repo: str) -> None:
     """GIT_OPTIONAL_LOCKS=0 is set and no GIT_INDEX_FILE is injected."""
     import tree_sitter_analyzer.diff_snapshot_readonly as module

--- a/tests/unit/test_diff_snapshot_readonly.py
+++ b/tests/unit/test_diff_snapshot_readonly.py
@@ -10,7 +10,10 @@ assert the read-only invocation set never materializes a temporary index.
 
 from __future__ import annotations
 
+import os
 import subprocess
+import time
+from pathlib import Path
 
 import pytest
 
@@ -133,3 +136,341 @@ def test_live_index_output_is_readonly_invocation(git_repo: str) -> None:
         module._run_git_readonly_bounded = original
     assert seen_env.get("GIT_OPTIONAL_LOCKS") == "0"
     assert "GIT_INDEX_FILE" not in seen_env
+
+
+def test_workspace_unsupported_fails_closed(git_repo: str, monkeypatch) -> None:
+    import tree_sitter_analyzer.diff_snapshot_readonly as module
+
+    monkeypatch.setattr(module, "_supports_nofollow", lambda: False)
+    with pytest.raises(Exception, match="DIFF_SNAPSHOT_WORKSPACE_UNSUPPORTED"):
+        oracle_generation_readonly(git_repo, "diff")
+
+
+def test_root_mismatch_fails_closed(git_repo: str) -> None:
+    import os
+
+    subdir = os.path.join(git_repo, "sub")
+    os.mkdir(subdir)
+    with pytest.raises(Exception, match="DIFF_SNAPSHOT_ROOT_MISMATCH"):
+        oracle_generation_readonly(subdir, "diff")
+
+
+def test_gitlink_generations_match(git_repo: str) -> None:
+    import pathlib
+
+    # A local-path submodule produces a 160000 gitlink entry; both oracles
+    # frame it identically (dirty marker + index identity).
+    sub_repo = pathlib.Path(git_repo, "vendor")
+    sub_repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(sub_repo)], check=True)
+    subprocess.run(
+        ["git", "-C", str(sub_repo), "config", "user.email", "t@t"], check=True
+    )
+    subprocess.run(["git", "-C", str(sub_repo), "config", "user.name", "t"], check=True)
+    (sub_repo / "lib.py").write_text("x = 1\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(sub_repo), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(sub_repo), "commit", "-qm", "sub"], check=True)
+    subprocess.run(
+        ["git", "-C", git_repo, "submodule", "add", "-q", str(sub_repo), "vendor"],
+        check=True,
+    )
+    frozen_epoch, readonly_epoch = _epochs(git_repo, "diff")
+    assert frozen_epoch.workspace_gitlinks == readonly_epoch.workspace_gitlinks
+    # git's diff-files name-only never reports gitlink entries (live or
+    # stat-invalidated), so neither oracle frames gitlink-dirty evidence;
+    # the gitlink is framed as an opaque tracked path instead.
+    assert frozen_epoch.workspace_gitlinks == ()
+    assert b"vendor" in frozen_epoch.tracked_paths
+
+
+def test_split_index_fails_closed(git_repo: str) -> None:
+    subprocess.run(["git", "-C", git_repo, "update-index", "--split-index"], check=True)
+    with pytest.raises(Exception, match="DIFF_SNAPSHOT_UNSUPPORTED_INDEX"):
+        oracle_generation_readonly(git_repo, "diff")
+
+
+def test_capacity_fails_closed(git_repo: str) -> None:
+    with pytest.raises(Exception, match="DIFF_SNAPSHOT_CAPACITY"):
+        oracle_generation_readonly(git_repo, "diff", byte_ceiling=1)
+
+
+def test_runner_popen_failure_is_stable_error(git_repo: str, monkeypatch) -> None:
+    import tree_sitter_analyzer.diff_snapshot_readonly as module
+
+    def boom(*args, **kwargs):
+        raise OSError("no git here")
+
+    monkeypatch.setattr(module.subprocess, "Popen", boom)
+    with pytest.raises(Exception, match="DIFF_SNAPSHOT_GIT_ERROR"):
+        _live_index_output(
+            git_repo,
+            b"",
+            ["ls-files", "--others"],
+            deadline=time.monotonic() + 35.0,
+            limit=1024,
+        )
+
+
+def test_runner_negative_limit_fails_closed(git_repo: str) -> None:
+    with pytest.raises(Exception, match="DIFF_SNAPSHOT_CAPACITY"):
+        _live_index_output(
+            git_repo,
+            b"",
+            ["ls-files", "--others"],
+            deadline=time.monotonic() + 35.0,
+            limit=-1,
+        )
+
+
+class _FakeProc:
+    """Minimal fake subprocess for runner error-path tests."""
+
+    def __init__(self, stdout, stderr, stdin=None, returncode=1):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.stdin = stdin
+        self.returncode = returncode
+
+    def wait(self, timeout=0):
+        return 0
+
+    def kill(self):
+        pass
+
+
+class _RaisingStream:
+    def read(self, size):
+        raise OSError("stream gone")
+
+
+class _UnboundedStream:
+    def read(self, size):
+        return b"x" * 65536
+
+
+def test_runner_stream_failure_is_stable_error(git_repo: str, monkeypatch) -> None:
+    import tree_sitter_analyzer.diff_snapshot_readonly as module
+
+    for proc in (
+        _FakeProc(stdout=None, stderr=None),  # missing streams
+        _FakeProc(stdout=_RaisingStream(), stderr=_RaisingStream()),
+        _FakeProc(stdout=_UnboundedStream(), stderr=_UnboundedStream()),
+    ):
+
+        def fake_popen(*a, _proc=proc, **k):
+            return _proc
+
+        monkeypatch.setattr(module.subprocess, "Popen", fake_popen)
+        with pytest.raises(
+            Exception, match="DIFF_SNAPSHOT_GIT_ERROR|DIFF_SNAPSHOT_CAPACITY"
+        ):
+            _live_index_output(
+                git_repo,
+                b"",
+                ["ls-files", "--others"],
+                deadline=time.monotonic() + 35.0,
+                limit=1024,
+            )
+
+
+def test_dirty_gitlink_frames_opaque_evidence(git_repo: str, monkeypatch) -> None:
+    # Mirrors the frozen oracle's own dirty-gitlink test (monkeypatched
+    # inventory): a gitlink reported in the dirty set frames opaque
+    # evidence and is retained as workspace_gitlinks.
+    import tree_sitter_analyzer.diff_snapshot_readonly as module
+
+    sub_repo = os.path.join(git_repo, "vendor")
+    os.mkdir(sub_repo)
+    subprocess.run(["git", "init", "-q", sub_repo], check=True)
+    subprocess.run(["git", "-C", sub_repo, "config", "user.email", "t@t"], check=True)
+    subprocess.run(["git", "-C", sub_repo, "config", "user.name", "t"], check=True)
+    (Path(sub_repo) / "lib.py").write_text("x = 1\n", encoding="utf-8")
+    subprocess.run(["git", "-C", sub_repo, "add", "."], check=True)
+    subprocess.run(["git", "-C", sub_repo, "commit", "-qm", "sub"], check=True)
+    subprocess.run(
+        ["git", "-C", git_repo, "submodule", "add", "-q", sub_repo, "vendor"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", git_repo, "commit", "-qm", "add submodule"], check=True
+    )
+    original = module._live_index_output
+
+    def fake_live_output(root, index_bytes, args, **kwargs):
+        if args and args[0] == "diff-files":
+            return b"vendor\0"
+        return original(root, index_bytes, args, **kwargs)
+
+    monkeypatch.setattr(module, "_live_index_output", fake_live_output)
+    epochs: list = []
+    oracle_generation_readonly(git_repo, "diff", epoch_out=epochs)
+    entry = dict(epochs[0].index_entries)[b"vendor"]
+    assert entry.startswith(b"160000 ")
+    assert epochs[0].workspace_gitlinks == ((b"vendor", entry),)
+
+
+def test_inventory_consistency_check_fails_closed(git_repo: str, monkeypatch) -> None:
+    import tree_sitter_analyzer.diff_snapshot_readonly as module
+
+    original = module._live_index_output
+
+    def fake_live_output(root, index_bytes, args, **kwargs):
+        if args and args[0] == "diff-files":
+            return b"not-tracked.py\0"
+        return original(root, index_bytes, args, **kwargs)
+
+    monkeypatch.setattr(module, "_live_index_output", fake_live_output)
+    with pytest.raises(Exception, match="DIFF_SNAPSHOT_GIT_ERROR"):
+        oracle_generation_readonly(git_repo, "diff")
+
+
+def test_worktree_path_capacity_fails_closed(git_repo: str, monkeypatch) -> None:
+    import tree_sitter_analyzer.diff_snapshot_readonly as module
+
+    original = module._live_index_output
+    many = b"".join(f"f{i}.py\0".encode() for i in range(250_000))
+
+    def fake_live_output(root, index_bytes, args, **kwargs):
+        if args and args[0] == "ls-files":
+            return many
+        return original(root, index_bytes, args, **kwargs)
+
+    monkeypatch.setattr(module, "_live_index_output", fake_live_output)
+    with pytest.raises(Exception, match="DIFF_SNAPSHOT_CAPACITY"):
+        oracle_generation_readonly(git_repo, "diff")
+
+
+def test_empty_repo_generations_match(tmp_path) -> None:
+    root = str(tmp_path / "empty")
+    os.mkdir(root)
+    subprocess.run(["git", "init", "-q", root], check=True)
+    for mode in ("diff", "staged"):
+        frozen_epochs: list = []
+        readonly_epochs: list = []
+        frozen_gen, _ = oracle_generation(root, mode, epoch_out=frozen_epochs)
+        readonly_gen, _ = oracle_generation_readonly(
+            root, mode, epoch_out=readonly_epochs
+        )
+        assert frozen_gen == readonly_gen
+
+
+def test_root_resolution_failure_fails_closed(git_repo: str, monkeypatch) -> None:
+    import tree_sitter_analyzer.diff_snapshot_readonly as module
+
+    original = module.git_output
+
+    def fake_git_output(root, args, *, deadline, limit):
+        if args and args[0] == "rev-parse" and "--show-toplevel" in args:
+            return b"no-such-dir-xyz\n"  # canonical_root stat fails
+        return original(root, args, deadline=deadline, limit=limit)
+
+    monkeypatch.setattr(module, "git_output", fake_git_output)
+    with pytest.raises(Exception, match="DIFF_SNAPSHOT_ROOT_MISMATCH"):
+        oracle_generation_readonly(git_repo, "diff")
+
+
+class _BlockingStream:
+    def read(self, size):
+        import time as _t
+
+        _t.sleep(30)  # blocks past any reasonable deadline
+        return b""
+
+
+class _BrokenStdin:
+    def write(self, data):
+        raise BrokenPipeError("pipe closed")
+
+    def close(self):
+        pass
+
+
+def test_runner_feed_broken_pipe_is_ignored(git_repo: str, monkeypatch) -> None:
+    import tree_sitter_analyzer.diff_snapshot_readonly as module
+
+    class _EmptyStream:
+        def read(self, size):
+            return b""
+
+    for stdin in (None, _BrokenStdin()):
+        proc = _FakeProc(
+            stdout=_EmptyStream(),
+            stderr=_EmptyStream(),
+            stdin=stdin,
+            returncode=0,
+        )
+
+        def fake_popen(*a, _proc=proc, **k):
+            return _proc
+
+        monkeypatch.setattr(module.subprocess, "Popen", fake_popen)
+        out = _live_index_output(
+            git_repo,
+            b"",
+            ["ls-files", "--others"],
+            deadline=time.monotonic() + 35.0,
+            limit=1024,
+            input_=b"input-data",
+        )
+        assert out == b""
+
+
+def test_runner_blocking_stream_times_out(git_repo: str, monkeypatch) -> None:
+    import tree_sitter_analyzer.diff_snapshot_readonly as module
+
+    proc = _FakeProc(stdout=_BlockingStream(), stderr=_BlockingStream())
+    monkeypatch.setattr(module.subprocess, "Popen", lambda *a, **k: proc)
+    with pytest.raises(Exception, match="DIFF_SNAPSHOT_TIMEOUT"):
+        _live_index_output(
+            git_repo,
+            b"",
+            ["ls-files", "--others"],
+            deadline=time.monotonic() + 0.8,
+            limit=1024,
+        )
+
+
+def test_runner_kill_cleanup_swallows_wait_errors(git_repo: str, monkeypatch) -> None:
+    import tree_sitter_analyzer.diff_snapshot_readonly as module
+
+    class _SlowKillProc(_FakeProc):
+        def wait(self, timeout=0):
+            if self._wait_calls:
+                raise subprocess.TimeoutExpired("git", 0)
+            self._wait_calls = True
+            return 0
+
+    class _EmptyStream:
+        def read(self, size):
+            return b""
+
+    proc = _SlowKillProc(stdout=_EmptyStream(), stderr=_EmptyStream(), returncode=1)
+    proc._wait_calls = False
+    monkeypatch.setattr(module.subprocess, "Popen", lambda *a, **k: proc)
+    with pytest.raises(Exception, match="DIFF_SNAPSHOT_GIT_ERROR"):
+        _live_index_output(
+            git_repo,
+            b"",
+            ["ls-files", "--others"],
+            deadline=time.monotonic() + 35.0,
+            limit=1024,
+        )
+
+
+def test_runner_nonzero_exit_is_stable_error(git_repo: str, monkeypatch) -> None:
+    import tree_sitter_analyzer.diff_snapshot_readonly as module
+
+    class _EmptyStream:
+        def read(self, size):
+            return b""
+
+    proc = _FakeProc(stdout=_EmptyStream(), stderr=_EmptyStream(), returncode=2)
+    monkeypatch.setattr(module.subprocess, "Popen", lambda *a, **k: proc)
+    with pytest.raises(Exception, match="DIFF_SNAPSHOT_GIT_ERROR"):
+        _live_index_output(
+            git_repo,
+            b"",
+            ["ls-files", "--others"],
+            deadline=time.monotonic() + 35.0,
+            limit=1024,
+        )

--- a/tests/unit/test_diff_snapshot_readonly.py
+++ b/tests/unit/test_diff_snapshot_readonly.py
@@ -48,6 +48,7 @@ def _epochs(root: str, mode: str) -> tuple[GitEpoch, GitEpoch]:
 
 
 @POSIX_SNAPSHOT_TEST
+@POSIX_SNAPSHOT_TEST
 def test_clean_repo_generations_match(git_repo: str) -> None:
     for mode in ("diff", "staged"):
         frozen_epoch, readonly_epoch = _epochs(git_repo, mode)
@@ -56,6 +57,7 @@ def test_clean_repo_generations_match(git_repo: str) -> None:
         assert frozen_epoch.untracked_paths == readonly_epoch.untracked_paths
 
 
+@POSIX_SNAPSHOT_TEST
 @POSIX_SNAPSHOT_TEST
 def test_dirty_and_untracked_generations_match(git_repo: str) -> None:
     import pathlib
@@ -82,6 +84,7 @@ def test_dirty_and_untracked_generations_match(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
+@POSIX_SNAPSHOT_TEST
 def test_generation_changes_when_source_changes(git_repo: str) -> None:
     import pathlib
 
@@ -93,6 +96,7 @@ def test_generation_changes_when_source_changes(git_repo: str) -> None:
     assert after == oracle_generation_readonly(git_repo, "diff")[0]
 
 
+@POSIX_SNAPSHOT_TEST
 @POSIX_SNAPSHOT_TEST
 def test_readonly_never_materializes_temporary_index(git_repo: str) -> None:
     import tempfile
@@ -109,6 +113,7 @@ def test_readonly_never_materializes_temporary_index(git_repo: str) -> None:
     assert mkstemp_calls == []
 
 
+@POSIX_SNAPSHOT_TEST
 @POSIX_SNAPSHOT_TEST
 def test_live_index_output_is_readonly_invocation(git_repo: str) -> None:
     """GIT_OPTIONAL_LOCKS=0 is set and no GIT_INDEX_FILE is injected."""
@@ -138,6 +143,7 @@ def test_live_index_output_is_readonly_invocation(git_repo: str) -> None:
     assert "GIT_INDEX_FILE" not in seen_env
 
 
+@POSIX_SNAPSHOT_TEST
 def test_workspace_unsupported_fails_closed(git_repo: str, monkeypatch) -> None:
     import tree_sitter_analyzer.diff_snapshot_readonly as module
 
@@ -146,6 +152,7 @@ def test_workspace_unsupported_fails_closed(git_repo: str, monkeypatch) -> None:
         oracle_generation_readonly(git_repo, "diff")
 
 
+@POSIX_SNAPSHOT_TEST
 def test_root_mismatch_fails_closed(git_repo: str) -> None:
     import os
 
@@ -155,6 +162,7 @@ def test_root_mismatch_fails_closed(git_repo: str) -> None:
         oracle_generation_readonly(subdir, "diff")
 
 
+@POSIX_SNAPSHOT_TEST
 def test_gitlink_generations_match(git_repo: str) -> None:
     import pathlib
 
@@ -183,17 +191,20 @@ def test_gitlink_generations_match(git_repo: str) -> None:
     assert b"vendor" in frozen_epoch.tracked_paths
 
 
+@POSIX_SNAPSHOT_TEST
 def test_split_index_fails_closed(git_repo: str) -> None:
     subprocess.run(["git", "-C", git_repo, "update-index", "--split-index"], check=True)
     with pytest.raises(Exception, match="DIFF_SNAPSHOT_UNSUPPORTED_INDEX"):
         oracle_generation_readonly(git_repo, "diff")
 
 
+@POSIX_SNAPSHOT_TEST
 def test_capacity_fails_closed(git_repo: str) -> None:
     with pytest.raises(Exception, match="DIFF_SNAPSHOT_CAPACITY"):
         oracle_generation_readonly(git_repo, "diff", byte_ceiling=1)
 
 
+@POSIX_SNAPSHOT_TEST
 def test_runner_popen_failure_is_stable_error(git_repo: str, monkeypatch) -> None:
     import tree_sitter_analyzer.diff_snapshot_readonly as module
 
@@ -211,6 +222,7 @@ def test_runner_popen_failure_is_stable_error(git_repo: str, monkeypatch) -> Non
         )
 
 
+@POSIX_SNAPSHOT_TEST
 def test_runner_negative_limit_fails_closed(git_repo: str) -> None:
     with pytest.raises(Exception, match="DIFF_SNAPSHOT_CAPACITY"):
         _live_index_output(
@@ -248,6 +260,7 @@ class _UnboundedStream:
         return b"x" * 65536
 
 
+@POSIX_SNAPSHOT_TEST
 def test_runner_stream_failure_is_stable_error(git_repo: str, monkeypatch) -> None:
     import tree_sitter_analyzer.diff_snapshot_readonly as module
 
@@ -273,6 +286,7 @@ def test_runner_stream_failure_is_stable_error(git_repo: str, monkeypatch) -> No
             )
 
 
+@POSIX_SNAPSHOT_TEST
 def test_dirty_gitlink_frames_opaque_evidence(git_repo: str, monkeypatch) -> None:
     # Mirrors the frozen oracle's own dirty-gitlink test (monkeypatched
     # inventory): a gitlink reported in the dirty set frames opaque
@@ -309,6 +323,7 @@ def test_dirty_gitlink_frames_opaque_evidence(git_repo: str, monkeypatch) -> Non
     assert epochs[0].workspace_gitlinks == ((b"vendor", entry),)
 
 
+@POSIX_SNAPSHOT_TEST
 def test_inventory_consistency_check_fails_closed(git_repo: str, monkeypatch) -> None:
     import tree_sitter_analyzer.diff_snapshot_readonly as module
 
@@ -324,6 +339,7 @@ def test_inventory_consistency_check_fails_closed(git_repo: str, monkeypatch) ->
         oracle_generation_readonly(git_repo, "diff")
 
 
+@POSIX_SNAPSHOT_TEST
 def test_worktree_path_capacity_fails_closed(git_repo: str, monkeypatch) -> None:
     import tree_sitter_analyzer.diff_snapshot_readonly as module
 
@@ -340,6 +356,7 @@ def test_worktree_path_capacity_fails_closed(git_repo: str, monkeypatch) -> None
         oracle_generation_readonly(git_repo, "diff")
 
 
+@POSIX_SNAPSHOT_TEST
 def test_empty_repo_generations_match(tmp_path) -> None:
     root = str(tmp_path / "empty")
     os.mkdir(root)
@@ -354,6 +371,7 @@ def test_empty_repo_generations_match(tmp_path) -> None:
         assert frozen_gen == readonly_gen
 
 
+@POSIX_SNAPSHOT_TEST
 def test_root_resolution_failure_fails_closed(git_repo: str, monkeypatch) -> None:
     import tree_sitter_analyzer.diff_snapshot_readonly as module
 
@@ -385,6 +403,7 @@ class _BrokenStdin:
         pass
 
 
+@POSIX_SNAPSHOT_TEST
 def test_runner_feed_broken_pipe_is_ignored(git_repo: str, monkeypatch) -> None:
     import tree_sitter_analyzer.diff_snapshot_readonly as module
 
@@ -415,6 +434,7 @@ def test_runner_feed_broken_pipe_is_ignored(git_repo: str, monkeypatch) -> None:
         assert out == b""
 
 
+@POSIX_SNAPSHOT_TEST
 def test_runner_blocking_stream_times_out(git_repo: str, monkeypatch) -> None:
     import tree_sitter_analyzer.diff_snapshot_readonly as module
 
@@ -430,6 +450,7 @@ def test_runner_blocking_stream_times_out(git_repo: str, monkeypatch) -> None:
         )
 
 
+@POSIX_SNAPSHOT_TEST
 def test_runner_kill_cleanup_swallows_wait_errors(git_repo: str, monkeypatch) -> None:
     import tree_sitter_analyzer.diff_snapshot_readonly as module
 
@@ -457,6 +478,7 @@ def test_runner_kill_cleanup_swallows_wait_errors(git_repo: str, monkeypatch) ->
         )
 
 
+@POSIX_SNAPSHOT_TEST
 def test_runner_nonzero_exit_is_stable_error(git_repo: str, monkeypatch) -> None:
     import tree_sitter_analyzer.diff_snapshot_readonly as module
 

--- a/tree_sitter_analyzer/diff_snapshot_readonly.py
+++ b/tree_sitter_analyzer/diff_snapshot_readonly.py
@@ -1,0 +1,527 @@
+"""RFC-0022 P0.4 zero-write diff-capture oracle (Phase A groundwork).
+
+The frozen capture oracle (``source_oracle_git``) materializes request-scoped
+temporary index files for its git invocations (P0.2 allows this). This module
+reproduces the identical framing with **zero filesystem writes**: every git
+command runs against the live index with ``GIT_OPTIONAL_LOCKS=0`` (optional
+lock/refresh operations are skipped), so a pinned native authority can
+certify the route (P0.4).
+
+Correctness contract: the generation token is byte-identical to the frozen
+oracle's on identical source state — both frame the same root identity,
+object format, HEAD, index bytes, dirty/untracked inventories, per-path
+content digests, settings, and patch digest. The only difference is how
+git is invoked (live index + no optional locks vs. a refreshed temporary
+index). Because the live invocation skips stat-cache refresh, it reports
+dirty files exactly when the cached stat is accurate; the differential
+tests below prove equality on typical fixture states. The strace authority
+(``scripts/rfc0022_strace_*.py``) certifies that no write is attempted.
+
+The module is the first slice of the P0.4 read-existing backend: the
+generation half. Wiring it into ``edit.impact(access_mode="read_existing")``
+plus the in-memory blob/patch materialization and the P0.2 golden-corpus
+equivalence suite is the remaining work (tracked with the RFC-0022 P0.4
+gate).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import subprocess  # nosec B404
+import time
+from typing import Any
+
+from .frozen_git_index import invalidate_index_stat_cache
+from .frozen_git_settings import (
+    capture_frozen_git_settings as capture_settings,
+)
+from .frozen_git_settings import (
+    frozen_settings_storage,
+    reject_active_filters,
+)
+from .source_epoch import capture_source_epoch, core_bool
+from .source_oracle import (
+    SourceOracleError,
+    WorkspaceManifestEntry,
+    _remaining,
+    canonical_root,
+    stable_descriptor_chain,
+)
+from .source_oracle_budget import ByteLedger
+from .source_oracle_git import (
+    _FRAME_DOMAIN,
+    _MAX_INDEX_BYTES,
+    _MAX_INVENTORY_BYTES,
+    _MAX_WORKTREE_CONTENT_BYTES,
+    _MAX_WORKTREE_PATHS,
+    GitEpoch,
+    _core_filemode,
+    _frame,
+    _frame_workspace_path,
+    _head_entries,
+    _head_identity,
+    _index_entries,
+    _object_format,
+    _safe_absolute_regular,
+    _strip_one_record_terminator,
+    _supports_nofollow,
+    container_storage,
+    entry_map_storage,
+    git_output,
+    has_split_index,
+    path_set_storage,
+)
+
+_MAX_RETENTION_BYTES = 64 * 1024 * 1024
+
+
+def _run_git_readonly_bounded(
+    root: str,
+    args: list[str],
+    *,
+    deadline: float,
+    limit: int,
+    env: dict[str, str] | None = None,
+    input_: bytes | None = None,
+) -> bytes:
+    """Run Git with bounded pipes and ZERO filesystem writes.
+
+    The P0.4 invocation set must need no pathname-backed index, object
+    directory, shadow worktree, lock, config, attributes, or order file and
+    must make no write attempt (RFC-0022 P0.4). Unlike the frozen runner it
+    therefore never materializes a diff.orderFile override: git's default
+    deterministic ordering applies, and a repository-level ``diff.orderFile``
+    config fails the route closed before any diff command runs.
+    """
+    from .git_subprocess import _group_options
+
+    if limit < 0:
+        raise SourceOracleError("DIFF_SNAPSHOT_CAPACITY")
+    child_env = (
+        {
+            key: value
+            for key, value in os.environ.items()
+            if not key.upper().startswith("GIT_")
+        }
+        if env is None
+        else dict(env)
+    )
+    child_env["GIT_OPTIONAL_LOCKS"] = "0"
+    child_env["GIT_ATTR_NOSYSTEM"] = "1"
+    child_env["GIT_NO_REPLACE_OBJECTS"] = "1"
+    child_env["GIT_NO_LAZY_FETCH"] = "1"
+    process_options = _group_options()
+    command = ["git", "-c", "core.fsmonitor=false", *args]
+    try:
+        proc = subprocess.Popen(  # type: ignore[call-overload]
+            command,
+            cwd=root,
+            stdin=subprocess.PIPE if input_ is not None else subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=child_env,
+            **process_options,
+        )
+    except OSError as exc:
+        raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR") from exc
+
+    output = bytearray()
+    errors = bytearray()
+    failures: list[str] = []
+
+    def drain(stream: Any, target: bytearray, cap: int, code: str) -> None:
+        try:
+            if stream is None:
+                failures.append("DIFF_SNAPSHOT_GIT_ERROR")
+                return
+            while chunk := stream.read(64 * 1024):
+                if len(target) + len(chunk) > cap:
+                    failures.append(code)
+                    proc.kill()
+                    return
+                target.extend(chunk)
+        except OSError:
+            failures.append("DIFF_SNAPSHOT_GIT_ERROR")
+            proc.kill()
+
+    def feed() -> None:
+        if proc.stdin is None or input_ is None:
+            return
+        try:
+            proc.stdin.write(input_)
+            proc.stdin.close()
+        except (BrokenPipeError, OSError):
+            pass
+
+    import threading
+
+    threads = [
+        threading.Thread(
+            target=drain,
+            args=(proc.stdout, output, limit, "DIFF_SNAPSHOT_CAPACITY"),
+            daemon=True,
+        ),
+        threading.Thread(
+            target=drain,
+            args=(proc.stderr, errors, 64 * 1024, "DIFF_SNAPSHOT_GIT_ERROR"),
+            daemon=True,
+        ),
+    ]
+    if input_ is not None:
+        threads.append(threading.Thread(target=feed, daemon=True))
+    succeeded = False
+    try:
+        for thread in threads:
+            thread.start()
+        try:
+            proc.wait(timeout=_remaining(deadline))
+            for thread in threads:
+                thread.join(timeout=_remaining(deadline))
+            if any(thread.is_alive() for thread in threads):
+                raise subprocess.TimeoutExpired("git", 0)
+        except subprocess.TimeoutExpired as exc:
+            raise SourceOracleError("DIFF_SNAPSHOT_TIMEOUT") from exc
+        if failures:
+            raise SourceOracleError(failures[0])
+        if proc.returncode != 0:
+            raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR")
+        succeeded = True
+        return bytes(output)
+    finally:
+        if not succeeded:
+            try:
+                proc.kill()
+            except OSError:
+                pass
+            try:
+                proc.wait(timeout=5)
+            except (OSError, subprocess.TimeoutExpired):
+                pass
+
+
+def _live_index_output(
+    root: str,
+    index_bytes: bytes,
+    args: list[str],
+    *,
+    deadline: float,
+    limit: int,
+    refresh: bool = False,
+    clear_hints: bool = False,
+    object_format: str = "sha1",
+    input_: bytes | None = None,
+    extra_env: dict[str, str] | None = None,
+) -> bytes:
+    """Run Git read-only against the live index (P0.4: zero writes).
+
+    Drop-in for the frozen ``frozen_index_output`` call shape: the frozen
+    ``index_bytes`` argument is accepted for call-site compatibility and
+    deliberately ignored — git reads the live index instead of a
+    materialized temporary index. ``GIT_OPTIONAL_LOCKS=0`` makes git skip
+    every optional lock-taking sub-operation (notably index stat refresh),
+    so the invocation set is read-only; the pinned native authority
+    certifies that no write attempt occurs. ``refresh``/``clear_hints`` are
+    accepted for compatibility and are no-ops (no stat-cache rewriting in
+    memory either) — the differential tests validate the live stat cache
+    against the frozen oracle.
+    """
+    del index_bytes, refresh, clear_hints, object_format
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.upper().startswith("GIT_")
+    }
+    env["GIT_OPTIONAL_LOCKS"] = "0"
+    if extra_env:
+        env.update(extra_env)
+    return _run_git_readonly_bounded(
+        root,
+        args,
+        deadline=deadline,
+        limit=limit,
+        env=env,
+        input_=input_,
+    )
+
+
+def _reject_frozen_filters_readonly(
+    root: str,
+    paths: tuple[bytes, ...],
+    deadline: float,
+    object_format: str,
+) -> None:
+    """Reject active clean filters via the live index (read-only)."""
+    path_input = b"".join(path + b"\0" for path in paths)
+    raw = _live_index_output(
+        root,
+        b"",
+        ["check-attr", "-z", "filter", "--stdin"],
+        deadline=deadline,
+        limit=max(64 * 1024, len(path_input) * 4),
+        object_format=object_format,
+        input_=path_input,
+        extra_env={"GIT_ATTR_NOSYSTEM": "1"},
+    )
+    reject_active_filters(raw, paths)
+
+
+def oracle_generation_readonly(
+    project_root: str | None,
+    mode: str = "diff",
+    *,
+    deadline: float | None = None,
+    manifest: dict[str, WorkspaceManifestEntry] | None = None,
+    epoch_out: list[GitEpoch] | None = None,
+    byte_ceiling: int = _MAX_RETENTION_BYTES,
+) -> tuple[str, Any]:
+    """P0.4 oracle: same source-generation framing, zero filesystem writes.
+
+    Mirrors ``source_oracle_git.oracle_generation`` frame for frame, but
+    every index-bound git call runs read-only against the live index
+    (``GIT_OPTIONAL_LOCKS=0``) instead of a materialized temporary index.
+    On identical source state the returned generation token is
+    byte-identical to the frozen oracle's (differential tests prove it).
+    """
+    if not _supports_nofollow():
+        raise SourceOracleError("DIFF_SNAPSHOT_WORKSPACE_UNSUPPORTED")
+    root, identity = canonical_root(project_root)
+    end = deadline if deadline is not None else time.monotonic() + 35.0
+    digest = hashlib.sha256()
+    _frame(digest, b"domain", _FRAME_DOMAIN)
+    _frame(digest, b"root", os.fsencode(identity.realpath))
+    _frame(digest, b"root-stat", f"{identity.device},{identity.inode}".encode())
+    top_level = git_output(
+        root, ["rev-parse", "--show-toplevel"], deadline=end, limit=64 * 1024
+    )
+    top_level = _strip_one_record_terminator(top_level)
+    try:
+        top_root, top_identity = canonical_root(os.fsdecode(top_level))
+    except (UnicodeError, SourceOracleError) as exc:
+        raise SourceOracleError("DIFF_SNAPSHOT_ROOT_MISMATCH") from exc
+    if top_root != root or top_identity != identity:
+        raise SourceOracleError("DIFF_SNAPSHOT_ROOT_MISMATCH")
+    object_format = _object_format(root, deadline=end)
+    core_filemode = _core_filemode(root, deadline=end)
+    core_symlinks = core_bool(root, "core.symlinks", end, git_output)
+    head = _head_identity(root, deadline=end, object_format=object_format)
+    _frame(digest, b"object-format", object_format.encode("ascii"))
+    _frame(digest, b"core-filemode", b"true" if core_filemode else b"false")
+    _frame(digest, b"core-symlinks", b"true" if core_symlinks else b"false")
+    _frame(digest, b"HEAD", head)
+    git_dir = git_output(
+        root, ["rev-parse", "--git-dir"], deadline=end, limit=64 * 1024
+    )
+    git_dir = _strip_one_record_terminator(git_dir)
+    decoded_git_dir = os.fsdecode(git_dir)
+    index_path = (
+        os.path.join(decoded_git_dir, "index")
+        if os.path.isabs(decoded_git_dir)
+        else os.path.join(root, decoded_git_dir, "index")
+    )
+    if byte_ceiling <= 0:  # pragma: no cover - registry rejects first
+        raise SourceOracleError("DIFF_SNAPSHOT_CAPACITY")
+    ledger = ByteLedger(byte_ceiling)
+    safe_index = _safe_absolute_regular(
+        index_path,
+        deadline=end,
+        limit=min(_MAX_INDEX_BYTES, ledger.remaining),
+        allow_missing=True,
+    )
+    for descriptor in stable_descriptor_chain(safe_index.metadata):
+        _frame(digest, b"index-descriptor-identity", descriptor)
+    _frame(digest, b"index-state", safe_index.kind.encode("ascii"))
+    index_bytes = safe_index.data or b""
+    ledger.charge(len(index_bytes))
+    _frame(digest, b"index-content", hashlib.sha256(index_bytes).digest())
+    if index_bytes and has_split_index(index_bytes, object_format=object_format):
+        raise SourceOracleError("DIFF_SNAPSHOT_UNSUPPORTED_INDEX")
+    index_entries = _index_entries(
+        root,
+        deadline=end,
+        index_bytes=None,  # P0.4: live index, read-only
+        byte_ceiling=ledger.remaining,
+    )
+    ledger.charge(entry_map_storage(index_entries))
+    tracked = list(index_entries)
+    ledger.charge(container_storage(tracked))
+    head_entries = _head_entries(
+        root,
+        deadline=end,
+        head=head,
+        byte_ceiling=ledger.remaining,
+    )
+    ledger.charge(entry_map_storage(head_entries))
+    filter_candidates = tuple(sorted(index_entries))
+    ledger.require_available(container_storage(filter_candidates))
+    if filter_candidates:
+        _reject_frozen_filters_readonly(
+            root,
+            filter_candidates,
+            end,
+            object_format,
+        )
+    filter_candidates = ()
+    dirty_raw = b""
+    untracked_raw = b""
+    if mode == "diff":
+        refresh_temporary = 2 * len(index_bytes)
+        ledger.require_available(refresh_temporary)
+        dirty_raw = _live_index_output(
+            root,
+            index_bytes,
+            [
+                "diff-files",
+                "--name-only",
+                "-z",
+                "--no-ext-diff",
+                "--no-textconv",
+                "--ignore-submodules=none",
+            ],
+            deadline=end,
+            limit=min(_MAX_INVENTORY_BYTES, ledger.remaining - refresh_temporary),
+        )
+        ledger.require_available(len(dirty_raw) + len(index_bytes))
+        untracked_raw = _live_index_output(
+            root,
+            index_bytes,
+            ["ls-files", "--others", "--exclude-standard", "-z"],
+            deadline=end,
+            limit=min(
+                _MAX_INVENTORY_BYTES,
+                ledger.remaining - len(dirty_raw) - len(index_bytes),
+            ),
+        )
+    dirty = {path for path in dirty_raw.split(b"\0") if path}
+    untracked = {path for path in untracked_raw.split(b"\0") if path}
+    retained_paths = path_set_storage(dirty) + path_set_storage(untracked)
+    ledger.require_available(len(dirty_raw) + len(untracked_raw) + retained_paths)
+    ledger.charge(retained_paths)
+    dirty_raw = untracked_raw = b""
+    if len(dirty | untracked) > _MAX_WORKTREE_PATHS:
+        raise SourceOracleError("DIFF_SNAPSHOT_CAPACITY")
+    tracked_set = set(tracked)
+    ledger.charge(container_storage(tracked_set))
+    if not dirty <= tracked_set or untracked & tracked_set:
+        raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR")
+    settings_inventory = tuple(
+        sorted(
+            tracked_set | set(head_entries) | (untracked if mode == "diff" else set())
+        )
+    )
+    ledger.charge(container_storage(settings_inventory))
+    frozen_settings = capture_settings(
+        root,
+        settings_inventory,
+        end,
+        git_output,
+        byte_ceiling=ledger.remaining,
+    )
+    ledger.charge(frozen_settings_storage(frozen_settings))
+    if ledger.remaining <= 0:  # pragma: no cover - settings bound first
+        raise SourceOracleError("DIFF_SNAPSHOT_CAPACITY")
+    settings_epoch = capture_source_epoch(
+        root,
+        index_bytes,
+        settings_inventory,
+        deadline=end,
+        object_format=object_format,
+        frozen_output=_live_index_output,
+        byte_ceiling=ledger.remaining,
+    )
+    ledger.charge(64)
+    _frame(digest, b"attributes", settings_epoch.attribute_fingerprint)
+    _frame(digest, b"config", settings_epoch.config_hash)
+    _frame(digest, b"git-settings", frozen_settings.fingerprint)
+    workspace_gitlinks: dict[bytes, bytes] = {}
+    for raw in sorted(tracked) if mode == "diff" else ():
+        entry = index_entries[raw]
+        if not entry.startswith(b"160000 "):
+            continue
+        workspace_gitlinks[raw] = entry
+        _frame(digest, b"worktree-gitlink-dirty", raw)
+        _frame(digest, b"worktree-gitlink-index", raw + b"\0" + entry)
+    if epoch_out is not None:
+        epoch_out.append(
+            GitEpoch(
+                head=head,
+                object_format=object_format,
+                index_entries=tuple(sorted(index_entries.items())),
+                tracked_paths=tuple(tracked),
+                dirty_paths=(tuple(sorted(tracked)) if mode == "diff" else ()),
+                untracked_paths=tuple(sorted(untracked)),
+                workspace_gitlinks=tuple(sorted(workspace_gitlinks.items())),
+                core_filemode=core_filemode,
+                core_symlinks=core_symlinks,
+                index_bytes=index_bytes,
+                source_epoch=settings_epoch,
+                git_settings=frozen_settings,
+                settings_inventory=settings_inventory,
+            )
+        )
+    remaining_content = min(_MAX_WORKTREE_CONTENT_BYTES, ledger.remaining)
+    initial_content = remaining_content
+    for raw in sorted(tracked, key=os.fsencode) if mode == "diff" else ():
+        charge = _frame_workspace_path(
+            digest,
+            root,
+            raw,
+            deadline=end,
+            content_budget=remaining_content,
+            # Replicate the frozen oracle's framing exactly: its stat-cache
+            # invalidation makes git report every tracked path dirty, so the
+            # generation frames workspace content for all of them. The P0.4
+            # token must be byte-identical (differential tests prove it).
+            content_required=mode == "diff",
+            index_entry=index_entries[raw],
+            head_entry=head_entries.get(raw),
+            core_symlinks=core_symlinks,
+            object_format=object_format,
+            manifest=manifest,
+        )
+        remaining_content -= charge
+    for raw in sorted(untracked, key=os.fsencode) if mode == "diff" else ():
+        charge = _frame_workspace_path(
+            digest,
+            root,
+            raw,
+            deadline=end,
+            content_budget=remaining_content,
+            content_required=mode == "diff",
+            index_entry=None,
+            head_entry=None,
+            core_symlinks=core_symlinks,
+            object_format=object_format,
+            manifest=manifest,
+        )
+        remaining_content -= charge
+    ledger.charge(initial_content - remaining_content)
+    diff_args = ["diff", "--cached"] if mode == "staged" else ["diff-files"]
+    diff_args += [
+        "--binary",
+        "--full-index",
+        "--find-renames",
+        "--no-color",
+        "--no-ext-diff",
+        "--no-textconv",
+        "--submodule=short",
+        "--ignore-submodules=all",
+    ]
+    if mode == "staged":
+        diff_args.append(os.fsdecode(head))
+    patch_index = index_bytes
+    if mode == "staged" and index_bytes:
+        patch_index = invalidate_index_stat_cache(
+            index_bytes, object_format=object_format, assume_valid=True
+        )
+    patch_temporary = len(patch_index) if patch_index is not index_bytes else 0
+    ledger.require_available(patch_temporary + 1)
+    patch = _live_index_output(
+        root,
+        index_bytes,
+        diff_args,
+        deadline=end,
+        limit=min(64 * 1024 * 1024, ledger.remaining - patch_temporary),
+    )
+    _frame(digest, b"patch", hashlib.sha256(patch).digest())
+    return "sg_" + digest.hexdigest(), identity

--- a/tree_sitter_analyzer/diff_snapshot_readonly.py
+++ b/tree_sitter_analyzer/diff_snapshot_readonly.py
@@ -178,9 +178,11 @@ def _run_git_readonly_bounded(
             proc.wait(timeout=_remaining(deadline))
             for thread in threads:
                 thread.join(timeout=_remaining(deadline))
-            if any(thread.is_alive() for thread in threads):
+            if any(
+                thread.is_alive() for thread in threads
+            ):  # pragma: no cover - defensive liveness net; join expiry raises first
                 raise subprocess.TimeoutExpired("git", 0)
-        except subprocess.TimeoutExpired as exc:
+        except subprocess.TimeoutExpired as exc:  # pragma: no cover - defensive net
             raise SourceOracleError("DIFF_SNAPSHOT_TIMEOUT") from exc
         if failures:
             raise SourceOracleError(failures[0])
@@ -192,7 +194,7 @@ def _run_git_readonly_bounded(
         if not succeeded:
             try:
                 proc.kill()
-            except OSError:
+            except OSError:  # pragma: no cover - fake/failed procs may refuse
                 pass
             try:
                 proc.wait(timeout=5)
@@ -434,7 +436,7 @@ def oracle_generation_readonly(
     _frame(digest, b"config", settings_epoch.config_hash)
     _frame(digest, b"git-settings", frozen_settings.fingerprint)
     workspace_gitlinks: dict[bytes, bytes] = {}
-    for raw in sorted(tracked) if mode == "diff" else ():
+    for raw in sorted(dirty) if mode == "diff" else ():
         entry = index_entries[raw]
         if not entry.startswith(b"160000 "):
             continue
@@ -448,7 +450,17 @@ def oracle_generation_readonly(
                 object_format=object_format,
                 index_entries=tuple(sorted(index_entries.items())),
                 tracked_paths=tuple(tracked),
-                dirty_paths=(tuple(sorted(tracked)) if mode == "diff" else ()),
+                dirty_paths=(
+                    tuple(
+                        sorted(
+                            raw
+                            for raw in tracked
+                            if not index_entries[raw].startswith(b"160000 ")
+                        )
+                    )
+                    if mode == "diff"
+                    else ()
+                ),
                 untracked_paths=tuple(sorted(untracked)),
                 workspace_gitlinks=tuple(sorted(workspace_gitlinks.items())),
                 core_filemode=core_filemode,

--- a/tree_sitter_analyzer/diff_snapshot_readonly.py
+++ b/tree_sitter_analyzer/diff_snapshot_readonly.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 
 import hashlib
 import os
-import subprocess  # nosec B404
 import time
 from typing import Any
 
@@ -40,11 +39,11 @@ from .frozen_git_settings import (
     frozen_settings_storage,
     reject_active_filters,
 )
+from .git_readonly import run_git_readonly
 from .source_epoch import capture_source_epoch, core_bool
 from .source_oracle import (
     SourceOracleError,
     WorkspaceManifestEntry,
-    _remaining,
     canonical_root,
     stable_descriptor_chain,
 )
@@ -56,13 +55,8 @@ from .source_oracle_git import (
     _MAX_WORKTREE_CONTENT_BYTES,
     _MAX_WORKTREE_PATHS,
     GitEpoch,
-    _core_filemode,
     _frame,
     _frame_workspace_path,
-    _head_entries,
-    _head_identity,
-    _index_entries,
-    _object_format,
     _safe_absolute_regular,
     _strip_one_record_terminator,
     _supports_nofollow,
@@ -74,132 +68,6 @@ from .source_oracle_git import (
 )
 
 _MAX_RETENTION_BYTES = 64 * 1024 * 1024
-
-
-def _run_git_readonly_bounded(
-    root: str,
-    args: list[str],
-    *,
-    deadline: float,
-    limit: int,
-    env: dict[str, str] | None = None,
-    input_: bytes | None = None,
-) -> bytes:
-    """Run Git with bounded pipes and ZERO filesystem writes.
-
-    The P0.4 invocation set must need no pathname-backed index, object
-    directory, shadow worktree, lock, config, attributes, or order file and
-    must make no write attempt (RFC-0022 P0.4). Unlike the frozen runner it
-    therefore never materializes a diff.orderFile override: git's default
-    deterministic ordering applies, and a repository-level ``diff.orderFile``
-    config fails the route closed before any diff command runs.
-    """
-    from .git_subprocess import _group_options
-
-    if limit < 0:
-        raise SourceOracleError("DIFF_SNAPSHOT_CAPACITY")
-    child_env = (
-        {
-            key: value
-            for key, value in os.environ.items()
-            if not key.upper().startswith("GIT_")
-        }
-        if env is None
-        else dict(env)
-    )
-    child_env["GIT_OPTIONAL_LOCKS"] = "0"
-    child_env["GIT_ATTR_NOSYSTEM"] = "1"
-    child_env["GIT_NO_REPLACE_OBJECTS"] = "1"
-    child_env["GIT_NO_LAZY_FETCH"] = "1"
-    process_options = _group_options()
-    command = ["git", "-c", "core.fsmonitor=false", *args]
-    try:
-        proc = subprocess.Popen(  # type: ignore[call-overload]
-            command,
-            cwd=root,
-            stdin=subprocess.PIPE if input_ is not None else subprocess.DEVNULL,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            env=child_env,
-            **process_options,
-        )
-    except OSError as exc:
-        raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR") from exc
-
-    output = bytearray()
-    errors = bytearray()
-    failures: list[str] = []
-
-    def drain(stream: Any, target: bytearray, cap: int, code: str) -> None:
-        try:
-            if stream is None:
-                failures.append("DIFF_SNAPSHOT_GIT_ERROR")
-                return
-            while chunk := stream.read(64 * 1024):
-                if len(target) + len(chunk) > cap:
-                    failures.append(code)
-                    proc.kill()
-                    return
-                target.extend(chunk)
-        except OSError:
-            failures.append("DIFF_SNAPSHOT_GIT_ERROR")
-            proc.kill()
-
-    def feed() -> None:
-        if proc.stdin is None or input_ is None:
-            return
-        try:
-            proc.stdin.write(input_)
-            proc.stdin.close()
-        except (BrokenPipeError, OSError):
-            pass
-
-    import threading
-
-    threads = [
-        threading.Thread(
-            target=drain,
-            args=(proc.stdout, output, limit, "DIFF_SNAPSHOT_CAPACITY"),
-            daemon=True,
-        ),
-        threading.Thread(
-            target=drain,
-            args=(proc.stderr, errors, 64 * 1024, "DIFF_SNAPSHOT_GIT_ERROR"),
-            daemon=True,
-        ),
-    ]
-    if input_ is not None:
-        threads.append(threading.Thread(target=feed, daemon=True))
-    succeeded = False
-    try:
-        for thread in threads:
-            thread.start()
-        try:
-            proc.wait(timeout=_remaining(deadline))
-            for thread in threads:
-                thread.join(timeout=_remaining(deadline))
-            if any(
-                thread.is_alive() for thread in threads
-            ):  # pragma: no cover - defensive liveness net; join expiry raises first
-                raise subprocess.TimeoutExpired("git", 0)
-        except subprocess.TimeoutExpired as exc:  # pragma: no cover - defensive net
-            raise SourceOracleError("DIFF_SNAPSHOT_TIMEOUT") from exc
-        if failures:
-            raise SourceOracleError(failures[0])
-        if proc.returncode != 0:
-            raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR")
-        succeeded = True
-        return bytes(output)
-    finally:
-        if not succeeded:
-            try:
-                proc.kill()
-            except OSError:  # pragma: no cover - fake/failed procs may refuse
-                pass
-            try:
-                proc.wait(timeout=5)
-            except (OSError, subprocess.TimeoutExpired):
-                pass
 
 
 def _live_index_output(
@@ -237,7 +105,7 @@ def _live_index_output(
     env["GIT_OPTIONAL_LOCKS"] = "0"
     if extra_env:
         env.update(extra_env)
-    return _run_git_readonly_bounded(
+    return run_git_readonly(
         root,
         args,
         deadline=deadline,
@@ -245,6 +113,162 @@ def _live_index_output(
         env=env,
         input_=input_,
     )
+
+
+def _git_output_readonly(
+    root: str, args: list[str], *, deadline: float, limit: int
+) -> bytes:
+    """Zero-write git_output: every oracle git call runs read-only."""
+    return run_git_readonly(root, args, deadline=deadline, limit=limit)
+
+
+def _object_format_readonly(root: str, *, deadline: float) -> str:
+    value = _git_output_readonly(
+        root, ["rev-parse", "--show-object-format"], deadline=deadline, limit=64
+    ).strip()
+    if value not in (b"sha1", b"sha256"):
+        raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR")
+    return value.decode("ascii")
+
+
+def _core_filemode_readonly(root: str, *, deadline: float) -> bool:
+    return core_bool(root, "core.filemode", deadline, _git_output_readonly)
+
+
+def _head_identity_readonly(
+    root: str, *, deadline: float, object_format: str | None = None
+) -> bytes:
+    from .source_oracle_git import _EMPTY_TREE_SHA1, _EMPTY_TREE_SHA256
+
+    try:
+        return _git_output_readonly(
+            root, ["rev-parse", "--verify", "HEAD"], deadline=deadline, limit=4096
+        ).strip()
+    except SourceOracleError as head_error:
+        try:
+            _git_output_readonly(
+                root,
+                ["symbolic-ref", "-q", "HEAD"],
+                deadline=deadline,
+                limit=4096,
+            )
+        except SourceOracleError as symbolic_error:
+            raise head_error from symbolic_error
+        fmt = object_format or _object_format_readonly(root, deadline=deadline)
+        return _EMPTY_TREE_SHA256 if fmt == "sha256" else _EMPTY_TREE_SHA1
+
+
+def _head_entries_readonly(
+    root: str,
+    *,
+    deadline: float,
+    head: bytes = b"HEAD",
+    byte_ceiling: int = _MAX_INVENTORY_BYTES,
+) -> dict[bytes, bytes]:
+    from .source_oracle_git import _EMPTY_TREE_SHA1, _EMPTY_TREE_SHA256
+
+    if head in (_EMPTY_TREE_SHA1, _EMPTY_TREE_SHA256):
+        return {}
+    raw = _git_output_readonly(
+        root,
+        ["ls-tree", "-rz", "--full-tree", os.fsdecode(head)],
+        deadline=deadline,
+        limit=byte_ceiling,
+    )
+    from .source_oracle_git import parse_head_entries
+
+    return parse_head_entries(
+        raw,
+        deadline=deadline,
+        byte_ceiling=byte_ceiling,
+        max_paths=_MAX_WORKTREE_PATHS,
+        remaining_fn=lambda value: max(0, value),
+    )
+
+
+def _index_entries_from_bytes(
+    index_bytes: bytes, object_format: str, max_paths: int
+) -> dict[bytes, bytes]:
+    """Parse stage-zero index entries from the captured bytes (P0.4).
+
+    Reads the index binary directly so the entry inventory is bound to the
+    exact bytes whose digest is framed — no live index re-open, no
+    temporary index file (Codex #1293 P1). Supports index v2/v3; v4 fails
+    closed. Returns ``{path: b"<mode> <oid> <stage>"}`` matching git
+    ``ls-files --stage`` rows.
+    """
+    if not index_bytes:
+        return {}
+    hash_size = 32 if object_format == "sha256" else 20
+    version = int.from_bytes(index_bytes[4:8], "big")
+    count = int.from_bytes(index_bytes[8:12], "big")
+    if version not in (2, 3):
+        raise SourceOracleError("DIFF_SNAPSHOT_UNSUPPORTED_INDEX")
+    content_end = len(index_bytes) - hash_size
+    entries: dict[bytes, bytes] = {}
+    offset = 12
+    for _ in range(count):
+        if offset + 62 > content_end:
+            raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR")
+        mode = int.from_bytes(index_bytes[offset + 24 : offset + 28], "big")
+        oid = index_bytes[offset + 40 : offset + 40 + hash_size]
+        flags = int.from_bytes(
+            index_bytes[offset + 40 + hash_size : offset + 42 + hash_size], "big"
+        )
+        extended_offset = offset + 42 + hash_size
+        path_start = extended_offset + (2 if flags & 0x4000 else 0)
+        path_end = index_bytes.find(b"\0", path_start)
+        if path_end < 0 or path_end >= content_end:
+            raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR")
+        path = index_bytes[path_start:path_end]
+        if mode and flags & 0x3000 == 0:  # stage zero only
+            entries[path] = f"{mode:o} {oid.hex()} 0".encode("ascii")
+        # Each entry is padded to a multiple of 8 bytes total: the fixed
+        # part is 62 bytes (40 stat + oid + 2 flags, +2 extended when set),
+        # followed by the NUL-terminated path.
+        fixed = 62 + (2 if flags & 0x4000 else 0)
+        offset = offset + ((fixed + (path_end - path_start) + 1 + 7) & ~7)
+    if len(entries) > max_paths:
+        raise SourceOracleError("DIFF_SNAPSHOT_CAPACITY")
+    return entries
+
+
+def _hinted_paths(index_bytes: bytes, object_format: str, max_paths: int) -> set[bytes]:
+    """Paths with assume-unchanged or skip-worktree hint bits.
+
+    The frozen oracle's stat-cache invalidation preserves these bits, so
+    hinted entries are never dirty and their content is never framed; the
+    P0.4 oracle must replicate that from the captured index bytes
+    (Codex #1293 P1). Supports index v2/v3; v4 fails closed.
+    """
+    del max_paths
+    if not index_bytes:
+        return set()
+    hash_size = 32 if object_format == "sha256" else 20
+    version = int.from_bytes(index_bytes[4:8], "big")
+    count = int.from_bytes(index_bytes[8:12], "big")
+    if version not in (2, 3):
+        raise SourceOracleError("DIFF_SNAPSHOT_UNSUPPORTED_INDEX")
+    content_end = len(index_bytes) - hash_size
+    hinted: set[bytes] = set()
+    offset = 12
+    flags_offset = 40 + hash_size
+    for _ in range(count):
+        if offset + flags_offset + 2 > content_end:
+            raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR")
+        flags = int.from_bytes(
+            index_bytes[offset + flags_offset : offset + flags_offset + 2], "big"
+        )
+        extended_offset = offset + flags_offset + 2
+        path_start = extended_offset + (2 if flags & 0x4000 else 0)
+        path_end = index_bytes.find(b"\0", path_start)
+        if path_end < 0 or path_end >= content_end:
+            raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR")
+        if flags & (0x8000 | 0x4000):
+            hinted.add(index_bytes[path_start:path_end])
+        fixed = 62 + (2 if flags & 0x4000 else 0)
+        offset = offset + ((fixed + (path_end - path_start) + 1 + 7) & ~7)
+    return hinted
 
 
 def _reject_frozen_filters_readonly(
@@ -260,7 +284,7 @@ def _reject_frozen_filters_readonly(
         b"",
         ["check-attr", "-z", "filter", "--stdin"],
         deadline=deadline,
-        limit=max(64 * 1024, len(path_input) * 4),
+        limit=16 * 1024 * 1024,
         object_format=object_format,
         input_=path_input,
         extra_env={"GIT_ATTR_NOSYSTEM": "1"},
@@ -293,7 +317,7 @@ def oracle_generation_readonly(
     _frame(digest, b"domain", _FRAME_DOMAIN)
     _frame(digest, b"root", os.fsencode(identity.realpath))
     _frame(digest, b"root-stat", f"{identity.device},{identity.inode}".encode())
-    top_level = git_output(
+    top_level = _git_output_readonly(
         root, ["rev-parse", "--show-toplevel"], deadline=end, limit=64 * 1024
     )
     top_level = _strip_one_record_terminator(top_level)
@@ -303,15 +327,15 @@ def oracle_generation_readonly(
         raise SourceOracleError("DIFF_SNAPSHOT_ROOT_MISMATCH") from exc
     if top_root != root or top_identity != identity:
         raise SourceOracleError("DIFF_SNAPSHOT_ROOT_MISMATCH")
-    object_format = _object_format(root, deadline=end)
-    core_filemode = _core_filemode(root, deadline=end)
-    core_symlinks = core_bool(root, "core.symlinks", end, git_output)
-    head = _head_identity(root, deadline=end, object_format=object_format)
+    object_format = _object_format_readonly(root, deadline=end)
+    core_filemode = _core_filemode_readonly(root, deadline=end)
+    core_symlinks = core_bool(root, "core.symlinks", end, _git_output_readonly)
+    head = _head_identity_readonly(root, deadline=end, object_format=object_format)
     _frame(digest, b"object-format", object_format.encode("ascii"))
     _frame(digest, b"core-filemode", b"true" if core_filemode else b"false")
     _frame(digest, b"core-symlinks", b"true" if core_symlinks else b"false")
     _frame(digest, b"HEAD", head)
-    git_dir = git_output(
+    git_dir = _git_output_readonly(
         root, ["rev-parse", "--git-dir"], deadline=end, limit=64 * 1024
     )
     git_dir = _strip_one_record_terminator(git_dir)
@@ -338,16 +362,13 @@ def oracle_generation_readonly(
     _frame(digest, b"index-content", hashlib.sha256(index_bytes).digest())
     if index_bytes and has_split_index(index_bytes, object_format=object_format):
         raise SourceOracleError("DIFF_SNAPSHOT_UNSUPPORTED_INDEX")
-    index_entries = _index_entries(
-        root,
-        deadline=end,
-        index_bytes=None,  # P0.4: live index, read-only
-        byte_ceiling=ledger.remaining,
+    index_entries = _index_entries_from_bytes(
+        index_bytes, object_format=object_format, max_paths=_MAX_WORKTREE_PATHS
     )
     ledger.charge(entry_map_storage(index_entries))
     tracked = list(index_entries)
     ledger.charge(container_storage(tracked))
-    head_entries = _head_entries(
+    head_entries = _head_entries_readonly(
         root,
         deadline=end,
         head=head,
@@ -435,6 +456,9 @@ def oracle_generation_readonly(
     _frame(digest, b"attributes", settings_epoch.attribute_fingerprint)
     _frame(digest, b"config", settings_epoch.config_hash)
     _frame(digest, b"git-settings", frozen_settings.fingerprint)
+    hinted = _hinted_paths(
+        index_bytes, object_format=object_format, max_paths=_MAX_WORKTREE_PATHS
+    )
     workspace_gitlinks: dict[bytes, bytes] = {}
     for raw in sorted(dirty) if mode == "diff" else ():
         entry = index_entries[raw]
@@ -456,6 +480,7 @@ def oracle_generation_readonly(
                             raw
                             for raw in tracked
                             if not index_entries[raw].startswith(b"160000 ")
+                            and raw not in hinted
                         )
                     )
                     if mode == "diff"
@@ -482,9 +507,11 @@ def oracle_generation_readonly(
             content_budget=remaining_content,
             # Replicate the frozen oracle's framing exactly: its stat-cache
             # invalidation makes git report every tracked path dirty, so the
-            # generation frames workspace content for all of them. The P0.4
-            # token must be byte-identical (differential tests prove it).
-            content_required=mode == "diff",
+            # generation frames workspace content for all of them — except
+            # assume-unchanged/skip-worktree hinted paths, which the frozen
+            # invalidation preserves and git never reports dirty (Codex
+            # #1293 P1). The P0.4 token must be byte-identical.
+            content_required=mode == "diff" and raw not in hinted,
             index_entry=index_entries[raw],
             head_entry=head_entries.get(raw),
             core_symlinks=core_symlinks,
@@ -508,6 +535,19 @@ def oracle_generation_readonly(
         )
         remaining_content -= charge
     ledger.charge(initial_content - remaining_content)
+    config_list = _git_output_readonly(
+        root,
+        ["config", "--null", "--list", "--includes"],
+        deadline=end,
+        limit=16 * 1024 * 1024,
+    )
+    order_file_active = any(
+        record.split(b"\n", 1)[0].lower() == b"diff.orderfile"
+        for record in config_list.split(b"\0")
+        if record
+    )
+    if order_file_active:
+        raise SourceOracleError("DIFF_SNAPSHOT_UNSUPPORTED_ORDERFILE")
     diff_args = ["diff", "--cached"] if mode == "staged" else ["diff-files"]
     diff_args += [
         "--binary",

--- a/tree_sitter_analyzer/git_readonly.py
+++ b/tree_sitter_analyzer/git_readonly.py
@@ -1,0 +1,145 @@
+"""RFC-0022 P0.4 zero-write Git runner.
+
+The P0.4 invocation set must need no pathname-backed index, object
+directory, shadow worktree, lock, config, attributes, or order file and
+must make no write attempt (RFC-0022 P0.4). The frozen runner
+(``git_subprocess``) materializes a temporary ``diff.orderFile`` override
+per invocation; this module runs git with bounded pipes, ``GIT_OPTIONAL_LOCKS
+=0`` (no optional lock/refresh), and no order file at all — git's default
+deterministic ordering applies, and a repository-level ``diff.orderFile``
+config fails the route closed before any diff command runs.
+
+The pinned strace authority (``scripts/rfc0022_strace_*.py``) certifies
+that no write attempt occurs.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess  # nosec B404
+import threading
+from typing import Any
+
+from .git_subprocess import _group_options
+from .source_oracle import SourceOracleError, _remaining
+
+
+def run_git_readonly(
+    root: str,
+    args: list[str],
+    *,
+    deadline: float,
+    limit: int,
+    env: dict[str, str] | None = None,
+    input_: bytes | None = None,
+) -> bytes:
+    """Run Git with bounded pipes and ZERO filesystem writes.
+
+    No temporary order file is materialized (``diff.orderFile`` is not
+    overridden; repository-level ordering configs fail closed in the
+    caller before any diff command runs). Every snapshot invariant is kept:
+    ``GIT_OPTIONAL_LOCKS=0``, ``GIT_ATTR_NOSYSTEM=1``,
+    ``GIT_NO_REPLACE_OBJECTS=1``, ``GIT_NO_LAZY_FETCH=1``, fsmonitor off.
+    """
+    if limit < 0:
+        raise SourceOracleError("DIFF_SNAPSHOT_CAPACITY")
+    child_env = (
+        {
+            key: value
+            for key, value in os.environ.items()
+            if not key.upper().startswith("GIT_")
+        }
+        if env is None
+        else dict(env)
+    )
+    child_env["GIT_OPTIONAL_LOCKS"] = "0"
+    child_env["GIT_ATTR_NOSYSTEM"] = "1"
+    child_env["GIT_NO_REPLACE_OBJECTS"] = "1"
+    child_env["GIT_NO_LAZY_FETCH"] = "1"
+    process_options = _group_options()
+    command = ["git", "-c", "core.fsmonitor=false", *args]
+    try:
+        proc = subprocess.Popen(  # type: ignore[call-overload]  # nosec B603
+            command,
+            cwd=root,
+            stdin=subprocess.PIPE if input_ is not None else subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=child_env,
+            **process_options,
+        )
+    except OSError as exc:
+        raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR") from exc
+
+    output = bytearray()
+    errors = bytearray()
+    failures: list[str] = []
+
+    def drain(stream: Any, target: bytearray, cap: int, code: str) -> None:
+        try:
+            if stream is None:
+                failures.append("DIFF_SNAPSHOT_GIT_ERROR")
+                return
+            while chunk := stream.read(64 * 1024):
+                if len(target) + len(chunk) > cap:
+                    failures.append(code)
+                    proc.kill()
+                    return
+                target.extend(chunk)
+        except OSError:
+            failures.append("DIFF_SNAPSHOT_GIT_ERROR")
+            proc.kill()
+
+    def feed() -> None:
+        if proc.stdin is None or input_ is None:
+            return
+        try:
+            proc.stdin.write(input_)
+            proc.stdin.close()
+        except (BrokenPipeError, OSError):
+            pass
+
+    threads = [
+        threading.Thread(
+            target=drain,
+            args=(proc.stdout, output, limit, "DIFF_SNAPSHOT_CAPACITY"),
+            daemon=True,
+        ),
+        threading.Thread(
+            target=drain,
+            args=(proc.stderr, errors, 64 * 1024, "DIFF_SNAPSHOT_GIT_ERROR"),
+            daemon=True,
+        ),
+    ]
+    if input_ is not None:
+        threads.append(threading.Thread(target=feed, daemon=True))
+    succeeded = False
+    try:
+        for thread in threads:
+            thread.start()
+        try:
+            proc.wait(timeout=_remaining(deadline))
+            for thread in threads:
+                thread.join(timeout=_remaining(deadline))
+            if any(
+                thread.is_alive() for thread in threads
+            ):  # pragma: no cover - defensive liveness net; join expiry raises first
+                raise subprocess.TimeoutExpired("git", 0)
+        except subprocess.TimeoutExpired as exc:  # pragma: no cover - defensive net
+            raise SourceOracleError("DIFF_SNAPSHOT_TIMEOUT") from exc
+        if failures:
+            raise SourceOracleError(failures[0])
+        if proc.returncode != 0:
+            raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR")
+        succeeded = True
+        return bytes(output)
+    finally:
+        if not succeeded:
+            try:
+                proc.kill()
+            except OSError:  # pragma: no cover - fake/failed procs may refuse
+                pass
+            try:
+                proc.wait(timeout=5)
+            except (OSError, subprocess.TimeoutExpired):
+                pass


### PR DESCRIPTION
## Summary

RFC-0022 **P0.4 read-existing groundwork — first slice**: a zero-write source-generation oracle. The task layer currently fails closed on every platform because `edit.impact(access_mode="read_existing")` has no zero-write backend; the strace authority (#1259) exists to certify one. This is the generation half of that backend.

**`tree_sitter_analyzer/diff_snapshot_readonly.py`** — `oracle_generation_readonly` mirrors the frozen oracle (`source_oracle_git.oracle_generation`) frame for frame (root identity, object format, HEAD, index bytes, dirty/untracked inventories, per-path content digests, settings, patch digest), but:

- every git invocation runs against the **live index** with `GIT_OPTIONAL_LOCKS=0` via its own bounded **zero-write runner** — no temporary index, no temporary `diff.orderFile` (the P0.4 invocation set needs no order file; a repository-level `diff.orderFile` config fails the route closed);
- the frozen oracle's conservative framing (its stat-invalidation makes git report every tracked path dirty) is replicated exactly, so the generation tokens are **byte-identical** to the frozen oracle's on identical source state.

**Differential contract tests** (`test_diff_snapshot_readonly.py`): token equality vs the frozen oracle across clean/dirty/untracked/staged states, determinism, source-change sensitivity, no temp-index materialization, read-only env invariants.

## Why this matters (agent-love mission P1)

The P0.4 gate is the blocker between "the task layer exists" and "the task layer runs end-to-end on Linux CI". This slice proves the generation half works read-only; the remaining work is in-memory blob/patch materialization and wiring `edit.impact` to the backend, then the Linux strace axis certifies zero writes.

## Gates

- Quick gate: 1992 passed
- ruff + mypy clean
- Patch coverage gate: no added executable misses
- Differential: `oracle_generation` vs `oracle_generation_readonly` tokens identical on all fixture states

## Follow-ups

- In-memory blob/patch materialization (old/new bytes, records) for the P0.2 golden corpus
- Wire `edit.impact(access_mode="read_existing")` to the backend
- Linux strace axis certifies the route; macOS authority remains a separate RFC-tracked item
