### PR TITLE
fix: unblock Python 3.10 and macOS release validation

### DIFF
--- a/tests/unit/mcp/tools/test_tql_tool.py
+++ b/tests/unit/mcp/tools/test_tql_tool.py
@@ -122,7 +122,8 @@ def test_bfs_sql_authorization_failure_is_not_empty_matches(ast_cache_conn, stag
         with pytest.raises(HyphaeSyntaxError, match="BFS_INDEX_UNAVAILABLE"):
             Evaluator(cache).eval(parse(".function:reaches(#B){1,2}"))
     finally:
-        ast_cache_conn.set_authorizer(None)
+        # 2026-09-09: Python 3.10 不支持用 None 撤销授权回调，恢复明确允许。
+        ast_cache_conn.set_authorizer(lambda *_: sqlite3.SQLITE_OK)
         ast_cache_conn.set_trace_callback(None)
 
 
@@ -318,7 +319,8 @@ def test_temporal_data_read_failure_after_lazy_state_check(indexed_tql, pseudo, 
             Evaluator(cache).eval(parse(f".function:{pseudo}"))
         assert denied == [column]
     finally:
-        db.set_authorizer(None)
+        # 2026-09-09: Python 3.10 不支持用 None 撤销授权回调，恢复明确允许。
+        db.set_authorizer(lambda *_: sqlite3.SQLITE_OK)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_cache_write.py
+++ b/tests/unit/test_cache_write.py
@@ -631,7 +631,8 @@ def test_activation_read_permission_failure_is_reported(tmp_path):
                 "errors": 1,
             }
         finally:
-            conn.set_authorizer(None)
+            # 2026-09-09: Python 3.10 不支持用 None 撤销授权回调，恢复明确允许。
+            conn.set_authorizer(lambda *_: sqlite3.SQLITE_OK)
         assert conn.in_transaction is False
         assert [
             r[0]

--- a/tests/unit/test_incremental_sync.py
+++ b/tests/unit/test_incremental_sync.py
@@ -2375,7 +2375,8 @@ def test_certification_write_denial_cannot_report_complete(tmp_path):
                 max_files=10, candidate_snapshot=_snapshot(tmp_path, path)
             )
         finally:
-            conn.set_authorizer(None)
+            # 2026-09-09: Python 3.10 不支持用 None 撤销授权回调，恢复明确允许。
+            conn.set_authorizer(lambda *_: sqlite3.SQLITE_OK)
         assert denied == [("ast_index", "certified_at")]
         assert (
             result.errors,
@@ -2533,7 +2534,8 @@ def test_failed_file_certification_reset_denial_rolls_back(tmp_path, truncated):
             ):
                 IncrementalSync(cache).sync(max_files=2, candidate_snapshot=snapshot)
         finally:
-            conn.set_authorizer(None)
+            # 2026-09-09: Python 3.10 不支持用 None 撤销授权回调，恢复明确允许。
+            conn.set_authorizer(lambda *_: sqlite3.SQLITE_OK)
         assert len(updates) == 3
         assert conn.in_transaction is False
         assert [

--- a/tests/unit/test_index_snapshot_schema_validation.py
+++ b/tests/unit/test_index_snapshot_schema_validation.py
@@ -210,7 +210,8 @@ def test_entire_extension_upgrade_rolls_back_and_retries(tmp_path, layout, fault
         ):
             schema.init_db(db, False, None, migrations)
         db.set_trace_callback(None)
-        db.set_authorizer(None)
+        # 2026-09-09: Python 3.10 不支持用 None 撤销授权回调，恢复明确允许。
+        db.set_authorizer(lambda *_: sqlite3.SQLITE_OK)
         assert db.in_transaction is False
         assert tuple(db.iterdump()) == before
         db.execute("DROP TRIGGER IF EXISTS deny_record")

--- a/tests/unit/test_verification_runner.py
+++ b/tests/unit/test_verification_runner.py
@@ -301,3 +301,18 @@ def test_step_lifecycle_errors_preserve_truthful_status(tmp_path, monkeypatch, f
     assert result["cleanup_complete"] is (failure != "wait_timeout")
     assert result["output_truncated"] is (failure == "reader_alive")
     assert process.stdout.closed is (failure != "reader_alive")
+
+
+def test_cleanup_does_not_signal_a_bare_process_group_id(monkeypatch):
+    # 2026-09-09：macOS 的已退出组可能拒绝信号；清理以保留的进程身份为准。
+    from types import SimpleNamespace
+
+    monkeypatch.setattr(runner.psutil, "process_iter", lambda: [])
+    monkeypatch.setattr(
+        runner,
+        "os",
+        SimpleNamespace(
+            name="posix", killpg=lambda *_: pytest.fail("不得凭旧组号发送信号")
+        ),
+    )
+    assert runner._cleanup(SimpleNamespace(pid=12345), {}, "owned") is True

--- a/tree_sitter_analyzer/verification_runner.py
+++ b/tree_sitter_analyzer/verification_runner.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import signal
 import subprocess
 import threading
 import time
@@ -104,11 +103,6 @@ def _cleanup(
                 continue
             except psutil.AccessDenied:
                 alive.append(process)
-        if os.name != "nt":
-            try:
-                os.killpg(proc.pid, signal.SIGKILL)
-            except ProcessLookupError:
-                pass
         if not alive:
             empty += 1
             if empty == 2:


### PR DESCRIPTION
Restore release validation on Python 3.10 and macOS. SQLite test fixtures now restore authorization with an allow callback supported on Python 3.10. The verification runner no longer sends a second signal to an unbound process group after terminating tracked processes; cleanup still verifies retained process identities, descendants, and quiescence.

Validation: 251 focused SQLite tests and 23 verification lifecycle tests pass locally on Python 3.10. Patch coverage reports no added executable misses. Full OS/Python CI is running at https://github.com/aimasteracc/tree-sitter-analyzer/actions/runs/34313311842.
