### PR TITLE
docs(rfc): RFC-0026 NO1-010B agent change-outcome benchmark (VCSR primary endpoint)

### DIFF
--- a/rfcs/0026-no1-010b-agent-change-outcome-benchmark.md
+++ b/rfcs/0026-no1-010b-agent-change-outcome-benchmark.md
@@ -85,7 +85,10 @@ The runner is a **patch verifier**; it never mutates the repository itself
    corpus runner receives a **unified diff in `git apply`-parseable form**
    (`--patch <file>`; the stdin `-` mode is mutually exclusive with the
    corpus `-` mode — one stdin stream cannot feed both parsers, so at most
-   one input may use `-` and the other must be a file). A `--repo` commit,
+   one input may use `-` and the other must be a file). The patch input is
+   **bounded before `git apply`** — a size cap (e.g. 1 MiB), a hunk-count
+   cap, and a per-hunk line cap; an over-bound patch is `UNKNOWN`, never
+   applied (C40). A `--repo` commit,
    `--arm` identity, and — for criterion 5 — a **provenance transcript**
    (the set of graph relationships the patch producer recorded seeing/using,
    e.g. the `nav.context` + `edit.safe` envelopes observed during
@@ -269,7 +272,7 @@ subset is `TEST_SELECTION_FAILED`, not a pass.
 |---|---|---|
 | **B0** | RFC accepted; strict `BenchmarkRecord` model; 10-task seed corpus; registration registry | `benchmarks/no1_010b/` with 10 tasks; corpus contract tests green (unknown-field rejection, oracle red-baseline + reason, allowlist semantics, per-class counts) |
 | **B1** | Patch-verifier runner complete (all 5 checks + oracle exit-code contract + stale-row queries + mutation suite) | 10/10 pre-registered outcomes matched exactly; mutation suite forces all 7 reason codes; CI reproduces |
-| **B2** | VCSR baseline measurement on pinned versions | `report.json` with VCSR + per-class/per-repo **and per-arm** breakdown (exact task counts and outcomes per client/model/backend — arms are never pooled in the report, C31) + **the reliability metric per arm and overall**: `successful_indexed_trials / all_trials` with exact numerator, denominator, failure classes (infrastructure vs product), and the 99% reliability gate status (C38) + provenance; baseline recorded in STATE.md; E0–E3 internal only |
+| **B2** | VCSR baseline measurement on pinned versions | `report.json` with VCSR + per-class/per-repo **and per-arm** breakdown (exact task counts and outcomes per client/model/backend — arms are never pooled in the report, C31) + **the reliability metric per arm and overall**: `successful_indexed_trials / all_trials` with exact numerator, denominator, failure classes (infrastructure vs product), and the 99% reliability gate status (C38). **B2 does not complete unless the 99% reliability threshold is met per arm and overall** — a below-threshold run is recorded but cannot advance to baseline (C39) + provenance; baseline recorded in STATE.md; E0–E3 internal only |
 | **B3** | (gated) E4 bounded admission | only with zero UNKNOWNs, E3 independent attestation, external E4 reproduction — per §4 |
 
 ## Interaction with existing seams

--- a/rfcs/0026-no1-010b-agent-change-outcome-benchmark.md
+++ b/rfcs/0026-no1-010b-agent-change-outcome-benchmark.md
@@ -8,175 +8,229 @@
 - **Affected source paths** (pin them — reviewers watch for drift here):
   - `tree_sitter_analyzer/task_harness.py` (corpus runner, stdin route)
   - `tree_sitter_analyzer/task/` (router truth-table, edge-evidence)
-  - `benchmarks/no1_010b/` (corpus, oracles, runner, report)
-  - `tests/unit/task/test_task_harness.py` (exact pins for the runner)
+  - `benchmarks/no1_010b/` (corpus, oracles, runner, report, registration)
+  - `tests/unit/task/test_no1_010b_corpus.py` (exact pins for the runner)
   - `rfcs/ROADMAP-no1-agent-trust.md` (ledger row NO1-010B)
 
 ## Summary
 
 A pre-registered, reproducible **agent change-outcome benchmark** whose primary
 endpoint is **Verified Change Success Rate (VCSR)** — the north star of
-`ROADMAP-no1-agent-trust.md`. The corpus is a pinned set of agent tasks, each
-with a repo fixture, a behavioral oracle, an allowed-path set, and a declared
-verification command. A task PASSES only when all five VCSR criteria hold;
-`unknown` is a first-class outcome, never a pass. The benchmark must fail
-closed when evidence is insufficient, exactly like RFC-0021's competitive
-benchmark and RFC-0022's fail-closed honesty.
+`ROADMAP-no1-agent-trust.md`. The corpus is a pinned set of change tasks, each
+with a repo fixture, a behavioral oracle, an allowed-path set, a declared
+verification command, and a closed-enum task class. The runner is a
+**patch verifier**: it applies an externally supplied patch (or a
+provenance-bound agent-arm output) and evaluates the five VCSR criteria on the
+resulting tree. A task PASSES only when all five hold; `unknown` is a
+first-class outcome, never a pass. The benchmark must fail closed when
+evidence is insufficient, exactly like RFC-0021 and RFC-0022's fail-closed
+honesty.
 
 ## Motivation
 
 NO1-010A (#1290 + follow-ups) proved the task layer runs end-to-end
 (`understand` / `plan_change` / `assess_change` through the internal harness
-bridge with exact wire contracts). What is missing is the **measurement**: no
-pre-registered corpus and oracle protocol exists that would let us claim
-VCSR with evidence. The north-star definition in
-`ROADMAP-no1-agent-trust.md` §3 names the five criteria but nothing
-operationalizes them into runnable tasks and pass/fail rules.
-
-Concrete pain: today a change is "verified" only by whichever tests an agent
-happens to run; there is no corpus where the expected outcome is known a
-priori, so regressions in task-layer routing (wrong primitive, dropped
-evidence, stale edges) are found by dogfooding, not by CI. The benchmark
-closes that gap: **every task's expected outcome is pinned before any arm
-runs**, so CI can detect routing/evidence regressions and the VCSR number is
-real.
+bridge). What is missing is the **measurement**: no pre-registered corpus and
+oracle protocol operationalizes the VCSR north-star criteria into runnable
+tasks with pass/fail rules. A change is "verified" today only by whichever
+tests an agent happens to run; there is no corpus where the expected outcome
+is known a priori, so routing/evidence regressions are found by dogfooding,
+not by CI. This RFC closes that gap: **every task's expected outcome is pinned
+before any run**, so CI detects regressions and the VCSR number is real.
 
 ## Detailed design
 
-### 1. Corpus format (JSONL, pre-registered)
+### 1. Corpus format (JSONL, pre-registered, strict model)
 
-One task per line, strict JSON (reuse `task_harness._strict_json_loads`'s
-rejection of unknown fields / duplicate keys / non-standard constants):
+One task per line. A **dedicated `BenchmarkRecord` model** (not
+`task_harness._strict_json_loads`) validates the record with a strict
+allowlist: unknown fields are rejected (schema typos fail), every field is
+typed, and only the `understand`/`plan_change`/`assess_change` projection is
+forwarded to the task harness `request_from_dict`. A record example:
 
 ```json
 {
   "id": "no1-010b/0001-bugfix-dispatch-null",
-  "repo": "fixtures/dispatch_app",          // pinned fixture repo (git commit)
-  "operation": "plan_change",               // understand | plan_change | assess_change
+  "task_class": "bugfix",
+  "repo": "fixtures/dispatch_app",
+  "operation": "plan_change",
   "task": "dispatch returns None for an unknown route; return a 404 object instead",
   "allowed_paths": ["src/dispatch.py", "tests/"],
-  "oracle": "oracles/0001.py",              // exact behavioral oracle (run after the change)
+  "oracle": "oracles/0001.py",
+  "oracle_baseline_reason": "returns None, no 404 branch",
   "verification_command": "uv run pytest tests/ -q",
   "defect": {"file": "src/dispatch.py", "line": 12, "kind": "missing-else"}
 }
 ```
 
-- **repo**: a committed fixture under `benchmarks/no1_010b/fixtures/` (small
-  multi-file apps, pinned by git commit; the runner checks out the pinned
-  commit and fails closed on drift).
-- **oracle**: a deterministic script that asserts the *post-change* behavior.
-  It must be pass/fail with a stable exit code and a one-line reason on
-  failure; no timers, no network.
-- **allowed_paths**: the only paths a compliant change may modify. A change
-  touching any other path fails the first VCSR criterion.
-- **verification_command**: the command the agent's declared verification must
-  satisfy; the harness runs it on the final tree.
-- **defect**: the seeded defect metadata (for bugfix tasks) so the oracle is
-  *demonstrably* red on the unmodified fixture — a corpus task whose oracle
-  passes before the change is a corpus bug, not a pass.
+- `task_class` is a **required closed enum**: `bugfix | refactor | migration |
+  test_selection`. The report must include exact per-class counts and VCSR per
+  class per repo (the ROADMAP scorecard requires it); classes are never
+  inferred from IDs.
+- `allowed_paths` entries are **canonical, repository-relative**, with
+  segment-aware semantics: a directory entry (`tests/`) matches its exact
+  descendants on path-segment boundaries (`tests/test_dispatch.py` yes,
+  `tests-escape/file.py` no); a file entry matches exactly.
+- `oracle_baseline_reason` documents why the oracle is red on the unmodified
+  fixture; the runner asserts the baseline failure matches it (see §3).
+- `repo` is pinned by git commit; the runner checks out the pinned commit and
+  fails closed on drift.
 
-### 2. Harness runner
+### 2. Patch protocol (how a change reaches the runner)
 
-`benchmarks/no1_010b/runner.py` consumes the corpus and produces
-`report.json`:
+The runner is a **patch verifier**; it never mutates the repository itself
+(the `task_harness` bridge contract stays read-only). Two input channels:
 
-- `run` phase: for each task, apply the agent's patch (input via
-  `task_harness.load_corpus` stdin/`--corpus` route, 8 MiB bound), then:
-  1. **paths**: diff vs `allowed_paths` (exact, no glob escape);
-  2. **oracle**: run `oracle.py` on the final tree (must be red pre-change);
-  3. **verification**: run `verification_command` on the final tree;
-  4. **stale rows**: run the analyzer's post-index staleness probe
-     (`edge_evidence` rejection family: no stale symbol/edge rows for the
-     modified files);
-  5. **unsupported relationships**: no high-confidence relationship used to
-     justify the change may be unsupported (the RFC-0022 truth-table
-     rejection family).
-- `score` phase: classify each task PASS / FAIL / UNKNOWN with an exact reason
-  code; VCSR = `PASS / corpus_size`. UNKNOWN counts as neither PASS nor FAIL
-  for the numerator but is reported separately (fail-closed: a run with any
-  UNKNOWN cannot produce a bounded "better-than" claim).
+1. **Supplied patch** (default): the corpus runner receives a **unified diff
+   in `git apply`-parseable form** (stdin `-` route or `--patch <file>`), a
+   `--repo` commit, and an optional `--arm` identity. The runner creates an
+   isolated worktree copy at the pinned commit, applies the patch with
+   `git apply --check` first (a non-applicable patch is `UNKNOWN`, never
+   `FAIL`), then evaluates the five criteria on the patched tree.
+2. **Agent arm** (separate, provenance-bound): an optional runner mode that
+   drives a pinned model/client through the task layer and captures the
+   agent's produced patch AND its **verification-command transcript** (the
+   exact commands the agent selected and ran, recorded with their outputs).
+   Each arm carries `client`, `model`, `backend`, and `arm_id` identity in the
+   manifest; arms are never pooled (ROADMAP requires ≥3 clients/models
+   measured without pooling). The primary B0–B2 endpoint is the patch
+   verifier; agent arms are isolated measurements feeding the same report
+   format.
 
-### 3. VCSR criteria ↔ code mapping (exact)
+The corpus record gains an optional `patch` field only for *fixture* tasks
+used to validate the runner's positive/negative controls (§5) — the real
+benchmark inputs always arrive through the channels above.
 
-| North-star criterion | Runner check | Reason code |
+### 3. Runner checks (exact VCSR criteria)
+
+After applying the patch in the isolated worktree:
+
+| Criterion | Runner check | Reason code |
 |---|---|---|
