### PR TITLE
fix: execute mapped shell verification with Bash

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -99,6 +99,12 @@ jobs:
       run: uv run pytest -q
       shell: bash
 
+    - name: Check Windows verification command execution
+      if: runner.os == 'Windows'
+      timeout-minutes: 3
+      run: uv run pytest tests/unit/mcp/test_verification_command.py -q --reruns 0 --tb=long
+      shell: bash
+
     - name: Run Tests with Coverage
       if: matrix.coverage
       id: test-coverage
@@ -227,6 +233,12 @@ jobs:
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == inputs.python-version
       timeout-minutes: 5
       run: uv run pytest -q
+      shell: bash
+
+    - name: Check Windows verification command execution
+      if: runner.os == 'Windows'
+      timeout-minutes: 3
+      run: uv run pytest tests/unit/mcp/test_verification_command.py -q --reruns 0 --tb=long
       shell: bash
 
     - name: Run Tests with Coverage

--- a/tests/unit/mcp/test_verification_command.py
+++ b/tests/unit/mcp/test_verification_command.py
@@ -265,3 +265,112 @@ def test_argv_batches_preserve_default_runner_semantics():
     assert build_test_argv_batches(
         DefaultTestCommand("pytest", "uv run pytest -q"), []
     ) == [["uv", "run", "pytest", "-q"]]
+
+
+def test_shell_targets_use_independent_bash_processes_in_order():
+    # 2026-09-09：TSA 把 .sh 交给 pytest，导致 shell 检查完全未执行。
+    from tree_sitter_analyzer.mcp.tools.utils.verification_command import (
+        PYTEST_COMMAND,
+        build_test_argv_batches,
+    )
+
+    assert build_test_argv_batches(
+        PYTEST_COMMAND,
+        [
+            "tests/test_a.py",
+            "tests/test one.sh",
+            "tests/test_two.sh",
+            "tests/test_b.py",
+        ],
+    ) == [
+        ["uv", "run", "pytest", "tests/test_a.py", "-q"],
+        ["bash", "--", "tests/test one.sh"],
+        ["bash", "--", "tests/test_two.sh"],
+        ["uv", "run", "pytest", "tests/test_b.py", "-q"],
+    ]
+
+
+def test_shell_command_uses_quoted_literal_path():
+    from tree_sitter_analyzer.mcp.tools.utils.verification_command import PYTEST_COMMAND
+
+    assert build_test_command(PYTEST_COMMAND, ["tests/test $HOME.sh"]) == (
+        "bash -- 'tests/test $HOME.sh'"
+    )
+
+
+def test_pytest_node_id_ending_in_sh_stays_with_pytest():
+    from tree_sitter_analyzer.mcp.tools.utils.verification_command import (
+        PYTEST_COMMAND,
+        build_test_argv_batches,
+    )
+
+    target = "tests/test_files.py::test_script.sh"
+    assert build_test_argv_batches(PYTEST_COMMAND, [target]) == [
+        ["uv", "run", "pytest", target, "-q"]
+    ]
+
+
+def test_shell_only_plan_does_not_claim_pytest_is_required():
+    from tree_sitter_analyzer.mcp.tools.utils.change_impact_verification import (
+        _build_verification_plan,
+    )
+
+    path = "tests/test_check.sh"
+    plan = _build_verification_plan([path], [path])
+    assert plan["verification_command"] == "bash -- tests/test_check.sh"
+    assert plan["test_required"] is True
+    assert plan["pytest_required"] is False
+    assert plan["pytest_command"] == ""
+
+
+def test_shell_target_still_has_a_command_length_budget():
+    import pytest
+
+    from tree_sitter_analyzer.mcp.tools.utils.verification_command import (
+        PYTEST_COMMAND,
+        build_test_argv_batches,
+    )
+
+    with pytest.raises(ValueError, match="TEST_TARGET_EXCEEDS_COMMAND_BUDGET"):
+        build_test_argv_batches(PYTEST_COMMAND, ["tests/" + "路径" * 4000 + ".sh"])
+
+
+def test_shell_only_cli_plan_executes_the_actual_script(tmp_path):
+    # 2026-09-09：用真实 CLI 和新仓库确认不会再返回 pytest 的空收集命令。
+    import json
+    import shlex
+    import subprocess
+    import sys
+
+    def run(argv):
+        return subprocess.run(
+            argv, cwd=tmp_path, capture_output=True, text=True, check=True
+        )
+
+    run(["git", "init", "-q"])
+    run(["git", "config", "user.email", "test@example.com"])
+    run(["git", "config", "user.name", "test"])
+    path = tmp_path / "tests/test_smoke.sh"
+    path.parent.mkdir()
+    path.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    run(["git", "add", "."])
+    run(["git", "-c", "commit.gpgsign=false", "commit", "-qm", "baseline"])
+    path.write_text(
+        "#!/usr/bin/env bash\nprintf shell-verified > receipt\n", encoding="utf-8"
+    )
+    response = run(
+        [
+            sys.executable,
+            "-m",
+            "tree_sitter_analyzer",
+            "--change-impact",
+            "--change-impact-full",
+            "--format",
+            "json",
+        ]
+    )
+    plan = json.loads(response.stdout)
+    assert plan["pytest_required"] is False
+    assert plan["test_required"] is True
+    run(shlex.split(plan["verification_command"]))
+    assert (tmp_path / "receipt").read_text(encoding="utf-8") == "shell-verified"

