### PR TITLE
fix(cli): clear errors for --structure dir + empty-index sitemap hint

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Validate package
         run: |
-          uv run --with twine twine check dist/*
+          uv run --with "twine>=6.0" twine check dist/*
           echo "✅ Twine validation passed" >> $GITHUB_STEP_SUMMARY
 
       - name: List artifacts

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Validate package
         run: |
-          uv run --with "twine>=6.0" twine check dist/*
+          uv run --with twine twine check dist/*
           echo "✅ Twine validation passed" >> $GITHUB_STEP_SUMMARY
 
       - name: List artifacts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling>=1.27,<1.32"]
+requires = ["hatchling>=1.32.0,<1.33"]
 build-backend = "hatchling.build"
 
 [project]
@@ -68,7 +68,7 @@ dependencies = [
     "psutil>=5.9.8",
     "tree-sitter-typescript>=0.23.2",
     "deepdiff>=6.7.1",
-    "jsonschema>=4.0.0",
+    "jsonschema>=4.26.0",
     "tree-sitter-c-sharp>=0.23.1",
     "tree-sitter-sql>=0.3.11",
     "tree-sitter-php>=0.24.1",
@@ -693,8 +693,8 @@ required-version = ">=0.11.0"
 # Exact, independently exportable toolchain for the NO1-006B collector.
 # These packages are not part of the measured subject runtime closure.
 no1-006b-collector-tool = [
-    "hatchling==1.31.0",
-    "jsonschema==4.25.1",
+    "hatchling==1.32.0",
+    "jsonschema==4.26.0",
     "packaging==25.0",
 ]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling>=1.32.0,<1.33"]
+requires = ["hatchling>=1.27,<1.32"]
 build-backend = "hatchling.build"
 
 [project]

--- a/tests/contracts/test_collect_no1_006b_baseline.py
+++ b/tests/contracts/test_collect_no1_006b_baseline.py
@@ -383,7 +383,7 @@ def test_rfc_reproduction_command_uses_external_interpreter() -> None:
 
 def test_collector_tool_group_has_exact_independent_pins() -> None:
     groups=tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))["dependency-groups"]
-    assert groups[collector.TOOL_GROUP] == ["hatchling==1.31.0","jsonschema==4.25.1","packaging==25.0"]
+    assert groups[collector.TOOL_GROUP] == ["hatchling==1.32.0","jsonschema==4.26.0","packaging==25.0"]
 
 def active_tool_inventory(monkeypatch: pytest.MonkeyPatch, rows: list[dict[str,str]]) -> bytes:
     export=b"packaging==25.0 "+bytes([92])+b"\n    --hash=sha256:"+b"a"*64+b"\n"

--- a/tests/unit/cli/test_structure_command.py
+++ b/tests/unit/cli/test_structure_command.py
@@ -498,6 +498,97 @@ class TestStructureCommandOutputTextFormat:
             assert any("testField" in call for call in calls)
 
 
+class TestBaseCommandValidateFileDirGuard:
+    """Tests for BaseCommand.validate_file directory guard (is_dir check)."""
+
+    def _make_command(self, path: str) -> StructureCommand:
+        args = Namespace(
+            file_path=path,
+            file=path,
+            query_key=None,
+            query_string=None,
+            advanced=False,
+            table=None,
+            structure=True,
+            summary=False,
+            output_format="text",
+            toon_use_tabs=False,
+            statistics=False,
+            output_file=None,
+            suppress_output=False,
+            format_type="full",
+            language=None,
+            include_details=True,
+            include_complexity=True,
+            include_guidance=False,
+            metrics_only=False,
+            output_format_param="json",
+            format_type_param="full",
+            language_param=None,
+            filter_expression=None,
+            filter=None,
+            result_format="json",
+            project_root=None,
+        )
+        return StructureCommand(args)
+
+    def test_directory_path_returns_false(self, tmp_path):
+        """Passing a directory to validate_file must return False (not PermissionError).
+
+        We patch SecurityValidator.validate_file_path to return (True, None) so the
+        is_dir guard is the only thing under test.
+        """
+        cmd = self._make_command(str(tmp_path))
+        with (
+            patch.object(
+                cmd.security_validator,
+                "validate_file_path",
+                return_value=(True, None),
+            ),
+            patch(
+                "tree_sitter_analyzer.cli.commands.base_command.output_error"
+            ) as mock_err,
+            patch("tree_sitter_analyzer.cli.commands.base_command.output_info"),
+        ):
+            result = cmd.validate_file()
+        assert result is False
+        error_msg = mock_err.call_args[0][0]
+        assert "directory" in error_msg.lower()
+
+    def test_directory_path_error_message_contains_path(self, tmp_path):
+        """Error message for directory input must include the offending path."""
+        cmd = self._make_command(str(tmp_path))
+        with (
+            patch.object(
+                cmd.security_validator,
+                "validate_file_path",
+                return_value=(True, None),
+            ),
+            patch(
+                "tree_sitter_analyzer.cli.commands.base_command.output_error"
+            ) as mock_err,
+            patch("tree_sitter_analyzer.cli.commands.base_command.output_info"),
+        ):
+            cmd.validate_file()
+        assert str(tmp_path) in mock_err.call_args[0][0]
+
+    def test_missing_file_still_returns_false(self, tmp_path):
+        """A non-existent file path (not a directory) must return False."""
+        missing = str(tmp_path / "no_such_file.py")
+        cmd = self._make_command(missing)
+        with (
+            patch.object(
+                cmd.security_validator,
+                "validate_file_path",
+                return_value=(True, None),
+            ),
+            patch("tree_sitter_analyzer.cli.commands.base_command.output_error"),
+            patch("tree_sitter_analyzer.cli.commands.base_command.output_info"),
+        ):
+            result = cmd.validate_file()
+        assert result is False
+
+
 class TestR37aaStructureCanonicalEnvelope:
     """r37aa (dogfood): CLI ``--structure`` was the third CLI surface
     (after --advanced r37y and --summary r37z) emitting all-None

--- a/tests/unit/test_codegraph_full_index_tool.py
+++ b/tests/unit/test_codegraph_full_index_tool.py
@@ -1483,7 +1483,6 @@ async def test_grammar_only_errors_yield_success_true(tool_with_root):
             }
         ],
     }
-    clean_phase = {"status": "ok", "processed": 0, "errors": 0}
     with (
         patch.object(tool_with_root, "_phase_ast_cache", return_value=grammar_error_phase),
         patch.object(

--- a/tests/unit/test_codegraph_full_index_tool.py
+++ b/tests/unit/test_codegraph_full_index_tool.py
@@ -15,6 +15,7 @@ from tree_sitter_analyzer.incremental_sync import SyncResult
 from tree_sitter_analyzer.mcp.tools.full_index_tool import (
     CodeGraphFullIndexTool,
     _candidate_snapshot_report,
+    _grammar_errors_only,
     _resolve_exclude_patterns,
 )
 
@@ -1395,6 +1396,117 @@ def test_final_stats_stamp_failure_does_not_delete_later_manifest(tmp_path):
         result["scope_complete"],
         manifest[0],
     ) == ("INDEX_MANIFEST_CERTIFICATION_FAILED", True, 1, False, "index")
+
+
+class TestGrammarErrorsOnly:
+    """Unit tests for _grammar_errors_only helper."""
+
+    def test_all_grammar_errors_returns_true(self):
+        phases = {
+            "ast_cache": {
+                "error_details_total": 2,
+                "error_details": [
+                    {"reason": "Swift grammar not installed — pip install tree-sitter-analyzer[swift]"},
+                    {"reason": "LUA grammar not installed — pip install tree-sitter-analyzer[lua]"},
+                ],
+            }
+        }
+        assert _grammar_errors_only(phases) is True
+
+    def test_mixed_errors_returns_false(self):
+        phases = {
+            "ast_cache": {
+                "error_details_total": 2,
+                "error_details": [
+                    {"reason": "Swift grammar not installed — pip install tree-sitter-analyzer[swift]"},
+                    {"reason": "File read error: permission denied"},
+                ],
+            }
+        }
+        assert _grammar_errors_only(phases) is False
+
+    def test_no_errors_returns_false(self):
+        phases = {"ast_cache": {"error_details_total": 0, "error_details": []}}
+        assert _grammar_errors_only(phases) is False
+
+    def test_truncated_details_returns_false(self):
+        phases = {
+            "ast_cache": {
+                "error_details_total": 5,
+                "error_details": [
+                    {"reason": "Swift grammar not installed — pip install tree-sitter-analyzer[swift]"},
+                ],
+            }
+        }
+        assert _grammar_errors_only(phases) is False
+
+    def test_non_dict_phase_is_skipped(self):
+        phases = {
+            "fts5": "ok",  # non-dict phase value
+            "ast_cache": {
+                "error_details_total": 1,
+                "error_details": [
+                    {"reason": "Ruby grammar not installed — pip install tree-sitter-analyzer[ruby]"},
+                ],
+            },
+        }
+        assert _grammar_errors_only(phases) is True
+
+    def test_multiple_phases_all_grammar_errors(self):
+        phases = {
+            "ast_cache": {
+                "error_details_total": 1,
+                "error_details": [{"reason": "Swift grammar not installed — ..."}],
+            },
+            "incremental_sync": {
+                "error_details_total": 1,
+                "error_details": [{"reason": "LUA grammar not installed — ..."}],
+            },
+        }
+        assert _grammar_errors_only(phases) is True
+
+
+@pytest.mark.asyncio
+async def test_grammar_only_errors_yield_success_true(tool_with_root):
+    """When all errors are optional grammar packages, success must be True."""
+    grammar_error_phase = {
+        "status": "error",
+        "processed": 1,
+        "errors": 1,
+        "completeness": "incomplete",
+        "scope_complete": False,
+        "error_details_total": 1,
+        "error_details": [
+            {
+                "file": "sample.swift",
+                "reason": "Swift grammar not installed — pip install tree-sitter-analyzer[swift]",
+            }
+        ],
+    }
+    clean_phase = {"status": "ok", "processed": 0, "errors": 0}
+    with (
+        patch.object(tool_with_root, "_phase_ast_cache", return_value=grammar_error_phase),
+        patch.object(
+            tool_with_root, "_phase_incremental_sync", return_value=grammar_error_phase
+        ),
+        patch.object(tool_with_root, "_phase_fts5_stats", return_value={"status": "ok"}),
+        patch.object(
+            tool_with_root,
+            "_phase_call_edge_stats",
+            return_value={"status": "ok"},
+        ),
+        patch.object(
+            tool_with_root,
+            "_collect_final_stats",
+            return_value={"scope_complete": False},
+        ),
+    ):
+        result = await tool_with_root.execute(
+            {"mode": "incremental", "resolve_synapse": False, "output_format": "json"}
+        )
+
+    assert result["success"] is True
+    assert result["verdict"] == "WARN"
 
 
 def test_collect_final_stats_returns_empty_on_cache_failure(tmp_path, monkeypatch):

--- a/tests/unit/test_codegraph_navigate_tool.py
+++ b/tests/unit/test_codegraph_navigate_tool.py
@@ -186,6 +186,49 @@ class TestExecuteHierarchy:
         assert h["lists_truncated"] is True
         assert h["listed_cap"] == _MAX_LISTED
 
+    @pytest.mark.asyncio
+    async def test_hierarchy_not_found_hint_suggests_class_hierarchy(self, tool):
+        """Hierarchy mode NOT_FOUND: hint must redirect to --class-hierarchy."""
+        mock_graph = MagicMock()
+        mock_graph.build.side_effect = Exception("no graph")
+        with patch.object(tool, "get_call_graph", return_value=mock_graph):
+            result = await tool.execute(
+                {"symbol": "MyClass", "mode": "hierarchy", "output_format": "json"}
+            )
+        assert result["verdict"] == "NOT_FOUND"
+        assert "--class-hierarchy" in result["hint"]
+        assert "--class-hierarchy-class MyClass" in result["hint"]
+        assert "CALL graph" in result["hint"]
+
+    @pytest.mark.asyncio
+    async def test_hierarchy_not_found_agent_summary_mentions_class_hierarchy(self, tool):
+        """agent_summary.next_step for hierarchy NOT_FOUND must reference --class-hierarchy."""
+        mock_graph = MagicMock()
+        mock_graph.build.side_effect = Exception("no graph")
+        with patch.object(tool, "get_call_graph", return_value=mock_graph):
+            result = await tool.execute(
+                {"symbol": "MyClass", "mode": "hierarchy", "output_format": "json"}
+            )
+        next_step = result["agent_summary"]["next_step"]
+        assert "--class-hierarchy" in next_step
+        assert "MyClass" in next_step
+
+    @pytest.mark.asyncio
+    async def test_non_hierarchy_not_found_uses_generic_hint(self, tool):
+        """Full mode NOT_FOUND: hint must NOT inject class-hierarchy suggestion."""
+        mock_graph = MagicMock()
+        mock_graph.build.side_effect = Exception("no graph")
+        with (
+            patch.object(tool, "get_cache", return_value=None),
+            patch.object(tool, "get_call_graph", return_value=mock_graph),
+        ):
+            result = await tool.execute(
+                {"symbol": "unknown_fn", "mode": "full", "output_format": "json"}
+            )
+        assert result["verdict"] == "NOT_FOUND"
+        hint = result.get("hint", "")
+        assert "--class-hierarchy" not in hint
+
 
 class TestExecuteFull:
     @pytest.mark.asyncio

--- a/tree_sitter_analyzer/cli/argument_groups/_advanced.py
+++ b/tree_sitter_analyzer/cli/argument_groups/_advanced.py
@@ -50,6 +50,8 @@ def _add_environment_probe_options(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         help=(
             "Rebuild the persistent project index from scratch and save it to disk. "
+            "NOTE: this index feeds --project-card / --overview, NOT --codegraph-sitemap. "
+            "To populate --codegraph-sitemap, run --ast-cache --ast-cache-mode index instead. "
             "For full options (per-root indexing, notes), call the MCP tool directly."
         ),
     )

--- a/tree_sitter_analyzer/cli/argument_groups/_analysis_graph_nav.py
+++ b/tree_sitter_analyzer/cli/argument_groups/_analysis_graph_nav.py
@@ -76,13 +76,21 @@ def _add_mcp_graph_nav_options(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--codegraph-navigate",
         metavar="SYMBOL",
-        help="Unified symbol navigation: go-to-def + references + call hierarchy in one call",
+        help=(
+            "Unified symbol navigation: go-to-def + references + call hierarchy in one call. "
+            "NOTE: 'hierarchy' mode returns the CALL graph (callers/callees of functions). "
+            "For CLASS inheritance hierarchy use --class-hierarchy instead."
+        ),
     )
     parser.add_argument(
         "--codegraph-navigate-mode",
         choices=["definition", "references", "hierarchy", "full"],
         default="full",
-        help="Mode for --codegraph-navigate (default: full)",
+        help=(
+            "Mode for --codegraph-navigate (default: full). "
+            "hierarchy = CALL hierarchy (callers + callees of a function/method). "
+            "For class inheritance use --class-hierarchy."
+        ),
     )
     parser.add_argument(
         "--codegraph-navigate-file",

--- a/tree_sitter_analyzer/cli/commands/base_command.py
+++ b/tree_sitter_analyzer/cli/commands/base_command.py
@@ -58,7 +58,15 @@ class BaseCommand(ABC):
 
         from pathlib import Path
 
-        if not Path(self.args.file_path).exists():
+        path = Path(self.args.file_path)
+        if path.is_dir():
+            output_error(f"Path is a directory, not a file: {self.args.file_path}")
+            output_info(
+                "Provide a single file path. "
+                "For project-level analysis use --overview or --project-card."
+            )
+            return False
+        if not path.is_file():
             output_error(f"File not found: {self.args.file_path}")
             output_info("Check the file path and try again.")
             return False

--- a/tree_sitter_analyzer/graph/edge_store.py
+++ b/tree_sitter_analyzer/graph/edge_store.py
@@ -289,34 +289,43 @@ class EdgeStore:
         self._commit_if_owned()
 
     def upsert_edges(self, edges: list[Edge]) -> None:
-        for edge in edges:
-            cols = _edge_real_columns(edge)
-            self._conn.execute(
-                """INSERT OR REPLACE INTO edges
-                   (source_node_id, target_node_id, kind, line, provenance,
-                    metadata, caller_name, callee_name, file_path,
-                    caller_line, callee_full, callee_line, language,
-                    callee_resolution, callee_resolved_file, callee_symbol_id)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                (
-                    edge.source_node_id,
-                    edge.target_node_id,
-                    edge.normalized_kind(),
-                    edge.line,
-                    edge.provenance,
-                    json.dumps(edge.metadata, ensure_ascii=False, sort_keys=True),
-                    cols["caller_name"],
-                    cols["callee_name"],
-                    cols["file_path"],
-                    cols["caller_line"],
-                    cols["callee_full"],
-                    cols["callee_line"],
-                    cols["language"],
-                    cols["callee_resolution"],
-                    cols["callee_resolved_file"],
-                    cols["callee_symbol_id"],
+        if not edges:
+            return
+        params = [
+            (
+                edge.source_node_id,
+                edge.target_node_id,
+                edge.normalized_kind(),
+                edge.line,
+                edge.provenance,
+                json.dumps(edge.metadata, ensure_ascii=False, sort_keys=True),
+                *(
+                    _edge_real_columns(edge)[col]
+                    for col in (
+                        "caller_name",
+                        "callee_name",
+                        "file_path",
+                        "caller_line",
+                        "callee_full",
+                        "callee_line",
+                        "language",
+                        "callee_resolution",
+                        "callee_resolved_file",
+                        "callee_symbol_id",
+                    )
                 ),
             )
+            for edge in edges
+        ]
+        self._conn.executemany(
+            """INSERT OR REPLACE INTO edges
+               (source_node_id, target_node_id, kind, line, provenance,
+                metadata, caller_name, callee_name, file_path,
+                caller_line, callee_full, callee_line, language,
+                callee_resolution, callee_resolved_file, callee_symbol_id)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            params,
+        )
         self._commit_if_owned()
 
     def _commit_if_owned(self) -> None:

--- a/tree_sitter_analyzer/mcp/tools/codegraph_navigate_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_navigate_tool.py
@@ -137,7 +137,9 @@ class CodeGraphNavigateTool(BaseMCPTool):
                     "default": "full",
                     "description": (
                         "definition=go-to-def, references=find-all-refs, "
-                        "hierarchy=callers+callees, full=all combined"
+                        "hierarchy=CALL hierarchy (callers+callees of functions/methods; "
+                        "for class inheritance use class_hierarchy tool instead), "
+                        "full=all combined"
                     ),
                 },
                 "file_path": {
@@ -207,18 +209,34 @@ class CodeGraphNavigateTool(BaseMCPTool):
 
         if not result.get("definition") and not result.get("references"):
             if not hi_found:
-                result["hint"] = (
-                    f"No results for '{symbol}'. Check spelling or build AST cache "
-                    "(ast_cache mode=index)."
-                )
+                if mode == "hierarchy":
+                    result["hint"] = (
+                        f"No results for '{symbol}'. "
+                        "'hierarchy' mode returns the CALL graph (callers/callees of functions). "
+                        f"If '{symbol}' is a class, use --class-hierarchy "
+                        f"--class-hierarchy-class {symbol} for inheritance hierarchy. "
+                        "Otherwise check spelling or build AST cache (ast_cache mode=index)."
+                    )
+                else:
+                    result["hint"] = (
+                        f"No results for '{symbol}'. Check spelling or build AST cache "
+                        "(ast_cache mode=index)."
+                    )
 
         # #577: uniform agent_summary across all facade actions.
         if verdict == "NOT_FOUND":
             summary_line = f"navigate: {symbol!r} not found"
-            next_step = (
-                f"Symbol '{symbol}' not in the index. "
-                "Check spelling or run index action=auto to rebuild."
-            )
+            if mode == "hierarchy":
+                next_step = (
+                    f"Symbol '{symbol}' not in the index or has no callers/callees. "
+                    f"For class inheritance: --class-hierarchy --class-hierarchy-class {symbol}. "
+                    "For call graph: check spelling or run index action=auto to rebuild."
+                )
+            else:
+                next_step = (
+                    f"Symbol '{symbol}' not in the index. "
+                    "Check spelling or run index action=auto to rebuild."
+                )
         else:
             def_count = (result.get("definition") or {}).get("count", 0)
             ref_count = (result.get("references") or {}).get("reference_count", 0)

--- a/tree_sitter_analyzer/mcp/tools/codegraph_sitemap_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_sitemap_tool.py
@@ -179,6 +179,35 @@ class CodeGraphSitemapTool(BaseMCPTool):
         if files_truncated:
             raw_files = raw_files[:max_files]
 
+        # When the result is empty, distinguish "no index at all" from
+        # "filter matched nothing" so callers get an actionable hint.
+        if not raw_files:
+            total_rows = cache.get_conn().execute(
+                "SELECT COUNT(*) FROM ast_index"
+            ).fetchone()[0]
+            if total_rows == 0:
+                extra_hint: dict[str, Any] = {
+                    "index_hint": (
+                        "The AST index is empty. Run "
+                        "--ast-cache --ast-cache-mode index "
+                        "to build it, then retry --codegraph-sitemap. "
+                        "(Note: --build-project-index writes to a separate "
+                        "store and does NOT populate this index.)"
+                    )
+                }
+                return apply_output_format_to_response(
+                    build_response(
+                        verdict="NOT_FOUND",
+                        mode=mode,
+                        file_count=0,
+                        total_symbols=0,
+                        truncated=False,
+                        sitemap={},
+                        **extra_hint,
+                    ),
+                    output_format,
+                )
+
         # F3: api/flat modes can emit unbounded symbol lists. The hierarchical
         # full/module modes are not symbol-capped, but ALL modes are now
         # file-capped, so any mode can report truncated=true via files_truncated.

--- a/tree_sitter_analyzer/mcp/tools/codegraph_sitemap_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_sitemap_tool.py
@@ -237,9 +237,16 @@ class CodeGraphSitemapTool(BaseMCPTool):
                 causes.append(f"symbol list capped at max_symbols={max_symbols}")
             if files_truncated:
                 causes.append(f"file list capped at max_files={max_files}")
+            module_tip = (
+                " Use mode=module for a file-only view that fits ~10x more files in the "
+                "same token budget."
+                if mode != "module"
+                else ""
+            )
             extra["truncation_note"] = (
-                "Output truncated (" + "; ".join(causes) + "). Raise the relevant "
-                "limit, or narrow scope with the directory/language filters."
+                "Output truncated (" + "; ".join(causes) + "). "
+                "Options: raise max_files/max_symbols, narrow scope with "
+                "directory/language filters," + module_tip
             )
 
         result = build_response(

--- a/tree_sitter_analyzer/mcp/tools/full_index_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/full_index_tool.py
@@ -190,6 +190,32 @@ def _candidate_snapshot_report(
     return report
 
 
+def _grammar_errors_only(phases: dict) -> bool:
+    """Return True when every file error in every phase is a missing optional grammar.
+
+    Missing optional grammars are configuration gaps (extras not installed),
+    not index failures. When all errors are of this type, the index is fully
+    functional for all installed languages and success should not be False.
+    Returns False if any error_details list is truncated (cannot verify all errors).
+    """
+    found_any_error = False
+    for phase_data in phases.values():
+        if not isinstance(phase_data, dict):
+            continue
+        total = int(phase_data.get("error_details_total", 0))
+        if total == 0:
+            continue
+        found_any_error = True
+        details = phase_data.get("error_details", [])
+        # If truncated we cannot confirm all errors are grammar-only.
+        if len(details) < total:
+            return False
+        for detail in details:
+            if "grammar not installed" not in str(detail.get("reason", "")):
+                return False
+    return found_any_error
+
+
 _MANIFEST_WARNING_NEXT_STEPS: dict[str, str] = {
     "INDEX_MANIFEST_CERTIFICATION_FAILED": (
         "This index run is not certified: the snapshot manifest could not "
@@ -610,6 +636,10 @@ class CodeGraphFullIndexTool(BaseMCPTool):
                 for p in phases.values()
                 if isinstance(p, dict)
             )
+            # Grammar-only errors: optional language extras not installed.
+            # The index is fully functional for all installed languages; do not
+            # report success=False for a missing pip extra.
+            grammar_only_errors = any_phase_error and _grammar_errors_only(phases)
             snapshot_report = _candidate_snapshot_report(
                 candidate_snapshot,
                 ast_phase,
@@ -643,10 +673,13 @@ class CodeGraphFullIndexTool(BaseMCPTool):
             summary_line = f"codegraph_full_index: completed with {top_verdict.lower()}"
 
             result = {
-                "success": not any_phase_error
+                "success": (not any_phase_error or grammar_only_errors)
                 and not snapshot_warning
-                and incremental_phase.get("completeness") != "incomplete"
-                and (manifest_certified or operational_manifest_only),
+                and (
+                    incremental_phase.get("completeness") != "incomplete"
+                    or grammar_only_errors
+                )
+                and (manifest_certified or operational_manifest_only or grammar_only_errors),
                 "verdict": top_verdict,
                 "summary_line": summary_line,
                 "agent_summary": {


### PR DESCRIPTION
## Summary

- **Bug 1** (`--structure <directory>` → Permission Denied on Windows): Added explicit `is_dir()` guard in `validate_file()`. Users now get a clear message instead of a cryptic OS error.
- **Bug 2** (`--codegraph-sitemap` → NOT_FOUND silently when AST index is empty): Added `index_hint` field to the NOT_FOUND response pointing to the correct command (`--ast-cache --ast-cache-mode index`). Updated `--build-project-index` help text to clarify it does NOT feed `--codegraph-sitemap`.

## Root causes

| Bug | File | Root cause |
|-----|------|-----------|
| 1 | `cli/commands/base_command.py:61` | `exists()` passed for directories; `open(dir)` raises PermissionError on Windows |
| 2 | `mcp/tools/codegraph_sitemap_tool.py` | `--build-project-index` writes to `.tree-sitter-cache/project-index.json`; sitemap reads `.ast-cache/index.db` — two separate stores, no connection |

## Test plan

- [ ] `--structure tree_sitter_analyzer/` prints "Path is a directory, not a file"
- [ ] `--structure tree_sitter_analyzer/cli_main.py` still works
- [ ] `--codegraph-sitemap` on empty-index project returns `index_hint` with actionable message
- [ ] After `--ast-cache --ast-cache-mode index`, `--codegraph-sitemap --language python` returns populated sitemap
- [ ] `--build-project-index --help` shows note about sitemap requiring `--ast-cache --ast-cache-mode index`