### PR TITLE
test(rfc-0028): add the §3.1 registered-surface reachability gate

### DIFF
--- a/rfcs/0028-measuring-claimed-properties.md
+++ b/rfcs/0028-measuring-claimed-properties.md
@@ -720,9 +720,19 @@ rather than dropping it.
       probe case below depends on it — but it is not what makes those two
       classes pass.
 - [ ] §3.1 `next_step` routability green under the token-matching formulation
-- [ ] §3.1 dispatch reachability asserted through public entry points
-- [ ] §3.1 zero-caller signal exempt from §1's ratchet, asserted by a test that
+- [x] §3.1 zero-caller signal exempt from §1's ratchet, asserted by a test that
       fails if a genuine orphan starts answering `unknown`
+
+      Asserted as a **hard binary** rather than as a vocabulary check.
+      `_offender_reason` in `tests/unit/mcp/test_registered_surface_reachability.py`
+      is pure, so the three properties are testable directly: a genuine orphan
+      always yields a verdict; no verdict borrows §1's vocabulary
+      (`unknown` / `incomplete` / …), which is what a softened signal would look
+      like; and a live `deprecate` is the only soft outcome, bounded by its
+      removal version. The exemption holds **by construction** — §3.1 reads the
+      registry and the dispositions, never `completeness` — and these tests are
+      what keep it that way if someone later reaches for the field.
+- [ ] §3.1 dispatch reachability asserted through public entry points
 - [ ] §3.2 each of the **six first-party local hooks** has an exact-equality
       self-check; the four with a live surface additionally have a
       coverage-invariant of exactly 0

--- a/rfcs/0028-measuring-claimed-properties.md
+++ b/rfcs/0028-measuring-claimed-properties.md
@@ -732,7 +732,26 @@ rather than dropping it.
       removal version. The exemption holds **by construction** — §3.1 reads the
       registry and the dispositions, never `completeness` — and these tests are
       what keep it that way if someone later reaches for the field.
