### PR TITLE
feat(pulse): reverse-import context for TypeScript/JavaScript

### DIFF
--- a/tests/unit/api/test_pulse_typescript_imported_by.py
+++ b/tests/unit/api/test_pulse_typescript_imported_by.py
@@ -1,0 +1,166 @@
+"""Pulse reverse-import context for TypeScript/JavaScript.
+
+``imported_by`` was Python-only: no ``module:`` edge carried a resolved file
+for other languages, and the module-name equality branch is gated on
+``t.language = 'python'``. Python can match by absolute dotted name because a
+target file yields exactly one module name; a TS specifier like ``./parser``
+is importer-relative and cannot be derived from the target, so TS resolves the
+specifier at index time and stores it in ``callee_resolved_file`` — the
+language-neutral branch the query already has.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tree_sitter_analyzer.api.pulse import query_pulse
+
+
+def _index(cache, paths: list) -> None:
+    for path in paths:
+        cache.index_file(str(path))
+
+
+@pytest.fixture
+def ts_project(tmp_path):
+    from tree_sitter_analyzer.ast_cache import ASTCache
+
+    def build(files: dict[str, str]):
+        for rel, body in files.items():
+            target = tmp_path / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(body, encoding="utf-8")
+        cache = ASTCache(str(tmp_path))
+        _index(cache, [tmp_path / rel for rel in files])
+        return cache
+
+    return build
+
+
+class TestTypeScriptReverseImport:
+    def test_named_import_is_reported(self, ts_project):
+        cache = ts_project(
+            {
+                "src/parser.ts": "export function parse() {\n  return 1;\n}\n",
+                "src/consumer.ts": "import { parse } from './parser';\nparse();\n",
+            }
+        )
+        try:
+            result = query_pulse(cache.get_conn(), "src/parser.ts", "parse")
+            assert result is not None
+            assert result.imported_by == ("src/consumer.ts",)
+        finally:
+            cache.close()
+
+    def test_parent_directory_specifier_is_reported(self, ts_project):
+        cache = ts_project(
+            {
+                "src/parser.ts": "export function parse() {\n  return 1;\n}\n",
+                "src/deep/consumer.ts": "import { parse } from '../parser';\nparse();\n",
+            }
+        )
+        try:
+            result = query_pulse(cache.get_conn(), "src/parser.ts", "parse")
+            assert result is not None
+            assert result.imported_by == ("src/deep/consumer.ts",)
+        finally:
+            cache.close()
+
+    def test_multiple_importers_are_all_reported(self, ts_project):
+        cache = ts_project(
+            {
+                "src/parser.ts": "export function parse() {\n  return 1;\n}\n",
+                "src/a.ts": "import { parse } from './parser';\nparse();\n",
+                "src/b.ts": "import { parse } from './parser';\nparse();\n",
+            }
+        )
+        try:
+            result = query_pulse(cache.get_conn(), "src/parser.ts", "parse")
+            assert result is not None
+            assert result.imported_by == ("src/a.ts", "src/b.ts")
+        finally:
+            cache.close()
+
+    def test_javascript_importer_of_typescript_target(self, ts_project):
+        # JS/TS are one language family; a gradual-migration repo cross-imports.
+        cache = ts_project(
+            {
+                "src/parser.ts": "export function parse() {\n  return 1;\n}\n",
+                "src/consumer.js": "import { parse } from './parser';\nparse();\n",
+            }
+        )
+        try:
+            result = query_pulse(cache.get_conn(), "src/parser.ts", "parse")
+            assert result is not None
+            assert result.imported_by == ("src/consumer.js",)
+        finally:
+            cache.close()
+
+
+class TestNoFalseEdges:
+    def test_bare_package_specifier_does_not_bind_to_a_project_file(self, ts_project):
+        # A project file named like a package must not be reported as imported
+        # just because a bare specifier shares its name.
+        cache = ts_project(
+            {
+                "src/react.ts": "export function parse() {\n  return 1;\n}\n",
+                "src/consumer.ts": "import { parse } from 'react';\nparse();\n",
+            }
+        )
+        try:
+            result = query_pulse(cache.get_conn(), "src/react.ts", "parse")
+            assert result is not None
+            assert result.imported_by == ()
+        finally:
+            cache.close()
+
+    def test_unrelated_importer_is_not_reported(self, ts_project):
+        cache = ts_project(
+            {
+                "src/parser.ts": "export function parse() {\n  return 1;\n}\n",
+                "src/other.ts": "export function other() {\n  return 2;\n}\n",
+                "src/consumer.ts": "import { other } from './other';\nother();\n",
+            }
+        )
+        try:
+            result = query_pulse(cache.get_conn(), "src/parser.ts", "parse")
+            assert result is not None
+            assert result.imported_by == ()
+        finally:
+            cache.close()
+
+    def test_target_own_outgoing_import_is_not_self_reported(self, ts_project):
+        cache = ts_project(
+            {
+                "src/parser.ts": (
+                    "import { helper } from './helper';\n"
+                    "export function parse() {\n  return helper();\n}\n"
+                ),
+                "src/helper.ts": "export function helper() {\n  return 1;\n}\n",
+            }
+        )
+        try:
+            result = query_pulse(cache.get_conn(), "src/parser.ts", "parse")
+            assert result is not None
+            assert "src/parser.ts" not in result.imported_by
+        finally:
+            cache.close()
+
+
+class TestPythonBehaviourUnchanged:
+    def test_python_reverse_import_still_works(self, tmp_path):
+        # Regression guard: the Python module-name branch must keep working.
+        from tree_sitter_analyzer.ast_cache import ASTCache
+
+        package = tmp_path / "pkg"
+        package.mkdir()
+        (package / "mod.py").write_text("def run():\n    pass\n", encoding="utf-8")
+        (package / "consumer.py").write_text("from .mod import run\n", encoding="utf-8")
+        cache = ASTCache(str(tmp_path))
+        try:
+            _index(cache, [package / "mod.py", package / "consumer.py"])
+            result = query_pulse(cache.get_conn(), "pkg/mod.py", "run")
+            assert result is not None
+            assert result.imported_by == ("pkg/consumer.py",)
+        finally:
+            cache.close()

--- a/tests/unit/synapse_resolver/test_typescript_imports.py
+++ b/tests/unit/synapse_resolver/test_typescript_imports.py
@@ -1,0 +1,192 @@
+"""Unit tests for TypeScript/JavaScript import parsing (reverse-import support).
+
+Pulse's ``imported_by`` context was Python-only because ``parse_imports``
+returned an empty list for every other language, so no ``module:`` edge was
+ever written for TS/JS files. These tests lock in the ES-module forms that
+carry a resolvable specifier, and — critically — the forms that must NOT
+produce a row (bare package specifiers are external, not project files).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tree_sitter_analyzer.synapse_resolver._imports import ImportEntry, parse_imports
+
+
+def _entry(
+    module_path: str,
+    local_name: str = "",
+    *,
+    is_relative: bool = True,
+    is_star: bool = False,
+    alias_of: str = "",
+    language: str = "typescript",
+    file_path: str = "src/consumer.ts",
+    line: int = 5,
+) -> ImportEntry:
+    return ImportEntry(
+        file_path=file_path,
+        language=language,
+        module_path=module_path,
+        local_name=local_name,
+        is_relative=is_relative,
+        is_star=is_star,
+        alias_of=alias_of,
+        line=line,
+    )
+
+
+class TestNamedImports:
+    def test_single_named_import(self) -> None:
+        assert parse_imports(
+            "import { parse } from './parser';", "typescript", "src/consumer.ts", 5
+        ) == [_entry("./parser", "parse")]
+
+    def test_multiple_named_imports_produce_one_row_each(self) -> None:
+        rows = parse_imports(
+            "import { parse, render } from './parser';",
+            "typescript",
+            "src/consumer.ts",
+            5,
+        )
+        assert rows == [_entry("./parser", "parse"), _entry("./parser", "render")]
+
+    def test_aliased_named_import_records_alias_of(self) -> None:
+        assert parse_imports(
+            "import { parse as doParse } from './parser';",
+            "typescript",
+            "src/consumer.ts",
+            5,
+        ) == [_entry("./parser", "doParse", alias_of="parse")]
+
+    def test_type_only_named_import_is_still_an_edge(self) -> None:
+        # A type-only import still creates a real file->file dependency.
+        assert parse_imports(
+            "import type { Node } from './ast';", "typescript", "src/consumer.ts", 5
+        ) == [_entry("./ast", "Node")]
+
+
+class TestDefaultAndNamespaceImports:
+    def test_default_import(self) -> None:
+        assert parse_imports(
+            "import parser from './parser';", "typescript", "src/consumer.ts", 5
+        ) == [_entry("./parser", "parser")]
+
+    def test_namespace_import_is_star(self) -> None:
+        rows = parse_imports(
+            "import * as parser from './parser';", "typescript", "src/consumer.ts", 5
+        )
+        assert len(rows) == 1
+        assert rows[0].is_star is True
+        assert rows[0].local_name == "parser"
+        assert rows[0].module_path == "./parser"
+
+    def test_default_plus_named_combination(self) -> None:
+        rows = parse_imports(
+            "import parser, { parse } from './parser';",
+            "typescript",
+            "src/consumer.ts",
+            5,
+        )
+        assert [r.local_name for r in rows] == ["parser", "parse"]
+        assert {r.module_path for r in rows} == {"./parser"}
+
+    def test_side_effect_only_import_has_no_bound_name(self) -> None:
+        rows = parse_imports(
+            "import './polyfills';", "typescript", "src/consumer.ts", 5
+        )
+        assert len(rows) == 1
+        assert rows[0].module_path == "./polyfills"
+        assert rows[0].local_name == ""
+
+
+class TestRelativeAndAbsoluteSpecifiers:
+    @pytest.mark.parametrize(
+        "specifier", ["./parser", "../parser", "../../lib/parser", "./a/b/parser"]
+    )
+    def test_relative_specifiers_are_marked_relative(self, specifier: str) -> None:
+        rows = parse_imports(
+            f"import {{ x }} from '{specifier}';", "typescript", "src/consumer.ts", 5
+        )
+        assert rows[0].is_relative is True
+        assert rows[0].module_path == specifier
+
+    @pytest.mark.parametrize(
+        "specifier", ["react", "@scope/pkg", "node:fs", "lodash/fp"]
+    )
+    def test_bare_package_specifiers_are_not_relative(self, specifier: str) -> None:
+        # These are external packages. They must still be recorded (the import
+        # exists) but must not be flagged relative, so module->file resolution
+        # never mistakes them for a project file.
+        rows = parse_imports(
+            f"import {{ x }} from '{specifier}';", "typescript", "src/consumer.ts", 5
+        )
+        assert rows[0].is_relative is False
+        assert rows[0].module_path == specifier
+
+
+class TestQuotingAndFormatting:
+    @pytest.mark.parametrize("quote", ["'", '"'])
+    def test_both_quote_styles(self, quote: str) -> None:
+        rows = parse_imports(
+            f"import {{ x }} from {quote}./parser{quote};",
+            "typescript",
+            "src/consumer.ts",
+            5,
+        )
+        assert rows[0].module_path == "./parser"
+
+    def test_missing_semicolon_is_accepted(self) -> None:
+        rows = parse_imports(
+            "import { x } from './parser'", "typescript", "src/consumer.ts", 5
+        )
+        assert rows[0].module_path == "./parser"
+
+    def test_multiline_named_import_block(self) -> None:
+        text = "import {\n  parse,\n  render,\n} from './parser';"
+        rows = parse_imports(text, "typescript", "src/consumer.ts", 5)
+        assert [r.local_name for r in rows] == ["parse", "render"]
+
+    def test_line_comment_is_stripped_before_matching(self) -> None:
+        text = "import { parse } from './parser'; // keep this out"
+        rows = parse_imports(text, "typescript", "src/consumer.ts", 5)
+        assert rows == [_entry("./parser", "parse")]
+
+
+class TestNonImportStatementsAreIgnored:
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "",
+            "   ",
+            "const parser = require('./parser');",
+            "export { parse } from './parser';",
+            "// import { parse } from './parser';",
+            "function importSomething() {}",
+        ],
+    )
+    def test_no_rows_for_non_import_statements(self, text: str) -> None:
+        assert parse_imports(text, "typescript", "src/consumer.ts", 5) == []
+
+
+class TestJavaScriptDialectSharesTheParser:
+    @pytest.mark.parametrize("language", ["javascript", "typescript"])
+    def test_both_dialects_parse(self, language: str) -> None:
+        rows = parse_imports(
+            "import { parse } from './parser';", language, "src/consumer.js", 5
+        )
+        assert len(rows) == 1
+        assert rows[0].language == language
+        assert rows[0].module_path == "./parser"
+
+
+class TestUnsupportedLanguagesStillReturnEmpty:
+    @pytest.mark.parametrize("language", ["go", "rust", "bash", "css"])
+    def test_no_regression_for_languages_without_a_parser(self, language: str) -> None:
+        assert (
+            parse_imports(
+                "import { parse } from './parser';", language, "src/consumer.x", 5
+            )
+            == []
+        )

