### PR TITLE
fix(pulse): degrade over-limit enrichment and mark imports graph availability

### DIFF
--- a/tests/unit/api/test_pulse.py
+++ b/tests/unit/api/test_pulse.py
@@ -313,6 +313,20 @@ def test_budget_uses_optional_tokenizer_without_network(monkeypatch):
     assert any("注释" in json.dumps(value, ensure_ascii=False) for value in calls)
 
 
+def test_budget_falls_back_when_tokenizer_breaks(monkeypatch):
+    """审计 P2-1：tiktoken 已安装但初始化失败（如离线冷缓存）时回退字符估算，不崩。"""
+    import sys
+    from types import SimpleNamespace
+
+    def broken(name):
+        raise RuntimeError("network unavailable")
+
+    monkeypatch.setitem(sys.modules, "tiktoken", SimpleNamespace(get_encoding=broken))
+    result = apply_budget(_make_pr_with_comments(10), token_budget=1)
+    assert result.comments == ()
+    assert result.truncated_fields == ("comments",)
+
+
 # ---------------------------------------------------------------------------
 # apply_budget — immutability
 # ---------------------------------------------------------------------------
@@ -396,6 +410,18 @@ def test_query_pulse_no_call_graph_language(ast_cache_conn):
     assert result.call_graph_available is False
     assert result.callers == ()
     assert result.callees == ()
+
+
+def test_query_pulse_imports_graph_availability_by_language(ast_cache_conn):
+    """issue #1444：无 import 边语言显式声明 iga=False，imported_by 是「声明过的空」。"""
+    _seed_symbol(ast_cache_conn, "my_query", "report.sql", language="sql")
+    result = query_pulse(ast_cache_conn, "report.sql", "my_query")
+    assert result.imports_graph_available is False
+    assert result.imported_by == ()
+
+    _seed_symbol(ast_cache_conn, "greet", "a.py")
+    py = query_pulse(ast_cache_conn, "a.py", "greet")
+    assert py.imports_graph_available is True
 
 
 def test_query_pulse_returns_none_for_missing_symbol(ast_cache_conn):
@@ -694,79 +720,39 @@ def test_pulse_legacy_comments_are_not_reported_as_empty_success(tmp_path):
         cache.close()
 
 
-@pytest.mark.parametrize("format", ["compact", "verbose"])
-def test_serialization_preserves_relationship_payloads(format):
-    # PR #1352：发布格式不能丢失关系身份、解析状态或 Git 消息。
-    from tree_sitter_analyzer.api.pulse import CalleeRef, GitHeat, ImportRef, SiblingRef
-    from tree_sitter_analyzer.api.serialization import serialize
-
-    pulse = PulseResponse(
-        symbol=_MINIMAL_SYM,
-        callers=(CallerRef("caller", "caller.py", 7, 3),),
-        callees=(CalleeRef("callee", "callee.py", 11, "resolved"),),
-        git_heat=GitHeat(
-            commit="sha", commit_msg="message", at=123, mod_30d=2, mod_90d=4, mod_all=5
-        ),
-        imports=(ImportRef("pkg", "pkg.py"),),
-        imported_by=("consumer.py",),
-        siblings=(SiblingRef("other", "function", 20),),
-        comments=(CommentRef(2, "note", "inline"),),
-    )
-    result = serialize(pulse, format)
-    if format == "compact":
-        assert result["cr"] == [{"n": "caller", "f": "caller.py", "l": 7, "h": 3}]
-        assert result["ce"] == [
-            {"n": "callee", "f": "callee.py", "l": 11, "r": "resolved"}
-        ]
-        assert result["gh"] == {
-            "sha": "sha",
-            "m": "message",
-            "at": 123,
-            "m30": 2,
-            "m90": 4,
-            "mall": 5,
-            "s": "tracked",
-        }
-        assert result["im"] == [{"m": "pkg", "f": "pkg.py"}]
-        assert result["ib"] == ["consumer.py"]
-        assert result["sib"] == [{"n": "other", "k": "function", "l": 20}]
-        assert result["cmt"] == [{"l": 2, "t": "note", "k": "inline"}]
-    else:
-        assert result["callers"] == [
-            {"name": "caller", "file": "caller.py", "line": 7, "hot30": 3}
-        ]
-        assert result["callees"] == [
-            {
-                "name": "callee",
-                "file": "callee.py",
-                "line": 11,
-                "resolution": "resolved",
-            }
-        ]
-        assert result["git_heat"] == {
-            "commit": "sha",
-            "commit_msg": "message",
-            "at": 123,
-            "mod_30d": 2,
-            "mod_90d": 4,
-            "mod_all": 5,
-            "state": "tracked",
-        }
-        assert result["imports"] == [{"module": "pkg", "file": "pkg.py"}]
-        assert result["imported_by"] == ["consumer.py"]
-        assert result["siblings"] == [{"name": "other", "kind": "function", "line": 20}]
-        assert result["comments"] == [{"line": 2, "text": "note", "kind": "inline"}]
+# 序列化视图契约测试已拆至 test_pulse_serialization.py（issue #1444/#1445
+# 测试增长使本文件越过 800 行治理阈值，断言原样迁移）。
 
 
-def test_query_pulse_import_capacity_is_an_error(ast_cache_conn):
-    """PR #1352：保留 SQL 层的反向导入资源上限见证，超限不能返回空列表。"""
+def test_query_pulse_import_capacity_degrades_instead_of_failing(ast_cache_conn):
+    """issue #1445：超资源上限时降级而非整体报错。
+
+    保留 #1352 的见证意图（超限不能静默返回空列表）：SQL 侧结果保留，
+    且 truncated_fields 必须声明 imported_by 被截断，其余字段不受影响。
+    """
     _seed_symbol(ast_cache_conn, "greet", "a.py")
     ast_cache_conn.executemany(
         "INSERT INTO ast_imports(file_path,language,module_path) VALUES ('a.py','python',?)",
         [(f"module_{i}",) for i in range(20001)],
     )
