### PR TITLE
fix: certify quiet indexes after SQLite WAL reuse

### DIFF
--- a/tests/unit/test_index_snapshot.py
+++ b/tests/unit/test_index_snapshot.py
@@ -1312,6 +1312,68 @@ class TestWalSnapshotPath:
         REGISTRY.close_all()
 
     @requires_posix_snapshot
+    @pytest.mark.parametrize(
+        "fault", [None, "checksum", "current_after_old", "header_salt"]
+    )
+    async def test_recycled_wal_certifies_current_committed_prefix(
+        self, tmp_path, wal_project, fault
+    ):
+        # 2026-09-08：真实 WAL 重用留下旧尾帧，静止索引不得误报并发写入。
+        import tree_sitter_analyzer.index_snapshot as owner
+
+        conn = wal_project
+        conn.execute("PRAGMA wal_autocheckpoint=0")
+        for value in range(12):
+            conn.execute(
+                "UPDATE ast_cache_metadata SET value=? WHERE key='wal_test'",
+                (str(value),),
+            )
+            conn.commit()
+        wal = tmp_path / ".ast-cache" / "index.db-wal"
+        previous = wal.read_bytes()
+        checkpoint = conn.execute("PRAGMA wal_checkpoint(RESTART)").fetchone()
+        assert checkpoint[0] == 0
+        assert checkpoint[1] == checkpoint[2]
+        conn.execute(
+            "UPDATE ast_cache_metadata SET value='current' WHERE key='wal_test'"
+        )
+        conn.commit()
+        captured = wal.read_bytes()
+        assert len(captured) == len(previous)
+        assert captured[16:24] != previous[16:24]
+        if fault:
+            damaged = bytearray(captured)
+            if fault == "checksum":
+                damaged[32 + 24] ^= 1
+            elif fault == "header_salt":
+                damaged[16] ^= 1
+            else:
+                frame_size = 24 + int.from_bytes(captured[8:12], "big")
+                damaged[-frame_size + 8 : -frame_size + 16] = captured[16:24]
+            wal.write_bytes(damaged)
+            try:
+                rejected = owner.read_existing_snapshot(str(tmp_path))
+                assert (rejected.completeness, rejected.reason) == (
+                    "unknown",
+                    "CONCURRENT_WRITER",
+                )
+            finally:
+                wal.write_bytes(captured)
+            return
+        snapshot = owner.read_existing_snapshot(str(tmp_path))
+        assert (snapshot.completeness, snapshot.reason) == ("complete", None)
+        with owner.read_existing_index_scope(
+            snapshot.snapshot_id, str(tmp_path), snapshot.source_generation
+        ) as (_, reader):
+            assert (
+                reader.execute(
+                    "SELECT value FROM ast_cache_metadata WHERE key='wal_test'"
+                ).fetchone()[0]
+                == "current"
+            )
+        assert wal.read_bytes() == captured
+
+    @requires_posix_snapshot
     @pytest.mark.parametrize("sidecars", ["present", "absent"])
     async def test_wal_snapshot_does_not_change_source_directory(
         self, tmp_path, wal_project, sidecars

--- a/tests/unit/test_index_snapshot_windows.py
+++ b/tests/unit/test_index_snapshot_windows.py
@@ -199,12 +199,25 @@ def test_rejected_native_handle_is_closed(tmp_path, kernel, fault, expected):
     assert kernel.handles == {}
 
 
-def test_wal_copy_recovers_committed_rows_and_closes_pins(tmp_path, pair, kernel):
+@pytest.mark.parametrize("recycled", [False, True])
+def test_wal_copy_recovers_committed_rows_and_closes_pins(
+    tmp_path, pair, kernel, recycled
+):
+    # 2026-09-08：Windows 能力路径也必须识别真实 SQLite 重用后的当前代帧数。
+    if recycled:
+        path, writer = pair
+        before = path.with_name("index.db-wal").read_bytes()
+        assert writer.execute("PRAGMA wal_checkpoint(RESTART)").fetchone() == (0, 3, 3)
+        writer.execute("UPDATE payload SET value=43")
+        writer.commit()
+        assert path.with_name("index.db-wal").stat().st_size == len(before)
     with _capture(tmp_path) as (private, frames):
-        assert frames == 3
+        assert frames == (1 if recycled else 3)
         conn = sqlite3.connect(private)
         try:
-            assert conn.execute("SELECT value FROM payload").fetchall() == [(42,)]
+            assert conn.execute("SELECT value FROM payload").fetchall() == [
+                (43 if recycled else 42,)
+            ]
         finally:
             conn.close()
     assert os.path.exists(private) is False

--- a/tree_sitter_analyzer/index_snapshot.py
+++ b/tree_sitter_analyzer/index_snapshot.py
@@ -309,7 +309,7 @@ def _capture_wal_snapshot(
                 reason = "NO_EXACT_FULL_INDEX_MANIFEST"
             connection, projection_exact = _copy_projection_evidence(staged, deadline)
             if wal_frames is not None:
-                # 私有 checkpoint 的帧数必须等于捕获的完整 WAL；不接受被 SQLite 忽略的尾帧。
+                # 帧数须等于当前 salt 的完整前缀；损坏或未提交的当前代帧不能被忽略。
                 checkpoint = tuple(
                     staged.execute("PRAGMA wal_checkpoint(PASSIVE)").fetchone()
                 )

--- a/tree_sitter_analyzer/index_snapshot_capability.py
+++ b/tree_sitter_analyzer/index_snapshot_capability.py
@@ -404,6 +404,24 @@ def _copy_pinned_wal_files(
                 ):
                     raise ValueError("CONCURRENT_WRITER")
                 wal_frames = (wal_size - 32) // (24 + page_size)
+                # SQLite 重用 WAL 不必截断旧代尾部；只认证当前 salt 的连续前缀。
+                # 校验和及提交边界仍由私有 SQLite 的精确 checkpoint 帧数核验。
+                with open(os.path.join(private, "index.db-wal"), "rb") as wal:
+                    current_frames = 0
+                    old_tail = False
+                    for frame in range(wal_frames):
+                        check_deadline(deadline)
+                        wal.seek(32 + frame * (24 + page_size))
+                        frame_header = wal.read(24)
+                        if frame_header[8:16] != header[16:24]:
+                            old_tail = True
+                        elif old_tail:
+                            raise ValueError("CONCURRENT_WRITER")
+                        else:
+                            current_frames += 1
+                    if wal_frames and not current_frames:
+                        raise ValueError("CONCURRENT_WRITER")
+                    wal_frames = current_frames
         yield os.path.join(private, "index.db"), wal_frames
         # 跨主库/WAL 的完整复核发生在私有 SQLite 读取之后、发布能力之前。
         for (_, fd, expected), captured in zip(files, hashes, strict=True):


### PR DESCRIPTION
Pulse rejects a quiet, fully indexed project after SQLite reuses a WAL without truncating its older tail. The snapshot reader counted every physical frame as current and rejected SQLite’s valid checkpoint result.

Count the contiguous current-salt frame prefix and require the private checkpoint to consume exactly that prefix. Older-generation tail frames are allowed; current frames after an older tail, a missing current prefix, corrupt current payloads, and concurrent source changes remain rejected. Source database files remain untouched.

Validation: real SQLite RESTART reproducer failed before the fix; TSA-reported focused suite passed (408 tests, 10 existing platform skips); patch coverage has no added executable misses; Ruff, MyPy and all commit hooks passed. The shared Windows capture path is exercised through its existing native-handle test harness; native CI is pending.

Integrated develop watcher fixes at 0849ecd5 (develop b7023f60). The default quick gate passed 2,041 tests with 28 existing skips in 33.85 seconds; fresh snapshot coverage passed 105 tests with 10 existing platform skips and the patch gate reported no executable misses.

A real end-to-end probe on that committed combination (no module overlay) used default polling/debounce and preserved-size/mtime saves. Pulse reported stale immediately and fresh after synchronization: 1,000 files took 7.42 seconds and 10,000 files took 7.78 seconds from save to successful Pulse return. Startup took 5.28 and 37.56 seconds respectively. These are single synthetic observations, not percentiles or latency guarantees. Both sizes previously returned CONCURRENT_WRITER after synchronization completed.

The prior head passed all native installation axes and evidence aggregation; its final upload-artifact step failed with GitHub’s “The server is busy” annotation. The new head runs a fresh CI qualification.