--- a/tests/unit/synapse_resolver/test_typescript_module_resolution.py
+++ b/tests/unit/synapse_resolver/test_typescript_module_resolution.py
@@ -1,0 +1,146 @@
+"""Unit tests for TypeScript/JavaScript relative-specifier -> file resolution.
+
+ES-module specifiers omit the extension (``./parser`` may be ``parser.ts``,
+``parser.tsx``, or ``parser/index.ts``), so resolution needs an ordered
+candidate list checked against the set of indexed files. Only ``./``/``../``
+specifiers resolve; bare package specifiers must never resolve to a project
+file even when a same-named file happens to be indexed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tree_sitter_analyzer.synapse_resolver._typescript_imports import (
+    resolve_typescript_specifier,
+)
+
+
+class TestExtensionCandidateOrder:
+    @pytest.mark.parametrize(
+        ("indexed", "expected"),
+        [
+            ({"src/parser.ts"}, "src/parser.ts"),
+            ({"src/parser.tsx"}, "src/parser.tsx"),
+            ({"src/parser.d.ts"}, "src/parser.d.ts"),
+            ({"src/parser.js"}, "src/parser.js"),
+            ({"src/parser.jsx"}, "src/parser.jsx"),
+            ({"src/parser.mts"}, "src/parser.mts"),
+            ({"src/parser/index.ts"}, "src/parser/index.ts"),
+            ({"src/parser/index.tsx"}, "src/parser/index.tsx"),
+            ({"src/parser/index.js"}, "src/parser/index.js"),
+        ],
+    )
+    def test_each_supported_extension_resolves(
+        self, indexed: set[str], expected: str
+    ) -> None:
+        assert (
+            resolve_typescript_specifier("./parser", "src/consumer.ts", indexed)
+            == expected
+        )
+
+    def test_source_extension_wins_over_index_directory(self) -> None:
+        # A file next to the consumer is a closer match than a directory
+        # barrel of the same name; TS resolves the file first.
+        indexed = {"src/parser.ts", "src/parser/index.ts"}
+        assert (
+            resolve_typescript_specifier("./parser", "src/consumer.ts", indexed)
+            == "src/parser.ts"
+        )
+
+    def test_typescript_wins_over_javascript(self) -> None:
+        indexed = {"src/parser.js", "src/parser.ts"}
+        assert (
+            resolve_typescript_specifier("./parser", "src/consumer.ts", indexed)
+            == "src/parser.ts"
+        )
+
+
+class TestRelativePathArithmetic:
+    def test_same_directory(self) -> None:
+        assert (
+            resolve_typescript_specifier(
+                "./parser", "src/consumer.ts", {"src/parser.ts"}
+            )
+            == "src/parser.ts"
+        )
+
+    def test_parent_directory(self) -> None:
+        assert (
+            resolve_typescript_specifier(
+                "../parser", "src/deep/consumer.ts", {"src/parser.ts"}
+            )
+            == "src/parser.ts"
+        )
+
+    def test_two_levels_up(self) -> None:
+        assert (
+            resolve_typescript_specifier(
+                "../../parser", "src/a/b/consumer.ts", {"src/parser.ts"}
+            )
+            == "src/parser.ts"
+        )
+
+    def test_nested_subdirectory(self) -> None:
+        assert (
+            resolve_typescript_specifier(
+                "./lib/parser", "src/consumer.ts", {"src/lib/parser.ts"}
+            )
+            == "src/lib/parser.ts"
+        )
+
+    def test_explicit_extension_in_specifier_is_honoured(self) -> None:
+        # NodeNext/ESM style: './parser.js' may point at the emitted name while
+        # the indexed source is parser.ts, but an exact indexed hit wins first.
+        assert (
+            resolve_typescript_specifier(
+                "./parser.ts", "src/consumer.ts", {"src/parser.ts"}
+            )
+            == "src/parser.ts"
+        )
+
+    def test_consumer_at_repository_root(self) -> None:
+        assert (
+            resolve_typescript_specifier("./parser", "consumer.ts", {"parser.ts"})
+            == "parser.ts"
+        )
+
+    def test_windows_style_consumer_path_is_normalized(self) -> None:
+        assert (
+            resolve_typescript_specifier(
+                "./parser", "src\\consumer.ts", {"src/parser.ts"}
+            )
+            == "src/parser.ts"
+        )
+
+
+class TestNonResolvingSpecifiers:
+    @pytest.mark.parametrize(
+        "specifier", ["react", "@scope/pkg", "node:fs", "lodash/fp"]
+    )
+    def test_bare_package_specifier_never_resolves(self, specifier: str) -> None:
+        # Even with a decoy file of the same name indexed, a bare specifier is
+        # an external package and must not bind to a project file.
+        indexed = {"react.ts", "src/react.ts", "@scope/pkg.ts", "node:fs.ts"}
+        assert resolve_typescript_specifier(specifier, "src/consumer.ts", indexed) == ""
+
+    def test_unindexed_target_returns_empty(self) -> None:
+        assert (
+            resolve_typescript_specifier(
+                "./missing", "src/consumer.ts", {"src/other.ts"}
+            )
+            == ""
+        )
+
+    def test_escaping_above_the_repository_root_returns_empty(self) -> None:
+        assert (
+            resolve_typescript_specifier(
+                "../../../outside", "src/consumer.ts", {"outside.ts"}
+            )
+            == ""
+        )
+
+    def test_empty_specifier_returns_empty(self) -> None:
+        assert (
+            resolve_typescript_specifier("", "src/consumer.ts", {"src/parser.ts"}) == ""
+        )

--- a/tree_sitter_analyzer/cache/write.py
+++ b/tree_sitter_analyzer/cache/write.py
@@ -9,6 +9,7 @@ import re
 import sqlite3
 import time
 from collections import OrderedDict
+from collections.abc import Callable
 from typing import Any
 
 from ..index_symbol_projection import (
@@ -544,6 +545,39 @@ def write_imports_for_file(
                 return
 
 
+#: Languages whose import specifiers are importer-relative, so the resolved
+#: file must be computed at index time rather than derived from the target.
+_RELATIVE_SPECIFIER_LANGUAGES = ("typescript", "javascript")
+
+
+def _import_specifier_resolver(
+    conn: sqlite3.Connection, language: str
+) -> Callable[[str, str], str]:
+    """Return a ``(specifier, importer) -> resolved_file`` callable.
+
+    Languages without importer-relative specifiers get a no-op resolver, so
+    Python keeps matching through its module-name branch unchanged.
+    """
+    if language not in _RELATIVE_SPECIFIER_LANGUAGES:
+        return lambda specifier, importer: ""
+    try:
+        from ..synapse_resolver._typescript_imports import (
+            resolve_typescript_specifier,
+        )
+
+        indexed = {
+            str(row[0]) for row in conn.execute("SELECT file_path FROM ast_index")
+        }
+    except Exception as exc:  # pragma: no cover - resolution is best-effort
+        logger.debug("import specifier resolver unavailable: %s", exc)
+        return lambda specifier, importer: ""
+
+    def resolve(specifier: str, importer: str) -> str:
+        return resolve_typescript_specifier(specifier, importer, indexed)
+
+    return resolve
+
+
 def write_graph_edges_for_file(
     conn: sqlite3.Connection,
     rel_path: str,
@@ -617,6 +651,7 @@ def write_graph_edges_for_file(
             )
         )
 
+    resolve_specifier = _import_specifier_resolver(conn, language)
     for raw in imports or []:
         text, line = _parse_import_raw(raw)
         if not text:
@@ -635,6 +670,12 @@ def write_graph_edges_for_file(
                         "is_relative": entry.is_relative,
                         "is_star": entry.is_star,
                         "alias_of": entry.alias_of,
+                        # Importer-relative specifiers cannot be derived from
+                        # the target, so resolve here and let the query match
+                        # on the language-neutral resolved-file column.
+                        "callee_resolved_file": resolve_specifier(
+                            entry.module_path, rel_path
+                        ),
                     },
                 )
             )

--- a/tree_sitter_analyzer/synapse_resolver/_imports.py
+++ b/tree_sitter_analyzer/synapse_resolver/_imports.py
@@ -65,9 +65,9 @@ def parse_imports(
     """Parse one import statement into structured rows (language dispatch).
 
     Python (``from .b import x, y`` etc.) keeps its original behaviour
