### PR TITLE
fix(ci): stamp MCP responses with format=json for attestation workflow

### DIFF
--- a/tests/unit/mcp/test_utils/test_format_helper.py
+++ b/tests/unit/mcp/test_utils/test_format_helper.py
@@ -184,7 +184,7 @@ class TestApplyOutputFormatToResponse:
         """Test apply_output_format_to_response returns original for JSON format."""
         result = {"key": "value", "number": 42}
         response = apply_output_format_to_response(result, "json")
-        assert response == result
+        assert response == {**result, "format": "json"}
         assert "toon_content" not in response
 
     def test_success_gets_default_verdict(self):
@@ -250,6 +250,7 @@ def test_final_oracle_snapshot_publish_errors() -> None:
 
     assert errors["DIFF_SNAPSHOT_UNSUPPORTED_FILTER"] == {
         "success": False,
+        "format": "json",
         "verdict": "ERROR",
         "error_code": "DIFF_SNAPSHOT_UNSUPPORTED_FILTER",
         "error": "DIFF_SNAPSHOT_UNSUPPORTED_FILTER",

--- a/tree_sitter_analyzer/mcp/utils/format_helper.py
+++ b/tree_sitter_analyzer/mcp/utils/format_helper.py
@@ -47,9 +47,14 @@ def apply_output_format_to_response(
     output_format: str = "json",
 ) -> dict[str, Any]:
     """Normalize every MCP response to the canonical JSON response shape."""
-    if result.get("success") is True and "verdict" not in result:
-        return {**result, "verdict": "INFO"}
-    return result
+    # Always stamp the response with the output format for backward
+    # compatibility with consumers (e.g. the native-qualification
+    # attestation workflow) that read ``envelope["format"]``.
+    out = dict(result)
+    out.setdefault("format", "json")
+    if out.get("success") is True and "verdict" not in out:
+        out["verdict"] = "INFO"
+    return out
 
 
 def format_for_file_output(


### PR DESCRIPTION
## Summary

The native-qualification attestation workflow reads `envelope["format"]` from the MCP transcript to verify the output format. Our TOON removal (GH-1335) removed this field, causing a `KeyError` on CI.

**Fix:**
- Add `setdefault("format", "json")` to `apply_output_format_to_response` so all MCP responses carry the stamp
- Update `test_format_helper.py` tests to expect the `format` key

## Test plan

- [x] `uv run pytest tests/unit/mcp/test_utils/test_format_helper.py` — 27 passed
- [x] `uv run pytest tests/unit/mcp/utils/test_verdict_safety_net.py` — 5 passed
- [x] `uv run ruff check` — clean
- [x] `uv run python -m compileall -q` — clean

Refs: GH-1335

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>