### PR TITLE
fix(security): reject Windows rooted paths on non-Windows hosts

### DIFF
--- a/tests/unit/security/test_validator.py
+++ b/tests/unit/security/test_validator.py
@@ -370,6 +370,37 @@ class TestIsSafePath:
 class TestValidateWindowsDriveLetter:
     """测试 _validate_windows_drive_letter 方法"""
 
+    @pytest.mark.parametrize("host", ["Linux", "Darwin"])
+    @pytest.mark.parametrize(
+        "path",
+        [
+            r"\rooted\file.txt",
+            r"\\server\share\file.txt",
+            r"\\?\C:\file.txt",
+            r"\\.\pipe\name",
+        ],
+    )
+    def test_foreign_rooted_path_is_rejected_before_boundary(
+        self, tmp_path, monkeypatch, host, path
+    ):
+        # 2026-09-07：项目根等于 cwd 时，UNC 不能被 POSIX 当成合法相对名称。
+        monkeypatch.chdir(tmp_path)
+        validator = SecurityValidator(str(tmp_path))
+        with patch("platform.system", return_value=host):
+            valid, error = validator.validate_file_path(path)
+        assert valid is False
+        assert error == f"Windows rooted paths are not allowed on {host} system"
+        assert path not in error
+
+    @pytest.mark.parametrize("path", [r"\rooted\file.txt", r"\\server\share\file.txt"])
+    def test_windows_rooted_path_reaches_existing_boundary(self, path):
+        # 本次只修跨平台语法，Windows 自身仍由既有目录边界裁决。
+        with patch("platform.system", return_value="Windows"):
+            assert SecurityValidator()._validate_windows_drive_letter(path) == (
+                True,
+                "",
+            )
+
     def test_validate_windows_drive_letter_on_windows(self):
         """测试Windows系统上的驱动器字母"""
         validator = SecurityValidator()

--- a/tree_sitter_analyzer/security/validator.py
+++ b/tree_sitter_analyzer/security/validator.py
@@ -136,7 +136,7 @@ class SecurityValidator:
                 log_warning(f"Null byte detected in file path: {file_path}")
                 return False, "File path contains null bytes"
 
-            # Layer 3: Windows drive letter check (only on non-Windows systems)
+            # 第三层：非 Windows 平台拒绝盘符、UNC 和设备等根路径语法。
             is_valid, error = self._validate_windows_drive_letter(file_path)
             if not is_valid:
                 return False, error
@@ -463,25 +463,16 @@ class SecurityValidator:
         return False
 
     def _validate_windows_drive_letter(self, file_path: str) -> tuple[bool, str]:
-        """
-        Validate Windows drive letter on non-Windows systems.
-
-        Args:
-            file_path: File path to validate
-
-        Returns:
-            Tuple of (is_valid, error_message)
-        """
+        """非 Windows 平台拒绝外来根路径语法，避免将 UNC 当作项目内相对名称。"""
         import platform
 
-        if (
-            len(file_path) > 1
-            and file_path[1] == ":"
-            and platform.system() != "Windows"
-        ):
+        host = platform.system()
+        if host != "Windows" and file_path.startswith("\\"):
+            return False, f"Windows rooted paths are not allowed on {host} system"
+        if len(file_path) > 1 and file_path[1] == ":" and host != "Windows":
             return (
                 False,
-                f"Windows drive letters are not allowed on {platform.system()} system",
+                f"Windows drive letters are not allowed on {host} system",
             )
 
         return True, ""


### PR DESCRIPTION
## Summary
- Reject Windows rooted, UNC and device-path syntax on non-Windows platforms before project-boundary normalization can reinterpret it as a relative filename.
- Preserve Windows handling and existing project-root canonicalization/boundary checks.
- This is a standalone security change, explicitly approved after TSA reported high downstream risk.

## Evidence
- Reproduced SecurityValidator(os.getcwd()).validate_file_path(UNC_input) returning true on macOS.
- Eight public-path regression cases failed before the fix and pass afterward; Windows syntax-stage delegation remains unchanged.
- Full unit/security suite with coverage: 274 passed.
- TSA reported verification: 321 passed, 1 existing skip.
- Quick gate: 2016 passed, 28 skipped.
- Patch coverage: no added executable misses. No hook or security gate bypass.

## Scope
No claim of observed data exfiltration. This fixes inconsistent cross-platform path classification exposed during PR #1352 full-suite verification. No API signature, project-root canonicalization, release or unrelated refactor.