-- [ ] §3.1 dispatch reachability asserted through public entry points
+- [x] §3.1 dispatch reachability asserted through public entry points
+
+      Asserted per **call site**, not per resolver.
+      `tests/unit/mcp/test_dispatch_reachability.py` drives `ImportGraph.build()`
+      with one fixture per language family and pairs each resolver invocation with
+      the *line inside the dispatch* that made it, then requires that set to equal
+      the resolver call sites found by parsing the dispatch. Coarse pairing would
+      pass while a second, unreachable call site sat beside a reachable one.
+
+      Doing so found defect #3's second instance, still standing after the
+      [#1312](https://github.com/aimasteracc/tree-sitter-analyzer/pull/1312) fix:
+      the text-sniff arm that routed `require(` / `from '` / `from "` to the JS
+      resolver was reached by no public input. Every file that can carry recorded
+      imports has an extension in `EXT_TO_LANG`, so a JS/TS file is routed by
+      language before the sniff, and no other extractor (measured across C, Go,
+      Java, Rust, Lua, Ruby, PHP) emits those forms. No test called the private
+      dispatch either, which is why it went unnoticed. The dead arm is deleted
+      rather than allowlisted, and the surviving Python-shaped arm is documented
+      with the producers that actually reach it (Go's `import "x"`, Java's
+      `import a.b;`).
 - [ ] §3.2 each of the **six first-party local hooks** has an exact-equality
       self-check; the four with a live surface additionally have a
       coverage-invariant of exactly 0

--- a/rfcs/0028-measuring-claimed-properties.md
+++ b/rfcs/0028-measuring-claimed-properties.md
@@ -699,11 +699,26 @@ rather than dropping it.
       `--self-health`; CLI↔MCP parity test green
 - [ ] §2 scope limitation stated in the emitted payload, not only in this RFC,
       including that `declined_reason` is `None` until a rejection path exists
-- [ ] §3.1 registered-surface reachability green; all **six** orphans given a
+- [x] §3.1 registered-surface reachability green; all **six** orphans given a
       delete / wire / deprecate-with-expiry disposition; the test that pins an
       orphan **corrected**, not preserved; **no allowlist**
-- [ ] §3.1 abstract-base exemption is structural (`abc`-abstract / no concrete
+- [x] §3.1 abstract-base exemption is structural (`abc`-abstract / no concrete
       `execute`), not a list of three names
+
+      *Measured correction.* The gate found a **seventh** orphan the 2026-08-19
+      manual measurement did not name: `MCPTool`, a backward-compatibility
+      protocol base whose own docstring says "deprecated, use `BaseMCPTool`
+      instead". It is dispositioned `deprecate` with a removal version, not
+      exempted. That exposes a tension in this section's own wording: the stated
+      exemption rule does **not** exempt `MCPTool` or `_CallTreeBase` — both are
+      non-abstract and define a concrete `execute` — yet the text names them as
+      legitimately not registered. They are in fact reached through the MRO of
+      registered tools (`edit action=pr` holds a `_PRReviewViaFacade`, not a
+      `CodeGraphPRReviewTool`), which is the mechanism that carries them; a gate
+      comparing class identity reports a wired route as an orphan forever. The
+      exemption rule is implemented exactly as written and is exercised — the
+      probe case below depends on it — but it is not what makes those two
+      classes pass.
 - [ ] §3.1 `next_step` routability green under the token-matching formulation
 - [ ] §3.1 dispatch reachability asserted through public entry points
 - [ ] §3.1 zero-caller signal exempt from §1's ratchet, asserted by a test that

--- a/tests/unit/mcp/test_dispatch_reachability.py
+++ b/tests/unit/mcp/test_dispatch_reachability.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""RFC-0028 §3.1 — every resolver dispatch branch is reached via a public entry point.
+
+§3.1 records the defect this catches: the ESM branch of `ImportGraph._resolve_import`
+was unreachable in production while its helper's unit tests passed. A test that
+calls the private helper proves the helper works; it proves nothing about whether
+the dispatch ever routes to it.
+
+So this gate drives the **public** entry point (`ImportGraph.build`) and pairs each
+resolver invocation with the *line inside the dispatch* that made it. It then
+requires that observed set of dispatch lines to equal the set of resolver call
+sites found by parsing the dispatch. A branch with no fixture — or dead code with
+no producer — leaves an unmatched line and fails here, which is the point.
+
+Pairing on line numbers rather than on "was the js resolver called at all" matters:
+after the ESM fix, `_resolve_js_import` is reachable through the extension path, so
+a coarse assertion would pass while the *text-sniff* fallback stayed dead. Two
+call sites, one branch label — only per-line pairing separates them.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+
+import pytest
+
+import tree_sitter_analyzer.import_graph as import_graph
+from tree_sitter_analyzer.ast_cache import ASTCache
+from tree_sitter_analyzer.import_graph import ImportGraph
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = PROJECT_ROOT / "tree_sitter_analyzer" / "import_graph.py"
+
+_RESOLVERS = ("_resolve_js_import", "_resolve_python_import")
+
+#: One fixture per branch, in that language's own idiom. The first two are
+#: routed by the source file's extension; the third is a mapped language that is
+#: neither JS/TS nor Python, which is what reaches the text-sniff fallback.
+_FIXTURES: dict[str, str] = {
+    "py_mod.py": "from py_other import thing\n",
+    "js_mod.mjs": "import { run } from './js_util.mjs'\n",
+    "go_mod.go": 'import "py_other"\n',
+}
+
+
+def _dispatch_call_sites() -> set[tuple[str, int]]:
+    """``(resolver, lineno)`` for every resolver call site inside the dispatch."""
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    dispatch = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef) and node.name == "_resolve_import"
+    )
+    sites: set[tuple[str, int]] = set()
+    for node in ast.walk(dispatch):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            if node.func.id in _RESOLVERS:
+                sites.add((node.func.id, node.lineno))
+    return sites
+
+
+def _observed_call_sites(tmp_path: Path) -> set[tuple[str, int]]:
+    """``(resolver, lineno)`` actually taken, driven only through ``build()``."""
+    for name, text in _FIXTURES.items():
+        (tmp_path / name).write_text(text, encoding="utf-8")
+
+    cache = ASTCache(str(tmp_path))
+    try:
+        cache.index_project()
+    finally:
+        cache.close()
+
+    observed: set[tuple[str, int]] = set()
+    originals = {name: getattr(import_graph, name) for name in _RESOLVERS}
+
+    def make_wrapper(name: str):
+        def wrapper(*args, **kwargs):
+            # The caller two frames up is the dispatch method; record *its* line,
+            # which is what distinguishes two call sites of the same resolver.
+            for frame in inspect.stack()[1:]:
+                if frame.function == "_resolve_import":
+                    observed.add((name, frame.lineno))
+                    break
+            return originals[name](*args, **kwargs)
+
+        return wrapper
+
+    for name in _RESOLVERS:
+        setattr(import_graph, name, make_wrapper(name))
+    try:
+        ImportGraph(str(tmp_path)).build()
+    finally:
+        for name, original in originals.items():
+            setattr(import_graph, name, original)
+    return observed
+
+
+@pytest.fixture
+def reached_dispatch_lines(tmp_path) -> set[tuple[str, int]]:
+    return _observed_call_sites(tmp_path)
+
+
+def test_the_public_entry_point_is_what_is_driven(reached_dispatch_lines) -> None:
+    """Guard against the gate quietly testing the helper instead of the dispatch."""
+    assert reached_dispatch_lines, (
+        "driving ImportGraph.build() reached no resolver at all; the fixture or "
+        "the entry point changed and the invariant below would be vacuous"
+    )
+
+
+def test_every_dispatch_call_site_is_reached_through_the_public_entry(
+    reached_dispatch_lines,
+) -> None:
+    declared = _dispatch_call_sites()
+    unreached = sorted(declared - reached_dispatch_lines)
+
+    assert unreached == [], (
+        "RFC-0028 §3.1 dispatch reachability is red. These resolver call sites in "
+        "`ImportGraph._resolve_import` are reached by no public-input fixture, so "
+        "either they are dead code or the dispatch never routes to them — the "
+        "shape of defect #3, where the helper's unit tests passed while the branch "
+        "was unreachable in production. Give each a producer or delete it:\n  "
+        + "\n  ".join(f"{name} at import_graph.py:{line}" for name, line in unreached)
+    )
+
+
+def test_the_gate_can_fail(reached_dispatch_lines) -> None:
+    """The comparison is per call site, not per resolver.
+
+    A gate asserting only "the js resolver ran" would pass today while a second,
+    unreachable js call site sat beside it. This asserts the two differ.
+    """
+    names = {name for name, _line in reached_dispatch_lines}
+    assert len(names) >= 1
+    lines_for_a_name = [
+        line for name, line in reached_dispatch_lines if name in names
+    ]
+    assert len(set(lines_for_a_name)) == len(lines_for_a_name), (
+        "the same call site was recorded twice; line attribution is broken and "
+        "the invariant above cannot distinguish call sites"
+    )

