### PR TITLE
fix: bind parser, graph and live tool caches to source content

### DIFF
--- a/tests/unit/core/test_parser.py
+++ b/tests/unit/core/test_parser.py
@@ -419,3 +419,24 @@ def temp_file() -> Path:
         temp_path.unlink()
     except Exception:
         pass
+
+
+@pytest.mark.parametrize("clear_stat", [False, True])
+def test_parse_file_cache_uses_current_content(tmp_path, clear_stat):
+    """保留时间戳和大小的改写不能复用旧 AST。"""
+    import os
+
+    path = tmp_path / "same.py"
+    path.write_text("before = 1\n", encoding="utf-8")
+    parser = Parser()
+    first = parser.parse_file(path, "python")
+    before = path.stat()
+    path.write_text("after_ = 2\n", encoding="utf-8")
+    os.utime(path, ns=(before.st_atime_ns, before.st_mtime_ns))
+    if clear_stat:
+        Parser.invalidate_stat_cache()
+    second = parser.parse_file(path, "python")
+    assert first.source_code == "before = 1\n"
+    assert second.source_code == "after_ = 2\n"
+    assert second.tree.root_node.text == b"after_ = 2\n"
+    assert parser.parse_file(path, "python") is second

--- a/tests/unit/mcp/test_graph_cache_invalidation.py
+++ b/tests/unit/mcp/test_graph_cache_invalidation.py
@@ -208,8 +208,9 @@ class TestDependencyAnalysisCacheInvalidatesOnFileChange:
 
 
 class TestSymbolLineageCacheInvalidatesOnFileChange:
+    @pytest.mark.parametrize("preserve_mtime", [False, True])
     def test_symbol_lineage_cache_invalidates_on_file_change(
-        self, project_root: Path
+        self, project_root: Path, preserve_mtime
     ) -> None:
         tool = SymbolLineageTool(project_root=str(project_root))
 
@@ -223,8 +224,17 @@ class TestSymbolLineageCacheInvalidatesOnFileChange:
         assert r2.get("from_cache") is True
         assert tool._dep_graph is cold_graph
 
-        time.sleep(0.05)
-        os.utime(project_root / "pkg" / "a.py")
+        path = project_root / "pkg" / "a.py"
+        if preserve_mtime:
+            before = path.stat()
+            path.write_text(
+                path.read_text(encoding="utf-8").replace("def foo", "def goo"),
+                encoding="utf-8",
+            )
+            os.utime(path, ns=(before.st_atime_ns, before.st_mtime_ns))
+        else:
+            time.sleep(0.05)
+            os.utime(path)
 
         r3 = asyncio.run(tool.execute({"symbol": "bar", "output_format": "json"}))
         # Rebuild must wipe the symbol cache too, so from_cache should be
