### PR TITLE
fix: distinguish semantic retrieval failures from no matches

### DIFF
--- a/tests/unit/test_codegraph_query_tool_core.py
+++ b/tests/unit/test_codegraph_query_tool_core.py
@@ -15,6 +15,66 @@ from tree_sitter_analyzer.mcp.tools.codegraph_query_tool import (
 
 
 class TestCodeGraphQueryTool:
+    @pytest.mark.asyncio
+    async def test_semantic_denied_index_read_is_an_error(self, tmp_path):
+        # 2026-09-09：真实 SQLite 拒读不能被旧表回退掩盖。
+        tool = CodeGraphQueryTool(str(tmp_path))
+        cache = tool.get_cache()
+        cache._fts5_available = False
+        conn = cache.get_conn()
+        conn.set_authorizer(lambda *_: sqlite3.SQLITE_DENY)
+        try:
+            result = await tool.execute({"query": "semantic('authentication')"})
+        finally:
+            conn.set_authorizer(None)
+            cache.close()
+        assert result["success"] is False
+        assert result["verdict"] == "ERROR"
+        assert "SEMANTIC_SEARCH_FAILED" in result["error"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("partial", [False, True])
+    async def test_semantic_backend_failure_is_not_a_negative_result(
+        self, tmp_path, partial
+    ):
+        # 2026-09-09：后端异常被吞掉后曾返回 NOT_FOUND。
+        failure = sqlite3.OperationalError("database is locked")
+        outcomes = (
+            [[{"name": "authenticate", "file": "auth.py", "line": 1}], failure]
+            if partial
+            else [failure]
+        )
+        with patch(
+            "tree_sitter_analyzer.codegraph_query_backend.CodeGraphQueryBackend.semantic_symbols",
+            side_effect=outcomes,
+        ):
+            result = await CodeGraphQueryTool(str(tmp_path)).execute(
+                {"query": "semantic(['authentication', 'credentials']).callers()"}
+            )
+        assert result["success"] is False
+        assert result["verdict"] == "ERROR"
+        assert "SEMANTIC_SEARCH_FAILED" in result["error"]
+        assert result["symbols"] == []
+
+    @pytest.mark.asyncio
+    async def test_semantic_chinese_query_explains_tokenizer_limit(self, tmp_path):
+        result = await CodeGraphQueryTool(str(tmp_path)).execute(
+            {"query": "semantic('身份验证失败后重试')"}
+        )
+        assert result["success"] is False
+        assert result["verdict"] == "ERROR"
+        assert "SEMANTIC_QUERY_NO_TERMS" in result["error"]
+        assert "ASCII" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_semantic_valid_zero_matches_remains_not_found(self, tmp_path):
+        result = await CodeGraphQueryTool(str(tmp_path)).execute(
+            {"query": "semantic('authentication')"}
+        )
+        assert result["success"] is True
+        assert result["verdict"] == "NOT_FOUND"
+        assert result["symbols"] == []
+
     def test_definition(self):
         definition = CodeGraphQueryTool().get_tool_definition()
 

--- a/tests/unit/test_semantic_symbol_search.py
+++ b/tests/unit/test_semantic_symbol_search.py
@@ -6,6 +6,8 @@ import sqlite3
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from tree_sitter_analyzer.semantic_search import SemanticSymbolSearch
 
 # ---------------------------------------------------------------------------
@@ -79,19 +81,23 @@ class TestSemanticSymbolSearchFallback:
         assert results[0]["name"] == "format_user"
         assert results[0]["semantic_score"]
 
-    def test_short_query_uses_full_scan(self):
-        """Queries shorter than 2 chars bypass BM25 pre-filter."""
+    def test_short_query_reports_unusable_terms(self):
+        """无可用词项时不能宣称检索完成且没有匹配。"""
         cache = _make_cache([("a", "function", "a.py", "python")])
 
         with patch.object(cache, "fts_search_ranked") as mock_fts:
-            SemanticSymbolSearch(cache).search("a", limit=5)
+            with pytest.raises(ValueError, match="SEMANTIC_QUERY_NO_TERMS"):
+                SemanticSymbolSearch(cache).search("a", limit=5)
 
         mock_fts.assert_not_called()
 
-    def test_empty_query_returns_empty(self):
+    @pytest.mark.parametrize("query", ["", "身份验证失败后重试", "!!!"])
+    def test_unusable_query_reports_error(self, query):
+        # 2026-09-09：词项为空曾被当成有效零匹配。
         cache = _make_cache([("foo", "function", "foo.py", "python")])
-        results = SemanticSymbolSearch(cache).search("", limit=5)
-        assert results == []
+        with pytest.raises(ValueError, match="SEMANTIC_QUERY_NO_TERMS"):
+            SemanticSymbolSearch(cache).search(query, limit=5)
+        cache.fts_search_ranked.assert_not_called()
 
     def test_no_fts5_uses_full_scan(self):
         cache = _make_cache([("find_user", "function", "users.py", "python")])
@@ -158,7 +164,21 @@ class TestSemanticSymbolSearchBm25Path:
 
 
 class TestSemanticSymbolSearchFallbackSchema:
-    """Tests for the _symbols_from_json path used on older DB schemas."""
+    """验证旧索引回退及损坏索引的失败行为。"""
+
+    def test_locked_symbol_table_does_not_fall_back_to_legacy_rows(self):
+        # 2026-09-09：只有缺失规范表才允许旧版回退。
+        cache = _make_cache([])
+        cache._fts5_available = False
+        cache.get_conn.return_value = MagicMock()
+        cache.get_conn.return_value.execute.side_effect = sqlite3.OperationalError(
+            "database is locked"
+        )
+        searcher = SemanticSymbolSearch(cache)
+        with patch.object(searcher, "_symbols_from_json") as fallback:
+            with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+                searcher.search("authentication")
+        fallback.assert_not_called()
 
     def _make_legacy_cache(self, rows: list[tuple[str, str, str, str]]) -> Any:
         """Cache backed by ast_index (no ast_symbol_rows table)."""
@@ -191,7 +211,7 @@ class TestSemanticSymbolSearchFallbackSchema:
 
         assert any(r["name"] == "parse_token" for r in results)
 
-    def test_symbols_from_json_empty_on_corrupt_row(self):
+    def test_symbols_from_json_reports_corrupt_row(self):
         conn = sqlite3.connect(":memory:")
         conn.row_factory = sqlite3.Row
         conn.execute(
@@ -204,9 +224,8 @@ class TestSemanticSymbolSearchFallbackSchema:
         cache.get_conn.return_value = conn
         cache._fts5_available = False
 
-        results = SemanticSymbolSearch(cache).search("find token", limit=5)
-
-        assert results == []
+        with pytest.raises(ValueError, match="Expecting value"):
+            SemanticSymbolSearch(cache).search("find token", limit=5)
 
     def test_symbols_from_json_fallback_on_symbol_rows_error(self):
         """ast_symbol_rows raises sqlite3.Error → falls back to _symbols_from_json."""

--- a/tree_sitter_analyzer/mcp/tools/codegraph_query_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_query_tool.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from typing import Any
 
 from ...codegraph_query_backend import CodeGraphQueryBackend
+from ...semantic_search import SemanticSearchError
 from ...utils import setup_logger
 from ..utils.format_helper import apply_output_format_to_response
 from . import _codegraph_explore_helpers as _h
@@ -265,6 +266,24 @@ class CodeGraphQueryTool(BaseMCPTool):
                     default_max_files=max_files,
                     default_include_code=include_code,
                 )
+            except SemanticSearchError as exc:
+                # 检索失败立即停止，不能把前序结果或后续步骤包装成成功证据。
+                result = build_response(
+                    verdict="ERROR",
+                    success=False,
+                    query=query,
+                    error=str(exc),
+                    normalized_chain=[step_to_dict(item) for item in steps],
+                    symbols=[],
+                    files=[],
+                    relationships={"callers": {}, "callees": {}},
+                    agent_summary={
+                        "summary_line": "chain: semantic retrieval failed",
+                        "verdict": "ERROR",
+                        "next_step": str(exc),
+                    },
+                )
+                return apply_output_format_to_response(result, output_format)
             except ValueError as exc:
                 warnings.append(str(exc))
 
@@ -593,8 +612,13 @@ def _semantic_queries_with_backend(
             break
         try:
             resolved.extend(backend.semantic_symbols(query, limit=remaining))
+        except SemanticSearchError:
+            raise
         except Exception as exc:
-            logger.debug("codegraph_query semantic(%r) failed: %s", query, exc)
+            raise SemanticSearchError(
+                f"SEMANTIC_SEARCH_FAILED: {exc}. Check index status and retry; "
+                "this failure does not establish that matching code is absent."
+            ) from exc
         resolved = _dedupe_symbols(resolved)
     return resolved[:limit]
 

--- a/tree_sitter_analyzer/semantic_search.py
+++ b/tree_sitter_analyzer/semantic_search.py
@@ -14,6 +14,10 @@ from .utils.test_detection import query_wants_tests, rank_tier
 _TOKEN_RE = re.compile(r"[A-Za-z][A-Za-z0-9]*")
 
 
+class SemanticSearchError(ValueError):
+    """检索未完成，调用方不得把异常转换为有效零匹配。"""
+
+
 class SemanticSymbolSearch:
     """Deterministic token-vector search for offline symbol discovery."""
 
@@ -26,7 +30,12 @@ class SemanticSymbolSearch:
     def search(self, query: str, *, limit: int = 20) -> list[dict[str, Any]]:
         query_vector = _vectorize(query)
         if not query_vector:
-            return []
+            raise SemanticSearchError(
+                "SEMANTIC_QUERY_NO_TERMS: this lexical semantic() route requires "
+                "ASCII identifier terms of at least two characters. "
+                "Use an identifier/English keyword, or the separately configured "
+                "search action=semantic embedding route for natural-language queries."
+            )
 
         # BM25 pre-filter: narrow the candidate pool before cosine reranking.
         # Avoids scanning all 40k+ symbols on every call.  Falls back to the
@@ -81,7 +90,10 @@ class SemanticSymbolSearch:
                    FROM ast_symbol_rows
                    ORDER BY file_path, line, name"""
             ).fetchall()
-        except sqlite3.Error:
+        except sqlite3.OperationalError as exc:
+            # 仅旧版缺表允许读取 JSON；锁定、权限或损坏必须向上报告。
+            if str(exc) != "no such table: ast_symbol_rows":
+                raise
             return self._symbols_from_json(conn)
         return [
             {
@@ -96,18 +108,12 @@ class SemanticSymbolSearch:
         ]
 
     def _symbols_from_json(self, conn: sqlite3.Connection) -> list[dict[str, Any]]:
-        try:
-            rows = conn.execute(
-                "SELECT file_path, symbols_json, language FROM ast_index"
-            ).fetchall()
-        except sqlite3.Error:
-            return []
+        rows = conn.execute(
+            "SELECT file_path, symbols_json, language FROM ast_index"
+        ).fetchall()
         symbols: list[dict[str, Any]] = []
         for row in rows:
-            try:
-                payload = json.loads(row["symbols_json"])
-            except (TypeError, json.JSONDecodeError):
-                continue
+            payload = json.loads(row["symbols_json"])
             for sym in payload.get("symbols", []):
                 line = int(sym.get("line", 0) or 0)
                 symbols.append(


### PR DESCRIPTION
The chain DSL's lexical `semantic()` route could return successful `NOT_FOUND` after discarding an unrepresentable query or swallowing a backend failure. A Chinese-only query, for example, produced no tokens and looked like a completed search with no matches.

Return an explicit error for queries without usable lexical terms, and stop the chain on semantic retrieval failures without exposing earlier partial results as completed evidence. SQLite fallback now applies only when the normalized symbol table is absent; database errors and malformed legacy JSON propagate. Existing embedding search remains separate and is named in the query guidance. This does not add multilingual retrieval or certify index freshness.

Validation: RED-first reproduction; 64 focused tests passed; quick gate 2,053 passed / 28 skipped in 28.63s; local patch coverage has no added executable misses; Ruff, mypy and all commit hooks passed. Real CLI Chinese-query smoke returns JSON `ERROR` and exit 1. Tests also cover a real SQLite denied read, partial multi-query failure, valid zero matches, and legacy-schema fallback.
