### PR TITLE
docs: correct current release migration and public surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,34 @@
 # Changelog
 
-## [1.29.5] - 2026-09-08
+## [Unreleased]
 
-**Develop merge-back:** retains all three published routes alongside existing preview-only planning and snapshot controls. Develop uses JSON-only output, exposes 355 CLI flags / 86 facade actions, and keeps its newer extractor version 39; the main-release details below describe the v1.29.5 release baseline.
+These changes describe develop relative to published v1.29.5. A release version
+has not been assigned here; older sections retain their published behavior.
+
+### Changed
+
+- MCP and CLI machine-readable output is JSON-only. Remove TOON decoders from clients; retain the structured response envelope. Table rendering supports `full` and `signatures`; legacy `compact` and `csv` table modes are removed.
+- Internal project file discovery and live symbol tracing use native discovery and a bounded Python source-scanning worker. This does not remove the remaining public fd/ripgrep wrappers or establish throughput parity.
+- Develop retains the published `edit.rename`, `health.unreachable`, and `health.middleware` routes alongside preview-only planning and process-local snapshot controls. Its current surface is 356 unique long CLI flags, 87 facade actions, and seven console scripts; extractor version 39 is retained.
+- Intent aliases `locate_usage` / `find_usage` now route to symbol search, and `find_impacted_code` routes to AST queries. These are code-intelligence routes, not arbitrary text-search equivalents.
+
+### Removed
+
+- `search.content` / legacy `search_content` / `search-content`, and `search.grep` / legacy `find_and_grep` / `find-and-grep`. For arbitrary text and file search, use the host's search tools or a suitable search program directly.
+
+### Fixed
+
+- Semantic chain queries distinguish unprocessable input, unavailable indexes and backend failures from a successful search with no matches.
+- Generated verification plans execute mapped shell tests with Bash, preserve project environments, and quote Windows shell arguments safely.
+
+### Migration
+
+See [the migration guide](docs/MIGRATION.md) for JSON, removed wrappers and current
+legacy-name mappings. `search.batch`, `project.files`, `project.tools`, `list-files`
+and `--check-tools` remain available. Further retirement and optional rg/fd
+integration remain separate proposals; neither is enabled by these notes.
+
+## [1.29.5] - 2026-09-08
 
 Hotfix for symbol extraction, safe Python renaming, and missing MCP/CLI routes.
 
@@ -90,28 +116,6 @@ Hotfix: index robustness and storage hygiene, from the 2026-09-05 agent dogfood 
 
 - AGENTS.md: new 注释语言规范 section — all new/modified code comments and docstrings in Chinese (leader ruling 2026-09-05).
 
-
-## [Unreleased] - search_content / find_and_grep 廃止
-
-### Removed
-
-- **`search_content` (SearchContentTool)**: 廃止・削除。テキストグレップには CC 組み込みの Grep tool を使用すること。
-- **`find_and_grep` (FindAndGrepTool)**: 廃止・削除。ファイル絞り込み + テキスト検索には CC 組み込みの Glob tool + Grep tool (2ステップ) を使用すること。
-- **Intent aliases の更新**:
-  - `locate_usage` / `find_usage` → `"search"` (search action=symbol) にルーティング変更
-  - `find_impacted_code` → `"query"` (query_code) にルーティング変更
-
-### Migration
-
-```
-旧: search_content(query="class Foo")
-新: CC 組み込み Grep tool で "class Foo" を検索
-
-旧: find_and_grep(pattern="*.py", query="class Foo")
-新: CC 組み込み Glob tool で *.py を取得 → Grep tool で "class Foo" を検索
-```
-
----
 
 ## [1.29.0] - 2026-07-04
 
@@ -1318,7 +1322,10 @@ in `docs/internal/CODEGRAPH_BENCHMARK_FINAL_2026-05-24.md`.
 - **ruff clean** across the whole repo.
 - **100 % coverage on the 5-language unblock regression suite**.
 
-## [Unreleased]
+## Historical development notes (release attribution unrecorded)
+
+These pre-existing notes are retained as historical context, not as changes awaiting
+the current release. Their original release attribution was not recorded here.
 
 ### Fixed
 
@@ -2545,9 +2552,6 @@ These languages are fully integrated into CLI, API, and MCP interfaces with prop
 ### 📚 Documentation
 - **Test Guide Added**: Documented golden master testing best practices
 - **Multi-language README Updates**: Synchronized version info and test counts
-
-## [Unreleased]
-
 
 ## [1.9.5] - 2025-11-06
 

--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -183,15 +183,14 @@ tree-sitter-analyzer --safe-to-edit <file>        # refuse if risky
 tree-sitter-analyzer --uml class                  # Mermaid UML class diagram
 ```
 
-Instalar el paquete también registra tres utilidades de búsqueda independientes (puntos de entrada delgados sobre el mismo motor, útiles en pipelines de shell):
+El paquete conserva la utilidad independiente para listar archivos:
 
 ```bash
 list-files <dir>          # fd-style file discovery
-search-content <pattern>  # ripgrep-style content search
-find-and-grep <pattern>   # two-stage fd + ripgrep
 ```
 
-Consulta [`docs/CODEMAPS/cli.md`](docs/CODEMAPS/cli.md) para la superficie completa.
+`search-content` y `find-and-grep` se han eliminado en develop. Consulta la
+[guía de migración](docs/MIGRATION.md) y el [mapa CLI](docs/CODEMAPS/cli.md).
 
 ---
 
@@ -304,13 +303,15 @@ Source code → tree-sitter parse → SQLite + FTS5 index (.ast-cache/index.db)
         nav (navigate) / structure (explore) / nav (callers) / ...
                                          ↓
                             JSON response envelope
-                            (compact for tabular output;
-                             verdict + agent_summary + data)
+                            (verdict + agent_summary + data)
                                          ↓
                               MCP client / CLI consumer
 ```
 
