### PR TITLE
chore(cli): complete the compact/csv removal — all three layers aligned

### DIFF
--- a/docs/CODEMAPS/cli.md
+++ b/docs/CODEMAPS/cli.md
@@ -42,7 +42,7 @@ enforced by `tests/unit/cli/test_mcp_commands.py`.
 Categories of CLI surface:
 
 ### Structural Analysis
-- `--table full|compact|csv` — full structural AST table
+- `--table full|signatures` — full structural AST table (compact/csv removed as useless, 2026-09-06)
 - `--summary` — one-screen summary
 - `--partial-read --start-line N --end-line M` — extract range
 
@@ -136,7 +136,7 @@ Categories of CLI surface:
 
 `--format` is intentionally narrower than `--output-format` and `--table`:
 use `--format json` for agent envelopes, `--output-format text` for the
-remaining human-readable text paths, and `--table csv|full|compact|json`
+remaining human-readable text paths, and `--table full|signatures`
 for table rendering. There is no global `--format yaml` mode.
 
 ## File Output

--- a/tree_sitter_analyzer/cli/argument_groups/_core.py
+++ b/tree_sitter_analyzer/cli/argument_groups/_core.py
@@ -30,9 +30,10 @@ def _add_output_options(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--table",
-        # 对齐 _VALID_FORMAT_TYPES(1d26baca 回退后含 compact/csv):
-        # 删格式的尝试已因 50 连爆被否决,CLI 选项必须与校验层一致
-        choices=["full", "compact", "csv", "signatures"],
+        # 领导裁决(2026-09-06):compact/csv 判无用,彻底删除。
+        # 实现层已在 d4fa151b 删除,此处菜单与校验层(同提交)同步收口,
+        # 终结「菜单承诺厨房做不出的菜」的三层分裂
+        choices=["full", "signatures"],
         help=(
             "Output in table format. "
             "'full' = all columns (default); "

--- a/tree_sitter_analyzer/mcp/tools/analyze_code_structure_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/analyze_code_structure_tool.py
@@ -388,7 +388,9 @@ def _validate_required_file_path(arguments: dict[str, Any]) -> None:
         raise ValueError("file_path cannot be empty")
 
 
-_VALID_FORMAT_TYPES = frozenset({"full", "compact", "csv", "signatures"})
+# 领导裁决(2026-09-06):compact/csv 判无用彻底删除(实现已随 d4fa151b 移除,
+# 本集合与其 CLI 菜单同步收口,终结 1d26baca 半回退造成的分层不一致)
+_VALID_FORMAT_TYPES = frozenset({"full", "signatures"})
 
 
 def _validate_format_type(arguments: dict[str, Any]) -> None:


### PR DESCRIPTION
Leader ruling (2026-09-06): compact/csv output judged useless — full removal.

Ends the three-layer split left by the indigestible removal: d4fa151b deleted implementations, 1d26baca reverted only the validation set (to pacify CI), #1379 re-aligned the CLI menu — a menu promising formats the kitchen couldn't cook. Now consistent:

- CLI `--table` choices: `{full, signatures}` (csv fails fast at argparse)
- `_VALID_FORMAT_TYPES`: `{full, signatures}`
- implementations: already absent
- `docs/CODEMAPS/cli.md` synced in the same change (codemap mandate)

Verified: csv/compact rejected cleanly, full/signatures work; CLI unit + contracts 1,709 passed; quick gate 2,004 passed; codemap-sync-check green.