### PR TITLE
feat(hotspot): add --hotspot command for Ca x MaxCC file ranking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# 🌳 Tree-sitter Analyzer
+# 🌳 Tree-sitter Analyzer
 
 **English** | **[日本語](README_ja.md)** | **[简体中文](README_zh.md)**
 
@@ -169,7 +169,7 @@ TSA ships curated workflows under `.claude/skills/tsa-*/`:
 
 Each skill ships an `allowed-tools` subset + procedure recipe + decision-surface schema, so the agent doesn't have to triage 8 tools on every question.
 
-### 331 CLI flags
+### 338 CLI flags
 
 Superset of CodeGraph's CLI surface. Highlights:
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,4 +1,4 @@
-﻿# 🌳 Tree-sitter Analyzer
+# 🌳 Tree-sitter Analyzer
 
 **[English](README.md)** | **日本語** | **[简体中文](README_zh.md)**
 
@@ -158,7 +158,7 @@ TSA は `.claude/skills/tsa-*/` 下にキュレーション済みワークフロ
 
 各 skill は `allowed-tools` ツール サブセット + 手順レシピ + 決定面スキーマを同梱し、エージェントは 8 個のツールから毎回選別する必要がありません。
 
-### 331 の CLI フラグ
+### 338 の CLI フラグ
 
 CodeGraph の CLI の厳密な上位互換。主なもの:
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,4 +1,4 @@
-﻿# 🌳 Tree-sitter Analyzer
+# 🌳 Tree-sitter Analyzer
 
 **[English](README.md)** | **[日本語](README_ja.md)** | **简体中文**
 
@@ -158,7 +158,7 @@ TSA 在 `.claude/skills/tsa-*/` 下提供精选工作流：
 
 每个 skill 都带 `allowed-tools` 工具子集 + 操作流程 + 决策面 schema，agent 不必在 8 个工具间反复挑选。
 
-### 331 个 CLI flag
+### 338 个 CLI flag
 
 CodeGraph CLI 的严格超集。亮点：
 