--- a/tests/unit/mcp/test_verification_command.py
+++ b/tests/unit/mcp/test_verification_command.py
@@ -354,9 +354,11 @@ def test_shell_only_cli_plan_executes_the_actual_script(tmp_path, project_kind):
     import sys
 
     def run(argv):
-        return subprocess.run(
-            argv, cwd=tmp_path, capture_output=True, text=True, check=True
+        result = subprocess.run(
+            argv, cwd=tmp_path, capture_output=True, text=True, check=False
         )
+        assert result.returncode == 0, (argv, result.stdout, result.stderr)
+        return result
 
     if project_kind == "node":
         (tmp_path / "package.json").write_text(
@@ -365,7 +367,7 @@ def test_shell_only_cli_plan_executes_the_actual_script(tmp_path, project_kind):
     run(["git", "init", "-q"])
     run(["git", "config", "user.email", "test@example.com"])
     run(["git", "config", "user.name", "test"])
-    path = tmp_path / "tests/test_smoke.sh"
+    path = tmp_path / "tests/test_smoke's.sh"
     path.parent.mkdir()
     path.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
     run(["git", "add", "."])
@@ -390,7 +392,11 @@ def test_shell_only_cli_plan_executes_the_actual_script(tmp_path, project_kind):
     plan = json.loads(response.stdout)
     assert plan["pytest_required"] is False
     assert plan["test_required"] is True
-    run(shlex.split(plan["verification_command"]))
+    command = plan["verification_command"]
+    if sys.platform == "win32":
+        run(["powershell", "-NoProfile", "-NonInteractive", "-Command", command])
+    else:
+        run(shlex.split(command))
     assert (tmp_path / "receipt").read_text(encoding="utf-8") == "shell-verified"
 
 
@@ -398,8 +404,12 @@ def test_shell_only_cli_plan_executes_the_actual_script(tmp_path, project_kind):
 def test_node_shell_targets_bypass_the_package_test_runner(runner):
     """Node 的 shell 检查也必须由 Bash 执行，不能传入 Jest/Vitest。"""
     default = DefaultTestCommand(runner, f"{runner} test")
+    import shutil
+    import sys
+
+    executable = shutil.which("bash") if sys.platform == "win32" else "bash"
     assert build_test_argv_batches(default, ["tests/test_smoke.sh"]) == [
-        ["bash", "--", "tests/test_smoke.sh"]
+        [executable, "--", "tests/test_smoke.sh"]
     ]
 
 
@@ -412,3 +422,24 @@ def test_single_shell_target_uses_powershell_literal_quoting(monkeypatch):
         "& { & 'uv' 'run' 'bash' '--' 'tests/a''b$HOME.sh'; "
         "if (-not $?) { throw 'Verification failed' } }"
     )
+
+
+@pytest.mark.parametrize("bash_path", ["C:/Program Files/Git/bin/bash.exe", None])
+def test_windows_node_shell_resolves_the_path_executable(monkeypatch, bash_path):
+    """Windows 原生启动不得绕过 PATH 选择另一个同名 Bash。"""
+    import shutil
+
+    from tree_sitter_analyzer.mcp.tools.utils import verification_command as module
+
+    monkeypatch.setattr(module.sys, "platform", "win32")
+    monkeypatch.setattr(
+        shutil, "which", lambda name: bash_path if name == "bash" else None
+    )
+    default = DefaultTestCommand("npm", "npm test")
+    if bash_path is None:
+        with pytest.raises(ValueError, match="BASH_EXECUTABLE_NOT_FOUND"):
+            build_test_argv_batches(default, ["tests/test_smoke.sh"])
+    else:
+        assert build_test_argv_batches(default, ["tests/test_smoke.sh"]) == [
+            [bash_path, "--", "tests/test_smoke.sh"]
+        ]

--- a/tests/unit/mcp/test_verification_command.py
+++ b/tests/unit/mcp/test_verification_command.py
@@ -357,7 +357,11 @@ def test_shell_only_cli_plan_executes_the_actual_script(tmp_path, project_kind):
         result = subprocess.run(
             argv, cwd=tmp_path, capture_output=True, text=True, check=False
         )
-        assert result.returncode == 0, (argv, result.stdout, result.stderr)
+        if result.returncode:
+            print("command:", argv)
+            print("stdout:", result.stdout)
+            print("stderr:", result.stderr)
+        assert result.returncode == 0
         return result
 
     if project_kind == "node":

--- a/tests/unit/mcp/test_verification_command.py
+++ b/tests/unit/mcp/test_verification_command.py
@@ -1,7 +1,11 @@
 """Unit tests for project-aware verification command selection."""
 
+import pytest
+
 from tree_sitter_analyzer.mcp.tools.utils.verification_command import (
+    PYTEST_COMMAND,
     DefaultTestCommand,
+    build_test_argv_batches,
     build_test_command,
     detect_default_test_command,
 )
@@ -198,7 +202,10 @@ def test_windows_native_verification_chain_stops_after_failure(tmp_path):
     assert (tmp_path / "should_not_exist").exists() is False
 
 
-def test_native_verification_chain_preserves_order_and_literal_arguments(tmp_path):
+@pytest.mark.parametrize("step_count", [1, 2])
+def test_native_verification_chain_preserves_order_and_literal_arguments(
+    tmp_path, step_count
+):
     # #1407：真实 shell 按顺序执行，并保留路径中的引号、空格和美元符号。
     import shlex
     import subprocess
@@ -227,7 +234,7 @@ def test_native_verification_chain_preserves_order_and_literal_arguments(tmp_pat
             ]
         ),
     ]
