### PR TITLE
fix(index): hotfix — 8 extraction defects across Python, C++, Kotlin, Java (extractor_version 14→17)

### DIFF
--- a/tests/unit/test_cpp_function_extraction.py
+++ b/tests/unit/test_cpp_function_extraction.py
@@ -1,0 +1,95 @@
+"""Regression tests: C++ function_definition nodes must be indexed.
+
+BUG: extraction.py gated _c_function_def_name() to language=="c" only.
+C++ shares the identical grammar shape (function_definition carries the
+identifier inside function_declarator, not in a "name" field), so all
+C++ free functions and class methods were absent from ast_symbol_rows.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import tree_sitter_cpp
+from tree_sitter import Language, Parser
+
+from tree_sitter_analyzer.ast_cache import ASTCache
+from tree_sitter_analyzer.cache.extraction import _extract_symbols
+
+_CPP_PARSER = Parser(Language(tree_sitter_cpp.language()))
+
+
+def _symbols(source: str) -> list[dict]:
+    tree = _CPP_PARSER.parse(source.encode("utf-8"))
+    return _extract_symbols(tree, source, "cpp")["symbols"]
+
+
+CPP_SRC = """\
+#include <iostream>
+
+int add(int a, int b) {
+    return a + b;
+}
+
+double multiply(double x, double y) {
+    return x * y;
+}
+
+class Calculator {
+public:
+    Calculator() {}
+    int compute(int n) { return n * 2; }
+    static int zero() { return 0; }
+};
+
+void free_func() {}
+"""
+
+
+def test_cpp_free_functions_are_indexed() -> None:
+    """Free C++ functions must produce function symbols."""
+    symbols = _symbols(CPP_SRC)
+    names = {s["name"] for s in symbols if s.get("kind") == "function"}
+    assert "add" in names, f"add missing from cpp symbols: {names}"
+    assert "multiply" in names, f"multiply missing: {names}"
+    assert "free_func" in names, f"free_func missing: {names}"
+
+
+def test_cpp_class_methods_are_indexed() -> None:
+    """C++ class methods must be indexed with kind=method."""
+    symbols = _symbols(CPP_SRC)
+    methods = {s["name"] for s in symbols if s.get("kind") == "method"}
+    assert "compute" in methods, f"compute missing from cpp methods: {methods}"
+    assert "zero" in methods, f"zero missing: {methods}"
+
+
+def test_cpp_function_line_numbers_correct() -> None:
+    """Line numbers of C++ functions must match source."""
+    symbols = _symbols(CPP_SRC)
+    by_name = {s["name"]: s for s in symbols}
+    assert by_name["add"]["line"] == 3, f"add line={by_name['add']['line']}"
+    assert by_name["multiply"]["line"] == 7
+
+
+def test_cpp_symbols_reach_sqlite(tmp_path) -> None:
+    """C++ functions and methods must persist into ast_symbol_rows."""
+    (tmp_path / "calc.cpp").write_text(CPP_SRC, encoding="utf-8")
+    cache = ASTCache(str(tmp_path))
+    cache.index_project()
+
+    con = sqlite3.connect(str(tmp_path / ".ast-cache" / "index.db"))
+    try:
+        rows = con.execute(
+            "SELECT kind, name FROM ast_symbol_rows WHERE language='cpp' ORDER BY kind, name"
+        ).fetchall()
+        names_by_kind = {}
+        for kind, name in rows:
+            names_by_kind.setdefault(kind, set()).add(name)
+
+        assert "function" in names_by_kind, f"no functions in cpp index: {rows}"
+        assert "add" in names_by_kind["function"]
+        assert "multiply" in names_by_kind["function"]
+        assert "method" in names_by_kind, f"no methods in cpp index: {rows}"
+        assert "compute" in names_by_kind["method"]
+    finally:
+        con.close()

--- a/tests/unit/test_cpp_function_extraction.py
+++ b/tests/unit/test_cpp_function_extraction.py
@@ -93,3 +93,39 @@ def test_cpp_symbols_reach_sqlite(tmp_path) -> None:
         assert "compute" in names_by_kind["method"]
     finally:
         con.close()
+
+
+# ---------------------------------------------------------------------------
+# Kotlin companion object attribution (found during multi-language MECE check)
+# ---------------------------------------------------------------------------
+
+
+def test_kotlin_companion_object_members_attributed_to_outer_class() -> None:
+    """Methods inside a companion object must be attributed to the enclosing class."""
+    import tree_sitter_kotlin as _kt
+    from tree_sitter import Language as _Lang
+    from tree_sitter import Parser as _Parser
+
+    from tree_sitter_analyzer.cache.extraction import _extract_symbols as _ex
+
+    src = """\
+class Person(val name: String) {
+    companion object {
+        fun createDefault(): Person = Person("Default")
+    }
+    fun greet() = name
+}
+"""
+    tree = _Parser(_Lang(_kt.language())).parse(src.encode())
+    symbols = _ex(tree, src, "kotlin")["symbols"]
+    by_name = {s["name"]: s for s in symbols}
+
+    create = by_name["createDefault"]
+    assert create["kind"] == "method", f"expected method, got {create['kind']}"
+    assert create["class"] == "Person", (
+        f"expected class=Person, got {create.get('class')}"
+    )
+
+    greet = by_name["greet"]
+    assert greet["kind"] == "method"
+    assert greet["class"] == "Person"

--- a/tests/unit/test_cpp_function_extraction.py
+++ b/tests/unit/test_cpp_function_extraction.py
@@ -129,3 +129,37 @@ class Person(val name: String) {
     greet = by_name["greet"]
     assert greet["kind"] == "method"
     assert greet["class"] == "Person"
+
+
+# ---------------------------------------------------------------------------
+# Java record_declaration (found during multi-language MECE check)
+# ---------------------------------------------------------------------------
+
+
+def test_java_record_methods_attributed_to_record() -> None:
+    """Java 16+ record methods must be classified kind=method, not function."""
+    import tree_sitter_java as _java
+    from tree_sitter import Language as _Lang
+    from tree_sitter import Parser as _Parser
+
+    from tree_sitter_analyzer.cache.extraction import _extract_symbols as _ex
+
+    src = """\
+public record Point(int x, int y) {
+    public double distance() {
+        return Math.sqrt(x * x + y * y);
+    }
+    public static Point origin() {
+        return new Point(0, 0);
+    }
+}
+"""
+    tree = _Parser(_Lang(_java.language())).parse(src.encode())
+    symbols = _ex(tree, src, "java")["symbols"]
+    by_name = {s["name"]: s for s in symbols}
+
+    assert by_name["Point"]["kind"] == "class"
+    assert by_name["distance"]["kind"] == "method"
+    assert by_name["distance"]["class"] == "Point"
+    assert by_name["origin"]["kind"] == "method"
+    assert by_name["origin"]["class"] == "Point"

--- a/tests/unit/test_cpp_method_resolution.py
+++ b/tests/unit/test_cpp_method_resolution.py
@@ -9,8 +9,6 @@ external method tiers, and — MANDATORY — the no-cross-language-mis-wire moat
 
 from __future__ import annotations
 
-import pytest
-
 from tree_sitter_analyzer.ast_cache import ASTCache
 from tree_sitter_analyzer.synapse_resolver import ResolverContext, resolve_callee
 from tree_sitter_analyzer.synapse_resolver._context import build_resolver_context
@@ -622,23 +620,10 @@ class TestRealIndexIntegration:
         else:
             assert (sym, res, f) == (None, "unknown", "")
 
-    @pytest.mark.xfail(
-        reason=(
-            "Known production gap: the shared generic symbol walker "
-            "(_ast_extraction._walk_for_symbols) gates on "
-            "child_by_field_name('name'), which tree-sitter C++ "
-            "function_definition nodes do not expose (the identifier lives "
-            "under function_declarator), so ordinary C++ free functions are "
-            "absent from ast_symbol_rows and the local/single-global tiers "
-            "cannot fire. Root cause lives in the shared extractor, out of "
-            "this resolver's scope; this xfail is the regression target so the "
-            "tier flips to PASS once the walker recovers C++ symbols."
-        ),
-        strict=True,
-    )
     def test_local_free_function_resolves_on_real_index(self, tmp_path) -> None:
-        """When the extractor populates C++ symbols, an unqualified call to a
-        same-file free function (``helper``) must resolve ``local``."""
+        """C++ free functions now reach ast_symbol_rows (extractor v16+, declarator
+        walk extended to cpp), so an unqualified call to a same-file free function
+        (``helper``) resolves ``local``. xfail removed: the production gap is fixed."""
         _root, cpp_ctx = _index_and_build(tmp_path, {"service.cpp": _REAL_CPP})
         _sym, res, f = resolve_cpp_callee("helper", "helper", "service.cpp", cpp_ctx)
         assert res == "local"

--- a/tests/unit/test_incremental_sync.py
+++ b/tests/unit/test_incremental_sync.py
@@ -330,11 +330,11 @@ class TestSavepointRollbackOnPartialWrite:
 
         original_write_imports = cache._write_imports_for_file
 
-        def _fail_after_ast_index(conn, rel_path, language, imports):
+        def _fail_after_ast_index(conn, rel_path, language, imports, symbols=None):
             if "flaky.py" in rel_path:
                 # Simulate failure AFTER ast_index INSERT but BEFORE conn.commit().
                 raise RuntimeError("simulated mid-write failure")
-            return original_write_imports(conn, rel_path, language, imports)
+            return original_write_imports(conn, rel_path, language, imports, symbols)
 
         sync = IncrementalSync(cache)
         with patch.object(
@@ -361,11 +361,11 @@ class TestSavepointRollbackOnPartialWrite:
         original_write_imports = cache._write_imports_for_file
         call_count = {"n": 0}
 
-        def _fail_once(conn, rel_path, language, imports):
+        def _fail_once(conn, rel_path, language, imports, symbols=None):
             if "fragile.py" in rel_path and call_count["n"] == 0:
                 call_count["n"] += 1
                 raise RuntimeError("first attempt fails")
-            return original_write_imports(conn, rel_path, language, imports)
+            return original_write_imports(conn, rel_path, language, imports, symbols)
 
         sync = IncrementalSync(cache)
         with patch.object(cache, "_write_imports_for_file", side_effect=_fail_once):

--- a/tests/unit/test_python_index_extraction_defects.py
+++ b/tests/unit/test_python_index_extraction_defects.py
@@ -1,0 +1,280 @@
+"""Regression tests for four Python index-extraction defects.
+
+Found by dogfooding the project index against a stdlib-``ast`` ground truth
+over all 1930 Python files in this repo:
+
+* BUG-1 ``from __future__ import X`` produced no ``import`` symbol at all
+  (787 occurrences repo-wide) because tree-sitter emits a dedicated
+  ``future_import_statement`` node type that ``_IMPORT_LIKE`` did not list.
+* BUG-2 a function nested inside a *method* was classified ``method`` and
+  attributed to the enclosing class (334 symbols, plus 226 bogus
+  ``contains`` edges) because ``_find_parent_class`` walked past the
+  intervening ``function_definition``.
+* BUG-3 ``ast_imports.line`` was 0 for every one of the 16171 rows because
+  the INSERT omitted the column even though ``ImportEntry.line`` was set.
+* BUG-4 a parenthesised multi-line ``from X import (...)`` carrying a
+  trailing comment lost every bound name (105 occurrences) because the
+  DOTALL regex let ``split("#", 1)[0]`` truncate the body.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+import tree_sitter_python
+from tree_sitter import Language, Parser
+
+from tree_sitter_analyzer.ast_cache import ASTCache
+from tree_sitter_analyzer.cache.extraction import _extract_symbols
+from tree_sitter_analyzer.synapse_resolver import parse_imports
+
+_PY_PARSER = Parser(Language(tree_sitter_python.language()))
+
+
+def _payload(source: str) -> dict:
+    tree = _PY_PARSER.parse(source.encode("utf-8"))
+    return _extract_symbols(tree, source, "python")
+
+
+def _symbols(source: str) -> list[dict]:
+    return _payload(source)["symbols"]
+
+
+def _by_kind(symbols: list[dict], kind: str) -> list[dict]:
+    return [s for s in symbols if s.get("kind") == kind]
+
+
+# ---------------------------------------------------------------------------
+# BUG-1: future_import_statement
+# ---------------------------------------------------------------------------
+
+
+def test_future_import_is_extracted_as_import_symbol() -> None:
+    """``from __future__ import annotations`` must yield an import symbol."""
+    symbols = _symbols("from __future__ import annotations\nimport os\n")
+    texts = [s.get("text", "") for s in _by_kind(symbols, "import")]
+
+    assert any("__future__" in t for t in texts), (
+        f"future import missing from extracted symbols: {texts}"
+    )
+    assert len(texts) == 2, f"expected 2 import symbols, got {texts}"
+
+
+def test_future_import_reaches_imports_json() -> None:
+    """The future import must also land in the imports_json projection."""
+    payload = _payload("from __future__ import annotations\n")
+    imports = [s for s in payload["symbols"] if s.get("kind") == "import"]
+    assert imports, "imports_json projection lost the future import"
+    assert imports[0]["line"] == 1
+
+
+# ---------------------------------------------------------------------------
+# BUG-2: nested function inside a method
+# ---------------------------------------------------------------------------
+
+
+NESTED_SRC = """\
+class Widget:
+    def method_a(self):
+        def inner_helper():
+            return 1
+        return inner_helper
+
+    async def method_b(self):
+        async def inner_async():
+            return 2
+        return inner_async
+
+
+def module_level():
+    def nested_in_function():
+        return 3
+    return nested_in_function
+"""
+
+
+def test_function_nested_in_method_is_not_a_method() -> None:
+    """A def inside a method body is a plain function, not a class member."""
+    symbols = _symbols(NESTED_SRC)
+    by_name = {s["name"]: s for s in symbols if "name" in s}
+
+    for nested in ("inner_helper", "inner_async"):
+        sym = by_name[nested]
+        assert sym["kind"] == "function", (
+            f"{nested} should be a function, got kind={sym['kind']!r} "
+            f"class={sym.get('class')!r}"
+        )
+        assert "class" not in sym, (
+            f"{nested} must not be attributed to a class, got {sym.get('class')!r}"
+        )
+
+
+def test_real_methods_are_still_methods() -> None:
+    """The fix must not regress genuine class members."""
+    symbols = _symbols(NESTED_SRC)
+    by_name = {s["name"]: s for s in symbols if "name" in s}
+
+    for method in ("method_a", "method_b"):
+        assert by_name[method]["kind"] == "method"
+        assert by_name[method]["class"] == "Widget"
+
+
+def test_function_nested_in_function_stays_a_function() -> None:
+    """Control case that already passed — guard against over-correction."""
+    symbols = _symbols(NESTED_SRC)
+    by_name = {s["name"]: s for s in symbols if "name" in s}
+
+    assert by_name["module_level"]["kind"] == "function"
+    assert by_name["nested_in_function"]["kind"] == "function"
+
+
+def test_class_nested_in_method_still_resolves_its_own_members() -> None:
+    """A class defined inside a method still owns its methods."""
+    src = """\
+class Outer:
+    def build(self):
+        class Inner:
+            def inner_method(self):
+                return 1
+        return Inner
+"""
+    symbols = _symbols(src)
+    by_name = {s["name"]: s for s in symbols if "name" in s}
+
+    assert by_name["inner_method"]["kind"] == "method"
+    assert by_name["inner_method"]["class"] == "Inner"
+    assert by_name["build"]["kind"] == "method"
+    assert by_name["build"]["class"] == "Outer"
+
+
+# ---------------------------------------------------------------------------
+# BUG-4: parenthesised multi-line import with a trailing comment
+# ---------------------------------------------------------------------------
+
+
+def test_multiline_import_with_trailing_comment_keeps_all_names() -> None:
+    """A trailing ``# noqa`` must not swallow the imported names."""
+    text = "from typing import (  # noqa: F401\n    Any,\n    Dict,\n)"
+    entries = parse_imports(text, "python", "sample.py", 4)
+
+    names = sorted(e.local_name for e in entries)
+    assert names == ["Any", "Dict"], f"expected Any/Dict, got {names}"
+    assert all(e.module_path == "typing" for e in entries)
+
+
+def test_multiline_import_without_comment_still_works() -> None:
+    """Control case for the comment-stripping change."""
+    text = "from typing import (\n    Any,\n    Dict,\n)"
+    entries = parse_imports(text, "python", "sample.py", 1)
+    assert sorted(e.local_name for e in entries) == ["Any", "Dict"]
+
+
+def test_single_line_trailing_comment_is_still_stripped() -> None:
+    """The original purpose of the ``#`` split must be preserved."""
+    entries = parse_imports(
+        "from os import path  # noqa: F401", "python", "sample.py", 1
+    )
+    assert [e.local_name for e in entries] == ["path"]
+
+
+def test_plain_import_trailing_comment_is_still_stripped() -> None:
+    entries = parse_imports("import os  # noqa: F401", "python", "sample.py", 1)
+    assert [e.local_name for e in entries] == ["os"]
+
+
+def test_multiline_import_with_per_name_comments() -> None:
+    """Comments on individual continuation lines must not drop later names."""
+    text = "from typing import (  # noqa: F401\n    Any,  # anything\n    Dict,\n)"
+    entries = parse_imports(text, "python", "sample.py", 1)
+    assert sorted(e.local_name for e in entries) == ["Any", "Dict"]
+
+
+def test_aliased_multiline_import_with_comment() -> None:
+    text = "from collections import (  # noqa: F401\n    OrderedDict as OD,\n)"
+    entries = parse_imports(text, "python", "sample.py", 1)
+    assert len(entries) == 1
+    assert entries[0].local_name == "OD"
+    assert entries[0].alias_of == "OrderedDict"
+
+
+# ---------------------------------------------------------------------------
+# BUG-3: ast_imports.line persisted end to end
+# ---------------------------------------------------------------------------
+
+
+END_TO_END_SRC = """\
+from __future__ import annotations
+
+import os
+from typing import (  # noqa: F401
+    Any,
+    Dict,
+)
+
+
+class Widget:
+    def method_a(self):
+        def inner_helper():
+            return 1
+        return inner_helper
+"""
+
+
+@pytest.fixture
+def indexed_db(tmp_path):
+    (tmp_path / "sample.py").write_text(END_TO_END_SRC, encoding="utf-8")
+    cache = ASTCache(str(tmp_path))
+    cache.index_project()
+    con = sqlite3.connect(str(tmp_path / ".ast-cache" / "index.db"))
+    try:
+        yield con
+    finally:
+        con.close()
+
+
+def test_ast_imports_line_is_persisted(indexed_db) -> None:
+    """Every ast_imports row must carry the source line it came from."""
+    rows = indexed_db.execute(
+        "SELECT local_name, line FROM ast_imports ORDER BY line, local_name"
+    ).fetchall()
+
+    assert rows, "no import rows were written"
+    zero = [name for name, line in rows if line == 0]
+    assert not zero, f"these imports lost their line number: {zero}"
+
+
+def test_ast_imports_line_values_are_correct(indexed_db) -> None:
+    lines = dict(
+        indexed_db.execute("SELECT local_name, line FROM ast_imports").fetchall()
+    )
+    assert lines["annotations"] == 1
+    assert lines["os"] == 3
+    assert lines["Any"] == 4
+    assert lines["Dict"] == 4
+
+
+def test_end_to_end_symbol_rows_are_correct(indexed_db) -> None:
+    """All four defects, observed through the persisted index."""
+    rows = indexed_db.execute(
+        "SELECT kind, name, line FROM ast_symbol_rows ORDER BY line"
+    ).fetchall()
+    kinds = {(kind, name) for kind, name, _ in rows}
+
+    # BUG-1
+    assert any(kind == "import" and "__future__" in name for kind, name in kinds)
+    # BUG-2
+    assert ("function", "inner_helper") in kinds
+    assert ("method", "inner_helper") not in kinds
+    assert ("method", "method_a") in kinds
+    # BUG-4
+    assert any(kind == "import" and "typing" in name for kind, name in kinds)
+
+
+def test_no_bogus_contains_edge_for_nested_function(indexed_db) -> None:
+    """BUG-2 also produced phantom class->function containment edges."""
+    bogus = indexed_db.execute(
+        "SELECT caller_name, callee_name FROM edges "
+        "WHERE kind='contains' AND callee_name='inner_helper'"
+    ).fetchall()
+    assert not bogus, f"phantom contains edge(s): {bogus}"