@@ -311,3 +321,61 @@ def test_dependency_graph_key_rejects_unstable_input(tmp_path, monkeypatch, fail
 
         monkeypatch.setattr(os, "fstat", changed)
     assert DependencyGraph._cache_key_for(str(tmp_path)) is None
+
+
+@pytest.mark.parametrize("kind", ["dependency", "lineage", "smart", "safe"])
+def test_live_tool_graph_rejects_preserved_mtime_edit(project_root, kind):
+    """常驻工具的外层图缓存也必须发现等时间戳改写。"""
+    from tree_sitter_analyzer.mcp.tools.safe_to_edit_tool import SafeToEditTool
+    from tree_sitter_analyzer.mcp.tools.smart_context_tool import SmartContextTool
+
+    factories = {
+        "dependency": DependencyAnalysisTool,
+        "lineage": SymbolLineageTool,
+        "smart": SmartContextTool,
+        "safe": SafeToEditTool,
+    }
+    (project_root / "pkg" / "c.py").write_text(
+        "def bar(): return 2\n", encoding="utf-8"
+    )
+    tool = factories[kind](str(project_root))
+    get_graph = tool._get_dep_graph if kind == "lineage" else tool._get_graph
+    first = get_graph()
+    assert first.dependencies_of("pkg/a.py") == ["pkg/b.py"]
+    assert get_graph() is first
+    path = project_root / "pkg" / "a.py"
+    before = path.stat()
+    path.write_text(
+        path.read_text(encoding="utf-8").replace("from .b", "from .c"), encoding="utf-8"
+    )
+    os.utime(path, ns=(before.st_atime_ns, before.st_mtime_ns))
+    assert get_graph().dependencies_of("pkg/a.py") == ["pkg/c.py"]
+
+
+def test_live_call_tool_rejects_preserved_mtime_edit(project_root):
+    """重复 MCP 调用不能沿用旧函数列表。"""
+    tool = CodeGraphCallTool(str(project_root))
+    args = {"mode": "all_functions", "output_format": "json"}
+    first = asyncio.run(tool.execute(args))
+    path = project_root / "pkg" / "a.py"
+    before = path.stat()
+    path.write_text(
+        path.read_text(encoding="utf-8").replace("def foo", "def goo"), encoding="utf-8"
+    )
+    os.utime(path, ns=(before.st_atime_ns, before.st_mtime_ns))
+    second = asyncio.run(tool.execute(args))
+    assert {row["name"] for row in first["functions"]} == {"foo", "bar"}
+    assert {row["name"] for row in second["functions"]} == {"goo", "bar"}
+
+
+@pytest.mark.parametrize("kind", ["smart", "safe"])
+def test_live_graph_requires_project_root(kind):
+    """项目根目录被清除后不能返回此前缓存的图。"""
+    from tree_sitter_analyzer.mcp.tools.safe_to_edit_tool import SafeToEditTool
+    from tree_sitter_analyzer.mcp.tools.smart_context_tool import SmartContextTool
+
+    cls = SmartContextTool if kind == "smart" else SafeToEditTool
+    tool = cls()
+    tool.project_root = None
+    with pytest.raises(ValueError, match="Project root not set"):
+        tool._get_graph()

--- a/tests/unit/mcp/test_graph_cache_invalidation.py
+++ b/tests/unit/mcp/test_graph_cache_invalidation.py
@@ -251,3 +251,63 @@ class TestDependencyGraphGlobalCacheRespectsFingerprint:
         g2 = DependencyGraph(str(project_root))
         # Different fingerprints -> different cache keys -> different objects.
         assert g2 is not g1
+
+
+@pytest.mark.parametrize(
+    "padding", ["", "#" + "x" * 131072 + "\n"], ids=["short", "tail"]
+)
+def test_dependency_graph_cache_tracks_full_content(project_root, padding):
+    """相同时间戳、长度及文件数不能掩盖导入变更，包括文件尾部。"""
+    from tree_sitter_analyzer.project_graph import DependencyGraph
+
+    importer = project_root / "pkg" / "a.py"
+    importer.write_text(padding + "from .b import bar\n", encoding="utf-8")
+    (project_root / "pkg" / "c.py").write_text(
+        "def bar(): return 2\n", encoding="utf-8"
+    )
+    first = DependencyGraph(str(project_root))
+    assert first.dependencies_of("pkg/a.py") == ["pkg/b.py"]
+    assert DependencyGraph(str(project_root)) is first
+    before = importer.stat()
+    importer.write_text(padding + "from .c import bar\n", encoding="utf-8")
+    os.utime(importer, ns=(before.st_atime_ns, before.st_mtime_ns))
+    second = DependencyGraph(str(project_root))
+    assert second.dependencies_of("pkg/a.py") == ["pkg/c.py"]
+    assert second is not first
+
+
+def test_dependency_graph_key_rejects_unreadable_walk(tmp_path, monkeypatch):
+    """遍历失败不能被当作可复用的空源码树。"""
+    from tree_sitter_analyzer.project_graph import DependencyGraph
+
+    def denied(_path):
+        raise PermissionError("unreadable tree")
+
+    monkeypatch.setattr(os, "scandir", denied)
+    assert DependencyGraph._cache_key_for(str(tmp_path)) is None
+
+
+@pytest.mark.parametrize("failure", ["oversized", "changed_during_read"])
+def test_dependency_graph_key_rejects_unstable_input(tmp_path, monkeypatch, failure):
+    """超限或读取期间变化的文件不能产生可复用键。"""
+    from tree_sitter_analyzer.project_graph import DependencyGraph
+
+    path = tmp_path / "a.py"
+    path.write_text("value = 1\n", encoding="utf-8")
+    if failure == "oversized":
+        with path.open("ab") as stream:
+            stream.truncate(64 * 1024 * 1024 + 1)
+    else:
+        original = os.fstat
+        calls = 0
+
+        def changed(fd):
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                before = path.stat()
+                os.utime(path, ns=(before.st_atime_ns, before.st_mtime_ns + 1000000))
+            return original(fd)
+
+        monkeypatch.setattr(os, "fstat", changed)
+    assert DependencyGraph._cache_key_for(str(tmp_path)) is None

--- a/tests/unit/mcp/test_safe_to_edit_tool_syntax_envelope.py
+++ b/tests/unit/mcp/test_safe_to_edit_tool_syntax_envelope.py
@@ -252,3 +252,20 @@ def test_snapshot_syntax_envelope_marks_incomplete_import_projection_unavailable
         "verification_command": None,
         "stale_edges": None,
     }
