### PR TITLE
fix: share AST cache identity across project root aliases

### DIFF
--- a/tests/unit/test_ast_cache.py
+++ b/tests/unit/test_ast_cache.py
@@ -224,6 +224,51 @@ class TestIndexFile:
 
 
 class TestLookup:
+    @pytest.mark.parametrize("through_alias", [False, True])
+    def test_root_alias_preserves_logical_descendant_path(
+        self, tmp_path, through_alias
+    ):
+        # 2026-09-08：只统一根目录；冻结后的子路径不能因活文件变成链接而重定向。
+        from tree_sitter_analyzer.cache.helpers import _canonical_project_path
+
+        root = tmp_path / "project"
+        root.mkdir()
+        alias = tmp_path / "alias"
+        alias.symlink_to(root, target_is_directory=True)
+        logical = root / "logical"
+        logical.symlink_to(tmp_path, target_is_directory=True)
+        supplied = (alias if through_alias else root) / "logical" / "sample.py"
+        assert _canonical_project_path(str(supplied), str(root)) == str(
+            logical / "sample.py"
+        )
+
+    @pytest.mark.parametrize("index_through_alias", [False, True])
+    def test_project_root_alias_has_one_cache_identity(
+        self, tmp_path, index_through_alias
+    ):
+        # 2026-09-08：根目录别名曾产生 ../alias 键，导致真实路径查询与删除失效。
+        root = tmp_path / "project"
+        root.mkdir()
+        alias = tmp_path / "alias"
+        alias.symlink_to(root, target_is_directory=True)
+        source = root / "sample.py"
+        source.write_text("def signal(): return 1\n", encoding="utf-8")
+        aliased = alias / source.name
+        cache = ASTCache(str(alias))
+        try:
+            result = cache.index_file(str(aliased if index_through_alias else source))
+            assert result["file"] == "sample.py"
+            row = cache.lookup(str(source))
+            assert row is not None
+            assert cache.lookup(str(aliased)) == row
+            assert cache.index_file(str(aliased))["status"] == "cached"
+            assert cache.get_stats()["total_files"] == 1
+            source.unlink()
+            assert cache.invalidate(str(aliased)) is True
+            assert cache.lookup(str(source)) is None
+        finally:
+            cache.close()
+
     def test_lookup_indexed_file(self, cache, tmp_project):
         f = str(tmp_project / "src" / "main.py")
         cache.index_file(f)

--- a/tests/unit/test_ast_cache.py
+++ b/tests/unit/test_ast_cache.py
@@ -225,8 +225,9 @@ class TestIndexFile:
 
 class TestLookup:
     @pytest.mark.parametrize("through_alias", [False, True])
+    @pytest.mark.parametrize("points_to_root", [False, True])
     def test_root_alias_preserves_logical_descendant_path(
-        self, tmp_path, through_alias
+        self, tmp_path, through_alias, points_to_root
     ):
         # 2026-09-08：只统一根目录；冻结后的子路径不能因活文件变成链接而重定向。
         from tree_sitter_analyzer.cache.helpers import _canonical_project_path
@@ -236,7 +237,9 @@ class TestLookup:
         alias = tmp_path / "alias"
         alias.symlink_to(root, target_is_directory=True)
         logical = root / "logical"
-        logical.symlink_to(tmp_path, target_is_directory=True)
+        logical.symlink_to(
+            root if points_to_root else tmp_path, target_is_directory=True
+        )
         supplied = (alias if through_alias else root) / "logical" / "sample.py"
         assert _canonical_project_path(str(supplied), str(root)) == str(
             logical / "sample.py"

--- a/tree_sitter_analyzer/_ast_cache_index_mixin.py
+++ b/tree_sitter_analyzer/_ast_cache_index_mixin.py
@@ -18,6 +18,7 @@ from .cache.callgraph_state import (
     mark_call_graph_built_strict as _mark_call_graph_built_strict,
 )
 from .cache.extraction import _content_hash
+from .cache.helpers import _canonical_project_path
 from .cache.schema import clear_activation_for_file as _clear_activation_for_file_fn
 from .index_source_snapshot import SourceScopeDescriptor
 from .indexing_snapshot import IndexCandidateSnapshot
@@ -82,7 +83,7 @@ class ASTCacheIndexMixin(ASTCacheSurface):
         _frozen_deadline: float | None = None,
     ) -> dict[str, Any]:
         """Index one logical path; private frozen inputs are engine-only evidence."""
-        abs_path = os.path.abspath(file_path)
+        abs_path = _canonical_project_path(file_path, self.project_root)
         rel_path = os.path.relpath(abs_path, self.project_root).replace("\\", "/")
         if language is None:
             language = _language_from_ext(abs_path)