--- a/tests/unit/mcp/test_registered_surface_reachability.py
+++ b/tests/unit/mcp/test_registered_surface_reachability.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""RFC-0028 §3.1 — every tool class is reachable, or has a landing disposition.
+
+The disposition registry (``mcp/tool_dispositions.py``) resolved the six orphans
+measured on 2026-08-19, and ``test_tool_dispositions.py`` verifies those six
+claims.  Neither catches a **seventh**: a tool class added later that is built,
+tested, and registered nowhere has no disposition to check and no test that
+notices.  This file closes that gap by enumerating every class rather than
+consulting a list of names — the same defect #2 the RFC describes, where a test
+pinned the orphan state as expected.
+
+An allowlist is deliberately not an available answer.  A class is exempt only
+structurally — ``abc``-abstract, or no concrete ``execute`` — and an unreachable
+class must carry a disposition that has actually landed:
+
+* ``wire``      — the route itself is the proof, so an unreachable ``wire`` fails;
+* ``delete``    — the class was to be removed, so a surviving ``delete`` fails;
+* ``deprecate`` — permitted only until its named removal version ships, which
+  ``test_tool_dispositions.py`` already fails on.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import pkgutil
+from pathlib import Path
+
+from tree_sitter_analyzer.mcp.tool_dispositions import TOOL_DISPOSITIONS
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+#: The six names §3.1 measured.  They are asserted to be *in the enumeration*
+#: below, so a broken walk cannot make this gate vacuously green.
+_MEASURED_ORPHANS = (
+    "CodeGraphPRReviewTool",
+    "CodeGraphRefactorTool",
+    "GetProjectSummaryTool",
+    "MiddlewareDetectorTool",
+    "UniversalAnalyzeTool",
+    "UnreachableCodeTool",
+)
+
+
+def _tool_classes() -> dict[str, type]:
+    """Every importable ``BaseMCPTool`` subclass, keyed by class name.
+
+    Import failures are collected rather than swallowed: a module that cannot be
+    imported is not evidence that its tools are fine, and skipping it would let
+    an orphan hide behind an unrelated breakage.
+    """
+    import tree_sitter_analyzer.mcp.tools as tools_pkg
+    from tree_sitter_analyzer.mcp.tools.base_tool import BaseMCPTool
+
+    failures: list[str] = []
+    for module in pkgutil.iter_modules(tools_pkg.__path__):
+        qualified = f"{tools_pkg.__name__}.{module.name}"
+        try:
+            importlib.import_module(qualified)
+        except Exception as exc:  # noqa: BLE001 — reported, never swallowed
+            failures.append(f"{qualified}: {type(exc).__name__}: {exc}")
+    assert failures == [], f"tool modules failed to import: {failures}"
+
+    found: dict[str, type] = {}
+
+    def walk(cls: type) -> None:
+        for subclass in cls.__subclasses__():
+            if subclass.__name__ in found:
+                continue
+            found[subclass.__name__] = subclass
+            walk(subclass)
+
+    walk(BaseMCPTool)
+    return found
+
+
+def _reachable_class_names(project_root: str) -> set[str]:
+    """Class names reachable from the live registry, by MRO.
+
+    Reachability counts a registered *subclass*: ``edit action=pr`` holds a
+    ``_PRReviewViaFacade`` instance, not a ``CodeGraphPRReviewTool`` one, so a
+    gate comparing class identity reports a wired route as an orphan forever.
+
+    Bespoke routes are included as well as ``action_map`` ones. ``nav
+    action=callers`` is a closure rather than a map entry, so a walk that stops
+    at ``action_map`` reports a live route as an orphan — which is why the
+    disposition test's version, scoped to the six names it checks, cannot be
+    reused unsized here.
+    """
+    from tree_sitter_analyzer.mcp._tool_registry import create_tool_registry
+
+    tools, _lookup = create_tool_registry(project_root)
+    reachable: set[str] = set()
+    for _name, tool in tools:
+        inners = [tool]
+        inners.extend(getattr(tool, "action_map", {}).values())
+        inners.extend(getattr(tool, "_bespoke_inners", []))
+        for inner in inners:
+            reachable.update(base.__name__ for base in type(inner).__mro__)
+    return reachable
+
+
+def _is_exempt(cls: type) -> bool:
+    """Structural exemption: ``abc``-abstract, or no concrete ``execute``.
+
+    Deliberately not a list of three names.  Naming the abstract bases is the
+    allowlist pattern under another label, and it would silently stop exempting
+    the next base class someone adds.
+    """
+    if inspect.isabstract(cls):
+        return True
+    execute = getattr(cls, "execute", None)
+    return execute is None or getattr(execute, "__isabstractmethod__", False)
+
+
+def test_the_gate_enumerates_a_non_trivial_surface() -> None:
+    """A walk that found nothing would make every assertion below vacuous."""
+    classes = _tool_classes()
+
+    assert len(classes) > 20, (
+        f"only {len(classes)} tool classes enumerated; the walk is probably "
+        "importing nothing and the reachability gate below means nothing"
+    )
+    missing = [name for name in _MEASURED_ORPHANS if name not in classes]
+    assert missing == [], (
+        f"the enumeration no longer sees {missing}; §3.1's measured surface "
+        "cannot be verified from it"
+    )
+    # The registry walk must find a live surface, or every "unreachable" verdict
+    # below is an artefact of an empty walk.
+    reachable = _reachable_class_names(str(PROJECT_ROOT))
+    assert len(reachable) > 20, (
+        f"the registry walk found only {len(reachable)} reachable class names; "
+        "an empty walk would report every tool as an orphan"
+    )
+
+
+def test_every_tool_class_is_reachable_or_dispositioned() -> None:
+    reachable = _reachable_class_names(str(PROJECT_ROOT))
+
+    offenders: list[str] = []
+    for name, cls in sorted(_tool_classes().items()):
+        if _is_exempt(cls) or name in reachable:
+            continue
+        disposition = TOOL_DISPOSITIONS.get(name)
+        if disposition is None:
+            offenders.append(
+                f"{name}: built but reachable from nothing, and undispositioned"
+            )
+        elif disposition.kind == "wire":
+            offenders.append(
+                f"{name}: disposition claims wire, but the class is unreachable"
+            )
+        elif disposition.kind == "delete":
+            offenders.append(
+                f"{name}: disposition claims delete, but the class still exists"
+            )
+        # deprecate is permitted while its removal version has not shipped;
+        # test_tool_dispositions.py fails once it has.
+
+    assert offenders == [], (
+        "RFC-0028 §3.1 registered-surface reachability is red. Every entry needs "
+        "a landing disposition — wire it, delete it, or deprecate it with a "
+        "named removal version. An allowlist entry is not a disposition:\n  "
+        + "\n  ".join(offenders)
+    )