+
+
+def test_live_syntax_error_response_preserves_json_envelope(tmp_path):
+    """损坏源码通过实际工具入口返回明确错误封套。"""
+    import asyncio
+
+    from tree_sitter_analyzer.mcp.tools.safe_to_edit_tool import SafeToEditTool
+
+    (tmp_path / "broken.py").write_text("def broken(:\n", encoding="utf-8")
+    result = asyncio.run(
+        SafeToEditTool(str(tmp_path)).execute(
+            {"file_path": "broken.py", "output_format": "json"}
+        )
+    )
+    assert result["verdict"] == "ERROR"
+    assert result["signal"] == "syntax_error"
+    assert result["output_format"] == "json"

--- a/tests/unit/test_health_scorer.py
+++ b/tests/unit/test_health_scorer.py
@@ -891,3 +891,93 @@ class TestScoreComplexityExtractorPath:
         assert score == 100.0, (
             f"4 simple Python functions must score 100.0 (avg_cc=1.0), got {score}"
         )
+
+
+def test_project_health_reuses_graph_only_within_one_call(tmp_path, monkeypatch):
+    """每次项目评分只校验一次依赖图，下次调用必须发现内容变化。"""
+    import os
+
+    from tree_sitter_analyzer.health_scorer import HealthScorer
+    from tree_sitter_analyzer.project_graph import DependencyGraph
+
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname="probe"\n', encoding="utf-8"
+    )
+    for name in ("b", "c"):
+        (tmp_path / f"{name}.py").write_text("value = 1\n", encoding="utf-8")
+    for index in range(6):
+        (tmp_path / f"a{index}.py").write_text("import b\n", encoding="utf-8")
+    original = DependencyGraph._cache_key_for
+    calls = []
+
+    def measured(root):
+        calls.append(root)
+        return original(root)
+
+    monkeypatch.setattr(DependencyGraph, "_cache_key_for", staticmethod(measured))
+    scorer = HealthScorer()
+    first, _ = scorer.score_project_with_stats(str(tmp_path), use_cache=False)
+    for index in range(6):
+        path = tmp_path / f"a{index}.py"
+        before = path.stat()
+        path.write_text("import c\n", encoding="utf-8")
+        os.utime(path, ns=(before.st_atime_ns, before.st_mtime_ns))
+    second, _ = scorer.score_project_with_stats(str(tmp_path), use_cache=False)
+    assert len(calls) == 2
+
+    def by_name(scores):
+        return {
+            Path(score.file_path).name: score.dimensions["dependencies"]
+            for score in scores
+        }
+
+    assert by_name(first)["b.py"] == 99.1
+    assert by_name(second)["b.py"] == 100.0
+    assert by_name(second)["c.py"] == 99.1
+
+
+def test_project_health_restores_graph_scope_after_failure(tmp_path, monkeypatch):
+    """评分失败也必须恢复调用方上下文，不泄漏项目图缓存。"""
+    from tree_sitter_analyzer.health_scorer import (
+        _PROJECT_DEPENDENCY_GRAPHS,
+        HealthScorer,
+    )
+
+    scorer = HealthScorer()
+    outer = {"outer": object()}
+    token = _PROJECT_DEPENDENCY_GRAPHS.set(outer)
+
+    def fail(_root):
+        raise RuntimeError("enumeration failed")
+
+    monkeypatch.setattr(scorer, "_iter_source_files", fail)
+    try:
+        with pytest.raises(RuntimeError, match="enumeration failed"):
+            scorer.score_project_with_stats(str(tmp_path), use_cache=False)
+        assert _PROJECT_DEPENDENCY_GRAPHS.get() is outer
+    finally:
+        _PROJECT_DEPENDENCY_GRAPHS.reset(token)
+
+
+def test_project_graph_timeout_does_not_populate_scope(tmp_path, monkeypatch):
+    """超时回退不能把未完成的图当作本次评分可复用的结果。"""
+    import time
+
+    import tree_sitter_analyzer.health_scorer as health
+
+    path = tmp_path / "a.py"
+    path.write_text("import os\n", encoding="utf-8")
+    graphs = {}
+    token = health._PROJECT_DEPENDENCY_GRAPHS.set(graphs)
+
+    def delayed(_root):
+        time.sleep(0.03)
+        return object()
+
+    monkeypatch.setattr(health, "_build_dep_graph", delayed)
+    monkeypatch.setattr(health, "_DEP_GRAPH_TIMEOUT_S", 0.001)
+    try:
+        assert health.score_dependencies(str(path)) == 100.0
+        assert graphs == {}
+    finally:
+        health._PROJECT_DEPENDENCY_GRAPHS.reset(token)

