### PR TITLE
fix: report missing indexes instead of false symbol misses

### DIFF
--- a/tests/e2e/test_tool_functional.py
+++ b/tests/e2e/test_tool_functional.py
@@ -1,25 +1,14 @@
-"""E2E-5 — Functional correctness tests for primary MCP tools.
+"""通过真实 MCP stdio 校验主要工具的功能和响应封装。
 
-These tests drive the server end-to-end and assert on *semantics* (not
-just latency or stderr cleanliness). Each test exercises one tool against
-the TSA checkout itself, which is a well-understood codebase, and checks
-that the response contains the expected shape of data.
-
-Design contract
----------------
-* We only assert on structural invariants ("result has key X", "value is
-  non-empty", "verdict is one of the legal set"). We do NOT pin exact
-  counts or file lists because those drift as the codebase evolves.
-* Each test calls ``initialized()`` itself so failures in initialization
-  surface clearly rather than being shadowed by the tool assertion.
-* ``java_plugin.py`` is a **negative fixture**: it's an intentionally
-  complex file with deep nesting used by unit tests to verify smell
-  detection. ``safe_to_edit`` must flag it as UNSAFE. Do not refactor it.
+所有八个门面都经过初始化、路由和序列化。搜索案例使用独立的单符号项目，
+精确验证冷索引错误、可执行恢复提示及构建后的真实命中；其余案例使用 TSA
+检出目录，保留各自的健康、安全和结构行为校验。
 """
 
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -32,7 +21,7 @@ FACADE_WIRE_CASES = [
         "search",
         {
             "action": "symbol",
-            "query": "MCP_INFO",
+            "query": "WireSearchSentinel",
             "output_format": "json",
         },
     ),
@@ -142,15 +131,42 @@ class TestFacadeWireContract:
         ids=[facade_name for facade_name, _ in FACADE_WIRE_CASES],
     )
     def test_all_facades_have_stdio_tools_call_envelopes(
-        self, mcp_server: MCPClient, facade_name: str, arguments: dict
+        self,
+        mcp_server: MCPClient,
+        facade_name: str,
+        arguments: dict,
+        tmp_path: Path,
     ) -> None:
-        """Issue #691: cover the real client→stdio→tools/call boundary.
-
-        Unit tests that call ``tool.execute()`` directly cannot catch JSON-RPC
-        framing, facade dispatch, MCP content wrapping, or serialization bugs.
-        This test drives every public facade once over the actual stdio wire.
-        """
+        """#691 / #1432：八门面走真实协议；搜索必须从冷错误恢复到真实命中。"""
         client = initialized(mcp_server)
+        if facade_name == "search":
+            fixture_file = tmp_path / "wire_fixture.py"
+            fixture_file.write_text(
+                "class WireSearchSentinel:\n    pass\n", encoding="utf-8"
+            )
+            bound = _json_text_payload(
+                client.call(
+                    "set_project_path", {"project_path": str(tmp_path.resolve())}
+                )
+            )
+            assert bound["status"] == "success"
+            assert bound["project_root"] == str(tmp_path.resolve())
+            cold = _json_text_payload(client.call("search", arguments))
+            assert cold["success"] is False
+            assert cold["verdict"] == "ERROR"
+            assert cold["error_code"] == "INDEX_NOT_READY"
+            assert cold["results"] == []
+            assert cold["next_step"] == cold["recovery_hint"]
+            assert cold["agent_summary"]["next_step"] == cold["next_step"]
+            assert "--ast-cache-mode index" in cold["next_step"]
+            assert "index action=cache mode=index" in cold["next_step"]
+            indexed = _json_text_payload(
+                client.call(
+                    "index",
+                    {"action": "cache", "mode": "index", "output_format": "json"},
+                )
+            )
+            _assert_agent_wire_envelope(indexed, "index")
         response = client.call(
             facade_name,
             arguments,
@@ -158,6 +174,13 @@ class TestFacadeWireContract:
         )
         payload = _json_text_payload(response)
         _assert_agent_wire_envelope(payload, facade_name)
+        if facade_name == "search":
+            assert payload["match_count"] == 1
+            assert payload["file_count"] == 1
+            assert [
+                (item["name"], item["kind"], item["file"], item["line"])
+                for item in payload["results"]
+            ] == [("WireSearchSentinel", "class", "wire_fixture.py", 1)]
 
     def test_facade_wire_cases_cover_all_public_facades(self) -> None:
         covered_facades = sorted(facade_name for facade_name, _ in FACADE_WIRE_CASES)

--- a/tests/unit/test_codegraph_context_tool.py
+++ b/tests/unit/test_codegraph_context_tool.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from tree_sitter_analyzer.ast_cache import ASTCache
+from tree_sitter_analyzer.mcp.tools.codegraph_context_tool import CodeGraphContextTool
 
 
 @pytest.fixture
@@ -2074,3 +2075,56 @@ def test_next_step_lean_production_anchor() -> None:
     eps = [{"name": "handle_call_tool", "file": "pkg/server.py"}]
     msg = _next_step_lean(True, True, entry_points=eps)
     assert "handle_call_tool" in msg
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("indexed", [False, True])
+async def test_empty_index_does_not_claim_symbol_absence(tmp_path, indexed):
+    # 2026-09-09：冷索引曾将真实存在的函数报告为 NOT_FOUND。
+    source = tmp_path / "auth.py"
+    source.write_text(
+        "def authenticate_user(token): return bool(token)\n", encoding="utf-8"
+    )
+    cache = ASTCache(str(tmp_path))
+    tool = CodeGraphContextTool(str(tmp_path))
+    try:
+        if indexed:
+            cache.index_file(str(source))
+        result = await tool.execute(
+            {"task": "authenticate_user", "output_format": "json"}
+        )
+        assert (result["success"], result["verdict"]) == (
+            (True, "INFO") if indexed else (False, "ERROR")
+        )
+        if not indexed:
+            assert result["error_code"] == "INDEX_NOT_READY"
+            assert result["entry_points"] == []
+            assert "--ast-cache-mode index" in result["next_step"]
+    finally:
+        cache.close()
+        if tool._cache is not None:
+            tool._cache.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("empty_project", [False, True])
+async def test_indexed_zero_symbols_can_report_not_found(tmp_path, empty_project):
+    # 2026-09-09：零符号文件和已完成的空项目不能被误判为尚未建索引。
+    if not empty_project:
+        (tmp_path / "empty.py").write_text("# 空模块\n", encoding="utf-8")
+    cache = ASTCache(str(tmp_path))
+    tool = CodeGraphContextTool(str(tmp_path))
+    try:
+        cache.index_project(max_files=20)
+        result = await tool.execute(
+            {"task": "authenticate_user", "output_format": "json"}
+        )
+        assert (result["success"], result["verdict"], result["entry_points"]) == (
+            True,
+            "NOT_FOUND",
+            [],
+        )
+    finally:
+        cache.close()
+        if tool._cache is not None:
+            tool._cache.close()

--- a/tests/unit/test_symbol_search_tool.py
+++ b/tests/unit/test_symbol_search_tool.py
@@ -684,6 +684,9 @@ async def test_empty_index_does_not_claim_symbol_absence(tmp_path, indexed):
         )
         if not indexed:
             assert result["error_code"] == "INDEX_NOT_READY"
