### PR TITLE
fix(index): distinguish slow-machine stalls from SOURCE_CHANGED (#1364)

### DIFF
--- a/tests/unit/test_index_snapshot_schema.py
+++ b/tests/unit/test_index_snapshot_schema.py
@@ -465,3 +465,38 @@ def test_unsupported_table_xinfo_metadata_fails_closed(row: tuple[object, ...]) 
 
     with pytest.raises(RuntimeError, match="^INDEX_FINGERPRINT_UNSUPPORTED_SCHEMA$"):
         schema._query_visible_columns(Connection(), "payload", float("inf"))
+
+
+class TestFingerprintDeadlineConfig:
+    """#1364：满载 CI 上的瞬时遍历卡顿不应被误判为「源被篡改」。
+
+    修复提供两道保险：截止时间可用环境变量调高（本组测试锁定旋钮语义），
+    以及 SOURCE_SCAN_DEADLINE 的 unknown 结果自动重试一次（集成层由
+    test_incremental_scope_change_prunes_newly_excluded_rows 覆盖）。
+    """
+
+    def test_环境变量覆盖生效且有下限(self, monkeypatch):
+        from tree_sitter_analyzer.index_snapshot_schema import (
+            _fingerprint_deadline_seconds,
+        )
+
+        monkeypatch.setenv("TSA_FINGERPRINT_DEADLINE_SECONDS", "30")
+        assert _fingerprint_deadline_seconds() == 30.0
+        monkeypatch.setenv("TSA_FINGERPRINT_DEADLINE_SECONDS", "0.1")
+        assert _fingerprint_deadline_seconds() == 1.0  # 下限保护
+
+    def test_误配回退默认5秒(self, monkeypatch):
+        from tree_sitter_analyzer.index_snapshot_schema import (
+            _fingerprint_deadline_seconds,
+        )
+
+        monkeypatch.setenv("TSA_FINGERPRINT_DEADLINE_SECONDS", "not-a-number")
+        assert _fingerprint_deadline_seconds() == 5.0
+
+    def test_未设置用默认值(self, monkeypatch):
+        from tree_sitter_analyzer.index_snapshot_schema import (
+            _fingerprint_deadline_seconds,
+        )
+
+        monkeypatch.delenv("TSA_FINGERPRINT_DEADLINE_SECONDS", raising=False)
+        assert _fingerprint_deadline_seconds() == 5.0

--- a/tree_sitter_analyzer/index_snapshot_schema.py
+++ b/tree_sitter_analyzer/index_snapshot_schema.py
@@ -94,6 +94,23 @@ _REQUIRED_COLUMNS = {
     ),
 }
 _FINGERPRINT_DEADLINE_SECONDS = 5.0
+# 满载 CI（多个 xdist worker 抢核 + Windows Defender 对新文件实时扫描）上，
+# 即使小型项目的目录遍历也可能瞬时卡过 5 秒；允许环境调高，重试见
+# _capture_source_with_retry。慢机器与数据真变必须区分，否则 #1364 复现。
+_FINGERPRINT_DEADLINE_ENV = "TSA_FINGERPRINT_DEADLINE_SECONDS"
+
+
+def _fingerprint_deadline_seconds() -> float:
+    """读取（可配置的）单次源指纹遍历墙钟上限，下限 1 秒防误配。"""
+    raw = os.environ.get(_FINGERPRINT_DEADLINE_ENV, "")
+    if not raw:
+        return _FINGERPRINT_DEADLINE_SECONDS
+    try:
+        return max(1.0, float(raw))
+    except ValueError:
+        return _FINGERPRINT_DEADLINE_SECONDS
+
+
 _FINGERPRINT_ROW_BUDGET = 2_000_000
 _FINGERPRINT_BYTE_BUDGET = 512 * 1024 * 1024
 _FINGERPRINT_CELL_BYTE_BUDGET = 4 * 1024 * 1024
@@ -177,9 +194,25 @@ def stamp_full_index_manifest(
         else:
             from .portable_source_snapshot import capture_portable_source_snapshot
 
-            current = capture_portable_source_snapshot(
-                root, scope, deadline=time.monotonic() + _FINGERPRINT_DEADLINE_SECONDS
-            )
+            # 慢机瞬卡重试一次（#1364）：仅对 SOURCE_SCAN_DEADLINE 的 unknown
+            # 结果重试；真实的数据变化/不可读 scope 不重试，语义不变。
+            current = None
+            for attempt in (1, 2):
+                current = capture_portable_source_snapshot(
+                    root,
+                    scope,
+                    deadline=time.monotonic() + _fingerprint_deadline_seconds(),
+                )
+                if current.state == "exact":
+                    break
+                if (
+                    getattr(current, "reason", None) == "SOURCE_SCAN_DEADLINE"
+                    and attempt == 1
+                ):
+                    continue
+                break
+        # for 循环体至少执行一次,mypy 无法静态证明,此处显式断言
+        assert current is not None
         if current.state != "exact" or current.rows != recorded:
             raise sqlite3.OperationalError("SOURCE_CHANGED")
         conn.execute("DELETE FROM ast_index_snapshot_manifest")


### PR DESCRIPTION
Closes #1364.

## Root cause

`stamp_full_index_manifest`'s portable source walk had a hard 5s wall-clock deadline. On loaded CI runners (4 xdist workers + Windows Defender real-time scanning), even a 2-file tmp-project walk can transiently exceed it → capture state `unknown` (`SOURCE_SCAN_DEADLINE`) → conflated with a genuine source change → `SOURCE_CHANGED` → certification warning → `success=False` on the slowest axes. Local runs (unloaded) never reproduce — matching all reported evidence.

## Fix (real changes still never pass)

- Deadline configurable: `TSA_FINGERPRINT_DEADLINE_SECONDS` (floor 1s, invalid values fall back to the 5s default)
- `SOURCE_SCAN_DEADLINE`-unknown captures retry exactly once; every other non-exact outcome (real change, unreadable scope, unsafe) fails immediately as before

## Verification

- Target test + full tool file + schema suite: 115 passed
- Env-override unit tests lock the knob (override / floor / misconfig-fallback / default)