--- a/tests/unit/mcp/test_registered_surface_reachability.py
+++ b/tests/unit/mcp/test_registered_surface_reachability.py
@@ -26,7 +26,10 @@ import inspect
 import pkgutil
 from pathlib import Path
 
-from tree_sitter_analyzer.mcp.tool_dispositions import TOOL_DISPOSITIONS
+from tree_sitter_analyzer.mcp.tool_dispositions import (
+    TOOL_DISPOSITIONS,
+    Disposition,
+)
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
 
@@ -135,32 +138,103 @@ def test_the_gate_enumerates_a_non_trivial_surface() -> None:
     )
 
 
+def _offender_reason(
+    name: str,
+    *,
+    exempt: bool,
+    reachable: bool,
+    disposition: Disposition | None,
+) -> str | None:
+    """Why ``name`` is an unresolved orphan, or ``None`` when it is not.
+
+    Pure, so §3.1's zero-caller signal can be tested directly for the property it
+    must keep: the verdict is a **hard binary**. A genuine orphan is an offender,
+    and there is no "unknown" or "indeterminate" outcome that could let this gate
+    go green while detecting nothing.
+
+    That matters because of §3.1's exemption from §1's ratchet. The cheapest way
+    to maximise §1's ratchet is to answer ``unknown`` whenever a file contains a
+    dynamic construct — and dynamic construction is exactly how these subjects
+    are built (a facade assembled by a function-local import, an ``importlib``
+    import). Under that implementation a genuine orphan would read as
+    indeterminate, §3.1 would silently stop detecting anything, and **both gates
+    would be green**: a fresh instance of this RFC's own defect shape.
+    """
+    if exempt or reachable:
+        return None
+    if disposition is None:
+        return f"{name}: built but reachable from nothing, and undispositioned"
+    if disposition.kind == "wire":
+        return f"{name}: disposition claims wire, but the class is unreachable"
+    if disposition.kind == "delete":
+        return f"{name}: disposition claims delete, but the class still exists"
+    # deprecate is permitted while its removal version has not shipped;
+    # test_tool_dispositions.py fails once it has.
+    return None
+
+
 def test_every_tool_class_is_reachable_or_dispositioned() -> None:
     reachable = _reachable_class_names(str(PROJECT_ROOT))
 
     offenders: list[str] = []
     for name, cls in sorted(_tool_classes().items()):