+            assert result["error_type"] == "validation"
+            assert result["recovery_hint"] == result["next_step"]
+            assert result["agent_summary"]["next_step"] == result["next_step"]
             assert result["results"] == []
             assert "--ast-cache-mode index" in result["next_step"]
     finally:

--- a/tests/unit/test_symbol_search_tool.py
+++ b/tests/unit/test_symbol_search_tool.py
@@ -411,8 +411,10 @@ class TestCodeGraphSymbolSearchNoCache:
         project.mkdir()
         tool = CodeGraphSymbolSearchTool(str(project))
         result = await tool.execute({"query": "anything", "output_format": "json"})
-        assert result["success"] is True
+        # 2026-09-09：没有索引时，不能断言项目里没有匹配符号。
+        assert (result["success"], result["error_code"]) == (False, "INDEX_NOT_READY")
         assert result["match_count"] == 0
+        tool._cache.close()
 
 
 class TestCodeGraphSymbolSearchSourceContext:
@@ -659,3 +661,56 @@ class TestSymbolSearchTruncation:
             {"query": "nonexistent_xyz", "output_format": "json"}
         )
         assert "truncated" in result
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("indexed", [False, True])
+async def test_empty_index_does_not_claim_symbol_absence(tmp_path, indexed):
+    # 2026-09-09：冷索引曾将真实存在的函数报告为 NOT_FOUND。
+    source = tmp_path / "auth.py"
+    source.write_text(
+        "def authenticate_user(token): return bool(token)\n", encoding="utf-8"
+    )
+    cache = ASTCache(str(tmp_path))
+    tool = CodeGraphSymbolSearchTool(str(tmp_path))
+    try:
+        if indexed:
+            cache.index_file(str(source))
+        result = await tool.execute(
+            {"query": "authenticate_user", "output_format": "json"}
+        )
+        assert (result["success"], result["verdict"]) == (
+            (True, "INFO") if indexed else (False, "ERROR")
+        )
+        if not indexed:
+            assert result["error_code"] == "INDEX_NOT_READY"
+            assert result["results"] == []
+            assert "--ast-cache-mode index" in result["next_step"]
+    finally:
+        cache.close()
+        if tool._cache is not None:
+            tool._cache.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("empty_project", [False, True])
+async def test_indexed_zero_symbols_can_report_not_found(tmp_path, empty_project):
+    # 2026-09-09：零符号文件和已完成的空项目不能被误判为尚未建索引。
+    if not empty_project:
+        (tmp_path / "empty.py").write_text("# 空模块\n", encoding="utf-8")
+    cache = ASTCache(str(tmp_path))
+    tool = CodeGraphSymbolSearchTool(str(tmp_path))
+    try:
+        cache.index_project(max_files=20)
+        result = await tool.execute(
+            {"query": "authenticate_user", "output_format": "json"}
+        )
+        assert (result["success"], result["verdict"], result["results"]) == (
+            True,
+            "NOT_FOUND",
+            [],
+        )
+    finally:
+        cache.close()
+        if tool._cache is not None:
+            tool._cache.close()

