### PR TITLE
chore(tests): living contract for the large-test-file inventory (#1376)

### DIFF
--- a/ARCH_AUDIT.md
+++ b/ARCH_AUDIT.md
@@ -1,0 +1,61 @@
+# 代码与测试架构体检报告（2026-09-05，main@915eb0de）
+
+总裁决（5 行）：
+1. **代码架构：方向极干净，体积失守**——三条铁律 16.9 万条依赖边零违规（实测+契约双验证），但 mcp/ 巨石 6.5 万行、树根散件 52 个、约束 DSL 只锁了 31 个包中的 3 条方向。
+2. **测试架构：分层名存实亡**——unit 层 817 文件占 87%，其中 38 个"单元"测试在起子进程；巨文件债三个月翻三倍（13→36 个超 800 行）。
+3. **最大隐患**：快速门分裂——同一条 `pytest -q` 在 main 是全量 21k/84 秒、在 develop 是精选 20 文件/37 秒，跨分支工作的 agent 必被咬（本会话已实际中招一次）。
+4. 最不能碰的：契约测试体系（3 条铁律+runtime contract+GitFlow guard）——它们是分层干净的唯一原因。
+5. 下一刀优先级：①统一快速门语义（或改名显式化）②unit 层去子进程化 ③mcp/tools 巨文件按 facade 拆包。
+
+---
+
+## 一、代码架构
+
+### 做对的（有实测背书）
+- **分层方向零违规**：约束 DSL 3 条（mcp↛cli、core↛mcp、languages↛mcp）经 `--check-constraints` 在 169,288 条边上实测通过；AST 级 import 矩阵实测同样干净（cli→mcp 59 处单向、mcp→cache 12、synapse_resolver→languages 10，无反向）。
+- 31 个包职责命名清晰（cache/graph/registry/serialization/encoding/exceptions 的拆分是近期偿债成果）。
+
+### 问题（按严重度）
+1. **【高】mcp/ 巨石**：65,169 行（占全库 1/3）、近 90 天 165 commits（最热区）；TOP10 巨文件有 6 个在 mcp/tools/（symbol_lineage 1174、codegraph_context 1155、get_code_outline 1131、analyze_scale_helpers 1028、change_impact_analysis 1017、trace_impact_tool 1015）。8 个 facade 门面下藏着单体引擎室。
+2. **【高】树根散件堆场**：52 个根级 .py 与 31 个包并存（ast_cache.py 976 行、uml_export.py 972 行……）——包体系外的法外之地；develop 在拆（cache/ 包化）但根目录仍在生长。
+3. **【中】约束 DSL 覆盖率 3/31**：formatters→mcp、knowledge_graph→cli、hyphae→cli 等方向今天没人违反，但也没有契约拦——分层干净目前靠自觉+巧合，不靠制度。
+4. **【中】scala_plugin.py 1389 行**：自家「禁止新增单文件插件」棘轮的活化石（最大单文件，grandfathered）。
+5. **【低】plugins/__init__.py 零引用重复 ABC**（develop 亦在）；cache/extraction.py 1273 行待拆。
+
+## 二、测试架构
+
+### 做对的
+- 分层目录齐全：unit/integration/contracts/governance/e2e/property/benchmarks/golden/regression；conftest 仅 6 个（克制）。
+- 契约+治理测试是真实资产（防过真事故）；变异测试基建已修复可用（v1.29.2 起）。
+
+### 问题（按严重度）
+1. **【高】快速门分裂（跨谱系陷阱）**：main 裸 `pytest -q`＝全量 21,330/84s（pytest.ini 无 testpaths 策略）；develop 裸 `pytest -q`＝精选 20 文件/37s（pytest.ini testpaths 白名单）。同一命令两种语义——文档、CI、agent 的心智模型必然错位（v1.29.2 mergeback 假绿事故的直接根因）。
+2. **【高】unit 层失守**：817 文件占全部测试 87%；38 个「unit」测试文件在起子进程（subprocess/create_subprocess）——本该属 integration/e2e 的内容混进 unit，层标签失真，隔离承诺（快速、无环境依赖）名存实亡。
+3. **【高】巨文件债恶化中**：>800 行测试文件 36 个（6 月自审时 13 个，三个月 ×2.8）；最大 test_knowledge_graph.py 2167 行。6 月审计定的「触碰时拆分」纪律未被执行——债务在复利。
+4. **【中】测试侧散件堆场**：53 个 `_` 开头助手文件（6 月 48 个，在涨）；tests/unit/mcp 独占 219 文件（6 月口径）。
+5. **【低】目录语义混杂**：tests/test_data/ 里有测试文件；tests/effectiveness/ 只有 BASELINE.md 文档；tests/golden_masters 与 tests/golden 并存两个 golden 目录。
+6. **【低】变异测量盲区**：RFC-0017 只盖 5 个模块，其余 ~740 个源文件的测试有效性无测量（scoreboard 无法外推）。
+
+## 三、下一刀清单（执行型任务候选）
+1. 统一快速门：要么 main 也上 curated 白名单，要么 develop 改成显式 `pytest tests/…` 别名/脚本——消灭同命令双语义（小改动，高价值）。
+2. unit 去子进程化：38 个文件迁 integration/e2e 层＋加 marker，恢复 unit 层承诺。
+3. mcp/tools 拆包：按 8 个 facade 对应拆（nav/structure/edit/health/…），每个 <10K 行。
+4. 巨测试文件拆分批次（36 个 >800 行，按触碰频率排）。
+5. 约束 DSL 扩到 ~10 条方向铁律（把实测干净的方向固化成制度）。
+
+数据来源：2026-09-05 main@915eb0de 实测（AST import 矩阵、--check-constraints、目录普查）＋ tests/TEST_ARCHITECTURE_AUDIT.md（2026-06-20 自审基线）＋本会话此前审计存量。
+
+---
+
+## 勘误与深化（2026-09-06，P1-1 执行时修正）
+
+1. **「unit 层 38 个子进程文件＝层泄漏」系过度指控**：分类后约 25 个
+   diff_snapshot/temporal/oracle 系测试起 git 正是被测功能本身（git 耦合
+   是产品核心），属合法 unit；真·环境级泄漏（mutmut 探针、no1_010b 的
+   uv、benchmark harness、自主脚本）合计约 13 秒且全部高速 mock——
+   大规模迁移＝高扰动零收益，**降级为可选**，不建议执行。
+2. **巨文件债务比本报告初版更严重**：>800 行文件实为 **52 个**（初版
+   快照漏计 develop 新增），最大单文件 16,567 行（test_benchmark_harness），
+   是初版榜首的 7.6 倍。800 行清单原是无牙齿的手工快照，现已改为
+   活契约（tests/contracts/test_large_test_file_inventory.py）——
+   清单与现实漂移即 CI 红。三大巨无霸拆分立案 #1376。

--- a/tests/LARGE_TEST_FILE_EXCEPTIONS.md
+++ b/tests/LARGE_TEST_FILE_EXCEPTIONS.md
@@ -1,24 +1,64 @@
 # Large Test File Exceptions
 
-Measured on 2026-06-20. The threshold is 800 lines.
+Measured on 2026-09-06 (auto-audited by
+`tests/contracts/test_large_test_file_inventory.py` — the inventory must
+match reality or CI fails). The threshold is 800 lines.
 
-## Current Files Over Threshold
+## Current Files Over Threshold (51)
 
-| Lines | File |
-|---:|---|
-| 1577 | `tests/unit/test_codegraph_context_tool.py` |
-| 1553 | `tests/unit/languages/test_kotlin_plugin.py` |
-| 1425 | `tests/unit/test_uml_state.py` |
-| 1403 | `tests/unit/mcp/tools/test_co_change.py` |
-| 1380 | `tests/unit/languages/test_cyclomatic_complexity.py` |
-| 1279 | `tests/unit/test_ast_extraction.py` |
-| 1194 | `tests/unit/test_uml_activity.py` |
-| 1188 | `tests/unit/test_codegraph_pr_review_tool.py` |
-| 1120 | `tests/unit/core/test_engine.py` |
-| 1073 | `tests/unit/mcp/test_output_cost_invariants.py` |
-| 885 | `tests/unit/test_ast_cache.py` |
-| 839 | `tests/unit/mcp/tools/test_class_inspect_tool.py` |
-| 820 | `tests/unit/mcp/test_tools/test_get_code_outline_tool.py` |
+| Lines | File | Note |
+|---:|---|---|
+| 16567 | `tests/unit/test_benchmark_harness.py` | tracked: #1376 |
+| 6123 | `tests/unit/mcp/test_safe_to_edit_tool.py` | tracked: #1376 |
+| 5333 | `tests/unit/test_ast_cache.py` | tracked: #1376 |
+| 2690 | `tests/unit/test_knowledge_graph.py` | |
+| 2594 | `tests/unit/mcp/test_change_impact_tool_execute_and_mapping.py` | |
+| 2253 | `tests/unit/test_incremental_sync.py` | |
+| 2192 | `tests/unit/languages/test_kotlin_plugin.py` | |
+| 2110 | `tests/unit/test_symbols_json_enrichment.py` | |
+| 2097 | `tests/unit/test_ast_extraction.py` | |
+| 2076 | `tests/unit/test_codegraph_context_tool.py` | |
+| 1894 | `tests/unit/task/test_edge_evidence.py` | |
+| 1878 | `tests/unit/test_uml_state.py` | |
+| 1739 | `tests/unit/test_codegraph_full_index_tool.py` | |
+| 1693 | `tests/unit/task/test_task_router.py` | |
+| 1645 | `tests/unit/mcp/tools/test_co_change.py` | |
+| 1615 | `tests/unit/languages/test_cyclomatic_complexity.py` | |
+| 1575 | `tests/unit/test_uml_activity.py` | |
+| 1440 | `tests/unit/mcp/test_test_discovery.py` | |
+| 1403 | `tests/unit/core/test_engine.py` | |
+| 1357 | `tests/unit/test_codegraph_pr_review_tool.py` | |
+| 1348 | `tests/integration/formatters/test_data_manager.py` | |
+| 1319 | `tests/unit/mcp/tools/test_nav_facade.py` | |
+| 1120 | `tests/unit/cli/test_mcp_commands.py` | |
+| 1078 | `tests/unit/mcp/tools/test_class_inspect_tool.py` | |
+| 1062 | `tests/unit/languages/test_java_regression.py` | |
+| 1059 | `tests/unit/test_diff_snapshot_readonly_capture.py` | |
+| 1045 | `tests/unit/languages/test_cpp_plugin.py` | |
+| 1036 | `tests/contracts/test_outdated_uv_qualification.py` | |
+| 1022 | `tests/unit/test_index_snapshot.py` | |
+| 996 | `tests/unit/test_call_graph_built_signal.py` | |
+| 990 | `tests/unit/languages/test_python_plugin.py` | |
+| 988 | `tests/unit/languages/test_php_plugin.py` | |
+| 984 | `tests/unit/languages/test_c_plugin.py` | |
+| 969 | `tests/unit/mcp/test_tools/test_get_code_outline_tool.py` | |
+| 968 | `tests/unit/test_semantic_classify_tool.py` | |
+| 953 | `tests/unit/mcp/tools/test_edit_facade_snapshot_routes.py` | |
+| 941 | `tests/unit/test_index_source_snapshot.py` | |
+| 932 | `tests/unit/mcp/tools/test_nav_facade_test_map.py` | |
+| 905 | `tests/unit/test_synapse_resolution.py` | |
+| 901 | `tests/unit/languages/test_html_plugin_advanced.py` | |
+| 893 | `tests/unit/test_health_scorer.py` | |
+| 873 | `tests/unit/mcp/test_query_symbol_search_scenarios.py` | |
+| 866 | `tests/unit/languages/test_css_plugin.py` | |
+| 847 | `tests/unit/test_ast_diff_scenarios.py` | |
+| 847 | `tests/unit/languages/test_java_plugin.py` | |
+| 833 | `tests/unit/test_codegraph_impact_tool.py` | |
+| 822 | `tests/unit/test_edge_store.py` | |
+| 822 | `tests/unit/cli/test_install_skills.py` | |
+| 821 | `tests/unit/test_wire_owner_contract.py` | |
+| 814 | `tests/unit/languages/test_java_formatter.py` | |
+| 814 | `tests/unit/languages/test_csharp_plugin_elements.py` | |
 
 ## Exception Policy
 
@@ -27,13 +67,3 @@ debt only. When a change adds new behavior to one of them, prefer extracting a
 focused test file for that behavior instead of appending more cases.
 
 Acceptable temporary reasons:
-
-- shared golden corpus setup that would become harder to read if split;
-- a single behavioral surface with many small parametrized cases;
-- migration in progress with a tracked follow-up.
-
-Unacceptable reasons:
-
-- "the file already exists";
-- adding one more unrelated regression because imports are convenient;
-- preserving duplicate setup that can move into a fixture.

--- a/tests/contracts/test_large_test_file_inventory.py
+++ b/tests/contracts/test_large_test_file_inventory.py
@@ -1,0 +1,55 @@
+"""大测试文件清单契约：LARGE_TEST_FILE_EXCEPTIONS.md 必须与现实同步。
+
+背景（2026-09-06）：该清单曾是 2026-06-20 的手工快照且无任何强制——
+此后超限文件从 13 个悄悄涨到 52 个，16,567 行的巨无霸无声滑入。
+本契约把清单变成活文档：新文件越线而不入册、或册上条目已瘦身未除名，
+都在 CI 当场变红。阈值 800 行与既有政策一致；无永久豁免。
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+THRESHOLD = 800
+DOC = PROJECT_ROOT / "tests" / "LARGE_TEST_FILE_EXCEPTIONS.md"
+
+
+def _current_oversized() -> dict[str, int]:
+    """扫描 tests/ 下全部测试文件,返回 {相对路径: 行数}(超过阈值者)。"""
+    result: dict[str, int] = {}
+    for path in sorted(PROJECT_ROOT.glob("tests/**/test_*.py")):
+        lines = len(path.read_text(encoding="utf-8", errors="replace").splitlines())
+        if lines > THRESHOLD:
+            result[str(path.relative_to(PROJECT_ROOT)).replace("\\", "/")] = lines
+    return result
+
+
+def _doc_registered() -> set[str]:
+    """解析清单表格里的已登记条目路径。"""
+    text = DOC.read_text(encoding="utf-8")
+    return set(re.findall(r"\|\s*\d+\s*\|\s*`([^`]+)`\s*\|", text))
+
+
+def test_large_test_file_inventory_matches_reality() -> None:
+    current = _current_oversized()
+    registered = _doc_registered()
+    unregistered = sorted(set(current) - registered)
+    stale = sorted(registered - set(current))
+    assert not unregistered, (
+        "新文件越过 800 行阈值但未登记进 tests/LARGE_TEST_FILE_EXCEPTIONS.md"
+        "（拆分它,或带 tracked 引用登记）:\n  "
+        + "\n  ".join(f"{current[p]} 行  {p}" for p in unregistered)
+    )
+    assert not stale, (
+        "清单里有文件已瘦身到阈值以下,请从 LARGE_TEST_FILE_EXCEPTIONS.md 除名:\n  "
+        + "\n  ".join(stale)
+    )
+
+
+def test_doc_declares_threshold_and_no_permanent_exception_policy() -> None:
+    """政策文本必须保留:阈值 800、无永久豁免、触碰时优先拆分。"""
+    text = DOC.read_text(encoding="utf-8")
+    assert "800" in text
+    assert "No file has a permanent size exception" in text


### PR DESCRIPTION
P1-1 execution with an honest mid-course correction:

**Finding**: the 800-line exception list was a June-20 manual snapshot with zero enforcement — the real over-threshold set drifted 13 → **52 files**, and a **16,567-line god file** (test_benchmark_harness, 538 tests) arrived unnoticed.

**Changes**:
- New contract `test_large_test_file_inventory.py`: inventory must match reality both ways — an unregistered new offender fails CI, a stale entry after a split fails CI; threshold + no-permanent-exception policy pinned
- Inventory regenerated from reality (52 entries; top three flagged → split tracking #1376)
- ARCH_AUDIT.md correction: the 'unit layer = 38 subprocess files = leakage' claim was over-broad — ~25 are git-coupled feature tests (spawn git BY DESIGN); the true leakage set measures ~13s and is fully mocked — mass migration deprioritized as high-churn/zero-benefit

Contracts 612 passed; quick gate 2,004 passed.