### PR TITLE
fix: fail closed on source snapshots and mutation-runner failures

### DIFF
--- a/BLOCKED.md
+++ b/BLOCKED.md
@@ -4,9 +4,14 @@
    与 tests/unit/test_patch_coverage_check.py 的 4 条断言与 origin/main 逐字节相同，
    却被报为「PR 新增」。本次以官方豁免通道（# ratchet: 注释）放行并留痕；
    检测逻辑本身（check_loose_assertions.py 的 diff 基准）待独立修复。
-2. ast_diff 剩余 64 个存活变异的逐个等价性论证未完成（目标 ≤20% 已达成，
-   存活率 15.2%）；多为 errors="replace" 语义与字符串字面量类近等价变异，
-   完整清单可由 `uv run mutmut results` 复现。
+2. [2026-09-07 撤回达标结论，等待可信复测] ast_diff 的“64 存活、15.2% 存活率、
+   目标 ≤20% 已达成”及“多为近等价变异”均未验证，不能继续作为实测结论。
+   九月发布的 422/246/510 总数只统计顶层 def，遗漏类方法；不能据此推断 killed。
+   `tests/effectiveness/BASELINE.md` 保留原始发布表并撤回九月分数、合计及改善结论。
+   必须以 mutmut 完整元数据的全状态、相同源范围和测试选择重建前后可比测量，
+   再逐项审查等价性。本机无 mutants/ 缓存，未复跑长变异任务，不提供替代成绩。
+   mutmut 3.7.0 的 `results --all true` 可读取已有全状态记录，但须使用对应运行配置；
+   默认 results 隐藏 killed，不能单独证明完整性或复现历史成绩。
 
 # 追加（v1.29.3 轮次二）
 

--- a/scripts/run_mutation_baseline.py
+++ b/scripts/run_mutation_baseline.py
@@ -134,13 +134,15 @@ def run_module(module_key: str, repo_root: Path) -> None:
                 capture_output=False,
             )
             print(f"\n=== mutmut run exit code: {result.returncode} ===")
+            result.check_returncode()
 
-            # Collect results
+            # 仅在变异运行成功后读取结果；读取失败同样必须向入口传播。
             print(f"\n=== Results for {module_key} ===")
