### PR TITLE
fix: prevent SQLite read-side creation and migration

### DIFF
--- a/tests/unit/mcp/_safe_to_edit_tool_helpers.py
+++ b/tests/unit/mcp/_safe_to_edit_tool_helpers.py
@@ -193,3 +193,20 @@ def _reverse_dependency_conn(
 class _BrokenConnection:
     def execute(self, _query: str) -> Any:
         raise sqlite3.DatabaseError("broken snapshot")
+
+
+@pytest.fixture(params=[False, True])
+def unreadable_index(tmp_path, monkeypatch, request):
+    """准备损坏数据库，或模拟存在检查之后文件被删除。"""
+    db_path = tmp_path / ".ast-cache" / "index.db"
+    db_path.parent.mkdir()
+    db_path.write_text("not-a-sqlite-database", encoding="utf-8")
+    if request.param:
+        connect = sqlite3.connect
+
+        def remove_then_connect(*args, **kwargs):
+            db_path.unlink()
+            return connect(*args, **kwargs)
+
+        monkeypatch.setattr(sqlite3, "connect", remove_then_connect)
+    return tmp_path, db_path, request.param

--- a/tests/unit/mcp/test_safe_to_edit_tool_snapshot_integrity.py
+++ b/tests/unit/mcp/test_safe_to_edit_tool_snapshot_integrity.py
@@ -15,23 +15,20 @@ from tree_sitter_analyzer.mcp.tools.safe_to_edit_tool import (
 )
 from tree_sitter_analyzer.mcp.tools.utils import safe_to_edit_helpers as helpers
 
+unreadable_index = _fixtures.unreadable_index
 tool = _fixtures.tool
 _close_index_snapshot_registry = _fixtures._close_index_snapshot_registry
 
 
-def test_live_violations_query_degrades_on_corrupt_db_file(
-    tmp_path: Path,
-) -> None:
-    """非 SQLite 的 index.db 降级为空违规列表。"""
+def test_live_violations_query_degrades_on_corrupt_db_file(unreadable_index) -> None:
+    """损坏或打开前被删除的数据库降级为空列表，且不重建文件。"""
     from tree_sitter_analyzer.mcp.tools.utils.constraint_violation_query import (
         violations_for_files,
     )
 
-    (tmp_path / ".ast-cache").mkdir()
-    (tmp_path / ".ast-cache" / "index.db").write_text(
-        "not-a-sqlite-database", encoding="utf-8"
-    )
+    tmp_path, db_path, remove_during_open = unreadable_index
     assert violations_for_files(str(tmp_path), ["app.py"]) == []
+    assert db_path.exists() is (not remove_during_open)
 
 
 def test_snapshot_dependency_view_degrades_on_closed_conn() -> None:

--- a/tests/unit/mcp/test_self_health_tool.py
+++ b/tests/unit/mcp/test_self_health_tool.py
@@ -226,9 +226,13 @@ def test_ast_index_reacts_to_a_real_index_on_disk(tmp_path: Any) -> None:
     assert (absent["status"], present["status"]) == ("ABSENT", "OK")
 
 
-def test_ast_index_counts_indexed_files(tmp_path: Any) -> None:
+@pytest.mark.parametrize("directory", ["project", "project # % 日本語"])
+def test_ast_index_counts_indexed_files(tmp_path: Any, directory: str) -> None:
+    """路径中的 URI 保留字符和 Unicode 不能让健康报告误判索引不可读。"""
     import sqlite3
 
+    tmp_path = tmp_path / directory
+    tmp_path.mkdir()
     cache_dir = tmp_path / ".ast-cache"
     cache_dir.mkdir()
     connection = sqlite3.connect(str(cache_dir / "index.db"))

--- a/tests/unit/mcp/test_symbol_lineage_tool.py
+++ b/tests/unit/mcp/test_symbol_lineage_tool.py
@@ -415,14 +415,27 @@ class TestInheritanceLineage:
 
 
 class TestAstIndexStaleness:
-    def test_empty_ast_index_is_unknown_not_stale(self, tool, tmp_path):
-        """An empty DB created by a read path is not a completed stale index."""
+    @pytest.mark.parametrize("remove_during_open", [False, True])
+    def test_empty_ast_index_is_unknown_not_stale(
+        self, tool, tmp_path, monkeypatch, remove_during_open
+    ):
+        """空库或打开前消失的库均为未知；读取不能重新创建已删除数据库。"""
         from tree_sitter_analyzer.ast_cache import ASTCache
+        from tree_sitter_analyzer.cache import fingerprint
 
         _write_py(tmp_path, "pkg/a.py", "class A:\n    pass\n")
         ASTCache(str(tmp_path)).close()
+        db = tmp_path / ".ast-cache" / "index.db"
+        if remove_during_open:
+            original = fingerprint.sqlite3.connect
 
+            def removed(*args, **kwargs):
+                db.unlink()
+                return original(*args, **kwargs)
+
+            monkeypatch.setattr(fingerprint.sqlite3, "connect", removed)
         assert is_ast_index_stale(str(tmp_path)) is False
+        assert db.exists() is (not remove_during_open)
 
     def test_stale_when_supported_source_file_is_added_after_index(
         self, tool, tmp_path

--- a/tests/unit/mcp/tools/test_refactor_queue_tool.py
+++ b/tests/unit/mcp/tools/test_refactor_queue_tool.py
@@ -199,3 +199,27 @@ class TestReadOnlyInPractice:
         before = snapshot()
         _run(RefactorQueueTool(project_root=str(tmp_path)), {"output_format": "json"})
         assert sorted(snapshot()) == sorted(before)
+
+
+@pytest.mark.parametrize("name", ["_churn_by_file", "_symbol_counts"])
+@pytest.mark.parametrize("directory", ["project", "project # % 日本語"])
+def test_queue_reads_do_not_recreate_removed_database(
+    tmp_path, monkeypatch, name, directory
+):
+    """统计读取保留正常结果，但存在检查后的删除不能重新创建空库。"""
+    from tree_sitter_analyzer.mcp.tools import refactor_queue_tool as module
+
+    root = tmp_path / directory
+    _seed_index(root, {"a.py": 3}, {"a.py": 3})
+    reader = getattr(module, name)
+    assert reader(root) == {"a.py": 3}
+    db = root / ".ast-cache" / "index.db"
+    original = sqlite3.connect
+
+    def removed(*args, **kwargs):
+        db.unlink()
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(module.sqlite3, "connect", removed)
+    assert reader(root) == {}
+    assert not db.exists()

--- a/tests/unit/mcp/tools/utils/test_dependents_index.py
+++ b/tests/unit/mcp/tools/utils/test_dependents_index.py
@@ -359,3 +359,25 @@ def test_index_derivation_reads_less_than_the_scan(project: Path) -> None:
         dependents_index.scan_dependents("pkg/target.py", project)
 
     assert len(reads_index) < len(reads_scan)
+
+
+def test_dependents_read_does_not_recreate_removed_database(project, monkeypatch):
+    """读取时数据库消失应明确回退到扫描，不能创建空索引。"""
+    db = project / ".ast-cache" / "index.db"
+    db.parent.mkdir()
+    sqlite3.connect(db).close()
+    original = sqlite3.connect
+
+    def removed(*args, **kwargs):
+        db.unlink()
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(dependents_index.sqlite3, "connect", removed)
+    answer = resolve_dependents("pkg/target.py", project)
+    assert answer.certification_reason == "INDEX_UNREADABLE"
+    assert answer.dependents == frozenset(
+        {"pkg/importer.py", "pkg/absolute_importer.py", "pkg/mentions_only.py"}
+    )
+    assert answer.basis == "scan"
+    assert answer.certified is False
+    assert not db.exists()

--- a/tests/unit/test_ast_cache_build_state.py
+++ b/tests/unit/test_ast_cache_build_state.py
@@ -33,6 +33,57 @@ from tree_sitter_analyzer.mcp.tools.codegraph_status_tool import CodeGraphStatus
 requires_posix_snapshot = pytest.mark.skipif(os.name != "posix", reason="GH-1253")
 
 
+@pytest.mark.parametrize("directory", ["project", "project # % 日本語"])
+def test_rebuild_signal_does_not_recreate_removed_database(
+    tmp_path, monkeypatch, directory
+):
+    """存在检查后数据库被删除时，状态探测不能创建替代空库。"""
+    from tree_sitter_analyzer.mcp.tools import index_rebuild_signal as signal
+
+    root = tmp_path / directory
+    db = root / ".ast-cache" / "index.db"
+    db.parent.mkdir(parents=True)
+    conn = sqlite3.connect(db)
+    bs.mark_build_in_progress(conn)
+    conn.close()
+    original_connect = sqlite3.connect
+
+    def remove_before_open(*args, **kwargs):
+        db.unlink()
+        return original_connect(*args, **kwargs)
+
+    monkeypatch.setattr(signal.sqlite3, "connect", remove_before_open)
+    assert signal.is_index_rebuilding(str(root)) is False
+    assert not db.exists()
+
+
+@pytest.mark.parametrize("directory", ["project", "project # % 日本語"])
+def test_rebuild_signal_reads_current_marker_with_readonly_connection(
+    tmp_path, monkeypatch, directory
+):
+    """正常标记仍可读取；特殊路径必须正确编码，连接不能写入。"""
+    from tree_sitter_analyzer.mcp.tools import index_rebuild_signal as signal
+
+    root = tmp_path / directory
+    db = root / ".ast-cache" / "index.db"
+    db.parent.mkdir(parents=True)
+    conn = sqlite3.connect(db)
+    bs.mark_build_in_progress(conn)
+    conn.close()
+    original_reader = bs.build_in_progress
+    observed = []
+
+    def verify_readonly(connection):
+        with pytest.raises(sqlite3.OperationalError, match="readonly"):
+            connection.execute("CREATE TABLE forbidden_write (value INTEGER)")
+        observed.append(True)
+        return original_reader(connection)
+
+    monkeypatch.setattr(bs, "build_in_progress", verify_readonly)
+    assert signal.is_index_rebuilding(str(root)) is True
+    assert observed == [True]
+
+
 def test_build_state_helpers_degrade_on_missing_table() -> None:
     """No ast_build_state table → safe defaults, no raise; mark creates it."""
     conn = sqlite3.connect(":memory:")

--- a/tests/unit/test_change_impact_cached_graph.py
+++ b/tests/unit/test_change_impact_cached_graph.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+import sqlite3
+
+import pytest
+
 from tree_sitter_analyzer.ast_cache import ASTCache
+from tree_sitter_analyzer.cache.schema import CURRENT_SCHEMA_VERSION
 from tree_sitter_analyzer.mcp.tools.utils import change_impact_cached_graph as cached
 from tree_sitter_analyzer.mcp.tools.utils.change_impact_cached_graph import (
     CachedDependencyGraph,
@@ -119,14 +124,7 @@ def test_cached_index_rows_handles_query_failure():
         def execute(self, query):
             raise RuntimeError("boom")
 
-    class BadCache:
-        def get_conn(self):
-            return BadConn()
-
-        def _get_conn(self):  # backward-compat alias
-            return self.get_conn()
-
-    assert cached._cached_index_rows(BadCache()) == []
+    assert cached._cached_index_rows(BadConn()) == []
 
 
 def test_add_cached_import_edges_ignores_unsupported_languages(tmp_path):
@@ -162,3 +160,40 @@ def test_add_cached_import_edges_normalizes_windows_resolver_paths(
     )
 
     assert graph.dependencies_of("src/index.js") == ["src/formatter.js"]
+
+
+def test_cached_graph_does_not_recreate_removed_database(tmp_path, monkeypatch):
+    """存在检查后消失的索引应回退，不能被查询重新创建。"""
+    _index_project(tmp_path)
+    db_path = tmp_path / ".ast-cache" / "index.db"
+    connect = sqlite3.connect
+
+    def remove_then_connect(*args, **kwargs):
+        db_path.unlink()
+        return connect(*args, **kwargs)
+
+    monkeypatch.setattr(sqlite3, "connect", remove_then_connect)
+    assert cached.load_cached_dependency_graph(str(tmp_path)) is None
+    assert not db_path.exists()
+
+
+@pytest.mark.parametrize("version", [1, CURRENT_SCHEMA_VERSION + 1])
+def test_cached_graph_does_not_migrate_incompatible_database(tmp_path, version):
+    """旧版或未来版本索引保持原状，由调用方回退到源码分析。"""
+    (tmp_path / "a.py").write_text("value = 1\n", encoding="utf-8")
+    _index_project(tmp_path)
+    db_path = tmp_path / ".ast-cache" / "index.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute("DELETE FROM ast_schema_version")
+        conn.execute(
+            "INSERT INTO ast_schema_version(version, applied_at, description) "
+            "VALUES (?, 0, 'test')",
+            (version,),
+        )
+        conn.commit()
+        before = list(conn.iterdump())
+        assert cached.load_cached_dependency_graph(str(tmp_path)) is None
+        assert list(conn.iterdump()) == before
+    finally:
+        conn.close()

--- a/tree_sitter_analyzer/cache/fingerprint.py
+++ b/tree_sitter_analyzer/cache/fingerprint.py
@@ -179,8 +179,15 @@ def is_ast_index_stale(project_root: str) -> bool:
     try:
         # timeout=10 与 ast_cache.py 的主连接保持一致：多进程共用缓存库时，
         # 无超时的连接遇到写锁会立刻抛 database is locked 而不是等待重试
-        conn = sqlite3.connect(str(db_path), timeout=10, check_same_thread=False)
+        conn = sqlite3.connect(
+            db_path.absolute().as_uri() + "?mode=rw",
+            uri=True,
+            timeout=10,
+            check_same_thread=False,
+        )
         try:
+            # 只查询现有索引；文件消失时拒绝连接，不能重建空库。
+            conn.execute("PRAGMA query_only=ON")
             rows = conn.execute("SELECT file_path, mtime_ns FROM ast_index").fetchall()
         finally:
             conn.close()

--- a/tree_sitter_analyzer/mcp/tools/index_rebuild_signal.py
+++ b/tree_sitter_analyzer/mcp/tools/index_rebuild_signal.py
@@ -1,17 +1,16 @@
-"""Shared read-side signal for AST cache full rebuild windows (#578)."""
+"""AST 缓存完整重建期间共用的只读状态信号（#578）。"""
 
 from __future__ import annotations
 
 import os
 import sqlite3
+from pathlib import Path
 
 
 def is_index_rebuilding(project_root: str | None) -> bool:
-    """Return True when a full AST-cache rebuild marker is active.
+    """尽力读取重建标记；缺失或读取失败时返回 False，不阻断导航。
 
-    Best-effort and deliberately fail-open. A slow/locked marker read must not
-    block navigation tools; missing the warning is preferable to turning every
-    read into a lock-contention failure.
+    只读打开防止存在检查后文件消失时创建空库；保留两秒锁等待上限。
     """
     if not project_root:
         return False
@@ -21,7 +20,9 @@ def is_index_rebuilding(project_root: str | None) -> bool:
     try:
         from tree_sitter_analyzer.cache.build_state import build_in_progress
 
-        conn = sqlite3.connect(db_path, timeout=2)
+        conn = sqlite3.connect(
+            Path(db_path).absolute().as_uri() + "?mode=ro", uri=True, timeout=2
+        )
         try:
             return bool(build_in_progress(conn))
         finally:

--- a/tree_sitter_analyzer/mcp/tools/refactor_queue_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/refactor_queue_tool.py
@@ -81,7 +81,9 @@ def _churn_by_file(root: Path) -> dict[str, int]:
         return {}
     conn: sqlite3.Connection | None = None
     try:
-        conn = sqlite3.connect(str(db_path))
+        conn = sqlite3.connect(db_path.absolute().as_uri() + "?mode=rw", uri=True)
+        # 禁止建库和 SQL 写入，同时保留 SQLite 关闭时的 WAL 清理。
+        conn.execute("PRAGMA query_only=ON")
         rows = conn.execute(
             "SELECT file_path, SUM(mod_count_30d) AS churn "
             "FROM ast_symbol_activation GROUP BY file_path"
@@ -102,7 +104,9 @@ def _symbol_counts(root: Path) -> dict[str, int]:
         return {}
     conn: sqlite3.Connection | None = None
     try:
-        conn = sqlite3.connect(str(db_path))
+        conn = sqlite3.connect(db_path.absolute().as_uri() + "?mode=rw", uri=True)
+        # 禁止建库和 SQL 写入，同时保留 SQLite 关闭时的 WAL 清理。
+        conn.execute("PRAGMA query_only=ON")
         rows = conn.execute(
             "SELECT file_path, COUNT(*) AS n FROM ast_symbol_rows GROUP BY file_path"
         ).fetchall()

--- a/tree_sitter_analyzer/mcp/tools/self_health_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/self_health_tool.py
@@ -49,6 +49,7 @@ from __future__ import annotations
 
 import os
 import sqlite3
+from pathlib import Path
 from typing import Any
 
 from ...latency import (
@@ -252,7 +253,9 @@ def _ast_index_report(project_root: str | None) -> dict[str, Any]:
     report["present"] = True
     try:
         report["size_bytes"] = os.path.getsize(db_path)
-        connection = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        connection = sqlite3.connect(
+            Path(db_path).absolute().as_uri() + "?mode=ro", uri=True
+        )
         try:
             row = connection.execute("SELECT COUNT(*) FROM ast_index").fetchone()
         finally:

--- a/tree_sitter_analyzer/mcp/tools/utils/change_impact_cached_graph.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/change_impact_cached_graph.py
@@ -11,11 +11,12 @@ from __future__ import annotations
 import json
 import logging
 import re
+import sqlite3
 from collections import defaultdict
 from pathlib import Path
 from typing import Any
 
-from ....ast_cache import ASTCache
+from ....cache.schema import CURRENT_SCHEMA_VERSION, already_applied_versions
 from ....project_graph import _IMPORT_RESOLVERS
 from ....synapse_resolver import parse_imports
 
@@ -89,10 +90,18 @@ def load_cached_dependency_graph(
     if not db_path.is_file():
         return None
 
-    cache: ASTCache | None = None
+    conn: sqlite3.Connection | None = None
     try:
-        cache = ASTCache(project_root)
-        rows = _cached_index_rows(cache)
+        # 查询不负责建库或迁移；旧索引交给现有源码分析路径处理。
+        conn = sqlite3.connect(db_path.absolute().as_uri() + "?mode=rw", uri=True)
+        conn.execute("PRAGMA query_only=ON")
+        conn.row_factory = sqlite3.Row
+        versions = already_applied_versions(conn)
+        if CURRENT_SCHEMA_VERSION not in versions or any(
+            version < 1 or version > CURRENT_SCHEMA_VERSION for version in versions
+        ):
+            return None
+        rows = _cached_index_rows(conn)
         if not rows:
             return None
         nodes = {row["file_path"] for row in rows}
@@ -104,15 +113,14 @@ def load_cached_dependency_graph(
         logger.debug("cached dependency graph load failed", exc_info=True)
         return None
     finally:
-        if cache is not None:
+        if conn is not None:
             try:
-                cache.close()
+                conn.close()
             except Exception:
                 pass
 
 
-def _cached_index_rows(cache: ASTCache) -> list[dict[str, Any]]:
-    conn = cache.get_conn()
+def _cached_index_rows(conn: sqlite3.Connection) -> list[dict[str, Any]]:
     try:
         rows = conn.execute(
             "SELECT file_path, language, imports_json FROM ast_index"

--- a/tree_sitter_analyzer/mcp/tools/utils/constraint_violation_query.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/constraint_violation_query.py
@@ -115,7 +115,11 @@ def violations_for_files(
 
     conn: sqlite3.Connection | None = None
     try:
-        conn = sqlite3.connect(str(db_path), timeout=10)
+        # 只打开已有文件并禁止业务 SQL 写入，保留 SQLite 的 WAL 清理行为。
+        conn = sqlite3.connect(
+            db_path.absolute().as_uri() + "?mode=rw", uri=True, timeout=10
+        )
+        conn.execute("PRAGMA query_only=ON")
         return violations_for_files_from_conn(conn, file_paths)
     except sqlite3.Error:
         logger.debug("violations_for_files: query failed", exc_info=True)

--- a/tree_sitter_analyzer/mcp/tools/utils/dependents_index.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/dependents_index.py
@@ -319,10 +319,12 @@ def resolve_dependents(target_rel: str, root: Path) -> DependentsAnswer:
         return _scan_answer(target_rel, root, "INDEX_ABSENT", len(inventory))
 
     try:
-        conn = sqlite3.connect(str(db_path))
+        conn = sqlite3.connect(db_path.absolute().as_uri() + "?mode=rw", uri=True)
     except sqlite3.Error:
         return _scan_answer(target_rel, root, "INDEX_UNREADABLE", len(inventory))
     try:
+        # 只打开已有数据库；禁止业务 SQL 写入，保留 SQLite 的正常关闭清理。
+        conn.execute("PRAGMA query_only=ON")
         return _derive(conn, target_rel, root, inventory)
     except sqlite3.DatabaseError:
         logger.debug("dependents index unreadable; falling back", exc_info=True)


### PR DESCRIPTION
Read-side SQLite helpers can recreate a deleted index.db between an existence check and connect. Separately, self-health interpolates the path into a URI without escaping it, so healthy indexes under paths containing URI delimiters are reported unreadable.

Use encoded file URIs with no-create opening modes for rebuild status, refactor-queue statistics, dependents lookup, constraint-violation queries and index-freshness checks, and cached dependency graphs. Rebuild status uses mode=ro. Queue/dependents/constraints/freshness/cached-graph use mode=rw plus query_only=ON to prohibit business SQL writes while retaining existing SQLite WAL-close cleanup; switching queue readers to mode=ro left WAL/SHM files behind and failed the existing no-added-files regression. Self-health keeps mode=ro and correctly encodes the path. This is not a claim of universally side-effect-free filesystem reads; SQLite query_only does not disable every engine maintenance operation ([SQLite documentation](https://www.sqlite.org/pragma.html#pragma_query_only)).

Cached dependency-graph reads now open SQLite directly instead of constructing ASTCache and triggering schema initialization/migration. Only a supported current schema is reused; older/future schemas fall back to the existing source-backed graph without modifying their database. This does not add source freshness certification.

Regression evidence includes deletion exactly at connect, normal query results, spaces/hash/percent/Unicode paths, read-only SQL enforcement for rebuild status, existing queue filesystem checks, and the conservative dependents scan fallback. Four original cases, six follow-up cases the freshness disappearance case and the constraint disappearance case failed before their respective fixes.

Validation:
- TSA-mapped cache and affected diagnostic suites: 905 passed, one existing skip without retries in 9.78 seconds, with fresh coverage JSON.
- Constraint snapshot-integrity suite after fixture cleanup: 25 passed; original corrupt-database case retained, module remains 495 lines.
- Cached-graph disappearance and old-schema cases failed before the fix; all 12 graph tests pass afterward, including Python/JavaScript edges and future-schema rejection.
- Real scoped change-impact CLI returned success and the focused verification command.
- Patch coverage gate: no added executable misses.
- TSA-selected quick gate: 2,047 passed, 28 existing skips in 27.26 seconds.
- Facade generation: no diff; three drift checks passed.
- Real CLI self-health smokes: empty index reported EMPTY; #/%/Unicode project path reported OK with exactly one indexed file.
- git diff --check and commit hooks passed.

No public fields/flags or schema changes. RFC-0032 storage migration and comprehensive path/snapshot certification remain separate work; other legacy read helpers have not been declared fully audited by this PR.
