### PR TITLE
fix(index): retry transient UNSAFE certifier walks; prefix-match SOURCE_CHANGED (#1364)

### DIFF
--- a/tests/unit/test_index_snapshot_schema_validation.py
+++ b/tests/unit/test_index_snapshot_schema_validation.py
@@ -83,7 +83,10 @@ def test_stamp_rejects_new_source_and_preserves_old_manifest(tmp_path):
     stamp_full_index_manifest(cache.get_conn(), str(tmp_path))
     (tmp_path / "late.py").write_text("late = True\n")
 
-    with pytest.raises(sqlite3.OperationalError, match="^SOURCE_CHANGED$"):
+    # #1364 起错误消息携带诊断后缀(state/reason/行数),锚定前缀即可
+    with pytest.raises(
+        sqlite3.OperationalError, match=r"^SOURCE_CHANGED:state=[a-z]+:"
+    ):
         stamp_full_index_manifest(cache.get_conn(), str(tmp_path))
     count = (
         cache.get_conn()

--- a/tree_sitter_analyzer/index_snapshot_schema.py
+++ b/tree_sitter_analyzer/index_snapshot_schema.py
@@ -208,8 +208,11 @@ def stamp_full_index_manifest(
                 )
                 if current.state == "exact":
                     break
+                # 瞬态失败重试一次(#1364):满载 CI 上目录遍历的超时与双走
+                # 不一致(UNSAFE)都是机器负载抖动;真实源变化/不可读不重试
                 if (
-                    getattr(current, "reason", None) == "SOURCE_SCAN_DEADLINE"
+                    getattr(current, "reason", None)
+                    in ("SOURCE_SCAN_DEADLINE", "SOURCE_SCOPE_UNSAFE")
                     and attempt == 1
                 ):
                     continue


### PR DESCRIPTION
Two follow-ups from the diagnostic run:

1. The diag message (state/reason suffix) broke 7 axes' exact-match `^SOURCE_CHANGED$` — test now anchors to the prefix.
2. New evidence: `portable_inventory` intermittently returns UNSAFE (double-walk inconsistency) under CI load on one axis — same #1364 family as the deadline stalls. Retry-once now covers SOURCE_SCOPE_UNSAFE too (genuinely-unsafe scopes fail again on retry; semantics for real changes unchanged).

187 passed locally (schema/manifest/portable/full-index suites).