### PR TITLE
fix: synchronize release registry versions and stop on sync failure

### DIFF
--- a/scripts/gitflow_release_automation.py
+++ b/scripts/gitflow_release_automation.py
@@ -191,8 +191,10 @@ class GitFlowReleaseAutomation:
                 )
                 print("Essential version synchronization completed successfully")
             except subprocess.CalledProcessError as e:
-                print(f"Warning: Version synchronization failed: {e}")
-                print("Continuing with release process...")
+                print(
+                    f"Version synchronization failed; release preparation stopped: {e}"
+                )
+                return False
 
             # Update CHANGELOG.md
             changelog_path = self.project_root / "CHANGELOG.md"
@@ -224,7 +226,9 @@ class GitFlowReleaseAutomation:
                 print("Updated CHANGELOG.md")
 
             # Commit changes
-            self.run_command(["git", "add", "pyproject.toml", "CHANGELOG.md"])
+            self.run_command(
+                ["git", "add", "pyproject.toml", "server.json", "CHANGELOG.md"]
+            )
             self.run_command(
                 ["git", "add", "tree_sitter_analyzer/"]
             )  # Add all updated __init__.py files

--- a/scripts/sync_version.py
+++ b/scripts/sync_version.py
@@ -9,6 +9,12 @@ It reads the version from pyproject.toml and updates all other locations.
 import re
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING or __package__:
+    from .sync_version_minimal import update_registry_version
+else:
+    from sync_version_minimal import update_registry_version
 
 
 class VersionSynchronizer:
@@ -102,6 +108,12 @@ class VersionSynchronizer:
         print(f"Synchronizing all versions to: {target_version}")
 
         updated_files = []
+        registry_changed, registry_message = update_registry_version(
+            target_version, project_root=self.project_root
+        )
+        print(registry_message)
+        if registry_changed:
+            updated_files.append("server.json")
 
         for file_name, patterns in self.version_patterns.items():
             file_path = self.project_root / file_name
@@ -121,6 +133,12 @@ class VersionSynchronizer:
         print(f"Checking version consistency (reference: {current_version})")
 
         inconsistent_files = []
+        registry_changed, registry_message = update_registry_version(
+            current_version, check_only=True, project_root=self.project_root
+        )
+        print(registry_message)
+        if registry_changed:
+            inconsistent_files.append("server.json")
 
         for file_name, patterns in self.version_patterns.items():
             file_path = self.project_root / file_name

--- a/scripts/sync_version_minimal.py
+++ b/scripts/sync_version_minimal.py
@@ -1,20 +1,13 @@
 #!/usr/bin/env python3
-"""
-Minimal Version Synchronization Script
+"""同步发布必需的版本元数据。
 
