### PR TITLE
fix(index): stale-snapshot recovery with ctime guard (#1364/#1373 form 5)

### DIFF
--- a/tests/unit/test_index_source_stream.py
+++ b/tests/unit/test_index_source_stream.py
@@ -443,3 +443,70 @@ def test_in_place_rewrite_with_restored_mtime_is_unsafe(tmp_path, monkeypatch):
         "<unsafe>",
         False,
     )
+
+
+class TestStaleSnapshotRecovery:
+    """#1364/#1373 家族:极新文件元数据沉降导致的「快照过期≠篡改」。
+
+    walker 的 lstat 快照(size/mtime_ns)与读后 fstat 之间,新写入文件的
+    元数据可能仍在沉降——旧实现直接判 unclean,满载 windows 轴反复
+    误报 SOURCE_SCOPE_UNSAFE。修复:终检不洁时重取一次 lstat,与读后
+    状态一致则判 clean;真篡改(读取中途被改)重取仍不一致,维持 unsafe。
+    """
+
+    def test_过期快照_重取一致后判clean(self, tmp_path):
+        from tree_sitter_analyzer.index_source_stream import hash_source_at
+        from tree_sitter_analyzer.portable_source_snapshot import _marker
+
+        target = tmp_path / "fresh.py"
+        target.write_text("value = 1\n", encoding="utf-8")
+        import os as _os
+
+        before = _os.lstat(target)
+        calls = []
+
+        def first_dirty_then_clean(a, b):
+            calls.append(1)
+            # 第一次(walker 旧快照 vs after)不洁;重取(refreshed vs after)一致
+            # (ctime 未变由真实文件保证——测试只写了一次)
+            return len(calls) > 1
+
+        _marker_fn, digest, clean = hash_source_at(
+            None,
+            str(target),
+            before,
+            float("inf"),
+            {"input": 0, "output": 0},
+            10 * 1024 * 1024,
+            _marker,
+            first_dirty_then_clean,
+        )
+        assert clean is True
+        assert digest != "<unsafe>"
+        assert len(calls) == 2  # 恢复分支确实重取并二次比对
+
+    def test_持续不一致_维持unsafe(self, tmp_path):
+        from tree_sitter_analyzer.index_source_stream import hash_source_at
+        from tree_sitter_analyzer.portable_source_snapshot import _marker
+
+        target = tmp_path / "hot.py"
+        target.write_text("a" * 100, encoding="utf-8")
+        import os as _os
+
+        before = _os.lstat(target)
+
+        def always_dirty(a, b):
+            return False
+
+        _marker_fn, digest, clean = hash_source_at(
+            None,
+            str(target),
+            before,
+            float("inf"),
+            {"input": 0, "output": 0},
+            10 * 1024 * 1024,
+            _marker,
+            always_dirty,
+        )
+        assert clean is False
+        assert digest == "<unsafe>"

--- a/tree_sitter_analyzer/index_source_stream.py
+++ b/tree_sitter_analyzer/index_source_stream.py
@@ -67,6 +67,25 @@ def hash_source_at(
     finally:
         os.close(fd)
     clean = same_file_metadata(before, after)
+    if not clean:
+        # #1364/#1373 家族：极新文件的元数据（size/mtime_ns）在 walker 的
+        # lstat 快照与读后 fstat 之间仍在沉降（NTFS/Defender 延迟，满载
+        # CI 上窗口更大）——旧快照过期被误判为篡改。重取一次 lstat：仅当
+        # 「与读后状态一致」且「ctime 未变」（自 walker 观测以来没有真实
+        # 写入，只是惰性沉降）才判 clean。原地重写会更新 ctime（POSIX），
+        # 即使恢复 mtime/size 也会在此维持 unsafe——防篡改不降级；
+        # Windows 上 ctime=创建时间不随重写变化，但此时内容摘要已变，
+        # 认证层的行比对（rows != recorded）仍会拦截，纵深防御保留。
+        try:
+            refreshed = os.lstat(name)
+        except OSError:
+            refreshed = None  # 无法重取时维持原判定
+        if (
+            refreshed is not None
+            and same_file_metadata(refreshed, after)
+            and int(refreshed.st_ctime_ns) == int(before.st_ctime_ns)
+        ):
+            clean = True
     return (
         metadata_marker(after),
         digest.hexdigest() if clean else "<unsafe>",


### PR DESCRIPTION
Follow-up to #1374's containment — the diagnostic message caught form 5 of the CI-load family red-handed: `SOURCE_CHANGED:state=unsafe` with **rows_current == rows_recorded** (no data change) on a private 1-file tree.

Root cause: `hash_source_at` binds the walker's early lstat snapshot against the post-read fstat; freshly-written files' size/mtime_ns are still settling across that gap (NTFS/Defender latency, widest under CI load) — a stale snapshot misread as tampering.

Fix: on an unclean final check, re-lstat once; recover as clean ONLY when the fresh stat matches post-read state AND **ctime unchanged** since observation (no real write — pure lazy settling). The restored-mtime in-place-rewrite adversarial test still passes (ctime bumps on POSIX rewrites); on Windows a rewrite changes the content digest and the row comparison still rejects — defense in depth intact.

250 index-suite tests green; quick gate 2002 passed.