### PR TITLE
chore(index): granular UNSAFE reasons in the portable walk (#1364/#1373 form 6 diagnosis)

### DIFF
--- a/tests/unit/test_index_source_snapshot.py
+++ b/tests/unit/test_index_source_snapshot.py
@@ -139,7 +139,7 @@ class TestSnapshotFailureContracts:
 
         (tmp_path / "notes.txt").write_text("ignored")
         rows, unsafe = source._inventory(str(tmp_path), float("inf"), with_content=True)
-        assert (rows, unsafe) == (frozenset(), False)
+        assert rows == frozenset() and not unsafe
 
     def test_inventory_rejects_scope_root_escape(self, tmp_path):
         import tree_sitter_analyzer.index_source_snapshot as source
@@ -311,7 +311,7 @@ class TestSnapshotFailureContracts:
 
         rows, unsafe = source._inventory(str(tmp_path), float("inf"), with_content=True)
 
-        assert (rows, unsafe) == (frozenset(), True)
+        assert rows == frozenset() and unsafe  # unsafe 现为原因字符串,非空即不安全
 
     def test_inventory_rejects_non_directory_root(self, tmp_path, monkeypatch):
         # PR #1253: the pinned root must itself be a directory descriptor.
@@ -442,7 +442,7 @@ class TestSnapshotFailureContracts:
         monkeypatch.setattr(source.os, "open", swap_root)
         rows, unsafe = source._inventory(str(root), float("inf"), with_content=True)
 
-        assert (rows, unsafe) == (frozenset(), True)
+        assert rows == frozenset() and unsafe  # unsafe 现为原因字符串,非空即不安全
 
     @requires_posix_fd
     def test_capture_revalidates_each_leaf_after_final_inventory(
@@ -600,7 +600,7 @@ class TestSnapshotFailureContracts:
         monkeypatch.setattr(source.os, "open", swap_child)
         rows, unsafe = source._inventory(str(tmp_path), float("inf"), with_content=True)
 
-        assert (rows, unsafe) == (frozenset(), True)
+        assert rows == frozenset() and unsafe  # unsafe 现为原因字符串,非空即不安全
 
     @requires_posix_fd
     def test_inventory_rejects_declared_scope_swapped_for_ordinary_directory(
@@ -630,7 +630,7 @@ class TestSnapshotFailureContracts:
             str(tmp_path), float("inf"), scope, with_content=True
         )
 
-        assert (rows, unsafe) == (frozenset(), True)
+        assert rows == frozenset() and unsafe  # unsafe 现为原因字符串,非空即不安全
 
 
 def test_revalidate_source_rows_enforces_absolute_deadline(tmp_path):

--- a/tests/unit/test_portable_source_snapshot.py
+++ b/tests/unit/test_portable_source_snapshot.py
@@ -54,7 +54,7 @@ def test_portable_inventory_rejects_non_directory_project_root(tmp_path: Path) -
 
     rows, unsafe = _inventory(project)
 
-    assert (rows, unsafe) == (frozenset(), True)
+    assert rows == frozenset() and unsafe  # unsafe 现为原因字符串,非空即不安全
 
 
 def test_portable_inventory_rejects_reparse_project_root(
@@ -64,13 +64,13 @@ def test_portable_inventory_rejects_reparse_project_root(
 
     rows, unsafe = _inventory(tmp_path)
 
-    assert (rows, unsafe) == (frozenset(), True)
+    assert rows == frozenset() and unsafe  # unsafe 现为原因字符串,非空即不安全
 
 
 def test_portable_inventory_rejects_missing_scope_root(tmp_path: Path) -> None:
     rows, unsafe = _inventory(tmp_path, roots=("missing",))
 
-    assert (rows, unsafe) == (frozenset(), True)
+    assert rows == frozenset() and unsafe  # unsafe 现为原因字符串,非空即不安全
 
 
 def test_portable_inventory_rejects_non_directory_scope_root(tmp_path: Path) -> None:
@@ -78,7 +78,7 @@ def test_portable_inventory_rejects_non_directory_scope_root(tmp_path: Path) -> 
 
     rows, unsafe = _inventory(tmp_path, roots=("scope",))
 
-    assert (rows, unsafe) == (frozenset(), True)
+    assert rows == frozenset() and unsafe  # unsafe 现为原因字符串,非空即不安全
 
 
 def test_portable_inventory_enforces_deadline(tmp_path: Path) -> None:
@@ -87,7 +87,7 @@ def test_portable_inventory_enforces_deadline(tmp_path: Path) -> None:
 
     rows, unsafe = portable._portable_inventory(str(tmp_path), scope, -1.0)
 
-    assert (rows, unsafe) == (frozenset(), True)
+    assert rows == frozenset() and unsafe  # unsafe 现为原因字符串,非空即不安全
 
 
 def test_portable_inventory_counts_unsupported_entries_against_budget(
@@ -115,7 +115,8 @@ def test_portable_inventory_skips_hidden_and_excluded_directories(
 
     rows, unsafe = _inventory(tmp_path)
 
-    assert ({row[0] for row in rows}, unsafe) == ({"pkg/kept.py"}, False)
+    assert {row[0] for row in rows} == {"pkg/kept.py"}
+    assert not unsafe  # None=安全
 
 
 def test_portable_inventory_skips_reparse_directory(
@@ -136,7 +137,7 @@ def test_portable_inventory_skips_reparse_directory(
 
     rows, unsafe = _inventory(tmp_path)
 
-    assert (rows, unsafe) == (frozenset(), False)
+    assert rows == frozenset() and not unsafe
 
 
 def test_portable_inventory_marks_supported_reparse_leaf_unsafe(
@@ -156,7 +157,7 @@ def test_portable_inventory_marks_supported_reparse_leaf_unsafe(
 
     rows, unsafe = _inventory(tmp_path)
 
-    assert (rows, unsafe) == (frozenset(), True)
+    assert rows == frozenset() and unsafe  # unsafe 现为原因字符串,非空即不安全
 
 
 def test_portable_inventory_ignores_unsupported_reparse_leaf(
@@ -176,7 +177,7 @@ def test_portable_inventory_ignores_unsupported_reparse_leaf(
 
     rows, unsafe = _inventory(tmp_path)
 
-    assert (rows, unsafe) == (frozenset(), False)
+    assert rows == frozenset() and not unsafe
 
 
 def test_portable_inventory_omits_effectively_excluded_source(tmp_path: Path) -> None:
@@ -186,7 +187,7 @@ def test_portable_inventory_omits_effectively_excluded_source(tmp_path: Path) ->
 
     rows, unsafe = portable._portable_inventory(str(tmp_path), scope, float("inf"))
 
-    assert (rows, unsafe) == (frozenset(), False)
+    assert rows == frozenset() and not unsafe
 
 
 def test_portable_inventory_marks_supported_nonregular_leaf_unsafe(
@@ -211,7 +212,7 @@ def test_portable_inventory_marks_supported_nonregular_leaf_unsafe(
 
     rows, unsafe = _inventory(tmp_path)
 
-    assert (rows, unsafe) == (frozenset(), True)
+    assert rows == frozenset() and unsafe  # unsafe 现为原因字符串,非空即不安全
 
 
 def test_portable_inventory_enforces_supported_file_capacity(
@@ -238,10 +239,8 @@ def test_portable_inventory_marks_unclean_source_hash_unsafe(
 
     rows, unsafe = _inventory(tmp_path)
 
-    assert (rows, unsafe) == (
-        frozenset({("sample.py", "<unsafe>", "python")}),
-        True,
-    )
+    assert rows == frozenset({("sample.py", "<unsafe>", "python")})
+    assert unsafe == "hash_unclean"
     assert len(observed) == 1
     assert observed[0][0] is None
     assert observed[0][1] == str(tmp_path / "sample.py")
@@ -259,7 +258,7 @@ def test_portable_inventory_normalizes_scandir_error(
 
     rows, unsafe = _inventory(tmp_path)
 
-    assert (rows, unsafe) == (frozenset(), True)
+    assert rows == frozenset() and unsafe  # unsafe 现为原因字符串,非空即不安全
 
 
 def test_portable_inventory_detects_directory_identity_change(
@@ -280,7 +279,7 @@ def test_portable_inventory_detects_directory_identity_change(
 
     rows, unsafe = _inventory(tmp_path)
 
-    assert (rows, unsafe) == (frozenset(), True)
+    assert rows == frozenset() and unsafe  # unsafe 现为原因字符串,非空即不安全
 
 
 def test_portable_inventory_detects_scope_root_identity_change(
@@ -305,7 +304,7 @@ def test_portable_inventory_detects_scope_root_identity_change(
 
     rows, unsafe = _inventory(tmp_path, roots=("first", "second"))
 
-    assert (rows, unsafe) == (frozenset(), True)
+    assert rows == frozenset() and unsafe  # unsafe 现为原因字符串,非空即不安全
 
 
 def test_portable_inventory_retains_unsafe_state_from_earlier_scope_root(
@@ -330,7 +329,7 @@ def test_portable_inventory_retains_unsafe_state_from_earlier_scope_root(
 
     rows, unsafe = _inventory(tmp_path, roots=("first", "second"))
 
-    assert (rows, unsafe) == (frozenset(), True)
+    assert rows == frozenset() and unsafe  # unsafe 现为原因字符串,非空即不安全
 
 
 def test_portable_inventory_detects_project_identity_change(
@@ -353,7 +352,7 @@ def test_portable_inventory_detects_project_identity_change(
 
     rows, unsafe = _inventory(tmp_path, roots=("src",))
 
-    assert (rows, unsafe) == (frozenset(), True)
+    assert rows == frozenset() and unsafe  # unsafe 现为原因字符串,非空即不安全
 
 
 @pytest.mark.parametrize(
@@ -404,11 +403,9 @@ def test_capture_portable_source_snapshot_rejects_changed_inventory(
     )
 
     # 两次尝试都双走不一致 → 仍如实返回 unsafe(重试不掩盖真实不稳定)
-    assert (result.rows, result.state, result.reason) == (
-        first,
-        "unsafe",
-        "SOURCE_SCOPE_UNSAFE",
-    )
+    # #1364/#1373 起 reason 携带首个触发的检查名,锚定前缀
+    assert (result.rows, result.state) == (first, "unsafe")
+    assert result.reason.startswith("SOURCE_SCOPE_UNSAFE")
     assert result.fingerprint is not None
     assert result.generation == "idxsrc-v3:" + result.fingerprint.removeprefix(
         "sha256:"
@@ -441,7 +438,8 @@ def test_portable_inventory_revalidates_queued_directory_before_scan(
     monkeypatch.setattr(portable.os, "lstat", lstat)
     monkeypatch.setattr(portable.os, "scandir", scandir)
 
-    assert _inventory(tmp_path) == (frozenset(), True)
+    result = _inventory(tmp_path)
+    assert result[0] == frozenset() and result[1]  # 原因非空=不安全
     assert scanned == [tmp_path]
 
 

--- a/tree_sitter_analyzer/portable_source_snapshot.py
+++ b/tree_sitter_analyzer/portable_source_snapshot.py
@@ -61,24 +61,36 @@ def _portable_inventory(
     project_root: str,
     scope: SourceScopeDescriptor,
     deadline: float,
-) -> tuple[frozenset[tuple[str, str, str]], bool]:
-    """Hash one bounded pathname inventory without following directory links."""
+) -> tuple[frozenset[tuple[str, str, str]], str | None]:
+    """Hash one bounded pathname inventory without following directory links.
+
+    返回 (rows, unsafe_reason);unsafe_reason 为 None 表示安全,否则给出
+    具体触发的安全检查名(#1364/#1373 诊断:满载 CI 上的 unsafe 需要
+    区分是目录身份漂移、双走不一致还是哈希不洁)。
+    """
     project = Path(project_root)
     root_before = os.lstat(project)
     if not stat.S_ISDIR(root_before.st_mode) or _is_reparse(root_before):
-        return frozenset(), True
+        return frozenset(), "root_reparse_or_not_dir"
     rows: set[tuple[str, str, str]] = set()
     counters = {"entries": 0, "path_bytes": 0, "input": 0, "output": 0}
     supported = 0
-    unsafe = False
+    # #1364/#1373 诊断:记录首个触发的安全检查名,None=安全
+    unsafe_reason: str | None = None
+
+    def _flag(reason: str) -> None:
+        nonlocal unsafe_reason
+        if unsafe_reason is None:
+            unsafe_reason = reason
+
     for relative_root in scope.roots:
         base = _scope_root(project, relative_root)
         try:
             base_before = os.lstat(base)
         except OSError:
-            return frozenset(), True
+            return frozenset(), "scope_root_stat_failed"
         if not stat.S_ISDIR(base_before.st_mode) or _is_reparse(base_before):
-            return frozenset(), True
+            return frozenset(), "scope_root_reparse_or_not_dir"
         stack = [(base, base_before)]
         while stack:
             directory, discovered = stack.pop()
@@ -89,7 +101,7 @@ def _portable_inventory(
                     or _is_reparse(directory_before)
                     or _identity(directory_before) != _identity(discovered)
                 ):
-                    return frozenset(), True
+                    return frozenset(), "dir_identity_changed"
                 entries = os.scandir(directory)
                 with entries:
                     for entry in entries:
@@ -117,7 +129,7 @@ def _portable_inventory(
                             continue
                         if _is_reparse(before):
                             if language is not None:
-                                unsafe = True
+                                _flag("reparse_supported_file")
                             continue
                         if language is None or any(
                             fnmatch.fnmatch(relative, pattern)
@@ -125,7 +137,7 @@ def _portable_inventory(
                         ):
                             continue
                         if not stat.S_ISREG(before.st_mode):
-                            unsafe = True
+                            _flag("supported_not_regular")
                             continue
                         supported += 1
                         if supported > min(
@@ -143,17 +155,17 @@ def _portable_inventory(
                             _same,
                         )
                         if not clean:
-                            unsafe = True
+                            _flag("hash_unclean")
                         rows.add((relative, digest, language))
             except OSError:
-                return frozenset(), True
+                return frozenset(), "walk_oserror"
             if _identity(os.lstat(directory)) != _identity(directory_before):
-                unsafe = True
+                _flag("dir_identity_changed")
         if _identity(os.lstat(base)) != _identity(base_before):
-            unsafe = True
+            _flag("scope_root_identity_changed")
     if _identity(os.lstat(project)) != _identity(root_before):
-        unsafe = True
-    return frozenset(rows), unsafe
+        _flag("project_root_identity_changed")
+    return frozenset(rows), unsafe_reason
 
 
 def capture_portable_source_snapshot(
@@ -190,8 +202,16 @@ def capture_portable_source_snapshot(
         if unsafe_first or unsafe_second or first != second:
             if attempt == 1:
                 continue
+            # 诊断细节随行(#1364/#1373):指出首个触发的安全检查名;
+            # 双走不一致时优先报 walk_mismatch。既有断言以
+            # SOURCE_SCOPE_UNSAFE 开头匹配的不受影响。
+            detail = unsafe_first or unsafe_second or "walk_mismatch"
             return CurrentSourceSnapshot(
-                first, fingerprint, generation, "unsafe", "SOURCE_SCOPE_UNSAFE"
+                first,
+                fingerprint,
+                generation,
+                "unsafe",
+                f"SOURCE_SCOPE_UNSAFE:{detail}",
             )
         return CurrentSourceSnapshot(first, fingerprint, generation, "exact", None)
     return CurrentSourceSnapshot(


### PR DESCRIPTION
The state=unsafe / rows-matching flake survived the stale-snapshot recovery on windows-3.13 (run 34018617269, 6x) — instead of a third blind swing, the walk now self-reports WHICH safety check fired:

- `_portable_inventory` returns `(rows, reason|None)`: dir_identity_changed / walk_mismatch / hash_unclean / reparse_supported_file / supported_not_regular / scope-root variants
- capture-level reason: `SOURCE_SCOPE_UNSAFE:<detail>` (prefix-stable — existing prefix/equality assertions updated in the same change)
- flows into the existing SOURCE_CHANGED diagnostic envelope; the next CI occurrence names its trigger directly

373 index-suite tests green; quick gate 2,004 passed.