### PR TITLE
fix: remove fd and ripgrep from internal source search

### DIFF
--- a/tests/unit/mcp/test_guard_caller_count_excludes_non_calls.py
+++ b/tests/unit/mcp/test_guard_caller_count_excludes_non_calls.py
@@ -16,7 +16,7 @@ guard total_callers must also return N (they must agree on call-site count).
 from __future__ import annotations
 
 import textwrap
-from unittest.mock import AsyncMock, patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -190,7 +190,7 @@ def _rg_match_line(file_path: str, line_no: int, text: str) -> bytes:
 
 
 class TestTraceImpactExcludesImportAndStringMatches:
-    """End-to-end fixture: 4 ripgrep hits, only 2 are real calls."""
+    """四个源码命中中只有两个是真实调用。"""
 
     @pytest.mark.asyncio
     async def test_call_count_excludes_import_and_string_literal(
@@ -230,8 +230,18 @@ class TestTraceImpactExcludesImportAndStringMatches:
 
         tool = TraceImpactTool(str(tmp_path))
         with patch(
-            "tree_sitter_analyzer.mcp.tools.trace_impact_tool.run_command_capture",
-            new=AsyncMock(return_value=(0, rg_stdout, b"")),
+            "tree_sitter_analyzer.mcp.tools.trace_impact_tool.scan_symbol_lines",
+            new=Mock(
+                return_value=[
+                    {
+                        "file": data["path"]["text"],
+                        "line": data["line_number"],
+                        "text": " ".join(data["lines"]["text"].split()),
+                    }
+                    for raw in rg_stdout.splitlines()
+                    for data in [__import__("json").loads(raw)["data"]]
+                ]
+            ),
         ):
             result = await tool.execute({"symbol": "my_func"})
 
@@ -290,8 +300,18 @@ class TestTraceImpactExcludesImportAndStringMatches:
 
         tool = TraceImpactTool(str(tmp_path))
         with patch(
-            "tree_sitter_analyzer.mcp.tools.trace_impact_tool.run_command_capture",
-            new=AsyncMock(return_value=(0, rg_stdout, b"")),
+            "tree_sitter_analyzer.mcp.tools.trace_impact_tool.scan_symbol_lines",
+            new=Mock(
+                return_value=[
+                    {
+                        "file": data["path"]["text"],
+                        "line": data["line_number"],
+                        "text": " ".join(data["lines"]["text"].split()),
+                    }
+                    for raw in rg_stdout.splitlines()
+                    for data in [__import__("json").loads(raw)["data"]]
+                ]
+            ),
         ):
             result = await tool.execute({"symbol": "my_func"})
 

--- a/tests/unit/mcp/test_numeric_param_coercion.py
+++ b/tests/unit/mcp/test_numeric_param_coercion.py
@@ -444,12 +444,8 @@ class TestTraceImpactMaxResultsCoercion:
                 return_value=["/fake/root"],
             ),
             patch(
-                "tree_sitter_analyzer.mcp.tools.trace_impact_tool.build_rg_command",
-                return_value=["rg", "--json", "my_func"],
-            ),
-            patch(
-                "tree_sitter_analyzer.mcp.tools.trace_impact_tool.run_command_capture",
-                return_value=(1, b"", b""),  # rc=1 → zero matches (NOT_FOUND path)
+                "tree_sitter_analyzer.mcp.tools.trace_impact_tool.scan_symbol_lines",
+                return_value=[],  # rc=1 → zero matches (NOT_FOUND path)
             ),
         ):
             resp = await tool.execute(

--- a/tests/unit/mcp/test_numeric_param_coercion.py
+++ b/tests/unit/mcp/test_numeric_param_coercion.py
@@ -10,6 +10,7 @@ Per CLAUDE.md LOCKED rule: assertion counts are exact pins, never >= / >.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -435,7 +436,7 @@ class TestTraceImpactMaxResultsCoercion:
     async def test_max_results_string_does_not_crash(self) -> None:
         from tree_sitter_analyzer.mcp.tools.trace_impact_tool import TraceImpactTool
 
-        tool = TraceImpactTool(project_root="/fake/root")
+        tool = TraceImpactTool(project_root=str(Path.cwd()))
 
         with (
             patch.object(

--- a/tests/unit/mcp/test_tools/test_trace_impact_tool.py
+++ b/tests/unit/mcp/test_tools/test_trace_impact_tool.py
@@ -2,7 +2,7 @@
 """
 Unit Tests for Trace Impact Tool
 
-Tests the trace_impact MCP tool using mocks (no real ripgrep execution).
+用模拟原生扫描结果验证 trace_impact MCP 工具。
 """
 
 from unittest.mock import patch
@@ -85,7 +85,7 @@ class TestTraceImpactToolBasic:
 
 
 class TestTraceImpactToolExecution:
-    """Test trace_impact execution with mocked ripgrep"""
+    """用模拟原生扫描结果验证执行逻辑"""
 
     def setup_method(self):
         """Set up test fixtures"""
@@ -94,11 +94,11 @@ class TestTraceImpactToolExecution:
     @pytest.mark.asyncio
     async def test_execute_no_matches(self):
         """Test execution when no matches are found"""
-        # Mock ripgrep returning no matches (rc=1)
+        # 模拟原生扫描没有命中
         with patch(
-            "tree_sitter_analyzer.mcp.tools.trace_impact_tool.run_command_capture"
+            "tree_sitter_analyzer.mcp.tools.trace_impact_tool.scan_symbol_lines"
         ) as mock_run:
-            mock_run.return_value = (1, b"", b"")
+            mock_run.return_value = []
 
             result = await self.tool.execute({"symbol": "nonexistent"})
 
@@ -111,14 +111,22 @@ class TestTraceImpactToolExecution:
     @pytest.mark.asyncio
     async def test_execute_with_matches(self):
         """Test execution with successful matches"""
-        # Mock ripgrep JSON output with matches
+        # 将原有命中样本转换为原生扫描结果
         json_output = b"""{"type":"match","data":{"path":{"text":"src/Service.java"},"line_number":23,"lines":{"text":"  processPayment(order);"},"submatches":[{"start":2,"end":16}]}}
 {"type":"match","data":{"path":{"text":"src/Controller.java"},"line_number":45,"lines":{"text":"    result = processPayment(req);"},"submatches":[{"start":13,"end":27}]}}
 """
         with patch(
-            "tree_sitter_analyzer.mcp.tools.trace_impact_tool.run_command_capture"
+            "tree_sitter_analyzer.mcp.tools.trace_impact_tool.scan_symbol_lines"
         ) as mock_run:
-            mock_run.return_value = (0, json_output, b"")
+            mock_run.return_value = [
+                {
+                    "file": data["path"]["text"],
+                    "line": data["line_number"],
+                    "text": " ".join(data["lines"]["text"].split()),
+                }
+                for raw in json_output.splitlines()
+                for data in [__import__("json").loads(raw)["data"]]
+            ]
 
             result = await self.tool.execute({"symbol": "processPayment"})
 
@@ -142,10 +150,18 @@ class TestTraceImpactToolExecution:
             mock_detect.return_value = "java"
 
             with patch(
-                "tree_sitter_analyzer.mcp.tools.trace_impact_tool.run_command_capture"
+                "tree_sitter_analyzer.mcp.tools.trace_impact_tool.scan_symbol_lines"
             ) as mock_run:
                 json_output = b"""{"type":"match","data":{"path":{"text":"Service.java"},"line_number":10,"lines":{"text":"test"},"submatches":[]}}"""
-                mock_run.return_value = (0, json_output, b"")
+                mock_run.return_value = [
+                    {
+                        "file": data["path"]["text"],
+                        "line": data["line_number"],
+                        "text": " ".join(data["lines"]["text"].split()),
+                    }
+                    for raw in json_output.splitlines()
+                    for data in [__import__("json").loads(raw)["data"]]
+                ]
 
                 result = await self.tool.execute(
                     {"symbol": "test", "file_path": "src/Service.java"}
@@ -159,7 +175,7 @@ class TestTraceImpactToolExecution:
     @pytest.mark.asyncio
     async def test_execute_with_max_results_truncation(self):
         """Test execution with max_results truncation"""
-        # Mock ripgrep with many matches
+        # 模拟大量源码命中
         json_lines = []
         for i in range(150):
             json_lines.append(
@@ -168,9 +184,17 @@ class TestTraceImpactToolExecution:
         json_output = "\n".join(json_lines).encode()
 
         with patch(
-            "tree_sitter_analyzer.mcp.tools.trace_impact_tool.run_command_capture"
+            "tree_sitter_analyzer.mcp.tools.trace_impact_tool.scan_symbol_lines"
         ) as mock_run:
-            mock_run.return_value = (0, json_output, b"")
+            mock_run.return_value = [
+                {
+                    "file": data["path"]["text"],
+                    "line": data["line_number"],
+                    "text": " ".join(data["lines"]["text"].split()),
+                }
+                for raw in json_output.splitlines()
+                for data in [__import__("json").loads(raw)["data"]]
+            ]
 
             result = await self.tool.execute({"symbol": "test", "max_results": 50})
 
@@ -182,47 +206,47 @@ class TestTraceImpactToolExecution:
             assert result["truncated"] is True
 
     @pytest.mark.asyncio
-    async def test_execute_ripgrep_not_installed(self):
-        """Test execution when ripgrep is not installed"""
+    async def test_execute_unavailable_root(self):
+        """扫描根目录不可用时返回失败"""
         with patch(
-            "tree_sitter_analyzer.mcp.tools.trace_impact_tool.run_command_capture"
+            "tree_sitter_analyzer.mcp.tools.trace_impact_tool.scan_symbol_lines"
         ) as mock_run:
-            mock_run.return_value = (127, b"", b"Command not found")
+            mock_run.side_effect = OSError("SOURCE_ROOT_UNAVAILABLE")
 
             result = await self.tool.execute({"symbol": "test"})
 
             assert result["success"] is False
-            assert "not installed" in result["error"]
+            assert result["error"] == "SOURCE_ROOT_UNAVAILABLE"
             assert result["call_count"] == 0
 
     @pytest.mark.asyncio
     async def test_execute_timeout(self):
         """Test execution timeout"""
         with patch(
-            "tree_sitter_analyzer.mcp.tools.trace_impact_tool.run_command_capture"
+            "tree_sitter_analyzer.mcp.tools.trace_impact_tool.scan_symbol_lines"
         ) as mock_run:
-            mock_run.return_value = (124, b"", b"Timeout")
+            mock_run.side_effect = TimeoutError("SOURCE_SCAN_BUDGET_EXCEEDED")
 
             result = await self.tool.execute({"symbol": "test"})
 
             assert result["success"] is False
-            assert "timed out" in result["error"]
+            assert result["error"] == "SOURCE_SCAN_BUDGET_EXCEEDED"
             assert result["call_count"] == 0
 
     @pytest.mark.asyncio
     async def test_execute_with_multiple_roots(self):
         """Test execution with multiple project roots"""
         with patch(
-            "tree_sitter_analyzer.mcp.tools.trace_impact_tool.run_command_capture"
+            "tree_sitter_analyzer.mcp.tools.trace_impact_tool.scan_symbol_lines"
         ) as mock_run:
-            mock_run.return_value = (1, b"", b"")
+            mock_run.return_value = []
 
             result = await self.tool.execute(
                 {"symbol": "test", "project_root": "/root1,/root2,/root3"}
             )
 
             assert result["success"] is True
-            # Verify command was called (roots are passed to ripgrep)
+            # 确认扫描器收到项目根目录
             assert mock_run.called
 
 

--- a/tests/unit/mcp/test_tools/test_trace_impact_tool.py
+++ b/tests/unit/mcp/test_tools/test_trace_impact_tool.py
@@ -15,13 +15,15 @@ from tree_sitter_analyzer.mcp.tools.trace_impact_tool import TraceImpactTool
 class TestTraceImpactToolBasic:
     """Basic functionality tests for trace_impact tool"""
 
-    def setup_method(self):
-        """Set up test fixtures"""
-        self.tool = TraceImpactTool(project_root="/test/project")
+    @pytest.fixture(autouse=True)
+    def setup_tool(self, tmp_path):
+        """为扫描边界提供真实且隔离的项目目录。"""
+        self.tool = TraceImpactTool(project_root=str(tmp_path))
+        self.project_dir = tmp_path
 
     def test_init(self):
         """Test tool initialization"""
-        assert self.tool.project_root == "/test/project"
+        assert self.tool.project_root == str(self.project_dir)
         assert self.tool.language_detector is not None
 
     def test_get_tool_definition(self):
@@ -87,9 +89,11 @@ class TestTraceImpactToolBasic:
 class TestTraceImpactToolExecution:
     """用模拟原生扫描结果验证执行逻辑"""
 
-    def setup_method(self):
-        """Set up test fixtures"""
-        self.tool = TraceImpactTool(project_root="/test/project")
+    @pytest.fixture(autouse=True)
+    def setup_tool(self, tmp_path):
+        """为扫描边界提供真实且隔离的项目目录。"""
+        self.tool = TraceImpactTool(project_root=str(tmp_path))
+        self.project_dir = tmp_path
 
     @pytest.mark.asyncio
     async def test_execute_no_matches(self):
@@ -235,14 +239,20 @@ class TestTraceImpactToolExecution:
 
     @pytest.mark.asyncio
     async def test_execute_with_multiple_roots(self):
-        """Test execution with multiple project roots"""
+        """只允许在已配置项目边界内选择多个扫描目录。"""
+        roots = [self.project_dir / name for name in ("one", "two", "three")]
+        for root in roots:
+            root.mkdir()
         with patch(
             "tree_sitter_analyzer.mcp.tools.trace_impact_tool.scan_symbol_lines"
         ) as mock_run:
             mock_run.return_value = []
 
             result = await self.tool.execute(
-                {"symbol": "test", "project_root": "/root1,/root2,/root3"}
+                {
+                    "symbol": "test",
+                    "project_root": ",".join(str(root) for root in roots),
+                }
             )
 
             assert result["success"] is True
@@ -253,9 +263,11 @@ class TestTraceImpactToolExecution:
 class TestTraceImpactToolLanguageDetection:
     """Test language detection and extension filtering"""
 
-    def setup_method(self):
-        """Set up test fixtures"""
-        self.tool = TraceImpactTool(project_root="/test/project")
+    @pytest.fixture(autouse=True)
+    def setup_tool(self, tmp_path):
+        """为扫描边界提供真实且隔离的项目目录。"""
+        self.tool = TraceImpactTool(project_root=str(tmp_path))
+        self.project_dir = tmp_path
 
     def test_get_extensions_for_language_java(self):
         """Test getting extensions for Java"""
@@ -318,3 +330,28 @@ class TestR37sImpactGuidanceGrammar:
         info = _get_impact_level(5)
         assert info["level"] == "low"
         assert "5 callers found" in info["guidance"]
+
+
+def test_trace_rejects_outside_project_root(tmp_path):
+    # 2026-09-09：调用参数不得覆盖已配置的项目边界。
+    project = tmp_path / "project"
+    project.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    with pytest.raises(ValueError):
+        TraceImpactTool(str(project))._resolve_search_roots(str(outside))
+
+
+def test_trace_rejects_empty_root_component(tmp_path):
+    with pytest.raises(ValueError, match="SOURCE_ROOT_EMPTY"):
+        TraceImpactTool(str(tmp_path))._resolve_search_roots(str(tmp_path) + ",")
+
+
+def test_display_hard_cap_keeps_complete_count():
+    from tree_sitter_analyzer.mcp.tools.trace_impact_tool import _truncate_for_display
+
+    matches = list(range(10001))
+    displayed, truncated = _truncate_for_display(matches, 1000000)
+    assert displayed == list(range(10000))
+    assert truncated is True
+    assert len(matches) == 10001

--- a/tests/unit/mcp/test_trace_impact_count_fix.py
+++ b/tests/unit/mcp/test_trace_impact_count_fix.py
@@ -10,7 +10,7 @@ causing impact_level to be classified as "low" when the true count is "high".
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -87,8 +87,18 @@ class TestTraceImpactCountAccuracy:
         )
 
         with patch(
-            "tree_sitter_analyzer.mcp.tools.trace_impact_tool.run_command_capture",
-            new=AsyncMock(return_value=(0, fake_stdout, b"")),
+            "tree_sitter_analyzer.mcp.tools.trace_impact_tool.scan_symbol_lines",
+            new=Mock(
+                return_value=[
+                    {
+                        "file": data["path"]["text"],
+                        "line": data["line_number"],
+                        "text": " ".join(data["lines"]["text"].split()),
+                    }
+                    for raw in fake_stdout.splitlines()
+                    for data in [__import__("json").loads(raw)["data"]]
+                ]
+            ),
         ):
             tool = TraceImpactTool("/tmp")
             r = asyncio.run(tool.execute({"symbol": "Component", "max_results": 5}))

--- a/tests/unit/mcp/test_utils/test_project_index.py
+++ b/tests/unit/mcp/test_utils/test_project_index.py
@@ -90,13 +90,7 @@ class TestProjectIndexManagerBuild:
 
     def test_build_creates_index(self, manager: ProjectIndexManager) -> None:
         """Test that build() returns a valid ProjectIndex."""
-        # Force the os.walk path: with fd installed the count differs (fd
-        # includes the __pycache__ file → 9), so pin the hermetic fallback
-        with patch(
-            "tree_sitter_analyzer.mcp.utils.project_index._filesystem.subprocess.run",
-            side_effect=FileNotFoundError("fd not found"),
-        ):
-            index = manager.build()
+        index = manager.build()
         assert isinstance(index, ProjectIndex)
         assert index.file_count == 8
 
@@ -254,58 +248,27 @@ class TestProjectIndexManagerStaleness:
         assert manager.is_stale(index, max_age_hours=3) is False
 
 
-class TestProjectIndexManagerFdFallback:
-    """Tests for fd fallback to os.walk."""
+class TestProjectIndexManagerNativeDiscovery:
+    """项目索引独立发现文件，不调用外部文件搜索程序。"""
 
-    def test_fd_fallback_to_os_walk(
-        self, manager: ProjectIndexManager, simple_project: Path
-    ) -> None:
-        """Test that when fd is not available, os.walk is used as fallback."""
-        # Simulate fd not being available by making subprocess.run raise FileNotFoundError
-        import subprocess
-
-        original_run = subprocess.run
-
-        def mock_run(cmd: list[str], **kwargs: object) -> object:
-            if cmd[0] == "fd":
-                raise FileNotFoundError("fd not found")
-            return original_run(cmd, **kwargs)
-
-        with patch("subprocess.run", side_effect=mock_run):
+    def test_build_without_external_process(self, manager: ProjectIndexManager) -> None:
+        with patch(
+            "subprocess.Popen", side_effect=AssertionError("不得启动外部搜索程序")
+        ):
             index = manager.build()
-
-        # Should still produce a valid index with files
         assert index.file_count == 8
         assert "python" in index.language_distribution
 
-    def test_os_walk_skips_artifact_dirs(self, tmp_path: Path) -> None:
-        """Test that os.walk fallback skips artifact directories like __pycache__."""
+    def test_discovery_skips_artifact_dirs(self, tmp_path: Path) -> None:
         src = tmp_path / "src"
         src.mkdir()
-        (src / "real.py").write_text("x = 1\n")
+        real = src / "real.py"
+        real.write_text("x = 1\n", encoding="utf-8")
         pycache = src / "__pycache__"
         pycache.mkdir()
         (pycache / "cache.pyc").write_bytes(b"\x00")
-
         mgr = ProjectIndexManager(str(tmp_path))
-
-        import subprocess
-
-        def mock_run(cmd: list[str], **kwargs: object) -> object:
-            if cmd[0] == "fd":
-                raise FileNotFoundError("fd not found")
-            return (
-                subprocess.run.__wrapped__(cmd, **kwargs)
-                if hasattr(subprocess.run, "__wrapped__")
-                else subprocess.__dict__["run"].__wrapped__(cmd, **kwargs)
-            )  # type: ignore[attr-defined]
-
-        with patch("subprocess.run", side_effect=FileNotFoundError("fd not found")):
-            files = mgr._list_files([str(tmp_path)])
-
-        # __pycache__ files should not be in results
-        for f in files:
-            assert "__pycache__" not in f
+        assert mgr._list_files([str(tmp_path)]) == [str(real)]
 
 
 class TestProjectIndexDataclass:

--- a/tests/unit/test_source_lines.py
+++ b/tests/unit/test_source_lines.py
@@ -1,0 +1,188 @@
+"""原生文件发现与符号核验的完整性和边界。"""
+
+import pytest
+
+from tree_sitter_analyzer.source_lines import scan_symbol_lines, workspace_files
+
+
+def scan(root, symbol="target", **kwargs):
+    return scan_symbol_lines(
+        symbol,
+        [str(root)],
+        case_sensitive=kwargs.get("case_sensitive", False),
+        word_match=kwargs.get("word_match", True),
+        include_globs=kwargs.get("include_globs", ["**/*.py"]),
+        exclude_globs=kwargs.get("exclude_globs", []),
+        timeout=kwargs.get("timeout", 5),
+    )
+
+
+def test_nested_ignore_negation_and_hidden_files(tmp_path):
+    (tmp_path / "sub").mkdir()
+    (tmp_path / ".gitignore").write_text("*.log\nskip/\n", encoding="utf-8")
+    (tmp_path / "sub/.gitignore").write_text("!keep.log\n", encoding="utf-8")
+    (tmp_path / "skip").mkdir()
+    for name in [
+        "a.py",
+        "a.log",
+        ".secret.py",
+        "sub/keep.log",
+        "sub/hide.log",
+        "skip/b.py",
+    ]:
+        (tmp_path / name).write_text("target()\n", encoding="utf-8")
+    assert [
+        p.relative_to(tmp_path).as_posix() for p in workspace_files([str(tmp_path)])
+    ] == ["a.py", "sub/keep.log"]
+
+
+def test_overlapping_roots_never_duplicate_files(tmp_path):
+    (tmp_path / "sub").mkdir()
+    path = tmp_path / "sub/a.py"
+    path.write_text("target()\n", encoding="utf-8")
+    assert list(workspace_files([str(tmp_path), str(tmp_path / "sub")])) == [path]
+
+
+def test_missing_root_is_an_error(tmp_path):
+    with pytest.raises(OSError, match="SOURCE_ROOT_UNAVAILABLE"):
+        list(workspace_files([str(tmp_path / "missing")]))
+
+
+def test_symlink_files_and_directories_are_not_followed(tmp_path):
+    inside = tmp_path / "inside"
+    inside.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.py").write_text("target()", encoding="utf-8")
+    (inside / "linked").symlink_to(outside, target_is_directory=True)
+    (inside / "file.py").symlink_to(outside / "secret.py")
+    assert list(workspace_files([str(inside)])) == []
+    with pytest.raises(OSError, match="SOURCE_ROOT_SYMLINK"):
+        list(workspace_files([str(inside / "linked")]))
+
+
+@pytest.mark.parametrize(
+    "symbol,case,word,expected",
+    [
+        ("target", False, True, [1, 2]),
+        ("Target", False, True, [2]),
+        ("target", True, True, [1]),
+        ("target", False, False, [1, 2, 3]),
+        ("变量", False, True, [4]),
+    ],
+)
+def test_smart_case_word_boundaries_and_unicode(tmp_path, symbol, case, word, expected):
+    (tmp_path / "a.py").write_text(
+        "target()\nTarget()\nmytarget()\n变量()\n", encoding="utf-8"
+    )
+    assert [
+        hit["line"]
+        for hit in scan(tmp_path, symbol, case_sensitive=case, word_match=word)
+    ] == expected
+
+
+def test_globs_binary_files_and_original_line_numbers(tmp_path):
+    (tmp_path / "a.py").write_text("nothing\n  target()\n", encoding="utf-8")
+    (tmp_path / "skip.py").write_text("target()", encoding="utf-8")
+    (tmp_path / "notes.txt").write_text("target()", encoding="utf-8")
+    (tmp_path / "binary.py").write_bytes(b"target()\x00")
+    assert scan(tmp_path, exclude_globs=["**/skip.py"]) == [
+        {"file": str(tmp_path / "a.py"), "line": 2, "text": "  target()"}
+    ]
+
+
+def test_timeout_does_not_return_partial_matches(tmp_path):
+    (tmp_path / "a.py").write_text("target()", encoding="utf-8")
+    with pytest.raises(TimeoutError, match="SOURCE_DISCOVERY_BUDGET_EXCEEDED"):
+        scan(tmp_path, timeout=0)
+
+
+def test_full_count_is_independent_of_display_limit(tmp_path, monkeypatch):
+    import asyncio
+    import subprocess
+
+    from tree_sitter_analyzer.mcp.tools.trace_impact_tool import TraceImpactTool
+
+    monkeypatch.setattr(
+        subprocess, "Popen", lambda *args, **kwargs: pytest.fail("核验不得启动外部进程")
+    )
+    (tmp_path / "a.py").write_text("target()\n" * 150, encoding="utf-8")
+    result = asyncio.run(
+        TraceImpactTool(str(tmp_path)).execute({"symbol": "target", "max_results": 3})
+    )
+    assert result["call_count"] == 150
+    assert len(result["usages"]) == 3
+    assert result["truncated"] is True
+
+
+def test_oversized_source_refuses_incomplete_success(tmp_path, monkeypatch):
+    import tree_sitter_analyzer.source_lines as native
+
+    monkeypatch.setattr(native, "_MAX_FILE_BYTES", 8)
+    (tmp_path / "a.py").write_text("target()\n", encoding="utf-8")
+    with pytest.raises(TimeoutError, match="SOURCE_FILE_BUDGET_EXCEEDED"):
+        scan(tmp_path)
+
+
+@pytest.mark.parametrize(
+    "budget,limit,error",
+    [
+        ("_MAX_ENTRIES", 1, "SOURCE_DISCOVERY_BUDGET_EXCEEDED"),
+        ("_MAX_TOTAL_BYTES", 8, "SOURCE_SCAN_BUDGET_EXCEEDED"),
+        ("_MAX_MATCHES", 1, "SOURCE_MATCH_BUDGET_EXCEEDED"),
+    ],
+)
+def test_exhausted_budget_never_returns_partial_results(
+    tmp_path, monkeypatch, budget, limit, error
+):
+    import tree_sitter_analyzer.source_lines as native
+
+    monkeypatch.setattr(native, budget, limit)
+    for name in ["a.py", "b.py"]:
+        (tmp_path / name).write_text("target()", encoding="utf-8")
+    with pytest.raises(TimeoutError, match=error):
+        scan(tmp_path)
+
+
+def test_directory_read_error_is_reported(tmp_path, monkeypatch):
+    import tree_sitter_analyzer.source_lines as native
+
+    def failed_walk(*args, onerror, **kwargs):
+        onerror(PermissionError("unreadable directory"))
+
+    monkeypatch.setattr(native.os, "walk", failed_walk)
+    with pytest.raises(PermissionError, match="unreadable directory"):
+        list(workspace_files([str(tmp_path)]))
+
+
+def test_file_replaced_with_nonregular_entry_is_rejected(tmp_path, monkeypatch):
+    import stat
+    from types import SimpleNamespace
+
+    import tree_sitter_analyzer.source_lines as native
+
+    (tmp_path / "a.py").write_text("target()", encoding="utf-8")
+    with monkeypatch.context() as patcher:
+        patcher.setattr(
+            native.os, "fstat", lambda _: SimpleNamespace(st_mode=stat.S_IFIFO)
+        )
+        with pytest.raises(OSError, match="SOURCE_FILE_CHANGED"):
+            scan(tmp_path)
+
+
+def test_discovery_excludes_nonregular_entries(tmp_path, monkeypatch):
+    import stat
+    from pathlib import Path
+    from types import SimpleNamespace
+
+    special = tmp_path / "pipe.py"
+    special.write_text("", encoding="utf-8")
+    original_stat = Path.stat
+
+    def entry_stat(path, *args, **kwargs):
+        if path == special:
+            return SimpleNamespace(st_mode=stat.S_IFIFO)
+        return original_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", entry_stat)
+    assert list(workspace_files([str(tmp_path)])) == []

--- a/tests/unit/test_source_lines.py
+++ b/tests/unit/test_source_lines.py
@@ -402,3 +402,59 @@ def test_isolated_worker_preserves_unicode_paths_and_symbols(tmp_path):
         include_globs=[],
         exclude_globs=[],
     ) == [{"file": str(path), "line": 1, "text": "变量()"}]
+
+
+@pytest.mark.asyncio
+async def test_trace_never_rereads_hits_in_parent_process(tmp_path, monkeypatch):
+    # 2026-09-09：注释过滤不能在有界扫描之后重新阻塞 MCP 主进程。
+    import tree_sitter_analyzer.mcp.tools.trace_impact_tool as trace
+
+    (tmp_path / "a.py").write_text("# target()\ntarget()\n", encoding="utf-8")
+    monkeypatch.setattr(
+        trace,
+        "_file_non_code_lines",
+        lambda path: pytest.fail("主进程不得重读命中文件"),
+    )
+    result = await trace.TraceImpactTool(str(tmp_path)).execute({"symbol": "target"})
+    assert result["success"] is True
+    assert result["call_count"] == 1
+    assert result["usages"][0]["line"] == 2
+
+
+def test_worker_protocol_classifies_code_and_comments(tmp_path, monkeypatch, capsys):
+    import io
+    import json
+
+    import tree_sitter_analyzer.source_lines as native
+
+    path = tmp_path / "a.py"
+    path.write_text("# target()\ntarget()\n", encoding="utf-8")
+    request = {
+        "symbol": "target",
+        "roots": [str(tmp_path)],
+        "case_sensitive": True,
+        "word_match": True,
+        "include_globs": [],
+        "exclude_globs": [],
+        "classify_source": True,
+    }
+    monkeypatch.setattr(native.sys, "stdin", io.StringIO(json.dumps(request)))
+    native._main()
+    matches = json.loads(capsys.readouterr().out)["matches"]
+    assert [(m["line"], m["_source_match"]) for m in matches] == [(1, False), (2, True)]
+
+
+def test_classified_worker_response_requires_boolean_classification(
+    tmp_path, monkeypatch
+):
+    from unittest.mock import Mock
+
+    import tree_sitter_analyzer.source_lines as native
+
+    process = Mock(returncode=0)
+    process.communicate.return_value = ('{"matches": [{"file": "a.py"}]}', "")
+    monkeypatch.setattr(native.subprocess, "Popen", Mock(return_value=process))
+    with pytest.raises(OSError, match="SOURCE_WORKER_INVALID_RESPONSE"):
+        native.scan_symbol_lines_bounded(
+            "target", [str(tmp_path)], classify_source=True
+        )

--- a/tests/unit/test_source_lines.py
+++ b/tests/unit/test_source_lines.py
@@ -81,12 +81,30 @@ def test_smart_case_word_boundaries_and_unicode(tmp_path, symbol, case, word, ex
     ] == expected
 
 
-def test_globs_binary_files_and_original_line_numbers(tmp_path):
-    (tmp_path / "a.py").write_text("nothing\n  target()\n", encoding="utf-8")
+def test_exclude_globs_apply_to_root_files(tmp_path):
     (tmp_path / "skip.py").write_text("target()", encoding="utf-8")
+    assert scan(tmp_path, exclude_globs=["**/skip.py"]) == []
+
+
+def test_already_negated_exclude_globs_are_preserved(tmp_path):
+    # 2026-09-09：旧调用方会传入已经带有 ! 的排除模式。
+    (tmp_path / "skip.py").write_text("target()", encoding="utf-8")
+    assert scan(tmp_path, exclude_globs=["!**/skip.py"]) == []
+
+
+def test_nonmatching_extensions_are_excluded(tmp_path):
     (tmp_path / "notes.txt").write_text("target()", encoding="utf-8")
+    assert scan(tmp_path) == []
+
+
+def test_binary_files_are_excluded(tmp_path):
     (tmp_path / "binary.py").write_bytes(b"target()\x00")
-    assert scan(tmp_path, exclude_globs=["**/skip.py"]) == [
+    assert scan(tmp_path) == []
+
+
+def test_source_positions_preserve_line_number_and_indent(tmp_path):
+    (tmp_path / "a.py").write_text("nothing\n  target()\n", encoding="utf-8")
+    assert scan(tmp_path) == [
         {"file": str(tmp_path / "a.py"), "line": 2, "text": "  target()"}
     ]
 
@@ -100,12 +118,24 @@ def test_timeout_does_not_return_partial_matches(tmp_path):
 def test_full_count_is_independent_of_display_limit(tmp_path, monkeypatch):
     import asyncio
     import subprocess
+    import sys
 
     from tree_sitter_analyzer.mcp.tools.trace_impact_tool import TraceImpactTool
 
-    monkeypatch.setattr(
-        subprocess, "Popen", lambda *args, **kwargs: pytest.fail("核验不得启动外部进程")
-    )
+    original = subprocess.Popen
+
+    def own_worker_only(argv, *args, **kwargs):
+        assert argv == [
+            sys.executable,
+            "-I",
+            "-X",
+            "utf8",
+            "-m",
+            "tree_sitter_analyzer.source_lines",
+        ]
+        return original(argv, *args, **kwargs)
+
+    monkeypatch.setattr(subprocess, "Popen", own_worker_only)
     (tmp_path / "a.py").write_text("target()\n" * 150, encoding="utf-8")
     result = asyncio.run(
         TraceImpactTool(str(tmp_path)).execute({"symbol": "target", "max_results": 3})
@@ -186,3 +216,189 @@ def test_discovery_excludes_nonregular_entries(tmp_path, monkeypatch):
 
     monkeypatch.setattr(Path, "stat", entry_stat)
     assert list(workspace_files([str(tmp_path)])) == []
+
+
+@pytest.mark.parametrize("root", ["", " "])
+def test_empty_roots_do_not_expand_to_working_directory(root):
+    # 2026-09-09：逗号分隔根列表的空分量不能偷偷引入工作目录。
+    with pytest.raises(OSError, match="SOURCE_ROOT_EMPTY"):
+        list(workspace_files([root]))
+
+
+def test_symlinked_ancestor_returns_canonical_paths(tmp_path):
+    # 2026-09-09：macOS 的 /var 与 /private/var 必须使用同一套路径表示。
+    real = tmp_path / "real"
+    project = real / "project"
+    project.mkdir(parents=True)
+    file = project / "a.py"
+    file.write_text("target()", encoding="utf-8")
+    alias = tmp_path / "alias"
+    alias.symlink_to(real, target_is_directory=True)
+    assert list(workspace_files([str(alias / "project")])) == [file.resolve()]
+
+
+def test_blocking_worker_is_killed_at_deadline(tmp_path, monkeypatch):
+    # 2026-09-09：模拟文件系统读取一直不返回，父进程仍必须结束请求并回收工作进程。
+    import subprocess
+    import sys
+    import time
+
+    import tree_sitter_analyzer.source_lines as native
+
+    original = subprocess.Popen
+    processes = []
+
+    def blocked_worker(argv, **kwargs):
+        process = original(
+            [sys.executable, "-I", "-c", "import time; time.sleep(60)"], **kwargs
+        )
+        processes.append(process)
+        return process
+
+    monkeypatch.setattr(subprocess, "Popen", blocked_worker)
+    started = time.monotonic()
+    with pytest.raises(TimeoutError, match="SOURCE_SCAN_BUDGET_EXCEEDED"):
+        native.scan_symbol_lines_bounded("target", [str(tmp_path)], timeout=0.1)
+    # 时间不可精确固定；上限包含 0.1 秒请求预算、一秒回收预算与调度余量。
+    assert time.monotonic() - started < 3
+    assert processes[0].poll() is not None
+
+
+def test_worker_module_json_protocol(tmp_path, monkeypatch, capsys):
+    import io
+    import json
+    import runpy
+    import sys
+
+    (tmp_path / "a.py").write_text("target()", encoding="utf-8")
+    request = {
+        "symbol": "target",
+        "roots": [str(tmp_path)],
+        "case_sensitive": True,
+        "word_match": True,
+        "include_globs": ["**/*.py"],
+        "exclude_globs": [],
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(request)))
+    # 模块入口与隔离 Python 进程使用同一协议；临时移除缓存避免 runpy 的重复导入警告。
+    monkeypatch.delitem(sys.modules, "tree_sitter_analyzer.source_lines")
+    runpy.run_module("tree_sitter_analyzer.source_lines", run_name="__main__")
+    assert json.loads(capsys.readouterr().out) == {
+        "matches": [{"file": str(tmp_path / "a.py"), "line": 1, "text": "target()"}]
+    }
+
+
+@pytest.mark.parametrize(
+    "response,exit_code,error_type,error",
+    [
+        ('{"matches": []}', 3, OSError, "SOURCE_WORKER_FAILED"),
+        (
+            '{"error": "SOURCE_ROOT_UNAVAILABLE", "timeout": false}',
+            0,
+            OSError,
+            "SOURCE_ROOT_UNAVAILABLE",
+        ),
+        (
+            '{"error": "SOURCE_SCAN_BUDGET_EXCEEDED", "timeout": true}',
+            0,
+            TimeoutError,
+            "SOURCE_SCAN_BUDGET_EXCEEDED",
+        ),
+        ('{"matches": null}', 0, OSError, "SOURCE_WORKER_INVALID_RESPONSE"),
+    ],
+)
+def test_worker_failure_is_never_reported_as_empty_success(
+    tmp_path, monkeypatch, response, exit_code, error_type, error
+):
+    from unittest.mock import Mock
+
+    import tree_sitter_analyzer.source_lines as native
+
+    process = Mock(returncode=exit_code)
+    process.communicate.return_value = (response, "")
+    monkeypatch.setattr(native.subprocess, "Popen", Mock(return_value=process))
+    with pytest.raises(error_type, match=error):
+        native.scan_symbol_lines_bounded("target", [str(tmp_path)])
+
+
+def test_unfinished_worker_cleanup_is_reported(tmp_path, monkeypatch):
+    import subprocess
+    from unittest.mock import Mock
+
+    import tree_sitter_analyzer.source_lines as native
+
+    process = Mock()
+    process.communicate.side_effect = subprocess.TimeoutExpired("worker", 1)
+    monkeypatch.setattr(native.subprocess, "Popen", Mock(return_value=process))
+    with pytest.raises(OSError, match="SOURCE_WORKER_CLEANUP_FAILED"):
+        native.scan_symbol_lines_bounded("target", [str(tmp_path)])
+    process.kill.assert_called_once_with()
+    assert process.communicate.call_args.kwargs == {"timeout": 1}
+
+
+@pytest.mark.parametrize(
+    "timeout,root_suffix,expected",
+    [
+        (5, "missing", {"error": "SOURCE_ROOT_UNAVAILABLE", "timeout": False}),
+        (0, "", {"error": "SOURCE_DISCOVERY_BUDGET_EXCEEDED", "timeout": True}),
+    ],
+)
+def test_worker_protocol_preserves_scan_errors(
+    tmp_path, monkeypatch, capsys, timeout, root_suffix, expected
+):
+    import io
+    import json
+
+    import tree_sitter_analyzer.source_lines as native
+
+    request = {
+        "symbol": "target",
+        "roots": [str(tmp_path / root_suffix)],
+        "case_sensitive": True,
+        "word_match": True,
+        "include_globs": [],
+        "exclude_globs": [],
+        "timeout": timeout,
+    }
+    monkeypatch.setattr(native.sys, "stdin", io.StringIO(json.dumps(request)))
+    native._main()
+    assert json.loads(capsys.readouterr().out) == expected
+
+
+def test_worker_protocol_rejects_oversized_payload(tmp_path, monkeypatch, capsys):
+    import io
+    import json
+
+    import tree_sitter_analyzer.source_lines as native
+
+    (tmp_path / "a.py").write_text("target()\n" * 100, encoding="utf-8")
+    request = {
+        "symbol": "target",
+        "roots": [str(tmp_path)],
+        "case_sensitive": True,
+        "word_match": True,
+        "include_globs": [],
+        "exclude_globs": [],
+    }
+    monkeypatch.setattr(native, "_MAX_RESPONSE_BYTES", 128)
+    monkeypatch.setattr(native.sys, "stdin", io.StringIO(json.dumps(request)))
+    native._main()
+    assert json.loads(capsys.readouterr().out) == {
+        "error": "SOURCE_RESPONSE_BUDGET_EXCEEDED",
+        "timeout": True,
+    }
+
+
+def test_isolated_worker_preserves_unicode_paths_and_symbols(tmp_path):
+    from tree_sitter_analyzer.source_lines import scan_symbol_lines_bounded
+
+    path = tmp_path / "名字.py"
+    path.write_text("变量()\n", encoding="utf-8")
+    assert scan_symbol_lines_bounded(
+        "变量",
+        [str(tmp_path)],
+        case_sensitive=True,
+        word_match=True,
+        include_globs=[],
+        exclude_globs=[],
+    ) == [{"file": str(path), "line": 1, "text": "变量()"}]

--- a/tree_sitter_analyzer/mcp/tools/__init__.py
+++ b/tree_sitter_analyzer/mcp/tools/__init__.py
@@ -26,7 +26,7 @@ AVAILABLE_TOOLS: dict[str, dict[str, Any]] = {
     "trace_impact": {
         "description": (
             "Find all usage sites of a symbol (method/class/function) to assess change impact. "
-            "Uses ripgrep for fast search with optional language filtering."
+            "Uses native source scanning with optional language filtering."
         ),
         "module": "trace_impact_tool",
         "class": "TraceImpactTool",

--- a/tree_sitter_analyzer/mcp/tools/trace_impact_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/trace_impact_tool.py
@@ -12,7 +12,7 @@ from typing import Any
 from tree_sitter_analyzer.cache.fingerprint import _SOURCE_EXTS
 
 from ...language_detector import LanguageDetector, detect_language_from_file
-from ...source_lines import scan_symbol_lines
+from ...source_lines import scan_symbol_lines_bounded as scan_symbol_lines
 from ...utils import setup_logger
 from ..utils.error_handler import handle_mcp_errors
 from .base_tool import BaseMCPTool
@@ -433,14 +433,15 @@ def _build_not_found_response(symbol: str, language: str | None) -> dict[str, An
 def _truncate_for_display(
     source_matches: list[Any], max_results: int
 ) -> tuple[list[Any], bool]:
-    """Display-cap source matches without affecting impact-level count."""
+    """展示最多一万行，不影响完整命中计数。"""
+    max_results = min(max_results, 10000)
     if len(source_matches) > max_results:
         return source_matches[:max_results], True
     return source_matches, False
 
 
 def _matches_to_usages(matches: list[Any]) -> list[dict[str, Any]]:
-    """Convert rg matches to usage dicts with both ``file``/``file_path`` aliases."""
+    """将源码命中转换为保留两种路径字段的引用结果。"""
     usages: list[dict[str, Any]] = []
     for match in matches:
         line_no = match["line"]
@@ -461,12 +462,12 @@ def _verdict_and_next_step_for_impact(level: str, total_count: int) -> tuple[str
     """K5: map impact level (magnitude vocab) → (verdict, next_step) (safety vocab)."""
     if level == "high":
         return "UNSAFE", (
-            f"nav action=trace to enumerate all {total_count} call sites before "
+            f"nav action=trace max_results={min(total_count, 10000)} with narrower project_root scopes to review {total_count} call sites before "
             "changing signature"
         )
     if level == "medium":
         return "CAUTION", (
-            f"nav action=trace to enumerate all {total_count} call sites before "
+            f"nav action=trace max_results={min(total_count, 10000)} with narrower project_root scopes to review {total_count} call sites before "
             "changing signature"
         )
     if level == "low":
@@ -533,20 +534,12 @@ def _trace_impact_apply_conditional_fields(
     truncated: bool,
     max_results: int,
 ) -> None:
-    """Mutate ``result`` with optional fields based on signal flags.
-
-    Adds in-place:
-    - ``warning`` when impact_level == "high" (advises nav action=trace)
-    - ``language`` + ``filtered_by_language`` when a language was inferred
-    - ``source_file`` when ``file_path`` was provided
-    - ``truncated`` + ``message`` when results overflowed ``max_results``
-    - ``non_source_match_count`` when raw matches exceeded source matches
-    """
+    """按影响程度、语言、文件和截断状态补充结果字段。"""
     if impact_level == "high":
         result["warning"] = (
             f"🚨 HIGH IMPACT: This symbol has {source_total} callers. "
             f"Modifying its signature requires updating all call sites. "
-            f"Use nav action=trace to locate all callers before proceeding."
+            f"Use narrower project_root scopes with nav action=trace max_results=10000 to review callers before proceeding."
         )
     if language:
         result["language"] = language
@@ -557,7 +550,7 @@ def _trace_impact_apply_conditional_fields(
         result["truncated"] = True
         result["message"] = (
             f"Results truncated to {max_results} usages. "
-            f"Consider narrowing the search scope or increasing max_results."
+            f"Narrow project_root to a smaller directory; display is capped at 10000 usages."
         )
     if true_total > source_total:
         result["non_source_match_count"] = true_total - source_total
@@ -810,7 +803,7 @@ class TraceImpactTool(BaseMCPTool):
         file_path = arguments.get("file_path")
         case_sensitive = arguments.get("case_sensitive", False)
         word_match = arguments.get("word_match", True)
-        max_results = arguments.get("max_results", 1000)
+        max_results = min(arguments.get("max_results", 1000), 10000)
         exclude_patterns = arguments.get("exclude_patterns", [])
 
         roots = self._resolve_search_roots(arguments.get("project_root"))
@@ -858,13 +851,16 @@ class TraceImpactTool(BaseMCPTool):
 
     def _resolve_search_roots(self, project_root_arg: str | None) -> list[str]:
         """按显式逗号分隔目录、工具项目目录、当前目录的顺序解析扫描根。"""
-        if project_root_arg:
-            return [root.strip() for root in project_root_arg.split(",")]
-        if self.project_root:
-            return [self.project_root]
-        from pathlib import Path
-
-        return [str(Path.cwd())]
+        values = (
+            project_root_arg.split(",")
+            if project_root_arg is not None
+            else [self.project_root or str(Path.cwd())]
+        )
+        if any(not root.strip() for root in values):
+            raise ValueError("SOURCE_ROOT_EMPTY")
+        return [
+            self.resolve_and_validate_directory_path(root.strip()) for root in values
+        ]
 
     def _detect_language_filter(
         self, file_path: str | None

--- a/tree_sitter_analyzer/mcp/tools/trace_impact_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/trace_impact_tool.py
@@ -1,17 +1,9 @@
 #!/usr/bin/env python3
-"""
-Trace Impact Tool
-
-Lightweight impact analysis tool that finds all call sites of a symbol (method/class/function)
-using ripgrep. Unlike full call graph solutions, this provides fast "usage tracing" without
-requiring a graph database.
-
-This tool is inspired by GitNexus's impact analysis but optimized for tree-sitter-analyzer's
-architecture, reusing existing ripgrep infrastructure.
-"""
+"""用原生源码扫描定位符号引用，并通过语言启发式区分调用、导入和注释。"""
 
 from __future__ import annotations
 
+import asyncio
 import re
 from functools import lru_cache
 from pathlib import Path
@@ -20,14 +12,10 @@ from typing import Any
 from tree_sitter_analyzer.cache.fingerprint import _SOURCE_EXTS
 
 from ...language_detector import LanguageDetector, detect_language_from_file
+from ...source_lines import scan_symbol_lines
 from ...utils import setup_logger
 from ..utils.error_handler import handle_mcp_errors
 from .base_tool import BaseMCPTool
-from .fd_rg_utils import (
-    build_rg_command,
-    parse_rg_json_lines_to_matches,
-    run_command_capture,
-)
 
 # Set up logging
 logger = setup_logger(__name__)
@@ -37,21 +25,14 @@ logger = setup_logger(__name__)
 # Mirrors the SOURCE_EXTS list used for graph fingerprinting so the call
 # count, the dependency graph, and the impact badge all describe the same
 # universe of files. Globs are rooted at any depth (``**/*.py`` style) so
-# ripgrep ``-g`` accepts them without translation.
+# 原生扫描器在每层目录应用这些扩展名规则。
 _SOURCE_EXT_GLOBS: tuple[str, ...] = tuple(f"**/*{ext}" for ext in _SOURCE_EXTS)
 
 
 def _filter_source_matches(
     matches: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
-    """H4 fix: drop hits whose file extension is not in ``_SOURCE_EXTS``.
-
-    The ``-g`` flag passed to ripgrep already restricts the search at the
-    boundary; this is a belt-and-braces filter so that ``call_count`` is
-    honest even when ``-g`` is bypassed (e.g. a future change adds
-    ``--no-ignore`` or a custom glob). The cost is O(n) over hits that
-    have already been parsed once.
-    """
+    """只保留源码扩展名，防止自定义 glob 扩大调用统计范围。"""
     if not matches:
         return matches
     return [match for match in matches if _is_source_file(match.get("file", ""))]
@@ -161,19 +142,7 @@ def _python_non_code_lines(text: str) -> set[int]:
 
 
 def _is_symbol_only_in_strings(line: str, symbol: str) -> bool:
-    """Return True if every occurrence of ``symbol`` in ``line`` is inside an
-    inline string literal (single or double quoted, not triple-quoted).
-
-    Used as a per-match heuristic (#655): if the only reason a line shows up
-    in ripgrep results is that the symbol name appears inside a string
-    argument (e.g. ``reason="my_func is not ready"``), it is NOT a call site.
-
-    Algorithm: walk the line character by character, tracking whether we are
-    inside a single-quoted or double-quoted string. For each position where
-    ``symbol`` starts, record whether we are inside a string at that point.
-    If ALL occurrences of ``symbol`` are inside strings → return True.
-    Returns False (not filtered) when symbol is absent (safety default).
-    """
+    """判断符号是否只出现在行内字符串中；f-string 替换表达式仍算代码，缺少符号时保守保留。"""
     if not symbol or symbol not in line:
         return False
 
@@ -407,13 +376,7 @@ def _build_trace_impact_globs(
     language_extensions: list[str],
     exclude_patterns: list[str],
 ) -> tuple[list[str], list[str]]:
-    """Build (include_globs, exclude_globs) for ripgrep.
-
-    r37bw: extracted from ``execute``. Adds common exclude patterns
-    (node_modules, .git, vendor, __pycache__, *.min.{js,css}) and either
-    language-specific extensions or the project-wide source extension
-    set (H4 fix).
-    """
+    """构建源码包含规则及依赖、缓存、压缩产物的排除规则。"""
     exclude_globs = list(exclude_patterns)
     exclude_globs.extend(
         [
@@ -435,55 +398,8 @@ def _build_trace_impact_globs(
     return include_globs, exclude_globs
 
 
-def _classify_rg_error(rc: int, stderr: bytes | None) -> dict[str, Any] | None:
-    """Map ripgrep exit code to an error envelope, or ``None`` on success/no-match.
-
-    r37bw: extracted from ``execute``. rc=127 means rg missing, rc=124
-    means timeout, anything other than 0/1 is a real failure. rc=0/1
-    return ``None`` so the caller continues to result parsing.
-    """
-    if rc == 127:
-        return {
-            "success": False,
-            "error": (
-                "ripgrep (rg) is not installed. Please install ripgrep "
-                "to use trace_impact."
-            ),
-            "usages": [],
-            "call_count": 0,
-        }
-    if rc == 124:
-        return {
-            "success": False,
-            "error": (
-                "Search timed out. Try narrowing the search scope or "
-                "excluding more directories."
-            ),
-            "usages": [],
-            "call_count": 0,
-        }
-    if rc not in (0, 1):
-        error_msg = (
-            stderr.decode("utf-8", errors="replace") if stderr else "Unknown error"
-        )
-        return {
-            "success": False,
-            "error": f"Search failed: {error_msg}",
-            "usages": [],
-            "call_count": 0,
-        }
-    return None
-
-
 def _build_not_found_response(symbol: str, language: str | None) -> dict[str, Any]:
-    """M11: ripgrep returned zero matches → NOT_FOUND envelope.
-
-    The typo-vs-real-zero-caller ambiguity is resolved as "verify
-    spelling first" to match symbol_lineage's behaviour. ``impact_verdict``
-    stays at the magnitude vocab (``NONE`` for zero callers) while
-    top-level ``verdict`` flips to ``NOT_FOUND`` so cross-tool readers
-    can branch on a single field.
-    """
+    """无文本命中时返回 NOT_FOUND，提示先核实符号拼写；影响量级仍为 NONE。"""
     impact = _get_impact_level(0)
     summary_line = f"trace_impact symbol={symbol} not_found"
     return {
@@ -545,12 +461,12 @@ def _verdict_and_next_step_for_impact(level: str, total_count: int) -> tuple[str
     """K5: map impact level (magnitude vocab) → (verdict, next_step) (safety vocab)."""
     if level == "high":
         return "UNSAFE", (
-            f"batch_search to enumerate all {total_count} call sites before "
+            f"nav action=trace to enumerate all {total_count} call sites before "
             "changing signature"
         )
     if level == "medium":
         return "CAUTION", (
-            f"batch_search to enumerate all {total_count} call sites before "
+            f"nav action=trace to enumerate all {total_count} call sites before "
             "changing signature"
         )
     if level == "low":
@@ -620,7 +536,7 @@ def _trace_impact_apply_conditional_fields(
     """Mutate ``result`` with optional fields based on signal flags.
 
     Adds in-place:
-    - ``warning`` when impact_level == "high" (advises batch_search)
+    - ``warning`` when impact_level == "high" (advises nav action=trace)
     - ``language`` + ``filtered_by_language`` when a language was inferred
     - ``source_file`` when ``file_path`` was provided
     - ``truncated`` + ``message`` when results overflowed ``max_results``
@@ -630,7 +546,7 @@ def _trace_impact_apply_conditional_fields(
         result["warning"] = (
             f"🚨 HIGH IMPACT: This symbol has {source_total} callers. "
             f"Modifying its signature requires updating all call sites. "
-            f"Use batch_search to locate all callers before proceeding."
+            f"Use nav action=trace to locate all callers before proceeding."
         )
     if language:
         result["language"] = language
@@ -785,12 +701,7 @@ _TRACE_IMPACT_INPUT_SCHEMA: dict[str, Any] = {
 
 
 class TraceImpactTool(BaseMCPTool):
-    """
-    MCP tool for tracing the impact of code changes by finding all usage sites of a symbol.
-
-    This tool uses ripgrep to efficiently search for occurrences of a method, class, or
-    function name across the project, optionally filtering by language to reduce noise.
-    """
+    """原生扫描源码中的符号引用，可按语言过滤；调用分类采用启发式规则。"""
 
     def __init__(self, project_root: str | None = None) -> None:
         """
@@ -908,40 +819,21 @@ class TraceImpactTool(BaseMCPTool):
             language_extensions, exclude_patterns
         )
 
-        cmd = build_rg_command(
-            query=symbol,
-            case="sensitive" if case_sensitive else "smart",
-            fixed_strings=True,
-            word=word_match,
-            multiline=False,
-            include_globs=include_globs if include_globs else None,
-            exclude_globs=exclude_globs,
-            follow_symlinks=False,
-            hidden=False,
-            no_ignore=False,
-            max_filesize="10M",
-            context_before=None,
-            context_after=None,
-            encoding=None,
-            max_count=None,
-            timeout_ms=5000,
-            roots=roots,
-            files_from=None,
-            count_only_matches=False,
-        )
-        logger.debug(f"Executing ripgrep command: {' '.join(cmd)}")
-        rc, stdout, stderr = await run_command_capture(cmd, timeout_ms=5000)
-
-        rg_error = _classify_rg_error(rc, stderr)
-        if rg_error is not None:
-            return rg_error
-
-        if rc == 1:
-            # M11: ripgrep zero-match → NOT_FOUND envelope (typo vs zero-caller
-            # ambiguity resolved as "verify spelling first" per symbol_lineage).
+        try:
+            matches = await asyncio.to_thread(
+                scan_symbol_lines,
+                symbol,
+                roots,
+                case_sensitive=case_sensitive,
+                word_match=word_match,
+                include_globs=include_globs,
+                exclude_globs=exclude_globs,
+            )
+        except (OSError, TimeoutError) as exc:
+            return {"success": False, "error": str(exc), "usages": [], "call_count": 0}
+        if not matches:
             return _build_not_found_response(symbol, language)
 
-        matches = parse_rg_json_lines_to_matches(stdout)
         ext_filtered = _filter_source_matches(matches)
         # #655: pass symbol so import lines and inline string-literal
         # mentions are excluded from the caller count.
@@ -965,11 +857,7 @@ class TraceImpactTool(BaseMCPTool):
         )
 
     def _resolve_search_roots(self, project_root_arg: str | None) -> list[str]:
-        """Compute the project root list for ripgrep.
-
-        Order: explicit ``project_root_arg`` (comma-split) → tool default
-        → cwd. r37bw extracted from execute.
-        """
+        """按显式逗号分隔目录、工具项目目录、当前目录的顺序解析扫描根。"""
         if project_root_arg:
             return [root.strip() for root in project_root_arg.split(",")]
         if self.project_root:

--- a/tree_sitter_analyzer/mcp/tools/trace_impact_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/trace_impact_tool.py
@@ -305,6 +305,11 @@ def _filter_comment_docstring_matches(
         return matches
     kept: list[dict[str, Any]] = []
     for match in matches:
+        # 原生工作进程已分类的命中直接使用，避免主进程再次执行阻塞文件读取。
+        if "_source_match" in match:
+            if match["_source_match"]:
+                kept.append(match)
+            continue
         file_path = match.get("file", "")
         line_no = match.get("line")
         if not file_path or not isinstance(line_no, int):
@@ -821,6 +826,7 @@ class TraceImpactTool(BaseMCPTool):
                 word_match=word_match,
                 include_globs=include_globs,
                 exclude_globs=exclude_globs,
+                classify_source=True,
             )
         except (OSError, TimeoutError) as exc:
             return {"success": False, "error": str(exc), "usages": [], "call_count": 0}

--- a/tree_sitter_analyzer/mcp/utils/project_index/_filesystem.py
+++ b/tree_sitter_analyzer/mcp/utils/project_index/_filesystem.py
@@ -1,16 +1,8 @@
-"""
-File-system scanning helpers for project_index.
-
-Provides file enumeration (fd / os.walk fallback), entry-point detection,
-top-level structure building, language distribution, and module description
-extraction.
-"""
+"""项目索引的原生文件发现、入口检测、目录结构与语言统计。"""
 
 from __future__ import annotations
 
-import os
 import re
-import subprocess  # nosec
 from pathlib import Path
 from typing import Any
 
@@ -54,48 +46,10 @@ _ARTIFACT_DIRS: frozenset[str] = frozenset(
 
 
 def list_files(roots: list[str]) -> list[str]:
-    """Return absolute paths of all regular files under *roots*.
+    """返回遵守忽略规则及符号链接边界的普通文件绝对路径。"""
+    from ....source_lines import workspace_files
 
-    Tries ``fd`` first for speed; falls back to ``os.walk``.
-    """
-    abs_roots = [str(Path(r).resolve()) for r in roots]
-
-    try:
-        result = subprocess.run(  # nosec
-            ["fd", "--type", "f", "--color", "never", "--absolute-path", "."]
-            + abs_roots,
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            timeout=30,
-        )
-        if result.returncode == 0:
-            return [line.strip() for line in result.stdout.splitlines() if line.strip()]
-    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
-        pass
-
-    # Fallback: os.walk
-    files: list[str] = []
-    skip_dirs = {
-        ".git",
-        ".tree-sitter-cache",
-        "node_modules",
-        "__pycache__",
-        ".venv",
-        "venv",
-        ".mypy_cache",
-        ".ruff_cache",
-        "dist",
-        "build",
-        "target",
-    }
-    for root_str in abs_roots:
-        for dirpath, dirnames, filenames in os.walk(root_str):
-            dirnames[:] = [d for d in dirnames if d not in skip_dirs]
-            for fname in filenames:
-                files.append(os.path.join(dirpath, fname))
-    return files
+    return [str(path) for path in workspace_files(roots)]
 
 
 def compute_language_distribution(all_files: list[str]) -> dict[str, int]:

--- a/tree_sitter_analyzer/source_lines.py
+++ b/tree_sitter_analyzer/source_lines.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import fnmatch
+import json
 import os
 import re
 import stat
+import subprocess
+import sys
 import time
 from collections.abc import Iterator
 from pathlib import Path
@@ -17,6 +20,7 @@ _MAX_ENTRIES = 200000
 _MAX_FILE_BYTES = 10 * 1024 * 1024
 _MAX_TOTAL_BYTES = 512 * 1024 * 1024
 _MAX_MATCHES = 100000
+_MAX_RESPONSE_BYTES = 32 * 1024 * 1024
 
 _EXCLUDED = frozenset(
     {".git", ".venv", "venv", "node_modules", "__pycache__", "build", "dist", "target"}
@@ -30,11 +34,14 @@ def workspace_files(
     seen: set[str] = set()
     entries = 0
     for value in roots:
+        if not isinstance(value, str) or not value.strip():
+            raise OSError("SOURCE_ROOT_EMPTY")
         root = Path(value).absolute()
         if root.is_symlink():
             raise OSError("SOURCE_ROOT_SYMLINK")
         if not root.is_dir():
             raise OSError("SOURCE_ROOT_UNAVAILABLE")
+        root = root.resolve(strict=True)
         rules: dict[Path, list[tuple[Path, pathspec.GitIgnoreSpec]]] = {}
         for current, directories, names in os.walk(
             root, followlinks=False, onerror=_raise_walk_error
@@ -129,9 +136,10 @@ def scan_symbol_lines(
     if word_match:
         expression = r"(?<!\w)" + expression + r"(?!\w)"
     matcher = re.compile(expression, 0 if sensitive else re.IGNORECASE)
+    exclude_globs = [pattern.removeprefix("!") for pattern in exclude_globs]
     matches = []
     total_bytes = 0
-    bases = [Path(root).absolute() for root in roots]
+    bases = [Path(root).resolve() for root in roots]
     for path in workspace_files(roots, deadline=deadline):
         relative = next(
             path.relative_to(base).as_posix()
@@ -173,3 +181,59 @@ def scan_symbol_lines(
                 if len(matches) > _MAX_MATCHES:
                     raise TimeoutError("SOURCE_MATCH_BUDGET_EXCEEDED")
     return matches
+
+
+def scan_symbol_lines_bounded(
+    symbol: str, roots: list[str], **options: Any
+) -> list[dict[str, Any]]:
+    """在自带的 Python 工作进程中扫描；阻塞 I/O 超时后终止该进程。"""
+    timeout = options.get("timeout", 5)
+    process = subprocess.Popen(
+        [sys.executable, "-I", "-X", "utf8", "-m", "tree_sitter_analyzer.source_lines"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="utf-8",
+    )
+    try:
+        stdout, stderr = process.communicate(
+            json.dumps({"symbol": symbol, "roots": roots, **options}), timeout=timeout
+        )
+    except subprocess.TimeoutExpired as exc:
+        process.kill()
+        try:
+            process.communicate(timeout=1)
+        except subprocess.TimeoutExpired:
+            raise OSError("SOURCE_WORKER_CLEANUP_FAILED") from exc
+        raise TimeoutError("SOURCE_SCAN_BUDGET_EXCEEDED") from exc
+    if process.returncode:
+        raise OSError("SOURCE_WORKER_FAILED")
+    result = json.loads(stdout)
+    if "error" in result:
+        error_type = TimeoutError if result.get("timeout") else OSError
+        raise error_type(result["error"])
+    matches = result["matches"]
+    if not isinstance(matches, list):
+        raise OSError("SOURCE_WORKER_INVALID_RESPONSE")
+    return matches
+
+
+def _main() -> None:
+    """内部工作进程协议：输入与输出均为 JSON，不输出诊断到标准输出。"""
+    result: dict[str, Any]
+    try:
+        request = json.loads(sys.stdin.read(1024 * 1024))
+        result = {"matches": scan_symbol_lines(**request)}
+    except (OSError, ValueError, TypeError) as exc:
+        result = {"error": str(exc), "timeout": isinstance(exc, TimeoutError)}
+    encoded = json.dumps(result, ensure_ascii=False)
+    if len(encoded.encode("utf-8")) > _MAX_RESPONSE_BYTES:
+        encoded = json.dumps(
+            {"error": "SOURCE_RESPONSE_BUDGET_EXCEEDED", "timeout": True}
+        )
+    print(encoded)
+
+
+if __name__ == "__main__":
+    _main()

--- a/tree_sitter_analyzer/source_lines.py
+++ b/tree_sitter_analyzer/source_lines.py
@@ -214,7 +214,10 @@ def scan_symbol_lines_bounded(
         error_type = TimeoutError if result.get("timeout") else OSError
         raise error_type(result["error"])
     matches = result["matches"]
-    if not isinstance(matches, list):
+    if not isinstance(matches, list) or (
+        options.get("classify_source")
+        and any(not isinstance(match.get("_source_match"), bool) for match in matches)
+    ):
         raise OSError("SOURCE_WORKER_INVALID_RESPONSE")
     return matches
 
@@ -224,7 +227,22 @@ def _main() -> None:
     result: dict[str, Any]
     try:
         request = json.loads(sys.stdin.read(1024 * 1024))
-        result = {"matches": scan_symbol_lines(**request)}
+        classify_source = request.pop("classify_source", False)
+        matches = scan_symbol_lines(**request)
+        if classify_source:
+            from .mcp.tools.trace_impact_tool import (
+                _filter_comment_docstring_matches,
+                _filter_source_matches,
+            )
+
+            # 注释分类的文件重读也必须留在可终止的工作进程内。
+            kept = _filter_comment_docstring_matches(
+                _filter_source_matches(matches), symbol=request["symbol"]
+            )
+            kept_ids = {id(match) for match in kept}
+            for match in matches:
+                match["_source_match"] = id(match) in kept_ids
+        result = {"matches": matches}
     except (OSError, ValueError, TypeError) as exc:
         result = {"error": str(exc), "timeout": isinstance(exc, TimeoutError)}
     encoded = json.dumps(result, ensure_ascii=False)

--- a/tree_sitter_analyzer/source_lines.py
+++ b/tree_sitter_analyzer/source_lines.py
@@ -1,0 +1,175 @@
+"""在项目内发现文件并核验符号文本，不启动外部搜索进程。"""
+
+from __future__ import annotations
+
+import fnmatch
+import os
+import re
+import stat
+import time
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pathspec
+
+_MAX_ENTRIES = 200000
+_MAX_FILE_BYTES = 10 * 1024 * 1024
+_MAX_TOTAL_BYTES = 512 * 1024 * 1024
+_MAX_MATCHES = 100000
+
+_EXCLUDED = frozenset(
+    {".git", ".venv", "venv", "node_modules", "__pycache__", "build", "dist", "target"}
+)
+
+
+def workspace_files(
+    roots: list[str], *, deadline: float | None = None
+) -> Iterator[Path]:
+    """遵守嵌套忽略规则、隐藏目录和符号链接边界，按路径顺序返回普通文件。"""
+    seen: set[str] = set()
+    entries = 0
+    for value in roots:
+        root = Path(value).absolute()
+        if root.is_symlink():
+            raise OSError("SOURCE_ROOT_SYMLINK")
+        if not root.is_dir():
+            raise OSError("SOURCE_ROOT_UNAVAILABLE")
+        rules: dict[Path, list[tuple[Path, pathspec.GitIgnoreSpec]]] = {}
+        for current, directories, names in os.walk(
+            root, followlinks=False, onerror=_raise_walk_error
+        ):
+            entries += len(directories) + len(names)
+            if entries > _MAX_ENTRIES or (
+                deadline is not None and time.monotonic() >= deadline
+            ):
+                raise TimeoutError("SOURCE_DISCOVERY_BUDGET_EXCEEDED")
+            parent = Path(current)
+            inherited = list(rules.get(parent.parent, []))
+            for rule_name in (".gitignore", ".ignore", ".rgignore"):
+                rule_path = parent / rule_name
+                if rule_path.is_file() and not rule_path.is_symlink():
+                    inherited.append(
+                        (
+                            parent,
+                            pathspec.GitIgnoreSpec.from_lines(
+                                rule_path.read_text(
+                                    encoding="utf-8", errors="replace"
+                                ).splitlines()
+                            ),
+                        )
+                    )
+            rules[parent] = inherited
+            directories[:] = sorted(
+                d
+                for d in directories
+                if d not in _EXCLUDED
+                and not d.startswith(".")
+                and not (parent / d).is_symlink()
+                and not _ignored(parent / d, inherited, directory=True)
+            )
+            for name in sorted(names):
+                path = parent / name
+                if (
+                    name.startswith(".")
+                    or path.is_symlink()
+                    or _ignored(path, inherited)
+                ):
+                    continue
+                key = str(path)
+                if key in seen:
+                    continue
+                if stat.S_ISREG(path.stat().st_mode):
+                    seen.add(key)
+                    yield path
+
+
+def _raise_walk_error(error: OSError) -> None:
+    raise error
+
+
+def _ignored(
+    path: Path,
+    rules: list[tuple[Path, pathspec.GitIgnoreSpec]],
+    *,
+    directory: bool = False,
+) -> bool:
+    ignored = False
+    for base, spec in rules:
+        result = spec.check_file(
+            path.relative_to(base).as_posix() + ("/" if directory else "")
+        )
+        if result.include is not None:
+            ignored = bool(result.include)
+    return ignored
+
+
+def _matches_glob(path: str, patterns: list[str]) -> bool:
+    return any(
+        fnmatch.fnmatchcase(path, pattern)
+        or (pattern.startswith("**/") and fnmatch.fnmatchcase(path, pattern[3:]))
+        for pattern in patterns
+    )
+
+
+def scan_symbol_lines(
+    symbol: str,
+    roots: list[str],
+    *,
+    case_sensitive: bool,
+    word_match: bool,
+    include_globs: list[str],
+    exclude_globs: list[str],
+    timeout: float = 5,
+) -> list[dict[str, Any]]:
+    """保留全部命中行供计数；预算或读取失败时拒绝返回不完整的成功结果。"""
+    deadline = time.monotonic() + timeout
+    sensitive = case_sensitive or any(c.isupper() for c in symbol)
+    expression = re.escape(symbol)
+    if word_match:
+        expression = r"(?<!\w)" + expression + r"(?!\w)"
+    matcher = re.compile(expression, 0 if sensitive else re.IGNORECASE)
+    matches = []
+    total_bytes = 0
+    bases = [Path(root).absolute() for root in roots]
+    for path in workspace_files(roots, deadline=deadline):
+        relative = next(
+            path.relative_to(base).as_posix()
+            for base in bases
+            if path.is_relative_to(base)
+        )
+        if (
+            include_globs and not _matches_glob(relative, include_globs)
+        ) or _matches_glob(relative, exclude_globs):
+            continue
+        flags = (
+            os.O_RDONLY
+            | getattr(os, "O_NOFOLLOW", 0)
+            | getattr(os, "O_NONBLOCK", 0)
+            | getattr(os, "O_BINARY", 0)
+        )
+        descriptor = os.open(path, flags)
+        with os.fdopen(descriptor, "rb") as stream:
+            info = os.fstat(stream.fileno())
+            if not stat.S_ISREG(info.st_mode):
+                raise OSError("SOURCE_FILE_CHANGED")
+            if info.st_size > _MAX_FILE_BYTES:
+                raise TimeoutError("SOURCE_FILE_BUDGET_EXCEEDED")
+            raw = stream.read(_MAX_FILE_BYTES + 1)
+        total_bytes += len(raw)
+        if (
+            len(raw) > _MAX_FILE_BYTES
+            or total_bytes > _MAX_TOTAL_BYTES
+            or time.monotonic() >= deadline
+        ):
+            raise TimeoutError("SOURCE_SCAN_BUDGET_EXCEEDED")
+        if b"\x00" in raw:
+            continue
+        for number, line in enumerate(
+            raw.decode("utf-8", errors="replace").splitlines(), 1
+        ):
+            if matcher.search(line):
+                matches.append({"file": str(path), "line": number, "text": line})
+                if len(matches) > _MAX_MATCHES:
+                    raise TimeoutError("SOURCE_MATCH_BUDGET_EXCEEDED")
+    return matches


### PR DESCRIPTION
Project indexing and live symbol tracing no longer invoke fd or ripgrep. File discovery uses the standard library and pathspec; live tracing runs that scanner in an isolated instance of the installed Python interpreter so blocked reads can be terminated at the request deadline. Public wrapper removal is tracked separately for the major-version migration.

The scanner preserves nested ignore rules and original source locations, validates every MCP root against the project boundary, canonicalizes ancestor aliases, rejects empty roots, and accepts existing negated exclusion globs. Complete occurrence counts remain separate from the 10,000-row display cap. Scan and response budgets fail explicitly rather than presenting partial success.

All eight Codex findings were accepted and fixed: canonical paths, blocking I/O deadline, negated globs, Chinese docstring, actionable truncation guidance, independent behavior tests, empty-root rejection, and the display cap. Regression tests include a real blocked worker and Unicode paths through the isolated worker protocol.

Validation: the comprehensive suite before the final filtering isolation change reports 24,788 comprehensive tests passed (125 existing skips) in 208.58 seconds; 128 focused tests passed (4 existing skips) after the final filtering isolation change. TSA change-impact verification, patch coverage (zero added executable/partial-branch misses), Ruff and pre-commit checks pass. The previous complete OS/Python matrix passed; a fresh full matrix is running for these review fixes. This change makes no throughput-equivalence claim against ripgrep.

Additional hardening: comment/docstring classification now runs in the same bounded worker, and the main process consumes its classification without rereading hit files. A real trace regression forbids parent-side reads. MyPy passes all 901 modules on Python 3.10. Latest full CI supersedes the previous run.
