### PR TITLE
test(windows): restore contained collector contracts and qualify Python 3.12

### DIFF
--- a/.github/workflows/windows-trust-diagnostics.yml
+++ b/.github/workflows/windows-trust-diagnostics.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.11', '3.13']
+        python-version: ['3.11', '3.12', '3.13']
     env:
       PYTHONUTF8: '1'
       PYTHONIOENCODING: utf-8
@@ -51,6 +51,8 @@ jobs:
           $output = Join-Path $env:RUNNER_TEMP "tsa-trust-$env:PYTHON_VERSION"
           New-Item -ItemType Directory -Force -Path $output | Out-Null
           $cases = @(
+            'tests/contracts/test_collect_no1_006b_baseline.py::test_receipt_binds_exact_collector_tool_lock_and_export',
+            'tests/contracts/test_collect_no1_006b_baseline.py::test_fresh_clone_can_resolve_and_checkout_collector_commit',
             'tests/contracts/test_collect_no1_006b_baseline.py::test_secrets_baseline_union_contract_works_in_fresh_clone_without_remote',
             'tests/unit/mcp/tools/test_constraint_check_portable_snapshot.py::test_portable_source_certifier_hashes_stable_supported_scope',
             'tests/unit/test_ast_cache.py::test_force_rebuild_without_secure_materialization_keeps_legacy_data_plane'
@@ -77,7 +79,7 @@ jobs:
               $xmlError = $_.Exception.Message
               $code = 1
             }
-            if ($executed -ne 3 -or $skipped -ne 0) { $code = 1 }
+            if ($executed -ne $cases.Count -or $skipped -ne 0) { $code = 1 }
             if ($code -ne 0) { $failures++ }
             @{
               sha = $env:TARGET_SHA

--- a/tests/contracts/test_collect_no1_006b_baseline.py
+++ b/tests/contracts/test_collect_no1_006b_baseline.py
@@ -362,14 +362,20 @@ def test_collector_commit_is_ancestor_of_reviewed_head() -> None:
     result=subprocess.run(["git","merge-base","--is-ancestor",commit,"HEAD"],cwd=REPO)
     assert result.returncode == 0
 
-def test_fresh_clone_can_resolve_and_checkout_collector_commit(tmp_path: Path) -> None:
+def test_fresh_clone_can_resolve_and_checkout_collector_commit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     # #1373：保留独立 Git 历史传输及真实脚本检出，移除重复传输与无关源码检出。
+    # Windows 的默认 CRLF 检出策略不能改变本测试要验证的绑定字节。
+    monkeypatch.setenv("GIT_CONFIG_COUNT","2")
+    monkeypatch.setenv("GIT_CONFIG_KEY_0","core.autocrlf")
+    monkeypatch.setenv("GIT_CONFIG_VALUE_0","true")
+    monkeypatch.setenv("GIT_CONFIG_KEY_1","core.eol")
+    monkeypatch.setenv("GIT_CONFIG_VALUE_1","crlf")
     commit=baseline()["collector"]["commit"]
     clone=tmp_path/"clone"; worktree=tmp_path/"collector"
     subprocess.run(["git","clone","-q","--no-local","--no-tags","--single-branch","--no-checkout",str(REPO),str(clone)],check=True)
     subprocess.run(["git","worktree","add","-q","--detach","--no-checkout",str(worktree),commit],cwd=clone,check=True)
     path="scripts/collect_no1_006b_baseline.py"
-    subprocess.run(["git","checkout",commit,"--",path],cwd=worktree,check=True)
+    subprocess.run(["git","-c","core.autocrlf=false","-c","core.eol=lf","checkout",commit,"--",path],cwd=worktree,check=True)
     assert subprocess.run(["git","rev-parse","HEAD"],cwd=worktree,check=True,capture_output=True,text=True).stdout.strip() == commit
     assert sorted(path.name for path in clone.iterdir()) == [".git"]
     assert sorted(path.name for path in worktree.iterdir()) == [".git", "scripts"]

--- a/tests/contracts/test_collect_no1_006b_baseline.py
+++ b/tests/contracts/test_collect_no1_006b_baseline.py
@@ -42,16 +42,6 @@ def mutated(path: tuple[str, ...], value: object) -> dict:
     target[path[-1]]=value; report["canonical_payload_sha256"]=collector.canonical_hash(report)
     return report
 
-# #1373:windows 轴上这两个真跑 git clone 的契约反复触发 xdist worker 原生崩溃
-# (node down: Not properly terminated)。采集器证据平台无关,按 full_language
-# 只跑 Linux 覆盖轴的同一原则,限 POSIX 轴执行;windows 原生崩溃根因另案追踪。
-_NO1_POSIX_ONLY = pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="tracked: #1373 windows xdist worker hard-crash around fresh-clone contract",
-)
-
-
-
 def test_checked_in_receipt_passes_schema_and_cross_field_validator() -> None:
     collector.validate_receipt(baseline(), schema())
 
