### PR TITLE
fix(test): fix Windows flaky auto_index_guard caplog test

### DIFF
--- a/tests/unit/test_auto_index_guard_convergence.py
+++ b/tests/unit/test_auto_index_guard_convergence.py
@@ -449,6 +449,10 @@ def test_lock_recheck_discards_stale_marker_before_warmup(
 def test_successful_warmup_without_current_marker_remains_uncertified(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
+    import logging
+
+    caplog.set_level(logging.WARNING)
+
     class Cache:
         def get_stats(self) -> dict[str, int]:
             return {"total_files": 0}


### PR DESCRIPTION
## Summary

`test_successful_warmup_without_current_marker_remains_uncertified` fails on all Windows CI variants (3.11, 3.12, 3.13) because the `caplog` fixture doesn't capture the WARNING log message from `auto_index_guard.ensure_indexed()`.

**Root cause:** Without explicitly calling `caplog.set_level(logging.WARNING)`, the `caplog` fixture's default capture level may not include WARNING on Windows xdist workers, resulting in `caplog.text` being empty.

**Fix:** Add `caplog.set_level(logging.WARNING)` before the code under test.

## Test plan

- [x] Local test passes: `uv run pytest tests/unit/test_auto_index_guard_convergence.py::test_successful_warmup_without_current_marker_remains_uncertified -v`
- [x] Full local suite: 2014 passed (2 pre-existing env-specific failures)
- [x] CI will verify Windows 3.11/3.12/3.13

Refs: GH-1335

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>