### PR TITLE
docs: align architecture and formatter maps with current surface

### DIFF
--- a/docs/CODEMAPS/architecture.md
+++ b/docs/CODEMAPS/architecture.md
@@ -15,7 +15,7 @@ tree_sitter_analyzer/
 │   ├── utils/        ← project_index, search_cache, file_output_factory
 │   └── resources/    ← MCP resources (read-only data exposed to AI)
 ├── languages/        ← 22 tree-sitter plugins                (languages.md)
-├── formatters/       ← TOON / JSON / table / CSV / YAML      (formatters.md)
+├── formatters/       ← JSON + explicit table/text views     (formatters.md)
 ├── core/             ← Parser, engine, AnalysisSession, AnalysisRequest
 ├── models/           ← AnalysisResult + Class/Function/Variable/Import models
 ├── plugins/          ← LanguagePlugin / ElementExtractor base + registry
@@ -48,7 +48,7 @@ languages/<lang>_plugin.analyze_file ← tree-sitter parse + extract elements
   ↓
 models.AnalysisResult               ← Class/Function/Variable/Import/Annotation
   ↓
-formatters/<fmt>_formatter          ← TOON (default for MCP) / JSON / table
+formatters/<fmt>_formatter          ← JSON / explicit terminal table views
   ↓
 agent_summary envelope              ← verdict (SAFE/REVIEW/CAUTION/UNSAFE)
   ↓
