### PR TITLE
fix(index): honor .gitignore when discovering index candidates

### DIFF
--- a/tests/unit/test_index_candidate_walker.py
+++ b/tests/unit/test_index_candidate_walker.py
@@ -558,3 +558,91 @@ def test_posix_missing_root_at_final_reopen_is_discovery_error(monkeypatch, tmp_
 
     with pytest.raises(CandidateDiscoveryError, match="INDEX_CANDIDATE"):
         list(walk_candidate_entries(str(tmp_path), **_DEFAULTS))
+
+
+def _write_ignore_file(root, *lines):
+    (root / ".gitignore").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _relative_all(root, values):
+    return sorted(os.path.relpath(value, str(root)) for value in values)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="descriptor-bound walk is POSIX-only")
+def test_posix_gitignored_build_directory_is_pruned(tmp_path):
+    # GH-1449: pruning used only the EXCLUDE_DIRS name list plus hidden names, so
+    # a gitignored build directory such as tsc's lib/ was indexed as source.
+    _write_ignore_file(tmp_path, "lib/", "custom-out/", "dist/")
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "index.ts").write_text("export const a = 1\n")
+    for name in ("lib", "custom-out", "dist"):
+        (tmp_path / name).mkdir()
+        (tmp_path / name / "index.js").write_text("var a = 1\n")
+
+    values = list(walk_candidate_entries(str(tmp_path), **_DEFAULTS))
+
+    assert _relative_all(tmp_path, values) == [
+        ".gitignore",
+        os.path.join("src", "index.ts"),
+    ]
+
+
+@pytest.mark.skipif(os.name != "posix", reason="descriptor-bound walk is POSIX-only")
+def test_posix_unignored_lib_directory_is_still_walked(tmp_path):
+    # The walk follows ignore rules instead of hardcoding ecosystem names: Ruby
+    # and Python keep first-party sources under lib/.
+    _write_ignore_file(tmp_path, "build/")
+    (tmp_path / "lib").mkdir()
+    (tmp_path / "lib" / "thing.rb").write_text("def thing; end\n")
+
+    values = list(walk_candidate_entries(str(tmp_path), **_DEFAULTS))
+
+    assert os.path.join("lib", "thing.rb") in _relative_all(tmp_path, values)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="descriptor-bound walk is POSIX-only")
+def test_posix_negated_file_is_retained(tmp_path):
+    _write_ignore_file(tmp_path, "*.log", "!keep.log")
+    (tmp_path / "drop.log").write_text("x\n")
+    (tmp_path / "keep.log").write_text("x\n")
+
+    values = _relative_all(
+        tmp_path, walk_candidate_entries(str(tmp_path), **_DEFAULTS)
+    )
+
+    assert "drop.log" not in values
+    assert "keep.log" in values
+
+
+@pytest.mark.skipif(os.name != "posix", reason="descriptor-bound walk is POSIX-only")
+def test_posix_nested_gitignore_prunes_descendant(tmp_path):
+    package = tmp_path / "pkg"
+    package.mkdir()
+    _write_ignore_file(package, "out/")
+    (package / "out").mkdir()
+    (package / "out" / "generated.js").write_text("var g = 1\n")
+    (package / "src.js").write_text("var s = 1\n")
+
+    values = _relative_all(
+        tmp_path, walk_candidate_entries(str(tmp_path), **_DEFAULTS)
+    )
+
+    assert os.path.join("pkg", "src.js") in values
+    assert os.path.join("pkg", "out", "generated.js") not in values
+
+
+def test_path_fallback_gitignored_directory_is_pruned(tmp_path, monkeypatch):
+    import tree_sitter_analyzer.index_candidate_walker as walker
+
+    _write_ignore_file(tmp_path, "lib/")
+    (tmp_path / "lib").mkdir()
+    (tmp_path / "lib" / "index.js").write_text("var a = 1\n")
+    (tmp_path / "src.js").write_text("var s = 1\n")
+    monkeypatch.setattr(walker.os, "name", "nt")
+
+    values = _relative_all(
+        tmp_path, walk_candidate_entries(str(tmp_path), **_DEFAULTS)
+    )
+
+    assert "src.js" in values
+    assert os.path.join("lib", "index.js") not in values