-El índice se construye perezosamente en la primera consulta, se actualiza ante cambios de archivo mediante una diferencia de hash de contenido (`index` action=sync). Las 8 herramientas leen del mismo `.ast-cache/`, por lo que una consulta y su seguimiento comparten trabajo.
+Antes de consultar símbolos o contexto indexados, construye el índice AST con
+`tree-sitter-analyzer --ast-cache --ast-cache-mode index --format json`. Tras
+cambiar el código, actualízalo con `index` action=sync. Las consultas indexadas
+reutilizan los datos AST; la construcción automática depende de cada herramienta.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Source code → tree-sitter parse → SQLite + FTS5 index (.ast-cache/index.db)
                               MCP client / CLI consumer
 ```
 
-The 8 facades expose indexed queries and direct source analysis.
+The 8 MCP tools expose indexed queries and direct source analysis.
 Build the AST index explicitly before indexed symbol/context queries with
 `tree-sitter-analyzer --ast-cache --ast-cache-mode index --format json`. Refresh
 it after source changes with `index` action=sync. Indexed queries reuse cached

--- a/README.md
+++ b/README.md
@@ -222,16 +222,14 @@ tree-sitter-analyzer --safe-to-edit <file>        # refuse if risky
 tree-sitter-analyzer --uml class                  # Mermaid UML class diagram
 ```
 
-Installing the package also registers standalone search helpers (thin
-entry points over the same engine, handy in shell pipelines):
+The package retains the standalone file-listing helper:
 
 ```bash
 list-files <dir>          # fd-style file discovery
-search-content <pattern>  # ripgrep-style content search
-find-and-grep <pattern>   # two-stage fd + ripgrep
 ```
 
-See [`docs/CODEMAPS/cli.md`](docs/CODEMAPS/cli.md) for the full surface.
+`search-content` and `find-and-grep` have been removed on develop. See the
+[migration guide](docs/MIGRATION.md) and [`CLI codemap`](docs/CODEMAPS/cli.md).
 
 ---
 
@@ -266,7 +264,10 @@ Source code → tree-sitter parse → SQLite + FTS5 index (.ast-cache/index.db)
                               MCP client / CLI consumer
 ```
 
-The index is built lazily on first query, refreshed on file change via a content-hash diff (`index` action=sync). All 8 tools read from the same `.ast-cache/`, so a query and its follow-up share work.
+Build the AST index explicitly before indexed symbol/context queries with
+`tree-sitter-analyzer --ast-cache --ast-cache-mode index --format json`. Refresh
+it after source changes with `index` action=sync. Indexed queries reuse cached
+AST data; automatic warming is specific to individual tools.
 
 ---
 
@@ -445,7 +446,7 @@ uv run python check_quality.py --new-code-only  # quality gate
 | `unsupported language` on `.swift / .kt / .rb / .php / .cs` | Update to a current supported release — the missing-language gap was patched in commit `50e99a8f`. Grammar modules for extras-gated languages are not bundled in the base install; run `pip install "tree-sitter-analyzer[swift]"` (or `kotlin`, `ruby`, `php`, `csharp`) to add them. |
 | MCP server doesn't appear in client | `TREE_SITTER_PROJECT_ROOT` must be an **absolute path** (e.g. `$(pwd)` or `/home/user/project`); a relative path causes the server to resolve against the wrong directory. Restart the client after editing. Run `tree-sitter-analyzer --doctor` to verify. |
 | `database is locked` | Stop any other process holding `.ast-cache/index.db`; if persistent, `rm -rf .ast-cache && tree-sitter-analyzer --full-index`. |
-| Slow first call | First call builds the index. Run `--full-index` upfront to amortise future calls. |
+| Slow first call or missing index | Some tools warm the index automatically. Run `--full-index` upfront before indexed queries. |
 | Agent picks the wrong tool | Use a `tsa-*` skill (`/tsa-graph`, `/tsa-find`, ...) — each skill restricts the visible tool set to its dedicated workflow. |
 
 ---

--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Source code → tree-sitter parse → SQLite + FTS5 index (.ast-cache/index.db)
                               MCP client / CLI consumer
 ```
 
+The 8 facades expose indexed queries and direct source analysis.
 Build the AST index explicitly before indexed symbol/context queries with
 `tree-sitter-analyzer --ast-cache --ast-cache-mode index --format json`. Refresh
 it after source changes with `index` action=sync. Indexed queries reuse cached

