### PR TITLE
perf: score ready health files while git history queries continue

### DIFF
--- a/tests/unit/test_health_scorer.py
+++ b/tests/unit/test_health_scorer.py
@@ -1247,11 +1247,12 @@ def test_project_git_prefetch_preserves_warm_hits_and_resets_scope(
     assert calls == [str(target)] * 3
 
 
+@pytest.mark.parametrize("interrupt_at", ["query", "submit"])
 def test_project_git_prefetch_cancels_queued_queries_on_interrupt(
-    tmp_path, monkeypatch
+    tmp_path, monkeypatch, interrupt_at
 ):
-    """中断后取消未启动的查询，并等待已经启动的工作退出。"""
-    # 2026-09-08：以实际首次调用触发中断，不假定文件枚举顺序。
+    """查询或提交中断后取消排队任务，并回收已启动工作及恢复上下文。"""
+    # 2026-09-09：submit 已入队但未返回时，中断也必须取消未登记任务。
     import concurrent.futures
     import threading
 
@@ -1259,23 +1260,38 @@ def test_project_git_prefetch_cancels_queued_queries_on_interrupt(
 
     futures = []
     release = threading.Event()
+    started = threading.Event()
     lock = threading.Lock()
     calls = 0
+    outer_graphs = health._PROJECT_DEPENDENCY_GRAPHS.get()
+    outer_hotspots = health._PROJECT_HOTSPOT_SCORES.get()
 
     class ObservedPool(concurrent.futures.ThreadPoolExecutor):
         def submit(self, *args, **kwargs):
             future = super().submit(*args, **kwargs)
             futures.append(future)
+            if interrupt_at == "submit" and len(futures) == 9:
+                assert started.wait(timeout=3)
+                # 第九个任务已入队，但调用方尚未收到并登记它的 future。
+                raise KeyboardInterrupt("cancel prefetch")
             return future
+
+        def shutdown(self, wait=True, *, cancel_futures=False):
+            # 先执行真实取消，再释放工作线程，避免用休眠制造调度竞态。
+            super().shutdown(wait=False, cancel_futures=cancel_futures)
+            release.set()
+            super().shutdown(wait=wait, cancel_futures=cancel_futures)
 
     def query(*args):
         nonlocal calls
         with lock:
             calls += 1
             first = calls == 1
-        if first:
+            if calls == 4:
+                started.set()
+        if interrupt_at == "query" and first:
             raise KeyboardInterrupt("cancel prefetch")
-        release.wait(timeout=0.1)
+        assert release.wait(timeout=3)
         return 100.0
 
     for index in range(40):
@@ -1284,7 +1300,52 @@ def test_project_git_prefetch_cancels_queued_queries_on_interrupt(
     monkeypatch.setattr(health, "calculate_git_hotspot", query)
     with pytest.raises(KeyboardInterrupt, match="cancel prefetch"):
         health.HealthScorer().score_project_with_stats(str(tmp_path), use_cache=False)
-    assert len(futures) == 40
+    assert len(futures) == (9 if interrupt_at == "submit" else 40)
     # 调度顺序决定取消数量；不变量是存在取消且没有未结束的任务。
     assert any(f.cancelled() for f in futures)
     assert all(f.done() for f in futures)
+    if interrupt_at == "submit":
+        assert calls == 4
+        assert sum(f.cancelled() for f in futures) == 5
+        assert futures[-1].cancelled()
+    assert health._PROJECT_DEPENDENCY_GRAPHS.get() is outer_graphs
+    assert health._PROJECT_HOTSPOT_SCORES.get() is outer_hotspots
+
+
+@pytest.mark.parametrize("ready_index", [0, 3])
+def test_project_health_stores_ready_scores_before_remaining_git_queries_finish(
+    tmp_path, monkeypatch, ready_index
+):
+    """2026-09-09：慢历史查询不能阻止已就绪文件评分与发布缓存。"""
+    import threading
+
+    from tree_sitter_analyzer import health_scorer as health
+    from tree_sitter_analyzer.registry.health_score_cache import HealthScoreCache
+
+    files = [tmp_path / f"f{index}.py" for index in range(4)]
+    for path in files:
+        path.write_text("value=1\n", encoding="utf-8")
+    stored = threading.Event()
+    observed = []
+    original_store = HealthScoreCache.store
+
+    def store(self, score, **kwargs):
+        result = original_store(self, score, **kwargs)
+        if score.file_path == str(files[ready_index]):
+            stored.set()
+        return result
+
+    def query(path, low, high):
+        if path != str(files[ready_index]):
+            observed.append(stored.wait(timeout=3))
+        return 100.0
+
+    monkeypatch.setattr(HealthScoreCache, "store", store)
+    monkeypatch.setattr(health, "calculate_git_hotspot", query)
+    monkeypatch.setattr(
+        health.HealthScorer, "_iter_source_files", lambda *_: (files, 0)
+    )
+    scores, stats = health.HealthScorer().score_project_with_stats(str(tmp_path))
+    assert observed == [True, True, True]
+    assert len(scores) == stats["total_files_scored"] == 4
+    assert [score.file_path for score in scores] == [str(path) for path in files]

--- a/tests/unit/test_health_scorer.py
+++ b/tests/unit/test_health_scorer.py
@@ -1349,3 +1349,88 @@ def test_project_health_stores_ready_scores_before_remaining_git_queries_finish(
     assert observed == [True, True, True]
     assert len(scores) == stats["total_files_scored"] == 4
     assert [score.file_path for score in scores] == [str(path) for path in files]
+
+
+def test_project_git_fallback_shares_four_workers_after_dependency_invalidation(
+    tmp_path, monkeypatch
+):
+    """#1437：依赖失效的暖文件与冷文件共用四路历史查询预算。"""
+    import concurrent.futures
+    import threading
+
+    from tree_sitter_analyzer import health_scorer as health
+    from tree_sitter_analyzer.registry.health_score_cache import HealthScoreCache
+
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname="probe"\n', encoding="utf-8"
+    )
+    warm = tmp_path / "warm.py"
+    warm.write_text("value=1\n", encoding="utf-8")
+    monkeypatch.setattr(health, "calculate_git_hotspot", lambda *_: 90.0)
+    for index in range(2):
+        (tmp_path / f"existing{index}.py").write_text("import warm\n", encoding="utf-8")
+    scorer = health.HealthScorer()
+    monkeypatch.setattr(scorer, "_iter_source_files", lambda *_: ([warm], 0))
+    initial = scorer.score_project(str(tmp_path))
+    assert initial[0].dimensions["dependencies"] == 100.0
+    cold = [tmp_path / f"cold{index}.py" for index in range(4)]
+    for path in cold:
+        path.write_text("import warm\n", encoding="utf-8")
+    all_started = threading.Event()
+    release = threading.Event()
+    stored = threading.Event()
+    original_store = HealthScoreCache.store
+
+    def store(self, score, **kwargs):
+        result = original_store(self, score, **kwargs)
+        if score.file_path == str(cold[0]):
+            stored.set()
+        return result
+
+    lock = threading.Lock()
+    active = maximum = 0
+    queried = []
+
+    class ObservedPool(concurrent.futures.ThreadPoolExecutor):
+        def submit(self, fn, path, *args, **kwargs):
+            future = super().submit(fn, path, *args, **kwargs)
+            if path == str(warm):
+                # 暖文件入队后释放四个冷任务，不依赖线程调度或休眠。
+                assert all_started.wait(timeout=3)
+                release.set()
+            return future
+
+    def query(path, low, high):
+        nonlocal active, maximum
+        if path == str(warm):
+            assert all_started.wait(timeout=3)
+        with lock:
+            active += 1
+            maximum = max(maximum, active)
+            queried.append(path)
+            if len(queried) == 4:
+                all_started.set()
+        try:
+            if path == str(warm):
+                # 旧实现直接在主线程调用，能在四个冷任务阻塞时暴露峰值五。
+                release.set()
+                # 暖查询尚未完成时，已就绪冷文件必须能够发布缓存。
+                assert stored.wait(timeout=3)
+            assert release.wait(timeout=3)
+            return 80.0
+        finally:
+            with lock:
+                active -= 1
+
+    monkeypatch.setattr(concurrent.futures, "ThreadPoolExecutor", ObservedPool)
+    monkeypatch.setattr(health, "calculate_git_hotspot", query)
+    monkeypatch.setattr(HealthScoreCache, "store", store)
+    monkeypatch.setattr(scorer, "_iter_source_files", lambda *_: ([warm, *cold], 0))
+    scores, stats = scorer.score_project_with_stats(str(tmp_path))
+    assert stats["total_files_scored"] == 5
+    assert stats["total_files_skipped"] == 0
+    assert maximum == 4
+    assert sorted(queried) == sorted(str(path) for path in [warm, *cold])
+    by_path = {score.file_path: score for score in scores}
+    assert by_path[str(warm)].dimensions["dependencies"] == 99.1
+    assert by_path[str(warm)].dimensions["git_hotspot"] == 80.0

--- a/tree_sitter_analyzer/health_scorer.py
+++ b/tree_sitter_analyzer/health_scorer.py
@@ -14,6 +14,7 @@ Computes a 0-100 health score for source files based on weighted dimensions:
 import json
 import logging
 import os
+from collections.abc import Callable
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -405,11 +406,22 @@ class HealthScorer:
                 and (cache is None or cache.lookup(str(f)) is None)
             }
 
-            def collect(path: str) -> None:
+            def collect(path: str, *, defer_cold: bool = False) -> None:
                 nonlocal scoring_failed
-                score = self._score_file_with_cache(path, cache)
+                deferred = False
+
+                def defer_score(file_path: str) -> None:
+                    nonlocal deferred
+                    # 暖缓存失效也进入同一队列，不阻塞已就绪冷文件的评分。
+                    pending[pool.submit(score_git_hotspot, file_path)] = file_path
+                    deferred = True
+
+                score = self._score_file_with_cache(
+                    path, cache, defer_score if defer_cold else None
+                )
                 if score is None:
-                    scoring_failed += 1
+                    if not deferred:
+                        scoring_failed += 1
                 else:
                     results.append(score)
 
@@ -428,7 +440,7 @@ class HealthScorer:
                             continue
                         path = str(f)
                         if path not in cold_paths:
-                            collect(path)
+                            collect(path, defer_cold=True)
                     for future in as_completed(pending):
                         path = pending[future]
                         hotspots[path] = future.result()
@@ -460,8 +472,9 @@ class HealthScorer:
         self,
         file_path: str,
         cache: Any,
+        defer_score: Callable[[str], None] | None = None,
     ) -> HealthScore | None:
-        """复用当前内容的评分；评分期间变化的文件不发布缓存。"""
+        """复用当前评分；可延后冷评分，评分期间变化的文件不发布缓存。"""
         from .registry.health_score_cache import _Fingerprint
 
         before = _Fingerprint.from_path(file_path) if cache is not None else None
@@ -479,6 +492,10 @@ class HealthScorer:
                     total=cached["total"],
                     dimensions=cached.get("dimensions", {}),
                 )