-    command = join_verification_steps(steps)
+    command = join_verification_steps(steps[:step_count])
     if sys.platform == "win32":
         args = ["powershell", "-NoProfile", "-NonInteractive", "-Command", command]
     else:
@@ -291,11 +298,14 @@ def test_shell_targets_use_independent_bash_processes_in_order():
 
 
 def test_shell_command_uses_quoted_literal_path():
-    from tree_sitter_analyzer.mcp.tools.utils.verification_command import PYTEST_COMMAND
-
-    assert build_test_command(PYTEST_COMMAND, ["tests/test $HOME.sh"]) == (
-        "uv run bash -- 'tests/test $HOME.sh'"
+    from tree_sitter_analyzer.mcp.tools.utils.verification_command import (
+        PYTEST_COMMAND,
+        join_verification_steps,
     )
+
+    assert build_test_command(
+        PYTEST_COMMAND, ["tests/test $HOME.sh"]
+    ) == join_verification_steps(["uv run bash -- 'tests/test $HOME.sh'"])
 
 
 def test_pytest_node_id_ending_in_sh_stays_with_pytest():
@@ -335,7 +345,8 @@ def test_shell_target_still_has_a_command_length_budget():
         build_test_argv_batches(PYTEST_COMMAND, ["tests/" + "路径" * 4000 + ".sh"])
 
 
-def test_shell_only_cli_plan_executes_the_actual_script(tmp_path):
+@pytest.mark.parametrize("project_kind", ["python", "node"])
+def test_shell_only_cli_plan_executes_the_actual_script(tmp_path, project_kind):
     # 2026-09-09：用真实 CLI 和新仓库确认不会再返回 pytest 的空收集命令。
     import json
     import shlex
@@ -347,6 +358,10 @@ def test_shell_only_cli_plan_executes_the_actual_script(tmp_path):
             argv, cwd=tmp_path, capture_output=True, text=True, check=True
         )
 
