### PR TITLE
fix: compare compatible Windows pytest config timestamps

### DIFF
--- a/tests/unit/test_change_impact_analysis.py
+++ b/tests/unit/test_change_impact_analysis.py
@@ -444,3 +444,57 @@ def test_read_only_request_skips_call_graph_impact(tmp_path, monkeypatch) -> Non
     )
 
     assert result["affected_count"] == 0
+
+
+@pytest.mark.parametrize(
+    "platform,change",
+    [
+        ("nt", "none"),
+        ("nt", "legacy"),
+        ("posix", "none"),
+        ("nt", "birthtime"),
+        ("nt", "read_ctime"),
+    ],
+)
+def test_config_windows_times(tmp_path, monkeypatch, platform, change):
+    """2026-09-09：跨接口使用创建时间，同句柄继续用变更时间拒绝竞态。"""
+    import os
+    from pathlib import Path
+    from types import SimpleNamespace
+
+    from tree_sitter_analyzer.mcp.tools.utils import (
+        verification_pytest_config as config,
+    )
+
+    monkeypatch.delenv("PYTEST_ADDOPTS", raising=False)
+    path = tmp_path / "pytest.ini"
+    path.write_text("[pytest]\naddopts = -m 'not slow'\n", encoding="utf-8")
+    original_lstat = Path.lstat
+    metadata = path.lstat()
+    names = ("st_mode", "st_dev", "st_ino", "st_size", "st_mtime_ns")
+    common = {name: getattr(metadata, name) for name in names}
+    path_info = SimpleNamespace(**common, st_ctime_ns=100)
+    handle = SimpleNamespace(**common, st_ctime_ns=100 if change == "legacy" else 200)
+    if change != "legacy":
+        path_info.st_birthtime_ns = 100
+        handle.st_birthtime_ns = 101 if change == "birthtime" else 100
+    after_info = SimpleNamespace(**vars(handle))
+    if change == "read_ctime":
+        after_info.st_ctime_ns = 300
+    observed = iter([handle, after_info])
+    monkeypatch.setattr(
+        Path, "lstat", lambda self: path_info if self == path else original_lstat(self)
+    )
+    monkeypatch.setattr(
+        config,
+        "os",
+        SimpleNamespace(
+            **{**vars(os), "name": platform, "fstat": lambda _: next(observed)}
+        ),
+    )
+    expected = (
+        "not network and not benchmark"
+        if platform == "nt" and change in {"none", "legacy"}
+        else None
+    )
+    assert config.targeted_marker_expression(tmp_path) == expected

--- a/tree_sitter_analyzer/mcp/tools/utils/verification_pytest_config.py
+++ b/tree_sitter_analyzer/mcp/tools/utils/verification_pytest_config.py
@@ -40,6 +40,17 @@ def _identity(info: os.stat_result) -> tuple[int, ...]:
     return (info.st_dev, info.st_ino, info.st_size, info.st_mtime_ns, info.st_ctime_ns)
 
 
+def _path_identity(info: os.stat_result) -> tuple[int, ...]:
+    """路径与句柄之间只比较同语义时间；同句柄读取前后仍检查 ctime。"""
+    # Windows 3.12 的 lstat.ctime 是创建时间，fstat.ctime 却是元数据变更时间。
+    if os.name == "nt":
+        return (
+            *_identity(info)[:-1],
+            getattr(info, "st_birthtime_ns", info.st_ctime_ns),
+        )
+    return _identity(info)
+
+
 def _read_config(path: Path) -> str:
     """只读取已核对身份的普通文件，拒绝链接、特殊文件及超大配置。"""
     before = path.lstat()
@@ -50,7 +61,9 @@ def _read_config(path: Path) -> str:
     descriptor = _open_config(path, flags)
     with os.fdopen(descriptor, "rb") as stream:
         current = os.fstat(stream.fileno())
-        if not stat.S_ISREG(current.st_mode) or _identity(before) != _identity(current):
+        if not stat.S_ISREG(current.st_mode) or _path_identity(
+            before
+        ) != _path_identity(current):
             raise ValueError("PYTEST_CONFIG_CHANGED")
         raw = stream.read(_MAX_CONFIG_BYTES + 1)
         after = os.fstat(stream.fileno())


### PR DESCRIPTION
Windows Python 3.12 sometimes rejected an unchanged pytest configuration, so explicitly selected test tiers stayed excluded. Develop full CI 34357512357 exposed the failure on Windows 3.12; two INI cases also failed before automatic test retries.

CPython 3.12.13 exposes creation time in path stat/lstat ctime but metadata change time in fstat ctime. Compare birth time across path/handle reads on Windows when available, using the legacy ctime fallback on Python 3.10. Keep exact device, inode, size, and mtime comparisons. Same-handle checks before/after reading still include ctime, so mutation protection remains intact.

Validation:
- Deterministic RED reproduced rejection when the path and handle have different ctime meanings. GREEN covers that case, legacy Windows metadata, POSIX rejection, changed birth time, and changed same-handle ctime.
- TSA-recommended focused verification: 405 passed. Broader config/runner focused coverage: 144 passed, 1 existing skip. Python 3.10 with four workers; final focused patch coverage has no added executable misses.
- Quick gate: 2,111 passed, 28 skipped in 26.65s. Independent review checked all compared fields. Ruff, mypy and commit hooks pass.
- Actual Windows 3.12 verification will use full CI on this branch; local simulation is not presented as a native Windows run.

CPython source: [path stat ctime conversion](https://github.com/python/cpython/blob/3bb231a6a5dc02b95658877318bf61501a7209e9/Modules/posixmodule.c#L2139-L2148), [fstat returns the underlying result](https://github.com/python/cpython/blob/3bb231a6a5dc02b95658877318bf61501a7209e9/Modules/posixmodule.c#L11174-L11194), [underlying ChangeTime assignment](https://github.com/python/cpython/blob/3bb231a6a5dc02b95658877318bf61501a7209e9/Python/fileutils.c#L1117-L1121).
