### PR TITLE
fix: reject incomplete Git history in health scores

### DIFF
--- a/tests/unit/test_health_score_cache.py
+++ b/tests/unit/test_health_score_cache.py
@@ -346,14 +346,19 @@ def test_cache_misses_when_coverage_report_disappears(project, monkeypatch):
 
 
 def test_cache_misses_when_context_version_changes(project, monkeypatch):
-    """A scoring-algorithm version bump must invalidate prior rows."""
-    # Issue #1183 (2026-07-27): the cache lacked an algorithm invalidation path.
+    """当前评分算法必须拒绝旧版已经缓存的浅历史满分。"""
+    # #1183；2026-09-09：v4 会缓存浅克隆的不完整历史评分，升级后须重算。
     monkeypatch.chdir(project)
     target = project / "src" / "main.py"
-    first = HealthScoreCache(str(project))
-    first.store(HealthScore(file_path=str(target), total=82.5, dimensions={}))
-    first.close()
-    monkeypatch.setattr(cache_module, "_CACHE_CONTEXT_VERSION", "test-next-version")
+    with monkeypatch.context() as old_version:
+        old_version.setattr(cache_module, "_CACHE_CONTEXT_VERSION", "health-score-v4")
+        first = HealthScoreCache(str(project))
+        first.store(
+            HealthScore(
+                file_path=str(target), total=100.0, dimensions={"git_hotspot": 100.0}
+            )
+        )
+        first.close()
 
     second = HealthScoreCache(str(project))
 

--- a/tests/unit/test_health_scorer.py
+++ b/tests/unit/test_health_scorer.py
@@ -606,6 +606,8 @@ class TestHealthScorer:
             calls.append((cmd, kwargs))
             if cmd[:3] == ["git", "rev-parse", "--show-toplevel"]:
                 return SimpleNamespace(returncode=0, stdout=f"{repo}\n")
+            if cmd == ["git", "rev-parse", "--is-shallow-repository"]:
+                return SimpleNamespace(returncode=0, stdout="false\n")
             return SimpleNamespace(returncode=0, stdout="\n".join(["abc"] * 10))
 
         monkeypatch.setattr(subprocess, "run", fake_run)
@@ -613,8 +615,8 @@ class TestHealthScorer:
         score = score_git_hotspot(str(file_path))
 
         assert score == pytest.approx(88.9, abs=0.1)
-        assert calls[1][0][-1] == "tree_sitter_analyzer/cli_main.py"
-        assert calls[1][1]["cwd"] == str(repo)
+        assert calls[2][0][-1] == "tree_sitter_analyzer/cli_main.py"
+        assert calls[2][1]["cwd"] == str(repo)
 
     def test_seven_dimensions_in_weights(self):
         """All 7 dimensions should be in DIMENSION_WEIGHTS."""

--- a/tests/unit/test_health_scorer_helpers.py
+++ b/tests/unit/test_health_scorer_helpers.py
@@ -37,6 +37,69 @@ from tree_sitter_analyzer.registry import health_scorer_helpers
 _NON_ASCII_SOURCE = "# 日本語コメント\nmessage = 'こんにちは世界'\nx = 1\n"
 
 
