### PR TITLE
docs(listing): version the published description and gate its claims

### DIFF
--- a/docs/repository-listing.md
+++ b/docs/repository-listing.md
@@ -1,0 +1,44 @@
+# Repository listing
+
+The text in this file is the project's published listing: the GitHub repository
+description, its topics, and the MCP registry entry in `server.json`. It is
+versioned here so a release can be checked before it ships, and so the claim
+rules below have something to bind to.
+
+Agents and users read this text before they read the README, so it is held to
+the same standard as the README: it advertises only current capabilities, and
+publishes no quantitative competitive claim that the claim registry does not
+authorize.
+
+## GitHub description
+
+```
+Cross-language-safe code-intelligence MCP for AI agents: 13 languages, family-gated call graph, blast radius, health grading, 8 facade tools, JSON envelopes, 100% local. Run miswire-audit on your repo.
+```
+
+The language count must match the generated inventory in
+`README.md` (`13 pipeline-registered`). `server.json` carries a shorter variant
+of the same text for the MCP registry.
+
+## Topics
+
+```
+ai, ai-agents, ai-coding, anthropic, ast, call-graph, claude-code, code-analysis, code-intelligence, codegraph, cross-language, developer-tools, llms, mcp, mcp-server, static-analysis, tree-sitter, tree-sitter-analyzer, vibe-coding
+```
+
+## Rules
+
+- **No removed capability.** A listing must not name an output format, tool, or
+  wrapper that a released breaking change removed. `CHANGELOG.md` is the record
+  of what was removed; `TOON`, `search-content`, and `find-and-grep` are gone as
+  of 1.30.0.
+- **No unauthorized quantitative claim.** A ratio or competitor comparison may
+  appear only when `benchmarks/codegraph_compare/claim_registry.json` carries a
+  matching claim at evidence level `E4`. Below `E4` the measured detail belongs
+  in its benchmark report, where it is read together with its methodology,
+  corpus, and measurement date — not in a one-line listing.
+- **Counts come from the generator.** A language or tool count in a listing
+  restates the generated inventory; it is not maintained by hand.
+
+`tests/governance/test_repository_listing_contract.py` enforces the first two
+rules against this file and `server.json`.

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.aimasteracc/tree-sitter-analyzer",
-  "description": "Cross-language-safe code intelligence MCP. 16 languages, family-gated call graph, 100% local.",
+  "description": "Cross-language-safe code intelligence MCP. 13 languages, family-gated call graph, 100% local.",
   "repository": {
     "url": "https://github.com/aimasteracc/tree-sitter-analyzer",
     "source": "github"

--- a/tests/governance/test_repository_listing_contract.py
+++ b/tests/governance/test_repository_listing_contract.py
@@ -1,0 +1,92 @@
+"""Contract tests for the published repository listing.
+
+The GitHub description, its topics, and the MCP registry entry in
+``server.json`` are read before the README is.  They must advertise only
+current capabilities and only quantitative claims the claim registry
+authorizes at E4.  See ``docs/repository-listing.md`` for the rules and the
+canonical text.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+LISTING_PATH = PROJECT_ROOT / "docs" / "repository-listing.md"
+REGISTRY_PATH = PROJECT_ROOT / "benchmarks" / "codegraph_compare" / "claim_registry.json"
+
+# Capabilities a released breaking change removed; CHANGELOG.md owns the record.
+# A listing that advertises one sends users after something that is not there.
+REMOVED_FEATURES = ("TOON", "search-content", "find-and-grep")
+
+# A ratio such as ``124x`` or ``390×``.  Authorized only at evidence level E4.
+RATIO_CLAIM = re.compile(r"\d+(?:\.\d+)?\s*[x×]", re.IGNORECASE)
+
+
+def _fenced_block_after(heading: str) -> str:
+    """Return the first fenced block under ``heading``, whitespace-collapsed."""
+    text = LISTING_PATH.read_text(encoding="utf-8")
+    assert heading in text, f"{LISTING_PATH.name} lost its {heading!r} section"
+    section = text.split(heading, 1)[1]
+    block = section.split("```", 2)[1]
+    return " ".join(block.split())
+
+
+def _listing_texts() -> dict[str, str]:
+    server = json.loads((PROJECT_ROOT / "server.json").read_text(encoding="utf-8"))
+    return {
+        "docs/repository-listing.md description": _fenced_block_after(
+            "## GitHub description"
+        ),
+        "docs/repository-listing.md topics": _fenced_block_after("## Topics"),
+        "server.json description": server["description"],
+    }
+
+
+def _authorized_e4_claims() -> list[dict]:
+    registry = json.loads(REGISTRY_PATH.read_text(encoding="utf-8"))
+    return [
+        claim
+        for claim in registry.get("claims", [])
+        if claim.get("evidence_level") == "E4"
+    ]
+
+
+def _generated_pipeline_language_count() -> str:
+    readme = (PROJECT_ROOT / "README.md").read_text(encoding="utf-8")
+    match = re.search(r"(\d+) pipeline-registered", readme)
+    assert match, "README lost its generated language-support inventory"
+    return match.group(1)
+
+
+def test_listings_advertise_no_removed_capability() -> None:
+    for name, text in _listing_texts().items():
+        lowered = text.lower()
+        for capability in REMOVED_FEATURES:
+            assert capability.lower() not in lowered, (
+                f"{name} advertises {capability!r}, which a released breaking "
+                "change removed (see CHANGELOG.md and docs/MIGRATION.md)"
+            )
+
+
+def test_listings_publish_no_unauthorized_quantitative_claim() -> None:
+    if _authorized_e4_claims():
+        return
+    for name, text in _listing_texts().items():
+        assert not RATIO_CLAIM.search(text), (
+            f"{name} publishes a competitive ratio while {REGISTRY_PATH.name} "
+            "authorizes no E4 claim; land the evidence first, or move the "
+            "measured detail to its benchmark report"
+        )
+
+
+def test_listings_agree_with_the_generated_language_count() -> None:
+    expected = _generated_pipeline_language_count()
+    for name in ("docs/repository-listing.md description", "server.json description"):
+        text = _listing_texts()[name]
+        assert expected in text, (
+            f"{name} does not restate the generated count {expected} from "
+            "README.md; a listing count is a restatement, not a second source"
+        )


### PR DESCRIPTION
Fixes the credibility half of the listing surface: the text users read before the README.

## What was wrong

**1. The MCP registry entry contradicted the README.** `server.json` said *"16 languages"*; the generated inventory in `README.md` says *"13 pipeline-registered"*. Two different counts for the same claim, neither derived from the other.

**2. Nothing guarded the published listing at all.** `server.json`'s version is gated (`test_gitflow_contract.py`), and the claim registry is gated (`test_claim_registry.py` + schema). The *description text* was gated by nothing — which is how the GitHub repository description came to advertise `TOON output` after TOON was removed by the 1.30.0 breaking release, and to publish `~124x by count, ~390x by rate` while `claim_registry.json` holds exactly one claim at evidence level **E0**, and `README.md` states that no quantitative public claim is currently authorized.

The ratios themselves are not invented: `tests/benchmarks/claims/test_390x_miswire_claim.py` documents both derivations from one same-session v1.21.0 pair, and records that the 2026-07-10 re-verification could not complete the CodeGraph arm. That is exactly why they are E0, and why a one-line listing is the wrong place for them — below E4 the number belongs beside its methodology, corpus, and measurement date.

## Change

- **`docs/repository-listing.md`** — gives the published listing a versioned home: the canonical GitHub description, the topics, and the three rules (no removed capability; no quantitative claim below E4; counts restate the generator). It is the source the repository settings mirror, so a release can be checked before it ships.
- **`server.json`** — the language count now restates the generated inventory (`13`).
- **`tests/governance/test_repository_listing_contract.py`** — enforces the first two rules against both the listing file and `server.json`.

## Verification

The gate is proven to reject the defects it was written for, not just to pass:

| state | result |
|---|---|
| as committed | 3 passed |
| `server.json` reverted to `16 languages` | **fails** — `assert '13' in '... 16 languages ...'` |
| listing re-seeded with `TOON output, ~124x fewer mis-wires` | **fails** — removed-capability + ratio rules |
| restored | 3 passed |

`ruff check` clean.

## Out of scope here

Two other stale-TOON documents are deliberately **not** touched:
`docs/regression-testing-guide.md` and `docs/agent-tooling-gap-report.md` both
open with a `HISTORICAL RECORD` marker stating that their paths may no longer
exist and are intentional. Their stale references are the marker's declared
scope, so editing them would break the contract that says so.

The GitHub repository description and topics are updated from
`docs/repository-listing.md` as a separate settings change.
