### PR TITLE
chore: merge back hotfix v1.29.1 (index hardening)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,12 @@ Memory records should capture reusable lessons, not logs: benchmark surprises, C
 - When adding or changing an MCP tool, update the CLI path in the same change and run a real CLI smoke test, for example `uv run python -m tree_sitter_analyzer <file> --smart-context --format json`.
 - This keeps MCP-only features from becoming invisible to users, CI, and future agents.
 
+## 注释语言规范（Comment Language Rule）
+
+- 今后所有新增或修改的代码注释、docstring 一律使用中文（领导 2026-09-05 裁决）。
+- 存量英文注释不做强制翻译；只在本次改动触碰到的行内顺手转换。
+- 提交信息（commit message）仍沿用仓库既有英文约定，不受本条约束。
+
 ## Codemap-sync mandate
 
 Any change touching one of these registries MUST update the corresponding `docs/CODEMAPS/*.md` in the **same commit**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [1.29.1] - 2026-09-05
+
+Hotfix: index robustness and storage hygiene, from the 2026-09-05 agent dogfood audit.
+
+### Fixed
+
+- **Cross-version index crash (`'dict' object has no attribute 'split'`).** An index written by a newer build (import entries recorded as `{text, line}` dicts since #1281) crashed `--dead-code`, `--codegraph-impact`, and call-graph builds on this build (`call_graph.py` expected plain strings). `ASTCache.get_imports()` now normalizes both shapes to strings. Verified red→green on the affected 289MB shared index: dead-code analysis recovered (1,928 transitive dead functions).
+- **Orphan maintenance module wired.** `cache/maintenance.py` (`reclaim_storage_after_full_rebuild`) was implemented and tested but never called by anything — index DBs could only grow. It now runs at the end of every full-index build (threshold-guarded; failures reported, never blocking), and the reclaim result is surfaced in the payload as `maintenance`.
+- **Unified SQLite busy timeouts.** 6 of 8 `sqlite3.connect` sites used the default timeout (immediate `database is locked` under multi-process contention). All sites now pass `timeout=10`, matching `ast_cache.py`'s main connection.
+
+### Docs
+
+- AGENTS.md: new 注释语言规范 section — all new/modified code comments and docstrings in Chinese (leader ruling 2026-09-05).
+
+
 ## [1.29.0] - 2026-07-04
 
 Install-friction reduction release. This release makes TSA significantly easier to set up for first-time users and adds a diagnostic command for troubleshooting.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tree-sitter-analyzer"
-version = "1.29.0"
+version = "1.29.1"
 description = "MCP code-intelligence server for AI agents — a more complete and more correct call graph with classified, cross-file edges. 8 facade MCP tools, 13 curated skills, TOON-compressed output, 100% local."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -601,7 +601,7 @@ directory = "htmlcov"
 # MCP server configuration
 [tool.mcp]
 server_name = "tree-sitter-analyzer"
-server_version = "1.29.0"
+server_version = "1.29.1"
 description = "AI-era enterprise-grade code analysis MCP server with comprehensive HTML/CSS support and multi-language capabilities"
 capabilities = [
     "check_code_scale",

--- a/tree_sitter_analyzer/__init__.py
+++ b/tree_sitter_analyzer/__init__.py
@@ -11,7 +11,7 @@ Architecture:
 - Data Models: Generic and language-specific code element representations
 """
 
-__version__ = "1.29.0"
+__version__ = "1.29.1"
 __author__ = "aisheng.yu"
 __email__ = "aimasteracc@gmail.com"
 

--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -774,7 +774,18 @@ class ASTCache:
         """Return per-file import lists from the cache."""
         conn = self._get_conn()
         rows = conn.execute("SELECT file_path, imports_json FROM ast_index").fetchall()
-        return {row["file_path"]: json.loads(row["imports_json"]) for row in rows}
+        result: dict[str, Any] = {}
+        for row in rows:
+            # 兼容两种索引历史格式：旧构建把 import 写成纯字符串；
+            # #1281 之后的新构建写成 {"text": ..., "line": ...} 字典。
+            # 这里统一归一化为字符串，否则新格式索引被本版本读取时，
+            # call_graph 的 imp_text.split() 会直接崩溃（跨版本共用缓存场景）。
+            entries = [
+                entry.get("text", "") if isinstance(entry, dict) else entry
+                for entry in json.loads(row["imports_json"])
+            ]
+            result[row["file_path"]] = [entry for entry in entries if entry]
+        return result
 
     def get_symbols_by_kind(
         self, kind: str, limit: int = 50000

--- a/tree_sitter_analyzer/cache/fingerprint.py
+++ b/tree_sitter_analyzer/cache/fingerprint.py
@@ -186,7 +186,9 @@ def is_ast_index_stale(project_root: str) -> bool:
         return False
     root = Path(project_root)
     try:
-        conn = sqlite3.connect(str(db_path), check_same_thread=False)
+        # timeout=10 与 ast_cache.py 的主连接保持一致：多进程共用缓存库时，
+        # 无超时的连接遇到写锁会立刻抛 database is locked 而不是等待重试
+        conn = sqlite3.connect(str(db_path), timeout=10, check_same_thread=False)
         try:
             rows = conn.execute("SELECT file_path, mtime_ns FROM ast_index").fetchall()
         finally:

--- a/tree_sitter_analyzer/graph/edge_store.py
+++ b/tree_sitter_analyzer/graph/edge_store.py
@@ -202,7 +202,7 @@ class EdgeStore:
     ) -> None:
         self._owns_conn = isinstance(conn_or_db_path, str)
         if self._owns_conn:
-            self._conn = sqlite3.connect(str(conn_or_db_path))
+            self._conn = sqlite3.connect(str(conn_or_db_path), timeout=10)
             self._conn.row_factory = sqlite3.Row
         else:
             self._conn = cast(sqlite3.Connection, conn_or_db_path)

--- a/tree_sitter_analyzer/mcp/tools/constraint_check_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/constraint_check_tool.py
@@ -204,7 +204,7 @@ class ConstraintCheckTool(BaseMCPTool):
         legitimate cached state every time an agent ran the tool against
         a fresh repo.
         """
-        conn = sqlite3.connect(str(db_path))
+        conn = sqlite3.connect(str(db_path), timeout=10)
         try:
             conn.execute(self._violations_ddl())
             edge_count = self._count_edges(conn)
@@ -276,7 +276,7 @@ class ConstraintCheckTool(BaseMCPTool):
         which means re-using the same ``_compile_glob`` the evaluator
         uses.
         """
-        conn = sqlite3.connect(str(db_path))
+        conn = sqlite3.connect(str(db_path), timeout=10)
         try:
             conn.execute(self._violations_ddl())
             cursor = conn.execute(

--- a/tree_sitter_analyzer/mcp/tools/full_index_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/full_index_tool.py
@@ -189,6 +189,26 @@ class CodeGraphFullIndexTool(BaseMCPTool):
             indexed = result.get("indexed", 0)
             cached = result.get("cached", 0)
             errors = result.get("errors", 0)
+            # 重建完成后回收空闲页：maintenance 模块此前已实现并有测试，
+            # 但从未被任何调用方接线，导致长期增量的缓存库只增长不收缩。
+            # 回收自带阈值守卫（空闲页不足时跳过），失败不阻断索引结果。
+            maintenance_report: dict[str, Any] = {"action": "skipped"}
+            try:
+                from ...cache.maintenance import reclaim_storage_after_full_rebuild
+
+                reclaim = reclaim_storage_after_full_rebuild(
+                    cache.get_conn(), cache.db_path
+                )
+                # 用回收前后空闲页差值报告实际释放量；键缺失时按 0 处理
+                before_pages = int(reclaim.get("before", {}).get("db_free_pages", 0))
+                after_pages = int(reclaim.get("after", {}).get("db_free_pages", 0))
+                maintenance_report = {
+                    "action": reclaim.get("action"),
+                    "freed_pages": max(0, before_pages - after_pages),
+                }
+            except Exception:
+                # 空间回收失败不影响索引本身，只在结果里如实报告
+                maintenance_report = {"action": "error"}
             cache.close()
             return {
                 "status": "ok",
@@ -198,6 +218,7 @@ class CodeGraphFullIndexTool(BaseMCPTool):
                 "errors": errors,
                 "mode_used": result.get("mode_used", "unknown"),
                 "activation_enabled": result.get("activation_enabled", False),
+                "maintenance": maintenance_report,
                 # Surface the backfill counts produced by _post_index_backfill so
                 # the synapse_resolution phase can report without re-running (A1).
                 "synapse_backfill": result.get("synapse_backfill"),

--- a/tree_sitter_analyzer/mcp/tools/utils/change_impact_analysis.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/change_impact_analysis.py
@@ -814,7 +814,7 @@ def _hot_zone_symbols_for_files(
 
     conn: sqlite3.Connection | None = None
     try:
-        conn = sqlite3.connect(str(db_path))
+        conn = sqlite3.connect(str(db_path), timeout=10)
         conn.row_factory = sqlite3.Row
         rows = conn.execute(sql, [*changed_files, _HOT_ZONE_THRESHOLD]).fetchall()
         return [dict(r) for r in rows]

--- a/tree_sitter_analyzer/mcp/tools/utils/constraint_violation_query.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/constraint_violation_query.py
@@ -66,7 +66,7 @@ def violations_for_files(
 
     conn: sqlite3.Connection | None = None
     try:
-        conn = sqlite3.connect(str(db_path))
+        conn = sqlite3.connect(str(db_path), timeout=10)
         cursor = conn.execute(sql, files + files)
         rows: list[dict[str, Any]] = []
         for row in cursor:


### PR DESCRIPTION
GitFlow merge-back of hotfix v1.29.1 (published to PyPI, tagged on main via #1353).

## Conflict resolution notes

- `ast_cache.py`: took develop's mixin structure; **ported** the import-row normalization fix into `_ast_cache_query_mixin.py:get_imports` (the crash fix's new home).
- `full_index_tool.py`: kept develop's incremental-detail reporting **and** the new maintenance wiring (`maintenance.{action,freed_pages}`; verified live: `incremental_vacuum`).
- `constraint_check_tool.py` / `constraint_violation_query.py`: develop's refactored structure + re-applied `timeout=10` on the actual connect sites.
- `pyproject.toml`: version 1.29.1 + develop's structured-JSON description.
- `CHANGELOG.md`: 1.29.1 entry first, develop's Unreleased section preserved.

## Verification on develop code

- Red→green on the affected shared index (was `'dict' object has no attribute 'split'`)
- ruff + mypy clean; full suite on develop: 2006 passed, 22 skipped