### PR TITLE
feat(cost): declare QueryCost on the three expensive routes (RFC-0027 L6.2)

### DIFF
--- a/rfcs/0027-agent-secretary-and-calibration.md
+++ b/rfcs/0027-agent-secretary-and-calibration.md
@@ -683,7 +683,7 @@ and emits a calibration report with non-placeholder numbers.
 - [x] L6.1 the harness drives the prescribed route pair **interleaved** and
       records `served_from` per call, so a 0% real-workflow hit rate cannot hide
       behind a grouped-repeat speedup
-- [ ] L6.2 `QueryCost` returned by the three most expensive routes;
+- [x] L6.2 `QueryCost` returned by the three most expensive routes;
       `estimated_ms` is `None` until observed
 - [ ] L6.3 canonical full id always present; abbreviation unique within the
       project index; `SYMBOL_ID_AMBIGUOUS` fail-closed on an ambiguous

--- a/tests/unit/test_query_cost.py
+++ b/tests/unit/test_query_cost.py
@@ -1,0 +1,112 @@
+"""RFC-0027 L6.2 — a route declares what it will cost before it runs.
+
+The load-bearing assertion is that ``estimated_ms`` stays ``None``: the RFC
+forbids a hardcoded guess, and a number invented here would be indistinguishable
+from a measured one.  Tiers, by contrast, are derived from state this process
+can observe.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tree_sitter_analyzer.cache import query_cost as qc
+
+
+@pytest.fixture
+def indexed_project(tmp_path):
+    """A project whose on-disk index holds rows."""
+    source = tmp_path / "a.py"
+    source.write_text("def target_symbol():\n    return 1\n", encoding="utf-8")
+    from tree_sitter_analyzer.ast_cache import ASTCache
+
+    cache = ASTCache(str(tmp_path))
+    try:
+        assert cache.index_file(str(source))["status"] == "indexed"
+    finally:
+        cache.close()
+    return str(tmp_path)
+
+
+def test_unlisted_route_declares_nothing() -> None:
+    # An ordinary route pays nothing to be asked, and so does its envelope.
+    assert qc.query_cost("structure", "outline", None) is None
+    assert qc.cost_fields(None) == {}
+
+
+def test_estimated_ms_is_never_guessed(indexed_project) -> None:
+    for tool, action in qc.EXPENSIVE_ROUTES:
+        cost = qc.query_cost(tool, action, indexed_project, {})
+        assert cost is not None
+        assert cost.estimated_ms is None, (
+            "no observation source exists yet; a number here would be a guess "
+            "the RFC forbids"
+        )
+
+
+def test_route_reading_the_index_reports_index_build_when_absent(tmp_path) -> None:
+    cost = qc.query_cost("nav", "callers", str(tmp_path), {"symbol": "x"})
+    assert cost is not None
+    assert (cost.tier, cost.requires_index_build) == ("index_build", True)
+    assert cost.cheaper_alternative == "nav action=context (1-hop, warm)"
+
+
+def test_route_not_reading_the_index_is_not_charged_for_one(tmp_path) -> None:
+    """``edit action=safe`` computed in 3453 ms with the index ABSENT.
+
+    The L5 baseline recorded ``ast_index_before.status: ABSENT`` for the run
+    that produced that number, so a missing index is not a cost for this route
+    and reporting ``index_build`` would overstate it.
+    """
+    cost = qc.query_cost("edit", "safe", str(tmp_path), {"file_path": "a.py"})
+    assert cost is not None
+    assert (cost.tier, cost.requires_index_build) == ("warm", False)
+
+
+def test_cacheable_route_reports_cold_on_a_miss(indexed_project, monkeypatch) -> None:
+    class _MissCache:
+        def lookup(self, key):  # noqa: ANN001, ANN201 - stub
+            return None
+
+    monkeypatch.setattr(qc, "get_answer_cache", lambda: _MissCache())
+
+    cost = qc.query_cost(
+        "edit", "safe", indexed_project, {"file_path": "tree_sitter_analyzer/latency.py"}
+    )
+    assert cost is not None
+    # The cache miss is the expensive call: 3453 ms computed against 51-69 ms
+    # for the cached repeats in the same baseline run.
+    assert cost.tier == "cold"
+
+
+def test_cacheable_route_reports_cached_on_a_hit(indexed_project, monkeypatch) -> None:
+    class _HitCache:
+        def lookup(self, key):  # noqa: ANN001, ANN201 - stub
+            return object()
+
+    monkeypatch.setattr(qc, "get_answer_cache", lambda: _HitCache())
+
+    cost = qc.query_cost(
+        "edit", "safe", indexed_project, {"file_path": "tree_sitter_analyzer/latency.py"}
+    )
+    assert cost is not None
+    assert cost.tier == "cached"
+
+
+def test_cost_fields_renders_the_declaration(indexed_project) -> None:
+    fields = qc.cost_fields(
+        qc.query_cost("nav", "callers", indexed_project, {"symbol": "x"})
+    )
+    assert set(fields) == {"query_cost"}
+    assert set(fields["query_cost"]) == {
+        "tier",
+        "estimated_ms",
+        "requires_index_build",
+        "cheaper_alternative",
+    }
+
+
+@pytest.mark.parametrize("tool", ["nav", "edit", "health"])
+def test_no_declared_route_is_silently_droppable(tool: str) -> None:
+    """Every listed route must be reachable by name, so a typo cannot hide."""
+    assert any(key[0] == tool for key in qc.EXPENSIVE_ROUTES)

--- a/tree_sitter_analyzer/cache/query_cost.py
+++ b/tree_sitter_analyzer/cache/query_cost.py
@@ -1,0 +1,157 @@
+"""RFC-0027 L6.2 — declare what an expensive route will cost.
+
+A budget-bound agent chooses between routes, so the cost must be stated in
+terms the caller can act on rather than discovered by hitting a timeout.
+
+``estimated_ms`` is derived from *observations*.  No observation source exists
+yet (the L9 calibration ledger is unimplemented), so it is ``None`` — which is
+the contract, not a placeholder: the RFC forbids a hardcoded guess, and a
+number invented here would be indistinguishable from a measured one.
+
+``tier`` is derived from state this process can actually observe:
+
+* ``index_build`` — the on-disk index holds no rows, so a route that reads it
+  will have to build one first.
+* ``cached`` / ``cold`` — for an answer-cacheable route, whether this exact
+  call is already answerable from the cache.  This is the distinction the L5
+  baseline measures: ``edit action=safe`` computed in 3453 ms and then served
+  in 51-69 ms, so a cache miss is the expensive call and a hit is not.
+* ``warm`` — anything else: the index exists and no cache answers this call.
+
+``cold`` is therefore only claimed where a cache miss proves the route has not
+been answered for this generation.  Routes without an answer cache get ``warm``,
+never a guessed ``cold``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from .answer_cache import get_answer_cache
+from .answer_cache_policy import build_answer_key, is_cacheable
+
+Tier = Literal["cached", "warm", "cold", "index_build"]
+
+
+@dataclass(frozen=True)
+class QueryCost:
+    """The declared cost of one route, as reported to the caller."""
+
+    tier: Tier
+    estimated_ms: int | None
+    requires_index_build: bool
+    cheaper_alternative: str | None
+
+
+@dataclass(frozen=True)
+class _Route:
+    """Static facts about an expensive route that no runtime probe can supply."""
+
+    #: Whether the route reads the AST index.  ``edit action=safe`` does not:
+    #: the L5 baseline computed it in 3453 ms with ``ast_index_before.status``
+    #: ABSENT, so a missing index is not a cost for it.
+    reads_index: bool
+    cheaper_alternative: str | None
+
+
+#: Routes whose cost a caller must be able to see before committing.
+#:
+#: Membership is evidence-based rather than a ranking of everything slow.
+#: RFC-0027's dogfood table names ``edit action=safe`` (seconds on the path
+#: taken before every edit) and ``nav action=callers`` (a 24.8 s -> 16 ms
+#: cold/warm cliff).  ``health action=project`` measured 202 s on a
+#: 268-package TypeScript monorepo, past the 60 s per-call default most MCP
+#: clients apply, so it is the third.  ``structure action=outline`` is
+#: deliberately absent: the answer-cache policy records it at 2.9 ms warm,
+#: where a declaration would be noise.
+EXPENSIVE_ROUTES: dict[tuple[str, str], _Route] = {
+    ("nav", "callers"): _Route(
+        reads_index=True,
+        cheaper_alternative="nav action=context (1-hop, warm)",
+    ),
+    ("edit", "safe"): _Route(reads_index=False, cheaper_alternative=None),
+    ("health", "project"): _Route(
+        reads_index=True,
+        cheaper_alternative="health action=file (one file, warm)",
+    ),
+}
+
+
+def _index_holds_rows(project_root: str | None) -> bool:
+    """Whether the on-disk index holds rows.
+
+    The same definition ``CodeGraphAutoIndexTool`` reports as ``indexed``: the
+    in-memory guard marker says only that *this* process warmed something, and
+    a fresh process facing a fully built cache must not read that as absent.
+    """
+    if not project_root:
+        return False
+    try:
+        from ..ast_cache import ASTCache
+
+        cache = ASTCache(project_root)
+        try:
+            stats = cache.get_stats()
+        finally:
+            cache.close()
+    except Exception:
+        return False
+    return bool(stats and stats.get("total_files", 0) > 0)
+
+
+def query_cost(
+    tool: str,
+    action: str,
+    project_root: str | None,
+    arguments: dict[str, Any] | None = None,
+) -> QueryCost | None:
+    """Return the declared cost for ``(tool, action)``, or ``None`` if unlisted.
+
+    ``None`` means "this route makes no claim", which is different from a
+    declared cost with unknown timing.  Only routes in :data:`EXPENSIVE_ROUTES`
+    answer, so an ordinary route pays nothing to be asked.
+    """
+    route = EXPENSIVE_ROUTES.get((tool, action))
+    if route is None:
+        return None
+
+    if route.reads_index and not _index_holds_rows(project_root):
+        return QueryCost(
+            tier="index_build",
+            estimated_ms=None,
+            requires_index_build=True,
+            cheaper_alternative=route.cheaper_alternative,
+        )
+
+    tier: Tier = "warm"
+    if is_cacheable(tool, action):
+        key = build_answer_key(tool, action, arguments or {}, project_root)
+        if key is not None:
+            tier = "cached" if get_answer_cache().lookup(key) is not None else "cold"
+
+    return QueryCost(
+        tier=tier,
+        estimated_ms=None,
+        requires_index_build=False,
+        cheaper_alternative=route.cheaper_alternative,
+    )
+
+
+def cost_fields(cost: QueryCost | None) -> dict[str, Any]:
+    """Render a cost declaration for a response envelope.
+
+    Absent by default: a route that declares no cost omits the key entirely
+    rather than emitting ``null``, so an envelope never gains a field that
+    carries no information.
+    """
+    if cost is None:
+        return {}
+    return {
+        "query_cost": {
+            "tier": cost.tier,
+            "estimated_ms": cost.estimated_ms,
+            "requires_index_build": cost.requires_index_build,
+            "cheaper_alternative": cost.cheaper_alternative,
+        }
+    }

