### PR TITLE
feat(l1): derive edit.safe dependents from index with fail-closed guarantee (RFC-0025 L1)

### DIFF
--- a/rfcs/0025-instant-causal-proprioception.md
+++ b/rfcs/0025-instant-causal-proprioception.md
@@ -82,6 +82,36 @@ file edit reflects in the causality index in **< 50 ms median** after save
 (measured by a new `tests/benchmarks/test_causality_latency.py`), with zero
 agent-visible re-index waits.
 
+**Implementation status (partial — the derivation landed, the watcher did not):**
+
+`tree_sitter_analyzer/mcp/tools/utils/dependents_index.py` implements the
+`dependents` row of the table above for the `edit.safe` pre-edit gate, derived
+from `ast_index.imports_json` rather than precomputed into a new reverse-edge
+table. A second dependents store was rejected deliberately: the AST cache
+already holds the import projection, and a parallel materialised reverse index
+is a second source of truth that has to be invalidated in lockstep — the drift
+class this project keeps paying for. The tree is still enumerated per call
+(`os.scandir`, no reads) because completeness requires accounting for files the
+index has never seen; only files whose `(mtime_ns, file_size)` do not match
+their row are read.
+
+**What is NOT in this increment:** the file watcher, the budget/eviction policy
+(`WATCH_INDEX_BUDGET_MB`, `WATCH_INDEX_ROWS`), and therefore the `< 50 ms`
+criterion above, which is a *post-save propagation* measurement that only a
+watch loop can satisfy. Without the watcher the per-call floor is the
+enumeration itself — measured at ~55 ms of `os.scandir` over 2,383 files on
+this repository, plus ~40 ms to read the index inventory. A watcher would
+replace both with an in-memory inventory kept current by events, removing that
+~95 ms floor and closing the mtime-preserving-replacement hole documented in
+the module. It is a separate change with its own budget and eviction policy and
+is not attempted here.
+
+Measured effect of this increment on the dependents derivation alone, 27
+targets on this repository (windows, E0, 2026-08-20): p50 830 ms -> 142 ms
+(5.9x), p95 894 ms -> 267 ms. It also removed 1,554 reported dependents that a
+filesystem-confirmed resolver says do not import the target, and added 3 that
+the previous scan missed; see the PR body for the full table.
+
 ### Layer 2 — Edit-time causal envelope (reflexes)
 
 `edit.safe` (and the read_existing certified path from #1299) grows a

--- a/scripts/measure_self_health_baseline.py
+++ b/scripts/measure_self_health_baseline.py
@@ -57,7 +57,9 @@ WARM_REPEATS = 5
 
 BASELINE_DIR = REPO_ROOT / "docs" / "baselines"
 ROADMAP_ID = "RFC-0025-L5"
-SCHEMA_VERSION = 1
+#: 2 adds ``cold_key_workflow`` (RFC-0025 L1): the edit-then-check row that
+#: neither the grouped nor the interleaved phase could express.
+SCHEMA_VERSION = 2
 
 #: Representative routes. Deliberately small and deliberately spread across
 #: the cost spectrum measured on this repo: a cheap single-file structural
@@ -91,6 +93,14 @@ INTERLEAVED_ROUTES: tuple[tuple[str, str, dict[str, Any]], ...] = (
 #: Rounds of the interleaved pair. Round 1 is cold for both; every later round
 #: is a repeat at an unchanged generation and must hit.
 INTERLEAVED_ROUNDS = 4
+
+#: The file the cold-key phase edits. It is the same target the routes above
+#: use, so the cold-key row is directly comparable with the warm rows.
+COLD_KEY_TARGET = "tree_sitter_analyzer/latency.py"
+
+#: Rounds of edit-then-check. Every round bumps the generation, so every round
+#: is a cache miss by construction.
+COLD_KEY_ROUNDS = 3
 
 _FACADE_BUILDERS = {
     "structure": "structure_facade.build_structure_facade",
@@ -278,6 +288,91 @@ def _ast_index_state(project_root: str) -> dict[str, Any]:
     return _ast_index_report(project_root)
 
 
+async def _drive_cold_key(project_root: str, rounds: int) -> dict[str, Any]:
+    """Edit a file, then call ``edit action=safe`` — the number the loop pays.
+
+    Neither phase above measures this. ``routes_driven`` and
+    ``interleaved_workflow`` both repeat a question at an **unchanged**
+    generation, which is exactly the case the L6.1 answer cache already made
+    cheap. The real edit loop is edit -> check -> edit -> check, and every edit
+    bumps the generation, so every check in it is a first call at a new key.
+    That is the latency an agent actually experiences and the one that decides
+    whether the gate gets used at all.
+
+    Each round appends a comment to :data:`COLD_KEY_TARGET`, so the source-tree
+    digest changes and the answer cannot be served from cache. ``served_from``
+    is recorded to prove that; a ``"cache"`` value here would mean the edit was
+    invisible to the key, which is a correctness bug, not a fast result. The
+    original bytes are restored in a ``finally`` block and the restore is
+    verified, because a half-restored file would silently invalidate the
+    provenance of the whole artifact.
+    """
+    facade = _build_facade("edit", project_root)
+    target = REPO_ROOT / COLD_KEY_TARGET
+    original = target.read_bytes()
+    row: dict[str, Any] = {
+        "target": COLD_KEY_TARGET,
+        "rounds": rounds,
+        "elapsed_ms": [],
+        "served_from": [],
+        "dependents_basis": [],
+        "errors": [],
+    }
+    try:
+        # One priming call so the measured rounds isolate the generation bump
+        # rather than first-import cost.
+        await facade.execute({"action": "safe", "file_path": COLD_KEY_TARGET})
+        for index in range(rounds):
+            probe = f"\n# rfc0025-l1 cold-key probe {index}\n".encode()
+            target.write_bytes(original + probe)
+            started = time.perf_counter_ns()
+            try:
+                result = await facade.execute(
+                    {"action": "safe", "file_path": COLD_KEY_TARGET}
+                )
+            except Exception as exc:  # noqa: BLE001 — record, never abort
+                row["errors"].append(f"{type(exc).__name__}: {exc}")
+                continue
+            elapsed_ms = (time.perf_counter_ns() - started) / 1_000_000.0
+            row["elapsed_ms"].append(round(elapsed_ms, 3))
+            provenance = result.get("provenance") if isinstance(result, dict) else None
+            row["served_from"].append(
+                provenance.get("served_from") if isinstance(provenance, dict) else None
+            )
+            row["dependents_basis"].append(
+                result.get("dependents_basis") if isinstance(result, dict) else None
+            )
+    finally:
+        target.write_bytes(original)
+        row["restored"] = target.read_bytes() == original
+
+    samples = row["elapsed_ms"]
+    row["p50_ms"] = _percentile(samples, 0.50) if samples else None
+    row["p95_ms"] = _percentile(samples, 0.95) if samples else None
+    served = row["served_from"]
+    # A hit here means the edit did not reach the cache key.
+    row["verdict"] = (
+        "OK"
+        if row["restored"] and served and all(s == "computed" for s in served)
+        else "COLD_KEY_NOT_COLD"
+        if served and any(s == "cache" for s in served)
+        else "COLD_KEY_NOT_MEASURED"
+    )
+    print(
+        f"  cold-key: {len(samples)}/{rounds} measured, p50="
+        f"{row['p50_ms']} ms ({row['verdict']})",
+        file=sys.stderr,
+    )
+    return row
+
+
+def _percentile(samples: list[float], quantile: float) -> float:
+    """Nearest-rank percentile — an exact sample value, no interpolation."""
+    ordered = sorted(samples)
+    index = min(len(ordered) - 1, int(quantile * len(ordered)))
+    return ordered[index]
+
+
 async def _collect(
     project_root: str, warm_repeats: int, *, allow_dirty: bool
 ) -> dict[str, Any]:
@@ -300,6 +395,8 @@ async def _collect(
     )
     print("Driving the prescribed pair interleaved...", file=sys.stderr)
     interleaved = await _drive_interleaved(project_root, INTERLEAVED_ROUNDS)
+    print("Driving the cold-key edit->check loop...", file=sys.stderr)
+    cold_key = await _drive_cold_key(project_root, COLD_KEY_ROUNDS)
     finished = datetime.now(timezone.utc)
 
     return {
@@ -374,6 +471,17 @@ async def _collect(
             "a 0% real-workflow cache hit rate behind a 62x grouped-repeat "
             "speedup (RFC-0027 L6.1 review P1-3). Judge the answer cache on "
             "these rows, not on the warm column above."
+        ),
+        "cold_key_workflow": cold_key,
+        "cold_key_workflow_note": (
+            "edit-then-check: the file is modified and edit action=safe is "
+            "called immediately, so every observation is a FIRST call at a new "
+            "generation. Both phases above repeat a question at an unchanged "
+            "generation, which the L6.1 answer cache already made cheap; this "
+            "is the row the real edit loop pays and the one RFC-0025 L1 exists "
+            "to move. served_from must be 'computed' on every round — a 'cache' "
+            "value would mean the edit did not reach the key. dependents_basis "
+            "records whether the L1 derived path or the fallback scan answered."
         ),
         "reproduction_command": (
             "uv run python scripts/measure_self_health_baseline.py"

--- a/tests/unit/mcp/tools/test_safe_to_edit_dependency_view.py
+++ b/tests/unit/mcp/tools/test_safe_to_edit_dependency_view.py
@@ -346,3 +346,123 @@ def test_import_spec_helpers_cover_unsupported_and_unresolved_cases(
     assert _extract_import_specs("package main\n", ".go") == set()
     assert _resolve_import_spec("..parent", "pkg/main.py", tmp_path) is None
     assert _resolve_import_spec("missing.module", "pkg/main.py", tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# L1 fail-open bug tests (2026-08-21)
+# When project_root is a relative path ("." or ".."), to_relative falls back
+# to the absolute path, so safe_dependents looks up the wrong key in
+# FileDependencyView._dependents and returns []. Both bugs are proven below.
+# ---------------------------------------------------------------------------
+
+
+def test_to_relative_with_unresolved_root_falls_back_to_absolute_path(
+    tmp_path: Path,
+) -> None:
+    # Issue 2026-08-21: to_relative(abs_path, ".") raises ValueError (abs path
+    # cannot be made relative to a relative root) and falls back to abs_path.
+    # The fix applies os.path.realpath to both sides in _collect_safe_to_edit_facts.
+    import os
+
+    from tree_sitter_analyzer.mcp.tools.utils.safe_to_edit_helpers import (
+        _normalize_relative_path,
+        to_relative,
+    )
+
+    abs_target = str(tmp_path / "pkg" / "main.py")
+    abs_root = str(tmp_path)
+
+    # With both sides absolute: correct relative path
+    good = _normalize_relative_path(to_relative(abs_target, abs_root))
+    assert good == "pkg/main.py"
+
+    # With relative root ".": falls back to absolute path (the bug)
+    bad = _normalize_relative_path(to_relative(abs_target, "."))
+    assert bad != "pkg/main.py"
+
+    # With realpath on both sides: resolves correctly regardless of input form
+    fixed = _normalize_relative_path(
+        to_relative(os.path.realpath(abs_target), os.path.realpath(abs_root))
+    )
+    assert fixed == "pkg/main.py"
+
+
+def test_safe_dependents_returns_empty_for_absolute_path_key(tmp_path: Path) -> None:
+    # Issue 2026-08-21: when rel_path is the absolute path of the target
+    # (because project_root was not realpath'd), safe_dependents returns []
+    # even though FileDependencyView._dependents has the correct relative key.
+    abs_target = str(tmp_path / "pkg" / "main.py")
+
+    view = FileDependencyView(
+        rel_path="pkg/main.py",
+        dependencies=set(),
+        dependents={"app/caller.py"},
+    )
+
+    # Correct key finds the dependents
+    assert safe_dependents(view, "pkg/main.py") == ["app/caller.py"]
+
+    # Absolute path key misses (the fail-open)
+    abs_key = abs_target.replace("\\", "/")
+    assert safe_dependents(view, abs_key) == []
+
+
+def test_uncertified_dependents_escalate_safe_verdict_to_caution(
+    tmp_path: Path,
+) -> None:
+    # Issue 2026-08-21: when FileDependencyView.dependents_answer.certified=False
+    # and the base verdict would be SAFE, _format_safe_to_edit_result must
+    # escalate to CAUTION so agents do not proceed on a false-safe signal.
+
+    from tree_sitter_analyzer.health_scorer import HealthScore
+    from tree_sitter_analyzer.mcp.tools.utils.dependents_index import DependentsAnswer
+    from tree_sitter_analyzer.mcp.tools.utils.safe_to_edit_helpers import (
+        SafeToEditContext,
+        SafeToEditFacts,
+        _format_safe_to_edit_result,
+    )
+
+    target = tmp_path / "pkg" / "leaf.py"
+    target.parent.mkdir()
+    target.write_text("VALUE = 1\n", encoding="utf-8")
+
+    uncertified_answer = DependentsAnswer(
+        dependents=frozenset(),
+        basis="index",
+        certified=False,
+        certification_reason="CALL_GRAPH_INCOMPLETE",
+        scanned_files=10,
+        delta_files=0,
+        unestablished=(),
+    )
+    view = FileDependencyView(
+        rel_path="pkg/leaf.py",
+        dependencies=set(),
+        dependents=set(),
+        dependents_answer=uncertified_answer,
+    )
+    health = HealthScore(file_path=str(target), total=85.0, dimensions={})
+    facts = SafeToEditFacts(
+        dependents=[],
+        dependencies=[],
+        health=health,
+        test_files=[],
+        has_tests=False,
+        risk="low",
+        risk_factors=[],
+        pre_edit_checklist=[],
+    )
+    context = SafeToEditContext(
+        file_path="pkg/leaf.py",
+        edit_type="edit",
+        resolved_path=str(target),
+        project_root=str(tmp_path),
+        graph=view,
+        scorer=None,  # type: ignore[arg-type]  # scorer only used in _collect_facts
+    )
+
+    result = _format_safe_to_edit_result(context, facts)
+
+    assert result["verdict"] == "CAUTION"
+    factor_names = [f["factor"] for f in result["risk_factors"]]
+    assert "uncertified_dependents" in factor_names

--- a/tests/unit/mcp/tools/utils/test_dependents_index.py
+++ b/tests/unit/mcp/tools/utils/test_dependents_index.py
@@ -1,0 +1,361 @@
+"""Tests for the RFC-0025 Layer 1 incremental dependents index.
+
+``edit action=safe`` is the pre-edit safety gate. Before this module the
+"who imports this file" answer was re-derived on every call by walking the
+whole tree and reading every source file, then substring-matching the target's
+basename. These tests pin the two properties that replaced it:
+
+1. the answer comes from the persisted AST index, and only files the index
+   cannot vouch for are read (incremental derivation), and
+2. the answer is never silently downgraded: the basis and the certification
+   state are reported with it.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from tree_sitter_analyzer.ast_cache import ASTCache
+from tree_sitter_analyzer.mcp.tools.utils import dependents_index
+from tree_sitter_analyzer.mcp.tools.utils.dependents_index import (
+    DELTA_READ_CAP,
+    DependentsAnswer,
+    prefilter_needles,
+    resolve_dependents,
+)
+
+
+def _write(root: Path, rel_path: str, body: str) -> Path:
+    path = root / rel_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Path:
+    """A small multi-package project with a cross-package basename collision."""
+    root = tmp_path / "proj"
+    root.mkdir()
+    _write(root, "pkg/__init__.py", "")
+    _write(root, "pkg/target.py", "VALUE = 1\n")
+    _write(root, "pkg/importer.py", "from .target import VALUE\n")
+    _write(root, "pkg/absolute_importer.py", "from pkg.target import VALUE\n")
+    # Same basename in another package: this must NOT be a dependent of
+    # pkg/target.py, and pkg/importer.py must NOT be a dependent of it.
+    _write(root, "other/__init__.py", "")
+    _write(root, "other/target.py", "VALUE = 2\n")
+    # Mentions the basename in prose only. The pre-L1 substring scan counted
+    # this as a dependent.
+    _write(root, "pkg/mentions_only.py", '"""Talks about target a lot."""\n')
+    return root
+
+
+def _index(root: Path) -> None:
+    ASTCache(str(root)).index_project()
+
+
+def test_index_derived_answer_is_exact_for_relative_and_absolute_imports(
+    project: Path,
+) -> None:
+    _index(project)
+
+    answer = resolve_dependents("pkg/target.py", project)
+
+    assert answer.dependents == frozenset(
+        {"pkg/absolute_importer.py", "pkg/importer.py"}
+    )
+
+
+def test_prose_mention_is_not_a_dependent(project: Path) -> None:
+    # The pre-L1 scan matched the bare basename anywhere in the file text,
+    # which made 782 of 821 reported dependents false on this repository.
+    _index(project)
+
+    answer = resolve_dependents("pkg/target.py", project)
+
+    assert "pkg/mentions_only.py" not in answer.dependents
+
+
+def test_same_basename_in_another_package_is_not_a_dependent(project: Path) -> None:
+    _index(project)
+
+    answer = resolve_dependents("other/target.py", project)
+
+    assert answer.dependents == frozenset()
+
+
+def test_fresh_index_reads_no_source_files(
+    project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _index(project)
+    reads: list[str] = []
+    original = Path.read_text
+
+    def counting_read_text(self: Path, *args: object, **kwargs: object) -> str:
+        reads.append(str(self))
+        return original(self, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "read_text", counting_read_text)
+
+    answer = resolve_dependents("pkg/target.py", project)
+
+    assert (answer.basis, answer.delta_files, reads) == ("index", 0, [])
+
+
+def test_only_the_edited_file_is_re_read_after_an_edit(project: Path) -> None:
+    _index(project)
+    _write(project, "pkg/late.py", "from .target import VALUE\n")
+
+    answer = resolve_dependents("pkg/target.py", project)
+
+    assert (answer.basis, answer.delta_files) == ("index_delta", 1)
+
+
+def test_a_file_created_after_indexing_is_still_found_as_a_dependent(
+    project: Path,
+) -> None:
+    # Missing a dependent is the dangerous failure mode: the agent is told a
+    # change is safe when it is not. A file the index has never seen must be
+    # established by reading it, not skipped.
+    _index(project)
+    _write(project, "pkg/late.py", "from .target import VALUE\n")
+
+    answer = resolve_dependents("pkg/target.py", project)
+
+    assert "pkg/late.py" in answer.dependents
+
+
+def test_answer_is_certified_when_the_call_graph_marker_is_current(
+    project: Path,
+) -> None:
+    _index(project)
+
+    answer = resolve_dependents("pkg/target.py", project)
+
+    assert (answer.certified, answer.certification_reason) == (True, None)
+
+
+def test_revoked_call_graph_marker_labels_the_answer_uncertified(
+    project: Path,
+) -> None:
+    # A revoked marker must not be read as authoritative, but it also must not
+    # make the dependents set unavailable: the marker certifies the call-edge
+    # pipeline, and this answer reads no call edges.
+    _index(project)
+    from tree_sitter_analyzer.cache.callgraph_state import (
+        clear_call_graph_built_strict,
+    )
+
+    conn = sqlite3.connect(project / ".ast-cache" / "index.db")
+    try:
+        clear_call_graph_built_strict(conn)
+    finally:
+        conn.close()
+
+    answer = resolve_dependents("pkg/target.py", project)
+
+    assert (answer.basis, answer.certified, answer.certification_reason) == (
+        "index",
+        False,
+        "CALL_GRAPH_INCOMPLETE",
+    )
+
+
+def test_revoked_marker_still_returns_the_full_dependents_set(project: Path) -> None:
+    _index(project)
+    from tree_sitter_analyzer.cache.callgraph_state import (
+        clear_call_graph_built_strict,
+    )
+
+    conn = sqlite3.connect(project / ".ast-cache" / "index.db")
+    try:
+        clear_call_graph_built_strict(conn)
+    finally:
+        conn.close()
+
+    answer = resolve_dependents("pkg/target.py", project)
+
+    assert answer.dependents == frozenset(
+        {"pkg/absolute_importer.py", "pkg/importer.py"}
+    )
+
+
+def test_absent_index_falls_back_to_the_scan_and_says_so(project: Path) -> None:
+    answer = resolve_dependents("pkg/target.py", project)
+
+    assert (answer.basis, answer.certified, answer.certification_reason) == (
+        "scan",
+        False,
+        "INDEX_ABSENT",
+    )
+
+
+def test_scan_fallback_is_a_superset_of_the_index_answer(project: Path) -> None:
+    # The fallback must never be smaller than the derived answer: reporting a
+    # smaller set is the failure mode that causes a wrong edit.
+    scan = resolve_dependents("pkg/target.py", project)
+    _index(project)
+    indexed = resolve_dependents("pkg/target.py", project)
+
+    assert indexed.dependents <= scan.dependents
+
+
+def test_delta_cap_exceeded_falls_back_to_the_scan(
+    project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _index(project)
+    monkeypatch.setattr(dependents_index, "DELTA_READ_CAP", 0)
+    _write(project, "pkg/late.py", "from .target import VALUE\n")
+
+    answer = resolve_dependents("pkg/target.py", project)
+
+    assert (answer.basis, answer.certification_reason) == (
+        "scan",
+        "DELTA_CAP_EXCEEDED",
+    )
+
+
+def test_delta_read_cap_is_a_positive_bound() -> None:
+    assert DELTA_READ_CAP == 400
+
+
+def test_unreadable_file_is_reported_rather_than_dropped(
+    project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _index(project)
+    _write(project, "pkg/late.py", "from .target import VALUE\n")
+    original = Path.read_text
+
+    def failing_read_text(self: Path, *args: object, **kwargs: object) -> str:
+        if self.name == "late.py":
+            raise OSError("permission denied")
+        return original(self, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "read_text", failing_read_text)
+
+    answer = resolve_dependents("pkg/target.py", project)
+
+    assert (answer.unestablished, answer.certification_reason) == (
+        ("pkg/late.py",),
+        "UNESTABLISHED_FILES",
+    )
+
+
+def test_out_of_scope_target_reports_an_unestablished_empty_set(
+    project: Path,
+) -> None:
+    # A .cs target cannot be named by any resolver this module runs, so the
+    # empty set must not look like a proven "nothing imports this".
+    _write(project, "pkg/Thing.cs", "class Thing {}\n")
+    _index(project)
+
+    answer = resolve_dependents("pkg/Thing.cs", project)
+
+    assert (
+        answer.dependents,
+        answer.certified,
+        answer.certification_reason,
+        answer.unestablished,
+    ) == (frozenset(), False, "TARGET_OUT_OF_SCOPE", ("pkg/Thing.cs",))
+
+
+def test_index_row_the_enumeration_missed_is_reconciled(
+    project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # If the enumeration disagrees with the indexer (e.g. os.walk follows a
+    # symlinked directory and scandir(follow_symlinks=False) does not), the
+    # missed file must be read, not dropped: dropping it loses a dependent.
+    _index(project)
+    real_inventory = dependents_index._live_inventory
+
+    def blind_inventory(root: Path) -> dict[str, tuple[int, int]]:
+        inventory = real_inventory(root)
+        inventory.pop("pkg/importer.py", None)
+        return inventory
+
+    monkeypatch.setattr(dependents_index, "_live_inventory", blind_inventory)
+
+    answer = resolve_dependents("pkg/target.py", project)
+
+    assert "pkg/importer.py" in answer.dependents
+
+
+def test_prefilter_covers_a_parent_package_relative_import() -> None:
+    # ``from .. import lua_plugin`` names the package initializer without
+    # containing the initializer's own path or dotted module. A prefilter built
+    # only from those needles would drop a real dependent.
+    needles = prefilter_needles("a/b/lua_plugin/__init__.py")
+
+    assert "lua_plugin" in needles
+
+
+def test_prefilter_covers_a_directory_index_import() -> None:
+    # ``import x from "./dir"`` resolves to ``dir/index.ts``.
+    needles = prefilter_needles("a/dir/index.ts")
+
+    assert needles == frozenset({"index", "dir"})
+
+
+def test_prefilter_covers_a_java_wildcard_package_import() -> None:
+    # ``import com.foo.*;`` never names Bar.
+    needles = prefilter_needles("com/foo/Bar.java")
+
+    assert "foo" in needles
+
+
+def test_mjs_importer_of_an_mts_target_is_a_dependent(tmp_path: Path) -> None:
+    # .mjs/.cjs/.mts/.cts support and the ESM dispatch fix landed recently; the
+    # index-derived answer must not regress them.
+    root = tmp_path / "esm"
+    root.mkdir()
+    _write(root, "src/target.mts", "export const V = 1;\n")
+    _write(root, "src/consumer.mts", 'import { V } from "./target.mjs";\n')
+    _index(root)
+
+    answer = resolve_dependents("src/target.mts", root)
+
+    assert answer.dependents == frozenset({"src/consumer.mts"})
+
+
+def test_answer_shape_is_frozen() -> None:
+    answer = DependentsAnswer(
+        dependents=frozenset({"a.py"}),
+        basis="index",
+        certified=True,
+        certification_reason=None,
+        scanned_files=1,
+        delta_files=0,
+        unestablished=(),
+    )
+
+    with pytest.raises(AttributeError):
+        answer.basis = "scan"  # type: ignore[misc]
+
+
+def test_index_derivation_reads_less_than_the_scan(project: Path) -> None:
+    # A relationship, not a millisecond ceiling: the derived path must read
+    # strictly fewer source files than the whole-tree scan it replaces.
+    _index(project)
+    reads_index: list[str] = []
+    reads_scan: list[str] = []
+    original = Path.read_text
+
+    def make_counter(sink: list[str]):
+        def counting(self: Path, *args: object, **kwargs: object) -> str:
+            sink.append(str(self))
+            return original(self, *args, **kwargs)  # type: ignore[arg-type]
+
+        return counting
+
+    import unittest.mock as mock
+
+    with mock.patch.object(Path, "read_text", make_counter(reads_index)):
+        resolve_dependents("pkg/target.py", project)
+    with mock.patch.object(Path, "read_text", make_counter(reads_scan)):
+        dependents_index.scan_dependents("pkg/target.py", project)
+
+    assert len(reads_index) < len(reads_scan)

--- a/tree_sitter_analyzer/mcp/tools/utils/dependents_index.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/dependents_index.py
@@ -1,0 +1,401 @@
+"""RFC-0025 Layer 1: incremental derivation of a file's dependents.
+
+``edit action=safe`` is the call an agent makes before every edit, and the
+question it cannot answer cheaply is *who imports this file*. Before this
+module that answer was re-derived on every call by walking the whole tree,
+reading every source file, and substring-matching the target's basename
+(``safe_to_edit_helpers._target_dependents``). Two things were wrong with it:
+
+* **Cost.** A cProfile of one warm ``edit action=safe`` on this repository
+  attributed 2.026 s of 3.739 s to ``Path.read_text`` over 5,799 calls, ~956 ms
+  of it inside the dependents walk. The L6.1 answer cache makes a *repeat*
+  question cheap, but every edit bumps the generation, so the first call after
+  each edit — the only call the edit loop actually makes — paid it again.
+* **Precision.** The needle set includes the target's bare basename, so any
+  file merely *mentioning* the word counted. Measured against a
+  filesystem-confirmed resolver over 10 targets in this repository: 821
+  reported dependents, 39 genuine, **782 false**. ``cache/schema.py`` reported
+  479 dependents; 7 import it.
+
+This module derives the answer from the persisted AST index instead:
+``ast_index.imports_json`` already holds every file's import statements for
+every language whose plugin extracts them. The tree is still enumerated — with
+``os.scandir`` and no reads — because completeness requires accounting for
+files the index has never seen. Only files the index cannot vouch for are
+read, which makes the derivation incremental per changed file.
+
+Freshness contract
+------------------
+A row vouches for a file when ``(mtime_ns, file_size)`` match the live entry.
+That is the same predicate ``incremental_sync_support.file_changed`` uses to
+decide what to re-index, so this path cannot disagree with the writer about
+what "unchanged" means. It is deliberately *stricter*: ``file_changed`` falls
+back to a content hash when only the mtime moved and may still conclude
+"unchanged", whereas any mismatch here sends the file to the delta and it is
+read. The residual hole is a mtime-preserving same-size replacement
+(``tar -x``, ``cp -p``, ``rsync --times``); RFC-0027 §L6.1 records the same
+residual for the answer-cache stamp. The RFC-0025 watch loop closes it; this
+module does not attempt to.
+
+Certification
+-------------
+The ``call-graph-built`` marker is honoured as a **label, not a gate**. It
+certifies the call-edge pipeline, and this answer reads no call edges: it reads
+``ast_index.imports_json``, verified per file against the live tree. Refusing
+to answer on a revoked marker would make the pre-edit gate unusable — measured
+on a stock checkout of this repository, ``--full-index`` exits 1 with
+``verdict=WARN`` and ``built=0`` purely because two optional grammars (Swift,
+Lua) are not installed, which has nothing to do with Python import edges. So a
+revoked marker yields the derived answer with ``certified=False`` and
+``certification_reason="CALL_GRAPH_INCOMPLETE"``, never a silently smaller set
+and never a silently authoritative one.
+
+Known coverage gap (unchanged by this module, and not claimed to be fixed):
+Go, Rust and C/C++ include syntax is resolved by neither the derived path nor
+the scan it replaces, so those files contribute no dependents in either. They
+are not reported as ``unestablished`` because that field tracks *this call's*
+failures, not a pre-existing language gap.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from .safe_to_edit_helpers import (
+    _DEPENDENCY_SKIP_DIRS,
+    _DEPENDENCY_SOURCE_EXTS,
+    _extract_import_specs,
+    _import_targets_from_text,
+    _module_path_without_suffix,
+    _resolve_import_spec,
+    _target_dependents_by_scan,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Above this many files the index is too far behind to be an incremental
+#: derivation, and reading them one by one would cost more than the scan it
+#: replaces. The scan is a proven superset, so falling back to it is the safe
+#: direction.
+DELTA_READ_CAP = 400
+
+Basis = Literal["index", "index_delta", "scan"]
+
+
+@dataclass(frozen=True)
+class DependentsAnswer:
+    """One dependents set plus how completely it was established."""
+
+    dependents: frozenset[str]
+    basis: Basis
+    certified: bool
+    certification_reason: str | None
+    scanned_files: int
+    delta_files: int
+    unestablished: tuple[str, ...]
+
+
+def prefilter_needles(target_rel: str) -> frozenset[str]:
+    """Return substrings that every import naming *target_rel* must contain.
+
+    This is a **soundness-critical superset**: an import statement that
+    resolves to the target and contains none of these would be dropped before
+    the exact resolver ever saw it, which is the dangerous direction.
+
+    The target's own module path is not sufficient. Three forms name a file
+    without containing it:
+
+    * ``from .. import pkg`` names ``pkg/__init__.py``,
+    * ``import x from "./dir"`` names ``dir/index.ts``,
+    * ``import com.foo.*;`` names ``com/foo/Bar.java``.
+
+    All three contain the file's parent directory name, so that token is added
+    for exactly those three shapes. It is *not* added otherwise: the parent of
+    a top-level module is the distribution package itself
+    (``tree_sitter_analyzer``), which appears in nearly every import statement
+    in the repository, and adding it made the filter select ~everything —
+    measured at a 0.3x slowdown before this restriction. Every other import
+    form must spell the file's own stem.
+    """
+    path = Path(target_rel)
+    stem = _module_path_without_suffix(path).name
+    needles = {stem}
+    if stem in {"__init__", "index"} or path.suffix.lower() == ".java":
+        needles.add(path.parent.name)
+    return frozenset(token for token in needles if token)
+
+
+def scan_dependents(target_rel: str, root: Path) -> frozenset[str]:
+    """Return the legacy whole-tree scan answer (a superset, and slow)."""
+    return frozenset(_target_dependents_by_scan(root / target_rel, target_rel, root))
+
+
+def _live_inventory(root: Path) -> dict[str, tuple[int, int]]:
+    """Map repo-relative path to ``(mtime_ns, size)`` without reading a file.
+
+    ``os.scandir`` carries the stat data the directory enumeration already
+    returned, so freshness verification costs no extra syscall per file.
+    """
+    inventory: dict[str, tuple[int, int]] = {}
+    stack = [str(root)]
+    while stack:
+        try:
+            entries = list(os.scandir(stack.pop()))
+        except OSError:
+            continue
+        for entry in entries:
+            if entry.name.startswith("."):
+                continue
+            try:
+                is_dir = entry.is_dir(follow_symlinks=False)
+            except OSError:
+                continue
+            if is_dir:
+                if entry.name not in _DEPENDENCY_SKIP_DIRS:
+                    stack.append(entry.path)
+                continue
+            if Path(entry.name).suffix.lower() not in _DEPENDENCY_SOURCE_EXTS:
+                continue
+            try:
+                stat = entry.stat()
+            except OSError:
+                continue
+            rel = os.path.relpath(entry.path, root).replace("\\", "/")
+            inventory[rel] = (stat.st_mtime_ns, stat.st_size)
+    return inventory
+
+
+def _fresh_rows(
+    conn: sqlite3.Connection, inventory: dict[str, tuple[int, int]], root: Path
+) -> set[str]:
+    """Return the inventory paths whose index row matches the live file.
+
+    Rows for in-scope extensions that this module's enumeration did not produce
+    are *reconciled*, not ignored. Two things can cause them: the file was
+    deleted (harmless), or the enumeration disagrees with the indexer's — for
+    example ``os.walk`` follows a symlinked directory and this module's
+    ``is_dir(follow_symlinks=False)`` does not. The second case would drop a
+    real dependent, which is the dangerous direction, so any such row that
+    still resolves to a file is added to the inventory and read. The stat cost
+    is bounded by the number of rows *absent* from the enumeration, which is
+    zero on a tree the enumeration covers.
+    """
+    fresh: set[str] = set()
+    for file_path, mtime_ns, file_size in conn.execute(
+        "SELECT file_path, mtime_ns, file_size FROM ast_index"
+    ):
+        rel = str(file_path).replace("\\", "/")
+        live = inventory.get(rel)
+        if live is None:
+            if (
+                Path(rel).suffix.lower() in _DEPENDENCY_SOURCE_EXTS
+                and (root / rel).is_file()
+            ):
+                # Enumeration gap, not a deletion: force it into the delta.
+                inventory[rel] = (-1, -1)
+            continue
+        if live == (int(mtime_ns or 0), int(file_size or 0)):
+            fresh.add(rel)
+    return fresh
+
+
+def _indexed_candidates(
+    conn: sqlite3.Connection, needles: frozenset[str], fresh: set[str]
+) -> list[tuple[str, str]]:
+    """Return ``(rel_path, imports_json)`` for fresh rows passing the prefilter.
+
+    ``instr`` rather than ``LIKE``: an underscore is a ``LIKE`` wildcard and
+    module names are full of them, so ``LIKE`` would need escaping to mean what
+    a substring test means. ``instr`` is already a byte-exact substring test.
+    """
+    ordered = sorted(needles)
+    if not ordered:
+        return []
+    clause = " OR ".join("instr(imports_json, ?) > 0" for _ in ordered)
+    rows = conn.execute(
+        f"SELECT file_path, imports_json FROM ast_index WHERE {clause}",  # noqa: S608
+        tuple(ordered),
+    )
+    candidates: list[tuple[str, str]] = []
+    for file_path, imports_json in rows:
+        rel = str(file_path).replace("\\", "/")
+        if rel in fresh:
+            candidates.append((rel, imports_json or "[]"))
+    return candidates
+
+
+def _imports_name_target(
+    imports_json: str,
+    importer_rel: str,
+    target_rel: str,
+    inventory_set: frozenset[str],
+    needles: frozenset[str],
+) -> bool | None:
+    """Resolve one file's projected imports. ``None`` means unparseable.
+
+    The SQL prefilter matched the file's whole import blob; most individual
+    statements in that blob still cannot name the target, so the same
+    soundness-preserving needle test is applied per statement before paying for
+    the exact resolver.
+    """
+    try:
+        entries = json.loads(imports_json)
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(entries, list):
+        return None
+    for entry in entries:
+        text = entry.get("text", "") if isinstance(entry, dict) else ""
+        if not text or not any(needle in text for needle in needles):
+            continue
+        if target_rel in _import_targets_from_text(text, importer_rel, inventory_set):
+            return True
+    return False
+
+
+def _read_imports_target(importer_rel: str, target_rel: str, root: Path) -> bool | None:
+    """Establish one file's imports by reading it. ``None`` means unreadable."""
+    try:
+        source = (root / importer_rel).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    suffix = Path(importer_rel).suffix.lower()
+    for spec in _extract_import_specs(source, suffix):
+        if _resolve_import_spec(spec, importer_rel, root) == target_rel:
+            return True
+    return False
+
+
+def _scan_answer(
+    target_rel: str, root: Path, reason: str, scanned: int
+) -> DependentsAnswer:
+    return DependentsAnswer(
+        dependents=scan_dependents(target_rel, root),
+        basis="scan",
+        certified=False,
+        certification_reason=reason,
+        scanned_files=scanned,
+        delta_files=0,
+        unestablished=(),
+    )
+
+
+def _marker_is_current(conn: sqlite3.Connection) -> bool:
+    """Read the marker row only, not the call-edge consistency scan.
+
+    ``call_graph_marker_is_current`` also runs ``call_graph_edges_are_consistent``,
+    which walks every ``edges`` row — 185,952 of them on this repository, and
+    measured at 5-14 s per call, dominating everything else this module does.
+    That scan certifies that resolved *call* targets are not dangling. This
+    answer reads no call edges, so the scan is irrelevant to it; the marker row
+    is the part that says "the pipeline certified itself at the current
+    version", and that is what the label reports.
+    """
+    from ....cache.callgraph_state import exact_call_graph_marker
+
+    try:
+        return bool(exact_call_graph_marker(conn))
+    except sqlite3.DatabaseError:
+        return False
+
+
+def resolve_dependents(target_rel: str, root: Path) -> DependentsAnswer:
+    """Return who imports *target_rel*, derived from the persisted index.
+
+    The tree is enumerated (stat only) so that a file the index has never seen
+    is still accounted for; only files the index cannot vouch for are read.
+    """
+    root = Path(root)
+    target_rel = target_rel.replace("\\", "/")
+    db_path = root / ".ast-cache" / "index.db"
+    inventory = _live_inventory(root)
+    if not db_path.is_file():
+        return _scan_answer(target_rel, root, "INDEX_ABSENT", len(inventory))
+
+    try:
+        conn = sqlite3.connect(str(db_path))
+    except sqlite3.Error:
+        return _scan_answer(target_rel, root, "INDEX_UNREADABLE", len(inventory))
+    try:
+        return _derive(conn, target_rel, root, inventory)
+    except sqlite3.DatabaseError:
+        logger.debug("dependents index unreadable; falling back", exc_info=True)
+        return _scan_answer(target_rel, root, "INDEX_UNREADABLE", len(inventory))
+    finally:
+        conn.close()
+
+
+def _derive(
+    conn: sqlite3.Connection,
+    target_rel: str,
+    root: Path,
+    inventory: dict[str, tuple[int, int]],
+) -> DependentsAnswer:
+    """Derive the answer from *conn*, reading only what the index cannot cover."""
+    fresh = _fresh_rows(conn, inventory, root)
+    inventory_set = frozenset(inventory)
+    if target_rel not in inventory_set:
+        # The resolvers can only name a file that is in the inventory, so an
+        # out-of-scope target (``.cs``, ``.rb``, ``.kt``, ``.swift``, ...) would
+        # yield an empty set that *looks* like a proven "nothing imports this".
+        # The scan is not a usable fallback here either: it only reads
+        # in-scope extensions, so every match it reports for such a target is a
+        # prose match by construction. Report the empty set as unestablished.
+        return DependentsAnswer(
+            dependents=frozenset(),
+            basis="index",
+            certified=False,
+            certification_reason="TARGET_OUT_OF_SCOPE",
+            scanned_files=len(inventory),
+            delta_files=0,
+            unestablished=(target_rel,),
+        )
+    delta = sorted(rel for rel in inventory if rel not in fresh and rel != target_rel)
+    if len(delta) > DELTA_READ_CAP:
+        return _scan_answer(target_rel, root, "DELTA_CAP_EXCEEDED", len(inventory))
+
+    needles = prefilter_needles(target_rel)
+    dependents: set[str] = set()
+    unestablished: list[str] = []
+    extra_delta: list[str] = []
+    for rel, imports_json in _indexed_candidates(conn, needles, fresh):
+        if rel == target_rel:
+            continue
+        named = _imports_name_target(
+            imports_json, rel, target_rel, inventory_set, needles
+        )
+        if named is None:
+            extra_delta.append(rel)
+        elif named:
+            dependents.add(rel)
+
+    for rel in [*delta, *extra_delta]:
+        named = _read_imports_target(rel, target_rel, root)
+        if named is None:
+            unestablished.append(rel)
+        elif named:
+            dependents.add(rel)
+
+    delta_files = len(delta) + len(extra_delta)
+    marker_current = _marker_is_current(conn)
+    if unestablished:
+        reason: str | None = "UNESTABLISHED_FILES"
+    elif not marker_current:
+        reason = "CALL_GRAPH_INCOMPLETE"
+    else:
+        reason = None
+    return DependentsAnswer(
+        dependents=frozenset(dependents),
+        basis="index_delta" if delta_files else "index",
+        certified=reason is None,
+        certification_reason=reason,
+        scanned_files=len(inventory),
+        delta_files=delta_files,
+        unestablished=tuple(sorted(unestablished)),
+    )

--- a/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
@@ -132,14 +132,19 @@ def build_safe_to_edit_result(context: SafeToEditContext) -> dict[str, Any]:
 
 def _collect_safe_to_edit_facts(context: SafeToEditContext) -> SafeToEditFacts:
     """Collect graph, health, test, and risk facts for a file."""
-    # Canonicalize before relativising: on macOS the security validator's
-    # abspath (/var/folders/...) and a canonical project_root
-    # (/private/var/folders/...) differ by symlink, which would make
-    # to_relative fall back to the absolute path and miss every graph node
-    # (CLAUDE.md §2 resolution contract) — downstream facts would silently
-    # undercount on macOS while Linux CI saw them.
+    # Canonicalize both sides before relativising. On macOS the security
+    # validator's abspath (/var/folders/...) differs from a canonical root
+    # (/private/var/folders/...) by symlink. On any platform, a relative
+    # project_root ("." or "..") causes Path(abs).relative_to(rel) to raise
+    # ValueError, so to_relative falls back to the absolute path — the returned
+    # key then misses every node in FileDependencyView._dependents, which is
+    # keyed by resolved-relative paths (build_file_dependency_view §L1).
+    # (CLAUDE.md §2 resolution contract)
     rel_path = _normalize_relative_path(
-        to_relative(os.path.realpath(context.resolved_path), context.project_root)
+        to_relative(
+            os.path.realpath(context.resolved_path),
+            os.path.realpath(context.project_root),
+        )
     )
     dependents = safe_dependents(context.graph, rel_path)
     dependencies = safe_dependencies(context.graph, rel_path)
@@ -247,7 +252,10 @@ def _format_safe_to_edit_result(
     # violation referencing this file forces UNSAFE; warn-only forces
     # CAUTION. The base_verdict (derived from risk_level) is the floor.
     certified_rel_path = _normalize_relative_path(
-        to_relative(os.path.realpath(context.resolved_path), context.project_root)
+        to_relative(
+            os.path.realpath(context.resolved_path),
+            os.path.realpath(context.project_root),
+        )
     )
     if context.snapshot_conn is not None:
         # Codex P1 (#1299): the certified read_existing route runs the
@@ -287,11 +295,30 @@ def _format_safe_to_edit_result(
     verdict = _max_verdict(
         _max_verdict(base_verdict, constraint_verdict), fixture_verdict
     )
+    # Fail-closed: an uncertified dependents set cannot support a SAFE verdict.
+    # The set was derived from the index but completeness was not certified —
+    # there may be additional dependents outside the index scope. Escalate so
+    # agents do not proceed on a false-safe signal.
+    _da = getattr(context.graph, "dependents_answer", None)
+    _escalated_uncertified = _da is not None and not _da.certified and verdict == "SAFE"
+    if _escalated_uncertified:
+        verdict = "CAUTION"
     risk_factors = list(facts.risk_factors)
     if violations:
         risk_factors.extend(constraint_risk_factor(row) for row in violations)
     if fixture_fact.is_fixture:
         risk_factors.append(_fixture_risk_factor(fixture_fact, context.file_path))
+    if _escalated_uncertified:
+        risk_factors.append(
+            {
+                "factor": "uncertified_dependents",
+                "detail": (
+                    f"Dependents not fully established "
+                    f"({_da.certification_reason}); cannot confirm SAFE"  # type: ignore[union-attr]
+                ),
+                "severity": "caution",
+            }
+        )
     # #1027: build the recommendation from the FINAL (possibly escalated)
     # verdict, never the un-escalated ``risk``. A constraint/fixture
     # promotion that lifts SAFE→UNSAFE must lift the recommendation too,

--- a/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/safe_to_edit_helpers.py
@@ -59,10 +59,16 @@ class FileDependencyView:
         rel_path: str,
         dependencies: set[str],
         dependents: set[str],
+        dependents_answer: Any | None = None,
     ) -> None:
         self._nodes = {rel_path, *dependencies, *dependents}
         self._deps = {rel_path: dependencies}
         self._dependents = {rel_path: dependents}
+        #: The RFC-0025 L1 ``DependentsAnswer`` this view's dependents came
+        #: from, or ``None`` for hand-built views. Carries how completely the
+        #: set was established so the response can say so rather than
+        #: presenting a fallback as the derived answer.
+        self.dependents_answer = dependents_answer
 
     def has_node(self, file_rel: str) -> bool:
         """Return True if *file_rel* is a node in this view (O(1) set lookup)."""
@@ -353,6 +359,39 @@ def _format_safe_to_edit_result(
         "pre_edit_checklist": facts.pre_edit_checklist,
         "agent_workflow": workflow,
         "causal_envelope": causal_envelope,
+        **_dependents_basis_fields(context.graph),
+    }
+
+
+def _dependents_basis_fields(graph: Any) -> dict[str, Any]:
+    """Report how the dependents set was established (RFC-0025 L1).
+
+    A stale or unusable index must not be read as authoritative, and a
+    fall-back must not be presented as the derived answer. ``dependents_basis``
+    says which path produced the set; ``dependents_certified`` and
+    ``dependents_certification_reason`` say whether it can be trusted as
+    complete.
+
+    These are deliberately **flat scalars** rather than a nested block: a
+    dict-valued key is a "bulk" value that TOON formatting strips, so the label
+    would vanish on exactly the surface (MCP) whose callers most need it.
+
+    ``dependents_basis="unavailable"`` is the hand-built or snapshot-certified
+    view, which reports its completeness through ``causal_envelope`` instead.
+    """
+    answer = getattr(graph, "dependents_answer", None)
+    if answer is None:
+        return {
+            "dependents_basis": "unavailable",
+            "dependents_certified": False,
+            "dependents_certification_reason": "NOT_DERIVED",
+            "dependents_delta_files": 0,
+        }
+    return {
+        "dependents_basis": answer.basis,
+        "dependents_certified": answer.certified,
+        "dependents_certification_reason": answer.certification_reason,
+        "dependents_delta_files": answer.delta_files,
     }
 
 
@@ -716,18 +755,21 @@ def build_file_dependency_view(
     ``safe_to_edit`` is latency-sensitive. A whole-project tree-sitter
     dependency graph is useful, but cold-building it for every MCP process
     makes the common pre-edit check too slow. This view keeps the same lookup
-    contract while limiting work to the target file plus a pruned text scan for
-    obvious importers.
+    contract while limiting work to the target file plus an incremental
+    dependents derivation (RFC-0025 L1, :mod:`dependents_index`).
     """
+    from .dependents_index import resolve_dependents
+
     root = Path(project_root).resolve()
     target = Path(resolved_path).resolve()
     rel_path = _normalize_relative_path(to_relative(str(target), str(root)))
     dependencies = _target_dependencies(target, rel_path, root)
-    dependents = _target_dependents(target, rel_path, root)
+    answer = resolve_dependents(rel_path, root)
     return FileDependencyView(
         rel_path=rel_path,
         dependencies=dependencies,
-        dependents=dependents,
+        dependents=set(answer.dependents),
+        dependents_answer=answer,
     )
 
 
@@ -746,6 +788,28 @@ def _target_dependencies(target: Path, rel_path: str, root: Path) -> set[str]:
 
 
 def _target_dependents(target: Path, rel_path: str, root: Path) -> set[str]:
+    """Return who imports *rel_path*, derived from the persisted AST index.
+
+    RFC-0025 Layer 1. Delegates to :mod:`dependents_index`, which reads
+    ``ast_index.imports_json`` and re-reads only the files the index cannot
+    vouch for. Falls back to :func:`_target_dependents_by_scan` — the previous
+    whole-tree read — when no usable index is present. The import is deferred
+    because ``dependents_index`` reuses this module's resolvers.
+    """
+    from .dependents_index import resolve_dependents
+
+    return set(resolve_dependents(rel_path, root).dependents)
+
+
+def _target_dependents_by_scan(target: Path, rel_path: str, root: Path) -> set[str]:
+    """Return dependents by reading every source file in the tree.
+
+    Kept as the fail-closed fallback for when the index cannot establish the
+    set: this is a superset of the derived answer (measured on this repository:
+    821 reported, 39 genuine), and returning a superset is the safe direction
+    for a pre-edit gate. It is not the primary path because it costs ~1 s per
+    call and 95% of what it reports is a prose match, not an import.
+    """
     needles = _import_needles_for_target(rel_path)
     if not needles:
         return set()


### PR DESCRIPTION
## Summary

- Derives `edit action=safe` dependents from `ast_index.imports_json` incrementally rather than re-walking the full project tree on every call (RFC-0025 L1, `dependents_index.py`)
- Fixes a fail-open bug: when `project_root="."`, `to_relative(abs_path, ".")` raised `ValueError` and fell back to the absolute path, causing `safe_dependents` to look up the wrong key in `FileDependencyView._dependents` — returning `[]` and producing `verdict=SAFE` even with 5 real dependents
- Fail-closed escalation: when `dependents_answer.certified=False`, escalates `SAFE` → `CAUTION` with an `uncertified_dependents` risk factor; an uncertified empty set cannot honestly support a SAFE verdict

## Key measurements (from the L1 commit)

| Route | Before | After (warm) |
|---|---|---|
| `edit action=safe` | ~3400ms p95 | ~50ms p95 (index path) |
| `health action=file` | ~430ms p95 | ~48ms p95 |

Interleaved pre-edit pair: 6/6 cache hits confirmed.

## What the fail-open fix changes

Before fix (`project_root="."`):
- `to_relative(abs_path, ".")` → falls back to absolute path
- `safe_dependents(view, abs_path)` → `[]` (key miss)
- `downstream_count=0` → `verdict=SAFE` (fail-open)

After fix (both sides realpath'd):
- `to_relative(realpath(abs_path), realpath("."))` → `"tree_sitter_analyzer/latency.py"`
- `safe_dependents(view, rel_path)` → correct set
- When `certified=False`: verdict escalated `SAFE` → `CAUTION`

## Test plan

- [ ] 3 new RED-first tests in `test_safe_to_edit_dependency_view.py`:
  - `test_to_relative_with_unresolved_root_falls_back_to_absolute_path` — proves the key mismatch bug
  - `test_safe_dependents_returns_empty_for_absolute_path_key` — proves the downstream effect
  - `test_uncertified_dependents_escalate_safe_verdict_to_caution` — proves the fail-closed escalation
- [ ] All pre-existing tests pass (3 failures are pre-existing Windows/baseline)
- [ ] All pre-commit hooks pass (ruff, mypy, encoding ratchet, weak-assertion ratchet)