### PR TITLE
ci: restore complete validation and portable budget retries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,7 @@ jobs:
           uv run pytest -q \
             tests/contracts/ \
             tests/governance/ \
+            tests/unit/test_claim_registry.py \
             tests/integration/docs/test_readme_structure.py
 
   quality-check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
     inputs:
       full-validation:
-        description: 'Run all validation routes and the full test matrix without publishing'
+        description: 'Run the full test matrix and connected CI checks without publishing'
         required: false
         default: false
         type: boolean

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,16 @@ on:
   pull_request:
     branches: [ main, develop ]
   workflow_dispatch:
+    inputs:
+      full-validation:
+        description: 'Run all validation routes and the full test matrix without publishing'
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # 手动验证固定事件 SHA，后续推送和其他手动验证不能取消它。
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && format('manual-{0}', github.run_id) || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -51,7 +58,14 @@ jobs:
 
       - name: Route jobs
         id: route
-        run: python3 scripts/ci_route.py --files changed-files.txt --github-output "$GITHUB_OUTPUT"
+        env:
+          FORCE_FULL: ${{ github.event_name == 'workflow_dispatch' && inputs.full-validation && 'true' || 'false' }}
+        run: |
+          args=()
+          if [[ "$FORCE_FULL" == "true" ]]; then
+            args+=(--force-full)
+          fi
+          python3 scripts/ci_route.py --files changed-files.txt --github-output "$GITHUB_OUTPUT" "${args[@]}"
         shell: bash
 
   docs-check:

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -122,6 +122,8 @@ jobs:
         echo '```' >&3
 
         if [ -f test_failed ]; then
+          # 摘要不可通过作业日志 API 读取；失败时保留完整错误上下文。
+          cat pytest-output.txt
           echo "❌ Tests failed!" >&3
           exit 1
         fi
@@ -167,6 +169,14 @@ jobs:
         uv run pytest tests/ -n auto -q --maxfail=200 --timeout=120 \
           -m "slow and not network and not e2e and not benchmark and not full_language"
       shell: bash
+
+    - name: Upload failed test diagnostics
+      if: failure() && hashFiles('pytest-output.txt') != ''
+      uses: actions/upload-artifact@v7.0.1
+      with:
+        name: pytest-failure-${{ inputs.matrix-profile }}-${{ matrix.os }}-py${{ matrix.python-version }}-attempt${{ github.run_attempt }}
+        path: pytest-output.txt
+        retention-days: 7
 
     - name: Upload coverage to Codecov
       if: inputs.upload-coverage && matrix.coverage
@@ -305,6 +315,14 @@ jobs:
         uv run pytest tests/ -n auto -q --maxfail=200 --timeout=120 \
           -m "slow and not network and not e2e and not benchmark and not full_language"
       shell: bash
+
+    - name: Upload failed test diagnostics
+      if: failure() && hashFiles('pytest-output.txt') != ''
+      uses: actions/upload-artifact@v7.0.1
+      with:
+        name: pytest-failure-${{ inputs.matrix-profile }}-${{ matrix.os }}-py${{ matrix.python-version }}-attempt${{ github.run_attempt }}
+        path: pytest-output.txt
+        retention-days: 7
 
     - name: Upload coverage to Codecov
       if: inputs.upload-coverage && matrix.os == 'ubuntu-latest' && matrix.python-version == inputs.python-version

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -151,7 +151,11 @@ jobs:
           pytest-output.txt --nodeids-output windows-budget-retry.txt; then
           exit "$test_status"
         fi
-        mapfile -t retry_nodeids < windows-budget-retry.txt
+        # macOS 自带 Bash 3 不支持 mapfile；逐行保留节点中的空格、反斜杠和通配符。
+        retry_nodeids=()
+        while IFS= read -r nodeid; do
+          retry_nodeids+=("$nodeid")
+        done < windows-budget-retry.txt
         echo "Runner degradation suspected ($RUNNER_OS); retrying budget-only failures once."
         uv run pytest "${retry_nodeids[@]}" -n auto -q --tb=short --maxfail=200
       shell: bash
@@ -286,7 +290,11 @@ jobs:
           pytest-output.txt --nodeids-output windows-budget-retry.txt; then
           exit "$test_status"
         fi