-| modify only allowed paths | `paths` check | `PATH_VIOLATION` |
-| satisfy exact behavioral oracles | `oracle` check | `ORACLE_FAILED` |
-| pass the declared verification command | `verification` check | `VERIFICATION_FAILED` |
-| leave no stale symbol or edge rows | staleness probe | `STALE_ROWS` |
-| contain no high-confidence unsupported relationship used to justify the change | truth-table rejection family | `UNSUPPORTED_RELATIONSHIP` |
-| evidence insufficient (any of the above unavailable, or analyzer fails closed) | runner fail-closed | `UNKNOWN` |
+| modify only allowed paths | segment-aware allowlist vs the applied diff | `PATH_VIOLATION` |
+| satisfy the behavioral oracle | oracle exit-code contract (below) | `ORACLE_FAILED` |
+| pass the declared verification command | run `verification_command`, exit 0 required | `VERIFICATION_FAILED` |
+| leave no stale symbol or edge rows | **exact persisted-row queries** (below) | `STALE_ROWS` |
+| no high-confidence unsupported relationship used to justify the change | RFC-0022 truth-table rejection family | `UNSUPPORTED_RELATIONSHIP` |
+| evidence insufficient / infra failure | any check unavailable, oracle error, patch not applicable, timeout | `UNKNOWN` |
 
-### 4. Baseline protocol and claim policy
+**Oracle exit-code contract** (three channels, never conflated):
 
-- Baseline is measured on a **pinned analyzer version + pinned corpus commit**,
-  recorded in `report.json` (`analyzer_version`, `corpus_commit`, `date`,
-  `host`), mirroring RFC-0021's provenance discipline.
+- `0` = behavioral assertion PASSED;
+- `1` = behavioral assertion FAILED (this is the only path that yields
+  `ORACLE_FAILED`);
+- `2` = oracle execution error (syntax error, missing interpreter/dependency,
+  harness failure);
+- timeout (60 s) or non-zero `2`-class exits and any `UNKNOWN`-class
+  infrastructure failure are scored `UNKNOWN`, never `FAIL`. The runner
+  validates that the baseline run fails with the recorded
+  `oracle_baseline_reason` before any patch is evaluated.
+
+**Stale-row check (persisted rows, not evidence freshness)**:
+
+`task/edge_evidence.py` validates *bundles*; it cannot see obsolete rows
+already in the index. The runner instead runs exact, post-change queries
+against the refreshed index and asserts present/absent counts, mirroring
+RFC-0021's incremental oracle:
+
+- for every deleted symbol `S` (file, name): `SELECT 1 FROM ast_symbol_rows
+  WHERE file_path = ? AND name = ?` must return no row;
+- for every deleted edge `E` (caller, callee): no `edges` row may reference
+  `E`;
+- for every added symbol/edge: exactly the expected rows exist (count-pinned,
+  no `>=` bounds).
+The refresh operation is specified as: rebuild the changed files' symbol and
+edge rows from the patched tree, then run the above queries.
+
+### 4. Claim policy and pre-registration gate
+
+- **Immutable registration record**: before the first execution of any task,
+  the runner appends the corpus manifest hash + per-task oracle hashes to an
+  **append-only registration registry** (a committed `registration.jsonl`
+  under `benchmarks/no1_010b/`, itself committed to git). A run's report is
+  only valid if every task/oracle hash in it was registered *before* that
+  run's first execution; a run whose hashes were registered after the fact is
+  rejected. Post-result oracle replacement is impossible by construction.
 - E0–E3: internal numbers only, no public competitive wording.
-- E4: the only admissible public sentence is the exact bounded form —
-  `VCSR = X/Y (Z%) on the pre-registered NO1-010B corpus vN at analyzer
-  commit <sha>` — and only when: corpus pre-registered before the run,
-  zero UNKNOWNs, CI reproduced the run on the Linux coverage axis.
-- The report fails closed (exit non-zero) if any task could not be evaluated
-  (missing oracle, repo drift, analyzer crash) — a partially-evaluated corpus
-  never yields a claim.
+- **E3 requires separately attested reproduction**: an independent machine,
+  blind evaluation, and a separate attestation record — a CI job in the
+  repository is still internal evidence and does not satisfy E3.
+- **E4** (the only admissible public sentence —
+  `VCSR = X/Y (Z%) on the pre-registered NO1-010B corpus vN at analyzer commit
+  <sha>`): requires all of: corpus pre-registered before the run, zero
+  UNKNOWNs, the E3 independent reproduction, AND an external E4 reproduction
+  artifact (a third party reproducing the report from the registration
+  record). Absent any one, no public wording is emitted.
 
-### 5. Seed corpus (implementation deliverable)
+### 5. Seed corpus and B1 non-vacuous gate
 
-The first corpus ships with **10 pre-registered tasks**, all green-repo
-fixtures:
+The first corpus ships with **10 pre-registered tasks** (4 bugfix, 2
+refactor, 2 migration, 2 test_selection), each with a **pre-registered
+expected outcome** (9 PASS + 1 FAIL for a known-wrong reference patch).
 
-- 4 bugfix (missing-else / off-by-one / null-deref / wrong-constant),
-- 2 refactor (rename with reference updates; extract-function with call-site
-  updates),
-- 2 migration (API rename across a package; import-path relocation),
-- 2 test-selection (a change that must run exactly the affected subset).
+**B1 completes only when the runner matches exact expected outcomes AND
+survives a mutation suite** that forces every reason code:
 
-Every oracle is verified **red-on-baseline** in CI (a fixture whose oracle
-passes before the change fails the corpus contract test), and every task has
-a pinned allowed-path set. The corpus manifest itself is guarded by exact
-contract tests (`tests/unit/task/test_no1_010b_corpus.py`): schema, oracle
-red-ness, allowed-path validity, no duplicate ids.
+- positive mutation: the reference (correct) patch → must yield the pinned
+  PASS with all five checks exercised;
+- `PATH_VIOLATION`: patch touching an out-of-allowlist path → exact code;
+- `ORACLE_FAILED`: patch leaving the oracle red → exact code;
+- `VERIFICATION_FAILED`: patch that passes the oracle but breaks the
+  verification command → exact code;
+- `STALE_ROWS`: patch whose index refresh leaves a stale row (injected) →
+  exact code;
+- `UNSUPPORTED_RELATIONSHIP`: patch justified by a high-confidence
+  unsupported relationship (fixture) → exact code;
+- `UNKNOWN`: a non-applicable patch and an oracle-execution-error fixture →
+  exact code.
 
-### 6. Interaction with existing seams
+An implementation that always returns `UNKNOWN` or always `FAIL` fails B1.
 
-- The runner drives the task layer through `task_harness.McpPrimitiveExecutor`
-  (the same same-process bridge NO1-010A pins); it never imports analyzer
-  internals — the `task/` import boundary is preserved.
-- The staleness/unsupported checks reuse `task/edge_evidence.py` + the
-  RFC-0022 truth-table rejection family (already covered by
-  `test_edge_evidence.py` and `test_task_truth_table.py`).
-- The harness stdin route (`load_corpus("-")`) is the corpus feed; the 8 MiB
-  bound and strict JSON are unchanged.
+For **test_selection** tasks, the check compares the agent arm's recorded
+selected-test transcript (or the supplied `selected_tests` field) against an
+exact affected-test oracle derived from the causality index — running the
+full suite, no tests, or the wrong subset is `TEST_SELECTION_FAILED`, not a
+pass.
 
 ## Phases with visible exit artifacts
 
 | Phase | Scope | Verifiable exit artifact |
 |---|---|---|
-| **B0** | RFC accepted; corpus schema + 10-task seed + runner skeleton | `benchmarks/no1_010b/` with 10 tasks; corpus contract tests green (oracle red-ness enforced) |
-| **B1** | Runner complete (paths/oracle/verification/staleness/unsupported) + `report.json` | 10/10 tasks evaluate to PASS/FAIL/UNKNOWN with exact reason codes on the seed corpus; CI reproduces |
-| **B2** | VCSR baseline measurement on pinned versions | `report.json` with VCSR + provenance; baseline recorded in STATE.md; E0–E3 internal only |
-| **B3** | (gated) E4 bounded admission | only when zero UNKNOWNs + CI reproduction + pre-registration, per §4 |
+| **B0** | RFC accepted; strict `BenchmarkRecord` model; 10-task seed corpus; registration registry | `benchmarks/no1_010b/` with 10 tasks; corpus contract tests green (unknown-field rejection, oracle red-baseline + reason, allowlist semantics, per-class counts) |
+| **B1** | Patch-verifier runner complete (all 5 checks + oracle exit-code contract + stale-row queries + mutation suite) | 10/10 pre-registered outcomes matched exactly; mutation suite forces all 7 reason codes; CI reproduces |
+| **B2** | VCSR baseline measurement on pinned versions | `report.json` with VCSR + per-class/per-repo breakdown + provenance; baseline recorded in STATE.md; E0–E3 internal only |
+| **B3** | (gated) E4 bounded admission | only with zero UNKNOWNs, E3 independent attestation, external E4 reproduction — per §4 |
+
+## Interaction with existing seams
+
+- The runner drives the task layer through `task_harness.McpPrimitiveExecutor`
+  (same-process bridge, read-only); the `task/` import boundary is preserved.
+- The stale-row/unsupported checks use the RFC-0022 truth-table rejection
+  family plus the new persisted-row queries (§3); `edge_evidence` remains the
+  bundle validator, not the staleness oracle.
+- The harness stdin route (`load_corpus("-")`, 8 MiB bound) carries corpus
+  input; the patch channel is a separate stdin/`--patch` stream so a corpus
+  record and a patch never share a parser.
 
 ## Alternatives considered
 
-1. **Benchmark the analyzer, not the agent** (compare tool answers on fixed
-   prompts): simpler, but measures retrieval, not whether a *change* succeeds —
-   the north star is change-outcome. NO1-010B complements RFC-0021, which
-   keeps the competitive answer-quality role.
-2. **Agent-in-the-loop benchmark** (drive a real LLM agent): closest to
-   production, but provider/model variance and cost make it non-reproducible
-   in CI. Rejected for the primary endpoint; a future E4-adjacent arm may run
-   a pinned model under the same protocol.
-3. **No pre-registration** (run tasks, then decide oracles): invalid — the
-   north star's evidence level requires oracles decided before the run.
-   Rejected.
+1. **Benchmark the analyzer, not the change** (compare tool answers on fixed
+   prompts): measures retrieval, not whether a *change* succeeds. RFC-0021
+   keeps the competitive answer-quality role; NO1-010B is the change-outcome
+   endpoint.
+2. **Agent-in-the-loop only**: closest to production, but provider/model
+   variance and cost make it non-reproducible in CI; also violates the
+   no-pooling rule if arms share backends. Chosen: patch verifier as the
+   primary endpoint, provenance-bound agent arms as isolated measurements.
+3. **No pre-registration** (run tasks, then decide oracles): invalid for the
+   evidence level. Rejected.
 
 ## Open questions
 