+
+        if defer_score is not None:
+            defer_score(file_path)
+            return None
 
         try:
             score = self.score_file(file_path)

--- a/tree_sitter_analyzer/health_scorer.py
+++ b/tree_sitter_analyzer/health_scorer.py
@@ -394,39 +394,56 @@ class HealthScorer:
         hotspots: dict[str, float | None] = {}
         hotspot_token = _PROJECT_HOTSPOT_SCORES.set(hotspots)
         try:
-            from concurrent.futures import ThreadPoolExecutor
+            from concurrent.futures import ThreadPoolExecutor, as_completed
 
             files, pruned_directories = self._iter_source_files(root)
-            cold_paths = [
+            file_order = {str(path): index for index, path in enumerate(files)}
+            cold_paths = {
                 str(f)
                 for f in files
                 if not self._is_excluded(f, root)
                 and (cache is None or cache.lookup(str(f)) is None)
-            ]
-            # 保留逐路径 git log 的合并历史语义，仅限制并发查询数量。
-            with ThreadPoolExecutor(max_workers=4) as pool:
-                hotspots.update(
-                    zip(
-                        cold_paths, pool.map(score_git_hotspot, cold_paths), strict=True
-                    )
-                )
-            for f in files:
-                scanned += 1
-                if self._is_excluded(f, root):
-                    excluded_files += 1
-                    continue
-                score = self._score_file_with_cache(str(f), cache)
+            }
+
+            def collect(path: str) -> None:
+                nonlocal scoring_failed
+                score = self._score_file_with_cache(path, cache)
                 if score is None:
                     scoring_failed += 1
