### PR TITLE
test: observe permanent-source retry decisions directly

### DIFF
--- a/tests/unit/test_incremental_sync.py
+++ b/tests/unit/test_incremental_sync.py
@@ -2861,18 +2861,18 @@ def test_watcher_retry_backoff_preserves_pending_file_notification(
 
 def test_watcher_does_not_retry_permanently_oversized_source(tmp_path):
     # #1405：永久超过字节上限不能启动无意义的后台重试。
+    # 2026-09-09：直接观察重试请求，避免把首轮同步未结束误判成已安排重试。
     from tree_sitter_analyzer.file_watcher import FileWatcherDaemon
 
     with (tmp_path / "a.py").open("wb") as source:
         source.truncate(64 * 1024 * 1024 + 1)
     cache = ASTCache(str(tmp_path))
-    results = []
-    watcher = FileWatcherDaemon(cache, debounce=0, on_sync=results.append)
+    watcher = FileWatcherDaemon(cache, debounce=0)
     try:
-        watcher._request_sync()
-        watcher._debounce_timer.join(timeout=3)
-        assert watcher.is_running() is False
-        assert [result["completeness"] for result in results] == ["incomplete"]
+        with patch.object(watcher, "_request_sync") as request_sync:
+            result = watcher.trigger_sync()
+        request_sync.assert_not_called()
+        assert result["completeness"] == "incomplete"
     finally:
         watcher.stop(timeout=3)
         cache.close()


### PR DESCRIPTION
The oversized-source retry test could fail when the first synchronization took longer than its three-second join. It used daemon liveness to infer that a retry had been scheduled, although liveness also includes the still-running first timer. This caused the Windows 3.13 failure in final-candidate CI run 34350502071, job 102462571383.

The existing test now executes the real synchronization synchronously and directly asserts that no retry is requested and completeness remains incomplete. Production watcher code and all test budgets remain unchanged; existing active-timer ownership tests retain lifecycle coverage. A controlled delayed-first-sync reproduction proves the old observation can fail without any retry; it does not identify the Windows runner's internal slow function.

Validation: TSA's recommended incremental-sync file passed 127 tests with coverage. The focused retry/lifecycle pair passed. A process-local negative mutation removing permanent-source rejection classification caused the new assertion to fail on exactly one retry=True request. Patch coverage and all applicable commit hooks passed. The CI failure classifier rejected a budget-only rerun, so this change addresses the test's actual predicate instead.