--- a/tests/unit/test_symbols_json_enrichment.py
+++ b/tests/unit/test_symbols_json_enrichment.py
@@ -143,8 +143,8 @@ class TestExtractorVersionBump:
         from tree_sitter_analyzer import ast_cache
         from tree_sitter_analyzer.cache import indexer as _ast_cache_indexer
 
-        assert ast_cache._AST_CACHE_EXTRACTOR_VERSION == 15
-        assert _ast_cache_indexer._AST_CACHE_EXTRACTOR_VERSION == 15
+        assert ast_cache._AST_CACHE_EXTRACTOR_VERSION == 16
+        assert _ast_cache_indexer._AST_CACHE_EXTRACTOR_VERSION == 16
 
 
 class TestBashVariableAssignmentScope:

--- a/tests/unit/test_symbols_json_enrichment.py
+++ b/tests/unit/test_symbols_json_enrichment.py
@@ -138,13 +138,13 @@ class TestReturnTypeAndParamsSerialized:
 class TestExtractorVersionBump:
     def test_extractor_version_matches_in_both_sites(self):
         # The two declarations must stay equal (they gate cache staleness).
-        # v14: #1094 — function symbols carry the extractor's canonical
-        # ``complexity``; the bump forces existing rows to re-index.
+        # v15: future imports are indexed and method-nested defs are classified
+        # ``function``; the bump forces existing rows to re-index.
         from tree_sitter_analyzer import ast_cache
         from tree_sitter_analyzer.cache import indexer as _ast_cache_indexer
 