--- a/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
@@ -212,9 +212,7 @@ class CodeGraphContextTool(BaseMCPTool):
                 "output_format": {
                     "type": "string",
                     "enum": ["json"],
-                    "description": (
-                        "Output format: JSON"
-                    ),
+                    "description": ("Output format: JSON"),
                     "default": "json",
                 },
                 "include_graph": {
@@ -297,6 +295,16 @@ class CodeGraphContextTool(BaseMCPTool):
             max_nodes=max_nodes,
             elapsed_ms=int((time.perf_counter() - started) * 1000),
         )
+
+        if not entry_points:
+            from ..utils.auto_index_guard import empty_index_diagnostic
+
+            diagnostic = empty_index_diagnostic(self._get_cache())
+            result.update(diagnostic)
+            if diagnostic:
+                result["agent_summary"].update(
+                    verdict="ERROR", next_step=diagnostic["next_step"]
+                )
 
         from ..utils.format_helper import apply_output_format_to_response
 

--- a/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/codegraph_context_tool.py
@@ -299,12 +299,7 @@ class CodeGraphContextTool(BaseMCPTool):
         if not entry_points:
             from ..utils.auto_index_guard import empty_index_diagnostic
 
-            diagnostic = empty_index_diagnostic(self._get_cache())
-            result.update(diagnostic)
-            if diagnostic:
-                result["agent_summary"].update(
-                    verdict="ERROR", next_step=diagnostic["next_step"]
-                )
+            result.update(empty_index_diagnostic(self._get_cache()))
 
         from ..utils.format_helper import apply_output_format_to_response
 

--- a/tree_sitter_analyzer/mcp/tools/symbol_search_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/symbol_search_tool.py
@@ -200,6 +200,10 @@ class CodeGraphSymbolSearchTool(BaseMCPTool):
                     f"Run structure action=explore query={query!r} before "
                     "raw grep/read to bulk-fetch related symbols and concept matches."
                 )
+        if not results:
+            from ..utils.auto_index_guard import empty_index_diagnostic
+
+            result.update(empty_index_diagnostic(cache))
         if language:
             result["language_filter"] = language
         if kind != "any":

