### PR TITLE
docs(auto-index): record that symbol search must not auto-warm

### DIFF
--- a/tree_sitter_analyzer/mcp/utils/auto_index_guard.py
+++ b/tree_sitter_analyzer/mcp/utils/auto_index_guard.py
@@ -2,16 +2,15 @@
 """
 Auto-Index Guard — Transparent AST cache warming for codegraph tools.
 
-Problem: codegraph_callers, codegraph_callees, codegraph_symbol_search, etc.
-all depend on the AST cache being populated.  Today an agent must first call
-``ast_cache mode=index`` and only then call the analysis tools.  Two-step.
+Problem: codegraph_callers, codegraph_callees, codegraph_metrics and others
+read the AST cache, so an agent would otherwise have to call
+``ast_cache mode=index`` before any analysis tool.  Two-step.
 
-Solution: ``AutoIndexGuard`` is a thin singleton that any tool can call before
+Solution: ``AutoIndexGuard`` is a thin singleton that a tool calls before
 accessing the cache.  On first invocation per project-root it triggers
-``ASTCache.index_project()`` automatically, so the first ``codegraph_callers``
-call "just works" even if the agent never called ``ast_cache``.
-
-Subsequent calls are instant (one dict lookup + one SQLite COUNT).
+``ASTCache.index_project()``, so the first call warms what it needs instead of
+failing on a cold cache.  Subsequent calls are instant (one dict lookup + one
+SQLite COUNT).
 
 Usage in a tool::
 
@@ -20,10 +19,21 @@ Usage in a tool::
     if cache is not None:
         callers = cache.query_callers(func_name)
 
-Integration points:
-  - callers_tool.py, callees_tool.py: replace ``_try_get_cache()``
-  - codegraph_metrics_tool.py: replace ``_get_cache()``
-  - codegraph_symbol_search_tool.py: replace ``_get_cache()``
+Pass ``auto_build=False`` for a strictly read-only lookup that must not write
+the cache.
+
+Current call sites: ``incremental_sync_tool``, ``codegraph_visualization_hub``,
+``codegraph_refactor_tool`` and ``auto_index_tool`` warm with the default
+``auto_build=True``; ``codegraph_metrics_tool`` reads with ``auto_build=False``.
+
+``codegraph_symbol_search_tool`` is deliberately **not** a call site.  Warming
+can leave an empty or partial index, and symbol search must never convert that
+into a "the symbol is absent" verdict; it keeps an explicit ``INDEX_NOT_READY``
+with a recovery hint instead.  That guarantee is pinned by
+``test_empty_index_does_not_claim_symbol_absence`` and
+``TestCodeGraphSymbolSearchNoCache::test_search_on_empty_project`` (2026-09-09).
+Do not wire ``ensure_indexed`` into that tool, and do not read its absence there
+as a missing integration.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Documentation-only. No behavior change.

## Why

`auto_index_guard.py`'s module docstring listed three integration points for `ensure_indexed`, and **none of them is correct today**:

| listed | actual |
|---|---|
| `callers_tool.py`, `callees_tool.py` — "replace `_try_get_cache()`" | neither file uses the guard (0 references) |
| `codegraph_metrics_tool.py` — "replace `_get_cache()`" | it does call the guard, but with `auto_build=False`, so it never warms |
| `codegraph_symbol_search_tool.py` — "replace `_get_cache()`" | **must not** call it — see below |

## The stale entry is a regression trap

I followed the docstring and wired `ensure_indexed` into `CodeGraphSymbolSearchTool._get_cache()`. It made a cold `--symbol-search` work on a fresh repository — and failed three tests:

- `test_empty_index_does_not_claim_symbol_absence[False]`
- `TestCodeGraphSymbolSearchNoCache::test_search_on_empty_project`
- `test_symbol_search_next_step_no_legacy`

The first two were added on 2026-09-09 with the rationale that a cold index once reported a genuinely existing function as NOT_FOUND, and that without an index a lookup cannot assert the project has no matching symbol. Warming a project that has nothing to index leaves an empty index, and an empty index must never be reported as "symbol absent". Symbol search deliberately keeps an explicit `INDEX_NOT_READY` with a recovery hint instead of warming, and its own tool description already says `Requires ast_cache index (run codegraph_autoindex mode=warm)`.

So the code is right and the docstring is wrong. A future contributor reading the old list is invited to make exactly the change the tests reject — which is what happened here.

## Change

Replaces the integration list with the real call sites, and records why `codegraph_symbol_search_tool` is excluded and which tests pin that. Also corrects the Problem/Solution paragraphs, which still described symbol search as a warming target and claimed a first call "just works".

## Verification

- `ruff check` clean on the changed file.
- `pytest tests/unit/test_auto_index_guard_convergence.py tests/unit/test_symbol_search_tool.py tests/unit/test_codegraph_autoindex_tool.py tests/unit/test_codegraph_metrics_tool.py tests/unit/test_unresolved_refs.py` → 114 passed.
- The behavior change attempted first is fully reverted: the only modified file is the docstring.
