### PR TITLE
test(rfc-0028): live unknown-rate measurement + first-party gate inventory

### DIFF
--- a/rfcs/0028-measuring-claimed-properties.md
+++ b/rfcs/0028-measuring-claimed-properties.md
@@ -730,9 +730,20 @@ rather than dropping it.
 - [ ] §3.2 every gate names its **marker set + workflow job** (or its pre-commit
       hook) and proves a non-zero collected count
 
-      *Partially landed.* The inventory gate asserts each scoped hook runs at the
-      `pre-commit` stage, which is the layer that enforces it. A non-zero
-      collected count per marker set is not yet asserted.
+      *Partially landed.* Both halves are now enumerated and checked:
+      `tests/governance/test_first_party_gate_inventory.py` asserts every scoped
+      hook runs at the `pre-commit` stage, and
+      `tests/governance/test_workflow_marker_sets.py` derives **10 marker-driven
+      gates across 6 workflows** from the workflow YAML, names each one's job,
+      and asserts every positive marker in each expression is carried by at least
+      one test — the vacuity case, where `pytest -m "<marker>"` collects nothing
+      and always succeeds. It also pins the one shell-templated set
+      (`e2e${EXTRA_MARKS}`) as a decision rather than a silent skip.
+
+      **What is still missing is the collected count itself.** Collection costs
+      5–15 s per expression here, so five expressions would add about a minute to
+      the fast suite; the static check catches vacuity and typos without that
+      cost, and does not read a count.
 - [ ] §3.2 the enforcement layer is named per gate: either
       `required_status_checks` added to a `develop` ruleset, or pre-commit
       declared as the blocking layer

--- a/rfcs/0028-measuring-claimed-properties.md
+++ b/rfcs/0028-measuring-claimed-properties.md
@@ -451,17 +451,26 @@ proving its detector still matches live production, asserting **exact** set
 equality — not a `count > 0` lower bound.
 
 **Scope, stated precisely, because "every blocking gate" is unimplementable.**
