### PR TITLE
docs(tests): finish quick-gate command unification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@
 ## Test Runtime Contract
 
 - The default local quick-gate command is `uv run pytest -q`.
+- Transition note: `main` inherits the curated quick-gate `pytest.ini` at the next release; until then bare `pytest -q` on `main` still runs the full suite. When validating on `main` before that sync, use the comprehensive command explicitly — one command must mean one thing, so the canonical full-suite path is always the explicit `tests/` form above.
 - The comprehensive local command is `uv run pytest tests/ -q --timeout=120 -m "not e2e and not network and not benchmark"`; the explicit marker override restores slow and full-language tests that the quick gate excludes.
 - Do not run either tier serially. Project pytest config enables four xdist workers with work stealing.
 - The quick gate must finish in under 5 minutes. The config enforces `--session-timeout=900` and `--timeout=30`. (Bumped from 300 in v1.13.1 — see `docs/POSTMORTEM_v1.13.md` § 9.)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@
 ## Test Runtime Contract
 
 - The default local quick-gate command is `uv run pytest -q`.
-- Transition note: `main` inherits the curated quick-gate `pytest.ini` at the next release; until then bare `pytest -q` on `main` still runs the full suite. When validating on `main` before that sync, use the comprehensive command explicitly — one command must mean one thing, so the canonical full-suite path is always the explicit `tests/` form above.
+- Transition note: `main` inherits the curated quick-gate `pytest.ini` at the next release; until then bare `uv run pytest -q` on `main` still runs the full suite. When validating on `main` before that sync, use the comprehensive command explicitly — one command must mean one thing, so the canonical full-suite path is always the explicit `tests/` form above.
 - The comprehensive local command is `uv run pytest tests/ -q --timeout=120 -m "not e2e and not network and not benchmark"`; the explicit marker override restores slow and full-language tests that the quick gate excludes.
 - Do not run either tier serially. Project pytest config enables four xdist workers with work stealing.
 - The quick gate must finish in under 5 minutes. The config enforces `--session-timeout=900` and `--timeout=30`. (Bumped from 300 in v1.13.1 — see `docs/POSTMORTEM_v1.13.md` § 9.)

--- a/README.md
+++ b/README.md
@@ -372,8 +372,8 @@ Mostly nothing. The defaults are designed so you can hook it into your agent and
 ```bash
 uv run pytest -q                                # bounded local quick gate
 uv run pytest tests/ -q --timeout=120 -m "not e2e and not network and not benchmark"  # comprehensive local suite
-PYTEST_XDIST_AUTO_NUM_WORKERS=1 uv run pytest -q --maxfail=1 -m "not slow and not full_language and not integration"  # one-worker mode for lower CPU load
-PYTEST_XDIST_AUTO_NUM_WORKERS=2 uv run pytest -q --maxfail=1 -m "not slow and not full_language and not integration"  # two-worker balanced mode
+PYTEST_XDIST_AUTO_NUM_WORKERS=1 uv run pytest -q --maxfail=1                  # quick gate, one worker (lower CPU load)
+PYTEST_XDIST_AUTO_NUM_WORKERS=2 uv run pytest -q --maxfail=1                  # quick gate, two workers (balanced)
 uv run pytest --lf --maxfail=1                  # rerun only failed tests from last run
 uv run python check_quality.py --new-code-only  # quality gate
 ```
@@ -398,7 +398,7 @@ uv run python check_quality.py --new-code-only  # quality gate
 git clone https://github.com/aimasteracc/tree-sitter-analyzer.git
 cd tree-sitter-analyzer
 uv sync --extra all --extra mcp
-uv run pytest -q
+uv run pytest -q                                # quick gate (bounded)
 ```
 
 See **[`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md)** for the development guide.