-        assert ast_cache._AST_CACHE_EXTRACTOR_VERSION == 14
-        assert _ast_cache_indexer._AST_CACHE_EXTRACTOR_VERSION == 14
+        assert ast_cache._AST_CACHE_EXTRACTOR_VERSION == 15
+        assert _ast_cache_indexer._AST_CACHE_EXTRACTOR_VERSION == 15
 
 
 class TestBashVariableAssignmentScope:

--- a/tests/unit/test_symbols_json_enrichment.py
+++ b/tests/unit/test_symbols_json_enrichment.py
@@ -143,8 +143,8 @@ class TestExtractorVersionBump:
         from tree_sitter_analyzer import ast_cache
         from tree_sitter_analyzer.cache import indexer as _ast_cache_indexer
 
-        assert ast_cache._AST_CACHE_EXTRACTOR_VERSION == 16
-        assert _ast_cache_indexer._AST_CACHE_EXTRACTOR_VERSION == 16
+        assert ast_cache._AST_CACHE_EXTRACTOR_VERSION == 17
+        assert _ast_cache_indexer._AST_CACHE_EXTRACTOR_VERSION == 17
 
 
 class TestBashVariableAssignmentScope:

--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -92,9 +92,11 @@ logger = logging.getLogger(__name__)
 #      ``function``; both change persisted rows, so re-indexing is required.
 # v16: C++ function_definition nodes recover names via _c_function_def_name;
 #      previously all C++ free functions and methods were absent from the index.
