### PR TITLE
fix: execute explicitly selected pytest tiers in verification plans

### DIFF
--- a/docs/CODEMAPS/cli.md
+++ b/docs/CODEMAPS/cli.md
@@ -163,6 +163,10 @@ uv run python -m tree_sitter_analyzer --change-impact --format json
 
 The command is tailored to the change: `pytest <specific tests>`, `mypy <touched module>`,
 or `git diff --check` for non-code edits.
+For explicit pytest targets, a known project exclusion such as `not slow` is
+lifted for the `e2e`, `slow`, and `full_language` tiers. Network, benchmark, and
+unknown exclusions remain in force. Unsupported or ambiguous configuration
+keeps its original selection policy; the default quick gate stays unchanged.
 For interactive agent work on a user's machine, add
 `--change-impact-resource-profile local_low_impact`; the local
 `verification_command` is capped with `nice -n 15` and `pytest -n 2`, while

--- a/tests/unit/mcp/test_change_impact_tool_execute_and_mapping.py
+++ b/tests/unit/mcp/test_change_impact_tool_execute_and_mapping.py
@@ -246,8 +246,8 @@ def test_execute_supports_agent_summary_only(monkeypatch):
     assert "test_mapping" not in result
 
 
-def test_execute_test_only_diff_skips_expensive_analysis(monkeypatch):
-    """Changed test files are exact targets; no graph/cache walk is needed."""
+def test_execute_test_only_diff_skips_expensive_analysis(monkeypatch, tmp_path):
+    """测试文件是精确目标；在独立项目验证快路径，避免继承 TSA 自身配置。"""
     monkeypatch.setattr(
         tool_module,
         "_get_changed_files",
@@ -272,7 +272,7 @@ def test_execute_test_only_diff_skips_expensive_analysis(monkeypatch):
         fail_expensive_path,
     )
 
