### PR TITLE
fix(index): settle-detection recovery for hash_unclean (#1364/#1373 final form)

### DIFF
--- a/tree_sitter_analyzer/index_source_stream.py
+++ b/tree_sitter_analyzer/index_source_stream.py
@@ -68,24 +68,26 @@ def hash_source_at(
         os.close(fd)
     clean = same_file_metadata(before, after)
     if not clean:
-        # #1364/#1373 家族：极新文件的元数据（size/mtime_ns）在 walker 的
-        # lstat 快照与读后 fstat 之间仍在沉降（NTFS/Defender 延迟，满载
-        # CI 上窗口更大）——旧快照过期被误判为篡改。重取一次 lstat：仅当
-        # 「与读后状态一致」且「ctime 未变」（自 walker 观测以来没有真实
-        # 写入，只是惰性沉降）才判 clean。原地重写会更新 ctime（POSIX），
-        # 即使恢复 mtime/size 也会在此维持 unsafe——防篡改不降级；
-        # Windows 上 ctime=创建时间不随重写变化，但此时内容摘要已变，
-        # 认证层的行比对（rows != recorded）仍会拦截，纵深防御保留。
-        try:
-            refreshed = os.lstat(name)
-        except OSError:
-            refreshed = None  # 无法重取时维持原判定
-        if (
-            refreshed is not None
-            and same_file_metadata(refreshed, after)
-            and int(refreshed.st_ctime_ns) == int(before.st_ctime_ns)
-        ):
-            clean = True
+        # #1364/#1373 家族终章（诊断实锤 SOURCE_SCOPE_UNSAFE:hash_unclean）：
+        # Windows 上同一未动文件的句柄缓存与路径缓存可返回不同 mtime_ns，
+        # 「重取 lstat 对比读后 fstat」在缓存分裂面前永远对不上。改为
+        # 「安静判定」：间隔 20ms 连续两次新鲜 lstat 互相全等，且 ctime
+        # 相对 walker 快照未变 → 文件已安静，判 clean。防篡改不降级：
+        # POSIX 原地重写必动 ctime；Windows 的 ctime=创建时间不随写变化，
+        # 但重写使内容摘要改变，认证层的行比对（rows != recorded）仍会
+        # 拦截——纵深防御保留。
+        for _ in range(3):
+            time.sleep(0.02)
+            try:
+                r1 = os.lstat(name)
+                r2 = os.lstat(name)
+            except OSError:
+                break  # 无法重取时维持原判定
+            if same_file_metadata(r1, r2) and int(r1.st_ctime_ns) == int(
+                before.st_ctime_ns
+            ):
+                clean = True
+                break
     return (
         metadata_marker(after),
         digest.hexdigest() if clean else "<unsafe>",


### PR DESCRIPTION
The granular diagnostic (armed in #1378) finally named the recurring killer: `SOURCE_SCOPE_UNSAFE:hash_unclean` — Windows returns DIFFERENT mtime_ns for the same untouched file depending on which stat cache answers (handle cache vs path cache). The single re-lstat-against-fstat recovery could never match under that cache split.

New recovery = settle detection: up to 3 rounds of (20ms sleep; two fresh lstats); if the two lstats fully agree AND ctime is unchanged since the walker's snapshot, the file is quiet → clean. Tamper defense unchanged: POSIX in-place rewrites bump ctime (blocked); Windows rewrites change the content digest, which the certifier's row comparison rejects (defense in depth).

236 index-suite tests green (incl. the restored-mtime adversarial contract); quick gate 2,004 passed.