### PR TITLE
fix(ci): bound the apt-get hang that cancels every ubuntu axis

### DIFF
--- a/.github/actions/setup-system/action.yml
+++ b/.github/actions/setup-system/action.yml
@@ -19,8 +19,34 @@ runs:
       if: inputs.os == 'ubuntu-latest'
       run: |
         echo "Installing fd and ripgrep on Linux..."
-        sudo apt-get update
-        sudo apt-get install -y fd-find ripgrep
+
+        # archive.ubuntu.com intermittently stalls without ever failing, which
+        # burned the entire 20-minute job timeout before a single test ran and
+        # cancelled every ubuntu axis (observed 5/5 attempts on 2026-08-19, and
+        # on develop's own run in the same window). A bare `apt-get update` has
+        # no wall-clock bound of its own, so bound it here.
+        #
+        # Deliberately NOT done: raising the job timeout or continue-on-error.
+        # Both would hide the hang instead of surviving it. This fails loudly
+        # after a bounded number of bounded attempts.
+        apt_with_timeout() {
+          local what="$1"; shift
+          local attempt
+          for attempt in 1 2 3; do
+            if timeout 180 "$@"; then
+              return 0
+            fi
+            echo "::warning::${what} attempt ${attempt}/3 timed out or failed; retrying"
+            sleep $(( attempt * 5 ))
+          done
+          echo "::error::${what} failed after 3 bounded attempts"
+          return 1
+        }
+
+        # -o Acquire::Retries makes apt itself retry a stalled mirror connection,
+        # and the timeouts stop a single hung socket from consuming the attempt.
+        apt_with_timeout "apt-get update" sudo apt-get update           -o Acquire::Retries=3           -o Acquire::http::Timeout=30           -o Acquire::https::Timeout=30
+        apt_with_timeout "apt-get install" sudo apt-get install -y fd-find ripgrep
 
         # Create symlink for fd command (Ubuntu packages it as fdfind)
         sudo ln -sf /usr/bin/fdfind /usr/bin/fd


### PR DESCRIPTION
## Summary

`archive.ubuntu.com` intermittently **stalls without ever returning an error**. A bare `sudo apt-get update` has no wall-clock bound of its own, so the stall consumed the entire 20-minute job timeout **before a single test executed**, and the job came back `cancelled` rather than `failed`.

Observed **5 out of 5** Linux job attempts on 2026-08-19, and on `develop`'s own CI run in the same window.

## Why this is the highest-leverage fix available right now

While this is live:

- both ubuntu axes are **unrunnable**
- so `Quality Gate` can **never** pass
- so **no PR can satisfy a green-CI merge bar**
- so CLAUDE.md's release gate ("every platform × every Python version must pass") is **unsatisfiable**

This is infrastructure, not tests, and it is arguably the largest single contributor to the red baseline on `develop`. It also has the specific nastiness of arriving as `cancelled`, which reads as "something else went wrong" rather than as a failure anyone owns.

## The fix

Three bounded attempts of `timeout 180` around each apt invocation, plus apt's own `Acquire::Retries=3` and 30s http/https timeouts so a single hung socket cannot consume a whole attempt. A `::warning::` per retry, an `::error::` on final failure.

## What was deliberately NOT done

Recorded in the file itself, not just here:

- **not** raising the job timeout
- **not** adding `continue-on-error`

Either would hide the hang rather than survive it. A step that cannot fail is the same class of defect as the dead codemap gate repaired in #1314 — a gate that manufactures confidence. A mirror that is genuinely down must still go red.

## Verification

- pre-commit `check yaml` → **Passed**
- the Linux step's shell body → `bash -n` clean
- full pre-commit hook set on the changed file → green

The real proof is the ubuntu axes on this PR. I am not claiming them green until I see them.