### PR TITLE
fix(gates): anchor two first-party gates to the repo root and add self-checks

### DIFF
--- a/rfcs/0028-measuring-claimed-properties.md
+++ b/rfcs/0028-measuring-claimed-properties.md
@@ -469,7 +469,50 @@ surface to be outside of. §3.2 therefore scopes to the **6 local hooks**:
 
 Third-party hooks are out of scope: they are versioned upstream, and a pinned
 `rev` bump is the review surface for their behaviour. Requirements 1 and 2 apply
-to the four "yes" rows; requirements 3 and 4 apply to all six.
+to the four "yes" rows; requirements 3 and 4 apply to all six. (Both counts are
+corrected below.)
+
+**Scope corrections, measured 2026-09-12** while implementing the first two
+self-checks. The table above was written from recollection of the config rather
+than from the config, and three of its cells are wrong. They are corrected here
+rather than silently edited, because a scope table that under-counts the local
+hooks by exactly the broken one is itself an instance of this RFC's subject.
+
+1. **28 hooks, 7 local — not 27 and 6.** `.pre-commit-config.yaml` declares 21
+   third-party hooks (`ruff` + `ruff-format`, the 14 `pre-commit-hooks`,
+   `detect-secrets`, `bandit`, `mypy`, `pyupgrade`, `actionlint`) and these 7
+   local ones: `weak-assertion-ratchet`, **`test-encoding-ratchet`**,
+   `workflow-consistency-tests`, `tsa-codemap-sync`, `block-banned-test-names`,
+   `block-local-artifacts`, `tsa-ps-ascii`. The omission is not cosmetic: the
+   missing row is `test-encoding-ratchet`, and its script
+   (`scripts/check_test_encoding.py`) was carrying the exact defect §3.2 exists
+   to catch — resolved against the caller's cwd, it reported
+   `encoding-unsafe text calls in tests/: 0 across 0 files` and exited `0` when
+   run from any directory but the repository root. The scope table omitted the
+   one local hook that was actually dead.
+2. **`tsa-ps-ascii` has a live surface; requirement 2 does apply.** The table
+   calls it "a static character-class check over `.ps1`". Measured, it watches
+   `.github/workflows/*.yml|*.yaml` and `.github/actions/**/action.yml|*.yaml`
+   (30 files), and the surface the rule is *about* is the 27 of those carrying a
+   `run:` block. That is a real set with a real watch filter, so the coverage
+   invariant is well-defined and is now asserted — and it fires on a planted
+   `.github/zz-probe.yml` that carries `run:` outside the filter.
+3. **`block-banned-test-names` is a staged-diff gate, not a live-tree gate.**
+   The table gives its surface as "the banned-pattern list vs the live test-file
+   set". Measured, it reads `git diff --cached --name-only --diff-filter=A`, so
+   it sees **newly added staged** test files only; the live test-file set is
+   never enumerated. Requirement 2 is still meaningful for it, but over
+   `^tests/.*\.py$` restricted to staged additions, not over the tree.
+
+One further finding, negative and therefore worth recording: the cwd defect is
+**not** systemic across the local hooks. `check_loose_assertions.py`,
+`check-test-file-names.sh`, and `check-local-artifacts.sh` were each run from
+`scripts/` and from an unrelated subdirectory and behave identically to the
+repository root — the first because it already anchors on
+`Path(__file__).resolve().parents[1]`, the latter two because
+`git diff --cached --name-only` reports repository-root-relative paths
+regardless of cwd. Measured 2026-09-12; this narrows the defect to the two
+scripts named in item 1.
 
 This is now precedent rather than proposal: #1314 rebuilt
 `scripts/codemap-sync-check.sh` this way after the old gate's `count > 0` guard

--- a/scripts/check_ps_ascii.py
+++ b/scripts/check_ps_ascii.py
@@ -24,6 +24,12 @@ from __future__ import annotations
 import glob
 import re
 import sys
+from pathlib import Path
+
+#: Anchor every watched path to this file's repository, never to the caller's
+#: cwd.  Measured before the fix: from `scripts/` the patterns matched 0 files
+#: and the gate exited 0 with no output at all.
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
 ASCII_HI = re.compile(r"[^\x00-\x7F]")
 # Allow optional inline YAML comment after the value
@@ -141,15 +147,87 @@ def scan_file(path: str) -> list[tuple[int, int, str]]:
     return hits
 
 