@@ -151,22 +141,23 @@ def test_receipt_binds_exact_collector_and_schema_bytes() -> None:
     blobs=[subprocess.run(["git","show",f"{commit}:{path}"],cwd=REPO,check=True,capture_output=True).stdout for path in paths]
     assert [report["collector"][key] for key in ("script_sha256","schema_sha256","support_sha256")] == [collector.digest_bytes(blob) for blob in blobs]
 
-@_NO1_POSIX_ONLY
 def test_receipt_binds_exact_collector_tool_lock_and_export(tmp_path: Path) -> None:
-    # PR #1250: the historical collector closure must be derived from its bound commit, never reviewed HEAD.
+    # #1373 / PR #1250：导出只需绑定提交中的两个输入，不必检出整棵历史源码树。
     report=baseline(); commit=report["collector"]["commit"]; command=report["commands"]["collector_tool_export"]
     uv=Path(shutil.which(command[0]) or "missing").resolve(strict=True)
     uv_version=subprocess.run([str(uv),"--version"],check=True,capture_output=True,text=True).stdout.strip()
     assert uv_version.split()[:2] == report["environment"]["uv"]["version"].split()[:2]
     bound_command=[str(uv),*command[1:]]
     worktree=tmp_path/"collector"
-    subprocess.run(["git","worktree","add","-q","--detach",str(worktree),commit],cwd=REPO,check=True)
+    worktree.mkdir()
+    inputs={name:collector.git(REPO,"show",f"{commit}:{name}") for name in ("pyproject.toml","uv.lock")}
+    for name,content in inputs.items(): (worktree/name).write_bytes(content)
     try:
-        assert subprocess.run(["git","status","--porcelain=v1","--untracked-files=all","--ignored"],cwd=worktree,check=True,capture_output=True,text=True).stdout == ""
         exported=subprocess.run(bound_command,cwd=worktree,env=collector.clean_env(),check=True,capture_output=True).stdout
-        lock_blob=subprocess.run(["git","show",f"{commit}:uv.lock"],cwd=worktree,env=collector.clean_env(),check=True,capture_output=True).stdout
+        assert {path.name:path.read_bytes() for path in worktree.iterdir()} == inputs
+        lock_blob=inputs["uv.lock"]
     finally:
-        subprocess.run(["git","worktree","remove","--force",str(worktree)],cwd=REPO,check=True)
+        shutil.rmtree(worktree)
     assert [report["collector"]["tool_lock_sha256"],report["collector"]["tool_export_sha256"]] == [collector.digest_bytes(lock_blob),collector.digest_bytes(exported)]
     assert worktree.exists() is False
 
@@ -370,15 +361,18 @@ def test_collector_commit_is_ancestor_of_reviewed_head() -> None:
     result=subprocess.run(["git","merge-base","--is-ancestor",commit,"HEAD"],cwd=REPO)
     assert result.returncode == 0
 
-@_NO1_POSIX_ONLY
 def test_fresh_clone_can_resolve_and_checkout_collector_commit(tmp_path: Path) -> None:
+    # #1373：保留独立 Git 历史传输及真实脚本检出，移除重复传输与无关源码检出。
     commit=baseline()["collector"]["commit"]