--- a/tree_sitter_analyzer/mcp/tools/callers_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/callers_tool.py
@@ -248,7 +248,17 @@ class CodeGraphCallersTool(CodeGraphRelationToolMixin, BaseMCPTool):
             "next_step": as_next_step,
         }
 
+        # RFC-0027 L6.2: this route's cold/warm cliff (24.8 s -> 16 ms in the
+        # L5 baseline) is the largest in the product, so a caller choosing
+        # between nav actions must see which tier it is about to pay for.
+        from ...cache.query_cost import cost_fields, query_cost
         from ..utils.format_helper import apply_output_format_to_response
+
+        result.update(
+            cost_fields(
+                query_cost("nav", "callers", self.project_root, arguments)
+            )
+        )
 
         return apply_output_format_to_response(result, output_format)
 

--- a/tree_sitter_analyzer/mcp/tools/project_health_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/project_health_tool.py
@@ -165,7 +165,16 @@ class ProjectHealthTool(BaseMCPTool):
             walk_stats=walk_stats,
         )
 
+        # RFC-0027 L6.2: the route's own ``estimated_seconds`` was advisory and
+        # agents still timed out on 4k-file repositories (see F9 above).  Carry
+        # the uniform declaration as well, which states the tier and names a
+        # cheaper scoped route rather than only a duration.
+        from ...cache.query_cost import cost_fields, query_cost
         from ..utils.format_helper import apply_output_format_to_response