--- a/README_ja.md
+++ b/README_ja.md
@@ -331,7 +331,7 @@ uv run python check_quality.py --new-code-only  # 品質ゲート
 | `.swift / .kt / .rb / .php / .cs` で `unsupported language` | ≥ 1.12.x へ更新 — 5 言語 gap は commit `50e99a8f` で修正済み。extras 区分の文法モジュールはベースインストールに同梱されません。`pip install "tree-sitter-analyzer[swift]"`(または `kotlin`、`ruby`、`php`、`csharp`)で追加してください |
 | MCP サーバーがクライアントに表示されない | `TREE_SITTER_PROJECT_ROOT` は**絶対パス**必須; 設定編集後にクライアント再起動。[TREE\_SITTER\_PROJECT\_ROOT に相対パスを指定した場合](#tree_sitter_project_root-に相対パスを指定した場合)も参照 |
 | `database is locked` | `.ast-cache/index.db` を保持する他プロセスを停止; 継続する場合は `rm -rf .ast-cache && tree-sitter-analyzer --autoindex` |
-| 初回呼び出しが遅い | 初回はインデックスを構築。後続はサブ秒。事前に `--full-index` を実行すれば償却可能 |
+| 初回呼び出しが遅い・インデックスがない | 自動構築はツールにより異なります。索引を使う検索の前に `--full-index` を実行してください。 |
 | エージェントが誤ったツールを選ぶ | `tsa-*` skill (`/tsa-graph`、`/tsa-find` 等) を使用 — 各 skill は可視ツールを 1 ワークフローに制限 |
 
 ### TREE\_SITTER\_PROJECT\_ROOT に相対パスを指定した場合

--- a/README_zh.md
+++ b/README_zh.md
@@ -204,7 +204,7 @@ tree-sitter-analyzer --safe-to-edit <file>        # 风险时拒绝
                        MCP 客户端 / CLI 消费者
 ```
 
-这 8 个门面提供索引查询和直接源代码分析。在查询索引中的符号或上下文前，先运行 `tree-sitter-analyzer --ast-cache --ast-cache-mode index --format json` 建立 AST 索引。源文件变更后使用 `index` action=sync 更新。索引查询复用已有 AST 数据；是否自动建索引取决于具体工具。
+这 8 个 MCP 工具提供索引查询和直接源代码分析。在查询索引中的符号或上下文前，先运行 `tree-sitter-analyzer --ast-cache --ast-cache-mode index --format json` 建立 AST 索引。源文件变更后使用 `index` action=sync 更新。索引查询复用已有 AST 数据；是否自动建索引取决于具体工具。
 
 ---
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -204,7 +204,7 @@ tree-sitter-analyzer --safe-to-edit <file>        # 风险时拒绝
                        MCP 客户端 / CLI 消费者
 ```
 
-在查询索引中的符号或上下文前，先运行 `tree-sitter-analyzer --ast-cache --ast-cache-mode index --format json` 建立 AST 索引。源文件变更后使用 `index` action=sync 更新。索引查询复用已有 AST 数据；是否自动建索引取决于具体工具。
+这 8 个门面提供索引查询和直接源代码分析。在查询索引中的符号或上下文前，先运行 `tree-sitter-analyzer --ast-cache --ast-cache-mode index --format json` 建立 AST 索引。源文件变更后使用 `index` action=sync 更新。索引查询复用已有 AST 数据；是否自动建索引取决于具体工具。
 
 ---
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -204,7 +204,7 @@ tree-sitter-analyzer --safe-to-edit <file>        # 风险时拒绝
                        MCP 客户端 / CLI 消费者
 ```
 
-索引首次查询时懒构建，文件变更时通过内容哈希增量刷新（`index` action=sync）。所有 8 个工具共享同一份 `.ast-cache/`，查询与跟进调用共享工作量。
+在查询索引中的符号或上下文前，先运行 `tree-sitter-analyzer --ast-cache --ast-cache-mode index --format json` 建立 AST 索引。源文件变更后使用 `index` action=sync 更新。索引查询复用已有 AST 数据；是否自动建索引取决于具体工具。
 
 ---
 
@@ -352,7 +352,7 @@ uv run python check_quality.py --new-code-only  # 质量闸门
 | `.swift / .kt / .rb / .php / .cs` 显示 `unsupported language` | 升级到 ≥ 1.12.x — 5 语言 gap 已在 commit `50e99a8f` 中修复。extras 门控语言的语法模块不随基础安装捆绑;运行 `pip install "tree-sitter-analyzer[swift]"`(或 `kotlin`、`ruby`、`php`、`csharp`)补装 |
 | MCP 服务在客户端中不出现 | `TREE_SITTER_PROJECT_ROOT` 必须是**绝对路径**；编辑配置后重启客户端。另见 [TREE\_SITTER\_PROJECT\_ROOT 使用了相对路径](#tree_sitter_project_root-使用了相对路径) |
 | `database is locked` | 关闭其他占用 `.ast-cache/index.db` 的进程；持续存在则 `rm -rf .ast-cache && tree-sitter-analyzer --autoindex` |
-| 首次调用慢 | 首次调用会建索引。后续亚秒。预先跑 `--full-index` 即可分摊 |
+| 首次调用慢或提示缺少索引 | 部分工具会自动建索引；可在索引查询前先运行 `--full-index`。 |
 | Agent 选错工具 | 使用 `tsa-*` skill（`/tsa-graph`、`/tsa-find` 等）— 每个 skill 把可见工具限定到一个工作流 |
 
 ### TREE\_SITTER\_PROJECT\_ROOT 使用了相对路径

--- a/docs/CODEMAPS/cli.md
+++ b/docs/CODEMAPS/cli.md
@@ -1,7 +1,7 @@
 <!-- Generated: 2026-05-22; doc-code re-sync: 2026-08-19 -->
 # CLI Codemap
 
-Five console-script entry points + flag-based dispatch through `cli_main.py`.
+Seven console-script entry points + flag-based dispatch through `cli_main.py`.
 
 ## Entry Points
 
@@ -9,11 +9,16 @@ Five console-script entry points + flag-based dispatch through `cli_main.py`.
 |---|---|---|
 | `tree-sitter-analyzer` | `cli_main.py` | `json` |
 | `tree-sitter-analyzer-mcp` | `mcp/server.py` (stdio) | `json` |
-| ~~`find-and-grep`~~ | *(廃止済み)* | — |
+| `tree-sitter-analyzer-doctor` | `cli_main.py:main_doctor` | text; `--doctor-json` for JSON |
+| `miswire-audit` | `miswire_audit.py` | text; `--card` adds Markdown |
+| `code-analyzer` | `cli_main.py` (alias) | `json` |
+| `java-analyzer` | `cli_main.py` (alias) | `json` |
 | `list-files` | `cli/commands/list_files_cli.py` | `json` |
-| ~~`search-content`~~ | *(廃止済み)* | — |
 
-All output formats are JSON. TOON has been removed.
+MCP and CLI machine-readable envelopes use JSON. Human-readable CLI paths remain
+as documented below; TOON has been removed. The `search-content` and
+`find-and-grep` console scripts are removed on develop. `list-files`, batch search
+and external-tool checks remain available; see the [migration guide](../MIGRATION.md).
 
 ## Command Modules
 
@@ -27,9 +32,7 @@ cli/commands/
 ├── structure_command.py        ← --table full
 ├── summary_command.py          ← --summary
 ├── table_command.py            ← table rendering helpers
-├── find_and_grep_cli.py        ← fd + ripgrep subcommands (廃止済み)
 ├── list_files_cli.py           ← `list-files` subcommand
-├── search_content_cli.py       ← `search-content` subcommand (廃止済み)
 ├── mcp_commands/               ← MCP-equivalent CLI flags (parity contract; package)
 └── codegraph_index_commands.py ← cache commands: autoindex / full-index / incremental-sync / metrics / knowledge graph index
 ```
@@ -84,7 +87,7 @@ Categories of CLI surface:
 - `--detect-routes` — framework route detection
 
 ### Cache & Index
-- `--ast-cache index|stats|lookup|invalidate` — AST cache ops (project index default cap: 20k files)
+- `--ast-cache --ast-cache-mode index|stats|lookup|search|sync|changes|watch_start|watch_stop|watch_status|invalidate` — AST cache ops (project index default cap: 20k files)
 - `--ast-cache-include-activation` — opt in to slower temporal git activation during project indexing
 - `--autoindex [--autoindex-mode status|warm|reset]` — transparent auto-index
 - `--full-index [--full-index-mode rebuild|stats|clear]` — one-shot complete index (default cap: 20k files)
@@ -136,7 +139,6 @@ Categories of CLI surface:
 | `json` | All outputs | jq-pipe friendly, human-readable |
 | `text` | `--output-format text` | human-readable output for legacy text paths |
 | `table` | `--table` flag | Box-drawing chars, terminal only |
-| `csv` | `--table csv` | spreadsheet ingestion |
 
 `--format` is intentionally narrower than `--output-format` and `--table`:
 use `--format json` for agent envelopes, `--output-format text` for the

--- a/docs/CODEMAPS/mcp-tools.md
+++ b/docs/CODEMAPS/mcp-tools.md
@@ -2,34 +2,36 @@
 # MCP Tools Codemap
 
 **8 facade tools** registered in [`mcp/_tool_registry.py`](../../tree_sitter_analyzer/mcp/_tool_registry.py)
-(v2.0 β cutover — was 66 discrete tools). Each facade fans an `action` parameter
-out to the unchanged inner tools; the 66 legacy names still work for one
-deprecation cycle via the legacy-name shim
-([`mcp/legacy_shim.py`](../../tree_sitter_analyzer/mcp/legacy_shim.py)).
+with **87 actions**. The published v1.29.5 baseline already has the eight-facade
+shape. Current develop forwards **65 legacy names** through
+[`mcp/legacy_shim.py`](../../tree_sitter_analyzer/mcp/legacy_shim.py); the removed
+`search_content` and `find_and_grep` names are excluded. See the
+[migration guide](../MIGRATION.md) for released versus Unreleased behavior.
 All tools return **JSON output** (locked — see `CLAUDE.md`). Response-envelope semantics (verdict alphabet and truncation fields) are specified in the [Agent Envelope Contract](../agent-envelope-contract.md).
 
-## Facade Surface (public, eager — the only 8 tools clients see)
+## Facade Surface (8 domain tools plus standalone infrastructure)
 
 | MCP name | action= | Purpose |
 |---|---|---|
-| `search` | symbol / query / content / grep / batch / chain / select / subscribe / unsubscribe | Code search: BM25 symbol lookup, tree-sitter .scm DSL, ripgrep, fd+rg, batch, graph-chain DSL, Hyphae DSL, reactive push subscriptions (RFC-0001) |
-| `nav` | pulse / pulse_batch / navigate / call_path / xref / resolve / lineage / impact / trace / context / callers / callees / callee_tree / caller_tree / test_map / co_change | Call-graph navigation + one-call symbol context; test_map = which tests exercise a function (RFC-0014 Phase B); co_change = git-history temporal coupling (RFC-0014 Phase C) |
-| `structure` | outline / analyze / ast_path / sitemap / class_tree / class_detail / explore / read / signatures | Structural AST analysis + partial file read + signature-only listing |
-| `health` | project / file / scale / patterns / heatmap / imports / matrix / dead / unreachable / routes / middleware / overview / deps / test_gap / self / refactor_queue | Code health, complexity, dependency analysis, untested symbol discovery; `self` = RFC-0025 Layer 5 self-proprioception (per-`(tool, action)` p50/p95 latency by tier + in-process analysis-cache hit rate + on-disk AST-index state, for the current process; CLI twin `--self-health`); `refactor_queue` = RFC-0027 §L8 top-N prioritized refactor queue ranked by `(1 - health/100) * log(1 + churn_30d) * (dead_ratio + 0.1)`, CLI twin `--refactor-queue` |
-| `edit` | safe / guard / impact / refactor / rename / constraints / pr / classify / ast_diff / release_snapshot / plan_rename / mutation_probe / verify | Edit-safety, blast-radius, refactor, PR review; RFC-0022 explicit-opt-in POSIX-only frozen workspace/staged snapshots (`impact` issues ID+lease or fails closed on Windows, `ast_diff`/`classify` consume ID+path, `release_snapshot` idempotently closes the owned lease in the same MCP process); legacy staged impact remains Windows-supported; `plan_rename` = RFC-0027 §L8 minimal rename edit set, PREVIEW ONLY (apply-like arguments are rejected with `PLAN_RENAME_IS_PREVIEW_ONLY`), CLI twin `--plan-rename`; `mutation_probe` = RFC-0029 on-demand "does this test constrain this code?" probe — applies one AST mutation in memory, runs named test in isolation, returns `constrains`/`does_not_constrain`/`unknown`, fail-closed, CLI twin `--mutation-probe`; `verify` 通过 `request` 描述符重新分析并运行完整验证计划，CLI twin `--verify-plan`，用户测试可能写文件及联网 |
-| `project` | overview / files / smart / parser / tools / metrics / skills / workflow / journal / doc_sync / card | Project-intelligence hub; `card` = RFC-0027 §L7 project card (purpose, top languages, entry points, module descriptions), CLI twin `--project-card` |
-| `index` | status / cache / build / full / auto / sync | CodeGraph index lifecycle |
-| `viz` | uml / graph / similarity | UML / graph diagrams + similarity |
+| `search` | batch / chain / query / select / semantic / subscribe / symbol / tql_execute / tql_schema / unsubscribe | Code search: BM25 symbols, tree-sitter .scm queries, ripgrep batch search, optional embedding search, graph-chain DSL, Hyphae/TQL and reactive subscriptions |
+| `nav` | call_path / callee_tree / callees / caller_tree / callers / co_change / context / impact / lineage / navigate / pulse / pulse_batch / resolve / test_map / trace / xref | Call-graph navigation + one-call symbol context; test_map = which tests exercise a function (RFC-0014 Phase B); co_change = git-history temporal coupling (RFC-0014 Phase C) |
+| `structure` | analyze / ast_path / class_detail / class_tree / explore / outline / read / signatures / sitemap | Structural AST analysis + partial file read + signature-only listing |
+| `health` | dead / deps / file / heatmap / imports / matrix / middleware / overview / patterns / project / refactor_queue / routes / scale / self / test_gap / unreachable | Code health, complexity, dependency analysis, untested symbol discovery; `self` = RFC-0025 Layer 5 self-proprioception (per-`(tool, action)` p50/p95 latency by tier + in-process analysis-cache hit rate + on-disk AST-index state, for the current process; CLI twin `--self-health`); `refactor_queue` = RFC-0027 §L8 top-N prioritized refactor queue ranked by `(1 - health/100) * log(1 + churn_30d) * (dead_ratio + 0.1)`, CLI twin `--refactor-queue` |
+| `edit` | ast_diff / classify / constraints / guard / impact / mutation_probe / plan_rename / pr / refactor / release_snapshot / rename / safe / verify | Edit-safety, blast-radius, refactor, PR review; RFC-0022 explicit-opt-in POSIX-only frozen workspace/staged snapshots (`impact` issues ID+lease or fails closed on Windows, `ast_diff`/`classify` consume ID+path, `release_snapshot` idempotently closes the owned lease in the same MCP process); legacy staged impact remains Windows-supported; `plan_rename` = RFC-0027 §L8 minimal rename edit set, PREVIEW ONLY (apply-like arguments are rejected with `PLAN_RENAME_IS_PREVIEW_ONLY`), CLI twin `--plan-rename`; `mutation_probe` = RFC-0029 on-demand "does this test constrain this code?" probe — applies one AST mutation in memory, runs named test in isolation, returns `constrains`/`does_not_constrain`/`unknown`, fail-closed, CLI twin `--mutation-probe`; `verify` 通过 `request` 描述符重新分析并运行完整验证计划，CLI twin `--verify-plan`，用户测试可能写文件及联网 |
+| `project` | card / doc_sync / files / journal / metrics / overview / parser / skills / smart / tools / workflow | Project-intelligence hub; `card` = RFC-0027 §L7 project card (purpose, top languages, entry points, module descriptions), CLI twin `--project-card` |
+| `index` | auto / build / cache / full / knowledge / schema / status / sync | CodeGraph index lifecycle |
+| `viz` | graph / knowledge / similarity / uml | UML / graph diagrams + similarity |
 
 > `set_project_path` remains a standalone infrastructure entry (not a facade
 > action) because it mutates server-level state. Final client surface = **8
 > facades + set_project_path**.
 
-## Legacy Capability → Facade Crosswalk (deprecated names, still shimmed)
+## Capability → CLI Reference
 
-The table below documents the 66 legacy capabilities and their CLI flags. Each
-legacy MCP name is now reached via its facade (`old_name` →
-`facade action=<...>`); see [`mcp/facade_map.py`](../../tree_sitter_analyzer/mcp/facade_map.py).
+This reference includes legacy aliases, newer facade capabilities, and explicitly
+marked removals. The exact 65-name shim crosswalk is in the
+[migration guide](../MIGRATION.md) and
+[`mcp/facade_map.py`](../../tree_sitter_analyzer/mcp/facade_map.py).
 
 | MCP name | CLI flag / handler | Purpose |
 |---|---|---|
@@ -39,8 +41,8 @@ legacy MCP name is now reached via its facade (`old_name` →
 | `extract_code_section` | `--partial-read --start-line N --end-line M` | Token-efficient line range |
 | `query_code` | `--query-key methods --filter "public=true"` | tree-sitter query DSL |
 | `list_files` | `list-files` subcommand (fd) | Discovery |
-| ~~`search_content`~~ | *(廃止済み)* | CC Grep tool を使用 |
-| ~~`find_and_grep`~~ | *(廃止済み)* | CC Glob + Grep tool を使用 |
+| ~~`search_content`~~ | *(Removed)* | Use host text search or a search program directly |
+| ~~`find_and_grep`~~ | *(Removed)* | Use host file/text search or a search program directly |
 | `batch_search` | `--batch-search` / `--batch-search-queries-json` | Multiple ripgrep searches in parallel |
 | `check_tools` | `--check-tools` | Verify fd + ripgrep are installed (and report versions) |
 | `list_agent_skills` | `--list-skills` | Curated skill index for AI agents |

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,94 +1,110 @@
-# Migration Guide: v1.x → v2.0 (66 Tools → 8 Facades)
+# Migration Guide: published v1.29.5 → Unreleased develop
 
-## Why 66 → 8?
+This guide describes the current develop implementation, compared with the published
+v1.29.5 baseline. It does not assign a release version or announce a publication.
+Both already expose **8 MCP facades plus `set_project_path`**; the facade cutover is
+not a new change in this migration.
 
-Tree-sitter Analyzer v1.x registered **66 discrete MCP tools** into every connected client.
-That worked on the CLI and in curl-style clients, but it created two real problems:
+## Changes callers must handle
 
-**Token cost.** Every MCP client (Roo Code, Cline, Copilot, Cursor) injects all tool
-definitions into every prompt. With 66 tools the eager payload hit **24,318 tokens of
-pure tool-definition overhead per session** — exactly the waste that TOON output was
-designed to avoid. The irony: the server that saved 50-70% on *response* tokens was
-burning 24k tokens on *discovery*.
+| Surface | Published v1.29.5 | Unreleased develop |
+|---|---|---|
+| MCP response encoding | TOON by default | JSON only; remove TOON decoding and consume the structured response envelope |
+| CLI machine-readable encoding | JSON available | `--format json`; TOON is removed |
+| Table rendering | Additional legacy table formats | `--table full` or `--table signatures`; compact/csv table modes are removed |
+| Text-search wrappers | `search.content`, `search.grep`; legacy `search_content`, `find_and_grep`; `search-content`, `find-and-grep` commands | Removed; use the host's text/file search tools, or invoke a suitable text-search program directly |
+| Remaining external-tool wrappers | Batch text search, file listing, tool checks | Still available: `search.batch`, `project.files`, `project.tools`, `list-files`, `--check-tools` |
+| Internal file discovery and live symbol tracing | External search processes | Native discovery and a bounded Python source-scanning worker |
 
-**Client breakage.** Cursor caps composed MCP tool names at 60 characters
-(`<server>__<tool>`). Several v1.x names were approaching that limit. Roo Code reports
-degraded tool-selection accuracy above ~50 tools because the LLM's tool picker is
-overwhelmed by near-duplicate names (`codegraph_callers` vs
-`codegraph_call_graph mode=callers`).
+Indexed symbol search and AST queries serve code-intelligence tasks. They are not
+replacements for arbitrary text search in unindexed files. Likewise, indexed
+`structure action=sitemap` is not a live filesystem listing. Native source
+occurrences are heuristic text evidence, not proof of AST call relationships.
 
-v2.0 collapses all 66 tools into **8 domain facades** (`search`, `nav`, `structure`,
-`health`, `edit`, `project`, `index`, `viz`). Each facade exposes an `action` parameter
-that routes to the same inner logic. **No capability is removed** — every tool is
-reachable via `(facade, action)`. The token cost drops to **~4,873 tokens (~80% less)**
-day-one.
+Develop currently has **87 facade actions, 356 unique long CLI flags, and seven
+console-script entry points**. The three published v1.29.5 routes `edit.rename`,
+`health.unreachable`, and `health.middleware` remain available. Explicit rename
+apply can write files; `edit.plan_rename` remains preview-only.
 
-Comparison (tool count in eager MCP surface):
+The remaining wrapper retirement is a separate proposal, not part of the current
+implementation. Optional rg/fd integration is also under qualification; their
+presence on PATH does not select a new core backend. See
+[RFC-0033](../rfcs/0033-native-search-independence.md) and
+[RFC-0034](../rfcs/0034-optional-search-backend-qualification.md).
 
-| Server | Tools |
-|---|---|
-| CodeGraph | ~12 |
-| Rhizome / mycelium | 1 (unified) |
-| **Tree-sitter Analyzer v2.0** | **8 (rich-output: verdict + TOON)** |
-| Tree-sitter Analyzer v1.x | 66 |
+## JSON and index migration
 
----
+Update clients to parse JSON and preserve the response envelope, including error,
+truncation and evidence fields. CLI diagnostics stay on stderr. Human-readable
+legacy CLI paths may still use `--output-format text`; this is not an alternate
+MCP encoding. No global `--format text`, `--format toon`, or `--table csv` exists.
 
-## Shim: one release cycle, then removed
+Rebuild indexes after upgrading when extractor/schema compatibility requires it.
+For an explicit AST index build and subsequent indexed structure view:
 
-v2.0 ships a **backwards-compatibility shim** in the MCP server layer. Any call that
-arrives using a v1.x tool name is transparently forwarded to the correct facade action.
-The shim emits a deprecation warning on **stderr** and includes a `deprecation` field in
-the response envelope so agent-side code can detect it:
+```bash
+uv run python -m tree_sitter_analyzer --ast-cache --ast-cache-mode index --format json
+uv run python -m tree_sitter_analyzer --codegraph-sitemap --codegraph-sitemap-mode flat --format json
+```
+
+## Legacy-name compatibility
+
+The current shim forwards the **65 names** in
+[`LEGACY_TOOL_MAP`](../tree_sitter_analyzer/mcp/facade_map.py). The removed
+`search_content` and `find_and_grep` names are not forwarded. Callers should migrate
+to facades rather than assume every historical name remains supported.
+
+A forwarded dictionary response receives a `deprecation` object; the shim also
+emits a warning on stderr. Example of that field, with the tool-specific response
+fields omitted:
 
 ```json
 {
-  "verdict": "INFO",
-  "deprecation": "codegraph_callers is deprecated (v1.x). Use: nav action=callers",
-  "data": { ... }
+  "deprecation": {
+    "deprecated": true,
+    "old_name": "codegraph_callers",
+    "facade": "nav",
+    "action": "callers",
+    "message": "'codegraph_callers' is deprecated; call 'nav' with action='callers'. The legacy name works for one release cycle."
+  }
 }
 ```
 
-The shim is present in **v2.0 and v2.1** and will be removed in **v2.2**.
+This describes present behavior, not a new promise about a future shim-removal
+version. Follow the migration notes for the selected release before upgrading.
 
----
+## Pin the published baseline
 
-## Pin to v1.x (escape hatch)
-
-If you need uninterrupted v1.x behaviour while your tooling migrates, pin:
+To keep the published behavior while migrating, pin its exact version:
 
 ```bash
-pip install "tree-sitter-analyzer<2"
+pip install "tree-sitter-analyzer==1.29.5"
 ```
 
-Or in `pyproject.toml`:
+For a project, use the normal dependency specification:
 
 ```toml
-[tool.uv.sources]
-tree-sitter-analyzer = { version = "<2" }
+[project]
+dependencies = ["tree-sitter-analyzer==1.29.5"]
 ```
 
----
+## Legacy name → current facade crosswalk
 
-## Old → New crosswalk (all 66 legacy tools)
-
-The table below is the canonical mapping maintained in
-`tree_sitter_analyzer/mcp/facade_map.py`. The shim is derived from this same table.
+This table covers every name in the current `LEGACY_TOOL_MAP`. New facade-only
+actions are listed in the [MCP codemap](CODEMAPS/mcp-tools.md).
 
 ### search facade
 
-| v1.x tool name | v2.0 call |
+| Legacy tool name | Current call |
 |---|---|
 | `codegraph_symbol_search` | `search` `action=symbol` |
-| `query_code` | `search` `action=query` (tree-sitter .scm DSL — distinct from symbol search) |
-| `search_content` | **廃止済み** — CC 組み込み Grep tool を使用 |
-| `find_and_grep` | **廃止済み** — CC 組み込み Glob + Grep tool を使用 |
+| `query_code` | `search` `action=query` |
 | `batch_search` | `search` `action=batch` |
 | `codegraph_query` | `search` `action=chain` |
 
 ### nav facade
 
-| v1.x tool name | v2.0 call |
+| Legacy tool name | Current call |
 |---|---|
 | `codegraph_navigate` | `nav` `action=navigate` |
 | `codegraph_call_path` | `nav` `action=call_path` |
@@ -98,15 +114,15 @@ The table below is the canonical mapping maintained in
 | `codegraph_impact` | `nav` `action=impact` |
 | `trace_impact` | `nav` `action=trace` |
 | `codegraph_context` | `nav` `action=context` |
-| `codegraph_callers` | `nav` `action=callers` (default `scope=point`) |
-| `codegraph_callees` | `nav` `action=callees` (default `scope=point`) |
-| `codegraph_call_graph` | `nav` `action=callers` `scope=graph` |
+| `codegraph_callers` | `nav` `action=callers` |
+| `codegraph_callees` | `nav` `action=callees` |
 | `codegraph_callee_tree` | `nav` `action=callee_tree` |
 | `codegraph_caller_tree` | `nav` `action=caller_tree` |
+| `codegraph_call_graph` | `nav` `action=callers` `scope=graph` |
 
 ### structure facade
 
-| v1.x tool name | v2.0 call |
+| Legacy tool name | Current call |
 |---|---|
 | `get_code_outline` | `structure` `action=outline` |
 | `analyze_code_structure` | `structure` `action=analyze` |
@@ -119,7 +135,7 @@ The table below is the canonical mapping maintained in
 
 ### health facade
 
-| v1.x tool name | v2.0 call |
+| Legacy tool name | Current call |
 |---|---|
 | `check_project_health` | `health` `action=project` |
 | `check_file_health` | `health` `action=file` |
@@ -136,7 +152,7 @@ The table below is the canonical mapping maintained in
 
 ### edit facade
 
-| v1.x tool name | v2.0 call |
+| Legacy tool name | Current call |
 |---|---|
 | `safe_to_edit` | `edit` `action=safe` |
 | `modification_guard` | `edit` `action=guard` |
@@ -149,7 +165,7 @@ The table below is the canonical mapping maintained in
 
 ### project facade
 
-| v1.x tool name | v2.0 call |
+| Legacy tool name | Current call |
 |---|---|
 | `get_project_overview` | `project` `action=overview` |
 | `list_files` | `project` `action=files` |
@@ -161,10 +177,11 @@ The table below is the canonical mapping maintained in
 | `get_agent_workflow` | `project` `action=workflow` |
 | `decision_journal` | `project` `action=journal` |
 | `doc_sync` | `project` `action=doc_sync` |
+| `get_project_summary` | `project` `action=card` |
 
 ### index facade
 
-| v1.x tool name | v2.0 call |
+| Legacy tool name | Current call |
 |---|---|
 | `codegraph_status` | `index` `action=status` |
 | `ast_cache` | `index` `action=cache` |
@@ -175,37 +192,35 @@ The table below is the canonical mapping maintained in
 
 ### viz facade
 
-| v1.x tool name | v2.0 call |
+| Legacy tool name | Current call |
 |---|---|
 | `codegraph_uml` | `viz` `action=uml` |
 | `codegraph_visualize` | `viz` `action=graph` |
 | `codegraph_similarity` | `viz` `action=similarity` |
 
----
-
 ## Infrastructure tool (not shimmed)
 
 `set_project_path` is **not a facade** and not in the crosswalk above. It mutates
 server-level state (analysis engine, security validator, inner-instance rebind) that
-no inner tool can reach, so it stays as a standalone entry in v2.0. No migration needed.
+no inner tool can reach, so it stays as a standalone entry in both baselines. No migration needed.
 
 ---
 
 ## MCP call examples
 
-**v1.x style (still works via shim through v2.1):**
+**Legacy name (currently forwarded by the shim):**
 
 ```json
 { "tool": "codegraph_callers", "arguments": { "function_name": "execute" } }
 ```
 
-**v2.0 style (preferred):**
+**Facade call (preferred):**
 
 ```json
 { "tool": "nav", "arguments": { "action": "callers", "function_name": "execute" } }
 ```
 
-**v2.0 graph scope (was `codegraph_call_graph`):**
+**Graph scope (legacy `codegraph_call_graph`):**
 
 ```json
 { "tool": "nav", "arguments": { "action": "callers", "function_name": "execute", "scope": "graph" } }
@@ -231,18 +246,7 @@ allowed-tools:
   - mcp__tree-sitter-analyzer__search
 ```
 
-The bundled `tsa-*` skills are updated in v2.0 as part of Wave D / G1.
-
----
-
-## Deprecation timeline
-
-| Version | Status |
-|---|---|
-| v1.x | All 66 tools live, no deprecation |
-| **v2.0** | 8 facades live; shim forwards 66 legacy names with `deprecation` field |
-| v2.1 | Shim still present; legacy names emit louder stderr warning |
-| **v2.2** | Shim removed; legacy names return `NOT_FOUND` |
+Use the bundled `tsa-*` skills that match the installed TSA version.
 
 ---
 

--- a/tests/governance/test_postmortem_guards.py
+++ b/tests/governance/test_postmortem_guards.py
@@ -376,7 +376,7 @@ def test_readme_counts_match_registry() -> None:
         ),
         (
             "README.md",
-            re.compile(r"The (\d+) facades expose"),
+            re.compile(r"The (\d+) MCP tools expose"),
             tool_count,
             "MCP tool count (en cache section)",
         ),
@@ -406,7 +406,7 @@ def test_readme_counts_match_registry() -> None:
         ),
         (
             "README_zh.md",
-            re.compile(r"这 (\d+) 个门面"),
+            re.compile(r"这 (\d+) 个 MCP 工具"),
             tool_count,
             "MCP tool count (zh cache section)",
         ),

