### PR TITLE
fix(task16): add output_format to action=card description in project facade

### DIFF
--- a/tree_sitter_analyzer/mcp/tools/project_facade.py
+++ b/tree_sitter_analyzer/mcp/tools/project_facade.py
@@ -85,7 +85,7 @@ _PROJECT_DESCRIPTION = (
     "descriptions of the top-level structure. Persistent — built once into "
     ".tree-sitter-cache/project-index.json and recalled instantly. Best first "
     "call on an unfamiliar repo when you want the *what*, not the file list. "
-    "Params: force_refresh, include_notes.\n"
+    "Params: force_refresh, include_notes, output_format.\n"
     "\n"
     "DECISION + DOC (may write):\n"
     "- action=journal — persistent architectural decision journal. "


### PR DESCRIPTION
## Summary

- `project action=card` description in `project_facade.py` omitted `output_format`, so agents reading the tool schema had no way to discover the parameter
- The implementation already honours `output_format` — this is a documentation-only fix
- No behavioral change

## Test plan

- [x] All pre-commit hooks pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)