### PR TITLE
fix(health): isolate gap classification from project ancestors

### DIFF
--- a/tests/unit/test_test_gap_analyzer.py
+++ b/tests/unit/test_test_gap_analyzer.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 
+from pathlib import Path
 
 import pytest
 
 from tree_sitter_analyzer.test_gap_analyzer import (
     CoverageGapResult,
     ProductionSymbol,
+    _collect_files,
     _extract_test_targets,
     _is_test_file,
     _make_reason,
@@ -141,6 +143,73 @@ class TestMakeReason:
 
 
 class TestAnalyzeCoverageGaps:
+    @pytest.mark.parametrize("parent", ["workspace", "pytest", "test", "tests"])
+    @pytest.mark.parametrize("root_form", ["absolute", "relative", "dot"])
+    def test_collection_ignores_project_ancestors(
+        self, tmp_path, monkeypatch, parent, root_form
+    ):
+        # #1400：项目外的 pytest/test/tests 目录不能改变生产分类或文件预算。
+        project = tmp_path / parent / "project"
+        expected = {
+            "src/service.py": False,
+            "src/test/helper.py": True,
+            "test/helper.py": True,
+            "tests/helper.py": True,
+            "test_support/service.py": False,
+        }
+        for relative in expected:
+            path = project / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("def work():\n    pass\n", encoding="utf-8")
+        root = str(project)
+        if root_form == "relative":
+            monkeypatch.chdir(project.parent)
+            root = "project"
+        elif root_form == "dot":
+            monkeypatch.chdir(project)
+            root = "."
+
+        files = _collect_files(root, max_files=2)
+
+        assert {
+            Path(path).resolve().relative_to(project.resolve()).as_posix(): is_test
+            for path, language, is_test in files
+        } == expected
+
+    @pytest.mark.parametrize("parent", ["workspace", "pytest"])
+    @pytest.mark.parametrize("target_file", [None, "service.py"])
+    def test_gap_results_ignore_project_ancestors(self, tmp_path, parent, target_file):
+        # #1400：真实解析必须保留未覆盖符号、命名覆盖及目标文件作用域。
+        project = tmp_path / parent / "project"
+        src = project / "src"
+        src.mkdir(parents=True)
+        (src / "service.py").write_text(
+            "def alpha():\n    return 1\n\ndef beta():\n    return 2\n",
+            encoding="utf-8",
+        )
+        (src / "other.py").write_text("def gamma():\n    return 3\n", encoding="utf-8")
+        tests = project / "tests"
+        tests.mkdir()
+        (tests / "test_service.py").write_text(
+            "def test_alpha():\n    assert alpha() == 1\n", encoding="utf-8"
+        )
+
+        result = analyze_coverage_gaps(
+            str(project), target_file=target_file, include_covered=True
+        )
+
+        assert result.total_production_symbols == (2 if target_file else 3)
+        assert result.total_test_symbols == 1
+        assert result.covered_count == 1
+        assert result.gap_count == (1 if target_file else 2)
+        assert result.coverage_pct == (50.0 if target_file else 33.3)
+        assert {gap.symbol.name for gap in result.gaps} == (
+            {"beta"} if target_file else {"beta", "gamma"}
+        )
+        assert [symbol.name for symbol in result.covered] == ["alpha"]
+        assert result.summary["production_files"] == (1 if target_file else 2)
+        assert result.summary["test_files"] == 1
+
     @pytest.fixture
     def project_with_gaps(self, tmp_path):
         src = tmp_path / "src"

--- a/tree_sitter_analyzer/test_gap_analyzer.py
+++ b/tree_sitter_analyzer/test_gap_analyzer.py
@@ -314,9 +314,10 @@ def _collect_files(
             lang = _language_from_ext(full) or ""
             if language_filter and lang != language_filter:
                 continue
-            # Files inside a non-production directory are always test/non-prod,
-            # regardless of their individual filename.
-            is_test = in_non_prod or _is_test_file(full)
+            # 分类仅看项目内路径，避免 pytest 等祖先目录污染整个项目。
+            # 保留前导分隔符，防止 test_support 等生产包被 ^test_ 误判。
+            relative = os.path.relpath(full, project_root).replace(os.sep, "/")
+            is_test = in_non_prod or _is_test_file(f"/{relative}")
             if not is_test:
                 # #713: a scoped request only wants production symbols from the
                 # target file — skip every other production file BEFORE the cap


### PR DESCRIPTION
## Summary
- Fix the existing product defect identified during #1400, independently of the test migration. Branch starts at origin/develop `8b4f21e70ce470db6114be36dd22d153955f71be`.
- `_collect_files` previously passed an absolute filesystem path to `_is_test_file`; the unanchored `tests?/` alternative matches the suffix of a parent named `pytest/`, marking every production file as test code. Call chain: `CodeGraphTestGapTool.execute -> analyze_coverage_gaps -> _collect_files -> _is_test_file`.
- Classify only project-relative paths, with POSIX separators and a leading separator preserving the existing rooted-path matching behavior. In particular, do not newly classify production packages such as `test_support/` through `^test_`. Preserve returned file paths, target scoping, production budgets, regex rules, shared detectors, and root canonicalisation.
- Add 16 parameterized real-filesystem cases to the existing analyzer test module: ordinary/pytest/test/tests ancestors, absolute/relative/dot roots, src/test/tests boundaries, production package names, exact gap/covered totals and target scoping. Only two files changed.

## Evidence And Verification
- Before the production fix, existing gap modules with `--basetemp=<evidence>/pytest --reruns=0`: **12 failed, 40 passed**, exactly the historical gap failures. No comprehensive suite was run.
- New regression cases before the fix: **5 failed, 11 passed** (default rerun reproduced the same five failures).
- Contaminated-path focused suite plus numeric-coercion module with `--cov=tree_sitter_analyzer --cov-branch --cov-report=json --reruns=0`: **80 passed**.
- Exact TSA verification command: `uv run pytest tests/unit/test_test_gap_analyzer.py tests/unit/test_test_gap_tool.py -q`: **68 passed**. TSA preflight was CAUTION (INDEX_ABSENT); impact reports REVIEW/high and requires the queue-boundary quick gate. Health unchanged: **B / 86.6**.
- `uv run pytest -q`: **2023 passed, 28 skipped in 28.19s**, four xdist workers; no test-runtime settings changed.
- `uv run python scripts/check_patch_coverage.py --base origin/develop --coverage-json coverage.json`: **passed, no added executable misses**, run after commit against the actual PR patch. Branch coverage enabled.
- Ruff, mypy, applicable pre-commit hooks, and `uv build`: passed.
- Real CLI `--test-gap` smoke under a `pytest/` ancestor: production=3, covered=1, gaps=2, coverage=33.3%, verdict=WARN.

## Scope
Dedicated worktree only; main/1352/1400 worktrees were not edited. No dependency, schema, registry, CLI flag, documentation, or version changes. This PR is for review only; do not merge automatically. Local red/green logs are in the sibling `tsa-gap-path-evidence/` directory.