### PR TITLE
fix(index): give the manifest WARN an actionable next_step (dogfood round 1)

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -1,5 +1,83 @@
 # Loop State — tree-sitter-analyzer
 
+## Dogfood round 1 — using TSA to build TSA (2026-08-20)
+
+Per CLAUDE.md section 11.4: a dogfood round must invoke the tools and look at
+the output, not run the suite. Task under dogfood: preparing RFC-0025 L1 (the
+standing index). Every timing below is wall-clock from the caller's seat,
+including interpreter start, because that is what the caller actually waits.
+
+### What the tool did well
+
+- `--self-health` on a cold process reported `ast_index: EMPTY`,
+  `NO_OBSERVATIONS`, `verdict: WARN` and *"no latency claim about it is
+  supportable"*. **It told me not to trust it before I asked it anything.**
+- `--callers _target_dependents` (3.4 s) returned 3 callers **with each source
+  body inlined**, and said so in `next_step`: "answer directly, no Read
+  needed". That removed tool calls rather than adding them.
+- `--test-map` (8.0 s) named the exact test file and function count.
+- `--safe-to-edit` on the L1 target returned `CAUTION`, health grade **D**,
+  **10 downstream files**, `edit_strategy: focused_edit_with_tests`, and the
+  precise 10-file pre-edit pytest command. I did not know the target was
+  grade D with 10 dependents; that changed how I approached the edit.
+
+### What failed, and what was changed as a result
+
+1. **`--full-index` WARN carried no `next_step`.** The run exited 1 with
+   `verdict: WARN`, `scope_complete: False`,
+   `manifest_warning: INDEX_MANIFEST_CERTIFICATION_FAILED` - all correct, and
+   the code fail-closes properly (it revokes the call-graph marker in a
+   separate committed transaction so direct readers cannot trust the run).
+   But `agent_summary.next_step` was **absent**, while every other route used
+   in this round carries one. The one output meaning *"do not trust graph
+   queries from this run"* was the only one with nothing in the field a caller
+   is trained to read - **so I ran `--callers` immediately afterwards.**
+   **Fixed in this commit**: `manifest_warning_next_step()` maps every known
+   warning code to a remedial action naming the affected flags, and an
+   unrecognised code still gets a step naming the code, because falling back
+   to silence is how the gap was created.
+2. **The prescribed pre-edit verification is not deterministic.** Running the
+   exact 10-file command `--safe-to-edit` gave me twice produced different
+   failure sets (546 passed / 1 failed, then 545 passed / 2 failed with a
+   different name). A gate whose output varies run to run cannot be used as a
+   pass/fail signal. Deterministic only with
+   `--override-ini="addopts="` (pytest.ini defaults to
+   `--numprocesses=4 --dist=worksteal --reruns=1`). Feeds task #10.
+3. **The swallowed cause is not visible.** The certification failure logs with
+   `exc_info=True`, but nothing reached stderr, so the reason is unavailable to
+   the caller. `exc_info` to a logger nobody reads is not visibility. Not
+   fixed here - filed.
+4. **Cost from the caller's seat**: `--self-health` 7.1 s to answer "what is
+   your state"; `--full-index` 106 s (68,767 FTS symbols); `--callers` 3.4 s;
+   `--test-map` 8.0 s. And `--safe-to-edit` took ~7.7 s on **both** calls,
+   because L6.1's cache is process-local and each CLI invocation is a new
+   process - **the cache does nothing from the CLI.** Documented in #1320,
+   now confirmed from the caller's seat.
+
+### What I got wrong, recorded because it is the same class
+
+- I reported `--safe-to-edit --format json` as emitting non-JSON. It emits
+  8,183 bytes of valid JSON; **my probe merged `2>&1` so uv warnings polluted
+  the stream.** Measurement error attributed to the thing measured - the exact
+  class of error caught in three agent reports this week.
+- I read `fts_indexed_symbols: 68767` and treated the run as success while
+  `verdict: WARN` and **exit code 1** were both right there. I piped through
+  `tail -3` and never checked `$?`.
+- I guessed two flag shapes wrong (`--search-content --query`) out of six
+  invocations. 325 flags is past the point where shape is guessable.
+- I made a structural edit with a naive text anchor, inserting module-level
+  code into a class body and breaking 24 tests - **after** `--safe-to-edit`
+  had told me the file was CAUTION with a prescribed pre-edit command that I
+  did not run. Reverted and redone at module level.
+
+### Loop rule established
+
+A dogfood round records three columns, not two: what helped, what failed, and
+**what I went around**. The third is the one that cannot be recovered later,
+because an agent that routes around a slow or confusing tool does not report
+it - it just uses the other answer. RFC-0028 section 2 exists for this and is
+currently an empty proxy; until it is populated, the record is manual.
+
 Last run: 2026-08-16 (P0.4 strace adapter-route certification merged, #1297)
 
 ## NO1-010B first VCSR measurement attempt (2026-08-20) - E0, internal only

--- a/tests/unit/test_codegraph_full_index_tool.py
+++ b/tests/unit/test_codegraph_full_index_tool.py
@@ -346,6 +346,80 @@ class TestExecute:
 
         assert (result["success"], result["verdict"]) == (False, "WARN")
 
+    async def test_manifest_warning_next_step_reaches_the_caller(self, tool_with_root):
+        """The remedial step must be in the response, not just derivable.
+
+        The first version of this change was covered only by unit tests on the
+        helper. Reverting the wiring that puts its result into agent_summary
+        left those three tests green -- the helper worked and its output
+        reached nobody, which is the exact defect class RFC-0029 corpus item 4
+        names. This test drives the real response assembly instead.
+        """
+        clean_phase = {"status": "ok", "processed": 1}
+        with (
+            patch.object(tool_with_root, "_phase_ast_cache", return_value=clean_phase),
+            patch.object(
+                tool_with_root, "_phase_incremental_sync", return_value=clean_phase
+            ),
+            patch.object(
+                tool_with_root, "_phase_fts5_stats", return_value={"status": "ok"}
+            ),
+            patch.object(
+                tool_with_root, "_phase_call_edge_stats", return_value={"status": "ok"}
+            ),
+            patch.object(
+                tool_with_root,
+                "_collect_final_stats",
+                return_value={
+                    "_manifest_certified": False,
+                    "manifest_certification_failed": True,
+                    "manifest_warning": "INDEX_MANIFEST_CERTIFICATION_FAILED",
+                },
+            ),
+        ):
+            result = await tool_with_root.execute(
+                {
+                    "mode": "incremental",
+                    "resolve_synapse": False,
+                    "output_format": "json",
+                }
+            )
+
+        step = result["agent_summary"]["next_step"]
+        assert step is not None
+        assert "--callers" in step
+        assert "re-index" in step.lower()
+
+    async def test_a_certified_run_carries_no_remedial_next_step(self, tool_with_root):
+        """A clean run must not tell the caller to remedy anything."""
+        clean_phase = {"status": "ok", "processed": 1}
+        with (
+            patch.object(tool_with_root, "_phase_ast_cache", return_value=clean_phase),
+            patch.object(
+                tool_with_root, "_phase_incremental_sync", return_value=clean_phase
+            ),
+            patch.object(
+                tool_with_root, "_phase_fts5_stats", return_value={"status": "ok"}
+            ),
+            patch.object(
+                tool_with_root, "_phase_call_edge_stats", return_value={"status": "ok"}
+            ),
+            patch.object(
+                tool_with_root,
+                "_collect_final_stats",
+                return_value={"_manifest_certified": True},
+            ),
+        ):
+            result = await tool_with_root.execute(
+                {
+                    "mode": "incremental",
+                    "resolve_synapse": False,
+                    "output_format": "json",
+                }
+            )
+
+        assert result["agent_summary"]["next_step"] is None
+
     async def test_synapse_phase_inherits_ast_backfill_failure(self, tool_with_root):
         result = tool_with_root._phase_synapse({"status": "ok", "backfill_errors": 1})
 

--- a/tests/unit/test_codegraph_full_index_tool.py
+++ b/tests/unit/test_codegraph_full_index_tool.py
@@ -1556,3 +1556,49 @@ def test_collect_final_stats_source_scope_unsupported_is_operational(tmp_path):
         result["manifest_certification_failed"],
         result["certification_errors"],
     ) == ("SOURCE_SCOPE_UNSUPPORTED", False, 0)
