### PR TITLE
fix: make CI feedback analyze PR changes and retain failures

### DIFF
--- a/.github/workflows/dogfood-pr-check.yml
+++ b/.github/workflows/dogfood-pr-check.yml
@@ -38,6 +38,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          # 固定 PR 合并提交，并取第一父提交以覆盖整个 PR 的差异。
+          ref: ${{ github.sha }}
+          fetch-depth: 2
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -63,7 +67,7 @@ jobs:
           mkdir -p dogfood-artifacts
 
           set +e
-          uv run python -m tree_sitter_analyzer --change-impact --output-format json \
+          uv run python -m tree_sitter_analyzer --change-impact --change-impact-mode branch --output-format json \
             > dogfood-artifacts/change-impact.json \
             2> dogfood-artifacts/change-impact.txt
           EXIT_CODE=$?

--- a/.github/workflows/dogfood-pr-check.yml
+++ b/.github/workflows/dogfood-pr-check.yml
@@ -159,6 +159,8 @@ jobs:
           path: |
             claims-output.txt
             dogfood-claims.xml
+            dogfood-artifacts/change-impact.json
+            dogfood-artifacts/change-impact.txt
           retention-days: 14
 
   post-dogfood-comment:

--- a/scripts/classify_windows_pytest_failure.py
+++ b/scripts/classify_windows_pytest_failure.py
@@ -9,19 +9,20 @@ import re
 from pathlib import Path
 
 _OUTCOME = re.compile(
-    r"^(?P<outcome>FAILED|ERROR) (?P<nodeid>\S+) - (?P<reason>.+)$",
+    r"^(?P<outcome>FAILED|ERROR) (?P<nodeid>\S+)(?: - (?P<reason>.*))?$",
     re.MULTILINE,
 )
 _BUDGET = "Unit test exceeded per-test budget:"
 
 
 def classify(output: str) -> dict[str, object]:
-    """Allow retry only when every reported failure is a runtime-budget failure."""
+    """仅在全部失败均明确归因于运行时间预算时允许重跑。"""
 
