### PR TITLE
fix: resolve import edges across directories on Windows, and admit Node module suffixes

### DIFF
--- a/tests/unit/mcp/test_graph_cache_invalidation.py
+++ b/tests/unit/mcp/test_graph_cache_invalidation.py
@@ -75,6 +75,48 @@ class TestGraphFingerprint:
         fp3 = compute_graph_fingerprint(str(project_root))
         assert fp3.file_count == fp1.file_count
 
+    def test_changes_on_added_mjs_file(self, project_root: Path) -> None:
+        """A new ``.mjs`` file must bump file_count.
+
+        ``project_graph`` resolves ``.mjs``/``.cjs``/``.mts``/``.cts``, so the
+        fingerprint must admit them too — otherwise the graph cache never
+        invalidates on Node module edits and stale answers are served.
+        """
+        fp1 = compute_graph_fingerprint(str(project_root))
+        (project_root / "pkg" / "esm.mjs").write_text("export const a = 1;\n")
+        fp2 = compute_graph_fingerprint(str(project_root))
+        assert fp2.file_count == fp1.file_count + 1
+
+    def test_changes_on_added_mts_file(self, project_root: Path) -> None:
+        """A new ``.mts`` file must bump file_count."""
+        fp1 = compute_graph_fingerprint(str(project_root))
+        (project_root / "pkg" / "esm.mts").write_text("export const a: number = 1;\n")
+        fp2 = compute_graph_fingerprint(str(project_root))
+        assert fp2.file_count == fp1.file_count + 1
+
+    def test_changes_on_added_cjs_file(self, project_root: Path) -> None:
+        """A new ``.cjs`` file must bump file_count."""
+        fp1 = compute_graph_fingerprint(str(project_root))
+        (project_root / "pkg" / "legacy.cjs").write_text("module.exports = {};\n")
+        fp2 = compute_graph_fingerprint(str(project_root))
+        assert fp2.file_count == fp1.file_count + 1
+
+    def test_changes_on_added_cts_file(self, project_root: Path) -> None:
+        """A new ``.cts`` file must bump file_count."""
+        fp1 = compute_graph_fingerprint(str(project_root))
+        (project_root / "pkg" / "legacy.cts").write_text("export = {};\n")
+        fp2 = compute_graph_fingerprint(str(project_root))
+        assert fp2.file_count == fp1.file_count + 1
+
+    def test_changes_on_touched_mjs_file(self, project_root: Path) -> None:
+        """Editing an existing ``.mjs`` file must move max_mtime_ns."""
+        (project_root / "pkg" / "esm.mjs").write_text("export const a = 1;\n")
+        fp1 = compute_graph_fingerprint(str(project_root))
+        time.sleep(0.05)  # ensure mtime granularity
+        os.utime(project_root / "pkg" / "esm.mjs")
+        fp2 = compute_graph_fingerprint(str(project_root))
+        assert fp2.max_mtime_ns > fp1.max_mtime_ns
+
     def test_idempotent_when_unchanged(self, project_root: Path) -> None:
         """Calling twice without edits returns the same fingerprint."""
         fp1 = compute_graph_fingerprint(str(project_root))

--- a/tests/unit/mcp/tools/test_safe_to_edit_dependency_view.py
+++ b/tests/unit/mcp/tools/test_safe_to_edit_dependency_view.py
@@ -312,6 +312,34 @@ def test_iter_dependency_source_files_skips_hidden_files(tmp_path: Path) -> None
     assert [path.name for path in files] == ["main.py"]
 
 
