### PR TITLE
fix(task12): expand Ruby and PHP file extension tables

### DIFF
--- a/tree_sitter_analyzer/languages/lang_extension_map.py
+++ b/tree_sitter_analyzer/languages/lang_extension_map.py
@@ -60,8 +60,18 @@ EXT_TO_LANG: dict[str, str] = {
     ".mjs": "javascript",
     ".mts": "typescript",
     ".php": "php",
+    ".php3": "php",
+    ".php4": "php",
+    ".php5": "php",
+    ".php7": "php",
+    ".phps": "php",
+    ".phtml": "php",
     ".py": "python",
     ".rb": "ruby",
+    ".rake": "ruby",
+    ".gemspec": "ruby",
+    ".ru": "ruby",
+    ".rbw": "ruby",
     ".rs": "rust",
     # .sc (Scala scripts / Ammonite) intentionally NOT wired — ambiguous
     # with SuperCollider; the plugin still accepts it via an explicit

--- a/tree_sitter_analyzer/languages/php_plugin.py
+++ b/tree_sitter_analyzer/languages/php_plugin.py
@@ -422,7 +422,7 @@ class PHPPlugin(LanguagePlugin):
         Returns:
             List of file extensions
         """
-        return [".php"]
+        return [".php", ".phtml", ".php3", ".php4", ".php5", ".php7", ".phps"]
 
     def get_tree_sitter_language(self) -> tree_sitter.Language:
         """

--- a/tree_sitter_analyzer/languages/ruby_plugin.py
+++ b/tree_sitter_analyzer/languages/ruby_plugin.py
@@ -478,7 +478,7 @@ class RubyPlugin(LanguagePlugin):
         return "ruby"
 
     def get_file_extensions(self) -> list[str]:
-        return [".rb"]
+        return [".rb", ".rake", ".gemspec", ".ru", ".rbw"]
 
     def get_tree_sitter_language(self) -> tree_sitter.Language:
         """Get the tree-sitter Language instance for Ruby (cached class-level)."""


### PR DESCRIPTION
## Summary

- Ruby: adds `.rake`, `.gemspec`, `.ru`, `.rbw` to `get_file_extensions()` and `EXT_TO_LANG`
- PHP: adds `.phtml`, `.php3`, `.php4`, `.php5`, `.php7`, `.phps` to `get_file_extensions()` and `EXT_TO_LANG`
- The 6 scaffold plugins (json, css, html, markdown, sql, yaml) remain intentionally unwired — their ast_cache indexing path is not fully validated yet

## Test plan

- [x] `uv run pytest tests/unit/test_lang_extension_map.py -x -q` → 15 passed
- [x] All pre-commit hooks pass
- [ ] CI green on all axes

🤖 Generated with [Claude Code](https://claude.com/claude-code)