### PR TITLE
test: preserve Pulse index admission after warming

### DIFF
--- a/tests/LARGE_TEST_FILE_EXCEPTIONS.md
+++ b/tests/LARGE_TEST_FILE_EXCEPTIONS.md
@@ -4,7 +4,7 @@ Measured on 2026-09-07 (auto-audited by
 `tests/contracts/test_large_test_file_inventory.py` — the inventory must
 match reality or CI fails). The threshold is 800 lines.
 
-## Current Files Over Threshold (48)
+## Current Files Over Threshold (49)
 
 | Lines | File | Note |
 |---:|---|---|
@@ -52,6 +52,7 @@ match reality or CI fails). The threshold is 800 lines.
 | 848 | `tests/unit/test_edge_store.py` | |
 | 847 | `tests/unit/test_ast_diff_scenarios.py` | |
 | 833 | `tests/unit/test_codegraph_impact_tool.py` | |
+| 823 | `tests/unit/mcp/tools/test_pulse_tool.py` | tracked: #1414 — two warm-index admission regressions stay with the existing Pulse suite (T-1); temporary growth from 791 lines. Follow-up must split by behavior under the controlled migration contract, preserving all cases and mutation evidence. |
 | 822 | `tests/unit/cli/test_install_skills.py` | |
 | 821 | `tests/unit/test_wire_owner_contract.py` | |
 | 814 | `tests/unit/languages/test_java_formatter.py` | |

--- a/tests/unit/mcp/tools/test_pulse_tool.py
+++ b/tests/unit/mcp/tools/test_pulse_tool.py
@@ -21,6 +21,38 @@ def _make_fake_cache(conn):
     return fake
 
 
+@pytest.mark.parametrize("kind", ["single", "batch"])
+async def test_warm_pulse_rejects_invalidated_index_with_unchanged_source(
+    indexed_pulse_project, kind
+):
+    """源码未变不能替代索引认证；已预热的单次和批次查询都必须拒绝失效索引。"""
+    root, cache = indexed_pulse_project
+    source = root / "a.py"
+    original = source.read_bytes()
+    tool = PulseTool(str(root)) if kind == "single" else PulseBatchTool(str(root))
+    target = {"file": "a.py", "symbol": "greet"}
+    arguments = target if kind == "single" else {"targets": [target]}
+    warm = await tool.execute(arguments)
+    assert warm["success"] is True
+    assert warm["source_evidence"]["freshness"] == "fresh"
+    assert warm["source_evidence"]["snapshot_id"] is not None
+
+    cache.invalidate(str(source))
+    assert source.read_bytes() == original
+    response = await tool.execute(arguments)
+    assert response == {
+        "success": False,
+        "error_code": "SOURCE_EVIDENCE_UNAVAILABLE",
+        "error": "Pulse source evidence unavailable: CALL_GRAPH_INCOMPLETE",
+        "source_evidence": {
+            "freshness": "unknown",
+            "snapshot_id": None,
+            "source_generation": None,
+            "reason": "CALL_GRAPH_INCOMPLETE",
+        },
+    }
+
+
 async def test_pulse_missing_relation_is_query_failure(indexed_pulse_project):
     """PR #1352：目标存在但关系表损坏时，不得谎报目标不存在。"""
     root, cache = indexed_pulse_project


### PR DESCRIPTION
A warmed Pulse snapshot must not bypass current index admission just because source bytes are unchanged. Add real-cache regressions for single and batch queries: warm a complete index, invalidate its file without editing source, then require the exact `CALL_GRAPH_INCOMPLETE` failure envelope with no result or snapshot identity.

This protects the existing behavior before optimizing source certification. An experimental wrapper that substitutes `lease_reusable_snapshot` returns fresh stale-index answers; both new tests reject it. No production implementation or schema changes.

Validation:
- TSA change-impact selected the existing Pulse module: 75 passed in 5.26 seconds, with fresh coverage JSON.
- Local patch coverage gate passed with no added executable misses.
- Unsafe-reuse mutation: both new parameter cases failed as expected, without retries.
- `git diff --check` and commit hooks passed.

CI follow-up: the initial Linux coverage job passed 2,053 tests but failed the large-test-file inventory because this existing suite grew from 791 to 823 lines. Register the temporary growth with tracked #1414 and a behavior-preserving migration follow-up; retain T-1 placement and the unchanged 800-line detector. All three inventory contracts now pass locally.