--- a/tests/governance/test_postmortem_guards.py
+++ b/tests/governance/test_postmortem_guards.py
@@ -376,7 +376,7 @@ def test_readme_counts_match_registry() -> None:
         ),
         (
             "README.md",
-            re.compile(r"All (\d+) tools read"),
+            re.compile(r"The (\d+) facades expose"),
             tool_count,
             "MCP tool count (en cache section)",
         ),
@@ -406,7 +406,7 @@ def test_readme_counts_match_registry() -> None:
         ),
         (
             "README_zh.md",
-            re.compile(r"所有 (\d+) 个工具"),
+            re.compile(r"这 (\d+) 个门面"),
             tool_count,
             "MCP tool count (zh cache section)",
         ),


### PR DESCRIPTION
The migration guide described v1.x as 66 tools and promised that no capability was removed, although published v1.29.5 already exposes eight facades and develop removes two text-search wrappers and TOON. This updates the actual 1.29.5-to-Unreleased migration, JSON examples, 65 retained legacy mappings, 87 facade actions, 356 CLI flags and seven console scripts. It consolidates current Unreleased notes while preserving historical release behavior. English/Spanish README examples no longer advertise deleted commands, and English/Chinese/Japanese/Spanish index guidance no longer promises automatic warming for every query.

Pending wrapper removal in #1426 and optional backend qualification in RFC-0034 remain proposals. No release version is selected or publishing workflow triggered.

Validation: TSA change-impact classified this as docs-only and prescribed git diff --check, which passed. Runtime enumeration matched all documented facade actions and legacy mappings; JSON examples and CLI examples were checked against the actual serializer/parser. All applicable commit hooks passed.

README changes exposed a count-contract regex tied to the inaccurate old cache sentence. The contract now matches the corrected eight-facade wording, retaining exact runtime equality; all 10 postmortem governance tests pass.

The full CI claim scanner also requires controlled inventory wording. The corrected cache description now uses its existing governed MCP-tools terminology; both the exact count contracts and complete public-claim scanner pass together (239 tests). No claim allowlist or scanner guard was weakened.