-        mapfile -t retry_nodeids < windows-budget-retry.txt
+        # macOS 自带 Bash 3 不支持 mapfile；逐行保留节点中的空格、反斜杠和通配符。
+        retry_nodeids=()
+        while IFS= read -r nodeid; do
+          retry_nodeids+=("$nodeid")
+        done < windows-budget-retry.txt
         echo "Runner degradation suspected ($RUNNER_OS); retrying budget-only failures once."
         uv run pytest "${retry_nodeids[@]}" -n auto -q --tb=short --maxfail=200
       shell: bash

--- a/scripts/ci_route.py
+++ b/scripts/ci_route.py
@@ -139,7 +139,6 @@ def route_changed_files(
         # 显式完整验证不受最后一次提交的路径或子范围限制。
         outputs["full_suite_required"] = True
         outputs["regression_scope"] = "all"
-        outputs["benchmark_scope"] = "all"
         reason_codes.append("manual-full-validation")
 
     if outputs["full_suite_required"]:
@@ -147,8 +146,17 @@ def route_changed_files(
             # run_docs_check is the LIGHTWEIGHT alternative to the full matrix —
             # never force it on a full-suite run (the matrix already covers it).
             if key.startswith("run_") and key != "run_docs_check":
-                outputs[key] = True
-        reason_codes.append("force-all-routes")
+                # 手动验证仅覆盖 ci.yml 已连接的检查；基准和语法资格由独立工作流执行。
+                outputs[key] = not (
+                    force_full and key in {"run_benchmarks", "run_grammar_coverage"}
+                )
+        if force_full:
+            reason_codes = [
+                code
+                for code in reason_codes
+                if code not in {"run_benchmarks", "run_grammar_coverage"}
+            ]
+        reason_codes.append("force-ci-routes" if force_full else "force-all-routes")
 
     # Docs-only short-circuit: a non-empty changeset whose files ALL match the
     # docs_only globs (and which did NOT trip full_suite) skips the heavy

--- a/scripts/ci_route.py
+++ b/scripts/ci_route.py
@@ -107,7 +107,7 @@ def matches_any(path: str, patterns: list[str]) -> bool:
 
 
 def route_changed_files(
-    changed_files: list[str], config: dict[str, Any]
+    changed_files: list[str], config: dict[str, Any], *, force_full: bool = False
 ) -> dict[str, Any]:
     outputs = dict(DEFAULT_OUTPUTS)
     outputs.update(config.get("always", {}))
@@ -134,6 +134,13 @@ def route_changed_files(
         elif len(matched_scopes) > 1:
             outputs[scope_name] = scope_config.get("default", "all")
             reason_codes.append(f"{scope_name}-multiple")
+
+    if force_full:
+        # 显式完整验证不受最后一次提交的路径或子范围限制。
+        outputs["full_suite_required"] = True
+        outputs["regression_scope"] = "all"
+        outputs["benchmark_scope"] = "all"
+        reason_codes.append("manual-full-validation")
 
     if outputs["full_suite_required"]:
         for key in list(outputs):
@@ -196,10 +203,13 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--config", default="config/ci-routing.yml")
     parser.add_argument("--files", action="append", default=[])
     parser.add_argument("--github-output")
+    parser.add_argument("--force-full", action="store_true")
     args = parser.parse_args(argv)
 
     config = load_routing_config(Path(args.config))
-    outputs = route_changed_files(_read_changed_files(args), config)
+    outputs = route_changed_files(
+        _read_changed_files(args), config, force_full=args.force_full
+    )
     print(json.dumps(outputs, indent=2, sort_keys=True))
     if args.github_output:
         _write_github_outputs(outputs, args.github_output)

--- a/tests/governance/test_ci_routing_contract.py
+++ b/tests/governance/test_ci_routing_contract.py
@@ -289,6 +289,8 @@ def test_docs_check_fetches_history_for_contract_subjects() -> None:
     checkout_end = docs_job.index("\n      - name:", checkout_start)
     checkout_step = docs_job[checkout_start:checkout_end]
     assert checkout_step.splitlines().count("          fetch-depth: 0") == 1
+    # 2026-09-09：PR #1430 的文档门禁遗漏声明注册表扫描，直到完整矩阵才发现漂移。
+    assert "tests/unit/test_claim_registry.py" in docs_job
 
 
 def test_dogfood_reads_complete_pr_diff_instead_of_output_files(tmp_path: Path) -> None:

--- a/tests/governance/test_ci_routing_contract.py
+++ b/tests/governance/test_ci_routing_contract.py
@@ -405,12 +405,21 @@ def test_ci_routing_uses_merge_parent_when_event_base_is_stale(tmp_path: Path) -
 
 
 @pytest.mark.parametrize("force_full", [False, True])
-@pytest.mark.parametrize("path", ["README.md", "tree_sitter_analyzer/formatters/x.py"])
+@pytest.mark.parametrize(
+    "path",
+    [
+        "README.md",
+        "tree_sitter_analyzer/formatters/x.py",
+        "tests/benchmarks/test_query_performance.py",
+        "tree_sitter_analyzer/grammar_coverage/x.py",
+    ],
+)
 def test_manual_full_validation_routes_real_cli(
     tmp_path: Path, capsys: pytest.CaptureFixture[str], force_full: bool, path: str
 ) -> None:
     """手动完整验证绕过文档跳过和子范围，同时保留普通路径路由。"""
     # 2026-09-09：CI 34340908809 的文档路由跳过了待补验的完整矩阵。
+    # PR #1431：启用集合必须对应实际消费路由的 CI 作业，不能包含独立资格工作流。
     import json
 
     from scripts.ci_route import main
@@ -424,25 +433,27 @@ def test_manual_full_validation_routes_real_cli(
     docs_only = path == "README.md" and not force_full
     assert result["run_docs_check"] is docs_only
     assert result["full_suite_required"] is force_full
+    assert [result["run_benchmarks"], result["run_grammar_coverage"]] == [
+        not force_full and "benchmarks" in path,
+        not force_full and "grammar_coverage" in path,
+    ]
     for key in ("run_quality", "run_test_matrix", "run_build", "upload_coverage"):
         assert result[key] is (not docs_only)
     assert result["regression_scope"] == (
-        "format" if not force_full and not docs_only else "all"
+        "format" if not force_full and "/formatters/" in path else "all"
     )
     if force_full:
         assert {
             key for key, value in result.items() if key.startswith("run_") and value
-        } == {
-            "run_quality",
-            "run_test_matrix",
-            "run_build",
-            "run_e2e_smoke",
-            "run_regression",
-            "run_sql_platform_compat",
-            "run_benchmarks",
-            "run_grammar_coverage",
-        }
-        assert result["benchmark_scope"] == "all"
+        } == set(
+            re.findall(
+                r"needs\.route\.outputs\.(run_\w+)",
+                (PROJECT_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8"),
+            )
+        ) - {"run_docs_check"}
+        assert {"run_benchmarks", "run_grammar_coverage"}.isdisjoint(
+            result["reason_codes"]
+        )
         assert "manual-full-validation" in result["reason_codes"]
     assert f"run_test_matrix={str(not docs_only).lower()}\n" in output.read_text(
         encoding="utf-8"

--- a/tests/governance/test_ci_routing_contract.py
+++ b/tests/governance/test_ci_routing_contract.py
@@ -402,3 +402,84 @@ def test_ci_routing_uses_merge_parent_when_event_base_is_stale(tmp_path: Path) -
     argv = shlex.split(command)
     assert git(*argv[1 : argv.index(">")]).splitlines() == ["proposal.md"]
     assert steps[0]["with"]["ref"] == "${{ github.sha }}"
+
+
+@pytest.mark.parametrize("force_full", [False, True])
+@pytest.mark.parametrize("path", ["README.md", "tree_sitter_analyzer/formatters/x.py"])
+def test_manual_full_validation_routes_real_cli(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], force_full: bool, path: str
+) -> None:
+    """手动完整验证绕过文档跳过和子范围，同时保留普通路径路由。"""
+    # 2026-09-09：CI 34340908809 的文档路由跳过了待补验的完整矩阵。
+    import json
+
+    from scripts.ci_route import main
+
+    output = tmp_path / "outputs"
+    args = [path, "--github-output", str(output)]
+    if force_full:
+        args.append("--force-full")
+    assert main(args) == 0
+    result = json.loads(capsys.readouterr().out)
+    docs_only = path == "README.md" and not force_full
+    assert result["run_docs_check"] is docs_only
+    assert result["full_suite_required"] is force_full
+    for key in ("run_quality", "run_test_matrix", "run_build", "upload_coverage"):
+        assert result[key] is (not docs_only)
+    assert result["regression_scope"] == (
+        "format" if not force_full and not docs_only else "all"
+    )
+    if force_full:
+        assert {
+            key for key, value in result.items() if key.startswith("run_") and value
+        } == {
+            "run_quality",
+            "run_test_matrix",
+            "run_build",
+            "run_e2e_smoke",
+            "run_regression",
+            "run_sql_platform_compat",
+            "run_benchmarks",
+            "run_grammar_coverage",
+        }
+        assert result["benchmark_scope"] == "all"
+        assert "manual-full-validation" in result["reason_codes"]
+    assert f"run_test_matrix={str(not docs_only).lower()}\n" in output.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_manual_validation_is_non_publishing_and_concurrency_isolated() -> None:
+    """固定 SHA 的手动验证不被推送取消，且不调用发布工作流。"""
+    # 2026-09-09：CI 34340202847 被同分支的后续文档推送取消。
+    import yaml
+
+    workflow = yaml.safe_load(
+        (PROJECT_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    )
+    inputs = workflow[True]["workflow_dispatch"]["inputs"]
+    assert inputs["full-validation"]["type"] == "boolean"
+    assert inputs["full-validation"]["default"] is False
+    assert workflow["concurrency"]["group"] == (
+        "${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' "
+        "&& format('manual-{0}', github.run_id) || github.ref }}"
+    )
+    jobs = workflow["jobs"]
+    route = next(step for step in jobs["route"]["steps"] if step.get("id") == "route")
+    assert route["env"]["FORCE_FULL"] == (
+        "${{ github.event_name == 'workflow_dispatch' && inputs.full-validation "
+        "&& 'true' || 'false' }}"
+    )
+    assert 'if [[ "$FORCE_FULL" == "true" ]]; then' in route["run"]
+    assert "args+=(--force-full)" in route["run"]
+    assert '"${args[@]}"' in route["run"]
+    assert jobs["test"]["with"]["matrix-profile"] == (
+        "${{ github.event_name == 'pull_request' && 'pr' || 'full' }}"
+    )
+    assert {job["uses"] for job in jobs.values() if "uses" in job} == {
+        "./.github/workflows/reusable-quality.yml",
+        "./.github/workflows/reusable-test.yml",
+        "./.github/workflows/reusable-build.yml",
+        "./.github/workflows/regression-tests.yml",
+        "./.github/workflows/sql-platform-compat.yml",
+    }

--- a/tests/unit/test_classify_windows_pytest_failure.py
+++ b/tests/unit/test_classify_windows_pytest_failure.py
@@ -90,15 +90,7 @@ def test_reasonless_failure_blocks_budget_retry(
 
 
 def test_nodeid_file_uses_lf_so_the_ci_retry_can_match(tmp_path: Path) -> None:
-    """The nodeid file must be LF-only or the Windows retry path cannot work.
-
-    reusable-test.yml reads this file with ``mapfile -t``, which strips only
-    the trailing newline. On Windows, ``Path.write_text`` without
-    ``newline=""`` translates each line separator into CRLF, so mapfile
-    leaves a carriage return attached to every nodeid, pytest matches
-    nothing, and the run exits 5 - turning a recoverable budget blip into a
-    red job. The retry path had never been able to succeed on Windows.
-    """
+    """节点文件必须使用 LF，避免 Bash 逐行读取后将回车保留在节点末尾。"""
     log = tmp_path / "pytest-output.txt"
     log.write_text(
         "FAILED tests/a.py::t1 - Failed: Unit test exceeded per-test "
@@ -113,3 +105,85 @@ def test_nodeid_file_uses_lf_so_the_ci_retry_can_match(tmp_path: Path) -> None:
         assert main() == 0
 
     assert out.read_bytes() == b"tests/a.py::t1" + chr(10).encode()
+
+
+@pytest.mark.parametrize("profile", ["test-matrix-pr", "test-matrix-full"])
+@pytest.mark.parametrize("budget_only", [False, True])
+def test_ci_retry_reads_exact_nodeids_with_system_bash(
+    tmp_path: Path, profile: str, budget_only: bool
+) -> None:
+    """执行真实分类器和工作流重试片段，保持预算资格及节点字面值。"""
+    # 2026-09-09：PR #1433 macOS 作业在获准重试后因 Bash 3 缺少 mapfile 失败。
+    import os
+    import shlex
+    import shutil
+    import subprocess
+
+    import yaml
+
+    root = Path(__file__).resolve().parents[2]
+    workflow = yaml.safe_load(
+        (root / ".github/workflows/reusable-test.yml").read_text(encoding="utf-8")
+    )
+    step = next(
+        item
+        for item in workflow["jobs"][profile]["steps"]
+        if item.get("name") == "Run Tests (no coverage)"
+    )
+    command = step["run"][step["run"].index("if ! uv run python") :]
+    command = command.replace(
+        "scripts/classify_windows_pytest_failure.py",
+        shlex.quote(str(root / "scripts/classify_windows_pytest_failure.py")),
+    )
+    nodeids = [
+        "tests/test_a.py::test_x[with spaces]",
+        r"tests/test_b.py::test_x[a'b\*$HOME]",
+    ]
+    reason = (
+        "Failed: Unit test exceeded per-test budget: 9.01s > 8.0s."
+        if budget_only
+        else "AssertionError: actual behavior changed"
+    )
+    (tmp_path / "pytest-output.txt").write_text(
+        "".join(f"FAILED {nodeid} - {reason}\n" for nodeid in nodeids),
+        encoding="utf-8",
+        newline="",
+    )
+    prefix = """
+uv() {
+  shift
+  if [ "$1" = python ]; then
+    shift
+    "$TSA_TEST_PYTHON" "$@"
+  else
+    printf '%s\\0' "$@" > retry-argv.bin
+  fi
+}
+test_status=1
+"""
+    bash = "/bin/bash" if sys.platform == "darwin" else shutil.which("bash")
+    assert bash is not None
+    result = subprocess.run(
+        [bash, "--noprofile", "--norc", "-e", "-c", prefix + command],
+        cwd=tmp_path,
+        capture_output=True,
+        env={**os.environ, "TSA_TEST_PYTHON": sys.executable, "RUNNER_OS": "test"},
+    )
+    assert result.returncode == (0 if budget_only else 1), result.stderr
+    receipt = tmp_path / "retry-argv.bin"
+    if budget_only:
+        assert receipt.read_bytes().split(b"\0") == [
+            value.encode()
+            for value in [
+                "pytest",
+                *nodeids,
+                "-n",
+                "auto",
+                "-q",
+                "--tb=short",
+                "--maxfail=200",
+                "",
+            ]
+        ]
+    else:
+        assert receipt.exists() is False

--- a/tests/unit/test_classify_windows_pytest_failure.py
+++ b/tests/unit/test_classify_windows_pytest_failure.py
@@ -167,7 +167,11 @@ test_status=1
         [bash, "--noprofile", "--norc", "-e", "-c", prefix + command],
         cwd=tmp_path,
         capture_output=True,
-        env={**os.environ, "TSA_TEST_PYTHON": sys.executable, "RUNNER_OS": "test"},
+        env={
+            **os.environ,
+            "TSA_TEST_PYTHON": Path(sys.executable).as_posix(),
+            "RUNNER_OS": "test",
+        },
     )
     assert result.returncode == (0 if budget_only else 1), result.stderr
     receipt = tmp_path / "retry-argv.bin"

--- a/tests/unit/test_classify_windows_pytest_failure.py
+++ b/tests/unit/test_classify_windows_pytest_failure.py
@@ -191,3 +191,46 @@ test_status=1
         ]
     else:
         assert receipt.exists() is False
+
+
+@pytest.mark.parametrize("profile", ["test-matrix-pr", "test-matrix-full"])
+def test_coverage_failure_retains_diagnostics(tmp_path: Path, profile: str) -> None:
+    """覆盖率失败必须在普通日志和诊断附件中保留，不能只写网页摘要。"""
+    # 2026-09-09：PR #1431 作业 102450961508 只留下 exit 1，真实 pytest 错误丢失。
+    import os
+    import shutil
+    import subprocess
+
+    import yaml
+
+    root = Path(__file__).resolve().parents[2]
+    workflow = yaml.safe_load(
+        (root / ".github/workflows/reusable-test.yml").read_text(encoding="utf-8")
+    )
+    steps = workflow["jobs"][profile]["steps"]
+    coverage = next(step for step in steps if step.get("id") == "test-coverage")
+    artifact = next(
+        step for step in steps if step.get("name") == "Upload failed test diagnostics"
+    )
+    assert artifact["if"] == "failure() && hashFiles('pytest-output.txt') != ''"
+    assert artifact["uses"] == "actions/upload-artifact@v7.0.1"
+    assert artifact["with"]["path"] == "pytest-output.txt"
+    assert artifact["with"]["name"] == (
+        "pytest-failure-${{ inputs.matrix-profile }}-${{ matrix.os }}"
+        "-py${{ matrix.python-version }}-attempt${{ github.run_attempt }}"
+    )
+    bash = "/bin/bash" if sys.platform == "darwin" else shutil.which("bash")
+    assert bash is not None
+    failure = "FAILED tests/test_subject.py::test_behavior - AssertionError: sentinel"
+    prefix = f"uv() {{ printf '%s\\n' '{failure}'; return 1; }}\n"
+    result = subprocess.run(
+        [bash, "--noprofile", "--norc", "-e", "-c", prefix + coverage["run"]],
+        cwd=tmp_path,
+        capture_output=True,
+        env={**os.environ, "GITHUB_STEP_SUMMARY": (tmp_path / "summary").as_posix()},
+    )
+    assert result.returncode == 1
+    assert failure.encode() in result.stdout
+    assert (tmp_path / "pytest-output.txt").read_text(
+        encoding="utf-8"
+    ) == failure + "\n"


### PR DESCRIPTION
Release validation could lose its full matrix to a later docs-only push; macOS budget retries crashed because Bash 3 has no mapfile; docs-only CI omitted the authoritative public-claim scanner.

This change adds an isolated manual full-validation mode for the full test matrix and connected quality/build/E2E/regression/SQL checks. Standalone benchmark and grammar qualifications remain separate and are explicitly not advertised by this mode. Both matrix profiles now preserve approved retry nodeids with a Bash 3-compatible loop, without changing budgets or retry eligibility. Docs Check also runs the existing claim-registry suite.

Validation: 36 routing tests, 43 retry-focused tests, 255 claim/routing tests and 17 final portable-shell tests passed. Quick gate: 2,062 passed, 28 skipped in 28.20s. Actual system Bash 3.2.57 verified exact arguments and rejection of non-budget failures. Direct router coverage has zero added executable misses or partial branches. Actionlint and all hooks passed. Manual run 34345334234 confirmed a fixed SHA 14982637 and ten full-matrix axes; it is not validation of the latest PR head or final integrated candidate. No publishing.

Review triage: comments 3967740840 and 3967740847 identified advertised but unconsumed benchmark/grammar routes. Both were addressed by limiting manual scope to actual workflow consumers and testing that mapping.

Coverage failure diagnostics: a later Linux job (102450961508) failed after its quick gate passed, but its redirected pytest log was not uploaded and the API exposes no job summary. The original failure is still unexplained. Coverage failures now retain the full log in normal job output and a seven-day artifact. Both actual Bash coverage fragments were exercised with an injected assertion failure to verify nonzero status and preserved diagnostics; 45 focused tests and 2,084 quick-gate tests passed. The branch also includes current develop 1e083582. New CI must pass before this PR is merged.

Additional local evidence: the CI-equivalent Python 3.11 coverage run with all extras produced 24,842 passes and two 5-second budget failures in binary snapshot consumer cases. Both cases passed separately with coverage and reruns disabled (0.92/0.94 seconds); capture accounts for about 0.85 seconds and consumer execution about 1 millisecond. No budgets, markers, or assertions were relaxed. This local load sensitivity does not establish the cause of the earlier Linux failure. Integrated develop 1e083582 separately passed full CI run 34348415171, including all ten matrix axes and connected checks.