-    byte-for-byte via :func:`_parse_python_imports`. Java dispatches to
-    the Java import parser. Any other language returns an empty list,
-    matching the pre-B3 non-Python behaviour (no regression).
+    byte-for-byte via :func:`_parse_python_imports`. Java and TypeScript/
+    JavaScript dispatch to their own parsers. Any other language returns an
+    empty list, matching the pre-B3 non-Python behaviour (no regression).
     """
     if language == "python":
         return _parse_python_imports(text, file_path, line)
@@ -75,6 +75,10 @@ def parse_imports(
         from ._java import parse_java_imports
 
         return parse_java_imports(text, file_path, line)
+    if language in ("typescript", "javascript"):
+        from ._typescript_imports import parse_typescript_imports
+
+        return parse_typescript_imports(text, language, file_path, line)
     return []
 
 

--- a/tree_sitter_analyzer/synapse_resolver/_typescript_imports.py
+++ b/tree_sitter_analyzer/synapse_resolver/_typescript_imports.py
@@ -1,0 +1,167 @@
+"""TypeScript/JavaScript ES-module import parsing.
+
+Produces ``ImportEntry`` rows so TS/JS files get ``module:`` import edges,
+which is what Pulse's ``imported_by`` context reads. Only static ES-module
+``import`` declarations are parsed; ``require()`` and re-exports are out of
+scope because they need call-expression and export-graph handling
+respectively.
+
+The specifier is recorded verbatim. ``is_relative`` is True only for ``./``
+and ``../`` specifiers — the forms that can name a project file. Bare
+specifiers (``react``, ``@scope/pkg``, ``node:fs``) are recorded but left
+non-relative so module->file resolution never mistakes a package for a
+project file.
+"""
+
+from __future__ import annotations
+
+import os
+import posixpath
+import re
+from collections.abc import Iterable
+
+from ._imports import ImportEntry
+
+#: Checked in order, so a source file beside the consumer wins over a
+#: directory barrel, and TypeScript wins over emitted JavaScript.
+_TS_RESOLUTION_SUFFIXES = (
+    "",
+    ".ts",
+    ".tsx",
+    ".mts",
+    ".cts",
+    ".d.ts",
+    ".js",
+    ".jsx",
+    ".mjs",
+    ".cjs",
+    "/index.ts",
+    "/index.tsx",
+    "/index.mts",
+    "/index.cts",
+    "/index.js",
+    "/index.jsx",
+)
+
+#: ``import <clause> from '<specifier>'`` — the clause is optional so a
+#: side-effect-only ``import './x'`` also matches.
+_TS_IMPORT_RE = re.compile(
+    r"^import\s+(?:type\s+)?(?:(?P<clause>.+?)\s+from\s+)?"
+    r"(?P<quote>['\"])(?P<specifier>[^'\"]+)(?P=quote)\s*;?\s*$",
+    re.DOTALL,
+)
+
+#: ``{ a, b as c }`` inside an import clause.
+_TS_NAMED_BLOCK_RE = re.compile(r"\{(?P<names>[^}]*)\}", re.DOTALL)
+
+#: ``* as ns``
+_TS_NAMESPACE_RE = re.compile(r"^\*\s+as\s+(?P<local>[\w$]+)$")
+
+_STRIP_LINE_COMMENTS_RE = re.compile(r"//[^\n]*")
+
+
+def _strip_line_comments(text: str) -> str:
+    return _STRIP_LINE_COMMENTS_RE.sub("", text)
+
+
+def _split_named_bindings(names: str) -> list[tuple[str, str]]:
+    """Return ``(local_name, alias_of)`` for each name in a ``{...}`` block."""
+    out: list[tuple[str, str]] = []
+    for raw in names.split(","):
+        item = raw.strip()
+        if item.startswith("type "):
+            item = item[len("type ") :].strip()
+        if not item:
+            continue
+        if " as " in item:
+            orig, alias = item.split(" as ", 1)
+            out.append((alias.strip(), orig.strip()))
+        else:
+            out.append((item, ""))
+    return out
+
+
+def _is_relative(specifier: str) -> bool:
+    return specifier.startswith("./") or specifier.startswith("../")
+
+
+def resolve_typescript_specifier(
+    specifier: str, importer_file: str, indexed_files: Iterable[str]
+) -> str:
+    """Resolve a relative TS/JS specifier to an indexed project file.
+
+    Returns ``""`` when the specifier is not relative, names nothing indexed,
+    or escapes the repository root. Bare package specifiers never resolve —
+    binding ``react`` to a project ``react.ts`` would be a false edge.
+    """
+    if not specifier or not _is_relative(specifier):
+        return ""
+    importer_dir = posixpath.dirname(importer_file.replace(os.sep, "/"))
+    base = posixpath.normpath(posixpath.join(importer_dir, specifier))
+    # normpath collapses '..' but leaves a leading '..' when the specifier
+    # climbs above the root; such a path can never name an indexed file.
+    if base == ".." or base.startswith("../"):
+        return ""
+    if base == ".":
+        return ""
+    known = (
+        indexed_files
+        if isinstance(indexed_files, (set, frozenset))
+        else set(indexed_files)
+    )
+    for suffix in _TS_RESOLUTION_SUFFIXES:
+        candidate = f"{base}{suffix}"
+        if candidate in known:
+            return candidate
+    return ""
+
+
+def parse_typescript_imports(
+    text: str, language: str, file_path: str = "", line: int = 0
+) -> list[ImportEntry]:
+    """Parse one TS/JS import declaration into one row per bound name."""
+    cleaned = _strip_line_comments(text).strip()
+    if not cleaned:
+        return []
+    match = _TS_IMPORT_RE.match(cleaned)
+    if not match:
+        return []
+
+    specifier = match.group("specifier")
+    relative = _is_relative(specifier)
+
+    def row(
+        local_name: str, *, is_star: bool = False, alias_of: str = ""
+    ) -> ImportEntry:
+        return ImportEntry(
+            file_path=file_path,
+            language=language,
+            module_path=specifier,
+            local_name=local_name,
+            is_relative=relative,
+            is_star=is_star,
+            alias_of=alias_of,
+            line=line,
+        )
+
+    clause = (match.group("clause") or "").strip()
+    if not clause:
+        # Side-effect-only import: the edge exists, nothing is bound.
+        return [row("")]
+
+    namespace = _TS_NAMESPACE_RE.match(clause)
+    if namespace:
+        return [row(namespace.group("local"), is_star=True)]
+
+    rows: list[ImportEntry] = []
+    named_block = _TS_NAMED_BLOCK_RE.search(clause)
+    # A default binding is whatever precedes the named block (or the whole
+    # clause when there is no block): ``parser, { parse }`` -> ``parser``.
+    head = clause[: named_block.start()] if named_block else clause
+    default_name = head.replace(",", " ").strip()
+    if default_name and not default_name.startswith("*"):
+        rows.append(row(default_name))
+    if named_block:
+        for local_name, alias_of in _split_named_bindings(named_block.group("names")):
+            rows.append(row(local_name, alias_of=alias_of))
+    return rows

--- a/tree_sitter_analyzer/synapse_resolver/_typescript_imports.py
+++ b/tree_sitter_analyzer/synapse_resolver/_typescript_imports.py
@@ -15,7 +15,6 @@ project file.
 
 from __future__ import annotations
 
-import os
 import posixpath
 import re
 from collections.abc import Iterable
@@ -96,7 +95,7 @@ def resolve_typescript_specifier(
     """
     if not specifier or not _is_relative(specifier):
         return ""