-1. Whether the first 10-task corpus should pin one language (Python) or span
-   three (Python + JS + Go) — propose Python-only for B0, expand after B1.
-2. Verification-command timeout and isolation (propose: 60 s, subprocess with
-   `setsid`, workspace copy — mirroring the strace certification discipline).
-3. Whether `report.json` should include a machine-readable per-criterion
-   breakdown for the future E4 sentence (propose: yes, always).
+1. Whether the agent-arm transcript should include raw stdout or only
+   exit-code + selected-test sets (propose: exit-codes + selected sets for
+   privacy; raw stdout stored locally, never in the committed report).
+2. Registration registry rotation: append-only file vs SQLite table (propose:
+   committed `registration.jsonl` + the runner's local SQLite mirror).
+3. Whether `git apply` should accept fuzz (propose: no — fuzz would admit
+   patches that do not match the pinned commit, breaking pre-registration).

--- a/rfcs/0026-no1-010b-agent-change-outcome-benchmark.md
+++ b/rfcs/0026-no1-010b-agent-change-outcome-benchmark.md
@@ -3,13 +3,14 @@
 - **Status**: draft
 - **Author(s)**: @lead-agent
 - **Created**: 2026-08-17
-- **Last updated**: 2026-08-17
+- **Last updated**: 2026-08-18
 - **Tracking issue**: TBD
 - **Affected source paths** (pin them — reviewers watch for drift here):
   - `tree_sitter_analyzer/task_harness.py` (corpus runner, stdin route)
   - `tree_sitter_analyzer/task/` (router truth-table, edge-evidence)
+  - `tree_sitter_analyzer/no1_010b/` (record, patch bounds, oracle, runner)
   - `benchmarks/no1_010b/` (corpus, oracles, runner, report, registration)
-  - `tests/unit/task/test_no1_010b_corpus.py` (exact pins for the runner)
+  - `tests/unit/no1_010b/` (exact record/oracle/runner contracts)
   - `rfcs/ROADMAP-no1-agent-trust.md` (ledger row NO1-010B)
 
 ## Summary
@@ -54,12 +55,14 @@ forwarded to the task harness `request_from_dict`. A record example:
   "id": "no1-010b/0001-bugfix-dispatch-null",
   "task_class": "bugfix",
   "repo": "fixtures/dispatch_app",
+  "repo_commit": "0000000000000000000000000000000000000000",
   "operation": "plan_change",
   "task": "dispatch returns None for an unknown route; return a 404 object instead",
   "allowed_paths": ["src/dispatch.py", "tests/"],
   "oracle": "oracles/0001.py",
   "oracle_baseline_reason": "dispatch-returns-none",
   "verification_argv": ["uv", "run", "pytest", "tests/", "-q"],
+  "expected_terminal": {"verdict": "PASS", "reason_code": null},
   "defect": {"file": "src/dispatch.py", "line": 12, "kind": "missing-else"}
 }
 ```
@@ -73,9 +76,17 @@ forwarded to the task harness `request_from_dict`. A record example:
   descendants on path-segment boundaries (`tests/test_dispatch.py` yes,
   `tests-escape/file.py` no); a file entry matches exactly.
 - `oracle_baseline_reason` is a **canonical token** (lowercase-kebab, e.g.
-  `dispatch-returns-none`) naming why the oracle is red on the unmodified
-  fixture; the runner asserts the oracle's emitted reason token equals it
-  exactly (see §3). Free-text descriptions are rejected at load (C43).
+  `dispatch-returns-none`) identifying the pre-registered assertion that is
+  red on the unmodified fixture; the runner asserts the oracle emits that
+  same token on every declared PASS or FAIL (see §3). Free-text descriptions
+  are rejected at load (C43).
+- `expected_terminal` is a **required strict object** registered per task and
+  included in the manifest hash. Its `verdict` is `PASS | FAIL | UNKNOWN`.
+  `reason_code` is `null` only for `PASS`, one exact product reason code for
+  `FAIL`, and one exact `unknown_reason` member for `UNKNOWN`. The aggregate
+  `9 PASS + 1 FAIL` statement is not executable truth; this object is. A
+  runner compares each reference attempt with this exact pair and may not
+  choose the failing task or code after execution (C55).
 - The verification executable is a **typed argv list, never a shell string**:
   `verification_argv` is executed with no shell, no quoting rules, and no
   globbing; a display-only `verification_command` string may accompany it for
@@ -98,10 +109,12 @@ The runner is a **patch verifier**; it never mutates the repository itself
    `patch_max_hunks = 512`, `patch_max_lines_per_hunk = 2000` (C41). An
    over-bound patch is `UNKNOWN`, never applied (C40). The limits are part
    of the manifest hash so an evaluator cannot choose thresholds after
-   observing an attempt. `patch_max_lines_per_hunk` counts **hunk-body
-   added + deleted lines only**: context lines, `@@` headers, and
-   `\ No newline at end of file` markers do not count; a hunk at exactly
-   the limit is accepted, limit+1 is over-bound (C43). **The same bounds
+   observing an attempt. `patch_max_lines_per_hunk` counts **every physical
+   hunk-body line** after an `@@` header and before the next hunk/file header:
+   additions, deletions, context, blank body lines, and
+   `\ No newline at end of file` markers all count; only the `@@` header and
+   file/diff headers do not. A hunk at exactly the limit is accepted, limit+1
+   is over-bound (C43/C44). **The same bounds
    apply to every input channel** — an agent-produced patch from a
    mandatory arm must pass the same registered streaming limits before
    parsing, so an oversized arm output is `UNKNOWN`, never processed (C43).
@@ -148,11 +161,37 @@ The runner is a **patch verifier**; it never mutates the repository itself
    over; the treatment/control pair uses identical fresh-state procedures so
    results are order-independent.
 
+**Pre-registered paired evidence-effect endpoint** (C56): every treatment
+arm has a `pair_id` with exactly one evidence-disabled control, and the
+external registration freezes the complete `pair_id × task_id ×
+repeat_index` matrix, matched random seed, and these endpoint parameters:
+`minimum_effect = 0.05`, one-sided exact McNemar/binomial test
+`alpha = 0.05`. For each registered cell, let `T`/`C` be 1 only when the
+treatment/control verdict is `PASS` (every FAIL or UNKNOWN is 0). Report
+`n11`, `n10`, `n01`, `n00`, where `n10` means treatment-only success, and
+`paired_effect = (n10 - n01) / N`. For `D = n10 + n01 > 0`, the exact
+one-sided p-value is `sum(comb(D, k) * 0.5^D for k = n10..D)`; for `D = 0`,
+`p = 1`. The improvement endpoint is `ADMITTED`
+iff the matrix is complete, there are zero UNKNOWN attempts, every arm and
+the overall run pass the 99% reliability gate, `paired_effect >= 0.05`, and
+the one-sided exact binomial test over the `n10 + n01` discordant pairs has
+`p <= 0.05` in the direction `n10 > n01`; with zero discordant pairs,
+`p = 1`. Missing cells are never dropped or imputed: they make the matrix
+invalid and block B2. The report always emits the counts, effect, p-value,
+thresholds, and `ADMITTED | NOT_ADMITTED`; only `ADMITTED` permits the
+bounded statement that graph evidence improved changes. A valid negative
+result remains publishable as `NOT_ADMITTED` and cannot be reframed after
+the run.
+
 **Sandbox**: patched code is executed in a resource-bounded sandbox — no
-network, no secrets/credentials mounted, and only the disposable worktree
-writable (C21). An isolated Git worktree does not isolate processes; the
-oracle and verification command must run with host permissions that cannot
-read credentials or touch files outside the worktree.
+network and no secrets/credentials mounted (C21). Patch application is the
+only phase allowed to write the candidate tree. Before oracle, verification,
+or index checks begin, the runner snapshots then mounts the **entire patched
+candidate tree read-only**, including paths that were allowed during patch
+application. The only writable mount is a fresh runner-owned scratch root
+outside the candidate tree; `TMPDIR`, tool caches, coverage files, Python
+bytecode, and both analyzer comparison databases are redirected there via
+the frozen environment. An isolated Git worktree alone is not a sandbox.
 
 The corpus record gains an optional `patch` field only for *fixture* tasks
 used to validate the runner's positive/negative controls (§5) — the real
@@ -181,19 +220,22 @@ failure (C19). The runner instead invokes each oracle through a **trusted
 wrapper** that separates loading/execution from the declared assertion:
 
 - wrapper performs import/load first; any import/syntax/type error → `UNKNOWN`;
-- only the oracle's explicitly declared assertion result maps to PASS
-  (exit 0) or FAIL (exit 1 → `ORACLE_FAILED`);
+- only a process exit 0 with exactly one final declared assertion result maps
+  to PASS or FAIL (`FAIL` → `ORACLE_FAILED`); the result marker, not the raw
+  process code, carries the behavioral verdict;
 - every other exception, timeout, or unexpected process exit → `UNKNOWN`
   (see the canonical timeouts below).
-The baseline validation uses a **typed reason protocol** (C42, C43): on a FAIL
-result the oracle also prints exactly one declared line
+The baseline validation uses a **typed reason protocol** (C42, C43): on every
+declared PASS or FAIL the oracle also prints exactly one declared line
 `NO1_010B_ORACLE_REASON: <token>`; the token must EQUAL the registered
 `oracle_baseline_reason` token (exact string match, no exception-text
-comparison). A PASS result must NOT print a reason line. Missing, duplicate,
-or mismatched reason lines are **corpus validation failures checked in
-preflight, before any attempt is recorded** — they never consume an attempt,
-never enter the `all_trials` denominator, and reject the whole corpus run
-with no report emitted (C43).
+comparison). Preflight executes the oracle on the unmodified fixture and
+requires declared FAIL plus the exact token. Missing, duplicate, or
+mismatched lines during that baseline check are corpus validation failures:
+they consume zero attempts and emit no report. After preflight, the same
+protocol failure during a retained patched-tree attempt is `UNKNOWN /
+ORACLE_PROTOCOL_ERROR`; it is never silently converted to PASS or a product
+failure.
 
 **Canonical execution spec (typed argv, frozen environment, canonical
 timeouts)** (C43):
@@ -210,19 +252,35 @@ timeouts)** (C43):
   a short grace period, then SIGKILL) and records `UNKNOWN` with
   `unknown_reason = ORACLE_TIMEOUT` / `VERIFICATION_TIMEOUT`.
 
-**Reliability mapping (exhaustive terminal states)** (C43): every retained
+**Reliability mapping (exhaustive terminal states)** (C43/C55): every retained
 attempt ends in exactly one terminal state; `UNKNOWN` outcomes MUST carry an
-`unknown_reason` subcode from the closed enum
-`{PATCH_NOT_APPLICABLE, PATCH_OVER_BOUND, ORACLE_LOAD_ERROR, ORACLE_TIMEOUT,
-VERIFICATION_TIMEOUT, SANDBOX_FAILURE, REGISTRY_FAILURE}`. The mapping to the
+`unknown_reason` subcode from the closed enum below. No catch-all string is
+permitted:
+
+`{PATCH_NOT_APPLICABLE, PATCH_OVER_BOUND, PROVENANCE_MISSING,
+AGENT_OUTPUT_ERROR, ORACLE_LOAD_ERROR, ORACLE_EXECUTION_ERROR,
+ORACLE_PROTOCOL_ERROR, ORACLE_TIMEOUT, VERIFICATION_EXECUTION_ERROR,
+VERIFICATION_TIMEOUT, INDEX_REFRESH_ERROR, INDEX_QUERY_ERROR,
+EVIDENCE_CHECK_ERROR, SANDBOX_FAILURE, REGISTRY_FAILURE}`.
+
+`ORACLE_EXECUTION_ERROR` covers runtime exceptions and unexpected exits after
+load; `PROVENANCE_MISSING` covers a supplied patch or arm without the required
+graph transcript; `INDEX_REFRESH_ERROR` and `INDEX_QUERY_ERROR` distinguish
+index construction/refresh from semantic comparison failures; command spawn,
+signal termination, or protocol-level launch failures use
+`VERIFICATION_EXECUTION_ERROR` (an ordinary nonzero verification exit remains
+the product verdict `VERIFICATION_FAILED`). A write
+journal or read-only mount failure is `SANDBOX_FAILURE`, and an unavailable
+unsupported-evidence check is `EVIDENCE_CHECK_ERROR`. The mapping to the
 per-arm reliability metric `successful_indexed_trials / all_trials` is fixed:
 
 | Terminal state | Verdict reached? | Counts toward numerator | Failure class |
 |---|---|---|---|
 | `PASS` | yes | yes | — |
-| `PATH_VIOLATION`, `ORACLE_FAILED`, `VERIFICATION_FAILED`, `STALE_ROWS`, `UNSUPPORTED_RELATIONSHIP`, `TEST_SELECTION_FAILED` | yes | yes | product |
-| `UNKNOWN` (`PATCH_NOT_APPLICABLE`, `PATCH_OVER_BOUND`) | no | no | product (input) |
-| `UNKNOWN` (`ORACLE_LOAD_ERROR`, `ORACLE_TIMEOUT`, `VERIFICATION_TIMEOUT`, `SANDBOX_FAILURE`, `REGISTRY_FAILURE`) | no | no | infrastructure |
+| `PATH_VIOLATION`, `ORACLE_FAILED`, `VERIFICATION_FAILED`, `STALE_ROWS`, `UNSUPPORTED_RELATIONSHIP`, `TEST_SELECTION_FAILED` (`{FAIL, reason_code}`) | yes | yes | product |
+| `UNKNOWN` (`PATCH_NOT_APPLICABLE`, `PATCH_OVER_BOUND`, `PROVENANCE_MISSING`, `AGENT_OUTPUT_ERROR`) | no | no | product (input/output) |
+| `UNKNOWN` (`ORACLE_LOAD_ERROR`, `ORACLE_EXECUTION_ERROR`, `ORACLE_PROTOCOL_ERROR`, `ORACLE_TIMEOUT`, `VERIFICATION_EXECUTION_ERROR`, `VERIFICATION_TIMEOUT`) | no | no | infrastructure (execution) |
+| `UNKNOWN` (`INDEX_REFRESH_ERROR`, `INDEX_QUERY_ERROR`, `EVIDENCE_CHECK_ERROR`, `SANDBOX_FAILURE`, `REGISTRY_FAILURE`) | no | no | infrastructure (runner) |
 
 The 99% reliability gate is `numerator / denominator ≥ 0.99` per arm and
 overall: at most 1% of retained attempts may end as `UNKNOWN`. Every product
@@ -238,7 +296,10 @@ whose denominator silently drops attempts is not trustworthy (C38, C43).
 `task/edge_evidence.py` validates *bundles*; it cannot see obsolete rows
 already in the index. The runner compares the **refreshed projection** with a
 **clean-rebuild projection** of the patched tree and requires byte-identical
-rows for the affected files — this covers added, deleted, AND modified rows
+semantic rows across the **complete symbol and edge tables** — benchmark
+fixtures are bounded, and a partial affected-file projection misses global
+resolution changes such as a new duplicate name altering an unchanged
+caller's target. This covers added, deleted, AND modified rows
 (a symbol that keeps `(file, name)` but moves line, or an edge that keeps
 endpoints but changes kind/line/resolution, must not survive) (C16):
 
@@ -253,39 +314,48 @@ endpoints but changes kind/line/resolution, must not survive) (C16):
    — autoincrement keys differ across rebuilds even when every semantic
    symbol/edge is correct (C35); compare `(file_path, name, line, kind, ...)`
    and `(source, target, kind, line, resolution, provenance, ...)`;
-5. include **incoming edges owned by unchanged files** (an unchanged caller's
-   `edges.file_path` row whose `callee_resolved_file` points into the changed
-   file must be compared too) — restricting to affected files misses those
-   cross-file rows (C34).
+5. compare the complete canonical edge projection, including incoming edges
+   owned by unchanged files and edges whose source/target files are unchanged
+   but whose resolution changed through a duplicate/renamed symbol; separately
+   validate referential integrity after deterministic surrogate-ID remapping
+   (C34/C57).
 
-**Allowed-path recheck**: the allowlist is compared against the applied diff
-AND re-compared after every executed command (oracle, verification) against a
-worktree snapshot, including untracked files — an allowed test-file change
-that rewrites a production file during evaluation is `PATH_VIOLATION` (C18).
+**Allowed-path recheck**: the allowlist is compared against the applied diff.
+After patch application, the immutable candidate-tree snapshot is re-compared
+after every executed command, including untracked files. Any candidate-tree
+change is `PATH_VIOLATION`, even if it touches a path that was allowed for the
+patch itself (C18/C55).
 
 **Write-boundary enforcement during execution, not only after** (C43):
 post-command snapshots cannot detect a write that is reverted before the
-process exits — an allowed test hook can temporarily overwrite an
-out-of-allowlist production file, run verification against the altered
-implementation, then restore the original bytes, leaving the snapshot clean
+process exits — an allowed test hook can temporarily overwrite a candidate
+production file, run verification against the altered implementation, then
+restore the original bytes, leaving the snapshot clean
 while an otherwise failing patch passes. The runner therefore enforces the
-boundary WHILE each process runs: out-of-allowlist worktree files are made
-**read-only before execution** (kernel-enforced, so a process cannot write
-them at all) AND a **write journal** records every write during each command;
-a journaled write outside the allowlist is `PATH_VIOLATION` regardless of the
-final bytes. The post-command snapshot is retained as defense in depth.
-**Trusted tool artifacts are excluded**: files the declared verification
-command or oracle legitimately creates (`.pytest_cache/`, `__pycache__/`,
-`.mypy_cache/`, `.ruff_cache/`) are on a pinned allowlist of excluded paths,
-so a correct reference patch never deterministically fails path enforcement
-(C25).
+boundary WHILE each process runs: the **entire candidate tree is read-only**
+(kernel-enforced) AND an audit/write journal records attempted and successful
+writes during each command. A journaled candidate-tree write is
+`PATH_VIOLATION` regardless of allowlist membership or final bytes. This
+prevents a candidate-controlled test hook from temporarily replacing even an
+allowed production file and restoring it after verification (C55). The
+post-command snapshot remains defense in depth. There is no trusted-artifact
+exception inside the candidate tree: `.pytest_cache`, `__pycache__`, mypy,
+ruff, coverage, temporary files, and TSA `.ast-cache` databases are redirected
+to the fresh runner scratch mount; if one appears in the candidate tree it is
+a violation (C25/C58).
 
 ### 4. Claim policy and pre-registration gate
 
 - **Immutable registration record**: before the first execution of any task,
-  the runner appends the corpus manifest hash + per-task oracle hashes +
-  **`repo_commit` + clean-tree fingerprint** (C15) + a **run/attempt
-  identity** to an **append-only registration registry**. **Every execution
+  the runner appends an explicit canonical payload containing the corpus
+  manifest hash; each task's `repo_commit`, clean-tree fingerprint,
+  `expected_terminal`, oracle hash, affected-test-oracle hash, and independent
+  oracle signature; the frozen environment/timeout/patch-limit digest; every
+  `arm_id`, `pair_id`, evidence toggle, full arm-configuration hash, spend
+  authorization hash, and random seed; the complete arm × task × repeat
+  matrix; repeat/retry policy; paired-endpoint thresholds; and every
+  **run/attempt identity** to an **append-only registration registry**. Any
+  execution-time mismatch rejects the run. **Every execution
   attempt is retained in the score** — a stochastic arm rerun after a
   failing patch cannot discard that run; a fixed repeat count and retry rule
   are registered per arm, and the report reflects all attempts, never a
@@ -302,6 +372,14 @@ so a correct reference patch never deterministically fails path enforcement
   typed argv, manifest limits, and oracle strict-subset validation (§5) are
   all checked first; a preflight failure rejects the corpus run with zero
   attempts consumed (C43).
+- **Independent oracle approval**: each registered behavioral and
+  affected-test oracle is signed over `(task_id, repo_commit, oracle_hash,
+  expected_terminal)` by at least one reviewer who is neither the corpus/
+  reference-patch author nor an author of the implementation under test. The
+  signer identity, public-key fingerprint, signature, and non-tool provenance
+  declaration are part of the external registration payload. Missing,
+  invalid, or non-independent signatures fail preflight; a hash timestamp
+  alone is not oracle truth (C59).
 - E0–E3: internal numbers only, no public competitive wording.
 - **E3 requires separately attested reproduction**: an independent machine,
   blind evaluation, and a separate attestation record — a CI job in the
@@ -319,8 +397,10 @@ so a correct reference patch never deterministically fails path enforcement
 ### 5. Seed corpus and B1 non-vacuous gate
 
 The first corpus ships with **10 pre-registered tasks** (4 bugfix, 2
-refactor, 2 migration, 2 test_selection), each with a **pre-registered
-expected outcome** (9 PASS + 1 FAIL for a known-wrong reference patch).
+refactor, 2 migration, 2 test_selection), each with its exact
+`expected_terminal = {verdict, reason_code}` in the strict JSONL and manifest
+hash (9 `PASS/null` + 1 named `FAIL/<product-code>` for a known-wrong
+reference patch). Aggregate counts never substitute for per-task truth.
 
 **B1 completes only when the runner matches exact expected outcomes AND
 survives a mutation suite** that forces every reason code:
@@ -335,9 +415,13 @@ survives a mutation suite** that forces every reason code:
   exact code;
 - `UNSUPPORTED_RELATIONSHIP`: patch justified by a high-confidence
   unsupported relationship (fixture) → exact code;
-- `UNKNOWN`: a non-applicable patch, an oracle-execution-error fixture, and
-  hunk-boundary fixtures (a hunk at exactly `patch_max_lines_per_hunk` is
-  processed; limit+1 is `UNKNOWN`) → exact code;
+- `UNKNOWN`: each closed subcode is forced independently, including a
+  non-applicable patch (`PATCH_NOT_APPLICABLE`), missing provenance
+  (`PROVENANCE_MISSING`), oracle runtime/unexpected exit
+  (`ORACLE_EXECUTION_ERROR`), index refresh/query failures, and hunk-boundary
+  fixtures (a physical-body hunk at exactly
+  `patch_max_lines_per_hunk` is processed; limit+1 is
+  `UNKNOWN/PATCH_OVER_BOUND`) → exact verdict/subcode;
 - `TEST_SELECTION_FAILED`: on a test_selection task, a transcript with an
   incorrect, empty, or full-suite selected-test set → exact code (C17).
 
@@ -362,9 +446,9 @@ oracle, running the full suite, no tests, or the wrong subset is always
 
 | Phase | Scope | Verifiable exit artifact |
 |---|---|---|
-| **B0** | RFC accepted; strict `BenchmarkRecord` model; 10-task seed corpus; registration registry | `benchmarks/no1_010b/` with 10 tasks; corpus contract tests green (unknown-field rejection, oracle red-baseline + reason, allowlist semantics, per-class counts) |
-| **B1** | Patch-verifier runner complete (all applicable checks + oracle exit-code contract + stale-row queries + mutation suite) | 10/10 pre-registered outcomes matched exactly; mutation suite forces all 7 reason codes; CI reproduces |
-| **B2** | VCSR baseline measurement on pinned versions | `report.json` with VCSR + per-class/per-repo **and per-arm** breakdown (exact task counts and outcomes per client/model/backend — arms are never pooled in the report, C31) + **the reliability metric per arm and overall**: `successful_indexed_trials / all_trials` with exact numerator, denominator, failure classes (infrastructure vs product), and the 99% reliability gate status (C38); the terminal-state → numerator/failure-class mapping is fixed in §3 (C43). **B2 does not complete unless the 99% reliability threshold is met per arm and overall** — a below-threshold run is recorded but cannot advance to baseline (C39) + provenance; baseline recorded in STATE.md; E0–E3 internal only |
+| **B0** | RFC accepted; strict `BenchmarkRecord` model; 10-task seed corpus; registration registry | `benchmarks/no1_010b/` with 10 tasks; corpus contract tests green (unknown-field rejection, exact per-task terminal state, oracle red-baseline + reason/signature, allowlist semantics, per-class counts) |
+| **B1** | Patch-verifier runner complete (all applicable checks + oracle exit-code contract + stale-row queries + mutation suite) | 10/10 pre-registered terminal pairs matched exactly; mutation suite forces every named product reason and every closed UNKNOWN subcode; CI reproduces |
+| **B2** | VCSR baseline measurement on pinned versions | `report.json` with VCSR + per-class/per-repo **and per-arm** breakdown (exact task counts and outcomes per client/model/backend — arms are never pooled in the report, C31) + **the reliability metric per arm and overall**: `successful_indexed_trials / all_trials` with exact numerator, denominator, failure classes (infrastructure vs product), and the 99% reliability gate status (C38); the terminal-state → numerator/failure-class mapping is fixed in §3 (C43). The complete registered arm × task × repeat matrix is mandatory; a missing cell blocks B2. The report also emits the paired endpoint's `n11/n10/n01/n00`, effect, exact p-value, frozen thresholds, and admission state. **B2 does not complete unless the 99% reliability threshold is met per arm and overall** — a below-threshold run is recorded but cannot advance to baseline (C39) + provenance; baseline recorded in STATE.md; E0–E3 internal only |
 | **B3** | (gated) E4 bounded admission | only with zero UNKNOWNs, E3 independent attestation, external E4 reproduction — per §4 |
 
 ## Interaction with existing seams

--- a/rfcs/0026-no1-010b-agent-change-outcome-benchmark.md
+++ b/rfcs/0026-no1-010b-agent-change-outcome-benchmark.md
@@ -114,9 +114,13 @@ The runner is a **patch verifier**; it never mutates the repository itself
    non-pooled, are a mandatory B2 completion gate** — a VCSR baseline
    produced only from supplied reference patches does not satisfy NO1-010B.
    **Paired control arms are also mandatory for the Wave-2 outcome**: for
-   each evidence-enabled arm there is a pre-registered control arm (same
-   client/model, graph evidence disabled) so the counterfactual "graph
-   evidence improved the change" is measurable, not asserted (C28).
+   each evidence-enabled arm there is a pre-registered control arm (graph
+   evidence disabled) so the counterfactual "graph evidence improved the
+   change" is measurable, not asserted (C28). The pair holds **every
+   non-evidence parameter constant** — same backend, system/developer
+   prompts, sampling parameters, permissions, budgets, random seeds, and
+   repeat schedule; the ONLY permitted difference is the pre-registered
+   evidence toggle (C37).
 
 **Sandbox**: patched code is executed in a resource-bounded sandbox — no
 network, no secrets/credentials mounted, and only the disposable worktree
@@ -265,7 +269,7 @@ subset is `TEST_SELECTION_FAILED`, not a pass.
 |---|---|---|
 | **B0** | RFC accepted; strict `BenchmarkRecord` model; 10-task seed corpus; registration registry | `benchmarks/no1_010b/` with 10 tasks; corpus contract tests green (unknown-field rejection, oracle red-baseline + reason, allowlist semantics, per-class counts) |
 | **B1** | Patch-verifier runner complete (all 5 checks + oracle exit-code contract + stale-row queries + mutation suite) | 10/10 pre-registered outcomes matched exactly; mutation suite forces all 7 reason codes; CI reproduces |
-| **B2** | VCSR baseline measurement on pinned versions | `report.json` with VCSR + per-class/per-repo **and per-arm** breakdown (exact task counts and outcomes per client/model/backend — arms are never pooled in the report, C31) + provenance; baseline recorded in STATE.md; E0–E3 internal only |
+| **B2** | VCSR baseline measurement on pinned versions | `report.json` with VCSR + per-class/per-repo **and per-arm** breakdown (exact task counts and outcomes per client/model/backend — arms are never pooled in the report, C31) + **the reliability metric per arm and overall**: `successful_indexed_trials / all_trials` with exact numerator, denominator, failure classes (infrastructure vs product), and the 99% reliability gate status (C38) + provenance; baseline recorded in STATE.md; E0–E3 internal only |
 | **B3** | (gated) E4 bounded admission | only with zero UNKNOWNs, E3 independent attestation, external E4 reproduction — per §4 |
 
 ## Interaction with existing seams

--- a/rfcs/0026-no1-010b-agent-change-outcome-benchmark.md
+++ b/rfcs/0026-no1-010b-agent-change-outcome-benchmark.md
@@ -99,13 +99,24 @@ The runner is a **patch verifier**; it never mutates the repository itself
    drives a pinned model/client through the task layer and captures the
    agent's produced patch AND its **verification-command transcript** (the
    exact commands the agent selected and ran, recorded with their outputs).
-   Each arm carries `client`, `model`, `backend`, and `arm_id` identity in the
-   manifest; arms are never pooled (ROADMAP requires ≥3 clients/models
-   measured without pooling). **At least three distinct client/model arms,
-   isolated and non-pooled, are a mandatory B2 completion gate** — a VCSR
-   baseline produced only from supplied reference patches does not satisfy
-   NO1-010B (the patch verifier validates the runner; it is not the agent
-   measurement).
+   Each arm carries `client`, `model`, `backend`, `arm_id`, AND a **frozen
+   full configuration hash** (client executable/version, system and
+   developer prompts, tool permissions/config, sampling parameters) — the
+   configuration is frozen before execution and any change invalidates the
+   arm (C29). The arm ALSO records the **graph evidence it was presented
+   with and used** (the `nav.context`/`edit.safe`/impact envelopes observed
+   during production) so criterion 5 is evaluable for arms, not only for
+   supplied patches (C33). Each arm has a **pre-authorized spend gate**: a
+   registered per-arm ceiling on calls, tokens, and cost, plus an
+   authorization artifact, per the ROADMAP budget-gate rule (C36). Arms are
+   never pooled (ROADMAP requires ≥3 clients/models measured without
+   pooling). **At least three distinct client/model arms, isolated and
+   non-pooled, are a mandatory B2 completion gate** — a VCSR baseline
+   produced only from supplied reference patches does not satisfy NO1-010B.
+   **Paired control arms are also mandatory for the Wave-2 outcome**: for
+   each evidence-enabled arm there is a pre-registered control arm (same
+   client/model, graph evidence disabled) so the counterfactual "graph
+   evidence improved the change" is measurable, not asserted (C28).
 
 **Sandbox**: patched code is executed in a resource-bounded sandbox — no
 network, no secrets/credentials mounted, and only the disposable worktree
@@ -127,7 +138,7 @@ After applying the patch in the isolated worktree:
 | satisfy the behavioral oracle | oracle exit-code contract (below) | `ORACLE_FAILED` |
 | pass the declared verification command | run `verification_command`, exit 0 required | `VERIFICATION_FAILED` |
 | leave no stale symbol or edge rows | **exact persisted-row queries** (below) | `STALE_ROWS` |
-| no high-confidence unsupported relationship used to justify the change | RFC-0022 truth-table rejection family | `UNSUPPORTED_RELATIONSHIP` |
+| no high-confidence unsupported relationship used to justify the change | **explicit oracle**: the RFC-0023 `edge_evidence` rejection family (concrete per-edge rules: unsupported kind, unresolved callee with high-confidence reliance, provenance-conflicting rows) applied to the recorded graph-evidence transcript; the RFC-0022 truth table alone does not classify this criterion (C30) | `UNSUPPORTED_RELATIONSHIP` |
 | evidence insufficient / infra failure | any check unavailable, oracle error, patch not applicable, timeout | `UNKNOWN` |
 
 **Oracle result protocol (trusted wrapper, not raw exit codes)**:
@@ -154,23 +165,42 @@ rows for the affected files — this covers added, deleted, AND modified rows
 (a symbol that keeps `(file, name)` but moves line, or an edge that keeps
 endpoints but changes kind/line/resolution, must not survive) (C16):
 
-1. index the patched tree fresh (clean rebuild);
-2. apply the incremental refresh;
-3. assert `ast_symbol_rows` + `edges` for every affected file are identical
-   between the two projections (exact row-set equality, count-pinned, no
-   `>=` bounds).
+1. index the BASELINE (pre-patch) tree;
+2. apply the incremental refresh over the baseline→patched transition (the
+   transition where stale rows actually arise — refreshing an index already
+   representing the patched sources proves nothing, C24);
+3. index the patched tree fresh (clean rebuild);
+4. assert the refreshed projection equals the clean-rebuild projection using
+   a **canonical semantic identity** that EXCLUDES surrogate keys
+   (`ast_symbol_rows.id`, `edges.id`, and the inherited `callee_symbol_id`)
+   — autoincrement keys differ across rebuilds even when every semantic
+   symbol/edge is correct (C35); compare `(file_path, name, line, kind, ...)`
+   and `(source, target, kind, line, resolution, provenance, ...)`;
+5. include **incoming edges owned by unchanged files** (an unchanged caller's
+   `edges.file_path` row whose `callee_resolved_file` points into the changed
+   file must be compared too) — restricting to affected files misses those
+   cross-file rows (C34).
 
 **Allowed-path recheck**: the allowlist is compared against the applied diff
 AND re-compared after every executed command (oracle, verification) against a
 worktree snapshot, including untracked files — an allowed test-file change
 that rewrites a production file during evaluation is `PATH_VIOLATION` (C18).
+**Trusted tool artifacts are excluded**: files the declared verification
+command or oracle legitimately creates (`.pytest_cache/`, `__pycache__/`,
+`.mypy_cache/`, `.ruff_cache/`) are on a pinned allowlist of excluded paths,
+so a correct reference patch never deterministically fails path enforcement
+(C25).
 
 ### 4. Claim policy and pre-registration gate
 
 - **Immutable registration record**: before the first execution of any task,
   the runner appends the corpus manifest hash + per-task oracle hashes +
-  **`repo_commit` + clean-tree fingerprint** (C15) to an **append-only
-  registration registry**. The registry is anchored OUTSIDE evaluator
+  **`repo_commit` + clean-tree fingerprint** (C15) + a **run/attempt
+  identity** to an **append-only registration registry**. **Every execution
+  attempt is retained in the score** — a stochastic arm rerun after a
+  failing patch cannot discard that run; a fixed repeat count and retry rule
+  are registered per arm, and the report reflects all attempts, never a
+  cherry-picked subset (C23). The registry is anchored OUTSIDE evaluator
   control (C14): an externally timestamped or independently controlled
   append-only store (e.g. a CI-only workflow with a dedicated key, or a
   third-party notary) — a plain git-committed file is NOT sufficient,
@@ -220,10 +250,14 @@ survives a mutation suite** that forces every reason code:
 An implementation that always returns `UNKNOWN` or always `FAIL` fails B1.
 
 For **test_selection** tasks, the check compares the agent arm's recorded
-selected-test transcript (or the supplied `selected_tests` field) against an
-exact affected-test oracle derived from the causality index — running the
-full suite, no tests, or the wrong subset is `TEST_SELECTION_FAILED`, not a
-pass.
+selected-test transcript (or the supplied `selected_tests` field — a typed,
+canonical relative-path list on the strict `BenchmarkRecord`, provided
+through the same `--patch`/`--selected-tests` CLI channel, C32) against an
+**independently pre-registered affected-test oracle** — frozen per task at
+registration, never derived at runtime from the causality index being
+evaluated (a self-derived oracle would validate comparison plumbing, not
+selection correctness, C26). Running the full suite, no tests, or the wrong
+subset is `TEST_SELECTION_FAILED`, not a pass.
 
 ## Phases with visible exit artifacts
 
@@ -231,7 +265,7 @@ pass.
 |---|---|---|
 | **B0** | RFC accepted; strict `BenchmarkRecord` model; 10-task seed corpus; registration registry | `benchmarks/no1_010b/` with 10 tasks; corpus contract tests green (unknown-field rejection, oracle red-baseline + reason, allowlist semantics, per-class counts) |
 | **B1** | Patch-verifier runner complete (all 5 checks + oracle exit-code contract + stale-row queries + mutation suite) | 10/10 pre-registered outcomes matched exactly; mutation suite forces all 7 reason codes; CI reproduces |
-| **B2** | VCSR baseline measurement on pinned versions | `report.json` with VCSR + per-class/per-repo breakdown + provenance; baseline recorded in STATE.md; E0–E3 internal only |
+| **B2** | VCSR baseline measurement on pinned versions | `report.json` with VCSR + per-class/per-repo **and per-arm** breakdown (exact task counts and outcomes per client/model/backend — arms are never pooled in the report, C31) + provenance; baseline recorded in STATE.md; E0–E3 internal only |
 | **B3** | (gated) E4 bounded admission | only with zero UNKNOWNs, E3 independent attestation, external E4 reproduction — per §4 |
 
 ## Interaction with existing seams
@@ -263,7 +297,9 @@ pass.
 1. Whether the agent-arm transcript should include raw stdout or only
    exit-code + selected-test sets (propose: exit-codes + selected sets for
    privacy; raw stdout stored locally, never in the committed report).
-2. Registration registry rotation: append-only file vs SQLite table (propose:
-   committed `registration.jsonl` + the runner's local SQLite mirror).
+2. Whether the externally controlled registration store should be a CI-only
+   workflow with a dedicated signing key or a third-party notary (both are
+   outside evaluator control; the committed-file + SQLite-mirror proposal is
+   rejected — it cannot establish pre-execution ordering, C27).
 3. Whether `git apply` should accept fuzz (propose: no — fuzz would admit
    patches that do not match the pinned commit, breaking pre-registration).

--- a/rfcs/0026-no1-010b-agent-change-outcome-benchmark.md
+++ b/rfcs/0026-no1-010b-agent-change-outcome-benchmark.md
@@ -81,21 +81,37 @@ forwarded to the task harness `request_from_dict`. A record example:
 The runner is a **patch verifier**; it never mutates the repository itself
 (the `task_harness` bridge contract stays read-only). Two input channels:
 
-1. **Supplied patch** (default): the corpus runner receives a **unified diff
-   in `git apply`-parseable form** (stdin `-` route or `--patch <file>`), a
-   `--repo` commit, and an optional `--arm` identity. The runner creates an
-   isolated worktree copy at the pinned commit, applies the patch with
-   `git apply --check` first (a non-applicable patch is `UNKNOWN`, never
-   `FAIL`), then evaluates the five criteria on the patched tree.
-2. **Agent arm** (separate, provenance-bound): an optional runner mode that
+1. **Supplied patch** (validation channel, not the agent measurement): the
+   corpus runner receives a **unified diff in `git apply`-parseable form**
+   (`--patch <file>`; the stdin `-` mode is mutually exclusive with the
+   corpus `-` mode — one stdin stream cannot feed both parsers, so at most
+   one input may use `-` and the other must be a file). A `--repo` commit,
+   `--arm` identity, and — for criterion 5 — a **provenance transcript**
+   (the set of graph relationships the patch producer recorded seeing/using,
+   e.g. the `nav.context` + `edit.safe` envelopes observed during
+   production) are required. The runner creates an isolated worktree copy at
+   the pinned commit, applies the patch with `git apply --check` first (a
+   non-applicable patch is `UNKNOWN`, never `FAIL`), then evaluates the five
+   criteria on the patched tree. **Criterion 5 is `UNKNOWN` for any supplied
+   patch without a provenance transcript** — a final diff cannot prove which
+   relationships justified the change.
+2. **Agent arm** (provenance-bound, MANDATORY gate): a runner mode that
    drives a pinned model/client through the task layer and captures the
    agent's produced patch AND its **verification-command transcript** (the
    exact commands the agent selected and ran, recorded with their outputs).
    Each arm carries `client`, `model`, `backend`, and `arm_id` identity in the
    manifest; arms are never pooled (ROADMAP requires ≥3 clients/models
-   measured without pooling). The primary B0–B2 endpoint is the patch
-   verifier; agent arms are isolated measurements feeding the same report
-   format.
+   measured without pooling). **At least three distinct client/model arms,
+   isolated and non-pooled, are a mandatory B2 completion gate** — a VCSR
+   baseline produced only from supplied reference patches does not satisfy
+   NO1-010B (the patch verifier validates the runner; it is not the agent
+   measurement).
+
+**Sandbox**: patched code is executed in a resource-bounded sandbox — no
+network, no secrets/credentials mounted, and only the disposable worktree
+writable (C21). An isolated Git worktree does not isolate processes; the
+oracle and verification command must run with host permissions that cannot
+read credentials or touch files outside the worktree.
 
 The corpus record gains an optional `patch` field only for *fixture* tasks
 used to validate the runner's positive/negative controls (§5) — the real
@@ -114,53 +130,68 @@ After applying the patch in the isolated worktree:
 | no high-confidence unsupported relationship used to justify the change | RFC-0022 truth-table rejection family | `UNSUPPORTED_RELATIONSHIP` |
 | evidence insufficient / infra failure | any check unavailable, oracle error, patch not applicable, timeout | `UNKNOWN` |
 
-**Oracle exit-code contract** (three channels, never conflated):
+**Oracle result protocol (trusted wrapper, not raw exit codes)**:
 
-- `0` = behavioral assertion PASSED;
-- `1` = behavioral assertion FAILED (this is the only path that yields
-  `ORACLE_FAILED`);
-- `2` = oracle execution error (syntax error, missing interpreter/dependency,
-  harness failure);
-- timeout (60 s) or non-zero `2`-class exits and any `UNKNOWN`-class
-  infrastructure failure are scored `UNKNOWN`, never `FAIL`. The runner
-  validates that the baseline run fails with the recorded
-  `oracle_baseline_reason` before any patch is evaluated.
+Raw numeric codes are insufficient: an uncaught `AssertionError`,
+`ImportError`, or `SyntaxError` in a Python oracle all exit with code 1, so a
+missing dependency or malformed oracle would masquerade as a behavioral
+failure (C19). The runner instead invokes each oracle through a **trusted
+wrapper** that separates loading/execution from the declared assertion:
+
+- wrapper performs import/load first; any import/syntax/type error → `UNKNOWN`;
+- only the oracle's explicitly declared assertion result maps to PASS
+  (exit 0) or FAIL (exit 1 → `ORACLE_FAILED`);
+- every other exception, timeout (60 s), or unexpected process exit → `UNKNOWN`.
+The runner validates that the baseline run fails with the recorded
+`oracle_baseline_reason` before any patch is evaluated.
 
 **Stale-row check (persisted rows, not evidence freshness)**:
 
 `task/edge_evidence.py` validates *bundles*; it cannot see obsolete rows
-already in the index. The runner instead runs exact, post-change queries
-against the refreshed index and asserts present/absent counts, mirroring
-RFC-0021's incremental oracle:
+already in the index. The runner compares the **refreshed projection** with a
+**clean-rebuild projection** of the patched tree and requires byte-identical
+rows for the affected files — this covers added, deleted, AND modified rows
+(a symbol that keeps `(file, name)` but moves line, or an edge that keeps
+endpoints but changes kind/line/resolution, must not survive) (C16):
 
-- for every deleted symbol `S` (file, name): `SELECT 1 FROM ast_symbol_rows
-  WHERE file_path = ? AND name = ?` must return no row;
-- for every deleted edge `E` (caller, callee): no `edges` row may reference
-  `E`;
-- for every added symbol/edge: exactly the expected rows exist (count-pinned,
-  no `>=` bounds).
-The refresh operation is specified as: rebuild the changed files' symbol and
-edge rows from the patched tree, then run the above queries.
+1. index the patched tree fresh (clean rebuild);
+2. apply the incremental refresh;
+3. assert `ast_symbol_rows` + `edges` for every affected file are identical
+   between the two projections (exact row-set equality, count-pinned, no
+   `>=` bounds).
+
+**Allowed-path recheck**: the allowlist is compared against the applied diff
+AND re-compared after every executed command (oracle, verification) against a
+worktree snapshot, including untracked files — an allowed test-file change
+that rewrites a production file during evaluation is `PATH_VIOLATION` (C18).
 
 ### 4. Claim policy and pre-registration gate
 
 - **Immutable registration record**: before the first execution of any task,
-  the runner appends the corpus manifest hash + per-task oracle hashes to an
-  **append-only registration registry** (a committed `registration.jsonl`
-  under `benchmarks/no1_010b/`, itself committed to git). A run's report is
-  only valid if every task/oracle hash in it was registered *before* that
-  run's first execution; a run whose hashes were registered after the fact is
-  rejected. Post-result oracle replacement is impossible by construction.
+  the runner appends the corpus manifest hash + per-task oracle hashes +
+  **`repo_commit` + clean-tree fingerprint** (C15) to an **append-only
+  registration registry**. The registry is anchored OUTSIDE evaluator
+  control (C14): an externally timestamped or independently controlled
+  append-only store (e.g. a CI-only workflow with a dedicated key, or a
+  third-party notary) — a plain git-committed file is NOT sufficient,
+  because the evaluator can run privately, tune, and then commit an entry
+  that appears to pre-date the disclosed run. ALL registration attempts are
+  retained (including superseded ones). A run's report is only valid if every
+  task/oracle hash in it was registered *before* that run's first execution;
+  a run whose hashes were registered after the fact is rejected.
 - E0–E3: internal numbers only, no public competitive wording.
 - **E3 requires separately attested reproduction**: an independent machine,
   blind evaluation, and a separate attestation record — a CI job in the
   repository is still internal evidence and does not satisfy E3.
-- **E4** (the only admissible public sentence —
+- **E4** (the only admissible public sentence — must be bounded by arm
+  identity, repository revisions, date, and versions per ROADMAP §6-7, C20):
   `VCSR = X/Y (Z%) on the pre-registered NO1-010B corpus vN at analyzer commit