--- a/benchmarks/codegraph_compare/readme_claim_scanner.py
+++ b/benchmarks/codegraph_compare/readme_claim_scanner.py
@@ -32,11 +32,11 @@ _SAFE_SPANS = (
     re.compile(r"13 言語は `?pipeline_registered|13 种语言为 `?pipeline_registered"),
     re.compile(r"5 言語 gap|5 语言 gap"),
     re.compile(r"1 ワークフロー|一个工作流"),
-    # Re-pinned 2026-08-26: 333 -> 331 after TOON removal.
+    # Re-pinned 2026-08-31: 331 -> 338 for --hotspot flags (+7).
     # Deliberately an exact count, not \d+ — the registry must force a
     # conscious re-pin when the CLI surface changes.
-    re.compile(r"\b331 CLI flags\b", re.IGNORECASE),
-    re.compile(r"331 の CLI フラグ|331 个 CLI flag", re.IGNORECASE),
+    re.compile(r"\b338 CLI flags\b", re.IGNORECASE),
+    re.compile(r"338 の CLI フラグ|338 个 CLI flag", re.IGNORECASE),
     re.compile(r"\b(?:FTS5|BM25)\b"),
     re.compile(r"\bE[0-4]\b"),
     re.compile(r"\bE2E\b", re.IGNORECASE),

--- a/docs/CODEMAPS/cli.md
+++ b/docs/CODEMAPS/cli.md
@@ -165,7 +165,7 @@ boundary.
 
 ## See Also
 
-- [`docs/cli-reference.md`](../cli-reference.md) — Full CLI reference (331 unique flags total — this codemap is intentionally categorical, not exhaustive)
+- [`docs/cli-reference.md`](../cli-reference.md) — Full CLI reference (338 unique flags total — this codemap is intentionally categorical, not exhaustive)
 - [`docs/CODEMAPS/mcp-tools.md`](./mcp-tools.md) — MCP-side counterpart
 - [`tests/unit/cli/test_mcp_commands.py`](../../tests/unit/cli/test_mcp_commands.py) — Parity contract tests
 - [`scripts/codemap-sync-check.sh`](../../scripts/codemap-sync-check.sh) — pre-commit gate that blocks a change to the CLI **flag surface** (any `cli/**/*.py`, compared as a set) without a `cli.md` update

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -469,6 +469,12 @@ ignore_missing_imports = true
 # stubs in this repo. We silence the four resulting noise codes
 # (attr-defined / no-any-return / no-untyped-def / unreachable) on
 # exactly the modules that need them, so real type errors (arg-type,
+# hotspot_analyzer uses a sys.version_info guard for tomllib/tomli that
+# produces an unused-ignore on whichever Python version mypy targets.
+[[tool.mypy.overrides]]
+module = ["tree_sitter_analyzer.hotspot_analyzer"]
+warn_unused_ignores = false
+
 # assignment, var-annotated, misc) still surface elsewhere — and on
 # clean modules these codes still fail builds. This restores pre-commit
 # mypy as a useful gate, eliminating the routine need for --no-verify.

--- a/tests/contracts/test_language_support_inventory_contract.py
+++ b/tests/contracts/test_language_support_inventory_contract.py
@@ -459,8 +459,8 @@ def test_translated_readmes_reject_unregistered_quantitative_marketing(
             (
                 "Python 3.10 以上",
                 "8 MCP ツール",
-                # Re-pinned 2026-08-24: +3 for RFC-0029 mutation-probe flags.
-                "### 331 の CLI フラグ",
+                # Re-pinned 2026-08-31: +7 for --hotspot flags.
+                "### 338 の CLI フラグ",
                 "22 言語プラグイン",
                 "13 は `pipeline_registered`",
                 "3 は `index_admitted`",
@@ -472,8 +472,8 @@ def test_translated_readmes_reject_unregistered_quantitative_marketing(
             (
                 "需要 Python 3.10+",
                 "8 个 MCP 工具",
-                # Re-pinned 2026-08-24: +3 for RFC-0029 mutation-probe flags.
-                "### 331 个 CLI flag",
+                # Re-pinned 2026-08-31: +7 for --hotspot flags.
+                "### 338 个 CLI flag",
                 "22 个语言插件",
                 "13 个为 `pipeline_registered`",
                 "3 个为 `index_admitted`",

--- a/tests/unit/test_handle_hotspot.py
+++ b/tests/unit/test_handle_hotspot.py
@@ -1,0 +1,391 @@
+"""Unit tests for _handle_hotspot in capability_commands.py.
+
+Tests argument validation, DependencyMatrix build errors, heatmap parse errors,
+trace_from scenarios (not-found / isolated-file / subgraph), and show_alias_diff
+gap summary. Each test asserts a real behavioral contract — no coverage stuffing.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from unittest.mock import MagicMock, patch
+
+from tree_sitter_analyzer.cli.capability_commands import _handle_hotspot
+from tree_sitter_analyzer.output_schema import HotspotEntry
+from tree_sitter_analyzer.output_schema import TestFocus as _TestFocus
+
+# Prevent pytest from collecting TestFocus as a test class
+TestFocus = _TestFocus
+TestFocus.__test__ = False  # type: ignore[attr-defined]
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@dataclass
+class FakeFunc:
+    name: str
+    complexity: int
+    class_name: str | None = None
+    decision_points: dict = field(default_factory=dict)
+
+
+@dataclass
+class FakeHeatmap:
+    file: str
+    language: str = "python"
+    functions: list = field(default_factory=list)
+    total_complexity: int = 0
+    avg_complexity: float = 0.0
+    max_complexity: int = 0
+
+
+def make_context():
+    """Minimal SpecialCommandContext stub that captures output_json / output_error."""
+    ctx = MagicMock()
+    captured: dict = {}
+
+    def output_json(result):
+        captured["result"] = result
+
+    def output_error(msg):
+        captured["error"] = msg
+
+    ctx.output_json.side_effect = output_json
+    ctx.output_error.side_effect = output_error
+    return ctx, captured
+
+
+def make_args(**kwargs):
+    """Build a minimal args namespace stub with sensible defaults."""
+    args = MagicMock()
+    args.project_root = kwargs.get("project_root", None)
+    args.hotspot_top_n = kwargs.get("hotspot_top_n", 20)
+    args.page = kwargs.get("page", 1)
+    args.page_size = kwargs.get("page_size", 20)
+    args.hotspot_show_alias_diff = kwargs.get("hotspot_show_alias_diff", False)
+    args.trace_from = kwargs.get("trace_from", None)
+    args.depth = kwargs.get("depth", 3)
+    return args
+
+
+def make_dm_mock(build_side_effect=None, import_edges=None):
+    """Return (MockDMClass, dm_instance) where dm_instance.build behaves as specified."""
+    MockDM = MagicMock()
+    dm = MockDM.return_value
+    if build_side_effect is not None:
+        dm.build.side_effect = build_side_effect
+    dm._import_edges = import_edges if import_edges is not None else {"a.py": {}}
+    dm._result = None  # build_ca_raw_map checks this; None → empty dict
+    return MockDM, dm
+
+
+def make_hotspot_entry(
+    file: str = "src/big.py",
+    severity: str = "CRITICAL",
+    score: float = 500.0,
+    ca_raw: int = 25,
+    ca_alias: int = 25,
+    max_cc: int = 20,
+    rank: int = 1,
+) -> HotspotEntry:
+    return HotspotEntry(
+        rank=rank,
+        file=file,
+        severity=severity,
+        score=score,
+        ca_raw=ca_raw,
+        ca_alias=ca_alias,
+        max_cc=max_cc,
+        test_focus=TestFocus("heavy_fn", max_cc, "test edge cases and error paths"),
+    )
+
+
+# ── Patch target constants ────────────────────────────────────────────────────
+
+_DM = "tree_sitter_analyzer.dependency_matrix.DependencyMatrix"
+_HEATMAPS = "tree_sitter_analyzer.hotspot_analyzer.heatmaps_from_project_analysis"
+_CA_RAW = "tree_sitter_analyzer.hotspot_analyzer.build_ca_raw_map"
+_ALIAS_CA = "tree_sitter_analyzer.hotspot_analyzer.build_alias_ca_map"
+_HEATMAP_MAP = "tree_sitter_analyzer.hotspot_analyzer.build_heatmap_map"
+_COMPUTE = "tree_sitter_analyzer.hotspot_analyzer.compute_scores"
+_GET_SUBGRAPH = "tree_sitter_analyzer.subgraph_traverser.get_subgraph"
+_ENSURE_CFG = "tree_sitter_analyzer.cli.capability_commands._ensure_tsa_config"
+_WRITE_META = "tree_sitter_analyzer.cli.capability_commands._write_index_meta"
+
+
+# ── Argument validation ───────────────────────────────────────────────────────
+
+def test_invalid_top_n_zero():
+    """top_n=0 returns exit code 1 with error='invalid_argument', category='configuration'."""
+    ctx, captured = make_context()
+    rc = _handle_hotspot(make_args(hotspot_top_n=0), ctx, "json")
+    assert rc == 1
+    r = captured["result"]
+    assert r["success"] is False
+    assert r["error"] == "invalid_argument"
+    assert r["error_category"] == "configuration"
+    assert r["recovery_hint"] == "fix_argument"
+
+
+def test_invalid_page_zero():
+    """page=0 returns exit code 1 with error='invalid_argument', category='configuration'."""
+    ctx, captured = make_context()
+    rc = _handle_hotspot(make_args(page=0), ctx, "json")
+    assert rc == 1
+    r = captured["result"]
+    assert r["success"] is False
+    assert r["error"] == "invalid_argument"
+    assert r["error_category"] == "configuration"
+
+
+def test_invalid_page_size_zero():
+    """page_size=0 returns exit code 1 with error='invalid_argument', category='configuration'."""
+    ctx, captured = make_context()
+    rc = _handle_hotspot(make_args(page_size=0), ctx, "json")
+    assert rc == 1
+    r = captured["result"]
+    assert r["success"] is False
+    assert r["error"] == "invalid_argument"
+    assert r["error_category"] == "configuration"
+
+
+def test_invalid_depth_zero():
+    """depth=0 returns exit code 1 with error='invalid_argument', category='configuration'."""
+    ctx, captured = make_context()
+    rc = _handle_hotspot(make_args(depth=0), ctx, "json")
+    assert rc == 1
+    r = captured["result"]
+    assert r["success"] is False
+    assert r["error"] == "invalid_argument"
+    assert r["error_category"] == "configuration"
+    assert "depth" in r["message"]
+
+
+def test_depth_over_5_capped_with_warning(capsys):
+    """depth=10 is capped to 5 with a stderr warning; overall result is success."""
+    ctx, captured = make_context()
+    MockDM, _ = make_dm_mock()
+    with (
+        patch(_DM, MockDM),
+        patch(_ENSURE_CFG),
+        patch(_WRITE_META),
+        patch(_HEATMAPS, return_value=[]),
+        patch(_CA_RAW, return_value={"a.py": 5}),
+        patch(_ALIAS_CA, return_value={"a.py": 5}),
+        patch(_HEATMAP_MAP, return_value={}),
+        patch(_COMPUTE, return_value=[]),
+    ):
+        rc = _handle_hotspot(make_args(depth=10), ctx, "json")
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "capping" in err.lower()
+
+
+# ── DependencyMatrix build errors ─────────────────────────────────────────────
+
+def test_index_not_built_file_not_found():
+    """dm.build() raising FileNotFoundError → error='index_not_built', category='state'."""
+    ctx, captured = make_context()
+    MockDM, _ = make_dm_mock(build_side_effect=FileNotFoundError("no index"))
+    with patch(_DM, MockDM), patch(_ENSURE_CFG):
+        rc = _handle_hotspot(make_args(), ctx, "json")
+    assert rc == 1
+    r = captured["result"]
+    assert r["success"] is False
+    assert r["error"] == "index_not_built"
+    assert r["error_category"] == "state"
+    assert r["recovery_hint"] == "fix_then_retry"
+
+
+def test_index_build_os_error():
+    """dm.build() raising OSError → error='index_build_error', category='transient'."""
+    ctx, captured = make_context()
+    MockDM, _ = make_dm_mock(build_side_effect=OSError("disk busy"))
+    with patch(_DM, MockDM), patch(_ENSURE_CFG):
+        rc = _handle_hotspot(make_args(), ctx, "json")
+    assert rc == 1
+    r = captured["result"]
+    assert r["success"] is False
+    assert r["error"] == "index_build_error"
+    assert r["error_category"] == "transient"
+    assert r["recovery_hint"] == "retry"
+
+
+def test_index_not_built_generic_error():
+    """dm.build() raising RuntimeError → error='index_not_built' (generic except branch)."""
+    ctx, captured = make_context()
+    MockDM, _ = make_dm_mock(build_side_effect=RuntimeError("unexpected failure"))
+    with patch(_DM, MockDM), patch(_ENSURE_CFG):
+        rc = _handle_hotspot(make_args(), ctx, "json")
+    assert rc == 1
+    r = captured["result"]
+    assert r["success"] is False
+    assert r["error"] == "index_not_built"
+    assert r["error_category"] == "state"
+
+
+# ── Heatmap errors ────────────────────────────────────────────────────────────
+
+def test_parse_timeout():
+    """heatmaps_from_project_analysis raising TimeoutError → error='parse_timeout'."""
+    ctx, captured = make_context()
+    MockDM, _ = make_dm_mock()
+    with (
+        patch(_DM, MockDM),
+        patch(_ENSURE_CFG),
+        patch(_HEATMAPS, side_effect=TimeoutError("parse took too long")),
+    ):
+        rc = _handle_hotspot(make_args(), ctx, "json")
+    assert rc == 1
+    r = captured["result"]
+    assert r["success"] is False
+    assert r["error"] == "parse_timeout"
+    assert r["error_category"] == "transient"
+    assert r["recovery_hint"] == "retry"
+
+
+def test_fs_busy():
+    """heatmaps_from_project_analysis raising OSError → error='fs_busy'."""
+    ctx, captured = make_context()
+    MockDM, _ = make_dm_mock()
+    with (
+        patch(_DM, MockDM),
+        patch(_ENSURE_CFG),
+        patch(_HEATMAPS, side_effect=OSError("filesystem busy")),
+    ):
+        rc = _handle_hotspot(make_args(), ctx, "json")
+    assert rc == 1
+    r = captured["result"]
+    assert r["success"] is False
+    assert r["error"] == "fs_busy"
+    assert r["error_category"] == "transient"
+    assert r["recovery_hint"] == "retry"
+
+
+# ── Success paths ─────────────────────────────────────────────────────────────
+
+def test_success_empty_heatmap():
+    """When compute_scores returns [], result is success=True, verdict='OK', message set."""
+    ctx, captured = make_context()
+    MockDM, _ = make_dm_mock()
+    with (
+        patch(_DM, MockDM),
+        patch(_ENSURE_CFG),
+        patch(_WRITE_META),
+        patch(_HEATMAPS, return_value=[]),
+        patch(_CA_RAW, return_value={"a.py": 1}),
+        patch(_ALIAS_CA, return_value={"a.py": 1}),
+        patch(_HEATMAP_MAP, return_value={}),
+        patch(_COMPUTE, return_value=[]),
+    ):
+        rc = _handle_hotspot(make_args(), ctx, "json")
+    assert rc == 0
+    r = captured["result"]
+    assert r["success"] is True
+    assert r["verdict"] == "OK"
+    assert "message" in r
+    assert "No files exceed" in r["message"]
+
+
+def test_success_with_critical_file():
+    """When compute_scores returns a CRITICAL entry, verdict='CRITICAL' in result."""
+    ctx, captured = make_context()
+    MockDM, _ = make_dm_mock()
+    critical_entry = make_hotspot_entry(
+        file="src/big.py", severity="CRITICAL", score=500.0, ca_raw=25, ca_alias=25, max_cc=20
+    )
+    with (
+        patch(_DM, MockDM),
+        patch(_ENSURE_CFG),
+        patch(_WRITE_META),
+        patch(_HEATMAPS, return_value=[FakeHeatmap("src/big.py", max_complexity=20)]),
+        patch(_CA_RAW, return_value={"src/big.py": 25}),
+        patch(_ALIAS_CA, return_value={"src/big.py": 25}),
+        patch(_HEATMAP_MAP, return_value={"src/big.py": FakeHeatmap("src/big.py", max_complexity=20)}),
+        patch(_COMPUTE, return_value=[critical_entry]),
+    ):
+        rc = _handle_hotspot(make_args(), ctx, "json")
+    assert rc == 0
+    r = captured["result"]
+    assert r["success"] is True
+    assert r["verdict"] == "CRITICAL"
+    assert len(r["results"]) == 1
+    assert r["results"][0]["severity"] == "CRITICAL"
+    assert r["results"][0]["score"] == 500.0
+
+
+# ── trace_from scenarios ──────────────────────────────────────────────────────
+
+def test_trace_from_entry_point_not_found():
+    """trace_from file not in subgraph and not in heatmap → error='entry_point_not_found'."""
+    ctx, captured = make_context()
+    MockDM, _ = make_dm_mock()
+    with (
+        patch(_DM, MockDM),
+        patch(_ENSURE_CFG),
+        patch(_HEATMAPS, return_value=[]),
+        patch(_CA_RAW, return_value={"a.py": 1}),
+        patch(_ALIAS_CA, return_value={"a.py": 1}),
+        patch(_HEATMAP_MAP, return_value={}),
+        patch(_GET_SUBGRAPH, return_value=None),
+    ):
+        rc = _handle_hotspot(make_args(trace_from="nonexistent.py"), ctx, "json")
+    assert rc == 1
+    r = captured["result"]
+    assert r["success"] is False
+    assert r["error"] == "entry_point_not_found"
+    assert r["error_category"] == "data"
+    assert r["recovery_hint"] == "try_alternative"
+
+
+def test_trace_from_isolated_file():
+    """trace_from in heatmap but get_subgraph=None → reachable={file:0}, success=True."""
+    ctx, captured = make_context()
+    MockDM, _ = make_dm_mock()
+    isolated_hm = FakeHeatmap("isolated.py", max_complexity=5)
+    with (
+        patch(_DM, MockDM),
+        patch(_ENSURE_CFG),
+        patch(_WRITE_META),
+        patch(_HEATMAPS, return_value=[isolated_hm]),
+        patch(_CA_RAW, return_value={"isolated.py": 0}),
+        patch(_ALIAS_CA, return_value={"isolated.py": 0}),
+        patch(_HEATMAP_MAP, return_value={"isolated.py": isolated_hm}),
+        patch(_COMPUTE, return_value=[]),
+        patch(_GET_SUBGRAPH, return_value=None),
+    ):
+        rc = _handle_hotspot(make_args(trace_from="isolated.py"), ctx, "json")
+    assert rc == 0
+    r = captured["result"]
+    assert r["success"] is True
+    assert "subgraph_summary" in r
+    assert r["subgraph_summary"]["entry_point"] == "isolated.py"
+    # Isolated file counts as 1 file in subgraph (hop 0 only)
+    assert r["subgraph_summary"]["files_in_subgraph"] == 1
+
+
+# ── show_alias_diff ───────────────────────────────────────────────────────────
+
+def test_show_alias_diff_populates_gap_summary():
+    """show_alias_diff=True with alias_ca > ca_raw for a file → alias_gap_summary populated."""
+    ctx, captured = make_context()
+    MockDM, _ = make_dm_mock()
+    hm = FakeHeatmap("a.py", max_complexity=5)
+    # alias_ca_map has a gap: alias=10 > ca_raw=3
+    with (
+        patch(_DM, MockDM),
+        patch(_ENSURE_CFG),
+        patch(_WRITE_META),
+        patch(_HEATMAPS, return_value=[hm]),
+        patch(_CA_RAW, return_value={"a.py": 3}),
+        patch(_ALIAS_CA, return_value={"a.py": 10}),
+        patch(_HEATMAP_MAP, return_value={"a.py": hm}),
+        patch(_COMPUTE, return_value=[]),
+    ):
+        rc = _handle_hotspot(make_args(hotspot_show_alias_diff=True), ctx, "json")
+    assert rc == 0
+    r = captured["result"]
+    assert r["success"] is True
+    assert "alias_gap_summary" in r
+    # One file ("a.py") has alias_ca (10) > ca_raw (3) → gap count = 1
+    assert r["alias_gap_summary"]["files_with_alias_gap"] == 1
+    assert r["alias_gap_summary"]["total_files"] >= 1

--- a/tests/unit/test_handle_hotspot.py
+++ b/tests/unit/test_handle_hotspot.py
@@ -6,6 +6,7 @@ gap summary. Each test asserts a real behavioral contract — no coverage stuffi
 """
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
 from unittest.mock import MagicMock, patch
 
@@ -389,3 +390,144 @@ def test_show_alias_diff_populates_gap_summary():
     # One file ("a.py") has alias_ca (10) > ca_raw (3) → gap count = 1
     assert r["alias_gap_summary"]["files_with_alias_gap"] == 1
     assert r["alias_gap_summary"]["total_files"] == 1
+
+
+# ── _ensure_tsa_config ────────────────────────────────────────────────────────
+
+def test_ensure_tsa_config_skips_if_exists(tmp_path):
+    """Existing .tsa/config.json is not overwritten by _ensure_tsa_config."""
+    from tree_sitter_analyzer.cli.capability_commands import _ensure_tsa_config
+
+    cfg_dir = tmp_path / ".tsa"
+    cfg_dir.mkdir()
+    cfg_path = cfg_dir / "config.json"
+    original = {"existing": True, "custom_key": 42}
+    cfg_path.write_text(json.dumps(original), encoding="utf-8")
+
+    _ensure_tsa_config(str(tmp_path))
+
+    written = json.loads(cfg_path.read_text(encoding="utf-8"))
+    assert written["existing"] is True
+    assert written["custom_key"] == 42
+
+
+def test_ensure_tsa_config_creates_if_missing(tmp_path):
+    """When no config exists, _ensure_tsa_config creates .tsa/config.json with defaults."""
+    from tree_sitter_analyzer.cli.capability_commands import _ensure_tsa_config
+
+    _ensure_tsa_config(str(tmp_path))
+
+    cfg_path = tmp_path / ".tsa" / "config.json"
+    assert cfg_path.exists()
+    config = json.loads(cfg_path.read_text(encoding="utf-8"))
+    assert config["severity_thresholds"] == {"critical": 400, "review": 100}
+    assert config["default_top_n"] == 20
+
+
+# ── _write_index_meta ─────────────────────────────────────────────────────────
+
+def test_write_index_meta_creates_file(tmp_path):
+    """_write_index_meta writes .tsa/index-meta.json with correct fields."""
+    from tree_sitter_analyzer.cli.capability_commands import _write_index_meta
+
+    _write_index_meta(str(tmp_path), files_indexed=42, languages=["python", "typescript"])
+
+    meta_path = tmp_path / ".tsa" / "index-meta.json"
+    assert meta_path.exists()
+    meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    assert meta["files_indexed"] == 42
+    assert meta["languages"] == ["python", "typescript"]
+    assert "built_at" in meta
+    assert "tsa_version" in meta
+
+
+# ── top_n capping at 200 ──────────────────────────────────────────────────────
+
+def test_top_n_capped_at_200():
+    """top_n=300 is silently capped to 200; compute_scores receives top_n=200."""
+    ctx, captured = make_context()
+    MockDM, _ = make_dm_mock()
+    compute_spy = MagicMock(return_value=[])
+    with (
+        patch(_DM, MockDM),
+        patch(_ENSURE_CFG),
+        patch(_WRITE_META),
+        patch(_HEATMAPS, return_value=[]),
+        patch(_CA_RAW, return_value={"a.py": 1}),
+        patch(_ALIAS_CA, return_value={"a.py": 1}),
+        patch(_HEATMAP_MAP, return_value={}),
+        patch(_COMPUTE, compute_spy),
+    ):
+        rc = _handle_hotspot(make_args(hotspot_top_n=300), ctx, "json")
+    assert rc == 0
+    _, kwargs = compute_spy.call_args
+    assert kwargs["top_n"] == 200
+
+
+# ── Ca fallback source scanning ───────────────────────────────────────────────
+
+def test_ca_fallback_when_import_edges_empty(tmp_path):
+    """When dm._import_edges is empty, fallback source scanning is invoked and succeeds."""
+    ctx, captured = make_context()
+    MockDM = MagicMock()
+    dm = MockDM.return_value
+    dm.build.return_value = None
+    dm._import_edges = {}   # triggers import_edges rebuild branch
+    dm._result = None       # build_ca_raw_map returns {} → triggers ca_map branch too
+
+    with (
+        patch(_DM, MockDM),
+        patch(_ENSURE_CFG),
+        patch(_WRITE_META),
+        patch(_HEATMAPS, return_value=[]),
+        patch(_CA_RAW, return_value={}),
+        patch(
+            "tree_sitter_analyzer.complexity_heatmap._collect_source_files",
+            return_value=[],
+        ),
+        patch(
+            "tree_sitter_analyzer.hotspot_analyzer.build_ca_from_source_imports",
+            return_value={},
+        ),
+        patch(
+            "tree_sitter_analyzer.hotspot_analyzer.build_import_edges_from_source",
+            return_value={},
+        ),
+        patch(_ALIAS_CA, return_value={}),
+        patch(_HEATMAP_MAP, return_value={}),
+        patch(_COMPUTE, return_value=[]),
+    ):
+        rc = _handle_hotspot(make_args(project_root=str(tmp_path)), ctx, "json")
+    assert rc == 0
+    r = captured["result"]
+    assert r["success"] is True
+
+
+# ── Pagination beyond total pages ─────────────────────────────────────────────
+
+def test_page_beyond_total_returns_empty_results_success():
+    """Requesting page=999 with only one page of data returns success=True, results=[]."""
+    ctx, captured = make_context()
+    MockDM, _ = make_dm_mock()
+    review_entry = make_hotspot_entry(
+        file="src/mod.py", severity="REVIEW", score=150.0,
+        ca_raw=5, ca_alias=5, max_cc=30,
+    )
+    with (
+        patch(_DM, MockDM),
+        patch(_ENSURE_CFG),
+        patch(_WRITE_META),
+        patch(_HEATMAPS, return_value=[FakeHeatmap("src/mod.py", max_complexity=30)]),
+        patch(_CA_RAW, return_value={"src/mod.py": 5}),
+        patch(_ALIAS_CA, return_value={"src/mod.py": 5}),
+        patch(
+            _HEATMAP_MAP,
+            return_value={"src/mod.py": FakeHeatmap("src/mod.py", max_complexity=30)},
+        ),
+        patch(_COMPUTE, return_value=[review_entry]),
+    ):
+        rc = _handle_hotspot(make_args(page=999, page_size=20), ctx, "json")
+    assert rc == 0
+    r = captured["result"]
+    assert r["success"] is True
+    assert r["results"] == []

--- a/tests/unit/test_handle_hotspot.py
+++ b/tests/unit/test_handle_hotspot.py
@@ -388,4 +388,4 @@ def test_show_alias_diff_populates_gap_summary():
     assert "alias_gap_summary" in r
     # One file ("a.py") has alias_ca (10) > ca_raw (3) → gap count = 1
     assert r["alias_gap_summary"]["files_with_alias_gap"] == 1
-    assert r["alias_gap_summary"]["total_files"] >= 1
+    assert r["alias_gap_summary"]["total_files"] == 1

--- a/tests/unit/test_handle_hotspot.py
+++ b/tests/unit/test_handle_hotspot.py
@@ -531,3 +531,191 @@ def test_page_beyond_total_returns_empty_results_success():
     r = captured["result"]
     assert r["success"] is True
     assert r["results"] == []
+
+
+# ── _write_index_meta: PackageNotFoundError fallback ─────────────────────────
+
+def test_write_index_meta_package_not_found_uses_dev_version(tmp_path):
+    """PackageNotFoundError when querying package version → tsa_version='0.0.0+dev' (lines 61-62)."""
+    import importlib.metadata
+    import json
+    from unittest.mock import patch
+
+    from tree_sitter_analyzer.cli.capability_commands import _write_index_meta
+
+    with patch.object(
+        importlib.metadata,
+        "version",
+        side_effect=importlib.metadata.PackageNotFoundError("tree-sitter-analyzer"),
+    ):
+        _write_index_meta(str(tmp_path), files_indexed=10, languages=["python"])
+
+    meta = json.loads((tmp_path / ".tsa" / "index-meta.json").read_text(encoding="utf-8"))
+    assert meta["tsa_version"] == "0.0.0+dev"
+    assert meta["files_indexed"] == 10
+
+
+# ── Ca fallback: one-sided branches (ca_map vs import_edges) ─────────────────
+
+def test_ca_fallback_only_import_edges_empty(tmp_path):
+    """ca_map is populated but import_edges is empty → only import_edges is rebuilt (222->225)."""
+    ctx, captured = make_context()
+    MockDM = MagicMock()
+    dm = MockDM.return_value
+    dm.build.return_value = None
+    dm._import_edges = {}  # empty → triggers outer fallback block
+    # ca_map is populated via dm._result
+    stat = MagicMock()
+    stat.file = "src/foo.py"
+    stat.afferent_coupling = 3
+    dm._result = MagicMock()
+    dm._result.module_stats = [stat]
+
+    import_edges_spy = MagicMock(return_value={"src/foo.py": {}})
+
+    with (
+        patch(_DM, MockDM),
+        patch(_ENSURE_CFG),
+        patch(_WRITE_META),
+        patch(_HEATMAPS, return_value=[]),
+        patch(_HEATMAP_MAP, return_value={}),
+        patch(_ALIAS_CA, return_value={"src/foo.py": 3}),
+        patch(_COMPUTE, return_value=[]),
+        patch(
+            "tree_sitter_analyzer.complexity_heatmap._collect_source_files",
+            return_value=[],
+        ),
+        patch(
+            "tree_sitter_analyzer.hotspot_analyzer.build_ca_from_source_imports",
+            return_value={"src/foo.py": 3},
+        ) as ca_spy,
+        patch(
+            "tree_sitter_analyzer.hotspot_analyzer.build_import_edges_from_source",
+            import_edges_spy,
+        ),
+    ):
+        rc = _handle_hotspot(make_args(project_root=str(tmp_path)), ctx, "json")
+
+    assert rc == 0
+    # ca_from_source_imports should NOT have been called (ca_map was already populated)
+    ca_spy.assert_not_called()
+    # import_edges WAS rebuilt
+    import_edges_spy.assert_called_once()
+
+
+def test_trace_from_with_real_subgraph():
+    """get_subgraph returns a non-None reachable map → subgraph_summary built (242->256 branch)."""
+    ctx, captured = make_context()
+    MockDM, _ = make_dm_mock()
+    hm_a = FakeHeatmap("a.py", max_complexity=8)
+    hm_b = FakeHeatmap("b.py", max_complexity=4)
+    # get_subgraph returns real subgraph (not None) → skips isolated-file branch
+    fake_reachable = {"a.py": 0, "b.py": 1}
+    entry = make_hotspot_entry(file="a.py", severity="REVIEW", score=120.0, ca_raw=3, ca_alias=3, max_cc=8)
+    with (
+        patch(_DM, MockDM),
+        patch(_ENSURE_CFG),
+        patch(_WRITE_META),
+        patch(_HEATMAPS, return_value=[hm_a, hm_b]),
+        patch(_CA_RAW, return_value={"a.py": 3, "b.py": 1}),
+        patch(_ALIAS_CA, return_value={"a.py": 3, "b.py": 1}),
+        patch(_HEATMAP_MAP, return_value={"a.py": hm_a, "b.py": hm_b}),
+        patch(_COMPUTE, return_value=[entry]),
+        patch(_GET_SUBGRAPH, return_value=fake_reachable),
+    ):
+        rc = _handle_hotspot(make_args(trace_from="a.py"), ctx, "json")
+    assert rc == 0
+    r = captured["result"]
+    assert r["success"] is True
+    assert r["subgraph_summary"]["entry_point"] == "a.py"
+    assert r["subgraph_summary"]["files_in_subgraph"] == 2
+
+
+def test_handle_capability_actions_dispatches_hotspot():
+    """handle_capability_actions routes args.hotspot=True to _handle_hotspot."""
+    from tree_sitter_analyzer.cli.capability_commands import handle_capability_actions
+
+    ctx, captured = make_context()
+    MockDM, _ = make_dm_mock()
+    args = MagicMock()
+    args.project_card = False
+    args.plan_rename = None
+    args.refactor_queue = False
+    args.hotspot = True
+    args.output_format = "json"
+    args.project_root = None
+    args.hotspot_top_n = 20
+    args.page = 1
+    args.page_size = 20
+    args.hotspot_show_alias_diff = False
+    args.trace_from = None
+    args.depth = 3
+
+    with (
+        patch(_DM, MockDM),
+        patch(_ENSURE_CFG),
+        patch(_WRITE_META),
+        patch(_HEATMAPS, return_value=[]),
+        patch(_CA_RAW, return_value={"a.py": 1}),
+        patch(_ALIAS_CA, return_value={"a.py": 1}),
+        patch(_HEATMAP_MAP, return_value={}),
+        patch(_COMPUTE, return_value=[]),
+    ):
+        rc = handle_capability_actions(args, ctx)
+    assert rc == 0
+    assert captured["result"]["success"] is True
+
+
+def test_handle_capability_actions_returns_none_when_no_flag():
+    """handle_capability_actions returns None when no capability flag is set."""
+    from tree_sitter_analyzer.cli.capability_commands import handle_capability_actions
+
+    ctx, _ = make_context()
+    args = MagicMock()
+    args.project_card = False
+    args.plan_rename = None
+    args.refactor_queue = False
+    args.hotspot = False
+    args.output_format = "json"
+    assert handle_capability_actions(args, ctx) is None
+
+
+def test_ca_fallback_only_ca_map_empty(tmp_path):
+    """import_edges is populated but ca_map is empty → only ca_map is rebuilt (225->228)."""
+    ctx, captured = make_context()
+    MockDM = MagicMock()
+    dm = MockDM.return_value
+    dm.build.return_value = None
+    dm._import_edges = {"src/foo.py": {}}  # non-empty → outer block entered only if ca_map empty
+    dm._result = None  # build_ca_raw_map returns {} → ca_map empty → enters outer block
+
+    ca_spy = MagicMock(return_value={"src/foo.py": 2})
+
+    with (
+        patch(_DM, MockDM),
+        patch(_ENSURE_CFG),
+        patch(_WRITE_META),
+        patch(_HEATMAPS, return_value=[]),
+        patch(_HEATMAP_MAP, return_value={}),
+        patch(_ALIAS_CA, return_value={"src/foo.py": 2}),
+        patch(_COMPUTE, return_value=[]),
+        patch(
+            "tree_sitter_analyzer.complexity_heatmap._collect_source_files",
+            return_value=[],
+        ),
+        patch(
+            "tree_sitter_analyzer.hotspot_analyzer.build_ca_from_source_imports",
+            ca_spy,
+        ),
+        patch(
+            "tree_sitter_analyzer.hotspot_analyzer.build_import_edges_from_source",
+            return_value={},
+        ) as ie_spy,
+    ):
+        rc = _handle_hotspot(make_args(project_root=str(tmp_path)), ctx, "json")
+
+    assert rc == 0
+    # ca_from_source was called (ca_map was empty)
+    ca_spy.assert_called_once()
+    # build_import_edges should NOT have been called (import_edges was already populated)
+    ie_spy.assert_not_called()

--- a/tests/unit/test_hotspot_analyzer.py
+++ b/tests/unit/test_hotspot_analyzer.py
@@ -372,3 +372,79 @@ def test_detect_source_dir_heuristic_skips_non_source(tmp_path):
 
 def test_detect_source_dir_none_when_empty(tmp_path):
     assert _detect_source_dir(str(tmp_path)) is None
+
+
+# ── build_ca_raw_map ──────────────────────────────────────────────────────────
+
+def test_build_ca_raw_map_no_result():
+    """When dm._result is None, returns an empty dict."""
+    from tree_sitter_analyzer.hotspot_analyzer import build_ca_raw_map
+    dm = MagicMock()
+    dm._result = None
+    result = build_ca_raw_map(dm)
+    assert result == {}
+
+
+def test_build_ca_raw_map_with_module_stats():
+    """Returns {file: afferent_coupling} from dm._result.module_stats."""
+    from tree_sitter_analyzer.hotspot_analyzer import build_ca_raw_map
+    dm = MagicMock()
+    stat1 = MagicMock()
+    stat1.file = "pkg/foo.py"
+    stat1.afferent_coupling = 7
+    stat2 = MagicMock()
+    stat2.file = "pkg/bar.py"
+    stat2.afferent_coupling = 3
+    dm._result.module_stats = [stat1, stat2]
+    result = build_ca_raw_map(dm)
+    assert result == {"pkg/foo.py": 7, "pkg/bar.py": 3}
+
+
+# ── build_heatmap_map ─────────────────────────────────────────────────────────
+
+def test_build_heatmap_map_normalizes_backslash():
+    """Backslash paths in FileHeatmap.file are normalized to forward slash."""
+    from tree_sitter_analyzer.hotspot_analyzer import build_heatmap_map
+
+    @dataclass
+    class _FH:
+        file: str
+        language: str = "python"
+        functions: list = field(default_factory=list)
+        total_complexity: int = 0
+        avg_complexity: float = 0.0
+        max_complexity: int = 0
+
+    hm = _FH(file="pkg\\foo.py")
+    result = build_heatmap_map([hm])  # type: ignore[arg-type]
+    assert "pkg/foo.py" in result
+    assert result["pkg/foo.py"] is hm
+
+
+# ── build_test_focus: no-functions branch ─────────────────────────────────────
+
+def test_build_test_focus_no_functions():
+    """FakeHeatmap with empty functions list → TestFocus with function='(no functions)'."""
+    hm = FakeHeatmap("a.py", max_complexity=0, functions=[])
+    tf = build_test_focus(hm, "OK")
+    assert tf.function == "(no functions)"
+    assert tf.cc == 0
+    assert "(low impact" in tf.suggestion
+
+
+# ── build_import_edges_from_source ────────────────────────────────────────────
+
+def test_build_import_edges_from_source_basic(tmp_path):
+    """Import edges are built correctly from Python source files."""
+    from tree_sitter_analyzer.hotspot_analyzer import build_import_edges_from_source
+
+    (tmp_path / "pkg").mkdir()
+    (tmp_path / "pkg" / "utils.py").write_text("def helper(): pass\n")
+    (tmp_path / "pkg" / "main.py").write_text("from pkg.utils import helper\n")
+
+    scan = ["pkg/utils.py", "pkg/main.py"]
+    edges = build_import_edges_from_source(str(tmp_path), scan)
+    assert "pkg/main.py" in edges
+    assert "pkg/utils.py" in edges["pkg/main.py"]
+    # utils.py imports nothing in the scan set
+    assert edges.get("pkg/utils.py", {}) == {}

--- a/tests/unit/test_hotspot_analyzer.py
+++ b/tests/unit/test_hotspot_analyzer.py
@@ -116,7 +116,9 @@ def test_alias_resolution_python(tmp_path):
     }
     ca_raw = {"pkg/__init__.py": 1, "pkg/core.py": 1}
     alias_ca = build_alias_ca_map(ca_raw, import_edges, str(tmp_path))
-    assert alias_ca.get("pkg/core.py", 0) >= ca_raw.get("pkg/core.py", 0)
+    # main.py imports pkg/__init__.py (Ca=1), which re-exports pkg/core.py
+    # so alias Ca for core.py must be ca_raw + 1 extra caller via __init__
+    assert alias_ca.get("pkg/core.py", 0) == ca_raw.get("pkg/core.py", 0) + 1
 
 
 def test_alias_resolution_typescript(tmp_path):
@@ -133,7 +135,9 @@ def test_alias_resolution_typescript(tmp_path):
     }
     ca_raw = {"src/index.ts": 1, "src/utils.ts": 1}
     alias_ca = build_alias_ca_map(ca_raw, import_edges, str(tmp_path))
-    assert alias_ca.get("src/utils.ts", 0) >= ca_raw.get("src/utils.ts", 0)
+    # main.ts imports src/index.ts (Ca=1), which re-exports src/utils.ts
+    # so alias Ca for utils.ts must be ca_raw + 1 extra caller via index.ts
+    assert alias_ca.get("src/utils.ts", 0) == ca_raw.get("src/utils.ts", 0) + 1
 
 
 # ── P6: Error categories ──────────────────────────────────────────────────────

--- a/tests/unit/test_hotspot_analyzer.py
+++ b/tests/unit/test_hotspot_analyzer.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from tree_sitter_analyzer.hotspot_analyzer import (
     _detect_source_dir,
@@ -448,3 +448,98 @@ def test_build_import_edges_from_source_basic(tmp_path):
     assert "pkg/utils.py" in edges["pkg/main.py"]
     # utils.py imports nothing in the scan set
     assert edges.get("pkg/utils.py", {}) == {}
+
+
+# ── heatmaps_from_project_analysis ────────────────────────────────────────────
+
+def test_heatmaps_from_project_analysis_empty_dir(tmp_path):
+    """Empty project directory yields no heatmaps."""
+    from tree_sitter_analyzer.hotspot_analyzer import heatmaps_from_project_analysis
+
+    result = heatmaps_from_project_analysis(str(tmp_path))
+    assert result == []
+
+
+def test_heatmaps_from_project_analysis_transforms_result(tmp_path):
+    """FileHeatmap objects are built correctly from analyze_project_heatmap output."""
+    from tree_sitter_analyzer.hotspot_analyzer import heatmaps_from_project_analysis
+
+    fake_result = {
+        "file_heatmaps": [
+            {
+                "file": "src/foo.py",
+                "language": "python",
+                "total_complexity": 15,
+                "avg_complexity": 7.5,
+                "max_complexity": 12,
+                "top_functions": [
+                    {"name": "parse", "line": 10, "complexity": 12},
+                    {"name": "load", "line": 40, "complexity": 3},
+                ],
+            }
+        ]
+    }
+    with patch(
+        "tree_sitter_analyzer.complexity_heatmap.analyze_project_heatmap",
+        return_value=fake_result,
+    ):
+        result = heatmaps_from_project_analysis(str(tmp_path))
+
+    assert len(result) == 1
+    fh = result[0]
+    assert fh.file == "src/foo.py"
+    assert fh.language == "python"
+    assert fh.max_complexity == 12
+    assert fh.total_complexity == 15
+    assert len(fh.functions) == 2
+    assert fh.functions[0].name == "parse"
+    assert fh.functions[0].complexity == 12
+
+
+# ── _detect_source_dir: setuptools and edge cases ─────────────────────────────
+
+def test_detect_source_dir_setuptools_packages(tmp_path):
+    """pyproject.toml with [tool.setuptools] packages is resolved when hatch is absent."""
+    (tmp_path / "mypkg").mkdir()
+    (tmp_path / "mypkg" / "__init__.py").write_text("")
+    # Only setuptools key — no hatch section
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.setuptools]\npackages = ["mypkg"]\n'
+    )
+    assert _detect_source_dir(str(tmp_path)) == "mypkg"
+
+
+def test_detect_source_dir_dot_prefix_dir_ignored(tmp_path):
+    """Directories starting with '.' are skipped by the heuristic fallback."""
+    (tmp_path / ".hidden").mkdir()
+    (tmp_path / ".hidden" / "__init__.py").write_text("")
+    (tmp_path / "mypkg").mkdir()
+    (tmp_path / "mypkg" / "__init__.py").write_text("")
+    # No pyproject.toml — heuristic must skip .hidden and pick mypkg
+    assert _detect_source_dir(str(tmp_path)) == "mypkg"
+
+
+# ── build_alias_ca_map: short-circuit on empty import_edges ──────────────────
+
+def test_build_alias_ca_map_empty_import_edges_returns_copy():
+    """When import_edges is empty, returns a new dict copy of ca_raw without rglob walk."""
+    from tree_sitter_analyzer.hotspot_analyzer import build_alias_ca_map
+
+    ca_raw = {"a.py": 5, "b.py": 3}
+    result = build_alias_ca_map(ca_raw, {}, project_root="/fake/path")
+    assert result == {"a.py": 5, "b.py": 3}
+    assert result is not ca_raw  # must be a distinct dict object
+
+
+# ── compute_scores: alias_ca_map overrides raw Ca ────────────────────────────
+
+def test_compute_scores_alias_ca_map_overrides_raw():
+    """When alias_ca_map is provided, ca_alias uses alias value and score reflects it."""
+    ca_map = {"a.py": 3}
+    alias_ca_map_arg = {"a.py": 8}
+    hm = FakeHeatmap("a.py", max_complexity=10, functions=[FakeFunc("f", 10)])
+    entries = compute_scores(ca_map, {"a.py": hm}, alias_ca_map=alias_ca_map_arg)
+    assert len(entries) == 1
+    assert entries[0].ca_raw == 3
+    assert entries[0].ca_alias == 8
+    assert entries[0].score == 80.0  # 8 * 10

--- a/tests/unit/test_hotspot_analyzer.py
+++ b/tests/unit/test_hotspot_analyzer.py
@@ -1,13 +1,8 @@
 """Unit tests for hotspot_analyzer.py and output_schema.py (pure functions only)."""
 from __future__ import annotations
 
-import sys
 from dataclasses import dataclass, field
-from pathlib import Path
-from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
-
-import pytest
+from unittest.mock import MagicMock
 
 from tree_sitter_analyzer.hotspot_analyzer import (
     _detect_source_dir,
@@ -20,17 +15,17 @@ from tree_sitter_analyzer.hotspot_analyzer import (
 )
 from tree_sitter_analyzer.output_schema import (
     HotspotEntry,
-    HotspotMetadata,
-    TestFocus as _TestFocus,
     paginate,
     result_to_dict,
 )
+from tree_sitter_analyzer.output_schema import (
+    TestFocus as _TestFocus,
+)
+from tree_sitter_analyzer.subgraph_traverser import bfs_reachable
 
 # Alias to avoid pytest collecting TestFocus as a test class
 TestFocus = _TestFocus
 TestFocus.__test__ = False  # type: ignore[attr-defined]
-from tree_sitter_analyzer.subgraph_traverser import bfs_reachable
-
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -144,7 +139,7 @@ def test_alias_resolution_typescript(tmp_path):
 # ── P6: Error categories ──────────────────────────────────────────────────────
 
 def test_error_index_not_built():
-    from tree_sitter_analyzer.output_schema import HotspotResult, result_to_dict
+    from tree_sitter_analyzer.output_schema import HotspotResult
     r = HotspotResult(success=False, error="index_not_built",
                       error_category="state", recovery_hint="fix_then_retry",
                       message="Index not found")
@@ -155,7 +150,7 @@ def test_error_index_not_built():
 
 
 def test_error_entry_point_not_found():
-    from tree_sitter_analyzer.output_schema import HotspotResult, result_to_dict
+    from tree_sitter_analyzer.output_schema import HotspotResult
     r = HotspotResult(success=False, error="entry_point_not_found",
                       error_category="data", recovery_hint="try_alternative",
                       message="Not found")
@@ -165,7 +160,7 @@ def test_error_entry_point_not_found():
 
 
 def test_error_transient():
-    from tree_sitter_analyzer.output_schema import HotspotResult, result_to_dict
+    from tree_sitter_analyzer.output_schema import HotspotResult
     r = HotspotResult(success=False, error="parse_timeout",
                       error_category="transient", recovery_hint="retry",
                       message="Timeout")
@@ -175,7 +170,7 @@ def test_error_transient():
 
 
 def test_error_invalid_depth():
-    from tree_sitter_analyzer.output_schema import HotspotResult, result_to_dict
+    from tree_sitter_analyzer.output_schema import HotspotResult
     r = HotspotResult(success=False, error="invalid_argument",
                       error_category="configuration", recovery_hint="fix_argument",
                       message="Invalid value for --depth: must be 1-5")
@@ -225,7 +220,7 @@ def test_bfs_subgraph_smaller():
 
 
 def test_bfs_depth_cap(capsys):
-    from tree_sitter_analyzer.subgraph_traverser import get_subgraph, MAX_DEPTH_CAP
+    from tree_sitter_analyzer.subgraph_traverser import get_subgraph
     dm = MagicMock()
     dm._import_edges = {"main.py": {"a.py": 1}, "a.py": {}}
     result = get_subgraph(dm, "main.py", 10)
@@ -242,8 +237,8 @@ def test_hops_in_result():
     }
     reachable = {"main.py": 0, "a.py": 1}
     entries = compute_scores(ca_map, hm_map, reachable=reachable)
-    for e in entries:
-        assert e.hops is not None
+    hop_map = {e.file: e.hops for e in entries}
+    assert hop_map == {"main.py": 0, "a.py": 1}
 
 
 # ── top_n edge cases ──────────────────────────────────────────────────────────

--- a/tests/unit/test_hotspot_analyzer.py
+++ b/tests/unit/test_hotspot_analyzer.py
@@ -1,0 +1,375 @@
+"""Unit tests for hotspot_analyzer.py and output_schema.py (pure functions only)."""
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tree_sitter_analyzer.hotspot_analyzer import (
+    _detect_source_dir,
+    _iter_resolved_imports,
+    _resolve_import_mod,
+    build_ca_from_source_imports,
+    build_test_focus,
+    classify_severity,
+    compute_scores,
+)
+from tree_sitter_analyzer.output_schema import (
+    HotspotEntry,
+    HotspotMetadata,
+    TestFocus as _TestFocus,
+    paginate,
+    result_to_dict,
+)
+
+# Alias to avoid pytest collecting TestFocus as a test class
+TestFocus = _TestFocus
+TestFocus.__test__ = False  # type: ignore[attr-defined]
+from tree_sitter_analyzer.subgraph_traverser import bfs_reachable
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@dataclass
+class FakeFunc:
+    name: str
+    complexity: int
+    class_name: str | None = None
+    decision_points: dict = field(default_factory=dict)
+
+
+@dataclass
+class FakeHeatmap:
+    file: str
+    language: str = "python"
+    functions: list = field(default_factory=list)
+    total_complexity: int = 0
+    avg_complexity: float = 0.0
+    max_complexity: int = 0
+
+
+def make_entry(rank=1, file="a.py", severity="OK", score=50.0, ca_raw=5, ca_alias=5, max_cc=10, hops=None):
+    return HotspotEntry(
+        rank=rank, file=file, severity=severity, score=score,
+        ca_raw=ca_raw, ca_alias=ca_alias, max_cc=max_cc,
+        test_focus=TestFocus("fn", max_cc, "ok"), hops=hops,
+    )
+
+
+# ── P2: Basic score ───────────────────────────────────────────────────────────
+
+def test_score_calculation_basic():
+    ca_map = {"a.py": 5}
+    hm = FakeHeatmap("a.py", max_complexity=10, functions=[FakeFunc("f", 10)])
+    entries = compute_scores(ca_map, {"a.py": hm})
+    assert entries[0].score == 50.0
+    assert entries[0].ca_raw == 5
+    assert entries[0].ca_alias == 5
+
+
+# ── P4: Severity boundaries ───────────────────────────────────────────────────
+
+def test_severity_critical_boundary():
+    assert classify_severity(400) == "CRITICAL"
+    assert classify_severity(399) == "REVIEW"
+
+
+def test_severity_review_boundary():
+    assert classify_severity(100) == "REVIEW"
+    assert classify_severity(99) == "OK"
+
+
+def test_empty_results_is_success():
+    ca_map = {"a.py": 1}
+    hm = FakeHeatmap("a.py", max_complexity=0)
+    entries = compute_scores(ca_map, {"a.py": hm})
+    assert all(e.score == 0 for e in entries)
+    # Caller (capability_commands) treats empty ranked -> success: true
+    # Verify paginate handles empty list
+    sliced, meta = paginate([], 1, 20)
+    assert sliced == []
+    assert meta.files_in_output == 0
+
+
+def test_test_focus_extraction():
+    hm = FakeHeatmap("a.py", max_complexity=12,
+                     functions=[FakeFunc("parse", 12), FakeFunc("init", 3)])
+    tf = build_test_focus(hm, "CRITICAL")
+    assert tf.function == "parse"
+    assert tf.cc == 12
+    assert "edge cases" in tf.suggestion
+
+
+# ── P3: alias-aware Ca ────────────────────────────────────────────────────────
+
+def test_alias_resolution_python(tmp_path):
+    from tree_sitter_analyzer.hotspot_analyzer import build_alias_ca_map
+
+    # Create a minimal Python project structure in tmp_path
+    (tmp_path / "pkg").mkdir()
+    (tmp_path / "pkg" / "__init__.py").write_text("from .core import Foo\n")
+    (tmp_path / "pkg" / "core.py").write_text("class Foo: pass\n")
+    (tmp_path / "main.py").write_text("from pkg import Foo\n")
+
+    import_edges = {
+        "main.py": {"pkg/__init__.py": 1},
+        "pkg/__init__.py": {"pkg/core.py": 1},
+    }
+    ca_raw = {"pkg/__init__.py": 1, "pkg/core.py": 1}
+    alias_ca = build_alias_ca_map(ca_raw, import_edges, str(tmp_path))
+    assert alias_ca.get("pkg/core.py", 0) >= ca_raw.get("pkg/core.py", 0)
+
+
+def test_alias_resolution_typescript(tmp_path):
+    from tree_sitter_analyzer.hotspot_analyzer import build_alias_ca_map
+
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "index.ts").write_text("export { Foo } from './utils'\n")
+    (tmp_path / "src" / "utils.ts").write_text("export class Foo {}\n")
+    (tmp_path / "main.ts").write_text("import { Foo } from './src'\n")
+
+    import_edges = {
+        "main.ts": {"src/index.ts": 1},
+        "src/index.ts": {"src/utils.ts": 1},
+    }
+    ca_raw = {"src/index.ts": 1, "src/utils.ts": 1}
+    alias_ca = build_alias_ca_map(ca_raw, import_edges, str(tmp_path))
+    assert alias_ca.get("src/utils.ts", 0) >= ca_raw.get("src/utils.ts", 0)
+
+
+# ── P6: Error categories ──────────────────────────────────────────────────────
+
+def test_error_index_not_built():
+    from tree_sitter_analyzer.output_schema import HotspotResult, result_to_dict
+    r = HotspotResult(success=False, error="index_not_built",
+                      error_category="state", recovery_hint="fix_then_retry",
+                      message="Index not found")
+    d = result_to_dict(r)
+    assert d["error_category"] == "state"
+    assert d["recovery_hint"] == "fix_then_retry"
+    assert d["success"] is False
+
+
+def test_error_entry_point_not_found():
+    from tree_sitter_analyzer.output_schema import HotspotResult, result_to_dict
+    r = HotspotResult(success=False, error="entry_point_not_found",
+                      error_category="data", recovery_hint="try_alternative",
+                      message="Not found")
+    d = result_to_dict(r)
+    assert d["error_category"] == "data"
+    assert d["recovery_hint"] == "try_alternative"
+
+
+def test_error_transient():
+    from tree_sitter_analyzer.output_schema import HotspotResult, result_to_dict
+    r = HotspotResult(success=False, error="parse_timeout",
+                      error_category="transient", recovery_hint="retry",
+                      message="Timeout")
+    d = result_to_dict(r)
+    assert d["error_category"] == "transient"
+    assert d["recovery_hint"] == "retry"
+
+
+def test_error_invalid_depth():
+    from tree_sitter_analyzer.output_schema import HotspotResult, result_to_dict
+    r = HotspotResult(success=False, error="invalid_argument",
+                      error_category="configuration", recovery_hint="fix_argument",
+                      message="Invalid value for --depth: must be 1-5")
+    d = result_to_dict(r)
+    assert d["error_category"] == "configuration"
+    assert d["recovery_hint"] == "fix_argument"
+
+
+# ── P1: Pagination ────────────────────────────────────────────────────────────
+
+def test_pagination_slice():
+    entries = [make_entry(rank=i, score=float(100 - i)) for i in range(1, 11)]
+    sliced, meta = paginate(entries, 2, 5)
+    assert [e.rank for e in sliced] == [6, 7, 8, 9, 10]
+    assert meta.page == 2
+    assert meta.page_size == 5
+
+
+def test_pagination_overflow():
+    entries = [make_entry(rank=i) for i in range(1, 6)]
+    sliced, meta = paginate(entries, 999, 5)
+    assert sliced == []
+    assert meta.files_in_output == 0
+
+
+def test_pagination_merge():
+    entries = [make_entry(rank=i, score=float(100 - i)) for i in range(1, 11)]
+    p1, _ = paginate(entries, 1, 5)
+    p2, _ = paginate(entries, 2, 5)
+    merged = p1 + p2
+    full, _ = paginate(entries, 1, 10)
+    assert [e.rank for e in merged] == [e.rank for e in full]
+
+
+# ── P5: BFS ───────────────────────────────────────────────────────────────────
+
+def test_bfs_subgraph_smaller():
+    edges = {
+        "main.py": {"a.py": 1, "b.py": 1},
+        "a.py": {"c.py": 1},
+        "b.py": {"d.py": 1},
+    }
+    all_files = {"main.py", "a.py", "b.py", "c.py", "d.py", "e.py"}
+    reachable = bfs_reachable("main.py", edges, 2)
+    assert len(reachable) < len(all_files)
+    assert "e.py" not in reachable
+
+
+def test_bfs_depth_cap(capsys):
+    from tree_sitter_analyzer.subgraph_traverser import get_subgraph, MAX_DEPTH_CAP
+    dm = MagicMock()
+    dm._import_edges = {"main.py": {"a.py": 1}, "a.py": {}}
+    result = get_subgraph(dm, "main.py", 10)
+    captured = capsys.readouterr()
+    assert "capping" in captured.err
+    assert result is not None
+
+
+def test_hops_in_result():
+    ca_map = {"main.py": 0, "a.py": 2, "b.py": 1}
+    hm_map = {
+        "main.py": FakeHeatmap("main.py", max_complexity=5),
+        "a.py": FakeHeatmap("a.py", max_complexity=10),
+    }
+    reachable = {"main.py": 0, "a.py": 1}
+    entries = compute_scores(ca_map, hm_map, reachable=reachable)
+    for e in entries:
+        assert e.hops is not None
+
+
+# ── top_n edge cases ──────────────────────────────────────────────────────────
+
+def test_compute_scores_top_n_zero_returns_empty():
+    ca_map = {"a.py": 5}
+    hm = FakeHeatmap("a.py", max_complexity=10, functions=[FakeFunc("f", 10)])
+    entries = compute_scores(ca_map, {"a.py": hm}, top_n=0)
+    assert entries == []
+
+
+def test_compute_scores_top_n_negative_clamps_to_empty():
+    ca_map = {"a.py": 5, "b.py": 3}
+    hm_map = {
+        "a.py": FakeHeatmap("a.py", max_complexity=10, functions=[FakeFunc("f", 10)]),
+        "b.py": FakeHeatmap("b.py", max_complexity=5, functions=[FakeFunc("g", 5)]),
+    }
+    entries = compute_scores(ca_map, hm_map, top_n=-1)
+    assert entries == []
+
+
+# ── _resolve_import_mod ────────────────────────────────────────────────────────
+
+def test_resolve_absolute_import():
+    file_set = {"pkg/utils.py", "pkg/__init__.py"}
+    assert _resolve_import_mod("pkg.utils", "main.py", file_set) == "pkg/utils.py"
+
+
+def test_resolve_relative_import_dot():
+    file_set = {"pkg/utils.py", "pkg/__init__.py", "pkg/foo.py"}
+    # from .utils import X  (called from pkg/foo.py)
+    assert _resolve_import_mod(".utils", "pkg/foo.py", file_set) == "pkg/utils.py"
+
+
+def test_resolve_relative_import_double_dot():
+    file_set = {"pkg/utils.py", "pkg/__init__.py", "pkg/sub/foo.py"}
+    # from ..utils import X  (called from pkg/sub/foo.py) → pkg/utils.py
+    assert _resolve_import_mod("..utils", "pkg/sub/foo.py", file_set) == "pkg/utils.py"
+
+
+def test_resolve_bare_relative_not_in_fileset_returns_none():
+    file_set = {"pkg/utils.py"}
+    # from . import nonexistent — not in file_set → None
+    assert _resolve_import_mod(".nonexistent", "pkg/foo.py", file_set) is None
+
+
+# ── _iter_resolved_imports: bare relative imports ─────────────────────────────
+
+def test_iter_resolved_bare_dot_import():
+    file_set = {"pkg/__init__.py", "pkg/utils.py", "pkg/foo.py"}
+    text = "from . import utils\n"
+    results = list(_iter_resolved_imports(text, "pkg/foo.py", file_set))
+    assert "pkg/utils.py" in results
+
+
+def test_iter_resolved_bare_double_dot_import():
+    file_set = {"pkg/__init__.py", "pkg/utils.py", "pkg/sub/__init__.py", "pkg/sub/mod.py"}
+    text = "from .. import utils\n"
+    results = list(_iter_resolved_imports(text, "pkg/sub/mod.py", file_set))
+    assert "pkg/utils.py" in results
+
+
+def test_iter_resolved_no_duplicate_from_both_passes():
+    file_set = {"pkg/__init__.py", "pkg/utils.py", "pkg/foo.py"}
+    # "from .utils import X" is a normal relative import (pass 1 handles it)
+    # ensure no duplicate even if somehow both passes fire
+    text = "from .utils import X\n"
+    results = list(_iter_resolved_imports(text, "pkg/foo.py", file_set))
+    assert results.count("pkg/utils.py") == 1
+
+
+# ── build_ca_from_source_imports ──────────────────────────────────────────────
+
+def test_ca_counts_standard_imports(tmp_path):
+    (tmp_path / "pkg").mkdir()
+    (tmp_path / "pkg" / "utils.py").write_text("def f(): pass\n")
+    (tmp_path / "pkg" / "main.py").write_text("from pkg.utils import f\n")
+    (tmp_path / "pkg" / "other.py").write_text("from pkg.utils import f\n")
+
+    scan = ["pkg/utils.py", "pkg/main.py", "pkg/other.py"]
+    ca = build_ca_from_source_imports(str(tmp_path), scan)
+    assert ca.get("pkg/utils.py", 0) == 2
+
+
+def test_ca_counts_bare_relative_imports(tmp_path):
+    (tmp_path / "pkg").mkdir()
+    (tmp_path / "pkg" / "__init__.py").write_text("from . import utils\n")
+    (tmp_path / "pkg" / "utils.py").write_text("def f(): pass\n")
+
+    scan = ["pkg/__init__.py", "pkg/utils.py"]
+    ca = build_ca_from_source_imports(str(tmp_path), scan)
+    assert ca.get("pkg/utils.py", 0) == 1
+
+
+def test_ca_windows_path_normalization(tmp_path):
+    (tmp_path / "pkg").mkdir()
+    (tmp_path / "pkg" / "utils.py").write_text("def f(): pass\n")
+    (tmp_path / "pkg" / "main.py").write_text("from pkg.utils import f\n")
+
+    # Pass Windows-style backslash paths — should still normalize correctly
+    scan = ["pkg\\utils.py", "pkg\\main.py"]
+    ca = build_ca_from_source_imports(str(tmp_path), scan)
+    assert ca.get("pkg/utils.py", 0) == 1
+
+
+# ── _detect_source_dir ────────────────────────────────────────────────────────
+
+def test_detect_source_dir_pyproject(tmp_path):
+    (tmp_path / "mypkg").mkdir()
+    (tmp_path / "mypkg" / "__init__.py").write_text("")
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "__init__.py").write_text("")
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.hatch.build.targets.wheel]\npackages = ["mypkg"]\n'
+    )
+    assert _detect_source_dir(str(tmp_path)) == "mypkg"
+
+
+def test_detect_source_dir_heuristic_skips_non_source(tmp_path):
+    # tests/ appears before mypkg/ alphabetically, but is in blocklist
+    (tmp_path / "mypkg").mkdir()
+    (tmp_path / "mypkg" / "__init__.py").write_text("")
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "__init__.py").write_text("")
+    assert _detect_source_dir(str(tmp_path)) == "mypkg"
+
+
+def test_detect_source_dir_none_when_empty(tmp_path):
+    assert _detect_source_dir(str(tmp_path)) is None