+
+        result.update(
+            cost_fields(query_cost("health", "project", self.project_root, arguments))
+        )
 
         return apply_output_format_to_response(
             result, output_format

--- a/tree_sitter_analyzer/mcp/tools/safe_to_edit_tool.py
+++ b/tree_sitter_analyzer/mcp/tools/safe_to_edit_tool.py
@@ -248,6 +248,14 @@ class SafeToEditTool(BaseMCPTool):
         # now propagates it into ``agent_summary``.
         result = mirror_summary_line(result)
 
+        # RFC-0027 L6.2: declare the cost beside the answer.  This is the route
+        # an agent runs before every edit, and the L5 baseline shows its first
+        # (computed) call at 3453 ms against 51-69 ms for every cached repeat,
+        # so the tier is the actionable part of the declaration.
+        from ...cache.query_cost import cost_fields, query_cost
+
+        result.update(cost_fields(query_cost("edit", "safe", self.project_root, arguments)))
+
         return apply_output_format_to_response(result, output_format)
 
     def _read_existing_payload(


### PR DESCRIPTION
Implements RFC-0027 L6.2. A budget-bound agent can now see what an expensive route will cost before committing to it, in one vocabulary, instead of discovering the cost by hitting a timeout.

## Shape

`QueryCost` exactly as the RFC specifies it, plus a renderer that omits the key entirely for routes that declare nothing:

```python
QueryCost(tier, estimated_ms, requires_index_build, cheaper_alternative)
tier: Literal["cached", "warm", "cold", "index_build"]
```

Returned by the three most expensive routes.

## `estimated_ms` is `None`, and that is the contract

The RFC requires it be derived from the L9 ledger's observed p50 and says it is *"never a hardcoded guess"*. The ledger does not exist, so the honest value is `None` — and a test asserts it for every listed route, so a future edit cannot quietly substitute a number that would be indistinguishable from a measured one. Wiring the ledger is L9's work, not a prerequisite for declaring cost.

## Tiers come from observed state, not from a heuristic

| tier | when |
|---|---|
| `index_build` | the on-disk index holds no rows, and the route reads it |
| `cached` / `cold` | answer-cacheable route: whether this exact call is already answerable |
| `warm` | index present, nothing else to claim |

The `cached`/`cold` split is not decorative — it is the distinction the committed L5 baseline measures. In one run `edit action=safe` computed in **3453 ms** and then served in **51 / 51 / 69 ms**, with `served_from` going `computed` → `cache`. So a cache miss *is* the expensive call, and a route without an answer cache gets `warm`, never a guessed `cold`.

`_index_holds_rows` deliberately does **not** use `auto_index_guard.is_indexed`: that is the in-memory guard marker, and `CodeGraphAutoIndexTool`'s own comment records a defect caused by reading it as on-disk state. It uses the same on-disk definition that tool reports as `indexed`.

## Why these three routes, and why `requires_index_build` is per-route

- `nav action=callers` and `edit action=safe` are the two paths RFC-0027's own dogfood table names — the 24.8 s → 16 ms cliff, and the route an agent runs before every edit with no warm benefit before L6.1.
- `health action=project` measured **202 s** on a 268-package TypeScript monorepo, past the 60 s per-call default most MCP clients apply, so it is the third.
- `structure action=outline` is deliberately **absent**: the answer-cache policy records it at 2.9 ms warm, where a declaration would be noise.

`requires_index_build` is declared per route from evidence rather than probed globally, because the routes genuinely differ: the L5 baseline computed `edit action=safe` in 3453 ms with `preconditions.ast_index_before.status: ABSENT`, so a missing index is not a cost for that route and reporting `index_build` for it would overstate the cost. A test pins that asymmetry.

## Verification

- `tests/unit/test_query_cost.py` — 10 new tests: unlisted routes declare nothing; `estimated_ms` is never guessed; an index-reading route reports `index_build` when the index is absent while `edit action=safe` does not; cache miss is `cold` and cache hit is `cached`; the rendered field set is exact.
- Driven on a real indexed corpus and on an index-less project, through both surfaces:

| route | surface | result |
|---|---|---|
| `nav.callers` | MCP + CLI | `warm`, cheaper alternative `nav action=context (1-hop, warm)` |
| `edit.safe` | MCP + CLI | `cold` (the computed call), `requires_index_build: False` |
| `health.project` | MCP | `warm`, cheaper alternative `health action=file` |

- `pytest` over the response-contract, CLI↔MCP parity, callers and safe-to-edit suites → **85 passed**.
- `ruff check` clean.
- RFC-0027's L6.2 acceptance box is now checked.

## Note on the existing field

`project_health_tool` already carried an ad-hoc `estimated_seconds`, and its own comment records that agents obeyed it and still timed out on 4k-file repositories. That field is left in place; the uniform declaration is added beside it rather than replacing a value consumers may already read. Consolidating the two is a follow-up worth doing on its own.