-                    continue
-                results.append(score)
+                else:
+                    results.append(score)
+
+            # 逐路径历史查询与评分流水执行，已就绪文件不等待全部历史完成。
+            with ThreadPoolExecutor(max_workers=4) as pool:
+                try:
+                    pending = {
+                        pool.submit(score_git_hotspot, str(path)): str(path)
+                        for path in files
+                        if str(path) in cold_paths
+                    }
+                    for f in files:
+                        scanned += 1
+                        if self._is_excluded(f, root):
+                            excluded_files += 1
+                            continue
+                        path = str(f)
+                        if path not in cold_paths:
+                            collect(path)
+                    for future in as_completed(pending):
+                        path = pending[future]
+                        hotspots[path] = future.result()
+                        collect(path)
+                finally:
+                    # 也取消已入队但尚未登记的任务，并等待已启动查询退出。
+                    pool.shutdown(wait=True, cancel_futures=True)
         finally:
             _PROJECT_HOTSPOT_SCORES.reset(hotspot_token)
             _PROJECT_DEPENDENCY_GRAPHS.reset(graph_token)
             if cache is not None:
                 cache.close()
 
-        results.sort(key=lambda r: r.total, reverse=True)
+        # 就绪顺序只影响执行；同分文件仍按原始枚举顺序返回。
+        results.sort(key=lambda r: (-r.total, file_order[r.file_path]))
         stats: dict[str, Any] = {
             "total_files_scanned": scanned,
             "total_files_scored": len(results),


### PR DESCRIPTION
Project health previously waited for every cold Git-history query before scoring any file. A slow query therefore held up all cache progress.

Score ready files as Git queries complete. Warm entries whose dependencies invalidate their cached score join the same pending queue, preserving four workers and ready-score progress. The original per-path Git-history semantics and deterministic tie ordering remain unchanged. Cancellation now covers the submission phase too: the executor cancels queued work even when a task was enqueued before submit returned its future, then waits for running work to finish before restoring request contexts.

Validation:
- RED-first event tests reproduced both the all-query barrier and a slow-first-file barrier; the fixed version publishes ready scores in either order while returning identical file order.
- Submission-interrupt test proves exactly 9 submitted / 4 running / 5 cancelled, including the unregistered ninth future; existing query-interrupt and context restoration checks pass.
- TSA-recommended focused coverage: 139 passed, 1 existing platform skip (Python 3.10, four workers); local patch gate reports no added executable misses.
- Quick gate: 2,106 passed, 28 skipped in 28.24s; mypy, Ruff, commit hooks, and source/wheel build passed.
- Real CLI cold/warm smoke: exactly 2 scanned/analyzed files, zero skips, identical grades and dimensions.
- Fixed TSA source project (2,254 files): complete score list and ordering match exactly; total 45.73s → 36.53s, first cache-write call 31.98s → 7.79s. A generated ignored cache directory changed the first two walks’ pruning count; rechecking both walkers on the same resulting directory state produced 2,254 files / 44 pruned directories for each.

This improves cold-start progress and throughput; it does not claim the full project now meets the previously observed 20-second client timeout. No timeout or scoring threshold was relaxed, and approximate batch Git counting is not included.

Codex review P2 (3968951167): accepted and fixed. A real mixed-cache fixture reproduced five concurrent Git queries; after the fix the exact peak is four, a ready cold file is stored before the warm query completes, and all five files are scored without skips.