+@pytest.mark.parametrize("linked_worktree", [False, True])
+def test_shallow_history_is_unavailable_until_unshallow(tmp_path, linked_worktree):
+    """浅克隆和关联工作树不能把缺失历史算成稳定满分。"""
+    # 2026-09-09：相同 HEAD 的七次近期变更在 depth=2 克隆中被误计为两次。
+    repo = tmp_path / "full"
+    repo.mkdir()
+
+    def git(directory, *arguments):
+        return subprocess.run(
+            ["git", *arguments],
+            cwd=directory,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+    git(repo, "init", "-q")
+    git(repo, "config", "user.email", "test@example.com")
+    git(repo, "config", "user.name", "Test")
+    for value in range(7):
+        (repo / "module.py").write_text(f"value = {value}\n", encoding="utf-8")
+        git(repo, "add", "module.py")
+        git(repo, "commit", "-qm", f"change {value}")
+    clone = tmp_path / "shallow"
+    git(tmp_path, "clone", "--depth=2", repo.as_uri(), str(clone))
+    target = clone
+    if linked_worktree:
+        target = tmp_path / "linked"
+        git(clone, "worktree", "add", "--detach", str(target))
+    head = git(repo, "rev-parse", "HEAD")
+    assert git(target, "rev-parse", "HEAD") == head
+    assert git(target, "rev-list", "--count", "HEAD", "--", "module.py") == "2"
+    assert health_scorer_helpers.count_recent_commits(repo, "module.py") == 7
+    assert (
+        health_scorer_helpers.calculate_git_hotspot(str(target / "module.py"), 5, 50)
+        is None
+    )
+    git(clone, "fetch", "--unshallow")
+    assert git(target, "rev-parse", "HEAD") == head
+    assert health_scorer_helpers.calculate_git_hotspot(
+        str(target / "module.py"), 5, 50
+    ) == health_scorer_helpers.score_commit_frequency(7, 5, 50)
+
+
+@pytest.mark.parametrize(
+    "returncode,stdout",
+    [(0, "true\n"), (0, ""), (0, "--is-shallow-repository\n"), (1, "false\n")],
+)
+def test_unknown_or_shallow_history_does_not_query_log(
+    monkeypatch, tmp_path, returncode, stdout
+):
+    """历史完整性无法确认时不执行可能给出误导计数的日志查询。"""
+    calls = []
+
+    def run(command, **kwargs):
+        calls.append(command)
+        return subprocess.CompletedProcess(command, returncode, stdout=stdout)
+
+    monkeypatch.setattr(subprocess, "run", run)
+    assert health_scorer_helpers.count_recent_commits(tmp_path, "module.py") is None
+    assert calls == [["git", "rev-parse", "--is-shallow-repository"]]
+
+
 @pytest.mark.parametrize("overlay", ["replace", "graft"])
 def test_recent_commit_count_ignores_replacement_and_graft_overrides(tmp_path, overlay):
     """Hotspot history must reflect immutable commits, not local Git overlays."""

--- a/tree_sitter_analyzer/registry/health_score_cache.py
+++ b/tree_sitter_analyzer/registry/health_score_cache.py
@@ -21,7 +21,7 @@ from .health_score_fingerprint import _Fingerprint
 
 logger = logging.getLogger(__name__)
 
-_CACHE_CONTEXT_VERSION = "health-score-v4"
+_CACHE_CONTEXT_VERSION = "health-score-v5"
 _CONTEXT_COLUMN = "context_fingerprint"
 _MAX_GIT_METADATA_BYTES = 64 * 1024
 _MAX_SYMBOLIC_REF_DEPTH = 16

--- a/tree_sitter_analyzer/registry/health_scorer_helpers.py
+++ b/tree_sitter_analyzer/registry/health_scorer_helpers.py
@@ -88,12 +88,25 @@ def find_git_root(start_dir: Path) -> Path | None:
 
 
 def count_recent_commits(repo_root: Path, pathspec: str) -> int | None:
-    """Count commits touching pathspec in the last 90 days."""
+    """仅在历史完整时统计最近九十天修改指定路径的提交。"""
     history_env = {
         **os.environ,
         "GIT_NO_REPLACE_OBJECTS": "1",
         "GIT_GRAFT_FILE": os.devnull,
     }
+    # 2026-09-09：浅克隆的少量可见提交不能作为稳定满分的依据。
+    history = subprocess.run(  # nosec
+        ["git", "rev-parse", "--is-shallow-repository"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=5,
+        cwd=str(repo_root),
+        env=history_env,
+    )
+    if history.returncode != 0 or history.stdout.strip() != "false":
+        return None
     result = subprocess.run(  # nosec
         [
             "git",


### PR DESCRIPTION
Health scoring treated the few commits visible in a shallow clone as complete history. A real repository with seven recent changes scored 95.6, while its depth-two clone at the same HEAD incorrectly reported a perfect Git stability score.

Check Git shallow state before counting recent commits. Shallow, failed, or unrecognized discovery leaves this optional dimension unavailable; other dimensions retain their existing weight normalization. Full-history counting still ignores replacement refs and graft overlays. Bump the scoring cache context to invalidate old cached results.

Validation:
- RED-first real Git fixtures cover depth-two clones and linked worktrees, then prove the same HEAD regains the full-history score after unshallow.
- Unknown/error discovery avoids running log; existing replacement/graft behavior remains covered.
- TSA-selected focused coverage: 145 passed, 1 existing platform skip on Python 3.10 with four workers; no added executable misses.
- Quick gate: 2,106 passed, 28 skipped in 26.80s. Commit hooks and source/wheel build pass.
- Real CLI smoke preserves the full repository Git score of 95.6 and omits the unavailable Git dimension in its shallow clone. Independent review found no blocking issues.

This adds one bounded Git discovery process per uncached file in a complete repository. It performs no fetch and does not change repository history. The overall health score still uses the existing normalization of available dimensions; this change does not introduce a new confidence field.

Integration: merged develop abd26d56 to combine the ready-score pipeline with shallow-history handling; focused coverage remains green. Initial Windows run 34358528669 had widespread timing overruns and worker termination without a diagnostic stack. Tiny-fixture and call-path investigation found no invocation of the changed health helpers; the underlying worker failure remains unexplained. The new head validates the actual integration and is not a rerun of that old job or a claimed fix for its worker failure.