+    if project_kind == "node":
+        (tmp_path / "package.json").write_text(
+            '{"scripts":{"test":"vitest run"}}', encoding="utf-8"
+        )
     run(["git", "init", "-q"])
     run(["git", "config", "user.email", "test@example.com"])
     run(["git", "config", "user.name", "test"])
@@ -355,10 +370,12 @@ def test_shell_only_cli_plan_executes_the_actual_script(tmp_path):
     path.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
     run(["git", "add", "."])
     run(["git", "-c", "commit.gpgsign=false", "commit", "-qm", "baseline"])
-    path.write_text(
-        '#!/usr/bin/env bash\npython -c \'print("shell-verified", end="")\' > receipt\n',
-        encoding="utf-8",
+    body = (
+        'python -c \'print("shell-verified", end="")\' > receipt'
+        if project_kind == "python"
+        else "printf shell-verified > receipt"
     )
+    path.write_text(f"#!/usr/bin/env bash\n{body}\n", encoding="utf-8")
     response = run(
         [
             sys.executable,
@@ -375,3 +392,23 @@ def test_shell_only_cli_plan_executes_the_actual_script(tmp_path):
     assert plan["test_required"] is True
     run(shlex.split(plan["verification_command"]))
     assert (tmp_path / "receipt").read_text(encoding="utf-8") == "shell-verified"
+
+
+@pytest.mark.parametrize("runner", ["npm", "pnpm", "yarn", "bun"])
+def test_node_shell_targets_bypass_the_package_test_runner(runner):
+    """Node 的 shell 检查也必须由 Bash 执行，不能传入 Jest/Vitest。"""
+    default = DefaultTestCommand(runner, f"{runner} test")
+    assert build_test_argv_batches(default, ["tests/test_smoke.sh"]) == [
+        ["bash", "--", "tests/test_smoke.sh"]
+    ]
+
+
+def test_single_shell_target_uses_powershell_literal_quoting(monkeypatch):
+    """单条 shell 命令中的撇号和美元符号也按 PowerShell 字面量传递。"""
+    from tree_sitter_analyzer.mcp.tools.utils import verification_command as module
+
+    monkeypatch.setattr(module.sys, "platform", "win32")
+    assert module.build_test_command(PYTEST_COMMAND, ["tests/a'b$HOME.sh"]) == (
+        "& { & 'uv' 'run' 'bash' '--' 'tests/a''b$HOME.sh'; "
+        "if (-not $?) { throw 'Verification failed' } }"
+    )

--- a/tests/unit/mcp/test_verification_command.py
+++ b/tests/unit/mcp/test_verification_command.py
@@ -284,8 +284,8 @@ def test_shell_targets_use_independent_bash_processes_in_order():
         ],
     ) == [
         ["uv", "run", "pytest", "tests/test_a.py", "-q"],
-        ["bash", "--", "tests/test one.sh"],
-        ["bash", "--", "tests/test_two.sh"],
+        ["uv", "run", "bash", "--", "tests/test one.sh"],
+        ["uv", "run", "bash", "--", "tests/test_two.sh"],
         ["uv", "run", "pytest", "tests/test_b.py", "-q"],
     ]
 
@@ -294,7 +294,7 @@ def test_shell_command_uses_quoted_literal_path():
     from tree_sitter_analyzer.mcp.tools.utils.verification_command import PYTEST_COMMAND
 
     assert build_test_command(PYTEST_COMMAND, ["tests/test $HOME.sh"]) == (
-        "bash -- 'tests/test $HOME.sh'"
+        "uv run bash -- 'tests/test $HOME.sh'"
     )
 
 
@@ -317,7 +317,7 @@ def test_shell_only_plan_does_not_claim_pytest_is_required():
 
     path = "tests/test_check.sh"
     plan = _build_verification_plan([path], [path])
-    assert plan["verification_command"] == "bash -- tests/test_check.sh"
+    assert plan["verification_command"] == "uv run bash -- tests/test_check.sh"
     assert plan["test_required"] is True
     assert plan["pytest_required"] is False
     assert plan["pytest_command"] == ""
@@ -356,7 +356,8 @@ def test_shell_only_cli_plan_executes_the_actual_script(tmp_path):
     run(["git", "add", "."])
     run(["git", "-c", "commit.gpgsign=false", "commit", "-qm", "baseline"])
     path.write_text(
-        "#!/usr/bin/env bash\nprintf shell-verified > receipt\n", encoding="utf-8"
+        '#!/usr/bin/env bash\npython -c \'print("shell-verified", end="")\' > receipt\n',
+        encoding="utf-8",
     )
     response = run(
         [

--- a/tests/unit/mcp/test_verification_command.py
+++ b/tests/unit/mcp/test_verification_command.py
@@ -274,7 +274,8 @@ def test_argv_batches_preserve_default_runner_semantics():
     ) == [["uv", "run", "pytest", "-q"]]
 
 
-def test_shell_targets_use_independent_bash_processes_in_order():
+def test_posix_shell_targets_use_independent_bash_processes_in_order(monkeypatch):
+    monkeypatch.setattr("sys.platform", "linux")
     # 2026-09-09：TSA 把 .sh 交给 pytest，导致 shell 检查完全未执行。
     from tree_sitter_analyzer.mcp.tools.utils.verification_command import (
         PYTEST_COMMAND,
@@ -297,7 +298,8 @@ def test_shell_targets_use_independent_bash_processes_in_order():
     ]
 
 
-def test_shell_command_uses_quoted_literal_path():
+def test_posix_shell_command_uses_quoted_literal_path(monkeypatch):
+    monkeypatch.setattr("sys.platform", "linux")
     from tree_sitter_analyzer.mcp.tools.utils.verification_command import (
         PYTEST_COMMAND,
         join_verification_steps,
@@ -327,7 +329,7 @@ def test_shell_only_plan_does_not_claim_pytest_is_required():
 
     path = "tests/test_check.sh"
     plan = _build_verification_plan([path], [path])
-    assert plan["verification_command"] == "uv run bash -- tests/test_check.sh"
+    assert plan["verification_command"] == build_test_command(PYTEST_COMMAND, [path])
     assert plan["test_required"] is True
     assert plan["pytest_required"] is False
     assert plan["pytest_command"] == ""
@@ -405,27 +407,23 @@ def test_shell_only_cli_plan_executes_the_actual_script(tmp_path, project_kind):
 
 
 @pytest.mark.parametrize("runner", ["npm", "pnpm", "yarn", "bun"])
-def test_node_shell_targets_bypass_the_package_test_runner(runner):
+def test_node_shell_targets_bypass_the_package_test_runner(runner, monkeypatch):
     """Node 的 shell 检查也必须由 Bash 执行，不能传入 Jest/Vitest。"""
     default = DefaultTestCommand(runner, f"{runner} test")
-    import shutil
-    import sys
-
-    executable = shutil.which("bash") if sys.platform == "win32" else "bash"
+    monkeypatch.setattr("sys.platform", "linux")
     assert build_test_argv_batches(default, ["tests/test_smoke.sh"]) == [
-        [executable, "--", "tests/test_smoke.sh"]
+        ["bash", "--", "tests/test_smoke.sh"]
     ]
 
 
-def test_single_shell_target_uses_powershell_literal_quoting(monkeypatch):
-    """单条 shell 命令中的撇号和美元符号也按 PowerShell 字面量传递。"""
+def test_windows_shell_argument_protects_msys_literal_path(monkeypatch):
+    """完整命令的外层引用与 Bash 内层引用共同保留撇号和美元符号。"""
     from tree_sitter_analyzer.mcp.tools.utils import verification_command as module
 
     monkeypatch.setattr(module.sys, "platform", "win32")
-    assert module.build_test_command(PYTEST_COMMAND, ["tests/a'b$HOME.sh"]) == (
-        "& { & 'uv' 'run' 'bash' '--' 'tests/a''b$HOME.sh'; "
-        "if (-not $?) { throw 'Verification failed' } }"
-    )
+    assert module.build_test_argv_batches(PYTEST_COMMAND, ["tests/a'b$HOME.sh"]) == [
+        ["uv", "run", "bash", "-c", "exec bash -- 'tests/a'\\''b$HOME.sh'"]
+    ]
 
 
 @pytest.mark.parametrize("bash_path", ["C:/Program Files/Git/bin/bash.exe", None])
@@ -445,5 +443,5 @@ def test_windows_node_shell_resolves_the_path_executable(monkeypatch, bash_path)
             build_test_argv_batches(default, ["tests/test_smoke.sh"])
     else:
         assert build_test_argv_batches(default, ["tests/test_smoke.sh"]) == [
-            [bash_path, "--", "tests/test_smoke.sh"]
+            [bash_path, "-c", "exec bash -- 'tests/test_smoke.sh'"]
         ]

--- a/tree_sitter_analyzer/mcp/tools/utils/change_impact_verification.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/change_impact_verification.py
@@ -8,6 +8,7 @@ from typing import Any
 from .verification_command import (
     PYTEST_COMMAND,
     DefaultTestCommand,
+    build_test_argv_batches,
     build_test_command,
     build_test_commands,
     join_verification_steps,
@@ -82,6 +83,14 @@ def _build_verification_plan(
     test_command = join_verification_steps(
         build_test_commands(default_test_command, tests_to_run)
     )
+    # 兼容字段只在计划确实运行 pytest 时置真；shell-only 计划仍要求验证。
+    pytest_required = default_test_command.runner == "pytest" and (
+        not tests_to_run
+        or any(
+            argv[:3] == ["uv", "run", "pytest"]
+            for argv in build_test_argv_batches(default_test_command, tests_to_run)
+        )
+    )
     reason = (
         "targeted tests cover mapped runtime changes"
         if tests_to_run
@@ -91,10 +100,8 @@ def _build_verification_plan(
         "test_required": True,
         "test_runner": default_test_command.runner,
         "default_test_command": default_test_command.command,
-        "pytest_required": default_test_command.runner == "pytest",
-        "pytest_command": test_command
-        if default_test_command.runner == "pytest"
-        else "",
+        "pytest_required": pytest_required,
+        "pytest_command": test_command if pytest_required else "",
         "test_command": test_command,
         "verification_command": test_command,
         "verification_reason": reason,

--- a/tree_sitter_analyzer/mcp/tools/utils/verification_command.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/verification_command.py
@@ -95,12 +95,13 @@ def _test_argv(default_command: DefaultTestCommand, targets: list[str]) -> list[
 def _shell_test_argv(
     default_command: DefaultTestCommand, target: str
 ) -> list[str] | None:
-    """Python 项目的 shell 测试单独交给 Bash；保留 pytest 节点选择器语义。"""
+    """shell 测试交给 Bash，Python 项目保留 uv 环境与 pytest 节点语义。"""
     file_part, separator, _ = target.partition("::")
     if separator and Path(file_part).suffix.lower() == ".py":
         return None
-    if default_command.runner == "pytest" and Path(target).suffix.lower() == ".sh":
-        return ["uv", "run", "bash", "--", target]
+    if Path(target).suffix.lower() == ".sh":
+        prefix = ["uv", "run"] if default_command.runner == "pytest" else []
+        return [*prefix, "bash", "--", target]
     return None
 
 
@@ -191,7 +192,7 @@ def _node_test_command(root: Path) -> DefaultTestCommand:
 
 def join_verification_steps(steps: list[str]) -> str:
     """组合内部 POSIX 引用的命令；Windows 使用 PowerShell 5.1 的失败即停语法。"""
-    if sys.platform == "win32" and len(steps) > 1:
+    if sys.platform == "win32" and (len(steps) > 1 or (steps and "'" in steps[0])):
         return _powershell_verification_steps(steps)
     return " && ".join(steps)
 

--- a/tree_sitter_analyzer/mcp/tools/utils/verification_command.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/verification_command.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import shlex
+import shutil
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -101,7 +102,13 @@ def _shell_test_argv(
         return None
     if Path(target).suffix.lower() == ".sh":
         prefix = ["uv", "run"] if default_command.runner == "pytest" else []
-        return [*prefix, "bash", "--", target]
+        executable = "bash"
+        if not prefix and sys.platform == "win32":
+            # CreateProcess 的搜索顺序不同于 PATH；固定发现的原生执行文件。
+            executable = shutil.which("bash") or ""
+            if not executable:
+                raise ValueError("BASH_EXECUTABLE_NOT_FOUND")
+        return [*prefix, executable, "--", target]
     return None
 
 

--- a/tree_sitter_analyzer/mcp/tools/utils/verification_command.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/verification_command.py
@@ -92,6 +92,18 @@ def _test_argv(default_command: DefaultTestCommand, targets: list[str]) -> list[
     return [runner, "test", *separator, *targets]
 
 
+def _shell_test_argv(
+    default_command: DefaultTestCommand, target: str
+) -> list[str] | None:
+    """Python 项目的 shell 测试单独交给 Bash；保留 pytest 节点选择器语义。"""
+    file_part, separator, _ = target.partition("::")
+    if separator and Path(file_part).suffix.lower() == ".py":
+        return None
+    if default_command.runner == "pytest" and Path(target).suffix.lower() == ".sh":
+        return ["bash", "--", target]
+    return None
+
+
 def build_test_command(
     default_command: DefaultTestCommand,
     tests_to_run: list[str],
@@ -99,6 +111,10 @@ def build_test_command(
     """支持定向执行时渲染精确参数，其余情况保留项目默认命令。"""
     if not tests_to_run or default_command.runner not in _TARGETED_RUNNERS:
         return default_command.command
+    if any(_shell_test_argv(default_command, target) for target in tests_to_run):
+        return join_verification_steps(
+            build_test_commands(default_command, tests_to_run)
+        )
     return shlex.join(_test_argv(default_command, tests_to_run))
 
 
@@ -119,6 +135,15 @@ def build_test_argv_batches(
     batches: list[list[str]] = []
     batch: list[str] = []
     for target in tests_to_run:
+        shell_argv = _shell_test_argv(default_command, target)
+        if shell_argv is not None:
+            if not _argv_within_budget(shell_argv):
+                raise ValueError("TEST_TARGET_EXCEEDS_COMMAND_BUDGET")
+            if batch:
+                batches.append(_test_argv(default_command, batch))
+                batch = []
+            batches.append(shell_argv)
+            continue
         if not _argv_within_budget(_test_argv(default_command, [target])):
             raise ValueError("TEST_TARGET_EXCEEDS_COMMAND_BUDGET")
         candidate = _test_argv(default_command, [*batch, target])
@@ -126,7 +151,8 @@ def build_test_argv_batches(
             batches.append(_test_argv(default_command, batch))
             batch = []
         batch.append(target)
-    batches.append(_test_argv(default_command, batch))
+    if batch:
+        batches.append(_test_argv(default_command, batch))
     return batches
 
 

--- a/tree_sitter_analyzer/mcp/tools/utils/verification_command.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/verification_command.py
@@ -100,7 +100,7 @@ def _shell_test_argv(
     if separator and Path(file_part).suffix.lower() == ".py":
         return None
     if default_command.runner == "pytest" and Path(target).suffix.lower() == ".sh":
-        return ["bash", "--", target]
+        return ["uv", "run", "bash", "--", target]
     return None
 
 

--- a/tree_sitter_analyzer/mcp/tools/utils/verification_command.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/verification_command.py
@@ -108,6 +108,10 @@ def _shell_test_argv(
             executable = shutil.which("bash") or ""
             if not executable:
                 raise ValueError("BASH_EXECUTABLE_NOT_FOUND")
+        if sys.platform == "win32":
+            # MSYS 会剥掉原生未引用参数中的撇号；整条含空格命令获得外层引用。
+            quoted_target = "'" + target.replace("'", "'\\''") + "'"
+            return [*prefix, executable, "-c", f"exec bash -- {quoted_target}"]
         return [*prefix, executable, "--", target]
     return None
 


### PR DESCRIPTION
Mapped `.sh` tests were emitted as pytest targets, which exits without executing the script. Each shell target now runs through Bash, preserving order and command budgets. Python projects retain their uv environment; npm/pnpm/yarn/bun targets bypass the package test runner. Shell-only plans report `test_required=true` and `pytest_required=false`.

Windows commands resolve the native Bash executable from PATH when launching it directly. A quoted Bash command preserves literal script paths across MSYS native argument parsing, which otherwise removed apostrophes. Single quoted verification steps also use PowerShell rendering. Real CLI tests execute both Python and Node projects with a script filename containing an apostrophe.

Both reusable CI profiles run the small Windows verification-command suite before comprehensive tests and retain full subprocess diagnostics. The comprehensive gates remain intact.

### Validation

- 89 focused tests passed, 1 existing platform skip; patch coverage has no added executable misses.
- Latest quick gate: 2,053 passed, 28 existing skips, 27.94 seconds.
- Native Windows: the early suite passes (30 tests, 1 existing skip), followed by 23,650 comprehensive tests passed / 1,213 existing skips.
- All PR checks, Linux coverage, and the routed SQL platform compatibility matrix pass on `6decae6f` ([CI](https://github.com/aimasteracc/tree-sitter-analyzer/actions/runs/34327103275)).
- Mypy, all pre-commit hooks, actionlint and workflow consistency checks pass.

### Codex review triage

| Finding | Decision | Resolution |
| --- | --- | --- |
| Node runners still receive shell targets | Accepted | Route shell files for all supported targeted runners to Bash; real Node-project execution test. |
| A single Windows shell target uses POSIX apostrophe quoting | Accepted | PowerShell rendering covers single quoted steps; native regressions also cover MSYS argument preservation. |
