### PR TITLE
fix(index): capture-layer retry for transient UNSAFE walks (#1364)

### DIFF
--- a/tests/unit/test_portable_source_snapshot.py
+++ b/tests/unit/test_portable_source_snapshot.py
@@ -393,7 +393,8 @@ def test_capture_portable_source_snapshot_rejects_changed_inventory(
 ) -> None:
     first = frozenset({("first.py", "digest", "python")})
     second = frozenset({("second.py", "digest", "python")})
-    inventories = iter(((first, False), (second, False)))
+    # #1364 起捕获层对 UNSAFE 整体重试一次——供料需覆盖两轮四走
+    inventories = iter(((first, False), (second, False)) * 2)
     monkeypatch.setattr(
         portable, "_portable_inventory", lambda *_args: next(inventories)
     )
@@ -402,6 +403,7 @@ def test_capture_portable_source_snapshot_rejects_changed_inventory(
         str(tmp_path), make_source_scope_descriptor(), deadline=float("inf")
     )
 
+    # 两次尝试都双走不一致 → 仍如实返回 unsafe(重试不掩盖真实不稳定)
     assert (result.rows, result.state, result.reason) == (
         first,
         "unsafe",

--- a/tree_sitter_analyzer/portable_source_snapshot.py
+++ b/tree_sitter_analyzer/portable_source_snapshot.py
@@ -164,25 +164,36 @@ def capture_portable_source_snapshot(
 ) -> CurrentSourceSnapshot:
     """Capture two equal bounded inventories on Windows/pathname-only hosts."""
     root = os.path.abspath(project_root)
-    try:
-        first, unsafe_first = _portable_inventory(root, source_scope, deadline)
-        second, unsafe_second = _portable_inventory(root, source_scope, deadline)
-        fingerprint = inventory_fingerprint(first, deadline=deadline)
-    except TimeoutError:
-        return CurrentSourceSnapshot(
-            frozenset(), None, None, "unknown", "SOURCE_SCAN_DEADLINE"
-        )
-    except OverflowError:
-        return CurrentSourceSnapshot(
-            frozenset(), None, None, "unknown", "SOURCE_SCOPE_UNBOUNDED"
-        )
-    except OSError:
-        return CurrentSourceSnapshot(
-            frozenset(), None, None, "unknown", "SOURCE_SCOPE_UNREADABLE"
-        )
-    generation = "idxsrc-v3:" + fingerprint.removeprefix("sha256:")
-    if unsafe_first or unsafe_second or first != second:
-        return CurrentSourceSnapshot(
-            first, fingerprint, generation, "unsafe", "SOURCE_SCOPE_UNSAFE"
-        )
-    return CurrentSourceSnapshot(first, fingerprint, generation, "exact", None)
+    # #1364：满载 CI（多 worker 抢核 + Defender 实时扫描）上,双走不一致
+    # (UNSAFE)与超时一样是机器抖动而非数据真变——整体重试一次;真实
+    # 不稳定 scope 第二次仍会失败,语义不变。重试也顺带覆盖超时分支。
+    for attempt in (1, 2):
+        try:
+            first, unsafe_first = _portable_inventory(root, source_scope, deadline)
+            second, unsafe_second = _portable_inventory(root, source_scope, deadline)
+            fingerprint = inventory_fingerprint(first, deadline=deadline)
+        except TimeoutError:
+            if attempt == 1:
+                continue
+            return CurrentSourceSnapshot(
+                frozenset(), None, None, "unknown", "SOURCE_SCAN_DEADLINE"
+            )
+        except OverflowError:
+            return CurrentSourceSnapshot(
+                frozenset(), None, None, "unknown", "SOURCE_SCOPE_UNBOUNDED"
+            )
+        except OSError:
+            return CurrentSourceSnapshot(
+                frozenset(), None, None, "unknown", "SOURCE_SCOPE_UNREADABLE"
+            )
+        generation = "idxsrc-v3:" + fingerprint.removeprefix("sha256:")
+        if unsafe_first or unsafe_second or first != second:
+            if attempt == 1:
+                continue
+            return CurrentSourceSnapshot(
+                first, fingerprint, generation, "unsafe", "SOURCE_SCOPE_UNSAFE"
+            )
+        return CurrentSourceSnapshot(first, fingerprint, generation, "exact", None)
+    return CurrentSourceSnapshot(
+        frozenset(), None, None, "unknown", "SOURCE_SCAN_DEADLINE"
+    )


### PR DESCRIPTION
Diagnostic evidence from the last run: `SOURCE_CHANGED:state=unsafe:reason=SOURCE_SCOPE_UNSAFE` caught in a DIRECT certifier caller (constraint_check_portable_snapshot) — the walk instability is systemic under CI load, and the stamp-level retry from #1368 only covered one caller.

Fix moves the retry into `capture_portable_source_snapshot` itself: one extra attempt on UNSAFE or DEADLINE, for every caller (stamp, constraint certifier, direct captures). Real instability re-fails on the second attempt — semantics preserved (locked by the updated rejects-changed-inventory test, which now feeds both attempts).

201 passed (portable/snapshot/schema/validation/manifest/full-index/constraint suites).