--- a/tree_sitter_analyzer/mcp/utils/auto_index_guard.py
+++ b/tree_sitter_analyzer/mcp/utils/auto_index_guard.py
@@ -195,13 +195,24 @@ def empty_index_diagnostic(cache: Any) -> dict[str, Any]:
     ).fetchone()[0]
     if populated or _call_graph_marker_is_current(cache):
         return {}
+    next_step = (
+        "From the project root, run tree-sitter-analyzer --ast-cache "
+        "--ast-cache-mode index --format json, or call index action=cache mode=index "
+        "for the bound project, then retry the query."
+    )
     return {
         "success": False,
         "verdict": "ERROR",
+        "error_type": "validation",
         "error_code": "INDEX_NOT_READY",
         "error": "INDEX_NOT_READY: No indexed files or completed indexing run. "
         "An empty lookup cannot establish that the requested symbol is absent.",
-        "next_step": "From the project root, run tree-sitter-analyzer --ast-cache "
-        "--ast-cache-mode index --format json, or call index action=cache mode=index "
-        "for the bound project, then retry the query.",
+        "next_step": next_step,
+        "recovery_hint": next_step,
+        "suggested_tool": "index action=cache mode=index",
+        "agent_summary": {
+            "verdict": "ERROR",
+            "summary_line": "INDEX_NOT_READY: Build the index before querying symbols.",
+            "next_step": next_step,
+        },
     }

--- a/tree_sitter_analyzer/mcp/utils/auto_index_guard.py
+++ b/tree_sitter_analyzer/mcp/utils/auto_index_guard.py
@@ -184,3 +184,24 @@ def reset() -> None:
 
 def is_indexed(project_root: str) -> bool:
     return _indexed_roots.get(project_root, False)
+
+
+def empty_index_diagnostic(cache: Any) -> dict[str, Any]:
+    """仅诊断未初始化的空索引，不证明已有索引的完整性或新鲜度。"""
+    conn = cache.get_conn()
+    populated = conn.execute(
+        "SELECT EXISTS(SELECT 1 FROM ast_index) "
+        "OR EXISTS(SELECT 1 FROM ast_index_snapshot_manifest)"
+    ).fetchone()[0]
+    if populated or _call_graph_marker_is_current(cache):
+        return {}
+    return {
+        "success": False,
+        "verdict": "ERROR",
+        "error_code": "INDEX_NOT_READY",
+        "error": "INDEX_NOT_READY: No indexed files or completed indexing run. "
+        "An empty lookup cannot establish that the requested symbol is absent.",
+        "next_step": "From the project root, run tree-sitter-analyzer --ast-cache "
+        "--ast-cache-mode index --format json, or call index action=cache mode=index "
+        "for the bound project, then retry the query.",
+    }


### PR DESCRIPTION
On a fresh project containing authenticate_user, symbol search and normal nav context previously returned success=true / NOT_FOUND before an index existed. Both now return INDEX_NOT_READY with an executable index-build instruction. Successful searches and legitimate misses against initialized indexes retain their existing behavior, including indexed files with zero symbols and completed empty-project indexing.

The check runs only for empty lookup results and reads index records/initialization markers. It does not scan source, auto-build an index, or certify freshness/completeness; the read_existing context path is unchanged.

Validation: 137 focused tests passed with coverage; no added executable or partial-branch misses in the patch gate. Quick gate: 2,057 passed, 28 skipped in 28.05s. Real CLI smoke verified both queries exit 1 with INDEX_NOT_READY before indexing, the suggested command succeeds, and both queries exit 0 and find the function after indexing. Facade doc drift tests (3) and commit hooks passed.


MCP black-box follow-up: the old facade test treated an unindexed zero-match response as successful search. It now verifies an isolated fixture through cold error → matching top-level/nested recovery hints → MCP index build → exact symbol/file/line match. All 9 facade boundary tests pass. The full functional file has 16 passes and two project-health 20s timeouts; the same health timeout reproduces on baseline runtime with identical Python3.10/dependencies. No timeout was relaxed or test skipped. That existing health-performance issue remains tracked separately.
