### PR TITLE
fix(cli): align --table choices with _VALID_FORMAT_TYPES

### DIFF
--- a/tree_sitter_analyzer/cli/argument_groups/_core.py
+++ b/tree_sitter_analyzer/cli/argument_groups/_core.py
@@ -30,7 +30,9 @@ def _add_output_options(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--table",
-        choices=["full", "signatures"],
+        # 对齐 _VALID_FORMAT_TYPES(1d26baca 回退后含 compact/csv):
+        # 删格式的尝试已因 50 连爆被否决,CLI 选项必须与校验层一致
+        choices=["full", "compact", "csv", "signatures"],
         help=(
             "Output in table format. "
             "'full' = all columns (default); "


### PR DESCRIPTION
Fallout from the 'remove unnecessary formatters' campaign (d4fa151b): the format removal triggered 50+ CI failures and was effectively rejected — 1d26baca restored `_VALID_FORMAT_TYPES` to include compact/csv — but the CLI `--table` choices were never re-aligned, leaving a split-brain surface (validator accepts 4 formats, CLI offers 2).

This restores CLI choices to match the validation layer: `{full,compact,csv,signatures}`. The helper-module consolidation (the genuinely dead ~1.5K lines) stays.

Verified: `--table {full,compact,csv,signatures}` in help; unit CLI + contracts 1,709 passed; quick gate green.