+def test_dynamic_import_plain_string_yields_spec() -> None:
+    assert _extract_import_specs('import("./dev.js");\n', ".js") == {"./dev.js"}
+
+
+def test_dynamic_import_with_options_object_yields_spec() -> None:
+    source = 'import("./dev.js", { with: { type: "json" } });\n'
+    assert _extract_import_specs(source, ".js") == {"./dev.js"}
+
+
+def test_dynamic_import_with_concatenated_suffix_yields_no_spec() -> None:
+    """A computed specifier must not be recorded by its literal prefix.
+
+    ``import("./dev.js" + suffix)`` selects a module that is unknowable
+    statically. Recording ``./dev.js`` invents an edge that is wrong AND
+    hides the real one, so the prefix must not be admitted at all.
+    """
+    assert _extract_import_specs('import("./dev.js" + suffix);\n', ".js") == set()
+
+
+def test_dynamic_import_template_literal_yields_spec() -> None:
+    assert _extract_import_specs("import(`./dev.js`);\n", ".js") == {"./dev.js"}
+
+
+def test_dynamic_import_template_literal_with_concat_yields_no_spec() -> None:
+    """The template-literal branch has the same computed-prefix hole."""
+    assert _extract_import_specs("import(`./dev.js` + suffix);\n", ".js") == set()
+
+
 def test_import_spec_helpers_cover_unsupported_and_unresolved_cases(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_call_graph_integration.py
+++ b/tests/unit/test_call_graph_integration.py
@@ -178,6 +178,39 @@ class TestCallGraphLanguageParity:
         assert names == {"loadData", "processData", "main"}
 
 
+class TestResolveImportPath:
+    """``CallGraph._resolve_import_path`` extension probing.
+
+    The probe table must cover the Node module suffixes the project graph
+    already admits (``.mjs``/``.cjs``/``.mts``/``.cts``), otherwise an
+    admitted ``.mts`` file importing an extensionless sibling silently
+    loses its cross-file call edges.
+    """
+
+    @staticmethod
+    def _probe(source_rel: str, spec: str, target_rel: str) -> str:
+        cg = CallGraph(str(PY_PROJECT))
+        return cg._resolve_import_path(
+            source_rel, spec, True, {target_rel: f"/abs/{target_rel}"}
+        )
+
+    def test_resolves_mts_sibling(self):
+        target = str(Path("src") / "util.mts")
+        assert self._probe(str(Path("src") / "app.mts"), "./util", target) == target
+
+    def test_resolves_mjs_sibling(self):
+        target = str(Path("src") / "util.mjs")
+        assert self._probe(str(Path("src") / "app.mjs"), "./util", target) == target
+
+    def test_resolves_cts_sibling(self):
+        target = str(Path("src") / "util.cts")
+        assert self._probe(str(Path("src") / "app.cts"), "./util", target) == target
+
+    def test_resolves_cjs_sibling(self):
+        target = str(Path("src") / "util.cjs")
+        assert self._probe(str(Path("src") / "app.cjs"), "./util", target) == target
+
+
 class TestCallGraphCallersOf:
     @_WINDOWS_SKIP_PY_FIXTURE
     def test_callers_of_called_function(self):

--- a/tests/unit/test_cross_file_resolver.py
+++ b/tests/unit/test_cross_file_resolver.py
@@ -99,6 +99,56 @@ class TestCrossFileResolverBuild:
         assert "utils" in mod_paths
 
 
+@pytest.fixture
+def mts_project(tmp_path):
+    """A real indexed project whose .mts entry imports an extensionless sibling."""
+    project = tmp_path / "mtsproj"
+    project.mkdir()
+    (project / "src").mkdir()
+
+    (project / "src" / "util.mts").write_text(
+        "export function run(value: number): number {\n    return value + 1;\n}\n"
+    )
+    (project / "src" / "app.mts").write_text(
+        "import { run } from './util';\n"
+        "\n"
+        "export function main(): number {\n"
+        "    return run(1);\n"
+        "}\n"
+    )
+
+    cache = ASTCache(str(project))
+    cache.index_project(max_files=100)
+    yield project, cache
+    cache.close()
+
+
+class TestNodeModuleCrossFileResolution:
+    """PUBLIC API: an ESM import in a .mts file must bind across files.
+
+    Regression for the Codex finding on #1312: ``_register_module_path``
+    registered ``src/util.mts`` correctly, but the LOOKUP in
+    ``_resolve_module_to_file`` probed only ``("", ".py", ".js", ".ts",
+    "/__init__.py")`` — so the relative ``./util`` never matched and the
+    binding was dropped. Registration worked; resolution did not.
+    """
+
+    def test_esm_relative_import_binds_to_mts_sibling(self, mts_project):
+        _project, cache = mts_project
+        resolver = CrossFileResolver(cache)
+        resolver.build()
+        assert resolver._name_to_source["src/app.mts"]["run"] == "src/util.mts"
+
+    def test_resolve_callee_finds_cross_file_mts_definition(self, mts_project):
+        _project, cache = mts_project
+        resolver = CrossFileResolver(cache)
+        resolver.build()
+        files = [
+            path for path, _confidence in resolver.resolve_callee("run", "src/app.mts")
+        ]
+        assert "src/util.mts" in files
+
+
 class TestRegisterNodeModulePaths:
     """``_register_module_path`` must strip the full Node module suffix.
 

--- a/tests/unit/test_cross_file_resolver.py
+++ b/tests/unit/test_cross_file_resolver.py
@@ -99,6 +99,44 @@ class TestCrossFileResolverBuild:
         assert "utils" in mod_paths
 
 
+class TestRegisterNodeModulePaths:
+    """``_register_module_path`` must strip the full Node module suffix.
+
+    ``"src/util.mts".endswith(".ts")`` is True, so a probe table that lists
+    ``.ts`` before ``.mts`` mangles the module name into ``src.util.m`` and
+    every ``./util`` import against it fails to resolve.
+    """
+
+    @staticmethod
+    def _register(fp: str, language: str) -> dict[str, str]:
+        resolver = CrossFileResolver(None)
+        resolver._register_module_path(fp, language)
+        return resolver._module_to_file
+
+    def test_mts_dotted_module_name(self):
+        assert (
+            self._register("src/util.mts", "typescript")["src.util"] == "src/util.mts"
+        )
+
+    def test_mts_short_module_name(self):
+        assert self._register("src/util.mts", "typescript")["util"] == "src/util.mts"
+
+    def test_cts_dotted_module_name(self):
+        assert (
+            self._register("src/util.cts", "typescript")["src.util"] == "src/util.cts"
+        )
+
+    def test_mjs_dotted_module_name(self):
+        assert (
+            self._register("src/util.mjs", "javascript")["src.util"] == "src/util.mjs"
+        )
+
+    def test_cjs_dotted_module_name(self):
+        assert (
+            self._register("src/util.cjs", "javascript")["src.util"] == "src/util.cjs"
+        )
+
+
 class TestCrossFileResolution:
     def test_resolve_same_file_callee(self, multi_file_project):
         _project, cache = multi_file_project

--- a/tests/unit/test_import_graph.py
+++ b/tests/unit/test_import_graph.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 
+from tree_sitter_analyzer.ast_cache import ASTCache
 from tree_sitter_analyzer.import_graph import (
     ImportEdge,
     ImportGraph,
@@ -264,6 +265,133 @@ class TestImportGraphBuild:
         assert result.edge_count == 1
         assert result.edges[0].source_file == "a.py"
         assert result.edges[0].target_file == "b.py"
+
+    def test_build_resolves_esm_import_from_mts_file(self, monkeypatch) -> None:
+        """PUBLIC API: an ESM import in a .mts file must produce an edge.
+
+        Regression for the Codex finding on #1312: ``_resolve_import``
+        dispatched on the text prefix, and ``import { run } from './util'``
+        starts with ``import `` — so ESM statements were routed to the PYTHON
+        resolver and never reached ``_resolve_js_import``. Unit tests on the
+        private helper passed while ``health action=imports`` still dropped
+        every ESM edge, which is the dominant form in .mjs/.mts files.
+        """
+        imports = {
+            "src/app.mts": ["import { run } from './util'"],
+            "src/util.mts": [],
+        }
+
+        class _FakeCache:
+            def __init__(self, root: str) -> None:
+                pass
+
+            def get_imports(self) -> dict[str, list[str]]:
+                return imports
+
+            def close(self) -> None:
+                pass
+
+        monkeypatch.setattr("tree_sitter_analyzer.ast_cache.ASTCache", _FakeCache)
+        result = ImportGraph(ROOT).build()
+
+        assert result.edge_count == 1
+        assert result.edges[0].target_file == "src/util.mts"
+
+    def test_build_resolves_esm_import_from_mjs_file(self, monkeypatch) -> None:
+        """PUBLIC API: same dispatch path for the .mjs/JavaScript family."""
+        imports = {
+            "src/app.mjs": ["import { run } from './util'"],
+            "src/util.mjs": [],
+        }
+
+        class _FakeCache:
+            def __init__(self, root: str) -> None:
+                pass
+
+            def get_imports(self) -> dict[str, list[str]]:
+                return imports
+
+            def close(self) -> None:
+                pass
+
+        monkeypatch.setattr("tree_sitter_analyzer.ast_cache.ASTCache", _FakeCache)
+        result = ImportGraph(ROOT).build()
+
+        assert result.edge_count == 1
+        assert result.edges[0].target_file == "src/util.mjs"
+
+    def test_build_still_resolves_python_import_from_py_file(self, monkeypatch) -> None:
+        """Guard: language-based dispatch must not break Python resolution."""
+        imports = {
+            "pkg/a.py": ["from pkg.b import thing"],
+            "pkg/b.py": [],
+        }
+
+        class _FakeCache:
+            def __init__(self, root: str) -> None:
+                pass
+
+            def get_imports(self) -> dict[str, list[str]]:
+                return imports
+
+            def close(self) -> None:
+                pass
+
+        monkeypatch.setattr("tree_sitter_analyzer.ast_cache.ASTCache", _FakeCache)
+        result = ImportGraph(ROOT).build()
+
+        assert result.edge_count == 1
+        assert result.edges[0].target_file == "pkg/b.py"
+
+    def test_build_over_real_indexed_mts_project_produces_edge(self, tmp_path) -> None:
+        """END-TO-END: real ASTCache index, no fake cache, no path massaging.
+
+        This is the test that actually proves the feature. The fake-cache tests
+        above passed while ``ImportGraph`` still produced ZERO edges against a
+        real index, because the cache keys paths POSIX-style while both
+        resolvers built candidates with ``os.path.normpath`` (backslashes on
+        Windows) — so every nested project resolved to nothing. Asserting
+        through the real indexer is what surfaced it. (#1312 Codex follow-up.)
+        """
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "util.mts").write_text(
+            "export function run(v: number): number {\n    return v + 1;\n}\n"
+        )
+        (tmp_path / "src" / "app.mts").write_text(
+            'import { run } from "./util";\nexport function main() {\n'
+            "    return run(1);\n}\n"
+        )
+
+        cache = ASTCache(str(tmp_path))
+        cache.index_project(max_files=50)
+        cache.close()
+
+        result = ImportGraph(str(tmp_path)).build()
+
+        assert result.edge_count == 1
+        assert result.edges[0].source_file == "src/app.mts"
+        assert result.edges[0].target_file == "src/util.mts"
+
+    def test_build_over_real_indexed_nested_python_produces_edge(
+        self, tmp_path
+    ) -> None:
+        """END-TO-END guard: the same separator fix must keep Python working."""
+        (tmp_path / "pkg").mkdir()
+        (tmp_path / "pkg" / "__init__.py").write_text("")
+        (tmp_path / "pkg" / "b.py").write_text("def bar():\n    return 1\n")
+        (tmp_path / "pkg" / "a.py").write_text(
+            "from pkg.b import bar\n\n\ndef foo():\n    return bar()\n"
+        )
+
+        cache = ASTCache(str(tmp_path))
+        cache.index_project(max_files=50)
+        cache.close()
+
+        result = ImportGraph(str(tmp_path)).build()
+
+        assert result.edge_count == 1
+        assert result.edges[0].source_file == "pkg/a.py"
+        assert result.edges[0].target_file == "pkg/b.py"
 
     def test_build_handles_cache_failure_gracefully(self, monkeypatch) -> None:
         class _BoomCache:

--- a/tests/unit/test_import_graph.py
+++ b/tests/unit/test_import_graph.py
@@ -115,6 +115,42 @@ class TestResolveJsImport:
             ROOT,
         ) == _np("src/widget/index.js")
 
+    def test_mts_sibling_resolution(self) -> None:
+        """An extensionless import must probe the ``.mts`` sibling."""
+        assert _resolve_js_import(
+            "import { run } from './util'",
+            _np("src/app.mts"),
+            {_np("src/util.mts")},
+            ROOT,
+        ) == _np("src/util.mts")
+
+    def test_mjs_sibling_resolution(self) -> None:
+        """An extensionless import must probe the ``.mjs`` sibling."""
+        assert _resolve_js_import(
+            "import { run } from './util'",
+            _np("src/app.mjs"),
+            {_np("src/util.mjs")},
+            ROOT,
+        ) == _np("src/util.mjs")
+
+    def test_cts_sibling_resolution(self) -> None:
+        """An extensionless import must probe the ``.cts`` sibling."""
+        assert _resolve_js_import(
+            "const u = require('./util')",
+            _np("src/app.cts"),
+            {_np("src/util.cts")},
+            ROOT,
+        ) == _np("src/util.cts")
+
+    def test_cjs_index_resolution(self) -> None:
+        """A directory import must probe ``<dir>/index.cjs``."""
+        assert _resolve_js_import(
+            "const w = require('./widget')",
+            _np("src/app.cjs"),
+            {_np("src/widget/index.cjs")},
+            ROOT,
+        ) == _np("src/widget/index.cjs")
+
     def test_bare_module_not_resolved(self) -> None:
         assert (
             _resolve_js_import(

--- a/tree_sitter_analyzer/cache/fingerprint.py
+++ b/tree_sitter_analyzer/cache/fingerprint.py
@@ -27,7 +27,7 @@ from collections.abc import Iterable
 from pathlib import Path
 from typing import NamedTuple
 
-from ..constants import EXCLUDE_DIRS
+from ..constants import EXCLUDE_DIRS, GRAPH_SOURCE_EXTS
 from ..languages.lang_extension_map import EXT_TO_LANG
 
 # Use the shared exclude set so the fingerprint scope matches the graph walkers
@@ -40,23 +40,13 @@ _EXCLUDE_DIRS: frozenset[str] = EXCLUDE_DIRS
 
 # Source file extensions handled by call_graph + project_graph + most plugins.
 # We cast a wide net so the same fingerprint can serve every graph kind.
-_SOURCE_EXTS: tuple[str, ...] = (
-    ".py",
-    ".js",
-    ".ts",
-    ".jsx",
-    ".tsx",
-    ".java",
-    ".go",
-    ".rs",
-    ".c",
-    ".cpp",
-    ".cc",
-    ".cxx",
-    ".h",
-    ".hpp",
-    ".hxx",
-)
+#
+# Sourced from the shared constant so this list can never drift from
+# ``project_graph``'s ``supported_exts`` again: an extension the graph indexes
+# but the fingerprint ignores means edits to those files never invalidate the
+# graph cache. That is exactly how ``.mjs``/``.cjs``/``.mts``/``.cts`` served
+# stale dependency and blast-radius answers.
+_SOURCE_EXTS: tuple[str, ...] = GRAPH_SOURCE_EXTS
 
 
 class GraphFingerprint(NamedTuple):

--- a/tree_sitter_analyzer/call_graph.py
+++ b/tree_sitter_analyzer/call_graph.py
@@ -20,6 +20,7 @@ from typing import Any
 
 from .callee_resolution import CalleeResolver
 from .constants import EXCLUDE_DIRS as _EXCLUDE_DIRS
+from .constants import JS_TS_MODULE_EXTS
 from .core.parser import Parser, ParseResult
 from .function_extraction import SUPPORTED_LANGUAGES as _FUNC_EXTRACTION_LANGUAGES
 from .function_extraction import (
@@ -273,7 +274,7 @@ class CallGraph:
         if is_relative:
             source_dir = str(Path(source_rel).parent)
             candidate = str(Path(source_dir) / resolved_path)
-            for ext in ("", ".py", ".js", ".ts", ".jsx", ".tsx"):
+            for ext in ("", ".py", *JS_TS_MODULE_EXTS):
                 check = candidate + ext
                 if check in rel_to_abs:
                     return check
@@ -282,7 +283,7 @@ class CallGraph:
                     return idx_path
         else:
             candidate = resolved_path
-            for ext in ("", ".py", ".js", ".ts", ".jsx", ".tsx"):
+            for ext in ("", ".py", *JS_TS_MODULE_EXTS):
                 check = candidate + ext
                 if check in rel_to_abs:
                     return check

--- a/tree_sitter_analyzer/constants.py
+++ b/tree_sitter_analyzer/constants.py
@@ -220,6 +220,12 @@ JS_TS_MODULE_EXTS: tuple[str, ...] = (
     ".cts",
 )
 
+# ``EXT_TO_LANG`` language names that share the Node/TypeScript module system.
+# Use this to dispatch import resolution on the SOURCE FILE's language — never
+# on the statement text. ``import `` opens both a Python import and an ESM
+# import, so a text sniff cannot tell them apart.
+JS_TS_LANGUAGES: frozenset[str] = frozenset({"javascript", "typescript"})
+
 # ``./widget`` → ``widget/index.<ext>`` probe forms, one per module extension.
 JS_TS_INDEX_SUFFIXES: tuple[str, ...] = tuple(
     f"/index{ext}" for ext in JS_TS_MODULE_EXTS

--- a/tree_sitter_analyzer/constants.py
+++ b/tree_sitter_analyzer/constants.py
@@ -196,3 +196,62 @@ EXCLUDE_DIRS: frozenset[str] = frozenset(
         ".tree-sitter-cache",
     }
 )
+
+
+# ---------------------------------------------------------------------------
+# Node / TypeScript module file extensions, in extension-PROBE order.
+#
+# Plain extensions come first so an extensionless ``./util`` still prefers
+# ``util.js`` over ``util.mjs`` — the precedence the resolvers already had
+# before the Node suffixes were added.
+#
+# Shared so every JS/TS resolver agrees. Previously import_graph, call_graph,
+# cross_file_resolver and project_graph each carried their own copy; the copies
+# drifted and ``.mjs``/``.cjs``/``.mts``/``.cts`` imports silently lost edges.
+# ---------------------------------------------------------------------------
+JS_TS_MODULE_EXTS: tuple[str, ...] = (
+    ".js",
+    ".ts",
+    ".jsx",
+    ".tsx",
+    ".mjs",
+    ".cjs",
+    ".mts",
+    ".cts",
+)
+
+# ``./widget`` → ``widget/index.<ext>`` probe forms, one per module extension.
+JS_TS_INDEX_SUFFIXES: tuple[str, ...] = tuple(
+    f"/index{ext}" for ext in JS_TS_MODULE_EXTS
+)
+
+# Same set as JS_TS_MODULE_EXTS, longest-first, for callers that STRIP the
+# extension off a path instead of appending it. ``"util.mts".endswith(".ts")``
+# is True, so a shortest-first scan mangles ``util.mts`` into ``util.m``.
+JS_TS_MODULE_EXTS_LONGEST_FIRST: tuple[str, ...] = tuple(
+    sorted(JS_TS_MODULE_EXTS, key=len, reverse=True)
+)
+
+# ---------------------------------------------------------------------------
+# Every source extension the project/dependency graph walkers admit.
+#
+# ``cache/fingerprint.py`` and ``project_graph.py`` MUST agree here: the
+# fingerprint is the staleness signal for the graph it invalidates, so an
+# extension the graph indexes but the fingerprint ignores produces a
+# permanently stale cache (adding or editing such a file changes neither
+# file_count nor max_mtime_ns, so the stale graph is reused forever).
+# ---------------------------------------------------------------------------
+GRAPH_SOURCE_EXTS: tuple[str, ...] = (
+    ".py",
+    *JS_TS_MODULE_EXTS,
+    ".java",
+    ".go",
+    ".rs",
+    ".c",
+    ".cpp",
+    ".cc",
+    ".cxx",
+    ".h",
+    ".hpp",
+    ".hxx",
+)

--- a/tree_sitter_analyzer/cross_file_resolver.py
+++ b/tree_sitter_analyzer/cross_file_resolver.py
@@ -24,9 +24,43 @@ from pathlib import Path
 from typing import Any
 
 from .callee_resolution import CalleeResolver
-from .constants import JS_TS_MODULE_EXTS_LONGEST_FIRST
+from .constants import (
+    JS_TS_INDEX_SUFFIXES,
+    JS_TS_LANGUAGES,
+    JS_TS_MODULE_EXTS,
+    JS_TS_MODULE_EXTS_LONGEST_FIRST,
+)
+from .languages.lang_extension_map import EXT_TO_LANG
 
 logger = logging.getLogger(__name__)
+
+#: Extension probes for a relative-module lookup, chosen by the IMPORTING
+#: file's language. Kept as two disjoint lists on purpose: a Python file must
+#: never probe ``.mts``, and a ``.mts`` file must never probe ``__init__.py``.
+#: The JS/TS list was previously the Python one (``.js``/``.ts`` only), so
+#: ``./util`` from a ``.mts`` file never found ``util.mts`` even though
+#: ``_register_module_path`` had registered it. (Codex review on #1312.)
+_JS_TS_RELATIVE_PROBE_EXTS: tuple[str, ...] = (
+    "",
+    *JS_TS_MODULE_EXTS,
+    *JS_TS_INDEX_SUFFIXES,
+)
+_DEFAULT_RELATIVE_PROBE_EXTS: tuple[str, ...] = (
+    "",
+    ".py",
+    ".js",
+    ".ts",
+    "/__init__.py",
+)
+
+
+def _relative_probe_exts(source_file: str) -> tuple[str, ...]:
+    """Return the extension probe list for ``source_file``'s language."""
+    language = EXT_TO_LANG.get(os.path.splitext(source_file)[1].lower(), "")
+    if language in JS_TS_LANGUAGES:
+        return _JS_TS_RELATIVE_PROBE_EXTS
+    return _DEFAULT_RELATIVE_PROBE_EXTS
+
 
 _PY_FROM_IMPORT_RE = re.compile(r"^from\s+([\w.]+)\s+import\s+(.+)$", re.MULTILINE)
 _PY_IMPORT_RE = re.compile(r"^import\s+([\w.]+)", re.MULTILINE)
@@ -437,7 +471,7 @@ class CrossFileResolver:
         if is_relative and source_file:
             source_dir = str(Path(source_file).parent)
             candidate = source_dir + "/" + module_path.lstrip("./").replace(".", "/")
-            for ext in ("", ".py", ".js", ".ts", "/__init__.py"):
+            for ext in _relative_probe_exts(source_file):
                 check = candidate + ext
                 if check in self._module_to_file:
                     return self._module_to_file[check]

--- a/tree_sitter_analyzer/cross_file_resolver.py
+++ b/tree_sitter_analyzer/cross_file_resolver.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Any
 
 from .callee_resolution import CalleeResolver
+from .constants import JS_TS_MODULE_EXTS_LONGEST_FIRST
 
 logger = logging.getLogger(__name__)
 
@@ -245,7 +246,9 @@ class CrossFileResolver:
                 if short not in self._module_to_file:
                     self._module_to_file[short] = fp
         elif language in ("javascript", "typescript"):
-            for ext in (".js", ".jsx", ".ts", ".tsx"):
+            # Longest-first: ``"util.mts".endswith(".ts")`` is True, so a
+            # shortest-first scan registers ``util.mts`` as module ``util.m``.
+            for ext in JS_TS_MODULE_EXTS_LONGEST_FIRST:
                 if parts.endswith(ext):
                     ext_len = len(ext)
                     mod = parts[:-ext_len].replace("/", ".")

--- a/tree_sitter_analyzer/import_graph.py
+++ b/tree_sitter_analyzer/import_graph.py
@@ -21,6 +21,8 @@ import re
 from dataclasses import dataclass, field
 from typing import Any
 
+from .constants import JS_TS_INDEX_SUFFIXES, JS_TS_MODULE_EXTS
+
 logger = logging.getLogger(__name__)
 
 _PY_FROM_IMPORT_RE = re.compile(r"^from\s+(?P<module>[a-zA-Z_][\w.]*)(?:\s+import\s+)")
@@ -260,7 +262,7 @@ def _resolve_js_import(
     req_path = m.group("path")
     candidate = os.path.normpath(os.path.join(src_dir, req_path))
 
-    for suffix in ("", ".js", ".ts", ".jsx", ".tsx", "/index.js", "/index.ts"):
+    for suffix in ("", *JS_TS_MODULE_EXTS, *JS_TS_INDEX_SUFFIXES):
         test = candidate + suffix
         test = os.path.normpath(test)
         if test in project_files:

--- a/tree_sitter_analyzer/import_graph.py
+++ b/tree_sitter_analyzer/import_graph.py
@@ -21,7 +21,12 @@ import re
 from dataclasses import dataclass, field
 from typing import Any
 
-from .constants import JS_TS_INDEX_SUFFIXES, JS_TS_MODULE_EXTS
+from .constants import (
+    JS_TS_INDEX_SUFFIXES,
+    JS_TS_LANGUAGES,
+    JS_TS_MODULE_EXTS,
+)
+from .languages.lang_extension_map import EXT_TO_LANG
 
 logger = logging.getLogger(__name__)
 
@@ -180,6 +185,27 @@ class ImportGraphResult:
         }
 
 
+def _file_lookup(project_files: set[str]) -> dict[str, str]:
+    """Index ``project_files`` by separator-agnostic key → original key.
+
+    The AST cache stores ``file_path`` POSIX-style (forward slashes) while both
+    resolvers build candidates with ``os.path.join``/``normpath``, which emits
+    backslashes on Windows. The membership test therefore never matched for any
+    project with a subdirectory, so ``ImportGraph`` produced ZERO edges on
+    Windows for both Python and JS/TS. Linux CI could not see it because
+    ``normpath`` is already POSIX there. (Found while writing the public-API
+    end-to-end test for #1312.)
+
+    Values are the ORIGINAL keys so returned edges reference real cache paths.
+    """
+    return {path.replace("\\", "/"): path for path in project_files}
+
+
+def _match_file(candidate: str, lookup: dict[str, str]) -> str | None:
+    """Return the project file matching ``candidate``, ignoring separator style."""
+    return lookup.get(os.path.normpath(candidate).replace("\\", "/"))
+
+
 def _resolve_python_import(
     import_text: str,
     source_file: str,
@@ -187,6 +213,7 @@ def _resolve_python_import(
     project_root: str,
 ) -> str | None:
     """Resolve a Python import statement to a project-relative file path."""
+    lookup = _file_lookup(project_files)
     rel_src = (
         os.path.relpath(source_file, project_root)
         if os.path.isabs(source_file)
@@ -207,14 +234,10 @@ def _resolve_python_import(
                 test = candidate + os.sep + "__init__.py"
             else:
                 test = candidate + suffix
-            test = os.path.normpath(test)
-            if test in project_files:
-                return test
-        test_pkg = os.path.join(candidate, "__init__.py")
-        test_pkg = os.path.normpath(test_pkg)
-        if test_pkg in project_files:
-            return test_pkg
-        return None
+            hit = _match_file(test, lookup)
+            if hit is not None:
+                return hit
+        return _match_file(os.path.join(candidate, "__init__.py"), lookup)
 
     m = _PY_FROM_IMPORT_RE.match(import_text)
     if not m:
@@ -228,17 +251,11 @@ def _resolve_python_import(
         return None
 
     parts = module.split(".")
-    candidate = os.path.join(*parts) + ".py"
-    candidate = os.path.normpath(candidate)
-    if candidate in project_files:
-        return candidate
+    hit = _match_file(os.path.join(*parts) + ".py", lookup)
+    if hit is not None:
+        return hit
 
-    candidate_pkg = os.path.join(*parts, "__init__.py")
-    candidate_pkg = os.path.normpath(candidate_pkg)
-    if candidate_pkg in project_files:
-        return candidate_pkg
-
-    return None
+    return _match_file(os.path.join(*parts, "__init__.py"), lookup)
 
 
 def _resolve_js_import(
@@ -262,11 +279,11 @@ def _resolve_js_import(
     req_path = m.group("path")
     candidate = os.path.normpath(os.path.join(src_dir, req_path))
 
+    lookup = _file_lookup(project_files)
     for suffix in ("", *JS_TS_MODULE_EXTS, *JS_TS_INDEX_SUFFIXES):
-        test = candidate + suffix
-        test = os.path.normpath(test)
-        if test in project_files:
-            return test
+        hit = _match_file(candidate + suffix, lookup)
+        if hit is not None:
+            return hit
     return None
 
 
@@ -331,6 +348,27 @@ class ImportGraph:
         return self._make_result()
 
     def _resolve_import(self, import_text: str, source_file: str) -> str | None:
+        """Route an import statement to the resolver for its SOURCE language.
+
+        Dispatch is on the source file's language, never on the statement text.
+        ``import `` is ambiguous — it opens both a Python import and an ESM
+        import — so a text-prefix check sent every ESM statement
+        (``import { run } from './util'``) to the Python resolver, and the JS
+        branch was reachable only via ``require(...)``. That made the JS
+        extension probe dead code for exactly the .mjs/.mts files it exists
+        to serve. (Codex review on #1312.)
+        """
+        language = EXT_TO_LANG.get(os.path.splitext(source_file)[1].lower(), "")
+        if language in JS_TS_LANGUAGES:
+            return _resolve_js_import(
+                import_text, source_file, self._project_files, self.project_root
+            )
+        if language == "python":
+            return _resolve_python_import(
+                import_text, source_file, self._project_files, self.project_root
+            )
+        # Unknown/unmapped extension — fall back to the historical text sniff
+        # so languages without an entry in EXT_TO_LANG keep resolving.
         if import_text.startswith("from ") or import_text.startswith("import "):
             return _resolve_python_import(
                 import_text, source_file, self._project_files, self.project_root

--- a/tree_sitter_analyzer/mcp/tools/nav_facade.py
+++ b/tree_sitter_analyzer/mcp/tools/nav_facade.py
@@ -46,6 +46,7 @@ from __future__ import annotations
 from typing import Any
 
 from ... import read_existing_access as read_access
+from ...constants import JS_TS_MODULE_EXTS
 from .facade_tool import FacadeTool
 
 # RFC-0014 Phase B: cap for test_map test_functions list (matches _MAX_LISTED).
@@ -157,7 +158,7 @@ def _is_collectible_caller(file_path: str, name: str, language: str = "") -> boo
     if lang == "go" or file_path.endswith(".go"):
         return _is_go_test_func(name)
     if lang in ("javascript", "typescript", "js", "ts", "jsx", "tsx") or (
-        file_path.endswith((".js", ".ts", ".jsx", ".tsx", ".mjs", ".cjs"))
+        file_path.endswith(JS_TS_MODULE_EXTS)
     ):
         return _is_js_test_func(name)
     if lang == "java" or file_path.endswith(".java"):

--- a/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
@@ -788,11 +788,20 @@ def _extract_import_specs(source: str, suffix: str) -> set[str]:
         specs.update(re.findall(r"\bfrom\s+['\"]([^'\"]+)['\"]", source))
         specs.update(re.findall(r"\bimport\s*['\"]([^'\"]+)['\"]", source))
         specs.update(re.findall(r"\brequire\(\s*['\"]([^'\"]+)['\"]\s*\)", source))
+        # The closing quote MUST be followed by the call's ``)`` or the ``,``
+        # that introduces the import-options object (``import(spec, {with:…})``).
+        # Without that anchor, ``import("./dev.js" + suffix)`` recorded the
+        # literal prefix ``./dev.js`` as if it were the whole runtime
+        # specifier — inventing an edge to a module that is never loaded while
+        # omitting the one that actually is. A computed specifier is unknowable
+        # statically, so it must contribute no spec at all.
         specs.update(
             match.group(2)
-            for match in re.finditer(r"\bimport\s*\(\s*(['\"])([^'\"]+)\1", source)
+            for match in re.finditer(
+                r"\bimport\s*\(\s*(['\"])([^'\"]+)\1\s*[,)]", source
+            )
         )
-        specs.update(re.findall(r"\bimport\s*\(\s*`([^`$]+)`", source))
+        specs.update(re.findall(r"\bimport\s*\(\s*`([^`$]+)`\s*[,)]", source))
     elif suffix == ".java":
         specs.update(re.findall(r"^\s*import\s+([\w.]+);", source, re.M))
     return specs

--- a/tree_sitter_analyzer/project_graph.py
+++ b/tree_sitter_analyzer/project_graph.py
@@ -16,7 +16,12 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any
 
-from .constants import EXCLUDE_DIRS
+from .constants import (
+    EXCLUDE_DIRS,
+    GRAPH_SOURCE_EXTS,
+    JS_TS_INDEX_SUFFIXES,
+    JS_TS_MODULE_EXTS,
+)
 from .core.parser import Parser, ParseResult
 from .import_extractors import (
     walk_imports,
@@ -250,22 +255,7 @@ def _resolve_js_ts_import(
     if not is_relative:
         return None
     candidate_raw = _project_rel_join(source_rel, module)
-    for ext in (
-        ".js",
-        ".ts",
-        ".jsx",
-        ".tsx",
-        ".mjs",
-        ".cjs",
-        ".mts",
-        ".cts",
-        "/index.js",
-        "/index.ts",
-        "/index.mjs",
-        "/index.cjs",
-        "/index.mts",
-        "/index.cts",
-    ):
+    for ext in (*JS_TS_MODULE_EXTS, *JS_TS_INDEX_SUFFIXES):
         candidate = candidate_raw + ext
         if candidate in nodes:
             return candidate
@@ -458,27 +448,9 @@ class DependencyGraph:
 
     def _build(self) -> None:
         """Scan project directory and build the dependency graph."""
-        supported_exts = {
-            ".py",
-            ".js",
-            ".mjs",
-            ".cjs",
-            ".ts",
-            ".jsx",
-            ".tsx",
-            ".mts",
-            ".cts",
-            ".java",
-            ".go",
-            ".rs",
-            ".c",
-            ".cpp",
-            ".cc",
-            ".cxx",
-            ".h",
-            ".hpp",
-            ".hxx",
-        }
+        # Shared with cache/fingerprint.py — the fingerprint is this graph's
+        # staleness signal, so the two sets must never drift.
+        supported_exts = set(GRAPH_SOURCE_EXTS)
 
         # Collect all source files (excluding generated/dependency dirs)
         all_files = self._iter_source_files(supported_exts)


### PR DESCRIPTION
Stacked on #1311 (`feature/loader-projection-fail-closed`), itself stacked on #1308. Target will be retargeted to `develop` with the rest of the stack.

Two independent changes, in order of importance. The first was found while building an honest end-to-end test for the second, and is much larger than the work that uncovered it.

---

# 1. Windows: import edges never resolved across a subdirectory (P2, pre-existing)

**This was not introduced by this PR.** It has been shipping. It is fixed here because the public-API test for part 2 could not pass without it.

**Root cause, one sentence:** the AST cache keys `file_path` POSIX-style (forward slashes), while both resolvers in `import_graph.py` built candidate paths with `os.path.join`/`os.path.normpath` — which emits **backslashes on Windows** — so the `candidate in project_files` membership test could never match once a path contained a separator.

**Blast radius:**

- **Language-independent.** Python is affected identically to JS/TS — this is not a Node-suffix issue.
- **Any project with a subdirectory.** Flat, root-level imports resolved fine (no separator to mismatch), which is exactly why it hid: the existing fixtures are flat (`a.py` → `b.py`).
- Since essentially every real project has subdirectories, **the import graph has been effectively empty for Windows users**, and `health action=imports`, cycle detection, and cross-file resolution all inherited it.
- **Invisible on Linux CI** — `normpath` already produces POSIX separators there, so every axis stayed green.

**Measured on a real `ASTCache` index, before → after:**

| fixture | before | after |
|---|---|---|
| nested `.mts` ESM (`src/app.mts` → `src/util.mts`) | **0 edges** | 1 |
| nested `.cjs` require (`src/legacy.cjs` → `src/helper.cjs`) | **0** | 1 |
| nested `.js` ESM (`src/app.js` → `src/util.js`) | **0** | 1 |
| nested Python (`pkg/a.py` → `pkg/b.py`) | **0** | 1 |
| flat Python (`a.py` → `b.py`) | 1 | 1 (unchanged) |

Independently reproduced by the reviewer on clean `develop` with a separate fixture: `edge_count=1` on develop (flat resolves, nested does not) vs `edge_count=2` with this PR.

**Fix:** `_file_lookup()` indexes `project_files` by a separator-agnostic key, and `_match_file()` probes through it. Values are the **original** cache keys, so returned edges still reference real paths. Both `_resolve_python_import` and `_resolve_js_import` now go through it.

## How this was missed

The existing tests called the private resolver helpers (`_resolve_js_import`, `_resolve_python_import`) directly, passing path sets the test itself had constructed. They proved **the helpers worked**; nothing proved the **public path** did, or that the helpers were ever reached with production-shaped data. My own first-round tests repeated the mistake in a sharper form — I keyed the fake-cache fixture with `_np()`, normalising the fixture *to the implementation* instead of to production, which masked the separator mismatch completely.

What I added: **public-API tests that drive `ImportGraph.build()` and `CrossFileResolver.build()` against a real `ASTCache` index**, with POSIX keys as the real cache emits them — no fake cache, no path massaging. `test_build_over_real_indexed_mts_project_produces_edge` and `test_build_over_real_indexed_nested_python_produces_edge` exist specifically so this cannot silently return to zero. Same failure shape as CLAUDE.md §11: a conformance test on a private helper cannot notice that the helper is never called.

---

# 2. Node module suffixes (`.mjs`/`.cjs`/`.mts`/`.cts`) missing from the graph fingerprint and four resolvers

`#1308` taught `project_graph.py` to resolve the four Node module suffixes. Five other hand-maintained suffix tables did not get the memo.

### 2a — P1: stale graph cache

`cache/fingerprint.py` `_SOURCE_EXTS` listed 16 extensions and **none** of the four. `compute_graph_fingerprint` returns `(file_count, max_mtime_ns)` scanned over that list only, so adding, removing or editing a `.mjs` file changed **neither** component. The fingerprint compared equal, `DependencyAnalysisTool._get_graph()` and `DependencyGraph._cache_key_for()` saw no change, and a **stale graph was reused** — dependency and blast-radius answers stayed wrong until an unrelated recognized file changed or the process restarted.

### 2b — P2: dropped import edges in four resolvers

| Location | Was | Problem |
|---|---|---|
| `import_graph.py:265` | `("", ".js", ".ts", ".jsx", ".tsx", "/index.js", "/index.ts")` | `./util` never probed `util.mts` |
| `call_graph.py:277`, `:286` | `("", ".py", ".js", ".ts", ".jsx", ".tsx")` | same, both branches |
| `cross_file_resolver.py:276` | `(".js", ".jsx", ".ts", ".tsx")` | **worse than a miss** — it *strips* the extension, and `"util.mts".endswith(".ts")` is `True`, so shortest-first registered `util.mts` under the mangled name `util.m`. Now longest-first. |
| `cross_file_resolver.py:440` | `("", ".py", ".js", ".ts", "/__init__.py")` | the **lookup** side. Registration stored `src/util.mts` correctly and this never found it. Now selected by the importing file's language, kept as **two disjoint lists** — a Python file must not probe `.mts`, a `.mts` file must not probe `__init__.py`. |

### 2c — P2: the dispatch made the JS probe unreachable for ESM

`import_graph.py` `_resolve_import` routed on a **text prefix**. `import { run } from './util'` starts with `import `, so every ESM statement went to the **Python** resolver and only `require(...)` ever reached the JS branch. The suffix table fixed in 2b was therefore **dead code for exactly the `.mjs`/`.mts` files this PR exists to serve.**

Dispatch is now on the **source file's language** via `EXT_TO_LANG`. `import ` is ambiguous between Python and ESM and that ambiguity was the root cause; the old text sniff survives only as a fallback for extensions absent from `EXT_TO_LANG`, so unmapped languages don't regress.

### 2d — P2: dynamic-import regex accepted a literal prefix of a computed specifier

`safe_to_edit_helpers.py` matched `import("./dev.js" + suffix)` and recorded `./dev.js` as if it were the complete runtime specifier — **inventing an edge to a module that is never loaded while omitting the one that actually is.** The template-literal branch had the same hole (`` [^`$]+ `` blocks `${...}` interpolation but not `` `./dev.js` + s ``). Both now require the closing delimiter to be followed by `,` (legal import options: `import(spec, { with: { type: "json" } })`) or the call's `)`.

**Decision:** a computed specifier yields **no spec at all**, not a different one. The runtime target is unknowable statically; recording nothing is a known-unknown, whereas recording the prefix is an actively wrong edge that *also* hides the real one.

---

# 3. Structural: five copies of the extension list collapsed into one derived constant

The root cause of every part-2 bug was the same — the extension surface was duplicated across five files and the copies drifted. `tree_sitter_analyzer/constants.py` now owns it:

| Constant | Purpose |
|---|---|
| `JS_TS_MODULE_EXTS` | the 8 JS/TS module extensions in **probe** order (plain first, so `./util` still prefers `util.js` over `util.mjs` — existing precedence unchanged) |
| `JS_TS_INDEX_SUFFIXES` | **derived** `/index.<ext>` forms |
| `JS_TS_MODULE_EXTS_LONGEST_FIRST` | **derived**, longest-first, for the call sites that *strip* rather than append |
| `JS_TS_LANGUAGES` | `EXT_TO_LANG` language names sharing the Node module system, for language-based dispatch |
| `GRAPH_SOURCE_EXTS` | full graph source surface, now shared by `fingerprint.py` and `project_graph.py` so the fingerprint can never again ignore an extension the graph indexes |

`LONGEST_FIRST` is deliberately kept separate rather than collapsed: append-probe and strip semantics need opposite orders, and merging them is what produced the `util.m` bug. A comment at each site says why.

---

## Audit method — corrected mid-review

My first report claimed "no additional incomplete suffix tables" after grepping for `.mjs/.cjs/.mts/.cts`. **That method cannot find a table that lacks those suffixes** — it only finds the ones already correct. It missed `cross_file_resolver.py:440` entirely.

Re-audited by **shape**: every tuple/list/set literal containing ≥2 dotted extensions across the whole package — 26 JS/TS-family hits, each given an explicit verdict.

- **4 needed the suffixes → fixed here**, including `nav_facade.py:160` which listed `.mjs`/`.cjs` but not `.mts`/`.cts`.
- **7 correctly do NOT need them** (by-design partitions: the JS plugin owns `.mjs`/`.cjs` while the TS plugin owns `.mts`/`.cts`; JSX detection, since `.mts` cannot contain JSX; the deliberate allowJs set). Two of these were **false positives of my own detector**, which reports at line granularity and split dicts that are complete as a whole — every hit needed a human verdict.
- **8 genuinely incomplete but a different cluster → deliberately NOT fixed here.** `middleware_detector`, `test_gap_analyzer`, `query_symbol_search`, `symbol_lineage_tool`, `trace_impact_tool`, `_codegraph_explore_helpers`, `gitignore_detector`, `_typescript_formatter_signatures_table`. These are "which files count as source?" inventory sets, not import resolvers. This is a **real shipping gap, not theoretical**; it is filed as a separate focused follow-up rather than turning a resolver PR into a 14-file cross-cutting diff.

---

## Files changed (13 across two commits)

| File | Why |
|---|---|
| `import_graph.py` | separator fix (§1), language dispatch (§2c), suffix probe (§2b) |
| `cross_file_resolver.py` | registration strip order + lookup probe (§2b) |
| `cache/fingerprint.py` | stale-cache fix (§2a) |
| `project_graph.py` | both tables now use the shared constants |
| `call_graph.py` | suffix probe, both branches (§2b) |
| `mcp/tools/utils/safe_to_edit_helpers.py` | dynamic-import regex (§2d) |
| `mcp/tools/nav_facade.py` | missing `.mts`/`.cts` |
| `constants.py` | the shared constants (§3) |
| 5 existing test files | 30 new tests — **no new test files** (T-1) |

### Behavior expansions worth flagging

- `project_graph` gains `/index.jsx` and `/index.tsx` probes (its index list previously skipped those two while listing the other six). Additive only.
- `import_graph` gains `/index.*` forms for all 8 extensions (previously only `.js`/`.ts`). Additive only.

## Answers to the review questions

**`typescript_plugin/plugin.py:41` — verified, NO change needed.** It already returns `['.ts','.tsx','.d.ts','.mts','.cts']`, and `JavaScriptPlugin` already returns `.mjs`/`.cjs`. `EXT_TO_LANG` and `detect_language_from_file` map all four. The plugin surface was never the gap; the graph/resolver tables were.

**Template-literal variant — same hole, fixed.** See §2d.

## Verification

- **RED first:** 30 new tests, **26 fail** on the relevant parent commit (20 of the 23 from commit 1, 6 of the 7 from commit 2). The 4 that pass on both are deliberate guards — they pin that the tightened dynamic-import regex still accepts legitimate specifiers, and that language-based dispatch did not break Python. The load-bearing ones go through the public API against a real index.
- Emitted `--change-impact` focused command → **184 passed, 3 skipped**
- `uv run ruff check .` → **All checks passed!**
- `uv run mypy tree_sitter_analyzer/` → **23 errors** = the baseline re-measured by stashing (not 24)
- `uv run pre-commit run --files <changed>` → **every hook Passed** (mypy, bandit, Weak Assertion Ratchet, T-1 banned names)
- `uv run pytest -q` → 14 failures, the **same 14 files** as the base commit (`test_collect_no1_006b_baseline`, `test_fresh_install_qualification`, `test_outdated_uv_qualification`, `test_ast_cache`, `test_codegraph_context_tool`) — pre-existing, unrelated
- **E2E dogfood:** `src/app.mts → src/util.mts` and `src/legacy.cjs → src/helper.cjs` both present; `CrossFileResolver` binds `run → src/util.mts`

Repo rules honored: no new test files (T-1), exact assertions only, one behavior per test, `fix:` prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