-  <sha>`): requires all of: corpus pre-registered before the run, zero
-  UNKNOWNs, the E3 independent reproduction, AND an external E4 reproduction
-  artifact (a third party reproducing the report from the registration
-  record). Absent any one, no public wording is emitted.
+  <sha>, arm <client>/<model>/<backend>/<arm_id>, repos <repo@commit,...>,
+  run <date>, evidence E4`. Requires all of: corpus pre-registered before the
+  run, zero UNKNOWNs, the three non-pooled agent arms executed, the E3
+  independent reproduction, AND an external E4 reproduction artifact (a
+  third party reproducing the report from the registration record). Absent
+  any one, no public wording is emitted.
 
 ### 5. Seed corpus and B1 non-vacuous gate
 
@@ -182,7 +213,9 @@ survives a mutation suite** that forces every reason code:
 - `UNSUPPORTED_RELATIONSHIP`: patch justified by a high-confidence
   unsupported relationship (fixture) → exact code;
 - `UNKNOWN`: a non-applicable patch and an oracle-execution-error fixture →
-  exact code.
+  exact code;
+- `TEST_SELECTION_FAILED`: on a test_selection task, a transcript with an
+  incorrect, empty, or full-suite selected-test set → exact code (C17).
 
 An implementation that always returns `UNKNOWN` or always `FAIL` fails B1.
 