-    with pytest.raises(ValueError, match="PULSE_IMPORT_RESOURCE_LIMIT"):
-        query_pulse(ast_cache_conn, "a.py", "greet", max_comments=0)
+    result = query_pulse(ast_cache_conn, "a.py", "greet", max_comments=0)
+    assert result is not None
+    assert result.symbol.name == "greet"
+    assert "imported_by" in result.truncated_fields
+    # 降级只影响 imported_by 富化，其余上下文照常返回。
+    assert result.callers == ()
+    assert result.call_graph_available is True
+
+
+def test_apply_budget_preserves_query_side_truncated_fields():
+    """issue #1445：预算裁剪不得覆盖 query_pulse 已声明的截断（合并去重保序）。"""
+    import dataclasses
+
+    pr = dataclasses.replace(
+        _make_pr_with_comments(10), truncated_fields=("imported_by",)
+    )
+    result = apply_budget(pr, token_budget=1)
+    assert result.truncated_fields == ("imported_by", "comments")
 
 
 def test_certified_pulse_missing_index_is_read_only(tmp_path):

--- a/tests/unit/api/test_pulse_serialization.py
+++ b/tests/unit/api/test_pulse_serialization.py
@@ -1,0 +1,118 @@
+"""Pulse 序列化视图的契约测试。
+
+从 test_pulse.py 拆出（issue #1444/#1445 的测试增长使原文件越过 800 行
+治理阈值），断言原样迁移，仅调整导入位置。
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from tree_sitter_analyzer.api.pulse import (
+    CalleeRef,
+    CallerRef,
+    CommentRef,
+    GitHeat,
+    ImportRef,
+    PulseResponse,
+    SiblingRef,
+    SymbolInfo,
+)
+from tree_sitter_analyzer.api.serialization import serialize
+
+_MINIMAL_SYM = SymbolInfo(
+    name="fn",
+    kind="function",
+    file="a.py",
+    line=1,
+    end_line=5,
+    language="python",
+)
+
+_MINIMAL_PR = PulseResponse(symbol=_MINIMAL_SYM)
+
+
+@pytest.mark.parametrize("format", ["compact", "verbose"])
+def test_serialization_preserves_relationship_payloads(format):
+    # PR #1352：发布格式不能丢失关系身份、解析状态或 Git 消息。
+    pulse = PulseResponse(
+        symbol=_MINIMAL_SYM,
+        callers=(CallerRef("caller", "caller.py", 7, 3),),
+        callees=(CalleeRef("callee", "callee.py", 11, "resolved"),),
+        git_heat=GitHeat(
+            commit="sha", commit_msg="message", at=123, mod_30d=2, mod_90d=4, mod_all=5
+        ),
+        imports=(ImportRef("pkg", "pkg.py"),),
+        imported_by=("consumer.py",),
+        siblings=(SiblingRef("other", "function", 20),),
+        comments=(CommentRef(2, "note", "inline"),),
+    )
+    result = serialize(pulse, format)
+    if format == "compact":
+        assert result["cr"] == [{"n": "caller", "f": "caller.py", "l": 7, "h": 3}]
+        assert result["ce"] == [
+            {"n": "callee", "f": "callee.py", "l": 11, "r": "resolved"}
+        ]
+        assert result["gh"] == {
+            "sha": "sha",
+            "m": "message",
+            "at": 123,
+            "m30": 2,
+            "m90": 4,
+            "mall": 5,
+            "s": "tracked",
+        }
+        assert result["im"] == [{"m": "pkg", "f": "pkg.py"}]
+        assert result["ib"] == ["consumer.py"]
+        assert result["sib"] == [{"n": "other", "k": "function", "l": 20}]
+        assert result["cmt"] == [{"l": 2, "t": "note", "k": "inline"}]
+    else:
+        assert result["callers"] == [
+            {"name": "caller", "file": "caller.py", "line": 7, "hot30": 3}
+        ]
+        assert result["callees"] == [
+            {
+                "name": "callee",
+                "file": "callee.py",
+                "line": 11,
+                "resolution": "resolved",
+            }
+        ]
+        assert result["git_heat"] == {
+            "commit": "sha",
+            "commit_msg": "message",
+            "at": 123,
+            "mod_30d": 2,
+            "mod_90d": 4,
+            "mod_all": 5,
+            "state": "tracked",
+        }
+        assert result["imports"] == [{"module": "pkg", "file": "pkg.py"}]
+        assert result["imported_by"] == ["consumer.py"]
+        assert result["siblings"] == [{"name": "other", "kind": "function", "line": 20}]
+        assert result["comments"] == [{"line": 2, "text": "note", "kind": "inline"}]
+
+
+def test_compact_availability_keys_and_conditional_reason():
+    """issue #1444：iga 常驻；cgr 仅在 call_graph 不可用时出现；verbose 出全键。"""
+    ok = serialize(_MINIMAL_PR, format="compact")
+    assert ok["cg"] is True
+    assert "cgr" not in ok
+    assert ok["iga"] is True
+
+    broken = dataclasses.replace(
+        _MINIMAL_PR,
+        call_graph_available=False,
+        call_graph_reason="sql: call-graph not supported",
+        imports_graph_available=False,
+        truncated_fields=("imported_by",),
+    )
+    out = serialize(broken, format="compact")
+    assert out["cgr"] == "sql: call-graph not supported"
+    assert out["iga"] is False
+    assert out["trunc"] == ["imported_by"]
+    verbose = serialize(broken, format="verbose")
+    assert verbose["imports_graph_available"] is False
+    assert verbose["call_graph_reason"] == "sql: call-graph not supported"

