### PR TITLE
fix(index): respect shared-cache lifecycle in full-index maintenance wiring

### DIFF
--- a/tree_sitter_analyzer/mcp/tools/full_index_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/full_index_tool.py
@@ -816,7 +816,10 @@ class CodeGraphFullIndexTool(BaseMCPTool):
             except Exception:
                 # 空间回收失败不影响索引本身，只在结果里如实报告
                 maintenance_report = {"action": "error"}
-            cache.close()
+            # 注意：这里不能无条件 cache.close()——cache 可能是 execute()
+            # 通过 _cache= 注入的共享实例，后续阶段（增量同步、FTS 统计、
+            # 调用边统计）还要复用同一连接。生命周期统一由函数末尾的
+            # `if owns_cache: _safe_close_cache(cache)` 管理。
             return {
                 "status": (
                     "error"


### PR DESCRIPTION
Fixes the develop CI regression introduced by the v1.29.1 merge-back (#1354).

## Root cause

The maintenance wiring was ported from main with its unconditional `cache.close()`. Develop's phase protocol instead shares one `ASTCache` across phases via `_cache=` injection and closes only when `owns_cache`. Closing mid-phase killed the shared connection for later phases → 16 CI failures (`KeyError: 'incremental_sync'` / `'total_files'`, scope-oracle state mismatches) — invisible locally because bare `pytest` is now the curated quick gate (pytest.ini `testpaths`), not the full suite.

## Fix

Remove the unconditional close; lifecycle stays with `if owns_cache: _safe_close_cache(cache)`. Maintenance reclaim still runs on the live connection before close — verified live: `maintenance: {action: incremental_vacuum, freed_pages: 1}`.

## Verification

- 30/30 previously failing tests green (`test_index_status_response`, `test_index_source_scope`)
- Comprehensive suite per AGENTS.md: `uv run pytest tests/ -q --timeout=120 -m "not e2e and not network and not benchmark"` → **23020 passed, 104 skipped, 0 failed**
- ruff + mypy clean