--- a/rfcs/0026-no1-010b-agent-change-outcome-benchmark.md
+++ b/rfcs/0026-no1-010b-agent-change-outcome-benchmark.md
@@ -17,12 +17,13 @@
 A pre-registered, reproducible **agent change-outcome benchmark** whose primary
 endpoint is **Verified Change Success Rate (VCSR)** — the north star of
 `ROADMAP-no1-agent-trust.md`. The corpus is a pinned set of change tasks, each
-with a repo fixture, a behavioral oracle, an allowed-path set, a declared
-verification command, and a closed-enum task class. The runner is a
+with a repo fixture, a behavioral oracle, an allowed-path set, a typed
+verification argv (no shell parsing), and a closed-enum task class. The runner is a
 **patch verifier**: it applies an externally supplied patch (or a
-provenance-bound agent-arm output) and evaluates the five VCSR criteria on the
-resulting tree. A task PASSES only when all five hold; `unknown` is a
-first-class outcome, never a pass. The benchmark must fail closed when
+provenance-bound agent-arm output) and evaluates the VCSR criteria on the
+resulting tree. A task PASSES only when **every applicable criterion holds**
+(five, plus the selected-test criterion for `test_selection` tasks);
+`unknown` is a first-class outcome, never a pass. The benchmark must fail closed when
 evidence is insufficient, exactly like RFC-0021 and RFC-0022's fail-closed
 honesty.
 