+
+
+def test_manifest_warning_carries_an_actionable_next_step() -> None:
+    """A WARN that names no action is a WARN an agent reads past.
+
+    Dogfood, 2026-08-20: --full-index returned verdict=WARN,
+    scope_complete=False and manifest_warning=INDEX_MANIFEST_CERTIFICATION_FAILED
+    with exit code 1 -- all correct -- but agent_summary.next_step was absent.
+    Every other route used in that session (--callers, --test-map,
+    --safe-to-edit, --self-health) carries a next_step, so that is the field an
+    agent is trained to read. The one output meaning 'do not trust graph
+    queries from this run' was the only one with nothing there, and the agent
+    ran --callers immediately afterwards.
+    """
+    from tree_sitter_analyzer.mcp.tools.full_index_tool import (
+        manifest_warning_next_step,
+    )
+
+    step = manifest_warning_next_step("INDEX_MANIFEST_CERTIFICATION_FAILED")
+
+    assert step is not None
+    lowered = step.lower()
+    assert "re-index" in lowered
+    assert "not certified" in lowered
+    assert "--callers" in step
+
+
+def test_a_certified_run_reports_no_remedial_next_step() -> None:
+    """The remedial step must be absent when nothing needs remedying."""
+    from tree_sitter_analyzer.mcp.tools.full_index_tool import (
+        manifest_warning_next_step,
+    )
+
+    assert manifest_warning_next_step(None) is None
+
+
+def test_an_unrecognised_warning_still_gets_a_next_step() -> None:
+    """A new warning code must not silently fall back to no guidance."""
+    from tree_sitter_analyzer.mcp.tools.full_index_tool import (
+        manifest_warning_next_step,
+    )
+
+    step = manifest_warning_next_step("SOME_FUTURE_CODE")
+
+    assert step is not None
+    assert "SOME_FUTURE_CODE" in step