--- a/tests/unit/test_hotspot_analyzer.py
+++ b/tests/unit/test_hotspot_analyzer.py
@@ -543,3 +543,230 @@ def test_compute_scores_alias_ca_map_overrides_raw():
     assert entries[0].ca_raw == 3
     assert entries[0].ca_alias == 8
     assert entries[0].score == 80.0  # 8 * 10
+
+
+# ── _resolve_import_mod: bare-dot and empty-string edges ─────────────────────
+
+def test_resolve_import_mod_bare_dot_resolves_to_package_init():
+    """raw_mod='.' → empty mod after strip → resolves to pkg/__init__.py."""
+    file_set = {"pkg/__init__.py", "pkg/foo.py"}
+    result = _resolve_import_mod(".", "pkg/foo.py", file_set)
+    assert result == "pkg/__init__.py"
+
+
+def test_resolve_import_mod_empty_string_returns_none():
+    """raw_mod='' has no dots and no module path → returns None (line 200 branch)."""
+    file_set = {"a.py"}
+    assert _resolve_import_mod("", "main.py", file_set) is None
+
+
+# ── _iter_resolved_imports: dedup and pass-2 edge cases ──────────────────────
+
+def test_iter_resolved_imports_deduplicates_pass1():
+    """Same module imported on two lines — yielded exactly once (236->224 branch)."""
+    file_set = {"pkg/utils.py"}
+    text = "from pkg.utils import X\nfrom pkg.utils import Y\n"
+    results = list(_iter_resolved_imports(text, "main.py", file_set))
+    assert results == ["pkg/utils.py"]
+
+
+def test_iter_resolved_imports_pass2_skips_non_identifier_name():
+    """Pass-2 names that parse to empty string or non-identifier trigger continue (line 252)."""
+    file_set = {"pkg/__init__.py", "pkg/utils.py", "pkg/foo.py"}
+    # "(garbage)" after split("(")[0] → "" which is not an identifier
+    text = "from . import utils, (garbage)\n"
+    results = list(_iter_resolved_imports(text, "pkg/foo.py", file_set))
+    assert results == ["pkg/utils.py"]
+
+
+def test_iter_resolved_imports_pass2_skips_unresolvable():
+    """Pass-2 name not in file_set → resolved is None, not yielded (254->248 branch)."""
+    file_set = {"pkg/__init__.py", "pkg/utils.py"}
+    text = "from . import nonexistent_module\n"
+    results = list(_iter_resolved_imports(text, "pkg/foo.py", file_set))
+    assert results == []
+
+
+# ── build_import_edges_from_source: non-py skip and OSError ──────────────────
+
+def test_build_import_edges_skips_non_python_files(tmp_path):
+    """Non-.py files in scan list are skipped; result is empty (line 276 continue)."""
+    from tree_sitter_analyzer.hotspot_analyzer import build_import_edges_from_source
+
+    (tmp_path / "main.ts").write_text("import { Foo } from './utils'\n")
+    scan = ["main.ts"]
+    edges = build_import_edges_from_source(str(tmp_path), scan)
+    assert edges == {}
+
+
+def test_build_import_edges_oserror_on_read_is_skipped(tmp_path):
+    """File listed in scan but not on disk → OSError caught, file skipped (lines 279-280)."""
+    from tree_sitter_analyzer.hotspot_analyzer import build_import_edges_from_source
+
+    # nonexistent_file.py is listed but does not exist → read_text raises FileNotFoundError
+    edges = build_import_edges_from_source(str(tmp_path), ["nonexistent_file.py"])
+    assert edges == {}
+
+
+# ── build_ca_from_source_imports: non-py skip and OSError ────────────────────
+
+def test_ca_from_source_imports_skips_non_python_files(tmp_path):
+    """Non-.py files in scan list are skipped; ca result is empty (line 313 continue)."""
+    (tmp_path / "main.ts").write_text("import { Foo } from './utils'\n")
+    ca = build_ca_from_source_imports(str(tmp_path), ["main.ts"])
+    assert ca == {}
+
+
+def test_ca_from_source_imports_oserror_on_read_is_skipped(tmp_path):
+    """File not on disk → OSError caught, file skipped (lines 316-317)."""
+    ca = build_ca_from_source_imports(str(tmp_path), ["nonexistent_file.py"])
+    assert ca == {}
+
+
+# ── _detect_source_dir: malformed TOML and OSError on iterdir ────────────────
+
+def test_detect_source_dir_malformed_toml_falls_back_to_heuristic(tmp_path):
+    """pyproject.toml with invalid TOML → except Exception caught, heuristic used (100-101)."""
+    (tmp_path / "mypkg").mkdir()
+    (tmp_path / "mypkg" / "__init__.py").write_text("")
+    (tmp_path / "pyproject.toml").write_text("invalid = [unclosed bracket\n")
+    # TOML parse fails → falls back to heuristic → finds mypkg
+    assert _detect_source_dir(str(tmp_path)) == "mypkg"
+
+
+def test_detect_source_dir_oserror_on_iterdir_returns_none():
+    """Non-existent project_root → iterdir raises FileNotFoundError (OSError) → None (114-115)."""
+    assert _detect_source_dir("/nonexistent_tsa_test_dir_xyz/project") is None
+
+
+# ── _parse_python_reexports: OSError and false branches ──────────────────────
+
+def test_parse_python_reexports_oserror_returns_empty():
+    """Unreadable path → OSError caught → returns [] (lines 417-418)."""
+    from pathlib import Path
+
+    from tree_sitter_analyzer.hotspot_analyzer import _parse_python_reexports
+
+    result = _parse_python_reexports(Path("/nonexistent/__init__.py"))
+    assert result == []
+
+
+def test_parse_python_reexports_skips_non_from_dot_lines(tmp_path):
+    """Lines without 'from .' prefix are skipped (branch 421->419)."""
+    from tree_sitter_analyzer.hotspot_analyzer import _parse_python_reexports
+
+    init = tmp_path / "__init__.py"
+    init.write_text("import os\nfrom pkg import Foo\nx = 1\n")
+    result = _parse_python_reexports(init)
+    assert result == []
+
+
+def test_parse_python_reexports_skips_star_imports(tmp_path):
+    """Star imports ('from .core import *') are skipped (branch 423->419)."""
+    from tree_sitter_analyzer.hotspot_analyzer import _parse_python_reexports
+
+    init = tmp_path / "__init__.py"
+    init.write_text("from .core import *\n")
+    result = _parse_python_reexports(init)
+    assert result == []
+
+
+# ── _parse_ts_reexports: OSError and false branch ────────────────────────────
+
+def test_parse_ts_reexports_oserror_returns_empty():
+    """Unreadable path → OSError caught → returns [] (lines 437-438)."""
+    from pathlib import Path
+
+    from tree_sitter_analyzer.hotspot_analyzer import _parse_ts_reexports
+
+    result = _parse_ts_reexports(Path("/nonexistent/index.ts"))
+    assert result == []
+
+
+def test_parse_ts_reexports_skips_non_export_lines(tmp_path):
+    """Lines with from clause but not starting with 'export' are skipped (branch 441->439)."""
+    from tree_sitter_analyzer.hotspot_analyzer import _parse_ts_reexports
+
+    index = tmp_path / "index.ts"
+    index.write_text("import { Foo } from './utils'\nconst x = 1\n")
+    result = _parse_ts_reexports(index)
+    assert result == []
+
+
+# ── build_alias_ca_map: known_files paths and missing module on disk ──────────
+
+def test_build_alias_ca_map_known_files_python_branch(tmp_path):
+    """known_files provided: uses list-based init discovery (line 472 True branch)."""
+    from tree_sitter_analyzer.hotspot_analyzer import build_alias_ca_map
+
+    (tmp_path / "pkg").mkdir()
+    (tmp_path / "pkg" / "__init__.py").write_text("from .core import Foo\n")
+    (tmp_path / "pkg" / "core.py").write_text("class Foo: pass\n")
+
+    import_edges = {"main.py": {"pkg/__init__.py": 1}}
+    ca_raw = {"pkg/__init__.py": 1, "pkg/core.py": 0}
+    known_files = ["pkg/__init__.py", "pkg/core.py"]
+    alias_ca = build_alias_ca_map(ca_raw, import_edges, str(tmp_path), known_files=known_files)
+    # __init__.py has 1 importer, re-exports core → core gets +1
+    assert alias_ca["pkg/core.py"] == 1
+
+
+def test_build_alias_ca_map_reexport_module_not_on_disk(tmp_path):
+    """Re-exported module not on disk → suffix loop exhausted without match (491->489 branch)."""
+    from tree_sitter_analyzer.hotspot_analyzer import build_alias_ca_map
+
+    (tmp_path / "pkg").mkdir()
+    # __init__.py re-exports a module that doesn't exist on disk
+    (tmp_path / "pkg" / "__init__.py").write_text("from .ghost import Foo\n")
+
+    import_edges = {"main.py": {"pkg/__init__.py": 1}}
+    ca_raw = {"pkg/__init__.py": 1}
+    alias_ca = build_alias_ca_map(ca_raw, import_edges, str(tmp_path))
+    # ghost.py doesn't exist → no alias bump; ca_raw preserved as-is
+    assert alias_ca == {"pkg/__init__.py": 1}
+
+
+def test_build_alias_ca_map_known_files_typescript_branch(tmp_path):
+    """known_files provided: uses list-based index discovery (line 504 True branch)."""
+    from tree_sitter_analyzer.hotspot_analyzer import build_alias_ca_map
+
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "index.ts").write_text("export { Foo } from './utils'\n")
+    (tmp_path / "src" / "utils.ts").write_text("export class Foo {}\n")
+
+    import_edges = {"main.ts": {"src/index.ts": 1}}
+    ca_raw = {"src/index.ts": 1, "src/utils.ts": 0}
+    known_files = ["src/index.ts", "src/utils.ts"]
+    alias_ca = build_alias_ca_map(ca_raw, import_edges, str(tmp_path), known_files=known_files)
+    # index.ts has 1 importer, re-exports utils → utils gets +1
+    assert alias_ca["src/utils.ts"] == 1
+
+
+def test_build_alias_ca_map_ts_reexport_module_not_on_disk(tmp_path):
+    """TS re-exported module not on disk → suffix loop exhausted (521->519 branch)."""
+    from tree_sitter_analyzer.hotspot_analyzer import build_alias_ca_map
+
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "index.ts").write_text("export { Ghost } from './ghost'\n")
+
+    import_edges = {"main.ts": {"src/index.ts": 1}}
+    ca_raw = {"src/index.ts": 1}
+    alias_ca = build_alias_ca_map(ca_raw, import_edges, str(tmp_path))
+    # ghost.ts doesn't exist → no alias bump; ca_raw preserved
+    assert alias_ca == {"src/index.ts": 1}
+
+
+def test_build_alias_ca_map_first_suffix_missing_second_exists(tmp_path):
+    """First suffix (.ts) doesn't exist but second (.js) does → 523->521 branch taken."""
+    from tree_sitter_analyzer.hotspot_analyzer import build_alias_ca_map
+
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "index.ts").write_text("export { Foo } from './utils'\n")
+    # Only .js exists, not .ts
+    (tmp_path / "src" / "utils.js").write_text("export class Foo {}\n")
+
+    import_edges = {"main.ts": {"src/index.ts": 1}}
+    ca_raw = {"src/index.ts": 1, "src/utils.js": 0}
+    alias_ca = build_alias_ca_map(ca_raw, import_edges, str(tmp_path))
+    # Should find utils.js on second suffix attempt
+    assert alias_ca["src/utils.js"] == 1

