### PR TITLE
fix(watcher): refresh source destinations after atomic saves

### DIFF
--- a/tests/unit/test_file_watcher.py
+++ b/tests/unit/test_file_watcher.py
@@ -212,3 +212,55 @@ class TestSkipDirExclusion:
             os.path.join("src", "main.py"),
             os.path.join("src", "util.py"),
         }
+
+
+@pytest.mark.parametrize(
+    "source,destination,expected",
+    [
+        ("save.tmp", "main.py", ["main.py"]),
+        ("main.py", "renamed.py", ["main.py", "renamed.py"]),
+        ("main.py", "archive.tmp", ["main.py"]),
+        ("save.tmp", "archive.tmp", []),
+        ("main.py", "main.py", ["main.py"]),
+        ("main.py", "", ["main.py"]),
+    ],
+)
+def test_watchdog_dispatches_supported_move_endpoints(source, destination, expected):
+    # 2026-09-08：原子保存的源文件扩展名不受支持时，目标源码仍必须触发刷新。
+    from types import SimpleNamespace
+
+    from tree_sitter_analyzer.file_watcher import _WatchdogHandler
+
+    paths = []
+    _WatchdogHandler(paths.append).dispatch(
+        SimpleNamespace(src_path=source, dest_path=destination, is_directory=False)
+    )
+    assert paths == expected
+
+
+def test_watchdog_atomic_save_refreshes_index(watcher, cache, project):
+    # 2026-09-08：验证真实替换、事件入队和增量索引，不以回调次数代替索引正确性。
+    from types import SimpleNamespace
+
+    from tree_sitter_analyzer.file_watcher import _WatchdogHandler
+
+    watcher.trigger_sync()
+    target = project / "src" / "main.py"
+    temporary = target.with_suffix(".tmp")
+    temporary.write_text("def saved():\n    pass\n", encoding="utf-8")
+    os.replace(temporary, target)
+    watcher._debounce = 60.0
+    _WatchdogHandler(watcher._enqueue).dispatch(
+        SimpleNamespace(
+            src_path=str(temporary), dest_path=str(target), is_directory=False
+        )
+    )
+    watcher._flush_pending()
+    rows = (
+        cache.get_conn()
+        .execute(
+            "SELECT name FROM ast_symbol_rows WHERE file_path='src/main.py' ORDER BY name"
+        )
+        .fetchall()
+    )
+    assert [row[0] for row in rows] == ["saved"]

--- a/tree_sitter_analyzer/file_watcher.py
+++ b/tree_sitter_analyzer/file_watcher.py
@@ -309,10 +309,10 @@ class _WatchdogHandler:
     def dispatch(self, event: Any) -> None:
         if getattr(event, "is_directory", False):
             return
-        src = getattr(event, "src_path", "")
-        if not src:
-            return
-        ext = os.path.splitext(src)[1].lower()
-        if ext not in _EXT_TO_LANG:
-            return
-        self._callback(src)
+        # 原子保存可能从临时扩展名移入源码；移动两端都要通知，并去除同路径重复。
+        paths = dict.fromkeys(
+            (getattr(event, "src_path", ""), getattr(event, "dest_path", ""))
+        )
+        for path in paths:
+            if path and os.path.splitext(path)[1].lower() in _EXT_TO_LANG:
+                self._callback(path)


### PR DESCRIPTION
Atomic editor saves can move a temporary file with an unsupported extension onto a supported source file. The watchdog handler previously inspected only the source path and dropped that event, leaving the index on the old definition. Inspect both move endpoints and deduplicate identical paths.

Validation:
- The new atomic-save test failed with the old `hello` symbol before the fix and returns only `saved` afterward.
- Six endpoint cases cover moves into/out of source extensions, source renames, duplicate endpoints, unrelated files, and ordinary events.
- 23 watcher tests pass; quick gate: 2,024 passed, 28 skipped (28.18 s); patch coverage has no added executable misses; Ruff, MyPy, pre-commit, and sdist/wheel build pass.
- A native macOS watchdog 6.0.0 probe received an actual `os.replace` save and indexed the new symbol in a single observed 0.136 s. This is not a latency SLA or whole-index certification claim.

Targets develop; no release/version change. Pulse source-certification work is separate.