@@ -62,7 +62,9 @@ Every path is validated against `TREE_SITTER_PROJECT_ROOT` by `security/validato
 **No tool ever reads outside the project root.** `ProjectBoundaryManager` is the single source of truth.
 
 ### Response format
-- **JSON** is the only MCP and CLI response format. There is no alternate compact wire encoding.
+- **JSON** is the canonical MCP and CLI machine-readable response format.
+  CLI terminal views remain available through `--table full`, `--table signatures`,
+  and command-specific text output. There is no alternate compact wire encoding.
 - AST results are stored in **SQLite** via `ast_cache.py` (content-hash keyed).
 - `incremental_sync.py` reindexes only changed files (mtime + SHA-256).
 - `indexing_snapshot.py` freezes one ordered project scope for both full-index
@@ -98,10 +100,12 @@ POSIX 发布包含文件与目录同步；Windows 目录掉电持久性仍不作
 1. `ast_cache.py` — persistent SQLite store of parsed AST symbols/imports/structure
 2. `_route_cache.py` — SQLite store of detected routes (Flask/Django/Express/Spring)
 3. `core/cache_service.py` — in-process LRU for formatter outputs
-4. `mcp/utils/search_cache.py` — fd/ripgrep result cache
-5. `registry/health_score_cache.py` — persistent per-file health scores keyed by
+4. `registry/health_score_cache.py` — persistent per-file health scores keyed by
    source fingerprint plus coverage, weights, moving-window, repository-specific
    git metadata, and scoring-version context
+
+`mcp/utils/search_cache.py` remains in the source tree, but has no production
+callers; it is not an active caching layer for the current search tools.
 
 ### MCP / CLI parity
 Every MCP tool has a CLI equivalent — enforced by `tests/contracts/test_mcp_cli_parity_contract.py`
@@ -112,11 +116,17 @@ contract violation.**
 
 | Surface | Module | Notes |
 |---|---|---|
-| `tree-sitter-analyzer` CLI | `cli_main.py` → `cli/` | Human-facing, JSON default |
+| `tree-sitter-analyzer` CLI; `code-analyzer` / `java-analyzer` aliases | `cli_main.py` → `cli/` | Human-facing, JSON default |
 | `tree-sitter-analyzer-mcp` MCP stdio server | `mcp/server.py` | AI-agent-facing, JSON output |
+| `tree-sitter-analyzer-doctor` | `cli_main.py:main_doctor` | Environment diagnostics |
 | `miswire-audit` | `miswire_audit.py` | Run-on-your-repo cross-language correctness demo |
-| `list-files` / `search-content` / `find-and-grep` | `cli/commands/*_cli.py` | fd / ripgrep / fd+rg standalone utilities |
+| `list-files` | `cli/commands/list_files_cli.py` | Retained fd-based file listing |
 | Python API (no console script) | `api/__init__.py` | Authoritative implementation of the existing `tree_sitter_analyzer.api` API; Pulse/serialization/semantic live in explicit submodules |
+
+The `search-content` and `find-and-grep` console scripts have been removed.
+The current facades still expose `search.batch` (ripgrep), `project.files` (fd),
+and `project.tools` (availability checks); their removal is not part of this surface.
+See [CLI](cli.md) and [MCP tools](mcp-tools.md) for the complete action mapping.
 
 The former sibling `api.py` has been removed. Existing Python imports and public
 function signatures remain unchanged; consumers must not load the removed file
@@ -179,7 +189,7 @@ has no winner or dominance/unlock authority.
 
 ## Critical Invariants (do NOT change without reading [`CLAUDE.md`](../../CLAUDE.md))
 
-1. **MCP and CLI `output_format` = `"json"`** — locked. One response contract serves agents, humans, and `jq`.
+1. **MCP and CLI machine-readable output = JSON** — locked. Explicit terminal views are documented separately in [CLI](cli.md).
 3. **`project_root` resolution must NOT be naively re-canonicalised in `BaseMCPTool.__init__`** — `SecurityValidator`, `PathResolver`, and the test fixtures already agree on a `Path.resolve()` (realpath) resolution; the macOS `/var → /private/var` symlink means a mismatched re-canonicalisation diverges. r36's attempt broke 164 tests on macOS (rolled back).
 4. **CLI diagnostic output → stderr; payload → stdout** — never mix.
 5. **markdown files** are NOT scored by `project_health` — use `markdown_health` for that.

--- a/docs/CODEMAPS/formatters.md
+++ b/docs/CODEMAPS/formatters.md
@@ -1,17 +1,26 @@
 <!-- Generated: 2026-05-30; doc-code re-sync: 2026-06-17 -->
 # Formatters Codemap
 
-Output formats supported by both CLI and MCP. Located in `tree_sitter_analyzer/formatters/`.
+JSON response formatting and explicit terminal views. Located in
+`tree_sitter_analyzer/formatters/`; a language formatter name describes its input
+language, not an additional MCP or CLI wire encoding.
 
 ## Format Registry
 
 | Format | Module | Default for | Use case |
 |---|---|---|---|
-| `json` | `formatters/json_formatter.py` | **MCP + CLI** | Canonical structured response format; `jq`-friendly programmatic ingestion |
-| `table` | `formatters/table_formatter.py` (canonical, re-exports `LegacyTableFormatter`) + `tree_sitter_analyzer/default_table_formatter.py` + `legacy_table_formatter.py` | `--table` flag | Terminal viewing with box-drawing chars |
-| `csv` | via `tree_sitter_analyzer/_legacy_table_formatter_csv.py` | `--table csv` | Spreadsheet ingestion |
-| `signatures` | `formatters/_java_formatter_signatures_mixin.py` (Java); `formatters/_python_formatter_signatures_table.py` (Python); `formatters/_typescript_formatter_signatures_table.py` (TypeScript); `default_table_formatter.py` (fallback) | `--table signatures` | Lightweight method-directory for large files — ~25-80% of full tokens; agent-first, then `--partial-read` for bodies |
-| `yaml` | `formatters/yaml_formatter.py` | explicit `--format yaml` | Human-readable structured |
+| `json` | Standard JSON serialization; `mcp/server_utils/tool_registration.py` serializes MCP results | **MCP + CLI** | Canonical structured response format; `jq`-friendly programmatic ingestion |
+| `full` table | `formatters/table_formatter.py` (canonical, re-exports `LegacyTableFormatter`) + `tree_sitter_analyzer/default_table_formatter.py` + `legacy_table_formatter.py` | `--table full` | Terminal structure view |
+| `signatures` | `formatters/_java_formatter_signatures_mixin.py` (Java); `formatters/_python_formatter_signatures_table.py` (Python); `formatters/_typescript_formatter_signatures_table.py` (TypeScript); `default_table_formatter.py` (fallback) | `--table signatures` | Method directory; use `--partial-read` for bodies |
+
+The generic `FormatterRegistry` registers exactly `json` and `full`; these
+`CodeElement` formatters are separate from the language-specific table registry.
+The main CLI accepts only `--format json` and `--table {full,signatures}`.
+Command-specific `--output-format` also permits `text`; CSV, YAML, and compact
+are not CLI format choices.
+`formatters/json_formatter.py` and `formatters/yaml_formatter.py` format analysis
+of JSON and YAML source files respectively; the latter does not provide a
+`--format yaml` response encoding.
 
 ## Why JSON for MCP and CLI?
 
@@ -32,12 +41,11 @@ Interfaces live in `formatters/_formatter_interface.py` (no upward imports — b
 
 | Interface | Implementors | Purpose |
 |---|---|---|
-| `IFormatter` | `HtmlFormatter`, `JsonFormatter`, `CsvFormatter`, … | `format(elements)` → str |
+| `IFormatter` | `HtmlFormatter`, `JsonFormatter`, `FullFormatter`, … | `format(elements)` → str |
 | `IStructureFormatter` | legacy adapters | `format_structure(dict)` → str |
 
 `formatters/formatter_registry.py` re-exports both for backward compat.
-Generic `CodeElement` implementations (`JsonFormatter`, `CsvFormatter`,
-`FullFormatter`, and `CompactFormatter`) live in
+Generic `CodeElement` implementations (`JsonFormatter` and `FullFormatter`) live in
 `formatters/_builtin_formatters.py`; the registry remains their stable import
 facade. `formatters/_language_formatter_registration.py` owns bundled-language
 registration and defers only the legacy default formatter during circular
@@ -48,7 +56,7 @@ the language-specific registry.
 
 ## Formatter Architecture
 
-Each formatter inherits from `formatters/base_formatter.py`:
+Language formatters use `formatters/base_formatter.py`:
 
 ```python
 class BaseFormatter(ABC):
@@ -59,10 +67,9 @@ class BaseFormatter(ABC):
     def format_table(self, ...) -> str: ...
 
 class BaseTableFormatter(BaseFormatter):
-    # table-flavour helpers live here, not on BaseFormatter
+    # 表格辅助方法位于此处；紧凑摘要方法仅为子类兼容保留。
     def _format_full_table(self, ...) -> str: ...
     def _format_compact_table(self, ...) -> str: ...
-    def _format_csv(self, ...) -> str: ...
 ```
 
 Per-language formatter mixins live alongside (`_java_formatter_*_mixin.py`,
@@ -70,16 +77,17 @@ Per-language formatter mixins live alongside (`_java_formatter_*_mixin.py`,
 classes via Python's MRO.
 
 Standalone per-language formatters (self-contained, no mixin composition):
-- `formatters/go_formatter.py` — `GoTableFormatter`; full/compact/csv/json; renders
+- `formatters/go_formatter.py` — `GoTableFormatter`; full-table and JSON rendering;
+  retains an internal compact summary method. The full table renders
   `| Func | Signature | Vis | Lines | Cx | Doc |` (functions) and
   `| Receiver | Func | Signature | Vis | Lines | Cx | Doc |` (methods)
 - `formatters/bash_formatter.py` — `BashTableFormatter`; registered for "bash" / "sh";
-  renders `| Name | Signature | Vis | Lines | Cx | Doc |` (full) and
-  `| Name | Sig | V | L | Cx | Doc |` (compact)
+  renders `| Name | Signature | Vis | Lines | Cx | Doc |` in the full table;
+  also retains an internal compact summary method. These summary methods do
+  not restore a public `--table compact` choice.
 
 Key mixins for the Java formatter:
 - `formatters/_java_formatter_full_mixin.py` — `_format_full_table`
-- `formatters/_java_formatter_compact_mixin.py` — `_format_compact_table`
 - `formatters/_java_formatter_signatures_mixin.py` — `_format_signatures_table` (lightweight
   method-directory; lists methods as `name →returnType(Np) L-L`, no bodies)
 
@@ -102,23 +110,9 @@ TS/JS full-table module-level functions:
   methods). JS reads both `methods` (class methods) and `functions` (top-level)
   since the JS plugin stores them in disjoint lists.
 
-## CSV Control-Char Safety
-
-`formatters/_csv_safety.py` (`csv_safe_row` / `csv_safe_cell`) strips
-C0/DEL control characters (NULL etc.) from CSV cells before they reach
-`csv.writer`. Python 3.10's `csv.writer` raises `_csv.Error: need to escape,
-but no escapechar set` on a NULL byte; setting `escapechar` would silence it
-but double literal backslashes in ordinary fields (a format regression). Tab
-and newline are preserved (the writer quotes them on every version); a bare
-carriage return is **stripped** because Python 3.10 emits it unquoted, yielding
-an unreadable CSV. Used by `CsvFormatter`, `format_html_csv`, and
-`format_csv_output`.
-
 ## JSON Format
 
 JSON emits a standard structured object with stable field names and nested response data.
-
-<!-- Legacy compact-format implementation removed; historical references belong in changelog/postmortems only. -->
 
 JSON example:
 
@@ -131,7 +125,7 @@ JSON example:
 ```
 
 The JSON serializer is the sole wire-format implementation. Language-specific
-formatters remain available for explicit terminal table/CSV views.
+formatters remain available for explicit terminal table views.
 
 ## Format Stability Contract
 
@@ -145,7 +139,6 @@ major version bump (semver).
 
 ## Cache & File Output
 
-- `mcp/utils/search_cache.py` — LRU for fd/ripgrep results (in-process)
 - `mcp/utils/file_output_factory.py` — atomic write for large payloads
 - `TREE_SITTER_OUTPUT_PATH` env var sets the default output directory
 
@@ -158,8 +151,6 @@ extracted from the monolithic `legacy_table_formatter.py`:
 |---|---|
 | `formatters/legacy/__init__.py` | Re-exports the public `LegacyTableFormatter` surface |
 | `formatters/legacy/common.py` | Shared constants and helper types used across legacy modules |
-| `formatters/legacy/compact.py` | `_format_compact_table` implementation for the legacy formatter |
-| `formatters/legacy/csv.py` | `_format_csv` implementation for the legacy formatter |
 | `formatters/legacy/detail.py` | Detail-row rendering helpers |
 | `formatters/legacy/full.py` | `_format_full_table` implementation for the legacy formatter |
 | `formatters/legacy/helpers.py` | General rendering helpers (column widths, header lines, etc.) |


### PR DESCRIPTION
The architecture and formatter codemaps still advertised TOON as the MCP default, removed search console scripts, and CSV/compact/YAML CLI formats. Align these existing maps with the current JSON contract, seven console entry points, and full/signatures terminal views.

Clarify that JSON/YAML language formatters describe input languages, remove references to deleted formatter modules, and distinguish the unused search-cache module from active caching layers. Retained search.batch and project.files/tools remain documented. This changes only two existing codemaps; no runtime code, version, or pending removal scope changes.

Validation:
- TSA structure query inspected the formatter registry; change-impact classified both changes as docs_only and prescribed git diff --check (passed).
- Actual registry/parser/facade assertions verified json/full, CLI choices, all seven console scripts, retained wrapper actions, and all 26 concrete formatter source paths referenced by the map.
- Existing codemap-sync-check.sh --self-check passed: exact MCP/CLI extraction, zero unwatched flags.
- All applicable commit hooks passed. Per the docs-only verification contract, pytest was not required.