-    tool = tool_module.ChangeImpactTool()
+    tool = tool_module.ChangeImpactTool(project_root=str(tmp_path))
     result = asyncio.run(
         tool.execute(
             {

--- a/tests/unit/mcp/test_safe_to_edit_tool_commands.py
+++ b/tests/unit/mcp/test_safe_to_edit_tool_commands.py
@@ -147,7 +147,9 @@ def test_certified_commands_use_extension_runner(tmp_path: Path) -> None:
     assert "uv run pytest" in str(py_workflow.get("after_edit_commands", []))
 
 
-def test_certified_commands_ignore_live_config_files(tmp_path: Path) -> None:
+def test_certified_commands_ignore_live_config_files(
+    tmp_path: Path, monkeypatch
+) -> None:
     """Codex P2 第六轮（C28）：认证清单和工作流使用 analyzer 的 pytest 默认值，不能读取未纳入清单的实时配置文件。"""
     from tree_sitter_analyzer.mcp.tools.utils.safe_to_edit_helpers import (
         AgentWorkflowContext,
@@ -172,6 +174,14 @@ def test_certified_commands_ignore_live_config_files(tmp_path: Path) -> None:
         )
     )
     assert "npm test" in str(live_workflow.get("after_edit_commands", []))
+
+    (tmp_path / "pytest.ini").write_text(
+        "[pytest]\naddopts = -m 'not e2e'\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        "tree_sitter_analyzer.mcp.tools.utils.verification_pytest_config.targeted_marker_expression",
+        lambda *_: pytest.fail("认证路径不得读取实时 pytest 配置"),
+    )
 
     certified_workflow = build_agent_workflow(
         AgentWorkflowContext(

--- a/tests/unit/mcp/test_verification_command.py
+++ b/tests/unit/mcp/test_verification_command.py
@@ -11,6 +11,25 @@ from tree_sitter_analyzer.mcp.tools.utils.verification_command import (
 )
 
 
+@pytest.mark.parametrize("argument", ["", "x", " ", "'", '"', "\\", '\\" ', "路", "🙂"])
+def test_argument_budget_matches_full_platform_serialization(argument):
+    """2026-09-09：累加预算必须与两种平台的完整转义结果完全一致。"""
+    import shlex
+    import subprocess
+
+    from tree_sitter_analyzer.mcp.tools.utils.verification_command import (
+        _argv_within_budget,
+    )
+
+    for count in [0, 1, 20, 5990, 6000, 6001]:
+        argv = ["uv", "run", "pytest", argument * count, "-q"] if count else []
+        expected = (
+            len(shlex.join(argv).encode("utf-8")) <= 6000
+            and len(subprocess.list2cmdline(argv).encode("utf-16-le")) // 2 + 1 <= 6000
+        )
+        assert _argv_within_budget(argv) is expected
+
+
 @pytest.mark.parametrize("error", [OSError("loop"), RuntimeError("loop")])
 def test_target_resolution_failure_preserves_default_policy(
     tmp_path, monkeypatch, error

--- a/tests/unit/mcp/test_verification_command.py
+++ b/tests/unit/mcp/test_verification_command.py
@@ -11,6 +11,35 @@ from tree_sitter_analyzer.mcp.tools.utils.verification_command import (
 )
 
 
+@pytest.mark.parametrize("error", [OSError("loop"), RuntimeError("loop")])
+def test_target_resolution_failure_preserves_default_policy(
+    tmp_path, monkeypatch, error
+):
+    """2026-09-09：跨 Python 版本的链接环异常不能使验证命令生成崩溃。"""
+    from pathlib import Path
+
+    from tree_sitter_analyzer.mcp.tools.utils import (
+        verification_pytest_config as config,
+    )
+
+    class UnresolvablePath(type(tmp_path)):
+        def resolve(self, *args, **kwargs):
+            if self.name == "test_loop.py":
+                raise error
+            return self
+
+    monkeypatch.setattr(config, "Path", UnresolvablePath)
+    default = DefaultTestCommand(
+        "pytest",
+        "uv run pytest -q",
+        "not network and not benchmark",
+        str(Path(tmp_path)),
+    )
+    assert (
+        build_test_command(default, ["test_loop.py"]) == "uv run pytest test_loop.py -q"
+    )
+
+
 def test_detect_default_test_command_falls_back_to_pytest(tmp_path):
     """Unknown or Python-style projects should keep the repo's pytest contract."""
     assert detect_default_test_command(tmp_path) == DefaultTestCommand(

--- a/tests/unit/test_change_impact_analysis.py
+++ b/tests/unit/test_change_impact_analysis.py
@@ -20,6 +20,72 @@ from tree_sitter_analyzer.mcp.tools.utils.change_impact_analysis import (
 )
 
 
+@pytest.mark.parametrize(
+    "name,content,expected",
+    [
+        (
+            "pytest.ini",
+            "[pytest]\naddopts = -m 'not slow and not network'",
+            "not network and not benchmark",
+        ),
+        (
+            ".pytest.ini",
+            "[pytest]\naddopts = -m 'not e2e and not custom'",
+            "not custom and not network and not benchmark",
+        ),
+        (
+            "tox.ini",
+            "[pytest]\naddopts = -m 'not full_language and not benchmark'",
+            "not benchmark and not network",
+        ),
+        (
+            "setup.cfg",
+            "[tool:pytest]\naddopts = -m 'not slow'",
+            "not network and not benchmark",
+        ),
+        (
+            "pyproject.toml",
+            '[tool.pytest.ini_options]\naddopts = ["-m", "not slow"]',
+            "not network and not benchmark",
+        ),
+        (
+            "pytest.ini",
+            "[pytest]\naddopts = -m'not slow'",
+            "not network and not benchmark",
+        ),
+        ("pytest.ini", "[pytest]\naddopts = -m 'not custom'", None),
+        ("pytest.ini", "[pytest]\naddopts = -m 'not slow or unit'", None),
+        ("pytest.ini", "[pytest]\naddopts = -m 'unit and not slow'", None),
+        ("pytest.ini", "[pytest]\naddopts = -m", None),
+        ("pytest.ini", "[pytest]\naddopts = -m 'not slow' -c other.ini", None),
+        ("pytest.ini", "[pytest]\naddopts = -m 'not slow' -o addopts=-q", None),
+        ("pytest.ini", "[pytest]\naddopts = 'unclosed", None),
+        ("pytest.ini", "invalid ini", None),
+        ("pytest.ini", "[other]\naddopts = -m 'not slow'", None),
+        ("tox.ini", "[other]\naddopts = -m 'not slow'", None),
+        ("pytest.ini", "[pytest]", None),
+        ("pyproject.toml", "[project]\nname='fixture'", None),
+        ("pyproject.toml", "invalid toml", None),
+        ("pyproject.toml", "[tool.pytest.ini_options]\naddopts=[1]", None),
+        ("pyproject.toml", "[tool]\npytest=1", None),
+        ("pyproject.toml", "[tool.pytest]\nini_options=1", None),
+    ],
+)
+def test_project_pytest_selection_preserves_unknown_policy(
+    tmp_path, monkeypatch, name, content, expected
+):
+    """2026-09-09：只解除明确的常规层级排除，不能猜测自定义测试策略。"""
+    from tree_sitter_analyzer.mcp.tools.utils.verification_command import (
+        detect_default_test_command,
+    )
+
+    monkeypatch.delenv("PYTEST_ADDOPTS", raising=False)
+    (tmp_path / name).write_text(content, encoding="utf-8")
+    command = detect_default_test_command(tmp_path)
+    assert command.pytest_marker == expected
+    assert command.command == "uv run pytest -q"
+
+
 class TestChangeImpactRequest:
     def test_construction(self):
         req = ChangeImpactRequest(

--- a/tests/unit/test_verification_plan.py
+++ b/tests/unit/test_verification_plan.py
@@ -238,7 +238,8 @@ def test_ten_thousand_targets_do_not_expand_launcher(tmp_path):
     assert targets == request.changed_files
 
 
-def test_low_impact_prefix_rebatches_near_limit_targets(monkeypatch):
+@pytest.mark.parametrize("marker", [None, "not network and not benchmark"])
+def test_low_impact_prefix_rebatches_near_limit_targets(monkeypatch, marker):
     from types import SimpleNamespace
 
     from tree_sitter_analyzer import verification_plan
@@ -247,13 +248,19 @@ def test_low_impact_prefix_rebatches_near_limit_targets(monkeypatch):
     )
 
     monkeypatch.setattr(verification_plan, "sys", SimpleNamespace(platform="linux"))
-    prefix = "tests/" + "/".join(["x" * 50] * 57) + "/" + "x" * 60
+    prefix = (
+        "tests/"
+        + "/".join(["x" * 50] * 57)
+        + "/"
+        + "x" * (60 if marker is None else 43)
+    )
     targets = [prefix + f"/test_{suffix}.py" for suffix in ("a", "b")]
     context = SimpleNamespace(
         verification={
             "test_runner": "pytest",
             "default_test_command": "uv run pytest -q",
             "test_required": True,
+            "_pytest_marker": marker,
         },
         all_tests=targets,
         test_mapping={"a.py": targets},
@@ -269,6 +276,34 @@ def test_low_impact_prefix_rebatches_near_limit_targets(monkeypatch):
         if arg.startswith("tests/")
     ] == targets
     assert all(_argv_within_budget(step["argv"]) for step in stages["verification"])
+    if marker:
+        assert [step["argv"][6:8] for step in stages["verification"]] == [
+            ["-m", marker]
+        ] * 2
+
+
+def test_marker_policy_changes_invalidate_replayed_plan(tmp_path, monkeypatch):
+    """2026-09-09：重放必须绑定定向筛选策略，不能采用变化后的配置。"""
+    monkeypatch.delenv("PYTEST_ADDOPTS", raising=False)
+    config = tmp_path / "pytest.ini"
+    config.write_text(
+        "[pytest]\naddopts = -m 'not slow and not custom'\n", encoding="utf-8"
+    )
+    request, response = make_plan(tmp_path)
+    value = descriptor(response)
+    monkeypatch.setattr(
+        "tree_sitter_analyzer.mcp.tools.utils.change_impact_git._get_changed_files",
+        lambda *args: request.changed_files,
+    )
+    stages = rebuild_request(value, str(tmp_path.resolve()))
+    assert [step["argv"][3:5] for step in stages] == [
+        ["-m", "not custom and not network and not benchmark"]
+    ] * 50
+    config.write_text(
+        "[pytest]\naddopts = -m 'not slow and not other'\n", encoding="utf-8"
+    )
+    with pytest.raises(ValueError, match="VERIFICATION_PLAN_CHANGED"):
+        rebuild_request(value, str(tmp_path.resolve()))
 
 
 def test_mapped_batches_keep_unmapped_default_gate(tmp_path):

--- a/tests/unit/test_verification_runner.py
+++ b/tests/unit/test_verification_runner.py
@@ -2,6 +2,9 @@
 
 import base64
 import json
+import os
+import shlex
+import subprocess
 import sys
 import threading
 import time
@@ -11,6 +14,185 @@ import psutil
 import pytest
 
 from tree_sitter_analyzer import verification_runner as runner
+
+
+def test_explicit_pytest_targets_execute_excluded_tiers(tmp_path, monkeypatch):
+    """2026-09-09：显式选择必须执行层级测试，并保留默认门禁及外部限制。"""
+    from tree_sitter_analyzer.mcp.tools.utils.verification_command import (
+        build_test_command,
+        detect_default_test_command,
+    )
+
+    monkeypatch.delenv("PYTEST_ADDOPTS", raising=False)
+    tiers = ["e2e", "slow", "full_language", "network", "benchmark", "quarantined"]
+    expression = " and ".join("not " + tier for tier in tiers)
+    (tmp_path / "pytest.ini").write_text(
+        '[pytest]\naddopts = -n 4 -m "'
+        + expression
+        + '"\nmarkers =\n'
+        + "".join("    " + tier + ": 选择契约\n" for tier in tiers),
+        encoding="utf-8",
+    )
+    (tmp_path / "test_selected.py").write_text(
+        "import pytest\nfrom pathlib import Path\n"
+        "def test_control():\n    Path('control.ran').touch()\n"
+        + "".join(
+            f"@pytest.mark.{tier}\ndef test_{tier}():\n    Path('{tier}.ran').touch()\n"
+            for tier in tiers
+        ),
+        encoding="utf-8",
+    )
+    default = detect_default_test_command(tmp_path)
+    env = {**os.environ, "VIRTUAL_ENV": sys.prefix, "UV_NO_SYNC": "1"}
+    for targets, expected in [
+        ([], ["control.ran"]),
+        (
+            ["test_selected.py"],
+            ["control.ran", "e2e.ran", "full_language.ran", "slow.ran"],
+        ),
+    ]:
+        result = subprocess.run(
+            shlex.split(build_test_command(default, targets)),
+            cwd=tmp_path,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert sorted(path.name for path in tmp_path.glob("*.ran")) == expected
+
+
+@pytest.mark.parametrize(
+    "condition",
+    [
+        "environment",
+        "new_config",
+        "precedence",
+        "nested",
+        "outside",
+        "large",
+        "directory",
+        "unreadable",
+        "native_table",
+        "defaults",
+        "uppercase",
+    ],
+)
+def test_explicit_selection_does_not_override_uncertain_configuration(
+    tmp_path, monkeypatch, condition
+):
+    """2026-09-09：未知来源或不安全配置必须保留原始 pytest 选择语义。"""
+    from tree_sitter_analyzer.mcp.tools.utils import (
+        verification_pytest_config as config,
+    )
+    from tree_sitter_analyzer.mcp.tools.utils.verification_command import (
+        build_test_command,
+        detect_default_test_command,
+    )
+
+    monkeypatch.delenv("PYTEST_ADDOPTS", raising=False)
+    settings = "[pytest]\naddopts = -m 'not e2e'\n"
+    path = tmp_path / "pytest.ini"
+    path.write_text(settings, encoding="utf-8")
+    target = "tests/test_example.py"
+    if condition == "environment":
+        monkeypatch.setenv("PYTEST_ADDOPTS", "-m 'not external'")
+    elif condition == "new_config":
+        (tmp_path / "pytest.toml").write_text("[pytest]\n", encoding="utf-8")
+    elif condition == "precedence":
+        path.write_text("", encoding="utf-8")
+        (tmp_path / "tox.ini").write_text(settings, encoding="utf-8")
+    elif condition == "nested":
+        (tmp_path / "tests").mkdir()
+        (tmp_path / "tests" / "pytest.ini").write_text(settings, encoding="utf-8")
+    elif condition == "outside":
+        target = "../outside/test_example.py"
+    elif condition == "large":
+        path.write_text(settings + "#" * 65537, encoding="utf-8")
+    elif condition == "directory":
+        path.unlink()
+        path.mkdir()
+    elif condition == "native_table":
+        path.unlink()
+        (tmp_path / "pyproject.toml").write_text(
+            '[tool.pytest]\naddopts=["-m", "not external"]\n', encoding="utf-8"
+        )
+        (tmp_path / "tox.ini").write_text(settings, encoding="utf-8")
+    elif condition == "defaults":
+        path.write_text(
+            "[DEFAULT]\naddopts = -m 'not e2e'\n[pytest]\n", encoding="utf-8"
+        )
+    elif condition == "uppercase":
+        path.write_text("[pytest]\nADDOPTS = -m 'not e2e'\n", encoding="utf-8")
+    else:
+        monkeypatch.setattr(
+            config,
+            "_open_config",
+            lambda *_args: (_ for _ in ()).throw(OSError("unavailable")),
+        )
+    default = detect_default_test_command(tmp_path)
+    assert build_test_command(default, [target]) == f"uv run pytest {target} -q"
+
+
+@pytest.mark.parametrize(
+    "mutation", ["replace", "grow", "shrink", "read_grow", "read_shrink"]
+)
+def test_pytest_config_mutation_cannot_authorize_tier_override(
+    tmp_path, monkeypatch, mutation
+):
+    """2026-09-09：配置在打开或读取期间发生变化时，不得采用其策略。"""
+    from tree_sitter_analyzer.mcp.tools.utils import (
+        verification_pytest_config as config,
+    )
+
+    monkeypatch.delenv("PYTEST_ADDOPTS", raising=False)
+    path = tmp_path / "pytest.ini"
+    settings = "[pytest]\naddopts = -m 'not e2e and not custom'\n"
+    path.write_text(settings, encoding="utf-8")
+    original_open = config._open_config
+
+    def mutate():
+        if mutation == "replace":
+            alternate = tmp_path / "new.ini"
+            alternate.write_text(settings, encoding="utf-8")
+            alternate.replace(path)
+        elif mutation in {"grow", "read_grow"}:
+            path.write_text(settings + "#" * 65537, encoding="utf-8")
+        else:
+            path.write_text("[pytest]\naddopts = -m 'not slow'\n", encoding="utf-8")
+
+    if mutation.startswith("read_"):
+        from types import SimpleNamespace
+
+        class ChangingReader:
+            def __init__(self, descriptor, mode):
+                self.stream = os.fdopen(descriptor, mode)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                self.stream.close()
+
+            def fileno(self):
+                return self.stream.fileno()
+
+            def read(self, size):
+                mutate()
+                return self.stream.read(size)
+
+        monkeypatch.setattr(
+            config, "os", SimpleNamespace(**{**vars(os), "fdopen": ChangingReader})
+        )
+    else:
+
+        def open_changed(name, flags):
+            mutate()
+            return original_open(name, flags)
+
+        monkeypatch.setattr(config, "_open_config", open_changed)
+    assert config.targeted_marker_expression(tmp_path) is None
 
 
 def request_token(tmp_path, timeout=10):

--- a/tree_sitter_analyzer/mcp/tools/utils/change_impact_analysis.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/change_impact_analysis.py
@@ -484,6 +484,8 @@ def _build_verification_strategy(
     default_command = DefaultTestCommand(
         verification["test_runner"],
         verification["default_test_command"],
+        verification.get("_pytest_marker"),
+        verification.get("_pytest_config_root"),
     )
     # 展示长度不能改变验证集合；每个子进程使用有界批次。
     focused_steps = (

--- a/tree_sitter_analyzer/mcp/tools/utils/change_impact_verification.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/change_impact_verification.py
@@ -53,8 +53,17 @@ def _build_verification_plan(
     default_test_command: DefaultTestCommand = PYTEST_COMMAND,
 ) -> dict[str, Any]:
     """Build the smallest recommended verification command for the diff."""
+    policy = (
+        {
+            "_pytest_marker": default_test_command.pytest_marker,
+            "_pytest_config_root": default_test_command.pytest_config_root,
+        }
+        if default_test_command.pytest_marker
+        else {}
+    )
     if not _requires_pytest(changed_files):
         return {
+            **policy,
             "test_required": False,
             "test_runner": default_test_command.runner,
             "default_test_command": default_test_command.command,
@@ -68,6 +77,7 @@ def _build_verification_plan(
     if _has_runtime_auto_discovery(test_mapping or {}):
         test_command = build_test_command(default_test_command, [])
         return {
+            **policy,
             "test_required": True,
             "test_runner": default_test_command.runner,
             "default_test_command": default_test_command.command,
@@ -97,6 +107,7 @@ def _build_verification_plan(
         else "no targeted tests found; run the default test command"
     )
     return {
+        **policy,
         "test_required": True,
         "test_runner": default_test_command.runner,
         "default_test_command": default_test_command.command,

--- a/tree_sitter_analyzer/mcp/tools/utils/verification_command.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/verification_command.py
@@ -7,7 +7,7 @@ import shlex
 import shutil
 import subprocess
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
@@ -18,6 +18,8 @@ class DefaultTestCommand:
 
     runner: str
     command: str
+    pytest_marker: str | None = None
+    pytest_config_root: str | None = None
 
 
 PYTEST_DEFAULT_COMMAND = "uv run pytest -q"
@@ -50,7 +52,15 @@ def detect_default_test_command(project_root: str | Path | None) -> DefaultTestC
     if (root / "pom.xml").exists():
         return DefaultTestCommand("maven", "mvn test")
 
-    return PYTEST_COMMAND
+    from .verification_pytest_config import targeted_marker_expression
+
+    marker = targeted_marker_expression(root)
+    return DefaultTestCommand(
+        "pytest",
+        PYTEST_DEFAULT_COMMAND,
+        marker,
+        str(root.resolve()) if marker else None,
+    )
 
 
 def certified_default_test_command(
@@ -82,13 +92,29 @@ def certified_default_test_command(
 _TARGETED_RUNNERS = frozenset({"pytest", "npm", "pnpm", "yarn", "bun"})
 
 
+def _for_targets(default: DefaultTestCommand, targets: list[str]) -> DefaultTestCommand:
+    """每个完整目标集合只核对子项目配置一次，预算试装参数时不重复访问磁盘。"""
+    from .verification_pytest_config import targets_share_root_config
+
+    if (
+        default.pytest_marker
+        and default.pytest_config_root
+        and targets
+        and not targets_share_root_config(default.pytest_config_root, targets)
+    ):
+        return replace(default, pytest_marker=None, pytest_config_root=None)
+    return default
+
+
 def _test_argv(default_command: DefaultTestCommand, targets: list[str]) -> list[str]:
     """从结构化目标直接构造参数，命令文本只在最后渲染。"""
     runner = default_command.runner
     if not targets or runner not in _TARGETED_RUNNERS:
         return shlex.split(default_command.command)
     if runner == "pytest":
-        return ["uv", "run", "pytest", *targets, "-q"]
+        marker = default_command.pytest_marker
+        options = ["-m", marker] if marker else []
+        return ["uv", "run", "pytest", *options, *targets, "-q"]
     separator = ["--"] if runner in {"npm", "pnpm"} else []
     return [runner, "test", *separator, *targets]
 
@@ -123,6 +149,7 @@ def build_test_command(
     """支持定向执行时渲染精确参数，其余情况保留项目默认命令。"""
     if not tests_to_run or default_command.runner not in _TARGETED_RUNNERS:
         return default_command.command
+    default_command = _for_targets(default_command, tests_to_run)
     if any(_shell_test_argv(default_command, target) for target in tests_to_run):
         return join_verification_steps(
             build_test_commands(default_command, tests_to_run)
@@ -144,6 +171,7 @@ def build_test_argv_batches(
     """编译完整有序批次，保留重复目标，且不经过 shell 文本反向解析。"""
     if not tests_to_run or default_command.runner not in _TARGETED_RUNNERS:
         return [_test_argv(default_command, [])]
+    default_command = _for_targets(default_command, tests_to_run)
     batches: list[list[str]] = []
     batch: list[str] = []
     for target in tests_to_run:

--- a/tree_sitter_analyzer/mcp/tools/utils/verification_command.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/verification_command.py
@@ -8,6 +8,7 @@ import shutil
 import subprocess
 import sys
 from dataclasses import dataclass, replace
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -157,12 +158,27 @@ def build_test_command(
     return shlex.join(_test_argv(default_command, tests_to_run))
 
 
-def _argv_within_budget(argv: list[str]) -> bool:
-    """同时检查 POSIX 命令字节数和 Windows 引用后的 UTF-16 启动长度。"""
+@lru_cache(maxsize=128)
+def _argument_lengths(argument: str) -> tuple[int, int]:
+    """缓存单参数的纯转义长度，避免试装批次时反复转义已有路径。"""
     return (
-        len(shlex.join(argv).encode("utf-8")) <= 6000
-        and len(subprocess.list2cmdline(argv).encode("utf-16-le")) // 2 + 1 <= 6000
+        len(shlex.quote(argument).encode("utf-8")),
+        len(subprocess.list2cmdline([argument]).encode("utf-16-le")) // 2,
     )
+
+
+def _argv_within_budget(argv: list[str]) -> bool:
+    """按参数累加精确转义长度，包含分隔空格与 Windows 末尾 NUL。"""
+    posix = max(0, len(argv) - 1)
+    windows = max(1, len(argv))
+    for argument in argv:
+        # 超长参数必定超限，也不能进入有界转义缓存。
+        if len(argument) > 6000:
+            return False
+        posix_size, windows_size = _argument_lengths(argument)
+        posix += posix_size
+        windows += windows_size
+    return posix <= 6000 and windows <= 6000
 
 
 def build_test_argv_batches(

--- a/tree_sitter_analyzer/mcp/tools/utils/verification_pytest_config.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/verification_pytest_config.py
@@ -14,7 +14,8 @@ from typing import Any
 if sys.version_info >= (3, 11):
     import tomllib
 else:
-    import tomli as tomllib
+    # tomli 只随 Python 3.10 安装；检查器环境可能缺包，或已忽略缺失导入。
+    import tomli as tomllib  # type: ignore[import-not-found, unused-ignore]
 
 _CONFIG_NAMES = (
     "pytest.toml",

--- a/tree_sitter_analyzer/mcp/tools/utils/verification_pytest_config.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/verification_pytest_config.py
@@ -1,0 +1,162 @@
+"""从项目配置提取保守的定向测试层级策略，不导入用户测试。"""
+
+from __future__ import annotations
+
+import configparser
+import os
+import re
+import shlex
+import stat
+import sys
+from pathlib import Path
+from typing import Any
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
+_CONFIG_NAMES = (
+    "pytest.toml",
+    ".pytest.toml",
+    "pytest.ini",
+    ".pytest.ini",
+    "pyproject.toml",
+    "tox.ini",
+    "setup.cfg",
+)
+_TARGET_TIERS = frozenset({"e2e", "slow", "full_language"})
+_MAX_CONFIG_BYTES = 65536
+_open_config = os.open
+
+
+class _CaseSensitiveConfig(configparser.ConfigParser):
+    def optionxform(self, optionstr: str) -> str:
+        return optionstr
+
+
+def _identity(info: os.stat_result) -> tuple[int, ...]:
+    return (info.st_dev, info.st_ino, info.st_size, info.st_mtime_ns, info.st_ctime_ns)
+
+
+def _read_config(path: Path) -> str:
+    """只读取已核对身份的普通文件，拒绝链接、特殊文件及超大配置。"""
+    before = path.lstat()
+    if not stat.S_ISREG(before.st_mode) or before.st_size > _MAX_CONFIG_BYTES:
+        raise ValueError("PYTEST_CONFIG_UNSUPPORTED")
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+    descriptor = _open_config(path, flags)
+    with os.fdopen(descriptor, "rb") as stream:
+        current = os.fstat(stream.fileno())
+        if not stat.S_ISREG(current.st_mode) or _identity(before) != _identity(current):
+            raise ValueError("PYTEST_CONFIG_CHANGED")
+        raw = stream.read(_MAX_CONFIG_BYTES + 1)
+        after = os.fstat(stream.fileno())
+    if len(raw) > _MAX_CONFIG_BYTES:
+        raise ValueError("PYTEST_CONFIG_TOO_LARGE")
+    if _identity(current) != _identity(after):
+        raise ValueError("PYTEST_CONFIG_CHANGED")
+    return raw.decode("utf-8")
+
+
+def _config_options(root: Path) -> Any:
+    for name in _CONFIG_NAMES:
+        path = root / name
+        if not os.path.lexists(path):
+            continue
+        # 原生 TOML 配置的优先级依赖 pytest 版本，不能擅自选用旧文件。
+        if name in {"pytest.toml", ".pytest.toml"}:
+            return None
+        text = _read_config(path)
+        if name == "pyproject.toml":
+            pytest = tomllib.loads(text).get("tool", {}).get("pytest")
+            if pytest is None:
+                continue
+            # 原生表在新 pytest 中优先；版本不明时不能采用低优先级配置。
+            if "ini_options" not in pytest or set(pytest) != {"ini_options"}:
+                return None
+            return pytest["ini_options"].get("addopts", "")
+        parser = _CaseSensitiveConfig(interpolation=None)
+        parser.read_string(text)
+        # pytest 的 INI 解析没有 DEFAULT 继承，也不把选项名转成小写。
+        if parser.defaults():
+            return None
+        section = "tool:pytest" if name == "setup.cfg" else "pytest"
+        if parser.has_section(section):
+            return parser.get(section, "addopts", fallback="")
+        if name in {"pytest.ini", ".pytest.ini"}:
+            return ""
+    return None
+
+
+def targeted_marker_expression(root: Path) -> str | None:
+    """仅放行配置中明确排除的常规层级，保留外部资源和未知限制。"""
+    if os.environ.get("PYTEST_ADDOPTS"):
+        return None
+    try:
+        options = _config_options(root)
+        argv = shlex.split(options) if isinstance(options, str) else options
+        if not isinstance(argv, list) or any(not isinstance(arg, str) for arg in argv):
+            return None
+        expression = None
+        for index, argument in enumerate(argv):
+            if argument in {
+                "-c",
+                "-o",
+                "--config-file",
+                "--override-ini",
+            } or argument.startswith(("--config-file=", "--override-ini=", "-c", "-o")):
+                return None
+            if argument == "-m":
+                expression = argv[index + 1]
+            elif argument.startswith("-m"):
+                expression = argument[2:]
+        if not expression:
+            return None
+        terms = re.split(r"\s+and\s+", expression.strip())
+        matches = [
+            re.fullmatch(r"not\s+([A-Za-z_]\w*)", term.strip()) for term in terms
+        ]
+        if not all(matches):
+            return None
+        markers = [match.group(1) for match in matches if match is not None]
+        if not _TARGET_TIERS.intersection(markers):
+            return None
+        retained = [marker for marker in markers if marker not in _TARGET_TIERS]
+        # 定向选择常规层级不代表授权外部网络或基准测量。
+        for marker in ("network", "benchmark"):
+            if marker not in retained:
+                retained.append(marker)
+        return " and ".join("not " + marker for marker in retained)
+    except (
+        OSError,
+        ValueError,
+        configparser.Error,
+        IndexError,
+        AttributeError,
+        TypeError,
+    ):
+        return None
+
+
+def targets_share_root_config(root: str, targets: list[str]) -> bool:
+    """子项目配置或越界目标存在时，不用根配置覆盖它们自己的选择规则。"""
+    checked: set[Path] = set()
+    try:
+        base = Path(root).resolve()
+        for target in targets:
+            path = (base / target.partition("::")[0]).resolve()
+            if not path.is_relative_to(base):
+                return False
+            parent = path if path.is_dir() else path.parent
+            while parent != base:
+                if parent in checked:
+                    break
+                checked.add(parent)
+                if any(os.path.lexists(parent / name) for name in _CONFIG_NAMES):
+                    return False
+                parent = parent.parent
+        return True
+    except (OSError, RuntimeError):
+        return False

--- a/tree_sitter_analyzer/verification_plan.py
+++ b/tree_sitter_analyzer/verification_plan.py
@@ -58,7 +58,10 @@ def compile_stages(context: Any) -> dict[str, list[dict[str, Any]]]:
 
     verification = context.verification
     default = DefaultTestCommand(
-        verification["test_runner"], verification["default_test_command"]
+        verification["test_runner"],
+        verification["default_test_command"],
+        verification.get("_pytest_marker"),
+        verification.get("_pytest_config_root"),
     )
     focused = (
         [
@@ -92,7 +95,9 @@ def compile_stages(context: Any) -> dict[str, list[dict[str, Any]]]:
                     "-q",
                 ]
             if not _argv_within_budget(argv):
-                targets = step["argv"][3:-1]
+                # 参数由统一编译器生成；层级选择属于前缀，不能作为测试路径拆分。
+                target_start = 5 if step["argv"][3:4] == ["-m"] else 3
+                targets = step["argv"][target_start:-1]
                 if step["role"] != "focused" or len(targets) < 2:
                     raise ValueError("VERIFICATION_REQUEST_TOO_LARGE")
                 middle = len(targets) // 2
@@ -101,7 +106,7 @@ def compile_stages(context: Any) -> dict[str, list[dict[str, Any]]]:
                         [
                             {
                                 "role": "focused",
-                                "argv": [*step["argv"][:3], *part, "-q"],
+                                "argv": [*step["argv"][:target_start], *part, "-q"],
                             }
                             for part in (targets[:middle], targets[middle:])
                         ]


### PR DESCRIPTION
Explicit test targets could inherit pytest’s quick-gate marker exclusions, so verification could skip its selected E2E/slow/full-language tests or pass after running only unmarked cases.

The planner now lifts those three tiers only when bounded project configuration reads establish a simple exclusion policy. Network, benchmark, and custom exclusions remain in force; ambiguous settings retain their original policy. Default quick gates stay unchanged. Marker options survive plan replay and low-resource argv splitting.

The first CI run also exposed repeated argument serialization in large plans. A bounded 128-entry cache now reuses exact per-argument POSIX/Windows lengths while preserving full-command limits. The existing 10,000-target budget test remains unchanged.

Validation on the final code:
- Real CLI-generated E2E command executed the selected test and wrote its expected receipt.
- TSA-related focused coverage suite: 579 passed, 1 skipped (10.51s); Python 3.10 compatibility checks: 27 passed. Combined local patch gate: no added executable misses.
- Default quick gate: 2,112 passed, 22 skipped (27.90s).
- 10,000-target test with coverage: 0.80s locally. Identical cProfile workload dropped from 2.45s to 0.645s; no budget changes or CI reruns were used.
- Independent review checked 10,000 mixed quoting/Unicode argv cases against both original platform serializers and verified the cache bound.
- All 902 source modules pass the CI-equivalent mypy command; Ruff, commit hooks and source/wheel build passed.
- Merged current develop, including the watcher test fix already verified by its complete cross-platform CI.
