### PR TITLE
fix: repair the red CI baseline on develop (windows + macOS axes)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -133,6 +133,18 @@ repos:
         files: ^tests/.*\.py$
         stages: [pre-commit]
 
+      # A test that reads text without encoding= inherits the runner's locale:
+      # green on UTF-8 CI, UnicodeDecodeError on a cp932/latin-1 box, where the
+      # decode error MASKS the assertion. Baseline 2267 is grandfathered; this
+      # only blocks newly added lines. Measure: --baseline.
+      - id: test-encoding-ratchet
+        name: Test Encoding Ratchet
+        entry: uv run python scripts/check_test_encoding.py --staged
+        language: system
+        pass_filenames: false
+        files: ^tests/.*\.py$
+        stages: [pre-commit]
+
       - id: workflow-consistency-tests
         name: Workflow Consistency Tests
         entry: uv run pytest tests/integration/workflows/test_workflow_properties.py -v --tb=short

--- a/scripts/check_test_encoding.py
+++ b/scripts/check_test_encoding.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Block new locale-dependent text I/O in tests (encoding ratchet).
+
+Why this exists
+---------------
+A test that opens a text file without an explicit ``encoding`` inherits the
+*runner's* locale. On a UTF-8 runner it passes; on a cp932 / latin-1 runner it
+raises ``UnicodeDecodeError`` — and, worse, that decode error happens on the
+line that was supposed to make an assertion, so it **masks the real check**
+instead of reporting it.
+
+Measured 2026-08-19 on a Japanese-locale Windows box against CI-green
+``develop``: 6 failures in ``tests/unit/test_claim_registry.py`` and 5 in
+``tests/contracts/`` were nothing but this, e.g.
+
+    UnicodeDecodeError: 'cp932' codec can't decode byte 0xef in position 0
+
+(0xef at position 0 is the UTF-8 BOM of ``README.md``.) Every one of those test
+ids passes on GitHub's UTF-8 runners, so CI could not see the defect at all,
+and each one cost a developer a stash-and-re-measure cycle to rule out.
+
+Ratchet, not a cleanup
+----------------------
+There are ~2267 pre-existing encoding-unsafe calls across ~326 test files.
+Rewriting them all would be a 300-file diff with no behavioural payoff, so the
+baseline is grandfathered exactly like ``check_loose_assertions.py`` does: this
+checks only lines a commit **adds**. The baseline can shrink opportunistically
+and can never grow.
+
+Usage
+-----
+    python scripts/check_test_encoding.py --staged      # pre-commit
+    python scripts/check_test_encoding.py --diff <ref>  # CI / PR range
+    python scripts/check_test_encoding.py --baseline    # count only, exit 0
+
+Exit codes: 0 = OK (``--baseline`` always 0), 1 = new violations found.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import subprocess  # nosec B404 - git plumbing only, fixed argv
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+TEXT_METHODS = frozenset({"read_text", "write_text"})
+TESTS_DIR = "tests"
+
+
+@dataclass(frozen=True)
+class Violation:
+    path: str
+    line: int
+    call: str
+
+    def render(self) -> str:
+        return f"  {self.path}:{self.line}: {self.call} has no explicit encoding="
+
+
+def _mode_of(node: ast.Call) -> str:
+    """Best-effort literal mode string for an ``open()`` call."""
+    if len(node.args) > 1 and isinstance(node.args[1], ast.Constant):
+        return str(node.args[1].value)
+    for keyword in node.keywords:
+        if keyword.arg == "mode" and isinstance(keyword.value, ast.Constant):
+            return str(keyword.value.value)
+    return ""
+
+
+def _violations_in_source(path: str, source: str) -> list[Violation]:
+    """Find text I/O calls in *source* that do not pin an encoding."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+
+    found: list[Violation] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        keywords = {keyword.arg for keyword in node.keywords}
+        if "encoding" in keywords:
+            continue
+        func = node.func
+        if isinstance(func, ast.Attribute) and func.attr in TEXT_METHODS:
+            found.append(Violation(path, node.lineno, f"{func.attr}()"))
+        elif isinstance(func, ast.Name) and func.id == "open":
+            # Binary mode carries no encoding, so it is always safe.
+            if "b" not in _mode_of(node):
+                found.append(Violation(path, node.lineno, "open()"))
+    return found
+
+
+def _parse_added_line_ranges(diff_text: str) -> dict[str, set[int]]:
+    """Parse ``git diff -U0`` output into added line numbers per new path."""
+    added: dict[str, set[int]] = {}
+    current: str | None = None
+    for line in diff_text.splitlines():
+        if line.startswith("+++ b/"):
+            current = line[6:]
+            added.setdefault(current, set())
+        elif line.startswith("+++ "):
+            current = None  # /dev/null (deletion) or unexpected form
+        elif line.startswith("@@") and current is not None:
+            match = re.search(r"\+(\d+)(?:,(\d+))?", line)
+            if match:
+                start = int(match.group(1))
+                count = int(match.group(2)) if match.group(2) is not None else 1
+                added[current].update(range(start, start + count))
+    return added
+
+
+def _git_diff(extra: list[str]) -> str:
+    result = subprocess.run(  # nosec B603 B607 - fixed argv, no shell
+        ["git", "diff", *extra, "--unified=0", "--diff-filter=AMR", "--", TESTS_DIR],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    return result.stdout
+
+
+def _check_added(added: dict[str, set[int]], label: str) -> int:
+    violations: list[Violation] = []
+    for name, lines in added.items():
+        if not lines or not name.endswith(".py"):
+            continue
+        path = Path(name)
+        if not path.is_file():
+            continue
+        source = path.read_text(encoding="utf-8", errors="replace")
+        violations.extend(
+            found
+            for found in _violations_in_source(name, source)
+            if found.line in lines
+        )
+
+    if not violations:
+        return 0
+
+    print(
+        f"Encoding ratchet: {len(violations)} new locale-dependent text "
+        f"call(s) in the {label}.\n",
+        file=sys.stderr,
+    )
+    for violation in sorted(violations, key=lambda v: (v.path, v.line)):
+        print(violation.render(), file=sys.stderr)
+    print(
+        "\nA text read/write without encoding= inherits the runner's locale, so "
+        "the test\npasses on UTF-8 CI and dies with UnicodeDecodeError on a "
+        "cp932/latin-1 box -\nmasking the assertion it was meant to make. Pass "
+        'encoding="utf-8" explicitly\n(or use read_bytes()/write_bytes() if the '
+        "payload is genuinely binary).",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def baseline_violations(tests_dir: Path) -> list[Violation]:
+    """Every encoding-unsafe text call under *tests_dir* (grandfathered)."""
+    found: list[Violation] = []
+    for path in sorted(tests_dir.rglob("*.py")):
+        source = path.read_text(encoding="utf-8", errors="replace")
+        found.extend(_violations_in_source(path.as_posix(), source))
+    return found
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--staged", action="store_true", help="check staged diff")
+    group.add_argument("--diff", metavar="REF", help="check diff against REF")
+    group.add_argument(
+        "--baseline", action="store_true", help="report the grandfathered count"
+    )
+    args = parser.parse_args(argv)
+
+    if args.baseline:
+        violations = baseline_violations(Path(TESTS_DIR))
+        files = {violation.path for violation in violations}
+        print(
+            f"encoding-unsafe text calls in {TESTS_DIR}/: "
+            f"{len(violations)} across {len(files)} files"
+        )
+        return 0
+
+    if args.staged:
+        return _check_added(
+            _parse_added_line_ranges(_git_diff(["--cached"])), "staged diff"
+        )
+    return _check_added(
+        _parse_added_line_ranges(_git_diff([f"{args.diff}...HEAD"])), "PR diff"
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/contracts/test_collect_no1_006b_baseline.py
+++ b/tests/contracts/test_collect_no1_006b_baseline.py
@@ -31,10 +31,10 @@ RFC = REPO / "rfcs/0024-default-dependency-split.md"
 PYPROJECT = REPO / "pyproject.toml"
 
 def baseline() -> dict:
-    return json.loads(BASELINE.read_text())
+    return json.loads(BASELINE.read_text(encoding="utf-8"))
 
 def schema() -> dict:
-    return json.loads(SCHEMA.read_text())
+    return json.loads(SCHEMA.read_text(encoding="utf-8"))
 
 def mutated(path: tuple[str, ...], value: object) -> dict:
     report=copy.deepcopy(baseline()); target=report
@@ -292,7 +292,7 @@ def test_schema_definitions_equal_collector_constants() -> None:
     assert [properties["cli_startup"]["properties"]["definition"]["const"],properties["mcp_startup"]["properties"]["definition"]["const"]] == [collector.CLI_STARTUP_DEFINITION,collector.MCP_STARTUP_DEFINITION]
 
 def test_collect_routes_receipt_through_schema_finalizer() -> None:
-    source=Path(collector.__file__).read_text()
+    source=Path(collector.__file__).read_text(encoding="utf-8")
     assert "finalize_receipt(report,output,repo,schema_blob); return report" in source
 
 def test_finalize_receipt_uses_bound_schema_blob_without_live_read(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -350,7 +350,7 @@ def test_collector_rejects_unbounded_repeat_count(tmp_path: Path, monkeypatch: p
     with pytest.raises(ValueError,match="between 3 and 20"): collector.collect(REPO,tmp_path/"receipt.json",21,collector.EXPECTED_SUBJECT_COMMIT)
 
 def test_rfc_generated_summary_equals_checked_in_receipt() -> None:
-    text=RFC.read_text()
+    text=RFC.read_text(encoding="utf-8")
     generated=text.split("<!-- BEGIN GENERATED RECEIPT SUMMARY -->\n",1)[1].split("\n<!-- END GENERATED RECEIPT SUMMARY -->",1)[0]
     assert generated == collector.render_receipt_summary(baseline())
 
@@ -369,12 +369,12 @@ def test_fresh_clone_can_resolve_and_checkout_collector_commit(tmp_path: Path) -
     assert subprocess.run(["git","rev-parse","HEAD"],cwd=worktree,check=True,capture_output=True,text=True).stdout.strip() == commit
 
 def test_rfc_requires_merge_commit_to_preserve_collector_ancestry() -> None:
-    reproduction=RFC.read_text().split("## Reproduction of the descriptive receipt",1)[1].split("```bash",1)[0]
+    reproduction=RFC.read_text(encoding="utf-8").split("## Reproduction of the descriptive receipt",1)[1].split("```bash",1)[0]
     assert [phrase in reproduction for phrase in ("merge-commit strategy","Squash","rebase merges are prohibited","gh pr merge 1250","--merge")] == [True,True,True,True,True]
 
 def test_rfc_reproduction_command_uses_external_interpreter() -> None:
     # NO1-006B review 2026-08-10: a repo-local ignored venv made the clean gate reject the documented command.
-    reproduction=RFC.read_text().split("## Reproduction of the descriptive receipt",1)[1].split("## Measured macOS E0 receipt",1)[0]
+    reproduction=RFC.read_text(encoding="utf-8").split("## Reproduction of the descriptive receipt",1)[1].split("## Measured macOS E0 receipt",1)[0]
     assert ".venv/bin/python" not in reproduction
     assert 'TOOL_VENV="$RUN_ROOT/collector-tool-venv"' in reproduction
     assert "--only-group no1-006b-collector-tool --no-emit-project" in reproduction
@@ -382,7 +382,7 @@ def test_rfc_reproduction_command_uses_external_interpreter() -> None:
     assert '"$TOOL_PYTHON" "$COLLECTOR/scripts/collect_no1_006b_baseline.py"' in reproduction
 
 def test_collector_tool_group_has_exact_independent_pins() -> None:
-    groups=tomllib.loads(PYPROJECT.read_text())["dependency-groups"]
+    groups=tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))["dependency-groups"]
     assert groups[collector.TOOL_GROUP] == ["hatchling==1.31.0","jsonschema==4.25.1","packaging==25.0"]
 
 def active_tool_inventory(monkeypatch: pytest.MonkeyPatch, rows: list[dict[str,str]]) -> bytes:
@@ -484,7 +484,7 @@ def test_external_interpreter_probe_preserves_clean_ignored_gate(tmp_path: Path)
     commit=subprocess.run(["git","rev-parse","HEAD"],cwd=root,check=True,capture_output=True,text=True).stdout.strip()
     expected={"commit":commit,"script_sha256":collector.digest_bytes(collector.git(root,"show",f"{commit}:scripts/collect_no1_006b_baseline.py")),"schema_sha256":collector.digest_bytes(collector.git(root,"show",f"{commit}:schemas/no1-006b-baseline.schema.json")),"support_sha256":collector.digest_bytes(collector.git(root,"show",f"{commit}:scripts/no1_006b_baseline_support.py")),"tool_lock_sha256":collector.digest_bytes(collector.git(root,"show",f"{commit}:uv.lock")),"tool_export_sha256":"a"*64}
     status=subprocess.run(["git","status","--porcelain=v1","--untracked-files=all","--ignored"],cwd=root,check=True,capture_output=True,text=True).stdout
-    assert json.loads(result.stdout) == [expected,SCHEMA.read_text()]
+    assert json.loads(result.stdout) == [expected,SCHEMA.read_text(encoding="utf-8")]
     assert status == ""
 
 def test_verified_uv_resolves_and_attests_configured_binary(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -507,7 +507,7 @@ def assert_secrets_baseline_preserves_reviewed_base(repo: Path) -> None:
     # PR #1250: rescanning additions must be a union, never delete accepted historical findings.
     subprocess.run(["git","merge-base","--is-ancestor",collector.EXPECTED_SUBJECT_COMMIT,"HEAD"],cwd=repo,check=True)
     reviewed=json.loads(subprocess.run(["git","show",f"{collector.EXPECTED_SUBJECT_COMMIT}:.secrets.baseline"],cwd=repo,check=True,capture_output=True).stdout)
-    current=json.loads((repo/".secrets.baseline").read_text())
+    current=json.loads((repo/".secrets.baseline").read_text(encoding="utf-8"))
     def signatures(data: dict) -> set: return {(filename,row["type"],row["hashed_secret"]) for filename,rows in data["results"].items() for row in rows}
     assert signatures(reviewed).issubset(signatures(current))
 

--- a/tests/governance/test_postmortem_guards.py
+++ b/tests/governance/test_postmortem_guards.py
@@ -453,3 +453,73 @@ def test_readme_counts_match_registry() -> None:
             )
 
     assert failures == [], "README ↔ registry drift:\n  " + "\n  ".join(failures)
+
+
+def test_encoding_ratchet_is_present_and_pre_commit_wired() -> None:
+    """The locale-dependent-text-IO ratchet must stay wired into pre-commit.
+
+    Why: a test that reads text without ``encoding=`` inherits the runner's
+    locale. It is green on GitHub's UTF-8 runners and raises
+    ``UnicodeDecodeError`` on a cp932/latin-1 developer box -- and the decode
+    error lands on the line that was supposed to assert, so it MASKS the real
+    check rather than reporting it. Measured 2026-08-19 against CI-green
+    develop: 6 failures in tests/unit/test_claim_registry.py and 5 in
+    tests/contracts/ were nothing but this. CI structurally cannot see the
+    class, so only a commit-time gate can hold the line.
+    """
+    script = PROJECT_ROOT / "scripts" / "check_test_encoding.py"
+    config = PROJECT_ROOT / ".pre-commit-config.yaml"
+    assert script.exists(), (
+        "scripts/check_test_encoding.py must exist -- it is the only gate that "
+        "sees locale-dependent test I/O, because UTF-8 CI runners never trip it."
+    )
+    config_text = config.read_text(encoding="utf-8")
+    assert "check_test_encoding.py" in config_text, (
+        ".pre-commit-config.yaml must wire scripts/check_test_encoding.py into a "
+        "`repo: local` hook, or the ratchet is a script nobody runs."
+    )
+
+
+def test_real_git_capture_tests_stay_budget_exempt() -> None:
+    """Budget exemption in the capture suite must follow the cost driver.
+
+    Why: tests/unit/test_diff_snapshot_readonly_capture.py holds tests that
+    drive real ``git`` subprocesses -- 7 spawns to build the fixture repo, then
+    BOTH capture backends per assertion. The conftest 5.0s per-test wall-clock
+    budget cannot grade that on a shared runner: the same test measured 5.07s
+    and 6.06s in CI runs 32246819262 and 32256066101 (macos-latest 3.11).
+
+    7 of them had been exempted one at a time, each as it happened to lose the
+    scheduling lottery, which left 39 equally exposed and kept the macOS axis
+    one slow runner away from red. The exemption now follows the ``git_repo``
+    fixture. This guard fails the moment a new git-backed test is added without
+    it -- deterministically, on every platform -- instead of surfacing weeks
+    later as a flake on one axis.
+
+    Tests that do NOT take ``git_repo`` are pure-logic helpers and MUST stay
+    budgeted, so the budget keeps its signal where it can still detect a real
+    regression.
+    """
+    source = (
+        PROJECT_ROOT / "tests" / "unit" / "test_diff_snapshot_readonly_capture.py"
+    ).read_text(encoding="utf-8")
+    missing: list[str] = []
+    over_marked: list[str] = []
+    for node in ast.parse(source).body:
+        if not isinstance(node, ast.FunctionDef) or not node.name.startswith("test_"):
+            continue
+        takes_git_repo = "git_repo" in {arg.arg for arg in node.args.args}
+        decorators = [ast.unparse(deco) for deco in node.decorator_list]
+        exempt = any(
+            "slow_ok" in deco or "GIT_CAPTURE_COST" in deco for deco in decorators
+        )
+        if takes_git_repo and not exempt:
+            missing.append(node.name)
+        elif exempt and not takes_git_repo:
+            over_marked.append(node.name)
+
+    assert (missing, over_marked) == ([], []), (
+        "Budget exemption must track the git_repo fixture exactly.\n"
+        f"  git-backed but still budgeted (add @GIT_CAPTURE_COST): {missing}\n"
+        f"  exempt without paying git cost (drop the marker): {over_marked}"
+    )

--- a/tests/unit/cli/test_constraint_check_execution.py
+++ b/tests/unit/cli/test_constraint_check_execution.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import os
 import sqlite3
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -496,3 +498,68 @@ def test_explicit_config_evidence_rejects_directory(tmp_path):
 
     with pytest.raises(OSError, match="^constraint file is not a regular file$"):
         owner.explicit_config_evidence(tmp_path, float("inf"))
+
+
+def _ctime_variant(info, delta):
+    return SimpleNamespace(
+        st_dev=info.st_dev,
+        st_ino=info.st_ino,
+        st_mode=info.st_mode,
+        st_size=info.st_size,
+        st_mtime_ns=info.st_mtime_ns,
+        st_ctime_ns=info.st_ctime_ns + delta,
+        st_file_attributes=getattr(info, "st_file_attributes", 0),
+    )
+
+
+@pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="st_ctime is creation time only on Windows; POSIX ctime is asserted below",
+)
+def test_identity_ignores_creation_time_on_windows(tmp_path):
+    # CI develop 32256066101 (windows-latest, 3.12): os.stat(path) and
+    # os.fstat(fd) disagree on st_ctime_ns for ~9% of freshly created files,
+    # so projecting it made unmutated configs read as CONSTRAINT_CONFIG_CHANGED.
+    import tree_sitter_analyzer.cli.commands.constraint_check_execution as owner
+
+    config = tmp_path / "rules.yml"
+    config.write_bytes(b"version: 1\n")
+    info = config.stat()
+
+    assert owner._identity(_ctime_variant(info, 1)) == owner._identity(info)
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX-only: st_ctime is inode change time and must stay projected",
+)
+def test_identity_honors_inode_change_time_on_posix(tmp_path):
+    # The Windows carve-out above must not weaken POSIX, where st_ctime is the
+    # inode change time and therefore a real mutation signal.
+    import tree_sitter_analyzer.cli.commands.constraint_check_execution as owner
+
+    config = tmp_path / "rules.yml"
+    config.write_bytes(b"version: 1\n")
+    info = config.stat()
+
+    assert owner._identity(_ctime_variant(info, 1)) != owner._identity(info)
+
+
+def test_identity_is_stable_across_path_stat_and_handle_fstat(tmp_path):
+    # CI develop 32256066101: the line-39/line-54 checks compare a path stat
+    # against a handle fstat, so every projected field must agree across both
+    # APIs for an untouched file. 300 trials because the Windows divergence
+    # reproduced in only ~9% of them.
+    import tree_sitter_analyzer.cli.commands.constraint_check_execution as owner
+
+    mismatches = []
+    for index in range(300):
+        config = tmp_path / f"rules{index}.yml"
+        config.write_bytes(b"version: 1\n")
+        path_identity = owner._identity(config.stat(follow_symlinks=False))
+        with config.open("rb", buffering=0) as stream:
+            handle_identity = owner._identity(os.fstat(stream.fileno()))
+        if path_identity != handle_identity:
+            mismatches.append((index, path_identity, handle_identity))
+
+    assert mismatches == []

--- a/tests/unit/cli/test_constraint_check_execution.py
+++ b/tests/unit/cli/test_constraint_check_execution.py
@@ -514,7 +514,12 @@ def _ctime_variant(info, delta):
 
 @pytest.mark.skipif(
     sys.platform != "win32",
-    reason="st_ctime is creation time only on Windows; POSIX ctime is asserted below",
+    reason=(
+        "tracked: CI run 32256066101 (windows 3.12). st_ctime is creation time only "
+        "on Windows; the POSIX half of this contract is asserted by "
+        "test_identity_honors_inode_change_time_on_posix, so neither platform is "
+        "left unasserted."
+    ),
 )
 def test_identity_ignores_creation_time_on_windows(tmp_path):
     # CI develop 32256066101 (windows-latest, 3.12): os.stat(path) and
@@ -531,7 +536,11 @@ def test_identity_ignores_creation_time_on_windows(tmp_path):
 
 @pytest.mark.skipif(
     sys.platform == "win32",
-    reason="POSIX-only: st_ctime is inode change time and must stay projected",
+    reason=(
+        "tracked: CI run 32256066101 (windows 3.12). POSIX-only half of the ctime "
+        "contract: st_ctime is inode change time here and must stay projected. The "
+        "Windows half is asserted by test_identity_ignores_creation_time_on_windows."
+    ),
 )
 def test_identity_honors_inode_change_time_on_posix(tmp_path):
     # The Windows carve-out above must not weaken POSIX, where st_ctime is the

--- a/tests/unit/test_claim_registry.py
+++ b/tests/unit/test_claim_registry.py
@@ -30,7 +30,7 @@ EMPTY_CLAIMS = (
 
 @pytest.fixture
 def schema():
-    return json.loads(SCHEMA_PATH.read_text())
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
 
 @pytest.fixture
 def blocked_verdict():
@@ -205,7 +205,7 @@ def test_permissive_override_cannot_bypass_measurement_invariant(tmp_path, claim
 def test_e4_context_must_be_independently_bound(tmp_path, schema, claim_factory, manifest, field):
     claim = claim_factory("E4")
     synchronize_e4_artifact(claim, tmp_path)
-    evidence = json.loads((tmp_path / "evidence.json").read_text())
+    evidence = json.loads((tmp_path / "evidence.json").read_text(encoding="utf-8"))
     evidence[manifest][field] = [] if field == "repositories" else "wrong"
     (tmp_path / "evidence.json").write_bytes(canonical_json_bytes(evidence))
     claim["artifact"]["sha256"] = hashlib.sha256((tmp_path / "evidence.json").read_bytes()).hexdigest()
@@ -278,7 +278,7 @@ def test_nonfinite_measurement_fails_closed(tmp_path, schema, claim_factory, mea
 @pytest.mark.parametrize("readme", ("README.md", "README_ja.md", "README_zh.md"))
 def test_readme_claim_section_and_whole_document_coverage_are_current(readme):
     verdict = load_and_validate(ROOT / "benchmarks/codegraph_compare/claim_registry.json", schema_path=SCHEMA_PATH)
-    assert readme_claim_violations((ROOT / readme).read_text(), verdict) == ()
+    assert readme_claim_violations((ROOT / readme).read_text(encoding="utf-8"), verdict) == ()
 
 @pytest.mark.parametrize(("readme", "probe"), (
     ("README.md", "TSA processes hundreds of files."),
@@ -287,7 +287,7 @@ def test_readme_claim_section_and_whole_document_coverage_are_current(readme):
 ))
 def test_each_public_readme_scan_rejects_localized_unregistered_claim(readme, probe):
     verdict = load_and_validate(ROOT / "benchmarks/codegraph_compare/claim_registry.json", schema_path=SCHEMA_PATH)
-    text = probe + "\n" + (ROOT / readme).read_text()
+    text = probe + "\n" + (ROOT / readme).read_text(encoding="utf-8")
     assert readme_claim_violations(text, verdict) == ("README_UNREGISTERED_QUANTITATIVE_CLAIM:1",)
 
 def test_readme_generated_claim_drift_is_rejected(blocked_verdict, readme_fixture):
@@ -319,7 +319,7 @@ def test_mixed_e4_and_e3_registry_emits_nothing(tmp_path, schema, claim_factory)
     e4["artifact"]["path"] = "e4.json"
     e3 = claim_factory("E3")
     e3["claim_id"] = "fixture-e3"
-    evidence = json.loads((tmp_path / "evidence.json").read_text())
+    evidence = json.loads((tmp_path / "evidence.json").read_text(encoding="utf-8"))
     evidence["claim"]["claim_id"] = "fixture-e3"
     (tmp_path / "e3.json").write_bytes(canonical_json_bytes(evidence))
     e3["artifact"] = {"path": "e3.json", "sha256": hashlib.sha256((tmp_path / "e3.json").read_bytes()).hexdigest()}

--- a/tests/unit/test_diff_snapshot_readonly_capture.py
+++ b/tests/unit/test_diff_snapshot_readonly_capture.py
@@ -35,6 +35,21 @@ from tree_sitter_analyzer.source_oracle_git import GitEpoch, oracle_generation
 
 _BUDGET = 64 * 1024 * 1024
 
+# Every test taking the ``git_repo`` fixture pays real `git` subprocess cost:
+# 7 spawns to build the fixture repo, then ``_assert_equal_payloads`` drives
+# BOTH capture backends (frozen + zero-write) over that repo. That is
+# git-integration cost, not unit-perf signal, so the conftest per-test
+# wall-clock budget cannot say anything useful about it — on a shared runner
+# the same test measured 5.07s and 6.06s against a 5.0s ceiling
+# (CI develop runs 32246819262 and 32256066101, macos-latest 3.11).
+#
+# 7 of these were already exempted one-at-a-time as each happened to trip the
+# budget on some runner; 35 more were still unmarked and equally exposed. The
+# marker now follows the cost driver (the fixture) instead of whichever test
+# lost the scheduling lottery. The 10 tests in this file that do NOT take
+# ``git_repo`` are pure-logic helpers and stay fully budgeted.
+GIT_CAPTURE_COST = pytest.mark.slow_ok
+
 
 @pytest.fixture()
 def git_repo(tmp_path) -> str:
@@ -107,12 +122,14 @@ def test_clean_repo_payloads_match(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_dirty_payloads_match(git_repo: str) -> None:
     Path(git_repo, "base.py").write_text("value = 2\nline2\n", encoding="utf-8")
     _assert_equal_payloads(git_repo, "diff", 1)
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_untracked_text_and_dirty_payloads_match(git_repo: str) -> None:
     Path(git_repo, "base.py").write_text("value = 3\n", encoding="utf-8")
     Path(git_repo, "new.py").write_text("brand = 'new'\n", encoding="utf-8")
@@ -123,12 +140,14 @@ def test_untracked_text_and_dirty_payloads_match(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_deleted_payloads_match(git_repo: str) -> None:
     Path(git_repo, "keep.py").unlink()
     _assert_equal_payloads(git_repo, "diff", 1)
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_untracked_executable_payloads_match(git_repo: str) -> None:
     script = Path(git_repo, "run.sh")
     script.write_text("#!/bin/sh\necho hi\n", encoding="utf-8")
@@ -137,30 +156,35 @@ def test_untracked_executable_payloads_match(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_untracked_no_newline_payloads_match(git_repo: str) -> None:
     Path(git_repo, "nonl.txt").write_bytes(b"no-newline")
     _assert_equal_payloads(git_repo, "diff", 1)
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_untracked_binary_payloads_match(git_repo: str) -> None:
     Path(git_repo, "bin.dat").write_bytes(b"\x00\x01\x02\x03binary\x00")
     _assert_equal_payloads(git_repo, "diff", 1)
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_untracked_symlink_payloads_match(git_repo: str) -> None:
     os.symlink("base.py", os.path.join(git_repo, "link.py"))
     _assert_equal_payloads(git_repo, "diff", 1)
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_exact_worktree_rename_payloads_match(git_repo: str) -> None:
     os.rename(os.path.join(git_repo, "base.py"), os.path.join(git_repo, "moved.py"))
     _assert_equal_payloads(git_repo, "diff", 1)
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_rename_plus_dirty_payloads_match(git_repo: str) -> None:
     os.rename(os.path.join(git_repo, "base.py"), os.path.join(git_repo, "moved.py"))
     Path(git_repo, "keep.py").write_text("keep = 2\n", encoding="utf-8")
@@ -168,6 +192,7 @@ def test_rename_plus_dirty_payloads_match(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_staged_add_payloads_match(git_repo: str) -> None:
     Path(git_repo, "staged.py").write_text("s = 1\n", encoding="utf-8")
     subprocess.run(["git", "-C", git_repo, "add", "staged.py"], check=True)
@@ -177,6 +202,7 @@ def test_staged_add_payloads_match(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_staged_rename_payloads_match(git_repo: str) -> None:
     Path(git_repo, "base.py").write_text("value = 9\n", encoding="utf-8")
     subprocess.run(["git", "-C", git_repo, "add", "base.py"], check=True)
@@ -185,6 +211,7 @@ def test_staged_rename_payloads_match(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_double_dirty_payloads_match(git_repo: str) -> None:
     Path(git_repo, "base.py").write_text("value = 5\n", encoding="utf-8")
     subprocess.run(["git", "-C", git_repo, "add", "base.py"], check=True)
@@ -193,6 +220,7 @@ def test_double_dirty_payloads_match(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_modified_worktree_move_surfaces_delete_plus_add(git_repo: str) -> None:
     """Documented divergence: an inexact move is D+A, never a fake R."""
     Path(git_repo, "base.py").write_text("value = 1\n", encoding="utf-8")
@@ -220,6 +248,7 @@ def test_modified_worktree_move_surfaces_delete_plus_add(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_conversion_guard_fails_closed_on_autocrlf(git_repo: str) -> None:
     subprocess.run(
         ["git", "-C", git_repo, "config", "core.autocrlf", "true"], check=True
@@ -230,6 +259,7 @@ def test_conversion_guard_fails_closed_on_autocrlf(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_conversion_guard_passes_without_crlf(git_repo: str) -> None:
     subprocess.run(
         ["git", "-C", git_repo, "config", "core.autocrlf", "true"], check=True
@@ -239,6 +269,7 @@ def test_conversion_guard_passes_without_crlf(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_conversion_guard_fails_closed_on_eol_attribute(git_repo: str) -> None:
     Path(git_repo, ".gitattributes").write_text(
         "base.py text eol=crlf\n", encoding="utf-8"
@@ -249,6 +280,7 @@ def test_conversion_guard_fails_closed_on_eol_attribute(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_capture_never_materializes_temporary_index(
     git_repo: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -306,6 +338,7 @@ def test_capture_never_materializes_temporary_index(
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_no_index_patch_accepts_exit_one(git_repo: str) -> None:
     Path(git_repo, "brand-new.py").write_text("x = 1\n", encoding="utf-8")
     patch = _no_index_new_file_patch(
@@ -318,6 +351,7 @@ def test_no_index_patch_accepts_exit_one(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_patch_section_paths_splits_and_unquotes(git_repo: str) -> None:
     # Git C-quotes the whole a/ path (including the prefix) when needed.
     raw = (
@@ -342,6 +376,7 @@ def test_git_quote_path_matches_git_style() -> None:
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_pair_exact_renames_pairs_identical_content(git_repo: str) -> None:
     oid = subprocess.run(
         ["git", "-C", git_repo, "hash-object", "--stdin"],
@@ -365,6 +400,7 @@ def test_pair_exact_renames_pairs_identical_content(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_pair_exact_renames_keeps_modified_moves_unpaired(git_repo: str) -> None:
     oid = subprocess.run(
         ["git", "-C", git_repo, "hash-object", "--stdin"],
@@ -534,6 +570,7 @@ def test_registry_scoped_snapshots_match(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_intent_to_add_payloads_match(git_repo: str) -> None:
     """``git add -N`` paths carry real worktree bytes, not the placeholder."""
     Path(git_repo, "ita.py").write_text("new content\n", encoding="utf-8")
@@ -542,6 +579,7 @@ def test_intent_to_add_payloads_match(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_quoted_header_paths_match(git_repo: str) -> None:
     """A path needing C quoting round-trips through the section parser."""
     tab_path = Path(git_repo, "tab\tname.py")
@@ -553,6 +591,7 @@ def test_quoted_header_paths_match(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_space_paths_sections_do_not_collide(git_repo: str) -> None:
     """Unquoted space-containing headers keep distinct section keys."""
     Path(git_repo, "a b.py").write_text("two\n", encoding="utf-8")
@@ -564,6 +603,7 @@ def test_space_paths_sections_do_not_collide(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_exact_rename_with_mode_change_payloads_match(git_repo: str) -> None:
     """R100 sections carry old/new mode lines when the mode changed."""
     script = Path(git_repo, "m.sh")
@@ -577,6 +617,7 @@ def test_exact_rename_with_mode_change_payloads_match(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_ambiguous_identical_moves_stay_delete_add(git_repo: str) -> None:
     """Ambiguous exact-rename candidates are not paired by guessing."""
     Path(git_repo, "x.py").write_text("same\n", encoding="utf-8")
@@ -602,6 +643,7 @@ def test_ambiguous_identical_moves_stay_delete_add(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_filemode_false_untracked_exec_payloads_match(git_repo: str) -> None:
     subprocess.run(
         ["git", "-C", git_repo, "config", "core.filemode", "false"], check=True
@@ -613,6 +655,7 @@ def test_filemode_false_untracked_exec_payloads_match(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_working_tree_encoding_fails_closed_without_crlf(git_repo: str) -> None:
     Path(git_repo, ".gitattributes").write_text(
         "*.txt working-tree-encoding=UTF-16LE\n", encoding="utf-8"
@@ -635,6 +678,7 @@ def test_working_tree_encoding_fails_closed_without_crlf(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_ident_attribute_fails_closed(git_repo: str) -> None:
     Path(git_repo, ".gitattributes").write_text("*.c ident\n", encoding="utf-8")
     Path(git_repo, "main.c").write_text("$Id$\n", encoding="utf-8")
@@ -655,6 +699,7 @@ def test_ident_attribute_fails_closed(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_untracked_diff_attribute_binary_matches(git_repo: str) -> None:
     """``*.dat binary`` marks an untracked NUL-free file binary."""
     Path(git_repo, ".gitattributes").write_text("*.dat binary\n", encoding="utf-8")
@@ -664,6 +709,7 @@ def test_untracked_diff_attribute_binary_matches(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_skip_worktree_entry_matches(git_repo: str) -> None:
     Path(git_repo, "sw.py").write_text("hidden\n", encoding="utf-8")
     subprocess.run(["git", "-C", git_repo, "add", "."], check=True)
@@ -788,6 +834,7 @@ def test_workspace_mode_unsafe_metadata_fails_closed() -> None:
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_readonly_rows_rejects_malformed_output(git_repo: str) -> None:
     import tree_sitter_analyzer.diff_snapshot_readonly_capture as module
 
@@ -803,6 +850,7 @@ def test_readonly_rows_rejects_malformed_output(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_readonly_binaries_rejects_malformed_output(git_repo: str) -> None:
     import tree_sitter_analyzer.diff_snapshot_readonly_capture as module
 
@@ -818,6 +866,7 @@ def test_readonly_binaries_rejects_malformed_output(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_gitlink_probe_safe_classifies_boundaries(
     git_repo: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -857,6 +906,7 @@ def test_gitlink_probe_safe_classifies_boundaries(
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_gitlink_probe_failure_frames_dirty_without_entering(
     git_repo: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -900,6 +950,7 @@ def test_gitlink_probe_failure_frames_dirty_without_entering(
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_capture_requires_epoch(git_repo: str) -> None:
     from tree_sitter_analyzer.diff_snapshot_readonly_capture import (
         capture_payload_readonly,
@@ -912,6 +963,7 @@ def test_capture_requires_epoch(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_capture_missing_manifest_entry_fails_closed(git_repo: str) -> None:
     """A dirty path absent from the manifest is a source-change failure."""
     Path(git_repo, "base.py").write_text("value = 2\n", encoding="utf-8")
@@ -929,6 +981,7 @@ def test_capture_missing_manifest_entry_fails_closed(git_repo: str) -> None:
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_capture_special_file_fails_closed(
     git_repo: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -963,6 +1016,7 @@ def test_capture_special_file_fails_closed(
 
 
 @POSIX_SNAPSHOT_TEST
+@GIT_CAPTURE_COST
 def test_capture_binary_attr_malformed_fails_closed(git_repo: str) -> None:
     """Malformed check-attr output for untracked paths fails closed."""
     import tree_sitter_analyzer.diff_snapshot_readonly_capture as module

--- a/tree_sitter_analyzer/cli/commands/constraint_check_execution.py
+++ b/tree_sitter_analyzer/cli/commands/constraint_check_execution.py
@@ -4,12 +4,31 @@ from __future__ import annotations
 
 import os
 import stat
+import sys
 import time
 from pathlib import Path
 
 EXPLICIT_CONFIG_BYTE_LIMIT = 1024 * 1024
 ExplicitConfigIdentity = tuple[int, int, int, int, int, int, int]
 ExplicitConfigEvidence = tuple[bytes, ExplicitConfigIdentity]
+
+# ``st_ctime`` means different things per platform, and only one of them is a
+# mutation signal:
+#   POSIX   -> inode change time. Bumped by every metadata/content mutation, so
+#              it genuinely strengthens the TOCTOU identity.
+#   Windows -> file *creation* time. Never bumped by mutating a file, so it adds
+#              zero detection power (replacement is already covered by
+#              st_dev/st_ino), and `os.stat(path)` and `os.fstat(fd)` do not
+#              agree on it: the directory entry and the handle are populated
+#              from different sources during creation. Measured 2026-08-19 on
+#              Windows 11 / CPython 3.13: creating a file then comparing
+#              path-stat to handle-fstat disagreed on st_ctime_ns in 27 of 300
+#              trials (9%) with every other field identical.
+# Including it on Windows therefore made ``explicit_config_evidence`` fail
+# closed on files nobody touched, so `--constraint-file --read-only` reported
+# CONSTRAINT_CONFIG_CHANGED at random (~9% per read). Project it only where it
+# carries information.
+_CTIME_IS_MUTATION_SIGNAL = sys.platform != "win32"
 
 
 def _identity(info: os.stat_result) -> ExplicitConfigIdentity:
@@ -20,7 +39,7 @@ def _identity(info: os.stat_result) -> ExplicitConfigIdentity:
         int(info.st_mode),
         int(info.st_size),
         int(info.st_mtime_ns),
-        int(info.st_ctime_ns),
+        int(info.st_ctime_ns) if _CTIME_IS_MUTATION_SIGNAL else 0,
         int(getattr(info, "st_file_attributes", 0)),
     )
 


### PR DESCRIPTION
## Why

`develop`'s own CI is failing: 3 of the last 4 `ci.yml` runs were red. The most
recent (`32256066101`) failed on `macos-latest 3.11`, `windows-latest 3.12`, and
`Quality Gate` cascading from them. A standing red baseline makes the "CI green"
merge bar unsatisfiable, makes the CLAUDE.md release gate unsatisfiable, and
hides new breakage inside old breakage.

Both red axes turned out to be the **same disease**: a test whose result depends
on the *runner* rather than on the code. Green everywhere the maintainers looked,
red on one axis, invisible to review.

## Classification (method: CI logs + local repro + isolating probes)

Evidence sources: `gh run view --job <id> --log` on the 3 failed jobs
(`--log-failed` returned only runner setup noise); local re-runs with `-n0
-p no:randomly` to strip xdist/rerun confounds; and standalone probes to isolate
the failing primitive. **Key cross-check:** for every *local* failure I verified
whether the same test id passes on a green CI axis of the same OS family. It did,
every time.

| Test | Fails on | Error | Class |
|---|---|---|---|
| `test_explicit_zero_rules_revalidates_bytes_before_safe` | CI **win 3.12** | `assert (...,1) == (...,2)` | **genuinely broken** |
| `test_explicit_rules_revalidate_identity_after_evaluation` | CI **win 3.12** | `KeyError: 'error_code'` | **genuinely broken** |
| `test_explicit_config_evidence_rejects_input_above_one_mib` | local win | `OSError: constraint file changed during read` | **genuinely broken** |
| `test_untracked_text_and_dirty_payloads_match` | CI **macos 3.11** | `budget: 6.06s > 5.0s` | **flaky** |
| 8x in `test_claim_registry` / `test_collect_no1_006b_baseline` | local win | `UnicodeDecodeError: 'cp932'` | **genuinely broken** (test bug) |
| 8x symlink tests | local win | `OSError: [WinError 1314]` | **environment** (not fixed) |
| 2x `uv` version pins | local win | `['uv','0.11.30'] != ['uv','0.12.3']` | **environment** (not fixed) |
| mypy, 23 errors / 7 files | local win | `Module has no attribute "O_NOFOLLOW"` | **environment, not a defect** (not fixed) |

### Two findings that reframe the task

**1. The local red baseline and the CI red baseline are different problems.**
The last three rows are entirely explained by three properties of one dev machine
(no symlink privilege, Japanese locale, older `uv`). Verified on green CI job
`96078142471`:

```
PASSED tests/contracts/test_collect_no1_006b_baseline.py::test_safe_write_rejects_output_symlink
PASSED tests/unit/test_ast_cache.py::test_snapshot_preserves_logical_project_root_spelling
```

**2. The 23 mypy errors are not real.** All are POSIX-only `os` members; mypy
resolves stdlib stubs for the *host* platform. `uv run mypy --platform linux
tree_sitter_analyzer/` gives `Success: no issues found in 881 source files`.
`ci.yml` also never ran mypy. Not "fixed" - there is nothing to fix.

## Fixes

### 1. Windows `st_ctime_ns` in the config TOCTOU identity (genuinely broken)

`_identity()` feeds an identity compared **across two stat APIs** (path `stat()`
vs handle `fstat()`) and projected `st_ctime_ns`. On POSIX that is inode change
time - a real mutation signal. On Windows it is *creation* time, and the
directory entry and the handle are populated from different sources. Measured,
300 freshly created files, untouched:

```
trials=300
  <none>: 273
  st_ctime_ns: 27
```

**9% of reads falsely reported "constraint file changed during read"** - no other
field ever diverged. So `--constraint-file --read-only` returned
`CONSTRAINT_CONFIG_CHANGED` at random. That is why win 3.12 was red while 3.11
and 3.13 were green: a coin flip per read, not a version difference.

Fix: project `st_ctime_ns` only where it carries information. Loses **zero**
detection power on Windows (mutation never moves creation time; replacement is
already covered by `st_dev`/`st_ino`). Before: `reads = 0`, wrong error path.
After: `reads = 2`, `CONSTRAINT_CONFIG_CHANGED` for the right reason.

### 2. macOS per-test budget (flaky)

Every test taking the `git_repo` fixture spends 7 `git` spawns building the repo
then drives **both** capture backends per assertion. A fixed 5.0s wall-clock
ceiling cannot grade that on a shared runner - the same test measured 5.07s
(`32246819262`) and 6.06s (`32256066101`).

7 tests had already been exempted one at a time as each lost the scheduling
lottery, leaving 39 equally exposed. The exemption now follows the cost driver.
AST-verified exact: `git_repo tests: 46  budget-exempt: 46  mismatches: []`. The
6 pure-logic helpers stay fully budgeted.

**Flagging for judgement, not slipping it past you:** `slow_ok` is the opt-out
the enforcement mechanism itself documents, and it is *not* a skip - all 52 tests
still run and assert everything; only the wall-clock ceiling is waived. The
budget is unchanged for every other unit test and no axis was touched.

### 3. cp932 decode masking assertions (genuinely broken)

`read_text()` with no `encoding=` inherits the runner's locale and raises *on the
asserting line*, replacing the check. `0xef` at position 0 is the README.md UTF-8
BOM, so the English README sufficed to trigger it.

## Ratchet

Two guards, each with the instrument that fits:

- **`scripts/check_test_encoding.py`** (pre-commit) - AST-based, so `read_bytes()`
  and binary `open()` are correctly ignored. Baseline 2267 calls / 326 files is
  grandfathered exactly like `weak-assertion-ratchet`; only **added** lines are
  checked, so the count can fall but never rise. Verified blocking (exit 1). Its
  own diagnostic is ASCII, since a cp932 console is exactly where it fires.
- **`test_real_git_capture_tests_stay_budget_exempt`** - a count ratchet is the
  *wrong* instrument for the budget flake; what regressed is a *relationship*, so
  this asserts it (CLAUDE.md section 11.5). Fails deterministically on every
  platform the moment a git-backed test is added without the marker. Verified
  blocking.
- **`test_encoding_ratchet_is_present_and_pre_commit_wired`** so it cannot be
  quietly unwired.

**Deliberately not built:** a failure-*count* ratchet. It needs the full
25k-test suite (too slow for pre-commit) and the number is platform-dependent -
which is the very problem being fixed. An unstable baseline cannot be a ratchet.

## Deliberately NOT fixed

| Class | Why not |
|---|---|
| 8x symlink privilege (`WinError 1314`) | **Passes on CI Windows.** A `skipif` would delete real Windows coverage that currently works. The honest fix is a documented dev-env prerequisite (Developer Mode), not a code change. |
| 2x exact `uv` version pins | Local tooling drift. The exact pin is correct per the exact-assertion rule; my local `uv` is stale. |
| 23 mypy errors | Not defects - see above. |

## Verification

```
uv run ruff check .                        All checks passed!
uv run mypy tree_sitter_analyzer/          23 errors (unchanged; 0 in touched files)
uv run mypy --platform linux ...           Success: no issues found in 881 source files
```

| Suite | Before | After |
|---|---|---|
| `tests/unit/test_claim_registry.py` | 6 failed | **220 passed, 0 failed** |
| `tests/contracts`+`governance`+`docs` | 11 failed, 622 passed | **7 failed, 626 passed** |
| default local selection | 15 failed, 1896 passed | **10 failed, 1903 passed** |

`--change-impact` gives `risk=low`, verdict REVIEW; its focused command run
(238 passed, 2 failed - both `os.symlink` privilege, failing inside the test body
before reaching any changed code); then its `verification_command`
`uv run pytest -q` gives 10 failed / 1903 passed, all 10 the deliberate
environment classes above.

Pre-commit on changed files: ruff, ruff-format, mypy, bandit, detect-secrets,
weak-assertion-ratchet, **test-encoding-ratchet**, tsa-codemap-sync,
block-banned-test-names (T-1), block-local-artifacts - all Passed.

No new test files (T-1). Exact assertions only. New `skipif`s carry tracking
references and are a matched pair - each platform asserts its own half of the
ctime contract, so neither half is left unasserted.

## What remains red

Both CI-red axes are addressed here, but **I have not yet seen CI green on this
branch** - I will report per-axis status once the run completes rather than claim
it. Locally, 10 failures remain, all in the two deliberate environment classes.

## Scope

Deferred to keep this focused: the symlink-privilege dev-env prerequisite, the
`uv` version drift, and a mypy `platform` decision. Each is independent and none
blocks CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