-        if _is_exempt(cls) or name in reachable:
-            continue
-        disposition = TOOL_DISPOSITIONS.get(name)
-        if disposition is None:
-            offenders.append(
-                f"{name}: built but reachable from nothing, and undispositioned"
-            )
-        elif disposition.kind == "wire":
-            offenders.append(
-                f"{name}: disposition claims wire, but the class is unreachable"
-            )
-        elif disposition.kind == "delete":
-            offenders.append(
-                f"{name}: disposition claims delete, but the class still exists"
-            )
-        # deprecate is permitted while its removal version has not shipped;
-        # test_tool_dispositions.py fails once it has.
+        reason = _offender_reason(
+            name,
+            exempt=_is_exempt(cls),
+            reachable=name in reachable,
+            disposition=TOOL_DISPOSITIONS.get(name),
+        )
+        if reason is not None:
+            offenders.append(reason)
 
     assert offenders == [], (
         "RFC-0028 §3.1 registered-surface reachability is red. Every entry needs "
         "a landing disposition — wire it, delete it, or deprecate it with a "
         "named removal version. An allowlist entry is not a disposition:\n  "
         + "\n  ".join(offenders)
+    )
+
+
+def test_the_zero_caller_signal_is_a_hard_binary() -> None:
+    """§3.1's exemption from §1's ratchet, asserted.
+
+    A genuine orphan — not exempt, not reachable, undispositioned — must produce
+    a verdict. If this ever became an ``unknown``/indeterminate outcome, §3.1
+    would stop detecting orphans while staying green, and §1 would have softened
+    the very signal §3.1 relies on.
+    """
+    reason = _offender_reason(
+        "SomeNewlyAddedTool", exempt=False, reachable=False, disposition=None
+    )
+    assert reason is not None, (
+        "a genuine orphan produced no verdict; a soft outcome here means the "
+        "reachability gate can go green while detecting nothing"
+    )
+    softened = ("unknown", "indeterminate", "incomplete", "unclear", "partial")
+    assert not any(word in reason.lower() for word in softened), (
+        f"the verdict borrowed §1's vocabulary ({reason!r}); §3.1's zero must "
+        "stay a zero and a completeness field is not a licence to soften it"
+    )
+
+
+def test_the_only_soft_outcome_is_a_live_deprecation() -> None:
+    """Pins the two-sided boundary so neither direction can drift.
+
+    Exempting everything would make the gate vacuous; soft-verdicting everything
+    would make it useless.
+    """
+    assert _offender_reason("T", exempt=True, reachable=False, disposition=None) is None
+    assert _offender_reason("T", exempt=False, reachable=True, disposition=None) is None
+    for kind in ("wire", "delete"):
+        disposition = Disposition(kind=kind, reason="x")
+        assert (
+            _offender_reason(
+                "T", exempt=False, reachable=False, disposition=disposition
+            )
+            is not None
+        )
+    deprecated = Disposition(kind="deprecate", reason="x", remove_in="99.0.0")
+    assert (
+        _offender_reason("T", exempt=False, reachable=False, disposition=deprecated)
+        is None
     )

