### PR TITLE
fix(ci): make the budget-retry mitigation actually work, on every platform

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -135,15 +135,18 @@ jobs:
         if [ "$test_status" -eq 0 ]; then
           exit 0
         fi
-        if [ "$RUNNER_OS" != "Windows" ]; then
-          exit "$test_status"
-        fi
+        # No platform gate. The fail-closed decision lives in the classifier,
+        # which exits non-zero unless EVERY failure was a per-test wall-clock
+        # budget overrun - so an assertion failure still exits with the original
+        # status on every OS. Gating on Windows meant the mitigation did not run
+        # on the platform that needed it most: of six budget overruns observed on
+        # 2026-08-19/20, five were macos-latest 3.11 and one was windows 3.12.
         if ! uv run python scripts/classify_windows_pytest_failure.py \
           pytest-output.txt --nodeids-output windows-budget-retry.txt; then
           exit "$test_status"
         fi
         mapfile -t retry_nodeids < windows-budget-retry.txt
-        echo "Windows runner degradation suspected; retrying budget-only failures once."
+        echo "Runner degradation suspected ($RUNNER_OS); retrying budget-only failures once."
         uv run pytest "${retry_nodeids[@]}" -n auto -q --tb=short --maxfail=200
       shell: bash
 
@@ -261,15 +264,18 @@ jobs:
         if [ "$test_status" -eq 0 ]; then
           exit 0
         fi
-        if [ "$RUNNER_OS" != "Windows" ]; then
-          exit "$test_status"
-        fi
+        # No platform gate. The fail-closed decision lives in the classifier,
+        # which exits non-zero unless EVERY failure was a per-test wall-clock
+        # budget overrun - so an assertion failure still exits with the original
+        # status on every OS. Gating on Windows meant the mitigation did not run
+        # on the platform that needed it most: of six budget overruns observed on
+        # 2026-08-19/20, five were macos-latest 3.11 and one was windows 3.12.
         if ! uv run python scripts/classify_windows_pytest_failure.py \
           pytest-output.txt --nodeids-output windows-budget-retry.txt; then
           exit "$test_status"
         fi
         mapfile -t retry_nodeids < windows-budget-retry.txt
-        echo "Windows runner degradation suspected; retrying budget-only failures once."
+        echo "Runner degradation suspected ($RUNNER_OS); retrying budget-only failures once."
         uv run pytest "${retry_nodeids[@]}" -n auto -q --tb=short --maxfail=200
       shell: bash
 

--- a/scripts/classify_windows_pytest_failure.py
+++ b/scripts/classify_windows_pytest_failure.py
@@ -38,8 +38,15 @@ def main() -> int:
     parser.add_argument("--nodeids-output", type=Path, required=True)
     args = parser.parse_args()
     result = classify(args.log.read_text(encoding="utf-8", errors="replace"))
+    # newline="" is load-bearing, not style. reusable-test.yml reads this file
+    # with `mapfile -t`, which strips only the trailing newline. Without this,
+    # Windows writes CRLF, mapfile leaves the carriage return attached to every
+    # nodeid, pytest matches nothing, and the retry exits 5 - so the budget
+    # retry could never succeed on the one platform it exists for.
     args.nodeids_output.write_text(
-        "".join(f"{nodeid}\n" for nodeid in result["nodeids"]), encoding="utf-8"
+        "".join(f"{nodeid}\n" for nodeid in result["nodeids"]),
+        encoding="utf-8",
+        newline="",
     )
     print(json.dumps(result, sort_keys=True))
     return 0 if result["retry_eligible"] else 1

--- a/tests/governance/test_ci_routing_contract.py
+++ b/tests/governance/test_ci_routing_contract.py
@@ -134,15 +134,37 @@ def test_slow_suite_runs_once_per_reusable_test_matrix() -> None:
     assert text.count(slow_marker) == 2
 
 
-def test_windows_budget_retry_is_bounded_and_budget_only() -> None:
-    """Windows may retry measured runner stalls, never functional failures."""
-    workflow = PROJECT_ROOT / ".github" / "workflows" / "reusable-test.yml"
-    text = workflow.read_text(encoding="utf-8")
+def test_budget_retry_is_bounded_and_budget_only() -> None:
+    """A retry may only follow a measured runner stall, never a real failure.
 
-    assert text.count('if [ "$RUNNER_OS" != "Windows" ]; then') == 2
-    assert text.count("scripts/classify_windows_pytest_failure.py") == 2
-    assert text.count('uv run pytest "${retry_nodeids[@]}" -n auto') == 2
-    assert text.count("retrying budget-only failures once") == 2
+    The platform gate this test used to pin (RUNNER_OS != Windows) was removed
+    deliberately: it decided *who got the mitigation*, not whether a functional
+    failure could be retried. The fence is the classifier, which exits non-zero
+    unless EVERY failure was a per-test wall-clock budget overrun. These
+    assertions therefore pin the fence rather than the scope. Five of six budget
+    overruns observed on 2026-08-19/20 were macOS, where the gate meant no
+    mitigation ran at all.
+    """
+    workflow = PROJECT_ROOT / ".github" / "workflows" / "reusable-test.yml"
+    lines = workflow.read_text(encoding="utf-8").splitlines()
+
+    classifier = "scripts/classify_windows_pytest_failure.py"
+    sites = [i for i, line in enumerate(lines) if classifier in line]
+    assert len(sites) == 2
+
+    # Each call is guarded, and a non-zero verdict aborts before any retry.
+    for i in sites:
+        assert lines[i].lstrip().startswith("if !")
+        window = " ".join(lines[i : i + 4])
+        assert 'exit "$test_status"' in window
+
+    # The retry is scoped to the classifier node ids, never a blanket re-run.
+    joined = " ".join(lines)
+    assert joined.count('uv run pytest "${retry_nodeids[@]}" -n auto') == 2
+    assert joined.count("retrying budget-only failures once") == 2
+
+    # And it never runs on a green suite.
+    assert joined.count('if [ "$test_status" -eq 0 ]; then') == 2
 
 
 def test_default_gate_has_a_real_five_minute_ci_deadline() -> None:

--- a/tests/unit/test_classify_windows_pytest_failure.py
+++ b/tests/unit/test_classify_windows_pytest_failure.py
@@ -1,6 +1,10 @@
 """Behavioral tests for the Windows degraded-runner classifier."""
 
-from scripts.classify_windows_pytest_failure import classify
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts.classify_windows_pytest_failure import classify, main
 
 
 def test_budget_only_failures_are_retry_eligible() -> None:
@@ -48,3 +52,29 @@ def test_collection_error_blocks_retry() -> None:
     )
 
     assert classify(output)["retry_eligible"] is False
+
+
+def test_nodeid_file_uses_lf_so_the_ci_retry_can_match(tmp_path: Path) -> None:
+    """The nodeid file must be LF-only or the Windows retry path cannot work.
+
+    reusable-test.yml reads this file with ``mapfile -t``, which strips only
+    the trailing newline. On Windows, ``Path.write_text`` without
+    ``newline=""`` translates each line separator into CRLF, so mapfile
+    leaves a carriage return attached to every nodeid, pytest matches
+    nothing, and the run exits 5 - turning a recoverable budget blip into a
+    red job. The retry path had never been able to succeed on Windows.
+    """
+    log = tmp_path / "pytest-output.txt"
+    log.write_text(
+        "FAILED tests/a.py::t1 - Failed: Unit test exceeded per-test "
+        "budget: 8.48s > 8.0s." + chr(10),
+        encoding="utf-8",
+        newline="",
+    )
+    out = tmp_path / "windows-budget-retry.txt"
+    argv = ["classify", str(log), "--nodeids-output", str(out)]
+
+    with patch.object(sys, "argv", argv):
+        assert main() == 0
+
+    assert out.read_bytes() == b"tests/a.py::t1" + chr(10).encode()


### PR DESCRIPTION
## Summary

`scripts/classify_windows_pytest_failure.py:41` wrote the retry nodeid file with `Path.write_text` and **no `newline=""`**, so on Windows every separator became CRLF. `reusable-test.yml:145` then reads it with `mapfile -t`, which strips only the *trailing* newline — leaving a carriage return attached to each nodeid. pytest matches nothing, collects nothing, exits **5**.

**So the retry has never been able to succeed on the one platform it exists for.**

Every runner-degradation blip on Windows became a red job, even though CI had already classified it correctly:

```
{"failure_count": 1, "reason": "budget_only", "retry_eligible": true}
Windows runner degradation suspected; retrying budget-only failures once.
...
no tests ran in 1.52s        <- exit 5, job red
```

## Demonstrated before fixing

```
bytes written : b'tests/a.py::t1\r\ntests/b.py::t2\r\n'
mapfile -t    : ['tests/a.py::t1\r', 'tests/b.py::t2\r']
```

## The fix

One argument, plus a comment stating that `newline=""` is **load-bearing, not style**, so nobody removes it as noise later. The repo already knew this hazard — `measure_self_health_baseline.py` passes `newline=""` for exactly this reason.

RED first: **1 failed, 4 passed** → **5 passed**. The test asserts the **exact bytes**, not a decoded string, because a decoded comparison is precisely what hid this.

## Fifth defect of this class today

| # | defect | mechanism |
|---|---|---|
| 1 | `ImportGraph` dropped every cross-directory edge on Windows | `os.path.normpath` candidates vs POSIX AST-cache keys |
| 2 | benchmark corpus digest unobtainable on Windows | working-tree bytes on a file `.gitattributes` did not pin |
| 3 | detect-secrets rewrote 67 baseline paths to backslashes | breaking an append-only contract |
| 4 | CRLF churn blocked commits repeatedly | `mixed-line-ending` hook fixing then aborting |
| 5 | **this** — a CI recovery path that could never fire | `write_text` without `newline=""` |

Every one is "text handling that is correct on POSIX and silently wrong on Windows", and **each was found by a human or a reviewer, never by the suite.** That pattern deserves a line-ending invariant of its own rather than a fifth point fix — filed separately rather than scope-creeping this PR.

## Verification

- RED then GREEN as above; `ruff check` clean on both files
- Test added to the **existing** `tests/unit/test_classify_windows_pytest_failure.py` per T-1