@@ -57,8 +58,8 @@ forwarded to the task harness `request_from_dict`. A record example:
   "task": "dispatch returns None for an unknown route; return a 404 object instead",
   "allowed_paths": ["src/dispatch.py", "tests/"],
   "oracle": "oracles/0001.py",
-  "oracle_baseline_reason": "returns None, no 404 branch",
-  "verification_command": "uv run pytest tests/ -q",
+  "oracle_baseline_reason": "dispatch-returns-none",
+  "verification_argv": ["uv", "run", "pytest", "tests/", "-q"],
   "defect": {"file": "src/dispatch.py", "line": 12, "kind": "missing-else"}
 }
 ```
@@ -71,8 +72,14 @@ forwarded to the task harness `request_from_dict`. A record example:
   segment-aware semantics: a directory entry (`tests/`) matches its exact
   descendants on path-segment boundaries (`tests/test_dispatch.py` yes,
   `tests-escape/file.py` no); a file entry matches exactly.
-- `oracle_baseline_reason` documents why the oracle is red on the unmodified
-  fixture; the runner asserts the baseline failure matches it (see §3).
+- `oracle_baseline_reason` is a **canonical token** (lowercase-kebab, e.g.
+  `dispatch-returns-none`) naming why the oracle is red on the unmodified
+  fixture; the runner asserts the oracle's emitted reason token equals it
+  exactly (see §3). Free-text descriptions are rejected at load (C43).
+- The verification executable is a **typed argv list, never a shell string**:
+  `verification_argv` is executed with no shell, no quoting rules, and no
+  globbing; a display-only `verification_command` string may accompany it for
+  humans but is never the execution spec (C43).
 - `repo` is pinned by git commit; the runner checks out the pinned commit and
   fails closed on drift.
 
@@ -91,14 +98,22 @@ The runner is a **patch verifier**; it never mutates the repository itself
    `patch_max_hunks = 512`, `patch_max_lines_per_hunk = 2000` (C41). An
    over-bound patch is `UNKNOWN`, never applied (C40). The limits are part
    of the manifest hash so an evaluator cannot choose thresholds after
-   observing an attempt. A `--repo` commit,
+   observing an attempt. `patch_max_lines_per_hunk` counts **hunk-body
+   added + deleted lines only**: context lines, `@@` headers, and
+   `\ No newline at end of file` markers do not count; a hunk at exactly
+   the limit is accepted, limit+1 is over-bound (C43). **The same bounds
+   apply to every input channel** — an agent-produced patch from a
+   mandatory arm must pass the same registered streaming limits before
+   parsing, so an oversized arm output is `UNKNOWN`, never processed (C43).
+   A `--repo` commit,
    `--arm` identity, and — for criterion 5 — a **provenance transcript**
    (the set of graph relationships the patch producer recorded seeing/using,
    e.g. the `nav.context` + `edit.safe` envelopes observed during
    production) are required. The runner creates an isolated worktree copy at
    the pinned commit, applies the patch with `git apply --check` first (a
-   non-applicable patch is `UNKNOWN`, never `FAIL`), then evaluates the five
-   criteria on the patched tree. **Criterion 5 is `UNKNOWN` for any supplied
+   non-applicable patch is `UNKNOWN`, never `FAIL`), then evaluates the
+   criteria on the patched tree (five, plus the selected-test criterion for
+   `test_selection` tasks). **Criterion 5 is `UNKNOWN` for any supplied
    patch without a provenance transcript** — a final diff cannot prove which
    relationships justified the change.
 2. **Agent arm** (provenance-bound, MANDATORY gate): a runner mode that
@@ -126,7 +141,12 @@ The runner is a **patch verifier**; it never mutates the repository itself
    non-evidence parameter constant** — same backend, system/developer
    prompts, sampling parameters, permissions, budgets, random seeds, and
    repeat schedule; the ONLY permitted difference is the pre-registered
-   evidence toggle (C37).
+   evidence toggle (C37). **Fresh state per attempt (C43)**: every
+   registered arm-task-repeat attempt starts from a fresh isolated worktree
+   at the pinned commit AND a fresh client conversation/session — no prior
+   attempt's conversation context, tool caches, or index state may carry
+   over; the treatment/control pair uses identical fresh-state procedures so
+   results are order-independent.
 
 **Sandbox**: patched code is executed in a resource-bounded sandbox — no
 network, no secrets/credentials mounted, and only the disposable worktree
@@ -146,10 +166,11 @@ After applying the patch in the isolated worktree:
 |---|---|---|
 | modify only allowed paths | segment-aware allowlist vs the applied diff | `PATH_VIOLATION` |
 | satisfy the behavioral oracle | oracle exit-code contract (below) | `ORACLE_FAILED` |
-| pass the declared verification command | run `verification_command`, exit 0 required | `VERIFICATION_FAILED` |
+| pass the declared verification command | run the typed `verification_argv`, exit 0 required | `VERIFICATION_FAILED` |
 | leave no stale symbol or edge rows | **exact persisted-row queries** (below) | `STALE_ROWS` |
 | no high-confidence unsupported relationship used to justify the change | **explicit oracle**: the RFC-0023 `edge_evidence` rejection family (concrete per-edge rules: unsupported kind, unresolved callee with high-confidence reliance, provenance-conflicting rows) applied to the recorded graph-evidence transcript; the RFC-0022 truth table alone does not classify this criterion (C30) | `UNSUPPORTED_RELATIONSHIP` |
-| evidence insufficient / infra failure | any check unavailable, oracle error, patch not applicable, timeout | `UNKNOWN` |
+| (test_selection tasks only) selected-test transcript equals the pre-registered affected-test oracle | compare the recorded transcript with the frozen oracle set (§5) | `TEST_SELECTION_FAILED` |
+| evidence insufficient / infra failure | any check unavailable, oracle error, patch not applicable, timeout | `UNKNOWN` (+ required `unknown_reason` subcode, below) |
 
 **Oracle result protocol (trusted wrapper, not raw exit codes)**:
 
@@ -162,13 +183,55 @@ wrapper** that separates loading/execution from the declared assertion:
 - wrapper performs import/load first; any import/syntax/type error → `UNKNOWN`;
 - only the oracle's explicitly declared assertion result maps to PASS
   (exit 0) or FAIL (exit 1 → `ORACLE_FAILED`);
-- every other exception, timeout (60 s), or unexpected process exit → `UNKNOWN`.
-The baseline validation uses a **typed reason protocol** (C42): on a FAIL
-result the oracle also prints a second declared line
-`NO1_010B_ORACLE_REASON: <token>`; the runner requires the baseline FAIL
-reason token to EQUAL the registered `oracle_baseline_reason` token (exact
-match, no exception-text comparison). A baseline red for a different reason —
-or missing the reason line — is a corpus/fixture error and fails closed.
+- every other exception, timeout, or unexpected process exit → `UNKNOWN`
+  (see the canonical timeouts below).
+The baseline validation uses a **typed reason protocol** (C42, C43): on a FAIL
+result the oracle also prints exactly one declared line
+`NO1_010B_ORACLE_REASON: <token>`; the token must EQUAL the registered
+`oracle_baseline_reason` token (exact string match, no exception-text
+comparison). A PASS result must NOT print a reason line. Missing, duplicate,
+or mismatched reason lines are **corpus validation failures checked in
+preflight, before any attempt is recorded** — they never consume an attempt,
+never enter the `all_trials` denominator, and reject the whole corpus run
+with no report emitted (C43).
+
+**Canonical execution spec (typed argv, frozen environment, canonical
+timeouts)** (C43):
+
+- Every executed command (oracle, verification) is a **typed argv list**
+  executed with no shell, no quoting rules, no globbing; cwd is always the
+  worktree root; the environment is the registered frozen base environment
+  (pinned PATH entries, no inherited secrets, an `env_digest` included in the
+  manifest hash). A free-form `verification_command` string may exist only as
+  a display hint, never as the execution spec.
+- Canonical wall-clock timeouts are bound into the registered manifest:
+  `oracle_timeout = 60 s`, `verification_timeout = 120 s`. On expiry the
+  runner terminates the **whole process tree** (SIGTERM to the process group,
+  a short grace period, then SIGKILL) and records `UNKNOWN` with
+  `unknown_reason = ORACLE_TIMEOUT` / `VERIFICATION_TIMEOUT`.
+
+**Reliability mapping (exhaustive terminal states)** (C43): every retained
+attempt ends in exactly one terminal state; `UNKNOWN` outcomes MUST carry an
+`unknown_reason` subcode from the closed enum
+`{PATCH_NOT_APPLICABLE, PATCH_OVER_BOUND, ORACLE_LOAD_ERROR, ORACLE_TIMEOUT,
+VERIFICATION_TIMEOUT, SANDBOX_FAILURE, REGISTRY_FAILURE}`. The mapping to the
+per-arm reliability metric `successful_indexed_trials / all_trials` is fixed:
+
+| Terminal state | Verdict reached? | Counts toward numerator | Failure class |
+|---|---|---|---|
+| `PASS` | yes | yes | — |
+| `PATH_VIOLATION`, `ORACLE_FAILED`, `VERIFICATION_FAILED`, `STALE_ROWS`, `UNSUPPORTED_RELATIONSHIP`, `TEST_SELECTION_FAILED` | yes | yes | product |
+| `UNKNOWN` (`PATCH_NOT_APPLICABLE`, `PATCH_OVER_BOUND`) | no | no | product (input) |
+| `UNKNOWN` (`ORACLE_LOAD_ERROR`, `ORACLE_TIMEOUT`, `VERIFICATION_TIMEOUT`, `SANDBOX_FAILURE`, `REGISTRY_FAILURE`) | no | no | infrastructure |
+
+The 99% reliability gate is `numerator / denominator ≥ 0.99` per arm and
+overall: at most 1% of retained attempts may end as `UNKNOWN`. Every product
+outcome — `PASS` or any named reason code — counts as a successfully indexed
+trial (a verdict was reached), so an agent failing tasks does not itself block
+the gate; only attempts that die before a verdict (input or infrastructure
+`UNKNOWN`) reduce reliability. Failure classes are reported for diagnosis,
+but the gate counts every non-verdict attempt equally, because a baseline
+whose denominator silently drops attempts is not trustworthy (C38, C43).
 
 **Stale-row check (persisted rows, not evidence freshness)**:
 
@@ -199,6 +262,18 @@ endpoints but changes kind/line/resolution, must not survive) (C16):
 AND re-compared after every executed command (oracle, verification) against a
 worktree snapshot, including untracked files — an allowed test-file change
 that rewrites a production file during evaluation is `PATH_VIOLATION` (C18).
+
+**Write-boundary enforcement during execution, not only after** (C43):
+post-command snapshots cannot detect a write that is reverted before the
+process exits — an allowed test hook can temporarily overwrite an
+out-of-allowlist production file, run verification against the altered
+implementation, then restore the original bytes, leaving the snapshot clean
+while an otherwise failing patch passes. The runner therefore enforces the
+boundary WHILE each process runs: out-of-allowlist worktree files are made
+**read-only before execution** (kernel-enforced, so a process cannot write
+them at all) AND a **write journal** records every write during each command;
+a journaled write outside the allowlist is `PATH_VIOLATION` regardless of the
+final bytes. The post-command snapshot is retained as defense in depth.
 **Trusted tool artifacts are excluded**: files the declared verification
 command or oracle legitimately creates (`.pytest_cache/`, `__pycache__/`,
 `.mypy_cache/`, `.ruff_cache/`) are on a pinned allowlist of excluded paths,
@@ -222,7 +297,11 @@ so a correct reference patch never deterministically fails path enforcement
   that appears to pre-date the disclosed run. ALL registration attempts are
   retained (including superseded ones). A run's report is only valid if every
   task/oracle hash in it was registered *before* that run's first execution;
-  a run whose hashes were registered after the fact is rejected.
+  a run whose hashes were registered after the fact is rejected. **Corpus
+  preflight runs before any attempt is recorded**: baseline-reason tokens,
+  typed argv, manifest limits, and oracle strict-subset validation (§5) are
+  all checked first; a preflight failure rejects the corpus run with zero
+  attempts consumed (C43).
 - E0–E3: internal numbers only, no public competitive wording.
 - **E3 requires separately attested reproduction**: an independent machine,
   blind evaluation, and a separate attestation record — a CI job in the
@@ -247,7 +326,7 @@ expected outcome** (9 PASS + 1 FAIL for a known-wrong reference patch).
 survives a mutation suite** that forces every reason code:
 
 - positive mutation: the reference (correct) patch → must yield the pinned
-  PASS with all five checks exercised;
+  PASS with all applicable checks exercised (six for `test_selection` tasks);
 - `PATH_VIOLATION`: patch touching an out-of-allowlist path → exact code;
 - `ORACLE_FAILED`: patch leaving the oracle red → exact code;
 - `VERIFICATION_FAILED`: patch that passes the oracle but breaks the
@@ -256,8 +335,9 @@ survives a mutation suite** that forces every reason code:
   exact code;
 - `UNSUPPORTED_RELATIONSHIP`: patch justified by a high-confidence
   unsupported relationship (fixture) → exact code;
-- `UNKNOWN`: a non-applicable patch and an oracle-execution-error fixture →
-  exact code;
+- `UNKNOWN`: a non-applicable patch, an oracle-execution-error fixture, and
+  hunk-boundary fixtures (a hunk at exactly `patch_max_lines_per_hunk` is
+  processed; limit+1 is `UNKNOWN`) → exact code;
 - `TEST_SELECTION_FAILED`: on a test_selection task, a transcript with an
   incorrect, empty, or full-suite selected-test set → exact code (C17).
 
@@ -270,16 +350,21 @@ through the same `--patch`/`--selected-tests` CLI channel, C32) against an
 **independently pre-registered affected-test oracle** — frozen per task at
 registration, never derived at runtime from the causality index being
 evaluated (a self-derived oracle would validate comparison plumbing, not
-selection correctness, C26). Running the full suite, no tests, or the wrong
-subset is `TEST_SELECTION_FAILED`, not a pass.
+selection correctness, C26). **The affected-test oracle must be a strict
+subset of the fixture's complete suite** — validated at corpus load; a
+full-suite or non-existent-path oracle is a registration error that fails
+preflight, because a full-suite oracle carries no selection signal and such a
+change is not a valid `test_selection` task (C43). With a strict-subset
+oracle, running the full suite, no tests, or the wrong subset is always
+`TEST_SELECTION_FAILED`, not a pass.
 
 ## Phases with visible exit artifacts
 
 | Phase | Scope | Verifiable exit artifact |
 |---|---|---|
 | **B0** | RFC accepted; strict `BenchmarkRecord` model; 10-task seed corpus; registration registry | `benchmarks/no1_010b/` with 10 tasks; corpus contract tests green (unknown-field rejection, oracle red-baseline + reason, allowlist semantics, per-class counts) |
-| **B1** | Patch-verifier runner complete (all 5 checks + oracle exit-code contract + stale-row queries + mutation suite) | 10/10 pre-registered outcomes matched exactly; mutation suite forces all 7 reason codes; CI reproduces |
-| **B2** | VCSR baseline measurement on pinned versions | `report.json` with VCSR + per-class/per-repo **and per-arm** breakdown (exact task counts and outcomes per client/model/backend — arms are never pooled in the report, C31) + **the reliability metric per arm and overall**: `successful_indexed_trials / all_trials` with exact numerator, denominator, failure classes (infrastructure vs product), and the 99% reliability gate status (C38). **B2 does not complete unless the 99% reliability threshold is met per arm and overall** — a below-threshold run is recorded but cannot advance to baseline (C39) + provenance; baseline recorded in STATE.md; E0–E3 internal only |
+| **B1** | Patch-verifier runner complete (all applicable checks + oracle exit-code contract + stale-row queries + mutation suite) | 10/10 pre-registered outcomes matched exactly; mutation suite forces all 7 reason codes; CI reproduces |
+| **B2** | VCSR baseline measurement on pinned versions | `report.json` with VCSR + per-class/per-repo **and per-arm** breakdown (exact task counts and outcomes per client/model/backend — arms are never pooled in the report, C31) + **the reliability metric per arm and overall**: `successful_indexed_trials / all_trials` with exact numerator, denominator, failure classes (infrastructure vs product), and the 99% reliability gate status (C38); the terminal-state → numerator/failure-class mapping is fixed in §3 (C43). **B2 does not complete unless the 99% reliability threshold is met per arm and overall** — a below-threshold run is recorded but cannot advance to baseline (C39) + provenance; baseline recorded in STATE.md; E0–E3 internal only |
 | **B3** | (gated) E4 bounded admission | only with zero UNKNOWNs, E3 independent attestation, external E4 reproduction — per §4 |
 
 ## Interaction with existing seams

--- a/rfcs/0026-no1-010b-agent-change-outcome-benchmark.md
+++ b/rfcs/0026-no1-010b-agent-change-outcome-benchmark.md
@@ -86,9 +86,12 @@ The runner is a **patch verifier**; it never mutates the repository itself
    (`--patch <file>`; the stdin `-` mode is mutually exclusive with the
    corpus `-` mode — one stdin stream cannot feed both parsers, so at most
    one input may use `-` and the other must be a file). The patch input is
-   **bounded before `git apply`** — a size cap (e.g. 1 MiB), a hunk-count
-   cap, and a per-hunk line cap; an over-bound patch is `UNKNOWN`, never
-   applied (C40). A `--repo` commit,
+   **bounded before `git apply`** — CANONICAL limits bound into the
+   registered manifest, not examples: `patch_max_bytes = 1 MiB`,
+   `patch_max_hunks = 512`, `patch_max_lines_per_hunk = 2000` (C41). An
+   over-bound patch is `UNKNOWN`, never applied (C40). The limits are part
+   of the manifest hash so an evaluator cannot choose thresholds after
+   observing an attempt. A `--repo` commit,
    `--arm` identity, and — for criterion 5 — a **provenance transcript**
    (the set of graph relationships the patch producer recorded seeing/using,
    e.g. the `nav.context` + `edit.safe` envelopes observed during
@@ -160,8 +163,12 @@ wrapper** that separates loading/execution from the declared assertion:
 - only the oracle's explicitly declared assertion result maps to PASS
   (exit 0) or FAIL (exit 1 → `ORACLE_FAILED`);
 - every other exception, timeout (60 s), or unexpected process exit → `UNKNOWN`.
-The runner validates that the baseline run fails with the recorded
-`oracle_baseline_reason` before any patch is evaluated.
+The baseline validation uses a **typed reason protocol** (C42): on a FAIL
+result the oracle also prints a second declared line
+`NO1_010B_ORACLE_REASON: <token>`; the runner requires the baseline FAIL
+reason token to EQUAL the registered `oracle_baseline_reason` token (exact
+match, no exception-text comparison). A baseline red for a different reason —
+or missing the reason line — is a corpus/fixture error and fails closed.
 
 **Stale-row check (persisted rows, not evidence freshness)**:
 

--- a/rfcs/0026-no1-010b-agent-change-outcome-benchmark.md
+++ b/rfcs/0026-no1-010b-agent-change-outcome-benchmark.md
@@ -1,0 +1,182 @@
+# RFC-0026: NO1-010B Agent Change-Outcome Benchmark (VCSR Primary Endpoint)
+
+- **Status**: draft
+- **Author(s)**: @lead-agent
+- **Created**: 2026-08-17
+- **Last updated**: 2026-08-17
+- **Tracking issue**: TBD
+- **Affected source paths** (pin them — reviewers watch for drift here):
+  - `tree_sitter_analyzer/task_harness.py` (corpus runner, stdin route)
+  - `tree_sitter_analyzer/task/` (router truth-table, edge-evidence)
+  - `benchmarks/no1_010b/` (corpus, oracles, runner, report)
+  - `tests/unit/task/test_task_harness.py` (exact pins for the runner)
+  - `rfcs/ROADMAP-no1-agent-trust.md` (ledger row NO1-010B)
+
+## Summary
+
+A pre-registered, reproducible **agent change-outcome benchmark** whose primary
+endpoint is **Verified Change Success Rate (VCSR)** — the north star of
+`ROADMAP-no1-agent-trust.md`. The corpus is a pinned set of agent tasks, each
+with a repo fixture, a behavioral oracle, an allowed-path set, and a declared
+verification command. A task PASSES only when all five VCSR criteria hold;
+`unknown` is a first-class outcome, never a pass. The benchmark must fail
+closed when evidence is insufficient, exactly like RFC-0021's competitive
+benchmark and RFC-0022's fail-closed honesty.
+
+## Motivation
+
+NO1-010A (#1290 + follow-ups) proved the task layer runs end-to-end
+(`understand` / `plan_change` / `assess_change` through the internal harness
+bridge with exact wire contracts). What is missing is the **measurement**: no
+pre-registered corpus and oracle protocol exists that would let us claim
+VCSR with evidence. The north-star definition in
+`ROADMAP-no1-agent-trust.md` §3 names the five criteria but nothing
+operationalizes them into runnable tasks and pass/fail rules.
+
+Concrete pain: today a change is "verified" only by whichever tests an agent
+happens to run; there is no corpus where the expected outcome is known a
+priori, so regressions in task-layer routing (wrong primitive, dropped
+evidence, stale edges) are found by dogfooding, not by CI. The benchmark
+closes that gap: **every task's expected outcome is pinned before any arm
+runs**, so CI can detect routing/evidence regressions and the VCSR number is
+real.
+
+## Detailed design
+
+### 1. Corpus format (JSONL, pre-registered)
+
+One task per line, strict JSON (reuse `task_harness._strict_json_loads`'s
+rejection of unknown fields / duplicate keys / non-standard constants):
+
+```json
+{
+  "id": "no1-010b/0001-bugfix-dispatch-null",
+  "repo": "fixtures/dispatch_app",          // pinned fixture repo (git commit)
+  "operation": "plan_change",               // understand | plan_change | assess_change
+  "task": "dispatch returns None for an unknown route; return a 404 object instead",
+  "allowed_paths": ["src/dispatch.py", "tests/"],
+  "oracle": "oracles/0001.py",              // exact behavioral oracle (run after the change)
+  "verification_command": "uv run pytest tests/ -q",
+  "defect": {"file": "src/dispatch.py", "line": 12, "kind": "missing-else"}
+}
+```
+
+- **repo**: a committed fixture under `benchmarks/no1_010b/fixtures/` (small
+  multi-file apps, pinned by git commit; the runner checks out the pinned
+  commit and fails closed on drift).
+- **oracle**: a deterministic script that asserts the *post-change* behavior.
+  It must be pass/fail with a stable exit code and a one-line reason on
+  failure; no timers, no network.
+- **allowed_paths**: the only paths a compliant change may modify. A change
+  touching any other path fails the first VCSR criterion.
+- **verification_command**: the command the agent's declared verification must
+  satisfy; the harness runs it on the final tree.
+- **defect**: the seeded defect metadata (for bugfix tasks) so the oracle is
+  *demonstrably* red on the unmodified fixture — a corpus task whose oracle
+  passes before the change is a corpus bug, not a pass.
+
+### 2. Harness runner
+
+`benchmarks/no1_010b/runner.py` consumes the corpus and produces
+`report.json`:
+
+- `run` phase: for each task, apply the agent's patch (input via
+  `task_harness.load_corpus` stdin/`--corpus` route, 8 MiB bound), then:
+  1. **paths**: diff vs `allowed_paths` (exact, no glob escape);
+  2. **oracle**: run `oracle.py` on the final tree (must be red pre-change);
+  3. **verification**: run `verification_command` on the final tree;
+  4. **stale rows**: run the analyzer's post-index staleness probe
+     (`edge_evidence` rejection family: no stale symbol/edge rows for the
+     modified files);
+  5. **unsupported relationships**: no high-confidence relationship used to
+     justify the change may be unsupported (the RFC-0022 truth-table
+     rejection family).
+- `score` phase: classify each task PASS / FAIL / UNKNOWN with an exact reason
+  code; VCSR = `PASS / corpus_size`. UNKNOWN counts as neither PASS nor FAIL
+  for the numerator but is reported separately (fail-closed: a run with any
+  UNKNOWN cannot produce a bounded "better-than" claim).
+
+### 3. VCSR criteria ↔ code mapping (exact)
+
+| North-star criterion | Runner check | Reason code |
+|---|---|---|
+| modify only allowed paths | `paths` check | `PATH_VIOLATION` |
+| satisfy exact behavioral oracles | `oracle` check | `ORACLE_FAILED` |
+| pass the declared verification command | `verification` check | `VERIFICATION_FAILED` |
+| leave no stale symbol or edge rows | staleness probe | `STALE_ROWS` |
+| contain no high-confidence unsupported relationship used to justify the change | truth-table rejection family | `UNSUPPORTED_RELATIONSHIP` |
+| evidence insufficient (any of the above unavailable, or analyzer fails closed) | runner fail-closed | `UNKNOWN` |
+
+### 4. Baseline protocol and claim policy
+
+- Baseline is measured on a **pinned analyzer version + pinned corpus commit**,
+  recorded in `report.json` (`analyzer_version`, `corpus_commit`, `date`,
+  `host`), mirroring RFC-0021's provenance discipline.
+- E0–E3: internal numbers only, no public competitive wording.
+- E4: the only admissible public sentence is the exact bounded form —
+  `VCSR = X/Y (Z%) on the pre-registered NO1-010B corpus vN at analyzer
+  commit <sha>` — and only when: corpus pre-registered before the run,
+  zero UNKNOWNs, CI reproduced the run on the Linux coverage axis.
+- The report fails closed (exit non-zero) if any task could not be evaluated
+  (missing oracle, repo drift, analyzer crash) — a partially-evaluated corpus
+  never yields a claim.
+
+### 5. Seed corpus (implementation deliverable)
+
+The first corpus ships with **10 pre-registered tasks**, all green-repo
+fixtures:
+
+- 4 bugfix (missing-else / off-by-one / null-deref / wrong-constant),
+- 2 refactor (rename with reference updates; extract-function with call-site
+  updates),
+- 2 migration (API rename across a package; import-path relocation),
+- 2 test-selection (a change that must run exactly the affected subset).
+
+Every oracle is verified **red-on-baseline** in CI (a fixture whose oracle
+passes before the change fails the corpus contract test), and every task has
+a pinned allowed-path set. The corpus manifest itself is guarded by exact
+contract tests (`tests/unit/task/test_no1_010b_corpus.py`): schema, oracle
+red-ness, allowed-path validity, no duplicate ids.
+
+### 6. Interaction with existing seams
+
+- The runner drives the task layer through `task_harness.McpPrimitiveExecutor`
+  (the same same-process bridge NO1-010A pins); it never imports analyzer
+  internals — the `task/` import boundary is preserved.
+- The staleness/unsupported checks reuse `task/edge_evidence.py` + the
+  RFC-0022 truth-table rejection family (already covered by
+  `test_edge_evidence.py` and `test_task_truth_table.py`).
+- The harness stdin route (`load_corpus("-")`) is the corpus feed; the 8 MiB
+  bound and strict JSON are unchanged.
+
+## Phases with visible exit artifacts
+
+| Phase | Scope | Verifiable exit artifact |
+|---|---|---|
+| **B0** | RFC accepted; corpus schema + 10-task seed + runner skeleton | `benchmarks/no1_010b/` with 10 tasks; corpus contract tests green (oracle red-ness enforced) |
+| **B1** | Runner complete (paths/oracle/verification/staleness/unsupported) + `report.json` | 10/10 tasks evaluate to PASS/FAIL/UNKNOWN with exact reason codes on the seed corpus; CI reproduces |
+| **B2** | VCSR baseline measurement on pinned versions | `report.json` with VCSR + provenance; baseline recorded in STATE.md; E0–E3 internal only |
+| **B3** | (gated) E4 bounded admission | only when zero UNKNOWNs + CI reproduction + pre-registration, per §4 |
+
+## Alternatives considered
+
+1. **Benchmark the analyzer, not the agent** (compare tool answers on fixed
+   prompts): simpler, but measures retrieval, not whether a *change* succeeds —
+   the north star is change-outcome. NO1-010B complements RFC-0021, which
+   keeps the competitive answer-quality role.
+2. **Agent-in-the-loop benchmark** (drive a real LLM agent): closest to
+   production, but provider/model variance and cost make it non-reproducible
+   in CI. Rejected for the primary endpoint; a future E4-adjacent arm may run
+   a pinned model under the same protocol.
+3. **No pre-registration** (run tasks, then decide oracles): invalid — the
+   north star's evidence level requires oracles decided before the run.
+   Rejected.
+
+## Open questions
+
+1. Whether the first 10-task corpus should pin one language (Python) or span
+   three (Python + JS + Go) — propose Python-only for B0, expand after B1.
+2. Verification-command timeout and isolation (propose: 60 s, subprocess with
+   `setsid`, workspace copy — mirroring the strace certification discipline).
+3. Whether `report.json` should include a machine-readable per-criterion
+   breakdown for the future E4 sentence (propose: yes, always).


### PR DESCRIPTION
RFC-0026 operationalizes the VCSR north star: a pre-registered corpus with behavioral oracles, allowed paths, declared verification, and staleness/unsupported-relationship probes; a fail-closed runner producing report.json with exact reason codes; E0-E3/E4 claim policy. 10-task seed corpus is the implementation deliverable. Draft for review.