+# v17: Kotlin companion_object members attributed to enclosing class;
+#      Java record_declaration added to _CLASS_LIKE. Both change symbol rows.
 #      MUST stay equal to the copy in ``cache/indexer.py``
 #      (gated by test_extractor_version_matches_in_both_sites).
-_AST_CACHE_EXTRACTOR_VERSION = 16
+_AST_CACHE_EXTRACTOR_VERSION = 17
 
 
 class SchemaIntegrityError(RuntimeError):

--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -90,9 +90,11 @@ logger = logging.getLogger(__name__)
 #      bump forces existing rows to re-index.
 # v15: future imports are indexed and method-nested defs are classified
 #      ``function``; both change persisted rows, so re-indexing is required.
+# v16: C++ function_definition nodes recover names via _c_function_def_name;
+#      previously all C++ free functions and methods were absent from the index.
 #      MUST stay equal to the copy in ``cache/indexer.py``
 #      (gated by test_extractor_version_matches_in_both_sites).
-_AST_CACHE_EXTRACTOR_VERSION = 15
+_AST_CACHE_EXTRACTOR_VERSION = 16
 
 
 class SchemaIntegrityError(RuntimeError):

--- a/tree_sitter_analyzer/ast_cache.py
+++ b/tree_sitter_analyzer/ast_cache.py
@@ -87,9 +87,12 @@ logger = logging.getLogger(__name__)
 #      (``FOO=bar make``) and unwrap subscript only for assignment targets.
 # v14: #1094 / RFC-0019 — function symbols carry the extractor's canonical
 #      ``complexity`` so the cache-backed heatmap matches the extractor; the
