### PR TITLE
fix: route PR checks against the actual merge parent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,13 +32,15 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          ref: ${{ github.sha }}
           fetch-depth: 0
 
       - name: Detect changed files
         run: |
           set -euo pipefail
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}" > changed-files.txt
+            # 事件中的 base SHA 可能落后于合并提交的实际第一父提交。
+            git diff --name-only "${{ github.sha }}^1" "${{ github.sha }}" > changed-files.txt
           elif [[ "${{ github.event.before || '' }}" != "" && "${{ github.event.before || '' }}" != "0000000000000000000000000000000000000000" ]]; then
             git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" > changed-files.txt
           else

--- a/tests/governance/test_ci_routing_contract.py
+++ b/tests/governance/test_ci_routing_contract.py
@@ -349,3 +349,56 @@ def test_dogfood_reads_complete_pr_diff_instead_of_output_files(tmp_path: Path) 
         "second.py",
     ]
     assert checkout["with"]["ref"] == "${{ github.sha }}"
+
+
+def test_ci_routing_uses_merge_parent_when_event_base_is_stale(tmp_path: Path) -> None:
+    """基线分支前进后，路由只看到 PR 自身的变更。"""
+    # 2026-09-09：#1412 事件中的旧 base SHA 把 develop 后续代码误计入文档 PR。
+    import shlex
+    import subprocess
+
+    import yaml
+
+    workflow = yaml.safe_load(
+        (PROJECT_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    )
+    steps = workflow["jobs"]["route"]["steps"]
+    detect = next(
+        step["run"] for step in steps if step.get("name") == "Detect changed files"
+    )
+    command = next(
+        line.strip() for line in detect.splitlines() if "git diff --name-only" in line
+    )
+
+    def git(*args: str) -> str:
+        return subprocess.run(
+            ["git", *args],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        ).stdout.strip()
+
+    git("init", "-b", "base")
+    git("config", "user.name", "TSA Test")
+    git("config", "user.email", "tsa@example.invalid")
+    (tmp_path / "README.md").write_text("base\n", encoding="utf-8")
+    git("add", ".")
+    git("commit", "-m", "base")
+    old_base = git("rev-parse", "HEAD")
+    git("checkout", "-b", "docs")
+    (tmp_path / "proposal.md").write_text("proposal\n", encoding="utf-8")
+    git("add", ".")
+    git("commit", "-m", "proposal")
+    git("checkout", "base")
+    (tmp_path / "unrelated.py").write_text("value = 1\n", encoding="utf-8")
+    git("add", ".")
+    git("commit", "-m", "advance base")
+    git("merge", "--no-ff", "docs", "-m", "PR merge")
+    merge_sha = git("rev-parse", "HEAD")
+    command = command.replace("${{ github.event.pull_request.base.sha }}", old_base)
+    command = command.replace("${{ github.sha }}", merge_sha)
+    argv = shlex.split(command)
+    assert git(*argv[1 : argv.index(">")]).splitlines() == ["proposal.md"]
+    assert steps[0]["with"]["ref"] == "${{ github.sha }}"


### PR DESCRIPTION
A long-lived docs PR could trigger the full CI matrix because the event base SHA lagged behind the synthetic merge commit. On #1412, CI compared c9479f48 to a99bca8d even though that merge commit was built on 0b5b447d, incorrectly including subsequent develop code changes.

Pin checkout to github.sha and compare the PR merge commit with its first parent. Push-event routing keeps its existing before/after behavior. This changes which diff is classified, not the routing policy or required test tiers.

Validation: a real Git history with an advancing base reproduces the old extra unrelated.py path; the workflow-derived command now returns exactly proposal.md. TSA-reported focused verification: 27 routing/contract tests passed in 5.28 s with coverage. Patch gate reports no added executable misses; actionlint, git diff --check and commit hooks passed.