--- a/tree_sitter_analyzer/core/parser.py
+++ b/tree_sitter_analyzer/core/parser.py
@@ -113,9 +113,7 @@ class Parser:
     # Class-level cache shared across all Parser instances. Sized for medium
     # projects.
     _cache: LRUCache = LRUCache(maxsize=_PARSER_CACHE_SIZE)
-    # Stat-only fast path: maps file_path → (mtime_ns, size, language,
-    # cache_key) so a hot warm pass can skip the SHA-256 entirely when
-    # mtime+size are unchanged. Falls back to the SHA-256 path on any miss.
+    # 记录文件属性与内容键；属性只用于命中统计，不能绕过源码读取。
     _stat_cache: dict[str, tuple[int, int, str, str]] = {}
     # Hit/miss counters — used by tests and by `cache_info()`.
     _hits = 0
@@ -153,23 +151,11 @@ class Parser:
 
     @classmethod
     def invalidate_stat_cache(cls) -> None:
-        """Drop only the stat-only fast path.
-
-        Codex P2 (#1299 round-13, C60): the stat fast path keys on
-        (path, mtime_ns, size) — a same-size rewrite with a restored mtime
-        would serve a stale parse on snapshot-certified reads, which must
-        always parse the freshly recaptured bytes. The content-addressed
-        SHA-256 cache stays intact.
-        """
+        """清理属性命中记录，保留已按实际解析内容寻址的 AST 缓存。"""
         cls._stat_cache.clear()
 
     def parse_file(self, file_path: str | Path, language: str) -> ParseResult:
-        """Parse a source code file.
-
-        r37ax (dogfood): tool flagged this at 113 lines / nesting depth 8.
-        Split into 4 named phases — existence check, cache lookup, file
-        read with encoding fallback, parse-and-store. Behaviour preserved.
-        """
+        """读取当前源码，以同一文本查缓存或解析，避免属性键误命中。"""
         file_path_str = str(file_path)
         path_obj = Path(file_path_str)
         if not path_obj.exists():
@@ -178,14 +164,13 @@ class Parser:
             )
 
         try:
-            cache_key, cached = self._cache_lookup(file_path_str, language)
-            if cached is not None:
-                return cached
-
             read_outcome = self._read_source_code(path_obj, language)
             if isinstance(read_outcome, ParseResult):
                 return read_outcome
             source_code = read_outcome
+            cache_key, cached = self._cache_lookup(file_path_str, language, source_code)
+            if cached is not None:
+                return cached
 
             result = self.parse_code(source_code, language, filename=file_path_str)
             if result.success and cache_key:
@@ -200,13 +185,9 @@ class Parser:
             )
 
     def _cache_lookup(
-        self, file_path_str: str, language: str
+        self, file_path_str: str, language: str, source_code: str
     ) -> tuple[str | None, ParseResult | None]:
-        """Return ``(cache_key, cached_result_or_None)`` for the cache layer.
-
-        Bumps ``_hits`` / ``_misses`` / ``_stat_hits`` as a side effect.
-        Returns ``(None, None)`` on stat errors so the caller still proceeds.
-        """
+        """用同一次读取的源码查找 AST；文件属性不可替代内容身份。"""
         try:
             stat = os.stat(file_path_str)
             mtime_ns = int(stat.st_mtime_ns)
@@ -216,7 +197,7 @@ class Parser:
             return (None, None)
 
         cache_key = self._lookup_or_record_stat_key(
-            file_path_str, mtime_ns, size, language
+            file_path_str, mtime_ns, size, language, source_code
         )
         cached = Parser._cache.get(cache_key)
         if cached is not None:
@@ -227,21 +208,26 @@ class Parser:
         return (cache_key, None)
 
     def _lookup_or_record_stat_key(
-        self, file_path_str: str, mtime_ns: int, size: int, language: str
+        self,
+        file_path_str: str,
+        mtime_ns: int,
+        size: int,
+        language: str,
+        source_code: str,
     ) -> str:
-        """Return the cache key, reusing a prior stat hit when possible."""
+        """内容键绑定实际解析文本，属性一致仅增加兼容诊断计数。"""
+        identity = f"{file_path_str}\0{language}\0{source_code}"
+        cache_key = hashlib.sha256(identity.encode("utf-8")).hexdigest()
         stat_entry = Parser._stat_cache.get(file_path_str)
         if (
             stat_entry is not None
             and stat_entry[0] == mtime_ns
             and stat_entry[1] == size
             and stat_entry[2] == language
+            and stat_entry[3] == cache_key
         ):
             Parser._stat_hits += 1
-            return str(stat_entry[3])
 
-        key_string = f"{file_path_str}:{mtime_ns}:{size}:{language}"
-        cache_key = hashlib.sha256(key_string.encode("utf-8")).hexdigest()
         Parser._stat_cache[file_path_str] = (mtime_ns, size, language, cache_key)
         return cache_key
 

--- a/tree_sitter_analyzer/health_scorer.py
+++ b/tree_sitter_analyzer/health_scorer.py
@@ -14,6 +14,7 @@ Computes a 0-100 health score for source files based on weighted dimensions:
 import json
 import logging
 import os
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -29,6 +30,11 @@ from .registry.health_scorer_helpers import (
 )
 
 logger = logging.getLogger(__name__)