--- a/tree_sitter_analyzer/api/_pulse_models.py
+++ b/tree_sitter_analyzer/api/_pulse_models.py
@@ -96,6 +96,8 @@ class PulseResponse:
     truncated_fields: tuple[str, ...] = field(default_factory=tuple)
     call_graph_available: bool = True
     call_graph_reason: str = ""
+    # 反向导入（import 边）是否支持该符号的语言；False 时 imported_by 恒为空（issue #1444）。
+    imports_graph_available: bool = True
     callers: tuple[CallerRef, ...] = field(default_factory=tuple)
     callees: tuple[CalleeRef, ...] = field(default_factory=tuple)
     git_heat: GitHeat | None = None

--- a/tree_sitter_analyzer/api/pulse.py
+++ b/tree_sitter_analyzer/api/pulse.py
@@ -66,6 +66,10 @@ _NO_CALL_GRAPH_LANGUAGES = frozenset(
     }
 )
 
+# 支持反向导入（import 边）的语言；其余语言的 imported_by 恒为空（issue #1444），
+# 用 imports_graph_available=False 显式声明，避免「没人导入」与「不支持」混淆。
+_IMPORT_GRAPH_LANGUAGES = frozenset({"python", "typescript", "javascript"})
+
 
 def _enrich_callees_with_lsp(
     conn: sqlite3.Connection,
@@ -133,6 +137,8 @@ def query_pulse(
     Python 反向 import 复用 Synapse resolver。注释必须来自新提取器写入的
     索引；旧索引或不支持注释的语言需重新索引或显式设置 max_comments=0。
     存量 activation 消息缺失时保持 NULL，并发出 COMMIT_MESSAGE_MISSING。
+    Python 反向导入富化超资源上限时降级：保留 SQL 侧结果并在
+    truncated_fields 声明 "imported_by"，不再整体报错（issue #1445）。
     """
     params: dict[str, Any] = {
         "file_path": file_path,
@@ -220,6 +226,7 @@ def _query_pulse_snapshot(
     call_graph_reason = (
         f"{language}: call-graph not supported" if not call_graph_available else ""
     )
+    imports_graph_available = language in _IMPORT_GRAPH_LANGUAGES
 
     docstring_raw = row[7]
 
@@ -281,34 +288,41 @@ def _query_pulse_snapshot(
     )
 
     imported_by = tuple(str(f) for f in imported_by_raw if f)
+    imports_degraded = False
     if language == "python":
         # 只读既有索引，不做仓库扫描；使用真实模块表解析相对 import 和子模块别名。
         files = conn.execute(
             "SELECT file_path FROM ast_index WHERE language='python' "
             "UNION SELECT file_path FROM ast_symbol_rows WHERE language='python' LIMIT 10001"
         ).fetchall()
-        bindings = conn.execute(
-            "SELECT module_path,is_relative,file_path,local_name,alias_of FROM ast_imports "
-            "WHERE language='python' LIMIT 20001"
-        ).fetchall()
-        if len(files) > 10000 or len(bindings) > 20000:
-            raise ValueError("PULSE_IMPORT_RESOURCE_LIMIT")
-        module_to_file = _build_module_to_file([r[0] for r in files])
-        importers = set(imported_by)
-        for module, relative, caller, local_name, alias_of in bindings:
-            resolved = _resolve_module_to_file(
-                module, bool(relative), caller, module_to_file
-            )
-            submodule = (
-                _local_name_as_submodule(
-                    local_name, alias_of, module, caller, module_to_file
+        bindings = (
+            conn.execute(
+                "SELECT module_path,is_relative,file_path,local_name,alias_of FROM ast_imports "
+                "WHERE language='python' LIMIT 20001"
+            ).fetchall()
+            if len(files) <= 10000
+            else []
+        )
+        # 超资源上限时降级（issue #1445）：保留 SQL 侧结果、跳过富化并声明截断，
+        # 不再让一个可选字段的富化拖垮整个查询。
+        imports_degraded = len(files) > 10000 or len(bindings) > 20000
+        if not imports_degraded:
+            module_to_file = _build_module_to_file([r[0] for r in files])
+            importers = set(imported_by)
+            for module, relative, caller, local_name, alias_of in bindings:
+                resolved = _resolve_module_to_file(
+                    module, bool(relative), caller, module_to_file
                 )
-                if relative
-                else ""
-            )
-            if file_path in (resolved, submodule):
-                importers.add(caller)
-        imported_by = tuple(sorted(importers)[:20])
+                submodule = (
+                    _local_name_as_submodule(
+                        local_name, alias_of, module, caller, module_to_file
+                    )
+                    if relative
+                    else ""
+                )
+                if file_path in (resolved, submodule):
+                    importers.add(caller)
+            imported_by = tuple(sorted(importers)[:20])
 
     siblings = tuple(
         SiblingRef(
@@ -342,6 +356,7 @@ def _query_pulse_snapshot(
         symbol=sym_info,
         call_graph_available=call_graph_available,
         call_graph_reason=call_graph_reason,
+        imports_graph_available=imports_graph_available,
         callers=callers,
         callees=callees,
         git_heat=git_heat,
@@ -349,6 +364,8 @@ def _query_pulse_snapshot(
         imported_by=imported_by,
         siblings=siblings,
         comments=comments,
+        # Python 富化降级时向消费者声明该字段被截断（issue #1445）。
+        truncated_fields=(("imported_by",) if imports_degraded else ()),
     )
 
 
@@ -364,7 +381,9 @@ def _estimate_tokens(value: Any) -> int:
 
         enc = tiktoken.get_encoding("cl100k_base")
         return len(enc.encode(json.dumps(value, ensure_ascii=False, default=str)))
-    except ImportError:
+    except Exception:
+        # 有意兜底：tiktoken 未安装（ImportError）、已安装但离线冷缓存导致
+        # 初始化抛网络异常等，都退回字符数估算，不让 pulse 整体失败。
         return len(json.dumps(value, ensure_ascii=False, default=str)) // 4
 
 
@@ -382,16 +401,6 @@ _PRIORITY_ORDER = [
     "siblings",
     "comments",
 ]
-
-_FIELD_BUDGETS = {
-    "callers": 150,
-    "callees": 120,
-    "git_heat": 80,
-    "imports": 100,
-    "imported_by": 60,
-    "siblings": 120,
-    "comments": 100,
-}
 
 _FIELD_TOP_N = {
     "callers": 5,
@@ -443,6 +452,13 @@ def apply_budget(pulse: PulseResponse, token_budget: int) -> PulseResponse:
         _estimate_tokens(v) for v in field_values.values()
     )
 
+    # 合并 query_pulse 已声明的截断（如 Python 富化降级）与预算裁剪产生的截断，
+    # 去重保序；直接覆盖会丢掉查询侧的降级声明。
+    merged_truncated = list(pulse.truncated_fields)
+    for field_name in truncated:
+        if field_name not in merged_truncated:
+            merged_truncated.append(field_name)
+
     return dataclasses.replace(
         pulse,
         callers=field_values["callers"],
@@ -453,5 +469,5 @@ def apply_budget(pulse: PulseResponse, token_budget: int) -> PulseResponse:
         siblings=field_values["siblings"],
         comments=field_values["comments"],
         token_estimate=total_estimate,
-        truncated_fields=tuple(truncated),
+        truncated_fields=tuple(merged_truncated),
     )

--- a/tree_sitter_analyzer/api/serialization.py
+++ b/tree_sitter_analyzer/api/serialization.py
@@ -15,8 +15,10 @@ COMPACT_LEGEND = (
     "sym=symbol, cr=callers, ce=callees, gh=git_heat, im=imports, ib=imported_by, "
     "sib=siblings, cmt=comments, n=name, k=kind, f=file, l=line, el=end_line, "
     "lang=language, cls=class, doc=docstring, h=hot30, r=resolution, "
-    "sha=commit, m=commit_msg, m30=mod_30d, m90=mod_90d, mall=mod_all, "
-    "s=git_state, tok=token_estimate, trunc=truncated_fields, cg=call_graph_available"
+    "sha=commit, m=commit_msg, at=timestamp_seconds, m30=mod_30d, m90=mod_90d, "
+    "mall=mod_all, s=git_state, tok=token_estimate, trunc=truncated_fields, "
+    "cg=call_graph_available, cgr=call_graph_reason (only when cg=false), "
+    "iga=imports_graph_available"
 )
 
 
@@ -48,7 +50,7 @@ def _compact(pulse: PulseResponse) -> dict[str, Any]:
     sym = pulse.symbol
     gh = pulse.git_heat
 
-    return {
+    result: dict[str, Any] = {
         "sym": {
             "n": sym.name,
             "k": sym.kind,
@@ -84,7 +86,12 @@ def _compact(pulse: PulseResponse) -> dict[str, Any]:
         "tok": pulse.token_estimate,
         "trunc": list(pulse.truncated_fields),
         "cg": pulse.call_graph_available,
+        "iga": pulse.imports_graph_available,
     }
+    # cg=false 时附原因短键，True 时省略以节约 token。
+    if not pulse.call_graph_available:
+        result["cgr"] = pulse.call_graph_reason
+    return result
 
 
 def _verbose(pulse: PulseResponse) -> dict[str, Any]:
@@ -139,4 +146,5 @@ def _verbose(pulse: PulseResponse) -> dict[str, Any]:
         "truncated_fields": list(pulse.truncated_fields),
         "call_graph_available": pulse.call_graph_available,
         "call_graph_reason": pulse.call_graph_reason,
+        "imports_graph_available": pulse.imports_graph_available,
     }

--- a/tree_sitter_analyzer/mcp/tools/pulse_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/pulse_tool.py
@@ -40,6 +40,8 @@ class PulseTool(BaseMCPTool):
                 "Token budget exceeded: drops fields lowest-priority first: "
                 "comments→siblings→imported_by→imports→git_heat→callees→callers. "
                 "call_graph=false for Bash/CSS/HTML/JSON/YAML/SQL/Markdown files. "
+                "iga=false (imports_graph_available) for languages without import "
+                "edges (e.g. Go/Rust/Java/C#): imported_by is empty by design then. "
                 "Requires a complete current index; stale or uncertified source returns "
                 "SOURCE_EVIDENCE_UNAVAILABLE. source_evidence is outside the content budget."
             ),


### PR DESCRIPTION
Closes #1445, Closes #1444. Audit trail: `docs/pulse-imported-by-audit-2026-09.md` (PR #1443).

## What

**#1445 — degradation instead of whole-response failure**
- `api/pulse.py`: past the resource bound (>10k Python files / >20k bindings) the Python `imported_by` enrichment is now skipped instead of raising `PULSE_IMPORT_RESOURCE_LIMIT`; the SQL-side result is kept and `truncated_fields` declares `"imported_by"`. Overflowing the files bound also skips the bindings query entirely.
- Fixed a latent trap found while implementing: `apply_budget` used to overwrite `truncated_fields` via `dataclasses.replace` — it now merges query-side declarations with budget drops (dedup, order-preserving).
- `test_query_pulse_import_capacity_is_an_error` rewritten as `..._degrades_instead_of_failing`; new merge-semantics test.

**#1444 — availability marker for languages without import edges**
- `PulseResponse.imports_graph_available` (default True), set from `_IMPORT_GRAPH_LANGUAGES = {python, typescript, javascript}` — mirrors `call_graph_available`. `imported_by == ()` for other languages is now a *declared* empty, not a silent one.
- Serialization: compact key `iga`, verbose full key, `COMPACT_LEGEND` updated; pulse tool description mentions it like `call_graph`.
- Tests: sql symbol → `iga=False, imported_by==()`; python → True.

**Audit P2-1 — tokenizer fallback widened**
- `_estimate_tokens` now catches `Exception` (not just `ImportError`): tiktoken installed + cold cache + offline no longer crashes pulse. New test injects a broken `get_encoding` and asserts the `//4` fallback.

**Audit P3 batch**
- `COMPACT_LEGEND` now documents `at=timestamp_seconds` and `iga`/`cgr`.
- compact view emits `cgr` (call_graph_reason) only when `cg=false`.
- dead `_FIELD_BUDGETS` removed (zero references, verified).

**Governance adaptation**
- `test_pulse.py` crossed the 800-line threshold contract (`test_large_test_file_inventory`) after adding tests → serialization-view tests split verbatim into `tests/unit/api/test_pulse_serialization.py` (767 + 118 lines).

## Verification (all run on this branch)

- Focused baseline 125 passed → 129 passed after changes (125 − 1 rewritten + 5 new)
- Reverse verification (red→green): temporarily restoring the `raise` fails `test_query_pulse_import_capacity_degrades_instead_of_failing` (`1 failed`); reverting → green
- change-impact verification_command: `148 passed` (incl. `tests/unit/mcp/tools/test_pulse_tool.py`)
- Quick gate: `uv run pytest -q` → `2111 passed, 28 skipped`
- Patch coverage gate: `check_patch_coverage.py --base origin/develop` → **passed, no added executable misses**
- Comments added in this change are in Chinese per AGENTS.md ruling; no new skips/xfails; skipped count unchanged (28)