--- a/tree_sitter_analyzer/mcp/tools/full_index_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/full_index_tool.py
@@ -190,6 +190,64 @@ def _candidate_snapshot_report(
     return report
 
 
+_MANIFEST_WARNING_NEXT_STEPS: dict[str, str] = {
+    "INDEX_MANIFEST_CERTIFICATION_FAILED": (
+        "This index run is not certified: the snapshot manifest could not "
+        "be stamped, so the call-graph marker was revoked. Do NOT trust "
+        "--callers, --callees, --change-impact or any graph query from this "
+        "run. Re-index (--full-index) and confirm verdict is INFO before "
+        "relying on graph answers."
+    ),
+    "CALL_GRAPH_INCOMPLETE": (
+        "The call graph is incomplete for this run, so graph answers may be "
+        "missing edges and are not certified. Do NOT trust --callers or "
+        "--callees from it. Re-index (--full-index) and confirm verdict is "
+        "INFO."
+    ),
+    "INDEX_RUN_INCOMPLETE": (
+        "The index run did not complete, so its rows are not certified. Do "
+        "NOT trust --callers or --callees from it. Re-index (--full-index) "
+        "and confirm verdict is INFO."
+    ),
+    "CALL_GRAPH_MARKER_CERTIFICATION_FAILED": (
+        "The call-graph marker is not certified for this run. Do NOT trust "
+        "--callers or --callees from it. Re-index (--full-index) and "
+        "confirm verdict is INFO."
+    ),
+    "INDEX_CANDIDATE_SNAPSHOT_CHANGED": (
+        "The source tree changed while indexing, so this run is not "
+        "certified against a stable snapshot. Do NOT trust --callers from "
+        "it. Re-index (--full-index) with the tree quiescent."
+    ),
+    "SOURCE_SCOPE_UNSUPPORTED": (
+        "The source-generation oracle is unsupported on this platform, so "
+        "this run carries no certified source scope. Index rows are usable; "
+        "treat the scope as unknown rather than complete, and do not read "
+        "--callers completeness as certified."
+    ),
+}
+
+
+def manifest_warning_next_step(manifest_warning: str | None) -> str | None:
+    """Return the remedial action for a manifest warning, or ``None``.
+
+    ``None`` in, ``None`` out: a certified run has nothing to remedy and must
+    not carry a remedial instruction. An unrecognised code still returns a
+    step naming the code, because a new warning falling back to silence is
+    exactly how the gap this function closes was created.
+    """
+    if manifest_warning is None:
+        return None
+    known = _MANIFEST_WARNING_NEXT_STEPS.get(manifest_warning)
+    if known is not None:
+        return known
+    return (
+        f"This index run reported {manifest_warning} and is not certified. "
+        "Do NOT trust --callers, --callees or --change-impact from it. "
+        "Re-index (--full-index) and confirm verdict is INFO."
+    )
+
+
 class CodeGraphFullIndexTool(BaseMCPTool):
     """MCP Tool for one-shot complete project intelligence indexing."""
 
@@ -594,6 +652,12 @@ class CodeGraphFullIndexTool(BaseMCPTool):
                 "agent_summary": {
                     "verdict": top_verdict,
                     "summary_line": summary_line,
+                    # A WARN that names no action is a WARN an agent reads past.
+                    # Every other route carries next_step, so that is the field
+                    # a caller is trained to read; leaving it empty made the one
+                    # signal meaning "do not trust graph queries from this run"
+                    # the only one with nothing in it. Dogfood 2026-08-20.
+                    "next_step": manifest_warning_next_step(manifest_warning),
                 },
                 "mode": mode,
                 "elapsed_seconds": elapsed,


### PR DESCRIPTION
## Found by using TSA, not by reading it

Dogfood round 1 (CLAUDE.md §11.4: *invoke the tools and look at the output, not run the suite*). Task under dogfood: preparing RFC-0025 L1.

`--full-index` on this repo returned **exit code 1**, `verdict: WARN`, `scope_complete: False`, `manifest_warning: INDEX_MANIFEST_CERTIFICATION_FAILED`. All of that is correct, and the code fail-closes properly — it revokes the call-graph-built marker in a **separate committed transaction** so direct `ASTCache` readers cannot trust the run, and it logs the cause with `exc_info=True`.

But `agent_summary` carried only `verdict` and `summary_line`. **`next_step` was absent.**

Every other route used in the same session carries one:

| route | `next_step` |
|---|---|
| `--callers` | "source bodies are inlined — answer directly, no Read needed" |
| `--test-map` | the exact pytest command |
| `--safe-to-edit` | the exact 10-file pre-edit command |
| `--self-health` | "no latency claim about it is supportable" |
| **`--full-index` (WARN)** | **nothing** |

So `next_step` is the field a caller is trained to read, and **the one output meaning "do not trust graph queries from this run" was the only one with nothing in it.**

The consequence was immediate and it was mine: I read `fts_indexed_symbols: 68767`, treated the run as success, and ran `--callers` against the uncertified index. The WARN and the exit code were both in output I had already printed.

## The fix

`manifest_warning_next_step()` maps every known warning code to a remedial action that **names the affected flags** (`--callers`, `--callees`, `--change-impact`) and says to re-index and confirm `verdict` is `INFO`.

An unrecognised code still returns a step **naming the code** — because a new warning falling back to silence is exactly how this gap was created. `None` in, `None` out: a certified run carries no remedial instruction.

## What the tool did well, for the record

`--safe-to-edit` on the L1 target returned `CAUTION`, health grade **D**, **10 downstream files**, and the precise pre-edit command. I did not know the target was grade D with 10 dependents, and it changed how I approached the edit. `--callers` returned 3 callers with each source body inlined, removing tool calls rather than adding them.

## Two findings filed rather than fixed

1. **The prescribed pre-edit verification is non-deterministic.** The same 10-file command gave `546 passed / 1 failed`, then `545 passed / 2 failed` **with a different name**. Deterministic only under `--override-ini="addopts="`, since `pytest.ini` defaults to `--numprocesses=4 --dist=worksteal --reruns=1`. A gate whose output varies run to run cannot be a pass/fail signal.
2. **The swallowed cause never reaches stderr.** `exc_info=True` to a logger nobody reads is not visibility.

## And four errors of my own, recorded because they are the same class

- I reported valid JSON (8,183 bytes) as non-JSON — my probe merged `2>&1` so `uv` warnings polluted the stream. **Measurement error attributed to the thing measured**, the exact class caught in three agent reports this week.
- I never checked `$?`. I piped through `tail -3`.
- I guessed 2 of 6 flag shapes wrong. 325 flags is past the point where shape is guessable.
- I made a structural edit with a naive text anchor, inserted module-level code into a class body and broke 24 tests — **after** `--safe-to-edit` handed me a pre-edit command I did not run.

## Verification

RED first (3 failed → green). Both candidate failures in the touched test file were measured **individually against a stashed baseline** and are identical there, so this change breaks nothing. `ruff` + `ruff-format` clean; `mypy --platform linux` clean on the touched module; full pre-commit hook set passed.

`STATE.md` records the round with **three columns, not two** — what helped, what failed, and **what I went around**. The third is the one that cannot be recovered later, because an agent that routes around a slow tool does not report it. RFC-0028 §2 exists for this and is currently an empty proxy; until it is populated the record is manual.