--- a/tests/contracts/test_pytest_runtime_contract.py
+++ b/tests/contracts/test_pytest_runtime_contract.py
@@ -50,7 +50,7 @@ DEFAULT_QUICK_TESTPATHS = (
     "tests/unit/security/test_validator.py",
 )
 COMPREHENSIVE_COMMAND = (
-    'uv run pytest tests/ -q --timeout=120 '
+    "uv run pytest tests/ -q --timeout=120 "
     '-m "not e2e and not network and not benchmark"'
 )
 SKIPPED_SCAN_DIRS = {
@@ -108,6 +108,39 @@ def test_comprehensive_command_overrides_quick_marker_exclusions() -> None:
     for relative_path in docs:
         text = (PROJECT_ROOT / relative_path).read_text(encoding="utf-8")
         assert COMPREHENSIVE_COMMAND in text, relative_path
+
+
+def test_no_third_marker_variant_in_docs() -> None:
+    """#1364 会话教训:同一动作只允许一套 canonical 命令。
+
+    历史上 README 的「低 CPU 模式」曾自带第三套 marker 过滤串
+    (not slow and not full_language and not integration),与快速门、
+    全量命令三足鼎立。契约钉死:任何文档不得再引入该串;低 CPU 模式
+    必须与 canonical 命令同构(仅改 worker 数)。
+    """
+    stale_variants = ("not slow and not full_language and not integration",)
+    docs = ("AGENTS.md", "README.md", "docs/TESTING.md", "docs/developer_guide.md")
+    for relative_path in docs:
+        path = PROJECT_ROOT / relative_path
+        if not path.exists():
+            continue
+        text = path.read_text(encoding="utf-8")
+        for stale in stale_variants:
+            assert stale not in text, f"{relative_path} reintroduces {stale!r}"
+
+
+def test_readme_labels_bare_quick_gate_and_agents_documents_transition() -> None:
+    """裸 `pytest -q` 在文档中必须标注为 quick gate;AGENTS.md 必须写明
+    main 分支在下一班 release 前的过渡语义(同命令双语义的唯一残留窗口)。
+    """
+    readme = (PROJECT_ROOT / "README.md").read_text(encoding="utf-8")
+    assert (
+        "uv run pytest -q                                # bounded local quick gate"
+        in readme
+    )
+    agents = (PROJECT_ROOT / "AGENTS.md").read_text(encoding="utf-8")
+    assert "Transition note" in agents
+    assert "one command must mean one thing" in agents
 
 
 def _assert_pytest_runtime_contract(
@@ -341,7 +374,9 @@ def test_managed_temp_directories_are_private(monkeypatch, tmp_path) -> None:
     from tests import pytest_temp_hygiene
 
     chmod_calls = []
-    monkeypatch.setattr(Path, "chmod", lambda self, mode: chmod_calls.append((self, mode)))
+    monkeypatch.setattr(
+        Path, "chmod", lambda self, mode: chmod_calls.append((self, mode))
+    )
     private_root = tmp_path / "private"
 
     pytest_temp_hygiene._ensure_private_directory(private_root)
@@ -432,6 +467,7 @@ def test_dead_pytest_process_temp_root_is_removed(tmp_path) -> None:
 def test_xdist_worker_keeps_controller_temp_root(monkeypatch, tmp_path) -> None:
     """Workers must inherit the controller root instead of replacing it."""
     from tests import pytest_temp_hygiene
+
     managed_parent = tmp_path / "managed-pytest-temp"
     controller_root = managed_parent / "run-12345678-deadbeef"
     monkeypatch.setenv("TSA_PYTEST_TEMP_ROOT", str(managed_parent))
@@ -449,9 +485,9 @@ def test_xdist_worker_keeps_controller_temp_root(monkeypatch, tmp_path) -> None:
 
 def test_cli_fixtures_do_not_create_collectable_python_inside_tests_tree() -> None:
     """Runtime CLI inputs must not become tests after an interrupted worker."""
-    source = (
-        PROJECT_ROOT / "tests/integration/cli/test_cli_async.py"
-    ).read_text(encoding="utf-8")
+    source = (PROJECT_ROOT / "tests/integration/cli/test_cli_async.py").read_text(
+        encoding="utf-8"
+    )
 
     assert 'Path("tests") / "temp_cli_test"' not in source
     assert 'Path("tests") / "temp_cli_test_large"' not in source
@@ -459,9 +495,9 @@ def test_cli_fixtures_do_not_create_collectable_python_inside_tests_tree() -> No
 
 def test_cli_subprocess_integration_suite_is_outside_default_gate() -> None:
     """The 19-process CLI suite belongs to the explicit slow lane."""
-    source = (
-        PROJECT_ROOT / "tests/integration/cli/test_cli_async.py"
-    ).read_text(encoding="utf-8")
+    source = (PROJECT_ROOT / "tests/integration/cli/test_cli_async.py").read_text(
+        encoding="utf-8"
+    )
 
     assert "pytestmark = pytest.mark.slow" in source
 


### PR DESCRIPTION
P0-2 from the architecture audit: one command, one meaning.

Residues closed:
- README low-CPU lines carried a THIRD marker variant; now compose with canonical commands (worker override only)
- README quickstart labels bare -q as the bounded quick gate
- AGENTS.md transition note: main runs the full suite on bare `uv run pytest -q` until the next release syncs the curated pytest.ini — the last window of dual semantics, documented instead of surprising
- New contracts: no third marker variant may return; README must label the quick gate; AGENTS.md must carry the transition note; the span uses the uv-run prefix (existing bare-pytest contract)

Quick gate 2,002 passed / 0 failed; contracts 610 passed.