--- a/tree_sitter_analyzer/cache/helpers.py
+++ b/tree_sitter_analyzer/cache/helpers.py
@@ -20,12 +20,14 @@ def _canonical_project_path(file_path: str, project_root: str) -> str:
     ):
         return absolute
     parent = os.path.dirname(absolute)
+    mapped = absolute
     while True:
         if os.path.normcase(os.path.realpath(parent)) == root_key:
-            return os.path.join(project_root, os.path.relpath(absolute, parent))
+            # 子链接也可能指回根目录；必须以最外层根别名保留完整逻辑后缀。
+            mapped = os.path.join(project_root, os.path.relpath(absolute, parent))
         ancestor = os.path.dirname(parent)
         if ancestor == parent:
-            return absolute
+            return mapped
         parent = ancestor
 
 

--- a/tree_sitter_analyzer/cache/helpers.py
+++ b/tree_sitter_analyzer/cache/helpers.py
@@ -10,6 +10,25 @@ import os
 from typing import Any
 
 
+def _canonical_project_path(file_path: str, project_root: str) -> str:
+    """统一项目根目录别名，保留根目录内逻辑路径及冻结源码的身份。"""
+    absolute = os.path.abspath(file_path)
+    root_key = os.path.normcase(project_root)
+    absolute_key = os.path.normcase(absolute)
+    if absolute_key == root_key or absolute_key.startswith(
+        root_key.rstrip(os.sep) + os.sep
+    ):
+        return absolute
+    parent = os.path.dirname(absolute)
+    while True:
+        if os.path.normcase(os.path.realpath(parent)) == root_key:
+            return os.path.join(project_root, os.path.relpath(absolute, parent))
+        ancestor = os.path.dirname(parent)
+        if ancestor == parent:
+            return absolute
+        parent = ancestor
+
+
 def _build_function_entry(
     sym: dict[str, Any], file_path: str, language: str
 ) -> dict[str, Any]:

--- a/tree_sitter_analyzer/cache/query.py
+++ b/tree_sitter_analyzer/cache/query.py
@@ -13,6 +13,7 @@ import sqlite3
 from typing import TYPE_CHECKING, Any, cast
 
 from ..utils.test_detection import query_wants_tests, rank_tier
+from .helpers import _canonical_project_path
 from .maintenance import get_db_storage_stats
 
 if TYPE_CHECKING:
@@ -48,7 +49,7 @@ def invalidate(
     """Remove all cached rows for file_path. Returns True if a row was deleted."""
     import os
 
-    abs_path = os.path.abspath(file_path)
+    abs_path = _canonical_project_path(file_path, project_root)
     try:
         rel = os.path.relpath(abs_path, project_root).replace("\\", "/")
     except ValueError:
@@ -66,7 +67,7 @@ def lookup(
     """Look up one file's cached AST metadata. Returns None if not indexed."""
     import os
 
-    abs_path = os.path.abspath(file_path)
+    abs_path = _canonical_project_path(file_path, project_root)
     try:
         rel = os.path.relpath(abs_path, project_root).replace("\\", "/")
     except ValueError:


### PR DESCRIPTION
Indexing a file through a project-root symlink stored a key such as `../alias/sample.py`. Looking up the same file by its canonical path then returned missing, and invalidation through the alternate spelling could leave rows behind.

Use the same project-root alias mapping in single-file indexing, lookup, and invalidation. Resolve only the root alias: keep descendant logical paths intact so a changed child symlink cannot redirect a frozen candidate’s identity. Missing files remain addressable for invalidation. Existing malformed rows are not migrated automatically; a complete reindex is needed to rebuild old affected caches.

Validation: both alias-indexed and canonical-indexed reproductions failed before the fix; the TSA-reported command passed 2,255 tests with one existing skip. Tests cover equal lookup identity, a single cached row, deletion through the alias after the source disappears, and preservation of logical descendant paths. Patch coverage reports no added executable misses. Ruff, MyPy and commit hooks passed. Native CI is pending.

Integrated develop b7023f60 at dd355fca. Post-merge TSA quick gate: 2,045 passed, 28 existing skips, 27.63 seconds. Fresh cache-focused coverage: 41 passed, with no added executable misses against origin/develop.

Review follow-up at 2f1d7dc9: select the outermost matching root alias when a descendant symlink points back to the project root. The new recursive-alias case failed before the fix; the reported verification passed 1,591 tests with one existing skip and fresh patch coverage had no executable misses.
