### PR TITLE
perf(pulse): cache python importers map with content stamps

### DIFF
--- a/tests/unit/api/test_pulse.py
+++ b/tests/unit/api/test_pulse.py
@@ -681,6 +681,9 @@ def test_pulse_relative_import_uses_existing_module_resolver(tmp_path, statement
         cache.close()
 
 
+# Python 反向导入缓存测试已拆至 test_pulse_import_cache.py（800 行治理阈值）。
+
+
 def test_pulse_reports_missing_legacy_commit_message(ast_cache_conn, caplog):
     # PR #1352：存量 activation 缺少消息时，保留 NULL 并发出 missing 诊断。
     caplog.set_level("WARNING", logger="tree_sitter_analyzer.api.pulse")

--- a/tests/unit/api/test_pulse_import_cache.py
+++ b/tests/unit/api/test_pulse_import_cache.py
@@ -1,0 +1,71 @@
+"""Pulse Python 反向导入派生表缓存的行为测试（审计 P2-2）。
+
+从 test_pulse.py 拆出以遵守 800 行治理阈值；断言原样迁移。
+"""
+
+from __future__ import annotations
+
+from tree_sitter_analyzer.api.pulse import query_pulse
+
+
+class _BindingFetchCounter:
+    """代理连接：统计 ast_imports 全量扫描次数（缓存命中验证，审计 P2-2）。"""
+
+    def __init__(self, conn):
+        self._conn = conn
+        self.full_fetches = 0
+
+    def execute(self, sql, *args):
+        if "FROM ast_imports" in sql and "COUNT" not in sql:
+            self.full_fetches += 1
+        return self._conn.execute(sql, *args)
+
+    def __getattr__(self, name):
+        return getattr(self._conn, name)
+
+
+def _indexed_two_file_project(tmp_path):
+    from tree_sitter_analyzer.ast_cache import ASTCache
+
+    (tmp_path / "mod.py").write_text("def run():\n    pass\n", encoding="utf-8")
+    (tmp_path / "consumer.py").write_text(
+        "from mod import run\nrun()\n", encoding="utf-8"
+    )
+    cache = ASTCache(str(tmp_path))
+    for name in ("mod.py", "consumer.py"):
+        cache.index_file(str(tmp_path / name))
+    return cache
+
+
+def test_python_importers_cache_hits_on_second_query(tmp_path):
+    """审计 P2-2：文件库上重复查询只做一次 ast_imports 全量扫描。"""
+    cache = _indexed_two_file_project(tmp_path)
+    try:
+        counter = _BindingFetchCounter(cache.get_conn())
+        first = query_pulse(counter, "mod.py", "run")
+        second = query_pulse(counter, "mod.py", "run")
+        assert first is not None and second is not None
+        assert second.imported_by == ("consumer.py",)
+        assert counter.full_fetches == 1
+    finally:
+        cache.close()
+
+
+def test_python_importers_cache_invalidates_on_binding_change(tmp_path):
+    """审计 P2-2：绑定表内容变化（计数戳变化）后缓存失效，新导入者可见。"""
+    cache = _indexed_two_file_project(tmp_path)
+    try:
+        conn = cache.get_conn()
+        first = query_pulse(conn, "mod.py", "run")
+        assert first is not None
+        assert "late.py" not in first.imported_by
+        conn.execute(
+            "INSERT INTO ast_imports(file_path,language,module_path,is_relative,"
+            "local_name,alias_of,line) VALUES ('late.py','python','mod',0,'run','',1)"
+        )
+        conn.commit()
+        second = query_pulse(conn, "mod.py", "run")
+        assert second is not None
+        assert "late.py" in second.imported_by
+    finally:
+        cache.close()

--- a/tree_sitter_analyzer/api/pulse.py
+++ b/tree_sitter_analyzer/api/pulse.py
@@ -184,11 +184,7 @@ def _query_pulse_snapshot(
     if len(targets) != 1:
         raise ValueError(f"AMBIGUOUS_SYMBOL: {file_path}:{symbol_name}")
     params["symbol_id"] = targets[0][0]
-    from ..synapse_resolver._context import (
-        _build_module_to_file,
-        _local_name_as_submodule,
-        _resolve_module_to_file,
-    )
+    from ..synapse_resolver._context import _build_module_to_file
 
     modules = _build_module_to_file([file_path])
     params["module_node"] = "module:" + next(iter(modules), "")
@@ -290,39 +286,13 @@ def _query_pulse_snapshot(
     imported_by = tuple(str(f) for f in imported_by_raw if f)
     imports_degraded = False
     if language == "python":
-        # 只读既有索引，不做仓库扫描；使用真实模块表解析相对 import 和子模块别名。
-        files = conn.execute(
-            "SELECT file_path FROM ast_index WHERE language='python' "
-            "UNION SELECT file_path FROM ast_symbol_rows WHERE language='python' LIMIT 10001"
-        ).fetchall()
-        bindings = (
-            conn.execute(
-                "SELECT module_path,is_relative,file_path,local_name,alias_of FROM ast_imports "
-                "WHERE language='python' LIMIT 20001"
-            ).fetchall()
-            if len(files) <= 10000
-            else []
-        )
-        # 超资源上限时降级（issue #1445）：保留 SQL 侧结果、跳过富化并声明截断，
-        # 不再让一个可选字段的富化拖垮整个查询。
-        imports_degraded = len(files) > 10000 or len(bindings) > 20000
+        # 富化走内容戳缓存（审计 P2-2）：同一索引版本内重复查询不再全量扫描。
+        imports_degraded, importers_map = _python_importers_snapshot(conn)
         if not imports_degraded:
-            module_to_file = _build_module_to_file([r[0] for r in files])
-            importers = set(imported_by)
-            for module, relative, caller, local_name, alias_of in bindings:
-                resolved = _resolve_module_to_file(
-                    module, bool(relative), caller, module_to_file
-                )
-                submodule = (
-                    _local_name_as_submodule(
-                        local_name, alias_of, module, caller, module_to_file
-                    )
-                    if relative
-                    else ""
-                )
-                if file_path in (resolved, submodule):
-                    importers.add(caller)
-            imported_by = tuple(sorted(importers)[:20])
+            merged_importers = set(imported_by) | importers_map.get(
+                file_path, frozenset()
+            )
+            imported_by = tuple(sorted(merged_importers)[:20])
 
     siblings = tuple(
         SiblingRef(
@@ -367,6 +337,104 @@ def _query_pulse_snapshot(
         # Python 富化降级时向消费者声明该字段被截断（issue #1445）。
         truncated_fields=(("imported_by",) if imports_degraded else ()),
     )
+
+
+# ---------------------------------------------------------------------------
+# Python 反向导入派生表（审计 P2-2：内容戳缓存，避免每次查询全量扫描）
+# ---------------------------------------------------------------------------
+
+# 键为（数据库文件路径, 文件集内容戳, 绑定集内容戳）；内容戳变化即整体失效。
+# 内存库无稳定标识不缓存；GIL 下的字典读写对单事件循环的 MCP 服务足够。
+_PY_IMPORTERS_CACHE: dict[
+    tuple[str, tuple[object, ...], tuple[object, ...]],
+    tuple[bool, dict[str, frozenset[str]]],
+] = {}
+_PY_IMPORTERS_CACHE_MAX = 32
+
+
+def _python_importers_snapshot(
+    conn: sqlite3.Connection,
+) -> tuple[bool, dict[str, frozenset[str]]]:
+    """返回（是否超限降级, 目标文件 → 导入者集合）；文件库带内容戳缓存。"""
+    main_path = ""
+    for row in conn.execute("PRAGMA database_list").fetchall():
+        if row[1] == "main":
+            main_path = (row[2] or "").strip()
+            break
+    if not main_path:
+        # 内存库（测试与一次性连接）没有稳定身份，直接构建、不缓存。
+        return _build_python_importers(conn)
+
+    index_row = conn.execute(
+        "SELECT COUNT(*), IFNULL(MAX(indexed_at),'') FROM ast_index WHERE language='python'"
+    ).fetchone()
+    symbol_row = conn.execute(
+        # ast_symbol_rows 没有 indexed_at 列，用 rowid 上界补充捕捉符号行变化。
+        "SELECT COUNT(*), IFNULL(MAX(rowid),0) FROM ast_symbol_rows WHERE language='python'"
+    ).fetchone()
+    bindings_row = conn.execute(
+        "SELECT COUNT(*), IFNULL(MAX(rowid),0) FROM ast_imports WHERE language='python'"
+    ).fetchone()
+    key = (
+        main_path,
+        (index_row[0], index_row[1], symbol_row[0], symbol_row[1]),
+        (bindings_row[0], bindings_row[1]),
+    )
+    cached = _PY_IMPORTERS_CACHE.get(key)
+    if cached is not None:
+        return cached
+    value = _build_python_importers(conn)
+    if len(_PY_IMPORTERS_CACHE) >= _PY_IMPORTERS_CACHE_MAX:
+        # 粗粒度上限：正常场景一个仓库只有一条记录，超限说明在测试等临时目录场景。
+        _PY_IMPORTERS_CACHE.clear()
+    _PY_IMPORTERS_CACHE[key] = value
+    return value
+
+
+def _build_python_importers(
+    conn: sqlite3.Connection,
+) -> tuple[bool, dict[str, frozenset[str]]]:
+    """全量构建「目标文件 → 导入者集合」派生表；超资源上限返回 (True, {})。"""
+    from ..synapse_resolver._context import (
+        _build_module_to_file,
+        _local_name_as_submodule,
+        _resolve_module_to_file,
+    )
+
+    files = conn.execute(
+        "SELECT file_path FROM ast_index WHERE language='python' "
+        "UNION SELECT file_path FROM ast_symbol_rows WHERE language='python' LIMIT 10001"
+    ).fetchall()
+    bindings = (
+        conn.execute(
+            "SELECT module_path,is_relative,file_path,local_name,alias_of FROM ast_imports "
+            "WHERE language='python' LIMIT 20001"
+        ).fetchall()
+        if len(files) <= 10000
+        else []
+    )
+    # 超资源上限时降级（issue #1445）：调用方保留 SQL 侧结果并声明截断。
+    if len(files) > 10000 or len(bindings) > 20000:
+        return True, {}
+    module_to_file = _build_module_to_file([r[0] for r in files])
+    importers_map: dict[str, set[str]] = {}
+    for module, relative, caller, local_name, alias_of in bindings:
+        resolved = _resolve_module_to_file(
+            module, bool(relative), caller, module_to_file
+        )
+        submodule = (
+            _local_name_as_submodule(
+                local_name, alias_of, module, caller, module_to_file
+            )
+            if relative
+            else ""
+        )
+        for target in (resolved, submodule):
+            if target:
+                importers_map.setdefault(target, set()).add(caller)
+    return False, {
+        target: frozenset(importers) for target, importers in importers_map.items()
+    }
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Audit P2-2 from `docs/pulse-imported-by-audit-2026-09.md` (follow-up to #1446).

## What

Every Python `query_pulse` call used to re-fetch up to 10k files + 20k import bindings and re-run the O(N) module resolution loop — multiplied per symbol by `pulse_batch`. This PR caches the derived "target file → importers" map:

- Cache key = (database file path, content stamps). Stamps: `(COUNT, MAX(indexed_at))` on `ast_index` python rows, `(COUNT, MAX(rowid))` on `ast_symbol_rows` and `ast_imports` python rows — any reindex or binding change invalidates.
- In-memory databases (tests, one-shot connections) bypass the cache entirely — no cross-DB collision risk.
- The over-limit degradation from #1445 is preserved and cached consistently with its stamp (degraded state is part of the derived value).
- `sqlite3.Connection` does not support weak references (verified), hence path+stamp keying instead of per-connection caching.
- Cache is capped at 32 entries with full clear on overflow (normal case: one entry per repo; overflow only in tmp-dir test scenarios).

## Tests

- `test_python_importers_cache_hits_on_second_query`: counting proxy asserts the `ast_imports` full scan runs exactly once across two queries, imported_by still correct
- `test_python_importers_cache_invalidates_on_binding_change`: direct binding insert changes the count stamp → new importer becomes visible
- Reverse verification (red→green): disabling the cache-hit path makes the hit test fail (`full_fetches == 2`), restoring → green
- All existing imported_by semantics tests unchanged and passing (they run through the new path)

## Verification (run on this branch)

- Focused suite (pulse ×3 + synapse ×2 + pulse_tool): 206 passed with coverage
- Quick gate: `uv run pytest -q` → `2111 passed, 28 skipped`
- Patch coverage gate vs `origin/develop`: **passed, no added executable misses**
- `test_pulse.py` kept under the 800-line threshold by splitting cache tests into `tests/unit/api/test_pulse_import_cache.py` (772 + 68 lines)
