### PR TITLE
feat(task): P0.1 read_existing backends for nav.context and edit.safe

### DIFF
--- a/rfcs/0022-task-outcome-apis.md
+++ b/rfcs/0022-task-outcome-apis.md
@@ -62,7 +62,11 @@ whose `completeness` is not `complete` with `INDEX_SNAPSHOT_INCOMPLETE` before
 serving any graph data (mirroring the constraint route's completeness gate).
 A target file outside the snapshot's source inventory is rejected with
 `FILE_NOT_INDEXED` before any of its bytes are read or scored (the source
-recaptures only certify inventory-covered files). In particular, `nav.context` may
+recaptures only certify inventory-covered files). Constraint rows are not used
+as certified safety facts until an evaluation epoch bound to the published
+source/index generation exists (reindexing does not recompute
+`ast_constraint_violations`); the certified route omits them rather than
+serving facts it cannot prove current. In particular, `nav.context` may
 not combine entry points from a cached graph with newer filesystem lines.
 Absence, disagreement, or a changed token stops the task route; no later
 `nav.context` or `edit.safe` call starts.

--- a/rfcs/0022-task-outcome-apis.md
+++ b/rfcs/0022-task-outcome-apis.md
@@ -57,7 +57,9 @@ task never scans or hashes the repository.
 `source_generation` returned by `index.status`. Each revalidates both tokens
 before and after reading, echoes both tokens actually used, and either serves all
 graph and source bytes from that immutable snapshot or returns
-`SOURCE_GENERATION_MISMATCH` without a result. In particular, `nav.context` may
+`SOURCE_GENERATION_MISMATCH` without a result. A consumer rejects a capability
+whose `completeness` is not `complete` with `INDEX_SNAPSHOT_INCOMPLETE` before
+serving any graph data (mirroring the constraint route's completeness gate). In particular, `nav.context` may
 not combine entry points from a cached graph with newer filesystem lines.
 Absence, disagreement, or a changed token stops the task route; no later
 `nav.context` or `edit.safe` call starts.

--- a/rfcs/0022-task-outcome-apis.md
+++ b/rfcs/0022-task-outcome-apis.md
@@ -59,7 +59,10 @@ before and after reading, echoes both tokens actually used, and either serves al
 graph and source bytes from that immutable snapshot or returns
 `SOURCE_GENERATION_MISMATCH` without a result. A consumer rejects a capability
 whose `completeness` is not `complete` with `INDEX_SNAPSHOT_INCOMPLETE` before
-serving any graph data (mirroring the constraint route's completeness gate). In particular, `nav.context` may
+serving any graph data (mirroring the constraint route's completeness gate).
+A target file outside the snapshot's source inventory is rejected with
+`FILE_NOT_INDEXED` before any of its bytes are read or scored (the source
+recaptures only certify inventory-covered files). In particular, `nav.context` may
 not combine entry points from a cached graph with newer filesystem lines.
 Absence, disagreement, or a changed token stops the task route; no later
 `nav.context` or `edit.safe` call starts.

--- a/tests/unit/mcp/test_safe_to_edit_tool.py
+++ b/tests/unit/mcp/test_safe_to_edit_tool.py
@@ -896,8 +896,11 @@ async def test_edit_safe_read_existing_ignores_unbound_constraint_rows(
     assert result["success"] is True
     assert result["access_state"] == "available"
     # The seeded error-severity row must NOT escalate: it cannot prove it
-    # belongs to the published generation (C21).
-    assert result["verdict"] == "SAFE"
+    # belongs to the published generation (C21). The CAUTION verdict comes
+    # from the snapshot dependency view (routes.py imports app.py), never
+    # from constraint rows.
+    assert result["verdict"] == "CAUTION"
+    assert result["downstream_count"] == 1
     assert not any(
         factor.get("factor") == "constraint_violation"
         for factor in result["risk_factors"]

--- a/tests/unit/mcp/test_safe_to_edit_tool.py
+++ b/tests/unit/mcp/test_safe_to_edit_tool.py
@@ -695,6 +695,35 @@ def test_certified_commands_use_extension_runner(tmp_path: Path) -> None:
     )
     assert java_summary.get("verification_command") == ""
     assert "unidentified" in java_summary.get("stop_condition", "")
+    # A workflow without guardrails exercises the empty-guardrails branch.
+    bare_workflow = build_agent_workflow(
+        AgentWorkflowContext(
+            file_path="Calc.java",
+            risk="safe",
+            edit_type="add",
+            has_tests=True,
+            test_files=["CalcTest.java"],
+            health_grade="A",
+            project_root=str(tmp_path),
+            certified=True,
+        )
+    )
+    assert bare_workflow.get("guardrails") == []
+    bare_summary = build_agent_summary(
+        AgentWorkflowContext(
+            file_path="Calc.java",
+            risk="safe",
+            edit_type="add",
+            has_tests=True,
+            test_files=["CalcTest.java"],
+            health_grade="A",
+            project_root=str(tmp_path),
+            certified=True,
+        ),
+        bare_workflow,
+        verdict_override=None,
+    )
+    assert "guardrails" not in bare_summary
     # C41: the queue-boundary list stays empty, never [""].
     assert java_workflow.get("queue_boundary_commands") == []
 

--- a/tests/unit/mcp/test_safe_to_edit_tool.py
+++ b/tests/unit/mcp/test_safe_to_edit_tool.py
@@ -391,6 +391,8 @@ class TestChecklistSequentialNumbering:
 async def test_edit_safe_explicit_read_existing_honors_compact_only(
     tmp_path,
 ) -> None:
+    import sys
+
     file_path = tmp_path / "inside.py"
     file_path.write_text("value = 1\n")
     result = await build_edit_facade(str(tmp_path)).execute(
@@ -404,6 +406,34 @@ async def test_edit_safe_explicit_read_existing_honors_compact_only(
             "compact_only": True,
         }
     )
+
+    if sys.platform.startswith("linux"):
+        # RFC-0022 P0.4: the certified backend runs and classifies the
+        # missing snapshot; the classified failure keeps the same TOON
+        # control surface and the wire-owner echo.
+        assert result["format"] == "toon"
+        assert "INDEX_SNAPSHOT_UNKNOWN" in result["toon_content"]
+        assert {
+            key: result[key]
+            for key in (
+                "success",
+                "verdict",
+                "access_mode",
+                "access_state",
+                "access_reason",
+                "output_format",
+                "action_version",
+            )
+        } == {
+            "success": False,
+            "verdict": "ERROR",
+            "access_mode": "read_existing",
+            "access_state": "unknown",
+            "access_reason": "INDEX_SNAPSHOT_UNKNOWN",
+            "output_format": "toon",
+            "action_version": "edit.safe/v1",
+        }
+        return
 
     assert result == {
         "format": "toon",
@@ -469,3 +499,156 @@ def test_execute_read_existing_fails_closed_without_project_root() -> None:
         "MISSING_PROJECT_ROOT: project_root must be bound before "
         "read_existing path validation"
     )
+
+
+# ---------------------------------------------------------------------------
+# RFC-0022 P0.4: certified-axis index-snapshot consumers (portable gate open)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _close_index_snapshot_registry():
+    yield
+    from tree_sitter_analyzer.index_snapshot import REGISTRY
+
+    REGISTRY.close_all()
+
+
+def _indexed_project(tmp_path: Path) -> Path:
+    """Index one small project and return its resolved root."""
+    from tree_sitter_analyzer.ast_cache import ASTCache
+
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / "app.py").write_text(
+        "def helper():\n"
+        "    return 1\n"
+        "\n"
+        "class UserService:\n"
+        "    def get_user(self, user_id):\n"
+        "        return self._find_user(user_id)\n"
+        "\n"
+        "    def _find_user(self, user_id):\n"
+        "        return {'id': user_id}\n",
+        encoding="utf-8",
+    )
+    (project / "routes.py").write_text(
+        "from app import UserService\n"
+        "\n"
+        "def dispatch(request):\n"
+        "    return UserService().get_user(1)\n",
+        encoding="utf-8",
+    )
+    cache = ASTCache(str(project))
+    cache.index_project(max_files=20)
+    cache.close()
+    return project.resolve()
+
+
+def _publish_index_snapshot(project: Path, *, source_generation: str | None = None):
+    """Publish one real index.db connection under the process-global registry.
+
+    The published capability carries the REAL captured source generation and
+    a full source scope so the consumer's after-read recapture passes: a
+    hand-faked generation would raise SOURCE_GENERATION_MISMATCH on exit.
+    """
+    import sqlite3
+
+    from tree_sitter_analyzer.index_snapshot import (
+        REGISTRY,
+        IndexSnapshot,
+        _capture_sources_with_deadline,
+    )
+    from tree_sitter_analyzer.index_source_scope import make_source_scope_descriptor
+
+    scope = make_source_scope_descriptor()
+    current = _capture_sources_with_deadline(str(project), scope, deadline=10**18)
+    assert current.state == "exact", current.reason
+    conn = sqlite3.connect(str(project / ".ast-cache" / "index.db"))
+    conn.row_factory = sqlite3.Row
+    snapshot = IndexSnapshot(
+        None,
+        current.fingerprint,
+        "index-fp",
+        source_generation or current.generation,
+        "complete",
+        None,
+        str(project.resolve()),
+        2,
+        None,
+        None,
+        scope,
+    )
+    return REGISTRY.publish(snapshot, conn, 0)
+
+
+@pytest.mark.asyncio
+async def test_edit_safe_read_existing_consumes_published_snapshot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The certified backend serves the risk envelope from the snapshot."""
+    import tree_sitter_analyzer.read_existing_access as read_access
+
+    monkeypatch.setattr(read_access, "read_existing_platform_supported", lambda: True)
+    project = _indexed_project(tmp_path)
+    published = _publish_index_snapshot(project)
+
+    tool = SafeToEditTool(str(project))
+    result = await tool.execute(
+        {
+            "file_path": "app.py",
+            "access_mode": "read_existing",
+            "snapshot_id": published.snapshot_id,
+            "source_generation": published.source_generation,
+            "output_format": "json",
+        }
+    )
+
+    assert result["success"] is True
+    assert result["access_mode"] == "read_existing"
+    assert result["access_state"] == "available"
+    assert result["access_reason"] is None
+    assert result["source_snapshots"] == [
+        {
+            "kind": "index",
+            "snapshot_id": published.snapshot_id,
+            "source_generation": published.source_generation,
+        }
+    ]
+    # The echo must come from the ACQUIRED snapshot, byte-matching the
+    # source_snapshots record (RFC-0022 route-table common rule 5).
+    assert result["snapshot_id"] == published.snapshot_id
+    assert result["source_generation"] == published.source_generation
+    assert result["action_version"] == "edit.safe/v1"
+    assert result["risk_level"] in {"safe", "caution", "dangerous"}
+    assert result["health_grade"]
+
+
+@pytest.mark.asyncio
+async def test_edit_safe_read_existing_generation_mismatch_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A wrong source_generation token classifies, never a successful read."""
+    import tree_sitter_analyzer.read_existing_access as read_access
+
+    monkeypatch.setattr(read_access, "read_existing_platform_supported", lambda: True)
+    project = _indexed_project(tmp_path)
+    published = _publish_index_snapshot(project)
+
+    tool = SafeToEditTool(str(project))
+    result = await tool.execute(
+        {
+            "file_path": "app.py",
+            "access_mode": "read_existing",
+            "snapshot_id": published.snapshot_id,
+            "source_generation": "WRONG-GENERATION",
+            "output_format": "json",
+        }
+    )
+
+    assert result["success"] is False
+    assert result["access_state"] == "unknown"
+    assert result["access_reason"] == "SOURCE_GENERATION_MISMATCH"
+    assert result["error_code"] == "SOURCE_GENERATION_MISMATCH"
+    assert result["source_snapshots"] == []
+    assert result["action_version"] == "edit.safe/v1"

--- a/tests/unit/mcp/test_safe_to_edit_tool.py
+++ b/tests/unit/mcp/test_safe_to_edit_tool.py
@@ -664,6 +664,33 @@ def test_snapshot_dependency_view_degrades_on_closed_conn() -> None:
     assert view.dependencies_of("app.py") == []
 
 
+def test_read_existing_payload_missing_indexed_file_returns_not_found(
+    tmp_path: Path,
+) -> None:
+    """An indexed target missing at read time still answers FILE_NOT_FOUND.
+
+    Codex P1 round-4 (C19): the inventory gate passes (the file IS in
+    ast_index), then the existence probe answers from the filesystem.
+    """
+    import sqlite3
+    from types import SimpleNamespace
+
+    from tree_sitter_analyzer.mcp.tools.safe_to_edit_tool import SafeToEditTool
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("CREATE TABLE ast_index (file_path TEXT)")
+    conn.execute("INSERT INTO ast_index VALUES ('app.py')")
+    tool = SafeToEditTool(str(tmp_path))
+    with pytest.raises(ValueError, match="FILE_NOT_FOUND"):
+        tool._read_existing_payload(
+            {"file_path": "app.py", "edit_type": "refactor"},
+            str(tmp_path / "app.py"),
+            conn,
+            snapshot=SimpleNamespace(canonical_root=str(tmp_path.resolve())),
+        )
+
+
 def test_read_existing_payload_language_detection_degrades(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -749,7 +776,7 @@ def test_snapshot_constraint_query_reads_from_given_conn() -> None:
 def test_format_result_reads_constraints_from_snapshot_conn(
     tmp_path: Path,
 ) -> None:
-    """Snapshot-mode formatting escalates verdict from the snapshot rows."""
+    """Snapshot-mode formatting ignores rows that cannot prove freshness."""
     import sqlite3
     from types import SimpleNamespace
 
@@ -792,8 +819,10 @@ def test_format_result_reads_constraints_from_snapshot_conn(
         snapshot_conn=conn,
     )
     result = _format_safe_to_edit_result(context, facts)
-    assert result["verdict"] == "UNSAFE"
-    assert any(
+    # C21: the seeded error row is unbound to the snapshot generation and
+    # must not escalate the verdict.
+    assert result["verdict"] == "SAFE"
+    assert not any(
         factor.get("factor") == "constraint_violation"
         for factor in result["risk_factors"]
     )
@@ -805,13 +834,15 @@ def test_format_result_reads_constraints_from_snapshot_conn(
     reason="tracked: RFC-0022 P0.4 source recapture needs POSIX /dev/fd",
 )
 @pytest.mark.asyncio
-async def test_edit_safe_read_existing_uses_snapshot_constraints_read_only(
+async def test_edit_safe_read_existing_ignores_unbound_constraint_rows(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Snapshot-mode facts come from the snapshot conn; fixture index never written.
+    """Unbound constraint rows never escalate; the certified read stays zero-write.
 
-    Codex P1 (#1299): the certified route must derive constraint violations
-    from the immutable snapshot connection and must not create
+    Codex P1 (#1299 round-4, C21): reindexing stamps the manifest without
+    recomputing ast_constraint_violations, so the rows cannot prove they
+    match the published generation — the certified route must NOT promote
+    UNSAFE from them. The route also never creates
     ``.ast-cache/fixture_index.json`` (zero-write read).
     """
     import sqlite3
@@ -864,9 +895,10 @@ async def test_edit_safe_read_existing_uses_snapshot_constraints_read_only(
 
     assert result["success"] is True
     assert result["access_state"] == "available"
-    # The error-severity snapshot row escalates the verdict above the base.
-    assert result["verdict"] == "UNSAFE"
-    assert any(
+    # The seeded error-severity row must NOT escalate: it cannot prove it
+    # belongs to the published generation (C21).
+    assert result["verdict"] == "SAFE"
+    assert not any(
         factor.get("factor") == "constraint_violation"
         for factor in result["risk_factors"]
     )
@@ -1093,7 +1125,14 @@ async def test_edit_safe_read_existing_syntax_error_short_circuits(
 async def test_edit_safe_read_existing_missing_file_fails_closed(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A missing target file fails closed on the snapshot route."""
+    """A missing target fails closed on the snapshot route.
+
+    Codex P1 round-4 (C19): the inventory gate precedes every live-filesystem
+    probe — a file the snapshot never indexed (missing or not) is answered
+    from the snapshot with FILE_NOT_INDEXED, never from uncertified disk
+    state. (An indexed-but-deleted file surfaces as SOURCE_GENERATION_MISMATCH
+    in the pre-read recapture instead.)
+    """
     import tree_sitter_analyzer.read_existing_access as read_access
 
     monkeypatch.setattr(read_access, "read_existing_platform_supported", lambda: True)
@@ -1111,7 +1150,7 @@ async def test_edit_safe_read_existing_missing_file_fails_closed(
         }
     )
     assert result["success"] is False
-    assert result["error_code"] == "FILE_NOT_FOUND"
-    assert result["access_reason"] == "FILE_NOT_FOUND"
+    assert result["error_code"] == "FILE_NOT_INDEXED"
+    assert result["access_reason"] == "FILE_NOT_INDEXED"
     assert result["access_state"] == "unknown"
     assert result["action_version"] == "edit.safe/v1"

--- a/tests/unit/mcp/test_safe_to_edit_tool.py
+++ b/tests/unit/mcp/test_safe_to_edit_tool.py
@@ -484,23 +484,26 @@ def test_execute_read_existing_fails_closed_without_project_root() -> None:
     # Codex P1 (#1257): with project_root unbound, resolve_and_validate_
     # file_path would pass base_path=None into SecurityValidator and skip
     # the project-boundary layer; the read_existing route must fail closed
-    # with the stable MISSING_PROJECT_ROOT error instead.
+    # with the stable MISSING_PROJECT_ROOT error. Review P2 (#1299): the
+    # failure is a classified envelope (evidence + action_version), not a
+    # bare raise.
     tool = SafeToEditTool()  # no project root bound
-    with pytest.raises(ValueError) as exc_info:
-        _run(
-            tool.execute(
-                {
-                    "file_path": "src/app.py",
-                    "access_mode": "read_existing",
-                    "snapshot_id": "snap-1",
-                    "source_generation": 1,
-                }
-            )
+    result = _run(
+        tool.execute(
+            {
+                "file_path": "src/app.py",
+                "access_mode": "read_existing",
+                "snapshot_id": "snap-1",
+                "source_generation": "1",
+            }
         )
-    assert str(exc_info.value) == (
-        "MISSING_PROJECT_ROOT: project_root must be bound before "
-        "read_existing path validation"
     )
+    assert result["success"] is False
+    assert result["error_code"] == "MISSING_PROJECT_ROOT"
+    assert result["access_reason"] == "MISSING_PROJECT_ROOT"
+    assert result["access_state"] == "missing"
+    assert result["action_version"] == "edit.safe/v1"
+    assert result["source_snapshots"] == []
 
 
 # ---------------------------------------------------------------------------
@@ -663,4 +666,145 @@ async def test_edit_safe_read_existing_generation_mismatch_fails_closed(
     assert result["access_reason"] == "SOURCE_GENERATION_MISMATCH"
     assert result["error_code"] == "SOURCE_GENERATION_MISMATCH"
     assert result["source_snapshots"] == []
+    assert result["action_version"] == "edit.safe/v1"
+
+
+# RFC-0022 P0.4: the snapshot dependency view degrades to an empty view on
+# schema drift (legacy connection without the edges/ast_index tables) so the
+# route still classifies honestly instead of crashing.
+def test_snapshot_dependency_view_degrades_on_schema_drift() -> None:
+    import sqlite3
+
+    from tree_sitter_analyzer.mcp.tools.utils.safe_to_edit_helpers import (
+        build_snapshot_file_dependency_view,
+    )
+
+    conn = sqlite3.connect(":memory:")
+    view = build_snapshot_file_dependency_view(conn, "app.py")
+    assert view.dependents_of("app.py") == []
+    assert view.dependencies_of("app.py") == []
+
+    # edges present but ast_index absent: exact resolution probes the missing
+    # table and degrades to not-indexed.
+    conn.execute("CREATE TABLE edges (file_path TEXT, callee_name TEXT, kind TEXT)")
+    conn.execute("INSERT INTO edges VALUES ('routes.py', 'app', 'imports')")
+    partial = build_snapshot_file_dependency_view(conn, "app.py")
+    assert partial.dependents_of("app.py") == []
+
+
+# RFC-0022 P0.4: the snapshot dependency view resolves exact IMPORTS edges
+# AND recalls member imports via the imports_json needle pass, matching the
+# legacy live axis ('from pkg import app' / 'from . import app').
+def test_snapshot_dependency_view_recalls_member_imports() -> None:
+    import json
+    import sqlite3
+
+    from tree_sitter_analyzer.mcp.tools.utils.safe_to_edit_helpers import (
+        build_snapshot_file_dependency_view,
+    )
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("CREATE TABLE edges (file_path TEXT, callee_name TEXT, kind TEXT)")
+    conn.execute("CREATE TABLE ast_index (file_path TEXT, imports_json TEXT)")
+    conn.execute("INSERT INTO edges VALUES ('routes.py', 'app', 'imports')")
+    conn.execute("INSERT INTO edges VALUES ('app.py', 'app', 'imports')")
+    # 'app.py' importing a module that does not index -> resolved is None.
+    conn.execute("INSERT INTO edges VALUES ('app.py', 'missing.mod', 'imports')")
+    # Relative import spec ('.sibling') exercises the relative branch.
+    conn.execute("INSERT INTO edges VALUES ('pkg/app.py', '.sibling', 'imports')")
+    # Parent-relative spec ('..') is rejected outright.
+    conn.execute("INSERT INTO edges VALUES ('pkg/app.py', '..up', 'imports')")
+    conn.execute(
+        "INSERT INTO ast_index VALUES ('routes.py', ?)",
+        (json.dumps([{"text": "from app import UserService", "line": 1}]),),
+    )
+    conn.execute(
+        "INSERT INTO ast_index VALUES ('unrelated.py', ?)",
+        (json.dumps([{"text": "import os", "line": 1}]),),
+    )
+    conn.execute(
+        "INSERT INTO ast_index VALUES ('odd.py', ?)",
+        (json.dumps([{"text": 123, "line": 1}]),),
+    )
+    conn.execute(
+        "INSERT INTO ast_index VALUES ('app.py', ?)",
+        (json.dumps([{"text": "import os", "line": 1}]),),
+    )
+    conn.execute("INSERT INTO ast_index VALUES ('broken.py', 'not-json')")
+    view = build_snapshot_file_dependency_view(conn, "app.py")
+    # 'routes.py' matches the needle pass; 'unrelated.py' exercises the
+    # non-match branch (no dependent added).
+    assert view.dependents_of("app.py") == ["routes.py"]
+
+
+@pytest.mark.slow_ok  # real git + index_project + source capture: subprocess work
+@pytest.mark.skipif(
+    sys.platform.startswith("win") or not os.path.exists("/dev/fd"),
+    reason="tracked: RFC-0022 P0.4 source recapture needs POSIX /dev/fd",
+)
+@pytest.mark.asyncio
+async def test_edit_safe_read_existing_syntax_error_short_circuits(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A broken file short-circuits the snapshot route like the legacy axis."""
+    import tree_sitter_analyzer.read_existing_access as read_access
+
+    monkeypatch.setattr(read_access, "read_existing_platform_supported", lambda: True)
+    project = _indexed_project(tmp_path)
+    (project / "app.py").write_text("def broken(:\n", encoding="utf-8")
+    published = _publish_index_snapshot(project)
+
+    tool = SafeToEditTool(str(project))
+    result = await tool.execute(
+        {
+            "file_path": "app.py",
+            "access_mode": "read_existing",
+            "snapshot_id": published.snapshot_id,
+            "source_generation": published.source_generation,
+            "output_format": "json",
+        }
+    )
+    assert result["success"] is True
+    assert result["verdict"] == "ERROR"
+    assert result["access_state"] == "available"
+    assert result["source_snapshots"] == [
+        {
+            "kind": "index",
+            "snapshot_id": published.snapshot_id,
+            "source_generation": published.source_generation,
+        }
+    ]
+
+
+@pytest.mark.slow_ok  # real git + index_project + source capture: subprocess work
+@pytest.mark.skipif(
+    sys.platform.startswith("win") or not os.path.exists("/dev/fd"),
+    reason="tracked: RFC-0022 P0.4 source recapture needs POSIX /dev/fd",
+)
+@pytest.mark.asyncio
+async def test_edit_safe_read_existing_missing_file_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A missing target file fails closed on the snapshot route."""
+    import tree_sitter_analyzer.read_existing_access as read_access
+
+    monkeypatch.setattr(read_access, "read_existing_platform_supported", lambda: True)
+    project = _indexed_project(tmp_path)
+    published = _publish_index_snapshot(project)
+
+    tool = SafeToEditTool(str(project))
+    result = await tool.execute(
+        {
+            "file_path": "does_not_exist.py",
+            "access_mode": "read_existing",
+            "snapshot_id": published.snapshot_id,
+            "source_generation": published.source_generation,
+            "output_format": "json",
+        }
+    )
+    assert result["success"] is False
+    assert result["error_code"] == "FILE_NOT_FOUND"
+    assert result["access_reason"] == "FILE_NOT_FOUND"
+    assert result["access_state"] == "unknown"
     assert result["action_version"] == "edit.safe/v1"

--- a/tests/unit/mcp/test_safe_to_edit_tool.py
+++ b/tests/unit/mcp/test_safe_to_edit_tool.py
@@ -1318,6 +1318,11 @@ def test_snapshot_dependency_view_recalls_member_imports() -> None:
     # C40: a valid-JSON non-array cell (42) must be skipped per row, NOT
     # abort the whole needle pass — the later matching row still counts.
     conn.execute("INSERT INTO ast_index VALUES ('scalar.py', '42')")
+    # C64: 'import happy' must NOT match the 'app' needle as a substring.
+    conn.execute(
+        "INSERT INTO ast_index VALUES ('tests/test_happy.py', ?)",
+        (json.dumps([{"text": "import happy", "line": 1}]),),
+    )
     conn.execute(
         "INSERT INTO ast_index VALUES ('later.py', ?)",
         (json.dumps([{"text": "from app import Member", "line": 1}]),),

--- a/tests/unit/mcp/test_safe_to_edit_tool.py
+++ b/tests/unit/mcp/test_safe_to_edit_tool.py
@@ -671,6 +671,10 @@ def test_certified_commands_use_extension_runner(tmp_path: Path) -> None:
     # C35: ambiguous ecosystems omit the command rather than guess.
     assert "mvn test" not in str(java_workflow.get("after_edit_commands", []))
     assert "go test" not in str(java_workflow.get("after_edit_commands", []))
+    # C41: the queue-boundary list stays empty, never [""].
+    assert java_workflow.get("queue_boundary_commands") == []
+    # C41: the queue-boundary list stays empty, never [""].
+    assert java_workflow.get("queue_boundary_commands") == []
 
     rust_workflow = build_agent_workflow(
         AgentWorkflowContext(
@@ -1228,6 +1232,12 @@ def test_snapshot_dependency_view_recalls_member_imports() -> None:
     conn.execute("CREATE TABLE edges (file_path TEXT, callee_name TEXT, kind TEXT)")
     conn.execute("CREATE TABLE ast_index (file_path TEXT, imports_json TEXT)")
     conn.execute("INSERT INTO edges VALUES ('routes.py', 'app', 'imports')")
+    # C44: a BLOB callee_name row must not abort the whole edges pass.
+    conn.execute(
+        "INSERT INTO edges VALUES ('blobbed.py', ?, 'imports')", (b"blob-module",)
+    )
+    # The target's OWN import row can also carry a BLOB (pass-1 skip).
+    conn.execute("INSERT INTO edges VALUES ('app.py', ?, 'imports')", (b"blob-own",))
     conn.execute("INSERT INTO edges VALUES ('app.py', 'app', 'imports')")
     # 'app.py' importing a module that does not index -> resolved is None.
     conn.execute("INSERT INTO edges VALUES ('app.py', 'missing.mod', 'imports')")

--- a/tests/unit/mcp/test_safe_to_edit_tool.py
+++ b/tests/unit/mcp/test_safe_to_edit_tool.py
@@ -656,6 +656,50 @@ def test_certified_commands_use_extension_runner(tmp_path: Path) -> None:
     )
     assert "go test" in str(go_workflow.get("after_edit_commands", []))
 
+    java_workflow = build_agent_workflow(
+        AgentWorkflowContext(
+            file_path="Calc.java",
+            risk="safe",
+            edit_type="refactor",
+            has_tests=True,
+            test_files=["CalcTest.java"],
+            health_grade="A",
+            project_root=str(tmp_path),
+            certified=True,
+        )
+    )
+    # C35: ambiguous ecosystems omit the command rather than guess.
+    assert "mvn test" not in str(java_workflow.get("after_edit_commands", []))
+    assert "go test" not in str(java_workflow.get("after_edit_commands", []))
+
+    rust_workflow = build_agent_workflow(
+        AgentWorkflowContext(
+            file_path="lib.rs",
+            risk="safe",
+            edit_type="refactor",
+            has_tests=True,
+            test_files=["tests/lib_test.rs"],
+            health_grade="A",
+            project_root=str(tmp_path),
+            certified=True,
+        )
+    )
+    assert "cargo test" in str(rust_workflow.get("after_edit_commands", []))
+
+    js_workflow = build_agent_workflow(
+        AgentWorkflowContext(
+            file_path="app.js",
+            risk="safe",
+            edit_type="refactor",
+            has_tests=True,
+            test_files=["__tests__/app.test.js"],
+            health_grade="A",
+            project_root=str(tmp_path),
+            certified=True,
+        )
+    )
+    assert "npm test" in str(js_workflow.get("after_edit_commands", []))
+
     py_workflow = build_agent_workflow(
         AgentWorkflowContext(
             file_path="app.py",

--- a/tests/unit/mcp/test_safe_to_edit_tool.py
+++ b/tests/unit/mcp/test_safe_to_edit_tool.py
@@ -634,6 +634,43 @@ async def test_edit_safe_read_existing_consumes_published_snapshot(
     assert result["health_grade"]
 
 
+def test_certified_commands_use_extension_runner(tmp_path: Path) -> None:
+    """Codex P2 round-7 (C32): the certified runner is inferred from the
+    target extension, never forced to pytest."""
+    from tree_sitter_analyzer.mcp.tools.utils.safe_to_edit_helpers import (
+        AgentWorkflowContext,
+        build_agent_workflow,
+    )
+
+    go_workflow = build_agent_workflow(
+        AgentWorkflowContext(
+            file_path="handler.go",
+            risk="safe",
+            edit_type="refactor",
+            has_tests=True,
+            test_files=["handler_test.go"],
+            health_grade="A",
+            project_root=str(tmp_path),
+            certified=True,
+        )
+    )
+    assert "go test" in str(go_workflow.get("after_edit_commands", []))
+
+    py_workflow = build_agent_workflow(
+        AgentWorkflowContext(
+            file_path="app.py",
+            risk="safe",
+            edit_type="refactor",
+            has_tests=True,
+            test_files=["tests/test_app.py"],
+            health_grade="A",
+            project_root=str(tmp_path),
+            certified=True,
+        )
+    )
+    assert "uv run pytest" in str(py_workflow.get("after_edit_commands", []))
+
+
 def test_certified_commands_ignore_live_config_files(tmp_path: Path) -> None:
     """Codex P2 round-6 (C28): certified checklists/workflows use the
     analyzer's pytest default, never live non-inventoried config files."""

--- a/tests/unit/mcp/test_safe_to_edit_tool.py
+++ b/tests/unit/mcp/test_safe_to_edit_tool.py
@@ -584,6 +584,7 @@ def _publish_index_snapshot(project: Path, *, source_generation: str | None = No
     return REGISTRY.publish(snapshot, conn, 0)
 
 
+@pytest.mark.slow_ok  # real git + index_project + source capture: subprocess work
 @pytest.mark.skipif(
     sys.platform.startswith("win") or not os.path.exists("/dev/fd"),
     reason="tracked: RFC-0022 P0.4 source recapture needs POSIX /dev/fd",
@@ -630,6 +631,7 @@ async def test_edit_safe_read_existing_consumes_published_snapshot(
     assert result["health_grade"]
 
 
+@pytest.mark.slow_ok  # real git + index_project + source capture: subprocess work
 @pytest.mark.skipif(
     sys.platform.startswith("win") or not os.path.exists("/dev/fd"),
     reason="tracked: RFC-0022 P0.4 source recapture needs POSIX /dev/fd",

--- a/tests/unit/mcp/test_safe_to_edit_tool.py
+++ b/tests/unit/mcp/test_safe_to_edit_tool.py
@@ -673,6 +673,28 @@ def test_certified_commands_use_extension_runner(tmp_path: Path) -> None:
     assert "go test" not in str(java_workflow.get("after_edit_commands", []))
     # C41: the queue-boundary list stays empty, never [""].
     assert java_workflow.get("queue_boundary_commands") == []
+    # C49: no runner -> health/impact commands are never promoted to TEST
+    # verification, and the stop condition says verification is unidentified.
+    from tree_sitter_analyzer.mcp.tools.utils.safe_to_edit_helpers import (
+        build_agent_summary,
+    )
+
+    java_summary = build_agent_summary(
+        AgentWorkflowContext(
+            file_path="Calc.java",
+            risk="safe",
+            edit_type="refactor",
+            has_tests=True,
+            test_files=["CalcTest.java"],
+            health_grade="A",
+            project_root=str(tmp_path),
+            certified=True,
+        ),
+        java_workflow,
+        verdict_override=None,
+    )
+    assert java_summary.get("verification_command") == ""
+    assert "unidentified" in java_summary.get("stop_condition", "")
     # C41: the queue-boundary list stays empty, never [""].
     assert java_workflow.get("queue_boundary_commands") == []
 

--- a/tests/unit/mcp/test_safe_to_edit_tool.py
+++ b/tests/unit/mcp/test_safe_to_edit_tool.py
@@ -634,6 +634,58 @@ async def test_edit_safe_read_existing_consumes_published_snapshot(
     assert result["health_grade"]
 
 
+def test_certified_commands_ignore_live_config_files(tmp_path: Path) -> None:
+    """Codex P2 round-6 (C28): certified checklists/workflows use the
+    analyzer's pytest default, never live non-inventoried config files."""
+    from tree_sitter_analyzer.mcp.tools.utils.safe_to_edit_helpers import (
+        AgentWorkflowContext,
+        build_agent_workflow,
+    )
+    from tree_sitter_analyzer.mcp.tools.utils.safe_to_edit_risk import (
+        build_checklist,
+    )
+
+    (tmp_path / "package.json").write_text('{"scripts": {"test": "node test"}}')
+    live_workflow = build_agent_workflow(
+        AgentWorkflowContext(
+            file_path="app.py",
+            risk="safe",
+            edit_type="refactor",
+            has_tests=True,
+            test_files=["tests/test_app.py"],
+            health_grade="A",
+            project_root=str(tmp_path),
+        )
+    )
+    assert "npm test" in str(live_workflow.get("after_edit_commands", []))
+
+    certified_workflow = build_agent_workflow(
+        AgentWorkflowContext(
+            file_path="app.py",
+            risk="safe",
+            edit_type="refactor",
+            has_tests=True,
+            test_files=["tests/test_app.py"],
+            health_grade="A",
+            project_root=str(tmp_path),
+            certified=True,
+        )
+    )
+    assert "npm test" not in str(certified_workflow.get("after_edit_commands", []))
+    assert "uv run pytest" in str(certified_workflow.get("after_edit_commands", []))
+
+    certified_checklist = build_checklist(
+        "safe",
+        0,
+        False,
+        [],
+        "refactor",
+        project_root=str(tmp_path),
+        certified=True,
+    )
+    assert all("npm test" not in item for item in certified_checklist)
+
+
 def test_live_violations_query_degrades_on_corrupt_db_file(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/mcp/test_safe_to_edit_tool.py
+++ b/tests/unit/mcp/test_safe_to_edit_tool.py
@@ -1260,6 +1260,8 @@ def test_snapshot_dependency_view_recalls_member_imports() -> None:
     )
     # The target's OWN import row can also carry a BLOB (pass-1 skip).
     conn.execute("INSERT INTO edges VALUES ('app.py', ?, 'imports')", (b"blob-own",))
+    # C53: a BLOB importer path in pass 2 is skipped, not fatal.
+    conn.execute("INSERT INTO edges VALUES (?, 'app', 'imports')", (b"blob-path",))
     conn.execute("INSERT INTO edges VALUES ('app.py', 'app', 'imports')")
     # 'app.py' importing a module that does not index -> resolved is None.
     conn.execute("INSERT INTO edges VALUES ('app.py', 'missing.mod', 'imports')")

--- a/tests/unit/mcp/test_safe_to_edit_tool.py
+++ b/tests/unit/mcp/test_safe_to_edit_tool.py
@@ -634,6 +634,213 @@ async def test_edit_safe_read_existing_consumes_published_snapshot(
     assert result["health_grade"]
 
 
+def test_read_existing_payload_language_detection_degrades(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A detector failure on the snapshot route degrades to no language key.
+
+    Codex-review P3 (#1299): language detection is best-effort — an
+    exception must yield a language-less result, never a crash.
+    """
+    import sqlite3
+    from types import SimpleNamespace
+
+    import tree_sitter_analyzer.mcp.tools.safe_to_edit_tool as tool_module
+
+    target = tmp_path / "app.py"
+    target.write_text("x = 1\n", encoding="utf-8")
+    monkeypatch.setattr(
+        tool_module,
+        "_syntax_error_response",
+        lambda resolved, file_path, edit_type: None,
+    )
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("detector down")
+
+    monkeypatch.setattr(
+        "tree_sitter_analyzer.language_detector.detect_language_from_file", boom
+    )
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    tool = tool_module.SafeToEditTool(str(tmp_path))
+    result = tool._read_existing_payload(
+        {"file_path": "app.py", "edit_type": "refactor"},
+        str(target),
+        conn,
+        snapshot=SimpleNamespace(canonical_root=str(tmp_path)),
+    )
+    assert result["success"] is True
+    assert "language" not in result
+
+
+def test_snapshot_constraint_query_reads_from_given_conn() -> None:
+    """The conn variant returns rows and degrades to [] on a missing table."""
+    import sqlite3
+
+    from tree_sitter_analyzer.mcp.tools.utils.constraint_violation_query import (
+        violations_for_files_from_conn,
+    )
+
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE ast_constraint_violations ("
+        "rule_id TEXT NOT NULL, caller_file TEXT NOT NULL, "
+        "caller_name TEXT NOT NULL, caller_line INTEGER NOT NULL, "
+        "callee_name TEXT NOT NULL, callee_file TEXT NOT NULL DEFAULT '', "
+        "severity TEXT NOT NULL, detected_at INTEGER NOT NULL)"
+    )
+    conn.execute(
+        "INSERT INTO ast_constraint_violations VALUES "
+        "('R1', 'app.py', 'app', 1, 'secret', '', 'error', 1)"
+    )
+    rows = violations_for_files_from_conn(conn, ["app.py"])
+    assert rows == [
+        {
+            "rule_id": "R1",
+            "caller_file": "app.py",
+            "caller_name": "app",
+            "caller_line": 1,
+            "callee_name": "secret",
+            "callee_file": "",
+            "severity": "error",
+            "detected_at": 1,
+            "factor": "constraint_violation",
+        }
+    ]
+    assert violations_for_files_from_conn(conn, []) == []
+    bare = sqlite3.connect(":memory:")
+    assert violations_for_files_from_conn(bare, ["app.py"]) == []
+
+
+def test_format_result_reads_constraints_from_snapshot_conn(
+    tmp_path: Path,
+) -> None:
+    """Snapshot-mode formatting escalates verdict from the snapshot rows."""
+    import sqlite3
+    from types import SimpleNamespace
+
+    from tree_sitter_analyzer.mcp.tools.utils.safe_to_edit_helpers import (
+        SafeToEditContext,
+        SafeToEditFacts,
+        _format_safe_to_edit_result,
+    )
+
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE ast_constraint_violations ("
+        "rule_id TEXT NOT NULL, caller_file TEXT NOT NULL, "
+        "caller_name TEXT NOT NULL, caller_line INTEGER NOT NULL, "
+        "callee_name TEXT NOT NULL, callee_file TEXT NOT NULL DEFAULT '', "
+        "severity TEXT NOT NULL, detected_at INTEGER NOT NULL)"
+    )
+    conn.execute(
+        "INSERT INTO ast_constraint_violations VALUES "
+        "('R1', 'app.py', 'app', 1, 'secret', '', 'error', 1)"
+    )
+    health = SimpleNamespace(grade="A", total=95, dimensions={})
+    facts = SafeToEditFacts(
+        dependents=[],
+        dependencies=[],
+        health=health,
+        test_files=[],
+        has_tests=False,
+        risk="safe",
+        risk_factors=[],
+        pre_edit_checklist=[],
+    )
+    context = SafeToEditContext(
+        file_path="app.py",
+        edit_type="refactor",
+        resolved_path=str(tmp_path / "app.py"),
+        project_root=str(tmp_path),
+        graph=None,
+        scorer=None,
+        snapshot_conn=conn,
+    )
+    result = _format_safe_to_edit_result(context, facts)
+    assert result["verdict"] == "UNSAFE"
+    assert any(
+        factor.get("factor") == "constraint_violation"
+        for factor in result["risk_factors"]
+    )
+
+
+@pytest.mark.slow_ok  # real git + index_project + source capture: subprocess work
+@pytest.mark.skipif(
+    sys.platform.startswith("win") or not os.path.exists("/dev/fd"),
+    reason="tracked: RFC-0022 P0.4 source recapture needs POSIX /dev/fd",
+)
+@pytest.mark.asyncio
+async def test_edit_safe_read_existing_uses_snapshot_constraints_read_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Snapshot-mode facts come from the snapshot conn; fixture index never written.
+
+    Codex P1 (#1299): the certified route must derive constraint violations
+    from the immutable snapshot connection and must not create
+    ``.ast-cache/fixture_index.json`` (zero-write read).
+    """
+    import sqlite3
+
+    import tree_sitter_analyzer.read_existing_access as read_access
+    from tree_sitter_analyzer.index_snapshot import (
+        REGISTRY,
+        IndexSnapshot,
+        _capture_sources_with_deadline,
+    )
+    from tree_sitter_analyzer.index_source_scope import make_source_scope_descriptor
+
+    monkeypatch.setattr(read_access, "read_existing_platform_supported", lambda: True)
+    project = _indexed_project(tmp_path)
+    scope = make_source_scope_descriptor()
+    current = _capture_sources_with_deadline(str(project), scope, deadline=10**18)
+    assert current.state == "exact", current.reason
+    conn = sqlite3.connect(str(project / ".ast-cache" / "index.db"))
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        "INSERT INTO ast_constraint_violations VALUES "
+        "('R1', 'app.py', 'app', 1, 'secret', '', 'error', 1)"
+    )
+    conn.commit()
+    snapshot = IndexSnapshot(
+        None,
+        current.fingerprint,
+        "index-fp",
+        current.generation,
+        "complete",
+        None,
+        str(project.resolve()),
+        2,
+        None,
+        None,
+        scope,
+    )
+    published = REGISTRY.publish(snapshot, conn, 0)
+
+    tool = SafeToEditTool(str(project))
+    result = await tool.execute(
+        {
+            "file_path": "app.py",
+            "access_mode": "read_existing",
+            "snapshot_id": published.snapshot_id,
+            "source_generation": published.source_generation,
+            "output_format": "json",
+        }
+    )
+
+    assert result["success"] is True
+    assert result["access_state"] == "available"
+    # The error-severity snapshot row escalates the verdict above the base.
+    assert result["verdict"] == "UNSAFE"
+    assert any(
+        factor.get("factor") == "constraint_violation"
+        for factor in result["risk_factors"]
+    )
+    # Zero-write: the certified read never persisted a fixture index.
+    assert not (project / ".ast-cache" / "fixture_index.json").exists()
+
+
 @pytest.mark.slow_ok  # real git + index_project + source capture: subprocess work
 @pytest.mark.skipif(
     sys.platform.startswith("win") or not os.path.exists("/dev/fd"),

--- a/tests/unit/mcp/test_safe_to_edit_tool.py
+++ b/tests/unit/mcp/test_safe_to_edit_tool.py
@@ -893,7 +893,10 @@ async def test_edit_safe_read_existing_unindexed_target_fails_closed(
 
     monkeypatch.setattr(read_access, "read_existing_platform_supported", lambda: True)
     project = _indexed_project(tmp_path)
-    (project / ".hidden.py").write_text("x = 1\n", encoding="utf-8")
+    # Broken syntax on purpose (Codex P1 round-3): the inventory gate must
+    # run BEFORE the syntax probe, so a broken out-of-inventory file can
+    # never short-circuit into a syntax-error success envelope.
+    (project / ".hidden.py").write_text("def broken(:\n", encoding="utf-8")
     published = _publish_index_snapshot(project)
 
     tool = SafeToEditTool(str(project))
@@ -963,12 +966,15 @@ def test_snapshot_dependency_view_degrades_on_schema_drift() -> None:
 
     from tree_sitter_analyzer.mcp.tools.utils.safe_to_edit_helpers import (
         build_snapshot_file_dependency_view,
+        snapshot_inventory,
     )
 
     conn = sqlite3.connect(":memory:")
     view = build_snapshot_file_dependency_view(conn, "app.py")
     assert view.dependents_of("app.py") == []
     assert view.dependencies_of("app.py") == []
+    # An unreadable inventory degrades to the empty set (fail-closed).
+    assert snapshot_inventory(conn) == frozenset()
 
     # edges present but ast_index absent: exact resolution probes the missing
     # table and degrades to not-indexed.

--- a/tests/unit/mcp/test_safe_to_edit_tool.py
+++ b/tests/unit/mcp/test_safe_to_edit_tool.py
@@ -634,6 +634,36 @@ async def test_edit_safe_read_existing_consumes_published_snapshot(
     assert result["health_grade"]
 
 
+def test_live_violations_query_degrades_on_corrupt_db_file(
+    tmp_path: Path,
+) -> None:
+    """A non-SQLite index.db degrades to an empty violation list."""
+    from tree_sitter_analyzer.mcp.tools.utils.constraint_violation_query import (
+        violations_for_files,
+    )
+
+    (tmp_path / ".ast-cache").mkdir()
+    (tmp_path / ".ast-cache" / "index.db").write_text(
+        "not-a-sqlite-database", encoding="utf-8"
+    )
+    assert violations_for_files(str(tmp_path), ["app.py"]) == []
+
+
+def test_snapshot_dependency_view_degrades_on_closed_conn() -> None:
+    """An unreadable connection degrades to an empty view, never raises."""
+    import sqlite3
+
+    from tree_sitter_analyzer.mcp.tools.utils.safe_to_edit_helpers import (
+        build_snapshot_file_dependency_view,
+    )
+
+    conn = sqlite3.connect(":memory:")
+    conn.close()
+    view = build_snapshot_file_dependency_view(conn, "app.py")
+    assert view.dependents_of("app.py") == []
+    assert view.dependencies_of("app.py") == []
+
+
 def test_read_existing_payload_language_detection_degrades(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -663,6 +693,9 @@ def test_read_existing_payload_language_detection_degrades(
     )
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
+    # The FILE_NOT_INDEXED gate needs the target present in ast_index.
+    conn.execute("CREATE TABLE ast_index (file_path TEXT)")
+    conn.execute("INSERT INTO ast_index VALUES ('app.py')")
     tool = tool_module.SafeToEditTool(str(tmp_path))
     result = tool._read_existing_payload(
         {"file_path": "app.py", "edit_type": "refactor"},
@@ -847,6 +880,52 @@ async def test_edit_safe_read_existing_uses_snapshot_constraints_read_only(
     reason="tracked: RFC-0022 P0.4 source recapture needs POSIX /dev/fd",
 )
 @pytest.mark.asyncio
+async def test_edit_safe_read_existing_unindexed_target_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A target outside the snapshot inventory is never served uncertified.
+
+    Codex P1 (#1299): hidden/excluded files are not covered by the source
+    recaptures, so the certified route rejects them with FILE_NOT_INDEXED
+    instead of reading and scoring their live bytes.
+    """
+    import tree_sitter_analyzer.read_existing_access as read_access
+
+    monkeypatch.setattr(read_access, "read_existing_platform_supported", lambda: True)
+    project = _indexed_project(tmp_path)
+    (project / ".hidden.py").write_text("x = 1\n", encoding="utf-8")
+    published = _publish_index_snapshot(project)
+
+    tool = SafeToEditTool(str(project))
+    result = await tool.execute(
+        {
+            "file_path": ".hidden.py",
+            "access_mode": "read_existing",
+            "snapshot_id": published.snapshot_id,
+            "source_generation": published.source_generation,
+            "output_format": "json",
+        }
+    )
+
+    assert result["success"] is False
+    assert result["error_code"] == "FILE_NOT_INDEXED"
+    assert result["access_reason"] == "FILE_NOT_INDEXED"
+    assert result["action_version"] == "edit.safe/v1"
+    assert result["source_snapshots"] == [
+        {
+            "kind": "index",
+            "snapshot_id": published.snapshot_id,
+            "source_generation": published.source_generation,
+        }
+    ]
+
+
+@pytest.mark.slow_ok  # real git + index_project + source capture: subprocess work
+@pytest.mark.skipif(
+    sys.platform.startswith("win") or not os.path.exists("/dev/fd"),
+    reason="tracked: RFC-0022 P0.4 source recapture needs POSIX /dev/fd",
+)
+@pytest.mark.asyncio
 async def test_edit_safe_read_existing_generation_mismatch_fails_closed(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -897,6 +976,21 @@ def test_snapshot_dependency_view_degrades_on_schema_drift() -> None:
     conn.execute("INSERT INTO edges VALUES ('routes.py', 'app', 'imports')")
     partial = build_snapshot_file_dependency_view(conn, "app.py")
     assert partial.dependents_of("app.py") == []
+
+    # Codex P2 (#1299): a current-version but damaged edges table (present,
+    # missing the callee_name column this reader selects) fails the route
+    # instead of silently degrading to an empty view (which would undercount
+    # risk).
+    import pytest
+
+    damaged = sqlite3.connect(":memory:")
+    damaged.row_factory = sqlite3.Row
+    damaged.execute(
+        "CREATE TABLE edges (source_node_id TEXT, target_node_id TEXT, "
+        "kind TEXT, file_path TEXT)"
+    )
+    with pytest.raises(ValueError, match="CORRUPT_INDEX"):
+        build_snapshot_file_dependency_view(damaged, "app.py")
 
 
 # RFC-0022 P0.4: the snapshot dependency view resolves exact IMPORTS edges

--- a/tests/unit/mcp/test_safe_to_edit_tool.py
+++ b/tests/unit/mcp/test_safe_to_edit_tool.py
@@ -1,6 +1,7 @@
 """Unit tests for SafeToEditTool."""
 
 import asyncio
+import os
 import sys
 from pathlib import Path
 
@@ -584,8 +585,8 @@ def _publish_index_snapshot(project: Path, *, source_generation: str | None = No
 
 
 @pytest.mark.skipif(
-    sys.platform.startswith("win"),
-    reason="tracked: RFC-0022 P0.4 source recapture is POSIX-only (no /dev/fd)",
+    sys.platform.startswith("win") or not os.path.exists("/dev/fd"),
+    reason="tracked: RFC-0022 P0.4 source recapture needs POSIX /dev/fd",
 )
 @pytest.mark.asyncio
 async def test_edit_safe_read_existing_consumes_published_snapshot(
@@ -630,8 +631,8 @@ async def test_edit_safe_read_existing_consumes_published_snapshot(
 
 
 @pytest.mark.skipif(
-    sys.platform.startswith("win"),
-    reason="tracked: RFC-0022 P0.4 source recapture is POSIX-only (no /dev/fd)",
+    sys.platform.startswith("win") or not os.path.exists("/dev/fd"),
+    reason="tracked: RFC-0022 P0.4 source recapture needs POSIX /dev/fd",
 )
 @pytest.mark.asyncio
 async def test_edit_safe_read_existing_generation_mismatch_fails_closed(

--- a/tests/unit/mcp/test_safe_to_edit_tool.py
+++ b/tests/unit/mcp/test_safe_to_edit_tool.py
@@ -1,6 +1,7 @@
 """Unit tests for SafeToEditTool."""
 
 import asyncio
+import sys
 from pathlib import Path
 
 import pytest
@@ -582,6 +583,10 @@ def _publish_index_snapshot(project: Path, *, source_generation: str | None = No
     return REGISTRY.publish(snapshot, conn, 0)
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="tracked: RFC-0022 P0.4 source recapture is POSIX-only (no /dev/fd)",
+)
 @pytest.mark.asyncio
 async def test_edit_safe_read_existing_consumes_published_snapshot(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -624,6 +629,10 @@ async def test_edit_safe_read_existing_consumes_published_snapshot(
     assert result["health_grade"]
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="tracked: RFC-0022 P0.4 source recapture is POSIX-only (no /dev/fd)",
+)
 @pytest.mark.asyncio
 async def test_edit_safe_read_existing_generation_mismatch_fails_closed(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/mcp/test_safe_to_edit_tool.py
+++ b/tests/unit/mcp/test_safe_to_edit_tool.py
@@ -698,7 +698,8 @@ def test_certified_commands_use_extension_runner(tmp_path: Path) -> None:
             certified=True,
         )
     )
-    assert "npm test" in str(js_workflow.get("after_edit_commands", []))
+    # C39: JS/TS npm-vs-pnpm-vs-Yarn cannot be distinguished snapshot-bound.
+    assert "npm test" not in str(js_workflow.get("after_edit_commands", []))
 
     py_workflow = build_agent_workflow(
         AgentWorkflowContext(
@@ -765,6 +766,50 @@ def test_certified_commands_ignore_live_config_files(tmp_path: Path) -> None:
         certified=True,
     )
     assert all("npm test" not in item for item in certified_checklist)
+
+    # C35: ambiguous ecosystem + no tests -> the checklist omits the
+    # command items entirely instead of advertising an unverifiable runner.
+    no_command = build_checklist(
+        "safe",
+        0,
+        False,
+        [],
+        "refactor",
+        file_path="Calc.java",
+        project_root=str(tmp_path),
+        certified=True,
+    )
+    assert all("command" not in item.lower() for item in no_command)
+
+    # C35: ambiguous ecosystem + tests -> the test items still appear,
+    # but without an advertised command.
+    java_tests = build_checklist(
+        "safe",
+        0,
+        True,
+        ["CalcTest.java"],
+        "refactor",
+        file_path="Calc.java",
+        project_root=str(tmp_path),
+        certified=True,
+    )
+    assert any("Run existing tests FIRST" in item for item in java_tests)
+    assert all(
+        "java" not in item.lower() and "mvn" not in item.lower() for item in java_tests
+    )
+
+    # Certified python + tests -> the pytest command items are present.
+    py_tests = build_checklist(
+        "safe",
+        0,
+        True,
+        ["tests/test_app.py"],
+        "refactor",
+        file_path="app.py",
+        project_root=str(tmp_path),
+        certified=True,
+    )
+    assert any("uv run pytest" in item for item in py_tests)
 
 
 def test_live_violations_query_degrades_on_corrupt_db_file(
@@ -1207,10 +1252,18 @@ def test_snapshot_dependency_view_recalls_member_imports() -> None:
         (json.dumps([{"text": "import os", "line": 1}]),),
     )
     conn.execute("INSERT INTO ast_index VALUES ('broken.py', 'not-json')")
+    # C40: a valid-JSON non-array cell (42) must be skipped per row, NOT
+    # abort the whole needle pass — the later matching row still counts.
+    conn.execute("INSERT INTO ast_index VALUES ('scalar.py', '42')")
+    conn.execute(
+        "INSERT INTO ast_index VALUES ('later.py', ?)",
+        (json.dumps([{"text": "from app import Member", "line": 1}]),),
+    )
     view = build_snapshot_file_dependency_view(conn, "app.py")
     # 'routes.py' matches the needle pass; 'unrelated.py' exercises the
-    # non-match branch (no dependent added).
-    assert view.dependents_of("app.py") == ["routes.py"]
+    # non-match branch (no dependent added); 'later.py' proves the pass
+    # survived the malformed 'scalar.py' row.
+    assert view.dependents_of("app.py") == ["later.py", "routes.py"]
 
 
 @pytest.mark.slow_ok  # real git + index_project + source capture: subprocess work

--- a/tests/unit/mcp/test_test_discovery.py
+++ b/tests/unit/mcp/test_test_discovery.py
@@ -720,6 +720,139 @@ def test_certified_test_files_cross_language_conventions(
     assert found == expected
 
 
+def test_certified_symbol_reference_tests_find_imported_symbols() -> None:
+    """Codex P2 round-7 (C31): tests using the target's public symbols are
+    found through snapshot-owned import records, not only path dependents."""
+    import json
+    import sqlite3
+
+    from tree_sitter_analyzer.mcp.tools.utils.safe_to_edit_helpers import (
+        _certified_symbol_reference_tests,
+    )
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        "CREATE TABLE ast_index (file_path TEXT, symbols_json TEXT, imports_json TEXT)"
+    )
+    conn.execute(
+        "INSERT INTO ast_index VALUES ('pkg/impl.py', ?, '[]')",
+        (
+            json.dumps(
+                {
+                    "symbols": [{"kind": "function", "name": "public_fn", "line": 1}],
+                    "node_count": 1,
+                }
+            ),
+        ),
+    )
+    conn.execute(
+        "INSERT INTO ast_index VALUES ('tests/test_behavior.py', '{}', ?)",
+        (json.dumps([{"text": "from pkg import public_fn", "line": 1}]),),
+    )
+    conn.execute(
+        "INSERT INTO ast_index VALUES ('tests/test_unrelated.py', '{}', ?)",
+        (json.dumps([{"text": "import os", "line": 1}]),),
+    )
+    inventory = frozenset(
+        {"pkg/impl.py", "tests/test_behavior.py", "tests/test_unrelated.py"}
+    )
+    found = _certified_symbol_reference_tests(conn, inventory, "pkg/impl.py", "python")
+    assert found == ["tests/test_behavior.py"]
+
+    # Legacy schema (no ast_index) degrades to no matches.
+    bare = sqlite3.connect(":memory:")
+    bare.row_factory = sqlite3.Row
+    assert (
+        _certified_symbol_reference_tests(bare, frozenset(), "pkg/impl.py", "python")
+        == []
+    )
+    # Malformed symbols_json degrades to no matches.
+    broken = sqlite3.connect(":memory:")
+    broken.row_factory = sqlite3.Row
+    broken.execute(
+        "CREATE TABLE ast_index (file_path TEXT, symbols_json TEXT, imports_json TEXT)"
+    )
+    broken.execute("INSERT INTO ast_index VALUES ('pkg/impl.py', 'not-json', '[]')")
+    assert (
+        _certified_symbol_reference_tests(
+            broken, frozenset({"pkg/impl.py"}), "pkg/impl.py", "python"
+        )
+        == []
+    )
+    # No public symbols -> no matches.
+    private = sqlite3.connect(":memory:")
+    private.row_factory = sqlite3.Row
+    private.execute(
+        "CREATE TABLE ast_index (file_path TEXT, symbols_json TEXT, imports_json TEXT)"
+    )
+    private.execute(
+        "INSERT INTO ast_index VALUES ('pkg/impl.py', ?, '[]')",
+        (json.dumps({"symbols": [{"name": "_hidden"}]}),),
+    )
+    assert (
+        _certified_symbol_reference_tests(
+            private, frozenset({"pkg/impl.py"}), "pkg/impl.py", "python"
+        )
+        == []
+    )
+    # Target row absent from ast_index -> no matches.
+    no_target = sqlite3.connect(":memory:")
+    no_target.row_factory = sqlite3.Row
+    no_target.execute(
+        "CREATE TABLE ast_index (file_path TEXT, symbols_json TEXT, imports_json TEXT)"
+    )
+    no_target.execute("INSERT INTO ast_index VALUES ('other.py', '{}', '[]')")
+    assert (
+        _certified_symbol_reference_tests(
+            no_target, frozenset({"tests/test_x.py"}), "pkg/impl.py", "python"
+        )
+        == []
+    )
+
+    # A mid-loop query failure (schema drift) degrades per row.
+    class _FlakyConn:
+        def __init__(self, real):
+            self._real = real
+            self._calls = 0
+
+        def execute(self, sql, params=()):
+            self._calls += 1
+            if self._calls == 2:
+                raise sqlite3.OperationalError("no such table: ast_index")
+            return self._real.execute(sql, params)
+
+    flaky_conn = _FlakyConn(conn)
+    flaky_inventory = frozenset(
+        {"pkg/impl.py", "tests/test_behavior.py", "tests/test_unrelated.py"}
+    )
+    assert (
+        _certified_symbol_reference_tests(
+            flaky_conn, flaky_inventory, "pkg/impl.py", "python"
+        )
+        == []
+    )
+    # A test-named inventory file absent from ast_index is skipped.
+    missing = sqlite3.connect(":memory:")
+    missing.row_factory = sqlite3.Row
+    missing.execute(
+        "CREATE TABLE ast_index (file_path TEXT, symbols_json TEXT, imports_json TEXT)"
+    )
+    missing.execute(
+        "INSERT INTO ast_index VALUES ('pkg/impl.py', ?, '[]')",
+        (json.dumps({"symbols": [{"name": "public_fn"}]}),),
+    )
+    assert (
+        _certified_symbol_reference_tests(
+            missing,
+            frozenset({"pkg/impl.py", "tests/test_ghost.py"}),
+            "pkg/impl.py",
+            "python",
+        )
+        == []
+    )
+
+
 def test_looks_like_test_name_unknown_language_is_false() -> None:
     """An unknown language is never treated as a test-name convention."""
     from tree_sitter_analyzer.mcp.tools.utils.safe_to_edit_helpers import (

--- a/tests/unit/mcp/test_test_discovery.py
+++ b/tests/unit/mcp/test_test_discovery.py
@@ -714,3 +714,15 @@ def test_certified_test_files_walk_inventory_only() -> None:
 
     # No inventory-covered test for the target -> empty.
     assert _certified_test_files(frozenset({"src/app.py"}), "src/app.py") == []
+
+    # Glob patterns (test_{stem}_*.py) match conventional suffixed tests.
+    globbed = _certified_test_files(
+        frozenset({"tests/test_app_behavior.py", "src/app.py"}), "src/app.py"
+    )
+    assert globbed == ["tests/test_app_behavior.py"]
+
+    # Go's co-located convention (test_dirs=["."]) accepts inventory paths.
+    go_tests = _certified_test_files(
+        frozenset({"handler.go", "handler_test.go"}), "handler.go"
+    )
+    assert go_tests == ["handler_test.go"]

--- a/tests/unit/mcp/test_test_discovery.py
+++ b/tests/unit/mcp/test_test_discovery.py
@@ -688,3 +688,29 @@ class TestFindTestFilesJavascript:
 
             results = find_test_files(str(source), tmp)
             assert any("utils.test.js" in r for r in results)
+
+
+def test_certified_test_files_walk_inventory_only() -> None:
+    """Codex P1 (#1299 round-3/4): certified discovery walks the inventory."""
+    from tree_sitter_analyzer.mcp.tools.utils.safe_to_edit_helpers import (
+        _certified_test_files,
+    )
+
+    inventory = frozenset(
+        {
+            "src/app.py",
+            "tests/test_app.py",
+            "tests/test_other.py",
+            "tests/unit/test_app.py",  # nested indexed test counts
+            "src/test_app.py",  # colocated with the target
+        }
+    )
+    found = _certified_test_files(inventory, "src/app.py")
+    assert found == [
+        "tests/test_app.py",
+        "tests/unit/test_app.py",
+        "src/test_app.py",
+    ]
+
+    # No inventory-covered test for the target -> empty.
+    assert _certified_test_files(frozenset({"src/app.py"}), "src/app.py") == []

--- a/tests/unit/mcp/test_test_discovery.py
+++ b/tests/unit/mcp/test_test_discovery.py
@@ -932,6 +932,87 @@ def test_certified_symbol_reference_tests_find_imported_symbols() -> None:
     )
     assert drifted == ["tests/test_calls.py"]
 
+    # C56: 'from other import run' must not count for pkg/impl.py when
+    # other.py itself defines 'run'.
+    bound = sqlite3.connect(":memory:")
+    bound.row_factory = sqlite3.Row
+    bound.execute(
+        "CREATE TABLE ast_index (file_path TEXT, symbols_json TEXT, imports_json TEXT)"
+    )
+    bound.execute(
+        "INSERT INTO ast_index VALUES ('pkg/impl.py', ?, '[]')",
+        (json.dumps({"symbols": [{"name": "run"}]}),),
+    )
+    bound.execute(
+        "INSERT INTO ast_index VALUES ('other.py', ?, '[]')",
+        (json.dumps({"symbols": [{"name": "run"}]}),),
+    )
+    bound.execute(
+        "INSERT INTO ast_index VALUES ('tests/test_other.py', '{}', ?)",
+        (json.dumps([{"text": "from other import run", "line": 1}]),),
+    )
+    bound.execute(
+        "INSERT INTO ast_index VALUES ('tests/test_pkg.py', '{}', ?)",
+        (json.dumps([{"text": "from pkg import run", "line": 1}]),),
+    )
+    bound.execute("INSERT INTO ast_index VALUES ('pkg/__init__.py', '{}', '[]')")
+    bound_inventory = frozenset(
+        {
+            "pkg/impl.py",
+            "other.py",
+            "pkg/__init__.py",
+            "tests/test_other.py",
+            "tests/test_pkg.py",
+        }
+    )
+    bound_found = _certified_symbol_reference_tests(
+        bound, bound_inventory, "pkg/impl.py", "python"
+    )
+    # 'from other import run' is rejected (other.py defines run); the
+    # package-level import through pkg/__init__.py is accepted.
+    assert bound_found == ["tests/test_pkg.py"]
+
+    # _file_defines_any direct branch coverage.
+    from tree_sitter_analyzer.mcp.tools.utils.safe_to_edit_helpers import (
+        _file_defines_any,
+    )
+
+    defs = sqlite3.connect(":memory:")
+    defs.row_factory = sqlite3.Row
+    defs.execute("CREATE TABLE ast_index (file_path TEXT, symbols_json TEXT)")
+    defs.execute(
+        "INSERT INTO ast_index VALUES ('ok.py', ?)",
+        (json.dumps({"symbols": [{"name": "run"}]}),),
+    )
+    defs.execute("INSERT INTO ast_index VALUES ('malformed.py', 'not-json')")
+    defs.execute("INSERT INTO ast_index VALUES ('array.py', '[]')")
+    assert _file_defines_any(defs, "ok.py", ["run"]) is True
+    assert _file_defines_any(defs, "ok.py", ["nope"]) is False
+    assert _file_defines_any(defs, "malformed.py", ["run"]) is False
+    assert _file_defines_any(defs, "array.py", ["run"]) is False
+    assert _file_defines_any(defs, "ghost.py", ["run"]) is False
+    bare = sqlite3.connect(":memory:")
+    assert _file_defines_any(bare, "ghost.py", ["run"]) is False
+
+    # C56: 'import run' and a bare 'run' record still accept via the
+    # no-module / import-module paths.
+    bound.execute(
+        "INSERT INTO ast_index VALUES ('tests/test_plain.py', '{}', ?)",
+        (json.dumps([{"text": "import run", "line": 1}]),),
+    )
+    bound.execute(
+        "INSERT INTO ast_index VALUES ('tests/test_bare.py', '{}', ?)",
+        (json.dumps([{"text": "run", "line": 1}]),),
+    )
+    plain_inventory = bound_inventory | frozenset(
+        {"tests/test_plain.py", "tests/test_bare.py"}
+    )
+    plain_found = _certified_symbol_reference_tests(
+        bound, plain_inventory, "pkg/impl.py", "python"
+    )
+    assert "tests/test_plain.py" in plain_found
+    assert "tests/test_bare.py" in plain_found
+
     # C34: a non-object symbols_json payload degrades, never crashes.
     array_payload = sqlite3.connect(":memory:")
     array_payload.row_factory = sqlite3.Row
@@ -1058,3 +1139,10 @@ def test_certified_test_files_walk_inventory_only() -> None:
         dependents=["tests/test_routes.py"],
     )
     assert dep_tests == ["tests/test_app.py", "tests/test_routes.py"]
+    # C54: a dependent outside the inventory is never a certified test.
+    outside_dep = _certified_test_files(
+        frozenset({"src/app.py", "tests/test_app.py"}),
+        "src/app.py",
+        dependents=["tests/test_routes.py"],
+    )
+    assert outside_dep == ["tests/test_app.py"]

--- a/tests/unit/mcp/test_test_discovery.py
+++ b/tests/unit/mcp/test_test_discovery.py
@@ -895,6 +895,26 @@ def test_certified_symbol_reference_tests_find_imported_symbols() -> None:
         )
         == []
     )
+    # C42: snapshot CALL references find tests using pkg.public_fn().
+    calls = sqlite3.connect(":memory:")
+    calls.row_factory = sqlite3.Row
+    calls.execute(
+        "CREATE TABLE ast_index (file_path TEXT, symbols_json TEXT, imports_json TEXT)"
+    )
+    calls.execute(
+        "INSERT INTO ast_index VALUES ('pkg/impl.py', ?, '[]')",
+        (json.dumps({"symbols": [{"name": "public_fn"}]}),),
+    )
+    calls.execute("CREATE TABLE edges (file_path TEXT, callee_name TEXT, kind TEXT)")
+    calls.execute(
+        "INSERT INTO edges VALUES ('tests/test_calls.py', 'public_fn', 'calls')"
+    )
+    calls_inventory = frozenset({"pkg/impl.py", "tests/test_calls.py"})
+    found_calls = _certified_symbol_reference_tests(
+        calls, calls_inventory, "pkg/impl.py", "python"
+    )
+    assert found_calls == ["tests/test_calls.py"]
+
     # C34: a non-object symbols_json payload degrades, never crashes.
     array_payload = sqlite3.connect(":memory:")
     array_payload.row_factory = sqlite3.Row

--- a/tests/unit/mcp/test_test_discovery.py
+++ b/tests/unit/mcp/test_test_discovery.py
@@ -1081,6 +1081,12 @@ def test_looks_like_test_name_unknown_language_is_false() -> None:
     assert _looks_like_test_name("test_x.py", "futurelang") is False
     assert _looks_like_test_name("test_x.py", "python") is True
     assert _looks_like_test_name("app.py", "python") is False
+    # C63: JSX/TSX spec conventions count.
+    assert _looks_like_test_name("component.spec.jsx", "javascript") is True
+    assert _looks_like_test_name("component.spec.tsx", "typescript") is True
+    # C63: JSX/TSX spec conventions count.
+    assert _looks_like_test_name("component.spec.jsx", "javascript") is True
+    assert _looks_like_test_name("component.spec.tsx", "typescript") is True
 
 
 def test_certified_test_files_rejects_non_test_target() -> None:

--- a/tests/unit/mcp/test_test_discovery.py
+++ b/tests/unit/mcp/test_test_discovery.py
@@ -4,6 +4,8 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 from tree_sitter_analyzer.mcp.tools.utils.test_discovery import (
     detect_language_from_ext,
     find_test_files,
@@ -690,6 +692,54 @@ class TestFindTestFilesJavascript:
             assert any("utils.test.js" in r for r in results)
 
 
+@pytest.mark.parametrize(
+    ("target", "expected"),
+    [
+        ("handler_test.go", ["handler_test.go"]),
+        ("lib_test.rs", ["lib_test.rs"]),
+        ("CalcTest.java", ["CalcTest.java"]),
+        ("app.test.js", ["app.test.js"]),
+        ("app.test.ts", ["app.test.ts"]),
+        ("test_util.c", ["test_util.c"]),
+        ("test_util.cpp", ["test_util.cpp"]),
+        ("CalcTest.cs", ["CalcTest.cs"]),
+        ("CalcTest.kt", ["CalcTest.kt"]),
+        ("calc_test.rb", ["calc_test.rb"]),
+        ("CalcTest.php", ["CalcTest.php"]),
+    ],
+)
+def test_certified_test_files_cross_language_conventions(
+    target: str, expected: list[str]
+) -> None:
+    """Round-6 (C27): a test-named target counts in every language."""
+    from tree_sitter_analyzer.mcp.tools.utils.safe_to_edit_helpers import (
+        _certified_test_files,
+    )
+
+    found = _certified_test_files(frozenset({target}), target)
+    assert found == expected
+
+
+def test_looks_like_test_name_unknown_language_is_false() -> None:
+    """An unknown language is never treated as a test-name convention."""
+    from tree_sitter_analyzer.mcp.tools.utils.safe_to_edit_helpers import (
+        _looks_like_test_name,
+    )
+
+    assert _looks_like_test_name("test_x.py", "futurelang") is False
+    assert _looks_like_test_name("test_x.py", "python") is True
+    assert _looks_like_test_name("app.py", "python") is False
+
+
+def test_certified_test_files_rejects_non_test_target() -> None:
+    """A non-test target is not its own test file."""
+    from tree_sitter_analyzer.mcp.tools.utils.safe_to_edit_helpers import (
+        _certified_test_files,
+    )
+
+    assert _certified_test_files(frozenset({"app.py"}), "app.py") == []
+
+
 def test_certified_test_files_walk_inventory_only() -> None:
     """Codex P1 (#1299 round-3/4): certified discovery walks the inventory."""
     from tree_sitter_analyzer.mcp.tools.utils.safe_to_edit_helpers import (
@@ -726,3 +776,17 @@ def test_certified_test_files_walk_inventory_only() -> None:
         frozenset({"handler.go", "handler_test.go"}), "handler.go"
     )
     assert go_tests == ["handler_test.go"]
+
+    # Round-6 (C27): a target that is itself a test file counts, and
+    # inventory-covered dependents matching the test patterns count
+    # (symbol-reference mode over certified inputs).
+    self_test = _certified_test_files(
+        frozenset({"tests/test_app.py", "src/app.py"}), "tests/test_app.py"
+    )
+    assert self_test == ["tests/test_app.py"]
+    dep_tests = _certified_test_files(
+        frozenset({"src/app.py", "tests/test_app.py", "tests/test_routes.py"}),
+        "src/app.py",
+        dependents=["tests/test_routes.py"],
+    )
+    assert dep_tests == ["tests/test_app.py", "tests/test_routes.py"]

--- a/tests/unit/mcp/test_test_discovery.py
+++ b/tests/unit/mcp/test_test_discovery.py
@@ -905,15 +905,32 @@ def test_certified_symbol_reference_tests_find_imported_symbols() -> None:
         "INSERT INTO ast_index VALUES ('pkg/impl.py', ?, '[]')",
         (json.dumps({"symbols": [{"name": "public_fn"}]}),),
     )
-    calls.execute("CREATE TABLE edges (file_path TEXT, callee_name TEXT, kind TEXT)")
     calls.execute(
-        "INSERT INTO edges VALUES ('tests/test_calls.py', 'public_fn', 'calls')"
+        "CREATE TABLE edges (file_path TEXT, callee_name TEXT, kind TEXT, "
+        "callee_resolved_file TEXT)"
+    )
+    calls.execute(
+        "INSERT INTO edges VALUES "
+        "('tests/test_calls.py', 'public_fn', 'calls', 'pkg/impl.py')"
     )
     calls_inventory = frozenset({"pkg/impl.py", "tests/test_calls.py"})
     found_calls = _certified_symbol_reference_tests(
         calls, calls_inventory, "pkg/impl.py", "python"
     )
     assert found_calls == ["tests/test_calls.py"]
+    # C48: a same-named symbol resolved to ANOTHER file must not attribute
+    # its calls to this target.
+    calls.execute(
+        "INSERT INTO edges VALUES "
+        "('tests/test_other.py', 'public_fn', 'calls', 'pkg/other.py')"
+    )
+    drift_inventory = frozenset(
+        {"pkg/impl.py", "tests/test_calls.py", "tests/test_other.py"}
+    )
+    drifted = _certified_symbol_reference_tests(
+        calls, drift_inventory, "pkg/impl.py", "python"
+    )
+    assert drifted == ["tests/test_calls.py"]
 
     # C34: a non-object symbols_json payload degrades, never crashes.
     array_payload = sqlite3.connect(":memory:")
@@ -993,6 +1010,12 @@ def test_certified_test_files_walk_inventory_only() -> None:
 
     # No inventory-covered test for the target -> empty.
     assert _certified_test_files(frozenset({"src/app.py"}), "src/app.py") == []
+
+    # C47: a root-level target's colocated test matches the normalized key.
+    root_colocated = _certified_test_files(
+        frozenset({"app.py", "test_app.py"}), "app.py"
+    )
+    assert root_colocated == ["test_app.py"]
 
     # Glob patterns (test_{stem}_*.py) match conventional suffixed tests.
     globbed = _certified_test_files(

--- a/tests/unit/mcp/test_test_discovery.py
+++ b/tests/unit/mcp/test_test_discovery.py
@@ -1013,6 +1013,31 @@ def test_certified_symbol_reference_tests_find_imported_symbols() -> None:
     assert "tests/test_plain.py" in plain_found
     assert "tests/test_bare.py" in plain_found
 
+    # C58: a relative import resolves from the TEST's directory — a test
+    # doing 'from .other import run' must not count for pkg/impl.py.
+    rel_bound = sqlite3.connect(":memory:")
+    rel_bound.row_factory = sqlite3.Row
+    rel_bound.execute(
+        "CREATE TABLE ast_index (file_path TEXT, symbols_json TEXT, imports_json TEXT)"
+    )
+    rel_bound.execute(
+        "INSERT INTO ast_index VALUES ('pkg/impl.py', ?, '[]')",
+        (json.dumps({"symbols": [{"name": "run"}]}),),
+    )
+    rel_bound.execute(
+        "INSERT INTO ast_index VALUES ('tests/other.py', ?, '[]')",
+        (json.dumps({"symbols": [{"name": "run"}]}),),
+    )
+    rel_bound.execute(
+        "INSERT INTO ast_index VALUES ('tests/test_other.py', '{}', ?)",
+        (json.dumps([{"text": "from .other import run", "line": 1}]),),
+    )
+    rel_inventory = frozenset({"pkg/impl.py", "tests/other.py", "tests/test_other.py"})
+    rel_found = _certified_symbol_reference_tests(
+        rel_bound, rel_inventory, "pkg/impl.py", "python"
+    )
+    assert rel_found == []
+
     # C34: a non-object symbols_json payload degrades, never crashes.
     array_payload = sqlite3.connect(":memory:")
     array_payload.row_factory = sqlite3.Row

--- a/tests/unit/mcp/test_test_discovery.py
+++ b/tests/unit/mcp/test_test_discovery.py
@@ -832,6 +832,82 @@ def test_certified_symbol_reference_tests_find_imported_symbols() -> None:
         )
         == []
     )
+    # C33: symbols match import IDENTIFIERS with word boundaries, never
+    # serialized substrings or JSON keys ('text' must not match every
+    # record's "text" key; 'get' must not match 'widget').
+    false_pos = sqlite3.connect(":memory:")
+    false_pos.row_factory = sqlite3.Row
+    false_pos.execute(
+        "CREATE TABLE ast_index (file_path TEXT, symbols_json TEXT, imports_json TEXT)"
+    )
+    false_pos.execute(
+        "INSERT INTO ast_index VALUES ('text.py', ?, '[]')",
+        (json.dumps({"symbols": [{"name": "text"}, {"name": "get"}]}),),
+    )
+    false_pos.execute(
+        "INSERT INTO ast_index VALUES ('tests/test_any.py', '{}', ?)",
+        (json.dumps([{"text": "import widget", "line": 1}]),),
+    )
+    false_pos_inventory = frozenset({"text.py", "tests/test_any.py"})
+    assert (
+        _certified_symbol_reference_tests(
+            false_pos, false_pos_inventory, "text.py", "python"
+        )
+        == []
+    )
+    # C33: malformed/non-list/non-str import records are skipped.
+    messy = sqlite3.connect(":memory:")
+    messy.row_factory = sqlite3.Row
+    messy.execute(
+        "CREATE TABLE ast_index (file_path TEXT, symbols_json TEXT, imports_json TEXT)"
+    )
+    messy.execute(
+        "INSERT INTO ast_index VALUES ('pkg/impl.py', ?, '[]')",
+        (json.dumps({"symbols": [{"name": "public_fn"}]}),),
+    )
+    messy.execute(
+        "INSERT INTO ast_index VALUES ('tests/test_messy.py', '{}', 'not-json')"
+    )
+    messy.execute(
+        "INSERT INTO ast_index VALUES ('tests/test_list.py', '{}', ?)",
+        (json.dumps(["just-a-string"]),),
+    )
+    messy.execute(
+        "INSERT INTO ast_index VALUES ('tests/test_num.py', '{}', ?)",
+        (json.dumps([{"text": 42}]),),
+    )
+    messy.execute(
+        "INSERT INTO ast_index VALUES ('tests/test_obj.py', '{}', ?)",
+        (json.dumps({"not": "a list"}),),
+    )
+    messy_inventory = frozenset(
+        {
+            "pkg/impl.py",
+            "tests/test_messy.py",
+            "tests/test_list.py",
+            "tests/test_num.py",
+            "tests/test_obj.py",
+        }
+    )
+    assert (
+        _certified_symbol_reference_tests(
+            messy, messy_inventory, "pkg/impl.py", "python"
+        )
+        == []
+    )
+    # C34: a non-object symbols_json payload degrades, never crashes.
+    array_payload = sqlite3.connect(":memory:")
+    array_payload.row_factory = sqlite3.Row
+    array_payload.execute(
+        "CREATE TABLE ast_index (file_path TEXT, symbols_json TEXT, imports_json TEXT)"
+    )
+    array_payload.execute("INSERT INTO ast_index VALUES ('pkg/impl.py', '[]', '[]')")
+    assert (
+        _certified_symbol_reference_tests(
+            array_payload, frozenset({"pkg/impl.py"}), "pkg/impl.py", "python"
+        )
+        == []
+    )
     # A test-named inventory file absent from ast_index is skipped.
     missing = sqlite3.connect(":memory:")
     missing.row_factory = sqlite3.Row
@@ -909,6 +985,22 @@ def test_certified_test_files_walk_inventory_only() -> None:
         frozenset({"handler.go", "handler_test.go"}), "handler.go"
     )
     assert go_tests == ["handler_test.go"]
+
+    # Round-8 (C36): package-family tests (test_<plugin>.py) match.
+    package_tests = _certified_test_files(
+        frozenset(
+            {
+                "languages/python_plugin/extract.py",
+                "tests/test_python_plugin.py",
+                "tests/test_python_plugin_behavior.py",
+            }
+        ),
+        "languages/python_plugin/extract.py",
+    )
+    assert package_tests == [
+        "tests/test_python_plugin.py",
+        "tests/test_python_plugin_behavior.py",
+    ]
 
     # Round-6 (C27): a target that is itself a test file counts, and
     # inventory-covered dependents matching the test patterns count

--- a/tests/unit/mcp/tools/test_edit_facade_snapshot_routes.py
+++ b/tests/unit/mcp/tools/test_edit_facade_snapshot_routes.py
@@ -308,17 +308,19 @@ async def test_edit_read_existing_arguments_survive_exact_projection(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("action", "reason"),
-    [
-        # nav-backed consumers still lack a certified read_existing backend.
-        ("safe", "READ_EXISTING_AUTHORITY_UNCERTIFIED"),
-    ],
-)
+@pytest.mark.parametrize("action", ["safe"])
 @pytest.mark.parametrize("output_format", ["json", "toon"])
 async def test_edit_read_existing_returns_exact_access_evidence(
-    tmp_path: Path, action: str, reason: str, output_format: str
+    tmp_path: Path, action: str, output_format: str
 ) -> None:
+    """RFC-0022 P0.4: the safe consumer is platform-aware.
+
+    On non-Linux axes it returns the stable uncertified classification; on
+    Linux it runs the certified index consumer and classifies the missing
+    snapshot (the fake ``idxsnap_test`` id) as an unknown acquisition failure.
+    """
+    import sys
+
     from tree_sitter_analyzer.mcp.tools.edit_facade import build_edit_facade
 
     (tmp_path / "inside.py").write_text("value = 1\n")
@@ -330,24 +332,34 @@ async def test_edit_read_existing_returns_exact_access_evidence(
         }
     )
 
-    assert {
-        key: result[key]
-        for key in (
-            "success",
-            "access_mode",
-            "access_state",
-            "access_reason",
-            "source_snapshots",
-            "output_format",
-        )
-    } == {
-        "success": True,
-        "access_mode": "read_existing",
-        "access_state": "unknown",
-        "access_reason": reason,
-        "source_snapshots": [],
-        "output_format": output_format,
-    }
+    if sys.platform.startswith("linux"):
+        assert result["success"] is False
+        assert result["access_mode"] == "read_existing"
+        assert result["access_state"] == "unknown"
+        assert result["access_reason"] == "INDEX_SNAPSHOT_UNKNOWN"
+        assert result["error_code"] == "INDEX_SNAPSHOT_UNKNOWN"
+        assert result["source_snapshots"] == []
+        assert result["output_format"] == output_format
+        assert result["action_version"] == "edit.safe/v1"
+    else:
+        assert {
+            key: result[key]
+            for key in (
+                "success",
+                "access_mode",
+                "access_state",
+                "access_reason",
+                "source_snapshots",
+                "output_format",
+            )
+        } == {
+            "success": True,
+            "access_mode": "read_existing",
+            "access_state": "unknown",
+            "access_reason": "READ_EXISTING_AUTHORITY_UNCERTIFIED",
+            "source_snapshots": [],
+            "output_format": output_format,
+        }
     assert (result.get("format"), "toon_content" in result) == (
         ("toon", True) if output_format == "toon" else (None, False)
     )

--- a/tests/unit/mcp/tools/test_nav_facade.py
+++ b/tests/unit/mcp/tools/test_nav_facade.py
@@ -1115,6 +1115,7 @@ def test_context_read_existing_fails_closed_without_project_root() -> None:
     assert result["action_version"] == "nav.context/v1"
 
 
+@pytest.mark.slow_ok  # real git + index_project + source capture: subprocess work
 @pytest.mark.skipif(
     sys.platform.startswith("win") or not os.path.exists("/dev/fd"),
     reason="tracked: RFC-0022 P0.4 source recapture needs POSIX /dev/fd",
@@ -1165,6 +1166,7 @@ def test_context_read_existing_consumes_published_snapshot(
     assert result["code_blocks"]
 
 
+@pytest.mark.slow_ok  # real git + index_project + source capture: subprocess work
 @pytest.mark.skipif(
     sys.platform.startswith("win") or not os.path.exists("/dev/fd"),
     reason="tracked: RFC-0022 P0.4 source recapture needs POSIX /dev/fd",

--- a/tests/unit/mcp/tools/test_nav_facade.py
+++ b/tests/unit/mcp/tools/test_nav_facade.py
@@ -19,6 +19,7 @@ Required cases per p0-facade-framework-spec.md §5:
 from __future__ import annotations
 
 import asyncio
+import os
 import sys
 from typing import Any
 from unittest.mock import AsyncMock, patch
@@ -1115,8 +1116,8 @@ def test_context_read_existing_fails_closed_without_project_root() -> None:
 
 
 @pytest.mark.skipif(
-    sys.platform.startswith("win"),
-    reason="tracked: RFC-0022 P0.4 source recapture is POSIX-only (no /dev/fd)",
+    sys.platform.startswith("win") or not os.path.exists("/dev/fd"),
+    reason="tracked: RFC-0022 P0.4 source recapture needs POSIX /dev/fd",
 )
 def test_context_read_existing_consumes_published_snapshot(
     tmp_path: Any, monkeypatch: pytest.MonkeyPatch
@@ -1165,8 +1166,8 @@ def test_context_read_existing_consumes_published_snapshot(
 
 
 @pytest.mark.skipif(
-    sys.platform.startswith("win"),
-    reason="tracked: RFC-0022 P0.4 source recapture is POSIX-only (no /dev/fd)",
+    sys.platform.startswith("win") or not os.path.exists("/dev/fd"),
+    reason="tracked: RFC-0022 P0.4 source recapture needs POSIX /dev/fd",
 )
 def test_context_read_existing_generation_mismatch_fails_closed(
     tmp_path: Any, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/mcp/tools/test_nav_facade.py
+++ b/tests/unit/mcp/tools/test_nav_facade.py
@@ -1106,8 +1106,14 @@ def test_context_read_existing_fails_closed_without_project_root() -> None:
     arguments["output_format"] = "json"
 
     if sys.platform.startswith("linux"):
-        with pytest.raises(ValueError, match="MISSING_PROJECT_ROOT"):
-            asyncio.run(context_inner.execute(arguments))
+        # The consumer seam classifies the unbound root (evidence + wire
+        # owner), it does not escape as a bare raise.
+        result = asyncio.run(context_inner.execute(arguments))
+        assert result["success"] is False
+        assert result["error_code"] == "MISSING_PROJECT_ROOT"
+        assert result["access_reason"] == "MISSING_PROJECT_ROOT"
+        assert result["access_state"] == "missing"
+        assert result["action_version"] == "nav.context/v1"
         return
     result = asyncio.run(context_inner.execute(arguments))
     assert result["success"] is True
@@ -1160,10 +1166,71 @@ def test_context_read_existing_consumes_published_snapshot(
     # source_snapshots record (RFC-0022 route-table common rule 5).
     assert result["snapshot_id"] == published.snapshot_id
     assert result["source_generation"] == published.source_generation
+    assert result["snapshot_id"] == published.snapshot_id
+    assert result["source_generation"] == published.source_generation
     assert result["action_version"] == "nav.context/v1"
     assert [entry.get("name") for entry in result["entry_points"]] == ["dispatch"]
     assert result["related_symbols"]
     assert result["code_blocks"]
+
+
+@pytest.mark.slow_ok  # real git + index_project + source capture: subprocess work
+@pytest.mark.skipif(
+    sys.platform.startswith("win") or not os.path.exists("/dev/fd"),
+    reason="tracked: RFC-0022 P0.4 source recapture needs POSIX /dev/fd",
+)
+def test_context_read_existing_no_match_returns_not_found(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A task with no symbol hits yields a certified NOT_FOUND envelope.
+
+    The empty-nodes path must still carry the full read_existing evidence
+    (echo tokens + action_version), not a bare success stub.
+    """
+    import tree_sitter_analyzer.read_existing_access as read_access
+
+    monkeypatch.setattr(read_access, "read_existing_platform_supported", lambda: True)
+    project = _indexed_project(tmp_path)
+    published = _publish_index_snapshot(project)
+
+    facade = build_nav_facade(project_root=str(project))
+    result = asyncio.run(
+        facade.execute(
+            {
+                "action": "context",
+                "task": "zzz_nonexistent_symbol_xyz",
+                "access_mode": "read_existing",
+                "snapshot_id": published.snapshot_id,
+                "source_generation": published.source_generation,
+                "output_format": "json",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["verdict"] == "NOT_FOUND"
+    assert result["access_mode"] == "read_existing"
+    assert result["access_state"] == "available"
+    assert result["access_reason"] is None
+    assert result["source_snapshots"] == [
+        {
+            "kind": "index",
+            "snapshot_id": published.snapshot_id,
+            "source_generation": published.source_generation,
+        }
+    ]
+    assert result["snapshot_id"] == published.snapshot_id
+    assert result["source_generation"] == published.source_generation
+    assert result["action_version"] == "nav.context/v1"
+    assert result["entry_points"] == []
+    assert result["code_blocks"] == []
+    assert result["stats"] == {
+        "entry_points": 0,
+        "entry_points_total": 0,
+        "nodes_total": 0,
+        "edges_total": 0,
+        "code_blocks": 0,
+    }
 
 
 @pytest.mark.slow_ok  # real git + index_project + source capture: subprocess work
@@ -1205,3 +1272,53 @@ def test_context_read_existing_generation_mismatch_fails_closed(
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))
+
+
+def test_snapshot_search_surface_degrades_without_fts5(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without FTS5 the snapshot search surface returns no raw hits."""
+    import sqlite3
+
+    import tree_sitter_analyzer.mcp.tools.codegraph_context_tool as cgt
+
+    monkeypatch.setattr(cgt, "sqlite_compile_supports_fts5", lambda conn: False)
+    conn = sqlite3.connect(":memory:")
+    surface = cgt._snapshot_search_surface(conn)
+    assert surface.fts_search("anything") == []
+    assert surface.fts_search_ranked("anything") == []
+
+
+def test_snapshot_search_surface_queries_real_fts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With FTS5 the snapshot search surface queries the connection."""
+    import sqlite3
+
+    import tree_sitter_analyzer.mcp.tools.codegraph_context_tool as cgt
+
+    monkeypatch.setattr(cgt, "sqlite_compile_supports_fts5", lambda conn: True)
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        "CREATE TABLE ast_symbol_rows (id INTEGER PRIMARY KEY, name TEXT, "
+        "kind TEXT, file_path TEXT, language TEXT, line INTEGER, end_line INTEGER)"
+    )
+    conn.execute("CREATE VIRTUAL TABLE ast_symbols_fts USING fts5(name, content='')")
+    conn.execute(
+        "INSERT INTO ast_symbol_rows VALUES "
+        "(1, 'hello_world', 'function', 'a.py', 'python', 1, 3)"
+    )
+    conn.execute("INSERT INTO ast_symbols_fts (rowid, name) VALUES (1, 'hello_world')")
+    surface = cgt._snapshot_search_surface(conn)
+    hits = surface.fts_search("hello")
+    assert hits == [
+        {
+            "name": "hello_world",
+            "kind": "function",
+            "file": "a.py",
+            "language": "python",
+            "line": 1,
+            "end_line": 3,
+        }
+    ]

--- a/tests/unit/mcp/tools/test_nav_facade.py
+++ b/tests/unit/mcp/tools/test_nav_facade.py
@@ -19,6 +19,7 @@ Required cases per p0-facade-framework-spec.md §5:
 from __future__ import annotations
 
 import asyncio
+import sys
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -1113,6 +1114,10 @@ def test_context_read_existing_fails_closed_without_project_root() -> None:
     assert result["action_version"] == "nav.context/v1"
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="tracked: RFC-0022 P0.4 source recapture is POSIX-only (no /dev/fd)",
+)
 def test_context_read_existing_consumes_published_snapshot(
     tmp_path: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1159,6 +1164,10 @@ def test_context_read_existing_consumes_published_snapshot(
     assert result["code_blocks"]
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="tracked: RFC-0022 P0.4 source recapture is POSIX-only (no /dev/fd)",
+)
 def test_context_read_existing_generation_mismatch_fails_closed(
     tmp_path: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/mcp/tools/test_nav_facade.py
+++ b/tests/unit/mcp/tools/test_nav_facade.py
@@ -894,6 +894,8 @@ def test_context_forwards_explicit_read_existing_capability() -> None:
 def test_context_read_existing_returns_exact_access_evidence_without_backend(
     tmp_path: Any, output_format: str, format_fields: dict[str, Any]
 ) -> None:
+    import sys
+
     facade = build_nav_facade(project_root=str(tmp_path))
     context_inner = facade._bespoke_inners[0]
 
@@ -908,7 +910,35 @@ def test_context_read_existing_returns_exact_access_evidence_without_backend(
             )
         )
 
+    # On every axis the certified/live backends never touch the live ASTCache
+    # (zero-write); the missing snapshot classifies before the reader runs.
     get_cache.assert_not_called()
+    if sys.platform.startswith("linux"):
+        # RFC-0022 P0.4: the certified backend runs and classifies the
+        # never-published pair as an unknown acquisition failure.
+        assert {
+            key: result[key]
+            for key in (
+                "success",
+                "access_mode",
+                "access_state",
+                "access_reason",
+                "error_code",
+                "source_snapshots",
+                "action_version",
+                "output_format",
+            )
+        } == {
+            "success": False,
+            "access_mode": "read_existing",
+            "access_state": "unknown",
+            "access_reason": "INDEX_SNAPSHOT_UNKNOWN",
+            "error_code": "INDEX_SNAPSHOT_UNKNOWN",
+            "source_snapshots": [],
+            "action_version": "nav.context/v1",
+            "output_format": output_format,
+        }
+        return
     assert result == {
         **format_fields,
         **_ACCESS_EVIDENCE,
@@ -969,6 +999,196 @@ def test_navigate_rejects_context_only_access_mode() -> None:
         "validation",
         "parameter 'access_mode' applies only to action(s): context",
     )
+
+
+# ---------------------------------------------------------------------------
+# RFC-0022 P0.4: certified-axis index-snapshot consumers (portable gate open)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _close_index_snapshot_registry():
+    yield
+    from tree_sitter_analyzer.index_snapshot import REGISTRY
+
+    REGISTRY.close_all()
+
+
+def _indexed_project(tmp_path: Any) -> Any:
+    """Index one small project and return its resolved root."""
+    from pathlib import Path
+
+    from tree_sitter_analyzer.ast_cache import ASTCache
+
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / "app.py").write_text(
+        "class UserService:\n"
+        "    def get_user(self, user_id):\n"
+        "        return self._find_user(user_id)\n"
+        "\n"
+        "    def _find_user(self, user_id):\n"
+        "        return {'id': user_id}\n"
+        "\n"
+        "def handle_request(request):\n"
+        "    svc = UserService()\n"
+        "    return svc.get_user(1)\n",
+        encoding="utf-8",
+    )
+    (project / "routes.py").write_text(
+        "from app import handle_request\n"
+        "\n"
+        "def dispatch(request):\n"
+        "    return handle_request(request)\n",
+        encoding="utf-8",
+    )
+    cache = ASTCache(str(project))
+    cache.index_project(max_files=20)
+    cache.close()
+    return Path(str(project.resolve()))
+
+
+def _publish_index_snapshot(project: Any, *, source_generation: str | None = None):
+    """Publish one real index.db connection under the process-global registry.
+
+    The published capability carries the REAL captured source generation and
+    a full source scope so the consumer's after-read recapture passes: a
+    hand-faked generation would raise SOURCE_GENERATION_MISMATCH on exit.
+    """
+    import sqlite3
+
+    from tree_sitter_analyzer.index_snapshot import (
+        REGISTRY,
+        IndexSnapshot,
+        _capture_sources_with_deadline,
+    )
+    from tree_sitter_analyzer.index_source_scope import make_source_scope_descriptor
+
+    scope = make_source_scope_descriptor()
+    current = _capture_sources_with_deadline(str(project), scope, deadline=10**18)
+    assert current.state == "exact", current.reason
+    conn = sqlite3.connect(str(project / ".ast-cache" / "index.db"))
+    conn.row_factory = sqlite3.Row
+    snapshot = IndexSnapshot(
+        None,
+        current.fingerprint,
+        "index-fp",
+        source_generation or current.generation,
+        "complete",
+        None,
+        str(project.resolve()),
+        2,
+        None,
+        None,
+        scope,
+    )
+    return REGISTRY.publish(snapshot, conn, 0)
+
+
+def test_context_read_existing_fails_closed_without_project_root() -> None:
+    """MISSING_PROJECT_ROOT on the certified axis; UNCERTIFIED elsewhere.
+
+    Codex P1 (#1257) mirror for nav.context: an unbound root must never let
+    the certified backend run (it would classify success with no project
+    boundary). Non-certified axes keep the stable UNCERTIFIED success stub.
+    """
+    import sys
+
+    facade = build_nav_facade(project_root=None)
+    context_inner = facade._bespoke_inners[0]
+    arguments = {
+        key: value
+        for key, value in _CONTEXT_READ_EXISTING_ARGS.items()
+        if key != "action"
+    }
+    arguments["output_format"] = "json"
+
+    if sys.platform.startswith("linux"):
+        with pytest.raises(ValueError, match="MISSING_PROJECT_ROOT"):
+            asyncio.run(context_inner.execute(arguments))
+        return
+    result = asyncio.run(context_inner.execute(arguments))
+    assert result["success"] is True
+    assert result["access_reason"] == "READ_EXISTING_AUTHORITY_UNCERTIFIED"
+    assert result["action_version"] == "nav.context/v1"
+
+
+def test_context_read_existing_consumes_published_snapshot(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The certified backend serves graph content from the snapshot connection."""
+    import tree_sitter_analyzer.read_existing_access as read_access
+
+    monkeypatch.setattr(read_access, "read_existing_platform_supported", lambda: True)
+    project = _indexed_project(tmp_path)
+    published = _publish_index_snapshot(project)
+
+    facade = build_nav_facade(project_root=str(project))
+    result = asyncio.run(
+        facade.execute(
+            {
+                "action": "context",
+                "task": "explain dispatch",
+                "access_mode": "read_existing",
+                "snapshot_id": published.snapshot_id,
+                "source_generation": published.source_generation,
+                "output_format": "json",
+            }
+        )
+    )
+
+    assert result["success"] is True
+    assert result["verdict"] == "INFO"
+    assert result["access_mode"] == "read_existing"
+    assert result["access_state"] == "available"
+    assert result["access_reason"] is None
+    assert result["source_snapshots"] == [
+        {
+            "kind": "index",
+            "snapshot_id": published.snapshot_id,
+            "source_generation": published.source_generation,
+        }
+    ]
+    # The echo must come from the ACQUIRED snapshot, byte-matching the
+    # source_snapshots record (RFC-0022 route-table common rule 5).
+    assert result["snapshot_id"] == published.snapshot_id
+    assert result["source_generation"] == published.source_generation
+    assert result["action_version"] == "nav.context/v1"
+    assert [entry.get("name") for entry in result["entry_points"]] == ["dispatch"]
+    assert result["related_symbols"]
+    assert result["code_blocks"]
+
+
+def test_context_read_existing_generation_mismatch_fails_closed(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A wrong source_generation token classifies, never a successful read."""
+    import tree_sitter_analyzer.read_existing_access as read_access
+
+    monkeypatch.setattr(read_access, "read_existing_platform_supported", lambda: True)
+    project = _indexed_project(tmp_path)
+    published = _publish_index_snapshot(project)
+
+    facade = build_nav_facade(project_root=str(project))
+    result = asyncio.run(
+        facade.execute(
+            {
+                "action": "context",
+                "task": "explain dispatch",
+                "access_mode": "read_existing",
+                "snapshot_id": published.snapshot_id,
+                "source_generation": "WRONG-GENERATION",
+                "output_format": "json",
+            }
+        )
+    )
+
+    assert result["success"] is False
+    assert result["access_state"] == "unknown"
+    assert result["access_reason"] == "SOURCE_GENERATION_MISMATCH"
+    assert result["error_code"] == "SOURCE_GENERATION_MISMATCH"
+    assert result["source_snapshots"] == []
+    assert result["action_version"] == "nav.context/v1"
 
 
 if __name__ == "__main__":

--- a/tests/unit/mcp/tools/test_nav_facade.py
+++ b/tests/unit/mcp/tools/test_nav_facade.py
@@ -1169,8 +1169,10 @@ def test_context_read_existing_consumes_published_snapshot(
     assert result["snapshot_id"] == published.snapshot_id
     assert result["source_generation"] == published.source_generation
     assert result["action_version"] == "nav.context/v1"
-    # C46: the certified adapter never echoes raw task text.
+    # C46/C51: the certified adapter never echoes raw task text or the
+    # task-derived candidate tokens.
     assert "task" not in result
+    assert "candidates" not in result
     assert [entry.get("name") for entry in result["entry_points"]] == ["dispatch"]
     assert result["related_symbols"]
     assert result["code_blocks"]

--- a/tests/unit/mcp/tools/test_nav_facade.py
+++ b/tests/unit/mcp/tools/test_nav_facade.py
@@ -1169,6 +1169,8 @@ def test_context_read_existing_consumes_published_snapshot(
     assert result["snapshot_id"] == published.snapshot_id
     assert result["source_generation"] == published.source_generation
     assert result["action_version"] == "nav.context/v1"
+    # C46: the certified adapter never echoes raw task text.
+    assert "task" not in result
     assert [entry.get("name") for entry in result["entry_points"]] == ["dispatch"]
     assert result["related_symbols"]
     assert result["code_blocks"]

--- a/tests/unit/mcp/tools/test_safe_to_edit_dependency_view.py
+++ b/tests/unit/mcp/tools/test_safe_to_edit_dependency_view.py
@@ -6,6 +6,7 @@ from tree_sitter_analyzer.mcp.tools.utils import safe_to_edit_helpers
 from tree_sitter_analyzer.mcp.tools.utils.safe_to_edit_helpers import (
     FileDependencyView,
     _extract_import_specs,
+    _import_needles_for_target,
     _iter_dependency_source_files,
     _resolve_import_spec,
     _target_dependencies,
@@ -53,6 +54,23 @@ def test_safe_graph_lookup_does_not_match_partial_basename_suffix() -> None:
 
     assert safe_dependencies(view, "main.py") == ["pkg/dep.py"]
     assert safe_dependencies(view, "ain.py") == []
+
+
+def test_resolve_import_spec_with_no_matching_file_returns_none(
+    tmp_path: Path,
+) -> None:
+    """A spec whose candidates do not exist on disk resolves to None."""
+    (tmp_path / "pkg").mkdir()
+    (tmp_path / "pkg" / "main.py").write_text("x = 1\n", encoding="utf-8")
+
+    resolved = _resolve_import_spec("missing.module", "pkg/main.py", tmp_path)
+    assert resolved is None
+
+
+def test_import_needles_for_init_package_add_package_names() -> None:
+    """An __init__.py target yields package-level needles, not the basename."""
+    needles = _import_needles_for_target("pkg/__init__.py")
+    assert needles == {"pkg/__init__", "pkg.__init__", "pkg"}
 
 
 def test_build_file_dependency_view_finds_python_imports_and_importers(

--- a/tests/unit/security/test_fixture_detector.py
+++ b/tests/unit/security/test_fixture_detector.py
@@ -244,6 +244,65 @@ class TestCache:
         is_fixture("tree_sitter_analyzer/foo.py", root)
         assert (root / ".ast-cache" / "fixture_index.json").is_file()
 
+    def test_valid_cache_hit_returns_without_rescan(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Tier-2 cache hit: the second call serves from cache and never
+        # rescans tests/ (basename seen but no PROJECT_ROOT pattern, so the
+        # targeted scan returns None and tier 2 is reached).
+        root = _make_project(
+            tmp_path,
+            {
+                "tests/test_x.py": ("def test_x():\n    assert 'foo.py' in __file__\n"),
+                "tree_sitter_analyzer/foo.py": "",
+            },
+        )
+        first = is_fixture("tree_sitter_analyzer/foo.py", root)
+        assert first.is_fixture is False
+        assert (root / ".ast-cache" / "fixture_index.json").is_file()
+
+        scans = {"n": 0}
+
+        def counting_scan(tests_dir, project_root):
+            scans["n"] += 1
+            return {}
+
+        monkeypatch.setattr(fixture_detector, "_scan_tests", counting_scan)
+        second = is_fixture("tree_sitter_analyzer/foo.py", root)
+        assert second.is_fixture is False
+        assert scans["n"] == 0  # served from the valid cache
+
+    def test_certified_scan_respects_snapshot_inventory(self, tmp_path: Path) -> None:
+        # Codex P1 (#1299 round-3): the certified probe must only consult
+        # generation-certified test files — a reference inside an
+        # oracle-pruned path (tests/vendor/) must not escalate.
+        root = _make_project(
+            tmp_path,
+            {
+                "tests/vendor/helper.py": (
+                    "from pathlib import Path\n"
+                    "PROJECT_ROOT = Path('.')\n"
+                    "name = PROJECT_ROOT / 'tree_sitter_analyzer' / 'foo.py'\n"
+                ),
+                "tree_sitter_analyzer/foo.py": "",
+            },
+        )
+        inventory = frozenset({"tree_sitter_analyzer/foo.py"})
+        excluded = is_fixture(
+            "tree_sitter_analyzer/foo.py",
+            root,
+            certified=True,
+            inventory=inventory,
+        )
+        assert excluded.is_fixture is False
+        included = is_fixture(
+            "tree_sitter_analyzer/foo.py",
+            root,
+            certified=True,
+            inventory=inventory | frozenset({"tests/vendor/helper.py"}),
+        )
+        assert included.is_fixture is True
+
     def test_certified_scan_skips_live_allowlist(self, tmp_path: Path) -> None:
         # Codex P1 (#1299): the CLAUDE.md allowlist is outside the source
         # generation, so a certified probe must not consult it — only

--- a/tests/unit/security/test_fixture_detector.py
+++ b/tests/unit/security/test_fixture_detector.py
@@ -222,6 +222,28 @@ class TestCache:
         is_fixture("tree_sitter_analyzer/foo.py", root)
         assert (root / ".ast-cache" / "fixture_index.json").is_file()
 
+    def test_readonly_scan_never_writes_cache(self, tmp_path: Path) -> None:
+        # Codex P1 (#1299): the certified read_existing route must stay
+        # zero-write — an absent cache is re-scanned in memory but never
+        # persisted (fixture_index.json must not appear).
+        root = _make_project(
+            tmp_path,
+            {
+                "tests/test_x.py": (
+                    "from pathlib import Path\n"
+                    "PROJECT_ROOT = Path('.')\n"
+                    "name = PROJECT_ROOT / 'tree_sitter_analyzer' / 'foo.py'\n"
+                ),
+                "tree_sitter_analyzer/foo.py": "",
+            },
+        )
+        fact = is_fixture("tree_sitter_analyzer/foo.py", root, rebuild_cache=False)
+        assert fact.is_fixture is True
+        assert not (root / ".ast-cache" / "fixture_index.json").exists()
+        # The default path still persists (unchanged behaviour).
+        is_fixture("tree_sitter_analyzer/foo.py", root)
+        assert (root / ".ast-cache" / "fixture_index.json").is_file()
+
     def test_cache_corrupt_falls_through_to_scan(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:

--- a/tests/unit/security/test_fixture_detector.py
+++ b/tests/unit/security/test_fixture_detector.py
@@ -133,6 +133,36 @@ class TestTier2Scan:
         assert fact.source in {"path_literal", "constant_assignment"}
         assert any("test_x.py" in line for line in fact.evidence)
 
+    def test_repo_relative_literal_statement_signal(self, tmp_path: Path) -> None:
+        # A bare repo-relative string EXPRESSION (non-assign) goes through
+        # _process_repo_relative_literals.
+        root = _make_project(
+            tmp_path,
+            {
+                "tests/test_x.py": ("print('tree_sitter_analyzer/foo.py')\n"),
+                "tree_sitter_analyzer/foo.py": "",
+            },
+        )
+        fact = is_fixture("tree_sitter_analyzer/foo.py", root)
+        assert fact.is_fixture is True
+        assert fact.source == "repo_relative_literal"
+
+    def test_certified_scan_tolerates_non_utf8_tests(self, tmp_path: Path) -> None:
+        # Codex P2 (#1299 round-10, C43): a non-UTF-8 indexed test must
+        # degrade, never raise UnicodeDecodeError out of the certified route.
+        root = _make_project(tmp_path, {"tree_sitter_analyzer/foo.py": ""})
+        bad = root / "tests" / "bad_utf8.py"
+        bad.parent.mkdir(parents=True, exist_ok=True)
+        bad.write_bytes(b"x = b'\xff\xfe'\n")
+        inventory = frozenset({"tree_sitter_analyzer/foo.py"})
+        fact = is_fixture(
+            "tree_sitter_analyzer/foo.py",
+            root,
+            certified=True,
+            inventory=inventory,
+        )
+        assert fact.is_fixture is False
+
     def test_bare_basename_literal_falls_through(self, tmp_path: Path) -> None:
         # A bare '.py' basename with no package prefix matches none of the
         # signal tiers and records nothing (falls through the elif chain).

--- a/tests/unit/security/test_fixture_detector.py
+++ b/tests/unit/security/test_fixture_detector.py
@@ -303,6 +303,35 @@ class TestCache:
         )
         assert included.is_fixture is True
 
+    def test_certified_scan_falls_through_to_inventory_filtered_scan(
+        self, tmp_path: Path
+    ) -> None:
+        # Codex P1 (#1299 round-3): when the targeted scan misses, the full
+        # in-memory scan runs over the inventory — files outside the
+        # inventory (e.g. tests/other_y.py) are skipped.
+        root = _make_project(
+            tmp_path,
+            {
+                "tests/test_x.py": ("def test_x():\n    assert 'foo.py' in __file__\n"),
+                "tests/other_y.py": (
+                    "from pathlib import Path\n"
+                    "PROJECT_ROOT = Path('.')\n"
+                    "name = PROJECT_ROOT / 'tree_sitter_analyzer' / 'foo.py'\n"
+                ),
+                "tree_sitter_analyzer/foo.py": "",
+            },
+        )
+        inventory = frozenset({"tests/test_x.py"})
+        fact = is_fixture(
+            "tree_sitter_analyzer/foo.py",
+            root,
+            certified=True,
+            inventory=inventory,
+        )
+        # test_x.py only mentions the basename (no PROJECT_ROOT pattern) and
+        # other_y.py is outside the inventory -> no escalation.
+        assert fact.is_fixture is False
+
     def test_certified_scan_skips_live_allowlist(self, tmp_path: Path) -> None:
         # Codex P1 (#1299): the CLAUDE.md allowlist is outside the source
         # generation, so a certified probe must not consult it — only

--- a/tests/unit/security/test_fixture_detector.py
+++ b/tests/unit/security/test_fixture_detector.py
@@ -133,6 +133,19 @@ class TestTier2Scan:
         assert fact.source in {"path_literal", "constant_assignment"}
         assert any("test_x.py" in line for line in fact.evidence)
 
+    def test_bare_basename_literal_falls_through(self, tmp_path: Path) -> None:
+        # A bare '.py' basename with no package prefix matches none of the
+        # signal tiers and records nothing (falls through the elif chain).
+        root = _make_project(
+            tmp_path,
+            {
+                "tests/test_x.py": "name = 'foo.py'\n",
+                "tree_sitter_analyzer/foo.py": "",
+            },
+        )
+        fact = is_fixture("tree_sitter_analyzer/foo.py", root)
+        assert fact.is_fixture is False
+
     def test_bare_repo_relative_literal_is_caution(self, tmp_path: Path) -> None:
         # A bare string ``"tree_sitter_analyzer/foo.py"`` outside any
         # SAMPLE_ assignment hits the lowest-confidence tier (0.7).
@@ -141,8 +154,12 @@ class TestTier2Scan:
         root = _make_project(
             tmp_path,
             {
-                "tests/test_x.py": "name = 'tree_sitter_analyzer/foo.py'\n",
+                "tests/test_x.py": (
+                    "name = ('tree_sitter_analyzer/foo.py', "
+                    "'tree_sitter_analyzer/bar.py')\n"
+                ),
                 "tree_sitter_analyzer/foo.py": "def f(): pass\n",
+                "tree_sitter_analyzer/bar.py": "def b(): pass\n",
             },
         )
         fact = is_fixture("tree_sitter_analyzer/foo.py", root)
@@ -331,6 +348,37 @@ class TestCache:
         # test_x.py only mentions the basename (no PROJECT_ROOT pattern) and
         # other_y.py is outside the inventory -> no escalation.
         assert fact.is_fixture is False
+
+    def test_constant_assignment_signal_with_plain_string(self, tmp_path: Path) -> None:
+        # The has_fixture_name branch: a plain-string assignment carrying a
+        # fixture basename records the constant-assignment signal.
+        root = _make_project(
+            tmp_path,
+            {
+                "tests/test_x.py": (
+                    "SAMPLE_FOO = ('tree_sitter_analyzer/foo.py', "
+                    "'tree_sitter_analyzer/bar.py')\n"
+                ),
+                "tree_sitter_analyzer/foo.py": "",
+                "tree_sitter_analyzer/bar.py": "",
+            },
+        )
+        fact = is_fixture("tree_sitter_analyzer/foo.py", root)
+        assert fact.is_fixture is True
+        assert fact.source == "constant_assignment"
+
+    def test_basename_with_separator_returns_normally(self, tmp_path: Path) -> None:
+        root = _make_project(tmp_path, {"tree_sitter_analyzer/foo.py": "x"})
+        resolved = fixture_detector._basename_to_repo_relative(
+            "tree_sitter_analyzer/foo.py", root
+        )
+        assert resolved == "tree_sitter_analyzer/foo.py"
+        # A path outside the root falls back to its string form.
+        import os
+
+        outside = os.path.realpath("/etc/passwd")
+        fallback = fixture_detector._safe_relative(Path(outside), root)
+        assert fallback == outside.replace("\\", "/")
 
     def test_basename_resolution_honors_inventory(self, tmp_path: Path) -> None:
         # Codex P1 (#1299 round-8, C37): an oracle-excluded duplicate must

--- a/tests/unit/security/test_fixture_detector.py
+++ b/tests/unit/security/test_fixture_detector.py
@@ -147,6 +147,23 @@ class TestTier2Scan:
         assert fact.is_fixture is True
         assert fact.source == "repo_relative_literal"
 
+    def test_signature_tolerates_dangling_symlink(self, tmp_path: Path) -> None:
+        # A dangling tests/ symlink makes path.stat() raise; the signature
+        # walk skips it instead of failing the fixture scan.
+        root = _make_project(
+            tmp_path,
+            {
+                "tests/test_x.py": "def test_x(): pass\n",
+                "tree_sitter_analyzer/foo.py": "",
+            },
+        )
+        import os
+
+        os.symlink(root / "tests" / "ghost.py", root / "tests" / "dangling.py")
+        # Drive the signature walk directly so the stat except fires.
+        index = fixture_detector._load_or_build_index(root)
+        assert index == {}
+
     def test_certified_scan_tolerates_non_utf8_tests(self, tmp_path: Path) -> None:
         # Codex P2 (#1299 round-10, C43): a non-UTF-8 indexed test must
         # degrade, never raise UnicodeDecodeError out of the certified route.

--- a/tests/unit/security/test_fixture_detector.py
+++ b/tests/unit/security/test_fixture_detector.py
@@ -222,10 +222,10 @@ class TestCache:
         is_fixture("tree_sitter_analyzer/foo.py", root)
         assert (root / ".ast-cache" / "fixture_index.json").is_file()
 
-    def test_readonly_scan_never_writes_cache(self, tmp_path: Path) -> None:
+    def test_certified_scan_never_writes_cache(self, tmp_path: Path) -> None:
         # Codex P1 (#1299): the certified read_existing route must stay
-        # zero-write — an absent cache is re-scanned in memory but never
-        # persisted (fixture_index.json must not appear).
+        # zero-write — the generation-certified scan never persists
+        # fixture_index.json.
         root = _make_project(
             tmp_path,
             {
@@ -237,12 +237,29 @@ class TestCache:
                 "tree_sitter_analyzer/foo.py": "",
             },
         )
-        fact = is_fixture("tree_sitter_analyzer/foo.py", root, rebuild_cache=False)
+        fact = is_fixture("tree_sitter_analyzer/foo.py", root, certified=True)
         assert fact.is_fixture is True
         assert not (root / ".ast-cache" / "fixture_index.json").exists()
         # The default path still persists (unchanged behaviour).
         is_fixture("tree_sitter_analyzer/foo.py", root)
         assert (root / ".ast-cache" / "fixture_index.json").is_file()
+
+    def test_certified_scan_skips_live_allowlist(self, tmp_path: Path) -> None:
+        # Codex P1 (#1299): the CLAUDE.md allowlist is outside the source
+        # generation, so a certified probe must not consult it — only
+        # test-file references count.
+        root = _make_project(
+            tmp_path,
+            {
+                "CLAUDE.md": _frontmatter([{"path": "tree_sitter_analyzer/foo.py"}]),
+                "tree_sitter_analyzer/foo.py": "",
+            },
+        )
+        certified = is_fixture("tree_sitter_analyzer/foo.py", root, certified=True)
+        assert certified.is_fixture is False
+        live = is_fixture("tree_sitter_analyzer/foo.py", root)
+        assert live.is_fixture is True
+        assert live.source == "allowlist"
 
     def test_cache_corrupt_falls_through_to_scan(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture

--- a/tests/unit/security/test_fixture_detector.py
+++ b/tests/unit/security/test_fixture_detector.py
@@ -332,6 +332,25 @@ class TestCache:
         # other_y.py is outside the inventory -> no escalation.
         assert fact.is_fixture is False
 
+    def test_basename_resolution_honors_inventory(self, tmp_path: Path) -> None:
+        # Codex P1 (#1299 round-8, C37): an oracle-excluded duplicate must
+        # not make the basename lookup ambiguous on a certified read.
+        root = _make_project(
+            tmp_path,
+            {
+                "tree_sitter_analyzer/foo.py": "x = 1\n",
+                "tree_sitter_analyzer/vendor/foo.py": "y = 2\n",
+            },
+        )
+        ambiguous = fixture_detector._basename_to_repo_relative("foo.py", root)
+        assert ambiguous is None  # two live matches, cannot disambiguate
+        certified = fixture_detector._basename_to_repo_relative(
+            "foo.py",
+            root,
+            inventory=frozenset({"tree_sitter_analyzer/foo.py"}),
+        )
+        assert certified == "tree_sitter_analyzer/foo.py"
+
     def test_certified_scan_skips_live_allowlist(self, tmp_path: Path) -> None:
         # Codex P1 (#1299): the CLAUDE.md allowlist is outside the source
         # generation, so a certified probe must not consult it — only

--- a/tests/unit/task/test_task_router.py
+++ b/tests/unit/task/test_task_router.py
@@ -731,6 +731,36 @@ def test_nav_access_unavailable_is_fail_closed_not_token_mismatch() -> None:
     )
 
 
+def test_understand_nav_certified_failure_is_access_unavailable_not_token_mismatch() -> (
+    None
+):
+    # P0.4 (RFC-0022): the certified-axis classification code is
+    # ACCESS_UNAVAILABLE, never SOURCE_GENERATION_MISMATCH — a missing
+    # snapshot is an availability problem, not a freshness disagreement.
+    executor = FakeExecutor(
+        responses={
+            ("nav", "context"): {
+                "success": False,
+                "verdict": "ERROR",
+                "action_version": "nav.context/v1",
+                "access_state": "unknown",
+                "access_reason": "INDEX_SNAPSHOT_UNKNOWN",
+                "error_code": "INDEX_SNAPSHOT_UNKNOWN",
+                "code_blocks": [],
+            }
+        }
+    )
+    outcome = _run(understand(UnderstandRequest(task="x"), executor))
+    assert outcome.status == "partial"
+    assert any(
+        u["reason"] == "ACCESS_UNAVAILABLE:INDEX_SNAPSHOT_UNKNOWN"
+        for u in outcome.unknowns
+    )
+    assert not any(
+        u["reason"] == "SOURCE_GENERATION_MISMATCH" for u in outcome.unknowns
+    )
+
+
 def test_diff_impact_access_unavailable_stops_route() -> None:
     impact = dict(IMPACT_OK)
     impact["access_state"] = "unknown"
@@ -901,6 +931,25 @@ def test_safe_access_unavailable_is_per_call_failure() -> None:
         and u["reason"] == "ACCESS_UNAVAILABLE:READ_EXISTING_AUTHORITY_UNCERTIFIED"
         for u in outcome.unknowns
     )
+
+
+def test_plan_change_safe_certified_failure_is_per_call_failure() -> None:
+    # P0.4 (RFC-0022): the certified-axis safe classification (missing index
+    # snapshot) is a per-call ACCESS_UNAVAILABLE unknown while the fan-out
+    # continues, exactly like the UNCERTIFIED twin.
+    safe = dict(SAFE_OK)
+    safe["success"] = False
+    safe["access_state"] = "unknown"
+    safe["access_reason"] = "INDEX_SNAPSHOT_UNKNOWN"
+    executor = FakeExecutor(responses={("edit", "safe"): safe})
+    outcome = _run(plan_change(PlanChangeRequest(task="refactor dispatch"), executor))
+    assert outcome.status == "partial"
+    assert any(
+        u["row"].startswith("plan_change:edit.safe:")
+        and u["reason"] == "ACCESS_UNAVAILABLE:INDEX_SNAPSHOT_UNKNOWN"
+        for u in outcome.unknowns
+    )
+    assert ("edit", "safe") in [(f, a) for f, a, _ in executor.calls]
 
 
 def test_error_verdict_on_success_is_malformed_unknown() -> None:

--- a/tests/unit/test_ast_diff_snapshot_consumers.py
+++ b/tests/unit/test_ast_diff_snapshot_consumers.py
@@ -138,6 +138,7 @@ def test_snapshot_consumer_uses_frozen_utf8_bytes(
 @pytest.mark.parametrize("tool_type", [ASTDiffTool, SemanticClassifyTool])
 @pytest.mark.parametrize("output_format", ["json", "toon"])
 @POSIX_SNAPSHOT_TEST
+@pytest.mark.slow_ok  # real git diff capture x2; brushes the 5s budget under --cov
 def test_snapshot_consumer_echoes_exact_frozen_identity(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_codegraph_context_tool.py
+++ b/tests/unit/test_codegraph_context_tool.py
@@ -1989,6 +1989,42 @@ def test_snapshot_definition_lines_resolve_callee_lines() -> None:
     bare = sqlite3.connect(":memory:")
     assert _snapshot_definition_lines(nodes, bare) == nodes
 
+    # C62: duplicate same-named definitions preserve identity — a node
+    # already on a definition line keeps it; an ambiguous line is not
+    # rewritten to a guessed definition.
+    dup = sqlite3.connect(":memory:")
+    dup.row_factory = sqlite3.Row
+    dup.execute(
+        "CREATE TABLE ast_symbol_rows (file_path TEXT, name TEXT, line INTEGER)"
+    )
+    dup.execute("INSERT INTO ast_symbol_rows VALUES ('pkg/callee.py', 'run', 5)")
+    dup.execute("INSERT INTO ast_symbol_rows VALUES ('pkg/callee.py', 'run', 80)")
+    dup_nodes = [
+        {"name": "run", "file": "pkg/callee.py", "line": 80},
+        {"name": "run", "file": "pkg/callee.py", "line": 200},
+    ]
+    dup_resolved = _snapshot_definition_lines(dup_nodes, dup)
+    assert dup_resolved[0]["line"] == 80  # already a definition line
+    assert dup_resolved[1]["line"] == 200  # ambiguous: not guessed
+
+    # C62: duplicate same-named definitions preserve identity — a node
+    # already on a definition line keeps it; an ambiguous line is not
+    # rewritten to a guessed definition.
+    dup = sqlite3.connect(":memory:")
+    dup.row_factory = sqlite3.Row
+    dup.execute(
+        "CREATE TABLE ast_symbol_rows (file_path TEXT, name TEXT, line INTEGER)"
+    )
+    dup.execute("INSERT INTO ast_symbol_rows VALUES ('pkg/callee.py', 'run', 5)")
+    dup.execute("INSERT INTO ast_symbol_rows VALUES ('pkg/callee.py', 'run', 80)")
+    dup_nodes = [
+        {"name": "run", "file": "pkg/callee.py", "line": 80},
+        {"name": "run", "file": "pkg/callee.py", "line": 200},
+    ]
+    dup_resolved = _snapshot_definition_lines(dup_nodes, dup)
+    assert dup_resolved[0]["line"] == 80  # already a definition line
+    assert dup_resolved[1]["line"] == 200  # ambiguous: not guessed
+
 
 def test_certified_expansion_propagates_edge_errors() -> None:
     """Codex P2 round-10 (C45): certified expansion re-raises edge errors."""

--- a/tests/unit/test_codegraph_context_tool.py
+++ b/tests/unit/test_codegraph_context_tool.py
@@ -1936,6 +1936,12 @@ def test_snapshot_certified_node_file_rejects_unsafe_files(
     assert _snapshot_certified_node_file("external_link", root, conn) is False
     # Existing but not in the inventory: not generation-certified.
     assert _snapshot_certified_node_file("excluded.py", root, conn) is False
+    # Legacy schema (no ast_index) degrades to reject.
+    import sqlite3 as _sqlite3
+
+    bare = _sqlite3.connect(":memory:")
+    bare.row_factory = _sqlite3.Row
+    assert _snapshot_certified_node_file("src/app.py", root, bare) is False
 
 
 def test_next_step_lean_production_anchor() -> None:

--- a/tests/unit/test_codegraph_context_tool.py
+++ b/tests/unit/test_codegraph_context_tool.py
@@ -1900,6 +1900,22 @@ def test_next_step_lean_entry_points_without_code() -> None:
     assert "include_graph=true" in msg
 
 
+def test_snapshot_certified_node_path_rejects_unsafe_files() -> None:
+    """Codex P1 round-6 (C29): only relative in-root paths are certified."""
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        _snapshot_certified_node_path,
+    )
+
+    assert _snapshot_certified_node_path({"file": "src/app.py"}) is True
+    assert _snapshot_certified_node_path({"file": "app.py"}) is True
+    assert _snapshot_certified_node_path({"file": "/etc/passwd"}) is False
+    assert _snapshot_certified_node_path({"file": "../secret.py"}) is False
+    assert _snapshot_certified_node_path({"file": "src/../secret.py"}) is False
+    assert _snapshot_certified_node_path({"file": ""}) is False
+    assert _snapshot_certified_node_path({}) is False
+    assert _snapshot_certified_node_path({"file": 42}) is False
+
+
 def test_next_step_lean_production_anchor() -> None:
     from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
         _next_step_lean,

--- a/tests/unit/test_codegraph_context_tool.py
+++ b/tests/unit/test_codegraph_context_tool.py
@@ -1990,6 +1990,19 @@ def test_certified_expansion_propagates_edge_errors() -> None:
     )
     assert tolerated == seed
 
+    # A caller-query failure alone also propagates on the certified route.
+    class CallersBrokenStore:
+        def query_callees(self, name, file_path=None, max_depth=1):
+            return []
+
+        def query_callers(self, name, file_path=None):
+            raise RuntimeError("broken caller row")
+
+    with pytest.raises(RuntimeError, match="broken caller row"):
+        tool._expand_nodes(
+            seed, "explain run", 10, graph=CallersBrokenStore(), certified=True
+        )
+
 
 def test_next_step_lean_production_anchor() -> None:
     from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (

--- a/tests/unit/test_codegraph_context_tool.py
+++ b/tests/unit/test_codegraph_context_tool.py
@@ -1964,6 +1964,32 @@ def test_resolve_entry_points_tolerates_cascade_failures() -> None:
     assert entry_points == []
 
 
+def test_snapshot_definition_lines_resolve_callee_lines() -> None:
+    """Codex P2 round-13 (C59): cross-file callee nodes get definition lines."""
+    import sqlite3
+
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        _snapshot_definition_lines,
+    )
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        "CREATE TABLE ast_symbol_rows (file_path TEXT, name TEXT, line INTEGER)"
+    )
+    conn.execute("INSERT INTO ast_symbol_rows VALUES ('pkg/callee.py', 'run', 5)")
+    nodes = [
+        {"name": "run", "file": "pkg/callee.py", "line": 80},
+        {"name": "unknown", "file": "pkg/x.py", "line": 3},
+    ]
+    resolved = _snapshot_definition_lines(nodes, conn)
+    assert resolved[0]["line"] == 5
+    assert resolved[1]["line"] == 3
+
+    bare = sqlite3.connect(":memory:")
+    assert _snapshot_definition_lines(nodes, bare) == nodes
+
+
 def test_certified_expansion_propagates_edge_errors() -> None:
     """Codex P2 round-10 (C45): certified expansion re-raises edge errors."""
     import pytest

--- a/tests/unit/test_codegraph_context_tool.py
+++ b/tests/unit/test_codegraph_context_tool.py
@@ -1944,6 +1944,53 @@ def test_snapshot_certified_node_file_rejects_unsafe_files(
     assert _snapshot_certified_node_file("src/app.py", root, bare) is False
 
 
+def test_resolve_entry_points_tolerates_cascade_failures() -> None:
+    """The substring-cascade failure path degrades to no hits."""
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        CodeGraphContextTool,
+    )
+
+    class BoomCache:
+        def fts_search_ranked(self, candidate, limit=None):
+            return []
+
+        def search_symbols_cascade(self, candidate, limit=None):
+            raise RuntimeError("cascade down")
+
+    tool = CodeGraphContextTool("/nonexistent")
+    entry_points = tool._resolve_entry_points(
+        ["apply", "index", "zzz"], 5, cache=BoomCache()
+    )
+    assert entry_points == []
+
+
+def test_certified_expansion_propagates_edge_errors() -> None:
+    """Codex P2 round-10 (C45): certified expansion re-raises edge errors."""
+    import pytest
+
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        CodeGraphContextTool,
+    )
+
+    tool = CodeGraphContextTool("/nonexistent")
+
+    class BrokenStore:
+        def query_callees(self, name, file_path=None, max_depth=1):
+            raise RuntimeError("broken edge row")
+
+        def query_callers(self, name, file_path=None):
+            raise RuntimeError("broken edge row")
+
+    seed = [{"name": "run", "file": "app.py"}]
+    with pytest.raises(RuntimeError, match="broken edge row"):
+        tool._expand_nodes(seed, "explain run", 10, graph=BrokenStore(), certified=True)
+    # The live path keeps its stale-graph tolerance.
+    tolerated = tool._expand_nodes(
+        seed, "explain run", 10, graph=BrokenStore(), certified=False
+    )
+    assert tolerated == seed
+
+
 def test_next_step_lean_production_anchor() -> None:
     from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
         _next_step_lean,

--- a/tests/unit/test_codegraph_context_tool.py
+++ b/tests/unit/test_codegraph_context_tool.py
@@ -1900,20 +1900,42 @@ def test_next_step_lean_entry_points_without_code() -> None:
     assert "include_graph=true" in msg
 
 
-def test_snapshot_certified_node_path_rejects_unsafe_files() -> None:
-    """Codex P1 round-6 (C29): only relative in-root paths are certified."""
+def test_snapshot_certified_node_file_rejects_unsafe_files(
+    tmp_path: Path,
+) -> None:
+    """Codex P1 round-6/7 (C29/C30): only relative, in-root, INVENTORY
+    paths are certified — symlinked escapes and excluded files are not."""
+    import os
+    import sqlite3
+
     from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
-        _snapshot_certified_node_path,
+        _snapshot_certified_node_file,
     )
 
-    assert _snapshot_certified_node_path({"file": "src/app.py"}) is True
-    assert _snapshot_certified_node_path({"file": "app.py"}) is True
-    assert _snapshot_certified_node_path({"file": "/etc/passwd"}) is False
-    assert _snapshot_certified_node_path({"file": "../secret.py"}) is False
-    assert _snapshot_certified_node_path({"file": "src/../secret.py"}) is False
-    assert _snapshot_certified_node_path({"file": ""}) is False
-    assert _snapshot_certified_node_path({}) is False
-    assert _snapshot_certified_node_path({"file": 42}) is False
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.py").write_text("x = 1\n", encoding="utf-8")
+    (tmp_path / "excluded.py").write_text("y = 2\n", encoding="utf-8")
+    outside = tmp_path.parent / "outside_secret.py"
+    outside.write_text("z = 3\n", encoding="utf-8")
+    os.symlink(outside, tmp_path / "external_link")
+
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE ast_index (file_path TEXT)")
+    conn.execute("INSERT INTO ast_index VALUES ('src/app.py')")
+    conn.row_factory = sqlite3.Row
+    root = str(tmp_path.resolve())
+
+    assert _snapshot_certified_node_file("src/app.py", root, conn) is True
+    assert _snapshot_certified_node_file("/etc/passwd", root, conn) is False
+    assert _snapshot_certified_node_file("../secret.py", root, conn) is False
+    assert _snapshot_certified_node_file("src/../secret.py", root, conn) is False
+    assert _snapshot_certified_node_file("", root, conn) is False
+    assert _snapshot_certified_node_file(None, root, conn) is False
+    assert _snapshot_certified_node_file(42, root, conn) is False
+    # Symlink escape: lexical path is relative, realpath leaves the root.
+    assert _snapshot_certified_node_file("external_link", root, conn) is False
+    # Existing but not in the inventory: not generation-certified.
+    assert _snapshot_certified_node_file("excluded.py", root, conn) is False
 
 
 def test_next_step_lean_production_anchor() -> None:

--- a/tests/unit/test_diff_snapshot_readonly_capture.py
+++ b/tests/unit/test_diff_snapshot_readonly_capture.py
@@ -516,6 +516,7 @@ def test_registry_staged_mode_snapshots_match(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
+@pytest.mark.slow_ok  # real git diff capture x2; brushes the 5s budget under --cov
 def test_registry_scoped_snapshots_match(git_repo: str) -> None:
     Path(git_repo, "base.py").write_text("value = 2\n", encoding="utf-8")
     Path(git_repo, "new.py").write_text("x = 1\n", encoding="utf-8")

--- a/tests/unit/test_health_scorer.py
+++ b/tests/unit/test_health_scorer.py
@@ -70,6 +70,35 @@ class TestHealthScorer:
         for r in results:
             assert 0 <= r.total <= 100
 
+    def test_certified_score_omits_coverage_and_git_dimensions(
+        self, scorer, tmp_path, monkeypatch
+    ):
+        # Codex P1 (#1299 round-4): coverage.json and git history are outside
+        # the snapshot source generation — certified reads must not report
+        # dimensions that can drift for the same snapshot identity, even when
+        # those inputs are present.
+        import tree_sitter_analyzer.health_scorer as health_scorer
+
+        monkeypatch.setattr(health_scorer, "score_git_hotspot", lambda file_path: 80.0)
+        monkeypatch.setattr(
+            health_scorer.HealthScorer,
+            "_score_coverage",
+            lambda self, file_path: 90.0,
+        )
+        target = tmp_path / "app.py"
+        target.write_text("def run():\n    return 1\n", encoding="utf-8")
+
+        live = scorer.score_file(str(target), fast_dependencies=True)
+        assert "coverage" in live.dimensions
+        assert "git_hotspot" in live.dimensions
+
+        certified = scorer.score_file(
+            str(target), fast_dependencies=True, certified=True
+        )
+        assert "coverage" not in certified.dimensions
+        assert "git_hotspot" not in certified.dimensions
+        assert certified.total > 0.0
+
     def test_score_project_includes_reported_source_extensions(self, scorer, tmp_path):
         """Project scoring should include all configured reportable extensions."""
         from tree_sitter_analyzer.health_scorer import PROJECT_HEALTH_SOURCE_EXTS

--- a/tests/unit/test_health_scorer.py
+++ b/tests/unit/test_health_scorer.py
@@ -99,6 +99,14 @@ class TestHealthScorer:
         assert "git_hotspot" not in certified.dimensions
         assert certified.total > 0.0
 
+    def test_invalidate_stat_cache_drops_only_stat_fast_path(self) -> None:
+        from tree_sitter_analyzer.core.parser import Parser
+
+        Parser.invalidate_stat_cache()
+        assert Parser._stat_cache == {}
+        # The content-addressed cache is untouched.
+        assert isinstance(Parser._cache, object)
+
     def test_certified_score_never_touches_coverage_or_git(
         self, scorer, tmp_path, monkeypatch
     ):

--- a/tests/unit/test_health_scorer.py
+++ b/tests/unit/test_health_scorer.py
@@ -99,6 +99,30 @@ class TestHealthScorer:
         assert "git_hotspot" not in certified.dimensions
         assert certified.total > 0.0
 
+    def test_certified_score_never_touches_coverage_or_git(
+        self, scorer, tmp_path, monkeypatch
+    ):
+        # Codex P2 round-5 (C23): the certified branch must not EVALUATE the
+        # omitted dimensions — a corrupt coverage.json must not flip a
+        # certified request into a failure.
+        import tree_sitter_analyzer.health_scorer as health_scorer
+
+        def boom_coverage(self, file_path):
+            raise ValueError("corrupt coverage.json")
+
+        monkeypatch.setattr(
+            health_scorer.HealthScorer, "_score_coverage", boom_coverage
+        )
+        monkeypatch.setattr(health_scorer, "score_git_hotspot", lambda file_path: 1 / 0)
+        target = tmp_path / "app.py"
+        target.write_text("def run():\n    return 1\n", encoding="utf-8")
+
+        certified = scorer.score_file(
+            str(target), fast_dependencies=True, certified=True
+        )
+        assert certified.total > 0.0
+        assert "coverage" not in certified.dimensions
+
     def test_score_project_includes_reported_source_extensions(self, scorer, tmp_path):
         """Project scoring should include all configured reportable extensions."""
         from tree_sitter_analyzer.health_scorer import PROJECT_HEALTH_SOURCE_EXTS

--- a/tests/unit/test_index_snapshot.py
+++ b/tests/unit/test_index_snapshot.py
@@ -649,9 +649,11 @@ class TestReadExistingConsumerRevalidation:
             assert index.snapshot_id == published.snapshot_id
             assert yielded_conn is conn
 
-        assert captured == [scope]  # recapture ran after the read
+        # Codex P1 (#1299): recapture runs BEFORE the read (at __enter__)
+        # AND after it (on normal exit).
+        assert captured == [scope, scope]
 
-    def test_read_existing_index_scope_mismatch_on_exit_fails_closed(
+    def test_read_existing_index_scope_mismatch_before_yield_fails_closed(
         self, tmp_path, monkeypatch
     ):
         import sqlite3
@@ -685,6 +687,127 @@ class TestReadExistingConsumerRevalidation:
         with pytest.raises(ValueError, match="SOURCE_GENERATION_MISMATCH"):
             with owner.read_existing_index_scope(
                 published.snapshot_id, str(tmp_path), "gen-1"
+            ):
+                pass
+
+    def test_read_existing_index_scope_mismatch_on_exit_fails_closed(
+        self, tmp_path, monkeypatch
+    ):
+        """The after-read recapture (normal exit) still gates the result."""
+        import sqlite3
+
+        import tree_sitter_analyzer.index_snapshot as owner
+        from tree_sitter_analyzer.index_source_scope import (
+            make_source_scope_descriptor,
+        )
+
+        calls = {"n": 0}
+
+        def sequence_capture(root, source_scope, deadline=None):
+            # Pre-read recapture matches; the after-read recapture does not.
+            calls["n"] += 1
+            return self._fake_capture("exact", "gen-1" if calls["n"] == 1 else "gen-2")
+
+        monkeypatch.setattr(owner, "_capture_sources_with_deadline", sequence_capture)
+        conn = sqlite3.connect(":memory:")
+        snapshot = owner.IndexSnapshot(
+            None,
+            "fp",
+            "ifp",
+            "gen-1",
+            "complete",
+            None,
+            str(tmp_path.resolve()),
+            0,
+            source_scope=make_source_scope_descriptor(),
+        )
+        published = owner.REGISTRY.publish(snapshot, conn, 0)
+
+        with pytest.raises(ValueError, match="SOURCE_GENERATION_MISMATCH"):
+            with owner.read_existing_index_scope(
+                published.snapshot_id, str(tmp_path), "gen-1"
+            ):
+                pass
+
+    def test_read_existing_index_scope_rejects_incomplete_snapshot(
+        self, tmp_path, monkeypatch
+    ):
+        """A partial capability (CALL_GRAPH_INCOMPLETE) never serves reads."""
+        import sqlite3
+
+        import tree_sitter_analyzer.index_snapshot as owner
+        from tree_sitter_analyzer.index_source_scope import (
+            make_source_scope_descriptor,
+        )
+
+        monkeypatch.setattr(
+            owner,
+            "_capture_sources_with_deadline",
+            lambda root, source_scope, deadline=None: self._fake_capture(
+                "exact", "gen-1"
+            ),
+        )
+        conn = sqlite3.connect(":memory:")
+        snapshot = owner.IndexSnapshot(
+            None,
+            "fp",
+            "ifp",
+            "gen-1",
+            "partial",
+            "CALL_GRAPH_INCOMPLETE",
+            str(tmp_path.resolve()),
+            0,
+            source_scope=make_source_scope_descriptor(),
+        )
+        published = owner.REGISTRY.publish(snapshot, conn, 0)
+
+        with pytest.raises(ValueError, match="INDEX_SNAPSHOT_INCOMPLETE"):
+            with owner.read_existing_index_scope(
+                published.snapshot_id, str(tmp_path), "gen-1"
+            ):
+                pass
+
+    def test_read_existing_index_scope_honors_expired_deadline(
+        self, tmp_path, monkeypatch
+    ):
+        """An absolute deadline in the past fails closed at acquisition."""
+        import sqlite3
+        import time
+
+        import tree_sitter_analyzer.index_snapshot as owner
+        from tree_sitter_analyzer.index_source_scope import (
+            make_source_scope_descriptor,
+        )
+
+        monkeypatch.setattr(
+            owner,
+            "_capture_sources_with_deadline",
+            lambda root, source_scope, deadline=None: self._fake_capture(
+                "exact", "gen-1"
+            ),
+        )
+        conn = sqlite3.connect(":memory:")
+        snapshot = owner.IndexSnapshot(
+            None,
+            "fp",
+            "ifp",
+            "gen-1",
+            "complete",
+            None,
+            str(tmp_path.resolve()),
+            0,
+            source_scope=make_source_scope_descriptor(),
+        )
+        published = owner.REGISTRY.publish(snapshot, conn, 0)
+
+        # REGISTRY.acquire raises RuntimeError for an expired deadline; the
+        # consumer seam classifies both ValueError and RuntimeError.
+        with pytest.raises(RuntimeError, match="INDEX_SNAPSHOT_DEADLINE"):
+            with owner.read_existing_index_scope(
+                published.snapshot_id,
+                str(tmp_path),
+                "gen-1",
+                deadline=time.monotonic() - 1,
             ):
                 pass
 

--- a/tests/unit/test_index_snapshot.py
+++ b/tests/unit/test_index_snapshot.py
@@ -684,11 +684,17 @@ class TestReadExistingConsumerRevalidation:
         )
         published = owner.REGISTRY.publish(snapshot, conn, 0)
 
-        with pytest.raises(ValueError, match="SOURCE_GENERATION_MISMATCH"):
+        with pytest.raises(ValueError, match="SOURCE_GENERATION_MISMATCH") as exc_info:
             with owner.read_existing_index_scope(
                 published.snapshot_id, str(tmp_path), "gen-1"
             ):
                 pass
+        # Codex P2 (#1299): pre-yield failures still cite the acquired
+        # capability identity.
+        assert getattr(exc_info.value, "_read_existing_identity", None) == (
+            published.snapshot_id,
+            "gen-1",
+        )
 
     def test_read_existing_index_scope_mismatch_on_exit_fails_closed(
         self, tmp_path, monkeypatch
@@ -761,11 +767,15 @@ class TestReadExistingConsumerRevalidation:
         )
         published = owner.REGISTRY.publish(snapshot, conn, 0)
 
-        with pytest.raises(ValueError, match="INDEX_SNAPSHOT_INCOMPLETE"):
+        with pytest.raises(ValueError, match="INDEX_SNAPSHOT_INCOMPLETE") as exc_info:
             with owner.read_existing_index_scope(
                 published.snapshot_id, str(tmp_path), "gen-1"
             ):
                 pass
+        assert getattr(exc_info.value, "_read_existing_identity", None) == (
+            published.snapshot_id,
+            "gen-1",
+        )
 
     def test_read_existing_index_scope_honors_expired_deadline(
         self, tmp_path, monkeypatch
@@ -810,6 +820,56 @@ class TestReadExistingConsumerRevalidation:
                 deadline=time.monotonic() - 1,
             ):
                 pass
+
+    def test_read_existing_index_scope_reader_deadline_enforced(
+        self, tmp_path, monkeypatch
+    ):
+        """Reader SQL work past the absolute deadline fails closed.
+
+        Codex P2 (#1299): the progress handler bounds SQLite work, and the
+        post-yield re-check is the hard guarantee even when a reader swallows
+        the abort — both share the scope's absolute deadline.
+        """
+        import sqlite3
+        import time
+
+        import tree_sitter_analyzer.index_snapshot as owner
+        from tree_sitter_analyzer.index_source_scope import (
+            make_source_scope_descriptor,
+        )
+
+        clock = {"now": time.monotonic()}
+        monkeypatch.setattr(owner, "_clock", lambda: clock["now"])
+        monkeypatch.setattr(
+            owner,
+            "_capture_sources_with_deadline",
+            lambda root, source_scope, deadline=None: self._fake_capture(
+                "exact", "gen-1"
+            ),
+        )
+        conn = sqlite3.connect(":memory:")
+        conn.execute("CREATE TABLE t (x INTEGER)")
+        conn.execute("INSERT INTO t VALUES (1)")
+        snapshot = owner.IndexSnapshot(
+            None,
+            "fp",
+            "ifp",
+            "gen-1",
+            "complete",
+            None,
+            str(tmp_path.resolve()),
+            0,
+            source_scope=make_source_scope_descriptor(),
+        )
+        published = owner.REGISTRY.publish(snapshot, conn, 0)
+
+        with pytest.raises(RuntimeError, match="INDEX_SNAPSHOT_DEADLINE"):
+            with owner.read_existing_index_scope(
+                published.snapshot_id, str(tmp_path), "gen-1"
+            ) as (index, scope_conn):
+                # The reader's SQL runs after the deadline has passed.
+                clock["now"] += 100.0
+                scope_conn.execute("SELECT count(*) FROM t")
 
     @pytest.mark.parametrize("bad_root", ["", b"not-a-str"])
     def test_verify_unusable_root_raises_index_snapshot_unknown(

--- a/tests/unit/test_index_snapshot.py
+++ b/tests/unit/test_index_snapshot.py
@@ -687,3 +687,121 @@ class TestReadExistingConsumerRevalidation:
                 published.snapshot_id, str(tmp_path), "gen-1"
             ):
                 pass
+
+    @pytest.mark.parametrize("bad_root", ["", b"not-a-str"])
+    def test_verify_unusable_root_raises_index_snapshot_unknown(
+        self, tmp_path, monkeypatch, bad_root
+    ):
+        import tree_sitter_analyzer.index_snapshot as owner
+
+        monkeypatch.setattr(
+            owner,
+            "_capture_sources_with_deadline",
+            lambda root, source_scope, deadline=None: self._fake_capture(
+                "exact", "gen-1"
+            ),
+        )
+        snapshot = owner.IndexSnapshot(
+            "s",
+            "fp",
+            "ifp",
+            "gen-1",
+            "complete",
+            None,
+            bad_root,
+            0,
+            source_scope=object(),
+        )
+
+        with pytest.raises(ValueError, match="INDEX_SNAPSHOT_UNKNOWN"):
+            owner.verify_snapshot_source_current(snapshot)
+
+    def test_verify_absent_generation_and_fingerprint_raises(
+        self, tmp_path, monkeypatch
+    ):
+        import tree_sitter_analyzer.index_snapshot as owner
+
+        monkeypatch.setattr(
+            owner,
+            "_capture_sources_with_deadline",
+            lambda root, source_scope, deadline=None: self._fake_capture(
+                "exact", None, fingerprint=None
+            ),
+        )
+        snapshot = owner.IndexSnapshot(
+            "s",
+            None,
+            "ifp",
+            None,
+            "complete",
+            None,
+            str(tmp_path.resolve()),
+            0,
+            source_scope=object(),
+        )
+
+        with pytest.raises(ValueError, match="SOURCE_GENERATION_MISMATCH"):
+            owner.verify_snapshot_source_current(snapshot)
+
+    def test_verify_fingerprint_match_passes_when_generation_absent(
+        self, tmp_path, monkeypatch
+    ):
+        import tree_sitter_analyzer.index_snapshot as owner
+
+        monkeypatch.setattr(
+            owner,
+            "_capture_sources_with_deadline",
+            lambda root, source_scope, deadline=None: self._fake_capture(
+                "exact", None, fingerprint="fp"
+            ),
+        )
+        snapshot = owner.IndexSnapshot(
+            "s",
+            "fp",
+            "ifp",
+            None,
+            "complete",
+            None,
+            str(tmp_path.resolve()),
+            0,
+            source_scope=object(),
+        )
+
+        owner.verify_snapshot_source_current(snapshot)  # no raise
+
+    def test_read_existing_index_scope_rejects_constrained_scope(
+        self, tmp_path, monkeypatch
+    ):
+        import sqlite3
+
+        import tree_sitter_analyzer.index_snapshot as owner
+        from tree_sitter_analyzer.index_source_scope import (
+            make_source_scope_descriptor,
+        )
+
+        monkeypatch.setattr(
+            owner,
+            "_capture_sources_with_deadline",
+            lambda root, source_scope, deadline=None: self._fake_capture(
+                "exact", "gen-1"
+            ),
+        )
+        conn = sqlite3.connect(":memory:")
+        snapshot = owner.IndexSnapshot(
+            None,
+            "fp",
+            "ifp",
+            "gen-1",
+            "complete",
+            None,
+            str(tmp_path.resolve()),
+            0,
+            source_scope=make_source_scope_descriptor(exclude_patterns=("vendor",)),
+        )
+        published = owner.REGISTRY.publish(snapshot, conn, 0)
+
+        with pytest.raises(ValueError, match="CONSTRAINED_INDEX_SCOPE"):
+            with owner.read_existing_index_scope(
+                published.snapshot_id, str(tmp_path), "gen-1"
+            ):
+                pass

--- a/tests/unit/test_index_snapshot.py
+++ b/tests/unit/test_index_snapshot.py
@@ -821,15 +821,7 @@ class TestReadExistingConsumerRevalidation:
             ):
                 pass
 
-    def test_read_existing_index_scope_reader_deadline_enforced(
-        self, tmp_path, monkeypatch
-    ):
-        """Reader SQL work past the absolute deadline fails closed.
-
-        Codex P2 (#1299): the progress handler bounds SQLite work, and the
-        post-yield re-check is the hard guarantee even when a reader swallows
-        the abort — both share the scope's absolute deadline.
-        """
+    def _deadline_scope_fixture(self, tmp_path, monkeypatch):
         import sqlite3
         import time
 
@@ -849,7 +841,9 @@ class TestReadExistingConsumerRevalidation:
         )
         conn = sqlite3.connect(":memory:")
         conn.execute("CREATE TABLE t (x INTEGER)")
-        conn.execute("INSERT INTO t VALUES (1)")
+        # Enough rows that the reader's query exceeds the progress-handler
+        # step (1000 VM opcodes) and the handler itself fires.
+        conn.executemany("INSERT INTO t VALUES (?)", [(i,) for i in range(50_000)])
         snapshot = owner.IndexSnapshot(
             None,
             "fp",
@@ -862,14 +856,52 @@ class TestReadExistingConsumerRevalidation:
             source_scope=make_source_scope_descriptor(),
         )
         published = owner.REGISTRY.publish(snapshot, conn, 0)
+        return owner, published, clock
 
-        with pytest.raises(RuntimeError, match="INDEX_SNAPSHOT_DEADLINE"):
+    def test_read_existing_index_scope_reader_sql_aborts_on_deadline(
+        self, tmp_path, monkeypatch
+    ):
+        """The progress handler aborts reader SQL past the deadline.
+
+        Codex P2 (#1299): the LIKE scan guarantees the handler fires
+        (count(*) is too optimized to reach the 1000-opcode step); the
+        abort surfaces as ``sqlite3.OperationalError: interrupted``, which
+        the consumer seam classifies as INDEX_SNAPSHOT_DEADLINE.
+        """
+        import sqlite3
+
+        owner, published, clock = self._deadline_scope_fixture(tmp_path, monkeypatch)
+
+        with pytest.raises(sqlite3.OperationalError, match="interrupted"):
             with owner.read_existing_index_scope(
                 published.snapshot_id, str(tmp_path), "gen-1"
             ) as (index, scope_conn):
                 # The reader's SQL runs after the deadline has passed.
                 clock["now"] += 100.0
-                scope_conn.execute("SELECT count(*) FROM t")
+                scope_conn.execute("SELECT x FROM t WHERE x LIKE '%7%'").fetchall()
+
+    def test_read_existing_index_scope_post_read_deadline_check(
+        self, tmp_path, monkeypatch
+    ):
+        """The post-yield re-check fires even when a reader swallows aborts.
+
+        Codex P2 (#1299): a reader that absorbs the interrupt and returns a
+        payload still cannot outlive the absolute deadline — the scope's own
+        re-check raises INDEX_SNAPSHOT_DEADLINE after the yield.
+        """
+        import sqlite3
+
+        owner, published, clock = self._deadline_scope_fixture(tmp_path, monkeypatch)
+
+        with pytest.raises(RuntimeError, match="INDEX_SNAPSHOT_DEADLINE"):
+            with owner.read_existing_index_scope(
+                published.snapshot_id, str(tmp_path), "gen-1"
+            ) as (index, scope_conn):
+                clock["now"] += 100.0
+                try:
+                    scope_conn.execute("SELECT x FROM t WHERE x LIKE '%7%'").fetchall()
+                except sqlite3.OperationalError:
+                    pass  # reader swallows the abort
 
     @pytest.mark.parametrize("bad_root", ["", b"not-a-str"])
     def test_verify_unusable_root_raises_index_snapshot_unknown(

--- a/tests/unit/test_index_snapshot.py
+++ b/tests/unit/test_index_snapshot.py
@@ -468,3 +468,222 @@ def test_hierarchy_cache_open_error_releases_temporary_root_fd(tmp_path, monkeyp
             os.close(fd)
 
     assert (matches, released) == (False, temporary)
+
+
+class TestReadExistingConsumerRevalidation:
+    """RFC-0022 P0.4 after-read revalidation seam for P0.1 consumers."""
+
+    @pytest.fixture(autouse=True)
+    def _close_registry(self):
+        yield
+        from tree_sitter_analyzer.index_snapshot import REGISTRY
+
+        REGISTRY.close_all()
+
+    @staticmethod
+    def _fake_capture(state, generation, fingerprint="fp", reason=None):
+        from tree_sitter_analyzer.index_source_snapshot import (
+            CurrentSourceSnapshot,
+        )
+
+        return CurrentSourceSnapshot(
+            frozenset(), fingerprint, generation, state, reason
+        )
+
+    def test_verify_skips_capture_without_source_scope(self, tmp_path, monkeypatch):
+        import tree_sitter_analyzer.index_snapshot as owner
+
+        captured: list[object] = []
+
+        def fake_capture(root, scope, deadline=None):
+            captured.append(scope)
+            return self._fake_capture("exact", "gen-1")
+
+        monkeypatch.setattr(owner, "_capture_sources_with_deadline", fake_capture)
+        snapshot = owner.IndexSnapshot(
+            "s", "fp", "ifp", "gen-1", "complete", None, str(tmp_path.resolve()), 0
+        )
+
+        owner.verify_snapshot_source_current(snapshot)
+
+        assert captured == []  # no scope descriptor -> nothing to revalidate
+
+    def test_verify_generation_match_passes(self, tmp_path, monkeypatch):
+        import tree_sitter_analyzer.index_snapshot as owner
+
+        scope = object()
+        monkeypatch.setattr(
+            owner,
+            "_capture_sources_with_deadline",
+            lambda root, source_scope, deadline=None: self._fake_capture(
+                "exact", "gen-1"
+            ),
+        )
+        snapshot = owner.IndexSnapshot(
+            "s",
+            "fp",
+            "ifp",
+            "gen-1",
+            "complete",
+            None,
+            str(tmp_path.resolve()),
+            0,
+            source_scope=scope,
+        )
+
+        owner.verify_snapshot_source_current(snapshot)  # no raise
+
+    def test_verify_generation_mismatch_raises(self, tmp_path, monkeypatch):
+        import tree_sitter_analyzer.index_snapshot as owner
+
+        monkeypatch.setattr(
+            owner,
+            "_capture_sources_with_deadline",
+            lambda root, source_scope, deadline=None: self._fake_capture(
+                "exact", "gen-2"
+            ),
+        )
+        snapshot = owner.IndexSnapshot(
+            "s",
+            "fp",
+            "ifp",
+            "gen-1",
+            "complete",
+            None,
+            str(tmp_path.resolve()),
+            0,
+            source_scope=object(),
+        )
+
+        with pytest.raises(ValueError, match="SOURCE_GENERATION_MISMATCH"):
+            owner.verify_snapshot_source_current(snapshot)
+
+    def test_verify_fingerprint_fallback_when_generation_absent(
+        self, tmp_path, monkeypatch
+    ):
+        import tree_sitter_analyzer.index_snapshot as owner
+
+        monkeypatch.setattr(
+            owner,
+            "_capture_sources_with_deadline",
+            lambda root, source_scope, deadline=None: self._fake_capture(
+                "exact", None, fingerprint="fp-new"
+            ),
+        )
+        snapshot = owner.IndexSnapshot(
+            "s",
+            "fp-old",
+            "ifp",
+            None,
+            "complete",
+            None,
+            str(tmp_path.resolve()),
+            0,
+            source_scope=object(),
+        )
+
+        with pytest.raises(ValueError, match="SOURCE_GENERATION_MISMATCH"):
+            owner.verify_snapshot_source_current(snapshot)
+
+    def test_verify_non_exact_state_raises(self, tmp_path, monkeypatch):
+        import tree_sitter_analyzer.index_snapshot as owner
+
+        monkeypatch.setattr(
+            owner,
+            "_capture_sources_with_deadline",
+            lambda root, source_scope, deadline=None: self._fake_capture(
+                "unsafe", "gen-1", reason="SOURCE_SCOPE_UNSAFE"
+            ),
+        )
+        snapshot = owner.IndexSnapshot(
+            "s",
+            "fp",
+            "ifp",
+            "gen-1",
+            "complete",
+            None,
+            str(tmp_path.resolve()),
+            0,
+            source_scope=object(),
+        )
+
+        with pytest.raises(ValueError, match="SOURCE_SCOPE_UNSAFE"):
+            owner.verify_snapshot_source_current(snapshot)
+
+    def test_read_existing_index_scope_recaptures_after_read(
+        self, tmp_path, monkeypatch
+    ):
+        import sqlite3
+
+        import tree_sitter_analyzer.index_snapshot as owner
+        from tree_sitter_analyzer.index_source_scope import (
+            make_source_scope_descriptor,
+        )
+
+        scope = make_source_scope_descriptor()
+        captured: list[object] = []
+        monkeypatch.setattr(
+            owner,
+            "_capture_sources_with_deadline",
+            lambda root, source_scope, deadline=None: (
+                captured.append(source_scope) or self._fake_capture("exact", "gen-1")
+            ),
+        )
+        conn = sqlite3.connect(":memory:")
+        snapshot = owner.IndexSnapshot(
+            None,
+            "fp",
+            "ifp",
+            "gen-1",
+            "complete",
+            None,
+            str(tmp_path.resolve()),
+            0,
+            source_scope=scope,
+        )
+        published = owner.REGISTRY.publish(snapshot, conn, 0)
+
+        with owner.read_existing_index_scope(
+            published.snapshot_id, str(tmp_path), "gen-1"
+        ) as (index, yielded_conn):
+            assert index.snapshot_id == published.snapshot_id
+            assert yielded_conn is conn
+
+        assert captured == [scope]  # recapture ran after the read
+
+    def test_read_existing_index_scope_mismatch_on_exit_fails_closed(
+        self, tmp_path, monkeypatch
+    ):
+        import sqlite3
+
+        import tree_sitter_analyzer.index_snapshot as owner
+        from tree_sitter_analyzer.index_source_scope import (
+            make_source_scope_descriptor,
+        )
+
+        monkeypatch.setattr(
+            owner,
+            "_capture_sources_with_deadline",
+            lambda root, source_scope, deadline=None: self._fake_capture(
+                "exact", "gen-2"
+            ),
+        )
+        conn = sqlite3.connect(":memory:")
+        snapshot = owner.IndexSnapshot(
+            None,
+            "fp",
+            "ifp",
+            "gen-1",
+            "complete",
+            None,
+            str(tmp_path.resolve()),
+            0,
+            source_scope=make_source_scope_descriptor(),
+        )
+        published = owner.REGISTRY.publish(snapshot, conn, 0)
+
+        with pytest.raises(ValueError, match="SOURCE_GENERATION_MISMATCH"):
+            with owner.read_existing_index_scope(
+                published.snapshot_id, str(tmp_path), "gen-1"
+            ):
+                pass

--- a/tests/unit/test_wire_owner_contract.py
+++ b/tests/unit/test_wire_owner_contract.py
@@ -396,6 +396,72 @@ def test_read_existing_consumer_post_read_mismatch_preserves_record(
     assert result["action_version"] == NAV_CONTEXT_ACTION_VERSION
 
 
+def test_read_existing_consumer_pre_read_mismatch_preserves_record(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A pre-yield recapture failure still cites the acquired snapshot."""
+    import sqlite3
+
+    import tree_sitter_analyzer.index_snapshot as snapshot_owner
+    import tree_sitter_analyzer.read_existing_access as read_access
+    from tree_sitter_analyzer.index_snapshot import REGISTRY, IndexSnapshot
+    from tree_sitter_analyzer.index_source_scope import make_source_scope_descriptor
+    from tree_sitter_analyzer.index_source_snapshot import CurrentSourceSnapshot
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        CodeGraphContextTool,
+    )
+    from tree_sitter_analyzer.wire_owner import NAV_CONTEXT_ACTION_VERSION
+
+    monkeypatch.setattr(read_access, "read_existing_platform_supported", lambda: True)
+    monkeypatch.setattr(
+        snapshot_owner,
+        "_capture_sources_with_deadline",
+        lambda root, source_scope, deadline=None: CurrentSourceSnapshot(
+            frozenset(), "fp", "gen-2", "exact", None
+        ),
+    )
+    conn = sqlite3.connect(":memory:")
+    snapshot = IndexSnapshot(
+        None,
+        "fp",
+        "ifp",
+        "gen-1",
+        "complete",
+        None,
+        str(tmp_path.resolve()),
+        0,
+        None,
+        None,
+        make_source_scope_descriptor(),
+    )
+    published = REGISTRY.publish(snapshot, conn, 0)
+
+    def ok_reader(snapshot, conn):
+        return {"success": True, "verdict": "INFO"}
+
+    result = read_access.read_existing_index_consumer(
+        CodeGraphContextTool(str(tmp_path)),
+        {
+            "access_mode": "read_existing",
+            "snapshot_id": published.snapshot_id,
+            "source_generation": "gen-1",
+            "output_format": "json",
+        },
+        reader=ok_reader,
+        action_version=NAV_CONTEXT_ACTION_VERSION,
+    )
+    assert result["success"] is False
+    assert result["error_code"] == "SOURCE_GENERATION_MISMATCH"
+    assert result["source_snapshots"] == [
+        {
+            "kind": "index",
+            "snapshot_id": published.snapshot_id,
+            "source_generation": "gen-1",
+        }
+    ]
+    assert result["action_version"] == NAV_CONTEXT_ACTION_VERSION
+
+
 @pytest.mark.parametrize(
     ("tool_type", "module_name"),
     [

--- a/tests/unit/test_wire_owner_contract.py
+++ b/tests/unit/test_wire_owner_contract.py
@@ -551,6 +551,25 @@ def test_read_existing_consumer_classifies_reader_sql_failures(
     assert interrupted["action_version"] == NAV_CONTEXT_ACTION_VERSION
 
     # Codex P2 round-4 (C20): a damaged edges row surfaces as IndexError
+    # Codex P2 round-12 (C55): a BLOB in a nominally textual edge column
+    # surfaces as TypeError from parse_node_id — classified too.
+    def type_error_reader(snapshot, conn):
+        raise TypeError("startswith first arg must be str")
+
+    type_error = read_access.read_existing_index_consumer(
+        CodeGraphContextTool(str(tmp_path)),
+        {
+            "access_mode": "read_existing",
+            "snapshot_id": published.snapshot_id,
+            "source_generation": "gen-1",
+            "output_format": "json",
+        },
+        reader=type_error_reader,
+        action_version=NAV_CONTEXT_ACTION_VERSION,
+    )
+    assert type_error["success"] is False
+    assert type_error["error_code"] == "CORRUPT_INDEX"
+
     # Codex P2 round-11 (C50): a metadata cell holding valid JSON of a
     # non-object type surfaces as AttributeError — classified too.
     def attr_error_reader(snapshot, conn):

--- a/tests/unit/test_wire_owner_contract.py
+++ b/tests/unit/test_wire_owner_contract.py
@@ -49,13 +49,15 @@ def test_nav_context_success_echoes_action_version(tmp_path: Path) -> None:
     assert result["action_version"] == "nav.context/v1"
 
 
-def test_nav_context_unavailable_echoes_action_version() -> None:
+def test_nav_context_unavailable_echoes_action_version(tmp_path: Path) -> None:
+    import sys
+
     from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
         CodeGraphContextTool,
     )
     from tree_sitter_analyzer.wire_owner import NAV_CONTEXT_ACTION_VERSION
 
-    tool = CodeGraphContextTool()
+    tool = CodeGraphContextTool(str(tmp_path))
     result = _run(
         tool.execute(
             {
@@ -67,9 +69,20 @@ def test_nav_context_unavailable_echoes_action_version() -> None:
         )
     )
     assert result["action_version"] == NAV_CONTEXT_ACTION_VERSION
+    if sys.platform.startswith("linux"):
+        # RFC-0022 P0.4: the certified backend runs and classifies the
+        # never-published pair; the classified failure still echoes the
+        # owner version.
+        assert result["success"] is False
+        assert result["access_state"] == "unknown"
+        assert result["access_reason"] == "INDEX_SNAPSHOT_UNKNOWN"
+        assert result["error_code"] == "INDEX_SNAPSHOT_UNKNOWN"
+        assert result["source_snapshots"] == []
 
 
 def test_safe_to_edit_unavailable_echoes_action_version() -> None:
+    import sys
+
     from tree_sitter_analyzer.mcp.tools.safe_to_edit_tool import SafeToEditTool
     from tree_sitter_analyzer.wire_owner import EDIT_SAFE_ACTION_VERSION
 
@@ -86,6 +99,15 @@ def test_safe_to_edit_unavailable_echoes_action_version() -> None:
     )
     assert result["action_version"] == EDIT_SAFE_ACTION_VERSION
     assert result["action_version"] == "edit.safe/v1"
+    if sys.platform.startswith("linux"):
+        # RFC-0022 P0.4: the certified backend runs and classifies the
+        # never-published pair; the classified failure still echoes the
+        # owner version.
+        assert result["success"] is False
+        assert result["access_state"] == "unknown"
+        assert result["access_reason"] == "INDEX_SNAPSHOT_UNKNOWN"
+        assert result["error_code"] == "INDEX_SNAPSHOT_UNKNOWN"
+        assert result["source_snapshots"] == []
 
 
 def test_change_impact_unavailable_echoes_action_version(tmp_path: Path) -> None:
@@ -352,3 +374,50 @@ def test_diff_consumer_platform_gate_handles_none_unavailable(
         "DIFF_SNAPSHOT_UNKNOWN",
         "MISSING_PROJECT_ROOT",
     }
+
+
+# RFC-0022 P0.4 (Codex P1 #1297, extended to the P0.1 consumers): with the
+# platform authority forced open, the acquire-failure envelopes of nav.context
+# and edit.safe must still echo their wire-owner action_version.
+def test_nav_and_safe_certified_failure_echoes_action_version(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import tree_sitter_analyzer.read_existing_access as read_access
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        CodeGraphContextTool,
+    )
+    from tree_sitter_analyzer.mcp.tools.safe_to_edit_tool import SafeToEditTool
+    from tree_sitter_analyzer.wire_owner import (
+        EDIT_SAFE_ACTION_VERSION,
+        NAV_CONTEXT_ACTION_VERSION,
+    )
+
+    monkeypatch.setattr(read_access, "read_existing_platform_supported", lambda: True)
+    nav = _run(
+        CodeGraphContextTool(str(tmp_path)).execute(
+            {
+                "task": "x",
+                "access_mode": "read_existing",
+                "snapshot_id": "s1",
+                "source_generation": "1",
+                "output_format": "json",
+            }
+        )
+    )
+    assert nav["action_version"] == NAV_CONTEXT_ACTION_VERSION
+    assert nav["success"] is False
+    assert nav["access_reason"] == "INDEX_SNAPSHOT_UNKNOWN"
+    safe = _run(
+        SafeToEditTool(str(tmp_path)).execute(
+            {
+                "file_path": "x.py",
+                "access_mode": "read_existing",
+                "snapshot_id": "s1",
+                "source_generation": "1",
+                "output_format": "json",
+            }
+        )
+    )
+    assert safe["action_version"] == EDIT_SAFE_ACTION_VERSION
+    assert safe["success"] is False
+    assert safe["access_reason"] == "INDEX_SNAPSHOT_UNKNOWN"

--- a/tests/unit/test_wire_owner_contract.py
+++ b/tests/unit/test_wire_owner_contract.py
@@ -550,6 +550,27 @@ def test_read_existing_consumer_classifies_reader_sql_failures(
     assert interrupted["error_code"] == "INDEX_SNAPSHOT_DEADLINE"
     assert interrupted["action_version"] == NAV_CONTEXT_ACTION_VERSION
 
+    # Codex P2 round-4 (C20): a damaged edges row surfaces as IndexError
+    # from EdgeStore._edge_from_row — classified, never escaping the wire
+    # contract.
+    def index_error_reader(snapshot, conn):
+        raise IndexError("tuple index out of range")
+
+    index_error = read_access.read_existing_index_consumer(
+        CodeGraphContextTool(str(tmp_path)),
+        {
+            "access_mode": "read_existing",
+            "snapshot_id": published.snapshot_id,
+            "source_generation": "gen-1",
+            "output_format": "json",
+        },
+        reader=index_error_reader,
+        action_version=NAV_CONTEXT_ACTION_VERSION,
+    )
+    assert index_error["success"] is False
+    assert index_error["error_code"] == "CORRUPT_INDEX"
+    assert index_error["action_version"] == NAV_CONTEXT_ACTION_VERSION
+
 
 @pytest.mark.parametrize(
     ("tool_type", "module_name"),

--- a/tests/unit/test_wire_owner_contract.py
+++ b/tests/unit/test_wire_owner_contract.py
@@ -326,6 +326,76 @@ def test_diff_snapshot_consumers_frozen_error_echoes_action_version(
 # ``read_existing_unavailable`` as potentially None; that defensive branch
 # cannot be reached from a read_existing call (the mode implies the access
 # token), so force it with a stub to keep the guard exact.
+def test_read_existing_consumer_post_read_mismatch_preserves_record(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An after-read recapture failure still cites the acquired snapshot."""
+    import sqlite3
+
+    import tree_sitter_analyzer.index_snapshot as snapshot_owner
+    import tree_sitter_analyzer.read_existing_access as read_access
+    from tree_sitter_analyzer.index_snapshot import REGISTRY, IndexSnapshot
+    from tree_sitter_analyzer.index_source_scope import make_source_scope_descriptor
+    from tree_sitter_analyzer.index_source_snapshot import CurrentSourceSnapshot
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        CodeGraphContextTool,
+    )
+    from tree_sitter_analyzer.wire_owner import NAV_CONTEXT_ACTION_VERSION
+
+    monkeypatch.setattr(read_access, "read_existing_platform_supported", lambda: True)
+    calls = {"n": 0}
+
+    def sequence_capture(root, source_scope, deadline=None):
+        calls["n"] += 1
+        generation = "gen-1" if calls["n"] == 1 else "gen-2"
+        return CurrentSourceSnapshot(frozenset(), "fp", generation, "exact", None)
+
+    monkeypatch.setattr(
+        snapshot_owner, "_capture_sources_with_deadline", sequence_capture
+    )
+    conn = sqlite3.connect(":memory:")
+    snapshot = IndexSnapshot(
+        None,
+        "fp",
+        "ifp",
+        "gen-1",
+        "complete",
+        None,
+        str(tmp_path.resolve()),
+        0,
+        None,
+        None,
+        make_source_scope_descriptor(),
+    )
+    published = REGISTRY.publish(snapshot, conn, 0)
+
+    def ok_reader(snapshot, conn):
+        return {"success": True, "verdict": "INFO"}
+
+    result = read_access.read_existing_index_consumer(
+        CodeGraphContextTool(str(tmp_path)),
+        {
+            "access_mode": "read_existing",
+            "snapshot_id": published.snapshot_id,
+            "source_generation": "gen-1",
+            "output_format": "json",
+        },
+        reader=ok_reader,
+        action_version=NAV_CONTEXT_ACTION_VERSION,
+    )
+    assert result["success"] is False
+    assert result["error_code"] == "SOURCE_GENERATION_MISMATCH"
+    assert result["access_reason"] == "SOURCE_GENERATION_MISMATCH"
+    assert result["source_snapshots"] == [
+        {
+            "kind": "index",
+            "snapshot_id": published.snapshot_id,
+            "source_generation": "gen-1",
+        }
+    ]
+    assert result["action_version"] == NAV_CONTEXT_ACTION_VERSION
+
+
 @pytest.mark.parametrize(
     ("tool_type", "module_name"),
     [
@@ -477,6 +547,18 @@ def test_read_existing_consumer_rejects_non_dict_payload(
     from tree_sitter_analyzer.wire_owner import NAV_CONTEXT_ACTION_VERSION
 
     monkeypatch.setattr(read_access, "read_existing_platform_supported", lambda: True)
+    # The pre-read recapture (Codex P1 #1299) must see the same generation
+    # the capability was published with, exactly like a real publish would.
+    import tree_sitter_analyzer.index_snapshot as snapshot_owner
+    from tree_sitter_analyzer.index_source_snapshot import CurrentSourceSnapshot
+
+    monkeypatch.setattr(
+        snapshot_owner,
+        "_capture_sources_with_deadline",
+        lambda root, source_scope, deadline=None: CurrentSourceSnapshot(
+            frozenset(), "fp", "gen-1", "exact", None
+        ),
+    )
     scope = make_source_scope_descriptor()
     conn = sqlite3.connect(":memory:")
     snapshot = IndexSnapshot(
@@ -514,3 +596,12 @@ def test_read_existing_consumer_rejects_non_dict_payload(
     assert result["error_code"] == "INDEX_SNAPSHOT_FAILED"
     assert result["access_reason"] == "INDEX_SNAPSHOT_FAILED"
     assert result["action_version"] == NAV_CONTEXT_ACTION_VERSION
+    # Codex P2 (#1299): a failure AFTER acquisition still cites the exact
+    # capability identity that was read.
+    assert result["source_snapshots"] == [
+        {
+            "kind": "index",
+            "snapshot_id": published.snapshot_id,
+            "source_generation": "gen-1",
+        }
+    ]

--- a/tests/unit/test_wire_owner_contract.py
+++ b/tests/unit/test_wire_owner_contract.py
@@ -421,3 +421,96 @@ def test_nav_and_safe_certified_failure_echoes_action_version(
     assert safe["action_version"] == EDIT_SAFE_ACTION_VERSION
     assert safe["success"] is False
     assert safe["access_reason"] == "INDEX_SNAPSHOT_UNKNOWN"
+
+
+# The P0.1 consumer seam classifies an unbound project root as a
+# MISSING_PROJECT_ROOT failure envelope with evidence + action_version
+# (Codex review P2, #1299): the raise is inside read_existing_index_consumer,
+# not a bare escape that loses the wire contract.
+def test_read_existing_consumer_unbound_root_is_classified(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tree_sitter_analyzer.read_existing_access as read_access
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        CodeGraphContextTool,
+    )
+    from tree_sitter_analyzer.wire_owner import NAV_CONTEXT_ACTION_VERSION
+
+    monkeypatch.setattr(read_access, "read_existing_platform_supported", lambda: True)
+
+    class UnboundTool(CodeGraphContextTool):
+        def __init__(self) -> None:
+            super().__init__(None)
+
+    result = _run(
+        UnboundTool().execute(
+            {
+                "task": "x",
+                "access_mode": "read_existing",
+                "snapshot_id": "s1",
+                "source_generation": "1",
+                "output_format": "json",
+            }
+        )
+    )
+    assert result["success"] is False
+    assert result["error_code"] == "MISSING_PROJECT_ROOT"
+    assert result["access_reason"] == "MISSING_PROJECT_ROOT"
+    assert result["access_state"] == "missing"
+    assert result["action_version"] == NAV_CONTEXT_ACTION_VERSION
+    assert result["source_snapshots"] == []
+
+
+# A reader that returns a non-dict payload is classified as
+# INDEX_SNAPSHOT_FAILED by the consumer seam (never served to the caller).
+def test_read_existing_consumer_rejects_non_dict_payload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import sqlite3
+
+    import tree_sitter_analyzer.read_existing_access as read_access
+    from tree_sitter_analyzer.index_snapshot import REGISTRY, IndexSnapshot
+    from tree_sitter_analyzer.index_source_scope import make_source_scope_descriptor
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        CodeGraphContextTool,
+    )
+    from tree_sitter_analyzer.wire_owner import NAV_CONTEXT_ACTION_VERSION
+
+    monkeypatch.setattr(read_access, "read_existing_platform_supported", lambda: True)
+    scope = make_source_scope_descriptor()
+    conn = sqlite3.connect(":memory:")
+    snapshot = IndexSnapshot(
+        None,
+        "fp",
+        "ifp",
+        "gen-1",
+        "complete",
+        None,
+        str(tmp_path.resolve()),
+        0,
+        None,
+        None,
+        scope,
+    )
+    published = REGISTRY.publish(snapshot, conn, 0)
+
+    import tree_sitter_analyzer.read_existing_access as seam
+
+    def bad_reader(snapshot, conn):
+        return "not-a-dict"
+
+    result = seam.read_existing_index_consumer(
+        CodeGraphContextTool(str(tmp_path)),
+        {
+            "access_mode": "read_existing",
+            "snapshot_id": published.snapshot_id,
+            "source_generation": "gen-1",
+            "output_format": "json",
+        },
+        reader=bad_reader,
+        action_version=NAV_CONTEXT_ACTION_VERSION,
+    )
+    assert result["success"] is False
+    assert result["error_code"] == "INDEX_SNAPSHOT_FAILED"
+    assert result["access_reason"] == "INDEX_SNAPSHOT_FAILED"
+    assert result["action_version"] == NAV_CONTEXT_ACTION_VERSION

--- a/tests/unit/test_wire_owner_contract.py
+++ b/tests/unit/test_wire_owner_contract.py
@@ -551,6 +551,25 @@ def test_read_existing_consumer_classifies_reader_sql_failures(
     assert interrupted["action_version"] == NAV_CONTEXT_ACTION_VERSION
 
     # Codex P2 round-4 (C20): a damaged edges row surfaces as IndexError
+    # Codex P2 round-11 (C50): a metadata cell holding valid JSON of a
+    # non-object type surfaces as AttributeError — classified too.
+    def attr_error_reader(snapshot, conn):
+        raise AttributeError("'list' object has no attribute 'get'")
+
+    attr_error = read_access.read_existing_index_consumer(
+        CodeGraphContextTool(str(tmp_path)),
+        {
+            "access_mode": "read_existing",
+            "snapshot_id": published.snapshot_id,
+            "source_generation": "gen-1",
+            "output_format": "json",
+        },
+        reader=attr_error_reader,
+        action_version=NAV_CONTEXT_ACTION_VERSION,
+    )
+    assert attr_error["success"] is False
+    assert attr_error["error_code"] == "CORRUPT_INDEX"
+
     # from EdgeStore._edge_from_row — classified, never escaping the wire
     # contract.
     def index_error_reader(snapshot, conn):

--- a/tests/unit/test_wire_owner_contract.py
+++ b/tests/unit/test_wire_owner_contract.py
@@ -462,6 +462,95 @@ def test_read_existing_consumer_pre_read_mismatch_preserves_record(
     assert result["action_version"] == NAV_CONTEXT_ACTION_VERSION
 
 
+def test_read_existing_consumer_classifies_reader_sql_failures(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """sqlite3.OperationalError from a reader maps to stable wire codes.
+
+    Codex P2 (#1299 round-3): a damaged index column (e.g. edges lacking
+    caller_name) must classify as CORRUPT_INDEX and the deadline progress
+    handler's interrupt as INDEX_SNAPSHOT_DEADLINE — never escape the wire
+    contract.
+    """
+    import sqlite3
+
+    import tree_sitter_analyzer.index_snapshot as snapshot_owner
+    import tree_sitter_analyzer.read_existing_access as read_access
+    from tree_sitter_analyzer.index_snapshot import REGISTRY, IndexSnapshot
+    from tree_sitter_analyzer.index_source_scope import make_source_scope_descriptor
+    from tree_sitter_analyzer.index_source_snapshot import CurrentSourceSnapshot
+    from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import (
+        CodeGraphContextTool,
+    )
+    from tree_sitter_analyzer.wire_owner import NAV_CONTEXT_ACTION_VERSION
+
+    monkeypatch.setattr(read_access, "read_existing_platform_supported", lambda: True)
+    monkeypatch.setattr(
+        snapshot_owner,
+        "_capture_sources_with_deadline",
+        lambda root, source_scope, deadline=None: CurrentSourceSnapshot(
+            frozenset(), "fp", "gen-1", "exact", None
+        ),
+    )
+    conn = sqlite3.connect(":memory:")
+    snapshot = IndexSnapshot(
+        None,
+        "fp",
+        "ifp",
+        "gen-1",
+        "complete",
+        None,
+        str(tmp_path.resolve()),
+        0,
+        None,
+        None,
+        make_source_scope_descriptor(),
+    )
+    published = REGISTRY.publish(snapshot, conn, 0)
+
+    def reader_raising(message: str):
+        def bad_reader(snapshot, conn):
+            raise sqlite3.OperationalError(message)
+
+        return bad_reader
+
+    corrupt = read_access.read_existing_index_consumer(
+        CodeGraphContextTool(str(tmp_path)),
+        {
+            "access_mode": "read_existing",
+            "snapshot_id": published.snapshot_id,
+            "source_generation": "gen-1",
+            "output_format": "json",
+        },
+        reader=reader_raising("no such column: caller_name"),
+        action_version=NAV_CONTEXT_ACTION_VERSION,
+    )
+    assert corrupt["success"] is False
+    assert corrupt["error_code"] == "CORRUPT_INDEX"
+    assert corrupt["source_snapshots"] == [
+        {
+            "kind": "index",
+            "snapshot_id": published.snapshot_id,
+            "source_generation": "gen-1",
+        }
+    ]
+
+    interrupted = read_access.read_existing_index_consumer(
+        CodeGraphContextTool(str(tmp_path)),
+        {
+            "access_mode": "read_existing",
+            "snapshot_id": published.snapshot_id,
+            "source_generation": "gen-1",
+            "output_format": "json",
+        },
+        reader=reader_raising("interrupted"),
+        action_version=NAV_CONTEXT_ACTION_VERSION,
+    )
+    assert interrupted["success"] is False
+    assert interrupted["error_code"] == "INDEX_SNAPSHOT_DEADLINE"
+    assert interrupted["action_version"] == NAV_CONTEXT_ACTION_VERSION
+
+
 @pytest.mark.parametrize(
     ("tool_type", "module_name"),
     [

--- a/tree_sitter_analyzer/core/parser.py
+++ b/tree_sitter_analyzer/core/parser.py
@@ -151,6 +151,18 @@ class Parser:
         cls._misses = 0
         cls._stat_hits = 0
 
+    @classmethod
+    def invalidate_stat_cache(cls) -> None:
+        """Drop only the stat-only fast path.
+
+        Codex P2 (#1299 round-13, C60): the stat fast path keys on
+        (path, mtime_ns, size) — a same-size rewrite with a restored mtime
+        would serve a stale parse on snapshot-certified reads, which must
+        always parse the freshly recaptured bytes. The content-addressed
+        SHA-256 cache stays intact.
+        """
+        cls._stat_cache.clear()
+
     def parse_file(self, file_path: str | Path, language: str) -> ParseResult:
         """Parse a source code file.
 

--- a/tree_sitter_analyzer/health_scorer.py
+++ b/tree_sitter_analyzer/health_scorer.py
@@ -229,7 +229,20 @@ class HealthScorer:
             if fast_dependencies
             else score_dependencies(file_path)
         )
-        dimensions: dict[str, float | None] = {
+        if certified:
+            # Codex P1 (#1299 round-4/5): coverage.json and git history are
+            # outside the snapshot source generation — a certified read must
+            # not even TOUCH them (a corrupt coverage.json must not flip a
+            # certified request to INDEX_SNAPSHOT_FAILED), so they are
+            # branched away from, never evaluated-and-discarded.
+            return {
+                "size": score_size(len(source.splitlines())),
+                "complexity": score_complexity(file_path, source, language),
+                "dependencies": dependency_score,
+                "duplication": score_duplication(source, language),
+                "structure": score_structure(file_path, source, language),
+            }
+        return {
             "size": score_size(len(source.splitlines())),
             "complexity": score_complexity(file_path, source, language),
             "dependencies": dependency_score,
@@ -238,13 +251,6 @@ class HealthScorer:
             "structure": score_structure(file_path, source, language),
             "git_hotspot": score_git_hotspot(file_path),
         }
-        if certified:
-            # Codex P1 (#1299 round-4): coverage.json and git history are
-            # outside the snapshot source generation — a certified read must
-            # not report dimensions that can drift for the same identity.
-            dimensions.pop("coverage")
-            dimensions.pop("git_hotspot")
-        return dimensions
 
     # Q4 (round-33 dogfood): ``golden_masters`` is a snapshot of expected
     # MCP output stored under tests/ — it is not source code and must be

--- a/tree_sitter_analyzer/health_scorer.py
+++ b/tree_sitter_analyzer/health_scorer.py
@@ -173,13 +173,22 @@ class HealthScorer:
         self._windows_coverage_cache: dict[str, float] | None = None
 
     def score_file(
-        self, file_path: str, *, fast_dependencies: bool = False
+        self,
+        file_path: str,
+        *,
+        fast_dependencies: bool = False,
+        certified: bool = False,
     ) -> HealthScore:
         """
         Score a single file.
 
         Args:
             file_path: Path to the source file
+            certified: True on RFC-0022 read_existing routes — the
+                ``coverage`` (coverage.json) and ``git_hotspot`` (git
+                history) dimensions are NOT part of the snapshot source
+                generation and are omitted (Codex P1 #1299 round-4); the
+                remaining dimensions renormalize.
 
         Returns:
             HealthScore with total and per-dimension scores
@@ -191,7 +200,11 @@ class HealthScorer:
 
         language = _EXT_TO_LANG.get(path.suffix.lower())
         dims = self._score_dimensions(
-            file_path, source, language, fast_dependencies=fast_dependencies
+            file_path,
+            source,
+            language,
+            fast_dependencies=fast_dependencies,
+            certified=certified,
         )
         total = calculate_weighted_total(dims, self.weights)
 
@@ -208,6 +221,7 @@ class HealthScorer:
         language: str | None,
         *,
         fast_dependencies: bool = False,
+        certified: bool = False,
     ) -> dict[str, float | None]:
         """Score each health dimension for a source file."""
         dependency_score = (
@@ -215,7 +229,7 @@ class HealthScorer:
             if fast_dependencies
             else score_dependencies(file_path)
         )
-        return {
+        dimensions: dict[str, float | None] = {
             "size": score_size(len(source.splitlines())),
             "complexity": score_complexity(file_path, source, language),
             "dependencies": dependency_score,
@@ -224,6 +238,13 @@ class HealthScorer:
             "structure": score_structure(file_path, source, language),
             "git_hotspot": score_git_hotspot(file_path),
         }
+        if certified:
+            # Codex P1 (#1299 round-4): coverage.json and git history are
+            # outside the snapshot source generation — a certified read must
+            # not report dimensions that can drift for the same identity.
+            dimensions.pop("coverage")
+            dimensions.pop("git_hotspot")
+        return dimensions
 
     # Q4 (round-33 dogfood): ``golden_masters`` is a snapshot of expected
     # MCP output stored under tests/ — it is not source code and must be

--- a/tree_sitter_analyzer/index_snapshot.py
+++ b/tree_sitter_analyzer/index_snapshot.py
@@ -10,7 +10,7 @@ import threading
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import Any
+from typing import Any, cast
 from urllib.parse import quote
 
 from .index_snapshot_capability import (
@@ -549,34 +549,64 @@ def read_existing_index_scope(
     with acquire_index_snapshot(
         snapshot_id, project_root, source_generation, deadline=scope_deadline
     ) as (snapshot, conn):
-        # Codex P1 (#1299): a partial capability (CALL_GRAPH_INCOMPLETE /
-        # SYMBOL_PROJECTION_INCOMPLETE) cannot certify project-wide graph
-        # claims. RFC-0022 P0.1 oracle: graph-consuming rows do not start
-        # without completeness "complete"; mirror the constraint route's
-        # completeness gate.
-        if snapshot.completeness != "complete":
-            raise ValueError("INDEX_SNAPSHOT_INCOMPLETE")
-        # A partial source scope (exclusions / non-root roots) cannot certify
-        # project-wide graph claims: the after-read recapture only re-checks
-        # the snapshot's OWN scope, so out-of-scope files could be served
-        # uncertified. Mirror the constraint route's full-scope gate.
-        from .index_source_scope import SourceScopeDescriptor
+        try:
+            # Codex P1 (#1299): a partial capability (CALL_GRAPH_INCOMPLETE /
+            # SYMBOL_PROJECTION_INCOMPLETE) cannot certify project-wide graph
+            # claims. RFC-0022 P0.1 oracle: graph-consuming rows do not start
+            # without completeness "complete"; mirror the constraint route's
+            # completeness gate.
+            if snapshot.completeness != "complete":
+                raise ValueError("INDEX_SNAPSHOT_INCOMPLETE")
+            # A partial source scope (exclusions / non-root roots) cannot
+            # certify project-wide graph claims: the after-read recapture
+            # only re-checks the snapshot's OWN scope, so out-of-scope files
+            # could be served uncertified. Mirror the constraint route's
+            # full-scope gate.
+            from .index_source_scope import SourceScopeDescriptor
 
-        if not (
-            isinstance(snapshot.source_scope, SourceScopeDescriptor)
-            and snapshot.source_scope.roots == (".",)
-            and not snapshot.source_scope.exclude_patterns
-        ):
-            raise ValueError("CONSTRAINED_INDEX_SCOPE")
-        # Codex P1 (#1299): recapture BEFORE the read too. Acquisition only
-        # compares the caller's token against registry metadata — a source
-        # already modified when the read starts (and restored mid-read) would
-        # otherwise pass the single after-read check while the reader consumed
-        # the modified bytes. The pre-read check runs at __enter__ (normal
-        # generator start), the post-read check only on normal exit — the
-        # reader's own exception always wins over the after-read check.
-        verify_snapshot_source_current(snapshot, deadline=scope_deadline)
-        yield snapshot, conn
+            if not (
+                isinstance(snapshot.source_scope, SourceScopeDescriptor)
+                and snapshot.source_scope.roots == (".",)
+                and not snapshot.source_scope.exclude_patterns
+            ):
+                raise ValueError("CONSTRAINED_INDEX_SCOPE")
+            # Codex P1 (#1299): recapture BEFORE the read too. Acquisition
+            # only compares the caller's token against registry metadata — a
+            # source already modified when the read starts (and restored
+            # mid-read) would otherwise pass the single after-read check
+            # while the reader consumed the modified bytes. The pre-read
+            # check runs at __enter__ (normal generator start), the
+            # post-read check only on normal exit — the reader's own
+            # exception always wins over the after-read check.
+            verify_snapshot_source_current(snapshot, deadline=scope_deadline)
+        except (ValueError, RuntimeError) as exc:
+            # Codex P2 (#1299): pre-yield failures still acquired the
+            # capability; carry its identity so the consumer's failure
+            # envelope can cite the exact snapshot that was acquired.
+            # cast(Any, ...) keeps mypy happy (ValueError/RuntimeError have
+            # no such attribute) without ruff rewriting a setattr back into
+            # an attribute assignment.
+            cast(Any, exc)._read_existing_identity = (
+                snapshot.snapshot_id,
+                snapshot.source_generation,
+            )
+            raise
+
+        # Codex P2 (#1299): bound the reader's SQL work with the same
+        # absolute deadline. SQLite's progress handler fires every 1000 VM
+        # opcodes; returning nonzero aborts the running statement. The
+        # post-yield deadline re-check below is the hard guarantee even when
+        # a reader swallows the abort inside its own exception guards.
+        def _deadline_breached() -> int:
+            return int(_clock() >= scope_deadline)
+
+        conn.set_progress_handler(_deadline_breached, 1_000)
+        try:
+            yield snapshot, conn
+        finally:
+            conn.set_progress_handler(None, 0)
+        if _clock() >= scope_deadline:
+            raise RuntimeError("INDEX_SNAPSHOT_DEADLINE")
         verify_snapshot_source_current(snapshot, deadline=scope_deadline)
 
 

--- a/tree_sitter_analyzer/index_snapshot.py
+++ b/tree_sitter_analyzer/index_snapshot.py
@@ -533,18 +533,29 @@ def read_existing_index_scope(
     *,
     deadline: float | None = None,
 ) -> Iterator[tuple[IndexSnapshot, sqlite3.Connection]]:
-    """Acquire one certified index capability and revalidate it after the read.
+    """Acquire one certified index capability and revalidate it around the read.
 
     Consumer seam for the P0.1 read_existing route: acquires the registry copy
-    (before-read token revalidation), yields the immutable snapshot + private
-    connection, then re-captures the current source and compares generations
-    (after-read revalidation). Any mismatch raises the stable code and the
-    route emits no result. Reader pins and the I/O lock are released by
-    ``acquire_index_snapshot``'s own cleanup on exit.
+    (before-read token revalidation) under one absolute deadline, gates the
+    capability (completeness + full source scope), re-captures the current
+    source BEFORE the read and AGAIN after it, and compares generations both
+    times. Any mismatch raises the stable code and the route emits no result.
+    Reader pins and the I/O lock are released by ``acquire_index_snapshot``'s
+    own cleanup on exit.
     """
+    scope_deadline = (
+        deadline if deadline is not None else _clock() + _CAPTURE_DEADLINE_SECONDS
+    )
     with acquire_index_snapshot(
-        snapshot_id, project_root, source_generation, deadline=deadline
+        snapshot_id, project_root, source_generation, deadline=scope_deadline
     ) as (snapshot, conn):
+        # Codex P1 (#1299): a partial capability (CALL_GRAPH_INCOMPLETE /
+        # SYMBOL_PROJECTION_INCOMPLETE) cannot certify project-wide graph
+        # claims. RFC-0022 P0.1 oracle: graph-consuming rows do not start
+        # without completeness "complete"; mirror the constraint route's
+        # completeness gate.
+        if snapshot.completeness != "complete":
+            raise ValueError("INDEX_SNAPSHOT_INCOMPLETE")
         # A partial source scope (exclusions / non-root roots) cannot certify
         # project-wide graph claims: the after-read recapture only re-checks
         # the snapshot's OWN scope, so out-of-scope files could be served
@@ -557,8 +568,16 @@ def read_existing_index_scope(
             and not snapshot.source_scope.exclude_patterns
         ):
             raise ValueError("CONSTRAINED_INDEX_SCOPE")
+        # Codex P1 (#1299): recapture BEFORE the read too. Acquisition only
+        # compares the caller's token against registry metadata — a source
+        # already modified when the read starts (and restored mid-read) would
+        # otherwise pass the single after-read check while the reader consumed
+        # the modified bytes. The pre-read check runs at __enter__ (normal
+        # generator start), the post-read check only on normal exit — the
+        # reader's own exception always wins over the after-read check.
+        verify_snapshot_source_current(snapshot, deadline=scope_deadline)
         yield snapshot, conn
-        verify_snapshot_source_current(snapshot, deadline=deadline)
+        verify_snapshot_source_current(snapshot, deadline=scope_deadline)
 
 
 def _unknown(reason: str) -> IndexSnapshot:

--- a/tree_sitter_analyzer/index_snapshot.py
+++ b/tree_sitter_analyzer/index_snapshot.py
@@ -492,5 +492,74 @@ def acquire_index_snapshot(
     )
 
 
+def verify_snapshot_source_current(
+    snapshot: IndexSnapshot, *, deadline: float | None = None
+) -> None:
+    """Revalidate one acquired snapshot's source state after a read.
+
+    RFC-0022 P0.4 after-read revalidation: recapture the current source over
+    the snapshot's ``source_scope`` and compare the generation (or fingerprint)
+    with the acquired capability. A mismatch raises ``SOURCE_GENERATION_MISMATCH``
+    and the caller must emit no result. Snapshots without a scope descriptor
+    (no manifest to capture against) skip the check, mirroring
+    ``constraint_index_snapshot.evaluate_ordinary_snapshot``.
+    """
+    source_scope = snapshot.source_scope
+    if source_scope is None:
+        return
+    source_root = snapshot.canonical_root
+    if not isinstance(source_root, str) or not source_root:
+        raise ValueError("INDEX_SNAPSHOT_UNKNOWN")
+    deadline = _clock() + _CAPTURE_DEADLINE_SECONDS if deadline is None else deadline
+    current = _capture_sources_with_deadline(source_root, source_scope, deadline)
+    if current.state != "exact":
+        raise ValueError(current.reason or "SOURCE_SCOPE_UNKNOWN")
+    expected_generation = snapshot.source_generation
+    if expected_generation is None:
+        expected_fingerprint = snapshot.source_fingerprint
+        if expected_fingerprint is None:
+            raise ValueError("SOURCE_GENERATION_MISMATCH")
+        if current.fingerprint != expected_fingerprint:
+            raise ValueError("SOURCE_GENERATION_MISMATCH")
+    elif current.generation != expected_generation:
+        raise ValueError("SOURCE_GENERATION_MISMATCH")
+
+
+@contextmanager
+def read_existing_index_scope(
+    snapshot_id: str,
+    project_root: str,
+    source_generation: str | None = None,
+    *,
+    deadline: float | None = None,
+) -> Iterator[tuple[IndexSnapshot, sqlite3.Connection]]:
+    """Acquire one certified index capability and revalidate it after the read.
+
+    Consumer seam for the P0.1 read_existing route: acquires the registry copy
+    (before-read token revalidation), yields the immutable snapshot + private
+    connection, then re-captures the current source and compares generations
+    (after-read revalidation). Any mismatch raises the stable code and the
+    route emits no result. Reader pins and the I/O lock are released by
+    ``acquire_index_snapshot``'s own cleanup on exit.
+    """
+    with acquire_index_snapshot(
+        snapshot_id, project_root, source_generation, deadline=deadline
+    ) as (snapshot, conn):
+        # A partial source scope (exclusions / non-root roots) cannot certify
+        # project-wide graph claims: the after-read recapture only re-checks
+        # the snapshot's OWN scope, so out-of-scope files could be served
+        # uncertified. Mirror the constraint route's full-scope gate.
+        from .index_source_scope import SourceScopeDescriptor
+
+        if not (
+            isinstance(snapshot.source_scope, SourceScopeDescriptor)
+            and snapshot.source_scope.roots == (".",)
+            and not snapshot.source_scope.exclude_patterns
+        ):
+            raise ValueError("CONSTRAINED_INDEX_SCOPE")
+        yield snapshot, conn
+        verify_snapshot_source_current(snapshot, deadline=deadline)
+
+
 def _unknown(reason: str) -> IndexSnapshot:
     return IndexSnapshot(None, None, None, None, "unknown", reason, None, 0)

--- a/tree_sitter_analyzer/index_snapshot_schema.py
+++ b/tree_sitter_analyzer/index_snapshot_schema.py
@@ -58,7 +58,18 @@ _REQUIRED_COLUMNS = {
     "ast_symbol_projection_state": frozenset(
         {"file_path", "content_hash", "symbol_count", "projection_digest"}
     ),
-    "edges": frozenset({"source_node_id", "target_node_id", "kind", "file_path"}),
+    "edges": frozenset(
+        {
+            "source_node_id",
+            "target_node_id",
+            "kind",
+            "file_path",
+            # Codex P2 (#1299): the snapshot dependency reader selects
+            # callee_name; a current-version index missing it would degrade
+            # to an empty dependency view and undercount risk.
+            "callee_name",
+        }
+    ),
     "ast_index_snapshot_manifest": frozenset(
         {
             "canonical_root",

--- a/tree_sitter_analyzer/index_snapshot_schema.py
+++ b/tree_sitter_analyzer/index_snapshot_schema.py
@@ -68,9 +68,15 @@ _REQUIRED_COLUMNS = {
             # callee_name; a current-version index missing it would degrade
             # to an empty dependency view and undercount risk. caller_name is
             # selected by nav.context's _callees_by_name, whose OperationalError
-            # would escape the classified failure envelope (round-3).
+            # would escape the classified failure envelope (round-3). Every
+            # column EdgeStore._edge_from_row indexes directly (line,
+            # provenance, metadata) must also be present, or nav.context
+            # would hit an IndexError outside the classified set (round-4).
             "callee_name",
             "caller_name",
+            "line",
+            "provenance",
+            "metadata",
         }
     ),
     "ast_index_snapshot_manifest": frozenset(

--- a/tree_sitter_analyzer/index_snapshot_schema.py
+++ b/tree_sitter_analyzer/index_snapshot_schema.py
@@ -66,8 +66,11 @@ _REQUIRED_COLUMNS = {
             "file_path",
             # Codex P2 (#1299): the snapshot dependency reader selects
             # callee_name; a current-version index missing it would degrade
-            # to an empty dependency view and undercount risk.
+            # to an empty dependency view and undercount risk. caller_name is
+            # selected by nav.context's _callees_by_name, whose OperationalError
+            # would escape the classified failure envelope (round-3).
             "callee_name",
+            "caller_name",
         }
     ),
     "ast_index_snapshot_manifest": frozenset(

--- a/tree_sitter_analyzer/index_snapshot_schema.py
+++ b/tree_sitter_analyzer/index_snapshot_schema.py
@@ -77,6 +77,9 @@ _REQUIRED_COLUMNS = {
             "line",
             "provenance",
             "metadata",
+            # Codex P2 (#1299 round-12, C52): the certified symbol-reference
+            # query binds call edges by callee_resolved_file.
+            "callee_resolved_file",
         }
     ),
     "ast_index_snapshot_manifest": frozenset(

--- a/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
@@ -357,7 +357,13 @@ class CodeGraphContextTool(BaseMCPTool):
             edges: list[dict[str, Any]] = []
 
             if nodes:
-                nodes = self._expand_nodes(nodes, task, max_nodes, graph=edge_store)
+                nodes = self._expand_nodes(
+                    nodes,
+                    task,
+                    max_nodes,
+                    graph=edge_store,
+                    certified=True,
+                )
                 # Codex P1 (#1299 round-6/7): graph expansion can surface node
                 # paths that are absolute or contain '..' (encoded in edge
                 # metadata), or that resolve through an in-project symlink to
@@ -381,7 +387,7 @@ class CodeGraphContextTool(BaseMCPTool):
             related_files = _unique_files(nodes)
             related_symbols = _build_related_symbols(nodes)
             verdict = "INFO" if entry_points else "NOT_FOUND"
-            return _compose_context_result(
+            payload = _compose_context_result(
                 verdict=verdict,
                 task=task,
                 candidates=candidates,
@@ -395,6 +401,13 @@ class CodeGraphContextTool(BaseMCPTool):
                 max_nodes=max_nodes,
                 elapsed_ms=int((time.perf_counter() - started) * 1000),
             )
+            # Codex P2 (#1299 round-10, C46): RFC-0022's input-only contract
+            # forbids echoing raw task text from routed adapters (tasks may
+            # carry credentials / absolute host paths); the task layer's
+            # projection drops it later, but the primitive wire response
+            # must not carry the sensitive bytes either.
+            payload.pop("task", None)
+            return payload
 
         result = read_access.read_existing_index_consumer(
             self,
@@ -516,6 +529,7 @@ class CodeGraphContextTool(BaseMCPTool):
         max_nodes: int,
         *,
         graph: Any = None,
+        certified: bool = False,
     ) -> list[dict[str, Any]]:
         if graph is None:
             try:
@@ -546,6 +560,12 @@ class CodeGraphContextTool(BaseMCPTool):
             try:
                 return graph.query_callees(name, file_path, max_depth=depth) or []
             except Exception:
+                # Codex P2 (#1299 round-10, C45): on the certified route a
+                # malformed edge row means a corrupt snapshot — propagate so
+                # the consumer classifies CORRUPT_INDEX instead of serving
+                # an incomplete graph. The live path keeps its tolerance.
+                if certified:
+                    raise
                 return []
 
         def _edge_store_callers(
@@ -554,6 +574,8 @@ class CodeGraphContextTool(BaseMCPTool):
             try:
                 return graph.query_callers(name, file_path) or []
             except Exception:
+                if certified:
+                    raise
                 return []
 
         for node in list(seed_nodes):

--- a/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
@@ -376,6 +376,11 @@ class CodeGraphContextTool(BaseMCPTool):
                     for n in nodes
                     if _snapshot_certified_node_file(n.get("file"), reader_root, conn)
                 ]
+                # Codex P2 (#1299 round-13, C59): cross-file callee nodes
+                # carry the CALL-SITE line; re-resolve the definition line
+                # from ast_symbol_rows so code blocks serve the certified
+                # definition context, never unrelated call-site lines.
+                nodes = _snapshot_definition_lines(nodes, conn)
                 edges = self._build_edges(nodes, graph=edge_store)
 
             code_blocks = _build_code_blocks(
@@ -1129,6 +1134,37 @@ def _edge_degrees(
         if edge["target"] in degrees:
             degrees[edge["target"]] += 1
     return degrees
+
+
+def _snapshot_definition_lines(
+    nodes: list[dict[str, Any]], conn: Any
+) -> list[dict[str, Any]]:
+    """Re-resolve each node's line to its symbol definition line.
+
+    Codex P2 (#1299 round-13, C59): ``EdgeStore.query_callees`` keeps the
+    call-site line on resolved cross-file callee nodes; certified code
+    blocks must point at the definition, so the line is re-looked-up from
+    ``ast_symbol_rows`` (degrading to the node's own line when unknown).
+    """
+
+    try:
+        rows = conn.execute(
+            "SELECT file_path, name, line FROM ast_symbol_rows"
+        ).fetchall()
+    except Exception:  # nosec B110 — legacy schema keeps node lines
+        return nodes
+    by_key: dict[tuple[str, str], int] = {}
+    for row in rows:
+        key = (str(row["file_path"]), str(row["name"]))
+        by_key.setdefault(key, int(row["line"]))
+    resolved: list[dict[str, Any]] = []
+    for node in nodes:
+        line = by_key.get((str(node.get("file", "")), str(node.get("name", ""))))
+        if line is not None:
+            node = dict(node)
+            node["line"] = line
+        resolved.append(node)
+    return resolved
 
 
 def _snapshot_certified_node_file(file_path: Any, reader_root: str, conn: Any) -> bool:

--- a/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
@@ -1153,16 +1153,24 @@ def _snapshot_definition_lines(
         ).fetchall()
     except Exception:  # nosec B110 — legacy schema keeps node lines
         return nodes
-    by_key: dict[tuple[str, str], int] = {}
+    by_key: dict[tuple[str, str], set[int]] = {}
     for row in rows:
         key = (str(row["file_path"]), str(row["name"]))
-        by_key.setdefault(key, int(row["line"]))
+        by_key.setdefault(key, set()).add(int(row["line"]))
     resolved: list[dict[str, Any]] = []
     for node in nodes:
-        line = by_key.get((str(node.get("file", "")), str(node.get("name", ""))))
-        if line is not None:
+        lines = by_key.get((str(node.get("file", "")), str(node.get("name", ""))))
+        if lines:
             node = dict(node)
-            node["line"] = line
+            current = node.get("line")
+            if current in lines:
+                pass  # already a definition line
+            elif len(lines) == 1:
+                # Single definition: the cross-file call-site line resolves
+                # to it deterministically.
+                node["line"] = next(iter(lines))
+            # else: overloaded/duplicate names — the call-site line is the
+            # only identity evidence; do NOT guess a different definition.
         resolved.append(node)
     return resolved
 

--- a/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
@@ -316,12 +316,14 @@ class CodeGraphContextTool(BaseMCPTool):
         snapshot generation.
         """
         if not read_access.read_existing_platform_supported():
+            # access_mode is present here (this route only runs for explicit
+            # read_existing calls), so the envelope is never None.
             unavailable = read_access.format_read_existing_unavailable(
                 arguments,
                 action_version=NAV_CONTEXT_ACTION_VERSION,
             )
-            if unavailable is not None:
-                return unavailable
+            assert unavailable is not None  # access_mode is present -> our route
+            return unavailable
         # Unbound root on the certified axis is classified by the consumer
         # seam (MISSING_PROJECT_ROOT envelope with evidence + action_version);
         # on non-certified axes the UNCERTIFIED stub above already returned.

--- a/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
@@ -358,6 +358,12 @@ class CodeGraphContextTool(BaseMCPTool):
 
             if nodes:
                 nodes = self._expand_nodes(nodes, task, max_nodes, graph=edge_store)
+                # Codex P1 (#1299 round-6): graph expansion can surface node
+                # paths that are absolute or contain '..' (encoded in edge
+                # metadata); those are outside the certified snapshot root —
+                # drop them before any code-block read so no uncertified or
+                # out-of-scope file bytes are served.
+                nodes = [n for n in nodes if _snapshot_certified_node_path(n)]
                 edges = self._build_edges(nodes, graph=edge_store)
 
             code_blocks = _build_code_blocks(
@@ -1094,6 +1100,24 @@ def _edge_degrees(
         if edge["target"] in degrees:
             degrees[edge["target"]] += 1
     return degrees
+
+
+def _snapshot_certified_node_path(node: dict[str, Any]) -> bool:
+    """Return whether one nav node's file path is snapshot-certified.
+
+    The certified route serves code blocks only for relative, in-root file
+    paths: absolute paths and ``..`` segments (which can be encoded in edge
+    metadata) would read bytes outside the snapshot's canonical root
+    (Codex P1 #1299 round-6).
+    """
+
+    file_path = node.get("file")
+    if not isinstance(file_path, str) or not file_path:
+        return False
+    normalized = file_path.replace("\\", "/")
+    if normalized.startswith("/") or ".." in normalized.split("/"):
+        return False
+    return True
 
 
 def _unique_files(nodes: list[dict[str, Any]]) -> list[str]:

--- a/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
@@ -358,12 +358,18 @@ class CodeGraphContextTool(BaseMCPTool):
 
             if nodes:
                 nodes = self._expand_nodes(nodes, task, max_nodes, graph=edge_store)
-                # Codex P1 (#1299 round-6): graph expansion can surface node
+                # Codex P1 (#1299 round-6/7): graph expansion can surface node
                 # paths that are absolute or contain '..' (encoded in edge
-                # metadata); those are outside the certified snapshot root —
-                # drop them before any code-block read so no uncertified or
-                # out-of-scope file bytes are served.
-                nodes = [n for n in nodes if _snapshot_certified_node_path(n)]
+                # metadata), or that resolve through an in-project symlink to
+                # an outside directory, or that name an excluded-but-existing
+                # file — none of those are generation-certified. Drop them
+                # before any code-block read so no out-of-inventory file
+                # bytes are served.
+                nodes = [
+                    n
+                    for n in nodes
+                    if _snapshot_certified_node_file(n.get("file"), reader_root, conn)
+                ]
                 edges = self._build_edges(nodes, graph=edge_store)
 
             code_blocks = _build_code_blocks(
@@ -1102,22 +1108,33 @@ def _edge_degrees(
     return degrees
 
 
-def _snapshot_certified_node_path(node: dict[str, Any]) -> bool:
+def _snapshot_certified_node_file(file_path: Any, reader_root: str, conn: Any) -> bool:
     """Return whether one nav node's file path is snapshot-certified.
 
-    The certified route serves code blocks only for relative, in-root file
-    paths: absolute paths and ``..`` segments (which can be encoded in edge
-    metadata) would read bytes outside the snapshot's canonical root
-    (Codex P1 #1299 round-6).
+    The certified route serves code blocks only for relative, in-root,
+    INVENTORY-COVERED file paths: absolute paths and ``..`` segments (which
+    can be encoded in edge metadata) are rejected lexically; a symlink-
+    resolved containment check keeps the path inside the snapshot's
+    canonical root; and ``ast_index`` membership guarantees the bytes are
+    generation-certified (Codex P1 #1299 round-6/7).
     """
 
-    file_path = node.get("file")
     if not isinstance(file_path, str) or not file_path:
         return False
     normalized = file_path.replace("\\", "/")
     if normalized.startswith("/") or ".." in normalized.split("/"):
         return False
-    return True
+    root_resolved = os.path.realpath(reader_root)
+    candidate = os.path.realpath(os.path.join(reader_root, normalized))
+    if candidate != root_resolved and not candidate.startswith(root_resolved + os.sep):
+        return False
+    try:
+        row = conn.execute(
+            "SELECT 1 FROM ast_index WHERE file_path = ? LIMIT 1", (normalized,)
+        ).fetchone()
+    except Exception:  # nosec B110 — legacy schema degrades to reject
+        return False
+    return row is not None
 
 
 def _unique_files(nodes: list[dict[str, Any]]) -> list[str]:

--- a/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
@@ -401,12 +401,13 @@ class CodeGraphContextTool(BaseMCPTool):
                 max_nodes=max_nodes,
                 elapsed_ms=int((time.perf_counter() - started) * 1000),
             )
-            # Codex P2 (#1299 round-10, C46): RFC-0022's input-only contract
-            # forbids echoing raw task text from routed adapters (tasks may
-            # carry credentials / absolute host paths); the task layer's
-            # projection drops it later, but the primitive wire response
-            # must not carry the sensitive bytes either.
+            # Codex P2 (#1299 round-10/12, C46/C51): RFC-0022's input-only
+            # contract forbids echoing raw task text from routed adapters —
+            # tasks may carry credentials / absolute host paths. Drop the
+            # task AND the task-derived candidate tokens (which copy task
+            # words verbatim) from the primitive wire response.
             payload.pop("task", None)
+            payload.pop("candidates", None)
             return payload
 
         result = read_access.read_existing_index_consumer(

--- a/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
@@ -14,6 +14,10 @@ import time
 from typing import Any
 
 from ... import read_existing_access as read_access
+from ...cache.query import fts_search as _conn_fts_search
+from ...cache.query import fts_search_ranked as _conn_fts_search_ranked
+from ...cache.search import search_symbols_cascade as _conn_search_symbols_cascade
+from ...index_symbol_projection import sqlite_compile_supports_fts5
 from ...test_gap_analyzer import _NON_PROD_DIRS as _SHARED_NON_PROD_DIRS
 from ...utils.test_detection import is_test_file as _shared_is_test_file
 from ...utils.test_detection import query_wants_tests as _task_wants_tests
@@ -239,11 +243,8 @@ class CodeGraphContextTool(BaseMCPTool):
 
     async def execute(self, arguments: dict[str, Any]) -> dict[str, Any]:
         self.validate_arguments(arguments)
-        if unavailable := read_access.format_read_existing_unavailable(
-            arguments,
-            action_version=NAV_CONTEXT_ACTION_VERSION,
-        ):
-            return unavailable
+        if "access_mode" in arguments:
+            return await self._execute_read_existing(arguments)
         started = time.perf_counter()
 
         task = str(arguments["task"]).strip()
@@ -275,12 +276,6 @@ class CodeGraphContextTool(BaseMCPTool):
         )
         related_files = _unique_files(nodes)
 
-        # Totals always computed from the FULL set before any capping so the
-        # agent knows how much graph is available even in lean mode.
-        total_nodes = len(nodes)
-        total_edges = len(edges)
-        total_entry_points = len(entry_points)
-
         # Compact related-symbols list (RFC-0006): always built, tiny cost.
         # Groups the full node set by file as "name:line" entries — mirrors
         # CG's Related Symbols format without the heavy per-node dict.
@@ -288,105 +283,129 @@ class CodeGraphContextTool(BaseMCPTool):
 
         verdict = "INFO" if entry_points else "NOT_FOUND"
 
-        # Cap entry_points for echo (same as before).
-        entry_points = entry_points[:_MAX_INLINE_ENTRY_POINTS]
-
-        if include_graph:
-            # Full graph path — identical to old default behaviour.
-            # The inline caps scale with max_nodes so agents that request more
-            # nodes actually receive them. _MAX_INLINE_NODES / _MAX_INLINE_EDGES
-            # are the floor defaults; larger max_nodes raises the cap
-            # proportionally.
-            inline_node_cap = max(_MAX_INLINE_NODES, max_nodes)
-            inline_edge_cap = max(_MAX_INLINE_EDGES, max_nodes * 2)
-            inline_nodes = nodes[:inline_node_cap]
-            _echoed_ids = {n.get("id") for n in inline_nodes}
-            inline_edges = [
-                e
-                for e in edges
-                if e.get("source") in _echoed_ids and e.get("target") in _echoed_ids
-            ][:inline_edge_cap]
-            result: dict[str, Any] = {
-                "success": True,
-                "verdict": verdict,
-                "action_version": NAV_CONTEXT_ACTION_VERSION,
-                "task": task,
-                "candidates": candidates,
-                "entry_points": entry_points,
-                "nodes": inline_nodes,
-                "edges": inline_edges,
-                "related_symbols": related_symbols,
-                "code_blocks": code_blocks,
-                "related_files": related_files,
-                "stats": {
-                    "entry_points": len(entry_points),
-                    "entry_points_total": total_entry_points,
-                    "nodes": len(inline_nodes),
-                    "nodes_total": total_nodes,
-                    "edges": len(inline_edges),
-                    "edges_total": total_edges,
-                    "code_blocks": len(code_blocks),
-                },
-                "agent_summary": {
-                    "summary_line": (
-                        f"codegraph_context: {len(entry_points)} entry points, "
-                        f"{len(inline_nodes)} nodes, {len(inline_edges)} edges, "
-                        f"{len(code_blocks)} code blocks"
-                    ),
-                    "verdict": verdict,
-                    "next_step": _next_step(bool(code_blocks), bool(entry_points)),
-                },
-                "elapsed_ms": int((time.perf_counter() - started) * 1000),
-            }
-        else:
-            # Lean path (default, RFC-0006): omit nodes/edges, expose totals.
-            # ~60% smaller payload — matches CG's compact related-symbols
-            # format. The agent answers from entry_points + code_blocks; the
-            # full graph is available on re-request with include_graph=true.
-            result = {
-                "success": True,
-                "verdict": verdict,
-                "action_version": NAV_CONTEXT_ACTION_VERSION,
-                "task": task,
-                "candidates": candidates,
-                "entry_points": entry_points,
-                "related_symbols": related_symbols,
-                "code_blocks": code_blocks,
-                "related_files": related_files,
-                "stats": {
-                    "entry_points": len(entry_points),
-                    "entry_points_total": total_entry_points,
-                    "nodes_total": total_nodes,
-                    "edges_total": total_edges,
-                    "code_blocks": len(code_blocks),
-                },
-                "agent_summary": {
-                    "summary_line": (
-                        f"codegraph_context: {len(entry_points)} entry points, "
-                        f"{total_nodes} symbols, "
-                        f"{len(code_blocks)} code blocks"
-                    ),
-                    "verdict": verdict,
-                    "next_step": _next_step_lean(
-                        bool(code_blocks), bool(entry_points), entry_points
-                    ),
-                },
-                "elapsed_ms": int((time.perf_counter() - started) * 1000),
-            }
+        result = _compose_context_result(
+            verdict=verdict,
+            task=task,
+            candidates=candidates,
+            entry_points=entry_points,
+            nodes=nodes,
+            edges=edges,
+            related_symbols=related_symbols,
+            code_blocks=code_blocks,
+            related_files=related_files,
+            include_graph=include_graph,
+            max_nodes=max_nodes,
+            elapsed_ms=int((time.perf_counter() - started) * 1000),
+        )
 
         from ..utils.format_helper import apply_toon_format_to_response
 
         return apply_toon_format_to_response(result, output_format)
 
+    async def _execute_read_existing(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        """RFC-0022 P0.4: serve context from the certified index snapshot.
+
+        The platform gate runs FIRST: non-certified axes keep the stable
+        UNCERTIFIED envelope even when the project root is unbound (the
+        backend never runs there). On the certified axis an unbound root
+        fails closed with the stable MISSING_PROJECT_ROOT error, then the
+        graph/symbol data is read exclusively from the acquired snapshot
+        connection (never the live ASTCache) and the after-read source
+        recapture gates the whole result; source snippets are only served
+        once that recapture certifies the live source still matches the
+        snapshot generation.
+        """
+        if not read_access.read_existing_platform_supported():
+            unavailable = read_access.format_read_existing_unavailable(
+                arguments,
+                action_version=NAV_CONTEXT_ACTION_VERSION,
+            )
+            if unavailable is not None:
+                return unavailable
+        # Unbound root on the certified axis is classified by the consumer
+        # seam (MISSING_PROJECT_ROOT envelope with evidence + action_version);
+        # on non-certified axes the UNCERTIFIED stub above already returned.
+
+        def reader(snapshot: Any, conn: Any) -> dict[str, Any]:
+            task = str(arguments["task"]).strip()
+            max_nodes = _bounded_int(arguments.get("max_nodes", 30), 1, 100)
+            max_code_blocks = _bounded_int(arguments.get("max_code_blocks", 5), 0, 25)
+            include_graph = _coerce_bool(arguments.get("include_graph", False))
+            started = time.perf_counter()
+            # Codex-review P3 (#1297-followup): live-file reads (code blocks)
+            # must use the ACQUIRED snapshot's root, never the shared tool
+            # root (a concurrent set_project_path could re-point it mid-read).
+            reader_root = snapshot.canonical_root or self.project_root or ""
+            # Zero-write: the private snapshot connection is the ONLY symbol /
+            # edge authority here — ASTCache is never constructed (it would
+            # mkdir + open the live index read-write).
+            cache = _snapshot_search_surface(conn)
+            from ...graph.edge_store import EdgeStore
+
+            edge_store = EdgeStore(conn, ensure_schema=False)
+            candidates = _extract_symbol_candidates(task)
+            wants_tests = _task_wants_tests(task)
+            entry_points = self._resolve_entry_points(
+                candidates,
+                max(5, max_nodes // 3),
+                wants_tests,
+                cache=cache,
+            )
+            nodes = _nodes_from_hits(entry_points, max_nodes)
+            edges: list[dict[str, Any]] = []
+
+            if nodes:
+                nodes = self._expand_nodes(nodes, task, max_nodes, graph=edge_store)
+                edges = self._build_edges(nodes, graph=edge_store)
+
+            code_blocks = _build_code_blocks(
+                nodes=nodes,
+                edges=edges,
+                max_code_blocks=max_code_blocks,
+                project_root=reader_root,
+            )
+            related_files = _unique_files(nodes)
+            related_symbols = _build_related_symbols(nodes)
+            verdict = "INFO" if entry_points else "NOT_FOUND"
+            return _compose_context_result(
+                verdict=verdict,
+                task=task,
+                candidates=candidates,
+                entry_points=entry_points,
+                nodes=nodes,
+                edges=edges,
+                related_symbols=related_symbols,
+                code_blocks=code_blocks,
+                related_files=related_files,
+                include_graph=include_graph,
+                max_nodes=max_nodes,
+                elapsed_ms=int((time.perf_counter() - started) * 1000),
+            )
+
+        result = read_access.read_existing_index_consumer(
+            self,
+            arguments,
+            reader=reader,
+            action_version=NAV_CONTEXT_ACTION_VERSION,
+        )
+        assert result is not None  # access_mode is present -> our route
+        return result
+
     def _resolve_entry_points(
-        self, candidates: list[str], limit: int, wants_tests: bool = False
+        self,
+        candidates: list[str],
+        limit: int,
+        wants_tests: bool = False,
+        *,
+        cache: Any = None,
     ) -> list[dict[str, Any]]:
         if not candidates:
             return []
-        try:
-            cache = self._get_cache()
-        except Exception:
-            return []
+        if cache is None:
+            try:
+                cache = self._get_cache()
+            except Exception:
+                return []
 
         # Aggregate hits across ALL candidates before ranking. A symbol that
         # matches more task words (e.g. ``applyIndexOperationOnPrimary`` for
@@ -477,12 +496,18 @@ class CodeGraphContextTool(BaseMCPTool):
         return [e["hit"] for e in ranked[:limit]]
 
     def _expand_nodes(
-        self, seed_nodes: list[dict[str, Any]], task: str, max_nodes: int
+        self,
+        seed_nodes: list[dict[str, Any]],
+        task: str,
+        max_nodes: int,
+        *,
+        graph: Any = None,
     ) -> list[dict[str, Any]]:
-        try:
-            graph = self._get_call_graph()
-        except Exception:
-            return seed_nodes
+        if graph is None:
+            try:
+                graph = self._get_call_graph()
+            except Exception:
+                return seed_nodes
 
         nodes = list(seed_nodes)
         seen = {(n["name"], n.get("file", "")) for n in nodes}
@@ -541,11 +566,14 @@ class CodeGraphContextTool(BaseMCPTool):
 
         return nodes[:max_nodes]
 
-    def _build_edges(self, nodes: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        try:
-            graph = self._get_call_graph()
-        except Exception:
-            return []
+    def _build_edges(
+        self, nodes: list[dict[str, Any]], *, graph: Any = None
+    ) -> list[dict[str, Any]]:
+        if graph is None:
+            try:
+                graph = self._get_call_graph()
+            except Exception:
+                return []
 
         by_key = {(n["name"], n.get("file", "")): n for n in nodes}
         by_name: dict[str, list[dict[str, Any]]] = {}
@@ -604,6 +632,146 @@ class CodeGraphContextTool(BaseMCPTool):
                         }
                     )
         return edges
+
+
+def _snapshot_search_surface(conn: Any) -> Any:
+    """Wrap one snapshot connection with the ASTCache search surface.
+
+    RFC-0022 P0.4 zero-write: nav.context's live path searches through
+    ``ASTCache`` (which mkdirs the cache dirs and opens the live index
+    read-write). The read_existing route instead binds the same method
+    names to the pure connection-based search helpers over the immutable
+    snapshot connection. ``fts5_available`` comes from the connection, not
+    from ASTCache state.
+    """
+    fts5 = sqlite_compile_supports_fts5(conn)
+
+    class _Surface:
+        def fts_search(self, query: str, limit: int = 100) -> list[dict[str, Any]]:
+            if not fts5:
+                return []
+            return _conn_fts_search(conn, query, None, limit)
+
+        def fts_search_ranked(
+            self, query: str, limit: int = 100
+        ) -> list[dict[str, Any]]:
+            return _conn_fts_search_ranked(conn, query, None, limit)
+
+        def search_symbols_cascade(
+            self, query: str, limit: int = 100
+        ) -> list[dict[str, Any]]:
+            return _conn_search_symbols_cascade(conn, query, None, limit, bool(fts5))
+
+    return _Surface()
+
+
+def _compose_context_result(
+    *,
+    verdict: str,
+    task: str,
+    candidates: list[str],
+    entry_points: list[dict[str, Any]],
+    nodes: list[dict[str, Any]],
+    edges: list[dict[str, Any]],
+    related_symbols: list[dict[str, Any]],
+    code_blocks: list[dict[str, Any]],
+    related_files: list[str],
+    include_graph: bool,
+    max_nodes: int,
+    elapsed_ms: int,
+) -> dict[str, Any]:
+    """Compose the nav.context success envelope (shared by live + snapshot).
+
+    Totals are always computed from the FULL sets before any echo capping so
+    the agent knows how much graph is available even in lean mode. Entry
+    points are capped for echo at :data:`_MAX_INLINE_ENTRY_POINTS`.
+    """
+    total_nodes = len(nodes)
+    total_edges = len(edges)
+    total_entry_points = len(entry_points)
+    entry_points = entry_points[:_MAX_INLINE_ENTRY_POINTS]
+
+    if include_graph:
+        # Full graph path — identical to old default behaviour.
+        # The inline caps scale with max_nodes so agents that request more
+        # nodes actually receive them. _MAX_INLINE_NODES / _MAX_INLINE_EDGES
+        # are the floor defaults; larger max_nodes raises the cap
+        # proportionally.
+        inline_node_cap = max(_MAX_INLINE_NODES, max_nodes)
+        inline_edge_cap = max(_MAX_INLINE_EDGES, max_nodes * 2)
+        inline_nodes = nodes[:inline_node_cap]
+        _echoed_ids = {n.get("id") for n in inline_nodes}
+        inline_edges = [
+            e
+            for e in edges
+            if e.get("source") in _echoed_ids and e.get("target") in _echoed_ids
+        ][:inline_edge_cap]
+        return {
+            "success": True,
+            "verdict": verdict,
+            "action_version": NAV_CONTEXT_ACTION_VERSION,
+            "task": task,
+            "candidates": candidates,
+            "entry_points": entry_points,
+            "nodes": inline_nodes,
+            "edges": inline_edges,
+            "related_symbols": related_symbols,
+            "code_blocks": code_blocks,
+            "related_files": related_files,
+            "stats": {
+                "entry_points": len(entry_points),
+                "entry_points_total": total_entry_points,
+                "nodes": len(inline_nodes),
+                "nodes_total": total_nodes,
+                "edges": len(inline_edges),
+                "edges_total": total_edges,
+                "code_blocks": len(code_blocks),
+            },
+            "agent_summary": {
+                "summary_line": (
+                    f"codegraph_context: {len(entry_points)} entry points, "
+                    f"{len(inline_nodes)} nodes, {len(inline_edges)} edges, "
+                    f"{len(code_blocks)} code blocks"
+                ),
+                "verdict": verdict,
+                "next_step": _next_step(bool(code_blocks), bool(entry_points)),
+            },
+            "elapsed_ms": elapsed_ms,
+        }
+    # Lean path (default, RFC-0006): omit nodes/edges, expose totals.
+    # ~60% smaller payload — matches CG's compact related-symbols
+    # format. The agent answers from entry_points + code_blocks; the
+    # full graph is available on re-request with include_graph=true.
+    return {
+        "success": True,
+        "verdict": verdict,
+        "action_version": NAV_CONTEXT_ACTION_VERSION,
+        "task": task,
+        "candidates": candidates,
+        "entry_points": entry_points,
+        "related_symbols": related_symbols,
+        "code_blocks": code_blocks,
+        "related_files": related_files,
+        "stats": {
+            "entry_points": len(entry_points),
+            "entry_points_total": total_entry_points,
+            "nodes_total": total_nodes,
+            "edges_total": total_edges,
+            "code_blocks": len(code_blocks),
+        },
+        "agent_summary": {
+            "summary_line": (
+                f"codegraph_context: {len(entry_points)} entry points, "
+                f"{total_nodes} symbols, "
+                f"{len(code_blocks)} code blocks"
+            ),
+            "verdict": verdict,
+            "next_step": _next_step_lean(
+                bool(code_blocks), bool(entry_points), entry_points
+            ),
+        },
+        "elapsed_ms": elapsed_ms,
+    }
 
 
 def _bounded_int(value: Any, minimum: int, maximum: int) -> int:

--- a/tree_sitter_analyzer/mcp/tools/safe_to_edit_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/safe_to_edit_tool.py
@@ -15,8 +15,8 @@ from ...constants import EDIT_KINDS
 from ...health_scorer import HealthScorer
 from ...project_graph import DependencyGraph
 from ...read_existing_access import (
-    format_read_existing_unavailable,
     index_capability_schema_properties,
+    read_existing_index_consumer,
     validate_required_index_access,
 )
 from ...utils import setup_logger
@@ -26,11 +26,13 @@ from .utils.parse_validity import is_file_parse_broken
 from .utils.safe_to_edit_helpers import (
     SafeToEditContext,
     build_file_dependency_view,
+    build_snapshot_file_dependency_view,
     is_init_file,
 )
 from .utils.safe_to_edit_helpers import (
     build_safe_to_edit_result as _build_safe_to_edit_result,
 )
+from .utils.safe_to_edit_helpers import to_relative as _to_relative
 from .utils.safe_to_edit_risk import compute_risk
 
 logger = setup_logger(__name__)
@@ -168,13 +170,17 @@ class SafeToEditTool(BaseMCPTool):
         # classification so malformed paths remain validation failures.
         resolved = self.resolve_and_validate_file_path(file_path)
         self.validate_arguments(arguments)
-        unavailable = format_read_existing_unavailable(
+        read_existing_result = read_existing_index_consumer(
+            self,
             arguments,
-            compact_only=bool(arguments.get("compact_only", False)),
+            reader=lambda snapshot, conn: self._read_existing_payload(
+                arguments, resolved, conn, snapshot=snapshot
+            ),
             action_version=EDIT_SAFE_ACTION_VERSION,
+            compact_only=bool(arguments.get("compact_only", False)),
         )
-        if unavailable is not None:
-            return unavailable
+        if read_existing_result is not None:
+            return read_existing_result
 
         edit_type = arguments.get("edit_type", "refactor")
         output_format = arguments.get("output_format", "toon")
@@ -247,6 +253,68 @@ class SafeToEditTool(BaseMCPTool):
         return apply_toon_format_to_response(
             result, output_format, compact_only=compact_only
         )
+
+    def _read_existing_payload(
+        self,
+        arguments: dict[str, Any],
+        resolved: str,
+        conn: Any,
+        snapshot: Any | None = None,
+    ) -> dict[str, Any]:
+        """RFC-0022 P0.4: build the risk envelope from the certified snapshot.
+
+        The dependency view comes exclusively from the snapshot ``edges``
+        table (IMPORTS kind); the syntax gate, health score, and test
+        discovery still read the live source, but the after-read source
+        recapture (in the consumer seam) certifies those bytes still match
+        the snapshot generation before any result is emitted. Syntax errors
+        short-circuit the dependency/health walk exactly like the legacy
+        path (M3 round-26 gate).
+        """
+        file_path = arguments["file_path"]
+        edit_type = arguments.get("edit_type", "refactor")
+        if not Path(resolved).exists():
+            raise ValueError(f"File not found: {file_path}")
+
+        syntax_response = _syntax_error_response(resolved, file_path, edit_type)
+        if syntax_response is not None:
+            return syntax_response
+
+        # Codex-review P3 (#1297-followup): the snapshot's canonical_root is
+        # the authoritative root for every relative/live-file computation —
+        # never the shared tool root (a concurrent set_project_path could
+        # re-point it mid-read).
+        reader_root = (
+            snapshot.canonical_root
+            if snapshot is not None and snapshot.canonical_root
+            else self.project_root or "."
+        )
+        rel_path = _to_relative(resolved, reader_root).replace("\\", "/")
+        result = _build_safe_to_edit_result(
+            SafeToEditContext(
+                file_path=file_path,
+                edit_type=edit_type,
+                resolved_path=resolved,
+                project_root=reader_root,
+                graph=build_snapshot_file_dependency_view(conn, rel_path),
+                scorer=self._get_scorer(),
+            )
+        )
+        # RFC-0022 P0.5: echo the adapter-owned wire owner version on the
+        # success path (the consumer seam adds output_format + evidence).
+        result["action_version"] = EDIT_SAFE_ACTION_VERSION
+        if "language" not in result:
+            from ...language_detector import detect_language_from_file
+
+            try:
+                detected = detect_language_from_file(
+                    resolved, project_root=self.project_root
+                )
+            except Exception:  # nosec B110 — language detection best-effort
+                detected = "unknown"
+            if detected and detected != "unknown":
+                result["language"] = detected
+        return mirror_summary_line(result)
 
 
 def _syntax_error_response(

--- a/tree_sitter_analyzer/mcp/tools/safe_to_edit_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/safe_to_edit_tool.py
@@ -283,8 +283,6 @@ class SafeToEditTool(BaseMCPTool):
         """
         file_path = arguments["file_path"]
         edit_type = arguments.get("edit_type", "refactor")
-        if not Path(resolved).exists():
-            raise ValueError("FILE_NOT_FOUND")
 
         # Codex-review P3 (#1297-followup): the snapshot's canonical_root is
         # the authoritative root for every relative/live-file computation —
@@ -307,10 +305,13 @@ class SafeToEditTool(BaseMCPTool):
         # (markdown/yaml, hidden, or excluded files) is not covered by the
         # before/after source recaptures. The gate runs BEFORE any
         # existence/language/syntax probe so uncertified bytes can never
-        # short-circuit into an available envelope (round-3: a hidden broken
-        # .py used to return a syntax-error success payload first).
+        # short-circuit into an available envelope — a missing target is
+        # necessarily outside the inventory too, so its answer also comes
+        # from the snapshot, never from live filesystem state (round-3/4).
         if snapshot is not None and not _snapshot_file_indexed(conn, rel_path):
             raise ValueError("FILE_NOT_INDEXED")
+        if not Path(resolved).exists():
+            raise ValueError("FILE_NOT_FOUND")
 
         syntax_response = _syntax_error_response(resolved, file_path, edit_type)
         if syntax_response is not None:

--- a/tree_sitter_analyzer/mcp/tools/safe_to_edit_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/safe_to_edit_tool.py
@@ -8,6 +8,7 @@ Combines dependency analysis, health scoring, and test proximity to produce
 a risk assessment with specific warnings and a concrete pre-edit checklist.
 """
 
+import os
 from pathlib import Path
 from typing import Any
 
@@ -26,6 +27,7 @@ from .base_tool import BaseMCPTool, mirror_summary_line
 from .utils.parse_validity import is_file_parse_broken
 from .utils.safe_to_edit_helpers import (
     SafeToEditContext,
+    _snapshot_file_indexed,
     build_file_dependency_view,
     build_snapshot_file_dependency_view,
     is_init_file,
@@ -297,7 +299,20 @@ class SafeToEditTool(BaseMCPTool):
             if snapshot is not None and snapshot.canonical_root
             else self.project_root or "."
         )
-        rel_path = _to_relative(resolved, reader_root).replace("\\", "/")
+        # Canonicalize the resolved path before relativising: on macOS the
+        # security validator's abspath (/var/folders/...) and the snapshot's
+        # canonical_root (/private/var/folders/...) differ by symlink, which
+        # would make to_relative fall back to the absolute path and miss every
+        # ast_index/edges row (CLAUDE.md §2 resolution contract).
+        rel_path = _to_relative(os.path.realpath(resolved), reader_root).replace(
+            "\\", "/"
+        )
+        if snapshot is not None and not _snapshot_file_indexed(conn, rel_path):
+            # Codex P1 (#1299): a target outside the snapshot source
+            # inventory (markdown/yaml, hidden, or excluded files) is not
+            # covered by the before/after source recaptures — serving its
+            # live bytes would be uncertified. Fail closed instead.
+            raise ValueError("FILE_NOT_INDEXED")
         result = _build_safe_to_edit_result(
             SafeToEditContext(
                 file_path=file_path,

--- a/tree_sitter_analyzer/mcp/tools/safe_to_edit_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/safe_to_edit_tool.py
@@ -286,10 +286,6 @@ class SafeToEditTool(BaseMCPTool):
         if not Path(resolved).exists():
             raise ValueError("FILE_NOT_FOUND")
 
-        syntax_response = _syntax_error_response(resolved, file_path, edit_type)
-        if syntax_response is not None:
-            return syntax_response
-
         # Codex-review P3 (#1297-followup): the snapshot's canonical_root is
         # the authoritative root for every relative/live-file computation —
         # never the shared tool root (a concurrent set_project_path could
@@ -307,12 +303,19 @@ class SafeToEditTool(BaseMCPTool):
         rel_path = _to_relative(os.path.realpath(resolved), reader_root).replace(
             "\\", "/"
         )
+        # Codex P1 (#1299): a target outside the snapshot source inventory
+        # (markdown/yaml, hidden, or excluded files) is not covered by the
+        # before/after source recaptures. The gate runs BEFORE any
+        # existence/language/syntax probe so uncertified bytes can never
+        # short-circuit into an available envelope (round-3: a hidden broken
+        # .py used to return a syntax-error success payload first).
         if snapshot is not None and not _snapshot_file_indexed(conn, rel_path):
-            # Codex P1 (#1299): a target outside the snapshot source
-            # inventory (markdown/yaml, hidden, or excluded files) is not
-            # covered by the before/after source recaptures — serving its
-            # live bytes would be uncertified. Fail closed instead.
             raise ValueError("FILE_NOT_INDEXED")
+
+        syntax_response = _syntax_error_response(resolved, file_path, edit_type)
+        if syntax_response is not None:
+            return syntax_response
+
         result = _build_safe_to_edit_result(
             SafeToEditContext(
                 file_path=file_path,

--- a/tree_sitter_analyzer/mcp/tools/safe_to_edit_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/safe_to_edit_tool.py
@@ -306,6 +306,10 @@ class SafeToEditTool(BaseMCPTool):
                 project_root=reader_root,
                 graph=build_snapshot_file_dependency_view(conn, rel_path),
                 scorer=self._get_scorer(),
+                # Codex P1 (#1299): the certified route derives constraint
+                # facts from the snapshot connection and never touches the
+                # live .ast-cache (zero-write read).
+                snapshot_conn=conn if snapshot is not None else None,
             )
         )
         # RFC-0022 P0.5: echo the adapter-owned wire owner version on the

--- a/tree_sitter_analyzer/mcp/tools/safe_to_edit_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/safe_to_edit_tool.py
@@ -15,6 +15,7 @@ from ...constants import EDIT_KINDS
 from ...health_scorer import HealthScorer
 from ...project_graph import DependencyGraph
 from ...read_existing_access import (
+    format_read_existing_failure,
     index_capability_schema_properties,
     read_existing_index_consumer,
     validate_required_index_access,
@@ -162,10 +163,17 @@ class SafeToEditTool(BaseMCPTool):
         # established. Mirror validate_read_existing_paths: unbound root +
         # read_existing route raises the stable MISSING_PROJECT_ROOT error.
         if arguments.get("access_mode") == "read_existing" and not self.project_root:
-            raise ValueError(
-                "MISSING_PROJECT_ROOT: project_root must be bound before "
-                "read_existing path validation"
+            # Codex P1 (#1257) + review P2 (#1299): fail closed BEFORE path
+            # validation (an arbitrary path must not validate with no
+            # boundary), and emit the CLASSIFIED failure envelope (evidence +
+            # action_version) instead of a bare raise that escapes the wire
+            # contract.
+            failure = format_read_existing_failure(
+                "MISSING_PROJECT_ROOT",
+                output_format=arguments.get("output_format", "toon"),
+                action_version=EDIT_SAFE_ACTION_VERSION,
             )
+            return failure
         # Security/project-boundary checks precede successful unavailable
         # classification so malformed paths remain validation failures.
         resolved = self.resolve_and_validate_file_path(file_path)
@@ -274,7 +282,7 @@ class SafeToEditTool(BaseMCPTool):
         file_path = arguments["file_path"]
         edit_type = arguments.get("edit_type", "refactor")
         if not Path(resolved).exists():
-            raise ValueError(f"File not found: {file_path}")
+            raise ValueError("FILE_NOT_FOUND")
 
         syntax_response = _syntax_error_response(resolved, file_path, edit_type)
         if syntax_response is not None:
@@ -302,18 +310,17 @@ class SafeToEditTool(BaseMCPTool):
         )
         # RFC-0022 P0.5: echo the adapter-owned wire owner version on the
         # success path (the consumer seam adds output_format + evidence).
+        # The builder never sets ``language``, so detect it here (the legacy
+        # axis keeps its own equivalent guard at the execute level).
         result["action_version"] = EDIT_SAFE_ACTION_VERSION
-        if "language" not in result:
-            from ...language_detector import detect_language_from_file
+        from ...language_detector import detect_language_from_file
 
-            try:
-                detected = detect_language_from_file(
-                    resolved, project_root=self.project_root
-                )
-            except Exception:  # nosec B110 — language detection best-effort
-                detected = "unknown"
-            if detected and detected != "unknown":
-                result["language"] = detected
+        try:
+            detected = detect_language_from_file(resolved, project_root=reader_root)
+        except Exception:  # nosec B110 — language detection best-effort
+            detected = "unknown"
+        if detected and detected != "unknown":
+            result["language"] = detected
         return mirror_summary_line(result)
 
 

--- a/tree_sitter_analyzer/mcp/tools/utils/constraint_violation_query.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/constraint_violation_query.py
@@ -29,6 +29,69 @@ _BLOCKING_SEVERITIES: frozenset[str] = frozenset({"error"})
 _WARNING_SEVERITIES: frozenset[str] = frozenset({"warn"})
 
 
+def violations_for_files_from_conn(
+    conn: sqlite3.Connection,
+    file_paths: Iterable[str],
+) -> list[dict[str, Any]]:
+    """Return violation rows touching any of the given files from ONE conn.
+
+    Snapshot-native variant (Codex P1 #1299): queries the caller-provided
+    connection (e.g. a certified index-snapshot private copy) instead of
+    opening the live ``.ast-cache/index.db``, so certified read_existing
+    routes derive constraint facts from the immutable snapshot only.
+    Returns an empty list (never raises) when the table is absent.
+    """
+
+    files = list(dict.fromkeys(file_paths))  # dedupe, preserve order
+    if not files:
+        return []
+
+    placeholders = ",".join(["?"] * len(files))
+    sql = (
+        "SELECT rule_id, caller_file, caller_name, caller_line, "  # nosec B608 - placeholders are generated from file count only.
+        "       callee_name, callee_file, severity, detected_at "
+        "FROM ast_constraint_violations "
+        f"WHERE caller_file IN ({placeholders}) "
+        f"   OR callee_file IN ({placeholders}) "
+        "ORDER BY severity DESC, caller_file, caller_line"
+    )
+    try:
+        cursor = conn.execute(sql, files + files)
+    except sqlite3.OperationalError:
+        return []
+
+    rows: list[dict[str, Any]] = []
+    for row in cursor:
+        (
+            rule_id,
+            caller_file,
+            caller_name,
+            caller_line,
+            callee_name,
+            callee_file,
+            severity,
+            detected_at,
+        ) = row
+        rows.append(
+            {
+                "rule_id": rule_id,
+                "caller_file": caller_file,
+                "caller_name": caller_name,
+                "caller_line": caller_line,
+                "callee_name": callee_name,
+                "callee_file": callee_file,
+                "severity": severity,
+                "detected_at": detected_at,
+                # risk_factors shape (per Coder-T3 spec gap #3):
+                # safe_to_edit's existing risk_factors entries use
+                # the ``factor`` key. We splice rows in directly,
+                # so embed it here.
+                "factor": "constraint_violation",
+            }
+        )
+    return rows
+
+
 def violations_for_files(
     project_root: str | None,
     file_paths: Iterable[str],
@@ -50,57 +113,12 @@ def violations_for_files(
     if not db_path.is_file():
         return []
 
-    files = list(dict.fromkeys(file_paths))  # dedupe, preserve order
-    if not files:
-        return []
-
-    placeholders = ",".join(["?"] * len(files))
-    sql = (
-        "SELECT rule_id, caller_file, caller_name, caller_line, "  # nosec B608 - placeholders are generated from file count only.
-        "       callee_name, callee_file, severity, detected_at "
-        "FROM ast_constraint_violations "
-        f"WHERE caller_file IN ({placeholders}) "
-        f"   OR callee_file IN ({placeholders}) "
-        "ORDER BY severity DESC, caller_file, caller_line"
-    )
-
     conn: sqlite3.Connection | None = None
     try:
         conn = sqlite3.connect(str(db_path))
-        cursor = conn.execute(sql, files + files)
-        rows: list[dict[str, Any]] = []
-        for row in cursor:
-            (
-                rule_id,
-                caller_file,
-                caller_name,
-                caller_line,
-                callee_name,
-                callee_file,
-                severity,
-                detected_at,
-            ) = row
-            rows.append(
-                {
-                    "rule_id": rule_id,
-                    "caller_file": caller_file,
-                    "caller_name": caller_name,
-                    "caller_line": caller_line,
-                    "callee_name": callee_name,
-                    "callee_file": callee_file,
-                    "severity": severity,
-                    "detected_at": detected_at,
-                    # risk_factors shape (per Coder-T3 spec gap #3):
-                    # safe_to_edit's existing risk_factors entries use
-                    # the ``factor`` key. We splice rows in directly,
-                    # so embed it here.
-                    "factor": "constraint_violation",
-                }
-            )
-        return rows
-    except sqlite3.OperationalError as exc:
-        # Table missing / cache schema mismatch. Log + degrade.
-        logger.debug("constraint violation query failed: %s", exc)
+        return violations_for_files_from_conn(conn, file_paths)
+    except sqlite3.Error:
+        logger.debug("violations_for_files: query failed", exc_info=True)
         return []
     finally:
         if conn is not None:

--- a/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
@@ -174,24 +174,27 @@ def _format_safe_to_edit_result(
     if context.snapshot_conn is not None:
         # Codex P1 (#1299): the certified read_existing route derives
         # constraint facts from the immutable snapshot connection and runs
-        # fixture detection read-only — never the live .ast-cache DB or a
-        # fixture-index rebuild write.
+        # the certified fixture probe — never the live .ast-cache DB and
+        # never the live allowlist/cache (both are outside the source
+        # generation and could drift after snapshot publication).
         violations = violations_for_files_from_conn(
             context.snapshot_conn, [_relative_for_constraints(context)]
         )
-        fixture_rebuild = False
+        fixture_certified = True
     else:
         violations = violations_for_files(
             context.project_root, [_relative_for_constraints(context)]
         )
-        fixture_rebuild = True
+        fixture_certified = False
     constraint_verdict = verdict_from_violations(violations)
     # P3: also check whether the file is a registered test fixture; that
     # promotes the verdict on top of any constraint-derived escalation.
     # The chokepoint design (see PRD §P3) is "every override flows
     # through _max_verdict" — so chaining is the only safe composition.
     fixture_fact = is_fixture(
-        context.resolved_path, context.project_root, rebuild_cache=fixture_rebuild
+        context.resolved_path,
+        context.project_root,
+        certified=fixture_certified,
     )
     fixture_verdict = fixture_to_verdict(fixture_fact)
     verdict = _max_verdict(
@@ -658,6 +661,30 @@ def _import_needles_for_target(rel_path: str) -> set[str]:
     return {needle for needle in needles if needle}
 
 
+def _require_edges_callee_name(conn: Any) -> None:
+    """Raise ``CORRUPT_INDEX`` when ``edges`` exists but lacks ``callee_name``.
+
+    The snapshot reader's pass 1 selects ``edges.callee_name``; a partially
+    migrated or damaged index would otherwise make that query fail inside the
+    broad degrade handler, returning an empty dependency view and
+    undercounting risk instead of classifying the snapshot as incompatible.
+    """
+
+    try:
+        table_row = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='edges' LIMIT 1"
+        ).fetchone()
+        if table_row is None:
+            return  # legacy schema without the table: degrade to empty
+        columns = {
+            str(row[1]) for row in conn.execute("PRAGMA table_info(edges)").fetchall()
+        }
+    except Exception:  # nosec B110 — unreadable conn degrades to legacy
+        return
+    if "callee_name" not in columns:
+        raise ValueError("CORRUPT_INDEX")
+
+
 def _snapshot_file_indexed(conn: Any, rel_path: str) -> bool:
     """Return whether the snapshot connection has indexed one relative file."""
     try:
@@ -720,10 +747,14 @@ def build_snapshot_file_dependency_view(conn: Any, rel_path: str) -> FileDepende
        import-statement text instead (no live bytes are consulted).
 
     A missing/legacy schema degrades to an empty view so the route can still
-    classify honestly.
+    classify honestly. A current-version but damaged ``edges`` table (present
+    yet missing the ``callee_name`` column this reader requires) raises
+    ``CORRUPT_INDEX`` instead of degrading silently — an empty view would
+    undercount risk (Codex P2 #1299).
     """
     import json
 
+    _require_edges_callee_name(conn)
     dependencies: set[str] = set()
     dependents: set[str] = set()
     try:

--- a/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
@@ -145,12 +145,15 @@ def _collect_safe_to_edit_facts(context: SafeToEditContext) -> SafeToEditFacts:
         test_files = find_test_files(context.resolved_path, context.project_root)
         certified_health = False
     if certified_health:
-        # Codex P2 (#1299 round-13, C60): certified reads must parse the
-        # freshly recaptured bytes — bypass the stat-only parser cache
-        # (same-size + restored-mtime rewrites would serve stale results).
+        # Codex P2 (#1299 round-13/14, C60/C61): certified reads must parse
+        # the freshly recaptured bytes. The content cache key derives from
+        # (path, mtime, size) too, so a same-size rewrite with a restored
+        # mtime regenerates the same key and would serve a stale parse —
+        # evict the whole parser cache (certified reads are rare; parse
+        # correctness beats cache warmth here).
         from ....core.parser import Parser as _Parser
 
-        _Parser.invalidate_stat_cache()
+        _Parser.cache_clear()
     health = context.scorer.score_file(
         context.resolved_path,
         fast_dependencies=True,
@@ -783,9 +786,9 @@ def _looks_like_test_name(name: str, language: str) -> bool:
     if language == "java":
         return name.endswith(("Test.java", "Tests.java"))
     if language == "javascript":
-        return name.endswith((".test.js", ".spec.js", ".test.jsx"))
+        return name.endswith((".test.js", ".spec.js", ".test.jsx", ".spec.jsx"))
     if language == "typescript":
-        return name.endswith((".test.ts", ".spec.ts", ".test.tsx"))
+        return name.endswith((".test.ts", ".spec.ts", ".test.tsx", ".spec.tsx"))
     if language == "c":
         return name.startswith("test_") and name.endswith((".c", ".h"))
     if language == "cpp":
@@ -1208,7 +1211,13 @@ def build_snapshot_file_dependency_view(conn: Any, rel_path: str) -> FileDepende
                 imp_text = imp["text"] if isinstance(imp, dict) else imp
                 if not isinstance(imp_text, str):
                     continue
-                if any(needle in imp_text for needle in needles):
+                # Codex P2 (#1299 round-14, C64): match import identifiers
+                # as whole tokens — a short basename like 'app' must not
+                # match 'import happy' as a substring.
+                if any(
+                    re.search(rf"\b{re.escape(needle)}\b", imp_text)
+                    for needle in needles
+                ):
                     dependents.add(file_path)
                     break
     except Exception:  # nosec B110 — snapshot schema drift degrades to empty

--- a/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
@@ -1071,6 +1071,12 @@ def build_snapshot_file_dependency_view(conn: Any, rel_path: str) -> FileDepende
                 imports = json.loads(row["imports_json"])
             except (TypeError, ValueError):
                 continue
+            if not isinstance(imports, list):
+                # Codex P2 (#1299 round-9, C40): a non-array cell would
+                # otherwise raise TypeError and abandon the WHOLE needle
+                # pass, dropping later member-import dependents; skip the
+                # malformed row only.
+                continue
             for imp in imports:
                 imp_text = imp["text"] if isinstance(imp, dict) else imp
                 if not isinstance(imp_text, str):

--- a/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
@@ -16,7 +16,6 @@ from .constraint_violation_query import (
     constraint_risk_factor,
     verdict_from_violations,
     violations_for_files,
-    violations_for_files_from_conn,
 )
 from .safe_to_edit_risk import build_checklist, compute_risk
 from .test_discovery import find_test_files
@@ -113,15 +112,22 @@ def _collect_safe_to_edit_facts(context: SafeToEditContext) -> SafeToEditFacts:
     rel_path = to_relative(context.resolved_path, context.project_root)
     dependents = safe_dependents(context.graph, rel_path)
     dependencies = safe_dependencies(context.graph, rel_path)
-    health = context.scorer.score_file(context.resolved_path, fast_dependencies=True)
-    test_files = find_test_files(context.resolved_path, context.project_root)
     if context.snapshot_conn is not None:
-        # Codex P1 (#1299 round-3): test facts must come from inventory-
-        # covered paths only — a test under an oracle-excluded directory
-        # (e.g. tests/vendor/) is outside the source generation and must
-        # not change has_tests/verdict for the same snapshot identity.
+        # Codex P1 (#1299 round-3/4): test facts must come from inventory-
+        # covered paths only — discovery runs over the snapshot's ast_index
+        # set, so oracle-excluded files (tests/vendor/) can neither fill the
+        # discovery cap nor change has_tests/verdict for the same identity.
         inventory = snapshot_inventory(context.snapshot_conn)
-        test_files = [tf for tf in test_files if tf in inventory]
+        test_files = _certified_test_files(inventory, context.resolved_path)
+        certified_health = True
+    else:
+        test_files = find_test_files(context.resolved_path, context.project_root)
+        certified_health = False
+    health = context.scorer.score_file(
+        context.resolved_path,
+        fast_dependencies=True,
+        certified=certified_health,
+    )
     has_tests = bool(test_files)
     risk, risk_factors = compute_risk(
         forward_count=len(dependents),
@@ -179,17 +185,18 @@ def _format_safe_to_edit_result(
     # violation referencing this file forces UNSAFE; warn-only forces
     # CAUTION. The base_verdict (derived from risk_level) is the floor.
     if context.snapshot_conn is not None:
-        # Codex P1 (#1299): the certified read_existing route derives
-        # constraint facts from the immutable snapshot connection and runs
-        # the certified fixture probe — never the live .ast-cache DB and
-        # never the live allowlist/cache (both are outside the source
-        # generation and could drift after snapshot publication). The
-        # inventory restriction keeps the fixture scan on generation-
-        # certified test files only (round-3: oracle-pruned paths such as
-        # tests/vendor/ must not influence escalation).
-        violations = violations_for_files_from_conn(
-            context.snapshot_conn, [_relative_for_constraints(context)]
-        )
+        # Codex P1 (#1299): the certified read_existing route runs the
+        # certified fixture probe — never the live .ast-cache DB and never
+        # the live allowlist/cache (both are outside the source generation
+        # and could drift after snapshot publication). The inventory
+        # restriction keeps the fixture scan on generation-certified test
+        # files only (round-3: oracle-pruned paths such as tests/vendor/
+        # must not influence escalation). Constraint rows are OMITTED on
+        # the certified route: reindexing stamps the manifest without
+        # recomputing ast_constraint_violations, so the rows cannot prove
+        # they match the published generation (round-4; an evaluation epoch
+        # bound to the index generation is the tracked follow-up).
+        violations: list[dict[str, Any]] = []
         fixture_inventory = snapshot_inventory(context.snapshot_conn)
         fixture_certified = True
     else:
@@ -696,6 +703,44 @@ def _require_edges_callee_name(conn: Any) -> None:
         return
     if "callee_name" not in columns:
         raise ValueError("CORRUPT_INDEX")
+
+
+def _certified_test_files(inventory: frozenset[str], file_path: str) -> list[str]:
+    """Find inventory-covered test files for one target.
+
+    Codex P1 (#1299 round-3/4): snapshot-certified test discovery walks the
+    snapshot's ``ast_index`` file set instead of the live filesystem, so
+    oracle-excluded paths (e.g. ``tests/vendor/``) can never influence
+    ``has_tests`` and the discovery cap cannot be filled by un-certified
+    candidates. Pattern and colocated conventions mirror the live axis.
+    """
+
+    from .test_discovery import (
+        _TEST_DIRS,
+        _TEST_PATTERNS,
+        _format_pattern,
+        detect_language_from_ext,
+    )
+
+    p = Path(file_path)
+    stem = p.stem
+    language = detect_language_from_ext(p.suffix.lower()) or "python"
+    patterns = _TEST_PATTERNS.get(language, ["test_{stem}.py"])
+    test_dirs = _TEST_DIRS.get(language, ["tests"])
+    filenames = {_format_pattern(pattern, stem) for pattern in patterns}
+
+    results: list[str] = []
+    for rel in sorted(inventory):
+        if Path(rel).name not in filenames:
+            continue
+        if any(rel.startswith(f"{test_dir}/") for test_dir in test_dirs):
+            results.append(rel)
+    parent = p.parent.as_posix()
+    for filename in filenames:
+        colocated = f"{parent}/{filename}"
+        if colocated in inventory and colocated not in results:
+            results.append(colocated)
+    return results[:10]
 
 
 def snapshot_inventory(conn: Any) -> frozenset[str]:

--- a/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
@@ -426,9 +426,11 @@ def build_agent_summary(
         "risk": context.risk,
         "edit_strategy": workflow["edit_strategy"],
         "next_step": _agent_next_step(context, workflow),
-        "verification_command": after[0]
-        if after
-        else (boundary[0] if boundary else ""),
+        "verification_command": (
+            ""
+            if workflow.get("test_verification_unidentified")
+            else (after[0] if after else (boundary[0] if boundary else ""))
+        ),
         "stop_condition": _agent_stop_condition(context, workflow),
     }
     if before:
@@ -458,6 +460,9 @@ def build_agent_workflow(context: AgentWorkflowContext) -> dict[str, Any]:
         else ""
     )
     boundary_command = default_command.command if default_command is not None else ""
+    # Codex P2 (#1299 round-11, C49): when no runner can be identified, the
+    # health/impact commands must never be promoted to TEST verification.
+    test_verification_unidentified = context.certified and default_command is None
     quoted_path = shlex.quote(context.file_path)
     pre_edit_commands = [focused_command] if focused_command else []
     post_edit_commands = [
@@ -478,6 +483,7 @@ def build_agent_workflow(context: AgentWorkflowContext) -> dict[str, Any]:
         "before_edit_commands": pre_edit_commands,
         "after_edit_commands": post_edit_commands,
         "queue_boundary_commands": [boundary_command] if boundary_command else [],
+        "test_verification_unidentified": test_verification_unidentified,
         "guardrails": _agent_guardrails(
             context.risk,
             context.edit_type,
@@ -542,6 +548,11 @@ def _agent_stop_condition(
     after = workflow["after_edit_commands"]
     boundary = workflow["queue_boundary_commands"]
     verify = after[0] if after else (boundary[0] if boundary else "")
+    if workflow.get("test_verification_unidentified"):
+        return (
+            "Test verification is unidentified for this project; run the "
+            "project's test suite manually before and after the edit."
+        )
     if context.risk == "dangerous":
         return "Each smaller edit passes focused verification before scope expands."
     if verify and boundary and verify != boundary[0]:
@@ -863,10 +874,14 @@ def _certified_symbol_reference_tests(
     # symbols is guaranteed non-empty here (the early return above).
     placeholders = ",".join("?" for _ in symbols)  # nosec B608
     try:
+        # Codex P2 (#1299 round-11, C48): bind by the resolved callee file,
+        # not the bare name — a same-named symbol exported by another module
+        # must not attribute its tests to this target.
         call_rows = conn.execute(
             f"SELECT DISTINCT file_path FROM edges "
-            f"WHERE kind = 'calls' AND callee_name IN ({placeholders})",
-            tuple(symbols),
+            f"WHERE kind = 'calls' AND callee_name IN ({placeholders}) "
+            f"AND callee_resolved_file = ?",
+            (*tuple(symbols), rel_path),
         ).fetchall()
     except Exception:  # nosec B110 — legacy schema degrades per call
         call_rows = []
@@ -937,10 +952,14 @@ def _certified_test_files(
         ):
             results.append(rel)
     parent = p.parent.as_posix()
+    # Codex P2 (#1299 round-11, C47): a root-level target's parent is '.',
+    # which would build './test_app.py' while inventory keys are normalized
+    # without the leading './'.
+    parent = "" if parent == "." else parent
     for filename in filenames:
         if "*" in filename:
             continue
-        colocated = f"{parent}/{filename}"
+        colocated = filename if not parent else f"{parent}/{filename}"
         if colocated in inventory and colocated not in results:
             results.append(colocated)
     if language == "python":

--- a/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
@@ -76,7 +76,13 @@ class FileDependencyView:
 
 @dataclass(frozen=True)
 class AgentWorkflowContext:
-    """Inputs needed to build the structured agent edit workflow."""
+    """Inputs needed to build the structured agent edit workflow.
+
+    ``certified`` (Codex P2 #1299 round-6): on snapshot-certified routes the
+    workflow's default test command must not be derived from live
+    non-inventoried config files (package.json/go.mod/...) that can drift
+    for the same snapshot identity.
+    """
 
     file_path: str
     risk: str
@@ -85,6 +91,7 @@ class AgentWorkflowContext:
     test_files: list[str]
     health_grade: str
     project_root: str
+    certified: bool = False
 
 
 @dataclass(frozen=True)
@@ -126,7 +133,7 @@ def _collect_safe_to_edit_facts(context: SafeToEditContext) -> SafeToEditFacts:
         # set, so oracle-excluded files (tests/vendor/) can neither fill the
         # discovery cap nor change has_tests/verdict for the same identity.
         inventory = snapshot_inventory(context.snapshot_conn)
-        test_files = _certified_test_files(inventory, rel_path)
+        test_files = _certified_test_files(inventory, rel_path, dependents)
         certified_health = True
     else:
         test_files = find_test_files(context.resolved_path, context.project_root)
@@ -154,6 +161,7 @@ def _collect_safe_to_edit_facts(context: SafeToEditContext) -> SafeToEditFacts:
         health_grade=health.grade,
         file_path=context.file_path,
         project_root=context.project_root,
+        certified=context.snapshot_conn is not None,
     )
     return SafeToEditFacts(
         dependents=dependents,
@@ -180,6 +188,7 @@ def _format_safe_to_edit_result(
         test_files=facts.test_files,
         health_grade=facts.health.grade,
         project_root=context.project_root,
+        certified=context.snapshot_conn is not None,
     )
     workflow = build_agent_workflow(workflow_context)
     # ``risk_level`` is the canonical field; ``verdict`` mirrors it for
@@ -427,7 +436,14 @@ def build_agent_summary(
 
 def build_agent_workflow(context: AgentWorkflowContext) -> dict[str, Any]:
     """Build a machine-friendly edit workflow for autonomous agents."""
-    default_command = detect_default_test_command(context.project_root)
+    if context.certified:
+        # Codex P2 (#1299 round-6): snapshot-bound default — live config
+        # detection would read non-inventoried files.
+        from .verification_command import PYTEST_COMMAND as _PYTEST_COMMAND
+
+        default_command = _PYTEST_COMMAND
+    else:
+        default_command = detect_default_test_command(context.project_root)
     focused_command = (
         build_test_command(default_command, context.test_files)
         if context.has_tests
@@ -713,7 +729,49 @@ def _require_edges_callee_name(conn: Any) -> None:
         raise ValueError("CORRUPT_INDEX")
 
 
-def _certified_test_files(inventory: frozenset[str], rel_path: str) -> list[str]:
+def _looks_like_test_name(name: str, language: str) -> bool:
+    """Mirror is_existing_test_file's NAME conventions over certified inputs.
+
+    The certified route has no filesystem to probe (and oracle-excluded
+    paths must not influence facts), so only the file-name conventions of
+    :func:`test_discovery_predicates.is_existing_test_file` are applied.
+    Unknown languages (never produced by the current extension map, but
+    possible after a future plugin addition) return False — the honest
+    "not recognized as a test" answer.
+    """
+
+    if language == "python":
+        return name.endswith(("_test.py", "_tests.py")) or name.startswith("test_")
+    if language == "go":
+        return name.endswith("_test.go")
+    if language == "rust":
+        return name.endswith(("_test.rs", "_tests.rs"))
+    if language == "java":
+        return name.endswith(("Test.java", "Tests.java"))
+    if language == "javascript":
+        return name.endswith((".test.js", ".spec.js", ".test.jsx"))
+    if language == "typescript":
+        return name.endswith((".test.ts", ".spec.ts", ".test.tsx"))
+    if language == "c":
+        return name.startswith("test_") and name.endswith((".c", ".h"))
+    if language == "cpp":
+        return name.startswith("test_") and name.endswith((".cpp", ".hpp"))
+    if language == "csharp":
+        return name.endswith(("Test.cs", "Tests.cs"))
+    if language == "kotlin":
+        return name.endswith(("Test.kt", "Tests.kt"))
+    if language == "ruby":
+        return name.endswith(("_test.rb", "_spec.rb")) or name.startswith("test_")
+    if language == "php":
+        return name.endswith(("Test.php", "test.php"))
+    return False
+
+
+def _certified_test_files(
+    inventory: frozenset[str],
+    rel_path: str,
+    dependents: list[str] | tuple[str, ...] = (),
+) -> list[str]:
     """Find inventory-covered test files for one target (RELATIVE posix path).
 
     Codex P1 (#1299 round-3/4): snapshot-certified test discovery walks the
@@ -723,7 +781,11 @@ def _certified_test_files(inventory: frozenset[str], rel_path: str) -> list[str]
     candidates. Pattern and colocated conventions mirror the live axis:
     basenames are matched with the patterns' GLOB semantics (round-5, e.g.
     ``test_app_*.py``) and ``test_dirs`` of ``"."`` (Go's co-located
-    convention) accept any inventory path (round-5).
+    convention) accept any inventory path (round-5). The legacy
+    ``_is_existing_test_file`` and ``_find_symbol_reference_tests`` modes are
+    preserved over certified inputs: a target that is itself a test file
+    counts, and inventory-covered dependents whose names match the test
+    patterns (tests that import the target) count (round-6).
     """
 
     import fnmatch
@@ -742,11 +804,17 @@ def _certified_test_files(inventory: frozenset[str], rel_path: str) -> list[str]
     test_dirs = _TEST_DIRS.get(language, ["tests"])
     filenames = [_format_pattern(pattern, stem) for pattern in patterns]
 
+    def matches_test_pattern(name: str) -> bool:
+        return any(fnmatch.fnmatchcase(name, pattern) for pattern in filenames)
+
     results: list[str] = []
+    if _looks_like_test_name(p.name, language):
+        # The target itself is a test file (legacy _is_existing_test_file).
+        results.append(rel_path)
     for rel in sorted(inventory):
-        if not any(
-            fnmatch.fnmatchcase(Path(rel).name, pattern) for pattern in filenames
-        ):
+        if rel == rel_path:
+            continue
+        if not matches_test_pattern(Path(rel).name):
             continue
         if any(
             test_dir == "." or rel.startswith(f"{test_dir}/") for test_dir in test_dirs
@@ -759,6 +827,11 @@ def _certified_test_files(inventory: frozenset[str], rel_path: str) -> list[str]
         colocated = f"{parent}/{filename}"
         if colocated in inventory and colocated not in results:
             results.append(colocated)
+    for dep in dependents:
+        # Symbol-reference mode over certified inputs: inventory-covered
+        # dependents that import the target and look like tests count.
+        if _looks_like_test_name(Path(dep).name, language) and dep not in results:
+            results.append(dep)
     return results[:10]
 
 

--- a/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
@@ -637,6 +637,124 @@ def _import_needles_for_target(rel_path: str) -> set[str]:
     return {needle for needle in needles if needle}
 
 
+def _snapshot_file_indexed(conn: Any, rel_path: str) -> bool:
+    """Return whether the snapshot connection has indexed one relative file."""
+    try:
+        row = conn.execute(
+            "SELECT 1 FROM ast_index WHERE file_path = ? LIMIT 1", (rel_path,)
+        ).fetchone()
+    except Exception:  # nosec B110 — legacy/partial schema degrades to missing
+        return False
+    return row is not None
+
+
+def _resolve_import_spec_in_snapshot(
+    conn: Any, spec: str, importer_rel_path: str
+) -> str | None:
+    """Mirror :func:`_resolve_import_spec` against the snapshot's ``ast_index``.
+
+    The live variant probes ``(root / candidate).is_file()``; the snapshot
+    variant asks the immutable connection instead, so no live filesystem byte
+    is consulted to build the dependency view.
+    """
+    if not spec or spec.startswith(".."):
+        return None
+    if spec.startswith("."):
+        base = Path(importer_rel_path).parent
+        candidate_base = (base / spec.lstrip("./")).as_posix()
+    else:
+        candidate_base = spec.replace(".", "/")
+
+    candidates = [
+        candidate_base,
+        f"{candidate_base}.py",
+        f"{candidate_base}.js",
+        f"{candidate_base}.ts",
+        f"{candidate_base}.tsx",
+        f"{candidate_base}.java",
+        f"{candidate_base}/__init__.py",
+        f"{candidate_base}/index.js",
+        f"{candidate_base}/index.ts",
+    ]
+    for candidate in candidates:
+        if _snapshot_file_indexed(conn, candidate):
+            return candidate
+    return None
+
+
+def build_snapshot_file_dependency_view(conn: Any, rel_path: str) -> FileDependencyView:
+    """Build the one-file import view from the snapshot connection.
+
+    RFC-0022 P0.4 read_existing: the live ``build_file_dependency_view``
+    re-parses the filesystem; this variant reads only the immutable snapshot
+    connection. Two passes mirror the legacy axis:
+
+    1. ``edges`` IMPORTS rows: exact module-path resolution (``callee_name``
+       resolved against the indexed files).
+    2. ``ast_index.imports_json`` needle pass: ``from pkg import app`` and
+       ``from . import app`` store the module path (``pkg`` / ``.``), which
+       exact resolution cannot map to the member file ``pkg/app.py``; the
+       legacy axis scans source text for import needles, so the snapshot
+       variant matches the same needles against each importer's recorded
+       import-statement text instead (no live bytes are consulted).
+
+    A missing/legacy schema degrades to an empty view so the route can still
+    classify honestly.
+    """
+    import json
+
+    dependencies: set[str] = set()
+    dependents: set[str] = set()
+    try:
+        import_rows = conn.execute(
+            "SELECT callee_name FROM edges WHERE kind = 'imports' AND file_path = ?",
+            (rel_path,),
+        ).fetchall()
+        for (module,) in import_rows:
+            resolved = _resolve_import_spec_in_snapshot(conn, module, rel_path)
+            if resolved:
+                dependencies.add(resolved)
+        all_rows = conn.execute(
+            "SELECT file_path, callee_name FROM edges WHERE kind = 'imports'",
+        ).fetchall()
+        for file_path, module in all_rows:
+            if not file_path or file_path == rel_path:
+                continue
+            resolved = _resolve_import_spec_in_snapshot(conn, module, file_path)
+            if resolved == rel_path:
+                dependents.add(file_path)
+    except Exception:  # nosec B110 — snapshot schema drift degrades to empty
+        pass
+    try:
+        needles = _import_needles_for_target(rel_path)
+        if needles:
+            rows = conn.execute(
+                "SELECT file_path, imports_json FROM ast_index"
+            ).fetchall()
+            for row in rows:
+                file_path = row["file_path"]
+                if not file_path or file_path == rel_path:
+                    continue
+                try:
+                    imports = json.loads(row["imports_json"])
+                except (TypeError, ValueError):
+                    continue
+                for imp in imports:
+                    imp_text = imp["text"] if isinstance(imp, dict) else imp
+                    if not isinstance(imp_text, str):
+                        continue
+                    if any(needle in imp_text for needle in needles):
+                        dependents.add(file_path)
+                        break
+    except Exception:  # nosec B110 — snapshot schema drift degrades to empty
+        pass
+    return FileDependencyView(
+        rel_path=rel_path,
+        dependencies=dependencies,
+        dependents=dependents,
+    )
+
+
 def safe_dependents(graph: Any, rel_path: str) -> list[str]:
     """Return files that depend on rel_path, tolerating stale graph data."""
     return _safe_graph_lookup(graph, rel_path, graph.dependents_of)

--- a/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
@@ -443,9 +443,10 @@ def build_agent_summary(
 def build_agent_workflow(context: AgentWorkflowContext) -> dict[str, Any]:
     """Build a machine-friendly edit workflow for autonomous agents."""
     if context.certified:
-        # Codex P2 (#1299 round-6/7): snapshot-bound default — live config
+        # Codex P2 (#1299 round-6/7/8): snapshot-bound default — live config
         # detection would read non-inventoried files, so the runner is
-        # inferred from the target's extension instead.
+        # inferred from the target's extension; ambiguous ecosystems omit
+        # the command entirely (None) rather than guessing.
         from .verification_command import certified_default_test_command
 
         default_command = certified_default_test_command(context.file_path)
@@ -453,10 +454,10 @@ def build_agent_workflow(context: AgentWorkflowContext) -> dict[str, Any]:
         default_command = detect_default_test_command(context.project_root)
     focused_command = (
         build_test_command(default_command, context.test_files)
-        if context.has_tests
+        if context.has_tests and default_command is not None
         else ""
     )
-    boundary_command = default_command.command
+    boundary_command = default_command.command if default_command is not None else ""
     quoted_path = shlex.quote(context.file_path)
     pre_edit_commands = [focused_command] if focused_command else []
     post_edit_commands = [
@@ -810,12 +811,17 @@ def _certified_symbol_reference_tests(
     symbols: set[str] = set()
     try:
         payload = _json.loads(str(target_row["symbols_json"]))
-        for entry in payload.get("symbols", []):
-            name = entry.get("name") if isinstance(entry, dict) else None
-            if isinstance(name, str) and not name.startswith("_"):
-                symbols.add(name)
     except (TypeError, ValueError):
         return []
+    if not isinstance(payload, dict):
+        # Codex P2 (#1299 round-8, C34): valid JSON of the wrong top-level
+        # shape must degrade, never crash with AttributeError outside the
+        # classified exception set.
+        return []
+    for entry in payload.get("symbols", []):
+        name = entry.get("name") if isinstance(entry, dict) else None
+        if isinstance(name, str) and not name.startswith("_"):
+            symbols.add(name)
     if not symbols:
         return []
 
@@ -834,9 +840,23 @@ def _certified_symbol_reference_tests(
             continue
         if row is None:
             continue
-        text = str(row["imports_json"])
-        if any(symbol in text for symbol in symbols):
-            results.append(rel)
+        # Codex P2 (#1299 round-8, C33): match symbols against the PARSED
+        # import identifiers, never the serialized cell — substrings and
+        # JSON keys (e.g. a symbol 'text' matching every record's "text"
+        # key) would otherwise produce false has_tests=True.
+        try:
+            records = _json.loads(str(row["imports_json"]))
+        except (TypeError, ValueError):
+            continue
+        if not isinstance(records, list):
+            continue
+        for record in records:
+            text = record.get("text") if isinstance(record, dict) else None
+            if not isinstance(text, str):
+                continue
+            if any(re.search(rf"\b{re.escape(symbol)}\b", text) for symbol in symbols):
+                results.append(rel)
+                break
     return results
 
 
@@ -900,6 +920,28 @@ def _certified_test_files(
         colocated = f"{parent}/{filename}"
         if colocated in inventory and colocated not in results:
             results.append(colocated)
+    if language == "python":
+        # Codex P2 (#1299 round-8, C36): preserve the live route's
+        # package-family convention (test_<plugin>.py) over the inventory.
+        from .test_discovery_stems import python_package_test_stems
+
+        for package_stem in python_package_test_stems(rel_path):
+            for pattern in (
+                f"test_{package_stem}.py",
+                f"test_{package_stem}_*.py",
+            ):
+                for rel in sorted(inventory):
+                    if rel == rel_path:
+                        continue
+                    if (
+                        fnmatch.fnmatchcase(Path(rel).name, pattern)
+                        and any(
+                            test_dir == "." or rel.startswith(f"{test_dir}/")
+                            for test_dir in test_dirs
+                        )
+                        and rel not in results
+                    ):
+                        results.append(rel)
     for dep in dependents:
         # Symbol-reference mode over certified inputs: inventory-covered
         # dependents that import the target and look like tests count.

--- a/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
@@ -144,6 +144,13 @@ def _collect_safe_to_edit_facts(context: SafeToEditContext) -> SafeToEditFacts:
     else:
         test_files = find_test_files(context.resolved_path, context.project_root)
         certified_health = False
+    if certified_health:
+        # Codex P2 (#1299 round-13, C60): certified reads must parse the
+        # freshly recaptured bytes — bypass the stat-only parser cache
+        # (same-size + restored-mtime rewrites would serve stale results).
+        from ....core.parser import Parser as _Parser
+
+        _Parser.invalidate_stat_cache()
     health = context.scorer.score_file(
         context.resolved_path,
         fast_dependencies=True,
@@ -921,8 +928,10 @@ def _certified_symbol_reference_tests(
             # itself defines the symbol, the import belongs to that module.
             import_module = _import_module_name(text)
             if import_module:
+                # Codex P2 (#1299 round-13, C58): relative imports resolve
+                # from the IMPORTING TEST's directory, never the target's.
                 resolved_module = _resolve_import_spec_in_snapshot(
-                    conn, import_module, rel_path
+                    conn, import_module, rel
                 )
                 if (
                     resolved_module

--- a/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
@@ -126,7 +126,7 @@ def _collect_safe_to_edit_facts(context: SafeToEditContext) -> SafeToEditFacts:
         # set, so oracle-excluded files (tests/vendor/) can neither fill the
         # discovery cap nor change has_tests/verdict for the same identity.
         inventory = snapshot_inventory(context.snapshot_conn)
-        test_files = _certified_test_files(inventory, context.resolved_path)
+        test_files = _certified_test_files(inventory, rel_path)
         certified_health = True
     else:
         test_files = find_test_files(context.resolved_path, context.project_root)
@@ -713,15 +713,20 @@ def _require_edges_callee_name(conn: Any) -> None:
         raise ValueError("CORRUPT_INDEX")
 
 
-def _certified_test_files(inventory: frozenset[str], file_path: str) -> list[str]:
-    """Find inventory-covered test files for one target.
+def _certified_test_files(inventory: frozenset[str], rel_path: str) -> list[str]:
+    """Find inventory-covered test files for one target (RELATIVE posix path).
 
     Codex P1 (#1299 round-3/4): snapshot-certified test discovery walks the
     snapshot's ``ast_index`` file set instead of the live filesystem, so
     oracle-excluded paths (e.g. ``tests/vendor/``) can never influence
     ``has_tests`` and the discovery cap cannot be filled by un-certified
-    candidates. Pattern and colocated conventions mirror the live axis.
+    candidates. Pattern and colocated conventions mirror the live axis:
+    basenames are matched with the patterns' GLOB semantics (round-5, e.g.
+    ``test_app_*.py``) and ``test_dirs`` of ``"."`` (Go's co-located
+    convention) accept any inventory path (round-5).
     """
+
+    import fnmatch
 
     from .test_discovery import (
         _TEST_DIRS,
@@ -730,21 +735,27 @@ def _certified_test_files(inventory: frozenset[str], file_path: str) -> list[str
         detect_language_from_ext,
     )
 
-    p = Path(file_path)
+    p = Path(rel_path)
     stem = p.stem
     language = detect_language_from_ext(p.suffix.lower()) or "python"
     patterns = _TEST_PATTERNS.get(language, ["test_{stem}.py"])
     test_dirs = _TEST_DIRS.get(language, ["tests"])
-    filenames = {_format_pattern(pattern, stem) for pattern in patterns}
+    filenames = [_format_pattern(pattern, stem) for pattern in patterns]
 
     results: list[str] = []
     for rel in sorted(inventory):
-        if Path(rel).name not in filenames:
+        if not any(
+            fnmatch.fnmatchcase(Path(rel).name, pattern) for pattern in filenames
+        ):
             continue
-        if any(rel.startswith(f"{test_dir}/") for test_dir in test_dirs):
+        if any(
+            test_dir == "." or rel.startswith(f"{test_dir}/") for test_dir in test_dirs
+        ):
             results.append(rel)
     parent = p.parent.as_posix()
     for filename in filenames:
+        if "*" in filename:
+            continue
         colocated = f"{parent}/{filename}"
         if colocated in inventory and colocated not in results:
             results.append(colocated)

--- a/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
@@ -115,6 +115,13 @@ def _collect_safe_to_edit_facts(context: SafeToEditContext) -> SafeToEditFacts:
     dependencies = safe_dependencies(context.graph, rel_path)
     health = context.scorer.score_file(context.resolved_path, fast_dependencies=True)
     test_files = find_test_files(context.resolved_path, context.project_root)
+    if context.snapshot_conn is not None:
+        # Codex P1 (#1299 round-3): test facts must come from inventory-
+        # covered paths only — a test under an oracle-excluded directory
+        # (e.g. tests/vendor/) is outside the source generation and must
+        # not change has_tests/verdict for the same snapshot identity.
+        inventory = snapshot_inventory(context.snapshot_conn)
+        test_files = [tf for tf in test_files if tf in inventory]
     has_tests = bool(test_files)
     risk, risk_factors = compute_risk(
         forward_count=len(dependents),
@@ -176,15 +183,20 @@ def _format_safe_to_edit_result(
         # constraint facts from the immutable snapshot connection and runs
         # the certified fixture probe — never the live .ast-cache DB and
         # never the live allowlist/cache (both are outside the source
-        # generation and could drift after snapshot publication).
+        # generation and could drift after snapshot publication). The
+        # inventory restriction keeps the fixture scan on generation-
+        # certified test files only (round-3: oracle-pruned paths such as
+        # tests/vendor/ must not influence escalation).
         violations = violations_for_files_from_conn(
             context.snapshot_conn, [_relative_for_constraints(context)]
         )
+        fixture_inventory = snapshot_inventory(context.snapshot_conn)
         fixture_certified = True
     else:
         violations = violations_for_files(
             context.project_root, [_relative_for_constraints(context)]
         )
+        fixture_inventory = None
         fixture_certified = False
     constraint_verdict = verdict_from_violations(violations)
     # P3: also check whether the file is a registered test fixture; that
@@ -195,6 +207,7 @@ def _format_safe_to_edit_result(
         context.resolved_path,
         context.project_root,
         certified=fixture_certified,
+        inventory=fixture_inventory,
     )
     fixture_verdict = fixture_to_verdict(fixture_fact)
     verdict = _max_verdict(
@@ -683,6 +696,22 @@ def _require_edges_callee_name(conn: Any) -> None:
         return
     if "callee_name" not in columns:
         raise ValueError("CORRUPT_INDEX")
+
+
+def snapshot_inventory(conn: Any) -> frozenset[str]:
+    """Return the snapshot's ``ast_index`` relative file set.
+
+    Codex P1 (#1299 round-3): certified reads must derive facts only from
+    inventory-covered paths (the source oracle prunes e.g. ``tests/vendor``
+    from the generation). An unreadable inventory degrades to the empty
+    set — the conservative, fail-closed direction for certified facts.
+    """
+
+    try:
+        rows = conn.execute("SELECT file_path FROM ast_index").fetchall()
+    except Exception:  # nosec B110 — legacy/partial schema
+        return frozenset()
+    return frozenset(str(row["file_path"]) for row in rows)
 
 
 def _snapshot_file_indexed(conn: Any, rel_path: str) -> bool:

--- a/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
@@ -16,6 +16,7 @@ from .constraint_violation_query import (
     constraint_risk_factor,
     verdict_from_violations,
     violations_for_files,
+    violations_for_files_from_conn,
 )
 from .safe_to_edit_risk import build_checklist, compute_risk
 from .test_discovery import find_test_files
@@ -24,7 +25,13 @@ from .verification_command import build_test_command, detect_default_test_comman
 
 @dataclass(frozen=True)
 class SafeToEditContext:
-    """Inputs needed to build a safe-to-edit response."""
+    """Inputs needed to build a safe-to-edit response.
+
+    ``snapshot_conn`` is the certified index-snapshot connection on the
+    read_existing route; when set, constraint violations are read from the
+    snapshot and fixture detection runs read-only (Codex P1 #1299: the
+    certified route must never open or write the live ``.ast-cache``).
+    """
 
     file_path: str
     edit_type: str
@@ -32,6 +39,7 @@ class SafeToEditContext:
     project_root: str
     graph: Any
     scorer: HealthScorer
+    snapshot_conn: Any | None = None
 
 
 class FileDependencyView:
@@ -163,15 +171,28 @@ def _format_safe_to_edit_result(
     # Constraint violations promote the verdict: an error-severity
     # violation referencing this file forces UNSAFE; warn-only forces
     # CAUTION. The base_verdict (derived from risk_level) is the floor.
-    violations = violations_for_files(
-        context.project_root, [_relative_for_constraints(context)]
-    )
+    if context.snapshot_conn is not None:
+        # Codex P1 (#1299): the certified read_existing route derives
+        # constraint facts from the immutable snapshot connection and runs
+        # fixture detection read-only — never the live .ast-cache DB or a
+        # fixture-index rebuild write.
+        violations = violations_for_files_from_conn(
+            context.snapshot_conn, [_relative_for_constraints(context)]
+        )
+        fixture_rebuild = False
+    else:
+        violations = violations_for_files(
+            context.project_root, [_relative_for_constraints(context)]
+        )
+        fixture_rebuild = True
     constraint_verdict = verdict_from_violations(violations)
     # P3: also check whether the file is a registered test fixture; that
     # promotes the verdict on top of any constraint-derived escalation.
     # The chokepoint design (see PRD §P3) is "every override flows
     # through _max_verdict" — so chaining is the only safe composition.
-    fixture_fact = is_fixture(context.resolved_path, context.project_root)
+    fixture_fact = is_fixture(
+        context.resolved_path, context.project_root, rebuild_cache=fixture_rebuild
+    )
     fixture_verdict = fixture_to_verdict(fixture_fact)
     verdict = _max_verdict(
         _max_verdict(base_verdict, constraint_verdict), fixture_verdict

--- a/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
@@ -477,7 +477,7 @@ def build_agent_workflow(context: AgentWorkflowContext) -> dict[str, Any]:
         "edit_strategy": _edit_strategy(context.risk, context.edit_type),
         "before_edit_commands": pre_edit_commands,
         "after_edit_commands": post_edit_commands,
-        "queue_boundary_commands": [boundary_command],
+        "queue_boundary_commands": [boundary_command] if boundary_command else [],
         "guardrails": _agent_guardrails(
             context.risk,
             context.edit_type,
@@ -857,6 +857,29 @@ def _certified_symbol_reference_tests(
             if any(re.search(rf"\b{re.escape(symbol)}\b", text) for symbol in symbols):
                 results.append(rel)
                 break
+    # Codex P2 (#1299 round-10, C42): snapshot CALL references too — a test
+    # doing 'import pkg; pkg.public_fn()' references the symbol through a
+    # call edge even though imports_json carries only 'import pkg'.
+    # symbols is guaranteed non-empty here (the early return above).
+    placeholders = ",".join("?" for _ in symbols)  # nosec B608
+    try:
+        call_rows = conn.execute(
+            f"SELECT DISTINCT file_path FROM edges "
+            f"WHERE kind = 'calls' AND callee_name IN ({placeholders})",
+            tuple(symbols),
+        ).fetchall()
+    except Exception:  # nosec B110 — legacy schema degrades per call
+        call_rows = []
+    for row in call_rows:
+        rel = str(row["file_path"])
+        if (
+            rel
+            and rel != rel_path
+            and rel in inventory
+            and _looks_like_test_name(Path(rel).name, language)
+            and rel not in results
+        ):
+            results.append(rel)
     return results
 
 
@@ -1044,6 +1067,10 @@ def build_snapshot_file_dependency_view(conn: Any, rel_path: str) -> FileDepende
             (rel_path,),
         ).fetchall()
         for (module,) in import_rows:
+            if not isinstance(module, str):
+                # Codex P2 (#1299 round-10, C44): a BLOB callee_name would
+                # raise TypeError at startswith and abandon the whole pass.
+                continue
             resolved = _resolve_import_spec_in_snapshot(conn, module, rel_path)
             if resolved:
                 dependencies.add(resolved)
@@ -1052,6 +1079,8 @@ def build_snapshot_file_dependency_view(conn: Any, rel_path: str) -> FileDepende
         ).fetchall()
         for file_path, module in all_rows:
             if not file_path or file_path == rel_path:
+                continue
+            if not isinstance(module, str):
                 continue
             resolved = _resolve_import_spec_in_snapshot(conn, module, file_path)
             if resolved == rel_path:

--- a/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
@@ -109,7 +109,15 @@ def build_safe_to_edit_result(context: SafeToEditContext) -> dict[str, Any]:
 
 def _collect_safe_to_edit_facts(context: SafeToEditContext) -> SafeToEditFacts:
     """Collect graph, health, test, and risk facts for a file."""
-    rel_path = to_relative(context.resolved_path, context.project_root)
+    # Canonicalize before relativising: on macOS the security validator's
+    # abspath (/var/folders/...) and a canonical project_root
+    # (/private/var/folders/...) differ by symlink, which would make
+    # to_relative fall back to the absolute path and miss every graph node
+    # (CLAUDE.md §2 resolution contract) — downstream facts would silently
+    # undercount on macOS while Linux CI saw them.
+    rel_path = to_relative(
+        os.path.realpath(context.resolved_path), context.project_root
+    )
     dependents = safe_dependents(context.graph, rel_path)
     dependencies = safe_dependencies(context.graph, rel_path)
     if context.snapshot_conn is not None:

--- a/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
@@ -726,26 +726,25 @@ def build_snapshot_file_dependency_view(conn: Any, rel_path: str) -> FileDepende
     except Exception:  # nosec B110 — snapshot schema drift degrades to empty
         pass
     try:
+        # _import_needles_for_target always yields at least one needle for a
+        # non-empty rel_path, so no guard is needed around the scan.
         needles = _import_needles_for_target(rel_path)
-        if needles:
-            rows = conn.execute(
-                "SELECT file_path, imports_json FROM ast_index"
-            ).fetchall()
-            for row in rows:
-                file_path = row["file_path"]
-                if not file_path or file_path == rel_path:
+        rows = conn.execute("SELECT file_path, imports_json FROM ast_index").fetchall()
+        for row in rows:
+            file_path = row["file_path"]
+            if not file_path or file_path == rel_path:
+                continue
+            try:
+                imports = json.loads(row["imports_json"])
+            except (TypeError, ValueError):
+                continue
+            for imp in imports:
+                imp_text = imp["text"] if isinstance(imp, dict) else imp
+                if not isinstance(imp_text, str):
                     continue
-                try:
-                    imports = json.loads(row["imports_json"])
-                except (TypeError, ValueError):
-                    continue
-                for imp in imports:
-                    imp_text = imp["text"] if isinstance(imp, dict) else imp
-                    if not isinstance(imp_text, str):
-                        continue
-                    if any(needle in imp_text for needle in needles):
-                        dependents.add(file_path)
-                        break
+                if any(needle in imp_text for needle in needles):
+                    dependents.add(file_path)
+                    break
     except Exception:  # nosec B110 — snapshot schema drift degrades to empty
         pass
     return FileDependencyView(

--- a/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
@@ -134,6 +134,12 @@ def _collect_safe_to_edit_facts(context: SafeToEditContext) -> SafeToEditFacts:
         # discovery cap nor change has_tests/verdict for the same identity.
         inventory = snapshot_inventory(context.snapshot_conn)
         test_files = _certified_test_files(inventory, rel_path, dependents)
+        test_files.extend(
+            _certified_symbol_reference_tests(
+                context.snapshot_conn, inventory, rel_path, _target_language(rel_path)
+            )
+        )
+        test_files = list(dict.fromkeys(test_files))[:10]
         certified_health = True
     else:
         test_files = find_test_files(context.resolved_path, context.project_root)
@@ -437,11 +443,12 @@ def build_agent_summary(
 def build_agent_workflow(context: AgentWorkflowContext) -> dict[str, Any]:
     """Build a machine-friendly edit workflow for autonomous agents."""
     if context.certified:
-        # Codex P2 (#1299 round-6): snapshot-bound default — live config
-        # detection would read non-inventoried files.
-        from .verification_command import PYTEST_COMMAND as _PYTEST_COMMAND
+        # Codex P2 (#1299 round-6/7): snapshot-bound default — live config
+        # detection would read non-inventoried files, so the runner is
+        # inferred from the target's extension instead.
+        from .verification_command import certified_default_test_command
 
-        default_command = _PYTEST_COMMAND
+        default_command = certified_default_test_command(context.file_path)
     else:
         default_command = detect_default_test_command(context.project_root)
     focused_command = (
@@ -729,6 +736,14 @@ def _require_edges_callee_name(conn: Any) -> None:
         raise ValueError("CORRUPT_INDEX")
 
 
+def _target_language(rel_path: str) -> str:
+    """Return the test-discovery language name for one relative path."""
+
+    from .test_discovery import detect_language_from_ext
+
+    return detect_language_from_ext(Path(rel_path).suffix.lower()) or "python"
+
+
 def _looks_like_test_name(name: str, language: str) -> bool:
     """Mirror is_existing_test_file's NAME conventions over certified inputs.
 
@@ -765,6 +780,64 @@ def _looks_like_test_name(name: str, language: str) -> bool:
     if language == "php":
         return name.endswith(("Test.php", "test.php"))
     return False
+
+
+def _certified_symbol_reference_tests(
+    conn: Any, inventory: frozenset[str], rel_path: str, language: str
+) -> list[str]:
+    """Symbol-reference test discovery over snapshot-owned data.
+
+    The legacy ``_find_symbol_reference_tests`` scans live test bytes for
+    the target's public symbols; the certified variant (Codex P2 #1299
+    round-7, C31) scans the snapshot's recorded import statements
+    (``imports_json``) of inventory-covered, test-named files for the
+    target's INDEXED public symbol names — tests that use ``from pkg
+    import public_fn`` are found even when they import a package, not the
+    defining file.
+    """
+
+    import json as _json
+
+    try:
+        target_row = conn.execute(
+            "SELECT symbols_json FROM ast_index WHERE file_path = ?",
+            (rel_path,),
+        ).fetchone()
+    except Exception:  # nosec B110 — legacy schema degrades to no matches
+        return []
+    if target_row is None:
+        return []
+    symbols: set[str] = set()
+    try:
+        payload = _json.loads(str(target_row["symbols_json"]))
+        for entry in payload.get("symbols", []):
+            name = entry.get("name") if isinstance(entry, dict) else None
+            if isinstance(name, str) and not name.startswith("_"):
+                symbols.add(name)
+    except (TypeError, ValueError):
+        return []
+    if not symbols:
+        return []
+
+    results: list[str] = []
+    for rel in sorted(inventory):
+        if rel == rel_path:
+            continue
+        if not _looks_like_test_name(Path(rel).name, language):
+            continue
+        try:
+            row = conn.execute(
+                "SELECT imports_json FROM ast_index WHERE file_path = ?",
+                (rel,),
+            ).fetchone()
+        except Exception:  # nosec B110 — legacy schema degrades per row
+            continue
+        if row is None:
+            continue
+        text = str(row["imports_json"])
+        if any(symbol in text for symbol in symbols):
+            results.append(rel)
+    return results
 
 
 def _certified_test_files(

--- a/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
@@ -794,6 +794,48 @@ def _looks_like_test_name(name: str, language: str) -> bool:
     return False
 
 
+def _import_module_name(import_text: str) -> str | None:
+    """Return the imported module path from one import statement text."""
+
+    import re as _re
+
+    m = _re.match(r"^\s*from\s+([.\w]+)\s+import\b", import_text)
+    if m:
+        return m.group(1)
+    m = _re.match(r"^\s*import\s+([.\w]+)", import_text)
+    if m:
+        return m.group(1)
+    return None
+
+
+def _file_defines_any(conn: Any, file_path: str, symbols: list[str]) -> bool:
+    """Return whether one indexed file defines ANY of the given symbols."""
+
+    import json as _json
+
+    try:
+        row = conn.execute(
+            "SELECT symbols_json FROM ast_index WHERE file_path = ?",
+            (file_path,),
+        ).fetchone()
+    except Exception:  # nosec B110
+        return False
+    if row is None:
+        return False
+    try:
+        payload = _json.loads(str(row["symbols_json"]))
+    except (TypeError, ValueError):
+        return False
+    if not isinstance(payload, dict):
+        return False
+    defined = {
+        entry.get("name")
+        for entry in payload.get("symbols", [])
+        if isinstance(entry, dict)
+    }
+    return bool(defined.intersection(symbols))
+
+
 def _certified_symbol_reference_tests(
     conn: Any, inventory: frozenset[str], rel_path: str, language: str
 ) -> list[str]:
@@ -865,9 +907,31 @@ def _certified_symbol_reference_tests(
             text = record.get("text") if isinstance(record, dict) else None
             if not isinstance(text, str):
                 continue
-            if any(re.search(rf"\b{re.escape(symbol)}\b", text) for symbol in symbols):
-                results.append(rel)
-                break
+            matched = [
+                symbol
+                for symbol in symbols
+                if re.search(rf"\b{re.escape(symbol)}\b", text)
+            ]
+            if not matched:
+                continue
+            # Codex P2 (#1299 round-12, C56): bind the import to the target
+            # module — a test doing 'from other import run' must not count
+            # for pkg/impl.py just because both define 'run'. Resolve the
+            # imported module; if it resolves to a DIFFERENT file that
+            # itself defines the symbol, the import belongs to that module.
+            import_module = _import_module_name(text)
+            if import_module:
+                resolved_module = _resolve_import_spec_in_snapshot(
+                    conn, import_module, rel_path
+                )
+                if (
+                    resolved_module
+                    and resolved_module != rel_path
+                    and _file_defines_any(conn, resolved_module, matched)
+                ):
+                    continue
+            results.append(rel)
+            break
     # Codex P2 (#1299 round-10, C42): snapshot CALL references too — a test
     # doing 'import pkg; pkg.public_fn()' references the symbol through a
     # call edge even though imports_json carries only 'import pkg'.
@@ -986,8 +1050,14 @@ def _certified_test_files(
                         results.append(rel)
     for dep in dependents:
         # Symbol-reference mode over certified inputs: inventory-covered
-        # dependents that import the target and look like tests count.
-        if _looks_like_test_name(Path(dep).name, language) and dep not in results:
+        # dependents that import the target and look like tests count —
+        # an IMPORTS edge left for an excluded/unindexed path must NOT be
+        # served as a certified test (Codex P2 #1299 round-12, C54).
+        if (
+            dep in inventory
+            and _looks_like_test_name(Path(dep).name, language)
+            and dep not in results
+        ):
             results.append(dep)
     return results[:10]
 
@@ -1097,7 +1167,7 @@ def build_snapshot_file_dependency_view(conn: Any, rel_path: str) -> FileDepende
             "SELECT file_path, callee_name FROM edges WHERE kind = 'imports'",
         ).fetchall()
         for file_path, module in all_rows:
-            if not file_path or file_path == rel_path:
+            if not isinstance(file_path, str) or not file_path or file_path == rel_path:
                 continue
             if not isinstance(module, str):
                 continue

--- a/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_risk.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_risk.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 
 from .verification_command import (
-    PYTEST_COMMAND,
     build_test_command,
     detect_default_test_command,
 )
@@ -56,7 +55,13 @@ def build_checklist(
     """
     raw: list[str] = [_risk_instruction(risk)]
     raw.extend(
-        _test_instructions(has_tests, test_files, project_root, certified=certified)
+        _test_instructions(
+            has_tests,
+            test_files,
+            project_root,
+            certified=certified,
+            file_path=file_path,
+        )
     )
 
     if downstream_count > 0:
@@ -270,16 +275,19 @@ def _test_instructions(
     project_root: str | Path | None,
     *,
     certified: bool = False,
+    file_path: str = "",
 ) -> list[str]:
     """Return checklist items for test coverage.
 
-    ``certified`` (Codex P2 #1299 round-6): the default test command must be
+    ``certified`` (Codex P2 #1299 round-6/7): the default test command must be
     snapshot-bound — live config detection (package.json/go.mod/Cargo.toml)
     reads non-inventoried files that can drift for the same identity, so the
-    certified route uses the analyzer's own pytest default instead.
+    certified route infers the runner from the target's extension.
     """
     if certified:
-        default_command = PYTEST_COMMAND
+        from .verification_command import certified_default_test_command
+
+        default_command = certified_default_test_command(file_path or "app.py")
     else:
         default_command = detect_default_test_command(project_root)
     if has_tests:

--- a/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_risk.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_risk.py
@@ -290,6 +290,15 @@ def _test_instructions(
         default_command = certified_default_test_command(file_path or "app.py")
     else:
         default_command = detect_default_test_command(project_root)
+    if default_command is None:
+        # Codex P2 (#1299 round-8, C35): ambiguous ecosystem — omit the
+        # command items rather than advertise an unverifiable runner.
+        if has_tests:
+            return [
+                "2. Run existing tests FIRST",
+                "3. Run same verification AFTER editing",
+            ]
+        return ["2. No tests found nearby - write tests BEFORE editing (TDD)"]
     if has_tests:
         test_command = build_test_command(default_command, test_files)
         return [

--- a/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_risk.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_risk.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from .verification_command import build_test_command, detect_default_test_command
+from .verification_command import (
+    PYTEST_COMMAND,
+    build_test_command,
+    detect_default_test_command,
+)
 
 RiskFactor = dict[str, str]
 
@@ -40,6 +44,8 @@ def build_checklist(
     health_grade: str = "",
     file_path: str = "",
     project_root: str | Path | None = None,
+    *,
+    certified: bool = False,
 ) -> list[str]:
     """Build a pre-edit checklist for the AI agent.
 
@@ -49,7 +55,9 @@ def build_checklist(
     [1, 2, 3, 5] when downstream_count == 0 (issue #641).
     """
     raw: list[str] = [_risk_instruction(risk)]
-    raw.extend(_test_instructions(has_tests, test_files, project_root))
+    raw.extend(
+        _test_instructions(has_tests, test_files, project_root, certified=certified)
+    )
 
     if downstream_count > 0:
         raw.append(
@@ -260,9 +268,20 @@ def _test_instructions(
     has_tests: bool,
     test_files: list[str],
     project_root: str | Path | None,
+    *,
+    certified: bool = False,
 ) -> list[str]:
-    """Return checklist items for test coverage."""
-    default_command = detect_default_test_command(project_root)
+    """Return checklist items for test coverage.
+
+    ``certified`` (Codex P2 #1299 round-6): the default test command must be
+    snapshot-bound — live config detection (package.json/go.mod/Cargo.toml)
+    reads non-inventoried files that can drift for the same identity, so the
+    certified route uses the analyzer's own pytest default instead.
+    """
+    if certified:
+        default_command = PYTEST_COMMAND
+    else:
+        default_command = detect_default_test_command(project_root)
     if has_tests:
         test_command = build_test_command(default_command, test_files)
         return [

--- a/tree_sitter_analyzer/mcp/tools/utils/verification_command.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/verification_command.py
@@ -60,9 +60,10 @@ def certified_default_test_command(
     from the TARGET's extension — a fact bound to the snapshot inventory.
     Only ecosystems with an unambiguous canonical runner map; ambiguous
     ones (Java's Maven-vs-Gradle, Kotlin, C#, PHP, C/C++, Ruby's
-    rspec-vs-minitest) return ``None`` so the route OMITS the command
-    rather than advertising an unverifiable choice. Python keeps the
-    pytest default.
+    rspec-vs-minitest, and JavaScript/TypeScript's npm-vs-pnpm-vs-Yarn-
+    vs-Bun, which only non-inventoried lockfiles can distinguish) return
+    ``None`` so the route OMITS the command rather than advertising an
+    unverifiable choice. Python keeps the pytest default.
     """
 
     ext = Path(file_path).suffix.lower()
@@ -70,8 +71,6 @@ def certified_default_test_command(
         return DefaultTestCommand("go", "go test ./...")
     if ext == ".rs":
         return DefaultTestCommand("cargo", "cargo test")
-    if ext in {".js", ".jsx", ".ts", ".tsx"}:
-        return DefaultTestCommand("node", "npm test")
     if ext == ".py":
         return PYTEST_COMMAND
     return None

--- a/tree_sitter_analyzer/mcp/tools/utils/verification_command.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/verification_command.py
@@ -50,13 +50,19 @@ def detect_default_test_command(project_root: str | Path | None) -> DefaultTestC
     return PYTEST_COMMAND
 
 
-def certified_default_test_command(file_path: str) -> DefaultTestCommand:
+def certified_default_test_command(
+    file_path: str,
+) -> DefaultTestCommand | None:
     """Extension-derived default test command, snapshot-bound.
 
-    Codex P2 (#1299 round-7, C32): the certified route cannot read live
-    config files (package.json/go.mod/...), so the runner is inferred from
-    the TARGET's extension — a fact bound to the snapshot inventory. Files
-    whose language has no conventional runner keep the pytest default.
+    Codex P2 (#1299 round-7/8, C32/C35): the certified route cannot read
+    live config files (package.json/go.mod/...), so the runner is inferred
+    from the TARGET's extension — a fact bound to the snapshot inventory.
+    Only ecosystems with an unambiguous canonical runner map; ambiguous
+    ones (Java's Maven-vs-Gradle, Kotlin, C#, PHP, C/C++, Ruby's
+    rspec-vs-minitest) return ``None`` so the route OMITS the command
+    rather than advertising an unverifiable choice. Python keeps the
+    pytest default.
     """
 
     ext = Path(file_path).suffix.lower()
@@ -66,19 +72,9 @@ def certified_default_test_command(file_path: str) -> DefaultTestCommand:
         return DefaultTestCommand("cargo", "cargo test")
     if ext in {".js", ".jsx", ".ts", ".tsx"}:
         return DefaultTestCommand("node", "npm test")
-    if ext == ".java":
-        return DefaultTestCommand("maven", "mvn test")
-    if ext == ".rb":
-        return DefaultTestCommand("ruby", "bundle exec rspec")
-    if ext == ".kt":
-        return DefaultTestCommand("gradle", "gradle test")
-    if ext == ".cs":
-        return DefaultTestCommand("dotnet", "dotnet test")
-    if ext == ".php":
-        return DefaultTestCommand("composer", "composer test")
-    if ext in {".c", ".h", ".cpp", ".hpp", ".cc"}:
-        return DefaultTestCommand("make", "make test")
-    return PYTEST_COMMAND
+    if ext == ".py":
+        return PYTEST_COMMAND
+    return None
 
 
 def build_test_command(

--- a/tree_sitter_analyzer/mcp/tools/utils/verification_command.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/verification_command.py
@@ -50,6 +50,37 @@ def detect_default_test_command(project_root: str | Path | None) -> DefaultTestC
     return PYTEST_COMMAND
 
 
+def certified_default_test_command(file_path: str) -> DefaultTestCommand:
+    """Extension-derived default test command, snapshot-bound.
+
+    Codex P2 (#1299 round-7, C32): the certified route cannot read live
+    config files (package.json/go.mod/...), so the runner is inferred from
+    the TARGET's extension — a fact bound to the snapshot inventory. Files
+    whose language has no conventional runner keep the pytest default.
+    """
+
+    ext = Path(file_path).suffix.lower()
+    if ext == ".go":
+        return DefaultTestCommand("go", "go test ./...")
+    if ext == ".rs":
+        return DefaultTestCommand("cargo", "cargo test")
+    if ext in {".js", ".jsx", ".ts", ".tsx"}:
+        return DefaultTestCommand("node", "npm test")
+    if ext == ".java":
+        return DefaultTestCommand("maven", "mvn test")
+    if ext == ".rb":
+        return DefaultTestCommand("ruby", "bundle exec rspec")
+    if ext == ".kt":
+        return DefaultTestCommand("gradle", "gradle test")
+    if ext == ".cs":
+        return DefaultTestCommand("dotnet", "dotnet test")
+    if ext == ".php":
+        return DefaultTestCommand("composer", "composer test")
+    if ext in {".c", ".h", ".cpp", ".hpp", ".cc"}:
+        return DefaultTestCommand("make", "make test")
+    return PYTEST_COMMAND
+
+
 def build_test_command(
     default_command: DefaultTestCommand,
     tests_to_run: list[str],

--- a/tree_sitter_analyzer/read_existing_access.py
+++ b/tree_sitter_analyzer/read_existing_access.py
@@ -389,6 +389,7 @@ _INDEX_CONSUMER_STABLE_CODES = frozenset(
         "CONSTRAINED_INDEX_SCOPE",
         "INDEX_SNAPSHOT_INCOMPLETE",
         "FILE_NOT_FOUND",
+        "FILE_NOT_INDEXED",
     }
 )
 
@@ -490,6 +491,11 @@ def read_existing_index_consumer(
                 result, output_format, compact_only=compact_only
             )
     except (ValueError, RuntimeError) as exc:
+        # Codex P2 (#1299): pre-yield failures (completeness/scope gate or
+        # pre-read recapture) attach the acquired identity to the exception;
+        # post-yield failures record it in ``acquired``. Either way the
+        # failure envelope cites the exact capability that was acquired.
+        identity = getattr(exc, "_read_existing_identity", None) or acquired
         return format_read_existing_failure(
             _stable_consumer_code(exc),
             output_format=output_format,
@@ -499,11 +505,11 @@ def read_existing_index_consumer(
                 [
                     {
                         "kind": "index",
-                        "snapshot_id": acquired[0],
-                        "source_generation": acquired[1],
+                        "snapshot_id": identity[0],
+                        "source_generation": identity[1],
                     }
                 ]
-                if acquired is not None
+                if identity is not None
                 else None
             ),
         )

--- a/tree_sitter_analyzer/read_existing_access.py
+++ b/tree_sitter_analyzer/read_existing_access.py
@@ -413,6 +413,10 @@ def _stable_consumer_code(exc: Exception) -> str:
         if "interrupt" in message.lower():
             return "INDEX_SNAPSHOT_DEADLINE"
         return "CORRUPT_INDEX"
+    if isinstance(exc, IndexError):
+        # EdgeStore._edge_from_row on a damaged edges row (missing columns
+        # that slipped past the schema gate) surfaces as IndexError.
+        return "CORRUPT_INDEX"
     token = message.split(":", 1)[0].strip()
     return token if token in _INDEX_CONSUMER_STABLE_CODES else "INDEX_SNAPSHOT_FAILED"
 
@@ -499,7 +503,7 @@ def read_existing_index_consumer(
             return apply_toon_format_to_response(
                 result, output_format, compact_only=compact_only
             )
-    except (ValueError, RuntimeError, sqlite3.OperationalError) as exc:
+    except (ValueError, RuntimeError, sqlite3.OperationalError, IndexError) as exc:
         # Codex P2 (#1299): pre-yield failures (completeness/scope gate or
         # pre-read recapture) attach the acquired identity to the exception;
         # post-yield failures record it in ``acquired``. Either way the

--- a/tree_sitter_analyzer/read_existing_access.py
+++ b/tree_sitter_analyzer/read_existing_access.py
@@ -413,10 +413,11 @@ def _stable_consumer_code(exc: Exception) -> str:
         if "interrupt" in message.lower():
             return "INDEX_SNAPSHOT_DEADLINE"
         return "CORRUPT_INDEX"
-    if isinstance(exc, (IndexError, AttributeError)):
+    if isinstance(exc, (IndexError, AttributeError, TypeError)):
         # EdgeStore._edge_from_row on a damaged edges row surfaces as
-        # IndexError (missing columns) or AttributeError (a metadata cell
-        # holding valid JSON of a non-object type, e.g. []).
+        # IndexError (missing columns), AttributeError (a metadata cell
+        # holding valid JSON of a non-object type, e.g. []), or TypeError
+        # (a BLOB in a nominally textual column, e.g. source_node_id).
         return "CORRUPT_INDEX"
     token = message.split(":", 1)[0].strip()
     return token if token in _INDEX_CONSUMER_STABLE_CODES else "INDEX_SNAPSHOT_FAILED"
@@ -510,6 +511,7 @@ def read_existing_index_consumer(
         sqlite3.OperationalError,
         IndexError,
         AttributeError,
+        TypeError,
     ) as exc:
         # Codex P2 (#1299): pre-yield failures (completeness/scope gate or
         # pre-read recapture) attach the acquired identity to the exception;

--- a/tree_sitter_analyzer/read_existing_access.py
+++ b/tree_sitter_analyzer/read_existing_access.py
@@ -280,6 +280,7 @@ def format_read_existing_failure(
     output_format: str = "toon",
     compact_only: bool = False,
     action_version: str | None = None,
+    source_snapshots: list[dict[str, str]] | None = None,
 ) -> dict[str, Any]:
     """Format one classified failure envelope with P0.4 evidence.
 
@@ -287,6 +288,9 @@ def format_read_existing_failure(
     (e.g. edit.safe's unbound-root guard, which must precede path
     validation): produces the same envelope shape the seam's except block
     emits, so the wire contract (evidence + action_version) is never lost.
+    ``source_snapshots`` cites the exact capability identity actually read
+    when the failure happened AFTER acquisition (Codex P2 #1299); failures
+    before acquisition keep the empty list.
     """
     from .mcp.utils.format_helper import apply_toon_format_to_response
 
@@ -298,7 +302,7 @@ def format_read_existing_failure(
         "action_version": action_version,
         "output_format": output_format,
     }
-    attach_read_existing_evidence(failure)
+    attach_read_existing_evidence(failure, records=source_snapshots)
     return apply_toon_format_to_response(
         failure, output_format, compact_only=compact_only
     )
@@ -383,6 +387,7 @@ _INDEX_CONSUMER_STABLE_CODES = frozenset(
         "SOURCE_SCOPE_UNBOUNDED",
         "SOURCE_INDEX_MISMATCH",
         "CONSTRAINED_INDEX_SCOPE",
+        "INDEX_SNAPSHOT_INCOMPLETE",
         "FILE_NOT_FOUND",
     }
 )
@@ -437,6 +442,10 @@ def read_existing_index_consumer(
     from .index_snapshot import read_existing_index_scope
     from .mcp.utils.format_helper import apply_toon_format_to_response
 
+    # Codex P2 (#1299): keep the acquired capability identity so failures
+    # that happen AFTER acquisition still cite the snapshot that was read
+    # (auditability); pre-acquisition failures keep the empty list.
+    acquired: tuple[str, str] | None = None
     try:
         # Codex-review P2 (#1299): an unbound root must be CLASSIFIED (failure
         # envelope with evidence + action_version), never a bare raise that
@@ -453,13 +462,14 @@ def read_existing_index_consumer(
             tool.project_root,
             arguments["source_generation"],
         ) as (snapshot, conn):
+            assert snapshot.snapshot_id is not None
+            assert snapshot.source_generation is not None
+            acquired = (snapshot.snapshot_id, snapshot.source_generation)
             payload = reader(snapshot, conn)
             if not isinstance(payload, dict):
                 raise ValueError("INDEX_SNAPSHOT_FAILED")
             # The acquired capability is identity-matched to the request pair
             # (the registry raises otherwise), so both tokens are bound here.
-            assert snapshot.snapshot_id is not None
-            assert snapshot.source_generation is not None
             result = dict(payload)
             result["snapshot_id"] = snapshot.snapshot_id
             result["source_generation"] = snapshot.source_generation
@@ -485,4 +495,15 @@ def read_existing_index_consumer(
             output_format=output_format,
             compact_only=compact_only,
             action_version=action_version,
+            source_snapshots=(
+                [
+                    {
+                        "kind": "index",
+                        "snapshot_id": acquired[0],
+                        "source_generation": acquired[1],
+                    }
+                ]
+                if acquired is not None
+                else None
+            ),
         )

--- a/tree_sitter_analyzer/read_existing_access.py
+++ b/tree_sitter_analyzer/read_existing_access.py
@@ -413,9 +413,10 @@ def _stable_consumer_code(exc: Exception) -> str:
         if "interrupt" in message.lower():
             return "INDEX_SNAPSHOT_DEADLINE"
         return "CORRUPT_INDEX"
-    if isinstance(exc, IndexError):
-        # EdgeStore._edge_from_row on a damaged edges row (missing columns
-        # that slipped past the schema gate) surfaces as IndexError.
+    if isinstance(exc, (IndexError, AttributeError)):
+        # EdgeStore._edge_from_row on a damaged edges row surfaces as
+        # IndexError (missing columns) or AttributeError (a metadata cell
+        # holding valid JSON of a non-object type, e.g. []).
         return "CORRUPT_INDEX"
     token = message.split(":", 1)[0].strip()
     return token if token in _INDEX_CONSUMER_STABLE_CODES else "INDEX_SNAPSHOT_FAILED"
@@ -503,7 +504,13 @@ def read_existing_index_consumer(
             return apply_toon_format_to_response(
                 result, output_format, compact_only=compact_only
             )
-    except (ValueError, RuntimeError, sqlite3.OperationalError, IndexError) as exc:
+    except (
+        ValueError,
+        RuntimeError,
+        sqlite3.OperationalError,
+        IndexError,
+        AttributeError,
+    ) as exc:
         # Codex P2 (#1299): pre-yield failures (completeness/scope gate or
         # pre-read recapture) attach the acquired identity to the exception;
         # post-yield failures record it in ``acquired``. Either way the

--- a/tree_sitter_analyzer/read_existing_access.py
+++ b/tree_sitter_analyzer/read_existing_access.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sqlite3
 import sys
 from typing import Any
 
@@ -399,11 +400,19 @@ def _stable_consumer_code(exc: Exception) -> str:
 
     ``acquire_index_snapshot`` raises ``ValueError``/``RuntimeError`` whose
     message IS the stable code; the after-read recapture does the same; the
-    unbound-root guard raises ``MISSING_PROJECT_ROOT: <detail>``. The RFC
-    requires those codes as result data, never serialized exception text, so
-    any message outside the stable set degrades to the generic fallback.
+    unbound-root guard raises ``MISSING_PROJECT_ROOT: <detail>``. A reader's
+    ``sqlite3.OperationalError`` is classified: an interrupt (the deadline
+    progress handler's abort) is ``INDEX_SNAPSHOT_DEADLINE``, anything else
+    (missing column/table in a damaged index) is ``CORRUPT_INDEX`` (Codex P2
+    #1299 round-3). The RFC requires those codes as result data, never
+    serialized exception text, so any message outside the stable set degrades
+    to the generic fallback.
     """
     message = str(exc)
+    if isinstance(exc, sqlite3.OperationalError):
+        if "interrupt" in message.lower():
+            return "INDEX_SNAPSHOT_DEADLINE"
+        return "CORRUPT_INDEX"
     token = message.split(":", 1)[0].strip()
     return token if token in _INDEX_CONSUMER_STABLE_CODES else "INDEX_SNAPSHOT_FAILED"
 
@@ -490,7 +499,7 @@ def read_existing_index_consumer(
             return apply_toon_format_to_response(
                 result, output_format, compact_only=compact_only
             )
-    except (ValueError, RuntimeError) as exc:
+    except (ValueError, RuntimeError, sqlite3.OperationalError) as exc:
         # Codex P2 (#1299): pre-yield failures (completeness/scope gate or
         # pre-read recapture) attach the acquired identity to the exception;
         # post-yield failures record it in ``acquired``. Either way the

--- a/tree_sitter_analyzer/read_existing_access.py
+++ b/tree_sitter_analyzer/read_existing_access.py
@@ -274,6 +274,36 @@ def format_read_existing_unavailable(
     )
 
 
+def format_read_existing_failure(
+    code: str,
+    *,
+    output_format: str = "toon",
+    compact_only: bool = False,
+    action_version: str | None = None,
+) -> dict[str, Any]:
+    """Format one classified failure envelope with P0.4 evidence.
+
+    Used by consumers that must fail closed BEFORE reaching the shared seam
+    (e.g. edit.safe's unbound-root guard, which must precede path
+    validation): produces the same envelope shape the seam's except block
+    emits, so the wire contract (evidence + action_version) is never lost.
+    """
+    from .mcp.utils.format_helper import apply_toon_format_to_response
+
+    failure: dict[str, Any] = {
+        "success": False,
+        "verdict": "ERROR",
+        "error_code": code,
+        "error": code,
+        "action_version": action_version,
+        "output_format": output_format,
+    }
+    attach_read_existing_evidence(failure)
+    return apply_toon_format_to_response(
+        failure, output_format, compact_only=compact_only
+    )
+
+
 def read_existing_gate(
     tool: Any,
     arguments: dict[str, Any],
@@ -353,6 +383,7 @@ _INDEX_CONSUMER_STABLE_CODES = frozenset(
         "SOURCE_SCOPE_UNBOUNDED",
         "SOURCE_INDEX_MISMATCH",
         "CONSTRAINED_INDEX_SCOPE",
+        "FILE_NOT_FOUND",
     }
 )
 
@@ -403,15 +434,18 @@ def read_existing_index_consumer(
             default_output_format=default_output_format,
             action_version=action_version,
         )
-    if not tool.project_root:
-        raise ValueError(
-            "MISSING_PROJECT_ROOT: project_root must be bound before "
-            "read_existing access"
-        )
     from .index_snapshot import read_existing_index_scope
     from .mcp.utils.format_helper import apply_toon_format_to_response
 
     try:
+        # Codex-review P2 (#1299): an unbound root must be CLASSIFIED (failure
+        # envelope with evidence + action_version), never a bare raise that
+        # escapes the wire contract — so the check lives inside the try.
+        if not tool.project_root:
+            raise ValueError(
+                "MISSING_PROJECT_ROOT: project_root must be bound before "
+                "read_existing access"
+            )
         # validate_required_index_access has already bound both tokens as
         # non-empty strings; index them directly so the acquire types cleanly.
         with read_existing_index_scope(
@@ -446,16 +480,9 @@ def read_existing_index_consumer(
                 result, output_format, compact_only=compact_only
             )
     except (ValueError, RuntimeError) as exc:
-        code = _stable_consumer_code(exc)
-        failure: dict[str, Any] = {
-            "success": False,
-            "verdict": "ERROR",
-            "error_code": code,
-            "error": code,
-            "action_version": action_version,
-            "output_format": output_format,
-        }
-        attach_read_existing_evidence(failure)
-        return apply_toon_format_to_response(
-            failure, output_format, compact_only=compact_only
+        return format_read_existing_failure(
+            _stable_consumer_code(exc),
+            output_format=output_format,
+            compact_only=compact_only,
+            action_version=action_version,
         )

--- a/tree_sitter_analyzer/read_existing_access.py
+++ b/tree_sitter_analyzer/read_existing_access.py
@@ -328,3 +328,134 @@ def attach_read_existing_evidence(
     result["access_reason"] = reason
     result["source_snapshots"] = list(records or [])
     return result
+
+
+# Stable acquire/after-read failure codes a P0.1 index consumer can raise;
+# anything outside this set degrades to the generic fallback code.
+_INDEX_CONSUMER_STABLE_CODES = frozenset(
+    {
+        "INDEX_SNAPSHOT_UNKNOWN",
+        "INDEX_SNAPSHOT_ROOT_MISMATCH",
+        "SOURCE_GENERATION_MISMATCH",
+        "INDEX_SNAPSHOT_DEADLINE",
+        "INDEX_SNAPSHOT_CAPACITY",
+        "INDEX_SNAPSHOT_FAILED",
+        "SOURCE_SCOPE_UNKNOWN",
+        "CONCURRENT_SOURCE",
+        "MISSING_PROJECT_ROOT",
+        "MISSING_INDEX",
+        "CORRUPT_INDEX",
+        "CONCURRENT_WRITER",
+        "SOURCE_SCOPE_UNSAFE",
+        "SOURCE_SCOPE_UNREADABLE",
+        "SOURCE_SCOPE_UNSUPPORTED",
+        "SOURCE_SCAN_DEADLINE",
+        "SOURCE_SCOPE_UNBOUNDED",
+        "SOURCE_INDEX_MISMATCH",
+        "CONSTRAINED_INDEX_SCOPE",
+    }
+)
+
+
+def _stable_consumer_code(exc: Exception) -> str:
+    """Map a consumer exception to its stable wire code.
+
+    ``acquire_index_snapshot`` raises ``ValueError``/``RuntimeError`` whose
+    message IS the stable code; the after-read recapture does the same; the
+    unbound-root guard raises ``MISSING_PROJECT_ROOT: <detail>``. The RFC
+    requires those codes as result data, never serialized exception text, so
+    any message outside the stable set degrades to the generic fallback.
+    """
+    message = str(exc)
+    token = message.split(":", 1)[0].strip()
+    return token if token in _INDEX_CONSUMER_STABLE_CODES else "INDEX_SNAPSHOT_FAILED"
+
+
+def read_existing_index_consumer(
+    tool: Any,
+    arguments: dict[str, Any],
+    *,
+    reader: Any,
+    action_version: str,
+    compact_only: bool = False,
+    default_output_format: str = "toon",
+) -> dict[str, Any] | None:
+    """Run one explicit read_existing route against the certified index snapshot.
+
+    Returns the formatted response envelope, or ``None`` when the request is
+    not an explicit read_existing call. Non-certified axes (no Linux strace
+    authority) keep the stable UNCERTIFIED envelope. On the certified axis the
+    snapshot is acquired (before-read token revalidation), read through
+    ``reader(snapshot, conn)``, re-captured after the read, and the ACTUALLY
+    used tokens are echoed from the acquired snapshot with the P0.4 evidence.
+    ``reader`` must return the full success payload (the route adds the token
+    echoes, ``output_format``, and access evidence); any stable
+    ``ValueError``/``RuntimeError`` is classified as a failure envelope with
+    ``error_code``/``access_reason`` equal to the stable code and no result.
+    """
+    if "access_mode" not in arguments:
+        return None
+    output_format = arguments.get("output_format", default_output_format)
+    if not read_existing_platform_supported():
+        return format_read_existing_unavailable(
+            arguments,
+            compact_only=compact_only,
+            default_output_format=default_output_format,
+            action_version=action_version,
+        )
+    if not tool.project_root:
+        raise ValueError(
+            "MISSING_PROJECT_ROOT: project_root must be bound before "
+            "read_existing access"
+        )
+    from .index_snapshot import read_existing_index_scope
+    from .mcp.utils.format_helper import apply_toon_format_to_response
+
+    try:
+        # validate_required_index_access has already bound both tokens as
+        # non-empty strings; index them directly so the acquire types cleanly.
+        with read_existing_index_scope(
+            arguments["snapshot_id"],
+            tool.project_root,
+            arguments["source_generation"],
+        ) as (snapshot, conn):
+            payload = reader(snapshot, conn)
+            if not isinstance(payload, dict):
+                raise ValueError("INDEX_SNAPSHOT_FAILED")
+            # The acquired capability is identity-matched to the request pair
+            # (the registry raises otherwise), so both tokens are bound here.
+            assert snapshot.snapshot_id is not None
+            assert snapshot.source_generation is not None
+            result = dict(payload)
+            result["snapshot_id"] = snapshot.snapshot_id
+            result["source_generation"] = snapshot.source_generation
+            result["source_fingerprint"] = snapshot.source_fingerprint
+            result["index_fingerprint"] = snapshot.index_fingerprint
+            result["output_format"] = output_format
+            attach_read_existing_evidence(
+                result,
+                records=[
+                    {
+                        "kind": "index",
+                        "snapshot_id": snapshot.snapshot_id,
+                        "source_generation": snapshot.source_generation,
+                    }
+                ],
+            )
+            return apply_toon_format_to_response(
+                result, output_format, compact_only=compact_only
+            )
+    except (ValueError, RuntimeError) as exc:
+        code = _stable_consumer_code(exc)
+        failure: dict[str, Any] = {
+            "success": False,
+            "verdict": "ERROR",
+            "error_code": code,
+            "error": code,
+            "action_version": action_version,
+            "output_format": output_format,
+        }
+        attach_read_existing_evidence(failure)
+        return apply_toon_format_to_response(
+            failure, output_format, compact_only=compact_only
+        )

--- a/tree_sitter_analyzer/security/fixture_detector.py
+++ b/tree_sitter_analyzer/security/fixture_detector.py
@@ -596,6 +596,8 @@ def _walk_module(
     relative_test: str,
     project_root: Path,
     aggregator: dict[str, _Aggregator],
+    *,
+    inventory: frozenset[str] | None = None,
 ) -> None:
     """Inspect the top-level nodes of ``tree`` and update ``aggregator``."""
 
@@ -623,11 +625,22 @@ def _walk_module(
     for node in tree.body:
         if isinstance(node, ast.Assign):
             _process_assign(
-                node, source, path_names, relative_test, project_root, aggregator
+                node,
+                source,
+                path_names,
+                relative_test,
+                project_root,
+                aggregator,
+                inventory=inventory,
             )
         else:
             _process_repo_relative_literals(
-                node, source, relative_test, project_root, aggregator
+                node,
+                source,
+                relative_test,
+                project_root,
+                aggregator,
+                inventory=inventory,
             )
 
 
@@ -670,6 +683,8 @@ def _process_assign(
     relative_test: str,
     project_root: Path,
     aggregator: dict[str, _Aggregator],
+    *,
+    inventory: frozenset[str] | None = None,
 ) -> None:
     """Extract signals from a top-level ``name = ...`` statement."""
 
@@ -704,6 +719,8 @@ def _process_repo_relative_literals(
     relative_test: str,
     project_root: Path,
     aggregator: dict[str, _Aggregator],
+    *,
+    inventory: frozenset[str] | None = None,
 ) -> None:
     """Catch repo-relative string literals outside of fixture-style assigns."""
 
@@ -810,12 +827,20 @@ def _safe_relative(path: Path, project_root: Path) -> str:
         return str(path).replace("\\", "/")
 
 
-def _basename_to_repo_relative(basename: str, project_root: Path) -> str | None:
+def _basename_to_repo_relative(
+    basename: str,
+    project_root: Path,
+    *,
+    inventory: frozenset[str] | None = None,
+) -> str | None:
     """Find the project-relative path for ``basename`` if exactly one exists.
 
     Tier-2 hits the basename layer; we need to map it back to the
     canonical project-relative path. Multiple matches resolve to
-    ``None`` because we cannot disambiguate without more context.
+    ``None`` because we cannot disambiguate without more context. On a
+    certified read, ``inventory`` restricts the lookup to snapshot-covered
+    files — an oracle-excluded duplicate (e.g. ``vendor/foo.py``) added
+    after publication must not flip the result (Codex P1 #1299 round-8).
     """
 
     if not basename or "/" in basename or "\\" in basename:
@@ -828,6 +853,10 @@ def _basename_to_repo_relative(basename: str, project_root: Path) -> str | None:
     if not src_dir.is_dir():
         return None
     matches = [path for path in src_dir.rglob(basename) if path.is_file()]
+    if inventory is not None:
+        matches = [
+            path for path in matches if _safe_relative(path, project_root) in inventory
+        ]
     if len(matches) != 1:
         return None
     return _safe_relative(matches[0], project_root)

--- a/tree_sitter_analyzer/security/fixture_detector.py
+++ b/tree_sitter_analyzer/security/fixture_detector.py
@@ -549,7 +549,14 @@ def _scan_tests(
             # broken test files just get skipped.
             continue
         relative_test = _safe_relative(path, project_root)
-        _walk_module(tree, source, relative_test, project_root, aggregator)
+        _walk_module(
+            tree,
+            source,
+            relative_test,
+            project_root,
+            aggregator,
+            inventory=inventory,
+        )
 
     result: dict[str, FixtureFact] = {}
     for rel_path, agg in aggregator.items():
@@ -616,7 +623,9 @@ def _walk_module(
         if isinstance(descendant, (ast.List, ast.Tuple)):
             basenames = _plugin_manifest_basenames(descendant)
             for basename in basenames:
-                rel = _basename_to_repo_relative(basename, project_root)
+                rel = _basename_to_repo_relative(
+                    basename, project_root, inventory=inventory
+                )
                 if rel:
                     agg = aggregator.setdefault(rel, _Aggregator())
                     agg.suppressed = True
@@ -699,7 +708,7 @@ def _process_assign(
         basename = os.path.basename(literal.replace("\\", "/"))
         if not basename.endswith(".py"):
             continue
-        rel = _basename_to_repo_relative(basename, project_root)
+        rel = _basename_to_repo_relative(basename, project_root, inventory=inventory)
         if not rel:
             continue
         agg = aggregator.setdefault(rel, _Aggregator())
@@ -733,7 +742,7 @@ def _process_repo_relative_literals(
         if not _REPO_RELATIVE_PATTERN.match(value):
             continue
         basename = os.path.basename(value)
-        rel = _basename_to_repo_relative(basename, project_root)
+        rel = _basename_to_repo_relative(basename, project_root, inventory=inventory)
         if not rel:
             continue
         agg = aggregator.setdefault(rel, _Aggregator())

--- a/tree_sitter_analyzer/security/fixture_detector.py
+++ b/tree_sitter_analyzer/security/fixture_detector.py
@@ -145,7 +145,11 @@ _DISABLED = FixtureFact(
 
 
 def is_fixture(
-    file_path: str, project_root: str | Path, *, certified: bool = False
+    file_path: str,
+    project_root: str | Path,
+    *,
+    certified: bool = False,
+    inventory: frozenset[str] | None = None,
 ) -> FixtureFact:
     """Return whether ``file_path`` is a registered or detected fixture.
 
@@ -159,7 +163,11 @@ def is_fixture(
     ``fixture_index.json`` cache are outside the source generation, so a
     certified route must not consult them (they could drift after
     snapshot publication). Only generation-certified ``tests/`` bytes are
-    scanned, and nothing is ever persisted.
+    scanned, and nothing is ever persisted. ``inventory`` (the snapshot's
+    ``ast_index`` relative file set) further restricts the scan to files
+    the source oracle actually captured — files the oracle prunes (e.g.
+    ``tests/vendor/``) are outside the generation and must not influence
+    fixture escalation (Codex P1 #1299 round-3).
 
     Failure modes (corrupt cache, unreadable test file, malformed YAML)
     all return ``_NEGATIVE`` and emit one WARNING — never raise.
@@ -174,7 +182,7 @@ def is_fixture(
         return _NEGATIVE
 
     if certified:
-        return _scan_only_fixture(root, relative)
+        return _scan_only_fixture(root, relative, inventory=inventory)
 
     # Tier 1 — allowlist first; cheap and authoritative.
     allowlist_hit = _check_allowlist(root, relative)
@@ -318,6 +326,8 @@ def _iter_test_files(tests_dir: Path) -> list[Path]:
 def _targeted_fixture_scan(
     project_root: Path,
     relative: str,
+    *,
+    inventory: frozenset[str] | None = None,
 ) -> FixtureFact | None:
     """Fast exact-path scan for the common single-file ``is_fixture`` query."""
     tests_dir = project_root / "tests"
@@ -329,6 +339,11 @@ def _targeted_fixture_scan(
         return None
     best: FixtureFact | None = None
     for path in _iter_test_files(tests_dir):
+        if (
+            inventory is not None
+            and _safe_relative(path, project_root) not in inventory
+        ):
+            continue
         try:
             source = path.read_text(encoding="utf-8")
         except OSError:
@@ -355,12 +370,19 @@ def _targeted_fixture_scan(
     return best
 
 
-def _basename_seen_in_tests(project_root: Path, basename: str) -> bool:
+def _basename_seen_in_tests(
+    project_root: Path, basename: str, *, inventory: frozenset[str] | None = None
+) -> bool:
     """Return whether the filename appears anywhere in tests/ source."""
     tests_dir = project_root / "tests"
     if not tests_dir.is_dir() or not basename:
         return False
     for path in _iter_test_files(tests_dir):
+        if (
+            inventory is not None
+            and _safe_relative(path, project_root) not in inventory
+        ):
+            continue
         try:
             if basename in path.read_text(encoding="utf-8"):
                 return True
@@ -388,11 +410,14 @@ def _load_or_build_index(project_root: Path) -> dict[str, FixtureFact]:
     return index
 
 
-def _scan_only_fixture(root: Path, relative: str) -> FixtureFact:
+def _scan_only_fixture(
+    root: Path, relative: str, *, inventory: frozenset[str] | None = None
+) -> FixtureFact:
     """Scan-only fixture probe for certified reads (no allowlist/cache).
 
     Consults only ``tests/`` bytes, which ARE part of the snapshot source
     generation: the targeted scan first, then the full in-memory scan.
+    ``inventory`` restricts both scans to files the source oracle captured.
     Never reads ``CLAUDE.md`` or ``fixture_index.json`` and never writes.
     """
 
@@ -400,12 +425,12 @@ def _scan_only_fixture(root: Path, relative: str) -> FixtureFact:
     if not tests_dir.is_dir():
         return _NEGATIVE
 
-    targeted = _targeted_fixture_scan(root, relative)
+    targeted = _targeted_fixture_scan(root, relative, inventory=inventory)
     if targeted is not None:
         return targeted
-    if not _basename_seen_in_tests(root, Path(relative).name):
+    if not _basename_seen_in_tests(root, Path(relative).name, inventory=inventory):
         return _NEGATIVE
-    index = _scan_tests(tests_dir, root)
+    index = _scan_tests(tests_dir, root, inventory=inventory)
     return index.get(relative, _NEGATIVE)
 
 
@@ -498,11 +523,21 @@ def _write_cache(
         )
 
 
-def _scan_tests(tests_dir: Path, project_root: Path) -> dict[str, FixtureFact]:
+def _scan_tests(
+    tests_dir: Path,
+    project_root: Path,
+    *,
+    inventory: frozenset[str] | None = None,
+) -> dict[str, FixtureFact]:
     """Walk ``tests_dir`` and merge signals from every ``*.py`` file."""
 
     aggregator: dict[str, _Aggregator] = {}
     for path in _iter_test_files(tests_dir):
+        if (
+            inventory is not None
+            and _safe_relative(path, project_root) not in inventory
+        ):
+            continue
         try:
             source = path.read_text(encoding="utf-8")
         except OSError:

--- a/tree_sitter_analyzer/security/fixture_detector.py
+++ b/tree_sitter_analyzer/security/fixture_detector.py
@@ -346,7 +346,7 @@ def _targeted_fixture_scan(
             continue
         try:
             source = path.read_text(encoding="utf-8")
-        except OSError:
+        except (OSError, UnicodeDecodeError):
             continue
         evidence = (_safe_relative(path, project_root),)
         confidence = 0.0
@@ -386,7 +386,7 @@ def _basename_seen_in_tests(
         try:
             if basename in path.read_text(encoding="utf-8"):
                 return True
-        except OSError:
+        except (OSError, UnicodeDecodeError):
             continue
     return False
 
@@ -441,7 +441,7 @@ def _tests_signature(tests_dir: Path) -> str:
     for path in sorted(_iter_test_files(tests_dir)):
         try:
             st = path.stat()
-        except OSError:
+        except (OSError, UnicodeDecodeError):
             continue
         hasher.update(f"{path}|{st.st_mtime_ns}|{st.st_size}\n".encode())
     return hasher.hexdigest()
@@ -540,7 +540,7 @@ def _scan_tests(
             continue
         try:
             source = path.read_text(encoding="utf-8")
-        except OSError:
+        except (OSError, UnicodeDecodeError):
             continue
         try:
             tree = ast.parse(source)

--- a/tree_sitter_analyzer/security/fixture_detector.py
+++ b/tree_sitter_analyzer/security/fixture_detector.py
@@ -144,12 +144,20 @@ _DISABLED = FixtureFact(
 # ---------------------------------------------------------------------------
 
 
-def is_fixture(file_path: str, project_root: str | Path) -> FixtureFact:
+def is_fixture(
+    file_path: str, project_root: str | Path, *, rebuild_cache: bool = True
+) -> FixtureFact:
     """Return whether ``file_path`` is a registered or detected fixture.
 
     ``file_path`` is interpreted relative to ``project_root`` unless it
     is already absolute. The query is O(1) on cache hit and at most
     O(tests/) on miss.
+
+    ``rebuild_cache=False`` (Codex P1 #1299, RFC-0022 P0.4 zero-write
+    certified reads) keeps the query strictly read-only: an absent or
+    stale cache is re-scanned in memory but never persisted to
+    ``fixture_index.json``, so the certified snapshot route cannot mutate
+    the workspace while deriving safety facts.
 
     Failure modes (corrupt cache, unreadable test file, malformed YAML)
     all return ``_NEGATIVE`` and emit one WARNING — never raise.
@@ -177,7 +185,7 @@ def is_fixture(file_path: str, project_root: str | Path) -> FixtureFact:
         return _NEGATIVE
 
     # Tier 2 — load (or rebuild) the test-fixture index and look up.
-    index = _load_or_build_index(root)
+    index = _load_or_build_index(root, write_cache=rebuild_cache)
     return index.get(relative, _NEGATIVE)
 
 
@@ -356,8 +364,14 @@ def _basename_seen_in_tests(project_root: Path, basename: str) -> bool:
     return False
 
 
-def _load_or_build_index(project_root: Path) -> dict[str, FixtureFact]:
-    """Return the Tier-2 index, building (and caching) on signature change."""
+def _load_or_build_index(
+    project_root: Path, *, write_cache: bool = True
+) -> dict[str, FixtureFact]:
+    """Return the Tier-2 index, building (and caching) on signature change.
+
+    ``write_cache=False`` keeps the read-only certified path: the in-memory
+    scan result is returned but never persisted.
+    """
 
     tests_dir = project_root / "tests"
     if not tests_dir.is_dir():
@@ -371,7 +385,8 @@ def _load_or_build_index(project_root: Path) -> dict[str, FixtureFact]:
         return cached
 
     index = _scan_tests(tests_dir, project_root)
-    _write_cache(cache_path, signature, index)
+    if write_cache:
+        _write_cache(cache_path, signature, index)
     return index
 
 

--- a/tree_sitter_analyzer/security/fixture_detector.py
+++ b/tree_sitter_analyzer/security/fixture_detector.py
@@ -145,7 +145,7 @@ _DISABLED = FixtureFact(
 
 
 def is_fixture(
-    file_path: str, project_root: str | Path, *, rebuild_cache: bool = True
+    file_path: str, project_root: str | Path, *, certified: bool = False
 ) -> FixtureFact:
     """Return whether ``file_path`` is a registered or detected fixture.
 
@@ -153,11 +153,13 @@ def is_fixture(
     is already absolute. The query is O(1) on cache hit and at most
     O(tests/) on miss.
 
-    ``rebuild_cache=False`` (Codex P1 #1299, RFC-0022 P0.4 zero-write
-    certified reads) keeps the query strictly read-only: an absent or
-    stale cache is re-scanned in memory but never persisted to
-    ``fixture_index.json``, so the certified snapshot route cannot mutate
-    the workspace while deriving safety facts.
+    ``certified=True`` (Codex P1 #1299, RFC-0022 P0.4 zero-write certified
+    reads) keeps the probe strictly read-only AND snapshot-generation
+    bound: the live ``CLAUDE.md`` allowlist and the on-disk
+    ``fixture_index.json`` cache are outside the source generation, so a
+    certified route must not consult them (they could drift after
+    snapshot publication). Only generation-certified ``tests/`` bytes are
+    scanned, and nothing is ever persisted.
 
     Failure modes (corrupt cache, unreadable test file, malformed YAML)
     all return ``_NEGATIVE`` and emit one WARNING — never raise.
@@ -170,6 +172,9 @@ def is_fixture(
     relative = _to_relative(file_path, root)
     if not relative:
         return _NEGATIVE
+
+    if certified:
+        return _scan_only_fixture(root, relative)
 
     # Tier 1 — allowlist first; cheap and authoritative.
     allowlist_hit = _check_allowlist(root, relative)
@@ -185,7 +190,7 @@ def is_fixture(
         return _NEGATIVE
 
     # Tier 2 — load (or rebuild) the test-fixture index and look up.
-    index = _load_or_build_index(root, write_cache=rebuild_cache)
+    index = _load_or_build_index(root)
     return index.get(relative, _NEGATIVE)
 
 
@@ -364,14 +369,8 @@ def _basename_seen_in_tests(project_root: Path, basename: str) -> bool:
     return False
 
 
-def _load_or_build_index(
-    project_root: Path, *, write_cache: bool = True
-) -> dict[str, FixtureFact]:
-    """Return the Tier-2 index, building (and caching) on signature change.
-
-    ``write_cache=False`` keeps the read-only certified path: the in-memory
-    scan result is returned but never persisted.
-    """
+def _load_or_build_index(project_root: Path) -> dict[str, FixtureFact]:
+    """Return the Tier-2 index, building (and caching) on signature change."""
 
     tests_dir = project_root / "tests"
     if not tests_dir.is_dir():
@@ -385,9 +384,29 @@ def _load_or_build_index(
         return cached
 
     index = _scan_tests(tests_dir, project_root)
-    if write_cache:
-        _write_cache(cache_path, signature, index)
+    _write_cache(cache_path, signature, index)
     return index
+
+
+def _scan_only_fixture(root: Path, relative: str) -> FixtureFact:
+    """Scan-only fixture probe for certified reads (no allowlist/cache).
+
+    Consults only ``tests/`` bytes, which ARE part of the snapshot source
+    generation: the targeted scan first, then the full in-memory scan.
+    Never reads ``CLAUDE.md`` or ``fixture_index.json`` and never writes.
+    """
+
+    tests_dir = root / "tests"
+    if not tests_dir.is_dir():
+        return _NEGATIVE
+
+    targeted = _targeted_fixture_scan(root, relative)
+    if targeted is not None:
+        return targeted
+    if not _basename_seen_in_tests(root, Path(relative).name):
+        return _NEGATIVE
+    index = _scan_tests(tests_dir, root)
+    return index.get(relative, _NEGATIVE)
 
 
 def _tests_signature(tests_dir: Path) -> str:


### PR DESCRIPTION
Completes the RFC-0022 P0.4 task-route consumers that were still UNCERTIFIED stubs, so understand/plan_change run end-to-end on the certified Linux axis (follows the strace certification #1297).

- Shared P0.1 consumer seam (read_existing_access.read_existing_index_consumer): platform gate, classified MISSING_PROJECT_ROOT, acquire → read → after-read recapture, echo of actually-acquired tokens, P0.4 evidence on every envelope, stable wire codes.
- index_snapshot.read_existing_index_scope: registry acquire + full-scope gate + recapture seam.
- nav.context: symbols/edges from the snapshot connection only (zero-write; ASTCache never constructed), code blocks rooted at snapshot canonical_root.
- edit.safe: snapshot-native dependency view + imports_json needle second pass (parity with legacy recall), live reads gated by recapture.
- Contract tests: platform-aware flips, portable consume/mismatch/fail-closed tests, task-router classification, recapture-seam units.

Local: quick gate 2003 passed; patch coverage gate passed; ruff/mypy clean.