--- a/tree_sitter_analyzer/cache/indexer.py
+++ b/tree_sitter_analyzer/cache/indexer.py
@@ -15,6 +15,9 @@ from typing import Any, cast
 
 
 from ..constants import EXCLUDE_DIRS as _EXCLUDE_DIRS
+from ..ignore_rules import IgnoreRules
+from ..ignore_rules import is_gitignored as _is_gitignored
+from ..ignore_rules import load_ignore_rules as _load_ignore_rules
 from ..index_candidate_walker import (
     CandidateDiscoveryBudgetExceeded,
     CandidateDiscoveryError,
@@ -129,21 +132,38 @@ _AST_CACHE_EXTRACTOR_VERSION = 39
 
 
 def _walk_source_files(project_root: str) -> Iterator[str]:
+    ignore_rules: dict[str, IgnoreRules] = {
+        "": _load_ignore_rules(project_root, "", [])
+    }
     for dirpath, dirnames, filenames in os.walk(project_root):
+        rel_dir = os.path.relpath(dirpath, project_root)
+        if rel_dir == os.curdir:
+            rel_dir = ""
+        inherited = ignore_rules[rel_dir]
         retained: list[str] = []
         for dirname in dirnames:
             if dirname in _EXCLUDE_DIRS or dirname.startswith("."):
                 continue
             candidate = os.path.join(dirpath, dirname)
+            child_rel = os.path.join(rel_dir, dirname) if rel_dir else dirname
             if os.path.islink(candidate):
-                if os.path.splitext(dirname)[1].lower() in _EXT_TO_LANG:
-                    yield candidate
+                if not _is_gitignored(child_rel, inherited, directory=False):
+                    if os.path.splitext(dirname)[1].lower() in _EXT_TO_LANG:
+                        yield candidate
                 continue
+            if _is_gitignored(child_rel, inherited, directory=True):
+                continue
+            ignore_rules[child_rel] = _load_ignore_rules(
+                project_root, child_rel, inherited
+            )
             retained.append(dirname)
         dirnames[:] = retained
         for fname in filenames:
             ext = os.path.splitext(fname)[1].lower()
             if ext in _EXT_TO_LANG:
+                file_rel = os.path.join(rel_dir, fname) if rel_dir else fname
+                if _is_gitignored(file_rel, inherited, directory=False):
+                    continue
                 yield os.path.join(dirpath, fname)
 
 

--- a/tree_sitter_analyzer/ignore_rules.py
+++ b/tree_sitter_analyzer/ignore_rules.py
@@ -1,0 +1,77 @@
+"""Ignore-rule matching shared by the filesystem discovery paths.
+
+Discovery that honors ``.gitignore`` must draw the rules from one place: the
+index paths and ``source_lines`` previously disagreed about which directories
+are part of a project. A rule file applies to the directory that declares it
+and to every directory below, and a later rule with an opinion overrides an
+earlier one, which is what makes ``!`` negation work.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pathspec
+
+# Rule files honored per directory, in increasing precedence.
+IGNORE_RULE_FILES = (".gitignore", ".ignore", ".rgignore")
+
+# Collected rules: each entry pairs the directory that declared a rule file
+# (relative to the walk root, "" for the root) with its compiled spec.
+IgnoreRules = list[tuple[str, pathspec.GitIgnoreSpec]]
+
+
+def load_ignore_rules(
+    project_root: str,
+    rel_dir: str,
+    inherited: IgnoreRules,
+) -> IgnoreRules:
+    """Return ``inherited`` plus the ignore specs declared in ``rel_dir``.
+
+    ``rel_dir`` is relative to ``project_root``; the empty string is the root.
+    A symlinked or unreadable rule file is skipped rather than fatal, so
+    discovery never fails because of an ignore file.
+    """
+    rules = list(inherited)
+    base = os.path.join(project_root, rel_dir) if rel_dir else project_root
+    for name in IGNORE_RULE_FILES:
+        path = os.path.join(base, name)
+        try:
+            if os.path.islink(path) or not os.path.isfile(path):
+                continue
+            with open(path, encoding="utf-8", errors="replace") as handle:
+                lines = handle.read().splitlines()
+        except OSError:
+            continue
+        rules.append((rel_dir, pathspec.GitIgnoreSpec.from_lines(lines)))
+    return rules
+
+
+def is_gitignored(
+    rel_path: str,
+    rules: IgnoreRules,
+    *,
+    directory: bool,
+) -> bool:
+    """Whether ``rules`` exclude ``rel_path``; later specs override earlier ones.
+
+    ``rel_path`` is relative to the same root the rules were collected from.
+    ``directory`` appends the trailing slash gitignore patterns use to anchor a
+    rule to directories.
+    """
+    ignored = False
+    posix = rel_path.replace(os.sep, "/")
+    for base, spec in rules:
+        if base:
+            prefix = base + "/"
+            if not posix.startswith(prefix):
+                continue
+            target = posix[len(prefix) :]
+        else:
+            target = posix
+        if not target:
+            continue
+        result = spec.check_file(target + ("/" if directory else ""))
+        if result.include is not None:
+            ignored = bool(result.include)
+    return ignored

--- a/tree_sitter_analyzer/index_candidate_walker.py
+++ b/tree_sitter_analyzer/index_candidate_walker.py
@@ -8,6 +8,10 @@ import time
 from collections.abc import Iterable
 from typing import Any
 
+from .ignore_rules import IgnoreRules
+from .ignore_rules import is_gitignored as _is_gitignored
+from .ignore_rules import load_ignore_rules as _load_ignore_rules
+
 
 class CandidateDiscoveryBudgetExceeded(RuntimeError):
     """Raised after the first filesystem entry beyond a discovery budget."""
@@ -33,6 +37,9 @@ def walk_candidate_entries(
     deadline = time.monotonic() + discovery_seconds
     entry_count = 0
     path_bytes = 0
+    ignore_rules: dict[str, IgnoreRules] = {
+        "": _load_ignore_rules(project_root, "", [])
+    }
     if os.name != "posix":  # pragma: no cover - exercised by Windows CI
         yield from _walk_path_entries(
             project_root,
@@ -98,9 +105,16 @@ def walk_candidate_entries(
             except OSError as exc:
                 raise CandidateDiscoveryError(_DISCOVERY_ERROR) from exc
             if not stat.S_ISDIR(entry_info.st_mode):
-                yield abs_path
+                if not _is_gitignored(
+                    rel_path, ignore_rules.get(parent_rel, []), directory=False
+                ):
+                    yield abs_path
                 continue
             if entry.name in excluded_dir_names or entry.name.startswith("."):
+                continue
+            if _is_gitignored(
+                rel_path, ignore_rules.get(parent_rel, []), directory=True
+            ):
                 continue
             child_fd: int | None = None
             try:
@@ -127,6 +141,9 @@ def walk_candidate_entries(
                 if child_fd is not None:
                     os.close(child_fd)
                 raise CandidateDiscoveryError(_DISCOVERY_ERROR) from exc
+            ignore_rules[rel_path] = _load_ignore_rules(
+                project_root, rel_path, ignore_rules.get(parent_rel, [])
+            )
             scanners.append((child_scanner, child_fd, rel_path))
         # Enumeration through the pinned descriptor is authoritative only while
         # the caller-visible pathname still names that exact directory.  A
@@ -176,22 +193,28 @@ def _walk_path_entries(
     """Non-POSIX fallback; secure snapshot capture is unsupported on this path."""
     entry_count = 0
     path_bytes = 0
-    scanners: list[Any] = []
+    scanners: list[tuple[Any, str]] = []
+    ignore_rules: dict[str, IgnoreRules] = {
+        "": _load_ignore_rules(project_root, "", [])
+    }
     try:
         try:
-            scanners.append(os.scandir(project_root))
+            scanners.append((os.scandir(project_root), ""))
         except OSError as exc:
             raise CandidateDiscoveryError(_DISCOVERY_ERROR) from exc
         while scanners:
-            scanner = scanners[-1]
+            scanner, parent_rel = scanners[-1]
             try:
                 entry = next(scanner)
             except StopIteration:
-                scanners.pop().close()
+                scanners.pop()[0].close()
                 continue
             except OSError as exc:
                 raise CandidateDiscoveryError(_DISCOVERY_ERROR) from exc
             entry_count += 1
+            rel_path = (
+                os.path.join(parent_rel, entry.name) if parent_rel else entry.name
+            )
             try:
                 path_bytes += len(
                     os.fspath(entry.path).encode("utf-8", errors="surrogatepass")
@@ -209,14 +232,25 @@ def _walk_path_entries(
             except OSError as exc:
                 raise CandidateDiscoveryError(_DISCOVERY_ERROR) from exc
             if not is_directory:
-                yield os.fspath(entry.path)
-            elif entry.name not in excluded_dir_names and not entry.name.startswith(
-                "."
+                if not _is_gitignored(
+                    rel_path, ignore_rules.get(parent_rel, []), directory=False
+                ):
+                    yield os.fspath(entry.path)
+            elif (
+                entry.name not in excluded_dir_names
+                and not entry.name.startswith(".")
+                and not _is_gitignored(
+                    rel_path, ignore_rules.get(parent_rel, []), directory=True
+                )
             ):
                 try:
-                    scanners.append(os.scandir(entry.path))
+                    child_scanner = os.scandir(entry.path)
                 except OSError as exc:
                     raise CandidateDiscoveryError(_DISCOVERY_ERROR) from exc
+                ignore_rules[rel_path] = _load_ignore_rules(
+                    project_root, rel_path, ignore_rules.get(parent_rel, [])
+                )
+                scanners.append((child_scanner, rel_path))
     finally:
-        for scanner in reversed(scanners):
+        for scanner, _rel in reversed(scanners):
             scanner.close()


### PR DESCRIPTION
Fixes #1449.

## Problem

Index discovery pruned directories only by the `EXCLUDE_DIRS` name list plus a hidden-name rule, so a gitignored build directory absent from that list was indexed as source. `lib/` — the standard `tsc` output for Node/TypeScript workspaces — is the common case.

## Evidence

Minimal repro (`.gitignore` = `lib/ dist/ node_modules/ custom-out/`) indexed 3 files, 2 of them gitignored: `lib/index.js` and `custom-out/index.js`. The `custom-out/` case is the point — the class is unbounded, so a name list can only chase instances, and adding `lib` outright would prune Ruby and Python first-party sources.

268-package TypeScript monorepo, `tsc`-built:

| | before | after |
|---|---:|---:|
| files indexed | 7,809 | 3,799 |
| `lib/` build output | 4,011 | 0 |
| `index.db` | 816 MiB | 549 MiB |
| `--symbol-search defineTool` top hit | `packages/core/tools/lib/index.js` | `packages/core/tools/src/schema.ts` |

## Change

Adds `tree_sitter_analyzer/ignore_rules.py` as the single home for ignore matching: `.gitignore` / `.ignore` / `.rgignore` are collected per directory, and a later rule with an opinion overrides an earlier one, so `!` negation behaves the way `source_lines` already implemented it. Name-list pruning stays as a cheap pre-filter.

Applied to both walk paths in `index_candidate_walker.py` (the POSIX descriptor-bound walk and the non-POSIX fallback) and to the legacy `cache/indexer._walk_source_files` walk.

**Note for review:** this needed three edits rather than one because discovery is implemented three times — `index_candidate_walker`, `cache/indexer._walk_source_files`, and `cache/fingerprint`. Consolidating them is a larger change than this fix; the shared module is the first step, and `source_lines._ignored` is a candidate to converge onto it as well. That duplication is also why #445's premise ("the indexer already does [respect `.gitignore`]") did not hold: `.benchmark-repos` was excluded for being a hidden directory, not for being ignored.

## Verification

- `tests/unit/test_index_candidate_walker.py` — 5 new tests: gitignored build directory pruned; **un-ignored `lib/` still walked** (guards against hardcoding the name); `!` negation retained; nested `.gitignore`; non-POSIX fallback.
- `pytest tests/unit/test_index_candidate_walker.py tests/unit/test_ast_cache*.py tests/unit/test_incremental_sync*.py tests/unit/test_rename*.py` → **590 passed**.
- `ruff check` clean on the changed files.
- The minimal repro and the monorepo re-index were both re-run on this branch.

## Acceptance from #1449

- The repro indexes `src/index.ts` only. Verified.
- On a `tsc`-built workspace, symbol search ranks source above `lib/` output and the index roughly halves. Verified.