-`.pre-commit-config.yaml` declares **27 hooks, of which 21 are third-party**:
+`.pre-commit-config.yaml` declares **28 hooks, of which 21 are third-party**:
 `ruff` + `ruff-format`, 14 `pre-commit-hooks`, `detect-secrets`, `bandit`,
 `mypy`, `pyupgrade`, `actionlint`. You cannot add a `--self-check` mode to
 `ruff`, and requirement 2 below ("count of surface items outside the watch
 filter == 0") has **no referent at all** for `check-yaml` — it has no watched
-surface to be outside of. §3.2 therefore scopes to the **6 local hooks**:
+surface to be outside of. §3.2 therefore scopes to the **7 local hooks**:
+
+*Measured correction (2026-09-12).* This section previously read "27 hooks … 6
+local hooks" and omitted `test-encoding-ratchet` from the table below. Both
+numbers are now derived from the configuration by
+`tests/governance/test_first_party_gate_inventory.py`, which fails if this table
+and `.pre-commit-config.yaml` disagree — the omission is why that check exists,
+and the omitted hook is itself a ratchet, the same class whose dead-detector
+defect this section records as #1.
 
 | local hook | has a live surface to drift from? |
 |---|---|
 | `tsa-codemap-sync` | **yes** — the MCP/CLI registry; already rebuilt this way in #1314 |
 | `weak-assertion-ratchet` | **yes** — the set of assertions it can parse (its blind spot to markdown is defect #5) |
+| `test-encoding-ratchet` | **yes** — the count of non-UTF-8-safe test files it measures against a grandfathered baseline |
 | `block-banned-test-names` | **yes** — the banned-pattern list vs the live test-file set |
 | `workflow-consistency-tests` | **yes** — the set of workflows it checks vs `.github/workflows/*` |
 | `block-local-artifacts` | partial — a static path/glob denylist; requirement 1 applies, requirement 2 does not |
@@ -708,14 +717,29 @@ rather than dropping it.
 - [ ] §3.1 dispatch reachability asserted through public entry points
 - [ ] §3.1 zero-caller signal exempt from §1's ratchet, asserted by a test that
       fails if a genuine orphan starts answering `unknown`
-- [ ] §3.2 each of the **six first-party local hooks** has an exact-equality
-      self-check; the four with a live surface additionally have a
+- [ ] §3.2 each of the **seven first-party local hooks** has an exact-equality
+      self-check; the five with a live surface additionally have a
       coverage-invariant of exactly 0
+
+      *Partially landed (2026-09-12).* The scope itself is now enforced:
+      `tests/governance/test_first_party_gate_inventory.py` derives the hook set
+      from `.pre-commit-config.yaml`, fails if this section's table disagrees with
+      it, and asserts every hook's `entry` resolves to a file that exists. That
+      check is what establishes the count as **seven**, not six. The per-hook
+      `--self-check` modes and the coverage invariants are still open.
 - [ ] §3.2 every gate names its **marker set + workflow job** (or its pre-commit
       hook) and proves a non-zero collected count
+
+      *Partially landed.* The inventory gate asserts each scoped hook runs at the
+      `pre-commit` stage, which is the layer that enforces it. A non-zero
+      collected count per marker set is not yet asserted.
 - [ ] §3.2 the enforcement layer is named per gate: either
       `required_status_checks` added to a `develop` ruleset, or pre-commit
       declared as the blocking layer
+
+      *Partially landed.* Pre-commit is the working layer and the inventory gate
+      pins that every scoped hook is present there. The per-gate naming this item
+      asks for, and the ruleset alternative, are still open.
 - [x] §3.2 `test_unknown_rate_threshold_value` and
       `test_unknown_rate_threshold_is_documented_in_this_file` replaced by a live
       measurement

--- a/rfcs/0028-measuring-claimed-properties.md
+++ b/rfcs/0028-measuring-claimed-properties.md
@@ -716,9 +716,22 @@ rather than dropping it.
 - [ ] §3.2 the enforcement layer is named per gate: either
       `required_status_checks` added to a `develop` ruleset, or pre-commit
       declared as the blocking layer
-- [ ] §3.2 `test_unknown_rate_threshold_value` and
+- [x] §3.2 `test_unknown_rate_threshold_value` and
       `test_unknown_rate_threshold_is_documented_in_this_file` replaced by a live
-      measurement or deleted
+      measurement
+
+      Replaced, not deleted. `test_unknown_rate_is_measured_within_threshold`
+      indexes the product source (`workers=1`, ~13 s on the `full_language` axis)
+      and measures the rate against the ceiling. Measured **2026-09-12: 9.78% on
+      the product source (4,941 / 50,528 CALLS edges)** and 6.27% on a 2,174-file
+      self-repo subset, against a 6.0% ceiling — the claim is **not met**, and was
+      not met while the two self-referential tests passed. The measurement is a
+      strict `xfail`, so it is recorded rather than hidden, and it is removed only
+      by a genuine improvement. Proved by experiment: raising
+      `UNKNOWN_RATE_THRESHOLD_PCT` to 10.0 makes the assertion pass, which turns
+      the `xfail` into an unexpected pass and **fails the run** — the "never
+      increase without a reviewed decision" rule is now enforced instead of
+      documented.
 - [ ] §3.2 doc-example extraction runs agent-facing doc examples in CI
 - [ ] §3.3 path-comparison invariant covers both separator conventions
 - [ ] Docs/CODEMAPS updated

--- a/tests/benchmarks/claims/test_unknown_rate_ratchet.py
+++ b/tests/benchmarks/claims/test_unknown_rate_ratchet.py
@@ -17,7 +17,11 @@ Measurement SQL (run against tree-sitter-analyzer self-repo index):
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
 
 pytestmark = [
     pytest.mark.benchmark,
@@ -34,32 +38,64 @@ pytestmark = [
 UNKNOWN_RATE_THRESHOLD_PCT = 6.0
 
 
-def test_unknown_rate_threshold_is_documented_in_this_file():
-    """The threshold value and baseline history must be readable in this file."""
-    import inspect
+def _measure_unknown_rate() -> tuple[float, int, int]:
+    """Measure the unknown callee-resolution rate over this repository.
 
-    src = inspect.getfile(test_unknown_rate_threshold_is_documented_in_this_file)
-    with open(src, encoding="utf-8") as f:
-        content = f.read()
-    assert "UNKNOWN_RATE_THRESHOLD_PCT" in content
-    assert "6.0" in content
-    assert "3.7" in content
-    assert "callee_resolution" in content, (
-        "The measurement SQL must be present in this test file."
-    )
-
-
-def test_unknown_rate_threshold_value():
-    """Threshold value is pinned at 6.0% (current measured floor, 2026-07-10).
-
-    This test does NOT run a live SQL query — it pins the threshold constant
-    so that any future increase to UNKNOWN_RATE_THRESHOLD_PCT triggers a
-    review. A live SQL measurement test requires the self-repo index to be
-    built first; that is tracked separately as a full_language benchmark test.
+    Scoped to the product source (`tree_sitter_analyzer/`): the claim is about
+    the resolver's behaviour on real code, this is real code, and it keeps the
+    build around six seconds on the axis that can afford it. `workers=1` is
+    deliberate — the default pool spawns processes, and a measured number must
+    not depend on pool scheduling.
     """
-    assert UNKNOWN_RATE_THRESHOLD_PCT == 6.0, (
-        f"Threshold must be 6.0% (current measured floor). "
-        f"Got: {UNKNOWN_RATE_THRESHOLD_PCT}%. "
-        "Lower this only after measuring a genuine improvement; "
-        "never raise it without an explicit decision."
+    from tree_sitter_analyzer.ast_cache import ASTCache
+
+    source_root = PROJECT_ROOT / "tree_sitter_analyzer"
+    cache = ASTCache(str(source_root))
+    try:
+        cache.index_project(workers=1)
+        row = cache.get_conn().execute(
+            "SELECT COUNT(*), SUM(callee_resolution = 'unknown') "
+            "FROM edges WHERE kind = 'calls'"
+        ).fetchone()
+    finally:
+        cache.close()
+    total, unknown = int(row[0]), int(row[1] or 0)
+    assert total > 0, (
+        "no CALLS edges were indexed, so the rate below would divide nothing; "
+        "the measurement is broken, not the resolver"
+    )
+    return 100.0 * unknown / total, unknown, total
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Measured 2026-09-12: 9.78% on the product source (4,941 / 50,528 CALLS "
+        "edges) and 6.27% on a 2,174-file self-repo subset, against a 6.0% "
+        "ceiling. The claim is not met, and it was not met while two tests "
+        "asserted the ceiling constant and that this file contains its own text. "
+        "Strict rather than skipped: the xfail is removed when the resolver "
+        "improves, and raising UNKNOWN_RATE_THRESHOLD_PCT to silence it turns "
+        "this into an unexpected pass and fails the run — which is the 'never "
+        "increase without a reviewed decision' rule enforced for the first time."
+    ),
+)
+def test_unknown_rate_is_measured_within_threshold():
+    """The claim, measured instead of restated (RFC-0028 §3.2).
+
+    Replaces two tests that could not fail: `test_unknown_rate_threshold_value`
+    asserted `UNKNOWN_RATE_THRESHOLD_PCT == 6.0` (a constant equalling itself)
+    and `test_unknown_rate_threshold_is_documented_in_this_file` asserted that
+    this file contains the string "6.0". Neither observed the code, so neither
+    noticed the rate had drifted above the ceiling they pin. §3.2 asks whether a
+    gate actually gates.
+    """
+    measured, unknown, total = _measure_unknown_rate()
+    print(
+        f"[claim] unknown_rate measured={measured:.2f}% unknown={unknown} "
+        f"total={total} threshold={UNKNOWN_RATE_THRESHOLD_PCT}%"
+    )
+    assert measured <= UNKNOWN_RATE_THRESHOLD_PCT, (
+        f"unknown rate {measured:.2f}% exceeds the {UNKNOWN_RATE_THRESHOLD_PCT}% "
+        f"ceiling ({unknown}/{total} CALLS edges unresolved)"
     )

--- a/tests/governance/test_first_party_gate_inventory.py
+++ b/tests/governance/test_first_party_gate_inventory.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""RFC-0028 §3.2 — the first-party gate inventory, derived from the live config.
+
+§3.2 scopes itself "precisely, because 'every blocking gate' is unimplementable":
+third-party hooks are out of scope because a pinned `rev` bump is their review
+surface, and the first-party local hooks are in scope. That scope is a claim
+about `.pre-commit-config.yaml`, so it is checked against that file rather than
+restated — and checked against the RFC's own table, so the spec cannot drift from
+the configuration it describes.
+
+Writing this immediately found such a drift: **the RFC names six local hooks and
+the configuration declares seven.** The unnamed one, `test-encoding-ratchet`, is
+itself a ratchet — the same class as `weak-assertion-ratchet`, whose dead-detector
+defect §3.2 records as #1.
+
+A hook whose `entry` points at a script that does not exist is a gate that cannot
+gate, so each entry's target is asserted to resolve.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+CONFIG_PATH = PROJECT_ROOT / ".pre-commit-config.yaml"
+RFC_PATH = PROJECT_ROOT / "rfcs" / "0028-measuring-claimed-properties.md"
+
+#: A path-shaped token in a hook entry: the thing the hook actually runs.
+_ENTRY_TARGET = re.compile(r"\S+\.(?:py|sh)\b")
+
+
+def _local_hooks() -> dict[str, str]:
+    """``{hook_id: entry}`` for every first-party (``repo: local``) hook."""
+    config = yaml.safe_load(CONFIG_PATH.read_text(encoding="utf-8"))
+    hooks: dict[str, str] = {}
+    for repo in config.get("repos", []):
+        if repo.get("repo") != "local":
+            continue
+        for hook in repo.get("hooks", []):
+            hooks[str(hook["id"])] = str(hook.get("entry", ""))
+    return hooks
+
+
+def _rfc_scoped_hooks() -> set[str]:
+    """Hook names the RFC's §3.2 scope table claims are in scope."""
+    text = RFC_PATH.read_text(encoding="utf-8")
+    section = text.split("§3.2 therefore scopes to the", 1)[1].split("\n## ", 1)[0]
+    return set(re.findall(r"\|\s*`([a-z0-9-]+)`\s*\|", section))
+
+
+def test_the_inventory_is_not_vacuous() -> None:
+    hooks = _local_hooks()
+    assert len(hooks) >= 6, (
+        f"only {len(hooks)} local hooks found in {CONFIG_PATH.name}; the parse or "
+        "the configuration changed shape and the assertions below mean nothing"
+    )
+    assert _rfc_scoped_hooks(), (
+        "no hook names parsed out of the RFC section; the table format changed "
+        "and the drift check below is vacuous"
+    )
+
+
+def test_every_local_hook_runs_something_that_exists() -> None:
+    """A hook whose entry resolves to nothing is a gate that cannot gate."""
+    missing: list[str] = []
+    for hook_id, entry in sorted(_local_hooks().items()):
+        match = _ENTRY_TARGET.search(entry)
+        assert match is not None, (
+            f"{hook_id}: entry {entry!r} names no .py/.sh target, so this test "
+            "cannot verify it runs anything — teach the parser or fix the hook"
+        )
+        target = PROJECT_ROOT / match.group(0)
+        if not target.exists():
+            missing.append(f"{hook_id} -> {match.group(0)}")
+    assert missing == [], "these first-party hooks run a target that does not exist:\n  " + "\n  ".join(missing)
+
+
+def test_the_rfc_scope_matches_the_live_configuration() -> None:
+    """§3.2's scope is a claim about this file; hold the spec to it.
+
+    This is the assertion that catches a hook added to the configuration without
+    a scope decision — and the one that would have caught the seventh hook, which
+    went unnamed while §3.2 described its own scope as stated precisely.
+    """
+    live = set(_local_hooks())
+    scoped = _rfc_scoped_hooks()
+
+    assert scoped == live, (
+        "RFC-0028 §3.2's scope table and the live pre-commit configuration "
+        "disagree. Third-party hooks stay out of scope; a first-party hook does "
+        "not, because §3.2's requirements are owed by exactly this set.\n"
+        f"  in config but not scoped: {sorted(live - scoped)}\n"
+        f"  scoped but not in config: {sorted(scoped - live)}"
+    )
+
+
+def test_every_scoped_gate_names_pre_commit_as_its_enforcement_layer() -> None:
+    """§3.2 requires the enforcement layer be named, and measured it is pre-commit.
+
+    CI cannot block a merge here (no `required_status_checks` on `develop`), so a
+    gate is enforced by the hook that runs it. Every scoped gate is by definition
+    in that file, which is what makes the naming dischargeable at all; this pins
+    that the file is still where they live rather than a prose list elsewhere.
+    """
+    config = yaml.safe_load(CONFIG_PATH.read_text(encoding="utf-8"))
+    stages = {
+        str(hook["id"]): hook.get("stages")
+        for repo in config.get("repos", [])
+        if repo.get("repo") == "local"
+        for hook in repo.get("hooks", [])
+    }
+    blocked = [name for name, stage in sorted(stages.items()) if stage and "pre-commit" not in stage]
+    assert blocked == [], (
+        "these first-party gates do not run at pre-commit, so nothing enforces "
+        f"them: {blocked}"
+    )

--- a/tests/governance/test_workflow_marker_sets.py
+++ b/tests/governance/test_workflow_marker_sets.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""RFC-0028 §3.2 — every workflow gate names its marker set and its job.
+
+§3.2 asks each gate to name the marker set it runs under and the CI job that runs
+it, and to prove the set is not empty. An empty set is the failure mode: a job
+invoked as `pytest -m "<marker>"` that no test carries collects zero tests and
+reports success, which is a gate that cannot gate.
+
+**How the proof is made, and its limit.** Running `pytest --collect-only` costs
+5–15 s per expression on this tree, so five expressions would add roughly a
+minute to the fast suite — a gate that makes the default loop slower is a gate
+people disable. This checks statically instead: every marker name must be
+registered, and every *positive* marker in the expression must be carried by at
+least one test file. That catches the vacuity case (a marker nothing carries) and
+the typo case, without the subprocess cost. It does **not** read a collected
+count, so §3.2's item stays open on that point.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = PROJECT_ROOT / ".github" / "workflows"
+PYTEST_INI = PROJECT_ROOT / "pytest.ini"
+TESTS_DIR = PROJECT_ROOT / "tests"
+
+_MARKER_FLAG = re.compile(r"-m\s+[\"']([^\"']+)[\"']")
+_MARKER_NAME = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+_KEYWORDS = frozenset({"and", "or", "not"})
+_SUBSTITUTION = re.compile(r"\$\{[^}]*\}")
+
+
+def _resolvable(expression: str) -> str:
+    """The expression with shell substitutions removed.
+
+    `-m "e2e${EXTRA_MARKS}"` is a runtime value the workflow composes; tokenizing
+    it literally would report `EXTRA_MARKS` as an unregistered marker, which is
+    about the shell, not the gate.
+    """
+    return _SUBSTITUTION.sub("", expression)
+
+
+_PYTEST_INVOCATION = re.compile(r"\bpytest\s")
+
+
+def _pytest_marker_expressions(command: str) -> list[str]:
+    """Marker expressions from pytest invocations in one ``run`` block.
+
+    Continuation-aware, because these invocations wrap across lines with a
+    trailing backslash and the `-m` sits on the last of them. And `-m` is only a
+    marker flag on a logical line that *invokes* pytest: `git commit -m "..."` and
+    `gh ... -m "..."` take a message, and matching those yields 23 phantom gates.
+    """
+    logical_lines: list[str] = []
+    buffer = ""
+    for raw in command.splitlines():
+        line = raw.rstrip()
+        if line.endswith("\\"):
+            buffer += line[:-1] + " "
+            continue
+        buffer += line
+        logical_lines.append(buffer)
+        buffer = ""
+    if buffer:
+        logical_lines.append(buffer)
+
+    expressions: list[str] = []
+    for logical in logical_lines:
+        if _PYTEST_INVOCATION.search(logical):
+            expressions.extend(_MARKER_FLAG.findall(logical))
+    return expressions
+
+
+def _workflow_marker_sets() -> list[tuple[str, str, str]]:
+    """``(workflow, job_key, marker_expression)`` for every gate that runs tests.
+
+    Expressions containing a shell substitution are returned but cannot be
+    resolved statically; the caller asserts they are exactly the known templated
+    ones, so a new one is a decision rather than a silent skip.
+    """
+    found: list[tuple[str, str, str]] = []
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        document = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        for job_key, job in (document.get("jobs") or {}).items():
+            if not isinstance(job, dict):
+                continue
+            for step in job.get("steps") or []:
+                if not isinstance(step, dict):
+                    continue
+                command = step.get("run")
+                if not isinstance(command, str):
+                    continue
+                for expression in _pytest_marker_expressions(command):
+                    found.append((path.name, str(job_key), expression))
+    return found
+
+
+def _registered_markers() -> set[str]:
+    """Markers from ``pytest.ini`` plus any registered through a conftest."""
+    registered = set()
+    in_markers = False
+    for line in PYTEST_INI.read_text(encoding="utf-8").splitlines():
+        if line.startswith("markers"):
+            in_markers = True
+            continue
+        if in_markers:
+            if line and not line[0].isspace():
+                in_markers = False
+                continue
+            name = line.strip().split(":", 1)[0].strip()
+            if name:
+                registered.add(name)
+    for conftest in TESTS_DIR.rglob("conftest.py"):
+        text = conftest.read_text(encoding="utf-8")
+        registered.update(re.findall(r'"markers",\s*"([A-Za-z_][A-Za-z0-9_]*)', text))
+    return registered
+
+
+def _markers_carried_by_tests() -> set[str]:
+    """Marker names that appear in a `pytestmark`, a decorator, or `mark`."""
+    carried = set()
+    for path in TESTS_DIR.rglob("test_*.py"):
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        carried.update(re.findall(r"pytest\.mark\.([A-Za-z_][A-Za-z0-9_]*)", text))
+    return carried
+
+
+@pytest.fixture(scope="module")
+def marker_sets() -> list[tuple[str, str, str]]:
+    return _workflow_marker_sets()
+
+
+def test_the_survey_found_the_gates(marker_sets) -> None:
+    """A parse that found nothing would make every assertion below vacuous."""
+    assert len(marker_sets) >= 3, (
+        f"only {len(marker_sets)} marker-driven workflows found; the parser or "
+        "the workflow shape changed and this gate no longer looks at anything"
+    )
+    templated = [entry for entry in marker_sets if "$" in entry[2]]
+    assert {entry[2] for entry in templated} <= {"e2e${EXTRA_MARKS}"}, (
+        "a new shell-templated marker set appeared; it cannot be checked "
+        f"statically and needs an explicit decision: {templated}"
+    )
+
+
+def test_every_workflow_marker_set_is_registered(marker_sets) -> None:
+    """`--strict-markers` rejects an unknown marker, so a typo fails the job.
+
+    Checked here as well because a marker registered in one place and used in a
+    workflow is the contract this item is about; the failure should name the
+    workflow and job, not surface as a collection error in CI.
+    """
+    registered = _registered_markers()
+    unknown: list[str] = []
+    for workflow, job, expression in marker_sets:
+        for token in _MARKER_NAME.findall(_resolvable(expression)):
+            if token in _KEYWORDS or token in registered:
+                continue
+            unknown.append(f"{workflow}:{job} uses marker {token!r} in -m {expression!r}")
+    assert unknown == [], "these gates run under a marker nothing registers:\n  " + "\n  ".join(unknown)
+
+
+def test_every_positive_marker_is_carried_by_a_test(marker_sets) -> None:
+    """The vacuity case: a job whose marker set selects nothing always passes."""
+    carried = _markers_carried_by_tests()
+    empty: list[str] = []
+    for workflow, job, expression in marker_sets:
+        expression = _resolvable(expression)
+        for token in _MARKER_NAME.findall(_resolvable(expression)):
+            if token in _KEYWORDS:
+                continue
+            # Only positive markers select tests; `not X` is satisfied by absence.
+            negated = re.search(rf"not\s+{re.escape(token)}\b", expression)
+            if negated or token in carried:
+                continue
+            empty.append(f"{workflow}:{job} selects on {token!r}, which no test carries")
+    assert empty == [], (
+        "these CI gates would collect zero tests and pass:\n  " + "\n  ".join(empty)
+    )
+
+
+def test_every_gate_names_a_job(marker_sets) -> None:
+    """§3.2 asks for the job to be named; an unnamed gate cannot be reviewed."""
+    unnamed = [entry for entry in marker_sets if not entry[1].strip()]
+    assert unnamed == [], f"marker sets found without an enclosing job key: {unnamed}"


### PR DESCRIPTION
RFC-0028 §3.2's fourth acceptance item: replace two tests that could not fail.

## What they asserted

- `test_unknown_rate_threshold_value` asserted `UNKNOWN_RATE_THRESHOLD_PCT == 6.0` — a constant equalling itself.
- `test_unknown_rate_threshold_is_documented_in_this_file` asserted this file contains the string `"6.0"` — a file containing its own text.

Neither observed the code, so neither noticed the measured rate had drifted **above** the ceiling they pin.

## Measured 2026-09-12

| population | CALLS edges | unresolved | rate |
|---|---:|---:|---:|
| product source (`tree_sitter_analyzer/`) | 50,528 | 4,941 | **9.78%** |
| self-repo subset (2,174 files) | 164,392 | 10,309 | **6.27%** |
| ceiling | | | 6.0% |

The claim is **not met**, and has not been for an unknown length of time. This is §3.2's premise demonstrated on the project's own gate.

## The replacement

`test_unknown_rate_is_measured_within_threshold` indexes the product source itself (`workers=1`, so the number cannot depend on pool scheduling) and asserts against the ceiling. It inherits this file's existing `full_language` marker, which is the axis where a ~13 s build is affordable. It is a **strict `xfail`**: the finding is recorded rather than hidden, and the marker comes off only when the resolver genuinely improves.

## It also enforces the rule the old test only documented

Proved by experiment rather than asserted: raising `UNKNOWN_RATE_THRESHOLD_PCT` to `10.0` makes the assertion pass, which turns the `xfail` into an **unexpected pass and fails the run**. "The threshold must NEVER increase without a reviewed decision" is now a failing condition instead of a comment.

Verification: `ruff check` clean; the test reports `1 xfailed` with the measured value printed; the threshold-raise experiment fails as intended; the fast suite deselects it as before.