### PR TITLE
feat(task): P0.4 zero-write diff payload materialization (read_existing producer) (#1295)

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -117,6 +117,7 @@ jobs:
 
         if [ -f test_failed ]; then
           echo "❌ Tests failed!" >&3
+          tail -n 40 pytest-output.txt || true
           exit 1
         fi
       shell: bash
@@ -244,6 +245,7 @@ jobs:
 
         if [ -f test_failed ]; then
           echo "❌ Tests failed!" >&3
+          tail -n 40 pytest-output.txt || true
           exit 1
         fi
       shell: bash

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -117,7 +117,6 @@ jobs:
 
         if [ -f test_failed ]; then
           echo "❌ Tests failed!" >&3
-          tail -n 40 pytest-output.txt || true
           exit 1
         fi
       shell: bash
@@ -245,7 +244,6 @@ jobs:
 
         if [ -f test_failed ]; then
           echo "❌ Tests failed!" >&3
-          tail -n 40 pytest-output.txt || true
           exit 1
         fi
       shell: bash

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -117,7 +117,6 @@ jobs:
 
         if [ -f test_failed ]; then
           echo "❌ Tests failed!" >&3
-          grep -E "FAILED|ERROR|passed|failed|Timeout" pytest-output.txt | tail -n 40 || true
           exit 1
         fi
       shell: bash

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -117,6 +117,7 @@ jobs:
 
         if [ -f test_failed ]; then
           echo "❌ Tests failed!" >&3
+          grep -E "FAILED|ERROR|passed|failed|Timeout" pytest-output.txt | tail -n 40 || true
           exit 1
         fi
       shell: bash

--- a/tests/unit/mcp/tools/test_edit_facade_snapshot_routes.py
+++ b/tests/unit/mcp/tools/test_edit_facade_snapshot_routes.py
@@ -658,3 +658,61 @@ async def test_edit_impact_read_existing_platform_gate_branch(
         "source_snapshots": [],
     }
     assert result["action_version"]
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="tracked: RFC-0022 P0.4 producer route is Linux-certified only",
+)
+@pytest.mark.asyncio
+async def test_edit_impact_read_existing_acquire_failure_classifies(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An acquire failure after capture closes the lease and classifies."""
+    import subprocess
+
+    import tree_sitter_analyzer.diff_snapshot_registry as snapshots
+    from tree_sitter_analyzer.mcp.tools.change_impact_tool import ChangeImpactTool
+
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    for cfg in (
+        ["user.email", "t@t"],
+        ["user.name", "t"],
+        ["maintenance.auto", "false"],
+        ["gc.auto", "0"],
+    ):
+        subprocess.run(["git", "-C", str(tmp_path), "config", *cfg], check=True)
+    (tmp_path / "inside.py").write_text("value = 1\n")
+    subprocess.run(["git", "-C", str(tmp_path), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(tmp_path), "commit", "-qm", "init"], check=True)
+    (tmp_path / "inside.py").write_text("value = 2\n")
+
+    closed: list[str] = []
+    original_close = snapshots.REGISTRY.close_lease
+
+    def fake_acquire(snapshot_id, project_root, **kwargs):
+        return None, "DIFF_SNAPSHOT_EXPIRED"
+
+    def spy_close(snapshot_id, lease):
+        closed.append(snapshot_id)
+        return original_close(snapshot_id, lease)
+
+    monkeypatch.setattr(snapshots.REGISTRY, "acquire", fake_acquire)
+    monkeypatch.setattr(snapshots.REGISTRY, "close_lease", spy_close)
+    try:
+        tool = ChangeImpactTool(str(tmp_path))
+        result = await tool.execute(
+            {
+                "mode": "diff",
+                "access_mode": "read_existing",
+                "scope_paths": [],
+                "output_format": "json",
+            }
+        )
+    finally:
+        monkeypatch.undo()
+    assert result["success"] is False
+    assert result["access_state"] == "unknown"
+    assert result["access_reason"] == "DIFF_SNAPSHOT_EXPIRED"
+    assert result["error_code"] == "DIFF_SNAPSHOT_EXPIRED"
+    assert len(closed) == 1

--- a/tests/unit/mcp/tools/test_edit_facade_snapshot_routes.py
+++ b/tests/unit/mcp/tools/test_edit_facade_snapshot_routes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import sys
 from pathlib import Path
 
 import pytest
@@ -311,7 +312,6 @@ async def test_edit_read_existing_arguments_survive_exact_projection(
     ("action", "reason"),
     [
         ("safe", "READ_EXISTING_AUTHORITY_UNCERTIFIED"),
-        ("impact", "DIFF_SNAPSHOT_READ_EXISTING_UNSUPPORTED"),
         ("ast_diff", "READ_EXISTING_AUTHORITY_UNCERTIFIED"),
         ("classify", "READ_EXISTING_AUTHORITY_UNCERTIFIED"),
         ("constraints", "READ_EXISTING_AUTHORITY_UNCERTIFIED"),
@@ -353,6 +353,132 @@ async def test_edit_read_existing_returns_exact_access_evidence(
     assert (result.get("format"), "toon_content" in result) == (
         ("toon", True) if output_format == "toon" else (None, False)
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("output_format", ["json", "toon"])
+async def test_edit_impact_read_existing_gate_is_platform_aware(
+    tmp_path: Path, output_format: str
+) -> None:
+    """RFC-0022 P0.4: impact's producer route depends on the certified axis.
+
+    On non-Linux axes (no pinned native authority) the route returns the
+    stable unsupported classification; on Linux it attempts the zero-write
+    backend and classifies failures with the exact capture code.
+    """
+    import sys
+
+    from tree_sitter_analyzer.mcp.tools.edit_facade import build_edit_facade
+
+    (tmp_path / "inside.py").write_text("value = 1\n")
+    arguments = {
+        **_READ_EXISTING_ROUTE_ARGS["impact"],
+        "output_format": output_format,
+    }
+    result = await build_edit_facade(str(tmp_path)).execute(
+        {"action": "impact", **arguments}
+    )
+
+    if sys.platform.startswith("linux"):
+        # The fixture is not a git repository: the producer fails closed
+        # with the oracle's stable code and the exact access evidence.
+        assert {
+            key: result[key]
+            for key in (
+                "success",
+                "access_mode",
+                "access_state",
+                "access_reason",
+                "source_snapshots",
+                "output_format",
+            )
+        } == {
+            "success": False,
+            "access_mode": "read_existing",
+            "access_state": "unknown",
+            "access_reason": "DIFF_SNAPSHOT_GIT_ERROR",
+            "source_snapshots": [],
+            "output_format": output_format,
+        }
+        assert result["error_code"] == "DIFF_SNAPSHOT_GIT_ERROR"
+    else:
+        assert {
+            key: result[key]
+            for key in (
+                "success",
+                "access_mode",
+                "access_state",
+                "access_reason",
+                "source_snapshots",
+                "output_format",
+            )
+        } == {
+            "success": True,
+            "access_mode": "read_existing",
+            "access_state": "unknown",
+            "access_reason": "DIFF_SNAPSHOT_READ_EXISTING_UNSUPPORTED",
+            "source_snapshots": [],
+            "output_format": output_format,
+        }
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="tracked: RFC-0022 P0.4 producer route is Linux-certified only",
+)
+@pytest.mark.asyncio
+async def test_edit_impact_read_existing_producer_publishes_snapshot(
+    tmp_path: Path,
+) -> None:
+    """The zero-write producer publishes both IDs with full access evidence."""
+    import subprocess
+
+    from tree_sitter_analyzer.mcp.tools.edit_facade import build_edit_facade
+
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    for cfg in (
+        ["user.email", "t@t"],
+        ["user.name", "t"],
+        ["maintenance.auto", "false"],
+        ["gc.auto", "0"],
+    ):
+        subprocess.run(["git", "-C", str(tmp_path), "config", *cfg], check=True)
+    (tmp_path / "inside.py").write_text("value = 1\n")
+    (tmp_path / "keep.py").write_text("keep = True\n")
+    subprocess.run(["git", "-C", str(tmp_path), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(tmp_path), "commit", "-qm", "init"], check=True)
+    (tmp_path / "inside.py").write_text("value = 2\n")
+    (tmp_path / "new.py").write_text("x = 1\n")
+
+    result = await build_edit_facade(str(tmp_path)).execute(
+        {
+            "action": "impact",
+            **_READ_EXISTING_ROUTE_ARGS["impact"],
+            "output_format": "json",
+        }
+    )
+
+    assert result["success"] is True
+    assert result["access_mode"] == "read_existing"
+    assert result["access_state"] == "available"
+    assert result["access_reason"] is None
+    assert result["source_snapshots"] == [
+        {
+            "kind": "diff",
+            "snapshot_id": result["diff_snapshot_id"],
+            "source_generation": result["source_generation"],
+        }
+    ]
+    assert result["diff_snapshot_id"].startswith("ds_")
+    assert result["route_lease_id"].startswith("dl_")
+    assert [
+        (record["path"], record["status"]) for record in result["changed_records"]
+    ] == [
+        ("inside.py", "M"),
+        ("new.py", "A"),
+    ]
+    assert "assessed_scope_paths" in result
+    assert result["action_version"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcp/tools/test_edit_facade_snapshot_routes.py
+++ b/tests/unit/mcp/tools/test_edit_facade_snapshot_routes.py
@@ -622,3 +622,39 @@ async def test_edit_action_controls_are_rejected_outside_supported_actions(
         "ERROR",
         f"parameter {parameter!r} applies only to action(s): {allowed}",
     )
+
+
+@pytest.mark.asyncio
+async def test_edit_impact_read_existing_platform_gate_branch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Forcing the non-certified axis returns the stable unsupported result."""
+    import tree_sitter_analyzer.read_existing_access as read_access
+    from tree_sitter_analyzer.mcp.tools.edit_facade import build_edit_facade
+
+    monkeypatch.setattr(read_access, "read_existing_platform_supported", lambda: False)
+    (tmp_path / "inside.py").write_text("value = 1\n")
+    result = await build_edit_facade(str(tmp_path)).execute(
+        {
+            "action": "impact",
+            **_READ_EXISTING_ROUTE_ARGS["impact"],
+            "output_format": "json",
+        }
+    )
+    assert {
+        key: result[key]
+        for key in (
+            "success",
+            "access_mode",
+            "access_state",
+            "access_reason",
+            "source_snapshots",
+        )
+    } == {
+        "success": True,
+        "access_mode": "read_existing",
+        "access_state": "unknown",
+        "access_reason": "DIFF_SNAPSHOT_READ_EXISTING_UNSUPPORTED",
+        "source_snapshots": [],
+    }
+    assert result["action_version"]

--- a/tests/unit/mcp/tools/test_edit_facade_snapshot_routes.py
+++ b/tests/unit/mcp/tools/test_edit_facade_snapshot_routes.py
@@ -450,10 +450,12 @@ async def test_edit_impact_read_existing_producer_publishes_snapshot(
     (tmp_path / "inside.py").write_text("value = 2\n")
     (tmp_path / "new.py").write_text("x = 1\n")
 
+    arguments = dict(_READ_EXISTING_ROUTE_ARGS["impact"])
+    arguments["scope_paths"] = []
     result = await build_edit_facade(str(tmp_path)).execute(
         {
             "action": "impact",
-            **_READ_EXISTING_ROUTE_ARGS["impact"],
+            **arguments,
             "output_format": "json",
         }
     )

--- a/tests/unit/test_diff_snapshot_constraints_readonly.py
+++ b/tests/unit/test_diff_snapshot_constraints_readonly.py
@@ -1,0 +1,142 @@
+"""RFC-0022 P0.4 zero-write staged constraint probe differential contract.
+
+The zero-write staged probes (``diff_snapshot_constraints_readonly``)
+must reproduce the frozen probes' evidence (constraint config discovery,
+staged-sources-match-worktree) with zero filesystem writes. These tests
+prove equality on staged constraint/config fixtures and assert the
+read-only invocation set never materializes a temporary index.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from tests.unit._diff_snapshot_support import POSIX_SNAPSHOT_TEST
+from tree_sitter_analyzer.diff_snapshot_constraints import (
+    frozen_index_constraint_config,
+    frozen_index_sources_match_worktree,
+)
+from tree_sitter_analyzer.diff_snapshot_constraints_readonly import (
+    frozen_index_constraint_config_readonly,
+    frozen_index_sources_match_worktree_readonly,
+)
+from tree_sitter_analyzer.diff_snapshot_readonly import oracle_generation_readonly
+from tree_sitter_analyzer.source_oracle_git import GitEpoch, oracle_generation
+
+
+@pytest.fixture()
+def git_repo(tmp_path) -> str:
+    root = str(tmp_path)
+    subprocess.run(["git", "init", "-q", root], check=True)
+    for cfg in (
+        ["user.email", "t@t"],
+        ["user.name", "t"],
+        ["maintenance.auto", "false"],
+        ["gc.auto", "0"],
+    ):
+        subprocess.run(["git", "-C", root, "config", *cfg], check=True)
+    (tmp_path / "base.py").write_text("value = 1\n", encoding="utf-8")
+    subprocess.run(["git", "-C", root, "add", "."], check=True)
+    subprocess.run(["git", "-C", root, "commit", "-qm", "init"], check=True)
+    return root
+
+
+def _epochs(root: str) -> tuple[GitEpoch, GitEpoch]:
+    frozen_epochs: list[GitEpoch] = []
+    readonly_epochs: list[GitEpoch] = []
+    frozen_gen, _ = oracle_generation(root, "staged", epoch_out=frozen_epochs)
+    readonly_gen, _ = oracle_generation_readonly(
+        root, "staged", epoch_out=readonly_epochs
+    )
+    assert frozen_gen == readonly_gen
+    return frozen_epochs[0], readonly_epochs[0]
+
+
+@POSIX_SNAPSHOT_TEST
+def test_constraint_config_missing_matches(git_repo: str) -> None:
+    frozen_epoch, readonly_epoch = _epochs(git_repo)
+    deadline = time.monotonic() + 60.0
+    assert frozen_index_constraint_config(
+        git_repo, frozen_epoch, deadline, 16 * 1024 * 1024
+    ) == frozen_index_constraint_config_readonly(
+        git_repo, readonly_epoch, deadline, 16 * 1024 * 1024
+    )
+
+
+@POSIX_SNAPSHOT_TEST
+def test_staged_constraint_config_matches(git_repo: str) -> None:
+    Path(git_repo, "architectural-constraints.yml").write_text(
+        "rules:\n  - id: r1\n", encoding="utf-8"
+    )
+    Path(git_repo, ".tree-sitter-analyzer").mkdir()
+    Path(git_repo, ".tree-sitter-analyzer", "constraints.yml").write_text(
+        "rules:\n  - id: r2\n", encoding="utf-8"
+    )
+    subprocess.run(["git", "-C", git_repo, "add", "."], check=True)
+    frozen_epoch, readonly_epoch = _epochs(git_repo)
+    deadline = time.monotonic() + 60.0
+    frozen = frozen_index_constraint_config(
+        git_repo, frozen_epoch, deadline, 16 * 1024 * 1024
+    )
+    readonly = frozen_index_constraint_config_readonly(
+        git_repo, readonly_epoch, deadline, 16 * 1024 * 1024
+    )
+    assert frozen == readonly
+    assert frozen[0] == "architectural-constraints.yml"
+    assert frozen[1] == b"rules:\n  - id: r1\n"
+
+
+@POSIX_SNAPSHOT_TEST
+def test_staged_sources_match_worktree_matches_clean(git_repo: str) -> None:
+    frozen_epoch, readonly_epoch = _epochs(git_repo)
+    deadline = time.monotonic() + 60.0
+    frozen = frozen_index_sources_match_worktree(
+        git_repo, frozen_epoch, deadline, 16 * 1024 * 1024
+    )
+    readonly = frozen_index_sources_match_worktree_readonly(
+        git_repo, readonly_epoch, deadline, 16 * 1024 * 1024
+    )
+    assert frozen == readonly
+
+
+@POSIX_SNAPSHOT_TEST
+def test_staged_sources_match_worktree_matches_dirty_source(git_repo: str) -> None:
+    # A dirty supported-language source must fail the match in both probes.
+    Path(git_repo, "base.py").write_text("value = 2\n", encoding="utf-8")
+    frozen_epoch, readonly_epoch = _epochs(git_repo)
+    deadline = time.monotonic() + 60.0
+    assert not frozen_index_sources_match_worktree(
+        git_repo, frozen_epoch, deadline, 16 * 1024 * 1024
+    )
+    assert not frozen_index_sources_match_worktree_readonly(
+        git_repo, readonly_epoch, deadline, 16 * 1024 * 1024
+    )
+
+
+@POSIX_SNAPSHOT_TEST
+def test_staged_probe_never_materializes_temporary_index(
+    git_repo: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import tempfile
+
+    mkstemp_calls: list[str] = []
+
+    def spy_mkstemp(*args, **kwargs):
+        mkstemp_calls.append("mkstemp")
+        return tempfile.mkstemp(*args, **kwargs)
+
+    monkeypatch.setattr(tempfile, "mkstemp", spy_mkstemp)
+    _readonly_epochs: list[GitEpoch] = []
+    oracle_generation_readonly(git_repo, "staged", epoch_out=_readonly_epochs)
+    deadline = time.monotonic() + 60.0
+    frozen_index_constraint_config_readonly(
+        git_repo, _readonly_epochs[0], deadline, 16 * 1024 * 1024
+    )
+    frozen_index_sources_match_worktree_readonly(
+        git_repo, _readonly_epochs[0], deadline, 16 * 1024 * 1024
+    )
+    assert mkstemp_calls == []

--- a/tests/unit/test_diff_snapshot_constraints_readonly.py
+++ b/tests/unit/test_diff_snapshot_constraints_readonly.py
@@ -9,6 +9,7 @@ read-only invocation set never materializes a temporary index.
 
 from __future__ import annotations
 
+import os
 import subprocess
 import time
 from pathlib import Path
@@ -25,6 +26,7 @@ from tree_sitter_analyzer.diff_snapshot_constraints_readonly import (
     frozen_index_sources_match_worktree_readonly,
 )
 from tree_sitter_analyzer.diff_snapshot_readonly import oracle_generation_readonly
+from tree_sitter_analyzer.source_oracle import SourceOracleError
 from tree_sitter_analyzer.source_oracle_git import GitEpoch, oracle_generation
 
 
@@ -140,3 +142,108 @@ def test_staged_probe_never_materializes_temporary_index(
         git_repo, _readonly_epochs[0], deadline, 16 * 1024 * 1024
     )
     assert mkstemp_calls == []
+
+
+@POSIX_SNAPSHOT_TEST
+def test_ignored_submodule_sources_parses_foreach_output(
+    git_repo: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Scripted ``submodule foreach`` output drives the supported-leaf scan."""
+    import tree_sitter_analyzer.diff_snapshot_constraints_readonly as module
+
+    sub_repo = Path(git_repo, "vendor")
+    sub_repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(sub_repo)], check=True)
+    for cfg in (
+        ["user.email", "t@t"],
+        ["user.name", "t"],
+        ["maintenance.auto", "false"],
+        ["gc.auto", "0"],
+    ):
+        subprocess.run(["git", "-C", str(sub_repo), "config", *cfg], check=True)
+    (sub_repo / "lib.py").write_text("x = 1\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(sub_repo), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(sub_repo), "commit", "-qm", "sub"], check=True)
+    subprocess.run(
+        ["git", "-C", git_repo, "submodule", "add", "-q", str(sub_repo), "vendor"],
+        check=True,
+    )
+    subprocess.run(["git", "-C", git_repo, "commit", "-qm", "add-sub"], check=True)
+    _readonly_epochs: list[GitEpoch] = []
+    oracle_generation_readonly(git_repo, "staged", epoch_out=_readonly_epochs)
+    epoch = _readonly_epochs[0]
+    deadline = time.monotonic() + 60.0
+    scripted = b"H\0vendor\0? ignored.py\0? notes.txt\0"
+    monkeypatch.setattr(module, "run_git_readonly", lambda *a, **k: scripted)
+    found = module._ignored_submodule_sources_readonly(
+        git_repo, epoch, deadline, 16 * 1024 * 1024
+    )
+    # Only supported-language leaves are retained (ignored.py yes, notes no).
+    assert found == (b"vendor/ignored.py",)
+    # An unvisited configured gitlink is conservatively retained.
+    monkeypatch.setattr(module, "run_git_readonly", lambda *a, **k: b"")
+    assert module._ignored_submodule_sources_readonly(
+        git_repo, epoch, deadline, 16 * 1024 * 1024
+    ) == (b"vendor",)
+
+
+@POSIX_SNAPSHOT_TEST
+def test_ignored_submodule_sources_rejects_malformed_output(
+    git_repo: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import tree_sitter_analyzer.diff_snapshot_constraints_readonly as module
+
+    sub_repo = Path(git_repo, "vendor")
+    sub_repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(sub_repo)], check=True)
+    for cfg in (["user.email", "t@t"], ["user.name", "t"]):
+        subprocess.run(["git", "-C", str(sub_repo), "config", *cfg], check=True)
+    (sub_repo / "lib.py").write_text("x = 1\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(sub_repo), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(sub_repo), "commit", "-qm", "sub"], check=True)
+    subprocess.run(
+        ["git", "-C", git_repo, "submodule", "add", "-q", str(sub_repo), "vendor"],
+        check=True,
+    )
+    subprocess.run(["git", "-C", git_repo, "commit", "-qm", "add-sub"], check=True)
+    _readonly_epochs: list[GitEpoch] = []
+    oracle_generation_readonly(git_repo, "staged", epoch_out=_readonly_epochs)
+    epoch = _readonly_epochs[0]
+    deadline = time.monotonic() + 60.0
+    monkeypatch.setattr(module, "run_git_readonly", lambda *a, **k: b"broken")
+    with pytest.raises(SourceOracleError, match="DIFF_SNAPSHOT_GIT_ERROR"):
+        module._ignored_submodule_sources_readonly(
+            git_repo, epoch, deadline, 16 * 1024 * 1024
+        )
+    monkeypatch.setattr(
+        module, "run_git_readonly", lambda *a, **k: b"H\0vendor\0broken"
+    )
+    with pytest.raises(SourceOracleError, match="DIFF_SNAPSHOT_GIT_ERROR"):
+        module._ignored_submodule_sources_readonly(
+            git_repo, epoch, deadline, 16 * 1024 * 1024
+        )
+    # A truncated H record (no display path) also fails closed.
+    monkeypatch.setattr(module, "run_git_readonly", lambda *a, **k: b"H\0")
+    with pytest.raises(SourceOracleError, match="DIFF_SNAPSHOT_GIT_ERROR"):
+        module._ignored_submodule_sources_readonly(
+            git_repo, epoch, deadline, 16 * 1024 * 1024
+        )
+
+
+@POSIX_SNAPSHOT_TEST
+def test_staged_constraint_config_unsafe_mode_fails_closed(git_repo: str) -> None:
+    """A non-regular staged constraint file is rejected by both probes."""
+    from tree_sitter_analyzer.diff_snapshot_constraints_readonly import (
+        frozen_index_constraint_config_readonly,
+    )
+
+    Path(git_repo, "real-constraints.yml").write_text("rules:\n", encoding="utf-8")
+    os.symlink("real-constraints.yml", Path(git_repo, "architectural-constraints.yml"))
+    subprocess.run(["git", "-C", git_repo, "add", "."], check=True)
+    _readonly_epochs: list[GitEpoch] = []
+    oracle_generation_readonly(git_repo, "staged", epoch_out=_readonly_epochs)
+    deadline = time.monotonic() + 60.0
+    with pytest.raises(SourceOracleError, match="CONSTRAINT_CONFIG_UNSAFE"):
+        frozen_index_constraint_config_readonly(
+            git_repo, _readonly_epochs[0], deadline, 16 * 1024 * 1024
+        )

--- a/tests/unit/test_diff_snapshot_readonly.py
+++ b/tests/unit/test_diff_snapshot_readonly.py
@@ -49,8 +49,6 @@ def _epochs(root: str, mode: str) -> tuple[GitEpoch, GitEpoch]:
 
 
 @POSIX_SNAPSHOT_TEST
-@POSIX_SNAPSHOT_TEST
-@POSIX_SNAPSHOT_TEST
 def test_clean_repo_generations_match(git_repo: str) -> None:
     for mode in ("diff", "staged"):
         frozen_epoch, readonly_epoch = _epochs(git_repo, mode)
@@ -59,8 +57,6 @@ def test_clean_repo_generations_match(git_repo: str) -> None:
         assert frozen_epoch.untracked_paths == readonly_epoch.untracked_paths
 
 
-@POSIX_SNAPSHOT_TEST
-@POSIX_SNAPSHOT_TEST
 @POSIX_SNAPSHOT_TEST
 def test_dirty_and_untracked_generations_match(git_repo: str) -> None:
     import pathlib
@@ -87,8 +83,6 @@ def test_dirty_and_untracked_generations_match(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
-@POSIX_SNAPSHOT_TEST
-@POSIX_SNAPSHOT_TEST
 def test_generation_changes_when_source_changes(git_repo: str) -> None:
     import pathlib
 
@@ -101,9 +95,9 @@ def test_generation_changes_when_source_changes(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
-@POSIX_SNAPSHOT_TEST
-@POSIX_SNAPSHOT_TEST
-def test_readonly_never_materializes_temporary_index(git_repo: str) -> None:
+def test_readonly_never_materializes_temporary_index(
+    git_repo: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
     import tempfile
 
     mkstemp_calls: list[str] = []
@@ -112,6 +106,7 @@ def test_readonly_never_materializes_temporary_index(git_repo: str) -> None:
         mkstemp_calls.append("mkstemp")
         return tempfile.mkstemp(*args, **kwargs)
 
+    monkeypatch.setattr(tempfile, "mkstemp", spy_mkstemp)
     # The read-only oracle must never invoke the temp-index machinery.
     frozen_epochs: list[GitEpoch] = []
     oracle_generation_readonly(git_repo, "diff", epoch_out=frozen_epochs)
@@ -119,15 +114,13 @@ def test_readonly_never_materializes_temporary_index(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
-@POSIX_SNAPSHOT_TEST
-@POSIX_SNAPSHOT_TEST
 def test_live_index_output_is_readonly_invocation(git_repo: str) -> None:
     """GIT_OPTIONAL_LOCKS=0 is set and no GIT_INDEX_FILE is injected."""
     import tree_sitter_analyzer.diff_snapshot_readonly as module
 
     seen_env: dict[str, str] = {}
 
-    def spy(root, args, *, deadline, limit, env=None, input_=None):
+    def spy(root, args, *, deadline, limit, env=None, input_=None, ok_returncodes=None):
         seen_env.update(dict(env or {}))
         return b""
 
@@ -150,7 +143,6 @@ def test_live_index_output_is_readonly_invocation(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
-@POSIX_SNAPSHOT_TEST
 def test_workspace_unsupported_fails_closed(git_repo: str, monkeypatch) -> None:
     import tree_sitter_analyzer.diff_snapshot_readonly as module
 
@@ -159,7 +151,6 @@ def test_workspace_unsupported_fails_closed(git_repo: str, monkeypatch) -> None:
         oracle_generation_readonly(git_repo, "diff")
 
 
-@POSIX_SNAPSHOT_TEST
 @POSIX_SNAPSHOT_TEST
 def test_root_mismatch_fails_closed(git_repo: str) -> None:
     import os
@@ -170,7 +161,6 @@ def test_root_mismatch_fails_closed(git_repo: str) -> None:
         oracle_generation_readonly(subdir, "diff")
 
 
-@POSIX_SNAPSHOT_TEST
 @POSIX_SNAPSHOT_TEST
 def test_gitlink_generations_match(git_repo: str) -> None:
     import pathlib
@@ -201,7 +191,6 @@ def test_gitlink_generations_match(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
-@POSIX_SNAPSHOT_TEST
 def test_split_index_fails_closed(git_repo: str) -> None:
     subprocess.run(["git", "-C", git_repo, "update-index", "--split-index"], check=True)
     with pytest.raises(Exception, match="DIFF_SNAPSHOT_UNSUPPORTED_INDEX"):
@@ -209,13 +198,11 @@ def test_split_index_fails_closed(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
-@POSIX_SNAPSHOT_TEST
 def test_capacity_fails_closed(git_repo: str) -> None:
     with pytest.raises(Exception, match="DIFF_SNAPSHOT_CAPACITY"):
         oracle_generation_readonly(git_repo, "diff", byte_ceiling=1)
 
 
-@POSIX_SNAPSHOT_TEST
 @POSIX_SNAPSHOT_TEST
 def test_runner_popen_failure_is_stable_error(git_repo: str, monkeypatch) -> None:
     import tree_sitter_analyzer.git_readonly as module
@@ -234,7 +221,6 @@ def test_runner_popen_failure_is_stable_error(git_repo: str, monkeypatch) -> Non
         )
 
 
-@POSIX_SNAPSHOT_TEST
 @POSIX_SNAPSHOT_TEST
 def test_runner_negative_limit_fails_closed(git_repo: str) -> None:
     with pytest.raises(Exception, match="DIFF_SNAPSHOT_CAPACITY"):
@@ -274,7 +260,6 @@ class _UnboundedStream:
 
 
 @POSIX_SNAPSHOT_TEST
-@POSIX_SNAPSHOT_TEST
 def test_runner_stream_failure_is_stable_error(git_repo: str, monkeypatch) -> None:
     import tree_sitter_analyzer.git_readonly as module
 
@@ -301,11 +286,10 @@ def test_runner_stream_failure_is_stable_error(git_repo: str, monkeypatch) -> No
 
 
 @POSIX_SNAPSHOT_TEST
-@POSIX_SNAPSHOT_TEST
 def test_dirty_gitlink_frames_opaque_evidence(git_repo: str, monkeypatch) -> None:
     # Mirrors the frozen oracle's own dirty-gitlink test (monkeypatched
-    # inventory): a gitlink reported in the dirty set frames opaque
-    # evidence and is retained as workspace_gitlinks.
+    # inventory): a gitlink the read-only probe reports dirty frames
+    # opaque evidence and is retained as workspace_gitlinks.
     import tree_sitter_analyzer.diff_snapshot_readonly as module
 
     sub_repo = os.path.join(git_repo, "vendor")
@@ -323,22 +307,18 @@ def test_dirty_gitlink_frames_opaque_evidence(git_repo: str, monkeypatch) -> Non
     subprocess.run(
         ["git", "-C", git_repo, "commit", "-qm", "add submodule"], check=True
     )
-    original = module._live_index_output
 
-    def fake_live_output(root, index_bytes, args, **kwargs):
-        if args and args[0] == "diff-files":
-            return b"vendor\0"
-        return original(root, index_bytes, args, **kwargs)
-
-    monkeypatch.setattr(module, "_live_index_output", fake_live_output)
+    monkeypatch.setattr(
+        module, "_dirty_gitlink_probes_readonly", lambda *a, **k: {b"vendor"}
+    )
     epochs: list = []
     oracle_generation_readonly(git_repo, "diff", epoch_out=epochs)
     entry = dict(epochs[0].index_entries)[b"vendor"]
     assert entry.startswith(b"160000 ")
     assert epochs[0].workspace_gitlinks == ((b"vendor", entry),)
+    assert b"vendor" in epochs[0].dirty_paths
 
 
-@POSIX_SNAPSHOT_TEST
 @POSIX_SNAPSHOT_TEST
 def test_inventory_consistency_check_fails_closed(git_repo: str, monkeypatch) -> None:
     import tree_sitter_analyzer.diff_snapshot_readonly as module
@@ -355,7 +335,6 @@ def test_inventory_consistency_check_fails_closed(git_repo: str, monkeypatch) ->
         oracle_generation_readonly(git_repo, "diff")
 
 
-@POSIX_SNAPSHOT_TEST
 @POSIX_SNAPSHOT_TEST
 def test_worktree_path_capacity_fails_closed(git_repo: str, monkeypatch) -> None:
     import tree_sitter_analyzer.diff_snapshot_readonly as module
@@ -374,7 +353,6 @@ def test_worktree_path_capacity_fails_closed(git_repo: str, monkeypatch) -> None
 
 
 @POSIX_SNAPSHOT_TEST
-@POSIX_SNAPSHOT_TEST
 def test_empty_repo_generations_match(tmp_path) -> None:
     root = str(tmp_path / "empty")
     os.mkdir(root)
@@ -389,7 +367,6 @@ def test_empty_repo_generations_match(tmp_path) -> None:
         assert frozen_gen == readonly_gen
 
 
-@POSIX_SNAPSHOT_TEST
 @POSIX_SNAPSHOT_TEST
 def test_root_resolution_failure_fails_closed(git_repo: str, monkeypatch) -> None:
     import tree_sitter_analyzer.diff_snapshot_readonly as module
@@ -423,7 +400,6 @@ class _BrokenStdin:
 
 
 @POSIX_SNAPSHOT_TEST
-@POSIX_SNAPSHOT_TEST
 def test_runner_feed_broken_pipe_is_ignored(git_repo: str, monkeypatch) -> None:
     import tree_sitter_analyzer.git_readonly as module
 
@@ -455,7 +431,6 @@ def test_runner_feed_broken_pipe_is_ignored(git_repo: str, monkeypatch) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
-@POSIX_SNAPSHOT_TEST
 def test_runner_blocking_stream_times_out(git_repo: str, monkeypatch) -> None:
     import tree_sitter_analyzer.git_readonly as module
 
@@ -471,7 +446,6 @@ def test_runner_blocking_stream_times_out(git_repo: str, monkeypatch) -> None:
         )
 
 
-@POSIX_SNAPSHOT_TEST
 @POSIX_SNAPSHOT_TEST
 def test_runner_kill_cleanup_swallows_wait_errors(git_repo: str, monkeypatch) -> None:
     import tree_sitter_analyzer.git_readonly as module
@@ -500,7 +474,6 @@ def test_runner_kill_cleanup_swallows_wait_errors(git_repo: str, monkeypatch) ->
         )
 
 
-@POSIX_SNAPSHOT_TEST
 @POSIX_SNAPSHOT_TEST
 def test_runner_nonzero_exit_is_stable_error(git_repo: str, monkeypatch) -> None:
     import tree_sitter_analyzer.git_readonly as module
@@ -674,3 +647,47 @@ def test_entries_parser_capacity_bound() -> None:
     payload += entry0 + b"\0" * 20
     with pytest.raises(Exception, match="DIFF_SNAPSHOT_CAPACITY"):
         _index_entries_from_bytes(payload, "sha1", max_paths=0)
+
+
+class _ByteStream:
+    """Minimal readable stream for fake-proc runner tests."""
+
+    def __init__(self, data: bytes):
+        self.data = data
+
+    def read(self, size: int) -> bytes:
+        chunk, self.data = self.data[:size], self.data[size:]
+        return chunk
+
+
+@POSIX_SNAPSHOT_TEST
+def test_runner_ok_returncodes_accepts_exit_one(git_repo: str, monkeypatch) -> None:
+    """``git diff --no-index`` exits 1 on differences (RFC-0022 P0.4)."""
+    import tree_sitter_analyzer.git_readonly as module
+
+    class _ExitOneProc(_FakeProc):
+        def __init__(self):
+            super().__init__(
+                stdout=_ByteStream(b"diff --git a/x b/x\n"),
+                stderr=_ByteStream(b""),
+                returncode=1,
+            )
+
+    monkeypatch.setattr(module.subprocess, "Popen", lambda *a, **k: _ExitOneProc())
+    out = module.run_git_readonly(
+        git_repo,
+        ["diff", "--no-index", "/dev/null", "x"],
+        deadline=time.monotonic() + 35.0,
+        limit=1024,
+        ok_returncodes=frozenset({0, 1}),
+    )
+    assert out == b"diff --git a/x b/x\n"
+    # The default invocation set still rejects exit 1.
+    monkeypatch.setattr(module.subprocess, "Popen", lambda *a, **k: _ExitOneProc())
+    with pytest.raises(Exception, match="DIFF_SNAPSHOT_GIT_ERROR"):
+        module.run_git_readonly(
+            git_repo,
+            ["diff", "--no-index", "/dev/null", "x"],
+            deadline=time.monotonic() + 35.0,
+            limit=1024,
+        )

--- a/tests/unit/test_diff_snapshot_readonly_capture.py
+++ b/tests/unit/test_diff_snapshot_readonly_capture.py
@@ -894,3 +894,109 @@ def test_gitlink_probe_failure_frames_dirty_without_entering(
     )
     # The nested submodule probes were never invoked for the unsafe gitlink.
     assert all(b"-C" not in args for args in nested_calls)
+
+
+@POSIX_SNAPSHOT_TEST
+def test_capture_requires_epoch(git_repo: str) -> None:
+    from tree_sitter_analyzer.diff_snapshot_readonly_capture import (
+        capture_payload_readonly,
+    )
+
+    with pytest.raises(SourceOracleError, match="DIFF_SNAPSHOT_GIT_ERROR"):
+        capture_payload_readonly(
+            git_repo, "diff", time.monotonic() + 60.0, _BUDGET, epoch=None
+        )
+
+
+@POSIX_SNAPSHOT_TEST
+def test_capture_missing_manifest_entry_fails_closed(git_repo: str) -> None:
+    """A dirty path absent from the manifest is a source-change failure."""
+    Path(git_repo, "base.py").write_text("value = 2\n", encoding="utf-8")
+    _readonly_epochs: list[GitEpoch] = []
+    oracle_generation_readonly(git_repo, "diff", epoch_out=_readonly_epochs)
+    with pytest.raises(SourceOracleError, match="DIFF_SNAPSHOT_SOURCE_CHANGED"):
+        capture_payload_readonly(
+            git_repo,
+            "diff",
+            time.monotonic() + 60.0,
+            _BUDGET,
+            expected_manifest={},
+            epoch=_readonly_epochs[0],
+        )
+
+
+@POSIX_SNAPSHOT_TEST
+def test_capture_special_file_fails_closed(
+    git_repo: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An uncertifiable worktree leaf cannot be materialized."""
+    import tree_sitter_analyzer.diff_snapshot_readonly_capture as module
+    from tree_sitter_analyzer.source_oracle import SafePath
+
+    Path(git_repo, "base.py").write_text("value = 2\n", encoding="utf-8")
+    _readonly_epochs: list[GitEpoch] = []
+    manifest: dict = {}
+    oracle_generation_readonly(
+        git_repo, "diff", manifest=manifest, epoch_out=_readonly_epochs
+    )
+
+    original_reader = module.safe_workspace_path
+
+    def unsafe_reader(_root, relative, **kwargs):
+        if relative == "base.py":
+            return SafePath(data=None, metadata=(b"unsafe",), kind="unsafe")
+        return original_reader(_root, relative, **kwargs)
+
+    monkeypatch.setattr(module, "safe_workspace_path", unsafe_reader)
+    with pytest.raises(SourceOracleError, match="DIFF_SNAPSHOT_SPECIAL_FILE"):
+        capture_payload_readonly(
+            git_repo,
+            "diff",
+            time.monotonic() + 60.0,
+            _BUDGET,
+            expected_manifest=manifest,
+            epoch=_readonly_epochs[0],
+        )
+
+
+@POSIX_SNAPSHOT_TEST
+def test_capture_binary_attr_malformed_fails_closed(git_repo: str) -> None:
+    """Malformed check-attr output for untracked paths fails closed."""
+    import tree_sitter_analyzer.diff_snapshot_readonly_capture as module
+
+    Path(git_repo, "blob.dat").write_text("x\n", encoding="utf-8")
+    _readonly_epochs: list[GitEpoch] = []
+    manifest: dict = {}
+    oracle_generation_readonly(
+        git_repo, "diff", manifest=manifest, epoch_out=_readonly_epochs
+    )
+    original = module._live_index_output
+    calls: list[list[str]] = []
+
+    def spy(root, index_bytes, args, *, deadline, limit, input_=None, **kwargs):
+        calls.append(args)
+        if args[:2] == ["check-attr", "-z"] and args[2:4] == ["diff", "--stdin"]:
+            return b"broken"
+        return original(
+            root,
+            index_bytes,
+            args,
+            deadline=deadline,
+            limit=limit,
+            input_=input_,
+            **kwargs,
+        )
+
+    module._live_index_output = spy
+    try:
+        with pytest.raises(SourceOracleError, match="DIFF_SNAPSHOT_GIT_ERROR"):
+            capture_payload_readonly(
+                git_repo,
+                "diff",
+                time.monotonic() + 60.0,
+                _BUDGET,
+                expected_manifest=manifest,
+                epoch=_readonly_epochs[0],
+            )
+    finally:
+        module._live_index_output = original

--- a/tests/unit/test_diff_snapshot_readonly_capture.py
+++ b/tests/unit/test_diff_snapshot_readonly_capture.py
@@ -525,3 +525,187 @@ def test_registry_scoped_snapshots_match(git_repo: str) -> None:
     assert frozen["source_generation"] == readonly["source_generation"]
     assert frozen["changed_records"] == readonly["changed_records"]
     assert frozen["assessed_scope_paths"] == readonly["assessed_scope_paths"]
+
+
+@POSIX_SNAPSHOT_TEST
+def test_intent_to_add_payloads_match(git_repo: str) -> None:
+    """``git add -N`` paths carry real worktree bytes, not the placeholder."""
+    Path(git_repo, "ita.py").write_text("new content\n", encoding="utf-8")
+    subprocess.run(["git", "-C", git_repo, "add", "-N", "ita.py"], check=True)
+    _assert_equal_payloads(git_repo, "diff", 1)
+
+
+@POSIX_SNAPSHOT_TEST
+def test_quoted_header_paths_match(git_repo: str) -> None:
+    """A path needing C quoting round-trips through the section parser."""
+    tab_path = Path(git_repo, "tab\tname.py")
+    tab_path.write_text("x\n", encoding="utf-8")
+    subprocess.run(["git", "-C", git_repo, "add", "."], check=True)
+    subprocess.run(["git", "-C", git_repo, "commit", "-qm", "tab"], check=True)
+    tab_path.write_text("y\n", encoding="utf-8")
+    _assert_equal_payloads(git_repo, "diff", 1)
+
+
+@POSIX_SNAPSHOT_TEST
+def test_space_paths_sections_do_not_collide(git_repo: str) -> None:
+    """Unquoted space-containing headers keep distinct section keys."""
+    Path(git_repo, "a b.py").write_text("two\n", encoding="utf-8")
+    Path(git_repo, "a c.py").write_text("three\n", encoding="utf-8")
+    subprocess.run(["git", "-C", git_repo, "add", "."], check=True)
+    subprocess.run(["git", "-C", git_repo, "commit", "-qm", "spaces"], check=True)
+    Path(git_repo, "a b.py").write_text("two2\n", encoding="utf-8")
+    _assert_equal_payloads(git_repo, "diff", 1)
+
+
+@POSIX_SNAPSHOT_TEST
+def test_exact_rename_with_mode_change_payloads_match(git_repo: str) -> None:
+    """R100 sections carry old/new mode lines when the mode changed."""
+    script = Path(git_repo, "m.sh")
+    script.write_text("#!/bin/sh\necho hi\n", encoding="utf-8")
+    script.chmod(0o755)
+    subprocess.run(["git", "-C", git_repo, "add", "."], check=True)
+    subprocess.run(["git", "-C", git_repo, "commit", "-qm", "m"], check=True)
+    os.rename(script, Path(git_repo, "n.sh"))
+    Path(git_repo, "n.sh").chmod(0o644)
+    _assert_equal_payloads(git_repo, "diff", 1)
+
+
+@POSIX_SNAPSHOT_TEST
+def test_ambiguous_identical_moves_stay_delete_add(git_repo: str) -> None:
+    """Ambiguous exact-rename candidates are not paired by guessing."""
+    Path(git_repo, "x.py").write_text("same\n", encoding="utf-8")
+    Path(git_repo, "y.py").write_text("same\n", encoding="utf-8")
+    subprocess.run(["git", "-C", git_repo, "add", "."], check=True)
+    subprocess.run(["git", "-C", git_repo, "commit", "-qm", "two"], check=True)
+    os.rename(Path(git_repo, "x.py"), Path(git_repo, "x2.py"))
+    os.rename(Path(git_repo, "y.py"), Path(git_repo, "y2.py"))
+    _readonly_epochs: list[GitEpoch] = []
+    manifest: dict = {}
+    oracle_generation_readonly(
+        git_repo, "diff", manifest=manifest, epoch_out=_readonly_epochs
+    )
+    _patch, files = capture_payload_readonly(
+        git_repo,
+        "diff",
+        time.monotonic() + 60.0,
+        _BUDGET,
+        expected_manifest=manifest,
+        epoch=_readonly_epochs[0],
+    )
+    assert sorted(file.record.status for file in files) == ["A", "A", "D", "D"]
+
+
+@POSIX_SNAPSHOT_TEST
+def test_filemode_false_untracked_exec_payloads_match(git_repo: str) -> None:
+    subprocess.run(
+        ["git", "-C", git_repo, "config", "core.filemode", "false"], check=True
+    )
+    script = Path(git_repo, "run.sh")
+    script.write_text("#!/bin/sh\necho hi\n", encoding="utf-8")
+    script.chmod(0o755)
+    _assert_equal_payloads(git_repo, "diff", 1)
+
+
+@POSIX_SNAPSHOT_TEST
+def test_working_tree_encoding_fails_closed_without_crlf(git_repo: str) -> None:
+    Path(git_repo, ".gitattributes").write_text(
+        "*.txt working-tree-encoding=UTF-16LE\n", encoding="utf-8"
+    )
+    Path(git_repo, "data.txt").write_text("hello\n", encoding="utf-8")
+    _readonly_epochs: list[GitEpoch] = []
+    manifest: dict = {}
+    oracle_generation_readonly(
+        git_repo, "diff", manifest=manifest, epoch_out=_readonly_epochs
+    )
+    with pytest.raises(SourceOracleError, match="DIFF_SNAPSHOT_UNSUPPORTED_CONVERSION"):
+        capture_payload_readonly(
+            git_repo,
+            "diff",
+            time.monotonic() + 60.0,
+            _BUDGET,
+            expected_manifest=manifest,
+            epoch=_readonly_epochs[0],
+        )
+
+
+@POSIX_SNAPSHOT_TEST
+def test_ident_attribute_fails_closed(git_repo: str) -> None:
+    Path(git_repo, ".gitattributes").write_text("*.c ident\n", encoding="utf-8")
+    Path(git_repo, "main.c").write_text("$Id$\n", encoding="utf-8")
+    _readonly_epochs: list[GitEpoch] = []
+    manifest: dict = {}
+    oracle_generation_readonly(
+        git_repo, "diff", manifest=manifest, epoch_out=_readonly_epochs
+    )
+    with pytest.raises(SourceOracleError, match="DIFF_SNAPSHOT_UNSUPPORTED_CONVERSION"):
+        capture_payload_readonly(
+            git_repo,
+            "diff",
+            time.monotonic() + 60.0,
+            _BUDGET,
+            expected_manifest=manifest,
+            epoch=_readonly_epochs[0],
+        )
+
+
+@POSIX_SNAPSHOT_TEST
+def test_untracked_diff_attribute_binary_matches(git_repo: str) -> None:
+    """``*.dat binary`` marks an untracked NUL-free file binary."""
+    Path(git_repo, ".gitattributes").write_text("*.dat binary\n", encoding="utf-8")
+    Path(git_repo, "blob.dat").write_text("plain text no nul\n", encoding="utf-8")
+    # .gitattributes is itself untracked: two added records, one binary.
+    _assert_equal_payloads(git_repo, "diff", 2)
+
+
+@POSIX_SNAPSHOT_TEST
+def test_skip_worktree_entry_matches(git_repo: str) -> None:
+    Path(git_repo, "sw.py").write_text("hidden\n", encoding="utf-8")
+    subprocess.run(["git", "-C", git_repo, "add", "."], check=True)
+    subprocess.run(["git", "-C", git_repo, "commit", "-qm", "sw"], check=True)
+    subprocess.run(
+        ["git", "-C", git_repo, "update-index", "--skip-worktree", "sw.py"],
+        check=True,
+    )
+    Path(git_repo, "sw.py").write_text("changed\n", encoding="utf-8")
+    Path(git_repo, "base.py").write_text("value = 2\n", encoding="utf-8")
+    _assert_equal_payloads(git_repo, "diff", 1)
+
+
+@POSIX_SNAPSHOT_TEST
+def test_readonly_revalidation_uses_readonly_oracle(git_repo: str) -> None:
+    """acquire/validate_publish revalidate readonly snapshots zero-write."""
+    import tree_sitter_analyzer.diff_snapshot_registry as snapshots
+
+    Path(git_repo, "base.py").write_text("value = 2\n", encoding="utf-8")
+    snapshots.reset_registry()
+    created = snapshots.REGISTRY.create(git_repo, "diff", [], readonly=True)
+    assert created.get("success"), created
+    frozen_calls: list[str] = []
+    readonly_calls: list[str] = []
+    original_frozen = snapshots.oracle_generation
+    original_readonly = snapshots.oracle_generation_readonly
+
+    @__import__("functools").wraps(original_frozen)
+    def spy_frozen(*args, **kwargs):
+        frozen_calls.append("frozen")
+        return original_frozen(*args, **kwargs)
+
+    @__import__("functools").wraps(original_readonly)
+    def spy_readonly(*args, **kwargs):
+        readonly_calls.append("readonly")
+        return original_readonly(*args, **kwargs)
+
+    monkeypatch = __import__("pytest").MonkeyPatch()
+    monkeypatch.setattr(snapshots, "oracle_generation", spy_frozen)
+    monkeypatch.setattr(snapshots, "oracle_generation_readonly", spy_readonly)
+    try:
+        consumer, error = snapshots.REGISTRY.acquire(
+            str(created["diff_snapshot_id"]), git_repo
+        )
+        assert error is None and consumer is not None
+        assert snapshots.REGISTRY.validate_publish(consumer) is None
+        consumer.release()
+    finally:
+        monkeypatch.undo()
+    assert frozen_calls == []
+    assert readonly_calls

--- a/tests/unit/test_diff_snapshot_readonly_capture.py
+++ b/tests/unit/test_diff_snapshot_readonly_capture.py
@@ -713,3 +713,184 @@ def test_readonly_revalidation_uses_readonly_oracle(git_repo: str) -> None:
         monkeypatch.undo()
     assert frozen_calls == []
     assert readonly_calls
+
+
+@POSIX_SNAPSHOT_TEST
+def test_git_unquote_round_trips_escapes() -> None:
+    from tree_sitter_analyzer.diff_snapshot_readonly_capture import _git_unquote
+
+    assert _git_unquote(b'"a\\tb"') == b"a\tb"
+    assert _git_unquote(b'"a\\nb"') == b"a\nb"
+    assert _git_unquote(b'"a\\\\b"') == b"a\\b"
+    assert _git_unquote(b'"a\\"b"') == b'a"b'
+    assert _git_unquote(b'"\\303\\251"') == "é".encode()
+    assert _git_unquote(b"plain") == b"plain"
+
+
+@POSIX_SNAPSHOT_TEST
+def test_git_unquote_rejects_malformed_escapes() -> None:
+    from tree_sitter_analyzer.diff_snapshot_readonly_capture import _git_unquote
+
+    with pytest.raises(SourceOracleError, match="DIFF_SNAPSHOT_GIT_ERROR"):
+        _git_unquote(b'"trailing\\"')
+    with pytest.raises(SourceOracleError, match="DIFF_SNAPSHOT_GIT_ERROR"):
+        _git_unquote(b'"\\x"')
+    with pytest.raises(SourceOracleError, match="DIFF_SNAPSHOT_GIT_ERROR"):
+        _git_unquote(b'"\\12"')
+    # Unquoted input is returned verbatim, never decoded.
+    assert _git_unquote(b'"unterminated') == b'"unterminated'
+
+
+@POSIX_SNAPSHOT_TEST
+def test_patch_section_paths_rejects_malformed_headers() -> None:
+    from tree_sitter_analyzer.diff_snapshot_readonly_capture import (
+        _patch_section_paths,
+    )
+
+    with pytest.raises(SourceOracleError, match="DIFF_SNAPSHOT_GIT_ERROR"):
+        _patch_section_paths(b"diff --git a/only-one-token\n")
+    with pytest.raises(SourceOracleError, match="DIFF_SNAPSHOT_GIT_ERROR"):
+        _patch_section_paths(b'diff --git "a/x" b/y\n')
+    with pytest.raises(SourceOracleError, match="DIFF_SNAPSHOT_GIT_ERROR"):
+        _patch_section_paths(b"diff --git x/y b/z\n")
+    with pytest.raises(SourceOracleError, match="DIFF_SNAPSHOT_GIT_ERROR"):
+        _patch_section_paths(b'diff --git "a/x" "c/y"\n')
+
+
+@POSIX_SNAPSHOT_TEST
+def test_rewrite_new_file_mode_aligns_and_keeps_others() -> None:
+    from tree_sitter_analyzer.diff_snapshot_readonly_capture import (
+        _rewrite_new_file_mode,
+    )
+
+    section = b"diff --git a/x b/x\nnew file mode 100755\nindex 0000..1111\n"
+    rewritten = _rewrite_new_file_mode(section, b"100644")
+    assert rewritten == b"diff --git a/x b/x\nnew file mode 100644\nindex 0000..1111\n"
+    # No mode line and identical modes pass through untouched.
+    assert _rewrite_new_file_mode(b"no mode here\n", b"100644") == b"no mode here\n"
+    assert _rewrite_new_file_mode(section, b"100755") == section
+
+
+@POSIX_SNAPSHOT_TEST
+def test_workspace_mode_unsafe_metadata_fails_closed() -> None:
+    from tree_sitter_analyzer.diff_snapshot_readonly_capture import _workspace_mode
+    from tree_sitter_analyzer.source_oracle import SafePath
+
+    epoch = GitEpoch(
+        b"head", "sha1", (), (), (), (), core_filemode=True, core_symlinks=True
+    )
+    unsafe = SafePath(data=b"x", metadata=(b"no-mode-field",), kind="file")
+    with pytest.raises(SourceOracleError, match="DIFF_SNAPSHOT_UNSAFE_PATH"):
+        _workspace_mode(epoch, unsafe, b"100644")
+
+
+@POSIX_SNAPSHOT_TEST
+def test_readonly_rows_rejects_malformed_output(git_repo: str) -> None:
+    import tree_sitter_analyzer.diff_snapshot_readonly_capture as module
+
+    original = module._live_index_output
+    module._live_index_output = lambda *a, **k: b"R\0only-one-token"
+    try:
+        with pytest.raises(SourceOracleError, match="DIFF_SNAPSHOT_GIT_ERROR"):
+            module._readonly_rows(
+                git_repo, "diff", b"head", time.monotonic() + 60.0, 1024
+            )
+    finally:
+        module._live_index_output = original
+
+
+@POSIX_SNAPSHOT_TEST
+def test_readonly_binaries_rejects_malformed_output(git_repo: str) -> None:
+    import tree_sitter_analyzer.diff_snapshot_readonly_capture as module
+
+    original = module._live_index_output
+    module._live_index_output = lambda *a, **k: b"not-numstat"
+    try:
+        with pytest.raises(SourceOracleError, match="DIFF_SNAPSHOT_GIT_ERROR"):
+            module._readonly_binaries(
+                git_repo, "diff", b"head", time.monotonic() + 60.0, 1024
+            )
+    finally:
+        module._live_index_output = original
+
+
+@POSIX_SNAPSHOT_TEST
+def test_gitlink_probe_safe_classifies_boundaries(
+    git_repo: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Probes never enter symlink-replaced or outside-pointing gitlinks."""
+    import tree_sitter_analyzer.diff_snapshot_readonly as module
+
+    sub_repo = Path(git_repo, "vendor")
+    sub_repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(sub_repo)], check=True)
+    for cfg in (["user.email", "t@t"], ["user.name", "t"]):
+        subprocess.run(["git", "-C", str(sub_repo), "config", *cfg], check=True)
+    (sub_repo / "lib.py").write_text("x = 1\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(sub_repo), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(sub_repo), "commit", "-qm", "sub"], check=True)
+    subprocess.run(
+        ["git", "-C", git_repo, "submodule", "add", "-q", str(sub_repo), "vendor"],
+        check=True,
+    )
+    subprocess.run(["git", "-C", git_repo, "commit", "-qm", "add-sub"], check=True)
+    git_dir = os.path.join(git_repo, ".git")
+    deadline = time.monotonic() + 60.0
+    assert module._gitlink_probe_safe(git_repo, git_dir, b"vendor", deadline) is True
+    # A symlink-replaced gitlink is never probed.
+    os.rename(os.path.join(git_repo, "vendor"), os.path.join(git_repo, "vendor.old"))
+    os.symlink("vendor.old", os.path.join(git_repo, "vendor"))
+    assert module._gitlink_probe_safe(git_repo, git_dir, b"vendor", deadline) is False
+    # A missing directory is not probed.
+    assert module._gitlink_probe_safe(git_repo, git_dir, b"absent", deadline) is False
+    # A .git file pointing outside the parent git dir is not probed.
+    outside = Path(git_repo, "outside")
+    outside.mkdir()
+    (outside / ".git").write_text("gitdir: /etc\n", encoding="utf-8")
+    assert module._gitlink_probe_safe(git_repo, git_dir, b"outside", deadline) is False
+    # A malformed .git file is not probed.
+    (outside / ".git").write_text("no gitdir line\n", encoding="utf-8")
+    assert module._gitlink_probe_safe(git_repo, git_dir, b"outside", deadline) is False
+
+
+@POSIX_SNAPSHOT_TEST
+def test_gitlink_probe_failure_frames_dirty_without_entering(
+    git_repo: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An uncertifiable gitlink is dirty and never entered."""
+    import tree_sitter_analyzer.diff_snapshot_readonly as module
+
+    sub_repo = Path(git_repo, "vendor")
+    sub_repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(sub_repo)], check=True)
+    for cfg in (
+        ["user.email", "t@t"],
+        ["user.name", "t"],
+        ["maintenance.auto", "false"],
+        ["gc.auto", "0"],
+    ):
+        subprocess.run(["git", "-C", str(sub_repo), "config", *cfg], check=True)
+    (sub_repo / "lib.py").write_text("x = 1\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(sub_repo), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(sub_repo), "commit", "-qm", "sub"], check=True)
+    subprocess.run(
+        ["git", "-C", git_repo, "submodule", "add", "-q", str(sub_repo), "vendor"],
+        check=True,
+    )
+    subprocess.run(["git", "-C", git_repo, "commit", "-qm", "add-sub"], check=True)
+    nested_calls: list[list[str]] = []
+    original_output = module._git_output_readonly
+
+    def spy_output(root, args, *, deadline, limit):
+        nested_calls.append(args)
+        return original_output(root, args, deadline=deadline, limit=limit)
+
+    monkeypatch.setattr(module, "_git_output_readonly", spy_output)
+    monkeypatch.setattr(module, "_gitlink_probe_safe", lambda *a, **k: False)
+    epochs: list[GitEpoch] = []
+    oracle_generation_readonly(git_repo, "diff", epoch_out=epochs)
+    assert epochs[0].workspace_gitlinks == (
+        (b"vendor", dict(epochs[0].index_entries)[b"vendor"]),
+    )
+    # The nested submodule probes were never invoked for the unsafe gitlink.
+    assert all(b"-C" not in args for args in nested_calls)

--- a/tests/unit/test_diff_snapshot_readonly_capture.py
+++ b/tests/unit/test_diff_snapshot_readonly_capture.py
@@ -1,0 +1,527 @@
+"""RFC-0022 P0.4 zero-write capture payload differential contract.
+
+The zero-write backend (``diff_snapshot_readonly_capture``) must reproduce
+the frozen capture (``diff_snapshot_capture._capture_payload``) exactly on
+identical source state: changed-file records, old/new bytes, and the
+normalized patch — otherwise task routes comparing P0.2 payloads would
+diverge between the two backends. These tests prove byte-equality across
+clean/dirty/untracked/deleted/binary/symlink/rename/staged states, pin the
+documented divergences (content-modified worktree moves surface as
+delete+add pairs; conversion-active repositories fail closed), and assert
+the zero-write invocation set never materializes a temporary index.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from tests.unit._diff_snapshot_support import POSIX_SNAPSHOT_TEST
+from tree_sitter_analyzer.diff_snapshot_capture import _capture_payload
+from tree_sitter_analyzer.diff_snapshot_readonly import oracle_generation_readonly
+from tree_sitter_analyzer.diff_snapshot_readonly_capture import (
+    _git_quote_path,
+    _no_index_new_file_patch,
+    _pair_exact_renames,
+    _patch_section_paths,
+    capture_payload_readonly,
+)
+from tree_sitter_analyzer.source_oracle import SourceOracleError
+from tree_sitter_analyzer.source_oracle_git import GitEpoch, oracle_generation
+
+_BUDGET = 64 * 1024 * 1024
+
+
+@pytest.fixture()
+def git_repo(tmp_path) -> str:
+    root = str(tmp_path)
+    subprocess.run(["git", "init", "-q", root], check=True)
+    for cfg in (
+        ["user.email", "t@t"],
+        ["user.name", "t"],
+        ["maintenance.auto", "false"],
+        ["gc.auto", "0"],
+    ):
+        subprocess.run(["git", "-C", root, "config", *cfg], check=True)
+    (tmp_path / "base.py").write_text("value = 1\n", encoding="utf-8")
+    (tmp_path / "keep.py").write_text("keep = True\n", encoding="utf-8")
+    subprocess.run(["git", "-C", root, "add", "."], check=True)
+    subprocess.run(["git", "-C", root, "commit", "-qm", "init"], check=True)
+    return root
+
+
+def _payloads(root: str, mode: str) -> tuple[bytes, tuple, bytes, tuple]:
+    """Capture both backends on the same source state and return pairs."""
+    frozen_epochs: list[GitEpoch] = []
+    readonly_epochs: list[GitEpoch] = []
+    frozen_manifest: dict = {}
+    readonly_manifest: dict = {}
+    frozen_gen, _ = oracle_generation(
+        root, mode, manifest=frozen_manifest, epoch_out=frozen_epochs
+    )
+    readonly_gen, _ = oracle_generation_readonly(
+        root, mode, manifest=readonly_manifest, epoch_out=readonly_epochs
+    )
+    assert frozen_gen == readonly_gen
+    deadline = time.monotonic() + 60.0
+    frozen_patch, frozen_files = _capture_payload(
+        root,
+        mode,
+        deadline,
+        _BUDGET,
+        expected_manifest=frozen_manifest,
+        epoch=frozen_epochs[0],
+    )
+    readonly_patch, readonly_files = capture_payload_readonly(
+        root,
+        mode,
+        deadline,
+        _BUDGET,
+        expected_manifest=readonly_manifest,
+        epoch=readonly_epochs[0],
+    )
+    return frozen_patch, frozen_files, readonly_patch, readonly_files
+
+
+def _assert_equal_payloads(root: str, mode: str, expected_records: int) -> None:
+    frozen_patch, frozen_files, readonly_patch, readonly_files = _payloads(root, mode)
+    assert [file.record.to_dict() for file in frozen_files] == [
+        file.record.to_dict() for file in readonly_files
+    ]
+    assert [
+        (file.record.path, file.old_bytes, file.new_bytes) for file in frozen_files
+    ] == [(file.record.path, file.old_bytes, file.new_bytes) for file in readonly_files]
+    assert frozen_patch == readonly_patch
+    assert len(frozen_files) == expected_records
+
+
+@POSIX_SNAPSHOT_TEST
+def test_clean_repo_payloads_match(git_repo: str) -> None:
+    _assert_equal_payloads(git_repo, "diff", 0)
+    _assert_equal_payloads(git_repo, "staged", 0)
+
+
+@POSIX_SNAPSHOT_TEST
+def test_dirty_payloads_match(git_repo: str) -> None:
+    Path(git_repo, "base.py").write_text("value = 2\nline2\n", encoding="utf-8")
+    _assert_equal_payloads(git_repo, "diff", 1)
+
+
+@POSIX_SNAPSHOT_TEST
+def test_untracked_text_and_dirty_payloads_match(git_repo: str) -> None:
+    Path(git_repo, "base.py").write_text("value = 3\n", encoding="utf-8")
+    Path(git_repo, "new.py").write_text("brand = 'new'\n", encoding="utf-8")
+    Path(git_repo, ".gitignore").write_text("*.log\n", encoding="utf-8")
+    Path(git_repo, "ignored.log").write_text("noise\n", encoding="utf-8")
+    # base.py modified, .gitignore and new.py added; ignored.log excluded.
+    _assert_equal_payloads(git_repo, "diff", 3)
+
+
+@POSIX_SNAPSHOT_TEST
+def test_deleted_payloads_match(git_repo: str) -> None:
+    Path(git_repo, "keep.py").unlink()
+    _assert_equal_payloads(git_repo, "diff", 1)
+
+
+@POSIX_SNAPSHOT_TEST
+def test_untracked_executable_payloads_match(git_repo: str) -> None:
+    script = Path(git_repo, "run.sh")
+    script.write_text("#!/bin/sh\necho hi\n", encoding="utf-8")
+    script.chmod(0o755)
+    _assert_equal_payloads(git_repo, "diff", 1)
+
+
+@POSIX_SNAPSHOT_TEST
+def test_untracked_no_newline_payloads_match(git_repo: str) -> None:
+    Path(git_repo, "nonl.txt").write_bytes(b"no-newline")
+    _assert_equal_payloads(git_repo, "diff", 1)
+
+
+@POSIX_SNAPSHOT_TEST
+def test_untracked_binary_payloads_match(git_repo: str) -> None:
+    Path(git_repo, "bin.dat").write_bytes(b"\x00\x01\x02\x03binary\x00")
+    _assert_equal_payloads(git_repo, "diff", 1)
+
+
+@POSIX_SNAPSHOT_TEST
+def test_untracked_symlink_payloads_match(git_repo: str) -> None:
+    os.symlink("base.py", os.path.join(git_repo, "link.py"))
+    _assert_equal_payloads(git_repo, "diff", 1)
+
+
+@POSIX_SNAPSHOT_TEST
+def test_exact_worktree_rename_payloads_match(git_repo: str) -> None:
+    os.rename(os.path.join(git_repo, "base.py"), os.path.join(git_repo, "moved.py"))
+    _assert_equal_payloads(git_repo, "diff", 1)
+
+
+@POSIX_SNAPSHOT_TEST
+def test_rename_plus_dirty_payloads_match(git_repo: str) -> None:
+    os.rename(os.path.join(git_repo, "base.py"), os.path.join(git_repo, "moved.py"))
+    Path(git_repo, "keep.py").write_text("keep = 2\n", encoding="utf-8")
+    _assert_equal_payloads(git_repo, "diff", 2)
+
+
+@POSIX_SNAPSHOT_TEST
+def test_staged_add_payloads_match(git_repo: str) -> None:
+    Path(git_repo, "staged.py").write_text("s = 1\n", encoding="utf-8")
+    subprocess.run(["git", "-C", git_repo, "add", "staged.py"], check=True)
+    # Worktree-only dirt must not leak into staged mode.
+    Path(git_repo, "keep.py").write_text("keep = 2\n", encoding="utf-8")
+    _assert_equal_payloads(git_repo, "staged", 1)
+
+
+@POSIX_SNAPSHOT_TEST
+def test_staged_rename_payloads_match(git_repo: str) -> None:
+    Path(git_repo, "base.py").write_text("value = 9\n", encoding="utf-8")
+    subprocess.run(["git", "-C", git_repo, "add", "base.py"], check=True)
+    subprocess.run(["git", "-C", git_repo, "mv", "keep.py", "renamed.py"], check=True)
+    _assert_equal_payloads(git_repo, "staged", 2)
+
+
+@POSIX_SNAPSHOT_TEST
+def test_double_dirty_payloads_match(git_repo: str) -> None:
+    Path(git_repo, "base.py").write_text("value = 5\n", encoding="utf-8")
+    subprocess.run(["git", "-C", git_repo, "add", "base.py"], check=True)
+    Path(git_repo, "base.py").write_text("value = 6\n", encoding="utf-8")
+    _assert_equal_payloads(git_repo, "diff", 1)
+
+
+@POSIX_SNAPSHOT_TEST
+def test_modified_worktree_move_surfaces_delete_plus_add(git_repo: str) -> None:
+    """Documented divergence: an inexact move is D+A, never a fake R."""
+    Path(git_repo, "base.py").write_text("value = 1\n", encoding="utf-8")
+    os.rename(os.path.join(git_repo, "base.py"), os.path.join(git_repo, "moved.py"))
+    Path(git_repo, "moved.py").write_text("value = 1\nchanged\n", encoding="utf-8")
+    _readonly_epochs: list[GitEpoch] = []
+    manifest: dict = {}
+    oracle_generation_readonly(
+        git_repo, "diff", manifest=manifest, epoch_out=_readonly_epochs
+    )
+    _patch, files = capture_payload_readonly(
+        git_repo,
+        "diff",
+        time.monotonic() + 60.0,
+        _BUDGET,
+        expected_manifest=manifest,
+        epoch=_readonly_epochs[0],
+    )
+    assert [(file.record.path, file.record.status) for file in files] == [
+        ("base.py", "D"),
+        ("moved.py", "A"),
+    ]
+    assert files[0].old_bytes == b"value = 1\n"
+    assert files[1].new_bytes == b"value = 1\nchanged\n"
+
+
+@POSIX_SNAPSHOT_TEST
+def test_conversion_guard_fails_closed_on_autocrlf(git_repo: str) -> None:
+    subprocess.run(
+        ["git", "-C", git_repo, "config", "core.autocrlf", "true"], check=True
+    )
+    Path(git_repo, "base.py").write_bytes(b"value = 1\r\nline2\r\n")
+    with pytest.raises(SourceOracleError, match="DIFF_SNAPSHOT_UNSUPPORTED_CONVERSION"):
+        _assert_equal_payloads(git_repo, "diff", 1)
+
+
+@POSIX_SNAPSHOT_TEST
+def test_conversion_guard_passes_without_crlf(git_repo: str) -> None:
+    subprocess.run(
+        ["git", "-C", git_repo, "config", "core.autocrlf", "true"], check=True
+    )
+    Path(git_repo, "base.py").write_text("value = 2\n", encoding="utf-8")
+    _assert_equal_payloads(git_repo, "diff", 1)
+
+
+@POSIX_SNAPSHOT_TEST
+def test_conversion_guard_fails_closed_on_eol_attribute(git_repo: str) -> None:
+    Path(git_repo, ".gitattributes").write_text(
+        "base.py text eol=crlf\n", encoding="utf-8"
+    )
+    Path(git_repo, "base.py").write_bytes(b"value = 1\r\n")
+    with pytest.raises(SourceOracleError, match="DIFF_SNAPSHOT_UNSUPPORTED_CONVERSION"):
+        _assert_equal_payloads(git_repo, "diff", 1)
+
+
+@POSIX_SNAPSHOT_TEST
+def test_capture_never_materializes_temporary_index(
+    git_repo: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The zero-write capture must never invoke the temp-index machinery."""
+    import tempfile
+
+    mkstemp_calls: list[str] = []
+    mkdtemp_calls: list[str] = []
+
+    def spy_mkstemp(*args, **kwargs):
+        mkstemp_calls.append("mkstemp")
+        return tempfile.mkstemp(*args, **kwargs)
+
+    def spy_mkdtemp(*args, **kwargs):
+        mkdtemp_calls.append("mkdtemp")
+        return tempfile.mkdtemp(*args, **kwargs)
+
+    monkeypatch.setattr(tempfile, "mkstemp", spy_mkstemp)
+    monkeypatch.setattr(tempfile, "mkdtemp", spy_mkdtemp)
+    import tree_sitter_analyzer.diff_snapshot_readonly as readonly_module
+
+    seen_env: dict[str, str] = {}
+    original_runner = readonly_module.run_git_readonly
+
+    def spy(root, args, *, deadline, limit, env=None, input_=None, ok_returncodes=None):
+        seen_env.update(dict(env or {}))
+        return original_runner(
+            root,
+            args,
+            deadline=deadline,
+            limit=limit,
+            env=env,
+            input_=input_,
+            ok_returncodes=ok_returncodes or frozenset({0}),
+        )
+
+    monkeypatch.setattr(readonly_module, "run_git_readonly", spy)
+    _readonly_epochs: list[GitEpoch] = []
+    manifest: dict = {}
+    oracle_generation_readonly(
+        git_repo, "diff", manifest=manifest, epoch_out=_readonly_epochs
+    )
+    capture_payload_readonly(
+        git_repo,
+        "diff",
+        time.monotonic() + 60.0,
+        _BUDGET,
+        expected_manifest=manifest,
+        epoch=_readonly_epochs[0],
+    )
+    assert mkstemp_calls == []
+    assert mkdtemp_calls == []
+    assert "GIT_INDEX_FILE" not in seen_env
+    assert seen_env.get("GIT_OPTIONAL_LOCKS") == "0"
+
+
+@POSIX_SNAPSHOT_TEST
+def test_no_index_patch_accepts_exit_one(git_repo: str) -> None:
+    Path(git_repo, "brand-new.py").write_text("x = 1\n", encoding="utf-8")
+    patch = _no_index_new_file_patch(
+        git_repo, b"brand-new.py", time.monotonic() + 60.0, 1024 * 1024
+    )
+    assert patch.startswith(
+        b"diff --git a/brand-new.py b/brand-new.py\nnew file mode 100644\n"
+    )
+    assert patch.endswith(b"+x = 1\n")
+
+
+@POSIX_SNAPSHOT_TEST
+def test_patch_section_paths_splits_and_unquotes(git_repo: str) -> None:
+    # Git C-quotes the whole a/ path (including the prefix) when needed.
+    raw = (
+        b"diff --git a/a.txt b/a.txt\n--- a/a.txt\n+++ b/a.txt\n"
+        b'\ndiff --git "a/we\tird" "b/we\tird"\n--- a/"we\tird"\n'
+    )
+    sections = _patch_section_paths(raw)
+    assert set(sections) == {b"a.txt", b"we\tird"}
+    assert sections[b"a.txt"].startswith(b"diff --git a/a.txt")
+    # The split token for the second section lacks the "diff --git " prefix
+    # and the header embeds the real tab byte, not the C-quoted escape.
+    assert sections[b"we\tird"].startswith(b'"a/we\tird" "b/we\tird"')
+
+
+@POSIX_SNAPSHOT_TEST
+def test_git_quote_path_matches_git_style() -> None:
+    assert _git_quote_path(b"plain.txt") == b"plain.txt"
+    assert _git_quote_path(b"a\tb") == b'"a\\tb"'
+    assert _git_quote_path(b'a"b') == b'"a\\"b"'
+    assert _git_quote_path(b"n\x01l") == b'"n\\001l"'
+    assert _git_quote_path("é".encode()) == b'"\\303\\251"'
+
+
+@POSIX_SNAPSHOT_TEST
+def test_pair_exact_renames_pairs_identical_content(git_repo: str) -> None:
+    oid = subprocess.run(
+        ["git", "-C", git_repo, "hash-object", "--stdin"],
+        input=b"value = 1\n",
+        check=True,
+        capture_output=True,
+    ).stdout.strip()
+    index_entries = {b"old.py": b"100644 " + oid + b" 0"}
+    safe_paths = {
+        b"new.py": type(
+            "Safe",
+            (),
+            {"kind": "file", "data": b"value = 1\n", "metadata": (b"x,100,33188",)},
+        )()
+    }
+    rows = [("D", None, b"old.py"), ("A", None, b"new.py")]
+    paired = _pair_exact_renames(
+        git_repo, rows, index_entries, safe_paths, time.monotonic() + 60.0, 1024
+    )
+    assert paired == [("R", b"old.py", b"new.py")]
+
+
+@POSIX_SNAPSHOT_TEST
+def test_pair_exact_renames_keeps_modified_moves_unpaired(git_repo: str) -> None:
+    oid = subprocess.run(
+        ["git", "-C", git_repo, "hash-object", "--stdin"],
+        input=b"value = 1\n",
+        check=True,
+        capture_output=True,
+    ).stdout.strip()
+    index_entries = {b"old.py": b"100644 " + oid + b" 0"}
+    safe_paths = {
+        b"new.py": type(
+            "Safe",
+            (),
+            {
+                "kind": "file",
+                "data": b"value = 1\nchanged\n",
+                "metadata": (b"x,100,33188",),
+            },
+        )()
+    }
+    rows = [("D", None, b"old.py"), ("A", None, b"new.py")]
+    paired = _pair_exact_renames(
+        git_repo, rows, index_entries, safe_paths, time.monotonic() + 60.0, 1024
+    )
+    assert [row[0] for row in paired] == ["D", "A"]
+
+
+@POSIX_SNAPSHOT_TEST
+def test_dirty_gitlink_payloads_match(git_repo: str) -> None:
+    """A dirty submodule yields one opaque dirty_gitlink record, no patch."""
+    sub_repo = Path(git_repo, "vendor")
+    sub_repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(sub_repo)], check=True)
+    for cfg in (["user.email", "t@t"], ["user.name", "t"]):
+        subprocess.run(["git", "-C", str(sub_repo), "config", *cfg], check=True)
+    (sub_repo / "lib.py").write_text("x = 1\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(sub_repo), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(sub_repo), "commit", "-qm", "sub"], check=True)
+    subprocess.run(
+        ["git", "-C", git_repo, "submodule", "add", "-q", str(sub_repo), "vendor"],
+        check=True,
+    )
+    subprocess.run(["git", "-C", git_repo, "commit", "-qm", "add-sub"], check=True)
+    (sub_repo / "lib.py").write_text("x = 2\n", encoding="utf-8")
+    Path(git_repo, "base.py").write_text("value = 2\n", encoding="utf-8")
+    _assert_equal_payloads(git_repo, "diff", 2)
+    # The dirty gitlink record is opaque: no patch section, unsupported.
+    _readonly_epochs: list[GitEpoch] = []
+    manifest: dict = {}
+    oracle_generation_readonly(
+        git_repo, "diff", manifest=manifest, epoch_out=_readonly_epochs
+    )
+    _patch, files = capture_payload_readonly(
+        git_repo,
+        "diff",
+        time.monotonic() + 60.0,
+        _BUDGET,
+        expected_manifest=manifest,
+        epoch=_readonly_epochs[0],
+    )
+    gitlink_records = [file.record for file in files if file.record.path == "vendor"]
+    assert len(gitlink_records) == 1
+    assert gitlink_records[0].status == "M"
+    assert gitlink_records[0].unsupported_kind == "dirty_gitlink"
+    assert gitlink_records[0].patch_available is False
+    assert gitlink_records[0].old_kind == "gitlink"
+    assert gitlink_records[0].new_kind == "gitlink"
+    assert b"vendor" not in _patch
+
+
+@POSIX_SNAPSHOT_TEST
+def test_clean_gitlink_payloads_match(git_repo: str) -> None:
+    """A clean submodule produces no record in either backend."""
+    sub_repo = Path(git_repo, "vendor")
+    sub_repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(sub_repo)], check=True)
+    for cfg in (["user.email", "t@t"], ["user.name", "t"]):
+        subprocess.run(["git", "-C", str(sub_repo), "config", *cfg], check=True)
+    (sub_repo / "lib.py").write_text("x = 1\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(sub_repo), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(sub_repo), "commit", "-qm", "sub"], check=True)
+    subprocess.run(
+        ["git", "-C", git_repo, "submodule", "add", "-q", str(sub_repo), "vendor"],
+        check=True,
+    )
+    subprocess.run(["git", "-C", git_repo, "commit", "-qm", "add-sub"], check=True)
+    _assert_equal_payloads(git_repo, "diff", 0)
+
+
+def _registry_snapshot_fields(
+    root: str, mode: str, readonly: bool
+) -> tuple[dict[str, object], dict[str, object]]:
+    """Create one snapshot via a backend and expose its published fields."""
+    import tree_sitter_analyzer.diff_snapshot_registry as snapshots
+
+    snapshots.reset_registry()
+    created = snapshots.REGISTRY.create(root, mode, [], readonly=readonly)
+    assert created.get("success"), created
+    consumer, error = snapshots.REGISTRY.acquire(str(created["diff_snapshot_id"]), root)
+    assert error is None
+    try:
+        snapshot = consumer.snapshot
+        fields = {
+            "source_generation": created["source_generation"],
+            "changed_records": created["changed_records"],
+            "assessed_scope_paths": created["assessed_scope_paths"],
+            "patch": snapshot.normalized_patch,
+            "files_bytes": tuple(
+                (file.record.path, file.old_bytes, file.new_bytes)
+                for file in snapshot.files
+            ),
+            "inventory_paths": snapshot.inventory_paths,
+            "staged_source_matches_worktree": (snapshot.staged_source_matches_worktree),
+            "staged_config_matches_worktree": snapshot.staged_config_matches_worktree,
+            "constraint_config_path": snapshot.constraint_config_path,
+            "constraint_config_data": snapshot.constraint_config_data,
+            "constraint_config_error": snapshot.constraint_config_error,
+        }
+        return created, fields
+    finally:
+        consumer.release()
+
+
+def _assert_equal_registry_snapshots(root: str, mode: str) -> None:
+    _frozen_created, frozen = _registry_snapshot_fields(root, mode, False)
+    _readonly_created, readonly = _registry_snapshot_fields(root, mode, True)
+    assert frozen == readonly
+
+
+@POSIX_SNAPSHOT_TEST
+def test_registry_diff_mode_snapshots_match(git_repo: str) -> None:
+    Path(git_repo, "base.py").write_text("value = 2\n", encoding="utf-8")
+    Path(git_repo, "new.py").write_text("x = 1\n", encoding="utf-8")
+    _assert_equal_registry_snapshots(git_repo, "diff")
+
+
+@POSIX_SNAPSHOT_TEST
+def test_registry_staged_mode_snapshots_match(git_repo: str) -> None:
+    Path(git_repo, "architectural-constraints.yml").write_text(
+        "rules:\n  - id: r2\n", encoding="utf-8"
+    )
+    subprocess.run(["git", "-C", git_repo, "add", "."], check=True)
+    Path(git_repo, "base.py").write_text("value = 9\n", encoding="utf-8")
+    subprocess.run(["git", "-C", git_repo, "add", "base.py"], check=True)
+    _assert_equal_registry_snapshots(git_repo, "staged")
+
+
+@POSIX_SNAPSHOT_TEST
+def test_registry_scoped_snapshots_match(git_repo: str) -> None:
+    Path(git_repo, "base.py").write_text("value = 2\n", encoding="utf-8")
+    Path(git_repo, "new.py").write_text("x = 1\n", encoding="utf-8")
+    import tree_sitter_analyzer.diff_snapshot_registry as snapshots
+
+    snapshots.reset_registry()
+    frozen = snapshots.REGISTRY.create(git_repo, "diff", ["base.py"], readonly=False)
+    assert frozen.get("success")
+    snapshots.reset_registry()
+    readonly = snapshots.REGISTRY.create(git_repo, "diff", ["base.py"], readonly=True)
+    assert readonly.get("success")
+    assert frozen["source_generation"] == readonly["source_generation"]
+    assert frozen["changed_records"] == readonly["changed_records"]
+    assert frozen["assessed_scope_paths"] == readonly["assessed_scope_paths"]

--- a/tests/unit/test_diff_snapshot_readonly_capture.py
+++ b/tests/unit/test_diff_snapshot_readonly_capture.py
@@ -391,6 +391,7 @@ def test_pair_exact_renames_keeps_modified_moves_unpaired(git_repo: str) -> None
 
 
 @POSIX_SNAPSHOT_TEST
+@pytest.mark.slow_ok  # two full captures + publish: real git subprocess work
 def test_dirty_gitlink_payloads_match(git_repo: str) -> None:
     """A dirty submodule yields one opaque dirty_gitlink record, no patch."""
     sub_repo = Path(git_repo, "vendor")
@@ -434,6 +435,7 @@ def test_dirty_gitlink_payloads_match(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
+@pytest.mark.slow_ok  # two full captures + publish: real git subprocess work
 def test_clean_gitlink_payloads_match(git_repo: str) -> None:
     """A clean submodule produces no record in either backend."""
     sub_repo = Path(git_repo, "vendor")
@@ -493,6 +495,7 @@ def _assert_equal_registry_snapshots(root: str, mode: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
+@pytest.mark.slow_ok  # two full captures + publish: real git subprocess work
 def test_registry_diff_mode_snapshots_match(git_repo: str) -> None:
     Path(git_repo, "base.py").write_text("value = 2\n", encoding="utf-8")
     Path(git_repo, "new.py").write_text("x = 1\n", encoding="utf-8")
@@ -500,6 +503,7 @@ def test_registry_diff_mode_snapshots_match(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
+@pytest.mark.slow_ok  # two full captures + publish: real git subprocess work
 def test_registry_staged_mode_snapshots_match(git_repo: str) -> None:
     Path(git_repo, "architectural-constraints.yml").write_text(
         "rules:\n  - id: r2\n", encoding="utf-8"

--- a/tests/unit/test_wire_owner_contract.py
+++ b/tests/unit/test_wire_owner_contract.py
@@ -86,11 +86,16 @@ def test_safe_to_edit_unavailable_echoes_action_version() -> None:
     assert result["action_version"] == "edit.safe/v1"
 
 
-def test_change_impact_unavailable_echoes_action_version() -> None:
+def test_change_impact_unavailable_echoes_action_version(tmp_path: Path) -> None:
+    # RFC-0022 P0.4: on the Linux axis the read-existing producer is live,
+    # so the unavailable fixture must be a non-repository directory — the
+    # working-tree root would trigger a real full-repo capture and blow the
+    # unit perf budget. The classified failure still echoes the owner
+    # version; non-Linux axes keep the stable unsupported envelope.
     from tree_sitter_analyzer.mcp.tools.change_impact_tool import ChangeImpactTool
     from tree_sitter_analyzer.wire_owner import EDIT_IMPACT_ACTION_VERSION
 
-    tool = ChangeImpactTool(str(Path.cwd()))
+    tool = ChangeImpactTool(str(tmp_path))
     result = _run(
         tool.execute(
             {

--- a/tree_sitter_analyzer/diff_snapshot_constraints_readonly.py
+++ b/tree_sitter_analyzer/diff_snapshot_constraints_readonly.py
@@ -1,0 +1,139 @@
+"""RFC-0022 P0.4 zero-write staged constraint probes (Phase A groundwork).
+
+The frozen staged probes (``diff_snapshot_constraints``) read the captured
+index through a temporary index/object store (P0.2 allows this). These
+variants reproduce the same evidence with zero filesystem writes: the
+constraint file blob is read with ``git cat-file`` against the live object
+database, and the staged-sources match check runs the same diff-files /
+ls-files invocation set read-only against the live index with
+``GIT_OPTIONAL_LOCKS=0``.
+"""
+
+from __future__ import annotations
+
+import os
+
+from .diff_snapshot_constraints import _entry_parts
+from .diff_snapshot_readonly import _live_index_output
+from .diff_snapshot_readonly_capture import _blob_readonly
+from .git_path_codec import path_to_raw, raw_to_path
+from .git_readonly import run_git_readonly
+from .languages.lang_extension_map import EXT_TO_LANG
+from .source_oracle import SourceOracleError
+from .source_oracle_git import GitEpoch
+
+
+def frozen_index_constraint_config_readonly(
+    root: str, epoch: GitEpoch, deadline: float, storage_limit: int
+) -> tuple[str | None, bytes | None, tuple[bytes, ...]]:
+    """Read constraint discovery and bytes from the captured stage-zero index.
+
+    Identical evidence to the frozen probe, but the blob comes from the
+    live object database through the zero-write runner.
+    """
+    entries = epoch.index_map()
+    for candidate in (
+        "architectural-constraints.yml",
+        ".tree-sitter-analyzer/constraints.yml",
+    ):
+        raw = path_to_raw(candidate)
+        entry = entries.get(raw)
+        if entry is None:
+            continue
+        mode, oid, kind = _entry_parts(entry)
+        if mode not in ("100644", "100755") or oid is None or kind != "file":
+            raise SourceOracleError("CONSTRAINT_CONFIG_UNSAFE")
+        data = _blob_readonly(root, oid, kind, deadline, 1024 * 1024)
+        if data is None:
+            raise SourceOracleError("CONSTRAINT_CONFIG_UNSAFE")
+        return candidate, data, (raw + b"\0" + entry,)
+    return None, None, ()
+
+
+def _ignored_submodule_sources_readonly(
+    root: str, epoch: GitEpoch, deadline: float, limit: int
+) -> tuple[bytes, ...]:
+    """Return ignored supported leaves or uncertifiable live gitlinks.
+
+    Mirrors ``diff_snapshot_constraints._ignored_submodule_sources`` with
+    the zero-write runner for ``git submodule foreach``.
+    """
+    gitlinks = tuple(
+        path
+        for path, entry in epoch.index_map().items()
+        if entry.startswith(b"160000 ")
+    )
+    if not gitlinks:
+        return ()
+    if not os.path.isfile(os.path.join(root, ".gitmodules")):
+        return gitlinks
+    script = (
+        'printf "H\\0%s\\0" "$displaypath"; '
+        "git ls-files --others --ignored --exclude-standard -t -z"
+    )
+    raw = run_git_readonly(
+        root,
+        ["submodule", "foreach", "--recursive", "--quiet", script],
+        deadline=deadline,
+        limit=limit,
+    )
+    fields = raw.split(b"\0")
+    if fields and fields[-1] == b"":
+        fields.pop()
+    supported: list[bytes] = []
+    visited: set[bytes] = set()
+    prefix: bytes | None = None
+    index = 0
+    while index < len(fields):
+        field = fields[index]
+        if field == b"H":
+            index += 1
+            if index >= len(fields):
+                raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR")
+            prefix = fields[index]
+            visited.add(prefix)
+            index += 1
+            continue
+        if prefix is None or not field.startswith(b"? "):
+            raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR")
+        leaf = field[2:]
+        path = raw_to_path(prefix + b"/" + leaf)
+        if EXT_TO_LANG.get(os.path.splitext(path)[1].lower()) is not None:
+            supported.append(prefix + b"/" + leaf)
+        index += 1
+    supported.extend(path for path in gitlinks if path not in visited)
+    return tuple(supported)
+
+
+def frozen_index_sources_match_worktree_readonly(
+    root: str, epoch: GitEpoch, deadline: float, limit: int
+) -> bool:
+    """Return whether every supported source has the same index/worktree plane.
+
+    The frozen probe refreshes a temporary index whose stat cache is fully
+    invalidated; with ``GIT_OPTIONAL_LOCKS=0`` that refresh is skipped, so
+    the frozen probe's dirty set is *every* tracked path. The zero-write
+    variant reproduces that exact effective semantic without any stat
+    machinery: any supported-language tracked path (or untracked path, or
+    uncertifiable gitlink) makes the check fail.
+    """
+    paths: set[bytes] = set(epoch.index_map())
+    untracked_raw = _live_index_output(
+        root,
+        epoch.index_bytes,
+        ["ls-files", "--others", "-z"],
+        deadline=deadline,
+        limit=limit,
+    )
+    paths.update(path for path in untracked_raw.split(b"\0") if path)
+    if _ignored_submodule_sources_readonly(root, epoch, deadline, limit):
+        return False
+    indexed_paths = epoch.index_map()
+    for raw in paths:
+        path = raw_to_path(raw)
+        if EXT_TO_LANG.get(os.path.splitext(path)[1].lower()) is not None:
+            return False
+        entry = indexed_paths.get(raw)
+        if entry is not None and entry.startswith(b"160000 "):
+            return False
+    return True

--- a/tree_sitter_analyzer/diff_snapshot_leases.py
+++ b/tree_sitter_analyzer/diff_snapshot_leases.py
@@ -33,6 +33,9 @@ class FrozenDiffSnapshot:
     constraint_config_error: str | None = None
     staged_source_matches_worktree: bool = True
     staged_config_matches_worktree: bool = True
+    # RFC-0022 P0.4: snapshots created by the zero-write backend revalidate
+    # through the read-only oracle (acquire/validate_publish).
+    readonly: bool = False
     _inventory_raw_paths: tuple[bytes, ...] = ()
     _assessed_scope_raw_paths: tuple[bytes, ...] = ()
 

--- a/tree_sitter_analyzer/diff_snapshot_readonly.py
+++ b/tree_sitter_analyzer/diff_snapshot_readonly.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import stat
 import time
 from typing import Any
 
@@ -45,6 +46,7 @@ from .source_epoch import capture_source_epoch, core_bool
 from .source_oracle import (
     SourceOracleError,
     WorkspaceManifestEntry,
+    _remaining,
     canonical_root,
     stable_descriptor_chain,
 )
@@ -236,6 +238,57 @@ def _index_entries_from_bytes(
     return entries
 
 
+def _gitlink_probe_safe(root: str, git_dir: str, raw: bytes, deadline: float) -> bool:
+    """Return whether probing one gitlink stays inside the project boundary.
+
+    The frozen oracle treats live gitlink leaves as opaque; the zero-write
+    probe must not follow a symlink-replaced gitlink directory or a
+    ``.git`` file that points outside the parent repository. A standalone
+    nested repository (real ``.git`` directory) reads only inside the
+    project tree; a ``.git`` file must resolve back inside the parent's
+    git directory. Any uncertifiable gitlink fails closed as dirty
+    without being entered.
+    """
+    path = raw_to_path(raw)
+    full = os.path.join(root, path)
+    try:
+        info = os.lstat(full)
+    except OSError:
+        return False
+    if not stat.S_ISDIR(info.st_mode):
+        return False
+    git_file = os.path.join(full, ".git")
+    try:
+        git_info = os.lstat(git_file)
+    except OSError:
+        return False
+    if stat.S_ISDIR(git_info.st_mode):
+        return True
+    if not stat.S_ISREG(git_info.st_mode):
+        return False
+    try:
+        with open(git_file, "rb") as handle:
+            data = handle.read(64 * 1024)
+    except OSError:
+        return False
+    _remaining(deadline)
+    for line in data.split(b"\n"):
+        if not line.startswith(b"gitdir:"):
+            continue
+        value = line[len(b"gitdir:") :].strip()
+        if not value:
+            return False
+        decoded = os.fsdecode(value)
+        resolved = decoded if os.path.isabs(decoded) else os.path.join(full, decoded)
+        real_resolved = os.path.realpath(resolved)
+        real_git = os.path.realpath(git_dir)
+        try:
+            return os.path.commonpath((real_git, real_resolved)) == real_git
+        except ValueError:
+            return False
+    return False
+
+
 def _dirty_gitlink_probes_readonly(
     root: str, index_entries: dict[bytes, bytes], deadline: float
 ) -> set[bytes]:
@@ -245,12 +298,24 @@ def _dirty_gitlink_probes_readonly(
     oid or its worktree has changes. The frozen oracle re-checks this via
     stat-cache invalidation; the zero-write oracle reproduces it with
     bounded read-only nested git calls. A submodule that cannot certify
-    its HEAD (uninitialized/broken) fails closed as dirty.
+    its HEAD (uninitialized/broken) fails closed as dirty; a gitlink that
+    cannot be probed inside the project boundary is conservatively dirty
+    and is never entered.
     """
+    git_dir = _git_output_readonly(
+        root, ["rev-parse", "--git-dir"], deadline=deadline, limit=64 * 1024
+    )
+    git_dir = _strip_one_record_terminator(git_dir)
+    decoded_git_dir = os.fsdecode(git_dir)
+    if not os.path.isabs(decoded_git_dir):
+        decoded_git_dir = os.path.join(root, decoded_git_dir)
     dirty: set[bytes] = set()
     for raw in sorted(index_entries):
         entry = index_entries[raw]
         if not entry.startswith(b"160000 "):
+            continue
+        if not _gitlink_probe_safe(root, decoded_git_dir, raw, deadline):
+            dirty.add(raw)
             continue
         path = raw_to_path(raw)
         index_oid = entry.split(b" ")[1]
@@ -281,7 +346,11 @@ def _hinted_paths(index_bytes: bytes, object_format: str, max_paths: int) -> set
     The frozen oracle's stat-cache invalidation preserves these bits, so
     hinted entries are never dirty and their content is never framed; the
     P0.4 oracle must replicate that from the captured index bytes
-    (Codex #1293 P1). Supports index v2/v3; v4 fails closed.
+    (Codex #1293 P1). Assume-unchanged lives in the base flags; the
+    skip-worktree bit lives in the *extended* flags word, so entries with
+    the extended marker (including intent-to-add, whose extended
+    CE_INTENT_TO_ADD bit must NOT count as a hint) are read correctly.
+    Supports index v2/v3; v4 fails closed.
     """
     del max_paths
     if not index_bytes:
@@ -302,11 +371,18 @@ def _hinted_paths(index_bytes: bytes, object_format: str, max_paths: int) -> set
             index_bytes[offset + flags_offset : offset + flags_offset + 2], "big"
         )
         extended_offset = offset + flags_offset + 2
+        extended = 0
+        if flags & 0x4000:
+            if extended_offset + 2 > content_end:
+                raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR")
+            extended = int.from_bytes(
+                index_bytes[extended_offset : extended_offset + 2], "big"
+            )
         path_start = extended_offset + (2 if flags & 0x4000 else 0)
         path_end = index_bytes.find(b"\0", path_start)
         if path_end < 0 or path_end >= content_end:
             raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR")
-        if flags & (0x8000 | 0x4000):
+        if flags & 0x8000 or extended & 0x4000:
             hinted.add(index_bytes[path_start:path_end])
         fixed = 62 + (2 if flags & 0x4000 else 0)
         offset = offset + ((fixed + (path_end - path_start) + 1 + 7) & ~7)

--- a/tree_sitter_analyzer/diff_snapshot_readonly.py
+++ b/tree_sitter_analyzer/diff_snapshot_readonly.py
@@ -17,11 +17,11 @@ dirty files exactly when the cached stat is accurate; the differential
 tests below prove equality on typical fixture states. The strace authority
 (``scripts/rfc0022_strace_*.py``) certifies that no write is attempted.
 
-The module is the first slice of the P0.4 read-existing backend: the
-generation half. Wiring it into ``edit.impact(access_mode="read_existing")``
-plus the in-memory blob/patch materialization and the P0.2 golden-corpus
-equivalence suite is the remaining work (tracked with the RFC-0022 P0.4
-gate).
+The module is the generation half of the P0.4 read-existing backend; the
+in-memory blob/patch materialization half lives in
+``diff_snapshot_readonly_capture`` and is wired into
+``edit.impact(access_mode="read_existing")`` through the registry's
+read-only capture path (tracked with the RFC-0022 P0.4 gate).
 """
 
 from __future__ import annotations
@@ -39,6 +39,7 @@ from .frozen_git_settings import (
     frozen_settings_storage,
     reject_active_filters,
 )
+from .git_path_codec import raw_to_path
 from .git_readonly import run_git_readonly
 from .source_epoch import capture_source_epoch, core_bool
 from .source_oracle import (
@@ -62,7 +63,6 @@ from .source_oracle_git import (
     _supports_nofollow,
     container_storage,
     entry_map_storage,
-    git_output,
     has_split_index,
     path_set_storage,
 )
@@ -82,6 +82,7 @@ def _live_index_output(
     object_format: str = "sha1",
     input_: bytes | None = None,
     extra_env: dict[str, str] | None = None,
+    ok_returncodes: frozenset[int] = frozenset({0}),
 ) -> bytes:
     """Run Git read-only against the live index (P0.4: zero writes).
 
@@ -94,7 +95,8 @@ def _live_index_output(
     certifies that no write attempt occurs. ``refresh``/``clear_hints`` are
     accepted for compatibility and are no-ops (no stat-cache rewriting in
     memory either) — the differential tests validate the live stat cache
-    against the frozen oracle.
+    against the frozen oracle. ``ok_returncodes`` extends the accepted exit
+    set for ``git diff --no-index`` (exit 1 = differences found).
     """
     del index_bytes, refresh, clear_hints, object_format
     env = {
@@ -112,6 +114,7 @@ def _live_index_output(
         limit=limit,
         env=env,
         input_=input_,
+        ok_returncodes=ok_returncodes,
     )
 
 
@@ -231,6 +234,45 @@ def _index_entries_from_bytes(
     if len(entries) > max_paths:
         raise SourceOracleError("DIFF_SNAPSHOT_CAPACITY")
     return entries
+
+
+def _dirty_gitlink_probes_readonly(
+    root: str, index_entries: dict[bytes, bytes], deadline: float
+) -> set[bytes]:
+    """Return gitlink paths git's refresh would report dirty (P0.4).
+
+    Git reports a submodule dirty when its HEAD moved away from the index
+    oid or its worktree has changes. The frozen oracle re-checks this via
+    stat-cache invalidation; the zero-write oracle reproduces it with
+    bounded read-only nested git calls. A submodule that cannot certify
+    its HEAD (uninitialized/broken) fails closed as dirty.
+    """
+    dirty: set[bytes] = set()
+    for raw in sorted(index_entries):
+        entry = index_entries[raw]
+        if not entry.startswith(b"160000 "):
+            continue
+        path = raw_to_path(raw)
+        index_oid = entry.split(b" ")[1]
+        try:
+            head = _git_output_readonly(
+                root,
+                ["-C", path, "rev-parse", "--verify", "HEAD"],
+                deadline=deadline,
+                limit=4096,
+            ).strip()
+            status = _git_output_readonly(
+                root,
+                ["-C", path, "status", "--porcelain"],
+                deadline=deadline,
+                limit=16 * 1024 * 1024,
+            )
+        except SourceOracleError:
+            dirty.add(raw)
+            continue
+        if head != index_oid or status:
+            dirty.add(raw)
+    return dirty
 
 
 def _hinted_paths(index_bytes: bytes, object_format: str, max_paths: int) -> set[bytes]:
@@ -417,6 +459,23 @@ def oracle_generation_readonly(
         )
     dirty = {path for path in dirty_raw.split(b"\0") if path}
     untracked = {path for path in untracked_raw.split(b"\0") if path}
+    probed_gitlinks: set[bytes] = set()
+    if mode == "diff":
+        # The frozen oracle's stat-cache invalidation makes git report
+        # every regular tracked path dirty and re-check every gitlink
+        # (submodule HEAD + worktree state); the live stat cache can do
+        # neither. The all-tracked framing below reproduces the first half
+        # and the read-only nested probes reproduce the second; the probe
+        # is authoritative for gitlinks (it also clears stat-racy false
+        # positives the frozen refresh would have re-checked away).
+        probed_gitlinks = _dirty_gitlink_probes_readonly(root, index_entries, end)
+        gitlink_paths = {
+            raw for raw, entry in index_entries.items() if entry.startswith(b"160000 ")
+        }
+        dirty = (dirty - gitlink_paths) | probed_gitlinks
+        if probed_gitlinks:
+            ledger.require_available(path_set_storage(probed_gitlinks))
+            ledger.charge(path_set_storage(probed_gitlinks))
     retained_paths = path_set_storage(dirty) + path_set_storage(untracked)
     ledger.require_available(len(dirty_raw) + len(untracked_raw) + retained_paths)
     ledger.charge(retained_paths)
@@ -437,7 +496,10 @@ def oracle_generation_readonly(
         root,
         settings_inventory,
         end,
-        git_output,
+        # The frozen runner materializes a temporary order file per call;
+        # the zero-write oracle must route every settings probe through the
+        # read-only runner (Codex #1293 finding tracked with RFC-0022 P0.4).
+        _git_output_readonly,
         byte_ceiling=ledger.remaining,
     )
     ledger.charge(frozen_settings_storage(frozen_settings))
@@ -477,10 +539,13 @@ def oracle_generation_readonly(
                 dirty_paths=(
                     tuple(
                         sorted(
-                            raw
-                            for raw in tracked
-                            if not index_entries[raw].startswith(b"160000 ")
-                            and raw not in hinted
+                            {
+                                raw
+                                for raw in tracked
+                                if raw not in hinted
+                                and not index_entries[raw].startswith(b"160000 ")
+                            }
+                            | set(probed_gitlinks)
                         )
                     )
                     if mode == "diff"

--- a/tree_sitter_analyzer/diff_snapshot_readonly_capture.py
+++ b/tree_sitter_analyzer/diff_snapshot_readonly_capture.py
@@ -32,6 +32,7 @@ Equivalence contract (proved by the differential golden suite in
 
 from __future__ import annotations
 
+import hashlib
 import os
 
 from .diff_snapshot_capture import (
@@ -51,6 +52,7 @@ from .source_oracle import (
     SafePath,
     SourceOracleError,
     WorkspaceManifestEntry,
+    _remaining,
     safe_workspace_path,
 )
 from .source_oracle_git import GitEpoch
@@ -154,32 +156,93 @@ def _readonly_binaries(
     return result
 
 
+_QUOTE_SHORTHAND = {
+    0x07: b"\\a",
+    0x08: b"\\b",
+    0x0C: b"\\f",
+    0x0A: b"\\n",
+    0x0D: b"\\r",
+    0x09: b"\\t",
+    0x0B: b"\\v",
+    0x5C: b"\\\\",
+    0x22: b'\\"',
+}
+_UNQUOTE_SHORTHAND = {
+    b"a": 0x07,
+    b"b": 0x08,
+    b"f": 0x0C,
+    b"n": 0x0A,
+    b"r": 0x0D,
+    b"t": 0x09,
+    b"v": 0x0B,
+    b"\\": 0x5C,
+    b'"': 0x22,
+}
+
+
 def _git_quote_path(raw: bytes) -> bytes:
-    """Quote one path for a synthetic diff header (git ``quote_c_style``)."""
+    """Quote one path for a synthetic diff header (git ``quote_c_style``).
+
+    Git quotes the whole ``a/<path>`` token (prefix included) when any
+    byte needs quoting; spaces are never quoted, so callers pass the
+    prefixed path when emitting ``diff --git`` headers.
+    """
     needs = any(value < 0x20 or value > 0x7E or value in (0x22, 0x5C) for value in raw)
     if not needs:
         return raw
     out = bytearray(b'"')
-    shorthand = {
-        0x07: b"\\a",
-        0x08: b"\\b",
-        0x0C: b"\\f",
-        0x0A: b"\\n",
-        0x0D: b"\\r",
-        0x09: b"\\t",
-        0x0B: b"\\v",
-        0x5C: b"\\\\",
-        0x22: b'\\"',
-    }
     for value in raw:
-        if value in shorthand:
-            out.extend(shorthand[value])
+        if value in _QUOTE_SHORTHAND:
+            out.extend(_QUOTE_SHORTHAND[value])
         elif value < 0x20 or value > 0x7E:
             out.extend(f"\\{value:03o}".encode("ascii"))
         else:
             out.append(value)
     out.append(0x22)
     return bytes(out)
+
+
+def _git_unquote(raw: bytes) -> bytes:
+    """Decode one git C-quoted token (the inverse of ``quote_c_style``)."""
+    if not raw.startswith(b'"') or not raw.endswith(b'"'):
+        return raw
+    body = raw[1:-1]
+    out = bytearray()
+    index = 0
+    while index < len(body):
+        value = body[index]
+        if value != 0x5C:
+            out.append(value)
+            index += 1
+            continue
+        index += 1
+        if index >= len(body):
+            raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR")
+        escape = body[index : index + 1]
+        if escape in _UNQUOTE_SHORTHAND:
+            out.append(_UNQUOTE_SHORTHAND[escape])
+            index += 1
+            continue
+        octal = body[index : index + 3]
+        if len(octal) == 3 and all(0x30 <= value <= 0x37 for value in octal):
+            out.append(int(octal, 8))
+            index += 3
+            continue
+        raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR")
+    return bytes(out)
+
+
+def _quoted_token_end(raw: bytes, start: int) -> int:
+    """Return the index just past an unescaped closing quote from ``start``."""
+    index = start
+    while index < len(raw):
+        if raw[index] == 0x5C:
+            index += 2
+            continue
+        if raw[index] == 0x22:
+            return index + 1
+        index += 1
+    raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR")
 
 
 def _no_index_new_file_patch(
@@ -227,21 +290,50 @@ def _reject_worktree_conversion(
     ``hash-object --path``, so its published ``new_bytes`` are the
     *cleaned* bytes (autocrlf/eol/encoding conversions applied). The
     zero-write backend publishes raw worktree bytes; those are equal only
-    when no checkin conversion applies. Conversions can only alter a
-    non-binary file that already contains CRLF, so the guard is: any such
-    file plus an active conversion configuration (``core.autocrlf``,
-    ``eol`` attribute, or ``working-tree-encoding`` attribute) fails the
-    route closed with a stable code.
+    when no checkin conversion applies. ``working-tree-encoding`` and
+    ``ident`` can alter any content (UTF-16 files, expanded ``$Id$``
+    markers), so they are probed for every materialized path;
+    ``core.autocrlf``/``eol`` only alter non-binary files that already
+    contain CRLF, so the CRLF guard scopes those probes.
     """
-    candidates = sorted(
+    materialized = sorted(
         (raw, safe)
         for raw, safe in safe_paths.items()
-        if safe.kind in ("file", "symlink")
-        and safe.data is not None
-        and not _is_binary(safe.data)
-        and b"\r\n" in safe.data
+        if safe.kind in ("file", "symlink") and safe.data is not None
     )
-    if not candidates:
+    if not materialized:
+        return
+    attr_input = b"".join(raw + b"\0" for raw, _safe in materialized)
+    attributes = _live_index_output(
+        root,
+        b"",
+        ["check-attr", "-z", "working-tree-encoding", "ident", "eol", "--stdin"],
+        deadline=deadline,
+        limit=16 * 1024 * 1024,
+        input_=attr_input,
+    )
+    tokens = [token for token in attributes.split(b"\0") if token]
+    if len(tokens) % 3 != 0:
+        raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR")
+    per_path: dict[bytes, dict[bytes, bytes]] = {}
+    for index in range(0, len(tokens), 3):
+        path, attr, value = tokens[index : index + 3]
+        per_path.setdefault(path, {})[attr] = value
+    for raw, _safe in materialized:
+        attrs = per_path.get(raw, {})
+        if attrs.get(b"working-tree-encoding", b"unspecified") not in (
+            b"unspecified",
+            b"unset",
+        ):
+            raise SourceOracleError("DIFF_SNAPSHOT_UNSUPPORTED_CONVERSION")
+        if attrs.get(b"ident") == b"set":
+            raise SourceOracleError("DIFF_SNAPSHOT_UNSUPPORTED_CONVERSION")
+    crlf_candidates: list[tuple[bytes, SafePath]] = []
+    for raw, safe in materialized:
+        data = safe.data
+        if data is not None and not _is_binary(data) and b"\r\n" in data:
+            crlf_candidates.append((raw, safe))
+    if not crlf_candidates:
         return
     config_list = _git_output_readonly(
         root,
@@ -257,26 +349,8 @@ def _reject_worktree_conversion(
         settings[key.lower()] = value.strip()
     if settings.get(b"core.autocrlf", b"false").lower() in (b"true", b"input"):
         raise SourceOracleError("DIFF_SNAPSHOT_UNSUPPORTED_CONVERSION")
-    attr_input = b"".join(raw + b"\0" for raw, _safe in candidates)
-    attributes = _live_index_output(
-        root,
-        b"",
-        ["check-attr", "-z", "eol", "working-tree-encoding", "--stdin"],
-        deadline=deadline,
-        limit=16 * 1024 * 1024,
-        input_=attr_input,
-    )
-    tokens = [token for token in attributes.split(b"\0") if token]
-    if len(tokens) % 3 != 0:
-        raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR")
-    for index in range(0, len(tokens), 3):
-        _path, attr, value = tokens[index : index + 3]
-        if attr == b"eol" and value in (b"crlf", b"lf"):
-            raise SourceOracleError("DIFF_SNAPSHOT_UNSUPPORTED_CONVERSION")
-        if attr == b"working-tree-encoding" and value not in (
-            b"unspecified",
-            b"unset",
-        ):
+    for raw, _safe in crlf_candidates:
+        if per_path.get(raw, {}).get(b"eol") in (b"crlf", b"lf"):
             raise SourceOracleError("DIFF_SNAPSHOT_UNSUPPORTED_CONVERSION")
 
 
@@ -312,9 +386,13 @@ def _pair_exact_renames(
     The live ``git diff`` queue never contains untracked paths, so git
     cannot detect worktree renames for it; the frozen backend's temporary
     index does contain them and reports content-identical moves as
-    ``R100``. This replicates the exact-rename half with a deterministic
-    greedy pairing; content-modified moves stay delete+add pairs (a
-    documented divergence from the frozen inexact ``R``).
+    ``R100``. This replicates the exact-rename half with content hashing:
+    a pair is formed only when exactly one deleted file and one added file
+    share the content hash (Git's own tie-breaking for ambiguous identical
+    candidates is not reproduced, so ambiguous matches stay delete+add
+    pairs rather than guessing a wrong lineage). Content-modified moves
+    stay delete+add pairs (a documented divergence from the frozen
+    inexact ``R``). Matching is O(n) and deadline-bounded.
     """
     deleted = [
         row for row in rows if row[0] == "D" and (row[1] or row[2]) in index_entries
@@ -323,22 +401,38 @@ def _pair_exact_renames(
     if not deleted or not added:
         return rows
     added_paths = {row[2] for row in added}
-    pairs: dict[bytes, bytes] = {}
-    used: set[bytes] = set()
+    hasher = hashlib.sha256
+    added_hashes: dict[bytes, bytes] = {}
+    for _status, _old_raw, raw in added:
+        safe = safe_paths[raw]
+        if safe.kind in ("file", "symlink") and safe.data is not None:
+            added_hashes[raw] = hasher(safe.data).digest()
+        _remaining(deadline)
+    deleted_hashes: dict[bytes, bytes] = {}
     for _status, old_raw, raw in deleted:
         lookup = old_raw or raw
         mode, oid, kind = _entry_parts(index_entries[lookup])
-        old = _blob_readonly(root, oid, kind, deadline, limit)
-        if old is None:
+        blob = _blob_readonly(root, oid, kind, deadline, limit)
+        if blob is not None:
+            deleted_hashes[lookup] = hasher(blob).digest()
+        _remaining(deadline)
+    members_by_hash: dict[bytes, list[bytes]] = {}
+    for path, digest in added_hashes.items():
+        members_by_hash.setdefault(digest, []).append(path)
+    for path, digest in deleted_hashes.items():
+        members_by_hash.setdefault(digest, []).append(path)
+    pairs: dict[bytes, bytes] = {}
+    used: set[bytes] = set()
+    for _digest, members in members_by_hash.items():
+        if len(members) != 2:
             continue
-        for _new_status, _new_old, new_raw in added:
-            if new_raw in used:
-                continue
-            safe = safe_paths[new_raw]
-            if safe.data == old:
-                pairs[lookup] = new_raw
-                used.add(new_raw)
-                break
+        deleted_members = [path for path in members if path in deleted_hashes]
+        added_members = [path for path in members if path in added_hashes]
+        if len(deleted_members) == 1 and len(added_members) == 1:
+            if added_members[0] not in used:
+                pairs[deleted_members[0]] = added_members[0]
+                used.add(added_members[0])
+        _remaining(deadline)
     if not pairs:
         return rows
     result: list[tuple[str, bytes | None, bytes]] = []
@@ -367,6 +461,9 @@ def _patch_section_paths(patch: bytes) -> dict[bytes, bytes]:
     Returns ``{destination_raw: section_without_trailing_newline}`` so the
     zero-write backend can drop delete sections consumed by renames and
     merge synthetic untracked sections in git's destination-path order.
+    Git never quotes spaces, so unquoted headers are split on the literal
+    `` b/`` separator (git's own parsing convention); quoted tokens are
+    C-unquoted with their ``a/`` prefix inside the quotes.
     """
     sections: dict[bytes, bytes] = {}
     for token in patch.split(b"\ndiff --git "):
@@ -378,34 +475,75 @@ def _patch_section_paths(patch: bytes) -> dict[bytes, bytes]:
             if first_line.startswith(b"diff --git ")
             else b"diff --git " + first_line
         )
-        body = body[len(b"diff --git ") :]
-        if body.startswith(b'"'):
-            end = body.find(b'"', 1)
-            if end < 0:
+        rest = body[len(b"diff --git ") :]
+        if rest.startswith(b'"'):
+            end = _quoted_token_end(rest, 1)
+            first = rest[1 : end - 1]
+            second_start = end
+            if second_start >= len(rest) or rest[second_start] != 0x20:
                 raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR")
-            first = body[1:end]
+            second = rest[second_start + 1 :]
+            if not second.startswith(b'"'):
+                raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR")
+            second = second[1 : _quoted_token_end(second, 1) - 1]
+            if not second.startswith(b"b/"):
+                raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR")
+            first = _git_unquote(first)
         else:
-            first = body.split(b" ", 1)[0]
+            marker = rest.find(b" b/")
+            if marker < 0:
+                raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR")
+            first = rest[:marker]
         if not first.startswith(b"a/"):
             raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR")
-        destination = first[2:]
+        destination = _git_unquote(first[2:])
         sections.setdefault(destination, _strip_one_newline(token))
     return sections
 
 
-def _synthesize_rename_section(old_raw: bytes, new_raw: bytes) -> bytes:
-    """Byte-identical 100%-rename section header body."""
-    return (
-        b"diff --git a/"
-        + _git_quote_path(old_raw)
-        + b" b/"
-        + _git_quote_path(new_raw)
-        + b"\nsimilarity index 100%\nrename from "
+def _rewrite_new_file_mode(section: bytes, mode: bytes) -> bytes:
+    """Align a synthetic new-file section's mode line with the record mode."""
+    marker = b"new file mode "
+    index = section.find(marker)
+    if index < 0:
+        return section
+    end = section.find(b"\n", index)
+    if end < 0:
+        return section
+    replacement = marker + mode
+    if section[index:end] == replacement:
+        return section
+    return section[:index] + replacement + section[end:]
+
+
+def _synthesize_rename_section(
+    old_raw: bytes,
+    new_raw: bytes,
+    old_mode: bytes | None = None,
+    new_mode: bytes | None = None,
+) -> bytes:
+    """Byte-identical 100%-rename section header body.
+
+    Git emits the mode-change lines before the similarity/rename lines,
+    and quotes each ``a/``/``b/``-prefixed header token as one unit.
+    """
+    header = (
+        b"diff --git "
+        + _git_quote_path(b"a/" + old_raw)
+        + b" "
+        + _git_quote_path(b"b/" + new_raw)
+    )
+    body = bytearray(header)
+    if old_mode is not None and new_mode is not None and old_mode != new_mode:
+        body.extend(b"\nold mode " + old_mode + b"\nnew mode " + new_mode)
+    body.extend(
+        b"\nsimilarity index 100%\nrename from "
         + _git_quote_path(old_raw)
         + b"\nrename to "
         + _git_quote_path(new_raw)
         + b"\n"
     )
+    return bytes(body)
 
 
 def capture_payload_readonly(
@@ -527,6 +665,31 @@ def capture_payload_readonly(
             for raw in safe_paths
             if (data := safe_paths[raw].data) is not None and _is_binary(data)
         )
+        # Untracked binary classification honors the effective ``diff``
+        # attribute (``binary``/``-diff`` mark a path binary even without a
+        # NUL byte), matching numstat's semantics for tracked rows.
+        untracked_attr_paths = sorted(
+            raw
+            for raw in safe_paths
+            if raw not in index_entries and safe_paths[raw].kind in ("file", "symlink")
+        )
+        if untracked_attr_paths:
+            attr_input = b"".join(raw + b"\0" for raw in untracked_attr_paths)
+            diff_attrs = _live_index_output(
+                root,
+                b"",
+                ["check-attr", "-z", "diff", "--stdin"],
+                deadline=deadline,
+                limit=16 * 1024 * 1024,
+                input_=attr_input,
+            )
+            diff_tokens = [t for t in diff_attrs.split(b"\0") if t]
+            if len(diff_tokens) % 3 != 0:
+                raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR")
+            for index in range(0, len(diff_tokens), 3):
+                token_path, attr, value = diff_tokens[index : index + 3]
+                if attr == b"diff" and value == b"unset":
+                    binaries.add(token_path)
         tracked_patch = _live_index_output(
             root,
             b"",
@@ -559,12 +722,29 @@ def capture_payload_readonly(
         synthetic: dict[bytes, bytes] = {}
         for status, old_raw, raw in rows:
             if status == "R":
-                synthetic[raw] = _synthesize_rename_section(old_raw or raw, raw)
+                lookup = old_raw or raw
+                old_mode = _entry_parts(index_entries.get(lookup))[0]
+                new_mode = _entry_parts(workspace_entries.get(raw))[0]
+                synthetic[raw] = _synthesize_rename_section(
+                    lookup,
+                    raw,
+                    old_mode.encode("ascii") if old_mode is not None else None,
+                    new_mode.encode("ascii") if new_mode is not None else None,
+                )
             elif status == "A" and raw in safe_paths and raw not in sections:
-                synthetic[raw] = _no_index_new_file_patch(
+                new_file = _no_index_new_file_patch(
                     root, raw, deadline, min(64 * 1024 * 1024, remaining)
                 )
-                remaining -= len(synthetic[raw])
+                # ``git diff --no-index`` reads the filesystem mode, but the
+                # published record carries the epoch-derived mode
+                # (core.filemode=false normalizes to 100644); align the
+                # header so the snapshot cannot contradict itself.
+                workspace_mode = workspace_entries.get(raw)
+                if workspace_mode is not None:
+                    derived = workspace_mode.split(b" ", 1)[0]
+                    new_file = _rewrite_new_file_mode(new_file, derived)
+                synthetic[raw] = new_file
+                remaining -= len(new_file)
         assembled: list[bytes] = []
         for raw in sorted(set(sections) | set(synthetic)):
             section = synthetic.get(raw, sections.get(raw))

--- a/tree_sitter_analyzer/diff_snapshot_readonly_capture.py
+++ b/tree_sitter_analyzer/diff_snapshot_readonly_capture.py
@@ -1,0 +1,703 @@
+"""RFC-0022 P0.4 zero-write diff payload materialization (Phase A groundwork).
+
+The frozen capture (``diff_snapshot_capture._capture_payload``) reproduces
+the complete P0.2 patch, status, blob, config, attribute, ordering and
+source-generation semantics through a temporary index/object store (P0.2
+allows this). This module reproduces the same payload **in memory** with
+zero filesystem writes: every git command runs read-only against the live
+index with ``GIT_OPTIONAL_LOCKS=0`` (``git_readonly``), worktree content is
+read through the same descriptor-verified ``safe_workspace_path`` reader as
+the frozen capture, and the only sections git cannot emit itself (new-file
+patches for untracked paths) are produced with the byte-identical
+``git diff --no-index`` format (RFC-0022 P0.4).
+
+Equivalence contract (proved by the differential golden suite in
+``tests/unit/test_diff_snapshot_readonly_capture.py``):
+
+- ``mode="staged"`` payloads are byte-identical: git compares the live
+  index (oracle-validated against the captured epoch) with HEAD using the
+  exact frozen argument set.
+- ``mode="diff"`` tracked rows, binary flags, patch sections, ordering and
+  blob bytes are byte-identical to the frozen payload on conversion-free
+  repositories. Worktree renames with unchanged content are detected as
+  exact (R100) renames; renames with modified content surface as explicit
+  delete+add pairs (the frozen backend reports an inexact R — a documented
+  divergence, see ``_pair_exact_renames``).
+- Repositories whose checkin conversion (``core.autocrlf``, ``eol`` or
+  ``working-tree-encoding`` attributes) would change any materialized
+  worktree byte fail closed with ``DIFF_SNAPSHOT_UNSUPPORTED_CONVERSION``:
+  the raw worktree bytes are only publishable when they equal the frozen
+  backend's cleaned bytes.
+"""
+
+from __future__ import annotations
+
+import os
+
+from .diff_snapshot_capture import (
+    ChangedFile,
+    FrozenFile,
+    _entry_parts,
+    _row_sort_key,
+    _safe_mode,
+)
+from .diff_snapshot_readonly import (
+    _git_output_readonly,
+    _head_entries_readonly,
+    _live_index_output,
+)
+from .git_path_codec import raw_to_path
+from .source_oracle import (
+    SafePath,
+    SourceOracleError,
+    WorkspaceManifestEntry,
+    safe_workspace_path,
+)
+from .source_oracle_git import GitEpoch
+
+_MAX_BINARY_PROBE = 8000
+_EMPTY_OID = b"0" * 40
+
+
+def _blob_readonly(
+    root: str, oid: str | None, kind: str, deadline: float, limit: int
+) -> bytes | None:
+    """Read one blob through the zero-write runner (gitlinks have no blob)."""
+    if oid is None or kind == "gitlink":
+        return None
+    return _git_output_readonly(
+        root, ["cat-file", "blob", oid], deadline=deadline, limit=limit
+    )
+
+
+def _is_binary(data: bytes) -> bool:
+    """Git's ``buffer_is_binary``: NUL within the first 8000 bytes."""
+    return b"\0" in data[:_MAX_BINARY_PROBE]
+
+
+def _readonly_rows(
+    root: str, mode: str, head: bytes, deadline: float, limit: int
+) -> list[tuple[str, bytes | None, bytes]]:
+    """Live zero-write name-status rows for tracked index/worktree changes."""
+    args = (["diff", "--cached"] if mode == "staged" else ["diff"]) + [
+        "--name-status",
+        "-z",
+        "--find-renames",
+        "--no-color",
+        "--no-ext-diff",
+        "--no-textconv",
+        "--ignore-submodules=none",
+    ]
+    if mode == "staged":
+        args.append(os.fsdecode(head))
+    raw = _live_index_output(root, b"", args, deadline=deadline, limit=limit)
+    tokens = [item for item in raw.split(b"\0") if item]
+    rows: list[tuple[str, bytes | None, bytes]] = []
+    index = 0
+    while index < len(tokens):
+        status = tokens[index][:1].decode("ascii", "strict")
+        index += 1
+        try:
+            if status in ("R", "C"):
+                old, path = tokens[index], tokens[index + 1]
+                index += 2
+            else:
+                old, path = None, tokens[index]
+                index += 1
+            raw_to_path(path)
+            if old is not None:
+                raw_to_path(old)
+        except (IndexError, UnicodeError, ValueError) as exc:
+            raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR") from exc
+        rows.append(("R" if status in ("R", "C") else status, old, path))
+    return rows
+
+
+def _readonly_binaries(
+    root: str, mode: str, head: bytes, deadline: float, limit: int
+) -> set[bytes]:
+    """Live zero-write numstat binary-path set (tracked rows only)."""
+    args = (["diff", "--cached"] if mode == "staged" else ["diff"]) + [
+        "--numstat",
+        "-z",
+        "--find-renames",
+        "--no-color",
+        "--no-ext-diff",
+        "--no-textconv",
+        "--ignore-submodules=none",
+    ]
+    if mode == "staged":
+        args.append(os.fsdecode(head))
+    raw = _live_index_output(root, b"", args, deadline=deadline, limit=limit)
+    tokens = raw.split(b"\0")
+    result: set[bytes] = set()
+    index = 0
+    while index < len(tokens):
+        row = tokens[index]
+        index += 1
+        if not row:
+            continue
+        fields = row.split(b"\t", 2)
+        if len(fields) != 3:
+            raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR")
+        path = fields[2]
+        if not path:
+            try:
+                old, path = tokens[index], tokens[index + 1]
+            except IndexError as exc:
+                raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR") from exc
+            index += 2
+            if not old or not path:
+                raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR")
+        if fields[0] == fields[1] == b"-":
+            result.add(path)
+    return result
+
+
+def _git_quote_path(raw: bytes) -> bytes:
+    """Quote one path for a synthetic diff header (git ``quote_c_style``)."""
+    needs = any(value < 0x20 or value > 0x7E or value in (0x22, 0x5C) for value in raw)
+    if not needs:
+        return raw
+    out = bytearray(b'"')
+    shorthand = {
+        0x07: b"\\a",
+        0x08: b"\\b",
+        0x0C: b"\\f",
+        0x0A: b"\\n",
+        0x0D: b"\\r",
+        0x09: b"\\t",
+        0x0B: b"\\v",
+        0x5C: b"\\\\",
+        0x22: b'\\"',
+    }
+    for value in raw:
+        if value in shorthand:
+            out.extend(shorthand[value])
+        elif value < 0x20 or value > 0x7E:
+            out.extend(f"\\{value:03o}".encode("ascii"))
+        else:
+            out.append(value)
+    out.append(0x22)
+    return bytes(out)
+
+
+def _no_index_new_file_patch(
+    root: str, raw: bytes, deadline: float, limit: int
+) -> bytes:
+    """Emit the byte-identical new-file patch git itself would produce.
+
+    ``git diff --no-index /dev/null <path>`` renders the exact new-file
+    section format used by ``diff --cached`` against a base tree (mode,
+    full index line, ``/dev/null`` old side, text hunks or ``GIT binary
+    patch`` literal), and exits 1 whenever the paths differ — the exit
+    code is the result, so the runner accepts it explicitly.
+    """
+    return _live_index_output(
+        root,
+        b"",
+        [
+            "diff",
+            "--no-index",
+            "--binary",
+            "--full-index",
+            "--src-prefix=a/",
+            "--dst-prefix=b/",
+            "--no-color",
+            "--no-ext-diff",
+            "--no-textconv",
+            "--",
+            "/dev/null",
+            os.fsdecode(raw),
+        ],
+        deadline=deadline,
+        limit=limit,
+        ok_returncodes=frozenset({0, 1}),
+    )
+
+
+def _reject_worktree_conversion(
+    root: str,
+    safe_paths: dict[bytes, SafePath],
+    deadline: float,
+) -> None:
+    """Fail closed when any materialized worktree byte would be cleaned.
+
+    The frozen backend hashes dirty/untracked leaves with
+    ``hash-object --path``, so its published ``new_bytes`` are the
+    *cleaned* bytes (autocrlf/eol/encoding conversions applied). The
+    zero-write backend publishes raw worktree bytes; those are equal only
+    when no checkin conversion applies. Conversions can only alter a
+    non-binary file that already contains CRLF, so the guard is: any such
+    file plus an active conversion configuration (``core.autocrlf``,
+    ``eol`` attribute, or ``working-tree-encoding`` attribute) fails the
+    route closed with a stable code.
+    """
+    candidates = sorted(
+        (raw, safe)
+        for raw, safe in safe_paths.items()
+        if safe.kind in ("file", "symlink")
+        and safe.data is not None
+        and not _is_binary(safe.data)
+        and b"\r\n" in safe.data
+    )
+    if not candidates:
+        return
+    config_list = _git_output_readonly(
+        root,
+        ["config", "--null", "--list", "--includes"],
+        deadline=deadline,
+        limit=16 * 1024 * 1024,
+    )
+    settings: dict[bytes, bytes] = {}
+    for record in config_list.split(b"\0"):
+        if not record:
+            continue
+        key, _, value = record.partition(b"\n")
+        settings[key.lower()] = value.strip()
+    if settings.get(b"core.autocrlf", b"false").lower() in (b"true", b"input"):
+        raise SourceOracleError("DIFF_SNAPSHOT_UNSUPPORTED_CONVERSION")
+    attr_input = b"".join(raw + b"\0" for raw, _safe in candidates)
+    attributes = _live_index_output(
+        root,
+        b"",
+        ["check-attr", "-z", "eol", "working-tree-encoding", "--stdin"],
+        deadline=deadline,
+        limit=16 * 1024 * 1024,
+        input_=attr_input,
+    )
+    tokens = [token for token in attributes.split(b"\0") if token]
+    if len(tokens) % 3 != 0:
+        raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR")
+    for index in range(0, len(tokens), 3):
+        _path, attr, value = tokens[index : index + 3]
+        if attr == b"eol" and value in (b"crlf", b"lf"):
+            raise SourceOracleError("DIFF_SNAPSHOT_UNSUPPORTED_CONVERSION")
+        if attr == b"working-tree-encoding" and value not in (
+            b"unspecified",
+            b"unset",
+        ):
+            raise SourceOracleError("DIFF_SNAPSHOT_UNSUPPORTED_CONVERSION")
+
+
+def _workspace_mode(
+    epoch: GitEpoch, safe: SafePath, existing_mode: bytes | None
+) -> bytes:
+    """Replicate ``FrozenGitEnvironment.apply_workspace`` mode computation."""
+    emulated_symlink = (
+        not epoch.core_symlinks and safe.kind == "file" and existing_mode == b"120000"
+    )
+    if safe.kind == "symlink" or emulated_symlink:
+        return b"120000"
+    if not epoch.core_filemode:
+        mode = existing_mode or b"100644"
+        return mode if mode in (b"100644", b"100755") else b"100644"
+    try:
+        bits = int(safe.metadata[-1].split(b",")[2])
+    except (IndexError, ValueError) as exc:
+        raise SourceOracleError("DIFF_SNAPSHOT_UNSAFE_PATH") from exc
+    return b"100755" if bits & 0o111 else b"100644"
+
+
+def _pair_exact_renames(
+    root: str,
+    rows: list[tuple[str, bytes | None, bytes]],
+    index_entries: dict[bytes, bytes],
+    safe_paths: dict[bytes, SafePath],
+    deadline: float,
+    limit: int,
+) -> list[tuple[str, bytes | None, bytes]]:
+    """Pair delete+untracked rows with identical content into R100 renames.
+
+    The live ``git diff`` queue never contains untracked paths, so git
+    cannot detect worktree renames for it; the frozen backend's temporary
+    index does contain them and reports content-identical moves as
+    ``R100``. This replicates the exact-rename half with a deterministic
+    greedy pairing; content-modified moves stay delete+add pairs (a
+    documented divergence from the frozen inexact ``R``).
+    """
+    deleted = [
+        row for row in rows if row[0] == "D" and (row[1] or row[2]) in index_entries
+    ]
+    added = [row for row in rows if row[0] == "A" and row[2] in safe_paths]
+    if not deleted or not added:
+        return rows
+    added_paths = {row[2] for row in added}
+    pairs: dict[bytes, bytes] = {}
+    used: set[bytes] = set()
+    for _status, old_raw, raw in deleted:
+        lookup = old_raw or raw
+        mode, oid, kind = _entry_parts(index_entries[lookup])
+        old = _blob_readonly(root, oid, kind, deadline, limit)
+        if old is None:
+            continue
+        for _new_status, _new_old, new_raw in added:
+            if new_raw in used:
+                continue
+            safe = safe_paths[new_raw]
+            if safe.data == old:
+                pairs[lookup] = new_raw
+                used.add(new_raw)
+                break
+    if not pairs:
+        return rows
+    result: list[tuple[str, bytes | None, bytes]] = []
+    for row in rows:
+        if row[0] == "D" and (row[1] or row[2]) in pairs:
+            continue
+        if row[0] == "A" and row[2] in added_paths:
+            continue
+        result.append(row)
+    for old_path, new_raw in sorted(pairs.items()):
+        result.append(("R", old_path, new_raw))
+    for status, _old_raw, raw in added:
+        if raw not in used:
+            result.append((status, None, raw))
+    return result
+
+
+def _strip_one_newline(section: bytes) -> bytes:
+    """Normalize one section boundary (git diff ends every line with LF)."""
+    return section[:-1] if section.endswith(b"\n") else section
+
+
+def _patch_section_paths(patch: bytes) -> dict[bytes, bytes]:
+    """Split one git diff stream into per-destination-path sections.
+
+    Returns ``{destination_raw: section_without_trailing_newline}`` so the
+    zero-write backend can drop delete sections consumed by renames and
+    merge synthetic untracked sections in git's destination-path order.
+    """
+    sections: dict[bytes, bytes] = {}
+    for token in patch.split(b"\ndiff --git "):
+        if not token:
+            continue
+        first_line = token.split(b"\n", 1)[0]
+        body = (
+            first_line
+            if first_line.startswith(b"diff --git ")
+            else b"diff --git " + first_line
+        )
+        body = body[len(b"diff --git ") :]
+        if body.startswith(b'"'):
+            end = body.find(b'"', 1)
+            if end < 0:
+                raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR")
+            first = body[1:end]
+        else:
+            first = body.split(b" ", 1)[0]
+        if not first.startswith(b"a/"):
+            raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR")
+        destination = first[2:]
+        sections.setdefault(destination, _strip_one_newline(token))
+    return sections
+
+
+def _synthesize_rename_section(old_raw: bytes, new_raw: bytes) -> bytes:
+    """Byte-identical 100%-rename section header body."""
+    return (
+        b"diff --git a/"
+        + _git_quote_path(old_raw)
+        + b" b/"
+        + _git_quote_path(new_raw)
+        + b"\nsimilarity index 100%\nrename from "
+        + _git_quote_path(old_raw)
+        + b"\nrename to "
+        + _git_quote_path(new_raw)
+        + b"\n"
+    )
+
+
+def capture_payload_readonly(
+    root: str,
+    mode: str,
+    deadline: float,
+    ceiling: int,
+    expected_manifest: dict[str, WorkspaceManifestEntry] | None = None,
+    epoch: GitEpoch | None = None,
+) -> tuple[bytes, tuple[FrozenFile, ...]]:
+    """Capture the frozen payload shape with zero filesystem writes.
+
+    Mirrors ``diff_snapshot_capture._capture_payload`` record-for-record:
+    same changed-file rows (status/old-path/kind/mode/oid/availability/
+    binary/unsupported), same normalized patch, same old/new bytes — all
+    from read-only git invocations against the live index and
+    descriptor-verified worktree reads.
+    """
+    if epoch is None:
+        raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR")
+    remaining = ceiling
+    index_entries = epoch.index_map()
+    head_entries = (
+        _head_entries_readonly(root, deadline=deadline, head=epoch.head)
+        if mode == "staged"
+        else {}
+    )
+    safe_paths: dict[bytes, SafePath] = {}
+    workspace_entries: dict[bytes, bytes] = {}
+    dirty_gitlinks = set(dict(epoch.workspace_gitlinks)) & set(epoch.dirty_paths)
+    if mode == "diff":
+        raw_paths = set(epoch.dirty_paths) | set(epoch.untracked_paths)
+        gitlink_entries = dict(epoch.workspace_gitlinks)
+        for raw in sorted(raw_paths):
+            path = raw_to_path(raw)
+            manifest_entry = (expected_manifest or {}).get(path)
+            if manifest_entry is None:
+                raise SourceOracleError("DIFF_SNAPSHOT_SOURCE_CHANGED")
+            if raw in gitlink_entries:
+                safe = SafePath(None, (), "directory")
+            else:
+                safe = safe_workspace_path(
+                    root,
+                    path,
+                    deadline=deadline,
+                    limit=remaining,
+                    expected_chain=manifest_entry.descriptor_chain,
+                    # Regular tracked leaves may have been replaced by dirs.
+                    allow_directory=True,
+                )
+            if safe.data is not None:
+                remaining -= len(safe.data)
+            if safe.kind == "file":
+                raw_changed = manifest_entry.raw_bytes != safe.data
+                if raw_changed:  # pragma: no cover - descriptor fails first
+                    raise SourceOracleError("DIFF_SNAPSHOT_SOURCE_CHANGED")
+                safe = SafePath(
+                    manifest_entry.raw_bytes,
+                    safe.metadata,
+                    safe.kind,
+                )
+            safe_paths[raw] = safe
+        _reject_worktree_conversion(root, safe_paths, deadline)
+        for raw, safe in sorted(safe_paths.items()):
+            existing = index_entries.get(raw)
+            existing_mode = existing.split(b" ", 1)[0] if existing is not None else None
+            if safe.kind == "missing":
+                continue
+            if safe.kind == "directory":
+                entry = dict(epoch.workspace_gitlinks).get(raw)
+                if entry is not None:
+                    if not entry.startswith(b"160000 "):
+                        raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR")
+                    workspace_entries[raw] = entry
+                continue
+            if safe.kind not in ("file", "symlink") or safe.data is None:
+                raise SourceOracleError("DIFF_SNAPSHOT_SPECIAL_FILE")
+            workspace_entries[raw] = (
+                _workspace_mode(epoch, safe, existing_mode) + b" " + _EMPTY_OID + b" 0"
+            )
+        row_limit = min(8 * 1024 * 1024, remaining)
+        rows = _readonly_rows(root, mode, epoch.head, deadline, row_limit)
+        untracked_raw = _live_index_output(
+            root,
+            b"",
+            ["ls-files", "--others", "--exclude-standard", "-z"],
+            deadline=deadline,
+            limit=row_limit,
+        )
+        remaining -= len(untracked_raw)
+        known = {row[2] for row in rows}
+        for item in untracked_raw.split(b"\0"):
+            if item:
+                raw_to_path(item)
+                if item not in known:
+                    rows.append(("A", None, item))
+        # The live diff reports dirty gitlinks (submodule state), but the
+        # frozen backend emits them only through its own workspace-gitlink
+        # rows appended below; dedupe the live copies and drop their patch
+        # sections so the record/patch surface matches exactly.
+        dropped_gitlinks: set[bytes] = set()
+        filtered_rows: list[tuple[str, bytes | None, bytes]] = []
+        for row in rows:
+            if (
+                row[0] == "M"
+                and row[2] in index_entries
+                and index_entries[row[2]].startswith(b"160000 ")
+            ):
+                dropped_gitlinks.add(row[2])
+                continue
+            filtered_rows.append(row)
+        rows = filtered_rows
+        rows = _pair_exact_renames(
+            root, rows, index_entries, safe_paths, deadline, row_limit
+        )
+        binaries = _readonly_binaries(root, mode, epoch.head, deadline, row_limit)
+        binaries.update(
+            raw
+            for raw in safe_paths
+            if (data := safe_paths[raw].data) is not None and _is_binary(data)
+        )
+        tracked_patch = _live_index_output(
+            root,
+            b"",
+            [
+                "diff",
+                "--binary",
+                "--full-index",
+                "--src-prefix=a/",
+                "--dst-prefix=b/",
+                "--find-renames",
+                "--no-color",
+                "--no-ext-diff",
+                "--no-textconv",
+                "--submodule=short",
+                "--ignore-submodules=none",
+            ],
+            deadline=deadline,
+            limit=min(64 * 1024 * 1024, remaining),
+        )
+        remaining -= len(tracked_patch)
+        sections = _patch_section_paths(tracked_patch)
+        # Delete sections consumed by exact renames must not survive: the
+        # frozen backend emits only the 100%-rename section for the pair.
+        for status, old_raw, _raw in rows:
+            if status == "R":
+                sections.pop(old_raw or b"", None)
+        # Dirty-gitlink sections belong to the appended rows, not the patch.
+        for raw in sorted(dropped_gitlinks):
+            sections.pop(raw, None)
+        synthetic: dict[bytes, bytes] = {}
+        for status, old_raw, raw in rows:
+            if status == "R":
+                synthetic[raw] = _synthesize_rename_section(old_raw or raw, raw)
+            elif status == "A" and raw in safe_paths and raw not in sections:
+                synthetic[raw] = _no_index_new_file_patch(
+                    root, raw, deadline, min(64 * 1024 * 1024, remaining)
+                )
+                remaining -= len(synthetic[raw])
+        assembled: list[bytes] = []
+        for raw in sorted(set(sections) | set(synthetic)):
+            section = synthetic.get(raw, sections.get(raw))
+            if section is None:  # pragma: no cover - key sets are equal
+                raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR")
+            section = _strip_one_newline(section)
+            assembled.append(
+                section
+                if section.startswith(b"diff --git ")
+                else b"diff --git " + section
+            )
+        patch = b"\n".join(assembled)
+        if patch:
+            patch += b"\n"
+        remaining -= len(patch)
+        patch_row_paths = {row[2] for row in rows}
+        for raw in sorted(dict(epoch.workspace_gitlinks)):
+            rows.append(("M", None, raw))
+    else:
+        row_limit = min(8 * 1024 * 1024, remaining)
+        rows = _readonly_rows(root, mode, epoch.head, deadline, row_limit)
+        binaries = _readonly_binaries(root, mode, epoch.head, deadline, row_limit)
+        patch = _live_index_output(
+            root,
+            b"",
+            [
+                "diff",
+                "--cached",
+                "--binary",
+                "--full-index",
+                "--src-prefix=a/",
+                "--dst-prefix=b/",
+                "--find-renames",
+                "--no-color",
+                "--no-ext-diff",
+                "--no-textconv",
+                "--submodule=short",
+                "--ignore-submodules=none",
+                os.fsdecode(epoch.head),
+            ],
+            deadline=deadline,
+            limit=min(64 * 1024 * 1024, remaining),
+        )
+        remaining -= len(patch)
+        patch_row_paths = {row[2] for row in rows}
+    rows.sort(key=_row_sort_key)
+    final_entries = dict(index_entries)
+    if mode == "diff":
+        for raw, safe in safe_paths.items():
+            if safe.kind in ("missing", "directory") and not (
+                safe.kind == "directory" and raw in workspace_entries
+            ):
+                final_entries.pop(raw, None)
+            else:
+                final_entries[raw] = workspace_entries[raw]
+    files: list[FrozenFile] = []
+    for status, old_raw, raw in rows:
+        lookup = old_raw or raw
+        old_entry = (
+            index_entries.get(lookup) if mode == "diff" else head_entries.get(lookup)
+        )
+        new_entry = final_entries.get(raw)
+        old_mode, old_oid, old_kind = _entry_parts(old_entry)
+        new_mode, new_oid, new_kind = _entry_parts(new_entry)
+        if status == "A":
+            # Includes intent-to-add: an added record has no coherent old
+            # identity even when the index contains a placeholder.
+            old_mode, old_oid, old_kind = None, None, "missing"
+        old = (
+            _blob_readonly(root, old_oid, old_kind, deadline, remaining)
+            if status != "A"
+            else None
+        )
+        remaining -= len(old or b"")
+        new = (
+            _blob_readonly(root, new_oid, new_kind, deadline, remaining)
+            if status != "D" and not (mode == "diff" and raw in safe_paths)
+            else None
+        )
+        remaining -= len(new or b"")
+        if mode == "diff" and raw in safe_paths:
+            safe = safe_paths[raw]
+            if safe.kind == "directory" and raw not in workspace_entries:
+                new_mode, new_kind, new_oid, new = None, "missing", None, None
+            else:
+                workspace_entry = workspace_entries.get(raw)
+                emulated_symlink = (
+                    safe.kind == "file"
+                    and not epoch.core_symlinks
+                    and workspace_entry is not None
+                    and workspace_entry.startswith(b"120000 ")
+                )
+                if (
+                    safe.kind == "file"
+                    and workspace_entry is not None
+                    and (not epoch.core_filemode or emulated_symlink)
+                ):
+                    new_mode, _temporary_oid, new_kind = _entry_parts(workspace_entry)
+                else:
+                    new_mode, new_kind = _safe_mode(safe.kind, safe.metadata)
+                if raw not in dirty_gitlinks:
+                    new_oid = None
+                if safe.kind == "missing":
+                    new = None
+                elif safe.kind in ("file", "symlink") and safe.data is not None:
+                    # The conversion guard above proves raw == cleaned.
+                    new = safe.data
+                    remaining -= len(new)
+        path = raw_to_path(raw)
+        old_path = raw_to_path(old_raw) if old_raw is not None else None
+        unsupported = "dirty_gitlink" if raw in dirty_gitlinks else None
+        files.append(
+            FrozenFile(
+                ChangedFile(
+                    path=path,
+                    status=status,
+                    old_available=old is not None or old_kind == "gitlink",
+                    new_available=new is not None or new_kind == "gitlink",
+                    binary=raw in binaries,
+                    old_path=old_path,
+                    patch_available=unsupported is None and raw in patch_row_paths,
+                    old_kind=old_kind,
+                    new_kind=new_kind,
+                    old_mode=old_mode,
+                    new_mode=new_mode,
+                    old_oid=old_oid,
+                    new_oid=new_oid,
+                    unsupported_kind=unsupported,
+                    _raw_path=raw,
+                    _raw_old_path=old_raw,
+                ),
+                old,
+                new,
+            )
+        )
+    return patch, tuple(files)

--- a/tree_sitter_analyzer/diff_snapshot_registry.py
+++ b/tree_sitter_analyzer/diff_snapshot_registry.py
@@ -485,7 +485,9 @@ class DiffSnapshotRegistry:
         *,
         deadline: float | None = None,
     ) -> str | None:
-        snapshot = consumer.snapshot
+        # ``_snapshot`` (not the raising property) so a released consumer
+        # still classifies through the registry state checks below.
+        snapshot = consumer._snapshot
         readonly = bool(snapshot is not None and snapshot.readonly)
         oracle = oracle_generation_readonly if readonly else oracle_generation
         shared = (

--- a/tree_sitter_analyzer/diff_snapshot_registry.py
+++ b/tree_sitter_analyzer/diff_snapshot_registry.py
@@ -17,9 +17,14 @@ from typing import cast
 from .diff_snapshot_capture import _capture_payload
 from .diff_snapshot_constraints import (
     frozen_index_constraint_config,
+    frozen_index_sources_match_worktree,
     live_constraint_config,
     staged_sources_match_worktree,
     staged_constraint_config,
+)
+from .diff_snapshot_constraints_readonly import (
+    frozen_index_constraint_config_readonly,
+    frozen_index_sources_match_worktree_readonly,
 )
 from .diff_snapshot_expiry import SnapshotExpiryScheduler, schedule_expiry
 from .diff_snapshot_leases import (
@@ -28,6 +33,8 @@ from .diff_snapshot_leases import (
     route_lease,
     snapshot_error,
 )
+from .diff_snapshot_readonly import oracle_generation_readonly
+from .diff_snapshot_readonly_capture import capture_payload_readonly
 from .diff_snapshot_validation import (
     acquire as acquire_snapshot,
     bind_assessed_scope as bind_snapshot_scope,
@@ -125,8 +132,20 @@ class DiffSnapshotRegistry:
     def _route_lease(self, snapshot_id: str) -> str:
         return route_lease(self._lease_key, snapshot_id)
     def create(
-        self, project_root: str | None, mode: str, assessed_scope_paths: list[str]
+        self,
+        project_root: str | None,
+        mode: str,
+        assessed_scope_paths: list[str],
+        *,
+        readonly: bool = False,
     ) -> dict[str, object]:
+        """Publish one bounded in-memory diff snapshot.
+
+        ``readonly=True`` selects the RFC-0022 P0.4 zero-write backend
+        (``oracle_generation_readonly`` + ``capture_payload_readonly`` +
+        read-only staged probes); the published snapshot shape is
+        identical to the frozen backend's.
+        """
         if mode not in ("diff", "staged"):
             return snapshot_error("DIFF_SNAPSHOT_UNSUPPORTED_MODE")
         try:
@@ -160,7 +179,9 @@ class DiffSnapshotRegistry:
             shared_before = shared_source_generation(root, deadline)
             pre_manifest: dict[str, WorkspaceManifestEntry] = {}
             epochs: list[GitEpoch] = []
-            oracle_call: Callable[..., tuple[str, RootIdentity]] = oracle_generation
+            oracle_call: Callable[..., tuple[str, RootIdentity]] = (
+                oracle_generation_readonly if readonly else oracle_generation
+            )
             oracle_params = inspect.signature(oracle_call).parameters
             oracle_budget = (
                 {"byte_ceiling": ceiling} if "byte_ceiling" in oracle_params else {}
@@ -196,7 +217,16 @@ class DiffSnapshotRegistry:
             )
             inventory_size = path_collection_storage(inventory_paths)
             capture_params = inspect.signature(_capture_payload).parameters
-            if "epoch" in capture_params and epoch is not None:
+            if readonly:
+                patch, files = capture_payload_readonly(
+                    root,
+                    mode,
+                    deadline,
+                    ceiling - inventory_size,
+                    expected_manifest=pre_manifest,
+                    epoch=epoch,
+                )
+            elif "epoch" in capture_params and epoch is not None:
                 patch, files = _capture_payload(
                     root,
                     mode,
@@ -251,6 +281,16 @@ class DiffSnapshotRegistry:
                 if epoch is None and "epoch_out" in oracle_params:
                     raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR")
                 staged_epoch = cast(GitEpoch, epoch)
+                staged_config_reader = (
+                    frozen_index_constraint_config_readonly
+                    if readonly
+                    else frozen_index_constraint_config
+                )
+                staged_match_reader = (
+                    frozen_index_sources_match_worktree_readonly
+                    if readonly
+                    else frozen_index_sources_match_worktree
+                )
                 (
                     constraint_config_path,
                     constraint_config_data,
@@ -261,13 +301,14 @@ class DiffSnapshotRegistry:
                     staged_epoch,
                     optional_deadline,
                     ceiling,
-                    frozen_index_constraint_config,
+                    staged_config_reader,
                 )
                 staged_source_matches_worktree = staged_sources_match_worktree(
                     root,
                     staged_epoch,
                     optional_deadline,
                     min(16 * 1024 * 1024, ceiling),
+                    staged_match_reader,
                 )
                 staged_config_matches_worktree = (
                     constraint_config_error is None

--- a/tree_sitter_analyzer/diff_snapshot_registry.py
+++ b/tree_sitter_analyzer/diff_snapshot_registry.py
@@ -78,6 +78,15 @@ def shared_source_generation(project_root: str, deadline: float) -> str:
     )
 
 
+def shared_source_generation_readonly(project_root: str, deadline: float) -> str:
+    """P0.4 variant: resolve the shared token through the zero-write oracle."""
+    return resolve_shared_source_generation(
+        project_root,
+        deadline,
+        oracle_generation=oracle_generation_readonly,
+    )
+
+
 @dataclass
 class _State:
     snapshot: FrozenDiffSnapshot
@@ -385,6 +394,7 @@ class DiffSnapshotRegistry:
                 constraint_config_error=constraint_config_error,
                 staged_source_matches_worktree=staged_source_matches_worktree,
                 staged_config_matches_worktree=staged_config_matches_worktree,
+                readonly=readonly,
                 _inventory_raw_paths=tuple(
                     sorted(path_to_raw(path) for path in inventory_paths)
                 ),
@@ -435,12 +445,21 @@ class DiffSnapshotRegistry:
         *,
         deadline: float | None = None,
     ) -> tuple[SnapshotConsumer | None, str | None]:
+        with self._lock:
+            state = self._states.get(snapshot_id)
+            readonly = bool(state is not None and state.snapshot.readonly)
+        oracle = oracle_generation_readonly if readonly else oracle_generation
+        shared = (
+            shared_source_generation_readonly
+            if readonly
+            else shared_source_generation
+        )
         return acquire_snapshot(
             self,
             snapshot_id,
             project_root,
-            oracle_generation=oracle_generation,
-            shared_source_generation=shared_source_generation,
+            oracle_generation=oracle,
+            shared_source_generation=shared,
             hard_lifetime_seconds=HARD_LIFETIME_SECONDS,
             canonicalize_root=canonical_root,
             deadline=deadline,
@@ -466,12 +485,20 @@ class DiffSnapshotRegistry:
         *,
         deadline: float | None = None,
     ) -> str | None:
+        snapshot = consumer.snapshot
+        readonly = bool(snapshot is not None and snapshot.readonly)
+        oracle = oracle_generation_readonly if readonly else oracle_generation
+        shared = (
+            shared_source_generation_readonly
+            if readonly
+            else shared_source_generation
+        )
         return validate_snapshot_publish(
             self,
             consumer,
             publish_guard,
-            oracle_generation=oracle_generation,
-            shared_source_generation=shared_source_generation,
+            oracle_generation=oracle,
+            shared_source_generation=shared,
             hard_lifetime_seconds=HARD_LIFETIME_SECONDS,
             deadline=deadline,
         )

--- a/tree_sitter_analyzer/diff_snapshot_registry.py
+++ b/tree_sitter_analyzer/diff_snapshot_registry.py
@@ -17,7 +17,6 @@ from typing import cast
 from .diff_snapshot_capture import _capture_payload
 from .diff_snapshot_constraints import (
     frozen_index_constraint_config,
-    frozen_index_sources_match_worktree,
     live_constraint_config,
     staged_sources_match_worktree,
     staged_constraint_config,
@@ -286,11 +285,6 @@ class DiffSnapshotRegistry:
                     if readonly
                     else frozen_index_constraint_config
                 )
-                staged_match_reader = (
-                    frozen_index_sources_match_worktree_readonly
-                    if readonly
-                    else frozen_index_sources_match_worktree
-                )
                 (
                     constraint_config_path,
                     constraint_config_data,
@@ -303,13 +297,25 @@ class DiffSnapshotRegistry:
                     ceiling,
                     staged_config_reader,
                 )
-                staged_source_matches_worktree = staged_sources_match_worktree(
-                    root,
-                    staged_epoch,
-                    optional_deadline,
-                    min(16 * 1024 * 1024, ceiling),
-                    staged_match_reader,
-                )
+                if readonly:
+                    # Explicit reader: the zero-write probe replaces the
+                    # frozen default (which materializes a temp index).
+                    staged_source_matches_worktree = staged_sources_match_worktree(
+                        root,
+                        staged_epoch,
+                        optional_deadline,
+                        min(16 * 1024 * 1024, ceiling),
+                        frozen_index_sources_match_worktree_readonly,
+                    )
+                else:
+                    # Legacy 4-argument call shape keeps the frozen default
+                    # reader and the existing test seam contract.
+                    staged_source_matches_worktree = staged_sources_match_worktree(
+                        root,
+                        staged_epoch,
+                        optional_deadline,
+                        min(16 * 1024 * 1024, ceiling),
+                    )
                 staged_config_matches_worktree = (
                     constraint_config_error is None
                     and live_config_error is None

--- a/tree_sitter_analyzer/git_readonly.py
+++ b/tree_sitter_analyzer/git_readonly.py
@@ -32,6 +32,7 @@ def run_git_readonly(
     limit: int,
     env: dict[str, str] | None = None,
     input_: bytes | None = None,
+    ok_returncodes: frozenset[int] = frozenset({0}),
 ) -> bytes:
     """Run Git with bounded pipes and ZERO filesystem writes.
 
@@ -40,6 +41,11 @@ def run_git_readonly(
     caller before any diff command runs). Every snapshot invariant is kept:
     ``GIT_OPTIONAL_LOCKS=0``, ``GIT_ATTR_NOSYSTEM=1``,
     ``GIT_NO_REPLACE_OBJECTS=1``, ``GIT_NO_LAZY_FETCH=1``, fsmonitor off.
+
+    ``ok_returncodes`` extends the accepted exit set. The read-existing
+    backend uses it only for ``git diff --no-index`` (RFC-0022 P0.4), which
+    returns 1 whenever the compared paths differ; the exit code is the
+    result, not a failure.
     """
     if limit < 0:
         raise SourceOracleError("DIFF_SNAPSHOT_CAPACITY")
@@ -129,7 +135,7 @@ def run_git_readonly(
             raise SourceOracleError("DIFF_SNAPSHOT_TIMEOUT") from exc
         if failures:
             raise SourceOracleError(failures[0])
-        if proc.returncode != 0:
+        if proc.returncode not in ok_returncodes:
             raise SourceOracleError("DIFF_SNAPSHOT_GIT_ERROR")
         succeeded = True
         return bytes(output)

--- a/tree_sitter_analyzer/mcp/tools/change_impact_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/change_impact_tool.py
@@ -11,6 +11,7 @@ from ...pr_url import (
     fetch_pr_diff_stat,
     parse_pr_url,
 )
+from ...source_oracle import SourceOracleError
 from ...wire_owner import EDIT_IMPACT_ACTION_VERSION
 from ..utils.format_helper import apply_toon_format_to_response
 from .base_tool import BaseMCPTool, mirror_summary_line
@@ -155,24 +156,45 @@ class ChangeImpactTool(BaseMCPTool):
         """Analyze git diff + dependency graph for change impact."""
         pr_url = arguments.get("pr_url", "") or ""
         mode = "pr" if pr_url else arguments.get("mode", "diff")
+        output_format = arguments.get("output_format", "toon")
+        compact_only = bool(arguments.get("compact_only", False))
+        if read_access.validate_read_existing_access(arguments):
+            # RFC-0022 P0.4: an unavailable adapter must still validate its
+            # complete action schema before returning classified success.
+            self.validate_arguments(arguments)
+            if not read_access.read_existing_platform_supported():
+                # An OS without the pinned native authority returns the
+                # stable unsupported result for read-existing mode.
+                unavailable = read_access.format_read_existing_unavailable(
+                    arguments,
+                    reason=read_access.DIFF_SNAPSHOT_READ_EXISTING_UNSUPPORTED,
+                    compact_only=compact_only,
+                    action_version=EDIT_IMPACT_ACTION_VERSION,
+                )
+                if unavailable is not None:
+                    return unavailable
+            return await self._execute_read_existing(
+                arguments,
+                mode=mode,
+                output_format=output_format,
+                compact_only=compact_only,
+            )
         unavailable = read_access.read_existing_gate(
             self,
             arguments,
             reason=read_access.DIFF_SNAPSHOT_READ_EXISTING_UNSUPPORTED,
-            compact_only=bool(arguments.get("compact_only", False)),
+            compact_only=compact_only,
             action_version=EDIT_IMPACT_ACTION_VERSION,
         )
         if unavailable is not None:
             return unavailable
         include_tests = arguments.get("include_tests", True)
-        output_format = arguments.get("output_format", "toon")
         scope_paths = arguments.get("scope_paths") or []
         scope_mode = arguments.get("scope_mode", "report")
         # MCP callers are always AI agents; default to low-impact so verification
         # commands don't stall the local machine. CLI uses its own default (#731).
         resource_profile = arguments.get("resource_profile", "local_low_impact")
         agent_summary_only = bool(arguments.get("agent_summary_only", False))
-        compact_only = bool(arguments.get("compact_only", False))
         capture_diff_snapshot = arguments.get("capture_diff_snapshot") is True
         frozen: dict[str, object] | None = None
         frozen_consumer: Any = None
@@ -343,6 +365,101 @@ class ChangeImpactTool(BaseMCPTool):
             result, output_format, compact_only=compact_only
         )
 
+    async def _execute_read_existing(
+        self,
+        arguments: dict[str, Any],
+        *,
+        mode: str,
+        output_format: str,
+        compact_only: bool,
+    ) -> dict[str, Any]:
+        """P0.4 producer route: atomically capture and publish in memory.
+
+        ``access_mode="read_existing"`` makes ``edit.impact`` the
+        unconditional in-memory diff-snapshot producer: the zero-write
+        registry backend captures the payload with no filesystem writes,
+        then the ordinary frozen-scope analysis runs against the published
+        snapshot. Every result carries the P0.4 access-evidence fields.
+        """
+        self.validate_arguments(arguments)
+        scope_paths: list[str] = []
+        try:
+            scope_paths = [
+                path_from_wire(str(path))
+                for path in (arguments.get("scope_paths") or [])
+            ]
+        except (SourceOracleError, ValueError) as exc:
+            return self._read_existing_error(str(exc), output_format, compact_only)
+        from ...diff_snapshot_registry import REGISTRY
+
+        frozen = REGISTRY.create(self.project_root, mode, scope_paths, readonly=True)
+        if not frozen.get("success"):
+            return self._read_existing_error(
+                str(frozen.get("error_code", "DIFF_SNAPSHOT_CAPTURE_ERROR")),
+                output_format,
+                compact_only,
+            )
+        frozen_consumer, error = REGISTRY.acquire(
+            str(frozen["diff_snapshot_id"]), self.project_root
+        )
+        if error:
+            REGISTRY.close_lease(
+                str(frozen["diff_snapshot_id"]), str(frozen["route_lease_id"])
+            )
+            return self._read_existing_error(error, output_format, compact_only)
+        assert frozen_consumer is not None
+        try:
+            result = self._execute_frozen_snapshot(
+                frozen=frozen,
+                consumer=frozen_consumer,
+                mode=mode,
+                scope_paths=scope_paths,
+                scope_mode=arguments.get("scope_mode", "report"),
+                output_format=output_format,
+                agent_summary_only=bool(arguments.get("agent_summary_only", False)),
+                compact_only=compact_only,
+                read_existing=True,
+            )
+            if not result.get("success"):
+                REGISTRY.close_lease(
+                    str(frozen["diff_snapshot_id"]),
+                    str(frozen["route_lease_id"]),
+                )
+            return result
+        except BaseException:
+            REGISTRY.close_lease(
+                str(frozen["diff_snapshot_id"]), str(frozen["route_lease_id"])
+            )
+            raise
+        finally:
+            frozen_consumer.release()
+
+    def _read_existing_error(
+        self, code: str, output_format: str, compact_only: bool
+    ) -> dict[str, Any]:
+        """Classify one read-existing producer failure with access evidence."""
+        state = (
+            "missing"
+            if code in {"MISSING_INDEX", "MISSING_PROJECT_ROOT"}
+            else "unknown"
+        )
+        return apply_toon_format_to_response(
+            {
+                "success": False,
+                "verdict": "ERROR",
+                "error_code": code,
+                "error": code,
+                "access_mode": "read_existing",
+                "access_state": state,
+                "access_reason": code,
+                "source_snapshots": [],
+                "output_format": output_format,
+                "action_version": EDIT_IMPACT_ACTION_VERSION,
+            },
+            output_format,
+            compact_only=compact_only,
+        )
+
     def _execute_frozen_snapshot(
         self,
         *,
@@ -354,11 +471,14 @@ class ChangeImpactTool(BaseMCPTool):
         output_format: str,
         agent_summary_only: bool,
         compact_only: bool,
+        read_existing: bool = False,
     ) -> dict[str, Any]:
         """Build strict impact solely from the captured snapshot records.
 
         Frozen capture intentionally cannot claim dependency or test impact: those
         require live graph/cache inputs which are outside the bound source epoch.
+        ``read_existing=True`` adds the exact P0.4 access-evidence fields to
+        every classified result (RFC-0022 P0.4).
         """
         from ...diff_snapshot_registry import REGISTRY
 
@@ -383,6 +503,17 @@ class ChangeImpactTool(BaseMCPTool):
             )
         response_frozen = dict(frozen)
         response_frozen["changed_records"] = records
+        if read_existing:
+            response_frozen["access_mode"] = "read_existing"
+            response_frozen["access_state"] = "available"
+            response_frozen["access_reason"] = None
+            response_frozen["source_snapshots"] = [
+                {
+                    "kind": "diff",
+                    "snapshot_id": response_frozen["diff_snapshot_id"],
+                    "source_generation": response_frozen["source_generation"],
+                }
+            ]
         result = self._attach_diff_snapshot(result, mode, True, frozen=response_frozen)
         if agent_summary_only:
             snapshot_surface: dict[str, Any] = {
@@ -393,6 +524,16 @@ class ChangeImpactTool(BaseMCPTool):
                     "source_generation",
                     "changed_records",
                     "assessed_scope_paths",
+                    *(
+                        (
+                            "access_mode",
+                            "access_state",
+                            "access_reason",
+                            "source_snapshots",
+                        )
+                        if read_existing
+                        else ()
+                    ),
                 )
                 if key in result
             }

--- a/tree_sitter_analyzer/read_existing_access.py
+++ b/tree_sitter_analyzer/read_existing_access.py
@@ -2,12 +2,26 @@
 
 from __future__ import annotations
 
+import sys
 from typing import Any
 
 from .git_path_codec import path_from_wire
 
 READ_EXISTING_AUTHORITY_UNCERTIFIED = "READ_EXISTING_AUTHORITY_UNCERTIFIED"
 DIFF_SNAPSHOT_READ_EXISTING_UNSUPPORTED = "DIFF_SNAPSHOT_READ_EXISTING_UNSUPPORTED"
+
+
+def read_existing_platform_supported() -> bool:
+    """Return whether this axis may run the read-existing backends.
+
+    RFC-0022 P0.4 certifies zero-write behavior through a pinned native
+    authority (the Linux strace monitor); an OS without that authority
+    must return a stable unsupported result and cannot be listed as
+    certified support. The read-only backends themselves are POSIX-only,
+    and their strace certification is Linux-only, so the runtime enables
+    them on Linux and fails closed everywhere else.
+    """
+    return sys.platform.startswith("linux")
 
 
 def validate_read_existing_access(arguments: dict[str, Any]) -> bool:


### PR DESCRIPTION
## RFC-0022 P0.4: zero-write diff payload materialization — the `read_existing` producer

This is the **materialization half** of the P0.4 read-existing backend (generation half was #1293). It reproduces the frozen P0.2 capture payload **entirely in memory** — no temporary index, no temporary object directory, no order file — and wires it into `edit.impact(access_mode="read_existing")` on the Linux (strace-certified) axis.

### What lands

**`diff_snapshot_readonly_capture.py`** — `capture_payload_readonly()` mirrors `_capture_payload()` record-for-record (path/status/old+new availability/kind/mode/oid/binary/unsupported, patch, old/new bytes):
- tracked rows/binaries/patch from the live index via the read-only runner (`GIT_OPTIONAL_LOCKS=0`)
- untracked new-file patch sections via the byte-identical `git diff --no-index` format (exit 1 = differences found, accepted explicitly)
- content-identical worktree moves paired as **R100 renames** (the live diff queue can't see untracked paths); modified moves surface as delete+add pairs — a **documented divergence** from the frozen inexact R
- conversion-active repos (`core.autocrlf`/`eol`/`working-tree-encoding` attributes + CRLF) fail closed with `DIFF_SNAPSHOT_UNSUPPORTED_CONVERSION` — raw worktree bytes are only published when they equal the frozen backend's cleaned bytes
- dirty gitlinks deduped into the frozen backend's canonical opaque row (no patch section, `unsupported_kind=dirty_gitlink`)

**`diff_snapshot_constraints_readonly.py`** — staged constraint-config probe (`cat-file` against the live object DB) and the sources-match-worktree probe with the frozen probe's exact effective semantics (any supported tracked/untracked path fails).

**`diff_snapshot_readonly.py` fixes** (found by the new differential tests):
- settings probes routed through the read-only runner — the merged #1293 oracle was calling the frozen runner, which **writes a temp order file per invocation** (zero-write violation)
- dirty gitlinks detected deterministically via read-only nested probes (submodule HEAD + `status --porcelain`), replicating the frozen oracle's invalidation semantics including epoch `dirty_paths`

**`diff_snapshot_registry.create(readonly=True)`** — the zero-write capture path publishes the identical snapshot shape (same generation, records, scope, config evidence).

**`edit.impact`** — `access_mode="read_existing"` is now the in-memory producer on Linux; other OSes keep the stable `DIFF_SNAPSHOT_READ_EXISTING_UNSUPPORTED` (RFC-0022: no native authority → stable unsupported). Every result (success or classified failure) carries the exact P0.4 access-evidence fields `access_mode`/`access_state`/`access_reason`/`source_snapshots`. Validation happens before the platform gate (the malformed-schema contract holds on every axis).

### Tests
- **Differential golden corpus** (`test_diff_snapshot_readonly_capture.py`): byte-equality with the frozen backend across clean/dirty/untracked/deleted/executable/no-newline/binary/symlink/exact-rename/rename+dirty/staged-add/staged-rename/double-dirty/gitlink states + registry-level snapshot equality (incl. `staged_source_matches_worktree`, constraint evidence) + conversion-guard fail-closed + no-tempfile-materialization assertions
- `test_diff_snapshot_constraints_readonly.py`: staged probe differential
- platform-aware `edit.impact` gate tests (Linux: real producer + classified failure; elsewhere: unsupported envelope)
- `git_readonly.ok_returncodes` unit test
- fixed a false-green: the merged oracle's "never materializes" test never installed its spy; it now does and passes

### Verified
- `uv run pytest -q`: 1992 passed, 27 skipped (baseline)
- patch-coverage gate: no added executable misses
- pre-commit (ruff/mypy/bandit/weak-assertion-ratchet): clean
- the zero-write invocation set is asserted to never call `tempfile.mkstemp/mkdtemp` and never set `GIT_INDEX_FILE`

### Follow-ups (unchanged from the P0.4 gate)
- Linux strace axis case that runs the real read-existing route (monitor infra exists; adapter-route case next)
- consumers (`ast_diff`/`classify`/`constraints`) read_existing backends
- object-directory-free HEAD traversal (Codex #1293 finding 5)