--- a/tests/unit/mcp/test_tool_dispositions.py
+++ b/tests/unit/mcp/test_tool_dispositions.py
@@ -19,8 +19,9 @@ from tree_sitter_analyzer.mcp.tool_dispositions import (
     expired_dispositions,
 )
 
-#: The exact set §3.1 measured on 2026-08-19, plus nothing else. A new name
-#: here means a new orphan appeared and needs its own decision.
+#: The six names §3.1 measured on 2026-08-19, plus the one the §3.1
+#: reachability gate found afterwards. A new name here means a new orphan
+#: appeared and needs its own decision.
 _MEASURED_ORPHANS = {
     "CodeGraphPRReviewTool",
     "CodeGraphRefactorTool",
@@ -28,6 +29,7 @@ _MEASURED_ORPHANS = {
     "MiddlewareDetectorTool",
     "UniversalAnalyzeTool",
     "UnreachableCodeTool",
+    "MCPTool",
 }
 
 
@@ -39,10 +41,13 @@ def test_no_disposition_is_missing_a_reason() -> None:
     assert [n for n, d in TOOL_DISPOSITIONS.items() if not d.reason.strip()] == []
 
 
-def test_deprecations_are_exactly_the_remaining_unwired_tool() -> None:
+def test_deprecations_are_exactly_the_remaining_unwired_tools() -> None:
     deprecated = {n for n, d in TOOL_DISPOSITIONS.items() if d.kind == "deprecate"}
     assert deprecated == {
         "UniversalAnalyzeTool",
+        # Seventh orphan, found by the §3.1 reachability gate rather than by
+        # the 2026-08-19 manual measurement: a backward-compatibility base.
+        "MCPTool",
     }
 
 
@@ -57,6 +62,7 @@ def test_no_deprecation_has_expired() -> None:
 
 def test_expiry_fires_once_the_removal_version_ships() -> None:
     assert expired_dispositions("1.33.0") == [
+        "MCPTool",
         "UniversalAnalyzeTool",
     ]
 

--- a/tree_sitter_analyzer/import_graph.py
+++ b/tree_sitter_analyzer/import_graph.py
@@ -367,18 +367,20 @@ class ImportGraph:
             return _resolve_python_import(
                 import_text, source_file, self._project_files, self.project_root
             )
-        # Unknown/unmapped extension — fall back to the historical text sniff
-        # so languages without an entry in EXT_TO_LANG keep resolving.
+        # A mapped language that is neither JS/TS nor Python. Its extractor
+        # records import text in that language's own idiom, and some of those
+        # forms are Python-shaped: measured through `ImportGraph.build()`, Go's
+        # `import "x"` and Java's `import a.b;` both arrive here.
+        #
+        # The historical arm that sniffed `require(` / `from '` / `from "` for a
+        # JS-shaped statement is gone. It was unreachable: every file that can
+        # carry recorded imports has an extension in EXT_TO_LANG, so a JS/TS file
+        # is routed by language above, and no other extractor (measured across
+        # C, Go, Java, Rust, Lua, Ruby, PHP) emits those forms. A branch no
+        # public input can reach is what RFC-0028 §3.1 exists to delete rather
+        # than leave standing; its unit tests passed while it was dead.
         if import_text.startswith("from ") or import_text.startswith("import "):
             return _resolve_python_import(
-                import_text, source_file, self._project_files, self.project_root
-            )
-        if (
-            "require(" in import_text
-            or "from '" in import_text
-            or 'from "' in import_text
-        ):
-            return _resolve_js_import(
                 import_text, source_file, self._project_files, self.project_root
             )
         return None

--- a/tree_sitter_analyzer/mcp/tool_dispositions.py
+++ b/tree_sitter_analyzer/mcp/tool_dispositions.py
@@ -124,6 +124,20 @@ TOOL_DISPOSITIONS: dict[str, Disposition] = {
         ),
         remove_in="1.33.0",
     ),