-    bare=tmp_path/"reviewed.git"; clone=tmp_path/"clone"; worktree=tmp_path/"collector"
-    subprocess.run(["git","init","--bare","-q",str(bare)],check=True)
-    subprocess.run(["git","push","-q",str(bare),"HEAD:refs/heads/reviewed"],cwd=REPO,check=True)
-    subprocess.run(["git","clone","-q","--no-local","--no-tags","--single-branch","--branch","reviewed",str(bare),str(clone)],check=True)
-    subprocess.run(["git","worktree","add","-q","--detach",str(worktree),commit],cwd=clone,check=True)
+    clone=tmp_path/"clone"; worktree=tmp_path/"collector"
+    subprocess.run(["git","clone","-q","--no-local","--no-tags","--single-branch","--no-checkout",str(REPO),str(clone)],check=True)
+    subprocess.run(["git","worktree","add","-q","--detach","--no-checkout",str(worktree),commit],cwd=clone,check=True)
+    path="scripts/collect_no1_006b_baseline.py"
+    subprocess.run(["git","checkout",commit,"--",path],cwd=worktree,check=True)
     assert subprocess.run(["git","rev-parse","HEAD"],cwd=worktree,check=True,capture_output=True,text=True).stdout.strip() == commit
+    assert sorted(path.name for path in clone.iterdir()) == [".git"]
+    assert sorted(path.name for path in worktree.iterdir()) == [".git", "scripts"]
+    assert (worktree/path).read_bytes() == collector.git(REPO,"show",f"{commit}:{path}")
 
 def test_rfc_requires_merge_commit_to_preserve_collector_ancestry() -> None:
     reproduction=RFC.read_text(encoding="utf-8").split("## Reproduction of the descriptive receipt",1)[1].split("```bash",1)[0]

--- a/tests/contracts/test_collect_no1_006b_baseline.py
+++ b/tests/contracts/test_collect_no1_006b_baseline.py
@@ -150,7 +150,8 @@ def test_receipt_binds_exact_collector_tool_lock_and_export(tmp_path: Path) -> N
     bound_command=[str(uv),*command[1:]]
     worktree=tmp_path/"collector"
     worktree.mkdir()
-    inputs={name:collector.git(REPO,"show",f"{commit}:{name}") for name in ("pyproject.toml","uv.lock")}
+    # 采集器的受限进程读取器仅支持 POSIX；此处使用跨平台 Git 字节接口。
+    inputs={name:subprocess.run(["git","show",f"{commit}:{name}"],cwd=REPO,env=collector.clean_env(),check=True,capture_output=True,timeout=60).stdout for name in ("pyproject.toml","uv.lock")}
     for name,content in inputs.items(): (worktree/name).write_bytes(content)
     try:
         exported=subprocess.run(bound_command,cwd=worktree,env=collector.clean_env(),check=True,capture_output=True).stdout
@@ -372,7 +373,8 @@ def test_fresh_clone_can_resolve_and_checkout_collector_commit(tmp_path: Path) -
     assert subprocess.run(["git","rev-parse","HEAD"],cwd=worktree,check=True,capture_output=True,text=True).stdout.strip() == commit
     assert sorted(path.name for path in clone.iterdir()) == [".git"]
     assert sorted(path.name for path in worktree.iterdir()) == [".git", "scripts"]
-    assert (worktree/path).read_bytes() == collector.git(REPO,"show",f"{commit}:{path}")
+    expected=subprocess.run(["git","show",f"{commit}:{path}"],cwd=REPO,env=collector.clean_env(),check=True,capture_output=True,timeout=60).stdout
+    assert (worktree/path).read_bytes() == expected
 
 def test_rfc_requires_merge_commit_to_preserve_collector_ancestry() -> None:
     reproduction=RFC.read_text(encoding="utf-8").split("## Reproduction of the descriptive receipt",1)[1].split("```bash",1)[0]


### PR DESCRIPTION
## Summary
- Remove the two Windows containment skips from the collector contracts.
- Derive dependency export from the exact pinned pyproject/lock Git blobs in a private input directory; verify input bytes and inventory are unchanged after the real uv export.
- Keep independent Git history transfer and a real pinned script checkout, but remove the duplicate push/clone transfer and full-tree materialization that the contract does not use.
- Expand the existing diagnostic to Windows 3.11/3.12/3.13 and all five original/restored node IDs, 20 iterations per axis, no skipped cases or hidden reruns.

## Verification
- The new checkout-footprint assertion fails with full-tree checkout and passes with bounded materialization.
- Full collector contract: 85 passed, 1 unrelated existing historical-environment skip on macOS.
- Quick gate: 2016 passed, 28 existing skips.
- Frozen receipt hashes, exact Git commit identity and source bytes remain checked; actionlint and diff checks passed.

## Acceptance
Related #1373 remains open pending native repeated execution of the restored contracts and normal CI. This is not a claim that a single green run explains every prior worker exit. No timeout increase, worker reduction, new skip or mock Git/uv result.