-    failures = tuple(_OUTCOME.finditer(output))
+    # worker 崩溃的摘要没有原因后缀；统一换行后仍须将该失败纳入判断。
+    failures = tuple(_OUTCOME.finditer("\n".join(output.splitlines())))
     nodeids = tuple(match.group("nodeid") for match in failures)
     budget_only = bool(failures) and all(
-        match.group("outcome") == "FAILED" and _BUDGET in match.group("reason")
+        match.group("outcome") == "FAILED" and _BUDGET in (match.group("reason") or "")
         for match in failures
     )
     return {

--- a/scripts/classify_windows_pytest_failure.py
+++ b/scripts/classify_windows_pytest_failure.py
@@ -9,7 +9,7 @@ import re
 from pathlib import Path
 
 _OUTCOME = re.compile(
-    r"^(?P<outcome>FAILED|ERROR) (?P<nodeid>\S+)(?: - (?P<reason>.*))?$",
+    r"^(?P<outcome>FAILED|ERROR) (?P<nodeid>.+?)(?: - (?P<reason>.*))?$",
     re.MULTILINE,
 )
 _BUDGET = "Unit test exceeded per-test budget:"

--- a/tests/governance/test_ci_routing_contract.py
+++ b/tests/governance/test_ci_routing_contract.py
@@ -289,3 +289,63 @@ def test_docs_check_fetches_history_for_contract_subjects() -> None:
     checkout_end = docs_job.index("\n      - name:", checkout_start)
     checkout_step = docs_job[checkout_start:checkout_end]
     assert checkout_step.splitlines().count("          fetch-depth: 0") == 1
+
+
+def test_dogfood_reads_complete_pr_diff_instead_of_output_files(tmp_path: Path) -> None:
+    """PR 分析覆盖全部提交，且不把自己的报告当作源码变更。"""
+    # 2026-09-08：#1418 的文档 PR 被报告为两个输出文件，真实提交完全遗漏。
+    import shlex
+    import subprocess
+
+    import yaml
+
+    from tree_sitter_analyzer.mcp.tools.utils.change_impact_git import (
+        _get_changed_files,
+    )
+
+    workflow = yaml.safe_load(
+        (PROJECT_ROOT / ".github/workflows/dogfood-pr-check.yml").read_text(
+            encoding="utf-8"
+        )
+    )
+    steps = workflow["jobs"]["claim-invariants"]["steps"]
+    checkout = next(
+        step for step in steps if "uses" in step and "checkout@" in step["uses"]
+    )
+    impact = next(step["run"] for step in steps if step.get("id") == "impact")
+    command = next(
+        line.strip() for line in impact.splitlines() if "uv run python -m" in line
+    )
+    argv = shlex.split(command.rstrip("\\").strip())[5:]
+    args = create_argument_parser().parse_args(argv)
+    source = tmp_path / "source"
+    source.mkdir()
+
+    def git(root: Path, *arguments: str) -> None:
+        subprocess.run(["git", *arguments], cwd=root, check=True, capture_output=True)
+
+    git(source, "init", "-b", "base")
+    git(source, "config", "user.name", "TSA Test")
+    git(source, "config", "user.email", "tsa@example.invalid")
+    (source / "README.md").write_text("base\n", encoding="utf-8")
+    git(source, "add", ".")
+    git(source, "commit", "-m", "base")
+    git(source, "checkout", "-b", "feature")
+    for name in ("first.py", "second.py"):
+        (source / name).write_text("value = 1\n", encoding="utf-8")
+        git(source, "add", name)
+        git(source, "commit", "-m", name)
+    git(source, "checkout", "base")
+    git(source, "merge", "--no-ff", "feature", "-m", "PR merge")
+    checkout_root = tmp_path / "checkout"
+    depth = str(checkout.get("with", {}).get("fetch-depth", 1))
+    git(tmp_path, "clone", "--depth", depth, source.as_uri(), str(checkout_root))
+    artifacts = checkout_root / "dogfood-artifacts"
+    artifacts.mkdir()
+    for suffix in ("json", "txt"):
+        (artifacts / f"change-impact.{suffix}").write_text("", encoding="utf-8")
+    assert _get_changed_files(args.change_impact_mode, str(checkout_root)) == [
+        "first.py",
+        "second.py",
+    ]
+    assert checkout["with"]["ref"] == "${{ github.sha }}"

--- a/tests/unit/test_classify_windows_pytest_failure.py
+++ b/tests/unit/test_classify_windows_pytest_failure.py
@@ -4,6 +4,8 @@ import sys
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from scripts.classify_windows_pytest_failure import classify, main
 
 
@@ -52,6 +54,38 @@ def test_collection_error_blocks_retry() -> None:
     )
 
     assert classify(output)["retry_eligible"] is False
+
+
+@pytest.mark.parametrize("outcome", ["FAILED", "ERROR"])
+@pytest.mark.parametrize("newline", ["\n", "\r\n"])
+def test_reasonless_failure_blocks_budget_retry(
+    tmp_path: Path, outcome: str, newline: str
+) -> None:
+    """无原因的失败仍须计入，且不能因另一项超时重跑成功而放行。"""
+    # 2026-09-09：#1419 Windows worker 崩溃行被分类器忽略，导致错误绿灯。
+    output = newline.join(
+        [
+            "FAILED tests/unit/test_a.py::test_a - Failed: Unit test exceeded "
+            "per-test budget: 16.47s > 12.8s.",
+            f"{outcome} tests/unit/test_decision_journal.py::TestSearch::test_search_returns_newest_first",
+            "2 failed, 23381 passed, 1211 skipped, 5 rerun in 801.13s",
+            "",
+        ]
+    )
+    assert classify(output) == {
+        "retry_eligible": False,
+        "nodeids": [],
+        "failure_count": 2,
+        "reason": "non_budget_or_unclassified",
+    }
+    log = tmp_path / "pytest-output.txt"
+    log.write_text(output, encoding="utf-8", newline="")
+    nodeids = tmp_path / "retry.txt"
+    with patch.object(
+        sys, "argv", ["classify", str(log), "--nodeids-output", str(nodeids)]
+    ):
+        assert main() == 1
+    assert nodeids.read_bytes() == b""
 
 
 def test_nodeid_file_uses_lf_so_the_ci_retry_can_match(tmp_path: Path) -> None:

--- a/tests/unit/test_classify_windows_pytest_failure.py
+++ b/tests/unit/test_classify_windows_pytest_failure.py
@@ -58,8 +58,9 @@ def test_collection_error_blocks_retry() -> None:
 
 @pytest.mark.parametrize("outcome", ["FAILED", "ERROR"])
 @pytest.mark.parametrize("newline", ["\n", "\r\n"])
+@pytest.mark.parametrize("parameter", ["", "[with spaces]"])
 def test_reasonless_failure_blocks_budget_retry(
-    tmp_path: Path, outcome: str, newline: str
+    tmp_path: Path, outcome: str, newline: str, parameter: str
 ) -> None:
     """无原因的失败仍须计入，且不能因另一项超时重跑成功而放行。"""
     # 2026-09-09：#1419 Windows worker 崩溃行被分类器忽略，导致错误绿灯。
@@ -67,7 +68,7 @@ def test_reasonless_failure_blocks_budget_retry(
         [
             "FAILED tests/unit/test_a.py::test_a - Failed: Unit test exceeded "
             "per-test budget: 16.47s > 12.8s.",
-            f"{outcome} tests/unit/test_decision_journal.py::TestSearch::test_search_returns_newest_first",
+            f"{outcome} tests/unit/test_decision_journal.py::TestSearch::test_search_returns_newest_first{parameter}",
             "2 failed, 23381 passed, 1211 skipped, 5 rerun in 801.13s",
             "",
         ]


### PR DESCRIPTION
CI feedback could analyze the wrong files and report success despite an unhandled test failure. Fix both observed gaps:

- Dogfood previously analyzed its own untracked JSON/log outputs and omitted committed PR changes. Pin the PR merge SHA, fetch depth 2, and use first-parent branch mode. Retain raw impact JSON/stderr in the existing artifact.
- The budget-retry classifier ignored pytest FAILED/ERROR lines without a reason suffix. On run 34239986595, Windows had a budget overrun plus a worker crash; only the budget case was retried and the job became green. Count reasonless failures, normalize LF/CRLF, and reject the retry whenever any failure is unclassified. The worker crash cause itself is not established.

Validation:
- Real two-commit Git merge and shallow clone regression failed before the input fix, then passed. Live run 34239986647 on 06c3b78c confirmed exactly the two committed paths with preview_truncated=false; generated outputs were absent.
- Four FAILED/ERROR × LF/CRLF retry cases failed before the classifier fix, then passed. Replaying the actual Windows log now returns failure_count=2 and retry_eligible=false. Related classifier/routing tests: 25 passed in 5.21 s; patch coverage gate reports no added executable misses.
- Prior YAML-only quick gate: 2,050 passed, 28 skipped in 27.45 s. Latest classifier change follows TSA-reported focused verification. Applicable hooks and git diff --check pass.

Do not treat the earlier Windows green job as a clean pass: its log reports 2 failures, 5 reruns and only one subsequent retry. Latest-head CI must provide the merge evidence. Original a767fd13 automatic review completed without inline findings; this does not claim review of the later classifier change.

Follow-up format verification: parameterized nodeids containing spaces were also omitted. The classifier now retains them; four additional LF/CRLF × FAILED/ERROR cases reproduced the bug before the fix. Final focused classifier/routing run: 29 passed in 5.15 s; patch gate and hooks passed.