-#      bump forces existing rows to re-index. MUST stay equal to the copy in
-#      ``_ast_cache_indexer.py`` (gated by test_extractor_version_matches_in_both_sites).
-_AST_CACHE_EXTRACTOR_VERSION = 14
+#      bump forces existing rows to re-index.
+# v15: future imports are indexed and method-nested defs are classified
+#      ``function``; both change persisted rows, so re-indexing is required.
+#      MUST stay equal to the copy in ``cache/indexer.py``
+#      (gated by test_extractor_version_matches_in_both_sites).
+_AST_CACHE_EXTRACTOR_VERSION = 15
 
 
 class SchemaIntegrityError(RuntimeError):
@@ -304,11 +307,12 @@ class ASTCache:
         rel_path: str,
         language: str,
         imports: list[str] | list[dict[str, Any]],
+        symbols: dict[str, Any] | None = None,
     ) -> None:
         """Refresh ``ast_imports`` rows for ``rel_path``."""
         from .cache import write as _write
 
-        _write.write_imports_for_file(conn, rel_path, language, imports)
+        _write.write_imports_for_file(conn, rel_path, language, imports, symbols)
 
     def _resolve_call_edges_for_file(
         self, conn: sqlite3.Connection, rel_path: str

--- a/tree_sitter_analyzer/cache/extraction.py
+++ b/tree_sitter_analyzer/cache/extraction.py
@@ -765,6 +765,12 @@ def _find_parent_class(node: Any, source: str) -> str | None:
                 name_node = parent.child_by_field_name("name")
                 if name_node:
                     return _node_text(name_node, source)
+                # Kotlin ``companion_object`` is a named body that belongs
+                # to its enclosing class — continue walking so the enclosing
+                # class_declaration can provide the name.
+                if parent.type == "companion_object":
+                    parent = parent.parent
+                    continue
             # An unnamed class-like ancestor (e.g. a Java anonymous class) is
             # still the owner; do not attribute the member to an outer class.
             return None

--- a/tree_sitter_analyzer/cache/extraction.py
+++ b/tree_sitter_analyzer/cache/extraction.py
@@ -981,15 +981,17 @@ def _walk_for_symbols(
         return
     node_type = node.type
     name_node = node.child_by_field_name("name")
-    # C ``function_definition`` nodes carry their identifier under
-    # ``function_declarator`` (no ``name`` field), so recover it explicitly —
-    # otherwise ordinary C free functions never reach ``ast_symbol_rows`` and the
-    # synapse C resolver's project-ownership gate cannot shadow the libc tier.
+    # C and C++ ``function_definition`` nodes carry their identifier under
+    # ``function_declarator`` (no ``name`` field), so recover it explicitly.
+    # The gate was previously limited to ``language == "c"``, which left all
+    # 68+ recoverable C++ functions and methods absent from ast_symbol_rows,
+    # FTS, and symbol search. C++ shares the same declarator grammar shape, so
+    # extending to ``"cpp"`` applies the same walk without any other change.
     func_name: str | None = None
     if node_type in _FUNCTION_LIKE:
         if name_node is not None:
             func_name = _node_text(name_node, source)
-        elif node_type == "function_definition" and language == "c":
+        elif node_type == "function_definition" and language in ("c", "cpp"):
             func_name = _c_function_def_name(node, source)
     if func_name is not None:
         name = func_name

--- a/tree_sitter_analyzer/cache/extraction.py
+++ b/tree_sitter_analyzer/cache/extraction.py
@@ -206,6 +206,10 @@ _IMPORT_LIKE = frozenset(
     {
         "import_statement",
         "import_from_statement",
+        # Python's grammar emits a dedicated node for ``from __future__
+        # import X``; without it the single most common import in a typed
+        # codebase never reached ast_symbol_rows / ast_imports / edges.
+        "future_import_statement",
         "import_declaration",
         "require_statement",
         "use_declaration",
@@ -736,6 +740,16 @@ def _find_parent_class(node: Any, source: str) -> str | None:
     - ``impl_item`` (Rust): exposes the implemented type in the ``type``
       field (e.g. ``Container<T>`` or ``User``), NOT a ``name`` field.
       Strip any generic parameters so ``Container<T>`` → ``"Container"``.
+
+    The walk stops at the first enclosing function-like node: a ``def``
+    nested inside a *method* body is a local function, not a member of the
+    surrounding class. Without this gate such nested defs were recorded as
+    ``kind="method"`` with a bogus ``class`` attribution, which also
+    produced phantom class->function ``contains`` edges.
+
+    ``_CLASS_LIKE`` is tested first so a class declared *inside* a function
+    body still owns its own members (a Python class defined in a method, or a
+    Java anonymous class); only the walk past that class is cut off.
     """
     parent = node.parent
     while parent:
@@ -751,6 +765,11 @@ def _find_parent_class(node: Any, source: str) -> str | None:
                 name_node = parent.child_by_field_name("name")
                 if name_node:
                     return _node_text(name_node, source)
+            # An unnamed class-like ancestor (e.g. a Java anonymous class) is
+            # still the owner; do not attribute the member to an outer class.
+            return None
+        if parent.type in _FUNCTION_LIKE:
+            return None
         parent = parent.parent
     return None
 

--- a/tree_sitter_analyzer/cache/extraction.py
+++ b/tree_sitter_analyzer/cache/extraction.py
@@ -184,6 +184,7 @@ _CLASS_LIKE = frozenset(
         "class_specifier",  # C++
         "type_spec",  # Go
         "annotation_type_declaration",  # Java
+        "record_declaration",  # Java 16+ records — methods/ctors classified as method
         "companion_object",  # Kotlin
         "module",  # Ruby
         "trait_item",  # Rust

--- a/tree_sitter_analyzer/cache/indexer.py
+++ b/tree_sitter_analyzer/cache/indexer.py
@@ -37,7 +37,11 @@ logger = logging.getLogger(__name__)
 # v14: #1094 / RFC-0019 — function symbols now carry the extractor's canonical
 #      ``complexity`` so the cache-backed heatmap matches the extractor instead
 #      of re-deriving the count from the per-arm ``decision_points`` sum.
-_AST_CACHE_EXTRACTOR_VERSION = 14
+# v15: ``from __future__ import X`` is now indexed (dedicated
+#      ``future_import_statement`` node), and a ``def`` nested inside a method
+#      is classified ``function`` rather than ``method``. Both change the
+#      persisted symbol rows, so cached entries must be re-indexed.
+_AST_CACHE_EXTRACTOR_VERSION = 15
 
 
 def check_cache_or_read(
@@ -136,7 +140,7 @@ def parse_and_write(
         if cache.fts5_available
         else []
     )
-    cache._write_imports_for_file(conn, rel_path, language, imports)  # noqa: SLF001
+    cache._write_imports_for_file(conn, rel_path, language, imports, symbols)  # noqa: SLF001
     cache._write_activation_for_file(conn, rel_path, inserted)  # noqa: SLF001
     # CALLS rows live in the unified ``edges`` table (B1.3 — no ast_call_edges).
     # Write the edges first so synapse resolution can UPDATE them in place.
@@ -270,8 +274,10 @@ def insert_index_row(
     )
     call_edges = json.loads(r.get("call_edges_json", "[]"))
     imports_list = json.loads(r.get("imports_json", "[]"))
-    cache._write_imports_for_file(conn, rel_path, r["language"], imports_list)  # noqa: SLF001
     symbols = json.loads(r.get("symbols_json", "{}"))
+    cache._write_imports_for_file(  # noqa: SLF001
+        conn, rel_path, r["language"], imports_list, symbols
+    )
     # CALLS rows live in the unified ``edges`` table (B1.3 — no ast_call_edges).
     # Cross-file / synapse resolution UPDATEs these rows in the post-index pass.
     _write.write_graph_edges_for_file(

--- a/tree_sitter_analyzer/cache/indexer.py
+++ b/tree_sitter_analyzer/cache/indexer.py
@@ -41,7 +41,10 @@ logger = logging.getLogger(__name__)
 #      ``future_import_statement`` node), and a ``def`` nested inside a method
 #      is classified ``function`` rather than ``method``. Both change the
 #      persisted symbol rows, so cached entries must be re-indexed.
-_AST_CACHE_EXTRACTOR_VERSION = 15
+# v16: C++ ``function_definition`` nodes now recover their name via
+#      ``_c_function_def_name`` (same declarator walk as C). Previously all
+#      C++ free functions and methods were absent from ast_symbol_rows.
+_AST_CACHE_EXTRACTOR_VERSION = 16
 
 
 def check_cache_or_read(

--- a/tree_sitter_analyzer/cache/indexer.py
+++ b/tree_sitter_analyzer/cache/indexer.py
@@ -44,7 +44,10 @@ logger = logging.getLogger(__name__)
 # v16: C++ ``function_definition`` nodes now recover their name via
 #      ``_c_function_def_name`` (same declarator walk as C). Previously all
 #      C++ free functions and methods were absent from ast_symbol_rows.
-_AST_CACHE_EXTRACTOR_VERSION = 16
+# v17: Kotlin companion_object members now attributed to their enclosing class;
+#      Java record_declaration added to _CLASS_LIKE so record methods/ctors are
+#      classified method instead of function. Both change persisted symbol rows.
+_AST_CACHE_EXTRACTOR_VERSION = 17
 
 
 def check_cache_or_read(

--- a/tree_sitter_analyzer/cache/write.py
+++ b/tree_sitter_analyzer/cache/write.py
@@ -131,8 +131,8 @@ def _insert_import_entry(
         conn.execute(
             """INSERT INTO ast_imports
                (file_path, language, module_path, local_name,
-                is_relative, is_star, alias_of)
-               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                is_relative, is_star, alias_of, line)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 rel_path,
                 language,
@@ -141,6 +141,7 @@ def _insert_import_entry(
                 1 if entry.is_relative else 0,
                 1 if entry.is_star else 0,
                 entry.alias_of,
+                entry.line,
             ),
         )
         return True
@@ -210,13 +211,36 @@ def write_activation_for_file(
         logger.debug("activation write failed for %s: %s", rel_path, exc)
 
 
+def _import_lines_from_symbols(symbols: dict[str, Any] | None) -> dict[str, int]:
+    """Map an import statement's raw text to the line it starts on.
+
+    ``imports_json`` is a plain ``list[str]`` consumed by many call sites, so it
+    cannot carry the line itself. The symbol payload written alongside it does,
+    and both are derived from the same nodes — so the text is a reliable key.
+    Duplicate statements keep the first occurrence.
+    """
+    lines: dict[str, int] = {}
+    for sym in (symbols or {}).get("symbols", []):
+        if sym.get("kind") != "import":
+            continue
+        text = sym.get("text")
+        if text and text not in lines:
+            lines[text] = int(sym.get("line", 0) or 0)
+    return lines
+
+
 def write_imports_for_file(
     conn: sqlite3.Connection,
     rel_path: str,
     language: str,
     imports: list[str] | list[dict[str, Any]],
+    symbols: dict[str, Any] | None = None,
 ) -> None:
-    """Refresh ast_imports rows for rel_path."""
+    """Refresh ast_imports rows for rel_path.
+
+    ``symbols`` is optional and only supplies line numbers for the plain-string
+    ``imports`` form; omitting it degrades to line 0 as before.
+    """
     try:
         from ..synapse_resolver import parse_imports
     except Exception as exc:  # pragma: no cover
@@ -226,10 +250,13 @@ def write_imports_for_file(
         conn.execute("DELETE FROM ast_imports WHERE file_path = ?", (rel_path,))
     except sqlite3.OperationalError:
         return
+    line_by_text = _import_lines_from_symbols(symbols)
     for raw in imports or []:
         text, line = _parse_import_raw(raw)
         if not text:
             continue
+        if not line:
+            line = line_by_text.get(text, 0)
         for entry in parse_imports(text, language, rel_path, line):
             if not _insert_import_entry(conn, rel_path, language, entry):
                 return

--- a/tree_sitter_analyzer/synapse_resolver/_imports.py
+++ b/tree_sitter_analyzer/synapse_resolver/_imports.py
@@ -30,6 +30,23 @@ class ImportEntry:
     line: int = 0
 
 
+def _strip_comments(text: str) -> str:
+    """Drop ``#`` comments line by line, preserving the rest of the statement.
+
+    A parenthesised import may carry a trailing comment on its opening line::
+
+        from typing import (  # noqa: F401
+            Any,
+            Dict,
+        )
+
+    Splitting the whole statement on the first ``#`` (the previous behaviour,
+    combined with ``re.DOTALL``) discarded every bound name after it. Stripping
+    per line keeps the continuation lines intact.
+    """
+    return "\n".join(line.split("#", 1)[0] for line in text.splitlines())
+
+
 def _split_names_clause(clause: str) -> list[tuple[str, str]]:
     """Parse ``"a, b as c, *"`` into ``[(local_name, alias_of), ...]``."""
     clause = clause.strip()
@@ -80,7 +97,11 @@ def _parse_python_imports(
     ``import a.b as c`` -> 1 row with module_path='a.b', local_name='c'.
     """
     language = "python"
-    text = text.strip()
+    # Strip comments up front: ``import os  # noqa`` previously failed the
+    # ``_PY_IMPORT_RE`` character class outright (yielding no rows at all),
+    # and a trailing comment on a parenthesised ``from`` import truncated the
+    # name list. Doing it per line handles both.
+    text = _strip_comments(text).strip()
     if not text:
         return []
 
@@ -88,7 +109,7 @@ def _parse_python_imports(
     if m_from:
         dots = m_from.group(1) or ""
         module_tail = m_from.group(2) or ""
-        names_clause = (m_from.group(3) or "").split("#", 1)[0]
+        names_clause = m_from.group(3) or ""
         module_path = dots + module_tail
         is_relative = bool(dots)
         entries: list[ImportEntry] = []
@@ -123,7 +144,7 @@ def _parse_python_imports(
 
     m_imp = _PY_IMPORT_RE.match(text)
     if m_imp:
-        body = m_imp.group(1).split("#", 1)[0]
+        body = m_imp.group(1)
         entries = []
         for item, alias_of in _split_names_clause(body):
             if alias_of:


### PR DESCRIPTION
## Summary

End-to-end MECE dogfood verification (independent ground-truth vs `ast_symbol_rows`, all languages in the repo) surfaced **8 silent data defects** across Python, C++, Kotlin, and Java. All are fixed in 5 commits with TDD regression tests.

## Defects fixed

| # | Language | Defect | Scope |
|---|---|---|---|
| 1 | Python | `from __future__ import X` never indexed (`future_import_statement` missing from `_IMPORT_LIKE`) | 787 import rows missing |
| 2 | Python | `def` nested in a method → `kind=method` + wrong class (`_find_parent_class` walked past function boundary) | 334 symbols + 226 bogus `contains` edges |
| 3 | Python | `ast_imports.line` always 0 for all 16,171 rows (INSERT omitted column) | 100% of `ast_imports` unusable for position |
| 4 | Python | `from X import (  # noqa) → 0 rows` (`re.DOTALL` + `split("#")` truncated body) | 105 import rows missing |
| 5 | Python | `import os  # noqa` → 0 rows (`_PY_IMPORT_RE` char class excludes `#`) | Additional silent case |
| 6 | C++ | All C++ free functions and methods absent from index (`language=="c"` gate excluded `"cpp"`) | 68+ functions/methods missing |
| 7 | Kotlin | `companion_object` members lost class attribution after BUG-2 fix | Methods classified `function` instead of `method` |
| 8 | Java | `record_declaration` not in `_CLASS_LIKE` — record methods classified `function` | Record members unattributed |

## Changes

- **`cache/extraction.py`**: `future_import_statement` → `_IMPORT_LIKE`; `_find_parent_class` stops at `_CLASS_LIKE` first then `_FUNCTION_LIKE`; `companion_object` walk-through; `record_declaration` → `_CLASS_LIKE`; `language in ("c", "cpp")` for declarator recovery
- **`synapse_resolver/_imports.py`**: `_strip_comments()` strips `#` per line before regex matching
- **`cache/write.py`**: `line` added to `ast_imports` INSERT; `_import_lines_from_symbols()` restores line numbers
- **`ast_cache.py` / `cache/indexer.py`**: `symbols` threaded through `_write_imports_for_file`
- **`extractor_version` bumped 14 → 17** — forces re-indexing of all affected files

## Test plan

- [x] 16 new TDD regression tests for Python defects (`test_python_index_extraction_defects.py`)
- [x] 6 new regression tests for C++, Kotlin, Java (`test_cpp_function_extraction.py`)
- [x] `test_symbols_json_enrichment.py` — version pin updated to 17
- [x] `test_incremental_sync.py` — mock signature updated for new `symbols` param
- [x] All 8,204+ existing tests pass; 0 new failures
- [x] Multi-language MECE verified across all 14 supported languages (bash/js/ts/java/go/rust/c/cpp/csharp/ruby/kotlin/php/scala/swift)
- [x] Independent code-review agent: **APPROVED**

🤖 Generated with [Claude Code](https://claude.com/claude-code)