-    importer_dir = posixpath.dirname(importer_file.replace(os.sep, "/"))
+    importer_dir = posixpath.dirname(importer_file.replace("\\", "/"))
     base = posixpath.normpath(posixpath.join(importer_dir, specifier))
     # normpath collapses '..' but leaves a leading '..' when the specifier
     # climbs above the root; such a path can never name an indexed file.


### PR DESCRIPTION
## Summary

`imported_by` in Pulse was Python-only. This PR extends it to TypeScript and JavaScript by solving all three blocking layers with TDD.

**Root cause (three layers, not one):**

| Layer | Before | After |
|---|---|---|
| ① Import parsing | Python + Java only (`parse_imports` returned `[]` for TS/JS) | New `_typescript_imports.py` handles ES-module `import` declarations |
| ② module→file resolution | Python-only `_build_module_to_file` (`.py`/`__init__.py`) | New `resolve_typescript_specifier()` with ordered extension/barrel candidates |
| ③ SQL gate | `t.language = 'python'` hardcode | **Unchanged** — resolved file stored at index time in `callee_resolved_file`, using the language-neutral branch already in the query |

A TS specifier like `./parser` is importer-relative and cannot be derived from the target (unlike Python's absolute `pkg.mod`), so the specifier is resolved at write time and stored in `callee_resolved_file`. No SQL change was needed.

**Scope:** TypeScript and JavaScript. Bare package specifiers (`react`, `@scope/pkg`, `node:fs`) are recorded but never resolved — a same-named project file can never be falsely bound. Python's existing module-name path is untouched (regression guard included).

## Test plan

- [x] 33 import-parsing unit tests (named/default/namespace/type-only/side-effect-only/multi-line/both-quote-styles/negative cases)
- [x] 25 specifier-resolution unit tests (extension priority, path arithmetic, Windows path normalization, bare-specifier rejection)
- [x] 8 real-index Pulse integration tests (same-dir, parent-dir, multiple importers, JS importer of TS target, three no-false-edge cases, Python regression guard)
- [x] Existing synapse_resolver + pulse test suites: 216 passed, 0 regressions
- [x] ruff, ruff format, mypy, all pre-commit hooks pass

Note on pre-existing failures: broad test run shows 21 failures on Windows (health scorer / benchmark harness / symlink permission) that reproduce identically without this change — confirmed pre-existing environment issue, not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)