-This script only synchronizes version numbers in essential files:
-- pyproject.toml (source of truth)
-- pyproject.toml [tool.mcp].server_version (MCP metadata)
-- tree_sitter_analyzer/__init__.py (main package version)
-
-Other __init__.py files are left unchanged to reduce complexity.
-
-Usage:
-    python scripts/sync_version_minimal.py
-    python scripts/sync_version_minimal.py --check  # Only check, don't update
+以 pyproject.toml 的项目版本为准，更新 MCP 元数据、包 __init__.py，
+以及 server.json 的服务器版本和本项目 PyPI 包版本。
+--check 只检查；发现漂移时返回非零状态。
 """
 
 import argparse
+import json
 import re
 import sys
 from pathlib import Path
@@ -44,13 +37,12 @@ def get_version_from_pyproject() -> str:
 
 
 def get_essential_version_files() -> list[Path]:
-    """Get only essential files that need version synchronization"""
+    """列出必须存在的包版本文件；缺失由读取步骤报告。"""
     essential_files = [
         Path("tree_sitter_analyzer/__init__.py"),  # Main package version
     ]
 
-    # Only include files that exist
-    return [f for f in essential_files if f.exists()]
+    return essential_files
 
 
 def update_version_in_file(
@@ -77,15 +69,12 @@ def update_version_in_file(
             try:
                 file_path.write_text(new_content, encoding="utf-8")
                 return True, f"✅ Updated {file_path.relative_to(Path('.'))}"
-            except Exception as e:
-                return (
-                    False,
-                    f"❌ Failed to write {file_path.relative_to(Path('.'))}: {e}",
-                )
+            except OSError as e:
+                raise OSError(f"Failed to write {file_path}: {e}") from e
         else:
             return False, f"ℹ️  No changes needed in {file_path.relative_to(Path('.'))}"
     else:
-        return False, f"⚠️  No __version__ found in {file_path.relative_to(Path('.'))}"
+        raise ValueError(f"No __version__ found in {file_path}")
 
 
 def update_mcp_server_version(
@@ -103,7 +92,7 @@ def update_mcp_server_version(
 
     server_version_pattern = r'server_version\s*=\s*"([^"]+)"'
     if not re.search(server_version_pattern, content):
-        return False, "⚠️  No [tool.mcp].server_version found in pyproject.toml"
+        raise ValueError("No [tool.mcp].server_version found in pyproject.toml")
 
     new_content = re.sub(
         server_version_pattern, f'server_version = "{new_version}"', content
@@ -117,8 +106,38 @@ def update_mcp_server_version(
     return True, "✅ Updated pyproject.toml [tool.mcp].server_version"
 
 
-def check_versions(check_only: bool = False) -> None:
-    """Check and optionally update essential version numbers only"""
+def update_registry_version(
+    new_version: str, *, check_only: bool = False, project_root: Path = Path(".")
+) -> tuple[bool, str]:
+    """同步注册表中服务器和本项目的 PyPI 包版本，保留其他字段。"""
+    path = project_root / "server.json"
+    metadata = json.loads(path.read_text(encoding="utf-8"))
+    packages = [
+        package
+        for package in metadata["packages"]
+        if package.get("registryType") == "pypi"
+        and package.get("identifier") == "tree-sitter-analyzer"
+    ]
+    if not packages:
+        raise ValueError("server.json is missing the tree-sitter-analyzer PyPI package")
+    changed = metadata["version"] != new_version or any(
+        package["version"] != new_version for package in packages
+    )
+    if not changed:
+        return False, "No changes needed in server.json"
+    if check_only:
+        return True, "Would update server.json"
+    metadata["version"] = new_version
+    for package in packages:
+        package["version"] = new_version
+    path.write_text(
+        json.dumps(metadata, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    return True, "Updated server.json"
+
+
+def check_versions(check_only: bool = False) -> bool:
+    """检查或同步必需版本，返回是否无需更改。"""
     current_version = get_version_from_pyproject()
     print(f"📦 Current version in pyproject.toml: {current_version}")
 
@@ -126,6 +145,12 @@ def check_versions(check_only: bool = False) -> None:
     print(f"🔍 Found {len(essential_files)} essential version files")
 
     updated_files = []
+    registry_changed, registry_message = update_registry_version(
+        current_version, check_only=check_only
+    )
+    if registry_changed:
+        updated_files.append(Path("server.json"))
+    print(registry_message)
 
     server_success, server_message = update_mcp_server_version(
         current_version, check_only=check_only
@@ -159,6 +184,7 @@ def check_versions(check_only: bool = False) -> None:
 
     print("\n💡 This script only updates essential version files.")
     print("   For full synchronization, use: python scripts/sync_version.py")
+    return not updated_files
 
 
 def main():
@@ -173,7 +199,9 @@ def main():
     args = parser.parse_args()
 
     try:
-        check_versions(check_only=args.check)
+        consistent = check_versions(check_only=args.check)
+        if args.check and not consistent:
+            sys.exit(1)
     except Exception as e:
         print(f"❌ Minimal version synchronization failed: {e}")
         sys.exit(1)

--- a/server.json
+++ b/server.json
@@ -6,13 +6,13 @@
     "url": "https://github.com/aimasteracc/tree-sitter-analyzer",
     "source": "github"
   },
-  "version": "1.29.0",
+  "version": "1.29.5",
   "license": "MIT",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "tree-sitter-analyzer",
-      "version": "1.29.0",
+      "version": "1.29.5",
       "transport": {
         "type": "stdio"
       }

--- a/tests/governance/test_gitflow_contract.py
+++ b/tests/governance/test_gitflow_contract.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 
 import ast
 import configparser
+import json
 import os
 import re
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -141,3 +144,247 @@ def test_release_and_hotfix_finalize_prs_do_not_mask_closed_prs() -> None:
         assert "refusing to treat finalization as successful" in body, workflow_name
         assert "exit 1" in body, workflow_name
         assert "|| gh pr view" not in body, workflow_name
+
+
+def test_release_registry_versions_match_package_version() -> None:
+    """2026-09-09 发布审计：注册表不能继续指向旧 PyPI 版本。"""
+    project = tomllib.loads(
+        (PROJECT_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    )
+    registry = json.loads((PROJECT_ROOT / "server.json").read_text(encoding="utf-8"))
+    version = project["project"]["version"]
+    assert registry["version"] == version
+    assert [
+        package["version"]
+        for package in registry["packages"]
+        if package["registryType"] == "pypi"
+        and package["identifier"] == "tree-sitter-analyzer"
+    ] == [version]
+
+
+@pytest.fixture
+def version_sync_project(tmp_path: Path) -> Path:
+    """在隔离目录执行真实版本脚本，避免写入工作区。"""
+    (tmp_path / "scripts").mkdir()
+    for filename in ("sync_version.py", "sync_version_minimal.py"):
+        (tmp_path / "scripts" / filename).write_bytes(
+            (PROJECT_ROOT / "scripts" / filename).read_bytes()
+        )
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nversion = "1.29.5"\n[tool.mcp]\nserver_version = "1.29.5"\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "tree_sitter_analyzer").mkdir()
+    (tmp_path / "tree_sitter_analyzer" / "__init__.py").write_text(
+        '__version__ = "1.29.5"\n', encoding="utf-8"
+    )
+    (tmp_path / "server.json").write_text(
+        json.dumps(
+            {
+                "version": "1.29.5",
+                "description": "保留描述",
+                "packages": [
+                    {
+                        "registryType": "pypi",
+                        "identifier": "tree-sitter-analyzer",
+                        "version": "1.29.5",
+                        "transport": {"type": "stdio"},
+                    },
+                    {
+                        "registryType": "npm",
+                        "identifier": "other-tool",
+                        "version": "0.1.0",
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+@pytest.mark.parametrize("script", ["sync_version.py", "sync_version_minimal.py"])
+@pytest.mark.parametrize("field", ["server", "package"])
+def test_version_check_rejects_registry_drift_without_writing(
+    version_sync_project: Path, script: str, field: str
+) -> None:
+    """2026-09-09 发布审计：任一注册表版本漂移都必须让检查失败。"""
+    root = version_sync_project
+    path = root / "server.json"
+    metadata = json.loads(path.read_text(encoding="utf-8"))
+    target = metadata if field == "server" else metadata["packages"][0]
+    target["version"] = "1.29.0"
+    path.write_text(json.dumps(metadata), encoding="utf-8")
+    before = path.read_bytes()
+    result = subprocess.run(
+        [sys.executable, str(root / "scripts" / script), "--check"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        encoding="utf-8",
+        env={**os.environ, "PYTHONIOENCODING": "utf-8"},
+    )
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert path.read_bytes() == before
+
+
+@pytest.mark.parametrize("script", ["sync_version.py", "sync_version_minimal.py"])
+def test_version_sync_updates_only_owned_registry_versions(
+    version_sync_project: Path, script: str
+) -> None:
+    """同步两个归属版本，保留其他包和元数据，再次同步不改字节。"""
+    root = version_sync_project
+    path = root / "server.json"
+    expected = json.loads(path.read_text(encoding="utf-8"))
+    stale = json.loads(path.read_text(encoding="utf-8"))
+    stale["version"] = "1.29.0"
+    stale["packages"][0]["version"] = "1.29.1"
+    path.write_text(json.dumps(stale), encoding="utf-8")
+    command = [sys.executable, str(root / "scripts" / script)]
+    synchronized_bytes = None
+    for args in (command, command + ["--check"], command):
+        result = subprocess.run(
+            args,
+            cwd=root,
+            capture_output=True,
+            text=True,
+            timeout=15,
+            encoding="utf-8",
+            env={**os.environ, "PYTHONIOENCODING": "utf-8"},
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert json.loads(path.read_text(encoding="utf-8")) == expected
+        if synchronized_bytes is None:
+            synchronized_bytes = path.read_bytes()
+        else:
+            assert path.read_bytes() == synchronized_bytes
+    assert (
+        path.read_text(encoding="utf-8")
+        == json.dumps(expected, indent=2, ensure_ascii=False) + "\n"
+    )
+
+
+@pytest.mark.parametrize("script", ["sync_version.py", "sync_version_minimal.py"])
+def test_version_sync_rejects_missing_registry_package(
+    version_sync_project: Path, script: str
+) -> None:
+    """缺失本项目包时同步失败，不能输出成功却留下不完整注册表。"""
+    root = version_sync_project
+    path = root / "server.json"
+    metadata = json.loads(path.read_text(encoding="utf-8"))
+    metadata["packages"] = metadata["packages"][1:]
+    path.write_text(json.dumps(metadata), encoding="utf-8")
+    before = path.read_bytes()
+    result = subprocess.run(
+        [sys.executable, str(root / "scripts" / script)],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        encoding="utf-8",
+        env={**os.environ, "PYTHONIOENCODING": "utf-8"},
+    )
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert path.read_bytes() == before
+
+
+@pytest.mark.parametrize("sync_succeeds", [False, True])
+def test_release_preparation_requires_synced_and_staged_registry(
+    version_sync_project: Path, monkeypatch: pytest.MonkeyPatch, sync_succeeds: bool
+) -> None:
+    """2026-09-09 发布审计：同步失败停止准备；成功时提交注册表。"""
+    from unittest.mock import Mock
+
+    from scripts.gitflow_release_automation import GitFlowReleaseAutomation
+
+    root = version_sync_project
+    changelog = root / "CHANGELOG.md"
+    changelog.write_text("# Changelog\n", encoding="utf-8")
+    release = GitFlowReleaseAutomation("v1.29.5")
+    release.project_root = root
+    run_git = Mock(
+        return_value=subprocess.CompletedProcess([], 0, stdout="", stderr="")
+    )
+    monkeypatch.setattr(release, "run_command", run_git)
+    sync = Mock(
+        return_value=subprocess.CompletedProcess([], 0),
+        side_effect=None if sync_succeeds else subprocess.CalledProcessError(1, "sync"),
+    )
+    monkeypatch.setattr("scripts.gitflow_release_automation.subprocess.run", sync)
+    assert release.create_release_branch() is sync_succeeds
+    sync.assert_called_once_with(
+        ["uv", "run", "python", "scripts/sync_version_minimal.py"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    commands = [call.args[0] for call in run_git.call_args_list]
+    expected = [["git", "checkout", "-b", "release/v1.29.5"]]
+    if sync_succeeds:
+        expected.extend(
+            [
+                ["git", "add", "pyproject.toml", "server.json", "CHANGELOG.md"],
+                ["git", "add", "tree_sitter_analyzer/"],
+                ["git", "commit", "-m", "chore: Prepare release v1.29.5"],
+            ]
+        )
+    else:
+        assert changelog.read_text(encoding="utf-8") == "# Changelog\n"
+    assert commands == expected
+
+
+@pytest.mark.parametrize("check_only", [False, True])
+@pytest.mark.parametrize("missing", ["package_file", "package_version", "mcp_version"])
+def test_essential_version_sync_rejects_missing_version_fields(
+    version_sync_project: Path, missing: str, check_only: bool
+) -> None:
+    """必需文件或版本字段缺失时，同步和检查都不能报告成功。"""
+    root = version_sync_project
+    package = root / "tree_sitter_analyzer" / "__init__.py"
+    if missing == "package_file":
+        package.unlink()
+    elif missing == "package_version":
+        package.write_text("", encoding="utf-8")
+    else:
+        (root / "pyproject.toml").write_text(
+            '[project]\nversion = "1.29.5"\n[tool.mcp]\n', encoding="utf-8"
+        )
+    command = [sys.executable, str(root / "scripts" / "sync_version_minimal.py")]
+    if check_only:
+        command.append("--check")
+    result = subprocess.run(
+        command,
+        cwd=root,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        encoding="utf-8",
+        env={**os.environ, "PYTHONIOENCODING": "utf-8"},
+    )
+    assert result.returncode == 1, result.stdout + result.stderr
+
+
+def test_essential_version_sync_propagates_package_write_failure(
+    version_sync_project: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """包版本写入失败必须向发布调用方传播，不能被当作无需同步。"""
+    from scripts.sync_version_minimal import check_versions
+
+    root = version_sync_project
+    package = root / "tree_sitter_analyzer" / "__init__.py"
+    package.write_text('__version__ = "1.29.0"\n', encoding="utf-8")
+    before = package.read_bytes()
+    monkeypatch.chdir(root)
+    write_text = Path.write_text
+
+    def deny_package_write(path: Path, *args: object, **kwargs: object) -> int:
+        if path.name == "__init__.py":
+            raise PermissionError("package write denied")
+        return write_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", deny_package_write)
+    with pytest.raises(OSError, match="Failed to write.*package write denied"):
+        check_versions()
+    assert package.read_bytes() == before


### PR DESCRIPTION
server.json still advertised version 1.29.0 while the package was 1.29.5, and both version synchronizers ignored the registry. Synchronize the registry server and owned PyPI package fields through the existing sync/check commands, preserving unrelated metadata. No new release version is selected.

Minimal --check now fails on drift or missing essential version fields/files; write failures propagate. Release preparation stops on synchronization failure and stages server.json on success, preventing a successful preparation with stale registry metadata.

Validation: 164 focused tests; 2,071 quick-gate tests passed (28 skipped, 26.48s). Real isolated CLI subprocess tests cover drift rejection without writes, synchronization, byte-level idempotence and missing-field failures. Direct script coverage measured all 46 added executable lines with no misses or missing branch sources. Both real version-check commands, the standard patch gate and all applicable commit hooks passed. Nothing was published.