+
+# 仅在一次项目评分内复用依赖图；上下文令牌隔离嵌套调用与并发请求。
+_PROJECT_DEPENDENCY_GRAPHS: ContextVar[dict[str, Any] | None] = ContextVar(
+    "project_health_dependency_graphs", default=None
+)
 
 # Dimension weights (must sum to 100)
 DIMENSION_WEIGHTS = {
@@ -379,6 +385,7 @@ class HealthScorer:
         excluded_files = 0
         pruned_directories = 0
         scoring_failed = 0
+        graph_token = _PROJECT_DEPENDENCY_GRAPHS.set({})
         try:
             files, pruned_directories = self._iter_source_files(root)
             for f in files:
@@ -392,6 +399,7 @@ class HealthScorer:
                     continue
                 results.append(score)
         finally:
+            _PROJECT_DEPENDENCY_GRAPHS.reset(graph_token)
             if cache is not None:
                 cache.close()
 
@@ -776,12 +784,18 @@ def score_dependencies(file_path: str) -> float:
         path = Path(file_path).resolve()
         project_root = find_project_root(path)
 
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
-            fut = ex.submit(_build_dep_graph, str(project_root))
-            try:
-                graph = fut.result(timeout=_DEP_GRAPH_TIMEOUT_S)
-            except concurrent.futures.TimeoutError:
-                return _score_deps_fallback(file_path)
+        graphs = _PROJECT_DEPENDENCY_GRAPHS.get()
+        root_key = str(project_root)
+        graph = graphs.get(root_key) if graphs is not None else None
+        if graph is None:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+                fut = ex.submit(_build_dep_graph, root_key)
+                try:
+                    graph = fut.result(timeout=_DEP_GRAPH_TIMEOUT_S)
+                except concurrent.futures.TimeoutError:
+                    return _score_deps_fallback(file_path)
+            if graphs is not None:
+                graphs[root_key] = graph
 
         rel = str(path.relative_to(project_root)).replace("\\", "/")
 

--- a/tree_sitter_analyzer/mcp/tools/call_graph_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/call_graph_tool.py
@@ -16,6 +16,7 @@ from tree_sitter_analyzer.cache.fingerprint import (
 )
 
 from ...call_graph import CallGraph
+from ...project_graph import DependencyGraph
 from ...utils import setup_logger
 from .base_tool import BaseMCPTool, _canonicalize_verdict, mirror_summary_line
 
@@ -252,6 +253,7 @@ class CodeGraphCallTool(BaseMCPTool):
         # Compared against a fresh fingerprint on every _get_call_graph()
         # to detect in-place edits that don't change the directory mtime.
         self._call_graph_fingerprint: GraphFingerprint | None = None
+        self._graph_content_key: str | None = None
         self._call_graph_built_at: float | None = None
         self._cache_invalidated_reason: str | None = None
         super().__init__(project_root)
@@ -259,6 +261,7 @@ class CodeGraphCallTool(BaseMCPTool):
     def _on_project_root_changed(self, project_root: str | None) -> None:
         self._call_graph = None
         self._call_graph_fingerprint = None
+        self._graph_content_key = None
         self._call_graph_built_at = None
         self._cache_invalidated_reason = None
 
@@ -267,6 +270,7 @@ class CodeGraphCallTool(BaseMCPTool):
             raise ValueError("Project root not set. Call set_project_path first.")
 
         current_fp = compute_graph_fingerprint(self.project_root)
+        content_key = DependencyGraph._cache_key_for(str(self.project_root))
         reason: str | None = None
         if self._call_graph is None:
             reason = "cold"
@@ -274,11 +278,14 @@ class CodeGraphCallTool(BaseMCPTool):
             reason = self._explain_fingerprint_delta(
                 self._call_graph_fingerprint, current_fp
             )
+        elif content_key is None or self._graph_content_key != content_key:
+            reason = "source_modified"
 
         if reason is not None:
             self._call_graph = CallGraph(self.project_root)
             self._call_graph.build()
             self._call_graph_fingerprint = current_fp
+            self._graph_content_key = content_key
             self._call_graph_built_at = time.time()
             self._cache_invalidated_reason = reason
         else:

--- a/tree_sitter_analyzer/mcp/tools/dependency_analysis_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/dependency_analysis_tool.py
@@ -32,6 +32,7 @@ class DependencyAnalysisTool(BaseMCPTool):
         # both the instance cache AND, indirectly, DependencyGraph's
         # _global_cache (whose key is now derived from the same fingerprint).
         self._graph_fingerprint: GraphFingerprint | None = None
+        self._graph_content_key: str | None = None
         self._graph_built_at: float | None = None
         self._cache_invalidated_reason: str | None = None
         super().__init__(project_root)
@@ -39,6 +40,7 @@ class DependencyAnalysisTool(BaseMCPTool):
     def _on_project_root_changed(self, project_root: str | None) -> None:
         self._graph = None
         self._graph_fingerprint = None
+        self._graph_content_key = None
         self._graph_built_at = None
         self._cache_invalidated_reason = None
 
@@ -47,6 +49,7 @@ class DependencyAnalysisTool(BaseMCPTool):
             raise ValueError("Project root not set. Call set_project_path first.")
 
         current_fp = compute_graph_fingerprint(self.project_root)
+        content_key = DependencyGraph._cache_key_for(str(self.project_root))
         reason: str | None = None
         if self._graph is None:
             reason = "cold"
@@ -54,10 +57,13 @@ class DependencyAnalysisTool(BaseMCPTool):
             reason = self._explain_fingerprint_delta(
                 self._graph_fingerprint, current_fp
             )
+        elif content_key is None or self._graph_content_key != content_key:
+            reason = "source_modified"
 
         if reason is not None:
             self._graph = DependencyGraph(self.project_root)
             self._graph_fingerprint = current_fp
+            self._graph_content_key = content_key
             self._graph_built_at = time.time()
             self._cache_invalidated_reason = reason
         else:

--- a/tree_sitter_analyzer/mcp/tools/safe_to_edit_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/safe_to_edit_tool.py
@@ -82,10 +82,9 @@ class SafeToEditTool(BaseMCPTool):
 
     # _get_graph: implementation
     def _get_graph(self) -> DependencyGraph:
-        if self._graph is None:
-            if not self.project_root:
-                raise ValueError("Project root not set.")
-            self._graph = DependencyGraph(self.project_root)
+        if not self.project_root:
+            raise ValueError("Project root not set.")
+        self._graph = DependencyGraph(self.project_root)
         return self._graph
 
     # _get_scorer: implementation
@@ -204,9 +203,7 @@ class SafeToEditTool(BaseMCPTool):
         syntax_response = _syntax_error_response(resolved, file_path, edit_type)
         if syntax_response is not None:
             syntax_response["output_format"] = output_format
-            return apply_output_format_to_response(
-                syntax_response, output_format
-            )
+            return apply_output_format_to_response(syntax_response, output_format)
 
         result = _build_safe_to_edit_result(
             SafeToEditContext(
@@ -251,9 +248,7 @@ class SafeToEditTool(BaseMCPTool):
         # now propagates it into ``agent_summary``.
         result = mirror_summary_line(result)
 
-        return apply_output_format_to_response(
-            result, output_format
-        )
+        return apply_output_format_to_response(result, output_format)
 
     def _read_existing_payload(
         self,

--- a/tree_sitter_analyzer/mcp/tools/smart_context_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/smart_context_tool.py
@@ -71,10 +71,9 @@ class SmartContextTool(BaseMCPTool):
 
     # _get_graph: implementation
     def _get_graph(self) -> DependencyGraph:
-        if self._graph is None:
-            if not self.project_root:
-                raise ValueError("Project root not set.")
-            self._graph = DependencyGraph(self.project_root)
+        if not self.project_root:
+            raise ValueError("Project root not set.")
+        self._graph = DependencyGraph(self.project_root)
         return self._graph
 
     # _get_scorer: implementation

--- a/tree_sitter_analyzer/mcp/tools/symbol_lineage_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/symbol_lineage_tool.py
@@ -216,6 +216,7 @@ class SymbolLineageTool(BaseMCPTool):
         # response cache are invalidated together — the symbol responses
         # bake in the graph's downstream/upstream sets.
         self._dep_graph_fingerprint: GraphFingerprint | None = None
+        self._graph_content_key: str | None = None
         self._dep_graph_built_at: float | None = None
         self._cache_invalidated_reason: str | None = None
         # #568: the hierarchy section is derived from the AST index (index.db),
@@ -231,6 +232,7 @@ class SymbolLineageTool(BaseMCPTool):
         self._dep_graph = None
         self._symbol_cache = {}
         self._dep_graph_fingerprint = None
+        self._graph_content_key = None
         self._dep_graph_built_at = None
         self._cache_invalidated_reason = None
         self._ast_index_mtime_ns = None
@@ -245,6 +247,7 @@ class SymbolLineageTool(BaseMCPTool):
             raise ValueError("Project root not set. Call set_project_path first.")
 
         current_fp = compute_graph_fingerprint(str(self.project_root))
+        content_key = DependencyGraph._cache_key_for(str(self.project_root))
         reason: str | None = None
         if self._dep_graph is None:
             reason = "cold"
@@ -252,6 +255,8 @@ class SymbolLineageTool(BaseMCPTool):
             reason = self._explain_fingerprint_delta(
                 self._dep_graph_fingerprint, current_fp
             )
+        elif content_key is None or self._graph_content_key != content_key:
+            reason = "source_modified"
 
         if reason is not None:
             # Invalidate downstream caches that depend on the graph.
@@ -259,6 +264,7 @@ class SymbolLineageTool(BaseMCPTool):
             try:
                 self._dep_graph = DependencyGraph(str(self.project_root))
                 self._dep_graph_fingerprint = current_fp
+                self._graph_content_key = content_key
                 self._dep_graph_built_at = time.time()
                 self._cache_invalidated_reason = reason
             except Exception as exc:  # noqa: BLE001

--- a/tree_sitter_analyzer/project_graph.py
+++ b/tree_sitter_analyzer/project_graph.py
@@ -9,6 +9,7 @@ Key classes:
 - BlastRadius: Impact analysis (forward/reverse dependency traversal)
 """
 
+import hashlib
 import os
 from collections import defaultdict, deque
 from collections.abc import Callable
@@ -359,7 +360,7 @@ class DependencyGraph:
     _global_cache: dict[str, "DependencyGraph"] = {}
 
     def __new__(cls, project_root: str) -> "DependencyGraph":
-        # Use cache keyed by project_root + mtime
+        # 完整内容与项目路径决定复用；无法读取时仅构建，不复用。
         key = cls._cache_key_for(project_root)
         if key is not None and key in cls._global_cache:
             return cls._global_cache[key]
@@ -398,24 +399,52 @@ class DependencyGraph:
 
     @staticmethod
     def _cache_key_for(project_root: str) -> str | None:
-        """Generate a cache key based on project source-file fingerprint.
+        """完整内容与路径共同决定缓存键；读取失败或超限时不复用。"""
 
-        Uses ``compute_graph_fingerprint`` (file_count + max_mtime_ns of all
-        source files) instead of the project-root directory mtime alone.
-        Directory mtime only flips on file add/remove, so modifying a file
-        in place previously left a stale graph cached forever.
+        def abort(error: OSError) -> None:
+            raise error
 
-        Cost: ~10ms on a 1300-file repo — fast enough to call on every
-        ``DependencyGraph(root)`` construction.
-        """
+        digest = hashlib.sha256()
         try:
             os.stat(project_root)
+            for directory, dirs, names in os.walk(project_root, onerror=abort):
+                dirs[:] = sorted(
+                    name
+                    for name in dirs
+                    if name not in EXCLUDE_DIRS and not name.startswith(".")
+                )
+                for name in sorted(names):
+                    if (
+                        name.startswith(".")
+                        or Path(name).suffix.lower() not in GRAPH_SOURCE_EXTS
+                    ):
+                        continue
+                    path = Path(directory) / name
+                    with path.open("rb") as stream:
+                        before = os.fstat(stream.fileno())
+                        content = stream.read(64 * 1024 * 1024 + 1)
+                        after = os.fstat(stream.fileno())
+                    if len(content) > 64 * 1024 * 1024 or (
+                        before.st_dev,
+                        before.st_ino,
+                        before.st_size,
+                        before.st_mtime_ns,
+                        before.st_ctime_ns,
+                    ) != (
+                        after.st_dev,
+                        after.st_ino,
+                        after.st_size,
+                        after.st_mtime_ns,
+                        after.st_ctime_ns,
+                    ):
+                        return None
+                    digest.update(os.fsencode(os.path.relpath(path, project_root)))
+                    digest.update(b"\0")
+                    digest.update(str(after.st_mtime_ns).encode("ascii") + b"\0")
+                    digest.update(hashlib.sha256(content).digest())
         except OSError:
             return None
-        from .cache.fingerprint import compute_graph_fingerprint
-
-        fp = compute_graph_fingerprint(project_root)
-        return f"{project_root}:{fp.file_count}:{fp.max_mtime_ns}"
+        return f"{project_root}:{digest.hexdigest()}"
 
     # Shared exclude set (incl. C#/Java/Rust build dirs) — constants.EXCLUDE_DIRS
     _EXCLUDE_DIRS = EXCLUDE_DIRS
@@ -448,8 +477,7 @@ class DependencyGraph:
 
     def _build(self) -> None:
         """Scan project directory and build the dependency graph."""
-        # Shared with cache/fingerprint.py — the fingerprint is this graph's
-        # staleness signal, so the two sets must never drift.
+        # 与内容缓存键使用相同的扩展名范围。
         supported_exts = set(GRAPH_SOURCE_EXTS)
 
         # Collect all source files (excluding generated/dependency dirs)


### PR DESCRIPTION
A same-size source rewrite with restored mtime could leave DependencyGraph reporting the old import. Causes included outer tool caches that returned before graph validation, plus two lower-level problems: the graph key used file count plus maximum mtime, and Parser hashed only path/mtime/size/language even after invalidate_stat_cache().

Parser now reads source before lookup and binds its cache key to the exact text sent to parse_code, together with path and language. File attributes remain diagnostic metadata and cannot authorize reuse. The parser core change is isolated in its own commit. DependencyGraph keys include all discovered source paths and complete file contents; unreadable walks, files over 64 MiB, and observed changes during a file read disable reuse. Unchanged graphs still reuse their instance, and the existing touch-invalidation behavior remains.

DependencyAnalysisTool, SymbolLineageTool and CodeGraphCallTool now compare full source content before returning their cached graphs; lineage also clears its dependent symbol-result cache. SmartContextTool and SafeToEditTool consult DependencyGraph on each graph request, allowing its content-keyed reuse to decide freshness. This covers the five live tool guards identified by review.

Project health scoring now lazily shares dependency graphs only within one scoring operation, using a ContextVar scope restored on exit or failure. This avoids recomputing the full-project content key for every scored file while preserving fresh admission on subsequent operations that need a graph. A regression verifies two eight-file scans compute two keys rather than sixteen and that changed fan-in changes the dependency scores.

Validation:
- RED: preserved-mtime parser cases failed with and without clearing stat records; graph cases failed for both short files and an import after 128 KiB of padding.
- TSA-selected tool suites plus parser and graph regressions: 659 passed, two existing skips in 9.42 seconds with fresh coverage.
- Five live-tool regressions failed before the outer guard fix; preserved-mtime lineage requests also verify symbol-result invalidation. After explicit UTF-8 fixture cleanup, all 27 cache-invalidation tests pass.
- Health scope failure restoration and timed-out graph non-publication are covered.
- MCP health cold/warm latency test passed locally in 113.45 seconds total. The two functional health tests initially timed out when run concurrently cold; after prewarming, both passed (about 0.55 seconds each). CI runs warm-up first. Native CI must revalidate; no timeout or test budget was relaxed.
- Patch coverage: no added executable misses.
- Quick gate on the final committed tree: 2,049 passed, 28 existing skips in 27.36 seconds.
- Real warm-graph smoke now reports c.py after import b changes to import c with identical mtime and size.
- Commit hooks and git diff --check passed.

A five-call local measurement on this repository recorded a graph-key median of about 51 ms (first call 167 ms); this is neither an SLA nor a cross-platform benchmark. Warm parser hits now read source, so native CI and performance evidence matter.

This fixes sequential content freshness for Parser and direct DependencyGraph reuse. It does not certify a concurrent project-wide snapshot, fix SQLite cached dependency-graph admission, or certify every remaining tool-level cache. RFC-0032 writer ownership and PR #1415 read-side SQLite changes remain separate.