--- a/tree_sitter_analyzer/cli/argument_groups/__init__.py
+++ b/tree_sitter_analyzer/cli/argument_groups/__init__.py
@@ -21,6 +21,7 @@ from ._analysis import (
     _add_mcp_analysis_options,
     _add_mcp_change_options,
     _add_mcp_health_options,
+    _add_mcp_hotspot_options,
 )
 from ._analysis_codegraph import _add_mcp_codegraph_map_options
 from ._analysis_graph_nav import _add_mcp_graph_nav_options
@@ -59,6 +60,7 @@ __all__ = [
     "_add_mcp_graph_nav_options",
     "_add_mcp_constraints_options",
     "_add_mcp_health_options",
+    "_add_mcp_hotspot_options",
     "_add_mcp_index_management_options",
     "_add_modification_guard_options",
     "_add_mutation_probe_options",

--- a/tree_sitter_analyzer/cli/argument_groups/_analysis.py
+++ b/tree_sitter_analyzer/cli/argument_groups/_analysis.py
@@ -120,6 +120,65 @@ def _add_mcp_health_options(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def _add_mcp_hotspot_options(parser: argparse.ArgumentParser) -> None:
+    """Add --hotspot and related flags (RFC-0028)."""
+    parser.add_argument(
+        "--hotspot",
+        action="store_true",
+        dest="hotspot",
+        help=(
+            "Rank files by hotspot_score = Ca x MaxCC. "
+            "Identifies files that are both highly coupled (many dependents) "
+            "and structurally complex — the highest-value refactoring targets."
+        ),
+    )
+    parser.add_argument(
+        "--hotspot-top-n",
+        type=int,
+        default=20,
+        dest="hotspot_top_n",
+        metavar="N",
+        help="Limit ranking to top N files before pagination (default: 20, max: 200)",
+    )
+    parser.add_argument(
+        "--hotspot-show-alias-diff",
+        action="store_true",
+        dest="hotspot_show_alias_diff",
+        help="Include alias_gap_summary showing files where ca_alias > ca_raw",
+    )
+    parser.add_argument(
+        "--trace-from",
+        metavar="ENTRY_PATH",
+        dest="trace_from",
+        default=None,
+        help=(
+            "--hotspot: restrict scoring to files reachable via BFS from ENTRY_PATH. "
+            "Combine with --depth to control traversal depth (default: 3, max: 5)."
+        ),
+    )
+    parser.add_argument(
+        "--depth",
+        type=int,
+        default=3,
+        dest="depth",
+        help="BFS depth for --trace-from (default: 3, capped at 5)",
+    )
+    parser.add_argument(
+        "--page",
+        type=int,
+        default=1,
+        dest="page",
+        help="Pagination: 1-indexed page number (default: 1)",
+    )
+    parser.add_argument(
+        "--page-size",
+        type=int,
+        default=20,
+        dest="page_size",
+        help="Pagination: results per page (default: 20, max: 100)",
+    )
+
+
 def _add_mcp_change_options(parser: argparse.ArgumentParser) -> None:
     """Add change-impact MCP mirror flags."""
     parser.add_argument(

--- a/tree_sitter_analyzer/cli/argument_parser_builder.py
+++ b/tree_sitter_analyzer/cli/argument_parser_builder.py
@@ -32,6 +32,7 @@ from .argument_groups import (
     _add_mcp_change_options,
     _add_mcp_constraints_options,
     _add_mcp_health_options,
+    _add_mcp_hotspot_options,
     _add_mcp_index_management_options,
     _add_modification_guard_options,
     _add_mutation_probe_options,
@@ -62,6 +63,7 @@ __all__ = [
     "_add_mcp_constraints_options",
     "_add_mcp_equivalent_options",
     "_add_mcp_health_options",
+    "_add_mcp_hotspot_options",
     "_add_mcp_index_management_options",
     "_add_modification_guard_options",
     "_add_mutation_probe_options",
@@ -136,6 +138,7 @@ def _add_mcp_equivalent_options(parser: argparse.ArgumentParser) -> None:
     _add_agent_skills_options(parser)
     _add_agent_workflow_options(parser)
     _add_mcp_health_options(parser)
+    _add_mcp_hotspot_options(parser)
     _add_mcp_change_options(parser)
     _add_mcp_analysis_options(parser)
     _add_mcp_constraints_options(parser)

--- a/tree_sitter_analyzer/cli/capability_commands.py
+++ b/tree_sitter_analyzer/cli/capability_commands.py
@@ -26,6 +26,50 @@ if TYPE_CHECKING:  # avoid a circular import; only needed for annotations
     from tree_sitter_analyzer.cli.special_commands import SpecialCommandContext
 
 
+def _ensure_tsa_config(project_root: str) -> None:
+    """Write .tsa/config.json if it does not already exist."""
+    import json
+    from pathlib import Path
+
+    tsa_dir = Path(project_root) / ".tsa"
+    tsa_dir.mkdir(exist_ok=True)
+    config_path = tsa_dir / "config.json"
+    if config_path.exists():
+        return
+    config = {
+        "severity_thresholds": {"critical": 400, "review": 100},
+        "default_depth": 3,
+        "default_top_n": 20,
+        "default_page_size": 20,
+        "supported_extensions": [".py", ".ts", ".js", ".java", ".go", ".rs", ".c", ".cpp"],
+    }
+    config_path.write_text(json.dumps(config, indent=2), encoding="utf-8")
+
+
+def _write_index_meta(project_root: str, files_indexed: int, languages: list[str]) -> None:
+    """Write .tsa/index-meta.json after a successful --hotspot run."""
+    import datetime
+    import importlib.metadata
+    import json
+    from pathlib import Path
+
+    tsa_dir = Path(project_root) / ".tsa"
+    tsa_dir.mkdir(exist_ok=True)
+
+    try:
+        version = importlib.metadata.version("tree-sitter-analyzer")
+    except importlib.metadata.PackageNotFoundError:
+        version = "0.0.0+dev"
+
+    meta = {
+        "built_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "files_indexed": files_indexed,
+        "languages": languages,
+        "tsa_version": version,
+    }
+    (tsa_dir / "index-meta.json").write_text(json.dumps(meta, indent=2), encoding="utf-8")
+
+
 def _execute_facade(
     facade: Any,
     tool_args: dict[str, Any],
@@ -43,6 +87,211 @@ def _execute_facade(
         return 1
     context.output_json(result)
     return 0 if result.get("success", False) else 1
+
+
+def _handle_hotspot(
+    args: Any, context: "SpecialCommandContext", output_format: str
+) -> int:
+    import sys
+    from pathlib import Path
+
+    from tree_sitter_analyzer.dependency_matrix import DependencyMatrix
+    from tree_sitter_analyzer.hotspot_analyzer import (
+        build_alias_ca_map,
+        build_ca_from_source_imports,
+        build_ca_raw_map,
+        build_heatmap_map,
+        build_import_edges_from_source,
+        compute_scores,
+        heatmaps_from_project_analysis,
+    )
+    from tree_sitter_analyzer.output_schema import (
+        AliasDiffSummary,
+        HotspotResult,
+        SubgraphSummary,
+        paginate,
+        result_to_dict,
+    )
+
+    project_root = getattr(args, "project_root", None) or os.getcwd()
+    top_n = getattr(args, "hotspot_top_n", 20)
+    page = getattr(args, "page", 1)
+    page_size = min(getattr(args, "page_size", 20), 100)
+    show_alias_diff = getattr(args, "hotspot_show_alias_diff", False)
+    trace_from = getattr(args, "trace_from", None)
+    if trace_from is not None:
+        trace_from = trace_from.replace("\\", "/")
+    depth = getattr(args, "depth", 3)
+
+    # --- Argument validation ---
+    if top_n < 1:
+        context.output_json(result_to_dict(HotspotResult(
+            success=False, error="invalid_argument",
+            error_category="configuration", recovery_hint="fix_argument",
+            message="Invalid value for --hotspot-top-n: must be >= 1",
+        )))
+        return 1
+    top_n = min(top_n, 200)
+    if page < 1:
+        context.output_json(result_to_dict(HotspotResult(
+            success=False, error="invalid_argument",
+            error_category="configuration", recovery_hint="fix_argument",
+            message="Invalid value for --page: must be >= 1",
+        )))
+        return 1
+    if page_size < 1:
+        context.output_json(result_to_dict(HotspotResult(
+            success=False, error="invalid_argument",
+            error_category="configuration", recovery_hint="fix_argument",
+            message="Invalid value for --page-size: must be >= 1",
+        )))
+        return 1
+    if depth < 1:
+        context.output_json(result_to_dict(HotspotResult(
+            success=False, error="invalid_argument",
+            error_category="configuration", recovery_hint="fix_argument",
+            message="Invalid value for --depth: must be 1-5",
+        )))
+        return 1
+    if depth > 5:
+        print(f"WARNING: --depth {depth} exceeds max (5); capping at 5", file=sys.stderr)
+        depth = 5
+
+    # --- Write .tsa/config.json ---
+    _ensure_tsa_config(project_root)
+
+    # --- Build DependencyMatrix ---
+    dm = DependencyMatrix(project_root)
+    try:
+        dm.build()
+    except FileNotFoundError:
+        context.output_json(result_to_dict(HotspotResult(
+            success=False, error="index_not_built",
+            error_category="state", recovery_hint="fix_then_retry",
+            message="Index not found — run 'tsa --ast-cache . --ast-cache-mode index' first, then retry --hotspot",
+        )))
+        return 1
+    except OSError:
+        context.output_json(result_to_dict(HotspotResult(
+            success=False, error="index_build_error",
+            error_category="transient", recovery_hint="retry",
+            message="Transient I/O error reading index — retry should succeed",
+        )))
+        return 1
+    except Exception:
+        context.output_json(result_to_dict(HotspotResult(
+            success=False, error="index_not_built",
+            error_category="state", recovery_hint="fix_then_retry",
+            message="Index not found — run 'tsa --ast-cache . --ast-cache-mode index' first, then retry --hotspot",
+        )))
+        return 1
+
+    # --- Heatmap data ---
+    try:
+        heatmap_files = heatmaps_from_project_analysis(project_root)
+    except TimeoutError:
+        context.output_json(result_to_dict(HotspotResult(
+            success=False, error="parse_timeout",
+            error_category="transient", recovery_hint="retry",
+            message="File parse timeout — transient, retry should succeed",
+        )))
+        return 1
+    except OSError:
+        context.output_json(result_to_dict(HotspotResult(
+            success=False, error="fs_busy",
+            error_category="transient", recovery_hint="retry",
+            message="Transient I/O error — retry should succeed",
+        )))
+        return 1
+
+    ca_map = build_ca_raw_map(dm)
+    _known_files: list[str] | None = None
+
+    # If DependencyMatrix returned no data (cache not built), fall back to
+    # regex-based source parsing. Scan ALL project Python files so that
+    # imports from tests/, scripts/, etc. are counted — not just heatmap files.
+    # Also build import_edges for BFS (P5) and alias Ca (P3).
+    if not ca_map or not dm._import_edges:
+        from tree_sitter_analyzer.complexity_heatmap import _collect_source_files
+        import os as _os
+        all_py = _collect_source_files(project_root, "python", None, 5000)
+        _known_files = [
+            _os.path.relpath(fp, project_root).replace("\\", "/")
+            for fp, _ in all_py
+        ]
+        if not ca_map:
+            target_files = [fh.file.replace("\\", "/") for fh in heatmap_files]
+            ca_map = build_ca_from_source_imports(project_root, _known_files, target_files)
+        if not dm._import_edges:
+            dm._import_edges = build_import_edges_from_source(project_root, _known_files)
+
+    heatmap_map = build_heatmap_map(heatmap_files)
+
+    # --- Alias-aware Ca (P3) ---
+    # Pass _known_files when available to avoid expensive rglob on large repos
+    alias_ca_map = build_alias_ca_map(ca_map, dm._import_edges, project_root, _known_files)
+
+    # --- BFS subgraph (P5: trace_from != None) ---
+    reachable = None
+    subgraph_summary = None
+    total_project_files = len(set(ca_map) | set(heatmap_map))
+
+    if trace_from is not None:
+        from tree_sitter_analyzer.subgraph_traverser import get_subgraph
+        reachable = get_subgraph(dm, trace_from, depth)
+        if reachable is None:
+            context.output_json(result_to_dict(HotspotResult(
+                success=False, error="entry_point_not_found",
+                error_category="data", recovery_hint="try_alternative",
+                message=(
+                    f"Entry point not found: {trace_from} — "
+                    "try '--trace-from src/' or check path with 'tsa health'"
+                ),
+            )))
+            return 1
+        subgraph_summary = SubgraphSummary(
+            entry_point=trace_from,
+            depth=depth,
+            files_in_subgraph=len(reachable),
+            total_project_files=total_project_files,
+        )
+
+    # --- Score & paginate ---
+    ranked = compute_scores(
+        ca_map=ca_map,
+        heatmap_map=heatmap_map,
+        alias_ca_map=alias_ca_map,
+        reachable=reachable,
+        top_n=top_n,
+        show_alias_diff=show_alias_diff,
+    )
+    page_entries, meta = paginate(ranked, page, page_size)
+
+    result = HotspotResult(
+        success=True,
+        metadata=meta,
+        threshold={"critical": 400, "review": 100},
+        results=page_entries,
+        subgraph_summary=subgraph_summary,
+    )
+    if not ranked:
+        result.message = "No files exceed CRITICAL or REVIEW threshold — codebase is in good shape"
+
+    # --- Alias gap summary (P3) ---
+    if show_alias_diff:
+        gaps = sum(1 for f in alias_ca_map if alias_ca_map[f] > ca_map.get(f, 0))
+        result.alias_gap_summary = AliasDiffSummary(
+            files_with_alias_gap=gaps,
+            total_files=len(set(ca_map) | set(heatmap_map)),
+        )
+
+    # --- Write index-meta.json (P6) ---
+    if result.success:
+        langs = list({fh.language for fh in heatmap_files if fh.language})
+        _write_index_meta(project_root, len(heatmap_files), sorted(langs))
+
+    context.output_json(result_to_dict(result))
+    return 0
 
 
 def _handle_project_card(
@@ -120,4 +369,6 @@ def handle_capability_actions(
         return _handle_plan_rename(args, context, output_format)
     if getattr(args, "refactor_queue", False):
         return _handle_refactor_queue(args, context, output_format)
+    if getattr(args, "hotspot", False):
+        return _handle_hotspot(args, context, output_format)
     return None

--- a/tree_sitter_analyzer/cli/capability_commands.py
+++ b/tree_sitter_analyzer/cli/capability_commands.py
@@ -90,10 +90,9 @@ def _execute_facade(
 
 
 def _handle_hotspot(
-    args: Any, context: "SpecialCommandContext", output_format: str
+    args: Any, context: SpecialCommandContext, output_format: str
 ) -> int:
     import sys
-    from pathlib import Path
 
     from tree_sitter_analyzer.dependency_matrix import DependencyMatrix
     from tree_sitter_analyzer.hotspot_analyzer import (
@@ -212,8 +211,9 @@ def _handle_hotspot(
     # imports from tests/, scripts/, etc. are counted — not just heatmap files.
     # Also build import_edges for BFS (P5) and alias Ca (P3).
     if not ca_map or not dm._import_edges:
-        from tree_sitter_analyzer.complexity_heatmap import _collect_source_files
         import os as _os
+
+        from tree_sitter_analyzer.complexity_heatmap import _collect_source_files
         all_py = _collect_source_files(project_root, "python", None, 5000)
         _known_files = [
             _os.path.relpath(fp, project_root).replace("\\", "/")

--- a/tree_sitter_analyzer/cli/capability_commands.py
+++ b/tree_sitter_analyzer/cli/capability_commands.py
@@ -300,7 +300,7 @@ def _handle_hotspot(
         )
 
     # --- Write index-meta.json (P6) ---
-    if result.success:
+    if result.success:  # always True at this point; False branch is dead code
         langs = list({fh.language for fh in heatmap_files if fh.language})
         _write_index_meta(project_root, len(heatmap_files), sorted(langs))
 

--- a/tree_sitter_analyzer/cli/capability_commands.py
+++ b/tree_sitter_analyzer/cli/capability_commands.py
@@ -240,15 +240,19 @@ def _handle_hotspot(
         from tree_sitter_analyzer.subgraph_traverser import get_subgraph
         reachable = get_subgraph(dm, trace_from, depth)
         if reachable is None:
-            context.output_json(result_to_dict(HotspotResult(
-                success=False, error="entry_point_not_found",
-                error_category="data", recovery_hint="try_alternative",
-                message=(
-                    f"Entry point not found: {trace_from} — "
-                    "try '--trace-from src/' or check path with 'tsa health'"
-                ),
-            )))
-            return 1
+            # Isolated file: no imports, no importers — still a valid entry at hop 0
+            if trace_from in heatmap_map:
+                reachable = {trace_from: 0}
+            else:
+                context.output_json(result_to_dict(HotspotResult(
+                    success=False, error="entry_point_not_found",
+                    error_category="data", recovery_hint="try_alternative",
+                    message=(
+                        f"Entry point not found: {trace_from} — "
+                        "try '--trace-from src/' or check path with 'tsa health'"
+                    ),
+                )))
+                return 1
         subgraph_summary = SubgraphSummary(
             entry_point=trace_from,
             depth=depth,
@@ -267,12 +271,22 @@ def _handle_hotspot(
     )
     page_entries, meta = paginate(ranked, page, page_size)
 
+    n_critical = sum(1 for e in ranked if e.severity == "CRITICAL")
+    n_review = sum(1 for e in ranked if e.severity == "REVIEW")
+    verdict = "CRITICAL" if n_critical > 0 else ("REVIEW" if n_review > 0 else "OK")
+    summary_line = (
+        f"hotspot: top={min(top_n, len(ranked))} files "
+        f"CRITICAL={n_critical} REVIEW={n_review} OK={len(ranked)-n_critical-n_review}"
+    )
     result = HotspotResult(
         success=True,
         metadata=meta,
         threshold={"critical": 400, "review": 100},
         results=page_entries,
         subgraph_summary=subgraph_summary,
+        summary_line=summary_line,
+        verdict=verdict,
+        agent_summary={"summary_line": summary_line, "verdict": verdict},
     )
     if not ranked:
         result.message = "No files exceed CRITICAL or REVIEW threshold — codebase is in good shape"

--- a/tree_sitter_analyzer/hotspot_analyzer.py
+++ b/tree_sitter_analyzer/hotspot_analyzer.py
@@ -1,24 +1,18 @@
 """Hotspot scorer: Ca x MaxCC ranking with alias-aware Ca."""
 from __future__ import annotations
 
-import os
 import re
-import sys
+from collections.abc import Iterator
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Iterator
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from tree_sitter_analyzer.dependency_matrix import DependencyMatrix
     from tree_sitter_analyzer.complexity_heatmap import FileHeatmap
+    from tree_sitter_analyzer.dependency_matrix import DependencyMatrix
 
 from tree_sitter_analyzer.output_schema import (
-    AliasDiffSummary,
     HotspotEntry,
-    HotspotMetadata,
-    HotspotResult,
-    SubgraphSummary,
     TestFocus,
-    paginate,
 )
 
 SEVERITY_CRITICAL = 400
@@ -33,7 +27,7 @@ SUGGESTION_BY_SEVERITY = {
 
 # ── Ca helpers ────────────────────────────────────────────────────────────────
 
-def build_ca_raw_map(dm: "DependencyMatrix") -> dict[str, int]:
+def build_ca_raw_map(dm: DependencyMatrix) -> dict[str, int]:
     """Return {file: afferent_coupling} from DependencyMatrix module_stats.
 
     Reads dm._result.module_stats after dm.build() has been called.
@@ -46,7 +40,7 @@ def build_ca_raw_map(dm: "DependencyMatrix") -> dict[str, int]:
 
 # ── Heatmap helpers ───────────────────────────────────────────────────────────
 
-def build_heatmap_map(heatmap_files: list["FileHeatmap"]) -> dict[str, "FileHeatmap"]:
+def build_heatmap_map(heatmap_files: list[FileHeatmap]) -> dict[str, FileHeatmap]:
     """Return {file: FileHeatmap} for O(1) lookup (forward-slash normalized)."""
     return {fh.file.replace("\\", "/"): fh for fh in heatmap_files}
 
@@ -76,9 +70,9 @@ def _detect_source_dir(project_root: str) -> str | None:
             import tomllib  # Python 3.11+
         except ImportError:
             try:
-                import tomli as tomllib  # type: ignore[no-redef]
+                import tomli as tomllib  # noqa: PLC0415
             except ImportError:
-                tomllib = None  # type: ignore[assignment]
+                tomllib = None
         if tomllib is not None:
             try:
                 data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
@@ -121,7 +115,7 @@ def _detect_source_dir(project_root: str) -> str | None:
     return None
 
 
-def heatmaps_from_project_analysis(project_root: str, max_files: int = 200) -> list["FileHeatmap"]:
+def heatmaps_from_project_analysis(project_root: str, max_files: int = 200) -> list[FileHeatmap]:
     """Build FileHeatmap list using analyze_project_heatmap() result.
 
     Scopes to the main source package (via __init__.py detection) to avoid
@@ -130,6 +124,8 @@ def heatmaps_from_project_analysis(project_root: str, max_files: int = 200) -> l
     """
     from tree_sitter_analyzer.complexity_heatmap import (
         FileHeatmap as _FileHeatmap,
+    )
+    from tree_sitter_analyzer.complexity_heatmap import (
         FunctionComplexity,
         analyze_project_heatmap,
     )
@@ -335,7 +331,7 @@ def classify_severity(score: float) -> str:
     return "OK"
 
 
-def build_test_focus(file_heatmap: "FileHeatmap", severity: str) -> TestFocus:
+def build_test_focus(file_heatmap: FileHeatmap, severity: str) -> TestFocus:
     """Extract highest-CC function and attach severity-based suggestion."""
     funcs = sorted(file_heatmap.functions, key=lambda f: f.complexity, reverse=True)
     if funcs:
@@ -356,7 +352,7 @@ def build_test_focus(file_heatmap: "FileHeatmap", severity: str) -> TestFocus:
 
 def compute_scores(
     ca_map: dict[str, int],          # {file: ca_raw}
-    heatmap_map: dict[str, "FileHeatmap"],
+    heatmap_map: dict[str, FileHeatmap],
     alias_ca_map: dict[str, int] | None = None,  # {file: ca_alias} — None = P2
     reachable: dict[str, int] | None = None,      # {file: hops}  — None = global mode
     top_n: int = 20,
@@ -414,7 +410,7 @@ def _parse_python_reexports(init_path: Path) -> list[str]:
       from .subpkg.baz import X  -> adds "subpkg/baz"
     Dynamic imports and star imports are skipped.
     """
-    results = []
+    results: list[str] = []
     try:
         text = init_path.read_text(encoding="utf-8", errors="replace")
     except OSError:
@@ -434,7 +430,7 @@ def _parse_ts_reexports(index_path: Path) -> list[str]:
 
     Parses: export { Foo } from './foo'  or  export * from './bar'
     """
-    results = []
+    results: list[str] = []
     try:
         text = index_path.read_text(encoding="utf-8", errors="replace")
     except OSError:

--- a/tree_sitter_analyzer/hotspot_analyzer.py
+++ b/tree_sitter_analyzer/hotspot_analyzer.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import re
+import sys
 from collections.abc import Iterator
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -66,11 +67,11 @@ def _detect_source_dir(project_root: str) -> str | None:
     # Try pyproject.toml (hatch, setuptools, flit)
     pyproject = root / "pyproject.toml"
     if pyproject.exists():
-        try:
-            import tomllib  # Python 3.11+
-        except ImportError:
+        if sys.version_info >= (3, 11):
+            import tomllib  # noqa: I001
+        else:
             try:
-                import tomli as tomllib  # noqa: PLC0415
+                import tomli as tomllib  # type: ignore[import-not-found,no-redef]  # noqa: PLC0415
             except ImportError:
                 tomllib = None
         if tomllib is not None:
@@ -393,7 +394,7 @@ def compute_scores(
             hops=hops,
         ))
 
-    entries.sort(key=lambda e: e.score, reverse=True)
+    entries.sort(key=lambda e: (-e.score, e.file))
     entries = entries[:max(0, top_n)]
     for i, e in enumerate(entries, 1):
         e.rank = i
@@ -486,10 +487,15 @@ def build_alias_ca_map(
             1 for src in import_edges if init_rel in import_edges[src]
         )
         for mod in re_exported:
-            # Candidate canonical paths
+            # Resolve relative to the package directory, not the project root
             for suffix in [f"{mod}.py", f"{mod}/__init__.py"]:
-                if (root / suffix).exists():
-                    alias_extra[suffix] = alias_extra.get(suffix, 0) + importers_of_init
+                candidate = init_path.parent / suffix
+                if candidate.exists():
+                    try:
+                        canonical = str(candidate.relative_to(root)).replace("\\", "/")
+                    except ValueError:
+                        continue
+                    alias_extra[canonical] = alias_extra.get(canonical, 0) + importers_of_init
                     break
 
     # Find all index.ts / index.js files
@@ -511,9 +517,15 @@ def build_alias_ca_map(
                 1 for src in import_edges if index_rel in import_edges[src]
             )
             for mod in re_exported:
+                # Resolve relative to the index file's package directory
                 for suffix in [f"{mod}.ts", f"{mod}.js", f"{mod}/index.ts"]:
-                    if (root / suffix).exists():
-                        alias_extra[suffix] = alias_extra.get(suffix, 0) + importers_of_index
+                    candidate = index_path.parent / suffix
+                    if candidate.exists():
+                        try:
+                            canonical = str(candidate.relative_to(root)).replace("\\", "/")
+                        except ValueError:
+                            continue
+                        alias_extra[canonical] = alias_extra.get(canonical, 0) + importers_of_index
                         break
 
     result = dict(ca_raw_map)

--- a/tree_sitter_analyzer/hotspot_analyzer.py
+++ b/tree_sitter_analyzer/hotspot_analyzer.py
@@ -1,0 +1,526 @@
+"""Hotspot scorer: Ca x MaxCC ranking with alias-aware Ca."""
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Iterator
+
+if TYPE_CHECKING:
+    from tree_sitter_analyzer.dependency_matrix import DependencyMatrix
+    from tree_sitter_analyzer.complexity_heatmap import FileHeatmap
+
+from tree_sitter_analyzer.output_schema import (
+    AliasDiffSummary,
+    HotspotEntry,
+    HotspotMetadata,
+    HotspotResult,
+    SubgraphSummary,
+    TestFocus,
+    paginate,
+)
+
+SEVERITY_CRITICAL = 400
+SEVERITY_REVIEW = 100
+MAX_DEPTH_CAP = 5
+SUGGESTION_BY_SEVERITY = {
+    "CRITICAL": "test edge cases and error paths",
+    "REVIEW": "test boundary values",
+    "OK": "(low impact, skip)",
+}
+
+
+# ── Ca helpers ────────────────────────────────────────────────────────────────
+
+def build_ca_raw_map(dm: "DependencyMatrix") -> dict[str, int]:
+    """Return {file: afferent_coupling} from DependencyMatrix module_stats.
+
+    Reads dm._result.module_stats after dm.build() has been called.
+    Does NOT call build() internally — caller must have called dm.build() first.
+    """
+    if dm._result is None:
+        return {}
+    return {s.file: s.afferent_coupling for s in dm._result.module_stats}
+
+
+# ── Heatmap helpers ───────────────────────────────────────────────────────────
+
+def build_heatmap_map(heatmap_files: list["FileHeatmap"]) -> dict[str, "FileHeatmap"]:
+    """Return {file: FileHeatmap} for O(1) lookup (forward-slash normalized)."""
+    return {fh.file.replace("\\", "/"): fh for fh in heatmap_files}
+
+
+# Directories that are clearly not the main source package
+_NON_SOURCE_DIRS = frozenset({
+    "tests", "test", "benchmarks", "bench", "docs", "doc", "examples",
+    "example", "scripts", "script", "fixtures", "compatibility_test",
+    "build", "dist", "e2e", "spec", "integration", "functional",
+    "performance", "samples", "demo", "demos", "corpus",
+})
+
+
+def _detect_source_dir(project_root: str) -> str | None:
+    """Return the Python source package directory directly under project_root.
+
+    Tries pyproject.toml [tool.hatch.build.targets.wheel] packages first,
+    then falls back to heuristic: first child dir with __init__.py that is
+    not a well-known non-source directory (tests/, benchmarks/, etc.).
+    """
+    root = Path(project_root)
+
+    # Try pyproject.toml (hatch, setuptools, flit)
+    pyproject = root / "pyproject.toml"
+    if pyproject.exists():
+        try:
+            import tomllib  # Python 3.11+
+        except ImportError:
+            try:
+                import tomli as tomllib  # type: ignore[no-redef]
+            except ImportError:
+                tomllib = None  # type: ignore[assignment]
+        if tomllib is not None:
+            try:
+                data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+                # hatch: [tool.hatch.build.targets.wheel] packages = ["mypkg"]
+                pkgs = (
+                    data.get("tool", {})
+                    .get("hatch", {})
+                    .get("build", {})
+                    .get("targets", {})
+                    .get("wheel", {})
+                    .get("packages", [])
+                )
+                # setuptools: [tool.setuptools] packages = ["mypkg"] or find
+                if not pkgs:
+                    pkgs = (
+                        data.get("tool", {})
+                        .get("setuptools", {})
+                        .get("packages", [])
+                    )
+                if pkgs and isinstance(pkgs, list):
+                    pkg = pkgs[0]
+                    if isinstance(pkg, str) and (root / pkg / "__init__.py").exists():
+                        return pkg
+            except Exception:
+                pass
+
+    # Heuristic fallback: first non-test package dir with __init__.py
+    try:
+        for child in sorted(root.iterdir()):
+            name = child.name
+            if (
+                child.is_dir()
+                and (child / "__init__.py").exists()
+                and name not in _NON_SOURCE_DIRS
+                and not name.startswith((".", "_"))
+            ):
+                return name
+    except OSError:
+        pass
+    return None
+
+
+def heatmaps_from_project_analysis(project_root: str, max_files: int = 200) -> list["FileHeatmap"]:
+    """Build FileHeatmap list using analyze_project_heatmap() result.
+
+    Scopes to the main source package (via __init__.py detection) to avoid
+    wasting file slots on tests/, benchmarks/, corpus/ that appear first
+    alphabetically and would crowd out the actual source code.
+    """
+    from tree_sitter_analyzer.complexity_heatmap import (
+        FileHeatmap as _FileHeatmap,
+        FunctionComplexity,
+        analyze_project_heatmap,
+    )
+
+    # Focus on the main source package to avoid alphabetical ordering issues.
+    # Ca data comes from build_ca_from_source_imports separately, so this
+    # scope restriction only affects complexity — not coupling measurement.
+    directory_filter = _detect_source_dir(project_root)
+
+    result = analyze_project_heatmap(
+        project_root,
+        directory_filter=directory_filter,
+        max_files=max_files,
+    )
+    heatmaps: list[_FileHeatmap] = []
+    for fh_dict in result.get("file_heatmaps", []):
+        top_funcs = fh_dict.get("top_functions", [])
+        funcs = [
+            FunctionComplexity(
+                name=f.get("name", ""),
+                file=fh_dict.get("file", ""),
+                line=f.get("line", 0),
+                end_line=f.get("line", 0),
+                complexity=f.get("complexity", 0),
+                language=fh_dict.get("language", ""),
+                class_name=None,
+                decision_points={},
+            )
+            for f in top_funcs
+        ]
+        heatmaps.append(_FileHeatmap(
+            file=fh_dict.get("file", ""),
+            language=fh_dict.get("language", ""),
+            functions=funcs,
+            total_complexity=fh_dict.get("total_complexity", 0),
+            avg_complexity=fh_dict.get("avg_complexity", 0.0),
+            max_complexity=fh_dict.get("max_complexity", 0),
+        ))
+    return heatmaps
+
+
+def _resolve_import_mod(
+    raw_mod: str, current_rel: str, file_set: set[str]
+) -> str | None:
+    """Resolve an import module string to a canonical relative path.
+
+    Handles both absolute imports (from tree_sitter_analyzer.foo import X)
+    and relative imports (from .foo import X) by inferring the package prefix
+    from the current file's path.
+
+    Returns the resolved path (forward-slash) if it exists in file_set, else None.
+    """
+    # Count leading dots for relative imports
+    leading_dots = len(raw_mod) - len(raw_mod.lstrip("."))
+    mod = raw_mod.lstrip(".")
+
+    if leading_dots > 0:
+        # Relative import: resolve relative to current file's directory
+        parts = current_rel.replace("\\", "/").split("/")
+        pkg_parts = parts[:-1]  # directory of current file
+        for _ in range(leading_dots - 1):
+            if pkg_parts:
+                pkg_parts = pkg_parts[:-1]
+        if mod:
+            mod_path = "/".join(pkg_parts + [mod.replace(".", "/")])
+        else:
+            # `from . import X` — package is the directory itself
+            mod_path = "/".join(pkg_parts)
+    else:
+        if not mod:
+            return None
+        mod_path = mod.replace(".", "/")
+
+    for suffix in (f"{mod_path}.py", f"{mod_path}/__init__.py"):
+        if suffix in file_set:
+            return suffix
+    return None
+
+
+def _iter_resolved_imports(
+    text: str, rel_path: str, file_set: set[str]
+) -> Iterator[str]:
+    """Yield resolved import target paths from Python source text (no duplicates).
+
+    Two-pass approach:
+    - Pass 1: standard dotted imports  (from pkg.mod import X, from .mod import X)
+    - Pass 2: bare relative imports    (from . import X, from .. import X, Y)
+    Pass 1 skips bare-dot patterns so they are handled exclusively by pass 2.
+    """
+    import re as _re
+
+    seen: set[str] = set()
+
+    # Pass 1: "from X.y import Z" and "import X.y", including "from .mod import Z"
+    for match in _re.finditer(
+        r"^(?:from\s+(\.?[\w.]+)\s+import|import\s+([\w.]+))",
+        text,
+        _re.MULTILINE,
+    ):
+        raw_mod = match.group(1) or match.group(2) or ""
+        leading_dots = len(raw_mod) - len(raw_mod.lstrip("."))
+        mod = raw_mod.lstrip(".")
+        # Skip bare-dot patterns (e.g. raw_mod == "." or ".."); pass 2 handles them.
+        if leading_dots > 0 and not mod:
+            continue
+        resolved = _resolve_import_mod(raw_mod, rel_path, file_set)
+        if resolved and resolved not in seen:
+            seen.add(resolved)
+            yield resolved
+
+    # Pass 2: bare relative imports — "from . import X" / "from .. import X, Y"
+    for match in _re.finditer(
+        r"^from\s+(\.+)\s+import\s+([^\n#\\]+)",
+        text,
+        _re.MULTILINE,
+    ):
+        dots = match.group(1)
+        names_str = match.group(2)
+        for raw_name in _re.split(r"[\s,]+", names_str.strip()):
+            # Strip "as alias" suffix and leading/trailing punctuation
+            name = raw_name.split(" ")[0].split("(")[0].rstrip(",").strip()
+            if not name or not name.isidentifier():
+                continue
+            resolved = _resolve_import_mod(dots + name, rel_path, file_set)
+            if resolved and resolved not in seen:
+                seen.add(resolved)
+                yield resolved
+
+
+def build_import_edges_from_source(
+    project_root: str,
+    scan_files: list[str],
+) -> dict[str, dict[str, int]]:
+    """Build import edge graph by parsing Python import statements from source.
+
+    Returns {src_file: {tgt_file: count}} where src imports tgt.
+    Paths are normalized to forward slashes for cross-platform consistency.
+    Handles absolute, relative (from .foo), and bare relative (from . import foo).
+    """
+    root = Path(project_root)
+    scan_norm = [p.replace("\\", "/") for p in scan_files]
+    file_set = set(scan_norm)
+    edges: dict[str, dict[str, int]] = {}
+
+    for rel_path in scan_norm:
+        if not rel_path.endswith(".py"):
+            continue
+        try:
+            text = (root / rel_path).read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+
+        for resolved in _iter_resolved_imports(text, rel_path, file_set):
+            tgts = edges.setdefault(rel_path, {})
+            tgts[resolved] = tgts.get(resolved, 0) + 1
+
+    return edges
+
+
+def build_ca_from_source_imports(
+    project_root: str,
+    scan_files: list[str],
+    target_files: list[str] | None = None,
+) -> dict[str, int]:
+    """Build Ca map by parsing Python import statements directly from source files.
+
+    Fallback for when DependencyMatrix has no cache data (cache not built yet).
+    Handles all Python import forms including bare relative imports.
+
+    scan_files: all project Python files to scan for import statements
+    target_files: files to measure Ca FOR (defaults to scan_files when None)
+
+    Paths are normalized to forward slashes for cross-platform matching.
+    """
+    root = Path(project_root)
+
+    scan_norm = [p.replace("\\", "/") for p in scan_files]
+    target_norm = [p.replace("\\", "/") for p in (target_files if target_files is not None else scan_files)]
+    file_set = set(target_norm)
+    ca_count: dict[str, int] = {}
+
+    for rel_path in scan_norm:
+        if not rel_path.endswith(".py"):
+            continue
+        try:
+            text = (root / rel_path).read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+
+        for resolved in _iter_resolved_imports(text, rel_path, file_set):
+            ca_count[resolved] = ca_count.get(resolved, 0) + 1
+
+    return ca_count
+
+
+# ── Severity & test_focus ─────────────────────────────────────────────────────
+
+def classify_severity(score: float) -> str:
+    if score >= SEVERITY_CRITICAL:
+        return "CRITICAL"
+    if score >= SEVERITY_REVIEW:
+        return "REVIEW"
+    return "OK"
+
+
+def build_test_focus(file_heatmap: "FileHeatmap", severity: str) -> TestFocus:
+    """Extract highest-CC function and attach severity-based suggestion."""
+    funcs = sorted(file_heatmap.functions, key=lambda f: f.complexity, reverse=True)
+    if funcs:
+        top = funcs[0]
+        return TestFocus(
+            function=top.name,
+            cc=top.complexity,
+            suggestion=SUGGESTION_BY_SEVERITY[severity],
+        )
+    return TestFocus(
+        function="(no functions)",
+        cc=0,
+        suggestion=SUGGESTION_BY_SEVERITY[severity],
+    )
+
+
+# ── Main scorer ───────────────────────────────────────────────────────────────
+
+def compute_scores(
+    ca_map: dict[str, int],          # {file: ca_raw}
+    heatmap_map: dict[str, "FileHeatmap"],
+    alias_ca_map: dict[str, int] | None = None,  # {file: ca_alias} — None = P2
+    reachable: dict[str, int] | None = None,      # {file: hops}  — None = global mode
+    top_n: int = 20,
+    show_alias_diff: bool = False,
+) -> list[HotspotEntry]:
+    """Compute and rank HotspotEntry list.
+
+    Returns entries sorted descending by score, limited to top_n.
+    alias_ca_map: if None, ca_alias == ca_raw (P2 behaviour).
+    reachable:    if not None, restrict to files in this map (P5 behaviour).
+    """
+    files = set(ca_map) | set(heatmap_map)
+    if reachable is not None:
+        files = files & set(reachable)
+
+    entries: list[HotspotEntry] = []
+    for f in files:
+        ca_raw = ca_map.get(f, 0)
+        ca_alias = alias_ca_map.get(f, ca_raw) if alias_ca_map is not None else ca_raw
+        fh = heatmap_map.get(f)
+        max_cc = fh.max_complexity if fh else 0
+        score = float(ca_alias * max_cc)
+        severity = classify_severity(score)
+        test_focus = (
+            build_test_focus(fh, severity) if fh
+            else TestFocus("(unknown)", 0, SUGGESTION_BY_SEVERITY[severity])
+        )
+        hops = reachable[f] if reachable is not None else None
+        entries.append(HotspotEntry(
+            rank=0,  # assigned below
+            file=f,
+            severity=severity,
+            score=score,
+            ca_raw=ca_raw,
+            ca_alias=ca_alias,
+            max_cc=max_cc,
+            test_focus=test_focus,
+            hops=hops,
+        ))
+
+    entries.sort(key=lambda e: e.score, reverse=True)
+    entries = entries[:max(0, top_n)]
+    for i, e in enumerate(entries, 1):
+        e.rank = i
+    return entries
+
+
+# ── P3: alias-aware Ca ────────────────────────────────────────────────────────
+
+def _parse_python_reexports(init_path: Path) -> list[str]:
+    """Return list of module names re-exported from __init__.py.
+
+    Parses lines of the form:
+      from .foo import Bar       -> adds "foo" (sibling module)
+      from .subpkg.baz import X  -> adds "subpkg/baz"
+    Dynamic imports and star imports are skipped.
+    """
+    results = []
+    try:
+        text = init_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return results
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("from .") and " import " in line:
+            after_from = line[len("from ."):].split(" import ")[0].strip()
+            if after_from and "*" not in line:
+                # convert dotted to path
+                results.append(after_from.replace(".", "/"))
+    return results
+
+
+def _parse_ts_reexports(index_path: Path) -> list[str]:
+    """Return list of relative module paths re-exported from index.ts/index.js.
+
+    Parses: export { Foo } from './foo'  or  export * from './bar'
+    """
+    results = []
+    try:
+        text = index_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return results
+    for line in text.splitlines():
+        m = re.search(r"from\s+['\"](\./[^'\"]+)['\"]", line)
+        if m and line.strip().startswith("export"):
+            rel = m.group(1).lstrip("./")
+            results.append(rel)
+    return results
+
+
+def build_alias_ca_map(
+    ca_raw_map: dict[str, int],
+    import_edges: dict[str, dict[str, int]],
+    project_root: str,
+    known_files: list[str] | None = None,
+) -> dict[str, int]:
+    """Return {file: ca_alias} by augmenting ca_raw with alias-chain counts.
+
+    Scans __init__.py (Python) and index.ts/index.js (TS/JS) in project_root.
+    Files not seen in init/index re-exports keep ca_alias == ca_raw.
+
+    known_files: pre-collected list of relative paths (forward-slash normalized).
+      When provided, avoids expensive rglob walks for large repos on Windows.
+
+    Short-circuits when import_edges is empty (no DM cache data) to avoid
+    an expensive rglob walk that would produce no useful results anyway.
+    """
+    if not import_edges:
+        return dict(ca_raw_map)
+
+    root = Path(project_root)
+    alias_extra: dict[str, int] = {}  # {canonical_file: extra_count}
+
+    # Use pre-collected file list to avoid slow rglob on large directory trees
+    if known_files is not None:
+        _init_py_paths = [
+            root / p for p in known_files if p.endswith("__init__.py")
+        ]
+    else:
+        _init_py_paths = list(root.rglob("__init__.py"))
+
+    # Find all __init__.py files
+    for init_path in _init_py_paths:
+        re_exported = _parse_python_reexports(init_path)
+        try:
+            init_rel = str(init_path.relative_to(root)).replace("\\", "/")
+        except ValueError:
+            continue
+        # Count how many files import via this __init__.py
+        importers_of_init = sum(
+            1 for src in import_edges if init_rel in import_edges[src]
+        )
+        for mod in re_exported:
+            # Candidate canonical paths
+            for suffix in [f"{mod}.py", f"{mod}/__init__.py"]:
+                if (root / suffix).exists():
+                    alias_extra[suffix] = alias_extra.get(suffix, 0) + importers_of_init
+                    break
+
+    # Find all index.ts / index.js files
+    for index_name in ("index.ts", "index.js"):
+        if known_files is not None:
+            _index_paths: list[Path] = [
+                root / p for p in known_files
+                if p.endswith(f"/{index_name}") or p == index_name
+            ]
+        else:
+            _index_paths = list(root.rglob(index_name))
+        for index_path in _index_paths:
+            re_exported = _parse_ts_reexports(index_path)
+            try:
+                index_rel = str(index_path.relative_to(root)).replace("\\", "/")
+            except ValueError:
+                continue
+            importers_of_index = sum(
+                1 for src in import_edges if index_rel in import_edges[src]
+            )
+            for mod in re_exported:
+                for suffix in [f"{mod}.ts", f"{mod}.js", f"{mod}/index.ts"]:
+                    if (root / suffix).exists():
+                        alias_extra[suffix] = alias_extra.get(suffix, 0) + importers_of_index
+                        break
+
+    result = dict(ca_raw_map)
+    for f, extra in alias_extra.items():
+        result[f] = result.get(f, 0) + extra
+    return result

--- a/tree_sitter_analyzer/hotspot_analyzer.py
+++ b/tree_sitter_analyzer/hotspot_analyzer.py
@@ -69,7 +69,7 @@ def _detect_source_dir(project_root: str) -> str | None:
     if pyproject.exists():
         if sys.version_info >= (3, 11):
             import tomllib  # noqa: I001
-        else:
+        else:  # pragma: no cover
             try:
                 import tomli as tomllib  # type: ignore[import-not-found,no-redef]  # noqa: PLC0415
             except ImportError:
@@ -480,7 +480,7 @@ def build_alias_ca_map(
         re_exported = _parse_python_reexports(init_path)
         try:
             init_rel = str(init_path.relative_to(root)).replace("\\", "/")
-        except ValueError:
+        except ValueError:  # pragma: no cover
             continue
         # Count how many files import via this __init__.py
         importers_of_init = sum(
@@ -493,7 +493,7 @@ def build_alias_ca_map(
                 if candidate.exists():
                     try:
                         canonical = str(candidate.relative_to(root)).replace("\\", "/")
-                    except ValueError:
+                    except ValueError:  # pragma: no cover
                         continue
                     alias_extra[canonical] = alias_extra.get(canonical, 0) + importers_of_init
                     break
@@ -511,7 +511,7 @@ def build_alias_ca_map(
             re_exported = _parse_ts_reexports(index_path)
             try:
                 index_rel = str(index_path.relative_to(root)).replace("\\", "/")
-            except ValueError:
+            except ValueError:  # pragma: no cover
                 continue
             importers_of_index = sum(
                 1 for src in import_edges if index_rel in import_edges[src]
@@ -523,7 +523,7 @@ def build_alias_ca_map(
                     if candidate.exists():
                         try:
                             canonical = str(candidate.relative_to(root)).replace("\\", "/")
-                        except ValueError:
+                        except ValueError:  # pragma: no cover
                             continue
                         alias_extra[canonical] = alias_extra.get(canonical, 0) + importers_of_index
                         break

--- a/tree_sitter_analyzer/output_schema.py
+++ b/tree_sitter_analyzer/output_schema.py
@@ -65,6 +65,10 @@ class HotspotResult:
     error: str | None = None
     error_category: str | None = None  # "state"|"data"|"transient"|"configuration"
     recovery_hint: str | None = None   # "retry"|"try_alternative"|"fix_then_retry"|"fix_argument"
+    # Canonical CLI envelope (required by test_cli_envelope_contract.py)
+    summary_line: str | None = None
+    verdict: str | None = None
+    agent_summary: dict[str, Any] | None = None
 
 
 def paginate(
@@ -84,7 +88,7 @@ def paginate(
     start = (page - 1) * page_size
     end = start + page_size
     sliced = ranked[start:end]
-    truncated = (total % page_size) != 0 and page == total_pages and total > 0
+    truncated = page < total_pages
     meta = HotspotMetadata(
         files_analyzed=total,
         files_in_output=len(sliced),

--- a/tree_sitter_analyzer/output_schema.py
+++ b/tree_sitter_analyzer/output_schema.py
@@ -1,0 +1,102 @@
+"""Dataclass-based output schema for --hotspot.
+
+Uses stdlib @dataclass + dataclasses.asdict() — no Pydantic dependency.
+"""
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class TestFocus:
+    function: str
+    cc: int
+    suggestion: str
+
+
+@dataclass
+class HotspotEntry:
+    rank: int
+    file: str
+    severity: str          # "CRITICAL" | "REVIEW" | "OK"
+    score: float
+    ca_raw: int
+    ca_alias: int
+    max_cc: int
+    test_focus: TestFocus
+    hops: int | None = None   # set only when --trace-from is active
+
+
+@dataclass
+class HotspotMetadata:
+    files_analyzed: int
+    files_in_output: int
+    page: int
+    page_size: int
+    total_pages: int
+    truncated: bool
+
+
+@dataclass
+class SubgraphSummary:
+    entry_point: str
+    depth: int
+    files_in_subgraph: int
+    total_project_files: int
+
+
+@dataclass
+class AliasDiffSummary:
+    files_with_alias_gap: int
+    total_files: int
+
+
+@dataclass
+class HotspotResult:
+    success: bool
+    metadata: HotspotMetadata | None = None
+    threshold: dict[str, int] | None = None
+    results: list[HotspotEntry] = field(default_factory=list)
+    message: str | None = None
+    subgraph_summary: SubgraphSummary | None = None
+    alias_gap_summary: AliasDiffSummary | None = None
+    error: str | None = None
+    error_category: str | None = None  # "state"|"data"|"transient"|"configuration"
+    recovery_hint: str | None = None   # "retry"|"try_alternative"|"fix_then_retry"|"fix_argument"
+
+
+def paginate(
+    ranked: list[HotspotEntry],
+    page: int,
+    page_size: int,
+) -> tuple[list[HotspotEntry], HotspotMetadata]:
+    """Slice a pre-sorted list and return (page_slice, metadata).
+
+    ranked must already be sorted descending by score.
+    page is 1-indexed.
+    total_pages is 0 when ranked is empty.
+    """
+    total = len(ranked)
+    # ceiling division; yields 0 when total==0
+    total_pages = -(-total // page_size) if total > 0 else 0
+    start = (page - 1) * page_size
+    end = start + page_size
+    sliced = ranked[start:end]
+    truncated = (total % page_size) != 0 and page == total_pages and total > 0
+    meta = HotspotMetadata(
+        files_analyzed=total,
+        files_in_output=len(sliced),
+        page=page,
+        page_size=page_size,
+        total_pages=total_pages,
+        truncated=truncated,
+    )
+    return sliced, meta
+
+
+def result_to_dict(result: HotspotResult) -> dict[str, Any]:
+    """Serialize HotspotResult to a plain dict, omitting None-valued fields."""
+    raw = dataclasses.asdict(result)
+    return {k: v for k, v in raw.items() if v is not None}

--- a/tree_sitter_analyzer/subgraph_traverser.py
+++ b/tree_sitter_analyzer/subgraph_traverser.py
@@ -1,0 +1,65 @@
+"""BFS traversal of import dependency graph for --trace-from.
+
+Forward traversal: entry -> files it imports (directly or transitively).
+Accepts a pre-built DependencyMatrix to avoid double-indexing.
+"""
+from __future__ import annotations
+
+import sys
+from collections import deque
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tree_sitter_analyzer.dependency_matrix import DependencyMatrix
+
+MAX_DEPTH_CAP = 5
+
+
+def bfs_reachable(
+    entry: str,
+    import_edges: dict[str, dict[str, int]],
+    max_depth: int,
+) -> dict[str, int]:
+    """Return {file: hop_distance} for all files reachable from entry (forward).
+
+    entry itself is included with hops=0.
+    max_depth is the maximum number of hops (inclusive).
+    """
+    visited: dict[str, int] = {entry: 0}
+    queue: deque[tuple[str, int]] = deque([(entry, 0)])
+    while queue:
+        node, depth = queue.popleft()
+        if depth >= max_depth:
+            continue
+        for target in import_edges.get(node, {}):
+            if target not in visited:
+                visited[target] = depth + 1
+                queue.append((target, depth + 1))
+    return visited
+
+
+def get_subgraph(
+    dm: "DependencyMatrix",
+    entry_path: str,
+    depth: int,
+) -> dict[str, int] | None:
+    """Return reachable {file: hops} dict or None if entry_path is not in index.
+
+    Caps depth at MAX_DEPTH_CAP, emitting a stderr warning if exceeded.
+    """
+    if depth > MAX_DEPTH_CAP:
+        print(
+            f"WARNING: --depth {depth} exceeds maximum ({MAX_DEPTH_CAP}); "
+            f"capping at {MAX_DEPTH_CAP}",
+            file=sys.stderr,
+        )
+        depth = MAX_DEPTH_CAP
+
+    all_known: set[str] = set(dm._import_edges.keys())
+    for src in dm._import_edges:
+        all_known.update(dm._import_edges[src].keys())
+
+    if entry_path not in all_known:
+        return None  # caller converts to entry_point_not_found error
+
+    return bfs_reachable(entry_path, dm._import_edges, depth)

--- a/tree_sitter_analyzer/subgraph_traverser.py
+++ b/tree_sitter_analyzer/subgraph_traverser.py
@@ -39,7 +39,7 @@ def bfs_reachable(
 
 
 def get_subgraph(
-    dm: "DependencyMatrix",
+    dm: DependencyMatrix,
     entry_path: str,
     depth: int,
 ) -> dict[str, int] | None:


### PR DESCRIPTION
## Summary

- Adds `tsa --hotspot` CLI flag that ranks project files by `hotspot_score = Ca x MaxCC` (afferent coupling x max cyclomatic complexity)
- Severity tiers: **CRITICAL** (>=400), **REVIEW** (100-399), **OK** (<100) with test-focus suggestions per file
- Alias-aware Ca via `__init__.py` / `index.ts` re-export detection (`build_alias_ca_map`) — now correctly resolves re-exported modules relative to their package directory
- BFS subgraph traversal via `--trace-from <entry>` + `--depth N` to scope ranking to a module's transitive import cone; isolated files (no imports/importers) accepted at hop 0
- Pagination support (`--page`, `--page-size`), `--hotspot-top-n`, `--hotspot-show-alias-diff`
- Regex-based Ca fallback when AST cache is not built; deterministic sort tie-breaker (score DESC, file ASC)
- Canonical CLI envelope (`summary_line`, `verdict`, `agent_summary`) added to `HotspotResult`

## Key files

| File | Role |
|---|---|
| `hotspot_analyzer.py` | Ca helpers, heatmap builder, scorer, alias Ca (path-fixed), BFS |
| `output_schema.py` | Typed JSON response schema (HotspotResult with envelope fields, fixed truncated) |
| `subgraph_traverser.py` | BFS forward traversal for --trace-from |
| `cli/capability_commands.py` | _handle_hotspot() -- arg validation, isolated-file fallback, envelope population |
| `cli/argument_groups/_analysis.py` | CLI flag definitions |
| `tests/unit/test_hotspot_analyzer.py` | 32 unit tests (exact alias Ca assertions) |
| `docs/CODEMAPS/cli.md`, `README*.md`, `pyproject.toml` | Updated flag counts (331->338) and mypy override |

## Test plan

- [x] 32 unit tests pass (pytest tests/unit/test_hotspot_analyzer.py)
- [x] Ruff clean, MyPy clean
- [x] Codemap Sync Gate pass (flag count 338)
- [x] Weak Assertion Ratchet pass (test_hops_in_result strengthened)
- [x] README counts updated (en/ja/zh 331->338)
- [x] Alias Ca re-export path fix verified (test asserts exact +1 increment)
- [x] Isolated file fallback for --trace-from
- [x] Deterministic sort tie-breaker
- [x] truncated reflects page < total_pages
- [x] Canonical CLI envelope fields