-            subprocess.run(
+            result = subprocess.run(
                 [*mutmut_command, "results"],
                 cwd=repo_root,
             )
+            result.check_returncode()
         finally:
             shutil.copy2(backup, real_pyproject)
 

--- a/tests/effectiveness/BASELINE.md
+++ b/tests/effectiveness/BASELINE.md
@@ -12,7 +12,16 @@
 
 ---
 
-## Results: all 5 RFC-0017 core modules measured
+## 2026-09-07 校正：九月更新未验证，达标结论撤回
+
+**当前没有可信复跑支持 2026-09 的高分或达标结论。** 下方保留原始发布表供审计，
+不是当前实测成绩，也不是验收依据。九月更新中的 `422 / 246 / 510` 总数来自只计
+顶层 `def` 的统计，遗漏类方法，不能作为完整变异分母，更不能据此用差值推断 killed。
+`semantic_change_classifier` 的九月更新也未经过可信复跑，同样标记为未验证。
+所有依赖这些数字的分数、合计、改善幅度及“剩余多为等价变异”结论均撤回。
+六月历史解释和 `toon_encoder` 历史行保留，但未在本轮复核，不能代表当前代码。
+
+## 原始发布表（封存；2026-09 更新数字全部未验证）
 
 | Module | Total mutants | Killed | Survived | No-test | Score | Surviving = bugs suite misses |
 |---|---|---|---|---|---|---|
@@ -23,11 +32,11 @@
 | `formatters/toon_encoder.py` | 464 | 141 | **140** | 183 | **30.4%** | 140 deliberate bugs the suite does not catch |
 | **TOTAL (5 modules)** | **1 972** | **1 466** | **323** | 183 | **74.3%** | **323 surviving mutants = 323 deliberate bugs the current suite cannot catch** |
 
-**Headline (RFC-0017 deliverable):** 323 surviving mutants across 5 core modules (was 874 at first measurement; toon_encoder rows are historical — module removed on develop).
-The suite is ~2× the size of the source, yet 323 deliberate bugs escape it.
-This is the quantified answer to "why does 2× test volume not catch bugs?":
-the suite tests *conformance* (does code match spec?), not *value* (is the spec correct/good?).
+**原合计结论已撤回：** 323 surviving、1 972 total、1 466 killed、74.3% 均为上述
+混合口径表的未验证合计，不能据此量化当前测试有效性。存活变异也不自动等于真实缺陷；
+是否等价必须逐项提供证据。
 
+> **历史原文，已撤回其测量与等价性结论（2026-09-07）**：
 > **2026-09-05 更新（v1.29.2 热修）**：`ast_diff.py` 完成场景化加固——
 > 新增 `tests/unit/test_ast_diff_scenarios.py`（65 个场景测试，断言对齐真实语义），
 > 存活变异 238 → 64、杀死率 59.0% → 84.8%。同轮修复了测量脚本
@@ -40,7 +49,7 @@ the suite tests *conformance* (does code match spec?), not *value* (is the spec 
 
 ---
 
-## Interpretation per module
+## Interpretation per module（六月历史记录，非当前验证结论）
 
 ### `ast_diff.py` — 238 surviving / 59.0%
 
@@ -81,7 +90,9 @@ per test line in the targeted set.
 
 ---
 
-## Mutation score emoji legend (from mutmut progress output)
+## Mutation score emoji legend（历史记录，不用于统计）
+
+图标含义随版本变化；以下保留原文。报告必须按对应版本的元数据状态解释，不按图标或源码计数。
 
 - 🎉 = killed (test caught the bug)
 - 🫥 = survived (test missed the bug) — THE NUMBER
@@ -104,6 +115,9 @@ would likely reveal additional survivors.
 
 ## How to re-run
 
+以下命令是未来复测入口，本轮未执行长变异任务。`toon_encoder` 已删除，历史命令不可
+直接作为当前复跑任务；应先核对源文件及测试选择。
+
 ```bash
 # Per-module run (see scripts/run_mutation_baseline.py):
 uv run python scripts/run_mutation_baseline.py ast_diff
@@ -116,11 +130,33 @@ uv run python scripts/run_mutation_baseline.py toon_encoder
 # .github/workflows/mutation-baseline.yml (manual trigger / on-label)
 ```
 
+### 可信复测与轻量读取要求
+
+1. 保存前后 source revision、测试 revision、精确源文件和测试选择、mutmut/Python 版本、
+   完整配置与命令、退出码及原始元数据。前后必须采用相同源范围、相同测试选择和统计规则；
+   若测试内容是被评估的变量，应记录其差异。若源代码或变异集合变化，先建立可比集合或重建基线，
+   不直接比较总存活数来宣称改善。
+2. 使用 mutmut 完整元数据中的全部 mutant key（包括类方法）逐项统计全部状态。
+   单列 killed、survived、no tests、not checked、timeout、skipped、suspicious、
+   interrupted、segfault、type-check caught 及未知状态；不能把非 survived 状态都算 killed。
+   明确分母和 killed 的定义，核对全状态之和与完整变异集合；未知、缺失、未完成结果必须披露。
+3. `run` 和结果读取均成功只是必要条件，不证明元数据完整、缓存新鲜或成绩达标。
+   使用隔离的运行目录保留每次证据，不把旧缓存混入新测试选择的成绩。
+4. 本机 2026-09-07 查验为 **mutmut 3.7.0**，`uv run mutmut results --help` 显示
+   `--all BOOLEAN`。其实现从 `SourceFileMutationData.exit_code_by_key` 读取状态，默认隐藏 killed。
+   在已有完整缓存、且配置与生成缓存时一致的隔离运行目录中，可轻量执行
+   `uv run mutmut results --all true` 查看所有已记录状态；该命令不启动变异测试。
+   runner 恢复原 `pyproject.toml` 后不能假定其配置仍与该次运行一致。
+5. 本工作区没有 `mutants/`，未获得可核验的历史元数据；上述方法只验证了本机版本的
+   CLI 及实现，不保证 3.6.0 或未来版本兼容。空输出不等于零变异，已有输出也不证明没有遗漏。
+   本轮不发布任何替代成绩。
+
 ---
 
 ## Phase-2 plan (separate PR)
 
-Once the ratchet is configured, a PR may not lower any module's mutation score.
+可信基线重建之前，不启用基于上述未验证分数的达标或退化判断。
+Once the ratchet is configured with a verified baseline, a PR may not lower any module's mutation score.
 Surviving mutants are triaged: kill (add the missing assertion) or annotate
 (equivalent mutant, document why behavior-preserving). The `query_symbol_search.py`
 score (37.2%) and `toon_encoder.py` score (30.4%) are the highest-priority targets.

--- a/tests/unit/test_index_snapshot_manifest.py
+++ b/tests/unit/test_index_snapshot_manifest.py
@@ -404,7 +404,12 @@ def test_manifest_boundary_delegates_connection_and_deadline(monkeypatch) -> Non
     assert observed == [(connection, 7.5)]
 
 
-def test_manifest_writer_uses_portable_source_certifier(tmp_path, monkeypatch) -> None:
+@pytest.mark.parametrize(
+    "failure_reason", [None, "SOURCE_SCAN_DEADLINE", "SOURCE_SCOPE_UNSAFE:hash_unclean"]
+)
+def test_manifest_writer_uses_portable_source_certifier(
+    tmp_path, monkeypatch, failure_reason
+) -> None:
     # PR #1254 review 3769193895: Windows-built indexes must stamp authority.
     from types import SimpleNamespace
 
@@ -439,9 +444,28 @@ def test_manifest_writer_uses_portable_source_certifier(tmp_path, monkeypatch) -
         "capture_portable_source_snapshot",
         lambda root, scope, *, deadline: (
             observed.append((root, scope))
-            or SimpleNamespace(state="exact", rows=expected_rows)
+            or SimpleNamespace(
+                state="unknown" if failure_reason else "exact",
+                rows=expected_rows,
+                reason=failure_reason,
+            )
         ),
     )
+
+    if failure_reason:
+        # #1364：即使行集相同，失败的捕获也不得盖戳或隐藏地续借一次预算。
+        with pytest.raises(sqlite3.OperationalError, match="SOURCE_CHANGED"):
+            schema.stamp_full_index_manifest(conn, str(tmp_path))
+        assert len(observed) == 1
+        assert (
+            conn.execute("SELECT COUNT(*) FROM ast_index_snapshot_manifest").fetchone()[
+                0
+            ]
+            == 0
+        )
+        assert not conn.in_transaction
+        conn.close()
+        return
 
     schema.stamp_full_index_manifest(conn, str(tmp_path))
 

--- a/tests/unit/test_index_snapshot_schema.py
+++ b/tests/unit/test_index_snapshot_schema.py
@@ -468,12 +468,16 @@ def test_unsupported_table_xinfo_metadata_fails_closed(row: tuple[object, ...]) 
 
 
 class TestFingerprintDeadlineConfig:
-    """#1364：满载 CI 上的瞬时遍历卡顿不应被误判为「源被篡改」。
+    """#1364：可配置扫描预算必须保持有限，超时不放行认证。"""
 
-    修复提供两道保险：截止时间可用环境变量调高（本组测试锁定旋钮语义），
-    以及 SOURCE_SCAN_DEADLINE 的 unknown 结果自动重试一次（集成层由
-    test_incremental_scope_change_prunes_newly_excluded_rows 覆盖）。
-    """
+    @pytest.mark.parametrize("value", ["inf", "-inf", "nan", "1e999"])
+    def test_非有限预算回退默认(self, monkeypatch, value):
+        from tree_sitter_analyzer.index_snapshot_schema import (
+            _fingerprint_deadline_seconds,
+        )
+
+        monkeypatch.setenv("TSA_FINGERPRINT_DEADLINE_SECONDS", value)
+        assert _fingerprint_deadline_seconds() == 5.0
 
     def test_环境变量覆盖生效且有下限(self, monkeypatch):
         from tree_sitter_analyzer.index_snapshot_schema import (

--- a/tests/unit/test_index_source_stream.py
+++ b/tests/unit/test_index_source_stream.py
@@ -446,15 +446,9 @@ def test_in_place_rewrite_with_restored_mtime_is_unsafe(tmp_path, monkeypatch):
 
 
 class TestStaleSnapshotRecovery:
-    """#1364/#1373 家族:极新文件元数据沉降导致的「快照过期≠篡改」。
+    """#1364/#1373：后续路径稳定不能洗白一次读取的一致性检查失败。"""
 
-    walker 的 lstat 快照(size/mtime_ns)与读后 fstat 之间,新写入文件的
-    元数据可能仍在沉降——旧实现直接判 unclean,满载 windows 轴反复
-    误报 SOURCE_SCOPE_UNSAFE。修复:终检不洁时重取一次 lstat,与读后
-    状态一致则判 clean;真篡改(读取中途被改)重取仍不一致,维持 unsafe。
-    """
-
-    def test_过期快照_重取一致后判clean(self, tmp_path):
+    def test_读取不一致时不能用后续路径比较恢复clean(self, tmp_path):
         from tree_sitter_analyzer.index_source_stream import hash_source_at
         from tree_sitter_analyzer.portable_source_snapshot import _marker
 
@@ -467,8 +461,7 @@ class TestStaleSnapshotRecovery:
 
         def first_dirty_then_clean(a, b):
             calls.append(1)
-            # 第一次(walker 旧快照 vs after)不洁;重取(refreshed vs after)一致
-            # (ctime 未变由真实文件保证——测试只写了一次)
+            # 只有读取绑定的第一次比较有意义；后续路径比较不能证明摘要有效。
             return len(calls) > 1
 
         _marker_fn, digest, clean = hash_source_at(
@@ -481,9 +474,43 @@ class TestStaleSnapshotRecovery:
             _marker,
             first_dirty_then_clean,
         )
-        assert clean is True
-        assert digest != "<unsafe>"
-        assert len(calls) == 2  # 恢复分支确实重取并二次比对
+        assert clean is False
+        assert digest == "<unsafe>"
+        assert len(calls) == 1
+
+    @requires_posix_fd
+    def test_dir_fd读取不能退回当前目录的同名文件(self, tmp_path, monkeypatch):
+        # #1364：相对名称绑定目录描述符，不得以工作目录中的同名路径替换证据。
+        import tree_sitter_analyzer.index_source_stream as stream
+
+        project = tmp_path / "project"
+        project.mkdir()
+        target = project / "sample.py"
+        target.write_text("value = 1\n", encoding="utf-8")
+        (tmp_path / "sample.py").write_text("unrelated = 2\n", encoding="utf-8")
+        monkeypatch.chdir(tmp_path)
+        before = target.stat()
+        fd = os.open(project, os.O_RDONLY)
+        try:
+            with monkeypatch.context() as context:
+                context.setattr(
+                    stream.os,
+                    "lstat",
+                    lambda *_args, **_kwargs: pytest.fail("读取证据不得退回路径重查"),
+                )
+                _, digest, clean = stream.hash_source_at(
+                    fd,
+                    "sample.py",
+                    before,
+                    float("inf"),
+                    {"input": 0, "output": 0},
+                    100,
+                    lambda info: str(info.st_ino),
+                    lambda *_args: False,
+                )
+        finally:
+            os.close(fd)
+        assert (digest, clean) == ("<unsafe>", False)
 
     def test_持续不一致_维持unsafe(self, tmp_path):
         from tree_sitter_analyzer.index_source_stream import hash_source_at

--- a/tests/unit/test_portable_source_snapshot.py
+++ b/tests/unit/test_portable_source_snapshot.py
@@ -392,8 +392,8 @@ def test_capture_portable_source_snapshot_rejects_changed_inventory(
 ) -> None:
     first = frozenset({("first.py", "digest", "python")})
     second = frozenset({("second.py", "digest", "python")})
-    # #1364 起捕获层对 UNSAFE 整体重试一次——供料需覆盖两轮四走
-    inventories = iter(((first, False), (second, False)) * 2)
+    # #1364：已经观察到源不一致，不能用后续恰好一致的扫描替换该证据。
+    inventories = iter(((first, None), (second, None), (first, None), (first, None)))
     monkeypatch.setattr(
         portable, "_portable_inventory", lambda *_args: next(inventories)
     )
@@ -402,13 +402,32 @@ def test_capture_portable_source_snapshot_rejects_changed_inventory(
         str(tmp_path), make_source_scope_descriptor(), deadline=float("inf")
     )
 
-    # 两次尝试都双走不一致 → 仍如实返回 unsafe(重试不掩盖真实不稳定)
-    # #1364/#1373 起 reason 携带首个触发的检查名,锚定前缀
     assert (result.rows, result.state) == (first, "unsafe")
-    assert result.reason.startswith("SOURCE_SCOPE_UNSAFE")
+    assert result.reason == "SOURCE_SCOPE_UNSAFE:walk_mismatch"
     assert result.fingerprint is not None
     assert result.generation == "idxsrc-v3:" + result.fingerprint.removeprefix(
         "sha256:"
+    )
+
+
+def test_capture_deadline_failure_does_not_restart_expired_budget(
+    tmp_path, monkeypatch
+):
+    # #1364：调用者的截止时间是整次捕获的上限，不得隐藏超时后重试。
+    calls = []
+
+    def timed_out(*_args):
+        calls.append(1)
+        raise TimeoutError
+
+    monkeypatch.setattr(portable, "_portable_inventory", timed_out)
+    result = portable.capture_portable_source_snapshot(
+        str(tmp_path), make_source_scope_descriptor(), deadline=0.0
+    )
+    assert (result.state, result.reason, calls) == (
+        "unknown",
+        "SOURCE_SCAN_DEADLINE",
+        [1],
     )
 
 

--- a/tests/unit/test_run_mutation_baseline.py
+++ b/tests/unit/test_run_mutation_baseline.py
@@ -2,10 +2,78 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 
 from scripts import run_mutation_baseline
+
+
+@pytest.mark.parametrize("failed_step", ["run", "results"])
+@pytest.mark.parametrize("returncode", [1, 7, -15])
+def test_main_propagates_mutmut_failure_and_restores_pyproject(
+    monkeypatch, tmp_path: Path, failed_step: str, returncode: int
+) -> None:
+    # 2026-09-07：外部变异命令失败曾被吞掉，入口必须失败且恢复原配置。
+    real_pyproject = tmp_path / "pyproject.toml"
+    original = b"[project]\r\nname = 'sample'\r\n"
+    real_pyproject.write_bytes(original)
+    monkeypatch.setattr(
+        run_mutation_baseline, "__file__", tmp_path / "scripts/runner.py"
+    )
+    monkeypatch.setattr(run_mutation_baseline.sys, "argv", ["runner", "ast_diff"])
+    monkeypatch.setattr(
+        run_mutation_baseline, "_resolve_mutmut_command", lambda: ["mutmut"]
+    )
+
+    def fake_run(cmd, **kwargs):
+        assert kwargs["cwd"] == tmp_path
+        assert "[tool.mutmut]" in real_pyproject.read_text(encoding="utf-8")
+        return subprocess.CompletedProcess(
+            cmd, returncode if cmd[-1] == failed_step else 0
+        )
+
+    mocked_run = Mock(side_effect=fake_run)
+    monkeypatch.setattr(run_mutation_baseline.subprocess, "run", mocked_run)
+
+    with pytest.raises(subprocess.CalledProcessError) as exc:
+        run_mutation_baseline.main()
+
+    assert exc.value.returncode == returncode
+    assert exc.value.cmd == ["mutmut", failed_step]
+    assert [call.args[0] for call in mocked_run.call_args_list] == (
+        [["mutmut", "run"]]
+        if failed_step == "run"
+        else [["mutmut", "run"], ["mutmut", "results"]]
+    )
+    assert real_pyproject.read_bytes() == original
+
+
+@pytest.mark.parametrize("failed_step", ["run", "results"])
+def test_run_module_restores_pyproject_when_process_cannot_start(
+    monkeypatch, tmp_path: Path, failed_step: str
+) -> None:
+    # 2026-09-07：进程启动异常也必须透传，不能遗留临时配置。
+    real_pyproject = tmp_path / "pyproject.toml"
+    original = b"[project]\nname = 'sample'\n"
+    real_pyproject.write_bytes(original)
+    monkeypatch.setattr(
+        run_mutation_baseline, "_resolve_mutmut_command", lambda: ["mutmut"]
+    )
+    error = OSError("cannot start mutmut")
+
+    def fake_run(cmd, **kwargs):
+        if cmd[-1] == failed_step:
+            raise error
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(run_mutation_baseline.subprocess, "run", fake_run)
+
+    with pytest.raises(OSError) as exc:
+        run_mutation_baseline.run_module("ast_diff", tmp_path)
+
+    assert exc.value is error
+    assert real_pyproject.read_bytes() == original
 
 
 def test_run_module_does_not_invoke_uv_while_pyproject_is_swapped(

--- a/tree_sitter_analyzer/index_snapshot_schema.py
+++ b/tree_sitter_analyzer/index_snapshot_schema.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import math
 import os
 import re
 import sqlite3
@@ -94,9 +95,7 @@ _REQUIRED_COLUMNS = {
     ),
 }
 _FINGERPRINT_DEADLINE_SECONDS = 5.0
-# 满载 CI（多个 xdist worker 抢核 + Windows Defender 对新文件实时扫描）上，
-# 即使小型项目的目录遍历也可能瞬时卡过 5 秒；允许环境调高，重试见
-# _capture_source_with_retry。慢机器与数据真变必须区分，否则 #1364 复现。
+# 单次便携式扫描允许配置有限预算；超时不等同于源变化，也不能放行认证。
 _FINGERPRINT_DEADLINE_ENV = "TSA_FINGERPRINT_DEADLINE_SECONDS"
 
 
@@ -109,9 +108,12 @@ def _fingerprint_deadline_seconds() -> float:
     if not raw:
         return _FINGERPRINT_DEADLINE_SECONDS
     try:
-        return max(1.0, float(raw))
+        value = float(raw)
     except ValueError:
         return _FINGERPRINT_DEADLINE_SECONDS
+    if not math.isfinite(value):
+        return _FINGERPRINT_DEADLINE_SECONDS
+    return max(1.0, value)
 
 
 _FINGERPRINT_ROW_BUDGET = 2_000_000
@@ -197,28 +199,11 @@ def stamp_full_index_manifest(
         else:
             from .portable_source_snapshot import capture_portable_source_snapshot
 
-            # 慢机瞬卡重试一次（#1364）：仅对 SOURCE_SCAN_DEADLINE 的 unknown
-            # 结果重试；真实的数据变化/不可读 scope 不重试，语义不变。
-            current = None
-            for attempt in (1, 2):
-                current = capture_portable_source_snapshot(
-                    root,
-                    scope,
-                    deadline=time.monotonic() + _fingerprint_deadline_seconds(),
-                )
-                if current.state == "exact":
-                    break
-                # 瞬态失败重试一次(#1364):满载 CI 上目录遍历的超时与双走
-                # 不一致(UNSAFE)都是机器负载抖动;真实源变化/不可读不重试
-                if (
-                    getattr(current, "reason", None)
-                    in ("SOURCE_SCAN_DEADLINE", "SOURCE_SCOPE_UNSAFE")
-                    and attempt == 1
-                ):
-                    continue
-                break
-        # for 循环体至少执行一次,mypy 无法静态证明,此处显式断言
-        assert current is not None
+            current = capture_portable_source_snapshot(
+                root,
+                scope,
+                deadline=time.monotonic() + _fingerprint_deadline_seconds(),
+            )
         if current.state != "exact" or current.rows != recorded:
             # 携带具体原因(#1364 诊断):区分超时/不安全/行不一致三种死法
             raise sqlite3.OperationalError(

--- a/tree_sitter_analyzer/index_source_stream.py
+++ b/tree_sitter_analyzer/index_source_stream.py
@@ -67,27 +67,8 @@ def hash_source_at(
     finally:
         os.close(fd)
     clean = same_file_metadata(before, after)
-    if not clean:
-        # #1364/#1373 家族终章（诊断实锤 SOURCE_SCOPE_UNSAFE:hash_unclean）：
-        # Windows 上同一未动文件的句柄缓存与路径缓存可返回不同 mtime_ns，
-        # 「重取 lstat 对比读后 fstat」在缓存分裂面前永远对不上。改为
-        # 「安静判定」：间隔 20ms 连续两次新鲜 lstat 互相全等，且 ctime
-        # 相对 walker 快照未变 → 文件已安静，判 clean。防篡改不降级：
-        # POSIX 原地重写必动 ctime；Windows 的 ctime=创建时间不随写变化，
-        # 但重写使内容摘要改变，认证层的行比对（rows != recorded）仍会
-        # 拦截——纵深防御保留。
-        for _ in range(3):
-            time.sleep(0.02)
-            try:
-                r1 = os.lstat(name)
-                r2 = os.lstat(name)
-            except OSError:
-                break  # 无法重取时维持原判定
-            if same_file_metadata(r1, r2) and int(r1.st_ctime_ns) == int(
-                before.st_ctime_ns
-            ):
-                clean = True
-                break
+    # 摘要只对本次已打开的文件成立；读取绑定失败后，后续路径 stat 相等
+    # 不能证明已读字节来自同一版本，也不能替代目录描述符绑定的路径。
     return (
         metadata_marker(after),
         digest.hexdigest() if clean else "<unsafe>",

--- a/tree_sitter_analyzer/portable_source_snapshot.py
+++ b/tree_sitter_analyzer/portable_source_snapshot.py
@@ -174,46 +174,28 @@ def capture_portable_source_snapshot(
     *,
     deadline: float,
 ) -> CurrentSourceSnapshot:
-    """Capture two equal bounded inventories on Windows/pathname-only hosts."""
+    """在调用者给定的总期限内双次扫描；不一致与超时均拒绝认证。"""
     root = os.path.abspath(project_root)
-    # #1364：满载 CI（多 worker 抢核 + Defender 实时扫描）上,双走不一致
-    # (UNSAFE)与超时一样是机器抖动而非数据真变——整体重试一次;真实
-    # 不稳定 scope 第二次仍会失败,语义不变。重试也顺带覆盖超时分支。
-    for attempt in (1, 2):
-        try:
-            first, unsafe_first = _portable_inventory(root, source_scope, deadline)
-            second, unsafe_second = _portable_inventory(root, source_scope, deadline)
-            fingerprint = inventory_fingerprint(first, deadline=deadline)
-        except TimeoutError:
-            if attempt == 1:
-                continue
-            return CurrentSourceSnapshot(
-                frozenset(), None, None, "unknown", "SOURCE_SCAN_DEADLINE"
-            )
-        except OverflowError:
-            return CurrentSourceSnapshot(
-                frozenset(), None, None, "unknown", "SOURCE_SCOPE_UNBOUNDED"
-            )
-        except OSError:
-            return CurrentSourceSnapshot(
-                frozenset(), None, None, "unknown", "SOURCE_SCOPE_UNREADABLE"
-            )
-        generation = "idxsrc-v3:" + fingerprint.removeprefix("sha256:")
-        if unsafe_first or unsafe_second or first != second:
-            if attempt == 1:
-                continue
-            # 诊断细节随行(#1364/#1373):指出首个触发的安全检查名;
-            # 双走不一致时优先报 walk_mismatch。既有断言以
-            # SOURCE_SCOPE_UNSAFE 开头匹配的不受影响。
-            detail = unsafe_first or unsafe_second or "walk_mismatch"
-            return CurrentSourceSnapshot(
-                first,
-                fingerprint,
-                generation,
-                "unsafe",
-                f"SOURCE_SCOPE_UNSAFE:{detail}",
-            )
-        return CurrentSourceSnapshot(first, fingerprint, generation, "exact", None)
-    return CurrentSourceSnapshot(
-        frozenset(), None, None, "unknown", "SOURCE_SCAN_DEADLINE"
-    )
+    try:
+        first, unsafe_first = _portable_inventory(root, source_scope, deadline)
+        second, unsafe_second = _portable_inventory(root, source_scope, deadline)
+        fingerprint = inventory_fingerprint(first, deadline=deadline)
+    except TimeoutError:
+        return CurrentSourceSnapshot(
+            frozenset(), None, None, "unknown", "SOURCE_SCAN_DEADLINE"
+        )
+    except OverflowError:
+        return CurrentSourceSnapshot(
+            frozenset(), None, None, "unknown", "SOURCE_SCOPE_UNBOUNDED"
+        )
+    except OSError:
+        return CurrentSourceSnapshot(
+            frozenset(), None, None, "unknown", "SOURCE_SCOPE_UNREADABLE"
+        )
+    generation = "idxsrc-v3:" + fingerprint.removeprefix("sha256:")
+    if unsafe_first or unsafe_second or first != second:
+        detail = unsafe_first or unsafe_second or "walk_mismatch"
+        return CurrentSourceSnapshot(
+            first, fingerprint, generation, "unsafe", f"SOURCE_SCOPE_UNSAFE:{detail}"
+        )
+    return CurrentSourceSnapshot(first, fingerprint, generation, "exact", None)


### PR DESCRIPTION
## Summary
- Keep source hashes bound to the opened descriptor; remove recovery based on later pathname stat equality, including the dir_fd/cwd fallback.
- Reject inconsistent portable inventories and expired scans without hidden retries or renewed budgets; reject non-finite configured deadline values.
- Propagate failures from both mutmut run and results while restoring pyproject.toml in finally.
- Preserve published mutation tables as historical evidence, explicitly retract unverified September scores and target-completion claims, and document requirements for trustworthy remeasurement.

## Commits
- 339e0860: fail-closed source certification and focused regressions.
- 2851b611: mutation-runner failure propagation, regression tests, and evidence corrections.

## Verification
- TSA-reported six-file verification: 147 passed.
- Focused tests including index status certification, with --cov=tree_sitter_analyzer --cov-report=json: 162 passed after committing.
- uv run python scripts/check_patch_coverage.py --base origin/develop --coverage-json coverage.json: passed, no added executable misses.
- uv run pytest -q: 2004 passed, 28 skipped in 27.71 seconds after committing; default four xdist workers retained.
- All applicable pre-commit hooks passed, including Ruff, mypy, secret detection, Bandit, assertion/encoding ratchets and codemap synchronization.
- git diff origin/develop...HEAD --check: passed.
- Two explicitly selected GPT-5.3-Codex-Spark workers handled bounded lint/format work and read-only mutation evidence review; lead reviewed source-certification changes and ran integration gates.

## Risks And Limits
- Removing settle/retry recovery intentionally favors rejecting uncertain certification over accepting potentially inconsistent data. Windows stat discrepancies may now surface as certification failures; Windows-host behavior still needs CI verification.
- Local verification ran on macOS with Python 3.12.13. Portable-path mocks do not substitute for real Windows qualification.
- No long mutation run was performed and no complete historical mutant metadata was available. This PR does not claim new mutation scores or proven test-effectiveness targets.
- No version bump, release, public CLI/tool-surface change, or unrelated storage-maintenance refactor. Existing local VALUE_AUDIT.md is excluded.

Related: #1364, #1373. Supersedes the unsafe settle-recovery behavior introduced by #1380.