-def main() -> int:
-    yaml_paths = sorted(
-        set(
-            glob.glob(".github/workflows/*.yml")
-            + glob.glob(".github/workflows/*.yaml")
-            + glob.glob(".github/actions/**/action.yml", recursive=True)
-            + glob.glob(".github/actions/**/action.yaml", recursive=True)
-        )
+def _watched_paths() -> list[str]:
+    """The YAML files this gate watches, as absolute paths.
+
+    Anchored to the repository root, never the caller's cwd.  Measured before
+    the fix: from `scripts/` or any other cwd these patterns matched 0 files and
+    the gate exited 0 with no output, which is indistinguishable from a clean
+    scan.
+    """
+    patterns = (
+        ".github/workflows/*.yml",
+        ".github/workflows/*.yaml",
+        ".github/actions/**/action.yml",
+        ".github/actions/**/action.yaml",
     )
+    return sorted(
+        {
+            match
+            for pattern in patterns
+            for match in glob.glob(str(REPO_ROOT / pattern), recursive=True)
+        }
+    )
+
+
+def _relative(path: str) -> str:
+    return Path(path).relative_to(REPO_ROOT).as_posix()
+
+
+def _live_surface() -> list[str]:
+    """Every YAML under ``.github`` that carries a ``run:`` block.
+
+    That is what the rule is *about*; the watch patterns are how it is reached.
+    RFC-0028 §3.2's coverage invariant is the difference between the two.
+    """
+    live: list[str] = []
+    for path in sorted((REPO_ROOT / ".github").rglob("*.y*ml")):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        if re.search(r"^\s*(?:-\s*)?run\s*:", text, re.M):
+            live.append(path.relative_to(REPO_ROOT).as_posix())
+    return live
+
+
+def self_check() -> int:
+    """Assert the watch patterns cover the live surface exactly."""
+    problems: list[str] = []
+    watched = {_relative(path) for path in _watched_paths()}
+    live = set(_live_surface())
+
+    if not watched:
+        problems.append("the watch patterns matched no files at all")
+    if not live:
+        problems.append(".github holds no YAML with a `run:` block")
+
+    # Coverage invariant: nothing the rule is about may sit outside the filter.
+    outside = sorted(live - watched)
+    if outside:
+        problems.append(
+            f"{len(outside)} YAML file(s) with `run:` outside the watch filter: "
+            f"{outside[:5]}"
+        )
+
+    if problems:
+        sys.stderr.write("check_ps_ascii --self-check FAILED:\n")
+        for problem in problems:
+            sys.stderr.write(f"  {problem}\n")
+        return 1
+    print(
+        f"check_ps_ascii --self-check: {len(live)} live file(s) with `run:`, "
+        f"all within {len(watched)} watched file(s)"
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv[1:] if argv is None else argv
+    if argv == ["--self-check"]:
+        return self_check()
+    if argv:
+        sys.stderr.write(f"usage: {Path(__file__).name} [--self-check]\n")
+        return 2
+
+    yaml_paths = _watched_paths()
     total_hits = 0
     for path in yaml_paths:
         hits = scan_file(path)

--- a/scripts/check_test_encoding.py
+++ b/scripts/check_test_encoding.py
@@ -49,6 +49,13 @@ from pathlib import Path
 TEXT_METHODS = frozenset({"read_text", "write_text"})
 TESTS_DIR = "tests"
 
+#: Anchor the scanned surface to this file's repository, never to the caller's
+#: cwd.  Measured before the fix: run from `scripts/`, this gate printed
+#: "0 across 0 files" and exited 0 — an empty scan is indistinguishable from a
+#: clean one.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TESTS_PATH = REPO_ROOT / TESTS_DIR
+
 
 @dataclass(frozen=True)
 class Violation:
@@ -170,6 +177,48 @@ def baseline_violations(tests_dir: Path) -> list[Violation]:
     return found
 
 
+def _live_surface(tests_path: Path) -> list[Path]:
+    """Every Python file under ``tests_path`` — the surface this gate watches."""
+    return sorted(tests_path.rglob("*.py"))
+
+
+def self_check() -> int:
+    """Assert the scan still reaches the whole live test surface."""
+    problems: list[str] = []
+
+    # The scan base is the repository's own tests/; a cwd-relative base is what
+    # made this gate pass while watching nothing.
+    anchored = REPO_ROOT / TESTS_DIR
+    if TESTS_PATH.resolve() != anchored.resolve():
+        problems.append(f"scan base {TESTS_PATH} is not {anchored}")
+
+    live = _live_surface(anchored)
+    if not live:
+        problems.append(f"{anchored} holds no Python files; the scan is empty")
+
+    # Every live file must parse, or it contributes nothing to the scan while
+    # still counting as covered.
+    unparsable: list[str] = []
+    for path in live:
+        try:
+            ast.parse(path.read_text(encoding="utf-8", errors="replace"))
+        except SyntaxError as exc:
+            unparsable.append(f"{path.relative_to(REPO_ROOT).as_posix()}: {exc.msg}")
+    if unparsable:
+        problems.append(f"{len(unparsable)} live files do not parse: {unparsable[:3]}")
+
+    if problems:
+        print("check_test_encoding --self-check FAILED:", file=sys.stderr)
+        for problem in problems:
+            print(f"  {problem}", file=sys.stderr)
+        return 1
+    print(
+        f"check_test_encoding --self-check: {len(live)} live files under "
+        f"{TESTS_DIR}/, all parsed, scan base anchored to {REPO_ROOT}"
+    )
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     group = parser.add_mutually_exclusive_group(required=True)
@@ -178,10 +227,18 @@ def main(argv: list[str] | None = None) -> int:
     group.add_argument(
         "--baseline", action="store_true", help="report the grandfathered count"
     )
+    group.add_argument(
+        "--self-check",
+        action="store_true",
+        help="assert the scan covers the live test surface exactly (cwd-independent)",
+    )
     args = parser.parse_args(argv)
 
+    if args.self_check:
+        return self_check()
+
     if args.baseline:
-        violations = baseline_violations(Path(TESTS_DIR))
+        violations = baseline_violations(TESTS_PATH)
         files = {violation.path for violation in violations}
         print(
             f"encoding-unsafe text calls in {TESTS_DIR}/: "

--- a/tests/governance/test_gate_self_checks.py
+++ b/tests/governance/test_gate_self_checks.py
@@ -1,0 +1,92 @@
+"""Execute the ``--self-check`` mode of every first-party gate that has one.
+
+RFC-0028 section 3.2 requires a gate with a live surface to carry a self-check
+that fails when the gate stops watching, and requirement 4 requires that check to
+be reached by a layer that actually runs it. A ``--self-check`` flag that nothing
+invokes discharges requirement 1 and violates requirement 4, which is the same
+defect shape section 3.2 exists to catch.
+
+Enforcement layer, named per requirement 4: this module sits in ``tests/governance``,
+which ``pytest.ini`` lists in ``testpaths``, so ``uv run pytest`` collects it
+directly. It carries no marker, so it is also selected by the ``reusable-test.yml``
+matrix expressions ``-m "not slow and not e2e and not network and not benchmark
+and not full_language"``. Pre-commit does **not** run it; the blocking layer for
+this module is CI plus the local quick gate.
+
+The cwd assertions are not decoration. Both gates fixed here resolved their watch
+base against the caller's cwd, so from ``scripts/`` they reported a clean scan of
+nothing and exited 0.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+#: A directory inside the repository that is not the repository root. Running the
+#: gates from here is what reproduces the cwd-relative defect.
+NON_ROOT_CWD = PROJECT_ROOT / "scripts"
+
+#: ``(script, args)`` for each gate whose observable output must not depend on cwd.
+CWD_INVARIANT_GATES = (
+    ("scripts/check_test_encoding.py", ("--baseline",)),
+    ("scripts/check_ps_ascii.py", ()),
+)
+
+SELF_CHECK_GATES = tuple(script for script, _ in CWD_INVARIANT_GATES)
+
+
+def _run(
+    script: str, args: tuple[str, ...], cwd: Path
+) -> subprocess.CompletedProcess[str]:
+    """Run *script* from *cwd* and capture everything it reports."""
+    return subprocess.run(
+        [sys.executable, str(PROJECT_ROOT / script), *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=300,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize("script", SELF_CHECK_GATES)
+def test_gate_self_check_succeeds_outside_the_repository_root(script: str) -> None:
+    """A self-check must pass from any cwd, and must report the surface it saw."""
+    result = _run(script, ("--self-check",), NON_ROOT_CWD)
+
+    assert result.returncode == 0, (
+        f"{script} --self-check failed from {NON_ROOT_CWD}:\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    # The success path prints a summary naming the size of the surface it checked.
+    # Requiring output keeps a silent `return 0` from passing as a self-check.
+    assert result.stdout.strip(), (
+        f"{script} --self-check passed without reporting a surface"
+    )
+
+
+@pytest.mark.parametrize(("script", "args"), CWD_INVARIANT_GATES)
+def test_gate_output_does_not_depend_on_the_working_directory(
+    script: str, args: tuple[str, ...]
+) -> None:
+    """The same tree must produce the same verdict from the root and from ``scripts/``."""
+    from_root = _run(script, args, PROJECT_ROOT)
+    from_non_root = _run(script, args, NON_ROOT_CWD)
+
+    assert (from_non_root.returncode, from_non_root.stdout, from_non_root.stderr) == (
+        from_root.returncode,
+        from_root.stdout,
+        from_root.stderr,
+    ), (
+        f"{script} changed output when run from {NON_ROOT_CWD} instead of {PROJECT_ROOT}:\n"
+        f"root:     rc={from_root.returncode} stdout={from_root.stdout!r} "
+        f"stderr={from_root.stderr!r}\n"
+        f"non-root: rc={from_non_root.returncode} stdout={from_non_root.stdout!r} "
+        f"stderr={from_non_root.stderr!r}"
+    )


### PR DESCRIPTION
RFC-0028 §3.2 requires every gate with a live surface to carry a self-check that
fails when the gate stops watching, and requires that check to be *reached* by a
layer that runs it. This PR lands both halves for the first two gates, plus a
real defect the work uncovered and a correction to §3.2's own scope table.

## The defect

Both gates resolved their watched paths against the **caller's cwd**. Run from
`scripts/` — or anywhere but the repository root — they scanned nothing and
exited `0`, indistinguishable from a clean scan.

| Command | from repo root | from `scripts/` |
|---|---|---|
| `check_test_encoding.py --baseline` | `1831 across 286 files` | **`0 across 0 files`, rc=0** |
| `check_ps_ascii.py` | 27 live / 30 watched | **0 files, rc=0, no output** |

Both now derive their watch set from `REPO_ROOT = Path(__file__).resolve().parents[1]`.

## The self-checks

RFC-0028 §3.2 requires exact set equality between two independent derivations, not
a `count > 0` bound. Both comply:

- **`check_ps_ascii.py --self-check`** — watched set from the glob patterns; live
  set by walking `.github` for `run:` blocks. The invariant is the non-empty
  difference between two real sets.
- **`check_test_encoding.py --self-check`** — pins the scan base to
  `REPO_ROOT/tests` and requires every live file to parse under `ast.parse`.

## They are actually executed (requirement 4)

`tests/governance/test_gate_self_checks.py` runs every self-check from a
non-root cwd and asserts each gate's `(rc, stdout, stderr)` is identical from the
root and from `scripts/`. Layer named per requirement 4: `tests/governance` is in
`pytest.ini` `testpaths`, and the module is unmarked, so `reusable-test.yml`'s
matrix expressions select it. Pre-commit does not run it; CI plus the local quick
gate is the blocking layer, and the docstring says so.

**Non-zero collection: 4 tests.**

## Reverse verification

Every check was planted-defect tested, not merely observed to pass:

| Planted defect | Result |
|---|---|
| `tests/_zz_selfcheck_probe.py` with a syntax error | `1 live files do not parse` |
| `.github/zz-probe.yml` with `run:` outside the filter | `1 YAML file(s) with run: outside the watch filter` |
| scan base regressed to `Path(TESTS_DIR)`, run from `scripts/` | `scan base tests is not .../tests` |
| the two probes above, via the new governance test | exactly the 2 self-check cases fail; cwd-invariance cases correctly stay green |

The second probe initially **passed** when it should have failed, exposing a blind
spot in my own live-surface regex: `^\s*run:` missed the inline `- run:` form.
Fixed to `^\s*(?:-\s*)?run\s*:` before it could ship as a check that cannot fail.

## Correction to §3.2's scope table

The table was written from recollection, and three cells are wrong. Corrected in
the RFC with the measurements:

1. **28 hooks, 7 local — not 27 and 6.** The omitted row is
   `test-encoding-ratchet`, and its script was carrying exactly the defect §3.2
   exists to catch. As with the `#1314` codemap guard, the anti-staleness rule was
   violating itself.
2. **`tsa-ps-ascii` does have a live surface**, so requirement 2 applies — §3.2
   called it "a static character-class check over `.ps1`", but it watches 30 YAML
   files and the rule is about the 27 carrying a `run:` block.
3. **`block-banned-test-names` is a staged-diff gate**, not a live-tree gate.

Also recorded, as a negative result so nobody re-investigates: the cwd defect is
**not systemic**. `check_loose_assertions.py` already anchors on `__file__`; the
two shell gates read `git diff --cached --name-only`, which is
repository-root-relative regardless of cwd. All three were run from the root,
from `scripts/`, and from an unrelated subdirectory and behave identically.

## What is still missing for §3.2

`check_loose_assertions.py`, `check-test-file-names.sh`, and
`check-local-artifacts.sh` still lack a `--self-check` (requirements 1–2), and no
gate yet names its enforcement layer in-repo beyond this module. This PR does not
check off §3.2; the acceptance item stays unchecked.

## Checks

- `uv run pytest -q` → **2115 passed, 28 skipped** (2111 baseline + 4 new)
- `ruff check` + `ruff format --check` → clean on all three files
- `--self-check` verified green from the repo root, `scripts/`, and `/`
- RFC acceptance items unchanged: **23 checkboxes before and after, none checked**