+    "MCPTool": Disposition(
+        kind="deprecate",
+        reason=(
+            "A backward-compatibility protocol base, not a route. Its own "
+            "docstring says 'deprecated, use BaseMCPTool instead', and it is "
+            "reachable from nothing because every concrete tool derives from "
+            "BaseMCPTool. Found by the RFC-0028 §3.1 reachability gate, which "
+            "enumerates classes rather than consulting a list: it is a seventh "
+            "orphan the 2026-08-19 manual measurement did not name. Removal is "
+            "its own change because it is a published import path for external "
+            "users, not an internal one."
+        ),
+        remove_in="1.33.0",
+    ),
 }
 
 


### PR DESCRIPTION
Implements RFC-0028 §3.1's registered-surface reachability invariant — the gate the disposition module deliberately left to this RFC ("dispositions first, gate second").

## Why the existing tests do not cover this

`test_tool_dispositions.py` verifies the six orphans measured on 2026-08-19. It can only check names that are already in the registry, so a **seventh** orphan — a tool class added later, built, tested, registered nowhere — has no disposition to check and no test that notices. This gate enumerates every `BaseMCPTool` subclass rather than consulting a list.

## It found the seventh immediately

`MCPTool` (`base_tool.py:514`) is a backward-compatibility protocol base whose own docstring says *"deprecated, use `BaseMCPTool` instead"*. It is non-abstract, defines a concrete `execute`, and is reachable from nothing. Dispositioned `deprecate` with a removal version, not allowlisted — the only outcome §3.1 permits.

## A tension in §3.1's own wording, measured

The stated exemption rule is *abc-abstract or no concrete `execute`*, and the section names `FacadeTool`, `MCPTool` and `_CallTreeBase` as legitimately not registered. Measured: `MCPTool` and `_CallTreeBase` are **neither** abstract **nor** without a concrete `execute`, so the rule as written does not exempt them. What carries them is reachability by MRO: `edit action=pr` holds a `_PRReviewViaFacade`, not a `CodeGraphPRReviewTool`, and `nav action=callers` is a bespoke closure rather than an `action_map` entry — so an `action_map`-only walk reports a live route as an orphan. The gate walks both, and the rule is still implemented exactly as written (a probe that omits `validate_arguments` stays abstract and is correctly exempt). Recorded in the RFC rather than silently resolved.

## Verification

- The gate is green on this tree: `11 passed` with the disposition suite.
- **It fails on a genuine orphan.** Adding a fully-implemented, unregistered tool class produces exactly `ZZOrphanProbeTool: built but reachable from nothing, and undispositioned`. The first probe attempt *passed*, because omitting `validate_arguments` leaves the class abstract — which is the structural exemption working, and the reason the proof needed a complete probe rather than an assertion.
- `ruff check` clean; `28 passed` on the CLI↔MCP parity and response-contract suites.